### PR TITLE
[IR] Remove Value::HasMetadata

### DIFF
--- a/llvm/include/llvm/IR/GlobalObject.h
+++ b/llvm/include/llvm/IR/GlobalObject.h
@@ -144,9 +144,42 @@ public:
   using Value::eraseMetadata;
   using Value::eraseMetadataIf;
   using Value::getAllMetadata;
-  using Value::getMetadata;
-  using Value::hasMetadata;
   using Value::setMetadata;
+
+  /// Return true if this GlobalObject has any metadata attached to it.
+  bool hasMetadata() const { return MetadataIndex != 0; }
+
+  /// Return true if this instruction has the given type of metadata attached.
+  bool hasMetadata(unsigned KindID) const {
+    return getMetadata(KindID) != nullptr;
+  }
+
+  /// Return true if this instruction has the given type of metadata attached.
+  bool hasMetadata(StringRef Kind) const {
+    return getMetadata(Kind) != nullptr;
+  }
+
+  /// Get the metadata of given kind attached to this GlobalObject.
+  /// If the metadata is not found then return null.
+  MDNode *getMetadata(unsigned KindID) const {
+    return hasMetadata() ? getMetadataImpl(KindID) : nullptr;
+  }
+
+  /// Get the metadata of given kind attached to this GlobalObject.
+  /// If the metadata is not found then return null.
+  MDNode *getMetadata(StringRef Kind) const {
+    return hasMetadata() ? Value::getMetadata(Kind) : nullptr;
+  }
+
+  /// Appends all attachments with the given ID to \c MDs in insertion order.
+  /// If the Value has no attachments with the given ID, or if ID is invalid,
+  /// leaves MDs unchanged.
+  /// @{
+  LLVM_ABI void getMetadata(unsigned KindID,
+                            SmallVectorImpl<MDNode *> &MDs) const;
+  LLVM_ABI void getMetadata(StringRef Kind,
+                            SmallVectorImpl<MDNode *> &MDs) const;
+  /// @}
 
   LLVM_ABI bool hasMetadataOtherThanDebugLoc() const;
 

--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -439,7 +439,7 @@ public:
   //===--------------------------------------------------------------------===//
 
   /// Return true if this instruction has any metadata attached to it.
-  bool hasMetadata() const { return DbgLoc || Value::hasMetadata(); }
+  bool hasMetadata() const { return DbgLoc || MetadataIndex != 0; }
 
   // Return true if this instruction contains loop metadata other than
   // a debug location
@@ -447,7 +447,7 @@ public:
 
   /// Return true if this instruction has metadata attached to it other than a
   /// debug location.
-  bool hasMetadataOtherThanDebugLoc() const { return Value::hasMetadata(); }
+  bool hasMetadataOtherThanDebugLoc() const { return MetadataIndex != 0; }
 
   /// Return true if this instruction has the given type of metadata attached.
   bool hasMetadata(unsigned KindID) const {
@@ -465,7 +465,8 @@ public:
     // Handle 'dbg' as a special case since it is not stored in the hash table.
     if (KindID == LLVMContext::MD_dbg)
       return DbgLoc.getAsMDNode();
-    return Value::getMetadata(KindID);
+    return hasMetadataOtherThanDebugLoc() ? Value::getMetadataImpl(KindID)
+                                          : nullptr;
   }
 
   /// Get the metadata of given kind attached to this Instruction.

--- a/llvm/include/llvm/IR/Value.h
+++ b/llvm/include/llvm/IR/Value.h
@@ -105,13 +105,12 @@ protected:
   ///
   /// Note, this should *NOT* be used directly by any class other than User.
   /// User uses this value to find the Use list.
-  enum : unsigned { NumUserOperandsBits = 27 };
+  enum : unsigned { NumUserOperandsBits = 28 };
   unsigned NumUserOperands : NumUserOperandsBits;
 
   // Use the same type as the bitfield above so that MSVC will pack them.
   unsigned IsUsedByMD : 1;
   unsigned HasName : 1;
