### PR TITLE
[compiler-rt][asan] Forward fix for free_aligned_sized_mismatch.cpp

### DIFF
--- a/compiler-rt/test/asan/TestCases/Linux/free_aligned_sized_mismatch.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/free_aligned_sized_mismatch.cpp
@@ -14,6 +14,9 @@
 /// The test should not fail for these cases since the size and alignment match.
 // RUN: %env_asan_opts=free_size_mismatch=1 %run %t 128 256
 
+/// aligned_alloc is not supported on android's libc.
+// UNSUPPORTED: android
+
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
Mark this test as UNSUPPORTED for android since android's libc doesn't seem to support aligned_alloc.