### PR TITLE
[SeparateConstOffsetFromGEP] Fix incorrect inbounds flag in case of non-negative index but negative offset

### DIFF
--- a/llvm/lib/Transforms/Scalar/SeparateConstOffsetFromGEP.cpp
+++ b/llvm/lib/Transforms/Scalar/SeparateConstOffsetFromGEP.cpp
@@ -388,8 +388,10 @@ private:
   /// LowerGEP is true, it finds in indices of both sequential and structure
   /// types, otherwise it only finds in sequential indices. The output
   /// NeedsExtraction indicates whether we successfully find a non-zero constant
-  /// offset.
-  APInt accumulateByteOffset(GetElementPtrInst *GEP, bool &NeedsExtraction);
+  /// offset, and SignedOverflow indicates if there was signed overflow in
+  /// offset calculation.
+  APInt accumulateByteOffset(GetElementPtrInst *GEP, bool &NeedsExtraction,
+                             bool &SignedOverflow);
 
   /// Canonicalize array indices to pointer-size integers. This helps to
   /// simplify the logic of splitting a GEP. For example, if a + b is a
@@ -930,8 +932,10 @@ bool SeparateConstOffsetFromGEP::canonicalizeArrayIndicesToIndexSize(
 }
 
 APInt SeparateConstOffsetFromGEP::accumulateByteOffset(GetElementPtrInst *GEP,
-                                                       bool &NeedsExtraction) {
+                                                       bool &NeedsExtraction,
+                                                       bool &SignedOverflow) {
   NeedsExtraction = false;
+  SignedOverflow = false;
   unsigned IdxWidth = DL->getIndexTypeSizeInBits(GEP->getType());
   APInt AccumulativeByteOffset(IdxWidth, 0);
   gep_type_iterator GTI = gep_type_begin(*GEP);
@@ -950,10 +954,15 @@ APInt SeparateConstOffsetFromGEP::accumulateByteOffset(GetElementPtrInst *GEP,
         // A GEP may have multiple indices.  We accumulate the extracted
         // constant offset to a byte offset, and later offset the remainder of
         // the original GEP with this byte offset.
-        AccumulativeByteOffset +=
-            ConstantOffset * APInt(IdxWidth,
-                                   GTI.getSequentialElementStride(*DL),
-                                   /*IsSigned=*/true, /*ImplicitTrunc=*/true);
+        bool Overflow;
+        auto ByteOffset = ConstantOffset.smul_ov(
+            APInt(IdxWidth, GTI.getSequentialElementStride(*DL),
+                  /*IsSigned=*/true, /*ImplicitTrunc=*/true),
+            Overflow);
+        SignedOverflow |= Overflow;
+        AccumulativeByteOffset =
+            AccumulativeByteOffset.sadd_ov(ByteOffset, Overflow);
+        SignedOverflow |= Overflow;
       }
     } else if (LowerGEP) {
       StructType *StTy = GTI.getStructType();
@@ -1038,8 +1047,9 @@ bool SeparateConstOffsetFromGEP::reorderGEP(GetElementPtrInst *GEP,
   if (!PtrGEP)
     return false;
 
-  bool NestedNeedsExtraction;
-  APInt NestedByteOffset = accumulateByteOffset(PtrGEP, NestedNeedsExtraction);
+  bool NestedNeedsExtraction, OffsetOverflow;
+  APInt NestedByteOffset =
+      accumulateByteOffset(PtrGEP, NestedNeedsExtraction, OffsetOverflow);
   if (!NestedNeedsExtraction)
     return false;
 
@@ -1099,9 +1109,13 @@ bool SeparateConstOffsetFromGEP::splitGEP(GetElementPtrInst *GEP) {
 
   bool Changed = canonicalizeArrayIndicesToIndexSize(GEP);
 
-  bool NeedsExtraction;
-  APInt NonBaseByteOffset = accumulateByteOffset(GEP, NeedsExtraction);
-  APInt AccumulativeByteOffset = BaseByteOffset + NonBaseByteOffset;
+  bool NeedsExtraction, OffsetOverflow;
+  APInt NonBaseByteOffset =
+      accumulateByteOffset(GEP, NeedsExtraction, OffsetOverflow);
+  bool AddOverflow;
+  APInt AccumulativeByteOffset =
+      BaseByteOffset.sadd_ov(NonBaseByteOffset, AddOverflow);
+  OffsetOverflow |= AddOverflow;
 
   TargetTransformInfo &TTI = GetTTI(*GEP->getFunction());
 
@@ -1142,7 +1156,8 @@ bool SeparateConstOffsetFromGEP::splitGEP(GetElementPtrInst *GEP) {
   }
 
   // Track information for preserving GEP flags.
-  bool AllOffsetsNonNegative = AccumulativeByteOffset.isNonNegative();
+  bool AllOffsetsNonNegative =
+      AccumulativeByteOffset.isNonNegative() && !OffsetOverflow;
   bool AllNUWPreserved = GEP->hasNoUnsignedWrap();
   bool NewGEPInBounds = GEP->isInBounds();
   bool NewGEPNUSW = GEP->hasNoUnsignedSignedWrap();

--- a/llvm/test/Transforms/SeparateConstOffsetFromGEP/RISCV/split-gep.ll
+++ b/llvm/test/Transforms/SeparateConstOffsetFromGEP/RISCV/split-gep.ll
@@ -299,8 +299,8 @@ define i64 @test_inbounds1(ptr %arr, i64 %x) {
 ; CHECK-NEXT:    [[MIN:%.*]] = tail call i64 @llvm.umin.i64(i64 [[X:%.*]], i64 4)
 ; CHECK-NEXT:    [[XOR:%.*]] = xor i64 [[MIN]], -1
 ; CHECK-NEXT:    [[SHR:%.*]] = lshr i64 [[XOR]], 1
-; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr inbounds [6 x i64], ptr [[ARR:%.*]], i64 0, i64 [[SHR]]
-; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr inbounds i8, ptr [[TMP0]], i64 40
+; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr [6 x i64], ptr [[ARR:%.*]], i64 0, i64 [[SHR]]
+; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[TMP0]], i64 40
 ; CHECK-NEXT:    [[RES:%.*]] = load i64, ptr [[GEP2]], align 8
 ; CHECK-NEXT:    ret i64 [[RES]]
 ;


### PR DESCRIPTION
Fixes #190187 

Currently, SeparateConstOffsetFromGEP preserves inbounds attribute if new sequence of GEPs from the same base pointer has non-negative offsets in each GEP (this was mentioned in https://github.com/llvm/llvm-project/pull/159515). This statement seems correct for me (if the sequence consists from 2 GEPs), but current implementation has a flaw: it checks that constant byte offset and GEP indices are non-negative. However, in some corner cases we can have a situation when the index is non-negative, but its offset (in bytes) is negative, so we can't preserve inbounds attribute. In the example, GEP index after transformation can have values `0x7ffffffffffffffd`/`0x7ffffffffffffffe`/`0x7fffffffffffffff`; they are all non-negative (sign bit is zero), however, after multiplication on sizeof(i64) they become negative and inbounds can't be preserved anymore.

The proposed fix is to check that Idx * ElementStride is non-negative (instead of checking Idx only).