### PR TITLE
[libc] Finetune libc.src.__support.OSUtil.osutil dependency.

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -182,6 +182,10 @@ function(_get_compile_options_from_config output_var)
     libc_add_definition(config_options "LIBC_COPT_PRINTF_DISABLE_BITINT")
   endif()
 
+  if(LIBC_COPT_USE_C_ASSERT)
+    list(APPEND config_options "-DLIBC_COPT_USE_C_ASSERT")
+  endif()
+
   set(${output_var} ${config_options} PARENT_SCOPE)
 endfunction(_get_compile_options_from_config)
 

--- a/libc/config/config.json
+++ b/libc/config/config.json
@@ -186,5 +186,11 @@
       "value": false,
       "doc": "Trap with SIGFPE when feraiseexcept is called with unmasked floating point exceptions, similar to glibc's behavior.  This is currently working only on x86 with SSE."
     }
+  },
+  "assert": {
+    "LIBC_COPT_USE_C_ASSERT": {
+      "value": false,
+      "doc": "Use the system assert macro for LIBC_ASSERT."
+    }
   }
 }

--- a/libc/config/gpu/config.json
+++ b/libc/config/gpu/config.json
@@ -49,5 +49,10 @@
     "LIBC_CONF_ENABLE_STRONG_STACK_PROTECTOR": {
       "value": false
     }
+  },
+  "assert": {
+    "LIBC_COPT_USE_C_ASSERT": {
+      "value": true
+    }
   }
 }

--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -369,15 +369,23 @@ add_header_library(
     libc.src.__support.macros.properties.types
 )
 
-add_header_library(
-  libc_assert
-  HDRS
-    libc_assert.h
-  DEPENDS
-    .integer_to_string
-    libc.src.__support.OSUtil.osutil
-    libc.src.__support.macros.optimization
-)
+if(LIBC_COPT_USE_C_ASSERT OR NOT LLVM_LIBC_FULL_BUILD)
+  add_header_library(
+    libc_assert
+    HDRS
+      libc_assert.h
+  )
+else()
+  add_header_library(
+    libc_assert
+    HDRS
+      libc_assert.h
+    DEPENDS
+      .integer_to_string
+      libc.src.__support.OSUtil.osutil
+      libc.src.__support.macros.optimization
+  )
+endif()
 
 add_header_library(
   hash

--- a/libc/src/__support/time/CMakeLists.txt
+++ b/libc/src/__support/time/CMakeLists.txt
@@ -7,9 +7,11 @@ add_header_library(
     libc.hdr.types.time_t
 )
 
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS}
+   AND TARGET libc.src.__support.OSUtil.osutil)
   add_subdirectory(${LIBC_TARGET_OS})
 else()
+  message(STATUS "Skip libc.src.__support.time.* targets.")
   return()
 endif()
 

--- a/libc/src/time/linux/CMakeLists.txt
+++ b/libc/src/time/linux/CMakeLists.txt
@@ -1,3 +1,9 @@
+if(NOT TARGET libc.src.__support.OSUtil.osutil)
+  message(STATUS "libc.src.__support.OSUtil.osutil is not available. "
+                  "Skip libc.src.time.linux.* targets.")
+  return()
+endif()
+
 add_entrypoint_object(
   timespec_get
   SRCS

--- a/libc/src/unistd/CMakeLists.txt
+++ b/libc/src/unistd/CMakeLists.txt
@@ -1,3 +1,9 @@
+if(NOT TARGET libc.src.__support.OSUtil.osutil)
+  message(STATUS "libc.src.__support.OSUtil.osutil is not avaiable. "
+                 "Skip unistd targets.")
+  return()
+endif()
+
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
 endif()

--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -60,7 +60,7 @@ function(add_unittest_framework_library name)
   endif()
 endfunction()
 
-if (NOT TARGET libc.src.__support.OSUtil.osutil AND NOT LLVM_LIBC_FULL_BUILD)
+if (NOT TARGET libc.src.__support.OSUtil.osutil OR NOT LLVM_LIBC_FULL_BUILD)
   message(STATUS "TestLogger will use system libc's stdio to print.")
   set(test_logger_compile_options "-DLIBC_TEST_USE_SYSTEM_PRINTF")
   set(test_logger_osutil "")

--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -3,7 +3,7 @@ function(add_unittest_framework_library name)
     "TEST_LIB"
     "" # No optional arguments
     "" # No single value arguments
-    "SRCS;HDRS;DEPENDS" # Multi value arguments
+    "SRCS;HDRS;DEPENDS;COMPILE_OPTIONS" # Multi value arguments
     ${ARGN}
   )
   if(NOT TEST_LIB_SRCS)
@@ -30,14 +30,17 @@ function(add_unittest_framework_library name)
     # making LibcFPExceptionHelpers and LibcDeathTestExecutors hermetic.
     set(LLVM_LIBC_FULL_BUILD "")
     _get_common_test_compile_options(compile_options "" "")
