### PR TITLE
[llvm-link] Inherit data layout from first archive member

### DIFF
--- a/llvm/test/tools/llvm-link/Inputs/archive-dl-a.ll
+++ b/llvm/test/tools/llvm-link/Inputs/archive-dl-a.ll
@@ -1,0 +1,6 @@
+target datalayout = "e-m:e-p:64:64-i64:64-n8:16:32:64"
+target triple = "spirv64-unknown-unknown"
+
+define void @archive_dl_a() {
+  ret void
+}

--- a/llvm/test/tools/llvm-link/Inputs/archive-dl-a2.ll
+++ b/llvm/test/tools/llvm-link/Inputs/archive-dl-a2.ll
@@ -1,0 +1,6 @@
+target datalayout = "e-m:e-p:64:64-i64:64-n8:16:32:64"
+target triple = "spirv64-unknown-unknown"
+
+define void @archive_dl_a2() {
+  ret void
+}

--- a/llvm/test/tools/llvm-link/Inputs/archive-dl-b.ll
+++ b/llvm/test/tools/llvm-link/Inputs/archive-dl-b.ll
@@ -1,0 +1,6 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @archive_dl_b() {
+  ret void
+}

--- a/llvm/test/tools/llvm-link/archive-datalayout-mismatch.test
+++ b/llvm/test/tools/llvm-link/archive-datalayout-mismatch.test
@@ -1,0 +1,19 @@
+# When archive members have different data layouts, llvm-link should still
+# warn about the genuine mismatch.  This verifies the fix does not suppress
+# legitimate warnings.
+
+# RUN: llvm-as %S/Inputs/archive-dl-a.ll -o %t.a1.bc
+# RUN: llvm-as %S/Inputs/archive-dl-b.ll -o %t.a2.bc
+# RUN: llvm-ar cr %t.mismatch.a %t.a1.bc %t.a2.bc
+# RUN: llvm-link %t.mismatch.a -S -o %t.out.ll 2>%t.err
+# RUN: FileCheck --check-prefix=WARN %s < %t.err
+# RUN: FileCheck --check-prefix=OUTPUT %s < %t.out.ll
+
+# The second member has a different layout, so it must warn.
+# WARN: warning: Linking two modules of different data layouts
+
+# The first archive member's layout should win.
+# OUTPUT: target datalayout = "e-m:e-p:64:64-i64:64-n8:16:32:64"
+# OUTPUT: target triple = "spirv64-unknown-unknown"
+# OUTPUT: define void @archive_dl_a()
+# OUTPUT: define void @archive_dl_b()

--- a/llvm/test/tools/llvm-link/archive-datalayout-same.test
+++ b/llvm/test/tools/llvm-link/archive-datalayout-same.test
@@ -1,0 +1,17 @@
+# When all archive members share the same data layout, llvm-link should
+# produce no warnings.  Before the fix, the empty result module's layout
+# mismatched every member, causing spurious warnings.
+
+# RUN: llvm-as %S/Inputs/archive-dl-a.ll -o %t.a1.bc
+# RUN: llvm-as %S/Inputs/archive-dl-a2.ll -o %t.a2.bc
+# RUN: llvm-ar cr %t.same.a %t.a1.bc %t.a2.bc
+# RUN: llvm-link %t.same.a -S -o %t.out.ll 2>%t.err
+# RUN: FileCheck --allow-empty --check-prefix=NO-WARN %s < %t.err
+# RUN: FileCheck --check-prefix=OUTPUT %s < %t.out.ll
+
+# NO-WARN-NOT: warning
+
+# OUTPUT: target datalayout = "e-m:e-p:64:64-i64:64-n8:16:32:64"
+# OUTPUT: target triple = "spirv64-unknown-unknown"
+# OUTPUT: define void @archive_dl_a()
+# OUTPUT: define void @archive_dl_a2()

--- a/llvm/tools/llvm-link/llvm-link.cpp
+++ b/llvm/tools/llvm-link/llvm-link.cpp
@@ -219,6 +219,16 @@ static std::unique_ptr<Module> loadArFile(const char *Argv0,
                          << "'\n";
       return nullptr;
     }
+
+    // The result module starts with an empty data layout and triple.
+    // Populate them from the first member that has them so the linker
+    // doesn't warn about every subsequent member mismatching an empty
+    // layout.  Genuine mismatches between archive members still warn.
+    if (Result->getDataLayoutStr().empty() && !M->getDataLayoutStr().empty())
+      Result->setDataLayout(M->getDataLayout());
+    if (Result->getTargetTriple().empty() && !M->getTargetTriple().empty())
+      Result->setTargetTriple(M->getTargetTriple());
+
     if (Verbose)
       errs() << "Linking member '" << ChildName << "' of archive library.\n";
     if (L.linkInModule(std::move(M)))


### PR DESCRIPTION
When `llvm-link` loads an archive, it creates an empty result `Module` with no data layout or target triple, then links archive members into it. This causes spurious "linking modules with different data layouts" warnings for every member, since the empty module's layout doesn't match anything.

Fix this by populating the result module's data layout and target triple from the first bitcode member that provides them, but only when the result doesn't already have them set. This way:
- The first member's layout seeds the result (no spurious warning).
- Subsequent members with different layouts still produce legitimate warnings, since the result now has a real layout to compare against.

The fix is placed after the non-bitcode check, so archives with mixed content (bitcode + non-bitcode members with `--ignore-non-bitcode`) correctly inherit from the first bitcode member.

## Open question

When archive members have **different** data layouts, should the result module inherit the first member's layout or remain empty? The current implementation picks the first member's layout, which is arbitrary (depends on archive order). An empty layout could be argued as more "honest" since there's no consensus among members. On the other hand, an empty layout means downstream tools get no layout info at all, and the mismatch warning already alerts the user. This matches how `llvm-link` handles regular file inputs (first file's layout wins, mismatches warn). Thoughts?
