### PR TITLE
[mlir][linalg] Add test for ReduceOp empty-input verifier; remove dead empty-output check

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -1897,8 +1897,6 @@ LogicalResult ReduceOp::verify() {
 
   if (getInputs().empty())
     return emitOpError() << "expected at least one input";
-  if (getInits().empty())
-    return emitOpError() << "expected at least one output";
 
   for (int64_t i = 1; i < getNumDpsInputs(); ++i) {
     if (llvm::cast<ShapedType>(getInputs()[i].getType()).getShape() !=

--- a/mlir/test/Dialect/Linalg/invalid.mlir
+++ b/mlir/test/Dialect/Linalg/invalid.mlir
@@ -2194,3 +2194,15 @@ func.func @reduce_unequal_input_output_count(
   %ext = tensor.extract %reduced[] : tensor<i32>
   return %ext : i32
 }
+
+// -----
+
+func.func @reduce_no_inputs() {
+  // expected-error @+1 {{'linalg.reduce' op expected at least one input}}
+  linalg.reduce
+      dimensions = []
+      () {
+        linalg.yield
+      }
+  func.return
+}


### PR DESCRIPTION
Add a FileCheck test covering the 'expected at least one input' error in ReduceOp::verify(). The companion 'expected at least one output' check was dead code: SameVariadicOperandSize fires first whenever inputs.size() \!= inits.size(), and when both are empty the input check fires first; remove the unreachable branch.

Assisted-by: Claude Code