### PR TITLE
libcxxabi: declare __gnu_unwind_frame in cxa_personality

### DIFF
--- a/libcxxabi/src/cxa_personality.cpp
+++ b/libcxxabi/src/cxa_personality.cpp
@@ -1116,6 +1116,8 @@ __gxx_personality_seh0(PEXCEPTION_RECORD ms_exc, void *this_frame,
 
 #else
 
+extern "C" _Unwind_Reason_Code __gnu_unwind_frame(_Unwind_Exception*, _Unwind_Context*);
+
 // Helper function to unwind one frame.
 // ARM EHABI 7.3 and 7.4: If the personality function returns _URC_CONTINUE_UNWIND, the
 // personality routine should update the virtual register set (VRS) according to the


### PR DESCRIPTION
ARM EHABI builds of libcxxabi fail with clang-22+ because cxa_personality.cpp calls __gnu_unwind_frame without a visible declaration, triggering:

  error: use of undeclared identifier '__gnu_unwind_frame'

Add an extern "C" forward declaration before the EHABI unwind helper so the source compiles correctly.