### PR TITLE
[flang][OpenMP] Avoid marking named main programs as declare target

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -778,9 +778,12 @@ static void getDeclareTargetInfo(
     if (clauses.empty()) {
       Fortran::lower::pft::FunctionLikeUnit *owningProc =
           eval.getOwningProcedure();
-      if (owningProc && (!owningProc->isMainProgram() ||
-                         owningProc->getMainProgramSymbol())) {
-        // Case: declare target, implicit capture of function
+      // Main programs are never device routines. Skip them so that a bare
+      // '!$omp declare target' inside an interface body that lives in a named
+      // main program does not incorrectly mark _QQmain as a device function.
+      if (owningProc && !owningProc->isMainProgram()) {
+        // Case: declare target, implicit capture of enclosing
+        // function/subroutine.
         symbolAndClause.emplace_back(mlir::omp::DeclareTargetCaptureClause::to,
                                      owningProc->getSubprogramSymbol());
       }

--- a/flang/test/Lower/OpenMP/declare-target-named-main-interface.f90
+++ b/flang/test/Lower/OpenMP/declare-target-named-main-interface.f90
@@ -1,0 +1,32 @@
+!RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s --check-prefix=HOST
+!RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-is-target-device %s -o - | FileCheck %s --check-prefix=DEVICE
+
+! Test that a bare '!$omp declare target' inside an interface body that
+! appears in a *named* main program does not incorrectly mark the main
+! program (_QQmain) as a declare-target function while still correctly
+! marking the declared subroutine (sub_a) as device_type(nohost).
+!
+! In host compilation _QQmain must not be tagged with declare_target at all.
+! In device compilation the MarkDeclareTargetPass may annotate _QQmain with
+! device_type(host) (harmless); the bug was device_type(any) which caused
+! _QQmain to be emitted into the device image.
+
+! HOST-NOT: func.func @_QQmain{{.*}}omp.declare_target
+! DEVICE-NOT: func.func @_QQmain{{.*}}device_type = (any)
+! DEVICE-NOT: func.func @_QQmain{{.*}}device_type = (nohost)
+! HOST: func.func private @_QPsub_a{{.*}}device_type = (nohost)
+! DEVICE: func.func private @_QPsub_a{{.*}}device_type = (nohost)
+
+program named_main
+  interface
+    subroutine sub_a(x)
+      implicit none
+      !$omp declare target
+      integer, intent(inout) :: x
+    end subroutine sub_a
+  end interface
+  integer :: v = 0
+  !$omp target
+    call sub_a(v)
+  !$omp end target
+end program named_main

--- a/flang/test/Lower/OpenMP/real10.f90
+++ b/flang/test/Lower/OpenMP/real10.f90
@@ -2,9 +2,9 @@
 
 !RUN: %flang_fc1 -emit-hlfir -fopenmp -triple amdgcn -fopenmp -fopenmp-is-target-device -o - %s | FileCheck %s
 
-!CHECK: hlfir.declare %{{.*}} {uniq_name = "_QFEx"} : (!fir.ref<f80>) -> (!fir.ref<f80>, !fir.ref<f80>)
+!CHECK: hlfir.declare %{{.*}} {uniq_name = "_QFtest_real10Ex"} : (!fir.ref<f80>) -> (!fir.ref<f80>, !fir.ref<f80>)
 
-program p
+subroutine test_real10()
   !$omp declare target
   real(10) :: x
-end
+end subroutine test_real10


### PR DESCRIPTION
A bare `!$omp declare target` could incorrectly mark `_QQmain` as
`omp.declare_target` when it appeared in an interface body inside a named
main program. That pulled host-only callees into device compilation and
caused offload link failures.

Fix this by skipping main programs in the implicit-capture path.
Also add a regression test for the named-main interface case and update
`real10.f90` to use a valid container for the bare `declare target` form.

This fixes offload link failures where `_QQmain` was incorrectly treated as
a device function and pulled in host-only symbols such as Fortran I/O
runtime calls.

Minimal reproducer:

```fortran
program named_main
  interface
    subroutine sub_a(x)
      !$omp declare target
      integer, intent(inout) :: x
    end subroutine
  end interface
  integer :: v
  !$omp target
    call sub_a(v)
  !$omp end target
end program