### PR TITLE
[NFC][SPIR-V] Remove stale XFAIL for spec_const_decoration.ll

### DIFF
--- a/llvm/test/CodeGen/SPIRV/spec_const_decoration.ll
+++ b/llvm/test/CodeGen/SPIRV/spec_const_decoration.ll
@@ -1,8 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
 
-; TODO: This test currently fails with LLVM_ENABLE_EXPENSIVE_CHECKS enabled
-; XFAIL: expensive_checks
-
 ; CHECK: OpDecorate %[[#SpecConst:]] SpecId 0
 ; CHECK: %[[#SpecConst]] = OpSpecConstant %[[#]] 70
 ; CHECK: %[[#]] = OpPhi %[[#]] %[[#]] %[[#]] %[[#SpecConst]] %[[#]]

--- a/llvm/test/CodeGen/SPIRV/spec_const_decoration.ll
+++ b/llvm/test/CodeGen/SPIRV/spec_const_decoration.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
 
 ; CHECK: OpDecorate %[[#SpecConst:]] SpecId 0
 ; CHECK: %[[#SpecConst]] = OpSpecConstant %[[#]] 70


### PR DESCRIPTION
The test no longer fails with expensive_checks enabled

```
Unexpectedly Passed Tests (1):
  LLVM :: CodeGen/SPIRV/spec_const_decoration.ll
```
after https://github.com/llvm/llvm-project/commit/18e695890306c6824cc15779e1acb7e5956cbec1 (https://github.com/llvm/llvm-project/pull/134016)

also add `-verify-machineinstrs` as per #188703