### PR TITLE
[clang][ssaf] Fix nondeterministic test failures of clang/test/Analysis/Scalable/call-graph.cpp

### DIFF
--- a/clang/test/Analysis/Scalable/call-graph.cpp
+++ b/clang/test/Analysis/Scalable/call-graph.cpp
@@ -1,39 +1,44 @@
-// RUN: rm -rf %t.summary.json
-// RUN: %clang_cc1 -fsyntax-only %s \
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -fsyntax-only %t/caller.cpp \
 // RUN:   --ssaf-extract-summaries=CallGraph \
-// RUN:   --ssaf-tu-summary-file=%t.summary.json
-// RUN: FileCheck %s --match-full-lines --input-file=%t.summary.json
+// RUN:   --ssaf-tu-summary-file=%t/caller.summary.json
+// RUN: FileCheck --match-full-lines --check-prefix=CALLER %t/caller.cpp --input-file=%t/caller.summary.json
 
-// caller() has a direct callee and no virtual callees.
-//   CHECK-LABEL: "entity_summary": {
-//   CHECK-DAG:     "def": {
-//   CHECK-DAG:       "col": {{[0-9]+}},
-//   CHECK-DAG:       "file": "{{.+}}",
-//   CHECK-DAG:       "line": {{[0-9]+}}
-//   CHECK-DAG:     "pretty_name": "caller()",
-//   CHECK-DAG:     "direct_callees": [
-//   CHECK-DAG:     "virtual_callees": []
+// RUN: %clang_cc1 -fsyntax-only %t/polymorphic.cpp \
+// RUN:   --ssaf-extract-summaries=CallGraph \
+// RUN:   --ssaf-tu-summary-file=%t/polymorphic.summary.json
+// RUN: FileCheck --match-full-lines --check-prefix=POLYMORPHIC %t/polymorphic.cpp --input-file=%t/polymorphic.summary.json
 
+//--- caller.cpp
 // polymorphic() has a virtual callee and no direct callees.
-//   CHECK-LABEL: "entity_summary": {
-//   CHECK-DAG:     "def": {
-//   CHECK-DAG:       "col": {{[0-9]+}},
-//   CHECK-DAG:       "file": "{{.+}}",
-//   CHECK-DAG:       "line": {{[0-9]+}}
-//   CHECK-DAG:     "pretty_name": "polymorphic(Base &)",
-//   CHECK-DAG:     "direct_callees": [],
-//   CHECK-DAG:     "virtual_callees": [
+//   CALLER-DAG:     "def": {
+//   CALLER-DAG:       "col": {{[0-9]+}},
+//   CALLER-DAG:       "file": "{{.+}}",
+//   CALLER-DAG:       "line": {{[0-9]+}}
+//   CALLER-DAG:     "pretty_name": "caller()",
+//   CALLER-DAG:     "direct_callees": [
+//   CALLER-DAG:     "virtual_callees": []
+void callee();
+void caller() {
+  callee();
+}
 
+//--- polymorphic.cpp
+// polymorphic() has a virtual callee and no direct callees.
+//   POLYMORPHIC-DAG:     "def": {
+//   POLYMORPHIC-DAG:       "col": {{[0-9]+}},
+//   POLYMORPHIC-DAG:       "file": "{{.+}}",
+//   POLYMORPHIC-DAG:       "line": {{[0-9]+}}
+//   POLYMORPHIC-DAG:     "pretty_name": "polymorphic(Base &)",
+//   POLYMORPHIC-DAG:     "direct_callees": [],
+//   POLYMORPHIC-DAG:     "virtual_callees": [
 struct Base {
   virtual ~Base();
   virtual void vmethod();
 };
-
-void callee();
-
-void caller() {
-  callee();
-}
 
 void polymorphic(Base &b) {
   b.vmethod();


### PR DESCRIPTION
fixup! [clang][ssaf] Implement JSON format for CallGraph summary

The order of checks were unspecified in the test.
Consequently, "polymorphic" may have appeared before "caller" failing the test.

This patch splits the test into separate files so these wouldn't interfere.

Example bot failures:
https://lab.llvm.org/buildbot/#/builders/225/builds/4974
https://lab.llvm.org/buildbot/#/builders/144/builds/50732
https://lab.llvm.org/buildbot/#/builders/190/builds/39773
https://lab.llvm.org/buildbot/#/builders/46/builds/33213

Fixes up #189681