### PR TITLE
[GlobalISel] Fix UMR in `SwiftErrorValueTracking`

### DIFF
--- a/llvm/include/llvm/CodeGen/SwiftErrorValueTracking.h
+++ b/llvm/include/llvm/CodeGen/SwiftErrorValueTracking.h
@@ -33,10 +33,10 @@ namespace llvm {
 
 class SwiftErrorValueTracking {
   // Some useful objects to reduce the number of function arguments needed.
-  MachineFunction *MF;
-  const Function *Fn;
-  const TargetLowering *TLI;
-  const TargetInstrInfo *TII;
+  MachineFunction *MF = nullptr;
+  const Function *Fn = nullptr;
+  const TargetLowering *TLI = nullptr;
+  const TargetInstrInfo *TII = nullptr;
 
   /// A map from swifterror value in a basic block to the virtual register it is
   /// currently represented by.
@@ -55,7 +55,7 @@ class SwiftErrorValueTracking {
       VRegDefUses;
 
   /// The swifterror argument of the current function.
-  const Value *SwiftErrorArg;
+  const Value *SwiftErrorArg = nullptr;
 
   using SwiftErrorValues = SmallVector<const Value*, 1>;
   /// A function can only have a single swifterror argument. And if it does

--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -4277,7 +4277,7 @@ bool IRTranslator::runOnMachineFunction(MachineFunction &CurMF) {
     ArrayRef<Register> VRegs = getOrCreateVRegs(Arg);
     VRegArgs.push_back(VRegs);
 
-    if (Arg.hasSwiftErrorAttr()) {
+    if (CLI->supportSwiftError() && Arg.hasSwiftErrorAttr()) {
       assert(VRegs.size() == 1 && "Too many vregs for Swift error");
       SwiftError.setCurrentVReg(EntryBB, SwiftError.getFunctionArg(), VRegs[0]);
     }

--- a/llvm/lib/CodeGen/SwiftErrorValueTracking.cpp
+++ b/llvm/lib/CodeGen/SwiftErrorValueTracking.cpp
@@ -81,14 +81,14 @@ void SwiftErrorValueTracking::setFunction(MachineFunction &mf) {
   TLI = MF->getSubtarget().getTargetLowering();
   TII = MF->getSubtarget().getInstrInfo();
 
-  if (!TLI->supportSwiftError())
-    return;
-
   SwiftErrorVals.clear();
   VRegDefMap.clear();
   VRegUpwardsUse.clear();
   VRegDefUses.clear();
   SwiftErrorArg = nullptr;
+
+  if (!TLI->supportSwiftError())
+    return;
 
   // Check if function has a swifterror argument.
   bool HaveSeenSwiftErrorArg = false;


### PR DESCRIPTION
Fix issue reported on https://github.com/llvm/llvm-project/pull/188296#issuecomment-4179103756

`SwiftErrorValueTracking` holds per-function state used by `IRTranslator`.

On targets where `TargetLowering::supportSwiftError()` is false, (e.g. wasm) `SwiftErrorValueTracking::setFunction()` exits early. Historically, that early return happened before clearing per-function containers, and pointer members (including `SwiftErrorArg`) had no in-class initialization.

The bad case is a function with a swifterror argument on such a target: `IRTranslator` uses `SwiftError.getFunctionArg()` without checking `supportSwiftError()` and this could read an uninitialized `SwiftErrorArg` value. (SelectionDAG gates the `getFunctionArg` usages behind `supportSwiftError()`, so it's specific to GlobalISel)

29391328ab66 added [a first test case](llvm/test/CodeGen/WebAssembly/GlobalISel/irtranslator/args-swiftcc.ll) that satisfies:
- the target is `supportSwiftError` = false
- use swiftcc
- use GlobalISel

and it made the issue observable with sanitizer builds. This commit fixes the per-function container reinitialization and defensively add explicit pointer member initializations.