### PR TITLE
[flang] Disambiguate derived component accesses in AliasAnalysis.

### DIFF
--- a/flang/include/flang/Optimizer/Analysis/AliasAnalysis.h
+++ b/flang/include/flang/Optimizer/Analysis/AliasAnalysis.h
@@ -12,10 +12,12 @@
 #include "flang/Common/enum-class.h"
 #include "flang/Common/enum-set.h"
 #include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace fir {
 
@@ -137,6 +139,60 @@ struct AliasAnalysis {
       bool isData{false};
     };
 
+    /// Represents a step in the access path from a root variable to the
+    /// memory location being queried. Built during the backward walk in
+    /// getSource() and stored in forward (root-to-leaf) order.
+    struct PathStep {
+      enum class Kind {
+        /// Named component access, e.g. x%field.
+        Component,
+        /// Loading a POINTER box (fir.load of !fir.box<!fir.ptr<...>>).
+        /// The resulting address depends on pointer association at runtime.
+        PointerDeref,
+        /// Loading an ALLOCATABLE box (fir.load of !fir.box<!fir.heap<...>>).
+        AllocDeref,
+      };
+      Kind kind;
+      /// For Component steps: the field name from hlfir.designate's component
+      /// attribute or fir.coordinate_of's field_indices (mapped through the
+      /// record type). Null for non-Component steps.
+      mlir::StringAttr component;
+
+      bool operator==(const PathStep &o) const {
+        return kind == o.kind && component == o.component;
+      }
+      bool operator!=(const PathStep &o) const { return !(*this == o); }
+    };
+
+    /// The access path from the root variable to the queried memory location.
+    /// For example, given:
+    ///   type(outer) :: x   ! outer has component "in" of type inner
+    ///                      ! inner has pointer component "p"
+    /// the target address of x%in%p (i.e. the data x%in%p points to) is:
+    ///   [{Component,"in"}, {Component,"p"}, {PointerDeref}]
+    /// where PointerDeref represents loading the pointer descriptor and
+    /// extracting the target address (fir.load + fir.box_addr in the IR).
+    /// This enables disambiguation of accesses to different components of
+    /// the same derived-type variable and tracks pointer dereferences for
+    /// pointer/target aliasing (Fortran 2018 8.5.7, 15.5.2.13).
+    struct AccessPath {
+      llvm::SmallVector<PathStep, 4> steps;
+
+      /// Whether the path is approximate (e.g. contains array indexing or
+      /// went through PackArrayOp). An approximate path cannot yield
+      /// MustAlias.
+      bool isApproximate{false};
+
+      /// Return true if any step is a PointerDeref.
+      bool hasPointerDeref() const {
+        return llvm::any_of(steps, [](const PathStep &s) {
+          return s.kind == PathStep::Kind::PointerDeref;
+        });
+      }
+
+      void print(llvm::raw_ostream &os) const;
+    };
+
     SourceOrigin origin;
 
     /// Kind of the memory source.
@@ -148,6 +204,8 @@ struct AliasAnalysis {
     /// Have we lost precision following the source such that
     /// even an exact match cannot be MustAlias?
     bool approximateSource;
+    /// The structured access path from the root variable.
+    AccessPath accessPath;
     /// Source object is used in an internal procedure via host association.
     bool isCapturedInInternalProcedure{false};
 

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -132,8 +132,9 @@ static fir::AliasAnalysis::Source getSourceForACCMappedValue(
             fir::AliasAnalysis::SourceKind::Allocate,
             mappedValue.getType(),
             accumulatedAttrs,
-            false,
-            false};
+            /*approximateSource=*/false,
+            /*accessPath=*/{},
+            /*isCapturedInInternalProcedure=*/false};
 
   // Not private-like: classify using the corresponding host variable's source.
   //
