### PR TITLE
Revert "[scudo] Fix reallocate for MTE."

### DIFF
--- a/compiler-rt/lib/scudo/standalone/combined.h
+++ b/compiler-rt/lib/scudo/standalone/combined.h
@@ -614,22 +614,13 @@ public:
 
     void *BlockBegin = getBlockBegin(OldTaggedPtr, &Header);
     uptr BlockEnd;
-    bool ExactSize = AllocatorConfig::getExactUsableSize() ||
-                     useMemoryTagging<AllocatorConfig>(Options);
+    uptr OldSize = getUsableSize(OldTaggedPtr, &Header);
     const uptr ClassId = Header.ClassId;
-    uptr OldSize;
     if (LIKELY(ClassId)) {
       BlockEnd = reinterpret_cast<uptr>(BlockBegin) +
                  SizeClassMap::getSizeByClassId(ClassId);
-      if (ExactSize)
-        OldSize = Header.SizeOrUnusedBytes;
-      else
-        OldSize = BlockEnd - reinterpret_cast<uptr>(OldTaggedPtr);
     } else {
       BlockEnd = SecondaryT::getBlockEnd(BlockBegin);
-      OldSize = BlockEnd - reinterpret_cast<uptr>(OldTaggedPtr);
-      if (ExactSize)
-        OldSize -= Header.SizeOrUnusedBytes;
     }
     // If the new chunk still fits in the previously allocated block (with a
     // reasonable delta), we just keep the old block, and update the chunk


### PR DESCRIPTION
Reverts llvm/llvm-project#190086

Broke https://lab.llvm.org/buildbot/#/builders/164/builds/20234 and https://lab.llvm.org/buildbot/#/builders/169/builds/21502