### PR TITLE
[SimplifyCFG] Do not redirect potential poison values from predecessors to PHI

### DIFF
--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -982,7 +982,8 @@ static void replaceUndefValuesInPhi(PHINode *PN,
   for (unsigned i = 0, e = PN->getNumIncomingValues(); i != e; ++i) {
     Value *V = PN->getIncomingValue(i);
 
-    if (!isa<UndefValue>(V)) continue;
+    if (!isa<UndefValue>(V))
+      continue;
 
     BasicBlock *BB = PN->getIncomingBlock(i);
     IncomingValueMap::const_iterator It = IncomingValues.find(BB);
@@ -1084,7 +1085,7 @@ static bool introduceTooManyPhiEntries(BasicBlock *BB, BasicBlock *Succ) {
 /// \param BBPreds The predecessors of BB.
 /// \param PN The phi that we are updating.
 /// \param CommonPred The common predecessor of BB and PN's BasicBlock
-static void redirectValuesFromPredecessorsToPhi(BasicBlock *BB,
+static bool redirectValuesFromPredecessorsToPhi(BasicBlock *BB,
                                                 const PredBlockVector &BBPreds,
                                                 PHINode *PN,
                                                 BasicBlock *CommonPred) {
@@ -1104,6 +1105,17 @@ static void redirectValuesFromPredecessorsToPhi(BasicBlock *BB,
   // consistent with the non-undef values.
 
   gatherIncomingValuesToPhi(PN, BBPreds, IncomingValues);
+  SmallVector<std::pair<Value *, BasicBlock *>> NewIncoming;
+
+  auto IsUnsafeUndefReplacement = [&](BasicBlock *PredBB,
+                                      Value *Selected) -> bool {
+    int BlockIdx = PN->getBasicBlockIndex(PredBB);
+    if (BlockIdx < 0 || !isa<UndefValue>(PN->getIncomingValue(BlockIdx)))
+      return false;
+
+    return !isa<Constant>(Selected) ||
+           !isGuaranteedNotToBeUndefOrPoison(Selected);
+  };
 
   // If this incoming value is one of the PHI nodes in BB, the new entries
   // in the PHI node are the entries from the old PHI.
@@ -1123,13 +1135,16 @@ static void redirectValuesFromPredecessorsToPhi(BasicBlock *BB,
       Value *PredVal = OldValPN->getIncomingValue(i);
       Value *Selected =
           selectIncomingValueForBlock(PredVal, PredBB, IncomingValues);
+      if (IsUnsafeUndefReplacement(PredBB, Selected)) {
+        PN->addIncoming(OldVal, BB);
+        return false;
+      }
 
-      // And add a new incoming value for this predecessor for the
-      // newly retargeted branch.
-      PN->addIncoming(Selected, PredBB);
+      NewIncoming.emplace_back(Selected, PredBB);
     }
     if (CommonPred)
-      PN->addIncoming(OldValPN->getIncomingValueForBlock(CommonPred), BB);
+      NewIncoming.emplace_back(OldValPN->getIncomingValueForBlock(CommonPred),
+                               BB);
 
   } else {
     for (BasicBlock *PredBB : BBPreds) {
@@ -1140,16 +1155,22 @@ static void redirectValuesFromPredecessorsToPhi(BasicBlock *BB,
 
       Value *Selected =
           selectIncomingValueForBlock(OldVal, PredBB, IncomingValues);
+      if (IsUnsafeUndefReplacement(PredBB, Selected)) {
+        PN->addIncoming(OldVal, BB);
+        return false;
+      }
 
-      // And add a new incoming value for this predecessor for the
-      // newly retargeted branch.
-      PN->addIncoming(Selected, PredBB);
+      NewIncoming.emplace_back(Selected, PredBB);
     }
     if (CommonPred)
-      PN->addIncoming(OldVal, BB);
+      NewIncoming.emplace_back(OldVal, BB);
   }
 
+  for (auto [V, PredBB] : NewIncoming)
+    PN->addIncoming(V, PredBB);
+
   replaceUndefValuesInPhi(PN, IncomingValues);
+  return true;
 }
 
 bool llvm::TryToSimplifyUncondBranchFromEmptyBlock(BasicBlock *BB,
@@ -1327,7 +1348,8 @@ bool llvm::TryToSimplifyUncondBranchFromEmptyBlock(BasicBlock *BB,
     // Loop over all of the PHI nodes in the successor of BB.
     for (BasicBlock::iterator I = Succ->begin(); isa<PHINode>(I); ++I) {
       PHINode *PN = cast<PHINode>(I);
-      redirectValuesFromPredecessorsToPhi(BB, BBPreds, PN, CommonPred);
+      if (!redirectValuesFromPredecessorsToPhi(BB, BBPreds, PN, CommonPred))
+        return false;
     }
   }
 

--- a/llvm/test/Transforms/SimplifyCFG/ForwardSwitchConditionToPHI.ll
+++ b/llvm/test/Transforms/SimplifyCFG/ForwardSwitchConditionToPHI.ll
@@ -240,3 +240,31 @@ bb5: ; preds = %bb3, %bb2, %bb
   %i9 = insertvalue { i64, i64 } %i8, i64 %i6, 1
   ret { i64, i64 } %i9
 }
+
+define i32 @NotPropagatingPoisonToUndef(i8 %cond, i32 %x) {
+; NO_FWD-LABEL: @NotPropagatingPoisonToUndef(
+; NO_FWD-NEXT:  D:
+; NO_FWD-NEXT:    [[COND1:%.*]] = icmp eq i8 [[COND:%.*]], 1
+; NO_FWD-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[COND1]], i32 0, i32 [[X:%.*]]
+; NO_FWD-NEXT:    ret i32 [[SPEC_SELECT]]
+;
+; FWD-LABEL: @NotPropagatingPoisonToUndef(
+; FWD-NEXT:  D:
+; FWD-NEXT:    [[COND1:%.*]] = icmp eq i8 [[COND:%.*]], 1
+; FWD-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[COND1]], i32 0, i32 [[X:%.*]]
+; FWD-NEXT:    ret i32 [[SPEC_SELECT]]
+;
+  switch i8 %cond, label %A [
+  i8 0, label %B
+  i8 1, label %C
+  ]
+A:
+  br label %D
+B:
+  br label %D
+C:
+  br label %D
+D:
+  %y = phi i32 [ undef, %A ], [ %x, %B ], [ 0, %C ]
+  ret i32 %y
+}

--- a/llvm/test/Transforms/SimplifyCFG/ForwardSwitchConditionToPHI.ll
+++ b/llvm/test/Transforms/SimplifyCFG/ForwardSwitchConditionToPHI.ll
@@ -206,15 +206,19 @@ define { i64, i64 } @PR95919(i64 noundef %arg, i64 noundef %arg1) {
 ;
 ; FWD-LABEL: @PR95919(
 ; FWD-NEXT:  bb:
-; FWD-NEXT:    [[SWITCH:%.*]] = icmp ult i64 [[ARG1:%.*]], 2
-; FWD-NEXT:    br i1 [[SWITCH]], label [[BB5:%.*]], label [[BB3:%.*]]
+; FWD-NEXT:    switch i64 [[ARG1:%.*]], label [[BB3:%.*]] [
+; FWD-NEXT:      i64 0, label [[BB5:%.*]]
+; FWD-NEXT:      i64 1, label [[BB2:%.*]]
+; FWD-NEXT:    ]
+; FWD:       bb2:
+; FWD-NEXT:    br label [[BB5]]
 ; FWD:       bb3:
 ; FWD-NEXT:    [[I:%.*]] = udiv i64 [[ARG:%.*]], [[ARG1]]
 ; FWD-NEXT:    [[I4:%.*]] = shl nuw i64 [[I]], 1
 ; FWD-NEXT:    br label [[BB5]]
 ; FWD:       bb5:
-; FWD-NEXT:    [[I6:%.*]] = phi i64 [ [[I4]], [[BB3]] ], [ [[ARG]], [[BB:%.*]] ]
-; FWD-NEXT:    [[I7:%.*]] = phi i64 [ 1, [[BB3]] ], [ [[ARG1]], [[BB]] ]
+; FWD-NEXT:    [[I6:%.*]] = phi i64 [ [[I4]], [[BB3]] ], [ undef, [[BB:%.*]] ], [ [[ARG]], [[BB2]] ]
+; FWD-NEXT:    [[I7:%.*]] = phi i64 [ 1, [[BB3]] ], [ [[ARG1]], [[BB2]] ], [ [[ARG1]], [[BB]] ]
 ; FWD-NEXT:    [[I8:%.*]] = insertvalue { i64, i64 } poison, i64 [[I7]], 0
 ; FWD-NEXT:    [[I9:%.*]] = insertvalue { i64, i64 } [[I8]], i64 [[I6]], 1
 ; FWD-NEXT:    ret { i64, i64 } [[I9]]
@@ -244,14 +248,14 @@ bb5: ; preds = %bb3, %bb2, %bb
 define i32 @NotPropagatingPoisonToUndef(i8 %cond, i32 %x) {
 ; NO_FWD-LABEL: @NotPropagatingPoisonToUndef(
 ; NO_FWD-NEXT:  D:
-; NO_FWD-NEXT:    [[COND1:%.*]] = icmp eq i8 [[COND:%.*]], 1
-; NO_FWD-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[COND1]], i32 0, i32 [[X:%.*]]
+; NO_FWD-NEXT:    [[COND1:%.*]] = icmp eq i8 [[COND:%.*]], 0
+; NO_FWD-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[COND1]], i32 [[X:%.*]], i32 0
 ; NO_FWD-NEXT:    ret i32 [[SPEC_SELECT]]
 ;
 ; FWD-LABEL: @NotPropagatingPoisonToUndef(
 ; FWD-NEXT:  D:
-; FWD-NEXT:    [[COND1:%.*]] = icmp eq i8 [[COND:%.*]], 1
-; FWD-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[COND1]], i32 0, i32 [[X:%.*]]
+; FWD-NEXT:    [[COND1:%.*]] = icmp eq i8 [[COND:%.*]], 0
+; FWD-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[COND1]], i32 [[X:%.*]], i32 0
 ; FWD-NEXT:    ret i32 [[SPEC_SELECT]]
 ;
   switch i8 %cond, label %A [

--- a/llvm/test/Transforms/SimplifyCFG/poison-merge.ll
+++ b/llvm/test/Transforms/SimplifyCFG/poison-merge.ll
@@ -8,10 +8,13 @@ define i32 @undef_merge(i32 %x) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    switch i32 [[X:%.*]], label [[EXIT:%.*]] [
 ; CHECK-NEXT:      i32 4, label [[G:%.*]]
-; CHECK-NEXT:      i32 12, label [[G]]
+; CHECK-NEXT:      i32 12, label [[G1:%.*]]
 ; CHECK-NEXT:    ]
+; CHECK:       loop:
+; CHECK-NEXT:    [[K2:%.*]] = phi i64 [ undef, [[ENTRY:%.*]] ], [ [[K3:%.*]], [[G1]] ]
+; CHECK-NEXT:    br label [[G1]]
 ; CHECK:       g:
-; CHECK-NEXT:    [[K3:%.*]] = phi i64 [ undef, [[ENTRY:%.*]] ], [ [[K3]], [[G]] ], [ undef, [[ENTRY]] ]
+; CHECK-NEXT:    [[K3]] = phi i64 [ undef, [[ENTRY]] ], [ [[K2]], [[G]] ]
 ; CHECK-NEXT:    br label [[G]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret i32 undef
@@ -41,10 +44,13 @@ define i32 @poison_merge(i32 %x) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    switch i32 [[X:%.*]], label [[EXIT:%.*]] [
 ; CHECK-NEXT:      i32 4, label [[G:%.*]]
-; CHECK-NEXT:      i32 12, label [[G]]
+; CHECK-NEXT:      i32 12, label [[G1:%.*]]
 ; CHECK-NEXT:    ]
+; CHECK:       loop:
+; CHECK-NEXT:    [[K2:%.*]] = phi i64 [ poison, [[ENTRY:%.*]] ], [ [[K3:%.*]], [[G1]] ]
+; CHECK-NEXT:    br label [[G1]]
 ; CHECK:       g:
-; CHECK-NEXT:    [[K3:%.*]] = phi i64 [ poison, [[ENTRY:%.*]] ], [ [[K3]], [[G]] ], [ poison, [[ENTRY]] ]
+; CHECK-NEXT:    [[K3]] = phi i64 [ poison, [[ENTRY]] ], [ [[K2]], [[G]] ]
 ; CHECK-NEXT:    br label [[G]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret i32 undef
@@ -173,10 +179,13 @@ define i32 @PR49218(i32 %x) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    switch i32 [[X:%.*]], label [[EXIT:%.*]] [
 ; CHECK-NEXT:      i32 4, label [[G:%.*]]
-; CHECK-NEXT:      i32 12, label [[G]]
+; CHECK-NEXT:      i32 12, label [[G1:%.*]]
 ; CHECK-NEXT:    ]
+; CHECK:       loop:
+; CHECK-NEXT:    [[K2:%.*]] = phi i64 [ undef, [[ENTRY:%.*]] ], [ [[K3:%.*]], [[G1]] ]
+; CHECK-NEXT:    br label [[G1]]
 ; CHECK:       g:
-; CHECK-NEXT:    [[K3:%.*]] = phi i64 [ undef, [[ENTRY:%.*]] ], [ [[K3]], [[G]] ], [ undef, [[ENTRY]] ]
+; CHECK-NEXT:    [[K3]] = phi i64 [ poison, [[ENTRY]] ], [ [[K2]], [[G]] ]
 ; CHECK-NEXT:    br label [[G]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret i32 undef


### PR DESCRIPTION
My attempt to fix #189526 .

I have did some debugging in SimplifyCFG and found that the things may go wrong when redirecting values from predecessors to the PHI node: https://alive2.llvm.org/ce/z/MRGLNx .

The issue is caused by replacing a `undef` with a potential poison value.

Here is the code generated after the patch for the code snippet in the issue: https://alive2.llvm.org/ce/z/p5Hv_y .

This PR may cause some regressions in generated code while fixing the issue!