### PR TITLE
[bolt] AArch64: Fix TLSDESC to LE relaxation by mold

### DIFF
--- a/bolt/lib/Target/AArch64/AArch64MCSymbolizer.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCSymbolizer.cpp
@@ -104,6 +104,7 @@ AArch64MCSymbolizer::adjustRelocation(const Relocation &Rel,
     default:
       break;
     case ELF::R_AARCH64_TLSDESC_LD64_LO12:
+    case ELF::R_AARCH64_TLSDESC_ADD_LO12:
     case ELF::R_AARCH64_TLSDESC_ADR_PAGE21:
     case ELF::R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC:
     case ELF::R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21:

--- a/bolt/test/AArch64/tls-desc-le-relaxation-alternative.test
+++ b/bolt/test/AArch64/tls-desc-le-relaxation-alternative.test
@@ -1,0 +1,28 @@
+# Check that BOLT handles case when TLSDESC is relaxed to LE
+# with NOP+NOP+MOVZ+MOVK layout (as produced by some linkers like mold).
+# The TLSDESC_ADD_LO12 relocation lands on a MOVZ instruction, which is
+# not a valid target for the S_LO12 specifier.
+
+# REQUIRES: system-linux
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-linux %s -o %t.o
+# RUN: ld.lld --emit-relocs -shared %t.o -o %t.so
+# RUN: llvm-bolt %t.so -o %t.bolt 2>&1 | FileCheck %s
+
+# CHECK-NOT: invalid fixup for movz/movk instruction
+# CHECK-NOT: BOLT-ERROR: Emission failed.
+
+  .text
+  .globl _start
+  .type _start, %function
+_start:
+  .cfi_startproc
+.Lblock:
+  movz x0, #0, lsl #16
+  ret
+  .cfi_endproc
+  .size _start, .-_start
+
+  .reloc .Lblock,  R_AARCH64_TLSDESC_ADD_LO12, tls_var
+
+  .globl tls_var
+  .type tls_var, @tls_object


### PR DESCRIPTION
mold linker creates relaxation stub from TLSDESC to LE, (lld makes it IE) using sequence as NOP+NOP+MOVZ+MOVK. This in itself is not an issue, when --emit-relocs is added the relocs R_AARCH64_TLSDESC_ADD_LO12 and R_AARCH64_TLSDESC_CALL are associated with useful MOVW instructions. However bolt does not check for R_AARCH64_TLSDESC_ADD_LO12 in adjustRelocation() when disassembling the file. This later triggers a bug when reloc is patched as movk is patched with S_LO12 fixup kind which is invalid.

Refer to bug: https://github.com/llvm/llvm-project/issues/190366 for details.
