### PR TITLE
[flang][NFC] Converted five tests from old lowering to new lowering (part 40)

### DIFF
--- a/flang/test/Lower/Intrinsics/same_type_as.f90
+++ b/flang/test/Lower/Intrinsics/same_type_as.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 module same_type_as_mod
 
@@ -28,8 +28,10 @@ contains
 
 ! CHECK-LABEL: func.func @_QMsame_type_as_modPis_same_type(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.class<none> {fir.bindc_name = "a"}, %[[ARG1:.*]]: !fir.class<none> {fir.bindc_name = "b"}) {
-! CHECK: %[[BOX0:.*]] = fir.convert %[[ARG0]] : (!fir.class<none>) -> !fir.box<none>
-! CHECK: %[[BOX1:.*]] = fir.convert %[[ARG1]] : (!fir.class<none>) -> !fir.box<none>
+! CHECK: %[[DECL0:.*]]:2 = hlfir.declare %[[ARG0]] {{.*}} : (!fir.class<none>, !fir.dscope) -> (!fir.class<none>, !fir.class<none>)
+! CHECK: %[[DECL1:.*]]:2 = hlfir.declare %[[ARG1]] {{.*}} : (!fir.class<none>, !fir.dscope) -> (!fir.class<none>, !fir.class<none>)
+! CHECK: %[[BOX0:.*]] = fir.convert %[[DECL0]]#1 : (!fir.class<none>) -> !fir.box<none>
+! CHECK: %[[BOX1:.*]] = fir.convert %[[DECL1]]#1 : (!fir.class<none>) -> !fir.box<none>
 ! CHECK: %{{.*}} = fir.call @_FortranASameTypeAs(%[[BOX0]], %[[BOX1]]) {{.*}} : (!fir.box<none>, !fir.box<none>) -> i1
 
 end module

--- a/flang/test/Lower/Intrinsics/scan.f90
+++ b/flang/test/Lower/Intrinsics/scan.f90
@@ -1,24 +1,16 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPscan_test(
 ! CHECK-SAME: %[[s:[^:]+]]: !fir.boxchar<1>{{.*}}, %[[ss:[^:]+]]: !fir.boxchar<1>{{.*}}) -> i32
 integer function scan_test(s1, s2)
 character(*) :: s1, s2
-! CHECK: %[[tmpBox:.*]] = fir.alloca !fir.box<!fir.heap<i32>>
-! CHECK-DAG: %[[c:.*]]:2 = fir.unboxchar %[[s]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK-DAG: %[[cBox:.*]] = fir.embox %[[c]]#0 typeparams %[[c]]#1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
-! CHECK-DAG: %[[cBoxNone:.*]] = fir.convert %[[cBox]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
-! CHECK-DAG: %[[c2:.*]]:2 = fir.unboxchar %[[ss]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK-DAG: %[[cBox2:.*]] = fir.embox %[[c2]]#0 typeparams %[[c2]]#1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
-! CHECK-DAG: %[[cBoxNone2:.*]] = fir.convert %[[cBox2]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
-! CHECK-DAG: %[[backOptBox:.*]] = fir.absent !fir.box<i1>
-! CHECK-DAG: %[[backBox:.*]] = fir.convert %[[backOptBox]] : (!fir.box<i1>) -> !fir.box<none>
-! CHECK-DAG: %[[kindConstant:.*]] = arith.constant 4 : i32
-! CHECK-DAG: %[[resBox:.*]] = fir.convert %[[tmpBox:.*]] : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
-! CHECK: fir.call @{{.*}}Scan(%[[resBox]], %[[cBoxNone]], %[[cBoxNone2]], %[[backBox]], %[[kindConstant]], {{.*}}) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.box<none>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> ()
+! CHECK: fir.alloca !fir.box<!fir.heap<i32>>
+! CHECK: arith.constant 4 : i32
+! CHECK: fir.absent !fir.box<i1>
+! CHECK: fir.call @_FortranAScan({{.*}}) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.box<none>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> ()
+! CHECK: fir.box_addr %{{.*}} : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK: fir.freemem %{{.*}}
 scan_test = scan(s1, s2, kind=4)
-! CHECK-DAG: %[[tmpAddr:.*]] = fir.box_addr
-! CHECK: fir.freemem %[[tmpAddr]]
 end function scan_test
 
 ! CHECK-LABEL: func @_QPscan_test2(
@@ -26,13 +18,8 @@ end function scan_test
 ! CHECK-SAME: %[[ss:[^:]+]]: !fir.boxchar<1>{{.*}}) -> i32
 integer function scan_test2(s1, s2)
 character(*) :: s1, s2
-! CHECK: %[[st:[^:]*]]:2 = fir.unboxchar %[[s]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK: %[[sst:[^:]*]]:2 = fir.unboxchar %[[ss]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK: %[[a1:.*]] = fir.convert %[[st]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
-! CHECK: %[[a2:.*]] = fir.convert %[[st]]#1 : (index) -> i64
-! CHECK: %[[a3:.*]] = fir.convert %[[sst]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
-! CHECK: %[[a4:.*]] = fir.convert %[[sst]]#1 : (index) -> i64
-! CHECK: = fir.call @_FortranAScan1(%[[a1]], %[[a2]], %[[a3]], %[[a4]], %{{.*}}) {{.*}}: (!fir.ref<i8>, i64, !fir.ref<i8>, i64, i1) -> i64
+! CHECK: arith.constant true
+! CHECK: fir.call @_FortranAScan1(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (!fir.ref<i8>, i64, !fir.ref<i8>, i64, i1) -> i64
 scan_test2 = scan(s1, s2, .true.)
 end function scan_test2
 
@@ -44,26 +31,12 @@ subroutine test_optional(string, set, back)
 character (*) :: string(:), set
 logical, optional :: back(:)
 print *, scan(string, set, back)
-! CHECK:  %[[VAL_11:.*]] = fir.is_present %[[VAL_2]] : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> i1
-! CHECK:  %[[VAL_12:.*]] = fir.zero_bits !fir.ref<!fir.array<?x!fir.logical<4>>>
-! CHECK:  %[[VAL_13:.*]] = arith.constant 0 : index
-! CHECK:  %[[VAL_14:.*]] = fir.shape %[[VAL_13]] : (index) -> !fir.shape<1>
-! CHECK:  %[[VAL_15:.*]] = fir.embox %[[VAL_12]](%[[VAL_14]]) : (!fir.ref<!fir.array<?x!fir.logical<4>>>, !fir.shape<1>) -> !fir.box<!fir.array<?x!fir.logical<4>>>
-! CHECK:  %[[VAL_16:.*]] = arith.select %[[VAL_11]], %[[VAL_2]], %[[VAL_15]] : !fir.box<!fir.array<?x!fir.logical<4>>>
-! CHECK:  %[[VAL_17:.*]] = fir.array_load %[[VAL_16]] {fir.optional} : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.array<?x!fir.logical<4>>
-! CHECK:  fir.do_loop %[[VAL_25:.*]] = %{{.*}} to %{{.*}} step %{{.*}} unordered iter_args(%{{.*}} = %{{.*}}) -> (!fir.array<?xi32>) {
-! CHECK:  %[[VAL_31:.*]] = fir.if %[[VAL_11]] -> (!fir.logical<4>) {
-  ! CHECK:  %[[VAL_32:.*]] = fir.array_fetch %[[VAL_17]], %[[VAL_25]] : (!fir.array<?x!fir.logical<4>>, index) -> !fir.logical<4>
-  ! CHECK:  fir.result %[[VAL_32]] : !fir.logical<4>
-! CHECK:  } else {
-  ! CHECK:  %[[VAL_33:.*]] = arith.constant false
-  ! CHECK:  %[[VAL_34:.*]] = fir.convert %[[VAL_33]] : (i1) -> !fir.logical<4>
-  ! CHECK:  fir.result %[[VAL_34]] : !fir.logical<4>
-! CHECK:  }
-! CHECK:  %[[VAL_39:.*]] = fir.convert %[[VAL_31]] : (!fir.logical<4>) -> i1
-! CHECK:  fir.call @_FortranAScan1(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[VAL_39]]) {{.*}}: (!fir.ref<i8>, i64, !fir.ref<i8>, i64, i1) -> i64
-! CHECK:  }
-! CHECK:  fir.array_merge_store
+! CHECK:  fir.is_present %{{.*}} : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> i1
+! CHECK:  hlfir.elemental %{{.*}} unordered
+! CHECK:  fir.if %{{.*}} -> (!fir.logical<4>)
+! CHECK:  fir.call @_FortranAScan1(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (!fir.ref<i8>, i64, !fir.ref<i8>, i64, i1) -> i64
+! CHECK:  hlfir.end_associate
+! CHECK:  hlfir.destroy
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_optional_scalar(
@@ -74,18 +47,10 @@ subroutine test_optional_scalar(string, set, back)
 character (*) :: string(:), set
 logical, optional :: back
 print *, scan(string, set, back)
-! CHECK:  %[[VAL_11:.*]] = fir.is_present %[[VAL_2]] : (!fir.ref<!fir.logical<4>>) -> i1
-! CHECK:  %[[VAL_12:.*]] = fir.if %[[VAL_11]] -> (!fir.logical<4>) {
-! CHECK:  %[[VAL_13:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.logical<4>>
-! CHECK:  fir.result %[[VAL_13]] : !fir.logical<4>
-! CHECK:  } else {
-! CHECK:  %[[VAL_14:.*]] = arith.constant false
-! CHECK:  %[[VAL_15:.*]] = fir.convert %[[VAL_14]] : (i1) -> !fir.logical<4>
-! CHECK:  fir.result %[[VAL_15]] : !fir.logical<4>
-! CHECK:  }
-! CHECK:  fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} unordered iter_args(%{{.*}} = %{{.*}}) -> (!fir.array<?xi32>) {
-! CHECK:  %[[VAL_39:.*]] = fir.convert %[[VAL_12]] : (!fir.logical<4>) -> i1
-! CHECK:  fir.call @_FortranAScan1(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[VAL_39]]) {{.*}}: (!fir.ref<i8>, i64, !fir.ref<i8>, i64, i1) -> i64
-! CHECK:  }
-! CHECK:  fir.array_merge_store
+! CHECK:  fir.is_present %{{.*}} : (!fir.ref<!fir.logical<4>>) -> i1
+! CHECK:  hlfir.elemental %{{.*}} unordered
+! CHECK:  fir.if %{{.*}} -> (!fir.logical<4>)
+! CHECK:  fir.call @_FortranAScan1(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (!fir.ref<i8>, i64, !fir.ref<i8>, i64, i1) -> i64
+! CHECK:  hlfir.end_associate
+! CHECK:  hlfir.destroy
 end subroutine

--- a/flang/test/Lower/Intrinsics/secnds.f90
+++ b/flang/test/Lower/Intrinsics/secnds.f90
@@ -1,23 +1,24 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func.func @_QPuse_secnds(
-! CHECK-SAME: %arg0: !fir.ref<f32>
+! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<f32>
 function use_secnds(refTime) result(elapsed)
   real :: refTime, elapsed
   elapsed = secnds(refTime)
 end function
 
-! File/line operands (don’t match the actual path/number)
+! CHECK: %[[DECL:.*]]:2 = hlfir.declare %[[ARG0]]{{.*}} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
+
+! File/line operands (don't match the actual path/number)
 ! CHECK: %[[STRADDR:.*]] = fir.address_of(
 ! CHECK: %[[LINE:.*]] = arith.constant {{.*}} : i32
 ! CHECK: %[[FNAME8:.*]] = fir.convert %[[STRADDR]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 
 ! Important: pass refTime by address and return a value f32
-! CHECK: %[[CALL:.*]] = fir.call @{{.*}}Secnds(%arg0, %[[FNAME8]], %[[LINE]]) {{.*}} : (!fir.ref<f32>, !fir.ref<i8>, i32) -> f32
+! CHECK: %[[CALL:.*]] = fir.call @{{.*}}Secnds(%[[DECL]]#0, %[[FNAME8]], %[[LINE]]) {{.*}} : (!fir.ref<f32>, !fir.ref<i8>, i32) -> f32
 
 ! Guard against illegal value ->ref conversion of result
 ! CHECK-NOT: fir.convert {{.*}} : (f32) -> !fir.ref<f32>
 
 ! Function returns an f32 value
 ! CHECK: return {{.*}} : f32
-

--- a/flang/test/Lower/Intrinsics/selected_int_kind.f90
+++ b/flang/test/Lower/Intrinsics/selected_int_kind.f90
@@ -1,13 +1,13 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func.func @_QPselected_int_kind_test1(
 ! CHECK-SAME:                                        %[[VAL_0:.*]]: !fir.ref<i8> {fir.bindc_name = "a"}) {
-! CHECK:         %[[VAL_1:.*]] = fir.alloca i8 {bindc_name = "res", uniq_name = "_QFselected_int_kind_test1Eres"}
-! CHECK:         %[[VAL_4:.*]] = arith.constant 1 : i32
-! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<i8>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_7:.*]] = fir.call @_FortranASelectedIntKind(%{{.*}}, %{{.*}}, %[[VAL_6]], %[[VAL_4]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
-! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i32) -> i8
-! CHECK:         fir.store %[[VAL_8]] to %[[VAL_1]] : !fir.ref<i8>
+! CHECK:         %[[DECL:.*]]:2 = hlfir.declare %[[VAL_0]] {{.*}} : (!fir.ref<i8>, !fir.dscope) -> (!fir.ref<i8>, !fir.ref<i8>)
+! CHECK:         %[[KIND:.*]] = arith.constant 1 : i32
+! CHECK:         %[[APTR:.*]] = fir.convert %[[DECL]]#0 : (!fir.ref<i8>) -> !fir.llvm_ptr<i8>
+! CHECK:         %[[RES:.*]] = fir.call @_FortranASelectedIntKind(%{{.*}}, %{{.*}}, %[[APTR]], %[[KIND]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
+! CHECK:         %[[CONV:.*]] = fir.convert %[[RES]] : (i32) -> i8
+! CHECK:         hlfir.assign %[[CONV]] to %{{.*}} : i8, !fir.ref<i8>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -18,12 +18,12 @@ end
 
 ! CHECK-LABEL: func.func @_QPselected_int_kind_test2(
 ! CHECK-SAME:                                        %[[VAL_0:.*]]: !fir.ref<i16> {fir.bindc_name = "a"}) {
-! CHECK:         %[[VAL_1:.*]] = fir.alloca i16 {bindc_name = "res", uniq_name = "_QFselected_int_kind_test2Eres"}
-! CHECK:         %[[VAL_4:.*]] = arith.constant 2 : i32
-! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<i16>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_7:.*]] = fir.call @_FortranASelectedIntKind(%{{.*}}, %{{.*}}, %[[VAL_6]], %[[VAL_4]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
-! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i32) -> i16
-! CHECK:         fir.store %[[VAL_8]] to %[[VAL_1]] : !fir.ref<i16>
+! CHECK:         %[[DECL:.*]]:2 = hlfir.declare %[[VAL_0]] {{.*}} : (!fir.ref<i16>, !fir.dscope) -> (!fir.ref<i16>, !fir.ref<i16>)
+! CHECK:         %[[KIND:.*]] = arith.constant 2 : i32
+! CHECK:         %[[APTR:.*]] = fir.convert %[[DECL]]#0 : (!fir.ref<i16>) -> !fir.llvm_ptr<i8>
+! CHECK:         %[[RES:.*]] = fir.call @_FortranASelectedIntKind(%{{.*}}, %{{.*}}, %[[APTR]], %[[KIND]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
+! CHECK:         %[[CONV:.*]] = fir.convert %[[RES]] : (i32) -> i16
+! CHECK:         hlfir.assign %[[CONV]] to %{{.*}} : i16, !fir.ref<i16>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -34,11 +34,11 @@ end
 
 ! CHECK-LABEL: func.func @_QPselected_int_kind_test4(
 ! CHECK-SAME:                                        %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"}) {
-! CHECK:         %[[VAL_1:.*]] = fir.alloca i32 {bindc_name = "res", uniq_name = "_QFselected_int_kind_test4Eres"}
-! CHECK:         %[[VAL_4:.*]] = arith.constant 4 : i32
-! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<i32>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_7:.*]] = fir.call @_FortranASelectedIntKind(%{{.*}}, %{{.*}}, %[[VAL_6]], %[[VAL_4]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
-! CHECK:         fir.store %[[VAL_7]] to %[[VAL_1]] : !fir.ref<i32>
+! CHECK:         %[[DECL:.*]]:2 = hlfir.declare %[[VAL_0]] {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:         %[[KIND:.*]] = arith.constant 4 : i32
+! CHECK:         %[[APTR:.*]] = fir.convert %[[DECL]]#0 : (!fir.ref<i32>) -> !fir.llvm_ptr<i8>
+! CHECK:         %[[RES:.*]] = fir.call @_FortranASelectedIntKind(%{{.*}}, %{{.*}}, %[[APTR]], %[[KIND]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
+! CHECK:         hlfir.assign %[[RES]] to %{{.*}} : i32, !fir.ref<i32>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -49,12 +49,12 @@ end
 
 ! CHECK-LABEL: func.func @_QPselected_int_kind_test8(
 ! CHECK-SAME:                                        %[[VAL_0:.*]]: !fir.ref<i64> {fir.bindc_name = "a"}) {
-! CHECK:         %[[VAL_1:.*]] = fir.alloca i64 {bindc_name = "res", uniq_name = "_QFselected_int_kind_test8Eres"}
-! CHECK:         %[[VAL_4:.*]] = arith.constant 8 : i32
-! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<i64>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_7:.*]] = fir.call @_FortranASelectedIntKind(%{{.*}}, %{{.*}}, %[[VAL_6]], %[[VAL_4]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
-! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i32) -> i64
-! CHECK:         fir.store %[[VAL_8]] to %[[VAL_1]] : !fir.ref<i64>
+! CHECK:         %[[DECL:.*]]:2 = hlfir.declare %[[VAL_0]] {{.*}} : (!fir.ref<i64>, !fir.dscope) -> (!fir.ref<i64>, !fir.ref<i64>)
+! CHECK:         %[[KIND:.*]] = arith.constant 8 : i32
+! CHECK:         %[[APTR:.*]] = fir.convert %[[DECL]]#0 : (!fir.ref<i64>) -> !fir.llvm_ptr<i8>
+! CHECK:         %[[RES:.*]] = fir.call @_FortranASelectedIntKind(%{{.*}}, %{{.*}}, %[[APTR]], %[[KIND]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
+! CHECK:         %[[CONV:.*]] = fir.convert %[[RES]] : (i32) -> i64
+! CHECK:         hlfir.assign %[[CONV]] to %{{.*}} : i64, !fir.ref<i64>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -65,12 +65,12 @@ end
 
 ! CHECK-LABEL: func.func @_QPselected_int_kind_test16(
 ! CHECK-SAME:                                         %[[VAL_0:.*]]: !fir.ref<i128> {fir.bindc_name = "a"}) {
-! CHECK:         %[[VAL_1:.*]] = fir.alloca i128 {bindc_name = "res", uniq_name = "_QFselected_int_kind_test16Eres"}
-! CHECK:         %[[VAL_4:.*]] = arith.constant 16 : i32
-! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<i128>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_7:.*]] = fir.call @_FortranASelectedIntKind(%{{.*}}, %{{.*}}, %[[VAL_6]], %[[VAL_4]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
-! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i32) -> i128
-! CHECK:         fir.store %[[VAL_8]] to %[[VAL_1]] : !fir.ref<i128>
+! CHECK:         %[[DECL:.*]]:2 = hlfir.declare %[[VAL_0]] {{.*}} : (!fir.ref<i128>, !fir.dscope) -> (!fir.ref<i128>, !fir.ref<i128>)
+! CHECK:         %[[KIND:.*]] = arith.constant 16 : i32
+! CHECK:         %[[APTR:.*]] = fir.convert %[[DECL]]#0 : (!fir.ref<i128>) -> !fir.llvm_ptr<i8>
+! CHECK:         %[[RES:.*]] = fir.call @_FortranASelectedIntKind(%{{.*}}, %{{.*}}, %[[APTR]], %[[KIND]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
+! CHECK:         %[[CONV:.*]] = fir.convert %[[RES]] : (i32) -> i128
+! CHECK:         hlfir.assign %[[CONV]] to %{{.*}} : i128, !fir.ref<i128>
 ! CHECK:         return
 ! CHECK:       }
 

--- a/flang/test/Lower/Intrinsics/selected_real_kind.f90
+++ b/flang/test/Lower/Intrinsics/selected_real_kind.f90
@@ -1,19 +1,13 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func.func @_QPselected_real_kind_test1(
 ! CHECK-SAME:                                         %[[VAL_0:.*]]: !fir.ref<i8> {fir.bindc_name = "p"},
 ! CHECK-SAME:                                         %[[VAL_1:.*]]: !fir.ref<i8> {fir.bindc_name = "r"},
 ! CHECK-SAME:                                         %[[VAL_2:.*]]: !fir.ref<i8> {fir.bindc_name = "d"}) {
-! CHECK:         %[[VAL_3:.*]] = fir.alloca i8 {bindc_name = "res", uniq_name = "_QFselected_real_kind_test1Eres"}
-! CHECK:         %[[VAL_6:.*]] = arith.constant 1 : i32
-! CHECK:         %[[VAL_7:.*]] = arith.constant 1 : i32
-! CHECK:         %[[VAL_8:.*]] = arith.constant 1 : i32
-! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<i8>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<i8>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<i8>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_13:.*]] = fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %[[VAL_10]], %[[VAL_6]], %[[VAL_11]], %[[VAL_7]], %[[VAL_12]], %[[VAL_8]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
-! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (i32) -> i8
-! CHECK:         fir.store %[[VAL_14]] to %[[VAL_3]] : !fir.ref<i8>
+! CHECK:         arith.constant 1 : i32
+! CHECK:         fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
+! CHECK:         %[[CONV:.*]] = fir.convert %{{.*}} : (i32) -> i8
+! CHECK:         hlfir.assign %[[CONV]] to %{{.*}} : i8, !fir.ref<i8>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -26,16 +20,10 @@ end
 ! CHECK-SAME:                                         %[[VAL_0:.*]]: !fir.ref<i16> {fir.bindc_name = "p"},
 ! CHECK-SAME:                                         %[[VAL_1:.*]]: !fir.ref<i16> {fir.bindc_name = "r"},
 ! CHECK-SAME:                                         %[[VAL_2:.*]]: !fir.ref<i16> {fir.bindc_name = "d"}) {
-! CHECK:         %[[VAL_3:.*]] = fir.alloca i16 {bindc_name = "res", uniq_name = "_QFselected_real_kind_test2Eres"}
-! CHECK:         %[[VAL_6:.*]] = arith.constant 2 : i32
-! CHECK:         %[[VAL_7:.*]] = arith.constant 2 : i32
-! CHECK:         %[[VAL_8:.*]] = arith.constant 2 : i32
-! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<i16>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<i16>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<i16>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_13:.*]] = fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %[[VAL_10]], %[[VAL_6]], %[[VAL_11]], %[[VAL_7]], %[[VAL_12]], %[[VAL_8]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
-! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (i32) -> i16
-! CHECK:         fir.store %[[VAL_14]] to %[[VAL_3]] : !fir.ref<i16>
+! CHECK:         arith.constant 2 : i32
+! CHECK:         fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
+! CHECK:         %[[CONV:.*]] = fir.convert %{{.*}} : (i32) -> i16
+! CHECK:         hlfir.assign %[[CONV]] to %{{.*}} : i16, !fir.ref<i16>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -48,15 +36,9 @@ end
 ! CHECK-SAME:                                         %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "p"},
 ! CHECK-SAME:                                         %[[VAL_1:.*]]: !fir.ref<i32> {fir.bindc_name = "r"},
 ! CHECK-SAME:                                         %[[VAL_2:.*]]: !fir.ref<i32> {fir.bindc_name = "d"}) {
-! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {bindc_name = "res", uniq_name = "_QFselected_real_kind_test4Eres"}
-! CHECK:         %[[VAL_6:.*]] = arith.constant 4 : i32
-! CHECK:         %[[VAL_7:.*]] = arith.constant 4 : i32
-! CHECK:         %[[VAL_8:.*]] = arith.constant 4 : i32
-! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<i32>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<i32>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<i32>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_13:.*]] = fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %[[VAL_10]], %[[VAL_6]], %[[VAL_11]], %[[VAL_7]], %[[VAL_12]], %[[VAL_8]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
-! CHECK:         fir.store %[[VAL_13]] to %[[VAL_3]] : !fir.ref<i32>
+! CHECK:         arith.constant 4 : i32
+! CHECK:         fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
+! CHECK:         hlfir.assign %{{.*}} to %{{.*}} : i32, !fir.ref<i32>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -69,16 +51,10 @@ end
 ! CHECK-SAME:                                         %[[VAL_0:.*]]: !fir.ref<i64> {fir.bindc_name = "p"},
 ! CHECK-SAME:                                         %[[VAL_1:.*]]: !fir.ref<i64> {fir.bindc_name = "r"},
 ! CHECK-SAME:                                         %[[VAL_2:.*]]: !fir.ref<i64> {fir.bindc_name = "d"}) {
-! CHECK:         %[[VAL_3:.*]] = fir.alloca i64 {bindc_name = "res", uniq_name = "_QFselected_real_kind_test8Eres"}
-! CHECK:         %[[VAL_6:.*]] = arith.constant 8 : i32
-! CHECK:         %[[VAL_7:.*]] = arith.constant 8 : i32
-! CHECK:         %[[VAL_8:.*]] = arith.constant 8 : i32
-! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<i64>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<i64>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<i64>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_13:.*]] = fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %[[VAL_10]], %[[VAL_6]], %[[VAL_11]], %[[VAL_7]], %[[VAL_12]], %[[VAL_8]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
-! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (i32) -> i64
-! CHECK:         fir.store %[[VAL_14]] to %[[VAL_3]] : !fir.ref<i64>
+! CHECK:         arith.constant 8 : i32
+! CHECK:         fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
+! CHECK:         %[[CONV:.*]] = fir.convert %{{.*}} : (i32) -> i64
+! CHECK:         hlfir.assign %[[CONV]] to %{{.*}} : i64, !fir.ref<i64>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -91,16 +67,10 @@ end
 ! CHECK-SAME:                                          %[[VAL_0:.*]]: !fir.ref<i128> {fir.bindc_name = "p"},
 ! CHECK-SAME:                                          %[[VAL_1:.*]]: !fir.ref<i128> {fir.bindc_name = "r"},
 ! CHECK-SAME:                                          %[[VAL_2:.*]]: !fir.ref<i128> {fir.bindc_name = "d"}) {
-! CHECK:         %[[VAL_3:.*]] = fir.alloca i128 {bindc_name = "res", uniq_name = "_QFselected_real_kind_test16Eres"}
-! CHECK:         %[[VAL_6:.*]] = arith.constant 16 : i32
-! CHECK:         %[[VAL_7:.*]] = arith.constant 16 : i32
-! CHECK:         %[[VAL_8:.*]] = arith.constant 16 : i32
-! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<i128>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<i128>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<i128>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_13:.*]] = fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %[[VAL_10]], %[[VAL_6]], %[[VAL_11]], %[[VAL_7]], %[[VAL_12]], %[[VAL_8]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
-! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (i32) -> i128
-! CHECK:         fir.store %[[VAL_14]] to %[[VAL_3]] : !fir.ref<i128>
+! CHECK:         arith.constant 16 : i32
+! CHECK:         fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
+! CHECK:         %[[CONV:.*]] = fir.convert %{{.*}} : (i32) -> i128
+! CHECK:         hlfir.assign %[[CONV]] to %{{.*}} : i128, !fir.ref<i128>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -112,16 +82,10 @@ end
 ! CHECK-LABEL: func.func @_QPselected_real_kind_test_rd(
 ! CHECK-SAME:                                           %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "r"},
 ! CHECK-SAME:                                           %[[VAL_1:.*]]: !fir.ref<i32> {fir.bindc_name = "d"}) {
-! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {bindc_name = "res", uniq_name = "_QFselected_real_kind_test_rdEres"}
-! CHECK:         %[[VAL_3:.*]] = fir.absent !fir.ref<i1>
-! CHECK:         %[[VAL_6:.*]] = arith.constant 0 : i32
-! CHECK:         %[[VAL_7:.*]] = arith.constant 4 : i32
-! CHECK:         %[[VAL_8:.*]] = arith.constant 4 : i32
-! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<i1>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<i32>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<i32>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_13:.*]] = fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %[[VAL_10]], %[[VAL_6]], %[[VAL_11]], %[[VAL_7]], %[[VAL_12]], %[[VAL_8]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
-! CHECK:         fir.store %[[VAL_13]] to %[[VAL_2]] : !fir.ref<i32>
+! CHECK:         fir.absent !fir.ref<i1>
+! CHECK:         arith.constant 0 : i32
+! CHECK:         fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
+! CHECK:         hlfir.assign %{{.*}} to %{{.*}} : i32, !fir.ref<i32>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -133,16 +97,10 @@ end
 ! CHECK-LABEL: func.func @_QPselected_real_kind_test_pd(
 ! CHECK-SAME:                                           %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "p"},
 ! CHECK-SAME:                                           %[[VAL_1:.*]]: !fir.ref<i32> {fir.bindc_name = "d"}) {
-! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {bindc_name = "res", uniq_name = "_QFselected_real_kind_test_pdEres"}
-! CHECK:         %[[VAL_3:.*]] = fir.absent !fir.ref<i1>
-! CHECK:         %[[VAL_6:.*]] = arith.constant 4 : i32
-! CHECK:         %[[VAL_7:.*]] = arith.constant 0 : i32
-! CHECK:         %[[VAL_8:.*]] = arith.constant 4 : i32
-! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<i32>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<i1>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<i32>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_13:.*]] = fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %[[VAL_10]], %[[VAL_6]], %[[VAL_11]], %[[VAL_7]], %[[VAL_12]], %[[VAL_8]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
-! CHECK:         fir.store %[[VAL_13]] to %[[VAL_2]] : !fir.ref<i32>
+! CHECK:         fir.absent !fir.ref<i1>
+! CHECK:         arith.constant 0 : i32
+! CHECK:         fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
+! CHECK:         hlfir.assign %{{.*}} to %{{.*}} : i32, !fir.ref<i32>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -154,16 +112,10 @@ end
 ! CHECK-LABEL: func.func @_QPselected_real_kind_test_pr(
 ! CHECK-SAME:                                           %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "p"},
 ! CHECK-SAME:                                           %[[VAL_1:.*]]: !fir.ref<i32> {fir.bindc_name = "r"}) {
-! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {bindc_name = "res", uniq_name = "_QFselected_real_kind_test_prEres"}
-! CHECK:         %[[VAL_3:.*]] = fir.absent !fir.ref<i1>
-! CHECK:         %[[VAL_6:.*]] = arith.constant 4 : i32
-! CHECK:         %[[VAL_7:.*]] = arith.constant 4 : i32
-! CHECK:         %[[VAL_8:.*]] = arith.constant 0 : i32
-! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<i32>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<i32>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<i1>) -> !fir.llvm_ptr<i8>
-! CHECK:         %[[VAL_13:.*]] = fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %[[VAL_10]], %[[VAL_6]], %[[VAL_11]], %[[VAL_7]], %[[VAL_12]], %[[VAL_8]]) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
-! CHECK:         fir.store %[[VAL_13]] to %[[VAL_2]] : !fir.ref<i32>
+! CHECK:         fir.absent !fir.ref<i1>
+! CHECK:         arith.constant 0 : i32
+! CHECK:         fir.call @_FortranASelectedRealKind(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (!fir.ref<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32, !fir.llvm_ptr<i8>, i32) -> i32
+! CHECK:         hlfir.assign %{{.*}} to %{{.*}} : i32, !fir.ref<i32>
 ! CHECK:         return
 ! CHECK:       }
 


### PR DESCRIPTION
Tests converted from test/Lower/Intrinsics: same_type_as.f9, scan.f90, scan.f90, selected_int_kind.f90, selected_real_kind.f90