### PR TITLE
[analyzer] Canonicalize _Atomic pointers in makeNullWithType

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
@@ -346,10 +346,11 @@ public:
   /// \param type pointer type.
   loc::ConcreteInt makeNullWithType(QualType type) {
     // We cannot use the `isAnyPointerType()`.
-    assert((type->isPointerType() || type->isObjCObjectPointerType() ||
-            type->isBlockPointerType() || type->isNullPtrType() ||
-            type->isReferenceType()) &&
+    assert((type->isObjCObjectPointerType() || Loc::isLocType(type)) &&
            "makeNullWithType must use pointer type");
+
+    type =
+        type->isAtomicType() ? type->getAs<AtomicType>()->getValueType() : type;
 
     // The `sizeof(T&)` is `sizeof(T)`, thus we replace the reference with a
     // pointer. Here we assume that references are actually implemented by

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
@@ -345,12 +345,12 @@ public:
   /// space.
   /// \param type pointer type.
   loc::ConcreteInt makeNullWithType(QualType type) {
+    type =
+        type->isAtomicType() ? type->getAs<AtomicType>()->getValueType() : type;
+
     // We cannot use the `isAnyPointerType()`.
     assert((type->isObjCObjectPointerType() || Loc::isLocType(type)) &&
            "makeNullWithType must use pointer type");
-
-    type =
-        type->isAtomicType() ? type->getAs<AtomicType>()->getValueType() : type;
 
     // The `sizeof(T&)` is `sizeof(T)`, thus we replace the reference with a
     // pointer. Here we assume that references are actually implemented by

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SVals.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SVals.h
@@ -260,6 +260,7 @@ public:
   void dumpToStream(raw_ostream &Out) const;
 
   static bool isLocType(QualType T) {
+    T = T->isAtomicType() ? T->getAs<AtomicType>()->getValueType() : T;
     return T->isAnyPointerType() || T->isBlockPointerType() ||
            T->isReferenceType() || T->isNullPtrType();
   }

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SVals.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SVals.h
@@ -260,7 +260,6 @@ public:
   void dumpToStream(raw_ostream &Out) const;
 
   static bool isLocType(QualType T) {
-    T = T->isAtomicType() ? T->getAs<AtomicType>()->getValueType() : T;
     return T->isAnyPointerType() || T->isBlockPointerType() ||
            T->isReferenceType() || T->isNullPtrType();
   }

--- a/clang/test/Analysis/atomics.c
+++ b/clang/test/Analysis/atomics.c
@@ -101,3 +101,8 @@ void test_atomic_compare(int input) {
     // no crash
   }
 }
+
+void test_atomic_gh187925(void) {
+  void foo(_Atomic(void*));
+  foo(0); // no assertion failure
+}


### PR DESCRIPTION
fixes: https://github.com/llvm/llvm-project/issues/187925

Previous code did not handle passing AtomicType to `makeNullWithType` and this led to an assertion failure.

This change updates `makeNullWithType` to allow for atomic types to be passed in and to "unwrap" them in order to get the correct pointer/reference type for constructing the nullptr.