### PR TITLE
[AMDGPU] Add AMDGPU support for llvm-objcopy

### DIFF
--- a/llvm/docs/CommandGuide/llvm-objcopy.rst
+++ b/llvm/docs/CommandGuide/llvm-objcopy.rst
@@ -621,6 +621,7 @@ options. For GNU :program:`objcopy` compatibility, the values are all bfdnames.
 - `elf32-loongarch`
 - `elf64-loongarch`
 - `elf64-s390`
+- `elf64-amdgpu`
 
 The following formats are supported by :program:`llvm-objcopy` for the
 :option:`--output-target` only:

--- a/llvm/test/tools/llvm-objcopy/ELF/binary-output-target.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/binary-output-target.test
@@ -97,6 +97,8 @@
 # SPARCEL-NEXT: Arch: sparcel
 # S390X-NEXT:   Arch: s390x
 # X86-64-NEXT:  Arch: x86_64
+## When converting from binary, e_flags is 0 (no EF_AMDGPU_MACH value set),
+## so llvm-readobj reports Arch: unknown. This is intentional.
 # AMDGPU-NEXT:  Arch: unknown
 
 # 32-NEXT:      AddressSize: 32bit

--- a/llvm/test/tools/llvm-objcopy/ELF/binary-output-target.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/binary-output-target.test
@@ -97,7 +97,7 @@
 # SPARCEL-NEXT: Arch: sparcel
 # S390X-NEXT:   Arch: s390x
 # X86-64-NEXT:  Arch: x86_64
-# AMDGPU-NEXT:  Arch: amdgpu
+# AMDGPU-NEXT:  Arch: unknown
 
 # 32-NEXT:      AddressSize: 32bit
 # 64-NEXT:      AddressSize: 64bit

--- a/llvm/test/tools/llvm-objcopy/ELF/binary-output-target.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/binary-output-target.test
@@ -57,6 +57,9 @@
 # RUN: llvm-objcopy -I binary -O elf64-s390 %t.txt %t.s390x.o
 # RUN: llvm-readobj --file-headers %t.s390x.o | FileCheck %s --check-prefixes=CHECK,BE,S390X,64
 
+# RUN: llvm-objcopy -I binary -O elf64-amdgpu %t.txt %t.amdgpu.o
+# RUN: llvm-readobj --file-headers %t.amdgpu.o | FileCheck %s --check-prefixes=CHECK,LE,AMDGPU,64
+
 # CHECK: Format:
 # 32-SAME:      elf32-
 # 64-SAME:      elf64-
@@ -75,6 +78,7 @@
 # SPARCEL-SAME: sparc
 # S390X-SAME:   s390
 # X86-64-SAME:  x86-64
+# AMDGPU-SAME:  amdgpu
 
 # AARCH64-NEXT: Arch: aarch64
 # ARM-NEXT:     Arch: arm
@@ -93,6 +97,7 @@
 # SPARCEL-NEXT: Arch: sparcel
 # S390X-NEXT:   Arch: s390x
 # X86-64-NEXT:  Arch: x86_64
+# AMDGPU-NEXT:  Arch: amdgpu
 
 # 32-NEXT:      AddressSize: 32bit
 # 64-NEXT:      AddressSize: 64bit
@@ -129,6 +134,7 @@
 # SPARCEL-NEXT:   Machine: EM_SPARC (0x2)
 # S390X-NEXT:     Machine: EM_S390 (0x16)
 # X86-64-NEXT:    Machine: EM_X86_64 (0x3E)
+# AMDGPU-NEXT:    Machine: EM_AMDGPU (0xE0)
 
 # CHECK-NEXT:     Version: 1
 # CHECK-NEXT:     Entry: 0x0

--- a/llvm/test/tools/llvm-objcopy/ELF/cross-arch-headers.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/cross-arch-headers.test
@@ -2,7 +2,8 @@
 # and DWO output.
 # Note that we don't actually need any DWARF to produce the DWO file.
 
