### PR TITLE
[AArch64][llvm] Some instructions should be `HINT` aliases (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -3186,8 +3186,10 @@ void AArch64AsmPrinter::emitInstruction(const MachineInstr *MI) {
     if (CurrentPatchableFunctionEntrySym &&
         CurrentPatchableFunctionEntrySym == CurrentFnBegin &&
         MI == &MF->front().front()) {
-      int64_t Imm = MI->getOperand(0).getImm();
-      if ((Imm & 32) && (Imm & 6)) {
+      uint64_t Imm = MI->getOperand(0).getImm();
+      // Match only exact BTI encodings in HINT space.
+      if (Imm >= 32 && Imm < 64 &&
+          AArch64BTIHint::lookupBTIByEncoding(Imm ^ 32)) {
         MCInst Inst;
         MCInstLowering.Lower(MI, Inst);
         EmitToStreamer(*OutStreamer, Inst);

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -3202,8 +3202,10 @@ void AArch64AsmPrinter::emitInstruction(const MachineInstr *MI) {
     if (CurrentPatchableFunctionEntrySym &&
         CurrentPatchableFunctionEntrySym == CurrentFnBegin &&
         MI == &MF->front().front()) {
-      int64_t Imm = MI->getOperand(0).getImm();
-      if ((Imm & 32) && (Imm & 6)) {
+      uint64_t Imm = MI->getOperand(0).getImm();
+      // Match only exact BTI encodings in HINT space.
+      if (Imm >= 32 && Imm < 64 &&
+          AArch64BTIHint::lookupBTIByEncoding(Imm ^ 32)) {
         MCInst Inst;
         MCInstLowering.Lower(MI, Inst);
         EmitToStreamer(*OutStreamer, Inst);

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -3202,10 +3202,7 @@ void AArch64AsmPrinter::emitInstruction(const MachineInstr *MI) {
     if (CurrentPatchableFunctionEntrySym &&
         CurrentPatchableFunctionEntrySym == CurrentFnBegin &&
         MI == &MF->front().front()) {
-      uint64_t Imm = MI->getOperand(0).getImm();
-      // Match only exact BTI encodings in HINT space.
-      if (Imm >= 32 && Imm < 64 &&
-          AArch64BTIHint::lookupBTIByEncoding(Imm ^ 32)) {
+      if (AArch64BTIHint::isHintSpaceBTI(MI->getOperand(0).getImm())) {
         MCInst Inst;
         MCInstLowering.Lower(MI, Inst);
         EmitToStreamer(*OutStreamer, Inst);

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -1875,18 +1875,51 @@ def PHintInstOperand : AsmOperandClass {
 def phint_op : Operand<i32> {
     let ParserMatchClass = PHintInstOperand;
     let PrintMethod = "printPHintOp";
+    let MCOperandPredicate = [{
+      if (!MCOp.isImm())
+        return false;
+      return AArch64PHint::lookupPHintByEncoding(MCOp.getImm()) != nullptr;
+    }];
     let OperandType = "OPERAND_IMMEDIATE";
     let MIOperandInfo = (ops i32imm: $policy);
-    let DecoderMethod = "DecodeUImm<3>";
+    let DecoderMethod = "DecodeUImm<7>";
 }
 
-class STSHHI
-    : SimpleSystemI<0, (ins phint_op:$policy), "stshh", "\t$policy", []>,
-      Sched<[WriteHint]> {
-  bits<3> policy;
-  let Inst{20-12} = 0b000110010;
-  let Inst{11-8} = 0b0110;
-  let Inst{7-5} = policy;
+def TSBHintOperand : AsmOperandClass {
+    let Name = "TSBHint";
+    let ParserMethod = "tryParseTSBHintOperand";
+}
+
+def tsbhint_op : Operand<i32> {
+    let ParserMatchClass = TSBHintOperand;
+    let PrintMethod = "printTSBHintOp";
+    let MCOperandPredicate = [{
+      if (!MCOp.isImm() || MCOp.getImm() < 16)
+        return false;
+      return AArch64TSB::lookupTSBByEncoding(MCOp.getImm() - 16) != nullptr;
+    }];
+    let OperandType = "OPERAND_IMMEDIATE";
+    let MIOperandInfo = (ops i32imm: $policy);
+    let DecoderMethod = "DecodeUImm<7>";
+}
+
+def SHUHintOperand : AsmOperandClass {
+    let Name = "SHUHint";
+    let ParserMethod = "tryParseSHUHintOperand";
+}
+
+def shuhint_op : Operand<i32> {
+    let ParserMatchClass = SHUHintOperand;
+    let PrintMethod = "printSHUHintOp";
+    let MCOperandPredicate = [{
+      if (!MCOp.isImm() || MCOp.getImm() < 50)
+        return false;
+      return AArch64CMHPriorityHint::lookupCMHPriorityHintByEncoding(
+                 MCOp.getImm() - 50) != nullptr;
+    }];
+    let OperandType = "OPERAND_IMMEDIATE";
+    let MIOperandInfo = (ops i32imm: $priority);
+    let DecoderMethod = "DecodeUImm<7>";
 }
 
 // System instructions taking a single literal operand which encodes into
@@ -13587,37 +13620,6 @@ multiclass SIMDThreeSameVectorFP8MatrixMul<string asm, SDPatternOperator OpNode>
                                                (v16i8 V128:$Rm)))]> {
       let Predicates = [HasNEON, HasF8F32MM];
     }
-}
-
-//----------------------------------------------------------------------------
-// Contention Management Hints - FEAT_CMH
-//----------------------------------------------------------------------------
-
-class SHUHInst<string asm> : I<
-    (outs),
-    (ins CMHPriorityHint_op:$priority),
-    asm, "\t$priority", "", []>, Sched<[]> {
-  bits<1> priority;
-  let Inst{31-12} = 0b11010101000000110010;
-  let Inst{11-8}  = 0b0110;
-  let Inst{7-6}   = 0b01;
-  let Inst{5}     = priority;
-  let Inst{4-0}   = 0b11111;
-}
-
-multiclass SHUH<string asm> {
-  def NAME : SHUHInst<asm>;
-  def      : InstAlias<asm, (!cast<Instruction>(NAME) 0), 1>;
-}
-
-class STCPHInst<string asm> : I<
-    (outs),
-    (ins),
-    asm, "", "", []>, Sched<[]> {
-    let Inst{31-12} = 0b11010101000000110010;
-    let Inst{11-8}  = 0b0110;
-    let Inst{7-5}   = 0b100;
-    let Inst{4-0}   = 0b11111;
 }
 
 //---

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -1861,60 +1861,36 @@ let mayStore = 1, mayLoad = 1, hasSideEffects = 1 in
     let Inst{11-5} = imm;
   }
 
-def PHintInstOperand : AsmOperandClass {
-    let Name = "PHint";
-    let ParserMethod = "tryParsePHintInstOperand";
+def PCDPHintOperand : AsmOperandClass {
+  let Name = "PCDPHint";
+  let ParserMethod = "tryParsePCDPHintOperand";
 }
 
-def phint_op : Operand<i32> {
-    let ParserMatchClass = PHintInstOperand;
-    let PrintMethod = "printPHintOp";
-    let MCOperandPredicate = [{
-      if (!MCOp.isImm() || MCOp.getImm() < 48)
-        return false;
-      return AArch64PHint::lookupPHintByEncoding(MCOp.getImm() - 48) != nullptr;
-    }];
-    let OperandType = "OPERAND_IMMEDIATE";
-    let MIOperandInfo = (ops i32imm: $policy);
-    let DecoderMethod = "DecodeUImm<7>";
-}
-
-def TSBHintOperand : AsmOperandClass {
-    let Name = "TSBHint";
-    let ParserMethod = "tryParseTSBHintOperand";
-}
-
-def tsbhint_op : Operand<i32> {
-    let ParserMatchClass = TSBHintOperand;
-    let PrintMethod = "printTSBHintOp";
-    let MCOperandPredicate = [{
-      if (!MCOp.isImm() || MCOp.getImm() < 16)
-        return false;
-      return AArch64TSBHint::lookupTSBHintByEncoding(MCOp.getImm() - 16) !=
-             nullptr;
-    }];
-    let OperandType = "OPERAND_IMMEDIATE";
-    let MIOperandInfo = (ops i32imm: $policy);
-    let DecoderMethod = "DecodeUImm<7>";
+def pcdphint_op : Operand<i32> {
+  let ParserMatchClass = PCDPHintOperand;
+  let PrintMethod = "printPCDPHintOp";
+  let MCOperandPredicate = [{
+    if (!MCOp.isImm() || MCOp.getImm() < 48)
+      return false;
+    return AArch64PCDPHint::lookupPCDPHintByEncoding(MCOp.getImm() - 48);
+  }];
+  let OperandType = "OPERAND_IMMEDIATE";
 }
 
 def SHUHintOperand : AsmOperandClass {
-    let Name = "SHUHint";
-    let ParserMethod = "tryParseSHUHintOperand";
+  let Name = "SHUHint";
+  let ParserMethod = "tryParseSHUHintOperand";
 }
 
 def shuhint_op : Operand<i32> {
-    let ParserMatchClass = SHUHintOperand;
-    let PrintMethod = "printSHUHintOp";
-    let MCOperandPredicate = [{
-      if (!MCOp.isImm() || MCOp.getImm() < 50)
-        return false;
-      return AArch64SHUHint::lookupSHUHintByEncoding(MCOp.getImm() - 50) !=
-             nullptr;
-    }];
-    let OperandType = "OPERAND_IMMEDIATE";
-    let MIOperandInfo = (ops i32imm: $priority);
-    let DecoderMethod = "DecodeUImm<7>";
+  let ParserMatchClass = SHUHintOperand;
+  let PrintMethod = "printSHUHintOp";
+  let MCOperandPredicate = [{
+    if (!MCOp.isImm() || MCOp.getImm() < 50)
+      return false;
+    return AArch64SHUHint::lookupSHUHintByEncoding(MCOp.getImm() - 50);
+  }];
+  let OperandType = "OPERAND_IMMEDIATE";
 }
 
 // System instructions taking a single literal operand which encodes into
@@ -1987,7 +1963,7 @@ def msr_sysreg_op : Operand<i32> {
 
 def PSBHintOperand : AsmOperandClass {
   let Name = "PSBHint";
-  let ParserMethod = "tryParsePSBHint";
+  let ParserMethod = "tryParsePSBHintOperand";
 }
 def psbhint_op : Operand<i32> {
   let ParserMatchClass = PSBHintOperand;
@@ -1995,16 +1971,34 @@ def psbhint_op : Operand<i32> {
   let MCOperandPredicate = [{
     // Check, if operand is valid, to fix exhaustive aliasing in disassembly.
     // "psb" is an alias to "hint" only for certain values of CRm:Op2 fields.
-    if (!MCOp.isImm())
+    if (!MCOp.isImm() || MCOp.getImm() < 16)
       return false;
-    return AArch64PSBHint::lookupPSBByEncoding(MCOp.getImm()) != nullptr;
+    return AArch64PSBHint::lookupPSBHintByEncoding(MCOp.getImm() - 16);
+  }];
+  let OperandType = "OPERAND_IMMEDIATE";
+}
+
+def TSBHintOperand : AsmOperandClass {
+  let Name = "TSBHint";
+  let ParserMethod = "tryParseTSBHintOperand";
+}
+
+def tsbhint_op : Operand<i32> {
+  let ParserMatchClass = TSBHintOperand;
+  let PrintMethod = "printTSBHintOp";
+  let MCOperandPredicate = [{
+    // Check, if operand is valid, to fix exhaustive aliasing in disassembly.
+    // "tsb" is an alias to "hint" only for certain values of CRm:Op2 fields.
+    if (!MCOp.isImm() || MCOp.getImm() < 16)
+      return false;
+    return AArch64TSBHint::lookupTSBHintByEncoding(MCOp.getImm() - 16);
   }];
   let OperandType = "OPERAND_IMMEDIATE";
 }
 
 def BTIHintOperand : AsmOperandClass {
   let Name = "BTIHint";
-  let ParserMethod = "tryParseBTIHint";
+  let ParserMethod = "tryParseBTIHintOperand";
 }
 def btihint_op : Operand<i32> {
   let ParserMatchClass = BTIHintOperand;
@@ -2014,22 +2008,6 @@ def btihint_op : Operand<i32> {
     if (!MCOp.isImm())
       return false;
     return AArch64BTIHint::isHintSpaceBTI(MCOp.getImm());
-  }];
-  let OperandType = "OPERAND_IMMEDIATE";
-}
-
-def CMHPriorityHintOperand : AsmOperandClass {
-  let Name = "CMHPriorityHint";
-  let ParserMethod = "tryParseCMHPriorityHint";
-}
-
-def CMHPriorityHint_op : Operand<i32> {
-  let ParserMatchClass = CMHPriorityHintOperand;
-  let PrintMethod = "printCMHPriorityHintOp";
-  let MCOperandPredicate = [{
-    if (!MCOp.isImm())
-      return false;
-    return AArch64CMHPriorityHint::lookupCMHPriorityHintByEncoding(MCOp.getImm()) != nullptr;
   }];
   let OperandType = "OPERAND_IMMEDIATE";
 }

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -1869,19 +1869,51 @@ def PHintInstOperand : AsmOperandClass {
 def phint_op : Operand<i32> {
     let ParserMatchClass = PHintInstOperand;
     let PrintMethod = "printPHintOp";
+    let MCOperandPredicate = [{
+      if (!MCOp.isImm())
+        return false;
+      return AArch64PHint::lookupPHintByEncoding(MCOp.getImm()) != nullptr;
+    }];
     let OperandType = "OPERAND_IMMEDIATE";
     let MIOperandInfo = (ops i32imm: $policy);
-    let DecoderMethod = "DecodeUImm<3>";
+    let DecoderMethod = "DecodeUImm<7>";
 }
 
-class STSHHI
-    : SimpleSystemI<0, (ins phint_op:$policy), "stshh", "\t$policy", []>,
-      Sched<[WriteHint]> {
-  bits<1> policy;
-  let Inst{20-12} = 0b000110010;
-  let Inst{11-8} = 0b0110;
-  let Inst{7-6} = 0b00;
-  let Inst{5} = policy;
+def TSBHintOperand : AsmOperandClass {
+    let Name = "TSBHint";
+    let ParserMethod = "tryParseTSBHintOperand";
+}
+
+def tsbhint_op : Operand<i32> {
+    let ParserMatchClass = TSBHintOperand;
+    let PrintMethod = "printTSBHintOp";
+    let MCOperandPredicate = [{
+      if (!MCOp.isImm() || MCOp.getImm() < 16)
+        return false;
+      return AArch64TSB::lookupTSBByEncoding(MCOp.getImm() - 16) != nullptr;
+    }];
+    let OperandType = "OPERAND_IMMEDIATE";
+    let MIOperandInfo = (ops i32imm: $policy);
+    let DecoderMethod = "DecodeUImm<7>";
+}
+
+def SHUHintOperand : AsmOperandClass {
+    let Name = "SHUHint";
+    let ParserMethod = "tryParseSHUHintOperand";
+}
+
+def shuhint_op : Operand<i32> {
+    let ParserMatchClass = SHUHintOperand;
+    let PrintMethod = "printSHUHintOp";
+    let MCOperandPredicate = [{
+      if (!MCOp.isImm() || MCOp.getImm() < 50)
+        return false;
+      return AArch64CMHPriorityHint::lookupCMHPriorityHintByEncoding(
+                 MCOp.getImm() - 50) != nullptr;
+    }];
+    let OperandType = "OPERAND_IMMEDIATE";
+    let MIOperandInfo = (ops i32imm: $priority);
+    let DecoderMethod = "DecodeUImm<7>";
 }
 
 // System instructions taking a single literal operand which encodes into
@@ -13598,37 +13630,6 @@ multiclass SIMDThreeSameVectorFP8MatrixMul<string asm, SDPatternOperator OpNode>
                                                (v16i8 V128:$Rm)))]> {
       let Predicates = [HasNEON, HasF8F32MM];
     }
-}
-
-//----------------------------------------------------------------------------
-// Contention Management Hints - FEAT_CMH
-//----------------------------------------------------------------------------
-
-class SHUHInst<string asm> : I<
-    (outs),
-    (ins CMHPriorityHint_op:$priority),
-    asm, "\t$priority", "", []>, Sched<[]> {
-  bits<1> priority;
-  let Inst{31-12} = 0b11010101000000110010;
-  let Inst{11-8}  = 0b0110;
-  let Inst{7-6}   = 0b01;
-  let Inst{5}     = priority;
-  let Inst{4-0}   = 0b11111;
-}
-
-multiclass SHUH<string asm> {
-  def NAME : SHUHInst<asm>;
-  def      : InstAlias<asm, (!cast<Instruction>(NAME) 0), 1>;
-}
-
-class STCPHInst<string asm> : I<
-    (outs),
-    (ins),
-    asm, "", "", []>, Sched<[]> {
-    let Inst{31-12} = 0b11010101000000110010;
-    let Inst{11-8}  = 0b0110;
-    let Inst{7-5}   = 0b100;
-    let Inst{4-0}   = 0b11111;
 }
 
 //---

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -1870,9 +1870,9 @@ def phint_op : Operand<i32> {
     let ParserMatchClass = PHintInstOperand;
     let PrintMethod = "printPHintOp";
     let MCOperandPredicate = [{
-      if (!MCOp.isImm())
+      if (!MCOp.isImm() || MCOp.getImm() < 48)
         return false;
-      return AArch64PHint::lookupPHintByEncoding(MCOp.getImm()) != nullptr;
+      return AArch64PHint::lookupPHintByEncoding(MCOp.getImm() - 48) != nullptr;
     }];
     let OperandType = "OPERAND_IMMEDIATE";
     let MIOperandInfo = (ops i32imm: $policy);
@@ -1890,7 +1890,8 @@ def tsbhint_op : Operand<i32> {
     let MCOperandPredicate = [{
       if (!MCOp.isImm() || MCOp.getImm() < 16)
         return false;
-      return AArch64TSB::lookupTSBByEncoding(MCOp.getImm() - 16) != nullptr;
+      return AArch64TSBHint::lookupTSBHintByEncoding(MCOp.getImm() - 16) !=
+             nullptr;
     }];
     let OperandType = "OPERAND_IMMEDIATE";
     let MIOperandInfo = (ops i32imm: $policy);
@@ -1908,8 +1909,8 @@ def shuhint_op : Operand<i32> {
     let MCOperandPredicate = [{
       if (!MCOp.isImm() || MCOp.getImm() < 50)
         return false;
-      return AArch64CMHPriorityHint::lookupCMHPriorityHintByEncoding(
-                 MCOp.getImm() - 50) != nullptr;
+      return AArch64SHUHint::lookupSHUHintByEncoding(MCOp.getImm() - 50) !=
+             nullptr;
     }];
     let OperandType = "OPERAND_IMMEDIATE";
     let MIOperandInfo = (ops i32imm: $priority);
@@ -2012,7 +2013,7 @@ def btihint_op : Operand<i32> {
     // "bti" is an alias to "hint" only for certain values of CRm:Op2 fields.
     if (!MCOp.isImm())
       return false;
-    return AArch64BTIHint::lookupBTIByEncoding(MCOp.getImm() ^ 32) != nullptr;
+    return AArch64BTIHint::isHintSpaceBTI(MCOp.getImm());
   }];
   let OperandType = "OPERAND_IMMEDIATE";
 }

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1564,7 +1564,10 @@ def NOP : SystemNoOperands<0b000, "hint\t#0">;
 
 def : InstAlias<"nop", (NOP)>;
 
-def STSHH: STSHHI;
+def : InstAlias<"stshh $policy", (HINT phint_op:$policy)>;
+def : InstAlias<"shuh", (HINT 50)>;
+def : InstAlias<"shuh $op", (HINT shuhint_op:$op)>;
+def : InstAlias<"stcph", (HINT 52)>;
 
 // In order to be able to write readable assembly, LLVM should accept assembly
 // inputs that use Branch Target Identification mnemonics, even with BTI disabled.
@@ -1594,12 +1597,6 @@ def DSB   : CRmSystemI<barrier_op, 0b100, "dsb",
 
 def ISB   : CRmSystemI<barrier_op, 0b110, "isb",
                        [(int_aarch64_isb (i32 imm32_0_15:$CRm))]>;
-
-def TSB   : CRmSystemI<barrier_op, 0b010, "tsb", []> {
-  let CRm        = 0b0010;
-  let Inst{12}   = 0;
-  let Predicates = [HasTRACEV8_4];
-}
 
 def DSBnXS  : CRmSystemI<barrier_nxs_op, 0b001, "dsb"> {
   let CRm{1-0}   = 0b11;
@@ -1680,6 +1677,7 @@ def GCSPOPM_NoOp : InstAlias<"gcspopm", (GCSPOPM XZR)>, Requires<[HasGCS]>; // R
 
 def GCSB_DSYNC_disable : InstAlias<"gcsb\tdsync", (HINT 19), 0>;
 def GCSB_DSYNC         : InstAlias<"gcsb\tdsync", (HINT 19), 1>, Requires<[HasGCS]>;
+def : InstAlias<"tsb\t$op", (HINT tsbhint_op:$op)>, Requires<[HasTRACEV8_4]>;
 
 def : TokenAlias<"DSYNC", "dsync">;
 
@@ -11920,13 +11918,6 @@ let Predicates = [HasF16F32MM] in
 
 let Uses = [FPMR, FPCR] in
   defm FMMLA : SIMDThreeSameVectorFP8MatrixMul<"fmmla", int_aarch64_neon_fmmla>;
-
-//===----------------------------------------------------------------------===//
-// Contention Management Hints (FEAT_CMH)
-//===----------------------------------------------------------------------===//
-
-defm SHUH  : SHUH<"shuh">;       // Shared Update Hint instruction
-def STCPH  : STCPHInst<"stcph">; // Store Concurrent Priority Hint instruction
 
 //===----------------------------------------------------------------------===//
 // Permission Overlays Extension 2 (FEAT_S1POE2)

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1566,7 +1566,10 @@ def NOP : SystemNoOperands<0b000, "hint\t#0">;
 
 def : InstAlias<"nop", (NOP)>;
 
-def STSHH: STSHHI;
+def : InstAlias<"stshh $policy", (HINT phint_op:$policy)>;
+def : InstAlias<"shuh", (HINT 50)>;
+def : InstAlias<"shuh $op", (HINT shuhint_op:$op)>;
+def : InstAlias<"stcph", (HINT 52)>;
 
 // In order to be able to write readable assembly, LLVM should accept assembly
 // inputs that use Branch Target Identification mnemonics, even with BTI disabled.
@@ -1596,12 +1599,6 @@ def DSB   : CRmSystemI<barrier_op, 0b100, "dsb",
 
 def ISB   : CRmSystemI<barrier_op, 0b110, "isb",
                        [(int_aarch64_isb (i32 imm32_0_15:$CRm))]>;
-
-def TSB   : CRmSystemI<barrier_op, 0b010, "tsb", []> {
-  let CRm        = 0b0010;
-  let Inst{12}   = 0;
-  let Predicates = [HasTRACEV8_4];
-}
 
 def DSBnXS  : CRmSystemI<barrier_nxs_op, 0b001, "dsb"> {
   let CRm{1-0}   = 0b11;
@@ -1672,6 +1669,7 @@ def GCSPOPM_NoOp : InstAlias<"gcspopm", (GCSPOPM XZR)>, Requires<[HasGCS]>; // R
 
 def GCSB_DSYNC_disable : InstAlias<"gcsb\tdsync", (HINT 19), 0>;
 def GCSB_DSYNC         : InstAlias<"gcsb\tdsync", (HINT 19), 1>, Requires<[HasGCS]>;
+def : InstAlias<"tsb\t$op", (HINT tsbhint_op:$op)>, Requires<[HasTRACEV8_4]>;
 
 def : TokenAlias<"DSYNC", "dsync">;
 
@@ -11931,13 +11929,6 @@ let Predicates = [HasF16F32MM] in
 
 let Uses = [FPMR, FPCR] in
   defm FMMLA : SIMDThreeSameVectorFP8MatrixMul<"fmmla", int_aarch64_neon_fmmla>;
-
-//===----------------------------------------------------------------------===//
-// Contention Management Hints (FEAT_CMH)
-//===----------------------------------------------------------------------===//
-
-defm SHUH  : SHUH<"shuh">;       // Shared Update Hint instruction
-def STCPH  : STCPHInst<"stcph">; // Store Concurrent Priority Hint instruction
 
 //===----------------------------------------------------------------------===//
 // Permission Overlays Extension 2 (FEAT_S1POE2)

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1552,13 +1552,13 @@ let hasSideEffects = 1, isCodeGenOnly = 1, isTerminator = 1, isBarrier = 1 in {
 //===----------------------------------------------------------------------===//
 
 def HINT : HintI<"hint">;
-def : InstAlias<"yield",(HINT 0b001)>;
-def : InstAlias<"wfe",  (HINT 0b010)>;
-def : InstAlias<"wfi",  (HINT 0b011)>;
-def : InstAlias<"sev",  (HINT 0b100)>;
-def : InstAlias<"sevl", (HINT 0b101)>;
-def : InstAlias<"dgh",  (HINT 0b110)>;
-def : InstAlias<"esb",  (HINT 0b10000)>, Requires<[HasRAS]>;
+def : InstAlias<"yield",(HINT 1)>;
+def : InstAlias<"wfe",  (HINT 2)>;
+def : InstAlias<"wfi",  (HINT 3)>;
+def : InstAlias<"sev",  (HINT 4)>;
+def : InstAlias<"sevl", (HINT 5)>;
+def : InstAlias<"dgh",  (HINT 6)>;
+def : InstAlias<"esb",  (HINT 16)>, Requires<[HasRAS]>;
 def : InstAlias<"csdb", (HINT 20)>;
 
 let CRm = 0b0000, hasSideEffects = 0 in
@@ -1583,6 +1583,8 @@ def : InstAlias<"bti $op", (HINT btihint_op:$op)>, Requires<[HasBTI]>;
 
 // v8.2a Statistical Profiling extension
 def : InstAlias<"psb $op",  (HINT psbhint_op:$op)>, Requires<[HasSPE]>;
+
+def : InstAlias<"tsb $op", (HINT tsbhint_op:$op)>, Requires<[HasTRACEV8_4]>;
 
 // As far as LLVM is concerned this writes to the system's exclusive monitors.
 let mayLoad = 1, mayStore = 1 in
@@ -1669,7 +1671,6 @@ def GCSPOPM_NoOp : InstAlias<"gcspopm", (GCSPOPM XZR)>, Requires<[HasGCS]>; // R
 
 def GCSB_DSYNC_disable : InstAlias<"gcsb\tdsync", (HINT 19), 0>;
 def GCSB_DSYNC         : InstAlias<"gcsb\tdsync", (HINT 19), 1>, Requires<[HasGCS]>;
-def : InstAlias<"tsb\t$op", (HINT tsbhint_op:$op)>, Requires<[HasTRACEV8_4]>;
 
 def : TokenAlias<"DSYNC", "dsync">;
 

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1566,7 +1566,7 @@ def NOP : SystemNoOperands<0b000, "hint\t#0">;
 
 def : InstAlias<"nop", (NOP)>;
 
-def : InstAlias<"stshh $policy", (HINT phint_op:$policy)>;
+def : InstAlias<"stshh $policy", (HINT pcdphint_op:$policy)>;
 def : InstAlias<"shuh", (HINT 50)>;
 def : InstAlias<"shuh $op", (HINT shuhint_op:$op)>;
 def : InstAlias<"stcph", (HINT 52)>;
@@ -1583,7 +1583,6 @@ def : InstAlias<"bti $op", (HINT btihint_op:$op)>, Requires<[HasBTI]>;
 
 // v8.2a Statistical Profiling extension
 def : InstAlias<"psb $op",  (HINT psbhint_op:$op)>, Requires<[HasSPE]>;
-
 def : InstAlias<"tsb $op", (HINT tsbhint_op:$op)>, Requires<[HasTRACEV8_4]>;
 
 // As far as LLVM is concerned this writes to the system's exclusive monitors.

--- a/llvm/lib/Target/AArch64/AArch64SystemOperands.td
+++ b/llvm/lib/Target/AArch64/AArch64SystemOperands.td
@@ -2450,15 +2450,10 @@ def : RWSysReg<"ACTLRALIAS_EL1",  0b11, 0b000, 0b0001, 0b0100, 0b101>;
 // v9.6a PCDPHINT instruction options.
 //===----------------------------------------------------------------------===//
 
-class PHint<bits<2> op0, bits<3> op1, bits<4> crn, bits<4> crm,
-              bits<3> op2, string name> {
+class PHint<string name, bits<7> encoding> {
   string Name = name;
-  bits<16> Encoding;
-  let Encoding{15-14} = op0;
-  let Encoding{13-11} = op1;
-  let Encoding{10-7} = crn;
-  let Encoding{6-3} = crm;
-  let Encoding{2-0} = op2;
+  bits<7> Encoding;
+  let Encoding = encoding;
   code Requires = [{ {} }];
 }
 
@@ -2481,8 +2476,8 @@ def lookupPHintByName : SearchIndex {
   let Key = ["Name"];
 }
 
-def KEEP : PHint<0b00, 0b000, 0b0000, 0b0000, 0b000, "keep">;
-def STRM : PHint<0b00, 0b000, 0b0000, 0b0000, 0b001, "strm">;
+def KEEP : PHint<"keep", 0b0110000>;
+def STRM : PHint<"strm", 0b0110001>;
 
 // v9.6a Realm management extension enhancements
 def : RWSysReg<"GPCBW_EL3", 0b11, 0b110, 0b0010, 0b0001, 0b101>;

--- a/llvm/lib/Target/AArch64/AArch64SystemOperands.td
+++ b/llvm/lib/Target/AArch64/AArch64SystemOperands.td
@@ -338,21 +338,6 @@ def lookupISBByName : SearchIndex {
 def : ISB<"sy", 0xf>;
 
 //===----------------------------------------------------------------------===//
-// TSB (Trace synchronization barrier) HINT instruction options.
-//===----------------------------------------------------------------------===//
-
-class TSBHint<string name, bits<4> encoding> : SearchableTable {
-  let SearchableFields = ["Name", "Encoding"];
-  let EnumValueField = "Encoding";
-
-  string Name = name;
-  bits<4> Encoding;
-  let Encoding = encoding;
-}
-
-def : TSBHint<"csync", 2>;
-
-//===----------------------------------------------------------------------===//
 // PRFM (prefetch) instruction options.
 //===----------------------------------------------------------------------===//
 
@@ -732,84 +717,52 @@ def : SVCR<"SVCRSMZA", 0b011>;
 }
 
 //===----------------------------------------------------------------------===//
-// PSB instruction options.
+// PSB (Profiling synchronization barrier) HINT instruction options.
 //===----------------------------------------------------------------------===//
 
-class PSB<string name, bits<5> encoding> {
+class PSBHint<string name, bits<4> encoding> : SearchableTable {
+  let SearchableFields = ["Name", "Encoding"];
+  let EnumValueField = "Encoding";
+
   string Name = name;
-  bits<5> Encoding;
+  bits<4> Encoding;
   let Encoding = encoding;
 }
 
-def PSBValues : GenericEnum {
-  let FilterClass = "PSB";
-  let NameField = "Name";
-  let ValueField = "Encoding";
+def : PSBHint<"csync", 1>;
+
+//===----------------------------------------------------------------------===//
+// TSB (Trace synchronization barrier) HINT instruction options.
+//===----------------------------------------------------------------------===//
+
+class TSBHint<string name, bits<4> encoding> : SearchableTable {
+  let SearchableFields = ["Name", "Encoding"];
+  let EnumValueField = "Encoding";
+
+  string Name = name;
+  bits<4> Encoding;
+  let Encoding = encoding;
 }
 
-def PSBsList : GenericTable {
-  let FilterClass = "PSB";
-  let Fields = ["Name", "Encoding"];
-
-  let PrimaryKey = ["Encoding"];
-  let PrimaryKeyName = "lookupPSBByEncoding";
-}
-
-def lookupPSBByName : SearchIndex {
-  let Table = PSBsList;
-  let Key = ["Name"];
-}
-
-def : PSB<"csync", 0x11>;
+def : TSBHint<"csync", 2>;
 
 //===----------------------------------------------------------------------===//
 // BTI instruction options.
 //===----------------------------------------------------------------------===//
 
-class BTI<string name, bits<3> encoding> {
+class BTIHint<string name, bits<3> encoding> : SearchableTable {
+  let SearchableFields = ["Name", "Encoding"];
+  let EnumValueField = "Encoding";
+
   string Name = name;
   bits<3> Encoding;
   let Encoding = encoding;
 }
 
-def BTIValues : GenericEnum {
-  let FilterClass = "BTI";
-  let NameField = "Name";
-  let ValueField = "Encoding";
-}
-
-def BTIsList : GenericTable {
-  let FilterClass = "BTI";
-  let Fields = ["Name", "Encoding"];
-
-  let PrimaryKey = ["Encoding"];
-  let PrimaryKeyName = "lookupBTIByEncoding";
-}
-
-def lookupBTIByName : SearchIndex {
-  let Table = BTIsList;
-  let Key = ["Name"];
-}
-
-def : BTI<"r",  0b000>;
-def : BTI<"c",  0b010>;
-def : BTI<"j",  0b100>;
-def : BTI<"jc", 0b110>;
-
-//===----------------------------------------------------------------------===//
-// CMHPriority instruction options.
-//===----------------------------------------------------------------------===//
-
-class CMHPriorityHint<string name, bits<1> encoding> : SearchableTable {
-  let SearchableFields = ["Name", "Encoding"];
-  let EnumValueField = "Encoding";
-
-  string Name = name;
-  bits<1> Encoding;
-  let Encoding = encoding;
-}
-
-def : CMHPriorityHint<"ph", 0b1>;
+def : BTIHint<"r",  0b000>;
+def : BTIHint<"c",  0b010>;
+def : BTIHint<"j",  0b100>;
+def : BTIHint<"jc", 0b110>;
 
 class SHUHint<string name, bits<1> encoding> : SearchableTable {
   let SearchableFields = ["Name", "Encoding"];
@@ -2443,7 +2396,7 @@ def : RWSysReg<"ACTLRALIAS_EL1",  0b11, 0b000, 0b0001, 0b0100, 0b101>;
 // v9.6a PCDPHINT instruction options.
 //===----------------------------------------------------------------------===//
 
-class PHint<string name, bits<1> encoding> : SearchableTable {
+class PCDPHint<string name, bits<1> encoding> : SearchableTable {
   let SearchableFields = ["Name", "Encoding"];
   let EnumValueField = "Encoding";
 
@@ -2452,8 +2405,8 @@ class PHint<string name, bits<1> encoding> : SearchableTable {
   let Encoding = encoding;
 }
 
-def : PHint<"keep", 0b0>;
-def : PHint<"strm", 0b1>;
+def : PCDPHint<"keep", 0b0>;
+def : PCDPHint<"strm", 0b1>;
 
 // v9.6a Realm management extension enhancements
 def : RWSysReg<"GPCBW_EL3", 0b11, 0b110, 0b0010, 0b0001, 0b101>;

--- a/llvm/lib/Target/AArch64/AArch64SystemOperands.td
+++ b/llvm/lib/Target/AArch64/AArch64SystemOperands.td
@@ -338,37 +338,19 @@ def lookupISBByName : SearchIndex {
 def : ISB<"sy", 0xf>;
 
 //===----------------------------------------------------------------------===//
-// TSB (Trace synchronization barrier) instruction options.
+// TSB (Trace synchronization barrier) HINT instruction options.
 //===----------------------------------------------------------------------===//
 
-class TSB<string name, bits<4> encoding> {
+class TSBHint<string name, bits<4> encoding> : SearchableTable {
+  let SearchableFields = ["Name", "Encoding"];
+  let EnumValueField = "Encoding";
+
   string Name = name;
   bits<4> Encoding;
   let Encoding = encoding;
-
-  code Requires = [{ {AArch64::FeatureTRACEV8_4} }];
 }
 
-def TSBValues : GenericEnum {
-  let FilterClass = "TSB";
-  let NameField = "Name";
-  let ValueField = "Encoding";
-}
-
-def TSBsList : GenericTable {
-  let FilterClass = "TSB";
-  let Fields = ["Name", "Encoding", "Requires"];
-
-  let PrimaryKey = ["Encoding"];
-  let PrimaryKeyName = "lookupTSBByEncoding";
-}
-
-def lookupTSBByName : SearchIndex {
-  let Table = TSBsList;
-  let Key = ["Name"];
-}
-
-def : TSB<"csync", 2>;
+def : TSBHint<"csync", 2>;
 
 //===----------------------------------------------------------------------===//
 // PRFM (prefetch) instruction options.
@@ -828,6 +810,17 @@ class CMHPriorityHint<string name, bits<1> encoding> : SearchableTable {
 }
 
 def : CMHPriorityHint<"ph", 0b1>;
+
+class SHUHint<string name, bits<1> encoding> : SearchableTable {
+  let SearchableFields = ["Name", "Encoding"];
+  let EnumValueField = "Encoding";
+
+  string Name = name;
+  bits<1> Encoding;
+  let Encoding = encoding;
+}
+
+def : SHUHint<"ph", 0b1>;
 
 
 //===----------------------------------------------------------------------===//
@@ -2450,34 +2443,17 @@ def : RWSysReg<"ACTLRALIAS_EL1",  0b11, 0b000, 0b0001, 0b0100, 0b101>;
 // v9.6a PCDPHINT instruction options.
 //===----------------------------------------------------------------------===//
 
-class PHint<string name, bits<7> encoding> {
+class PHint<string name, bits<1> encoding> : SearchableTable {
+  let SearchableFields = ["Name", "Encoding"];
+  let EnumValueField = "Encoding";
+
   string Name = name;
-  bits<7> Encoding;
+  bits<1> Encoding;
   let Encoding = encoding;
-  code Requires = [{ {} }];
 }
 
-def PHintValues : GenericEnum {
-  let FilterClass = "PHint";
-  let NameField = "Name";
-  let ValueField = "Encoding";
-}
-
-def PHintsList : GenericTable {
-  let FilterClass = "PHint";
-  let Fields = ["Name", "Encoding", "Requires"];
-
-  let PrimaryKey = ["Encoding"];
-  let PrimaryKeyName = "lookupPHintByEncoding";
-}
-
-def lookupPHintByName : SearchIndex {
-  let Table = PHintsList;
-  let Key = ["Name"];
-}
-
-def KEEP : PHint<"keep", 0b0110000>;
-def STRM : PHint<"strm", 0b0110001>;
+def : PHint<"keep", 0b0>;
+def : PHint<"strm", 0b1>;
 
 // v9.6a Realm management extension enhancements
 def : RWSysReg<"GPCBW_EL3", 0b11, 0b110, 0b0010, 0b0001, 0b101>;

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -268,6 +268,8 @@ private:
   ParseStatus tryParseRPRFMOperand(OperandVector &Operands);
   ParseStatus tryParsePSBHint(OperandVector &Operands);
   ParseStatus tryParseBTIHint(OperandVector &Operands);
+  ParseStatus tryParseSHUHintOperand(OperandVector &Operands);
+  ParseStatus tryParseTSBHintOperand(OperandVector &Operands);
   ParseStatus tryParseCMHPriorityHint(OperandVector &Operands);
   ParseStatus tryParseTIndexHint(OperandVector &Operands);
   ParseStatus tryParseAdrpLabel(OperandVector &Operands);
@@ -374,6 +376,8 @@ private:
     k_PSBHint,
     k_PHint,
     k_BTIHint,
+    k_SHUHint,
+    k_TSBHint,
     k_CMHPriorityHint,
     k_TIndexHint,
   } Kind;
@@ -505,6 +509,16 @@ private:
     unsigned Length;
     unsigned Val;
   };
+  struct SHUHintOp {
+    const char *Data;
+    unsigned Length;
+    unsigned Val;
+  };
+  struct TSBHintOp {
+    const char *Data;
+    unsigned Length;
+    unsigned Val;
+  };
   struct CMHPriorityHintOp {
     const char *Data;
     unsigned Length;
@@ -541,6 +555,8 @@ private:
     struct PSBHintOp PSBHint;
     struct PHintOp PHint;
     struct BTIHintOp BTIHint;
+    struct SHUHintOp SHUHint;
+    struct TSBHintOp TSBHint;
     struct CMHPriorityHintOp CMHPriorityHint;
     struct TIndexHintOp TIndexHint;
     struct ShiftExtendOp ShiftExtend;
@@ -612,6 +628,12 @@ public:
       break;
     case k_BTIHint:
       BTIHint = o.BTIHint;
+      break;
+    case k_SHUHint:
+      SHUHint = o.SHUHint;
+      break;
+    case k_TSBHint:
+      TSBHint = o.TSBHint;
       break;
     case k_CMHPriorityHint:
       CMHPriorityHint = o.CMHPriorityHint;
@@ -788,9 +810,29 @@ public:
     return BTIHint.Val;
   }
 
+  unsigned getSHUHint() const {
+    assert(Kind == k_SHUHint && "Invalid access!");
+    return SHUHint.Val;
+  }
+
+  unsigned getTSBHint() const {
+    assert(Kind == k_TSBHint && "Invalid access!");
+    return TSBHint.Val;
+  }
+
   StringRef getBTIHintName() const {
     assert(Kind == k_BTIHint && "Invalid access!");
     return StringRef(BTIHint.Data, BTIHint.Length);
+  }
+
+  StringRef getSHUHintName() const {
+    assert(Kind == k_SHUHint && "Invalid access!");
+    return StringRef(SHUHint.Data, SHUHint.Length);
+  }
+
+  StringRef getTSBHintName() const {
+    assert(Kind == k_TSBHint && "Invalid access!");
+    return StringRef(TSBHint.Data, TSBHint.Length);
   }
 
   unsigned getCMHPriorityHint() const {
@@ -1555,6 +1597,8 @@ public:
   bool isPSBHint() const { return Kind == k_PSBHint; }
   bool isPHint() const { return Kind == k_PHint; }
   bool isBTIHint() const { return Kind == k_BTIHint; }
+  bool isSHUHint() const { return Kind == k_SHUHint; }
+  bool isTSBHint() const { return Kind == k_TSBHint; }
   bool isCMHPriorityHint() const { return Kind == k_CMHPriorityHint; }
   bool isTIndexHint() const { return Kind == k_TIndexHint; }
   bool isShiftExtend() const { return Kind == k_ShiftExtend; }
@@ -2242,6 +2286,16 @@ public:
     Inst.addOperand(MCOperand::createImm(getBTIHint()));
   }
 
+  void addSHUHintOperands(MCInst &Inst, unsigned N) const {
+    assert(N == 1 && "Invalid number of operands!");
+    Inst.addOperand(MCOperand::createImm(getSHUHint()));
+  }
+
+  void addTSBHintOperands(MCInst &Inst, unsigned N) const {
+    assert(N == 1 && "Invalid number of operands!");
+    Inst.addOperand(MCOperand::createImm(getTSBHint()));
+  }
+
   void addCMHPriorityHintOperands(MCInst &Inst, unsigned N) const {
     assert(N == 1 && "Invalid number of operands!");
     Inst.addOperand(MCOperand::createImm(getCMHPriorityHint()));
@@ -2600,6 +2654,28 @@ public:
   }
 
   static std::unique_ptr<AArch64Operand>
+  CreateSHUHint(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
+    auto Op = std::make_unique<AArch64Operand>(k_SHUHint, Ctx);
+    Op->SHUHint.Val = Val + 50;
+    Op->SHUHint.Data = Str.data();
+    Op->SHUHint.Length = Str.size();
+    Op->StartLoc = S;
+    Op->EndLoc = S;
+    return Op;
+  }
+
+  static std::unique_ptr<AArch64Operand>
+  CreateTSBHint(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
+    auto Op = std::make_unique<AArch64Operand>(k_TSBHint, Ctx);
+    Op->TSBHint.Val = Val | 16;
+    Op->TSBHint.Data = Str.data();
+    Op->TSBHint.Length = Str.size();
+    Op->StartLoc = S;
+    Op->EndLoc = S;
+    return Op;
+  }
+
+  static std::unique_ptr<AArch64Operand>
   CreateCMHPriorityHint(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
     auto Op = std::make_unique<AArch64Operand>(k_CMHPriorityHint, Ctx);
     Op->CMHPriorityHint.Val = Val;
@@ -2730,6 +2806,12 @@ void AArch64Operand::print(raw_ostream &OS, const MCAsmInfo &MAI) const {
     break;
   case k_BTIHint:
     OS << getBTIHintName();
+    break;
+  case k_SHUHint:
+    OS << getSHUHintName();
+    break;
+  case k_TSBHint:
+    OS << getTSBHintName();
     break;
   case k_CMHPriorityHint:
     OS << getCMHPriorityHintName();
@@ -4434,6 +4516,39 @@ AArch64AsmParser::tryParsePHintInstOperand(OperandVector &Operands) {
 
   Operands.push_back(AArch64Operand::CreatePHintInst(
       PH->Encoding, Tok.getString(), S, getContext()));
+  Lex(); // Eat identifier token.
+  return ParseStatus::Success;
+}
+
+ParseStatus AArch64AsmParser::tryParseSHUHintOperand(OperandVector &Operands) {
+  SMLoc S = getLoc();
+  const AsmToken &Tok = getTok();
+  if (Tok.isNot(AsmToken::Identifier))
+    return TokError("invalid operand for instruction");
+
+  auto SHU =
+      AArch64CMHPriorityHint::lookupCMHPriorityHintByName(Tok.getString());
+  if (!SHU)
+    return TokError("invalid operand for instruction");
+
+  Operands.push_back(AArch64Operand::CreateSHUHint(
+      SHU->Encoding, Tok.getString(), S, getContext()));
+  Lex(); // Eat identifier token.
+  return ParseStatus::Success;
+}
+
+ParseStatus AArch64AsmParser::tryParseTSBHintOperand(OperandVector &Operands) {
+  SMLoc S = getLoc();
+  const AsmToken &Tok = getTok();
+  if (Tok.isNot(AsmToken::Identifier))
+    return TokError("'csync' operand expected");
+
+  auto TSB = AArch64TSB::lookupTSBByName(Tok.getString());
+  if (!TSB || TSB->Encoding != AArch64TSB::csync)
+    return TokError("'csync' operand expected");
+
+  Operands.push_back(AArch64Operand::CreateTSBHint(
+      TSB->Encoding, Tok.getString(), S, getContext()));
   Lex(); // Eat identifier token.
   return ParseStatus::Success;
 }

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -2597,6 +2597,10 @@ public:
     unsigned operator()(unsigned Val) const { return Val | 32; }
   };
 
+  struct PHintEncoding {
+    unsigned operator()(unsigned Val) const { return Val + 48; }
+  };
+
   template <KindTy Kind, NamedHintOp AArch64Operand::*Member,
             typename Encode = IdentityHintEncoding>
   static std::unique_ptr<AArch64Operand>
@@ -2614,8 +2618,8 @@ public:
 
   static std::unique_ptr<AArch64Operand>
   CreatePHintInst(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
-    return CreateNamedHintOperand<k_PHint, &AArch64Operand::PHint>(Val, Str, S,
-                                                                   Ctx);
+    return CreateNamedHintOperand<k_PHint, &AArch64Operand::PHint>(
+        Val, Str, S, Ctx, PHintEncoding{});
   }
 
   static std::unique_ptr<AArch64Operand> CreateSysCR(unsigned Val, SMLoc S,
@@ -4338,15 +4342,15 @@ ParseStatus AArch64AsmParser::tryParseBarrierOperand(OperandVector &Operands) {
     return TokError("invalid operand for instruction");
 
   StringRef Operand = Tok.getString();
-  auto TSB = AArch64TSB::lookupTSBByName(Operand);
+  bool IsTSB = Mnemonic == "tsb" && Operand == "csync";
   auto DB = AArch64DB::lookupDBByName(Operand);
   // The only valid named option for ISB is 'sy'
   if (Mnemonic == "isb" && (!DB || DB->Encoding != AArch64DB::sy))
     return TokError("'sy' or #imm operand expected");
   // The only valid named option for TSB is 'csync'
-  if (Mnemonic == "tsb" && (!TSB || TSB->Encoding != AArch64TSB::csync))
+  if (Mnemonic == "tsb" && !IsTSB)
     return TokError("'csync' operand expected");
-  if (!DB && !TSB) {
+  if (!DB && !IsTSB) {
     if (Mnemonic == "dsb") {
       // This case is a no match here, but it might be matched by the nXS
       // variant.
@@ -4356,8 +4360,8 @@ ParseStatus AArch64AsmParser::tryParseBarrierOperand(OperandVector &Operands) {
   }
 
   Operands.push_back(AArch64Operand::CreateBarrier(
-      DB ? DB->Encoding : TSB->Encoding, Tok.getString(), getLoc(),
-      getContext(), false /*hasnXSModifier*/));
+      DB ? DB->Encoding : 2, Tok.getString(), getLoc(), getContext(),
+      false /*hasnXSModifier*/));
   Lex(); // Consume the option
 
   return ParseStatus::Success;
@@ -4451,25 +4455,13 @@ AArch64AsmParser::tryParsePHintInstOperand(OperandVector &Operands) {
 }
 
 ParseStatus AArch64AsmParser::tryParseSHUHintOperand(OperandVector &Operands) {
-  return tryParseNamedHintOperand(
-      Operands, AArch64CMHPriorityHint::lookupCMHPriorityHintByName,
-      AArch64Operand::CreateSHUHint);
+  return tryParseNamedHintOperand(Operands, AArch64SHUHint::lookupSHUHintByName,
+                                  AArch64Operand::CreateSHUHint);
 }
 
 ParseStatus AArch64AsmParser::tryParseTSBHintOperand(OperandVector &Operands) {
-  SMLoc S = getLoc();
-  const AsmToken &Tok = getTok();
-  if (Tok.isNot(AsmToken::Identifier))
-    return TokError("'csync' operand expected");
-
-  auto TSB = AArch64TSB::lookupTSBByName(Tok.getString());
-  if (!TSB || TSB->Encoding != AArch64TSB::csync)
-    return TokError("'csync' operand expected");
-
-  Operands.push_back(AArch64Operand::CreateTSBHint(
-      TSB->Encoding, Tok.getString(), S, getContext()));
-  Lex(); // Eat identifier token.
-  return ParseStatus::Success;
+  return tryParseNamedHintOperand(Operands, AArch64TSBHint::lookupTSBHintByName,
+                                  AArch64Operand::CreateTSBHint);
 }
 
 /// tryParseNeonVectorRegister - Parse a vector register operand.

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -268,6 +268,8 @@ private:
   ParseStatus tryParseRPRFMOperand(OperandVector &Operands);
   ParseStatus tryParsePSBHint(OperandVector &Operands);
   ParseStatus tryParseBTIHint(OperandVector &Operands);
+  ParseStatus tryParseSHUHintOperand(OperandVector &Operands);
+  ParseStatus tryParseTSBHintOperand(OperandVector &Operands);
   ParseStatus tryParseCMHPriorityHint(OperandVector &Operands);
   ParseStatus tryParseTIndexHint(OperandVector &Operands);
   ParseStatus tryParseAdrpLabel(OperandVector &Operands);
@@ -392,6 +394,8 @@ private:
     k_PSBHint,
     k_PHint,
     k_BTIHint,
+    k_SHUHint,
+    k_TSBHint,
     k_CMHPriorityHint,
     k_TIndexHint,
   } Kind;
@@ -516,6 +520,8 @@ private:
   using PSBHintOp = NamedHintOp;
   using PHintOp = NamedHintOp;
   using BTIHintOp = NamedHintOp;
+  using SHUHintOp = NamedHintOp;
+  using TSBHintOp = NamedHintOp;
   using CMHPriorityHintOp = NamedHintOp;
   using TIndexHintOp = NamedHintOp;
 
@@ -544,6 +550,8 @@ private:
     PSBHintOp PSBHint;
     PHintOp PHint;
     BTIHintOp BTIHint;
+    SHUHintOp SHUHint;
+    TSBHintOp TSBHint;
     CMHPriorityHintOp CMHPriorityHint;
     TIndexHintOp TIndexHint;
     ShiftExtendOp ShiftExtend;
@@ -615,6 +623,12 @@ public:
       break;
     case k_BTIHint:
       BTIHint = o.BTIHint;
+      break;
+    case k_SHUHint:
+      SHUHint = o.SHUHint;
+      break;
+    case k_TSBHint:
+      TSBHint = o.TSBHint;
       break;
     case k_CMHPriorityHint:
       CMHPriorityHint = o.CMHPriorityHint;
@@ -791,9 +805,29 @@ public:
     return BTIHint.Val;
   }
 
+  unsigned getSHUHint() const {
+    assert(Kind == k_SHUHint && "Invalid access!");
+    return SHUHint.Val;
+  }
+
+  unsigned getTSBHint() const {
+    assert(Kind == k_TSBHint && "Invalid access!");
+    return TSBHint.Val;
+  }
+
   StringRef getBTIHintName() const {
     assert(Kind == k_BTIHint && "Invalid access!");
     return StringRef(BTIHint.Data, BTIHint.Length);
+  }
+
+  StringRef getSHUHintName() const {
+    assert(Kind == k_SHUHint && "Invalid access!");
+    return StringRef(SHUHint.Data, SHUHint.Length);
+  }
+
+  StringRef getTSBHintName() const {
+    assert(Kind == k_TSBHint && "Invalid access!");
+    return StringRef(TSBHint.Data, TSBHint.Length);
   }
 
   unsigned getCMHPriorityHint() const {
@@ -1558,6 +1592,8 @@ public:
   bool isPSBHint() const { return Kind == k_PSBHint; }
   bool isPHint() const { return Kind == k_PHint; }
   bool isBTIHint() const { return Kind == k_BTIHint; }
+  bool isSHUHint() const { return Kind == k_SHUHint; }
+  bool isTSBHint() const { return Kind == k_TSBHint; }
   bool isCMHPriorityHint() const { return Kind == k_CMHPriorityHint; }
   bool isTIndexHint() const { return Kind == k_TIndexHint; }
   bool isShiftExtend() const { return Kind == k_ShiftExtend; }
@@ -2245,6 +2281,16 @@ public:
     Inst.addOperand(MCOperand::createImm(getBTIHint()));
   }
 
+  void addSHUHintOperands(MCInst &Inst, unsigned N) const {
+    assert(N == 1 && "Invalid number of operands!");
+    Inst.addOperand(MCOperand::createImm(getSHUHint()));
+  }
+
+  void addTSBHintOperands(MCInst &Inst, unsigned N) const {
+    assert(N == 1 && "Invalid number of operands!");
+    Inst.addOperand(MCOperand::createImm(getTSBHint()));
+  }
+
   void addCMHPriorityHintOperands(MCInst &Inst, unsigned N) const {
     assert(N == 1 && "Invalid number of operands!");
     Inst.addOperand(MCOperand::createImm(getCMHPriorityHint()));
@@ -2611,6 +2657,18 @@ public:
   }
 
   static std::unique_ptr<AArch64Operand>
+  CreateSHUHint(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
+    return CreateNamedHintOperand<k_SHUHint, &AArch64Operand::SHUHint>(
+        Val, Str, S, Ctx, [](unsigned EncodedVal) { return EncodedVal + 50; });
+  }
+
+  static std::unique_ptr<AArch64Operand>
+  CreateTSBHint(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
+    return CreateNamedHintOperand<k_TSBHint, &AArch64Operand::TSBHint>(
+        Val, Str, S, Ctx, [](unsigned EncodedVal) { return EncodedVal | 16; });
+  }
+
+  static std::unique_ptr<AArch64Operand>
   CreateCMHPriorityHint(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
     return CreateNamedHintOperand<k_CMHPriorityHint,
                                   &AArch64Operand::CMHPriorityHint>(Val, Str, S,
@@ -2732,6 +2790,12 @@ void AArch64Operand::print(raw_ostream &OS, const MCAsmInfo &MAI) const {
     break;
   case k_BTIHint:
     OS << getBTIHintName();
+    break;
+  case k_SHUHint:
+    OS << getSHUHintName();
+    break;
+  case k_TSBHint:
+    OS << getTSBHintName();
     break;
   case k_CMHPriorityHint:
     OS << getCMHPriorityHintName();
@@ -4384,6 +4448,28 @@ ParseStatus
 AArch64AsmParser::tryParsePHintInstOperand(OperandVector &Operands) {
   return tryParseNamedHintOperand(Operands, AArch64PHint::lookupPHintByName,
                                   AArch64Operand::CreatePHintInst);
+}
+
+ParseStatus AArch64AsmParser::tryParseSHUHintOperand(OperandVector &Operands) {
+  return tryParseNamedHintOperand(
+      Operands, AArch64CMHPriorityHint::lookupCMHPriorityHintByName,
+      AArch64Operand::CreateSHUHint);
+}
+
+ParseStatus AArch64AsmParser::tryParseTSBHintOperand(OperandVector &Operands) {
+  SMLoc S = getLoc();
+  const AsmToken &Tok = getTok();
+  if (Tok.isNot(AsmToken::Identifier))
+    return TokError("'csync' operand expected");
+
+  auto TSB = AArch64TSB::lookupTSBByName(Tok.getString());
+  if (!TSB || TSB->Encoding != AArch64TSB::csync)
+    return TokError("'csync' operand expected");
+
+  Operands.push_back(AArch64Operand::CreateTSBHint(
+      TSB->Encoding, Tok.getString(), S, getContext()));
+  Lex(); // Eat identifier token.
+  return ParseStatus::Success;
 }
 
 /// tryParseNeonVectorRegister - Parse a vector register operand.

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -266,11 +266,11 @@ private:
   template <bool IsSVEPrefetch = false>
   ParseStatus tryParsePrefetch(OperandVector &Operands);
   ParseStatus tryParseRPRFMOperand(OperandVector &Operands);
-  ParseStatus tryParsePSBHint(OperandVector &Operands);
-  ParseStatus tryParseBTIHint(OperandVector &Operands);
+  ParseStatus tryParsePSBHintOperand(OperandVector &Operands);
+  ParseStatus tryParsePCDPHintOperand(OperandVector &Operands);
+  ParseStatus tryParseBTIHintOperand(OperandVector &Operands);
   ParseStatus tryParseSHUHintOperand(OperandVector &Operands);
   ParseStatus tryParseTSBHintOperand(OperandVector &Operands);
-  ParseStatus tryParseCMHPriorityHint(OperandVector &Operands);
   ParseStatus tryParseTIndexHint(OperandVector &Operands);
   ParseStatus tryParseAdrpLabel(OperandVector &Operands);
   ParseStatus tryParseAdrLabel(OperandVector &Operands);
@@ -301,7 +301,6 @@ private:
   ParseStatus tryParseGPR64x8(OperandVector &Operands);
   ParseStatus tryParseImmRange(OperandVector &Operands);
   template <int> ParseStatus tryParseAdjImm0_63(OperandVector &Operands);
-  ParseStatus tryParsePHintInstOperand(OperandVector &Operands);
   template <typename LookupFn, typename CreateFn>
   ParseStatus tryParseNamedHintOperand(OperandVector &Operands,
                                        LookupFn LookupByName,
@@ -392,11 +391,10 @@ private:
     k_FPImm,
     k_Barrier,
     k_PSBHint,
-    k_PHint,
+    k_PCDPHint,
     k_BTIHint,
     k_SHUHint,
     k_TSBHint,
-    k_CMHPriorityHint,
     k_TIndexHint,
   } Kind;
 
@@ -518,11 +516,10 @@ private:
     unsigned Val;
   };
   using PSBHintOp = NamedHintOp;
-  using PHintOp = NamedHintOp;
+  using PCDPHintOp = NamedHintOp;
   using BTIHintOp = NamedHintOp;
   using SHUHintOp = NamedHintOp;
   using TSBHintOp = NamedHintOp;
-  using CMHPriorityHintOp = NamedHintOp;
   using TIndexHintOp = NamedHintOp;
 
   struct SVCROp {
@@ -548,11 +545,10 @@ private:
     SysCRImmOp SysCRImm;
     PrefetchOp Prefetch;
     PSBHintOp PSBHint;
-    PHintOp PHint;
+    PCDPHintOp PCDPHint;
     BTIHintOp BTIHint;
     SHUHintOp SHUHint;
     TSBHintOp TSBHint;
-    CMHPriorityHintOp CMHPriorityHint;
     TIndexHintOp TIndexHint;
     ShiftExtendOp ShiftExtend;
     SVCROp SVCR;
@@ -618,8 +614,8 @@ public:
     case k_PSBHint:
       PSBHint = o.PSBHint;
       break;
-    case k_PHint:
-      PHint = o.PHint;
+    case k_PCDPHint:
+      PCDPHint = o.PCDPHint;
       break;
     case k_BTIHint:
       BTIHint = o.BTIHint;
@@ -629,9 +625,6 @@ public:
       break;
     case k_TSBHint:
       TSBHint = o.TSBHint;
-      break;
-    case k_CMHPriorityHint:
-      CMHPriorityHint = o.CMHPriorityHint;
       break;
     case k_TIndexHint:
       TIndexHint = o.TIndexHint;
@@ -785,19 +778,9 @@ public:
     return PSBHint.Val;
   }
 
-  unsigned getPHint() const {
-    assert(Kind == k_PHint && "Invalid access!");
-    return PHint.Val;
-  }
-
-  StringRef getPSBHintName() const {
-    assert(Kind == k_PSBHint && "Invalid access!");
-    return StringRef(PSBHint.Data, PSBHint.Length);
-  }
-
-  StringRef getPHintName() const {
-    assert(Kind == k_PHint && "Invalid access!");
-    return StringRef(PHint.Data, PHint.Length);
+  unsigned getPCDPHint() const {
+    assert(Kind == k_PCDPHint && "Invalid access!");
+    return PCDPHint.Val;
   }
 
   unsigned getBTIHint() const {
@@ -815,6 +798,16 @@ public:
     return TSBHint.Val;
   }
 
+  StringRef getPSBHintName() const {
+    assert(Kind == k_PSBHint && "Invalid access!");
+    return StringRef(PSBHint.Data, PSBHint.Length);
+  }
+
+  StringRef getPCDPHintName() const {
+    assert(Kind == k_PCDPHint && "Invalid access!");
+    return StringRef(PCDPHint.Data, PCDPHint.Length);
+  }
+
   StringRef getBTIHintName() const {
     assert(Kind == k_BTIHint && "Invalid access!");
     return StringRef(BTIHint.Data, BTIHint.Length);
@@ -828,16 +821,6 @@ public:
   StringRef getTSBHintName() const {
     assert(Kind == k_TSBHint && "Invalid access!");
     return StringRef(TSBHint.Data, TSBHint.Length);
-  }
-
-  unsigned getCMHPriorityHint() const {
-    assert(Kind == k_CMHPriorityHint && "Invalid access!");
-    return CMHPriorityHint.Val;
-  }
-
-  StringRef getCMHPriorityHintName() const {
-    assert(Kind == k_CMHPriorityHint && "Invalid access!");
-    return StringRef(CMHPriorityHint.Data, CMHPriorityHint.Length);
   }
 
   unsigned getTIndexHint() const {
@@ -1590,11 +1573,10 @@ public:
   bool isSysCR() const { return Kind == k_SysCR; }
   bool isPrefetch() const { return Kind == k_Prefetch; }
   bool isPSBHint() const { return Kind == k_PSBHint; }
-  bool isPHint() const { return Kind == k_PHint; }
+  bool isPCDPHint() const { return Kind == k_PCDPHint; }
   bool isBTIHint() const { return Kind == k_BTIHint; }
   bool isSHUHint() const { return Kind == k_SHUHint; }
   bool isTSBHint() const { return Kind == k_TSBHint; }
-  bool isCMHPriorityHint() const { return Kind == k_CMHPriorityHint; }
   bool isTIndexHint() const { return Kind == k_TIndexHint; }
   bool isShiftExtend() const { return Kind == k_ShiftExtend; }
   bool isShifter() const {
@@ -2271,9 +2253,9 @@ public:
     Inst.addOperand(MCOperand::createImm(getPSBHint()));
   }
 
-  void addPHintOperands(MCInst &Inst, unsigned N) const {
+  void addPCDPHintOperands(MCInst &Inst, unsigned N) const {
     assert(N == 1 && "Invalid number of operands!");
-    Inst.addOperand(MCOperand::createImm(getPHint()));
+    Inst.addOperand(MCOperand::createImm(getPCDPHint()));
   }
 
   void addBTIHintOperands(MCInst &Inst, unsigned N) const {
@@ -2289,11 +2271,6 @@ public:
   void addTSBHintOperands(MCInst &Inst, unsigned N) const {
     assert(N == 1 && "Invalid number of operands!");
     Inst.addOperand(MCOperand::createImm(getTSBHint()));
-  }
-
-  void addCMHPriorityHintOperands(MCInst &Inst, unsigned N) const {
-    assert(N == 1 && "Invalid number of operands!");
-    Inst.addOperand(MCOperand::createImm(getCMHPriorityHint()));
   }
 
   void addTIndexHintOperands(MCInst &Inst, unsigned N) const {
@@ -2589,17 +2566,16 @@ public:
     return Op;
   }
 
-  struct IdentityHintEncoding {
-    unsigned operator()(unsigned Val) const { return Val; }
+  template <unsigned Offset> struct OffsetHintEncoding {
+    unsigned operator()(unsigned Val) const { return Val + Offset; }
   };
 
-  struct BTIHintEncoding {
-    unsigned operator()(unsigned Val) const { return Val | 32; }
-  };
-
-  struct PHintEncoding {
-    unsigned operator()(unsigned Val) const { return Val + 48; }
-  };
+  using IdentityHintEncoding = OffsetHintEncoding<0>;
+  using BTIHintEncoding = OffsetHintEncoding<32>;
+  using PCDPHintEncoding = OffsetHintEncoding<48>;
+  using PSBHintEncoding = OffsetHintEncoding<16>;
+  using SHUHintEncoding = OffsetHintEncoding<50>;
+  using TSBHintEncoding = OffsetHintEncoding<16>;
 
   template <KindTy Kind, NamedHintOp AArch64Operand::*Member,
             typename Encode = IdentityHintEncoding>
@@ -2617,9 +2593,9 @@ public:
   }
 
   static std::unique_ptr<AArch64Operand>
-  CreatePHintInst(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
-    return CreateNamedHintOperand<k_PHint, &AArch64Operand::PHint>(
-        Val, Str, S, Ctx, PHintEncoding{});
+  CreatePCDPHint(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
+    return CreateNamedHintOperand<k_PCDPHint, &AArch64Operand::PCDPHint>(
+        Val, Str, S, Ctx, PCDPHintEncoding{});
   }
 
   static std::unique_ptr<AArch64Operand> CreateSysCR(unsigned Val, SMLoc S,
@@ -2644,18 +2620,14 @@ public:
     return Op;
   }
 
-  static std::unique_ptr<AArch64Operand> CreatePSBHint(unsigned Val,
-                                                       StringRef Str,
-                                                       SMLoc S,
-                                                       MCContext &Ctx) {
-    return CreateNamedHintOperand<k_PSBHint, &AArch64Operand::PSBHint>(Val, Str,
-                                                                       S, Ctx);
+  static std::unique_ptr<AArch64Operand>
+  CreatePSBHint(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
+    return CreateNamedHintOperand<k_PSBHint, &AArch64Operand::PSBHint>(
+        Val, Str, S, Ctx, PSBHintEncoding{});
   }
 
-  static std::unique_ptr<AArch64Operand> CreateBTIHint(unsigned Val,
-                                                       StringRef Str,
-                                                       SMLoc S,
-                                                       MCContext &Ctx) {
+  static std::unique_ptr<AArch64Operand>
+  CreateBTIHint(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
     return CreateNamedHintOperand<k_BTIHint, &AArch64Operand::BTIHint,
                                   BTIHintEncoding>(Val, Str, S, Ctx);
   }
@@ -2663,20 +2635,13 @@ public:
   static std::unique_ptr<AArch64Operand>
   CreateSHUHint(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
     return CreateNamedHintOperand<k_SHUHint, &AArch64Operand::SHUHint>(
-        Val, Str, S, Ctx, [](unsigned EncodedVal) { return EncodedVal + 50; });
+        Val, Str, S, Ctx, SHUHintEncoding{});
   }
 
   static std::unique_ptr<AArch64Operand>
   CreateTSBHint(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
     return CreateNamedHintOperand<k_TSBHint, &AArch64Operand::TSBHint>(
-        Val, Str, S, Ctx, [](unsigned EncodedVal) { return EncodedVal | 16; });
-  }
-
-  static std::unique_ptr<AArch64Operand>
-  CreateCMHPriorityHint(unsigned Val, StringRef Str, SMLoc S, MCContext &Ctx) {
-    return CreateNamedHintOperand<k_CMHPriorityHint,
-                                  &AArch64Operand::CMHPriorityHint>(Val, Str, S,
-                                                                    Ctx);
+        Val, Str, S, Ctx, TSBHintEncoding{});
   }
 
   static std::unique_ptr<AArch64Operand>
@@ -2789,8 +2754,8 @@ void AArch64Operand::print(raw_ostream &OS, const MCAsmInfo &MAI) const {
   case k_PSBHint:
     OS << getPSBHintName();
     break;
-  case k_PHint:
-    OS << getPHintName();
+  case k_PCDPHint:
+    OS << getPCDPHintName();
     break;
   case k_BTIHint:
     OS << getBTIHintName();
@@ -2800,9 +2765,6 @@ void AArch64Operand::print(raw_ostream &OS, const MCAsmInfo &MAI) const {
     break;
   case k_TSBHint:
     OS << getTSBHintName();
-    break;
-  case k_CMHPriorityHint:
-    OS << getCMHPriorityHintName();
     break;
   case k_TIndexHint:
     OS << getTIndexHintName();
@@ -3363,9 +3325,9 @@ ParseStatus AArch64AsmParser::tryParsePrefetch(OperandVector &Operands) {
   return ParseStatus::Success;
 }
 
-/// tryParsePSBHint - Try to parse a PSB operand, mapped to Hint command
-ParseStatus AArch64AsmParser::tryParsePSBHint(OperandVector &Operands) {
-  return tryParseNamedHintOperand(Operands, AArch64PSBHint::lookupPSBByName,
+/// tryParsePSBHintOperand - Try to parse a PSB operand, mapped to Hint command
+ParseStatus AArch64AsmParser::tryParsePSBHintOperand(OperandVector &Operands) {
+  return tryParseNamedHintOperand(Operands, AArch64PSBHint::lookupPSBHintByName,
                                   AArch64Operand::CreatePSBHint);
 }
 
@@ -3402,17 +3364,10 @@ ParseStatus AArch64AsmParser::tryParseSyspXzrPair(OperandVector &Operands) {
   return ParseStatus::Success;
 }
 
-/// tryParseBTIHint - Try to parse a BTI operand, mapped to Hint command
-ParseStatus AArch64AsmParser::tryParseBTIHint(OperandVector &Operands) {
-  return tryParseNamedHintOperand(Operands, AArch64BTIHint::lookupBTIByName,
+/// tryParseBTIHintOperand - Try to parse a BTI operand, mapped to Hint command
+ParseStatus AArch64AsmParser::tryParseBTIHintOperand(OperandVector &Operands) {
+  return tryParseNamedHintOperand(Operands, AArch64BTIHint::lookupBTIHintByName,
                                   AArch64Operand::CreateBTIHint);
-}
-
-/// tryParseCMHPriorityHint - Try to parse a CMHPriority operand
-ParseStatus AArch64AsmParser::tryParseCMHPriorityHint(OperandVector &Operands) {
-  return tryParseNamedHintOperand(
-      Operands, AArch64CMHPriorityHint::lookupCMHPriorityHintByName,
-      AArch64Operand::CreateCMHPriorityHint);
 }
 
 /// tryParseTIndexHint - Try to parse a TIndex operand
@@ -4342,15 +4297,15 @@ ParseStatus AArch64AsmParser::tryParseBarrierOperand(OperandVector &Operands) {
     return TokError("invalid operand for instruction");
 
   StringRef Operand = Tok.getString();
-  bool IsTSB = Mnemonic == "tsb" && Operand == "csync";
+  auto TSB = AArch64TSBHint::lookupTSBHintByName(Operand);
   auto DB = AArch64DB::lookupDBByName(Operand);
   // The only valid named option for ISB is 'sy'
   if (Mnemonic == "isb" && (!DB || DB->Encoding != AArch64DB::sy))
     return TokError("'sy' or #imm operand expected");
   // The only valid named option for TSB is 'csync'
-  if (Mnemonic == "tsb" && !IsTSB)
+  if (Mnemonic == "tsb" && (!TSB || TSB->Encoding != AArch64TSBHint::csync))
     return TokError("'csync' operand expected");
-  if (!DB && !IsTSB) {
+  if (!DB && (Mnemonic != "tsb" || !TSB)) {
     if (Mnemonic == "dsb") {
       // This case is a no match here, but it might be matched by the nXS
       // variant.
@@ -4360,8 +4315,8 @@ ParseStatus AArch64AsmParser::tryParseBarrierOperand(OperandVector &Operands) {
   }
 
   Operands.push_back(AArch64Operand::CreateBarrier(
-      DB ? DB->Encoding : 2, Tok.getString(), getLoc(), getContext(),
-      false /*hasnXSModifier*/));
+      DB ? DB->Encoding : TSB->Encoding, Tok.getString(), getLoc(),
+      getContext(), false /*hasnXSModifier*/));
   Lex(); // Consume the option
 
   return ParseStatus::Success;
@@ -4448,10 +4403,10 @@ ParseStatus AArch64AsmParser::tryParseSysReg(OperandVector &Operands) {
   return ParseStatus::Success;
 }
 
-ParseStatus
-AArch64AsmParser::tryParsePHintInstOperand(OperandVector &Operands) {
-  return tryParseNamedHintOperand(Operands, AArch64PHint::lookupPHintByName,
-                                  AArch64Operand::CreatePHintInst);
+ParseStatus AArch64AsmParser::tryParsePCDPHintOperand(OperandVector &Operands) {
+  return tryParseNamedHintOperand(Operands,
+                                  AArch64PCDPHint::lookupPCDPHintByName,
+                                  AArch64Operand::CreatePCDPHint);
 }
 
 ParseStatus AArch64AsmParser::tryParseSHUHintOperand(OperandVector &Operands) {

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.cpp
@@ -1593,6 +1593,28 @@ void AArch64InstPrinter::printBTIHintOp(const MCInst *MI, unsigned OpNum,
     markup(O, Markup::Immediate) << '#' << formatImm(btihintop);
 }
 
+void AArch64InstPrinter::printSHUHintOp(const MCInst *MI, unsigned OpNum,
+                                        const MCSubtargetInfo &STI,
+                                        raw_ostream &O) {
+  unsigned shuhintop = MI->getOperand(OpNum).getImm() - 50;
+  auto SHU = AArch64CMHPriorityHint::lookupCMHPriorityHintByEncoding(shuhintop);
+  if (SHU)
+    O << SHU->Name;
+  else
+    markup(O, Markup::Immediate) << '#' << formatImm(shuhintop);
+}
+
+void AArch64InstPrinter::printTSBHintOp(const MCInst *MI, unsigned OpNum,
+                                        const MCSubtargetInfo &STI,
+                                        raw_ostream &O) {
+  unsigned tsbhintop = MI->getOperand(OpNum).getImm() ^ 16;
+  auto TSB = AArch64TSB::lookupTSBByEncoding(tsbhintop);
+  if (TSB)
+    O << TSB->Name;
+  else
+    markup(O, Markup::Immediate) << '#' << formatImm(tsbhintop);
+}
+
 void AArch64InstPrinter::printCMHPriorityHintOp(const MCInst *MI,
                                                 unsigned OpNum,
                                                 const MCSubtargetInfo &STI,
@@ -1966,9 +1988,6 @@ void AArch64InstPrinter::printBarrierOption(const MCInst *MI, unsigned OpNo,
   if (Opcode == AArch64::ISB) {
     auto ISB = AArch64ISB::lookupISBByEncoding(Val);
     Name = ISB ? ISB->Name : "";
-  } else if (Opcode == AArch64::TSB) {
-    auto TSB = AArch64TSB::lookupTSBByEncoding(Val);
-    Name = TSB ? TSB->Name : "";
   } else {
     auto DB = AArch64DB::lookupDBByEncoding(Val);
     Name = DB ? DB->Name : "";

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.cpp
@@ -1586,14 +1586,21 @@ void AArch64InstPrinter::printPSBHintOp(const MCInst *MI, unsigned OpNum,
                                         const MCSubtargetInfo &STI,
                                         raw_ostream &O) {
   printNamedHintOp(MI->getOperand(OpNum).getImm(), O,
-                   AArch64PSBHint::lookupPSBByEncoding, decodeIdentityHint);
+                   AArch64PSBHint::lookupPSBHintByEncoding, decodePSBHint);
+}
+
+void AArch64InstPrinter::printPCDPHintOp(const MCInst *MI, unsigned OpNum,
+                                         const MCSubtargetInfo &STI,
+                                         raw_ostream &O) {
+  printNamedHintOp(MI->getOperand(OpNum).getImm(), O,
+                   AArch64PCDPHint::lookupPCDPHintByEncoding, decodePCDPHint);
 }
 
 void AArch64InstPrinter::printBTIHintOp(const MCInst *MI, unsigned OpNum,
                                         const MCSubtargetInfo &STI,
                                         raw_ostream &O) {
   printNamedHintOp(MI->getOperand(OpNum).getImm(), O,
-                   AArch64BTIHint::lookupBTIByEncoding, decodeBTIHint);
+                   AArch64BTIHint::lookupBTIHintByEncoding, decodeBTIHint);
 }
 
 void AArch64InstPrinter::printSHUHintOp(const MCInst *MI, unsigned OpNum,
@@ -1608,15 +1615,6 @@ void AArch64InstPrinter::printTSBHintOp(const MCInst *MI, unsigned OpNum,
                                         raw_ostream &O) {
   printNamedHintOp(MI->getOperand(OpNum).getImm(), O,
                    AArch64TSBHint::lookupTSBHintByEncoding, decodeTSBHint);
-}
-
-void AArch64InstPrinter::printCMHPriorityHintOp(const MCInst *MI,
-                                                unsigned OpNum,
-                                                const MCSubtargetInfo &STI,
-                                                raw_ostream &O) {
-  printNamedHintOp(MI->getOperand(OpNum).getImm(), O,
-                   AArch64CMHPriorityHint::lookupCMHPriorityHintByEncoding,
-                   decodeIdentityHint);
 }
 
 void AArch64InstPrinter::printTIndexHintOp(const MCInst *MI, unsigned OpNum,
@@ -2266,11 +2264,4 @@ void AArch64InstPrinter::printSyspXzrPair(const MCInst *MI, unsigned OpNum,
   assert(Reg == AArch64::XZR &&
          "MC representation of SyspXzrPair should be XZR");
   O << getRegisterName(Reg) << ", " << getRegisterName(Reg);
-}
-
-void AArch64InstPrinter::printPHintOp(const MCInst *MI, unsigned OpNum,
-                                      const MCSubtargetInfo &STI,
-                                      raw_ostream &O) {
-  printNamedHintOp(MI->getOperand(OpNum).getImm(), O,
-                   AArch64PHint::lookupPHintByEncoding, decodePHint);
 }

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.cpp
@@ -1596,6 +1596,28 @@ void AArch64InstPrinter::printBTIHintOp(const MCInst *MI, unsigned OpNum,
                    AArch64BTIHint::lookupBTIByEncoding, decodeBTIHint);
 }
 
+void AArch64InstPrinter::printSHUHintOp(const MCInst *MI, unsigned OpNum,
+                                        const MCSubtargetInfo &STI,
+                                        raw_ostream &O) {
+  unsigned shuhintop = MI->getOperand(OpNum).getImm() - 50;
+  auto SHU = AArch64CMHPriorityHint::lookupCMHPriorityHintByEncoding(shuhintop);
+  if (SHU)
+    O << SHU->Name;
+  else
+    markup(O, Markup::Immediate) << '#' << formatImm(shuhintop);
+}
+
+void AArch64InstPrinter::printTSBHintOp(const MCInst *MI, unsigned OpNum,
+                                        const MCSubtargetInfo &STI,
+                                        raw_ostream &O) {
+  unsigned tsbhintop = MI->getOperand(OpNum).getImm() ^ 16;
+  auto TSB = AArch64TSB::lookupTSBByEncoding(tsbhintop);
+  if (TSB)
+    O << TSB->Name;
+  else
+    markup(O, Markup::Immediate) << '#' << formatImm(tsbhintop);
+}
+
 void AArch64InstPrinter::printCMHPriorityHintOp(const MCInst *MI,
                                                 unsigned OpNum,
                                                 const MCSubtargetInfo &STI,
@@ -1962,9 +1984,6 @@ void AArch64InstPrinter::printBarrierOption(const MCInst *MI, unsigned OpNo,
   if (Opcode == AArch64::ISB) {
     auto ISB = AArch64ISB::lookupISBByEncoding(Val);
     Name = ISB ? ISB->Name : "";
-  } else if (Opcode == AArch64::TSB) {
-    auto TSB = AArch64TSB::lookupTSBByEncoding(Val);
-    Name = TSB ? TSB->Name : "";
   } else {
     auto DB = AArch64DB::lookupDBByEncoding(Val);
     Name = DB ? DB->Name : "";

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.cpp
@@ -1599,23 +1599,15 @@ void AArch64InstPrinter::printBTIHintOp(const MCInst *MI, unsigned OpNum,
 void AArch64InstPrinter::printSHUHintOp(const MCInst *MI, unsigned OpNum,
                                         const MCSubtargetInfo &STI,
                                         raw_ostream &O) {
-  unsigned shuhintop = MI->getOperand(OpNum).getImm() - 50;
-  auto SHU = AArch64CMHPriorityHint::lookupCMHPriorityHintByEncoding(shuhintop);
-  if (SHU)
-    O << SHU->Name;
-  else
-    markup(O, Markup::Immediate) << '#' << formatImm(shuhintop);
+  printNamedHintOp(MI->getOperand(OpNum).getImm(), O,
+                   AArch64SHUHint::lookupSHUHintByEncoding, decodeSHUHint);
 }
 
 void AArch64InstPrinter::printTSBHintOp(const MCInst *MI, unsigned OpNum,
                                         const MCSubtargetInfo &STI,
                                         raw_ostream &O) {
-  unsigned tsbhintop = MI->getOperand(OpNum).getImm() ^ 16;
-  auto TSB = AArch64TSB::lookupTSBByEncoding(tsbhintop);
-  if (TSB)
-    O << TSB->Name;
-  else
-    markup(O, Markup::Immediate) << '#' << formatImm(tsbhintop);
+  printNamedHintOp(MI->getOperand(OpNum).getImm(), O,
+                   AArch64TSBHint::lookupTSBHintByEncoding, decodeTSBHint);
 }
 
 void AArch64InstPrinter::printCMHPriorityHintOp(const MCInst *MI,
@@ -2280,5 +2272,5 @@ void AArch64InstPrinter::printPHintOp(const MCInst *MI, unsigned OpNum,
                                       const MCSubtargetInfo &STI,
                                       raw_ostream &O) {
   printNamedHintOp(MI->getOperand(OpNum).getImm(), O,
-                   AArch64PHint::lookupPHintByEncoding, decodeIdentityHint);
+                   AArch64PHint::lookupPHintByEncoding, decodePHint);
 }

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.h
@@ -153,6 +153,12 @@ protected:
   void printBTIHintOp(const MCInst *MI, unsigned OpNum,
                       const MCSubtargetInfo &STI, raw_ostream &O);
 
+  void printSHUHintOp(const MCInst *MI, unsigned OpNum,
+                      const MCSubtargetInfo &STI, raw_ostream &O);
+
+  void printTSBHintOp(const MCInst *MI, unsigned OpNum,
+                      const MCSubtargetInfo &STI, raw_ostream &O);
+
   void printCMHPriorityHintOp(const MCInst *MI, unsigned OpNum,
                               const MCSubtargetInfo &STI, raw_ostream &O);
 

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.h
@@ -174,6 +174,9 @@ protected:
 
   static unsigned decodeIdentityHint(unsigned Value) { return Value; }
   static unsigned decodeBTIHint(unsigned Value) { return Value ^ 32; }
+  static unsigned decodePHint(unsigned Value) { return Value - 48; }
+  static unsigned decodeSHUHint(unsigned Value) { return Value - 50; }
+  static unsigned decodeTSBHint(unsigned Value) { return Value ^ 16; }
 
   void printVectorList(const MCInst *MI, unsigned OpNum,
                        const MCSubtargetInfo &STI, raw_ostream &O,

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.h
@@ -150,6 +150,9 @@ protected:
   void printPSBHintOp(const MCInst *MI, unsigned OpNum,
                       const MCSubtargetInfo &STI, raw_ostream &O);
 
+  void printPCDPHintOp(const MCInst *MI, unsigned OpNum,
+                       const MCSubtargetInfo &STI, raw_ostream &O);
+
   void printBTIHintOp(const MCInst *MI, unsigned OpNum,
                       const MCSubtargetInfo &STI, raw_ostream &O);
 
@@ -158,9 +161,6 @@ protected:
 
   void printTSBHintOp(const MCInst *MI, unsigned OpNum,
                       const MCSubtargetInfo &STI, raw_ostream &O);
-
-  void printCMHPriorityHintOp(const MCInst *MI, unsigned OpNum,
-                              const MCSubtargetInfo &STI, raw_ostream &O);
 
   void printTIndexHintOp(const MCInst *MI, unsigned OpNum,
                          const MCSubtargetInfo &STI, raw_ostream &O);
@@ -173,10 +173,11 @@ protected:
                         LookupFn LookupByEncoding, DecodeFn DecodeValue);
 
   static unsigned decodeIdentityHint(unsigned Value) { return Value; }
-  static unsigned decodeBTIHint(unsigned Value) { return Value ^ 32; }
-  static unsigned decodePHint(unsigned Value) { return Value - 48; }
+  static unsigned decodePSBHint(unsigned Value) { return Value - 16; }
+  static unsigned decodePCDPHint(unsigned Value) { return Value - 48; }
+  static unsigned decodeBTIHint(unsigned Value) { return Value - 32; }
   static unsigned decodeSHUHint(unsigned Value) { return Value - 50; }
-  static unsigned decodeTSBHint(unsigned Value) { return Value ^ 16; }
+  static unsigned decodeTSBHint(unsigned Value) { return Value - 16; }
 
   void printVectorList(const MCInst *MI, unsigned OpNum,
                        const MCSubtargetInfo &STI, raw_ostream &O,
@@ -261,8 +262,6 @@ protected:
   template <unsigned ImmIs0, unsigned ImmIs1>
   void printExactFPImm(const MCInst *MI, unsigned OpNum,
                        const MCSubtargetInfo &STI, raw_ostream &O);
-  void printPHintOp(const MCInst *MI, unsigned OpNum,
-                    const MCSubtargetInfo &STI, raw_ostream &O);
 };
 
 class AArch64AppleInstPrinter : public AArch64InstPrinter {

--- a/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.cpp
+++ b/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.cpp
@@ -60,13 +60,6 @@ namespace llvm {
 }
 
 namespace llvm {
-  namespace AArch64TSB {
-#define GET_TSBsList_IMPL
-#include "AArch64GenSystemOperands.inc"
-  }
-}
-
-namespace llvm {
   namespace AArch64PRFM {
 #define GET_PRFMsList_IMPL
 #include "AArch64GenSystemOperands.inc"
@@ -126,9 +119,16 @@ namespace llvm {
 
 namespace llvm {
 namespace AArch64PHint {
-#define GET_PHintsList_IMPL
+#define GET_PHINT_IMPL
 #include "AArch64GenSystemOperands.inc"
 } // namespace AArch64PHint
+} // namespace llvm
+
+namespace llvm {
+namespace AArch64TSBHint {
+#define GET_TSBHINT_IMPL
+#include "AArch64GenSystemOperands.inc"
+} // namespace AArch64TSBHint
 } // namespace llvm
 
 namespace llvm {
@@ -143,6 +143,13 @@ namespace AArch64CMHPriorityHint {
 #define GET_CMHPRIORITYHINT_IMPL
 #include "AArch64GenSystemOperands.inc"
 } // namespace AArch64CMHPriorityHint
+} // namespace llvm
+
+namespace llvm {
+namespace AArch64SHUHint {
+#define GET_SHUHINT_IMPL
+#include "AArch64GenSystemOperands.inc"
+} // namespace AArch64SHUHint
 } // namespace llvm
 
 namespace llvm {

--- a/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.cpp
+++ b/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.cpp
@@ -111,17 +111,31 @@ namespace llvm {
 }
 
 namespace llvm {
-  namespace AArch64PSBHint {
-#define GET_PSBsList_IMPL
+namespace AArch64PSBHint {
+#define GET_PSBHINT_IMPL
+#include "AArch64GenSystemOperands.inc"
+} // namespace AArch64PSBHint
+} // namespace llvm
+
+namespace llvm {
+namespace AArch64PCDPHint {
+#define GET_PCDPHINT_IMPL
+#include "AArch64GenSystemOperands.inc"
+} // namespace AArch64PCDPHint
+} // namespace llvm
+
+namespace llvm {
+  namespace AArch64BTIHint {
+#define GET_BTIHINT_IMPL
 #include "AArch64GenSystemOperands.inc"
   }
 }
 
 namespace llvm {
-namespace AArch64PHint {
-#define GET_PHINT_IMPL
+namespace AArch64SHUHint {
+#define GET_SHUHINT_IMPL
 #include "AArch64GenSystemOperands.inc"
-} // namespace AArch64PHint
+} // namespace AArch64SHUHint
 } // namespace llvm
 
 namespace llvm {
@@ -129,27 +143,6 @@ namespace AArch64TSBHint {
 #define GET_TSBHINT_IMPL
 #include "AArch64GenSystemOperands.inc"
 } // namespace AArch64TSBHint
-} // namespace llvm
-
-namespace llvm {
-  namespace AArch64BTIHint {
-#define GET_BTIsList_IMPL
-#include "AArch64GenSystemOperands.inc"
-  }
-}
-
-namespace llvm {
-namespace AArch64CMHPriorityHint {
-#define GET_CMHPRIORITYHINT_IMPL
-#include "AArch64GenSystemOperands.inc"
-} // namespace AArch64CMHPriorityHint
-} // namespace llvm
-
-namespace llvm {
-namespace AArch64SHUHint {
-#define GET_SHUHINT_IMPL
-#include "AArch64GenSystemOperands.inc"
-} // namespace AArch64SHUHint
 } // namespace llvm
 
 namespace llvm {

--- a/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
+++ b/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
@@ -726,7 +726,7 @@ struct PHint {
 #include "AArch64GenSystemOperands.inc"
 
 const PHint *lookupPHintByName(StringRef);
-const PHint *lookupPHintByEncoding(uint16_t);
+const PHint *lookupPHintByEncoding(uint8_t);
 } // namespace AArch64PHint
 
 namespace AArch64BTIHint {

--- a/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
+++ b/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
@@ -541,15 +541,6 @@ namespace  AArch64ISB {
 #include "AArch64GenSystemOperands.inc"
 }
 
-namespace  AArch64TSB {
-  struct TSB : SysAlias {
-    using SysAlias::SysAlias;
-  };
-#define GET_TSBValues_DECL
-#define GET_TSBsList_DECL
-#include "AArch64GenSystemOperands.inc"
-}
-
 namespace AArch64PRFM {
   struct PRFM : SysAlias {
     using SysAlias::SysAlias;
@@ -710,24 +701,22 @@ namespace AArch64PSBHint {
 }
 
 namespace AArch64PHint {
-struct PHint {
-  const char *Name;
-  unsigned Encoding;
-  FeatureBitset FeaturesRequired;
-
-  bool haveFeatures(FeatureBitset ActiveFeatures) const {
-    return ActiveFeatures[llvm::AArch64::FeatureAll] ||
-           (FeaturesRequired & ActiveFeatures) == FeaturesRequired;
-  }
+struct PHint : SysAlias {
+  using SysAlias::SysAlias;
 };
 
-#define GET_PHintValues_DECL
-#define GET_PHintsList_DECL
+#define GET_PHINT_DECL
 #include "AArch64GenSystemOperands.inc"
-
-const PHint *lookupPHintByName(StringRef);
-const PHint *lookupPHintByEncoding(uint8_t);
 } // namespace AArch64PHint
+
+namespace AArch64TSBHint {
+struct TSBHint : SysAlias {
+  using SysAlias::SysAlias;
+};
+
+#define GET_TSBHINT_DECL
+#include "AArch64GenSystemOperands.inc"
+} // namespace AArch64TSBHint
 
 namespace AArch64BTIHint {
   struct BTI : SysAlias {
@@ -736,6 +725,10 @@ namespace AArch64BTIHint {
 #define GET_BTIValues_DECL
 #define GET_BTIsList_DECL
 #include "AArch64GenSystemOperands.inc"
+
+  inline static bool isHintSpaceBTI(int64_t Imm) {
+    return Imm >= 32 && Imm < 64 && lookupBTIByEncoding(Imm ^ 32);
+  }
 }
 
 namespace AArch64CMHPriorityHint {
@@ -745,6 +738,15 @@ struct CMHPriorityHint : SysAlias {
 #define GET_CMHPRIORITYHINT_DECL
 #include "AArch64GenSystemOperands.inc"
 } // namespace AArch64CMHPriorityHint
+
+namespace AArch64SHUHint {
+struct SHUHint : SysAlias {
+  using SysAlias::SysAlias;
+};
+
+#define GET_SHUHINT_DECL
+#include "AArch64GenSystemOperands.inc"
+} // namespace AArch64SHUHint
 
 namespace AArch64TIndexHint {
 struct TIndex : SysAlias {

--- a/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
+++ b/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
@@ -692,52 +692,33 @@ namespace AArch64PState {
 }
 
 namespace AArch64PSBHint {
-  struct PSB : SysAlias {
-    using SysAlias::SysAlias;
-  };
-#define GET_PSBValues_DECL
-#define GET_PSBsList_DECL
+struct PSBHint : SysAlias {
+  using SysAlias::SysAlias;
+};
+#define GET_PSBHINT_DECL
 #include "AArch64GenSystemOperands.inc"
-}
+} // namespace AArch64PSBHint
 
-namespace AArch64PHint {
-struct PHint : SysAlias {
+namespace AArch64PCDPHint {
+struct PCDPHint : SysAlias {
   using SysAlias::SysAlias;
 };
 
-#define GET_PHINT_DECL
+#define GET_PCDPHINT_DECL
 #include "AArch64GenSystemOperands.inc"
-} // namespace AArch64PHint
-
-namespace AArch64TSBHint {
-struct TSBHint : SysAlias {
-  using SysAlias::SysAlias;
-};
-
-#define GET_TSBHINT_DECL
-#include "AArch64GenSystemOperands.inc"
-} // namespace AArch64TSBHint
+} // namespace AArch64PCDPHint
 
 namespace AArch64BTIHint {
-  struct BTI : SysAlias {
-    using SysAlias::SysAlias;
-  };
-#define GET_BTIValues_DECL
-#define GET_BTIsList_DECL
+struct BTIHint : SysAlias {
+  using SysAlias::SysAlias;
+};
+#define GET_BTIHINT_DECL
 #include "AArch64GenSystemOperands.inc"
 
   inline static bool isHintSpaceBTI(int64_t Imm) {
-    return Imm >= 32 && Imm < 64 && lookupBTIByEncoding(Imm ^ 32);
+    return Imm >= 32 && Imm < 64 && lookupBTIHintByEncoding(Imm - 32);
   }
 }
-
-namespace AArch64CMHPriorityHint {
-struct CMHPriorityHint : SysAlias {
-  using SysAlias::SysAlias;
-};
-#define GET_CMHPRIORITYHINT_DECL
-#include "AArch64GenSystemOperands.inc"
-} // namespace AArch64CMHPriorityHint
 
 namespace AArch64SHUHint {
 struct SHUHint : SysAlias {
@@ -747,6 +728,15 @@ struct SHUHint : SysAlias {
 #define GET_SHUHINT_DECL
 #include "AArch64GenSystemOperands.inc"
 } // namespace AArch64SHUHint
+
+namespace AArch64TSBHint {
+struct TSBHint : SysAlias {
+  using SysAlias::SysAlias;
+};
+
+#define GET_TSBHINT_DECL
+#include "AArch64GenSystemOperands.inc"
+} // namespace AArch64TSBHint
 
 namespace AArch64TIndexHint {
 struct TIndex : SysAlias {

--- a/llvm/test/MC/AArch64/armv8.2a-statistical-profiling.s
+++ b/llvm/test/MC/AArch64/armv8.2a-statistical-profiling.s
@@ -9,6 +9,9 @@
 // NO_SPE_OUT-NOT: mrs
 // NO_SPE_OUT-NOT: psb
 
+  hint #17
+// CHECK: psb csync              // encoding: [0x3f,0x22,0x03,0xd5]
+
   psb csync
 // CHECK: psb csync              // encoding: [0x3f,0x22,0x03,0xd5]
 // NO_SPE:  instruction requires: spe

--- a/llvm/test/MC/AArch64/armv8.4a-trace-error.s
+++ b/llvm/test/MC/AArch64/armv8.4a-trace-error.s
@@ -12,12 +12,12 @@ tsb 0
 //CHECK-ERROR: error: too few operands for instruction
 //CHECK-ERROR: tsb
 //CHECK-ERROR: ^
-//CHECK-ERROR: error: 'csync' operand expected
+//CHECK-ERROR: error: invalid operand for instruction
 //CHECK-ERROR: tsb foo
 //CHECK-ERROR:     ^
-//CHECK-ERROR: error: 'csync' operand expected
+//CHECK-ERROR: error: invalid operand for instruction
 //CHECK-ERROR: tsb #0
 //CHECK-ERROR:     ^
-//CHECK-ERROR: error: 'csync' operand expected
+//CHECK-ERROR: error: invalid operand for instruction
 //CHECK-ERROR: tsb 0
 //CHECK-ERROR:     ^

--- a/llvm/test/MC/AArch64/armv8.4a-trace.s
+++ b/llvm/test/MC/AArch64/armv8.4a-trace.s
@@ -10,6 +10,10 @@
 // RUN: not llvm-mc -triple aarch64-none-linux-gnu -show-encoding -mattr=+v8.4a,-tracev8.4 -o - %s 2>&1 | \
 // RUN: FileCheck %s --check-prefixes CHECK-ERROR
 
+// RUN: llvm-mc -triple aarch64-none-linux-gnu -filetype=obj -mattr=+tracev8.4 %s \
+// RUN:        | llvm-objdump -d --mattr=+tracev8.4 --no-print-imm-hex - \
+// RUN:        | FileCheck %s --check-prefix=CHECK-HINT-ALIAS
+
 //------------------------------------------------------------------------------
 // ARMV8.4-A Debug, Trace and PMU Extensions
 //------------------------------------------------------------------------------
@@ -22,6 +26,9 @@ mrs x0, TRFCR_EL1
 mrs x0, TRFCR_EL2
 mrs x0, TRFCR_EL12
 
+hint #18
+//CHECK-HINT-ALIAS: tsb csync
+
 tsb csync
 
 //CHECK:  msr TRFCR_EL1, x0           // encoding: [0x20,0x12,0x18,0xd5]
@@ -32,6 +39,7 @@ tsb csync
 //CHECK:  mrs x0, TRFCR_EL2           // encoding: [0x20,0x12,0x3c,0xd5]
 //CHECK:  mrs x0, TRFCR_EL12          // encoding: [0x20,0x12,0x3d,0xd5]
 
+//CHECK:  tsb csync                   // encoding: [0x5f,0x22,0x03,0xd5]
 //CHECK:  tsb csync                   // encoding: [0x5f,0x22,0x03,0xd5]
 
 //CHECK-ERROR: error: expected writable system register or pstate

--- a/llvm/test/MC/AArch64/armv8.4a-trace.s
+++ b/llvm/test/MC/AArch64/armv8.4a-trace.s
@@ -10,10 +10,6 @@
 // RUN: not llvm-mc -triple aarch64-none-linux-gnu -show-encoding -mattr=+v8.4a,-tracev8.4 -o - %s 2>&1 | \
 // RUN: FileCheck %s --check-prefixes CHECK-ERROR
 
-// RUN: llvm-mc -triple aarch64-none-linux-gnu -filetype=obj -mattr=+tracev8.4 %s \
-// RUN:        | llvm-objdump -d --mattr=+tracev8.4 --no-print-imm-hex - \
-// RUN:        | FileCheck %s --check-prefix=CHECK-HINT-ALIAS
-
 //------------------------------------------------------------------------------
 // ARMV8.4-A Debug, Trace and PMU Extensions
 //------------------------------------------------------------------------------
@@ -27,8 +23,6 @@ mrs x0, TRFCR_EL2
 mrs x0, TRFCR_EL12
 
 hint #18
-//CHECK-HINT-ALIAS: tsb csync
-
 tsb csync
 
 //CHECK:  msr TRFCR_EL1, x0           // encoding: [0x20,0x12,0x18,0xd5]
@@ -40,7 +34,7 @@ tsb csync
 //CHECK:  mrs x0, TRFCR_EL12          // encoding: [0x20,0x12,0x3d,0xd5]
 
 //CHECK:  tsb csync                   // encoding: [0x5f,0x22,0x03,0xd5]
-//CHECK:  tsb csync                   // encoding: [0x5f,0x22,0x03,0xd5]
+//CHECK-NEXT:  tsb csync              // encoding: [0x5f,0x22,0x03,0xd5]
 
 //CHECK-ERROR: error: expected writable system register or pstate
 //CHECK-ERROR: msr TRFCR_EL1, x0

--- a/llvm/test/MC/AArch64/armv9.5a-pauthlr.s
+++ b/llvm/test/MC/AArch64/armv9.5a-pauthlr.s
@@ -170,6 +170,12 @@ label1:
 // CHECK-ERROR: instruction requires: pauth-lr
 // CHECK-UNKNOWN: d65f0fe3 <unknown>
 
+  hint #39
+// CHECK-INST: hint #39
+// CHECK-DISASS: pacm
+// CHECK-ENCODING: [0xff,0x24,0x03,0xd5]
+// CHECK-UNKNOWN: d50324ff hint #39
+
   pacm
 // CHECK-INST: pacm
 // CHECK-DISASS: pacm

--- a/llvm/test/MC/AArch64/armv9.6a-pcdphint.s
+++ b/llvm/test/MC/AArch64/armv9.6a-pcdphint.s
@@ -6,7 +6,15 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
 // RUN:        | llvm-mc -triple=aarch64 -disassemble -show-encoding \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST,CHECK-HINT-ALIAS
+
+hint #48
+// CHECK-HINT-ALIAS: stshh keep
+// CHECK-ENCODING: encoding: [0x1f,0x26,0x03,0xd5]
+
+hint #49
+// CHECK-HINT-ALIAS: stshh strm
+// CHECK-ENCODING: encoding: [0x3f,0x26,0x03,0xd5]
 
 stshh keep
 // CHECK-INST: stshh keep

--- a/llvm/test/MC/AArch64/armv9.6a-pcdphint.s
+++ b/llvm/test/MC/AArch64/armv9.6a-pcdphint.s
@@ -13,7 +13,7 @@ hint #48
 // CHECK-ENCODING: encoding: [0x1f,0x26,0x03,0xd5]
 
 hint #49
-// CHECK-HINT-ALIAS: stshh strm
+// CHECK-HINT-ALIAS-NEXT: stshh strm
 // CHECK-ENCODING: encoding: [0x3f,0x26,0x03,0xd5]
 
 stshh keep

--- a/llvm/test/MC/AArch64/armv9.7a-memsys.s
+++ b/llvm/test/MC/AArch64/armv9.7a-memsys.s
@@ -10,9 +10,21 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+lscp < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
 // RUN:        | llvm-mc -triple=aarch64 -mattr=+lscp -disassemble -show-encoding \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST,CHECK-HINT-ALIAS
 
 // Armv9.7-A Contention Management Hints (FEAT_CMH).
+
+hint #50
+// CHECK-HINT-ALIAS: shuh
+// CHECK-ENCODING: encoding: [0x5f,0x26,0x03,0xd5]
+
+hint #51
+// CHECK-HINT-ALIAS: shuh  ph
+// CHECK-ENCODING: encoding: [0x7f,0x26,0x03,0xd5]
+
+hint #52
+// CHECK-HINT-ALIAS: stcph
+// CHECK-ENCODING: encoding: [0x9f,0x26,0x03,0xd5]
 
 shuh
 // CHECK-INST: shuh

--- a/llvm/test/MC/AArch64/armv9.7a-memsys.s
+++ b/llvm/test/MC/AArch64/armv9.7a-memsys.s
@@ -19,11 +19,11 @@ hint #50
 // CHECK-ENCODING: encoding: [0x5f,0x26,0x03,0xd5]
 
 hint #51
-// CHECK-HINT-ALIAS: shuh  ph
+// CHECK-HINT-ALIAS-NEXT: shuh  ph
 // CHECK-ENCODING: encoding: [0x7f,0x26,0x03,0xd5]
 
 hint #52
-// CHECK-HINT-ALIAS: stcph
+// CHECK-HINT-ALIAS-NEXT: stcph
 // CHECK-ENCODING: encoding: [0x9f,0x26,0x03,0xd5]
 
 shuh

--- a/llvm/test/MC/AArch64/basic-a64-instructions.s
+++ b/llvm/test/MC/AArch64/basic-a64-instructions.s
@@ -3460,8 +3460,20 @@ _func:
 //------------------------------------------------------------------------------
 
         hint #0
+        hint #1
+        hint #2
+        hint #3
+        hint #4
+        hint #5
+        hint #6
         hint #127
 // CHECK: nop                             // encoding: [0x1f,0x20,0x03,0xd5]
+// CHECK: yield                           // encoding: [0x3f,0x20,0x03,0xd5]
+// CHECK: wfe                             // encoding: [0x5f,0x20,0x03,0xd5]
+// CHECK: wfi                             // encoding: [0x7f,0x20,0x03,0xd5]
+// CHECK: sev                             // encoding: [0x9f,0x20,0x03,0xd5]
+// CHECK: sevl                            // encoding: [0xbf,0x20,0x03,0xd5]
+// CHECK: dgh                             // encoding: [0xdf,0x20,0x03,0xd5]
 // CHECK: hint    #{{127|0x7f}}           // encoding: [0xff,0x2f,0x03,0xd5]
 
         nop

--- a/llvm/test/MC/AArch64/basic-a64-instructions.s
+++ b/llvm/test/MC/AArch64/basic-a64-instructions.s
@@ -3468,13 +3468,13 @@ _func:
         hint #6
         hint #127
 // CHECK: nop                             // encoding: [0x1f,0x20,0x03,0xd5]
-// CHECK: yield                           // encoding: [0x3f,0x20,0x03,0xd5]
-// CHECK: wfe                             // encoding: [0x5f,0x20,0x03,0xd5]
-// CHECK: wfi                             // encoding: [0x7f,0x20,0x03,0xd5]
-// CHECK: sev                             // encoding: [0x9f,0x20,0x03,0xd5]
-// CHECK: sevl                            // encoding: [0xbf,0x20,0x03,0xd5]
-// CHECK: dgh                             // encoding: [0xdf,0x20,0x03,0xd5]
-// CHECK: hint    #{{127|0x7f}}           // encoding: [0xff,0x2f,0x03,0xd5]
+// CHECK-NEXT: yield                           // encoding: [0x3f,0x20,0x03,0xd5]
+// CHECK-NEXT: wfe                             // encoding: [0x5f,0x20,0x03,0xd5]
+// CHECK-NEXT: wfi                             // encoding: [0x7f,0x20,0x03,0xd5]
+// CHECK-NEXT: sev                             // encoding: [0x9f,0x20,0x03,0xd5]
+// CHECK-NEXT: sevl                            // encoding: [0xbf,0x20,0x03,0xd5]
+// CHECK-NEXT: dgh                             // encoding: [0xdf,0x20,0x03,0xd5]
+// CHECK-NEXT: hint    #{{127|0x7f}}           // encoding: [0xff,0x2f,0x03,0xd5]
 
         nop
         yield
@@ -5027,4 +5027,3 @@ _func:
 // CHECK: ret                                 // encoding: [0xc0,0x03,0x5f,0xd6]
 // CHECK: eret                                // encoding: [0xe0,0x03,0x9f,0xd6]
 // CHECK: drps                                // encoding: [0xe0,0x03,0xbf,0xd6]
-

--- a/llvm/test/MC/AArch64/ras-extension.s
+++ b/llvm/test/MC/AArch64/ras-extension.s
@@ -5,6 +5,9 @@
 // RUN: llvm-mc -triple aarch64-none-linux-gnu -show-encoding -mcpu=cortex-r82 < %s | FileCheck %s
 // RUN: llvm-mc -triple aarch64-none-linux-gnu -show-encoding -mattr=+v8r < %s | FileCheck %s
 
+  hint #16
+// CHECK: esb                             // encoding: [0x1f,0x22,0x03,0xd5]
+
   esb
 // CHECK: esb                             // encoding: [0x1f,0x22,0x03,0xd5]
 

--- a/llvm/test/MC/AArch64/speculation-barriers.s
+++ b/llvm/test/MC/AArch64/speculation-barriers.s
@@ -1,9 +1,11 @@
 // RUN: llvm-mc -triple aarch64-none-linux-gnu -show-encoding < %s | FileCheck %s
 
+hint #20
 csdb
 ssbb
 pssbb
 
+// CHECK: csdb   // encoding: [0x9f,0x22,0x03,0xd5]
 // CHECK: csdb   // encoding: [0x9f,0x22,0x03,0xd5]
 // CHECK: ssbb   // encoding: [0x9f,0x30,0x03,0xd5]
 // CHECK: pssbb  // encoding: [0x9f,0x34,0x03,0xd5]


### PR DESCRIPTION
Implement the following instructions as a `HINT` alias instead of a
dedicated instruction in separate classes:
   * `stshh`
   * `stcph`
   * `shuh`
   * `tsb`

and also updated `psb` handling to use the same named HINT operand
mechanism, and keep the named operand tables in the newer
`SearchableTable` style.

Rename `PHint` to `PCDPHint` for the `stshh` policy operand, and
replace `CMHPriorityHint` with `SHUHint`. Also convert `BTIHint` to
`SearchableTable` for consistency.

No test changes, apart from a small `tsb csync` error tweak because
it's now using shared, standard code. Add `HINT` test coverage for
`HINT`s `#1-#6`, `#16`, `#17`, `#18`, `#20`, `#39`, and `#48-#52`.