### PR TITLE
[lldb] Remove "flash" and "blocksize" from MemoryRegionInfo constructor

### DIFF
--- a/lldb/include/lldb/Target/MemoryRegionInfo.h
+++ b/lldb/include/lldb/Target/MemoryRegionInfo.h
@@ -27,11 +27,9 @@ public:
   MemoryRegionInfo() = default;
   MemoryRegionInfo(RangeType range, OptionalBool read, OptionalBool write,
                    OptionalBool execute, OptionalBool shared,
-                   OptionalBool mapped, ConstString name, OptionalBool flash,
-                   lldb::offset_t blocksize)
+                   OptionalBool mapped, ConstString name)
       : m_range(range), m_read(read), m_write(write), m_execute(execute),
-        m_shared(shared), m_mapped(mapped), m_name(name), m_flash(flash),
-        m_blocksize(blocksize) {}
+        m_shared(shared), m_mapped(mapped), m_name(name) {}
 
   RangeType &GetRange() { return m_range; }
 

--- a/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
+++ b/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
@@ -90,8 +90,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0, 1), MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 ConstString("[abc]"),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 ConstString("[abc]")),
             },
             "unexpected /proc/{pid}/maps exec permission char"),
         // Single entry
@@ -101,8 +100,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x55a4512f7000, 0x55a451b68000),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[heap]"),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString("[heap]")),
             },
             ""),
         // Multiple entries
@@ -115,19 +113,16 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x7fc090021000, 0x7fc094000000),
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString(nullptr)),
                 MemoryRegionInfo(make_range(0x7fc094000000, 0x7fc094a00000),
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString(nullptr)),
                 MemoryRegionInfo(
                     make_range(0xffffffffff600000, 0xffffffffff601000),
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eYes, ConstString("[vsyscall]"),
-                    MemoryRegionInfo::eDontKnow, 0),
+                    MemoryRegionInfo::eYes, ConstString("[vsyscall]")),
             },
             "")));
 
@@ -151,8 +146,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString("[foo]")),
             },
             "malformed /proc/{pid}/smaps entry, missing dash between address "
             "range"),
@@ -170,8 +164,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString("[foo]")),
             },
             ""),
         // Single shared region parses, has no flags
@@ -181,8 +174,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString("[foo]")),
             },
             ""),
         // Single region with flags, other lines ignored
@@ -195,8 +187,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0)
+                                 MemoryRegionInfo::eYes, ConstString("[foo]"))
                     .SetIsShadowStack(MemoryRegionInfo::eNo)
                     .SetMemoryTagged(MemoryRegionInfo::eYes),
             },
@@ -209,8 +200,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0)
+                                 ConstString(nullptr))
                     .SetIsShadowStack(MemoryRegionInfo::eNo)
                     .SetMemoryTagged(MemoryRegionInfo::eYes),
             },
@@ -223,8 +213,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0)
+                                 ConstString(nullptr))
                     .SetIsShadowStack(MemoryRegionInfo::eNo)
                     .SetMemoryTagged(MemoryRegionInfo::eNo),
             },
@@ -240,13 +229,11 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString("[foo]")),
                 MemoryRegionInfo(make_range(0x3333, 0x4444),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[bar]"),
-                                 MemoryRegionInfo::eDontKnow, 0)
+                                 MemoryRegionInfo::eYes, ConstString("[bar]"))
                     .SetIsShadowStack(MemoryRegionInfo::eNo)
                     .SetMemoryTagged(MemoryRegionInfo::eYes),
             },
@@ -263,13 +250,11 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString(nullptr)),
                 MemoryRegionInfo(make_range(0x3333, 0x4444),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString(nullptr)),
             },
             ""),
         // We must look for exact flag strings, ignoring substrings of longer
@@ -281,8 +266,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0)
+                                 ConstString(nullptr))
                     .SetIsShadowStack(MemoryRegionInfo::eNo)
                     .SetMemoryTagged(MemoryRegionInfo::eNo),
             },
@@ -295,8 +279,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0)
+                                 ConstString(nullptr))
                     .SetIsShadowStack(MemoryRegionInfo::eYes)
                     .SetMemoryTagged(MemoryRegionInfo::eNo),
             },

--- a/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
+++ b/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
@@ -233,8 +233,7 @@ static MemoryRegionInfo MakeRegionInfo(lldb::addr_t base, lldb::addr_t size,
   return MemoryRegionInfo(MemoryRegionInfo::RangeType(base, size),
                           MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                           MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                          MemoryRegionInfo::eYes, ConstString(),
-                          MemoryRegionInfo::eNo, 0)
+                          MemoryRegionInfo::eYes, ConstString())
       .SetMemoryTagged(tagged ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo);
 }
 

