### PR TITLE
[wip] Apply all remaining LLVM_ABI annotations to build, tests, tools and benchmarks

### DIFF
--- a/.github/workflows/Windows_Shared_Library_build.yml
+++ b/.github/workflows/Windows_Shared_Library_build.yml
@@ -1,0 +1,61 @@
+name: Build LLVM as shared library on Windows
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-main:
+    name: Windows-LLVM-Shared-Library
+    runs-on: windows-2025
+
+    if: github.repository == 'llvm/llvm-project'
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        path: ${{ github.workspace }}/llvm
+
+    - name: Setup compiler on Windows
+      run: |
+        $env:CC="clang-cl"
+        $env:CXX="clang-cl"
+        echo "CC=clang-cl" >> $env:GITHUB_ENV
+        echo "CXX=clang-cl" >> $env:GITHUB_ENV
+
+    - name: Install dependencies
+      run: |
+        choco install ninja
+
+    - name: Build LLVM as a shared library on Windows
+      run: |
+        function Error-On-Failure {
+          param (
+              [Parameter(Mandatory)]
+              [ScriptBlock]$Command
+          )
+
+         & $Command
+
+         if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+         }
+        }
+        cd ${{ github.workspace }}/llvm
+        cmake -S ./llvm/ -B build -G Ninja                `
+              -DCMAKE_ASM_MASM_FLAGS="-m64"     `
+              -DLLVM_ENABLE_PLUGINS=On                    `
+              -DLLVM_TARGETS_TO_BUILD="host"              `
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo           `
+              -DCMAKE_CXX_COMPILER=clang-cl               `
+              -DCMAKE_C_COMPILER=clang-cl                 `
+              -DCMAKE_ASM_MASM_COMPILER=llvm-ml           `
+              -DLLVM_BUILD_LLVM_DYLIB_VIS=On              `
+              -DLLVM_LINK_LLVM_DYLIB=On                   `
+              -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+        Error-On-Failure { cmake --build build --config RelWithDebInfo --parallel ${{ env.ncpus }} }
+        Error-On-Failure { cmake --build build --target check-llvm-unit --config RelWithDebInfo --parallel ${{ env.ncpus }} }
+        Error-On-Failure { cmake --build build --target check-llvm --config RelWithDebInfo --parallel ${{ env.ncpus }} }

--- a/llvm/include/llvm/Analysis/CycleAnalysis.h
+++ b/llvm/include/llvm/Analysis/CycleAnalysis.h
@@ -18,6 +18,7 @@
 #include "llvm/IR/CycleInfo.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -27,7 +28,7 @@ class CycleInfoWrapperPass : public FunctionPass {
   CycleInfo CI;
 
 public:
-  static char ID;
+  LLVM_ABI_FOR_TEST static char ID;
 
   CycleInfoWrapperPass();
 

--- a/llvm/include/llvm/CAS/BuiltinObjectHasher.h
+++ b/llvm/include/llvm/CAS/BuiltinObjectHasher.h
@@ -10,6 +10,7 @@
 #define LLVM_CAS_BUILTINOBJECTHASHER_H
 
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 
 namespace llvm::cas {
@@ -39,7 +40,7 @@ public:
     return H.finish();
   }
 
-  static Expected<HashT> hashFile(StringRef FilePath);
+  LLVM_ABI_FOR_TEST static Expected<HashT> hashFile(StringRef FilePath);
 
 private:
   HashT finish() { return Hasher.final(); }

--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -20,6 +20,7 @@
 #include "llvm/CAS/OnDiskCASLogger.h"
 #include "llvm/CAS/OnDiskDataAllocator.h"
 #include "llvm/CAS/OnDiskTrieRawHashMap.h"
