### PR TITLE
[AArch64][NFC] Move `isZExtLoad/isSExtLoad` from `AArch64FastISel` to `AArch64InstrInfo`

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64FastISel.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FastISel.cpp
@@ -4458,54 +4458,6 @@ Register AArch64FastISel::emitIntExt(MVT SrcVT, Register SrcReg, MVT DestVT,
   return fastEmitInst_rii(Opc, RC, SrcReg, 0, Imm);
 }
 
-static bool isZExtLoad(const MachineInstr *LI) {
-  switch (LI->getOpcode()) {
-  default:
-    return false;
-  case AArch64::LDURBBi:
-  case AArch64::LDURHHi:
-  case AArch64::LDURWi:
-  case AArch64::LDRBBui:
-  case AArch64::LDRHHui:
-  case AArch64::LDRWui:
-  case AArch64::LDRBBroX:
-  case AArch64::LDRHHroX:
-  case AArch64::LDRWroX:
-  case AArch64::LDRBBroW:
-  case AArch64::LDRHHroW:
-  case AArch64::LDRWroW:
-    return true;
-  }
-}
-
-static bool isSExtLoad(const MachineInstr *LI) {
-  switch (LI->getOpcode()) {
-  default:
-    return false;
-  case AArch64::LDURSBWi:
-  case AArch64::LDURSHWi:
-  case AArch64::LDURSBXi:
-  case AArch64::LDURSHXi:
-  case AArch64::LDURSWi:
-  case AArch64::LDRSBWui:
-  case AArch64::LDRSHWui:
-  case AArch64::LDRSBXui:
-  case AArch64::LDRSHXui:
-  case AArch64::LDRSWui:
-  case AArch64::LDRSBWroX:
-  case AArch64::LDRSHWroX:
-  case AArch64::LDRSBXroX:
-  case AArch64::LDRSHXroX:
-  case AArch64::LDRSWroX:
-  case AArch64::LDRSBWroW:
-  case AArch64::LDRSHWroW:
-  case AArch64::LDRSBXroW:
-  case AArch64::LDRSHXroW:
-  case AArch64::LDRSWroW:
-    return true;
-  }
-}
-
 bool AArch64FastISel::optimizeIntExtLoad(const Instruction *I, MVT RetVT,
                                          MVT SrcVT) {
   const auto *LI = dyn_cast<LoadInst>(I->getOperand(0));
@@ -4531,7 +4483,8 @@ bool AArch64FastISel::optimizeIntExtLoad(const Instruction *I, MVT RetVT,
     LoadMI = MRI.getUniqueVRegDef(LoadReg);
     assert(LoadMI && "Expected valid instruction");
   }
-  if (!(IsZExt && isZExtLoad(LoadMI)) && !(!IsZExt && isSExtLoad(LoadMI)))
+  if (!(IsZExt && AArch64InstrInfo::isZExtLoad(*LoadMI)) &&
+      !(!IsZExt && AArch64InstrInfo::isSExtLoad(*LoadMI)))
     return false;
 
   // Nothing to be done.

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -5037,6 +5037,54 @@ bool AArch64InstrInfo::isPreLdSt(const MachineInstr &MI) {
   return isPreLd(MI) || isPreSt(MI);
 }
 
+bool AArch64InstrInfo::isZExtLoad(const MachineInstr &MI) {
+  switch (MI.getOpcode()) {
+  default:
+    return false;
+  case AArch64::LDURBBi:
+  case AArch64::LDURHHi:
+  case AArch64::LDURWi:
+  case AArch64::LDRBBui:
+  case AArch64::LDRHHui:
+  case AArch64::LDRWui:
+  case AArch64::LDRBBroX:
+  case AArch64::LDRHHroX:
+  case AArch64::LDRWroX:
+  case AArch64::LDRBBroW:
+  case AArch64::LDRHHroW:
+  case AArch64::LDRWroW:
+    return true;
+  }
+}
+
+bool AArch64InstrInfo::isSExtLoad(const MachineInstr &MI) {
+  switch (MI.getOpcode()) {
+  default:
+    return false;
+  case AArch64::LDURSBWi:
+  case AArch64::LDURSHWi:
+  case AArch64::LDURSBXi:
+  case AArch64::LDURSHXi:
+  case AArch64::LDURSWi:
+  case AArch64::LDRSBWui:
+  case AArch64::LDRSHWui:
+  case AArch64::LDRSBXui:
+  case AArch64::LDRSHXui:
+  case AArch64::LDRSWui:
+  case AArch64::LDRSBWroX:
+  case AArch64::LDRSHWroX:
+  case AArch64::LDRSBXroX:
+  case AArch64::LDRSHXroX:
+  case AArch64::LDRSWroX:
+  case AArch64::LDRSBWroW:
+  case AArch64::LDRSHWroW:
+  case AArch64::LDRSBXroW:
+  case AArch64::LDRSHXroW:
+  case AArch64::LDRSWroW:
+    return true;
+  }
+}
+
 bool AArch64InstrInfo::isPairedLdSt(const MachineInstr &MI) {
   switch (MI.getOpcode()) {
   default:

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -255,6 +255,12 @@ public:
   /// Returns whether the instruction is a pre-indexed load/store.
   static bool isPreLdSt(const MachineInstr &MI);
 
+  /// Returns whether the instruction is a zero-extending load.
+  static bool isZExtLoad(const MachineInstr &MI);
+
+  /// Returns whether the instruction is a sign-extending load.
+  static bool isSExtLoad(const MachineInstr &MI);
+
   /// Returns whether the instruction is a paired load/store.
   static bool isPairedLdSt(const MachineInstr &MI);
 


### PR DESCRIPTION
Move the static function `isZExtLoad` and `isSExtLoad` helper functions from `AArch64FastISel` into `AArch64InstrInfo` to be reused by other passes.
