### PR TITLE
[mlir][bufferization] Add tests for OptimizeAllocationLiveness edge cases

### DIFF
--- a/mlir/test/Dialect/Bufferization/Transforms/optimize-allocation-liveness.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/optimize-allocation-liveness.mlir
@@ -249,22 +249,3 @@ func.func private @test_alloc_no_non_dealloc_users() {
   return
 }
 
-// -----
-
-// CHECK-LABEL: func.func private @test_dynamic_dimensions
-// CHECK: %[[alloc:.*]] = memref.alloc
-// CHECK-NEXT: memref.load %[[alloc]]
-// CHECK-NEXT: memref.dealloc %[[alloc]]
-
-// The pass moves the dealloc of a dynamic alloc to right after its last use.
-func.func private @test_dynamic_dimensions(%n: index) {
-  %c0 = arith.constant 0 : index
-  %alloc = memref.alloc(%n) {alignment = 64 : i64} : memref<?xf32>
-  %val = memref.load %alloc[%c0] : memref<?xf32>
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<32xf32>
-  %cf0 = arith.constant 0.0 : f32
-  memref.store %cf0, %alloc_1[%c0] : memref<32xf32>
-  memref.dealloc %alloc : memref<?xf32>
-  memref.dealloc %alloc_1 : memref<32xf32>
-  return
-}

