### PR TITLE
[Hexagon][MIR] Serialize HexagonMachineFunctionInfo::StackAlignBaseReg to MIR

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonMachineFunctionInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonMachineFunctionInfo.cpp
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "HexagonMachineFunctionInfo.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/CodeGen/TargetRegisterInfo.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 
@@ -19,3 +22,24 @@ MachineFunctionInfo *HexagonMachineFunctionInfo::clone(
     const {
   return DestMF.cloneInfo<HexagonMachineFunctionInfo>(*this);
 }
+
+static yaml::StringValue regToString(Register Reg,
+                                     const TargetRegisterInfo &TRI) {
+  yaml::StringValue Dest;
+  if (Reg.isValid()) {
+    raw_string_ostream OS(Dest.Value);
+    OS << printReg(Reg, &TRI);
+  }
+  return Dest;
+}
+
+yaml::HexagonFunctionInfo::HexagonFunctionInfo(
+    const llvm::HexagonMachineFunctionInfo &MFI, const TargetRegisterInfo &TRI)
+    : StackAlignBaseReg(regToString(MFI.getStackAlignBaseReg(), TRI)) {}
+
+void yaml::HexagonFunctionInfo::mappingImpl(yaml::IO &YamlIO) {
+  MappingTraits<HexagonFunctionInfo>::mapping(YamlIO, *this);
+}
+
+void HexagonMachineFunctionInfo::initializeBaseYamlFields(
+    const yaml::HexagonFunctionInfo &YamlMFI) {}

--- a/llvm/lib/Target/Hexagon/HexagonMachineFunctionInfo.h
+++ b/llvm/lib/Target/Hexagon/HexagonMachineFunctionInfo.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIB_TARGET_HEXAGON_HEXAGONMACHINEFUNCTIONINFO_H
 #define LLVM_LIB_TARGET_HEXAGON_HEXAGONMACHINEFUNCTIONINFO_H
 
+#include "llvm/CodeGen/MIRYamlMapping.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include <map>
 
 namespace llvm {
+
+namespace yaml {
+struct HexagonFunctionInfo;
+} // end namespace yaml
 
 namespace Hexagon {
 
@@ -47,6 +52,8 @@ public:
   clone(BumpPtrAllocator &Allocator, MachineFunction &DestMF,
         const DenseMap<MachineBasicBlock *, MachineBasicBlock *> &Src2DstMBB)
       const override;
+
+  void initializeBaseYamlFields(const yaml::HexagonFunctionInfo &YamlMFI);
 
   unsigned getSRetReturnReg() const { return SRetReturnReg; }
   void setSRetReturnReg(unsigned Reg) { SRetReturnReg = Reg; }
@@ -86,6 +93,28 @@ public:
   void setStackAlignBaseReg(Register R) { StackAlignBaseReg = R; }
   Register getStackAlignBaseReg() const { return StackAlignBaseReg; }
 };
+
+namespace yaml {
+
+/// Hexagon-specific MachineFunction properties for YAML serialization.
+struct HexagonFunctionInfo final : public yaml::MachineFunctionInfo {
+  StringValue StackAlignBaseReg;
+
+  HexagonFunctionInfo() = default;
+  HexagonFunctionInfo(const llvm::HexagonMachineFunctionInfo &MFI,
+                      const TargetRegisterInfo &TRI);
+
+  void mappingImpl(yaml::IO &YamlIO) override;
+  ~HexagonFunctionInfo() override = default;
+};
+
+template <> struct MappingTraits<HexagonFunctionInfo> {
+  static void mapping(IO &YamlIO, HexagonFunctionInfo &MFI) {
+    YamlIO.mapOptional("stackAlignBaseReg", MFI.StackAlignBaseReg);
+  }
+};
+
+} // end namespace yaml
 
 } // end namespace llvm
 

--- a/llvm/lib/Target/Hexagon/HexagonRegisterInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonRegisterInfo.cpp
@@ -242,16 +242,6 @@ bool HexagonRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
   // Add the offset from the instruction.
   int RealOffset = Offset + MI.getOperand(FIOp+1).getImm();
 
-  // If AP is used as the base register, add it to this block's liveins.
-  // AP is defined in the entry block and may be used in other blocks for
-  // stack access. Liveness must be accurate for the verifier.
-  auto &HMFI = *MF.getInfo<HexagonMachineFunctionInfo>();
-  Register AP = HMFI.getStackAlignBaseReg();
-  if (AP.isValid() && BP == AP) {
-    if (!MB.isLiveIn(AP))
-      MB.addLiveIn(AP);
-  }
-
   unsigned Opc = MI.getOpcode();
   switch (Opc) {
     case Hexagon::PS_fia:

--- a/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
@@ -20,6 +20,7 @@
 #include "HexagonTargetTransformInfo.h"
 #include "HexagonVectorLoopCarriedReuse.h"
 #include "TargetInfo/HexagonTargetInfo.h"
+#include "llvm/CodeGen/MIRParser/MIParser.h"
 #include "llvm/CodeGen/Passes.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
 #include "llvm/CodeGen/VLIWMachineScheduler.h"
@@ -297,6 +298,41 @@ MachineFunctionInfo *HexagonTargetMachine::createMachineFunctionInfo(
     const TargetSubtargetInfo *STI) const {
   return HexagonMachineFunctionInfo::create<HexagonMachineFunctionInfo>(
       Allocator, F, STI);
+}
+
+yaml::MachineFunctionInfo *
+HexagonTargetMachine::createDefaultFuncInfoYAML() const {
+  return new yaml::HexagonFunctionInfo();
+}
+
+yaml::MachineFunctionInfo *
+HexagonTargetMachine::convertFuncInfoToYAML(const MachineFunction &MF) const {
+  const auto *MFI = MF.getInfo<HexagonMachineFunctionInfo>();
+  const auto &TRI = *MF.getSubtarget().getRegisterInfo();
+  return new yaml::HexagonFunctionInfo(*MFI, TRI);
+}
+
+bool HexagonTargetMachine::parseMachineFunctionInfo(
+    const yaml::MachineFunctionInfo &MFI_, PerFunctionMIParsingState &PFS,
+    SMDiagnostic &Error, SMRange &SourceRange) const {
+  const auto &YamlMFI = static_cast<const yaml::HexagonFunctionInfo &>(MFI_);
+  MachineFunction &MF = PFS.MF;
+  HexagonMachineFunctionInfo *MFI = MF.getInfo<HexagonMachineFunctionInfo>();
+
+  MFI->initializeBaseYamlFields(YamlMFI);
+
+  // Parse StackAlignBaseReg register name
+  if (!YamlMFI.StackAlignBaseReg.Value.empty()) {
+    Register Reg;
+    if (parseNamedRegisterReference(PFS, Reg, YamlMFI.StackAlignBaseReg.Value,
+                                    Error)) {
+      SourceRange = YamlMFI.StackAlignBaseReg.SourceRange;
+      return true;
+    }
+    MFI->setStackAlignBaseReg(Reg);
+  }
+
+  return false;
 }
 
 HexagonTargetMachine::~HexagonTargetMachine() = default;

--- a/llvm/lib/Target/Hexagon/HexagonTargetMachine.h
+++ b/llvm/lib/Target/Hexagon/HexagonTargetMachine.h
@@ -47,6 +47,14 @@ public:
   createMachineFunctionInfo(BumpPtrAllocator &Allocator, const Function &F,
                             const TargetSubtargetInfo *STI) const override;
 
+  yaml::MachineFunctionInfo *createDefaultFuncInfoYAML() const override;
+  yaml::MachineFunctionInfo *
+  convertFuncInfoToYAML(const MachineFunction &MF) const override;
+  bool parseMachineFunctionInfo(const yaml::MachineFunctionInfo &,
+                                PerFunctionMIParsingState &PFS,
+                                SMDiagnostic &Error,
+                                SMRange &SourceRange) const override;
+
   bool isNoopAddrSpaceCast(unsigned SrcAS, unsigned DestAS) const override {
     return true;
   }

--- a/llvm/test/CodeGen/Hexagon/aligna-prologue-expansion.mir
+++ b/llvm/test/CodeGen/Hexagon/aligna-prologue-expansion.mir
@@ -5,6 +5,8 @@
 # Verify that PS_aligna is placed AFTER all CSR spills.
 #
 # CHECK-LABEL: name: test_aligna_expansion
+# CHECK: machineFunctionInfo:
+# CHECK-NEXT: stackAlignBaseReg: '$r16'
 # CHECK: S2_allocframe
 # CHECK: S2_storerd_io $r30, -8
 # CHECK: S2_storerd_io $r30, -16
@@ -15,20 +17,13 @@
 # CHECK: PS_aligna
 # CHECK-NOT: S2_storerd_io
 #
-# Verify that AP (R16) is added to liveins of blocks that use it.
-# CHECK: bb.3:
-# CHECK-NEXT: successors:
-# CHECK-NEXT: liveins: {{.*}}$r16
-#
 # SPILL-FUNC-LABEL: name: test_aligna_expansion
+# SPILL-FUNC: machineFunctionInfo:
+# SPILL-FUNC-NEXT: stackAlignBaseReg: '$r16'
 # SPILL-FUNC: S2_allocframe
 # SPILL-FUNC: SAVE_REGISTERS_CALL_V4
 # SPILL-FUNC: PS_aligna
 # SPILL-FUNC-NOT: SAVE_REGISTERS_CALL_V4
-#
-# SPILL-FUNC: bb.3:
-# SPILL-FUNC-NEXT: successors:
-# SPILL-FUNC-NEXT: liveins: {{.*}}$r16
 
 --- |
   declare void @external_func()
@@ -39,6 +34,8 @@
 name:            test_aligna_expansion
 alignment:       16
 tracksRegLiveness: true
+machineFunctionInfo:
+  stackAlignBaseReg: '$r16'
 frameInfo:
   maxAlignment:    128
   adjustsStack:    true


### PR DESCRIPTION
This patch adds serialization of HexagonMachineFunctionInfo::StackAlignBaseReg
into MIR. This field stores the physical register used as the aligned-stack base pointer 
when a function has both variable-sized stack objects and requires stack alignment 
greater than the default.

This replaces the workaround from commit 2e10b6299591 ("[Hexagon] Add AP
register to liveins when used for frame index access") which manually added
AP to liveins. That approach was incorrect because it only updated one block
without updating predecessors, breaking liveness invariants.
