### PR TITLE
[IR] Fix C API after getTerminator() change

### DIFF
--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -2880,7 +2880,7 @@ LLVMValueRef LLVMGetBasicBlockParent(LLVMBasicBlockRef BB) {
 }
 
 LLVMValueRef LLVMGetBasicBlockTerminator(LLVMBasicBlockRef BB) {
-  return wrap(unwrap(BB)->getTerminator());
+  return wrap(unwrap(BB)->getTerminatorOrNull());
 }
 
 unsigned LLVMCountBasicBlocks(LLVMValueRef FnRef) {

--- a/llvm/tools/llvm-c-test/echo.cpp
+++ b/llvm/tools/llvm-c-test/echo.cpp
@@ -1119,6 +1119,8 @@ struct FunCloner {
 
     LLVMContextRef Ctx = LLVMGetModuleContext(M);
     LLVMBasicBlockRef BB = LLVMAppendBasicBlockInContext(Ctx, Fun, Name);
+    if (LLVMGetBasicBlockTerminator(BB) != nullptr)
+      report_fatal_error("Basic block must not have terminator");
     return BBMap[Src] = BB;
   }
 
@@ -1160,6 +1162,9 @@ struct FunCloner {
 
       Cur = Next;
     }
+
+    if (LLVMGetBasicBlockTerminator(BB) != LLVMGetLastInstruction(BB))
+      report_fatal_error("Basic block terminator mismatch");
 
     LLVMDisposeBuilder(Builder);
     return BB;


### PR DESCRIPTION
The C API function LLVMGetBasicBlockTerminator should return NULL when
the basic block is not well-formed.
