### PR TITLE
[clang][Driver] Add CLANG_DEFAULT_FRTLIB_ADD_RPATH for HIP/SYCL offload runtime rpath

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -280,6 +280,10 @@ set(CLANG_SPAWN_CC1 OFF CACHE BOOL
 
 option(CLANG_DEFAULT_PIE_ON_LINUX "Default to -fPIE and -pie on linux-gnu" ON)
 
+option(CLANG_DEFAULT_FRTLIB_ADD_RPATH
+  "Default -frtlib-add-rpath for HIP/SYCL offload runtimes (e.g. split-prefix ROCm). Use -fno-rtlib-add-rpath to disable."
+  OFF)
+
 set(CLANG_DEFAULT_LINKER "" CACHE STRING
   "Default linker to use (linker name or absolute path, empty for platform default)")
 

--- a/clang/include/clang/Config/config.h.cmake
+++ b/clang/include/clang/Config/config.h.cmake
@@ -11,6 +11,9 @@
 /* Default to -fPIE and -pie on Linux. */
 #cmakedefine01 CLANG_DEFAULT_PIE_ON_LINUX
 
+/* Default -frtlib-add-rpath for HIP/SYCL offload libs in Linux::addOffloadRTLibs only. */
+#cmakedefine01 CLANG_DEFAULT_FRTLIB_ADD_RPATH
+
 /* Default linker to use. */
 #define CLANG_DEFAULT_LINKER "${CLANG_DEFAULT_LINKER}"
 

--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -870,7 +870,8 @@ void Linux::addOffloadRTLibs(unsigned ActiveKinds, const ArgList &Args,
 
   for (auto [Path, Library] : Libraries) {
     if (Args.hasFlag(options::OPT_frtlib_add_rpath,
-                     options::OPT_fno_rtlib_add_rpath, false)) {
+                     options::OPT_fno_rtlib_add_rpath,
+                     (bool)CLANG_DEFAULT_FRTLIB_ADD_RPATH)) {
       SmallString<0> p = Path;
       llvm::sys::path::remove_dots(p, true);
       CmdArgs.append({"-rpath", Args.MakeArgString(p)});


### PR DESCRIPTION
Clang only adds -rpath for the HIP/SYCL offload runtimes (libamdhip64, libsycl) when `-frtlib-add-rpath` is passed. The default is off, so binaries built against a non-unified ROCm layout (e.g. Spack, separate install prefixes) often link fine but fail at run time with `libamdhip64.so.7 => not found`.

This adds a CMake option `CLANG_DEFAULT_FRTLIB_ADD_RPATH` (default OFF) that makes that behavior the default for `Linux::addOffloadRTLibs` only. Users can still disable with `-fno-rtlib-add-rpath`.