### PR TITLE
[llvm-objcopy] Add -o to install_name_tool

### DIFF
--- a/llvm/docs/CommandGuide/llvm-install-name-tool.rst
+++ b/llvm/docs/CommandGuide/llvm-install-name-tool.rst
@@ -57,6 +57,10 @@ the same `<rpath>` value.
  specified binary. If specified multiple times, only the last :option:`-id` option is
  selected. Option is ignored if the specified Mach-O binary is not a dynamic shared library.
 
+.. option:: -o <file>, --output <file>
+
+ Write the modified binary to ``<file>`` instead of updating the input file in place.
+
 .. option:: -rpath <old_rpath> <new_rpath>
 
  Change an rpath named ``<old_rpath>`` to ``<new_rpath>`` in the specified binary. Can be specified

--- a/llvm/test/tools/llvm-objcopy/MachO/install-name-tool-output.test
+++ b/llvm/test/tools/llvm-objcopy/MachO/install-name-tool-output.test
@@ -1,0 +1,37 @@
+## This test checks writing install-name-tool changes to a separate output file.
+
+# RUN: yaml2obj %s -o %t
+
+## Writing to a separate file with -o:
+# RUN: llvm-install-name-tool -id /usr/lib/short-id -o %t.short %t
+# RUN: llvm-objdump -p %t | FileCheck %s --check-prefix=INPUT --implicit-check-not='name /usr/lib/short-id'
+# RUN: llvm-objdump -p %t.short | FileCheck %s --check-prefix=SHORT --implicit-check-not='name /usr/lib/original-id'
+
+# INPUT: name /usr/lib/original-id
+# SHORT: name /usr/lib/short-id
+
+## Writing to a separate file with --output:
+# RUN: llvm-install-name-tool -id /usr/lib/long-id --output %t.long %t
+# RUN: llvm-objdump -p %t.long | FileCheck %s --check-prefix=LONG --implicit-check-not='name /usr/lib/original-id'
+
+# LONG: name /usr/lib/long-id
+
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x01000007
+  cpusubtype:      0x00000003
+  filetype:        0x00000006
+  ncmds:           1
+  sizeofcmds:      72
+  flags:           0x00002000
+  reserved:        0x00000000
+LoadCommands:
+  - cmd:                        LC_ID_DYLIB
+    cmdsize:                    72
+    dylib:
+      name:                     24
+      timestamp:                2
+      current_version:          82115073
+      compatibility_version:    65536
+    Content:                    '/usr/lib/original-id'

--- a/llvm/tools/llvm-objcopy/InstallNameToolOpts.td
+++ b/llvm/tools/llvm-objcopy/InstallNameToolOpts.td
@@ -15,6 +15,14 @@ include "llvm/Option/OptParser.td"
 def help : Flag<["--"], "help">;
 def h : Flag<["-"], "h">, Alias<help>;
 
+def output : Option<["--"], "output", KIND_SEPARATE>,
+             HelpText<"Write output to <file>">,
+             MetaVarName<"<file>">;
+def o : JoinedOrSeparate<["-"], "o">,
+        Alias<output>,
+        HelpText<"Alias for --output">,
+        MetaVarName<"<file>">;
+
 def add_rpath : Option<["-", "--"], "add_rpath", KIND_SEPARATE>,
                 HelpText<"Add new rpath">;
 

--- a/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
+++ b/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
@@ -1434,7 +1434,8 @@ objcopy::parseInstallNameToolOptions(ArrayRef<const char *> ArgsArr) {
         errc::invalid_argument,
         "llvm-install-name-tool expects a single input file");
   Config.InputFilename = Positional[0];
-  Config.OutputFilename = Positional[0];
+  Config.OutputFilename =
+      InputArgs.getLastArgValue(INSTALL_NAME_TOOL_output, Positional[0]);
 
   Expected<OwningBinary<Binary>> BinaryOrErr =
       createBinary(Config.InputFilename);


### PR DESCRIPTION
This allows copying the binary vs updating it in place

Assisted-by: claude