### PR TITLE
[CIR] Fix incorrect CIR_GlobalOp.global_visibility assembly format

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2849,7 +2849,7 @@ def CIR_GlobalOp : CIR_Op<"global", [
 
   let assemblyFormat = [{
     ($sym_visibility^)?
-    (`` $global_visibility^)?
+    (custom<VisibilityAttr>($global_visibility)^)?
     (`constant` $constant^)?
     $linkage
     (`comdat` $comdat^)?

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -221,10 +221,16 @@ void printVisibilityAttr(OpAsmPrinter &printer,
   }
 }
 
-void parseVisibilityAttr(OpAsmParser &parser, cir::VisibilityAttr &visibility) {
+void printVisibilityAttr(OpAsmPrinter &printer, cir::GlobalOp,
+                         cir::VisibilityAttr visibility) {
+    printVisibilityAttr(printer, visibility);
+}
+
+mlir::OptionalParseResult parseVisibilityAttr(OpAsmParser &parser, cir::VisibilityAttr &visibility) {
   cir::VisibilityKind visibilityKind =
       parseOptionalCIRKeyword(parser, cir::VisibilityKind::Default);
   visibility = cir::VisibilityAttr::get(parser.getContext(), visibilityKind);
+  return mlir::success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -223,10 +223,11 @@ void printVisibilityAttr(OpAsmPrinter &printer,
 
 void printVisibilityAttr(OpAsmPrinter &printer, cir::GlobalOp,
                          cir::VisibilityAttr visibility) {
-    printVisibilityAttr(printer, visibility);
+  printVisibilityAttr(printer, visibility);
 }
 
-mlir::OptionalParseResult parseVisibilityAttr(OpAsmParser &parser, cir::VisibilityAttr &visibility) {
+mlir::OptionalParseResult parseVisibilityAttr(OpAsmParser &parser,
+                                              cir::VisibilityAttr &visibility) {
   cir::VisibilityKind visibilityKind =
       parseOptionalCIRKeyword(parser, cir::VisibilityKind::Default);
   visibility = cir::VisibilityAttr::get(parser.getContext(), visibilityKind);

--- a/clang/test/CIR/CodeGen/attribute-visibility.c
+++ b/clang/test/CIR/CodeGen/attribute-visibility.c
@@ -1,0 +1,45 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+int normal_var = 10;
+// CIR: cir.global external @normal_var {{.*}}
+// LLVM: @normal_var = global {{.*}}
+// OGCG: @normal_var = global {{.*}}
+
+__attribute__((visibility("hidden")))
+int hidden_var = 10;
+// CIR: cir.global hidden external @hidden_var {{.*}}
+// LLVM: @hidden_var = hidden global {{.*}}
+// OGCG: @hidden_var = hidden global {{.*}}
+
+static int normal_static_var = 10;
+// CIR: cir.global "private" internal dso_local @normal_static_var {{.*}}
+// LLVM: @normal_static_var = internal global {{.*}}
+// OGCG: @normal_static_var = internal global {{.*}}
+
+__attribute__((visibility("hidden")))
+static int hidden_static_var = 10;
+// CIR: cir.global "private" hidden internal dso_local @hidden_static_var {{.*}}
+// LLVM: @hidden_static_var = internal hidden global {{.*}}
+// OGCG: @hidden_static_var = internal global {{.*}}
+
+void normal_func() {
+    normal_var = 0;
+    normal_static_var = 0;
+}
+// CIR: cir.func no_inline no_proto dso_local @normal_func() {{.*}} {
+// LLVM: define dso_local void @normal_func() {{.*}}
+// OGCG: define dso_local void @normal_func() {{.*}}
+
+__attribute__((visibility("hidden")))
+void hidden_func() {
+    hidden_var = 0;
+    hidden_static_var = 0;
+}
+// CIR: cir.func no_inline no_proto hidden dso_local @hidden_func() {{.*}} {
+// LLVM: define hidden void @hidden_func() {{.*}}
+// OGCG: define hidden void @hidden_func() {{.*}}

--- a/clang/test/CIR/CodeGen/attribute-visibility.c
+++ b/clang/test/CIR/CodeGen/attribute-visibility.c
@@ -21,12 +21,6 @@ static int normal_static_var = 10;
 // LLVM: @normal_static_var = internal global {{.*}}
 // OGCG: @normal_static_var = internal global {{.*}}
 
-__attribute__((visibility("hidden")))
-static int hidden_static_var = 10;
-// CIR: cir.global "private" hidden internal dso_local @hidden_static_var {{.*}}
-// LLVM: @hidden_static_var = internal hidden global {{.*}}
-// OGCG: @hidden_static_var = internal global {{.*}}
-
 void normal_func() {
     normal_var = 0;
     normal_static_var = 0;
@@ -38,7 +32,6 @@ void normal_func() {
 __attribute__((visibility("hidden")))
 void hidden_func() {
     hidden_var = 0;
-    hidden_static_var = 0;
 }
 // CIR: cir.func no_inline no_proto hidden dso_local @hidden_func() {{.*}} {
 // LLVM: define hidden void @hidden_func() {{.*}}

--- a/clang/test/CIR/IR/attribute-visibility.cir
+++ b/clang/test/CIR/IR/attribute-visibility.cir
@@ -1,0 +1,28 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+module {
+  cir.global external dso_local @normal_var = #cir.int<10> : !s32i {alignment = 4 : i64}
+  // CHECK: cir.global external dso_local @normal_var = #cir.int<10> : !s32i {alignment = 4 : i64}
+
+  cir.global hidden external dso_local @hidden_var = #cir.int<10> : !s32i {alignment = 4 : i64}
+  // CHECK: cir.global hidden external dso_local @hidden_var = #cir.int<10> : !s32i {alignment = 4 : i64}
+
+  cir.global "private" internal dso_local @normal_static_var = #cir.int<10> : !s32i {alignment = 4 : i64}
+  // CHECK: cir.global "private" internal dso_local @normal_static_var = #cir.int<10> : !s32i {alignment = 4 : i64}
+
+  cir.global "private" hidden internal dso_local @hidden_static_var = #cir.int<10> : !s32i {alignment = 4 : i64}
+  // CHECK: cir.global "private" hidden internal dso_local @hidden_static_var = #cir.int<10> : !s32i {alignment = 4 : i64}
+
+  cir.func no_inline no_proto dso_local @normal_func() {
+    cir.return
+  }
+  // CHECK: cir.func no_inline no_proto dso_local @normal_func()
+  // CHECK:   cir.return
+
+  cir.func no_inline no_proto hidden dso_local @hidden_func() {
+    cir.return
+  }
+  // CHECK: cir.func no_inline no_proto hidden dso_local @hidden_func()
+  // CHECK:   cir.return
+}


### PR DESCRIPTION
Closes #189666 .

Fix incorrect printing and parsing of `cir.global` if `global_visibility` attribute is present. Incorrect assembly format 
```
(`` $global_visibility^)?
```

Resulted in keyword sticking to previous word and producing incorrect cir like this:
```
cir.globalhidden external dso_local @hidden_var = #cir.int<10> : !s32i {alignment = 4 : i64} loc(#loc22)
cir.global "private"hidden internal dso_local @hidden_static_var = #cir.int<10> : !s32i {alignment = 4 : i64} loc(#loc24)
```

Using custom parser/printer that is used in `cir.func` parser fixes this issue and makes printed/parsed attribute for functions and global values consistent.

Also added tests for both global values and functions.