### PR TITLE
[clang-tidy] add fragment support to `misc-include-cleaner`

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.cpp
@@ -46,21 +46,25 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy::misc {
 
-namespace {
-struct MissingIncludeInfo {
-  include_cleaner::SymbolReference SymRef;
-  include_cleaner::Header Missing;
-};
-} // namespace
+static bool matchesAnyRegex(llvm::ArrayRef<llvm::Regex> Regexes,
+                            llvm::StringRef Path) {
+  return llvm::any_of(Regexes,
+                      [&](const llvm::Regex &R) { return R.match(Path); });
+}
 
 IncludeCleanerCheck::IncludeCleanerCheck(StringRef Name,
                                          ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       IgnoreHeaders(
           utils::options::parseStringList(Options.get("IgnoreHeaders", ""))),
+      FragmentDependencyCommentFormat(
+          Options.get("FragmentDependencyCommentFormat", "")),
       DeduplicateFindings(Options.get("DeduplicateFindings", true)),
       UnusedIncludes(Options.get("UnusedIncludes", true)),
       MissingIncludes(Options.get("MissingIncludes", true)) {
+  for (const StringRef Pattern :
+       utils::options::parseStringList(Options.get("FragmentHeaders", "")))
+    FragmentHeaderPatterns.push_back(Pattern.str());
   for (const auto &Header : IgnoreHeaders) {
     if (!llvm::Regex{Header}.isValid())
       configurationDiag("Invalid ignore headers regex '%0'") << Header;
@@ -68,6 +72,12 @@ IncludeCleanerCheck::IncludeCleanerCheck(StringRef Name,
     if (!Header.ends_with('$'))
       HeaderSuffix += '$';
     IgnoreHeadersRegex.emplace_back(HeaderSuffix);
+  }
+  for (const auto &Pattern : FragmentHeaderPatterns) {
+    llvm::Regex CompiledRegex(Pattern);
+    if (!CompiledRegex.isValid())
+      configurationDiag("Invalid fragment headers regex '%0'") << Pattern;
+    FragmentHeaderRegexes.push_back(std::move(CompiledRegex));
   }
 
   if (UnusedIncludes == false && MissingIncludes == false)
@@ -79,6 +89,14 @@ IncludeCleanerCheck::IncludeCleanerCheck(StringRef Name,
 void IncludeCleanerCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "IgnoreHeaders",
                 utils::options::serializeStringList(IgnoreHeaders));
+  llvm::SmallVector<StringRef> FragmentHeaderRefs;
+  FragmentHeaderRefs.reserve(FragmentHeaderPatterns.size());
+  for (const auto &Pattern : FragmentHeaderPatterns)
+    FragmentHeaderRefs.push_back(Pattern);
+  Options.store(Opts, "FragmentHeaders",
+                utils::options::serializeStringList(FragmentHeaderRefs));
+  Options.store(Opts, "FragmentDependencyCommentFormat",
+                FragmentDependencyCommentFormat);
   Options.store(Opts, "DeduplicateFindings", DeduplicateFindings);
   Options.store(Opts, "UnusedIncludes", UnusedIncludes);
   Options.store(Opts, "MissingIncludes", MissingIncludes);
@@ -121,84 +139,23 @@ bool IncludeCleanerCheck::shouldIgnore(const include_cleaner::Header &H) {
 void IncludeCleanerCheck::check(const MatchFinder::MatchResult &Result) {
   const SourceManager *SM = Result.SourceManager;
   const FileEntry *MainFile = SM->getFileEntryForID(SM->getMainFileID());
-  llvm::DenseSet<const include_cleaner::Include *> Used;
-  std::vector<MissingIncludeInfo> Missing;
-  SmallVector<Decl *> MainFileDecls;
+  llvm::SmallVector<Decl *> RootDecls;
   for (Decl *D : Result.Nodes.getNodeAs<TranslationUnitDecl>("top")->decls()) {
-    if (!SM->isWrittenInMainFile(SM->getExpansionLoc(D->getLocation())))
-      continue;
     // FIXME: Filter out implicit template specializations.
-    MainFileDecls.push_back(D);
+    RootDecls.push_back(D);
   }
-  llvm::DenseSet<include_cleaner::Symbol> SeenSymbols;
-  OptionalDirectoryEntryRef ResourceDir =
-      PP->getHeaderSearchInfo().getModuleMap().getBuiltinDir();
-  // FIXME: Find a way to have less code duplication between include-cleaner
-  // analysis implementation and the below code.
-  walkUsed(MainFileDecls, RecordedPreprocessor.MacroReferences, &RecordedPI,
-           *PP,
-           [&](const include_cleaner::SymbolReference &Ref,
-               llvm::ArrayRef<include_cleaner::Header> Providers) {
-             // Process each symbol once to reduce noise in the findings.
-             // Tidy checks are used in two different workflows:
-             // - Ones that show all the findings for a given file. For such
-             // workflows there is not much point in showing all the occurences,
-             // as one is enough to indicate the issue.
-             // - Ones that show only the findings on changed pieces. For such
-             // workflows it's useful to show findings on every reference of a
-             // symbol as otherwise tools might give incosistent results
-             // depending on the parts of the file being edited. But it should
-             // still help surface findings for "new violations" (i.e.
-             // dependency did not exist in the code at all before).
-             if (DeduplicateFindings && !SeenSymbols.insert(Ref.Target).second)
-               return;
-             bool Satisfied = false;
-             for (const include_cleaner::Header &H : Providers) {
-               if (H.kind() == include_cleaner::Header::Physical &&
-                   (H.physical() == MainFile ||
-                    H.physical().getDir() == ResourceDir)) {
-                 Satisfied = true;
-                 continue;
-               }
-
-               for (const include_cleaner::Include *I :
-                    RecordedPreprocessor.Includes.match(H)) {
-                 Used.insert(I);
-                 Satisfied = true;
-               }
-             }
-             if (!Satisfied && !Providers.empty() &&
-                 Ref.RT == include_cleaner::RefType::Explicit &&
-                 !shouldIgnore(Providers.front()))
-               Missing.push_back({Ref, Providers.front()});
-           });
-
-  std::vector<const include_cleaner::Include *> Unused;
-  for (const include_cleaner::Include &I :
-       RecordedPreprocessor.Includes.all()) {
-    if (Used.contains(&I) || !I.Resolved || I.Resolved->getDir() == ResourceDir)
-      continue;
-    if (RecordedPI.shouldKeep(*I.Resolved))
-      continue;
-    // Check if main file is the public interface for a private header. If so
-    // we shouldn't diagnose it as unused.
-    if (auto PHeader = RecordedPI.getPublic(*I.Resolved); !PHeader.empty()) {
-      PHeader = PHeader.trim("<>\"");
-      // Since most private -> public mappings happen in a verbatim way, we
-      // check textually here. This might go wrong in presence of symlinks or
-      // header mappings. But that's not different than rest of the places.
-      if (getCurrentMainFile().ends_with(PHeader))
-        continue;
-    }
-    auto StdHeader = tooling::stdlib::Header::named(
-        I.quote(), PP->getLangOpts().CPlusPlus ? tooling::stdlib::Lang::CXX
-                                               : tooling::stdlib::Lang::C);
-    if (StdHeader && shouldIgnore(*StdHeader))
-      continue;
-    if (shouldIgnore(*I.Resolved))
-      continue;
-    Unused.push_back(&I);
+  include_cleaner::AnalysisOptions AnalyzeOptions;
+  AnalyzeOptions.HeaderFilter = [&](const include_cleaner::Header &H) {
+    return shouldIgnore(H);
+  };
+  if (!FragmentHeaderRegexes.empty()) {
+    AnalyzeOptions.FragmentHeaderFilter = [&](llvm::StringRef Path) {
+      return matchesAnyRegex(FragmentHeaderRegexes, Path);
+    };
   }
+  const include_cleaner::AnalysisResults Results =
+      analyze(RootDecls, RecordedPreprocessor.MacroReferences,
+              RecordedPreprocessor.Includes, &RecordedPI, *PP, AnalyzeOptions);
 
   const StringRef Code = SM->getBufferData(SM->getMainFileID());
   auto FileStyle =
@@ -209,7 +166,7 @@ void IncludeCleanerCheck::check(const MatchFinder::MatchResult &Result) {
     FileStyle = format::getLLVMStyle();
 
   if (UnusedIncludes) {
-    for (const auto *Inc : Unused) {
+    for (const auto *Inc : Results.Unused) {
       diag(Inc->HashLocation, "included header %0 is not used directly")
           << llvm::sys::path::filename(Inc->Spelled,
                                        llvm::sys::path::Style::posix)
@@ -224,9 +181,35 @@ void IncludeCleanerCheck::check(const MatchFinder::MatchResult &Result) {
                                                  FileStyle->IncludeStyle);
     // Deduplicate insertions when running in bulk fix mode.
     llvm::StringSet<> InsertedHeaders{};
-    for (const auto &Inc : Missing) {
+    llvm::DenseSet<include_cleaner::Symbol> SeenSymbols;
+    auto DiagLocation = [&](const include_cleaner::MissingIncludeRef &Missing) {
+      if (Missing.Origin == include_cleaner::SymbolReferenceOrigin::Fragment &&
+          Missing.FragmentInclude) {
+        // Fragment refs are reported on their direct include site in the main
+        // file to preserve the main-file-only diagnostics contract.
+        return Missing.FragmentInclude->FilenameLocation.isValid()
+                   ? Missing.FragmentInclude->FilenameLocation
+                   : Missing.FragmentInclude->HashLocation;
+      }
+      return SM->getSpellingLoc(Missing.Ref.RefLocation);
+    };
+    for (const auto &Missing : Results.MissingRefs) {
+      // Process each symbol once to reduce noise in the findings.
+      // Tidy checks are used in two different workflows:
+      // - Ones that show all the findings for a given file. For such
+      // workflows there is not much point in showing all the occurences,
+      // as one is enough to indicate the issue.
+      // - Ones that show only the findings on changed pieces. For such
+      // workflows it's useful to show findings on every reference of a
+      // symbol as otherwise tools might give incosistent results
+      // depending on the parts of the file being edited. But it should
+      // still help surface findings for "new violations" (i.e.
+      // dependency did not exist in the code at all before).
+      if (DeduplicateFindings && !SeenSymbols.insert(Missing.Ref.Target).second)
+        continue;
+      assert(!Missing.Providers.empty() && "missing include without provider");
       const std::string Spelling = include_cleaner::spellHeader(
-          {Inc.Missing, PP->getHeaderSearchInfo(), MainFile});
+          {Missing.Providers.front(), PP->getHeaderSearchInfo(), MainFile});
       const bool Angled = StringRef{Spelling}.starts_with('<');
       // We might suggest insertion of an existing include in edge cases, e.g.,
       // include is present in a PP-disabled region, or spelling of the header
@@ -236,15 +219,46 @@ void IncludeCleanerCheck::check(const MatchFinder::MatchResult &Result) {
               HeaderIncludes.insert(StringRef{Spelling}.trim("\"<>"), Angled,
                                     tooling::IncludeDirective::Include)) {
         const DiagnosticBuilder DB =
-            diag(SM->getSpellingLoc(Inc.SymRef.RefLocation),
+            diag(DiagLocation(Missing),
                  "no header providing \"%0\" is directly included")
-            << Inc.SymRef.Target.name();
+            << Missing.Ref.Target.name();
         if (areDiagsSelfContained() ||
             InsertedHeaders.insert(Replacement->getReplacementText()).second) {
           DB << FixItHint::CreateInsertion(
               SM->getComposedLoc(SM->getMainFileID(), Replacement->getOffset()),
               Replacement->getReplacementText());
         }
+      }
+    }
+  }
+
+  if (!FragmentDependencyCommentFormat.empty()) {
+    include_cleaner::FixIncludesOptions FixOptions;
+    FixOptions.FragmentDependencyCommentFormat =
+        FragmentDependencyCommentFormat;
+    const include_cleaner::IncludeFixes Fixes = computeIncludeFixes(
+        Results, getCurrentMainFile(), Code, *FileStyle, FixOptions);
+    for (const auto &Comment : Fixes.FragmentComments) {
+      if (Comment.Status ==
+          include_cleaner::FragmentDependencyCommentStatus::AlreadyPresent) {
+        continue;
+      }
+      std::string FragmentList;
+      for (const auto *Fragment : Comment.Fragments) {
+        if (!FragmentList.empty())
+          FragmentList += ", ";
+        FragmentList += Fragment->quote();
+      }
+      const DiagnosticBuilder DB =
+          diag(Comment.Preserved->HashLocation,
+               "included header %0 is used only by fragment header(s) %1")
+          << llvm::sys::path::filename(Comment.Preserved->Spelled,
+                                       llvm::sys::path::Style::posix)
+          << FragmentList;
+      if (const auto Replacement = Comment.Replacement) {
+        DB << FixItHint::CreateInsertion(
+            SM->getComposedLoc(SM->getMainFileID(), Replacement->getOffset()),
+            Replacement->getReplacementText());
       }
     }
   }

--- a/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.h
@@ -20,12 +20,14 @@
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/Preprocessor.h"
 #include "llvm/Support/Regex.h"
+#include <string>
 #include <vector>
 
 namespace clang::tidy::misc {
 
 /// Checks for unused and missing includes. Generates findings only for
-/// the main file of a translation unit.
+/// the main file of a translation unit, optionally treating some direct
+/// includes as fragments of the main file for usage scanning.
 /// Findings correspond to https://clangd.llvm.org/design/include-cleaner.
 ///
 /// For the user-facing documentation see:
@@ -45,6 +47,8 @@ private:
   include_cleaner::PragmaIncludes RecordedPI;
   const Preprocessor *PP = nullptr;
   std::vector<StringRef> IgnoreHeaders;
+  llvm::SmallVector<std::string> FragmentHeaderPatterns;
+  std::string FragmentDependencyCommentFormat;
   // Whether emit only one finding per usage of a symbol.
   const bool DeduplicateFindings;
   // Whether to report unused includes.
@@ -52,6 +56,7 @@ private:
   // Whether to report missing includes.
   const bool MissingIncludes;
   SmallVector<llvm::Regex> IgnoreHeadersRegex;
+  llvm::SmallVector<llvm::Regex> FragmentHeaderRegexes;
   bool shouldIgnore(const include_cleaner::Header &H);
 };
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -450,6 +450,14 @@ Miscellaneous
 Improvements to include-fixer
 -----------------------------
 
+Improvements to clang-include-cleaner
+-------------------------------------
+
+- Added :program:`clang-include-cleaner` support for treating matching direct
+  includes as fragments of the main file with ``--fragment-headers`` and for
+  optionally annotating preserved includes with
+  ``--fragment-dependency-comment-format``.
+
 Improvements to clang-include-fixer
 -----------------------------------
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -292,12 +292,17 @@ Changes in existing checks
 
   - Added support for analyzing function parameters with the `AnalyzeParameters`
     option.
-
   - Fixed false positive where an array of pointers to ``const`` was
     incorrectly diagnosed as allowing the pointee to be made ``const``.
 
   - Fixed false positive where a pointer used with placement new was
     incorrectly diagnosed as allowing the pointee to be made ``const``.
+
+- Improved :doc:`misc-include-cleaner
+  <clang-tidy/checks/misc/include-cleaner>` check by adding the
+  `FragmentHeaders` option for fragment-aware usage scanning and the
+  `FragmentDependencyCommentFormat` option for annotating includes kept only by
+  those fragments.
 
 - Improved :doc:`misc-multiple-inheritance
   <clang-tidy/checks/misc/multiple-inheritance>` by avoiding false positives when

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/include-cleaner.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/include-cleaner.rst
@@ -4,7 +4,8 @@ misc-include-cleaner
 ====================
 
 Checks for unused and missing includes. Generates findings only for
-the main file of a translation unit.
+the main file of a translation unit. Optionally, direct includes can be
+treated as fragments of the main file for usage scanning.
 Findings correspond to https://clangd.llvm.org/design/include-cleaner.
 
 Example:
@@ -33,6 +34,50 @@ Options
    files that match this regex as a suffix.  E.g., `foo/.*` disables
    insertion/removal for all headers under the directory `foo`. Default is an
    empty string, no headers will be ignored.
+
+.. option:: FragmentHeaders
+
+   A semicolon-separated list of regular expressions that match against
+   normalized resolved include paths (POSIX-style separators). Direct includes
+   of the main file that match are treated as fragments of the main file for
+   usage scanning. This is intended for non-self-contained include fragments
+   such as TableGen ``.inc``/``.def`` files or generated headers. Only direct
+   includes are considered; includes inside fragments are not treated as
+   fragments.
+
+   Diagnostics remain anchored to the main file, but symbol uses inside
+   fragments can keep prerequisite includes in the main file from being
+   removed or marked missing. Note that include-cleaner does not support
+   ``// IWYU pragma: associated``.
+
+   Example configuration:
+
+   .. code-block:: yaml
+
+      CheckOptions:
+        - key: misc-include-cleaner.FragmentHeaders
+          value: 'gen-out/;generated/;\\.(inc|def)$'
+
+.. option:: FragmentDependencyCommentFormat
+
+   A trailing comment format to add to includes that are kept only because they
+   are used from fragment headers matched by :option:`FragmentHeaders`. The
+   value should not include the leading ``//``. An empty string disables these
+   diagnostics and fix-its.
+
+   Use ``{0}`` to substitute the comma-separated direct fragment include
+   spellings that keep the include alive.
+
+   Example configuration:
+
+   .. code-block:: yaml
+
+      CheckOptions:
+        - key: misc-include-cleaner.FragmentDependencyCommentFormat
+          value: 'needed by {0}'
+
+   For example, setting the value to ``IWYU pragma: keep`` inserts
+   ``// IWYU pragma: keep``.
 
 .. option:: DeduplicateFindings
 

--- a/clang-tools-extra/include-cleaner/include/clang-include-cleaner/Analysis.h
+++ b/clang-tools-extra/include-cleaner/include/clang-include-cleaner/Analysis.h
@@ -16,21 +16,24 @@
 #include "clang/Format/Format.h"
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/Preprocessor.h"
+#include "clang/Tooling/Core/Replacement.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include <functional>
+#include <optional>
 #include <string>
 #include <utility>
 
 namespace clang {
 class SourceLocation;
+class FileID;
 class SourceManager;
 class Decl;
 class FileEntry;
 class HeaderSearch;
 namespace tooling {
-class Replacements;
 struct IncludeStyle;
 } // namespace tooling
 namespace include_cleaner {
@@ -60,24 +63,100 @@ void walkUsed(llvm::ArrayRef<Decl *> ASTRoots,
               llvm::ArrayRef<SymbolReference> MacroRefs,
               const PragmaIncludes *PI, const Preprocessor &PP,
               UsedSymbolCB CB);
+/// Overload that allows customizing which FileIDs are treated as "main file".
+/// The predicate is evaluated on the expansion file of a reference.
+void walkUsed(llvm::ArrayRef<Decl *> ASTRoots,
+              llvm::ArrayRef<SymbolReference> MacroRefs,
+              const PragmaIncludes *PI, const Preprocessor &PP, UsedSymbolCB CB,
+              llvm::function_ref<bool(FileID)> IsMainFile);
 
+/// A location kind where a symbol reference is observed.
+enum class SymbolReferenceOrigin {
+  MainFile,
+  Preamble,
+  Fragment,
+};
+
+/// A missing include finding with per-reference provenance.
+struct MissingIncludeRef {
+  SymbolReference Ref;
+  llvm::SmallVector<Header> Providers;
+  SymbolReferenceOrigin Origin = SymbolReferenceOrigin::MainFile;
+  // Null if the fragment file has multiple direct include sites.
+  const Include *FragmentInclude = nullptr;
+};
+
+/// An include kept alive only by fragment usage.
+struct FragmentDependency {
+  const Include *Preserved = nullptr;
+  llvm::SmallVector<const Include *> Fragments;
+};
+
+/// The result of include-cleaner analysis for one main file.
 struct AnalysisResults {
   std::vector<const Include *> Unused;
-  // Spellings, like "<vector>" paired with the Header that generated it.
-  std::vector<std::pair<std::string, Header>> Missing;
+  // Deduplicated insertion plan, e.g. "<vector>" paired with the chosen
+  // provider Header.
+  std::vector<std::pair<std::string, Header>> MissingIncludes;
+  // Per-reference provenance for consumers that need richer diagnostics.
+  std::vector<MissingIncludeRef> MissingRefs;
+  std::vector<FragmentDependency> FragmentDependencies;
+};
+
+/// Analysis configuration shared by include-cleaner consumers.
+struct AnalysisOptions {
+  /// No analysis will be performed for headers that satisfy the predicate.
+  std::function<bool(const Header &)> HeaderFilter;
+  /// A predicate matched against normalized resolved paths, and normalized
+  /// spelled paths as a fallback, to identify direct include fragments.
+  std::function<bool(llvm::StringRef)> FragmentHeaderFilter;
 };
 
 /// Determine which headers should be inserted or removed from the main file.
 /// This exposes conclusions but not reasons: use lower-level walkUsed for that.
-///
-/// The HeaderFilter is a predicate that receives absolute path or spelling
-/// without quotes/brackets, when a phyiscal file doesn't exist.
-/// No analysis will be performed for headers that satisfy the predicate.
-AnalysisResults
-analyze(llvm::ArrayRef<Decl *> ASTRoots,
-        llvm::ArrayRef<SymbolReference> MacroRefs, const Includes &I,
-        const PragmaIncludes *PI, const Preprocessor &PP,
-        llvm::function_ref<bool(llvm::StringRef)> HeaderFilter = nullptr);
+AnalysisResults analyze(llvm::ArrayRef<Decl *> ASTRoots,
+                        llvm::ArrayRef<SymbolReference> MacroRefs,
+                        const Includes &I, const PragmaIncludes *PI,
+                        const Preprocessor &PP,
+                        const AnalysisOptions &Options = {});
+
+enum class FragmentDependencyCommentStatus {
+  CanInsert,
+  AlreadyPresent,
+  ConflictingComment,
+};
+
+/// Planned comment state for an include kept alive by fragments.
+struct FragmentDependencyComment {
+  const Include *Preserved = nullptr;
+  llvm::SmallVector<const Include *> Fragments;
+  std::string Text;
+  FragmentDependencyCommentStatus Status =
+      FragmentDependencyCommentStatus::CanInsert;
+  std::optional<tooling::Replacement> Replacement;
+};
+
+/// Replacements computed from include-cleaner findings.
+struct IncludeFixes {
+  tooling::Replacements Replacements;
+  std::vector<FragmentDependencyComment> FragmentComments;
+};
+
+/// Options for turning analysis results into source edits.
+struct FixIncludesOptions {
+  /// Raw trailing comment text without the leading //.
+  ///
+  /// When it contains `{0}`, that placeholder is replaced with a comma-
+  /// separated list of direct fragment include spellings that keep the include
+  /// alive.
+  llvm::StringRef FragmentDependencyCommentFormat;
+};
+
+/// Computes replacements to apply include-cleaner findings to the main file.
+IncludeFixes computeIncludeFixes(const AnalysisResults &Results,
+                                 llvm::StringRef FileName, llvm::StringRef Code,
+                                 const format::FormatStyle &IncludeStyle,
+                                 const FixIncludesOptions &Options = {});
 
 /// Removes unused includes and inserts missing ones in the main file.
 /// Returns the modified main-file code.
@@ -85,6 +164,10 @@ analyze(llvm::ArrayRef<Decl *> ASTRoots,
 std::string fixIncludes(const AnalysisResults &Results,
                         llvm::StringRef FileName, llvm::StringRef Code,
                         const format::FormatStyle &IncludeStyle);
+std::string fixIncludes(const AnalysisResults &Results,
+                        llvm::StringRef FileName, llvm::StringRef Code,
+                        const format::FormatStyle &IncludeStyle,
+                        const FixIncludesOptions &Options);
 
 /// Gets all the providers for a symbol by traversing each location.
 /// Returned headers are sorted by relevance, first element is the most

--- a/clang-tools-extra/include-cleaner/include/clang-include-cleaner/Record.h
+++ b/clang-tools-extra/include-cleaner/include/clang-include-cleaner/Record.h
@@ -132,7 +132,7 @@ struct RecordedAST {
   std::vector<Decl *> Roots;
 };
 
-/// Recorded main-file preprocessor events relevant to include-cleaner.
+/// Recorded preprocessor events relevant to include-cleaner.
 ///
 /// This doesn't include facts that we record globally for the whole TU, even
 /// when they occur in the main file (e.g. IWYU pragmas).
@@ -140,7 +140,8 @@ struct RecordedPP {
   /// The callback (when installed into clang) tracks macros/includes in this.
   std::unique_ptr<PPCallbacks> record(const Preprocessor &PP);
 
-  /// Describes where macros were used in the main file.
+  /// Describes where macros were used in the main file or in files directly
+  /// included by the main file.
   std::vector<SymbolReference> MacroReferences;
 
   /// The include directives seen in the main file.

--- a/clang-tools-extra/include-cleaner/include/clang-include-cleaner/Types.h
+++ b/clang-tools-extra/include-cleaner/include/clang-include-cleaner/Types.h
@@ -155,13 +155,14 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &, const Header &);
 
 /// A single #include directive written in the main file.
 struct Include {
-  llvm::StringRef Spelled;             // e.g. vector
-  OptionalFileEntryRef Resolved;       // e.g. /path/to/c++/v1/vector
-                                       // nullopt if the header was not found
-  SourceLocation HashLocation;         // of hash in #include <vector>
-  unsigned Line = 0;                   // 1-based line number for #include
-  bool Angled = false;                 // True if spelled with <angle> quotes.
-  std::string quote() const;           // e.g. <vector>
+  llvm::StringRef Spelled;         // e.g. vector
+  OptionalFileEntryRef Resolved;   // e.g. /path/to/c++/v1/vector
+                                   // nullopt if the header was not found
+  SourceLocation HashLocation;     // of hash in #include <vector>
+  SourceLocation FilenameLocation; // of the filename token in #include
+  unsigned Line = 0;               // 1-based line number for #include
+  bool Angled = false;             // True if spelled with <angle> quotes.
+  std::string quote() const;       // e.g. <vector>
 };
 llvm::raw_ostream &operator<<(llvm::raw_ostream &, const Include &);
 

--- a/clang-tools-extra/include-cleaner/lib/Analysis.cpp
+++ b/clang-tools-extra/include-cleaner/lib/Analysis.cpp
@@ -8,6 +8,7 @@
 
 #include "clang-include-cleaner/Analysis.h"
 #include "AnalysisInternal.h"
+#include "TypesInternal.h"
 #include "clang-include-cleaner/IncludeSpeller.h"
 #include "clang-include-cleaner/Record.h"
 #include "clang-include-cleaner/Types.h"
@@ -22,9 +23,11 @@
 #include "clang/Tooling/Core/Replacement.h"
 #include "clang/Tooling/Inclusions/StandardLibrary.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -32,13 +35,91 @@
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 #include <climits>
+#include <optional>
 #include <string>
 
 namespace clang::include_cleaner {
 
 namespace {
+
+struct ClassifiedReference {
+  SymbolReferenceOrigin Origin;
+  // Null if the fragment file has multiple direct include sites.
+  const Include *FragmentInclude = nullptr;
+};
+
+class FragmentTracker {
+public:
+  FragmentTracker(const Includes &Inc, const SourceManager &SM,
+                  const std::function<bool(llvm::StringRef)> &HeaderFilter)
+      : SM(SM) {
+    if (!HeaderFilter)
+      return;
+
+    for (const Include &I : Inc.all()) {
+      if (!I.Resolved ||
+          locateInMainFile(I.HashLocation, SM) != MainFileLocation::MainFile) {
+        continue;
+      }
+
+      // Match the canonical path first, but fall back to the spelled include
+      // so generated paths can still be configured even when resolution loses
+      // that spelling detail.
+      const llvm::SmallString<128> ResolvedPath =
+          normalizePath(I.Resolved->getName());
+      bool IsFragment = HeaderFilter(ResolvedPath);
+      if (!IsFragment) {
+        const llvm::SmallString<128> SpelledPath = normalizePath(I.Spelled);
+        if (!SpelledPath.empty())
+          IsFragment = HeaderFilter(SpelledPath);
+      }
+      if (!IsFragment)
+        continue;
+
+      // Fragments are intentionally direct-includes-only for now. If a
+      // fragment includes another file, that nested include keeps normal
+      // header semantics.
+      IncludeSitesByFile[&I.Resolved->getFileEntry()].push_back(&I);
+      DirectIncludes.insert(&I);
+    }
+  }
+
+  std::optional<ClassifiedReference> classify(FileID FID) const {
+    if (FID == SM.getMainFileID())
+      return ClassifiedReference{SymbolReferenceOrigin::MainFile};
+    if (FID == SM.getPreambleFileID())
+      return ClassifiedReference{SymbolReferenceOrigin::Preamble};
+    auto FE = SM.getFileEntryRefForID(FID);
+    if (!FE)
+      return std::nullopt;
+    auto It = IncludeSitesByFile.find(&FE->getFileEntry());
+    if (It == IncludeSitesByFile.end())
+      return std::nullopt;
+    if (It->second.size() != 1)
+      return ClassifiedReference{SymbolReferenceOrigin::Fragment};
+    return ClassifiedReference{SymbolReferenceOrigin::Fragment,
+                               It->second.front()};
+  }
+
+  bool isDirectInclude(const Include *I) const {
+    return DirectIncludes.contains(I);
+  }
+
+private:
+  const SourceManager &SM;
+  llvm::DenseMap<const FileEntry *, llvm::SmallVector<const Include *>>
+      IncludeSitesByFile;
+  llvm::DenseSet<const Include *> DirectIncludes;
+};
+
+using UsedSymbolWithOriginCB = llvm::function_ref<void(
+    const SymbolReference &Ref, llvm::ArrayRef<Header> Providers,
+    const ClassifiedReference &Info)>;
+
 bool shouldIgnoreMacroReference(const Preprocessor &PP, const Macro &M) {
-  auto *MI = PP.getMacroInfo(M.Name);
+  auto &MutablePP = const_cast<Preprocessor &>(PP);
+  auto MD = MutablePP.getMacroDefinitionAtLoc(M.Name, M.Definition);
+  auto *MI = MD ? MD.getMacroInfo() : PP.getMacroInfo(M.Name);
   // Macros that expand to themselves are confusing from user's point of view.
   // They usually aspect the usage to be attributed to the underlying decl and
   // not the macro definition. So ignore such macros (e.g. std{in,out,err} are
@@ -47,15 +128,12 @@ bool shouldIgnoreMacroReference(const Preprocessor &PP, const Macro &M) {
   return MI && MI->getNumTokens() == 1 && MI->isObjectLike() &&
          MI->getReplacementToken(0).getIdentifierInfo() == M.Name;
 }
-} // namespace
 
-void walkUsed(llvm::ArrayRef<Decl *> ASTRoots,
-              llvm::ArrayRef<SymbolReference> MacroRefs,
-              const PragmaIncludes *PI, const Preprocessor &PP,
-              UsedSymbolCB CB) {
+void walkUsedWithOrigins(
+    llvm::ArrayRef<Decl *> ASTRoots, llvm::ArrayRef<SymbolReference> MacroRefs,
+    const PragmaIncludes *PI, const Preprocessor &PP, UsedSymbolWithOriginCB CB,
+    llvm::function_ref<std::optional<ClassifiedReference>(FileID)> Classify) {
   const auto &SM = PP.getSourceManager();
-  // This is duplicated in writeHTMLReport, changes should be mirrored there.
-  tooling::stdlib::Recognizer Recognizer;
   for (auto *Root : ASTRoots) {
     walkAST(*Root, [&](SourceLocation Loc, NamedDecl &ND, RefType RT) {
       auto SpellLoc = SM.getSpellingLoc(Loc);
@@ -71,111 +149,385 @@ void walkUsed(llvm::ArrayRef<Decl *> ASTRoots,
         SpellLoc = SM.getSpellingLoc(Loc);
       }
       auto FID = SM.getFileID(SpellLoc);
-      if (FID != SM.getMainFileID() && FID != SM.getPreambleFileID())
+      auto Info = Classify(FID);
+      if (!Info)
         return;
       // FIXME: Most of the work done here is repetitive. It might be useful to
       // have a cache/batching.
       SymbolReference SymRef{ND, Loc, RT};
-      return CB(SymRef, headersForSymbol(ND, PP, PI));
+      return CB(SymRef, headersForSymbol(ND, PP, PI), *Info);
     });
   }
+
   for (const SymbolReference &MacroRef : MacroRefs) {
     assert(MacroRef.Target.kind() == Symbol::Macro);
-    if (!SM.isWrittenInMainFile(SM.getSpellingLoc(MacroRef.RefLocation)) ||
-        shouldIgnoreMacroReference(PP, MacroRef.Target.macro()))
+    if (shouldIgnoreMacroReference(PP, MacroRef.Target.macro()))
       continue;
-    CB(MacroRef, headersForSymbol(MacroRef.Target, PP, PI));
+    auto FID = SM.getFileID(SM.getSpellingLoc(MacroRef.RefLocation));
+    auto Info = Classify(FID);
+    if (!Info)
+      continue;
+    CB(MacroRef, headersForSymbol(MacroRef.Target, PP, PI), *Info);
   }
 }
 
-AnalysisResults
-analyze(llvm::ArrayRef<Decl *> ASTRoots,
-        llvm::ArrayRef<SymbolReference> MacroRefs, const Includes &Inc,
-        const PragmaIncludes *PI, const Preprocessor &PP,
-        llvm::function_ref<bool(llvm::StringRef)> HeaderFilter) {
+bool isFilteredInclude(const Include &I,
+                       llvm::function_ref<bool(const Header &)> HeaderFilter,
+                       const Preprocessor &PP) {
+  if (I.Angled) {
+    auto Lang = PP.getLangOpts().CPlusPlus ? tooling::stdlib::Lang::CXX
+                                           : tooling::stdlib::Lang::C;
+    if (auto StdHeader = tooling::stdlib::Header::named(I.quote(), Lang);
+        StdHeader && HeaderFilter(*StdHeader)) {
+      return true;
+    }
+  }
+  return I.Resolved && HeaderFilter(*I.Resolved);
+}
+
+bool shouldSuppressIncludeDiagnostic(
+    const Include &I, FileEntryRef MainFile,
+    llvm::function_ref<bool(const Header &)> HeaderFilter,
+    const PragmaIncludes *PI, const Preprocessor &PP,
+    OptionalDirectoryEntryRef ResourceDir) {
+  if (!I.Resolved || I.Resolved->getDir() == ResourceDir ||
+      isFilteredInclude(I, HeaderFilter, PP)) {
+    return true;
+  }
+  if (!PI)
+    return false;
+  if (PI->shouldKeep(*I.Resolved))
+    return true;
+  // Check if main file is the public interface for a private header. If so
+  // we shouldn't diagnose it as unused, or add fragment comments for it.
+  if (auto PHeader = PI->getPublic(*I.Resolved); !PHeader.empty()) {
+    PHeader = PHeader.trim("<>\"");
+    if (MainFile.getName().ends_with(PHeader))
+      return true;
+  }
+  return false;
+}
+
+} // namespace
+
+void walkUsed(llvm::ArrayRef<Decl *> ASTRoots,
+              llvm::ArrayRef<SymbolReference> MacroRefs,
+              const PragmaIncludes *PI, const Preprocessor &PP,
+              UsedSymbolCB CB) {
+  const auto &SM = PP.getSourceManager();
+  walkUsed(ASTRoots, MacroRefs, PI, PP, CB, [&](FileID FID) {
+    return FID == SM.getMainFileID() || FID == SM.getPreambleFileID();
+  });
+}
+
+void walkUsed(llvm::ArrayRef<Decl *> ASTRoots,
+              llvm::ArrayRef<SymbolReference> MacroRefs,
+              const PragmaIncludes *PI, const Preprocessor &PP, UsedSymbolCB CB,
+              llvm::function_ref<bool(FileID)> IsMainFile) {
+  walkUsedWithOrigins(
+      ASTRoots, MacroRefs, PI, PP,
+      [&](const SymbolReference &Ref, llvm::ArrayRef<Header> Providers,
+          const ClassifiedReference &) { CB(Ref, Providers); },
+      [&](FileID FID) -> std::optional<ClassifiedReference> {
+        if (!IsMainFile(FID))
+          return std::nullopt;
+        return ClassifiedReference{SymbolReferenceOrigin::MainFile};
+      });
+}
+
+namespace {
+
+class IncludeUsage {
+public:
+  void mark(const Include *I, const ClassifiedReference &Info) {
+    Used.insert(I);
+    if (Info.Origin != SymbolReferenceOrigin::Fragment) {
+      UsedByMainOrPreamble.insert(I);
+      return;
+    }
+
+    UsedByFragment.insert(I);
+    if (!Info.FragmentInclude)
+      return;
+    auto &Reasons = ByPreserved[I];
+    if (!llvm::is_contained(Reasons, Info.FragmentInclude))
+      Reasons.push_back(Info.FragmentInclude);
+  }
+
+  bool contains(const Include *I) const { return Used.contains(I); }
+
+  bool isFragmentOnly(const Include *I) const {
+    return UsedByFragment.contains(I) && !UsedByMainOrPreamble.contains(I);
+  }
+
+  llvm::SmallVector<const Include *> fragmentSites(const Include *I) const {
+    auto It = ByPreserved.find(I);
+    if (It == ByPreserved.end())
+      return {};
+    return It->second;
+  }
+
+private:
+  llvm::DenseSet<const Include *> Used;
+  llvm::DenseSet<const Include *> UsedByMainOrPreamble;
+  llvm::DenseSet<const Include *> UsedByFragment;
+  llvm::DenseMap<const Include *, llvm::SmallVector<const Include *>>
+      ByPreserved;
+};
+
+class MissingIncludeCollector {
+public:
+  void add(llvm::StringRef Spelling, const Header &Provider) {
+    Missing.try_emplace(Spelling, Provider);
+  }
+
+  std::vector<std::pair<std::string, Header>> take() && {
+    std::vector<std::pair<std::string, Header>> Result;
+    Result.reserve(Missing.size());
+    for (auto &E : Missing)
+      Result.emplace_back(E.first().str(), E.second);
+    llvm::sort(Result);
+    return Result;
+  }
+
+private:
+  llvm::StringMap<Header> Missing;
+};
+
+} // namespace
+
+AnalysisResults analyze(llvm::ArrayRef<Decl *> ASTRoots,
+                        llvm::ArrayRef<SymbolReference> MacroRefs,
+                        const Includes &Inc, const PragmaIncludes *PI,
+                        const Preprocessor &PP,
+                        const AnalysisOptions &Options) {
   auto &SM = PP.getSourceManager();
   const auto MainFile = *SM.getFileEntryRefForID(SM.getMainFileID());
-  llvm::DenseSet<const Include *> Used;
-  llvm::StringMap<Header> Missing;
-  constexpr auto DefaultHeaderFilter = [](llvm::StringRef) { return false; };
-  if (!HeaderFilter)
-    HeaderFilter = DefaultHeaderFilter;
+  auto HeaderFilter = [&](const Header &H) {
+    return Options.HeaderFilter && Options.HeaderFilter(H);
+  };
+  FragmentTracker Fragments(Inc, SM, Options.FragmentHeaderFilter);
+  IncludeUsage Usage;
+  MissingIncludeCollector MissingIncludes;
+  std::vector<MissingIncludeRef> MissingRefs;
   OptionalDirectoryEntryRef ResourceDir =
       PP.getHeaderSearchInfo().getModuleMap().getBuiltinDir();
-  walkUsed(ASTRoots, MacroRefs, PI, PP,
-           [&](const SymbolReference &Ref, llvm::ArrayRef<Header> Providers) {
-             bool Satisfied = false;
-             for (const Header &H : Providers) {
-               if (H.kind() == Header::Physical &&
-                   (H.physical() == MainFile ||
-                    H.physical().getDir() == ResourceDir)) {
-                 Satisfied = true;
-               }
-               for (const Include *I : Inc.match(H)) {
-                 Used.insert(I);
-                 Satisfied = true;
-               }
-             }
-             // Bail out if we can't (or need not) insert an include.
-             if (Satisfied || Providers.empty() || Ref.RT != RefType::Explicit)
-               return;
-             if (HeaderFilter(Providers.front().resolvedPath()))
-               return;
-             // Check if we have any headers with the same spelling, in edge
-             // cases like `#include_next "foo.h"`, the user can't ever
-             // include the physical foo.h, but can have a spelling that
-             // refers to it.
-             auto Spelling = spellHeader(
-                 {Providers.front(), PP.getHeaderSearchInfo(), MainFile});
-             for (const Include *I : Inc.match(Header{Spelling})) {
-               Used.insert(I);
-               Satisfied = true;
-             }
-             if (!Satisfied)
-               Missing.try_emplace(std::move(Spelling), Providers.front());
-           });
 
-  AnalysisResults Results;
+  walkUsedWithOrigins(
+      ASTRoots, MacroRefs, PI, PP,
+      [&](const SymbolReference &Ref, llvm::ArrayRef<Header> Providers,
+          const ClassifiedReference &Info) {
+        bool Satisfied = false;
+        for (const Header &H : Providers) {
+          if (H.kind() == Header::Physical &&
+              (H.physical() == MainFile ||
+               H.physical().getDir() == ResourceDir)) {
+            Satisfied = true;
+          }
+          for (const Include *I : Inc.match(H)) {
+            Usage.mark(I, Info);
+            Satisfied = true;
+          }
+        }
+
+        if (Satisfied || Providers.empty() || Ref.RT != RefType::Explicit)
+          return;
+        if (HeaderFilter(Providers.front()))
+          return;
+
+        auto Spelling = spellHeader(
+            {Providers.front(), PP.getHeaderSearchInfo(), MainFile});
+        for (const Include *I : Inc.match(Header{Spelling})) {
+          Usage.mark(I, Info);
+          Satisfied = true;
+        }
+        if (Satisfied)
+          return;
+
+        // MissingIncludes drives edits, while MissingRefs preserves where the
+        // unsatisfied use came from for higher-level diagnostics.
+        MissingIncludes.add(Spelling, Providers.front());
+        MissingRefs.push_back(MissingIncludeRef{
+            Ref, llvm::SmallVector<Header>(Providers.begin(), Providers.end()),
+            Info.Origin, Info.FragmentInclude});
+      },
+      [&](FileID FID) { return Fragments.classify(FID); });
+
+  AnalysisResults Results{{}, {}, std::move(MissingRefs), {}};
   for (const Include &I : Inc.all()) {
-    if (Used.contains(&I) || !I.Resolved ||
-        HeaderFilter(I.Resolved->getName()) ||
-        I.Resolved->getDir() == ResourceDir)
-      continue;
-    if (PI) {
-      if (PI->shouldKeep(*I.Resolved))
-        continue;
-      // Check if main file is the public interface for a private header. If so
-      // we shouldn't diagnose it as unused.
-      if (auto PHeader = PI->getPublic(*I.Resolved); !PHeader.empty()) {
-        PHeader = PHeader.trim("<>\"");
-        // Since most private -> public mappings happen in a verbatim way, we
-        // check textually here. This might go wrong in presence of symlinks or
-        // header mappings. But that's not different than rest of the places.
-        if (MainFile.getName().ends_with(PHeader))
-          continue;
+    bool Suppressed = shouldSuppressIncludeDiagnostic(I, MainFile, HeaderFilter,
+                                                      PI, PP, ResourceDir);
+    if (Usage.contains(&I)) {
+      const llvm::SmallVector<const Include *> FragmentSites =
+          Usage.fragmentSites(&I);
+      // Ambiguous fragment sites still preserve the header, but get no comment.
+      if (!Suppressed && Usage.isFragmentOnly(&I) &&
+          !Fragments.isDirectInclude(&I) && !FragmentSites.empty()) {
+        Results.FragmentDependencies.push_back(
+            FragmentDependency{&I, FragmentSites});
       }
+      continue;
     }
+    if (Suppressed)
+      continue;
     Results.Unused.push_back(&I);
   }
-  for (auto &E : Missing)
-    Results.Missing.emplace_back(E.first().str(), E.second);
-  llvm::sort(Results.Missing);
+  Results.MissingIncludes = std::move(MissingIncludes).take();
   return Results;
+}
+
+namespace {
+
+// computeIncludeFixes works on plain text, so comment planning needs its own
+// lightweight line lookup rather than SourceManager-based offsets.
+class LineIndex {
+public:
+  explicit LineIndex(llvm::StringRef Code) : Code(Code) {
+    Starts.push_back(0);
+    for (unsigned I = 0; I < Code.size(); ++I) {
+      if (Code[I] == '\n')
+        Starts.push_back(I + 1);
+    }
+    Starts.push_back(Code.size());
+  }
+
+  llvm::StringRef line(unsigned OneBasedLine) const {
+    auto [Start, End] = bounds(OneBasedLine);
+    return Code.slice(Start, End);
+  }
+
+  unsigned trimmedLineEnd(unsigned OneBasedLine) const {
+    auto [Start, End] = bounds(OneBasedLine);
+    while (End > Start && (Code[End - 1] == ' ' || Code[End - 1] == '\t'))
+      --End;
+    return End;
+  }
+
+private:
+  std::pair<unsigned, unsigned> bounds(unsigned OneBasedLine) const {
+    if (OneBasedLine == 0 || OneBasedLine >= Starts.size())
+      return {Code.size(), Code.size()};
+    unsigned Start = Starts[OneBasedLine - 1];
+    unsigned End =
+        Starts[OneBasedLine] == 0 ? Code.size() : Starts[OneBasedLine] - 1;
+    if (End > Start && Code[End - 1] == '\r')
+      --End;
+    return {Start, End};
+  }
+
+  llvm::StringRef Code;
+  llvm::SmallVector<unsigned> Starts;
+};
+
+std::string formatFragmentDependencyComment(
+    llvm::StringRef Format, llvm::ArrayRef<const Include *> FragmentIncludes) {
+  if (Format.empty())
+    return {};
+
+  std::string FragmentList;
+  for (const Include *Fragment : FragmentIncludes) {
+    if (!FragmentList.empty())
+      FragmentList += ", ";
+    FragmentList += Fragment->quote();
+  }
+
+  std::string Result;
+  llvm::StringRef Remaining = Format;
+  while (true) {
+    auto Pos = Remaining.find("{0}");
+    if (Pos == llvm::StringRef::npos) {
+      Result += Remaining.str();
+      return Result;
+    }
+    Result += Remaining.take_front(Pos).str();
+    Result += FragmentList;
+    Remaining = Remaining.drop_front(Pos + 3);
+  }
+}
+
+FragmentDependencyComment inspectFragmentDependencyComment(
+    const FragmentDependency &Dependency, llvm::StringRef FileName,
+    const LineIndex &Lines, llvm::StringRef CommentFormat) {
+  FragmentDependencyComment Comment{
+      Dependency.Preserved, Dependency.Fragments,
+      formatFragmentDependencyComment(CommentFormat, Dependency.Fragments),
+      FragmentDependencyCommentStatus::CanInsert, std::nullopt};
+  if (Comment.Text.empty())
+    return Comment;
+
+  llvm::StringRef Line = Lines.line(Dependency.Preserved->Line);
+  size_t IncludePos = Line.find(Dependency.Preserved->quote());
+  if (IncludePos == llvm::StringRef::npos) {
+    Comment.Status = FragmentDependencyCommentStatus::ConflictingComment;
+    return Comment;
+  }
+
+  llvm::StringRef Tail =
+      Line.drop_front(IncludePos + Dependency.Preserved->quote().size());
+  llvm::StringRef TrimmedTail = Tail.ltrim(" \t");
+  if (TrimmedTail.empty()) {
+    Comment.Status = FragmentDependencyCommentStatus::CanInsert;
+    Comment.Replacement = tooling::Replacement(
+        FileName, Lines.trimmedLineEnd(Dependency.Preserved->Line), 0,
+        " // " + Comment.Text);
+    return Comment;
+  }
+
+  if (TrimmedTail.starts_with("//")) {
+    llvm::StringRef Existing = TrimmedTail.drop_front(2).trim();
+    Comment.Status = Existing == Comment.Text
+                         ? FragmentDependencyCommentStatus::AlreadyPresent
+                         : FragmentDependencyCommentStatus::ConflictingComment;
+    return Comment;
+  }
+
+  Comment.Status = FragmentDependencyCommentStatus::ConflictingComment;
+  return Comment;
+}
+
+} // namespace
+
+IncludeFixes computeIncludeFixes(const AnalysisResults &Results,
+                                 llvm::StringRef FileName, llvm::StringRef Code,
+                                 const format::FormatStyle &Style,
+                                 const FixIncludesOptions &Options) {
+  assert(Style.isCpp() && "Only C++ style supports include insertions!");
+  IncludeFixes Fixes;
+  for (const Include *I : Results.Unused)
+    cantFail(Fixes.Replacements.add(
+        tooling::Replacement(FileName, UINT_MAX, 1, I->quote())));
+  for (const auto &[Spelled, _] : Results.MissingIncludes)
+    cantFail(Fixes.Replacements.add(
+        tooling::Replacement(FileName, UINT_MAX, 0, "#include " + Spelled)));
+
+  if (Options.FragmentDependencyCommentFormat.empty())
+    return Fixes;
+
+  LineIndex Lines(Code);
+  for (const FragmentDependency &Dependency : Results.FragmentDependencies) {
+    FragmentDependencyComment Comment = inspectFragmentDependencyComment(
+        Dependency, FileName, Lines, Options.FragmentDependencyCommentFormat);
+    if (Comment.Replacement)
+      cantFail(Fixes.Replacements.add(*Comment.Replacement));
+    Fixes.FragmentComments.push_back(std::move(Comment));
+  }
+  return Fixes;
 }
 
 std::string fixIncludes(const AnalysisResults &Results,
                         llvm::StringRef FileName, llvm::StringRef Code,
                         const format::FormatStyle &Style) {
-  assert(Style.isCpp() && "Only C++ style supports include insertions!");
-  tooling::Replacements R;
-  // Encode insertions/deletions in the magic way clang-format understands.
-  for (const Include *I : Results.Unused)
-    cantFail(R.add(tooling::Replacement(FileName, UINT_MAX, 1, I->quote())));
-  for (auto &[Spelled, _] : Results.Missing)
-    cantFail(R.add(
-        tooling::Replacement(FileName, UINT_MAX, 0, "#include " + Spelled)));
-  // "cleanup" actually turns the UINT_MAX replacements into concrete edits.
-  auto Positioned = cantFail(format::cleanupAroundReplacements(Code, R, Style));
+  return fixIncludes(Results, FileName, Code, Style, {});
+}
+
+std::string fixIncludes(const AnalysisResults &Results,
+                        llvm::StringRef FileName, llvm::StringRef Code,
+                        const format::FormatStyle &Style,
+                        const FixIncludesOptions &Options) {
+  IncludeFixes Fixes =
+      computeIncludeFixes(Results, FileName, Code, Style, Options);
+  auto Positioned = cantFail(
+      format::cleanupAroundReplacements(Code, Fixes.Replacements, Style));
   return cantFail(tooling::applyAllReplacements(Code, Positioned));
 }
 

--- a/clang-tools-extra/include-cleaner/lib/Record.cpp
+++ b/clang-tools-extra/include-cleaner/lib/Record.cpp
@@ -84,13 +84,13 @@ public:
 
   void MacroExpands(const Token &MacroName, const MacroDefinition &MD,
                     SourceRange Range, const MacroArgs *Args) override {
-    if (!Active)
+    if (!shouldRecordMacroRef(MacroName.getLocation()))
       return;
     recordMacroRef(MacroName, *MD.getMacroInfo());
   }
 
   void MacroDefined(const Token &MacroName, const MacroDirective *MD) override {
-    if (!Active)
+    if (!shouldRecordMacroRef(MacroName.getLocation()))
       return;
 
     const auto *MI = MD->getMacroInfo();
@@ -110,7 +110,7 @@ public:
 
   void MacroUndefined(const Token &MacroName, const MacroDefinition &MD,
                       const MacroDirective *) override {
-    if (!Active)
+    if (!shouldRecordMacroRef(MacroName.getLocation()))
       return;
     if (const auto *MI = MD.getMacroInfo())
       recordMacroRef(MacroName, *MI);
@@ -118,7 +118,7 @@ public:
 
   void Ifdef(SourceLocation Loc, const Token &MacroNameTok,
              const MacroDefinition &MD) override {
-    if (!Active)
+    if (!shouldRecordMacroRef(MacroNameTok.getLocation()))
       return;
     if (const auto *MI = MD.getMacroInfo())
       recordMacroRef(MacroNameTok, *MI, RefType::Ambiguous);
@@ -126,7 +126,7 @@ public:
 
   void Ifndef(SourceLocation Loc, const Token &MacroNameTok,
               const MacroDefinition &MD) override {
-    if (!Active)
+    if (!shouldRecordMacroRef(MacroNameTok.getLocation()))
       return;
     if (const auto *MI = MD.getMacroInfo())
       recordMacroRef(MacroNameTok, *MI, RefType::Ambiguous);
@@ -136,14 +136,14 @@ public:
   using PPCallbacks::Elifndef;
   void Elifdef(SourceLocation Loc, const Token &MacroNameTok,
                const MacroDefinition &MD) override {
-    if (!Active)
+    if (!shouldRecordMacroRef(MacroNameTok.getLocation()))
       return;
     if (const auto *MI = MD.getMacroInfo())
       recordMacroRef(MacroNameTok, *MI, RefType::Ambiguous);
   }
   void Elifndef(SourceLocation Loc, const Token &MacroNameTok,
                 const MacroDefinition &MD) override {
-    if (!Active)
+    if (!shouldRecordMacroRef(MacroNameTok.getLocation()))
       return;
     if (const auto *MI = MD.getMacroInfo())
       recordMacroRef(MacroNameTok, *MI, RefType::Ambiguous);
@@ -151,13 +151,23 @@ public:
 
   void Defined(const Token &MacroNameTok, const MacroDefinition &MD,
                SourceRange Range) override {
-    if (!Active)
+    if (!shouldRecordMacroRef(MacroNameTok.getLocation()))
       return;
     if (const auto *MI = MD.getMacroInfo())
       recordMacroRef(MacroNameTok, *MI, RefType::Ambiguous);
   }
 
 private:
+  bool shouldRecordMacroRef(SourceLocation Loc) const {
+    const SourceLocation ExpandedLoc = SM.getExpansionLoc(Loc);
+    const FileID FID = SM.getFileID(ExpandedLoc);
+    if (FID == SM.getMainFileID())
+      return true;
+    const SourceLocation IncludeLoc = SM.getIncludeLoc(FID);
+    return IncludeLoc.isValid() &&
+           SM.getFileID(IncludeLoc) == SM.getMainFileID();
+  }
+
   void recordMacroRef(const Token &Tok, const MacroInfo &MI,
                       RefType RT = RefType::Explicit) {
     if (MI.isBuiltinMacro())

--- a/clang-tools-extra/include-cleaner/lib/Record.cpp
+++ b/clang-tools-extra/include-cleaner/lib/Record.cpp
@@ -76,6 +76,7 @@ public:
 
     Include I;
     I.HashLocation = Hash;
+    I.FilenameLocation = FilenameRange.getBegin();
     I.Resolved = File;
     I.Line = SM.getSpellingLineNumber(Hash);
     I.Spelled = SpelledFilename;

--- a/clang-tools-extra/include-cleaner/lib/Record.cpp
+++ b/clang-tools-extra/include-cleaner/lib/Record.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-include-cleaner/Record.h"
+#include "TypesInternal.h"
 #include "clang-include-cleaner/Types.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
@@ -159,13 +160,7 @@ public:
 
 private:
   bool shouldRecordMacroRef(SourceLocation Loc) const {
-    const SourceLocation ExpandedLoc = SM.getExpansionLoc(Loc);
-    const FileID FID = SM.getFileID(ExpandedLoc);
-    if (FID == SM.getMainFileID())
-      return true;
-    const SourceLocation IncludeLoc = SM.getIncludeLoc(FID);
-    return IncludeLoc.isValid() &&
-           SM.getFileID(IncludeLoc) == SM.getMainFileID();
+    return locateInMainFile(Loc, SM) != MainFileLocation::Other;
   }
 
   void recordMacroRef(const Token &Tok, const MacroInfo &MI,

--- a/clang-tools-extra/include-cleaner/lib/Types.cpp
+++ b/clang-tools-extra/include-cleaner/lib/Types.cpp
@@ -100,14 +100,12 @@ std::string Include::quote() const {
       .str();
 }
 
-static llvm::SmallString<128> normalizePath(llvm::StringRef Path) {
+llvm::SmallString<128> normalizePath(llvm::StringRef Path) {
   namespace path = llvm::sys::path;
 
   llvm::SmallString<128> P = Path;
   path::remove_dots(P, /*remove_dot_dot=*/true);
   path::native(P, path::Style::posix);
-  while (!P.empty() && P.back() == '/')
-    P.pop_back();
   return P;
 }
 

--- a/clang-tools-extra/include-cleaner/lib/Types.cpp
+++ b/clang-tools-extra/include-cleaner/lib/Types.cpp
@@ -10,6 +10,7 @@
 #include "TypesInternal.h"
 #include "clang/AST/Decl.h"
 #include "clang/Basic/FileEntry.h"
+#include "clang/Basic/SourceManager.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
@@ -107,6 +108,22 @@ llvm::SmallString<128> normalizePath(llvm::StringRef Path) {
   path::remove_dots(P, /*remove_dot_dot=*/true);
   path::native(P, path::Style::posix);
   return P;
+}
+
+MainFileLocation locateInMainFile(SourceLocation Loc, const SourceManager &SM) {
+  const SourceLocation ExpandedLoc = SM.getExpansionLoc(Loc);
+  const FileID FID = SM.getFileID(ExpandedLoc);
+  if (FID == SM.getMainFileID() || FID == SM.getPreambleFileID())
+    return MainFileLocation::MainFile;
+  const SourceLocation IncludeLoc = SM.getIncludeLoc(FID);
+  if (!IncludeLoc.isValid())
+    return MainFileLocation::Other;
+  const FileID IncludeFID = SM.getFileID(SM.getExpansionLoc(IncludeLoc));
+  if (IncludeFID == SM.getMainFileID() ||
+      IncludeFID == SM.getPreambleFileID()) {
+    return MainFileLocation::DirectInclude;
+  }
+  return MainFileLocation::Other;
 }
 
 void Includes::addSearchDirectory(llvm::StringRef Path) {

--- a/clang-tools-extra/include-cleaner/lib/TypesInternal.h
+++ b/clang-tools-extra/include-cleaner/lib/TypesInternal.h
@@ -96,6 +96,8 @@ template <typename T> struct Hinted : public T {
   }
 };
 
+llvm::SmallString<128> normalizePath(llvm::StringRef Path);
+
 } // namespace clang::include_cleaner
 
 #endif

--- a/clang-tools-extra/include-cleaner/lib/TypesInternal.h
+++ b/clang-tools-extra/include-cleaner/lib/TypesInternal.h
@@ -19,6 +19,9 @@
 namespace llvm {
 class raw_ostream;
 }
+namespace clang {
+class SourceManager;
+}
 namespace clang::include_cleaner {
 /// A place where a symbol can be provided.
 /// It is either a physical file of the TU (SourceLocation) or a logical
@@ -48,6 +51,12 @@ private:
   std::variant<SourceLocation, tooling::stdlib::Symbol> Storage;
 };
 llvm::raw_ostream &operator<<(llvm::raw_ostream &, const SymbolLocation &);
+
+enum class MainFileLocation {
+  MainFile,
+  DirectInclude,
+  Other,
+};
 
 /// Represents properties of a symbol provider.
 ///
@@ -97,6 +106,7 @@ template <typename T> struct Hinted : public T {
 };
 
 llvm::SmallString<128> normalizePath(llvm::StringRef Path);
+MainFileLocation locateInMainFile(SourceLocation Loc, const SourceManager &SM);
 
 } // namespace clang::include_cleaner
 

--- a/clang-tools-extra/include-cleaner/test/Inputs/a.inc
+++ b/clang-tools-extra/include-cleaner/test/Inputs/a.inc
@@ -1,0 +1,4 @@
+#pragma once
+struct A {
+  std::vector<int> Values;
+};

--- a/clang-tools-extra/include-cleaner/test/Inputs/b.inc
+++ b/clang-tools-extra/include-cleaner/test/Inputs/b.inc
@@ -1,0 +1,4 @@
+#pragma once
+struct B {
+  std::vector<int> Values;
+};

--- a/clang-tools-extra/include-cleaner/test/Inputs/gen.inc
+++ b/clang-tools-extra/include-cleaner/test/Inputs/gen.inc
@@ -1,0 +1,4 @@
+#pragma once
+struct Gen {
+  std::vector<int> Values;
+};

--- a/clang-tools-extra/include-cleaner/test/Inputs/generated/gen.inc
+++ b/clang-tools-extra/include-cleaner/test/Inputs/generated/gen.inc
@@ -1,0 +1,4 @@
+#pragma once
+struct SpelledGen {
+  std::vector<int> Values;
+};

--- a/clang-tools-extra/include-cleaner/test/Inputs/inner.inc
+++ b/clang-tools-extra/include-cleaner/test/Inputs/inner.inc
@@ -1,0 +1,4 @@
+#pragma once
+struct Inner {
+  std::vector<int> Values;
+};

--- a/clang-tools-extra/include-cleaner/test/Inputs/outer.inc
+++ b/clang-tools-extra/include-cleaner/test/Inputs/outer.inc
@@ -1,0 +1,2 @@
+#pragma once
+#include "inner.inc"

--- a/clang-tools-extra/include-cleaner/test/Inputs/vector
+++ b/clang-tools-extra/include-cleaner/test/Inputs/vector
@@ -1,0 +1,4 @@
+#pragma once
+namespace std {
+template <typename T> struct vector {};
+} // namespace std

--- a/clang-tools-extra/include-cleaner/test/fragments-block-comment.cpp
+++ b/clang-tools-extra/include-cleaner/test/fragments-block-comment.cpp
@@ -1,0 +1,6 @@
+#include <vector> /* keep me */
+#include "gen.inc"
+
+Gen G;
+
+// RUN: clang-include-cleaner -print=changes %s --fragment-headers=.*\.inc$ --fragment-dependency-comment-format='needed by {0}' -- -I%S/Inputs/ | count 0

--- a/clang-tools-extra/include-cleaner/test/fragments-empty-comment.cpp
+++ b/clang-tools-extra/include-cleaner/test/fragments-empty-comment.cpp
@@ -1,0 +1,6 @@
+#include <vector>
+#include "gen.inc"
+
+Gen G;
+
+// RUN: clang-include-cleaner -print=changes %s --fragment-headers=.*\.inc$ -- -I%S/Inputs/ | count 0

--- a/clang-tools-extra/include-cleaner/test/fragments-multi.cpp
+++ b/clang-tools-extra/include-cleaner/test/fragments-multi.cpp
@@ -1,0 +1,10 @@
+#include <vector>
+#include "a.inc"
+#include "b.inc"
+
+A AValue;
+B BValue;
+
+// RUN: clang-include-cleaner -print=changes %s --fragment-headers=.*\.inc$ --fragment-dependency-comment-format='needed by {0}' -- -I%S/Inputs/ | FileCheck --check-prefix=CHANGES %s
+// CHANGES: ~ <vector> @Line:1 // needed by "a.inc", "b.inc"
+// CHANGES-NOT: - <vector>

--- a/clang-tools-extra/include-cleaner/test/fragments-nonrecursive.cpp
+++ b/clang-tools-extra/include-cleaner/test/fragments-nonrecursive.cpp
@@ -1,0 +1,5 @@
+#include <vector>
+#include "outer.inc"
+
+// RUN: clang-include-cleaner -print=changes %s --fragment-headers=.*\.inc$ -- -I%S/Inputs/ | FileCheck --check-prefix=CHANGES %s
+// CHANGES: - <vector> @Line:1

--- a/clang-tools-extra/include-cleaner/test/fragments-spelled-path.cpp
+++ b/clang-tools-extra/include-cleaner/test/fragments-spelled-path.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+#include "generated/gen.inc"
+
+SpelledGen G;
+
+// RUN: clang-include-cleaner -print=changes %s --fragment-headers='generated/gen\.inc' --fragment-dependency-comment-format='needed by {0}' -- -I%S/Inputs/ | FileCheck --check-prefix=CHANGES %s
+// CHANGES: ~ <vector> @Line:1 // needed by "generated/gen.inc"
+// CHANGES-NOT: - <vector>

--- a/clang-tools-extra/include-cleaner/test/fragments.cpp
+++ b/clang-tools-extra/include-cleaner/test/fragments.cpp
@@ -1,0 +1,16 @@
+#include <vector>
+#include "gen.inc"
+
+Gen G;
+
+// RUN: clang-include-cleaner -print=changes %s --fragment-headers=.*\\.inc$ --fragment-dependency-comment-format='needed by {0}' -- -I%S/Inputs/ | FileCheck --check-prefix=CHANGES %s
+// CHANGES: ~ <vector> @Line:1 // needed by "gen.inc"
+// CHANGES-NOT: - <vector>
+
+// RUN: clang-include-cleaner -print %s --fragment-headers=.*\\.inc$ --fragment-dependency-comment-format='needed by {0}' -- -I%S/Inputs/ | FileCheck --check-prefix=PRINT %s
+// PRINT: #include <vector> // needed by "gen.inc"
+
+// RUN: cp %s %t.cpp
+// RUN: clang-include-cleaner -edit %t.cpp --fragment-headers=.*\\.inc$ --fragment-dependency-comment-format='IWYU pragma: keep' -- -I%S/Inputs/
+// RUN: FileCheck --check-prefix=EDIT %s < %t.cpp
+// EDIT: #include <vector> // IWYU pragma: keep

--- a/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
+++ b/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
@@ -31,8 +31,15 @@
 
 namespace clang {
 namespace include_cleaner {
+
 namespace {
 namespace cl = llvm::cl;
+
+llvm::SmallVector<Decl *> topLevelDecls(ASTContext &Ctx);
+std::function<bool(llvm::StringRef)> matchesAny(llvm::StringRef RegexFlag,
+                                                bool AnchorToSuffix);
+std::function<bool(const Header &)> headerFilter();
+std::function<bool(llvm::StringRef)> fragmentHeaderFilter();
 
 llvm::StringRef Overview = llvm::StringLiteral(R"(
 clang-include-cleaner analyzes the #include directives in source code.
@@ -69,6 +76,24 @@ cl::opt<std::string> IgnoreHeaders{
     "ignore-headers",
     cl::desc("A comma-separated list of regexes to match against suffix of a "
              "header, and disable analysis if matched."),
+    cl::init(""),
+    cl::cat(IncludeCleaner),
+};
+
+cl::opt<std::string> FragmentHeaders{
+    "fragment-headers",
+    cl::desc("A comma-separated list of regular expressions matched against "
+             "normalized include paths. Matching direct includes are treated "
+             "as fragments of the main file."),
+    cl::init(""),
+    cl::cat(IncludeCleaner),
+};
+
+cl::opt<std::string> FragmentDependencyCommentFormat{
+    "fragment-dependency-comment-format",
+    cl::desc("Append this trailing comment to includes that are used only by "
+             "fragment headers. Use {0} for the matched fragment include "
+             "spellings."),
     cl::init(""),
     cl::cat(IncludeCleaner),
 };
@@ -130,15 +155,23 @@ format::FormatStyle getStyle(llvm::StringRef Filename) {
 
 class Action : public clang::ASTFrontendAction {
 public:
-  Action(llvm::function_ref<bool(llvm::StringRef)> HeaderFilter,
+  Action(std::function<bool(const Header &)> HeaderFilter,
+         std::function<bool(llvm::StringRef)> FragmentHeaderFilter,
+         std::string FragmentDependencyCommentFormat,
          llvm::StringMap<std::string> &EditedFiles)
-      : HeaderFilter(HeaderFilter), EditedFiles(EditedFiles) {}
+      : HeaderFilter(std::move(HeaderFilter)),
+        FragmentHeaderFilter(std::move(FragmentHeaderFilter)),
+        FragmentDependencyCommentFormat(
+            std::move(FragmentDependencyCommentFormat)),
+        EditedFiles(EditedFiles) {}
 
 private:
   RecordedAST AST;
   RecordedPP PP;
   PragmaIncludes PI;
-  llvm::function_ref<bool(llvm::StringRef)> HeaderFilter;
+  std::function<bool(const Header &)> HeaderFilter;
+  std::function<bool(llvm::StringRef)> FragmentHeaderFilter;
+  std::string FragmentDependencyCommentFormat;
   llvm::StringMap<std::string> &EditedFiles;
 
   bool BeginInvocation(CompilerInstance &CI) override {
@@ -192,9 +225,13 @@ private:
     SM.getFileManager().makeAbsolutePath(AbsPath);
     llvm::StringRef Code = SM.getBufferData(SM.getMainFileID());
 
+    AnalysisOptions AnalyzeOptions;
+    AnalyzeOptions.HeaderFilter = HeaderFilter;
+    AnalyzeOptions.FragmentHeaderFilter = FragmentHeaderFilter;
+    llvm::SmallVector<Decl *> RootDecls = topLevelDecls(*AST.Ctx);
     auto Results =
-        analyze(AST.Roots, PP.MacroReferences, PP.Includes, &PI,
-                getCompilerInstance().getPreprocessor(), HeaderFilter);
+        analyze(RootDecls, PP.MacroReferences, PP.Includes, &PI,
+                getCompilerInstance().getPreprocessor(), AnalyzeOptions);
 
     if (!Insert) {
       llvm::errs()
@@ -213,18 +250,34 @@ private:
     }
 
     if (!Insert || DisableInsert)
-      Results.Missing.clear();
+      Results.MissingIncludes.clear();
     if (!Remove || DisableRemove)
       Results.Unused.clear();
-    std::string Final = fixIncludes(Results, AbsPath, Code, getStyle(AbsPath));
+    format::FormatStyle Style = getStyle(AbsPath);
+    FixIncludesOptions FixOptions;
+    FixOptions.FragmentDependencyCommentFormat =
+        FragmentDependencyCommentFormat;
+    IncludeFixes Fixes =
+        computeIncludeFixes(Results, AbsPath, Code, Style, FixOptions);
+    auto Positioned = cantFail(
+        format::cleanupAroundReplacements(Code, Fixes.Replacements, Style));
+    std::string Final =
+        cantFail(tooling::applyAllReplacements(Code, Positioned));
 
     if (Print.getNumOccurrences()) {
       switch (Print) {
       case PrintStyle::Changes:
         for (const Include *I : Results.Unused)
           llvm::outs() << "- " << I->quote() << " @Line:" << I->Line << "\n";
-        for (const auto &[I, _] : Results.Missing)
+        for (const auto &[I, _] : Results.MissingIncludes)
           llvm::outs() << "+ " << I << "\n";
+        for (const auto &Comment : Fixes.FragmentComments) {
+          if (!Comment.Replacement)
+            continue;
+          llvm::outs() << "~ " << Comment.Preserved->quote()
+                       << " @Line:" << Comment.Preserved->Line << " // "
+                       << Comment.Text << "\n";
+        }
         break;
       case PrintStyle::Final:
         llvm::outs() << Final;
@@ -232,7 +285,7 @@ private:
       }
     }
 
-    if (!Results.Missing.empty() || !Results.Unused.empty())
+    if (!Fixes.Replacements.empty())
       EditedFiles.try_emplace(AbsPath, Final);
   }
 
@@ -246,17 +299,24 @@ private:
       return;
     }
     writeHTMLReport(AST.Ctx->getSourceManager().getMainFileID(), PP.Includes,
-                    AST.Roots, PP.MacroReferences, *AST.Ctx,
+                    topLevelDecls(*AST.Ctx), PP.MacroReferences, *AST.Ctx,
                     getCompilerInstance().getPreprocessor(), &PI, OS);
   }
 };
 class ActionFactory : public tooling::FrontendActionFactory {
 public:
-  ActionFactory(llvm::function_ref<bool(llvm::StringRef)> HeaderFilter)
-      : HeaderFilter(HeaderFilter) {}
+  ActionFactory(std::function<bool(const Header &)> HeaderFilter,
+                std::function<bool(llvm::StringRef)> FragmentHeaderFilter,
+                std::string FragmentDependencyCommentFormat)
+      : HeaderFilter(std::move(HeaderFilter)),
+        FragmentHeaderFilter(std::move(FragmentHeaderFilter)),
+        FragmentDependencyCommentFormat(
+            std::move(FragmentDependencyCommentFormat)) {}
 
   std::unique_ptr<clang::FrontendAction> create() override {
-    return std::make_unique<Action>(HeaderFilter, EditedFiles);
+    return std::make_unique<Action>(HeaderFilter, FragmentHeaderFilter,
+                                    FragmentDependencyCommentFormat,
+                                    EditedFiles);
   }
 
   const llvm::StringMap<std::string> &editedFiles() const {
@@ -264,19 +324,31 @@ public:
   }
 
 private:
-  llvm::function_ref<bool(llvm::StringRef)> HeaderFilter;
+  std::function<bool(const Header &)> HeaderFilter;
+  std::function<bool(llvm::StringRef)> FragmentHeaderFilter;
+  std::string FragmentDependencyCommentFormat;
   // Map from file name to final code with the include edits applied.
   llvm::StringMap<std::string> EditedFiles;
 };
 
+llvm::SmallVector<Decl *> topLevelDecls(ASTContext &Ctx) {
+  llvm::SmallVector<Decl *> Decls;
+  for (Decl *D : Ctx.getTranslationUnitDecl()->decls())
+    Decls.push_back(D);
+  return Decls;
+}
+
 // Compiles a regex list into a function that return true if any match a header.
 // Prints and returns nullptr if any regexes are invalid.
-std::function<bool(llvm::StringRef)> matchesAny(llvm::StringRef RegexFlag) {
+std::function<bool(llvm::StringRef)> matchesAny(llvm::StringRef RegexFlag,
+                                                bool AnchorToSuffix) {
   auto FilterRegs = std::make_shared<std::vector<llvm::Regex>>();
   llvm::SmallVector<llvm::StringRef> Headers;
   RegexFlag.split(Headers, ',', -1, /*KeepEmpty=*/false);
   for (auto HeaderPattern : Headers) {
-    std::string AnchoredPattern = "(" + HeaderPattern.str() + ")$";
+    std::string AnchoredPattern = HeaderPattern.str();
+    if (AnchorToSuffix)
+      AnchoredPattern = "(" + AnchoredPattern + ")$";
     llvm::Regex CompiledRegex(AnchoredPattern);
     std::string RegexError;
     if (!CompiledRegex.isValid(RegexError)) {
@@ -295,19 +367,24 @@ std::function<bool(llvm::StringRef)> matchesAny(llvm::StringRef RegexFlag) {
   };
 }
 
-std::function<bool(llvm::StringRef)> headerFilter() {
-  auto OnlyMatches = matchesAny(OnlyHeaders);
-  auto IgnoreMatches = matchesAny(IgnoreHeaders);
+std::function<bool(const Header &)> headerFilter() {
+  auto OnlyMatches = matchesAny(OnlyHeaders, /*AnchorToSuffix=*/true);
+  auto IgnoreMatches = matchesAny(IgnoreHeaders, /*AnchorToSuffix=*/true);
   if (!OnlyMatches || !IgnoreMatches)
     return nullptr;
 
-  return [OnlyMatches, IgnoreMatches](llvm::StringRef Header) {
-    if (!OnlyHeaders.empty() && !OnlyMatches(Header))
+  return [OnlyMatches, IgnoreMatches](const Header &Header) {
+    llvm::StringRef Path = Header.resolvedPath();
+    if (!OnlyHeaders.empty() && !OnlyMatches(Path))
       return true;
-    if (!IgnoreHeaders.empty() && IgnoreMatches(Header))
+    if (!IgnoreHeaders.empty() && IgnoreMatches(Path))
       return true;
     return false;
   };
+}
+
+std::function<bool(llvm::StringRef)> fragmentHeaderFilter() {
+  return matchesAny(FragmentHeaders, /*AnchorToSuffix=*/false);
 }
 
 // Maps absolute path of each files of each compilation commands to the
@@ -388,9 +465,11 @@ int main(int argc, const char **argv) {
   clang::tooling::ClangTool Tool(CDB, OptionsParser->getSourcePathList());
 
   auto HeaderFilter = headerFilter();
-  if (!HeaderFilter)
+  auto FragmentHeaderFilter = fragmentHeaderFilter();
+  if (!HeaderFilter || !FragmentHeaderFilter)
     return 1; // error already reported.
-  ActionFactory Factory(HeaderFilter);
+  ActionFactory Factory(HeaderFilter, FragmentHeaderFilter,
+                        FragmentDependencyCommentFormat);
   auto ErrorCode = Tool.run(&Factory);
   if (Edit) {
     for (const auto &NameAndContent : Factory.editedFiles()) {

--- a/clang-tools-extra/include-cleaner/unittests/AnalysisTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/AnalysisTest.cpp
@@ -39,6 +39,14 @@
 #include <vector>
 
 namespace clang::include_cleaner {
+
+static std::vector<Decl *> topLevelDecls(TestAST &AST) {
+  std::vector<Decl *> Decls;
+  for (auto *D : AST.context().getTranslationUnitDecl()->decls())
+    Decls.push_back(D);
+  return Decls;
+}
+
 namespace {
 using testing::_;
 using testing::AllOf;
@@ -269,7 +277,8 @@ int x = a + c;
 
   const Include *B = PP.Includes.atLine(3);
   ASSERT_EQ(B->Spelled, "b.h");
-  EXPECT_THAT(Results.Missing, ElementsAre(Pair("\"c.h\"", Header(CHeader))));
+  EXPECT_THAT(Results.MissingIncludes,
+              ElementsAre(Pair("\"c.h\"", Header(CHeader))));
   EXPECT_THAT(Results.Unused, ElementsAre(B));
 }
 
@@ -317,7 +326,7 @@ TEST_F(AnalyzeTest, ResourceDirIsIgnored) {
   TestAST AST(Inputs);
   auto Results = analyze({}, {}, PP.Includes, &PI, AST.preprocessor());
   EXPECT_THAT(Results.Unused, testing::IsEmpty());
-  EXPECT_THAT(Results.Missing, testing::IsEmpty());
+  EXPECT_THAT(Results.MissingIncludes, testing::IsEmpty());
 }
 
 TEST_F(AnalyzeTest, DifferentHeaderSameSpelling) {
@@ -342,7 +351,7 @@ TEST_F(AnalyzeTest, DifferentHeaderSameSpelling) {
     DeclsInTU.push_back(D);
   auto Results = analyze(DeclsInTU, {}, PP.Includes, &PI, AST.preprocessor());
   EXPECT_THAT(Results.Unused, testing::IsEmpty());
-  EXPECT_THAT(Results.Missing, testing::IsEmpty());
+  EXPECT_THAT(Results.MissingIncludes, testing::IsEmpty());
 }
 
 TEST_F(AnalyzeTest, SpellingIncludesWithSymlinks) {
@@ -368,33 +377,361 @@ TEST_F(AnalyzeTest, SpellingIncludesWithSymlinks) {
                            /*ModificationTime=*/{});
 
   TestAST AST(Inputs);
-  std::vector<Decl *> DeclsInTU;
-  for (auto *D : AST.context().getTranslationUnitDecl()->decls())
-    DeclsInTU.push_back(D);
+  std::vector<Decl *> DeclsInTU = topLevelDecls(AST);
   auto Results = analyze(DeclsInTU, {}, PP.Includes, &PI, AST.preprocessor());
   // Check that we're spelling header using the symlink, and not underlying
   // path.
-  EXPECT_THAT(Results.Missing, testing::ElementsAre(Pair("\"inner.h\"", _)));
+  EXPECT_THAT(Results.MissingIncludes,
+              testing::ElementsAre(Pair("\"inner.h\"", _)));
   // header.h should be unused.
   EXPECT_THAT(Results.Unused, Not(testing::IsEmpty()));
 
   {
     // Make sure filtering is also applied to symlink, not underlying file.
-    auto HeaderFilter = [](llvm::StringRef Path) { return Path == "inner.h"; };
-    Results = analyze(DeclsInTU, {}, PP.Includes, &PI, AST.preprocessor(),
-                      HeaderFilter);
-    EXPECT_THAT(Results.Missing, testing::ElementsAre(Pair("\"inner.h\"", _)));
+    AnalysisOptions Options;
+    Options.HeaderFilter = [](const Header &H) {
+      return H.resolvedPath() == "inner.h";
+    };
+    Results =
+        analyze(DeclsInTU, {}, PP.Includes, &PI, AST.preprocessor(), Options);
+    EXPECT_THAT(Results.MissingIncludes,
+                testing::ElementsAre(Pair("\"inner.h\"", _)));
     // header.h should be unused.
     EXPECT_THAT(Results.Unused, Not(testing::IsEmpty()));
   }
   {
-    auto HeaderFilter = [](llvm::StringRef Path) { return Path == "header.h"; };
-    Results = analyze(DeclsInTU, {}, PP.Includes, &PI, AST.preprocessor(),
-                      HeaderFilter);
+    AnalysisOptions Options;
+    Options.HeaderFilter = [](const Header &H) {
+      return H.resolvedPath() == "header.h";
+    };
+    Results =
+        analyze(DeclsInTU, {}, PP.Includes, &PI, AST.preprocessor(), Options);
     // header.h should be ignored now.
     EXPECT_THAT(Results.Unused, Not(testing::IsEmpty()));
-    EXPECT_THAT(Results.Missing, testing::ElementsAre(Pair("\"inner.h\"", _)));
+    EXPECT_THAT(Results.MissingIncludes,
+                testing::ElementsAre(Pair("\"inner.h\"", _)));
   }
+}
+
+TEST_F(AnalyzeTest, FragmentDeclUsePreservesInclude) {
+  Inputs.Code = R"cpp(
+#include "support.h"
+#include "gen.inc"
+Holder H;
+)cpp";
+  Inputs.ExtraFiles["support.h"] = guard(R"cpp(
+  namespace support {
+  template <typename> struct vector {};
+  }
+  )cpp");
+  Inputs.ExtraFiles["gen.inc"] = guard(R"cpp(
+  struct Holder {
+    support::vector<int> Values;
+  };
+  )cpp");
+
+  TestAST AST(Inputs);
+  AnalysisOptions Options;
+  Options.FragmentHeaderFilter = [](llvm::StringRef Path) {
+    return Path.ends_with(".inc");
+  };
+  auto Results = analyze(topLevelDecls(AST), PP.MacroReferences, PP.Includes,
+                         &PI, AST.preprocessor(), Options);
+
+  const Include *Vector = PP.Includes.atLine(2);
+  const Include *Fragment = PP.Includes.atLine(3);
+  ASSERT_NE(Vector, nullptr);
+  ASSERT_NE(Fragment, nullptr);
+  EXPECT_THAT(Results.Unused, testing::IsEmpty());
+  ASSERT_THAT(Results.FragmentDependencies, testing::SizeIs(1));
+  EXPECT_EQ(Results.FragmentDependencies.front().Preserved, Vector);
+  EXPECT_THAT(Results.FragmentDependencies.front().Fragments,
+              ElementsAre(Fragment));
+}
+
+TEST_F(AnalyzeTest, FragmentDependencyExcludedWhenAlsoUsedInMainFile) {
+  Inputs.Code = R"cpp(
+#include "support.h"
+#include "gen.inc"
+support::vector<int> MainValues;
+)cpp";
+  Inputs.ExtraFiles["support.h"] = guard(R"cpp(
+  namespace support {
+  template <typename> struct vector {};
+  }
+  )cpp");
+  Inputs.ExtraFiles["gen.inc"] = guard(R"cpp(
+  struct Holder {
+    support::vector<int> Values;
+  };
+  )cpp");
+
+  TestAST AST(Inputs);
+  AnalysisOptions Options;
+  Options.FragmentHeaderFilter = [](llvm::StringRef Path) {
+    return Path.ends_with(".inc");
+  };
+  auto Results = analyze(topLevelDecls(AST), PP.MacroReferences, PP.Includes,
+                         &PI, AST.preprocessor(), Options);
+
+  const Include *Support = PP.Includes.atLine(2);
+  ASSERT_NE(Support, nullptr);
+  EXPECT_THAT(Results.Unused, testing::Not(Contains(Support)));
+  EXPECT_THAT(Results.FragmentDependencies, testing::IsEmpty());
+}
+
+TEST_F(AnalyzeTest, MultipleFragmentsPreserveSingleInclude) {
+  Inputs.Code = R"cpp(
+#include "support.h"
+#include "a.inc"
+#include "b.inc"
+A AValue;
+B BValue;
+)cpp";
+  Inputs.ExtraFiles["support.h"] = guard(R"cpp(
+  namespace support {
+  template <typename> struct vector {};
+  }
+  )cpp");
+  Inputs.ExtraFiles["a.inc"] = guard(R"cpp(
+  struct A {
+    support::vector<int> Values;
+  };
+  )cpp");
+  Inputs.ExtraFiles["b.inc"] = guard(R"cpp(
+  struct B {
+    support::vector<int> Values;
+  };
+  )cpp");
+
+  TestAST AST(Inputs);
+  AnalysisOptions Options;
+  Options.FragmentHeaderFilter = [](llvm::StringRef Path) {
+    return Path.ends_with(".inc");
+  };
+  auto Results = analyze(topLevelDecls(AST), PP.MacroReferences, PP.Includes,
+                         &PI, AST.preprocessor(), Options);
+
+  const Include *Support = PP.Includes.atLine(2);
+  const Include *FragmentA = PP.Includes.atLine(3);
+  const Include *FragmentB = PP.Includes.atLine(4);
+  ASSERT_NE(Support, nullptr);
+  ASSERT_NE(FragmentA, nullptr);
+  ASSERT_NE(FragmentB, nullptr);
+  EXPECT_THAT(Results.Unused, testing::IsEmpty());
+  ASSERT_THAT(Results.FragmentDependencies, testing::SizeIs(1));
+  EXPECT_EQ(Results.FragmentDependencies.front().Preserved, Support);
+  EXPECT_THAT(Results.FragmentDependencies.front().Fragments,
+              ElementsAre(FragmentA, FragmentB));
+}
+
+TEST_F(AnalyzeTest, FragmentDependencyDeduplicatesFragmentReason) {
+  Inputs.Code = R"cpp(
+#include "support.h"
+#include "gen.inc"
+Holder H;
+)cpp";
+  Inputs.ExtraFiles["support.h"] = guard(R"cpp(
+  namespace support {
+  template <typename> struct vector {};
+  }
+  )cpp");
+  Inputs.ExtraFiles["gen.inc"] = guard(R"cpp(
+  struct Holder {
+    support::vector<int> First;
+    support::vector<int> Second;
+  };
+  )cpp");
+
+  TestAST AST(Inputs);
+  AnalysisOptions Options;
+  Options.FragmentHeaderFilter = [](llvm::StringRef Path) {
+    return Path.ends_with(".inc");
+  };
+  auto Results = analyze(topLevelDecls(AST), PP.MacroReferences, PP.Includes,
+                         &PI, AST.preprocessor(), Options);
+
+  const Include *Fragment = PP.Includes.atLine(3);
+  ASSERT_NE(Fragment, nullptr);
+  ASSERT_THAT(Results.FragmentDependencies, testing::SizeIs(1));
+  EXPECT_THAT(Results.FragmentDependencies.front().Fragments,
+              ElementsAre(Fragment));
+}
+
+TEST_F(AnalyzeTest, DuplicateFragmentIncludesPreserveIncludeWithoutProvenance) {
+  Inputs.Code = R"cpp(
+#include "support.h"
+#include "gen.inc"
+#include "./gen.inc"
+)cpp";
+  Inputs.ExtraFiles["support.h"] = guard("struct SupportType {};");
+  Inputs.ExtraFiles["gen.inc"] = "void use(SupportType);\n";
+
+  TestAST AST(Inputs);
+  AnalysisOptions Options;
+  Options.FragmentHeaderFilter = [](llvm::StringRef Path) {
+    return Path.ends_with(".inc");
+  };
+  auto Results = analyze(topLevelDecls(AST), PP.MacroReferences, PP.Includes,
+                         &PI, AST.preprocessor(), Options);
+
+  const Include *Support = PP.Includes.atLine(2);
+  ASSERT_NE(Support, nullptr);
+  EXPECT_THAT(Results.Unused, testing::Not(Contains(Support)));
+  EXPECT_THAT(Results.FragmentDependencies, testing::IsEmpty());
+}
+
+TEST_F(AnalyzeTest, FragmentMacroUsePreservesInclude) {
+  Inputs.Code = R"cpp(
+#include "macro.h"
+#include "gen.inc"
+)cpp";
+  Inputs.ExtraFiles["macro.h"] = guard("#define FOO 42");
+  Inputs.ExtraFiles["gen.inc"] = guard("int Value = FOO;");
+
+  TestAST AST(Inputs);
+  AnalysisOptions Options;
+  Options.FragmentHeaderFilter = [](llvm::StringRef Path) {
+    return Path.ends_with(".inc");
+  };
+  auto Results = analyze(topLevelDecls(AST), PP.MacroReferences, PP.Includes,
+                         &PI, AST.preprocessor(), Options);
+
+  const Include *Macro = PP.Includes.atLine(2);
+  const Include *Fragment = PP.Includes.atLine(3);
+  ASSERT_NE(Macro, nullptr);
+  ASSERT_NE(Fragment, nullptr);
+  EXPECT_THAT(Results.Unused, testing::IsEmpty());
+  ASSERT_THAT(Results.FragmentDependencies, testing::SizeIs(1));
+  EXPECT_EQ(Results.FragmentDependencies.front().Preserved, Macro);
+  EXPECT_THAT(Results.FragmentDependencies.front().Fragments,
+              ElementsAre(Fragment));
+}
+
+TEST_F(AnalyzeTest, FragmentHeadersAreNotRecursive) {
+  Inputs.Code = R"cpp(
+#include "support.h"
+#include "outer.inc"
+)cpp";
+  Inputs.ExtraFiles["support.h"] = guard(R"cpp(
+  namespace support {
+  template <typename> struct vector {};
+  }
+  )cpp");
+  Inputs.ExtraFiles["outer.inc"] = guard(R"cpp(
+  #include "inner.inc"
+  )cpp");
+  Inputs.ExtraFiles["inner.inc"] = guard(R"cpp(
+  struct Inner {
+    support::vector<int> Values;
+  };
+  )cpp");
+
+  TestAST AST(Inputs);
+  AnalysisOptions Options;
+  Options.FragmentHeaderFilter = [](llvm::StringRef Path) {
+    return Path.ends_with(".inc");
+  };
+  auto Results = analyze(topLevelDecls(AST), PP.MacroReferences, PP.Includes,
+                         &PI, AST.preprocessor(), Options);
+
+  const Include *Support = PP.Includes.atLine(2);
+  ASSERT_NE(Support, nullptr);
+  EXPECT_THAT(Results.Unused, Contains(Support));
+  EXPECT_THAT(Results.FragmentDependencies, testing::IsEmpty());
+}
+
+TEST_F(AnalyzeTest, FragmentHeaderMatcherFallsBackToSpelledPath) {
+  Inputs.ExtraArgs.push_back("-I/headers");
+  Inputs.Code = R"cpp(
+#include "support.h"
+#include "generated/gen.inc"
+Holder H;
+)cpp";
+  Inputs.ExtraFiles["/headers/support.h"] = guard(R"cpp(
+  namespace support {
+  template <typename> struct vector {};
+  }
+  )cpp");
+  Inputs.ExtraFiles["/headers/generated/gen.inc"] = guard(R"cpp(
+  struct Holder {
+    support::vector<int> Values;
+  };
+  )cpp");
+
+  TestAST AST(Inputs);
+  const Include *Fragment = PP.Includes.atLine(3);
+  ASSERT_NE(Fragment, nullptr);
+  ASSERT_TRUE(Fragment->Resolved.has_value());
+  EXPECT_NE(normalizePath(Fragment->Resolved->getName()).str(),
+            "generated/gen.inc");
+
+  AnalysisOptions Options;
+  Options.FragmentHeaderFilter = [](llvm::StringRef Path) {
+    return Path == "generated/gen.inc";
+  };
+  auto Results = analyze(topLevelDecls(AST), PP.MacroReferences, PP.Includes,
+                         &PI, AST.preprocessor(), Options);
+
+  const Include *Support = PP.Includes.atLine(2);
+  ASSERT_NE(Support, nullptr);
+  ASSERT_THAT(Results.FragmentDependencies, testing::SizeIs(1));
+  EXPECT_EQ(Results.FragmentDependencies.front().Preserved, Support);
+  EXPECT_THAT(Results.FragmentDependencies.front().Fragments,
+              ElementsAre(Fragment));
+}
+
+TEST_F(AnalyzeTest, FragmentMissingIncludeRecordsOrigin) {
+  Inputs.Code = R"cpp(
+#include "gen.inc"
+)cpp";
+  Inputs.ExtraFiles["foo.h"] = guard("int foo();");
+  Inputs.ExtraFiles["gen.inc"] = guard(R"cpp(
+  #include "foo.h"
+  int Value = foo();
+  )cpp");
+
+  TestAST AST(Inputs);
+  AnalysisOptions Options;
+  Options.FragmentHeaderFilter = [](llvm::StringRef Path) {
+    return Path.ends_with(".inc");
+  };
+  auto Results = analyze(topLevelDecls(AST), PP.MacroReferences, PP.Includes,
+                         &PI, AST.preprocessor(), Options);
+
+  const Include *Fragment = PP.Includes.atLine(2);
+  ASSERT_NE(Fragment, nullptr);
+  ASSERT_THAT(Results.MissingRefs, testing::SizeIs(1));
+  EXPECT_EQ(Results.MissingRefs.front().Origin,
+            SymbolReferenceOrigin::Fragment);
+  EXPECT_EQ(Results.MissingRefs.front().FragmentInclude, Fragment);
+  EXPECT_EQ(Results.MissingIncludes.front().first, "\"foo.h\"");
+}
+
+TEST_F(AnalyzeTest, DuplicateFragmentIncludesSuppressMissingProvenance) {
+  Inputs.Code = R"cpp(
+#include "gen.inc"
+#include "./gen.inc"
+)cpp";
+  Inputs.ExtraFiles["foo.h"] = guard("int foo();");
+  Inputs.ExtraFiles["gen.inc"] = R"cpp(
+  #include "foo.h"
+  auto useFoo() -> decltype(foo());
+  )cpp";
+
+  TestAST AST(Inputs);
+  AnalysisOptions Options;
+  Options.FragmentHeaderFilter = [](llvm::StringRef Path) {
+    return Path.ends_with(".inc");
+  };
+  auto Results = analyze(topLevelDecls(AST), PP.MacroReferences, PP.Includes,
+                         &PI, AST.preprocessor(), Options);
+
+  ASSERT_FALSE(Results.MissingRefs.empty());
+  EXPECT_EQ(Results.MissingRefs.front().Origin,
+            SymbolReferenceOrigin::Fragment);
+  EXPECT_EQ(Results.MissingRefs.front().FragmentInclude, nullptr);
+  EXPECT_EQ(Results.MissingIncludes.front().first, "\"foo.h\"");
 }
 
 // Make sure that the references to implicit operator new/delete are reported as
@@ -422,7 +759,7 @@ TEST_F(AnalyzeTest, ImplicitOperatorNewDeleteNotMissing) {
   for (auto *D : AST.context().getTranslationUnitDecl()->decls())
     DeclsInTU.push_back(D);
   auto Results = analyze(DeclsInTU, {}, PP.Includes, &PI, AST.preprocessor());
-  EXPECT_THAT(Results.Missing, testing::IsEmpty());
+  EXPECT_THAT(Results.MissingIncludes, testing::IsEmpty());
 }
 
 TEST_F(AnalyzeTest, ImplicitOperatorNewDeleteNotUnused) {
@@ -467,14 +804,14 @@ TEST(FixIncludes, Basic) {
   Inc.add(I);
 
   AnalysisResults Results;
-  Results.Missing.emplace_back("\"aa.h\"", Header(""));
-  Results.Missing.emplace_back("\"ab.h\"", Header(""));
-  Results.Missing.emplace_back("<e.h>", Header(""));
+  Results.MissingIncludes.emplace_back("\"aa.h\"", Header(""));
+  Results.MissingIncludes.emplace_back("\"ab.h\"", Header(""));
+  Results.MissingIncludes.emplace_back("<e.h>", Header(""));
   Results.Unused.push_back(Inc.atLine(3));
   Results.Unused.push_back(Inc.atLine(4));
 
   EXPECT_EQ(fixIncludes(Results, "d.cc", Code, format::getLLVMStyle()),
-R"cpp(#include "d.h"
+            R"cpp(#include "d.h"
 #include "a.h"
 #include "aa.h"
 #include "ab.h"
@@ -482,11 +819,208 @@ R"cpp(#include "d.h"
 )cpp");
 
   Results = {};
-  Results.Missing.emplace_back("\"d.h\"", Header(""));
+  Results.MissingIncludes.emplace_back("\"d.h\"", Header(""));
   Code = R"cpp(#include "a.h")cpp";
   EXPECT_EQ(fixIncludes(Results, "d.cc", Code, format::getLLVMStyle()),
-R"cpp(#include "d.h"
+            R"cpp(#include "d.h"
 #include "a.h")cpp");
+}
+
+TEST(FixIncludes, FragmentDependencyComments) {
+  llvm::StringRef Code = R"cpp(#include "a.h"
+#include "gen.inc"
+#include "existing.h" // needed by "gen.inc"
+#include "conflict.h" // keep me
+)cpp";
+
+  Includes Inc;
+  Include A;
+  A.Spelled = "a.h";
+  A.Line = 1;
+  Inc.add(A);
+  Include Gen;
+  Gen.Spelled = "gen.inc";
+  Gen.Line = 2;
+  Inc.add(Gen);
+  Include Existing;
+  Existing.Spelled = "existing.h";
+  Existing.Line = 3;
+  Inc.add(Existing);
+  Include Conflict;
+  Conflict.Spelled = "conflict.h";
+  Conflict.Line = 4;
+  Inc.add(Conflict);
+
+  AnalysisResults Results;
+  Results.FragmentDependencies.push_back({Inc.atLine(1), {Inc.atLine(2)}});
+  Results.FragmentDependencies.push_back({Inc.atLine(3), {Inc.atLine(2)}});
+  Results.FragmentDependencies.push_back({Inc.atLine(4), {Inc.atLine(2)}});
+
+  FixIncludesOptions Options;
+  Options.FragmentDependencyCommentFormat = "needed by {0}";
+  IncludeFixes Fixes = computeIncludeFixes(Results, "d.cc", Code,
+                                           format::getLLVMStyle(), Options);
+
+  ASSERT_THAT(Fixes.FragmentComments, testing::SizeIs(3));
+  EXPECT_EQ(Fixes.FragmentComments[0].Status,
+            FragmentDependencyCommentStatus::CanInsert);
+  ASSERT_TRUE(Fixes.FragmentComments[0].Replacement.has_value());
+  EXPECT_EQ(Fixes.FragmentComments[1].Status,
+            FragmentDependencyCommentStatus::AlreadyPresent);
+  EXPECT_FALSE(Fixes.FragmentComments[1].Replacement.has_value());
+  EXPECT_EQ(Fixes.FragmentComments[2].Status,
+            FragmentDependencyCommentStatus::ConflictingComment);
+  EXPECT_FALSE(Fixes.FragmentComments[2].Replacement.has_value());
+
+  EXPECT_EQ(fixIncludes(Results, "d.cc", Code, format::getLLVMStyle(), Options),
+            R"cpp(#include "a.h" // needed by "gen.inc"
+#include "gen.inc"
+#include "existing.h" // needed by "gen.inc"
+#include "conflict.h" // keep me
+)cpp");
+}
+
+TEST(FixIncludes, FragmentDependencyCommentsEmptyFormat) {
+  llvm::StringRef Code = R"cpp(#include "a.h"
+#include "gen.inc"
+)cpp";
+
+  Includes Inc;
+  Include A;
+  A.Spelled = "a.h";
+  A.Line = 1;
+  Inc.add(A);
+  Include Gen;
+  Gen.Spelled = "gen.inc";
+  Gen.Line = 2;
+  Inc.add(Gen);
+
+  AnalysisResults Results;
+  Results.FragmentDependencies.push_back({Inc.atLine(1), {Inc.atLine(2)}});
+
+  IncludeFixes Fixes =
+      computeIncludeFixes(Results, "d.cc", Code, format::getLLVMStyle(), {});
+  EXPECT_THAT(Fixes.FragmentComments, testing::IsEmpty());
+  EXPECT_EQ(fixIncludes(Results, "d.cc", Code, format::getLLVMStyle()), Code);
+}
+
+TEST(FixIncludes, FragmentDependencyCommentsLiteralFormat) {
+  llvm::StringRef Code = R"cpp(#include "a.h"
+#include "gen.inc"
+)cpp";
+
+  Includes Inc;
+  Include A;
+  A.Spelled = "a.h";
+  A.Line = 1;
+  Inc.add(A);
+  Include Gen;
+  Gen.Spelled = "gen.inc";
+  Gen.Line = 2;
+  Inc.add(Gen);
+
+  AnalysisResults Results;
+  Results.FragmentDependencies.push_back({Inc.atLine(1), {Inc.atLine(2)}});
+
+  FixIncludesOptions Options;
+  Options.FragmentDependencyCommentFormat = "IWYU pragma: keep";
+  IncludeFixes Fixes = computeIncludeFixes(Results, "d.cc", Code,
+                                           format::getLLVMStyle(), Options);
+  ASSERT_THAT(Fixes.FragmentComments, testing::SizeIs(1));
+  EXPECT_EQ(Fixes.FragmentComments.front().Text, "IWYU pragma: keep");
+  EXPECT_EQ(fixIncludes(Results, "d.cc", Code, format::getLLVMStyle(), Options),
+            R"cpp(#include "a.h" // IWYU pragma: keep
+#include "gen.inc"
+)cpp");
+}
+
+TEST(FixIncludes, FragmentDependencyCommentsMultipleFragments) {
+  llvm::StringRef Code = R"cpp(#include "a.h"
+#include "a.inc"
+#include "b.inc"
+)cpp";
+
+  Includes Inc;
+  Include A;
+  A.Spelled = "a.h";
+  A.Line = 1;
+  Inc.add(A);
+  Include FragmentA;
+  FragmentA.Spelled = "a.inc";
+  FragmentA.Line = 2;
+  Inc.add(FragmentA);
+  Include FragmentB;
+  FragmentB.Spelled = "b.inc";
+  FragmentB.Line = 3;
+  Inc.add(FragmentB);
+
+  AnalysisResults Results;
+  Results.FragmentDependencies.push_back(
+      {Inc.atLine(1), {Inc.atLine(2), Inc.atLine(3)}});
+
+  FixIncludesOptions Options;
+  Options.FragmentDependencyCommentFormat = "needed by {0}";
+  IncludeFixes Fixes = computeIncludeFixes(Results, "d.cc", Code,
+                                           format::getLLVMStyle(), Options);
+  ASSERT_THAT(Fixes.FragmentComments, testing::SizeIs(1));
+  EXPECT_EQ(Fixes.FragmentComments.front().Text,
+            "needed by \"a.inc\", \"b.inc\"");
+}
+
+TEST(FixIncludes, FragmentDependencyCommentsBlockCommentConflict) {
+  llvm::StringRef Code = R"cpp(#include "a.h" /* keep me */
+#include "gen.inc"
+)cpp";
+
+  Includes Inc;
+  Include A;
+  A.Spelled = "a.h";
+  A.Line = 1;
+  Inc.add(A);
+  Include Gen;
+  Gen.Spelled = "gen.inc";
+  Gen.Line = 2;
+  Inc.add(Gen);
+
+  AnalysisResults Results;
+  Results.FragmentDependencies.push_back({Inc.atLine(1), {Inc.atLine(2)}});
+
+  FixIncludesOptions Options;
+  Options.FragmentDependencyCommentFormat = "needed by {0}";
+  IncludeFixes Fixes = computeIncludeFixes(Results, "d.cc", Code,
+                                           format::getLLVMStyle(), Options);
+  ASSERT_THAT(Fixes.FragmentComments, testing::SizeIs(1));
+  EXPECT_EQ(Fixes.FragmentComments.front().Status,
+            FragmentDependencyCommentStatus::ConflictingComment);
+  EXPECT_FALSE(Fixes.FragmentComments.front().Replacement.has_value());
+}
+
+TEST(FixIncludes, FragmentDependencyCommentsCRLFAndTrailingWhitespace) {
+  llvm::StringRef Code = "#include \"a.h\"  \r\n#include \"gen.inc\"\r\n";
+
+  Includes Inc;
+  Include A;
+  A.Spelled = "a.h";
+  A.Line = 1;
+  Inc.add(A);
+  Include Gen;
+  Gen.Spelled = "gen.inc";
+  Gen.Line = 2;
+  Inc.add(Gen);
+
+  AnalysisResults Results;
+  Results.FragmentDependencies.push_back({Inc.atLine(1), {Inc.atLine(2)}});
+
+  FixIncludesOptions Options;
+  Options.FragmentDependencyCommentFormat = "needed by {0}";
+  IncludeFixes Fixes = computeIncludeFixes(Results, "d.cc", Code,
+                                           format::getLLVMStyle(), Options);
+  ASSERT_THAT(Fixes.FragmentComments, testing::SizeIs(1));
+  ASSERT_TRUE(Fixes.FragmentComments.front().Replacement.has_value());
+  size_t ExpectedOffset = Code.find("  \r\n");
+  ASSERT_NE(ExpectedOffset, llvm::StringRef::npos);
+  EXPECT_EQ(Fixes.FragmentComments.front().Replacement->getOffset(),
+            ExpectedOffset);
 }
 
 MATCHER_P3(expandedAt, FileID, Offset, SM, "") {

--- a/clang-tools-extra/include-cleaner/unittests/RecordTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/RecordTest.cpp
@@ -209,8 +209,8 @@ TEST_F(RecordPPTest, CapturesMacroRefs) {
     #define $def^X 1
 
     // Refs, but not in main file.
-    #define Y X
-    int one = X;
+    #define Y $hdr^X
+    int one = $hdr^X;
   )cpp");
   llvm::Annotations MainFile(R"cpp(
     #define EARLY X // not a ref, no definition
@@ -244,11 +244,15 @@ TEST_F(RecordPPTest, CapturesMacroRefs) {
 
   std::vector<unsigned> RefOffsets;
   std::vector<unsigned> ExpOffsets; // Expansion locs of refs in macro locs.
+  std::vector<unsigned> HeaderOffsets;
   for (const auto &Ref : Recorded.MacroReferences) {
     if (Ref.Target == OrigX) {
       auto [FID, Off] = SM.getDecomposedLoc(Ref.RefLocation);
       if (FID == SM.getMainFileID()) {
         RefOffsets.push_back(Off);
+      } else if (FID == SM.translateFile(*AST.fileManager().getOptionalFileRef(
+                            "header.h"))) {
+        HeaderOffsets.push_back(Off);
       } else if (Ref.RefLocation.isMacroID() &&
                  SM.isWrittenInMainFile(SM.getExpansionLoc(Ref.RefLocation))) {
         ExpOffsets.push_back(
@@ -260,6 +264,7 @@ TEST_F(RecordPPTest, CapturesMacroRefs) {
   }
   EXPECT_THAT(RefOffsets, ElementsAreArray(MainFile.points()));
   EXPECT_THAT(ExpOffsets, ElementsAreArray(MainFile.points("exp")));
+  EXPECT_THAT(HeaderOffsets, ElementsAreArray(Header.points("hdr")));
 }
 
 TEST_F(RecordPPTest, CapturesConditionalMacroRefs) {
@@ -298,6 +303,68 @@ TEST_F(RecordPPTest, CapturesConditionalMacroRefs) {
     RefOffsets.push_back(Off);
   }
   EXPECT_THAT(RefOffsets, ElementsAreArray(MainFile.points()));
+}
+
+TEST_F(RecordPPTest, CapturesConditionalMacroRefsInDirectIncludes) {
+  llvm::Annotations Header(R"cpp(
+    #ifdef ^X
+    #endif
+
+    #if defined(^X)
+    #endif
+
+    #ifndef ^X
+    #endif
+
+    #ifdef Y
+    #elifdef ^X
+    #endif
+
+    #ifndef ^X
+    #elifndef ^X
+    #endif
+  )cpp");
+
+  Inputs.Code = R"cpp(
+    #define X 1
+    #include "header.h"
+  )cpp";
+  Inputs.ExtraFiles["header.h"] = Header.code();
+  Inputs.ExtraArgs.push_back("-std=c++2b");
+  auto AST = build();
+
+  std::vector<unsigned> RefOffsets;
+  SourceManager &SM = AST.sourceManager();
+  FileID HeaderID =
+      SM.translateFile(*AST.fileManager().getOptionalFileRef("header.h"));
+  for (const auto &Ref : Recorded.MacroReferences) {
+    auto [FID, Off] = SM.getDecomposedLoc(Ref.RefLocation);
+    ASSERT_EQ(FID, HeaderID);
+    EXPECT_EQ(Ref.RT, RefType::Ambiguous);
+    EXPECT_EQ("X", Ref.Target.macro().Name->getName());
+    RefOffsets.push_back(Off);
+  }
+  EXPECT_THAT(RefOffsets, ElementsAreArray(Header.points()));
+}
+
+TEST_F(RecordPPTest, DoesNotCaptureMacroRefsInTransitiveIncludes) {
+  Inputs.Code = R"cpp(
+    #define X 1
+    #include "header.h"
+  )cpp";
+  Inputs.ExtraFiles["header.h"] = R"cpp(
+    #include "nested.h"
+  )cpp";
+  Inputs.ExtraFiles["nested.h"] = R"cpp(
+    int one = X;
+
+    #ifdef X
+    #endif
+  )cpp";
+  Inputs.ExtraArgs.push_back("-std=c++2b");
+  build();
+
+  EXPECT_THAT(Recorded.MacroReferences, IsEmpty());
 }
 
 class PragmaIncludeTest : public ::testing::Test {

--- a/clang-tools-extra/include-cleaner/unittests/TypesTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/TypesTest.cpp
@@ -1,4 +1,4 @@
-//===-- RecordTest.cpp ----------------------------------------------------===//
+//===-- TypesTest.cpp -----------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-include-cleaner/Types.h"
+#include "TypesInternal.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/FileSystemOptions.h"
 #include "clang/Tooling/Inclusions/StandardLibrary.h"
@@ -96,6 +97,19 @@ TEST(RecordedIncludesTest, MatchVerbatimMixedAbsoluteRelative) {
   Inc.addSearchDirectory("/working/rel1/rel2");
   Inc.add(Include{"rel2/bar.h", Bar, SourceLocation(), 1});
   EXPECT_THAT(Inc.match(Header("<bar.h>")), IsEmpty());
+}
+
+TEST(NormalizePathTest, RemovesDotSegments) {
+  EXPECT_EQ(normalizePath("foo/./bar/../baz").str(), "foo/baz");
+  EXPECT_EQ(normalizePath("foo/bar/").str(), "foo/bar");
+}
+
+TEST(NormalizePathTest, CanonicalizesSeparators) {
+  EXPECT_EQ(normalizePath("foo\\bar").str(), "foo/bar");
+}
+
+TEST(NormalizePathTest, PreservesRootPath) {
+  EXPECT_EQ(normalizePath("/").str(), "/");
 }
 
 } // namespace

--- a/clang-tools-extra/include-cleaner/unittests/TypesTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/TypesTest.cpp
@@ -34,12 +34,13 @@ TEST(RecordedIncludesTest, Match) {
   FileEntryRef B = FM.getVirtualFileRef("/path/b", /*Size=*/0, time_t{});
 
   Includes Inc;
-  Inc.add(Include{"a", A, SourceLocation(), 1});
-  Inc.add(Include{"a2", A, SourceLocation(), 2});
-  Inc.add(Include{"b", B, SourceLocation(), 3});
-  Inc.add(Include{"vector", B, SourceLocation(), 4});
-  Inc.add(Include{"vector", B, SourceLocation(), 5});
-  Inc.add(Include{"missing", std::nullopt, SourceLocation(), 6});
+  Inc.add(Include{"a", A, SourceLocation(), SourceLocation(), 1});
+  Inc.add(Include{"a2", A, SourceLocation(), SourceLocation(), 2});
+  Inc.add(Include{"b", B, SourceLocation(), SourceLocation(), 3});
+  Inc.add(Include{"vector", B, SourceLocation(), SourceLocation(), 4});
+  Inc.add(Include{"vector", B, SourceLocation(), SourceLocation(), 5});
+  Inc.add(
+      Include{"missing", std::nullopt, SourceLocation(), SourceLocation(), 6});
 
   EXPECT_THAT(Inc.match(A), ElementsAre(line(1), line(2)));
   EXPECT_THAT(Inc.match(B), ElementsAre(line(3), line(4), line(5)));
@@ -55,8 +56,9 @@ TEST(RecordedIncludesTest, MatchVerbatim) {
   // By default, a verbatim header only matches includes with the same spelling.
   auto Foo =
       FM.getVirtualFileRef("repo/lib/include/rel/foo.h", /*Size=*/0, time_t{});
-  Inc.add(Include{"lib/include/rel/foo.h", Foo, SourceLocation(), 1});
-  Inc.add(Include{"rel/foo.h", Foo, SourceLocation(), 2});
+  Inc.add(Include{"lib/include/rel/foo.h", Foo, SourceLocation(),
+                  SourceLocation(), 1});
+  Inc.add(Include{"rel/foo.h", Foo, SourceLocation(), SourceLocation(), 2});
   EXPECT_THAT(Inc.match(Header("<rel/foo.h>")), ElementsAre(line(2)));
 
   // A verbatim header can match another spelling if the search path
@@ -65,15 +67,17 @@ TEST(RecordedIncludesTest, MatchVerbatim) {
       FM.getVirtualFileRef("repo/lib/include/rel/bar.h", /*Size=*/0, time_t{});
   Inc.addSearchDirectory("repo/");
   Inc.addSearchDirectory("repo/lib/include");
-  Inc.add(Include{"lib/include/rel/bar.h", Bar, SourceLocation(), 3});
-  Inc.add(Include{"rel/bar.h", Bar, SourceLocation(), 4});
+  Inc.add(Include{"lib/include/rel/bar.h", Bar, SourceLocation(),
+                  SourceLocation(), 3});
+  Inc.add(Include{"rel/bar.h", Bar, SourceLocation(), SourceLocation(), 4});
   EXPECT_THAT(Inc.match(Header("<rel/bar.h>")),
               UnorderedElementsAre(line(3), line(4)));
 
   // We don't apply this logic to system headers, though.
   auto Vector =
       FM.getVirtualFileRef("repo/lib/include/vector", /*Size=*/0, time_t{});
-  Inc.add(Include{"lib/include/vector", Vector, SourceLocation(), 5});
+  Inc.add(Include{"lib/include/vector", Vector, SourceLocation(),
+                  SourceLocation(), 5});
   EXPECT_THAT(Inc.match(Header(*tooling::stdlib::Header::named("<vector>"))),
               IsEmpty());
 }
@@ -88,14 +92,14 @@ TEST(RecordedIncludesTest, MatchVerbatimMixedAbsoluteRelative) {
       FM.getVirtualFileRef("/working/rel1/rel2/foo.h", /*Size=*/0, time_t{});
   Inc.addSearchDirectory("rel1");
   Inc.addSearchDirectory("rel1/rel2");
-  Inc.add(Include{"rel2/foo.h", Foo, SourceLocation(), 1});
+  Inc.add(Include{"rel2/foo.h", Foo, SourceLocation(), SourceLocation(), 1});
   EXPECT_THAT(Inc.match(Header("<foo.h>")), IsEmpty());
 
   Inc = Includes{};
   auto Bar = FM.getVirtualFileRef("rel1/rel2/bar.h", /*Size=*/0, time_t{});
   Inc.addSearchDirectory("/working/rel1");
   Inc.addSearchDirectory("/working/rel1/rel2");
-  Inc.add(Include{"rel2/bar.h", Bar, SourceLocation(), 1});
+  Inc.add(Include{"rel2/bar.h", Bar, SourceLocation(), SourceLocation(), 1});
   EXPECT_THAT(Inc.match(Header("<bar.h>")), IsEmpty());
 }
 

--- a/clang-tools-extra/unittests/clang-tidy/IncludeCleanerTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/IncludeCleanerTest.cpp
@@ -339,6 +339,329 @@ TEST(IncludeCleanerCheckTest, UnusedIncludes) {
   }
 }
 
+TEST(IncludeCleanerCheckTest, FragmentHeadersPreserveIncludes) {
+  const std::string Fragment = "gen.inc";
+  const std::string Code = llvm::formatv(R"(
+#include <vector>
+#include "{0}"
+
+Gen G;
+)",
+                                         Fragment)
+                               .str();
+  const char *FragmentCode = R"(
+struct Gen {
+  std::vector<int> Values;
+};
+)";
+  const char *VectorHeader = R"(
+#pragma once
+namespace std {
+template <typename T>
+struct vector {};
+} // namespace std
+)";
+
+  {
+    std::vector<ClangTidyError> Errors;
+    runCheckOnCode<IncludeCleanerCheck>(
+        Code, &Errors, "file.cpp", {}, ClangTidyOptions(),
+        {{Fragment, FragmentCode}, {"vector", VectorHeader}});
+    ASSERT_THAT(Errors.size(), testing::Eq(1U));
+    EXPECT_EQ(Errors.front().Message.Message,
+              "included header vector is not used directly");
+  }
+  {
+    std::vector<ClangTidyError> Errors;
+    ClangTidyOptions Opts;
+    Opts.CheckOptions["test-check-0.FragmentHeaders"] = "";
+    runCheckOnCode<IncludeCleanerCheck>(
+        Code, &Errors, "file.cpp", {}, Opts,
+        {{Fragment, FragmentCode}, {"vector", VectorHeader}});
+    ASSERT_THAT(Errors.size(), testing::Eq(1U));
+  }
+  {
+    std::vector<ClangTidyError> Errors;
+    ClangTidyOptions Opts;
+    Opts.CheckOptions["test-check-0.FragmentHeaders"] = ".*\\.inc$";
+    runCheckOnCode<IncludeCleanerCheck>(
+        Code, &Errors, "file.cpp", {}, Opts,
+        {{Fragment, FragmentCode}, {"vector", VectorHeader}});
+    ASSERT_THAT(Errors.size(), testing::Eq(0U));
+  }
+}
+
+TEST(IncludeCleanerCheckTest, FragmentHeadersGeneratedPaths) {
+  const std::string Fragment =
+      appendPathFileSystemIndependent({"gen-out", "bin", "gen.inc"});
+  const std::string Code = llvm::formatv(R"(
+#include <vector>
+#include "{0}"
+
+Gen G;
+)",
+                                         Fragment)
+                               .str();
+  const char *FragmentCode = R"(
+struct Gen {
+  std::vector<int> Values;
+};
+)";
+  const char *VectorHeader = R"(
+#pragma once
+namespace std {
+template <typename T>
+struct vector {};
+} // namespace std
+)";
+
+  std::vector<ClangTidyError> Errors;
+  ClangTidyOptions Opts;
+  Opts.CheckOptions["test-check-0.FragmentHeaders"] =
+      "(^|.*/)(gen-out|generated)/";
+  runCheckOnCode<IncludeCleanerCheck>(
+      Code, &Errors, "file.cpp", {}, Opts,
+      {{Fragment, FragmentCode}, {"vector", VectorHeader}});
+  ASSERT_THAT(Errors.size(), testing::Eq(0U));
+}
+
+TEST(IncludeCleanerCheckTest, FragmentHeadersMultiplePatterns) {
+  const char *Code = R"(
+#include <vector>
+#include <string>
+#include "gen.inc"
+#include "gen.def"
+
+IncGen Inc;
+DefGen Def;
+)";
+  const char *IncCode = R"(
+struct IncGen {
+  std::vector<int> Values;
+};
+)";
+  const char *DefCode = R"(
+struct DefGen {
+  std::string Name;
+};
+)";
+  const char *VectorHeader = R"(
+#pragma once
+namespace std {
+template <typename T>
+struct vector {};
+} // namespace std
+)";
+  const char *StringHeader = R"(
+#pragma once
+namespace std {
+struct string {};
+} // namespace std
+)";
+
+  std::vector<ClangTidyError> Errors;
+  ClangTidyOptions Opts;
+  Opts.CheckOptions["test-check-0.FragmentHeaders"] = ".*\\.inc$;.*\\.def$";
+  runCheckOnCode<IncludeCleanerCheck>(Code, &Errors, "file.cpp", {}, Opts,
+                                      {{"gen.inc", IncCode},
+                                       {"gen.def", DefCode},
+                                       {"vector", VectorHeader},
+                                       {"string", StringHeader}});
+  ASSERT_THAT(Errors.size(), testing::Eq(0U));
+}
+
+TEST(IncludeCleanerCheckTest, FragmentHeadersNonRecursive) {
+  const char *Code = R"(
+#include <vector>
+#include "gen.inc"
+
+int use = gen_value;
+)";
+  const char *GenCode = R"(
+int gen_value = 0;
+#include "sub.inc"
+)";
+  const char *SubCode = R"(
+struct Gen {
+  std::vector<int> Values;
+};
+)";
+  const char *VectorHeader = R"(
+#pragma once
+namespace std {
+template <typename T>
+struct vector {};
+} // namespace std
+)";
+
+  std::vector<ClangTidyError> Errors;
+  ClangTidyOptions Opts;
+  Opts.CheckOptions["test-check-0.FragmentHeaders"] = ".*\\.inc$";
+  runCheckOnCode<IncludeCleanerCheck>(
+      Code, &Errors, "file.cpp", {}, Opts,
+      {{"gen.inc", GenCode}, {"sub.inc", SubCode}, {"vector", VectorHeader}});
+  ASSERT_THAT(Errors.size(), testing::Eq(1U));
+  EXPECT_EQ(Errors.front().Message.Message,
+            "included header vector is not used directly");
+}
+
+TEST(IncludeCleanerCheckTest, FragmentHeadersMissingIncludeAnchored) {
+  llvm::Annotations Code(R"(
+#include $diag^"gen.inc"
+int use = gen_value;
+)");
+  const char *GenCode = R"(
+#include "foo.h"
+int gen_value = 0;
+int missing = foo();
+)";
+  const char *FooHeader = R"(
+#pragma once
+int foo();
+)";
+
+  std::vector<ClangTidyError> Errors;
+  ClangTidyOptions Opts;
+  Opts.CheckOptions["test-check-0.FragmentHeaders"] = ".*\\.inc$";
+  runCheckOnCode<IncludeCleanerCheck>(
+      Code.code(), &Errors, "file.cpp", {}, Opts,
+      {{"gen.inc", GenCode}, {"foo.h", FooHeader}});
+  ASSERT_THAT(Errors.size(), testing::Eq(1U));
+  EXPECT_EQ(Errors.front().Message.Message,
+            "no header providing \"foo\" is directly included");
+  EXPECT_EQ(Errors.front().Message.FileOffset, Code.point("diag"));
+}
+
+TEST(IncludeCleanerCheckTest, FragmentHeadersMacroUsePreservesInclude) {
+  const char *Code = R"(
+#include "macros.h"
+#include "gen.inc"
+
+int use = x;
+)";
+  const char *GenCode = R"(
+MAKE_INT(x)
+)";
+  const char *MacrosHeader = R"(
+#pragma once
+#define MAKE_INT(name) int name;
+)";
+
+  std::vector<ClangTidyError> Errors;
+  ClangTidyOptions Opts;
+  Opts.CheckOptions["test-check-0.FragmentHeaders"] = ".*\\.inc$";
+  runCheckOnCode<IncludeCleanerCheck>(
+      Code, &Errors, "file.cpp", {}, Opts,
+      {{"gen.inc", GenCode}, {"macros.h", MacrosHeader}});
+  ASSERT_THAT(Errors.size(), testing::Eq(0U));
+}
+
+TEST(IncludeCleanerCheckTest, FragmentDependencyCommentInserted) {
+  const char *PreCode = R"(
+#include <vector>
+#include "gen.inc"
+
+Gen G;
+)";
+  const char *PostCode = R"(
+#include <vector> // needed by "gen.inc"
+#include "gen.inc"
+
+Gen G;
+)";
+  const char *FragmentCode = R"(
+struct Gen {
+  std::vector<int> Values;
+};
+)";
+  const char *VectorHeader = R"(
+#pragma once
+namespace std {
+template <typename T>
+struct vector {};
+} // namespace std
+)";
+
+  std::vector<ClangTidyError> Errors;
+  ClangTidyOptions Opts;
+  Opts.CheckOptions["test-check-0.FragmentHeaders"] = ".*\\.inc$";
+  Opts.CheckOptions["test-check-0.FragmentDependencyCommentFormat"] =
+      "needed by {0}";
+  EXPECT_EQ(PostCode,
+            runCheckOnCode<IncludeCleanerCheck>(
+                PreCode, &Errors, "file.cpp", {}, Opts,
+                {{"gen.inc", FragmentCode}, {"vector", VectorHeader}}));
+  ASSERT_THAT(Errors.size(), testing::Eq(1U));
+  EXPECT_EQ(
+      Errors.front().Message.Message,
+      "included header vector is used only by fragment header(s) \"gen.inc\"");
+}
+
+TEST(IncludeCleanerCheckTest, FragmentDependencyCommentAlreadyPresent) {
+  const char *Code = R"(
+#include <vector> // needed by "gen.inc"
+#include "gen.inc"
+
+Gen G;
+)";
+  const char *FragmentCode = R"(
+struct Gen {
+  std::vector<int> Values;
+};
+)";
+  const char *VectorHeader = R"(
+#pragma once
+namespace std {
+template <typename T>
+struct vector {};
+} // namespace std
+)";
+
+  std::vector<ClangTidyError> Errors;
+  ClangTidyOptions Opts;
+  Opts.CheckOptions["test-check-0.FragmentHeaders"] = ".*\\.inc$";
+  Opts.CheckOptions["test-check-0.FragmentDependencyCommentFormat"] =
+      "needed by {0}";
+  EXPECT_EQ(Code, runCheckOnCode<IncludeCleanerCheck>(
+                      Code, &Errors, "file.cpp", {}, Opts,
+                      {{"gen.inc", FragmentCode}, {"vector", VectorHeader}}));
+  ASSERT_THAT(Errors.size(), testing::Eq(0U));
+}
+
+TEST(IncludeCleanerCheckTest, FragmentDependencyCommentConflict) {
+  const char *Code = R"(
+#include <vector> // keep me
+#include "gen.inc"
+
+Gen G;
+)";
+  const char *FragmentCode = R"(
+struct Gen {
+  std::vector<int> Values;
+};
+)";
+  const char *VectorHeader = R"(
+#pragma once
+namespace std {
+template <typename T>
+struct vector {};
+} // namespace std
+)";
+
+  std::vector<ClangTidyError> Errors;
+  ClangTidyOptions Opts;
+  Opts.CheckOptions["test-check-0.FragmentHeaders"] = ".*\\.inc$";
+  Opts.CheckOptions["test-check-0.FragmentDependencyCommentFormat"] =
+      "IWYU pragma: keep";
+  EXPECT_EQ(Code, runCheckOnCode<IncludeCleanerCheck>(
+                      Code, &Errors, "file.cpp", {}, Opts,
+                      {{"gen.inc", FragmentCode}, {"vector", VectorHeader}}));
+  ASSERT_THAT(Errors.size(), testing::Eq(1U));
+  EXPECT_EQ(
+      Errors.front().Message.Message,
+      "included header vector is used only by fragment header(s) \"gen.inc\"");
+}
+
 TEST(IncludeCleanerCheckTest, MissingIncludes) {
   const char *PreCode = R"(
 #include "baz.h" // IWYU pragma: keep


### PR DESCRIPTION
Depends on: #189458 (only last commit should reviewed in the current PR)