### PR TITLE
Triple: Expose parseArch as a public method

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -1384,6 +1384,10 @@ public:
   /// The canonical type for the given LLVM architecture name (e.g., "x86").
   LLVM_ABI static ArchType getArchTypeForLLVMName(StringRef Str);
 
+  /// Parse anything recognized as an architecture for the first field of the
+  /// triple.
+  LLVM_ABI static ArchType parseArch(StringRef Str);
+
   /// @}
 
   /// Returns a canonicalized OS version number for the specified OS.

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -592,7 +592,7 @@ static Triple::ArchType parseARMArch(StringRef ArchName) {
   return arch;
 }
 
-static Triple::ArchType parseArch(StringRef ArchName) {
+Triple::ArchType Triple::parseArch(StringRef ArchName) {
   auto AT =
       StringSwitch<Triple::ArchType>(ArchName)
           .Cases({"i386", "i486", "i586", "i686"}, Triple::x86)


### PR DESCRIPTION
Clang has some code which is doing a direct arch name
string compare which should really be recognizing anything
usable as a triple architecture. It makes more sense to
directly parse the architecture than to construct a temporary
triple just to see what the parsed arch is.

For some reason the existing public parsing method is
getArchTypeForLLVMName. I'm not fully sure what the difference between
the 2 is supposed to be. My current guess is getArchTypeForLLVMName is
only supposed to handle the canonical architecture name.