### PR TITLE
[clang] Include header providing `off_t`

### DIFF
--- a/clang/include/clang/Serialization/ModuleCache.h
+++ b/clang/include/clang/Serialization/ModuleCache.h
@@ -13,6 +13,7 @@
 
 #include <ctime>
 #include <memory>
+#include <sys/types.h>
 #include <system_error>
 
 namespace llvm {


### PR DESCRIPTION
This should fix the modules build.