### PR TITLE
[JumpThreading][DRAFT][Experiment] Set different limits for PHIs to JumpThreading

### DIFF
--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -101,6 +101,11 @@ static cl::opt<unsigned> PhiDuplicateThreshold(
     cl::desc("Max PHIs in BB to duplicate for jump threading"), cl::init(76),
     cl::Hidden);
 
+static cl::opt<unsigned>
+    UsesRenameThreshold("jump-threading-rename-threshold",
+                        cl::desc("Max renaming uses in BB for jump threading"),
+                        cl::init(400), cl::Hidden);
+
 static cl::opt<bool> ThreadAcrossLoopHeaders(
     "jump-threading-across-loop-headers",
     cl::desc("Allow JumpThreading to thread across loop headers, for testing"),
@@ -432,8 +437,8 @@ static unsigned getJumpThreadDuplicationCost(const TargetTransformInfo *TTI,
   assert(StopAt->getParent() == BB && "Not an instruction from proper BB?");
 
   // Do not duplicate the BB if it has a lot of PHI nodes.
-  // If a threadable chain is too long then the number of PHI nodes can add up,
-  // leading to a substantial increase in compile time when rewriting the SSA.
+  // If a threadable chain is too long then the number of PHI nodes can add
+  // up, leading to an increase in compile time.
   unsigned PhiCount = 0;
   Instruction *FirstNonPHI = nullptr;
   for (Instruction &I : *BB) {
@@ -443,6 +448,23 @@ static unsigned getJumpThreadDuplicationCost(const TargetTransformInfo *TTI,
     }
     if (++PhiCount > PhiDuplicateThreshold)
       return ~0U;
+  }
+
+  // Scan all uses of this instruction to see if it is used outside its block,
+  // as that could introduce additional PHI nodes when rewriting the SSA, which
+  // would lead to a substantial increase in compile time.
+  unsigned UsesToRenameCount = 0;
+  for (Instruction &I : *BB) {
+    for (Use &U : I.uses()) {
+      Instruction *User = cast<Instruction>(U.getUser());
+      if (PHINode *UserPN = dyn_cast<PHINode>(User)) {
+        if (UserPN->getIncomingBlock(U) == BB)
+          continue;
+      } else if (User->getParent() == BB)
+        continue;
+      if (++UsesToRenameCount > UsesRenameThreshold)
+        return ~0U;
+    }
   }
 
   /// Ignore PHI nodes, these will be flattened when duplication happens.

--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -81,6 +81,8 @@ using namespace jumpthreading;
 #define DEBUG_TYPE "jump-threading"
 
 STATISTIC(NumThreads, "Number of jumps threaded");
+STATISTIC(MaxRenamingUsesInBB, "Max number of renaming uses in one BB");
+STATISTIC(NumRenamingUses, "Number of renaming uses");
 STATISTIC(NumFolds,   "Number of terminators folded");
 STATISTIC(NumDupes,   "Number of branch blocks duplicated to eliminate phi");
 
@@ -2000,6 +2002,7 @@ void JumpThreadingPass::updateSSA(BasicBlock *BB, BasicBlock *NewBB,
   SSAUpdater SSAUpdate;
   SmallVector<Use *, 16> UsesToRename;
   SmallVector<DbgVariableRecord *, 4> DbgVariableRecords;
+  unsigned RewriteUseCountInBB = 0;
 
   for (Instruction &I : *BB) {
     // Scan all uses of this instruction to see if it is used outside of its
@@ -2025,6 +2028,7 @@ void JumpThreadingPass::updateSSA(BasicBlock *BB, BasicBlock *NewBB,
     if (UsesToRename.empty() && DbgVariableRecords.empty())
       continue;
     LLVM_DEBUG(dbgs() << "JT: Renaming non-local uses of: " << I << "\n");
+    RewriteUseCountInBB += UsesToRename.size();
 
     // We found a use of I outside of BB.  Rename all uses of I that are outside
     // its block to be uses of the appropriate PHI node etc.  See ValuesInBlocks
@@ -2042,6 +2046,9 @@ void JumpThreadingPass::updateSSA(BasicBlock *BB, BasicBlock *NewBB,
 
     LLVM_DEBUG(dbgs() << "\n");
   }
+  if (RewriteUseCountInBB > MaxRenamingUsesInBB)
+    MaxRenamingUsesInBB = RewriteUseCountInBB;
+  NumRenamingUses += RewriteUseCountInBB;
 }
 
 static void remapSourceAtoms(ValueToValueMapTy &VM, BasicBlock::iterator Begin,

--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -106,7 +106,7 @@ static cl::opt<unsigned> PhiDuplicateThreshold(
 static cl::opt<unsigned>
     UsesRenameThreshold("jump-threading-rename-threshold",
                         cl::desc("Max renaming uses in BB for jump threading"),
-                        cl::init(400), cl::Hidden);
+                        cl::init(800), cl::Hidden);
 
 static cl::opt<bool> ThreadAcrossLoopHeaders(
     "jump-threading-across-loop-headers",
@@ -432,25 +432,32 @@ static bool replaceFoldableUses(Instruction *Cond, Value *ToVal,
 /// Return the cost of duplicating a piece of this block from first non-phi
 /// and before StopAt instruction to thread across it. Stop scanning the block
 /// when exceeding the threshold. If duplication is impossible, returns ~0U.
-static unsigned getJumpThreadDuplicationCost(const TargetTransformInfo *TTI,
-                                             BasicBlock *BB,
-                                             Instruction *StopAt,
-                                             unsigned Threshold) {
+static unsigned
+getJumpThreadDuplicationCost(const TargetTransformInfo *TTI, BasicBlock *BB,
+                             const SmallVectorImpl<BasicBlock *> &PredBBs,
+                             Instruction *StopAt, unsigned Threshold) {
   assert(StopAt->getParent() == BB && "Not an instruction from proper BB?");
 
   // Do not duplicate the BB if it has a lot of PHI nodes.
   // If a threadable chain is too long then the number of PHI nodes can add
   // up, leading to an increase in compile time.
-  unsigned PhiCount = 0;
-  Instruction *FirstNonPHI = nullptr;
-  for (Instruction &I : *BB) {
-    if (!isa<PHINode>(&I)) {
-      FirstNonPHI = &I;
-      break;
+  // If there is only one predecessor, no PHI nodes will be duplicated.
+  if (PredBBs.size() > 1) {
+    unsigned PhiCount = 0;
+    for (PHINode &PHI : BB->phis()) {
+      Value *IncomingVal = PHI.getIncomingValueForBlock(PredBBs[0]);
+      // If all incoming values are the same value from predecessors, the PHI
+      // node is not duplicated.
+      if (llvm::all_of(
+              drop_begin(PredBBs), [&PHI, IncomingVal](const BasicBlock *Pred) {
+                return PHI.getIncomingValueForBlock(Pred) == IncomingVal;
+              })) {
+        continue;
+      }
+      if (++PhiCount > PhiDuplicateThreshold)
+        return ~0U;
     }
-    if (++PhiCount > PhiDuplicateThreshold)
-      return ~0U;
-  }
+  };
 
   // Scan all uses of this instruction to see if it is used outside its block,
   // as that could introduce additional PHI nodes when rewriting the SSA, which
@@ -470,7 +477,7 @@ static unsigned getJumpThreadDuplicationCost(const TargetTransformInfo *TTI,
   }
 
   /// Ignore PHI nodes, these will be flattened when duplication happens.
-  BasicBlock::const_iterator I(FirstNonPHI);
+  BasicBlock::const_iterator I(BB->getFirstNonPHIIt());
 
   // FIXME: THREADING will delete values that are just used to compute the
   // branch, so they shouldn't count against the duplication cost.
@@ -2272,11 +2279,15 @@ bool JumpThreadingPass::maybethreadThroughTwoBasicBlocks(BasicBlock *BB,
     return false;
   }
 
+  SmallVector<BasicBlock *, 1> PredPredBBs;
+  PredPredBBs.push_back(PredPredBB);
+  SmallVector<BasicBlock *, 1> PredBBs;
+  PredBBs.push_back(PredBB);
   // Compute the cost of duplicating BB and PredBB.
   unsigned BBCost = getJumpThreadDuplicationCost(
-      TTI, BB, BB->getTerminator(), BBDupThreshold);
+      TTI, BB, PredBBs, BB->getTerminator(), BBDupThreshold);
   unsigned PredBBCost = getJumpThreadDuplicationCost(
-      TTI, PredBB, PredBB->getTerminator(), BBDupThreshold);
+      TTI, PredBB, PredPredBBs, PredBB->getTerminator(), BBDupThreshold);
 
   // Give up if costs are too high.  We need to check BBCost and PredBBCost
   // individually before checking their sum because getJumpThreadDuplicationCost
@@ -2395,7 +2406,7 @@ bool JumpThreadingPass::tryThreadEdge(
   }
 
   unsigned JumpThreadCost = getJumpThreadDuplicationCost(
-      TTI, BB, BB->getTerminator(), BBDupThreshold);
+      TTI, BB, PredBBs, BB->getTerminator(), BBDupThreshold);
   if (JumpThreadCost > BBDupThreshold) {
     LLVM_DEBUG(dbgs() << "  Not threading BB '" << BB->getName()
                       << "' - Cost is too high: " << JumpThreadCost << "\n");
@@ -2669,7 +2680,7 @@ bool JumpThreadingPass::duplicateCondBranchOnPHIIntoPred(
   }
 
   unsigned DuplicationCost = getJumpThreadDuplicationCost(
-      TTI, BB, BB->getTerminator(), BBDupThreshold);
+      TTI, BB, PredBBs, BB->getTerminator(), BBDupThreshold);
   if (DuplicationCost > BBDupThreshold) {
     LLVM_DEBUG(dbgs() << "  Not duplicating BB '" << BB->getName()
                       << "' - Cost is too high: " << DuplicationCost << "\n");
@@ -3154,8 +3165,11 @@ bool JumpThreadingPass::threadGuard(BasicBlock *BB, IntrinsicInst *Guard,
 
   ValueToValueMapTy UnguardedMapping, GuardedMapping;
   Instruction *AfterGuard = Guard->getNextNode();
-  unsigned Cost =
-      getJumpThreadDuplicationCost(TTI, BB, AfterGuard, BBDupThreshold);
+  SmallVector<BasicBlock *, 2> PredBBs;
+  PredBBs.push_back(PredUnguardedBlock);
+  PredBBs.push_back(PredGuardedBlock);
+  unsigned Cost = getJumpThreadDuplicationCost(TTI, BB, PredBBs, AfterGuard,
+                                               BBDupThreshold);
   if (Cost > BBDupThreshold)
     return false;
   // Duplicate all instructions before the guard and the guard itself to the

--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -108,6 +108,11 @@ static cl::opt<unsigned>
                         cl::desc("Max renaming uses in BB for jump threading"),
                         cl::init(800), cl::Hidden);
 
+static cl::opt<unsigned> UsesRenameBBThreshold(
+    "jump-threading-rename-bb-threshold",
+    cl::desc("Max BBs containing renaming uses for jump threading"),
+    cl::init(60), cl::Hidden);
+
 static cl::opt<bool> ThreadAcrossLoopHeaders(
     "jump-threading-across-loop-headers",
     cl::desc("Allow JumpThreading to thread across loop headers, for testing"),
@@ -463,6 +468,7 @@ getJumpThreadDuplicationCost(const TargetTransformInfo *TTI, BasicBlock *BB,
   // as that could introduce additional PHI nodes when rewriting the SSA, which
   // would lead to a substantial increase in compile time.
   unsigned UsesToRenameCount = 0;
+  SmallSet<BasicBlock *, 9> UseBBs;
   for (Instruction &I : *BB) {
     for (Use &U : I.uses()) {
       Instruction *User = cast<Instruction>(U.getUser());
@@ -472,6 +478,11 @@ getJumpThreadDuplicationCost(const TargetTransformInfo *TTI, BasicBlock *BB,
       } else if (User->getParent() == BB)
         continue;
       if (++UsesToRenameCount > UsesRenameThreshold)
+        return ~0U;
+      UseBBs.insert(User->getParent());
+      // Introducing additional PHI nodes to different BBs also lead to a
+      // substantial increase in compile time.
+      if (UseBBs.size() > UsesRenameBBThreshold)
         return ~0U;
     }
   }


### PR DESCRIPTION
The limit `-jump-threading-phi-threshold` doesn't seem to be what is expected. AFAIK, rewriting SSA compilation time is from the uses of the instruction if they are used outside the threaded BB. The phis in the BB are not related to those uses.

The new limit `-jump-threading-rename-threshold` should do the correct thing. However, I'm not sure of the root reason that results in huge compilation time for https://github.com/llvm/llvm-project/issues/58203. I think some jump threading transformations introduce more phis to other jump threading transformations, leading to an exponential increase.