### PR TITLE
[Codegen] Relax start stop test so riscv passes

### DIFF
--- a/llvm/test/CodeGen/X86/llc-start-stop.ll
+++ b/llvm/test/CodeGen/X86/llc-start-stop.ll
@@ -18,7 +18,7 @@
 ; RUN: llc < %s -debug-pass=Structure -start-after=loop-reduce -o /dev/null 2>&1 | FileCheck %s -check-prefix=START-AFTER
 ; START-AFTER: -gc-lowering
 ; START-AFTER: FunctionPass Manager
-; START-AFTER-NEXT: Lower Garbage Collection Instructions
+; START-AFTER: Lower Garbage Collection Instructions
 
 ; RUN: llc < %s -debug-pass=Structure -start-before=loop-reduce -o /dev/null 2>&1 | FileCheck %s -check-prefix=START-BEFORE
 ; START-BEFORE: -machine-branch-prob -regalloc-evict -regalloc-priority -domtree


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/pull/77370 this test fails in riscv. That's because it runs Loop Terminator Folding and the next check is then wrong

