### PR TITLE
[lldb] Remove Log::Error and Log::Warning (NFC)

### DIFF
--- a/lldb/include/lldb/Utility/Log.h
+++ b/lldb/include/lldb/Utility/Log.h
@@ -255,11 +255,7 @@ public:
   /// Prefer using LLDB_LOGF whenever possible.
   void Printf(const char *format, ...) __attribute__((format(printf, 2, 3)));
 
-  void Error(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
-
   void Verbose(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
-
-  void Warning(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
   const Flags GetOptions() const;
 
@@ -268,7 +264,6 @@ public:
   bool GetVerbose() const;
 
   void VAPrintf(const char *format, va_list args);
-  void VAError(const char *format, va_list args);
   void VAFormatf(llvm::StringRef file, llvm::StringRef function,
                  const char *format, va_list args);
 

--- a/lldb/source/Breakpoint/BreakpointResolverName.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverName.cpp
@@ -37,9 +37,8 @@ BreakpointResolverName::BreakpointResolverName(
     if (!m_regex.IsValid()) {
       Log *log = GetLog(LLDBLog::Breakpoints);
 
-      if (log)
-        log->Warning("function name regexp: \"%s\" did not compile.",
-                     name_cstr);
+      LLDB_LOGF(log, "warning: function name regexp: \"%s\" did not compile.",
+                name_cstr);
     }
   } else {
     AddNameLookup(ConstString(name_cstr), name_type_mask);
@@ -287,8 +286,7 @@ BreakpointResolverName::SearchCallback(SearchFilter &filter,
     }
     break;
   case Breakpoint::Glob:
-    if (log)
-      log->Warning("glob is not supported yet.");
+    LLDB_LOG(log, "warning: glob is not supported yet.");
     break;
   }
 

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -4517,11 +4517,11 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
                   ++sym_idx;
                 }
               } else {
-                if (log)
-                  log->Warning("symbol stub referencing symbol table symbol "
-                               "%u that isn't in our minimal symbol table, "
-                               "fix this!!!",
-                               stub_sym_id);
+                LLDB_LOGF(log,
+                          "warning: symbol stub referencing symbol table "
+                          "symbol %u that isn't in our minimal symbol table, "
+                          "fix this!!!",
+                          stub_sym_id);
               }
             }
           }

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -4420,9 +4420,8 @@ void ProcessGDBRemote::GetMaxMemorySize() {
         // In unlikely scenario that max packet size is less then 70, we will
         // hope that data being written is small enough to fit.
         Log *log(GetLog(GDBRLog::Comm | GDBRLog::Memory));
-        if (log)
-          log->Warning("Packet size is too small. "
-                       "LLDB may face problems while writing memory");
+        LLDB_LOG(log, "warning: Packet size is too small. "
+                      "LLDB may face problems while writing memory");
       }
 
       m_max_memory_size = stub_max_size;

