### PR TITLE
Fix formatting of changes in recent redefine_extname changes.

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -9722,9 +9722,9 @@ void ASTReader::ReadExtnameUndeclaredIdentifiers(
     IdentifierInfo *NameId =
         DecodeIdentifierInfo(ExtnameUndeclaredIdentifiers[I]);
     IdentifierInfo *ExtnameId =
-        DecodeIdentifierInfo(ExtnameUndeclaredIdentifiers[I+1]);
+        DecodeIdentifierInfo(ExtnameUndeclaredIdentifiers[I + 1]);
     SourceLocation Loc =
-        SourceLocation::getFromRawEncoding(ExtnameUndeclaredIdentifiers[I+2]);
+        SourceLocation::getFromRawEncoding(ExtnameUndeclaredIdentifiers[I + 2]);
     AsmLabelAttr *Attr = AsmLabelAttr::CreateImplicit(
         getContext(), ExtnameId->getName(),
         AttributeCommonInfo(ExtnameId, SourceRange(Loc),

--- a/clang/test/Sema/redefine_extname.cpp
+++ b/clang/test/Sema/redefine_extname.cpp
@@ -31,7 +31,7 @@ int foo_nsfunc() { return 1; }
 // CHECK-DAG: {{@[^ ]*foo_nsfunc}}
 int foo_nsvar = 1;
 // CHECK-DAG: {{@[^ ]*foo_nsvar}}
-}
+} // namespace ns
 
 /// Check that the warning goes away when doing it in a class.
 /// Such uses are clearly scoped and need no warning (and often can be intentional).


### PR DESCRIPTION
My recent commits fd7388d14083bb5094bce6a75444a37e424689d7 and 37888541a96e4f10bf1b71b869145f0d31a9d580 had minor formatting issues which happened during editing the PR as I had forgotten to rerun clang-format. Sorry for that. So here is the update.

Did not fix line lengths in the FileCheck tests as exceeding line length in these seems more consistent.