### PR TITLE
[llvm-reduce] Set the target triple before parsing machine functions

### DIFF
--- a/llvm/test/tools/llvm-reduce/mir/set-triple-on-module.mir
+++ b/llvm/test/tools/llvm-reduce/mir/set-triple-on-module.mir
@@ -1,0 +1,16 @@
+# REQUIRES: x86-registered-target
+
+# RUN: llvm-reduce -simplify-mir --test FileCheck --test-arg --check-prefix=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
+# RUN: FileCheck %s < %t
+
+# CHECK-INTERESTINGNESS: RET64
+
+# CHECK: target triple = "x86_64-unknown-linux-gnu"
+# CHECK: name:            func
+
+---
+name: func
+body: |
+  bb.0:
+    RET64
+...

--- a/llvm/test/tools/llvm-reduce/mir/set-triple-on-module.mir
+++ b/llvm/test/tools/llvm-reduce/mir/set-triple-on-module.mir
@@ -1,6 +1,6 @@
 # REQUIRES: x86-registered-target
 
-# RUN: llvm-reduce -simplify-mir --test FileCheck --test-arg --check-prefix=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
+# RUN: llvm-reduce -simplify-mir -mtriple="x86_64-unknown-linux-gnu" --test FileCheck --test-arg --check-prefix=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
 # RUN: FileCheck %s < %t
 
 # CHECK-INTERESTINGNESS: RET64

--- a/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
+++ b/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
@@ -859,6 +859,9 @@ llvm::parseReducerWorkItem(StringRef ToolName, StringRef Filename,
 
     std::unique_ptr<Module> M = MParser->parseIRModule(SetDataLayout);
 
+    if (!TheTriple.empty())
+      M->setTargetTriple(TheTriple);
+
     MMM->MMI = std::make_unique<MachineModuleInfo>(TM.get());
     MParser->parseMachineFunctions(*M, *MMM->MMI);
     MMM->M = std::move(M);


### PR DESCRIPTION
Make sure that the module has a target triple set before trying to parse machine functions. This can be required for (downstream) targets if MIR parsing relies on features guarded by the target triple.