### PR TITLE
[CIR] Fix mixing of catch-all and type-specific catch handlers

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -6908,20 +6908,29 @@ def CIR_EhInflightOp : CIR_Op<"eh.inflight_exception"> {
     This helps CIR to pass down more accurate information for LLVM lowering
     to landingpads.
 
+    The `catch_all` attribute indicates that a catch-all handler exists for
+    the exception being dispatched. When lowered to LLVM IR, this results in
+    a `catch ptr null` clause on the landing pad. When `catch_all` is present
+    alongside typed catches, the landing pad will contain both the typed catch
+    clauses and a trailing `catch ptr null`.
+
     Example:
 
     ```mlir
     %exception_ptr, %type_id = cir.eh.inflight_exception
     %exception_ptr, %type_id = cir.eh.inflight_exception [@_ZTIi, @_ZTIPKc]
     %exception_ptr, %type_id = cir.eh.inflight_exception cleanup
+    %exception_ptr, %type_id = cir.eh.inflight_exception catch_all [@_ZTIi]
     ``
   }];
 
   let arguments = (ins UnitAttr:$cleanup,
+                       UnitAttr:$catch_all,
                        OptionalAttr<FlatSymbolRefArrayAttr>:$catch_type_list);
   let results = (outs CIR_VoidPtrType:$exception_ptr, CIR_UInt32:$type_id);
   let assemblyFormat = [{
     (`cleanup` $cleanup^)?
+    (`catch_all` $catch_all^)?
     ($catch_type_list^)?
     attr-dict
   }];

--- a/clang/lib/CIR/Dialect/Transforms/EHABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/EHABILowering.cpp
@@ -318,6 +318,7 @@ void ItaniumEHLowering::lowerEhInitiate(
   builder.setInsertionPoint(initiateOp);
   auto inflightOp = cir::EhInflightOp::create(
       builder, initiateOp.getLoc(), /*cleanup=*/initiateOp.getCleanup(),
+      /*catch_all=*/false,
       /*catch_type_list=*/mlir::ArrayAttr{});
 
   ehTokenMap[rootToken] = {inflightOp.getExceptionPtr(),
@@ -412,6 +413,8 @@ void ItaniumEHLowering::lowerEhInitiate(
                 mlir::cast<cir::GlobalViewAttr>(attr).getSymbol());
           inflightOp.setCatchTypeListAttr(builder.getArrayAttr(typeSymbols));
         }
+        if (op.getDefaultIsCatchAll())
+          inflightOp.setCatchAllAttr(builder.getUnitAttr());
         // Only lower the dispatch once. A sibling initiate sharing the same
         // dispatch will still read its catch types (above), but the comparison
         // chain and branch replacement are only created the first time.

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -3926,10 +3926,12 @@ mlir::LogicalResult CIRToLLVMEhInflightOpLowering::matchAndRewrite(
           rewriter, loc, llvmPtrTy, symAttr.getValue());
       catchSymAddrs.push_back(addrOp);
     }
-  } else if (!op.getCleanup()) {
-    // We need to emit catch-all only if cleanup is not set, because when we
-    // have catch-all handler, there is no case when we set would unwind past
-    // the handler
+  }
+
+  // Emit a catch-all clause (catch ptr null) when:
+  //   - The catch_all attribute is set (typed catches + catch-all), or
+  //   - No typed catches and no cleanup (legacy pure catch-all form)
+  if (op.getCatchAll() || (!catchListAttr && !op.getCleanup())) {
     mlir::OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPointToStart(entryBlock);
     mlir::Value nullOp = mlir::LLVM::ZeroOp::create(rewriter, loc, llvmPtrTy);
@@ -3943,7 +3945,10 @@ mlir::LogicalResult CIRToLLVMEhInflightOpLowering::matchAndRewrite(
   auto landingPadOp = mlir::LLVM::LandingpadOp::create(
       rewriter, loc, llvmLandingPadStructTy, catchSymAddrs);
 
-  if (op.getCleanup())
+  // The LLVM cleanup flag is only needed when there is no catch-all handler,
+  // since catch-all (catch ptr null) already ensures the personality function
+  // enters the landing pad for all exception types.
+  if (op.getCleanup() && !op.getCatchAll())
     landingPadOp.setCleanup(true);
 
   mlir::Value slot =

--- a/clang/test/CIR/CodeGen/try-catch-all-with-cleanup.cpp
+++ b/clang/test/CIR/CodeGen/try-catch-all-with-cleanup.cpp
@@ -136,3 +136,175 @@ void test_catch_all_with_cleanup() {
 // OGCG:         call ptr @__cxa_begin_catch
 // OGCG:         call void @__cxa_end_catch()
 // OGCG:         ret void
+
+void test_catch_all_and_specific_with_cleanup() {
+  try {
+    S s;
+    mayThrow();
+  } catch (int e) {
+  } catch (...) {
+  }
+}
+
+// CIR-LABEL: cir.func {{.*}} @_Z40test_catch_all_and_specific_with_cleanupv()
+// CIR:   cir.scope {
+// CIR:     %[[S:.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["s", init]
+// CIR:     %[[E:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["e"]
+// CIR:     cir.try {
+// CIR:       cir.call @_ZN1SC1Ev(%[[S]])
+// CIR:       cir.cleanup.scope {
+// CIR:         cir.call @_Z8mayThrowv()
+// CIR:         cir.yield
+// CIR:       } cleanup all {
+// CIR:         cir.call @_ZN1SD1Ev(%[[S]]) nothrow
+// CIR:         cir.yield
+// CIR:       }
+// CIR:       cir.yield
+// CIR:     } catch [type #cir.global_view<@_ZTIi> : !cir.ptr<!u8i>] (%{{.*}}: !cir.eh_token {{.*}}) {
+// CIR:       %{{.*}}, %[[EXN:.*]] = cir.begin_catch %{{.*}} : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
+// CIR:       cir.cleanup.scope {
+// CIR:         cir.load{{.*}} %[[EXN]] : !cir.ptr<!s32i>, !s32i
+// CIR:         cir.store{{.*}} %{{.*}}, %[[E]] : !s32i, !cir.ptr<!s32i>
+// CIR:         cir.yield
+// CIR:       } cleanup all {
+// CIR:         cir.end_catch %{{.*}} : !cir.catch_token
+// CIR:         cir.yield
+// CIR:       }
+// CIR:       cir.yield
+// CIR:     } catch all (%{{.*}}: !cir.eh_token {{.*}}) {
+// CIR:       %{{.*}}, %{{.*}} = cir.begin_catch %{{.*}} : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
+// CIR:       cir.cleanup.scope {
+// CIR:         cir.yield
+// CIR:       } cleanup all {
+// CIR:         cir.end_catch %{{.*}} : !cir.catch_token
+// CIR:         cir.yield
+// CIR:       }
+// CIR:       cir.yield
+// CIR:     }
+// CIR:   }
+
+// CIR-FLAT-LABEL: cir.func {{.*}} @_Z40test_catch_all_and_specific_with_cleanupv()
+//
+// CIR-FLAT:         %[[S:.*]] = cir.alloca !rec_S
+// CIR-FLAT:         %[[E:.*]] = cir.alloca !s32i
+//
+// Ctor may throw; unwinds directly to the dispatch (no cleanup needed yet).
+// CIR-FLAT:         cir.try_call @_ZN1SC1Ev(%[[S]]) ^[[AFTER_CTOR:bb[0-9]+]], ^[[CTOR_UNWIND:bb[0-9]+]]
+//
+// After the ctor, enter the cleanup scope where mayThrow may throw.
+// CIR-FLAT:       ^[[AFTER_CTOR]]:
+// CIR-FLAT:         cir.try_call @_Z8mayThrowv() ^[[NORMAL:bb[0-9]+]], ^[[INNER_UNWIND:bb[0-9]+]]
+//
+// Normal path: destroy s and exit the try.
+// CIR-FLAT:       ^[[NORMAL]]:
+// CIR-FLAT:         cir.call @_ZN1SD1Ev(%[[S]]) nothrow
+// CIR-FLAT:         cir.br ^{{.*}}
+//
+// Inner unwind: run cleanup (dtor of s), then dispatch int vs catch-all.
+// CIR-FLAT:       ^[[INNER_UNWIND]]:
+// CIR-FLAT:         %[[INNER_ET:.*]] = cir.eh.initiate : !cir.eh_token
+// CIR-FLAT:         cir.br ^[[EH_CLEANUP:bb[0-9]+]](%[[INNER_ET]] : !cir.eh_token)
+//
+// EH cleanup: destroy s on the exception path, then go to dispatch.
+// CIR-FLAT:       ^[[EH_CLEANUP]](%[[EH_ET:.*]]: !cir.eh_token):
+// CIR-FLAT:         %[[CT:.*]] = cir.begin_cleanup %[[EH_ET]]
+// CIR-FLAT:         cir.call @_ZN1SD1Ev(%[[S]]) nothrow
+// CIR-FLAT:         cir.end_cleanup %[[CT]]
+// CIR-FLAT:         cir.br ^[[DISPATCH:bb[0-9]+]](%[[EH_ET]] : !cir.eh_token)
+//
+// Ctor unwind: NO cleanup flag — goes directly to dispatch.
+// CIR-FLAT:       ^[[CTOR_UNWIND]]:
+// CIR-FLAT:         %[[CTOR_ET:.*]] = cir.eh.initiate : !cir.eh_token
+// CIR-FLAT:         cir.br ^[[DISPATCH]](%[[CTOR_ET]] : !cir.eh_token)
+//
+// Dispatch: typed catch (int) first, then catch-all.
+// CIR-FLAT:       ^[[DISPATCH]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CIR-FLAT:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
+// CIR-FLAT:           catch(#cir.global_view<@_ZTIi> : !cir.ptr<!u8i>) : ^[[CATCH_INT:bb[0-9]+]],
+// CIR-FLAT:           catch_all : ^[[CATCH_ALL:bb[0-9]+]]
+// CIR-FLAT:         ]
+//
+// Catch (int): bind e, end_catch, merge to return.
+// CIR-FLAT:       ^[[CATCH_INT]](%{{.*}}: !cir.eh_token):
+// CIR-FLAT:         %{{.*}}, %[[EXN_PTR:.*]] = cir.begin_catch %{{.*}} : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
+// CIR-FLAT:         cir.load{{.*}} %[[EXN_PTR]] : !cir.ptr<!s32i>, !s32i
+// CIR-FLAT:         cir.store{{.*}} %{{.*}}, %[[E]] : !s32i, !cir.ptr<!s32i>
+// CIR-FLAT:         cir.end_catch %{{.*}} : !cir.catch_token
+// CIR-FLAT:         cir.br ^{{.*}}
+//
+// Catch-all handler.
+// CIR-FLAT:       ^[[CATCH_ALL]](%[[CA_ET:.*]]: !cir.eh_token):
+// CIR-FLAT:         %{{.*}}, %{{.*}} = cir.begin_catch %[[CA_ET]]
+// CIR-FLAT:         cir.br ^{{.*}}
+// CIR-FLAT:         cir.end_catch %{{.*}} : !cir.catch_token
+// CIR-FLAT:         cir.br ^{{.*}}
+//
+// CIR-FLAT:         cir.return
+
+// Lowering from CIR lists only the typed catch in each landingpad; the
+// catch-all is reached from the shared dispatch block (typeid / icmp), not from
+// a separate "catch ptr null" clause on those pads.
+
+// LLVM-LABEL: define {{.*}} void @_Z40test_catch_all_and_specific_with_cleanupv()
+// LLVM-SAME:    personality ptr @__gxx_personality_v0
+// LLVM:         %[[S:.*]] = alloca %struct.S
+// LLVM:         %[[E:.*]] = alloca i32
+// LLVM:         invoke void @_ZN1SC1Ev({{.*}}%[[S]])
+// LLVM:                 to label %[[AFTER_CTOR:.*]] unwind label %[[CTOR_LP:.*]]
+// LLVM:       [[AFTER_CTOR]]:
+// LLVM:         invoke void @_Z8mayThrowv()
+// LLVM:                 to label %[[NORMAL:.*]] unwind label %[[INNER_LP:.*]]
+// LLVM:       [[NORMAL]]:
+// LLVM:         call void @_ZN1SD1Ev({{.*}}%[[S]])
+// LLVM:       [[INNER_LP]]:
+// LLVM:         landingpad { ptr, i32 }
+// LLVM:                 catch ptr @_ZTIi
+// LLVM:                 catch ptr null
+// LLVM:         call void @_ZN1SD1Ev({{.*}}%[[S]])
+// LLVM:       [[CTOR_LP]]:
+// LLVM:         landingpad { ptr, i32 }
+// LLVM:                 catch ptr @_ZTIi
+// LLVM:                 catch ptr null
+// LLVM:         call i32 @llvm.eh.typeid.for.p0(ptr @_ZTIi)
+// LLVM:         icmp eq i32 {{.*}}, {{.*}}
+// LLVM:       {{.*}}:
+// LLVM:         call ptr @__cxa_begin_catch
+// LLVM:         load i32, ptr {{.*}}
+// LLVM:         store i32 {{.*}}, ptr %[[E]]
+// LLVM:         call void @__cxa_end_catch()
+// LLVM:       {{.*}}:
+// LLVM:         call ptr @__cxa_begin_catch
+// LLVM:         call void @__cxa_end_catch()
+// LLVM:         ret void
+
+// OGCG-LABEL: define {{.*}} void @_Z40test_catch_all_and_specific_with_cleanupv()
+// OGCG-SAME:    personality ptr @__gxx_personality_v0
+// OGCG:         %[[S:.*]] = alloca %struct.S
+// OGCG:         invoke void @_ZN1SC1Ev({{.*}}%[[S]])
+// OGCG:                 to label %[[AFTER_CTOR:.*]] unwind label %[[CTOR_LP:.*]]
+// OGCG:       [[AFTER_CTOR]]:
+// OGCG:         invoke void @_Z8mayThrowv()
+// OGCG:                 to label %[[NORMAL:.*]] unwind label %[[INNER_LP:.*]]
+// OGCG:       [[NORMAL]]:
+// OGCG:         call void @_ZN1SD1Ev({{.*}}%[[S]])
+// OGCG:       [[CTOR_LP]]:
+// OGCG:         landingpad { ptr, i32 }
+// OGCG:                 catch ptr @_ZTIi
+// OGCG:                 catch ptr null
+// OGCG:       [[INNER_LP]]:
+// OGCG:         landingpad { ptr, i32 }
+// OGCG:                 catch ptr @_ZTIi
+// OGCG:                 catch ptr null
+// OGCG:         call void @_ZN1SD1Ev({{.*}}%[[S]])
+// OGCG:         call ptr @__cxa_begin_catch
+// OGCG:         load i32, ptr {{.*}}
+// OGCG:         store i32 {{.*}}, ptr %e
+// OGCG:         call void @__cxa_end_catch()
+// OGCG:         br label %try.cont
+// OGCG:       try.cont:
+// OGCG:         ret void
+// OGCG:       catch:
+// OGCG:         load ptr, ptr {{.*}}
+// OGCG:         call ptr @__cxa_begin_catch
+// OGCG:         call void @__cxa_end_catch()
+// OGCG:         br label %try.cont

--- a/clang/test/CIR/IR/eh-inflight.cir
+++ b/clang/test/CIR/IR/eh-inflight.cir
@@ -37,4 +37,24 @@ cir.func dso_local @inflight_exception_with_catch_type_list() {
 // CHECK:  cir.return
 // CHECK:}
 
+cir.func dso_local @inflight_exception_with_catch_all() {
+  %exception_ptr, %type_id = cir.eh.inflight_exception catch_all
+  cir.return
+}
+
+// CHECK: cir.func dso_local @inflight_exception_with_catch_all() {
+// CHECK:  %exception_ptr, %type_id = cir.eh.inflight_exception catch_all
+// CHECK:  cir.return
+// CHECK:}
+
+cir.func dso_local @inflight_exception_with_catch_all_and_type_list() {
+  %exception_ptr, %type_id = cir.eh.inflight_exception catch_all [@_ZTIi]
+  cir.return
+}
+
+// CHECK: cir.func dso_local @inflight_exception_with_catch_all_and_type_list() {
+// CHECK:  %exception_ptr, %type_id = cir.eh.inflight_exception catch_all [@_ZTIi]
+// CHECK:  cir.return
+// CHECK:}
+
 }

--- a/clang/test/CIR/Lowering/eh-inflight.cir
+++ b/clang/test/CIR/Lowering/eh-inflight.cir
@@ -52,5 +52,32 @@ cir.func @inflight_exception_with_catch_type_list() personality(@__gxx_personali
 // CHECK:   llvm.return
 // CHECK: }
 
+cir.func @inflight_exception_catch_all_with_type_list() personality(@__gxx_personality_v0) {
+  %exception_ptr, %type_id = cir.eh.inflight_exception catch_all [@_ZTIi]
+  cir.return
+}
+
+// CHECK: llvm.func @inflight_exception_catch_all_with_type_list() attributes {personality = @__gxx_personality_v0} {
+// CHECK:   %[[NULL:.*]] = llvm.mlir.zero : !llvm.ptr
+// CHECK:   %[[TI_ADDR:.*]] = llvm.mlir.addressof @_ZTIi : !llvm.ptr
+// CHECK:   %[[LP:.*]] = llvm.landingpad (catch %[[TI_ADDR]] : !llvm.ptr) (catch %[[NULL]] : !llvm.ptr) : !llvm.struct<(ptr, i32)>
+// CHECK:   %[[EXCEPTION_PTR:.*]] = llvm.extractvalue %[[LP]][0] : !llvm.struct<(ptr, i32)>
+// CHECK:   %[[TYPE_ID:.*]] = llvm.extractvalue %[[LP]][1] : !llvm.struct<(ptr, i32)>
+// CHECK:   llvm.return
+// CHECK: }
+
+cir.func @inflight_exception_catch_all_only() personality(@__gxx_personality_v0) {
+  %exception_ptr, %type_id = cir.eh.inflight_exception catch_all
+  cir.return
+}
+
+// CHECK: llvm.func @inflight_exception_catch_all_only() attributes {personality = @__gxx_personality_v0} {
+// CHECK:   %[[NULL:.*]] = llvm.mlir.zero : !llvm.ptr
+// CHECK:   %[[LP:.*]] = llvm.landingpad (catch %[[NULL]] : !llvm.ptr) : !llvm.struct<(ptr, i32)>
+// CHECK:   %[[EXCEPTION_PTR:.*]] = llvm.extractvalue %[[LP]][0] : !llvm.struct<(ptr, i32)>
+// CHECK:   %[[TYPE_ID:.*]] = llvm.extractvalue %[[LP]][1] : !llvm.struct<(ptr, i32)>
+// CHECK:   llvm.return
+// CHECK: }
+
 
 }

--- a/clang/test/CIR/Transforms/eh-abi-lowering-itanium.cir
+++ b/clang/test/CIR/Transforms/eh-abi-lowering-itanium.cir
@@ -93,7 +93,7 @@ cir.func @test_catch_all() {
 //
 // Landing pad with catch_all (no cleanup, no typed catches).
 // CHECK:       ^[[UNWIND]]:
-// CHECK:         %[[EXN:.*]], %[[TID:.*]] = cir.eh.inflight_exception
+// CHECK:         %[[EXN:.*]], %[[TID:.*]] = cir.eh.inflight_exception catch_all
 // CHECK:         cir.br ^[[DISPATCH:bb[0-9]+]](%[[EXN]], %[[TID]] : !cir.ptr<!void>, !u32i)
 //
 // Dispatch replaced with direct branch to catch-all handler.
@@ -209,7 +209,7 @@ cir.func @test_multiple_typed_and_catch_all() {
 //
 // Landing pad with typed catches AND catch-all.
 // CHECK:       ^[[UNWIND]]:
-// CHECK:         %[[EXN:.*]], %[[TID:.*]] = cir.eh.inflight_exception [@_ZTISt9exception, @_ZTIi]
+// CHECK:         %[[EXN:.*]], %[[TID:.*]] = cir.eh.inflight_exception catch_all [@_ZTISt9exception, @_ZTIi]
 // CHECK:         cir.br ^[[CMP1_BLOCK:bb[0-9]+]](%[[EXN]], %[[TID]] : !cir.ptr<!void>, !u32i)
 //
 // Dispatch: branch to comparison chain.
@@ -298,14 +298,14 @@ cir.func @test_catch_with_cleanup() {
 // CHECK:         cir.call @dtor
 // CHECK:         cir.br ^[[RETURN:bb[0-9]+]]
 //
-// Ctor unwind: landing pad without cleanup.
+// Ctor unwind: landing pad without cleanup, with catch_all.
 // CHECK:       ^[[CTOR_UNWIND]]:
-// CHECK:         %[[E1:.*]], %[[T1:.*]] = cir.eh.inflight_exception
+// CHECK:         %[[E1:.*]], %[[T1:.*]] = cir.eh.inflight_exception catch_all
 // CHECK:         cir.br ^[[DISPATCH:bb[0-9]+]](%[[E1]], %[[T1]] : !cir.ptr<!void>, !u32i)
 //
-// doSomething unwind: landing pad with cleanup.
+// doSomething unwind: landing pad with cleanup and catch_all.
 // CHECK:       ^[[DO_UNWIND]]:
-// CHECK:         %[[E2:.*]], %[[T2:.*]] = cir.eh.inflight_exception cleanup
+// CHECK:         %[[E2:.*]], %[[T2:.*]] = cir.eh.inflight_exception cleanup catch_all
 // CHECK:         cir.br ^[[CLEANUP:bb[0-9]+]](%[[E2]], %[[T2]] : !cir.ptr<!void>, !u32i)
 //
 // EH cleanup: begin_cleanup and end_cleanup are REMOVED, dtor call stays.
@@ -467,9 +467,9 @@ cir.func no_inline dso_local @test_catch_with_cleanup_no_ctor() personality(@__g
 // CHECK:       ^[[NORMAL]]:
 // CHECK:         cir.call @dtor
 //
-// Unwind: initiate cleanup → inflight_exception cleanup with std::exception type.
+// Unwind: initiate cleanup → inflight_exception cleanup catch_all with std::exception type.
 // CHECK:       ^[[UNWIND]]:
-// CHECK:         %[[EXN:.*]], %[[TID:.*]] = cir.eh.inflight_exception cleanup [@_ZTISt9exception]
+// CHECK:         %[[EXN:.*]], %[[TID:.*]] = cir.eh.inflight_exception cleanup catch_all [@_ZTISt9exception]
 // CHECK:         cir.br ^[[CLEANUP:bb[0-9]+]](%[[EXN]], %[[TID]] : !cir.ptr<!void>, !u32i)
 //
 // Cleanup: begin_cleanup/end_cleanup removed, destructor call stays.


### PR DESCRIPTION
If a try block has a catch-all handler and one or more type-specific catch handlers, we were failing to generate the null type specifier when lowering from CIR to LLVM IR. This change fixes that problem.

Assisted-by: Cursor / claude-4.6-opus-high