### PR TITLE
[Runtimes] Gracefully handle invalid LLVM_TARGET_TRIPLE

### DIFF
--- a/cmake/Modules/GetToolchainDirs.cmake
+++ b/cmake/Modules/GetToolchainDirs.cmake
@@ -118,11 +118,21 @@ endfunction()
 # Corresponds to Clang's ToolChain::getRuntimePath().
 function (get_toolchain_target_dirname outvar)
   string(FIND "${LLVM_TARGET_TRIPLE}" "-" dash_index)
-  string(SUBSTRING "${LLVM_TARGET_TRIPLE}" 0 "${dash_index}" triple_cpu)
-  set(arch "${triple_cpu}")
-  if("${arch}" MATCHES "^i.86$")
-    set(arch "i386")
-  endif()
-  get_runtimes_target_libdir_common("${LLVM_TARGET_TRIPLE}" "${arch}" target)
+  if (dash_index EQUAL "-1")
+    # This means LLVM_TARGET_TRIPLE is not set and we cannot derive the dirname
+    # from it. The proper behavior here would be to emit an error since we have
+    # no target we can build for. However, compiler-rt uses
+    # COMPILER_RT_DEFAULT_TARGET_TRIPLE instead and ignores LLVM_TARGET_TRIPLE.
+    # To not break the build when building only compiler-rt, we skip the triple
+    # subdirectory.
+    set(target "")
+  else ()
+    string(SUBSTRING "${LLVM_TARGET_TRIPLE}" 0 "${dash_index}" triple_cpu)
+    set(arch "${triple_cpu}")
+    if("${arch}" MATCHES "^i.86$")
+      set(arch "i386")
+    endif()
+    get_runtimes_target_libdir_common("${LLVM_TARGET_TRIPLE}" "${arch}" target)
+  endif ()
   set("${outvar}" "${target}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
In some situations such as reported at https://github.com/llvm/llvm-project/pull/177953#issuecomment-4179014239, LLVM_(DEFAULT_)TARGET_TRIPLE is not set. It is used to derive the output directory in #177953. Only flang-rt currently uses RUNTIMES_(INSTALL|OUTPUT)_RESOURCE_LIB_PATH, we should not fail building other despite a missing LLVM_TARGET_TRIPLE.

Compiler-rt uses COMPILER_RT_DEFAULT_TARGET_TRIPLE instead which it derives itself. Most other LLVM runtimes libraries just skip the target portion of the library path (explicitly so since #93354). Do the same for RUNTIMES_(INSTALL|OUTPUT)_RESOURCE_LIB_PATH which we hope eventually can replace the other mechanisms.