### PR TITLE
clang: driver: update android packed relocation logic

### DIFF
--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -274,15 +274,16 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
       // issue that this flag is not accepted by other linkers.
       ExtraOpts.push_back("--no-rosegment");
     }
-    if (!Triple.isAndroidVersionLT(28)) {
-      // Android supports relr packing starting with API 28 and had its own
-      // flavor (--pack-dyn-relocs=android) starting in API 23.
-      // TODO: It's possible to use both with --pack-dyn-relocs=android+relr,
-      // but we need to gather some data on the impact of that form before we
-      // can know if it's a good default.
-      // On the other hand, relr should always be an improvement.
+    // SHT_RELR relocations are only supported at API level >= 30.
+    // ANDROID_RELR relocations were supported at API level >= 28.
+    // Relocation packer was supported at API level >= 23.
+    if (!Triple.isAndroidVersionLT(30)) {
+      ExtraOpts.push_back("--pack-dyn-relocs=android+relr");
+    } else if (!Triple.isAndroidVersionLT(28)) {
+      ExtraOpts.push_back("--pack-dyn-relocs=android+relr");
       ExtraOpts.push_back("--use-android-relr-tags");
-      ExtraOpts.push_back("--pack-dyn-relocs=relr");
+    } else if (!Triple.isAndroidVersionLT(23)) {
+      ExtraOpts.push_back("--pack-dyn-relocs=android");
     }
   }
 

--- a/clang/test/Driver/linux-ld.c
+++ b/clang/test/Driver/linux-ld.c
@@ -954,21 +954,53 @@
 // CHECK-ANDROID-ROSEGMENT-29: "{{.*}}ld{{(.exe)?}}"
 // CHECK-ANDROID-ROSEGMENT-29-NOT: "--no-rosegment"
 
-// Check that we pass --pack-dyn-relocs=relr for API 28+ and not before.
+// Check that we pass --pack-dyn-relocs=android for API 23-27 and not before.
+// RUN: %clang %s -### -o %t.o 2>&1 \
+// RUN:     --target=armv7-linux-android22 \
+// RUN:   | FileCheck --check-prefix=CHECK-ANDROID-RELR-22 %s
+// CHECK-ANDROID-RELR-22: "{{.*}}ld{{(.exe)?}}"
+// CHECK-ANDROID-RELR-22-NOT: "--pack-dyn-relocs=android"
+// CHECK-ANDROID-RELR-22-NOT: "--pack-dyn-relocs=relr"
+// CHECK-ANDROID-RELR-22-NOT: "--pack-dyn-relocs=android+relr"
+// CHECK-ANDROID-RELR-22-NOT: "--use-android-relr-tags"
+//
+// RUN: %clang %s -### -o %t.o 2>&1 \
+// RUN:     --target=armv7-linux-android23 \
+// RUN:   | FileCheck --check-prefix=CHECK-ANDROID-RELR-23 %s
+// CHECK-ANDROID-RELR-23: "{{.*}}ld{{(.exe)?}}"
+// CHECK-ANDROID-RELR-23: "--pack-dyn-relocs=android"
+// CHECK-ANDROID-RELR-23-NOT: "--pack-dyn-relocs=relr"
+// CHECK-ANDROID-RELR-23-NOT: "--pack-dyn-relocs=android+relr"
+// CHECK-ANDROID-RELR-23-NOT: "--use-android-relr-tags"
+//
+// Check that we pass --pack-dyn-relocs=relr --use-android-relr-tags for API 28-30 and not before.
 // RUN: %clang %s -### -o %t.o 2>&1 \
 // RUN:     --target=armv7-linux-android27 \
 // RUN:   | FileCheck --check-prefix=CHECK-ANDROID-RELR-27 %s
 // CHECK-ANDROID-RELR-27: "{{.*}}ld{{(.exe)?}}"
