### PR TITLE
[AArch64] Emit async PAuth epilogue CFI for outlined functions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
@@ -143,7 +143,9 @@ void AArch64PointerAuthImpl::authenticateLR(
     MachineFunction &MF, MachineBasicBlock::iterator MBBI) const {
   const AArch64FunctionInfo *MFnI = MF.getInfo<AArch64FunctionInfo>();
   bool UseBKey = MFnI->shouldSignWithBKey();
-  bool EmitAsyncCFI = MFnI->needsAsyncDwarfUnwindInfo(MF);
+  bool EmitAsyncCFI = MFnI->needsAsyncDwarfUnwindInfo(MF) ||
+                      (MFnI->needsDwarfUnwindInfo(MF) &&
+                       MF.getFunction().getUWTableKind() == UWTableKind::Async);
   bool NeedsWinCFI = MF.hasWinCFI();
 
   MachineBasicBlock &MBB = *MBBI->getParent();

--- a/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-sp-mod.mir
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-sp-mod.mir
@@ -203,4 +203,5 @@ body:             |
 # CHECK-NEXT:         $sp = frame-setup SUBXri $sp, 16, 0
 # CHECK:              $sp = frame-destroy ADDXri $sp, 16, 0
 # CHECK-NEXT:         frame-destroy AUTIASP implicit-def $lr, implicit $lr, implicit $sp
+# CHECK-NEXT:         frame-destroy CFI_INSTRUCTION negate_ra_sign_state
 # CHECK-NEXT:         RET $lr


### PR DESCRIPTION
Outlined functions are marked minsize and thus by needsAsyncDwarfUnwindInfo do not receive their necessary CFI marker negate_ra_state in async unwind.