### PR TITLE
[lldb] Remove libc++ category from TestNavigateHiddenFrame.py

### DIFF
--- a/lldb/test/API/commands/frame/select-hidden/TestNavigateHiddenFrame.py
+++ b/lldb/test/API/commands/frame/select-hidden/TestNavigateHiddenFrame.py
@@ -7,7 +7,6 @@ from lldbsuite.test import lldbutil
 class NavigateHiddenFrameTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @add_test_categories(["libc++"])
     def test(self):
         """Test going up/down a backtrace but we started in a hidden frame."""
         self.build()


### PR DESCRIPTION
This test technically does not require libc++. The test binary mimics libc++'s namespace layout to trigger some frame hiding logic in lldb, but it does not require libc++ to function.