### PR TITLE
[OpenMP] Add target to build OpenMP runtime

### DIFF
--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -139,6 +139,12 @@ else()
   get_clang_resource_dir(LIBOMP_HEADERS_INSTALL_PATH SUBDIR include)
 endif()
 
+# Meta-target for building OpenMP runtime artifacts (libraries, device RTL, tools).
+# Subdirectories call openmp_register_meta_dep() for each target they add.
+add_custom_target(openmp ALL
+  COMMENT "OpenMP meta-target. Use 'ninja openmp' to build all OpenMP runtime targets."
+)
+
 # Use the current compiler target to determine the appropriate runtime to build.
 if("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn|^nvptx|^spirv64" OR
    "${CMAKE_CXX_COMPILER_TARGET}" MATCHES "^amdgcn|^nvptx|^spirv64")

--- a/openmp/cmake/modules/LibompUtils.cmake
+++ b/openmp/cmake/modules/LibompUtils.cmake
@@ -210,3 +210,12 @@ function(libomp_string_to_list str return_list)
   set(${return_list} "${outstr}" PARENT_SCOPE)
 endfunction()
 
+# Register built targets with the top-level `openmp` meta-target in openmp/CMakeLists.txt.
+function(openmp_register_meta_dep)
+  foreach(tgt IN LISTS ARGN)
+    if(TARGET openmp AND TARGET "${tgt}")
+      add_dependencies(openmp "${tgt}")
+    endif()
+  endforeach()
+endfunction()
+

--- a/openmp/device/CMakeLists.txt
+++ b/openmp/device/CMakeLists.txt
@@ -106,3 +106,5 @@ set_target_properties(ompdevice PROPERTIES
 )
 target_link_libraries(ompdevice PRIVATE ompdevice.all_objs)
 install(TARGETS ompdevice ARCHIVE DESTINATION "${OPENMP_INSTALL_LIBDIR}")
+
+openmp_register_meta_dep(ompdevice)

--- a/openmp/libompd/gdb-plugin/CMakeLists.txt
+++ b/openmp/libompd/gdb-plugin/CMakeLists.txt
@@ -36,5 +36,7 @@ target_link_libraries (ompdModule ${CMAKE_DL_LIBS})
 set_target_properties (ompdModule PROPERTIES PREFIX "")
 set_target_properties (ompdModule PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/python-module/ompd/")
 
+openmp_register_meta_dep(ompd_gdb_plugin ompdModule)
+
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python-module/ompd DESTINATION share/gdb/python/ PATTERN ompdModule.so PERMISSIONS OWNER_READ WORLD_READ GROUP_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)
 

--- a/openmp/libompd/src/CMakeLists.txt
+++ b/openmp/libompd/src/CMakeLists.txt
@@ -13,6 +13,8 @@ cmake_minimum_required(VERSION 3.20.0)
 
 add_library (ompd SHARED TargetValue.cpp omp-debug.cpp omp-state.cpp omp-icv.cpp)
 
+openmp_register_meta_dep(ompd)
+
 # libompd must not link against libomp, there is no code dependency.
 add_dependencies(ompd omp) # ensure generated import library is created first
 

--- a/openmp/module/CMakeLists.txt
+++ b/openmp/module/CMakeLists.txt
@@ -74,3 +74,5 @@ if (BUILD_FORTRAN_MODULES)
     DESTINATION ${destination}
   )
 endif ()
+
+openmp_register_meta_dep(libomp-mod)

--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -189,6 +189,9 @@ else()
   # libomp must be a C++ library such that it can link libLLVMSupport
   set(LIBOMP_LINKER_LANGUAGE CXX)
 endif()
+
+openmp_register_meta_dep(omp)
+
 if(LIBOMP_USE_HWLOC)
   # Since we are using an OBJECT library, the PRIVATE and INTERFACE options are split
   # (instead of using PUBLIC): obj.omp for compiling itself, omp for propagating

--- a/openmp/tools/archer/CMakeLists.txt
+++ b/openmp/tools/archer/CMakeLists.txt
@@ -34,5 +34,7 @@ if(LIBOMP_OMPT_SUPPORT AND LIBOMP_ARCHER_SUPPORT)
     LIBRARY DESTINATION ${OPENMP_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${OPENMP_INSTALL_LIBDIR})
 
+  openmp_register_meta_dep(archer archer_static)
+
   add_subdirectory(tests)
 endif()

--- a/openmp/tools/omptest/CMakeLists.txt
+++ b/openmp/tools/omptest/CMakeLists.txt
@@ -122,6 +122,8 @@ if(TARGET cxxabi_shared)
   add_dependencies(omptest cxxabi_shared)
 endif()
 
+openmp_register_meta_dep(omptest)
+
 # Add common include directories.
 target_include_directories(omptest PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
This adds a top-level target to build the OpenMP runtime, similar to what was done in https://github.com/llvm/llvm-project/pull/186099 for the Offload runtime.

Having this top-level target enables us to execute the build in the pre-commit CI as shown in https://github.com/llvm/llvm-project/pull/174955 (I actually just cherry-picked the commit from that branch)