### PR TITLE
[lldb] Make argument to ConstString::AsCString explicit

### DIFF
--- a/lldb/include/lldb/DataFormatters/FormattersContainer.h
+++ b/lldb/include/lldb/DataFormatters/FormattersContainer.h
@@ -104,7 +104,7 @@ public:
       // Skip callback matching in these cases.
       if (candidate_type.GetScriptInterpreter())
         return candidate_type.GetScriptInterpreter()->FormatterCallbackFunction(
-            m_name.AsCString(),
+            m_name.AsCString(nullptr),
             std::make_shared<TypeImpl>(candidate_type.GetType()));
     }
     return false;

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -23,6 +23,7 @@
 #include "lldb/DataFormatters/FormatterBytecode.h"
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/ValueObject/ValueObject.h"
+#include "llvm/Support/ErrorExtras.h"
 
 namespace lldb_private {
 class SyntheticChildrenFrontEnd {
@@ -52,8 +53,7 @@ public:
   /// subscripting behavior - for example a sparse array, disable automatic
   /// subscripting with TypeOptions::eTypeOptionCustomSubscripting.
   virtual llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
+    return llvm::createStringErrorV("Type has no child named '{0}'", name);
   }
 
   /// This function is assumed to always succeed and if it fails, the front-end
@@ -120,8 +120,7 @@ public:
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override { return nullptr; }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
+    return llvm::createStringErrorV("Type has no child named '{0}'", name);
   }
 
   lldb::ChildCacheState Update() override {

--- a/lldb/include/lldb/Utility/ConstString.h
+++ b/lldb/include/lldb/Utility/ConstString.h
@@ -178,14 +178,9 @@ public:
 
   /// Get the string value as a C string.
   ///
-  /// Get the value of the contained string as a NULL terminated C string
-  /// value.
-  ///
-  /// If \a value_if_empty is nullptr, then nullptr will be returned.
-  ///
   /// \return Returns \a value_if_empty if the string is empty, otherwise
   ///     the C string value contained in this object.
-  const char *AsCString(const char *value_if_empty = nullptr) const {
+  const char *AsCString(const char *value_if_empty) const {
     return (IsEmpty() ? value_if_empty : m_string);
   }
 

--- a/lldb/source/API/SBAttachInfo.cpp
+++ b/lldb/source/API/SBAttachInfo.cpp
@@ -280,7 +280,7 @@ const char *SBAttachInfo::GetScriptedProcessClassName() const {
   // Constify this string so that it is saved in the string pool.  Otherwise it
   // would be freed when this function goes out of scope.
   ConstString class_name(metadata_sp->GetClassName().data());
-  return class_name.AsCString();
+  return class_name.AsCString(nullptr);
 }
 
 void SBAttachInfo::SetScriptedProcessClassName(const char *class_name) {

--- a/lldb/source/API/SBCommandInterpreter.cpp
+++ b/lldb/source/API/SBCommandInterpreter.cpp
@@ -526,7 +526,7 @@ const char *SBCommandInterpreter::GetBroadcasterClass() {
   LLDB_INSTRUMENT();
 
   return ConstString(CommandInterpreter::GetStaticBroadcasterClass())
-      .AsCString();
+      .AsCString(nullptr);
 }
 
 const char *SBCommandInterpreter::GetArgumentTypeAsCString(
@@ -661,21 +661,22 @@ SBCommand::operator bool() const {
 const char *SBCommand::GetName() {
   LLDB_INSTRUMENT_VA(this);
 
-  return (IsValid() ? ConstString(m_opaque_sp->GetCommandName()).AsCString()
-                    : nullptr);
+  return (IsValid()
+              ? ConstString(m_opaque_sp->GetCommandName()).AsCString(nullptr)
+              : nullptr);
 }
 
 const char *SBCommand::GetHelp() {
   LLDB_INSTRUMENT_VA(this);
 
-  return (IsValid() ? ConstString(m_opaque_sp->GetHelp()).AsCString()
+  return (IsValid() ? ConstString(m_opaque_sp->GetHelp()).AsCString(nullptr)
                     : nullptr);
 }
 
 const char *SBCommand::GetHelpLong() {
   LLDB_INSTRUMENT_VA(this);
 
-  return (IsValid() ? ConstString(m_opaque_sp->GetHelpLong()).AsCString()
+  return (IsValid() ? ConstString(m_opaque_sp->GetHelpLong()).AsCString(nullptr)
                     : nullptr);
 }
 

--- a/lldb/source/API/SBCommunication.cpp
+++ b/lldb/source/API/SBCommunication.cpp
@@ -171,5 +171,5 @@ const char *SBCommunication::GetBroadcasterClass() {
   LLDB_INSTRUMENT();
 
   return ConstString(ThreadedCommunication::GetStaticBroadcasterClass())
-      .AsCString();
+      .AsCString(nullptr);
 }

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -113,7 +113,7 @@ SBDebugger &SBDebugger::operator=(const SBDebugger &rhs) {
 const char *SBDebugger::GetBroadcasterClass() {
   LLDB_INSTRUMENT();
 
-  return ConstString(Debugger::GetStaticBroadcasterClass()).AsCString();
+  return ConstString(Debugger::GetStaticBroadcasterClass()).AsCString(nullptr);
 }
 
 const char *SBDebugger::GetProgressFromEvent(const lldb::SBEvent &event,
@@ -132,7 +132,7 @@ const char *SBDebugger::GetProgressFromEvent(const lldb::SBEvent &event,
   total = progress_data->GetTotal();
   is_debugger_specific = progress_data->IsDebuggerSpecific();
   ConstString message(progress_data->GetMessage());
-  return message.AsCString();
+  return message.AsCString(nullptr);
 }
 
 lldb::SBStructuredData
@@ -1269,7 +1269,7 @@ const char *SBDebugger::GetInstanceName() {
   if (!m_opaque_sp)
     return nullptr;
 
-  return ConstString(m_opaque_sp->GetInstanceName()).AsCString();
+  return ConstString(m_opaque_sp->GetInstanceName()).AsCString(nullptr);
 }
 
 SBError SBDebugger::SetInternalVariable(const char *var_name, const char *value,

--- a/lldb/source/API/SBEvent.cpp
+++ b/lldb/source/API/SBEvent.cpp
@@ -96,7 +96,7 @@ const char *SBEvent::GetBroadcasterClass() const {
   const Event *lldb_event = get();
   if (lldb_event)
     return ConstString(lldb_event->GetBroadcaster()->GetBroadcasterClass())
-        .AsCString();
+        .AsCString(nullptr);
   else
     return "unknown class";
 }

--- a/lldb/source/API/SBFileSpec.cpp
+++ b/lldb/source/API/SBFileSpec.cpp
@@ -108,7 +108,7 @@ int SBFileSpec::ResolvePath(const char *src_path, char *dst_path,
 const char *SBFileSpec::GetFilename() const {
   LLDB_INSTRUMENT_VA(this);
 
-  return m_opaque_up->GetFilename().AsCString();
+  return m_opaque_up->GetFilename().AsCString(nullptr);
 }
 
 const char *SBFileSpec::GetDirectory() const {

--- a/lldb/source/API/SBFunction.cpp
+++ b/lldb/source/API/SBFunction.cpp
@@ -57,7 +57,7 @@ const char *SBFunction::GetName() const {
   LLDB_INSTRUMENT_VA(this);
 
   if (m_opaque_ptr)
-    return m_opaque_ptr->GetName().AsCString();
+    return m_opaque_ptr->GetName().AsCString(nullptr);
 
   return nullptr;
 }
@@ -66,7 +66,8 @@ const char *SBFunction::GetDisplayName() const {
   LLDB_INSTRUMENT_VA(this);
 
   if (m_opaque_ptr)
-    return m_opaque_ptr->GetMangled().GetDisplayDemangledName().AsCString();
+    return m_opaque_ptr->GetMangled().GetDisplayDemangledName().AsCString(
+        nullptr);
 
   return nullptr;
 }
@@ -75,7 +76,7 @@ const char *SBFunction::GetMangledName() const {
   LLDB_INSTRUMENT_VA(this);
 
   if (m_opaque_ptr)
-    return m_opaque_ptr->GetMangled().GetMangledName().AsCString();
+    return m_opaque_ptr->GetMangled().GetMangledName().AsCString(nullptr);
   return nullptr;
 }
 
@@ -85,7 +86,7 @@ const char *SBFunction::GetBaseName() const {
   if (!m_opaque_ptr)
     return nullptr;
 
-  return m_opaque_ptr->GetMangled().GetBaseName().AsCString();
+  return m_opaque_ptr->GetMangled().GetBaseName().AsCString(nullptr);
 }
 
 bool SBFunction::operator==(const SBFunction &rhs) const {
@@ -105,10 +106,10 @@ bool SBFunction::GetDescription(SBStream &s) {
 
   if (m_opaque_ptr) {
     s.Printf("SBFunction: id = 0x%8.8" PRIx64 ", name = %s",
-             m_opaque_ptr->GetID(), m_opaque_ptr->GetName().AsCString());
+             m_opaque_ptr->GetID(), m_opaque_ptr->GetName().AsCString(""));
     Type *func_type = m_opaque_ptr->GetType();
     if (func_type)
-      s.Printf(", type = %s", func_type->GetName().AsCString());
+      s.Printf(", type = %s", func_type->GetName().AsCString(""));
     return true;
   }
   s.Printf("No value");

--- a/lldb/source/API/SBLanguageRuntime.cpp
+++ b/lldb/source/API/SBLanguageRuntime.cpp
@@ -56,13 +56,13 @@ bool SBLanguageRuntime::SupportsExceptionBreakpointsOnCatch(
 const char *
 SBLanguageRuntime::GetThrowKeywordForLanguage(lldb::LanguageType language) {
   if (Language *lang_plugin = Language::FindPlugin(language))
-    return ConstString(lang_plugin->GetThrowKeyword()).AsCString();
+    return ConstString(lang_plugin->GetThrowKeyword()).AsCString(nullptr);
   return nullptr;
 }
 
 const char *
 SBLanguageRuntime::GetCatchKeywordForLanguage(lldb::LanguageType language) {
   if (Language *lang_plugin = Language::FindPlugin(language))
-    return ConstString(lang_plugin->GetCatchKeyword()).AsCString();
+    return ConstString(lang_plugin->GetCatchKeyword()).AsCString(nullptr);
   return nullptr;
 }

--- a/lldb/source/API/SBLaunchInfo.cpp
+++ b/lldb/source/API/SBLaunchInfo.cpp
@@ -210,7 +210,8 @@ void SBLaunchInfo::Clear() {
 const char *SBLaunchInfo::GetWorkingDirectory() const {
   LLDB_INSTRUMENT_VA(this);
 
-  return m_opaque_sp->GetWorkingDirectory().GetPathAsConstString().AsCString();
+  return m_opaque_sp->GetWorkingDirectory().GetPathAsConstString().AsCString(
+      nullptr);
 }
 
 void SBLaunchInfo::SetWorkingDirectory(const char *working_dir) {
@@ -249,7 +250,7 @@ const char *SBLaunchInfo::GetShell() {
   // Constify this string so that it is saved in the string pool.  Otherwise it
   // would be freed when this function goes out of scope.
   ConstString shell(m_opaque_sp->GetShell().GetPath().c_str());
-  return shell.AsCString();
+  return shell.AsCString(nullptr);
 }
 
 void SBLaunchInfo::SetShell(const char *path) {
@@ -342,7 +343,7 @@ const char *SBLaunchInfo::GetScriptedProcessClassName() const {
   // Constify this string so that it is saved in the string pool.  Otherwise it
   // would be freed when this function goes out of scope.
   ConstString class_name(metadata_sp->GetClassName().data());
-  return class_name.AsCString();
+  return class_name.AsCString(nullptr);
 }
 
 void SBLaunchInfo::SetScriptedProcessClassName(const char *class_name) {

--- a/lldb/source/API/SBMemoryRegionInfo.cpp
+++ b/lldb/source/API/SBMemoryRegionInfo.cpp
@@ -119,7 +119,7 @@ bool SBMemoryRegionInfo::IsMapped() {
 const char *SBMemoryRegionInfo::GetName() {
   LLDB_INSTRUMENT_VA(this);
 
-  return m_opaque_up->GetName().AsCString();
+  return m_opaque_up->GetName().AsCString(nullptr);
 }
 
 bool SBMemoryRegionInfo::HasDirtyMemoryPageList() {

--- a/lldb/source/API/SBModule.cpp
+++ b/lldb/source/API/SBModule.cpp
@@ -684,5 +684,5 @@ const char *SBModule::GetObjectName() const {
 
   if (!m_opaque_sp)
     return nullptr;
-  return m_opaque_sp->GetObjectName().AsCString();
+  return m_opaque_sp->GetObjectName().AsCString(nullptr);
 }

--- a/lldb/source/API/SBPlatform.cpp
+++ b/lldb/source/API/SBPlatform.cpp
@@ -347,7 +347,7 @@ const char *SBPlatform::GetName() {
 
   PlatformSP platform_sp(GetSP());
   if (platform_sp)
-    return ConstString(platform_sp->GetName()).AsCString();
+    return ConstString(platform_sp->GetName()).AsCString(nullptr);
   return nullptr;
 }
 
@@ -362,7 +362,8 @@ const char *SBPlatform::GetWorkingDirectory() {
 
   PlatformSP platform_sp(GetSP());
   if (platform_sp)
-    return platform_sp->GetWorkingDirectory().GetPathAsConstString().AsCString();
+    return platform_sp->GetWorkingDirectory().GetPathAsConstString().AsCString(
+        nullptr);
   return nullptr;
 }
 

--- a/lldb/source/API/SBProcess.cpp
+++ b/lldb/source/API/SBProcess.cpp
@@ -81,7 +81,7 @@ SBProcess::~SBProcess() = default;
 const char *SBProcess::GetBroadcasterClassName() {
   LLDB_INSTRUMENT();
 
-  return ConstString(Process::GetStaticBroadcasterClass()).AsCString();
+  return ConstString(Process::GetStaticBroadcasterClass()).AsCString(nullptr);
 }
 
 const char *SBProcess::GetPluginName() {
@@ -824,7 +824,7 @@ SBBroadcaster SBProcess::GetBroadcaster() const {
 const char *SBProcess::GetBroadcasterClass() {
   LLDB_INSTRUMENT();
 
-  return ConstString(Process::GetStaticBroadcasterClass()).AsCString();
+  return ConstString(Process::GetStaticBroadcasterClass()).AsCString(nullptr);
 }
 
 lldb::SBAddressRangeList SBProcess::FindRangesInMemory(
@@ -1014,7 +1014,7 @@ bool SBProcess::GetDescription(SBStream &description) {
     Module *exe_module = process_sp->GetTarget().GetExecutableModulePointer();
     const char *exe_name = nullptr;
     if (exe_module)
-      exe_name = exe_module->GetFileSpec().GetFilename().AsCString();
+      exe_name = exe_module->GetFileSpec().GetFilename().AsCString(nullptr);
 
     strm.Printf("SBProcess: pid = %" PRIu64 ", state = %s, threads = %d%s%s",
                 process_sp->GetID(), lldb_private::StateAsCString(GetState()),
@@ -1196,7 +1196,7 @@ const char *SBProcess::GetExtendedBacktraceTypeAtIndex(uint32_t idx) {
     const std::vector<ConstString> &names =
         runtime->GetExtendedBacktraceTypes();
     if (idx < names.size()) {
-      return names[idx].AsCString();
+      return names[idx].AsCString(nullptr);
     }
   }
   return nullptr;

--- a/lldb/source/API/SBSymbol.cpp
+++ b/lldb/source/API/SBSymbol.cpp
@@ -55,7 +55,7 @@ const char *SBSymbol::GetName() const {
 
   const char *name = nullptr;
   if (m_opaque_ptr)
-    name = m_opaque_ptr->GetName().AsCString();
+    name = m_opaque_ptr->GetName().AsCString(nullptr);
 
   return name;
 }
@@ -65,7 +65,8 @@ const char *SBSymbol::GetDisplayName() const {
 
   const char *name = nullptr;
   if (m_opaque_ptr)
-    name = m_opaque_ptr->GetMangled().GetDisplayDemangledName().AsCString();
+    name =
+        m_opaque_ptr->GetMangled().GetDisplayDemangledName().AsCString(nullptr);
 
   return name;
 }
@@ -75,7 +76,7 @@ const char *SBSymbol::GetMangledName() const {
 
   const char *name = nullptr;
   if (m_opaque_ptr)
-    name = m_opaque_ptr->GetMangled().GetMangledName().AsCString();
+    name = m_opaque_ptr->GetMangled().GetMangledName().AsCString(nullptr);
   return name;
 }
 
@@ -85,7 +86,7 @@ const char *SBSymbol::GetBaseName() const {
   if (!m_opaque_ptr)
     return nullptr;
 
-  return m_opaque_ptr->GetMangled().GetBaseName().AsCString();
+  return m_opaque_ptr->GetMangled().GetBaseName().AsCString(nullptr);
 }
 
 bool SBSymbol::operator==(const SBSymbol &rhs) const {

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -158,7 +158,7 @@ SBModule SBTarget::GetModuleAtIndexFromEvent(const uint32_t idx,
 const char *SBTarget::GetBroadcasterClassName() {
   LLDB_INSTRUMENT();
 
-  return ConstString(Target::GetStaticBroadcasterClass()).AsCString();
+  return ConstString(Target::GetStaticBroadcasterClass()).AsCString(nullptr);
 }
 
 bool SBTarget::IsValid() const {
@@ -1652,7 +1652,7 @@ const char *SBTarget::GetLabel() const {
   LLDB_INSTRUMENT_VA(this);
 
   if (TargetSP target_sp = GetSP())
-    return ConstString(target_sp->GetLabel().data()).AsCString();
+    return ConstString(target_sp->GetLabel().data()).AsCString(nullptr);
   return nullptr;
 }
 
@@ -1668,7 +1668,7 @@ const char *SBTarget::GetTargetSessionName() const {
   LLDB_INSTRUMENT_VA(this);
 
   if (TargetSP target_sp = GetSP())
-    return ConstString(target_sp->GetTargetSessionName()).AsCString();
+    return ConstString(target_sp->GetTargetSessionName()).AsCString(nullptr);
   return nullptr;
 }
 

--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -54,7 +54,7 @@ using namespace lldb_private;
 const char *SBThread::GetBroadcasterClassName() {
   LLDB_INSTRUMENT();
 
-  return ConstString(Thread::GetStaticBroadcasterClass()).AsCString();
+  return ConstString(Thread::GetStaticBroadcasterClass()).AsCString(nullptr);
 }
 
 // Constructors

--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -219,7 +219,7 @@ const char *SBValue::GetObjectDescription() {
     llvm::consumeError(str.takeError());
     return nullptr;
   }
-  return ConstString(*str).AsCString();
+  return ConstString(*str).AsCString(nullptr);
 }
 
 SBType SBValue::GetType() {

--- a/lldb/source/API/SBWatchpoint.cpp
+++ b/lldb/source/API/SBWatchpoint.cpp
@@ -326,7 +326,7 @@ const char *SBWatchpoint::GetWatchSpec() {
   // so that the C string we return has a sufficiently long
   // lifetime. Note this a memory leak but should be fairly
   // low impact.
-  return ConstString(watchpoint_sp->GetWatchSpec()).AsCString();
+  return ConstString(watchpoint_sp->GetWatchSpec()).AsCString(nullptr);
 }
 
 bool SBWatchpoint::IsWatchingReads() {

--- a/lldb/source/Breakpoint/BreakpointResolverFileRegex.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverFileRegex.cpp
@@ -119,11 +119,11 @@ Searcher::CallbackReturn BreakpointResolverFileRegex::SearchCallback(
       for (size_t i = 0; i < sc_list.GetSize(); i++) {
         SymbolContext sc_ctx;
         sc_list.GetContextAtIndex(i, sc_ctx);
-        std::string name(
+        std::string name =
             sc_ctx
                 .GetFunctionName(
                     Mangled::NamePreference::ePreferDemangledWithoutArguments)
-                .AsCString());
+                .GetString();
         if (!m_function_names.count(name)) {
           sc_to_remove.push_back(i);
         }

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -704,7 +704,7 @@ protected:
                 options.SetVariableFormatDisplayLanguage(
                     valobj_sp->GetPreferredDisplayLanguage());
                 options.SetRootValueObjectName(
-                    var_sp ? var_sp->GetName().AsCString() : nullptr);
+                    var_sp ? var_sp->GetName().AsCString(nullptr) : nullptr);
                 if (llvm::Error error =
                         valobj_sp->Dump(result.GetOutputStream(), options))
                   result.AppendError(toString(std::move(error)));
@@ -728,7 +728,8 @@ protected:
             options.SetFormat(m_option_format.GetFormat());
             options.SetVariableFormatDisplayLanguage(
                 rec_value_sp->GetPreferredDisplayLanguage());
-            options.SetRootValueObjectName(rec_value_sp->GetName().AsCString());
+            options.SetRootValueObjectName(
+                rec_value_sp->GetName().AsCString(nullptr));
             if (llvm::Error error =
                     rec_value_sp->Dump(result.GetOutputStream(), options))
               result.AppendError(toString(std::move(error)));

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -202,8 +202,8 @@ protected:
     uint32_t num_matches = 0;
     assert(module);
     if (cu) {
-      assert(file_spec.GetFilename().AsCString());
-      bool has_path = (file_spec.GetDirectory().AsCString() != nullptr);
+      assert(file_spec.GetFilename().AsCString(nullptr));
+      bool has_path = (file_spec.GetDirectory().AsCString(nullptr) != nullptr);
       const SupportFileList &cu_file_list = cu->GetSupportFiles();
       size_t file_idx = cu_file_list.FindFileIndex(0, file_spec, has_path);
       if (file_idx != UINT32_MAX) {
@@ -428,30 +428,29 @@ protected:
           StreamString error_strm;
           if (!GetSymbolContextsForAddress(module_list, addr, sc_list_lines,
                                            error_strm))
-            result.AppendWarningWithFormat("in symbol '%s': %s",
-                                           sc.GetFunctionName().AsCString(),
-                                           error_strm.GetData());
+            result.AppendWarningWithFormatv("in symbol '{0}': {1}",
+                                            sc.GetFunctionName(),
+                                            error_strm.GetData());
           else
             context_found_for_symbol = true;
         }
       }
       if (!context_found_for_symbol)
-        result.AppendWarningWithFormat("Unable to find line information"
-                                       " for matching symbol '%s'.\n",
-                                       sc.GetFunctionName().AsCString());
+        result.AppendWarningWithFormatv("Unable to find line information"
+                                        " for matching symbol '{0}'.\n",
+                                        sc.GetFunctionName());
     }
     if (sc_list_lines.GetSize() == 0) {
-      result.AppendErrorWithFormat("No line information could be found"
-                                   " for any symbols matching '%s'.\n",
-                                   name.AsCString());
+      result.AppendErrorWithFormatv("No line information could be found"
+                                    " for any symbols matching '{0}'.\n",
+                                    name);
       return false;
     }
     FileSpec file_spec;
     if (!DumpLinesInSymbolContexts(result.GetOutputStream(), sc_list_lines,
                                    module_list, file_spec)) {
-      result.AppendErrorWithFormat(
-          "Unable to dump line information for symbol '%s'.\n",
-          name.AsCString());
+      result.AppendErrorWithFormatv(
+          "Unable to dump line information for symbol '{0}'.\n", name);
       return false;
     }
     return true;

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -3612,10 +3612,10 @@ protected:
       if (!func_unwinders_sp)
         continue;
 
-      result.GetOutputStream().Printf(
-          "UNWIND PLANS for %s`%s (start addr 0x%" PRIx64 ")\n",
-          sc.module_sp->GetPlatformFileSpec().GetFilename().AsCString(),
-          funcname.AsCString(), start_addr);
+      result.GetOutputStream().Format(
+          "UNWIND PLANS for {0}`{1} (start addr {2:x})\n",
+          sc.module_sp->GetPlatformFileSpec().GetFilename(), funcname,
+          start_addr);
 
       Args args;
       target->GetUserSpecifiedTrapHandlerNames(args);
@@ -3644,20 +3644,20 @@ protected:
 
       if (std::shared_ptr<const UnwindPlan> plan_sp =
               func_unwinders_sp->GetUnwindPlanAtNonCallSite(*target, *thread)) {
-        result.GetOutputStream().Printf(
-            "Asynchronous (not restricted to call-sites) UnwindPlan is '%s'\n",
-            plan_sp->GetSourceName().AsCString());
+        result.GetOutputStream().Format(
+            "Asynchronous (not restricted to call-sites) UnwindPlan is '{0}'\n",
+            plan_sp->GetSourceName());
       }
       if (std::shared_ptr<const UnwindPlan> plan_sp =
               func_unwinders_sp->GetUnwindPlanAtCallSite(*target, *thread)) {
-        result.GetOutputStream().Printf(
-            "Synchronous (restricted to call-sites) UnwindPlan is '%s'\n",
-            plan_sp->GetSourceName().AsCString());
+        result.GetOutputStream().Format(
+            "Synchronous (restricted to call-sites) UnwindPlan is '{0}'\n",
+            plan_sp->GetSourceName());
       }
       if (std::shared_ptr<const UnwindPlan> plan_sp =
               func_unwinders_sp->GetUnwindPlanFastUnwind(*target, *thread)) {
-        result.GetOutputStream().Printf("Fast UnwindPlan is '%s'\n",
-                                        plan_sp->GetSourceName().AsCString());
+        result.GetOutputStream().Format("Fast UnwindPlan is '{0}'\n",
+                                        plan_sp->GetSourceName());
       }
 
       result.GetOutputStream().Printf("\n");

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -1616,7 +1616,7 @@ bool CommandObjectTypeSummaryAdd::AddSummary(ConstString type_name,
   }
 
   if (match_type == eFormatterMatchCallback) {
-    const char *function_name = type_name.AsCString();
+    const char *function_name = type_name.AsCString(nullptr);
     ScriptInterpreter *interpreter = GetDebugger().GetScriptInterpreter();
     if (interpreter && !interpreter->CheckObjectExists(function_name)) {
       *error = Status::FromErrorStringWithFormat(
@@ -2262,10 +2262,10 @@ bool CommandObjectTypeSynthAdd::AddSynth(ConstString type_name,
     if (category->AnyMatches(candidate_type, eFormatCategoryItemFilter,
                              false)) {
       if (error)
-        *error = Status::FromErrorStringWithFormat(
-            "cannot add synthetic for type %s when "
+        *error = Status::FromErrorStringWithFormatv(
+            "cannot add synthetic for type {0} when "
             "filter is defined in same category!",
-            type_name.AsCString());
+            type_name);
       return false;
     }
   }
@@ -2281,7 +2281,7 @@ bool CommandObjectTypeSynthAdd::AddSynth(ConstString type_name,
   }
 
   if (match_type == eFormatterMatchCallback) {
-    const char *function_name = type_name.AsCString();
+    const char *function_name = type_name.AsCString(nullptr);
     ScriptInterpreter *interpreter = GetDebugger().GetScriptInterpreter();
     if (interpreter && !interpreter->CheckObjectExists(function_name)) {
       *error = Status::FromErrorStringWithFormat(
@@ -2404,11 +2404,11 @@ private:
       if (category->AnyMatches(candidate_type, eFormatCategoryItemSynth,
                                false)) {
         if (error)
-          *error = Status::FromErrorStringWithFormat(
-              "cannot add filter for type %s when "
+          *error = Status::FromErrorStringWithFormatv(
+              "cannot add filter for type {0} when "
               "synthetic is defined in same "
               "category!",
-              type_name.AsCString());
+              type_name);
         return false;
       }
     }

--- a/lldb/source/Core/AddressRange.cpp
+++ b/lldb/source/Core/AddressRange.cpp
@@ -229,7 +229,7 @@ bool AddressRange::GetDescription(Stream *s, Target *target) const {
   const auto section_sp = m_base_addr.GetSection();
   if (section_sp) {
     if (const auto object_file = section_sp->GetObjectFile())
-      file_name = object_file->GetFileSpec().GetFilename().AsCString();
+      file_name = object_file->GetFileSpec().GetFilename().AsCString(nullptr);
   }
   start_addr = m_base_addr.GetFileAddress();
   const addr_t end_addr = (start_addr == LLDB_INVALID_ADDRESS)

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -2316,7 +2316,8 @@ bool Debugger::StartEventHandlerThread() {
     // function. We do this by listening to events for the
     // eBroadcastBitEventThreadIsListening from the m_sync_broadcaster
     ConstString full_name("lldb.debugger.event-handler");
-    ListenerSP listener_sp(Listener::MakeListener(full_name.AsCString()));
+    ListenerSP listener_sp(
+        Listener::MakeListener(full_name.AsCString(nullptr)));
     listener_sp->StartListeningForEvents(&m_sync_broadcaster,
                                          eBroadcastBitEventThreadIsListening);
 

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -387,7 +387,7 @@ VariableAnnotator::AnnotateStructured(Instruction &inst) {
     if (!v || v->IsArtificial())
       continue;
 
-    const char *nm = v->GetName().AsCString();
+    const char *nm = v->GetName().AsCString(nullptr);
     llvm::StringRef name = nm ? nm : "<anon>";
 
     DWARFExpressionList &exprs = v->LocationExpressionList();
@@ -419,7 +419,7 @@ VariableAnnotator::AnnotateStructured(Instruction &inst) {
     }
 
     if (Type *type = v->GetType())
-      if (const char *type_str = type->GetName().AsCString())
+      if (const char *type_str = type->GetName().AsCString(nullptr))
         type_name = type_str;
 
     current_vars.try_emplace(
@@ -1369,7 +1369,7 @@ size_t Disassembler::AppendInstructions(Target &target, Address start,
 
   if (bytes_read == 0) {
     if (error_strm_ptr) {
-      if (const char *error_cstr = error.AsCString())
+      if (const char *error_cstr = error.AsCString(nullptr))
         error_strm_ptr->Printf("error: %s\n", error_cstr);
     }
     return 0;

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -908,7 +908,7 @@ bool FormatEntity::Formatter::DumpValue(Stream &s,
   if (target->IsBitfield() && was_var_indexed) {
     // TODO: check for a (T:n)-specific summary - we should still obey that
     StreamString bitfield_name;
-    bitfield_name.Printf("%s:%d", target->GetTypeName().AsCString(),
+    bitfield_name.Format("{0}:{1}", target->GetTypeName(),
                          target->GetBitfieldBitSize());
     auto type_sp = std::make_shared<TypeNameSpecifierImpl>(
         bitfield_name.GetString(), lldb::eFormatterMatchExact);
@@ -1219,7 +1219,7 @@ static bool PrintFunctionNameWithArgs(Stream &s,
 
   const char *cstr = sc.GetPossiblyInlinedFunctionName()
                          .GetName(Mangled::ePreferDemangled)
-                         .AsCString();
+                         .AsCString(nullptr);
   if (!cstr)
     return false;
 
@@ -1823,7 +1823,7 @@ bool FormatEntity::Formatter::Format(const Entry &entry, Stream &s,
 
       const char *name = m_sc->GetPossiblyInlinedFunctionName()
                              .GetName(Mangled::NamePreference::ePreferDemangled)
-                             .AsCString();
+                             .AsCString(nullptr);
       if (name) {
         s.PutCString(name);
         return true;
@@ -1868,7 +1868,7 @@ bool FormatEntity::Formatter::Format(const Entry &entry, Stream &s,
           m_sc->GetPossiblyInlinedFunctionName()
               .GetName(
                   Mangled::NamePreference::ePreferDemangledWithoutArguments)
-              .AsCString();
+              .AsCString(nullptr);
       if (name) {
         s.PutCString(name);
         return true;
@@ -1940,7 +1940,7 @@ bool FormatEntity::Formatter::Format(const Entry &entry, Stream &s,
 
     const char *name = m_sc->GetPossiblyInlinedFunctionName()
                            .GetName(Mangled::NamePreference::ePreferMangled)
-                           .AsCString();
+                           .AsCString(nullptr);
     if (!name)
       return false;
 

--- a/lldb/source/Core/IOHandlerCursesGUI.cpp
+++ b/lldb/source/Core/IOHandlerCursesGUI.cpp
@@ -2961,7 +2961,7 @@ public:
     if (!module_sp->IsExecutable())
       return "";
 
-    return module_sp->GetFileSpec().GetFilename().AsCString();
+    return module_sp->GetFileSpec().GetFilename().GetString();
   }
 
   bool StopRunningProcess() {

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -393,10 +393,8 @@ void Mangled::Dump(Stream *s) const {
   if (m_mangled) {
     *s << ", mangled = " << m_mangled;
   }
-  if (m_demangled) {
-    const char *demangled = m_demangled.AsCString();
-    s->Printf(", demangled = %s", demangled[0] ? demangled : "<error>");
-  }
+  if (m_demangled)
+    s->Format(", demangled = {0}", m_demangled.GetStringRef());
 }
 
 // Dumps a debug version of this string with extra object and state information

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1257,7 +1257,7 @@ const Symbol *Module::FindFirstSymbolWithNameAndType(ConstString name,
                                                      SymbolType symbol_type) {
   LLDB_SCOPED_TIMERF(
       "Module::FindFirstSymbolWithNameAndType (name = %s, type = %i)",
-      name.AsCString(), symbol_type);
+      name.AsCString(""), symbol_type);
   if (Symtab *symtab = GetSymtab())
     return symtab->FindFirstSymbolWithNameAndType(
         name, symbol_type, Symtab::eDebugAny, Symtab::eVisibilityAny);
@@ -1284,7 +1284,7 @@ void Module::SymbolIndicesToSymbolContextList(
 void Module::FindFunctionSymbols(ConstString name, uint32_t name_type_mask,
                                  SymbolContextList &sc_list) {
   LLDB_SCOPED_TIMERF("Module::FindSymbolsFunctions (name = %s, mask = 0x%8.8x)",
-                     name.AsCString(), name_type_mask);
+                     name.AsCString(""), name_type_mask);
   if (Symtab *symtab = GetSymtab())
     symtab->FindFunctionSymbols(name, name_type_mask, sc_list);
 }

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -317,10 +317,10 @@ void Section::DumpName(llvm::raw_ostream &s) const {
 
     if (m_obj_file) {
       const FileSpec &file_spec = m_obj_file->GetFileSpec();
-      name = file_spec.GetFilename().AsCString();
+      name = file_spec.GetFilename().AsCString(nullptr);
     }
     if ((!name || !name[0]) && module_sp)
-      name = module_sp->GetFileSpec().GetFilename().AsCString();
+      name = module_sp->GetFileSpec().GetFilename().AsCString(nullptr);
     if (name && name[0])
       s << name << '.';
   }

--- a/lldb/source/Core/SourceManager.cpp
+++ b/lldb/source/Core/SourceManager.cpp
@@ -519,7 +519,7 @@ void SourceManager::File::CommonInitializerImpl(SupportFileNSP support_file_nsp,
           SymbolContextList sc_list;
           size_t num_matches =
               target_sp->GetImages().ResolveSymbolContextForFilePath(
-                  file_spec.GetFilename().AsCString(), 0, check_inlines,
+                  file_spec.GetFilename().AsCString(nullptr), 0, check_inlines,
                   SymbolContextItem(eSymbolContextModule |
                                     eSymbolContextCompUnit),
                   sc_list);

--- a/lldb/source/DataFormatters/FormatManager.cpp
+++ b/lldb/source/DataFormatters/FormatManager.cpp
@@ -189,7 +189,7 @@ void FormatManager::GetPossibleMatches(
       target_sp->GetDebugger().GetScriptInterpreter();
   if (valobj.GetBitfieldBitSize() > 0) {
     StreamString sstring;
-    sstring.Printf("%s:%d", type_name.AsCString(), valobj.GetBitfieldBitSize());
+    sstring.Format("{0}:{1}", type_name, valobj.GetBitfieldBitSize());
     ConstString bitfieldname(sstring.GetString());
     entries.push_back({bitfieldname, script_interpreter,
                        TypeImpl(compiler_type), current_flags,

--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -186,7 +186,7 @@ void ValueObjectPrinter::SetupMostSpecializedValue() {
 const char *ValueObjectPrinter::GetRootNameForDisplay() {
   const char *root_valobj_name =
       m_options.m_root_valobj_name.empty()
-          ? GetMostSpecializedValue().GetName().AsCString()
+          ? GetMostSpecializedValue().GetName().AsCString(nullptr)
           : m_options.m_root_valobj_name.c_str();
   return root_valobj_name ? root_valobj_name : "";
 }

--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -125,8 +125,8 @@ Status IRExecutionUnit::DisassembleFunction(Stream &stream,
   }
 
   if (func_local_addr == LLDB_INVALID_ADDRESS) {
-    ret = Status::FromErrorStringWithFormat(
-        "Couldn't find function %s for disassembly", m_name.AsCString());
+    ret = Status::FromErrorStringWithFormatv(
+        "Couldn't find function {0} for disassembly", m_name);
     return ret;
   }
 
@@ -140,8 +140,8 @@ Status IRExecutionUnit::DisassembleFunction(Stream &stream,
   func_range = GetRemoteRangeForLocal(func_local_addr);
 
   if (func_range.first == 0 && func_range.second == 0) {
-    ret = Status::FromErrorStringWithFormat(
-        "Couldn't find code range for function %s", m_name.AsCString());
+    ret = Status::FromErrorStringWithFormatv(
+        "Couldn't find code range for function {0}", m_name);
     return ret;
   }
 
@@ -615,8 +615,8 @@ uint8_t *IRExecutionUnit::MemoryManager::allocateDataSection(
 
 void IRExecutionUnit::CollectCandidateCNames(std::vector<ConstString> &C_names,
                                              ConstString name) {
-  if (m_strip_underscore && name.AsCString()[0] == '_')
-    C_names.insert(C_names.begin(), ConstString(&name.AsCString()[1]));
+  if (m_strip_underscore && name.GetStringRef().starts_with('_'))
+    C_names.insert(C_names.begin(), ConstString(&name.GetCString()[1]));
   C_names.push_back(name);
 }
 

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -132,10 +132,9 @@ public:
         write_error);
 
     if (!write_error.Success()) {
-      err = Status::FromErrorStringWithFormat(
-          "couldn't write %s to the target: %s",
-          m_persistent_variable_sp->GetName().AsCString(),
-          write_error.AsCString());
+      err = Status::FromErrorStringWithFormatv(
+          "couldn't write {0} to the target: {1}",
+          m_persistent_variable_sp->GetName(), write_error.AsCString());
       return;
     }
   }
@@ -164,12 +163,11 @@ public:
 
     const lldb::addr_t load_addr = process_address + m_offset;
 
-    LLDB_LOGF(log,
-              "EntityPersistentVariable::Materialize [address = 0x%" PRIx64
-              ", m_name = %s, m_flags = 0x%hx]",
-              (uint64_t)load_addr,
-              m_persistent_variable_sp->GetName().AsCString(),
-              m_persistent_variable_sp->m_flags);
+    LLDB_LOG(log,
+             "EntityPersistentVariable::Materialize [address = {0:x}, m_name = "
+             "{1}, m_flags = {2:x}]",
+             (uint64_t)load_addr, m_persistent_variable_sp->GetName(),
+             m_persistent_variable_sp->m_flags);
 
     if (m_persistent_variable_sp->m_flags &
         ExpressionVariable::EVNeedsAllocation) {
@@ -194,15 +192,14 @@ public:
           map.GetAddressByteSize(), write_error);
 
       if (!write_error.Success()) {
-        err = Status::FromErrorStringWithFormat(
-            "couldn't write the location of %s to memory: %s",
-            m_persistent_variable_sp->GetName().AsCString(),
-            write_error.AsCString());
+        err = Status::FromErrorStringWithFormatv(
+            "couldn't write the location of {0} to memory: {1}",
+            m_persistent_variable_sp->GetName(), write_error.AsCString());
       }
     } else {
-      err = Status::FromErrorStringWithFormat(
-          "no materialization happened for persistent variable %s",
-          m_persistent_variable_sp->GetName().AsCString());
+      err = Status::FromErrorStringWithFormatv(
+          "no materialization happened for persistent variable {0}",
+          m_persistent_variable_sp->GetName());
       return;
     }
   }
@@ -214,12 +211,12 @@ public:
 
     const lldb::addr_t load_addr = process_address + m_offset;
 
-    LLDB_LOGF(log,
-              "EntityPersistentVariable::Dematerialize [address = 0x%" PRIx64
-              ", m_name = %s, m_flags = 0x%hx]",
-              (uint64_t)process_address + m_offset,
-              m_persistent_variable_sp->GetName().AsCString(),
-              m_persistent_variable_sp->m_flags);
+    LLDB_LOG(log,
+             "EntityPersistentVariable::Dematerialize [address = {0:x}, m_name "
+             "= {1}, m_flags = {2}]",
+             (uint64_t)process_address + m_offset,
+             m_persistent_variable_sp->GetName(),
+             m_persistent_variable_sp->m_flags);
 
     if (m_delegate) {
       m_delegate->DidDematerialize(m_persistent_variable_sp);
@@ -327,9 +324,9 @@ public:
             ~ExpressionVariable::EVNeedsFreezeDry;
       }
     } else {
-      err = Status::FromErrorStringWithFormat(
-          "no dematerialization happened for persistent variable %s",
-          m_persistent_variable_sp->GetName().AsCString());
+      err = Status::FromErrorStringWithFormatv(
+          "no dematerialization happened for persistent variable {0}",
+          m_persistent_variable_sp->GetName());
       return;
     }
 
@@ -351,9 +348,8 @@ public:
 
     const lldb::addr_t load_addr = process_address + m_offset;
 
-    dump_stream.Printf("0x%" PRIx64 ": EntityPersistentVariable (%s)\n",
-                       load_addr,
-                       m_persistent_variable_sp->GetName().AsCString());
+    dump_stream.Format("{0:x}: EntityPersistentVariable ({1})\n", load_addr,
+                       m_persistent_variable_sp->GetName());
 
     {
       dump_stream.Printf("Pointer:\n");
@@ -458,16 +454,16 @@ public:
     lldb::ValueObjectSP valobj_sp = SetupValueObject(scope);
 
     if (!valobj_sp) {
-      err = Status::FromErrorStringWithFormat(
-          "couldn't get a value object for variable %s", GetName().AsCString());
+      err = Status::FromErrorStringWithFormatv(
+          "couldn't get a value object for variable {0}", GetName());
       return;
     }
 
     Status valobj_error = valobj_sp->GetError().Clone();
 
     if (valobj_error.Fail()) {
-      err = Status::FromErrorStringWithFormat(
-          "couldn't get the value of variable %s: %s", GetName().AsCString(),
+      err = Status::FromErrorStringWithFormatv(
+          "couldn't get the value of variable {0}: {1}", GetName(),
           valobj_error.AsCString());
       return;
     }
@@ -478,9 +474,9 @@ public:
       valobj_sp->GetData(valobj_extractor, extract_error);
 
       if (!extract_error.Success()) {
-        err = Status::FromErrorStringWithFormat(
-            "couldn't read contents of reference variable %s: %s",
-            GetName().AsCString(), extract_error.AsCString());
+        err = Status::FromErrorStringWithFormatv(
+            "couldn't read contents of reference variable {0}: {1}", GetName(),
+            extract_error.AsCString());
         return;
       }
 
@@ -491,10 +487,10 @@ public:
       map.WritePointerToMemory(load_addr, reference_addr, write_error);
 
       if (!write_error.Success()) {
-        err = Status::FromErrorStringWithFormat(
-            "couldn't write the contents of reference "
-            "variable %s to memory: %s",
-            GetName().AsCString(), write_error.AsCString());
+        err = Status::FromErrorStringWithFormatv(
+            "couldn't write the contents of reference variable {0} to memory: "
+            "{0}",
+            GetName(), write_error.AsCString());
         return;
       }
     } else {
@@ -505,9 +501,9 @@ public:
         map.WritePointerToMemory(load_addr, addr_of_valobj, write_error);
 
         if (!write_error.Success()) {
-          err = Status::FromErrorStringWithFormat(
-              "couldn't write the address of variable %s to memory: %s",
-              GetName().AsCString(), write_error.AsCString());
+          err = Status::FromErrorStringWithFormatv(
+              "couldn't write the address of variable {0} to memory: {1}",
+              GetName(), write_error.AsCString());
           return;
         }
       } else {
@@ -515,31 +511,31 @@ public:
         Status extract_error;
         valobj_sp->GetData(data, extract_error);
         if (!extract_error.Success()) {
-          err = Status::FromErrorStringWithFormat(
-              "couldn't get the value of %s: %s", GetName().AsCString(),
+          err = Status::FromErrorStringWithFormatv(
+              "couldn't get the value of {0}: {1}", GetName(),
               extract_error.AsCString());
           return;
         }
 
         if (m_temporary_allocation != LLDB_INVALID_ADDRESS) {
-          err = Status::FromErrorStringWithFormat(
-              "trying to create a temporary region for %s but one exists",
-              GetName().AsCString());
+          err = Status::FromErrorStringWithFormatv(
+              "trying to create a temporary region for {0} but one exists",
+              GetName());
           return;
         }
 
         if (data.GetByteSize() <
             llvm::expectedToOptional(GetByteSize(scope)).value_or(0)) {
           if (data.GetByteSize() == 0 && !LocationExpressionIsValid()) {
-            err = Status::FromErrorStringWithFormat(
-                "the variable '%s' has no location, "
+            err = Status::FromErrorStringWithFormatv(
+                "the variable '{0}' has no location, "
                 "it may have been optimized out",
-                GetName().AsCString());
+                GetName());
           } else {
-            err = Status::FromErrorStringWithFormat(
-                "size of variable %s (%" PRIu64
-                ") is larger than the ValueObject's size (%" PRIu64 ")",
-                GetName().AsCString(),
+            err = Status::FromErrorStringWithFormatv(
+                "size of variable {0} ({1}) is larger than the ValueObject's "
+                "size ({2})",
+                GetName(),
                 llvm::expectedToOptional(GetByteSize(scope)).value_or(0),
                 data.GetByteSize());
           }
@@ -548,8 +544,8 @@ public:
 
         std::optional<size_t> opt_bit_align = GetTypeBitAlign(scope);
         if (!opt_bit_align) {
-          err = Status::FromErrorStringWithFormat(
-              "can't get the type alignment for %s", GetName().AsCString());
+          err = Status::FromErrorStringWithFormatv(
+              "can't get the type alignment for {0}", GetName());
           return;
         }
 
@@ -562,10 +558,9 @@ public:
                 IRMemoryMap::eAllocationPolicyMirror, zero_memory)) {
           m_temporary_allocation = *address_or_error;
         } else {
-          err = Status::FromErrorStringWithFormat(
-              "couldn't allocate a temporary region for %s: %s",
-              GetName().AsCString(),
-              toString(address_or_error.takeError()).c_str());
+          err = Status::FromErrorStringWithFormatv(
+              "couldn't allocate a temporary region for {0}: {1}", GetName(),
+              toString(address_or_error.takeError()));
           return;
         }
 
@@ -580,9 +575,9 @@ public:
                         data.GetByteSize(), write_error);
 
         if (!write_error.Success()) {
-          err = Status::FromErrorStringWithFormat(
-              "couldn't write to the temporary region for %s: %s",
-              GetName().AsCString(), write_error.AsCString());
+          err = Status::FromErrorStringWithFormatv(
+              "couldn't write to the temporary region for {0}: {1}", GetName(),
+              write_error.AsCString());
           return;
         }
 
@@ -592,9 +587,9 @@ public:
                                  pointer_write_error);
 
         if (!pointer_write_error.Success()) {
-          err = Status::FromErrorStringWithFormat(
-              "couldn't write the address of the temporary region for %s: %s",
-              GetName().AsCString(), pointer_write_error.AsCString());
+          err = Status::FromErrorStringWithFormatv(
+              "couldn't write the address of the temporary region for {0}: {1}",
+              GetName(), pointer_write_error.AsCString());
         }
       }
     }
@@ -606,10 +601,10 @@ public:
     Log *log = GetLog(LLDBLog::Expressions);
 
     const lldb::addr_t load_addr = process_address + m_offset;
-    LLDB_LOGF(log,
-              "EntityVariable::Dematerialize [address = 0x%" PRIx64
-              ", m_variable_sp = %s]",
-              (uint64_t)load_addr, GetName().AsCString());
+    LLDB_LOG(
+        log,
+        "EntityVariable::Dematerialize [address = {0:x}, m_variable_sp = {1}]",
+        (uint64_t)load_addr, GetName());
 
     if (m_temporary_allocation != LLDB_INVALID_ADDRESS) {
       ExecutionContextScope *scope = frame_sp.get();
@@ -620,9 +615,8 @@ public:
       lldb::ValueObjectSP valobj_sp = SetupValueObject(scope);
 
       if (!valobj_sp) {
-        err = Status::FromErrorStringWithFormat(
-            "couldn't get a value object for variable %s",
-            GetName().AsCString());
+        err = Status::FromErrorStringWithFormatv(
+            "couldn't get a value object for variable {0}", GetName());
         return;
       }
 
@@ -636,8 +630,8 @@ public:
           extract_error);
 
       if (!extract_error.Success()) {
-        err = Status::FromErrorStringWithFormat(
-            "couldn't get the data for variable %s", GetName().AsCString());
+        err = Status::FromErrorStringWithFormatv(
+            "couldn't get the data for variable {0}", GetName());
         return;
       }
 
@@ -657,9 +651,9 @@ public:
         valobj_sp->SetData(data, set_error);
 
         if (!set_error.Success()) {
-          err = Status::FromErrorStringWithFormat(
-              "couldn't write the new contents of %s back into the variable",
-              GetName().AsCString());
+          err = Status::FromErrorStringWithFormatv(
+              "couldn't write the new contents of {0} back into the variable",
+              GetName());
           return;
         }
       }
@@ -669,9 +663,9 @@ public:
       map.Free(m_temporary_allocation, free_error);
 
       if (!free_error.Success()) {
-        err = Status::FromErrorStringWithFormat(
-            "couldn't free the temporary region for %s: %s",
-            GetName().AsCString(), free_error.AsCString());
+        err = Status::FromErrorStringWithFormatv(
+            "couldn't free the temporary region for {0}: {1}", GetName(),
+            free_error.AsCString());
         return;
       }
 
@@ -946,9 +940,8 @@ public:
 
       std::optional<size_t> opt_bit_align = m_type.GetTypeBitAlign(exe_scope);
       if (!opt_bit_align) {
-        err = Status::FromErrorStringWithFormat(
-            "can't get the alignment of type  \"%s\"",
-            m_type.GetTypeName().AsCString());
+        err = Status::FromErrorStringWithFormatv(
+            "can't get the alignment of type  \"{0}\"", m_type.GetTypeName());
         return;
       }
 
@@ -1058,10 +1051,10 @@ public:
         exe_scope, name, m_type, map.GetByteOrder(), map.GetAddressByteSize());
 
     if (!ret) {
-      err = Status::FromErrorStringWithFormat(
-          "couldn't dematerialize a result variable: "
-          "failed to make persistent variable %s",
-          name.AsCString());
+      err = Status::FromErrorStringWithFormatv(
+          "couldn't dematerialize a result variable: failed to make persistent "
+          "variable {0}",
+          name);
       return;
     }
 
@@ -1226,10 +1219,8 @@ public:
 
     const lldb::addr_t load_addr = process_address + m_offset;
 
-    LLDB_LOGF(log,
-              "EntitySymbol::Materialize [address = 0x%" PRIx64
-              ", m_symbol = %s]",
-              (uint64_t)load_addr, m_symbol.GetName().AsCString());
+    LLDB_LOG(log, "EntitySymbol::Materialize [address = {0}, m_symbol = {1}]",
+             (uint64_t)load_addr, m_symbol.GetName());
 
     const Address sym_address = m_symbol.GetAddress();
 
@@ -1243,9 +1234,9 @@ public:
       target_sp = map.GetBestExecutionContextScope()->CalculateTarget();
 
     if (!target_sp) {
-      err = Status::FromErrorStringWithFormat(
-          "couldn't resolve symbol %s because there is no target",
-          m_symbol.GetName().AsCString());
+      err = Status::FromErrorStringWithFormatv(
+          "couldn't resolve symbol {0} because there is no target",
+          m_symbol.GetName());
       return;
     }
 
@@ -1259,9 +1250,9 @@ public:
     map.WritePointerToMemory(load_addr, resolved_address, pointer_write_error);
 
     if (!pointer_write_error.Success()) {
-      err = Status::FromErrorStringWithFormat(
-          "couldn't write the address of symbol %s: %s",
-          m_symbol.GetName().AsCString(), pointer_write_error.AsCString());
+      err = Status::FromErrorStringWithFormatv(
+          "couldn't write the address of symbol {0}: {1}", m_symbol.GetName(),
+          pointer_write_error.AsCString());
       return;
     }
   }
@@ -1273,10 +1264,9 @@ public:
 
     const lldb::addr_t load_addr = process_address + m_offset;
 
-    LLDB_LOGF(log,
-              "EntitySymbol::Dematerialize [address = 0x%" PRIx64
-              ", m_symbol = %s]",
-              (uint64_t)load_addr, m_symbol.GetName().AsCString());
+    LLDB_LOG(log,
+             "EntitySymbol::Dematerialize [address = {0:x}, m_symbol = {1}]",
+             (uint64_t)load_addr, m_symbol.GetName());
 
     // no work needs to be done
   }
@@ -1289,8 +1279,8 @@ public:
 
     const lldb::addr_t load_addr = process_address + m_offset;
 
-    dump_stream.Printf("0x%" PRIx64 ": EntitySymbol (%s)\n", load_addr,
-                       m_symbol.GetName().AsCString());
+    dump_stream.Format("{0:x}: EntitySymbol ({1})\n", load_addr,
+                       m_symbol.GetName());
 
     {
       dump_stream.Printf("Pointer:\n");

--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -1058,7 +1058,7 @@ void DynamicLoaderDarwinKernel::LoadKernelModuleIfNeeded() {
       kernel_name =
           m_kernel.GetModule()->GetObjectFile()->GetFileSpec().GetFilename();
     }
-    m_kernel.SetName(kernel_name.AsCString());
+    m_kernel.SetName(kernel_name.AsCString(nullptr));
 
     if (m_kernel.GetLoadAddress() == LLDB_INVALID_ADDRESS) {
       m_kernel.SetLoadAddress(m_kernel_load_address);

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -821,9 +821,10 @@ DynamicLoaderPOSIXDYLD::GetThreadLocalData(const lldb::ModuleSP module_sp,
   Log *log = GetLog(LLDBLog::DynamicLoader);
   std::optional<addr_t> link_map_addr_opt = GetLoadedModuleLinkAddr(module_sp);
   if (!link_map_addr_opt.has_value()) {
-    LLDB_LOGF(
-        log, "GetThreadLocalData error: module(%s) not found in loaded modules",
-        module_sp->GetObjectName().AsCString());
+    LLDB_LOG(
+        log,
+        "GetThreadLocalData error: module({0}) not found in loaded modules",
+        module_sp->GetObjectName());
     return LLDB_INVALID_ADDRESS;
   }
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
@@ -931,7 +931,7 @@ void ClangASTSource::FindObjCMethodDecls(NameSearchContext &context) {
 
   do {
     StreamString ms;
-    ms.Printf("-[%s %s]", interface_name.c_str(), selector_name.AsCString());
+    ms.Format("-[{0} {1}]", interface_name, selector_name);
     ms.Flush();
     ConstString instance_method_name(ms.GetString());
 
@@ -944,7 +944,7 @@ void ClangASTSource::FindObjCMethodDecls(NameSearchContext &context) {
       break;
 
     ms.Clear();
-    ms.Printf("+[%s %s]", interface_name.c_str(), selector_name.AsCString());
+    ms.Format("+[{0} {1}]", interface_name, selector_name);
     ms.Flush();
     ConstString class_method_name(ms.GetString());
 
@@ -970,7 +970,8 @@ void ClangASTSource::FindObjCMethodDecls(NameSearchContext &context) {
       if (!candidate_sc.function)
         continue;
 
-      const char *candidate_name = candidate_sc.function->GetName().AsCString();
+      const char *candidate_name =
+          candidate_sc.function->GetName().AsCString(nullptr);
 
       const char *cursor = candidate_name;
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -1512,8 +1512,8 @@ lldb_private::Status ClangExpressionParser::DoPrepareForExecution(
           "Couldn't find %s() in the module", m_expr.FunctionName());
       return err;
     } else {
-      LLDB_LOGF(log, "Found function %s for %s", function_name.AsCString(),
-                m_expr.FunctionName());
+      LLDB_LOG(log, "Found function {0} for {1}", function_name,
+               m_expr.FunctionName());
     }
   }
 
@@ -1564,9 +1564,9 @@ lldb_private::Status ClangExpressionParser::DoPrepareForExecution(
 
   if (decl_map) {
     StreamString error_stream;
-    IRForTarget ir_for_target(decl_map, m_expr.NeedsVariableResolution(),
-                              *execution_unit_sp, error_stream,
-                              execution_policy, function_name.AsCString());
+    IRForTarget ir_for_target(
+        decl_map, m_expr.NeedsVariableResolution(), *execution_unit_sp,
+        error_stream, execution_policy, function_name.AsCString(nullptr));
 
     if (!ir_for_target.runOnModule(*execution_unit_sp->GetModule())) {
       err = Status(error_stream.GetString().str());
@@ -1628,7 +1628,7 @@ lldb_private::Status ClangExpressionParser::DoPrepareForExecution(
         if (auto *checker_funcs = llvm::dyn_cast<ClangDynamicCheckerFunctions>(
                 process->GetDynamicCheckers())) {
           IRDynamicChecks ir_dynamic_checks(*checker_funcs,
-                                            function_name.AsCString());
+                                            function_name.AsCString(nullptr));
 
           llvm::Module *module = execution_unit_sp->GetModule();
           if (!module || !ir_dynamic_checks.runOnModule(*module)) {

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionSourceCode.cpp
@@ -160,13 +160,13 @@ static void AddMacros(const DebugMacros *dm, CompileUnit *comp_unit,
     switch (entry.GetType()) {
     case DebugMacroEntry::DEFINE:
       if (state.IsValidEntry(entry.GetLineNumber()))
-        stream.Printf("#define %s\n", entry.GetMacroString().AsCString());
+        stream.Format("#define {0}\n", entry.GetMacroString());
       else
         return;
       break;
     case DebugMacroEntry::UNDEF:
       if (state.IsValidEntry(entry.GetLineNumber()))
-        stream.Printf("#undef %s\n", entry.GetMacroString().AsCString());
+        stream.Format("#undef {0}\n", entry.GetMacroString());
       else
         return;
       break;
@@ -359,7 +359,7 @@ void ClangExpressionSourceCode::AddLocalVariableDecls(StreamString &stream,
     if ((var_name == "self" || var_name == "_cmd") && is_objc)
       continue;
 
-    stream.Printf("using $__lldb_local_vars::%s;\n", var_name.AsCString());
+    stream.Format("using $__lldb_local_vars::{0};\n", var_name);
   }
 }
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -338,8 +338,8 @@ ClangModulesDeclVendorImpl::AddModule(const SourceModule &module,
   }
 
   if (!HS.lookupModule(module.path.front().GetStringRef()))
-    return llvm::createStringError("header search couldn't locate module '%s'",
-                                   module.path.front().AsCString());
+    return llvm::createStringErrorV(
+        "header search couldn't locate module '{0}'", module.path.front());
 
   llvm::SmallVector<clang::IdentifierLoc, 4> clang_path;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -150,7 +150,7 @@ public:
       return llvm::createStringErrorV("type has no child named '{0}'", name);
 
     const bool omit_empty_base_classes = false;
-    return m_block_struct_type.GetIndexOfChildWithName(name.AsCString(),
+    return m_block_struct_type.GetIndexOfChildWithName(name.AsCString(nullptr),
                                                        omit_empty_base_classes);
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -2270,7 +2270,7 @@ static bool PrintFunctionNameWithArgs(Stream &s,
 
   const char *cstr = sc.GetPossiblyInlinedFunctionName()
                          .GetName(Mangled::NamePreference::ePreferDemangled)
-                         .AsCString();
+                         .AsCString(nullptr);
   if (!cstr)
     return false;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -269,7 +269,7 @@ lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_count || !m_base_data_address)
     return llvm::createStringErrorV("type has no child named '{0}'", name);
-  auto optional_idx = ExtractIndexFromString(name.AsCString());
+  auto optional_idx = ExtractIndexFromString(name.AsCString(nullptr));
   if (!optional_idx) {
     return llvm::createStringErrorV("type has no child named '{0}'", name);
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVector.cpp
@@ -267,7 +267,7 @@ lldb_private::formatters::MsvcStlVectorBoolSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_count || !m_base_data_address)
     return llvm::createStringErrorV("type has no child named '{0}'", name);
-  auto optional_idx = ExtractIndexFromString(name.AsCString());
+  auto optional_idx = ExtractIndexFromString(name.AsCString(nullptr));
   if (!optional_idx) {
     return llvm::createStringErrorV("type has no child named '{0}'", name);
   }

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABIRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABIRuntime.cpp
@@ -91,7 +91,7 @@ ItaniumABIRuntime::GetTypeInfo(ValueObject &in_value,
                       ": static-type = '%s' has dynamic type: uid={0x%" PRIx64
                       "}, type-name='%s'\n",
                       in_value.GetPointerValue().address,
-                      in_value.GetTypeName().AsCString(), type_sp->GetID(),
+                      in_value.GetTypeName().AsCString(""), type_sp->GetID(),
                       type_sp->GetName().GetCString());
             type_info.SetTypeSP(type_sp);
           }
@@ -107,7 +107,7 @@ ItaniumABIRuntime::GetTypeInfo(ValueObject &in_value,
                         ": static-type = '%s' has multiple matching dynamic "
                         "types: uid={0x%" PRIx64 "}, type-name='%s'\n",
                         in_value.GetPointerValue().address,
-                        in_value.GetTypeName().AsCString(), type_sp->GetID(),
+                        in_value.GetTypeName().AsCString(""), type_sp->GetID(),
                         type_sp->GetName().GetCString());
             }
           }
@@ -123,7 +123,7 @@ ItaniumABIRuntime::GetTypeInfo(ValueObject &in_value,
                         "matching dynamic types, picking "
                         "this one: uid={0x%" PRIx64 "}, type-name='%s'\n",
                         in_value.GetPointerValue().address,
-                        in_value.GetTypeName().AsCString(), type_sp->GetID(),
+                        in_value.GetTypeName().AsCString(""), type_sp->GetID(),
                         type_sp->GetName().GetCString());
               type_info.SetTypeSP(type_sp);
             }
@@ -135,7 +135,7 @@ ItaniumABIRuntime::GetTypeInfo(ValueObject &in_value,
                   ": static-type = '%s' has multiple matching dynamic "
                   "types, didn't find a C++ match\n",
                   in_value.GetPointerValue().address,
-                  in_value.GetTypeName().AsCString());
+                  in_value.GetTypeName().AsCString(""));
       }
       if (type_info)
         SetDynamicTypeInfo(vtable_info.addr, type_info);

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.cpp
@@ -497,10 +497,10 @@ bool AppleObjCDeclVendor::FinishDecl(clang::ObjCInterfaceDecl *interface_decl) {
     return false;
   };
 
-  LLDB_LOGF(log,
-            "[AppleObjCDeclVendor::FinishDecl] Finishing Objective-C "
-            "interface for %s",
-            descriptor->GetClassName().AsCString());
+  LLDB_LOG(log,
+           "[AppleObjCDeclVendor::FinishDecl] Finishing Objective-C interface "
+           "for {0}",
+           descriptor->GetClassName());
 
   if (!descriptor->Describe(superclass_func, instance_method_func,
                             class_method_func, ivar_func))
@@ -521,9 +521,8 @@ uint32_t AppleObjCDeclVendor::FindDecls(ConstString name, bool append,
   Log *log(
       GetLog(LLDBLog::Expressions)); // FIXME - a more appropriate log channel?
 
-  LLDB_LOGF(log, "AppleObjCDeclVendor::FindDecls ('%s', %s, %u, )",
-            (const char *)name.AsCString(), append ? "true" : "false",
-            max_matches);
+  LLDB_LOG(log, "AppleObjCDeclVendor::FindDecls ('{0}', {1}, {2}, )", name,
+           append ? "true" : "false", max_matches);
 
   if (!append)
     decls.clear();
@@ -566,8 +565,7 @@ uint32_t AppleObjCDeclVendor::FindDecls(ConstString name, bool append,
     return 0;
   }
 
-  LLDB_LOGF(log, "AOCTV::FT Couldn't find %s in the ASTContext",
-            name.AsCString());
+  LLDB_LOG(log, "AOCTV::FT Couldn't find {0} in the ASTContext", name);
 
   // It's not.  If it exists, we have to put it into our ASTContext.
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
@@ -100,7 +100,7 @@ AppleObjCRuntimeV1::CreateExceptionResolver(const BreakpointSP &bkpt,
 
   if (throw_bp)
     resolver_sp = std::make_shared<BreakpointResolverName>(
-        bkpt, std::get<1>(GetExceptionThrowLocation()).AsCString(),
+        bkpt, std::get<1>(GetExceptionThrowLocation()).AsCString(nullptr),
         eFunctionNameTypeBase, eLanguageTypeUnknown, Breakpoint::Exact, 0,
         /*offset_is_insn_count = */ false, eLazyBoolNo);
   // FIXME: don't do catch yet.

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -312,8 +312,8 @@ __lldb_apple_objc_v2_get_dynamic_class_info3(void *gdb_objc_realized_classes_ptr
 static const char *g_shared_cache_class_name_funcptr = R"(
 extern "C"
 {
-    const char *%s(void *objc_class);
-    const char *(*class_name_lookup_func)(void *) = %s;
+    const char *{0}(void *objc_class);
+    const char *(*class_name_lookup_func)(void *) = {1};
 }
 )";
 
@@ -1189,7 +1189,7 @@ AppleObjCRuntimeV2::CreateExceptionResolver(const BreakpointSP &bkpt,
 
   if (throw_bp)
     resolver_sp = std::make_shared<BreakpointResolverName>(
-        bkpt, std::get<1>(GetExceptionThrowLocation()).AsCString(),
+        bkpt, std::get<1>(GetExceptionThrowLocation()).AsCString(nullptr),
         eFunctionNameTypeBase, eLanguageTypeUnknown, Breakpoint::Exact, 0,
         /*offset_is_insn_count = */ false, eLazyBoolNo);
   // FIXME: We don't do catch breakpoints for ObjC yet.
@@ -1960,10 +1960,9 @@ AppleObjCRuntimeV2::SharedCacheClassInfoExtractor::
   // concatenate the two parts of our expression text.  The format string has
   // two %s's, so provide the name twice.
   std::string shared_class_expression;
-  llvm::raw_string_ostream(shared_class_expression)
-      << llvm::format(g_shared_cache_class_name_funcptr,
-                      class_name_getter_function_name.AsCString(),
-                      class_name_getter_function_name.AsCString());
+  llvm::raw_string_ostream(shared_class_expression) << llvm::formatv(
+      g_shared_cache_class_name_funcptr, class_name_getter_function_name,
+      class_name_getter_function_name);
 
   shared_class_expression += g_get_shared_cache_class_info_definitions;
   shared_class_expression += g_get_shared_cache_class_info_body;
@@ -2775,7 +2774,7 @@ DeclVendor *AppleObjCRuntimeV2::GetDeclVendor() {
 lldb::addr_t AppleObjCRuntimeV2::LookupRuntimeSymbol(ConstString name) {
   lldb::addr_t ret = LLDB_INVALID_ADDRESS;
 
-  const char *name_cstr = name.AsCString();
+  const char *name_cstr = name.AsCString(nullptr);
 
   if (name_cstr) {
     llvm::StringRef name_strref(name_cstr);
@@ -2796,7 +2795,7 @@ lldb::addr_t AppleObjCRuntimeV2::LookupRuntimeSymbol(ConstString name) {
 
         if (descriptor) {
           const ConstString ivar_name_cs(class_and_ivar.second);
-          const char *ivar_name_cstr = ivar_name_cs.AsCString();
+          const char *ivar_name_cstr = ivar_name_cs.AsCString(nullptr);
 
           auto ivar_func = [&ret,
                             ivar_name_cstr](const char *name, const char *type,

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
@@ -622,10 +622,10 @@ AppleObjCTrampolineHandler::AppleObjCTrampolineHandler(
     // step through any method dispatches.  Warn to that effect and get out of
     // here.
     if (process_sp->CanJIT()) {
-      process_sp->GetTarget().GetDebugger().GetAsyncErrorStream()->Printf(
-          "Could not find implementation lookup function \"%s\""
-          " step in through ObjC method dispatch will not work.\n",
-          get_impl_name.AsCString());
+      process_sp->GetTarget().GetDebugger().GetAsyncErrorStream()->Format(
+          "Could not find implementation lookup function \"{0}\" step in "
+          "through ObjC method dispatch will not work.\n",
+          get_impl_name);
     }
     return;
   }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -67,7 +67,7 @@ public:
     // for the known v1/v2 this is all that needs to be done
     virtual bool IsKVO() {
       if (m_is_kvo == eLazyBoolCalculate) {
-        const char *class_name = GetClassName().AsCString();
+        const char *class_name = GetClassName().AsCString(nullptr);
         if (class_name && *class_name)
           m_is_kvo =
               (LazyBool)(strstr(class_name, "NSKVONotifying_") == class_name);
@@ -79,7 +79,7 @@ public:
     // for the known v1/v2 this is all that needs to be done
     virtual bool IsCFType() {
       if (m_is_cf == eLazyBoolCalculate) {
-        const char *class_name = GetClassName().AsCString();
+        const char *class_name = GetClassName().AsCString(nullptr);
         if (class_name && *class_name)
           m_is_cf = (LazyBool)(strcmp(class_name, "__NSCFType") == 0 ||
                                strcmp(class_name, "NSCFType") == 0);

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -682,9 +682,10 @@ ModuleSpecList ObjectFileELF::GetModuleSpecifications(
           uint32_t core_notes_crc = 0;
 
           if (!gnu_debuglink_crc) {
-            LLDB_SCOPED_TIMERF(
-                "Calculating module crc32 %s with size %" PRIu64 " KiB",
-                file.GetFilename().AsCString(), (length - file_offset) / 1024);
+            LLDB_SCOPED_TIMERF("Calculating module crc32 %s with size %" PRIu64
+                               " KiB",
+                               file.GetFilename().AsCString(""),
+                               (length - file_offset) / 1024);
 
             // For core files - which usually don't happen to have a
             // gnu_debuglink, and are pretty bulky - calculating whole

--- a/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.cpp
+++ b/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.cpp
@@ -264,10 +264,9 @@ bool ObjectFileJSON::SetLoadAddress(Target &target, lldb::addr_t value,
   for (const SectionSP &section_sp : *m_sections_up) {
     addr_t section_load_addr = section_sp->GetFileAddress();
     if (section_load_addr != LLDB_INVALID_ADDRESS) {
-      LLDB_LOGF(
-          log,
-          "ObjectFileJSON::SetLoadAddress section %s to load addr 0x%" PRIx64,
-          section_sp->GetName().AsCString(), section_load_addr + slide);
+      LLDB_LOG(log,
+               "ObjectFileJSON::SetLoadAddress section {0} to load addr {1:x}",
+               section_sp->GetName(), section_load_addr + slide);
       target.SetSectionLoadAddress(section_sp, section_load_addr + slide,
                                    /*warn_multiple=*/true);
     }

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -1652,8 +1652,8 @@ void ObjectFileMachO::ProcessSegmentCommand(
         log->Printf(
             "Installing dSYM's %s segment file address over ObjectFile's "
             "so symbol table/debug info resolves correctly for %s",
-            const_segname.AsCString(),
-            module_sp->GetFileSpec().GetFilename().AsCString());
+            const_segname.AsCString(""),
+            module_sp->GetFileSpec().GetFilename().AsCString(""));
       }
 
       // Make sure we've parsed the symbol table from the ObjectFile before
@@ -2134,7 +2134,7 @@ static SymbolType GetSymbolType(const char *&symbol_name,
                                 const SectionSP &symbol_section) {
   SymbolType type = eSymbolTypeInvalid;
 
-  const char *symbol_sect_name = symbol_section->GetName().AsCString();
+  const char *symbol_sect_name = symbol_section->GetName().AsCString(nullptr);
   if (symbol_section->IsDescendant(text_section_sp.get())) {
     if (symbol_section->IsClear(S_ATTR_PURE_INSTRUCTIONS |
                                 S_ATTR_SELF_MODIFYING_CODE |
@@ -3335,7 +3335,7 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
 
                           if (type == eSymbolTypeInvalid) {
                             const char *symbol_sect_name =
-                                symbol_section->GetName().AsCString();
+                                symbol_section->GetName().AsCString(nullptr);
                             if (symbol_section->IsDescendant(
                                     text_section_sp.get())) {
                               if (symbol_section->IsClear(
@@ -4095,7 +4095,7 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
 
             if (type == eSymbolTypeInvalid) {
               const char *symbol_sect_name =
-                  symbol_section->GetName().AsCString();
+                  symbol_section->GetName().AsCString(nullptr);
               if (symbol_section->IsDescendant(text_section_sp.get())) {
                 if (symbol_section->IsClear(S_ATTR_PURE_INSTRUCTIONS |
                                             S_ATTR_SELF_MODIFYING_CODE |
@@ -6037,11 +6037,10 @@ bool ObjectFileMachO::SetLoadAddress(Target &target, lldb::addr_t value,
       // sections that size on disk (to avoid __PAGEZERO) and load them
       SectionSP section_sp(section_list->GetSectionAtIndex(sect_idx));
       if (SectionIsLoadable(section_sp.get())) {
-        LLDB_LOGF(log,
-                  "ObjectFileMachO::SetLoadAddress segment '%s' load addr is "
-                  "0x%" PRIx64,
-                  section_sp->GetName().AsCString(),
-                  section_sp->GetFileAddress() + value);
+        LLDB_LOG(
+            log,
+            "ObjectFileMachO::SetLoadAddress segment '{0}' load addr is {1:x}",
+            section_sp->GetName(), section_sp->GetFileAddress() + value);
         if (target.SetSectionLoadAddress(section_sp,
                                          section_sp->GetFileAddress() + value,
                                          warn_multiple))
@@ -6062,9 +6061,9 @@ bool ObjectFileMachO::SetLoadAddress(Target &target, lldb::addr_t value,
                 value, mach_header_section, section_sp.get());
         if (section_load_addr != LLDB_INVALID_ADDRESS) {
           LLDB_LOGF(log,
-                    "ObjectFileMachO::SetLoadAddress segment '%s' load addr is "
-                    "0x%" PRIx64,
-                    section_sp->GetName().AsCString(), section_load_addr);
+                    "ObjectFileMachO::SetLoadAddress segment '{0}' load addr "
+                    "is {1:x}",
+                    section_sp->GetName(), section_load_addr);
           if (target.SetSectionLoadAddress(section_sp, section_load_addr,
                                            warn_multiple))
             ++num_loaded_sections;
@@ -6223,7 +6222,7 @@ CreateAllImageInfosPayload(const lldb::ProcessSP &process_sp,
         // is not guaranteed to be nul-terminated if all 16 characters are
         // used.
         // coverity[buffer_size_warning]
-        strncpy(seg_vmaddr.segname, name.AsCString(),
+        strncpy(seg_vmaddr.segname, name.AsCString(nullptr),
                 sizeof(seg_vmaddr.segname));
         seg_vmaddr.vmaddr = vmaddr;
         seg_vmaddr.unused = 0;

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6060,10 +6060,10 @@ bool ObjectFileMachO::SetLoadAddress(Target &target, lldb::addr_t value,
             CalculateSectionLoadAddressForMemoryImage(
                 value, mach_header_section, section_sp.get());
         if (section_load_addr != LLDB_INVALID_ADDRESS) {
-          LLDB_LOGF(log,
-                    "ObjectFileMachO::SetLoadAddress segment '{0}' load addr "
-                    "is {1:x}",
-                    section_sp->GetName(), section_load_addr);
+          LLDB_LOG(log,
+                   "ObjectFileMachO::SetLoadAddress segment '{0}' load addr is "
+                   "{1:x}",
+                   section_sp->GetName(), section_load_addr);
           if (target.SetSectionLoadAddress(section_sp, section_load_addr,
                                            warn_multiple))
             ++num_loaded_sections;

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -165,7 +165,7 @@ static UUID GetCoffUUID(llvm::object::COFFObjectFile &coff_obj) {
     auto raw_data = coff_obj.getData();
     LLDB_SCOPED_TIMERF(
         "Calculating module crc32 %s with size %" PRIu64 " KiB",
-        FileSpec(coff_obj.getFileName()).GetFilename().AsCString(),
+        FileSpec(coff_obj.getFileName()).GetFilename().AsCString(""),
         static_cast<lldb::offset_t>(raw_data.size()) / 1024);
     gnu_debuglink_crc = llvm::crc32(0, llvm::arrayRefFromStringRef(raw_data));
   }

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
@@ -277,16 +277,16 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
     Process *process) {
 
   Log *log = GetLog(LLDBLog::Platform);
-  LLDB_LOGF(log,
-            "[%s] Trying to find module %s/%s - platform path %s/%s symbol "
-            "path %s/%s",
-            (IsHost() ? "host" : "remote"),
-            module_spec.GetFileSpec().GetDirectory().AsCString(),
-            module_spec.GetFileSpec().GetFilename().AsCString(),
-            module_spec.GetPlatformFileSpec().GetDirectory().AsCString(),
-            module_spec.GetPlatformFileSpec().GetFilename().AsCString(),
-            module_spec.GetSymbolFileSpec().GetDirectory().AsCString(),
-            module_spec.GetSymbolFileSpec().GetFilename().AsCString());
+  LLDB_LOG(log,
+           "[{0}] Trying to find module {1}/{2} - platform path {3}/{4} symbol "
+           "path {5}/{6}",
+           (IsHost() ? "host" : "remote"),
+           module_spec.GetFileSpec().GetDirectory(),
+           module_spec.GetFileSpec().GetFilename(),
+           module_spec.GetPlatformFileSpec().GetDirectory(),
+           module_spec.GetPlatformFileSpec().GetFilename(),
+           module_spec.GetSymbolFileSpec().GetDirectory(),
+           module_spec.GetSymbolFileSpec().GetFilename());
 
   Status err;
 
@@ -341,10 +341,10 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
           return err;
         if (FileSystem::Instance().Exists(module_cache_spec)) {
           Log *log = GetLog(LLDBLog::Platform);
-          LLDB_LOGF(log, "[%s] module %s/%s was rsynced and is now there",
-                    (IsHost() ? "host" : "remote"),
-                    module_spec.GetFileSpec().GetDirectory().AsCString(),
-                    module_spec.GetFileSpec().GetFilename().AsCString());
+          LLDB_LOG(log, "[{0}] module {1}/{2} was rsynced and is now there",
+                   (IsHost() ? "host" : "remote"),
+                   module_spec.GetFileSpec().GetDirectory(),
+                   module_spec.GetFileSpec().GetFilename());
           ModuleSpec local_spec(module_cache_spec,
                                 module_spec.GetArchitecture());
           module_sp = std::make_shared<Module>(local_spec);
@@ -375,11 +375,12 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
             requires_transfer = *MD5 != *remote_md5;
           if (requires_transfer) {
             // bring in the remote file
-            LLDB_LOGF(log,
-                      "[%s] module %s/%s needs to be replaced from remote copy",
-                      (IsHost() ? "host" : "remote"),
-                      module_spec.GetFileSpec().GetDirectory().AsCString(),
-                      module_spec.GetFileSpec().GetFilename().AsCString());
+            LLDB_LOG(
+                log,
+                "[{0}] module {1}/{2} needs to be replaced from remote copy",
+                (IsHost() ? "host" : "remote"),
+                module_spec.GetFileSpec().GetDirectory(),
+                module_spec.GetFileSpec().GetFilename());
             Status err =
                 BringInRemoteFile(this, module_spec, module_cache_spec);
             if (err.Fail())
@@ -391,27 +392,27 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
         module_sp = std::make_shared<Module>(local_spec);
         module_sp->SetPlatformFileSpec(module_spec.GetFileSpec());
         Log *log = GetLog(LLDBLog::Platform);
-        LLDB_LOGF(log, "[%s] module %s/%s was found in the cache",
-                  (IsHost() ? "host" : "remote"),
-                  module_spec.GetFileSpec().GetDirectory().AsCString(),
-                  module_spec.GetFileSpec().GetFilename().AsCString());
+        LLDB_LOG(log, "[{0}] module {1}/{2} was found in the cache",
+                 (IsHost() ? "host" : "remote"),
+                 module_spec.GetFileSpec().GetDirectory(),
+                 module_spec.GetFileSpec().GetFilename());
         return Status();
       }
 
       // bring in the remote module file
-      LLDB_LOGF(log, "[%s] module %s/%s needs to come in remotely",
-                (IsHost() ? "host" : "remote"),
-                module_spec.GetFileSpec().GetDirectory().AsCString(),
-                module_spec.GetFileSpec().GetFilename().AsCString());
+      LLDB_LOG(log, "[{0}] module {1}/{2} needs to come in remotely",
+               (IsHost() ? "host" : "remote"),
+               module_spec.GetFileSpec().GetDirectory(),
+               module_spec.GetFileSpec().GetFilename());
       Status err = BringInRemoteFile(this, module_spec, module_cache_spec);
       if (err.Fail())
         return err;
       if (FileSystem::Instance().Exists(module_cache_spec)) {
         Log *log = GetLog(LLDBLog::Platform);
-        LLDB_LOGF(log, "[%s] module %s/%s is now cached and fine",
-                  (IsHost() ? "host" : "remote"),
-                  module_spec.GetFileSpec().GetDirectory().AsCString(),
-                  module_spec.GetFileSpec().GetFilename().AsCString());
+        LLDB_LOG(log, "[{0}] module {1}/{2} is now cached and fine",
+                 (IsHost() ? "host" : "remote"),
+                 module_spec.GetFileSpec().GetDirectory(),
+                 module_spec.GetFileSpec().GetFilename());
         ModuleSpec local_spec(module_cache_spec, module_spec.GetArchitecture());
         module_sp = std::make_shared<Module>(local_spec);
         module_sp->SetPlatformFileSpec(module_spec.GetFileSpec());

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -1834,9 +1834,9 @@ Status NativeProcessLinux::GetLoadedModuleFileSpec(const char *module_path,
       return Status();
     }
   }
-  return Status::FromErrorStringWithFormat(
-      "Module file (%s) not found in /proc/%" PRIu64 "/maps file!",
-      module_file_spec.GetFilename().AsCString(), GetID());
+  return Status::FromErrorStringWithFormatv(
+      "Module file ({0}) not found in /proc/{1}/maps file!",
+      module_file_spec.GetFilename(), GetID());
 }
 
 Status NativeProcessLinux::GetFileLoadAddress(const llvm::StringRef &file_name,

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -4978,13 +4978,13 @@ bool ParseRegisters(
             if (reg_info.byte_size == flags_type->GetSize())
               reg_info.flags_type = flags_type;
             else
-              LLDB_LOGF(log,
-                        "ProcessGDBRemote::ParseRegisters Size of register "
-                        "flags %s (%d bytes) for "
-                        "register %s does not match the register size (%d "
-                        "bytes). Ignoring this set of flags.",
-                        flags_type->GetID().c_str(), flags_type->GetSize(),
-                        reg_info.name.AsCString(), reg_info.byte_size);
+              LLDB_LOG(
+                  log,
+                  "ProcessGDBRemote::ParseRegisters Size of register flags {0} "
+                  "({1} bytes) for register {2} does not match the register "
+                  "size ({3} bytes). Ignoring this set of flags.",
+                  flags_type->GetID().c_str(), flags_type->GetSize(),
+                  reg_info.name, reg_info.byte_size);
           }
 
           // There's a slim chance that the gdb_type name is both a flags type
@@ -5037,9 +5037,9 @@ bool ParseRegisters(
         }
 
         if (reg_info.byte_size == 0) {
-          LLDB_LOGF(log,
-                    "ProcessGDBRemote::%s Skipping zero bitsize register %s",
-                    __FUNCTION__, reg_info.name.AsCString());
+          LLDB_LOG(log,
+                   "ProcessGDBRemote::{0} Skipping zero bitsize register {1}",
+                   __FUNCTION__, reg_info.name);
         } else
           registers.push_back(reg_info);
 

--- a/lldb/source/Plugins/Process/mach-core/RegisterContextUnifiedCore.cpp
+++ b/lldb/source/Plugins/Process/mach-core/RegisterContextUnifiedCore.cpp
@@ -151,9 +151,9 @@ RegisterContextUnifiedCore::RegisterContextUnifiedCore(
   // Put the RegisterSet names in the constant string pool,
   // to sidestep lifetime issues of char*'s.
   auto copy_regset_name = [](RegisterSet &dst, const RegisterSet &src) {
-    dst.name = ConstString(src.name).AsCString();
+    dst.name = ConstString(src.name).AsCString(nullptr);
     if (src.short_name)
-      dst.short_name = ConstString(src.short_name).AsCString();
+      dst.short_name = ConstString(src.short_name).AsCString(nullptr);
     else
       dst.short_name = nullptr;
   };

--- a/lldb/source/Plugins/Process/scripted/ScriptedFrame.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedFrame.cpp
@@ -144,7 +144,7 @@ const char *ScriptedFrame::GetFunctionName() {
   std::optional<std::string> function_name = GetInterface()->GetFunctionName();
   if (!function_name)
     return StackFrame::GetFunctionName();
-  return ConstString(function_name->c_str()).AsCString();
+  return ConstString(function_name->c_str()).AsCString(nullptr);
 }
 
 const char *ScriptedFrame::GetDisplayFunctionName() {
@@ -153,7 +153,7 @@ const char *ScriptedFrame::GetDisplayFunctionName() {
       GetInterface()->GetDisplayFunctionName();
   if (!function_name)
     return StackFrame::GetDisplayFunctionName();
-  return ConstString(function_name->c_str()).AsCString();
+  return ConstString(function_name->c_str()).AsCString(nullptr);
 }
 
 bool ScriptedFrame::IsInlined() { return GetInterface()->IsInlined(); }
@@ -311,7 +311,8 @@ lldb::ValueObjectSP ScriptedFrame::GetValueObjectForFrameVariable(
   if (!values)
     return {};
 
-  return values->FindValueObjectByValueName(variable_sp->GetName().AsCString());
+  return values->FindValueObjectByValueName(
+      variable_sp->GetName().AsCString(nullptr));
 }
 
 lldb::ValueObjectSP ScriptedFrame::GetValueForVariableExpressionPath(

--- a/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
@@ -94,7 +94,7 @@ const char *ScriptedThread::GetName() {
   std::optional<std::string> thread_name = GetInterface()->GetName();
   if (!thread_name)
     return nullptr;
-  return ConstString(thread_name->c_str()).AsCString();
+  return ConstString(thread_name->c_str()).AsCString(nullptr);
 }
 
 const char *ScriptedThread::GetQueueName() {
@@ -102,7 +102,7 @@ const char *ScriptedThread::GetQueueName() {
   std::optional<std::string> queue_name = GetInterface()->GetQueue();
   if (!queue_name)
     return nullptr;
-  return ConstString(queue_name->c_str()).AsCString();
+  return ConstString(queue_name->c_str()).AsCString(nullptr);
 }
 
 void ScriptedThread::WillResume(StateType resume_state) {}

--- a/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
+++ b/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
@@ -902,9 +902,10 @@ size_t SymbolFileCTF::ParseObjects(CompileUnit &comp_unit) {
 
       lldb::user_id_t variable_type_uid = m_variables.size();
       m_variables.emplace_back(std::make_shared<Variable>(
-          variable_type_uid, symbol->GetName().AsCString(),
-          symbol->GetName().AsCString(), type_sp, eValueTypeVariableGlobal,
-          m_comp_unit_sp.get(), ranges, &decl, location, symbol->IsExternal(),
+          variable_type_uid, symbol->GetName().AsCString(nullptr),
+          symbol->GetName().AsCString(nullptr), type_sp,
+          eValueTypeVariableGlobal, m_comp_unit_sp.get(), ranges, &decl,
+          location, symbol->IsExternal(),
           /*artificial=*/false,
           /*location_is_constant_data*/ false));
     }

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -1767,7 +1767,7 @@ TypeSP DWARFASTParserClang::ParseStructureLikeDIE(
       dwarf->GetObjectFile()->GetModule()->LogMessage(
           log, "SymbolFileDWARF({0:p}) - {1:x16}: {2} has unique name: {3} ",
           static_cast<void *>(this), die.GetID(), DW_TAG_value_to_name(tag),
-          unique_typename.AsCString());
+          unique_typename.AsCString(nullptr));
     }
     if (UniqueDWARFASTType *unique_ast_entry_type =
             dwarf->GetUniqueDWARFASTTypeMap().Find(

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -482,7 +482,7 @@ Module *SymbolFileDWARFDebugMap::GetModuleByCompUnitInfo(
             "\"%s\" object from the \"%s\" archive: "
             "either the .o file doesn't exist in the archive or the "
             "modification time (0x%8.8x) of the .o file doesn't match",
-            oso_object.AsCString(), oso_file.GetPath().c_str(),
+            oso_object.AsCString(""), oso_file.GetPath().c_str(),
             (uint32_t)llvm::sys::toTimeT(comp_unit_info->oso_mod_time));
       }
     }

--- a/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -1761,7 +1761,7 @@ SymbolFilePDB::FindNamespace(lldb_private::ConstString name,
       GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
   if (auto err = type_system_or_err.takeError()) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
-                   "Unable to find namespace {1}: {0}", name.AsCString());
+                   "Unable to find namespace {1}: {0}", name);
     return CompilerDeclContext();
   }
   auto ts = *type_system_or_err;

--- a/lldb/source/Plugins/SymbolFile/Symtab/SymbolFileSymtab.cpp
+++ b/lldb/source/Plugins/SymbolFile/Symtab/SymbolFileSymtab.cpp
@@ -120,9 +120,10 @@ CompUnitSP SymbolFileSymtab::ParseCompileUnitAtIndex(uint32_t idx) {
     const Symbol *cu_symbol =
         m_objfile_sp->GetSymtab()->SymbolAtIndex(m_source_indexes[idx]);
     if (cu_symbol)
-      cu_sp = std::make_shared<CompileUnit>(m_objfile_sp->GetModule(), nullptr,
-                                            cu_symbol->GetName().AsCString(), 0,
-                                            eLanguageTypeUnknown, eLazyBoolNo);
+      cu_sp =
+          std::make_shared<CompileUnit>(m_objfile_sp->GetModule(), nullptr,
+                                        cu_symbol->GetName().AsCString(nullptr),
+                                        0, eLanguageTypeUnknown, eLazyBoolNo);
   }
   return cu_sp;
 }

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/SystemRuntimeMacOSX.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/SystemRuntimeMacOSX.cpp
@@ -542,7 +542,7 @@ ThreadSP SystemRuntimeMacOSX::GetExtendedBacktraceThread(ThreadSP real_thread,
     originating_thread_sp = std::make_shared<HistoryThread>(
         *m_process, real_thread->GetIndexID(), app_specific_backtrace_pcs,
         HistoryPCType::Calls);
-    originating_thread_sp->SetQueueName(type.AsCString());
+    originating_thread_sp->SetQueueName(type.AsCString(nullptr));
   }
   return originating_thread_sp;
 }

--- a/lldb/source/Plugins/UnwindAssembly/x86/x86AssemblyInspectionEngine.cpp
+++ b/lldb/source/Plugins/UnwindAssembly/x86/x86AssemblyInspectionEngine.cpp
@@ -1541,7 +1541,7 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
 
   unwind_plan.SetPlanValidAddressRanges({func_range});
   if (unwind_plan_updated) {
-    std::string unwind_plan_source(unwind_plan.GetSourceName().AsCString());
+    std::string unwind_plan_source = unwind_plan.GetSourceName().GetString();
     unwind_plan_source += " plus augmentation from assembly parsing";
     unwind_plan.SetSourceName(unwind_plan_source.c_str());
     unwind_plan.SetSourcedFromCompiler(eLazyBoolNo);

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -840,7 +840,7 @@ const Symbol *SymbolContext::FindBestGlobalDataSymbol(ConstString name,
 
     if (external_symbols.size() > 1) {
       StreamString ss;
-      ss.Printf("Multiple external symbols found for '%s'\n", name.AsCString());
+      ss.Format("Multiple external symbols found for '{0}'\n", name);
       for (const Symbol *symbol : external_symbols) {
         symbol->GetDescription(&ss, eDescriptionLevelFull, &target);
       }
@@ -851,7 +851,7 @@ const Symbol *SymbolContext::FindBestGlobalDataSymbol(ConstString name,
       return external_symbols[0];
     } else if (internal_symbols.size() > 1) {
       StreamString ss;
-      ss.Printf("Multiple internal symbols found for '%s'\n", name.AsCString());
+      ss.Format("Multiple internal symbols found for '{0}'\n", name);
       for (const Symbol *symbol : internal_symbols) {
         symbol->GetDescription(&ss, eDescriptionLevelVerbose, &target);
         ss.PutChar('\n');

--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -760,7 +760,7 @@ uint32_t Symtab::AppendSymbolIndexesMatchingRegExAndType(
     if (symbol_type == eSymbolTypeAny ||
         m_symbols[i].GetType() == symbol_type) {
       const char *name =
-          m_symbols[i].GetMangled().GetName(name_preference).AsCString();
+          m_symbols[i].GetMangled().GetName(name_preference).AsCString(nullptr);
       if (name) {
         if (regexp.Execute(name))
           indexes.push_back(i);
@@ -786,7 +786,7 @@ uint32_t Symtab::AppendSymbolIndexesMatchingRegExAndType(
         continue;
 
       const char *name =
-          m_symbols[i].GetMangled().GetName(name_preference).AsCString();
+          m_symbols[i].GetMangled().GetName(name_preference).AsCString(nullptr);
       if (name) {
         if (regexp.Execute(name))
           indexes.push_back(i);

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -1239,12 +1239,12 @@ bool TypeMemberFunctionImpl::GetDescription(Stream &stream) {
                   m_type.GetTypeName().AsCString("<unknown>"));
     break;
   case lldb::eMemberFunctionKindInstanceMethod:
-    stream.Printf("instance method %s of type %s", m_name.AsCString(),
-                  m_decl.GetDeclContext().GetName().AsCString());
+    stream.Format("instance method {0} of type {1}", m_name,
+                  m_decl.GetDeclContext().GetName());
     break;
   case lldb::eMemberFunctionKindStaticMethod:
-    stream.Printf("static method %s of type %s", m_name.AsCString(),
-                  m_decl.GetDeclContext().GetName().AsCString());
+    stream.Format("static method {0} of type {1}", m_name,
+                  m_decl.GetDeclContext().GetName());
     break;
   }
   return true;

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -96,7 +96,7 @@ bool Variable::NameMatches(ConstString name) const {
   return m_mangled.NameMatches(name);
 }
 bool Variable::NameMatches(const RegularExpression &regex) const {
-  if (regex.Execute(m_name.AsCString()))
+  if (regex.Execute(m_name.AsCString(nullptr)))
     return true;
   if (m_mangled)
     return m_mangled.NameMatches(regex);

--- a/lldb/source/Target/DynamicRegisterInfo.cpp
+++ b/lldb/source/Target/DynamicRegisterInfo.cpp
@@ -209,8 +209,8 @@ DynamicRegisterInfo::SetRegisterInfo(const StructuredData::Dictionary &dict,
       std::optional<llvm::StringRef> maybe_set_name =
           sets->GetItemAtIndexAsString(i);
       if (maybe_set_name && !maybe_set_name->empty()) {
-        m_sets.push_back(
-            {ConstString(*maybe_set_name).AsCString(), nullptr, 0, nullptr});
+        m_sets.push_back({ConstString(*maybe_set_name).AsCString(nullptr),
+                          nullptr, 0, nullptr});
       } else {
         Clear();
         printf("error: register sets must have valid names\n");
@@ -412,14 +412,19 @@ size_t DynamicRegisterInfo::SetRegisterInfo(
       m_value_reg_offset_map[local_regnum] = reg.value_reg_offset;
     }
 
-    struct RegisterInfo reg_info {
-      reg.name.AsCString(), reg.alt_name.AsCString(), reg.byte_size,
-          reg.byte_offset, reg.encoding, reg.format,
-          {reg.regnum_ehframe, reg.regnum_dwarf, reg.regnum_generic,
-           reg.regnum_remote, local_regnum},
-          // value_regs and invalidate_regs are filled by Finalize()
-          nullptr, nullptr, reg.flags_type
-    };
+    struct RegisterInfo reg_info{
+        reg.name.AsCString(nullptr),
+        reg.alt_name.AsCString(nullptr),
+        reg.byte_size,
+        reg.byte_offset,
+        reg.encoding,
+        reg.format,
+        {reg.regnum_ehframe, reg.regnum_dwarf, reg.regnum_generic,
+         reg.regnum_remote, local_regnum},
+        // value_regs and invalidate_regs are filled by Finalize()
+        nullptr,
+        nullptr,
+        reg.flags_type};
 
     m_regs.push_back(reg_info);
 
@@ -716,7 +721,7 @@ DynamicRegisterInfo::GetRegisterSetIndexByName(const ConstString &set_name,
 
   m_set_names.push_back(set_name);
   m_set_reg_nums.resize(m_set_reg_nums.size() + 1);
-  RegisterSet new_set = {set_name.AsCString(), nullptr, 0, nullptr};
+  RegisterSet new_set = {set_name.AsCString(nullptr), nullptr, 0, nullptr};
   m_sets.push_back(new_set);
   return m_sets.size() - 1;
 }

--- a/lldb/source/Target/ModuleCache.cpp
+++ b/lldb/source/Target/ModuleCache.cpp
@@ -194,7 +194,7 @@ Status ModuleCache::Put(const FileSpec &root_dir_spec, const char *hostname,
   const auto module_spec_dir =
       GetModuleDirectory(root_dir_spec, module_spec.GetUUID());
   const auto module_file_path =
-      JoinPath(module_spec_dir, target_file.GetFilename().AsCString());
+      JoinPath(module_spec_dir, target_file.GetFilename().AsCString(nullptr));
 
   const auto tmp_file_path = tmp_file.GetPath();
   const auto err_code =
@@ -227,8 +227,9 @@ Status ModuleCache::Get(const FileSpec &root_dir_spec, const char *hostname,
 
   const auto module_spec_dir =
       GetModuleDirectory(root_dir_spec, module_spec.GetUUID());
-  const auto module_file_path = JoinPath(
-      module_spec_dir, module_spec.GetFileSpec().GetFilename().AsCString());
+  const auto module_file_path =
+      JoinPath(module_spec_dir,
+               module_spec.GetFileSpec().GetFilename().AsCString(nullptr));
 
   if (!FileSystem::Instance().Exists(module_file_path))
     return Status::FromErrorStringWithFormat(

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -6155,7 +6155,7 @@ addr_t Process::ResolveIndirectFunction(const Address *address, Status &error) {
       const Symbol *symbol = address->CalculateSymbolContextSymbol();
       error = Status::FromErrorStringWithFormat(
           "Unable to call resolver for indirect function %s",
-          symbol ? symbol->GetName().AsCString() : "<UNKNOWN>");
+          symbol ? symbol->GetName().AsCString(nullptr) : "<UNKNOWN>");
       function_addr = LLDB_INVALID_ADDRESS;
     } else {
       if (ABISP abi_sp = GetABI())

--- a/lldb/source/Target/RegisterContextUnwind.cpp
+++ b/lldb/source/Target/RegisterContextUnwind.cpp
@@ -646,7 +646,7 @@ void RegisterContextUnwind::InitializeNonZerothFrame() {
       active_row->Dump(active_row_strm, m_fast_unwind_plan_sp.get(), &m_thread,
                        m_start_pc.GetLoadAddress(exe_ctx.GetTargetPtr()));
       UnwindLogMsg("Using fast unwind plan '%s'",
-                   m_fast_unwind_plan_sp->GetSourceName().AsCString());
+                   m_fast_unwind_plan_sp->GetSourceName().AsCString(""));
       UnwindLogMsg("active row: %s", active_row_strm.GetData());
     }
   } else {
@@ -662,7 +662,7 @@ void RegisterContextUnwind::InitializeNonZerothFrame() {
                          &m_thread,
                          m_start_pc.GetLoadAddress(exe_ctx.GetTargetPtr()));
         UnwindLogMsg("Using full unwind plan '%s'",
-                     m_full_unwind_plan_sp->GetSourceName().AsCString());
+                     m_full_unwind_plan_sp->GetSourceName().AsCString(""));
         UnwindLogMsg("active row: %s", active_row_strm.GetData());
       }
     }
@@ -1358,7 +1358,7 @@ RegisterContextUnwind::GetAbstractRegisterLocation(uint32_t lldb_regnum,
       active_row->Dump(active_row_strm, m_full_unwind_plan_sp.get(), &m_thread,
                        m_start_pc.GetLoadAddress(exe_ctx.GetTargetPtr()));
       UnwindLogMsg("Using full unwind plan '%s'",
-                   m_full_unwind_plan_sp->GetSourceName().AsCString());
+                   m_full_unwind_plan_sp->GetSourceName().AsCString(""));
       UnwindLogMsg("active row: %s", active_row_strm.GetData());
     }
 
@@ -1499,7 +1499,7 @@ RegisterContextUnwind::GetAbstractRegisterLocation(uint32_t lldb_regnum,
   std::string unwindplan_name;
   if (m_full_unwind_plan_sp) {
     unwindplan_name += "via '";
-    unwindplan_name += m_full_unwind_plan_sp->GetSourceName().AsCString();
+    unwindplan_name += m_full_unwind_plan_sp->GetSourceName().AsCString("");
     unwindplan_name += "'";
   }
   UnwindLogMsg("no save location for %s (%d) %s", regnum.GetName(),
@@ -1747,7 +1747,7 @@ UnwindPlanSP RegisterContextUnwind::TryAdoptArchitectureUnwindPlan() {
     if (GetLog(LLDBLog::Unwind)) {
       UnwindLogMsg(
           "Replacing Full Unwindplan with Architecture UnwindPlan, '%s'",
-          m_full_unwind_plan_sp->GetSourceName().AsCString());
+          m_full_unwind_plan_sp->GetSourceName().AsCString(""));
       const UnwindPlan::Row *active_row =
           m_full_unwind_plan_sp->GetRowForFunctionOffset(m_current_offset);
       if (active_row) {
@@ -2124,7 +2124,7 @@ bool RegisterContextUnwind::ReadFrameAddress(
           process.ReadPointerFromMemory(candidate_addr, st);
       if (st.Fail()) {
         UnwindLogMsg("Cannot read memory at 0x%" PRIx64 ": %s", candidate_addr,
-                     st.AsCString());
+                     st.AsCString(""));
         return false;
       }
       Address addr;

--- a/lldb/source/Target/SectionLoadList.cpp
+++ b/lldb/source/Target/SectionLoadList.cpp
@@ -132,12 +132,11 @@ bool SectionLoadList::SetSectionLoadAddress(const lldb::SectionSP &section,
     return true; // Changed
 
   } else {
-    LLDB_LOGF(
-        log,
-        "SectionLoadList::%s (section = %p (%s), load_addr = 0x%16.16" PRIx64
-        ") error: module has been deleted",
-        __FUNCTION__, static_cast<void *>(section.get()),
-        section->GetName().AsCString(), load_addr);
+    LLDB_LOG(log,
+             "SectionLoadList::{0} (section = {1} ({2}), load_addr = {3:x}) "
+             "error: module has been deleted",
+             __FUNCTION__, static_cast<void *>(section.get()),
+             section->GetName(), load_addr);
   }
   return false;
 }
@@ -156,9 +155,9 @@ size_t SectionLoadList::SetSectionUnloaded(const lldb::SectionSP &section_sp) {
             section_sp->GetModule()->GetFileSpec());
         module_name = module_file_spec.GetPath();
       }
-      LLDB_LOGF(log, "SectionLoadList::%s (section = %p (%s.%s))", __FUNCTION__,
-                static_cast<void *>(section_sp.get()), module_name.c_str(),
-                section_sp->GetName().AsCString());
+      LLDB_LOG(log, "SectionLoadList::{0} (section = {1} ({2}.{3}))",
+               __FUNCTION__, static_cast<void *>(section_sp.get()), module_name,
+               section_sp->GetName());
     }
 
     std::lock_guard<std::recursive_mutex> guard(m_mutex);
@@ -195,7 +194,7 @@ bool SectionLoadList::SetSectionUnloaded(const lldb::SectionSP &section_sp,
         "SectionLoadList::%s (section = %p (%s.%s), load_addr = 0x%16.16" PRIx64
         ")",
         __FUNCTION__, static_cast<void *>(section_sp.get()),
-        module_name.c_str(), section_sp->GetName().AsCString(), load_addr);
+        module_name.c_str(), section_sp->GetName().AsCString(""), load_addr);
   }
   bool erased = false;
   std::lock_guard<std::recursive_mutex> guard(m_mutex);

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -1301,7 +1301,7 @@ const char *StackFrame::GetFunctionName() {
       const InlineFunctionInfo *inlined_info =
           inlined_block->GetInlinedFunctionInfo();
       if (inlined_info)
-        name = inlined_info->GetName().AsCString();
+        name = inlined_info->GetName().AsCString(nullptr);
     }
   }
 
@@ -1328,7 +1328,7 @@ const char *StackFrame::GetDisplayFunctionName() {
       const InlineFunctionInfo *inlined_info =
           inlined_block->GetInlinedFunctionInfo();
       if (inlined_info)
-        name = inlined_info->GetDisplayName().AsCString();
+        name = inlined_info->GetDisplayName().AsCString(nullptr);
     }
   }
 
@@ -1411,8 +1411,8 @@ GetBaseExplainingValue(const Instruction::Operand &operand,
     return base_and_offset;
   }
   case Instruction::Operand::Type::Register: {
-    const RegisterInfo *info =
-        register_context.GetRegisterInfoByName(operand.m_register.AsCString());
+    const RegisterInfo *info = register_context.GetRegisterInfoByName(
+        operand.m_register.AsCString(nullptr));
     if (!info) {
       return std::make_pair(nullptr, 0);
     }
@@ -1654,7 +1654,7 @@ lldb::ValueObjectSP DoGuessValueAt(StackFrame &frame, ConstString reg,
   using namespace OperandMatchers;
 
   const RegisterInfo *reg_info =
-      frame.GetRegisterContext()->GetRegisterInfoByName(reg.AsCString());
+      frame.GetRegisterContext()->GetRegisterInfoByName(reg.AsCString(nullptr));
   if (!reg_info) {
     return ValueObjectSP();
   }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -870,10 +870,8 @@ BreakpointName *Target::FindBreakpointName(ConstString name, bool can_create,
   }
 
   if (!can_create) {
-    error = Status::FromErrorStringWithFormat(
-        "Breakpoint name \"%s\" doesn't exist and "
-        "can_create is false.",
-        name.AsCString());
+    error = Status::FromErrorStringWithFormatv(
+        "Breakpoint name \"{0}\" doesn't exist and can_create is false.", name);
     return nullptr;
   }
 
@@ -886,7 +884,7 @@ void Target::DeleteBreakpointName(ConstString name) {
   BreakpointNameList::iterator iter = m_breakpoint_names.find(name);
 
   if (iter != m_breakpoint_names.end()) {
-    const char *name_cstr = name.AsCString();
+    const char *name_cstr = name.AsCString(nullptr);
     m_breakpoint_names.erase(iter);
     for (auto bp_sp : m_breakpoint_list.Breakpoints())
       bp_sp->RemoveName(name_cstr);
@@ -895,7 +893,7 @@ void Target::DeleteBreakpointName(ConstString name) {
 
 void Target::RemoveNameFromBreakpoint(lldb::BreakpointSP &bp_sp,
                                       ConstString name) {
-  bp_sp->RemoveName(name.AsCString());
+  bp_sp->RemoveName(name.AsCString(nullptr));
 }
 
 void Target::ConfigureBreakpointName(
@@ -908,7 +906,8 @@ void Target::ConfigureBreakpointName(
 
 void Target::ApplyNameToBreakpoints(BreakpointName &bp_name) {
   llvm::Expected<std::vector<BreakpointSP>> expected_vector =
-      m_breakpoint_list.FindBreakpointsByName(bp_name.GetName().AsCString());
+      m_breakpoint_list.FindBreakpointsByName(
+          bp_name.GetName().AsCString(nullptr));
 
   if (!expected_vector) {
     LLDB_LOG(GetLog(LLDBLog::Breakpoints), "invalid breakpoint name: {}",

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -1865,19 +1865,17 @@ Status Thread::JumpToLine(const FileSpec &file, uint32_t line,
   // Check if we got anything.
   if (candidates.empty()) {
     if (outside_function.empty()) {
-      return Status::FromErrorStringWithFormat(
-          "Cannot locate an address for %s:%i.", file.GetFilename().AsCString(),
-          line);
+      return Status::FromErrorStringWithFormatv(
+          "Cannot locate an address for {0}:{1}.", file.GetFilename(), line);
     } else if (outside_function.size() == 1) {
-      return Status::FromErrorStringWithFormat(
-          "%s:%i is outside the current function.",
-          file.GetFilename().AsCString(), line);
+      return Status::FromErrorStringWithFormatv(
+          "{0}:{1} is outside the current function.", file.GetFilename(), line);
     } else {
       StreamString sstr;
       DumpAddressList(sstr, outside_function, target);
-      return Status::FromErrorStringWithFormat(
-          "%s:%i has multiple candidate locations:\n%s",
-          file.GetFilename().AsCString(), line, sstr.GetData());
+      return Status::FromErrorStringWithFormatv(
+          "{0}:{1} has multiple candidate locations:\n{2}", file.GetFilename(),
+          line, sstr.GetData());
     }
   }
 
@@ -1885,9 +1883,10 @@ Status Thread::JumpToLine(const FileSpec &file, uint32_t line,
   Address dest = candidates[0];
   if (warnings && candidates.size() > 1) {
     StreamString sstr;
-    sstr.Printf("%s:%i appears multiple times in this function, selecting the "
-                "first location:\n",
-                file.GetFilename().AsCString(), line);
+    sstr.Format(
+        "{0}:{1} appears multiple times in this function, selecting the "
+        "first location:\n",
+        file.GetFilename(), line);
     DumpAddressList(sstr, candidates, target);
     *warnings = std::string(sstr.GetString());
   }

--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -112,9 +112,8 @@ void ThreadPlanStepInRange::GetDescription(Stream *s,
     printed_line_info = true;
   }
 
-  const char *step_into_target = m_step_into_target.AsCString();
-  if (step_into_target && step_into_target[0] != '\0')
-    s->Printf(" targeting %s", m_step_into_target.AsCString());
+  if (m_step_into_target)
+    s->Format(" targeting {0}", m_step_into_target);
 
   if (!printed_line_info || level == eDescriptionLevelVerbose) {
     s->Printf(" using ranges:");
@@ -379,8 +378,8 @@ bool ThreadPlanStepInRange::DefaultShouldStopHereCallback(
           should_stop_here = true;
         } else {
           const char *target_name =
-              step_in_range_plan->m_step_into_target.AsCString();
-          const char *function_name = sc.GetFunctionName().AsCString();
+              step_in_range_plan->m_step_into_target.AsCString(nullptr);
+          const char *function_name = sc.GetFunctionName().AsCString(nullptr);
 
           if (function_name == nullptr)
             should_stop_here = false;
@@ -388,11 +387,11 @@ bool ThreadPlanStepInRange::DefaultShouldStopHereCallback(
             should_stop_here = false;
         }
         if (log && !should_stop_here)
-          LLDB_LOGF(log,
-                    "Stepping out of frame %s which did not match step into "
-                    "target %s.",
-                    sc.GetFunctionName().AsCString(),
-                    step_in_range_plan->m_step_into_target.AsCString());
+          LLDB_LOG(log,
+                   "Stepping out of frame {0} which did not match step into "
+                   "target {1}.",
+                   sc.GetFunctionName(),
+                   step_in_range_plan->m_step_into_target);
       }
     }
 

--- a/lldb/source/Target/ThreadPlanStepOverRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepOverRange.cpp
@@ -420,7 +420,7 @@ bool ThreadPlanStepOverRange::DoWillResume(lldb::StateType resume_state,
                   frame_block->GetInlinedFunctionInfo();
               const char *name;
               if (inline_info)
-                name = inline_info->GetName().AsCString();
+                name = inline_info->GetName().AsCString("");
               else
                 name = "<unknown-notinlined>";
 

--- a/lldb/source/Target/TraceDumper.cpp
+++ b/lldb/source/Target/TraceDumper.cpp
@@ -30,7 +30,7 @@ static std::optional<const char *> ToOptionalString(const char *s) {
 static const char *GetModuleName(const SymbolContext &sc) {
   if (!sc.module_sp)
     return nullptr;
-  return sc.module_sp->GetFileSpec().GetFilename().AsCString();
+  return sc.module_sp->GetFileSpec().GetFilename().AsCString(nullptr);
 }
 
 /// \return
@@ -377,7 +377,8 @@ public:
       m_j.attribute("module", ToOptionalString(GetModuleName(item)));
       m_j.attribute(
           "symbol",
-          ToOptionalString(item.symbol_info->sc.GetFunctionName().AsCString()));
+          ToOptionalString(
+              item.symbol_info->sc.GetFunctionName().AsCString(nullptr)));
 
       if (lldb::InstructionSP instruction = item.symbol_info->instruction) {
         ExecutionContext exe_ctx = item.symbol_info->exe_ctx;

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -1557,8 +1557,7 @@ bool ValueObject::DumpPrintableRepresentation(
         str = GetSummaryAsCString();
       else if (val_obj_display == eValueObjectRepresentationStyleSummary) {
         if (!CanProvideValue()) {
-          strm.Printf("%s @ %s", GetTypeName().AsCString(),
-                      GetLocationAsCString());
+          strm.Format("{0} @ {1}", GetTypeName(), GetLocationAsCString());
           str = strm.GetString();
         } else
           str = GetValueAsCString();

--- a/lldb/source/ValueObject/ValueObjectSynthetic.cpp
+++ b/lldb/source/ValueObject/ValueObjectSynthetic.cpp
@@ -99,11 +99,10 @@ ValueObjectSynthetic::CalculateNumChildren(uint32_t max) {
 
   if (max < UINT32_MAX) {
     auto num_children = m_synth_filter_up->CalculateNumChildren(max);
-    LLDB_LOGF(log,
-              "[ValueObjectSynthetic::CalculateNumChildren] for VO of name "
-              "%s and type %s, the filter returned %u child values",
-              GetName().AsCString(), GetTypeName().AsCString(),
-              num_children ? *num_children : 0);
+    LLDB_LOG(log,
+             "[ValueObjectSynthetic::CalculateNumChildren] for VO of name "
+             "{0} and type {1}, the filter returned {2} child values",
+             GetName(), GetTypeName(), num_children ? *num_children : 0);
     return num_children;
   } else {
     auto num_children_or_err = m_synth_filter_up->CalculateNumChildren(max);
@@ -112,10 +111,10 @@ ValueObjectSynthetic::CalculateNumChildren(uint32_t max) {
       return num_children_or_err;
     }
     auto num_children = (m_synthetic_children_count = *num_children_or_err);
-    LLDB_LOGF(log,
-              "[ValueObjectSynthetic::CalculateNumChildren] for VO of name "
-              "%s and type %s, the filter returned %u child values",
-              GetName().AsCString(), GetTypeName().AsCString(), num_children);
+    LLDB_LOG(log,
+             "[ValueObjectSynthetic::CalculateNumChildren] for VO of name "
+             "{0} and type {1}, the filter returned {2} child values",
+             GetName(), GetTypeName(), num_children);
     return num_children;
   }
 }
@@ -178,21 +177,20 @@ bool ValueObjectSynthetic::UpdateValue() {
   // type of an object changes, so does their synthetic filter of choice.
   ConstString new_parent_type_name = m_parent->GetTypeName();
   if (new_parent_type_name != m_parent_type_name) {
-    LLDB_LOGF(log,
-              "[ValueObjectSynthetic::UpdateValue] name=%s, type changed "
-              "from %s to %s, recomputing synthetic filter",
-              GetName().AsCString(), m_parent_type_name.AsCString(),
-              new_parent_type_name.AsCString());
+    LLDB_LOG(log,
+             "[ValueObjectSynthetic::UpdateValue] name={0}, type changed "
+             "from {1} to {2}, recomputing synthetic filter",
+             GetName(), m_parent_type_name, new_parent_type_name);
     m_parent_type_name = new_parent_type_name;
     CreateSynthFilter();
   }
 
   // let our backend do its update
   if (m_synth_filter_up->Update() == lldb::ChildCacheState::eRefetch) {
-    LLDB_LOGF(log,
-              "[ValueObjectSynthetic::UpdateValue] name=%s, synthetic "
-              "filter said caches are stale - clearing",
-              GetName().AsCString());
+    LLDB_LOG(log,
+             "[ValueObjectSynthetic::UpdateValue] name={0}, synthetic "
+             "filter said caches are stale - clearing",
+             GetName());
     // filter said that cached values are stale
     {
       std::lock_guard<std::mutex> guard(m_child_mutex);
@@ -211,10 +209,10 @@ bool ValueObjectSynthetic::UpdateValue() {
     m_synthetic_children_count = UINT32_MAX;
     m_might_have_children = eLazyBoolCalculate;
   } else {
-    LLDB_LOGF(log,
-              "[ValueObjectSynthetic::UpdateValue] name=%s, synthetic "
-              "filter said caches are still valid",
-              GetName().AsCString());
+    LLDB_LOG(log,
+             "[ValueObjectSynthetic::UpdateValue] name={0}, synthetic "
+             "filter said caches are still valid",
+             GetName());
   }
 
   m_provides_value = eLazyBoolCalculate;
@@ -222,18 +220,18 @@ bool ValueObjectSynthetic::UpdateValue() {
   lldb::ValueObjectSP synth_val(m_synth_filter_up->GetSyntheticValue());
 
   if (synth_val && synth_val->CanProvideValue()) {
-    LLDB_LOGF(log,
-              "[ValueObjectSynthetic::UpdateValue] name=%s, synthetic "
-              "filter said it can provide a value",
-              GetName().AsCString());
+    LLDB_LOG(log,
+             "[ValueObjectSynthetic::UpdateValue] name={0}, synthetic "
+             "filter said it can provide a value",
+             GetName());
 
     m_provides_value = eLazyBoolYes;
     CopyValueData(synth_val.get());
   } else {
-    LLDB_LOGF(log,
-              "[ValueObjectSynthetic::UpdateValue] name=%s, synthetic "
-              "filter said it will not provide a value",
-              GetName().AsCString());
+    LLDB_LOG(log,
+             "[ValueObjectSynthetic::UpdateValue] name={0}, synthetic "
+             "filter said it will not provide a value",
+             GetName());
 
     m_provides_value = eLazyBoolNo;
     // Copying the data of an incomplete type won't work as it has no byte size.
@@ -249,10 +247,10 @@ lldb::ValueObjectSP ValueObjectSynthetic::GetChildAtIndex(uint32_t idx,
                                                           bool can_create) {
   Log *log = GetLog(LLDBLog::DataFormatters);
 
-  LLDB_LOGF(log,
-            "[ValueObjectSynthetic::GetChildAtIndex] name=%s, retrieving "
-            "child at index %u",
-            GetName().AsCString(), idx);
+  LLDB_LOG(log,
+           "[ValueObjectSynthetic::GetChildAtIndex] name={0}, retrieving "
+           "child at index {1}",
+           GetName(), idx);
 
   UpdateValueIfNeeded();
 
@@ -268,19 +266,19 @@ lldb::ValueObjectSP ValueObjectSynthetic::GetChildAtIndex(uint32_t idx,
 
   if (!child_is_cached) {
     if (can_create && m_synth_filter_up != nullptr) {
-      LLDB_LOGF(log,
-                "[ValueObjectSynthetic::GetChildAtIndex] name=%s, child at "
-                "index %u not cached and will be created",
-                GetName().AsCString(), idx);
+      LLDB_LOG(log,
+               "[ValueObjectSynthetic::GetChildAtIndex] name={0}, child at "
+               "index {1} not cached and will be created",
+               GetName(), idx);
 
       lldb::ValueObjectSP synth_guy = m_synth_filter_up->GetChildAtIndex(idx);
 
-      LLDB_LOGF(
+      LLDB_LOG(
           log,
-          "[ValueObjectSynthetic::GetChildAtIndex] name=%s, child at index "
-          "%u created as %p (is "
-          "synthetic: %s)",
-          GetName().AsCString(), idx, static_cast<void *>(synth_guy.get()),
+          "[ValueObjectSynthetic::GetChildAtIndex] name={0}, child at index "
+          "{1} created as {2} (is "
+          "synthetic: {3})",
+          GetName(), idx, static_cast<void *>(synth_guy.get()),
           synth_guy.get()
               ? (synth_guy->IsSyntheticChildrenGenerated() ? "yes" : "no")
               : "no");
@@ -298,20 +296,20 @@ lldb::ValueObjectSP ValueObjectSynthetic::GetChildAtIndex(uint32_t idx,
           GetPreferredDisplayLanguage());
       return synth_guy;
     } else {
-      LLDB_LOGF(log,
-                "[ValueObjectSynthetic::GetChildAtIndex] name=%s, child at "
-                "index %u not cached and cannot "
-                "be created (can_create = %s, synth_filter = %p)",
-                GetName().AsCString(), idx, can_create ? "yes" : "no",
-                static_cast<void *>(m_synth_filter_up.get()));
+      LLDB_LOG(log,
+               "[ValueObjectSynthetic::GetChildAtIndex] name={0}, child at "
+               "index {1} not cached and cannot "
+               "be created (can_create = {2}, synth_filter = {3})",
+               GetName(), idx, can_create ? "yes" : "no",
+               static_cast<void *>(m_synth_filter_up.get()));
 
       return lldb::ValueObjectSP();
     }
   } else {
-    LLDB_LOGF(log,
-              "[ValueObjectSynthetic::GetChildAtIndex] name=%s, child at "
-              "index %u cached as %p",
-              GetName().AsCString(), idx, static_cast<void *>(valobj));
+    LLDB_LOG(log,
+             "[ValueObjectSynthetic::GetChildAtIndex] name={0}, child at "
+             "index {1} cached as {2}",
+             GetName(), idx, static_cast<void *>(valobj));
 
     return valobj->GetSP();
   }

--- a/lldb/unittests/Utility/ConstStringTest.cpp
+++ b/lldb/unittests/Utility/ConstStringTest.cpp
@@ -145,7 +145,7 @@ TEST(ConstStringTest, StringConversions) {
   // Member functions.
   EXPECT_EQ(llvm::StringRef("foo"), foo.GetStringRef());
   EXPECT_EQ(std::string("foo"), foo.GetString());
-  EXPECT_STREQ("foo", foo.AsCString());
+  EXPECT_STREQ("foo", foo.AsCString(nullptr));
 
   // Conversion operators.
   EXPECT_EQ(llvm::StringRef("foo"), llvm::StringRef(foo));


### PR DESCRIPTION
This patch makes the default parameter to `ConstString::AsCString` explicit. Currently it defaults to nullptr. However, there a bunch of callsites that do some form of `printf("%s", foo.AsCString())`, which is UB (I have at least 1 crash on me where this was the root cause).

Alternatively we could change the default to "" instead of nullptr, but code that did if (foo.AsCString()) would then change meaning.

Initially I tried doing this via a `sed` on the entire codebase but there are several APIs also called `AsCString` so that got very fiddly. Instead I made the parameter explicit and fixed all compilation errors manually. Where it was trivial I changed `llvm::format`/`printf` calls to use the LLVM-style format specifiers (e.g., `LLDB_LOG` instead of `LLDB_LOGF` and `Stream::Format` instead of `Stream::Printf`). That way we could drop the `AsCString` call entirely. Also there are a couple of places where we could use `ConstString::GetString` instead of `ConstString::AsCString` to initialize a `std::string`.

rdar://171219173