### PR TITLE
[lldb] Use GetOutputStream instead of repeated AppendMessageWithFormat

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -114,9 +114,6 @@ public:
 
   void AppendMessage(llvm::StringRef in_string);
 
-  void AppendMessageWithFormat(const char *format, ...)
-      __attribute__((format(printf, 2, 3)));
-
   void AppendNote(llvm::StringRef in_string);
 
   void AppendNoteWithFormat(const char *format, ...)

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -1701,15 +1701,16 @@ protected:
           page_count);
       if (page_count > 0) {
         bool print_comma = false;
-        result.AppendMessageWithFormat("Dirty pages: ");
+        Stream &strm = result.GetOutputStream();
+        strm << "Dirty pages: ";
         for (size_t i = 0; i < page_count; i++) {
           if (print_comma)
-            result.AppendMessageWithFormat(", ");
+            strm << ", ";
           else
             print_comma = true;
-          result.AppendMessageWithFormat("0x%" PRIx64, (*dirty_page_list)[i]);
+          strm << llvm::formatv("{0:x}", (*dirty_page_list)[i]);
         }
-        result.AppendMessage(".");
+        strm << ".\n";
       }
     }
   }

--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -1288,10 +1288,11 @@ protected:
           result.AppendMessageWithFormatv(
               "{0} matching process{1} found on \"{2}\"", matches,
               matches > 1 ? "es were" : " was", platform_sp->GetName());
+          Stream &strm = result.GetOutputStream();
           if (match_desc)
-            result.AppendMessageWithFormat(" whose name %s \"%s\"", match_desc,
-                                           match_name);
-          result.AppendMessageWithFormat("\n");
+            strm << llvm::formatv(" whose name {0} \"{1}\"", match_desc,
+                                  match_name);
+          strm.PutChar('\n');
           ProcessInstanceInfo::DumpTableHeader(ostrm, m_options.show_args,
                                                m_options.verbose);
           for (uint32_t i = 0; i < matches; ++i) {

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -5472,13 +5472,14 @@ protected:
       return;
     }
 
-    result.AppendMessageWithFormat("%zu frame provider(s) registered:\n\n",
-                                   descriptors.size());
+    Stream &strm = result.GetOutputStream();
+    strm << llvm::formatv("{0} frame provider(s) registered:\n\n",
+                          descriptors.size());
 
     for (const auto &entry : descriptors) {
       const ScriptedFrameProviderDescriptor &descriptor = entry.second;
-      descriptor.Dump(&result.GetOutputStream());
-      result.GetOutputStream().PutChar('\n');
+      descriptor.Dump(&strm);
+      strm.PutChar('\n');
     }
 
     result.SetStatus(eReturnStatusSuccessFinishResult);

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -877,10 +877,11 @@ public:
           result.AppendError("no valid thread indexes were specified");
           return;
         } else {
+          Stream &strm = result.GetOutputStream();
           if (resume_threads.size() == 1)
-            result.AppendMessageWithFormat("Resuming thread: ");
+            strm << "Resuming thread: ";
           else
-            result.AppendMessageWithFormat("Resuming threads: ");
+            strm << "Resuming threads: ";
 
           for (uint32_t idx = 0; idx < num_threads; ++idx) {
             Thread *thread =
@@ -891,9 +892,9 @@ public:
             if (this_thread_pos != resume_threads.end()) {
               resume_threads.erase(this_thread_pos);
               if (!resume_threads.empty())
-                result.AppendMessageWithFormat("%u, ", thread->GetIndexID());
+                strm << llvm::formatv("{0}, ", thread->GetIndexID());
               else
-                result.AppendMessageWithFormat("%u ", thread->GetIndexID());
+                strm << llvm::formatv("{0} ", thread->GetIndexID());
 
               const bool override_suspend = true;
               thread->SetResumeState(eStateRunning, override_suspend);

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -257,7 +257,7 @@ void CommandInterpreter::ResolveCommand(const char *command_line,
                                         CommandReturnObject &result) {
   std::string command = command_line;
   if (ResolveCommandImpl(command, result) != nullptr) {
-    result.AppendMessageWithFormat("%s", command.c_str());
+    result.GetOutputStream() << command;
     result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 }

--- a/lldb/source/Interpreter/CommandReturnObject.cpp
+++ b/lldb/source/Interpreter/CommandReturnObject.cpp
@@ -68,18 +68,6 @@ void CommandReturnObject::AppendErrorWithFormat(const char *format, ...) {
   }
 }
 
-void CommandReturnObject::AppendMessageWithFormat(const char *format, ...) {
-  if (!format)
-    return;
-  va_list args;
-  va_start(args, format);
-  StreamString sstrm;
-  sstrm.PrintfVarArg(format, args);
-  va_end(args);
-
-  GetOutputStream() << sstrm.GetString();
-}
-
 void CommandReturnObject::AppendNoteWithFormat(const char *format, ...) {
   if (!format)
     return;


### PR DESCRIPTION
AppendMessageWithFormat is odd because it's the only AppendMessage...
method that does not add a newline for you.

This PR changes places that use it to output raw text, or build
up a large message. They now use GetOutputStream() instead,
which makes it a bit clearer that we're building one big message,
and where newlines end up. 

This removes the last callers of AppendMessageWithFormat, so I am
removing it too.