### PR TITLE
Add a target triple to clang/test/Modules/pr189415.cppm

### DIFF
--- a/clang/test/Modules/pr189415.cppm
+++ b/clang/test/Modules/pr189415.cppm
@@ -2,9 +2,9 @@
 // RUN: mkdir -p %t
 // RUN: split-file %s %t
 // 
-// RUN: %clang_cc1 -std=c++20 %t/counter.cppm -triple %itanium_abi_triple \
+// RUN: %clang_cc1 -std=c++20 %t/counter.cppm -triple x86_64-pc-linux-gnu \
 // RUN:   -emit-reduced-module-interface -o %t/counter.pcm
-// RUN: %clang_cc1 -std=c++20 %t/user.cpp -triple %itanium_abi_triple -fprebuilt-module-path=%t \
+// RUN: %clang_cc1 -std=c++20 %t/user.cpp -triple x86_64-pc-linux-gnu -fprebuilt-module-path=%t \
 // RUN:   -disable-llvm-passes -emit-llvm -o - | FileCheck %s
 
 //--- counter.cppm


### PR DESCRIPTION
Not all targets support thread_local, so in some environments the test would fail with:

  tools/clang/test/Modules/Output/pr189415.cppm.tmp/counter.cppm:6:1:
  error: thread-local storage is not supported for the current target

Follow-up to #189796