### PR TITLE
[lldb] Handle simulator printout in TestSimulatorPlatform

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -1799,7 +1799,6 @@ def launch_exe_in_apple_simulator(
     device_uuid,
     exe_path,
     exe_args=[],
-    stderr_lines_to_read=0,
     stderr_patterns=[],
     log=None,
 ):
@@ -1823,18 +1822,21 @@ def launch_exe_in_apple_simulator(
     total_patterns = len(stderr_patterns)
     matches_found = 0
     matched_strings = [None] * total_patterns
-    for _ in range(0, stderr_lines_to_read):
-        stderr = sim_launcher.stderr.readline().decode("utf-8")
-        if not stderr:
-            continue
-        for i, pattern in enumerate(stderr_patterns):
-            if matched_strings[i] is not None:
+    if len(stderr_patterns) != 0:
+        while True:
+            stderr = sim_launcher.stderr.readline().decode("utf-8")
+            if not stderr:
                 continue
-            match = re.match(pattern, stderr)
-            if match:
-                matched_strings[i] = str(match.group(1))
-                matches_found += 1
-        if matches_found == total_patterns:
-            break
+            if log:
+                log(f"searching stderr line: {stderr}")
+            for i, pattern in enumerate(stderr_patterns):
+                if matched_strings[i] is not None:
+                    continue
+                match = re.match(pattern, stderr)
+                if match:
+                    matched_strings[i] = str(match.group(1))
+                    matches_found += 1
+            if matches_found == total_patterns:
+                break
 
     return exe_path, matched_strings

--- a/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
+++ b/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
@@ -97,7 +97,6 @@ class TestSimulatorPlatformLaunching(TestBase):
                 device_udid,
                 self.getBuildArtifact("a.out"),
                 exe_args=[],
-                stderr_lines_to_read=1,  # in hello.cpp, the pid is printed first
                 stderr_patterns=[r"PID: (.*)"],
                 log=self.trace,
             )


### PR DESCRIPTION
This test invokes a binary in a simulator and then reads the first line of stderr to parse the PID of the invoked binary.

This approach fails when the simulator itself prints a warning/error on startup. In this case, we try to parse the error as the PID and fail.

This patch just removes the line limit. It doesn't seem to add any value as we anyway need to search until we find the PID line, and if there is no PID line we cannot do anything but time out eventually.

See also rdar://169799464