### PR TITLE
[clang-doc] Prepare Info types for Arena allocation

### DIFF
--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -20,6 +20,7 @@
 #include "clang/Tooling/Execution.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/ilist_node.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Mutex.h"
 #include "llvm/Support/StringSaver.h"
@@ -158,7 +159,7 @@ CommentKind stringToCommentKind(llvm::StringRef KindStr);
 llvm::StringRef commentKindToString(CommentKind Kind);
 
 // A representation of a parsed comment.
-struct CommentInfo {
+struct CommentInfo : public llvm::ilist_node<CommentInfo> {
   CommentInfo() = default;
   CommentInfo(CommentInfo &Other) = delete;
   CommentInfo(CommentInfo &&Other) = default;
@@ -388,7 +389,7 @@ struct MemberTypeInfo : public FieldTypeInfo {
   bool IsStatic = false;
 };
 
-struct Location {
+struct Location : public llvm::ilist_node<Location> {
   Location(int StartLineNumber = 0, int EndLineNumber = 0,
            StringRef Filename = StringRef(), bool IsFileInRootDir = false)
       : Filename(internString(Filename)), StartLineNumber(StartLineNumber),
@@ -509,7 +510,7 @@ struct SymbolInfo : public Info {
   bool IsStatic = false;
 };
 
-struct FriendInfo : SymbolInfo {
+struct FriendInfo : public SymbolInfo, public llvm::ilist_node<FriendInfo> {
   FriendInfo() : SymbolInfo(InfoType::IT_friend) {}
   FriendInfo(SymbolID USR) : SymbolInfo(InfoType::IT_friend, USR) {}
   FriendInfo(const InfoType IT, const SymbolID &USR,
@@ -525,7 +526,7 @@ struct FriendInfo : SymbolInfo {
   bool IsClass = false;
 };
 
-struct VarInfo : SymbolInfo {
+struct VarInfo : public SymbolInfo, public llvm::ilist_node<VarInfo> {
   VarInfo() : SymbolInfo(InfoType::IT_variable) {}
   explicit VarInfo(SymbolID USR) : SymbolInfo(InfoType::IT_variable, USR) {}
 
@@ -536,7 +537,7 @@ struct VarInfo : SymbolInfo {
 
 // TODO: Expand to allow for documenting templating and default args.
 // Info for functions.
-struct FunctionInfo : public SymbolInfo {
+struct FunctionInfo : public SymbolInfo, public llvm::ilist_node<FunctionInfo> {
   FunctionInfo(SymbolID USR = SymbolID())
       : SymbolInfo(InfoType::IT_function, USR) {}
 
@@ -597,7 +598,7 @@ struct RecordInfo : public SymbolInfo {
 };
 
 // Info for typedef and using statements.
-struct TypedefInfo : public SymbolInfo {
+struct TypedefInfo : public SymbolInfo, public llvm::ilist_node<TypedefInfo> {
   TypedefInfo(SymbolID USR = SymbolID())
       : SymbolInfo(InfoType::IT_typedef, USR) {}
 
@@ -661,7 +662,7 @@ struct EnumValueInfo {
 
 // TODO: Expand to allow for documenting templating.
 // Info for types.
-struct EnumInfo : public SymbolInfo {
+struct EnumInfo : public SymbolInfo, public llvm::ilist_node<EnumInfo> {
   EnumInfo() : SymbolInfo(InfoType::IT_enum) {}
   EnumInfo(SymbolID USR) : SymbolInfo(InfoType::IT_enum, USR) {}
 
@@ -678,7 +679,7 @@ struct EnumInfo : public SymbolInfo {
   llvm::SmallVector<EnumValueInfo, 4> Members; // List of enum members.
 };
 
-struct ConceptInfo : public SymbolInfo {
+struct ConceptInfo : public SymbolInfo, public llvm::ilist_node<ConceptInfo> {
   ConceptInfo() : SymbolInfo(InfoType::IT_concept) {}
   ConceptInfo(SymbolID USR) : SymbolInfo(InfoType::IT_concept, USR) {}
 


### PR DESCRIPTION
To allocate Info structures directly in an Arena, they cannot have
members with nontrivial destructors, or we will leak memory. Before we
migrate them, we can replace growable vector types with intrusive lists.

This introduces some slight overhead as these types now have new pointer
members for use in ilists in later patches.

| Metric | Baseline | Prev | This | Culm% | Seq% |
| :--- | :--- | :--- | :--- | :--- | :--- |
| Time | 920.5s | 1005.7s | 1010.5s | +9.8% | +0.5% |
| Memory | 86.0G | 42.1G | 42.9G | -50.2% | +1.8% |

| Benchmark | Baseline | Prev | This | Culm% | Seq% |
| :--- | :--- | :--- | :--- | :--- | :--- |
| BM_BitcodeReader_Scale/10 | 67.9us | 68.6us | 69.2us | +1.9% | +0.9% |
| BM_BitcodeReader_Scale/10000 | 70.5ms | 21.3ms | 21.9ms | -68.9% | +2.8% |
| BM_BitcodeReader_Scale/4096 | 23.2ms | 4.6ms | 4.6ms | -80.0% | +0.8% |
| BM_BitcodeReader_Scale/512 | 509.4us | 546.3us | 541.8us | +6.4% | -0.8% |
| BM_BitcodeReader_Scale/64 | 114.8us | 117.9us | 117.6us | +2.5% | -0.2% |
| BM_EmitInfoFunction | 1.6us | 1.5us | 1.6us | -1.9% | +3.9% |
| BM_Index_Insertion/10 | 2.3us | 3.9us | 4.0us | +75.3% | +3.0% |
| BM_Index_Insertion/10000 | 3.1ms | 5.3ms | 5.4ms | +72.7% | +2.4% |
| BM_Index_Insertion/4096 | 1.3ms | 2.1ms | 2.1ms | +67.1% | +1.8% |
| BM_Index_Insertion/512 | 153.6us | 253.0us | 259.0us | +68.6% | +2.4% |
| BM_Index_Insertion/64 | 18.1us | 30.1us | 30.3us | +67.8% | +0.5% |
| BM_JSONGenerator_Scale/10 | 36.8us | 37.0us | 38.2us | +3.6% | +3.2% |
| BM_JSONGenerator_Scale/10000 | 89.6ms | 91.7ms | 90.7ms | +1.2% | -1.1% |
| BM_JSONGenerator_Scale/4096 | 33.7ms | 35.1ms | 34.7ms | +2.9% | -1.1% |
| BM_JSONGenerator_Scale/512 | 1.9ms | 1.9ms | 2.0ms | +3.9% | +4.0% |
| BM_JSONGenerator_Scale/64 | 222.4us | 223.3us | 230.1us | +3.5% | +3.1% |
| BM_Mapper_Scale/10000 | 104.3ms | 105.6ms | 100.9ms | -3.2% | -4.4% |
| BM_Mapper_Scale/4096 | 44.3ms | 44.8ms | 42.8ms | -3.5% | -4.4% |
| BM_Mapper_Scale/512 | 7.6ms | 7.6ms | 7.4ms | -2.6% | -3.2% |
| BM_Mapper_Scale/64 | 3.1ms | 3.0ms | 3.0ms | -2.0% | -1.3% |
| BM_MergeInfos_Scale/10000 | 12.2ms | 1.4ms | 1.6ms | -86.7% | +12.5% |
| BM_MergeInfos_Scale/2 | 1.9us | 1.7us | 1.7us | -10.2% | -1.9% |
| BM_MergeInfos_Scale/4096 | 2.8ms | 487.3us | 503.4us | -81.9% | +3.3% |
| BM_MergeInfos_Scale/512 | 68.9us | 38.7us | 38.1us | -44.6% | -1.4% |
| BM_MergeInfos_Scale/64 | 10.3us | 6.4us | 6.4us | -37.6% | -0.4% |
| BM_MergeInfos_Scale/8 | 2.8us | 2.2us | 2.2us | -21.7% | -1.5% |
| BM_SerializeFunctionInfo | 25.5us | 25.9us | 26.0us | +1.9% | +0.4% |