### PR TITLE
[lldb] Replace OptionalBool with LazyBool

### DIFF
--- a/lldb/include/lldb/Target/MemoryRegionInfo.h
+++ b/lldb/include/lldb/Target/MemoryRegionInfo.h
@@ -24,8 +24,8 @@ public:
 
   MemoryRegionInfo() = default;
   MemoryRegionInfo(RangeType range, LazyBool read, LazyBool write,
-                   LazyBool execute, LazyBool shared,
-                   LazyBool mapped, ConstString name)
+                   LazyBool execute, LazyBool shared, LazyBool mapped,
+                   ConstString name)
       : m_range(range), m_read(read), m_write(write), m_execute(execute),
         m_shared(shared), m_mapped(mapped), m_name(name) {}
 
@@ -97,9 +97,12 @@ public:
   // Set permissions from a uint32_t that contains one or more bits from the
   // lldb::Permissions
   void SetLLDBPermissions(uint32_t permissions) {
-    m_read = (permissions & lldb::ePermissionsReadable) ? eLazyBoolYes : eLazyBoolNo;
-    m_write = (permissions & lldb::ePermissionsWritable) ? eLazyBoolYes : eLazyBoolNo;
-    m_execute = (permissions & lldb::ePermissionsExecutable) ? eLazyBoolYes : eLazyBoolNo;
+    m_read =
+        (permissions & lldb::ePermissionsReadable) ? eLazyBoolYes : eLazyBoolNo;
+    m_write =
+        (permissions & lldb::ePermissionsWritable) ? eLazyBoolYes : eLazyBoolNo;
+    m_execute = (permissions & lldb::ePermissionsExecutable) ? eLazyBoolYes
+                                                             : eLazyBoolNo;
   }
 
   bool operator==(const MemoryRegionInfo &rhs) const {
@@ -189,8 +192,8 @@ template <>
 /// while "no" is printed as "-", and "don't know" as "?". This can be used to
 /// print the permissions in the traditional "rwx" form.
 struct format_provider<lldb_private::LazyBool> {
-  static void format(const lldb_private::LazyBool &B,
-                     raw_ostream &OS, StringRef Options);
+  static void format(const lldb_private::LazyBool &B, raw_ostream &OS,
+                     StringRef Options);
 };
 } // namespace llvm
 

