### PR TITLE
[RISCV] Fix discarded return value in RISCVOperand::print for FRM

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -1083,7 +1083,7 @@ public:
       break;
     case KindTy::FRM:
       OS << "<frm: ";
-      roundingModeToString(getFRM());
+      OS << roundingModeToString(getFRM());
       OS << '>';
       break;
     case KindTy::Fence:


### PR DESCRIPTION
The roundingModeToString() return value was not being written to the output stream, causing FRM operands to print as "<frm: >" with no rounding mode name in debug output.