### PR TITLE
[RISCV][P-ext] Support i32 ushlsat on RV32.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -488,15 +488,12 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
                        MVT::i32, Custom);
   }
 
-  if (Subtarget.hasVendorXqcia() && !Subtarget.is64Bit()) {
-    setOperationAction(ISD::USHLSAT, MVT::i32, Legal);
-  }
-
   if ((Subtarget.hasStdExtP() || Subtarget.hasVendorXqcia()) &&
       !Subtarget.is64Bit()) {
     // FIXME: Support i32 on RV64+P by inserting into a v2i32 vector, doing
-    // pssha.w and extracting.
+    // pssha.w/psshl.w and extracting.
     setOperationAction(ISD::SSHLSAT, MVT::i32, Legal);
+    setOperationAction(ISD::USHLSAT, MVT::i32, Legal);
   }
 
   if (Subtarget.hasStdExtZbc() || Subtarget.hasStdExtZbkc())

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1929,7 +1929,9 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def : PatGprGpr<uaddsat, SADDU>;
   def : PatGprGpr<usubsat, SSUBU>;
   def : PatGprGpr<sshlsat, SSHA>;
+  def : PatGprGpr<ushlsat, SSHL>;
   def : PatGprUimmLog2XLen<sshlsat, SSLAI>;
+  // No SSLLI
 
   // Narrowing shift patterns (NSRL/NSRA)
   // Immediate shift amount patterns

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -614,6 +614,95 @@ define i32 @shlsati_i32(i32 %a) {
  ret i32 %sshlsat
 }
 
