### PR TITLE
[AArch64][llvm] Separate TLBI-only feature gating from TLBIP aliases (part 2)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SystemOperands.td
+++ b/llvm/lib/Target/AArch64/AArch64SystemOperands.td
@@ -1036,7 +1036,7 @@ foreach I = TLBIRMI in {
   }
 }
 
-// Armv9-A Realm Management Extension TLBI Instructions
+// Armv9-A Realm Management Extension TLBI Instructions.
 defvar TLBIRME = [
   //    name        op1    CRm     op2    reguse
   TLBI<"RPAOS",     0b110, 0b0100, 0b011, REG_REQUIRED>,


### PR DESCRIPTION
(This is the change message for 306e86be5, which GitHub unhelpfully discarded
when I enabled "auto-merge" when all tests had passed. It merged my change
and didn't merge the detailed commit message which I had carefully written(!)

So this is an NFC change, for those in the future looking for the lost message,
which explains the changes in 306e86be5)

-------------

Correct the `TLBI` system operand definitions so the emitted aliases are
generated from a single data table per feature group. The TLBI data is now
written once as anonymous `TLBI<...>` entries inside a defvar list, and we
iterate over it with a foreach to define those entries.

Hopefully this is clearer and more future-proof, since it is a complex set of
interactions between `tlbi`/`tlbip` with `*nXS` variants, and differing gating.

The gating was incorrect before. The gating is now:
  - `FeatureTLB_RMI`, `FeatureRME`, and `FeatureTLBIW` gate only TLBI aliases
  - non-TLBIW `TLBI` ...nXS aliases are `FeatureXS-only`
  - `TLBIW` ...nXS aliases are `FeatureTLBIW`-only
  - all `TLBIP` aliases, including ...nXS, are `FeatureD128`-only

Update testcases accordingly (`llvm/test/MC/AArch64/armv8.7a-xs.s` had
inconsistent use of hyphen and underscore for error checking)