### PR TITLE
[sanitizer_common] Fix memory leak in ListOfModules

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_common.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common.h
@@ -906,7 +906,14 @@ class LoadedModule {
 class ListOfModules {
  public:
   ListOfModules() : initialized(false) {}
-  ~ListOfModules() { clear(); }
+  ~ListOfModules() {
+    clear();
+    if (initialized)
+      modules_.Destroy();
+  }
+  ListOfModules(const ListOfModules&) = delete;
+  ListOfModules& operator=(const ListOfModules&) = delete;
+
   void init();
   void fallbackInit();  // Uses fallback init if available, otherwise clears
   const LoadedModule *begin() const { return modules_.begin(); }


### PR DESCRIPTION
I found a rather old leak in `ListOfModules`. `ListOfModules` has a member

```
  InternalMmapVectorNoCtor<LoadedModule> modules_;
```

Which has neither a constructor nor destructor. As a consequence, we need to call `Destroy` on it when ListOfModules is destroyed, so that the memory is released to the OS (via munmap).


rdar://173906291