### PR TITLE
[lldb][Platform] Handle LoadScriptFromSymFile per-module FileSpec

### DIFF
--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -273,15 +273,15 @@ public:
 
   /// Locate the scripting resource given a module specification.
   ///
-  /// Locating the file should happen only on the local computer or using the
-  /// current computers global settings.
-  FileSpecList LocateExecutableScriptingResources(Target *target,
-                                                  Module &module,
-                                                  Stream &feedback_stream);
+  /// Returns a map from a located script's \c FileSpec to the
+  /// \c LoadScriptFromSymFile with which LLDB should load it.
+  llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
+  LocateExecutableScriptingResources(Target *target, Module &module,
+                                     Stream &feedback_stream);
 
   /// Locate the platform-specific scripting resource given a module
   /// specification.
-  virtual FileSpecList
+  virtual llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
   LocateExecutableScriptingResourcesForPlatform(Target *target, Module &module,
                                                 Stream &feedback_stream);
 
@@ -291,8 +291,10 @@ public:
   ///
   /// E.g., for Python it will look for a script at:
   ///   \c <safe-path>/<module-name>/<module-name>.py
-  static FileSpecList LocateExecutableScriptingResourcesFromSafePaths(
-      Stream &feedback_stream, FileSpec module_spec, const Target &target);
+  static llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
+  LocateExecutableScriptingResourcesFromSafePaths(Stream &feedback_stream,
+                                                  FileSpec module_spec,
+                                                  const Target &target);
 
   /// \param[in] module_spec
   ///     The ModuleSpec of a binary to find.

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1440,12 +1440,6 @@ bool Module::LoadScriptingResourceInTarget(Target *target, Status &error) {
     return false;
   }
 
-  LoadScriptFromSymFile should_load =
-      target->TargetProperties::GetLoadScriptFromSymbolFile();
-
-  if (should_load == eLoadScriptFromSymFileFalse)
-    return false;
-
   Debugger &debugger = target->GetDebugger();
   const ScriptLanguage script_language = debugger.GetScriptLanguage();
   if (script_language == eScriptLanguageNone)
@@ -1465,22 +1459,21 @@ bool Module::LoadScriptingResourceInTarget(Target *target, Status &error) {
   }
 
   StreamString feedback_stream;
-  FileSpecList file_specs = platform_sp->LocateExecutableScriptingResources(
-      target, *this, feedback_stream);
+  llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile> file_specs =
+      platform_sp->LocateExecutableScriptingResources(target, *this,
+                                                      feedback_stream);
 
   if (!feedback_stream.Empty())
     debugger.ReportWarning(feedback_stream.GetString().str(), debugger.GetID());
 
