### PR TITLE
[InstCombine] Use ComputeNumSignBits in isKnownExactCastIntToFP

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -2039,15 +2039,23 @@ static bool isKnownExactCastIntToFP(CastInst &I, InstCombinerImpl &IC) {
       return true;
   }
 
-  // TODO:
   // Try harder to find if the source integer type has less significant bits.
-  // For example, compute number of sign bits.
+  // Compute number of sign bits or determine trailing zeros.
   KnownBits SrcKnown = IC.computeKnownBits(Src, &I);
   int SigBits = (int)SrcTy->getScalarSizeInBits() -
                 SrcKnown.countMinLeadingZeros() -
                 SrcKnown.countMinTrailingZeros();
   if (SigBits <= DestNumSigBits)
     return true;
+
+  // For sitofp, the sign maps to the FP sign bit, so only magnitude bits
+  // (BitWidth - NumSignBits) consume mantissa.
+  if (IsSigned) {
+    SigBits =
+        (int)SrcTy->getScalarSizeInBits() - IC.ComputeNumSignBits(Src, &I);
+    if (SigBits <= DestNumSigBits)
+      return true;
+  }
 
   return false;
 }

--- a/llvm/test/Transforms/InstCombine/fpcast.ll
+++ b/llvm/test/Transforms/InstCombine/fpcast.ll
@@ -555,9 +555,7 @@ entry:
 define i32 @signbits_sitofp_fptosi_roundtrip(i32 %x) {
 ; CHECK-LABEL: @signbits_sitofp_fptosi_roundtrip(
 ; CHECK-NEXT:    [[M:%.*]] = ashr i32 [[X:%.*]], 7
-; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[M]] to float
-; CHECK-NEXT:    [[R:%.*]] = fptosi float [[F]] to i32
-; CHECK-NEXT:    ret i32 [[R]]
+; CHECK-NEXT:    ret i32 [[M]]
 ;
   %m = ashr i32 %x, 7
   %f = sitofp i32 %m to float
@@ -568,9 +566,7 @@ define i32 @signbits_sitofp_fptosi_roundtrip(i32 %x) {
 define <4 x i32> @signbits_sitofp_fptosi_roundtrip_vec(<4 x i32> %x) {
 ; CHECK-LABEL: @signbits_sitofp_fptosi_roundtrip_vec(
 ; CHECK-NEXT:    [[M:%.*]] = ashr <4 x i32> [[X:%.*]], splat (i32 7)
-; CHECK-NEXT:    [[F:%.*]] = sitofp <4 x i32> [[M]] to <4 x float>
-; CHECK-NEXT:    [[R:%.*]] = fptosi <4 x float> [[F]] to <4 x i32>
-; CHECK-NEXT:    ret <4 x i32> [[R]]
+; CHECK-NEXT:    ret <4 x i32> [[M]]
 ;
   %m = ashr <4 x i32> %x, splat (i32 7)
   %f = sitofp <4 x i32> %m to <4 x float>

--- a/llvm/test/Transforms/InstCombine/fpcast.ll
+++ b/llvm/test/Transforms/InstCombine/fpcast.ll
@@ -551,3 +551,43 @@ entry:
   %conv = fptosi float %ret to i32
   ret i32 %conv
 }
+
+define i32 @signbits_sitofp_fptosi_roundtrip(i32 %x) {
+; CHECK-LABEL: @signbits_sitofp_fptosi_roundtrip(
+; CHECK-NEXT:    [[M:%.*]] = ashr i32 [[X:%.*]], 7
+; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[M]] to float
+; CHECK-NEXT:    [[R:%.*]] = fptosi float [[F]] to i32
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %m = ashr i32 %x, 7
+  %f = sitofp i32 %m to float
+  %r = fptosi float %f to i32
+  ret i32 %r
+}
+
+define <4 x i32> @signbits_sitofp_fptosi_roundtrip_vec(<4 x i32> %x) {
+; CHECK-LABEL: @signbits_sitofp_fptosi_roundtrip_vec(
+; CHECK-NEXT:    [[M:%.*]] = ashr <4 x i32> [[X:%.*]], splat (i32 7)
+; CHECK-NEXT:    [[F:%.*]] = sitofp <4 x i32> [[M]] to <4 x float>
+; CHECK-NEXT:    [[R:%.*]] = fptosi <4 x float> [[F]] to <4 x i32>
+; CHECK-NEXT:    ret <4 x i32> [[R]]
+;
+  %m = ashr <4 x i32> %x, splat (i32 7)
+  %f = sitofp <4 x i32> %m to <4 x float>
+  %r = fptosi <4 x float> %f to <4 x i32>
+  ret <4 x i32> %r
+}
+
+; Negative: 26 significant bits, 25 mantissa > 24.
+define i32 @signbits_sitofp_fptosi_roundtrip_neg(i32 %x) {
+; CHECK-LABEL: @signbits_sitofp_fptosi_roundtrip_neg(
+; CHECK-NEXT:    [[M:%.*]] = ashr i32 [[X:%.*]], 6
+; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[M]] to float
+; CHECK-NEXT:    [[R:%.*]] = fptosi float [[F]] to i32
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %m = ashr i32 %x, 6
+  %f = sitofp i32 %m to float
+  %r = fptosi float %f to i32
+  ret i32 %r
+}


### PR DESCRIPTION
For signed int-to-FP casts, ComputeNumSignBits can prove exactness where computeKnownBits
cannot -- e.g. through ashr(shl x, a), b where sign propagation is tracked precisely but
individual known bits are all unknown.
