### PR TITLE
[lldb] Fix handling of unaligned results in DoFindInMemory

### DIFF
--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2008,7 +2008,7 @@ void Process::DoFindInMemory(lldb::addr_t start_addr, lldb::addr_t end_addr,
     if (found_addr % alignment) {
       // We need to check the alignment because the FindInMemory uses a special
       // algorithm to efficiently search mememory but doesn't support alignment.
-      start = llvm::alignTo(start + 1, alignment);
+      start = llvm::alignTo(found_addr + 1, alignment);
       continue;
     }
 


### PR DESCRIPTION
While encountering an unaligned result in DoFindInMemory, instead of skipping already searched memory, the function incorrectly restart the search from almost the beginning of the search range.