### PR TITLE
[clang-doc] Update type aliases

### DIFF
--- a/clang-tools-extra/clang-doc/BitcodeReader.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeReader.cpp
@@ -154,7 +154,7 @@ static llvm::Error decodeRecord(const Record &R, FieldId &Field,
                                  "invalid value for FieldId");
 }
 
-static llvm::Error decodeRecord(const Record &R, OwningVec<Location> &Field,
+static llvm::Error decodeRecord(const Record &R, DocList<Location> &Field,
                                 llvm::StringRef Blob) {
   if (R.size() < 3)
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
@@ -1489,8 +1489,8 @@ ClangDocBitcodeReader::readBlockToInfo(unsigned ID) {
 }
 
 // Entry point
-llvm::Expected<OwningPtrArray<Info>> ClangDocBitcodeReader::readBitcode() {
-  OwningPtrArray<Info> Infos;
+llvm::Expected<std::vector<Info *>> ClangDocBitcodeReader::readBitcode() {
+  std::vector<Info *> Infos;
   if (auto Err = validateStream())
     return std::move(Err);
 

--- a/clang-tools-extra/clang-doc/BitcodeReader.h
+++ b/clang-tools-extra/clang-doc/BitcodeReader.h
@@ -31,7 +31,7 @@ public:
       : Stream(Stream), Diags(Diags) {}
 
   // Main entry point, calls readBlock to read each block in the given stream.
-  llvm::Expected<OwningPtrArray<Info>> readBitcode();
+  llvm::Expected<std::vector<Info *>> readBitcode();
 
 private:
   enum class Cursor { BadBlock = 1, Record, BlockEnd, BlockBegin };

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -384,7 +384,7 @@ void JSONGenerator::generateContext(const Info &I, Object &Obj) {
   ContextArrayRef.back().getAsObject()->insert({"End", true});
 }
 
-static void serializeDescription(const OwningVec<CommentInfo> &Description,
+static void serializeDescription(const DocList<CommentInfo> &Description,
                                  json::Object &Obj, StringRef Key = "") {
   if (Description.empty())
     return;

--- a/clang-tools-extra/clang-doc/MDGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDGenerator.cpp
@@ -81,7 +81,7 @@ class TableCommentWriter {
 public:
   explicit TableCommentWriter(llvm::raw_ostream &OS) : OS(OS) {}
 
-  void write(const OwningVec<CommentInfo> &Comments) {
+  void write(const DocList<CommentInfo> &Comments) {
     for (const auto &C : Comments)
       writeTableSafeComment(C);
 

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -94,7 +94,7 @@ llvm::StringRef commentKindToString(CommentKind Kind) {
 const SymbolID EmptySID = SymbolID();
 
 template <typename T>
-static llvm::Expected<OwnedPtr<Info>> reduce(OwningPtrArray<Info> &Values) {
+static llvm::Expected<Info *> reduce(SmallVectorImpl<Info *> &Values) {
   if (Values.empty() || !Values[0])
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "no value to reduce");
@@ -106,8 +106,7 @@ static llvm::Expected<OwnedPtr<Info>> reduce(OwningPtrArray<Info> &Values) {
 }
 
 template <typename T>
-static void reduceChildren(OwningVec<T> &Children,
-                           OwningVec<T> &&ChildrenToMerge) {
+static void reduceChildren(DocList<T> &Children, DocList<T> &&ChildrenToMerge) {
   while (!ChildrenToMerge.empty()) {
     T *Ptr = ChildrenToMerge.front().Ptr;
     ChildrenToMerge.pop_front();
@@ -126,8 +125,8 @@ static void reduceChildren(OwningVec<T> &Children,
 }
 
 template <>
-void reduceChildren<Reference>(OwningVec<Reference> &Children,
-                               OwningVec<Reference> &&ChildrenToMerge) {
+void reduceChildren<Reference>(DocList<Reference> &Children,
+                               DocList<Reference> &&ChildrenToMerge) {
   while (!ChildrenToMerge.empty()) {
     Reference *Ptr = ChildrenToMerge.front().Ptr;
     ChildrenToMerge.pop_front();
@@ -147,7 +146,7 @@ void reduceChildren<Reference>(OwningVec<Reference> &Children,
 }
 
 template <typename T>
-static void mergeUnkeyed(OwningVec<T> &Target, OwningVec<T> &&Source) {
+static void mergeUnkeyed(DocList<T> &Target, DocList<T> &&Source) {
   while (!Source.empty()) {
     T *Ptr = Source.front().Ptr;
     Source.pop_front();
@@ -160,8 +159,8 @@ static void mergeUnkeyed(OwningVec<T> &Target, OwningVec<T> &&Source) {
 }
 
 template <>
-void mergeUnkeyed<CommentInfo>(OwningVec<CommentInfo> &Target,
-                               OwningVec<CommentInfo> &&Source) {
+void mergeUnkeyed<CommentInfo>(DocList<CommentInfo> &Target,
+                               DocList<CommentInfo> &&Source) {
   while (!Source.empty()) {
     CommentInfo *Ptr = Source.front().Ptr;
     Source.pop_front();
@@ -255,7 +254,7 @@ llvm::Error mergeSingleInfo(doc::OwnedPtr<doc::Info> &Reduced,
 }
 
 // Dispatch function.
-llvm::Expected<OwnedPtr<Info>> mergeInfos(OwningPtrArray<Info> &Values) {
+llvm::Expected<Info *> mergeInfos(SmallVectorImpl<Info *> &Values) {
   if (Values.empty() || !Values[0])
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "no info values to merge");

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -108,10 +108,6 @@ llvm::ArrayRef<T> deepCopyArray(llvm::ArrayRef<T> V,
 // to be eventually transitioned to bare pointers in an arena.
 template <typename T> using OwnedPtr = T *;
 
-// An abstraction for vectors that are populated and read sequentially.
-// To be eventually transitioned to llvm::ArrayRef for arena storage.
-template <typename T> using OwningArray = std::vector<T>;
-
 // A helper function to create an owned pointer, abstracting away the memory
 // allocation mechanism.
 template <typename T, typename... Args>
@@ -187,7 +183,7 @@ template <typename T> InfoNode<T> *allocateListNodePersistent(T *Item) {
 
 // An abstraction for lists that are dynamically managed (inserted/removed).
 // To be eventually transitioned to llvm::simple_ilist.
-template <typename T> using OwningVec = llvm::simple_ilist<InfoNode<T>>;
+template <typename T> using DocList = llvm::simple_ilist<InfoNode<T>>;
 
 // An abstraction for dynamic lists of owned pointers.
 // To be eventually transitioned to llvm::simple_ilist<T*> or similar.
@@ -375,13 +371,13 @@ struct ScopeChildren {
   //
   // Namespaces are not syntactically valid as children of records, but making
   // this general for all possible container types reduces code complexity.
-  OwningVec<Reference> Namespaces = {};
-  OwningVec<Reference> Records = {};
-  OwningVec<FunctionInfo> Functions = {};
-  OwningVec<EnumInfo> Enums = {};
-  OwningVec<TypedefInfo> Typedefs = {};
-  OwningVec<ConceptInfo> Concepts = {};
-  OwningVec<VarInfo> Variables = {};
+  DocList<Reference> Namespaces = {};
+  DocList<Reference> Records = {};
+  DocList<FunctionInfo> Functions = {};
+  DocList<EnumInfo> Enums = {};
+  DocList<TypedefInfo> Typedefs = {};
+  DocList<ConceptInfo> Concepts = {};
+  DocList<VarInfo> Variables = {};
 
   void sort();
 };
@@ -491,7 +487,7 @@ struct MemberTypeInfo : public FieldTypeInfo {
                       Other.Description.begin(), Other.Description.end());
   }
 
-  OwningVec<CommentInfo> Description;
+  DocList<CommentInfo> Description;
 
   // Access level associated with this info (public, protected, private, none).
   // AS_public is set as default because the bitcode writer requires the enum
@@ -576,7 +572,7 @@ struct Info {
   InfoType IT = InfoType::IT_default;
 
   // Comment description of this decl.
-  OwningVec<CommentInfo> Description = {};
+  DocList<CommentInfo> Description = {};
 };
 
 inline Context::Context(const Info &I)
@@ -617,7 +613,7 @@ struct SymbolInfo : public Info {
   }
 
   std::optional<Location> DefLoc;     // Location where this decl is defined.
-  OwningVec<Location> Loc;            // Locations where this decl is declared.
+  DocList<Location> Loc = {};         // Locations where this decl is declared.
   StringRef MangledName = {};
   bool IsStatic = false;
 };
@@ -775,7 +771,7 @@ struct EnumValueInfo {
   StringRef ValueExpr = {};
 
   /// Comment description of this field.
-  OwningVec<CommentInfo> Description;
+  DocList<CommentInfo> Description;
 };
 
 // TODO: Expand to allow for documenting templating.
@@ -831,7 +827,7 @@ struct Index : public Reference {
 // A standalone function to call to merge a vector of infos into one.
 // This assumes that all infos in the vector are of the same type, and will fail
 // if they are different.
-llvm::Expected<OwnedPtr<Info>> mergeInfos(OwningPtrArray<Info> &Values);
+llvm::Expected<Info *> mergeInfos(SmallVectorImpl<Info *> &Values);
 
 // Merges a single new Info into an existing Reduced Info (allocating it if
 // needed).

--- a/clang-tools-extra/clang-doc/YAMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/YAMLGenerator.cpp
@@ -69,11 +69,9 @@ template <typename T> struct SequenceTraits<llvm::simple_ilist<T>> {
   }
 };
 
-template <typename T> struct SequenceTraits<clang::doc::OwningVec<T>> {
-  static size_t size(IO &io, clang::doc::OwningVec<T> &seq) {
-    return seq.size();
-  }
-  static T &element(IO &io, clang::doc::OwningVec<T> &seq, size_t index) {
+template <typename T> struct SequenceTraits<clang::doc::DocList<T>> {
+  static size_t size(IO &io, clang::doc::DocList<T> &seq) { return seq.size(); }
+  static T &element(IO &io, clang::doc::DocList<T> &seq, size_t index) {
     return *(std::next(seq.begin(), index));
   }
 };

--- a/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
+++ b/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
@@ -117,13 +117,13 @@ static void BM_MergeInfos_Scale(benchmark::State &State) {
 
   for (auto _ : State) {
     State.PauseTiming();
-    OwningPtrArray<Info> Input;
+    SmallVector<Info *> Input;
     Input.reserve(State.range(0));
-    for (int i = 0; i < State.range(0); ++i) {
-      auto I = allocatePtr<FunctionInfo>();
+    for (int Idx = 0; Idx < State.range(0); ++Idx) {
+      auto *I = allocatePtr<FunctionInfo>();
       I->Name = "f";
       I->USR = USR;
-      I->DefLoc = Location(10, i, "test.cpp");
+      I->DefLoc = Location(10, Idx, "test.cpp");
       Input.push_back(std::move(I));
     }
     State.ResumeTiming();

--- a/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
@@ -51,8 +51,8 @@ static std::string writeInfo(Info *I, DiagnosticsEngine &Diags) {
   }
 }
 
-static OwningPtrVec<Info> readInfo(StringRef Bitcode, size_t NumInfos,
-                                   DiagnosticsEngine &Diags) {
+static std::vector<Info *> readInfo(StringRef Bitcode, size_t NumInfos,
+                                    DiagnosticsEngine &Diags) {
   llvm::BitstreamCursor Stream(Bitcode);
   doc::ClangDocBitcodeReader Reader(Stream, Diags);
   auto Infos = Reader.readBitcode();
@@ -85,7 +85,7 @@ TEST_F(BitcodeTest, emitNamespaceInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
+  std::vector<Info *> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckNamespaceInfo(&I, InfoAsNamespace(ReadResults[0]));
 }
@@ -144,7 +144,7 @@ TEST_F(BitcodeTest, emitRecordInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
+  std::vector<Info *> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckRecordInfo(&I, InfoAsRecord(ReadResults[0]));
 }
@@ -169,7 +169,7 @@ TEST_F(BitcodeTest, emitFunctionInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
+  std::vector<Info *> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckFunctionInfo(&I, InfoAsFunction(ReadResults[0]));
 }
@@ -196,7 +196,7 @@ TEST_F(BitcodeTest, emitMethodInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
+  std::vector<Info *> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckFunctionInfo(&I, InfoAsFunction(ReadResults[0]));
 }
@@ -219,7 +219,7 @@ TEST_F(BitcodeTest, emitEnumInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
+  std::vector<Info *> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckEnumInfo(&I, InfoAsEnum(ReadResults[0]));
 }
@@ -244,7 +244,7 @@ TEST_F(BitcodeTest, emitTypedefInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
+  std::vector<Info *> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckTypedefInfo(&I, InfoAsTypedef(ReadResults[0]));
 
@@ -343,7 +343,7 @@ TEST_F(BitcodeTest, emitInfoWithCommentBitcode) {
 
   std::string WriteResult = writeInfo(&F, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
+  std::vector<Info *> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckFunctionInfo(&F, InfoAsFunction(ReadResults[0]));
 }

--- a/clang-tools-extra/unittests/clang-doc/ClangDocTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/ClangDocTest.cpp
@@ -56,8 +56,8 @@ TypedefInfo *InfoAsTypedef(Info *I) {
 
 void CheckCommentInfo(ArrayRef<CommentInfo> Expected,
                       ArrayRef<CommentInfo> Actual);
-void CheckCommentInfo(const OwningVec<CommentInfo> &Expected,
-                      const OwningVec<CommentInfo> &Actual);
+void CheckCommentInfo(const DocList<CommentInfo> &Expected,
+                      const DocList<CommentInfo> &Actual);
 
 void CheckCommentInfo(const CommentInfo &Expected, const CommentInfo &Actual) {
   EXPECT_EQ(Expected.Kind, Actual.Kind);
@@ -96,8 +96,8 @@ void CheckCommentInfo(ArrayRef<CommentInfo> Expected,
   EXPECT_TRUE(ItE == Expected.end() && ItA == Actual.end());
 }
 
-void CheckCommentInfo(const OwningVec<CommentInfo> &Expected,
-                      const OwningVec<CommentInfo> &Actual) {
+void CheckCommentInfo(const DocList<CommentInfo> &Expected,
+                      const DocList<CommentInfo> &Actual) {
   auto ItE = Expected.begin();
   auto ItA = Actual.begin();
   while (ItE != Expected.end() && ItA != Actual.end()) {

--- a/clang-tools-extra/unittests/clang-doc/ClangDocTest.h
+++ b/clang-tools-extra/unittests/clang-doc/ClangDocTest.h
@@ -19,7 +19,7 @@
 namespace clang {
 namespace doc {
 
-using EmittedInfoList = OwningPtrVec<Info>;
+using EmittedInfoList = std::vector<Info *>;
 
 static const SymbolID EmptySID = SymbolID();
 static const SymbolID NonEmptySID =
@@ -33,8 +33,8 @@ TypedefInfo *InfoAsTypedef(Info *I);
 
 void CheckCommentInfo(ArrayRef<CommentInfo> Expected,
                       ArrayRef<CommentInfo> Actual);
-void CheckCommentInfo(const OwningVec<CommentInfo> &Expected,
-                      const OwningVec<CommentInfo> &Actual);
+void CheckCommentInfo(const DocList<CommentInfo> &Expected,
+                      const DocList<CommentInfo> &Actual);
 void CheckReference(const Reference &Expected, const Reference &Actual);
 void CheckTypeInfo(const TypeInfo *Expected, const TypeInfo *Actual);
 void CheckFieldTypeInfo(const FieldTypeInfo *Expected,

--- a/clang-tools-extra/unittests/clang-doc/MergeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/MergeTest.cpp
@@ -62,7 +62,7 @@ TEST_F(MergeTest, mergeNamespaceInfos) {
   InfoNode<EnumInfo> E2Node(&E2);
   Two.Children.Enums.push_back(E2Node);
 
-  OwningPtrVec<Info> Infos;
+  SmallVector<Info *> Infos;
   Infos.push_back(&One);
   Infos.push_back(&Two);
 
@@ -281,7 +281,7 @@ TEST_F(MergeTest, mergeRecordInfos) {
   InfoNode<EnumInfo> E2Node(&E2);
   Two.Children.Enums.push_back(E2Node);
 
-  OwningPtrVec<Info> Infos;
+  SmallVector<Info *> Infos;
   Infos.push_back(&One);
   Infos.push_back(&Two);
 
@@ -383,7 +383,7 @@ TEST_F(MergeTest, mergeFunctionInfos) {
   InfoNode<CommentInfo> TopTwoNode(&TopTwo);
   Two.Description.push_back(TopTwoNode);
 
-  OwningPtrVec<Info> Infos;
+  SmallVector<Info *> Infos;
   Infos.push_back(&One);
   Infos.push_back(&Two);
 
@@ -442,7 +442,7 @@ TEST_F(MergeTest, mergeEnumInfos) {
   EnumValueInfo EV2[] = {EnumValueInfo("X"), EnumValueInfo("Y")};
   Two.Members = llvm::ArrayRef(EV2);
 
-  OwningPtrVec<Info> Infos;
+  SmallVector<Info *> Infos;
   Infos.push_back(&One);
   Infos.push_back(&Two);
 


### PR DESCRIPTION
Many of the type aliases we introduced to simplify migration to arena
allocation  are no longer relevant after completing the migration. We
can use more relevant names and remove dead aliases.