-  unsigned HasMetadata : 1; // Has metadata attached to this?
   unsigned HasHungOffUses : 1;
   unsigned HasDescriptor : 1;
 
@@ -574,12 +573,7 @@ protected:
   /// These functions require that the value have at most a single attachment
   /// of the given kind, and return \c nullptr if such an attachment is missing.
   /// @{
-  MDNode *getMetadata(unsigned KindID) const {
-    if (!HasMetadata)
-      return nullptr;
-    return getMetadataImpl(KindID);
-  }
-  LLVM_ABI MDNode *getMetadata(StringRef Kind) const;
+  LLVM_ABI MDNode *getMetadata(StringRef Kind) const LLVM_READONLY;
   /// @}
 
 private:
@@ -587,35 +581,12 @@ private:
   LLVM_ABI unsigned &getMetadataIndex();
 
 protected:
-  /// Appends all attachments with the given ID to \c MDs in insertion order.
-  /// If the Value has no attachments with the given ID, or if ID is invalid,
-  /// leaves MDs unchanged.
-  /// @{
-  LLVM_ABI void getMetadata(unsigned KindID,
-                            SmallVectorImpl<MDNode *> &MDs) const;
-  LLVM_ABI void getMetadata(StringRef Kind,
-                            SmallVectorImpl<MDNode *> &MDs) const;
-  /// @}
-
   /// Appends all metadata attached to this value to \c MDs, sorting by
   /// KindID. The first element of each pair returned is the KindID, the second
   /// element is the metadata value. Attachments with the same ID appear in
   /// insertion order.
   LLVM_ABI void
   getAllMetadata(SmallVectorImpl<std::pair<unsigned, MDNode *>> &MDs) const;
-
-  /// Return true if this value has any metadata attached to it.
-  bool hasMetadata() const { return (bool)HasMetadata; }
-
-  /// Return true if this value has the given type of metadata attached.
-  /// @{
-  bool hasMetadata(unsigned KindID) const {
-    return getMetadata(KindID) != nullptr;
-  }
-  bool hasMetadata(StringRef Kind) const {
-    return getMetadata(Kind) != nullptr;
-  }
-  /// @}
 
   /// Set a particular kind of metadata attachment.
   ///
@@ -646,7 +617,7 @@ protected:
   /// Get metadata for the given kind, if any.
   /// This is an internal function that must only be called after
   /// checking that `hasMetadata()` returns true.
-  LLVM_ABI MDNode *getMetadataImpl(unsigned KindID) const;
+  LLVM_ABI MDNode *getMetadataImpl(unsigned KindID) const LLVM_READONLY;
 
 public:
   /// Return true if this value is a swifterror value.

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -105,7 +105,13 @@ void GlobalValue::eraseFromParent() {
   llvm_unreachable("not a global");
 }
 
