### PR TITLE
[AArch64][llvm] Fix encoding for `stshh` instruction (#189588)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -1850,7 +1850,7 @@ class STSHHI
     : SimpleSystemI<0, (ins phint_op:$policy), "stshh", "\t$policy", []>,
       Sched<[WriteHint]> {
   bits<3> policy;
-  let Inst{20-12} = 0b000011001;
+  let Inst{20-12} = 0b000110010;
   let Inst{11-8} = 0b0110;
   let Inst{7-5} = policy;
 }

--- a/llvm/test/MC/AArch64/armv9.6a-pcdphint.s
+++ b/llvm/test/MC/AArch64/armv9.6a-pcdphint.s
@@ -14,12 +14,12 @@
 
 stshh keep
 // CHECK-INST: stshh keep
-// CHECK-ENCODING: encoding: [0x1f,0x96,0x01,0xd5]
+// CHECK-ENCODING: encoding: [0x1f,0x26,0x03,0xd5]
 // CHECK-ERROR: error: instruction requires: pcdphint
-// CHECK-UNKNOWN:  d501961f      msr S0_1_C9_C6_0, xzr
+// CHECK-UNKNOWN:  d503261f      hint #0x30
 
 stshh strm
 // CHECK-INST: stshh strm
-// CHECK-ENCODING: encoding: [0x3f,0x96,0x01,0xd5]
+// CHECK-ENCODING: encoding: [0x3f,0x26,0x03,0xd5]
 // CHECK-ERROR: error: instruction requires: pcdphint
-// CHECK-UNKNOWN:  d501963f      msr S0_1_C9_C6_1, xzr
+// CHECK-UNKNOWN:  d503263f      hint #0x31


### PR DESCRIPTION
The encoding for `stshh` was incorrect, and has been fixed. This has been checked against the Arm ARM.