### PR TITLE
[lldb] Remove memory_tagged from MemoryRegionInfo

### DIFF
--- a/lldb/include/lldb/Target/MemoryRegionInfo.h
+++ b/lldb/include/lldb/Target/MemoryRegionInfo.h
@@ -28,10 +28,10 @@ public:
   MemoryRegionInfo(RangeType range, OptionalBool read, OptionalBool write,
                    OptionalBool execute, OptionalBool shared,
                    OptionalBool mapped, ConstString name, OptionalBool flash,
-                   lldb::offset_t blocksize, OptionalBool memory_tagged)
+                   lldb::offset_t blocksize)
       : m_range(range), m_read(read), m_write(write), m_execute(execute),
         m_shared(shared), m_mapped(mapped), m_name(name), m_flash(flash),
-        m_blocksize(blocksize), m_memory_tagged(memory_tagged) {}
+        m_blocksize(blocksize) {}
 
   RangeType &GetRange() { return m_range; }
 
@@ -75,7 +75,10 @@ public:
 
   void SetBlocksize(lldb::offset_t blocksize) { m_blocksize = blocksize; }
 
-  void SetMemoryTagged(OptionalBool val) { m_memory_tagged = val; }
+  MemoryRegionInfo &SetMemoryTagged(OptionalBool val) {
+    m_memory_tagged = val;
+    return *this;
+  }
 
   MemoryRegionInfo &SetIsShadowStack(OptionalBool val) {
     m_is_shadow_stack = val;

--- a/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
+++ b/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
@@ -91,8 +91,7 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  ConstString("[abc]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
             },
             "unexpected /proc/{pid}/maps exec permission char"),
         // Single entry
@@ -103,8 +102,7 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[heap]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
             },
             ""),
         // Multiple entries
@@ -118,21 +116,18 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
                 MemoryRegionInfo(make_range(0x7fc094000000, 0x7fc094a00000),
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
                 MemoryRegionInfo(
                     make_range(0xffffffffff600000, 0xffffffffff601000),
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, ConstString("[vsyscall]"),
-                    MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, 0),
             },
             "")));
 
@@ -157,8 +152,7 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
             },
             "malformed /proc/{pid}/smaps entry, missing dash between address "
             "range"),
@@ -177,8 +171,7 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
             },
             ""),
         // Single shared region parses, has no flags
@@ -189,8 +182,7 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
             },
             ""),
         // Single region with flags, other lines ignored
@@ -204,9 +196,9 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eYes)
-                    .SetIsShadowStack(MemoryRegionInfo::eNo),
+                                 MemoryRegionInfo::eDontKnow, 0)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo)
+                    .SetMemoryTagged(MemoryRegionInfo::eYes),
             },
             ""),
         // Whitespace ignored
@@ -218,9 +210,9 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eYes)
-                    .SetIsShadowStack(MemoryRegionInfo::eNo),
+                                 MemoryRegionInfo::eDontKnow, 0)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo)
+                    .SetMemoryTagged(MemoryRegionInfo::eYes),
             },
             ""),
         // VmFlags line means it has flag info, but nothing is set
@@ -232,9 +224,9 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eNo)
-                    .SetIsShadowStack(MemoryRegionInfo::eNo),
+                                 MemoryRegionInfo::eDontKnow, 0)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo)
+                    .SetMemoryTagged(MemoryRegionInfo::eNo),
             },
             ""),
         // Handle some pages not having a flags line
@@ -249,15 +241,14 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
                 MemoryRegionInfo(make_range(0x3333, 0x4444),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[bar]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eYes)
-                    .SetIsShadowStack(MemoryRegionInfo::eNo),
+                                 MemoryRegionInfo::eDontKnow, 0)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo)
+                    .SetMemoryTagged(MemoryRegionInfo::eYes),
             },
             ""),
         // Handle no pages having a flags line (older kernels)
@@ -273,14 +264,12 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
                 MemoryRegionInfo(make_range(0x3333, 0x4444),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
             },
             ""),
         // We must look for exact flag strings, ignoring substrings of longer
@@ -293,9 +282,9 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eNo)
-                    .SetIsShadowStack(MemoryRegionInfo::eNo),
+                                 MemoryRegionInfo::eDontKnow, 0)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo)
+                    .SetMemoryTagged(MemoryRegionInfo::eNo),
             },
             ""),
         // "ss" means shadow stack.
@@ -307,9 +296,9 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eNo)
-                    .SetIsShadowStack(MemoryRegionInfo::eYes),
+                                 MemoryRegionInfo::eDontKnow, 0)
+                    .SetIsShadowStack(MemoryRegionInfo::eYes)
+                    .SetMemoryTagged(MemoryRegionInfo::eNo),
             },
             "")));
 

