### PR TITLE
[NFC][LLVM] Rename several `ArgsTys` arguments to `OverloadTys`.

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -102,12 +102,12 @@ namespace Intrinsic {
   /// \p M. If it does not exist, add a declaration and return it. Otherwise,
   /// return the existing declaration.
   ///
-  /// The \p Tys parameter is for intrinsics with overloaded types (e.g., those
-  /// using iAny, fAny, vAny, or pAny).  For a declaration of an overloaded
-  /// intrinsic, Tys must provide exactly one type for each overloaded type in
-  /// the intrinsic.
+  /// The \p OverloadTys parameter is for intrinsics with overloaded types
+  // (e.g., those using iAny, fAny, vAny, or pAny).  For a declaration of an
+  // overloaded intrinsic, OverloadTys must provide exactly one type for each
+  // overloaded type in the intrinsic.
   LLVM_ABI Function *getOrInsertDeclaration(Module *M, ID id,
-                                            ArrayRef<Type *> Tys = {});
+                                            ArrayRef<Type *> OverloadTys = {});
 
   /// Look up the Function declaration of the intrinsic \p IID in the Module
   /// \p M. If it does not exist, add a declaration and return it. Otherwise,
@@ -131,7 +131,7 @@ namespace Intrinsic {
 
   /// This version supports overloaded intrinsics.
   LLVM_ABI Function *getDeclarationIfExists(Module *M, ID id,
-                                            ArrayRef<Type *> Tys,
+                                            ArrayRef<Type *> OverloadTys,
                                             FunctionType *FT = nullptr);
 
   /// Map a Clang builtin name to an intrinsic ID.
@@ -265,13 +265,13 @@ namespace Intrinsic {
 
   /// Match the specified function type with the type constraints specified by
   /// the .td file. If the given type is an overloaded type it is pushed to the
-  /// ArgTys vector.
+  /// OverloadTys vector.
   ///
   /// Returns false if the given type matches with the constraints, true
   /// otherwise.
   LLVM_ABI MatchIntrinsicTypesResult
   matchIntrinsicSignature(FunctionType *FTy, ArrayRef<IITDescriptor> &Infos,
-                          SmallVectorImpl<Type *> &ArgTys);
+                          SmallVectorImpl<Type *> &OverloadTys);
 
   /// Verify if the intrinsic has variable arguments. This method is intended to
   /// be called after all the fixed arguments have been matched first.
@@ -282,16 +282,16 @@ namespace Intrinsic {
 
   /// Gets the type arguments of an intrinsic call by matching type contraints
   /// specified by the .td file. The overloaded types are pushed into the
-  /// AgTys vector.
+  /// OverloadTys vector.
   ///
   /// Returns false if the given ID and function type combination is not a
   /// valid intrinsic call.
   LLVM_ABI bool getIntrinsicSignature(Intrinsic::ID, FunctionType *FT,
-                                      SmallVectorImpl<Type *> &ArgTys);
+                                      SmallVectorImpl<Type *> &OverloadTys);
 
   /// Same as previous, but accepts a Function instead of ID and FunctionType.
   LLVM_ABI bool getIntrinsicSignature(Function *F,
-                                      SmallVectorImpl<Type *> &ArgTys);
+                                      SmallVectorImpl<Type *> &OverloadTys);
 
   // Checks if the intrinsic name matches with its signature and if not
   // returns the declaration with the same signature and remangled name.

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -472,8 +472,7 @@ class LLVMPartiallyDependentType<int oidx, IIT_Base IIT_Info>
 
 // Match the type of another intrinsic parameter. `oidx` is the overload index
 // of the overloaded type that this type is dependent on. Overload types are
-// either LLVMAnyType or LLVMPartiallyDependentType. The `oidx` value must refer
-// to a previously listed type. For example:
+// either LLVMAnyType or LLVMPartiallyDependentType.
 //
 //   Intrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_anyfloat_ty, LLVMMatchType<0>]>
 //

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -846,7 +846,7 @@ using DeferredIntrinsicMatchPair =
 
 static bool
 matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
