### PR TITLE
[UniformityAnalysis] Skip CycleAnalysis on targets without branch divergence

### DIFF
--- a/llvm/include/llvm/ADT/GenericUniformityImpl.h
+++ b/llvm/include/llvm/ADT/GenericUniformityImpl.h
@@ -1293,30 +1293,22 @@ GenericUniformityInfo<ContextT>::getFunction() const {
 /// as uniform, which is conservatively correct for non-divergent targets.
 template <typename ContextT>
 bool GenericUniformityInfo<ContextT>::isDivergent(ConstValueRefT V) const {
-  if (!DA)
-    return false;
-  return DA->isDivergent(V);
+  return DA && DA->isDivergent(V);
 }
 
 template <typename ContextT>
 bool GenericUniformityInfo<ContextT>::isDivergent(const InstructionT *I) const {
-  if (!DA)
-    return false;
-  return DA->isDivergent(*I);
+  return DA && DA->isDivergent(*I);
 }
 
 template <typename ContextT>
 bool GenericUniformityInfo<ContextT>::isDivergentUse(const UseT &U) const {
-  if (!DA)
-    return false;
-  return DA->isDivergentUse(U);
+  return DA && DA->isDivergentUse(U);
 }
 
 template <typename ContextT>
 bool GenericUniformityInfo<ContextT>::hasDivergentTerminator(const BlockT &B) {
-  if (!DA)
-    return false;
-  return DA->hasDivergentTerminator(B);
+  return DA && DA->hasDivergentTerminator(B);
 }
 
 /// \brief T helper function for printing.

--- a/llvm/include/llvm/ADT/GenericUniformityImpl.h
+++ b/llvm/include/llvm/ADT/GenericUniformityImpl.h
@@ -1289,29 +1289,43 @@ GenericUniformityInfo<ContextT>::getFunction() const {
 }
 
 /// Whether \p V is divergent at its definition.
+/// A default-constructed instance (no analysis computed) reports everything
+/// as uniform, which is conservatively correct for non-divergent targets.
 template <typename ContextT>
 bool GenericUniformityInfo<ContextT>::isDivergent(ConstValueRefT V) const {
+  if (!DA)
+    return false;
   return DA->isDivergent(V);
 }
 
 template <typename ContextT>
 bool GenericUniformityInfo<ContextT>::isDivergent(const InstructionT *I) const {
+  if (!DA)
+    return false;
   return DA->isDivergent(*I);
 }
 
 template <typename ContextT>
 bool GenericUniformityInfo<ContextT>::isDivergentUse(const UseT &U) const {
+  if (!DA)
+    return false;
   return DA->isDivergentUse(U);
 }
 
 template <typename ContextT>
 bool GenericUniformityInfo<ContextT>::hasDivergentTerminator(const BlockT &B) {
+  if (!DA)
+    return false;
   return DA->hasDivergentTerminator(B);
 }
 
 /// \brief T helper function for printing.
 template <typename ContextT>
 void GenericUniformityInfo<ContextT>::print(raw_ostream &out) const {
+  if (!DA) {
+    out << "  Uniformity analysis not computed (no branch divergence).\n";
+    return;
+  }
   DA->print(out);
 }
 

--- a/llvm/lib/Analysis/UniformityAnalysis.cpp
+++ b/llvm/lib/Analysis/UniformityAnalysis.cpp
@@ -167,14 +167,13 @@ template struct llvm::GenericUniformityAnalysisImplDeleter<
 
 llvm::UniformityInfo UniformityInfoAnalysis::run(Function &F,
                                                  FunctionAnalysisManager &FAM) {
-  auto &DT = FAM.getResult<DominatorTreeAnalysis>(F);
   auto &TTI = FAM.getResult<TargetIRAnalysis>(F);
+  if (!TTI.hasBranchDivergence(&F))
+    return UniformityInfo{};
+  auto &DT = FAM.getResult<DominatorTreeAnalysis>(F);
   auto &CI = FAM.getResult<CycleAnalysis>(F);
   UniformityInfo UI{DT, CI, &TTI};
-  // Skip computation if we can assume everything is uniform.
-  if (TTI.hasBranchDivergence(&F))
-    UI.compute();
-
+  UI.compute();
   return UI;
 }
 
@@ -215,18 +214,20 @@ void UniformityInfoWrapperPass::getAnalysisUsage(AnalysisUsage &AU) const {
 }
 
 bool UniformityInfoWrapperPass::runOnFunction(Function &F) {
-  auto &cycleInfo = getAnalysis<CycleInfoWrapperPass>().getResult();
-  auto &domTree = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
   auto &targetTransformInfo =
       getAnalysis<TargetTransformInfoWrapperPass>().getTTI(F);
 
   m_function = &F;
+
+  if (!targetTransformInfo.hasBranchDivergence(m_function)) {
+    m_uniformityInfo = UniformityInfo{};
+    return false;
+  }
+
+  auto &cycleInfo = getAnalysis<CycleInfoWrapperPass>().getResult();
+  auto &domTree = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
   m_uniformityInfo = UniformityInfo{domTree, cycleInfo, &targetTransformInfo};
-
-  // Skip computation if we can assume everything is uniform.
-  if (targetTransformInfo.hasBranchDivergence(m_function))
-    m_uniformityInfo.compute();
-
+  m_uniformityInfo.compute();
   return false;
 }
 


### PR DESCRIPTION
UniformityAnalysis unconditionally computes CycleAnalysis even on targets that don't care about divergence, causing measurable compile-time overhead (see [#99878 (comment)](https://github.com/llvm/llvm-project/pull/175167#issuecomment-4156230947)).