### PR TITLE
[lldb] Simplify some tests to run_to_source_breakpoint (NFC)

### DIFF
--- a/lldb/test/API/commands/disassemble/basic/TestFrameDisassemble.py
+++ b/lldb/test/API/commands/disassemble/basic/TestFrameDisassemble.py
@@ -18,39 +18,11 @@ class FrameDisassembleTestCase(TestBase):
 
     def frame_disassemble_test(self):
         """Sample test to ensure SBFrame::Disassemble produces SOME output"""
-        # Create a target by the debugger.
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
         )
 
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
+        frame = thread.GetFrameAtIndex(0)
         disassembly = frame.Disassemble()
         self.assertNotEqual(disassembly, "")
         self.assertNotIn("error", disassembly)

--- a/lldb/test/API/commands/frame/language/TestGuessLanguage.py
+++ b/lldb/test/API/commands/frame/language/TestGuessLanguage.py
@@ -30,38 +30,9 @@ class TestFrameGuessLanguage(TestBase):
 
     def do_test(self):
         """Test GuessLanguage for C & C++."""
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set breakpoint here", lldb.SBFileSpec("somefunc.c")
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "Set breakpoint here", lldb.SBFileSpec("somefunc.c")
         )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        thread = threads[0]
 
         c_frame_language = lldb.eLanguageTypeC99
         cxx_frame_language = lldb.eLanguageTypeC_plus_plus_11

--- a/lldb/test/API/commands/frame/var/TestFrameVar.py
+++ b/lldb/test/API/commands/frame/var/TestFrameVar.py
@@ -23,38 +23,10 @@ class TestFrameVar(TestBase):
         self.do_test()
 
     def do_test(self):
-        target = self.createTestTarget()
-
-        # Now create a breakpoint in main.c at the source matching
-        # "Set a breakpoint here"
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set a breakpoint here", lldb.SBFileSpec("main.c")
-        )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() >= 1, VALID_BREAKPOINT
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "Set a breakpoint here", lldb.SBFileSpec("main.c")
         )
 
-        error = lldb.SBError()
-        # This is the launch info.  If you want to launch with arguments or
-        # environment variables, add them using SetArguments or
-        # SetEnvironmentEntries
-
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        from lldbsuite.test.lldbutil import get_threads_stopped_at_breakpoint
-
-        threads = get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-
-        # The hit count for the breakpoint should be 1.
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        frame = threads[0].GetFrameAtIndex(0)
         command_result = lldb.SBCommandReturnObject()
         interp = self.dbg.GetCommandInterpreter()
 

--- a/lldb/test/API/functionalities/ptr_refs/TestPtrRefs.py
+++ b/lldb/test/API/functionalities/ptr_refs/TestPtrRefs.py
@@ -16,28 +16,8 @@ class TestPtrRefs(TestBase):
     def test_ptr_refs(self):
         """Test format string functionality."""
         self.build()
-        exe = self.getBuildArtifact("a.out")
 
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        main_file_spec = lldb.SBFileSpec("main.c")
-        breakpoint = target.BreakpointCreateBySourceRegex("break", main_file_spec)
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() == 1, VALID_BREAKPOINT
-        )
-
-        process = target.LaunchSimple(None, None, self.get_process_working_directory())
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Frame #0 should be on self.line1 and the break condition should hold.
-        thread = lldbutil.get_stopped_thread(process, lldb.eStopReasonBreakpoint)
-        self.assertTrue(
-            thread.IsValid(),
-            "There should be a thread stopped due to breakpoint condition",
-        )
-
-        frame = thread.GetFrameAtIndex(0)
+        lldbutil.run_to_source_breakpoint(self, "break", lldb.SBFileSpec("main.c"))
 
         self.runCmd("command script import lldb.macosx.heap")
         self.expect("ptr_refs my_ptr", substrs=["malloc", "stack"])

