### PR TITLE
[libc] Add wchar support to File

### DIFF
--- a/libc/src/__support/File/CMakeLists.txt
+++ b/libc/src/__support/File/CMakeLists.txt
@@ -20,6 +20,9 @@ add_object_library(
     libc.src.__support.CPP.span
     libc.src.__support.threads.mutex
     libc.src.__support.error_or
+    libc.src.__support.wchar.mbrtowc
+    libc.src.__support.wchar.mbstate
+    libc.src.__support.wchar.wcrtomb
 )
 
 add_object_library(

--- a/libc/src/__support/File/CMakeLists.txt
+++ b/libc/src/__support/File/CMakeLists.txt
@@ -18,6 +18,7 @@ add_object_library(
     libc.hdr.types.off_t
     libc.hdr.types.wchar_t
     libc.hdr.types.wint_t
+    libc.hdr.wchar_macros
     libc.src.__support.CPP.new
     libc.src.__support.CPP.span
     libc.src.__support.threads.mutex

--- a/libc/src/__support/File/CMakeLists.txt
+++ b/libc/src/__support/File/CMakeLists.txt
@@ -16,13 +16,19 @@ add_object_library(
     libc.hdr.stdint_proxy
     libc.hdr.func.realloc
     libc.hdr.types.off_t
+    libc.hdr.types.wchar_t
+    libc.hdr.types.wint_t
     libc.src.__support.CPP.new
     libc.src.__support.CPP.span
     libc.src.__support.threads.mutex
     libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.src.__support.macros.properties.architectures
     libc.src.__support.wchar.mbrtowc
     libc.src.__support.wchar.mbstate
     libc.src.__support.wchar.wcrtomb
+    libc.src.string.memory_utils.inline_memcpy
+    libc.src.__support.libc_errno
 )
 
 add_object_library(

--- a/libc/src/__support/File/CMakeLists.txt
+++ b/libc/src/__support/File/CMakeLists.txt
@@ -25,11 +25,11 @@ add_object_library(
     libc.src.__support.error_or
     libc.src.__support.macros.config
     libc.src.__support.macros.properties.architectures
-    libc.src.__support.wchar.mbrtowc
     libc.src.__support.wchar.mbstate
     libc.src.__support.wchar.wcrtomb
+    libc.src.__support.wchar.character_converter
     libc.src.string.memory_utils.inline_memcpy
-    libc.src.__support.libc_errno
+    libc.hdr.errno_macros
 )
 
 add_object_library(

--- a/libc/src/__support/File/file.cpp
+++ b/libc/src/__support/File/file.cpp
@@ -581,13 +581,10 @@ FileIOResult File::write_unlocked(const wchar_t *ws, size_t len) {
       }
       char8_t byte = pop_res.value();
       auto write_res = write_unlocked_impl(&byte, 1);
-      if (write_res.has_error()) {
-        err = true;
+      if (write_res.has_error())
         return {written, write_res.error};
-      }
-      if (write_res.value < 1) {
+      if (write_res.value < 1)
         return {written, 0};
-      }
     }
     ++written;
   }
@@ -612,9 +609,8 @@ FileIOResult File::read_unlocked(wchar_t *ws, size_t len) {
     while (!cr.isFull()) {
       uint8_t byte;
       auto read_res = read_unlocked_impl(&byte, 1);
-      if (read_res.has_error()) {
+      if (read_res.has_error())
         return {read_count, read_res.error};
-      }
       if (read_res.value == 0) { // EOF
         if (cr.isEmpty())
           return {read_count, 0};
@@ -638,41 +634,42 @@ FileIOResult File::read_unlocked(wchar_t *ws, size_t len) {
   return {read_count, 0};
 }
 
-wint_t File::ungetwc_unlocked(wchar_t wc) {
-  if (orientation == Orientation::UNORIENTED)
-    orientation = Orientation::WIDE;
-  if (orientation != Orientation::WIDE) {
+wint_t File::ungetwc_unlocked(wint_t wc) {
+  if (wc == WEOF)
+    return WEOF;
+  switch (orientation) {
+  case Orientation::BYTE:
     err = true;
     return WEOF;
+  case Orientation::UNORIENTED:
+    orientation = Orientation::WIDE;
+    break;
+  case Orientation::WIDE:
+    break;
   }
 
   char buf[4];
-  auto result = internal::wcrtomb(buf, wc, &mbstate);
-  if (!result.has_value()) {
-    err = true;
+  auto result = internal::wcrtomb(buf, static_cast<wchar_t>(wc), &mbstate);
+  if (!result.has_value())
     return WEOF;
-  }
+
   size_t n = result.value();
 
   if (read_limit == 0) {
-    if (n > bufsize) {
-      err = true;
+    if (n > bufsize)
       return WEOF;
-    }
-    for (size_t i = 0; i < n; ++i) {
+
+    for (size_t i = 0; i < n; ++i)
       this->buf[i] = static_cast<uint8_t>(buf[i]);
-    }
+
     read_limit = n;
     pos = 0;
   } else {
-    if (pos < n) {
-      err = true;
+    if (pos < n)
       return WEOF;
-    }
     pos -= n;
-    for (size_t i = 0; i < n; ++i) {
+    for (size_t i = 0; i < n; ++i)
       this->buf[pos + i] = static_cast<uint8_t>(buf[i]);
-    }
   }
   eof = false;
   err = false;

--- a/libc/src/__support/File/file.cpp
+++ b/libc/src/__support/File/file.cpp
@@ -17,7 +17,7 @@
 #include "src/__support/alloc-checker.h"
 #include "src/__support/libc_errno.h" // For error macros
 #include "src/__support/macros/config.h"
-#include "src/__support/wchar/mbrtowc.h"
+#include "src/__support/wchar/character_converter.h"
 #include "src/__support/wchar/wcrtomb.h"
 #include "src/string/memory_utils/inline_memcpy.h"
 
@@ -567,48 +567,31 @@ FileIOResult File::write_unlocked(const wchar_t *ws, size_t len) {
 
   size_t written = 0;
   for (size_t i = 0; i < len; ++i) {
-    char buf[4];
-    auto result = internal::wcrtomb(buf, ws[i], &mbstate);
-    if (!result.has_value()) {
+    internal::CharacterConverter cr(&mbstate);
+    int push_err = cr.push(static_cast<char32_t>(ws[i]));
+    if (push_err != 0) {
       err = true;
-      return {written, result.error()};
+      return {written, push_err};
     }
-    size_t n = result.value();
-    auto write_res = write_unlocked_impl(buf, n);
-    if (write_res.has_error()) {
-      err = true;
-      return {written, write_res.error};
-    }
-    if (write_res.value < n) {
-      // Partial write of bytes.
-      return {written, 0};
+    while (!cr.isEmpty()) {
+      auto pop_res = cr.pop<char8_t>();
+      if (!pop_res.has_value()) {
+        err = true;
+        return {written, pop_res.error()};
+      }
+      char8_t byte = pop_res.value();
+      auto write_res = write_unlocked_impl(&byte, 1);
+      if (write_res.has_error()) {
+        err = true;
+        return {written, write_res.error};
+      }
+      if (write_res.value < 1) {
+        return {written, 0};
+      }
     }
     ++written;
   }
   return {written, 0};
-}
-
-FileIOResult File::write_wide_character_unlocked(wchar_t wc) {
-  switch (orientation) {
-  case Orientation::BYTE:
-    err = true;
-    return {0, EINVAL};
-  case Orientation::UNORIENTED:
-    orientation = Orientation::WIDE;
-    break;
-  case Orientation::WIDE:
-    break;
-  }
-
-  char buf[4];
-  auto result = internal::wcrtomb(buf, wc, &mbstate);
-  if (!result.has_value()) {
-    err = true;
-    return {0, result.error()};
-  }
-
-  size_t n = result.value();
-  return write_unlocked_impl(buf, n);
 }
 
 FileIOResult File::read_unlocked(wchar_t *ws, size_t len) {
@@ -625,62 +608,35 @@ FileIOResult File::read_unlocked(wchar_t *ws, size_t len) {
 
   size_t read_count = 0;
   for (size_t i = 0; i < len; ++i) {
-    auto res = read_wide_character_unlocked();
-    if (!res.has_value()) {
-      if (res.error() == 0) { // EOF
-        break;
+    internal::CharacterConverter cr(&mbstate);
+    while (!cr.isFull()) {
+      uint8_t byte;
+      auto read_res = read_unlocked_impl(&byte, 1);
+      if (read_res.has_error()) {
+        err = true;
+        return {read_count, read_res.error};
       }
-      err = true;
-      return {read_count, res.error()};
+      if (read_res.value == 0) { // EOF
+        if (cr.isEmpty())
+          return {read_count, 0};
+        err = true;
+        return {read_count, EILSEQ}; // Incomplete character at EOF
+      }
+      int push_err = cr.push(static_cast<char8_t>(byte));
+      if (push_err != 0) {
+        err = true;
+        return {read_count, push_err};
+      }
     }
-    ws[i] = res.value();
+    auto pop_res = cr.pop<char32_t>();
+    if (!pop_res.has_value()) {
+      err = true;
+      return {read_count, pop_res.error()};
+    }
+    ws[i] = static_cast<wchar_t>(pop_res.value());
     ++read_count;
   }
   return {read_count, 0};
-}
-
-ErrorOr<wchar_t> File::read_wide_character_unlocked() {
-  switch (orientation) {
-  case Orientation::BYTE:
-    err = true;
-    return Error(EINVAL);
-  case Orientation::UNORIENTED:
-    orientation = Orientation::WIDE;
-    break;
-  case Orientation::WIDE:
-    break;
-  }
-
-  wchar_t wc;
-  bool first_byte = true;
-  while (true) {
-    uint8_t byte;
-    FileIOResult read_result = read_unlocked_impl(&byte, 1);
-    if (read_result.has_error()) {
-      err = true;
-      return Error(read_result.error);
-    }
-    if (read_result.value == 0) { // EOF
-      if (first_byte) {
-        return Error(0); // EOF
-      }
-      err = true;
-      return Error(EILSEQ); // Incomplete character at EOF
-    }
-    char c = static_cast<char>(byte);
-    auto res = internal::mbrtowc(&wc, &c, 1, &mbstate);
-    if (!res.has_value()) {
-      err = true;
-      return Error(res.error());
-    }
-    if (res.value() == 0) { // null terminator
-      return L'\0';
-    }
-    if (res.value() != static_cast<size_t>(-2)) { // Complete character
-      return wc;
-    }
-    first_byte = false;
-  }
 }
 
 wint_t File::ungetwc_unlocked(wchar_t wc) {

--- a/libc/src/__support/File/file.cpp
+++ b/libc/src/__support/File/file.cpp
@@ -86,9 +86,8 @@ FileIOResult File::write_unlocked_impl(const void *data, size_t len) {
   if (bufmode == _IOFBF) { // fully buffered
     return write_unlocked_fbf(static_cast<const uint8_t *>(data), len);
   }
-  /*if (bufmode == _IOLBF) */ { // line buffered
-    return write_unlocked_lbf(static_cast<const uint8_t *>(data), len);
-  }
+  return write_unlocked_lbf(static_cast<const uint8_t *>(data),
+                            len); // line buffered
 }
 
 FileIOResult File::write_unlocked_nbf(const uint8_t *data, size_t len) {
@@ -280,9 +279,7 @@ size_t File::copy_data_from_buf(uint8_t *data, size_t len) {
   }
 
   // Copy all of the available data.
-  // TODO: Replace the for loop with a call to internal memcpy.
-  for (size_t i = 0; i < available_data; ++i)
-    dataref[i] = bufref[i + pos];
+  inline_memcpy(dataref.data(), bufref.data() + pos, available_data);
   read_limit = pos = 0; // Reset the pointers.
 
   return available_data;
@@ -409,14 +406,19 @@ ErrorOr<int> File::seek(off_t offset, int whence) {
     // function. Note that read_limit >= pos is always true.
     offset -= (read_limit - pos);
   }
-  pos = read_limit = 0;
-  prev_op = FileOp::SEEK;
-  // Reset the eof flag as a seek might move the file positon to some place
-  // readable.
-  eof = false;
   auto result = platform_seek(this, offset, whence);
   if (!result.has_value())
     return Error(result.error());
+
+  pos = read_limit = 0;
+  prev_op = FileOp::SEEK;
+  // Reset the eof flag as a seek might move the file position to some place
+  // readable.
+  eof = false;
+  if (orientation == Orientation::WIDE ||
+      orientation == Orientation::UNORIENTED)
+    mbstate = internal::mbstate();
+
   return 0;
 }
 

--- a/libc/src/__support/File/file.cpp
+++ b/libc/src/__support/File/file.cpp
@@ -255,11 +255,9 @@ FileIOResult File::read_unlocked_impl(void *data, size_t len) {
 
   if (bufmode == _IONBF) { // unbuffered.
     return read_unlocked_nbf(static_cast<uint8_t *>(data), len);
-  }
-  if (bufmode == _IOFBF) { // fully buffered
+  } else if (bufmode == _IOFBF) { // fully buffered
     return read_unlocked_fbf(static_cast<uint8_t *>(data), len);
-  }
-  /*if (bufmode == _IOLBF) */ { // line buffered
+  } else /*if (bufmode == _IOLBF) */ { // line buffered
     // There is no line buffered mode for read. Use fully buffered instead.
     return read_unlocked_fbf(static_cast<uint8_t *>(data), len);
   }

--- a/libc/src/__support/File/file.cpp
+++ b/libc/src/__support/File/file.cpp
@@ -56,13 +56,20 @@ void File::lock_list() { File::list_lock.lock(); }
 void File::unlock_list() { File::list_lock.unlock(); }
 
 FileIOResult File::write_unlocked(const void *data, size_t len) {
-  if (orientation == Orientation::WIDE) {
+  switch (orientation) {
+  case Orientation::WIDE:
     err = true;
     return {0, EINVAL};
-  }
-  if (orientation == Orientation::UNORIENTED)
+  case Orientation::UNORIENTED:
     orientation = Orientation::BYTE;
+    break;
+  case Orientation::BYTE:
+    break;
+  }
+  return write_unlocked_impl(data, len);
+}
 
+FileIOResult File::write_unlocked_impl(const void *data, size_t len) {
   if (!write_allowed()) {
     err = true;
     return {0, EBADF};
@@ -75,9 +82,11 @@ FileIOResult File::write_unlocked(const void *data, size_t len) {
         write_unlocked_nbf(static_cast<const uint8_t *>(data), len);
     flush_unlocked();
     return ret_val;
-  } else if (bufmode == _IOFBF) { // fully buffered
+  }
+  if (bufmode == _IOFBF) { // fully buffered
     return write_unlocked_fbf(static_cast<const uint8_t *>(data), len);
-  } else /*if (bufmode == _IOLBF) */ { // line buffered
+  }
+  /*if (bufmode == _IOLBF) */ { // line buffered
     return write_unlocked_lbf(static_cast<const uint8_t *>(data), len);
   }
 }
@@ -224,13 +233,20 @@ FileIOResult File::write_unlocked_lbf(const uint8_t *data, size_t len) {
 }
 
 FileIOResult File::read_unlocked(void *data, size_t len) {
-  if (orientation == Orientation::WIDE) {
+  switch (orientation) {
+  case Orientation::WIDE:
     err = true;
     return {0, EINVAL};
-  }
-  if (orientation == Orientation::UNORIENTED)
+  case Orientation::UNORIENTED:
     orientation = Orientation::BYTE;
+    break;
+  case Orientation::BYTE:
+    break;
+  }
+  return read_unlocked_impl(data, len);
+}
 
+FileIOResult File::read_unlocked_impl(void *data, size_t len) {
   if (!read_allowed()) {
     err = true;
     return {0, EBADF};
@@ -240,9 +256,11 @@ FileIOResult File::read_unlocked(void *data, size_t len) {
 
   if (bufmode == _IONBF) { // unbuffered.
     return read_unlocked_nbf(static_cast<uint8_t *>(data), len);
-  } else if (bufmode == _IOFBF) { // fully buffered
+  }
+  if (bufmode == _IOFBF) { // fully buffered
     return read_unlocked_fbf(static_cast<uint8_t *>(data), len);
-  } else /*if (bufmode == _IOLBF) */ { // line buffered
+  }
+  /*if (bufmode == _IOLBF) */ { // line buffered
     // There is no line buffered mode for read. Use fully buffered instead.
     return read_unlocked_fbf(static_cast<uint8_t *>(data), len);
   }
@@ -533,66 +551,109 @@ File::ModeFlags File::mode_flags(const char *mode) {
   return flags;
 }
 
-FileIOResult File::write_wide_character_unlocked(wchar_t wc) {
-  if (orientation == Orientation::UNORIENTED)
-    orientation = Orientation::WIDE;
-  if (orientation != Orientation::WIDE) {
+FileIOResult File::write_unlocked(const wchar_t *ws, size_t len) {
+  switch (orientation) {
+  case Orientation::BYTE:
     err = true;
     return {0, EINVAL};
+  case Orientation::UNORIENTED:
+    orientation = Orientation::WIDE;
+    break;
+  case Orientation::WIDE:
+    break;
   }
 
-  if (!write_allowed()) {
+  size_t written = 0;
+  for (size_t i = 0; i < len; ++i) {
+    char buf[4];
+    auto result = internal::wcrtomb(buf, ws[i], &mbstate);
+    if (!result.has_value()) {
+      err = true;
+      return {written, result.error()};
+    }
+    size_t n = result.value();
+    auto write_res = write_unlocked_impl(buf, n);
+    if (write_res.has_error()) {
+      err = true;
+      return {written, write_res.error};
+    }
+    if (write_res.value < n) {
+      // Partial write of bytes.
+      return {written, 0};
+    }
+    ++written;
+  }
+  return {written, 0};
+}
+
+FileIOResult File::write_wide_character_unlocked(wchar_t wc) {
+  switch (orientation) {
+  case Orientation::BYTE:
     err = true;
-    return {0, EBADF};
+    return {0, EINVAL};
+  case Orientation::UNORIENTED:
+    orientation = Orientation::WIDE;
+    break;
+  case Orientation::WIDE:
+    break;
   }
-
-  prev_op = FileOp::WRITE;
 
   char buf[4];
-  auto result = internal::wcrtomb(buf, wc, &shift_state);
+  auto result = internal::wcrtomb(buf, wc, &mbstate);
   if (!result.has_value()) {
     err = true;
     return {0, result.error()};
   }
 
   size_t n = result.value();
-  if (bufmode == _IONBF) {
-    size_t ret_val =
-        write_unlocked_nbf(reinterpret_cast<const uint8_t *>(buf), n);
-    flush_unlocked();
-    return ret_val;
-  } else if (bufmode == _IOFBF) {
-    return write_unlocked_fbf(reinterpret_cast<const uint8_t *>(buf), n);
-  } else {
-    return write_unlocked_lbf(reinterpret_cast<const uint8_t *>(buf), n);
+  return write_unlocked_impl(buf, n);
+}
+
+FileIOResult File::read_unlocked(wchar_t *ws, size_t len) {
+  switch (orientation) {
+  case Orientation::BYTE:
+    err = true;
+    return {0, EINVAL};
+  case Orientation::UNORIENTED:
+    orientation = Orientation::WIDE;
+    break;
+  case Orientation::WIDE:
+    break;
   }
+
+  size_t read_count = 0;
+  for (size_t i = 0; i < len; ++i) {
+    auto res = read_wide_character_unlocked();
+    if (!res.has_value()) {
+      if (res.error() == 0) { // EOF
+        break;
+      }
+      err = true;
+      return {read_count, res.error()};
+    }
+    ws[i] = res.value();
+    ++read_count;
+  }
+  return {read_count, 0};
 }
 
 ErrorOr<wchar_t> File::read_wide_character_unlocked() {
-  if (orientation == Orientation::UNORIENTED)
-    orientation = Orientation::WIDE;
-  if (orientation != Orientation::WIDE) {
+  switch (orientation) {
+  case Orientation::BYTE:
     err = true;
     return Error(EINVAL);
+  case Orientation::UNORIENTED:
+    orientation = Orientation::WIDE;
+    break;
+  case Orientation::WIDE:
+    break;
   }
-
-  if (!read_allowed()) {
-    err = true;
-    return Error(EBADF);
-  }
-
-  prev_op = FileOp::READ;
 
   wchar_t wc;
   bool first_byte = true;
   while (true) {
     uint8_t byte;
-    FileIOResult read_result{0};
-    if (bufmode == _IONBF) {
-      read_result = read_unlocked_nbf(&byte, 1);
-    } else {
-      read_result = read_unlocked_fbf(&byte, 1);
-    }
+    FileIOResult read_result = read_unlocked_impl(&byte, 1);
     if (read_result.has_error()) {
       err = true;
       return Error(read_result.error);
@@ -600,13 +661,12 @@ ErrorOr<wchar_t> File::read_wide_character_unlocked() {
     if (read_result.value == 0) { // EOF
       if (first_byte) {
         return Error(0); // EOF
-      } else {
-        err = true;
-        return Error(EILSEQ); // Incomplete character at EOF
       }
+      err = true;
+      return Error(EILSEQ); // Incomplete character at EOF
     }
     char c = static_cast<char>(byte);
-    auto res = internal::mbrtowc(&wc, &c, 1, &shift_state);
+    auto res = internal::mbrtowc(&wc, &c, 1, &mbstate);
     if (!res.has_value()) {
       err = true;
       return Error(res.error());
@@ -630,7 +690,7 @@ wint_t File::ungetwc_unlocked(wchar_t wc) {
   }
 
   char buf[4];
-  auto result = internal::wcrtomb(buf, wc, &shift_state);
+  auto result = internal::wcrtomb(buf, wc, &mbstate);
   if (!result.has_value()) {
     err = true;
     return WEOF;

--- a/libc/src/__support/File/file.cpp
+++ b/libc/src/__support/File/file.cpp
@@ -11,11 +11,14 @@
 #include "hdr/func/realloc.h"
 #include "hdr/stdio_macros.h"
 #include "hdr/types/off_t.h"
+#include "hdr/wchar_macros.h"
 #include "src/__support/CPP/new.h"
 #include "src/__support/CPP/span.h"
 #include "src/__support/alloc-checker.h"
 #include "src/__support/libc_errno.h" // For error macros
 #include "src/__support/macros/config.h"
+#include "src/__support/wchar/mbrtowc.h"
+#include "src/__support/wchar/wcrtomb.h"
 #include "src/string/memory_utils/inline_memcpy.h"
 
 namespace LIBC_NAMESPACE_DECL {
@@ -53,6 +56,13 @@ void File::lock_list() { File::list_lock.lock(); }
 void File::unlock_list() { File::list_lock.unlock(); }
 
 FileIOResult File::write_unlocked(const void *data, size_t len) {
+  if (orientation == Orientation::WIDE) {
+    err = true;
+    return {0, EINVAL};
+  }
+  if (orientation == Orientation::UNORIENTED)
+    orientation = Orientation::BYTE;
+
   if (!write_allowed()) {
     err = true;
     return {0, EBADF};
@@ -214,6 +224,13 @@ FileIOResult File::write_unlocked_lbf(const uint8_t *data, size_t len) {
 }
 
 FileIOResult File::read_unlocked(void *data, size_t len) {
+  if (orientation == Orientation::WIDE) {
+    err = true;
+    return {0, EINVAL};
+  }
+  if (orientation == Orientation::UNORIENTED)
+    orientation = Orientation::BYTE;
+
   if (!read_allowed()) {
     err = true;
     return {0, EBADF};
@@ -315,6 +332,13 @@ FileIOResult File::read_unlocked_nbf(uint8_t *data, size_t len) {
 }
 
 int File::ungetc_unlocked(int c) {
+  if (orientation == Orientation::WIDE) {
+    err = true;
+    return EOF;
+  }
+  if (orientation == Orientation::UNORIENTED)
+    orientation = Orientation::BYTE;
+
   // There is no meaning to unget if:
   // 1. You are trying to push back EOF.
   // 2. Read operations are not allowed on this file.
@@ -507,6 +531,131 @@ File::ModeFlags File::mode_flags(const char *mode) {
     return 0;
 
   return flags;
+}
+
+FileIOResult File::write_wide_character_unlocked(wchar_t wc) {
+  if (orientation == Orientation::UNORIENTED)
+    orientation = Orientation::WIDE;
+  if (orientation != Orientation::WIDE) {
+    err = true;
+    return {0, EINVAL};
+  }
+
+  if (!write_allowed()) {
+    err = true;
+    return {0, EBADF};
+  }
+
+  prev_op = FileOp::WRITE;
+
+  char buf[4];
+  auto result = internal::wcrtomb(buf, wc, &shift_state);
+  if (!result.has_value()) {
+    err = true;
+    return {0, result.error()};
+  }
+
+  size_t n = result.value();
+  if (bufmode == _IONBF) {
+    size_t ret_val =
+        write_unlocked_nbf(reinterpret_cast<const uint8_t *>(buf), n);
+    flush_unlocked();
+    return ret_val;
+  } else if (bufmode == _IOFBF) {
+    return write_unlocked_fbf(reinterpret_cast<const uint8_t *>(buf), n);
+  } else {
+    return write_unlocked_lbf(reinterpret_cast<const uint8_t *>(buf), n);
+  }
+}
+
+ErrorOr<wchar_t> File::read_wide_character_unlocked() {
+  if (orientation == Orientation::UNORIENTED)
+    orientation = Orientation::WIDE;
+  if (orientation != Orientation::WIDE) {
+    err = true;
+    return Error(EINVAL);
+  }
+
+  if (!read_allowed()) {
+    err = true;
+    return Error(EBADF);
+  }
+
+  prev_op = FileOp::READ;
+
+  wchar_t wc;
+  bool first_byte = true;
+  while (true) {
+    uint8_t byte;
+    FileIOResult read_result{0};
+    if (bufmode == _IONBF) {
+      read_result = read_unlocked_nbf(&byte, 1);
+    } else {
+      read_result = read_unlocked_fbf(&byte, 1);
+    }
+    if (read_result.has_error()) {
+      err = true;
+      return Error(read_result.error);
+    }
+    if (read_result.value == 0) { // EOF
+      if (first_byte) {
+        return Error(0); // EOF
+      } else {
+        err = true;
+        return Error(EILSEQ); // Incomplete character at EOF
+      }
+    }
+    char c = static_cast<char>(byte);
+    auto res = internal::mbrtowc(&wc, &c, 1, &shift_state);
+    if (!res.has_value()) {
+      err = true;
+      return Error(res.error());
+    }
+    if (res.value() == 0) { // null terminator
+      return L'\0';
+    }
+    if (res.value() != static_cast<size_t>(-2)) { // Complete character
+      return wc;
+    }
+    first_byte = false;
+  }
+}
+
+wint_t File::ungetwc_unlocked(wchar_t wc) {
+  if (orientation == Orientation::UNORIENTED)
+    orientation = Orientation::WIDE;
+  if (orientation != Orientation::WIDE) {
+    err = true;
+    return WEOF;
+  }
+
+  char buf[4];
+  auto result = internal::wcrtomb(buf, wc, &shift_state);
+  if (!result.has_value()) {
+    err = true;
+    return WEOF;
+  }
+  size_t n = result.value();
+
+  if (read_limit == 0) {
+    for (size_t i = 0; i < n; ++i) {
+      this->buf[i] = static_cast<uint8_t>(buf[i]);
+    }
+    read_limit = n;
+    pos = 0;
+  } else {
+    if (pos < n) {
+      err = true;
+      return WEOF;
+    }
+    pos -= n;
+    for (size_t i = 0; i < n; ++i) {
+      this->buf[pos + i] = static_cast<uint8_t>(buf[i]);
+    }
+  }
+  eof = false;
+  err = false;
+  return wc;
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/__support/File/file.cpp
+++ b/libc/src/__support/File/file.cpp
@@ -8,6 +8,7 @@
 
 #include "file.h"
 
+#include "hdr/errno_macros.h"
 #include "hdr/func/realloc.h"
 #include "hdr/stdio_macros.h"
 #include "hdr/types/off_t.h"
@@ -15,7 +16,6 @@
 #include "src/__support/CPP/new.h"
 #include "src/__support/CPP/span.h"
 #include "src/__support/alloc-checker.h"
-#include "src/__support/libc_errno.h" // For error macros
 #include "src/__support/macros/config.h"
 #include "src/__support/wchar/character_converter.h"
 #include "src/__support/wchar/wcrtomb.h"

--- a/libc/src/__support/File/file.cpp
+++ b/libc/src/__support/File/file.cpp
@@ -613,7 +613,6 @@ FileIOResult File::read_unlocked(wchar_t *ws, size_t len) {
       uint8_t byte;
       auto read_res = read_unlocked_impl(&byte, 1);
       if (read_res.has_error()) {
-        err = true;
         return {read_count, read_res.error};
       }
       if (read_res.value == 0) { // EOF

--- a/libc/src/__support/File/file.cpp
+++ b/libc/src/__support/File/file.cpp
@@ -655,6 +655,10 @@ wint_t File::ungetwc_unlocked(wchar_t wc) {
   size_t n = result.value();
 
   if (read_limit == 0) {
+    if (n > bufsize) {
+      err = true;
+      return WEOF;
+    }
     for (size_t i = 0; i < n; ++i) {
       this->buf[i] = static_cast<uint8_t>(buf[i]);
     }

--- a/libc/src/__support/File/file.cpp
+++ b/libc/src/__support/File/file.cpp
@@ -83,9 +83,8 @@ FileIOResult File::write_unlocked_impl(const void *data, size_t len) {
     flush_unlocked();
     return ret_val;
   }
-  if (bufmode == _IOFBF) { // fully buffered
+  if (bufmode == _IOFBF) // fully buffered
     return write_unlocked_fbf(static_cast<const uint8_t *>(data), len);
-  }
   return write_unlocked_lbf(static_cast<const uint8_t *>(data),
                             len); // line buffered
 }
@@ -571,6 +570,9 @@ FileIOResult File::write_unlocked(const wchar_t *ws, size_t len) {
       err = true;
       return {written, push_err};
     }
+    // buffer the whole wchar to save on calls to write.
+    char buffer[4];
+    size_t char_size = 0;
     while (!cr.isEmpty()) {
       auto pop_res = cr.pop<char8_t>();
       if (!pop_res.has_value()) {
@@ -578,12 +580,14 @@ FileIOResult File::write_unlocked(const wchar_t *ws, size_t len) {
         return {written, pop_res.error()};
       }
       char8_t byte = pop_res.value();
-      auto write_res = write_unlocked_impl(&byte, 1);
-      if (write_res.has_error())
-        return {written, write_res.error};
-      if (write_res.value < 1)
-        return {written, 0};
+      buffer[char_size] = byte;
+      ++char_size;
     }
+    auto write_res = write_unlocked_impl(buffer, char_size);
+    if (write_res.has_error())
+      return {written, write_res.error};
+    if (write_res.value < 1)
+      return {written, 0};
     ++written;
   }
   return {written, 0};

--- a/libc/src/__support/File/file.cpp
+++ b/libc/src/__support/File/file.cpp
@@ -344,19 +344,23 @@ FileIOResult File::read_unlocked_nbf(uint8_t *data, size_t len) {
 }
 
 int File::ungetc_unlocked(int c) {
-  if (orientation == Orientation::WIDE) {
-    err = true;
-    return EOF;
-  }
-  if (orientation == Orientation::UNORIENTED)
-    orientation = Orientation::BYTE;
-
   // There is no meaning to unget if:
   // 1. You are trying to push back EOF.
   // 2. Read operations are not allowed on this file.
   // 3. The previous operation was a write operation.
   if (c == EOF || !read_allowed() || (prev_op == FileOp::WRITE))
     return EOF;
+
+  switch (orientation) {
+  case Orientation::WIDE:
+    err = true;
+    return EOF;
+  case Orientation::UNORIENTED:
+    orientation = Orientation::BYTE;
+    break;
+  case Orientation::BYTE:
+    break;
+  }
 
   cpp::span<uint8_t> bufref(static_cast<uint8_t *>(buf), bufsize);
   if (read_limit == 0) {
@@ -637,7 +641,11 @@ FileIOResult File::read_unlocked(wchar_t *ws, size_t len) {
 }
 
 wint_t File::ungetwc_unlocked(wint_t wc) {
-  if (wc == WEOF)
+  // There is no meaning to unget if:
+  // 1. You are trying to push back EOF.
+  // 2. Read operations are not allowed on this file.
+  // 3. The previous operation was a write operation.
+  if (wc == WEOF || !read_allowed() || (prev_op == FileOp::WRITE))
     return WEOF;
   switch (orientation) {
   case Orientation::BYTE:

--- a/libc/src/__support/File/file.h
+++ b/libc/src/__support/File/file.h
@@ -107,8 +107,9 @@ private:
 
   // For files which are readable, we should be able to support one ungetc
   // operation even if |buf| is nullptr. So, in the constructor of File, we
-  // set |buf| to point to this buffer character.
-  uint8_t ungetc_buf;
+  // set |buf| to point to this buffer character. It needs to be at least 4
+  // bytes so we can store a widechar.
+  uint8_t ungetc_buf[4];
 
   uint8_t *buf;   // Pointer to the stream buffer for buffered streams
   size_t bufsize; // Size of the buffer pointed to by |buf|.
@@ -178,7 +179,7 @@ public:
       : platform_write(wf), platform_read(rf), platform_seek(sf),
         platform_close(cf), mutex(/*timed=*/false, /*recursive=*/false,
                                   /*robust=*/false, /*pshared=*/false),
-        ungetc_buf(0), buf(buffer), bufsize(buffer_size), bufmode(buffer_mode),
+        ungetc_buf{}, buf(buffer), bufsize(buffer_size), bufmode(buffer_mode),
         own_buf(owned), mode(modeflags), pos(0), prev_op(FileOp::NONE),
         read_limit(0), eof(false), err(false),
         orientation(Orientation::UNORIENTED), mbstate(), prev(nullptr),
@@ -371,8 +372,9 @@ private:
       // 3. If user wants _IONBF, then the buffer is ignored for writing.
       // So, all of the above cases, having a single ungetc buffer does not
       // affect the behavior experienced by the user.
-      buf = &ungetc_buf;
-      bufsize = 1;
+      buf = ungetc_buf;
+      bufsize = sizeof(ungetc_buf);
+      own_buf = false; // We shouldn't call free on |buf| when closing the file.
     }
   }
 

--- a/libc/src/__support/File/file.h
+++ b/libc/src/__support/File/file.h
@@ -240,9 +240,9 @@ public:
     return read_unlocked(ws, len);
   }
 
-  wint_t ungetwc_unlocked(wchar_t wc);
+  wint_t ungetwc_unlocked(wint_t wc);
 
-  wint_t ungetwc(wchar_t wc) {
+  wint_t ungetwc(wint_t wc) {
     FileLock lock(this);
     return ungetwc_unlocked(wc);
   }

--- a/libc/src/__support/File/file.h
+++ b/libc/src/__support/File/file.h
@@ -137,7 +137,7 @@ private:
   bool err;
 
   Orientation orientation;
-  internal::mbstate shift_state;
+  internal::mbstate mbstate;
 
   // This is a convenience RAII class to lock and unlock file objects.
   class FileLock {
@@ -181,7 +181,7 @@ public:
         ungetc_buf(0), buf(buffer), bufsize(buffer_size), bufmode(buffer_mode),
         own_buf(owned), mode(modeflags), pos(0), prev_op(FileOp::NONE),
         read_limit(0), eof(false), err(false),
-        orientation(Orientation::UNORIENTED), shift_state(), prev(nullptr),
+        orientation(Orientation::UNORIENTED), mbstate(), prev(nullptr),
         next(nullptr), {
     adjust_buf();
   }
@@ -223,6 +223,20 @@ public:
   int ungetc(int c) {
     FileLock lock(this);
     return ungetc_unlocked(c);
+  }
+
+  FileIOResult write_unlocked(const wchar_t *ws, size_t len);
+
+  FileIOResult write(const wchar_t *ws, size_t len) {
+    FileLock l(this);
+    return write_unlocked(ws, len);
+  }
+
+  FileIOResult read_unlocked(wchar_t *ws, size_t len);
+
+  FileIOResult read(wchar_t *ws, size_t len) {
+    FileLock l(this);
+    return read_unlocked(ws, len);
   }
 
   FileIOResult write_wide_character_unlocked(wchar_t wc);
@@ -326,6 +340,9 @@ public:
   static ModeFlags mode_flags(const char *mode);
 
 private:
+  FileIOResult write_unlocked_impl(const void *data, size_t len);
+  FileIOResult read_unlocked_impl(void *data, size_t len);
+
   FileIOResult write_unlocked_lbf(const uint8_t *data, size_t len);
   FileIOResult write_unlocked_fbf(const uint8_t *data, size_t len);
   FileIOResult write_unlocked_nbf(const uint8_t *data, size_t len);

--- a/libc/src/__support/File/file.h
+++ b/libc/src/__support/File/file.h
@@ -239,20 +239,6 @@ public:
     return read_unlocked(ws, len);
   }
 
-  FileIOResult write_wide_character_unlocked(wchar_t wc);
-
-  FileIOResult write_wide_character(wchar_t wc) {
-    FileLock l(this);
-    return write_wide_character_unlocked(wc);
-  }
-
-  ErrorOr<wchar_t> read_wide_character_unlocked();
-
-  ErrorOr<wchar_t> read_wide_character() {
-    FileLock l(this);
-    return read_wide_character_unlocked();
-  }
-
   wint_t ungetwc_unlocked(wchar_t wc);
 
   wint_t ungetwc(wchar_t wc) {

--- a/libc/src/__support/File/file.h
+++ b/libc/src/__support/File/file.h
@@ -12,11 +12,14 @@
 #include "hdr/stdint_proxy.h"
 #include "hdr/stdio_macros.h"
 #include "hdr/types/off_t.h"
+#include "hdr/types/wchar_t.h"
+#include "hdr/types/wint_t.h"
 #include "src/__support/CPP/new.h"
 #include "src/__support/error_or.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/architectures.h"
 #include "src/__support/threads/mutex.h"
+#include "src/__support/wchar/mbstate.h"
 
 #include <stddef.h>
 
@@ -51,6 +54,8 @@ public:
   File *get_next() const { return next; }
 
   static constexpr size_t DEFAULT_BUFFER_SIZE = 1024;
+
+  enum class Orientation { UNORIENTED, BYTE, WIDE };
 
   using LockFunc = void(File *);
   using UnlockFunc = void(File *);
@@ -131,6 +136,9 @@ private:
   bool eof;
   bool err;
 
+  Orientation orientation;
+  internal::mbstate shift_state;
+
   // This is a convenience RAII class to lock and unlock file objects.
   class FileLock {
     File *file;
@@ -172,7 +180,9 @@ public:
                                   /*robust=*/false, /*pshared=*/false),
         ungetc_buf(0), buf(buffer), bufsize(buffer_size), bufmode(buffer_mode),
         own_buf(owned), mode(modeflags), pos(0), prev_op(FileOp::NONE),
-        read_limit(0), eof(false), err(false), prev(nullptr), next(nullptr) {
+        read_limit(0), eof(false), err(false),
+        orientation(Orientation::UNORIENTED), shift_state(), prev(nullptr),
+        next(nullptr), {
     adjust_buf();
   }
 
@@ -213,6 +223,27 @@ public:
   int ungetc(int c) {
     FileLock lock(this);
     return ungetc_unlocked(c);
+  }
+
+  FileIOResult write_wide_character_unlocked(wchar_t wc);
+
+  FileIOResult write_wide_character(wchar_t wc) {
+    FileLock l(this);
+    return write_wide_character_unlocked(wc);
+  }
+
+  ErrorOr<wchar_t> read_wide_character_unlocked();
+
+  ErrorOr<wchar_t> read_wide_character() {
+    FileLock l(this);
+    return read_wide_character_unlocked();
+  }
+
+  wint_t ungetwc_unlocked(wchar_t wc);
+
+  wint_t ungetwc(wchar_t wc) {
+    FileLock lock(this);
+    return ungetwc_unlocked(wc);
   }
 
   // Does the following:

--- a/libc/src/__support/File/file.h
+++ b/libc/src/__support/File/file.h
@@ -183,7 +183,7 @@ public:
         own_buf(owned), mode(modeflags), pos(0), prev_op(FileOp::NONE),
         read_limit(0), eof(false), err(false),
         orientation(Orientation::UNORIENTED), mbstate(), prev(nullptr),
-        next(nullptr), {
+        next(nullptr) {
     adjust_buf();
   }
 

--- a/libc/src/__support/File/file.h
+++ b/libc/src/__support/File/file.h
@@ -335,6 +335,24 @@ public:
     return iseof_unlocked();
   }
 
+  Orientation get_orientation_unlocked() const { return orientation; }
+
+  Orientation get_orientation() {
+    FileLock l(this);
+    return get_orientation_unlocked();
+  }
+
+  Orientation try_set_orientation_unlocked(Orientation o) {
+    if (orientation == Orientation::UNORIENTED)
+      orientation = o;
+    return orientation;
+  }
+
+  Orientation try_set_orientation(Orientation o) {
+    FileLock l(this);
+    return try_set_orientation_unlocked(o);
+  }
+
   // Returns an bit map of flags corresponding to enumerations of
   // OpenMode, ContentType and CreateType.
   static ModeFlags mode_flags(const char *mode);

--- a/libc/test/src/__support/File/CMakeLists.txt
+++ b/libc/test/src/__support/File/CMakeLists.txt
@@ -19,6 +19,7 @@ add_libc_test(
     libc.src.errno.errno
     libc.src.__support.CPP.new
     libc.src.__support.File.file
+    libc.src.__support.error_or
 )
 
 add_libc_test(

--- a/libc/test/src/__support/File/CMakeLists.txt
+++ b/libc/test/src/__support/File/CMakeLists.txt
@@ -15,6 +15,7 @@ add_libc_test(
     LibcMemoryHelpers
   DEPENDS
     libc.include.stdio
+    libc.hdr.wchar_macros
     libc.hdr.types.size_t
     libc.src.errno.errno
     libc.src.__support.CPP.new

--- a/libc/test/src/__support/File/file_test.cpp
+++ b/libc/test/src/__support/File/file_test.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/types/size_t.h"
+#include "hdr/wchar_macros.h"
 #include "src/__support/CPP/new.h"
 #include "src/__support/File/file.h"
 #include "src/__support/alloc-checker.h"
@@ -734,6 +735,73 @@ TEST(LlvmLibcFileTest, SeekResetsMbstate) {
   EXPECT_EQ(read_res2.value, size_t(1));
   EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
             static_cast<unsigned int>(L'A'));
+
+  ASSERT_EQ(f->close(), 0);
+}
+
+TEST(LlvmLibcFileTest, ReadWideNotStopAtNewline) {
+  constexpr size_t FILE_BUFFER_SIZE = 100;
+  char file_buffer[FILE_BUFFER_SIZE];
+  StringFile *f =
+      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "w+");
+  ASSERT_FALSE(f == nullptr);
+
+  const wchar_t *ws = L"Hello\nWorld!";
+  size_t len = 12;
+
+  auto write_res = f->write(ws, len);
+  ASSERT_FALSE(write_res.has_error());
+  EXPECT_EQ(write_res.value, len);
+
+  ASSERT_EQ(f->flush(), 0);
+  ASSERT_EQ(f->seek(0, SEEK_SET).value(), 0);
+
+  wchar_t read_buf[20];
+  auto read_res = f->read(read_buf, len);
+  ASSERT_FALSE(read_res.has_error());
+  // Should NOT stop at newline, so should read all 12 characters.
+  EXPECT_EQ(read_res.value, len);
+  EXPECT_EQ(static_cast<unsigned int>(read_buf[5]),
+            static_cast<unsigned int>(L'\n'));
+  EXPECT_EQ(static_cast<unsigned int>(read_buf[11]),
+            static_cast<unsigned int>(L'!'));
+
+  ASSERT_EQ(f->close(), 0);
+}
+
+TEST(LlvmLibcFileTest, UngetwcWEOF) {
+  constexpr size_t FILE_BUFFER_SIZE = 100;
+  char file_buffer[FILE_BUFFER_SIZE];
+  StringFile *f =
+      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "r+");
+  ASSERT_FALSE(f == nullptr);
+
+  EXPECT_EQ(static_cast<unsigned int>(f->get_orientation()),
+            static_cast<unsigned int>(File::Orientation::UNORIENTED));
+
+  auto unget_res = f->ungetwc(WEOF);
+  EXPECT_EQ(static_cast<unsigned int>(unget_res),
+            static_cast<unsigned int>(WEOF));
+
+  EXPECT_EQ(static_cast<unsigned int>(f->get_orientation()),
+            static_cast<unsigned int>(File::Orientation::UNORIENTED));
+
+  ASSERT_EQ(f->close(), 0);
+}
+
+TEST(LlvmLibcFileTest, UngetwcErrorIndicator) {
+  constexpr size_t FILE_BUFFER_SIZE = 100;
+  char file_buffer[FILE_BUFFER_SIZE];
+  StringFile *f =
+      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "w+");
+  ASSERT_FALSE(f == nullptr);
+
+  f->write("A", 1);
+
+  auto unget_res = f->ungetwc(L'B');
+  EXPECT_EQ(static_cast<unsigned int>(unget_res),
+            static_cast<unsigned int>(WEOF));
+  EXPECT_FALSE(f->error());
 
   ASSERT_EQ(f->close(), 0);
 }

--- a/libc/test/src/__support/File/file_test.cpp
+++ b/libc/test/src/__support/File/file_test.cpp
@@ -512,3 +512,91 @@ TEST(LlvmLibcFileTest, WriteSplit) {
   EXPECT_TRUE(f->error());
   ASSERT_EQ(f->close(), 0);
 }
+
+TEST(LlvmLibcFileTest, WideCharIO) {
+  constexpr size_t FILE_BUFFER_SIZE = 512;
+  char file_buffer[FILE_BUFFER_SIZE];
+  StringFile *f =
+      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "w+");
+
+  wchar_t wc = L'A';
+  auto write_res = f->write_wide_character(wc);
+  ASSERT_EQ(write_res.value, size_t(1));
+
+  wchar_t wc2 = L'€';
+  write_res = f->write_wide_character(wc2);
+  ASSERT_EQ(write_res.value, size_t(3));
+
+  ASSERT_EQ(f->flush(), 0);
+
+  ASSERT_EQ(f->seek(0, SEEK_SET).value(), 0);
+
+  auto read_res = f->read_wide_character();
+  ASSERT_TRUE(read_res.has_value());
+  EXPECT_EQ(static_cast<unsigned int>(read_res.value()),
+            static_cast<unsigned int>(L'A'));
+
+  read_res = f->read_wide_character();
+  ASSERT_TRUE(read_res.has_value());
+  EXPECT_EQ(static_cast<unsigned int>(read_res.value()),
+            static_cast<unsigned int>(L'€'));
+
+  ASSERT_EQ(f->close(), 0);
+}
+
+TEST(LlvmLibcFileTest, WideCharOrientation) {
+  constexpr size_t FILE_BUFFER_SIZE = 512;
+  char file_buffer[FILE_BUFFER_SIZE];
+  StringFile *f =
+      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "w+");
+
+  f->write_wide_character(L'A');
+
+  auto write_res = f->write("B", 1);
+  EXPECT_EQ(write_res.value, size_t(0));
+  EXPECT_TRUE(f->error());
+
+  ASSERT_EQ(f->close(), 0);
+}
+
+TEST(LlvmLibcFileTest, ByteCharOrientation) {
+  constexpr size_t FILE_BUFFER_SIZE = 512;
+  char file_buffer[FILE_BUFFER_SIZE];
+  StringFile *f =
+      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "w+");
+
+  f->write("A", 1);
+
+  auto write_res = f->write_wide_character(L'B');
+  EXPECT_EQ(write_res.value, size_t(0));
+  EXPECT_TRUE(f->error());
+
+  ASSERT_EQ(f->close(), 0);
+}
+
+TEST(LlvmLibcFileTest, Ungetwc) {
+  constexpr size_t FILE_BUFFER_SIZE = 512;
+  char file_buffer[FILE_BUFFER_SIZE];
+  StringFile *f =
+      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "w+");
+
+  f->write_wide_character(L'A');
+  f->flush();
+  f->seek(0, SEEK_SET);
+
+  auto read_res = f->read_wide_character();
+  ASSERT_TRUE(read_res.has_value());
+  EXPECT_EQ(static_cast<unsigned int>(read_res.value()),
+            static_cast<unsigned int>(L'A'));
+
+  auto unget_res = f->ungetwc(L'B');
+  EXPECT_EQ(static_cast<unsigned int>(unget_res),
+            static_cast<unsigned int>(L'B'));
+
+  read_res = f->read_wide_character();
+  ASSERT_TRUE(read_res.has_value());
+  EXPECT_EQ(static_cast<unsigned int>(read_res.value()),
+            static_cast<unsigned int>(L'B'));
+
+  ASSERT_EQ(f->close(), 0);
+}

--- a/libc/test/src/__support/File/file_test.cpp
+++ b/libc/test/src/__support/File/file_test.cpp
@@ -513,44 +513,13 @@ TEST(LlvmLibcFileTest, WriteSplit) {
   ASSERT_EQ(f->close(), 0);
 }
 
-TEST(LlvmLibcFileTest, WideCharIO) {
-  constexpr size_t FILE_BUFFER_SIZE = 512;
-  char file_buffer[FILE_BUFFER_SIZE];
-  StringFile *f =
-      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "w+");
-
-  wchar_t wc = L'A';
-  auto write_res = f->write_wide_character(wc);
-  ASSERT_EQ(write_res.value, size_t(1));
-
-  wchar_t wc2 = L'€';
-  write_res = f->write_wide_character(wc2);
-  ASSERT_EQ(write_res.value, size_t(3));
-
-  ASSERT_EQ(f->flush(), 0);
-
-  ASSERT_EQ(f->seek(0, SEEK_SET).value(), 0);
-
-  auto read_res = f->read_wide_character();
-  ASSERT_TRUE(read_res.has_value());
-  EXPECT_EQ(static_cast<unsigned int>(read_res.value()),
-            static_cast<unsigned int>(L'A'));
-
-  read_res = f->read_wide_character();
-  ASSERT_TRUE(read_res.has_value());
-  EXPECT_EQ(static_cast<unsigned int>(read_res.value()),
-            static_cast<unsigned int>(L'€'));
-
-  ASSERT_EQ(f->close(), 0);
-}
-
 TEST(LlvmLibcFileTest, WideCharOrientation) {
   constexpr size_t FILE_BUFFER_SIZE = 512;
   char file_buffer[FILE_BUFFER_SIZE];
   StringFile *f =
       new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "w+");
 
-  f->write_wide_character(L'A');
+  f->write(L"A", 1);
 
   auto write_res = f->write("B", 1);
   EXPECT_EQ(write_res.value, size_t(0));
@@ -567,7 +536,7 @@ TEST(LlvmLibcFileTest, ByteCharOrientation) {
 
   f->write("A", 1);
 
-  auto write_res = f->write_wide_character(L'B');
+  auto write_res = f->write(L"B", 1);
   EXPECT_EQ(write_res.value, size_t(0));
   EXPECT_TRUE(f->error());
 
@@ -580,22 +549,23 @@ TEST(LlvmLibcFileTest, Ungetwc) {
   StringFile *f =
       new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "w+");
 
-  f->write_wide_character(L'A');
+  f->write(L"A", 1);
   f->flush();
   f->seek(0, SEEK_SET);
 
-  auto read_res = f->read_wide_character();
-  ASSERT_TRUE(read_res.has_value());
-  EXPECT_EQ(static_cast<unsigned int>(read_res.value()),
+  wchar_t ws_out[2];
+  auto read_res = f->read(ws_out, 1);
+  ASSERT_EQ(read_res.value, size_t(1));
+  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
             static_cast<unsigned int>(L'A'));
 
   auto unget_res = f->ungetwc(L'B');
   EXPECT_EQ(static_cast<unsigned int>(unget_res),
             static_cast<unsigned int>(L'B'));
 
-  read_res = f->read_wide_character();
-  ASSERT_TRUE(read_res.has_value());
-  EXPECT_EQ(static_cast<unsigned int>(read_res.value()),
+  auto read_res2 = f->read(ws_out, 1);
+  ASSERT_EQ(read_res2.value, size_t(1));
+  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
             static_cast<unsigned int>(L'B'));
 
   ASSERT_EQ(f->close(), 0);

--- a/libc/test/src/__support/File/file_test.cpp
+++ b/libc/test/src/__support/File/file_test.cpp
@@ -563,8 +563,8 @@ TEST(LlvmLibcFileTest, Ungetwc) {
   auto unget_res = f->ungetwc(L'B');
   EXPECT_EQ(static_cast<unsigned int>(unget_res),
             static_cast<unsigned int>(L'B'));
-
   auto read_res2 = f->read(ws_out, 1);
+
   ASSERT_EQ(read_res2.value, size_t(1));
   EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
             static_cast<unsigned int>(L'B'));
@@ -785,23 +785,6 @@ TEST(LlvmLibcFileTest, UngetwcWEOF) {
 
   EXPECT_EQ(static_cast<unsigned int>(f->get_orientation()),
             static_cast<unsigned int>(File::Orientation::UNORIENTED));
-
-  ASSERT_EQ(f->close(), 0);
-}
-
-TEST(LlvmLibcFileTest, UngetwcErrorIndicator) {
-  constexpr size_t FILE_BUFFER_SIZE = 100;
-  char file_buffer[FILE_BUFFER_SIZE];
-  StringFile *f =
-      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "w+");
-  ASSERT_FALSE(f == nullptr);
-
-  f->write("A", 1);
-
-  auto unget_res = f->ungetwc(L'B');
-  EXPECT_EQ(static_cast<unsigned int>(unget_res),
-            static_cast<unsigned int>(WEOF));
-  EXPECT_FALSE(f->error());
 
   ASSERT_EQ(f->close(), 0);
 }

--- a/libc/test/src/__support/File/file_test.cpp
+++ b/libc/test/src/__support/File/file_test.cpp
@@ -656,6 +656,31 @@ TEST(LlvmLibcFileTest, UngetwcMultiByte) {
   ASSERT_EQ(f->close(), 0);
 }
 
+TEST(LlvmLibcFileTest, UngetwcUnbufferedMultiByte) {
+  StringFile *f = new_string_file(nullptr, 0, _IONBF, true, "w+");
+  ASSERT_FALSE(f == nullptr);
+
+  f->write(L"€", 1);
+  f->seek(0, SEEK_SET);
+
+  wchar_t ws_out[2];
+  auto read_res = f->read(ws_out, 1);
+  ASSERT_EQ(read_res.value, size_t(1));
+  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
+            static_cast<unsigned int>(L'€'));
+
+  auto unget_res = f->ungetwc(L'¢');
+  EXPECT_EQ(static_cast<unsigned int>(unget_res),
+            static_cast<unsigned int>(L'¢'));
+
+  auto read_res2 = f->read(ws_out, 1);
+  ASSERT_EQ(read_res2.value, size_t(1));
+  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
+            static_cast<unsigned int>(L'¢'));
+
+  ASSERT_EQ(f->close(), 0);
+}
+
 TEST(LlvmLibcFileTest, WideStringIO_Multibyte) {
   constexpr size_t FILE_BUFFER_SIZE = 100;
   char file_buffer[FILE_BUFFER_SIZE];

--- a/libc/test/src/__support/File/file_test.cpp
+++ b/libc/test/src/__support/File/file_test.cpp
@@ -631,3 +631,29 @@ TEST(LlvmLibcFileTest, WideStringIO) {
 
   ASSERT_EQ(f->close(), 0);
 }
+
+TEST(LlvmLibcFileTest, TrySetOrientation) {
+  constexpr size_t FILE_BUFFER_SIZE = 100;
+  char file_buffer[FILE_BUFFER_SIZE];
+  StringFile *f =
+      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "r+");
+  ASSERT_FALSE(f == nullptr);
+
+  EXPECT_EQ(static_cast<unsigned int>(f->get_orientation()),
+            static_cast<unsigned int>(File::Orientation::UNORIENTED));
+
+  EXPECT_EQ(static_cast<unsigned int>(
+                f->try_set_orientation(File::Orientation::WIDE)),
+            static_cast<unsigned int>(File::Orientation::WIDE));
+  EXPECT_EQ(static_cast<unsigned int>(f->get_orientation()),
+            static_cast<unsigned int>(File::Orientation::WIDE));
+
+  EXPECT_EQ(
+      static_cast<unsigned int>(
+          f->try_set_orientation(File::Orientation::BYTE)),
+      static_cast<unsigned int>(File::Orientation::WIDE)); // Cannot change
+  EXPECT_EQ(static_cast<unsigned int>(f->get_orientation()),
+            static_cast<unsigned int>(File::Orientation::WIDE));
+
+  ASSERT_EQ(f->close(), 0);
+}

--- a/libc/test/src/__support/File/file_test.cpp
+++ b/libc/test/src/__support/File/file_test.cpp
@@ -627,3 +627,88 @@ TEST(LlvmLibcFileTest, TrySetOrientation) {
 
   ASSERT_EQ(f->close(), 0);
 }
+
+TEST(LlvmLibcFileTest, UngetwcMultiByte) {
+  constexpr size_t FILE_BUFFER_SIZE = 512;
+  char file_buffer[FILE_BUFFER_SIZE];
+  StringFile *f =
+      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "w+");
+
+  f->write(L"€", 1);
+  f->flush();
+  f->seek(0, SEEK_SET);
+
+  wchar_t ws_out[2];
+  auto read_res = f->read(ws_out, 1);
+  ASSERT_EQ(read_res.value, size_t(1));
+  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
+            static_cast<unsigned int>(L'€'));
+
+  auto unget_res = f->ungetwc(L'¢');
+  EXPECT_EQ(static_cast<unsigned int>(unget_res),
+            static_cast<unsigned int>(L'¢'));
+
+  auto read_res2 = f->read(ws_out, 1);
+  ASSERT_EQ(read_res2.value, size_t(1));
+  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
+            static_cast<unsigned int>(L'¢'));
+
+  ASSERT_EQ(f->close(), 0);
+}
+
+TEST(LlvmLibcFileTest, WideStringIO_Multibyte) {
+  constexpr size_t FILE_BUFFER_SIZE = 100;
+  char file_buffer[FILE_BUFFER_SIZE];
+  StringFile *f =
+      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "w+");
+  ASSERT_FALSE(f == nullptr);
+
+  const wchar_t *ws = L"Hello € World!";
+  size_t len = 14;
+
+  auto write_res = f->write(ws, len);
+  ASSERT_FALSE(write_res.has_error());
+  EXPECT_EQ(write_res.value, len);
+
+  ASSERT_EQ(f->flush(), 0);
+
+  ASSERT_EQ(f->seek(0, SEEK_SET).value(), 0);
+
+  wchar_t read_buf[20];
+  auto read_res = f->read(read_buf, len);
+  ASSERT_FALSE(read_res.has_error());
+  EXPECT_EQ(read_res.value, len);
+
+  for (size_t i = 0; i < len; ++i) {
+    EXPECT_EQ(static_cast<unsigned int>(read_buf[i]),
+              static_cast<unsigned int>(ws[i]));
+  }
+
+  ASSERT_EQ(f->close(), 0);
+}
+
+TEST(LlvmLibcFileTest, SeekResetsMbstate) {
+  constexpr size_t FILE_BUFFER_SIZE = 100;
+  char file_buffer[FILE_BUFFER_SIZE];
+  StringFile *f =
+      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "r+");
+  ASSERT_FALSE(f == nullptr);
+
+  f->reset_and_fill("\xE2\x82", 2);
+
+  wchar_t ws_out[1];
+  auto read_res = f->read(ws_out, 1);
+  EXPECT_EQ(read_res.value, size_t(0));
+  EXPECT_TRUE(f->error());
+
+  f->reset_and_fill("A", 1);
+  f->seek(0, SEEK_SET);
+  f->clearerr();
+
+  auto read_res2 = f->read(ws_out, 1);
+  EXPECT_EQ(read_res2.value, size_t(1));
+  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
+            static_cast<unsigned int>(L'A'));
+
+  ASSERT_EQ(f->close(), 0);
+}

--- a/libc/test/src/__support/File/file_test.cpp
+++ b/libc/test/src/__support/File/file_test.cpp
@@ -600,3 +600,34 @@ TEST(LlvmLibcFileTest, Ungetwc) {
 
   ASSERT_EQ(f->close(), 0);
 }
+
+TEST(LlvmLibcFileTest, WideStringIO) {
+  constexpr size_t FILE_BUFFER_SIZE = 100;
+  char file_buffer[FILE_BUFFER_SIZE];
+  StringFile *f =
+      new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "w+");
+  ASSERT_FALSE(f == nullptr);
+
+  const wchar_t *ws = L"Hello, World!";
+  size_t len = 13;
+
+  auto write_res = f->write(ws, len);
+  ASSERT_FALSE(write_res.has_error());
+  EXPECT_EQ(write_res.value, len);
+
+  ASSERT_EQ(f->flush(), 0); // Ensure everything is written to StringFile
+
+  ASSERT_EQ(f->seek(0, SEEK_SET).value(), 0);
+
+  wchar_t read_buf[20];
+  auto read_res = f->read(read_buf, len);
+  ASSERT_FALSE(read_res.has_error());
+  EXPECT_EQ(read_res.value, len);
+
+  for (size_t i = 0; i < len; ++i) {
+    EXPECT_EQ(static_cast<unsigned int>(read_buf[i]),
+              static_cast<unsigned int>(ws[i]));
+  }
+
+  ASSERT_EQ(f->close(), 0);
+}

--- a/libc/test/src/__support/File/file_test.cpp
+++ b/libc/test/src/__support/File/file_test.cpp
@@ -557,17 +557,14 @@ TEST(LlvmLibcFileTest, Ungetwc) {
   wchar_t ws_out[2];
   auto read_res = f->read(ws_out, 1);
   ASSERT_EQ(read_res.value, size_t(1));
-  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
-            static_cast<unsigned int>(L'A'));
+  EXPECT_EQ(static_cast<uint32_t>(ws_out[0]), static_cast<uint32_t>(L'A'));
 
   auto unget_res = f->ungetwc(L'B');
-  EXPECT_EQ(static_cast<unsigned int>(unget_res),
-            static_cast<unsigned int>(L'B'));
+  EXPECT_EQ(static_cast<uint32_t>(unget_res), static_cast<uint32_t>(L'B'));
   auto read_res2 = f->read(ws_out, 1);
 
   ASSERT_EQ(read_res2.value, size_t(1));
-  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
-            static_cast<unsigned int>(L'B'));
+  EXPECT_EQ(static_cast<uint32_t>(ws_out[0]), static_cast<uint32_t>(L'B'));
 
   ASSERT_EQ(f->close(), 0);
 }
@@ -596,8 +593,7 @@ TEST(LlvmLibcFileTest, WideStringIO) {
   EXPECT_EQ(read_res.value, len);
 
   for (size_t i = 0; i < len; ++i) {
-    EXPECT_EQ(static_cast<unsigned int>(read_buf[i]),
-              static_cast<unsigned int>(ws[i]));
+    EXPECT_EQ(static_cast<uint32_t>(read_buf[i]), static_cast<uint32_t>(ws[i]));
   }
 
   ASSERT_EQ(f->close(), 0);
@@ -610,21 +606,20 @@ TEST(LlvmLibcFileTest, TrySetOrientation) {
       new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "r+");
   ASSERT_FALSE(f == nullptr);
 
-  EXPECT_EQ(static_cast<unsigned int>(f->get_orientation()),
-            static_cast<unsigned int>(File::Orientation::UNORIENTED));
-
-  EXPECT_EQ(static_cast<unsigned int>(
-                f->try_set_orientation(File::Orientation::WIDE)),
-            static_cast<unsigned int>(File::Orientation::WIDE));
-  EXPECT_EQ(static_cast<unsigned int>(f->get_orientation()),
-            static_cast<unsigned int>(File::Orientation::WIDE));
+  EXPECT_EQ(static_cast<uint32_t>(f->get_orientation()),
+            static_cast<uint32_t>(File::Orientation::UNORIENTED));
 
   EXPECT_EQ(
-      static_cast<unsigned int>(
-          f->try_set_orientation(File::Orientation::BYTE)),
-      static_cast<unsigned int>(File::Orientation::WIDE)); // Cannot change
-  EXPECT_EQ(static_cast<unsigned int>(f->get_orientation()),
-            static_cast<unsigned int>(File::Orientation::WIDE));
+      static_cast<uint32_t>(f->try_set_orientation(File::Orientation::WIDE)),
+      static_cast<uint32_t>(File::Orientation::WIDE));
+  EXPECT_EQ(static_cast<uint32_t>(f->get_orientation()),
+            static_cast<uint32_t>(File::Orientation::WIDE));
+
+  EXPECT_EQ(
+      static_cast<uint32_t>(f->try_set_orientation(File::Orientation::BYTE)),
+      static_cast<uint32_t>(File::Orientation::WIDE)); // Cannot change
+  EXPECT_EQ(static_cast<uint32_t>(f->get_orientation()),
+            static_cast<uint32_t>(File::Orientation::WIDE));
 
   ASSERT_EQ(f->close(), 0);
 }
@@ -642,17 +637,14 @@ TEST(LlvmLibcFileTest, UngetwcMultiByte) {
   wchar_t ws_out[2];
   auto read_res = f->read(ws_out, 1);
   ASSERT_EQ(read_res.value, size_t(1));
-  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
-            static_cast<unsigned int>(L'€'));
+  EXPECT_EQ(static_cast<uint32_t>(ws_out[0]), static_cast<uint32_t>(L'€'));
 
   auto unget_res = f->ungetwc(L'¢');
-  EXPECT_EQ(static_cast<unsigned int>(unget_res),
-            static_cast<unsigned int>(L'¢'));
+  EXPECT_EQ(static_cast<uint32_t>(unget_res), static_cast<uint32_t>(L'¢'));
 
   auto read_res2 = f->read(ws_out, 1);
   ASSERT_EQ(read_res2.value, size_t(1));
-  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
-            static_cast<unsigned int>(L'¢'));
+  EXPECT_EQ(static_cast<uint32_t>(ws_out[0]), static_cast<uint32_t>(L'¢'));
 
   ASSERT_EQ(f->close(), 0);
 }
@@ -667,17 +659,14 @@ TEST(LlvmLibcFileTest, UngetwcUnbufferedMultiByte) {
   wchar_t ws_out[2];
   auto read_res = f->read(ws_out, 1);
   ASSERT_EQ(read_res.value, size_t(1));
-  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
-            static_cast<unsigned int>(L'€'));
+  EXPECT_EQ(static_cast<uint32_t>(ws_out[0]), static_cast<uint32_t>(L'€'));
 
   auto unget_res = f->ungetwc(L'¢');
-  EXPECT_EQ(static_cast<unsigned int>(unget_res),
-            static_cast<unsigned int>(L'¢'));
+  EXPECT_EQ(static_cast<uint32_t>(unget_res), static_cast<uint32_t>(L'¢'));
 
   auto read_res2 = f->read(ws_out, 1);
   ASSERT_EQ(read_res2.value, size_t(1));
-  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
-            static_cast<unsigned int>(L'¢'));
+  EXPECT_EQ(static_cast<uint32_t>(ws_out[0]), static_cast<uint32_t>(L'¢'));
 
   ASSERT_EQ(f->close(), 0);
 }
@@ -706,8 +695,7 @@ TEST(LlvmLibcFileTest, WideStringIO_Multibyte) {
   EXPECT_EQ(read_res.value, len);
 
   for (size_t i = 0; i < len; ++i) {
-    EXPECT_EQ(static_cast<unsigned int>(read_buf[i]),
-              static_cast<unsigned int>(ws[i]));
+    EXPECT_EQ(static_cast<uint32_t>(read_buf[i]), static_cast<uint32_t>(ws[i]));
   }
 
   ASSERT_EQ(f->close(), 0);
@@ -733,8 +721,7 @@ TEST(LlvmLibcFileTest, SeekResetsMbstate) {
 
   auto read_res2 = f->read(ws_out, 1);
   EXPECT_EQ(read_res2.value, size_t(1));
-  EXPECT_EQ(static_cast<unsigned int>(ws_out[0]),
-            static_cast<unsigned int>(L'A'));
+  EXPECT_EQ(static_cast<uint32_t>(ws_out[0]), static_cast<uint32_t>(L'A'));
 
   ASSERT_EQ(f->close(), 0);
 }
@@ -761,10 +748,8 @@ TEST(LlvmLibcFileTest, ReadWideNotStopAtNewline) {
   ASSERT_FALSE(read_res.has_error());
   // Should NOT stop at newline, so should read all 12 characters.
   EXPECT_EQ(read_res.value, len);
-  EXPECT_EQ(static_cast<unsigned int>(read_buf[5]),
-            static_cast<unsigned int>(L'\n'));
-  EXPECT_EQ(static_cast<unsigned int>(read_buf[11]),
-            static_cast<unsigned int>(L'!'));
+  EXPECT_EQ(static_cast<uint32_t>(read_buf[5]), static_cast<uint32_t>(L'\n'));
+  EXPECT_EQ(static_cast<uint32_t>(read_buf[11]), static_cast<uint32_t>(L'!'));
 
   ASSERT_EQ(f->close(), 0);
 }
@@ -776,15 +761,14 @@ TEST(LlvmLibcFileTest, UngetwcWEOF) {
       new_string_file(file_buffer, FILE_BUFFER_SIZE, _IOFBF, false, "r+");
   ASSERT_FALSE(f == nullptr);
 
-  EXPECT_EQ(static_cast<unsigned int>(f->get_orientation()),
-            static_cast<unsigned int>(File::Orientation::UNORIENTED));
+  EXPECT_EQ(static_cast<uint32_t>(f->get_orientation()),
+            static_cast<uint32_t>(File::Orientation::UNORIENTED));
 
   auto unget_res = f->ungetwc(WEOF);
-  EXPECT_EQ(static_cast<unsigned int>(unget_res),
-            static_cast<unsigned int>(WEOF));
+  EXPECT_EQ(static_cast<uint32_t>(unget_res), static_cast<uint32_t>(WEOF));
 
-  EXPECT_EQ(static_cast<unsigned int>(f->get_orientation()),
-            static_cast<unsigned int>(File::Orientation::UNORIENTED));
+  EXPECT_EQ(static_cast<uint32_t>(f->get_orientation()),
+            static_cast<uint32_t>(File::Orientation::UNORIENTED));
 
   ASSERT_EQ(f->close(), 0);
 }


### PR DESCRIPTION
This PR adds support for wide character operations such as read, write, and ungetwc to the File class. It also adds tests but does not yet add entrypoints, that will be done in a followup.

Assisted by Gemini