### PR TITLE
[clang-doc] Update lookup routines for consistency

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -922,7 +922,12 @@ static void serializeContexts(Info *I, StringMap<OwnedPtr<Info>> &Infos) {
   auto ParentUSR = I->ParentUSR;
 
   while (true) {
-    auto &ParentInfo = Infos.at(llvm::toHex(ParentUSR));
+    // Infos may not have the ParentUSR, if its been filtered (public or path),
+    // so we can't use at() for the lookup, since it would abort.
+    auto Iter = Infos.find(llvm::toHex(ParentUSR));
+    if (Iter == Infos.end())
+      break;
+    auto &ParentInfo = Iter->second;
 
     if (ParentInfo && ParentInfo->USR == GlobalNamespaceID) {
       Context GlobalRef(ParentInfo->USR, "Global Namespace",

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -452,7 +452,16 @@ llvm::SmallString<16> Info::extractName() const {
 
 // Order is based on the Name attribute: case insensitive order
 bool Index::operator<(const Index &Other) const {
-  return Name.str().compare_insensitive(Other.Name) < 0;
+  // Start with case-insensitive (e.g., 'apple' < 'Zebra').
+  // This prevents 'Zebra' from appearing before 'apple' due to ASCII values,
+  // where uppercase letters have a lower numeric value than lowercase.
+  int Cmp = Name.compare_insensitive(Other.Name);
+  if (Cmp != 0)
+    return Cmp < 0;
+
+  // If names are identical, we fall back to standard string comparison where
+  // uppercase precedes lowercase (e.g., 'Apple' < 'apple').
+  return Name < Other.Name;
 }
 
 OwningVec<const Index *> Index::getSortedChildren() const {

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -452,22 +452,7 @@ llvm::SmallString<16> Info::extractName() const {
 
 // Order is based on the Name attribute: case insensitive order
 bool Index::operator<(const Index &Other) const {
-  // Loop through each character of both strings
-  for (unsigned I = 0; I < Name.size() && I < Other.Name.size(); ++I) {
-    // Compare them after converting both to lower case
-    int D = tolower(Name[I]) - tolower(Other.Name[I]);
-    if (D == 0)
-      continue;
-    return D < 0;
-  }
-  // If both strings have the size it means they would be equal if changed to
-  // lower case. In here, lower case will be smaller than upper case
-  // Example: string < stRing = true
-  // This is the opposite of how operator < handles strings
-  if (Name.size() == Other.Name.size())
-    return Name > Other.Name;
-  // If they are not the same size; the shorter string is smaller
-  return Name.size() < Other.Name.size();
+  return Name.str().compare_insensitive(Other.Name) < 0;
 }
 
 OwningVec<const Index *> Index::getSortedChildren() const {


### PR DESCRIPTION
 When filtering is enabled, its possible an Info doesn't have a 
Parent USR. Use `find()` to safely handle that case.

Additionally, I noticed the comparison code for the index
poorly reimplemented the existing comparison from StringRef.
We can just use the one from ADT. 