### PR TITLE
[libc] Indentation consistency in CMake

### DIFF
--- a/libc/test/src/math/CMakeLists.txt
+++ b/libc/test/src/math/CMakeLists.txt
@@ -586,7 +586,7 @@ add_fp_unittest(
   SRCS
     roundeven_test.cpp
   HDRS
-  RoundEvenTest.h
+    RoundEvenTest.h
   DEPENDS
     libc.src.math.roundeven
     libc.src.__support.CPP.algorithm
@@ -601,7 +601,7 @@ add_fp_unittest(
   SRCS
     roundevenf_test.cpp
   HDRS
-  RoundEvenTest.h
+    RoundEvenTest.h
   DEPENDS
     libc.src.math.roundevenf
     libc.src.__support.CPP.algorithm
@@ -616,7 +616,7 @@ add_fp_unittest(
   SRCS
     roundevenl_test.cpp
   HDRS
-  RoundEvenTest.h
+    RoundEvenTest.h
   DEPENDS
     libc.src.math.roundevenl
     libc.src.__support.CPP.algorithm
@@ -631,7 +631,7 @@ add_fp_unittest(
   SRCS
     roundevenf16_test.cpp
   HDRS
-  RoundEvenTest.h
+    RoundEvenTest.h
   DEPENDS
     libc.src.math.roundevenf16
     libc.src.__support.CPP.algorithm
@@ -2086,15 +2086,15 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
- log_test
- NEED_MPFR
- SUITE
-   libc-math-unittests
- SRCS
-   log_test.cpp
- DEPENDS
-   libc.src.math.log
-   libc.src.__support.FPUtil.fp_bits
+  log_test
+  NEED_MPFR
+  SUITE
+    libc-math-unittests
+  SRCS
+    log_test.cpp
+  DEPENDS
+    libc.src.math.log
+    libc.src.__support.FPUtil.fp_bits
 )
 
 add_fp_unittest(
@@ -2133,15 +2133,15 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
-log2_test
- NEED_MPFR
- SUITE
-   libc-math-unittests
- SRCS
-   log2_test.cpp
- DEPENDS
-   libc.src.math.log2
-   libc.src.__support.FPUtil.fp_bits
+  log2_test
+  NEED_MPFR
+  SUITE
+    libc-math-unittests
+  SRCS
+    log2_test.cpp
+  DEPENDS
+    libc.src.math.log2
+    libc.src.__support.FPUtil.fp_bits
 )
 
 add_fp_unittest(
@@ -2169,15 +2169,15 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
- log10_test
- NEED_MPFR
- SUITE
-   libc-math-unittests
- SRCS
-   log10_test.cpp
- DEPENDS
-   libc.src.math.log10
-   libc.src.__support.FPUtil.fp_bits
+  log10_test
+  NEED_MPFR
+  SUITE
+    libc-math-unittests
+  SRCS
+    log10_test.cpp
+  DEPENDS
+    libc.src.math.log10
+    libc.src.__support.FPUtil.fp_bits
 )
 
 add_fp_unittest(
@@ -2226,15 +2226,15 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
-log1p_test
- NEED_MPFR
- SUITE
-   libc-math-unittests
- SRCS
-   log1p_test.cpp
- DEPENDS
-   libc.src.math.log1p
-   libc.src.__support.FPUtil.fp_bits
+  log1p_test
+  NEED_MPFR
+  SUITE
+    libc-math-unittests
+  SRCS
+    log1p_test.cpp
+  DEPENDS
+    libc.src.math.log1p
+    libc.src.__support.FPUtil.fp_bits
 )
 
 add_fp_unittest(


### PR DESCRIPTION
This PR just fixes the indentation/style for the whole CMake file for consistency.
No other changes.
c698f55b0245ffbaae55c7f854fadba33df16e9d