+define i8 @ushlsat_i8(i8 %a, i8 %b) {
+; CHECK-LABEL: ushlsat_i8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 24
+; CHECK-NEXT:    sll a2, a0, a1
+; CHECK-NEXT:    srl a1, a2, a1
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    seqz a0, a0
+; CHECK-NEXT:    addi a0, a0, -1
+; CHECK-NEXT:    or a0, a0, a2
+; CHECK-NEXT:    srli a0, a0, 24
+; CHECK-NEXT:    ret
+ %ushlsat = tail call i8 @llvm.ushl.sat.i8(i8 %a,i8 %b)
+ ret i8 %ushlsat
+}
+
+define i16 @ushlsat_i16(i16 %a, i16 %b) {
+; CHECK-LABEL: ushlsat_i16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 16
+; CHECK-NEXT:    sll a2, a0, a1
+; CHECK-NEXT:    srl a1, a2, a1
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    seqz a0, a0
+; CHECK-NEXT:    addi a0, a0, -1
+; CHECK-NEXT:    or a0, a0, a2
+; CHECK-NEXT:    srli a0, a0, 16
+; CHECK-NEXT:    ret
+ %ushlsat = tail call i16 @llvm.ushl.sat.i16(i16 %a,i16 %b)
+ ret i16 %ushlsat
+}
+
+define i32 @ushlsat_i32(i32 %a, i32 %b) {
+; CHECK-LABEL: ushlsat_i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sll a2, a0, a1
+; CHECK-NEXT:    srl a1, a2, a1
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    seqz a0, a0
+; CHECK-NEXT:    addi a0, a0, -1
+; CHECK-NEXT:    or a0, a0, a2
+; CHECK-NEXT:    ret
+ %ushlsat = tail call i32 @llvm.ushl.sat.i32(i32 %a,i32 %b)
+ ret i32 %ushlsat
+}
+
+define i8 @ushlsati_i8(i8 %a) {
+; CHECK-LABEL: ushlsati_i8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a1, a0, 29
+; CHECK-NEXT:    slli a0, a0, 24
+; CHECK-NEXT:    srli a0, a0, 27
+; CHECK-NEXT:    seqz a0, a0
+; CHECK-NEXT:    addi a0, a0, -1
+; CHECK-NEXT:    or a0, a0, a1
+; CHECK-NEXT:    srli a0, a0, 24
+; CHECK-NEXT:    ret
+ %ushlsat = tail call i8 @llvm.ushl.sat.i8(i8 %a, i8 5)
+ ret i8 %ushlsat
+}
+
+define i16 @ushlsati_i16(i16 %a) {
+; CHECK-LABEL: ushlsati_i16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a1, a0, 26
+; CHECK-NEXT:    slli a0, a0, 16
+; CHECK-NEXT:    srli a0, a0, 22
+; CHECK-NEXT:    seqz a0, a0
+; CHECK-NEXT:    addi a0, a0, -1
+; CHECK-NEXT:    or a0, a0, a1
+; CHECK-NEXT:    srli a0, a0, 16
+; CHECK-NEXT:    ret
+ %ushlsat = tail call i16 @llvm.ushl.sat.i16(i16 %a, i16 10)
+ ret i16 %ushlsat
+}
+
+define i32 @ushlsati_i32(i32 %a) {
+; CHECK-LABEL: ushlsati_i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a1, a0, 21
+; CHECK-NEXT:    andi a0, a0, -2048
+; CHECK-NEXT:    seqz a0, a0
+; CHECK-NEXT:    addi a0, a0, -1
+; CHECK-NEXT:    or a0, a0, a1
+; CHECK-NEXT:    ret
+ %ushlsat = tail call i32 @llvm.ushl.sat.i32(i32 %a, i32 21)
+ ret i32 %ushlsat
+}
+
 define i8 @sadd_i8(i8 %x, i8 %y) {
 ; CHECK-LABEL: sadd_i8:
 ; CHECK:       # %bb.0:

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -617,13 +617,9 @@ define i32 @shlsati_i32(i32 %a) {
 define i8 @ushlsat_i8(i8 %a, i8 %b) {
 ; CHECK-LABEL: ushlsat_i8:
 ; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.b a1, a1
 ; CHECK-NEXT:    slli a0, a0, 24
-; CHECK-NEXT:    sll a2, a0, a1
-; CHECK-NEXT:    srl a1, a2, a1
-; CHECK-NEXT:    xor a0, a0, a1
-; CHECK-NEXT:    seqz a0, a0
-; CHECK-NEXT:    addi a0, a0, -1
-; CHECK-NEXT:    or a0, a0, a2
+; CHECK-NEXT:    sshl a0, a0, a1
 ; CHECK-NEXT:    srli a0, a0, 24
 ; CHECK-NEXT:    ret
  %ushlsat = tail call i8 @llvm.ushl.sat.i8(i8 %a,i8 %b)
@@ -633,13 +629,9 @@ define i8 @ushlsat_i8(i8 %a, i8 %b) {
 define i16 @ushlsat_i16(i16 %a, i16 %b) {
 ; CHECK-LABEL: ushlsat_i16:
 ; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.h a1, a1
 ; CHECK-NEXT:    slli a0, a0, 16
-; CHECK-NEXT:    sll a2, a0, a1
-; CHECK-NEXT:    srl a1, a2, a1
-; CHECK-NEXT:    xor a0, a0, a1
-; CHECK-NEXT:    seqz a0, a0
-; CHECK-NEXT:    addi a0, a0, -1
-; CHECK-NEXT:    or a0, a0, a2
+; CHECK-NEXT:    sshl a0, a0, a1
 ; CHECK-NEXT:    srli a0, a0, 16
 ; CHECK-NEXT:    ret
  %ushlsat = tail call i16 @llvm.ushl.sat.i16(i16 %a,i16 %b)
@@ -649,12 +641,7 @@ define i16 @ushlsat_i16(i16 %a, i16 %b) {
 define i32 @ushlsat_i32(i32 %a, i32 %b) {
 ; CHECK-LABEL: ushlsat_i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sll a2, a0, a1
-; CHECK-NEXT:    srl a1, a2, a1
-; CHECK-NEXT:    xor a0, a0, a1
-; CHECK-NEXT:    seqz a0, a0
-; CHECK-NEXT:    addi a0, a0, -1
-; CHECK-NEXT:    or a0, a0, a2
+; CHECK-NEXT:    sshl a0, a0, a1
 ; CHECK-NEXT:    ret
  %ushlsat = tail call i32 @llvm.ushl.sat.i32(i32 %a,i32 %b)
  ret i32 %ushlsat
@@ -663,12 +650,9 @@ define i32 @ushlsat_i32(i32 %a, i32 %b) {
 define i8 @ushlsati_i8(i8 %a) {
 ; CHECK-LABEL: ushlsati_i8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a1, a0, 29
 ; CHECK-NEXT:    slli a0, a0, 24
-; CHECK-NEXT:    srli a0, a0, 27
-; CHECK-NEXT:    seqz a0, a0
-; CHECK-NEXT:    addi a0, a0, -1
-; CHECK-NEXT:    or a0, a0, a1
+; CHECK-NEXT:    li a1, 5
+; CHECK-NEXT:    sshl a0, a0, a1
 ; CHECK-NEXT:    srli a0, a0, 24
 ; CHECK-NEXT:    ret
  %ushlsat = tail call i8 @llvm.ushl.sat.i8(i8 %a, i8 5)
@@ -678,12 +662,9 @@ define i8 @ushlsati_i8(i8 %a) {
 define i16 @ushlsati_i16(i16 %a) {
 ; CHECK-LABEL: ushlsati_i16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a1, a0, 26
 ; CHECK-NEXT:    slli a0, a0, 16
-; CHECK-NEXT:    srli a0, a0, 22
-; CHECK-NEXT:    seqz a0, a0
-; CHECK-NEXT:    addi a0, a0, -1
-; CHECK-NEXT:    or a0, a0, a1
+; CHECK-NEXT:    li a1, 10
+; CHECK-NEXT:    sshl a0, a0, a1
 ; CHECK-NEXT:    srli a0, a0, 16
 ; CHECK-NEXT:    ret
  %ushlsat = tail call i16 @llvm.ushl.sat.i16(i16 %a, i16 10)
@@ -693,11 +674,8 @@ define i16 @ushlsati_i16(i16 %a) {
 define i32 @ushlsati_i32(i32 %a) {
 ; CHECK-LABEL: ushlsati_i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a1, a0, 21
-; CHECK-NEXT:    andi a0, a0, -2048
-; CHECK-NEXT:    seqz a0, a0
-; CHECK-NEXT:    addi a0, a0, -1
-; CHECK-NEXT:    or a0, a0, a1
+; CHECK-NEXT:    li a1, 21
+; CHECK-NEXT:    sshl a0, a0, a1
 ; CHECK-NEXT:    ret
  %ushlsat = tail call i32 @llvm.ushl.sat.i32(i32 %a, i32 21)
  ret i32 %ushlsat


### PR DESCRIPTION
We have a sshl instruction on RV32 in the 0.21 spec. Unfortunately,
we don't have a SSLLI instruction, but we can put a constant shift
amount in a register.