### PR TITLE
[lldb][windows] simplify the ConPTY draining subprocess

### DIFF
--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -252,7 +252,7 @@ llvm::Error PseudoConsole::DrainInitSequences() {
         std::error_code(GetLastError(), std::system_category()),
         "Failed to get the 'COMSPEC' environment variable");
 
-  std::wstring cmdline_str = std::wstring(comspec) + L" /c 'echo foo && exit'";
+  std::wstring cmdline_str = std::wstring(comspec) + L" /c cls";
   std::vector<wchar_t> cmdline(cmdline_str.begin(), cmdline_str.end());
   cmdline.push_back(L'\0');
 


### PR DESCRIPTION
In some environments like swiftlang, the `''` causes the command used to drain the init sequence of the ConPTY to fail. Replacing with a `cls` invocation removes the need for quotation marks and works just as well.