### PR TITLE
[ELF] Enable parallel relocation scanning for -z nocombreloc and PPC64

### DIFF
--- a/lld/ELF/Arch/PPC64.cpp
+++ b/lld/ELF/Arch/PPC64.cpp
@@ -1196,8 +1196,10 @@ void PPC64::scanSectionImpl(InputSectionBase &sec, Relocs<RelTy> rels) {
     case R_PPC64_TOC16_LO:
       // Record the TOC entry (.toc + addend) as not relaxable.
       if (sym.isSection() && isa<Defined>(sym) &&
-          cast<Defined>(sym).section->name == ".toc")
+          cast<Defined>(sym).section->name == ".toc") {
+        std::lock_guard<std::mutex> lock(ctx.relocMutex);
         ctx.ppc64noTocRelax.insert({&sym, addend});
+      }
       expr = R_GOTREL;
       break;
     case R_PPC64_TOC16_HA:

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1184,11 +1184,9 @@ template <class ELFT> void elf::scanRelocations(Ctx &ctx) {
   // copy relocations, etc. Note that relocations for non-alloc sections are
   // directly processed by InputSection::relocateNonAlloc.
 
-  // Deterministic parallellism needs sorting relocations which is unsuitable
-  // for -z nocombreloc. MIPS and PPC64 use global states which are not suitable
-  // for parallelism.
-  bool serial = !ctx.arg.zCombreloc || ctx.arg.emachine == EM_MIPS ||
-                ctx.arg.emachine == EM_PPC64;
+  // MIPS modifies MipsGotSection during relocation scanning, which is not
+  // suitable for parallelism.
+  bool serial = ctx.arg.emachine == EM_MIPS;
   parallel::TaskGroup tg;
   auto outerFn = [&]() {
     for (ELFFileBase *f : ctx.objectFiles) {

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -4564,7 +4564,7 @@ template <class ELFT> void elf::createSyntheticSections(Ctx &ctx) {
           ctx, relaDynName, threadCount);
     else
       part.relaDyn = std::make_unique<RelocationSection<ELFT>>(
-          ctx, relaDynName, ctx.arg.zCombreloc, threadCount);
+          ctx, relaDynName, /*combreloc=*/true, threadCount);
 
     if (ctx.hasDynsym) {
       add(*part.dynSymTab);

--- a/lld/test/ELF/combreloc.s
+++ b/lld/test/ELF/combreloc.s
@@ -32,11 +32,11 @@
 # NOCOMB:      Relocations [
 # NOCOMB-NEXT:   Section ({{.*}}) .rela.dyn {
 # NOCOMB-NEXT:     0x3418 R_X86_64_RELATIVE - 0x3420
-# NOCOMB-NEXT:     0x33F8 R_X86_64_64 aaa 0x0
-# NOCOMB-NEXT:     0x3400 R_X86_64_64 ccc 0x0
-# NOCOMB-NEXT:     0x3408 R_X86_64_64 bbb 0x0
-# NOCOMB-NEXT:     0x3410 R_X86_64_64 aaa 0x0
 # NOCOMB-NEXT:     0x23F0 R_X86_64_GLOB_DAT aaa 0x0
+# NOCOMB-NEXT:     0x33F8 R_X86_64_64 aaa 0x0
+# NOCOMB-NEXT:     0x3410 R_X86_64_64 aaa 0x0
+# NOCOMB-NEXT:     0x3408 R_X86_64_64 bbb 0x0
+# NOCOMB-NEXT:     0x3400 R_X86_64_64 ccc 0x0
 # NOCOMB-NEXT:   }
 
 .globl aaa, bbb, ccc


### PR DESCRIPTION
The `bool serial` condition in scanRelocations disabled parallelism for
three cases: -z nocombreloc, MIPS, and PPC64. Resolve two cases:

- nocombreloc: .rela.dyn is now always created with combreloc=true so
  non-relative relocations are sorted deterministically. Since
  #187964 already separates relative relocations unconditionally,
  the only remaining effect of -z nocombreloc is suppressing
  DT_RELACOUNT (gated on ctx.arg.zCombreloc in DynamicSection).

- PPC64: After #181496 moved scanning into scanSectionImpl, the
  sole thread-unsafe access is ctx.ppc64noTocRelax (DenseSet::insert).
  Protect it with ctx.relocMutex, which is already used for rare
  operations during parallel scanning.

MIPS retains serial scanning due to `MipsGotSection` mutations.