### PR TITLE
[lldb] Remove stack_memory from MemoryRegionInfo constructor

### DIFF
--- a/lldb/include/lldb/Target/MemoryRegionInfo.h
+++ b/lldb/include/lldb/Target/MemoryRegionInfo.h
@@ -28,12 +28,10 @@ public:
   MemoryRegionInfo(RangeType range, OptionalBool read, OptionalBool write,
                    OptionalBool execute, OptionalBool shared,
                    OptionalBool mapped, ConstString name, OptionalBool flash,
-                   lldb::offset_t blocksize, OptionalBool memory_tagged,
-                   OptionalBool stack_memory)
+                   lldb::offset_t blocksize, OptionalBool memory_tagged)
       : m_range(range), m_read(read), m_write(write), m_execute(execute),
         m_shared(shared), m_mapped(mapped), m_name(name), m_flash(flash),
-        m_blocksize(blocksize), m_memory_tagged(memory_tagged),
-        m_is_stack_memory(stack_memory) {}
+        m_blocksize(blocksize), m_memory_tagged(memory_tagged) {}
 
   RangeType &GetRange() { return m_range; }
 

--- a/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
+++ b/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
@@ -87,12 +87,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rwzp 00000000 00:00 0\n"
             "2-3 r-xp 00000000 00:00 0 [def]\n",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0, 1), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString("[abc]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0, 1), MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 ConstString("[abc]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
             },
             "unexpected /proc/{pid}/maps exec permission char"),
         // Single entry
@@ -104,7 +104,6 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[heap]"),
                                  MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow,
                                  MemoryRegionInfo::eDontKnow),
             },
             ""),
@@ -120,21 +119,19 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString(nullptr),
                                  MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow,
                                  MemoryRegionInfo::eDontKnow),
                 MemoryRegionInfo(make_range(0x7fc094000000, 0x7fc094a00000),
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, ConstString(nullptr),
                                  MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow,
                                  MemoryRegionInfo::eDontKnow),
                 MemoryRegionInfo(
                     make_range(0xffffffffff600000, 0xffffffffff601000),
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, ConstString("[vsyscall]"),
-                    MemoryRegionInfo::eDontKnow, 0, MemoryRegionInfo::eDontKnow,
+                    MemoryRegionInfo::eDontKnow, 0,
                     MemoryRegionInfo::eDontKnow),
             },
             "")));
@@ -156,12 +153,12 @@ INSTANTIATE_TEST_SUITE_P(
             "1111-2222 rw-p 00000000 00:00 0 [foo]\n"
             "0/0 rw-p 00000000 00:00 0",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x1111, 0x2222), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x1111, 0x2222),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
             },
             "malformed /proc/{pid}/smaps entry, missing dash between address "
             "range"),
@@ -176,24 +173,24 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(
             "1111-2222 rw-p 00000000 00:00 0    [foo]",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x1111, 0x2222), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x1111, 0x2222),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
             },
             ""),
         // Single shared region parses, has no flags
         std::make_tuple(
             "1111-2222 rw-s 00000000 00:00 0    [foo]",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x1111, 0x2222), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
-                    ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x1111, 0x2222),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
             },
             ""),
         // Single region with flags, other lines ignored
@@ -203,12 +200,12 @@ INSTANTIATE_TEST_SUITE_P(
             "AnonHugePages:         0 kB\n"
             "VmFlags: mt",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x1111, 0x2222), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow)
+                MemoryRegionInfo(make_range(0x1111, 0x2222),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eYes)
                     .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
@@ -217,12 +214,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rw-p 00000000 00:00 0\n"
             "VmFlags:      mt      ",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0, 0), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow)
+                MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eYes)
                     .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
@@ -231,12 +228,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rw-p 00000000 00:00 0\n"
             "VmFlags:         ",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0, 0), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow)
+                MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eNo)
                     .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
@@ -248,18 +245,18 @@ INSTANTIATE_TEST_SUITE_P(
             "3333-4444 r-xp 00000000 00:00 0    [bar]\n"
             "VmFlags: mt",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x1111, 0x2222), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
-                MemoryRegionInfo(
-                    make_range(0x3333, 0x4444), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString("[bar]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow)
+                MemoryRegionInfo(make_range(0x1111, 0x2222),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x3333, 0x4444),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString("[bar]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eYes)
                     .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
@@ -272,18 +269,18 @@ INSTANTIATE_TEST_SUITE_P(
             "KernelPageSize:        4 kB\n"
             "MMUPageSize:           4 kB\n",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x1111, 0x2222), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
-                MemoryRegionInfo(
-                    make_range(0x3333, 0x4444), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x1111, 0x2222),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x3333, 0x4444),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
             },
             ""),
         // We must look for exact flag strings, ignoring substrings of longer
@@ -292,12 +289,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rw-p 00000000 00:00 0\n"
             "VmFlags: amt mtb amtb",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0, 0), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow)
+                MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eNo)
                     .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
@@ -306,12 +303,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rw-p 00000000 00:00 0\n"
             "VmFlags: ss",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0, 0), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow)
+                MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eNo)
                     .SetIsShadowStack(MemoryRegionInfo::eYes),
             },
             "")));

