### PR TITLE
[gsymutil] Fix a warning on systems with 32-bit `off_t`

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/FileWriter.cpp
+++ b/llvm/lib/DebugInfo/GSYM/FileWriter.cpp
@@ -85,10 +85,10 @@ uint64_t FileWriter::tell() {
 }
 
 void FileWriter::alignTo(size_t Align) {
-  off_t Offset = OS.tell();
-  off_t AlignedOffset = (Offset + Align - 1) / Align * Align;
+  uint64_t Offset = OS.tell();
+  uint64_t AlignedOffset = (Offset + Align - 1) / Align * Align;
   if (AlignedOffset == Offset)
     return;
-  off_t PadCount = AlignedOffset - Offset;
+  uint64_t PadCount = AlignedOffset - Offset;
   OS.write_zeros(PadCount);
 }

--- a/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
@@ -145,7 +145,7 @@ llvm::Error GsymCreator::encode(FileWriter &O) const {
 
   // Write out all zeros for the AddrInfoOffsets.
   O.alignTo(4);
-  const off_t AddrInfoOffsetsOffset = O.tell();
+  const uint64_t AddrInfoOffsetsOffset = O.tell();
   for (size_t i = 0, n = Funcs.size(); i < n; ++i)
     O.writeU32(0);
 

--- a/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
@@ -164,9 +164,9 @@ llvm::Error GsymCreator::encode(FileWriter &O) const {
   }
 
   // Write out the string table.
-  const off_t StrtabOffset = O.tell();
+  const uint64_t StrtabOffset = O.tell();
   StrTab.write(O.get_stream());
-  const off_t StrtabSize = O.tell() - StrtabOffset;
+  const uint64_t StrtabSize = O.tell() - StrtabOffset;
   std::vector<uint32_t> AddrInfoOffsets;
 
   // Verify that the size of the string table does not exceed 32-bit max.


### PR DESCRIPTION
The size of `off_t` isn't specified, so it can be either 32 or 64 bits depending on the system. In particular, on LLP64 systems like windows it's generally only 32 bits. This means the `if (StrtabSize > UINT32_MAX)` check added in #181458 may warn on such systems (Giving -Wsign-compare).

Given that `FileWriter::tell` (and the underlying `raw_ostream::tell`) explicitly return `uint64_t`, the simplest fix is to just use the return type of the function instead of potentially truncating. Since the same logic applies even where we don't happen to have a warning here, I've applied this for all of these uses of `off_t`.