### PR TITLE
[lldb] Make command-dil-diagnostics.test UNSUPPORTED on Windows

### DIFF
--- a/lldb/test/Shell/Commands/command-dil-diagnostics.test
+++ b/lldb/test/Shell/Commands/command-dil-diagnostics.test
@@ -1,5 +1,5 @@
 ## Check DIL error diagnostics output.
-# XFAIL: target-windows
+# UNSUPPORTED: target-windows
 # RUN: %clang_host -g -O0 %S/Inputs/main.c -o %t
 # RUN: %lldb %t -o "command source -e 0 %s" -o exit 2>&1 | FileCheck %s --strict-whitespace
 settings set target.experimental.use-DIL true


### PR DESCRIPTION
The test from #187680 passes on some Windows buildbots, but fails on others.