### PR TITLE
[llvm][Coroutines] Support ptrauth signing of coroutine resume pointers

### DIFF
--- a/llvm/docs/PointerAuth.md
+++ b/llvm/docs/PointerAuth.md
@@ -311,6 +311,34 @@ derived from the parent function's name, using the SipHash stable discriminator:
 ```
 
 
+### Coroutine Resume Pointer Signing
+
+The ``!ptrauth.resume`` metadata can be attached to ``@llvm.coro.id.retcon``
+and ``@llvm.coro.id.retcon.once`` intrinsic calls to request that the resume
+function pointer stored in the continuation be signed using pointer
+authentication.
+
+The metadata takes three operands:
+
+```
+!ptrauth.resume !{i32 <key>, i64 <discriminator>, i1 <addr_discriminated>}
+```
+
+- **key**: The ptrauth key to use for signing (e.g., 0 for IA).
+- **discriminator**: A constant discriminator value.
+- **addr_discriminated**: If true, the discriminator is blended with the
+  address of the continuation buffer using ``llvm.ptrauth.blend`` before
+  signing, providing address diversity.
+
+When this metadata is present, ``CoroSplit`` emits ``llvm.ptrauth.sign``
+(and optionally ``llvm.ptrauth.blend``) calls in the ramp function to sign
+the resume pointer before returning it to the caller.
+
+This is used by Swift IRGen to sign resume pointers for modify accessors
+(yield-once coroutines) on arm64e, where the runtime authenticates them
+with ``blraa`` before calling.
+
+
 ## AArch64 Support
 
 AArch64 is currently the only architecture with full support of the pointer

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -1913,6 +1913,41 @@ void coro::AnyRetconABI::splitCoroutine(Function &F, coro::Shape &Shape,
       auto *CastedContinuation =
           Builder.CreateBitCast(ContinuationPhi, CastedContinuationTy);
 
+      // Sign the resume function pointer if !ptrauth.resume metadata is
+      // present.
+      if (auto *MD = Id->getMetadata("ptrauth.resume")) {
+        auto *KeyMD = cast<ConstantAsMetadata>(MD->getOperand(0));
+        auto *DiscMD = cast<ConstantAsMetadata>(MD->getOperand(1));
+        auto *AddrDivMD = cast<ConstantAsMetadata>(MD->getOperand(2));
+        unsigned Key = cast<ConstantInt>(KeyMD->getValue())->getZExtValue();
+        uint64_t Disc = cast<ConstantInt>(DiscMD->getValue())->getZExtValue();
+        bool AddrDiv = cast<ConstantInt>(AddrDivMD->getValue())->getZExtValue();
+
+        auto &Ctx = F.getContext();
+        auto *Int64Ty = Type::getInt64Ty(Ctx);
+        auto *Int32Ty = Type::getInt32Ty(Ctx);
+
+        auto *ContInt = Builder.CreatePtrToInt(CastedContinuation, Int64Ty);
+
+        Value *Modifier;
+        if (AddrDiv) {
+          auto *BufAddr = Builder.CreatePtrToInt(Id->getStorage(), Int64Ty);
+          auto *BlendFn = Intrinsic::getOrInsertDeclaration(
+              F.getParent(), Intrinsic::ptrauth_blend);
+          Modifier = Builder.CreateCall(
+              BlendFn, {BufAddr, ConstantInt::get(Int64Ty, Disc)});
+        } else {
+          Modifier = ConstantInt::get(Int64Ty, Disc);
+        }
+
+        auto *SignFn = Intrinsic::getOrInsertDeclaration(
+            F.getParent(), Intrinsic::ptrauth_sign);
+        auto *Signed = Builder.CreateCall(
+            SignFn, {ContInt, ConstantInt::get(Int32Ty, Key), Modifier});
+        CastedContinuation =
+            Builder.CreateIntToPtr(Signed, CastedContinuationTy);
+      }
+
       Value *RetV = CastedContinuation;
       if (!ReturnPHIs.empty()) {
         auto ValueIdx = 0;

--- a/llvm/test/Transforms/Coroutines/coro-retcon-ptrauth.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-ptrauth.ll
@@ -1,0 +1,79 @@
+; RUN: opt < %s -passes='cgscc(coro-split),simplifycfg,early-cse' -S | FileCheck %s
+;
+; When !ptrauth.resume metadata is attached to coro.id.retcon.once,
+; CoroSplit signs the resume pointer using llvm.ptrauth.sign.
+
+target triple = "arm64e-apple-darwin"
+
+declare void @prototype(ptr, i1)
+declare noalias ptr @allocate(i32)
+declare void @deallocate(ptr)
+
+; Test address-diversified signing (addr_div=true).
+; The discriminator is blended with the buffer address before signing.
+define {ptr, ptr} @test_ptrauth_resume(ptr %buffer, ptr %ptr) presplitcoroutine {
+entry:
+  %temp = alloca i32, align 4
+  %id = call token @llvm.coro.id.retcon.once(i32 8, i32 8, ptr %buffer, ptr @prototype, ptr @allocate, ptr @deallocate), !ptrauth.resume !0
+  %hdl = call ptr @llvm.coro.begin(token %id, ptr null)
+  %oldvalue = load i32, ptr %ptr
+  store i32 %oldvalue, ptr %temp
+  %unwind = call i1 (...) @llvm.coro.suspend.retcon.i1(ptr %temp)
+  br i1 %unwind, label %cleanup, label %cont
+
+cont:
+  %newvalue = load i32, ptr %temp
+  store i32 %newvalue, ptr %ptr
+  br label %cleanup
+
+cleanup:
+  call void @llvm.coro.end(ptr %hdl, i1 0, token none)
+  unreachable
+}
+
+; CHECK-LABEL: define { ptr, ptr } @test_ptrauth_resume(
+; Address-diversified: blend buffer address with discriminator, then sign.
+; CHECK: %[[BUFINT:.*]] = ptrtoint ptr %buffer to i64
+; CHECK: %[[BLEND:.*]] = call i64 @llvm.ptrauth.blend(i64 %[[BUFINT]], i64 3909)
+; CHECK: %[[SIGNED:.*]] = call i64 @llvm.ptrauth.sign(i64 ptrtoint (ptr @test_ptrauth_resume.resume.0 to i64), i32 0, i64 %[[BLEND]])
+; CHECK: %[[PTR:.*]] = inttoptr i64 %[[SIGNED]] to ptr
+; CHECK: ret { ptr, ptr }
+
+; Test non-address-diversified signing (addr_div=false).
+; The discriminator is used directly without blending.
+define {ptr, ptr} @test_ptrauth_resume_no_addrdiv(ptr %buffer, ptr %ptr) presplitcoroutine {
+entry:
+  %temp = alloca i32, align 4
+  %id = call token @llvm.coro.id.retcon.once(i32 8, i32 8, ptr %buffer, ptr @prototype, ptr @allocate, ptr @deallocate), !ptrauth.resume !1
+  %hdl = call ptr @llvm.coro.begin(token %id, ptr null)
+  %oldvalue = load i32, ptr %ptr
+  store i32 %oldvalue, ptr %temp
+  %unwind = call i1 (...) @llvm.coro.suspend.retcon.i1(ptr %temp)
+  br i1 %unwind, label %cleanup, label %cont
+
+cont:
+  %newvalue = load i32, ptr %temp
+  store i32 %newvalue, ptr %ptr
+  br label %cleanup
+
+cleanup:
+  call void @llvm.coro.end(ptr %hdl, i1 0, token none)
+  unreachable
+}
+
+; CHECK-LABEL: define { ptr, ptr } @test_ptrauth_resume_no_addrdiv(
+; Non-address-diversified: no blend, discriminator passed directly to sign.
+; CHECK-NOT: @llvm.ptrauth.blend
+; CHECK: %[[SIGNED2:.*]] = call i64 @llvm.ptrauth.sign(i64 ptrtoint (ptr @test_ptrauth_resume_no_addrdiv.resume.0 to i64), i32 0, i64 3909)
+; CHECK: %[[PTR2:.*]] = inttoptr i64 %[[SIGNED2]] to ptr
+; CHECK: ret { ptr, ptr }
+
+declare token @llvm.coro.id.retcon.once(i32, i32, ptr, ptr, ptr, ptr)
+declare ptr @llvm.coro.begin(token, ptr)
+declare i1 @llvm.coro.suspend.retcon.i1(...)
+declare void @llvm.coro.end(ptr, i1, token)
+
+; key=0 (IA), disc=3909 (0x0F45), addr_div=true
+!0 = !{i32 0, i64 3909, i1 true}
+; key=0 (IA), disc=3909 (0x0F45), addr_div=false
+!1 = !{i32 0, i64 3909, i1 false}


### PR DESCRIPTION
This is part of work being done in #188378 and #188638, split out from #188650. This PR was mostly developed with LLM assistance, but human tested on arm64e hardware.

## Problem

On arm64e, the Swift runtime authenticates coroutine resume pointers with `blraa` before calling them. Yield-once (retcon) coroutines return the resume function pointer to the caller in the continuation, but CoroSplit currently stores it unsigned. This causes `EXC_ARM_PAC_FAIL` when the runtime attempts to authenticate it.

## Approach

This patch introduces a new `!ptrauth.resume` metadata kind that frontends can attach to `@llvm.coro.id.retcon` and `@llvm.coro.id.retcon.once` intrinsic calls:

```
!ptrauth.resume !{i32 <key>, i64 <discriminator>, i1 <addr_discriminated>}
```

When present, CoroSplit signs the resume pointer in the ramp function using `llvm.ptrauth.sign`, optionally blending the discriminator with the continuation buffer address via `llvm.ptrauth.blend` for address diversity.

The signing is done at the IR level using target-independent intrinsics, so the metadata can be emitted by any frontend targeting arm64e. The intended consumer is Swift IRGen, which would attach this metadata when lowering modify accessors.

## Alternatives considered

The signing could be done entirely in Swift IRGen (sign the pointer after CoroSplit runs, or wrap it in a `ConstantPtrAuth`). Doing it in CoroSplit is cleaner because the resume pointer is constructed during splitting — the frontend doesn't have access to it before then.