### PR TITLE
OpenMP: Match all Triple recognized arch aliases

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -1384,6 +1384,10 @@ public:
   /// The canonical type for the given LLVM architecture name (e.g., "x86").
   LLVM_ABI static ArchType getArchTypeForLLVMName(StringRef Str);
 
+  /// Parse anything recognized as an architecture for the first field of the
+  /// triple.
+  LLVM_ABI static ArchType parseArch(StringRef Str);
+
   /// @}
 
   /// Returns a canonicalized OS version number for the specified OS.

--- a/llvm/lib/Frontend/OpenMP/OMPContext.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPContext.cpp
@@ -61,11 +61,7 @@ OMPContext::OMPContext(bool IsDeviceCompilation, Triple TargetTriple,
     // Add the appropriate device architecture trait based on the triple.
 #define OMP_TRAIT_PROPERTY(Enum, TraitSetEnum, TraitSelectorEnum, Str)         \
   if (TraitSelector::TraitSelectorEnum == TraitSelector::target_device_arch) { \
-    if (TargetOffloadTriple.getArch() ==                                       \
-        TargetOffloadTriple.getArchTypeForLLVMName(Str))                       \
-      ActiveTraits.set(unsigned(TraitProperty::Enum));                         \
-    if (StringRef(Str) == "x86_64" &&                                          \
-        TargetOffloadTriple.getArch() == Triple::x86_64)                       \
+    if (TargetOffloadTriple.getArch() == Triple::parseArch(Str))               \
       ActiveTraits.set(unsigned(TraitProperty::Enum));                         \
   }
 #include "llvm/Frontend/OpenMP/OMPKinds.def"
@@ -111,10 +107,7 @@ OMPContext::OMPContext(bool IsDeviceCompilation, Triple TargetTriple,
 #define OMP_TRAIT_PROPERTY(Enum, TraitSetEnum, TraitSelectorEnum, Str)         \
   if (TraitSelector::TraitSelectorEnum == TraitSelector::device_arch ||        \
       TraitSelector::TraitSelectorEnum == TraitSelector::target_device_arch) { \
-    if (TargetTriple.getArch() == TargetTriple.getArchTypeForLLVMName(Str))    \
-      ActiveTraits.set(unsigned(TraitProperty::Enum));                         \
-    if (StringRef(Str) == "x86_64" &&                                          \
-        TargetTriple.getArch() == Triple::x86_64)                              \
+    if (TargetTriple.getArch() == Triple::parseArch(Str))                      \
       ActiveTraits.set(unsigned(TraitProperty::Enum));                         \
   }
 #include "llvm/Frontend/OpenMP/OMPKinds.def"

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -592,7 +592,7 @@ static Triple::ArchType parseARMArch(StringRef ArchName) {
   return arch;
 }
 
-static Triple::ArchType parseArch(StringRef ArchName) {
+Triple::ArchType Triple::parseArch(StringRef ArchName) {
   auto AT =
       StringSwitch<Triple::ArchType>(ArchName)
           .Cases({"i386", "i486", "i586", "i686"}, Triple::x86)


### PR DESCRIPTION
This liberalizes match(device = {arch(some_arch)} to recognize
other names for some_arch.

Previously this compared against getArchTypeForLLVMName, which
only matches a subset of names (which seems to be the canonical
architecture names). There was a special case hack for "x86_64",
which is one of the "x86-64" aliases accepted by parseArch, but is
not the canonical architecture name.