### PR TITLE
clang: Check -Xarch compatibility using Triple parsed architecture.

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -2008,6 +2008,14 @@ void ToolChain::TranslateXarchArgs(
     AllocatedArgs->push_back(A);
 }
 
+/// Match any triple recognized arch aliases.
+static bool isXArchCompatibleTripleArch(const llvm::Triple &TT,
+                                        StringRef XArchVal) {
+  llvm::Triple ParsedTriple(XArchVal);
+  return TT.getArch() == ParsedTriple.getArch() &&
+         TT.getSubArch() == ParsedTriple.getSubArch();
+}
+
 llvm::opt::DerivedArgList *ToolChain::TranslateXarchArgs(
     const llvm::opt::DerivedArgList &Args, StringRef BoundArch,
     Action::OffloadKind OFK,
@@ -2028,9 +2036,8 @@ llvm::opt::DerivedArgList *ToolChain::TranslateXarchArgs(
     } else if (A->getOption().matches(options::OPT_Xarch__)) {
       StringRef Val = A->getValue();
       NeedTrans = Val == getArchName() ||
-                  (!BoundArch.empty() && A->getValue() == BoundArch) ||
-                  // Match any triple recognized arch aliases.
-                  Triple.getArch() == llvm::Triple::parseArch(Val);
+                  (!BoundArch.empty() && Val == BoundArch) ||
+                  isXArchCompatibleTripleArch(Triple, Val);
       Skip = !NeedTrans;
     }
     if (NeedTrans || Skip)

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -2026,8 +2026,11 @@ llvm::opt::DerivedArgList *ToolChain::TranslateXarchArgs(
       NeedTrans = !IsDevice;
       Skip = IsDevice;
     } else if (A->getOption().matches(options::OPT_Xarch__)) {
-      NeedTrans = A->getValue() == getArchName() ||
-                  (!BoundArch.empty() && A->getValue() == BoundArch);
+      StringRef Val = A->getValue();
+      NeedTrans = Val == getArchName() ||
+                  (!BoundArch.empty() && A->getValue() == BoundArch) ||
+                  // Match any triple recognized arch aliases.
+                  Triple.getArch() == llvm::Triple::parseArch(Val);
       Skip = !NeedTrans;
     }
     if (NeedTrans || Skip)

--- a/clang/test/Driver/Xarch.c
+++ b/clang/test/Driver/Xarch.c
@@ -20,5 +20,6 @@
 // LINKER: "foo"
 
 // RUN: %clang -target x86_64-unknown-linux-gnu -Xarch_x86_64 -O1 %s -S -### 2>&1 | FileCheck -check-prefix=O1ONCE %s
+// RUN: %clang -target x86_64-unknown-linux-gnu -Xarch_amd64 -O1 %s -S -### 2>&1 | FileCheck -check-prefix=O1ONCE %s
 // O1ONCE: "-O1"
 // O1ONCE-NOT: "-O1"


### PR DESCRIPTION
This will allow recognizing any of the triple aliases for the architecture.
This will avoid test failures when the amdgcn triple top level architecture
is renamed.