### PR TITLE
[AMDGPU][GlobalISel] Improve combining on v_ldexp

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUCombine.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombine.td
@@ -232,9 +232,18 @@ def AMDGPUPostLegalizerCombiner: GICombiner<
   let CombineAllMethodName = "tryCombineAllImpl";
 }
 
+// Like combine_fmul_with_select_to_fldexp but with VGPR detection for RegBankCombiner.
+def combine_fmul_select_to_fldexp_regbank : GICombineRule<
+  (defs root:$root, build_fn_matchinfo:$matchinfo),
+  (match  (G_FMUL $dst, $x, $select):$root,
+          (G_SELECT $select, $y, $A, $B):$sel,
+          [{ return matchFmulSelectToFldexpVgpr(*${root}, *${sel}, ${matchinfo}); }]),
+  (apply  [{ Helper.applyBuildFn(*${root}, ${matchinfo}); }])>;
+
 def AMDGPURegBankCombiner : GICombiner<
   "AMDGPURegBankCombinerImpl",
-  [unmerge_merge, unmerge_cst, unmerge_undef,
+  [combine_fmul_select_to_fldexp_regbank,
+   unmerge_merge, unmerge_cst, unmerge_undef,
    zext_trunc_fold, int_minmax_to_med3, ptr_add_immed_chain,
    fp_minmax_to_clamp, fp_minmax_to_med3, fmed3_intrinsic_to_clamp,
    identity_combines, redundant_and, constant_fold_cast_op,

--- a/llvm/lib/Target/AMDGPU/AMDGPUCombine.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombine.td
@@ -140,6 +140,16 @@ def combine_fmul_with_select_to_fldexp : GICombineRule<
           [{ return Helper.matchCombineFmulWithSelectToFldexp(*${root}, *${sel}, ${matchinfo}); }]),
   (apply  [{ Helper.applyBuildFn(*${root}, ${matchinfo}); }])>;
 
+// Like combine_fmul_with_select_to_fldexp but with VGPR detection for RegBankCombiner.
+// Note that the combine for s64, s32, and s16 would not trigger under the combine_fmul_with_select_to_fldexp
+// in the pre/post legalizer (it is only gating s{64,32,16} with SALU for the regcombiner).
+def combine_fmul_select_to_fldexp_regbank : GICombineRule<
+  (defs root:$root, build_fn_matchinfo:$matchinfo),
+  (match  (G_FMUL $dst, $x, $select):$root,
+          (G_SELECT $select, $y, $A, $B):$sel,
+          [{ return matchFmulSelectToFldexpVgpr(*${root}, *${sel}, ${matchinfo}); }]),
+  (apply  [{ Helper.applyBuildFn(*${root}, ${matchinfo}); }])>;
+
 // (shift x, (zext amt)) -> (shift x, (and (anyext amt), mask)
 //
 // The pattern is longer, but is better for matching during ISel.
@@ -231,14 +241,6 @@ def AMDGPUPostLegalizerCombiner: GICombiner<
    binop_s64_with_s32_mask_combines, combine_or_s64_s32]> {
   let CombineAllMethodName = "tryCombineAllImpl";
 }
-
-// Like combine_fmul_with_select_to_fldexp but with VGPR detection for RegBankCombiner.
-def combine_fmul_select_to_fldexp_regbank : GICombineRule<
-  (defs root:$root, build_fn_matchinfo:$matchinfo),
-  (match  (G_FMUL $dst, $x, $select):$root,
-          (G_SELECT $select, $y, $A, $B):$sel,
-          [{ return matchFmulSelectToFldexpVgpr(*${root}, *${sel}, ${matchinfo}); }]),
-  (apply  [{ Helper.applyBuildFn(*${root}, ${matchinfo}); }])>;
 
 def AMDGPURegBankCombiner : GICombiner<
   "AMDGPURegBankCombinerImpl",

--- a/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
@@ -452,9 +452,10 @@ void AMDGPUCombinerHelper::applyExpandPromotedF16FMed3(MachineInstr &MI,
   MI.eraseFromParent();
 }
 
