### PR TITLE
[clang][DebugInfo][test] Set -fuse-lld for test matching linker invocation.

### DIFF
--- a/clang/test/DebugInfo/CXX/hotpatch.cpp
+++ b/clang/test/DebugInfo/CXX/hotpatch.cpp
@@ -9,7 +9,8 @@
 // RUN: llvm-pdbutil dump -symbols %t.obj | FileCheck %s --check-prefix=NO-HOTPATCH
 // NO-HOTPATCH-NOT: flags = hot patchable
 ///
-// RUN: %clang_cl --target=x86_64-windows-msvc /hotpatch -### -- %s 2>&1 \
+// RUN: %clang_cl --target=x86_64-windows-msvc -fuse-ld=link \
+// RUN:    /hotpatch -### -- %s 2>&1 \
 // RUN:    | FileCheck %s --check-prefix=FUNCTIONPADMIN
 // FUNCTIONPADMIN: clang{{.*}}
 // FUNCTIONPADMIN: {{link[^"]*"}} 


### PR DESCRIPTION
This test doesn't appear to work when an alternative default linker is specified via `-DCLANG_DEFAULT_LINKER=ld`. If this test isn't intended to support alternate default linker, lmk I can just change the downstream usage I'm seeing, though I figure other folks may have similar configurations. Repro:

```
cmake -S llvm -B build -DLLVM_ENABLE_PROJECTS="clang" -DCLANG_DEFAULT_LINKER=ld -GNinja
ninja -C build
./build/bin/llvm-lit -v clang/test/DebugInfo/CXX/hotpatch.cpp

...

possible intended match
# |             6:  "/usr/bin/ld" "-out:hotpatch.exe" "-libpath:lib/amd64" "-libpath:atlmfc/lib/amd64" "-nologo" "-functionpadmin" "/tmp/lit-tmp-o7x0r1o_/hotpatch-4595de.obj" 
```

afaict it passed before because `-mincremental-linker-compatible` was being used until e97a42d5f9fe51de50aabd4d9bf6874a4955f9fa, which would match on the compilation line.