### PR TITLE
Allow DIBasicType (and others) to have a scope and location

### DIFF
--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -219,41 +219,74 @@ namespace llvm {
                     uint32_t NumExtraInhabitants = 0,
                     uint32_t DataSizeInBits = 0);
 
+    /// Create debugging information entry for a basic
+    /// type.
+    /// \param Name        Type name.
+    /// \param File        File where this type is defined.
+    /// \param LineNo      Line number.
+    /// \param Context     The surrounding context for the typedef.
+    /// \param SizeInBits  Size of the type.
+    /// \param Encoding    DWARF encoding code, e.g., dwarf::DW_ATE_float.
+    /// \param Flags       Optional DWARF attributes, e.g., DW_AT_endianity.
+    /// \param NumExtraInhabitants The number of extra inhabitants of the type.
+    /// An extra inhabitant is a bit pattern that does not represent a valid
+    /// value for instances of a given type. This is used by the Swift language.
+    /// \param DataSizeInBits Optionally describes the number of bits used by
+    /// the value of the object when this is less than the storage size of
+    /// SizeInBits. Default value of zero indicates the object value and storage
+    /// sizes are equal.
+    LLVM_ABI DIBasicType *
+    createBasicType(StringRef Name, DIFile *File, unsigned LineNo,
+                    DIScope *Context, uint64_t SizeInBits, unsigned Encoding,
+                    DINode::DIFlags Flags = DINode::FlagZero,
+                    uint32_t NumExtraInhabitants = 0,
+                    uint32_t DataSizeInBits = 0);
+
     /// Create debugging information entry for a binary fixed-point type.
     /// \param Name        Type name.
+    /// \param File        File where this type is defined.
+    /// \param LineNo      Line number.
+    /// \param Context     The surrounding context for the typedef.
     /// \param Encoding    DWARF encoding code, either
     ///                    dwarf::DW_ATE_signed_fixed or DW_ATE_unsigned_fixed.
     /// \param Flags       Optional DWARF attributes, e.g., DW_AT_endianity.
     /// \param Factor      Binary scale factor.
     LLVM_ABI DIFixedPointType *
