### PR TITLE
[mlir][CSE] Fix double-counting of numCSE statistic

### DIFF
--- a/mlir/lib/Transforms/CSE.cpp
+++ b/mlir/lib/Transforms/CSE.cpp
@@ -298,7 +298,6 @@ LogicalResult CSEDriver::simplifyOperation(ScopedMapTy &knownValues,
   // Look for an existing definition for the operation.
   if (auto *existing = knownValues.lookup(op)) {
     replaceUsesAndDelete(knownValues, op, existing, hasSSADominance);
-    ++numCSE;
     return success();
   }
 


### PR DESCRIPTION
This PR fixes a regression where the numCSE statistic was being incremented twice for a single operation elimination. The numCSE counter is already internally incremented within the replaceUsesAndDelete function. Manually incrementing it again after the function call leads to an inaccurate total count. This is part of the https://github.com/llvm/llvm-project/pull/180556.