--- a/lldb/include/lldb/Target/MemoryRegionInfo.h
+++ b/lldb/include/lldb/Target/MemoryRegionInfo.h
@@ -22,12 +22,10 @@ class MemoryRegionInfo {
 public:
   typedef Range<lldb::addr_t, lldb::addr_t> RangeType;
 
-  enum OptionalBool { eDontKnow = -1, eNo = 0, eYes = 1 };
-
   MemoryRegionInfo() = default;
-  MemoryRegionInfo(RangeType range, OptionalBool read, OptionalBool write,
-                   OptionalBool execute, OptionalBool shared,
-                   OptionalBool mapped, ConstString name)
+  MemoryRegionInfo(RangeType range, LazyBool read, LazyBool write,
+                   LazyBool execute, LazyBool shared,
+                   LazyBool mapped, ConstString name)
       : m_range(range), m_read(read), m_write(write), m_execute(execute),
         m_shared(shared), m_mapped(mapped), m_name(name) {}
 
@@ -37,48 +35,48 @@ public:
 
   const RangeType &GetRange() const { return m_range; }
 
-  OptionalBool GetReadable() const { return m_read; }
+  LazyBool GetReadable() const { return m_read; }
 
-  OptionalBool GetWritable() const { return m_write; }
+  LazyBool GetWritable() const { return m_write; }
 
-  OptionalBool GetExecutable() const { return m_execute; }
+  LazyBool GetExecutable() const { return m_execute; }
 
-  OptionalBool GetShared() const { return m_shared; }
+  LazyBool GetShared() const { return m_shared; }
 
-  OptionalBool GetMapped() const { return m_mapped; }
+  LazyBool GetMapped() const { return m_mapped; }
 
   ConstString GetName() const { return m_name; }
 
-  OptionalBool GetMemoryTagged() const { return m_memory_tagged; }
+  LazyBool GetMemoryTagged() const { return m_memory_tagged; }
 
-  OptionalBool IsShadowStack() const { return m_is_shadow_stack; }
+  LazyBool IsShadowStack() const { return m_is_shadow_stack; }
 
-  void SetReadable(OptionalBool val) { m_read = val; }
+  void SetReadable(LazyBool val) { m_read = val; }
 
-  void SetWritable(OptionalBool val) { m_write = val; }
+  void SetWritable(LazyBool val) { m_write = val; }
 
-  void SetExecutable(OptionalBool val) { m_execute = val; }
+  void SetExecutable(LazyBool val) { m_execute = val; }
 
-  void SetShared(OptionalBool val) { m_shared = val; }
+  void SetShared(LazyBool val) { m_shared = val; }
 
-  void SetMapped(OptionalBool val) { m_mapped = val; }
+  void SetMapped(LazyBool val) { m_mapped = val; }
 
   void SetName(const char *name) { m_name = ConstString(name); }
 
-  OptionalBool GetFlash() const { return m_flash; }
+  LazyBool GetFlash() const { return m_flash; }
 
-  void SetFlash(OptionalBool val) { m_flash = val; }
+  void SetFlash(LazyBool val) { m_flash = val; }
 
   lldb::offset_t GetBlocksize() const { return m_blocksize; }
 
   void SetBlocksize(lldb::offset_t blocksize) { m_blocksize = blocksize; }
 
-  MemoryRegionInfo &SetMemoryTagged(OptionalBool val) {
+  MemoryRegionInfo &SetMemoryTagged(LazyBool val) {
     m_memory_tagged = val;
     return *this;
   }
 
-  MemoryRegionInfo &SetIsShadowStack(OptionalBool val) {
+  MemoryRegionInfo &SetIsShadowStack(LazyBool val) {
     m_is_shadow_stack = val;
     return *this;
   }
@@ -87,11 +85,11 @@ public:
   // lldb::Permissions
   uint32_t GetLLDBPermissions() const {
     uint32_t permissions = 0;
-    if (m_read == eYes)
+    if (m_read == eLazyBoolYes)
       permissions |= lldb::ePermissionsReadable;
-    if (m_write == eYes)
+    if (m_write == eLazyBoolYes)
       permissions |= lldb::ePermissionsWritable;
-    if (m_execute == eYes)
+    if (m_execute == eLazyBoolYes)
       permissions |= lldb::ePermissionsExecutable;
     return permissions;
   }
@@ -99,9 +97,9 @@ public:
   // Set permissions from a uint32_t that contains one or more bits from the
   // lldb::Permissions
   void SetLLDBPermissions(uint32_t permissions) {
-    m_read = (permissions & lldb::ePermissionsReadable) ? eYes : eNo;
-    m_write = (permissions & lldb::ePermissionsWritable) ? eYes : eNo;
-    m_execute = (permissions & lldb::ePermissionsExecutable) ? eYes : eNo;
+    m_read = (permissions & lldb::ePermissionsReadable) ? eLazyBoolYes : eLazyBoolNo;
+    m_write = (permissions & lldb::ePermissionsWritable) ? eLazyBoolYes : eLazyBoolNo;
+    m_execute = (permissions & lldb::ePermissionsExecutable) ? eLazyBoolYes : eLazyBoolNo;
   }
 
   bool operator==(const MemoryRegionInfo &rhs) const {
@@ -131,9 +129,9 @@ public:
     return m_dirty_pages;
   }
 
-  OptionalBool IsStackMemory() const { return m_is_stack_memory; }
+  LazyBool IsStackMemory() const { return m_is_stack_memory; }
 
-  void SetIsStackMemory(OptionalBool val) { m_is_stack_memory = val; }
+  void SetIsStackMemory(LazyBool val) { m_is_stack_memory = val; }
 
   void SetPageSize(int pagesize) { m_pagesize = pagesize; }
 
@@ -145,17 +143,17 @@ public:
 
 protected:
   RangeType m_range;
-  OptionalBool m_read = eDontKnow;
-  OptionalBool m_write = eDontKnow;
-  OptionalBool m_execute = eDontKnow;
-  OptionalBool m_shared = eDontKnow;
-  OptionalBool m_mapped = eDontKnow;
+  LazyBool m_read = eLazyBoolDontKnow;
+  LazyBool m_write = eLazyBoolDontKnow;
+  LazyBool m_execute = eLazyBoolDontKnow;
+  LazyBool m_shared = eLazyBoolDontKnow;
+  LazyBool m_mapped = eLazyBoolDontKnow;
   ConstString m_name;
-  OptionalBool m_flash = eDontKnow;
+  LazyBool m_flash = eLazyBoolDontKnow;
   lldb::offset_t m_blocksize = 0;
-  OptionalBool m_memory_tagged = eDontKnow;
-  OptionalBool m_is_stack_memory = eDontKnow;
-  OptionalBool m_is_shadow_stack = eDontKnow;
+  LazyBool m_memory_tagged = eLazyBoolDontKnow;
+  LazyBool m_is_stack_memory = eLazyBoolDontKnow;
+  LazyBool m_is_shadow_stack = eLazyBoolDontKnow;
   int m_pagesize = 0;
   std::optional<std::vector<lldb::addr_t>> m_dirty_pages;
 };
@@ -190,8 +188,8 @@ template <>
 /// Options is a single character, it uses that character for the "yes" value,
 /// while "no" is printed as "-", and "don't know" as "?". This can be used to
 /// print the permissions in the traditional "rwx" form.
-struct format_provider<lldb_private::MemoryRegionInfo::OptionalBool> {
-  static void format(const lldb_private::MemoryRegionInfo::OptionalBool &B,
+struct format_provider<lldb_private::LazyBool> {
+  static void format(const lldb_private::LazyBool &B,
                      raw_ostream &OS, StringRef Options);
 };
 } // namespace llvm

--- a/lldb/include/lldb/lldb-private-enumerations.h
+++ b/lldb/include/lldb/lldb-private-enumerations.h
@@ -120,7 +120,11 @@ enum SortOrder {
 // LazyBool is for boolean values that need to be calculated lazily. Values
 // start off set to eLazyBoolCalculate, and then they can be calculated once
 // and set to eLazyBoolNo or eLazyBoolYes.
-enum LazyBool { eLazyBoolCalculate = -1, eLazyBoolNo = 0, eLazyBoolYes = 1 };
+//
+// eLazyBoolDontKnow is the same value as eLazyBoolCalculate but is used in
+// contexts where the calculation is always attempted, but may turn out to not
+// be possible.
+enum LazyBool { eLazyBoolCalculate = -1, eLazyBoolDontKnow = eLazyBoolCalculate, eLazyBoolNo = 0, eLazyBoolYes = 1 };
 
 /// Instruction types
 enum InstructionType {

--- a/lldb/include/lldb/lldb-private-enumerations.h
+++ b/lldb/include/lldb/lldb-private-enumerations.h
@@ -124,7 +124,12 @@ enum SortOrder {
 // eLazyBoolDontKnow is the same value as eLazyBoolCalculate but is used in
 // contexts where the calculation is always attempted, but may turn out to not
 // be possible.
-enum LazyBool { eLazyBoolCalculate = -1, eLazyBoolDontKnow = eLazyBoolCalculate, eLazyBoolNo = 0, eLazyBoolYes = 1 };
+enum LazyBool {
+  eLazyBoolCalculate = -1,
+  eLazyBoolDontKnow = eLazyBoolCalculate,
+  eLazyBoolNo = 0,
+  eLazyBoolYes = 1
+};
 
 /// Instruction types
 enum InstructionType {

--- a/lldb/source/API/SBMemoryRegionInfo.cpp
+++ b/lldb/source/API/SBMemoryRegionInfo.cpp
@@ -32,10 +32,8 @@ SBMemoryRegionInfo::SBMemoryRegionInfo(const char *name, lldb::addr_t begin,
   m_opaque_up->GetRange().SetRangeBase(begin);
   m_opaque_up->GetRange().SetRangeEnd(end);
   m_opaque_up->SetLLDBPermissions(permissions);
-  m_opaque_up->SetMapped(mapped ? eLazyBoolYes
-                                : eLazyBoolNo);
-  m_opaque_up->SetIsStackMemory(stack_memory ? eLazyBoolYes
-                                             : eLazyBoolNo);
+  m_opaque_up->SetMapped(mapped ? eLazyBoolYes : eLazyBoolNo);
+  m_opaque_up->SetIsStackMemory(stack_memory ? eLazyBoolYes : eLazyBoolNo);
 }
 
 SBMemoryRegionInfo::SBMemoryRegionInfo(const MemoryRegionInfo *lldb_object_ptr)

--- a/lldb/source/API/SBMemoryRegionInfo.cpp
+++ b/lldb/source/API/SBMemoryRegionInfo.cpp
@@ -32,10 +32,10 @@ SBMemoryRegionInfo::SBMemoryRegionInfo(const char *name, lldb::addr_t begin,
   m_opaque_up->GetRange().SetRangeBase(begin);
   m_opaque_up->GetRange().SetRangeEnd(end);
   m_opaque_up->SetLLDBPermissions(permissions);
-  m_opaque_up->SetMapped(mapped ? MemoryRegionInfo::eYes
-                                : MemoryRegionInfo::eNo);
-  m_opaque_up->SetIsStackMemory(stack_memory ? MemoryRegionInfo::eYes
-                                             : MemoryRegionInfo::eNo);
+  m_opaque_up->SetMapped(mapped ? eLazyBoolYes
+                                : eLazyBoolNo);
+  m_opaque_up->SetIsStackMemory(stack_memory ? eLazyBoolYes
+                                             : eLazyBoolNo);
 }
 
 SBMemoryRegionInfo::SBMemoryRegionInfo(const MemoryRegionInfo *lldb_object_ptr)
@@ -97,25 +97,25 @@ lldb::addr_t SBMemoryRegionInfo::GetRegionEnd() {
 bool SBMemoryRegionInfo::IsReadable() {
   LLDB_INSTRUMENT_VA(this);
 
-  return m_opaque_up->GetReadable() == MemoryRegionInfo::eYes;
+  return m_opaque_up->GetReadable() == eLazyBoolYes;
 }
 
 bool SBMemoryRegionInfo::IsWritable() {
   LLDB_INSTRUMENT_VA(this);
 
-  return m_opaque_up->GetWritable() == MemoryRegionInfo::eYes;
+  return m_opaque_up->GetWritable() == eLazyBoolYes;
 }
 
 bool SBMemoryRegionInfo::IsExecutable() {
   LLDB_INSTRUMENT_VA(this);
 
-  return m_opaque_up->GetExecutable() == MemoryRegionInfo::eYes;
+  return m_opaque_up->GetExecutable() == eLazyBoolYes;
 }
 
 bool SBMemoryRegionInfo::IsMapped() {
   LLDB_INSTRUMENT_VA(this);
 
-  return m_opaque_up->GetMapped() == MemoryRegionInfo::eYes;
+  return m_opaque_up->GetMapped() == eLazyBoolYes;
 }
 
 const char *SBMemoryRegionInfo::GetName() {

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -1688,11 +1688,11 @@ protected:
         range_info.GetRange().GetRangeEnd(), range_info.GetReadable(),
         range_info.GetWritable(), range_info.GetExecutable(), name ? " " : "",
         name, section_name ? " " : "", section_name);
-    MemoryRegionInfo::OptionalBool memory_tagged = range_info.GetMemoryTagged();
-    if (memory_tagged == MemoryRegionInfo::OptionalBool::eYes)
+    LazyBool memory_tagged = range_info.GetMemoryTagged();
+    if (memory_tagged == eLazyBoolYes)
       result.AppendMessage("memory tagging: enabled");
-    MemoryRegionInfo::OptionalBool is_shadow_stack = range_info.IsShadowStack();
-    if (is_shadow_stack == MemoryRegionInfo::OptionalBool::eYes)
+    LazyBool is_shadow_stack = range_info.IsShadowStack();
+    if (is_shadow_stack == eLazyBoolYes)
       result.AppendMessage("shadow stack: yes");
 
     const std::optional<std::vector<addr_t>> &dirty_page_list =

--- a/lldb/source/Expression/IRMemoryMap.cpp
+++ b/lldb/source/Expression/IRMemoryMap.cpp
@@ -123,11 +123,11 @@ lldb::addr_t IRMemoryMap::FindSpace(size_t size) {
           // in the inferior.
           ret = region_info.GetRange().GetRangeEnd();
         } else if (region_info.GetReadable() !=
-                       MemoryRegionInfo::OptionalBool::eNo ||
+                       eLazyBoolNo ||
                    region_info.GetWritable() !=
-                       MemoryRegionInfo::OptionalBool::eNo ||
+                       eLazyBoolNo ||
                    region_info.GetExecutable() !=
-                       MemoryRegionInfo::OptionalBool::eNo) {
+                       eLazyBoolNo) {
           if (region_info.GetRange().GetRangeEnd() - 1 >= end_of_memory) {
             ret = LLDB_INVALID_ADDRESS;
             break;

--- a/lldb/source/Expression/IRMemoryMap.cpp
+++ b/lldb/source/Expression/IRMemoryMap.cpp
@@ -122,12 +122,9 @@ lldb::addr_t IRMemoryMap::FindSpace(size_t size) {
           // it can make it harder to debug null dereference crashes
           // in the inferior.
           ret = region_info.GetRange().GetRangeEnd();
-        } else if (region_info.GetReadable() !=
-                       eLazyBoolNo ||
-                   region_info.GetWritable() !=
-                       eLazyBoolNo ||
-                   region_info.GetExecutable() !=
-                       eLazyBoolNo) {
+        } else if (region_info.GetReadable() != eLazyBoolNo ||
+                   region_info.GetWritable() != eLazyBoolNo ||
+                   region_info.GetExecutable() != eLazyBoolNo) {
           if (region_info.GetRange().GetRangeEnd() - 1 >= end_of_memory) {
             ret = LLDB_INVALID_ADDRESS;
             break;

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -625,7 +625,7 @@ ModuleSP DynamicLoaderPOSIXDYLD::LoadInterpreterModule() {
   MemoryRegionInfo info;
   Target &target = m_process->GetTarget();
   Status status = m_process->GetMemoryRegionInfo(m_interpreter_base, info);
-  if (status.Fail() || info.GetMapped() != MemoryRegionInfo::eYes ||
+  if (status.Fail() || info.GetMapped() != eLazyBoolYes ||
       info.GetName().IsEmpty()) {
     Log *log = GetLog(LLDBLog::DynamicLoader);
     LLDB_LOG(log, "Failed to get interpreter region info: {0}", status);

--- a/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
@@ -615,10 +615,10 @@ Status NativeProcessFreeBSD::GetMemoryRegionInfo(lldb::addr_t load_addr,
       range_info.GetRange().SetRangeBase(load_addr);
       range_info.GetRange().SetByteSize(
           proc_entry_info.GetRange().GetRangeBase() - load_addr);
-      range_info.SetReadable(MemoryRegionInfo::OptionalBool::eNo);
-      range_info.SetWritable(MemoryRegionInfo::OptionalBool::eNo);
-      range_info.SetExecutable(MemoryRegionInfo::OptionalBool::eNo);
-      range_info.SetMapped(MemoryRegionInfo::OptionalBool::eNo);
+      range_info.SetReadable(eLazyBoolNo);
+      range_info.SetWritable(eLazyBoolNo);
+      range_info.SetExecutable(eLazyBoolNo);
+      range_info.SetMapped(eLazyBoolNo);
       return error;
     } else if (proc_entry_info.GetRange().Contains(load_addr)) {
       // The target address is within the memory region we're processing here.
@@ -633,10 +633,10 @@ Status NativeProcessFreeBSD::GetMemoryRegionInfo(lldb::addr_t load_addr,
   // load address and the end of the memory as size.
   range_info.GetRange().SetRangeBase(load_addr);
   range_info.GetRange().SetRangeEnd(LLDB_INVALID_ADDRESS);
-  range_info.SetReadable(MemoryRegionInfo::OptionalBool::eNo);
-  range_info.SetWritable(MemoryRegionInfo::OptionalBool::eNo);
-  range_info.SetExecutable(MemoryRegionInfo::OptionalBool::eNo);
-  range_info.SetMapped(MemoryRegionInfo::OptionalBool::eNo);
+  range_info.SetReadable(eLazyBoolNo);
+  range_info.SetWritable(eLazyBoolNo);
+  range_info.SetExecutable(eLazyBoolNo);
+  range_info.SetMapped(eLazyBoolNo);
   return error;
 }
 
@@ -680,22 +680,22 @@ Status NativeProcessFreeBSD::PopulateMemoryRegionCache() {
     info.Clear();
     info.GetRange().SetRangeBase(kv->kve_start);
     info.GetRange().SetRangeEnd(kv->kve_end);
-    info.SetMapped(MemoryRegionInfo::OptionalBool::eYes);
+    info.SetMapped(eLazyBoolYes);
 
     if (kv->kve_protection & VM_PROT_READ)
-      info.SetReadable(MemoryRegionInfo::OptionalBool::eYes);
+      info.SetReadable(eLazyBoolYes);
     else
-      info.SetReadable(MemoryRegionInfo::OptionalBool::eNo);
+      info.SetReadable(eLazyBoolNo);
 
     if (kv->kve_protection & VM_PROT_WRITE)
-      info.SetWritable(MemoryRegionInfo::OptionalBool::eYes);
+      info.SetWritable(eLazyBoolYes);
     else
-      info.SetWritable(MemoryRegionInfo::OptionalBool::eNo);
+      info.SetWritable(eLazyBoolNo);
 
     if (kv->kve_protection & VM_PROT_EXECUTE)
-      info.SetExecutable(MemoryRegionInfo::OptionalBool::eYes);
+      info.SetExecutable(eLazyBoolYes);
     else
-      info.SetExecutable(MemoryRegionInfo::OptionalBool::eNo);
+      info.SetExecutable(eLazyBoolNo);
 
     if (kv->kve_path[0])
       info.SetName(kv->kve_path);

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -1326,7 +1326,7 @@ NativeProcessLinux::Syscall(llvm::ArrayRef<uint64_t> args) {
   PopulateMemoryRegionCache();
   auto region_it = llvm::find_if(m_mem_region_cache, [](const auto &pair) {
     return pair.first.GetExecutable() == eLazyBoolYes &&
-        pair.first.GetShared() != eLazyBoolYes;
+           pair.first.GetShared() != eLazyBoolYes;
   });
   if (region_it == m_mem_region_cache.end())
     return llvm::createStringError(llvm::inconvertibleErrorCode(),

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -1222,10 +1222,10 @@ Status NativeProcessLinux::GetMemoryRegionInfo(lldb::addr_t load_addr,
       range_info.GetRange().SetRangeBase(load_addr);
       range_info.GetRange().SetByteSize(
           proc_entry_info.GetRange().GetRangeBase() - load_addr);
-      range_info.SetReadable(MemoryRegionInfo::OptionalBool::eNo);
-      range_info.SetWritable(MemoryRegionInfo::OptionalBool::eNo);
-      range_info.SetExecutable(MemoryRegionInfo::OptionalBool::eNo);
-      range_info.SetMapped(MemoryRegionInfo::OptionalBool::eNo);
+      range_info.SetReadable(eLazyBoolNo);
+      range_info.SetWritable(eLazyBoolNo);
+      range_info.SetExecutable(eLazyBoolNo);
+      range_info.SetMapped(eLazyBoolNo);
 
       return error;
     } else if (proc_entry_info.GetRange().Contains(load_addr)) {
@@ -1243,10 +1243,10 @@ Status NativeProcessLinux::GetMemoryRegionInfo(lldb::addr_t load_addr,
   // load address and the end of the memory as size.
   range_info.GetRange().SetRangeBase(load_addr);
   range_info.GetRange().SetRangeEnd(LLDB_INVALID_ADDRESS);
-  range_info.SetReadable(MemoryRegionInfo::OptionalBool::eNo);
-  range_info.SetWritable(MemoryRegionInfo::OptionalBool::eNo);
-  range_info.SetExecutable(MemoryRegionInfo::OptionalBool::eNo);
-  range_info.SetMapped(MemoryRegionInfo::OptionalBool::eNo);
+  range_info.SetReadable(eLazyBoolNo);
+  range_info.SetWritable(eLazyBoolNo);
+  range_info.SetExecutable(eLazyBoolNo);
+  range_info.SetMapped(eLazyBoolNo);
   return error;
 }
 
@@ -1325,8 +1325,8 @@ llvm::Expected<uint64_t>
 NativeProcessLinux::Syscall(llvm::ArrayRef<uint64_t> args) {
   PopulateMemoryRegionCache();
   auto region_it = llvm::find_if(m_mem_region_cache, [](const auto &pair) {
-    return pair.first.GetExecutable() == MemoryRegionInfo::eYes &&
-        pair.first.GetShared() != MemoryRegionInfo::eYes;
+    return pair.first.GetExecutable() == eLazyBoolYes &&
+        pair.first.GetShared() != eLazyBoolYes;
   });
   if (region_it == m_mem_region_cache.end())
     return llvm::createStringError(llvm::inconvertibleErrorCode(),

--- a/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
+++ b/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
@@ -647,10 +647,10 @@ Status NativeProcessNetBSD::GetMemoryRegionInfo(lldb::addr_t load_addr,
       range_info.GetRange().SetRangeBase(load_addr);
       range_info.GetRange().SetByteSize(
           proc_entry_info.GetRange().GetRangeBase() - load_addr);
-      range_info.SetReadable(MemoryRegionInfo::OptionalBool::eNo);
-      range_info.SetWritable(MemoryRegionInfo::OptionalBool::eNo);
-      range_info.SetExecutable(MemoryRegionInfo::OptionalBool::eNo);
-      range_info.SetMapped(MemoryRegionInfo::OptionalBool::eNo);
+      range_info.SetReadable(eLazyBoolNo);
+      range_info.SetWritable(eLazyBoolNo);
+      range_info.SetExecutable(eLazyBoolNo);
+      range_info.SetMapped(eLazyBoolNo);
       return error;
     } else if (proc_entry_info.GetRange().Contains(load_addr)) {
       // The target address is within the memory region we're processing here.
@@ -665,10 +665,10 @@ Status NativeProcessNetBSD::GetMemoryRegionInfo(lldb::addr_t load_addr,
   // load address and the end of the memory as size.
   range_info.GetRange().SetRangeBase(load_addr);
   range_info.GetRange().SetRangeEnd(LLDB_INVALID_ADDRESS);
-  range_info.SetReadable(MemoryRegionInfo::OptionalBool::eNo);
-  range_info.SetWritable(MemoryRegionInfo::OptionalBool::eNo);
-  range_info.SetExecutable(MemoryRegionInfo::OptionalBool::eNo);
-  range_info.SetMapped(MemoryRegionInfo::OptionalBool::eNo);
+  range_info.SetReadable(eLazyBoolNo);
+  range_info.SetWritable(eLazyBoolNo);
+  range_info.SetExecutable(eLazyBoolNo);
+  range_info.SetMapped(eLazyBoolNo);
   return error;
 }
 
@@ -696,22 +696,22 @@ Status NativeProcessNetBSD::PopulateMemoryRegionCache() {
     info.Clear();
     info.GetRange().SetRangeBase(vm[i].kve_start);
     info.GetRange().SetRangeEnd(vm[i].kve_end);
-    info.SetMapped(MemoryRegionInfo::OptionalBool::eYes);
+    info.SetMapped(eLazyBoolYes);
 
     if (vm[i].kve_protection & VM_PROT_READ)
-      info.SetReadable(MemoryRegionInfo::OptionalBool::eYes);
+      info.SetReadable(eLazyBoolYes);
     else
-      info.SetReadable(MemoryRegionInfo::OptionalBool::eNo);
+      info.SetReadable(eLazyBoolNo);
 
     if (vm[i].kve_protection & VM_PROT_WRITE)
-      info.SetWritable(MemoryRegionInfo::OptionalBool::eYes);
+      info.SetWritable(eLazyBoolYes);
     else
-      info.SetWritable(MemoryRegionInfo::OptionalBool::eNo);
+      info.SetWritable(eLazyBoolNo);
 
     if (vm[i].kve_protection & VM_PROT_EXECUTE)
-      info.SetExecutable(MemoryRegionInfo::OptionalBool::eYes);
+      info.SetExecutable(eLazyBoolYes);
     else
-      info.SetExecutable(MemoryRegionInfo::OptionalBool::eNo);
+      info.SetExecutable(eLazyBoolNo);
 
     if (vm[i].kve_path[0])
       info.SetName(vm[i].kve_path);

--- a/lldb/source/Plugins/Process/Utility/LinuxProcMaps.cpp
+++ b/lldb/source/Plugins/Process/Utility/LinuxProcMaps.cpp
@@ -56,7 +56,7 @@ ParseMemoryRegionInfoFromProcMapsLine(llvm::StringRef maps_line,
 
   // Any memory region in /proc/{pid}/(maps|smaps) is by definition mapped
   // into the process.
-  region.SetMapped(MemoryRegionInfo::OptionalBool::eYes);
+  region.SetMapped(eLazyBoolYes);
 
   // Parse out each permission entry.
   if (line_extractor.GetBytesLeft() < 4)
@@ -68,9 +68,9 @@ ParseMemoryRegionInfoFromProcMapsLine(llvm::StringRef maps_line,
   // Handle read permission.
   const char read_perm_char = line_extractor.GetChar();
   if (read_perm_char == 'r')
-    region.SetReadable(MemoryRegionInfo::OptionalBool::eYes);
+    region.SetReadable(eLazyBoolYes);
   else if (read_perm_char == '-')
-    region.SetReadable(MemoryRegionInfo::OptionalBool::eNo);
+    region.SetReadable(eLazyBoolNo);
   else
     return ProcMapError("unexpected /proc/{pid}/%s read permission char",
                         maps_kind);
@@ -78,9 +78,9 @@ ParseMemoryRegionInfoFromProcMapsLine(llvm::StringRef maps_line,
   // Handle write permission.
   const char write_perm_char = line_extractor.GetChar();
   if (write_perm_char == 'w')
-    region.SetWritable(MemoryRegionInfo::OptionalBool::eYes);
+    region.SetWritable(eLazyBoolYes);
   else if (write_perm_char == '-')
-    region.SetWritable(MemoryRegionInfo::OptionalBool::eNo);
+    region.SetWritable(eLazyBoolNo);
   else
     return ProcMapError("unexpected /proc/{pid}/%s write permission char",
                         maps_kind);
@@ -88,9 +88,9 @@ ParseMemoryRegionInfoFromProcMapsLine(llvm::StringRef maps_line,
   // Handle execute permission.
   const char exec_perm_char = line_extractor.GetChar();
   if (exec_perm_char == 'x')
-    region.SetExecutable(MemoryRegionInfo::OptionalBool::eYes);
+    region.SetExecutable(eLazyBoolYes);
   else if (exec_perm_char == '-')
-    region.SetExecutable(MemoryRegionInfo::OptionalBool::eNo);
+    region.SetExecutable(eLazyBoolNo);
   else
     return ProcMapError("unexpected /proc/{pid}/%s exec permission char",
                         maps_kind);
@@ -98,11 +98,11 @@ ParseMemoryRegionInfoFromProcMapsLine(llvm::StringRef maps_line,
   // Handle sharing status (private/shared).
   const char sharing_char = line_extractor.GetChar();
   if (sharing_char == 's')
-    region.SetShared(MemoryRegionInfo::OptionalBool::eYes);
+    region.SetShared(eLazyBoolYes);
   else if (sharing_char == 'p')
-    region.SetShared(MemoryRegionInfo::OptionalBool::eNo);
+    region.SetShared(eLazyBoolNo);
   else
-    region.SetShared(MemoryRegionInfo::OptionalBool::eDontKnow);
+    region.SetShared(eLazyBoolDontKnow);
 
   line_extractor.SkipSpaces();           // Skip the separator
   line_extractor.GetHexMaxU64(false, 0); // Read the offset
@@ -164,16 +164,16 @@ void lldb_private::ParseLinuxSMapRegions(llvm::StringRef linux_smap,
     if (!name.contains(' ')) {
       if (region) {
         if (name == "VmFlags") {
-          region->SetMemoryTagged(MemoryRegionInfo::eNo);
-          region->SetIsShadowStack(MemoryRegionInfo::eNo);
+          region->SetMemoryTagged(eLazyBoolNo);
+          region->SetIsShadowStack(eLazyBoolNo);
 
           llvm::SmallVector<llvm::StringRef> flags;
           value.split(flags, ' ', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
           for (llvm::StringRef flag : flags)
             if (flag == "mt")
-              region->SetMemoryTagged(MemoryRegionInfo::eYes);
+              region->SetMemoryTagged(eLazyBoolYes);
             else if (flag == "ss")
-              region->SetIsShadowStack(MemoryRegionInfo::eYes);
+              region->SetIsShadowStack(eLazyBoolYes);
         }
       } else {
         // Orphaned settings line

--- a/lldb/source/Plugins/Process/Utility/MemoryTagManagerAArch64MTE.cpp
+++ b/lldb/source/Plugins/Process/Utility/MemoryTagManagerAArch64MTE.cpp
@@ -107,7 +107,7 @@ MemoryTagManagerAArch64MTE::MakeTaggedRange(
         });
 
     if (region == memory_regions.cend() ||
-        region->GetMemoryTagged() != MemoryRegionInfo::eYes) {
+        region->GetMemoryTagged() != eLazyBoolYes) {
       // Some part of this range is untagged (or unmapped) so error
       return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                      "Address range 0x%" PRIx64 ":0x%" PRIx64

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessDebugger.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessDebugger.cpp
@@ -288,7 +288,7 @@ Status ProcessDebugger::ReadMemory(lldb::addr_t vm_addr, void *buf, size_t size,
   error = Status(GetLastError(), eErrorTypeWin32);
   MemoryRegionInfo info;
   if (GetMemoryRegionInfo(vm_addr, info).Fail() ||
-      info.GetMapped() != MemoryRegionInfo::OptionalBool::eYes)
+      info.GetMapped() != eLazyBoolYes)
     return error;
   size = info.GetRange().GetRangeEnd() - vm_addr;
   LLDB_LOG(log, "retrying the read with size {0:x}", size);
@@ -421,10 +421,10 @@ Status ProcessDebugger::GetMemoryRegionInfo(lldb::addr_t vm_addr,
       // range from the vm_addr to LLDB_INVALID_ADDRESS
       info.GetRange().SetRangeBase(vm_addr);
       info.GetRange().SetRangeEnd(LLDB_INVALID_ADDRESS);
-      info.SetReadable(MemoryRegionInfo::eNo);
-      info.SetExecutable(MemoryRegionInfo::eNo);
-      info.SetWritable(MemoryRegionInfo::eNo);
-      info.SetMapped(MemoryRegionInfo::eNo);
+      info.SetReadable(eLazyBoolNo);
+      info.SetExecutable(eLazyBoolNo);
+      info.SetWritable(eLazyBoolNo);
+      info.SetMapped(eLazyBoolNo);
       return error;
     } else {
       error = Status(last_error, eErrorTypeWin32);
@@ -441,14 +441,14 @@ Status ProcessDebugger::GetMemoryRegionInfo(lldb::addr_t vm_addr,
     const bool readable = IsPageReadable(mem_info.Protect);
     const bool executable = IsPageExecutable(mem_info.Protect);
     const bool writable = IsPageWritable(mem_info.Protect);
-    info.SetReadable(readable ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo);
-    info.SetExecutable(executable ? MemoryRegionInfo::eYes
-                                  : MemoryRegionInfo::eNo);
-    info.SetWritable(writable ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo);
+    info.SetReadable(readable ? eLazyBoolYes : eLazyBoolNo);
+    info.SetExecutable(executable ? eLazyBoolYes
+                                  : eLazyBoolNo);
+    info.SetWritable(writable ? eLazyBoolYes : eLazyBoolNo);
   } else {
-    info.SetReadable(MemoryRegionInfo::eNo);
-    info.SetExecutable(MemoryRegionInfo::eNo);
-    info.SetWritable(MemoryRegionInfo::eNo);
+    info.SetReadable(eLazyBoolNo);
+    info.SetExecutable(eLazyBoolNo);
+    info.SetWritable(eLazyBoolNo);
   }
 
   // AllocationBase is defined for MEM_COMMIT and MEM_RESERVE but not MEM_FREE.
@@ -457,7 +457,7 @@ Status ProcessDebugger::GetMemoryRegionInfo(lldb::addr_t vm_addr,
         reinterpret_cast<addr_t>(mem_info.BaseAddress));
     info.GetRange().SetRangeEnd(reinterpret_cast<addr_t>(mem_info.BaseAddress) +
                                 mem_info.RegionSize);
-    info.SetMapped(MemoryRegionInfo::eYes);
+    info.SetMapped(eLazyBoolYes);
   } else {
     // In the unmapped case we need to return the distance to the next block of
     // memory. VirtualQueryEx nearly does that except that it gives the
@@ -467,7 +467,7 @@ Status ProcessDebugger::GetMemoryRegionInfo(lldb::addr_t vm_addr,
     DWORD page_offset = vm_addr % data.dwPageSize;
     info.GetRange().SetRangeBase(vm_addr);
     info.GetRange().SetByteSize(mem_info.RegionSize - page_offset);
-    info.SetMapped(MemoryRegionInfo::eNo);
+    info.SetMapped(eLazyBoolNo);
   }
 
   LLDB_LOG_VERBOSE(log,

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessDebugger.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessDebugger.cpp
@@ -442,8 +442,7 @@ Status ProcessDebugger::GetMemoryRegionInfo(lldb::addr_t vm_addr,
     const bool executable = IsPageExecutable(mem_info.Protect);
     const bool writable = IsPageWritable(mem_info.Protect);
     info.SetReadable(readable ? eLazyBoolYes : eLazyBoolNo);
-    info.SetExecutable(executable ? eLazyBoolYes
-                                  : eLazyBoolNo);
+    info.SetExecutable(executable ? eLazyBoolYes : eLazyBoolNo);
     info.SetWritable(writable ? eLazyBoolYes : eLazyBoolNo);
   } else {
     info.SetReadable(eLazyBoolNo);

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -400,43 +400,43 @@ Status ProcessElfCore::DoGetMemoryRegionInfo(lldb::addr_t load_addr,
       region_info.GetRange().SetRangeEnd(permission_entry->GetRangeEnd());
       const Flags permissions(permission_entry->data);
       region_info.SetReadable(permissions.Test(lldb::ePermissionsReadable)
-                                  ? MemoryRegionInfo::eYes
-                                  : MemoryRegionInfo::eNo);
+                                  ? eLazyBoolYes
+                                  : eLazyBoolNo);
       region_info.SetWritable(permissions.Test(lldb::ePermissionsWritable)
-                                  ? MemoryRegionInfo::eYes
-                                  : MemoryRegionInfo::eNo);
+                                  ? eLazyBoolYes
+                                  : eLazyBoolNo);
       region_info.SetExecutable(permissions.Test(lldb::ePermissionsExecutable)
-                                    ? MemoryRegionInfo::eYes
-                                    : MemoryRegionInfo::eNo);
-      region_info.SetMapped(MemoryRegionInfo::eYes);
+                                    ? eLazyBoolYes
+                                    : eLazyBoolNo);
+      region_info.SetMapped(eLazyBoolYes);
 
       // A region is memory tagged if there is a memory tag segment that covers
       // the exact same range.
-      region_info.SetMemoryTagged(MemoryRegionInfo::eNo);
+      region_info.SetMemoryTagged(eLazyBoolNo);
       const VMRangeToFileOffset::Entry *tag_entry =
           m_core_tag_ranges.FindEntryStartsAt(permission_entry->GetRangeBase());
       if (tag_entry &&
           tag_entry->GetRangeEnd() == permission_entry->GetRangeEnd())
-        region_info.SetMemoryTagged(MemoryRegionInfo::eYes);
+        region_info.SetMemoryTagged(eLazyBoolYes);
     } else if (load_addr < permission_entry->GetRangeBase()) {
       region_info.GetRange().SetRangeBase(load_addr);
       region_info.GetRange().SetRangeEnd(permission_entry->GetRangeBase());
-      region_info.SetReadable(MemoryRegionInfo::eNo);
-      region_info.SetWritable(MemoryRegionInfo::eNo);
-      region_info.SetExecutable(MemoryRegionInfo::eNo);
-      region_info.SetMapped(MemoryRegionInfo::eNo);
-      region_info.SetMemoryTagged(MemoryRegionInfo::eNo);
+      region_info.SetReadable(eLazyBoolNo);
+      region_info.SetWritable(eLazyBoolNo);
+      region_info.SetExecutable(eLazyBoolNo);
+      region_info.SetMapped(eLazyBoolNo);
+      region_info.SetMemoryTagged(eLazyBoolNo);
     }
     return Status();
   }
 
   region_info.GetRange().SetRangeBase(load_addr);
   region_info.GetRange().SetRangeEnd(LLDB_INVALID_ADDRESS);
-  region_info.SetReadable(MemoryRegionInfo::eNo);
-  region_info.SetWritable(MemoryRegionInfo::eNo);
-  region_info.SetExecutable(MemoryRegionInfo::eNo);
-  region_info.SetMapped(MemoryRegionInfo::eNo);
-  region_info.SetMemoryTagged(MemoryRegionInfo::eNo);
+  region_info.SetReadable(eLazyBoolNo);
+  region_info.SetWritable(eLazyBoolNo);
+  region_info.SetExecutable(eLazyBoolNo);
+  region_info.SetMapped(eLazyBoolNo);
+  region_info.SetMemoryTagged(eLazyBoolNo);
   return Status();
 }
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -1610,28 +1610,28 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
           saw_permissions = true;
           if (region_info.GetRange().Contains(addr)) {
             if (value.contains('r'))
-              region_info.SetReadable(MemoryRegionInfo::eYes);
+              region_info.SetReadable(eLazyBoolYes);
             else
-              region_info.SetReadable(MemoryRegionInfo::eNo);
+              region_info.SetReadable(eLazyBoolNo);
 
             if (value.contains('w'))
-              region_info.SetWritable(MemoryRegionInfo::eYes);
+              region_info.SetWritable(eLazyBoolYes);
             else
-              region_info.SetWritable(MemoryRegionInfo::eNo);
+              region_info.SetWritable(eLazyBoolNo);
 
             if (value.contains('x'))
-              region_info.SetExecutable(MemoryRegionInfo::eYes);
+              region_info.SetExecutable(eLazyBoolYes);
             else
-              region_info.SetExecutable(MemoryRegionInfo::eNo);
+              region_info.SetExecutable(eLazyBoolNo);
 
-            region_info.SetMapped(MemoryRegionInfo::eYes);
+            region_info.SetMapped(eLazyBoolYes);
           } else {
             // The reported region does not contain this address -- we're
             // looking at an unmapped page
-            region_info.SetReadable(MemoryRegionInfo::eNo);
-            region_info.SetWritable(MemoryRegionInfo::eNo);
-            region_info.SetExecutable(MemoryRegionInfo::eNo);
-            region_info.SetMapped(MemoryRegionInfo::eNo);
+            region_info.SetReadable(eLazyBoolNo);
+            region_info.SetWritable(eLazyBoolNo);
+            region_info.SetExecutable(eLazyBoolNo);
+            region_info.SetMapped(eLazyBoolNo);
           }
         } else if (name == "name") {
           StringExtractorGDBRemote name_extractor(value);
@@ -1639,8 +1639,8 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
           name_extractor.GetHexByteString(name);
           region_info.SetName(name.c_str());
         } else if (name == "flags") {
-          region_info.SetMemoryTagged(MemoryRegionInfo::eNo);
-          region_info.SetIsShadowStack(MemoryRegionInfo::eNo);
+          region_info.SetMemoryTagged(eLazyBoolNo);
+          region_info.SetIsShadowStack(eLazyBoolNo);
 
           llvm::StringRef flags = value;
           llvm::StringRef flag;
@@ -1650,17 +1650,17 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
             // To account for trailing whitespace
             if (flag.size()) {
               if (flag == "mt")
-                region_info.SetMemoryTagged(MemoryRegionInfo::eYes);
+                region_info.SetMemoryTagged(eLazyBoolYes);
               else if (flag == "ss")
-                region_info.SetIsShadowStack(MemoryRegionInfo::eYes);
+                region_info.SetIsShadowStack(eLazyBoolYes);
             }
           }
         } else if (name == "type") {
           for (llvm::StringRef entry : llvm::split(value, ',')) {
             if (entry == "stack")
-              region_info.SetIsStackMemory(MemoryRegionInfo::eYes);
+              region_info.SetIsStackMemory(eLazyBoolYes);
             else if (entry == "heap")
-              region_info.SetIsStackMemory(MemoryRegionInfo::eNo);
+              region_info.SetIsStackMemory(eLazyBoolNo);
           }
         } else if (name == "error") {
           StringExtractorGDBRemote error_extractor(value);
@@ -1687,10 +1687,10 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
         // We got a valid address range back but no permissions -- which means
         // this is an unmapped page
         if (!saw_permissions) {
-          region_info.SetReadable(MemoryRegionInfo::eNo);
-          region_info.SetWritable(MemoryRegionInfo::eNo);
-          region_info.SetExecutable(MemoryRegionInfo::eNo);
-          region_info.SetMapped(MemoryRegionInfo::eNo);
+          region_info.SetReadable(eLazyBoolNo);
+          region_info.SetWritable(eLazyBoolNo);
+          region_info.SetExecutable(eLazyBoolNo);
+          region_info.SetMapped(eLazyBoolNo);
         }
       } else {
         // We got an invalid address range back
@@ -1799,14 +1799,14 @@ Status GDBRemoteCommunicationClient::LoadQXferMemoryMap() {
     region.GetRange().SetRangeBase(start);
     region.GetRange().SetByteSize(length);
     if (type == "rom") {
-      region.SetReadable(MemoryRegionInfo::eYes);
+      region.SetReadable(eLazyBoolYes);
       this->m_qXfer_memory_map.push_back(region);
     } else if (type == "ram") {
-      region.SetReadable(MemoryRegionInfo::eYes);
-      region.SetWritable(MemoryRegionInfo::eYes);
+      region.SetReadable(eLazyBoolYes);
+      region.SetWritable(eLazyBoolYes);
       this->m_qXfer_memory_map.push_back(region);
     } else if (type == "flash") {
-      region.SetFlash(MemoryRegionInfo::eYes);
+      region.SetFlash(eLazyBoolYes);
       memory_node.ForEachChildElement(
           [&region](const XMLNode &prop_node) -> bool {
             if (!prop_node.IsElement())

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -2873,10 +2873,8 @@ GDBRemoteCommunicationServerLLGS::Handle_qMemoryRegionInfo(
     }
 
     // Flags
-    LazyBool memory_tagged =
-        region_info.GetMemoryTagged();
-    LazyBool is_shadow_stack =
-        region_info.IsShadowStack();
+    LazyBool memory_tagged = region_info.GetMemoryTagged();
+    LazyBool is_shadow_stack = region_info.IsShadowStack();
 
     if (memory_tagged != eLazyBoolDontKnow ||
         is_shadow_stack != eLazyBoolDontKnow) {

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -2873,18 +2873,18 @@ GDBRemoteCommunicationServerLLGS::Handle_qMemoryRegionInfo(
     }
 
     // Flags
-    MemoryRegionInfo::OptionalBool memory_tagged =
+    LazyBool memory_tagged =
         region_info.GetMemoryTagged();
-    MemoryRegionInfo::OptionalBool is_shadow_stack =
+    LazyBool is_shadow_stack =
         region_info.IsShadowStack();
 
-    if (memory_tagged != MemoryRegionInfo::eDontKnow ||
-        is_shadow_stack != MemoryRegionInfo::eDontKnow) {
+    if (memory_tagged != eLazyBoolDontKnow ||
+        is_shadow_stack != eLazyBoolDontKnow) {
       response.PutCString("flags:");
       // Space is the separator.
-      if (memory_tagged == MemoryRegionInfo::eYes)
+      if (memory_tagged == eLazyBoolYes)
         response.PutCString("mt ");
-      if (is_shadow_stack == MemoryRegionInfo::eYes)
+      if (is_shadow_stack == eLazyBoolYes)
         response.PutCString("ss ");
 
       response.PutChar(';');

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -3116,7 +3116,7 @@ size_t ProcessGDBRemote::DoWriteMemory(addr_t addr, const void *buf,
   Status region_status = GetMemoryRegionInfo(addr, region);
 
   bool is_flash =
-      region_status.Success() && region.GetFlash() == MemoryRegionInfo::eYes;
+      region_status.Success() && region.GetFlash() == eLazyBoolYes;
 
   if (is_flash) {
     if (!m_allow_flash_writes) {

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -3115,8 +3115,7 @@ size_t ProcessGDBRemote::DoWriteMemory(addr_t addr, const void *buf,
   MemoryRegionInfo region;
   Status region_status = GetMemoryRegionInfo(addr, region);
 
-  bool is_flash =
-      region_status.Success() && region.GetFlash() == eLazyBoolYes;
+  bool is_flash = region_status.Success() && region.GetFlash() == eLazyBoolYes;
 
   if (is_flash) {
     if (!m_allow_flash_writes) {

--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
@@ -780,12 +780,10 @@ Status ProcessMachCore::DoGetMemoryRegionInfo(addr_t load_addr,
       region_info.GetRange().SetRangeBase(permission_entry->GetRangeBase());
       region_info.GetRange().SetRangeEnd(permission_entry->GetRangeEnd());
       const Flags permissions(permission_entry->data);
-      region_info.SetReadable(permissions.Test(ePermissionsReadable)
-                                  ? eLazyBoolYes
-                                  : eLazyBoolNo);
-      region_info.SetWritable(permissions.Test(ePermissionsWritable)
-                                  ? eLazyBoolYes
-                                  : eLazyBoolNo);
+      region_info.SetReadable(
+          permissions.Test(ePermissionsReadable) ? eLazyBoolYes : eLazyBoolNo);
+      region_info.SetWritable(
+          permissions.Test(ePermissionsWritable) ? eLazyBoolYes : eLazyBoolNo);
       region_info.SetExecutable(permissions.Test(ePermissionsExecutable)
                                     ? eLazyBoolYes
                                     : eLazyBoolNo);

--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
@@ -781,22 +781,22 @@ Status ProcessMachCore::DoGetMemoryRegionInfo(addr_t load_addr,
       region_info.GetRange().SetRangeEnd(permission_entry->GetRangeEnd());
       const Flags permissions(permission_entry->data);
       region_info.SetReadable(permissions.Test(ePermissionsReadable)
-                                  ? MemoryRegionInfo::eYes
-                                  : MemoryRegionInfo::eNo);
+                                  ? eLazyBoolYes
+                                  : eLazyBoolNo);
       region_info.SetWritable(permissions.Test(ePermissionsWritable)
-                                  ? MemoryRegionInfo::eYes
-                                  : MemoryRegionInfo::eNo);
+                                  ? eLazyBoolYes
+                                  : eLazyBoolNo);
       region_info.SetExecutable(permissions.Test(ePermissionsExecutable)
-                                    ? MemoryRegionInfo::eYes
-                                    : MemoryRegionInfo::eNo);
-      region_info.SetMapped(MemoryRegionInfo::eYes);
+                                    ? eLazyBoolYes
+                                    : eLazyBoolNo);
+      region_info.SetMapped(eLazyBoolYes);
     } else if (load_addr < permission_entry->GetRangeBase()) {
       region_info.GetRange().SetRangeBase(load_addr);
       region_info.GetRange().SetRangeEnd(permission_entry->GetRangeBase());
-      region_info.SetReadable(MemoryRegionInfo::eNo);
-      region_info.SetWritable(MemoryRegionInfo::eNo);
-      region_info.SetExecutable(MemoryRegionInfo::eNo);
-      region_info.SetMapped(MemoryRegionInfo::eNo);
+      region_info.SetReadable(eLazyBoolNo);
+      region_info.SetWritable(eLazyBoolNo);
+      region_info.SetExecutable(eLazyBoolNo);
+      region_info.SetMapped(eLazyBoolNo);
     }
     return Status();
   } else {
@@ -820,10 +820,10 @@ Status ProcessMachCore::DoGetMemoryRegionInfo(addr_t load_addr,
 
   region_info.GetRange().SetRangeBase(load_addr);
   region_info.GetRange().SetRangeEnd(LLDB_INVALID_ADDRESS);
-  region_info.SetReadable(MemoryRegionInfo::eNo);
-  region_info.SetWritable(MemoryRegionInfo::eNo);
-  region_info.SetExecutable(MemoryRegionInfo::eNo);
-  region_info.SetMapped(MemoryRegionInfo::eNo);
+  region_info.SetReadable(eLazyBoolNo);
+  region_info.SetWritable(eLazyBoolNo);
+  region_info.SetExecutable(eLazyBoolNo);
+  region_info.SetMapped(eLazyBoolNo);
   return Status();
 }
 

--- a/lldb/source/Plugins/Process/minidump/MinidumpParser.cpp
+++ b/lldb/source/Plugins/Process/minidump/MinidumpParser.cpp
@@ -353,7 +353,7 @@ static bool CheckForLinuxExecutable(ConstString path,
   lldb::addr_t addr = base_of_image;
   MemoryRegionInfo region = MinidumpParser::GetMemoryRegionInfo(regions, addr);
   while (region.GetName() == path) {
-    if (region.GetExecutable() == MemoryRegionInfo::eYes)
+    if (region.GetExecutable() == eLazyBoolYes)
       return true;
     addr += region.GetRange().GetByteSize();
     region = MinidumpParser::GetMemoryRegionInfo(regions, addr);
@@ -535,8 +535,8 @@ CreateRegionsCacheFromMemoryInfoList(MinidumpParser &parser,
                    "Failed to read memory info list: {0}");
     return false;
   }
-  constexpr auto yes = MemoryRegionInfo::eYes;
-  constexpr auto no = MemoryRegionInfo::eNo;
+  constexpr auto yes = eLazyBoolYes;
+  constexpr auto no = eLazyBoolNo;
   for (const MemoryInfo &entry : *ExpectedInfo) {
     MemoryRegionInfo region;
     region.GetRange().SetRangeBase(entry.BaseAddress);
@@ -579,8 +579,8 @@ CreateRegionsCacheFromMemoryList(MinidumpParser &parser,
       MemoryRegionInfo region;
       region.GetRange().SetRangeBase(memory_desc.StartOfMemoryRange);
       region.GetRange().SetByteSize(memory_desc.Memory.DataSize);
-      region.SetReadable(MemoryRegionInfo::eYes);
-      region.SetMapped(MemoryRegionInfo::eYes);
+      region.SetReadable(eLazyBoolYes);
+      region.SetMapped(eLazyBoolYes);
       regions.push_back(region);
     }
   }
@@ -593,8 +593,8 @@ CreateRegionsCacheFromMemoryList(MinidumpParser &parser,
       MemoryRegionInfo region;
       region.GetRange().SetRangeBase(memory_desc.first.StartOfMemoryRange);
       region.GetRange().SetByteSize(memory_desc.first.DataSize);
-      region.SetReadable(MemoryRegionInfo::eYes);
-      region.SetMapped(MemoryRegionInfo::eYes);
+      region.SetReadable(eLazyBoolYes);
+      region.SetMapped(eLazyBoolYes);
       regions.push_back(region);
     }
 
@@ -705,9 +705,9 @@ MinidumpParser::GetMemoryRegionInfo(const MemoryRegionInfos &regions,
   else
     region.GetRange().SetRangeEnd(pos->GetRange().GetRangeBase());
 
-  region.SetReadable(MemoryRegionInfo::eNo);
-  region.SetWritable(MemoryRegionInfo::eNo);
-  region.SetExecutable(MemoryRegionInfo::eNo);
-  region.SetMapped(MemoryRegionInfo::eNo);
+  region.SetReadable(eLazyBoolNo);
+  region.SetWritable(eLazyBoolNo);
+  region.SetExecutable(eLazyBoolNo);
+  region.SetMapped(eLazyBoolNo);
   return region;
 }

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -394,13 +394,13 @@ void ProcessMinidump::BuildMemoryRegions() {
                                                 section_sp->GetByteSize());
       MemoryRegionInfo region =
           MinidumpParser::GetMemoryRegionInfo(*m_memory_regions, load_addr);
-      if (region.GetMapped() != MemoryRegionInfo::eYes &&
+      if (region.GetMapped() != eLazyBoolYes &&
           region.GetRange().GetRangeBase() <= section_range.GetRangeBase() &&
           section_range.GetRangeEnd() <= region.GetRange().GetRangeEnd()) {
         to_add.emplace_back();
         to_add.back().GetRange() = section_range;
         to_add.back().SetLLDBPermissions(section_sp->GetPermissions());
-        to_add.back().SetMapped(MemoryRegionInfo::eYes);
+        to_add.back().SetMapped(eLazyBoolYes);
         to_add.back().SetName(module_sp->GetFileSpec().GetPath().c_str());
       }
     }

--- a/lldb/source/Target/MemoryRegionInfo.cpp
+++ b/lldb/source/Target/MemoryRegionInfo.cpp
@@ -22,9 +22,8 @@ llvm::raw_ostream &lldb_private::operator<<(llvm::raw_ostream &OS,
                              Info.IsStackMemory(), Info.IsShadowStack());
 }
 
-void llvm::format_provider<LazyBool>::format(
-    const LazyBool &B, raw_ostream &OS,
-    StringRef Options) {
+void llvm::format_provider<LazyBool>::format(const LazyBool &B, raw_ostream &OS,
+                                             StringRef Options) {
   assert(Options.size() <= 1);
   bool Empty = Options.empty();
   switch (B) {

--- a/lldb/source/Target/MemoryRegionInfo.cpp
+++ b/lldb/source/Target/MemoryRegionInfo.cpp
@@ -22,19 +22,19 @@ llvm::raw_ostream &lldb_private::operator<<(llvm::raw_ostream &OS,
                              Info.IsStackMemory(), Info.IsShadowStack());
 }
 
-void llvm::format_provider<MemoryRegionInfo::OptionalBool>::format(
-    const MemoryRegionInfo::OptionalBool &B, raw_ostream &OS,
+void llvm::format_provider<LazyBool>::format(
+    const LazyBool &B, raw_ostream &OS,
     StringRef Options) {
   assert(Options.size() <= 1);
   bool Empty = Options.empty();
   switch (B) {
-  case lldb_private::MemoryRegionInfo::eNo:
+  case lldb_private::eLazyBoolNo:
     OS << (Empty ? "no" : "-");
     return;
-  case lldb_private::MemoryRegionInfo::eYes:
+  case lldb_private::eLazyBoolYes:
     OS << (Empty ? "yes" : Options);
     return;
-  case lldb_private::MemoryRegionInfo::eDontKnow:
+  case lldb_private::eLazyBoolDontKnow:
     OS << (Empty ? "don't know" : "?");
     return;
   }

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2623,9 +2623,9 @@ bool Process::GetLoadAddressPermissions(lldb::addr_t load_addr,
   Status error(GetMemoryRegionInfo(load_addr, range_info));
   if (!error.Success())
     return false;
-  if (range_info.GetReadable() == MemoryRegionInfo::eDontKnow ||
-      range_info.GetWritable() == MemoryRegionInfo::eDontKnow ||
-      range_info.GetExecutable() == MemoryRegionInfo::eDontKnow) {
+  if (range_info.GetReadable() == eLazyBoolDontKnow ||
+      range_info.GetWritable() == eLazyBoolDontKnow ||
+      range_info.GetExecutable() == eLazyBoolDontKnow) {
     return false;
   }
   permissions = range_info.GetLLDBPermissions();
@@ -6374,7 +6374,7 @@ Status Process::GetMemoryRegions(lldb_private::MemoryRegionInfos &region_list) {
     // region, the last mappable region, will have non-address bits in its end
     // address.
     range_end = region_info.GetRange().GetRangeEnd();
-    if (region_info.GetMapped() == MemoryRegionInfo::eYes) {
+    if (region_info.GetMapped() == eLazyBoolYes) {
       region_list.push_back(std::move(region_info));
     }
   } while (
@@ -6795,7 +6795,7 @@ static void GetCoreFileSaveRangesDirtyOnly(Process &process,
     const bool try_dirty_pages = false;
     for (const auto &region : regions)
       if (stack_ends.count(region.GetRange().GetRangeEnd()) == 0 &&
-          region.GetWritable() == MemoryRegionInfo::eYes)
+          region.GetWritable() == eLazyBoolYes)
         AddRegion(region, try_dirty_pages, ranges);
   }
 }
@@ -6819,7 +6819,7 @@ static void GetCoreFileSaveRangesStackOnly(Process &process,
   for (const auto &region : regions) {
     // Save all the stack memory ranges not associated with a stack pointer.
     if (stack_ends.count(region.GetRange().GetRangeEnd()) == 0 &&
-        region.IsStackMemory() == MemoryRegionInfo::eYes)
+        region.IsStackMemory() == eLazyBoolYes)
       AddRegion(region, try_dirty_pages, ranges);
   }
 }

--- a/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
+++ b/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
@@ -82,25 +82,24 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple("0-0 rwzp 00000000 00:00 0", MemoryRegionInfos{},
                         "unexpected /proc/{pid}/maps exec permission char"),
         // Stops at first parsing error
-        std::make_tuple(
-            "0-1 rw-p 00000000 00:00 0 [abc]\n"
-            "0-0 rwzp 00000000 00:00 0\n"
-            "2-3 r-xp 00000000 00:00 0 [def]\n",
-            MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0, 1), eLazyBoolYes,
-                                 eLazyBoolYes, eLazyBoolNo,
-                                 eLazyBoolNo, eLazyBoolYes,
-                                 ConstString("[abc]")),
-            },
-            "unexpected /proc/{pid}/maps exec permission char"),
+        std::make_tuple("0-1 rw-p 00000000 00:00 0 [abc]\n"
+                        "0-0 rwzp 00000000 00:00 0\n"
+                        "2-3 r-xp 00000000 00:00 0 [def]\n",
+                        MemoryRegionInfos{
+                            MemoryRegionInfo(make_range(0, 1), eLazyBoolYes,
+                                             eLazyBoolYes, eLazyBoolNo,
+                                             eLazyBoolNo, eLazyBoolYes,
+                                             ConstString("[abc]")),
+                        },
+                        "unexpected /proc/{pid}/maps exec permission char"),
         // Single entry
         std::make_tuple(
             "55a4512f7000-55a451b68000 rw-p 00000000 00:00 0    [heap]",
             MemoryRegionInfos{
                 MemoryRegionInfo(make_range(0x55a4512f7000, 0x55a451b68000),
-                                 eLazyBoolYes, eLazyBoolYes,
-                                 eLazyBoolNo, eLazyBoolNo,
-                                 eLazyBoolYes, ConstString("[heap]")),
+                                 eLazyBoolYes, eLazyBoolYes, eLazyBoolNo,
+                                 eLazyBoolNo, eLazyBoolYes,
+                                 ConstString("[heap]")),
             },
             ""),
         // Multiple entries
@@ -111,17 +110,16 @@ INSTANTIATE_TEST_SUITE_P(
             "[vsyscall]",
             MemoryRegionInfos{
                 MemoryRegionInfo(make_range(0x7fc090021000, 0x7fc094000000),
-                                 eLazyBoolNo, eLazyBoolNo,
-                                 eLazyBoolNo, eLazyBoolNo,
-                                 eLazyBoolYes, ConstString(nullptr)),
-                MemoryRegionInfo(make_range(0x7fc094000000, 0x7fc094a00000),
-                                 eLazyBoolNo, eLazyBoolNo,
+                                 eLazyBoolNo, eLazyBoolNo, eLazyBoolNo,
                                  eLazyBoolNo, eLazyBoolYes,
-                                 eLazyBoolYes, ConstString(nullptr)),
+                                 ConstString(nullptr)),
+                MemoryRegionInfo(make_range(0x7fc094000000, 0x7fc094a00000),
+                                 eLazyBoolNo, eLazyBoolNo, eLazyBoolNo,
+                                 eLazyBoolYes, eLazyBoolYes,
+                                 ConstString(nullptr)),
                 MemoryRegionInfo(
                     make_range(0xffffffffff600000, 0xffffffffff601000),
-                    eLazyBoolYes, eLazyBoolNo,
-                    eLazyBoolYes, eLazyBoolNo,
+                    eLazyBoolYes, eLazyBoolNo, eLazyBoolYes, eLazyBoolNo,
                     eLazyBoolYes, ConstString("[vsyscall]")),
             },
             "")));
@@ -143,9 +141,8 @@ INSTANTIATE_TEST_SUITE_P(
             "1111-2222 rw-p 00000000 00:00 0 [foo]\n"
             "0/0 rw-p 00000000 00:00 0",
             MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0x1111, 0x2222),
-                                 eLazyBoolYes, eLazyBoolYes,
-                                 eLazyBoolNo, eLazyBoolNo,
+                MemoryRegionInfo(make_range(0x1111, 0x2222), eLazyBoolYes,
+                                 eLazyBoolYes, eLazyBoolNo, eLazyBoolNo,
                                  eLazyBoolYes, ConstString("[foo]")),
             },
             "malformed /proc/{pid}/smaps entry, missing dash between address "
@@ -161,9 +158,8 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(
             "1111-2222 rw-p 00000000 00:00 0    [foo]",
             MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0x1111, 0x2222),
-                                 eLazyBoolYes, eLazyBoolYes,
-                                 eLazyBoolNo, eLazyBoolNo,
+                MemoryRegionInfo(make_range(0x1111, 0x2222), eLazyBoolYes,
+                                 eLazyBoolYes, eLazyBoolNo, eLazyBoolNo,
                                  eLazyBoolYes, ConstString("[foo]")),
             },
             ""),
@@ -171,53 +167,49 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(
             "1111-2222 rw-s 00000000 00:00 0    [foo]",
             MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0x1111, 0x2222),
-                                 eLazyBoolYes, eLazyBoolYes,
-                                 eLazyBoolNo, eLazyBoolYes,
+                MemoryRegionInfo(make_range(0x1111, 0x2222), eLazyBoolYes,
+                                 eLazyBoolYes, eLazyBoolNo, eLazyBoolYes,
                                  eLazyBoolYes, ConstString("[foo]")),
             },
             ""),
         // Single region with flags, other lines ignored
-        std::make_tuple(
-            "1111-2222 rw-p 00000000 00:00 0    [foo]\n"
-            "Referenced:         2188 kB\n"
-            "AnonHugePages:         0 kB\n"
-            "VmFlags: mt",
-            MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0x1111, 0x2222),
-                                 eLazyBoolYes, eLazyBoolYes,
-                                 eLazyBoolNo, eLazyBoolNo,
-                                 eLazyBoolYes, ConstString("[foo]"))
-                    .SetIsShadowStack(eLazyBoolNo)
-                    .SetMemoryTagged(eLazyBoolYes),
-            },
-            ""),
+        std::make_tuple("1111-2222 rw-p 00000000 00:00 0    [foo]\n"
+                        "Referenced:         2188 kB\n"
+                        "AnonHugePages:         0 kB\n"
+                        "VmFlags: mt",
+                        MemoryRegionInfos{
+                            MemoryRegionInfo(make_range(0x1111, 0x2222),
+                                             eLazyBoolYes, eLazyBoolYes,
+                                             eLazyBoolNo, eLazyBoolNo,
+                                             eLazyBoolYes, ConstString("[foo]"))
+                                .SetIsShadowStack(eLazyBoolNo)
+                                .SetMemoryTagged(eLazyBoolYes),
+                        },
+                        ""),
         // Whitespace ignored
-        std::make_tuple(
-            "0-0 rw-p 00000000 00:00 0\n"
-            "VmFlags:      mt      ",
-            MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
-                                 eLazyBoolYes, eLazyBoolNo,
-                                 eLazyBoolNo, eLazyBoolYes,
-                                 ConstString(nullptr))
-                    .SetIsShadowStack(eLazyBoolNo)
-                    .SetMemoryTagged(eLazyBoolYes),
-            },
-            ""),
+        std::make_tuple("0-0 rw-p 00000000 00:00 0\n"
+                        "VmFlags:      mt      ",
+                        MemoryRegionInfos{
+                            MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
+                                             eLazyBoolYes, eLazyBoolNo,
+                                             eLazyBoolNo, eLazyBoolYes,
+                                             ConstString(nullptr))
+                                .SetIsShadowStack(eLazyBoolNo)
+                                .SetMemoryTagged(eLazyBoolYes),
+                        },
+                        ""),
         // VmFlags line means it has flag info, but nothing is set
-        std::make_tuple(
-            "0-0 rw-p 00000000 00:00 0\n"
-            "VmFlags:         ",
-            MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
-                                 eLazyBoolYes, eLazyBoolNo,
-                                 eLazyBoolNo, eLazyBoolYes,
-                                 ConstString(nullptr))
-                    .SetIsShadowStack(eLazyBoolNo)
-                    .SetMemoryTagged(eLazyBoolNo),
-            },
-            ""),
+        std::make_tuple("0-0 rw-p 00000000 00:00 0\n"
+                        "VmFlags:         ",
+                        MemoryRegionInfos{
+                            MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
+                                             eLazyBoolYes, eLazyBoolNo,
+                                             eLazyBoolNo, eLazyBoolYes,
+                                             ConstString(nullptr))
+                                .SetIsShadowStack(eLazyBoolNo)
+                                .SetMemoryTagged(eLazyBoolNo),
+                        },
+                        ""),
         // Handle some pages not having a flags line
         std::make_tuple(
             "1111-2222 rw-p 00000000 00:00 0    [foo]\n"
@@ -226,13 +218,11 @@ INSTANTIATE_TEST_SUITE_P(
             "3333-4444 r-xp 00000000 00:00 0    [bar]\n"
             "VmFlags: mt",
             MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0x1111, 0x2222),
-                                 eLazyBoolYes, eLazyBoolYes,
-                                 eLazyBoolNo, eLazyBoolNo,
+                MemoryRegionInfo(make_range(0x1111, 0x2222), eLazyBoolYes,
+                                 eLazyBoolYes, eLazyBoolNo, eLazyBoolNo,
                                  eLazyBoolYes, ConstString("[foo]")),
-                MemoryRegionInfo(make_range(0x3333, 0x4444),
-                                 eLazyBoolYes, eLazyBoolNo,
-                                 eLazyBoolYes, eLazyBoolNo,
+                MemoryRegionInfo(make_range(0x3333, 0x4444), eLazyBoolYes,
+                                 eLazyBoolNo, eLazyBoolYes, eLazyBoolNo,
                                  eLazyBoolYes, ConstString("[bar]"))
                     .SetIsShadowStack(eLazyBoolNo)
                     .SetMemoryTagged(eLazyBoolYes),
@@ -247,43 +237,39 @@ INSTANTIATE_TEST_SUITE_P(
             "KernelPageSize:        4 kB\n"
             "MMUPageSize:           4 kB\n",
             MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0x1111, 0x2222),
-                                 eLazyBoolYes, eLazyBoolYes,
-                                 eLazyBoolNo, eLazyBoolNo,
+                MemoryRegionInfo(make_range(0x1111, 0x2222), eLazyBoolYes,
+                                 eLazyBoolYes, eLazyBoolNo, eLazyBoolNo,
                                  eLazyBoolYes, ConstString(nullptr)),
-                MemoryRegionInfo(make_range(0x3333, 0x4444),
-                                 eLazyBoolYes, eLazyBoolNo,
-                                 eLazyBoolYes, eLazyBoolNo,
+                MemoryRegionInfo(make_range(0x3333, 0x4444), eLazyBoolYes,
+                                 eLazyBoolNo, eLazyBoolYes, eLazyBoolNo,
                                  eLazyBoolYes, ConstString(nullptr)),
             },
             ""),
         // We must look for exact flag strings, ignoring substrings of longer
         // flag names.
-        std::make_tuple(
-            "0-0 rw-p 00000000 00:00 0\n"
-            "VmFlags: amt mtb amtb",
-            MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
-                                 eLazyBoolYes, eLazyBoolNo,
-                                 eLazyBoolNo, eLazyBoolYes,
-                                 ConstString(nullptr))
-                    .SetIsShadowStack(eLazyBoolNo)
-                    .SetMemoryTagged(eLazyBoolNo),
-            },
-            ""),
+        std::make_tuple("0-0 rw-p 00000000 00:00 0\n"
+                        "VmFlags: amt mtb amtb",
+                        MemoryRegionInfos{
+                            MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
+                                             eLazyBoolYes, eLazyBoolNo,
+                                             eLazyBoolNo, eLazyBoolYes,
+                                             ConstString(nullptr))
+                                .SetIsShadowStack(eLazyBoolNo)
+                                .SetMemoryTagged(eLazyBoolNo),
+                        },
+                        ""),
         // "ss" means shadow stack.
-        std::make_tuple(
-            "0-0 rw-p 00000000 00:00 0\n"
-            "VmFlags: ss",
-            MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
-                                 eLazyBoolYes, eLazyBoolNo,
-                                 eLazyBoolNo, eLazyBoolYes,
-                                 ConstString(nullptr))
-                    .SetIsShadowStack(eLazyBoolYes)
-                    .SetMemoryTagged(eLazyBoolNo),
-            },
-            "")));
+        std::make_tuple("0-0 rw-p 00000000 00:00 0\n"
+                        "VmFlags: ss",
+                        MemoryRegionInfos{
+                            MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
+                                             eLazyBoolYes, eLazyBoolNo,
+                                             eLazyBoolNo, eLazyBoolYes,
+                                             ConstString(nullptr))
+                                .SetIsShadowStack(eLazyBoolYes)
+                                .SetMemoryTagged(eLazyBoolNo),
+                        },
+                        "")));
 
 TEST_P(LinuxProcSMapsTestFixture, ParseSMapRegions) {
   auto params = GetParam();

--- a/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
+++ b/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
@@ -87,9 +87,9 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rwzp 00000000 00:00 0\n"
             "2-3 r-xp 00000000 00:00 0 [def]\n",
             MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0, 1), MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                MemoryRegionInfo(make_range(0, 1), eLazyBoolYes,
+                                 eLazyBoolYes, eLazyBoolNo,
+                                 eLazyBoolNo, eLazyBoolYes,
                                  ConstString("[abc]")),
             },
             "unexpected /proc/{pid}/maps exec permission char"),
@@ -98,9 +98,9 @@ INSTANTIATE_TEST_SUITE_P(
             "55a4512f7000-55a451b68000 rw-p 00000000 00:00 0    [heap]",
             MemoryRegionInfos{
                 MemoryRegionInfo(make_range(0x55a4512f7000, 0x55a451b68000),
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[heap]")),
+                                 eLazyBoolYes, eLazyBoolYes,
+                                 eLazyBoolNo, eLazyBoolNo,
+                                 eLazyBoolYes, ConstString("[heap]")),
             },
             ""),
         // Multiple entries
@@ -111,18 +111,18 @@ INSTANTIATE_TEST_SUITE_P(
             "[vsyscall]",
             MemoryRegionInfos{
                 MemoryRegionInfo(make_range(0x7fc090021000, 0x7fc094000000),
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString(nullptr)),
+                                 eLazyBoolNo, eLazyBoolNo,
+                                 eLazyBoolNo, eLazyBoolNo,
+                                 eLazyBoolYes, ConstString(nullptr)),
                 MemoryRegionInfo(make_range(0x7fc094000000, 0x7fc094a00000),
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eYes, ConstString(nullptr)),
+                                 eLazyBoolNo, eLazyBoolNo,
+                                 eLazyBoolNo, eLazyBoolYes,
+                                 eLazyBoolYes, ConstString(nullptr)),
                 MemoryRegionInfo(
                     make_range(0xffffffffff600000, 0xffffffffff601000),
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eYes, ConstString("[vsyscall]")),
+                    eLazyBoolYes, eLazyBoolNo,
+                    eLazyBoolYes, eLazyBoolNo,
+                    eLazyBoolYes, ConstString("[vsyscall]")),
             },
             "")));
 
@@ -144,9 +144,9 @@ INSTANTIATE_TEST_SUITE_P(
             "0/0 rw-p 00000000 00:00 0",
             MemoryRegionInfos{
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]")),
+                                 eLazyBoolYes, eLazyBoolYes,
+                                 eLazyBoolNo, eLazyBoolNo,
+                                 eLazyBoolYes, ConstString("[foo]")),
             },
             "malformed /proc/{pid}/smaps entry, missing dash between address "
             "range"),
@@ -162,9 +162,9 @@ INSTANTIATE_TEST_SUITE_P(
             "1111-2222 rw-p 00000000 00:00 0    [foo]",
             MemoryRegionInfos{
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]")),
+                                 eLazyBoolYes, eLazyBoolYes,
+                                 eLazyBoolNo, eLazyBoolNo,
+                                 eLazyBoolYes, ConstString("[foo]")),
             },
             ""),
         // Single shared region parses, has no flags
@@ -172,9 +172,9 @@ INSTANTIATE_TEST_SUITE_P(
             "1111-2222 rw-s 00000000 00:00 0    [foo]",
             MemoryRegionInfos{
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]")),
+                                 eLazyBoolYes, eLazyBoolYes,
+                                 eLazyBoolNo, eLazyBoolYes,
+                                 eLazyBoolYes, ConstString("[foo]")),
             },
             ""),
         // Single region with flags, other lines ignored
@@ -185,11 +185,11 @@ INSTANTIATE_TEST_SUITE_P(
             "VmFlags: mt",
             MemoryRegionInfos{
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]"))
-                    .SetIsShadowStack(MemoryRegionInfo::eNo)
-                    .SetMemoryTagged(MemoryRegionInfo::eYes),
+                                 eLazyBoolYes, eLazyBoolYes,
+                                 eLazyBoolNo, eLazyBoolNo,
+                                 eLazyBoolYes, ConstString("[foo]"))
+                    .SetIsShadowStack(eLazyBoolNo)
+                    .SetMemoryTagged(eLazyBoolYes),
             },
             ""),
         // Whitespace ignored
@@ -197,12 +197,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rw-p 00000000 00:00 0\n"
             "VmFlags:      mt      ",
             MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
+                                 eLazyBoolYes, eLazyBoolNo,
+                                 eLazyBoolNo, eLazyBoolYes,
                                  ConstString(nullptr))
