### PR TITLE
[JITLink] Remove unnecessary SymbolStringPtr copy.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/JITLink.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/JITLink.h
@@ -525,7 +525,7 @@ public:
 
   /// Rename this symbol. The client is responsible for updating scope and
   /// linkage if this name-change requires it.
-  void setName(const orc::SymbolStringPtr Name) { this->Name = Name; }
+  void setName(orc::SymbolStringPtr Name) { this->Name = std::move(Name); }
 
   /// Returns true if this Symbol has content (potentially) defined within this
   /// object file (i.e. is anything but an external or absolute symbol).


### PR DESCRIPTION
This was probably intended to be a `const SymbolStringPtr&` originally, but if we were going to copy it anyway it's better to just take the argument by value and std::move it.