-  const uint32_t num_specs = file_specs.GetSize();
-  if (num_specs == 0)
-    return true;
+  for (const auto &[scripting_fspec, load_style] : file_specs) {
+    if (load_style == eLoadScriptFromSymFileFalse)
+      continue;
 
-  for (uint32_t i = 0; i < num_specs; ++i) {
-    FileSpec scripting_fspec(file_specs.GetFileSpecAtIndex(i));
     if (!FileSystem::Instance().Exists(scripting_fspec))
       continue;
 
-    if (should_load == eLoadScriptFromSymFileWarn) {
+    if (load_style == eLoadScriptFromSymFileWarn) {
       // clang-format off
       debugger.ReportWarning(
           llvm::formatv(

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -256,13 +256,13 @@ PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
 llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
 PlatformDarwin::LocateExecutableScriptingResourcesForPlatform(
     Target *target, Module &module, Stream &feedback_stream) {
-  llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile> file_specs;
+  llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile> empty;
   if (!target)
-    return file_specs;
+    return empty;
 
   // For now only Python scripts supported for auto-loading.
   if (target->GetDebugger().GetScriptLanguage() != eScriptLanguagePython)
-    return file_specs;
+    return empty;
 
   // NB some extensions might be meaningful and should not be stripped -
   // "this.binary.file"
@@ -274,15 +274,15 @@ PlatformDarwin::LocateExecutableScriptingResourcesForPlatform(
   const FileSpec &module_spec = module.GetFileSpec();
 
   if (!module_spec)
-    return file_specs;
+    return empty;
 
   SymbolFile *symfile = module.GetSymbolFile();
   if (!symfile)
-    return file_specs;
+    return empty;
 
   ObjectFile *objfile = symfile->GetObjectFile();
   if (!objfile)
-    return file_specs;
+    return empty;
 
   const FileSpec &symfile_spec = objfile->GetFileSpec();
   if (symfile_spec &&
@@ -292,7 +292,7 @@ PlatformDarwin::LocateExecutableScriptingResourcesForPlatform(
     return LocateExecutableScriptingResourcesFromDSYM(
         feedback_stream, module_spec, *target, symfile_spec);
 
-  return file_specs;
+  return empty;
 }
 
 Status PlatformDarwin::ResolveSymbolFile(Target &target,

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -196,7 +196,8 @@ PlatformDarwin::PutFile(const lldb_private::FileSpec &source,
   return PlatformPOSIX::PutFile(source, destination, uid, gid);
 }
 
-FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
+llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
+PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
     Stream &feedback_stream, FileSpec module_spec, const Target &target,
     const FileSpec &symfile_spec) {
 
@@ -204,7 +205,7 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
          "Trying to locate scripting resources but no ScriptInterpreter is "
          "available.");
 
-  FileSpecList file_list;
+  llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile> file_specs;
   while (module_spec.GetFilename()) {
     ScriptInterpreter::SanitizedScriptingModuleName sanitized_name =
         target.GetDebugger()
@@ -234,7 +235,8 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
                                          orig_script_fspec, script_fspec);
 
     if (FileSystem::Instance().Exists(script_fspec)) {
-      file_list.Append(script_fspec);
+      file_specs.try_emplace(std::move(script_fspec),
+                             target.GetLoadScriptFromSymbolFile());
       break;
     }
 
@@ -248,17 +250,19 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
     module_spec.SetFilename(filename_no_extension);
   }
 
-  return file_list;
+  return file_specs;
 }
 
-FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesForPlatform(
+llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
+PlatformDarwin::LocateExecutableScriptingResourcesForPlatform(
     Target *target, Module &module, Stream &feedback_stream) {
+  llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile> file_specs;
   if (!target)
-    return {};
+    return file_specs;
 
   // For now only Python scripts supported for auto-loading.
   if (target->GetDebugger().GetScriptLanguage() != eScriptLanguagePython)
-    return {};
+    return file_specs;
 
   // NB some extensions might be meaningful and should not be stripped -
   // "this.binary.file"
@@ -270,15 +274,15 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesForPlatform(
   const FileSpec &module_spec = module.GetFileSpec();
 
   if (!module_spec)
-    return {};
+    return file_specs;
 
   SymbolFile *symfile = module.GetSymbolFile();
   if (!symfile)
-    return {};
+    return file_specs;
 
   ObjectFile *objfile = symfile->GetObjectFile();
   if (!objfile)
-    return {};
+    return file_specs;
 
   const FileSpec &symfile_spec = objfile->GetFileSpec();
   if (symfile_spec &&
@@ -288,7 +292,7 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesForPlatform(
     return LocateExecutableScriptingResourcesFromDSYM(
         feedback_stream, module_spec, *target, symfile_spec);
 
-  return {};
+  return file_specs;
 }
 
 Status PlatformDarwin::ResolveSymbolFile(Target &target,

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -67,7 +67,8 @@ public:
   Status ResolveSymbolFile(Target &target, const ModuleSpec &sym_spec,
                            FileSpec &sym_file) override;
 
-  FileSpecList LocateExecutableScriptingResourcesForPlatform(
+  llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
+  LocateExecutableScriptingResourcesForPlatform(
       Target *target, Module &module_spec, Stream &feedback_stream) override;
 
   Status GetSharedModule(const ModuleSpec &module_spec, Process *process,
@@ -150,9 +151,11 @@ public:
   /// Resources directory in the same dSYM.
   /// E.g., \c /path/to/.dSYM/Contents/Resources/DWARF/a.out
   ///
-  static FileSpecList LocateExecutableScriptingResourcesFromDSYM(
-      Stream &feedback_stream, FileSpec module_spec, const Target &target,
-      const FileSpec &symfile_spec);
+  static llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
+  LocateExecutableScriptingResourcesFromDSYM(Stream &feedback_stream,
+                                             FileSpec module_spec,
+                                             const Target &target,
+                                             const FileSpec &symfile_spec);
 
 protected:
   static const char *GetCompatibleArch(ArchSpec::Core core, size_t idx);

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -157,14 +157,17 @@ Status Platform::GetFileWithUUID(const FileSpec &platform_file,
   return Status();
 }
 
-FileSpecList Platform::LocateExecutableScriptingResourcesFromSafePaths(
+llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
+Platform::LocateExecutableScriptingResourcesFromSafePaths(
     Stream &feedback_stream, FileSpec module_spec, const Target &target) {
   assert(module_spec);
   assert(target.GetDebugger().GetScriptInterpreter());
 
+  llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile> file_specs;
+
   // For now only Python scripts supported for auto-loading.
   if (target.GetDebugger().GetScriptLanguage() != eScriptLanguagePython)
-    return {};
+    return file_specs;
 
   ScriptInterpreter::SanitizedScriptingModuleName sanitized_name =
       target.GetDebugger()
@@ -172,7 +175,6 @@ FileSpecList Platform::LocateExecutableScriptingResourcesFromSafePaths(
           ->GetSanitizedScriptingModuleName(
               module_spec.GetFileNameStrippingExtension().GetStringRef());
 
-  FileSpecList file_list;
   FileSpecList paths = Debugger::GetSafeAutoLoadPaths();
 
   // Iterate in reverse so we consider the latest appended path first.
@@ -197,36 +199,40 @@ FileSpecList Platform::LocateExecutableScriptingResourcesFromSafePaths(
                                          orig_script_fspec, script_fspec);
 
     if (FileSystem::Instance().Exists(script_fspec))
-      file_list.Append(script_fspec);
+      file_specs.try_emplace(std::move(script_fspec),
+                             target.GetLoadScriptFromSymbolFile());
 
     // If we successfully found a directory in a safe auto-load path
     // stop looking at any other paths.
     break;
   }
 
-  return file_list;
+  return file_specs;
 }
 
-FileSpecList Platform::LocateExecutableScriptingResourcesForPlatform(
+llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
+Platform::LocateExecutableScriptingResourcesForPlatform(
     Target *target, Module &module, Stream &feedback_stream) {
-  return {};
+  llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile> empty;
+  return empty;
 }
 
-FileSpecList
+llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
 Platform::LocateExecutableScriptingResources(Target *target, Module &module,
                                              Stream &feedback_stream) {
+  llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile> empty;
   if (!target)
-    return {};
+    return empty;
 
   // Give derived platforms a chance to locate scripting resources.
-  if (FileSpecList fspecs = LocateExecutableScriptingResourcesForPlatform(
+  if (auto fspecs = LocateExecutableScriptingResourcesForPlatform(
           target, module, feedback_stream);
-      !fspecs.IsEmpty())
+      !fspecs.empty())
     return fspecs;
 
   const FileSpec &module_spec = module.GetFileSpec();
   if (!module_spec)
-    return {};
+    return empty;
 
   return LocateExecutableScriptingResourcesFromSafePaths(feedback_stream,
                                                          module_spec, *target);

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -145,12 +145,11 @@ TEST_F(PlatformDarwinLocateTest,
   CreateFile("TestModule.sh", m_tmp_dsym_python_dir);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 1u);
-  EXPECT_EQ(fspecs.GetFileSpecAtIndex(0).GetFilename(), "TestModule.py");
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 1u);
+  EXPECT_EQ(fspecs.begin()->getFirst().GetFilename(), "TestModule.py");
 }
 
 TEST_F(PlatformDarwinLocateTest,
@@ -171,12 +170,11 @@ TEST_F(PlatformDarwinLocateTest,
   CreateFile("TestModule.sh", m_tmp_dsym_python_dir);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 1u);
-  EXPECT_EQ(fspecs.GetFileSpecAtIndex(0).GetFilename(), "TestModule.py");
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 1u);
+  EXPECT_EQ(fspecs.begin()->getFirst().GetFilename(), "TestModule.py");
 }
 
 TEST_F(PlatformDarwinLocateTest,
@@ -197,11 +195,10 @@ TEST_F(PlatformDarwinLocateTest,
   CreateFile("TestModule.1.py", m_tmp_dsym_python_dir);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 0u);
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 0u);
 }
 
 TEST_F(PlatformDarwinLocateTest,
@@ -228,11 +225,10 @@ TEST_F(PlatformDarwinLocateTest,
   CreateFile("TestModule.py", nested_dir);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 0u);
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 0u);
 }
 
 TEST_F(
@@ -256,12 +252,11 @@ TEST_F(
   CreateFile("TestModule_import.py", m_tmp_dsym_python_dir);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 1u);
-  EXPECT_EQ(fspecs.GetFileSpecAtIndex(0).GetFilename(), "TestModule_import.py");
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 1u);
+  EXPECT_EQ(fspecs.begin()->getFirst().GetFilename(), "TestModule_import.py");
   EXPECT_TRUE(ss.Empty());
 }
 
@@ -285,11 +280,10 @@ TEST_F(PlatformDarwinLocateTest,
   ASSERT_TRUE(script_fspec);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 0u);
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 0u);
 
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because 'import.py' "
@@ -321,12 +315,11 @@ TEST_F(PlatformDarwinLocateTest,
   ASSERT_TRUE(orig_fspec);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 1u);
-  EXPECT_EQ(fspecs.GetFileSpecAtIndex(0).GetFilename(), "_import.py");
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 1u);
+  EXPECT_EQ(fspecs.begin()->getFirst().GetFilename(), "_import.py");
 
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because 'import.py' "
@@ -356,12 +349,11 @@ TEST_F(
   CreateFile("_import.py", m_tmp_dsym_python_dir);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 1u);
-  EXPECT_EQ(fspecs.GetFileSpecAtIndex(0).GetFilename(), "_import.py");
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 1u);
+  EXPECT_EQ(fspecs.begin()->getFirst().GetFilename(), "_import.py");
   EXPECT_TRUE(ss.GetString().empty());
 }
 
@@ -386,11 +378,10 @@ TEST_F(
   ASSERT_TRUE(script_fspec);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 0u);
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 0u);
 
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because 'TestModule-1.1 1.py' "
@@ -423,12 +414,11 @@ TEST_F(
   CreateFile("TestModule_1_1_1.py", m_tmp_dsym_python_dir);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 1u);
-  EXPECT_EQ(fspecs.GetFileSpecAtIndex(0).GetFilename(), "TestModule_1_1_1.py");
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 1u);
+  EXPECT_EQ(fspecs.begin()->getFirst().GetFilename(), "TestModule_1_1_1.py");
 
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because"
@@ -458,12 +448,11 @@ TEST_F(
   CreateFile("TestModule_1_1_1.py", m_tmp_dsym_python_dir);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 1u);
-  EXPECT_EQ(fspecs.GetFileSpecAtIndex(0).GetFilename(), "TestModule_1_1_1.py");
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 1u);
+  EXPECT_EQ(fspecs.begin()->getFirst().GetFilename(), "TestModule_1_1_1.py");
   EXPECT_TRUE(ss.GetString().empty());
 }
 
@@ -487,11 +476,10 @@ TEST_F(
   CreateFile("mykeyword-1.1 1.py", m_tmp_dsym_python_dir);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 0u);
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 0u);
   EXPECT_TRUE(
       ss.GetString().contains("conflicts with the keyword 'mykeyword_1_1_1'"));
 }
@@ -518,12 +506,11 @@ TEST_F(
   CreateFile("_mykeyword_1_1_1.py", m_tmp_dsym_python_dir);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 1u);
-  EXPECT_EQ(fspecs.GetFileSpecAtIndex(0).GetFilename(), "_mykeyword_1_1_1.py");
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 1u);
+  EXPECT_EQ(fspecs.begin()->getFirst().GetFilename(), "_mykeyword_1_1_1.py");
   EXPECT_TRUE(ss.GetString().contains("Ignoring 'mykeyword-1.1 1.py' and "
                                       "loading '_mykeyword_1_1_1.py' instead"));
 }
