### PR TITLE
[libc][syscall] lift raise to syscall wrapper

### DIFF
--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
@@ -37,6 +37,20 @@ add_header_library(
 )
 
 add_header_library(
+  raise
+  HDRS
+    raise.h
+  DEPENDS
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.hdr.signal_macros
+    libc.hdr.types.sigset_t
+    libc.include.sys_syscall
+)
+
+add_header_library(
   write
   HDRS
     write.h

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/raise.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/raise.h
@@ -19,43 +19,47 @@
 
 namespace LIBC_NAMESPACE_DECL {
 namespace linux_syscalls {
-
 LIBC_INLINE ErrorOr<int> raise(int sig) {
-  sigset_t full_set = sigset_t{{-1UL}};
-#ifdef LIBC_COMPILER_IS_CLANG
-  [[clang::uninitialized]] sigset_t old_set;
-#else
-  sigset_t old_set;
-#endif
-  auto restore_signals = [&old_set]() {
-    return syscall_impl<int>(SYS_rt_sigprocmask, SIG_SETMASK, &old_set, nullptr,
-                             sizeof(sigset_t));
+  class SigMaskGuard {
+    [[maybe_unused]] sigset_t old_set;
+    [[maybe_unused]] ErrorOr<int> &status;
+
+  public:
+    LIBC_INLINE SigMaskGuard(ErrorOr<int> &status) : old_set{}, status(status) {
+      sigset_t full_set = sigset_t{{-1UL}};
+      status = syscall_impl<int>(SYS_rt_sigprocmask, SIG_BLOCK, &full_set,
+                                 &old_set, sizeof(sigset_t));
+    }
+    LIBC_INLINE ~SigMaskGuard() {
+      if (status.has_value()) {
+        int restore_result =
+            syscall_impl<int>(SYS_rt_sigprocmask, SIG_SETMASK, &old_set,
+                              nullptr, sizeof(sigset_t));
+        if (restore_result < 0)
+          status = Error(-restore_result);
+      }
+    }
   };
+  ErrorOr<int> status = 0;
+  {
+    SigMaskGuard sig_mask(status);
 
-  int mask_result = syscall_impl<int>(SYS_rt_sigprocmask, SIG_BLOCK, &full_set,
-                                      &old_set, sizeof(sigset_t));
-  if (mask_result < 0)
-    return Error(-mask_result);
+    if (!status.has_value())
+      return status;
 
-  long pid = syscall_impl<long>(SYS_getpid);
-  if (pid < 0) {
-    restore_signals();
-    return Error(-static_cast<int>(pid));
+    long pid = syscall_impl<long>(SYS_getpid);
+    if (pid < 0)
+      return Error(-static_cast<int>(pid));
+
+    long tid = syscall_impl<long>(SYS_gettid);
+    if (tid < 0)
+      return Error(-static_cast<int>(tid));
+
+    int result = syscall_impl<int>(SYS_tgkill, pid, tid, sig);
+    if (result < 0)
+      return Error(-result);
   }
-
-  long tid = syscall_impl<long>(SYS_gettid);
-  if (tid < 0) {
-    restore_signals();
-    return Error(-static_cast<int>(tid));
-  }
-
-  int result = syscall_impl<int>(SYS_tgkill, pid, tid, sig);
-  int restore_result = restore_signals();
-  if (result < 0)
-    return Error(-result);
-  if (restore_result < 0)
-    return Error(-restore_result);
-  return result;
+  return status;
 }
 
 } // namespace linux_syscalls

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/raise.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/raise.h
@@ -1,0 +1,64 @@
+//===-- Implementation header for raise -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_RAISE_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_RAISE_H
+
+#include "hdr/signal_macros.h"
+#include "hdr/types/sigset_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> raise(int sig) {
+  sigset_t full_set = sigset_t{{-1UL}};
+#ifdef LIBC_COMPILER_IS_CLANG
+  [[clang::uninitialized]] sigset_t old_set;
+#else
+  sigset_t old_set;
+#endif
+  auto restore_signals = [&old_set]() {
+    return syscall_impl<int>(SYS_rt_sigprocmask, SIG_SETMASK, &old_set, nullptr,
+                             sizeof(sigset_t));
+  };
+
+  int mask_result = syscall_impl<int>(SYS_rt_sigprocmask, SIG_BLOCK, &full_set,
+                                      &old_set, sizeof(sigset_t));
+  if (mask_result < 0)
+    return Error(-mask_result);
+
+  long pid = syscall_impl<long>(SYS_getpid);
+  if (pid < 0) {
+    restore_signals();
+    return Error(-static_cast<int>(pid));
+  }
+
+  long tid = syscall_impl<long>(SYS_gettid);
+  if (tid < 0) {
+    restore_signals();
+    return Error(-static_cast<int>(tid));
+  }
+
+  int result = syscall_impl<int>(SYS_tgkill, pid, tid, sig);
+  int restore_result = restore_signals();
+  if (result < 0)
+    return Error(-result);
+  if (restore_result < 0)
+    return Error(-restore_result);
+  return result;
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_RAISE_H

--- a/libc/src/signal/linux/CMakeLists.txt
+++ b/libc/src/signal/linux/CMakeLists.txt
@@ -29,10 +29,8 @@ add_entrypoint_object(
   HDRS
     ../raise.h
   DEPENDS
-    .signal_utils
-    libc.hdr.types.sigset_t
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
+    libc.src.__support.OSUtil.linux.syscall_wrappers.raise
+    libc.src.errno.errno
 )
 
 add_object_library(

--- a/libc/src/signal/linux/raise.cpp
+++ b/libc/src/signal/linux/raise.cpp
@@ -8,21 +8,20 @@
 
 #include "src/signal/raise.h"
 
-#include "hdr/types/sigset_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/raise.h"
 #include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include "src/signal/linux/signal_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, raise, (int sig)) {
-  sigset_t sigset;
-  block_all_signals(sigset);
-  long pid = LIBC_NAMESPACE::syscall_impl<long>(SYS_getpid);
-  long tid = LIBC_NAMESPACE::syscall_impl<long>(SYS_gettid);
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_tgkill, pid, tid, sig);
-  restore_signals(sigset);
-  return ret;
+  auto result = linux_syscalls::raise(sig);
+  if (!result.has_value()) {
+    libc_errno = result.error();
+    return -1;
+  }
+  return result.value();
 }
 
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
This is needed for lifting abort to an internal library routine.