### PR TITLE
Use dyn_cast_or_null for COMDAT keys to prevent segfaults

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -3583,7 +3583,7 @@ bool AsmPrinter::emitSpecialLLVMGlobal(const GlobalVariable *GV) {
       int Kind = cast<ConstantInt>(C->getOperand(2))->getZExtValue();
 
       if (Src->hasDLLImportStorageClass()) {
-        // For now, we assume dllimport functionss aren't directly called.
+        // For now, we assume dllimport functions aren't directly called.
         // (We might change this later to match MSVC.)
         OutStreamer->emitCOFFSymbolIndex(
             OutContext.getOrCreateSymbol("__imp_" + Src->getName()));

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -3583,7 +3583,7 @@ bool AsmPrinter::emitSpecialLLVMGlobal(const GlobalVariable *GV) {
       int Kind = cast<ConstantInt>(C->getOperand(2))->getZExtValue();
 
       if (Src->hasDLLImportStorageClass()) {
-        // For now, we assume dllimport functions aren't directly called.
+        // For now, we assume dllimport functionss aren't directly called.
         // (We might change this later to match MSVC.)
         OutStreamer->emitCOFFSymbolIndex(
             OutContext.getOrCreateSymbol("__imp_" + Src->getName()));
@@ -3664,8 +3664,8 @@ void AsmPrinter::preprocessXXStructorList(const DataLayout &DL,
             "associated data of XXStructor list is not yet supported on AIX");
       }
 
-      S.ComdatKey =
-          dyn_cast<GlobalValue>(CS->getOperand(2)->stripPointerCasts());
+      Value *Stripped = CS->getOperand(2)->stripPointerCasts();
+      S.ComdatKey = dyn_cast_or_null<GlobalValue>(Stripped);
     }
   }
 

--- a/llvm/test/CodeGen/X86/mingw-global-ctor-null-comdat.ll
+++ b/llvm/test/CodeGen/X86/mingw-global-ctor-null-comdat.ll
@@ -1,0 +1,12 @@
+; RUN: llc -mtriple=x86_64-w64-mingw32 %s -o - | FileCheck %s
+
+; CHECK: my_init_func
+
+define internal void @my_init_func() {
+  ret void
+}
+
+; Test that the backend gracefully handles null/invalid COMDAT keys
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [
+  { i32, ptr, ptr } { i32 65535, ptr @my_init_func, ptr null }
+]


### PR DESCRIPTION
Issue :  #190008 
Cause : 
The crash occurs during the deserialization of a C++20 ` .pcm ` file on a  Clang build (version 22.1.2). The module ` deserializer ` is yielding a raw C++ ` nullptr ` (or invalid pointer) for the ` ComdatKey `  field, bypassing the frontend's usual ` ConstantPointerNull ` allocation. When standard ` dyn_cast ` receives this raw null, it faults in ` classof `.

Fix : 
Because standard  ` dyn_cast ` assumes a non-null valid object, this patch uses ` dyn_cast_or_null ` . 

Testing: 
Because the IR parser safely allocates ` ConstantPointerNull ` , it is impossible to trigger the raw ` nullptr segfault ` via an ` .ll ` file. However, I have included ` mingw-comdat-null-ctor.ll ` to verify that the backend cleanly handles the conceptual case of a null COMDAT key.