@@ -550,12 +537,11 @@ TEST_F(
   CreateFile("_mykeyword_1_1_1.py", m_tmp_dsym_python_dir);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 1u);
-  EXPECT_EQ(fspecs.GetFileSpecAtIndex(0).GetFilename(), "_mykeyword_1_1_1.py");
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 1u);
+  EXPECT_EQ(fspecs.begin()->getFirst().GetFilename(), "_mykeyword_1_1_1.py");
   EXPECT_TRUE(ss.Empty());
 }
 
@@ -591,11 +577,10 @@ TEST_P(PlatformDarwinLocateWithSpecialCharsTestFixture,
   CreateFile(script_name, m_tmp_dsym_python_dir);
 
   StreamString ss;
-  FileSpecList fspecs =
-      std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
-          ->LocateExecutableScriptingResourcesFromDSYM(
-              ss, module_fspec, *m_target_sp, dsym_module_fpec);
-  EXPECT_EQ(fspecs.GetSize(), 0u);
+  auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                    ->LocateExecutableScriptingResourcesFromDSYM(
+                        ss, module_fspec, *m_target_sp, dsym_module_fpec);
+  EXPECT_EQ(fspecs.size(), 0u);
 
   std::string expected =
       llvm::formatv("please rename it to '{0}'", recommended_script_name);

--- a/lldb/unittests/Platform/PlatformTest.cpp
+++ b/lldb/unittests/Platform/PlatformTest.cpp
@@ -18,6 +18,7 @@
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Target/Platform.h"
+#include "lldb/Target/Target.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -225,11 +226,10 @@ TEST_F(PlatformLocateSafePathTest,
   CreateFile("TestModule.py", module_dir);
 
   StreamString ss;
-  FileSpecList file_specs =
-      Platform::LocateExecutableScriptingResourcesFromSafePaths(
-          ss, module_fspec, *m_target_sp);
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
 
-  ASSERT_EQ(file_specs.GetSize(), 0u);
+  ASSERT_EQ(file_specs.size(), 0u);
 }
 
 TEST_F(PlatformLocateSafePathTest,
@@ -252,11 +252,10 @@ TEST_F(PlatformLocateSafePathTest,
   CreateFile("TestModule1.py", module_dir);
 
   StreamString ss;
-  FileSpecList file_specs =
-      Platform::LocateExecutableScriptingResourcesFromSafePaths(
-          ss, module_fspec, *m_target_sp);
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
 
-  ASSERT_EQ(file_specs.GetSize(), 0u);
+  ASSERT_EQ(file_specs.size(), 0u);
 }
 
 TEST_F(PlatformLocateSafePathTest,
@@ -281,12 +280,14 @@ TEST_F(PlatformLocateSafePathTest,
   CreateFile("not_a_script.txt", module_dir);
 
   StreamString ss;
-  FileSpecList file_specs =
-      Platform::LocateExecutableScriptingResourcesFromSafePaths(
-          ss, module_fspec, *m_target_sp);
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
 
-  EXPECT_EQ(file_specs.GetSize(), 1u);
-  EXPECT_EQ(file_specs.GetFileSpecAtIndex(0).GetFilename(), "TestModule.py");
+  EXPECT_EQ(file_specs.size(), 1u);
+
+  auto [fspec, load_style] = *file_specs.begin();
+  EXPECT_EQ(fspec.GetFilename(), "TestModule.py");
+  EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
 }
 
 TEST_F(PlatformLocateSafePathTest,
@@ -313,11 +314,10 @@ TEST_F(PlatformLocateSafePathTest,
   CreateFile("TestModule.py", nested_dir);
 
   StreamString ss;
-  FileSpecList file_specs =
-      Platform::LocateExecutableScriptingResourcesFromSafePaths(
-          ss, module_fspec, *m_target_sp);
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
 
-  EXPECT_EQ(file_specs.GetSize(), 0u);
+  EXPECT_EQ(file_specs.size(), 0u);
 }
 
 TEST_F(PlatformLocateSafePathTest,
@@ -373,15 +373,14 @@ TEST_F(PlatformLocateSafePathTest,
       FileSpec(path2));
 
   StreamString ss;
-  FileSpecList file_specs =
-      Platform::LocateExecutableScriptingResourcesFromSafePaths(
-          ss, module_fspec, *m_target_sp);
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
 
   // path1 was the last appended path with a matching directory.
-  EXPECT_EQ(file_specs.GetSize(), 1u);
-  EXPECT_TRUE(llvm::StringRef(file_specs.GetFileSpecAtIndex(0).GetPath())
-                  .contains("AnotherSafePath"));
-  EXPECT_EQ(file_specs.GetFileSpecAtIndex(0).GetFilename(), "TestModule.py");
+  auto [fspec, load_style] = *file_specs.begin();
+  EXPECT_TRUE(llvm::StringRef(fspec.GetPath()).contains("AnotherSafePath"));
+  EXPECT_EQ(fspec.GetFilename(), "TestModule.py");
+  EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
 
   // Now add another safe path with a valid module directory but no
   // TestModule.py inside. LLDB shouldn't fall back to other matching safe
@@ -393,7 +392,7 @@ TEST_F(PlatformLocateSafePathTest,
   file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
       ss, module_fspec, *m_target_sp);
 
-  EXPECT_EQ(file_specs.GetSize(), 0u);
+  EXPECT_EQ(file_specs.size(), 0u);
 
   // Now place the correctly named script in path3.
   CreateFile("TestModule.py", path3_module_dir);
@@ -401,10 +400,12 @@ TEST_F(PlatformLocateSafePathTest,
   file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
       ss, module_fspec, *m_target_sp);
 
-  EXPECT_EQ(file_specs.GetSize(), 1u);
-  EXPECT_TRUE(llvm::StringRef(file_specs.GetFileSpecAtIndex(0).GetPath())
-                  .contains("EmptySafePath"));
-  EXPECT_EQ(file_specs.GetFileSpecAtIndex(0).GetFilename(), "TestModule.py");
+  EXPECT_EQ(file_specs.size(), 1u);
+
+  auto [fspec1, load_style1] = *file_specs.begin();
+  EXPECT_TRUE(llvm::StringRef(fspec1.GetPath()).contains("EmptySafePath"));
+  EXPECT_EQ(fspec1.GetFilename(), "TestModule.py");
+  EXPECT_EQ(load_style1, m_target_sp->GetLoadScriptFromSymbolFile());
 }
 
 TEST_F(PlatformLocateSafePathTest,
@@ -428,11 +429,10 @@ TEST_F(PlatformLocateSafePathTest,
   ASSERT_TRUE(orig_fspec);
 
   StreamString ss;
-  FileSpecList file_specs =
-      Platform::LocateExecutableScriptingResourcesFromSafePaths(
-          ss, module_fspec, *m_target_sp);
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
 
-  EXPECT_EQ(file_specs.GetSize(), 0u);
+  EXPECT_EQ(file_specs.size(), 0u);
 
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because"
@@ -465,13 +465,14 @@ TEST_F(PlatformLocateSafePathTest,
   CreateFile("TestModule_1_1_1.py", module_dir);
 
   StreamString ss;
-  FileSpecList file_specs =
-      Platform::LocateExecutableScriptingResourcesFromSafePaths(
-          ss, module_fspec, *m_target_sp);
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
 
-  EXPECT_EQ(file_specs.GetSize(), 1u);
-  EXPECT_EQ(file_specs.GetFileSpecAtIndex(0).GetFilename(),
-            "TestModule_1_1_1.py");
+  EXPECT_EQ(file_specs.size(), 1u);
+
+  auto [fspec, load_style] = *file_specs.begin();
+  EXPECT_EQ(fspec.GetFilename(), "TestModule_1_1_1.py");
+  EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
 
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because"
@@ -500,13 +501,14 @@ TEST_F(PlatformLocateSafePathTest,
   CreateFile("TestModule_1_1_1.py", module_dir);
 
   StreamString ss;
-  FileSpecList file_specs =
-      Platform::LocateExecutableScriptingResourcesFromSafePaths(
-          ss, module_fspec, *m_target_sp);
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
 
-  EXPECT_EQ(file_specs.GetSize(), 1u);
-  EXPECT_EQ(file_specs.GetFileSpecAtIndex(0).GetFilename(),
-            "TestModule_1_1_1.py");
+  EXPECT_EQ(file_specs.size(), 1u);
+
+  auto [fspec, load_style] = *file_specs.begin();
+  EXPECT_EQ(fspec.GetFilename(), "TestModule_1_1_1.py");
+  EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
   EXPECT_TRUE(ss.GetString().empty());
 }
 
@@ -530,11 +532,10 @@ TEST_F(PlatformLocateSafePathTest,
   ASSERT_TRUE(orig_fspec);
 
   StreamString ss;
-  FileSpecList file_specs =
-      Platform::LocateExecutableScriptingResourcesFromSafePaths(
-          ss, module_fspec, *m_target_sp);
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
 
-  EXPECT_EQ(file_specs.GetSize(), 0u);
+  EXPECT_EQ(file_specs.size(), 0u);
 
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because 'import.py' "
@@ -566,12 +567,14 @@ TEST_F(PlatformLocateSafePathTest,
   CreateFile("_import.py", module_dir);
 
   StreamString ss;
-  FileSpecList file_specs =
-      Platform::LocateExecutableScriptingResourcesFromSafePaths(
-          ss, module_fspec, *m_target_sp);
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
 
-  EXPECT_EQ(file_specs.GetSize(), 1u);
-  EXPECT_EQ(file_specs.GetFileSpecAtIndex(0).GetFilename(), "_import.py");
+  EXPECT_EQ(file_specs.size(), 1u);
+
+  auto [fspec, load_style] = *file_specs.begin();
+  EXPECT_EQ(fspec.GetFilename(), "_import.py");
+  EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
 
   std::string expected =
       llvm::formatv("debug script '{0}' cannot be loaded because 'import.py' "
@@ -600,12 +603,14 @@ TEST_F(PlatformLocateSafePathTest,
   CreateFile("_import.py", module_dir);
 
   StreamString ss;
-  FileSpecList file_specs =
-      Platform::LocateExecutableScriptingResourcesFromSafePaths(
-          ss, module_fspec, *m_target_sp);
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
 
-  EXPECT_EQ(file_specs.GetSize(), 1u);
-  EXPECT_EQ(file_specs.GetFileSpecAtIndex(0).GetFilename(), "_import.py");
+  EXPECT_EQ(file_specs.size(), 1u);
+
+  auto [fspec, load_style] = *file_specs.begin();
+  EXPECT_EQ(fspec.GetFilename(), "_import.py");
+  EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
   EXPECT_TRUE(ss.GetString().empty());
 }
 
@@ -629,11 +634,10 @@ TEST_F(PlatformLocateSafePathTest,
   CreateFile("TestModule.py", inner_dir);
 
   StreamString ss;
-  FileSpecList file_specs =
-      Platform::LocateExecutableScriptingResourcesFromSafePaths(
-          ss, module_fspec, *m_target_sp);
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
 
-  EXPECT_EQ(file_specs.GetSize(), 0u);
+  EXPECT_EQ(file_specs.size(), 0u);
   EXPECT_TRUE(ss.GetString().empty());
 }
 
@@ -662,11 +666,10 @@ TEST_F(PlatformLocateSafePathTest,
   CreateFile("TestModule.py", module_dir);
 
   StreamString ss;
-  FileSpecList file_specs =
-      Platform::LocateExecutableScriptingResourcesFromSafePaths(
-          ss, module_fspec, *m_target_sp);
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
 
-  EXPECT_EQ(file_specs.GetSize(), 1u);
+  EXPECT_EQ(file_specs.size(), 1u);
   EXPECT_TRUE(ss.GetString().empty());
 }
 #endif // NDEBUG


### PR DESCRIPTION
This patch changes the `Platform::LocateXXX` to return a map from `FileSpec` to `LoadScriptFromSymFile` enum.

This is needed for https://github.com/llvm/llvm-project/pull/188722, where I intend to set `LoadScriptFromSymFile` per-module.

By default the `Platform::LocateXXX` set the value to whatever the target's current `target.load-script-from-symbol-file` is set to. In https://github.com/llvm/llvm-project/pull/188722 we'll allow overriding this per-target setting on a per-module basis.

Drive-by:
* Added logging when we fail to load a script.