### PR TITLE
[llvm lib] `DataExtractor`: Add `StringOffsetSize` field and `getStringOffset()`

### DIFF
--- a/llvm/include/llvm/Support/DataExtractor.h
+++ b/llvm/include/llvm/Support/DataExtractor.h
@@ -39,6 +39,8 @@ class DataExtractor {
   StringRef Data;
   uint8_t IsLittleEndian;
   uint8_t AddressSize;
+  uint8_t StringOffsetSize = 4;
+
 public:
   /// A class representing a position in a DataExtractor, as well as any error
   /// encountered during extraction. It enables one to extract a sequence of
@@ -96,6 +98,10 @@ public:
   uint8_t getAddressSize() const { return AddressSize; }
   /// Set the address size for this extractor.
   void setAddressSize(uint8_t Size) { AddressSize = Size; }
+  /// Get the string offset size for this extractor.
+  uint8_t getStringOffsetSize() const { return StringOffsetSize; }
+  /// Set the string offset size for this extractor.
+  void setStringOffsetSize(uint8_t Size) { StringOffsetSize = Size; }
 
   /// Extract a C string from \a *offset_ptr.
   ///
@@ -329,6 +335,18 @@ public:
   /// cursor. In case of an extraction error, or if the cursor is already in
   /// an error state, zero is returned.
   uint64_t getAddress(Cursor &C) const { return getUnsigned(C, AddressSize); }
+
+  /// Extract a string offset of StringOffsetSize bytes from \a *offset_ptr.
+  uint64_t getStringOffset(uint64_t *offset_ptr) const {
+    return getUnsigned(offset_ptr, StringOffsetSize);
+  }
+
+  /// Extract a string offset of StringOffsetSize bytes from the location given
+  /// by the cursor. In case of an extraction error, or if the cursor is already
+  /// in an error state, zero is returned.
+  uint64_t getStringOffset(Cursor &C) const {
+    return getUnsigned(C, StringOffsetSize);
+  }
 
   /// Extract a uint8_t value from \a *offset_ptr.
   ///

--- a/llvm/unittests/Support/DataExtractorTest.cpp
+++ b/llvm/unittests/Support/DataExtractorTest.cpp
@@ -449,4 +449,84 @@ TEST(DataExtractorTest, GetBytes) {
   EXPECT_THAT_ERROR(C.takeError(), Failed());
 }
 
+TEST(DataExtractorTest, StringOffsetSize) {
+  // Default StringOffsetSize is 4.
+  DataExtractor DE(StringRef("\0", 1), false, 8);
+  EXPECT_EQ(4u, DE.getStringOffsetSize());
+
+  // Set and get for all sizes 1-8.
+  for (uint8_t Size = 1; Size <= 8; ++Size) {
+    DE.setStringOffsetSize(Size);
+    EXPECT_EQ(Size, DE.getStringOffsetSize());
+  }
+}
+
+TEST(DataExtractorTest, GetStringOffset) {
+  // Data: 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x08
+  const char Data[] = "\x01\x02\x03\x04\x05\x06\x07\x08";
+  DataExtractor LE(StringRef(Data, 8), true, 8);
+  DataExtractor BE(StringRef(Data, 8), false, 8);
+
+  // Expected little-endian values for sizes 1-8 reading from offset 0.
+  const uint64_t ExpectedLE[] = {
+      0x01u,               // size 1
+      0x0201u,             // size 2
+      0x030201u,           // size 3
+      0x04030201u,         // size 4
+      0x0504030201u,       // size 5
+      0x060504030201u,     // size 6
+      0x07060504030201u,   // size 7
+      0x0807060504030201u, // size 8
+  };
+  // Expected big-endian values for sizes 1-8 reading from offset 0.
+  const uint64_t ExpectedBE[] = {
+      0x01u,               // size 1
+      0x0102u,             // size 2
+      0x010203u,           // size 3
+      0x01020304u,         // size 4
+      0x0102030405u,       // size 5
+      0x010203040506u,     // size 6
+      0x01020304050607u,   // size 7
+      0x0102030405060708u, // size 8
+  };
+
+  for (uint8_t Size = 1; Size <= 8; ++Size) {
+    LE.setStringOffsetSize(Size);
+    BE.setStringOffsetSize(Size);
+    uint64_t Offset = 0;
+    EXPECT_EQ(ExpectedLE[Size - 1], LE.getStringOffset(&Offset))
+        << "LE size=" << (int)Size;
+    EXPECT_EQ(Size, Offset);
+    Offset = 0;
+    EXPECT_EQ(ExpectedBE[Size - 1], BE.getStringOffset(&Offset))
+        << "BE size=" << (int)Size;
+    EXPECT_EQ(Size, Offset);
+  }
+}
+
+TEST(DataExtractorTest, GetStringOffsetCursor) {
+  const char Data[] = "\x01\x02\x03\x04\x05\x06\x07\x08";
+  DataExtractor DE(StringRef(Data, 8), true, 8);
+
+  // Test Cursor-based reads for all sizes 1-8.
+  for (uint8_t Size = 1; Size <= 8; ++Size) {
+    DE.setStringOffsetSize(Size);
+    DataExtractor::Cursor C(0);
+    // Read the first element.
+    uint64_t Val = DE.getStringOffset(C);
+    EXPECT_EQ(Size, C.tell()) << "size=" << (int)Size;
+    EXPECT_NE(0u, Val) << "size=" << (int)Size;
+    EXPECT_THAT_ERROR(C.takeError(), Succeeded());
+  }
+
+  // Verify reading past end fails.
+  DE.setStringOffsetSize(4);
+  DataExtractor::Cursor C(0);
+  DE.getStringOffset(C); // offset 0-3
+  DE.getStringOffset(C); // offset 4-7
+  EXPECT_EQ(8u, C.tell());
+  EXPECT_THAT_ERROR(C.takeError(), Succeeded());
+  EXPECT_EQ(0u, DE.getStringOffset(C)); // past end
+  EXPECT_THAT_ERROR(C.takeError(), Failed());
+}
 }


### PR DESCRIPTION
Add a uint8_t StringOffsetSize field (default 4) with get/set accessors and getStringOffset() methods to DataExtractor, following the existing AddressSize/getAddress() pattern. This enables variable-width string table offset reading.

Add unit tests covering all sizes 1-8 for both endiannesses, Cursor-based reads, and past-end error handling.