### PR TITLE
[mlir][EmitC] Add tests for arith.max/min float/signed int conversions

### DIFF
--- a/mlir/test/Conversion/ArithToEmitC/arith-expand-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-expand-to-emitc.mlir
@@ -1,0 +1,65 @@
+// RUN: mlir-opt -arith-expand -convert-arith-to-emitc %s | FileCheck %s
+
+/// This file checks the combined `-arith-expand | -convert-arith-to-emitc`
+/// pipeline with intentionally minimal FileCheck coverage.
+/// The full expansion is covered in `test/Dialect/Arith/expand-ops.mlir`, and
+/// the full ArithToEmitC lowering is covered in
+/// `test/Conversion/ArithToEmitC/arith-to-emitc.mlir`; this test only covers
+/// that the combination of the two produces the expected EmitC ops.
+
+/// Vector cases excluded because `arith.maximumf`/`arith.minimumf` expansion
+/// introduces `arith.cmpf`, and ArithToEmitC cannot convert `VectorType`.
+/// i.e. operand conversion for `vector<...>` fails before `cmpf` lowering.
+
+/// Tensor cases excluded because `arith.maximumf`/`arith.minimumf` expansion
+/// introduces `arith.cmpf`, but ArithToEmitC only lowers scalar `cmpf`.
+/// i.e. `cmpf` rejects tensors with: "only supported on floats, not
+/// tensors/vectors thereof".
+
+// CHECK-LABEL: func @maximumf
+// CHECK-SAME:  %[[ARG0:.*]]: f32, %[[ARG1:.*]]: f32) -> f32
+func.func @maximumf(%a: f32, %b: f32) -> f32 {
+// CHECK-NOT:   arith
+// CHECK:       %[[CMP:.*]] = emitc.cmp gt, %[[ARG0]], %[[ARG1]] : (f32, f32) -> i1
+// CHECK:       %[[OR:.*]] = emitc.logical_or %{{.*}}, %[[CMP]] : i1, i1
+// CHECK:       %[[SEL0:.*]] = emitc.conditional %[[OR]], %[[ARG0]], %[[ARG1]] : f32
+// CHECK:       %[[SEL1:.*]] = emitc.conditional %{{.*}}, %[[ARG1]], %[[SEL0]] : f32
+  %result = arith.maximumf %a, %b : f32
+// CHECK:       return %[[SEL1]] : f32
+  return %result : f32
+}
+
+// CHECK-LABEL: func @minimumf
+// CHECK-SAME:  %[[ARG0:.*]]: f32, %[[ARG1:.*]]: f32) -> f32
+func.func @minimumf(%a: f32, %b: f32) -> f32 {
+// CHECK-NOT:   arith
+// CHECK:       %[[CMP:.*]] = emitc.cmp lt, %[[ARG0]], %[[ARG1]] : (f32, f32) -> i1
+// CHECK:       %[[OR:.*]] = emitc.logical_or %{{.*}}, %[[CMP]] : i1, i1
+// CHECK:       %[[SEL0:.*]] = emitc.conditional %[[OR]], %[[ARG0]], %[[ARG1]] : f32
+// CHECK:       %[[SEL1:.*]] = emitc.conditional %{{.*}}, %[[ARG1]], %[[SEL0]] : f32
+  %result = arith.minimumf %a, %b : f32
+// CHECK:       return %[[SEL1]] : f32
+  return %result : f32
+}
+
+// CHECK-LABEL: func @minsi
+// CHECK-SAME:  %[[ARG0:.*]]: i32, %[[ARG1:.*]]: i32) -> i32
+func.func @minsi(%a: i32, %b: i32) -> i32 {
+// CHECK-NOT:   arith
+// CHECK:       %[[CMP:.*]] = emitc.cmp lt, %[[ARG0]], %[[ARG1]] : (i32, i32) -> i1
+// CHECK:       %[[SEL:.*]] = emitc.conditional %[[CMP]], %[[ARG0]], %[[ARG1]] : i32
+  %result = arith.minsi %a, %b : i32
+// CHECK:       return %[[SEL]] : i32
+  return %result : i32
+}
+
+// CHECK-LABEL: func @maxsi
+// CHECK-SAME:  %[[ARG0:.*]]: i32, %[[ARG1:.*]]: i32) -> i32
+func.func @maxsi(%a: i32, %b: i32) -> i32 {
+// CHECK-NOT:   arith
+// CHECK:       %[[CMP:.*]] = emitc.cmp gt, %[[ARG0]], %[[ARG1]] : (i32, i32) -> i1
+// CHECK:       %[[SEL:.*]] = emitc.conditional %[[CMP]], %[[ARG0]], %[[ARG1]] : i32
+  %result = arith.maxsi %a, %b : i32
+// CHECK:       return %[[SEL]] : i32
+  return %result : i32
+}

--- a/mlir/test/Dialect/EmitC/arith/ops.mlir
+++ b/mlir/test/Dialect/EmitC/arith/ops.mlir
@@ -7,14 +7,9 @@
 /// `test/Conversion/ArithToEmitC/arith-to-emitc.mlir`; this test only covers
 /// that the combination of the two produces the expected EmitC ops.
 
-/// Vector cases excluded because `arith.maximumf`/`arith.minimumf` expansion
-/// introduces `arith.cmpf`, and ArithToEmitC cannot convert `VectorType`.
-/// i.e. operand conversion for `vector<...>` fails before `cmpf` lowering.
-
-/// Tensor cases excluded because `arith.maximumf`/`arith.minimumf` expansion
-/// introduces `arith.cmpf`, but ArithToEmitC only lowers scalar `cmpf`.
-/// i.e. `cmpf` rejects tensors with: "only supported on floats, not
-/// tensors/vectors thereof".
+/// `arith.maximumf`/`arith.minimumf` expand through `arith.cmpf`.
+/// Vector cases excluded because ArithToEmitC cannot convert `VectorType`.
+/// Tensor cases excluded because ArithToEmitC only lowers scalar `cmpf`.
 
 // CHECK-LABEL: func @maximumf
 // CHECK-SAME:  %[[ARG0:.*]]: f32, %[[ARG1:.*]]: f32) -> f32


### PR DESCRIPTION
This patch adds test coverage for the combined `-arith-expand | -convert-arith-to-emitc`  
pipeline for selected `arith` max/min operations.

The new tests exercise:

- `arith.maximumf`
- `arith.minimumf`
- `arith.minsi`
- `arith.maxsi`

The intent is not to re-test the individual passes in isolation. Expansion is  
already covered in `test/Dialect/Arith/expand-ops.mlir`, and the direct  
Arith-to-EmitC lowering is already covered in  
`test/Conversion/ArithToEmitC/arith-to-emitc.mlir`. This patch specifically  
checks that the combined pipeline produces the expected EmitC operations after  
expansion.

For floating-point max/min, the test verifies the expanded form lowers to the  
expected sequence of `emitc.cmp`, `emitc.logical_or`, and `emitc.conditional` 
operations. For signed integer min/max, it verifies lowering to the expected  
`emitc.cmp` and `emitc.conditional` sequence.

The test also documents currently unsupported cases for the combined pipeline:  
vector cases are excluded because expansion introduces `arith.cmpf`, and  
`ArithToEmitC` does not convert `VectorType`; tensor cases are excluded because  
`ArithToEmitC` only lowers scalar `cmpf`.

Assisted-by: Codex (refine tests and comments).
I reviewed all code and tests before submission.