-                    .SetIsShadowStack(MemoryRegionInfo::eNo)
-                    .SetMemoryTagged(MemoryRegionInfo::eYes),
+                    .SetIsShadowStack(eLazyBoolNo)
+                    .SetMemoryTagged(eLazyBoolYes),
             },
             ""),
         // VmFlags line means it has flag info, but nothing is set
@@ -210,12 +210,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rw-p 00000000 00:00 0\n"
             "VmFlags:         ",
             MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
+                                 eLazyBoolYes, eLazyBoolNo,
+                                 eLazyBoolNo, eLazyBoolYes,
                                  ConstString(nullptr))
-                    .SetIsShadowStack(MemoryRegionInfo::eNo)
-                    .SetMemoryTagged(MemoryRegionInfo::eNo),
+                    .SetIsShadowStack(eLazyBoolNo)
+                    .SetMemoryTagged(eLazyBoolNo),
             },
             ""),
         // Handle some pages not having a flags line
@@ -227,15 +227,15 @@ INSTANTIATE_TEST_SUITE_P(
             "VmFlags: mt",
             MemoryRegionInfos{
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]")),
+                                 eLazyBoolYes, eLazyBoolYes,
+                                 eLazyBoolNo, eLazyBoolNo,
+                                 eLazyBoolYes, ConstString("[foo]")),
                 MemoryRegionInfo(make_range(0x3333, 0x4444),
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[bar]"))
-                    .SetIsShadowStack(MemoryRegionInfo::eNo)
-                    .SetMemoryTagged(MemoryRegionInfo::eYes),
+                                 eLazyBoolYes, eLazyBoolNo,
+                                 eLazyBoolYes, eLazyBoolNo,
+                                 eLazyBoolYes, ConstString("[bar]"))
+                    .SetIsShadowStack(eLazyBoolNo)
+                    .SetMemoryTagged(eLazyBoolYes),
             },
             ""),
         // Handle no pages having a flags line (older kernels)
