### PR TITLE
Make C99 functions builtins only available in C99 mode

### DIFF
--- a/clang/include/clang/Basic/Builtins.h
+++ b/clang/include/clang/Basic/Builtins.h
@@ -46,6 +46,7 @@ enum LanguageID : uint16_t {
   ALL_OCL_LANGUAGES = 0x800, // builtin for OCL languages.
   HLSL_LANG = 0x1000,        // builtin requires HLSL.
   C23_LANG = 0x2000,         // builtin requires C23 or later.
+  C99_LANG = 0x4000,         // builtin requires C99 or later.
   ALL_LANGUAGES = C_LANG | CXX_LANG | OBJC_LANG, // builtin for all languages.
   ALL_GNU_LANGUAGES = ALL_LANGUAGES | GNU_LANG,  // builtin requires GNU mode.
   ALL_MS_LANGUAGES = ALL_LANGUAGES | MS_LANG     // builtin requires MS mode.

--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -11,6 +11,10 @@ include "clang/Basic/BuiltinsBase.td"
 class FPMathTemplate : Template<["float", "double", "long double"],
                                 ["f",     "",       "l"]>;
 
+class FPMathTemplateWithoutDouble :
+  Template<["float", "long double"],
+           ["f",     "l"]>;
+
 class FPMathWithF16Template :
     Template<["float", "double", "long double", "__fp16"],
              ["f",     "",       "l",           "f16"]>;
@@ -28,6 +32,10 @@ class F16F128MathTemplate : Template<["__fp16", "__float128"],
 
 class IntMathTemplate : Template<["int", "long int", "long long int"],
                                  ["",     "l",       "ll"], /*AsPrefix=*/1>;
+
+class IntMathTemplateWithoutLongLong :
+  Template<["int", "long int"],
+           ["",    "l"], /*AsPrefix=*/1>;
 
 class MSInt8_16_32Template : Template<["char", "short", "msint32_t"],
                                       ["8",    "16",    ""]>;
@@ -2943,13 +2951,18 @@ def Abort : LibBuiltin<"stdlib.h"> {
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Abs : IntMathTemplate, LibBuiltin<"stdlib.h"> {
+class AbsBase : LibBuiltinBase<"stdlib.h"> {
   let Spellings = ["abs"];
   let Attributes = [NoThrow, Const];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
   let OnlyBuiltinPrefixedAliasIsConstexpr = 1;
 }
+
+def Abs : IntMathTemplateWithoutLongLong, LibBuiltin<"stdlib.h">, AbsBase;
+
+def AbsC99 : C99LibBuiltin<"stdlib.h">, AbsBase,
+  Template<["long long int"], ["ll"], /*AsPrefix=*/1>;
 
 def Calloc : LibBuiltin<"stdlib.h"> {
   let Spellings = ["calloc"];
@@ -3755,14 +3768,18 @@ def NSLogv : ObjCLibBuiltin<"foundation_nsobjcruntime.h"> {
   let Prototype = "void(id, __builtin_va_list)";
 }
 
-def Atan2 : FPMathTemplate, LibBuiltin<"math.h"> {
+class Atan2Base : LibBuiltinBase<"math.h"> {
   let Spellings = ["atan2"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T, T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Copysign : FPMathTemplate, LibBuiltin<"math.h"> {
+def Atan2 : LibBuiltin<"math.h">, Atan2Base, Template<["double"], [""]>;
+
+def Atan2C99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, Atan2Base;
+
+def Copysign : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["copysign"];
   let Attributes = [NoThrow, Const];
   let Prototype = "T(T, T)";
@@ -3770,13 +3787,17 @@ def Copysign : FPMathTemplate, LibBuiltin<"math.h"> {
   let OnlyBuiltinPrefixedAliasIsConstexpr = 1;
 }
 
-def Fabs : FPMathTemplate, LibBuiltin<"math.h"> {
+class FabsBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["fabs"];
   let Attributes = [NoThrow, Const];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
   let OnlyBuiltinPrefixedAliasIsConstexpr = 1;
 }
+
+def Fabs : LibBuiltin<"math.h">, FabsBase, Template<["double"], [""]>;
+
+def FabsC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, FabsBase;
 
 def Finite : FPMathTemplate, GNULibBuiltin<"math.h"> {
   let Spellings = ["finite"];
@@ -3791,19 +3812,27 @@ def OSXFinite : FPMathTemplate, LibBuiltin<"math.h"> {
   let Prototype = "int(T)";
 }
 
-def Fmod : FPMathTemplate, LibBuiltin<"math.h"> {
+class FmodBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["fmod"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T, T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Frexp : FPMathTemplate, LibBuiltin<"math.h"> {
+def Fmod : LibBuiltin<"math.h">, FmodBase, Template<["double"], [""]>;
+
+def FmodC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, FmodBase;
+
+class FrexpBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["frexp"];
   let Attributes = [NoThrow];
   let Prototype = "T(T, int*)";
   let AddBuiltinPrefixedAlias = 1;
 }
+
+def Frexp : LibBuiltin<"math.h">, FrexpBase, Template<["double"], [""]>;
+
+def FrexpC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, FrexpBase;
 
 def Sincos : FPMathTemplate, GNULibBuiltin<"math.h"> {
   let Spellings = ["sincos"];
@@ -3818,21 +3847,29 @@ def SincosF16F128 : F16F128MathTemplate, Builtin {
   let Prototype = "void(T, T*, T*)";
 }
 
-def Ldexp : FPMathTemplate, LibBuiltin<"math.h"> {
+class LdexpBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["ldexp"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T, int)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Modf : FPMathTemplate, LibBuiltin<"math.h"> {
+def Ldexp : LibBuiltin<"math.h">, LdexpBase, Template<["double"], [""]>;
+
+def LdexpC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, LdexpBase;
+
+class ModfBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["modf"];
   let Attributes = [NoThrow];
   let Prototype = "T(T, T*)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Nan : FPMathTemplate, LibBuiltin<"math.h"> {
+def Modf : LibBuiltin<"math.h">, ModfBase, Template<["double"], [""]>;
+
+def ModfC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, ModfBase;
+
+def Nan : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["nan"];
   let Attributes = [Pure, NoThrow];
   let Prototype = "T(char const*)";
@@ -3840,110 +3877,146 @@ def Nan : FPMathTemplate, LibBuiltin<"math.h"> {
   let OnlyBuiltinPrefixedAliasIsConstexpr = 1;
 }
 
-def Pow : FPMathTemplate, LibBuiltin<"math.h"> {
+class PowBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["pow"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T, T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Acos : FPMathTemplate, LibBuiltin<"math.h"> {
+def Pow : LibBuiltin<"math.h">, PowBase, Template<["double"], [""]>;
+
+def PowC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, PowBase;
+
+class AcosBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["acos"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Acosh : FPMathTemplate, LibBuiltin<"math.h"> {
+def Acos : LibBuiltin<"math.h">, AcosBase, Template<["double"], [""]>;
+
+def AcosC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, AcosBase;
+
+def Acosh : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["acosh"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Asin : FPMathTemplate, LibBuiltin<"math.h"> {
+class AsinBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["asin"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Asinh : FPMathTemplate, LibBuiltin<"math.h"> {
+def Asin : LibBuiltin<"math.h">, AsinBase, Template<["double"], [""]>;
+
+def AsinC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, AsinBase;
+
+def Asinh : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["asinh"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Atan : FPMathTemplate, LibBuiltin<"math.h"> {
+class AtanBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["atan"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Atanh : FPMathTemplate, LibBuiltin<"math.h"> {
+def Atan : LibBuiltin<"math.h">, AtanBase, Template<["double"], [""]>;
+
+def AtanC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, AtanBase;
+
+def Atanh : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["atanh"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Cbrt : FPMathTemplate, LibBuiltin<"math.h"> {
+def Cbrt : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["cbrt"];
   let Attributes = [NoThrow, Const];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Ceil : FPMathTemplate, LibBuiltin<"math.h"> {
+class CeilBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["ceil"];
   let Attributes = [NoThrow, Const];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Cos : FPMathTemplate, LibBuiltin<"math.h"> {
+def Ceil : LibBuiltin<"math.h">, CeilBase, Template<["double"], [""]>;
+
+def CeilC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, CeilBase;
+
+class CosBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["cos"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Cosh : FPMathTemplate, LibBuiltin<"math.h"> {
+def Cos : LibBuiltin<"math.h">, CosBase, Template<["double"], [""]>;
+
+def CosC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, CosBase;
+
+class CoshBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["cosh"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Erf : FPMathTemplate, LibBuiltin<"math.h"> {
+def Cosh : LibBuiltin<"math.h">, CoshBase, Template<["double"], [""]>;
+
+def CoshC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, CoshBase;
+
+def Erf : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["erf"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Erfc : FPMathTemplate, LibBuiltin<"math.h"> {
+def Erfc : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["erfc"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Exp : FPMathTemplate, LibBuiltin<"math.h"> {
+class ExpBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["exp"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Exp2 : FPMathTemplate, LibBuiltin<"math.h"> {
+def Exp : LibBuiltin<"math.h">, ExpBase, Template<["double"], [""]>;
+
+def ExpC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, ExpBase;
+
+class Exp2Base : LibBuiltinBase<"math.h"> {
   let Spellings = ["exp2"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
+
+def Exp2 : LibBuiltin<"math.h">, Exp2Base, Template<["double"], [""]>;
+
+def Exp2C99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, Exp2Base;
 
 // FIXME: Why is there no builtin without the prefix?
 def Exp10 : FPMathTemplate, Builtin {
@@ -3953,35 +4026,39 @@ def Exp10 : FPMathTemplate, Builtin {
   let Prototype = "T(T)";
 }
 
-def Expm1 : FPMathTemplate, LibBuiltin<"math.h"> {
+def Expm1 : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["expm1"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Fdim : FPMathTemplate, LibBuiltin<"math.h"> {
+def Fdim : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["fdim"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T, T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Floor : FPMathTemplate, LibBuiltin<"math.h"> {
+class FloorBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["floor"];
   let Attributes = [NoThrow, Const];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Fma : FPMathTemplate, LibBuiltin<"math.h"> {
+def Floor : LibBuiltin<"math.h">, FloorBase, Template<["double"], [""]>;
+
+def FloorC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, FloorBase;
+
+def Fma : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["fma"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T, T, T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Fmax : FPMathTemplate, LibBuiltin<"math.h"> {
+def Fmax : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["fmax"];
   let Attributes = [NoThrow, Const];
   let Prototype = "T(T, T)";
@@ -3989,7 +4066,7 @@ def Fmax : FPMathTemplate, LibBuiltin<"math.h"> {
   let OnlyBuiltinPrefixedAliasIsConstexpr = 1;
 }
 
-def Fmin : FPMathTemplate, LibBuiltin<"math.h"> {
+def Fmin : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["fmin"];
   let Attributes = [NoThrow, Const];
   let Prototype = "T(T, T)";
@@ -4013,133 +4090,141 @@ def FminimumNum : FPMathTemplate, LibBuiltin<"math.h"> {
   let OnlyBuiltinPrefixedAliasIsConstexpr = 1;
 }
 
-def Hypot : FPMathTemplate, LibBuiltin<"math.h"> {
+def Hypot : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["hypot"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T, T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Ilogb : FPMathTemplate, LibBuiltin<"math.h"> {
+def Ilogb : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["ilogb"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "int(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Lgamma : FPMathTemplate, LibBuiltin<"math.h"> {
+def Lgamma : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["lgamma"];
   let Attributes = [NoThrow];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Llrint : FPMathTemplate, LibBuiltin<"math.h"> {
+def Llrint : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["llrint"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "long long int(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Llround : FPMathTemplate, LibBuiltin<"math.h"> {
+def Llround : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["llround"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "long long int(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Log : FPMathTemplate, LibBuiltin<"math.h"> {
+class LogBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["log"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Log10 : FPMathTemplate, LibBuiltin<"math.h"> {
+def Log : LibBuiltin<"math.h">, LogBase, Template<["double"], [""]>;
+
+def LogC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, LogBase;
+
+class Log10Base : LibBuiltinBase<"math.h"> {
   let Spellings = ["log10"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Log1p : FPMathTemplate, LibBuiltin<"math.h"> {
+def Log10 : LibBuiltin<"math.h">, Log10Base, Template<["double"], [""]>;
+
+def Log10C99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, Log10Base;
+
+def Log1p : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["log1p"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Log2 : FPMathTemplate, LibBuiltin<"math.h"> {
+def Log2 : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["log2"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Logb : FPMathTemplate, LibBuiltin<"math.h"> {
+def Logb : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["logb"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Lrint : FPMathTemplate, LibBuiltin<"math.h"> {
+def Lrint : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["lrint"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "long int(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Lround : FPMathTemplate, LibBuiltin<"math.h"> {
+def Lround : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["lround"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "long int(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Nearbyint : FPMathTemplate, LibBuiltin<"math.h"> {
+def Nearbyint : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["nearbyint"];
   let Attributes = [NoThrow, Const];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Nextafter : FPMathTemplate, LibBuiltin<"math.h"> {
+def Nextafter : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["nextafter"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T, T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Nexttoward : FPMathTemplate, LibBuiltin<"math.h"> {
+def Nexttoward : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["nexttoward"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T, long double)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Remainder : FPMathTemplate, LibBuiltin<"math.h"> {
+def Remainder : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["remainder"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T, T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Remquo : FPMathTemplate, LibBuiltin<"math.h"> {
+def Remquo : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["remquo"];
   let Attributes = [NoThrow];
   let Prototype = "T(T, T, int*)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Rint : FPMathTemplate, LibBuiltin<"math.h"> {
+def Rint : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["rint"];
   let Attributes = [NoThrow, ConstIgnoringExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Round : FPMathTemplate, LibBuiltin<"math.h"> {
+def Round : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["round"];
   let Attributes = [NoThrow, Const];
   let Prototype = "T(T)";
@@ -4153,210 +4238,230 @@ def RoundEven : FPMathTemplate, LibBuiltin<"math.h"> {
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Scalbln : FPMathTemplate, LibBuiltin<"math.h"> {
+def Scalbln : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["scalbln"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T, long int)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Scalbn : FPMathTemplate, LibBuiltin<"math.h"> {
+def Scalbn : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["scalbn"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T, int)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Sin : FPMathTemplate, LibBuiltin<"math.h"> {
+class SinBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["sin"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Sinh : FPMathTemplate, LibBuiltin<"math.h"> {
+def Sin : LibBuiltin<"math.h">, SinBase, Template<["double"], [""]>;
+
+def SinC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, SinBase;
+
+class SinhBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["sinh"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Sqrt : FPMathTemplate, LibBuiltin<"math.h"> {
+def Sinh : LibBuiltin<"math.h">, SinhBase, Template<["double"], [""]>;
+
+def SinhC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, SinhBase;
+
+class SqrtBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["sqrt"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Tan : FPMathTemplate, LibBuiltin<"math.h"> {
+def Sqrt : LibBuiltin<"math.h">, SqrtBase, Template<["double"], [""]>;
+
+def SqrtC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, SqrtBase;
+
+class TanBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["tan"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Tanh : FPMathTemplate, LibBuiltin<"math.h"> {
+def Tan : LibBuiltin<"math.h">, TanBase, Template<["double"], [""]>;
+
+def TanC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, TanBase;
+
+class TanhBase : LibBuiltinBase<"math.h"> {
   let Spellings = ["tanh"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Tgamma : FPMathTemplate, LibBuiltin<"math.h"> {
+def Tanh : LibBuiltin<"math.h">, TanhBase, Template<["double"], [""]>;
+
+def TanhC99 : FPMathTemplateWithoutDouble, C99LibBuiltin<"math.h">, TanhBase;
+
+def Tgamma : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["tgamma"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Trunc : FPMathTemplate, LibBuiltin<"math.h"> {
+def Trunc : FPMathTemplate, C99LibBuiltin<"math.h"> {
   let Spellings = ["trunc"];
   let Attributes = [NoThrow, Const];
   let Prototype = "T(T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Cabs : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Cabs : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["cabs"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Cacos : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Cacos : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["cacos"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Cacosh : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Cacosh : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["cacosh"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Carg : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Carg : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["carg"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Casin : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Casin : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["casin"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Casinh : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Casinh : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["casinh"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Catan : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Catan : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["catan"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Catanh : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Catanh : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["catanh"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Ccos : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Ccos : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["ccos"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Ccosh : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Ccosh : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["ccosh"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Cexp : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Cexp : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["cexp"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Cimag : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Cimag : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["cimag"];
   let Attributes = [NoThrow, Const];
   let Prototype = "T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Conj : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Conj : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["conj"];
   let Attributes = [NoThrow, Const];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Clog : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Clog : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["clog"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Cproj : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Cproj : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["cproj"];
   let Attributes = [NoThrow, Const];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Cpow : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Cpow : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["cpow"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T, _Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Creal : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Creal : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["creal"];
   let Attributes = [NoThrow, Const];
   let Prototype = "T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Csin : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Csin : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["csin"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Csinh : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Csinh : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["csinh"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Csqrt : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Csqrt : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["csqrt"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";
   let AddBuiltinPrefixedAlias = 1;
 }
 
-def Ctan : FPMathTemplate, LibBuiltin<"complex.h"> {
+def Ctan : FPMathTemplate, C99LibBuiltin<"complex.h"> {
   let Spellings = ["ctan"];
   let Attributes = [NoThrow, ConstIgnoringErrnoAndExceptions];
   let Prototype = "_Complex T(_Complex T)";

--- a/clang/include/clang/Basic/BuiltinsBase.td
+++ b/clang/include/clang/Basic/BuiltinsBase.td
@@ -177,17 +177,21 @@ class Builtin {
 
 class AtomicBuiltin : Builtin;
 
-class LibBuiltin<string header, string languages = "ALL_LANGUAGES"> : Builtin {
+class LibBuiltinBase<string header> : Builtin {
   string Header = header;
-  string Languages = languages;
   bit AddBuiltinPrefixedAlias = 0;
   bit OnlyBuiltinPrefixedAliasIsConstexpr = 0;
+}
+
+class LibBuiltin<string header, string languages = "ALL_LANGUAGES"> : LibBuiltinBase<header> {
+  string Languages = languages;
 }
 
 class MSLibBuiltin<string header> : LibBuiltin<header, "ALL_MS_LANGUAGES">;
 class GNULibBuiltin<string header> : LibBuiltin<header, "ALL_GNU_LANGUAGES">;
 class ObjCLibBuiltin<string header> : LibBuiltin<header, "OBJC_LANG">;
 class CxxLibBuiltin<string header> : LibBuiltin<header, "CXX_LANG">;
+class C99LibBuiltin<string header> : LibBuiltin<header, "C99_LANG">;
 
 class LangBuiltin<string languages> : Builtin {
   string Languages = languages;

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -38,6 +38,7 @@
 #endif
 
 // FIXME: A lot of the Benign options should be Compatible instead.
+LANGOPT(C89               , 1, 0, NotCompatible, "C89")
 LANGOPT(C99               , 1, 0, NotCompatible, "C99")
 LANGOPT(C11               , 1, 0, NotCompatible, "C11")
 LANGOPT(C17               , 1, 0, NotCompatible, "C17")

--- a/clang/include/clang/Basic/LangStandard.h
+++ b/clang/include/clang/Basic/LangStandard.h
@@ -63,7 +63,8 @@ enum LangFeatures {
   GNUMode = (1 << 14),
   HexFloat = (1 << 15),
   OpenCL = (1 << 16),
-  HLSL = (1 << 17)
+  HLSL = (1 << 17),
+  C89 = (1 << 18)
 };
 
 /// LangStandard - Information about the properties of a particular language
@@ -96,6 +97,9 @@ public:
 
   /// Language supports '//' comments.
   bool hasLineComments() const { return Flags & LineComment; }
+
+  /// isC89 - Language is a superset of C89.
+  bool isC89() const { return Flags & C89; }
 
   /// isC99 - Language is a superset of C99.
   bool isC99() const { return Flags & C99; }

--- a/clang/include/clang/Basic/LangStandards.def
+++ b/clang/include/clang/Basic/LangStandards.def
@@ -38,76 +38,76 @@
 
 // C89-ish modes.
 LANGSTANDARD(c89, "c89",
-             C, "ISO C 1990", 0, std::nullopt)
+             C, "ISO C 1990", C89, std::nullopt)
 LANGSTANDARD_ALIAS(c89, "c90")
 LANGSTANDARD_ALIAS(c89, "iso9899:1990")
 
 LANGSTANDARD(c94, "iso9899:199409",
              C, "ISO C 1990 with amendment 1",
-             Digraphs, 199409)
+             C89 | Digraphs, 199409)
 
 LANGSTANDARD(gnu89, "gnu89",
              C, "ISO C 1990 with GNU extensions",
-             LineComment | Digraphs | GNUMode, std::nullopt)
+             C89 | LineComment | Digraphs | GNUMode, std::nullopt)
 LANGSTANDARD_ALIAS(gnu89, "gnu90")
 
 // C99-ish modes
 LANGSTANDARD(c99, "c99",
              C, "ISO C 1999",
-             LineComment | C99 | Digraphs | HexFloat, 199901)
+             LineComment | C89 | C99 | Digraphs | HexFloat, 199901)
 LANGSTANDARD_ALIAS(c99, "iso9899:1999")
 LANGSTANDARD_ALIAS_DEPR(c99, "c9x")
 LANGSTANDARD_ALIAS_DEPR(c99, "iso9899:199x")
 
 LANGSTANDARD(gnu99, "gnu99",
              C, "ISO C 1999 with GNU extensions",
-             LineComment | C99 | Digraphs | GNUMode | HexFloat, 199901)
+             LineComment | C89 | C99 | Digraphs | GNUMode | HexFloat, 199901)
 LANGSTANDARD_ALIAS_DEPR(gnu99, "gnu9x")
 
 // C11 modes
 LANGSTANDARD(c11, "c11",
              C, "ISO C 2011",
-             LineComment | C99 | C11 | Digraphs | HexFloat, 201112)
+             LineComment | C89 | C99 | C11 | Digraphs | HexFloat, 201112)
 LANGSTANDARD_ALIAS(c11, "iso9899:2011")
 LANGSTANDARD_ALIAS_DEPR(c11, "c1x")
 LANGSTANDARD_ALIAS_DEPR(c11, "iso9899:201x")
 
 LANGSTANDARD(gnu11, "gnu11",
              C, "ISO C 2011 with GNU extensions",
-             LineComment | C99 | C11 | Digraphs | GNUMode | HexFloat, 201112)
+             LineComment | C89 | C99 | C11 | Digraphs | GNUMode | HexFloat, 201112)
 LANGSTANDARD_ALIAS_DEPR(gnu11, "gnu1x")
 
 // C17 modes
 LANGSTANDARD(c17, "c17",
              C, "ISO C 2017",
-             LineComment | C99 | C11 | C17 | Digraphs | HexFloat, 201710)
+             LineComment | C89 | C99 | C11 | C17 | Digraphs | HexFloat, 201710)
 LANGSTANDARD_ALIAS(c17, "iso9899:2017")
 LANGSTANDARD_ALIAS(c17, "c18")
 LANGSTANDARD_ALIAS(c17, "iso9899:2018")
 LANGSTANDARD(gnu17, "gnu17",
              C, "ISO C 2017 with GNU extensions",
-             LineComment | C99 | C11 | C17 | Digraphs | GNUMode | HexFloat, 201710)
+             LineComment | C89 | C99 | C11 | C17 | Digraphs | GNUMode | HexFloat, 201710)
 LANGSTANDARD_ALIAS(gnu17, "gnu18")
 
 // C23 modes
 LANGSTANDARD(c23, "c23",
              C, "ISO C 2023",
-             LineComment | C99 | C11 | C17 | C23 | Digraphs | HexFloat, 202311)
+             LineComment | C89 | C99 | C11 | C17 | C23 | Digraphs | HexFloat, 202311)
 LANGSTANDARD_ALIAS(c23, "iso9899:2024")
 LANGSTANDARD_ALIAS_DEPR(c23, "c2x")
 LANGSTANDARD(gnu23, "gnu23",
              C, "ISO C 2023 with GNU extensions",
-             LineComment | C99 | C11 | C17 | C23 | Digraphs | GNUMode | HexFloat, 202311)
+             LineComment | C89 | C99 | C11 | C17 | C23 | Digraphs | GNUMode | HexFloat, 202311)
 LANGSTANDARD_ALIAS_DEPR(gnu23, "gnu2x")
 
 // C2y modes
 // FIXME: Use correct version code for C2y once published.
 LANGSTANDARD(c2y, "c2y",
              C, "Working Draft for ISO C2y",
-             LineComment | C99 | C11 | C17 | C23 | C2y | Digraphs | HexFloat, 202400)
+             LineComment | C89 | C99 | C11 | C17 | C23 | C2y | Digraphs | HexFloat, 202400)
 LANGSTANDARD(gnu2y, "gnu2y",
              C, "Working Draft for ISO C2y with GNU extensions",
-             LineComment | C99 | C11 | C17 | C23 | C2y | Digraphs | GNUMode | HexFloat, 202400)
+             LineComment | C89 | C99 | C11 | C17 | C23 | C2y | Digraphs | GNUMode | HexFloat, 202400)
 // TODO: Add the iso9899:202y alias once ISO publishes the standard.
 
 // C++ modes
@@ -194,21 +194,21 @@ LANGSTANDARD_ALIAS(gnucxx26, "gnu++26")
 // OpenCL
 LANGSTANDARD(opencl10, "cl1.0",
              OpenCL, "OpenCL 1.0",
-             LineComment | C99 | Digraphs | HexFloat | OpenCL, std::nullopt)
+             LineComment | C89 | C99 | Digraphs | HexFloat | OpenCL, std::nullopt)
 LANGSTANDARD_ALIAS_DEPR(opencl10, "cl")
 
 LANGSTANDARD(opencl11, "cl1.1",
              OpenCL, "OpenCL 1.1",
-             LineComment | C99 | Digraphs | HexFloat | OpenCL, std::nullopt)
+             LineComment | C89 | C99 | Digraphs | HexFloat | OpenCL, std::nullopt)
 LANGSTANDARD(opencl12, "cl1.2",
              OpenCL, "OpenCL 1.2",
-             LineComment | C99 | Digraphs | HexFloat | OpenCL, std::nullopt)
+             LineComment | C89 | C99 | Digraphs | HexFloat | OpenCL, std::nullopt)
 LANGSTANDARD(opencl20, "cl2.0",
              OpenCL, "OpenCL 2.0",
-             LineComment | C99 | Digraphs | HexFloat | OpenCL, std::nullopt)
+             LineComment | C89 | C99 | Digraphs | HexFloat | OpenCL, std::nullopt)
 LANGSTANDARD(opencl30, "cl3.0",
              OpenCL, "OpenCL 3.0",
-             LineComment | C99 | Digraphs | HexFloat | OpenCL, std::nullopt)
+             LineComment | C89 | C99 | Digraphs | HexFloat | OpenCL, std::nullopt)
 
 LANGSTANDARD(openclcpp10, "clc++1.0",
              OpenCL, "C++ for OpenCL 1.0",

--- a/clang/lib/Basic/Builtins.cpp
+++ b/clang/lib/Basic/Builtins.cpp
@@ -194,6 +194,9 @@ static bool builtinIsSupported(const llvm::StringTable &Strings,
   /* C23 unsupported */
   if (!LangOpts.C23 && BuiltinInfo.Langs == C23_LANG)
     return false;
+  /* C99 unsupported */
+  if (!LangOpts.C99 && BuiltinInfo.Langs == C99_LANG)
+    return false;
   return true;
 }
 

--- a/clang/lib/Basic/Builtins.cpp
+++ b/clang/lib/Basic/Builtins.cpp
@@ -195,7 +195,7 @@ static bool builtinIsSupported(const llvm::StringTable &Strings,
   if (!LangOpts.C23 && BuiltinInfo.Langs == C23_LANG)
     return false;
   /* C99 unsupported */
-  if (!LangOpts.C99 && BuiltinInfo.Langs == C99_LANG)
+  if (LangOpts.C89 && !LangOpts.C99 && BuiltinInfo.Langs == C99_LANG)
     return false;
   return true;
 }

--- a/clang/lib/Basic/LangOptions.cpp
+++ b/clang/lib/Basic/LangOptions.cpp
@@ -111,7 +111,7 @@ void LangOptions::setLangDefaults(LangOptions &Opts, Language Lang,
   const LangStandard &Std = LangStandard::getLangStandardForKind(LangStd);
   Opts.LangStd = LangStd;
   Opts.LineComment = Std.hasLineComments();
-  Opts.C89 = Std.isC99();
+  Opts.C89 = Std.isC89();
   Opts.C99 = Std.isC99();
   Opts.C11 = Std.isC11();
   Opts.C17 = Std.isC17();

--- a/clang/lib/Basic/LangOptions.cpp
+++ b/clang/lib/Basic/LangOptions.cpp
@@ -111,6 +111,7 @@ void LangOptions::setLangDefaults(LangOptions &Opts, Language Lang,
   const LangStandard &Std = LangStandard::getLangStandardForKind(LangStd);
   Opts.LangStd = LangStd;
   Opts.LineComment = Std.hasLineComments();
+  Opts.C89 = Std.isC99();
   Opts.C99 = Std.isC99();
   Opts.C11 = Std.isC11();
   Opts.C17 = Std.isC17();

--- a/clang/test/C/C89/c99_functions.c
+++ b/clang/test/C/C89/c99_functions.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -verify -std=c89 %s
+
+// See https://github.com/llvm/llvm-project/issues/15522
+
+// logf doesn't exist in C89
+int logf = 5;
+
+// But log does
+int log = 6; // expected-error {{redefinition of 'log' as different kind of symbol}}
+
+int main() {
+    return logf;
+}

--- a/clang/test/C/C89/c99_functions.c
+++ b/clang/test/C/C89/c99_functions.c
@@ -6,10 +6,9 @@
 int logf = 5;
 
 // But log does
-int log = 6;
-// expected-error {{redefinition of 'log' as different kind of symbol}}
-// expected-note {{unguarded header; consider using #ifdef guards or #pragma once}}
-// expected-note {{previous definition is here}}
+int log = 6; // expected-error {{redefinition of 'log' as different kind of symbol}} \
+		expected-note {{unguarded header; consider using #ifdef guards or #pragma once}} \
+		expected-note {{previous definition is here}}
 
 int main() {
     return logf;

--- a/clang/test/C/C89/c99_functions.c
+++ b/clang/test/C/C89/c99_functions.c
@@ -6,7 +6,10 @@
 int logf = 5;
 
 // But log does
-int log = 6; // expected-error {{redefinition of 'log' as different kind of symbol}}
+int log = 6;
+// expected-error {{redefinition of 'log' as different kind of symbol}}
+// expected-note {{unguarded header; consider using #ifdef guards or #pragma once}}
+// expected-note {{previous definition is here}}
 
 int main() {
     return logf;


### PR DESCRIPTION
This patch makes C99 builtins not available in C89 mode, so example below compiles now:

```c++
int logf = 5;
int main() {
        return logf;
}
```

It does so by introducing `LanguageID::C99_LANG` && `C99LibBuiltin` class and replacing `LibBuiltin` base class in builtins corresponding to functions introduced in C99 with `C99LibBuiltin` base class.

The reason for introduction of C89 language option is to distinguish C89 language mode from the CPlusPlus etc modes: if I'll write only 

```cpp
if(LangOpts.C99 && BuiltinInfo.Langs == C99_LANG) return false;
```

It would `return false` when LangOpts.CPlusPlus is on, what is undesirable, cause the intention is to disable C99 builtins only in C89 mode. With C89 language option we could write the code below which should do exactly the right thing.

```cpp
if (LangOpts.C89 && !LangOpts.C99 &&
    BuiltinInfo.Langs == C99_LANG) return false;
```

Closes #15522 