### PR TITLE
[LifetimeSafety] Propagate loans through pointer arithmetic

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
@@ -61,6 +61,8 @@ private:
 
   void handleAssignment(const Expr *LHSExpr, const Expr *RHSExpr);
 
+  void handlePointerArithmetic(const BinaryOperator *BO);
+
   void handleCXXCtorInitializer(const CXXCtorInitializer *CII);
 
   void handleLifetimeEnds(const CFGLifetimeEnds &LifetimeEnds);

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -382,10 +382,11 @@ void FactsGenerator::handlePointerArithmetic(const BinaryOperator *BO) {
 }
 
 void FactsGenerator::VisitBinaryOperator(const BinaryOperator *BO) {
-  if (BO->getType()->isPointerType() && BO->isAdditiveOp())
-    handlePointerArithmetic(BO);
   if (BO->isCompoundAssignmentOp())
     return;
+
+  if (BO->getType()->isPointerType() && BO->isAdditiveOp())
+    handlePointerArithmetic(BO);
   handleUse(BO->getRHS());
   if (BO->isAssignmentOp())
     handleAssignment(BO->getLHS(), BO->getRHS());

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -373,13 +373,13 @@ void FactsGenerator::handleAssignment(const Expr *LHSExpr,
 
 void FactsGenerator::handlePointerArithmetic(const BinaryOperator *BO) {
   if (Expr *RHS = BO->getRHS(); RHS->getType()->isPointerType()) {
-    flowOrigin(*BO, *RHS);
+    killAndFlowOrigin(*BO, *RHS);
     return;
   }
   Expr *LHS = BO->getLHS();
   assert(LHS->getType()->isPointerType() &&
          "Pointer arithmetic must have a pointer operand");
-  flowOrigin(*BO, *LHS);
+  killAndFlowOrigin(*BO, *LHS);
 }
 
 void FactsGenerator::VisitBinaryOperator(const BinaryOperator *BO) {

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -377,14 +377,14 @@ void FactsGenerator::handlePointerArithmetic(const BinaryOperator *BO) {
     return;
   }
   Expr *LHS = BO->getLHS();
-  assert(LHS->getType()->isPointerType() && "Unexpected operand was found");
+  assert(LHS->getType()->isPointerType() &&
+         "Pointer arithmetic must have a pointer operand");
   flowOrigin(*BO, *LHS);
 }
 
 void FactsGenerator::VisitBinaryOperator(const BinaryOperator *BO) {
   if (BO->isCompoundAssignmentOp())
     return;
-
   if (BO->getType()->isPointerType() && BO->isAdditiveOp())
     handlePointerArithmetic(BO);
   handleUse(BO->getRHS());

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -371,9 +371,19 @@ void FactsGenerator::handleAssignment(const Expr *LHSExpr,
   flow(LHSList->peelOuterOrigin(), RHSList, /*Kill=*/true);
 }
 
+void FactsGenerator::handlePointerArithmetic(const BinaryOperator *BO) {
+  if (Expr *RHS = BO->getRHS(); RHS->getType()->isPointerType()) {
+    flowOrigin(*BO, *RHS);
+    return;
+  }
+  Expr *LHS = BO->getLHS();
+  assert(LHS->getType()->isPointerType() && "Unexpected operand was found");
+  flowOrigin(*BO, *LHS);
+}
+
 void FactsGenerator::VisitBinaryOperator(const BinaryOperator *BO) {
-  // TODO: Handle pointer arithmetic (e.g., `p + 1` or `1 + p`) where the
-  // result should have the same loans as the pointer operand.
+  if (BO->getType()->isPointerType() && BO->isAdditiveOp())
+    handlePointerArithmetic(BO);
   if (BO->isCompoundAssignmentOp())
     return;
   handleUse(BO->getRHS());

--- a/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
@@ -436,13 +436,9 @@ struct MemberArrayReturn {
   int* getData() { // expected-warning {{implicit this in intra-TU function should be marked [[clang::lifetimebound]]}}
     return arr;    // expected-note {{param returned here}}
   }
-};
-
-struct MemberPointerArithmeticReturn {
-    int arr[10];
-    int* end() {         // expected-warning {{implicit this in intra-TU function should be marked [[clang::lifetimebound]]}}
-        return arr + 10; // expected-note {{param returned here}}
-    }
+  int* getLast() {   // expected-warning {{implicit this in intra-TU function should be marked [[clang::lifetimebound]]}}
+    return arr + 10; // expected-note {{param returned here}}
+  }
 };
 
 } // namespace array

--- a/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
@@ -438,4 +438,11 @@ struct MemberArrayReturn {
   }
 };
 
+struct MemberPointerArithmeticReturn {
+    int arr[10];
+    int* end() {         // expected-warning {{implicit this in intra-TU function should be marked [[clang::lifetimebound]]}}
+        return arr + 10; // expected-note {{param returned here}}
+    }
+};
+
 } // namespace array

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2073,13 +2073,16 @@ int* static_array() {
 void pointer_arithmetic_use_after_scope() {
   int* p;
   int* p2;
+  int* p3;
   {
     int a[10]{};
     p = a + 5;  // expected-warning {{object whose reference is captured does not live long enough}}
     p2 = a - 5; // expected-warning {{object whose reference is captured does not live long enough}}
-  }             // expected-note 2 {{destroyed here}}
+    p3 = 5 + a; // expected-warning {{object whose reference is captured does not live long enough}}
+  }             // expected-note 3 {{destroyed here}}
   (void)*p;     // expected-note {{later used here}}
   (void)*p2;    // expected-note {{later used here}}
+  (void)*p3;    // expected-note {{later used here}}
 }
 
 // FIXME: Copying a pointer value out of an array element is not tracked.

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2070,14 +2070,13 @@ int* static_array() {
   return &a[1];
 }
 
-// FIXME: Pointer arithmetic is not yet tracked.
 void pointer_arithmetic_use_after_scope() {
   int* p;
   {
     int a[10]{};
-    p = a + 5;
-  }
-  (void)*p; // Should warn.
+    p = a + 5; // expected-warning {{object whose reference is captured does not live long enough}}
+  }            // expected-note {{destroyed here}}
+  (void)*p;    // expected-note {{later used here}}
 }
 
 // FIXME: Copying a pointer value out of an array element is not tracked.

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2072,11 +2072,14 @@ int* static_array() {
 
 void pointer_arithmetic_use_after_scope() {
   int* p;
+  int* p2;
   {
     int a[10]{};
-    p = a + 5; // expected-warning {{object whose reference is captured does not live long enough}}
-  }            // expected-note {{destroyed here}}
-  (void)*p;    // expected-note {{later used here}}
+    p = a + 5;  // expected-warning {{object whose reference is captured does not live long enough}}
+    p2 = a - 5; // expected-warning {{object whose reference is captured does not live long enough}}
+  }             // expected-note 2 {{destroyed here}}
+  (void)*p;     // expected-note {{later used here}}
+  (void)*p2;    // expected-note {{later used here}}
 }
 
 // FIXME: Copying a pointer value out of an array element is not tracked.


### PR DESCRIPTION
This PR adds loan propagation for pointer arithmetic.

It also updates the tests to match the new behavior.

Fixes #180933