### PR TITLE
[clang-tidy] Fix readability-identifier-naming for C++17 structured bindings

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -1242,7 +1242,8 @@ StyleKind IdentifierNamingCheck::findStyleKind(
   // with the same storage and qualifiers as the parent DecompositionDecl.
   if (const auto *BD = dyn_cast<BindingDecl>(D)) {
     if (const auto *Decomp = dyn_cast_or_null<VarDecl>(BD->getDecomposedDecl()))
-      return findStyleKindForVar(Decomp, BD->getType(), NamingStyles);
+      if (!BD->getType().isNull())
+        return findStyleKindForVar(Decomp, BD->getType(), NamingStyles);
     return SK_Invalid;
   }
 

--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -1238,6 +1238,14 @@ StyleKind IdentifierNamingCheck::findStyleKind(
   if (const auto *Decl = dyn_cast<VarDecl>(D))
     return findStyleKindForVar(Decl, Decl->getType(), NamingStyles);
 
+  // C++17 structured bindings: treat each binding as if it were a variable
+  // with the same storage and qualifiers as the parent DecompositionDecl.
+  if (const auto *BD = dyn_cast<BindingDecl>(D)) {
+    if (const auto *Decomp = dyn_cast_or_null<VarDecl>(BD->getDecomposedDecl()))
+      return findStyleKindForVar(Decomp, BD->getType(), NamingStyles);
+    return SK_Invalid;
+  }
+
   if (const auto *Decl = dyn_cast<CXXMethodDecl>(D)) {
     if (Decl->isMain() || !Decl->isUserProvided() ||
         Decl->size_overridden_methods() > 0 || Decl->hasAttr<OverrideAttr>())

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -422,6 +422,10 @@ Changes in existing checks
   now uses separate note diagnostics for each uninitialized enumerator, making
   it easier to see which specific enumerators need explicit initialization.
 
+- Improved :doc:`readability-identifier-naming
+  <clang-tidy/checks/readability/identifier-naming>` check by fixing incorrect
+  naming style application to C++17 structured bindings.
+
 - Improved :doc:`readability-implicit-bool-conversion
   <clang-tidy/checks/readability/implicit-bool-conversion>` check:
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
@@ -479,6 +479,32 @@ void global_function(int PARAMETER_1, int const CONST_parameter) {
     }
 }
 
+struct Binding_holder {
+  int field_a;
+  int field_b;
+};
+
+Binding_holder GetHolder();
+
+void StructuredBindingTests() {
+    auto [BAD_Local_1, BAD_Local_2] = GetHolder();
+// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for local variable 'BAD_Local_1'
+// CHECK-MESSAGES: :[[@LINE-2]]:24: warning: invalid case style for local variable 'BAD_Local_2'
+// CHECK-FIXES: auto [bad_local_1, bad_local_2] = GetHolder();
+
+    const auto [BAD_Const_1, BAD_Const_2] = GetHolder();
+// CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for local constant 'BAD_Const_1'
+// CHECK-MESSAGES: :[[@LINE-2]]:30: warning: invalid case style for local constant 'BAD_Const_2'
+// CHECK-FIXES: const auto [kBadConst1, kBadConst2] = GetHolder();
+
+    const auto &[BAD_ConstRef_1, BAD_ConstRef_2] = GetHolder();
+// CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for local constant 'BAD_ConstRef_1'
+// CHECK-MESSAGES: :[[@LINE-2]]:34: warning: invalid case style for local constant 'BAD_ConstRef_2'
+// CHECK-FIXES: const auto &[kBadConstRef1, kBadConstRef2] = GetHolder();
+
+    auto [good_local_1, good_local_2] = GetHolder();
+}
+
 template<typename ... TYPE_parameters>
 // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: invalid case style for type template parameter 'TYPE_parameters'
 // CHECK-FIXES: template<typename ... typeParameters_t>


### PR DESCRIPTION
`BindingDecl` nodes, i.e. the individual names in a structured binding, were not handled in `IdentifierNamingCheck::findStyleKind()`, causing them to fall through to the Default style or be silently ignored.
This led to incorrect renames, e.g. applying member variable conventions to local bindings.