### PR TITLE
[clang-doc] Removed OwnedPtr alias

### DIFF
--- a/clang-tools-extra/clang-doc/BitcodeReader.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeReader.cpp
@@ -1446,16 +1446,15 @@ llvm::Error ClangDocBitcodeReader::readBlockInfoBlock() {
 }
 
 template <typename T>
-llvm::Expected<OwnedPtr<Info>> ClangDocBitcodeReader::createInfo(unsigned ID) {
+llvm::Expected<Info *> ClangDocBitcodeReader::createInfo(unsigned ID) {
   llvm::TimeTraceScope("Reducing infos", "createInfo");
   auto *I = doc::allocateTransient<T>();
-  if (auto Err = readBlock(ID, static_cast<T *>(getPtr(I))))
+  if (auto Err = readBlock(ID, I))
     return std::move(Err);
   return I;
 }
 
-llvm::Expected<OwnedPtr<Info>>
-ClangDocBitcodeReader::readBlockToInfo(unsigned ID) {
+llvm::Expected<Info *> ClangDocBitcodeReader::readBlockToInfo(unsigned ID) {
   llvm::TimeTraceScope("Reducing infos", "readBlockToInfo");
   switch (ID) {
   case BI_NAMESPACE_BLOCK_ID:

--- a/clang-tools-extra/clang-doc/BitcodeReader.h
+++ b/clang-tools-extra/clang-doc/BitcodeReader.h
@@ -78,14 +78,14 @@ private:
   template <typename T> llvm::Error readRecord(unsigned ID, T I);
 
   // Allocate the relevant type of info and add read data to the object.
-  template <typename T> llvm::Expected<OwnedPtr<Info>> createInfo(unsigned ID);
+  template <typename T> llvm::Expected<Info *> createInfo(unsigned ID);
 
   // Helper function to step through blocks to find and dispatch the next record
   // or block to be read.
   llvm::Expected<Cursor> skipUntilRecordOrBlock(unsigned &BlockOrRecordID);
 
   // Helper function to set up the appropriate type of Info.
-  llvm::Expected<OwnedPtr<Info>> readBlockToInfo(unsigned ID);
+  llvm::Expected<Info *> readBlockToInfo(unsigned ID);
 
   template <typename InfoType, typename T, typename CallbackFunction>
   llvm::Error handleSubBlock(unsigned ID, T Parent, CallbackFunction Function);

--- a/clang-tools-extra/clang-doc/Generators.cpp
+++ b/clang-tools-extra/clang-doc/Generators.cpp
@@ -66,7 +66,7 @@ Error MustacheGenerator::setupTemplate(
 }
 
 Error MustacheGenerator::generateDocumentation(
-    StringRef RootDir, StringMap<doc::OwnedPtr<doc::Info>> Infos,
+    StringRef RootDir, StringMap<doc::Info *> Infos,
     const clang::doc::ClangDocContext &CDCtx, std::string DirName) {
   {
     llvm::TimeTraceScope TS("Setup Templates");

--- a/clang-tools-extra/clang-doc/Generators.h
+++ b/clang-tools-extra/clang-doc/Generators.h
@@ -29,9 +29,10 @@ public:
 
   // Write out the decl info for the objects in the given map in the specified
   // format.
-  virtual llvm::Error generateDocumentation(
-      StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
-      const ClangDocContext &CDCtx, std::string DirName = "") = 0;
+  virtual llvm::Error generateDocumentation(StringRef RootDir,
+                                            llvm::StringMap<doc::Info *> Infos,
+                                            const ClangDocContext &CDCtx,
+                                            std::string DirName = "") = 0;
 
   // This function writes a file with the index previously constructed.
   // It can be overwritten by any of the inherited generators.
@@ -131,9 +132,10 @@ struct MustacheGenerator : public Generator {
   /// 3. Iterates over the JSON files, recreates the directory structure from
   /// JSON, and calls generateDocForJSON for each file.
   /// 4. A file of the desired format is created.
-  llvm::Error generateDocumentation(
-      StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
-      const clang::doc::ClangDocContext &CDCtx, std::string DirName) override;
+  llvm::Error generateDocumentation(StringRef RootDir,
+                                    llvm::StringMap<doc::Info *> Infos,
+                                    const clang::doc::ClangDocContext &CDCtx,
+                                    std::string DirName) override;
 };
 
 // This anchor is used to force the linker to link in the generated object file

--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -44,9 +44,10 @@ public:
   // Populates templates with CSS stylesheets, JS scripts paths.
   Error setupTemplateResources(const ClangDocContext &CDCtx, json::Value &V,
                                SmallString<128> RelativeRootPath);
-  llvm::Error generateDocumentation(
-      StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
-      const ClangDocContext &CDCtx, std::string DirName) override;
+  llvm::Error generateDocumentation(StringRef RootDir,
+                                    llvm::StringMap<doc::Info *> Infos,
+                                    const ClangDocContext &CDCtx,
+                                    std::string DirName) override;
 };
 
 Error HTMLGenerator::setupTemplateFiles(const ClangDocContext &CDCtx) {
@@ -182,9 +183,10 @@ Error HTMLGenerator::createResources(ClangDocContext &CDCtx) {
   return Error::success();
 }
 
-Error HTMLGenerator::generateDocumentation(
-    StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
-    const ClangDocContext &CDCtx, std::string DirName) {
+Error HTMLGenerator::generateDocumentation(StringRef RootDir,
+                                           llvm::StringMap<doc::Info *> Infos,
+                                           const ClangDocContext &CDCtx,
+                                           std::string DirName) {
   return MustacheGenerator::generateDocumentation(RootDir, std::move(Infos),
                                                   CDCtx, "html");
 }

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -27,7 +27,7 @@ class JSONGenerator : public Generator {
   void serializeCommonChildren(
       const ScopeChildren &Children, json::Object &Obj,
       std::optional<ReferenceFunc> MDReferenceLambda = std::nullopt);
-  void serializeContexts(Info *I, llvm::StringMap<OwnedPtr<Info>> &Infos);
+  void serializeContexts(Info *I, llvm::StringMap<Info *> &Infos);
   void serializeInfo(const ConstraintInfo &I, Object &Obj);
   void serializeInfo(const TemplateInfo &Template, Object &Obj);
   void serializeInfo(const ConceptInfo &I, Object &Obj);
@@ -70,7 +70,7 @@ public:
   static const char *Format;
 
   Error generateDocumentation(StringRef RootDir,
-                              llvm::StringMap<OwnedPtr<doc::Info>> Infos,
+                              llvm::StringMap<doc::Info *> Infos,
                               const ClangDocContext &CDCtx,
                               std::string DirName) override;
   Error createResources(ClangDocContext &CDCtx) override;
@@ -920,8 +920,7 @@ Error JSONGenerator::serializeIndex(StringRef RootDir) {
   return Error::success();
 }
 
-void JSONGenerator::serializeContexts(Info *I,
-                                      StringMap<OwnedPtr<Info>> &Infos) {
+void JSONGenerator::serializeContexts(Info *I, StringMap<Info *> &Infos) {
   if (I->USR == GlobalNamespaceID)
     return;
   auto ParentUSR = I->ParentUSR;
@@ -949,14 +948,15 @@ void JSONGenerator::serializeContexts(Info *I,
   }
 }
 
-Error JSONGenerator::generateDocumentation(
-    StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
-    const ClangDocContext &CDCtx, std::string DirName) {
+Error JSONGenerator::generateDocumentation(StringRef RootDir,
+                                           llvm::StringMap<doc::Info *> Infos,
+                                           const ClangDocContext &CDCtx,
+                                           std::string DirName) {
   this->CDCtx = &CDCtx;
   StringSet<> CreatedDirs;
   StringMap<std::vector<doc::Info *>> FileToInfos;
   for (const auto &Group : Infos) {
-    Info *Info = getPtr(Group.getValue());
+    Info *Info = Group.getValue();
 
     SmallString<128> Path;
     auto RootDirStr = RootDir.str() + "/json";

--- a/clang-tools-extra/clang-doc/MDGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDGenerator.cpp
@@ -500,9 +500,10 @@ class MDGenerator : public Generator {
 public:
   static const char *Format;
 
-  llvm::Error generateDocumentation(
-      StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
-      const ClangDocContext &CDCtx, std::string DirName) override;
+  llvm::Error generateDocumentation(StringRef RootDir,
+                                    llvm::StringMap<doc::Info *> Infos,
+                                    const ClangDocContext &CDCtx,
+                                    std::string DirName) override;
   llvm::Error createResources(ClangDocContext &CDCtx) override;
   llvm::Error generateDocForInfo(Info *I, llvm::raw_ostream &OS,
                                  const ClangDocContext &CDCtx) override;
@@ -511,7 +512,7 @@ public:
 const char *MDGenerator::Format = "md";
 
 llvm::Error MDGenerator::generateDocumentation(
-    StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
+    StringRef RootDir, llvm::StringMap<doc::Info *> Infos,
     const ClangDocContext &CDCtx, std::string DirName) {
   // Track which directories we already tried to create.
   llvm::StringSet<> CreatedDirs;
@@ -519,7 +520,7 @@ llvm::Error MDGenerator::generateDocumentation(
   // Collect all output by file name and create the necessary directories.
   llvm::StringMap<std::vector<doc::Info *>> FileToInfos;
   for (const auto &Group : Infos) {
-    doc::Info *Info = getPtr(Group.getValue());
+    doc::Info *Info = Group.getValue();
 
     llvm::SmallString<128> Path;
     llvm::sys::path::native(RootDir, Path);

--- a/clang-tools-extra/clang-doc/MDMustacheGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDMustacheGenerator.cpp
@@ -26,8 +26,7 @@ static std::unique_ptr<MustacheTemplateFile> IndexTemplate = nullptr;
 
 struct MDMustacheGenerator : public MustacheGenerator {
   static const char *Format;
-  Error generateDocumentation(StringRef RootDir,
-                              StringMap<doc::OwnedPtr<doc::Info>> Infos,
+  Error generateDocumentation(StringRef RootDir, StringMap<doc::Info *> Infos,
                               const ClangDocContext &CDCtx,
                               std::string DirName) override;
   Error setupTemplateFiles(const ClangDocContext &CDCtx) override;
@@ -72,7 +71,7 @@ Error MDMustacheGenerator::setupTemplateFiles(const ClangDocContext &CDCtx) {
 }
 
 Error MDMustacheGenerator::generateDocumentation(
-    StringRef RootDir, StringMap<doc::OwnedPtr<doc::Info>> Infos,
+    StringRef RootDir, StringMap<doc::Info *> Infos,
     const clang::doc::ClangDocContext &CDCtx, std::string Dirname) {
   return MustacheGenerator::generateDocumentation(RootDir, std::move(Infos),
                                                   CDCtx, "md");

--- a/clang-tools-extra/clang-doc/Mapper.cpp
+++ b/clang-tools-extra/clang-doc/Mapper.cpp
@@ -65,7 +65,7 @@ bool MapASTVisitor::mapDecl(const T *D, bool IsDefinition) {
       return true;
   }
 
-  std::pair<OwnedPtr<Info>, OwnedPtr<Info>> CP;
+  std::pair<Info *, Info *> CP;
 
   {
     llvm::TimeTraceScope TS("emit info from astnode");
@@ -99,10 +99,10 @@ bool MapASTVisitor::mapDecl(const T *D, bool IsDefinition) {
     // this decl for some reason (e.g. we're only reporting public decls).
     if (Child)
       CDCtx.ECtx->reportResult(llvm::toHex(llvm::toStringRef(Child->USR)),
-                               serialize::serialize(Child, CDCtx.Diags));
+                               serialize::serialize(*Child, CDCtx.Diags));
     if (Parent)
       CDCtx.ECtx->reportResult(llvm::toHex(llvm::toStringRef(Parent->USR)),
-                               serialize::serialize(Parent, CDCtx.Diags));
+                               serialize::serialize(*Parent, CDCtx.Diags));
   }
   return true;
 }

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -172,8 +172,7 @@ void mergeUnkeyed<CommentInfo>(DocList<CommentInfo> &Target,
   }
 }
 
-llvm::Error mergeSingleInfo(doc::OwnedPtr<doc::Info> &Reduced,
-                            doc::OwnedPtr<doc::Info> &&NewInfo,
+llvm::Error mergeSingleInfo(doc::Info *&Reduced, doc::Info *NewInfo,
                             llvm::BumpPtrAllocator &Arena) {
   if (!Reduced) {
     switch (NewInfo->IT) {
@@ -213,36 +212,36 @@ llvm::Error mergeSingleInfo(doc::OwnedPtr<doc::Info> &Reduced,
 
   switch (Reduced->IT) {
   case InfoType::IT_namespace:
-    static_cast<NamespaceInfo *>(getPtr(Reduced))
-        ->merge(std::move(*static_cast<NamespaceInfo *>(getPtr(NewInfo))));
+    static_cast<NamespaceInfo *>(Reduced)->merge(
+        std::move(*static_cast<NamespaceInfo *>(NewInfo)));
     break;
   case InfoType::IT_record:
-    static_cast<RecordInfo *>(getPtr(Reduced))
-        ->merge(std::move(*static_cast<RecordInfo *>(getPtr(NewInfo))));
+    static_cast<RecordInfo *>(Reduced)->merge(
+        std::move(*static_cast<RecordInfo *>(NewInfo)));
     break;
   case InfoType::IT_enum:
-    static_cast<EnumInfo *>(getPtr(Reduced))
-        ->merge(std::move(*static_cast<EnumInfo *>(getPtr(NewInfo))));
+    static_cast<EnumInfo *>(Reduced)->merge(
+        std::move(*static_cast<EnumInfo *>(NewInfo)));
     break;
   case InfoType::IT_function:
-    static_cast<FunctionInfo *>(getPtr(Reduced))
-        ->merge(std::move(*static_cast<FunctionInfo *>(getPtr(NewInfo))));
+    static_cast<FunctionInfo *>(Reduced)->merge(
+        std::move(*static_cast<FunctionInfo *>(NewInfo)));
     break;
   case InfoType::IT_typedef:
-    static_cast<TypedefInfo *>(getPtr(Reduced))
-        ->merge(std::move(*static_cast<TypedefInfo *>(getPtr(NewInfo))));
+    static_cast<TypedefInfo *>(Reduced)->merge(
+        std::move(*static_cast<TypedefInfo *>(NewInfo)));
     break;
   case InfoType::IT_concept:
-    static_cast<ConceptInfo *>(getPtr(Reduced))
-        ->merge(std::move(*static_cast<ConceptInfo *>(getPtr(NewInfo))));
+    static_cast<ConceptInfo *>(Reduced)->merge(
+        std::move(*static_cast<ConceptInfo *>(NewInfo)));
     break;
   case InfoType::IT_variable:
-    static_cast<VarInfo *>(getPtr(Reduced))
-        ->merge(std::move(*static_cast<VarInfo *>(getPtr(NewInfo))));
+    static_cast<VarInfo *>(Reduced)->merge(
+        std::move(*static_cast<VarInfo *>(NewInfo)));
     break;
   case InfoType::IT_friend:
-    static_cast<FriendInfo *>(getPtr(Reduced))
-        ->merge(std::move(*static_cast<FriendInfo *>(getPtr(NewInfo))));
+    static_cast<FriendInfo *>(Reduced)->merge(
+        std::move(*static_cast<FriendInfo *>(NewInfo)));
     break;
   default:
     return llvm::createStringError(llvm::inconvertibleErrorCode(),

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -104,20 +104,14 @@ llvm::ArrayRef<T> deepCopyArray(llvm::ArrayRef<T> V,
   return llvm::ArrayRef<T>(Allocated, V.size());
 }
 
-// An abstraction for owned pointers. Initially mapped to OwnedPtr,
-// to be eventually transitioned to bare pointers in an arena.
-template <typename T> using OwnedPtr = T *;
-
 // A helper function to create an owned pointer, abstracting away the memory
 // allocation mechanism.
-template <typename T, typename... Args>
-OwnedPtr<T> allocateTransient(Args &&...args) {
+template <typename T, typename... Args> T *allocateTransient(Args &&...args) {
   return new (TransientArena.Allocate<T>()) T(std::forward<Args>(args)...);
 }
 
 // A helper function to create memory allocated in the TransientArena.
-template <typename T, typename... Args>
-OwnedPtr<T> allocatePersistent(Args &&...args) {
+template <typename T, typename... Args> T *allocatePersistent(Args &&...args) {
   return new (PersistentArena.Allocate<T>()) T(std::forward<Args>(args)...);
 }
 
@@ -126,10 +120,6 @@ template <typename T, typename... Args>
 T *allocatePtr(llvm::BumpPtrAllocator &Alloc, Args &&...args) {
   return new (Alloc.Allocate<T>()) T(std::forward<Args>(args)...);
 }
-
-// A helper function to access the underlying pointer from an owned pointer,
-// abstracting away the pointer dereferencing mechanism.
-template <typename T> T *getPtr(const OwnedPtr<T> &O) { return O; }
 
 template <typename T> struct InfoNode : public llvm::ilist_node<InfoNode<T>> {
   InfoNode(T *P) : Ptr(P) {}
@@ -190,14 +180,6 @@ template <typename T> InfoNode<T> *allocateListNodePersistent(T *Item) {
 // An abstraction for lists that are dynamically managed (inserted/removed).
 // To be eventually transitioned to llvm::simple_ilist.
 template <typename T> using DocList = llvm::simple_ilist<InfoNode<T>>;
-
-// An abstraction for dynamic lists of owned pointers.
-// To be eventually transitioned to llvm::simple_ilist<T*> or similar.
-template <typename T> using OwningPtrVec = std::vector<OwnedPtr<T>>;
-
-// An abstraction for arrays of owned pointers.
-// To be eventually transitioned to arena-allocated arrays of bare pointers.
-template <typename T> using OwningPtrArray = std::vector<OwnedPtr<T>>;
 
 // SHA1'd hash of a USR.
 using SymbolID = std::array<uint8_t, 20>;
@@ -837,8 +819,7 @@ llvm::Expected<Info *> mergeInfos(SmallVectorImpl<Info *> &Values);
 
 // Merges a single new Info into an existing Reduced Info (allocating it if
 // needed).
-llvm::Error mergeSingleInfo(doc::OwnedPtr<doc::Info> &Reduced,
-                            doc::OwnedPtr<doc::Info> &&NewInfo,
+llvm::Error mergeSingleInfo(doc::Info *&Reduced, doc::Info *NewInfo,
                             llvm::BumpPtrAllocator &Arena);
 
 struct ClangDocContext {

--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -354,7 +354,7 @@ StringRef Serializer::getSourceCode(const Decl *D, const SourceRange &R) {
 }
 
 template <typename T>
-static std::string serialize(T &I, DiagnosticsEngine &Diags) {
+static std::string serialize(const T &I, DiagnosticsEngine &Diags) {
   SmallString<2048> Buffer;
   llvm::BitstreamWriter Stream(Buffer);
   ClangDocBitcodeWriter Writer(Stream, Diags);
@@ -362,20 +362,20 @@ static std::string serialize(T &I, DiagnosticsEngine &Diags) {
   return Buffer.str().str();
 }
 
-std::string serialize(OwnedPtr<Info> &I, DiagnosticsEngine &Diags) {
-  switch (I->IT) {
+std::string serialize(const Info &I, DiagnosticsEngine &Diags) {
+  switch (I.IT) {
   case InfoType::IT_namespace:
-    return serialize(*static_cast<NamespaceInfo *>(getPtr(I)), Diags);
+    return serialize(static_cast<const NamespaceInfo &>(I), Diags);
   case InfoType::IT_record:
-    return serialize(*static_cast<RecordInfo *>(getPtr(I)), Diags);
+    return serialize(static_cast<const RecordInfo &>(I), Diags);
   case InfoType::IT_enum:
-    return serialize(*static_cast<EnumInfo *>(getPtr(I)), Diags);
+    return serialize(static_cast<const EnumInfo &>(I), Diags);
   case InfoType::IT_function:
-    return serialize(*static_cast<FunctionInfo *>(getPtr(I)), Diags);
+    return serialize(static_cast<const FunctionInfo &>(I), Diags);
   case InfoType::IT_concept:
-    return serialize(*static_cast<ConceptInfo *>(getPtr(I)), Diags);
+    return serialize(static_cast<const ConceptInfo &>(I), Diags);
   case InfoType::IT_variable:
-    return serialize(*static_cast<VarInfo *>(getPtr(I)), Diags);
+    return serialize(static_cast<const VarInfo &>(I), Diags);
   case InfoType::IT_friend:
   case InfoType::IT_typedef:
   case InfoType::IT_default:
@@ -506,7 +506,7 @@ void Serializer::InsertChild(ScopeChildren &Scope, VarInfo &Info) {
 // parameter. Since each variant is used once, it's not worth having a more
 // elaborate system to automatically deduce this information.
 template <typename ChildType>
-OwnedPtr<Info> Serializer::makeAndInsertIntoParent(ChildType &Child) {
+Info *Serializer::makeAndInsertIntoParent(ChildType &Child) {
   if (Child.Namespace.empty()) {
     // Insert into unnamed parent namespace.
     auto *ParentNS = allocateTransient<NamespaceInfo>();
@@ -1005,9 +1005,9 @@ void Serializer::parseBases(llvm::SmallVectorImpl<BaseRecordInfo> &Bases,
   }
 }
 
-std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
-Serializer::emitInfo(const NamespaceDecl *D, const FullComment *FC,
-                     Location Loc, bool PublicOnly) {
+std::pair<Info *, Info *> Serializer::emitInfo(const NamespaceDecl *D,
+                                               const FullComment *FC,
+                                               Location Loc, bool PublicOnly) {
   auto *NSI = allocateTransient<NamespaceInfo>();
   bool IsInAnonymousNamespace = false;
   populateInfo(*NSI, D, FC, IsInAnonymousNamespace);
@@ -1017,7 +1017,7 @@ Serializer::emitInfo(const NamespaceDecl *D, const FullComment *FC,
   NSI->Name = D->isAnonymousNamespace() ? "@nonymous_namespace" : NSI->Name;
   NSI->Path = getInfoRelativePath(NSI->Namespace);
   if (NSI->Namespace.empty() && NSI->USR == SymbolID())
-    return {OwnedPtr<Info>{std::move(NSI)}, nullptr};
+    return {NSI, nullptr};
 
   // Namespaces are inserted into the parent by reference, so we need to return
   // both the parent and the record itself.
@@ -1080,9 +1080,9 @@ void Serializer::parseFriends(RecordInfo &RI, const CXXRecordDecl *D) {
     RI.Friends = allocateArray<FriendInfo>(LocalFriends, TransientArena);
 }
 
-std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
-Serializer::emitInfo(const RecordDecl *D, const FullComment *FC, Location Loc,
-                     bool PublicOnly) {
+std::pair<Info *, Info *> Serializer::emitInfo(const RecordDecl *D,
+                                               const FullComment *FC,
+                                               Location Loc, bool PublicOnly) {
 
   auto *RI = allocateTransient<RecordInfo>();
   bool IsInAnonymousNamespace = false;
@@ -1164,9 +1164,9 @@ Serializer::emitInfo(const RecordDecl *D, const FullComment *FC, Location Loc,
   return {std::move(RI), std::move(Parent)};
 }
 
-std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
-Serializer::emitInfo(const FunctionDecl *D, const FullComment *FC, Location Loc,
-                     bool PublicOnly) {
+std::pair<Info *, Info *> Serializer::emitInfo(const FunctionDecl *D,
+                                               const FullComment *FC,
+                                               Location Loc, bool PublicOnly) {
   FunctionInfo *Func = allocateTransient<FunctionInfo>();
   bool IsInAnonymousNamespace = false;
   populateFunctionInfo(*Func, D, FC, Loc, IsInAnonymousNamespace);
@@ -1178,9 +1178,9 @@ Serializer::emitInfo(const FunctionDecl *D, const FullComment *FC, Location Loc,
   return {nullptr, makeAndInsertIntoParent(*Func)};
 }
 
-std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
-Serializer::emitInfo(const CXXMethodDecl *D, const FullComment *FC,
-                     Location Loc, bool PublicOnly) {
+std::pair<Info *, Info *> Serializer::emitInfo(const CXXMethodDecl *D,
+                                               const FullComment *FC,
+                                               Location Loc, bool PublicOnly) {
   FunctionInfo *Func = allocateTransient<FunctionInfo>();
   bool IsInAnonymousNamespace = false;
   populateFunctionInfo(*Func, D, FC, Loc, IsInAnonymousNamespace);
@@ -1222,9 +1222,9 @@ void Serializer::extractCommentFromDecl(const Decl *D, TypedefInfo &Info) {
   }
 }
 
-std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
-Serializer::emitInfo(const TypedefDecl *D, const FullComment *FC, Location Loc,
-                     bool PublicOnly) {
+std::pair<Info *, Info *> Serializer::emitInfo(const TypedefDecl *D,
+                                               const FullComment *FC,
+                                               Location Loc, bool PublicOnly) {
   TypedefInfo *Info = allocateTransient<TypedefInfo>();
   bool IsInAnonymousNamespace = false;
   populateInfo(*Info, D, FC, IsInAnonymousNamespace);
@@ -1254,9 +1254,9 @@ Serializer::emitInfo(const TypedefDecl *D, const FullComment *FC, Location Loc,
 
 // A type alias is a C++ "using" declaration for a type. It gets mapped to a
 // TypedefInfo with the IsUsing flag set.
-std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
-Serializer::emitInfo(const TypeAliasDecl *D, const FullComment *FC,
-                     Location Loc, bool PublicOnly) {
+std::pair<Info *, Info *> Serializer::emitInfo(const TypeAliasDecl *D,
+                                               const FullComment *FC,
+                                               Location Loc, bool PublicOnly) {
   TypedefInfo *Info = allocateTransient<TypedefInfo>();
   bool IsInAnonymousNamespace = false;
   populateInfo(*Info, D, FC, IsInAnonymousNamespace);
@@ -1278,9 +1278,9 @@ Serializer::emitInfo(const TypeAliasDecl *D, const FullComment *FC,
   return {nullptr, makeAndInsertIntoParent(*Info)};
 }
 
-std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
-Serializer::emitInfo(const EnumDecl *D, const FullComment *FC, Location Loc,
-                     bool PublicOnly) {
+std::pair<Info *, Info *> Serializer::emitInfo(const EnumDecl *D,
+                                               const FullComment *FC,
+                                               Location Loc, bool PublicOnly) {
   EnumInfo *Enum = allocateTransient<EnumInfo>();
   bool IsInAnonymousNamespace = false;
   populateSymbolInfo(*Enum, D, FC, Loc, IsInAnonymousNamespace);
@@ -1299,9 +1299,10 @@ Serializer::emitInfo(const EnumDecl *D, const FullComment *FC, Location Loc,
   return {nullptr, makeAndInsertIntoParent(*Enum)};
 }
 
-std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
-Serializer::emitInfo(const ConceptDecl *D, const FullComment *FC,
-                     const Location &Loc, bool PublicOnly) {
+std::pair<Info *, Info *> Serializer::emitInfo(const ConceptDecl *D,
+                                               const FullComment *FC,
+                                               const Location &Loc,
+                                               bool PublicOnly) {
   ConceptInfo *Concept = allocateTransient<ConceptInfo>();
 
   bool IsInAnonymousNamespace = false;
@@ -1326,9 +1327,10 @@ Serializer::emitInfo(const ConceptDecl *D, const FullComment *FC,
   return {nullptr, makeAndInsertIntoParent(*Concept)};
 }
 
-std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
-Serializer::emitInfo(const VarDecl *D, const FullComment *FC,
-                     const Location &Loc, bool PublicOnly) {
+std::pair<Info *, Info *> Serializer::emitInfo(const VarDecl *D,
+                                               const FullComment *FC,
+                                               const Location &Loc,
+                                               bool PublicOnly) {
   VarInfo *Var = allocateTransient<VarInfo>();
   bool IsInAnonymousNamespace = false;
   populateSymbolInfo(*Var, D, FC, Loc, IsInAnonymousNamespace);

--- a/clang-tools-extra/clang-doc/Serialize.h
+++ b/clang-tools-extra/clang-doc/Serialize.h
@@ -37,54 +37,42 @@ class Serializer {
 public:
   Serializer() = default;
 
-  std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const NamespaceDecl *D,
-                                                     const FullComment *FC,
-                                                     Location Loc,
-                                                     bool PublicOnly);
+  std::pair<Info *, Info *> emitInfo(const NamespaceDecl *D,
+                                     const FullComment *FC, Location Loc,
+                                     bool PublicOnly);
 
-  std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const RecordDecl *D,
-                                                     const FullComment *FC,
-                                                     Location Loc,
-                                                     bool PublicOnly);
+  std::pair<Info *, Info *> emitInfo(const RecordDecl *D, const FullComment *FC,
+                                     Location Loc, bool PublicOnly);
 
-  std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const EnumDecl *D,
-                                                     const FullComment *FC,
-                                                     Location Loc,
-                                                     bool PublicOnly);
+  std::pair<Info *, Info *> emitInfo(const EnumDecl *D, const FullComment *FC,
+                                     Location Loc, bool PublicOnly);
 
-  std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const FunctionDecl *D,
-                                                     const FullComment *FC,
-                                                     Location Loc,
-                                                     bool PublicOnly);
+  std::pair<Info *, Info *> emitInfo(const FunctionDecl *D,
+                                     const FullComment *FC, Location Loc,
+                                     bool PublicOnly);
 
-  std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
-  emitInfo(const VarDecl *D, const FullComment *FC, int LineNumber,
-           StringRef File, bool IsFileInRootDir, bool PublicOnly);
+  std::pair<Info *, Info *> emitInfo(const VarDecl *D, const FullComment *FC,
+                                     int LineNumber, StringRef File,
+                                     bool IsFileInRootDir, bool PublicOnly);
 
-  std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const CXXMethodDecl *D,
-                                                     const FullComment *FC,
-                                                     Location Loc,
-                                                     bool PublicOnly);
+  std::pair<Info *, Info *> emitInfo(const CXXMethodDecl *D,
+                                     const FullComment *FC, Location Loc,
+                                     bool PublicOnly);
 
-  std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const TypedefDecl *D,
-                                                     const FullComment *FC,
-                                                     Location Loc,
-                                                     bool PublicOnly);
+  std::pair<Info *, Info *> emitInfo(const TypedefDecl *D,
+                                     const FullComment *FC, Location Loc,
+                                     bool PublicOnly);
 
-  std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const TypeAliasDecl *D,
-                                                     const FullComment *FC,
-                                                     Location Loc,
-                                                     bool PublicOnly);
+  std::pair<Info *, Info *> emitInfo(const TypeAliasDecl *D,
+                                     const FullComment *FC, Location Loc,
+                                     bool PublicOnly);
 
-  std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const ConceptDecl *D,
-                                                     const FullComment *FC,
-                                                     const Location &Loc,
-                                                     bool PublicOnly);
+  std::pair<Info *, Info *> emitInfo(const ConceptDecl *D,
+                                     const FullComment *FC, const Location &Loc,
+                                     bool PublicOnly);
 
-  std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const VarDecl *D,
-                                                     const FullComment *FC,
-                                                     const Location &Loc,
-                                                     bool PublicOnly);
+  std::pair<Info *, Info *> emitInfo(const VarDecl *D, const FullComment *FC,
+                                     const Location &Loc, bool PublicOnly);
 
 private:
   void getTemplateParameters(const TemplateParameterList *TemplateParams,
@@ -123,8 +111,7 @@ private:
   void InsertChild(ScopeChildren &Scope, ConceptInfo &Info);
   void InsertChild(ScopeChildren &Scope, VarInfo &Info);
 
-  template <typename ChildType>
-  OwnedPtr<Info> makeAndInsertIntoParent(ChildType &Child);
+  template <typename ChildType> Info *makeAndInsertIntoParent(ChildType &Child);
 
   AccessSpecifier getFinalAccessSpecifier(AccessSpecifier FirstAS,
                                           AccessSpecifier SecondAS);
@@ -193,7 +180,7 @@ private:
 // memory (vs storing USRs directly).
 SymbolID hashUSR(llvm::StringRef USR);
 
-std::string serialize(OwnedPtr<Info> &I, DiagnosticsEngine &Diags);
+std::string serialize(const Info &I, DiagnosticsEngine &Diags);
 
 } // namespace serialize
 } // namespace doc

--- a/clang-tools-extra/clang-doc/YAMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/YAMLGenerator.cpp
@@ -28,7 +28,6 @@ LLVM_YAML_IS_SEQUENCE_VECTOR(EnumValueInfo)
 LLVM_YAML_IS_SEQUENCE_VECTOR(TemplateParamInfo)
 LLVM_YAML_IS_SEQUENCE_VECTOR(TypedefInfo)
 LLVM_YAML_IS_SEQUENCE_VECTOR(BaseRecordInfo)
-LLVM_YAML_IS_SEQUENCE_VECTOR(OwnedPtr<CommentInfo>)
 
 namespace llvm {
 
@@ -520,9 +519,10 @@ class YAMLGenerator : public Generator {
 public:
   static const char *Format;
 
-  llvm::Error generateDocumentation(
-      StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
-      const ClangDocContext &CDCtx, std::string DirName) override;
+  llvm::Error generateDocumentation(StringRef RootDir,
+                                    llvm::StringMap<doc::Info *> Infos,
+                                    const ClangDocContext &CDCtx,
+                                    std::string DirName) override;
   llvm::Error generateDocForInfo(Info *I, llvm::raw_ostream &OS,
                                  const ClangDocContext &CDCtx) override;
 };
@@ -530,10 +530,10 @@ public:
 const char *YAMLGenerator::Format = "yaml";
 
 llvm::Error YAMLGenerator::generateDocumentation(
-    StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
+    StringRef RootDir, llvm::StringMap<doc::Info *> Infos,
     const ClangDocContext &CDCtx, std::string DirName) {
   for (const auto &Group : Infos) {
-    doc::Info *Info = getPtr(Group.getValue());
+    doc::Info *Info = Group.getValue();
 
     // Output file names according to the USR except the global namesapce.
     // Anonymous namespaces are taken care of in serialization, so here we can

--- a/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
+++ b/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
@@ -102,10 +102,10 @@ static void BM_SerializeFunctionInfo(benchmark::State &State) {
   DiagnosticOptions DiagOpts;
   DiagnosticsEngine Diags(DiagID, DiagOpts, new IgnoringDiagConsumer());
 
-  OwnedPtr<Info> InfoPtr = std::move(I);
+  Info *InfoPtr = I;
 
   for (auto _ : State) {
-    auto Result = serialize::serialize(InfoPtr, Diags);
+    auto Result = serialize::serialize(*InfoPtr, Diags);
     benchmark::DoNotOptimize(Result);
   }
 }
@@ -200,7 +200,7 @@ static void BM_JSONGenerator_Scale(benchmark::State &State) {
 
   for (auto _ : State) {
     Output.clear();
-    auto Err = (*G)->generateDocForInfo(getPtr(NI), OS, CDCtx);
+    auto Err = (*G)->generateDocForInfo(NI, OS, CDCtx);
     if (Err) {
       State.SkipWithError("generateDocForInfo failed");
       llvm::consumeError(std::move(Err));

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -224,16 +224,15 @@ static llvm::Error getMdFiles(const char *Argv0,
 
 /// Make the output of clang-doc deterministic by sorting the children of
 /// namespaces and records.
-static void
-sortUsrToInfo(llvm::StringMap<doc::OwnedPtr<doc::Info>> &USRToInfo) {
+static void sortUsrToInfo(llvm::StringMap<doc::Info *> &USRToInfo) {
   for (auto &I : USRToInfo) {
     auto &Info = I.second;
     if (Info->IT == doc::InfoType::IT_namespace) {
-      auto *Namespace = static_cast<clang::doc::NamespaceInfo *>(getPtr(Info));
+      auto *Namespace = static_cast<clang::doc::NamespaceInfo *>(Info);
       Namespace->Children.sort();
     }
     if (Info->IT == doc::InfoType::IT_record) {
-      auto *Record = static_cast<clang::doc::RecordInfo *>(getPtr(Info));
+      auto *Record = static_cast<clang::doc::RecordInfo *>(Info);
       Record->Children.sort();
     }
   }
@@ -340,7 +339,7 @@ Example usage for a project using a compile commands database:
     // Collects all Infos according to their unique USR value. This map is added
     // to from the thread pool below and is protected by the USRToInfoMutex.
     llvm::sys::Mutex USRToInfoMutex;
-    llvm::StringMap<doc::OwnedPtr<doc::Info>> USRToInfo;
+    llvm::StringMap<doc::Info *> USRToInfo;
 
     // First reducing phase (reduce all decls into one info per decl).
     llvm::outs() << "Reducing " << USRToBitcode.size() << " infos...\n";
@@ -368,7 +367,7 @@ Example usage for a project using a compile commands database:
           if (CDCtx.FTimeTrace)
             llvm::timeTraceProfilerInitialize(200, "clang-doc");
 
-          doc::OwnedPtr<doc::Info> Reduced = nullptr;
+          doc::Info *Reduced = nullptr;
           {
             llvm::TimeTraceScope Red("decoding and merging bitcode");
             for (const auto &Bitcode : Bitcodes) {
@@ -402,7 +401,7 @@ Example usage for a project using a compile commands database:
           {
             llvm::TimeTraceScope Merge("addInfoToIndex");
             std::lock_guard<llvm::sys::Mutex> Guard(IndexMutex);
-            clang::doc::Generator::addInfoToIndex(CDCtx.Idx, getPtr(Reduced));
+            clang::doc::Generator::addInfoToIndex(CDCtx.Idx, Reduced);
           }
           // Save in the result map (needs a lock due to threaded access).
           {

--- a/clang-tools-extra/unittests/clang-doc/MergeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/MergeTest.cpp
@@ -199,7 +199,7 @@ TEST_F(MergeTest, mergeSingleNamespaceInfo) {
   Expected.Children.Enums.push_back(EE2Node);
   NamespaceInfo ReducedObj;
   ReducedObj.IT = InfoType::IT_namespace;
-  doc::OwnedPtr<doc::Info> Reduced = &ReducedObj;
+  doc::Info *Reduced = &ReducedObj;
 
   Info *PtrOne = &One;
   auto Err1 = mergeSingleInfo(Reduced, std::move(PtrOne), doc::PersistentArena);
@@ -210,9 +210,9 @@ TEST_F(MergeTest, mergeSingleNamespaceInfo) {
   assert(!Err2);
 
   CheckNamespaceInfo(InfoAsNamespace(&Expected),
-                     static_cast<NamespaceInfo *>(getPtr(Reduced)));
+                     static_cast<NamespaceInfo *>(Reduced));
 
-  auto *RedNS = static_cast<NamespaceInfo *>(getPtr(Reduced));
+  auto *RedNS = static_cast<NamespaceInfo *>(Reduced);
   // Check that children functions are NOT the same instances as in One or Two
   ASSERT_NE(RedNS->Children.Functions.front().Ptr, &F1);
   ASSERT_NE(RedNS->Children.Functions.back().Ptr, &F2);


### PR DESCRIPTION
The alias served a purpose during migration, but now conveys the wrong semantics, as the memory of these pointers is interned inside a local arena.