### PR TITLE
[ELF] Decouple SharedFile::isNeeded from GC mark. NFC

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1628,7 +1628,8 @@ template <class ELFT> void SharedFile::parse() {
   // --as-needed, --no-as-needed takes precedence over --as-needed because a
   // user can add an extra DSO with --no-as-needed to force it to be added to
   // the dependency list.
-  it->second->isNeeded |= isNeeded;
+  if (isNeeded)
+    it->second->isNeeded.store(true, std::memory_order_relaxed);
   if (!wasInserted)
     return;
 

--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -356,7 +356,7 @@ public:
   template <typename ELFT> void parse();
 
   // Used for --as-needed
-  bool isNeeded;
+  std::atomic<bool> isNeeded;
 
   // Non-weak undefined symbols which are not yet resolved when the SO is
   // parsed. Only filled for `--no-allow-shlib-undefined`.

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -179,13 +179,9 @@ void MarkLive<ELFT, TrackWhyLive>::resolveReloc(InputSectionBase &sec,
     return;
   }
 
-  if (auto *ss = dyn_cast<SharedSymbol>(sym)) {
-    if (!ss->isWeak()) {
-      cast<SharedFile>(ss->file)->isNeeded = true;
-      if (TrackWhyLive)
-        whyLive.try_emplace(sym, reason);
-    }
-  }
+  if (auto *ss = dyn_cast<SharedSymbol>(sym))
+    if (!ss->isWeak() && TrackWhyLive)
+      whyLive.try_emplace(sym, reason);
 
   for (InputSectionBase *sec : cNamedSections.lookup(sym->getName()))
     enqueue(sec, /*offset=*/0, /*sym=*/nullptr, reason);
@@ -546,6 +542,14 @@ template <class ELFT> void elf::markLive(Ctx &ctx) {
   // there now.
   if (ctx.partitions.size() != 1)
     MarkLive<ELFT, false>(ctx, 1).moveToMain();
+
+  // Determine which DSOs are needed. A DSO is needed if a non-weak SharedSymbol
+  // is used from a live section.
+  parallelForEach(ctx.symtab->getSymbols(), [](Symbol *sym) {
+    if (auto *ss = dyn_cast<SharedSymbol>(sym))
+      if (ss->used && !ss->isWeak())
+        cast<SharedFile>(ss->file)->isNeeded = true;
+  });
 
   // Report garbage-collected sections.
   if (ctx.arg.printGcSections.empty())


### PR DESCRIPTION
... out of the per-relocation resolveReloc and into a post-GC scan of
global symbols. This decouples the --as-needed logic from the mark
algorithm, simplifying the imminent parallel GC mark.