### PR TITLE
[C++20] [Modules] Fix thread_local variable handling in modules

### DIFF
--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -361,7 +361,8 @@ namespace clang {
 // compilation of that unit, not by its users. (Inline variables are still
 // emitted in module users.)
 static bool shouldVarGenerateHereOnly(const VarDecl *VD) {
-  if (VD->getStorageDuration() != SD_Static)
+  if (VD->getStorageDuration() != SD_Static &&
+      VD->getStorageDuration() != SD_Thread)
     return false;
 
   if (VD->getDescribedVarTemplate())

--- a/clang/test/Modules/pr189415.cppm
+++ b/clang/test/Modules/pr189415.cppm
@@ -1,0 +1,34 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+// 
+// RUN: %clang_cc1 -std=c++20 %t/counter.cppm -triple %itanium_abi_triple \
+// RUN:   -emit-reduced-module-interface -o %t/counter.pcm
+// RUN: %clang_cc1 -std=c++20 %t/user.cpp -triple %itanium_abi_triple -fprebuilt-module-path=%t \
+// RUN:   -disable-llvm-passes -emit-llvm -o - | FileCheck %s
+
+//--- counter.cppm
+export module counter;
+
+namespace counter {
+
+// Works without thread_local or with inline keyword
+thread_local int next = 1;
+
+export inline auto get_next() noexcept -> int
+{
+    return next++;
+}
+
+}
+
+//--- user.cpp
+import counter;
+
+auto user() -> int
+{
+    return counter::get_next();
+}
+
+// CHECK: @_ZN7counterW7counter4nextE = external {{.*}}thread_local {{.*}}global
+


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/issues/189415

The function shouldVarGenerateHereOnly should also handle thread_local variables, not just static variables. This fixes incorrect code generation for thread_local variables in named modules.