### PR TITLE
[clang] Extract in-memory module cache writes from `ASTWriter`

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -160,7 +160,6 @@ ENUM_LANGOPT(CompilingModule, CompilingModuleKind, 3, CMK_None, Benign,
              "compiling a module interface")
 LANGOPT(CompilingPCH, 1, 0, Benign, "building a pch")
 LANGOPT(BuildingPCHWithObjectFile, 1, 0, Benign, "building a pch which has a corresponding object file")
-LANGOPT(CacheGeneratedPCH, 1, 0, Benign, "cache generated PCH files in memory")
 LANGOPT(PCHInstantiateTemplates, 1, 0, Benign, "instantiate templates while building a PCH")
 LANGOPT(ModulesDeclUse    , 1, 0, Compatible, "require declaration of module uses")
 LANGOPT(ModulesSearchAll  , 1, 1, Benign, "searching even non-imported modules to find unresolved references")

--- a/clang/include/clang/Serialization/ASTWriter.h
+++ b/clang/include/clang/Serialization/ASTWriter.h
@@ -733,8 +733,7 @@ public:
   /// the module but currently is merely a random 32-bit number.
   ASTFileSignature WriteAST(llvm::PointerUnion<Sema *, Preprocessor *> Subject,
                             StringRef OutputFile, Module *WritingModule,
-                            StringRef isysroot,
-                            bool ShouldCacheASTInMemory = false);
+                            StringRef isysroot);
 
   /// Emit a token.
   void AddToken(const Token &Tok, RecordDataImpl &Record);
@@ -1011,7 +1010,6 @@ class PCHGenerator : public SemaConsumer {
   llvm::BitstreamWriter Stream;
   ASTWriter Writer;
   bool AllowASTWithErrors;
-  bool ShouldCacheASTInMemory;
 
 protected:
   ASTWriter &getWriter() { return Writer; }
@@ -1033,7 +1031,6 @@ public:
                ArrayRef<std::shared_ptr<ModuleFileExtension>> Extensions,
                bool AllowASTWithErrors = false, bool IncludeTimestamps = true,
                bool BuildingImplicitModule = false,
-               bool ShouldCacheASTInMemory = false,
                bool GeneratingReducedBMI = false);
   ~PCHGenerator() override;
 

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1488,6 +1488,18 @@ static bool compileModuleImpl(CompilerInstance &ImportingInstance,
     ImportingInstance.getModuleCache().updateModuleTimestamp(ModuleFileName);
   }
 
+  // This isn't strictly necessary, but it's more efficient to extract the AST
+  // file (which may be wrapped in an object file) now rather than doing so
+  // repeatedly in the readers.
+  const PCHContainerReader &Rdr = ImportingInstance.getPCHContainerReader();
+  StringRef ExtractedBuffer = Rdr.ExtractPCH(*Buffer);
+  // FIXME: Avoid the copy here by having InMemoryModuleCache accept both the
+  // owning buffer and the StringRef.
+  Buffer = llvm::MemoryBuffer::getMemBufferCopy(ExtractedBuffer);
+
+  ImportingInstance.getModuleCache().getInMemoryModuleCache().addBuiltPCM(
+      ModuleFileName, std::move(Buffer));
+
   return true;
 }
 

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -142,8 +142,7 @@ GeneratePCHAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
       CI.getPreprocessor(), CI.getModuleCache(), OutputFile, Sysroot, Buffer,
       CI.getCodeGenOpts(), FrontendOpts.ModuleFileExtensions,
       CI.getPreprocessorOpts().AllowPCHWithCompilerErrors,
-      FrontendOpts.IncludeTimestamps, FrontendOpts.BuildingImplicitModule,
-      +CI.getLangOpts().CacheGeneratedPCH));
+      FrontendOpts.IncludeTimestamps, FrontendOpts.BuildingImplicitModule));
   Consumers.push_back(CI.getPCHContainerWriter().CreatePCHContainerGenerator(
       CI, std::string(InFile), OutputFile, std::move(OS), Buffer));
 
