### PR TITLE
Revert "[lldb/test] Codesign executables built with custom Makefile rules"

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -728,13 +728,6 @@ include $(wildcard $(PREREQS) $(DYLIB_PREREQS))
 .PHONY: clean
 dsym:	$(DSYM)
 all:	$(EXE) $(DSYM)
-ifneq "$(CODESIGN)" ""
-	@for bin in $(EXE) a.out; do \
-		if [ -n "$$bin" ] && [ -f "$$bin" ]; then \
-			$(CODESIGN) -s -f - "$$bin" 2>/dev/null || true; \
-		fi; \
-	done
-endif
 clean::
 ifeq "$(findstring lldb-test-build.noindex, $(BUILDDIR))" ""
 	$(error Trying to invoke the clean rule, but not using the default build tree layout)


### PR DESCRIPTION
Reverts llvm/llvm-project#189902 because this seems to cause hangs.