### PR TITLE
[compiler-rt] Add hexagon to libFuzzer supported architectures

### DIFF
--- a/compiler-rt/cmake/Modules/AllSupportedArchDefs.cmake
+++ b/compiler-rt/cmake/Modules/AllSupportedArchDefs.cmake
@@ -63,7 +63,7 @@ endif()
 
 if(OS_NAME MATCHES "Linux")
   set(ALL_FUZZER_SUPPORTED_ARCH ${X86} ${X86_64} ${ARM32} ${ARM64} ${S390X}
-      ${RISCV64} ${LOONGARCH64})
+      ${RISCV64} ${LOONGARCH64} ${HEXAGON})
 elseif (OS_NAME MATCHES "Windows")
   set(ALL_FUZZER_SUPPORTED_ARCH ${X86} ${X86_64})
 elseif(OS_NAME MATCHES "Android")


### PR DESCRIPTION
LibFuzzer builds successfully for Hexagon Linux.