### PR TITLE
[BOLT] Move extern "C" out of unnamed namespace

### DIFF
--- a/bolt/runtime/instr.cpp
+++ b/bolt/runtime/instr.cpp
@@ -255,10 +255,10 @@ void *operator new[](size_t Sz, BumpPtrAllocator &A, char C) {
 // C++ language weirdness
 void operator delete(void *Ptr, BumpPtrAllocator &A) { A.deallocate(Ptr); }
 
-namespace {
-
 // Disable instrumentation optimizations that sacrifice profile accuracy
 extern "C" bool __bolt_instr_conservative;
+
+namespace {
 
 /// Basic key-val atom stored in our hash
 struct SimpleHashTableEntryBase {


### PR DESCRIPTION
GCC 15 changes how it interprets extern "C" in unnamed namespaces and gives the variable internal linkage.