### PR TITLE
[lldb] Change MemoryRegionInfo::SetIsShadowStack into a "builder" method

### DIFF
--- a/lldb/include/lldb/Target/MemoryRegionInfo.h
+++ b/lldb/include/lldb/Target/MemoryRegionInfo.h
@@ -29,11 +29,11 @@ public:
                    OptionalBool execute, OptionalBool shared,
                    OptionalBool mapped, ConstString name, OptionalBool flash,
                    lldb::offset_t blocksize, OptionalBool memory_tagged,
-                   OptionalBool stack_memory, OptionalBool shadow_stack)
+                   OptionalBool stack_memory)
       : m_range(range), m_read(read), m_write(write), m_execute(execute),
         m_shared(shared), m_mapped(mapped), m_name(name), m_flash(flash),
         m_blocksize(blocksize), m_memory_tagged(memory_tagged),
-        m_is_stack_memory(stack_memory), m_is_shadow_stack(shadow_stack) {}
+        m_is_stack_memory(stack_memory) {}
 
   RangeType &GetRange() { return m_range; }
 
@@ -79,7 +79,10 @@ public:
 
   void SetMemoryTagged(OptionalBool val) { m_memory_tagged = val; }
 
-  void SetIsShadowStack(OptionalBool val) { m_is_shadow_stack = val; }
+  MemoryRegionInfo &SetIsShadowStack(OptionalBool val) {
+    m_is_shadow_stack = val;
+    return *this;
+  }
 
   // Get permissions as a uint32_t that is a mask of one or more bits from the
   // lldb::Permissions

--- a/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
+++ b/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
@@ -92,21 +92,20 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString("[abc]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
             },
             "unexpected /proc/{pid}/maps exec permission char"),
         // Single entry
         std::make_tuple(
             "55a4512f7000-55a451b68000 rw-p 00000000 00:00 0    [heap]",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x55a4512f7000, 0x55a451b68000),
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eYes, ConstString("[heap]"),
-                    MemoryRegionInfo::eDontKnow, 0, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x55a4512f7000, 0x55a451b68000),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString("[heap]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow,
+                                 MemoryRegionInfo::eDontKnow),
             },
             ""),
         // Multiple entries
@@ -116,27 +115,27 @@ INSTANTIATE_TEST_SUITE_P(
             "ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0 "
             "[vsyscall]",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x7fc090021000, 0x7fc094000000),
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eYes, ConstString(nullptr),
-                    MemoryRegionInfo::eDontKnow, 0, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
-                MemoryRegionInfo(
-                    make_range(0x7fc094000000, 0x7fc094a00000),
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, ConstString(nullptr),
-                    MemoryRegionInfo::eDontKnow, 0, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x7fc090021000, 0x7fc094000000),
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow,
+                                 MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x7fc094000000, 0x7fc094a00000),
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow,
+                                 MemoryRegionInfo::eDontKnow),
                 MemoryRegionInfo(
                     make_range(0xffffffffff600000, 0xffffffffff601000),
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, ConstString("[vsyscall]"),
                     MemoryRegionInfo::eDontKnow, 0, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow),
             },
             "")));
 
@@ -162,8 +161,7 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
             },
             "malformed /proc/{pid}/smaps entry, missing dash between address "
             "range"),
@@ -183,8 +181,7 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
             },
             ""),
         // Single shared region parses, has no flags
@@ -196,8 +193,7 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                     ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
             },
             ""),
         // Single region with flags, other lines ignored
@@ -212,8 +208,8 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eNo),
+                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
         // Whitespace ignored
@@ -226,8 +222,8 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eNo),
+                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
         // VmFlags line means it has flag info, but nothing is set
@@ -240,8 +236,8 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eNo),
+                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
         // Handle some pages not having a flags line
@@ -257,15 +253,14 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
                 MemoryRegionInfo(
                     make_range(0x3333, 0x4444), MemoryRegionInfo::eYes,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString("[bar]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eNo),
+                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
         // Handle no pages having a flags line (older kernels)
@@ -282,15 +277,13 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
                 MemoryRegionInfo(
                     make_range(0x3333, 0x4444), MemoryRegionInfo::eYes,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
             },
             ""),
         // We must look for exact flag strings, ignoring substrings of longer
@@ -304,8 +297,22 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eNo),
+                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo),
+            },
+            ""),
+        // "ss" means shadow stack.
+        std::make_tuple(
+            "0-0 rw-p 00000000 00:00 0\n"
+            "VmFlags: ss",
+            MemoryRegionInfos{
+                MemoryRegionInfo(
+                    make_range(0, 0), MemoryRegionInfo::eYes,
+                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
+                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow)
+                    .SetIsShadowStack(MemoryRegionInfo::eYes),
             },
             "")));
 

