### PR TITLE
[DA] Fix warning introduced by #189740

### DIFF
--- a/llvm/lib/Analysis/DependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/DependenceAnalysis.cpp
@@ -2000,7 +2000,7 @@ bool DependenceInfo::testSIV(const SCEV *Src, const SCEV *Dst, unsigned &Level,
     Level = mapDstLoop(CurDstLoop);
     return weakZeroSrcSIVtest(Src, DstAddRec, Level, Result);
   }
-  assert((SrcAddRec != nullptr || DstAddRec != nullptr ) &&
+  assert((SrcAddRec != nullptr || DstAddRec != nullptr) &&
          "SIV test expected at least one AddRec");
   return false;
 }

--- a/llvm/lib/Analysis/DependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/DependenceAnalysis.cpp
@@ -2000,8 +2000,8 @@ bool DependenceInfo::testSIV(const SCEV *Src, const SCEV *Dst, unsigned &Level,
     Level = mapDstLoop(CurDstLoop);
     return weakZeroSrcSIVtest(Src, DstAddRec, Level, Result);
   }
-  assert(SrcAddRec != nullptr ||
-         DstAddRec != nullptr && "SIV test expected at least one AddRec");
+  assert((SrcAddRec != nullptr || DstAddRec != nullptr ) &&
+         "SIV test expected at least one AddRec");
   return false;
 }
 


### PR DESCRIPTION
llvm-project/llvm/lib/Analysis/DependenceAnalysis.cpp:2004:31: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
2004 |          DstAddRec != nullptr && "SIV test expected at least one AddRec");