### PR TITLE
[SelectionDAGBuilder] Only check VPCmp for NaNs in fp comparisons

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -8860,8 +8860,8 @@ void SelectionDAGBuilder::visitVPCmp(const VPCmpIntrinsic &VPIntrin) {
   ISD::CondCode Condition;
   CmpInst::Predicate CondCode = VPIntrin.getPredicate();
 
-  SDValue Op1 = getValue(VPIntrin.getOperand(0));
-  SDValue Op2 = getValue(VPIntrin.getOperand(1));
+  Value *Op1 = VPIntrin.getOperand(0);
+  Value *Op2 = VPIntrin.getOperand(1);
   // #2 is the condition code
   SDValue MaskOp = getValue(VPIntrin.getOperand(3));
   SDValue EVL = getValue(VPIntrin.getOperand(4));
@@ -8872,7 +8872,8 @@ void SelectionDAGBuilder::visitVPCmp(const VPCmpIntrinsic &VPIntrin) {
 
   if (VPIntrin.getOperand(0)->getType()->isFPOrFPVectorTy()) {
     Condition = getFCmpCondCode(CondCode);
-    if (DAG.isKnownNeverNaN(Op1) && DAG.isKnownNeverNaN(Op2))
+    SimplifyQuery SQ(DAG.getDataLayout(), &VPIntrin);
+    if (isKnownNeverNaN(Op1, SQ) && isKnownNeverNaN(Op2, SQ))
       Condition = getFCmpCodeWithoutNaN(Condition);
   } else {
     Condition = getICmpCondCode(CondCode);
@@ -8880,8 +8881,8 @@ void SelectionDAGBuilder::visitVPCmp(const VPCmpIntrinsic &VPIntrin) {
 
   EVT DestVT = DAG.getTargetLoweringInfo().getValueType(DAG.getDataLayout(),
                                                         VPIntrin.getType());
-  setValue(&VPIntrin,
-           DAG.getSetCCVP(DL, DestVT, Op1, Op2, Condition, MaskOp, EVL));
+  setValue(&VPIntrin, DAG.getSetCCVP(DL, DestVT, getValue(Op1), getValue(Op2),
+                                     Condition, MaskOp, EVL));
 }
 
 void SelectionDAGBuilder::visitVectorPredicationIntrinsic(

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -8873,7 +8873,7 @@ void SelectionDAGBuilder::visitVPCmp(const VPCmpIntrinsic &VPIntrin) {
   if (VPIntrin.getOperand(0)->getType()->isFPOrFPVectorTy()) {
     Condition = getFCmpCondCode(CondCode);
     SimplifyQuery SQ(DAG.getDataLayout(), &VPIntrin);
-    if (isKnownNeverNaN(Op1, SQ) && isKnownNeverNaN(Op2, SQ))
+    if (isKnownNeverNaN(Op2, SQ) && isKnownNeverNaN(Op1, SQ))
       Condition = getFCmpCodeWithoutNaN(Condition);
   } else {
     Condition = getICmpCondCode(CondCode);

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -8859,8 +8859,6 @@ void SelectionDAGBuilder::visitVPCmp(const VPCmpIntrinsic &VPIntrin) {
 
   ISD::CondCode Condition;
   CmpInst::Predicate CondCode = VPIntrin.getPredicate();
-  bool IsFP = VPIntrin.getOperand(0)->getType()->isFPOrFPVectorTy();
-  Condition = IsFP ? getFCmpCondCode(CondCode) : getICmpCondCode(CondCode);
 
   SDValue Op1 = getValue(VPIntrin.getOperand(0));
   SDValue Op2 = getValue(VPIntrin.getOperand(1));
@@ -8872,10 +8870,16 @@ void SelectionDAGBuilder::visitVPCmp(const VPCmpIntrinsic &VPIntrin) {
          "Unexpected target EVL type");
   EVL = DAG.getNode(ISD::ZERO_EXTEND, DL, EVLParamVT, EVL);
 
+  if (VPIntrin.getOperand(0)->getType()->isFPOrFPVectorTy()) {
+    Condition = getFCmpCondCode(CondCode);
+    if (DAG.isKnownNeverNaN(Op1) && DAG.isKnownNeverNaN(Op2))
+      Condition = getFCmpCodeWithoutNaN(Condition);
+  } else {
+    Condition = getICmpCondCode(CondCode);
+  }
+
   EVT DestVT = DAG.getTargetLoweringInfo().getValueType(DAG.getDataLayout(),
                                                         VPIntrin.getType());
-  if (DAG.isKnownNeverNaN(Op1) && DAG.isKnownNeverNaN(Op2))
-    Condition = getFCmpCodeWithoutNaN(Condition);
   setValue(&VPIntrin,
            DAG.getSetCCVP(DL, DestVT, Op1, Op2, Condition, MaskOp, EVL));
 }


### PR DESCRIPTION
`getFCmpCodeWithoutNaN` should only be used for FP comparisons (which is also the only context in which `isKnownNeverNaN` makes sense).