### PR TITLE
[clang] [fixit] Properly apply warning options during fixit-recompile

### DIFF
--- a/clang/lib/Frontend/Rewrite/FrontendActions.cpp
+++ b/clang/lib/Frontend/Rewrite/FrontendActions.cpp
@@ -149,6 +149,8 @@ bool FixItRecompile::BeginInvocation(CompilerInstance &CI) {
     return false;
   CI.getDiagnosticClient().clear();
   CI.getDiagnostics().Reset();
+  ProcessWarningOptions(CI.getDiagnostics(), CI.getDiagnosticOpts(),
+                        CI.getVirtualFileSystem());
 
   PreprocessorOptions &PPOpts = CI.getPreprocessorOpts();
   PPOpts.RemappedFiles.insert(PPOpts.RemappedFiles.end(),

--- a/clang/test/FixIt/fixit-recompile-warning-options.cpp
+++ b/clang/test/FixIt/fixit-recompile-warning-options.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -std=c++14 %s -fixit-recompile -fixit-to-temporary -Werror \
+// RUN:   -Wno-deprecated-register 2>&1 | FileCheck %s
+
+//In c++14 this produces a fixit, which we fix with -fixit-recompile
+static_assert(true);
+
+// During the recompile we ensure that the -Wno-deprecated-register option
+// is properly applied
+void f() {
+  register int data;
+}
+
+// CHECK: error: 'static_assert' with no message is a C++17 extension
+// CHECK: note: FIX-IT applied suggested code changes
+// CHECK-NOT: 'register' storage class specifier is deprecated and incompatible with C++17


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/18707

During fixit recompile, the frontend was not reapplying command-line diagnostic options, so the second pass could lose -Wno-* suppressions and other warning configuration.

Added regression test to make sure that diagnostic options are properly applied in the fixit-recompile path.