### PR TITLE
[SLP][AMDGPU] Vectorize operands of non-trivially-vectorizable intrinsic calls

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SLPVectorizer.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SLPVectorizer.h
@@ -148,6 +148,11 @@ private:
   bool vectorizeInserts(InstSetVector &Instructions, BasicBlock *BB,
                         slpvectorizer::BoUpSLP &R);
 
+  /// Tries to vectorize the operands of the non-trivially-vectorizable
+  /// intrinsic calls.
+  bool vectorizeNonTriviallyVectrizableIntrinsicCallOperand(
+      InstSetVector &IIs, BasicBlock *BB, slpvectorizer::BoUpSLP &R);
+
   /// Scan the basic block and look for patterns that are likely to start
   /// a vectorization chain.
   bool vectorizeChainsInBlock(BasicBlock *BB, slpvectorizer::BoUpSLP &R);

--- a/llvm/include/llvm/Transforms/Vectorize/SLPVectorizer.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SLPVectorizer.h
@@ -152,11 +152,6 @@ private:
   /// a vectorization chain.
   bool vectorizeChainsInBlock(BasicBlock *BB, slpvectorizer::BoUpSLP &R);
 
-  /// Tries to vectorize non-trivially-vectorizable intrinsic calls operands in
-  /// the block.
-  bool vectorizeIntrinsicSeedsInBlock(BasicBlock *BB,
-                                      slpvectorizer::BoUpSLP &R);
-
   std::optional<bool> vectorizeStoreChain(ArrayRef<Value *> Chain,
                                           slpvectorizer::BoUpSLP &R,
                                           unsigned Idx, unsigned MinVF,

--- a/llvm/include/llvm/Transforms/Vectorize/SLPVectorizer.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SLPVectorizer.h
@@ -152,6 +152,11 @@ private:
   /// a vectorization chain.
   bool vectorizeChainsInBlock(BasicBlock *BB, slpvectorizer::BoUpSLP &R);
 
+  /// Tries to vectorize non-trivially-vectorizable intrinsic calls operands in
+  /// the block.
+  bool vectorizeIntrinsicSeedsInBlock(BasicBlock *BB,
+                                      slpvectorizer::BoUpSLP &R);
+
   std::optional<bool> vectorizeStoreChain(ArrayRef<Value *> Chain,
                                           slpvectorizer::BoUpSLP &R,
                                           unsigned Idx, unsigned MinVF,

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -29099,6 +29099,89 @@ bool SLPVectorizerPass::vectorizeCmpInsts(iterator_range<ItT> CmpInsts,
   return Changed;
 }
 
+bool SLPVectorizerPass::vectorizeNonTriviallyVectrizableIntrinsicCallOperand(
+    InstSetVector &IIs, BasicBlock *BB, BoUpSLP &R) {
+
+  bool Changed = false;
+
+  // Pass1 - try to find horizontal reductions of operands.
+  for (Instruction *I : IIs) {
+    auto *II = dyn_cast<IntrinsicInst>(I);
+    if (!II || R.isDeleted(II))
+      continue;
+    for (Value *Op : II->args())
+      if (auto *RootOp = dyn_cast<Instruction>(Op)) {
+        Changed |= vectorizeRootInstruction(nullptr, RootOp, BB, R);
+        if (R.isDeleted(II))
+          break;
+      }
+  }
+  // Operands sorter.
+  auto OperandSorter = [this](Value *V1, Value *V2) -> bool {
+    if (V1 == V2)
+      return false;
+    auto *I1 = cast<Instruction>(V1);
+    auto *I2 = cast<Instruction>(V2);
+    if (I1->getType()->getTypeID() != I2->getType()->getTypeID())
+      return I1->getType()->getTypeID() < I2->getType()->getTypeID();
+    if (I1->getType()->getScalarSizeInBits() !=
+        I2->getType()->getScalarSizeInBits())
+      return I1->getType()->getScalarSizeInBits() <
+             I2->getType()->getScalarSizeInBits();
+    DomTreeNodeBase<BasicBlock> *Node1 = DT->getNode(I1->getParent());
+    DomTreeNodeBase<BasicBlock> *Node2 = DT->getNode(I2->getParent());
+    if (!Node1)
+      return Node2 != nullptr;
+    if (!Node2)
+      return false;
+    if (Node1->getDFSNumIn() == Node2->getDFSNumIn()) {
+      if (I1->getOpcode() != I2->getOpcode())
+        return I1->getOpcode() < I2->getOpcode();
+      return I1->comesBefore(I2);
+    }
+    return Node1->getDFSNumIn() < Node2->getDFSNumIn();
+  };
+
+  // Compatibility checker for the operands.
+  auto AreCompatibleOperands = [](ArrayRef<Value *> VL, Value *V) -> bool {
+    if (VL.empty() || VL.back() == V)
+      return true;
+    auto *I1 = cast<Instruction>(VL.back());
+    auto *I2 = cast<Instruction>(V);
+    return I1->getType() == I2->getType() &&
+           I1->getParent() == I2->getParent() &&
+           I1->getOpcode() == I2->getOpcode();
+  };
+
+  // Collect the operands of the non-trivially-vectorizable intrinsic calls.
+  SmallVector<Value *, 4> CandidateSeeds;
+  for (Instruction *I : IIs) {
+    auto *II = dyn_cast<IntrinsicInst>(I);
+    if (!II || R.isDeleted(II))
+      continue;
+    SmallVector<Value *, 4> Ops =
+        getNonTriviallyVectorizableIntrinsicCallOperand(II);
+    for (Value *Op : Ops)
+      if (auto *OpI = dyn_cast<Instruction>(Op))
+        CandidateSeeds.push_back(Op);
+  }
+
+  auto CandidatesFiltered = make_filter_range(CandidateSeeds, [&](Value *V) {
+    auto *I = dyn_cast<Instruction>(V);
+    return I && !R.isDeleted(I) && isValidElementType(I->getType());
+  });
+  SmallVector<Value *, 4> CandidateVec(CandidatesFiltered);
+  // Pass2 - try to vectorize the operands.
+  Changed |= tryToVectorizeSequence<Value>(
+      CandidateVec, OperandSorter, AreCompatibleOperands,
+      [this, &R](ArrayRef<Value *> Candidates, bool MaxVFOnly) {
+        return tryToVectorizeList(Candidates, R, MaxVFOnly);
+      },
+      /*MaxVFOnly=*/true, R);
+
+  return Changed;
+}
+
 bool SLPVectorizerPass::vectorizeInserts(InstSetVector &Instructions,
                                          BasicBlock *BB, BoUpSLP &R) {
   assert(all_of(Instructions, IsaPred<InsertElementInst, InsertValueInst>) &&
@@ -29371,6 +29454,7 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
 
   InstSetVector PostProcessInserts;
   SmallSetVector<CmpInst *, 8> PostProcessCmps;
+  InstSetVector PostProcessIntrinsicCalls;
   // Vectorizes Inserts in `PostProcessInserts` and if `VectorizeCmps` is true
   // also vectorizes `PostProcessCmps`.
   auto VectorizeInsertsAndCmps = [&](bool VectorizeCmps) {
@@ -29378,14 +29462,25 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
     if (VectorizeCmps) {
       Changed |= vectorizeCmpInsts(reverse(PostProcessCmps), BB, R);
       PostProcessCmps.clear();
+      Changed |= vectorizeNonTriviallyVectrizableIntrinsicCallOperand(
+          PostProcessIntrinsicCalls, BB, R);
+      PostProcessIntrinsicCalls.clear();
     }
     PostProcessInserts.clear();
     return Changed;
+  };
+  auto isNonTriviallyVectorizableIntrinsic = [](const IntrinsicInst *II) {
+    return !isTriviallyVectorizable(II->getIntrinsicID()) &&
+           !isAssumeLikeIntrinsic(II) &&
+           !(!SLPReVec && II->getType()->isVectorTy());
   };
   // Returns true if `I` is in `PostProcessInserts` or `PostProcessCmps`.
   auto IsInPostProcessInstrs = [&](Instruction *I) {
     if (auto *Cmp = dyn_cast<CmpInst>(I))
       return PostProcessCmps.contains(Cmp);
+    if (auto *II = dyn_cast<IntrinsicInst>(I);
+        II && isNonTriviallyVectorizableIntrinsic(II))
+      return PostProcessIntrinsicCalls.contains(II);
     return isa<InsertElementInst, InsertValueInst>(I) &&
            PostProcessInserts.contains(I);
   };
@@ -29508,36 +29603,10 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
       PostProcessInserts.insert(&*It);
     else if (isa<CmpInst>(It))
       PostProcessCmps.insert(cast<CmpInst>(&*It));
-
-    // Collect operands of non-trivially vectorizable intrinsic calls (e.g.,
-    // llvm.amdgcn.exp2) and group by intrinsic ID, so their operands can be
-    // vectorized independently.
-    // FIXME: Extend for all non-vectorized functions.
-    if (R.isDeleted(&*It))
-      continue;
-    SmallVector<Value *, 4> Ops =
-        getNonTriviallyVectorizableIntrinsicCallOperand(&*It);
-    if (!Ops.empty()) {
-      Intrinsic::ID ID = cast<CallInst>(&*It)->getIntrinsicID();
-      for (auto [OpIdx, Op] : enumerate(Ops)) {
-        if (auto *OpI = dyn_cast<Instruction>(Op)) {
-          IntrinsicSeedOps[{ID, OpIdx}][OpI->getOpcode()].push_back(Op);
-        }
-      }
-    }
+    else if (auto *II = dyn_cast<IntrinsicInst>(&*It);
+             II && isNonTriviallyVectorizableIntrinsic(II))
+      PostProcessIntrinsicCalls.insert(II);
   }
-
-  // Vectorize non-trivially-vectorizable intrinsic candidates.
-  for (auto &[_, OpcodeMap] : IntrinsicSeedOps)
-    for (auto &[_, Group] : OpcodeMap) {
-      // Don't include instructions that were deleted by previous
-      // vectorization.
-      auto Candidates = make_filter_range(Group, [&](Value *V) {
-        auto *I = dyn_cast<Instruction>(V);
-        return I && !R.isDeleted(I);
-      });
-      Changed |= tryToVectorizeList(SmallVector<Value *, 4>(Candidates), R);
-    }
 
   return Changed;
 }

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -271,7 +271,7 @@ getNonTriviallyVectorizableIntrinsicCallOperand(Value *V) {
   }
 
   return Operands;
-}  
+}
 
 /// Predicate for the element types that the SLP vectorizer supports.
 ///
@@ -12276,8 +12276,9 @@ void BoUpSLP::buildTreeRec(ArrayRef<Value *> VLRef, unsigned Depth,
           }
         }
         if (NewLoopNest.size() > CurrentLoopNest.size())
-          CurrentLoopNest.append(std::next(NewLoopNest.begin(), CurrentLoopNest.size()),
-                          NewLoopNest.end());
+          CurrentLoopNest.append(
+              std::next(NewLoopNest.begin(), CurrentLoopNest.size()),
+              NewLoopNest.end());
       }
     }
   }
@@ -18475,10 +18476,9 @@ InstructionCost BoUpSLP::getTreeCost(InstructionCost TreeCost,
           assert(SLPReVec && "Only supported by REVEC.");
           SrcTy = getWidenedType(SrcTy, VecTy->getNumElements());
         }
-        InstructionCost CastCost =
-            TTI->getCastInstrCost(Opcode, DstTy, SrcTy,
-                                  TTI::CastContextHint::None,
-                                  TTI::TCK_RecipThroughput);
+        InstructionCost CastCost = TTI->getCastInstrCost(
+            Opcode, DstTy, SrcTy, TTI::CastContextHint::None,
+            TTI::TCK_RecipThroughput);
         CastCost = ScaleCost(CastCost, Root, /*Scalar=*/nullptr, ReductionRoot);
         Cost += CastCost;
       }
@@ -18647,9 +18647,8 @@ InstructionCost BoUpSLP::getTreeCost(InstructionCost TreeCost,
         default:
           break;
         }
-        InstructionCost CastCost =
-            TTI->getCastInstrCost(Opcode, DstVecTy, SrcVecTy, CCH,
-                                  TTI::TCK_RecipThroughput);
+        InstructionCost CastCost = TTI->getCastInstrCost(
+            Opcode, DstVecTy, SrcVecTy, CCH, TTI::TCK_RecipThroughput);
         CastCost = ScaleCost(CastCost, *VectorizableTree.front().get(),
                              /*Scalar=*/nullptr, ReductionRoot);
         Cost += CastCost;

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -243,7 +243,7 @@ static const int MinScheduleRegionSize = 16;
 /// Maximum allowed number of operands in the PHI nodes.
 static const unsigned MaxPHINumOperands = 128;
 
-/// For instructions that are not trivially vectorizable, try to vectorize their
+/// For the non-trivially vectorizable intrinsics calls, try to vectorize their
 /// operands.
 /// FIXME: Extend for all non-vectorized functions.
 SmallVector<Value *, 4>
@@ -256,7 +256,7 @@ getNonTriviallyVectorizableIntrinsicCallOperand(Value *V) {
   if (isTriviallyVectorizable(II->getIntrinsicID()))
     return {};
 
-  // Skip memory intrinsics (e.g., masked.load, masked.gather etc.)
+  // Skip vector-returning intrinsics in non-revec mode.
   if (!SLPReVec && II->getType()->isVectorTy())
     return {};
 

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -243,6 +243,39 @@ static const int MinScheduleRegionSize = 16;
 /// Maximum allowed number of operands in the PHI nodes.
 static const unsigned MaxPHINumOperands = 128;
 
+/// For instructions that are not trivially vectorizable, try to vectorize their
+/// operands.
+/// FIXME: Extend for all non-vectorized functions.
+static Value *getNonTriviallyVectorizableIntrinsicCallOperand(Value *V) {
+  auto *CI = dyn_cast<CallInst>(V);
+  if (!CI)
+    return nullptr;
+  Intrinsic::ID ID = CI->getIntrinsicID();
+  // Only consider intrinsic calls.
+  // FIXME: We may want to relax this condition in future.
+  if (ID == Intrinsic::not_intrinsic)
+    return nullptr;
+  // Skip trivially vectorizable intrinsics.
+  if (isTriviallyVectorizable(ID))
+    return nullptr;
+  // Only look through unary intrinsic calls.
+  if (CI->arg_size() != 1)
+    return nullptr;
+  // Check if it is speculatable, no memory access and will return
+  if (!CI->hasFnAttr(Attribute::Speculatable) || !CI->doesNotAccessMemory() ||
+      !CI->willReturn())
+    return nullptr;
+  auto *Operand = dyn_cast<Instruction>(CI->getArgOperand(0));
+  if (!Operand)
+    return nullptr;
+  // Operand type should match the result type we ignore type changing
+  // intrinsics.
+  if (Operand->getType() != CI->getType())
+    return nullptr;
+
+  return Operand;
+}
+
 /// Predicate for the element types that the SLP vectorizer supports.
 ///
 /// The most important thing to filter here are types which are invalid in LLVM
@@ -29475,6 +29508,22 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
       PostProcessInserts.insert(&*It);
     else if (isa<CmpInst>(It))
       PostProcessCmps.insert(cast<CmpInst>(&*It));
+  }
+
+  DenseMap<Intrinsic::ID, SmallSetVector<Value *, 4>> IntrinsicSeedOps;
+  for (Instruction &I : *BB) {
+    if (R.isDeleted(&I))
+      continue;
+    // Collect operands of non-trivially vectorizable intrinsic calls (e.g.,
+    // llvm.amdgcn.exp2) and group by intrinsic ID, so their operands can be
+    // vectorized independently.
+    // FIXME: Extend for all non-vectorized functions.
+    if (Value *Op = getNonTriviallyVectorizableIntrinsicCallOperand(&I))
+      IntrinsicSeedOps[cast<CallInst>(&I)->getIntrinsicID()].insert(Op);
+  }
+  // Try to vectorize per intrinsic call ID.
+  for (auto &[ID, Ops] : IntrinsicSeedOps) {
+    Changed |= tryToVectorizeList(Ops.getArrayRef(), R);
   }
 
   return Changed;

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -246,35 +246,32 @@ static const unsigned MaxPHINumOperands = 128;
 /// For instructions that are not trivially vectorizable, try to vectorize their
 /// operands.
 /// FIXME: Extend for all non-vectorized functions.
