### PR TITLE
[clang][bytecode] Add an assertion in initScope() op

### DIFF
--- a/clang/lib/AST/ByteCode/InterpFrame.cpp
+++ b/clang/lib/AST/ByteCode/InterpFrame.cpp
@@ -97,6 +97,7 @@ void InterpFrame::initScope(unsigned Idx) {
     return;
 
   for (auto &Local : Func->getScope(Idx).locals()) {
+    assert(!localBlock(Local.Offset)->isInitialized());
     localBlock(Local.Offset)->invokeCtor();
   }
 }


### PR DESCRIPTION
I've run into a problem in a branch lately that would've benefitted from this assertion.