### PR TITLE
[lldb][bytecode] Remove "Generated with" comment

### DIFF
--- a/lldb/examples/python/formatter_bytecode.py
+++ b/lldb/examples/python/formatter_bytecode.py
@@ -1153,11 +1153,6 @@ def _main():
     )
     parser.add_argument("-n", "--type-name", help="source type of formatter")
     parser.add_argument(
-        "--skip-invocation-comment",
-        action="store_true",
-        help="do not print invocation comment in compiled output",
-    )
-    parser.add_argument(
         "-o",
         "--output",
         help="output file (required for --assemble)",
@@ -1198,9 +1193,6 @@ def _main():
         else:
             mode = "a" if args.append else "w"
             with open(args.output, mode) as output:
-                if not args.skip_invocation_comment:
-                    print("// Generated with:", file=output)
-                    print("//  ", shlex.join(sys.argv), file=output)
                 section.write_source(output, language=args.format)
     elif args.assemble:
         if not args.type_name:

--- a/lldb/test/Shell/ScriptInterpreter/Python/python-bytecode.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/python-bytecode.test
@@ -1,6 +1,6 @@
 # RUN: mkdir -p %t
-# RUN: %python %S/../../../../examples/python/formatter_bytecode.py --compile %s --format c --type-name RigidArray --output %t/c-output.txt --skip-invocation-comment
-# RUN: %python %S/../../../../examples/python/formatter_bytecode.py --compile %s --format swift --type-name RigidArray --output %t/swift-output.txt --skip-invocation-comment
+# RUN: %python %S/../../../../examples/python/formatter_bytecode.py --compile %s --format c --type-name RigidArray --output %t/c-output.txt
+# RUN: %python %S/../../../../examples/python/formatter_bytecode.py --compile %s --format swift --type-name RigidArray --output %t/swift-output.txt
 # RUN: diff -u --strip-trailing-cr %S/Inputs/FormatterBytecode/RigidArrayLLDBFormatterC.txt %t/c-output.txt
 # RUN: diff -u --strip-trailing-cr %S/Inputs/FormatterBytecode/RigidArrayLLDBFormatterSwift.txt %t/swift-output.txt
 import lldb


### PR DESCRIPTION
In most cases, some other script/tool will call the compiler, and it's the invocation of that script that ought to be documented in the output.