-                   SmallVectorImpl<Type *> &ArgTys,
+                   SmallVectorImpl<Type *> &OverloadTys,
                    SmallVectorImpl<DeferredIntrinsicMatchPair> &DeferredChecks,
                    bool IsDeferredCheck) {
   using namespace Intrinsic;
@@ -901,7 +901,7 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
   case IITDescriptor::Vector: {
     VectorType *VT = dyn_cast<VectorType>(Ty);
     return !VT || VT->getElementCount() != D.VectorWidth ||
-           matchIntrinsicType(VT->getElementType(), Infos, ArgTys,
+           matchIntrinsicType(VT->getElementType(), Infos, OverloadTys,
                               DeferredChecks, IsDeferredCheck);
   }
   case IITDescriptor::Pointer: {
@@ -916,7 +916,7 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
       return true;
 
     for (unsigned i = 0, e = D.StructNumElements; i != e; ++i)
-      if (matchIntrinsicType(ST->getElementType(i), Infos, ArgTys,
+      if (matchIntrinsicType(ST->getElementType(i), Infos, OverloadTys,
                              DeferredChecks, IsDeferredCheck))
         return true;
     return false;
@@ -925,16 +925,16 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
   case IITDescriptor::Overloaded:
     // If this is the second occurrence of an argument,
     // verify that the later instance matches the previous instance.
-    if (D.getOverloadIndex() < ArgTys.size())
-      return Ty != ArgTys[D.getOverloadIndex()];
+    if (D.getOverloadIndex() < OverloadTys.size())
+      return Ty != OverloadTys[D.getOverloadIndex()];
 
-    if (D.getOverloadIndex() > ArgTys.size() ||
+    if (D.getOverloadIndex() > OverloadTys.size() ||
         D.getOverloadKind() == IITDescriptor::AK_MatchType)
       return IsDeferredCheck || DeferCheck(Ty);
 
-    assert(D.getOverloadIndex() == ArgTys.size() && !IsDeferredCheck &&
+    assert(D.getOverloadIndex() == OverloadTys.size() && !IsDeferredCheck &&
            "Table consistency error");
-    ArgTys.push_back(Ty);
+    OverloadTys.push_back(Ty);
 
     switch (D.getOverloadKind()) {
     case IITDescriptor::AK_Any:
@@ -954,10 +954,10 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
 
   case IITDescriptor::Extend: {
     // If this is a forward reference, defer the check for later.
-    if (D.getOverloadIndex() >= ArgTys.size())
+    if (D.getOverloadIndex() >= OverloadTys.size())
       return IsDeferredCheck || DeferCheck(Ty);
 
-    Type *NewTy = ArgTys[D.getOverloadIndex()];
+    Type *NewTy = OverloadTys[D.getOverloadIndex()];
     if (VectorType *VTy = dyn_cast<VectorType>(NewTy))
       NewTy = VectorType::getExtendedElementVectorType(VTy);
     else if (IntegerType *ITy = dyn_cast<IntegerType>(NewTy))
@@ -969,10 +969,10 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
   }
   case IITDescriptor::Trunc: {
     // If this is a forward reference, defer the check for later.
-    if (D.getOverloadIndex() >= ArgTys.size())
+    if (D.getOverloadIndex() >= OverloadTys.size())
       return IsDeferredCheck || DeferCheck(Ty);
 
-    Type *NewTy = ArgTys[D.getOverloadIndex()];
+    Type *NewTy = OverloadTys[D.getOverloadIndex()];
     if (VectorType *VTy = dyn_cast<VectorType>(NewTy))
       NewTy = VectorType::getTruncatedElementVectorType(VTy);
     else if (IntegerType *ITy = dyn_cast<IntegerType>(NewTy))
@@ -984,9 +984,9 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
   }
   case IITDescriptor::OneNthEltsVec: {
     // If this is a forward reference, defer the check for later.
-    if (D.getOverloadIndex() >= ArgTys.size())
+    if (D.getOverloadIndex() >= OverloadTys.size())
       return IsDeferredCheck || DeferCheck(Ty);
-    auto *VTy = dyn_cast<VectorType>(ArgTys[D.getOverloadIndex()]);
+    auto *VTy = dyn_cast<VectorType>(OverloadTys[D.getOverloadIndex()]);
     if (!VTy)
       return true;
     if (!VTy->getElementCount().isKnownMultipleOf(D.getVectorDivisor()))
@@ -995,12 +995,13 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
            Ty;
   }
   case IITDescriptor::SameVecWidth: {
-    if (D.getOverloadIndex() >= ArgTys.size()) {
+    if (D.getOverloadIndex() >= OverloadTys.size()) {
       // Defer check and subsequent check for the vector element type.
       Infos = Infos.slice(1);
       return IsDeferredCheck || DeferCheck(Ty);
     }
-    auto *ReferenceType = dyn_cast<VectorType>(ArgTys[D.getOverloadIndex()]);
+    auto *ReferenceType =
+        dyn_cast<VectorType>(OverloadTys[D.getOverloadIndex()]);
     auto *ThisArgType = dyn_cast<VectorType>(Ty);
     // Both must be vectors of the same number of elements or neither.
     if ((ReferenceType != nullptr) != (ThisArgType != nullptr))
@@ -1011,30 +1012,30 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
         return true;
       EltTy = ThisArgType->getElementType();
     }
-    return matchIntrinsicType(EltTy, Infos, ArgTys, DeferredChecks,
+    return matchIntrinsicType(EltTy, Infos, OverloadTys, DeferredChecks,
                               IsDeferredCheck);
   }
   case IITDescriptor::VecOfAnyPtrsToElt: {
     unsigned RefOverloadIndex = D.getRefOverloadIndex();
-    if (RefOverloadIndex >= ArgTys.size()) {
+    if (RefOverloadIndex >= OverloadTys.size()) {
       if (IsDeferredCheck)
         return true;
       // If forward referencing, already add the pointer-vector type and
       // defer the checks for later.
-      ArgTys.push_back(Ty);
+      OverloadTys.push_back(Ty);
       return DeferCheck(Ty);
     }
 
     if (!IsDeferredCheck) {
-      assert(D.getOverloadIndex() == ArgTys.size() &&
+      assert(D.getOverloadIndex() == OverloadTys.size() &&
              "Table consistency error");
-      ArgTys.push_back(Ty);
+      OverloadTys.push_back(Ty);
     }
 
     // Verify the overloaded type "matches" the Ref type.
     // i.e. Ty is a vector with the same width as Ref.
     // Composed of pointers to the same element type as Ref.
-    auto *ReferenceType = dyn_cast<VectorType>(ArgTys[RefOverloadIndex]);
+    auto *ReferenceType = dyn_cast<VectorType>(OverloadTys[RefOverloadIndex]);
     auto *ThisArgVecTy = dyn_cast<VectorType>(Ty);
     if (!ThisArgVecTy || !ReferenceType ||
         (ReferenceType->getElementCount() != ThisArgVecTy->getElementCount()))
@@ -1042,18 +1043,19 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     return !ThisArgVecTy->getElementType()->isPointerTy();
   }
   case IITDescriptor::VecElement: {
-    if (D.getOverloadIndex() >= ArgTys.size())
+    if (D.getOverloadIndex() >= OverloadTys.size())
       return IsDeferredCheck ? true : DeferCheck(Ty);
-    auto *ReferenceType = dyn_cast<VectorType>(ArgTys[D.getOverloadIndex()]);
+    auto *ReferenceType =
+        dyn_cast<VectorType>(OverloadTys[D.getOverloadIndex()]);
     return !ReferenceType || Ty != ReferenceType->getElementType();
   }
   case IITDescriptor::Subdivide2:
   case IITDescriptor::Subdivide4: {
     // If this is a forward reference, defer the check for later.
-    if (D.getOverloadIndex() >= ArgTys.size())
+    if (D.getOverloadIndex() >= OverloadTys.size())
       return IsDeferredCheck || DeferCheck(Ty);
 
-    Type *NewTy = ArgTys[D.getOverloadIndex()];
+    Type *NewTy = OverloadTys[D.getOverloadIndex()];
     if (auto *VTy = dyn_cast<VectorType>(NewTy)) {
       int SubDivs = D.Kind == IITDescriptor::Subdivide2 ? 1 : 2;
       NewTy = VectorType::getSubdividedVectorType(VTy, SubDivs);
@@ -1062,9 +1064,10 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     return true;
   }
   case IITDescriptor::VecOfBitcastsToInt: {
-    if (D.getOverloadIndex() >= ArgTys.size())
+    if (D.getOverloadIndex() >= OverloadTys.size())
       return IsDeferredCheck || DeferCheck(Ty);
-    auto *ReferenceType = dyn_cast<VectorType>(ArgTys[D.getOverloadIndex()]);
+    auto *ReferenceType =
+        dyn_cast<VectorType>(OverloadTys[D.getOverloadIndex()]);
     auto *ThisArgVecTy = dyn_cast<VectorType>(Ty);
     if (!ThisArgVecTy || !ReferenceType)
       return true;
@@ -1077,22 +1080,22 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
 Intrinsic::MatchIntrinsicTypesResult
 Intrinsic::matchIntrinsicSignature(FunctionType *FTy,
                                    ArrayRef<Intrinsic::IITDescriptor> &Infos,
-                                   SmallVectorImpl<Type *> &ArgTys) {
+                                   SmallVectorImpl<Type *> &OverloadTys) {
   SmallVector<DeferredIntrinsicMatchPair, 2> DeferredChecks;
-  if (matchIntrinsicType(FTy->getReturnType(), Infos, ArgTys, DeferredChecks,
-                         false))
+  if (matchIntrinsicType(FTy->getReturnType(), Infos, OverloadTys,
+                         DeferredChecks, false))
     return MatchIntrinsicTypes_NoMatchRet;
 
   unsigned NumDeferredReturnChecks = DeferredChecks.size();
 
   for (auto *Ty : FTy->params())
-    if (matchIntrinsicType(Ty, Infos, ArgTys, DeferredChecks, false))
+    if (matchIntrinsicType(Ty, Infos, OverloadTys, DeferredChecks, false))
       return MatchIntrinsicTypes_NoMatchArg;
 
   for (unsigned I = 0, E = DeferredChecks.size(); I != E; ++I) {
     DeferredIntrinsicMatchPair &Check = DeferredChecks[I];
-    if (matchIntrinsicType(Check.first, Check.second, ArgTys, DeferredChecks,
-                           true))
+    if (matchIntrinsicType(Check.first, Check.second, OverloadTys,
+                           DeferredChecks, true))
       return I < NumDeferredReturnChecks ? MatchIntrinsicTypes_NoMatchRet
                                          : MatchIntrinsicTypes_NoMatchArg;
   }
@@ -1120,7 +1123,7 @@ bool Intrinsic::matchIntrinsicVarArg(
 }
 
 bool Intrinsic::getIntrinsicSignature(Intrinsic::ID ID, FunctionType *FT,
-                                      SmallVectorImpl<Type *> &ArgTys) {
+                                      SmallVectorImpl<Type *> &OverloadTys) {
   if (!ID)
     return false;
 
@@ -1128,7 +1131,7 @@ bool Intrinsic::getIntrinsicSignature(Intrinsic::ID ID, FunctionType *FT,
   getIntrinsicInfoTableEntries(ID, Table);
   ArrayRef<Intrinsic::IITDescriptor> TableRef = Table;
 
-  if (Intrinsic::matchIntrinsicSignature(FT, TableRef, ArgTys) !=
+  if (Intrinsic::matchIntrinsicSignature(FT, TableRef, OverloadTys) !=
       Intrinsic::MatchIntrinsicTypesResult::MatchIntrinsicTypes_Match) {
     return false;
   }
@@ -1138,20 +1141,20 @@ bool Intrinsic::getIntrinsicSignature(Intrinsic::ID ID, FunctionType *FT,
 }
 
 bool Intrinsic::getIntrinsicSignature(Function *F,
-                                      SmallVectorImpl<Type *> &ArgTys) {
+                                      SmallVectorImpl<Type *> &OverloadTys) {
   return getIntrinsicSignature(F->getIntrinsicID(), F->getFunctionType(),
-                               ArgTys);
+                               OverloadTys);
 }
 
 std::optional<Function *> Intrinsic::remangleIntrinsicFunction(Function *F) {
-  SmallVector<Type *, 4> ArgTys;
-  if (!getIntrinsicSignature(F, ArgTys))
+  SmallVector<Type *, 4> OverloadTys;
+  if (!getIntrinsicSignature(F, OverloadTys))
     return std::nullopt;
 
   Intrinsic::ID ID = F->getIntrinsicID();
   StringRef Name = F->getName();
   std::string WantedName =
-      Intrinsic::getName(ID, ArgTys, F->getParent(), F->getFunctionType());
+      Intrinsic::getName(ID, OverloadTys, F->getParent(), F->getFunctionType());
   if (Name == WantedName)
     return std::nullopt;
 
@@ -1167,7 +1170,7 @@ std::optional<Function *> Intrinsic::remangleIntrinsicFunction(Function *F) {
       // invalid and we'll get an error.
       ExistingGV->setName(WantedName + ".renamed");
     }
-    return Intrinsic::getOrInsertDeclaration(F->getParent(), ID, ArgTys);
+    return Intrinsic::getOrInsertDeclaration(F->getParent(), ID, OverloadTys);
   }();
 
   NewDecl->setCallingConv(F->getCallingConv());


### PR DESCRIPTION
Rename several arguments to intrinsic related functions from `ArgsTys` to `OverloadTys` to better reflect their meaning. The only variables left with name `ArgTys` now actually mean function argument types.

Also reamove an incorrect comment in Intrinsics.td. Dependent types do allow forward references starting with https://github.com/llvm/llvm-project/commit/7957fc6547e1b8af8e6586e2c25446b724eabb75