### PR TITLE
[llvm][docs] Fix typo

### DIFF
--- a/llvm/docs/GettingStarted.rst
+++ b/llvm/docs/GettingStarted.rst
@@ -174,7 +174,7 @@ Once llvm is installed, to configure a project for a stand-alone build, invoke C
 Notice that:
 
 * The stand-alone build needs to happen in a folder that is not the
-  original folder where LLVMN was built
+  original folder where LLVM was built
   (`$builddir!=$builddir_subproj`).
 * ``LLVM_ROOT`` should point to the prefix of your llvm installation,
   so for example, if llvm is installed into ``/usr/bin`` and


### PR DESCRIPTION
This commit corrects a typo in the project documentation.