--- a/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
+++ b/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
@@ -230,12 +230,12 @@ TEST(MemoryTagManagerAArch64MTETest, ExpandToGranule) {
 
 static MemoryRegionInfo MakeRegionInfo(lldb::addr_t base, lldb::addr_t size,
                                        bool tagged) {
-  return MemoryRegionInfo(
-      MemoryRegionInfo::RangeType(base, size), MemoryRegionInfo::eYes,
-      MemoryRegionInfo::eYes, MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-      MemoryRegionInfo::eYes, ConstString(), MemoryRegionInfo::eNo, 0,
-      /*memory_tagged=*/
-      tagged ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo);
+  return MemoryRegionInfo(MemoryRegionInfo::RangeType(base, size),
+                          MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                          MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                          MemoryRegionInfo::eYes, ConstString(),
+                          MemoryRegionInfo::eNo, 0)
+      .SetMemoryTagged(tagged ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo);
 }
 
 TEST(MemoryTagManagerAArch64MTETest, MakeTaggedRange) {

--- a/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
+++ b/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
@@ -385,15 +385,15 @@ Streams:
       testing::Pair(
           testing::ElementsAre(
               MemoryRegionInfo({0x0, 0x10000}, no, no, no, unknown, no,
-                               ConstString(), unknown, 0, unknown),
+                               ConstString(), unknown, 0),
               MemoryRegionInfo({0x10000, 0x21000}, yes, yes, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown),
+                               ConstString(), unknown, 0),
               MemoryRegionInfo({0x40000, 0x1000}, yes, no, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown),
+                               ConstString(), unknown, 0),
               MemoryRegionInfo({0x7ffe0000, 0x1000}, yes, no, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown),
+                               ConstString(), unknown, 0),
               MemoryRegionInfo({0x7ffe1000, 0xf000}, no, no, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown)),
+                               ConstString(), unknown, 0)),
           true));
 }
 
@@ -419,9 +419,9 @@ Streams:
       testing::Pair(
           testing::ElementsAre(
               MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0, unknown),
+                               yes, ConstString(), unknown, 0),
               MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0, unknown)),
+                               yes, ConstString(), unknown, 0)),
           false));
 }
 
@@ -435,9 +435,9 @@ TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemory64List) {
       testing::Pair(
           testing::ElementsAre(
               MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0, unknown),
+                               yes, ConstString(), unknown, 0),
               MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0, unknown)),
+                               yes, ConstString(), unknown, 0)),
           false));
 }
 
@@ -462,22 +462,22 @@ Streams:
   ConstString app_process("/system/bin/app_process");
   ConstString linker("/system/bin/linker");
   ConstString liblog("/system/lib/liblog.so");
-  EXPECT_THAT(parser->BuildMemoryRegions(),
-              testing::Pair(
-                  testing::ElementsAre(
-                      MemoryRegionInfo({0x400d9000, 0x2000}, yes, no, yes, no,
-                                       yes, app_process, unknown, 0, unknown),
-                      MemoryRegionInfo({0x400db000, 0x1000}, yes, no, no, no,
-                                       yes, app_process, unknown, 0, unknown),
-                      MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes, no, no,
-                                       yes, ConstString(), unknown, 0, unknown),
-                      MemoryRegionInfo({0x400ec000, 0x1000}, yes, no, no, no,
-                                       yes, ConstString(), unknown, 0, unknown),
-                      MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes, no, no,
-                                       yes, linker, unknown, 0, unknown),
-                      MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes, yes, no,
-                                       yes, liblog, unknown, 0, unknown)),
-                  true));
+  EXPECT_THAT(
+      parser->BuildMemoryRegions(),
+      testing::Pair(testing::ElementsAre(
+                        MemoryRegionInfo({0x400d9000, 0x2000}, yes, no, yes, no,
+                                         yes, app_process, unknown, 0),
+                        MemoryRegionInfo({0x400db000, 0x1000}, yes, no, no, no,
+                                         yes, app_process, unknown, 0),
+                        MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes, no, no,
+                                         yes, ConstString(), unknown, 0),
+                        MemoryRegionInfo({0x400ec000, 0x1000}, yes, no, no, no,
+                                         yes, ConstString(), unknown, 0),
+                        MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes, no, no,
+                                         yes, linker, unknown, 0),
+                        MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes, yes,
+                                         no, yes, liblog, unknown, 0)),
+                    true));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoLinuxMapsError) {
@@ -496,7 +496,7 @@ Streams:
   EXPECT_THAT(parser->BuildMemoryRegions(),
               testing::Pair(testing::ElementsAre(MemoryRegionInfo(
                                 {0x400fc000, 0x1000}, yes, yes, yes, no, yes,
-                                ConstString(nullptr), unknown, 0, unknown)),
+                                ConstString(nullptr), unknown, 0)),
                             true));
 }
 


### PR DESCRIPTION
By turning SetMemoryTagged into a builder method (returns a reference to self). Then only using that in the tests that need to change the default of "don't know".