### PR TITLE
[clang-tidy] Properly escape printed clang-tidy command in `run-clang-tidy.py`

### DIFF
--- a/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+++ b/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
@@ -42,6 +42,7 @@ import json
 import multiprocessing
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -732,7 +733,7 @@ async def main() -> None:
             progress = f"[{i + 1: >{len(f'{len(files)}')}}/{len(files)}]"
             runtime = f"[{result.elapsed:.1f}s]"
             if not args.hide_progress:
-                print(f"{progress}{runtime} {' '.join(result.invocation)}")
+                print(f"{progress}{runtime} {shlex.join(result.invocation)}")
             if result.stdout:
                 print(result.stdout, end=("" if result.stderr else "\n"))
             if result.stderr:


### PR DESCRIPTION
The `run-clang-tidy.py` script now uses `shlex.join()` to construct the command string for printing.

This ensures that arguments containing shell metacharacters, such as the asterisk in `--warnings-as-errors=*`, are correctly quoted. This allows the command to be safely copied and pasted into any shell for manual execution, fixing errors previously seen with shells like `fish` that are strict about wildcard expansion.

Before:
```
[ 1/15][0.2s] /usr/bin/clang-tidy -p=/home/user/work/project/build --warnings-as-errors=* /home/user/work/project/src/main.cpp
```

Note: When running this command in fish shell you get some error like `fish: No matches for wildcard '--warnings-as-errors=*'. See `help wildcards-globbing``

After:
```
[ 1/15][0.2s] /usr/bin/clang-tidy -p=/home/user/work/project/build '--warnings-as-errors=*' /home/user/work/project/src/main.cpp
```

