### PR TITLE
[clang-doc] Use distinct APIs for fixed arena allocation sites

### DIFF
--- a/clang-tools-extra/clang-doc/BitcodeReader.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeReader.cpp
@@ -1108,8 +1108,9 @@ static void addChild(Target I, Child &&R) {
     if constexpr (has_children<Pointee>::value) {
       using BareChild = std::remove_cv_t<std::remove_reference_t<Child>>;
       if constexpr (is_valid_child<BareChild>::value) {
-        auto *Node = allocatePtr<BareChild>(std::forward<Child>(R));
-        getList(I->Children, Node).push_back(*allocateListNodeTransient(Node));
+        auto *NodeNode =
+            allocateListNodeTransient<BareChild>(std::forward<Child>(R));
+        getList(I->Children, NodeNode->Ptr).push_back(*NodeNode);
         return;
       }
     }
@@ -1287,7 +1288,7 @@ llvm::Error ClangDocBitcodeReader::handleSubBlock(unsigned ID, T Parent,
 
 template <typename InfoType, typename T>
 llvm::Error ClangDocBitcodeReader::handleSubBlock(unsigned ID, T Parent) {
-  InfoType *Info = allocatePtr<InfoType>();
+  InfoType *Info = allocateTransient<InfoType>();
   if (auto Err = readBlock(ID, Info))
     return Err;
   addChildPtr(Parent, Info);
@@ -1456,10 +1457,10 @@ llvm::Error ClangDocBitcodeReader::readBlockInfoBlock() {
 template <typename T>
 llvm::Expected<OwnedPtr<Info>> ClangDocBitcodeReader::createInfo(unsigned ID) {
   llvm::TimeTraceScope("Reducing infos", "createInfo");
-  OwnedPtr<Info> I = doc::allocatePtr<T>();
+  auto *I = doc::allocateTransient<T>();
   if (auto Err = readBlock(ID, static_cast<T *>(getPtr(I))))
     return std::move(Err);
-  return OwnedPtr<Info>{std::move(I)};
+  return I;
 }
 
 llvm::Expected<OwnedPtr<Info>>

--- a/clang-tools-extra/clang-doc/BitcodeReader.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeReader.cpp
@@ -1108,9 +1108,9 @@ static void addChild(Target I, Child &&R) {
     if constexpr (has_children<Pointee>::value) {
       using BareChild = std::remove_cv_t<std::remove_reference_t<Child>>;
       if constexpr (is_valid_child<BareChild>::value) {
-        auto *NodeNode =
+        auto *Node =
             allocateListNodeTransient<BareChild>(std::forward<Child>(R));
-        getList(I->Children, NodeNode->Ptr).push_back(*NodeNode);
+        getList(I->Children, Node->Ptr).push_back(*Node);
         return;
       }
     }

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -98,11 +98,10 @@ static llvm::Expected<Info *> reduce(SmallVectorImpl<Info *> &Values) {
   if (Values.empty() || !Values[0])
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "no value to reduce");
-  OwnedPtr<Info> Merged = allocatePtr<T>(Values[0]->USR);
-  T *Tmp = static_cast<T *>(getPtr(Merged));
+  T *Merged = allocateTransient<T>(Values[0]->USR);
   for (auto &I : Values)
-    Tmp->merge(std::move(*static_cast<T *>(getPtr(I))));
-  return std::move(Merged);
+    Merged->merge(std::move(*static_cast<T *>(I)));
+  return Merged;
 }
 
 template <typename T>
@@ -165,7 +164,7 @@ void mergeUnkeyed<CommentInfo>(DocList<CommentInfo> &Target,
     CommentInfo *Ptr = Source.front().Ptr;
     Source.pop_front();
 
-    if (!llvm::any_of(Target,
+    if (llvm::none_of(Target,
                       [Ptr](const auto &E) { return *E.Ptr == *Ptr; })) {
       Target.push_back(
           *allocateListNodePersistent<CommentInfo>(*Ptr, PersistentArena));

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -111,8 +111,14 @@ template <typename T> using OwnedPtr = T *;
 // A helper function to create an owned pointer, abstracting away the memory
 // allocation mechanism.
 template <typename T, typename... Args>
-OwnedPtr<T> allocatePtr(Args &&...args) {
+OwnedPtr<T> allocateTransient(Args &&...args) {
   return new (TransientArena.Allocate<T>()) T(std::forward<Args>(args)...);
+}
+
+// A helper function to create memory allocated in the TransientArena.
+template <typename T, typename... Args>
+OwnedPtr<T> allocatePersistent(Args &&...args) {
+  return new (PersistentArena.Allocate<T>()) T(std::forward<Args>(args)...);
 }
 
 // An overload to explicitly allocate on an arena, returning a bare pointer.

--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -509,20 +509,20 @@ template <typename ChildType>
 OwnedPtr<Info> Serializer::makeAndInsertIntoParent(ChildType &Child) {
   if (Child.Namespace.empty()) {
     // Insert into unnamed parent namespace.
-    auto ParentNS = allocatePtr<NamespaceInfo>();
+    auto *ParentNS = allocateTransient<NamespaceInfo>();
     InsertChild(ParentNS->Children, Child);
     return ParentNS;
   }
 
   switch (Child.Namespace[0].RefType) {
   case InfoType::IT_namespace: {
-    auto ParentNS = allocatePtr<NamespaceInfo>();
+    auto *ParentNS = allocateTransient<NamespaceInfo>();
     ParentNS->USR = Child.Namespace[0].USR;
     InsertChild(ParentNS->Children, Child);
     return ParentNS;
   }
   case InfoType::IT_record: {
-    auto ParentRec = allocatePtr<RecordInfo>();
+    auto *ParentRec = allocateTransient<RecordInfo>();
     ParentRec->USR = Child.Namespace[0].USR;
     InsertChild(ParentRec->Children, Child);
     return ParentRec;
@@ -991,9 +991,8 @@ void Serializer::parseBases(llvm::SmallVectorImpl<BaseRecordInfo> &Bases,
                                  IsInAnonymousNamespace);
             FI.Access =
                 getFinalAccessSpecifier(BI.Access, MD->getAccessUnsafe());
-            FunctionInfo *FIPtr = allocatePtr<FunctionInfo>(std::move(FI));
             BI.Children.Functions.push_back(
-                *allocatePtr<InfoNode<FunctionInfo>>(FIPtr));
+                *allocateListNodeTransient<FunctionInfo>(std::move(FI)));
           }
         Bases.emplace_back(std::move(BI));
         // Call this function recursively to get the inherited classes of
@@ -1009,7 +1008,7 @@ void Serializer::parseBases(llvm::SmallVectorImpl<BaseRecordInfo> &Bases,
 std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
 Serializer::emitInfo(const NamespaceDecl *D, const FullComment *FC,
                      Location Loc, bool PublicOnly) {
-  auto NSI = allocatePtr<NamespaceInfo>();
+  auto *NSI = allocateTransient<NamespaceInfo>();
   bool IsInAnonymousNamespace = false;
   populateInfo(*NSI, D, FC, IsInAnonymousNamespace);
   if (!shouldSerializeInfo(PublicOnly, IsInAnonymousNamespace, D))
@@ -1085,7 +1084,7 @@ std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
 Serializer::emitInfo(const RecordDecl *D, const FullComment *FC, Location Loc,
                      bool PublicOnly) {
 
-  auto RI = allocatePtr<RecordInfo>();
+  auto *RI = allocateTransient<RecordInfo>();
   bool IsInAnonymousNamespace = false;
 
   populateSymbolInfo(*RI, D, FC, Loc, IsInAnonymousNamespace);
@@ -1168,7 +1167,7 @@ Serializer::emitInfo(const RecordDecl *D, const FullComment *FC, Location Loc,
 std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
 Serializer::emitInfo(const FunctionDecl *D, const FullComment *FC, Location Loc,
                      bool PublicOnly) {
-  FunctionInfo *Func = allocatePtr<FunctionInfo>();
+  FunctionInfo *Func = allocateTransient<FunctionInfo>();
   bool IsInAnonymousNamespace = false;
   populateFunctionInfo(*Func, D, FC, Loc, IsInAnonymousNamespace);
   Func->Access = clang::AccessSpecifier::AS_none;
@@ -1182,7 +1181,7 @@ Serializer::emitInfo(const FunctionDecl *D, const FullComment *FC, Location Loc,
 std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
 Serializer::emitInfo(const CXXMethodDecl *D, const FullComment *FC,
                      Location Loc, bool PublicOnly) {
-  FunctionInfo *Func = allocatePtr<FunctionInfo>();
+  FunctionInfo *Func = allocateTransient<FunctionInfo>();
   bool IsInAnonymousNamespace = false;
   populateFunctionInfo(*Func, D, FC, Loc, IsInAnonymousNamespace);
   if (!shouldSerializeInfo(PublicOnly, IsInAnonymousNamespace, D))
@@ -1226,7 +1225,7 @@ void Serializer::extractCommentFromDecl(const Decl *D, TypedefInfo &Info) {
 std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
 Serializer::emitInfo(const TypedefDecl *D, const FullComment *FC, Location Loc,
                      bool PublicOnly) {
-  TypedefInfo *Info = allocatePtr<TypedefInfo>();
+  TypedefInfo *Info = allocateTransient<TypedefInfo>();
   bool IsInAnonymousNamespace = false;
   populateInfo(*Info, D, FC, IsInAnonymousNamespace);
 
@@ -1258,7 +1257,7 @@ Serializer::emitInfo(const TypedefDecl *D, const FullComment *FC, Location Loc,
 std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
 Serializer::emitInfo(const TypeAliasDecl *D, const FullComment *FC,
                      Location Loc, bool PublicOnly) {
-  TypedefInfo *Info = allocatePtr<TypedefInfo>();
+  TypedefInfo *Info = allocateTransient<TypedefInfo>();
   bool IsInAnonymousNamespace = false;
   populateInfo(*Info, D, FC, IsInAnonymousNamespace);
   if (!shouldSerializeInfo(PublicOnly, IsInAnonymousNamespace, D))
@@ -1282,7 +1281,7 @@ Serializer::emitInfo(const TypeAliasDecl *D, const FullComment *FC,
 std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
 Serializer::emitInfo(const EnumDecl *D, const FullComment *FC, Location Loc,
                      bool PublicOnly) {
-  EnumInfo *Enum = allocatePtr<EnumInfo>();
+  EnumInfo *Enum = allocateTransient<EnumInfo>();
   bool IsInAnonymousNamespace = false;
   populateSymbolInfo(*Enum, D, FC, Loc, IsInAnonymousNamespace);
 
@@ -1303,7 +1302,7 @@ Serializer::emitInfo(const EnumDecl *D, const FullComment *FC, Location Loc,
 std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
 Serializer::emitInfo(const ConceptDecl *D, const FullComment *FC,
                      const Location &Loc, bool PublicOnly) {
-  ConceptInfo *Concept = allocatePtr<ConceptInfo>();
+  ConceptInfo *Concept = allocateTransient<ConceptInfo>();
 
   bool IsInAnonymousNamespace = false;
   populateInfo(*Concept, D, FC, IsInAnonymousNamespace);
@@ -1330,7 +1329,7 @@ Serializer::emitInfo(const ConceptDecl *D, const FullComment *FC,
 std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
 Serializer::emitInfo(const VarDecl *D, const FullComment *FC,
                      const Location &Loc, bool PublicOnly) {
-  VarInfo *Var = allocatePtr<VarInfo>();
+  VarInfo *Var = allocateTransient<VarInfo>();
   bool IsInAnonymousNamespace = false;
   populateSymbolInfo(*Var, D, FC, Loc, IsInAnonymousNamespace);
   if (!shouldSerializeInfo(PublicOnly, IsInAnonymousNamespace, D))

--- a/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
+++ b/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
@@ -92,7 +92,7 @@ BENCHMARK(BM_Mapper_Scale)->Range(10, 10000);
 // --- Reducer Benchmarks ---
 
 static void BM_SerializeFunctionInfo(benchmark::State &State) {
-  auto I = allocatePtr<FunctionInfo>();
+  auto I = allocateTransient<FunctionInfo>();
   I->Name = "f";
   I->DefLoc = Location(0, 0, "test.cpp");
   I->ReturnType = TypeInfo("void");
@@ -120,7 +120,7 @@ static void BM_MergeInfos_Scale(benchmark::State &State) {
     SmallVector<Info *> Input;
     Input.reserve(State.range(0));
     for (int Idx = 0; Idx < State.range(0); ++Idx) {
-      auto *I = allocatePtr<FunctionInfo>();
+      auto *I = allocateTransient<FunctionInfo>();
       I->Name = "f";
       I->USR = USR;
       I->DefLoc = Location(10, Idx, "test.cpp");
@@ -181,13 +181,12 @@ static void BM_JSONGenerator_Scale(benchmark::State &State) {
     return;
   }
   int NumRecords = State.range(0);
-  auto NI = allocatePtr<NamespaceInfo>();
+  auto *NI = allocateTransient<NamespaceInfo>();
   NI->Name = "GlobalNamespace";
   for (int i = 0; i < NumRecords; ++i) {
-    Reference *R = new (TransientArena.Allocate<Reference>())
-        Reference(SymbolID{(uint8_t)(i & 0xFF)}, "Record" + std::to_string(i),
-                  InfoType::IT_record);
-    NI->Children.Records.push_back(*allocatePtr<InfoNode<Reference>>(R));
+    NI->Children.Records.push_back(*allocateListNodeTransient<Reference>(
+        SymbolID{(uint8_t)(i & 0xFF)}, "Record" + std::to_string(i),
+        InfoType::IT_record));
   }
 
   IntrusiveRefCntPtr<DiagnosticIDs> DiagID(new DiagnosticIDs());


### PR DESCRIPTION
Typically, code either always emits data into the TransientArena or the
PersistentArena. Use more explicit APIs to convey the intent directly
instead of relying on parameters or defaults.