-static Value *getNonTriviallyVectorizableIntrinsicCallOperand(Value *V) {
+SmallVector<Value *, 4>
+getNonTriviallyVectorizableIntrinsicCallOperand(Value *V) {
+
+  SmallVector<Value *, 4> Operands;
   auto *CI = dyn_cast<CallInst>(V);
-  if (!CI)
-    return nullptr;
+
+  if (!CI || isAssumeLikeIntrinsic(CI))
+    return {};
   Intrinsic::ID ID = CI->getIntrinsicID();
   // Only consider intrinsic calls.
   // FIXME: We may want to relax this condition in future.
-  if (ID == Intrinsic::not_intrinsic)
-    return nullptr;
-  // Skip trivially vectorizable intrinsics.
-  if (isTriviallyVectorizable(ID))
-    return nullptr;
-  // Only consider unary intrinsic calls.
-  if (CI->arg_size() != 1)
-    return nullptr;
-  // Check if it is speculatable, no memory access and will return
-  if (!CI->hasFnAttr(Attribute::Speculatable) || !CI->doesNotAccessMemory() ||
-      !CI->willReturn())
-    return nullptr;
-  auto *Operand = dyn_cast<Instruction>(CI->getArgOperand(0));
-  if (!Operand)
-    return nullptr;
-  // Operand type should match the result type we ignore type changing
-  // intrinsics.
-  if (Operand->getType() != CI->getType())
-    return nullptr;
+  if (ID == Intrinsic::not_intrinsic || isTriviallyVectorizable(ID))
+    return {};
 
-  return Operand;
-}
+  // Skip memory intrinsics (e.g., masked.load, masked.gather etc.)
+  if (CI->mayReadOrWriteMemory())
+    return {};
+
+  for (Value *ArgOp : CI->args()) {
+    if (auto *I = dyn_cast<Instruction>(ArgOp)) {
+      Operands.emplace_back(I);
+    }
+  }
+
+  return Operands;
+}  
 
 /// Predicate for the element types that the SLP vectorizer supports.
 ///
@@ -29510,7 +29507,7 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
       PostProcessCmps.insert(cast<CmpInst>(&*It));
   }
 
-  DenseMap<Intrinsic::ID, SmallSetVector<Value *, 4>> IntrinsicSeedOps;
+  SmallMapVector<Intrinsic::ID, SmallSetVector<Value *, 4>, 4> IntrinsicSeedOps;
   for (Instruction &I : *BB) {
     if (R.isDeleted(&I))
       continue;
@@ -29518,12 +29515,21 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
     // llvm.amdgcn.exp2) and group by intrinsic ID, so their operands can be
     // vectorized independently.
     // FIXME: Extend for all non-vectorized functions.
-    if (Value *Op = getNonTriviallyVectorizableIntrinsicCallOperand(&I))
-      IntrinsicSeedOps[cast<CallInst>(&I)->getIntrinsicID()].insert(Op);
+    SmallVector<Value *, 4> Ops =
+        getNonTriviallyVectorizableIntrinsicCallOperand(&I);
+    if (!Ops.empty())
+      IntrinsicSeedOps[cast<CallInst>(&I)->getIntrinsicID()].insert_range(Ops);
   }
   // Try to vectorize per intrinsic call ID.
   for (auto &[ID, Ops] : IntrinsicSeedOps) {
-    Changed |= tryToVectorizeList(Ops.getArrayRef(), R);
+    // Sub-group by opcode so we do not get bailed early
+    SmallMapVector<unsigned, SmallVector<Value *, 4>, 4> OpcodeGroups;
+    for (Value *Op : Ops) {
+      if (auto *I = dyn_cast<Instruction>(Op))
+        OpcodeGroups[I->getOpcode()].push_back(Op);
+    }
+    for (auto &[Opc, Group] : OpcodeGroups)
+      Changed |= tryToVectorizeList(Group, R);
   }
 
   return Changed;

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -25296,9 +25296,6 @@ bool SLPVectorizerPass::runImpl(Function &F, ScalarEvolution *SE_,
     // Vectorize trees that end at reductions.
     Changed |= vectorizeChainsInBlock(BB, R);
 
-    // Vectorize non-trivially-vectorizable intrinsic.
-    Changed |= vectorizeIntrinsicSeedsInBlock(BB, R);
-
     // Vectorize the index computations of getelementptr instructions. This
     // is primarily intended to catch gather-like idioms ending at
     // non-consecutive loads.
@@ -29399,6 +29396,11 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
     return I->use_empty() &&
            (I->getType()->isVoidTy() || isa<CallInst, InvokeInst>(I));
   };
+  SmallMapVector<std::pair<Intrinsic::ID, unsigned>, // (ID, OpIndex)
+                 SmallMapVector<unsigned,            // Opcode
+                                SmallVector<Value *, 4>, 4>,
+                 4>
+      IntrinsicSeedOps;
   for (BasicBlock::iterator It = BB->begin(), E = BB->end(); It != E; ++It) {
     // Skip instructions with scalable type. The num of elements is unknown at
     // compile-time for scalable type.
@@ -29506,30 +29508,17 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
       PostProcessInserts.insert(&*It);
     else if (isa<CmpInst>(It))
       PostProcessCmps.insert(cast<CmpInst>(&*It));
-  }
 
-  return Changed;
-}
-
-bool SLPVectorizerPass::vectorizeIntrinsicSeedsInBlock(BasicBlock *BB,
-                                                       BoUpSLP &R) {
-  bool Changed = false;
-  // Collect operands of non-trivially vectorizable intrinsic calls (e.g.,
-  // llvm.amdgcn.exp2) and group by intrinsic ID, so their operands can be
-  // vectorized independently.
-  // FIXME: Extend for all non-vectorized functions.
-  SmallMapVector<std::pair<Intrinsic::ID, unsigned>, // (ID, OpIndex)
-                 SmallMapVector<unsigned,            // Opcode
-                                SmallVector<Value *, 4>, 4>,
-                 4>
-      IntrinsicSeedOps;
-  for (Instruction &I : *BB) {
-    if (R.isDeleted(&I))
+    // Collect operands of non-trivially vectorizable intrinsic calls (e.g.,
+    // llvm.amdgcn.exp2) and group by intrinsic ID, so their operands can be
+    // vectorized independently.
+    // FIXME: Extend for all non-vectorized functions.
+    if (R.isDeleted(&*It))
       continue;
     SmallVector<Value *, 4> Ops =
-        getNonTriviallyVectorizableIntrinsicCallOperand(&I);
+        getNonTriviallyVectorizableIntrinsicCallOperand(&*It);
     if (!Ops.empty()) {
-      Intrinsic::ID ID = cast<CallInst>(&I)->getIntrinsicID();
+      Intrinsic::ID ID = cast<CallInst>(&*It)->getIntrinsicID();
       for (auto [OpIdx, Op] : enumerate(Ops)) {
         if (auto *OpI = dyn_cast<Instruction>(Op)) {
           IntrinsicSeedOps[{ID, OpIdx}][OpI->getOpcode()].push_back(Op);
@@ -29538,6 +29527,7 @@ bool SLPVectorizerPass::vectorizeIntrinsicSeedsInBlock(BasicBlock *BB,
     }
   }
 
+  // Vectorize non-trivially-vectorizable intrinsic candidates.
   for (auto &[_, OpcodeMap] : IntrinsicSeedOps)
     for (auto &[_, Group] : OpcodeMap) {
       // Don't include instructions that were deleted by previous
@@ -29548,6 +29538,7 @@ bool SLPVectorizerPass::vectorizeIntrinsicSeedsInBlock(BasicBlock *BB,
       });
       Changed |= tryToVectorizeList(SmallVector<Value *, 4>(Candidates), R);
     }
+
   return Changed;
 }
 

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -261,7 +261,7 @@ getNonTriviallyVectorizableIntrinsicCallOperand(Value *V) {
     return {};
 
   // Skip memory intrinsics (e.g., masked.load, masked.gather etc.)
-  if (CI->mayReadOrWriteMemory())
+  if (!SLPReVec && CI->getType()->isVectorTy())
     return {};
 
   for (Value *ArgOp : CI->args()) {
@@ -12276,9 +12276,8 @@ void BoUpSLP::buildTreeRec(ArrayRef<Value *> VLRef, unsigned Depth,
           }
         }
         if (NewLoopNest.size() > CurrentLoopNest.size())
-          CurrentLoopNest.append(
-              std::next(NewLoopNest.begin(), CurrentLoopNest.size()),
-              NewLoopNest.end());
+          CurrentLoopNest.append(std::next(NewLoopNest.begin(), CurrentLoopNest.size()),
+                          NewLoopNest.end());
       }
     }
   }
@@ -18476,9 +18475,10 @@ InstructionCost BoUpSLP::getTreeCost(InstructionCost TreeCost,
           assert(SLPReVec && "Only supported by REVEC.");
           SrcTy = getWidenedType(SrcTy, VecTy->getNumElements());
         }
-        InstructionCost CastCost = TTI->getCastInstrCost(
-            Opcode, DstTy, SrcTy, TTI::CastContextHint::None,
-            TTI::TCK_RecipThroughput);
+        InstructionCost CastCost =
+            TTI->getCastInstrCost(Opcode, DstTy, SrcTy,
+                                  TTI::CastContextHint::None,
+                                  TTI::TCK_RecipThroughput);
         CastCost = ScaleCost(CastCost, Root, /*Scalar=*/nullptr, ReductionRoot);
         Cost += CastCost;
       }
@@ -18647,8 +18647,9 @@ InstructionCost BoUpSLP::getTreeCost(InstructionCost TreeCost,
         default:
           break;
         }
-        InstructionCost CastCost = TTI->getCastInstrCost(
-            Opcode, DstVecTy, SrcVecTy, CCH, TTI::TCK_RecipThroughput);
+        InstructionCost CastCost =
+            TTI->getCastInstrCost(Opcode, DstVecTy, SrcVecTy, CCH,
+                                  TTI::TCK_RecipThroughput);
         CastCost = ScaleCost(CastCost, *VectorizableTree.front().get(),
                              /*Scalar=*/nullptr, ReductionRoot);
         Cost += CastCost;
@@ -29506,30 +29507,27 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
       PostProcessCmps.insert(cast<CmpInst>(&*It));
   }
 
