### PR TITLE
[lldb][Utility] Remove address size from Stream class (NFC)

### DIFF
--- a/lldb/include/lldb/Host/StreamFile.h
+++ b/lldb/include/lldb/Host/StreamFile.h
@@ -24,7 +24,7 @@ namespace lldb_private {
 
 class StreamFile : public Stream {
 public:
-  StreamFile(uint32_t flags, uint32_t addr_size, lldb::ByteOrder byte_order);
+  StreamFile(uint32_t flags, lldb::ByteOrder byte_order);
 
   StreamFile(int fd, bool transfer_ownership);
 

--- a/lldb/include/lldb/Utility/GDBRemote.h
+++ b/lldb/include/lldb/Utility/GDBRemote.h
@@ -26,8 +26,7 @@ class StreamGDBRemote : public StreamString {
 public:
   StreamGDBRemote();
 
-  StreamGDBRemote(uint32_t flags, uint32_t addr_size,
-                  lldb::ByteOrder byte_order);
+  StreamGDBRemote(uint32_t flags, lldb::ByteOrder byte_order);
 
   ~StreamGDBRemote() override;
 

--- a/lldb/include/lldb/Utility/Stream.h
+++ b/lldb/include/lldb/Utility/Stream.h
@@ -65,10 +65,9 @@ public:
 
   /// Construct with flags and address size and byte order.
   ///
-  /// Construct with dump flags \a flags and the default address size. \a
-  /// flags can be any of the above enumeration logical OR'ed together.
-  Stream(uint32_t flags, uint32_t addr_size, lldb::ByteOrder byte_order,
-         bool colors = false);
+  /// Construct with dump flags \a flags.
+  /// \a flags can be any of the above enumeration logical OR'ed together.
+  Stream(uint32_t flags, lldb::ByteOrder byte_order, bool colors = false);
 
   /// Construct a default Stream, not binary, host byte order and host addr
   /// size.
@@ -80,7 +79,6 @@ public:
 
   Stream &operator=(const Stream &rhs) {
     m_flags = rhs.m_flags;
-    m_addr_size = rhs.m_addr_size;
     m_byte_order = rhs.m_byte_order;
     m_indent_level = rhs.m_indent_level;
     return *this;
@@ -279,13 +277,6 @@ public:
   /// Output and End of Line character to the stream.
   size_t EOL();
 
-  /// Get the address size in bytes.
-  ///
-  /// \return
-  ///     The size of an address in bytes that is used when outputting
-  ///     address and pointer values to the stream.
-  uint32_t GetAddressByteSize() const;
-
   /// The flags accessor.
   ///
   /// \return
@@ -389,13 +380,6 @@ public:
   ///     The optional C string format that can be overridden.
   void QuotedCString(const char *cstr, const char *format = "\"%s\"");
 
-  /// Set the address size in bytes.
-  ///
-  /// \param[in] addr_size
-  ///     The new size in bytes of an address to use when outputting
-  ///     address and pointer values.
-  void SetAddressByteSize(uint32_t addr_size);
-
   /// Output a SLEB128 number to the stream.
   ///
   /// Put an SLEB128 \a uval out to the stream using the printf format in \a
@@ -421,8 +405,7 @@ public:
 
 protected:
   // Member variables
-  Flags m_flags;        ///< Dump flags.
-  uint32_t m_addr_size = 4; ///< Size of an address in bytes.
+  Flags m_flags; ///< Dump flags.
   lldb::ByteOrder
       m_byte_order;   ///< Byte order to use when encoding scalar types.
   unsigned m_indent_level = 0;     ///< Indention level.

--- a/lldb/include/lldb/Utility/StreamBuffer.h
+++ b/lldb/include/lldb/Utility/StreamBuffer.h
@@ -18,10 +18,10 @@ namespace lldb_private {
 
 template <unsigned N> class StreamBuffer : public Stream {
 public:
-  StreamBuffer() : Stream(0, 4, lldb::eByteOrderBig), m_packet() {}
+  StreamBuffer() : Stream(0, lldb::eByteOrderBig), m_packet() {}
 
-  StreamBuffer(uint32_t flags, uint32_t addr_size, lldb::ByteOrder byte_order)
-      : Stream(flags, addr_size, byte_order), m_packet() {}
+  StreamBuffer(uint32_t flags, lldb::ByteOrder byte_order)
+      : Stream(flags, byte_order), m_packet() {}
 
   ~StreamBuffer() override = default;
 

--- a/lldb/include/lldb/Utility/StreamString.h
+++ b/lldb/include/lldb/Utility/StreamString.h
@@ -26,7 +26,7 @@ class StreamString : public Stream {
 public:
   StreamString(bool colors = false);
 
-  StreamString(uint32_t flags, uint32_t addr_size, lldb::ByteOrder byte_order);
+  StreamString(uint32_t flags, lldb::ByteOrder byte_order);
 
   ~StreamString() override;
 

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -1279,10 +1279,7 @@ protected:
       return;
     }
 
-    StreamString buffer(
-        Stream::eBinary,
-        process->GetTarget().GetArchitecture().GetAddressByteSize(),
-        process->GetTarget().GetArchitecture().GetByteOrder());
+    StreamString buffer(Stream::eBinary, process->GetByteOrder());
 
     OptionValueUInt64 &byte_size_value = m_format_options.GetByteSizeValue();
     size_t item_byte_size = byte_size_value.GetCurrentValue();
@@ -1336,7 +1333,7 @@ protected:
       return;
     } else if (item_byte_size == 0) {
       if (m_format_options.GetFormat() == eFormatPointer)
-        item_byte_size = buffer.GetAddressByteSize();
+        item_byte_size = process->GetAddressByteSize();
       else
         item_byte_size = 1;
     }

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -535,10 +535,6 @@ protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetTarget();
 
-    uint32_t addr_byte_size = target.GetArchitecture().GetAddressByteSize();
-    result.GetOutputStream().SetAddressByteSize(addr_byte_size);
-    result.GetErrorStream().SetAddressByteSize(addr_byte_size);
-
     // Collect the list of modules to search.
     m_module_list.Clear();
     if (!m_options.modules.empty()) {

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -1911,10 +1911,6 @@ protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetTarget();
 
-    uint32_t addr_byte_size = target.GetArchitecture().GetAddressByteSize();
-    result.GetOutputStream().SetAddressByteSize(addr_byte_size);
-    result.GetErrorStream().SetAddressByteSize(addr_byte_size);
-
     size_t num_dumped = 0;
     if (command.GetArgumentCount() == 0) {
       // Dump all headers for all modules images
@@ -2016,10 +2012,6 @@ protected:
         (m_options.m_prefer_mangled ? Mangled::ePreferMangled
                                     : Mangled::ePreferDemangled);
 
-    uint32_t addr_byte_size = target.GetArchitecture().GetAddressByteSize();
-    result.GetOutputStream().SetAddressByteSize(addr_byte_size);
-    result.GetErrorStream().SetAddressByteSize(addr_byte_size);
-
     if (command.GetArgumentCount() == 0) {
       // Dump all sections for all modules images
       const ModuleList &module_list = target.GetImages();
@@ -2110,10 +2102,6 @@ protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetTarget();
     uint32_t num_dumped = 0;
-
-    uint32_t addr_byte_size = target.GetArchitecture().GetAddressByteSize();
-    result.GetOutputStream().SetAddressByteSize(addr_byte_size);
-    result.GetErrorStream().SetAddressByteSize(addr_byte_size);
 
     if (command.GetArgumentCount() == 0) {
       // Dump all sections for all modules images
@@ -2339,10 +2327,6 @@ protected:
     Target &target = GetTarget();
     uint32_t num_dumped = 0;
 
-    uint32_t addr_byte_size = target.GetArchitecture().GetAddressByteSize();
-    result.GetOutputStream().SetAddressByteSize(addr_byte_size);
-    result.GetErrorStream().SetAddressByteSize(addr_byte_size);
-
     if (command.GetArgumentCount() == 0) {
       // Dump all sections for all modules images
       const ModuleList &target_modules = target.GetImages();
@@ -2421,10 +2405,6 @@ protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = m_exe_ctx.GetTargetPtr();
     uint32_t total_num_dumped = 0;
-
-    uint32_t addr_byte_size = target->GetArchitecture().GetAddressByteSize();
-    result.GetOutputStream().SetAddressByteSize(addr_byte_size);
-    result.GetErrorStream().SetAddressByteSize(addr_byte_size);
 
     if (command.GetArgumentCount() == 0) {
       result.AppendError("file option must be specified");
@@ -2568,10 +2548,6 @@ protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetTarget();
     uint32_t num_dumped = 0;
-
-    uint32_t addr_byte_size = target.GetArchitecture().GetAddressByteSize();
-    result.GetOutputStream().SetAddressByteSize(addr_byte_size);
-    result.GetErrorStream().SetAddressByteSize(addr_byte_size);
 
     StructuredData::Array separate_debug_info_lists_by_module;
     if (command.GetArgumentCount() == 0) {
@@ -3207,9 +3183,6 @@ protected:
     // "locker" object which might lock its contents below (through the
     // "module_list_ptr" variable).
     ModuleList module_list;
-    uint32_t addr_byte_size = target.GetArchitecture().GetAddressByteSize();
-    result.GetOutputStream().SetAddressByteSize(addr_byte_size);
-    result.GetErrorStream().SetAddressByteSize(addr_byte_size);
     // Dump all sections for all modules images
     Stream &strm = result.GetOutputStream();
 
@@ -4099,9 +4072,6 @@ protected:
     bool syntax_error = false;
     uint32_t i;
     uint32_t num_successful_lookups = 0;
-    uint32_t addr_byte_size = target.GetArchitecture().GetAddressByteSize();
-    result.GetOutputStream().SetAddressByteSize(addr_byte_size);
-    result.GetErrorStream().SetAddressByteSize(addr_byte_size);
     // Dump all sections for all modules images
 
     if (command.GetArgumentCount() == 0) {

--- a/lldb/source/Core/DumpDataExtractor.cpp
+++ b/lldb/source/Core/DumpDataExtractor.cpp
@@ -361,7 +361,7 @@ lldb::offset_t lldb_private::DumpDataExtractor(
 
   if (item_format == eFormatPointer) {
     if (item_byte_size != 4 && item_byte_size != 8)
-      item_byte_size = s->GetAddressByteSize();
+      item_byte_size = DE.GetAddressByteSize();
   }
 
   offset_t offset = start_offset;

--- a/lldb/source/Core/EmulateInstruction.cpp
+++ b/lldb/source/Core/EmulateInstruction.cpp
@@ -198,7 +198,7 @@ uint64_t EmulateInstruction::ReadMemoryUnsigned(const Context &context,
 bool EmulateInstruction::WriteMemoryUnsigned(const Context &context,
                                              lldb::addr_t addr, uint64_t uval,
                                              size_t uval_byte_size) {
-  StreamString strm(Stream::eBinary, GetAddressByteSize(), GetByteOrder());
+  StreamString strm(Stream::eBinary, GetByteOrder());
   strm.PutMaxHex64(uval, uval_byte_size);
 
   size_t bytes_written = m_write_mem_callback(

--- a/lldb/source/Core/StreamAsynchronousIO.cpp
+++ b/lldb/source/Core/StreamAsynchronousIO.cpp
@@ -16,7 +16,7 @@ using namespace lldb_private;
 
 StreamAsynchronousIO::StreamAsynchronousIO(
     Debugger &debugger, StreamAsynchronousIO::ForSTDOUT for_stdout)
-    : Stream(0, 4, eByteOrderBig, debugger.GetUseColor()), m_debugger(debugger),
+    : Stream(0, eByteOrderBig, debugger.GetUseColor()), m_debugger(debugger),
       m_data(), m_for_stdout(for_stdout) {}
 
 StreamAsynchronousIO::~StreamAsynchronousIO() {

--- a/lldb/source/Host/common/StreamFile.cpp
+++ b/lldb/source/Host/common/StreamFile.cpp
@@ -16,8 +16,8 @@
 using namespace lldb;
 using namespace lldb_private;
 
-StreamFile::StreamFile(uint32_t flags, uint32_t addr_size, ByteOrder byte_order)
-    : Stream(flags, addr_size, byte_order) {
+StreamFile::StreamFile(uint32_t flags, ByteOrder byte_order)
+    : Stream(flags, byte_order) {
   m_file_sp = std::make_shared<File>();
 }
 

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6406,7 +6406,7 @@ bool ObjectFileMachO::SaveCore(const lldb::ProcessSP &process_sp,
           segment_load_commands.push_back(segment);
         }
 
-        StreamString buffer(Stream::eBinary, addr_byte_size, byte_order);
+        StreamString buffer(Stream::eBinary, byte_order);
 
         llvm::MachO::mach_header_64 mach_header;
         mach_header.magic = addr_byte_size == 8 ? MH_MAGIC_64 : MH_MAGIC;
@@ -6426,7 +6426,6 @@ bool ObjectFileMachO::SaveCore(const lldb::ProcessSP &process_sp,
         std::vector<StreamString> LC_THREAD_datas(num_threads);
         for (auto &LC_THREAD_data : LC_THREAD_datas) {
           LC_THREAD_data.GetFlags().Set(Stream::eBinary);
-          LC_THREAD_data.SetAddressByteSize(addr_byte_size);
           LC_THREAD_data.SetByteOrder(byte_order);
         }
         for (uint32_t thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
@@ -6511,7 +6510,7 @@ bool ObjectFileMachO::SaveCore(const lldb::ProcessSP &process_sp,
         // Add "addrable bits" LC_NOTE when an address mask is available
         if (address_mask != LLDB_INVALID_ADDRESS_MASK) {
           std::unique_ptr<LCNoteEntry> addrable_bits_lcnote_up(
-              new LCNoteEntry(addr_byte_size, byte_order));
+              new LCNoteEntry(byte_order));
           addrable_bits_lcnote_up->name = "addrable bits";
           addrable_bits_lcnote_up->payload_file_offset = file_offset;
           int bits = std::bitset<64>(~address_mask).count();
@@ -6529,7 +6528,7 @@ bool ObjectFileMachO::SaveCore(const lldb::ProcessSP &process_sp,
 
         // Add "process metadata" LC_NOTE
         std::unique_ptr<LCNoteEntry> thread_extrainfo_lcnote_up(
-            new LCNoteEntry(addr_byte_size, byte_order));
+            new LCNoteEntry(byte_order));
         thread_extrainfo_lcnote_up->name = "process metadata";
         thread_extrainfo_lcnote_up->payload_file_offset = file_offset;
 
@@ -6556,7 +6555,7 @@ bool ObjectFileMachO::SaveCore(const lldb::ProcessSP &process_sp,
 
         // Add "all image infos" LC_NOTE
         std::unique_ptr<LCNoteEntry> all_image_infos_lcnote_up(
-            new LCNoteEntry(addr_byte_size, byte_order));
+            new LCNoteEntry(byte_order));
         all_image_infos_lcnote_up->name = "all image infos";
         all_image_infos_lcnote_up->payload_file_offset = file_offset;
         file_offset = CreateAllImageInfosPayload(

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -247,8 +247,8 @@ protected:
   };
 
   struct LCNoteEntry {
-    LCNoteEntry(uint32_t addr_byte_size, lldb::ByteOrder byte_order)
-        : payload(lldb_private::Stream::eBinary, addr_byte_size, byte_order) {}
+    explicit LCNoteEntry(lldb::ByteOrder byte_order)
+        : payload(lldb_private::Stream::eBinary, byte_order) {}
 
     std::string name;
     lldb::addr_t payload_file_offset = 0;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -100,7 +100,7 @@ size_t GDBRemoteCommunication::SendNack() {
 
 GDBRemoteCommunication::PacketResult
 GDBRemoteCommunication::SendPacketNoLock(llvm::StringRef payload) {
-  StreamString packet(0, 4, eByteOrderBig);
+  StreamString packet(0, eByteOrderBig);
   packet.PutChar('$');
   packet.Write(payload.data(), payload.size());
   packet.PutChar('#');
@@ -119,7 +119,7 @@ GDBRemoteCommunication::SendNotificationPacketNoLock(
   // If there are no notification in the queue, send the notification
   // packet.
   if (queue.empty()) {
-    StreamString packet(0, 4, eByteOrderBig);
+    StreamString packet(0, eByteOrderBig);
     packet.PutChar('%');
     packet.Write(notify_type.data(), notify_type.size());
     packet.PutChar(':');

--- a/lldb/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.cpp
+++ b/lldb/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.cpp
@@ -564,8 +564,7 @@ ResolveRegisterOrRA(const llvm::Triple &triple,
 
 llvm::ArrayRef<uint8_t> SymbolFileBreakpad::SaveAsDWARF(postfix::Node &node) {
   ArchSpec arch = m_objfile_sp->GetArchitecture();
-  StreamString dwarf(Stream::eBinary, arch.GetAddressByteSize(),
-                     arch.GetByteOrder());
+  StreamString dwarf(Stream::eBinary, arch.GetByteOrder());
   ToDWARF(node, dwarf);
   uint8_t *saved = m_allocator.Allocate<uint8_t>(dwarf.GetSize());
   std::memcpy(saved, dwarf.GetData(), dwarf.GetSize());

--- a/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
+++ b/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
@@ -850,7 +850,7 @@ static DWARFExpression CreateDWARFExpression(ModuleSP module_sp,
   ByteOrder byte_order = architecture.GetByteOrder();
   uint32_t address_size = architecture.GetAddressByteSize();
 
-  StreamBuffer<32> stream(Stream::eBinary, address_size, byte_order);
+  StreamBuffer<32> stream(Stream::eBinary, byte_order);
   stream.PutHex8(llvm::dwarf::DW_OP_addr);
   stream.PutMaxHex64(symbol.GetFileAddress(), address_size, byte_order);
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
@@ -118,7 +118,7 @@ static DWARFExpression MakeLocationExpressionInternal(lldb::ModuleSP module,
     return DWARFExpression();
 
   RegisterKind register_kind = eRegisterKindDWARF;
-  StreamBuffer<32> stream(Stream::eBinary, address_size, byte_order);
+  StreamBuffer<32> stream(Stream::eBinary, byte_order);
 
   if (!writer(stream, register_kind))
     return DWARFExpression();
@@ -245,8 +245,9 @@ DWARFExpression lldb_private::npdb::MakeGlobalLocationExpression(
         if (!section_ptr)
           return false;
 
+        const ArchSpec &arch = module->GetArchitecture();
         stream.PutMaxHex64(section_ptr->GetFileAddress() + offset,
-                           stream.GetAddressByteSize(), stream.GetByteOrder());
+                           arch.GetAddressByteSize(), arch.GetByteOrder());
 
         return true;
       });

--- a/lldb/source/Plugins/SymbolFile/PDB/PDBLocationToDWARFExpression.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/PDBLocationToDWARFExpression.cpp
@@ -80,7 +80,7 @@ DWARFExpression ConvertPDBLocationToDWARFExpression(
     return DWARFExpression();
 
   RegisterKind register_kind = eRegisterKindDWARF;
-  StreamBuffer<32> stream(Stream::eBinary, address_size, byte_order);
+  StreamBuffer<32> stream(Stream::eBinary, byte_order);
   switch (symbol.getLocationType()) {
   case PDB_LocType::Static:
   case PDB_LocType::TLS: {

--- a/lldb/source/Utility/GDBRemote.cpp
+++ b/lldb/source/Utility/GDBRemote.cpp
@@ -19,9 +19,8 @@ using namespace llvm;
 
 StreamGDBRemote::StreamGDBRemote() : StreamString() {}
 
-StreamGDBRemote::StreamGDBRemote(uint32_t flags, uint32_t addr_size,
-                                 ByteOrder byte_order)
-    : StreamString(flags, addr_size, byte_order) {}
+StreamGDBRemote::StreamGDBRemote(uint32_t flags, ByteOrder byte_order)
+    : StreamString(flags, byte_order) {}
 
 StreamGDBRemote::~StreamGDBRemote() = default;
 

--- a/lldb/source/Utility/Stream.cpp
+++ b/lldb/source/Utility/Stream.cpp
@@ -24,10 +24,8 @@
 using namespace lldb;
 using namespace lldb_private;
 
-Stream::Stream(uint32_t flags, uint32_t addr_size, ByteOrder byte_order,
-               bool colors)
-    : m_flags(flags), m_addr_size(addr_size), m_byte_order(byte_order),
-      m_forwarder(*this, colors) {}
+Stream::Stream(uint32_t flags, ByteOrder byte_order, bool colors)
+    : m_flags(flags), m_byte_order(byte_order), m_forwarder(*this, colors) {}
 
 Stream::Stream(bool colors)
     : m_flags(0), m_byte_order(endian::InlHostByteOrder()),
@@ -215,12 +213,6 @@ Stream::IndentScope Stream::MakeIndentScope(unsigned indent_amount) {
   IndentMore(indent_amount);
   return indent_scope;
 }
-
-// Get the address size in bytes
-uint32_t Stream::GetAddressByteSize() const { return m_addr_size; }
-
-// Set the address size in bytes
-void Stream::SetAddressByteSize(uint32_t addr_size) { m_addr_size = addr_size; }
 
 // The flags get accessor
 Flags &Stream::GetFlags() { return m_flags; }

--- a/lldb/source/Utility/StreamString.cpp
+++ b/lldb/source/Utility/StreamString.cpp
@@ -11,11 +11,10 @@
 using namespace lldb;
 using namespace lldb_private;
 
-StreamString::StreamString(bool colors) : Stream(0, 4, eByteOrderBig, colors) {}
+StreamString::StreamString(bool colors) : Stream(0, eByteOrderBig, colors) {}
 
-StreamString::StreamString(uint32_t flags, uint32_t addr_size,
-                           ByteOrder byte_order)
-    : Stream(flags, addr_size, byte_order), m_packet() {}
+StreamString::StreamString(uint32_t flags, ByteOrder byte_order)
+    : Stream(flags, byte_order) {}
 
 StreamString::~StreamString() = default;
 

--- a/lldb/unittests/Symbol/PostfixExpressionTest.cpp
+++ b/lldb/unittests/Symbol/PostfixExpressionTest.cpp
@@ -151,7 +151,7 @@ static std::string ParseAndGenerateDWARF(llvm::StringRef expr) {
   }
 
   const size_t addr_size = 4;
-  StreamString dwarf(Stream::eBinary, addr_size, lldb::eByteOrderLittle);
+  StreamString dwarf(Stream::eBinary, lldb::eByteOrderLittle);
   ToDWARF(*ast, dwarf);
 
   // print dwarf expression to comparable textual representation

--- a/lldb/unittests/SymbolFile/NativePDB/PdbFPOProgramToDWARFExpressionTests.cpp
+++ b/lldb/unittests/SymbolFile/NativePDB/PdbFPOProgramToDWARFExpressionTests.cpp
@@ -30,7 +30,7 @@ CheckValidProgramTranslation(llvm::StringRef fpo_program,
                              llvm::StringRef target_register_name,
                              llvm::StringRef expected_dwarf_expression) {
   // program translation
-  StreamBuffer<32> stream(Stream::eBinary, 4, eByteOrderLittle);
+  StreamBuffer<32> stream(Stream::eBinary, eByteOrderLittle);
   ASSERT_TRUE(TranslateFPOProgramToDWARFExpression(
       fpo_program, target_register_name, llvm::Triple::x86, stream));
 
@@ -79,7 +79,7 @@ CheckInvalidProgramTranslation(llvm::StringRef fpo_program,
   uint32_t address_size = arch_spec.GetAddressByteSize();
 
   // program translation
-  StreamBuffer<32> stream(Stream::eBinary, address_size, byte_order);
+  StreamBuffer<32> stream(Stream::eBinary, byte_order);
   EXPECT_FALSE(TranslateFPOProgramToDWARFExpression(
       fpo_program, target_register_name, arch_type, stream));
   EXPECT_EQ((size_t)0, stream.GetSize());

--- a/lldb/unittests/SymbolFile/NativePDB/PdbFPOProgramToDWARFExpressionTests.cpp
+++ b/lldb/unittests/SymbolFile/NativePDB/PdbFPOProgramToDWARFExpressionTests.cpp
@@ -76,7 +76,6 @@ CheckInvalidProgramTranslation(llvm::StringRef fpo_program,
   ArchSpec arch_spec("i686-pc-windows");
   llvm::Triple::ArchType arch_type = arch_spec.GetMachine();
   ByteOrder byte_order = arch_spec.GetByteOrder();
-  uint32_t address_size = arch_spec.GetAddressByteSize();
 
   // program translation
   StreamBuffer<32> stream(Stream::eBinary, byte_order);


### PR DESCRIPTION
It violates abstraction. Luckily, it was used only in two places, see DumpDataExtractor.cpp and CommandObjectMemory.cpp.