### PR TITLE
[libc] Install the RPC headers so they can be used without LLVM source

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -403,6 +403,7 @@ else()
 endif()
 
 add_subdirectory(include)
+add_subdirectory(shared)
 add_subdirectory(config)
 add_subdirectory(hdr)
 add_subdirectory(src)

--- a/libc/shared/CMakeLists.txt
+++ b/libc/shared/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(LLVM_LIBC_SHARED_RPC_EXPORT_HEADERS
+    "${CMAKE_CURRENT_SOURCE_DIR}/rpc.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/rpc_util.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/rpc_dispatch.h"
+)
+
+# Install the freestanding RPC interface to the compiler tree.
+if(LIBC_TARGET_OS_IS_GPU)
+  foreach(header_path IN LISTS LLVM_LIBC_SHARED_RPC_EXPORT_HEADERS)
+    install(FILES "${header_path}"
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/shared"
+            COMPONENT libc-headers)
+  endforeach()
+endif()


### PR DESCRIPTION
Summary:
The RPC headers are completely freestanding and can be installed and
used. This just places them in the standard compiler install directory
along with everything else. We put it under `shared/` so the usage
matches with using the upstream version. People using the installed
version will need to manuall `-isystem` into the include directory, but
this is part for the course for these LLVM extra headers.