@@ -207,9 +206,7 @@ GenerateModuleAction::CreateMultiplexConsumer(CompilerInstance &CI,
       /*IncludeTimestamps=*/
       +CI.getFrontendOpts().BuildingImplicitModule &&
           +CI.getFrontendOpts().IncludeTimestamps,
-      /*BuildingImplicitModule=*/+CI.getFrontendOpts().BuildingImplicitModule,
-      /*ShouldCacheASTInMemory=*/
-      +CI.getFrontendOpts().BuildingImplicitModule));
+      /*BuildingImplicitModule=*/+CI.getFrontendOpts().BuildingImplicitModule));
   Consumers.push_back(CI.getPCHContainerWriter().CreatePCHContainerGenerator(
       CI, std::string(InFile), OutputFile, std::move(OS), Buffer));
   return Consumers;

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -5496,7 +5496,7 @@ time_t ASTWriter::getTimestampForOutput(time_t ModTime) const {
 ASTFileSignature
 ASTWriter::WriteAST(llvm::PointerUnion<Sema *, Preprocessor *> Subject,
                     StringRef OutputFile, Module *WritingModule,
-                    StringRef isysroot, bool ShouldCacheASTInMemory) {
+                    StringRef isysroot) {
   llvm::TimeTraceScope scope("WriteAST", OutputFile);
   WritingAST = true;
 
@@ -5523,12 +5523,6 @@ ASTWriter::WriteAST(llvm::PointerUnion<Sema *, Preprocessor *> Subject,
 
   WritingAST = false;
 
-  if (ShouldCacheASTInMemory) {
-    // Construct MemoryBuffer and update buffer manager.
-    ModCache.getInMemoryModuleCache().addBuiltPCM(
-        OutputFile, llvm::MemoryBuffer::getMemBufferCopy(
-                        StringRef(Buffer.begin(), Buffer.size())));
-  }
   return Signature;
 }
 

--- a/clang/lib/Serialization/GeneratePCH.cpp
+++ b/clang/lib/Serialization/GeneratePCH.cpp
@@ -28,7 +28,7 @@ PCHGenerator::PCHGenerator(
     const CodeGenOptions &CodeGenOpts,
     ArrayRef<std::shared_ptr<ModuleFileExtension>> Extensions,
     bool AllowASTWithErrors, bool IncludeTimestamps,
-    bool BuildingImplicitModule,bool GeneratingReducedBMI)
+    bool BuildingImplicitModule, bool GeneratingReducedBMI)
     : PP(PP), Subject(&PP), OutputFile(OutputFile), isysroot(isysroot.str()),
       Buffer(std::move(Buffer)), Stream(this->Buffer->Data),
       Writer(Stream, this->Buffer->Data, ModCache, CodeGenOpts, Extensions,

--- a/clang/lib/Serialization/GeneratePCH.cpp
+++ b/clang/lib/Serialization/GeneratePCH.cpp
@@ -28,14 +28,12 @@ PCHGenerator::PCHGenerator(
     const CodeGenOptions &CodeGenOpts,
     ArrayRef<std::shared_ptr<ModuleFileExtension>> Extensions,
     bool AllowASTWithErrors, bool IncludeTimestamps,
-    bool BuildingImplicitModule, bool ShouldCacheASTInMemory,
-    bool GeneratingReducedBMI)
+    bool BuildingImplicitModule,bool GeneratingReducedBMI)
     : PP(PP), Subject(&PP), OutputFile(OutputFile), isysroot(isysroot.str()),
       Buffer(std::move(Buffer)), Stream(this->Buffer->Data),
       Writer(Stream, this->Buffer->Data, ModCache, CodeGenOpts, Extensions,
              IncludeTimestamps, BuildingImplicitModule, GeneratingReducedBMI),
-      AllowASTWithErrors(AllowASTWithErrors),
-      ShouldCacheASTInMemory(ShouldCacheASTInMemory) {
+      AllowASTWithErrors(AllowASTWithErrors) {
   this->Buffer->IsComplete = false;
 }
 
@@ -84,8 +82,7 @@ void PCHGenerator::HandleTranslationUnit(ASTContext &Ctx) {
   if (AllowASTWithErrors)
     PP.getDiagnostics().getClient()->clear();
 
-  Buffer->Signature = Writer.WriteAST(Subject, OutputFile, Module, isysroot,
-                                      ShouldCacheASTInMemory);
+  Buffer->Signature = Writer.WriteAST(Subject, OutputFile, Module, isysroot);
 
   Buffer->IsComplete = true;
 }
@@ -111,8 +108,7 @@ CXX20ModulesGenerator::CXX20ModulesGenerator(Preprocessor &PP,
           std::make_shared<PCHBuffer>(), CodeGenOpts,
           /*Extensions=*/ArrayRef<std::shared_ptr<ModuleFileExtension>>(),
           AllowASTWithErrors, /*IncludeTimestamps=*/false,
-          /*BuildingImplicitModule=*/false, /*ShouldCacheASTInMemory=*/false,
-          GeneratingReducedBMI) {}
+          /*BuildingImplicitModule=*/false, GeneratingReducedBMI) {}
 
 Module *CXX20ModulesGenerator::getEmittingModule(ASTContext &Ctx) {
   Module *M = Ctx.getCurrentNamedModule();

--- a/clang/unittests/Frontend/FrontendActionTest.cpp
+++ b/clang/unittests/Frontend/FrontendActionTest.cpp
@@ -259,42 +259,4 @@ TEST(ASTFrontendAction, ExternalSemaSource) {
   EXPECT_EQ("This is a note", std::string(TDC->Note));
 }
 
-TEST(GeneratePCHFrontendAction, CacheGeneratedPCH) {
-  // Create a temporary file for writing out the PCH that will be cleaned up.
-  int PCHFD;
-  llvm::SmallString<128> PCHFilename;
-  ASSERT_FALSE(
-      llvm::sys::fs::createTemporaryFile("test.h", "pch", PCHFD, PCHFilename));
-  llvm::ToolOutputFile PCHFile(PCHFilename, PCHFD);
-
-  for (bool ShouldCache : {false, true}) {
-    auto Invocation = std::make_shared<CompilerInvocation>();
-    Invocation->getLangOpts().CacheGeneratedPCH = ShouldCache;
-    Invocation->getPreprocessorOpts().addRemappedFile(
-        "test.h",
-        MemoryBuffer::getMemBuffer("int foo(void) { return 1; }\n").release());
-    Invocation->getFrontendOpts().Inputs.push_back(
-        FrontendInputFile("test.h", Language::C));
-    Invocation->getFrontendOpts().OutputFile = PCHFilename.str().str();
-    Invocation->getFrontendOpts().ProgramAction = frontend::GeneratePCH;
-    Invocation->getTargetOpts().Triple = "x86_64-apple-darwin19.0.0";
-    CompilerInstance Compiler(std::move(Invocation));
-    Compiler.setVirtualFileSystem(llvm::vfs::getRealFileSystem());
-    Compiler.createDiagnostics();
-
-    GeneratePCHAction TestAction;
-    ASSERT_TRUE(Compiler.ExecuteAction(TestAction));
-
-    // Check whether the PCH was cached.
-    if (ShouldCache)
-      EXPECT_EQ(InMemoryModuleCache::Final,
-                Compiler.getModuleCache().getInMemoryModuleCache().getPCMState(
-                    PCHFilename));
-    else
-      EXPECT_EQ(InMemoryModuleCache::Unknown,
-                Compiler.getModuleCache().getInMemoryModuleCache().getPCMState(
-                    PCHFilename));
-  }
-}
-
 } // anonymous namespace


### PR DESCRIPTION
This PR extracts the write to the in-memory module cache from within `ASTWriter` into `CompilerInstance.` This brings it closer to other module cache manipulations, making the ordering much more clear and explicit.