### PR TITLE
[AMDGPU][NFCI] CustomOperand to have a default type

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
@@ -122,12 +122,12 @@ class CustomOperandProps<bit optional = 0, string name = NAME> {
   string OperandType = "OPERAND_IMMEDIATE";
 }
 
-class CustomOperand<ValueType type, bit optional = 0, string name = NAME>
+class CustomOperand<bit optional = 0, string name = NAME, ValueType type = i32>
   : Operand<type>, CustomOperandProps<optional, name>;
 
 class ImmOperand<ValueType type, string name = NAME, bit optional = 0,
                  string printer = "print"#name>
-    : CustomOperand<type, optional, name> {
+    : CustomOperand<optional, name, type=type> {
   let ImmTy = "ImmTyNone";
   let ParserMethod = "";
   let PrintMethod = printer;
@@ -140,7 +140,7 @@ def u16imm : ImmOperand<i16, "U16Imm", 0, "printU16ImmOperand">;
 
 class ValuePredicatedOperand<CustomOperand op, string valuePredicate,
                              bit optional = 0>
-    : CustomOperand<op.Type, optional> {
+    : CustomOperand<optional, type=op.Type> {
   let ImmTy = op.ImmTy;
   defvar OpPredicate = op.ParserMatchClass.PredicateMethod;
   let PredicateMethod =

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -1057,7 +1057,7 @@ def extract_cpol_set_glc : SDNodeXForm<timm, [{
 // Custom Operands
 //===----------------------------------------------------------------------===//
 
-def SOPPBrTarget : CustomOperand<OtherVT> {
+def SOPPBrTarget : CustomOperand<type=OtherVT> {
   let PrintMethod = "printOperand";
   let EncoderMethod = "getSOPPBrEncoding";
   let DecoderMethod = "decodeSOPPBrTarget";
@@ -1066,11 +1066,11 @@ def SOPPBrTarget : CustomOperand<OtherVT> {
 
 def si_ga : Operand<iPTR>;
 
-def InterpSlot : CustomOperand<i32>;
+def InterpSlot : CustomOperand;
 
 // It appears to be necessary to create a separate operand for this to
 // be able to parse attr<num> with no space.
-def InterpAttr : CustomOperand<i32>;
+def InterpAttr : CustomOperand;
 
 def InterpAttrChan : ImmOperand<i32>;
 
@@ -1093,19 +1093,19 @@ def VReg32OrOffClass : AsmOperandClass {
   let ParserMethod = "parseVReg32OrOff";
 }
 
-def SendMsg : CustomOperand<i32>;
+def SendMsg : CustomOperand;
 
-def WaitEvent : CustomOperand<i16>;
+def WaitEvent : CustomOperand<type=i16>;
 
-def Swizzle : CustomOperand<i16, 1>;
+def Swizzle : CustomOperand<1, type=i16>;
 
-def Endpgm : CustomOperand<i16, 1>;
+def Endpgm : CustomOperand<1, type=i16>;
 
-def SWaitCnt : CustomOperand<i32>;
+def SWaitCnt : CustomOperand;
 
-def DepCtr : CustomOperand<i32>;
+def DepCtr : CustomOperand;
 
-def SDelayALU : CustomOperand<i32>;
+def SDelayALU : CustomOperand;
 
 include "SIInstrFormats.td"
 include "VIInstrFormats.td"
@@ -1187,7 +1187,7 @@ def SDWAVopcDst : BoolRC {
 }
 
 class NamedIntOperand<string prefix, bit Optional = 1, string name = NAME>
-    : CustomOperand<i32, Optional, name> {
+    : CustomOperand<Optional, name> {
   string Prefix = prefix;
 
   let PredicateMethod =
@@ -1211,7 +1211,7 @@ class NamedIntOperand<string prefix, bit Optional = 1, string name = NAME>
 }
 
 class NamedBitOperand<string Id, string Name = NAME, bit AlwaysIgnoreNegative = 0>
-    : CustomOperand<i1, 1, Name> {
+    : CustomOperand<1, Name, i1> {
   let PredicateMethod = "isImmTy<AMDGPUOperand::"#ImmTy#">";
   let ParserMethod =
     "[this](OperandVector &Operands) -> ParseStatus { "#
@@ -1229,7 +1229,7 @@ class DefaultOperand<CustomOperand Op, int Value>
 }
 
 class SDWAOperand<string Id, string Name = NAME>
-    : CustomOperand<i32, 1, Name> {
+    : CustomOperand<1, Name> {
   let ParserMethod =
     "[this](OperandVector &Operands) -> ParseStatus { "#
     "return parseSDWASel(Operands, \""#Id#"\", AMDGPUOperand::"#ImmTy#"); }";
@@ -1245,7 +1245,7 @@ class ArrayOperand0<string Id, string Name = NAME>
 }
 
 let ImmTy = "ImmTyOffset" in
-def flat_offset : CustomOperand<i32, 1, "FlatOffset">;
+def flat_offset : CustomOperand<1, "FlatOffset">;
 let PrintMethod = "printOffset" in
 def Offset : NamedIntOperand<"offset">;
 let Validator = "isUInt<8>" in {
@@ -1255,7 +1255,7 @@ def Offset1 : NamedIntOperand<"offset1">;
 
 def gds : NamedBitOperand<"gds", "GDS">;
 
-def omod : CustomOperand<i32, 1, "OModSI">;
+def omod : CustomOperand<1, "OModSI">;
 def omod0 : DefaultOperand<omod, 0>;
 
 // We need to make the cases with a default of 0 distinct from no
@@ -1265,7 +1265,7 @@ def Clamp : NamedBitOperand<"clamp">;
 def Clamp0 : DefaultOperand<Clamp, 0>;
 def highmod : NamedBitOperand<"high", "High">;
 
-def CPol : CustomOperand<i32, 1>;
+def CPol : CustomOperand<1>;
 def CPol_0 : DefaultOperand<CPol, 0>;
 def CPol_GLC1 : DefaultOperand<CPol, 1>;
 def CPol_GLC : ValuePredicatedOperand<CPol, "Op.getImm() & CPol::GLC">;
@@ -1278,7 +1278,7 @@ def IsAsync : NamedBitOperand<"isasync">;
 def TFE : NamedBitOperand<"tfe">;
 def UNorm : NamedBitOperand<"unorm">;
 def DA : NamedBitOperand<"da">;
-def R128A16 : CustomOperand<i1, 1>;
+def R128A16 : CustomOperand<1, type=i1>;
 def A16 : NamedBitOperand<"a16">;
 def D16 : NamedBitOperand<"d16">;
 def LWE : NamedBitOperand<"lwe">;
@@ -1287,29 +1287,29 @@ def exp_vm : NamedBitOperand<"vm", "ExpVM", 1>;
 def exp_done : NamedBitOperand<"done", "Done", 1>;
 def exp_row_en : NamedBitOperand<"row_en", "RowEn", 1>;
 
-def FORMAT : CustomOperand<i8>;
+def FORMAT : CustomOperand<type=i8>;
 
 let PrintInHex = 1 in
 def DMask : NamedIntOperand<"dmask">;
 
-def Dim : CustomOperand<i8, /*optional=*/1>;
+def Dim : CustomOperand</*optional=*/1, type=i8>;
 
 def dst_sel : SDWAOperand<"dst_sel", "SDWADstSel">;
 def src0_sel : SDWAOperand<"src0_sel", "SDWASrc0Sel">;
 def src1_sel : SDWAOperand<"src1_sel", "SDWASrc1Sel">;
-def dst_unused : CustomOperand<i32, 1, "SDWADstUnused">;
+def dst_unused : CustomOperand<1, "SDWADstUnused">;
 
 def op_sel0 : ArrayOperand0<"op_sel", "OpSel">;
 def op_sel_hi0 : ArrayOperand0<"op_sel_hi", "OpSelHi">;
 def neg_lo0 : ArrayOperand0<"neg_lo", "NegLo">;
 def neg_hi0 : ArrayOperand0<"neg_hi", "NegHi">;
 
-def IndexKey32bit : CustomOperand<i32, 1>;
-def IndexKey16bit : CustomOperand<i32, 1>;
-def IndexKey8bit : CustomOperand<i32, 1>;
+def IndexKey32bit : CustomOperand<1>;
+def IndexKey16bit : CustomOperand<1>;
+def IndexKey8bit : CustomOperand<1>;
 
-def dpp8 : CustomOperand<i32, 0, "DPP8">;
-def dpp_ctrl : CustomOperand<i32, 0, "DPPCtrl">;
+def dpp8 : CustomOperand<0, "DPP8">;
+def dpp_ctrl : CustomOperand<0, "DPPCtrl">;
 
 let DefaultValue = "0xf", PrintInHex = 1, AlwaysPrint = 1 in {
 def DppRowMask : NamedIntOperand<"row_mask">;
@@ -1325,16 +1325,16 @@ def Dpp8FI : NamedIntOperand<"fi", 1, "DppFI">;
 let PrintMethod = "printDppFI" in
 def Dpp16FI : NamedIntOperand<"fi", 1, "DppFI">;
 
-def blgp : CustomOperand<i32, 1, "BLGP">;
+def blgp : CustomOperand<1, "BLGP">;
 def CBSZ : NamedIntOperand<"cbsz"> {
   let Validator = "isUInt<3>";
 }
 def ABID : NamedIntOperand<"abid"> {
   let Validator = "isUInt<4>";
 }
-def hwreg : CustomOperand<i32, 0, "Hwreg">;
+def hwreg : CustomOperand<0, "Hwreg">;
 
-def exp_tgt : CustomOperand<i32, 0, "ExpTgt">;
+def exp_tgt : CustomOperand<0, "ExpTgt">;
 
 let AlwaysPrint = 1 in {
 def WaitVDST : NamedIntOperand<"wait_vdst"> {
@@ -1360,14 +1360,14 @@ let PrintMethod = "printBitOp3" in
 def BitOp3 : NamedIntOperand<"bitop3">;
 def bitop3_0 : DefaultOperand<BitOp3, 0>;
 
-def MatrixAFMT : CustomOperand<i32, 1, "MatrixAFMT">;
-def MatrixBFMT : CustomOperand<i32, 1, "MatrixBFMT">;
+def MatrixAFMT : CustomOperand<1, "MatrixAFMT">;
+def MatrixBFMT : CustomOperand<1, "MatrixBFMT">;
 
-def MatrixAScale : CustomOperand<i32, 1, "MatrixAScale">;
-def MatrixBScale : CustomOperand<i32, 1, "MatrixBScale">;
+def MatrixAScale : CustomOperand<1, "MatrixAScale">;
+def MatrixBScale : CustomOperand<1, "MatrixBScale">;
 
-def MatrixAScaleFmt : CustomOperand<i32, 1, "MatrixAScaleFmt">;
-def MatrixBScaleFmt : CustomOperand<i32, 1, "MatrixBScaleFmt">;
+def MatrixAScaleFmt : CustomOperand<1, "MatrixAScaleFmt">;
+def MatrixBScaleFmt : CustomOperand<1, "MatrixBScaleFmt">;
 
 def MatrixAReuse : NamedBitOperand<"matrix_a_reuse">;
 def MatrixBReuse : NamedBitOperand<"matrix_b_reuse">;

--- a/llvm/lib/Target/AMDGPU/SOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SOPInstructions.td
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-def GPRIdxMode : CustomOperand<i32>;
+def GPRIdxMode : CustomOperand;
 
 class SOP_Pseudo<string opName, dag outs, dag ins, string asmOps,
                   list<dag> pattern=[]> :


### PR DESCRIPTION
Most of the time, we should not need to care about the type at all, so having it as a mandatory parameter confuses people and invites using i1/i8/i16 where not necessary.