--- a/lldb/test/API/functionalities/step-avoids-no-debug/TestStepNoDebug.py
+++ b/lldb/test/API/functionalities/step-avoids-no-debug/TestStepNoDebug.py
@@ -90,28 +90,9 @@ class StepAvoidsNoDebugTestCase(TestBase):
         )
 
     def get_to_starting_point(self):
-        exe = self.getBuildArtifact("a.out")
-        error = lldb.SBError()
-
-        self.target = self.dbg.CreateTarget(exe)
-        self.assertTrue(self.target, VALID_TARGET)
-
-        inner_bkpt = self.target.BreakpointCreateBySourceRegex(
-            "Stop here and step out of me", self.main_source_spec
+        self.target, self.process, self.thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "Stop here and step out of me", self.main_source_spec
         )
-        self.assertTrue(inner_bkpt, VALID_BREAKPOINT)
-
-        # Now launch the process, and do not stop at entry point.
-        self.process = self.target.LaunchSimple(
-            None, None, self.get_process_working_directory()
-        )
-
-        self.assertTrue(self.process, PROCESS_IS_VALID)
-
-        # Now finish, and make sure the return value is correct.
-        threads = lldbutil.get_threads_stopped_at_breakpoint(self.process, inner_bkpt)
-        self.assertEqual(len(threads), 1, "Stopped at inner breakpoint.")
-        self.thread = threads[0]
 
     def do_step_out_past_nodebug(self):
         # The first step out takes us to the called_from_nodebug frame, just to make sure setting

--- a/lldb/test/API/functionalities/tail_call_frames/sbapi_support/TestTailCallFrameSBAPI.py
+++ b/lldb/test/API/functionalities/tail_call_frames/sbapi_support/TestTailCallFrameSBAPI.py
@@ -17,33 +17,9 @@ class TestTailCallFrameSBAPI(TestBase):
         self.do_test()
 
     def do_test(self):
-        exe = self.getBuildArtifact("a.out")
-
-        # Create a target by the debugger.
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "break here", lldb.SBFileSpec("main.cpp")
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
         )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() == 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        threads = lldbutil.get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        thread = threads[0]
 
         # Here's what we expect to see in the backtrace:
         #   frame #0: ... a.out`sink() at main.cpp:13:4 [opt]

--- a/lldb/test/API/functionalities/tail_call_frames/thread_step_out_or_return/TestSteppingOutWithArtificialFrames.py
+++ b/lldb/test/API/functionalities/tail_call_frames/thread_step_out_or_return/TestSteppingOutWithArtificialFrames.py
@@ -15,33 +15,9 @@ class TestArtificialFrameThreadStepOut1(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     def prepare_thread(self):
-        exe = self.getBuildArtifact("a.out")
-
-        # Create a target by the debugger.
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            "break here", lldb.SBFileSpec("main.cpp")
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
         )
-        self.assertTrue(
-            breakpoint and breakpoint.GetNumLocations() == 1, VALID_BREAKPOINT
-        )
-
-        error = lldb.SBError()
-        launch_info = target.GetLaunchInfo()
-        process = target.Launch(launch_info, error)
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Did we hit our breakpoint?
-        threads = lldbutil.get_threads_stopped_at_breakpoint(process, breakpoint)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at our breakpoint"
-        )
-
-        self.assertEqual(breakpoint.GetHitCount(), 1)
-
-        thread = threads[0]
 
         # Here's what we expect to see in the backtrace:
         #   frame #0: ... a.out`sink() at main.cpp:13:4 [opt]

--- a/lldb/test/API/lang/c/anonymous/TestAnonymous.py
+++ b/lldb/test/API/lang/c/anonymous/TestAnonymous.py
@@ -87,31 +87,12 @@ class AnonymousTestCase(TestBase):
     def test_child_by_name(self):
         self.build()
 
