### PR TITLE
[RISCV] Fix stack frame layout diagrams in RISCVFrameLowering (NFC)

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -1482,10 +1482,10 @@ RISCVFrameLowering::getFrameIndexReference(const MachineFunction &MF, int FI,
     // If the stack was realigned, the frame pointer is set in order to allow
     // SP to be restored, so we need another base register to record the stack
     // after realignment.
-    // |--------------------------| -- <-- FP
+    // |--------------------------| --
     // | callee-allocated save    | | <----|
     // | area for register varargs| |      |
-    // |--------------------------| |      |
+    // |--------------------------| <-- FP |
     // | callee-saved registers   | |      |
     // |--------------------------| --     |
     // | realignment (the size of | |      |
@@ -1527,10 +1527,10 @@ RISCVFrameLowering::getFrameIndexReference(const MachineFunction &MF, int FI,
     // When using FP to access scalable vector objects, we need to minus
     // the frame size.
     //
-    // |--------------------------| -- <-- FP
+    // |--------------------------| --
     // | callee-allocated save    | |
     // | area for register varargs| |
-    // |--------------------------| |
+    // |--------------------------| | -- <-- FP
     // | callee-saved registers   | |
     // |--------------------------| | MFI.getStackSize()
     // | scalar local variables   | |
@@ -1558,10 +1558,10 @@ RISCVFrameLowering::getFrameIndexReference(const MachineFunction &MF, int FI,
 
   // When using SP to access frame objects, we need to add RVV stack size.
   //
-  // |--------------------------| -- <-- FP
+  // |--------------------------| --
   // | callee-allocated save    | | <----|
   // | area for register varargs| |      |
-  // |--------------------------| |      |
+  // |--------------------------| |      | <-- FP
   // | callee-saved registers   | |      |
   // |--------------------------| --     |
   // | RVV alignment padding    | |      |


### PR DESCRIPTION
Fix stack layout diagram by pointing FP to start of the callee allocated varargs instead of at the end.