-bool AMDGPUCombinerHelper::matchCombineFmulWithSelectToFldexp(
+bool llvm::matchFmulWithSelectToFldexpImpl(
     MachineInstr &MI, MachineInstr &Sel,
-    std::function<void(MachineIRBuilder &)> &MatchInfo) const {
+    std::function<void(MachineIRBuilder &)> &MatchInfo,
+    const MachineRegisterInfo &MRI, const SIInstrInfo &TII) {
   assert(MI.getOpcode() == TargetOpcode::G_FMUL);
   assert(Sel.getOpcode() == TargetOpcode::G_SELECT);
   assert(MI.getOperand(2).getReg() == Sel.getOperand(0).getReg());
@@ -470,8 +471,11 @@ bool AMDGPUCombinerHelper::matchCombineFmulWithSelectToFldexp(
     return false;
 
   Register SelectCondReg = Sel.getOperand(1).getReg();
-  MachineInstr *SelectTrue = MRI.getVRegDef(Sel.getOperand(2).getReg());
-  MachineInstr *SelectFalse = MRI.getVRegDef(Sel.getOperand(3).getReg());
+  Register SelectTrueReg = Sel.getOperand(2).getReg();
+  Register SelectFalseReg = Sel.getOperand(3).getReg();
+  // Look through copies (needed in RegBankCombiner where regbank copies exist).
+  MachineInstr *SelectTrue = getDefIgnoringCopies(SelectTrueReg, MRI);
+  MachineInstr *SelectFalse = getDefIgnoringCopies(SelectFalseReg, MRI);
 
   const auto SelectTrueVal =
       isConstantOrConstantSplatVectorFP(*SelectTrue, MRI);
@@ -498,7 +502,7 @@ bool AMDGPUCombinerHelper::matchCombineFmulWithSelectToFldexp(
   if (SelectFalseLog2Val == INT_MIN)
     return false;
 
-  MatchInfo = [=, &MI](MachineIRBuilder &Builder) {
+  MatchInfo = [=, &MI, &MRI](MachineIRBuilder &Builder) {
     LLT IntDestTy = DestTy.changeElementType(LLT::scalar(32));
     auto NewSel = Builder.buildSelect(
         IntDestTy, SelectCondReg,
@@ -516,6 +520,22 @@ bool AMDGPUCombinerHelper::matchCombineFmulWithSelectToFldexp(
   };
 
   return true;
+}
+
+bool AMDGPUCombinerHelper::matchCombineFmulWithSelectToFldexp(
+    MachineInstr &MI, MachineInstr &Sel,
+    std::function<void(MachineIRBuilder &)> &MatchInfo) const {
+  Register Dst = MI.getOperand(0).getReg();
+  LLT ScalarDestTy = MRI.getType(Dst).getScalarType();
+
+  // fldexp has no SALU form. On targets with SALU float, defer this combine
+  // to the RegBankCombiner where register banks are known and we can limit it
+  // to VGPR (divergent) values only.
+  if (STI.hasSALUFloatInsts() &&
+      (ScalarDestTy == LLT::scalar(32) || ScalarDestTy == LLT::scalar(16)))
+    return false;
+
+  return matchFmulWithSelectToFldexpImpl(MI, Sel, MatchInfo, MRI, TII);
 }
 
 bool AMDGPUCombinerHelper::matchConstantIs32BitMask(Register Reg) const {

--- a/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
@@ -509,10 +509,22 @@ bool llvm::matchFmulWithSelectToFldexpImpl(
         Builder.buildConstant(IntDestTy, SelectTrueLog2Val),
         Builder.buildConstant(IntDestTy, SelectFalseLog2Val));
 
+    const auto *RegBank = MRI.getRegBankOrNull(Dst);
+    if (RegBank) {
+      auto &MutMRI = Builder.getMF().getRegInfo();
+      MutMRI.setRegBank(NewSel.getReg(0), *RegBank);
+      MutMRI.setRegBank(NewSel->getOperand(2).getReg(), *RegBank);
+      MutMRI.setRegBank(NewSel->getOperand(3).getReg(), *RegBank);
+    }
+
     Register XReg = MI.getOperand(1).getReg();
     if (SelectTrueVal->isNegative()) {
       auto NegX =
           Builder.buildFNeg(DestTy, XReg, MRI.getVRegDef(XReg)->getFlags());
+      if (RegBank) {
+        auto &MutMRI = Builder.getMF().getRegInfo();
+        MutMRI.setRegBank(NegX.getReg(0), *RegBank);
+      }
       Builder.buildFLdexp(Dst, NegX, NewSel, MI.getFlags());
     } else {
       Builder.buildFLdexp(Dst, XReg, NewSel, MI.getFlags());
@@ -531,9 +543,7 @@ bool AMDGPUCombinerHelper::matchCombineFmulWithSelectToFldexp(
   // fldexp has no SALU form. On targets with SALU float, defer this combine
   // to the RegBankCombiner where register banks are known and we can limit it
   // to VGPR (divergent) values only.
-  if (STI.hasSALUFloatInsts() &&
-      (ScalarDestTy == LLT::scalar(64) || ScalarDestTy == LLT::scalar(32) ||
-       ScalarDestTy == LLT::scalar(16)))
+  if (STI.hasSALUFloatInsts() && ScalarDestTy == LLT::scalar(32))
     return false;
 
   return matchFmulWithSelectToFldexpImpl(MI, Sel, MatchInfo, MRI, TII);

--- a/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
@@ -532,7 +532,8 @@ bool AMDGPUCombinerHelper::matchCombineFmulWithSelectToFldexp(
   // to the RegBankCombiner where register banks are known and we can limit it
   // to VGPR (divergent) values only.
   if (STI.hasSALUFloatInsts() &&
-      (ScalarDestTy == LLT::scalar(32) || ScalarDestTy == LLT::scalar(16)))
+      (ScalarDestTy == LLT::scalar(64) || ScalarDestTy == LLT::scalar(32) ||
+       ScalarDestTy == LLT::scalar(16)))
     return false;
 
   return matchFmulWithSelectToFldexpImpl(MI, Sel, MatchInfo, MRI, TII);

--- a/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.cpp
@@ -455,7 +455,8 @@ void AMDGPUCombinerHelper::applyExpandPromotedF16FMed3(MachineInstr &MI,
 bool llvm::matchFmulWithSelectToFldexpImpl(
     MachineInstr &MI, MachineInstr &Sel,
     std::function<void(MachineIRBuilder &)> &MatchInfo,
-    const MachineRegisterInfo &MRI, const SIInstrInfo &TII) {
+    const MachineRegisterInfo &MRI, const SIInstrInfo &TII, DstOp DestTyOp,
+    DstOp IntDestTyOp) {
   assert(MI.getOpcode() == TargetOpcode::G_FMUL);
   assert(Sel.getOpcode() == TargetOpcode::G_SELECT);
   assert(MI.getOperand(2).getReg() == Sel.getOperand(0).getReg());
@@ -503,28 +504,15 @@ bool llvm::matchFmulWithSelectToFldexpImpl(
     return false;
 
   MatchInfo = [=, &MI, &MRI](MachineIRBuilder &Builder) {
-    LLT IntDestTy = DestTy.changeElementType(LLT::scalar(32));
     auto NewSel = Builder.buildSelect(
-        IntDestTy, SelectCondReg,
-        Builder.buildConstant(IntDestTy, SelectTrueLog2Val),
-        Builder.buildConstant(IntDestTy, SelectFalseLog2Val));
-
-    const auto *RegBank = MRI.getRegBankOrNull(Dst);
-    if (RegBank) {
-      auto &MutMRI = Builder.getMF().getRegInfo();
-      MutMRI.setRegBank(NewSel.getReg(0), *RegBank);
-      MutMRI.setRegBank(NewSel->getOperand(2).getReg(), *RegBank);
-      MutMRI.setRegBank(NewSel->getOperand(3).getReg(), *RegBank);
-    }
+        IntDestTyOp, SelectCondReg,
+        Builder.buildConstant(IntDestTyOp, SelectTrueLog2Val),
+        Builder.buildConstant(IntDestTyOp, SelectFalseLog2Val));
 
     Register XReg = MI.getOperand(1).getReg();
     if (SelectTrueVal->isNegative()) {
       auto NegX =
-          Builder.buildFNeg(DestTy, XReg, MRI.getVRegDef(XReg)->getFlags());
-      if (RegBank) {
-        auto &MutMRI = Builder.getMF().getRegInfo();
-        MutMRI.setRegBank(NegX.getReg(0), *RegBank);
-      }
+          Builder.buildFNeg(DestTyOp, XReg, MRI.getVRegDef(XReg)->getFlags());
       Builder.buildFLdexp(Dst, NegX, NewSel, MI.getFlags());
     } else {
       Builder.buildFLdexp(Dst, XReg, NewSel, MI.getFlags());
@@ -546,7 +534,10 @@ bool AMDGPUCombinerHelper::matchCombineFmulWithSelectToFldexp(
   if (STI.hasSALUFloatInsts() && ScalarDestTy == LLT::scalar(32))
     return false;
 
-  return matchFmulWithSelectToFldexpImpl(MI, Sel, MatchInfo, MRI, TII);
+  LLT DestTy = MRI.getType(Dst);
+  LLT IntDestTy = DestTy.changeElementType(LLT::scalar(32));
+  return matchFmulWithSelectToFldexpImpl(MI, Sel, MatchInfo, MRI, TII, DestTy,
+                                         IntDestTy);
 }
 
 bool AMDGPUCombinerHelper::matchConstantIs32BitMask(Register Reg) const {

--- a/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.h
@@ -47,6 +47,13 @@ public:
   bool matchConstantIs32BitMask(Register Reg) const;
 };
 
+// Shared helper used by both
+// PostLegalizerCombiner and RegBankCombiner 
+bool matchFmulWithSelectToFldexpImpl(
+    MachineInstr &MI, MachineInstr &Sel,
+    std::function<void(MachineIRBuilder &)> &MatchInfo,
+    const MachineRegisterInfo &MRI, const SIInstrInfo &TII);
+
 } // namespace llvm
 
 #endif // LLVM_LIB_TARGET_AMDGPU_AMDGPUCOMBINERHELPER_H

--- a/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.h
@@ -48,7 +48,7 @@ public:
 };
 
 // Shared helper used by both
-// PostLegalizerCombiner and RegBankCombiner 
+// PostLegalizerCombiner and RegBankCombiner
 bool matchFmulWithSelectToFldexpImpl(
     MachineInstr &MI, MachineInstr &Sel,
     std::function<void(MachineIRBuilder &)> &MatchInfo,

--- a/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCombinerHelper.h
@@ -18,6 +18,7 @@
 #include "GCNSubtarget.h"
 #include "llvm/CodeGen/GlobalISel/Combiner.h"
 #include "llvm/CodeGen/GlobalISel/CombinerHelper.h"
+#include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 
 namespace llvm {
 class AMDGPUCombinerHelper : public CombinerHelper {
@@ -52,7 +53,8 @@ public:
 bool matchFmulWithSelectToFldexpImpl(
     MachineInstr &MI, MachineInstr &Sel,
     std::function<void(MachineIRBuilder &)> &MatchInfo,
-    const MachineRegisterInfo &MRI, const SIInstrInfo &TII);
+    const MachineRegisterInfo &MRI, const SIInstrInfo &TII, DstOp DestTyOp,
+    DstOp IntDestTyOp);
 
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankCombiner.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankCombiner.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AMDGPU.h"
+#include "AMDGPUCombinerHelper.h"
 #include "AMDGPULegalizerInfo.h"
 #include "AMDGPURegisterBankInfo.h"
 #include "GCNSubtarget.h"
@@ -89,6 +90,10 @@ public:
 
   void applyCanonicalizeZextShiftAmt(MachineInstr &MI, MachineInstr &Ext) const;
 
+  bool matchFmulSelectToFldexpVgpr(
+      MachineInstr &MI, MachineInstr &Sel,
+      std::function<void(MachineIRBuilder &)> &MatchInfo) const;
+
   bool combineD16Load(MachineInstr &MI) const;
   bool applyD16Load(unsigned D16Opc, MachineInstr &DstMI,
                     MachineInstr *SmallLoad, Register ToOverwriteD16) const;
@@ -148,6 +153,18 @@ Register AMDGPURegBankCombinerImpl::getAsVgpr(Register Reg) const {
   Register VgprReg = B.buildCopy(MRI.getType(Reg), Reg).getReg(0);
   MRI.setRegBank(VgprReg, RBI.getRegBank(AMDGPU::VGPRRegBankID));
   return VgprReg;
+}
+
+bool AMDGPURegBankCombinerImpl::matchFmulSelectToFldexpVgpr(
+    MachineInstr &MI, MachineInstr &Sel,
+    std::function<void(MachineIRBuilder &)> &MatchInfo) const {
+  // Only combine for VGPR (divergent) operands. SGPR operands benefit from
+  // keeping fmul which has an SALU form (S_FMUL), while fldexp does not.
+  Register Dst = MI.getOperand(0).getReg();
+  if (!isVgprRegBank(Dst))
+    return false;
+
+  return matchFmulWithSelectToFldexpImpl(MI, Sel, MatchInfo, MRI, TII);
 }
 
 AMDGPURegBankCombinerImpl::MinMaxMedOpc

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankCombiner.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankCombiner.cpp
@@ -164,7 +164,11 @@ bool AMDGPURegBankCombinerImpl::matchFmulSelectToFldexpVgpr(
   if (!isVgprRegBank(Dst))
     return false;
 
-  return matchFmulWithSelectToFldexpImpl(MI, Sel, MatchInfo, MRI, TII);
+  const RegisterBank *RB = MRI.getRegBankOrNull(Dst);
+  LLT DestTy = MRI.getType(Dst);
+  LLT IntDestTy = DestTy.changeElementType(LLT::scalar(32));
+  return matchFmulWithSelectToFldexpImpl(
+      MI, Sel, MatchInfo, MRI, TII, DstOp(RB, DestTy), DstOp(RB, IntDestTy));
 }
 
 AMDGPURegBankCombinerImpl::MinMaxMedOpc

--- a/llvm/test/CodeGen/AMDGPU/pseudo-scalar-transcendental.ll
+++ b/llvm/test/CodeGen/AMDGPU/pseudo-scalar-transcendental.ll
@@ -2,34 +2,20 @@
 ; RUN: llc -global-isel=0 -mtriple=amdgcn -mcpu=gfx1200 < %s | FileCheck -check-prefixes=GFX12,GFX12-SDAG %s
 ; RUN: llc -global-isel=1 -mtriple=amdgcn -mcpu=gfx1200 < %s | FileCheck -check-prefixes=GFX12,GFX12-GISEL %s
 
-; TODO: GlobalISel should avoid generating v_ldexp_f32.
 define amdgpu_cs float @v_s_exp_f32(float inreg %src) {
-; GFX12-SDAG-LABEL: v_s_exp_f32:
-; GFX12-SDAG:       ; %bb.0:
-; GFX12-SDAG-NEXT:    s_cmp_lt_f32 s0, 0xc2fc0000
-; GFX12-SDAG-NEXT:    s_cselect_b32 s1, 0x42800000, 0
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_2)
-; GFX12-SDAG-NEXT:    s_add_f32 s0, s0, s1
-; GFX12-SDAG-NEXT:    s_cselect_b32 s1, 0x1f800000, 1.0
-; GFX12-SDAG-NEXT:    v_s_exp_f32 s0, s0
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_2)
-; GFX12-SDAG-NEXT:    s_mul_f32 s0, s0, s1
-; GFX12-SDAG-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v0, s0
-; GFX12-SDAG-NEXT:    ; return to shader part epilog
-;
-; GFX12-GISEL-LABEL: v_s_exp_f32:
-; GFX12-GISEL:       ; %bb.0:
-; GFX12-GISEL-NEXT:    s_cmp_lt_f32 s0, 0xc2fc0000
-; GFX12-GISEL-NEXT:    s_cselect_b32 s1, 0x42800000, 0
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_2)
-; GFX12-GISEL-NEXT:    s_add_f32 s0, s0, s1
-; GFX12-GISEL-NEXT:    s_cselect_b32 s1, 0xffffffc0, 0
-; GFX12-GISEL-NEXT:    v_s_exp_f32 s0, s0
-; GFX12-GISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
-; GFX12-GISEL-NEXT:    v_ldexp_f32 v0, s0, s1
-; GFX12-GISEL-NEXT:    ; return to shader part epilog
+; GFX12-LABEL: v_s_exp_f32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_cmp_lt_f32 s0, 0xc2fc0000
+; GFX12-NEXT:    s_cselect_b32 s1, 0x42800000, 0
+; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_2)
+; GFX12-NEXT:    s_add_f32 s0, s0, s1
+; GFX12-NEXT:    s_cselect_b32 s1, 0x1f800000, 1.0
+; GFX12-NEXT:    v_s_exp_f32 s0, s0
+; GFX12-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_2)
+; GFX12-NEXT:    s_mul_f32 s0, s0, s1
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    ; return to shader part epilog
   %result = call float @llvm.exp2.f32(float %src)
   ret float %result
 }
@@ -71,34 +57,19 @@ define amdgpu_cs half @v_s_amdgcn_exp_f16(half inreg %src) {
 }
 
 define amdgpu_cs float @v_s_log_f32(float inreg %src) {
-; GFX12-SDAG-LABEL: v_s_log_f32:
-; GFX12-SDAG:       ; %bb.0:
-; GFX12-SDAG-NEXT:    s_cmp_lt_f32 s0, 0x800000
-; GFX12-SDAG-NEXT:    s_cselect_b32 s1, 0x4f800000, 1.0
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_2)
-; GFX12-SDAG-NEXT:    s_mul_f32 s0, s0, s1
-; GFX12-SDAG-NEXT:    s_cselect_b32 s1, 0x42000000, 0
-; GFX12-SDAG-NEXT:    v_s_log_f32 s0, s0
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_2)
-; GFX12-SDAG-NEXT:    s_sub_f32 s0, s0, s1
-; GFX12-SDAG-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v0, s0
-; GFX12-SDAG-NEXT:    ; return to shader part epilog
-;
-; GFX12-GISEL-LABEL: v_s_log_f32:
-; GFX12-GISEL:       ; %bb.0:
-; GFX12-GISEL-NEXT:    s_cmp_lt_f32 s0, 0x800000
-; GFX12-GISEL-NEXT:    s_cselect_b32 s1, 1, 0
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
-; GFX12-GISEL-NEXT:    s_lshl_b32 s2, s1, 5
-; GFX12-GISEL-NEXT:    s_cmp_lg_u32 s1, 0
-; GFX12-GISEL-NEXT:    v_ldexp_f32 v0, s0, s2
-; GFX12-GISEL-NEXT:    s_cselect_b32 s0, 0x42000000, 0
-; GFX12-GISEL-NEXT:    v_log_f32_e32 v0, v0
-; GFX12-GISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
-; GFX12-GISEL-NEXT:    v_subrev_f32_e32 v0, s0, v0
-; GFX12-GISEL-NEXT:    ; return to shader part epilog
+; GFX12-LABEL: v_s_log_f32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_cmp_lt_f32 s0, 0x800000
+; GFX12-NEXT:    s_cselect_b32 s1, 0x4f800000, 1.0
+; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_2)
+; GFX12-NEXT:    s_mul_f32 s0, s0, s1
+; GFX12-NEXT:    s_cselect_b32 s1, 0x42000000, 0
+; GFX12-NEXT:    v_s_log_f32 s0, s0
+; GFX12-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_2)
+; GFX12-NEXT:    s_sub_f32 s0, s0, s1
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    ; return to shader part epilog
   %result = call float @llvm.log2.f32(float %src)
   ret float %result
 }
@@ -312,37 +283,21 @@ define amdgpu_cs half @v_amdgcn_sqrt_f16(half inreg %src)  {
 }
 
 define amdgpu_cs float @srcmods_abs_f32(float inreg %src) {
-; GFX12-SDAG-LABEL: srcmods_abs_f32:
-; GFX12-SDAG:       ; %bb.0:
-; GFX12-SDAG-NEXT:    s_bitset0_b32 s0, 31
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX12-SDAG-NEXT:    s_cmp_lt_f32 s0, 0x800000
-; GFX12-SDAG-NEXT:    s_cselect_b32 s1, 0x4f800000, 1.0
-; GFX12-SDAG-NEXT:    s_mul_f32 s0, s0, s1
-; GFX12-SDAG-NEXT:    s_cselect_b32 s1, 0x42000000, 0
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_2) | instskip(NEXT) | instid1(TRANS32_DEP_1)
-; GFX12-SDAG-NEXT:    v_s_log_f32 s0, s0
-; GFX12-SDAG-NEXT:    s_sub_f32 s0, s0, s1
-; GFX12-SDAG-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_2)
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v0, s0
-; GFX12-SDAG-NEXT:    ; return to shader part epilog
-;
-; GFX12-GISEL-LABEL: srcmods_abs_f32:
-; GFX12-GISEL:       ; %bb.0:
-; GFX12-GISEL-NEXT:    s_and_b32 s1, s0, 0x7fffffff
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX12-GISEL-NEXT:    s_cmp_lt_f32 s1, 0x800000
-; GFX12-GISEL-NEXT:    s_cselect_b32 s1, 1, 0
-; GFX12-GISEL-NEXT:    s_lshl_b32 s2, s1, 5
-; GFX12-GISEL-NEXT:    s_cmp_lg_u32 s1, 0
-; GFX12-GISEL-NEXT:    v_ldexp_f32 v0, |s0|, s2
-; GFX12-GISEL-NEXT:    s_cselect_b32 s0, 0x42000000, 0
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX12-GISEL-NEXT:    v_log_f32_e32 v0, v0
-; GFX12-GISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GISEL-NEXT:    v_subrev_f32_e32 v0, s0, v0
-; GFX12-GISEL-NEXT:    ; return to shader part epilog
+; GFX12-LABEL: srcmods_abs_f32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_bitset0_b32 s0, 31
+; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
+; GFX12-NEXT:    s_cmp_lt_f32 s0, 0x800000
+; GFX12-NEXT:    s_cselect_b32 s1, 0x4f800000, 1.0
+; GFX12-NEXT:    s_mul_f32 s0, s0, s1
+; GFX12-NEXT:    s_cselect_b32 s1, 0x42000000, 0
+; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_2) | instskip(NEXT) | instid1(TRANS32_DEP_1)
+; GFX12-NEXT:    v_s_log_f32 s0, s0
+; GFX12-NEXT:    s_sub_f32 s0, s0, s1
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_2)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    ; return to shader part epilog
   %abs = call float @llvm.fabs.f32(float %src)
   %result = call float @llvm.log2.f32(float %abs)
   ret float %result
@@ -366,18 +321,18 @@ define amdgpu_cs float @srcmods_neg_f32(float inreg %src) {
 ;
 ; GFX12-GISEL-LABEL: srcmods_neg_f32:
 ; GFX12-GISEL:       ; %bb.0:
-; GFX12-GISEL-NEXT:    s_xor_b32 s1, s0, 0x80000000
+; GFX12-GISEL-NEXT:    s_xor_b32 s0, s0, 0x80000000
 ; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX12-GISEL-NEXT:    s_cmp_lt_f32 s1, 0x800000
-; GFX12-GISEL-NEXT:    s_cselect_b32 s1, 1, 0
-; GFX12-GISEL-NEXT:    s_lshl_b32 s2, s1, 5
-; GFX12-GISEL-NEXT:    s_cmp_lg_u32 s1, 0
-; GFX12-GISEL-NEXT:    v_ldexp_f32 v0, -s0, s2
-; GFX12-GISEL-NEXT:    s_cselect_b32 s0, 0x42000000, 0
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX12-GISEL-NEXT:    v_log_f32_e32 v0, v0
+; GFX12-GISEL-NEXT:    s_cmp_lt_f32 s0, 0x800000
+; GFX12-GISEL-NEXT:    s_cselect_b32 s1, 0x4f800000, 1.0
+; GFX12-GISEL-NEXT:    s_mul_f32 s0, s0, s1
+; GFX12-GISEL-NEXT:    s_cselect_b32 s1, 0x42000000, 0
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_2) | instskip(NEXT) | instid1(TRANS32_DEP_1)
+; GFX12-GISEL-NEXT:    v_s_log_f32 s0, s0
+; GFX12-GISEL-NEXT:    s_sub_f32 s0, s0, s1
 ; GFX12-GISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GISEL-NEXT:    v_subrev_f32_e32 v0, s0, v0
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_2)
+; GFX12-GISEL-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX12-GISEL-NEXT:    ; return to shader part epilog
   %neg = fneg float %src
   %result = call float @llvm.log2.f32(float %neg)
