### PR TITLE
[runtimes] Skip custom linker validation for gpu/offload targets

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -429,12 +429,11 @@ if( LLVM_ENABLE_LLD )
 endif()
 
 if( LLVM_USE_LINKER )
+  check_cxx_source_compiles("int main() { return 0; }" _CAN_LINK_EXECUTABLE)
+  mark_as_advanced(_CAN_LINK_EXECUTABLE)
   append("-fuse-ld=${LLVM_USE_LINKER}"
     CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
-  # Skip linker validation in per-target runtime sub-builds since GPU/offload
-  # targets cannot link test executables via the cross-compiler. For other
-  # targets, linker configuration errors will be caught later at build time.
-  if(NOT LLVM_RUNTIMES_TARGET)
+  if(_CAN_LINK_EXECUTABLE)
     check_cxx_source_compiles("int main() { return 0; }" CXX_SUPPORTS_CUSTOM_LINKER)
     if ( NOT CXX_SUPPORTS_CUSTOM_LINKER )
       message(FATAL_ERROR "Host compiler does not support '-fuse-ld=${LLVM_USE_LINKER}'. "
@@ -442,6 +441,8 @@ if( LLVM_USE_LINKER )
                           "that your host compiler can compile a simple program when "
                           "given the option '-fuse-ld=${LLVM_USE_LINKER}'.")
     endif()
+  else()
+    message(STATUS "Skipping custom linker check: offload target cannot link executable")
   endif()
 endif()
 

--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -431,12 +431,17 @@ endif()
 if( LLVM_USE_LINKER )
   append("-fuse-ld=${LLVM_USE_LINKER}"
     CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
-  check_cxx_source_compiles("int main() { return 0; }" CXX_SUPPORTS_CUSTOM_LINKER)
-  if ( NOT CXX_SUPPORTS_CUSTOM_LINKER )
-    message(FATAL_ERROR "Host compiler does not support '-fuse-ld=${LLVM_USE_LINKER}'. "
-                        "Please make sure that '${LLVM_USE_LINKER}' is installed and "
-                        "that your host compiler can compile a simple program when "
-                        "given the option '-fuse-ld=${LLVM_USE_LINKER}'.")
+  # Skip linker validation in per-target runtime sub-builds since GPU/offload
+  # targets cannot link test executables via the cross-compiler. For other
+  # targets, linker configuration errors will be caught later at build time.
+  if(NOT LLVM_RUNTIMES_TARGET)
+    check_cxx_source_compiles("int main() { return 0; }" CXX_SUPPORTS_CUSTOM_LINKER)
+    if ( NOT CXX_SUPPORTS_CUSTOM_LINKER )
+      message(FATAL_ERROR "Host compiler does not support '-fuse-ld=${LLVM_USE_LINKER}'. "
+                          "Please make sure that '${LLVM_USE_LINKER}' is installed and "
+                          "that your host compiler can compile a simple program when "
+                          "given the option '-fuse-ld=${LLVM_USE_LINKER}'.")
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
This fixes `Host compiler does not support '-fuse-ld=lld'` error when cross-build libclc for gpu target. Cmake configure command is: -DRUNTIMES_amdgcn-amd-amdhsa-llvm_LLVM_ENABLE_RUNTIMES=libclc \ -DLLVM_RUNTIME_TARGETS="amdgcn-amd-amdhsa-llvm"
libclc targets only support offload target cross-build and can't link host executable. The configuration error is false positive for offload.

This PR adds a baseline test to first check if the target can link
executable. If it fails (typical for gpu/offload), we skip the custom
linker validation.