### PR TITLE
DiagnosticInfo: Use Twine for resource name

### DIFF
--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -1369,6 +1369,25 @@ inline const StreamingDiagnostic &operator<<(const StreamingDiagnostic &DB,
 }
 
 inline const StreamingDiagnostic &operator<<(const StreamingDiagnostic &DB,
+                                             const llvm::Twine &S) {
+  DB.AddString(S.str());
+  return DB;
+}
+
+inline const StreamingDiagnostic &operator<<(const StreamingDiagnostic &DB,
+                                             const std::string &S) {
+  DB.AddString(S);
+  return DB;
+}
+
+inline const StreamingDiagnostic &
+operator<<(const StreamingDiagnostic &DB,
+           const llvm::SmallVectorImpl<char> &S) {
+  DB.AddString(llvm::StringRef(S.data(), S.size()));
+  return DB;
+}
+
+inline const StreamingDiagnostic &operator<<(const StreamingDiagnostic &DB,
                                              const char *Str) {
   DB.AddTaggedVal(reinterpret_cast<intptr_t>(Str),
                   DiagnosticsEngine::ak_c_string);

--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -469,7 +469,7 @@ private:
   const Function &Fn;
 
   /// Description of the resource type (e.g. stack size)
-  const char *ResourceName;
+  const Twine &ResourceName;
 
   /// The computed size usage
   uint64_t ResourceSize;
@@ -480,13 +480,13 @@ private:
 public:
   /// \p The function that is concerned by this stack size diagnostic.
   /// \p The computed stack size.
-  DiagnosticInfoResourceLimit(const Function &Fn, const char *ResourceName,
+  DiagnosticInfoResourceLimit(const Function &Fn, const Twine &ResourceName,
                               uint64_t ResourceSize, uint64_t ResourceLimit,
                               DiagnosticSeverity Severity = DS_Warning,
                               DiagnosticKind Kind = DK_ResourceLimit);
 
   const Function &getFunction() const { return Fn; }
-  const char *getResourceName() const { return ResourceName; }
+  const Twine &getResourceName() const { return ResourceName; }
   uint64_t getResourceSize() const { return ResourceSize; }
   uint64_t getResourceLimit() const { return ResourceLimit; }
 

--- a/llvm/lib/IR/DiagnosticInfo.cpp
+++ b/llvm/lib/IR/DiagnosticInfo.cpp
@@ -104,7 +104,7 @@ void DiagnosticInfoRegAllocFailure::print(DiagnosticPrinter &DP) const {
 }
 
 DiagnosticInfoResourceLimit::DiagnosticInfoResourceLimit(
-    const Function &Fn, const char *ResourceName, uint64_t ResourceSize,
+    const Function &Fn, const Twine &ResourceName, uint64_t ResourceSize,
     uint64_t ResourceLimit, DiagnosticSeverity Severity, DiagnosticKind Kind)
     : DiagnosticInfoWithLocationBase(Kind, Severity, Fn, Fn.getSubprogram()),
       Fn(Fn), ResourceName(ResourceName), ResourceSize(ResourceSize),


### PR DESCRIPTION
Allow more flexibility in phrasing of the overallocated
resource.