### PR TITLE
fixup! [clang][analyzer] Forward CTU-import failure conditions

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCrossTUKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCrossTUKinds.td
@@ -41,7 +41,7 @@ def err_ctu_import_failure: Error<
 
 def remark_ctu_import_threshold_reached: Remark<
   "reached a the CTU-import threshold before trying to import definition">,
-  InGroup<CrossTU>;
+  InGroup<CrossTURemarks>;
 
 def warn_ctu_incompat_lang : Warning<
   "imported AST from '%0' had been generated for a different language, "

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1800,6 +1800,7 @@ def BoundsSafetyCountedByEltTyUnknownSize :
 
 // A group for cross translation unit static analysis related warnings.
 def CrossTU : DiagGroup<"ctu">;
+def CrossTURemarks : DiagGroup<"ctu-remarks">;
 
 def CTADMaybeUnsupported : DiagGroup<"ctad-maybe-unsupported">;
 

--- a/clang/test/Analysis/ctu/diag/load-threshold.cpp
+++ b/clang/test/Analysis/ctu/diag/load-threshold.cpp
@@ -25,7 +25,7 @@
 // RUN:   -analyzer-config experimental-enable-naive-ctu-analysis=true \
 // RUN:   -analyzer-config ctu-dir=%t \
 // RUN:   -analyzer-config ctu-import-cpp-threshold=1 \
-// RUN:   -Rctu \
+// RUN:   -Rctu-remarks \
 // RUN:   -verify %s
 
 // foo is loaded successfully (first load, within threshold).


### PR DESCRIPTION
Fix the Sphinx build failure  https://lab.llvm.org/buildbot/#/builders/45/builds/24533
introduced in e3cfcf48d0c966f163c9807839a900936af0e759 (PR #189064)  by using a dedicated group for CTU remarks.

```
73.006 [8/5/546] Building DiagnosticsReference.rst...
FAILED: tools/clang/docs/DiagnosticsReference.rst /work/as-worker-4/publish-sphinx-docs/build/tools/clang/docs/DiagnosticsReference.rst
/work/as-worker-4/publish-sphinx-docs/llvm-project/clang/docs/../include/clang/Basic/DiagnosticGroups.td:1802:5: error: Diagnostic group contains both remark and non-remark diagnostics
def CrossTU : DiagGroup<"ctu">;
    ^
```