+#include "llvm/Support/Compiler.h"
 #include <atomic>
 
 namespace llvm::cas::ondisk {
@@ -351,7 +352,8 @@ public:
   /// loading the data in memory and then writing it to a file, the client could
   /// clone the underlying file directly. The client *must not* write to or
   /// delete the underlying file, the path is provided only for reading/copying.
-  FileBackedData getInternalFileBackedObjectData(ObjectHandle Node) const;
+  LLVM_ABI_FOR_TEST FileBackedData
+  getInternalFileBackedObjectData(ObjectHandle Node) const;
 
   /// \returns Total size of stored objects.
   ///

--- a/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
+++ b/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
@@ -11,6 +11,7 @@
 
 #include "llvm/CAS/OnDiskGraphDB.h"
 #include "llvm/CAS/ValidationResult.h"
+#include "llvm/Support/Compiler.h"
 #include <atomic>
 
 namespace llvm::cas::ondisk {
@@ -93,7 +94,7 @@ public:
   /// was invalid but has been cleared, \c Skipped if validation is not needed,
   /// or an \c Error if validation cannot be performed or if the data is left
   /// in an invalid state because \p AllowRecovery is false.
-  static Expected<ValidationResult>
+  LLVM_ABI_FOR_TEST static Expected<ValidationResult>
   validateIfNeeded(StringRef Path, StringRef HashName, unsigned HashByteSize,
                    bool CheckHash, OnDiskGraphDB::HashingFuncT HashFn,
                    bool AllowRecovery, bool ForceValidation,

--- a/llvm/include/llvm/CodeGen/Rematerializer.h
+++ b/llvm/include/llvm/CodeGen/Rematerializer.h
@@ -21,6 +21,7 @@
 #include "llvm/CodeGen/TargetInstrInfo.h"
 #include "llvm/CodeGen/TargetOpcodes.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
+#include "llvm/Support/Compiler.h"
 #include <iterator>
 
 namespace llvm {
@@ -196,16 +197,16 @@ public:
 
   /// Simply initializes some internal state, does not identify
   /// rematerialization candidates.
-  Rematerializer(MachineFunction &MF,
-                 SmallVectorImpl<RegionBoundaries> &Regions,
-                 LiveIntervals &LIS);
+  LLVM_ABI_FOR_TEST Rematerializer(MachineFunction &MF,
+                                   SmallVectorImpl<RegionBoundaries> &Regions,
+                                   LiveIntervals &LIS);
 
   /// Goes through the whole MF and identifies all rematerializable registers.
   /// When \p SupportRollback is set, rematerializations of original registers
   /// can be rolled back and original registers are maintained in the IR even
   /// when they longer have any users. Returns whether there is any
   /// rematerializable register in regions.
-  bool analyze(bool SupportRollback);
+  LLVM_ABI_FOR_TEST bool analyze(bool SupportRollback);
 
   inline const Reg &getReg(RegisterIdx RegIdx) const {
     assert(RegIdx < Regs.size() && "out of bounds");
@@ -304,8 +305,9 @@ public:
   /// registers of the root's dependency DAG that needed to be rematerialized
   /// along the root. References to \ref Rematerializer::Reg should be
   /// considered invalidated by calls to this method.
-  RegisterIdx rematerializeToRegion(RegisterIdx RootIdx, unsigned UseRegion,
-                                    DependencyReuseInfo &DRI);
+  LLVM_ABI_FOR_TEST RegisterIdx rematerializeToRegion(RegisterIdx RootIdx,
+                                                      unsigned UseRegion,
+                                                      DependencyReuseInfo &DRI);
 
   /// Rematerializes register \p RootIdx before position \p InsertPos and
   /// returns the new register's index. The root's dependency DAG is
@@ -315,9 +317,9 @@ public:
   /// registers of the root's dependency DAG that needed to be rematerialized
   /// along the root. References to \ref Rematerializer::Reg should be
   /// considered invalidated by calls to this method.
-  RegisterIdx rematerializeToPos(RegisterIdx RootIdx,
-                                 MachineBasicBlock::iterator InsertPos,
-                                 DependencyReuseInfo &DRI);
+  LLVM_ABI_FOR_TEST RegisterIdx
+  rematerializeToPos(RegisterIdx RootIdx, MachineBasicBlock::iterator InsertPos,
+                     DependencyReuseInfo &DRI);
 
   /// Rolls back all rematerializations of original register \p RootIdx,
   /// transfering all their users back to it and permanently deleting them from
@@ -326,7 +328,7 @@ public:
   /// dependencies of the root register that were fully rematerialized are
   /// re-vived at their original positions; this requires that rollback support
   /// was set when they were rematerialized.
-  void rollbackRematsOf(RegisterIdx RootIdx);
+  LLVM_ABI_FOR_TEST void rollbackRematsOf(RegisterIdx RootIdx);
 
   /// Rolls back register \p RematIdx (which must be a rematerialization)
   /// transfering all its users back to its origin. The latter is revived if it
@@ -345,23 +347,25 @@ public:
   /// ToRegIdx, the latter of which must be a rematerialization of the former or
   /// have the same origin register. Users in \p UseRegion must be reachable
   /// from \p ToRegIdx.
-  void transferRegionUsers(RegisterIdx FromRegIdx, RegisterIdx ToRegIdx,
-                           unsigned UseRegion);
+  LLVM_ABI_FOR_TEST void transferRegionUsers(RegisterIdx FromRegIdx,
+                                             RegisterIdx ToRegIdx,
+                                             unsigned UseRegion);
 
   /// Transfers user \p UserMI from register \p FromRegIdx to \p ToRegIdx,
   /// the latter of which must be a rematerialization of the former or have the
   /// same origin register. \p UserMI must be a direct user of \p FromRegIdx. \p
   /// UserMI must be reachable from \p ToRegIdx.
-  void transferUser(RegisterIdx FromRegIdx, RegisterIdx ToRegIdx,
-                    MachineInstr &UserMI);
+  LLVM_ABI_FOR_TEST void transferUser(RegisterIdx FromRegIdx,
+                                      RegisterIdx ToRegIdx,
+                                      MachineInstr &UserMI);
 
   /// Recomputes all live intervals that have changed as a result of previous
   /// rematerializations/rollbacks.
-  void updateLiveIntervals();
+  LLVM_ABI_FOR_TEST void updateLiveIntervals();
 
   /// Deletes unused rematerialized registers that were left in the MIR to
   /// support rollback.
-  void commitRematerializations();
+  LLVM_ABI_FOR_TEST void commitRematerializations();
 
   /// Determines whether (sub-)register operand \p MO has the same value at
   /// all \p Uses as at \p MO. This implies that it is also available at all \p

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -42,6 +42,7 @@
 #include "llvm/IR/Operator.h"
 #include "llvm/IR/Value.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {
@@ -155,7 +156,7 @@ inline class_match<IntrinsicInst> m_AnyIntrinsic() {
 
 struct undef_match {
 private:
-  static bool checkAggregate(const ConstantAggregate *CA);
+  LLVM_ABI_FOR_TEST static bool checkAggregate(const ConstantAggregate *CA);
 
 public:
   static bool check(const Value *V) {

--- a/llvm/include/llvm/SandboxIR/Instruction.h
+++ b/llvm/include/llvm/SandboxIR/Instruction.h
@@ -1079,8 +1079,8 @@ class UncondBrInst : public SingleLLVMInstructionImpl<llvm::UncondBrInst>,
   friend Context; // for UncondBrInst()
 
 public:
-  static UncondBrInst *create(BasicBlock *Target, InsertPosition InsertBefore,
-                              Context &Ctx);
+  LLVM_ABI_FOR_TEST static UncondBrInst *
+  create(BasicBlock *Target, InsertPosition InsertBefore, Context &Ctx);
   LLVM_ABI BasicBlock *getSuccessor() const;
   LLVM_ABI void setSuccessor(BasicBlock *NewSucc);
   unsigned getNumSuccessors() const { return 1; }
@@ -1105,11 +1105,12 @@ class CondBrInst : public SingleLLVMInstructionImpl<llvm::CondBrInst>,
   friend Context; // for UcnondBrInst()
 
 public:
-  static CondBrInst *create(Value *Cond, BasicBlock *IfTrue,
-                            BasicBlock *IfFalse, InsertPosition InsertBefore,
-                            Context &Ctx);
+  LLVM_ABI_FOR_TEST static CondBrInst *create(Value *Cond, BasicBlock *IfTrue,
+                                              BasicBlock *IfFalse,
+                                              InsertPosition InsertBefore,
+                                              Context &Ctx);
   LLVM_ABI Value *getCondition() const;
-  void setCondition(Value *V);
+  LLVM_ABI_FOR_TEST void setCondition(Value *V);
   LLVM_ABI BasicBlock *getSuccessor(unsigned SuccIdx) const;
   LLVM_ABI void setSuccessor(unsigned Idx, BasicBlock *NewSucc);
   unsigned getNumSuccessors() const { return 2; }

--- a/llvm/include/llvm/Support/HTTP/HTTPClient.h
+++ b/llvm/include/llvm/Support/HTTP/HTTPClient.h
@@ -17,6 +17,7 @@
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 
@@ -32,7 +33,7 @@ struct HTTPRequest {
   SmallVector<std::string, 0> Headers;
   HTTPMethod Method = HTTPMethod::GET;
   bool FollowRedirects = true;
-  HTTPRequest(StringRef Url);
+  LLVM_ABI HTTPRequest(StringRef Url);
 };
 
 bool operator==(const HTTPRequest &A, const HTTPRequest &B);
@@ -46,7 +47,7 @@ public:
   virtual Error handleBodyChunk(StringRef BodyChunk) = 0;
 
 protected:
-  ~HTTPResponseHandler();
+  LLVM_ABI ~HTTPResponseHandler();
 };
 
 /// A reusable client that can perform HTTPRequests through a network socket.
@@ -56,31 +57,32 @@ class HTTPClient {
 #endif
 
 public:
-  HTTPClient();
-  ~HTTPClient();
+  LLVM_ABI HTTPClient();
+  LLVM_ABI ~HTTPClient();
 
-  static bool IsInitialized;
+  LLVM_ABI static bool IsInitialized;
 
   /// Returns true only if LLVM has been compiled with a working HTTPClient.
-  static bool isAvailable();
+  LLVM_ABI static bool isAvailable();
 
   /// Must be called at the beginning of a program, while it is a single thread.
-  static void initialize();
+  LLVM_ABI static void initialize();
 
   /// Must be called at the end of a program, while it is a single thread.
   static void cleanup();
 
   /// Sets the timeout for the entire request, in milliseconds. A zero or
   /// negative value means the request never times out.
-  void setTimeout(std::chrono::milliseconds Timeout);
+  LLVM_ABI void setTimeout(std::chrono::milliseconds Timeout);
 
   /// Performs the Request, passing response data to the Handler. Returns all
   /// errors which occur during the request. Aborts if an error is returned by a
   /// Handler method.
-  Error perform(const HTTPRequest &Request, HTTPResponseHandler &Handler);
+  LLVM_ABI Error perform(const HTTPRequest &Request,
+                         HTTPResponseHandler &Handler);
 
   /// Returns the last received response code or zero if none.
-  unsigned responseCode();
+  LLVM_ABI unsigned responseCode();
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Support/HTTP/HTTPServer.h
+++ b/llvm/include/llvm/Support/HTTP/HTTPServer.h
@@ -17,6 +17,7 @@
 #define LLVM_SUPPORT_HTTP_HTTPSERVER_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 #ifdef LLVM_ENABLE_HTTPLIB
@@ -62,7 +63,7 @@ public:
   // TODO bring in HTTP headers
 
   void setResponse(StreamingHTTPResponse Response);
-  void setResponse(HTTPResponse Response);
+  LLVM_ABI void setResponse(HTTPResponse Response);
 };
 
 struct HTTPResponse {
@@ -92,7 +93,7 @@ struct StreamingHTTPResponse {
 
 /// Sets the response to stream the file at FilePath, if available, and
 /// otherwise an HTTP 404 error response.
-bool streamFile(HTTPServerRequest &Request, StringRef FilePath);
+LLVM_ABI bool streamFile(HTTPServerRequest &Request, StringRef FilePath);
 
 /// An HTTP server which can listen on a single TCP/IP port for HTTP
 /// requests and delgate them to the appropriate registered handler.
@@ -102,28 +103,28 @@ class HTTPServer {
   unsigned Port = 0;
 #endif
 public:
-  HTTPServer();
+  LLVM_ABI HTTPServer();
   ~HTTPServer();
 
   /// Returns true only if LLVM has been compiled with a working HTTPServer.
-  static bool isAvailable();
+  LLVM_ABI_FOR_TEST static bool isAvailable();
 
   /// Registers a URL pattern routing rule. When the server is listening, each
   /// request is dispatched to the first registered handler whose UrlPathPattern
   /// matches the UrlPath.
-  Error get(StringRef UrlPathPattern, HTTPRequestHandler Handler);
+  LLVM_ABI Error get(StringRef UrlPathPattern, HTTPRequestHandler Handler);
 
   /// Attempts to assign the requested port and interface, returning an Error
   /// upon failure.
-  Error bind(unsigned Port, const char *HostInterface = "0.0.0.0");
+  LLVM_ABI Error bind(unsigned Port, const char *HostInterface = "0.0.0.0");
 
   /// Attempts to assign any available port and interface, returning either the
   /// port number or an Error upon failure.
-  Expected<unsigned> bind(const char *HostInterface = "0.0.0.0");
+  LLVM_ABI Expected<unsigned> bind(const char *HostInterface = "0.0.0.0");
 
   /// Attempts to listen for requests on the bound port. Returns an Error if
   /// called before binding a port.
-  Error listen();
+  LLVM_ABI Error listen();
 
   /// If the server is listening, stop and unbind the socket.
   void stop();

--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -787,7 +787,7 @@ using stack_float_t = float;
 #endif
 
 /// Returns the number of digits in the given integer.
-int NumDigitsBase10(uint64_t X);
+LLVM_ABI int NumDigitsBase10(uint64_t X);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/TargetParser/RISCVTargetParser.h
+++ b/llvm/include/llvm/TargetParser/RISCVTargetParser.h
@@ -61,7 +61,7 @@ struct ParserWarning : public ErrorInfo<ParserWarning, StringError> {
   using ErrorInfo<ParserWarning, StringError>::ErrorInfo;
   explicit ParserWarning(const Twine &S)
       : ErrorInfo(S, inconvertibleErrorCode()) {}
-  static char ID;
+  LLVM_ABI_FOR_TEST static char ID;
 };
 
 // We use 64 bits as the known part in the scalable vector types.

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -1247,7 +1247,7 @@ public:
   }
 
   /// Returns the default wchar_t size (in bytes) for this target triple.
-  unsigned getDefaultWCharSize() const;
+  LLVM_ABI unsigned getDefaultWCharSize() const;
 
   /// Tests if the environment supports dllimport/export annotations.
   bool hasDLLImportExport() const { return isOSWindows() || isPS(); }

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -1089,7 +1089,7 @@ public:
   /// Returns default flags for \p Opcode for opcodes that support it, asserts
   /// otherwise. Opcodes not supporting default flags include compares and
   /// ComputeReductionResult.
-  static VPIRFlags getDefaultFlags(unsigned Opcode);
+  LLVM_ABI_FOR_TEST static VPIRFlags getDefaultFlags(unsigned Opcode);
 
 #if !defined(NDEBUG)
   /// Returns true if the set flags are valid for \p Opcode.

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
@@ -135,7 +135,7 @@ struct VPlanTransforms {
   /// VPHeaderPHIRecipe subclasses for inductions, reductions, and
   /// fixed-order recurrences. This processes all header phis and creates
   /// the appropriate widened recipe for each one.
-  static void createHeaderPhiRecipes(
+  LLVM_ABI_FOR_TEST static void createHeaderPhiRecipes(
       VPlan &Plan, PredicatedScalarEvolution &PSE, Loop &OrigLoop,
       const MapVector<PHINode *, InductionDescriptor> &Inductions,
       const MapVector<PHINode *, RecurrenceDescriptor> &Reductions,

--- a/llvm/unittests/Support/HTTP/CMakeLists.txt
+++ b/llvm/unittests/Support/HTTP/CMakeLists.txt
@@ -2,7 +2,13 @@ add_llvm_unittest(SupportHTTPTests
   HTTPServerTests.cpp
   )
 
-target_link_libraries(SupportHTTPTests PRIVATE
-  LLVMSupportHTTP
-  LLVMTestingSupport
-  )
+if(LLVM_LINK_LLVM_DYLIB)
+  target_link_libraries(SupportHTTPTests PRIVATE
+    LLVM
+    )
+else()
+  target_link_libraries(SupportHTTPTests PRIVATE
+    LLVMSupportHTTP
+    LLVMTestingSupport
+    )
+endif()


### PR DESCRIPTION
Towards https://github.com/llvm/llvm-project/issues/109483 , and does the first 2 of plan laid out https://github.com/llvm/llvm-project/pull/188587#issuecomment-4161464169

The purpose of this is to add all the remaining LLVM_ABI annotations such that all llvm tools, tests and benchmarks can be built using the LLVM shared library on Windows. As of putting in this PR all unit tests can build, but 3 tests fail. I'm unsure what to with these tests. Putting in this PR as it stands allows people to review the ci, and suggest how to proceed with dealing with the failed tests. I could skip 2 of them by having `LLVM_ENABLE_PLUGINS=OFF` for now. It is only set to ON in the workflow for now as one of the purposes of https://github.com/llvm/llvm-project/issues/109483 is to enable plugin support on Windows. That would still leave one failing test.

I'm aware this PR hits a large number of files, and can broken up into smaller PRs, once everyone is happy with the changes.

cc @nikic 