### PR TITLE
[clang] Store size & mtime in in-memory module cache

### DIFF
--- a/clang/include/clang/Serialization/InMemoryModuleCache.h
+++ b/clang/include/clang/Serialization/InMemoryModuleCache.h
@@ -19,13 +19,13 @@ namespace clang {
 /// In-memory cache for modules.
 ///
 /// This is a cache for modules for use across a compilation, sharing state
-/// between the CompilerInstances in an implicit modules build.  It must be
-/// shared by each CompilerInstance, ASTReader, ASTWriter, and ModuleManager
-/// that are coordinating.
+/// between the CompilerInstances in a modules build. It must be shared by each
+/// CompilerInstance, ASTReader, ASTWriter, and ModuleManager that are
+/// coordinating.
 ///
 /// Critically, it ensures that a single process has a consistent view of each
-/// PCM.  This is used by \a CompilerInstance when building PCMs to ensure that
-/// each \a ModuleManager sees the same files.
+/// implicitly-built PCM. This is used by \a CompilerInstance when building PCMs
+/// to ensure that each \a ModuleManager sees the same files.
 class InMemoryModuleCache : public llvm::RefCountedBase<InMemoryModuleCache> {
   struct PCM {
     /// The contents of the PCM as produced by \c ASTWriter.

--- a/clang/include/clang/Serialization/InMemoryModuleCache.h
+++ b/clang/include/clang/Serialization/InMemoryModuleCache.h
@@ -28,7 +28,15 @@ namespace clang {
 /// each \a ModuleManager sees the same files.
 class InMemoryModuleCache : public llvm::RefCountedBase<InMemoryModuleCache> {
   struct PCM {
+    /// The contents of the PCM as produced by \c ASTWriter.
     std::unique_ptr<llvm::MemoryBuffer> Buffer;
+
+    /// The size of this PCM. This may be different from the size of \c Buffer
+    /// when it's wrapped in an object file.
+    off_t Size = 0;
+
+    /// The modification time of this PCM.
+    time_t ModTime = 0;
 
     /// Track whether this PCM is known to be good (either built or
     /// successfully imported by a CompilerInstance/ASTReader using this
@@ -36,8 +44,8 @@ class InMemoryModuleCache : public llvm::RefCountedBase<InMemoryModuleCache> {
     bool IsFinal = false;
 
     PCM() = default;
-    PCM(std::unique_ptr<llvm::MemoryBuffer> Buffer)
-        : Buffer(std::move(Buffer)) {}
+    PCM(std::unique_ptr<llvm::MemoryBuffer> Buffer, off_t Size, time_t ModTime)
+        : Buffer(std::move(Buffer)), Size(Size), ModTime(ModTime) {}
   };
 
   /// Cache of buffers.
@@ -64,7 +72,8 @@ public:
   /// \post state is Tentative
   /// \return a reference to the buffer as a convenience.
   llvm::MemoryBuffer &addPCM(llvm::StringRef Filename,
-                             std::unique_ptr<llvm::MemoryBuffer> Buffer);
+                             std::unique_ptr<llvm::MemoryBuffer> Buffer,
+                             off_t Size, time_t ModTime);
 
   /// Store a just-built PCM under the Filename.
   ///
@@ -72,7 +81,8 @@ public:
   /// \pre state is not Tentative.
   /// \return a reference to the buffer as a convenience.
   llvm::MemoryBuffer &addBuiltPCM(llvm::StringRef Filename,
-                                  std::unique_ptr<llvm::MemoryBuffer> Buffer);
+                                  std::unique_ptr<llvm::MemoryBuffer> Buffer,
+                                  off_t Size, time_t ModTime);
 
   /// Try to remove a buffer from the cache.  No effect if state is Final.
   ///
@@ -87,8 +97,11 @@ public:
   /// \post state is Final.
   void finalizePCM(llvm::StringRef Filename);
 
-  /// Get a pointer to the pCM if it exists; else nullptr.
-  llvm::MemoryBuffer *lookupPCM(llvm::StringRef Filename) const;
+  /// Get a pointer to the PCM if it exists and set \c Size and \c ModTime to
+  /// its on-disk size and modification time. Otherwise, return nullptr and
+  /// don't change \c Size and \c ModTime.
+  llvm::MemoryBuffer *lookupPCM(llvm::StringRef Filename, off_t &Size,
+                                time_t &ModTime) const;
 
   /// Check whether the PCM is final and has been shown to work.
   ///

--- a/clang/include/clang/Serialization/ModuleCache.h
+++ b/clang/include/clang/Serialization/ModuleCache.h
@@ -54,8 +54,8 @@ public:
   virtual const InMemoryModuleCache &getInMemoryModuleCache() const = 0;
 
   /// Write the PCM contents to the given path in the module cache.
-  virtual std::error_code write(StringRef Path,
-                                llvm::MemoryBufferRef Buffer) = 0;
+  virtual std::error_code write(StringRef Path, llvm::MemoryBufferRef Buffer,
+                                off_t &Size, time_t &ModTime) = 0;
 
   virtual Expected<std::unique_ptr<llvm::MemoryBuffer>>
   read(StringRef FileName, off_t &Size, time_t &ModTime) = 0;
@@ -74,7 +74,8 @@ void maybePruneImpl(StringRef Path, time_t PruneInterval, time_t PruneAfter,
                     bool PruneTopLevel = false);
 
 /// Shared implementation of `ModuleCache::write()`.
-std::error_code writeImpl(StringRef Path, llvm::MemoryBufferRef Buffer);
+std::error_code writeImpl(StringRef Path, llvm::MemoryBufferRef Buffer,
+                          off_t &Size, time_t &ModTime);
 
 /// Shared implementation of `ModuleCache::read()`.
 Expected<std::unique_ptr<llvm::MemoryBuffer>>

--- a/clang/include/clang/Serialization/ModuleManager.h
+++ b/clang/include/clang/Serialization/ModuleManager.h
@@ -129,7 +129,8 @@ class ModuleManager {
   /// Preprocessor's HeaderSearchInfo containing the module map.
   const HeaderSearch &HeaderSearchInfo;
 
-  /// A lookup of in-memory (virtual file) buffers
+  /// A lookup of in-memory (virtual file) buffers.
+  // FIXME: No need to key this by `FileEntry`.
   llvm::DenseMap<const FileEntry *, std::unique_ptr<llvm::MemoryBuffer>>
       InMemoryBuffers;
 
@@ -245,7 +246,8 @@ public:
   ModuleFile *lookup(ModuleFileKey Key) const;
 
   /// Returns the in-memory (virtual file) buffer with the given name
-  std::unique_ptr<llvm::MemoryBuffer> lookupBuffer(StringRef Name);
+  std::unique_ptr<llvm::MemoryBuffer> lookupBuffer(StringRef Name, off_t &Size,
+                                                   time_t &ModTime);
 
   /// Number of modules loaded
   unsigned size() const { return Chain.size(); }

--- a/clang/lib/DependencyScanning/InProcessModuleCache.cpp
+++ b/clang/lib/DependencyScanning/InProcessModuleCache.cpp
@@ -132,13 +132,14 @@ public:
     return InMemory;
   }
 
-  std::error_code write(StringRef Path, llvm::MemoryBufferRef Buffer) override {
+  std::error_code write(StringRef Path, llvm::MemoryBufferRef Buffer,
+                        off_t &Size, time_t &ModTime) override {
     // This is a compiler-internal input/output, let's bypass the sandbox.
     auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
 
     // FIXME: This could use an in-memory cache to avoid IO, and only write to
     // disk at the end of the scan.
-    return writeImpl(Path, Buffer);
+    return writeImpl(Path, Buffer, Size, ModTime);
   }
 
   Expected<std::unique_ptr<llvm::MemoryBuffer>>

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1470,8 +1470,10 @@ static bool compileModuleImpl(CompilerInstance &ImportingInstance,
     }
   }
 
-  std::error_code EC =
-      ImportingInstance.getModuleCache().write(ModuleFileName, *Buffer);
+  off_t Size;
+  time_t ModTime;
+  std::error_code EC = ImportingInstance.getModuleCache().write(
+      ModuleFileName, *Buffer, Size, ModTime);
   if (EC) {
     ImportingInstance.getDiagnostics().Report(ModuleNameLoc,
                                               diag::err_module_not_written)
@@ -1498,7 +1500,7 @@ static bool compileModuleImpl(CompilerInstance &ImportingInstance,
   Buffer = llvm::MemoryBuffer::getMemBufferCopy(ExtractedBuffer);
 
   ImportingInstance.getModuleCache().getInMemoryModuleCache().addBuiltPCM(
-      ModuleFileName, std::move(Buffer));
+      ModuleFileName, std::move(Buffer), Size, ModTime);
 
   return true;
 }

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -5938,9 +5938,11 @@ bool ASTReader::readASTFileControlBlock(
     ASTReaderListener &Listener, bool ValidateDiagnosticOptions,
     unsigned ClientLoadCapabilities) {
   // Open the AST file.
+  off_t Size;
+  time_t ModTime;
   std::unique_ptr<llvm::MemoryBuffer> OwnedBuffer;
   llvm::MemoryBuffer *Buffer =
-      ModCache.getInMemoryModuleCache().lookupPCM(Filename);
+      ModCache.getInMemoryModuleCache().lookupPCM(Filename, Size, ModTime);
   if (!Buffer) {
     // FIXME: We should add the pcm to the InMemoryModuleCache if it could be
     // read again later, but we do not have the context here to determine if it

--- a/clang/lib/Serialization/InMemoryModuleCache.cpp
+++ b/clang/lib/Serialization/InMemoryModuleCache.cpp
@@ -23,28 +23,36 @@ InMemoryModuleCache::getPCMState(llvm::StringRef Filename) const {
 
 llvm::MemoryBuffer &
 InMemoryModuleCache::addPCM(llvm::StringRef Filename,
-                            std::unique_ptr<llvm::MemoryBuffer> Buffer) {
-  auto Insertion = PCMs.insert(std::make_pair(Filename, std::move(Buffer)));
+                            std::unique_ptr<llvm::MemoryBuffer> Buffer,
+                            off_t Size, time_t ModTime) {
+  auto Insertion = PCMs.insert(
+      std::make_pair(Filename, PCM(std::move(Buffer), Size, ModTime)));
   assert(Insertion.second && "Already has a PCM");
   return *Insertion.first->second.Buffer;
 }
 
 llvm::MemoryBuffer &
 InMemoryModuleCache::addBuiltPCM(llvm::StringRef Filename,
-                                 std::unique_ptr<llvm::MemoryBuffer> Buffer) {
+                                 std::unique_ptr<llvm::MemoryBuffer> Buffer,
+                                 off_t Size, time_t ModTime) {
   auto &PCM = PCMs[Filename];
   assert(!PCM.IsFinal && "Trying to override finalized PCM?");
   assert(!PCM.Buffer && "Trying to override tentative PCM?");
   PCM.Buffer = std::move(Buffer);
+  PCM.Size = Size;
+  PCM.ModTime = ModTime;
   PCM.IsFinal = true;
   return *PCM.Buffer;
 }
 
-llvm::MemoryBuffer *
-InMemoryModuleCache::lookupPCM(llvm::StringRef Filename) const {
+llvm::MemoryBuffer *InMemoryModuleCache::lookupPCM(llvm::StringRef Filename,
+                                                   off_t &Size,
+                                                   time_t &ModTime) const {
   auto I = PCMs.find(Filename);
   if (I == PCMs.end())
     return nullptr;
+  Size = I->second.Size;
+  ModTime = I->second.ModTime;
   return I->second.Buffer.get();
 }
 

--- a/clang/lib/Serialization/ModuleCache.cpp
+++ b/clang/lib/Serialization/ModuleCache.cpp
@@ -114,7 +114,8 @@ void clang::maybePruneImpl(StringRef Path, time_t PruneInterval,
   }
 }
 
-std::error_code clang::writeImpl(StringRef Path, llvm::MemoryBufferRef Buffer) {
+std::error_code clang::writeImpl(StringRef Path, llvm::MemoryBufferRef Buffer,
+                                 off_t &Size, time_t &ModTime) {
   StringRef Extension = llvm::sys::path::extension(Path);
   SmallString<128> ModelPath = StringRef(Path).drop_back(Extension.size());
   ModelPath += "-%%%%%%%%";
@@ -136,11 +137,19 @@ std::error_code clang::writeImpl(StringRef Path, llvm::MemoryBufferRef Buffer) {
       return EC;
   }
 
+  llvm::sys::fs::file_status Status;
   {
     llvm::raw_fd_ostream OS(FD, /*shouldClose=*/true);
     OS << Buffer.getBuffer();
+    // Using the status from an open file descriptor ensures this is not racy.
+    if ((EC = llvm::sys::fs::status(FD, Status)))
+      return EC;
   }
 
+  Size = Status.getSize();
+  ModTime = llvm::sys::toTimeT(Status.getLastModificationTime());
+
+  // This preserves both size and modification time.
   if ((EC = llvm::sys::fs::rename(TmpPath, Path)))
     return EC;
 
@@ -218,11 +227,12 @@ public:
     return InMemory;
   }
 
-  std::error_code write(StringRef Path, llvm::MemoryBufferRef Buffer) override {
+  std::error_code write(StringRef Path, llvm::MemoryBufferRef Buffer,
+                        off_t &Size, time_t &ModTime) override {
     // This is a compiler-internal input/output, let's bypass the sandbox.
     auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
 
-    return writeImpl(Path, Buffer);
+    return writeImpl(Path, Buffer, Size, ModTime);
   }
 
   Expected<std::unique_ptr<llvm::MemoryBuffer>>

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -59,12 +59,14 @@ ModuleFile *ModuleManager::lookup(ModuleFileKey Key) const {
 }
 
 std::unique_ptr<llvm::MemoryBuffer>
-ModuleManager::lookupBuffer(StringRef Name) {
+ModuleManager::lookupBuffer(StringRef Name, off_t &Size, time_t &ModTime) {
   auto Entry = FileMgr.getOptionalFileRef(Name, /*OpenFile=*/false,
                                           /*CacheFailure=*/false,
                                           /*IsText=*/false);
   if (!Entry)
     return nullptr;
+  Size = Entry->getSize();
+  ModTime = Entry->getModificationTime();
   return std::move(InMemoryBuffers[*Entry]);
 }
 
@@ -166,33 +168,15 @@ AddModuleResult ModuleManager::addModule(
   time_t ModTime = ExpectedModTime;
   llvm::MemoryBuffer *ModuleBuffer = nullptr;
   std::unique_ptr<llvm::MemoryBuffer> NewFileBuffer = nullptr;
-  if (std::unique_ptr<llvm::MemoryBuffer> Buffer = lookupBuffer(FileName)) {
+  if (std::unique_ptr<llvm::MemoryBuffer> Buffer =
+          lookupBuffer(FileName, Size, ModTime)) {
     // The buffer was already provided for us.
     ModuleBuffer = &getModuleCache().getInMemoryModuleCache().addBuiltPCM(
-        FileName, std::move(Buffer));
+        FileName, std::move(Buffer), Size, ModTime);
   } else if (llvm::MemoryBuffer *Buffer =
                  getModuleCache().getInMemoryModuleCache().lookupPCM(
-                     FileName)) {
+                     FileName, Size, ModTime)) {
     ModuleBuffer = Buffer;
-    if (!FileName.getImplicitModuleSuffixLength()) {
-      // Explicitly-built PCM files maintain consistency via mtime/size
-      // expectations on their imports. Even if we've previously successfully
-      // loaded a PCM file and stored it in the in-memory module cache, that
-      // does not mean its mtime/size matches current importer's expectations.
-      // Get that information so that it can be checked below.
-      // FIXME: Even though this FileManager access is likely already cached, we
-      // should store this directly in the in-memory module cache.
-      OptionalFileEntryRef Entry =
-          FileMgr.getOptionalFileRef(FileName, /*OpenFile=*/true,
-                                     /*CacheFailure=*/false,
-                                     /*IsText=*/false);
-      if (!Entry) {
-        Result.K = AddModuleResult::Missing;
-        return Result;
-      }
-      ModTime = Entry->getModificationTime();
-      Size = Entry->getSize();
-    }
   } else if (getModuleCache().getInMemoryModuleCache().shouldBuildPCM(
                  FileName)) {
     // Report that the module is out of date, since we tried (and failed) to
@@ -269,8 +253,8 @@ AddModuleResult ModuleManager::addModule(
   }
 
   if (NewFileBuffer)
-    getModuleCache().getInMemoryModuleCache().addPCM(FileName,
-                                                     std::move(NewFileBuffer));
+    getModuleCache().getInMemoryModuleCache().addPCM(
+        FileName, std::move(NewFileBuffer), Size, ModTime);
 
   // We're keeping this module. Store it in the map.
   Result.Module = Modules[*FileKey] = NewModule.get();

--- a/clang/unittests/Serialization/InMemoryModuleCacheTest.cpp
+++ b/clang/unittests/Serialization/InMemoryModuleCacheTest.cpp
@@ -39,15 +39,17 @@ TEST(InMemoryModuleCacheTest, addPCM) {
   auto *RawB = B.get();
 
   InMemoryModuleCache Cache;
-  EXPECT_EQ(RawB, &Cache.addPCM("B", std::move(B)));
+  EXPECT_EQ(RawB, &Cache.addPCM("B", std::move(B), 0, 0));
   EXPECT_EQ(InMemoryModuleCache::Tentative, Cache.getPCMState("B"));
-  EXPECT_EQ(RawB, Cache.lookupPCM("B"));
+  off_t Size;
+  time_t ModTime;
+  EXPECT_EQ(RawB, Cache.lookupPCM("B", Size, ModTime));
   EXPECT_FALSE(Cache.isPCMFinal("B"));
   EXPECT_FALSE(Cache.shouldBuildPCM("B"));
 
 #if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
-  EXPECT_DEATH(Cache.addPCM("B", getBuffer(2)), "Already has a PCM");
-  EXPECT_DEATH(Cache.addBuiltPCM("B", getBuffer(2)),
+  EXPECT_DEATH(Cache.addPCM("B", getBuffer(2), 0, 0), "Already has a PCM");
+  EXPECT_DEATH(Cache.addBuiltPCM("B", getBuffer(2), 0, 0),
                "Trying to override tentative PCM");
 #endif
 }
@@ -57,15 +59,17 @@ TEST(InMemoryModuleCacheTest, addBuiltPCM) {
   auto *RawB = B.get();
 
   InMemoryModuleCache Cache;
-  EXPECT_EQ(RawB, &Cache.addBuiltPCM("B", std::move(B)));
+  EXPECT_EQ(RawB, &Cache.addBuiltPCM("B", std::move(B), 0, 0));
   EXPECT_EQ(InMemoryModuleCache::Final, Cache.getPCMState("B"));
-  EXPECT_EQ(RawB, Cache.lookupPCM("B"));
+  off_t Size;
+  time_t ModTime;
+  EXPECT_EQ(RawB, Cache.lookupPCM("B", Size, ModTime));
   EXPECT_TRUE(Cache.isPCMFinal("B"));
   EXPECT_FALSE(Cache.shouldBuildPCM("B"));
 
 #if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
-  EXPECT_DEATH(Cache.addPCM("B", getBuffer(2)), "Already has a PCM");
-  EXPECT_DEATH(Cache.addBuiltPCM("B", getBuffer(2)),
+  EXPECT_DEATH(Cache.addPCM("B", getBuffer(2), 0, 0), "Already has a PCM");
+  EXPECT_DEATH(Cache.addBuiltPCM("B", getBuffer(2), 0, 0),
                "Trying to override finalized PCM");
 #endif
 }
@@ -79,27 +83,31 @@ TEST(InMemoryModuleCacheTest, tryToDropPCM) {
 
   InMemoryModuleCache Cache;
   EXPECT_EQ(InMemoryModuleCache::Unknown, Cache.getPCMState("B"));
-  EXPECT_EQ(RawB1, &Cache.addPCM("B", std::move(B1)));
+  EXPECT_EQ(RawB1, &Cache.addPCM("B", std::move(B1), 0, 0));
   EXPECT_FALSE(Cache.tryToDropPCM("B"));
-  EXPECT_EQ(nullptr, Cache.lookupPCM("B"));
+  off_t Size1;
+  time_t ModTime1;
+  EXPECT_EQ(nullptr, Cache.lookupPCM("B", Size1, ModTime1));
   EXPECT_EQ(InMemoryModuleCache::ToBuild, Cache.getPCMState("B"));
   EXPECT_FALSE(Cache.isPCMFinal("B"));
   EXPECT_TRUE(Cache.shouldBuildPCM("B"));
 
 #if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
-  EXPECT_DEATH(Cache.addPCM("B", getBuffer(2)), "Already has a PCM");
+  EXPECT_DEATH(Cache.addPCM("B", getBuffer(2), 0, 0), "Already has a PCM");
   EXPECT_DEATH(Cache.tryToDropPCM("B"),
                "PCM to remove is scheduled to be built");
   EXPECT_DEATH(Cache.finalizePCM("B"), "Trying to finalize a dropped PCM");
 #endif
 
   // Add a new one.
-  EXPECT_EQ(RawB2, &Cache.addBuiltPCM("B", std::move(B2)));
+  EXPECT_EQ(RawB2, &Cache.addBuiltPCM("B", std::move(B2), 0, 0));
   EXPECT_TRUE(Cache.isPCMFinal("B"));
 
   // Can try to drop again, but this should error and do nothing.
   EXPECT_TRUE(Cache.tryToDropPCM("B"));
-  EXPECT_EQ(RawB2, Cache.lookupPCM("B"));
+  off_t Size2;
+  time_t ModTime2;
+  EXPECT_EQ(RawB2, Cache.lookupPCM("B", Size2, ModTime2));
 }
 
 TEST(InMemoryModuleCacheTest, finalizePCM) {
@@ -108,7 +116,7 @@ TEST(InMemoryModuleCacheTest, finalizePCM) {
 
   InMemoryModuleCache Cache;
   EXPECT_EQ(InMemoryModuleCache::Unknown, Cache.getPCMState("B"));
-  EXPECT_EQ(RawB, &Cache.addPCM("B", std::move(B)));
+  EXPECT_EQ(RawB, &Cache.addPCM("B", std::move(B), 0, 0));
 
   // Call finalize.
   Cache.finalizePCM("B");


### PR DESCRIPTION
In this PR, the in-memory module cache now stores the size and modification time of PCM files. This is needed so that the `ModuleManager` doesn't need to consult the file system to obtain this information, which _might_ be in a different state than when we stored the PCM file buffer into the in-memory cache.