### PR TITLE
[HLSL] Add TableGen-generated header files to the HLSL distribution

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -809,6 +809,12 @@ install(
   COMPONENT hlsl-resource-headers)
 
 install(
+  FILES ${hlsl_generated_files}
+  DESTINATION ${header_install_dir}/hlsl
+  ${EXCLUDE_HLSL}
+  COMPONENT hlsl-resource-headers)
+
+install(
   FILES ${spirv_files}
   DESTINATION ${header_install_dir}
   EXCLUDE_FROM_ALL


### PR DESCRIPTION
This PR adds the TableGen-generated headers from https://github.com/llvm/llvm-project/pull/187610 to the HLSL distribution.

Currently the HLSL distribution is incomplete due to missing these generated headers, preventing successful compilation:
```
Command Output (stderr):
--
In file included from <built-in>:1:

In file included from D:\a\_work\1\ClangHLSL\Binaries\lib\clang\23\include\hlsl.h:24:

D:\a\_work\1\ClangHLSL\Binaries\lib\clang\23\include\hlsl/hlsl_alias_intrinsics.h:42:10: fatal error: 'hlsl_alias_intrinsics_gen.inc' file not found

   42 | #include "hlsl_alias_intrinsics_gen.inc"

      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

1 error generated.
```
This PR fixes the error by including `hlsl_alias_intrinsics_gen.inc` and `hlsl_inline_intrinsics_gen.inc` in the HLSL distribution.