-    createBinaryFixedPointType(StringRef Name, uint64_t SizeInBits,
+    createBinaryFixedPointType(StringRef Name, DIFile *File, unsigned LineNo,
+                               DIScope *Context, uint64_t SizeInBits,
                                uint32_t AlignInBits, unsigned Encoding,
                                DINode::DIFlags Flags, int Factor);
 
     /// Create debugging information entry for a decimal fixed-point type.
     /// \param Name        Type name.
+    /// \param File        File where this type is defined.
+    /// \param LineNo      Line number.
+    /// \param Context     The surrounding context for the typedef.
     /// \param Encoding    DWARF encoding code, either
     ///                    dwarf::DW_ATE_signed_fixed or DW_ATE_unsigned_fixed.
     /// \param Flags       Optional DWARF attributes, e.g., DW_AT_endianity.
     /// \param Factor      Decimal scale factor.
     LLVM_ABI DIFixedPointType *
-    createDecimalFixedPointType(StringRef Name, uint64_t SizeInBits,
+    createDecimalFixedPointType(StringRef Name, DIFile *File, unsigned LineNo,
+                                DIScope *Context, uint64_t SizeInBits,
                                 uint32_t AlignInBits, unsigned Encoding,
                                 DINode::DIFlags Flags, int Factor);
 
     /// Create debugging information entry for an arbitrary rational
     /// fixed-point type.
     /// \param Name        Type name.
+    /// \param File        File where this type is defined.
+    /// \param LineNo      Line number.
+    /// \param Context     The surrounding context for the typedef.
     /// \param Encoding    DWARF encoding code, either
     ///                    dwarf::DW_ATE_signed_fixed or DW_ATE_unsigned_fixed.
     /// \param Flags       Optional DWARF attributes, e.g., DW_AT_endianity.
     /// \param Numerator   Numerator of scale factor.
     /// \param Denominator Denominator of scale factor.
-    LLVM_ABI DIFixedPointType *
-    createRationalFixedPointType(StringRef Name, uint64_t SizeInBits,
-                                 uint32_t AlignInBits, unsigned Encoding,
-                                 DINode::DIFlags Flags, APInt Numerator,
-                                 APInt Denominator);
+    LLVM_ABI DIFixedPointType *createRationalFixedPointType(
+        StringRef Name, DIFile *File, unsigned LineNo, DIScope *Context,
+        uint64_t SizeInBits, uint32_t AlignInBits, unsigned Encoding,
+        DINode::DIFlags Flags, APInt Numerator, APInt Denominator);
 
     /// Create debugging information entry for a string
     /// type.

--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -843,100 +843,124 @@ class DIBasicType : public DIType {
 
 protected:
   DIBasicType(LLVMContext &C, StorageType Storage, unsigned Tag,
-              uint32_t AlignInBits, unsigned Encoding,
+              unsigned LineNo, uint32_t AlignInBits, unsigned Encoding,
               uint32_t NumExtraInhabitants, uint32_t DataSizeInBits,
               DIFlags Flags, ArrayRef<Metadata *> Ops)
-      : DIType(C, DIBasicTypeKind, Storage, Tag, 0, AlignInBits,
+      : DIType(C, DIBasicTypeKind, Storage, Tag, LineNo, AlignInBits,
                NumExtraInhabitants, Flags, Ops),
         Encoding(Encoding), DataSizeInBits(DataSizeInBits) {}
   DIBasicType(LLVMContext &C, unsigned ID, StorageType Storage, unsigned Tag,
-              uint32_t AlignInBits, unsigned Encoding,
+              unsigned LineNo, uint32_t AlignInBits, unsigned Encoding,
               uint32_t NumExtraInhabitants, uint32_t DataSizeInBits,
               DIFlags Flags, ArrayRef<Metadata *> Ops)
-      : DIType(C, ID, Storage, Tag, 0, AlignInBits, NumExtraInhabitants, Flags,
-               Ops),
+      : DIType(C, ID, Storage, Tag, LineNo, AlignInBits, NumExtraInhabitants,
+               Flags, Ops),
         Encoding(Encoding), DataSizeInBits(DataSizeInBits) {}
   ~DIBasicType() = default;
 
   static DIBasicType *getImpl(LLVMContext &Context, unsigned Tag,
-                              StringRef Name, uint64_t SizeInBits,
+                              StringRef Name, DIFile *File, unsigned LineNo,
+                              DIScope *Scope, uint64_t SizeInBits,
                               uint32_t AlignInBits, unsigned Encoding,
                               uint32_t NumExtraInhabitants,
                               uint32_t DataSizeInBits, DIFlags Flags,
                               StorageType Storage, bool ShouldCreate = true) {
-    return getImpl(Context, Tag, getCanonicalMDString(Context, Name),
-                   SizeInBits, AlignInBits, Encoding, NumExtraInhabitants,
-                   DataSizeInBits, Flags, Storage, ShouldCreate);
+    return getImpl(Context, Tag, getCanonicalMDString(Context, Name), File,
+                   LineNo, Scope, SizeInBits, AlignInBits, Encoding,
+                   NumExtraInhabitants, DataSizeInBits, Flags, Storage,
+                   ShouldCreate);
   }
   static DIBasicType *getImpl(LLVMContext &Context, unsigned Tag,
-                              MDString *Name, uint64_t SizeInBits,
+                              MDString *Name, DIFile *File, unsigned LineNo,
+                              DIScope *Scope, uint64_t SizeInBits,
                               uint32_t AlignInBits, unsigned Encoding,
                               uint32_t NumExtraInhabitants,
                               uint32_t DataSizeInBits, DIFlags Flags,
                               StorageType Storage, bool ShouldCreate = true) {
     auto *SizeInBitsNode = ConstantAsMetadata::get(
         ConstantInt::get(Type::getInt64Ty(Context), SizeInBits));
-    return getImpl(Context, Tag, Name, SizeInBitsNode, AlignInBits, Encoding,
-                   NumExtraInhabitants, DataSizeInBits, Flags, Storage,
-                   ShouldCreate);
+    return getImpl(Context, Tag, Name, File, LineNo, Scope, SizeInBitsNode,
+                   AlignInBits, Encoding, NumExtraInhabitants, DataSizeInBits,
+                   Flags, Storage, ShouldCreate);
   }
   LLVM_ABI static DIBasicType *
-  getImpl(LLVMContext &Context, unsigned Tag, MDString *Name,
-          Metadata *SizeInBits, uint32_t AlignInBits, unsigned Encoding,
-          uint32_t NumExtraInhabitants, uint32_t DataSizeInBits, DIFlags Flags,
-          StorageType Storage, bool ShouldCreate = true);
+  getImpl(LLVMContext &Context, unsigned Tag, MDString *Name, Metadata *File,
+          unsigned LineNo, Metadata *Scope, Metadata *SizeInBits,
+          uint32_t AlignInBits, unsigned Encoding, uint32_t NumExtraInhabitants,
+          uint32_t DataSizeInBits, DIFlags Flags, StorageType Storage,
+          bool ShouldCreate = true);
 
   TempDIBasicType cloneImpl() const {
-    return getTemporary(getContext(), getTag(), getRawName(),
-                        getRawSizeInBits(), getAlignInBits(), getEncoding(),
-                        getNumExtraInhabitants(), getDataSizeInBits(),
-                        getFlags());
+    return getTemporary(
+        getContext(), getTag(), getRawName(), getFile(), getLine(), getScope(),
+        getRawSizeInBits(), getAlignInBits(), getEncoding(),
+        getNumExtraInhabitants(), getDataSizeInBits(), getFlags());
   }
 
 public:
   DEFINE_MDNODE_GET(DIBasicType, (unsigned Tag, StringRef Name),
-                    (Tag, Name, 0, 0, 0, 0, 0, FlagZero))
+                    (Tag, Name, nullptr, 0, nullptr, 0, 0, 0, 0, 0, FlagZero))
   DEFINE_MDNODE_GET(DIBasicType,
                     (unsigned Tag, StringRef Name, uint64_t SizeInBits),
-                    (Tag, Name, SizeInBits, 0, 0, 0, 0, FlagZero))
+                    (Tag, Name, nullptr, 0, nullptr, SizeInBits, 0, 0, 0, 0,
+                     FlagZero))
   DEFINE_MDNODE_GET(DIBasicType,
                     (unsigned Tag, MDString *Name, uint64_t SizeInBits),
-                    (Tag, Name, SizeInBits, 0, 0, 0, 0, FlagZero))
+                    (Tag, Name, nullptr, 0, nullptr, SizeInBits, 0, 0, 0, 0,
+                     FlagZero))
   DEFINE_MDNODE_GET(DIBasicType,
                     (unsigned Tag, StringRef Name, uint64_t SizeInBits,
                      uint32_t AlignInBits, unsigned Encoding, DIFlags Flags),
-                    (Tag, Name, SizeInBits, AlignInBits, Encoding, 0, 0, Flags))
+                    (Tag, Name, nullptr, 0, nullptr, SizeInBits, AlignInBits,
+                     Encoding, 0, 0, Flags))
   DEFINE_MDNODE_GET(DIBasicType,
                     (unsigned Tag, MDString *Name, uint64_t SizeInBits,
                      uint32_t AlignInBits, unsigned Encoding, DIFlags Flags),
-                    (Tag, Name, SizeInBits, AlignInBits, Encoding, 0, 0, Flags))
+                    (Tag, Name, nullptr, 0, nullptr, SizeInBits, AlignInBits,
+                     Encoding, 0, 0, Flags))
   DEFINE_MDNODE_GET(DIBasicType,
                     (unsigned Tag, StringRef Name, uint64_t SizeInBits,
                      uint32_t AlignInBits, unsigned Encoding,
                      uint32_t NumExtraInhabitants, DIFlags Flags),
-                    (Tag, Name, SizeInBits, AlignInBits, Encoding,
-                     NumExtraInhabitants, 0, Flags))
+                    (Tag, Name, nullptr, 0, nullptr, SizeInBits, AlignInBits,
+                     Encoding, NumExtraInhabitants, 0, Flags))
   DEFINE_MDNODE_GET(DIBasicType,
                     (unsigned Tag, StringRef Name, uint64_t SizeInBits,
                      uint32_t AlignInBits, unsigned Encoding,
                      uint32_t NumExtraInhabitants, uint32_t DataSizeInBits,
                      DIFlags Flags),
-                    (Tag, Name, SizeInBits, AlignInBits, Encoding,
-                     NumExtraInhabitants, DataSizeInBits, Flags))
+                    (Tag, Name, nullptr, 0, nullptr, SizeInBits, AlignInBits,
+                     Encoding, NumExtraInhabitants, DataSizeInBits, Flags))
+  DEFINE_MDNODE_GET(DIBasicType,
+                    (unsigned Tag, StringRef Name, DIFile *File,
+                     unsigned LineNo, DIScope *Scope, uint64_t SizeInBits,
+                     uint32_t AlignInBits, unsigned Encoding,
+                     uint32_t NumExtraInhabitants, uint32_t DataSizeInBits,
+                     DIFlags Flags),
+                    (Tag, Name, File, LineNo, Scope, SizeInBits, AlignInBits,
+                     Encoding, NumExtraInhabitants, DataSizeInBits, Flags))
   DEFINE_MDNODE_GET(DIBasicType,
                     (unsigned Tag, MDString *Name, uint64_t SizeInBits,
                      uint32_t AlignInBits, unsigned Encoding,
                      uint32_t NumExtraInhabitants, uint32_t DataSizeInBits,
                      DIFlags Flags),
-                    (Tag, Name, SizeInBits, AlignInBits, Encoding,
-                     NumExtraInhabitants, DataSizeInBits, Flags))
+                    (Tag, Name, nullptr, 0, nullptr, SizeInBits, AlignInBits,
+                     Encoding, NumExtraInhabitants, DataSizeInBits, Flags))
   DEFINE_MDNODE_GET(DIBasicType,
                     (unsigned Tag, MDString *Name, Metadata *SizeInBits,
                      uint32_t AlignInBits, unsigned Encoding,
                      uint32_t NumExtraInhabitants, uint32_t DataSizeInBits,
                      DIFlags Flags),
-                    (Tag, Name, SizeInBits, AlignInBits, Encoding,
-                     NumExtraInhabitants, DataSizeInBits, Flags))
+                    (Tag, Name, nullptr, 0, nullptr, SizeInBits, AlignInBits,
+                     Encoding, NumExtraInhabitants, DataSizeInBits, Flags))
+  DEFINE_MDNODE_GET(DIBasicType,
+                    (unsigned Tag, MDString *Name, Metadata *File,
+                     unsigned LineNo, Metadata *Scope, Metadata *SizeInBits,
+                     uint32_t AlignInBits, unsigned Encoding,
+                     uint32_t NumExtraInhabitants, uint32_t DataSizeInBits,
+                     DIFlags Flags),
+                    (Tag, Name, File, LineNo, Scope, SizeInBits, AlignInBits,
+                     Encoding, NumExtraInhabitants, DataSizeInBits, Flags))
 
   TempDIBasicType clone() const { return cloneImpl(); }
 
