### PR TITLE
[libc++] Properly calculate rounded-up size for `{allocate,make}_shared`

### DIFF
--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -752,7 +752,7 @@ struct __unbounded_array_control_block<_Tp[], _Alloc> : __shared_weak_count {
     // [1]: https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
     size_t __bytes           = __elements == 0 ? sizeof(__unbounded_array_control_block)
                                                : (__elements - 1) * sizeof(_Tp) + sizeof(__unbounded_array_control_block);
-    constexpr size_t __align = alignof(_Tp);
+    constexpr size_t __align = alignof(__unbounded_array_control_block);
     return (__bytes + __align - 1) & ~(__align - 1);
   }
 

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared.array.unbounded.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared.array.unbounded.pass.cpp
@@ -107,6 +107,17 @@ int main(int, char**) {
         assert(ptr[i][2][1] == 0);
       }
     }
+    {
+      // https://llvm.org/PR169765
+      // Ensure that the allocated size is properly rounded up
+      using Array                = char[][3];
+      std::shared_ptr<Array> ptr = std::allocate_shared<Array>(std::allocator<Array>{}, 3);
+      for (unsigned i = 0; i < 3; ++i) {
+        assert(ptr[i][0] == '\0');
+        assert(ptr[i][1] == '\0');
+        assert(ptr[i][2] == '\0');
+      }
+    }
 
     // Passing an initial value
     {

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/make_shared.array.unbounded.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/make_shared.array.unbounded.pass.cpp
@@ -105,6 +105,17 @@ int main(int, char**) {
         assert(ptr[i][2][1] == 0);
       }
     }
+    {
+      // https://llvm.org/PR169765
+      // Ensure that the allocated size is properly rounded up
+      using Array                = char[][3];
+      std::shared_ptr<Array> ptr = std::make_shared<Array>(3);
+      for (unsigned i = 0; i < 3; ++i) {
+        assert(ptr[i][0] == '\0');
+        assert(ptr[i][1] == '\0');
+        assert(ptr[i][2] == '\0');
+      }
+    }
 
     // Passing an initial value
     {


### PR DESCRIPTION
Previously, the allocated size might be a bit too small for certain cases. This patch makes the size calculated with potentially larger alignment of the whole control block.

Fixes #169765.