### PR TITLE
[LifetimeSafety] Document record type origin tracking for lifetimebound calls

### DIFF
--- a/clang/docs/LifetimeSafety.rst
+++ b/clang/docs/LifetimeSafety.rst
@@ -179,20 +179,23 @@ with ``[[clang::lifetimebound]]`` annotated parameters:
 
   #include <string>
 
-  struct S {
-    S(const std::string &s [[clang::lifetimebound]]);
+  struct StringView {
+    StringView();
+    StringView(const std::string &s [[clang::lifetimebound]]);
   };
 
-  S getS(const std::string &s [[clang::lifetimebound]]);
+  StringView getStringView(const std::string &s [[clang::lifetimebound]]);
 
   void test() {
-    S a(std::string("temp")); // warning: object whose reference is captured does not live long enough
-                              // note: destroyed here
-    (void)a;                  // note: later used here
-
-    S b = getS(std::string("temp")); // warning: object whose reference is captured does not live long enough
-                                     // note: destroyed here
-    (void)b;                         // note: later used here
+    StringView a, b;
+    {
+      std::string s = "temp";
+      StringView tmp(s);    // warning: object whose reference is captured does not live long enough
+      a = tmp;
+      b = getStringView(s); // warning: object whose reference is captured does not live long enough
+    }                       // note: destroyed here
+    (void)a;                // note: later used here
+    (void)b;                // note: later used here
   }
 
 For more details, see `lifetimebound <https://clang.llvm.org/docs/AttributeReference.html#lifetimebound>`_.

--- a/clang/docs/LifetimeSafety.rst
+++ b/clang/docs/LifetimeSafety.rst
@@ -173,7 +173,7 @@ know that the value returned by ``getView()`` depends on the temporary
 ``MyOwner`` object, and it would not be able to diagnose the dangling ``sv``.
 
 The analysis also tracks record types returned from functions and constructors
-with ``[[clang::lifetimebound]]`` parameters:
+with ``[[clang::lifetimebound]]`` annotated parameters:
 
 .. code-block:: c++
 

--- a/clang/docs/LifetimeSafety.rst
+++ b/clang/docs/LifetimeSafety.rst
@@ -145,8 +145,8 @@ LifetimeBound
 
 The ``[[clang::lifetimebound]]`` attribute can be applied to function parameters
 or to the implicit ``this`` parameter of a method (by placing it after the
-method declarator). It indicates that the returned pointer or reference becomes
-invalid when the attributed parameter or ``this`` object is destroyed.
+method declarator). It indicates that the returned value becomes invalid when
+the attributed parameter or ``this`` object is destroyed.
 This is crucial for functions that return views or references to their
 arguments.
 
@@ -171,6 +171,29 @@ arguments.
 Without ``[[clang::lifetimebound]]`` on ``getView()``, the analysis would not
 know that the value returned by ``getView()`` depends on the temporary
 ``MyOwner`` object, and it would not be able to diagnose the dangling ``sv``.
+
+The analysis also tracks record types returned from functions and constructors
+with ``[[clang::lifetimebound]]`` parameters:
+
+.. code-block:: c++
+
+  #include <string>
+
+  struct S {
+    S(const std::string &s [[clang::lifetimebound]]);
+  };
+
+  S getS(const std::string &s [[clang::lifetimebound]]);
+
+  void test() {
+    S a(std::string("temp")); // warning: object whose reference is captured does not live long enough
+                              // note: destroyed here
+    (void)a;                  // note: later used here
+
+    S b = getS(std::string("temp")); // warning: object whose reference is captured does not live long enough
+                                     // note: destroyed here
+    (void)b;                         // note: later used here
+  }
 
 For more details, see `lifetimebound <https://clang.llvm.org/docs/AttributeReference.html#lifetimebound>`_.
 


### PR DESCRIPTION
Update the doc for #187917