### PR TITLE
[SPIR-V] Fix OpVectorExtractDynamic operand type

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
@@ -450,7 +450,7 @@ def OpRoundFToTF32INTEL : UnOp<"OpRoundFToTF32INTEL", 6426>;
 
 // 3.42.12 Composite Instructions
 
-def OpVectorExtractDynamic: Op<77, (outs ID:$res), (ins TYPE:$type, vID:$vec, ID:$idx),
+def OpVectorExtractDynamic: Op<77, (outs ID:$res), (ins TYPE:$type, ID:$vec, ID:$idx),
                   "$res = OpVectorExtractDynamic $type $vec $idx">;
 def OpVectorInsertDynamic: Op<78, (outs ID:$res), (ins TYPE:$ty, ID:$vec, ID:$comp, ID:$idx),
                   "$res = OpVectorInsertDynamic $ty $vec $comp $idx">;

--- a/llvm/test/CodeGen/SPIRV/instructions/vector-shuffle.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/vector-shuffle.ll
@@ -1,7 +1,4 @@
-; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
-
-; TODO: This test currently fails with LLVM_ENABLE_EXPENSIVE_CHECKS enabled
-; XFAIL: expensive_checks
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
 ; CHECK-DAG: OpName [[SHFv4:%.+]] "shuffle_v4"
 ; CHECK-DAG: OpName [[INSv4:%.+]] "insert_v4"

--- a/llvm/test/CodeGen/SPIRV/instructions/vector-shuffle.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/vector-shuffle.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-DAG: OpName [[SHFv4:%.+]] "shuffle_v4"
 ; CHECK-DAG: OpName [[INSv4:%.+]] "insert_v4"

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpVectorExtractDynamic.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpVectorExtractDynamic.ll
@@ -1,7 +1,4 @@
-; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-
-; TODO: This test currently fails with LLVM_ENABLE_EXPENSIVE_CHECKS enabled
-; XFAIL: expensive_checks
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; CHECK-SPIRV: OpName %[[#vec:]] "vec"
 ; CHECK-SPIRV: OpName %[[#index:]] "index"

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpVectorExtractDynamic.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpVectorExtractDynamic.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-SPIRV: OpName %[[#vec:]] "vec"
 ; CHECK-SPIRV: OpName %[[#index:]] "index"


### PR DESCRIPTION
vID is a register class for integer vector registers only. vfID (float vector registers) should be also accepted. Aligning the definition with other instructions of this kind

related to #188703 