@@ -248,13 +248,13 @@ INSTANTIATE_TEST_SUITE_P(
             "MMUPageSize:           4 kB\n",
             MemoryRegionInfos{
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString(nullptr)),
+                                 eLazyBoolYes, eLazyBoolYes,
+                                 eLazyBoolNo, eLazyBoolNo,
+                                 eLazyBoolYes, ConstString(nullptr)),
                 MemoryRegionInfo(make_range(0x3333, 0x4444),
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString(nullptr)),
+                                 eLazyBoolYes, eLazyBoolNo,
+                                 eLazyBoolYes, eLazyBoolNo,
+                                 eLazyBoolYes, ConstString(nullptr)),
             },
             ""),
         // We must look for exact flag strings, ignoring substrings of longer
@@ -263,12 +263,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rw-p 00000000 00:00 0\n"
             "VmFlags: amt mtb amtb",
             MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
+                                 eLazyBoolYes, eLazyBoolNo,
+                                 eLazyBoolNo, eLazyBoolYes,
                                  ConstString(nullptr))
-                    .SetIsShadowStack(MemoryRegionInfo::eNo)
-                    .SetMemoryTagged(MemoryRegionInfo::eNo),
+                    .SetIsShadowStack(eLazyBoolNo)
+                    .SetMemoryTagged(eLazyBoolNo),
             },
             ""),
         // "ss" means shadow stack.