+// CHECK-ANDROID-RELR-27: "--pack-dyn-relocs=android"
 // CHECK-ANDROID-RELR-27-NOT: "--pack-dyn-relocs=relr"
 // CHECK-ANDROID-RELR-27-NOT: "--pack-dyn-relocs=android+relr"
+// CHECK-ANDROID-RELR-27-NOT: "--use-android-relr-tags"
 //
 // RUN: %clang %s -### -o %t.o 2>&1 \
 // RUN:     --target=armv7-linux-android28 \
 // RUN:   | FileCheck --check-prefix=CHECK-ANDROID-RELR-28 %s
 // CHECK-ANDROID-RELR-28: "{{.*}}ld{{(.exe)?}}"
+// CHECK-ANDROID-RELR-28: "--pack-dyn-relocs=android+relr"
 // CHECK-ANDROID-RELR-28: "--use-android-relr-tags"
-// CHECK-ANDROID-RELR-28: "--pack-dyn-relocs=relr"
+// CHECK-ANDROID-RELR-28-NOT: "--pack-dyn-relocs=android"
 // CHECK-ANDROID-RELR-28-NOT: "--pack-dyn-relocs=android+relr"
+//
+// Check that we stop passing --use-android-relr-tags for ABI 30+.
+// RUN: %clang %s -### -o %t.o 2>&1 \
+// RUN:     --target=armv7-linux-android30 \
+// RUN:   | FileCheck --check-prefix=CHECK-ANDROID-RELR-30 %s
+// CHECK-ANDROID-RELR-30: "{{.*}}ld{{(.exe)?}}"
+// CHECK-ANDROID-RELR-30: "--pack-dyn-relocs=android+relr"
+// CHECK-ANDROID-RELR-30-NOT: "--use-android-relr-tags"
+// CHECK-ANDROID-RELR-30-NOT: "--pack-dyn-relocs=android"
+// CHECK-ANDROID-RELR-30-NOT: "--pack-dyn-relocs=android+relr"
 
 // RUN: %clang -### %s -no-pie 2>&1 --target=mips64-linux-gnuabin32 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64EL-GNUABIN32 %s

--- a/clang/test/Driver/linux-ld.c
+++ b/clang/test/Driver/linux-ld.c
@@ -990,7 +990,7 @@
 // CHECK-ANDROID-RELR-28: "--pack-dyn-relocs=android+relr"
 // CHECK-ANDROID-RELR-28: "--use-android-relr-tags"
 // CHECK-ANDROID-RELR-28-NOT: "--pack-dyn-relocs=android"
-// CHECK-ANDROID-RELR-28-NOT: "--pack-dyn-relocs=android+relr"
+// CHECK-ANDROID-RELR-28-NOT: "--pack-dyn-relocs=relr"
 //
 // Check that we stop passing --use-android-relr-tags for ABI 30+.
 // RUN: %clang %s -### -o %t.o 2>&1 \
@@ -1000,7 +1000,7 @@
 // CHECK-ANDROID-RELR-30: "--pack-dyn-relocs=android+relr"
 // CHECK-ANDROID-RELR-30-NOT: "--use-android-relr-tags"
 // CHECK-ANDROID-RELR-30-NOT: "--pack-dyn-relocs=android"
-// CHECK-ANDROID-RELR-30-NOT: "--pack-dyn-relocs=android+relr"
+// CHECK-ANDROID-RELR-30-NOT: "--pack-dyn-relocs=relr"
 
 // RUN: %clang -### %s -no-pie 2>&1 --target=mips64-linux-gnuabin32 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64EL-GNUABIN32 %s


### PR DESCRIPTION
Hoist this up from the build system so that users of Android's NDK can
benefit from these various packed relocation encodings depending on
which API level they are targeting.

Link: https://github.com/android/ndk/issues/909
Fixes: https://github.com/android/ndk/issues/2193
Link: https://github.com/android/ndk/issues/2188#issuecomment-3366591142
Link: https://android.googlesource.com/platform/build/soong/+/d046c2afef086a35d24222b09f4d2c4914e8a2a5/cc/linker.go#548
