### PR TITLE
Fully disable `preserve_none` under ASan

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -36,12 +36,12 @@
 #include "llvm/ADT/ScopeExit.h"
 #include <type_traits>
 
-// preserve_none is supported on aarch64, but causes problems when asan is
-// enabled. See https://github.com/llvm/llvm-project/issues/177519.
-// preserve_none also causes problems on clang <= 19 if asan is enabled.
+// preserve_none causes problems when asan is enabled on both AArch64 and other
+// platforms. Disable it until all the bugs are fixed here.
+//
+// See https://github.com/llvm/llvm-project/issues/177519 for AArch64.
 #if !defined(__aarch64__) && !defined(__i386__) &&                             \
-    !(defined(__clang_major__) && __clang_major__ <= 19 &&                     \
-      __has_feature(address_sanitizer)) &&                                     \
+    !__has_feature(address_sanitizer) &&                                       \
     __has_cpp_attribute(clang::preserve_none)
 #define PRESERVE_NONE [[clang::preserve_none]]
 #else


### PR DESCRIPTION
This crashes Clang 19, 21, and 22 on x86-64 that I've tested and I don't have a ready-to-test build of any other versions but it seems much safer to just disable for now.