### PR TITLE
[BOLT] Check for write errors before keeping output file

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -6345,6 +6345,13 @@ void RewriteInstance::rewriteFile() {
     BC->printSections(BC->outs());
   }
 
+  if (OS.has_error()) {
+    BC->errs() << "BOLT-ERROR: failed to write output file '"
+               << opts::OutputFilename << "': " << OS.error().message() << "\n";
+    OS.clear_error();
+    exit(1);
+  }
+
   Out->keep();
   EC = sys::fs::setPermissions(
       opts::OutputFilename,


### PR DESCRIPTION
Summary:
When the disk runs out of space during output file writing, BOLT would crash with SIGSEGV/SIGABRT because raw_fd_ostream silently records write errors and only reports them via abort() in its destructor. This made it difficult to distinguish real BOLT bugs from infrastructure issues in production monitoring.

Add an explicit error check on the output stream before calling Out->keep(), so BOLT exits cleanly with exit code 1 and a clear error message instead.

Test: manually verified with a full filesystem that BOLT now prints "BOLT-ERROR: failed to write output file: No space left on device" and exits with code 1.