--- a/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
+++ b/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
@@ -382,19 +382,18 @@ Streams:
 
   EXPECT_THAT(
       parser->BuildMemoryRegions(),
-      testing::Pair(
-          testing::ElementsAre(
-              MemoryRegionInfo({0x0, 0x10000}, no, no, no, unknown, no,
-                               ConstString(), unknown, 0),
-              MemoryRegionInfo({0x10000, 0x21000}, yes, yes, no, unknown, yes,
-                               ConstString(), unknown, 0),
-              MemoryRegionInfo({0x40000, 0x1000}, yes, no, no, unknown, yes,
-                               ConstString(), unknown, 0),
-              MemoryRegionInfo({0x7ffe0000, 0x1000}, yes, no, no, unknown, yes,
-                               ConstString(), unknown, 0),
-              MemoryRegionInfo({0x7ffe1000, 0xf000}, no, no, no, unknown, yes,
-                               ConstString(), unknown, 0)),
-          true));
+      testing::Pair(testing::ElementsAre(
+                        MemoryRegionInfo({0x0, 0x10000}, no, no, no, unknown,
+                                         no, ConstString()),
+                        MemoryRegionInfo({0x10000, 0x21000}, yes, yes, no,
+                                         unknown, yes, ConstString()),
+                        MemoryRegionInfo({0x40000, 0x1000}, yes, no, no,
+                                         unknown, yes, ConstString()),
+                        MemoryRegionInfo({0x7ffe0000, 0x1000}, yes, no, no,
+                                         unknown, yes, ConstString()),
+                        MemoryRegionInfo({0x7ffe1000, 0xf000}, no, no, no,
+                                         unknown, yes, ConstString())),
+                    true));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemoryList) {
@@ -416,13 +415,12 @@ Streams:
 
   EXPECT_THAT(
       parser->BuildMemoryRegions(),
-      testing::Pair(
-          testing::ElementsAre(
-              MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0),
-              MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0)),
-          false));
+      testing::Pair(testing::ElementsAre(
+                        MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown,
+                                         unknown, yes, ConstString()),
+                        MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown,
+                                         unknown, yes, ConstString())),
+                    false));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemory64List) {
@@ -432,13 +430,12 @@ TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemory64List) {
   // we don't have a MemoryInfoListStream.
   EXPECT_THAT(
       parser->BuildMemoryRegions(),
-      testing::Pair(
-          testing::ElementsAre(
-              MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0),
-              MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0)),
-          false));
+      testing::Pair(testing::ElementsAre(
+                        MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown,
+                                         unknown, yes, ConstString()),
+                        MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown,
+                                         unknown, yes, ConstString())),
+                    false));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoLinuxMaps) {
@@ -462,22 +459,21 @@ Streams:
   ConstString app_process("/system/bin/app_process");
   ConstString linker("/system/bin/linker");
   ConstString liblog("/system/lib/liblog.so");
-  EXPECT_THAT(
-      parser->BuildMemoryRegions(),
-      testing::Pair(testing::ElementsAre(
-                        MemoryRegionInfo({0x400d9000, 0x2000}, yes, no, yes, no,
-                                         yes, app_process, unknown, 0),
-                        MemoryRegionInfo({0x400db000, 0x1000}, yes, no, no, no,
-                                         yes, app_process, unknown, 0),
-                        MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes, no, no,
-                                         yes, ConstString(), unknown, 0),
-                        MemoryRegionInfo({0x400ec000, 0x1000}, yes, no, no, no,
-                                         yes, ConstString(), unknown, 0),
-                        MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes, no, no,
-                                         yes, linker, unknown, 0),
-                        MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes, yes,
-                                         no, yes, liblog, unknown, 0)),
-                    true));
+  EXPECT_THAT(parser->BuildMemoryRegions(),
+              testing::Pair(testing::ElementsAre(
+                                MemoryRegionInfo({0x400d9000, 0x2000}, yes, no,
+                                                 yes, no, yes, app_process),
+                                MemoryRegionInfo({0x400db000, 0x1000}, yes, no,
+                                                 no, no, yes, app_process),
+                                MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes,
+                                                 no, no, yes, ConstString()),
+                                MemoryRegionInfo({0x400ec000, 0x1000}, yes, no,
+                                                 no, no, yes, ConstString()),
+                                MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes,
+                                                 no, no, yes, linker),
+                                MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes,
+                                                 yes, no, yes, liblog)),
+                            true));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoLinuxMapsError) {
@@ -496,7 +492,7 @@ Streams:
   EXPECT_THAT(parser->BuildMemoryRegions(),
               testing::Pair(testing::ElementsAre(MemoryRegionInfo(
                                 {0x400fc000, 0x1000}, yes, yes, yes, no, yes,
-                                ConstString(nullptr), unknown, 0)),
+                                ConstString(nullptr))),
                             true));
 }
 


### PR DESCRIPTION
These are only set to non-default values after calling a constructor. Removing them removes noise from many tests that make MemoryRegionInfos.