### PR TITLE
[clang][Modules] Diagnosing Module Redefinition Across ModuleMaps

### DIFF
--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -1756,8 +1756,8 @@ void ModuleMapLoader::handleModuleDecl(const modulemap::ModuleDecl &MD) {
   if (Module *Existing = Map.lookupModuleQualified(ModuleName, ActiveModule)) {
     // We might see a (re)definition of a module that we already have a
     // definition for in four cases:
-    //  - If the module was loaded from an AST file and we've found its original
-    //  definition again (same source module map)
+    //  - If the Existing module was loaded from an AST file and we've found its
+    //    original source module map, or
     bool LoadedFromASTFile = Existing->IsFromModuleFile;
     if (LoadedFromASTFile) {
       OptionalFileEntryRef ExistingModMapFile =

--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -1756,14 +1756,10 @@ void ModuleMapLoader::handleModuleDecl(const modulemap::ModuleDecl &MD) {
   if (Module *Existing = Map.lookupModuleQualified(ModuleName, ActiveModule)) {
     // We might see a (re)definition of a module that we already have a
     // definition for in four cases:
-    //  - If we loaded one definition from an AST file and we've just found the
-    //    corresponding definition in the same module map file, or
+    //  - If the module was loaded from an AST file and we've found its original
+    //  definition again (same source module map)
     bool LoadedFromASTFile = Existing->IsFromModuleFile;
     if (LoadedFromASTFile) {
-      // Only suppress the redefinition error if the existing module was defined
-      // in the same module map file we are currently parsing. If they come from
-      // different module map files, this is a genuine conflict that should be
-      // diagnosed.
       OptionalFileEntryRef ExistingModMapFile =
           Map.getContainingModuleMapFile(Existing);
       OptionalFileEntryRef CurrentModMapFile =

--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -1756,9 +1756,24 @@ void ModuleMapLoader::handleModuleDecl(const modulemap::ModuleDecl &MD) {
   if (Module *Existing = Map.lookupModuleQualified(ModuleName, ActiveModule)) {
     // We might see a (re)definition of a module that we already have a
     // definition for in four cases:
-    //  - If we loaded one definition from an AST file and we've just found a
-    //    corresponding definition in a module map file, or
+    //  - If we loaded one definition from an AST file and we've just found the
+    //    corresponding definition in the same module map file, or
     bool LoadedFromASTFile = Existing->IsFromModuleFile;
+    if (LoadedFromASTFile) {
+      // Only suppress the redefinition error if the existing module was defined
+      // in the same module map file we are currently parsing. If they come from
+      // different module map files, this is a genuine conflict that should be
+      // diagnosed.
+      OptionalFileEntryRef ExistingModMapFile =
+          Map.getContainingModuleMapFile(Existing);
+      OptionalFileEntryRef CurrentModMapFile =
+          SourceMgr.getFileEntryRefForID(ModuleMapFID);
+      if (ExistingModMapFile && CurrentModMapFile &&
+          *ExistingModMapFile == *CurrentModMapFile)
+        LoadedFromASTFile = true;
+      else
+        LoadedFromASTFile = false;
+    }
     //  - If we previously inferred this module from different module map file.
     bool Inferred = Existing->IsInferred;
     //  - If we're building a framework that vends a module map, we might've

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -605,9 +605,6 @@ bool CompilerInstanceWithContext::computeDependencies(
   if (!ModResult)
     return false;
 
-  // Check for errors that occurred as side effects during module loading
-  // (e.g., modulemap parsing errors like duplicate module definitions).
-  // loadModule may return a valid module even when such errors occur.
   if (CI.getDiagnostics().hasErrorOccurred())
     return false;
 

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -605,6 +605,12 @@ bool CompilerInstanceWithContext::computeDependencies(
   if (!ModResult)
     return false;
 
+  // Check for errors that occurred as side effects during module loading
+  // (e.g., modulemap parsing errors like duplicate module definitions).
+  // loadModule may return a valid module even when such errors occur.
+  if (CI.getDiagnostics().hasErrorOccurred())
+    return false;
+
   MDC->applyDiscoveredDependencies(ModuleInvocation);
 
   if (!Controller.finalize(CI, ModuleInvocation))

--- a/clang/test/ClangScanDeps/modules-byname-dup-module-decl-diag.c
+++ b/clang/test/ClangScanDeps/modules-byname-dup-module-decl-diag.c
@@ -5,16 +5,15 @@
 // 1. The compiler has seen the module decl during previous lookups.
 // 2. The previous decl comes from a different modulemap.
 // In this case, an error is produced with no dependency information returned.
-
-// RUN: rm -rf %t
-// RUN: split-file %s %t
-// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
-
-// Scenario setup:
+// Specifically, we have the following setup:
 //   - "A" is a framework module whose modulemap also declares an empty "B".
 //   - A separate include path has its own B/module.modulemap that declares "B"
 //     with a header depending on module "Dep"
 // We scan B first, and during A's scan, the compiler should report an error.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
 
 // RUN: not clang-scan-deps -compilation-database %t/cdb.json -format \
 // RUN:   experimental-full -module-names=B,A > %t/result_ab.json 2> %t/err.txt

--- a/clang/test/ClangScanDeps/modules-byname-dup-module-decl-diag.c
+++ b/clang/test/ClangScanDeps/modules-byname-dup-module-decl-diag.c
@@ -16,17 +16,11 @@
 // RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
 
 // RUN: not clang-scan-deps -compilation-database %t/cdb.json -format \
-// RUN:   experimental-full -module-names=B,A > %t/result_ab.json 2> %t/err.txt
-// RUN: cat %t/result_ab.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
-// RUN: cat %t/err.txt | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t \
-// RUN:   -check-prefix=ERROR %s
+// RUN:   experimental-full -module-names=B,A 2>&1 | \
+// RUN:   sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
 
-// We should not produce scanning results for A, since there is a duplicating
-// module decl.
-// CHECK-NOT: "name": "A"
-
-// ERROR: A.framework/Modules/module.modulemap:8:8: error: redefinition of module 'B'
-// ERROR: include/B/module.modulemap:1:8: note: previously defined here
+// CHECK: A.framework/Modules/module.modulemap:7:8: error: redefinition of module 'B'
+// CHECK: include/B/module.modulemap:1:8: note: previously defined here
 
 //--- frameworks/A.framework/Modules/module.modulemap
 framework module A [system] {
@@ -35,7 +29,6 @@ framework module A [system] {
   module * { export * }
 }
 
-// This empty definition of B shadows the real one when cached.
 module B {
   export *
 }

--- a/clang/test/ClangScanDeps/modules-byname-dup-module-decl-diag.c
+++ b/clang/test/ClangScanDeps/modules-byname-dup-module-decl-diag.c
@@ -1,0 +1,73 @@
+// Test duplicating module decls discovered during by-name module scanning with
+// a shared compiler instance.
+// This tests covers the case where the current modulemap we are loading
+// contains a module decl that satisfies two conditions:
+// 1. The compiler has seen the module decl during previous lookups.
+// 2. The previous decl comes from a different modulemap.
+// In this case, an error is produced with no dependency information returned.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// Scenario setup:
+//   - "A" is a framework module whose modulemap also declares an empty "B".
+//   - A separate include path has its own B/module.modulemap that declares "B"
+//     with a header depending on module "Dep"
+// We scan B first, and during A's scan, the compiler should report an error.
+
+// RUN: not clang-scan-deps -compilation-database %t/cdb.json -format \
+// RUN:   experimental-full -module-names=B,A > %t/result_ab.json 2> %t/err.txt
+// RUN: cat %t/result_ab.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
+// RUN: cat %t/err.txt | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t \
+// RUN:   -check-prefix=ERROR %s
+
+// We should not produce scanning results for A, since there is a duplicating
+// module decl.
+// CHECK-NOT: "name": "A"
+
+// ERROR: A.framework/Modules/module.modulemap:8:8: error: redefinition of module 'B'
+// ERROR: include/B/module.modulemap:1:8: note: previously defined here
+
+//--- frameworks/A.framework/Modules/module.modulemap
+framework module A [system] {
+  umbrella header "A.h"
+  export *
+  module * { export * }
+}
+
+// This empty definition of B shadows the real one when cached.
+module B {
+  export *
+}
+
+//--- frameworks/A.framework/Headers/A.h
+// Framework A umbrella header
+void a_func(void);
+
+//--- include/B/module.modulemap
+module B {
+  header "B.h"
+  export *
+}
+
+//--- include/B/B.h
+#include "Dep.h"
+void b_func(void);
+
+//--- include/Dep/module.modulemap
+module Dep {
+  header "Dep.h"
+  export *
+}
+
+//--- include/Dep/Dep.h
+// Module Dep header
+void dep_func(void);
+
+//--- cdb.json.template
+[{
+  "file": "",
+  "directory": "DIR",
+  "command": "clang -fmodules -fmodules-cache-path=DIR/cache -I DIR/include/B -F DIR/frameworks -I DIR/include/Dep -x c"
+}]

--- a/clang/test/ClangScanDeps/modules-mmap-redef.c
+++ b/clang/test/ClangScanDeps/modules-mmap-redef.c
@@ -5,12 +5,11 @@
 // RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
 
 // RUN: not clang-scan-deps -compilation-database %t/cdb.json -format \
-// RUN:   experimental-full -module-names=A > %t/result.json 2> %t/err.txt
-// RUN: cat %t/err.txt | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t \
-// RUN:   -check-prefix=ERROR %s
+// RUN:   experimental-full -module-names=A 2>&1 | sed 's:\\\\\?:/:g' | \
+// RUN:   FileCheck -DPREFIX=%/t %s
 
-// ERROR: include/A/module.modulemap:9:8: error: redefinition of module 'A'
-// ERROR-NEXT: include/A/module.modulemap:1:8: note: previously defined here
+// CHECK: include/A/module.modulemap:9:8: error: redefinition of module 'A'
+// CHECK-NEXT: include/A/module.modulemap:1:8: note: previously defined here
 
 //--- include/A/module.modulemap
 module A {

--- a/clang/test/ClangScanDeps/modules-mmap-redef.c
+++ b/clang/test/ClangScanDeps/modules-mmap-redef.c
@@ -1,0 +1,40 @@
+// Test duplicating module definitions in the same modulemap.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: not clang-scan-deps -compilation-database %t/cdb.json -format \
+// RUN:   experimental-full -module-names=A > %t/result.json 2> %t/err.txt
+// RUN: cat %t/err.txt | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t \
+// RUN:   -check-prefix=ERROR %s
+
+// ERROR: include/A/module.modulemap:9:8: error: redefinition of module 'A'
+// ERROR-NEXT: include/A/module.modulemap:1:8: note: previously defined here
+
+//--- include/A/module.modulemap
+module A {
+    header "A.h"
+}
+
+module A1 {
+    header "A1.h"
+}
+
+module A{
+    header "A.h"
+}
+
+//--- include/A/A.h
+
+//--- include/A/A1.h
+
+//--- include/A/A2.h
+
+
+//--- cdb.json.template
+[{
+  "file": "",
+  "directory": "DIR",
+  "command": "clang -fmodules -fmodules-cache-path=DIR/cache -I DIR/include/A -x c"
+}]

--- a/clang/test/Modules/implicit-module-redefinition-same-file.c
+++ b/clang/test/Modules/implicit-module-redefinition-same-file.c
@@ -1,0 +1,36 @@
+// Test that implicit module builds diagnose redefinition of a module when the
+// same modulemap file contains duplicate module declarations.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: not %clang_cc1 -x objective-c -fmodules -fimplicit-module-maps \
+// RUN:   -I %t/include \
+// RUN:   -fmodules-cache-path=%t/cache \
+// RUN:   %t/test.m 2>&1 | FileCheck %s
+
+// CHECK: module.modulemap:9:8: error: redefinition of module 'A'
+// CHECK: module.modulemap:1:8: note: previously defined here
+// CHECK: fatal error: could not build module 'A'
+
+//--- include/module.modulemap
+module A {
+    header "A.h"
+}
+
+module A1 {
+    header "A1.h"
+}
+
+module A {
+    header "A.h"
+}
+
+//--- include/A.h
+// empty
+
+//--- include/A1.h
+// empty
+
+//--- test.m
+@import A;

--- a/clang/test/Modules/implicit-module-redefinition.c
+++ b/clang/test/Modules/implicit-module-redefinition.c
@@ -1,0 +1,56 @@
+// Test that implicit module builds diagnose redefinition of a module when two
+// different modulemaps define the same module name.
+//
+// Module "b" is defined in both first/module.modulemap and
+// second/module.modulemap.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// We detect the error when we read a's modulemap in first
+// and discovers another b, which we have seen earlier in
+// second/module.modulemap.
+// RUN: not %clang_cc1 -x objective-c -fmodules -fimplicit-module-maps \
+// RUN:   -I %t/second -I %t/first \
+// RUN:   -fmodules-cache-path=%t/cache \
+// RUN:   %t/sourcefile.c 2>&1 | FileCheck %s
+
+// CHECK: first{{[/\\]}}module.modulemap:5:8: error: redefinition of module 'b'
+// CHECK: second{{[/\\]}}module.modulemap:1:8: note: previously defined here
+
+// On the other hand, we do NOT detect error if we load a's modulemap first.
+// Checking duplicating module decls in general is too expensive, since
+// it requires loading all the modulemaps. The command below should succeed.
+// RUN: %clang_cc1 -x objective-c -fmodules -fimplicit-module-maps \
+// RUN:   -I %t/first -I %t/second \
+// RUN:   -fmodules-cache-path=%t/cache \
+// RUN:   %t/sourcefile.c
+
+//--- first/module.modulemap
+module a {
+  header "a.h"
+}
+
+module b {
+  export *
+}
+
+//--- first/a.h
+// empty
+
+//--- second/module.modulemap
+module b {
+  header "b.h"
+}
+
+//--- second/b.h
+// empty
+
+
+//--- sourcefile.c
+@import b;
+@import a;
+
+int main() {
+  return 0;
+}


### PR DESCRIPTION
This PR enhances the module redefinition diagnostic to cover a very specific case. 

1. A module, say `B`, is discovered first during header search. In other words, it is declared in a modulemap that shows up first on the search paths. 
2. `B` is declared again in a different modulemap, which shows up in a later search path, and the compiler discovers `B` again when it is searching for a different named module. 

See the two tests added for examples of this specific scenario. Under such a scenario, the compiler now reports the module redefined error.

Note that we are not diagnosing duplicating module definitions globally, because that requires looking through all search paths and loading all module maps, which is too expensive. 

Assisted-by: claude-opus-4.6