### PR TITLE
[lldb][AIX] Enable NativeProcessAIX Manager for lldb-server

### DIFF
--- a/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
@@ -86,7 +86,7 @@ NativeProcessAIX::Manager::Launch(ProcessLaunchInfo &launch_info,
 
   ProcessInstanceInfo Info;
   if (!Host::GetProcessInfo(pid, Info)) {
-    return llvm::make_error<StringError>("Cannot get process architectrue",
+    return llvm::make_error<StringError>("Cannot get process architecture",
                                          llvm::inconvertibleErrorCode());
   }
 

--- a/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
@@ -84,9 +84,19 @@ NativeProcessAIX::Manager::Launch(ProcessLaunchInfo &launch_info,
   }
   LLDB_LOG(log, "inferior started, now in stopped state");
 
+  ProcessInstanceInfo Info;
+  if (!Host::GetProcessInfo(pid, Info)) {
+    return llvm::make_error<StringError>("Cannot get process architectrue",
+                                         llvm::inconvertibleErrorCode());
+  }
+
+  // Set the architecture to the exe architecture.
+  LLDB_LOG(log, "pid = {0}, detected architecture {1}", pid,
+           Info.GetArchitecture().GetArchitectureName());
+
   return std::unique_ptr<NativeProcessAIX>(new NativeProcessAIX(
       pid, launch_info.GetPTY().ReleasePrimaryFileDescriptor(), native_delegate,
-      HostInfo::GetArchitecture(HostInfo::eArchKind64), *this, {pid}));
+      Info.GetArchitecture(), *this, {pid}));
 }
 
 llvm::Expected<std::unique_ptr<NativeProcessProtocol>>
@@ -240,6 +250,11 @@ size_t NativeProcessAIX::UpdateThreads() {
   // respect to thread state and they keep the thread list populated properly.
   // All this method needs to do is return the thread count.
   return m_threads.size();
+}
+
+Status NativeProcessAIX::GetFileLoadAddress(const llvm::StringRef &file_name,
+                                            lldb::addr_t &load_addr) {
+  return Status("unsupported");
 }
 
 Status NativeProcessAIX::GetLoadedModuleFileSpec(const char *module_path,

--- a/lldb/tools/lldb-server/lldb-gdbserver.cpp
+++ b/lldb/tools/lldb-server/lldb-gdbserver.cpp
@@ -94,7 +94,7 @@ public:
   }
 };
 #endif
-} // namespace
+}
 
 #ifndef _WIN32
 // Watch for signals
@@ -138,8 +138,9 @@ llvm::Error handle_attach(GDBRemoteCommunicationServerLLGS &gdb_server,
   const long int pid = strtol(attach_target.c_str(), &end_p, 10);
 
   // We'll call it a match if the entire argument is consumed.
-  if (end_p && static_cast<size_t>(end_p - attach_target.c_str()) ==
-                   attach_target.size())
+  if (end_p &&
+      static_cast<size_t>(end_p - attach_target.c_str()) ==
+          attach_target.size())
     return handle_attach_to_pid(gdb_server, static_cast<lldb::pid_t>(pid));
   return handle_attach_to_process_name(gdb_server, attach_target);
 }

--- a/lldb/tools/lldb-server/lldb-gdbserver.cpp
+++ b/lldb/tools/lldb-server/lldb-gdbserver.cpp
@@ -46,6 +46,8 @@
 #include "Plugins/Process/NetBSD/NativeProcessNetBSD.h"
 #elif defined(_WIN32)
 #include "Plugins/Process/Windows/Common/NativeProcessWindows.h"
+#elif defined(_AIX)
+#include "Plugins/Process/AIX/NativeProcessAIX.h"
 #endif
 
 #ifndef LLGS_PROGRAM_NAME
@@ -71,6 +73,8 @@ typedef process_freebsd::NativeProcessFreeBSD::Manager NativeProcessManager;
 typedef process_netbsd::NativeProcessNetBSD::Manager NativeProcessManager;
 #elif defined(_WIN32)
 typedef NativeProcessWindows::Manager NativeProcessManager;
+#elif defined(_AIX)
+typedef process_aix::NativeProcessAIX::Manager NativeProcessManager;
 #else
 // Dummy implementation to make sure the code compiles
 class NativeProcessManager : public NativeProcessProtocol::Manager {
@@ -90,7 +94,7 @@ public:
   }
 };
 #endif
-}
+} // namespace
 
 #ifndef _WIN32
 // Watch for signals
@@ -134,9 +138,8 @@ llvm::Error handle_attach(GDBRemoteCommunicationServerLLGS &gdb_server,
   const long int pid = strtol(attach_target.c_str(), &end_p, 10);
 
   // We'll call it a match if the entire argument is consumed.
-  if (end_p &&
-      static_cast<size_t>(end_p - attach_target.c_str()) ==
-          attach_target.size())
+  if (end_p && static_cast<size_t>(end_p - attach_target.c_str()) ==
+                   attach_target.size())
     return handle_attach_to_pid(gdb_server, static_cast<lldb::pid_t>(pid));
   return handle_attach_to_process_name(gdb_server, attach_target);
 }


### PR DESCRIPTION
This PR is in reference to porting LLDB on AIX. Ref discusssions: [llvm discourse](https://discourse.llvm.org/t/port-lldb-to-ibm-aix/80640) and https://github.com/llvm/llvm-project/issues/101657.
Complete changes together in this draft:
- https://github.com/llvm/llvm-project/pull/102601

Description:
This change enables proper AIX processes integration with lldb-server,  ensuring correct loading and handling of AIX target architectures.
It also retrieves the target process architecture from the host and configures NativeProcessAIX accordingly.