-# RUN: yaml2obj %s -o %t.o
+# RUN: yaml2obj -DMACHINE=EM_NONE %s -o %t.o
+# RUN: yaml2obj -DMACHINE=EM_AMDGPU -DFLAGS=[EF_AMDGPU_MACH_AMDGCN_GFX900] %s -o %t-amdgpu.o
 
 # Without --output-format, the format should match the input.
 # RUN: llvm-objcopy %t.o %t.default.o --split-dwo=%t.default.dwo
@@ -121,13 +122,18 @@
 # RUN: llvm-readobj --file-headers %t.elf64_s390.o | FileCheck %s --check-prefixes=CHECK,BE,S390X,64,SYSV
 # RUN: llvm-readobj --file-headers %t.elf64_s390.dwo | FileCheck %s --check-prefixes=CHECK,BE,S390X,64,SYSV
 
+# RUN: llvm-objcopy %t-amdgpu.o -O elf64-amdgpu %t-amdgpu.elf64_amdgpu.o --split-dwo=%t-amdgpu.elf64_amdgpu.dwo
+# RUN: llvm-readobj --file-headers %t-amdgpu.elf64_amdgpu.o | FileCheck %s --check-prefixes=CHECK,LE,AMDGPU,64,SYSV
+# RUN: llvm-readobj --file-headers %t-amdgpu.elf64_amdgpu.dwo | FileCheck %s --check-prefixes=CHECK,LE,AMDGPU,64,SYSV
+
 !ELF
 FileHeader:
   Class:           ELFCLASS32
   Data:            ELFDATA2LSB
   Type:            ET_EXEC
   # Arbitrary values that do not match any value we convert to via --output-format.
-  Machine:         EM_NONE
+  Machine:         [[MACHINE]]
+  Flags:           [[FLAGS=<none>]]
   OSABI:           ELFOSABI_STANDALONE
 Sections:
   - Name:            .text
@@ -154,6 +160,7 @@ Symbols:
 # I386-SAME:    i386
 # IAMCU-SAME:   iamcu
 # AARCH-SAME:   aarch64
+# AMDGPU-SAME:  amdgpu
 # ARM-SAME:     littlearm
 # HEXAGON-SAME: hexagon
 # LA32-SAME:    loongarch{{$}}
@@ -171,6 +178,7 @@ Symbols:
 # I386-NEXT:     Arch: i386
 # IAMCU-NEXT:    Arch: i386
 # AARCH-NEXT:    Arch: aarch64
+# AMDGPU-NEXT:   Arch: amdgcn
 # ARM-NEXT:      Arch: arm
 # HEXAGON-NEXT:  Arch: hexagon
 # LA32-NEXT:     Arch: loongarch32
@@ -204,6 +212,7 @@ Symbols:
 # DEFAULT: OS/ABI: Standalone (0xFF)
 
 # AARCH:   Machine: EM_AARCH64 (0xB7)
+# AMDGPU:  Machine: EM_AMDGPU (0xE0)
 # ARM:     Machine: EM_ARM (0x28)
 # HEXAGON: Machine: EM_HEXAGON (0xA4)
 # I386:    Machine: EM_386 (0x3)

--- a/llvm/test/tools/llvm-objcopy/ELF/cross-arch-headers.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/cross-arch-headers.test
@@ -178,7 +178,7 @@ Symbols:
 # I386-NEXT:     Arch: i386
 # IAMCU-NEXT:    Arch: i386
 # AARCH-NEXT:    Arch: aarch64
-# AMDGPU-NEXT:   Arch: amdgcn
+# AMDGPU-NEXT:   Arch: amdgpu
 # ARM-NEXT:      Arch: arm
 # HEXAGON-NEXT:  Arch: hexagon
 # LA32-NEXT:     Arch: loongarch32

--- a/llvm/test/tools/llvm-objcopy/ELF/cross-arch-headers.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/cross-arch-headers.test
@@ -2,7 +2,7 @@
 # and DWO output.
 # Note that we don't actually need any DWARF to produce the DWO file.
 
