### PR TITLE
[libc] Rename rpc::Status to rpc::RPCStatus to reduce conflicts

### DIFF
--- a/flang-rt/lib/runtime/io-api-server.cpp
+++ b/flang-rt/lib/runtime/io-api-server.cpp
@@ -156,7 +156,7 @@ bool EnqueueDeferred(FnTy &&fn, Cookie cookie, Args &&...args) {
 }
 
 template <std::uint32_t NumLanes>
-rpc::Status HandleOpcodesImpl(rpc::Server::Port &port) {
+rpc::RPCStatus HandleOpcodesImpl(rpc::Server::Port &port) {
   switch (port.get_opcode()) {
   case BeginExternalListOutput_Opcode:
     rpc::invoke<NumLanes>(port,

--- a/libc/shared/rpc.h
+++ b/libc/shared/rpc.h
@@ -41,7 +41,7 @@ namespace rpc {
 #endif
 
 /// Generic codes that can be used when implementing the server.
-enum Status {
+enum RPCStatus {
   RPC_SUCCESS = 0x0,
   RPC_ERROR = 0x1000,
   RPC_UNHANDLED_OPCODE = 0x1001,

--- a/libc/src/__support/RPC/rpc_server.h
+++ b/libc/src/__support/RPC/rpc_server.h
@@ -311,7 +311,7 @@ LIBC_INLINE static void handle_printf(rpc::Server::Port &port,
 }
 
 template <uint32_t num_lanes>
-LIBC_INLINE static rpc::Status handle_port_impl(rpc::Server::Port &port) {
+LIBC_INLINE static rpc::RPCStatus handle_port_impl(rpc::Server::Port &port) {
   TempStorage temp_storage;
 
   switch (port.get_opcode()) {
@@ -586,8 +586,8 @@ namespace LIBC_NAMESPACE_DECL {
 namespace rpc {
 
 // Handles any opcode generated from the 'libc' client code.
-LIBC_INLINE ::rpc::Status handle_libc_opcodes(::rpc::Server::Port &port,
-                                              uint32_t num_lanes) {
+LIBC_INLINE ::rpc::RPCStatus handle_libc_opcodes(::rpc::Server::Port &port,
+                                                 uint32_t num_lanes) {
   switch (num_lanes) {
   case 1:
     return internal::handle_port_impl<1>(port);

--- a/offload/plugins-nextgen/common/src/RPC.cpp
+++ b/offload/plugins-nextgen/common/src/RPC.cpp
@@ -26,8 +26,8 @@ using namespace omp;
 using namespace target;
 
 template <uint32_t NumLanes>
-rpc::Status handleOffloadOpcodes(plugin::GenericDeviceTy &Device,
-                                 rpc::Server::Port &Port) {
+rpc::RPCStatus handleOffloadOpcodes(plugin::GenericDeviceTy &Device,
+                                    rpc::Server::Port &Port) {
 
   switch (Port.get_opcode()) {
   case LIBC_MALLOC: {
@@ -74,9 +74,9 @@ rpc::Status handleOffloadOpcodes(plugin::GenericDeviceTy &Device,
   return rpc::RPC_SUCCESS;
 }
 
-static rpc::Status handleOffloadOpcodes(plugin::GenericDeviceTy &Device,
-                                        rpc::Server::Port &Port,
-                                        uint32_t NumLanes) {
+static rpc::RPCStatus handleOffloadOpcodes(plugin::GenericDeviceTy &Device,
+                                           rpc::Server::Port &Port,
+                                           uint32_t NumLanes) {
   if (NumLanes == 1)
     return handleOffloadOpcodes<1>(Device, Port);
   else if (NumLanes == 32)
@@ -87,7 +87,7 @@ static rpc::Status handleOffloadOpcodes(plugin::GenericDeviceTy &Device,
     return rpc::RPC_ERROR;
 }
 
-static rpc::Status
+static rpc::RPCStatus
 runServer(plugin::GenericDeviceTy &Device, void *Buffer,
           llvm::SmallSetVector<RPCServerTy::RPCServerCallbackTy, 0> &Callbacks,
           bool &ClientInUse) {
@@ -100,11 +100,11 @@ runServer(plugin::GenericDeviceTy &Device, void *Buffer,
     return rpc::RPC_SUCCESS;
   ClientInUse = true;
 
-  rpc::Status Status = rpc::RPC_UNHANDLED_OPCODE;
+  rpc::RPCStatus Status = rpc::RPC_UNHANDLED_OPCODE;
   const uint32_t NumLanes = Device.getRPCNumLanes();
 
   for (RPCServerTy::RPCServerCallbackTy Callback : Callbacks) {
-    Status = static_cast<rpc::Status>(Callback(&*Port, NumLanes));
+    Status = static_cast<rpc::RPCStatus>(Callback(&*Port, NumLanes));
     if (Status != rpc::RPC_UNHANDLED_OPCODE)
       break;
   }
@@ -117,7 +117,7 @@ runServer(plugin::GenericDeviceTy &Device, void *Buffer,
 
 #ifdef OFFLOAD_HAS_FLANG_RT
   if (Status == rpc::RPC_UNHANDLED_OPCODE)
-    Status = static_cast<rpc::Status>(
+    Status = static_cast<rpc::RPCStatus>(
         Fortran::runtime::io::IONAME(HandleRPCOpcodes)(&*Port, NumLanes));
 #endif
 


### PR DESCRIPTION
Summary:
`Status` is unfortunately heavily overloaded in practice. Things like
X11 define it as a macro. Best to just remove that possibility entirely.
