### PR TITLE
[RISCV] Add assertions to VSETVLIInfo::hasSEWLMULRatioOnly(). NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVVSETVLIInfoAnalysis.h
+++ b/llvm/lib/Target/RISCV/RISCVVSETVLIInfoAnalysis.h
@@ -268,7 +268,11 @@ public:
     }
   }
 
-  bool hasSEWLMULRatioOnly() const { return SEWLMULRatioOnly; }
+  bool hasSEWLMULRatioOnly() const {
+    assert(isValid() && !isUnknown() &&
+           "Can't use VTYPE for uninitialized or unknown");
+    return SEWLMULRatioOnly;
+  }
 
   unsigned getSEW() const {
     assert(isValid() && !isUnknown() && !hasSEWLMULRatioOnly() &&


### PR DESCRIPTION
Ensure that we can only call this on valid and not unknown.