### PR TITLE
[Hexagon] Add sanitizer-aware library paths for Linux/musl targets

### DIFF
--- a/clang/lib/Driver/ToolChains/Hexagon.cpp
+++ b/clang/lib/Driver/ToolChains/Hexagon.cpp
@@ -11,6 +11,8 @@
 #include "clang/Driver/Compilation.h"
 #include "clang/Driver/Driver.h"
 #include "clang/Driver/InputInfo.h"
+#include "clang/Driver/MultilibBuilder.h"
+#include "clang/Driver/SanitizerArgs.h"
 #include "clang/Options/Options.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/FileSystem.h"
@@ -344,6 +346,12 @@ constructHexagonLinkArgs(Compilation &C, const JobAction &JA,
              !Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib))
       CmdArgs.push_back(Args.MakeArgString(D.SysRoot + "/usr/lib/crti.o"));
 
+    if (!HTC.getSelectedMultilibs().empty() &&
+        !HTC.getSelectedMultilibs().back().isDefault()) {
+      CmdArgs.push_back(
+          Args.MakeArgString(StringRef("-L") + D.SysRoot + "/usr/lib" +
+                             HTC.getSelectedMultilibs().back().gccSuffix()));
+    }
     CmdArgs.push_back(
         Args.MakeArgString(StringRef("-L") + D.SysRoot + "/usr/lib"));
     Args.addAllArgs(CmdArgs, {options::OPT_T_Group, options::OPT_s,
@@ -631,6 +639,34 @@ HexagonToolChain::HexagonToolChain(const Driver &D, const llvm::Triple &Triple,
   // support 'linux' we'll need to fix this up
   LibPaths.clear();
   getHexagonLibraryPaths(Args, LibPaths);
+
+  if (getTriple().isMusl()) {
+    Multilibs.push_back(Multilib());
+    Multilibs.push_back(MultilibBuilder("msan", {}, {})
+                            .flag("-fsanitize=memory")
+                            .makeMultilib());
+    Multilibs.push_back(MultilibBuilder("asan", {}, {})
+                            .flag("-fsanitize=address")
+                            .makeMultilib());
+
+    Multilib::flags_list Flags;
+    addMultilibFlag(getSanitizerArgs(Args).needsMsanRt(), "-fsanitize=memory",
+                    Flags);
+    addMultilibFlag(getSanitizerArgs(Args).needsAsanRt(), "-fsanitize=address",
+                    Flags);
+
+    if (Multilibs.select(D, Flags, SelectedMultilibs)) {
+      Multilib LastSelected = SelectedMultilibs.back();
+      SelectedMultilibs = {LastSelected};
+
+      if (!SelectedMultilibs.back().isDefault()) {
+        SmallString<128> SanLibPath(D.SysRoot);
+        llvm::sys::path::append(SanLibPath, "usr", "lib");
+        SanLibPath += SelectedMultilibs.back().gccSuffix();
+        LibPaths.insert(LibPaths.begin(), std::string(SanLibPath));
+      }
+    }
+  }
 }
 
 HexagonToolChain::~HexagonToolChain() {}

--- a/clang/test/Driver/hexagon-toolchain-linux.c
+++ b/clang/test/Driver/hexagon-toolchain-linux.c
@@ -180,3 +180,36 @@
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree -r %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-PIE-RELOCATABLE %s
 // CHECK-PIE-RELOCATABLE-NOT:  "-pie"
+
+// -----------------------------------------------------------------------------
+// Sanitizer library paths: -fsanitize=memory
+// -----------------------------------------------------------------------------
+// RUN: %clang -### --target=hexagon-unknown-linux-musl \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
+// RUN:   -mcpu=hexagonv60 \
+// RUN:   -fuse-ld=lld \
+// RUN:   -fsanitize=memory \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree %s 2>&1 | FileCheck -check-prefix=CHECK-MSAN %s
+// CHECK-MSAN:      "-L{{[^"]*}}basic_linux_libcxx_tree{{/|\\\\}}usr{{/|\\\\}}lib{{/|\\\\}}msan"
+// CHECK-MSAN-SAME: "-L{{[^"]*}}basic_linux_libcxx_tree{{/|\\\\}}usr{{/|\\\\}}lib"
+// -----------------------------------------------------------------------------
+// Sanitizer library paths: -fsanitize=address
+// -----------------------------------------------------------------------------
+// RUN: %clang -### --target=hexagon-unknown-linux-musl \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
+// RUN:   -mcpu=hexagonv60 \
+// RUN:   -fuse-ld=lld \
+// RUN:   -fsanitize=address \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree %s 2>&1 | FileCheck -check-prefix=CHECK-ASAN %s
+// CHECK-ASAN:      "-L{{[^"]*}}basic_linux_libcxx_tree{{/|\\\\}}usr{{/|\\\\}}lib{{/|\\\\}}asan"
+// CHECK-ASAN-SAME: "-L{{[^"]*}}basic_linux_libcxx_tree{{/|\\\\}}usr{{/|\\\\}}lib"
+// -----------------------------------------------------------------------------
+// No sanitizer: no msan/asan library paths
+// -----------------------------------------------------------------------------
+// RUN: %clang -### --target=hexagon-unknown-linux-musl \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
+// RUN:   -mcpu=hexagonv60 \
+// RUN:   -fuse-ld=lld \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree %s 2>&1 | FileCheck -check-prefix=CHECK-NOSAN %s
+// CHECK-NOSAN-NOT: "-L{{.*}}{{/|\\\\}}msan"
+// CHECK-NOSAN-NOT: "-L{{.*}}{{/|\\\\}}asan"


### PR DESCRIPTION
When compiling with -fsanitize=memory or -fsanitize=address on hexagon-unknown-linux-musl, the driver now prepends sanitizer-specific library paths (e.g. $SYSROOT/usr/lib/msan/) before the normal $SYSROOT/usr/lib/ so that instrumented libraries (libc, libc++, etc.) are found first by the linker.