### PR TITLE
[CIR] Add OpenMP and OpenACC dialect dependencies

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -27,4 +27,6 @@ add_clang_library(MLIRCIRTransforms
   MLIRCIR
   MLIRCIRInterfaces
   MLIRCIRTargetLowering
+  MLIROpenACCDialect
+  MLIROpenMPDialect
 )


### PR DESCRIPTION
This patch adds dependencies on OpenMP and OpenACC dialects to prevent link errors when compiling with shared libraries.