### PR TITLE
[clang] fix getReplacedTemplateParameter for function template specializations

### DIFF
--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -1707,10 +1707,12 @@ clang::getReplacedTemplateParameter(Decl *D, unsigned Index) {
   case Decl::Kind::CXXConstructor:
   case Decl::Kind::CXXDestructor:
   case Decl::Kind::CXXMethod:
-  case Decl::Kind::Function:
-    return getReplacedTemplateParameter(
-        cast<FunctionDecl>(D)->getTemplateSpecializationInfo()->getTemplate(),
-        Index);
+  case Decl::Kind::Function: {
+    const FunctionTemplateSpecializationInfo *Info =
+        cast<FunctionDecl>(D)->getTemplateSpecializationInfo();
+    return {Info->getTemplate()->getTemplateParameters()->getParam(Index),
+            Info->TemplateArguments->asArray()[Index]};
+  }
   default:
     llvm_unreachable("Unhandled templated declaration kind");
   }

--- a/clang/test/SemaTemplate/GH188759.cpp
+++ b/clang/test/SemaTemplate/GH188759.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++26 %s
+
+namespace t1 {
+  template <int> struct integer_sequence {};
+  template <int> struct array {};
+  template <int ARRAY_SIZE, array<ARRAY_SIZE> test_apdus> void runBlobs() {
+    []<int... INDEX>(integer_sequence<INDEX...>) { // expected-note {{requested here}}
+      int x{operator0<test_apdus, INDEX>()...};
+      // expected-error@-1 {{use of undeclared identifier 'operator0'}}
+    }(integer_sequence<1>{});
+  }
+  template void runBlobs<2, {}>(); // expected-note {{requested here}}
+} // namespace t1


### PR DESCRIPTION
This fixes the transformation of substituted constant template parameters by providing the instantiated parameter type for the function template specialization case.

This fixes a regression introduced in #161029 which will be backported to llvm-22, so there are no release notes.

Fixes #188759