### PR TITLE
[ADT] Align `GenericCycle::getExitBlocks`/`getExitingBlocks` methods with LoopBase

### DIFF
--- a/llvm/include/llvm/ADT/GenericCycleImpl.h
+++ b/llvm/include/llvm/ADT/GenericCycleImpl.h
@@ -48,36 +48,33 @@ template <typename ContextT>
 void GenericCycle<ContextT>::getExitBlocks(
     SmallVectorImpl<BlockT *> &TmpStorage) const {
   if (!ExitBlocksCache.empty()) {
-    TmpStorage = ExitBlocksCache;
+    TmpStorage.append(ExitBlocksCache.begin(), ExitBlocksCache.end());
     return;
   }
 
-  TmpStorage.clear();
-
   size_t NumExitBlocks = 0;
   for (BlockT *Block : blocks()) {
-    llvm::append_range(TmpStorage, successors(Block));
+    llvm::append_range(ExitBlocksCache, successors(Block));
 
-    for (size_t Idx = NumExitBlocks, End = TmpStorage.size(); Idx < End;
+    for (size_t Idx = NumExitBlocks, End = ExitBlocksCache.size(); Idx < End;
          ++Idx) {
-      BlockT *Succ = TmpStorage[Idx];
+      BlockT *Succ = ExitBlocksCache[Idx];
       if (!contains(Succ)) {
-        auto ExitEndIt = TmpStorage.begin() + NumExitBlocks;
-        if (std::find(TmpStorage.begin(), ExitEndIt, Succ) == ExitEndIt)
-          TmpStorage[NumExitBlocks++] = Succ;
+        auto ExitEndIt = ExitBlocksCache.begin() + NumExitBlocks;
+        if (std::find(ExitBlocksCache.begin(), ExitEndIt, Succ) == ExitEndIt)
+          ExitBlocksCache[NumExitBlocks++] = Succ;
       }
     }
 
-    TmpStorage.resize(NumExitBlocks);
+    ExitBlocksCache.resize(NumExitBlocks);
   }
-  ExitBlocksCache.append(TmpStorage.begin(), TmpStorage.end());
+
+  TmpStorage.append(ExitBlocksCache.begin(), ExitBlocksCache.end());
 }
 
 template <typename ContextT>
 void GenericCycle<ContextT>::getExitingBlocks(
     SmallVectorImpl<BlockT *> &TmpStorage) const {
-  TmpStorage.clear();
-
   for (BlockT *Block : blocks()) {
     for (BlockT *Succ : successors(Block)) {
       if (!contains(Succ)) {

--- a/llvm/unittests/Analysis/CFGTest.cpp
+++ b/llvm/unittests/Analysis/CFGTest.cpp
@@ -517,3 +517,23 @@ TEST_F(IsPotentiallyReachableTest, UnreachableToReachable) {
                 "}");
   ExpectPath(true);
 }
+
+TEST_F(IsPotentiallyReachableTest, CycleExitBlocksSelfLoop) {
+  ParseAssembly("define void @test() {\n"
+                "entry:\n"
+                "  br label %loop.header\n"
+                "loop.header:\n"
+                "  %A = bitcast i32 0 to i32\n"
+                "  br i1 undef, label %loop.latch, label %loop.exit\n"
+                "loop.latch:\n"
+                "  br label %loop.header\n"
+                "loop.exit:\n"
+                "  br i1 undef, label %exit, label %loop.body\n"
+                "loop.body:\n"
+                "  br label %loop.body\n"
+                "exit:\n"
+                "  %B = bitcast i32 0 to i32\n"
+                "  ret void\n"
+                "}");
+  ExpectPath(true);
+}


### PR DESCRIPTION
Ensure `GenericCycle::getExitBlocks` does not replace the content of the output vector and behaves as `LoopBase::getExitBlocks`, previously exposing an issue within `isPotentiallyReachable`.

Fixes: https://github.com/llvm/llvm-project/issues/189800.
Fixes: https://github.com/llvm/llvm-project/issues/189289.
Fixes: https://github.com/llvm/llvm-project/issues/189234.
Fixes: https://github.com/llvm/llvm-project/issues/189180.