### PR TITLE
[clang-doc] Make test alias depend on the unit test binary

### DIFF
--- a/clang-tools-extra/test/Unit/CMakeLists.txt
+++ b/clang-tools-extra/test/Unit/CMakeLists.txt
@@ -8,5 +8,6 @@ configure_lit_site_cfg(
 add_lit_testsuite(check-clang-doc-unit "Running clang-doc unit tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   EXCLUDE_FROM_CHECK_ALL
+  DEPENDS ClangDocTests
   ARGS --filter=ClangDocTests
   )


### PR DESCRIPTION
Without depends, this doesn't seem to rebuild the ClangDocTests target.