### PR TITLE
[NFCI] Check for non-null before dereferencing a VPBB ptr

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -402,15 +402,14 @@ bool vputils::isUniformAcrossVFsAndUFs(VPValue *V) {
   VPRecipeBase *R = V->getDefiningRecipe();
   VPBasicBlock *VPBB = R ? R->getParent() : nullptr;
   VPlan *Plan = VPBB ? VPBB->getPlan() : nullptr;
-  if (VPBB &&
-      (VPBB == Plan->getVectorPreheader() || VPBB == Plan->getEntry())) {
-    if (match(V->getDefiningRecipe(),
-              m_VPInstruction<VPInstruction::CanonicalIVIncrementForPart>()))
-      return false;
-    return all_of(R->operands(), isUniformAcrossVFsAndUFs);
-  }
-
   if (VPBB) {
+    if ((VPBB == Plan->getVectorPreheader() || VPBB == Plan->getEntry())) {
+      if (match(V->getDefiningRecipe(),
+                m_VPInstruction<VPInstruction::CanonicalIVIncrementForPart>()))
+        return false;
+      return all_of(R->operands(), isUniformAcrossVFsAndUFs);
+    }
+
     if (VPRegionBlock *EnclosingRegion = VPBB->getEnclosingLoopRegion()) {
       // Canonical IV is uniform.
       if (V == EnclosingRegion->getCanonicalIV())

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -410,10 +410,12 @@ bool vputils::isUniformAcrossVFsAndUFs(VPValue *V) {
     return all_of(R->operands(), isUniformAcrossVFsAndUFs);
   }
 
-  if (VPRegionBlock *EnclosingRegion = VPBB->getEnclosingLoopRegion()) {
-    // Canonical IV is uniform.
-    if (V == EnclosingRegion->getCanonicalIV())
-      return true;
+  if (VPBB) {
+    if (VPRegionBlock *EnclosingRegion = VPBB->getEnclosingLoopRegion()) {
+      // Canonical IV is uniform.
+      if (V == EnclosingRegion->getCanonicalIV())
+        return true;
+    }
   }
 
   return TypeSwitch<const VPRecipeBase *, bool>(R)


### PR DESCRIPTION
A VPBB variable is possibly null (defined via a ternary), but is subsequently dereferenced without a check included. This patch adds a check for it to avoid any possibly null dereference. This was found via static analysis, there is not a known case right now where this issue is hit.
