### PR TITLE
[NFC][llvm-profgen] Fix a few minor issues

### DIFF
--- a/llvm/tools/llvm-profgen/MissingFrameInferrer.cpp
+++ b/llvm/tools/llvm-profgen/MissingFrameInferrer.cpp
@@ -118,12 +118,14 @@ void MissingFrameInferrer::initialize(
         }
       };
 
-  LLVM_DEBUG(dbgs() << "============================\n ";
-             dbgs() << "Call targets:\n";
-             PrintCallTargets(CallEdges, false);
-             dbgs() << "\nTail call targets:\n";
-             PrintCallTargets(CallEdges, true);
-             dbgs() << "============================\n";);
+  LLVM_DEBUG({
+    dbgs() << "============================\n ";
+    dbgs() << "Call targets:\n";
+    PrintCallTargets(CallEdges, false);
+    dbgs() << "\nTail call targets:\n";
+    PrintCallTargets(TailCallEdges, true);
+    dbgs() << "============================\n";
+  });
 #endif
 }
 

--- a/llvm/tools/llvm-profgen/PerfReader.h
+++ b/llvm/tools/llvm-profgen/PerfReader.h
@@ -299,7 +299,7 @@ struct UnwindState {
   uint64_t getCurrentLBRTarget() const { return LBRStack[LBRIndex].Target; }
   const LBREntry &getCurrentLBR() const { return LBRStack[LBRIndex]; }
   bool IsLastLBR() const { return LBRIndex == 0; }
-  bool getLBRStackSize() const { return LBRStack.size(); }
+  size_t getLBRStackSize() const { return LBRStack.size(); }
   void advanceLBR() { LBRIndex++; }
   ProfiledFrame *getParentFrame() { return CurrentLeafFrame->Parent; }
 

--- a/llvm/tools/llvm-profgen/ProfileGenerator.cpp
+++ b/llvm/tools/llvm-profgen/ProfileGenerator.cpp
@@ -244,10 +244,10 @@ bool ProfileGeneratorBase::filterAmbiguousProfile(FunctionSamples &FS) {
 // from the profile map during the profile generation time. The profiles are all
 // cold functions, it won't have perf impact.
 void ProfileGeneratorBase::filterAmbiguousProfile(SampleProfileMap &Profiles) {
-  for (auto I = ProfileMap.begin(); I != ProfileMap.end();) {
+  for (auto I = Profiles.begin(); I != Profiles.end();) {
     auto FS = I++;
     if (filterAmbiguousProfile(FS->second))
-      ProfileMap.erase(FS);
+      Profiles.erase(FS);
   }
 }
 
@@ -529,15 +529,14 @@ void ProfileGeneratorBase::markAllContextPreinlined(
 
 void ProfileGenerator::postProcessProfiles() {
   computeSummaryAndThreshold(ProfileMap);
-  trimColdProfiles(ProfileMap, ColdCountThreshold);
+  trimColdProfiles(ColdCountThreshold);
   filterAmbiguousProfile(ProfileMap);
   if (MarkAllContextPreinlined)
     markAllContextPreinlined(ProfileMap);
   calculateAndShowDensity(ProfileMap);
 }
 
-void ProfileGenerator::trimColdProfiles(const SampleProfileMap &Profiles,
-                                        uint64_t ColdCntThreshold) {
+void ProfileGenerator::trimColdProfiles(uint64_t ColdCntThreshold) {
   if (!TrimColdProfile)
     return;
 

--- a/llvm/tools/llvm-profgen/ProfileGenerator.h
+++ b/llvm/tools/llvm-profgen/ProfileGenerator.h
@@ -184,8 +184,7 @@ private:
   void
   populateTypeSamplesForAllFunctions(const DataAccessSample &DataAccessSamples);
   void postProcessProfiles();
-  void trimColdProfiles(const SampleProfileMap &Profiles,
-                        uint64_t ColdCntThreshold);
+  void trimColdProfiles(uint64_t ColdCntThreshold);
   bool collectFunctionsFromLLVMProfile(
       std::unordered_set<const BinaryFunction *> &ProfiledFunctions) override;
 };

--- a/llvm/tools/llvm-profgen/llvm-profgen.cpp
+++ b/llvm/tools/llvm-profgen/llvm-profgen.cpp
@@ -168,6 +168,8 @@ int main(int argc, const char *argv[]) {
     auto FS = vfs::getRealFileSystem();
     auto ReaderOrErr =
         SampleProfileReader::create(SampleProfFilename, Context, *FS);
+    if (std::error_code EC = ReaderOrErr.getError())
+      exitWithError(EC, SampleProfFilename);
     std::unique_ptr<sampleprof::SampleProfileReader> Reader =
         std::move(ReaderOrErr.get());
     Reader->read();


### PR DESCRIPTION
A few NFC (mostly) fixes:
- Drop unused parameters.
- Check return error.
- Fix return type.