-  SmallMapVector<Intrinsic::ID, SmallSetVector<Value *, 4>, 4> IntrinsicSeedOps;
+  // Collect operands of non-trivially vectorizable intrinsic calls (e.g.,
+  // llvm.amdgcn.exp2) and group by intrinsic ID, so their operands can be
+  // vectorized independently.
+  // FIXME: Extend for all non-vectorized functions.
+  SmallMapVector<std::pair<Intrinsic::ID, unsigned>, SmallVector<Value *, 4>, 4>
+      OpcodeGroups;
+
   for (Instruction &I : *BB) {
     if (R.isDeleted(&I))
       continue;
-    // Collect operands of non-trivially vectorizable intrinsic calls (e.g.,
-    // llvm.amdgcn.exp2) and group by intrinsic ID, so their operands can be
-    // vectorized independently.
-    // FIXME: Extend for all non-vectorized functions.
     SmallVector<Value *, 4> Ops =
         getNonTriviallyVectorizableIntrinsicCallOperand(&I);
-    if (!Ops.empty())
-      IntrinsicSeedOps[cast<CallInst>(&I)->getIntrinsicID()].insert_range(Ops);
-  }
-  // Try to vectorize per intrinsic call ID.
-  for (auto &[ID, Ops] : IntrinsicSeedOps) {
-    // Sub-group by opcode so we do not get bailed early
-    SmallMapVector<unsigned, SmallVector<Value *, 4>, 4> OpcodeGroups;
-    for (Value *Op : Ops) {
-      if (auto *I = dyn_cast<Instruction>(Op))
-        OpcodeGroups[I->getOpcode()].push_back(Op);
+    if (!Ops.empty()) {
+      Intrinsic::ID ID = cast<CallInst>(&I)->getIntrinsicID();
+      for (Value *Op : Ops)
+        if (auto *OpI = dyn_cast<Instruction>(Op))
+          OpcodeGroups[{ID, OpI->getOpcode()}].push_back(Op);
     }
-    for (auto &[Opc, Group] : OpcodeGroups)
-      Changed |= tryToVectorizeList(Group, R);
   }
+  for (auto &[_, OpGroup] : OpcodeGroups)
+    Changed |= tryToVectorizeList(OpGroup, R);
 
   return Changed;
 }

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -249,22 +249,20 @@ static const unsigned MaxPHINumOperands = 128;
 SmallVector<Value *, 4>
 getNonTriviallyVectorizableIntrinsicCallOperand(Value *V) {
 
-  SmallVector<Value *, 4> Operands;
-  auto *CI = dyn_cast<CallInst>(V);
-
-  if (!CI || isAssumeLikeIntrinsic(CI))
+  auto *II = dyn_cast<IntrinsicInst>(V);
+  if (!II || isAssumeLikeIntrinsic(II))
     return {};
-  Intrinsic::ID ID = CI->getIntrinsicID();
-  // Only consider intrinsic calls.
-  // FIXME: We may want to relax this condition in future.
-  if (ID == Intrinsic::not_intrinsic || isTriviallyVectorizable(ID))
+
+  if (isTriviallyVectorizable(II->getIntrinsicID()))
     return {};
 
   // Skip memory intrinsics (e.g., masked.load, masked.gather etc.)
-  if (!SLPReVec && CI->getType()->isVectorTy())
+  if (!SLPReVec && II->getType()->isVectorTy())
     return {};
 
-  for (Value *ArgOp : CI->args()) {
+  // FIXME: Add non-instructions operands to the list.
+  SmallVector<Value *, 4> Operands;
+  for (Value *ArgOp : II->args()) {
     if (auto *I = dyn_cast<Instruction>(ArgOp)) {
       Operands.emplace_back(I);
     }
@@ -25298,6 +25296,9 @@ bool SLPVectorizerPass::runImpl(Function &F, ScalarEvolution *SE_,
     // Vectorize trees that end at reductions.
     Changed |= vectorizeChainsInBlock(BB, R);
 
+    // Vectorize non-trivially-vectorizable intrinsic.
+    Changed |= vectorizeIntrinsicSeedsInBlock(BB, R);
+
     // Vectorize the index computations of getelementptr instructions. This
     // is primarily intended to catch gather-like idioms ending at
     // non-consecutive loads.
@@ -29507,13 +29508,21 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
       PostProcessCmps.insert(cast<CmpInst>(&*It));
   }
 
+  return Changed;
+}
+
+bool SLPVectorizerPass::vectorizeIntrinsicSeedsInBlock(BasicBlock *BB,
+                                                       BoUpSLP &R) {
+  bool Changed = false;
   // Collect operands of non-trivially vectorizable intrinsic calls (e.g.,
   // llvm.amdgcn.exp2) and group by intrinsic ID, so their operands can be
   // vectorized independently.
   // FIXME: Extend for all non-vectorized functions.
-  SmallMapVector<std::pair<Intrinsic::ID, unsigned>, SmallVector<Value *, 4>, 4>
-      OpcodeGroups;
-
+  SmallMapVector<std::pair<Intrinsic::ID, unsigned>, // (ID, OpIndex)
+                 SmallMapVector<unsigned,            // Opcode
+                                SmallVector<Value *, 4>, 4>,
+                 4>
+      IntrinsicSeedOps;
   for (Instruction &I : *BB) {
     if (R.isDeleted(&I))
       continue;
@@ -29521,14 +29530,24 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
         getNonTriviallyVectorizableIntrinsicCallOperand(&I);
     if (!Ops.empty()) {
       Intrinsic::ID ID = cast<CallInst>(&I)->getIntrinsicID();
-      for (Value *Op : Ops)
-        if (auto *OpI = dyn_cast<Instruction>(Op))
-          OpcodeGroups[{ID, OpI->getOpcode()}].push_back(Op);
+      for (auto [OpIdx, Op] : enumerate(Ops)) {
+        if (auto *OpI = dyn_cast<Instruction>(Op)) {
+          IntrinsicSeedOps[{ID, OpIdx}][OpI->getOpcode()].push_back(Op);
+        }
+      }
     }
   }
-  for (auto &[_, OpGroup] : OpcodeGroups)
-    Changed |= tryToVectorizeList(OpGroup, R);
 
+  for (auto &[_, OpcodeMap] : IntrinsicSeedOps)
+    for (auto &[_, Group] : OpcodeMap) {
+      // Don't include instructions that were deleted by previous
+      // vectorization.
+      auto Candidates = make_filter_range(Group, [&](Value *V) {
+        auto *I = dyn_cast<Instruction>(V);
+        return I && !R.isDeleted(I);
+      });
+      Changed |= tryToVectorizeList(SmallVector<Value *, 4>(Candidates), R);
+    }
   return Changed;
 }
 

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -29508,7 +29508,7 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
     // We may go through BB multiple times so skip the one we have checked.
     if (!VisitedInstrs.insert(&*It).second) {
       if (HasNoUsers(&*It) &&
-          VectorizeInsertsAndCmps(/*VectorizeCmps=*/It->isTerminator())) {
+          VectorizeInsertsAndCmps(/*AtTerminator=*/It->isTerminator())) {
         // We would like to start over since some instructions are deleted
         // and the iterator may become invalid value.
         Changed = true;
@@ -29588,7 +29588,7 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
       // top-tree instructions to try to vectorize as many instructions as
       // possible.
       OpsChanged |=
-          VectorizeInsertsAndCmps(/*VectorizeCmps=*/It->isTerminator());
+          VectorizeInsertsAndCmps(/*AtTerminator=*/It->isTerminator());
       if (OpsChanged) {
         // We would like to start over since some instructions are deleted
         // and the iterator may become invalid value.

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -29162,7 +29162,7 @@ bool SLPVectorizerPass::vectorizeNonTriviallyVectrizableIntrinsicCallOperand(
     SmallVector<Value *, 4> Ops =
         getNonTriviallyVectorizableIntrinsicCallOperand(II);
     for (Value *Op : Ops)
-      if (auto *OpI = dyn_cast<Instruction>(Op))
+      if (isa<Instruction>(Op))
         CandidateSeeds.push_back(Op);
   }
 
@@ -29455,11 +29455,11 @@ bool SLPVectorizerPass::vectorizeChainsInBlock(BasicBlock *BB, BoUpSLP &R) {
   InstSetVector PostProcessInserts;
   SmallSetVector<CmpInst *, 8> PostProcessCmps;
   InstSetVector PostProcessIntrinsicCalls;
-  // Vectorizes Inserts in `PostProcessInserts` and if `VectorizeCmps` is true
-  // also vectorizes `PostProcessCmps`.
-  auto VectorizeInsertsAndCmps = [&](bool VectorizeCmps) {
+  // Vectorizes Inserts in `PostProcessInserts` and if `AtTerminator` is true
+  // also vectorizes `PostProcessCmps` and `PostProcessIntrinsicCalls`.
+  auto VectorizeInsertsAndCmps = [&](bool AtTerminator) {
     bool Changed = vectorizeInserts(PostProcessInserts, BB, R);
-    if (VectorizeCmps) {
+    if (AtTerminator) {
       Changed |= vectorizeCmpInsts(reverse(PostProcessCmps), BB, R);
       PostProcessCmps.clear();
       Changed |= vectorizeNonTriviallyVectrizableIntrinsicCallOperand(

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -258,7 +258,7 @@ static Value *getNonTriviallyVectorizableIntrinsicCallOperand(Value *V) {
   // Skip trivially vectorizable intrinsics.
   if (isTriviallyVectorizable(ID))
     return nullptr;
-  // Only look through unary intrinsic calls.
+  // Only consider unary intrinsic calls.
   if (CI->arg_size() != 1)
     return nullptr;
   // Check if it is speculatable, no memory access and will return

--- a/llvm/test/Transforms/SLPVectorizer/AMDGPU/notriviallyvectorizableintrinsicoperands.ll
+++ b/llvm/test/Transforms/SLPVectorizer/AMDGPU/notriviallyvectorizableintrinsicoperands.ll
@@ -355,6 +355,190 @@ entry:
   ret void
 }
 
+define amdgpu_kernel void @kernel_div_scale(ptr addrspace(1) %num, ptr addrspace(1) %den, ptr addrspace(1) %output) {
+; GCN-LABEL: define amdgpu_kernel void @kernel_div_scale(
+; GCN-SAME: ptr addrspace(1) [[NUM:%.*]], ptr addrspace(1) [[DEN:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
+; GCN-NEXT:  [[ENTRY:.*:]]
+; GCN-NEXT:    [[NPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[NUM]], i64 2
+; GCN-NEXT:    [[N2:%.*]] = load float, ptr addrspace(1) [[NPTR2]], align 4
+; GCN-NEXT:    [[DPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[DEN]], i64 2
+; GCN-NEXT:    [[D2:%.*]] = load float, ptr addrspace(1) [[DPTR2]], align 4
+; GCN-NEXT:    [[TMP0:%.*]] = load <2 x float>, ptr addrspace(1) [[NUM]], align 4
+; GCN-NEXT:    [[TMP1:%.*]] = fmul <2 x float> [[TMP0]], splat (float 2.000000e+00)
+; GCN-NEXT:    [[MUL_N2:%.*]] = fmul float [[N2]], 2.000000e+00
+; GCN-NEXT:    [[TMP2:%.*]] = load <2 x float>, ptr addrspace(1) [[DEN]], align 4
+; GCN-NEXT:    [[TMP3:%.*]] = fmul <2 x float> [[TMP2]], splat (float 4.000000e+00)
+; GCN-NEXT:    [[MUL_D2:%.*]] = fmul float [[D2]], 4.000000e+00
+; GCN-NEXT:    [[TMP4:%.*]] = extractelement <2 x float> [[TMP1]], i32 0
+; GCN-NEXT:    [[TMP5:%.*]] = extractelement <2 x float> [[TMP3]], i32 0
+; GCN-NEXT:    [[DS0:%.*]] = call { float, i1 } @llvm.amdgcn.div.scale.f32(float [[TMP4]], float [[TMP5]], i1 false)
+; GCN-NEXT:    [[TMP6:%.*]] = extractelement <2 x float> [[TMP1]], i32 1
+; GCN-NEXT:    [[TMP7:%.*]] = extractelement <2 x float> [[TMP3]], i32 1
+; GCN-NEXT:    [[DS1:%.*]] = call { float, i1 } @llvm.amdgcn.div.scale.f32(float [[TMP6]], float [[TMP7]], i1 false)
+; GCN-NEXT:    [[DS2:%.*]] = call { float, i1 } @llvm.amdgcn.div.scale.f32(float [[MUL_N2]], float [[MUL_D2]], i1 false)
+; GCN-NEXT:    [[R0:%.*]] = extractvalue { float, i1 } [[DS0]], 0
+; GCN-NEXT:    [[R1:%.*]] = extractvalue { float, i1 } [[DS1]], 0
+; GCN-NEXT:    [[R2:%.*]] = extractvalue { float, i1 } [[DS2]], 0
+; GCN-NEXT:    [[SUM01:%.*]] = fadd float [[R0]], [[R1]]
+; GCN-NEXT:    [[SUM:%.*]] = fadd float [[SUM01]], [[R2]]
+; GCN-NEXT:    store float [[SUM]], ptr addrspace(1) [[OUTPUT]], align 4
+; GCN-NEXT:    ret void
+;
+entry:
+  %n0 = load float, ptr addrspace(1) %num, align 4
+  %nptr1 = getelementptr float, ptr addrspace(1) %num, i64 1
+  %n1 = load float, ptr addrspace(1) %nptr1, align 4
+  %nptr2 = getelementptr float, ptr addrspace(1) %num, i64 2
+  %n2 = load float, ptr addrspace(1) %nptr2, align 4
+  %d0 = load float, ptr addrspace(1) %den, align 4
+  %dptr1 = getelementptr float, ptr addrspace(1) %den, i64 1
+  %d1 = load float, ptr addrspace(1) %dptr1, align 4
+  %dptr2 = getelementptr float, ptr addrspace(1) %den, i64 2
+  %d2 = load float, ptr addrspace(1) %dptr2, align 4
+  %mul_n0 = fmul float %n0, 2.0
+  %mul_n1 = fmul float %n1, 2.0
+  %mul_n2 = fmul float %n2, 2.0
+  %mul_d0 = fmul float %d0, 4.0
+  %mul_d1 = fmul float %d1, 4.0
+  %mul_d2 = fmul float %d2, 4.0
+  %ds0 = call { float, i1 } @llvm.amdgcn.div.scale.f32(float %mul_n0, float %mul_d0, i1 false)
+  %ds1 = call { float, i1 } @llvm.amdgcn.div.scale.f32(float %mul_n1, float %mul_d1, i1 false)
+  %ds2 = call { float, i1 } @llvm.amdgcn.div.scale.f32(float %mul_n2, float %mul_d2, i1 false)
+  %r0 = extractvalue { float, i1 } %ds0, 0
+  %r1 = extractvalue { float, i1 } %ds1, 0
+  %r2 = extractvalue { float, i1 } %ds2, 0
+  %sum01 = fadd float %r0, %r1
+  %sum   = fadd float %sum01, %r2
+  store float %sum, ptr addrspace(1) %output, align 4
+  ret void
+}
+
+define amdgpu_kernel void @kernel_fmed3(ptr addrspace(1) %a, ptr addrspace(1) %b, ptr addrspace(1) %output) {
+; GCN-LABEL: define amdgpu_kernel void @kernel_fmed3(
+; GCN-SAME: ptr addrspace(1) [[A:%.*]], ptr addrspace(1) [[B:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
+; GCN-NEXT:  [[ENTRY:.*:]]
+; GCN-NEXT:    [[APTR2:%.*]] = getelementptr float, ptr addrspace(1) [[A]], i64 2
+; GCN-NEXT:    [[A2:%.*]] = load float, ptr addrspace(1) [[APTR2]], align 4
+; GCN-NEXT:    [[BPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[B]], i64 2
+; GCN-NEXT:    [[B2:%.*]] = load float, ptr addrspace(1) [[BPTR2]], align 4
+; GCN-NEXT:    [[TMP0:%.*]] = load <2 x float>, ptr addrspace(1) [[A]], align 4
+; GCN-NEXT:    [[TMP1:%.*]] = load <2 x float>, ptr addrspace(1) [[B]], align 4
+; GCN-NEXT:    [[TMP2:%.*]] = fadd <2 x float> [[TMP0]], [[TMP1]]
+; GCN-NEXT:    [[ADD2:%.*]] = fadd float [[A2]], [[B2]]
+; GCN-NEXT:    [[TMP3:%.*]] = extractelement <2 x float> [[TMP2]], i32 0
+; GCN-NEXT:    [[MED0:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[TMP3]], float [[TMP3]], float 1.000000e+00)
+; GCN-NEXT:    [[TMP4:%.*]] = extractelement <2 x float> [[TMP2]], i32 1
+; GCN-NEXT:    [[MED1:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[TMP4]], float [[TMP4]], float 1.000000e+00)
+; GCN-NEXT:    [[MED2:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[ADD2]], float [[ADD2]], float 1.000000e+00)
+; GCN-NEXT:    [[SUM01:%.*]] = fadd float [[MED0]], [[MED1]]
+; GCN-NEXT:    [[SUM:%.*]] = fadd float [[SUM01]], [[MED2]]
+; GCN-NEXT:    store float [[SUM]], ptr addrspace(1) [[OUTPUT]], align 4
+; GCN-NEXT:    ret void
+;
+entry:
+  %a0 = load float, ptr addrspace(1) %a, align 4
+  %aptr1 = getelementptr float, ptr addrspace(1) %a, i64 1
+  %a1 = load float, ptr addrspace(1) %aptr1, align 4
+  %aptr2 = getelementptr float, ptr addrspace(1) %a, i64 2
+  %a2 = load float, ptr addrspace(1) %aptr2, align 4
+
+  %b0 = load float, ptr addrspace(1) %b, align 4
+  %bptr1 = getelementptr float, ptr addrspace(1) %b, i64 1
+  %b1 = load float, ptr addrspace(1) %bptr1, align 4
+  %bptr2 = getelementptr float, ptr addrspace(1) %b, i64 2
+  %b2 = load float, ptr addrspace(1) %bptr2, align 4
+
+  %add0 = fadd float %a0, %b0
+  %add1 = fadd float %a1, %b1
+  %add2 = fadd float %a2, %b2
+
+  %med0 = call float @llvm.amdgcn.fmed3.f32(float %add0, float %add0, float 1.0)
+  %med1 = call float @llvm.amdgcn.fmed3.f32(float %add1, float %add1, float 1.0)
+  %med2 = call float @llvm.amdgcn.fmed3.f32(float %add2, float %add2, float 1.0)
+
+  %sum01 = fadd float %med0, %med1
+  %sum   = fadd float %sum01, %med2
+  store float %sum, ptr addrspace(1) %output, align 4
+  ret void
+}
+
+define amdgpu_kernel void @kernel_fmed3_1(ptr addrspace(1) %a, ptr addrspace(1) %b, ptr addrspace(1) %output) {
+; GCN-LABEL: define amdgpu_kernel void @kernel_fmed3_1(
+; GCN-SAME: ptr addrspace(1) [[A:%.*]], ptr addrspace(1) [[B:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
+; GCN-NEXT:  [[ENTRY:.*:]]
+; GCN-NEXT:    [[A0:%.*]] = load float, ptr addrspace(1) [[A]], align 4
+; GCN-NEXT:    [[APTR1:%.*]] = getelementptr float, ptr addrspace(1) [[A]], i64 1
+; GCN-NEXT:    [[A1:%.*]] = load float, ptr addrspace(1) [[APTR1]], align 4
+; GCN-NEXT:    [[APTR2:%.*]] = getelementptr float, ptr addrspace(1) [[A]], i64 2
+; GCN-NEXT:    [[A2:%.*]] = load float, ptr addrspace(1) [[APTR2]], align 4
+; GCN-NEXT:    [[APTR3:%.*]] = getelementptr float, ptr addrspace(1) [[A]], i64 3
+; GCN-NEXT:    [[A3:%.*]] = load float, ptr addrspace(1) [[APTR3]], align 4
+; GCN-NEXT:    [[BPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[B]], i64 2
+; GCN-NEXT:    [[TMP0:%.*]] = load <2 x float>, ptr addrspace(1) [[B]], align 4
+; GCN-NEXT:    [[TMP1:%.*]] = fadd <2 x float> splat (float 5.000000e+00), [[TMP0]]
+; GCN-NEXT:    [[TMP2:%.*]] = load <2 x float>, ptr addrspace(1) [[BPTR2]], align 4
+; GCN-NEXT:    [[TMP3:%.*]] = fadd <2 x float> splat (float 5.000000e+00), [[TMP2]]
+; GCN-NEXT:    [[TMP4:%.*]] = fadd <2 x float> splat (float 1.000000e+00), [[TMP0]]
+; GCN-NEXT:    [[TMP5:%.*]] = fadd <2 x float> splat (float 1.000000e+00), [[TMP2]]
+; GCN-NEXT:    [[TMP6:%.*]] = extractelement <2 x float> [[TMP1]], i32 0
+; GCN-NEXT:    [[TMP7:%.*]] = extractelement <2 x float> [[TMP4]], i32 0
+; GCN-NEXT:    [[MED0:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[TMP6]], float [[TMP7]], float 1.000000e+00)
+; GCN-NEXT:    [[TMP8:%.*]] = extractelement <2 x float> [[TMP1]], i32 1
+; GCN-NEXT:    [[TMP9:%.*]] = extractelement <2 x float> [[TMP4]], i32 1
+; GCN-NEXT:    [[MED1:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[TMP8]], float [[TMP9]], float 1.000000e+00)
+; GCN-NEXT:    [[TMP10:%.*]] = extractelement <2 x float> [[TMP3]], i32 0
+; GCN-NEXT:    [[TMP11:%.*]] = extractelement <2 x float> [[TMP5]], i32 0
+; GCN-NEXT:    [[MED2:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[TMP10]], float [[TMP11]], float 1.000000e+00)
+; GCN-NEXT:    [[TMP12:%.*]] = extractelement <2 x float> [[TMP3]], i32 1
+; GCN-NEXT:    [[TMP13:%.*]] = extractelement <2 x float> [[TMP5]], i32 1
+; GCN-NEXT:    [[MED3:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[TMP12]], float [[TMP13]], float 1.000000e+00)
+; GCN-NEXT:    [[SUM01:%.*]] = fadd float [[MED0]], [[MED1]]
+; GCN-NEXT:    [[SUM02:%.*]] = fadd float [[MED2]], [[MED3]]
+; GCN-NEXT:    [[SUM:%.*]] = fadd float [[SUM01]], [[SUM02]]
+; GCN-NEXT:    store float [[SUM]], ptr addrspace(1) [[OUTPUT]], align 4
+; GCN-NEXT:    ret void
+;
+entry:
+  %a0 = load float, ptr addrspace(1) %a, align 4
+  %aptr1 = getelementptr float, ptr addrspace(1) %a, i64 1
+  %a1 = load float, ptr addrspace(1) %aptr1, align 4
+  %aptr2 = getelementptr float, ptr addrspace(1) %a, i64 2
+  %a2 = load float, ptr addrspace(1) %aptr2, align 4
+  %aptr3 = getelementptr float, ptr addrspace(1) %a, i64 3
+  %a3 = load float, ptr addrspace(1) %aptr3, align 4
+
+  %b0 = load float, ptr addrspace(1) %b, align 4
+  %bptr1 = getelementptr float, ptr addrspace(1) %b, i64 1
+  %b1 = load float, ptr addrspace(1) %bptr1, align 4
+  %bptr2 = getelementptr float, ptr addrspace(1) %b, i64 2
+  %b2 = load float, ptr addrspace(1) %bptr2, align 4
+  %bptr3 = getelementptr float, ptr addrspace(1) %b, i64 3
+  %b3 = load float, ptr addrspace(1) %bptr3, align 4
+
+  %add0 = fadd float 5.0, %b0
+  %add1 = fadd float 5.0, %b1
+  %add2 = fadd float 5.0, %b2
+  %add3 = fadd float 5.0, %b3
+
+  %sub0 = fadd float 1.0, %b0
+  %sub1 = fadd float 1.0, %b1
+  %sub2 = fadd float 1.0, %b2
+  %sub3 = fadd float 1.0, %b3
+
+  %med0 = call float @llvm.amdgcn.fmed3.f32(float %add0, float %sub0, float 1.0)
+  %med1 = call float @llvm.amdgcn.fmed3.f32(float %add1, float %sub1, float 1.0)
+  %med2 = call float @llvm.amdgcn.fmed3.f32(float %add2, float %sub2, float 1.0)
+  %med3 = call float @llvm.amdgcn.fmed3.f32(float %add3, float %sub3, float 1.0)
+
+  %sum01 = fadd float %med0, %med1
+  %sum02 = fadd float %med2, %med3
+  %sum   = fadd float %sum01, %sum02
+  store float %sum, ptr addrspace(1) %output, align 4
+  ret void
+}
+
+declare float @llvm.amdgcn.fmed3.f32(float, float, float)
+declare { float, i1 } @llvm.amdgcn.div.scale.f32(float, float, i1)
 declare half @llvm.amdgcn.exp2.f16(half)
 declare float @llvm.amdgcn.exp2.f32(float)
 declare <8 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v8f32.v16i32.v16i32(i32 immarg, <16 x i32>, i32 immarg, <16 x i32>, i16 immarg, <8 x float>, i32 immarg, i32 immarg, i32, i32 immarg, i32 immarg, i32, i1 immarg, i1 immarg)

--- a/llvm/test/Transforms/SLPVectorizer/AMDGPU/notriviallyvectorizableintrinsicoperands.ll
+++ b/llvm/test/Transforms/SLPVectorizer/AMDGPU/notriviallyvectorizableintrinsicoperands.ll
@@ -5,15 +5,15 @@ define amdgpu_kernel void @test_with_wmma( ptr addrspace(1) %input, ptr addrspac
 ; GCN-LABEL: define amdgpu_kernel void @test_with_wmma(
 ; GCN-SAME: ptr addrspace(1) [[INPUT:%.*]], ptr addrspace(1) [[OUTPUT:%.*]], float [[SCALED_MAX:%.*]], <16 x i32> [[A:%.*]], <16 x i32> [[B:%.*]], i32 [[SCALE_IDX:%.*]]) #[[ATTR0:[0-9]+]] {
 ; GCN-NEXT:  [[ENTRY:.*:]]
-; GCN-NEXT:    [[IN0:%.*]] = load float, ptr addrspace(1) [[INPUT]], align 4
-; GCN-NEXT:    [[PTR1:%.*]] = getelementptr float, ptr addrspace(1) [[INPUT]], i64 1
-; GCN-NEXT:    [[IN1:%.*]] = load float, ptr addrspace(1) [[PTR1]], align 4
-; GCN-NEXT:    [[MUL0:%.*]] = fmul contract float [[IN0]], 0x3FC0527DC0000000
-; GCN-NEXT:    [[MUL1:%.*]] = fmul contract float [[IN1]], 0x3FC0527DC0000000
-; GCN-NEXT:    [[SUB0:%.*]] = fsub contract float [[MUL0]], [[SCALED_MAX]]
-; GCN-NEXT:    [[SUB1:%.*]] = fsub contract float [[MUL1]], [[SCALED_MAX]]
-; GCN-NEXT:    [[EXP0:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[SUB0]])
-; GCN-NEXT:    [[EXP1:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[SUB1]])
+; GCN-NEXT:    [[TMP0:%.*]] = load <2 x float>, ptr addrspace(1) [[INPUT]], align 4
+; GCN-NEXT:    [[TMP1:%.*]] = fmul contract <2 x float> [[TMP0]], splat (float 0x3FC0527DC0000000)
+; GCN-NEXT:    [[TMP2:%.*]] = insertelement <2 x float> poison, float [[SCALED_MAX]], i32 0
+; GCN-NEXT:    [[TMP3:%.*]] = shufflevector <2 x float> [[TMP2]], <2 x float> poison, <2 x i32> zeroinitializer
+; GCN-NEXT:    [[TMP4:%.*]] = fsub contract <2 x float> [[TMP1]], [[TMP3]]
+; GCN-NEXT:    [[TMP5:%.*]] = extractelement <2 x float> [[TMP4]], i32 0
+; GCN-NEXT:    [[EXP0:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP5]])
+; GCN-NEXT:    [[TMP6:%.*]] = extractelement <2 x float> [[TMP4]], i32 1
+; GCN-NEXT:    [[EXP1:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP6]])
 ; GCN-NEXT:    [[VEC0:%.*]] = insertelement <2 x float> poison, float [[EXP0]], i64 0
 ; GCN-NEXT:    [[VEC1:%.*]] = insertelement <2 x float> [[VEC0]], float [[EXP1]], i64 1
 ; GCN-NEXT:    [[VEC_I32:%.*]] = bitcast <2 x float> [[VEC1]] to <2 x i32>
@@ -63,19 +63,15 @@ define amdgpu_kernel void @test_amdgcn_exp_log(ptr addrspace(1) %input, ptr addr
 ; GCN-LABEL: define amdgpu_kernel void @test_amdgcn_exp_log(
 ; GCN-SAME: ptr addrspace(1) [[INPUT:%.*]], ptr addrspace(1) [[SCALES:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
 ; GCN-NEXT:  [[ENTRY:.*:]]
-; GCN-NEXT:    [[IN0:%.*]] = load float, ptr addrspace(1) [[INPUT]], align 4
-; GCN-NEXT:    [[PTR1:%.*]] = getelementptr float, ptr addrspace(1) [[INPUT]], i64 1
-; GCN-NEXT:    [[IN1:%.*]] = load float, ptr addrspace(1) [[PTR1]], align 4
-; GCN-NEXT:    [[SCALE0:%.*]] = load float, ptr addrspace(1) [[SCALES]], align 4
-; GCN-NEXT:    [[SPTR1:%.*]] = getelementptr float, ptr addrspace(1) [[SCALES]], i64 1
-; GCN-NEXT:    [[SCALE1:%.*]] = load float, ptr addrspace(1) [[SPTR1]], align 4
-; GCN-NEXT:    [[MUL0:%.*]] = fmul contract float [[IN0]], 0x3FC0527DC0000000
-; GCN-NEXT:    [[MUL1:%.*]] = fmul contract float [[IN1]], 0x3FC0527DC0000000
-; GCN-NEXT:    [[SUB0:%.*]] = fsub contract float [[MUL0]], [[SCALE0]]
-; GCN-NEXT:    [[SUB1:%.*]] = fsub contract float [[MUL1]], [[SCALE1]]
-; GCN-NEXT:    [[EXP0:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[SUB0]])
+; GCN-NEXT:    [[TMP0:%.*]] = load <2 x float>, ptr addrspace(1) [[INPUT]], align 4
+; GCN-NEXT:    [[TMP1:%.*]] = load <2 x float>, ptr addrspace(1) [[SCALES]], align 4
+; GCN-NEXT:    [[TMP2:%.*]] = fmul contract <2 x float> [[TMP0]], splat (float 0x3FC0527DC0000000)
+; GCN-NEXT:    [[TMP3:%.*]] = fsub contract <2 x float> [[TMP2]], [[TMP1]]
+; GCN-NEXT:    [[TMP4:%.*]] = extractelement <2 x float> [[TMP3]], i32 0
+; GCN-NEXT:    [[EXP0:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP4]])
 ; GCN-NEXT:    [[LOG0:%.*]] = tail call float @llvm.amdgcn.log.f32(float [[EXP0]])
-; GCN-NEXT:    [[EXP1:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[SUB1]])
+; GCN-NEXT:    [[TMP5:%.*]] = extractelement <2 x float> [[TMP3]], i32 1
+; GCN-NEXT:    [[EXP1:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP5]])
 ; GCN-NEXT:    [[LOG1:%.*]] = tail call float @llvm.amdgcn.log.f32(float [[EXP1]])
 ; GCN-NEXT:    [[SUM:%.*]] = fadd fast float [[LOG0]], [[LOG1]]
 ; GCN-NEXT:    store float [[SUM]], ptr addrspace(1) [[OUTPUT]], align 4
@@ -105,18 +101,14 @@ define amdgpu_kernel void @test_amdgcn_exp_f16(ptr addrspace(1) %input, ptr addr
 ; GCN-LABEL: define amdgpu_kernel void @test_amdgcn_exp_f16(
 ; GCN-SAME: ptr addrspace(1) [[INPUT:%.*]], ptr addrspace(1) [[SCALES:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
 ; GCN-NEXT:  [[ENTRY:.*:]]
-; GCN-NEXT:    [[IN0:%.*]] = load half, ptr addrspace(1) [[INPUT]], align 2
-; GCN-NEXT:    [[PTR1:%.*]] = getelementptr half, ptr addrspace(1) [[INPUT]], i64 1
-; GCN-NEXT:    [[IN1:%.*]] = load half, ptr addrspace(1) [[PTR1]], align 2
-; GCN-NEXT:    [[SCALE0:%.*]] = load half, ptr addrspace(1) [[SCALES]], align 2
-; GCN-NEXT:    [[SPTR1:%.*]] = getelementptr half, ptr addrspace(1) [[SCALES]], i64 1
-; GCN-NEXT:    [[SCALE1:%.*]] = load half, ptr addrspace(1) [[SPTR1]], align 2
-; GCN-NEXT:    [[MUL0:%.*]] = fmul contract half [[IN0]], 0xH3E14
-; GCN-NEXT:    [[MUL1:%.*]] = fmul contract half [[IN1]], 0xH3E14
-; GCN-NEXT:    [[SUB0:%.*]] = fsub contract half [[MUL0]], [[SCALE0]]
-; GCN-NEXT:    [[SUB1:%.*]] = fsub contract half [[MUL1]], [[SCALE1]]
-; GCN-NEXT:    [[EXP0:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[SUB0]])
-; GCN-NEXT:    [[EXP1:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[SUB1]])
+; GCN-NEXT:    [[TMP0:%.*]] = load <2 x half>, ptr addrspace(1) [[INPUT]], align 2
+; GCN-NEXT:    [[TMP1:%.*]] = load <2 x half>, ptr addrspace(1) [[SCALES]], align 2
+; GCN-NEXT:    [[TMP2:%.*]] = fmul contract <2 x half> [[TMP0]], splat (half 0xH3E14)
+; GCN-NEXT:    [[TMP3:%.*]] = fsub contract <2 x half> [[TMP2]], [[TMP1]]
+; GCN-NEXT:    [[TMP4:%.*]] = extractelement <2 x half> [[TMP3]], i32 0
+; GCN-NEXT:    [[EXP0:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[TMP4]])
+; GCN-NEXT:    [[TMP5:%.*]] = extractelement <2 x half> [[TMP3]], i32 1
+; GCN-NEXT:    [[EXP1:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[TMP5]])
 ; GCN-NEXT:    [[SUM:%.*]] = fadd fast half [[EXP0]], [[EXP1]]
 ; GCN-NEXT:    store half [[SUM]], ptr addrspace(1) [[OUTPUT]], align 2
 ; GCN-NEXT:    ret void
@@ -143,18 +135,14 @@ define amdgpu_kernel void @kernel_f16(ptr addrspace(1) %input, ptr addrspace(1) 
 ; GCN-LABEL: define amdgpu_kernel void @kernel_f16(
 ; GCN-SAME: ptr addrspace(1) [[INPUT:%.*]], ptr addrspace(1) [[SCALES:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
 ; GCN-NEXT:  [[ENTRY:.*:]]
-; GCN-NEXT:    [[IN0:%.*]] = load half, ptr addrspace(1) [[INPUT]], align 2
-; GCN-NEXT:    [[PTR1:%.*]] = getelementptr half, ptr addrspace(1) [[INPUT]], i64 1
-; GCN-NEXT:    [[IN1:%.*]] = load half, ptr addrspace(1) [[PTR1]], align 2
-; GCN-NEXT:    [[SCALE0:%.*]] = load half, ptr addrspace(1) [[SCALES]], align 2
-; GCN-NEXT:    [[SPTR1:%.*]] = getelementptr half, ptr addrspace(1) [[SCALES]], i64 1
-; GCN-NEXT:    [[SCALE1:%.*]] = load half, ptr addrspace(1) [[SPTR1]], align 2
-; GCN-NEXT:    [[MUL0:%.*]] = fmul contract half [[IN0]], 0xH3E14
-; GCN-NEXT:    [[MUL1:%.*]] = fmul contract half [[IN1]], 0xH3E14
-; GCN-NEXT:    [[SUB0:%.*]] = fsub contract half [[MUL0]], [[SCALE0]]
-; GCN-NEXT:    [[SUB1:%.*]] = fsub contract half [[MUL1]], [[SCALE1]]
-; GCN-NEXT:    [[EXP0:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[SUB0]])
-; GCN-NEXT:    [[EXP1:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[SUB1]])
+; GCN-NEXT:    [[TMP0:%.*]] = load <2 x half>, ptr addrspace(1) [[INPUT]], align 2
+; GCN-NEXT:    [[TMP1:%.*]] = load <2 x half>, ptr addrspace(1) [[SCALES]], align 2
+; GCN-NEXT:    [[TMP2:%.*]] = fmul contract <2 x half> [[TMP0]], splat (half 0xH3E14)
+; GCN-NEXT:    [[TMP3:%.*]] = fsub contract <2 x half> [[TMP2]], [[TMP1]]
+; GCN-NEXT:    [[TMP4:%.*]] = extractelement <2 x half> [[TMP3]], i32 0
+; GCN-NEXT:    [[EXP0:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[TMP4]])
+; GCN-NEXT:    [[TMP5:%.*]] = extractelement <2 x half> [[TMP3]], i32 1
+; GCN-NEXT:    [[EXP1:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[TMP5]])
 ; GCN-NEXT:    [[LOG0:%.*]] = tail call half @llvm.amdgcn.log.f16(half [[EXP0]])
 ; GCN-NEXT:    [[LOG1:%.*]] = tail call half @llvm.amdgcn.log.f16(half [[EXP1]])
 ; GCN-NEXT:    [[SUM:%.*]] = fadd fast half [[LOG0]], [[LOG1]]
@@ -185,22 +173,18 @@ define amdgpu_kernel void @look_through_reuse_shuffle(
 ; GCN-LABEL: define amdgpu_kernel void @look_through_reuse_shuffle(
 ; GCN-SAME: ptr addrspace(1) noalias [[INPUT:%.*]], ptr addrspace(1) noalias [[SCALES:%.*]], ptr addrspace(1) noalias [[OUTPUT:%.*]]) #[[ATTR0]] {
 ; GCN-NEXT:  [[ENTRY:.*:]]
-; GCN-NEXT:    [[IPTR1:%.*]] = getelementptr half, ptr addrspace(1) [[INPUT]], i64 1
-; GCN-NEXT:    [[SPTR1:%.*]] = getelementptr half, ptr addrspace(1) [[SCALES]], i64 1
-; GCN-NEXT:    [[IN0:%.*]] = load half, ptr addrspace(1) [[INPUT]], align 2
-; GCN-NEXT:    [[IN1:%.*]] = load half, ptr addrspace(1) [[IPTR1]], align 2
-; GCN-NEXT:    [[S0:%.*]] = load half, ptr addrspace(1) [[SCALES]], align 2
-; GCN-NEXT:    [[S1:%.*]] = load half, ptr addrspace(1) [[SPTR1]], align 2
-; GCN-NEXT:    [[ADD0:%.*]] = fadd contract half [[IN0]], 0xH3E14
-; GCN-NEXT:    [[ADD1:%.*]] = fadd contract half [[IN1]], 0xH3E14
-; GCN-NEXT:    [[MUL0:%.*]] = fmul contract half [[ADD0]], [[S0]]
-; GCN-NEXT:    [[MUL1:%.*]] = fmul contract half [[ADD1]], [[S1]]
-; GCN-NEXT:    [[EXP0:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[MUL0]])
-; GCN-NEXT:    [[EXP1:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[MUL1]])
-; GCN-NEXT:    [[TMP0:%.*]] = insertelement <4 x half> poison, half [[EXP0]], i32 0
-; GCN-NEXT:    [[TMP1:%.*]] = insertelement <4 x half> [[TMP0]], half [[EXP1]], i32 1
-; GCN-NEXT:    [[TMP2:%.*]] = shufflevector <4 x half> [[TMP1]], <4 x half> poison, <4 x i32> <i32 0, i32 1, i32 1, i32 1>
-; GCN-NEXT:    store <4 x half> [[TMP2]], ptr addrspace(1) [[OUTPUT]], align 2
+; GCN-NEXT:    [[TMP0:%.*]] = load <2 x half>, ptr addrspace(1) [[INPUT]], align 2
+; GCN-NEXT:    [[TMP1:%.*]] = load <2 x half>, ptr addrspace(1) [[SCALES]], align 2
+; GCN-NEXT:    [[TMP2:%.*]] = fadd contract <2 x half> [[TMP0]], splat (half 0xH3E14)
+; GCN-NEXT:    [[TMP3:%.*]] = fmul contract <2 x half> [[TMP2]], [[TMP1]]
+; GCN-NEXT:    [[TMP4:%.*]] = extractelement <2 x half> [[TMP3]], i32 0
+; GCN-NEXT:    [[EXP0:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[TMP4]])
+; GCN-NEXT:    [[TMP5:%.*]] = extractelement <2 x half> [[TMP3]], i32 1
+; GCN-NEXT:    [[EXP1:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[TMP5]])
+; GCN-NEXT:    [[TMP6:%.*]] = insertelement <4 x half> poison, half [[EXP0]], i32 0
+; GCN-NEXT:    [[TMP7:%.*]] = insertelement <4 x half> [[TMP6]], half [[EXP1]], i32 1
+; GCN-NEXT:    [[TMP8:%.*]] = shufflevector <4 x half> [[TMP7]], <4 x half> poison, <4 x i32> <i32 0, i32 1, i32 1, i32 1>
+; GCN-NEXT:    store <4 x half> [[TMP8]], ptr addrspace(1) [[OUTPUT]], align 2
 ; GCN-NEXT:    ret void
 ;
   ptr addrspace(1) noalias %input, ptr addrspace(1) noalias %scales,
@@ -237,32 +221,24 @@ define amdgpu_kernel void @wider_exp2_f32(ptr addrspace(1) %input, ptr addrspace
 ; GCN-LABEL: define amdgpu_kernel void @wider_exp2_f32(
 ; GCN-SAME: ptr addrspace(1) [[INPUT:%.*]], ptr addrspace(1) [[SCALES:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
 ; GCN-NEXT:  [[ENTRY:.*:]]
-; GCN-NEXT:    [[IN0:%.*]] = load float, ptr addrspace(1) [[INPUT]], align 4
-; GCN-NEXT:    [[PTR1:%.*]] = getelementptr float, ptr addrspace(1) [[INPUT]], i64 1
-; GCN-NEXT:    [[IN1:%.*]] = load float, ptr addrspace(1) [[PTR1]], align 4
 ; GCN-NEXT:    [[PTR2:%.*]] = getelementptr float, ptr addrspace(1) [[INPUT]], i64 2
-; GCN-NEXT:    [[IN2:%.*]] = load float, ptr addrspace(1) [[PTR2]], align 4
-; GCN-NEXT:    [[PTR3:%.*]] = getelementptr float, ptr addrspace(1) [[INPUT]], i64 3
-; GCN-NEXT:    [[IN3:%.*]] = load float, ptr addrspace(1) [[PTR3]], align 4
-; GCN-NEXT:    [[SCALE0:%.*]] = load float, ptr addrspace(1) [[SCALES]], align 4
-; GCN-NEXT:    [[SPTR1:%.*]] = getelementptr float, ptr addrspace(1) [[SCALES]], i64 1
-; GCN-NEXT:    [[SCALE1:%.*]] = load float, ptr addrspace(1) [[SPTR1]], align 4
 ; GCN-NEXT:    [[SPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[SCALES]], i64 2
-; GCN-NEXT:    [[SCALE2:%.*]] = load float, ptr addrspace(1) [[SPTR2]], align 4
-; GCN-NEXT:    [[SPTR3:%.*]] = getelementptr float, ptr addrspace(1) [[SCALES]], i64 3
-; GCN-NEXT:    [[SCALE3:%.*]] = load float, ptr addrspace(1) [[SPTR3]], align 4
-; GCN-NEXT:    [[MUL0:%.*]] = fmul contract float [[IN0]], 0x3FC0527DC0000000
-; GCN-NEXT:    [[MUL1:%.*]] = fmul contract float [[IN1]], 0x3FC0527DC0000000
-; GCN-NEXT:    [[MUL2:%.*]] = fmul contract float [[IN2]], 0x3FC0527DC0000000
-; GCN-NEXT:    [[MUL3:%.*]] = fmul contract float [[IN3]], 0x3FC0527DC0000000
-; GCN-NEXT:    [[SUB0:%.*]] = fsub contract float [[MUL0]], [[SCALE0]]
-; GCN-NEXT:    [[SUB1:%.*]] = fsub contract float [[MUL1]], [[SCALE1]]
-; GCN-NEXT:    [[SUB2:%.*]] = fsub contract float [[MUL2]], [[SCALE2]]
-; GCN-NEXT:    [[SUB3:%.*]] = fsub contract float [[MUL3]], [[SCALE3]]
-; GCN-NEXT:    [[EXP0:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[SUB0]])
-; GCN-NEXT:    [[EXP1:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[SUB1]])
-; GCN-NEXT:    [[EXP2:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[SUB2]])
-; GCN-NEXT:    [[EXP3:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[SUB3]])
+; GCN-NEXT:    [[TMP0:%.*]] = load <2 x float>, ptr addrspace(1) [[INPUT]], align 4
+; GCN-NEXT:    [[TMP1:%.*]] = load <2 x float>, ptr addrspace(1) [[SCALES]], align 4
+; GCN-NEXT:    [[TMP2:%.*]] = fmul contract <2 x float> [[TMP0]], splat (float 0x3FC0527DC0000000)
+; GCN-NEXT:    [[TMP3:%.*]] = fsub contract <2 x float> [[TMP2]], [[TMP1]]
+; GCN-NEXT:    [[TMP4:%.*]] = load <2 x float>, ptr addrspace(1) [[PTR2]], align 4
+; GCN-NEXT:    [[TMP5:%.*]] = load <2 x float>, ptr addrspace(1) [[SPTR2]], align 4
+; GCN-NEXT:    [[TMP6:%.*]] = fmul contract <2 x float> [[TMP4]], splat (float 0x3FC0527DC0000000)
+; GCN-NEXT:    [[TMP7:%.*]] = fsub contract <2 x float> [[TMP6]], [[TMP5]]
+; GCN-NEXT:    [[TMP8:%.*]] = extractelement <2 x float> [[TMP3]], i32 0
+; GCN-NEXT:    [[EXP0:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP8]])
+; GCN-NEXT:    [[TMP9:%.*]] = extractelement <2 x float> [[TMP3]], i32 1
+; GCN-NEXT:    [[EXP1:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP9]])
+; GCN-NEXT:    [[TMP10:%.*]] = extractelement <2 x float> [[TMP7]], i32 0
+; GCN-NEXT:    [[EXP2:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP10]])
+; GCN-NEXT:    [[TMP11:%.*]] = extractelement <2 x float> [[TMP7]], i32 1
+; GCN-NEXT:    [[EXP3:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP11]])
 ; GCN-NEXT:    [[SUM01:%.*]] = fadd fast float [[EXP0]], [[EXP1]]
 ; GCN-NEXT:    [[SUM23:%.*]] = fadd fast float [[EXP2]], [[EXP3]]
 ; GCN-NEXT:    [[SUM:%.*]] = fadd fast float [[SUM01]], [[SUM23]]
@@ -313,32 +289,24 @@ define amdgpu_kernel void @wider_exp2_half(ptr addrspace(1) %input, ptr addrspac
 ; GCN-LABEL: define amdgpu_kernel void @wider_exp2_half(
 ; GCN-SAME: ptr addrspace(1) [[INPUT:%.*]], ptr addrspace(1) [[SCALES:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
 ; GCN-NEXT:  [[ENTRY:.*:]]
-; GCN-NEXT:    [[IN0:%.*]] = load half, ptr addrspace(1) [[INPUT]], align 2
-; GCN-NEXT:    [[PTR1:%.*]] = getelementptr half, ptr addrspace(1) [[INPUT]], i64 1
-; GCN-NEXT:    [[IN1:%.*]] = load half, ptr addrspace(1) [[PTR1]], align 2
 ; GCN-NEXT:    [[PTR2:%.*]] = getelementptr half, ptr addrspace(1) [[INPUT]], i64 2
-; GCN-NEXT:    [[IN2:%.*]] = load half, ptr addrspace(1) [[PTR2]], align 2
-; GCN-NEXT:    [[PTR3:%.*]] = getelementptr half, ptr addrspace(1) [[INPUT]], i64 3
-; GCN-NEXT:    [[IN3:%.*]] = load half, ptr addrspace(1) [[PTR3]], align 2
-; GCN-NEXT:    [[SCALE0:%.*]] = load half, ptr addrspace(1) [[SCALES]], align 2
-; GCN-NEXT:    [[SPTR1:%.*]] = getelementptr half, ptr addrspace(1) [[SCALES]], i64 1
-; GCN-NEXT:    [[SCALE1:%.*]] = load half, ptr addrspace(1) [[SPTR1]], align 2
 ; GCN-NEXT:    [[SPTR2:%.*]] = getelementptr half, ptr addrspace(1) [[SCALES]], i64 2
-; GCN-NEXT:    [[SCALE2:%.*]] = load half, ptr addrspace(1) [[SPTR2]], align 2
-; GCN-NEXT:    [[SPTR3:%.*]] = getelementptr half, ptr addrspace(1) [[SCALES]], i64 3
-; GCN-NEXT:    [[SCALE3:%.*]] = load half, ptr addrspace(1) [[SPTR3]], align 2
-; GCN-NEXT:    [[MUL0:%.*]] = fmul contract half [[IN0]], 0xH3E14
-; GCN-NEXT:    [[MUL1:%.*]] = fmul contract half [[IN1]], 0xH3E14
-; GCN-NEXT:    [[MUL2:%.*]] = fmul contract half [[IN2]], 0xH3E14
-; GCN-NEXT:    [[MUL3:%.*]] = fmul contract half [[IN3]], 0xH3E14
-; GCN-NEXT:    [[SUB0:%.*]] = fsub contract half [[MUL0]], [[SCALE0]]
-; GCN-NEXT:    [[SUB1:%.*]] = fsub contract half [[MUL1]], [[SCALE1]]
-; GCN-NEXT:    [[SUB2:%.*]] = fsub contract half [[MUL2]], [[SCALE2]]
-; GCN-NEXT:    [[SUB3:%.*]] = fsub contract half [[MUL3]], [[SCALE3]]
-; GCN-NEXT:    [[EXP0:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[SUB0]])
-; GCN-NEXT:    [[EXP1:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[SUB1]])
-; GCN-NEXT:    [[EXP2:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[SUB2]])
-; GCN-NEXT:    [[EXP3:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[SUB3]])
+; GCN-NEXT:    [[TMP0:%.*]] = load <2 x half>, ptr addrspace(1) [[INPUT]], align 2
+; GCN-NEXT:    [[TMP1:%.*]] = load <2 x half>, ptr addrspace(1) [[SCALES]], align 2
+; GCN-NEXT:    [[TMP2:%.*]] = fmul contract <2 x half> [[TMP0]], splat (half 0xH3E14)
+; GCN-NEXT:    [[TMP3:%.*]] = fsub contract <2 x half> [[TMP2]], [[TMP1]]
+; GCN-NEXT:    [[TMP4:%.*]] = load <2 x half>, ptr addrspace(1) [[PTR2]], align 2
+; GCN-NEXT:    [[TMP5:%.*]] = load <2 x half>, ptr addrspace(1) [[SPTR2]], align 2
+; GCN-NEXT:    [[TMP6:%.*]] = fmul contract <2 x half> [[TMP4]], splat (half 0xH3E14)
+; GCN-NEXT:    [[TMP7:%.*]] = fsub contract <2 x half> [[TMP6]], [[TMP5]]
+; GCN-NEXT:    [[TMP8:%.*]] = extractelement <2 x half> [[TMP3]], i32 0
+; GCN-NEXT:    [[EXP0:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[TMP8]])
+; GCN-NEXT:    [[TMP9:%.*]] = extractelement <2 x half> [[TMP3]], i32 1
+; GCN-NEXT:    [[EXP1:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[TMP9]])
+; GCN-NEXT:    [[TMP10:%.*]] = extractelement <2 x half> [[TMP7]], i32 0
+; GCN-NEXT:    [[EXP2:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[TMP10]])
+; GCN-NEXT:    [[TMP11:%.*]] = extractelement <2 x half> [[TMP7]], i32 1
+; GCN-NEXT:    [[EXP3:%.*]] = tail call half @llvm.amdgcn.exp2.f16(half [[TMP11]])
 ; GCN-NEXT:    [[SUM01:%.*]] = fadd fast half [[EXP0]], [[EXP1]]
 ; GCN-NEXT:    [[SUM23:%.*]] = fadd fast half [[EXP2]], [[EXP3]]
 ; GCN-NEXT:    [[SUM:%.*]] = fadd fast half [[SUM01]], [[SUM23]]
@@ -387,383 +355,6 @@ entry:
   ret void
 }
 
-define amdgpu_kernel void @kernel_div_scale(ptr addrspace(1) %num, ptr addrspace(1) %den, ptr addrspace(1) %output) {
-; GCN-LABEL: define amdgpu_kernel void @kernel_div_scale(
-; GCN-SAME: ptr addrspace(1) [[NUM:%.*]], ptr addrspace(1) [[DEN:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
-; GCN-NEXT:  [[ENTRY:.*:]]
-; GCN-NEXT:    [[N0:%.*]] = load float, ptr addrspace(1) [[NUM]], align 4
-; GCN-NEXT:    [[NPTR1:%.*]] = getelementptr float, ptr addrspace(1) [[NUM]], i64 1
-; GCN-NEXT:    [[N1:%.*]] = load float, ptr addrspace(1) [[NPTR1]], align 4
-; GCN-NEXT:    [[NPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[NUM]], i64 2
-; GCN-NEXT:    [[N2:%.*]] = load float, ptr addrspace(1) [[NPTR2]], align 4
-; GCN-NEXT:    [[D0:%.*]] = load float, ptr addrspace(1) [[DEN]], align 4
-; GCN-NEXT:    [[DPTR1:%.*]] = getelementptr float, ptr addrspace(1) [[DEN]], i64 1
-; GCN-NEXT:    [[D1:%.*]] = load float, ptr addrspace(1) [[DPTR1]], align 4
-; GCN-NEXT:    [[DPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[DEN]], i64 2
-; GCN-NEXT:    [[D2:%.*]] = load float, ptr addrspace(1) [[DPTR2]], align 4
-; GCN-NEXT:    [[MUL_N0:%.*]] = fmul float [[N0]], 2.000000e+00
-; GCN-NEXT:    [[MUL_N1:%.*]] = fmul float [[N1]], 2.000000e+00
-; GCN-NEXT:    [[MUL_N2:%.*]] = fmul float [[N2]], 2.000000e+00
-; GCN-NEXT:    [[MUL_D0:%.*]] = fmul float [[D0]], 4.000000e+00
-; GCN-NEXT:    [[MUL_D1:%.*]] = fmul float [[D1]], 4.000000e+00
-; GCN-NEXT:    [[MUL_D2:%.*]] = fmul float [[D2]], 4.000000e+00
-; GCN-NEXT:    [[DS0:%.*]] = call { float, i1 } @llvm.amdgcn.div.scale.f32(float [[MUL_N0]], float [[MUL_D0]], i1 false)
-; GCN-NEXT:    [[DS1:%.*]] = call { float, i1 } @llvm.amdgcn.div.scale.f32(float [[MUL_N1]], float [[MUL_D1]], i1 false)
-; GCN-NEXT:    [[DS2:%.*]] = call { float, i1 } @llvm.amdgcn.div.scale.f32(float [[MUL_N2]], float [[MUL_D2]], i1 false)
-; GCN-NEXT:    [[R0:%.*]] = extractvalue { float, i1 } [[DS0]], 0
-; GCN-NEXT:    [[R1:%.*]] = extractvalue { float, i1 } [[DS1]], 0
-; GCN-NEXT:    [[R2:%.*]] = extractvalue { float, i1 } [[DS2]], 0
-; GCN-NEXT:    [[SUM01:%.*]] = fadd float [[R0]], [[R1]]
-; GCN-NEXT:    [[SUM:%.*]] = fadd float [[SUM01]], [[R2]]
-; GCN-NEXT:    store float [[SUM]], ptr addrspace(1) [[OUTPUT]], align 4
-; GCN-NEXT:    ret void
-;
-entry:
-  %n0 = load float, ptr addrspace(1) %num, align 4
-  %nptr1 = getelementptr float, ptr addrspace(1) %num, i64 1
-  %n1 = load float, ptr addrspace(1) %nptr1, align 4
-  %nptr2 = getelementptr float, ptr addrspace(1) %num, i64 2
-  %n2 = load float, ptr addrspace(1) %nptr2, align 4
-  %d0 = load float, ptr addrspace(1) %den, align 4
-  %dptr1 = getelementptr float, ptr addrspace(1) %den, i64 1
-  %d1 = load float, ptr addrspace(1) %dptr1, align 4
-  %dptr2 = getelementptr float, ptr addrspace(1) %den, i64 2
-  %d2 = load float, ptr addrspace(1) %dptr2, align 4
-  %mul_n0 = fmul float %n0, 2.0
-  %mul_n1 = fmul float %n1, 2.0
-  %mul_n2 = fmul float %n2, 2.0
-  %mul_d0 = fmul float %d0, 4.0
-  %mul_d1 = fmul float %d1, 4.0
-  %mul_d2 = fmul float %d2, 4.0
-  %ds0 = call { float, i1 } @llvm.amdgcn.div.scale.f32(float %mul_n0, float %mul_d0, i1 false)
-  %ds1 = call { float, i1 } @llvm.amdgcn.div.scale.f32(float %mul_n1, float %mul_d1, i1 false)
-  %ds2 = call { float, i1 } @llvm.amdgcn.div.scale.f32(float %mul_n2, float %mul_d2, i1 false)
-  %r0 = extractvalue { float, i1 } %ds0, 0
-  %r1 = extractvalue { float, i1 } %ds1, 0
-  %r2 = extractvalue { float, i1 } %ds2, 0
-  %sum01 = fadd float %r0, %r1
-  %sum   = fadd float %sum01, %r2
-  store float %sum, ptr addrspace(1) %output, align 4
-  ret void
-}
-
-define amdgpu_kernel void @kernel_fmed3(ptr addrspace(1) %a, ptr addrspace(1) %b, ptr addrspace(1) %output) {
-; GCN-LABEL: define amdgpu_kernel void @kernel_fmed3(
-; GCN-SAME: ptr addrspace(1) [[A:%.*]], ptr addrspace(1) [[B:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
-; GCN-NEXT:  [[ENTRY:.*:]]
-; GCN-NEXT:    [[A0:%.*]] = load float, ptr addrspace(1) [[A]], align 4
-; GCN-NEXT:    [[APTR1:%.*]] = getelementptr float, ptr addrspace(1) [[A]], i64 1
-; GCN-NEXT:    [[A1:%.*]] = load float, ptr addrspace(1) [[APTR1]], align 4
-; GCN-NEXT:    [[APTR2:%.*]] = getelementptr float, ptr addrspace(1) [[A]], i64 2
-; GCN-NEXT:    [[A2:%.*]] = load float, ptr addrspace(1) [[APTR2]], align 4
-; GCN-NEXT:    [[B0:%.*]] = load float, ptr addrspace(1) [[B]], align 4
-; GCN-NEXT:    [[BPTR1:%.*]] = getelementptr float, ptr addrspace(1) [[B]], i64 1
-; GCN-NEXT:    [[B1:%.*]] = load float, ptr addrspace(1) [[BPTR1]], align 4
-; GCN-NEXT:    [[BPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[B]], i64 2
-; GCN-NEXT:    [[B2:%.*]] = load float, ptr addrspace(1) [[BPTR2]], align 4
-; GCN-NEXT:    [[ADD0:%.*]] = fadd float [[A0]], [[B0]]
-; GCN-NEXT:    [[ADD1:%.*]] = fadd float [[A1]], [[B1]]
-; GCN-NEXT:    [[ADD2:%.*]] = fadd float [[A2]], [[B2]]
-; GCN-NEXT:    [[MED0:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[ADD0]], float [[ADD0]], float 1.000000e+00)
-; GCN-NEXT:    [[MED1:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[ADD1]], float [[ADD1]], float 1.000000e+00)
-; GCN-NEXT:    [[MED2:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[ADD2]], float [[ADD2]], float 1.000000e+00)
-; GCN-NEXT:    [[SUM01:%.*]] = fadd float [[MED0]], [[MED1]]
-; GCN-NEXT:    [[SUM:%.*]] = fadd float [[SUM01]], [[MED2]]
-; GCN-NEXT:    store float [[SUM]], ptr addrspace(1) [[OUTPUT]], align 4
-; GCN-NEXT:    ret void
-;
-entry:
-  %a0 = load float, ptr addrspace(1) %a, align 4
-  %aptr1 = getelementptr float, ptr addrspace(1) %a, i64 1
-  %a1 = load float, ptr addrspace(1) %aptr1, align 4
-  %aptr2 = getelementptr float, ptr addrspace(1) %a, i64 2
-  %a2 = load float, ptr addrspace(1) %aptr2, align 4
-
-  %b0 = load float, ptr addrspace(1) %b, align 4
-  %bptr1 = getelementptr float, ptr addrspace(1) %b, i64 1
-  %b1 = load float, ptr addrspace(1) %bptr1, align 4
-  %bptr2 = getelementptr float, ptr addrspace(1) %b, i64 2
-  %b2 = load float, ptr addrspace(1) %bptr2, align 4
-
-  %add0 = fadd float %a0, %b0
-  %add1 = fadd float %a1, %b1
-  %add2 = fadd float %a2, %b2
-
-  %med0 = call float @llvm.amdgcn.fmed3.f32(float %add0, float %add0, float 1.0)
-  %med1 = call float @llvm.amdgcn.fmed3.f32(float %add1, float %add1, float 1.0)
-  %med2 = call float @llvm.amdgcn.fmed3.f32(float %add2, float %add2, float 1.0)
-
-  %sum01 = fadd float %med0, %med1
-  %sum   = fadd float %sum01, %med2
-  store float %sum, ptr addrspace(1) %output, align 4
-  ret void
-}
-
-define amdgpu_kernel void @kernel_fmed3_1(ptr addrspace(1) %a, ptr addrspace(1) %b, ptr addrspace(1) %output) {
-; GCN-LABEL: define amdgpu_kernel void @kernel_fmed3_1(
-; GCN-SAME: ptr addrspace(1) [[A:%.*]], ptr addrspace(1) [[B:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
-; GCN-NEXT:  [[ENTRY:.*:]]
-; GCN-NEXT:    [[A0:%.*]] = load float, ptr addrspace(1) [[A]], align 4
-; GCN-NEXT:    [[APTR1:%.*]] = getelementptr float, ptr addrspace(1) [[A]], i64 1
-; GCN-NEXT:    [[A1:%.*]] = load float, ptr addrspace(1) [[APTR1]], align 4
-; GCN-NEXT:    [[APTR2:%.*]] = getelementptr float, ptr addrspace(1) [[A]], i64 2
-; GCN-NEXT:    [[A2:%.*]] = load float, ptr addrspace(1) [[APTR2]], align 4
-; GCN-NEXT:    [[APTR3:%.*]] = getelementptr float, ptr addrspace(1) [[A]], i64 3
-; GCN-NEXT:    [[A3:%.*]] = load float, ptr addrspace(1) [[APTR3]], align 4
-; GCN-NEXT:    [[B0:%.*]] = load float, ptr addrspace(1) [[B]], align 4
-; GCN-NEXT:    [[BPTR1:%.*]] = getelementptr float, ptr addrspace(1) [[B]], i64 1
-; GCN-NEXT:    [[B1:%.*]] = load float, ptr addrspace(1) [[BPTR1]], align 4
-; GCN-NEXT:    [[BPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[B]], i64 2
-; GCN-NEXT:    [[B2:%.*]] = load float, ptr addrspace(1) [[BPTR2]], align 4
-; GCN-NEXT:    [[BPTR3:%.*]] = getelementptr float, ptr addrspace(1) [[B]], i64 3
-; GCN-NEXT:    [[B3:%.*]] = load float, ptr addrspace(1) [[BPTR3]], align 4
-; GCN-NEXT:    [[ADD0:%.*]] = fadd float 5.000000e+00, [[B0]]
-; GCN-NEXT:    [[ADD1:%.*]] = fadd float 5.000000e+00, [[B1]]
-; GCN-NEXT:    [[ADD2:%.*]] = fadd float 5.000000e+00, [[B2]]
-; GCN-NEXT:    [[ADD3:%.*]] = fadd float 5.000000e+00, [[B3]]
-; GCN-NEXT:    [[SUB0:%.*]] = fadd float 1.000000e+00, [[B0]]
-; GCN-NEXT:    [[SUB1:%.*]] = fadd float 1.000000e+00, [[B1]]
-; GCN-NEXT:    [[SUB2:%.*]] = fadd float 1.000000e+00, [[B2]]
-; GCN-NEXT:    [[SUB3:%.*]] = fadd float 1.000000e+00, [[B3]]
-; GCN-NEXT:    [[MED0:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[ADD0]], float [[SUB0]], float 1.000000e+00)
-; GCN-NEXT:    [[MED1:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[ADD1]], float [[SUB1]], float 1.000000e+00)
-; GCN-NEXT:    [[MED2:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[ADD2]], float [[SUB2]], float 1.000000e+00)
-; GCN-NEXT:    [[MED3:%.*]] = call float @llvm.amdgcn.fmed3.f32(float [[ADD3]], float [[SUB3]], float 1.000000e+00)
-; GCN-NEXT:    [[SUM01:%.*]] = fadd float [[MED0]], [[MED1]]
-; GCN-NEXT:    [[SUM02:%.*]] = fadd float [[MED2]], [[MED3]]
-; GCN-NEXT:    [[SUM:%.*]] = fadd float [[SUM01]], [[SUM02]]
-; GCN-NEXT:    store float [[SUM]], ptr addrspace(1) [[OUTPUT]], align 4
-; GCN-NEXT:    ret void
-;
-entry:
-  %a0 = load float, ptr addrspace(1) %a, align 4
-  %aptr1 = getelementptr float, ptr addrspace(1) %a, i64 1
-  %a1 = load float, ptr addrspace(1) %aptr1, align 4
-  %aptr2 = getelementptr float, ptr addrspace(1) %a, i64 2
-  %a2 = load float, ptr addrspace(1) %aptr2, align 4
-  %aptr3 = getelementptr float, ptr addrspace(1) %a, i64 3
-  %a3 = load float, ptr addrspace(1) %aptr3, align 4
-
-  %b0 = load float, ptr addrspace(1) %b, align 4
-  %bptr1 = getelementptr float, ptr addrspace(1) %b, i64 1
-  %b1 = load float, ptr addrspace(1) %bptr1, align 4
-  %bptr2 = getelementptr float, ptr addrspace(1) %b, i64 2
-  %b2 = load float, ptr addrspace(1) %bptr2, align 4
-  %bptr3 = getelementptr float, ptr addrspace(1) %b, i64 3
-  %b3 = load float, ptr addrspace(1) %bptr3, align 4
-
-  %add0 = fadd float 5.0, %b0
-  %add1 = fadd float 5.0, %b1
-  %add2 = fadd float 5.0, %b2
-  %add3 = fadd float 5.0, %b3
-
-  %sub0 = fadd float 1.0, %b0
-  %sub1 = fadd float 1.0, %b1
-  %sub2 = fadd float 1.0, %b2
-  %sub3 = fadd float 1.0, %b3
-
-  %med0 = call float @llvm.amdgcn.fmed3.f32(float %add0, float %sub0, float 1.0)
-  %med1 = call float @llvm.amdgcn.fmed3.f32(float %add1, float %sub1, float 1.0)
-  %med2 = call float @llvm.amdgcn.fmed3.f32(float %add2, float %sub2, float 1.0)
-  %med3 = call float @llvm.amdgcn.fmed3.f32(float %add3, float %sub3, float 1.0)
-
-  %sum01 = fadd float %med0, %med1
-  %sum02 = fadd float %med2, %med3
-  %sum   = fadd float %sum01, %sum02
-  store float %sum, ptr addrspace(1) %output, align 4
-  ret void
-}
-
-define amdgpu_kernel void @test_single_exp_hreduction(
-; GCN-LABEL: define amdgpu_kernel void @test_single_exp_hreduction(
-; GCN-SAME: ptr addrspace(1) [[INPUT:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
-; GCN-NEXT:  [[ENTRY:.*:]]
-; GCN-NEXT:    [[P0:%.*]] = getelementptr float, ptr addrspace(1) [[INPUT]], i64 0
-; GCN-NEXT:    [[TMP0:%.*]] = load <4 x float>, ptr addrspace(1) [[P0]], align 4
-; GCN-NEXT:    [[TMP1:%.*]] = call fast float @llvm.vector.reduce.fadd.v4f32(float 0.000000e+00, <4 x float> [[TMP0]])
-; GCN-NEXT:    [[EXP0:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP1]])
-; GCN-NEXT:    store float [[EXP0]], ptr addrspace(1) [[OUTPUT]], align 4
-; GCN-NEXT:    ret void
-;
-  ptr addrspace(1) %input, ptr addrspace(1) %output) {
-entry:
-  %p0 = getelementptr float, ptr addrspace(1) %input, i64 0
-  %p1 = getelementptr float, ptr addrspace(1) %input, i64 1
-  %p2 = getelementptr float, ptr addrspace(1) %input, i64 2
-  %p3 = getelementptr float, ptr addrspace(1) %input, i64 3
-
-  %a0 = load float, ptr addrspace(1) %p0, align 4
-  %a1 = load float, ptr addrspace(1) %p1, align 4
-  %a2 = load float, ptr addrspace(1) %p2, align 4
-  %a3 = load float, ptr addrspace(1) %p3, align 4
-
-  %add01 = fadd fast float %a0, %a1
-  %add23 = fadd fast float %a2, %a3
-  %sum   = fadd fast float %add01, %add23
-
-  %exp0 = tail call float @llvm.amdgcn.exp2.f32(float %sum)
-  store float %exp0, ptr addrspace(1) %output, align 4
-  ret void
-}
-
-define amdgpu_kernel void @test_hreduction_into_exp(
-; GCN-LABEL: define amdgpu_kernel void @test_hreduction_into_exp(
-; GCN-SAME: ptr addrspace(1) [[INPUT:%.*]], ptr addrspace(1) [[OUTPUT:%.*]], <16 x i32> [[A:%.*]], <16 x i32> [[B:%.*]], i32 [[SCALE_IDX:%.*]]) #[[ATTR0]] {
-; GCN-NEXT:  [[ENTRY:.*:]]
-; GCN-NEXT:    [[P0:%.*]] = getelementptr float, ptr addrspace(1) [[INPUT]], i64 0
-; GCN-NEXT:    [[P4:%.*]] = getelementptr float, ptr addrspace(1) [[INPUT]], i64 4
-; GCN-NEXT:    [[TMP0:%.*]] = load <4 x float>, ptr addrspace(1) [[P0]], align 4
-; GCN-NEXT:    [[TMP1:%.*]] = load <4 x float>, ptr addrspace(1) [[P4]], align 4
-; GCN-NEXT:    [[TMP2:%.*]] = call fast float @llvm.vector.reduce.fadd.v4f32(float 0.000000e+00, <4 x float> [[TMP0]])
-; GCN-NEXT:    [[TMP3:%.*]] = call fast float @llvm.vector.reduce.fadd.v4f32(float 0.000000e+00, <4 x float> [[TMP1]])
-; GCN-NEXT:    [[EXP0:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP2]])
-; GCN-NEXT:    [[EXP1:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP3]])
-; GCN-NEXT:    [[VEC0:%.*]] = insertelement <2 x float> poison, float [[EXP0]], i64 0
-; GCN-NEXT:    [[VEC1:%.*]] = insertelement <2 x float> [[VEC0]], float [[EXP1]], i64 1
-; GCN-NEXT:    [[VEC_I32:%.*]] = bitcast <2 x float> [[VEC1]] to <2 x i32>
-; GCN-NEXT:    [[SCALE0:%.*]] = extractelement <2 x i32> [[VEC_I32]], i64 0
-; GCN-NEXT:    [[SCALE1:%.*]] = extractelement <2 x i32> [[VEC_I32]], i64 1
-; GCN-NEXT:    [[WMMA0:%.*]] = tail call <8 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v8f32.v16i32.v16i32(i32 0, <16 x i32> [[A]], i32 0, <16 x i32> [[B]], i16 0, <8 x float> zeroinitializer, i32 0, i32 0, i32 [[SCALE0]], i32 0, i32 0, i32 [[SCALE_IDX]], i1 false, i1 false)
-; GCN-NEXT:    [[WMMA1:%.*]] = tail call <8 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v8f32.v16i32.v16i32(i32 0, <16 x i32> [[A]], i32 0, <16 x i32> [[B]], i16 0, <8 x float> [[WMMA0]], i32 0, i32 0, i32 [[SCALE1]], i32 0, i32 0, i32 [[SCALE_IDX]], i1 false, i1 false)
-; GCN-NEXT:    store <8 x float> [[WMMA1]], ptr addrspace(1) [[OUTPUT]], align 32
-; GCN-NEXT:    ret void
-;
-  ptr addrspace(1) %input, ptr addrspace(1) %output,
-  <16 x i32> %A, <16 x i32> %B, i32 %scale_idx) {
-entry:
-  %p0 = getelementptr float, ptr addrspace(1) %input, i64 0
-  %p1 = getelementptr float, ptr addrspace(1) %input, i64 1
-  %p2 = getelementptr float, ptr addrspace(1) %input, i64 2
-  %p3 = getelementptr float, ptr addrspace(1) %input, i64 3
-  %p4 = getelementptr float, ptr addrspace(1) %input, i64 4
-  %p5 = getelementptr float, ptr addrspace(1) %input, i64 5
-  %p6 = getelementptr float, ptr addrspace(1) %input, i64 6
-  %p7 = getelementptr float, ptr addrspace(1) %input, i64 7
-
-  %a0 = load float, ptr addrspace(1) %p0, align 4
-  %a1 = load float, ptr addrspace(1) %p1, align 4
-  %a2 = load float, ptr addrspace(1) %p2, align 4
-  %a3 = load float, ptr addrspace(1) %p3, align 4
-  %b0 = load float, ptr addrspace(1) %p4, align 4
-  %b1 = load float, ptr addrspace(1) %p5, align 4
-  %b2 = load float, ptr addrspace(1) %p6, align 4
-  %b3 = load float, ptr addrspace(1) %p7, align 4
-
-  %add_a01 = fadd fast float %a0, %a1
-  %add_a23 = fadd fast float %a2, %a3
-  %sum0    = fadd fast float %add_a01, %add_a23
-
-  %add_b01 = fadd fast float %b0, %b1
-  %add_b23 = fadd fast float %b2, %b3
-  %sum1    = fadd fast float %add_b01, %add_b23
-
-
-  %exp0 = tail call float @llvm.amdgcn.exp2.f32(float %sum0)
-  %exp1 = tail call float @llvm.amdgcn.exp2.f32(float %sum1)
-
-  %vec0    = insertelement <2 x float> poison, float %exp0, i64 0
-  %vec1    = insertelement <2 x float> %vec0,  float %exp1, i64 1
-  %vec_i32 = bitcast <2 x float> %vec1 to <2 x i32>
-  %scale0  = extractelement <2 x i32> %vec_i32, i64 0
-  %scale1  = extractelement <2 x i32> %vec_i32, i64 1
-
-  %wmma0 = tail call <8 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v8f32.v16i32.v16i32(
-  i32 0, <16 x i32> %A, i32 0, <16 x i32> %B, i16 0, <8 x float> zeroinitializer,
-  i32 0, i32 0, i32 %scale0, i32 0, i32 0, i32 %scale_idx, i1 false, i1 false)
-
-  %wmma1 = tail call <8 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v8f32.v16i32.v16i32(
-  i32 0, <16 x i32> %A, i32 0, <16 x i32> %B, i16 0, <8 x float> %wmma0,
-  i32 0, i32 0, i32 %scale1, i32 0, i32 0, i32 %scale_idx, i1 false, i1 false)
-
-  store <8 x float> %wmma1, ptr addrspace(1) %output, align 32
-  ret void
-}
-
-define amdgpu_kernel void @kernel_alternate(ptr addrspace(1) %a, ptr addrspace(1) %b, ptr addrspace(1) %output) {
-; GCN-LABEL: define amdgpu_kernel void @kernel_alternate(
-; GCN-SAME: ptr addrspace(1) [[A:%.*]], ptr addrspace(1) [[B:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
-; GCN-NEXT:  [[ENTRY:.*:]]
-; GCN-NEXT:    [[A0:%.*]] = load float, ptr addrspace(1) [[A]], align 4
-; GCN-NEXT:    [[APTR1:%.*]] = getelementptr float, ptr addrspace(1) [[A]], i64 1
-; GCN-NEXT:    [[A1:%.*]] = load float, ptr addrspace(1) [[APTR1]], align 4
-; GCN-NEXT:    [[APTR2:%.*]] = getelementptr float, ptr addrspace(1) [[A]], i64 2
-; GCN-NEXT:    [[A2:%.*]] = load float, ptr addrspace(1) [[APTR2]], align 4
-; GCN-NEXT:    [[B0:%.*]] = load float, ptr addrspace(1) [[B]], align 4
-; GCN-NEXT:    [[BPTR1:%.*]] = getelementptr float, ptr addrspace(1) [[B]], i64 1
-; GCN-NEXT:    [[B1:%.*]] = load float, ptr addrspace(1) [[BPTR1]], align 4
-; GCN-NEXT:    [[BPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[B]], i64 2
-; GCN-NEXT:    [[B2:%.*]] = load float, ptr addrspace(1) [[BPTR2]], align 4
-; GCN-NEXT:    [[ADD0:%.*]] = fadd float [[A0]], [[B0]]
-; GCN-NEXT:    [[SUB0:%.*]] = fsub float [[A0]], [[B0]]
-; GCN-NEXT:    [[ADD1:%.*]] = fadd float [[A1]], [[B1]]
-; GCN-NEXT:    [[SUB1:%.*]] = fsub float [[A1]], [[B1]]
-; GCN-NEXT:    [[ADD2:%.*]] = fadd float [[A2]], [[B2]]
-; GCN-NEXT:    [[SUB2:%.*]] = fsub float [[A2]], [[B2]]
-; GCN-NEXT:    [[E0:%.*]] = call float @llvm.amdgcn.exp2.f32(float [[ADD0]])
-; GCN-NEXT:    [[E1:%.*]] = call float @llvm.amdgcn.exp2.f32(float [[SUB0]])
-; GCN-NEXT:    [[E2:%.*]] = call float @llvm.amdgcn.log.f32(float [[ADD1]])
-; GCN-NEXT:    [[E3:%.*]] = call float @llvm.amdgcn.log.f32(float [[SUB1]])
-; GCN-NEXT:    [[E4:%.*]] = call float @llvm.amdgcn.exp2.f32(float [[ADD2]])
-; GCN-NEXT:    [[E5:%.*]] = call float @llvm.amdgcn.exp2.f32(float [[SUB2]])
-; GCN-NEXT:    [[OPTR0:%.*]] = getelementptr float, ptr addrspace(1) [[OUTPUT]], i64 0
-; GCN-NEXT:    [[OPTR1:%.*]] = getelementptr float, ptr addrspace(1) [[OUTPUT]], i64 1
-; GCN-NEXT:    [[OPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[OUTPUT]], i64 2
-; GCN-NEXT:    [[OPTR3:%.*]] = getelementptr float, ptr addrspace(1) [[OUTPUT]], i64 3
-; GCN-NEXT:    [[OPTR4:%.*]] = getelementptr float, ptr addrspace(1) [[OUTPUT]], i64 4
-; GCN-NEXT:    [[OPTR5:%.*]] = getelementptr float, ptr addrspace(1) [[OUTPUT]], i64 5
-; GCN-NEXT:    store float [[E0]], ptr addrspace(1) [[OPTR0]], align 4
-; GCN-NEXT:    store float [[E1]], ptr addrspace(1) [[OPTR1]], align 4
-; GCN-NEXT:    store float [[E2]], ptr addrspace(1) [[OPTR2]], align 4
-; GCN-NEXT:    store float [[E3]], ptr addrspace(1) [[OPTR3]], align 4
-; GCN-NEXT:    store float [[E4]], ptr addrspace(1) [[OPTR4]], align 4
-; GCN-NEXT:    store float [[E5]], ptr addrspace(1) [[OPTR5]], align 4
-; GCN-NEXT:    ret void
-;
-entry:
-  %a0    = load float, ptr addrspace(1) %a, align 4
-  %aptr1 = getelementptr float, ptr addrspace(1) %a, i64 1
-  %a1    = load float, ptr addrspace(1) %aptr1, align 4
-  %aptr2 = getelementptr float, ptr addrspace(1) %a, i64 2
-  %a2    = load float, ptr addrspace(1) %aptr2, align 4
-
-  %b0    = load float, ptr addrspace(1) %b, align 4
-  %bptr1 = getelementptr float, ptr addrspace(1) %b, i64 1
-  %b1    = load float, ptr addrspace(1) %bptr1, align 4
-  %bptr2 = getelementptr float, ptr addrspace(1) %b, i64 2
-  %b2    = load float, ptr addrspace(1) %bptr2, align 4
-
-  %add0 = fadd float %a0, %b0
-  %sub0 = fsub float %a0, %b0
-  %add1 = fadd float %a1, %b1
-  %sub1 = fsub float %a1, %b1
-  %add2 = fadd float %a2, %b2
-  %sub2 = fsub float %a2, %b2
-
-  %e0 = call float @llvm.amdgcn.exp2.f32(float %add0)
-  %e1 = call float @llvm.amdgcn.exp2.f32(float %sub0)
-  %e2 = call float @llvm.amdgcn.log.f32(float %add1)
-  %e3 = call float @llvm.amdgcn.log.f32(float %sub1)
-  %e4 = call float @llvm.amdgcn.exp2.f32(float %add2)
-  %e5 = call float @llvm.amdgcn.exp2.f32(float %sub2)
-
-  %optr0 = getelementptr float, ptr addrspace(1) %output, i64 0
-  %optr1 = getelementptr float, ptr addrspace(1) %output, i64 1
-  %optr2 = getelementptr float, ptr addrspace(1) %output, i64 2
-  %optr3 = getelementptr float, ptr addrspace(1) %output, i64 3
-  %optr4 = getelementptr float, ptr addrspace(1) %output, i64 4
-  %optr5 = getelementptr float, ptr addrspace(1) %output, i64 5
-
-  store float %e0, ptr addrspace(1) %optr0, align 4
-  store float %e1, ptr addrspace(1) %optr1, align 4
-  store float %e2, ptr addrspace(1) %optr2, align 4
-  store float %e3, ptr addrspace(1) %optr3, align 4
-  store float %e4, ptr addrspace(1) %optr4, align 4
-  store float %e5, ptr addrspace(1) %optr5, align 4
-  ret void
-}
-
-declare float @llvm.amdgcn.fmed3.f32(float, float, float)
-declare { float, i1 } @llvm.amdgcn.div.scale.f32(float, float, i1)
 declare half @llvm.amdgcn.exp2.f16(half)
 declare float @llvm.amdgcn.exp2.f32(float)
 declare <8 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v8f32.v16i32.v16i32(i32 immarg, <16 x i32>, i32 immarg, <16 x i32>, i16 immarg, <8 x float>, i32 immarg, i32 immarg, i32, i32 immarg, i32 immarg, i32, i1 immarg, i1 immarg)

--- a/llvm/test/Transforms/SLPVectorizer/AMDGPU/notriviallyvectorizableintrinsicoperands.ll
+++ b/llvm/test/Transforms/SLPVectorizer/AMDGPU/notriviallyvectorizableintrinsicoperands.ll
@@ -361,20 +361,23 @@ define amdgpu_kernel void @kernel_div_scale(ptr addrspace(1) %num, ptr addrspace
 ; GCN-NEXT:  [[ENTRY:.*:]]
 ; GCN-NEXT:    [[NPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[NUM]], i64 2
 ; GCN-NEXT:    [[N2:%.*]] = load float, ptr addrspace(1) [[NPTR2]], align 4
-; GCN-NEXT:    [[DPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[DEN]], i64 2
-; GCN-NEXT:    [[D2:%.*]] = load float, ptr addrspace(1) [[DPTR2]], align 4
+; GCN-NEXT:    [[D0:%.*]] = load float, ptr addrspace(1) [[DEN]], align 4
+; GCN-NEXT:    [[DPTR1:%.*]] = getelementptr float, ptr addrspace(1) [[DEN]], i64 1
 ; GCN-NEXT:    [[TMP0:%.*]] = load <2 x float>, ptr addrspace(1) [[NUM]], align 4
 ; GCN-NEXT:    [[TMP1:%.*]] = fmul <2 x float> [[TMP0]], splat (float 2.000000e+00)
-; GCN-NEXT:    [[MUL_N2:%.*]] = fmul float [[N2]], 2.000000e+00
-; GCN-NEXT:    [[TMP2:%.*]] = load <2 x float>, ptr addrspace(1) [[DEN]], align 4
+; GCN-NEXT:    [[TMP8:%.*]] = insertelement <2 x float> poison, float [[N2]], i32 0
+; GCN-NEXT:    [[TMP9:%.*]] = insertelement <2 x float> [[TMP8]], float [[D0]], i32 1
+; GCN-NEXT:    [[TMP10:%.*]] = fmul <2 x float> [[TMP9]], <float 2.000000e+00, float 4.000000e+00>
+; GCN-NEXT:    [[TMP2:%.*]] = load <2 x float>, ptr addrspace(1) [[DPTR1]], align 4
 ; GCN-NEXT:    [[TMP3:%.*]] = fmul <2 x float> [[TMP2]], splat (float 4.000000e+00)
-; GCN-NEXT:    [[MUL_D2:%.*]] = fmul float [[D2]], 4.000000e+00
 ; GCN-NEXT:    [[TMP4:%.*]] = extractelement <2 x float> [[TMP1]], i32 0
-; GCN-NEXT:    [[TMP5:%.*]] = extractelement <2 x float> [[TMP3]], i32 0
+; GCN-NEXT:    [[TMP5:%.*]] = extractelement <2 x float> [[TMP10]], i32 1
 ; GCN-NEXT:    [[DS0:%.*]] = call { float, i1 } @llvm.amdgcn.div.scale.f32(float [[TMP4]], float [[TMP5]], i1 false)
 ; GCN-NEXT:    [[TMP6:%.*]] = extractelement <2 x float> [[TMP1]], i32 1
-; GCN-NEXT:    [[TMP7:%.*]] = extractelement <2 x float> [[TMP3]], i32 1
+; GCN-NEXT:    [[TMP7:%.*]] = extractelement <2 x float> [[TMP3]], i32 0
 ; GCN-NEXT:    [[DS1:%.*]] = call { float, i1 } @llvm.amdgcn.div.scale.f32(float [[TMP6]], float [[TMP7]], i1 false)
+; GCN-NEXT:    [[MUL_N2:%.*]] = extractelement <2 x float> [[TMP10]], i32 0
+; GCN-NEXT:    [[MUL_D2:%.*]] = extractelement <2 x float> [[TMP3]], i32 1
 ; GCN-NEXT:    [[DS2:%.*]] = call { float, i1 } @llvm.amdgcn.div.scale.f32(float [[MUL_N2]], float [[MUL_D2]], i1 false)
 ; GCN-NEXT:    [[R0:%.*]] = extractvalue { float, i1 } [[DS0]], 0
 ; GCN-NEXT:    [[R1:%.*]] = extractvalue { float, i1 } [[DS1]], 0
@@ -534,6 +537,192 @@ entry:
   %sum02 = fadd float %med2, %med3
   %sum   = fadd float %sum01, %sum02
   store float %sum, ptr addrspace(1) %output, align 4
+  ret void
+}
+
+define amdgpu_kernel void @test_single_exp_hreduction(
+; GCN-LABEL: define amdgpu_kernel void @test_single_exp_hreduction(
+; GCN-SAME: ptr addrspace(1) [[INPUT:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
+; GCN-NEXT:  [[ENTRY:.*:]]
+; GCN-NEXT:    [[P0:%.*]] = getelementptr float, ptr addrspace(1) [[INPUT]], i64 0
+; GCN-NEXT:    [[TMP0:%.*]] = load <4 x float>, ptr addrspace(1) [[P0]], align 4
+; GCN-NEXT:    [[TMP1:%.*]] = call fast float @llvm.vector.reduce.fadd.v4f32(float 0.000000e+00, <4 x float> [[TMP0]])
+; GCN-NEXT:    [[EXP0:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP1]])
+; GCN-NEXT:    store float [[EXP0]], ptr addrspace(1) [[OUTPUT]], align 4
+; GCN-NEXT:    ret void
+;
+  ptr addrspace(1) %input, ptr addrspace(1) %output) {
+entry:
+  %p0 = getelementptr float, ptr addrspace(1) %input, i64 0
+  %p1 = getelementptr float, ptr addrspace(1) %input, i64 1
+  %p2 = getelementptr float, ptr addrspace(1) %input, i64 2
+  %p3 = getelementptr float, ptr addrspace(1) %input, i64 3
+
+  %a0 = load float, ptr addrspace(1) %p0, align 4
+  %a1 = load float, ptr addrspace(1) %p1, align 4
+  %a2 = load float, ptr addrspace(1) %p2, align 4
+  %a3 = load float, ptr addrspace(1) %p3, align 4
+
+  %add01 = fadd fast float %a0, %a1
+  %add23 = fadd fast float %a2, %a3
+  %sum   = fadd fast float %add01, %add23
+
+  %exp0 = tail call float @llvm.amdgcn.exp2.f32(float %sum)
+  store float %exp0, ptr addrspace(1) %output, align 4
+  ret void
+}
+
+define amdgpu_kernel void @test_hreduction_into_exp(
+; GCN-LABEL: define amdgpu_kernel void @test_hreduction_into_exp(
+; GCN-SAME: ptr addrspace(1) [[INPUT:%.*]], ptr addrspace(1) [[OUTPUT:%.*]], <16 x i32> [[A:%.*]], <16 x i32> [[B:%.*]], i32 [[SCALE_IDX:%.*]]) #[[ATTR0]] {
+; GCN-NEXT:  [[ENTRY:.*:]]
+; GCN-NEXT:    [[P0:%.*]] = getelementptr float, ptr addrspace(1) [[INPUT]], i64 0
+; GCN-NEXT:    [[P4:%.*]] = getelementptr float, ptr addrspace(1) [[INPUT]], i64 4
+; GCN-NEXT:    [[TMP0:%.*]] = load <4 x float>, ptr addrspace(1) [[P0]], align 4
+; GCN-NEXT:    [[TMP1:%.*]] = load <4 x float>, ptr addrspace(1) [[P4]], align 4
+; GCN-NEXT:    [[TMP2:%.*]] = call fast float @llvm.vector.reduce.fadd.v4f32(float 0.000000e+00, <4 x float> [[TMP0]])
+; GCN-NEXT:    [[TMP3:%.*]] = call fast float @llvm.vector.reduce.fadd.v4f32(float 0.000000e+00, <4 x float> [[TMP1]])
+; GCN-NEXT:    [[EXP0:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP2]])
+; GCN-NEXT:    [[EXP1:%.*]] = tail call float @llvm.amdgcn.exp2.f32(float [[TMP3]])
+; GCN-NEXT:    [[VEC0:%.*]] = insertelement <2 x float> poison, float [[EXP0]], i64 0
+; GCN-NEXT:    [[VEC1:%.*]] = insertelement <2 x float> [[VEC0]], float [[EXP1]], i64 1
+; GCN-NEXT:    [[VEC_I32:%.*]] = bitcast <2 x float> [[VEC1]] to <2 x i32>
+; GCN-NEXT:    [[SCALE0:%.*]] = extractelement <2 x i32> [[VEC_I32]], i64 0
+; GCN-NEXT:    [[SCALE1:%.*]] = extractelement <2 x i32> [[VEC_I32]], i64 1
+; GCN-NEXT:    [[WMMA0:%.*]] = tail call <8 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v8f32.v16i32.v16i32(i32 0, <16 x i32> [[A]], i32 0, <16 x i32> [[B]], i16 0, <8 x float> zeroinitializer, i32 0, i32 0, i32 [[SCALE0]], i32 0, i32 0, i32 [[SCALE_IDX]], i1 false, i1 false)
+; GCN-NEXT:    [[WMMA1:%.*]] = tail call <8 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v8f32.v16i32.v16i32(i32 0, <16 x i32> [[A]], i32 0, <16 x i32> [[B]], i16 0, <8 x float> [[WMMA0]], i32 0, i32 0, i32 [[SCALE1]], i32 0, i32 0, i32 [[SCALE_IDX]], i1 false, i1 false)
+; GCN-NEXT:    store <8 x float> [[WMMA1]], ptr addrspace(1) [[OUTPUT]], align 32
+; GCN-NEXT:    ret void
+;
+  ptr addrspace(1) %input, ptr addrspace(1) %output,
+  <16 x i32> %A, <16 x i32> %B, i32 %scale_idx) {
+entry:
+  %p0 = getelementptr float, ptr addrspace(1) %input, i64 0
+  %p1 = getelementptr float, ptr addrspace(1) %input, i64 1
+  %p2 = getelementptr float, ptr addrspace(1) %input, i64 2
+  %p3 = getelementptr float, ptr addrspace(1) %input, i64 3
+  %p4 = getelementptr float, ptr addrspace(1) %input, i64 4
+  %p5 = getelementptr float, ptr addrspace(1) %input, i64 5
+  %p6 = getelementptr float, ptr addrspace(1) %input, i64 6
+  %p7 = getelementptr float, ptr addrspace(1) %input, i64 7
+
+  %a0 = load float, ptr addrspace(1) %p0, align 4
+  %a1 = load float, ptr addrspace(1) %p1, align 4
+  %a2 = load float, ptr addrspace(1) %p2, align 4
+  %a3 = load float, ptr addrspace(1) %p3, align 4
+  %b0 = load float, ptr addrspace(1) %p4, align 4
+  %b1 = load float, ptr addrspace(1) %p5, align 4
+  %b2 = load float, ptr addrspace(1) %p6, align 4
+  %b3 = load float, ptr addrspace(1) %p7, align 4
+
+  %add_a01 = fadd fast float %a0, %a1
+  %add_a23 = fadd fast float %a2, %a3
+  %sum0    = fadd fast float %add_a01, %add_a23
+
+  %add_b01 = fadd fast float %b0, %b1
+  %add_b23 = fadd fast float %b2, %b3
+  %sum1    = fadd fast float %add_b01, %add_b23
+
+
+  %exp0 = tail call float @llvm.amdgcn.exp2.f32(float %sum0)
+  %exp1 = tail call float @llvm.amdgcn.exp2.f32(float %sum1)
+
+  %vec0    = insertelement <2 x float> poison, float %exp0, i64 0
+  %vec1    = insertelement <2 x float> %vec0,  float %exp1, i64 1
+  %vec_i32 = bitcast <2 x float> %vec1 to <2 x i32>
+  %scale0  = extractelement <2 x i32> %vec_i32, i64 0
+  %scale1  = extractelement <2 x i32> %vec_i32, i64 1
+
+  %wmma0 = tail call <8 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v8f32.v16i32.v16i32(
+  i32 0, <16 x i32> %A, i32 0, <16 x i32> %B, i16 0, <8 x float> zeroinitializer,
+  i32 0, i32 0, i32 %scale0, i32 0, i32 0, i32 %scale_idx, i1 false, i1 false)
+
+  %wmma1 = tail call <8 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v8f32.v16i32.v16i32(
+  i32 0, <16 x i32> %A, i32 0, <16 x i32> %B, i16 0, <8 x float> %wmma0,
+  i32 0, i32 0, i32 %scale1, i32 0, i32 0, i32 %scale_idx, i1 false, i1 false)
+
+  store <8 x float> %wmma1, ptr addrspace(1) %output, align 32
+  ret void
+}
+
+define amdgpu_kernel void @kernel_alternate(ptr addrspace(1) %a, ptr addrspace(1) %b, ptr addrspace(1) %output) {
+; GCN-LABEL: define amdgpu_kernel void @kernel_alternate(
+; GCN-SAME: ptr addrspace(1) [[A:%.*]], ptr addrspace(1) [[B:%.*]], ptr addrspace(1) [[OUTPUT:%.*]]) #[[ATTR0]] {
+; GCN-NEXT:  [[ENTRY:.*:]]
+; GCN-NEXT:    [[APTR2:%.*]] = getelementptr float, ptr addrspace(1) [[A]], i64 2
+; GCN-NEXT:    [[A2:%.*]] = load float, ptr addrspace(1) [[APTR2]], align 4
+; GCN-NEXT:    [[BPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[B]], i64 2
+; GCN-NEXT:    [[B2:%.*]] = load float, ptr addrspace(1) [[BPTR2]], align 4
+; GCN-NEXT:    [[TMP0:%.*]] = load <2 x float>, ptr addrspace(1) [[A]], align 4
+; GCN-NEXT:    [[TMP1:%.*]] = load <2 x float>, ptr addrspace(1) [[B]], align 4
+; GCN-NEXT:    [[TMP5:%.*]] = fadd <2 x float> [[TMP0]], [[TMP1]]
+; GCN-NEXT:    [[TMP6:%.*]] = fsub <2 x float> [[TMP0]], [[TMP1]]
+; GCN-NEXT:    [[ADD2:%.*]] = fadd float [[A2]], [[B2]]
+; GCN-NEXT:    [[SUB2:%.*]] = fsub float [[A2]], [[B2]]
+; GCN-NEXT:    [[ADD1:%.*]] = extractelement <2 x float> [[TMP5]], i32 0
+; GCN-NEXT:    [[E2:%.*]] = call float @llvm.amdgcn.exp2.f32(float [[ADD1]])
+; GCN-NEXT:    [[TMP7:%.*]] = extractelement <2 x float> [[TMP6]], i32 0
+; GCN-NEXT:    [[E3:%.*]] = call float @llvm.amdgcn.exp2.f32(float [[TMP7]])
+; GCN-NEXT:    [[TMP10:%.*]] = extractelement <2 x float> [[TMP5]], i32 1
+; GCN-NEXT:    [[E6:%.*]] = call float @llvm.amdgcn.log.f32(float [[TMP10]])
+; GCN-NEXT:    [[SUB1:%.*]] = extractelement <2 x float> [[TMP6]], i32 1
+; GCN-NEXT:    [[E7:%.*]] = call float @llvm.amdgcn.log.f32(float [[SUB1]])
+; GCN-NEXT:    [[E4:%.*]] = call float @llvm.amdgcn.exp2.f32(float [[ADD2]])
+; GCN-NEXT:    [[E5:%.*]] = call float @llvm.amdgcn.exp2.f32(float [[SUB2]])
+; GCN-NEXT:    [[OPTR0:%.*]] = getelementptr float, ptr addrspace(1) [[OUTPUT]], i64 0
+; GCN-NEXT:    [[OPTR1:%.*]] = getelementptr float, ptr addrspace(1) [[OUTPUT]], i64 1
+; GCN-NEXT:    [[OPTR2:%.*]] = getelementptr float, ptr addrspace(1) [[OUTPUT]], i64 2
+; GCN-NEXT:    [[OPTR3:%.*]] = getelementptr float, ptr addrspace(1) [[OUTPUT]], i64 3
+; GCN-NEXT:    [[OPTR4:%.*]] = getelementptr float, ptr addrspace(1) [[OUTPUT]], i64 4
+; GCN-NEXT:    [[OPTR5:%.*]] = getelementptr float, ptr addrspace(1) [[OUTPUT]], i64 5
+; GCN-NEXT:    store float [[E2]], ptr addrspace(1) [[OPTR0]], align 4
+; GCN-NEXT:    store float [[E3]], ptr addrspace(1) [[OPTR1]], align 4
+; GCN-NEXT:    store float [[E6]], ptr addrspace(1) [[OPTR2]], align 4
+; GCN-NEXT:    store float [[E7]], ptr addrspace(1) [[OPTR3]], align 4
+; GCN-NEXT:    store float [[E4]], ptr addrspace(1) [[OPTR4]], align 4
+; GCN-NEXT:    store float [[E5]], ptr addrspace(1) [[OPTR5]], align 4
+; GCN-NEXT:    ret void
+;
+entry:
+  %a0    = load float, ptr addrspace(1) %a, align 4
+  %aptr1 = getelementptr float, ptr addrspace(1) %a, i64 1
+  %a1    = load float, ptr addrspace(1) %aptr1, align 4
+  %aptr2 = getelementptr float, ptr addrspace(1) %a, i64 2
+  %a2    = load float, ptr addrspace(1) %aptr2, align 4
+
+  %b0    = load float, ptr addrspace(1) %b, align 4
+  %bptr1 = getelementptr float, ptr addrspace(1) %b, i64 1
+  %b1    = load float, ptr addrspace(1) %bptr1, align 4
+  %bptr2 = getelementptr float, ptr addrspace(1) %b, i64 2
+  %b2    = load float, ptr addrspace(1) %bptr2, align 4
+
+  %add0 = fadd float %a0, %b0
+  %sub0 = fsub float %a0, %b0
+  %add1 = fadd float %a1, %b1
+  %sub1 = fsub float %a1, %b1
+  %add2 = fadd float %a2, %b2
+  %sub2 = fsub float %a2, %b2
+
+  %e0 = call float @llvm.amdgcn.exp2.f32(float %add0)
+  %e1 = call float @llvm.amdgcn.exp2.f32(float %sub0)
+  %e2 = call float @llvm.amdgcn.log.f32(float %add1)
+  %e3 = call float @llvm.amdgcn.log.f32(float %sub1)
+  %e4 = call float @llvm.amdgcn.exp2.f32(float %add2)
+  %e5 = call float @llvm.amdgcn.exp2.f32(float %sub2)
+
+  %optr0 = getelementptr float, ptr addrspace(1) %output, i64 0
+  %optr1 = getelementptr float, ptr addrspace(1) %output, i64 1
+  %optr2 = getelementptr float, ptr addrspace(1) %output, i64 2
+  %optr3 = getelementptr float, ptr addrspace(1) %output, i64 3
+  %optr4 = getelementptr float, ptr addrspace(1) %output, i64 4
+  %optr5 = getelementptr float, ptr addrspace(1) %output, i64 5
+
+  store float %e0, ptr addrspace(1) %optr0, align 4
+  store float %e1, ptr addrspace(1) %optr1, align 4
+  store float %e2, ptr addrspace(1) %optr2, align 4
+  store float %e3, ptr addrspace(1) %optr3, align 4
+  store float %e4, ptr addrspace(1) %optr4, align 4
+  store float %e5, ptr addrspace(1) %optr5, align 4
   ret void
 }
 

--- a/llvm/test/Transforms/SLPVectorizer/RISCV/revec.ll
+++ b/llvm/test/Transforms/SLPVectorizer/RISCV/revec.ll
@@ -177,11 +177,10 @@ define ptr @test4() {
 ; NONPOWEROF2-NEXT:    [[TMP8:%.*]] = phi <6 x float> [ poison, [[TMP6:%.*]] ], [ [[TMP5]], [[TMP0:%.*]] ]
 ; NONPOWEROF2-NEXT:    br label [[TMP9:%.*]]
 ; NONPOWEROF2:       10:
-; NONPOWEROF2-NEXT:    [[TMP10:%.*]] = shufflevector <6 x float> [[TMP8]], <6 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
-; NONPOWEROF2-NEXT:    [[TMP11:%.*]] = fmul <3 x float> zeroinitializer, [[TMP10]]
-; NONPOWEROF2-NEXT:    [[TMP12:%.*]] = shufflevector <6 x float> [[TMP8]], <6 x float> poison, <3 x i32> <i32 3, i32 4, i32 5>
-; NONPOWEROF2-NEXT:    [[TMP13:%.*]] = fmul <3 x float> zeroinitializer, [[TMP12]]
+; NONPOWEROF2-NEXT:    [[TMP12:%.*]] = fmul <6 x float> zeroinitializer, [[TMP8]]
+; NONPOWEROF2-NEXT:    [[TMP11:%.*]] = shufflevector <6 x float> [[TMP12]], <6 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
 ; NONPOWEROF2-NEXT:    [[TMP14:%.*]] = call reassoc nsz float @llvm.vector.reduce.fadd.v3f32(float 0.000000e+00, <3 x float> [[TMP11]])
+; NONPOWEROF2-NEXT:    [[TMP13:%.*]] = shufflevector <6 x float> [[TMP12]], <6 x float> poison, <3 x i32> <i32 3, i32 4, i32 5>
 ; NONPOWEROF2-NEXT:    [[TMP15:%.*]] = call reassoc nsz float @llvm.vector.reduce.fadd.v3f32(float 0.000000e+00, <3 x float> [[TMP13]])
 ; NONPOWEROF2-NEXT:    [[TMP16:%.*]] = tail call float @llvm.sqrt.f32(float [[TMP14]])
 ; NONPOWEROF2-NEXT:    [[TMP17:%.*]] = tail call float @llvm.sqrt.f32(float [[TMP15]])


### PR DESCRIPTION
A non-trivially vectorizable target intrinsic (e.g., llvm.amdgcn.exp2, llvm.amdgcn.log) blocks the SLP vectorizer from building a deeper tree. This patch finds the operands of such intrinsics and tries them as independent SLP tree roots so that the operands continues to get vectorized.

Previously, the SLP vectorizer would terminate tree building at these intrinsic calls (as NeedToGather nodes). That left their operand chains (loads, fmul, fsub, etc.) entirely scalar. This patch adds a new seed discovery pass at the end of vectorizeChainsInBlock.