@@ -150,6 +151,28 @@ static fir::AliasAnalysis::Source getSourceForACCMappedValue(
 
 namespace fir {
 
+void AliasAnalysis::Source::AccessPath::print(llvm::raw_ostream &os) const {
+  os << "[";
+  for (auto it = steps.begin(); it != steps.end(); ++it) {
+    if (it != steps.begin())
+      os << ", ";
+    switch (it->kind) {
+    case PathStep::Kind::Component:
+      os << "Component(\"" << it->component.getValue() << "\")";
+      break;
+    case PathStep::Kind::PointerDeref:
+      os << "PointerDeref";
+      break;
+    case PathStep::Kind::AllocDeref:
+      os << "AllocDeref";
+      break;
+    }
+  }
+  os << "]";
+  if (isApproximate)
+    os << "(~)";
+}
+
 void AliasAnalysis::Source::print(llvm::raw_ostream &os) const {
   if (auto v = llvm::dyn_cast<mlir::Value>(origin.u))
     os << v;
@@ -162,6 +185,9 @@ void AliasAnalysis::Source::print(llvm::raw_ostream &os) const {
   } else {
     os << " following box reference ";
   }
+  os << " AccessPath: ";
+  accessPath.print(os);
+  os << " ";
   attributes.Dump(os, EnumToString);
 }
 
@@ -321,6 +347,22 @@ AliasResult AliasAnalysis::alias(Source lhsSrc, Source rhsSrc, mlir::Value lhs,
   if (lhsSrc.kind >= SourceKind::Indirect ||
       rhsSrc.kind >= SourceKind::Indirect) {
     LLVM_DEBUG(llvm::dbgs() << "  aliasing because of indirect access\n");
+    return AliasResult::MayAlias;
+  }
+
+  // After a POINTER dereference the actual address is determined at runtime
+  // by pointer association (Fortran 2018 8.5.7, 15.5.2.13). A POINTER can
+  // only be associated with a TARGET or another POINTER, so the dereferenced
+  // address may alias any source that carries the TARGET or POINTER attribute.
+  // When both sides trace to the same origin variable, the pointer deref
+  // does not introduce cross-variable aliasing, so this check is skipped
+  // (the normal same-origin logic handles that case).
+  if (lhsSrc.origin.u != rhsSrc.origin.u &&
+      ((lhsSrc.accessPath.hasPointerDeref() && rhsSrc.isTargetOrPointer()) ||
+       (rhsSrc.accessPath.hasPointerDeref() && lhsSrc.isTargetOrPointer()))) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "  aliasing because pointer dereference may reach "
+               << "target/pointer\n");
     return AliasResult::MayAlias;
   }
 
@@ -705,6 +747,13 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
   mlir::SymbolRefAttr global;
   Source::Attributes attributes;
   mlir::Operation *instantiationPoint{nullptr};
+
+  // Access path steps collected during the backward walk (leaf-to-root order).
+  // Reversed into the final AccessPath at the end, unless the box-load branch
+  // composes the full path directly.
+  llvm::SmallVector<Source::PathStep, 4> pathSteps;
+  Source::AccessPath accessPath;
+  bool accessPathFinalized{false};
   while (defOp && !breakFromLoop) {
     // Value-scoped allocation detection via effects.
     if (classifyAllocateFromEffects(defOp, v) == SourceKind::Allocate) {
@@ -764,13 +813,17 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
             return;
           }
 
-          // If we are loading a box reference, but following the data,
-          // we gather the attributes of the box to populate the source
-          // and stop tracking.
-          if (auto boxTy = mlir::dyn_cast<fir::BaseBoxType>(ty);
-              boxTy && followingData) {
+          // Loading a box value from memory (e.g. a pointer/allocatable
+          // component's descriptor). Trace the memref so derived-type
+          // component accesses reach their [hl]fir.declare instead of
+          // SourceKind::Indirect (which forces MayAlias broadly in alias()).
+          // The access path records a PointerDeref or AllocDeref step here
+          // so that alias() can distinguish pointer-dereferenced addresses
+          // from statically known ones.
+          if (auto boxTy = mlir::dyn_cast<fir::BaseBoxType>(ty); boxTy) {
 
-            if (mlir::isa<fir::PointerType>(boxTy.getEleTy()))
+            bool isPointerBox = mlir::isa<fir::PointerType>(boxTy.getEleTy());
+            if (isPointerBox)
               attributes.set(Attribute::Pointer);
 
             auto boxSrc = getSource(op.getMemref());
@@ -785,6 +838,20 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
             } else {
               instantiationPoint = boxSrc.origin.instantiationPoint;
             }
+
+            // Compose the access path: inner path (root to this load point)
+            // + deref step + outer path (this load to the queried value).
+            accessPath.steps = boxSrc.accessPath.steps;
+            Source::PathStep derefStep;
+            derefStep.kind = isPointerBox ? Source::PathStep::Kind::PointerDeref
+                                          : Source::PathStep::Kind::AllocDeref;
+            derefStep.component = {};
+            accessPath.steps.push_back(derefStep);
+            for (int i = pathSteps.size() - 1; i >= 0; --i)
+              accessPath.steps.push_back(pathSteps[i]);
+            accessPath.isApproximate =
+                boxSrc.accessPath.isApproximate || approximateSource;
+            accessPathFinalized = true;
 
             global = llvm::dyn_cast<mlir::SymbolRefAttr>(boxSrc.origin.u);
             if (global) {
@@ -949,6 +1016,45 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
             return;
           }
 
+          // Record component access steps for the access path.
+          //
+          // hlfir.designate carries the component name directly as a
+          // StringAttr, e.g. hlfir.designate %x{"fieldName"}.
+          if (auto designateOp = mlir::dyn_cast<hlfir::DesignateOp>(defOp)) {
+            if (auto comp = designateOp.getComponent()) {
+              Source::PathStep step;
+              step.kind = Source::PathStep::Kind::Component;
+              step.component = *comp;
+              pathSteps.push_back(step);
+            }
+          } else if (auto coordOp = mlir::dyn_cast<fir::CoordinateOp>(defOp)) {
+            // fir.coordinate_of encodes field accesses as integer indices
+            // into the record type's field list (the field_indices attr).
+            // To recover the field name, look up the first static field
+            // index in the base operand's RecordType.  Dynamic indices
+            // (kDynamicIndex) correspond to array subscripts, not named
+            // components, so they are skipped.
+            std::optional<llvm::ArrayRef<int32_t>> fieldIndices =
+                coordOp.getFieldIndices();
+            if (fieldIndices && !fieldIndices->empty() &&
+                (*fieldIndices)[0] != fir::CoordinateOp::kDynamicIndex) {
+              mlir::Type baseTy =
+                  fir::getFortranElementType(coordOp.getRef().getType());
+              if (auto recTy = mlir::dyn_cast<fir::RecordType>(baseTy)) {
+                auto typeList = recTy.getTypeList();
+                int32_t fieldIdx = (*fieldIndices)[0];
+                if (fieldIdx >= 0 &&
+                    static_cast<size_t>(fieldIdx) < typeList.size()) {
+                  Source::PathStep step;
+                  step.kind = Source::PathStep::Kind::Component;
+                  step.component = mlir::StringAttr::get(
+                      defOp->getContext(), typeList[fieldIdx].first);
+                  pathSteps.push_back(step);
+                }
+              }
+            }
+          }
+
           // Collect attributes from FortranVariableOpInterface operations.
           if (auto varIf =
                   mlir::dyn_cast<fir::FortranVariableOpInterface>(defOp))
@@ -1015,12 +1121,20 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
     }
   }
 
+  // Finalize the access path if not already done by the box-load branch.
+  if (!accessPathFinalized) {
+    std::reverse(pathSteps.begin(), pathSteps.end());
+    accessPath.steps = std::move(pathSteps);
+    accessPath.isApproximate = approximateSource;
+  }
+
   if (type == SourceKind::Global) {
     return {{global, instantiationPoint, followingData},
             type,
             ty,
             attributes,
             approximateSource,
+            accessPath,
             isCapturedInInternalProcedure};
   }
   return {{v, instantiationPoint, followingData},
@@ -1028,6 +1142,7 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
           ty,
           attributes,
           approximateSource,
+          accessPath,
           isCapturedInInternalProcedure};
 }
 

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -1097,27 +1097,60 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
           } else if (auto coordOp = mlir::dyn_cast<fir::CoordinateOp>(defOp)) {
             // fir.coordinate_of encodes field accesses as integer indices
             // into the record type's field list (the field_indices attr).
-            // To recover the field name, look up the first static field
-            // index in the base operand's RecordType.  Dynamic indices
+            // A single coordinate_of may access multiple nested fields,
+            // e.g. fir.coordinate_of %obj, inner, a has field_indices
+            // [inner_idx, a_idx].  Walk the type hierarchy to recover
+            // the field name for each static index.  Dynamic indices
             // (kDynamicIndex) correspond to array subscripts, not named
-            // components, so they are skipped.
+            // components, so they only advance the type through the
+            // array dimension.
             std::optional<llvm::ArrayRef<int32_t>> fieldIndices =
                 coordOp.getFieldIndices();
-            if (fieldIndices && !fieldIndices->empty() &&
-                (*fieldIndices)[0] != fir::CoordinateOp::kDynamicIndex) {
-              mlir::Type baseTy =
-                  fir::getFortranElementType(coordOp.getRef().getType());
-              if (auto recTy = mlir::dyn_cast<fir::RecordType>(baseTy)) {
-                auto typeList = recTy.getTypeList();
-                int32_t fieldIdx = (*fieldIndices)[0];
-                if (fieldIdx >= 0 &&
-                    static_cast<size_t>(fieldIdx) < typeList.size()) {
-                  Source::PathStep step;
-                  step.kind = Source::PathStep::Kind::Component;
-                  step.component = mlir::StringAttr::get(
-                      defOp->getContext(), typeList[fieldIdx].first);
-                  pathSteps.push_back(step);
+            if (fieldIndices) {
+              mlir::Type currentTy =
+                  fir::dyn_cast_ptrOrBoxEleTy(coordOp.getRef().getType());
+              llvm::SmallVector<mlir::StringAttr, 4> componentNames;
+              unsigned dimension = 0;
+              for (int32_t idx : *fieldIndices) {
+                if (idx == fir::CoordinateOp::kDynamicIndex) {
+                  if (dimension == 0) {
+                    if (auto seqTy =
+                            mlir::dyn_cast<fir::SequenceType>(currentTy))
+                      dimension = seqTy.getDimension();
+                  }
+                  if (dimension) {
+                    if (--dimension == 0)
+                      currentTy = mlir::cast<fir::SequenceType>(currentTy)
+                                      .getElementType();
+                  }
+                  continue;
                 }
+                auto recTy = mlir::dyn_cast<fir::RecordType>(currentTy);
+                if (!recTy) {
+                  // Unexpected type structure; discard any partially
+                  // collected names so the access path stays conservative
+                  // rather than recording a misleading partial path.
+                  componentNames.clear();
+                  break;
+                }
+                auto typeList = recTy.getTypeList();
+                if (idx < 0 || static_cast<size_t>(idx) >= typeList.size()) {
+                  // Out-of-bounds field index; same conservative treatment.
+                  componentNames.clear();
+                  break;
+                }
+                componentNames.push_back(mlir::StringAttr::get(
+                    defOp->getContext(), typeList[idx].first));
+                currentTy = typeList[idx].second;
+              }
+              // pathSteps is in leaf-to-root order (reversed at the end),
+              // so push innermost component first.
+              for (auto it = componentNames.rbegin();
+                   it != componentNames.rend(); ++it) {
+                Source::PathStep step;
+                step.kind = Source::PathStep::Kind::Component;
+                step.component = *it;
+                pathSteps.push_back(step);
               }
             }
           }

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -317,6 +317,44 @@ static bool noAliasBasedOnType(mlir::Value lhs, mlir::Value rhs) {
   return false;
 }
 
+/// Return true if two access paths from the same origin variable diverge at
+/// a named component step, meaning they address disjoint subobjects of the
+/// root variable. For example, paths [Component("a")] and [Component("b")]
+/// diverge immediately, while [Component("a"), Component("x")] and
+/// [Component("a"), Component("y")] share a common prefix "a" and diverge
+/// at the second step.
+///
+/// If the paths diverge at steps that are not both Component (e.g., one is
+/// a PointerDeref), or if either path continues through a PointerDeref or
+/// AllocDeref after the divergence, we conservatively return false because
+/// the runtime address after a dereference is not guaranteed to stay within
+/// the subobject.
+static bool pathsDivergeAtComponent(const fir::AliasAnalysis::Source &lhsSrc,
+                                    const fir::AliasAnalysis::Source &rhsSrc) {
+  using PathStep = fir::AliasAnalysis::Source::PathStep;
+  auto &lhsSteps = lhsSrc.accessPath.steps;
+  auto &rhsSteps = rhsSrc.accessPath.steps;
+  size_t minLen = std::min(lhsSteps.size(), rhsSteps.size());
+  for (size_t i = 0; i < minLen; ++i) {
+    if (lhsSteps[i].kind == PathStep::Kind::Component &&
+        rhsSteps[i].kind == PathStep::Kind::Component &&
+        lhsSteps[i].component != rhsSteps[i].component) {
+      auto hasDerefAfter = [](llvm::ArrayRef<PathStep> steps, size_t from) {
+        for (size_t j = from; j < steps.size(); ++j)
+          if (steps[j].kind != PathStep::Kind::Component)
+            return true;
+        return false;
+      };
+      if (hasDerefAfter(lhsSteps, i + 1) || hasDerefAfter(rhsSteps, i + 1))
+        return false;
+      return true;
+    }
+    if (lhsSteps[i] != rhsSteps[i])
+      break;
+  }
+  return false;
+}
+
 AliasResult AliasAnalysis::alias(mlir::Value lhs, mlir::Value rhs) {
   // A wrapper around alias(Source lhsSrc, Source rhsSrc, mlir::Value lhs,
   // mlir::Value rhs) This allows a user to provide Source that may be obtained
@@ -383,8 +421,14 @@ AliasResult AliasAnalysis::alias(Source lhsSrc, Source rhsSrc, mlir::Value lhs,
     if (lhsSrc.origin == rhsSrc.origin) {
       LLVM_DEBUG(llvm::dbgs()
                  << "  aliasing because same source kind and origin\n");
-      if (approximateSource)
+      if (approximateSource) {
+        if (pathsDivergeAtComponent(lhsSrc, rhsSrc)) {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "  no alias: different components of same origin\n");
+          return AliasResult::NoAlias;
+        }
         return AliasResult::MayAlias;
+      }
       // One should be careful about relying on MustAlias.
       // The LLVM definition implies that the two MustAlias
       // memory objects start at exactly the same location.
@@ -418,6 +462,11 @@ AliasResult AliasAnalysis::alias(Source lhsSrc, Source rhsSrc, mlir::Value lhs,
     if (lhsSrc.origin.u == rhsSrc.origin.u &&
         ((isRecordWithPointerComponent(lhs.getType()) && !rhsSrc.isData()) ||
          (isRecordWithPointerComponent(rhs.getType()) && !lhsSrc.isData()))) {
+      if (pathsDivergeAtComponent(lhsSrc, rhsSrc)) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "  no alias: different components of same origin\n");
+        return AliasResult::NoAlias;
+      }
       LLVM_DEBUG(llvm::dbgs()
                  << "  aliasing between composite and non-data component with "
                  << "same source kind and origin value\n");

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -324,11 +324,20 @@ static bool noAliasBasedOnType(mlir::Value lhs, mlir::Value rhs) {
 /// [Component("a"), Component("y")] share a common prefix "a" and diverge
 /// at the second step.
 ///
-/// If the paths diverge at steps that are not both Component (e.g., one is
-/// a PointerDeref), or if either path continues through a PointerDeref or
-/// AllocDeref after the divergence, we conservatively return false because
-/// the runtime address after a dereference is not guaranteed to stay within
-/// the subobject.
+/// When either path continues through a PointerDeref or AllocDeref after
+/// the divergence point, the runtime address could potentially reach a
+/// sibling subobject only if that sibling is a valid pointer target.
+/// A subobject has TARGET when the root variable has the TARGET attribute
+/// (Fortran 2018 8.5.7), or when we arrived at the current level through
+/// a PointerDeref (the pointer target carries TARGET by definition).
+/// When neither condition holds, the pointer cannot be associated with a
+/// sibling subobject and the addresses are still disjoint.  Note that the
+/// source's POINTER attribute reflects the component traversed during the
+/// walk, not the root variable, so we check only TARGET on the source.
+///
+/// One exception: if BOTH sides end with a PointerDeref, the two pointers
+/// could independently be associated with the same third-party TARGET
+/// variable, so we conservatively return false.
 static bool pathsDivergeAtComponent(const fir::AliasAnalysis::Source &lhsSrc,
                                     const fir::AliasAnalysis::Source &rhsSrc) {
   using PathStep = fir::AliasAnalysis::Source::PathStep;
@@ -339,14 +348,23 @@ static bool pathsDivergeAtComponent(const fir::AliasAnalysis::Source &lhsSrc,
     if (lhsSteps[i].kind == PathStep::Kind::Component &&
         rhsSteps[i].kind == PathStep::Kind::Component &&
         lhsSteps[i].component != rhsSteps[i].component) {
-      auto hasDerefAfter = [](llvm::ArrayRef<PathStep> steps, size_t from) {
+      auto hasPtrDerefAfter = [](llvm::ArrayRef<PathStep> steps, size_t from) {
         for (size_t j = from; j < steps.size(); ++j)
-          if (steps[j].kind != PathStep::Kind::Component)
+          if (steps[j].kind == PathStep::Kind::PointerDeref)
             return true;
         return false;
       };
-      if (hasDerefAfter(lhsSteps, i + 1) || hasDerefAfter(rhsSteps, i + 1))
+      bool lhsHasPtrDeref = hasPtrDerefAfter(lhsSteps, i + 1);
+      bool rhsHasPtrDeref = hasPtrDerefAfter(rhsSteps, i + 1);
+      if (lhsHasPtrDeref && rhsHasPtrDeref)
         return false;
+      if (lhsHasPtrDeref || rhsHasPtrDeref) {
+        for (size_t j = 0; j < i; ++j)
+          if (lhsSteps[j].kind == PathStep::Kind::PointerDeref)
+            return false;
+        if (lhsSrc.isTarget() || rhsSrc.isTarget())
+          return false;
+      }
       return true;
     }
     if (lhsSteps[i] != rhsSteps[i])

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-access-path.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-access-path.fir
@@ -104,3 +104,75 @@ func.func @_QPtest_nested() {
   %v3 = fir.load %j : !fir.ref<f32>
   return
 }
+
+// -----
+
+// Multi-field fir.coordinate_of accessing nested fields in a single operation.
+// The access path must record a PathStep for each field index.
+
+// CHECK-LABEL: Testing : "_QPtest_multi_field_coord"
+// CHECK-DAG: mf_inner_a#0 <-> mf_inner_b#0: NoAlias
+// CHECK-DAG: mf_inner_a#0 <-> mf_outer_j#0: NoAlias
+// CHECK-DAG: mf_inner_b#0 <-> mf_outer_j#0: NoAlias
+
+func.func @_QPtest_multi_field_coord() {
+  %0 = fir.alloca !fir.type<_QMmTouter{inner:!fir.type<_QMmTinner{a:f32,b:f32}>,j:f32}> {uniq_name = "_QFtestEobj"}
+  %obj = fir.declare %0 {uniq_name = "_QFtestEobj"} : (!fir.ref<!fir.type<_QMmTouter{inner:!fir.type<_QMmTinner{a:f32,b:f32}>,j:f32}>>) -> !fir.ref<!fir.type<_QMmTouter{inner:!fir.type<_QMmTinner{a:f32,b:f32}>,j:f32}>>
+  %a = fir.coordinate_of %obj, inner, a {test.ptr = "mf_inner_a"} : (!fir.ref<!fir.type<_QMmTouter{inner:!fir.type<_QMmTinner{a:f32,b:f32}>,j:f32}>>) -> !fir.ref<f32>
+  %b = fir.coordinate_of %obj, inner, b {test.ptr = "mf_inner_b"} : (!fir.ref<!fir.type<_QMmTouter{inner:!fir.type<_QMmTinner{a:f32,b:f32}>,j:f32}>>) -> !fir.ref<f32>
+  %j = fir.coordinate_of %obj, j {test.ptr = "mf_outer_j"} : (!fir.ref<!fir.type<_QMmTouter{inner:!fir.type<_QMmTinner{a:f32,b:f32}>,j:f32}>>) -> !fir.ref<f32>
+  %v1 = fir.load %a : !fir.ref<f32>
+  %v2 = fir.load %b : !fir.ref<f32>
+  %v3 = fir.load %j : !fir.ref<f32>
+  return
+}
+
+// -----
+
+// Interleaved component and 1-D array index in a single fir.coordinate_of.
+// The dynamic index (kDynamicIndex) must be consumed by the dimension peeling
+// logic without producing a Component step.
+// obj%arr_of_inner(idx)%a and obj%arr_of_inner(idx)%b diverge at the leaf
+// component -> NoAlias.  Both diverge from obj%j at the first step -> NoAlias.
+
+// CHECK-LABEL: Testing : "_QPtest_interleaved_1d"
+// CHECK-DAG: arr_inner_a#0 <-> arr_inner_b#0: NoAlias
+// CHECK-DAG: arr_inner_a#0 <-> outer_j#0: NoAlias
+// CHECK-DAG: arr_inner_b#0 <-> outer_j#0: NoAlias
+
+func.func @_QPtest_interleaved_1d(%idx1: index, %idx2: index) {
+  %0 = fir.alloca !fir.type<_QMmTwrap{arr_of_inner:!fir.array<10x!fir.type<_QMmTinner{a:f32,b:f32}>>,j:f32}> {uniq_name = "_QFtestEobj"}
+  %obj = fir.declare %0 {uniq_name = "_QFtestEobj"} : (!fir.ref<!fir.type<_QMmTwrap{arr_of_inner:!fir.array<10x!fir.type<_QMmTinner{a:f32,b:f32}>>,j:f32}>>) -> !fir.ref<!fir.type<_QMmTwrap{arr_of_inner:!fir.array<10x!fir.type<_QMmTinner{a:f32,b:f32}>>,j:f32}>>
+  %a = fir.coordinate_of %obj, arr_of_inner, %idx1, a {test.ptr = "arr_inner_a"} : (!fir.ref<!fir.type<_QMmTwrap{arr_of_inner:!fir.array<10x!fir.type<_QMmTinner{a:f32,b:f32}>>,j:f32}>>, index) -> !fir.ref<f32>
+  %b = fir.coordinate_of %obj, arr_of_inner, %idx2, b {test.ptr = "arr_inner_b"} : (!fir.ref<!fir.type<_QMmTwrap{arr_of_inner:!fir.array<10x!fir.type<_QMmTinner{a:f32,b:f32}>>,j:f32}>>, index) -> !fir.ref<f32>
+  %j = fir.coordinate_of %obj, j {test.ptr = "outer_j"} : (!fir.ref<!fir.type<_QMmTwrap{arr_of_inner:!fir.array<10x!fir.type<_QMmTinner{a:f32,b:f32}>>,j:f32}>>) -> !fir.ref<f32>
+  %v1 = fir.load %a : !fir.ref<f32>
+  %v2 = fir.load %b : !fir.ref<f32>
+  %v3 = fir.load %j : !fir.ref<f32>
+  return
+}
+
+// -----
+
+// Nested 2-D arrays: component, idx, idx, component, idx, idx.
+// The dimension peeling loop must fire twice (once per array level), each
+// time consuming two kDynamicIndex entries before advancing to the element type.
+// obj%arr_of_inner(i,j)%x(k,l) and obj%arr_of_inner(i,j)%y(k,l) diverge at
+// the second component -> NoAlias.
+
+// CHECK-LABEL: Testing : "_QPtest_nested_2d_arrays"
+// CHECK-DAG: nested_x#0 <-> nested_y#0: NoAlias
+// CHECK-DAG: nested_x#0 <-> outer_k#0: NoAlias
+// CHECK-DAG: nested_y#0 <-> outer_k#0: NoAlias
+
+func.func @_QPtest_nested_2d_arrays(%idx1: index, %idx2: index, %idx3: index, %idx4: index, %idx5: index, %idx6: index, %idx7: index, %idx8: index) {
+  %0 = fir.alloca !fir.type<_QMmTouter2{arr_of_inner:!fir.array<10x20x!fir.type<_QMmTinner2{x:!fir.array<5x10xf32>,y:!fir.array<5x10xf32>}>>,k:f32}> {uniq_name = "_QFtestEobj"}
+  %obj = fir.declare %0 {uniq_name = "_QFtestEobj"} : (!fir.ref<!fir.type<_QMmTouter2{arr_of_inner:!fir.array<10x20x!fir.type<_QMmTinner2{x:!fir.array<5x10xf32>,y:!fir.array<5x10xf32>}>>,k:f32}>>) -> !fir.ref<!fir.type<_QMmTouter2{arr_of_inner:!fir.array<10x20x!fir.type<_QMmTinner2{x:!fir.array<5x10xf32>,y:!fir.array<5x10xf32>}>>,k:f32}>>
+  %x = fir.coordinate_of %obj, arr_of_inner, %idx1, %idx2, x, %idx3, %idx4 {test.ptr = "nested_x"} : (!fir.ref<!fir.type<_QMmTouter2{arr_of_inner:!fir.array<10x20x!fir.type<_QMmTinner2{x:!fir.array<5x10xf32>,y:!fir.array<5x10xf32>}>>,k:f32}>>, index, index, index, index) -> !fir.ref<f32>
+  %y = fir.coordinate_of %obj, arr_of_inner, %idx5, %idx6, y, %idx7, %idx8 {test.ptr = "nested_y"} : (!fir.ref<!fir.type<_QMmTouter2{arr_of_inner:!fir.array<10x20x!fir.type<_QMmTinner2{x:!fir.array<5x10xf32>,y:!fir.array<5x10xf32>}>>,k:f32}>>, index, index, index, index) -> !fir.ref<f32>
+  %k = fir.coordinate_of %obj, k {test.ptr = "outer_k"} : (!fir.ref<!fir.type<_QMmTouter2{arr_of_inner:!fir.array<10x20x!fir.type<_QMmTinner2{x:!fir.array<5x10xf32>,y:!fir.array<5x10xf32>}>>,k:f32}>>) -> !fir.ref<f32>
+  %v1 = fir.load %x : !fir.ref<f32>
+  %v2 = fir.load %y : !fir.ref<f32>
+  %v3 = fir.load %k : !fir.ref<f32>
+  return
+}

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-access-path.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-access-path.fir
@@ -1,0 +1,106 @@
+// Edge-case tests for the AccessPath infrastructure in fir::AliasAnalysis.
+//
+// These tests exercise scenarios that may arise when the IR is not in the
+// canonical form produced by lowering (e.g. missing fir.declare, non-FIR ops
+// in the def-use chain) and verify that alias analysis remains sound.
+
+// RUN: fir-opt %s -split-input-file -o /dev/null --mlir-disable-threading  \
+// RUN:   -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' \
+// RUN:   2>&1 | FileCheck -match-full-lines %s
+
+// -----
+
+// Bare fir.alloca without fir.declare.
+// Component disambiguation must still work because fir.coordinate_of sets
+// approximateSource (its getViewOffset returns nullopt), which triggers
+// pathsDivergeAtComponent.
+
+// CHECK-LABEL: Testing : "_QPtest_bare_alloca"
+// CHECK-DAG: comp_a#0 <-> comp_b#0: NoAlias
+// CHECK-DAG: comp_a#0 <-> comp_a2#0: MayAlias
+// CHECK-DAG: comp_b#0 <-> comp_a2#0: NoAlias
+
+func.func @_QPtest_bare_alloca() {
+  %0 = fir.alloca !fir.type<_QMmTty{a:f32,b:f32}> {uniq_name = "_QFtestEobj"}
+  %a = fir.coordinate_of %0, a {test.ptr = "comp_a"} : (!fir.ref<!fir.type<_QMmTty{a:f32,b:f32}>>) -> !fir.ref<f32>
+  %b = fir.coordinate_of %0, b {test.ptr = "comp_b"} : (!fir.ref<!fir.type<_QMmTty{a:f32,b:f32}>>) -> !fir.ref<f32>
+  %a2 = fir.coordinate_of %0, a {test.ptr = "comp_a2"} : (!fir.ref<!fir.type<_QMmTty{a:f32,b:f32}>>) -> !fir.ref<f32>
+  %v1 = fir.load %a : !fir.ref<f32>
+  %v2 = fir.load %b : !fir.ref<f32>
+  %v3 = fir.load %a2 : !fir.ref<f32>
+  return
+}
+
+// -----
+
+// Non-FIR operation (arith.select) breaking the def-use chain.
+// The walk hits the Default handler, producing SourceKind::Unknown, so all
+// pairs involving the broken chain must conservatively return MayAlias.
+// The direct access through the original alloca is also MayAlias with the
+// broken-chain accesses because their origins differ (Unknown vs Allocate).
+
+// CHECK-LABEL: Testing : "_QPtest_unknown_op"
+// CHECK-DAG: sel_comp_a#0 <-> sel_comp_b#0: MayAlias
+// CHECK-DAG: sel_comp_a#0 <-> direct_comp_a#0: MayAlias
+// CHECK-DAG: sel_comp_b#0 <-> direct_comp_a#0: MayAlias
+
+func.func @_QPtest_unknown_op(%cond: i1) {
+  %0 = fir.alloca !fir.type<_QMmTty{a:f32,b:f32}> {uniq_name = "_QFtestEobj1"}
+  %1 = fir.alloca !fir.type<_QMmTty{a:f32,b:f32}> {uniq_name = "_QFtestEobj2"}
+  %sel = arith.select %cond, %0, %1 : !fir.ref<!fir.type<_QMmTty{a:f32,b:f32}>>
+  %a = fir.coordinate_of %sel, a {test.ptr = "sel_comp_a"} : (!fir.ref<!fir.type<_QMmTty{a:f32,b:f32}>>) -> !fir.ref<f32>
+  %b = fir.coordinate_of %sel, b {test.ptr = "sel_comp_b"} : (!fir.ref<!fir.type<_QMmTty{a:f32,b:f32}>>) -> !fir.ref<f32>
+  %direct_a = fir.coordinate_of %0, a {test.ptr = "direct_comp_a"} : (!fir.ref<!fir.type<_QMmTty{a:f32,b:f32}>>) -> !fir.ref<f32>
+  %v1 = fir.load %a : !fir.ref<f32>
+  %v2 = fir.load %b : !fir.ref<f32>
+  %v3 = fir.load %direct_a : !fir.ref<f32>
+  return
+}
+
+// -----
+
+// Dynamic array index in fir.coordinate_of must NOT produce a Component step.
+// Two subscripts of the same array component are MayAlias (could be the same
+// element), but an array element vs a different named component is NoAlias.
+
+// CHECK-LABEL: Testing : "_QPtest_dynamic_index"
+// CHECK-DAG: arr_elem1#0 <-> arr_elem2#0: MayAlias
+// CHECK-DAG: arr_elem1#0 <-> comp_b#0: NoAlias
+// CHECK-DAG: arr_elem2#0 <-> comp_b#0: NoAlias
+
+func.func @_QPtest_dynamic_index(%idx1: index, %idx2: index) {
+  %0 = fir.alloca !fir.type<_QMmTty2{arr:!fir.array<10xf32>,b:f32}> {uniq_name = "_QFtestEobj"}
+  %obj = fir.declare %0 {uniq_name = "_QFtestEobj"} : (!fir.ref<!fir.type<_QMmTty2{arr:!fir.array<10xf32>,b:f32}>>) -> !fir.ref<!fir.type<_QMmTty2{arr:!fir.array<10xf32>,b:f32}>>
+  %arrref = fir.coordinate_of %obj, arr : (!fir.ref<!fir.type<_QMmTty2{arr:!fir.array<10xf32>,b:f32}>>) -> !fir.ref<!fir.array<10xf32>>
+  %elem1 = fir.coordinate_of %arrref, %idx1 {test.ptr = "arr_elem1"} : (!fir.ref<!fir.array<10xf32>>, index) -> !fir.ref<f32>
+  %elem2 = fir.coordinate_of %arrref, %idx2 {test.ptr = "arr_elem2"} : (!fir.ref<!fir.array<10xf32>>, index) -> !fir.ref<f32>
+  %bref = fir.coordinate_of %obj, b {test.ptr = "comp_b"} : (!fir.ref<!fir.type<_QMmTty2{arr:!fir.array<10xf32>,b:f32}>>) -> !fir.ref<f32>
+  %v1 = fir.load %elem1 : !fir.ref<f32>
+  %v2 = fir.load %elem2 : !fir.ref<f32>
+  %v3 = fir.load %bref : !fir.ref<f32>
+  return
+}
+
+// -----
+
+// Nested derived type: multi-level component paths.
+// x%inner%a and x%inner%b diverge at the second Component step -> NoAlias.
+// x%inner%a and x%j diverge at the first Component step -> NoAlias.
+
+// CHECK-LABEL: Testing : "_QPtest_nested"
+// CHECK-DAG: inner_a#0 <-> inner_b#0: NoAlias
+// CHECK-DAG: inner_a#0 <-> outer_j#0: NoAlias
+// CHECK-DAG: inner_b#0 <-> outer_j#0: NoAlias
+
+func.func @_QPtest_nested() {
+  %0 = fir.alloca !fir.type<_QMmTouter{inner:!fir.type<_QMmTinner{a:f32,b:f32}>,j:f32}> {uniq_name = "_QFtestEobj"}
+  %obj = fir.declare %0 {uniq_name = "_QFtestEobj"} : (!fir.ref<!fir.type<_QMmTouter{inner:!fir.type<_QMmTinner{a:f32,b:f32}>,j:f32}>>) -> !fir.ref<!fir.type<_QMmTouter{inner:!fir.type<_QMmTinner{a:f32,b:f32}>,j:f32}>>
+  %inner = fir.coordinate_of %obj, inner : (!fir.ref<!fir.type<_QMmTouter{inner:!fir.type<_QMmTinner{a:f32,b:f32}>,j:f32}>>) -> !fir.ref<!fir.type<_QMmTinner{a:f32,b:f32}>>
+  %a = fir.coordinate_of %inner, a {test.ptr = "inner_a"} : (!fir.ref<!fir.type<_QMmTinner{a:f32,b:f32}>>) -> !fir.ref<f32>
+  %b = fir.coordinate_of %inner, b {test.ptr = "inner_b"} : (!fir.ref<!fir.type<_QMmTinner{a:f32,b:f32}>>) -> !fir.ref<f32>
+  %j = fir.coordinate_of %obj, j {test.ptr = "outer_j"} : (!fir.ref<!fir.type<_QMmTouter{inner:!fir.type<_QMmTinner{a:f32,b:f32}>,j:f32}>>) -> !fir.ref<f32>
+  %v1 = fir.load %a : !fir.ref<f32>
+  %v2 = fir.load %b : !fir.ref<f32>
+  %v3 = fir.load %j : !fir.ref<f32>
+  return
+}

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-derived-type-box-load.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-derived-type-box-load.fir
@@ -1,0 +1,449 @@
+// Exercise AliasAnalysis for fir.load of fir.box values coming from dummy
+// arguments, nested derived-type component chains, allocatable variables,
+// whole-object pointer/target semantics, and globals.
+
+// RUN: fir-opt %s -split-input-file -o /dev/null --mlir-disable-threading \
+// RUN:   -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' \
+// RUN:   2>&1 | FileCheck %s
+
+// subroutine test_dummy_ptr(p)
+//   real, pointer :: p
+//   real :: v
+// end subroutine
+
+// CHECK-LABEL: Testing : "_QPtest_dummy_ptr"
+// Data through the pointer dummy cannot alias an unrelated local scalar.
+// CHECK-DAG: local#0 <-> p_dummy.tgt#0: NoAlias
+// CHECK-LABEL: Testing : "_QPtest_dummy_ptr.fir"
+// CHECK-DAG: local.fir#0 <-> p_dummy.tgt.fir#0: NoAlias
+
+func.func @_QPtest_dummy_ptr(%arg0: !fir.ref<!fir.box<!fir.ptr<f32>>> {fir.bindc_name = "p"}) {
+  %0:2 = hlfir.declare %arg0 {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "p_dummy", uniq_name = "_QFtest_dummy_ptrEp"} : (!fir.ref<!fir.box<!fir.ptr<f32>>>) -> (!fir.ref<!fir.box<!fir.ptr<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>)
+  %1 = fir.alloca f32 {bindc_name = "v", uniq_name = "_QFtest_dummy_ptrEv"}
+  %2:2 = hlfir.declare %1 {test.ptr = "local", uniq_name = "_QFtest_dummy_ptrEv"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
+  %3 = fir.load %0#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %4 = fir.box_addr %3 {test.ptr = "p_dummy.tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+func.func @_QPtest_dummy_ptr.fir(%arg0: !fir.ref<!fir.box<!fir.ptr<f32>>> {fir.bindc_name = "p"}) {
+  %0 = fir.declare %arg0 {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "p_dummy.fir", uniq_name = "_QFtest_dummy_ptrEp"} : (!fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %1 = fir.alloca f32 {bindc_name = "v", uniq_name = "_QFtest_dummy_ptrEv"}
+  %2 = fir.declare %1 {test.ptr = "local.fir", uniq_name = "_QFtest_dummy_ptrEv"} : (!fir.ref<f32>) -> !fir.ref<f32>
+  %3 = fir.load %0 : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %4 = fir.box_addr %3 {test.ptr = "p_dummy.tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+// -----
+
+// module m
+// type :: inner
+//   real, pointer :: p
+// end type inner
+// type :: outer
+//   type(inner) :: in
+// end type outer
+// contains
+// subroutine nested_ptr(x)
+//   type(outer) :: x
+//   real :: v
+// end subroutine
+// end module
+
+// CHECK-LABEL: Testing : "_QMmPnested_ptr"
+// Target of nested pointer component vs unrelated local.
+// CHECK-DAG: nested_local#0 <-> x_in_p.tgt#0: NoAlias
+// Whole-variable x may overlap component storage (see load-ptr-designate.fir).
+// CHECK-DAG: x#0 <-> x_in_p#0: MayAlias
+// CHECK-DAG: x#0 <-> x_in_p.tgt#0: MayAlias
+// CHECK-LABEL: Testing : "_QMmPnested_ptr.fir"
+// CHECK-DAG: nested_local.fir#0 <-> x_in_p.tgt.fir#0: NoAlias
+// CHECK-DAG: x.fir#0 <-> x_in_p.fir#0: MayAlias
+// CHECK-DAG: x.fir#0 <-> x_in_p.tgt.fir#0: MayAlias
+
+func.func @_QMmPnested_ptr(%arg0: !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>> {fir.bindc_name = "x"}) {
+  %0:2 = hlfir.declare %arg0 {test.ptr = "x", uniq_name = "_QMmFnested_ptrEx"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>, !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>)
+  %1 = fir.alloca f32 {bindc_name = "v", uniq_name = "_QMmFnested_ptrEv"}
+  %2:2 = hlfir.declare %1 {test.ptr = "nested_local", uniq_name = "_QMmFnested_ptrEv"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
+  %3 = hlfir.designate %0#0{"in"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %4 = hlfir.designate %3{"p"} {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "x_in_p"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %5 = fir.load %4 : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %6 = fir.box_addr %5 {test.ptr = "x_in_p.tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+func.func @_QMmPnested_ptr.fir(%arg0: !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>> {fir.bindc_name = "x"}) {
+  %0 = fir.declare %arg0 {test.ptr = "x.fir", uniq_name = "_QMmFnested_ptrEx"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %1 = fir.alloca f32 {bindc_name = "v", uniq_name = "_QMmFnested_ptrEv"}
+  %2 = fir.declare %1 {test.ptr = "nested_local.fir", uniq_name = "_QMmFnested_ptrEv"} : (!fir.ref<f32>) -> !fir.ref<f32>
+  %3 = fir.coordinate_of %0, in : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %4 = fir.coordinate_of %3, p {test.ptr = "x_in_p.fir"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %5 = fir.load %4 : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %6 = fir.box_addr %5 {test.ptr = "x_in_p.tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+// -----
+
+// type(outer), allocatable :: y — the variable is a box holding heap-allocated
+// outer; y%in%p uses fir.load of the outer box, box_addr to the record, then
+// component access and fir.load of the inner pointer's box.
+//
+// Fortran sketch (module m types as in nested_ptr above):
+//   type(outer), allocatable :: y
+//   real :: v
+//   allocate(y)
+//   y%in%p = 2.0
+
+// CHECK-LABEL: Testing : "_QMmPalloc_outer_box"
+// Target of component pointer inside allocatable outer vs unrelated local.
+// CHECK-DAG: alloc_outer_local#0 <-> y_alloc_in_p.tgt#0: NoAlias
+// CHECK-LABEL: Testing : "_QMmPalloc_outer_box.fir"
+// CHECK-DAG: alloc_outer_local.fir#0 <-> y_alloc_in_p.tgt.fir#0: NoAlias
+
+func.func @_QMmPalloc_outer_box() {
+  %0 = fir.alloca !fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>> {bindc_name = "y", uniq_name = "_QMmFalloc_outer_boxEy"}
+  %1 = fir.allocmem !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}> {uniq_name = "_QMmFalloc_outer_boxEy.alloc"}
+  %2 = fir.embox %1 : (!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>
+  fir.store %2 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %3:2 = hlfir.declare %0 {fortran_attrs = #fir.var_attrs<allocatable>, test.ptr = "y_alloc", uniq_name = "_QMmFalloc_outer_boxEy"} : (!fir.ref<!fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>, !fir.ref<!fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>)
+  %4 = fir.alloca f32 {bindc_name = "v", uniq_name = "_QMmFalloc_outer_boxEv"}
+  %5:2 = hlfir.declare %4 {test.ptr = "alloc_outer_local", uniq_name = "_QMmFalloc_outer_boxEv"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
+  %6 = fir.load %3#0 : !fir.ref<!fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %7 = fir.box_addr %6 : (!fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>) -> !fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %8 = hlfir.designate %7{"in"} : (!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %9 = hlfir.designate %8{"p"} {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "y_alloc_in_p"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %10 = fir.load %9 : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %11 = fir.box_addr %10 {test.ptr = "y_alloc_in_p.tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+func.func @_QMmPalloc_outer_box.fir() {
+  %0 = fir.alloca !fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>> {bindc_name = "y", uniq_name = "_QMmFalloc_outer_boxEy"}
+  %1 = fir.allocmem !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}> {uniq_name = "_QMmFalloc_outer_boxEy.alloc"}
+  %2 = fir.embox %1 : (!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>
+  fir.store %2 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %3 = fir.declare %0 {fortran_attrs = #fir.var_attrs<allocatable>, test.ptr = "y_alloc.fir", uniq_name = "_QMmFalloc_outer_boxEy"} : (!fir.ref<!fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %4 = fir.alloca f32 {bindc_name = "v", uniq_name = "_QMmFalloc_outer_boxEv"}
+  %5 = fir.declare %4 {test.ptr = "alloc_outer_local.fir", uniq_name = "_QMmFalloc_outer_boxEv"} : (!fir.ref<f32>) -> !fir.ref<f32>
+  %6 = fir.load %3 : !fir.ref<!fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %7 = fir.box_addr %6 : (!fir.box<!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>) -> !fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %8 = fir.coordinate_of %7, in : (!fir.heap<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %9 = fir.coordinate_of %8, p {test.ptr = "y_alloc_in_p.fir"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %10 = fir.load %9 : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %11 = fir.box_addr %10 {test.ptr = "y_alloc_in_p.tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+// -----
+
+// type(outer), pointer :: p, q  — whole derived-type POINTER variables (box of
+// ptr-to-type).  MayAlias each other's pointees and scalars with TARGET.
+// type(outer), target :: z, u — data via z%in%p may alias a real POINTER dummy
+// but currently MayAlias a second target's component data (conservative).
+// fir.global outer — disambiguate from locals and from a second global.
+
+// CHECK-LABEL: Testing : "_QMmPtest_derived_ptr_neg"
+// CHECK-DAG: p_rec#0 <-> q_rec#0: MayAlias
+// CHECK-DAG: t_scalar#0 <-> p_rec#0: MayAlias
+// CHECK-LABEL: Testing : "_QMmPtest_derived_ptr_neg_fir"
+// CHECK-DAG: p_rec.fir#0 <-> q_rec.fir#0: MayAlias
+// CHECK-DAG: t_scalar.fir#0 <-> p_rec.fir#0: MayAlias
+
+func.func @_QMmPtest_derived_ptr_neg(%arg0: !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>> {fir.bindc_name = "p"}, %arg1: !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>> {fir.bindc_name = "q"}, %arg2: !fir.ref<f32> {fir.bindc_name = "tscalar", fir.target}) {
+  %p:2 = hlfir.declare %arg0 {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "p_op", uniq_name = "_QMmFp"} : (!fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>)
+  %q:2 = hlfir.declare %arg1 {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "q_op", uniq_name = "_QMmFq"} : (!fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>)
+  %t:2 = hlfir.declare %arg2 {fortran_attrs = #fir.var_attrs<target>, test.ptr = "t_scalar", uniq_name = "_QMmFt"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
+  %lp = fir.load %p#0 : !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %p_rec = fir.box_addr %lp {test.ptr = "p_rec"} : (!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>) -> !fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %lq = fir.load %q#0 : !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %q_rec = fir.box_addr %lq {test.ptr = "q_rec"} : (!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>) -> !fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  return
+}
+
+func.func @_QMmPtest_derived_ptr_neg_fir(%arg0: !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>> {fir.bindc_name = "p"}, %arg1: !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>> {fir.bindc_name = "q"}, %arg2: !fir.ref<f32> {fir.bindc_name = "tscalar", fir.target}) {
+  %p = fir.declare %arg0 {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "p_op.fir", uniq_name = "_QMmFp"} : (!fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %q = fir.declare %arg1 {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "q_op.fir", uniq_name = "_QMmFq"} : (!fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %t = fir.declare %arg2 {fortran_attrs = #fir.var_attrs<target>, test.ptr = "t_scalar.fir", uniq_name = "_QMmFt"} : (!fir.ref<f32>) -> !fir.ref<f32>
+  %lp = fir.load %p : !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %p_rec = fir.box_addr %lp {test.ptr = "p_rec.fir"} : (!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>) -> !fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %lq = fir.load %q : !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %q_rec = fir.box_addr %lq {test.ptr = "q_rec.fir"} : (!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>) -> !fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: Testing : "_QMmPtest_derived_target_neg"
+// TODO: Fortran allows refining z_p_tgt vs u_p_tgt to NoAlias (distinct TARGET).
+// CHECK-DAG: z_p_tgt#0 <-> rptr_tgt#0: MayAlias
+// CHECK-DAG: z_p_tgt#0 <-> u_p_tgt#0: MayAlias
+// CHECK-LABEL: Testing : "_QMmPtest_derived_target_neg_fir"
+// CHECK-DAG: z_p_tgt.fir#0 <-> rptr_tgt.fir#0: MayAlias
+// CHECK-DAG: z_p_tgt.fir#0 <-> u_p_tgt.fir#0: MayAlias
+
+func.func @_QMmPtest_derived_target_neg(%arg0: !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>> {fir.bindc_name = "z", fir.target}, %arg1: !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>> {fir.bindc_name = "u", fir.target}, %arg2: !fir.ref<!fir.box<!fir.ptr<f32>>> {fir.bindc_name = "rptr"}) {
+  %z:2 = hlfir.declare %arg0 {fortran_attrs = #fir.var_attrs<target>, test.ptr = "z_op", uniq_name = "_QMmFz"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>, !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>)
+  %u:2 = hlfir.declare %arg1 {fortran_attrs = #fir.var_attrs<target>, test.ptr = "u_op", uniq_name = "_QMmFu"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>, !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>)
+  %r:2 = hlfir.declare %arg2 {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "rptr_op", uniq_name = "_QMmFr"} : (!fir.ref<!fir.box<!fir.ptr<f32>>>) -> (!fir.ref<!fir.box<!fir.ptr<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>)
+  %zin = hlfir.designate %z#0{"in"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %zp = hlfir.designate %zin{"p"} {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "z_in_p"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %zpl = fir.load %zp : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %zpt = fir.box_addr %zpl {test.ptr = "z_p_tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  %uin = hlfir.designate %u#0{"in"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %up = hlfir.designate %uin{"p"} {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "u_in_p"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %upl = fir.load %up : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %upt = fir.box_addr %upl {test.ptr = "u_p_tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  %rl = fir.load %r#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %rt = fir.box_addr %rl {test.ptr = "rptr_tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+func.func @_QMmPtest_derived_target_neg_fir(%arg0: !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>> {fir.bindc_name = "z", fir.target}, %arg1: !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>> {fir.bindc_name = "u", fir.target}, %arg2: !fir.ref<!fir.box<!fir.ptr<f32>>> {fir.bindc_name = "rptr"}) {
+  %z = fir.declare %arg0 {fortran_attrs = #fir.var_attrs<target>, test.ptr = "z_op.fir", uniq_name = "_QMmFz"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %u = fir.declare %arg1 {fortran_attrs = #fir.var_attrs<target>, test.ptr = "u_op.fir", uniq_name = "_QMmFu"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %r = fir.declare %arg2 {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "rptr_op.fir", uniq_name = "_QMmFr"} : (!fir.ref<!fir.box<!fir.ptr<f32>>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %zin = fir.coordinate_of %z, in : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %zp = fir.coordinate_of %zin, p {test.ptr = "z_in_p.fir"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %zpl = fir.load %zp : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %zpt = fir.box_addr %zpl {test.ptr = "z_p_tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  %uin = fir.coordinate_of %u, in : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %up = fir.coordinate_of %uin, p {test.ptr = "u_in_p.fir"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %upl = fir.load %up : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %upt = fir.box_addr %upl {test.ptr = "u_p_tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  %rl = fir.load %r : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %rt = fir.box_addr %rl {test.ptr = "rptr_tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+// -----
+
+fir.global @_QMmEg_outer : !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}> {
+  %0 = fir.undefined !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>
+  fir.has_value %0 : !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>
+}
+
+// CHECK-LABEL: Testing : "_QMmPtest_global_outer"
+// CHECK-DAG: g_outer#0 <-> loc_outer#0: NoAlias
+// CHECK-DAG: g_in_p#0 <-> loc_in_p#0: NoAlias
+// CHECK-DAG: g_p_tgt#0 <-> loc_in_p#0: NoAlias
+// CHECK-LABEL: Testing : "_QMmPtest_global_outer_fir"
+// CHECK-DAG: g_outer.fir#0 <-> loc_outer.fir#0: NoAlias
+// CHECK-DAG: g_in_p.fir#0 <-> loc_in_p.fir#0: NoAlias
+// CHECK-DAG: g_p_tgt.fir#0 <-> loc_in_p.fir#0: NoAlias
+
+func.func @_QMmPtest_global_outer() {
+  %0 = fir.address_of(@_QMmEg_outer) : !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %g:2 = hlfir.declare %0 {test.ptr = "g_outer", uniq_name = "_QMmEg_outer"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>, !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>)
+  %1 = fir.alloca !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}> {uniq_name = "_QMmFloc"}
+  %loc:2 = hlfir.declare %1 {test.ptr = "loc_outer", uniq_name = "_QMmFloc"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>, !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>)
+  %gin = hlfir.designate %g#0{"in"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %gp = hlfir.designate %gin{"p"} {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "g_in_p"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %gl = fir.load %gp : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %gt = fir.box_addr %gl {test.ptr = "g_p_tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  %lin = hlfir.designate %loc#0{"in"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %lp = hlfir.designate %lin{"p"} {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "loc_in_p"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %ll = fir.load %lp : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %lt = fir.box_addr %ll {test.ptr = "loc_p_tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+func.func @_QMmPtest_global_outer_fir() {
+  %0 = fir.address_of(@_QMmEg_outer) : !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %g = fir.declare %0 {test.ptr = "g_outer.fir", uniq_name = "_QMmEg_outer"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %1 = fir.alloca !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}> {uniq_name = "_QMmFloc"}
+  %loc = fir.declare %1 {test.ptr = "loc_outer.fir", uniq_name = "_QMmFloc"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %gin = fir.coordinate_of %g, in : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %gp = fir.coordinate_of %gin, p {test.ptr = "g_in_p.fir"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %gl = fir.load %gp : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %gt = fir.box_addr %gl {test.ptr = "g_p_tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  %lin = fir.coordinate_of %loc, in : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %lp = fir.coordinate_of %lin, p {test.ptr = "loc_in_p.fir"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %ll = fir.load %lp : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %lt = fir.box_addr %ll {test.ptr = "loc_p_tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+// -----
+
+fir.global @_QMmEg1pair : !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}> {
+  %0 = fir.undefined !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>
+  fir.has_value %0 : !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>
+}
+fir.global @_QMmEg2pair : !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}> {
+  %0 = fir.undefined !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>
+  fir.has_value %0 : !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>
+}
+
+// CHECK-LABEL: Testing : "_QMmPtest_two_globals_outer"
+// CHECK-DAG: g1_outer#0 <-> g2_outer#0: NoAlias
+// CHECK-DAG: g1_p_tgt#0 <-> g2_in_p#0: NoAlias
+// CHECK-DAG: g1_p_tgt#0 <-> g2_p_tgt#0: MayAlias
+// CHECK-LABEL: Testing : "_QMmPtest_two_globals_outer_fir"
+// CHECK-DAG: g1_outer.fir#0 <-> g2_outer.fir#0: NoAlias
+// CHECK-DAG: g1_p_tgt.fir#0 <-> g2_in_p.fir#0: NoAlias
+// CHECK-DAG: g1_p_tgt.fir#0 <-> g2_p_tgt.fir#0: MayAlias
+
+func.func @_QMmPtest_two_globals_outer() {
+  %0 = fir.address_of(@_QMmEg1pair) : !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %g1:2 = hlfir.declare %0 {test.ptr = "g1_outer", uniq_name = "_QMmEg1pair"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>, !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>)
+  %1 = fir.address_of(@_QMmEg2pair) : !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %g2:2 = hlfir.declare %1 {test.ptr = "g2_outer", uniq_name = "_QMmEg2pair"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>, !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>)
+  %g1in = hlfir.designate %g1#0{"in"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %g1p = hlfir.designate %g1in{"p"} {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "g1_in_p"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %g1l = fir.load %g1p : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %g1t = fir.box_addr %g1l {test.ptr = "g1_p_tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  %g2in = hlfir.designate %g2#0{"in"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %g2p = hlfir.designate %g2in{"p"} {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "g2_in_p"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %g2l = fir.load %g2p : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %g2t = fir.box_addr %g2l {test.ptr = "g2_p_tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+func.func @_QMmPtest_two_globals_outer_fir() {
+  %0 = fir.address_of(@_QMmEg1pair) : !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %g1 = fir.declare %0 {test.ptr = "g1_outer.fir", uniq_name = "_QMmEg1pair"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %1 = fir.address_of(@_QMmEg2pair) : !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %g2 = fir.declare %1 {test.ptr = "g2_outer.fir", uniq_name = "_QMmEg2pair"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %g1in = fir.coordinate_of %g1, in : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %g1p = fir.coordinate_of %g1in, p {test.ptr = "g1_in_p.fir"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %g1l = fir.load %g1p : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %g1t = fir.box_addr %g1l {test.ptr = "g1_p_tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  %g2in = fir.coordinate_of %g2, in : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %g2p = fir.coordinate_of %g2in, p {test.ptr = "g2_in_p.fir"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %g2l = fir.load %g2p : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %g2t = fir.box_addr %g2l {test.ptr = "g2_p_tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+// -----
+
+// Two globals of the same outer type: one ordinary, one TARGET. Exercises
+// disambiguation of static storage for composite objects vs pointer-component
+// slots; pointee access stays MayAlias across globals (pointer vs target).
+
+fir.global @_QMmEg_nt : !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}> {
+  %0 = fir.undefined !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>
+  fir.has_value %0 : !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>
+}
+fir.global @_QMmEg_tgt_m target : !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}> {
+  %0 = fir.undefined !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>
+  fir.has_value %0 : !fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>
+}
+
+// CHECK-LABEL: Testing : "_QMmPtest_global_target_vs_ptr"
+// CHECK-DAG: g_nt#0 <-> g_tg#0: NoAlias
+// CHECK-DAG: g_nt_in_p#0 <-> g_tg_in_p#0: NoAlias
+// CHECK-DAG: g_tg_in_p#0 <-> g_nt_p_tgt#0: NoAlias
+// CHECK-DAG: g_nt_p_tgt#0 <-> g_tg_p_tgt#0: MayAlias
+// CHECK-LABEL: Testing : "_QMmPtest_global_target_vs_ptr_fir"
+// CHECK-DAG: g_nt.fir#0 <-> g_tg.fir#0: NoAlias
+// CHECK-DAG: g_nt_in_p.fir#0 <-> g_tg_in_p.fir#0: NoAlias
+// CHECK-DAG: g_tg_in_p.fir#0 <-> g_nt_p_tgt.fir#0: NoAlias
+// CHECK-DAG: g_nt_p_tgt.fir#0 <-> g_tg_p_tgt.fir#0: MayAlias
+
+func.func @_QMmPtest_global_target_vs_ptr() {
+  %0 = fir.address_of(@_QMmEg_nt) : !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %nt:2 = hlfir.declare %0 {test.ptr = "g_nt", uniq_name = "_QMmEg_nt"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>, !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>)
+  %1 = fir.address_of(@_QMmEg_tgt_m) : !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %tg:2 = hlfir.declare %1 {fortran_attrs = #fir.var_attrs<target>, test.ptr = "g_tg", uniq_name = "_QMmEg_tgt_m"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>, !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>)
+  %ntin = hlfir.designate %nt#0{"in"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %ntp = hlfir.designate %ntin{"p"} {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "g_nt_in_p"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %tgin = hlfir.designate %tg#0{"in"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %tgp = hlfir.designate %tgin{"p"} {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "g_tg_in_p"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %ntl = fir.load %ntp : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %ntt = fir.box_addr %ntl {test.ptr = "g_nt_p_tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  %tgl = fir.load %tgp : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %tgt = fir.box_addr %tgl {test.ptr = "g_tg_p_tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+func.func @_QMmPtest_global_target_vs_ptr_fir() {
+  %0 = fir.address_of(@_QMmEg_nt) : !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %nt = fir.declare %0 {test.ptr = "g_nt.fir", uniq_name = "_QMmEg_nt"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %1 = fir.address_of(@_QMmEg_tgt_m) : !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %tg = fir.declare %1 {fortran_attrs = #fir.var_attrs<target>, test.ptr = "g_tg.fir", uniq_name = "_QMmEg_tgt_m"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %ntin = fir.coordinate_of %nt, in : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %ntp = fir.coordinate_of %ntin, p {test.ptr = "g_nt_in_p.fir"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %tgin = fir.coordinate_of %tg, in : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %tgp = fir.coordinate_of %tgin, p {test.ptr = "g_tg_in_p.fir"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %ntl = fir.load %ntp : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %ntt = fir.box_addr %ntl {test.ptr = "g_nt_p_tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  %tgl = fir.load %tgp : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %tgt = fir.box_addr %tgl {test.ptr = "g_tg_p_tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+// -----
+
+// Reproducer for pointer-deref vs TARGET aliasing.
+// A local POINTER may be associated with a TARGET dummy argument at runtime.
+// Accessing a component's descriptor slot or pointee data through the pointer
+// must MayAlias the same access through the TARGET variable.
+//
+// subroutine test_ptr_target_slot(tgt)
+//   type(outer), target :: tgt
+//   type(outer), pointer :: ptr
+//   ptr => tgt         ! legal per F18 8.5.7
+//   ! ptr%in%p (box) may alias tgt%in%p (box)
+//   ! ptr%in%p.tgt may alias tgt%in%p.tgt
+// end subroutine
+
+// CHECK-LABEL: Testing : "_QMmPtest_ptr_target_slot"
+// Descriptor slots accessed through pointer vs TARGET: must MayAlias.
+// CHECK-DAG: ptr_in_p#0 <-> tgt_in_p#0: MayAlias
+// Data through pointer vs TARGET: must MayAlias.
+// CHECK-DAG: ptr_in_p_tgt#0 <-> tgt_in_p_tgt#0: MayAlias
+// Data through pointer vs local without TARGET: NoAlias.
+// CHECK-DAG: slot_local#0 <-> ptr_in_p_tgt#0: NoAlias
+// CHECK-LABEL: Testing : "_QMmPtest_ptr_target_slot_fir"
+// CHECK-DAG: ptr_in_p.fir#0 <-> tgt_in_p.fir#0: MayAlias
+// CHECK-DAG: ptr_in_p_tgt.fir#0 <-> tgt_in_p_tgt.fir#0: MayAlias
+// CHECK-DAG: slot_local.fir#0 <-> ptr_in_p_tgt.fir#0: NoAlias
+
+func.func @_QMmPtest_ptr_target_slot(%arg0: !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>> {fir.bindc_name = "tgt", fir.target}) {
+  %0 = fir.alloca !fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>> {uniq_name = "_QMmFtest_ptr_target_slotEptr"}
+  %ptr:2 = hlfir.declare %0 {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "ptr_op", uniq_name = "_QMmFtest_ptr_target_slotEptr"} : (!fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>)
+  %tgt:2 = hlfir.declare %arg0 {fortran_attrs = #fir.var_attrs<target>, test.ptr = "tgt_op", uniq_name = "_QMmFtest_ptr_target_slotEtgt"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>, !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>)
+  %local = fir.alloca f32 {bindc_name = "v", uniq_name = "_QMmFtest_ptr_target_slotEv"}
+  %ldecl:2 = hlfir.declare %local {test.ptr = "slot_local", uniq_name = "_QMmFtest_ptr_target_slotEv"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
+
+  // Access through pointer: ptr%in%p (descriptor slot)
+  %lptr = fir.load %ptr#0 : !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %ptr_addr = fir.box_addr %lptr : (!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>) -> !fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %ptr_in = hlfir.designate %ptr_addr{"in"} : (!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %ptr_in_p = hlfir.designate %ptr_in{"p"} {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "ptr_in_p"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %ptr_in_p_load = fir.load %ptr_in_p : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %ptr_in_p_tgt = fir.box_addr %ptr_in_p_load {test.ptr = "ptr_in_p_tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+
+  // Access through target: tgt%in%p (descriptor slot)
+  %tgt_in = hlfir.designate %tgt#0{"in"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %tgt_in_p = hlfir.designate %tgt_in{"p"} {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "tgt_in_p"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %tgt_in_p_load = fir.load %tgt_in_p : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %tgt_in_p_tgt = fir.box_addr %tgt_in_p_load {test.ptr = "tgt_in_p_tgt"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}
+
+func.func @_QMmPtest_ptr_target_slot_fir(%arg0: !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>> {fir.bindc_name = "tgt", fir.target}) {
+  %0 = fir.alloca !fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>> {uniq_name = "_QMmFtest_ptr_target_slotEptr"}
+  %ptr = fir.declare %0 {fortran_attrs = #fir.var_attrs<pointer>, test.ptr = "ptr_op.fir", uniq_name = "_QMmFtest_ptr_target_slotEptr"} : (!fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %tgt = fir.declare %arg0 {fortran_attrs = #fir.var_attrs<target>, test.ptr = "tgt_op.fir", uniq_name = "_QMmFtest_ptr_target_slotEtgt"} : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %local = fir.alloca f32 {bindc_name = "v", uniq_name = "_QMmFtest_ptr_target_slotEv"}
+  %ldecl = fir.declare %local {test.ptr = "slot_local.fir", uniq_name = "_QMmFtest_ptr_target_slotEv"} : (!fir.ref<f32>) -> !fir.ref<f32>
+
+  // Access through pointer: ptr%in%p (descriptor slot)
+  %lptr = fir.load %ptr : !fir.ref<!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>>
+  %ptr_addr = fir.box_addr %lptr : (!fir.box<!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>>) -> !fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>
+  %ptr_in = fir.coordinate_of %ptr_addr, in : (!fir.ptr<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %ptr_in_p = fir.coordinate_of %ptr_in, p {test.ptr = "ptr_in_p.fir"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %ptr_in_p_load = fir.load %ptr_in_p : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %ptr_in_p_tgt = fir.box_addr %ptr_in_p_load {test.ptr = "ptr_in_p_tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+
+  // Access through target: tgt%in%p (descriptor slot)
+  %tgt_in = fir.coordinate_of %tgt, in : (!fir.ref<!fir.type<_QMmTouter{in:!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>
+  %tgt_in_p = fir.coordinate_of %tgt_in, p {test.ptr = "tgt_in_p.fir"} : (!fir.ref<!fir.type<_QMmTinner{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %tgt_in_p_load = fir.load %tgt_in_p : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  %tgt_in_p_tgt = fir.box_addr %tgt_in_p_load {test.ptr = "tgt_in_p_tgt.fir"} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  return
+}

--- a/flang/test/Analysis/AliasAnalysis/load-ptr-designate.fir
+++ b/flang/test/Analysis/AliasAnalysis/load-ptr-designate.fir
@@ -51,26 +51,23 @@
 // CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%p1.fir#0: NoAlias
 // CHECK-DAG: obj%p1.fir#0 <-> obj%p1.tgt.fir#0: NoAlias
 
-// For some cases, AliasAnalysis analyzes hlfir.designate like fir.box_addr, so
-// make sure it doesn't mistakenly see the address of obj%arr(1) as an address
-// that was loaded from a pointer and that could alias something.  However,
-// t_obj%arr is a target.
-// TODO: Thus, we expect the first case (and corresponding .fir case) below to
-// be NoAlias.  However, the addresses obj%p0.tgt and obj%arr(1) are analyzed as
-// MayAlias because they have the same source and both are data.
-// CHECK-DAG: obj%p0.tgt#0 <-> obj%arr(1)#0: MayAlias
+// The address in a pointer component cannot alias the address of a sibling
+// data component when the root variable does not have TARGET, because only
+// TARGET subobjects are valid pointer association targets (Fortran 2018
+// 8.5.7).  However, t_obj has TARGET, so its components may alias the
+// pointer's target.
+// CHECK-DAG: obj%p0.tgt#0 <-> obj%arr(1)#0: NoAlias
 // CHECK-DAG: obj%p0.tgt#0 <-> t_obj%arr(1)#0: MayAlias
-// CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%arr(1).fir#0: MayAlias
+// CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%arr(1).fir#0: NoAlias
 // CHECK-DAG: obj%p0.tgt.fir#0 <-> t_obj%arr(1).fir#0: MayAlias
 
 // Like a pointer, an allocatable contains an address, but an allocatable is not
-// a pointer and so cannot alias pointers.  However, t_obj%alloc is a target.
-// TODO: Thus, we expect the first case (and corresponding .fir case) below to
-// be NoAlias.  However, the addresses obj%p0.tgt and obj%alloc.tgt are analyzed
-// as MayAlias because they have the same source and both are data.
-// CHECK-DAG: obj%p0.tgt#0 <-> obj%alloc.tgt#0: MayAlias
+// a pointer and so cannot alias pointers.  obj does not have TARGET, so its
+// allocatable's data and pointer's target are disjoint.  However, t_obj has
+// TARGET, so its allocatable data may alias the pointer target.
+// CHECK-DAG: obj%p0.tgt#0 <-> obj%alloc.tgt#0: NoAlias
 // CHECK-DAG: obj%p0.tgt#0 <-> t_obj%alloc.tgt#0: MayAlias
-// CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%alloc.tgt.fir#0: MayAlias
+// CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%alloc.tgt.fir#0: NoAlias
 // CHECK-DAG: obj%p0.tgt.fir#0 <-> t_obj%alloc.tgt.fir#0: MayAlias
 
 // The address in an allocatable cannot alias the address of that allocatable.
@@ -213,26 +210,18 @@ func.func @_QPtest.fir() {
 // CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%p1.fir#0: NoAlias
 // CHECK-DAG: obj%p1.fir#0 <-> obj%p1.tgt.fir#0: NoAlias
 
-// For some cases, AliasAnalysis analyzes hlfir.designate like fir.box_addr, so
-// make sure it doesn't mistakenly see the address of obj%arr(1) as an address
-// that was loaded from a pointer and that could alias something.  However,
-// t_obj%arr is a target.
-// TODO: Thus, we expect the first case (and corresponding .fir case) below to
-// be NoAlias.  However, the addresses obj%p0.tgt and obj%arr(1) are analyzed as
-// MayAlias because they have the same source and both are data.
-// CHECK-DAG: obj%p0.tgt#0 <-> obj%arr(1)#0: MayAlias
+// The address in a pointer component cannot alias the address of a sibling
+// data component when the root variable does not have TARGET.
+// CHECK-DAG: obj%p0.tgt#0 <-> obj%arr(1)#0: NoAlias
 // CHECK-DAG: obj%p0.tgt#0 <-> t_obj%arr(1)#0: MayAlias
-// CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%arr(1).fir#0: MayAlias
+// CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%arr(1).fir#0: NoAlias
 // CHECK-DAG: obj%p0.tgt.fir#0 <-> t_obj%arr(1).fir#0: MayAlias
 
 // Like a pointer, an allocatable contains an address, but an allocatable is not
-// a pointer and so cannot alias pointers.  However, t_obj%alloc is a target.
-// TODO: Thus, we expect the first case (and corresponding .fir case) below to
-// be NoAlias.  However, the addresses obj%p0.tgt and obj%alloc.tgt are analyzed
-// as MayAlias because they have the same source and both are data.
-// CHECK-DAG: obj%p0.tgt#0 <-> obj%alloc.tgt#0: MayAlias
+// a pointer and so cannot alias pointers.  obj does not have TARGET.
+// CHECK-DAG: obj%p0.tgt#0 <-> obj%alloc.tgt#0: NoAlias
 // CHECK-DAG: obj%p0.tgt#0 <-> t_obj%alloc.tgt#0: MayAlias
-// CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%alloc.tgt.fir#0: MayAlias
+// CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%alloc.tgt.fir#0: NoAlias
 // CHECK-DAG: obj%p0.tgt.fir#0 <-> t_obj%alloc.tgt.fir#0: MayAlias
 
 // The address in an allocatable cannot alias the address of that allocatable.
@@ -373,26 +362,18 @@ func.func @_QPtest.fir(%arg0: !fir.ref<!fir.type<_QMmTty{p0:!fir.box<!fir.ptr<f3
 // CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%p1.fir#0: NoAlias
 // CHECK-DAG: obj%p1.fir#0 <-> obj%p1.tgt.fir#0: NoAlias
 
-// For some cases, AliasAnalysis analyzes hlfir.designate like fir.box_addr, so
-// make sure it doesn't mistakenly see the address of obj%arr(1) as an address
-// that was loaded from a pointer and that could alias something.  However,
-// t_obj%arr is a target.
-// TODO: Thus, we expect the first case (and corresponding .fir case) below to
-// be NoAlias.  However, the addresses obj%p0.tgt and obj%arr(1) are analyzed as
-// MayAlias because they have the same source and both are data.
-// CHECK-DAG: obj%p0.tgt#0 <-> obj%arr(1)#0: MayAlias
+// The address in a pointer component cannot alias the address of a sibling
+// data component when the root variable does not have TARGET.
+// CHECK-DAG: obj%p0.tgt#0 <-> obj%arr(1)#0: NoAlias
 // CHECK-DAG: obj%p0.tgt#0 <-> t_obj%arr(1)#0: MayAlias
-// CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%arr(1).fir#0: MayAlias
+// CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%arr(1).fir#0: NoAlias
 // CHECK-DAG: obj%p0.tgt.fir#0 <-> t_obj%arr(1).fir#0: MayAlias
 
 // Like a pointer, an allocatable contains an address, but an allocatable is not
-// a pointer and so cannot alias pointers.  However, t_obj%alloc is a target.
-// TODO: Thus, we expect the first case (and corresponding .fir case) below to
-// be NoAlias.  However, the addresses obj%p0.tgt and obj%alloc.tgt are analyzed
-// as MayAlias because they have the same source and both are data.
-// CHECK-DAG: obj%p0.tgt#0 <-> obj%alloc.tgt#0: MayAlias
+// a pointer and so cannot alias pointers.  obj does not have TARGET.
+// CHECK-DAG: obj%p0.tgt#0 <-> obj%alloc.tgt#0: NoAlias
 // CHECK-DAG: obj%p0.tgt#0 <-> t_obj%alloc.tgt#0: MayAlias
-// CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%alloc.tgt.fir#0: MayAlias
+// CHECK-DAG: obj%p0.tgt.fir#0 <-> obj%alloc.tgt.fir#0: NoAlias
 // CHECK-DAG: obj%p0.tgt.fir#0 <-> t_obj%alloc.tgt.fir#0: MayAlias
 
 // The address in an allocatable cannot alias the address of that allocatable.
@@ -419,6 +400,9 @@ func.func @_QPtest.fir(%arg0: !fir.ref<!fir.type<_QMmTty{p0:!fir.box<!fir.ptr<f3
 // allocatable can alias.
 // CHECK-DAG: obj%alloc.tgt#0 <-> obj%alloc.tgt2#0: MayAlias
 // CHECK-DAG: obj%alloc.tgt.fir#0 <-> obj%alloc.tgt2.fir#0: MayAlias
+
+fir.global @_QMmEobj : !fir.type<_QMmTty{p0:!fir.box<!fir.ptr<f32>>,p1:!fir.box<!fir.ptr<f32>>,arr:!fir.array<2xf32>,alloc:!fir.box<!fir.heap<f32>>}>
+fir.global @_QMmEt_obj target : !fir.type<_QMmTty{p0:!fir.box<!fir.ptr<f32>>,p1:!fir.box<!fir.ptr<f32>>,arr:!fir.array<2xf32>,alloc:!fir.box<!fir.heap<f32>>}>
 
 func.func @_QPtest() {
   %0 = fir.address_of(@_QMmEobj) : !fir.ref<!fir.type<_QMmTty{p0:!fir.box<!fir.ptr<f32>>,p1:!fir.box<!fir.ptr<f32>>,arr:!fir.array<2xf32>,alloc:!fir.box<!fir.heap<f32>>}>>

--- a/flang/test/Analysis/AliasAnalysis/ptr-component.fir
+++ b/flang/test/Analysis/AliasAnalysis/ptr-component.fir
@@ -262,21 +262,12 @@ func.func @_QMmPtest.fir() {
 // CHECK-DAG: x%x.fir#0 <-> x%x%p.fir#0: MayAlias
 
 // The addresses of different components of the same composite do not alias.
-//
-// TODO: Thus, all results below should be NoAlias.  However, AliasAnalysis
-// normally does not recognize when two values (x%x vs. x%i) are distinct
-// components of the same composite (x) as opposed to being potentially
-// overlapping parts of something, so it returns MayAlias.  There is special
-// handling for a pointer component (x%p) that does recognize it as separate
-// from other components (x%i).  But it does not yet distinguish the composite
-// (x) from a component (x%x) that is also a composite with a pointer component
-// (x%x%p).  Thus, because x and x%p can alias, it assumes x%x and x%p can too.
-// CHECK-DAG: x%x#0 <-> x%i#0: MayAlias
+// CHECK-DAG: x%x#0 <-> x%i#0: NoAlias
 // CHECK-DAG: x%p#0 <-> x%i#0: NoAlias
-// CHECK-DAG: x%x#0 <-> x%p#0: MayAlias
-// CHECK-DAG: x%x.fir#0 <-> x%i.fir#0: MayAlias
+// CHECK-DAG: x%x#0 <-> x%p#0: NoAlias
+// CHECK-DAG: x%x.fir#0 <-> x%i.fir#0: NoAlias
 // CHECK-DAG: x%p.fir#0 <-> x%i.fir#0: NoAlias
-// CHECK-DAG: x%x.fir#0 <-> x%p.fir#0: MayAlias
+// CHECK-DAG: x%x.fir#0 <-> x%p.fir#0: NoAlias
 
 func.func @_QMmPtest() {
   %0 = fir.alloca !fir.type<_QMmTt2{x:!fir.type<_QMmTt1{p:!fir.box<!fir.ptr<i32>>}>,p:!fir.box<!fir.ptr<i32>>,i:i32}> {bindc_name = "x", uniq_name = "_QMmFtestEx"}

--- a/flang/test/Transforms/tbaa-derived-type-records.fir
+++ b/flang/test/Transforms/tbaa-derived-type-records.fir
@@ -1,0 +1,154 @@
+// TBAA tags for derived-type *descriptor* components (fir.box in records) after
+// multi-level fir.coordinate_of chains; pointer pointees use the "target data"
+// subtree. Nested allocatable components still attach TBAA to the heap payload
+// access under the enclosing allocation/
+//
+// RUN: fir-opt --split-input-file --fir-add-alias-tags %s | FileCheck %s
+
+// type(outer) with type(inner) and real, pointer :: p — local composite,
+// two record levels before the pointer component box.
+
+// CHECK: #[[R0:.+]] = #llvm.tbaa_root<id = "Flang function root _QPtest_ptr_component">
+// CHECK: #[[ANY0:.+]] = #llvm.tbaa_type_desc<id = "any access", members = {<#[[R0]], 0>}>
+// CHECK: #[[ANYDATA0:.+]] = #llvm.tbaa_type_desc<id = "any data access", members = {<#[[ANY0]], 0>}>
+// CHECK: #[[TGT0:.+]] = #llvm.tbaa_type_desc<id = "target data", members = {<#[[ANYDATA0]], 0>}>
+// CHECK: #[[PTRTAG0:.+]] = #llvm.tbaa_tag<base_type = #[[TGT0]], access_type = #[[TGT0]], offset = 0>
+// CHECK-LABEL: func.func @_QPtest_ptr_component
+// CHECK: fir.load %{{[0-9]+}} : !fir.ref<!fir.box<!fir.ptr<f32>>>
+// CHECK: fir.load %{{[0-9]+}} {tbaa = [#[[PTRTAG0]]]} : !fir.ptr<f32>
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, i64 = dense<[32, 64]> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little">, llvm.data_layout = ""} {
+  func.func @_QPtest_ptr_component() {
+    %0 = fir.alloca !fir.type<_QMtbaaTouterP{in:!fir.type<_QMtbaaTinnerP{p:!fir.box<!fir.ptr<f32>>}>}> {uniq_name = "_QMtbaaFtest_ptr_componentEz", bindc_name = "z"}
+    %z = fir.declare %0 {uniq_name = "_QMtbaaFtest_ptr_componentEz"} : (!fir.ref<!fir.type<_QMtbaaTouterP{in:!fir.type<_QMtbaaTinnerP{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTouterP{in:!fir.type<_QMtbaaTinnerP{p:!fir.box<!fir.ptr<f32>>}>}>>
+    %in = fir.coordinate_of %z, in : (!fir.ref<!fir.type<_QMtbaaTouterP{in:!fir.type<_QMtbaaTinnerP{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTinnerP{p:!fir.box<!fir.ptr<f32>>}>>
+    %pref = fir.coordinate_of %in, p : (!fir.ref<!fir.type<_QMtbaaTinnerP{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %bl = fir.load %pref : !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %pt = fir.box_addr %bl : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+    %v = fir.load %pt : !fir.ptr<f32>
+    return
+  }
+}
+
+// -----
+
+// Three record nesting levels (a, b) before pointer component p.
+
+// CHECK: #[[R1:.+]] = #llvm.tbaa_root<id = "Flang function root _QPtest_deep_ptr_component">
+// CHECK: #[[ANY1:.+]] = #llvm.tbaa_type_desc<id = "any access", members = {<#[[R1]], 0>}>
+// CHECK: #[[ANYDATA1:.+]] = #llvm.tbaa_type_desc<id = "any data access", members = {<#[[ANY1]], 0>}>
+// CHECK: #[[TGT1:.+]] = #llvm.tbaa_type_desc<id = "target data", members = {<#[[ANYDATA1]], 0>}>
+// CHECK: #[[PTRTAG1:.+]] = #llvm.tbaa_tag<base_type = #[[TGT1]], access_type = #[[TGT1]], offset = 0>
+// CHECK-LABEL: func.func @_QPtest_deep_ptr_component
+// CHECK: fir.load %{{[0-9]+}} : !fir.ref<!fir.box<!fir.ptr<f32>>>
+// CHECK: fir.load %{{[0-9]+}} {tbaa = [#[[PTRTAG1]]]} : !fir.ptr<f32>
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, i64 = dense<[32, 64]> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little">, llvm.data_layout = ""} {
+  func.func @_QPtest_deep_ptr_component() {
+    %0 = fir.alloca !fir.type<_QMtbaaTl0{a:!fir.type<_QMtbaaTl1{b:!fir.type<_QMtbaaTl2{p:!fir.box<!fir.ptr<f32>>}>}>}> {uniq_name = "_QMtbaaFtest_deep_ptr_componentEz"}
+    %z = fir.declare %0 {uniq_name = "_QMtbaaFtest_deep_ptr_componentEz"} : (!fir.ref<!fir.type<_QMtbaaTl0{a:!fir.type<_QMtbaaTl1{b:!fir.type<_QMtbaaTl2{p:!fir.box<!fir.ptr<f32>>}>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTl0{a:!fir.type<_QMtbaaTl1{b:!fir.type<_QMtbaaTl2{p:!fir.box<!fir.ptr<f32>>}>}>}>>
+    %l1 = fir.coordinate_of %z, a : (!fir.ref<!fir.type<_QMtbaaTl0{a:!fir.type<_QMtbaaTl1{b:!fir.type<_QMtbaaTl2{p:!fir.box<!fir.ptr<f32>>}>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTl1{b:!fir.type<_QMtbaaTl2{p:!fir.box<!fir.ptr<f32>>}>}>>
+    %l2 = fir.coordinate_of %l1, b : (!fir.ref<!fir.type<_QMtbaaTl1{b:!fir.type<_QMtbaaTl2{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTl2{p:!fir.box<!fir.ptr<f32>>}>>
+    %pref = fir.coordinate_of %l2, p : (!fir.ref<!fir.type<_QMtbaaTl2{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %bl = fir.load %pref : !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %pt = fir.box_addr %bl : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+    %v = fir.load %pt : !fir.ptr<f32>
+    return
+  }
+}
+
+// -----
+
+// Global composite: two coordinate_of steps (a, then p) to the pointer box.
+
+// CHECK: #[[R2:.+]] = #llvm.tbaa_root<id = "Flang function root _QPtest_glob_nested_ptr">
+// CHECK: #[[ANY2:.+]] = #llvm.tbaa_type_desc<id = "any access", members = {<#[[R2]], 0>}>
+// CHECK: #[[ANYDATA2:.+]] = #llvm.tbaa_type_desc<id = "any data access", members = {<#[[ANY2]], 0>}>
+// CHECK: #[[TGT2:.+]] = #llvm.tbaa_type_desc<id = "target data", members = {<#[[ANYDATA2]], 0>}>
+// CHECK: #[[PTRTAG2:.+]] = #llvm.tbaa_tag<base_type = #[[TGT2]], access_type = #[[TGT2]], offset = 0>
+// CHECK-LABEL: func.func @_QPtest_glob_nested_ptr
+// CHECK: fir.load %{{[0-9]+}} : !fir.ref<!fir.box<!fir.ptr<f32>>>
+// CHECK: fir.load %{{[0-9]+}} {tbaa = [#[[PTRTAG2]]]} : !fir.ptr<f32>
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, i64 = dense<[32, 64]> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little">, llvm.data_layout = ""} {
+  fir.global @_QMtbaaEgdeep : !fir.type<_QMtbaaTg0{a:!fir.type<_QMtbaaTg1{p:!fir.box<!fir.ptr<f32>>}>}> {
+    %0 = fir.undefined !fir.type<_QMtbaaTg0{a:!fir.type<_QMtbaaTg1{p:!fir.box<!fir.ptr<f32>>}>}>
+    fir.has_value %0 : !fir.type<_QMtbaaTg0{a:!fir.type<_QMtbaaTg1{p:!fir.box<!fir.ptr<f32>>}>}>
+  }
+  func.func @_QPtest_glob_nested_ptr() {
+    %0 = fir.address_of(@_QMtbaaEgdeep) : !fir.ref<!fir.type<_QMtbaaTg0{a:!fir.type<_QMtbaaTg1{p:!fir.box<!fir.ptr<f32>>}>}>>
+    %g = fir.declare %0 {uniq_name = "_QMtbaaEgdeep"} : (!fir.ref<!fir.type<_QMtbaaTg0{a:!fir.type<_QMtbaaTg1{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTg0{a:!fir.type<_QMtbaaTg1{p:!fir.box<!fir.ptr<f32>>}>}>>
+    %in = fir.coordinate_of %g, a : (!fir.ref<!fir.type<_QMtbaaTg0{a:!fir.type<_QMtbaaTg1{p:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTg1{p:!fir.box<!fir.ptr<f32>>}>>
+    %pref = fir.coordinate_of %in, p : (!fir.ref<!fir.type<_QMtbaaTg1{p:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %bl = fir.load %pref : !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %pt = fir.box_addr %bl : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+    %v = fir.load %pt : !fir.ptr<f32>
+    return
+  }
+}
+
+// -----
+
+// Two separate local objects, each with nested p%q pointer boxes (two box
+// loads without TBAA; pointer load/store use target data).
+
+// CHECK: #[[R3:.+]] = #llvm.tbaa_root<id = "Flang function root _QPtest_two_nested_ptr_paths">
+// CHECK: #[[ANY3:.+]] = #llvm.tbaa_type_desc<id = "any access", members = {<#[[R3]], 0>}>
+// CHECK: #[[ANYDATA3:.+]] = #llvm.tbaa_type_desc<id = "any data access", members = {<#[[ANY3]], 0>}>
+// CHECK: #[[TGT3:.+]] = #llvm.tbaa_type_desc<id = "target data", members = {<#[[ANYDATA3]], 0>}>
+// CHECK: #[[PTRTAG3:.+]] = #llvm.tbaa_tag<base_type = #[[TGT3]], access_type = #[[TGT3]], offset = 0>
+// CHECK-LABEL: func.func @_QPtest_two_nested_ptr_paths
+// CHECK: fir.load %{{[0-9]+}} : !fir.ref<!fir.box<!fir.ptr<f32>>>
+// CHECK: fir.load %{{[0-9]+}} : !fir.ref<!fir.box<!fir.ptr<f32>>>
+// CHECK: fir.load %{{[0-9]+}} {tbaa = [#[[PTRTAG3]]]} : !fir.ptr<f32>
+// CHECK: fir.store %{{[0-9]+}} to %{{[0-9]+}} {tbaa = [#[[PTRTAG3]]]} : !fir.ptr<f32>
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, i64 = dense<[32, 64]> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little">, llvm.data_layout = ""} {
+  func.func @_QPtest_two_nested_ptr_paths() {
+    %0 = fir.alloca !fir.type<_QMtbaaTx0{p:!fir.type<_QMtbaaTx1{q:!fir.box<!fir.ptr<f32>>}>}> {uniq_name = "_QMtbaaFtest_two_nested_ptr_pathsEx"}
+    %1 = fir.alloca !fir.type<_QMtbaaTy0{p:!fir.type<_QMtbaaTy1{q:!fir.box<!fir.ptr<f32>>}>}> {uniq_name = "_QMtbaaFtest_two_nested_ptr_pathsEy"}
+    %x = fir.declare %0 {uniq_name = "_QMtbaaFtest_two_nested_ptr_pathsEx"} : (!fir.ref<!fir.type<_QMtbaaTx0{p:!fir.type<_QMtbaaTx1{q:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTx0{p:!fir.type<_QMtbaaTx1{q:!fir.box<!fir.ptr<f32>>}>}>>
+    %y = fir.declare %1 {uniq_name = "_QMtbaaFtest_two_nested_ptr_pathsEy"} : (!fir.ref<!fir.type<_QMtbaaTy0{p:!fir.type<_QMtbaaTy1{q:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTy0{p:!fir.type<_QMtbaaTy1{q:!fir.box<!fir.ptr<f32>>}>}>>
+    %x1 = fir.coordinate_of %x, p : (!fir.ref<!fir.type<_QMtbaaTx0{p:!fir.type<_QMtbaaTx1{q:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTx1{q:!fir.box<!fir.ptr<f32>>}>>
+    %xq = fir.coordinate_of %x1, q : (!fir.ref<!fir.type<_QMtbaaTx1{q:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %y1 = fir.coordinate_of %y, p : (!fir.ref<!fir.type<_QMtbaaTy0{p:!fir.type<_QMtbaaTy1{q:!fir.box<!fir.ptr<f32>>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTy1{q:!fir.box<!fir.ptr<f32>>}>>
+    %yq = fir.coordinate_of %y1, q : (!fir.ref<!fir.type<_QMtbaaTy1{q:!fir.box<!fir.ptr<f32>>}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %bx = fir.load %xq : !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %by = fir.load %yq : !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %px = fir.box_addr %bx : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+    %py = fir.box_addr %by : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+    %vx = fir.load %px : !fir.ptr<f32>
+    fir.store %vx to %py : !fir.ptr<f32>
+    return
+  }
+}
+
+// -----
+
+// real, allocatable :: f after three record nesting levels (v%w%mid%f) — box
+// load is untagged; heap payload is tagged under the enclosing allocation.
+
+// CHECK: #[[R4:.+]] = #llvm.tbaa_root<id = "Flang function root _QPtest_nested_alloc_descriptor">
+// CHECK: #[[ANY4:.+]] = #llvm.tbaa_type_desc<id = "any access", members = {<#[[R4]], 0>}>
+// CHECK: #[[ANYDATA4:.+]] = #llvm.tbaa_type_desc<id = "any data access", members = {<#[[ANY4]], 0>}>
+// CHECK: #[[ALLOC4:.+]] = #llvm.tbaa_type_desc<id = "allocated data", members = {<#[[ANYDATA4]], 0>}>
+// CHECK: #[[UNODE:.+]] = #llvm.tbaa_type_desc<id = "allocated data/_QMtbaaFtest_nested_alloc_descriptorEv", members = {<#[[ALLOC4]], 0>}>
+// CHECK: #[[HEAPTAG:.+]] = #llvm.tbaa_tag<base_type = #[[UNODE]], access_type = #[[UNODE]], offset = 0>
+// CHECK-LABEL: func.func @_QPtest_nested_alloc_descriptor
+// CHECK: fir.load %{{[0-9]+}} : !fir.ref<!fir.box<!fir.heap<f32>>>
+// CHECK: fir.load %{{[0-9]+}} {tbaa = [#[[HEAPTAG]]]} : !fir.ref<f32>
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, i64 = dense<[32, 64]> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little">, llvm.data_layout = ""} {
+  func.func @_QPtest_nested_alloc_descriptor() {
+    %0 = fir.alloca !fir.type<_QMtbaaTd0{w:!fir.type<_QMtbaaTd1{mid:!fir.type<_QMtbaaTd2{f:!fir.box<!fir.heap<f32>>}>}>}> {uniq_name = "_QMtbaaFtest_nested_alloc_descriptorEv"}
+    %v = fir.declare %0 {uniq_name = "_QMtbaaFtest_nested_alloc_descriptorEv"} : (!fir.ref<!fir.type<_QMtbaaTd0{w:!fir.type<_QMtbaaTd1{mid:!fir.type<_QMtbaaTd2{f:!fir.box<!fir.heap<f32>>}>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTd0{w:!fir.type<_QMtbaaTd1{mid:!fir.type<_QMtbaaTd2{f:!fir.box<!fir.heap<f32>>}>}>}>>
+    %w = fir.coordinate_of %v, w : (!fir.ref<!fir.type<_QMtbaaTd0{w:!fir.type<_QMtbaaTd1{mid:!fir.type<_QMtbaaTd2{f:!fir.box<!fir.heap<f32>>}>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTd1{mid:!fir.type<_QMtbaaTd2{f:!fir.box<!fir.heap<f32>>}>}>>
+    %mid = fir.coordinate_of %w, mid : (!fir.ref<!fir.type<_QMtbaaTd1{mid:!fir.type<_QMtbaaTd2{f:!fir.box<!fir.heap<f32>>}>}>>) -> !fir.ref<!fir.type<_QMtbaaTd2{f:!fir.box<!fir.heap<f32>>}>>
+    %fref = fir.coordinate_of %mid, f : (!fir.ref<!fir.type<_QMtbaaTd2{f:!fir.box<!fir.heap<f32>>}>>) -> !fir.ref<!fir.box<!fir.heap<f32>>>
+    %bl = fir.load %fref : !fir.ref<!fir.box<!fir.heap<f32>>>
+    %hp = fir.box_addr %bl : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+    %r = fir.convert %hp : (!fir.heap<f32>) -> !fir.ref<f32>
+    %x = fir.load %r : !fir.ref<f32>
+    return
+  }
+}

--- a/flang/test/Transforms/tbaa-derived-type-records.fir
+++ b/flang/test/Transforms/tbaa-derived-type-records.fir
@@ -152,3 +152,91 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr = dense<64> : vector<4
     return
   }
 }
+
+// -----
+
+// Dummy argument of derived type with pointer, allocatable, and scalar
+// components.  The pointer target goes into the "target data" subtree;
+// the allocatable payload and the scalar component are tagged under the
+// per-argument "dummy arg data" subtree.
+
+// CHECK: #[[R5:.+]] = #llvm.tbaa_root<id = "Flang function root _QPtest_dummy_ptr_alloc">
+// CHECK: #[[ANY5:.+]] = #llvm.tbaa_type_desc<id = "any access", members = {<#[[R5]], 0>}>
+// CHECK: #[[ANYDATA5:.+]] = #llvm.tbaa_type_desc<id = "any data access", members = {<#[[ANY5]], 0>}>
+// CHECK: #[[TGT5:.+]] = #llvm.tbaa_type_desc<id = "target data", members = {<#[[ANYDATA5]], 0>}>
+// CHECK: #[[DUMMYARG5:.+]] = #llvm.tbaa_type_desc<id = "dummy arg data", members = {<#[[ANYDATA5]], 0>}>
+// CHECK: #[[PTRTAG5:.+]] = #llvm.tbaa_tag<base_type = #[[TGT5]], access_type = #[[TGT5]], offset = 0>
+// CHECK: #[[ARGNODE5:.+]] = #llvm.tbaa_type_desc<id = "dummy arg data/{{.*}}Eobj", members = {<#[[DUMMYARG5]], 0>}>
+// CHECK: #[[ARGTAG5:.+]] = #llvm.tbaa_tag<base_type = #[[ARGNODE5]], access_type = #[[ARGNODE5]], offset = 0>
+// CHECK-LABEL: func.func @_QPtest_dummy_ptr_alloc
+// pointer target: "target data"
+// CHECK: fir.load %{{[0-9]+}} : !fir.ref<!fir.box<!fir.ptr<f32>>>
+// CHECK: fir.load %{{[0-9]+}} {tbaa = [#[[PTRTAG5]]]} : !fir.ptr<f32>
+// allocatable payload: per-argument tag
+// CHECK: fir.load %{{[0-9]+}} : !fir.ref<!fir.box<!fir.heap<f32>>>
+// CHECK: fir.load %{{[0-9]+}} {tbaa = [#[[ARGTAG5]]]} : !fir.ref<f32>
+// scalar component: same per-argument tag
+// CHECK: fir.load %{{[0-9]+}} {tbaa = [#[[ARGTAG5]]]} : !fir.ref<f32>
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, i64 = dense<[32, 64]> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little">, llvm.data_layout = ""} {
+  func.func @_QPtest_dummy_ptr_alloc(%arg0: !fir.ref<!fir.type<_QMtbaaTmix{p:!fir.box<!fir.ptr<f32>>,a:!fir.box<!fir.heap<f32>>,i:f32}>> {fir.bindc_name = "obj"}) {
+    %scope = fir.dummy_scope : !fir.dscope
+    %obj = fir.declare %arg0 dummy_scope %scope {uniq_name = "_QFtest_dummy_ptr_allocEobj"} : (!fir.ref<!fir.type<_QMtbaaTmix{p:!fir.box<!fir.ptr<f32>>,a:!fir.box<!fir.heap<f32>>,i:f32}>>, !fir.dscope) -> !fir.ref<!fir.type<_QMtbaaTmix{p:!fir.box<!fir.ptr<f32>>,a:!fir.box<!fir.heap<f32>>,i:f32}>>
+    %pref = fir.coordinate_of %obj, p : (!fir.ref<!fir.type<_QMtbaaTmix{p:!fir.box<!fir.ptr<f32>>,a:!fir.box<!fir.heap<f32>>,i:f32}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %pbox = fir.load %pref : !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %paddr = fir.box_addr %pbox : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+    %pval = fir.load %paddr : !fir.ptr<f32>
+    %aref = fir.coordinate_of %obj, a : (!fir.ref<!fir.type<_QMtbaaTmix{p:!fir.box<!fir.ptr<f32>>,a:!fir.box<!fir.heap<f32>>,i:f32}>>) -> !fir.ref<!fir.box<!fir.heap<f32>>>
+    %abox = fir.load %aref : !fir.ref<!fir.box<!fir.heap<f32>>>
+    %aheap = fir.box_addr %abox : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+    %adataref = fir.convert %aheap : (!fir.heap<f32>) -> !fir.ref<f32>
+    %aval = fir.load %adataref : !fir.ref<f32>
+    %iref = fir.coordinate_of %obj, i : (!fir.ref<!fir.type<_QMtbaaTmix{p:!fir.box<!fir.ptr<f32>>,a:!fir.box<!fir.heap<f32>>,i:f32}>>) -> !fir.ref<f32>
+    %ival = fir.load %iref : !fir.ref<f32>
+    return
+  }
+}
+
+// -----
+
+// TARGET local composite with pointer, allocatable, and scalar components.
+// The pointer target gets the generic "target data" tag (pointer targets can
+// alias any other pointer or target).  The allocatable payload and the scalar
+// component get a named tag under the "target data" subtree, since they are
+// part of a TARGET variable but are not themselves pointers.
+
+// CHECK: #[[R6:.+]] = #llvm.tbaa_root<id = "Flang function root _QPtest_target_local">
+// CHECK: #[[ANY6:.+]] = #llvm.tbaa_type_desc<id = "any access", members = {<#[[R6]], 0>}>
+// CHECK: #[[ANYDATA6:.+]] = #llvm.tbaa_type_desc<id = "any data access", members = {<#[[ANY6]], 0>}>
+// CHECK: #[[TGT6:.+]] = #llvm.tbaa_type_desc<id = "target data", members = {<#[[ANYDATA6]], 0>}>
+// CHECK: #[[PTRTAG6:.+]] = #llvm.tbaa_tag<base_type = #[[TGT6]], access_type = #[[TGT6]], offset = 0>
+// CHECK: #[[TGTNODE6:.+]] = #llvm.tbaa_type_desc<id = "target data/{{.*}}Eobj", members = {<#[[TGT6]], 0>}>
+// CHECK: #[[TGTTAG6:.+]] = #llvm.tbaa_tag<base_type = #[[TGTNODE6]], access_type = #[[TGTNODE6]], offset = 0>
+// CHECK-LABEL: func.func @_QPtest_target_local
+// pointer target: generic "target data"
+// CHECK: fir.load %{{[0-9]+}} : !fir.ref<!fir.box<!fir.ptr<f32>>>
+// CHECK: fir.load %{{[0-9]+}} {tbaa = [#[[PTRTAG6]]]} : !fir.ptr<f32>
+// allocatable payload: named "target data/<obj>" tag
+// CHECK: fir.load %{{[0-9]+}} : !fir.ref<!fir.box<!fir.heap<f32>>>
+// CHECK: fir.load %{{[0-9]+}} {tbaa = [#[[TGTTAG6]]]} : !fir.ref<f32>
+// scalar component: same named target tag
+// CHECK: fir.load %{{[0-9]+}} {tbaa = [#[[TGTTAG6]]]} : !fir.ref<f32>
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, i64 = dense<[32, 64]> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little">, llvm.data_layout = ""} {
+  func.func @_QPtest_target_local() {
+    %0 = fir.alloca !fir.type<_QMtbaaTmix{p:!fir.box<!fir.ptr<f32>>,a:!fir.box<!fir.heap<f32>>,i:f32}> {bindc_name = "obj", fir.target, uniq_name = "_QFtest_target_localEobj"}
+    %obj = fir.declare %0 {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFtest_target_localEobj"} : (!fir.ref<!fir.type<_QMtbaaTmix{p:!fir.box<!fir.ptr<f32>>,a:!fir.box<!fir.heap<f32>>,i:f32}>>) -> !fir.ref<!fir.type<_QMtbaaTmix{p:!fir.box<!fir.ptr<f32>>,a:!fir.box<!fir.heap<f32>>,i:f32}>>
+    %pref = fir.coordinate_of %obj, p : (!fir.ref<!fir.type<_QMtbaaTmix{p:!fir.box<!fir.ptr<f32>>,a:!fir.box<!fir.heap<f32>>,i:f32}>>) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %pbox = fir.load %pref : !fir.ref<!fir.box<!fir.ptr<f32>>>
+    %paddr = fir.box_addr %pbox : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+    %pval = fir.load %paddr : !fir.ptr<f32>
+    %aref = fir.coordinate_of %obj, a : (!fir.ref<!fir.type<_QMtbaaTmix{p:!fir.box<!fir.ptr<f32>>,a:!fir.box<!fir.heap<f32>>,i:f32}>>) -> !fir.ref<!fir.box<!fir.heap<f32>>>
+    %abox = fir.load %aref : !fir.ref<!fir.box<!fir.heap<f32>>>
+    %aheap = fir.box_addr %abox : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+    %adataref = fir.convert %aheap : (!fir.heap<f32>) -> !fir.ref<f32>
+    %aval = fir.load %adataref : !fir.ref<f32>
+    %iref = fir.coordinate_of %obj, i : (!fir.ref<!fir.type<_QMtbaaTmix{p:!fir.box<!fir.ptr<f32>>,a:!fir.box<!fir.heap<f32>>,i:f32}>>) -> !fir.ref<f32>
+    %ival = fir.load %iref : !fir.ref<f32>
+    return
+  }
+}


### PR DESCRIPTION
This change introduces an AccessPath representation inside the AliasAnalysis
Source object that tracks the sequence of named component accesses
and pointer/allocatable dereferences from the root variable to the queried
memory location. The access path is built during the backward walk
in getSource and enables more precise alias analysis for Fortran derived types.

Previously, accesses to different components of the same derived-type
variable (such as x%a and x%b) were reported as MayAlias
because the analysis could not distinguish them once they traced back
to the same origin. With the access path, the analysis can now identify
when two accesses diverge at a named component step
and return NoAlias for disjoint subobjects.

This patch does not get rid of `followingData` and `isData` completely.

Assisted by Claude.