@@ -276,12 +276,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rw-p 00000000 00:00 0\n"
             "VmFlags: ss",
             MemoryRegionInfos{
-                MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
+                                 eLazyBoolYes, eLazyBoolNo,
+                                 eLazyBoolNo, eLazyBoolYes,
                                  ConstString(nullptr))
-                    .SetIsShadowStack(MemoryRegionInfo::eYes)
-                    .SetMemoryTagged(MemoryRegionInfo::eNo),
+                    .SetIsShadowStack(eLazyBoolYes)
+                    .SetMemoryTagged(eLazyBoolNo),
             },
             "")));
 

--- a/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
+++ b/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
@@ -230,10 +230,9 @@ TEST(MemoryTagManagerAArch64MTETest, ExpandToGranule) {
 
 static MemoryRegionInfo MakeRegionInfo(lldb::addr_t base, lldb::addr_t size,
                                        bool tagged) {
-  return MemoryRegionInfo(MemoryRegionInfo::RangeType(base, size),
-                          eLazyBoolYes, eLazyBoolYes,
-                          eLazyBoolYes, eLazyBoolNo,
-                          eLazyBoolYes, ConstString())
+  return MemoryRegionInfo(MemoryRegionInfo::RangeType(base, size), eLazyBoolYes,
+                          eLazyBoolYes, eLazyBoolYes, eLazyBoolNo, eLazyBoolYes,
+                          ConstString())
       .SetMemoryTagged(tagged ? eLazyBoolYes : eLazyBoolNo);
 }
 

--- a/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
+++ b/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
@@ -231,10 +231,10 @@ TEST(MemoryTagManagerAArch64MTETest, ExpandToGranule) {
 static MemoryRegionInfo MakeRegionInfo(lldb::addr_t base, lldb::addr_t size,
                                        bool tagged) {
   return MemoryRegionInfo(MemoryRegionInfo::RangeType(base, size),
-                          MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
-                          MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                          MemoryRegionInfo::eYes, ConstString())
-      .SetMemoryTagged(tagged ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo);
+                          eLazyBoolYes, eLazyBoolYes,
+                          eLazyBoolYes, eLazyBoolNo,
+                          eLazyBoolYes, ConstString())
+      .SetMemoryTagged(tagged ? eLazyBoolYes : eLazyBoolNo);
 }
 
 TEST(MemoryTagManagerAArch64MTETest, MakeTaggedRange) {
@@ -304,7 +304,7 @@ TEST(MemoryTagManagerAArch64MTETest, MakeTaggedRange) {
                        llvm::FailedWithMessage(err_msg));
 
   // If we tag that first part it succeeds
-  memory_regions.back().SetMemoryTagged(MemoryRegionInfo::eYes);
+  memory_regions.back().SetMemoryTagged(eLazyBoolYes);
   expected_range = MemoryTagManagerAArch64MTE::TagRange(0x0, 0x1000);
   got = manager.MakeTaggedRange(0, 0x1000, memory_regions);
   ASSERT_THAT_EXPECTED(got, llvm::Succeeded());
@@ -324,7 +324,7 @@ TEST(MemoryTagManagerAArch64MTETest, MakeTaggedRange) {
                        llvm::FailedWithMessage(err_msg));
 
   // If we tag the last part it succeeds
-  memory_regions.back().SetMemoryTagged(MemoryRegionInfo::eYes);
+  memory_regions.back().SetMemoryTagged(eLazyBoolYes);
   got = manager.MakeTaggedRange(0, 0x1000, memory_regions);
   ASSERT_THAT_EXPECTED(got, llvm::Succeeded());
   ASSERT_EQ(*got, expected_range);
@@ -344,7 +344,7 @@ TEST(MemoryTagManagerAArch64MTETest, MakeTaggedRange) {
                        llvm::FailedWithMessage(err_msg));
 
   // If we tag the middle part it succeeds
-  memory_regions.back().SetMemoryTagged(MemoryRegionInfo::eYes);
+  memory_regions.back().SetMemoryTagged(eLazyBoolYes);
   got = manager.MakeTaggedRange(0, 0x1000, memory_regions);
   ASSERT_THAT_EXPECTED(got, llvm::Succeeded());
   ASSERT_EQ(*got, expected_range);
@@ -379,7 +379,7 @@ TEST(MemoryTagManagerAArch64MTETest, MakeTaggedRanges) {
   ASSERT_EQ(*got, std::vector<MemoryTagManager::TagRange>{});
 
   // Make the region tagged and it'll be the one range returned.
-  memory_regions.back().SetMemoryTagged(MemoryRegionInfo::eYes);
+  memory_regions.back().SetMemoryTagged(eLazyBoolYes);
   got = manager.MakeTaggedRanges(0, 0x20, memory_regions);
   ASSERT_THAT_EXPECTED(got, llvm::Succeeded());
   ASSERT_EQ(*got, std::vector<MemoryTagManager::TagRange>{

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
@@ -391,15 +391,15 @@ TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfo) {
   EXPECT_TRUE(result.get().Success());
   EXPECT_EQ(addr, region_info.GetRange().GetRangeBase());
   EXPECT_EQ(0x2000u, region_info.GetRange().GetByteSize());
-  EXPECT_EQ(lldb_private::MemoryRegionInfo::eYes, region_info.GetReadable());
-  EXPECT_EQ(lldb_private::MemoryRegionInfo::eNo, region_info.GetWritable());
-  EXPECT_EQ(lldb_private::MemoryRegionInfo::eYes, region_info.GetExecutable());
+  EXPECT_EQ(lldb_private::eLazyBoolYes, region_info.GetReadable());
+  EXPECT_EQ(lldb_private::eLazyBoolNo, region_info.GetWritable());
+  EXPECT_EQ(lldb_private::eLazyBoolYes, region_info.GetExecutable());
   EXPECT_EQ("/foo/bar.so", region_info.GetName().GetStringRef());
-  EXPECT_EQ(lldb_private::MemoryRegionInfo::eDontKnow,
+  EXPECT_EQ(lldb_private::eLazyBoolDontKnow,
             region_info.GetMemoryTagged());
-  EXPECT_EQ(lldb_private::MemoryRegionInfo::eDontKnow,
+  EXPECT_EQ(lldb_private::eLazyBoolDontKnow,
             region_info.IsStackMemory());
-  EXPECT_EQ(lldb_private::MemoryRegionInfo::eDontKnow,
+  EXPECT_EQ(lldb_private::eLazyBoolDontKnow,
             region_info.IsShadowStack());
 
   result = std::async(std::launch::async, [&] {
@@ -409,9 +409,9 @@ TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfo) {
   HandlePacket(server, "qMemoryRegionInfo:a000",
                "start:a000;size:2000;flags:;type:stack;");
   EXPECT_TRUE(result.get().Success());
-  EXPECT_EQ(lldb_private::MemoryRegionInfo::eNo, region_info.GetMemoryTagged());
-  EXPECT_EQ(lldb_private::MemoryRegionInfo::eYes, region_info.IsStackMemory());
-  EXPECT_EQ(lldb_private::MemoryRegionInfo::eNo, region_info.IsShadowStack());
+  EXPECT_EQ(lldb_private::eLazyBoolNo, region_info.GetMemoryTagged());
+  EXPECT_EQ(lldb_private::eLazyBoolYes, region_info.IsStackMemory());
+  EXPECT_EQ(lldb_private::eLazyBoolNo, region_info.IsShadowStack());
 
   result = std::async(std::launch::async, [&] {
     return client.GetMemoryRegionInfo(addr, region_info);
@@ -420,10 +420,10 @@ TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfo) {
   HandlePacket(server, "qMemoryRegionInfo:a000",
                "start:a000;size:2000;flags: mt  zz mt ss  ;type:ha,ha,stack;");
   EXPECT_TRUE(result.get().Success());
-  EXPECT_EQ(lldb_private::MemoryRegionInfo::eYes,
+  EXPECT_EQ(lldb_private::eLazyBoolYes,
             region_info.GetMemoryTagged());
-  EXPECT_EQ(lldb_private::MemoryRegionInfo::eYes, region_info.IsStackMemory());
-  EXPECT_EQ(lldb_private::MemoryRegionInfo::eYes, region_info.IsShadowStack());
+  EXPECT_EQ(lldb_private::eLazyBoolYes, region_info.IsStackMemory());
+  EXPECT_EQ(lldb_private::eLazyBoolYes, region_info.IsShadowStack());
 
   result = std::async(std::launch::async, [&] {
     return client.GetMemoryRegionInfo(addr, region_info);
@@ -432,7 +432,7 @@ TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfo) {
   HandlePacket(server, "qMemoryRegionInfo:a000",
                "start:a000;size:2000;type:heap;");
   EXPECT_TRUE(result.get().Success());
-  EXPECT_EQ(lldb_private::MemoryRegionInfo::eNo, region_info.IsStackMemory());
+  EXPECT_EQ(lldb_private::eLazyBoolNo, region_info.IsStackMemory());
 }
 
 TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfoInvalidResponse) {

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
@@ -395,12 +395,9 @@ TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfo) {
   EXPECT_EQ(lldb_private::eLazyBoolNo, region_info.GetWritable());
   EXPECT_EQ(lldb_private::eLazyBoolYes, region_info.GetExecutable());
   EXPECT_EQ("/foo/bar.so", region_info.GetName().GetStringRef());
-  EXPECT_EQ(lldb_private::eLazyBoolDontKnow,
-            region_info.GetMemoryTagged());
-  EXPECT_EQ(lldb_private::eLazyBoolDontKnow,
-            region_info.IsStackMemory());
-  EXPECT_EQ(lldb_private::eLazyBoolDontKnow,
-            region_info.IsShadowStack());
+  EXPECT_EQ(lldb_private::eLazyBoolDontKnow, region_info.GetMemoryTagged());
+  EXPECT_EQ(lldb_private::eLazyBoolDontKnow, region_info.IsStackMemory());
+  EXPECT_EQ(lldb_private::eLazyBoolDontKnow, region_info.IsShadowStack());
 
   result = std::async(std::launch::async, [&] {
     return client.GetMemoryRegionInfo(addr, region_info);
@@ -420,8 +417,7 @@ TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfo) {
   HandlePacket(server, "qMemoryRegionInfo:a000",
                "start:a000;size:2000;flags: mt  zz mt ss  ;type:ha,ha,stack;");
   EXPECT_TRUE(result.get().Success());
-  EXPECT_EQ(lldb_private::eLazyBoolYes,
-            region_info.GetMemoryTagged());
+  EXPECT_EQ(lldb_private::eLazyBoolYes, region_info.GetMemoryTagged());
   EXPECT_EQ(lldb_private::eLazyBoolYes, region_info.IsStackMemory());
   EXPECT_EQ(lldb_private::eLazyBoolYes, region_info.IsShadowStack());
 

--- a/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
+++ b/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
@@ -337,9 +337,9 @@ TEST_F(MinidumpParserTest, FindMemoryRangeWithFullMemoryMinidump) {
   EXPECT_FALSE(parser->FindMemoryRange(0x7ffe0000 + 4096).has_value());
 }
 
-constexpr auto yes = MemoryRegionInfo::eYes;
-constexpr auto no = MemoryRegionInfo::eNo;
-constexpr auto unknown = MemoryRegionInfo::eDontKnow;
+constexpr auto yes = eLazyBoolYes;
+constexpr auto no = eLazyBoolNo;
+constexpr auto unknown = eLazyBoolDontKnow;
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfo) {
   ASSERT_THAT_ERROR(SetUpFromYaml(R"(

--- a/lldb/unittests/Target/MemoryRegionInfoTest.cpp
+++ b/lldb/unittests/Target/MemoryRegionInfoTest.cpp
@@ -13,7 +13,7 @@
 using namespace lldb_private;
 
 TEST(MemoryRegionInfoTest, Formatv) {
-  EXPECT_EQ("yes", llvm::formatv("{0}", MemoryRegionInfo::eYes).str());
-  EXPECT_EQ("no", llvm::formatv("{0}", MemoryRegionInfo::eNo).str());
-  EXPECT_EQ("don't know", llvm::formatv("{0}", MemoryRegionInfo::eDontKnow).str());
+  EXPECT_EQ("yes", llvm::formatv("{0}", eLazyBoolYes).str());
+  EXPECT_EQ("no", llvm::formatv("{0}", eLazyBoolNo).str());
+  EXPECT_EQ("don't know", llvm::formatv("{0}", eLazyBoolDontKnow).str());
 }


### PR DESCRIPTION
The only difference between them is that OptionalBool's third state
is "unknown" and LazyBool's is "calculate". We don't need to tell
the difference in a single context, so I've made a new eLazyBoolDontKnow which is an
alias of eLazyBoolCalculate.