### PR TITLE
clang/AMDGPU: Refactor triple adjustments

### DIFF
--- a/clang/lib/Driver/CMakeLists.txt
+++ b/clang/lib/Driver/CMakeLists.txt
@@ -39,6 +39,7 @@ add_clang_library(clangDriver
   Tool.cpp
   ToolChain.cpp
   ToolChains/Arch/AArch64.cpp
+  ToolChains/Arch/AMDGPU.cpp
   ToolChains/Arch/ARM.cpp
   ToolChains/Arch/CSKY.cpp
   ToolChains/Arch/LoongArch.cpp

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -8,6 +8,7 @@
 
 #include "clang/Driver/ToolChain.h"
 #include "ToolChains/Arch/AArch64.h"
+#include "ToolChains/Arch/AMDGPU.h"
 #include "ToolChains/Arch/ARM.h"
 #include "ToolChains/Arch/RISCV.h"
 #include "ToolChains/Clang.h"
@@ -1279,8 +1280,7 @@ std::string ToolChain::ComputeLLVMTriple(const ArgList &Args,
     return getTripleString().str();
   case llvm::Triple::amdgcn: {
     llvm::Triple Triple = getTriple();
-    if (Args.getLastArgValue(options::OPT_mcpu_EQ) == "amdgcnspirv")
-      Triple.setArch(llvm::Triple::ArchType::spirv64);
+    tools::AMDGPU::setArchNameInTriple(getDriver(), Args, InputType, Triple);
     return Triple.getTriple();
   }
   case llvm::Triple::arm:

--- a/clang/lib/Driver/ToolChains/Arch/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/AMDGPU.cpp
@@ -1,0 +1,38 @@
+//===--- AMDGPU.cpp - AMDGPU Helpers for Tools ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "AMDGPU.h"
+#include "clang/Basic/TargetID.h"
+#include "clang/Driver/Driver.h"
+#include "clang/Options/Options.h"
+#include "llvm/TargetParser/TargetParser.h"
+
+using namespace clang::driver;
+using namespace clang::driver::tools;
+using namespace clang;
+using namespace llvm::opt;
+
+void AMDGPU::setArchNameInTriple(const Driver &D, const ArgList &Args,
+                                 types::ID InputType, llvm::Triple &Triple) {
+  StringRef MArch;
+  AMDGPU::getAMDGPUArchCPUFromArgs(Triple, Args, MArch);
+
+  if (MArch == "amdgcnspirv") {
+    Triple.setArch(llvm::Triple::ArchType::spirv64);
+    return;
+  }
+}
+
+void AMDGPU::getAMDGPUArchCPUFromArgs(const llvm::Triple &Triple,
+                                      const llvm::opt::ArgList &Args,
+                                      llvm::StringRef &Arch) {
+  if (const Arg *MArch = Args.getLastArg(options::OPT_march_EQ))
+    Arch = MArch->getValue();
+  else if (const Arg *MCPU = Args.getLastArg(options::OPT_mcpu_EQ))
+    Arch = MCPU->getValue();
+}

--- a/clang/lib/Driver/ToolChains/Arch/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/Arch/AMDGPU.h
@@ -1,0 +1,32 @@
+//===--- AMDGPU.h - AMDGPU-specific Tool Helpers ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_ARCH_AMDGPU_H
+#define LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_ARCH_AMDGPU_H
+
+#include "clang/Driver/ToolChain.h"
+#include "llvm/Option/ArgList.h"
+#include "llvm/Option/Option.h"
+#include <string>
+
+namespace clang {
+namespace driver {
+namespace tools {
+namespace AMDGPU {
+
+void setArchNameInTriple(const Driver &D, const llvm::opt::ArgList &Args,
+                         types::ID InputType, llvm::Triple &Triple);
+void getAMDGPUArchCPUFromArgs(const llvm::Triple &Triple,
+                              const llvm::opt::ArgList &Args,
+                              llvm::StringRef &Arch);
+} // end namespace AMDGPU
+} // end namespace tools
+} // end namespace driver
+} // end namespace clang
+
+#endif // LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_ARCH_AMDGPU_H


### PR DESCRIPTION
Factor this similar to the ARM case for future
expansion. The difference being -mcpu is treated as
an alias for -mcpu instead of something separately
useful.

I don't understand this mutation of the triple into
spirv64. The only test where this appears to matter
does not use -mcpu. Previously this would only match
for -mcpu, but this would change the behavior to prefer
-march before falling back to -mcpu.