@@ -970,73 +994,79 @@ class DIFixedPointType : public DIBasicType {
   APInt Denominator;
 
   DIFixedPointType(LLVMContext &C, StorageType Storage, unsigned Tag,
-                   uint32_t AlignInBits, unsigned Encoding, DIFlags Flags,
-                   unsigned Kind, int Factor, ArrayRef<Metadata *> Ops)
-      : DIBasicType(C, DIFixedPointTypeKind, Storage, Tag, AlignInBits,
+                   unsigned LineNo, uint32_t AlignInBits, unsigned Encoding,
+                   DIFlags Flags, unsigned Kind, int Factor,
+                   ArrayRef<Metadata *> Ops)
+      : DIBasicType(C, DIFixedPointTypeKind, Storage, Tag, LineNo, AlignInBits,
                     Encoding, 0, 0, Flags, Ops),
         Kind(Kind), Factor(Factor) {
     assert(Kind == FixedPointBinary || Kind == FixedPointDecimal);
   }
   DIFixedPointType(LLVMContext &C, StorageType Storage, unsigned Tag,
-                   uint32_t AlignInBits, unsigned Encoding, DIFlags Flags,
-                   unsigned Kind, APInt Numerator, APInt Denominator,
-                   ArrayRef<Metadata *> Ops)
-      : DIBasicType(C, DIFixedPointTypeKind, Storage, Tag, AlignInBits,
+                   unsigned LineNo, uint32_t AlignInBits, unsigned Encoding,
+                   DIFlags Flags, unsigned Kind, APInt Numerator,
+                   APInt Denominator, ArrayRef<Metadata *> Ops)
+      : DIBasicType(C, DIFixedPointTypeKind, Storage, Tag, LineNo, AlignInBits,
                     Encoding, 0, 0, Flags, Ops),
         Kind(Kind), Factor(0), Numerator(Numerator), Denominator(Denominator) {
     assert(Kind == FixedPointRational);
   }
   DIFixedPointType(LLVMContext &C, StorageType Storage, unsigned Tag,
-                   uint32_t AlignInBits, unsigned Encoding, DIFlags Flags,
-                   unsigned Kind, int Factor, APInt Numerator,
+                   unsigned LineNo, uint32_t AlignInBits, unsigned Encoding,
+                   DIFlags Flags, unsigned Kind, int Factor, APInt Numerator,
                    APInt Denominator, ArrayRef<Metadata *> Ops)
-      : DIBasicType(C, DIFixedPointTypeKind, Storage, Tag, AlignInBits,
+      : DIBasicType(C, DIFixedPointTypeKind, Storage, Tag, LineNo, AlignInBits,
                     Encoding, 0, 0, Flags, Ops),
         Kind(Kind), Factor(Factor), Numerator(Numerator),
         Denominator(Denominator) {}
   ~DIFixedPointType() = default;
 
   static DIFixedPointType *
-  getImpl(LLVMContext &Context, unsigned Tag, StringRef Name,
-          uint64_t SizeInBits, uint32_t AlignInBits, unsigned Encoding,
-          DIFlags Flags, unsigned Kind, int Factor, APInt Numerator,
-          APInt Denominator, StorageType Storage, bool ShouldCreate = true) {
+  getImpl(LLVMContext &Context, unsigned Tag, StringRef Name, DIFile *File,
+          unsigned LineNo, DIScope *Scope, uint64_t SizeInBits,
+          uint32_t AlignInBits, unsigned Encoding, DIFlags Flags, unsigned Kind,
+          int Factor, APInt Numerator, APInt Denominator, StorageType Storage,
+          bool ShouldCreate = true) {
     auto *SizeInBitsNode = ConstantAsMetadata::get(
         ConstantInt::get(Type::getInt64Ty(Context), SizeInBits));
-    return getImpl(Context, Tag, getCanonicalMDString(Context, Name),
-                   SizeInBitsNode, AlignInBits, Encoding, Flags, Kind, Factor,
-                   Numerator, Denominator, Storage, ShouldCreate);
+    return getImpl(Context, Tag, getCanonicalMDString(Context, Name), File,
+                   LineNo, Scope, SizeInBitsNode, AlignInBits, Encoding, Flags,
+                   Kind, Factor, Numerator, Denominator, Storage, ShouldCreate);
   }
   static DIFixedPointType *
-  getImpl(LLVMContext &Context, unsigned Tag, StringRef Name,
-          Metadata *SizeInBits, uint32_t AlignInBits, unsigned Encoding,
-          DIFlags Flags, unsigned Kind, int Factor, APInt Numerator,
-          APInt Denominator, StorageType Storage, bool ShouldCreate = true) {
-    return getImpl(Context, Tag, getCanonicalMDString(Context, Name),
-                   SizeInBits, AlignInBits, Encoding, Flags, Kind, Factor,
-                   Numerator, Denominator, Storage, ShouldCreate);
+  getImpl(LLVMContext &Context, unsigned Tag, StringRef Name, DIFile *File,
+          unsigned LineNo, DIScope *Scope, Metadata *SizeInBits,
+          uint32_t AlignInBits, unsigned Encoding, DIFlags Flags, unsigned Kind,
+          int Factor, APInt Numerator, APInt Denominator, StorageType Storage,
+          bool ShouldCreate = true) {
+    return getImpl(Context, Tag, getCanonicalMDString(Context, Name), File,
+                   LineNo, Scope, SizeInBits, AlignInBits, Encoding, Flags,
+                   Kind, Factor, Numerator, Denominator, Storage, ShouldCreate);
   }
   static DIFixedPointType *
-  getImpl(LLVMContext &Context, unsigned Tag, MDString *Name,
-          uint64_t SizeInBits, uint32_t AlignInBits, unsigned Encoding,
-          DIFlags Flags, unsigned Kind, int Factor, APInt Numerator,
-          APInt Denominator, StorageType Storage, bool ShouldCreate = true) {
+  getImpl(LLVMContext &Context, unsigned Tag, MDString *Name, DIFile *File,
+          unsigned LineNo, DIScope *Scope, uint64_t SizeInBits,
+          uint32_t AlignInBits, unsigned Encoding, DIFlags Flags, unsigned Kind,
+          int Factor, APInt Numerator, APInt Denominator, StorageType Storage,
+          bool ShouldCreate = true) {
     auto *SizeInBitsNode = ConstantAsMetadata::get(
         ConstantInt::get(Type::getInt64Ty(Context), SizeInBits));
-    return getImpl(Context, Tag, Name, SizeInBitsNode, AlignInBits, Encoding,
-                   Flags, Kind, Factor, Numerator, Denominator, Storage,
-                   ShouldCreate);
+    return getImpl(Context, Tag, Name, File, LineNo, Scope, SizeInBitsNode,
+                   AlignInBits, Encoding, Flags, Kind, Factor, Numerator,
+                   Denominator, Storage, ShouldCreate);
   }
   LLVM_ABI static DIFixedPointType *
-  getImpl(LLVMContext &Context, unsigned Tag, MDString *Name,
-          Metadata *SizeInBits, uint32_t AlignInBits, unsigned Encoding,
-          DIFlags Flags, unsigned Kind, int Factor, APInt Numerator,
-          APInt Denominator, StorageType Storage, bool ShouldCreate = true);
+  getImpl(LLVMContext &Context, unsigned Tag, MDString *Name, Metadata *File,
+          unsigned LineNo, Metadata *Scope, Metadata *SizeInBits,
+          uint32_t AlignInBits, unsigned Encoding, DIFlags Flags, unsigned Kind,
+          int Factor, APInt Numerator, APInt Denominator, StorageType Storage,
+          bool ShouldCreate = true);
 
   TempDIFixedPointType cloneImpl() const {
-    return getTemporary(getContext(), getTag(), getRawName(),
-                        getRawSizeInBits(), getAlignInBits(), getEncoding(),
-                        getFlags(), Kind, Factor, Numerator, Denominator);
+    return getTemporary(getContext(), getTag(), getRawName(), getFile(),
+                        getLine(), getScope(), getRawSizeInBits(),
+                        getAlignInBits(), getEncoding(), getFlags(), Kind,
+                        Factor, Numerator, Denominator);
   }
 
 public:
@@ -1055,26 +1085,29 @@ public:
   LLVM_ABI static const char *fixedPointKindString(FixedPointKind);
 
   DEFINE_MDNODE_GET(DIFixedPointType,
-                    (unsigned Tag, MDString *Name, uint64_t SizeInBits,
+                    (unsigned Tag, MDString *Name, DIFile *File,
+                     unsigned LineNo, DIScope *Scope, uint64_t SizeInBits,
                      uint32_t AlignInBits, unsigned Encoding, DIFlags Flags,
                      unsigned Kind, int Factor, APInt Numerator,
                      APInt Denominator),
-                    (Tag, Name, SizeInBits, AlignInBits, Encoding, Flags, Kind,
-                     Factor, Numerator, Denominator))
+                    (Tag, Name, File, LineNo, Scope, SizeInBits, AlignInBits,
+                     Encoding, Flags, Kind, Factor, Numerator, Denominator))
   DEFINE_MDNODE_GET(DIFixedPointType,
-                    (unsigned Tag, StringRef Name, uint64_t SizeInBits,
+                    (unsigned Tag, StringRef Name, DIFile *File,
+                     unsigned LineNo, DIScope *Scope, uint64_t SizeInBits,
                      uint32_t AlignInBits, unsigned Encoding, DIFlags Flags,
                      unsigned Kind, int Factor, APInt Numerator,
                      APInt Denominator),
-                    (Tag, Name, SizeInBits, AlignInBits, Encoding, Flags, Kind,
-                     Factor, Numerator, Denominator))
+                    (Tag, Name, File, LineNo, Scope, SizeInBits, AlignInBits,
+                     Encoding, Flags, Kind, Factor, Numerator, Denominator))
   DEFINE_MDNODE_GET(DIFixedPointType,
-                    (unsigned Tag, MDString *Name, Metadata *SizeInBits,
+                    (unsigned Tag, MDString *Name, Metadata *File,
+                     unsigned LineNo, Metadata *Scope, Metadata *SizeInBits,
                      uint32_t AlignInBits, unsigned Encoding, DIFlags Flags,
                      unsigned Kind, int Factor, APInt Numerator,
                      APInt Denominator),
-                    (Tag, Name, SizeInBits, AlignInBits, Encoding, Flags, Kind,
-                     Factor, Numerator, Denominator))
+                    (Tag, Name, File, LineNo, Scope, SizeInBits, AlignInBits,
+                     Encoding, Flags, Kind, Factor, Numerator, Denominator))
 
   TempDIFixedPointType clone() const { return cloneImpl(); }
 

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -5849,6 +5849,9 @@ bool LLParser::parseDIBasicType(MDNode *&Result, bool IsDistinct) {
 #define VISIT_MD_FIELDS(OPTIONAL, REQUIRED)                                    \
   OPTIONAL(tag, DwarfTagField, (dwarf::DW_TAG_base_type));                     \
   OPTIONAL(name, MDStringField, );                                             \
+  OPTIONAL(file, MDField, );                                                   \
+  OPTIONAL(line, LineField, );                                                 \
+  OPTIONAL(scope, MDField, );                                                  \
   OPTIONAL(size, MDUnsignedOrMDField, (0, UINT64_MAX));                        \
   OPTIONAL(align, MDUnsignedField, (0, UINT32_MAX));                           \
   OPTIONAL(dataSize, MDUnsignedField, (0, UINT32_MAX));                        \
@@ -5859,9 +5862,9 @@ bool LLParser::parseDIBasicType(MDNode *&Result, bool IsDistinct) {
 #undef VISIT_MD_FIELDS
 
   Result = GET_OR_DISTINCT(
-      DIBasicType,
-      (Context, tag.Val, name.Val, size.getValueAsMetadata(Context), align.Val,
-       encoding.Val, num_extra_inhabitants.Val, dataSize.Val, flags.Val));
+      DIBasicType, (Context, tag.Val, name.Val, file.Val, line.Val, scope.Val,
+                    size.getValueAsMetadata(Context), align.Val, encoding.Val,
+                    num_extra_inhabitants.Val, dataSize.Val, flags.Val));
   return false;
 }
 
@@ -5874,6 +5877,9 @@ bool LLParser::parseDIFixedPointType(MDNode *&Result, bool IsDistinct) {
 #define VISIT_MD_FIELDS(OPTIONAL, REQUIRED)                                    \
   OPTIONAL(tag, DwarfTagField, (dwarf::DW_TAG_base_type));                     \
   OPTIONAL(name, MDStringField, );                                             \
+  OPTIONAL(file, MDField, );                                                   \
+  OPTIONAL(line, LineField, );                                                 \
+  OPTIONAL(scope, MDField, );                                                  \
   OPTIONAL(size, MDUnsignedOrMDField, (0, UINT64_MAX));                        \
   OPTIONAL(align, MDUnsignedField, (0, UINT32_MAX));                           \
   OPTIONAL(encoding, DwarfAttEncodingField, );                                 \
@@ -5886,10 +5892,10 @@ bool LLParser::parseDIFixedPointType(MDNode *&Result, bool IsDistinct) {
 #undef VISIT_MD_FIELDS
 
   Result = GET_OR_DISTINCT(DIFixedPointType,
-                           (Context, tag.Val, name.Val,
-                            size.getValueAsMetadata(Context), align.Val,
-                            encoding.Val, flags.Val, kind.Val, factor.Val,
-                            numerator.Val, denominator.Val));
+                           (Context, tag.Val, name.Val, file.Val, line.Val,
+                            scope.Val, size.getValueAsMetadata(Context),
+                            align.Val, encoding.Val, flags.Val, kind.Val,
+                            factor.Val, numerator.Val, denominator.Val));
   return false;
 }
 

--- a/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
+++ b/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
@@ -1596,7 +1596,7 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
     break;
   }
   case bitc::METADATA_BASIC_TYPE: {
-    if (Record.size() < 6 || Record.size() > 9)
+    if (Record.size() < 6 || Record.size() > 12)
       return error("Invalid record");
 
     IsDistinct = Record[0] & 1;
@@ -1607,11 +1607,19 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
     uint32_t NumExtraInhabitants = (Record.size() > 7) ? Record[7] : 0;
     uint32_t DataSizeInBits = (Record.size() > 8) ? Record[8] : 0;
     Metadata *SizeInBits = getMetadataOrConstant(SizeIsMetadata, Record[3]);
+    Metadata *File = nullptr;
+    unsigned LineNo = 0;
+    Metadata *Scope = nullptr;
+    if (Record.size() > 9) {
+      File = getMDOrNull(Record[9]);
+      LineNo = Record[10];
+      Scope = getMDOrNull(Record[11]);
+    }
     MetadataList.assignValue(
         GET_OR_DISTINCT(DIBasicType,
-                        (Context, Record[1], getMDString(Record[2]), SizeInBits,
-                         Record[4], Record[5], NumExtraInhabitants,
-                         DataSizeInBits, Flags)),
+                        (Context, Record[1], getMDString(Record[2]), File,
+                         LineNo, Scope, SizeInBits, Record[4], Record[5],
+                         NumExtraInhabitants, DataSizeInBits, Flags)),
         NextMetadataNo);
     NextMetadataNo++;
     break;
@@ -1640,14 +1648,22 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
     APInt Numerator = ReadWideInt();
     APInt Denominator = ReadWideInt();
 
-    if (Offset != Record.size())
+    Metadata *File = nullptr;
+    unsigned LineNo = 0;
+    Metadata *Scope = nullptr;
+
+    if (Offset + 3 == Record.size()) {
+      File = getMDOrNull(Record[Offset]);
+      LineNo = Record[Offset + 1];
+      Scope = getMDOrNull(Record[Offset + 2]);
+    } else if (Offset != Record.size())
       return error("Invalid record");
 
     MetadataList.assignValue(
         GET_OR_DISTINCT(DIFixedPointType,
-                        (Context, Record[1], getMDString(Record[2]), SizeInBits,
-                         Record[4], Record[5], Flags, Record[7], Record[8],
-                         Numerator, Denominator)),
+                        (Context, Record[1], getMDString(Record[2]), File,
+                         LineNo, Scope, SizeInBits, Record[4], Record[5], Flags,
+                         Record[7], Record[8], Numerator, Denominator)),
         NextMetadataNo);
     NextMetadataNo++;
     break;

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -1935,6 +1935,9 @@ void ModuleBitcodeWriter::writeDIBasicType(const DIBasicType *N,
   Record.push_back(N->getFlags());
   Record.push_back(N->getNumExtraInhabitants());
   Record.push_back(N->getDataSizeInBits());
+  Record.push_back(VE.getMetadataOrNullID(N->getFile()));
+  Record.push_back(N->getLine());
+  Record.push_back(VE.getMetadataOrNullID(N->getScope()));
 
   Stream.EmitRecord(bitc::METADATA_BASIC_TYPE, Record, Abbrev);
   Record.clear();
@@ -1965,6 +1968,10 @@ void ModuleBitcodeWriter::writeDIFixedPointType(
 
   WriteWideInt(N->getNumeratorRaw());
   WriteWideInt(N->getDenominatorRaw());
+
+  Record.push_back(VE.getMetadataOrNullID(N->getFile()));
+  Record.push_back(N->getLine());
+  Record.push_back(VE.getMetadataOrNullID(N->getScope()));
 
   Stream.EmitRecord(bitc::METADATA_FIXED_POINT_TYPE, Record, Abbrev);
   Record.clear();

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2238,6 +2238,9 @@ static void writeDIBasicType(raw_ostream &Out, const DIBasicType *N,
   if (N->getTag() != dwarf::DW_TAG_base_type)
     Printer.printTag(N);
   Printer.printString("name", N->getName());
+  Printer.printMetadata("scope", N->getRawScope());
+  Printer.printMetadata("file", N->getRawFile());
+  Printer.printInt("line", N->getLine());
   Printer.printMetadataOrInt("size", N->getRawSizeInBits(), true);
   Printer.printInt("align", N->getAlignInBits());
   Printer.printInt("dataSize", N->getDataSizeInBits());
@@ -2255,6 +2258,9 @@ static void writeDIFixedPointType(raw_ostream &Out, const DIFixedPointType *N,
   if (N->getTag() != dwarf::DW_TAG_base_type)
     Printer.printTag(N);
   Printer.printString("name", N->getName());
+  Printer.printMetadata("scope", N->getRawScope());
+  Printer.printMetadata("file", N->getRawFile());
+  Printer.printInt("line", N->getLine());
   Printer.printMetadataOrInt("size", N->getRawSizeInBits(), true);
   Printer.printInt("align", N->getAlignInBits());
   Printer.printDwarfEnum("encoding", N->getEncoding(),

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -276,40 +276,66 @@ DIBasicType *DIBuilder::createBasicType(StringRef Name, uint64_t SizeInBits,
                                         DINode::DIFlags Flags,
                                         uint32_t NumExtraInhabitants,
                                         uint32_t DataSizeInBits) {
-  return DIBasicType::get(VMContext, dwarf::DW_TAG_base_type, Name, SizeInBits,
-                          0, Encoding, NumExtraInhabitants, DataSizeInBits,
-                          Flags);
+  return DIBasicType::get(VMContext, dwarf::DW_TAG_base_type, Name, nullptr, 0,
+                          nullptr, SizeInBits, 0, Encoding, NumExtraInhabitants,
+                          DataSizeInBits, Flags);
 }
 
-DIFixedPointType *
-DIBuilder::createBinaryFixedPointType(StringRef Name, uint64_t SizeInBits,
-                                      uint32_t AlignInBits, unsigned Encoding,
-                                      DINode::DIFlags Flags, int Factor) {
-  return DIFixedPointType::get(VMContext, dwarf::DW_TAG_base_type, Name,
-                               SizeInBits, AlignInBits, Encoding, Flags,
-                               DIFixedPointType::FixedPointBinary, Factor,
-                               APInt(), APInt());
+DIBasicType *DIBuilder::createBasicType(StringRef Name, DIFile *File,
+                                        unsigned LineNo, DIScope *Context,
+                                        uint64_t SizeInBits, unsigned Encoding,
+                                        DINode::DIFlags Flags,
+                                        uint32_t NumExtraInhabitants,
+                                        uint32_t DataSizeInBits) {
+  auto *R = DIBasicType::get(VMContext, dwarf::DW_TAG_base_type, Name, File,
+                             LineNo, Context, SizeInBits, 0, Encoding,
+                             NumExtraInhabitants, DataSizeInBits, Flags);
+  if (isa_and_nonnull<DILocalScope>(Context))
+    getSubprogramNodesTrackingVector(Context).emplace_back(R);
+  trackIfUnresolved(R);
+  return R;
 }
 
-DIFixedPointType *
-DIBuilder::createDecimalFixedPointType(StringRef Name, uint64_t SizeInBits,
-                                       uint32_t AlignInBits, unsigned Encoding,
-                                       DINode::DIFlags Flags, int Factor) {
-  return DIFixedPointType::get(VMContext, dwarf::DW_TAG_base_type, Name,
-                               SizeInBits, AlignInBits, Encoding, Flags,
-                               DIFixedPointType::FixedPointDecimal, Factor,
-                               APInt(), APInt());
+DIFixedPointType *DIBuilder::createBinaryFixedPointType(
+    StringRef Name, DIFile *File, unsigned LineNo, DIScope *Context,
+    uint64_t SizeInBits, uint32_t AlignInBits, unsigned Encoding,
+    DINode::DIFlags Flags, int Factor) {
+  auto *R = DIFixedPointType::get(
+      VMContext, dwarf::DW_TAG_base_type, Name, File, LineNo, Context,
+      SizeInBits, AlignInBits, Encoding, Flags,
+      DIFixedPointType::FixedPointBinary, Factor, APInt(), APInt());
+  if (isa_and_nonnull<DILocalScope>(Context))
+    getSubprogramNodesTrackingVector(Context).emplace_back(R);
+  trackIfUnresolved(R);
+  return R;
 }
 
-DIFixedPointType *
-DIBuilder::createRationalFixedPointType(StringRef Name, uint64_t SizeInBits,
-                                        uint32_t AlignInBits, unsigned Encoding,
-                                        DINode::DIFlags Flags, APInt Numerator,
-                                        APInt Denominator) {
-  return DIFixedPointType::get(VMContext, dwarf::DW_TAG_base_type, Name,
-                               SizeInBits, AlignInBits, Encoding, Flags,
-                               DIFixedPointType::FixedPointRational, 0,
-                               Numerator, Denominator);
+DIFixedPointType *DIBuilder::createDecimalFixedPointType(
+    StringRef Name, DIFile *File, unsigned LineNo, DIScope *Context,
+    uint64_t SizeInBits, uint32_t AlignInBits, unsigned Encoding,
+    DINode::DIFlags Flags, int Factor) {
+  auto *R = DIFixedPointType::get(
+      VMContext, dwarf::DW_TAG_base_type, Name, File, LineNo, Context,
+      SizeInBits, AlignInBits, Encoding, Flags,
+      DIFixedPointType::FixedPointDecimal, Factor, APInt(), APInt());
+  if (isa_and_nonnull<DILocalScope>(Context))
+    getSubprogramNodesTrackingVector(Context).emplace_back(R);
+  trackIfUnresolved(R);
+  return R;
+}
+
+DIFixedPointType *DIBuilder::createRationalFixedPointType(
+    StringRef Name, DIFile *File, unsigned LineNo, DIScope *Context,
+    uint64_t SizeInBits, uint32_t AlignInBits, unsigned Encoding,
+    DINode::DIFlags Flags, APInt Numerator, APInt Denominator) {
+  auto *R = DIFixedPointType::get(
+      VMContext, dwarf::DW_TAG_base_type, Name, File, LineNo, Context,
+      SizeInBits, AlignInBits, Encoding, Flags,
+      DIFixedPointType::FixedPointRational, 0, Numerator, Denominator);
+  if (isa_and_nonnull<DILocalScope>(Context))
+    getSubprogramNodesTrackingVector(Context).emplace_back(R);
+  trackIfUnresolved(R);
+  return R;
 }
 
 DIStringType *DIBuilder::createStringType(StringRef Name, uint64_t SizeInBits) {

--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -873,20 +873,22 @@ DIEnumerator *DIEnumerator::getImpl(LLVMContext &Context, const APInt &Value,
 }
 
 DIBasicType *DIBasicType::getImpl(LLVMContext &Context, unsigned Tag,
-                                  MDString *Name, Metadata *SizeInBits,
-                                  uint32_t AlignInBits, unsigned Encoding,
+                                  MDString *Name, Metadata *File,
+                                  unsigned LineNo, Metadata *Scope,
+                                  Metadata *SizeInBits, uint32_t AlignInBits,
+                                  unsigned Encoding,
                                   uint32_t NumExtraInhabitants,
                                   uint32_t DataSizeInBits, DIFlags Flags,
                                   StorageType Storage, bool ShouldCreate) {
   assert(isCanonical(Name) && "Expected canonical MDString");
-  DEFINE_GETIMPL_LOOKUP(DIBasicType,
-                        (Tag, Name, SizeInBits, AlignInBits, Encoding,
-                         NumExtraInhabitants, DataSizeInBits, Flags));
-  Metadata *Ops[] = {nullptr, nullptr, Name, SizeInBits, nullptr};
-  DEFINE_GETIMPL_STORE(
-      DIBasicType,
-      (Tag, AlignInBits, Encoding, NumExtraInhabitants, DataSizeInBits, Flags),
-      Ops);
+  DEFINE_GETIMPL_LOOKUP(
+      DIBasicType, (Tag, Name, File, LineNo, Scope, SizeInBits, AlignInBits,
+                    Encoding, NumExtraInhabitants, DataSizeInBits, Flags));
+  Metadata *Ops[] = {File, Scope, Name, SizeInBits, nullptr};
+  DEFINE_GETIMPL_STORE(DIBasicType,
+                       (Tag, LineNo, AlignInBits, Encoding, NumExtraInhabitants,
+                        DataSizeInBits, Flags),
+                       Ops);
 }
 
 std::optional<DIBasicType::Signedness> DIBasicType::getSignedness() const {
@@ -906,18 +908,20 @@ std::optional<DIBasicType::Signedness> DIBasicType::getSignedness() const {
 
 DIFixedPointType *
 DIFixedPointType::getImpl(LLVMContext &Context, unsigned Tag, MDString *Name,
+                          Metadata *File, unsigned LineNo, Metadata *Scope,
                           Metadata *SizeInBits, uint32_t AlignInBits,
                           unsigned Encoding, DIFlags Flags, unsigned Kind,
                           int Factor, APInt Numerator, APInt Denominator,
                           StorageType Storage, bool ShouldCreate) {
   DEFINE_GETIMPL_LOOKUP(DIFixedPointType,
-                        (Tag, Name, SizeInBits, AlignInBits, Encoding, Flags,
-                         Kind, Factor, Numerator, Denominator));
-  Metadata *Ops[] = {nullptr, nullptr, Name, SizeInBits, nullptr};
-  DEFINE_GETIMPL_STORE(
-      DIFixedPointType,
-      (Tag, AlignInBits, Encoding, Flags, Kind, Factor, Numerator, Denominator),
-      Ops);
+                        (Tag, Name, File, LineNo, Scope, SizeInBits,
+                         AlignInBits, Encoding, Flags, Kind, Factor, Numerator,
+                         Denominator));
+  Metadata *Ops[] = {File, Scope, Name, SizeInBits, nullptr};
+  DEFINE_GETIMPL_STORE(DIFixedPointType,
+                       (Tag, LineNo, AlignInBits, Encoding, Flags, Kind, Factor,
+                        Numerator, Denominator),
+                       Ops);
 }
 
 bool DIFixedPointType::isSigned() const {

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -476,6 +476,9 @@ template <> struct MDNodeKeyImpl<DIEnumerator> {
 template <> struct MDNodeKeyImpl<DIBasicType> {
   unsigned Tag;
   MDString *Name;
+  Metadata *File;
+  unsigned LineNo;
+  Metadata *Scope;
   Metadata *SizeInBits;
   uint32_t AlignInBits;
   unsigned Encoding;
@@ -483,15 +486,17 @@ template <> struct MDNodeKeyImpl<DIBasicType> {
   uint32_t DataSizeInBits;
   unsigned Flags;
 
-  MDNodeKeyImpl(unsigned Tag, MDString *Name, Metadata *SizeInBits,
-                uint32_t AlignInBits, unsigned Encoding,
-                uint32_t NumExtraInhabitants, uint32_t DataSizeInBits,
-                unsigned Flags)
-      : Tag(Tag), Name(Name), SizeInBits(SizeInBits), AlignInBits(AlignInBits),
-        Encoding(Encoding), NumExtraInhabitants(NumExtraInhabitants),
+  MDNodeKeyImpl(unsigned Tag, MDString *Name, Metadata *File, unsigned LineNo,
+                Metadata *Scope, Metadata *SizeInBits, uint32_t AlignInBits,
+                unsigned Encoding, uint32_t NumExtraInhabitants,
+                uint32_t DataSizeInBits, unsigned Flags)
+      : Tag(Tag), Name(Name), File(File), LineNo(LineNo), Scope(Scope),
+        SizeInBits(SizeInBits), AlignInBits(AlignInBits), Encoding(Encoding),
+        NumExtraInhabitants(NumExtraInhabitants),
         DataSizeInBits(DataSizeInBits), Flags(Flags) {}
   MDNodeKeyImpl(const DIBasicType *N)
-      : Tag(N->getTag()), Name(N->getRawName()),
+      : Tag(N->getTag()), Name(N->getRawName()), File(N->getRawFile()),
+        LineNo(N->getLine()), Scope(N->getRawScope()),
         SizeInBits(N->getRawSizeInBits()), AlignInBits(N->getAlignInBits()),
         Encoding(N->getEncoding()),
         NumExtraInhabitants(N->getNumExtraInhabitants()),
@@ -499,6 +504,8 @@ template <> struct MDNodeKeyImpl<DIBasicType> {
 
   bool isKeyOf(const DIBasicType *RHS) const {
     return Tag == RHS->getTag() && Name == RHS->getRawName() &&
+           File == RHS->getRawFile() && LineNo == RHS->getLine() &&
+           Scope == RHS->getRawScope() &&
            SizeInBits == RHS->getRawSizeInBits() &&
            AlignInBits == RHS->getAlignInBits() &&
            Encoding == RHS->getEncoding() &&
@@ -508,13 +515,17 @@ template <> struct MDNodeKeyImpl<DIBasicType> {
   }
 
   unsigned getHashValue() const {
-    return hash_combine(Tag, Name, SizeInBits, AlignInBits, Encoding);
+    return hash_combine(Tag, Name, File, LineNo, Scope, SizeInBits, AlignInBits,
+                        Encoding);
   }
 };
 
 template <> struct MDNodeKeyImpl<DIFixedPointType> {
   unsigned Tag;
   MDString *Name;
+  Metadata *File;
+  unsigned LineNo;
+  Metadata *Scope;
   Metadata *SizeInBits;
   uint32_t AlignInBits;
   unsigned Encoding;
@@ -524,21 +535,26 @@ template <> struct MDNodeKeyImpl<DIFixedPointType> {
   APInt Numerator;
   APInt Denominator;
 
-  MDNodeKeyImpl(unsigned Tag, MDString *Name, Metadata *SizeInBits,
-                uint32_t AlignInBits, unsigned Encoding, unsigned Flags,
-                unsigned Kind, int Factor, APInt Numerator, APInt Denominator)
-      : Tag(Tag), Name(Name), SizeInBits(SizeInBits), AlignInBits(AlignInBits),
-        Encoding(Encoding), Flags(Flags), Kind(Kind), Factor(Factor),
-        Numerator(Numerator), Denominator(Denominator) {}
+  MDNodeKeyImpl(unsigned Tag, MDString *Name, Metadata *File, unsigned LineNo,
+                Metadata *Scope, Metadata *SizeInBits, uint32_t AlignInBits,
+                unsigned Encoding, unsigned Flags, unsigned Kind, int Factor,
+                APInt Numerator, APInt Denominator)
+      : Tag(Tag), Name(Name), File(File), LineNo(LineNo), Scope(Scope),
+        SizeInBits(SizeInBits), AlignInBits(AlignInBits), Encoding(Encoding),
+        Flags(Flags), Kind(Kind), Factor(Factor), Numerator(Numerator),
+        Denominator(Denominator) {}
   MDNodeKeyImpl(const DIFixedPointType *N)
-      : Tag(N->getTag()), Name(N->getRawName()),
+      : Tag(N->getTag()), Name(N->getRawName()), File(N->getRawFile()),
+        LineNo(N->getLine()), Scope(N->getRawScope()),
         SizeInBits(N->getRawSizeInBits()), AlignInBits(N->getAlignInBits()),
         Encoding(N->getEncoding()), Flags(N->getFlags()), Kind(N->getKind()),
         Factor(N->getFactorRaw()), Numerator(N->getNumeratorRaw()),
         Denominator(N->getDenominatorRaw()) {}
 
   bool isKeyOf(const DIFixedPointType *RHS) const {
-    return Name == RHS->getRawName() && SizeInBits == RHS->getRawSizeInBits() &&
+    return Name == RHS->getRawName() && File == RHS->getRawFile() &&
+           LineNo == RHS->getLine() && Scope == RHS->getRawScope() &&
+           SizeInBits == RHS->getRawSizeInBits() &&
            AlignInBits == RHS->getAlignInBits() && Kind == RHS->getKind() &&
            (RHS->isRational() ? (Numerator == RHS->getNumerator() &&
                                  Denominator == RHS->getDenominator())
@@ -546,7 +562,8 @@ template <> struct MDNodeKeyImpl<DIFixedPointType> {
   }
 
   unsigned getHashValue() const {
-    return hash_combine(Name, Flags, Kind, Factor, Numerator, Denominator);
+    return hash_combine(Name, File, LineNo, Scope, Flags, Kind, Factor,
+                        Numerator, Denominator);
   }
 };
 

--- a/llvm/test/Bitcode/fixedpoint_scope.ll
+++ b/llvm/test/Bitcode/fixedpoint_scope.ll
@@ -1,0 +1,39 @@
+;; This test checks generation of DIFixedPointType with scopes.
+
+; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s
+
+;; Test whether DIFixedPointType is generated.
+; CHECK: !DIFixedPointType(name: "fp__decimal", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: 2, size: 32, align: 32, encoding: DW_ATE_signed_fixed, kind: Decimal, factor: -4)
+; CHECK: !DIFixedPointType(name: "fp__rational", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: 2, size: 32, align: 32, encoding: DW_ATE_unsigned_fixed, kind: Rational, numerator: 1234, denominator: 5678)
+; CHECK: !DIFixedPointType(name: "fp__binary", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: 2, size: 64, encoding: DW_ATE_unsigned_fixed, kind: Binary, factor: -16)
+
+; ModuleID = 'fixedpoint_type.ll'
+source_filename = "/dir/fixedpoint_type.adb"
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @foo()
+
+define void @bar(ptr %this) !dbg !6 {
+  call void @foo(), !dbg !14
+  ret void, !dbg !14
+}
+
+!llvm.module.flags = !{!0, !1}
+!llvm.dbg.cu = !{!2}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{i32 2, !"Dwarf Version", i32 4}
+!2 = distinct !DICompileUnit(language: DW_LANG_Ada95, file: !3, producer: "GNAT/LLVM", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!3 = !DIFile(filename: "fixedpoint_type.adb", directory: "/dir")
+
+!6 = distinct !DISubprogram(name: "fp", scope: !3, file: !3, line: 1, type: !7, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !9)
+!7 = !DISubroutineType(types: !8)
+!8 = !{}
+!9 = !{!10, !11, !12, !13}
+!10 = !DILocalVariable(name: "x", scope: !6, file: !3, line: 3, type: !11, align: 32)
+!11 = !DIFixedPointType(name: "fp__decimal", size: 32, align: 32, encoding: DW_ATE_signed_fixed, kind: Decimal, factor: -4, scope: !6, file: !3, line: 2)
+!12 = !DIFixedPointType(name: "fp__rational", size: 32, align: 32, encoding: DW_ATE_unsigned_fixed, kind: Rational, numerator: 1234, denominator: 5678, scope: !6, file: !3, line: 2)
+!13 = !DIFixedPointType(name: "fp__binary", size: 64, align: 0, encoding: DW_ATE_unsigned_fixed, kind: Binary, factor: -16, scope: !6, file: !3, line: 2)
+!14 = !DILocation(line: 69, column: 18, scope: !6)

--- a/llvm/unittests/IR/DebugInfoTest.cpp
+++ b/llvm/unittests/IR/DebugInfoTest.cpp
@@ -526,14 +526,16 @@ TEST(DIBuilder, FixedPointType) {
   DIBuilder DIB(*M);
 
   DIFixedPointType *Ty = DIB.createBinaryFixedPointType(
-      {}, 32, 0, dwarf::DW_ATE_signed_fixed, DINode::FlagZero, -4);
+      {}, nullptr, 0, nullptr, 32, 0, dwarf::DW_ATE_signed_fixed,
+      DINode::FlagZero, -4);
   EXPECT_TRUE(Ty);
   EXPECT_TRUE(Ty->getKind() == DIFixedPointType::FixedPointBinary);
   EXPECT_TRUE(Ty->getFactor() == -4);
   EXPECT_TRUE(Ty->getEncoding() == dwarf::DW_ATE_signed_fixed);
   EXPECT_TRUE(Ty->getTag() == dwarf::DW_TAG_base_type);
 
-  Ty = DIB.createDecimalFixedPointType({}, 32, 0, dwarf::DW_ATE_unsigned_fixed,
+  Ty = DIB.createDecimalFixedPointType({}, nullptr, 0, nullptr, 32, 0,
+                                       dwarf::DW_ATE_unsigned_fixed,
                                        DINode::FlagZero, -7);
   EXPECT_TRUE(Ty);
   EXPECT_TRUE(Ty->getKind() == DIFixedPointType::FixedPointDecimal);
@@ -543,7 +545,8 @@ TEST(DIBuilder, FixedPointType) {
 
   APSInt Num(APInt(32, 1));
   APSInt Denom(APInt(33, 72));
-  Ty = DIB.createRationalFixedPointType({}, 32, 0, dwarf::DW_ATE_unsigned_fixed,
+  Ty = DIB.createRationalFixedPointType({}, nullptr, 0, nullptr, 32, 0,
+                                        dwarf::DW_ATE_unsigned_fixed,
                                         DINode::FlagZero, Num, Denom);
   EXPECT_TRUE(Ty);
   EXPECT_TRUE(Ty->getKind() == DIFixedPointType::FixedPointRational);


### PR DESCRIPTION
DIBasicType derives from DIType and so it already has slots to store the scope and location of the type.  However, the DIBasicType constructor (and corresponding DIBuilder method) does not expose this, presumably because it is not needed by C or C++.

In Ada it is more common to create one's own basic type.  So, for Ada exposing this functionality would be handy.

This patch adds a new overload of DIBuilder::createBasicType to allow this.  Because only Ada uses fixed point types, the patch simply updates these DIBuilder methods unconditionally.

Note that DwarfUnit already handles this scenario and so no changes were needed there.