### PR TITLE
[lldb-dap] Using an empty target instead of a dummy target.

### DIFF
--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -72,12 +72,8 @@ Error AttachRequestHandler::Run(const AttachRequestArguments &args) const {
     target = dap.CreateTarget(error);
   }
 
-  // Fallback to the 'dummy' target if we failed to create a real target, so we
-  // can try to attach.
-  if (!target.IsValid())
-    target = dap.debugger.GetDummyTarget();
-
-  dap.SetTarget(target);
+  if (target.IsValid())
+    dap.SetTarget(target);
 
   // Run any pre run LLDB commands the user specified in the launch.json
   if (Error err = dap.RunPreRunCommands())


### PR DESCRIPTION
Removing the use of the dummy target and instead letting the debugger instance create the target it needs.