-        # Set debugger into synchronous mode
-        self.dbg.SetAsync(False)
-
-        # Create a target
-        exe = self.getBuildArtifact("a.out")
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        break_in_main = target.BreakpointCreateBySourceRegex(
-            "// Set breakpoint 2 here.", lldb.SBFileSpec(self.source)
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "// Set breakpoint 2 here.", lldb.SBFileSpec(self.source)
         )
-        self.assertTrue(break_in_main, VALID_BREAKPOINT)
 
-        process = target.LaunchSimple(None, None, self.get_process_working_directory())
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        threads = lldbutil.get_threads_stopped_at_breakpoint(process, break_in_main)
-        if len(threads) != 1:
-            self.fail("Failed to stop at breakpoint in main.")
-
-        thread = threads[0]
         frame = thread.frames[0]
-
-        if not frame.IsValid():
-            self.fail("Failed to get frame 0.")
+        self.assertTrue(frame.IsValid(), "Failed to get frame 0.")
 
         var_n = frame.FindVariable("n")
         if not var_n.IsValid():

--- a/lldb/test/API/lang/c/step-target/TestStepTarget.py
+++ b/lldb/test/API/lang/c/step-target/TestStepTarget.py
@@ -18,31 +18,13 @@ class TestStepTarget(TestBase):
     @add_test_categories(["pyapi"])
     def get_to_start(self):
         self.build()
-        exe = self.getBuildArtifact("a.out")
-
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
 
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
-        break_in_main = target.BreakpointCreateBySourceRegex(
-            "Break here to try targetted stepping", self.main_source_spec
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "Break here to try targetted stepping", self.main_source_spec
         )
-        self.assertTrue(break_in_main, VALID_BREAKPOINT)
-        self.assertGreater(break_in_main.GetNumLocations(), 0, "Has locations.")
 
-        # Now launch the process, and do not stop at entry point.
-        process = target.LaunchSimple(None, None, self.get_process_working_directory())
-
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # The stop reason of the thread should be breakpoint.
-        threads = lldbutil.get_threads_stopped_at_breakpoint(process, break_in_main)
-
-        if len(threads) != 1:
-            self.fail("Failed to stop at first breakpoint in main.")
-
-        thread = threads[0]
         return thread
 
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr32343")

--- a/lldb/test/API/lang/cpp/global_operators/TestCppGlobalOperators.py
+++ b/lldb/test/API/lang/cpp/global_operators/TestCppGlobalOperators.py
@@ -11,36 +11,9 @@ class TestCppGlobalOperators(TestBase):
     def prepare_executable_and_get_frame(self):
         self.build()
 
-        # Get main source file
-        src_file = "main.cpp"
-        src_file_spec = lldb.SBFileSpec(src_file)
-        self.assertTrue(src_file_spec.IsValid(), "Main source file")
-
-        # Get the path of the executable
-        exe_path = self.getBuildArtifact("a.out")
-
-        # Load the executable
-        target = self.dbg.CreateTarget(exe_path)
-        self.assertTrue(target.IsValid(), VALID_TARGET)
-
-        # Break on main function
-        main_breakpoint = target.BreakpointCreateBySourceRegex(
-            "// break here", src_file_spec
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp")
         )
-        self.assertTrue(
-            main_breakpoint.IsValid() and main_breakpoint.GetNumLocations() >= 1,
-            VALID_BREAKPOINT,
-        )
-
-        # Launch the process
-        args = None
-        env = None
-        process = target.LaunchSimple(args, env, self.get_process_working_directory())
-        self.assertTrue(process.IsValid(), PROCESS_IS_VALID)
-
-        # Get the thread of the process
-        self.assertEqual(process.GetState(), lldb.eStateStopped, PROCESS_STOPPED)
-        thread = lldbutil.get_stopped_thread(process, lldb.eStopReasonBreakpoint)
 
         return thread.GetSelectedFrame()
 


### PR DESCRIPTION
Many tests have ad hoc forms of the launch & break steps done by `lldbutil.run_to_source_breakpoint`.  This changes some of those tests to use `run_to_source_breakpoint` instead.

Assisted-by: claude