### PR TITLE
[SCEV] Replace some hasFlags calls with hasNo(Un)SignedWrap (NFC).

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -395,8 +395,8 @@ void SCEV::print(raw_ostream &OS) const {
       OS << "nuw><";
     if (AR->hasNoSignedWrap())
       OS << "nsw><";
-    if (AR->hasNoSelfWrap() &&
-        !AR->getNoWrapFlags((NoWrapFlags)(FlagNUW | FlagNSW)))
+    if (AR->hasNoSelfWrap() && !AR->hasNoUnsignedWrap() &&
+        !AR->hasNoSignedWrap())
       OS << "nw><";
     AR->getLoop()->getHeader()->printAsOperand(OS, /*PrintType=*/false);
     OS << ">";
@@ -3299,7 +3299,7 @@ const SCEV *ScalarEvolution::getMulExpr(SmallVectorImpl<SCEVUse> &Ops,
           // maximum signed value. In all other cases signed overflow is
           // impossible.
           auto FlagsMask = SCEV::FlagNW;
-          if (hasFlags(AddRec->getNoWrapFlags(), SCEV::FlagNSW)) {
+          if (AddRec->hasNoSignedWrap()) {
             auto MinInt =
                 APInt::getSignedMinValue(getTypeSizeInBits(AddRec->getType()));
             if (getSignedRangeMin(AddRec) != MinInt)

--- a/llvm/lib/Transforms/Utils/LoopConstrainer.cpp
+++ b/llvm/lib/Transforms/Utils/LoopConstrainer.cpp
@@ -200,7 +200,7 @@ LoopStructure::parseLoopStructure(ScalarEvolution &SE, Loop &L,
   }
 
   auto HasNoSignedWrap = [&](const SCEVAddRecExpr *AR) {
-    if (AR->getNoWrapFlags(SCEV::FlagNSW))
+    if (AR->hasNoSignedWrap())
       return true;
 
     IntegerType *Ty = cast<IntegerType>(AR->getType());
@@ -222,7 +222,7 @@ LoopStructure::parseLoopStructure(ScalarEvolution &SE, Loop &L,
     }
 
     // We may have proved this when computing the sign extension above.
-    return AR->getNoWrapFlags(SCEV::FlagNSW) != SCEV::FlagAnyWrap;
+    return AR->hasNoSignedWrap();
   };
 
   // `ICI` is interpreted as taking the backedge if the *next* value of the
@@ -287,7 +287,7 @@ LoopStructure::parseLoopStructure(ScalarEvolution &SE, Loop &L,
         //     break;                       break;
         //   ...                          ...
         // }                            }
-        if (IndVarBase->getNoWrapFlags(SCEV::FlagNUW) &&
+        if (IndVarBase->hasNoUnsignedWrap() &&
             cannotBeMinInLoop(RightSCEV, &L, SE, /*Signed*/ false)) {
           Pred = ICmpInst::ICMP_UGT;
           RightSCEV =
@@ -351,7 +351,7 @@ LoopStructure::parseLoopStructure(ScalarEvolution &SE, Loop &L,
         //     break;                       break;
         //   ...                          ...
         // }                            }
-        if (IndVarBase->getNoWrapFlags(SCEV::FlagNUW) &&
+        if (IndVarBase->hasNoUnsignedWrap() &&
             cannotBeMaxInLoop(RightSCEV, &L, SE, /* Signed */ false)) {
           Pred = ICmpInst::ICMP_ULT;
           RightSCEV = SE.getAddExpr(RightSCEV, SE.getOne(RightSCEV->getType()));

--- a/polly/lib/Support/SCEVAffinator.cpp
+++ b/polly/lib/Support/SCEVAffinator.cpp
@@ -178,7 +178,7 @@ bool SCEVAffinator::hasNSWAddRecForLoop(Loop *L) const {
       continue;
     if (AddRec->getLoop() != L)
       continue;
-    if (AddRec->getNoWrapFlags() & SCEV::FlagNSW)
+    if (AddRec->hasNoSignedWrap())
       return true;
   }
 
@@ -189,7 +189,7 @@ bool SCEVAffinator::computeModuloForExpr(const SCEV *Expr) {
   unsigned Width = TD.getTypeSizeInBits(Expr->getType());
   // We assume nsw expressions never overflow.
   if (auto *NAry = dyn_cast<SCEVNAryExpr>(Expr))
-    if (NAry->getNoWrapFlags() & SCEV::FlagNSW)
+    if (NAry->hasNoSignedWrap())
       return false;
   return Width <= MaxSmallBitWidth;
 }


### PR DESCRIPTION
This is slightly more compact and reduces diff when switching to enum class (https://github.com/llvm/llvm-project/pull/190199).