### PR TITLE
[AArch64][GISel] Skip SME call-attr checks on non-SME targets

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -31418,12 +31418,11 @@ bool AArch64TargetLowering::fallBackToDAGISel(const Instruction &Inst) const {
 
   // Checks to allow the use of SME instructions
   if (auto *Base = dyn_cast<CallBase>(&Inst)) {
-    const Function *Caller = Base->getCaller();
-    // Per-call SME attribute checks via SMECallAttrs can be compile-time
-    // expensive, avoid for non-SME targets.
-    if (Subtarget->hasSME() ||
-        Caller->hasFnAttribute("aarch64_pstate_sm_compatible") ||
-        Caller->hasFnAttribute("aarch64_za_state_agnostic")) {
+    // Per-call SME attribute checks via SMECallAttrs are compile-time
+    // expensive, avoid for non-SME targets. We do the checks even if the
+    // target only has SVE, since streaming-mode changes might still be
+    // required.
+    if (Subtarget->hasSME() || Subtarget->hasSVE()) {
       auto CallAttrs = SMECallAttrs(*Base, &getRuntimeLibcallsInfo());
       if (CallAttrs.requiresSMChange() || CallAttrs.requiresLazySave() ||
           CallAttrs.requiresPreservingZT0() ||

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -31417,12 +31417,15 @@ bool AArch64TargetLowering::fallBackToDAGISel(const Instruction &Inst) const {
   }
 
   // Checks to allow the use of SME instructions
-  if (auto *Base = dyn_cast<CallBase>(&Inst)) {
-    auto CallAttrs = SMECallAttrs(*Base, &getRuntimeLibcallsInfo());
-    if (CallAttrs.requiresSMChange() || CallAttrs.requiresLazySave() ||
-        CallAttrs.requiresPreservingZT0() ||
-        CallAttrs.requiresPreservingAllZAState())
-      return true;
+  // If the subtarget lacks SME/SME2 we can skip per-call SME attribute checks.
+  if (Subtarget->hasSME() || Subtarget->hasSME2()) {
+    if (auto *Base = dyn_cast<CallBase>(&Inst)) {
+      auto CallAttrs = SMECallAttrs(*Base, &getRuntimeLibcallsInfo());
+      if (CallAttrs.requiresSMChange() || CallAttrs.requiresLazySave() ||
+          CallAttrs.requiresPreservingZT0() ||
+          CallAttrs.requiresPreservingAllZAState())
+        return true;
+    }
   }
   return false;
 }

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -31419,6 +31419,8 @@ bool AArch64TargetLowering::fallBackToDAGISel(const Instruction &Inst) const {
   // Checks to allow the use of SME instructions
   if (auto *Base = dyn_cast<CallBase>(&Inst)) {
     const Function *Caller = Base->getCaller();
+    // Per-call SME attribute checks via SMECallAttrs can be compile-time
+    // expensive, avoid for non-SME targets.
     if (Subtarget->hasSME() ||
         Caller->hasFnAttribute("aarch64_pstate_sm_compatible") ||
         Caller->hasFnAttribute("aarch64_za_state_agnostic")) {

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -31417,9 +31417,11 @@ bool AArch64TargetLowering::fallBackToDAGISel(const Instruction &Inst) const {
   }
 
   // Checks to allow the use of SME instructions
-  // If the subtarget lacks SME/SME2 we can skip per-call SME attribute checks.
-  if (Subtarget->hasSME() || Subtarget->hasSME2()) {
-    if (auto *Base = dyn_cast<CallBase>(&Inst)) {
+  if (auto *Base = dyn_cast<CallBase>(&Inst)) {
+    const Function *Caller = Base->getCaller();
+    if (Subtarget->hasSME() ||
+        Caller->hasFnAttribute("aarch64_pstate_sm_compatible") ||
+        Caller->hasFnAttribute("aarch64_za_state_agnostic")) {
       auto CallAttrs = SMECallAttrs(*Base, &getRuntimeLibcallsInfo());
       if (CallAttrs.requiresSMChange() || CallAttrs.requiresLazySave() ||
           CallAttrs.requiresPreservingZT0() ||


### PR DESCRIPTION
`fallBackToDAGISel` was constructing `SMECallAttrs` for every call even when the subtarget had no SME/SME2 support. This shows up in compile-time profiles without ever triggering a fallback.

https://llvm-compile-time-tracker.com/compare.php?from=ed44820f722aae43f1f00bb3e201300966716973&to=ba75f8fe1f0e44f7456dd282e066b6d6e781ada3&stat=instructions%3Au