### PR TITLE
[NFC][LLVM] Simplify `matchIntrinsicVarArg`

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -269,11 +269,12 @@ namespace Intrinsic {
   matchIntrinsicSignature(FunctionType *FTy, ArrayRef<IITDescriptor> &Infos,
                           SmallVectorImpl<Type *> &ArgTys);
 
-  /// Verify if the intrinsic has variable arguments. This method is intended to
-  /// be called after all the fixed arguments have been matched first.
+  /// Verify if the intrinsic vararg propertly matches \p IsVarArg. This method
+  /// is intended to be called after all the fixed arguments have been matched
+  /// first.
   ///
   /// This method returns true on error.
-  LLVM_ABI bool matchIntrinsicVarArg(bool isVarArg,
+  LLVM_ABI bool matchIntrinsicVarArg(bool IsVarArg,
                                      ArrayRef<IITDescriptor> &Infos);
 
   /// Gets the type arguments of an intrinsic call by matching type contraints

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -472,8 +472,7 @@ class LLVMPartiallyDependentType<int oidx, IIT_Base IIT_Info>
 
 // Match the type of another intrinsic parameter. `oidx` is the overload index
 // of the overloaded type that this type is dependent on. Overload types are
-// either LLVMAnyType or LLVMPartiallyDependentType. The `oidx` value must refer
-// to a previously listed type. For example:
+// either LLVMAnyType or LLVMPartiallyDependentType. For example:
 //
 //   Intrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_anyfloat_ty, LLVMMatchType<0>]>
 //

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -1096,22 +1096,12 @@ Intrinsic::matchIntrinsicSignature(FunctionType *FTy,
 }
 
 bool Intrinsic::matchIntrinsicVarArg(
-    bool isVarArg, ArrayRef<Intrinsic::IITDescriptor> &Infos) {
-  // If there are no descriptors left, then it can't be a vararg.
-  if (Infos.empty())
-    return isVarArg;
+    bool IsVarArg, ArrayRef<Intrinsic::IITDescriptor> &Infos) {
+  bool InferredVarArg =
+      Infos.size() == 1 && Infos.consume_front().Kind == IITDescriptor::VarArg;
 
-  // There should be only one descriptor remaining at this point.
-  if (Infos.size() != 1)
-    return true;
-
-  // Check and verify the descriptor.
-  IITDescriptor D = Infos.front();
-  Infos = Infos.slice(1);
-  if (D.Kind == IITDescriptor::VarArg)
-    return !isVarArg;
-
-  return true;
+  // Return true of the inferred VarArg and IsVarArg mismatch.
+  return InferredVarArg != IsVarArg;
 }
 
 bool Intrinsic::getIntrinsicSignature(Intrinsic::ID ID, FunctionType *FT,


### PR DESCRIPTION
Shorten the code by computing the inferred `IsVarArg` property and comparing against the `IsVarArg` supplied as an argument.

Additionally, remove an incorrect comment about overload index for dependent types. We do not require that we can only user overload index of a type after it has been listed and support forward references with

https://github.com/llvm/llvm-project/commit/7957fc6547e1b8af8e6586e2c25446b724eabb75