### PR TITLE
Revert "[CIR][NFC] Add NYI for OMPSplitDirective stmt"

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -2223,7 +2223,6 @@ public:
   mlir::LogicalResult
   emitOMPGenericLoopDirective(const OMPGenericLoopDirective &s);
   mlir::LogicalResult emitOMPReverseDirective(const OMPReverseDirective &s);
-  mlir::LogicalResult emitOMPSplitDirective(const OMPSplitDirective &s);
   mlir::LogicalResult
   emitOMPInterchangeDirective(const OMPInterchangeDirective &s);
   mlir::LogicalResult emitOMPAssumeDirective(const OMPAssumeDirective &s);

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -403,8 +403,6 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
     return emitOMPGenericLoopDirective(cast<OMPGenericLoopDirective>(*s));
   case Stmt::OMPReverseDirectiveClass:
     return emitOMPReverseDirective(cast<OMPReverseDirective>(*s));
-  case Stmt::OMPSplitDirectiveClass:
-    return emitOMPSplitDirective(cast<OMPSplitDirective>(*s));
   case Stmt::OMPInterchangeDirectiveClass:
     return emitOMPInterchangeDirective(cast<OMPInterchangeDirective>(*s));
   case Stmt::OMPAssumeDirectiveClass:

--- a/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
@@ -470,11 +470,6 @@ CIRGenFunction::emitOMPReverseDirective(const OMPReverseDirective &s) {
   return mlir::failure();
 }
 mlir::LogicalResult
-CIRGenFunction::emitOMPSplitDirective(const OMPSplitDirective &s) {
-  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPSplitDirective");
-  return mlir::failure();
-}
-mlir::LogicalResult
 CIRGenFunction::emitOMPInterchangeDirective(const OMPInterchangeDirective &s) {
   getCIRGenModule().errorNYI(s.getSourceRange(),
                              "OpenMP OMPInterchangeDirective");


### PR DESCRIPTION
Reverts llvm/llvm-project#190329

The patch this depends on got reverted.