### PR TITLE
[ELF] Move Symbol::used to atomic flags field

### DIFF
--- a/lld/ELF/Arch/Hexagon.cpp
+++ b/lld/ELF/Arch/Hexagon.cpp
@@ -709,9 +709,8 @@ void Hexagon::finalizeRelocScan() {
                                                 "__tls_get_addr", STB_GLOBAL,
                                                 STV_DEFAULT, STT_FUNC});
           tga->isUsedInRegularObj = true;
-          tga->used = true;
           tga->isPreemptible = true;
-          tga->setFlags(NEEDS_PLT);
+          tga->setFlags(NEEDS_PLT | USED);
         }
         rel.sym = tga;
       }

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -124,7 +124,7 @@ void MarkLive<ELFT, TrackWhyLive>::resolveReloc(InputSectionBase &sec,
   } else {
     sym = &sec.file->getRelocTargetSym(rel);
   }
-  sym->used = true;
+  sym->setFlags(USED);
 
   LiveReason reason;
   if (TrackWhyLive) {
@@ -547,7 +547,7 @@ template <class ELFT> void elf::markLive(Ctx &ctx) {
   // is used from a live section.
   parallelForEach(ctx.symtab->getSymbols(), [](Symbol *sym) {
     if (auto *ss = dyn_cast<SharedSymbol>(sym))
-      if (ss->used && !ss->isWeak())
+      if (ss->hasFlag(USED) && !ss->isWeak())
         cast<SharedFile>(ss->file)->isNeeded = true;
   });
 

--- a/lld/ELF/Symbols.h
+++ b/lld/ELF/Symbols.h
@@ -40,15 +40,19 @@ const ELFSyncStream &operator<<(const ELFSyncStream &, const Symbol *);
 void printTraceSymbol(const Symbol &sym, StringRef name);
 
 enum {
-  NEEDS_GOT = 1 << 0,
-  NEEDS_PLT = 1 << 1,
-  HAS_DIRECT_RELOC = 1 << 2,
+  // True if an undefined or shared symbol is used from a live section.
+  //
+  // NOTE: In Writer.cpp the field is used to mark local defined symbols
+  // which are referenced by relocations when -r or --emit-relocs is given.
+  USED = 1 << 0,
+  NEEDS_GOT = 1 << 1,
+  NEEDS_PLT = 1 << 2,
+  HAS_DIRECT_RELOC = 1 << 3,
   // True if this symbol needs a canonical PLT entry, or (during
   // postScanRelocations) a copy relocation.
-  NEEDS_COPY = 1 << 3,
-  NEEDS_TLSDESC = 1 << 4,
-  NEEDS_TLSGD = 1 << 5,
-  // 1 << 6 unused
+  NEEDS_COPY = 1 << 4,
+  NEEDS_TLSDESC = 1 << 5,
+  NEEDS_TLSGD = 1 << 6,
   NEEDS_GOT_DTPREL = 1 << 7,
   NEEDS_TLSIE = 1 << 8,
   NEEDS_GOT_AUTH = 1 << 9,
@@ -117,13 +121,6 @@ public:
   // are unreferenced except by other bitcode objects.
   LLVM_PREFERRED_TYPE(bool)
   uint8_t isUsedInRegularObj : 1;
-
-  // True if an undefined or shared symbol is used from a live section.
-  //
-  // NOTE: In Writer.cpp the field is used to mark local defined symbols
-  // which are referenced by relocations when -r or --emit-relocs is given.
-  LLVM_PREFERRED_TYPE(bool)
-  uint8_t used : 1;
 
   // Used by a Defined symbol with protected or default visibility, to record
   // whether it is required to be exported into .dynsym. This is set when any of

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -401,11 +401,11 @@ static void markUsedLocalSymbolsImpl(ObjFile<ELFT> *file,
   for (const RelTy &rel : rels) {
     Symbol &sym = file->getRelocTargetSym(rel);
     if (sym.isLocal())
-      sym.used = true;
+      sym.setFlags(USED);
   }
 }
 
-// The function ensures that the "used" field of local symbols reflects the fact
+// The function ensures that the USED flag of local symbols reflects the fact
 // that the symbol is used in a relocation from a live section.
 template <class ELFT> static void markUsedLocalSymbols(Ctx &ctx) {
   // With --gc-sections, the field is already filled.
@@ -428,7 +428,7 @@ template <class ELFT> static void markUsedLocalSymbols(Ctx &ctx) {
         for (Elf_Crel_Impl<true> r : RelocsCrel<true>(isec->content_)) {
           Symbol &sym = file->getSymbol(r.r_symidx);
           if (sym.isLocal())
-            sym.used = true;
+            sym.setFlags(USED);
         }
       }
     }
@@ -441,7 +441,7 @@ static bool shouldKeepInSymtab(Ctx &ctx, const Defined &sym) {
 
   // If --emit-reloc or -r is given, preserve symbols referenced by relocations
   // from live sections.
-  if (sym.used && ctx.arg.copyRelocs)
+  if (sym.hasFlag(USED) && ctx.arg.copyRelocs)
     return true;
 
   // Exclude local symbols pointing to .ARM.exidx sections.
@@ -482,7 +482,7 @@ bool elf::includeInSymtab(Ctx &ctx, const Symbol &b) {
       return s->getSectionPiece(d->value).live;
     return true;
   }
-  return b.used || !ctx.arg.gcSections;
+  return b.hasFlag(USED) || !ctx.arg.gcSections;
 }
 
 // Scan local symbols to:


### PR DESCRIPTION
Move the `used` bitfield into the existing `std::atomic<uint16_t> flags`,
making it safe for concurrent access from parallel GC mark (#189321).