--- a/mlir/test/Dialect/Bufferization/Transforms/optimize-allocation-liveness.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/optimize-allocation-liveness.mlir
@@ -237,13 +237,12 @@ func.func private @test_alloc_with_multiple_results() -> () {
 
 // -----
 
-// CHECK-LABEL:   func.func private @test_alloc_no_non_dealloc_users() {
-// CHECK:           %[[ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<32xf32>
-// CHECK-NEXT:      memref.dealloc %[[ALLOC]] : memref<32xf32>
-// CHECK-NEXT:      return
+// CHECK-LABEL: func.func private @test_alloc_no_non_dealloc_users
+// CHECK: %[[alloc:.*]] = memref.alloc
+// CHECK-NEXT: memref.dealloc %[[alloc]]
+// CHECK-NEXT: return
 
-// The pass finds no last user when an alloc has only a dealloc as its user.
-// Verify the IR stays unchanged.
+// No non-dealloc users. The pass should not move the dealloc.
 func.func private @test_alloc_no_non_dealloc_users() {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<32xf32>
   memref.dealloc %alloc : memref<32xf32>
@@ -252,21 +251,12 @@ func.func private @test_alloc_no_non_dealloc_users() {
 
 // -----
 
-// CHECK-LABEL:   func.func private @test_dynamic_dimensions(
-// CHECK-SAME:                                               %[[N:.*]]: index) {
-// CHECK:           %[[C0:.*]] = arith.constant 0 : index
-// CHECK:           %[[ALLOC:.*]] = memref.alloc(%[[N]]) {alignment = 64 : i64} : memref<?xf32>
-// CHECK:           memref.load %[[ALLOC]][%[[C0]]]
-// CHECK:           memref.dealloc %[[ALLOC]] : memref<?xf32>
-// CHECK:           %[[ALLOC1:.*]] = memref.alloc() {alignment = 64 : i64} : memref<32xf32>
-// CHECK:           arith.constant
-// CHECK:           memref.store {{.*}}, %[[ALLOC1]][%[[C0]]]
-// CHECK:           memref.dealloc %[[ALLOC1]] : memref<32xf32>
-// CHECK:           return
+// CHECK-LABEL: func.func private @test_dynamic_dimensions
+// CHECK: %[[alloc:.*]] = memref.alloc
+// CHECK-NEXT: memref.load %[[alloc]]
+// CHECK-NEXT: memref.dealloc %[[alloc]]
 
-// The pass moves the dealloc of a dynamic alloc to right after its last user.
-// %alloc starts with its dealloc at the end of the block. The pass moves it
-// to right after the memref.load, which is the last use of %alloc.
+// The pass moves the dealloc of a dynamic alloc to right after its last use.
 func.func private @test_dynamic_dimensions(%n: index) {
   %c0 = arith.constant 0 : index
   %alloc = memref.alloc(%n) {alignment = 64 : i64} : memref<?xf32>

--- a/mlir/test/Dialect/Bufferization/Transforms/optimize-allocation-liveness.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/optimize-allocation-liveness.mlir
@@ -234,3 +234,47 @@ func.func private @test_alloc_with_multiple_results() -> () {
   memref.dealloc %alloc2 : memref<64xf32>
   return
 }
+
+// -----
+
+// CHECK-LABEL:   func.func private @test_alloc_no_non_dealloc_users() {
+// CHECK:           %[[ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<32xf32>
+// CHECK-NEXT:      memref.dealloc %[[ALLOC]] : memref<32xf32>
+// CHECK-NEXT:      return
+
+// The pass finds no last user when an alloc has only a dealloc as its user.
+// Verify the IR stays unchanged.
+func.func private @test_alloc_no_non_dealloc_users() {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<32xf32>
+  memref.dealloc %alloc : memref<32xf32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   func.func private @test_dynamic_dimensions(
+// CHECK-SAME:                                               %[[N:.*]]: index) {
+// CHECK:           %[[C0:.*]] = arith.constant 0 : index
+// CHECK:           %[[ALLOC:.*]] = memref.alloc(%[[N]]) {alignment = 64 : i64} : memref<?xf32>
+// CHECK:           memref.load %[[ALLOC]][%[[C0]]]
+// CHECK:           memref.dealloc %[[ALLOC]] : memref<?xf32>
+// CHECK:           %[[ALLOC1:.*]] = memref.alloc() {alignment = 64 : i64} : memref<32xf32>
+// CHECK:           arith.constant
+// CHECK:           memref.store {{.*}}, %[[ALLOC1]][%[[C0]]]
+// CHECK:           memref.dealloc %[[ALLOC1]] : memref<32xf32>
+// CHECK:           return
+
+// The pass moves the dealloc of a dynamic alloc to right after its last user.
+// %alloc starts with its dealloc at the end of the block. The pass moves it
+// to right after the memref.load, which is the last use of %alloc.
+func.func private @test_dynamic_dimensions(%n: index) {
+  %c0 = arith.constant 0 : index
+  %alloc = memref.alloc(%n) {alignment = 64 : i64} : memref<?xf32>
+  %val = memref.load %alloc[%c0] : memref<?xf32>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<32xf32>
+  %cf0 = arith.constant 0.0 : f32
+  memref.store %cf0, %alloc_1[%c0] : memref<32xf32>
+  memref.dealloc %alloc : memref<?xf32>
+  memref.dealloc %alloc_1 : memref<32xf32>
+  return
+}


### PR DESCRIPTION
Add two test cases to `mlir/test/Dialect/Bufferization/Transforms/optimize-allocation-liveness.mlir` that cover untested code paths in `OptimizeAllocationLiveness.cpp`.

**test_alloc_no_non_dealloc_users**

When an alloc has no users other than its dealloc, `findUserWithFreeSideEffect` returns the dealloc and the dep-walk loop skips it (since `user == deallocOp`), leaving `lastUser` as null. The pass hits the early-return at line 157 and leaves the IR unchanged. No existing test exercises this path.

**test_dynamic_dimensions**

All seven existing tests use static memref shapes (e.g. `memref<32xf32>`). This test uses a dynamic dimension (`memref<?xf32>`) with a runtime size operand, which is the common case after bufferization of ML workloads. The pass should resolve the alloc's deps via `BufferViewFlowAnalysis`, find the `memref.load` as the last user, and move the dealloc to right after it.

Tested locally with `ninja check-mlir-dialect-bufferization` (50/50 pass).