### PR TITLE
[VPlan] Strip single-scalar special-casing for replicates (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -365,12 +365,6 @@ bool vputils::isSingleScalar(const VPValue *VPV) {
     return true;
 
   if (auto *Rep = dyn_cast<VPReplicateRecipe>(VPV)) {
-    const VPRegionBlock *RegionOfR = Rep->getRegion();
-    // Don't consider recipes in replicate regions as uniform yet; their first
-    // lane cannot be accessed when executing the replicate region for other
-    // lanes.
-    if (RegionOfR && RegionOfR->isReplicator())
-      return false;
     return Rep->isSingleScalar() || (preservesUniformity(Rep->getOpcode()) &&
                                      all_of(Rep->operands(), isSingleScalar));
   }


### PR DESCRIPTION
The recently landed 99aa33d ([VPlan] Explicitly unroll replicate-regions without live-outs by VF, #188947) and 713c70d ([VPlan] Handle regions with live-outs and scalar VF when replicating, #186252) teach the unroller to work with Replicate recipes in replicate regions, making this special-casing redundant.

-- 8< --
Cannot proceed until #189022 has landed.