### PR TITLE
[InstCombine] Match a new form of truncating saturation

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1174,21 +1174,17 @@ Instruction *InstCombinerImpl::visitTrunc(TruncInst &Trunc) {
   // trunc (select(icmp_ult(A, DestTy_umax+1), A, sext(icmp_sgt(A, 0)))) -->
   // trunc (smin(smax(0, A), DestTy_umax))
   if (SrcTy->isIntegerTy() && isPowerOf2_64(SrcTy->getPrimitiveSizeInBits()) &&
-      DestTy->isIntegerTy() &&
       isPowerOf2_64(DestTy->getPrimitiveSizeInBits()) &&
-      match(Src,
-            m_OneUse(m_Select(
-                m_SpecificICmp(ICmpInst::ICMP_ULT, m_Value(A), m_Constant(C)),
-                m_Deferred(A),
-                m_SExt(m_SpecificICmp(ICmpInst::ICMP_SGT, m_Deferred(A),
-                                      m_Zero())))))) {
+      match(Src, m_OneUse(m_Select(
+                     m_OneUse(m_SpecificICmp(ICmpInst::ICMP_ULT, m_Value(A),
+                                             m_Constant(C))),
+                     m_Deferred(A),
+                     m_OneUse(m_SExt(m_OneUse(m_SpecificICmp(
+                         ICmpInst::ICMP_SGT, m_Deferred(A), m_Zero())))))))) {
     APInt UpperBound = C->getUniqueInteger();
     APInt TruncatedMax = APInt::getAllOnes(DestTy->getIntegerBitWidth());
-    unsigned MaxBitWidth =
-        std::max(UpperBound.getBitWidth(), TruncatedMax.getBitWidth());
-    UpperBound = UpperBound.zext(MaxBitWidth);
-    TruncatedMax = TruncatedMax.zext(MaxBitWidth);
-    if (UpperBound - 1 == TruncatedMax) {
+    TruncatedMax = TruncatedMax.zext(UpperBound.getBitWidth());
+    if (!UpperBound.isZero() && UpperBound - 1 == TruncatedMax) {
       Value *SMax = Builder.CreateIntrinsic(Intrinsic::smax, {SrcTy},
                                             {ConstantInt::get(SrcTy, 0), A});
       Value *SMin = Builder.CreateIntrinsic(

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1171,6 +1171,33 @@ Instruction *InstCombinerImpl::visitTrunc(TruncInst &Trunc) {
     }
   }
 
+  // trunc (select(icmp_ult(A, DestTy_umax+1), A, sext(icmp_sgt(A, 0)))) -->
+  // trunc (smin(smax(0, A), DestTy_umax))
+  if (SrcTy->isIntegerTy() && isPowerOf2_64(SrcTy->getPrimitiveSizeInBits()) &&
+      DestTy->isIntegerTy() &&
+      isPowerOf2_64(DestTy->getPrimitiveSizeInBits()) &&
+      match(Src,
+            m_OneUse(m_Select(
+                m_SpecificICmp(ICmpInst::ICMP_ULT, m_Value(A), m_Constant(C)),
+                m_Deferred(A),
+                m_SExt(m_SpecificICmp(ICmpInst::ICMP_SGT, m_Deferred(A),
+                                      m_Zero())))))) {
+    APInt UpperBound = C->getUniqueInteger();
+    APInt TruncatedMax = APInt::getAllOnes(DestTy->getIntegerBitWidth());
+    unsigned MaxBitWidth =
+        std::max(UpperBound.getBitWidth(), TruncatedMax.getBitWidth());
+    UpperBound = UpperBound.zext(MaxBitWidth);
+    TruncatedMax = TruncatedMax.zext(MaxBitWidth);
+    if (UpperBound - 1 == TruncatedMax) {
+      Value *SMax = Builder.CreateIntrinsic(Intrinsic::smax, {SrcTy},
+                                            {ConstantInt::get(SrcTy, 0), A});
+      Value *SMin = Builder.CreateIntrinsic(
+          Intrinsic::smin, {SrcTy},
+          {SMax, ConstantInt::get(SrcTy, TruncatedMax)});
+      return new TruncInst(SMin, DestTy);
+    }
+  }
+
   if (Instruction *I = foldVecTruncToExtElt(Trunc, *this))
     return I;
 

--- a/llvm/test/Transforms/InstCombine/truncating-saturate.ll
+++ b/llvm/test/Transforms/InstCombine/truncating-saturate.ll
@@ -717,3 +717,67 @@ entry:
   ret i32 %trunc
 }
 
+define i8 @no_clamp_i32_to_i8_multiple_use_icmp(i32 %x, ptr %p) {
+; CHECK-LABEL: @no_clamp_i32_to_i8_multiple_use_icmp(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i32 [[X:%.*]], 256
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i32
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i32 [[X]], i32 [[SHR]]
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i32 [[COND]] to i8
+; CHECK-NEXT:    [[EXTRA_USE:%.*]] = sext i1 [[TOBOOL_NOT]] to i64
+; CHECK-NEXT:    store i64 [[EXTRA_USE]], ptr [[P:%.*]], align 8
+; CHECK-NEXT:    ret i8 [[TRUNC]]
+;
+entry:
+  %tobool.not = icmp ult i32 %x, 256
+  %0 = icmp sgt i32 %x, 0
+  %shr = sext i1 %0 to i32
+  %cond = select i1 %tobool.not, i32 %x, i32 %shr
+  %trunc = trunc i32 %cond to i8
+  %extra_use = sext i1 %tobool.not to i64
+  store i64 %extra_use, ptr %p, align 8
+  ret i8 %trunc
+}
+
+define i8 @no_clamp_i32_to_i8_multiple_use_select(i32 %x, ptr %p) {
+; CHECK-LABEL: @no_clamp_i32_to_i8_multiple_use_select(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i32 [[X:%.*]], 256
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i32
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i32 [[X]], i32 [[SHR]]
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i32 [[COND]] to i8
+; CHECK-NEXT:    [[EXTRA_USE:%.*]] = sext i32 [[COND]] to i64
+; CHECK-NEXT:    store i64 [[EXTRA_USE]], ptr [[P:%.*]], align 8
+; CHECK-NEXT:    ret i8 [[TRUNC]]
+;
+entry:
+  %tobool.not = icmp ult i32 %x, 256
+  %0 = icmp sgt i32 %x, 0
+  %shr = sext i1 %0 to i32
+  %cond = select i1 %tobool.not, i32 %x, i32 %shr
+  %trunc = trunc i32 %cond to i8
+  %extra_use = sext i32 %cond to i64
+  store i64 %extra_use, ptr %p, align 8
+  ret i8 %trunc
+}
+
+define <4 x i8> @no_clamp_i32_to_i8_vector(<4 x i32> %x) {
+; CHECK-LABEL: @no_clamp_i32_to_i8_vector(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult <4 x i32> [[X:%.*]], splat (i32 256)
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt <4 x i32> [[X]], zeroinitializer
+; CHECK-NEXT:    [[SHR:%.*]] = sext <4 x i1> [[TMP0]] to <4 x i32>
+; CHECK-NEXT:    [[COND:%.*]] = select <4 x i1> [[TOBOOL_NOT]], <4 x i32> [[X]], <4 x i32> [[SHR]]
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc <4 x i32> [[COND]] to <4 x i8>
+; CHECK-NEXT:    ret <4 x i8> [[TRUNC]]
+;
+entry:
+  %tobool.not = icmp ult <4 x i32> %x, splat(i32 256)
+  %0 = icmp sgt <4 x i32> %x, zeroinitializer
+  %shr = sext <4 x i1> %0 to <4 x i32>
+  %cond = select <4 x i1> %tobool.not, <4 x i32> %x, <4 x i32> %shr
+  %trunc = trunc <4 x i32> %cond to <4 x i8>
+  ret <4 x i8> %trunc
+}

--- a/llvm/test/Transforms/InstCombine/truncating-saturate.ll
+++ b/llvm/test/Transforms/InstCombine/truncating-saturate.ll
@@ -614,3 +614,118 @@ entry:
   %cond = select i1 %cmp.i.i, i8 %conv4, i8 %cond.i
   ret i8 %cond
 }
+
+define i8 @clamp_i16_to_i8(i16 %x) {
+; CHECK-LABEL: @clamp_i16_to_i8(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i16 [[X:%.*]], 256
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i16 [[X]], 0
+; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i16
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i16 [[X]], i16 [[SHR]]
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i16 [[COND]] to i8
+; CHECK-NEXT:    ret i8 [[TRUNC]]
+;
+entry:
+  %tobool.not = icmp ult i16 %x, 256
+  %0 = icmp sgt i16 %x, 0
+  %shr = sext i1 %0 to i16
+  %cond = select i1 %tobool.not, i16 %x, i16 %shr
+  %trunc = trunc i16 %cond to i8
+  ret i8 %trunc
+}
+
+define i8 @clamp_i32_to_i8(i32 %x) {
+; CHECK-LABEL: @clamp_i32_to_i8(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i32 [[X:%.*]], 256
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i32
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i32 [[X]], i32 [[SHR]]
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i32 [[COND]] to i8
+; CHECK-NEXT:    ret i8 [[TRUNC]]
+;
+entry:
+  %tobool.not = icmp ult i32 %x, 256
+  %0 = icmp sgt i32 %x, 0
+  %shr = sext i1 %0 to i32
+  %cond = select i1 %tobool.not, i32 %x, i32 %shr
+  %trunc = trunc i32 %cond to i8
+  ret i8 %trunc
+}
+
+define i8 @clamp_i64_to_i8(i64 %x) {
+; CHECK-LABEL: @clamp_i64_to_i8(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i64 [[X:%.*]], 256
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i64 [[X]], 0
+; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i64
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i64 [[X]], i64 [[SHR]]
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[COND]] to i8
+; CHECK-NEXT:    ret i8 [[TRUNC]]
+;
+entry:
+  %tobool.not = icmp ult i64 %x, 256
+  %0 = icmp sgt i64 %x, 0
+  %shr = sext i1 %0 to i64
+  %cond = select i1 %tobool.not, i64 %x, i64 %shr
+  %trunc = trunc i64 %cond to i8
+  ret i8 %trunc
+}
+
+define i16 @clamp_i32_to_i16(i32 %x) {
+; CHECK-LABEL: @clamp_i32_to_i16(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i32 [[X:%.*]], 65536
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i32
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i32 [[X]], i32 [[SHR]]
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i32 [[COND]] to i16
+; CHECK-NEXT:    ret i16 [[TRUNC]]
+;
+entry:
+  %tobool.not = icmp ult i32 %x, 65536
+  %0 = icmp sgt i32 %x, 0
+  %shr = sext i1 %0 to i32
+  %cond = select i1 %tobool.not, i32 %x, i32 %shr
+  %trunc = trunc i32 %cond to i16
+  ret i16 %trunc
+}
+
+define i16 @clamp_i64_to_i16(i64 %x) {
+; CHECK-LABEL: @clamp_i64_to_i16(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i64 [[X:%.*]], 65536
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i64 [[X]], 0
+; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i64
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i64 [[X]], i64 [[SHR]]
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[COND]] to i16
+; CHECK-NEXT:    ret i16 [[TRUNC]]
+;
+entry:
+  %tobool.not = icmp ult i64 %x, 65536
+  %0 = icmp sgt i64 %x, 0
+  %shr = sext i1 %0 to i64
+  %cond = select i1 %tobool.not, i64 %x, i64 %shr
+  %trunc = trunc i64 %cond to i16
+  ret i16 %trunc
+}
+
+define i32 @clamp_i64_to_i32(i64 %x) {
+; CHECK-LABEL: @clamp_i64_to_i32(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i64 [[X:%.*]], 4294967296
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i64 [[X]], 0
+; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i64
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i64 [[X]], i64 [[SHR]]
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[COND]] to i32
+; CHECK-NEXT:    ret i32 [[TRUNC]]
+;
+entry:
+  %tobool.not = icmp ult i64 %x, 4294967296
+  %0 = icmp sgt i64 %x, 0
+  %shr = sext i1 %0 to i64
+  %cond = select i1 %tobool.not, i64 %x, i64 %shr
+  %trunc = trunc i64 %cond to i32
+  ret i32 %trunc
+}
+

--- a/llvm/test/Transforms/InstCombine/truncating-saturate.ll
+++ b/llvm/test/Transforms/InstCombine/truncating-saturate.ll
@@ -618,11 +618,9 @@ entry:
 define i8 @clamp_i16_to_i8(i16 %x) {
 ; CHECK-LABEL: @clamp_i16_to_i8(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i16 [[X:%.*]], 256
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i16 [[X]], 0
-; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i16
-; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i16 [[X]], i16 [[SHR]]
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i16 [[COND]] to i8
+; CHECK-NEXT:    [[TMP0:%.*]] = call i16 @llvm.smax.i16(i16 [[X:%.*]], i16 0)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i16 @llvm.smin.i16(i16 [[TMP0]], i16 255)
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw i16 [[TMP1]] to i8
 ; CHECK-NEXT:    ret i8 [[TRUNC]]
 ;
 entry:
@@ -637,11 +635,9 @@ entry:
 define i8 @clamp_i32_to_i8(i32 %x) {
 ; CHECK-LABEL: @clamp_i32_to_i8(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i32 [[X:%.*]], 256
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i32 [[X]], 0
-; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i32
-; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i32 [[X]], i32 [[SHR]]
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i32 [[COND]] to i8
+; CHECK-NEXT:    [[TMP0:%.*]] = call i32 @llvm.smax.i32(i32 [[X:%.*]], i32 0)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.smin.i32(i32 [[TMP0]], i32 255)
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw i32 [[TMP1]] to i8
 ; CHECK-NEXT:    ret i8 [[TRUNC]]
 ;
 entry:
@@ -656,11 +652,9 @@ entry:
 define i8 @clamp_i64_to_i8(i64 %x) {
 ; CHECK-LABEL: @clamp_i64_to_i8(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i64 [[X:%.*]], 256
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i64 [[X]], 0
-; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i64
-; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i64 [[X]], i64 [[SHR]]
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[COND]] to i8
+; CHECK-NEXT:    [[TMP0:%.*]] = call i64 @llvm.smax.i64(i64 [[X:%.*]], i64 0)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i64 @llvm.smin.i64(i64 [[TMP0]], i64 255)
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw i64 [[TMP1]] to i8
 ; CHECK-NEXT:    ret i8 [[TRUNC]]
 ;
 entry:
@@ -675,11 +669,9 @@ entry:
 define i16 @clamp_i32_to_i16(i32 %x) {
 ; CHECK-LABEL: @clamp_i32_to_i16(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i32 [[X:%.*]], 65536
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i32 [[X]], 0
-; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i32
-; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i32 [[X]], i32 [[SHR]]
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i32 [[COND]] to i16
+; CHECK-NEXT:    [[TMP0:%.*]] = call i32 @llvm.smax.i32(i32 [[X:%.*]], i32 0)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i32 @llvm.smin.i32(i32 [[TMP0]], i32 65535)
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw i32 [[TMP1]] to i16
 ; CHECK-NEXT:    ret i16 [[TRUNC]]
 ;
 entry:
@@ -694,11 +686,9 @@ entry:
 define i16 @clamp_i64_to_i16(i64 %x) {
 ; CHECK-LABEL: @clamp_i64_to_i16(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i64 [[X:%.*]], 65536
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i64 [[X]], 0
-; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i64
-; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i64 [[X]], i64 [[SHR]]
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[COND]] to i16
+; CHECK-NEXT:    [[TMP0:%.*]] = call i64 @llvm.smax.i64(i64 [[X:%.*]], i64 0)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i64 @llvm.smin.i64(i64 [[TMP0]], i64 65535)
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw i64 [[TMP1]] to i16
 ; CHECK-NEXT:    ret i16 [[TRUNC]]
 ;
 entry:
@@ -713,11 +703,9 @@ entry:
 define i32 @clamp_i64_to_i32(i64 %x) {
 ; CHECK-LABEL: @clamp_i64_to_i32(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp ult i64 [[X:%.*]], 4294967296
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i64 [[X]], 0
-; CHECK-NEXT:    [[SHR:%.*]] = sext i1 [[TMP0]] to i64
-; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL_NOT]], i64 [[X]], i64 [[SHR]]
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[COND]] to i32
+; CHECK-NEXT:    [[TMP0:%.*]] = call i64 @llvm.smax.i64(i64 [[X:%.*]], i64 0)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i64 @llvm.smin.i64(i64 [[TMP0]], i64 4294967295)
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw i64 [[TMP1]] to i32
 ; CHECK-NEXT:    ret i32 [[TRUNC]]
 ;
 entry:


### PR DESCRIPTION
This matches a pattern that clamps an integer value to the range for an integer type with a smaller bitwidth, before truncating to that type.

alive2: https://alive2.llvm.org/ce/z/WPfmyS