### PR TITLE
[llvm] Fix SupportHTTP linkage with libLLVM in unit-tests

### DIFF
--- a/llvm/unittests/Debuginfod/CMakeLists.txt
+++ b/llvm/unittests/Debuginfod/CMakeLists.txt
@@ -1,9 +1,12 @@
+set(LLVM_LINK_COMPONENTS
+  LLVMSupportHTTP
+  )
+
 add_llvm_unittest(DebuginfodTests
   DebuginfodTests.cpp
   )
 
 target_link_libraries(DebuginfodTests PRIVATE
   LLVMDebuginfod
-  LLVMSupportHTTP
   LLVMTestingSupport
   )

--- a/llvm/unittests/Debuginfod/CMakeLists.txt
+++ b/llvm/unittests/Debuginfod/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(LLVM_LINK_COMPONENTS
-  LLVMSupportHTTP
+  SupportHTTP
   )
 
 add_llvm_unittest(DebuginfodTests

--- a/llvm/unittests/Support/HTTP/CMakeLists.txt
+++ b/llvm/unittests/Support/HTTP/CMakeLists.txt
@@ -1,8 +1,11 @@
+set(LLVM_LINK_COMPONENTS
+  LLVMSupportHTTP
+  )
+
 add_llvm_unittest(SupportHTTPTests
   HTTPServerTests.cpp
   )
 
 target_link_libraries(SupportHTTPTests PRIVATE
-  LLVMSupportHTTP
   LLVMTestingSupport
   )

--- a/llvm/unittests/Support/HTTP/CMakeLists.txt
+++ b/llvm/unittests/Support/HTTP/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(LLVM_LINK_COMPONENTS
-  LLVMSupportHTTP
+  SupportHTTP
   )
 
 add_llvm_unittest(SupportHTTPTests


### PR DESCRIPTION
Since libSupportHTTP is part of the LLVM dylib, we must link it as a component now.