### PR TITLE
[lldb/test] Codesign executables built with custom Makefile rules

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -728,6 +728,13 @@ include $(wildcard $(PREREQS) $(DYLIB_PREREQS))
 .PHONY: clean
 dsym:	$(DSYM)
 all:	$(EXE) $(DSYM)
+ifneq "$(CODESIGN)" ""
+	@for bin in $(EXE) a.out; do \
+		if [ -n "$$bin" ] && [ -f "$$bin" ]; then \
+			$(CODESIGN) -s -f - "$$bin" 2>/dev/null || true; \
+		fi; \
+	done
+endif
 clean::
 ifeq "$(findstring lldb-test-build.noindex, $(BUILDDIR))" ""
 	$(error Trying to invoke the clean rule, but not using the default build tree layout)


### PR DESCRIPTION
Tests with custom a.out targets in their Makefile (i.e. `TestBSDArchives.py`) bypass the standard Makefile.rules linking step where `CODESIGN` is applied. This leaves the binary unsigned, causing the process to get kill it on remote darwin devices.

This adds a codesigning step to the all target in Makefile.rules that signs both $(EXE) and a.out if they exist. This ensures all test binaries are signed regardless of how they were built.

rdar://173840592