--- a/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
+++ b/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
@@ -235,8 +235,7 @@ static MemoryRegionInfo MakeRegionInfo(lldb::addr_t base, lldb::addr_t size,
       MemoryRegionInfo::eYes, MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
       MemoryRegionInfo::eYes, ConstString(), MemoryRegionInfo::eNo, 0,
       /*memory_tagged=*/
-      tagged ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo,
-      MemoryRegionInfo::eDontKnow);
+      tagged ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo);
 }
 
 TEST(MemoryTagManagerAArch64MTETest, MakeTaggedRange) {

--- a/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
+++ b/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
@@ -385,15 +385,15 @@ Streams:
       testing::Pair(
           testing::ElementsAre(
               MemoryRegionInfo({0x0, 0x10000}, no, no, no, unknown, no,
-                               ConstString(), unknown, 0, unknown, unknown),
+                               ConstString(), unknown, 0, unknown),
               MemoryRegionInfo({0x10000, 0x21000}, yes, yes, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown, unknown),
+                               ConstString(), unknown, 0, unknown),
               MemoryRegionInfo({0x40000, 0x1000}, yes, no, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown, unknown),
+                               ConstString(), unknown, 0, unknown),
               MemoryRegionInfo({0x7ffe0000, 0x1000}, yes, no, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown, unknown),
+                               ConstString(), unknown, 0, unknown),
               MemoryRegionInfo({0x7ffe1000, 0xf000}, no, no, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown, unknown)),
+                               ConstString(), unknown, 0, unknown)),
           true));
 }
 
@@ -416,14 +416,13 @@ Streams:
 
   EXPECT_THAT(
       parser->BuildMemoryRegions(),
-      testing::Pair(testing::ElementsAre(
-                        MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown),
-                        MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown)),
-                    false));
+      testing::Pair(
+          testing::ElementsAre(
+              MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown, unknown,
+                               yes, ConstString(), unknown, 0, unknown),
+              MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown, unknown,
+                               yes, ConstString(), unknown, 0, unknown)),
+          false));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemory64List) {
@@ -433,14 +432,13 @@ TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemory64List) {
   // we don't have a MemoryInfoListStream.
   EXPECT_THAT(
       parser->BuildMemoryRegions(),
-      testing::Pair(testing::ElementsAre(
-                        MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown),
-                        MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown)),
-                    false));
+      testing::Pair(
+          testing::ElementsAre(
+              MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown, unknown,
+                               yes, ConstString(), unknown, 0, unknown),
+              MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown, unknown,
+                               yes, ConstString(), unknown, 0, unknown)),
+          false));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoLinuxMaps) {
@@ -464,23 +462,22 @@ Streams:
   ConstString app_process("/system/bin/app_process");
   ConstString linker("/system/bin/linker");
   ConstString liblog("/system/lib/liblog.so");
-  EXPECT_THAT(
-      parser->BuildMemoryRegions(),
-      testing::Pair(
-          testing::ElementsAre(
-              MemoryRegionInfo({0x400d9000, 0x2000}, yes, no, yes, no, yes,
-                               app_process, unknown, 0, unknown, unknown),
-              MemoryRegionInfo({0x400db000, 0x1000}, yes, no, no, no, yes,
-                               app_process, unknown, 0, unknown, unknown),
-              MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes, no, no, yes,
-                               ConstString(), unknown, 0, unknown, unknown),
-              MemoryRegionInfo({0x400ec000, 0x1000}, yes, no, no, no, yes,
-                               ConstString(), unknown, 0, unknown, unknown),
-              MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes, no, no, yes,
-                               linker, unknown, 0, unknown, unknown),
-              MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes, yes, no, yes,
-                               liblog, unknown, 0, unknown, unknown)),
-          true));
+  EXPECT_THAT(parser->BuildMemoryRegions(),
+              testing::Pair(
+                  testing::ElementsAre(
+                      MemoryRegionInfo({0x400d9000, 0x2000}, yes, no, yes, no,
+                                       yes, app_process, unknown, 0, unknown),
+                      MemoryRegionInfo({0x400db000, 0x1000}, yes, no, no, no,
+                                       yes, app_process, unknown, 0, unknown),
+                      MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes, no, no,
+                                       yes, ConstString(), unknown, 0, unknown),
+                      MemoryRegionInfo({0x400ec000, 0x1000}, yes, no, no, no,
+                                       yes, ConstString(), unknown, 0, unknown),
+                      MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes, no, no,
+                                       yes, linker, unknown, 0, unknown),
+                      MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes, yes, no,
+                                       yes, liblog, unknown, 0, unknown)),
+                  true));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoLinuxMapsError) {
@@ -496,12 +493,11 @@ Streams:
                     llvm::Succeeded());
   // Test that when a /proc/maps region fails to parse
   // we handle the error and continue with the rest.
-  EXPECT_THAT(
-      parser->BuildMemoryRegions(),
-      testing::Pair(testing::ElementsAre(MemoryRegionInfo(
-                        {0x400fc000, 0x1000}, yes, yes, yes, no, yes,
-                        ConstString(nullptr), unknown, 0, unknown, unknown)),
-                    true));
+  EXPECT_THAT(parser->BuildMemoryRegions(),
+              testing::Pair(testing::ElementsAre(MemoryRegionInfo(
+                                {0x400fc000, 0x1000}, yes, yes, yes, no, yes,
+                                ConstString(nullptr), unknown, 0, unknown)),
+                            true));
 }
 
 // Windows Minidump tests


### PR DESCRIPTION
Nothing passes anything but the default value here. Code that wants to set it is starting with a default constructed info, and filling in the fields one by one (the gdb-remote client for example).