### PR TITLE
[lldb] Enable template getters on pointer types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -7077,6 +7077,8 @@ TypeSystemClang::GetNumTemplateArguments(lldb::opaque_compiler_type_t type,
     return 0;
 
   clang::QualType qual_type = RemoveWrappingTypes(GetCanonicalQualType(type));
+  if (qual_type->isPointerOrReferenceType())
+    qual_type = qual_type->getPointeeType();
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
   switch (type_class) {
   case clang::Type::Record:
@@ -7116,6 +7118,8 @@ TypeSystemClang::GetAsTemplateSpecialization(
     return nullptr;
 
   clang::QualType qual_type(RemoveWrappingTypes(GetCanonicalQualType(type)));
+  if (qual_type->isPointerOrReferenceType())
+    qual_type = qual_type->getPointeeType();
   const clang::Type::TypeClass type_class = qual_type->getTypeClass();
   switch (type_class) {
   case clang::Type::Record: {

--- a/lldb/test/API/lang/cpp/template-arguments/TestCppTemplateArguments.py
+++ b/lldb/test/API/lang/cpp/template-arguments/TestCppTemplateArguments.py
@@ -12,40 +12,43 @@ class TestCase(TestBase):
         self.build()
         target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
 
-        value = self.expect_expr("temp1", result_type="C<int, 2>")
-        template_type = value.GetType()
-        self.assertEqual(template_type.GetNumberOfTemplateArguments(), 2)
+        temp1 = self.expect_expr("temp1", result_type="C<int, 2>")
+        ptemp1 = self.expect_expr("ptemp1", result_type="C<int, 2> *")
+        for value in (temp1, ptemp1):
+            template_type = value.GetType()
+            self.assertEqual(template_type.GetNumberOfTemplateArguments(), 2)
 
-        # Check a type argument.
-        self.assertEqual(
-            template_type.GetTemplateArgumentKind(0), lldb.eTemplateArgumentKindType
-        )
-        self.assertEqual(template_type.GetTemplateArgumentType(0).GetName(), "int")
+            # Check a type argument.
+            self.assertEqual(
+                template_type.GetTemplateArgumentKind(0), lldb.eTemplateArgumentKindType
+            )
+            self.assertEqual(template_type.GetTemplateArgumentType(0).GetName(), "int")
 
-        # Check a integral argument.
-        self.assertEqual(
-            template_type.GetTemplateArgumentKind(1), lldb.eTemplateArgumentKindIntegral
-        )
-        self.assertEqual(
-            template_type.GetTemplateArgumentType(1).GetName(), "unsigned int"
-        )
+            # Check a integral argument.
+            self.assertEqual(
+                template_type.GetTemplateArgumentKind(1),
+                lldb.eTemplateArgumentKindIntegral,
+            )
+            self.assertEqual(
+                template_type.GetTemplateArgumentType(1).GetName(), "unsigned int"
+            )
 
-        # Template parameter isn't a NTTP.
-        self.assertFalse(template_type.GetTemplateArgumentValue(target, 0))
+            # Template parameter isn't a NTTP.
+            self.assertFalse(template_type.GetTemplateArgumentValue(target, 0))
 
-        # Template parameter index out-of-bounds.
-        self.assertFalse(template_type.GetTemplateArgumentValue(target, 2))
+            # Template parameter index out-of-bounds.
+            self.assertFalse(template_type.GetTemplateArgumentValue(target, 2))
 
-        # Template parameter is a NTTP.
-        param_val = template_type.GetTemplateArgumentValue(target, 1)
-        self.assertEqual(param_val.GetTypeName(), "unsigned int")
-        self.assertEqual(param_val.GetValueAsUnsigned(), 2)
+            # Template parameter is a NTTP.
+            param_val = template_type.GetTemplateArgumentValue(target, 1)
+            self.assertEqual(param_val.GetTypeName(), "unsigned int")
+            self.assertEqual(param_val.GetValueAsUnsigned(), 2)
 
-        # Try to get an invalid template argument.
-        self.assertEqual(
-            template_type.GetTemplateArgumentKind(2), lldb.eTemplateArgumentKindNull
-        )
-        self.assertEqual(template_type.GetTemplateArgumentType(2).GetName(), "")
+            # Try to get an invalid template argument.
+            self.assertEqual(
+                template_type.GetTemplateArgumentKind(2), lldb.eTemplateArgumentKindNull
+            )
+            self.assertEqual(template_type.GetTemplateArgumentType(2).GetName(), "")
 
         value = self.expect_expr("temp2", result_type="Foo<short, -2>")
 

--- a/lldb/test/API/lang/cpp/template-arguments/main.cpp
+++ b/lldb/test/API/lang/cpp/template-arguments/main.cpp
@@ -4,6 +4,7 @@ struct C {
 };
 
 C<int, 2> temp1;
+auto *ptemp1 = &temp1;
 
 template <typename T, T value> struct Foo {};
 Foo<short, -2> temp2;


### PR DESCRIPTION
Fixes `GetNumberOfTemplateArguments` and `GetTemplateArgumentType` for pointers to template instances.

Consider a value declared like:

```cpp
Generic<int> *generic_ptr;
```

With this change, the following now works:

```py
inner_type = generic_ptr.GetType().GetTemplateArgumentType(0)
```

Previously, the type would have to be manually/explicitly unwrapped:

```py
inner_type = generic_ptr.GetType().GetPointeeType().GetTemplateArgumentType(0)
```

See for example SmallVectorSynthProvider in lldbDataFormatters.py
