### PR TITLE
[CIR] Implement top level 'ExportDecl' emission

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1970,6 +1970,9 @@ void CIRGenModule::emitTopLevelDecl(Decl *decl) {
       emitGlobal(fd);
     break;
   }
+  case Decl::Export:
+    emitDeclContext(cast<ExportDecl>(decl));
+    break;
 
   case Decl::Var:
   case Decl::Decomposition:

--- a/clang/test/CIR/CodeGen/export-decl.cppm
+++ b/clang/test/CIR/CodeGen/export-decl.cppm
@@ -1,0 +1,27 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+export module Foo;
+
+export void exportedFunc() {}
+// CIR-DAG:  cir.func no_inline dso_local @_ZW3Foo12exportedFuncv
+// LLVM-DAG: define dso_local void @_ZW3Foo12exportedFuncv
+
+export {
+  void exportedFunc2() {}
+  int exportedVar = 42;
+}
+// CIR-DAG:  cir.func no_inline dso_local @_ZW3Foo13exportedFunc2v
+// LLVM-DAG: define dso_local void @_ZW3Foo13exportedFunc2v
+
+// CIR-DAG:  cir.global external @_ZW3Foo11exportedVar = #cir.int<42> : !s32i
+// LLVM-DAG: @_ZW3Foo11exportedVar = global i32 42
+
+// Not exported, but still has mangling/linkage.
+void internalFunc() {}
+// CIR-DAG:  cir.func no_inline dso_local @_ZW3Foo12internalFuncv
+// LLVM-DAG: define dso_local void @_ZW3Foo12internalFuncv


### PR DESCRIPTION
This is a pretty simple one, its just a type of decl-context.  The actual exporty-ness is handled on a per-declaration basis.

This patch just makes sure we emit them, as I suspect this will reveal quite a bit more issues in module code I suspect.