### PR TITLE
[clang][bytecode] Disable tail calls on sparc

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -41,7 +41,7 @@ using namespace clang::interp;
 // to handle the way we use tailcalls.
 // PPC can't tail-call external calls, which is a problem for InterpNext.
 #if defined(_MSC_VER) || defined(__powerpc__) || !defined(MUSTTAIL) ||         \
-    defined(__i386__)
+    defined(__i386__) || defined(__sparc__)
 #undef MUSTTAIL
 #define MUSTTAIL
 #define USE_TAILCALLS 0


### PR DESCRIPTION
Looks like this causes problems there as well:
https://lab.llvm.org/buildbot/#/builders/114/builds/252

Interp.cpp:2572:21: error: cannot tail-call: target is not able to optimize the call into a sibling call
 2572 |   MUSTTAIL return Fn(S, PC);
      |                   ~~^~~~~~~