### PR TITLE
[libc][hdrgen] Extend guard attribute support for types

### DIFF
--- a/libc/utils/hdrgen/hdrgen/header.py
+++ b/libc/utils/hdrgen/hdrgen/header.py
@@ -10,7 +10,6 @@ import re
 from functools import reduce
 from pathlib import PurePosixPath
 
-
 STDINT_SIZES = [
     "16",
     "32",
@@ -175,6 +174,7 @@ class HeaderFile:
                     PurePosixPath("llvm-libc-types") / f"{typ.name}.h",
                 )
                 for typ in self.all_types()
+                if typ.guard is None
             }
             | {
                 PurePosixPath("llvm-libc-macros") / f"{attr.split('(')[0]}.h"
@@ -239,7 +239,7 @@ class HeaderFile:
         # It's implicitly emitted here when using the default template so
         # it can get the right relative path.  Custom template files should
         # all have it explicitly with their right particular relative path.
-        return [
+        content = [
             f"#include {file}"
             for file in ([f'"{relpath(COMMON_HEADER)!s}"'] if with_common else [])
             + sorted(
@@ -247,6 +247,38 @@ class HeaderFile:
                 for file in self.includes()
             )
         ]
+
+        # Add guarded types
+        seen_guard = False
+        current_guard = None
+        for typ in sorted(self.types):
+            path = COMPILER_HEADER_TYPES.get(
+                typ.name,
+                PurePosixPath("llvm-libc-types") / f"{typ.name}.h",
+            )
+            if not seen_guard and typ.guard is not None:
+                seen_guard = True
+                content.append("")
+            if typ.guard is None:
+                continue
+            if current_guard is None:
+                current_guard = typ.guard
+                content.append(f"#ifdef {current_guard}")
+                content.append(f'#include "{relpath(path)!s}"')
+            elif current_guard == typ.guard:
+                content.append(f'#include "{relpath(path)!s}"')
+            else:
+                content.append(f"#endif // {current_guard}")
+                content.append("")
+                current_guard = typ.guard
+                if current_guard is not None:
+                    content.append(f"#ifdef {current_guard}")
+                content.append(f'#include "{relpath(path)!s}"')
+        if current_guard is not None:
+            content.append(f"#endif // {current_guard}")
+            content.append("")
+
+        return content
 
     def macro_lines(self):
         content = []

--- a/libc/utils/hdrgen/hdrgen/type.py
+++ b/libc/utils/hdrgen/hdrgen/type.py
@@ -10,6 +10,7 @@ from hdrgen.symbol import Symbol
 
 
 class Type(Symbol):
-    # A type so far carries no specific information beyond its name.
-    def __init__(self, name):
+    # A type carries its name and an optional guard.
+    def __init__(self, name, guard=None):
         super().__init__(name)
+        self.guard = guard

--- a/libc/utils/hdrgen/hdrgen/yaml_to_classes.py
+++ b/libc/utils/hdrgen/hdrgen/yaml_to_classes.py
@@ -52,7 +52,21 @@ def yaml_to_classes(yaml_data, header_class, entry_points=None):
     types = yaml_data.get("types", [])
     sorted_types = sorted(types, key=lambda x: x["type_name"])
     for type_data in sorted_types:
-        header.add_type(Type(type_data["type_name"]))
+        type_name = type_data["type_name"]
+        type_guard = type_data.get("guard")
+        # If a type has a guard, the macro it references must exist in
+        # the same yaml file with a macro_header attribute.
+        if type_guard is not None and not any(
+            macro_data["macro_name"] == type_guard
+            and "macro_header" in macro_data
+            for macro_data in yaml_data.get("macros", [])
+        ):
+            raise ValueError(
+                f"Type '{type_name}' has guard '{type_guard}' but no macro with "
+                f"macro_header '{type_guard}' was found in this file."
+            )
+
+        header.add_type(Type(type_name, type_guard))
 
     for enum_data in yaml_data.get("enums", []):
         header.add_enumeration(

--- a/libc/utils/hdrgen/tests/expected_output/type_guarding.h
+++ b/libc/utils/hdrgen/tests/expected_output/type_guarding.h
@@ -1,0 +1,22 @@
+//===-- Standard C header <type_guarding.h> --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef _LLVM_LIBC_TYPE_GUARDING_H
+#define _LLVM_LIBC_TYPE_GUARDING_H
+
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/size_t-macro.h"
+#include "llvm-libc-types/myType.h"
+#include <stdint.h>
+
+#ifdef LIBC_TYPES_HAS_SIZE_T
+#include "llvm-libc-types/size_t.h"
+#include "llvm-libc-types/ssize_t.h"
+#endif // LIBC_TYPES_HAS_SIZE_T
+
+#endif // _LLVM_LIBC_TYPE_GUARDING_H

--- a/libc/utils/hdrgen/tests/expected_output/type_guarding_mixed.h
+++ b/libc/utils/hdrgen/tests/expected_output/type_guarding_mixed.h
@@ -1,0 +1,27 @@
+//===-- Standard C header <type_guarding_mixed.h> --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef _LLVM_LIBC_TYPE_GUARDING_MIXED_H
+#define _LLVM_LIBC_TYPE_GUARDING_MIXED_H
+
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/float16-macro.h"
+#include "llvm-libc-macros/size_t-macro.h"
+#include "llvm-libc-types/myType.h"
+#include <stdint.h>
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+#include "llvm-libc-types/float16.h"
+#endif // LIBC_TYPES_HAS_FLOAT16
+
+#ifdef LIBC_TYPES_HAS_SIZE_T
+#include "llvm-libc-types/size_t.h"
+#include "llvm-libc-types/ssize_t.h"
+#endif // LIBC_TYPES_HAS_SIZE_T
+
+#endif // _LLVM_LIBC_TYPE_GUARDING_MIXED_H

--- a/libc/utils/hdrgen/tests/input/type_guarding.yaml
+++ b/libc/utils/hdrgen/tests/input/type_guarding.yaml
@@ -1,0 +1,15 @@
+header: type_guarding.h
+standards:
+  - stdc
+
+macros:
+  - macro_name: LIBC_TYPES_HAS_SIZE_T
+    macro_header: size_t-macro.h
+
+types:
+  - type_name: size_t
+    guard: LIBC_TYPES_HAS_SIZE_T
+  - type_name: ssize_t
+    guard: LIBC_TYPES_HAS_SIZE_T
+  - type_name: uint8_t
+  - type_name: myType

--- a/libc/utils/hdrgen/tests/input/type_guarding_invalid_macro.yaml
+++ b/libc/utils/hdrgen/tests/input/type_guarding_invalid_macro.yaml
@@ -1,0 +1,17 @@
+header: type_guarding_invalid_macro.h
+standards:
+  - stdc
+
+macros:
+  - macro_name: LIBC_TYPES_HAS_SIZE_T
+    macro_header: size_t-macro.h
+  - macro_name: MY_TYPES_GUARD
+
+types:
+  - type_name: size_t
+    guard: LIBC_TYPES_HAS_SIZE_T
+  - type_name: ssize_t
+    guard: LIBC_TYPES_HAS_SIZE_T
+  - type_name: uint8_t
+  - type_name: myType
+    guard: MY_TYPES_GUARD

--- a/libc/utils/hdrgen/tests/input/type_guarding_mixed.yaml
+++ b/libc/utils/hdrgen/tests/input/type_guarding_mixed.yaml
@@ -1,0 +1,19 @@
+header: type_guarding_mixed.h
+standards:
+  - stdc
+
+macros:
+  - macro_name: LIBC_TYPES_HAS_SIZE_T
+    macro_header: size_t-macro.h
+  - macro_name: LIBC_TYPES_HAS_FLOAT16
+    macro_header: float16-macro.h
+
+types:
+  - type_name: size_t
+    guard: LIBC_TYPES_HAS_SIZE_T
+  - type_name: ssize_t
+    guard: LIBC_TYPES_HAS_SIZE_T
+  - type_name: float16
+    guard: LIBC_TYPES_HAS_FLOAT16
+  - type_name: uint8_t
+  - type_name: myType

--- a/libc/utils/hdrgen/tests/test_integration.py
+++ b/libc/utils/hdrgen/tests/test_integration.py
@@ -96,6 +96,27 @@ class TestHeaderGenIntegration(unittest.TestCase):
         self.run_script(yaml_file, output_file)
         self.compare_files(output_file, expected_output_file)
 
+    def test_type_guarding(self):
+        yaml_file = self.source_dir / "input/type_guarding.yaml"
+        expected_output_file = self.source_dir / "expected_output/type_guarding.h"
+        output_file = self.output_dir / "type_guarding.h"
+        self.run_script(yaml_file, output_file)
+        self.compare_files(output_file, expected_output_file)
+
+    def test_type_guarding_mixed(self):
+        yaml_file = self.source_dir / "input/type_guarding_mixed.yaml"
+        expected_output_file = self.source_dir / "expected_output/type_guarding_mixed.h"
+        output_file = self.output_dir / "type_guarding_mixed.h"
+        self.run_script(yaml_file, output_file)
+        self.compare_files(output_file, expected_output_file)
+
+    def test_type_guarding_invalid_macro(self):
+        yaml_file = self.source_dir / "input/type_guarding_invalid_macro.yaml"
+        output_file = self.output_dir / "type_guarding_invalid_macro.h"
+        with self.assertRaises(subprocess.CalledProcessError):
+            self.run_script(yaml_file, output_file)
+
+
 def main():
     parser = argparse.ArgumentParser(description="TestHeaderGenIntegration arguments")
     parser.add_argument(


### PR DESCRIPTION
Closes #187404 
- Add guard field to Type class
- Parse guard from yaml in yaml_to_classes.py
- Emit #ifdef/#endif for guarded types in include_lines()
- Validate that guard macros have macro_header in same yaml file
- Add integration tests for type guarding
