### PR TITLE
[PAC][clang] Use `Error` behavior for ptrauth module flags

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1383,12 +1383,12 @@ void CodeGenModule::Release() {
                                 "sign-return-address-with-bkey", 2);
 
     if (LangOpts.PointerAuthELFGOT)
-      getModule().addModuleFlag(llvm::Module::Min, "ptrauth-elf-got", 1);
+      getModule().addModuleFlag(llvm::Module::Error, "ptrauth-elf-got", 1);
 
     if (getTriple().isOSLinux()) {
       if (LangOpts.PointerAuthCalls)
-        getModule().addModuleFlag(llvm::Module::Min, "ptrauth-sign-personality",
-                                  1);
+        getModule().addModuleFlag(llvm::Module::Error,
+                                  "ptrauth-sign-personality", 1);
       assert(getTriple().isOSBinFormatELF());
       using namespace llvm::ELF;
       uint64_t PAuthABIVersion =

--- a/clang/test/CodeGen/ptrauth-module-flags.c
+++ b/clang/test/CodeGen/ptrauth-module-flags.c
@@ -4,10 +4,10 @@
 
 // ELFGOT:      !llvm.module.flags = !{
 // ELFGOT-SAME: !0
-// ELFGOT:      !0 = !{i32 8, !"ptrauth-elf-got", i32 1}
+// ELFGOT:      !0 = !{i32 1, !"ptrauth-elf-got", i32 1}
 
 // PERSONALITY:      !llvm.module.flags = !{
 // PERSONALITY-SAME: !0
-// PERSONALITY:      !0 = !{i32 8, !"ptrauth-sign-personality", i32 1}
+// PERSONALITY:      !0 = !{i32 1, !"ptrauth-sign-personality", i32 1}
 
 // OFF-NOT: "ptrauth-


### PR DESCRIPTION
Previous use of `Min` for `ptrauth-elf-got` and `ptrauth-sign-personality` module flags was introducing a risk of silent decrease of security during module merge. The previous choice for `Min` was mimicking the behavior for the `sign-return-address*` family of module flags, but it does not make sense to apply this behavior here.