-    target_compile_options(${name}.unit PRIVATE ${compile_options})
     set(LLVM_LIBC_FULL_BUILD ON)
   else()
     _get_common_test_compile_options(compile_options "" "")
-    target_compile_options(${name}.unit PRIVATE ${compile_options})
   endif()
 
-  _get_hermetic_test_compile_options(compile_options "")
+  if (TEST_LIB_COMPILE_OPTIONS)
+    list(APPEND compile_options ${TEST_LIB_COMPILE_OPTIONS})
+  endif()
+  target_compile_options(${name}.unit PRIVATE ${compile_options})
+
+    _get_hermetic_test_compile_options(compile_options "")
   target_include_directories(${name}.hermetic PRIVATE ${LIBC_INCLUDE_DIR})
   target_compile_options(${name}.hermetic PRIVATE ${compile_options} -nostdinc++)
 
@@ -57,6 +60,15 @@ function(add_unittest_framework_library name)
   endif()
 endfunction()
 
+if (NOT TARGET libc.src.__support.OSUtil.osutil AND NOT LLVM_LIBC_FULL_BUILD)
+  message(STATUS "TestLogger will use system libc's stdio to print.")
+  set(test_logger_compile_options "-DLIBC_TEST_USE_SYSTEM_PRINTF")
+  set(test_logger_osutil "")
+else()
+  set(test_logger_compile_options "")
+  set(test_logger_osutil "libc.src.__support.OSUtil.osutil")
+endif()
+
 add_unittest_framework_library(
   LibcTest
   SRCS
@@ -68,6 +80,8 @@ add_unittest_framework_library(
     LibcTest.h
     Test.h
     TestLogger.h
+  COMPILE_OPTIONS
+    ${test_logger_compile_options}
   DEPENDS
     libc.hdr.stdint_proxy
     libc.src.__support.big_int
@@ -78,8 +92,8 @@ add_unittest_framework_library(
     libc.src.__support.fixed_point.fx_rep
     libc.src.__support.macros.properties.compiler
     libc.src.__support.macros.properties.types
-    libc.src.__support.OSUtil.osutil
     libc.src.__support.uint128
+    ${test_logger_osutil}
 )
 
 set(libc_death_test_srcs LibcDeathTestExecutors.cpp)

--- a/libc/test/UnitTest/TestLogger.cpp
+++ b/libc/test/UnitTest/TestLogger.cpp
@@ -12,11 +12,13 @@
 #include <stdio.h>
 
 namespace LIBC_NAMESPACE_DECL {
+namespace testing {
 
 void write_to_stderr(cpp::string_view str) {
   fprintf(stderr, "%.*s", static_cast<int>(str.size()), str.data());
 }
 
+} // namespace testing
 } // namespace LIBC_NAMESPACE_DECL
 
 #else // !LIBC_TEST_USE_SYSTEM_PRINTF
@@ -31,7 +33,7 @@ namespace testing {
 // cpp::string_view specialization
 template <>
 TestLogger &TestLogger::operator<< <cpp::string_view>(cpp::string_view str) {
-  LIBC_NAMESPACE::write_to_stderr(str);
+  write_to_stderr(str);
   return *this;
 }
 

--- a/libc/test/UnitTest/TestLogger.cpp
+++ b/libc/test/UnitTest/TestLogger.cpp
@@ -2,11 +2,28 @@
 #include "hdr/stdint_proxy.h"
 #include "src/__support/CPP/string.h"
 #include "src/__support/CPP/string_view.h"
-#include "src/__support/OSUtil/io.h" // write_to_stderr
 #include "src/__support/big_int.h"   // is_big_int
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h" // LIBC_TYPES_HAS_INT128
 #include "src/__support/uint128.h"
+
+#ifdef LIBC_TEST_USE_SYSTEM_PRINTF
+
+#include <stdio.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+void write_to_stderr(cpp::string_view str) {
+  fprintf(stderr, "%.*s", static_cast<int>(str.size()), str.data());
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#else // !LIBC_TEST_USE_SYSTEM_PRINTF
+
+#include "src/__support/OSUtil/io.h" // write_to_stderr
+
+#endif // LIBC_TEST_USE_SYSTEM_PRINTF
 
 namespace LIBC_NAMESPACE_DECL {
 namespace testing {


### PR DESCRIPTION
Several key targets unconditionally depend on `OSUtil.osutil` target, causing errors when it is unnecessarily linked, or not available.  This PR fine-tuning the dependency on `OSUtil.osutil` to cleanly decouple those targets, and gracefully skip targets that need `osutil`.  Main changes include:

* Make `LIBC_COPT_USE_C_ASSERT` to a cmake config, allowing `LIBC_ASSERT` to use system's `assert` and not depending on `osutil`.
* Adjust cmake dependency for the following targets:
  - libc.src.__support.libc_assert
  - libc.src.__support.time.*
  - libc.src.time.linux.*
  - libc.src.unistd.*
  - LibcTest
* Give an option for `TestLogger` to use system's `fprintf` instead of `osutil`.