### PR TITLE
Remove unnecessary -O1 from clang command.

### DIFF
--- a/clang/test/CodeGenCXX/pfp-load-store.cpp
+++ b/clang/test/CodeGenCXX/pfp-load-store.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple aarch64-linux -fexperimental-pointer-field-protection-abi -fexperimental-pointer-field-protection-tagged -emit-llvm -O1 -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple aarch64-linux -fexperimental-pointer-field-protection-abi -fexperimental-pointer-field-protection-tagged -emit-llvm -o - %s | FileCheck %s
 
 int val;
 


### PR DESCRIPTION
It is generally inappropriate to pass -O flags to IRGen tests because
it makes them sensitive to optimizer behavior. #186548 makes a change to
optimizer behavior that would cause this test to fail without this change.
