### PR TITLE
[libc++] Remove full header path from assertion messages

### DIFF
--- a/libcxx/include/__assert
+++ b/libcxx/include/__assert
@@ -20,7 +20,7 @@
 #define _LIBCPP_ASSERT(expression, message)                                                                            \
   (__builtin_expect(static_cast<bool>(expression), 1)                                                                  \
        ? (void)0                                                                                                       \
-       : _LIBCPP_ASSERTION_HANDLER(__FILE__ ":" _LIBCPP_TOSTRING(                                                      \
+       : _LIBCPP_ASSERTION_HANDLER(__FILE_NAME__ ":" _LIBCPP_TOSTRING(                                                 \
              __LINE__) ": libc++ Hardening assertion " _LIBCPP_TOSTRING(expression) " failed: " message "\n"))
 
 // WARNING: __builtin_assume can currently inhibit optimizations. Only add assumptions with a clear


### PR DESCRIPTION
This creates additional bloat in programs or debug info, without much additional value beyond just the file name.

Fixes #190058