-# RUN: yaml2obj -DMACHINE=EM_NONE %s -o %t.o
+# RUN: yaml2obj %s -o %t.o
 
 # Without --output-format, the format should match the input.
 # RUN: llvm-objcopy %t.o %t.default.o --split-dwo=%t.default.dwo
@@ -134,8 +134,7 @@ FileHeader:
   Data:            ELFDATA2LSB
   Type:            ET_EXEC
   # Arbitrary values that do not match any value we convert to via --output-format.
-  Machine:         [[MACHINE]]
-  Flags:           [[FLAGS=<none>]]
+  Machine:         EM_NONE
   OSABI:           ELFOSABI_STANDALONE
 Sections:
   - Name:            .text

--- a/llvm/test/tools/llvm-objcopy/ELF/cross-arch-headers.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/cross-arch-headers.test
@@ -3,7 +3,6 @@
 # Note that we don't actually need any DWARF to produce the DWO file.
 
 # RUN: yaml2obj -DMACHINE=EM_NONE %s -o %t.o
-# RUN: yaml2obj -DMACHINE=EM_AMDGPU -DFLAGS=[EF_AMDGPU_MACH_AMDGCN_GFX900] %s -o %t-amdgpu.o
 
 # Without --output-format, the format should match the input.
 # RUN: llvm-objcopy %t.o %t.default.o --split-dwo=%t.default.dwo
@@ -122,7 +121,10 @@
 # RUN: llvm-readobj --file-headers %t.elf64_s390.o | FileCheck %s --check-prefixes=CHECK,BE,S390X,64,SYSV
 # RUN: llvm-readobj --file-headers %t.elf64_s390.dwo | FileCheck %s --check-prefixes=CHECK,BE,S390X,64,SYSV
 
-# RUN: llvm-objcopy %t-amdgpu.o -O elf64-amdgpu %t-amdgpu.elf64_amdgpu.o --split-dwo=%t-amdgpu.elf64_amdgpu.dwo
+# Converting a non-AMDGPU ELF to elf64-amdgpu sets EM_AMDGPU but leaves
+# e_flags=0 (no EF_AMDGPU_MACH value), so llvm-readobj reports Arch: unknown.
+# Flag control is a separate concern not addressed by --output-format.
+# RUN: llvm-objcopy %t.o -O elf64-amdgpu %t-amdgpu.elf64_amdgpu.o --split-dwo=%t-amdgpu.elf64_amdgpu.dwo
 # RUN: llvm-readobj --file-headers %t-amdgpu.elf64_amdgpu.o | FileCheck %s --check-prefixes=CHECK,LE,AMDGPU,64,SYSV
 # RUN: llvm-readobj --file-headers %t-amdgpu.elf64_amdgpu.dwo | FileCheck %s --check-prefixes=CHECK,LE,AMDGPU,64,SYSV
 
@@ -178,7 +180,7 @@ Symbols:
 # I386-NEXT:     Arch: i386
 # IAMCU-NEXT:    Arch: i386
 # AARCH-NEXT:    Arch: aarch64
-# AMDGPU-NEXT:   Arch: amdgpu
+# AMDGPU-NEXT:   Arch: unknown
 # ARM-NEXT:      Arch: arm
 # HEXAGON-NEXT:  Arch: hexagon
 # LA32-NEXT:     Arch: loongarch32

--- a/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
+++ b/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
@@ -369,6 +369,8 @@ static const StringMap<MachineInfo> TargetMap{
     {"elf64-loongarch", {ELF::EM_LOONGARCH, true, true}},
     // SystemZ
     {"elf64-s390", {ELF::EM_S390, true, false}},
+    // AMDGPU
+    {"elf64-amdgpu", {ELF::EM_AMDGPU, true, true}},
 };
 
 static Expected<TargetInfo>


### PR DESCRIPTION
llvm-objcopy does not support AMDGPU currently. It does not get target names where all other tools do but has it's own list. Update the list to support amdgpu.

https://reviews.llvm.org/D143539
https://github.com/llvm/llvm-project/pull/92066