### PR TITLE
[SPIR-V] Preserve module analysis for XeVM lowering

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -140,6 +140,7 @@ void SPIRVAsmPrinter::emitEndOfAsmFile(Module &M) {
 // Any cleanup actions with the Module after we don't care about its content
 // anymore.
 void SPIRVAsmPrinter::cleanUp(Module &M) {
+  clearCachedSPIRVModuleAnalysis(M);
   // Verifier disallows uses of intrinsic global variables.
   for (StringRef GVName :
        {"llvm.global_ctors", "llvm.global_dtors", "llvm.used"}) {
@@ -819,7 +820,12 @@ void SPIRVAsmPrinter::outputModuleSections() {
   // Get the global subtarget to output module-level info.
   ST = static_cast<const SPIRVTargetMachine &>(TM).getSubtargetImpl();
   TII = ST->getInstrInfo();
-  MAI = &getAnalysis<SPIRVModuleAnalysis>().MAI;
+  if (!MAI) {
+    if (auto *ModuleAnalysis = getAnalysisIfAvailable<SPIRVModuleAnalysis>())
+      MAI = &ModuleAnalysis->MAI;
+    else if (M)
+      MAI = getCachedSPIRVModuleAnalysis(*M);
+  }
   assert(ST && TII && MAI && M && "Module analysis is required");
   // Output instructions according to the Logical Layout of a Module:
   // 1,2. All OpCapability instructions, then optional OpExtension
@@ -861,6 +867,7 @@ void SPIRVAsmPrinter::outputModuleSections() {
 
 bool SPIRVAsmPrinter::doInitialization(Module &M) {
   ModuleSectionsEmitted = false;
+  MAI = nullptr;
   // We need to call the parent's one explicitly.
   return AsmPrinter::doInitialization(M);
 }

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -29,9 +29,16 @@
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
 
+#include <memory>
+
 using namespace llvm;
 
 #define DEBUG_TYPE "spirv-module-analysis"
+
+namespace {
+DenseMap<const Module *, std::unique_ptr<SPIRV::ModuleAnalysisInfo>>
+    CachedModuleAnalyses;
+} // namespace
 
 static cl::opt<bool>
     SPVDumpDeps("spv-dump-deps",
@@ -2942,6 +2949,16 @@ bool SPIRVModuleAnalysis::runOnModule(Module &M) {
 
   // Set maximum ID used.
   GR->setBound(MAI.MaxID);
+  CachedModuleAnalyses[&M] = std::make_unique<SPIRV::ModuleAnalysisInfo>(MAI);
 
   return false;
+}
+
+SPIRV::ModuleAnalysisInfo *llvm::getCachedSPIRVModuleAnalysis(const Module &M) {
+  auto It = CachedModuleAnalyses.find(&M);
+  return It == CachedModuleAnalyses.end() ? nullptr : It->second.get();
+}
+
+void llvm::clearCachedSPIRVModuleAnalysis(const Module &M) {
+  CachedModuleAnalyses.erase(&M);
 }

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -25,6 +25,7 @@ namespace llvm {
 class SPIRVSubtarget;
 class MachineFunction;
 class MachineModuleInfo;
+class Module;
 
 namespace SPIRV {
 // The enum contains logical module sections for the instruction collection.
@@ -258,5 +259,8 @@ private:
   const SPIRVInstrInfo *TII;
   MachineModuleInfo *MMI;
 };
+
+SPIRV::ModuleAnalysisInfo *getCachedSPIRVModuleAnalysis(const Module &M);
+void clearCachedSPIRVModuleAnalysis(const Module &M);
 } // namespace llvm
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVMODULEANALYSIS_H

--- a/mlir/test/Conversion/MathToXeVM/declaration-only-kernels.mlir
+++ b/mlir/test/Conversion/MathToXeVM/declaration-only-kernels.mlir
@@ -1,0 +1,18 @@
+// RUN: mlir-opt %s --gpu-lower-to-xevm-pipeline="binary-format=assembly" | FileCheck %s
+
+module attributes {gpu.container_module} {
+  // CHECK-LABEL: module attributes {gpu.container_module} {
+  // CHECK: gpu.binary @kernels
+  // CHECK-NOT: gpu.module @kernels
+  gpu.module @kernels {
+    func.func private @__hipblaslt_init_kernel(
+        %arg0: memref<?xf32, 1>, %arg1: index, %arg2: index, %arg3: index,
+        %arg4: index, %arg5: index) attributes {gpu.kernel}
+    func.func private @__hipblaslt_init_small_kernel(
+        %arg0: memref<?xf32, 1>, %arg1: index, %arg2: index, %arg3: index,
+        %arg4: index, %arg5: index) attributes {gpu.kernel}
+    func.func private @__hipblaslt_init_nan_tri_kernel(
+        %arg0: memref<?xf32, 1>, %arg1: index, %arg2: index, %arg3: index,
+        %arg4: index, %arg5: index, %arg6: i1) attributes {gpu.kernel}
+  }
+}

--- a/mlir/test/Conversion/MathToXeVM/lit.local.cfg
+++ b/mlir/test/Conversion/MathToXeVM/lit.local.cfg
@@ -1,5 +1,6 @@
 spirv_backend_tests = [
     'native-spirv-builtins.mlir',
+    'declaration-only-kernels.mlir',
 ]
  
 # Exclude SPIRV backend tests if SPIRV target is disabled: 


### PR DESCRIPTION
## Summary

Fix a crash in the XeVM SPIR-V lowering path when a `gpu.module` contains only declaration-only kernels.

This happens because `SPIRVAsmPrinter` may need to emit module-level sections in `emitEndOfAsmFile()`, but at that point `SPIRVModuleAnalysis` is not always available through the normal pass lookup path. For declaration-only kernels, that leaves the printer without the module analysis it still needs.

This change preserves the computed `SPIRVModuleAnalysis` for the lifetime of the module and lets `SPIRVAsmPrinter` fall back to that cached analysis when necessary.

Closes #186729.

## Problem

The XeVM lowering pipeline can reach the SPIR-V backend with GPU kernels that are declarations only. In that case, no function body emission happens, but the backend still needs to emit module-level SPIR-V sections at end-of-file.

Before this patch, `SPIRVAsmPrinter::outputModuleSections()` relied on retrieving `SPIRVModuleAnalysis` directly from the pass manager. That works during the usual function emission flow, but it is not reliable in the declaration-only case when module sections are emitted later from `emitEndOfAsmFile()`.

The result is a crash/assert because the printer still needs `ModuleAnalysisInfo`, but no longer has a valid way to retrieve it.

## Fix

The fix is deliberately small:

- Cache a copy of `SPIRVModuleAnalysis::MAI` after `SPIRVModuleAnalysis::runOnModule()`.
- In `SPIRVAsmPrinter`, prefer the live analysis when it is available.
- If the live analysis is not available, fall back to the cached module analysis.
- Clear the cached analysis during printer cleanup so the cache does not outlive the module unnecessarily.

This keeps the existing flow intact for normal cases and only changes behavior for the path that previously lost access to the analysis.

## Tests

Added a regression test covering a `gpu.module` with declaration-only kernels:

- [declaration-only-kernels.mlir](/Users/aviralgarg/Everything/llvm-project/mlir/test/Conversion/MathToXeVM/declaration-only-kernels.mlir)

The test runs the XeVM lowering pipeline with `binary-format=assembly` so it exercises the LLVM SPIR-V backend directly and does not depend on `ocloc` being present.

Also updated:

- [lit.local.cfg](/Users/aviralgarg/Everything/llvm-project/mlir/test/Conversion/MathToXeVM/lit.local.cfg)

## Verification

Ran:

```bash
ninja -C /tmp/llvm-build-186729 mlir-opt FileCheck not count
```

```bash
/tmp/llvm-build-186729/bin/mlir-opt \
  mlir/test/Conversion/MathToXeVM/declaration-only-kernels.mlir \
  --gpu-lower-to-xevm-pipeline='binary-format=assembly' \
  | /tmp/llvm-build-186729/bin/FileCheck \
  mlir/test/Conversion/MathToXeVM/declaration-only-kernels.mlir
```

The direct reproducer above was run three times.

Ran lit coverage:

```bash
/tmp/llvm-build-186729/bin/llvm-lit -sv \
  mlir/test/Conversion/MathToXeVM/declaration-only-kernels.mlir
```

```bash
/tmp/llvm-build-186729/bin/llvm-lit -sv \
  mlir/test/Conversion/MathToXeVM/native-spirv-builtins.mlir
```

```bash
/tmp/llvm-build-186729/bin/llvm-lit -sv \
  mlir/test/Conversion/MathToXeVM
```

Checked formatting / whitespace:

```bash
git diff --check
```

## Notes

This patch only touches the SPIR-V backend pieces needed to preserve module analysis and the minimal MLIR regression coverage for the XeVM path. It does not change unrelated pipeline behavior.