### PR TITLE
[CIR][OpenMP] Add OpenMP-to-LLVM type conversion for CIR-to-LLVM lowering

### DIFF
--- a/clang/lib/CIR/Dialect/OpenMP/RegisterOpenMPExtensions.cpp
+++ b/clang/lib/CIR/Dialect/OpenMP/RegisterOpenMPExtensions.cpp
@@ -11,8 +11,20 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/CIR/Dialect/OpenMP/RegisterOpenMPExtensions.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/OpenMP/OpenMPInterfaces.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
+
+namespace {
+struct OpenMPPointerLikeModel
+    : public mlir::omp::PointerLikeType::ExternalModel<OpenMPPointerLikeModel,
+                                                       cir::PointerType> {
+  mlir::Type getElementType(mlir::Type pointer) const {
+    return mlir::cast<cir::PointerType>(pointer).getPointee();
+  }
+};
+} // namespace
 
 namespace cir::omp {
 
@@ -20,6 +32,7 @@ void registerOpenMPExtensions(mlir::DialectRegistry &registry) {
   registry.addExtension(+[](mlir::MLIRContext *ctx, cir::CIRDialect *dialect) {
     cir::FuncOp::attachInterface<
         mlir::omp::DeclareTargetDefaultModel<cir::FuncOp>>(*ctx);
+    cir::PointerType::attachInterface<OpenMPPointerLikeModel>(*ctx);
   });
 }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
@@ -22,6 +22,7 @@ add_clang_library(clangCIRLoweringDirectToLLVM
   MLIRCIRTargetLowering
   MLIRBuiltinToLLVMIRTranslation
   MLIRLLVMToLLVMIRTranslation
+  MLIROpenMPToLLVM
   MLIROpenMPToLLVMIRTranslation
   MLIROpenMPTransforms
   MLIRIR

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -17,10 +17,12 @@
 #include <optional>
 
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Conversion/OpenMPToLLVM/ConvertOpenMPToLLVM.h"
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/OpenMP/Transforms/Passes.h"
 #include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -3443,6 +3445,9 @@ void ConvertCIRToLLVMPass::runOnOperation() {
   mlir::ConversionTarget target(getContext());
   target.addLegalOp<mlir::ModuleOp>();
   target.addLegalDialect<mlir::LLVM::LLVMDialect>();
+  mlir::configureOpenMPToLLVMConversionLegality(target, converter);
+  target.addLegalDialect<mlir::omp::OpenMPDialect>();
+  mlir::populateOpenMPToLLVMConversionPatterns(converter, patterns);
   target.addIllegalDialect<mlir::BuiltinDialect, cir::CIRDialect,
                            mlir::func::FuncDialect>();
 

--- a/clang/test/CIR/Lowering/omp-target-map.cir
+++ b/clang/test/CIR/Lowering/omp-target-map.cir
@@ -1,0 +1,30 @@
+// RUN: cir-opt %s --cir-to-llvm | FileCheck %s
+
+// Verify that OpenMP operations have their CIR types properly converted to
+// LLVM types during CIR-to-LLVM lowering. Without the OpenMP-to-LLVM
+// conversion patterns, this would fail with unrealized_conversion_cast errors.
+
+!s32i = !cir.int<s, 32>
+
+module {
+  // CHECK-LABEL: llvm.func @target_map_from
+  cir.func @target_map_from(%arg0 : !s32i) {
+    %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, !cir.ptr<!s32i>
+
+    // CHECK: %[[ALLOCA:.*]] = llvm.alloca {{.*}} x i32
+    // CHECK: %[[MAP:.*]] = omp.map.info var_ptr(%[[ALLOCA]] : !llvm.ptr, i32) map_clauses(from) capture(ByRef) -> !llvm.ptr {name = "x"}
+    %1 = omp.map.info var_ptr(%0 : !cir.ptr<!s32i>, !s32i) map_clauses(from) capture(ByRef) -> !cir.ptr<!s32i> {name = "x"}
+
+    // CHECK: omp.target map_entries(%[[MAP]] -> %[[ARG:.*]] : !llvm.ptr)
+    omp.target map_entries(%1 -> %arg1 : !cir.ptr<!s32i>) {
+      // CHECK: %[[C10:.*]] = llvm.mlir.constant(10 : i32) : i32
+      // CHECK: llvm.store %[[C10]], %[[ARG]]
+      %c10 = cir.const #cir.int<10> : !s32i
+      cir.store %c10, %arg1 : !s32i, !cir.ptr<!s32i>
+      // CHECK: omp.terminator
+      omp.terminator
+    }
+    cir.return
+  }
+}


### PR DESCRIPTION
Register OpenMP conversion legality and patterns in the CIR-to-LLVM pass so that OpenMP operations (e.g. omp.map.info, omp.target) have their CIR types properly converted to LLVM types during lowering. Without this, the conversion leaves behind unrealized_conversion_cast ops that cause translation to LLVM IR to fail.

Also registers omp::PointerLikeType on cir::PointerType so that CIR pointers are accepted as operands in OpenMP map operations.

Assised-by: Cursor / Claude Opus 4.6