--- a/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
+++ b/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
@@ -236,7 +236,7 @@ static MemoryRegionInfo MakeRegionInfo(lldb::addr_t base, lldb::addr_t size,
       MemoryRegionInfo::eYes, ConstString(), MemoryRegionInfo::eNo, 0,
       /*memory_tagged=*/
       tagged ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo,
-      MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow);
+      MemoryRegionInfo::eDontKnow);
 }
 
 TEST(MemoryTagManagerAArch64MTETest, MakeTaggedRange) {

--- a/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
+++ b/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
@@ -382,23 +382,19 @@ Streams:
 
   EXPECT_THAT(
       parser->BuildMemoryRegions(),
-      testing::Pair(testing::ElementsAre(
-                        MemoryRegionInfo({0x0, 0x10000}, no, no, no, unknown,
-                                         no, ConstString(), unknown, 0, unknown,
-                                         unknown, unknown),
-                        MemoryRegionInfo({0x10000, 0x21000}, yes, yes, no,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown),
-                        MemoryRegionInfo({0x40000, 0x1000}, yes, no, no,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown),
-                        MemoryRegionInfo({0x7ffe0000, 0x1000}, yes, no, no,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown),
-                        MemoryRegionInfo({0x7ffe1000, 0xf000}, no, no, no,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown)),
-                    true));
+      testing::Pair(
+          testing::ElementsAre(
+              MemoryRegionInfo({0x0, 0x10000}, no, no, no, unknown, no,
+                               ConstString(), unknown, 0, unknown, unknown),
+              MemoryRegionInfo({0x10000, 0x21000}, yes, yes, no, unknown, yes,
+                               ConstString(), unknown, 0, unknown, unknown),
+              MemoryRegionInfo({0x40000, 0x1000}, yes, no, no, unknown, yes,
+                               ConstString(), unknown, 0, unknown, unknown),
+              MemoryRegionInfo({0x7ffe0000, 0x1000}, yes, no, no, unknown, yes,
+                               ConstString(), unknown, 0, unknown, unknown),
+              MemoryRegionInfo({0x7ffe1000, 0xf000}, no, no, no, unknown, yes,
+                               ConstString(), unknown, 0, unknown, unknown)),
+          true));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemoryList) {
@@ -423,10 +419,10 @@ Streams:
       testing::Pair(testing::ElementsAre(
                         MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown,
                                          unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown),
+                                         0, unknown, unknown),
                         MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown,
                                          unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown)),
+                                         0, unknown, unknown)),
                     false));
 }
 
@@ -440,10 +436,10 @@ TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemory64List) {
       testing::Pair(testing::ElementsAre(
                         MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown,
                                          unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown),
+                                         0, unknown, unknown),
                         MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown,
                                          unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown)),
+                                         0, unknown, unknown)),
                     false));
 }
 
@@ -473,21 +469,17 @@ Streams:
       testing::Pair(
           testing::ElementsAre(
               MemoryRegionInfo({0x400d9000, 0x2000}, yes, no, yes, no, yes,
-                               app_process, unknown, 0, unknown, unknown,
-                               unknown),
+                               app_process, unknown, 0, unknown, unknown),
               MemoryRegionInfo({0x400db000, 0x1000}, yes, no, no, no, yes,
-                               app_process, unknown, 0, unknown, unknown,
-                               unknown),
+                               app_process, unknown, 0, unknown, unknown),
               MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes, no, no, yes,
-                               ConstString(), unknown, 0, unknown, unknown,
-                               unknown),
+                               ConstString(), unknown, 0, unknown, unknown),
               MemoryRegionInfo({0x400ec000, 0x1000}, yes, no, no, no, yes,
-                               ConstString(), unknown, 0, unknown, unknown,
-                               unknown),
+                               ConstString(), unknown, 0, unknown, unknown),
               MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes, no, no, yes,
-                               linker, unknown, 0, unknown, unknown, unknown),
+                               linker, unknown, 0, unknown, unknown),
               MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes, yes, no, yes,
-                               liblog, unknown, 0, unknown, unknown, unknown)),
+                               liblog, unknown, 0, unknown, unknown)),
           true));
 }
 
@@ -504,12 +496,12 @@ Streams:
                     llvm::Succeeded());
   // Test that when a /proc/maps region fails to parse
   // we handle the error and continue with the rest.
-  EXPECT_THAT(parser->BuildMemoryRegions(),
-              testing::Pair(testing::ElementsAre(MemoryRegionInfo(
-                                {0x400fc000, 0x1000}, yes, yes, yes, no, yes,
-                                ConstString(nullptr), unknown, 0, unknown,
-                                unknown, unknown)),
-                            true));
+  EXPECT_THAT(
+      parser->BuildMemoryRegions(),
+      testing::Pair(testing::ElementsAre(MemoryRegionInfo(
+                        {0x400fc000, 0x1000}, yes, yes, yes, no, yes,
+                        ConstString(nullptr), unknown, 0, unknown, unknown)),
+                    true));
 }
 
 // Windows Minidump tests


### PR DESCRIPTION
Meaning a method on an object, which returns a reference to self.

I am doing this because it was pointed out to me that MemoryRegionInfo has lots of construction paramaters, and most of the time, we want the default value for most of the things.

So now we can do:
MemoryRegionInfo(...); // Shadow stack is "don't know".
MemoryRegionInfo(...).SetIsShadowStack(eNo) // Shadow stack is "no".

Which removes one parameter from every use of the constructor.

Along the way I realised that the shadow stack "ss" flag is only tested by the Guarded Control Stack tests, which only run on specific Arm hardware. I've added a new "ss" test to LinuxProcMapsTest, which will run on any system.