### PR TITLE
[clang][test] Add missing FileCheck pipe in constant-string-class-1.m

### DIFF
--- a/clang/test/CodeGenObjC/constant-string-class-1.m
+++ b/clang/test/CodeGenObjC/constant-string-class-1.m
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-apple-darwin10 -fno-constant-cfstrings -fconstant-string-class OFConstantString  -emit-llvm -o %t %s
+// RUN: %clang_cc1 -triple x86_64-apple-darwin10 -fno-constant-cfstrings -fconstant-string-class OFConstantString  -emit-llvm -o - %s | FileCheck %s
 // pr9914
 
 @interface OFConstantString 


### PR DESCRIPTION
The test had a CHECK directive that was never executed because the RUN line did not pipe output to FileCheck.