### PR TITLE
[lldb][AArch64][Linux] Qualify uses of user_sve_header

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
@@ -1179,9 +1179,9 @@ Status NativeRegisterContextLinux_arm64::WriteAllRegisterValues(
             (data_size + sve::vq_bytes - 1) / sve::vq_bytes * sve::vq_bytes;
         std::vector<uint8_t> sve_fpsimd_data(data_size);
 
-        user_sve_header *header =
-            reinterpret_cast<user_sve_header *>(sve_fpsimd_data.data());
-        std::memset(header, 0, sizeof(user_sve_header));
+        sve::user_sve_header *header =
+            reinterpret_cast<sve::user_sve_header *>(sve_fpsimd_data.data());
+        std::memset(header, 0, sizeof(sve::user_sve_header));
         header->size = sve_fpsimd_data.size();
         // VL = 0 tells the process to exit streaming mode.
         header->vl = 0;


### PR DESCRIPTION
Fixes #165413. Where a build failure was reported:
```
/b/s/w/ir/x/w/llvm-llvm-project/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp:1182:9: error: unknown type name 'user_sve_header'; did you mean 'sve::user_sve_header'?
 1182 |         user_sve_header *header =
      |         ^~~~~~~~~~~~~~~
      |         sve::user_sve_header
```
To fix this, add sve:: as we do for all other uses of this.

This is LLDB's copy of a structure that Linux also defines. I think the build worked on some machines because that version ended up being included, but with a more isolated build, it may not.

We have our own definition of it so we can be sure what we're using in case Linux extends it later.