### PR TITLE
[CMake] Extract Mach-O version helper

### DIFF
--- a/clang/tools/libclang/CMakeLists.txt
+++ b/clang/tools/libclang/CMakeLists.txt
@@ -170,11 +170,7 @@ if(ENABLE_SHARED)
       # implicitly be exported from libclang.
       target_compile_definitions(libclang PRIVATE CLANG_BUILD_STATIC)
   elseif(APPLE)
-    set(LIBCLANG_LINK_FLAGS " -Wl,-compatibility_version -Wl,1")
-    set(LIBCLANG_LINK_FLAGS "${LIBCLANG_LINK_FLAGS} -Wl,-current_version -Wl,${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
-
-    set_property(TARGET libclang APPEND_STRING PROPERTY
-                 LINK_FLAGS ${LIBCLANG_LINK_FLAGS})
+    llvm_set_macho_current_version(libclang ${LLVM_VERSION_MAJOR})
   else()
     set_target_properties(libclang
       PROPERTIES

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -246,6 +246,13 @@ function(add_llvm_symbol_exports target_name export_file)
   set(LLVM_COMMON_DEPENDS ${LLVM_COMMON_DEPENDS} PARENT_SCOPE)
 endfunction(add_llvm_symbol_exports)
 
+function(llvm_set_macho_current_version target major)
+  set_target_properties(${target} PROPERTIES
+    MACHO_COMPATIBILITY_VERSION 1
+    MACHO_CURRENT_VERSION
+      ${major}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH})
+endfunction()
+
 if (NOT DEFINED LLVM_LINKER_DETECTED AND NOT WIN32)
   # Detect what linker we have here.
   if(APPLE)

--- a/llvm/tools/llvm-shlib/CMakeLists.txt
+++ b/llvm/tools/llvm-shlib/CMakeLists.txt
@@ -96,9 +96,7 @@ if(LLVM_BUILD_LLVM_DYLIB)
   endif()
 
   if (APPLE)
-    set_property(TARGET LLVM APPEND_STRING PROPERTY
-                LINK_FLAGS
-                " -compatibility_version 1 -current_version ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
+    llvm_set_macho_current_version(LLVM ${LLVM_VERSION_MAJOR})
   endif()
 
   if(TARGET libLLVMExports)
@@ -140,9 +138,10 @@ if(LLVM_BUILD_LLVM_C_DYLIB AND NOT MSVC)
   target_link_libraries(LLVM-C PUBLIC LLVM)
   add_dependencies(LLVM-C libLLVMCExports)
 
+  llvm_set_macho_current_version(LLVM-C ${LLVM_VERSION_MAJOR})
   set_property(TARGET LLVM-C APPEND_STRING PROPERTY
               LINK_FLAGS
-              " -compatibility_version 1 -current_version ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH} -Wl,-reexport_library ${LIB_PATH}")
+              " -Wl,-reexport_library ${LIB_PATH}")
 endif()
 
 if(LLVM_BUILD_LLVM_C_DYLIB AND MSVC)

--- a/llvm/tools/lto/CMakeLists.txt
+++ b/llvm/tools/lto/CMakeLists.txt
@@ -45,9 +45,7 @@ if(LLVM_ENABLE_PIC)
     if(LLVM_LTO_VERSION_OFFSET)
       math(EXPR LTO_VERSION "${LLVM_VERSION_MAJOR} + ${LLVM_LTO_VERSION_OFFSET}")
     endif()
-    set_property(TARGET LTO APPEND_STRING PROPERTY
-                LINK_FLAGS
-                " -compatibility_version 1 -current_version ${LTO_VERSION}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
+    llvm_set_macho_current_version(LTO ${LTO_VERSION})
     if(LLVM_USE_SANITIZER)
       execute_process(COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=lib
                       OUTPUT_VARIABLE clang_lib_dir)

--- a/llvm/tools/remarks-shlib/CMakeLists.txt
+++ b/llvm/tools/remarks-shlib/CMakeLists.txt
@@ -25,10 +25,7 @@ if(LLVM_ENABLE_PIC)
     COMPONENT Remarks)
 
   if (APPLE)
-    set(REMARKS_VERSION ${LLVM_VERSION_MAJOR})
-    set_property(TARGET Remarks APPEND_STRING PROPERTY
-                 LINK_FLAGS
-                 " -compatibility_version 1 -current_version ${REMARKS_VERSION}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
+    llvm_set_macho_current_version(Remarks ${LLVM_VERSION_MAJOR})
   endif()
 
 endif()


### PR DESCRIPTION
Use CMake's native MACHO_COMPATIBILITY_VERSION and MACHO_CURRENT_VERSION
properties rather than manually pass linker flags. These properties are
available since CMake 3.17.0, released in 2020.