### PR TITLE
[llvm] Re-enable llvm-debuginfod-find/headers-winhttp.test

### DIFF
--- a/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
+++ b/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, http-server, disabled-temp
+REQUIRES: system-windows, http-server
 
 RUN: not llvm-debuginfod-find --debuginfo 0 2>&1 | FileCheck %s --check-prefix CHECK-STDOUT
 CHECK-STDOUT: Build ID 00 could not be found


### PR DESCRIPTION
This test fails on Windows bots for unclear reasons