### PR TITLE
Revert "[Clang] Fix assertion when __block is used on global variables in C mode"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -430,7 +430,6 @@ Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 - Fixed a bug where explicit nullability property attributes were not stored in AST nodes in Objective-C. (#GH179703)
 - Fixed a crash when parsing Doxygen ``@param`` commands attached to invalid declarations or non-function entities. (#GH182737)
-- Fixed a assertion when __block is used on global variables in C mode. (#GH183974)
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaObjC.cpp
+++ b/clang/lib/Sema/SemaObjC.cpp
@@ -1711,12 +1711,6 @@ void SemaObjC::handleBlocksAttr(Decl *D, const ParsedAttr &AL) {
     return;
   }
 
-  VarDecl *VD = dyn_cast<VarDecl>(D);
-  if (!VD || !VD->hasLocalStorage()) {
-    Diag(AL.getLoc(), diag::err_block_on_nonlocal) << AL;
-    return;
-  }
-
   D->addAttr(::new (getASTContext()) BlocksAttr(getASTContext(), AL, type));
 }
 

--- a/clang/test/Sema/gh183974.c
+++ b/clang/test/Sema/gh183974.c
@@ -1,5 +1,0 @@
-// RUN: %clang_cc1 -fblocks -fsyntax-only -verify %s
-
-__block int x; // expected-error {{__block attribute not allowed, only allowed on local variables}}
-
-int x;


### PR DESCRIPTION
Reverts llvm/llvm-project#183988

Breaks ObjC code, see https://github.com/llvm/llvm-project/pull/183988#issuecomment-4134934748