### PR TITLE
[flang][OpenMP] Remove qualification from evaluate::SymbolVector, NFC

### DIFF
--- a/flang/lib/Semantics/check-omp-atomic.cpp
+++ b/flang/lib/Semantics/check-omp-atomic.cpp
@@ -595,7 +595,7 @@ void OmpStructureChecker::CheckAtomicVariable(
     return;
   }
 
-  evaluate::SymbolVector syms{evaluate::GetSymbolVector(dsgs.front())};
+  SymbolVector syms{evaluate::GetSymbolVector(dsgs.front())};
   if (syms.empty()) {
     return;
   }

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -4404,7 +4404,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Map &x) {
     }
 
     auto hasBasePointer{[&](const SomeExpr &item) {
-      evaluate::SymbolVector symbols{evaluate::GetSymbolVector(item)};
+      SymbolVector symbols{evaluate::GetSymbolVector(item)};
       return llvm::any_of(
           symbols, [](SymbolRef s) { return IsPointer(s.get()); });
     }};

--- a/flang/lib/Semantics/openmp-utils.cpp
+++ b/flang/lib/Semantics/openmp-utils.cpp
@@ -423,7 +423,7 @@ std::vector<SomeExpr> GetTopLevelDesignators(const SomeExpr &expr) {
 }
 
 static bool HasCommonDesignatorSymbols(
-    const evaluate::SymbolVector &baseSyms, const SomeExpr &other) {
+    const SymbolVector &baseSyms, const SomeExpr &other) {
   // Compare the designators used in "other" with the designators whose
   // symbols are given in baseSyms.
   // This is a part of the check if these two expressions can access the same
@@ -450,28 +450,28 @@ static bool HasCommonDesignatorSymbols(
     return false;
   }
 
-  auto isSubsequence{// Is u a subsequence of v.
-      [](const evaluate::SymbolVector &u, const evaluate::SymbolVector &v) {
-        size_t us{u.size()}, vs{v.size()};
-        if (us > vs) {
-          return false;
+  // Is u a subsequence of v.
+  auto isSubsequence{[](const SymbolVector &u, const SymbolVector &v) {
+    size_t us{u.size()}, vs{v.size()};
+    if (us > vs) {
+      return false;
+    }
+    for (size_t off{0}; off != vs - us + 1; ++off) {
+      bool same{true};
+      for (size_t i{0}; i != us; ++i) {
+        if (u[i] != v[off + i]) {
+          same = false;
+          break;
         }
-        for (size_t off{0}; off != vs - us + 1; ++off) {
-          bool same{true};
-          for (size_t i{0}; i != us; ++i) {
-            if (u[i] != v[off + i]) {
-              same = false;
-              break;
-            }
-          }
-          if (same) {
-            return true;
-          }
-        }
-        return false;
-      }};
+      }
+      if (same) {
+        return true;
+      }
+    }
+    return false;
+  }};
 
-  evaluate::SymbolVector otherSyms{evaluate::GetSymbolVector(other)};
+  SymbolVector otherSyms{evaluate::GetSymbolVector(other)};
   return isSubsequence(baseSyms, otherSyms);
 }
 
@@ -492,7 +492,7 @@ static bool HasCommonTopLevelDesignators(
 
 const SomeExpr *HasStorageOverlap(
     const SomeExpr &base, llvm::ArrayRef<SomeExpr> exprs) {
-  evaluate::SymbolVector baseSyms{evaluate::GetSymbolVector(base)};
+  SymbolVector baseSyms{evaluate::GetSymbolVector(base)};
   std::vector<SomeExpr> baseDsgs{GetTopLevelDesignators(base)};
 
   for (const SomeExpr &expr : exprs) {


### PR DESCRIPTION
`SymbolVector` is defined in flang/Semantics/symbol.h, so there is no need to use a namespace-qualified name for it in lib/Semantics.