### PR TITLE
[LLVM][Transforms][Attributor] - Add configurable access cap for AAPointerInfo

### DIFF
--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -114,6 +114,8 @@ static cl::opt<unsigned> MaxAccessesPerAAPointerInfo(
 
 STATISTIC(NumAAs, "Number of abstract attributes created");
 STATISTIC(NumIndirectCallsPromoted, "Number of indirect calls promoted");
+STATISTIC(NumAAPointerInfoAccessesCapped,
+          "Number of AAPointerInfo instances capped to pessimistic");
 
 // Some helper macros to deal with statistics tracking.
 //
@@ -944,8 +946,10 @@ ChangeStatus AA::PointerInfo::State::addAccess(
     std::optional<Value *> Content, AAPointerInfo::AccessKind Kind, Type *Ty,
     Instruction *RemoteI) {
   if (MaxAccessesPerAAPointerInfo > 0 &&
-      AccessList.size() >= MaxAccessesPerAAPointerInfo)
+      AccessList.size() >= MaxAccessesPerAAPointerInfo) {
+    ++NumAAPointerInfoAccessesCapped;
     return indicatePessimisticFixpoint();
+  }
 
   RemoteI = RemoteI ? RemoteI : &I;
 

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -106,6 +106,11 @@ static cl::opt<int> MaxPotentialValuesIterations(
     cl::desc(
         "Maximum number of iterations we keep dismantling potential values."),
     cl::init(64));
+static cl::opt<unsigned> MaxAccessesPerAAPointerInfo(
+    "attributor-max-pi-accesses", cl::Hidden,
+    cl::desc("Maximum number of accesses in a single AAPointerInfo instance "
+             "before going pessimistic (0 = unlimited)"),
+    cl::init(0));
 
 STATISTIC(NumAAs, "Number of abstract attributes created");
 STATISTIC(NumIndirectCallsPromoted, "Number of indirect calls promoted");
@@ -938,6 +943,10 @@ ChangeStatus AA::PointerInfo::State::addAccess(
     Attributor &A, const AAPointerInfo::RangeList &Ranges, Instruction &I,
     std::optional<Value *> Content, AAPointerInfo::AccessKind Kind, Type *Ty,
     Instruction *RemoteI) {
+  if (MaxAccessesPerAAPointerInfo > 0 &&
+      AccessList.size() >= MaxAccessesPerAAPointerInfo)
+    return indicatePessimisticFixpoint();
+
   RemoteI = RemoteI ? RemoteI : &I;
 
   // Check if we have an access for this instruction, if not, simply add it.

--- a/llvm/test/Transforms/Attributor/value-simplify-pointer-info-access-cap.ll
+++ b/llvm/test/Transforms/Attributor/value-simplify-pointer-info-access-cap.ll
@@ -45,7 +45,7 @@ define i32 @local_alloca_simplifiable() {
 ; With cap=3, the global's AAPointerInfoFloating goes pessimistic
 ; after 3 accesses and the load cannot be simplified.
 
-@G = internal global i32 undef, align 4
+@G = internal global i32 poison, align 4
 
 define void @writer1() {
   store i32 42, ptr @G, align 4

--- a/llvm/test/Transforms/Attributor/value-simplify-pointer-info-access-cap.ll
+++ b/llvm/test/Transforms/Attributor/value-simplify-pointer-info-access-cap.ll
@@ -1,0 +1,81 @@
+; NOTE: Tests that -attributor-max-pi-accesses caps AAPointerInfo and prevents
+; value simplification when the access limit is exceeded.
+
+; Without the cap, the Attributor simplifies loads via AAPointerInfo.
+; RUN: opt -aa-pipeline=basic-aa -passes=attributor -attributor-manifest-internal  -attributor-annotate-decl-cs  -S < %s | FileCheck %s --check-prefix=NOCAP
+; RUN: opt -aa-pipeline=basic-aa -passes=attributor-cgscc -attributor-manifest-internal  -attributor-annotate-decl-cs -S < %s | FileCheck %s --check-prefix=NOCAP
+
+; With cap=3, AAPointerInfo goes pessimistic after 3 accesses and
+; value simplification is blocked.
+; RUN: opt -aa-pipeline=basic-aa -passes=attributor -attributor-manifest-internal  -attributor-annotate-decl-cs  -attributor-max-pi-accesses=3 -S < %s | FileCheck %s --check-prefix=CAP
+; RUN: opt -aa-pipeline=basic-aa -passes=attributor-cgscc -attributor-manifest-internal  -attributor-annotate-decl-cs -attributor-max-pi-accesses=3 -S < %s | FileCheck %s --check-prefix=CAP
+
+; Verify that the cap triggers the expected statistic.
+; REQUIRES: asserts
+; RUN: opt -aa-pipeline=basic-aa -passes=attributor -attributor-manifest-internal  -attributor-annotate-decl-cs  -attributor-max-pi-accesses=3 -stats -S < %s 2>&1 | FileCheck %s --check-prefix=STATS
+
+
+; Test 1: Alloca with multiple stores followed by a load.
+; Without the cap, the load is simplified to the last stored value.
+; With cap=3, AAPointerInfo for %p goes pessimistic after 3 accesses
+; and the load cannot be simplified.
+
+define i32 @local_alloca_simplifiable() {
+; NOCAP-LABEL: define {{.*}}i32 @local_alloca_simplifiable
+; NOCAP-NEXT:    ret i32 5
+;
+; CAP-LABEL: define {{.*}}i32 @local_alloca_simplifiable
+; CAP:         %v = load i32, ptr %p
+; CAP-NEXT:    ret i32 %v
+  %p = alloca i32, align 4
+  store i32 1, ptr %p, align 4
+  store i32 2, ptr %p, align 4
+  store i32 3, ptr %p, align 4
+  store i32 4, ptr %p, align 4
+  store i32 5, ptr %p, align 4
+  %v = load i32, ptr %p, align 4
+  ret i32 %v
+}
+
+
+; Test 2: Inter-procedural case with an internal global.
+; Four separate functions write the same value (42) to @G.
+; Without the cap, the Attributor determines the unique stored value
+; and simplifies the load in @reader to ret i32 42.
+; With cap=3, the global's AAPointerInfoFloating goes pessimistic
+; after 3 accesses and the load cannot be simplified.
+
+@G = internal global i32 undef, align 4
+
+define void @writer1() {
+  store i32 42, ptr @G, align 4
+  ret void
+}
+
+define void @writer2() {
+  store i32 42, ptr @G, align 4
+  ret void
+}
+
+define void @writer3() {
+  store i32 42, ptr @G, align 4
+  ret void
+}
+
+define void @writer4() {
+  store i32 42, ptr @G, align 4
+  ret void
+}
+
+define i32 @reader() {
+; NOCAP-LABEL: define {{.*}}i32 @reader
+; NOCAP:         ret i32 42
+;
+; CAP-LABEL: define {{.*}}i32 @reader
+; CAP:         %v = load i32, ptr @G
+; CAP-NEXT:    ret i32 %v
+  %v = load i32, ptr @G, align 4
+  ret i32 %v
+}
+
+; STATS: {{[1-9][0-9]*}} attributor - Number of AAPointerInfo instances capped to pessimistic


### PR DESCRIPTION
During LTO of GPU programs with many kernel entry points, a single `AAPointerInfoFloating` instance for a shared global (e.g., an OpenMP runtime LDS variable like `@TeamState`) can accumulate tens of thousands of accesses. This happens because the OpenMP device runtime uses a small set of shared globals that every kernel touches, and runtime helper functions marked `alwaysinline` are inlined into kernel entry points during LTO. Each kernel's loads and stores to these globals are then recorded as direct accesses in the global's AAPointerInfoFloating instance. With N kernels in an LTO partition, a single global accumulates O(N) accesses from O(N) source functions.

Every function that references one of these globals — including compiler-generated wrapper functions, reduction helpers, and the kernels themselves — queries the global's `AAPointerInfo` via `forallInterferingAccesses`, which iterates the full access list. With O(N) querying functions each iterating an O(N)-sized list, the total cost is O(N²).

Profiling a large Fortran/OpenMP GPU application with ~300 kernel entry points confirms this:

  - forallInterferingAccesses accounted for 55% of total link time
  - A single global accumulated 21,748 accesses from 168 source functions in the dominant LTO partition
  - Scaling from ~50 to ~300 kernels caused a 6.35x increase in `forallInterferingAccesses` time for only a 2.16x increase in kernel count, confirming super-linear O(N²) behavior
  - 18.7M `AAInterFnReachability::instructionCanReach` queries were triggered, with 1.26M cache misses requiring full traversals
  - Wrapper and reduction helper functions each encountered 6-7M cross-function accesses despite their own AAPointerInfo being small (~300 accesses)

Going pessimistic is always correct (it is the conservative default). It may cause missed optimization opportunities for the affected pointers. The flag defaults to 0 (unlimited) so there is no behavioral change unless explicitly enabled.

This patch adds a `cl::opt` flag `-attributor-max-pi-accesses=<N>` (default 0 = unlimited) that caps the number of accesses in any single `AAPointerInfo` instance. When `AccessList.size()` reaches the threshold during `addAccess()`, the instance transitions to a pessimistic fixpoint via `indicatePessimisticFixpoint()`. This is safe because pessimistic is always a valid conservative answer — `forallInterferingAccesses` returns false, and callers treat this as "we know nothing about this pointer's accesses."

By placing the check in `addAccess` (the single entry point for all access recording), the cap applies uniformly to direct accesses (from `handleAccess`), imported accesses (from `translateAndAddState` and `translateAndAddStateFromCallee`), and fallback unknown accesses. No other code changes are needed — the existing pessimistic state handling in `forallInterferingAccesses`, `translateAndAddState`, and `translateAndAddStateFromCallee` already does the right thing.

On the profiled application:

  With cap=512:
  - Link time reduced by ~75% (3.96x speedup)
  - `forallInterferingAccesses` time reduced by 97% (42x)
  - O(N²) scaling eliminated: the 6.35x super-linear increase drops to 1.82x (sub-linear)
  - `AAInterFnReachability::instructionCanReach` queries reduced from 18.7M to 1.37M (13.7x)

  Threshold sweep:
  | -attributor-max-pi-accesses | Link time reduction | Speedup |
  |-----------------------------|--------------------:|--------:|
  | 2048                        |                63%  |   2.68x |
  | 1024                        |                65%  |   2.83x |
  | 512                         |                75%  |   3.96x |
  | 256                         |                75%  |   4.07x |
  | 128                         |                79%  |   4.83x |
  | 64                          |                80%  |   4.94x |

Diminishing returns below 256; the sweet spot is 128-256.

No behavioral change when the flag is not set (default 0 = unlimited).

Assisted by: Cursor