### PR TITLE
[PAC][libunwind] Protect dso_base argument of getInfoFromFdeCie

### DIFF
--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -1064,7 +1064,7 @@ private:
   bool getInfoFromFdeCie(const typename CFI_Parser<A>::FDE_Info &fdeInfo,
                          const typename CFI_Parser<A>::CIE_Info &cieInfo,
                          typename R::link_hardened_reg_arg_t pc,
-                         uintptr_t dso_base);
+                         typename R::link_hardened_reg_arg_t dso_base);
   bool getInfoFromDwarfSection(typename R::link_hardened_reg_arg_t pc,
                                const UnwindInfoSections &sects,
                                uint32_t fdeSectionOffsetHint = 0);
@@ -1735,7 +1735,8 @@ template <typename A, typename R>
 bool UnwindCursor<A, R>::getInfoFromFdeCie(
     const typename CFI_Parser<A>::FDE_Info &fdeInfo,
     const typename CFI_Parser<A>::CIE_Info &cieInfo,
-    typename R::link_hardened_reg_arg_t pc, uintptr_t dso_base) {
+    typename R::link_hardened_reg_arg_t pc,
+    typename R::link_hardened_reg_arg_t dso_base) {
   typename CFI_Parser<A>::PrologInfo prolog;
   if (CFI_Parser<A>::template parseFDEInstructions<R>(
           _addressSpace, fdeInfo, cieInfo, pc, R::getArch(), &prolog)) {


### PR DESCRIPTION
Pass the `dso_base` argument of `UnwindCursor::getInfoFromFdeCie` as a constant reference to a `__ptrauth`-qualified type. This resolves the signing oracle in getInfoFromFdeCie when assigning dso_base to the `__ptrauth`-qualified `_info.extra` field. This commit applies the approach of #173765 to one more function argument.

In the current libunwind source, getInfoFromFdeCie is called three times, with only one invocation not passing literal 0 as the dso_base argument. In that only non-trivial case, the value to be passed as `dso_base` is read from the `dso_base` field of `UnwindInfoSections`, which is itself `__ptrauth`-qualified.