--- a/lldb/source/Target/ThreadPlan.cpp
+++ b/lldb/source/Target/ThreadPlan.cpp
@@ -201,10 +201,10 @@ bool ThreadPlanNull::ValidatePlan(Stream *error) {
           LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
 #else
   Log *log = GetLog(LLDBLog::Thread);
-  if (log)
-    log->Error("%s called on thread that has been destroyed (tid = 0x%" PRIx64
-               ", ptid = 0x%" PRIx64 ")",
-               LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
+  LLDB_LOGF(log,
+            "error: %s called on thread that has been destroyed "
+            "(tid = 0x%" PRIx64 ", ptid = 0x%" PRIx64 ")",
+            LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
 #endif
   return true;
 }
@@ -217,10 +217,10 @@ bool ThreadPlanNull::ShouldStop(Event *event_ptr) {
           LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
 #else
   Log *log = GetLog(LLDBLog::Thread);
-  if (log)
-    log->Error("%s called on thread that has been destroyed (tid = 0x%" PRIx64
-               ", ptid = 0x%" PRIx64 ")",
-               LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
+  LLDB_LOGF(log,
+            "error: %s called on thread that has been destroyed "
+            "(tid = 0x%" PRIx64 ", ptid = 0x%" PRIx64 ")",
+            LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
 #endif
   return true;
 }
@@ -233,10 +233,10 @@ bool ThreadPlanNull::WillStop() {
           LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
 #else
   Log *log = GetLog(LLDBLog::Thread);
-  if (log)
-    log->Error("%s called on thread that has been destroyed (tid = 0x%" PRIx64
-               ", ptid = 0x%" PRIx64 ")",
-               LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
+  LLDB_LOGF(log,
+            "error: %s called on thread that has been destroyed "
+            "(tid = 0x%" PRIx64 ", ptid = 0x%" PRIx64 ")",
+            LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
 #endif
   return true;
 }
@@ -249,10 +249,10 @@ bool ThreadPlanNull::DoPlanExplainsStop(Event *event_ptr) {
           LLVM_PRETTY_FUNCTION, GetThread().GetID(), GetThread().GetProtocolID());
 #else
   Log *log = GetLog(LLDBLog::Thread);
-  if (log)
-    log->Error("%s called on thread that has been destroyed (tid = 0x%" PRIx64
-               ", ptid = 0x%" PRIx64 ")",
-               LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
+  LLDB_LOGF(log,
+            "error: %s called on thread that has been destroyed "
+            "(tid = 0x%" PRIx64 ", ptid = 0x%" PRIx64 ")",
+            LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
 #endif
   return true;
 }
@@ -267,10 +267,10 @@ bool ThreadPlanNull::MischiefManaged() {
           LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
 #else
   Log *log = GetLog(LLDBLog::Thread);
-  if (log)
-    log->Error("%s called on thread that has been destroyed (tid = 0x%" PRIx64
-               ", ptid = 0x%" PRIx64 ")",
-               LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
+  LLDB_LOGF(log,
+            "error: %s called on thread that has been destroyed "
+            "(tid = 0x%" PRIx64 ", ptid = 0x%" PRIx64 ")",
+            LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
 #endif
   return false;
 }
@@ -284,10 +284,10 @@ lldb::StateType ThreadPlanNull::GetPlanRunState() {
           LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
 #else
   Log *log = GetLog(LLDBLog::Thread);
-  if (log)
-    log->Error("%s called on thread that has been destroyed (tid = 0x%" PRIx64
-               ", ptid = 0x%" PRIx64 ")",
-               LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
+  LLDB_LOGF(log,
+            "error: %s called on thread that has been destroyed "
+            "(tid = 0x%" PRIx64 ", ptid = 0x%" PRIx64 ")",
+            LLVM_PRETTY_FUNCTION, m_tid, GetThread().GetProtocolID());
 #endif
   return eStateRunning;
 }

--- a/lldb/source/Utility/Log.cpp
+++ b/lldb/source/Utility/Log.cpp
@@ -181,21 +181,6 @@ void Log::VAFormatf(llvm::StringRef file, llvm::StringRef function,
   Format(file, function, llvm::formatv("{0}", Content));
 }
 
-// Printing of errors that are not fatal.
-void Log::Error(const char *format, ...) {
-  va_list args;
-  va_start(args, format);
-  VAError(format, args);
-  va_end(args);
-}
-
-void Log::VAError(const char *format, va_list args) {
-  llvm::SmallString<64> Content;
-  VASprintf(Content, format, args);
-
-  Printf("error: %s", Content.c_str());
-}
-
 // Printing of warnings that are not fatal only if verbose mode is enabled.
 void Log::Verbose(const char *format, ...) {
   if (!GetVerbose())
@@ -205,17 +190,6 @@ void Log::Verbose(const char *format, ...) {
   va_start(args, format);
   VAPrintf(format, args);
   va_end(args);
-}
-
-// Printing of warnings that are not fatal.
-void Log::Warning(const char *format, ...) {
-  llvm::SmallString<64> Content;
-  va_list args;
-  va_start(args, format);
-  VASprintf(Content, format, args);
-  va_end(args);
-
-  Printf("warning: %s", Content.c_str());
 }
 
 void Log::Register(llvm::StringRef name, Channel &channel) {


### PR DESCRIPTION
These two methods are rarely used and encourages using the log directly instead of going through the LLDB_LOG macro. Inline the warning:/error: part and replace them with calls to the macro.