-GlobalObject::~GlobalObject() { setComdat(nullptr); }
+GlobalObject::~GlobalObject() {
+  // Remove associated metadata from context.
+  if (hasMetadata())
+    clearMetadata();
+
+  setComdat(nullptr);
+}
 
 bool GlobalValue::isInterposable() const {
   if (isInterposableLinkage(getLinkage()))

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -74,9 +74,14 @@ Instruction::~Instruction() {
   if (isUsedByMetadata())
     ValueAsMetadata::handleRAUW(this, PoisonValue::get(getType()));
 
-  // Explicitly remove DIAssignID metadata to clear up ID -> Instruction(s)
-  // mapping in LLVMContext.
-  setMetadata(LLVMContext::MD_DIAssignID, nullptr);
+  // Remove associated metadata from context.
+  if (hasMetadata()) {
+    // Explicitly remove DIAssignID metadata to clear up ID -> Instruction(s)
+    // mapping in LLVMContext.
+    // TODO: still needed?
+    setMetadata(LLVMContext::MD_DIAssignID, nullptr);
+    clearMetadata();
+  }
 }
 
 const Module *Instruction::getModule() const {

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -78,8 +78,7 @@ Instruction::~Instruction() {
   if (hasMetadata()) {
     // Explicitly remove DIAssignID metadata to clear up ID -> Instruction(s)
     // mapping in LLVMContext.
-    // TODO: still needed?
-    setMetadata(LLVMContext::MD_DIAssignID, nullptr);
+    updateDIAssignIDMapping(nullptr);
     clearMetadata();
   }
 }

--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -1558,8 +1558,6 @@ unsigned Value::getMetadataIndex() const {
 }
 
 MDNode *Value::getMetadata(StringRef Kind) const {
-  if (!hasMetadata())
-    return nullptr;
   unsigned KindID = getContext().getMDKindID(Kind);
   return getMetadataImpl(KindID);
 }
@@ -1576,9 +1574,10 @@ MDNode *Value::getMetadataImpl(unsigned KindID) const {
   return nullptr;
 }
 
-void Value::getMetadata(unsigned KindID, SmallVectorImpl<MDNode *> &MDs) const {
+void GlobalObject::getMetadata(unsigned KindID,
+                               SmallVectorImpl<MDNode *> &MDs) const {
   const LLVMContext &Ctx = getContext();
-  unsigned Idx = getMetadataIndex();
+  unsigned Idx = MetadataIndex;
   while (Idx) {
     const MDAttachment &A = Ctx.pImpl->Metadatas[Idx];
     if (A.MDKind == KindID)
@@ -1589,7 +1588,8 @@ void Value::getMetadata(unsigned KindID, SmallVectorImpl<MDNode *> &MDs) const {
   std::reverse(MDs.begin(), MDs.end());
 }
 
-void Value::getMetadata(StringRef Kind, SmallVectorImpl<MDNode *> &MDs) const {
+void GlobalObject::getMetadata(StringRef Kind,
+                               SmallVectorImpl<MDNode *> &MDs) const {
   getMetadata(getContext().getMDKindID(Kind), MDs);
 }
 
@@ -1613,20 +1613,17 @@ void Value::getAllMetadata(
 void Value::setMetadata(unsigned KindID, MDNode *Node) {
   assert(isa<Instruction>(this) || isa<GlobalObject>(this));
 
-  eraseMetadata(KindID);
+  if (getMetadataIndex() != 0)
+    eraseMetadata(KindID);
   if (Node)
     addMetadata(KindID, *Node);
 }
 
 void Value::setMetadata(StringRef Kind, MDNode *Node) {
-  if (!Node && !HasMetadata)
-    return;
   setMetadata(getContext().getMDKindID(Kind), Node);
 }
 
 void Value::addMetadata(unsigned KindID, MDNode &MD) {
-  if (!HasMetadata)
-    HasMetadata = true;
   const LLVMContext &Ctx = getContext();
   unsigned &Idx = getMetadataIndex();
   unsigned NewIdx = Ctx.pImpl->MetadataRecycleHead;
@@ -1677,8 +1674,6 @@ void Value::eraseMetadataIf(function_ref<bool(unsigned, MDNode *)> Pred) {
       Idx = &A.Next;
     }
   }
-  if (getMetadataIndex() == 0)
-    HasMetadata = false;
 }
 
 void Value::clearMetadata() {
@@ -1686,8 +1681,6 @@ void Value::clearMetadata() {
 }
 
 void Instruction::setMetadata(StringRef Kind, MDNode *Node) {
-  if (!Node && !hasMetadata())
-    return;
   setMetadata(getContext().getMDKindID(Kind), Node);
 }
 
@@ -1696,7 +1689,7 @@ MDNode *Instruction::getMetadataImpl(StringRef Kind) const {
   unsigned KindID = Ctx.getMDKindID(Kind);
   if (KindID == LLVMContext::MD_dbg)
     return DbgLoc.getAsMDNode();
-  return Value::getMetadata(KindID);
+  return Value::getMetadataImpl(KindID);
 }
 
 void Instruction::eraseMetadataIf(function_ref<bool(unsigned, MDNode *)> Pred) {
@@ -1707,7 +1700,7 @@ void Instruction::eraseMetadataIf(function_ref<bool(unsigned, MDNode *)> Pred) {
 }
 
 void Instruction::dropUnknownNonDebugMetadata(ArrayRef<unsigned> KnownIDs) {
-  if (!Value::hasMetadata())
+  if (!hasMetadataOtherThanDebugLoc())
     return; // Nothing to remove!
 
   SmallSet<unsigned, 32> KnownSet(llvm::from_range, KnownIDs);
@@ -1824,9 +1817,7 @@ void Instruction::addAnnotationMetadata(StringRef Name) {
 
 AAMDNodes Instruction::getAAMetadata() const {
   AAMDNodes Result;
-  // Not using Instruction::hasMetadata() because we're not interested in
-  // DebugInfoMetadata.
-  if (Value::hasMetadata()) {
+  if (hasMetadataOtherThanDebugLoc()) {
     unsigned Idx = MetadataIndex;
     const auto &Metadatas = getContext().pImpl->Metadatas;
     while (Idx) {

--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -1620,6 +1620,8 @@ void Value::setMetadata(unsigned KindID, MDNode *Node) {
 }
 
 void Value::setMetadata(StringRef Kind, MDNode *Node) {
+  if (!Node && getMetadataIndex() == 0)
+    return;
   setMetadata(getContext().getMDKindID(Kind), Node);
 }
 

--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -1683,6 +1683,8 @@ void Value::clearMetadata() {
 }
 
 void Instruction::setMetadata(StringRef Kind, MDNode *Node) {
+  if (!Node && MetadataIndex == 0)
+    return;
   setMetadata(getContext().getMDKindID(Kind), Node);
 }
 

--- a/llvm/lib/IR/Value.cpp
+++ b/llvm/lib/IR/Value.cpp
@@ -53,7 +53,7 @@ static inline Type *checkType(Type *Ty) {
 Value::Value(Type *ty, unsigned scid)
     : SubclassID(scid), HasValueHandle(0), SubclassOptionalData(0),
       SubclassData(0), NumUserOperands(0), IsUsedByMD(false), HasName(false),
-      HasMetadata(false), VTy(checkType(ty)) {
+      VTy(checkType(ty)) {
   static_assert(ConstantFirstVal == 0, "!(SubclassID < ConstantFirstVal)");
   // FIXME: Why isn't this in the subclass gunk??
   // Note, we cannot call isa<CallInst> before the CallInst has been
@@ -79,10 +79,6 @@ Value::~Value() {
     ValueHandleBase::ValueIsDeleted(this);
   if (isUsedByMetadata())
     ValueAsMetadata::handleDeletion(this);
-
-  // Remove associated metadata from context.
-  if (HasMetadata)
-    clearMetadata();
 
 #ifndef NDEBUG      // Only in -g mode...
   // Check to make sure that there are no uses of this value that are still
@@ -848,7 +844,8 @@ bool Value::canBeFreed() const {
       return false;
   }
 
-  if (isa<IntToPtrInst>(this) && getMetadata(LLVMContext::MD_nofree))
+  if (auto *ITP = dyn_cast<IntToPtrInst>(this);
+      ITP && ITP->hasMetadata(LLVMContext::MD_nofree))
     return false;
 
   const Function *F = nullptr;


### PR DESCRIPTION
Metadata already has two separate implementations, one for GlobalObject
and one for Instruction. Instruction was already separate due to special
MD_dbg handling, so move the GlobalObject-specific metadata parts from
Value to GlobalObject.

The HasMetadata bit, originally an optimization to avoid the hash table
lookup when a value has no metadata, is no longer needed, because the
information is now stored directly in Instruction/GlobalObject's
MetadataIndex field.

This also fixes MSan builds, currently ~Value clears metadata and
therefore needs to access the subclass's MetadataIndex field, which was
already destructed at this point.
