### PR TITLE
[HLSL] Fix test writing to an output files

### DIFF
--- a/clang/test/SemaHLSL/Texture2D-mips-errors.hlsl
+++ b/clang/test/SemaHLSL/Texture2D-mips-errors.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm-only -o - -disable-llvm-passes -finclude-default-header -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm-only -disable-llvm-passes -finclude-default-header -verify %s
 
 Texture2D<float4> t;
 

--- a/clang/test/SemaHLSL/Texture2D-mips-errors.hlsl
+++ b/clang/test/SemaHLSL/Texture2D-mips-errors.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm -disable-llvm-passes -finclude-default-header -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -emit-llvm-only -o - -disable-llvm-passes -finclude-default-header -verify %s
 
 Texture2D<float4> t;
 


### PR DESCRIPTION
The Texture2D-mips-errors.hlsl test was writing it output to a file, but
that is not needed.