@@ -461,9 +416,10 @@ define amdgpu_cs float @fmul_select_pow2_divergent_f32(float %x, i1 %cond) {
 ;
 ; GFX12-GISEL-LABEL: fmul_select_pow2_divergent_f32:
 ; GFX12-GISEL:       ; %bb.0:
-; GFX12-GISEL-NEXT:    v_and_b32_e32 v1, 1, v1
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX12-GISEL-NEXT:    v_lshlrev_b32_e32 v1, 3, v1
+; GFX12-GISEL-NEXT:    v_and_b16 v1.l, 1, v1.l
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX12-GISEL-NEXT:    v_cmp_ne_u16_e32 vcc_lo, 0, v1.l
+; GFX12-GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 8, vcc_lo
 ; GFX12-GISEL-NEXT:    v_ldexp_f32 v0, v0, v1
 ; GFX12-GISEL-NEXT:    ; return to shader part epilog
   %sel = select i1 %cond, float 256.0, float 1.0

--- a/llvm/test/CodeGen/AMDGPU/pseudo-scalar-transcendental.ll
+++ b/llvm/test/CodeGen/AMDGPU/pseudo-scalar-transcendental.ll
@@ -447,3 +447,26 @@ define amdgpu_cs half @fdiv_f16_i16(half inreg %a, i16 inreg %b) {
   %result = fdiv afn half %a, %uint
   ret half %result
 }
+
+; Test that the fmul+select -> fldexp combine works for divergent values.
+define amdgpu_cs float @fmul_select_pow2_divergent_f32(float %x, i1 %cond) {
+; GFX12-SDAG-LABEL: fmul_select_pow2_divergent_f32:
+; GFX12-SDAG:       ; %bb.0:
+; GFX12-SDAG-NEXT:    v_and_b32_e32 v1, 1, v1
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX12-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 1, v1
+; GFX12-SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, 8, vcc_lo
+; GFX12-SDAG-NEXT:    v_ldexp_f32 v0, v0, v1
+; GFX12-SDAG-NEXT:    ; return to shader part epilog
+;
+; GFX12-GISEL-LABEL: fmul_select_pow2_divergent_f32:
+; GFX12-GISEL:       ; %bb.0:
+; GFX12-GISEL-NEXT:    v_and_b32_e32 v1, 1, v1
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12-GISEL-NEXT:    v_lshlrev_b32_e32 v1, 3, v1
+; GFX12-GISEL-NEXT:    v_ldexp_f32 v0, v0, v1
+; GFX12-GISEL-NEXT:    ; return to shader part epilog
+  %sel = select i1 %cond, float 256.0, float 1.0
+  %result = fmul float %x, %sel
+  ret float %result
+}

--- a/llvm/test/CodeGen/AMDGPU/pseudo-scalar-transcendental.ll
+++ b/llvm/test/CodeGen/AMDGPU/pseudo-scalar-transcendental.ll
@@ -426,3 +426,28 @@ define amdgpu_cs float @fmul_select_pow2_divergent_f32(float %x, i1 %cond) {
   %result = fmul float %x, %sel
   ret float %result
 }
+
+; Test that the fmul+select -> fldexp combine works for divergent values
+; with negative constants
+define amdgpu_cs float @fmul_select_neg_pow2_divergent_f32(float %x, i1 %cond) {
+; GFX12-SDAG-LABEL: fmul_select_neg_pow2_divergent_f32:
+; GFX12-SDAG:       ; %bb.0:
+; GFX12-SDAG-NEXT:    v_and_b32_e32 v1, 1, v1
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX12-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 1, v1
+; GFX12-SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, 8, vcc_lo
+; GFX12-SDAG-NEXT:    v_ldexp_f32 v0, -v0, v1
+; GFX12-SDAG-NEXT:    ; return to shader part epilog
+;
+; GFX12-GISEL-LABEL: fmul_select_neg_pow2_divergent_f32:
+; GFX12-GISEL:       ; %bb.0:
+; GFX12-GISEL-NEXT:    v_and_b16 v1.l, 1, v1.l
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX12-GISEL-NEXT:    v_cmp_ne_u16_e32 vcc_lo, 0, v1.l
+; GFX12-GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 8, vcc_lo
+; GFX12-GISEL-NEXT:    v_ldexp_f32 v0, -v0, v1
+; GFX12-GISEL-NEXT:    ; return to shader part epilog
+  %sel = select i1 %cond, float -256.0, float -1.0
+  %result = fmul float %x, %sel
+  ret float %result
+}


### PR DESCRIPTION
Addresses #189936

In SDag's performFMulCombine, we're checking if N is divergent or not as well as if subtarget has SALU float instr before matching them.

In this PR, I ported over the same feature by wiring MachineUniformityInfo from AMDGPUPostLegalizerCombiner down to AMDGPUCombinerHelper and perform the same check in matchCombineFmulWithSelectToFldexp