### PR TITLE
[NVPTX] Lower nvvm.fmax to maximumnum not maxnum

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -3414,22 +3414,14 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
           IsFMax = true;
           break;
         }
-        APFloat Res = IsFMax ? maximum(A, B) : minimum(A, B);
+        APFloat Res =
+            IsFMax ? (IsNaNPropagating ? maximum(A, B) : maximumnum(A, B))
+                   : (IsNaNPropagating ? minimum(A, B) : minimumnum(A, B));
 
-        if (ShouldCanonicalizeNaNs) {
+        if (ShouldCanonicalizeNaNs && Res.isNaN()) {
           APFloat NVCanonicalNaN(Res.getSemantics(), APInt(32, 0x7fffffff));
-          if (A.isNaN() && B.isNaN())
-            return ConstantFP::get(Ty, NVCanonicalNaN);
-          else if (IsNaNPropagating && (A.isNaN() || B.isNaN()))
-            return ConstantFP::get(Ty, NVCanonicalNaN);
+          return ConstantFP::get(Ty, NVCanonicalNaN);
         }
-
-        if (A.isNaN() && B.isNaN())
-          return Operands[1];
-        else if (A.isNaN())
-          Res = B;
-        else if (B.isNaN())
-          Res = A;
 
         if (IsXorSignAbs && XorSign != Res.isNegative())
           Res.changeSign();

--- a/llvm/lib/Target/NVPTX/NVPTXTargetTransformInfo.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXTargetTransformInfo.cpp
@@ -210,23 +210,23 @@ static Instruction *convertNvvmIntrinsicToLlvm(InstCombiner &IC,
     case Intrinsic::nvvm_fma_rn_bf16x2:
       return {Intrinsic::fma, FTZ_MustBeOff, true};
     case Intrinsic::nvvm_fmax_d:
-      return {Intrinsic::maxnum, FTZ_Any};
+      return {Intrinsic::maximumnum, FTZ_Any};
     case Intrinsic::nvvm_fmax_f:
-      return {Intrinsic::maxnum, FTZ_MustBeOff};
+      return {Intrinsic::maximumnum, FTZ_MustBeOff};
     case Intrinsic::nvvm_fmax_ftz_f:
-      return {Intrinsic::maxnum, FTZ_MustBeOn};
+      return {Intrinsic::maximumnum, FTZ_MustBeOn};
     case Intrinsic::nvvm_fmax_nan_f:
       return {Intrinsic::maximum, FTZ_MustBeOff};
     case Intrinsic::nvvm_fmax_ftz_nan_f:
       return {Intrinsic::maximum, FTZ_MustBeOn};
     case Intrinsic::nvvm_fmax_f16:
-      return {Intrinsic::maxnum, FTZ_MustBeOff, true};
+      return {Intrinsic::maximumnum, FTZ_MustBeOff, true};
     case Intrinsic::nvvm_fmax_ftz_f16:
-      return {Intrinsic::maxnum, FTZ_MustBeOn, true};
+      return {Intrinsic::maximumnum, FTZ_MustBeOn, true};
     case Intrinsic::nvvm_fmax_f16x2:
-      return {Intrinsic::maxnum, FTZ_MustBeOff, true};
+      return {Intrinsic::maximumnum, FTZ_MustBeOff, true};
     case Intrinsic::nvvm_fmax_ftz_f16x2:
-      return {Intrinsic::maxnum, FTZ_MustBeOn, true};
+      return {Intrinsic::maximumnum, FTZ_MustBeOn, true};
     case Intrinsic::nvvm_fmax_nan_f16:
       return {Intrinsic::maximum, FTZ_MustBeOff, true};
     case Intrinsic::nvvm_fmax_ftz_nan_f16:
@@ -236,23 +236,23 @@ static Instruction *convertNvvmIntrinsicToLlvm(InstCombiner &IC,
     case Intrinsic::nvvm_fmax_ftz_nan_f16x2:
       return {Intrinsic::maximum, FTZ_MustBeOn, true};
     case Intrinsic::nvvm_fmin_d:
-      return {Intrinsic::minnum, FTZ_Any};
+      return {Intrinsic::minimumnum, FTZ_Any};
     case Intrinsic::nvvm_fmin_f:
-      return {Intrinsic::minnum, FTZ_MustBeOff};
+      return {Intrinsic::minimumnum, FTZ_MustBeOff};
     case Intrinsic::nvvm_fmin_ftz_f:
-      return {Intrinsic::minnum, FTZ_MustBeOn};
+      return {Intrinsic::minimumnum, FTZ_MustBeOn};
     case Intrinsic::nvvm_fmin_nan_f:
       return {Intrinsic::minimum, FTZ_MustBeOff};
     case Intrinsic::nvvm_fmin_ftz_nan_f:
       return {Intrinsic::minimum, FTZ_MustBeOn};
     case Intrinsic::nvvm_fmin_f16:
-      return {Intrinsic::minnum, FTZ_MustBeOff, true};
+      return {Intrinsic::minimumnum, FTZ_MustBeOff, true};
     case Intrinsic::nvvm_fmin_ftz_f16:
-      return {Intrinsic::minnum, FTZ_MustBeOn, true};
+      return {Intrinsic::minimumnum, FTZ_MustBeOn, true};
     case Intrinsic::nvvm_fmin_f16x2:
-      return {Intrinsic::minnum, FTZ_MustBeOff, true};
+      return {Intrinsic::minimumnum, FTZ_MustBeOff, true};
     case Intrinsic::nvvm_fmin_ftz_f16x2:
-      return {Intrinsic::minnum, FTZ_MustBeOn, true};
+      return {Intrinsic::minimumnum, FTZ_MustBeOn, true};
     case Intrinsic::nvvm_fmin_nan_f16:
       return {Intrinsic::minimum, FTZ_MustBeOff, true};
     case Intrinsic::nvvm_fmin_ftz_nan_f16:

--- a/llvm/test/CodeGen/NVPTX/math-intrins-sm80-ptx70-instcombine.ll
+++ b/llvm/test/CodeGen/NVPTX/math-intrins-sm80-ptx70-instcombine.ll
@@ -33,7 +33,7 @@ declare <2 x half> @llvm.nvvm.fma.rn.ftz.f16x2(<2 x half>, <2 x half>, <2 x half
 ; CHECK-LABEL: fmin_f16
 define half @fmin_f16(half %0, half %1) {
   ; CHECK-NOT: @llvm.nvvm.fmin.f16
-  ; CHECK: @llvm.minnum.f16
+  ; CHECK: @llvm.minimumnum.f16
   %res = call half @llvm.nvvm.fmin.f16(half %0, half %1)
   ret half %res
 }
@@ -41,14 +41,14 @@ define half @fmin_f16(half %0, half %1) {
 ; CHECK-LABEL: fmin_ftz_f16
 define half @fmin_ftz_f16(half %0, half %1) #0 {
   ; CHECK-NOT: @llvm.nvvm.fmin.ftz.f16
-  ; CHECK: @llvm.minnum.f16
+  ; CHECK: @llvm.minimumnum.f16
   %res = call half @llvm.nvvm.fmin.ftz.f16(half %0, half %1)
   ret half %res
 }
 
 ; CHECK-LABEL: fmin_ftz_f16_no_attr
 define half @fmin_ftz_f16_no_attr(half %0, half %1) {
-  ; CHECK-NOT: @llvm.minnum.f16
+  ; CHECK-NOT: @llvm.minimumnum.f16
   ; CHECK: @llvm.nvvm.fmin.ftz.f16
   %res = call half @llvm.nvvm.fmin.ftz.f16(half %0, half %1)
   ret half %res
@@ -57,7 +57,7 @@ define half @fmin_ftz_f16_no_attr(half %0, half %1) {
 ; CHECK-LABEL: fmin_f16x2
 define <2 x half> @fmin_f16x2(<2 x half> %0, <2 x half> %1) {
   ; CHECK-NOT: @llvm.nvvm.fmin.f16x2
-  ; CHECK: @llvm.minnum.v2f16
+  ; CHECK: @llvm.minimumnum.v2f16
   %res = call <2 x half> @llvm.nvvm.fmin.f16x2(<2 x half> %0, <2 x half> %1)
   ret <2 x half> %res
 }
@@ -65,14 +65,14 @@ define <2 x half> @fmin_f16x2(<2 x half> %0, <2 x half> %1) {
 ; CHECK-LABEL: fmin_ftz_f16x2
 define <2 x half> @fmin_ftz_f16x2(<2 x half> %0, <2 x half> %1) #0 {
   ; CHECK-NOT: @llvm.nvvm.fmin.ftz.f16x2
-  ; CHECK: @llvm.minnum.v2f16
+  ; CHECK: @llvm.minimumnum.v2f16
   %res = call <2 x half> @llvm.nvvm.fmin.ftz.f16x2(<2 x half> %0, <2 x half> %1)
   ret <2 x half> %res
 }
 
 ; CHECK-LABEL: fmin_ftz_f16x2_no_attr
 define <2 x half> @fmin_ftz_f16x2_no_attr(<2 x half> %0, <2 x half> %1) {
-  ; CHECK-NOT: @llvm.minnum.v2f16
+  ; CHECK-NOT: @llvm.minimumnum.v2f16
   ; CHECK: @llvm.nvvm.fmin.ftz.f16x2
   %res = call <2 x half> @llvm.nvvm.fmin.ftz.f16x2(<2 x half> %0, <2 x half> %1)
   ret <2 x half> %res
@@ -153,7 +153,7 @@ define <2 x half> @fmin_ftz_nan_f16x2_no_attr(<2 x half> %0, <2 x half> %1) {
 ; CHECK-LABEL: fmax_f16
 define half @fmax_f16(half %0, half %1) {
   ; CHECK-NOT: @llvm.nvvm.fmax.f16
-  ; CHECK: @llvm.maxnum.f16
+  ; CHECK: @llvm.maximumnum.f16
   %res = call half @llvm.nvvm.fmax.f16(half %0, half %1)
   ret half %res
 }
@@ -161,14 +161,14 @@ define half @fmax_f16(half %0, half %1) {
 ; CHECK-LABEL: fmax_ftz_f16
 define half @fmax_ftz_f16(half %0, half %1) #0 {
   ; CHECK-NOT: @llvm.nvvm.fmax.ftz.f16
-  ; CHECK: @llvm.maxnum.f16
+  ; CHECK: @llvm.maximumnum.f16
   %res = call half @llvm.nvvm.fmax.ftz.f16(half %0, half %1)
   ret half %res
 }
 
 ; CHECK-LABEL: fmax_ftz_f16_no_attr
 define half @fmax_ftz_f16_no_attr(half %0, half %1) {
-  ; CHECK-NOT: @llvm.maxnum.f16
+  ; CHECK-NOT: @llvm.maximumnum.f16
   ; CHECK: @llvm.nvvm.fmax.ftz.f16
   %res = call half @llvm.nvvm.fmax.ftz.f16(half %0, half %1)
   ret half %res
@@ -177,7 +177,7 @@ define half @fmax_ftz_f16_no_attr(half %0, half %1) {
 ; CHECK-LABEL: fmax_f16x2
 define <2 x half> @fmax_f16x2(<2 x half> %0, <2 x half> %1) {
   ; CHECK-NOT: @llvm.nvvm.fmax.f16x2
-  ; CHECK: @llvm.maxnum.v2f16
+  ; CHECK: @llvm.maximumnum.v2f16
   %res = call <2 x half> @llvm.nvvm.fmax.f16x2(<2 x half> %0, <2 x half> %1)
   ret <2 x half> %res
 }
@@ -185,14 +185,14 @@ define <2 x half> @fmax_f16x2(<2 x half> %0, <2 x half> %1) {
 ; CHECK-LABEL: fmax_ftz_f16x2
 define <2 x half> @fmax_ftz_f16x2(<2 x half> %0, <2 x half> %1) #0 {
   ; CHECK-NOT: @llvm.nvvm.fmax.ftz.f16x2
-  ; CHECK: @llvm.maxnum.v2f16
+  ; CHECK: @llvm.maximumnum.v2f16
   %res = call <2 x half> @llvm.nvvm.fmax.ftz.f16x2(<2 x half> %0, <2 x half> %1)
   ret <2 x half> %res
 }
 
 ; CHECK-LABEL: fmax_ftz_f16x2_no_attr
 define <2 x half> @fmax_ftz_f16x2_no_attr(<2 x half> %0, <2 x half> %1) {
-  ; CHECK-NOT: @llvm.maxnum.v2f16
+  ; CHECK-NOT: @llvm.maximumnum.v2f16
   ; CHECK: @llvm.nvvm.fmax.ftz.f16x2
   %res = call <2 x half> @llvm.nvvm.fmax.ftz.f16x2(<2 x half> %0, <2 x half> %1)
   ret <2 x half> %res

--- a/llvm/test/Transforms/InstCombine/NVPTX/nvvm-intrins.ll
+++ b/llvm/test/Transforms/InstCombine/NVPTX/nvvm-intrins.ll
@@ -104,13 +104,13 @@ define float @fma_float_ftz(float %a, float %b, float %c) #0 {
 
 ; CHECK-LABEL: @fmax_double
 define double @fmax_double(double %a, double %b) #0 {
-; CHECK: call double @llvm.maxnum.f64
+; CHECK: call double @llvm.maximumnum.f64
   %ret = call double @llvm.nvvm.fmax.d(double %a, double %b)
   ret double %ret
 }
 ; CHECK-LABEL: @fmax_float
 define float @fmax_float(float %a, float %b) #0 {
-; NOFTZ: call float @llvm.maxnum.f32
+; NOFTZ: call float @llvm.maximumnum.f32
 ; FTZ: call float @llvm.nvvm.fmax.f
   %ret = call float @llvm.nvvm.fmax.f(float %a, float %b)
   ret float %ret
@@ -118,20 +118,20 @@ define float @fmax_float(float %a, float %b) #0 {
 ; CHECK-LABEL: @fmax_float_ftz
 define float @fmax_float_ftz(float %a, float %b) #0 {
 ; NOFTZ: call float @llvm.nvvm.fmax.ftz.f
-; FTZ: call float @llvm.maxnum.f32
+; FTZ: call float @llvm.maximumnum.f32
   %ret = call float @llvm.nvvm.fmax.ftz.f(float %a, float %b)
   ret float %ret
 }
 
 ; CHECK-LABEL: @fmin_double
 define double @fmin_double(double %a, double %b) #0 {
-; CHECK: call double @llvm.minnum.f64
+; CHECK: call double @llvm.minimumnum.f64
   %ret = call double @llvm.nvvm.fmin.d(double %a, double %b)
   ret double %ret
 }
 ; CHECK-LABEL: @fmin_float
 define float @fmin_float(float %a, float %b) #0 {
-; NOFTZ: call float @llvm.minnum.f32
+; NOFTZ: call float @llvm.minimumnum.f32
 ; FTZ: call float @llvm.nvvm.fmin.f
   %ret = call float @llvm.nvvm.fmin.f(float %a, float %b)
   ret float %ret
@@ -139,7 +139,7 @@ define float @fmin_float(float %a, float %b) #0 {
 ; CHECK-LABEL: @fmin_float_ftz
 define float @fmin_float_ftz(float %a, float %b) #0 {
 ; NOFTZ: call float @llvm.nvvm.fmin.ftz.f
-; FTZ: call float @llvm.minnum.f32
+; FTZ: call float @llvm.minimumnum.f32
   %ret = call float @llvm.nvvm.fmin.ftz.f(float %a, float %b)
   ret float %ret
 }


### PR DESCRIPTION
Converting nvvm.{fmin/fmax} into llvm.{min/max}num is slightly incorrect, as {min/max}(a, sNaN) should produce "a" according to the PTX spec, but LLVM's {min/max}num intrinsics may return either NaN or "a".

Use the {min/max}imumnum intrinsics instead for correct sNaN behaviour.

Also tidy up NVVM FMin/FMax constant-folding using these tighter definitions of how the NVVM intrinsics map to {min/max}imum and {min/max}imumnum.