### PR TITLE
[offload][lit] Disable target_critical_region.cpp on Intel GPU

### DIFF
--- a/offload/test/offloading/target_critical_region.cpp
+++ b/offload/test/offloading/target_critical_region.cpp
@@ -4,6 +4,7 @@
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 // UNSUPPORTED: amdgcn-amd-amdhsa
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
Already disabled on other GPU platforms and sporadically failing on our builder, so this test seems not be doing too hot.