### PR TITLE
[ELF] Pass SectionPiece by reference in getSectionPiece. NFC

### DIFF
--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -1557,7 +1557,8 @@ SectionPiece &MergeInputSection::getSectionPiece(uint64_t offset) {
   if (!(flags & SHF_STRINGS))
     return pieces[offset / entsize];
   return partition_point(
-      pieces, [=](SectionPiece p) { return p.inputOff <= offset; })[-1];
+      pieces,
+      [=](const SectionPiece &p) { return p.inputOff <= offset; })[-1];
 }
 
 // Return the offset in an output section for a given input offset.


### PR DESCRIPTION
The generated assembly looks more optimized. In addition, this avoids
widened load, which would cause a TSan-detected data race with parallel
--gc-sections (#189321).