### PR TITLE
[clang-doc] Move non-arena allocated types off the OwnedPtr alias

### DIFF
--- a/clang-tools-extra/clang-doc/ClangDoc.cpp
+++ b/clang-tools-extra/clang-doc/ClangDoc.cpp
@@ -25,18 +25,18 @@ namespace doc {
 class MapperActionFactory : public tooling::FrontendActionFactory {
 public:
   MapperActionFactory(ClangDocContext CDCtx) : CDCtx(CDCtx) {}
-  OwnedPtr<FrontendAction> create() override;
+  std::unique_ptr<FrontendAction> create() override;
 
 private:
   ClangDocContext CDCtx;
 };
 
-OwnedPtr<FrontendAction> MapperActionFactory::create() {
+std::unique_ptr<FrontendAction> MapperActionFactory::create() {
   class ClangDocAction : public clang::ASTFrontendAction {
   public:
     ClangDocAction(ClangDocContext CDCtx) : CDCtx(CDCtx) {}
 
-    OwnedPtr<clang::ASTConsumer>
+    std::unique_ptr<clang::ASTConsumer>
     CreateASTConsumer(clang::CompilerInstance &Compiler,
                       llvm::StringRef InFile) override {
       return std::make_unique<MapASTVisitor>(&Compiler.getASTContext(), CDCtx);
@@ -48,7 +48,7 @@ OwnedPtr<FrontendAction> MapperActionFactory::create() {
   return std::make_unique<ClangDocAction>(CDCtx);
 }
 
-OwnedPtr<tooling::FrontendActionFactory>
+std::unique_ptr<tooling::FrontendActionFactory>
 newMapperActionFactory(ClangDocContext CDCtx) {
   return std::make_unique<MapperActionFactory>(CDCtx);
 }

--- a/clang-tools-extra/clang-doc/ClangDoc.h
+++ b/clang-tools-extra/clang-doc/ClangDoc.h
@@ -22,7 +22,7 @@
 namespace clang {
 namespace doc {
 
-OwnedPtr<tooling::FrontendActionFactory>
+std::unique_ptr<tooling::FrontendActionFactory>
 newMapperActionFactory(ClangDocContext CDCtx);
 
 } // namespace doc

--- a/clang-tools-extra/clang-doc/Generators.cpp
+++ b/clang-tools-extra/clang-doc/Generators.cpp
@@ -53,7 +53,7 @@ Error createFileOpenError(StringRef FileName, std::error_code EC) {
 }
 
 Error MustacheGenerator::setupTemplate(
-    OwnedPtr<MustacheTemplateFile> &Template, StringRef TemplatePath,
+    std::unique_ptr<MustacheTemplateFile> &Template, StringRef TemplatePath,
     std::vector<std::pair<StringRef, StringRef>> Partials) {
   auto T = MustacheTemplateFile::createMustacheFile(TemplatePath);
   if (Error Err = T.takeError())

--- a/clang-tools-extra/clang-doc/Generators.h
+++ b/clang-tools-extra/clang-doc/Generators.h
@@ -60,12 +60,12 @@ class MustacheTemplateFile {
   llvm::StringSaver Saver;
   llvm::mustache::MustacheContext Ctx;
   llvm::mustache::Template T;
-  OwnedPtr<llvm::MemoryBuffer> Buffer;
+  std::unique_ptr<llvm::MemoryBuffer> Buffer;
 
 public:
-  static Expected<OwnedPtr<MustacheTemplateFile>>
+  static Expected<std::unique_ptr<MustacheTemplateFile>>
   createMustacheFile(StringRef FileName) {
-    llvm::ErrorOr<OwnedPtr<llvm::MemoryBuffer>> BufferOrError =
+    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> BufferOrError =
         llvm::MemoryBuffer::getFile(FileName);
     if (auto EC = BufferOrError.getError())
       return createFileOpenError(FileName, EC);
@@ -74,12 +74,12 @@ public:
   }
 
   llvm::Error registerPartialFile(StringRef Name, StringRef FileName) {
-    llvm::ErrorOr<OwnedPtr<llvm::MemoryBuffer>> BufferOrError =
+    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> BufferOrError =
         llvm::MemoryBuffer::getFile(FileName);
     if (auto EC = BufferOrError.getError())
       return createFileOpenError(FileName, EC);
 
-    OwnedPtr<llvm::MemoryBuffer> Buffer = std::move(BufferOrError.get());
+    std::unique_ptr<llvm::MemoryBuffer> Buffer = std::move(BufferOrError.get());
     StringRef FileContent = Buffer->getBuffer();
     T.registerPartial(Name.str(), FileContent.str());
     return llvm::Error::success();
@@ -91,7 +91,7 @@ public:
     T.overrideEscapeCharacters(Characters);
   }
 
-  MustacheTemplateFile(OwnedPtr<llvm::MemoryBuffer> &&B)
+  MustacheTemplateFile(std::unique_ptr<llvm::MemoryBuffer> &&B)
       : Saver(Allocator), Ctx(Allocator, Saver), T(B->getBuffer(), Ctx),
         Buffer(std::move(B)) {}
 };
@@ -120,7 +120,7 @@ struct MustacheGenerator : public Generator {
 
   /// Registers partials to templates.
   llvm::Error
-  setupTemplate(OwnedPtr<MustacheTemplateFile> &Template,
+  setupTemplate(std::unique_ptr<MustacheTemplateFile> &Template,
                 StringRef TemplatePath,
                 std::vector<std::pair<StringRef, StringRef>> Partials);
 

--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -25,11 +25,11 @@ using namespace llvm::mustache;
 namespace clang {
 namespace doc {
 
-static OwnedPtr<MustacheTemplateFile> NamespaceTemplate = nullptr;
+static std::unique_ptr<MustacheTemplateFile> NamespaceTemplate = nullptr;
 
-static OwnedPtr<MustacheTemplateFile> RecordTemplate = nullptr;
+static std::unique_ptr<MustacheTemplateFile> RecordTemplate = nullptr;
 
-static OwnedPtr<MustacheTemplateFile> IndexTemplate = nullptr;
+static std::unique_ptr<MustacheTemplateFile> IndexTemplate = nullptr;
 
 class HTMLGenerator : public MustacheGenerator {
 public:

--- a/clang-tools-extra/clang-doc/MDMustacheGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDMustacheGenerator.cpp
@@ -16,13 +16,13 @@
 namespace clang {
 using namespace llvm;
 namespace doc {
-static OwnedPtr<MustacheTemplateFile> RecordTemplate = nullptr;
+static std::unique_ptr<MustacheTemplateFile> RecordTemplate = nullptr;
 
-static OwnedPtr<MustacheTemplateFile> NamespaceTemplate = nullptr;
+static std::unique_ptr<MustacheTemplateFile> NamespaceTemplate = nullptr;
 
-static OwnedPtr<MustacheTemplateFile> AllFilesTemplate = nullptr;
+static std::unique_ptr<MustacheTemplateFile> AllFilesTemplate = nullptr;
 
-static OwnedPtr<MustacheTemplateFile> IndexTemplate = nullptr;
+static std::unique_ptr<MustacheTemplateFile> IndexTemplate = nullptr;
 
 struct MDMustacheGenerator : public MustacheGenerator {
   static const char *Format;

--- a/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
+++ b/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
@@ -50,7 +50,7 @@ private:
 
 static void BM_EmitInfoFunction(benchmark::State &State) {
   std::string Code = "void f() {}";
-  OwnedPtr<clang::ASTUnit> AST = clang::tooling::buildASTFromCode(Code);
+  std::unique_ptr<clang::ASTUnit> AST = clang::tooling::buildASTFromCode(Code);
   const FunctionDecl *Func = nullptr;
   BenchmarkVisitor Visitor(Func);
   Visitor.TraverseDecl(AST->getASTContext().getTranslationUnitDecl());
@@ -83,7 +83,7 @@ static void BM_Mapper_Scale(benchmark::State &State) {
     ClangDocContext CDCtx(&ECtx, "test-project", false, "", "", "", "", "", {},
                           Diags, OutputFormatTy::json, false);
     auto ActionFactory = doc::newMapperActionFactory(CDCtx);
-    OwnedPtr<FrontendAction> Action = ActionFactory->create();
+    std::unique_ptr<FrontendAction> Action = ActionFactory->create();
     tooling::runToolOnCode(std::move(Action), Code, "test.cpp");
   }
 }


### PR DESCRIPTION
Some types should not be using this alias, which was over applied to
APIs that wont participate in arena style allocation. This patch
restores them to their correct spelling.