### PR TITLE
[RISCV][P-ext] Add isel patterns for for macc*.h00/macc*.w00.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1952,6 +1952,13 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def : PatGprGpr<avgfloors, AADD, i32>;
   def : PatGprGpr<avgflooru, AADDU, i32>;
 
+  def : Pat<(i32 (add GPR:$rd, (mul_oneuse sexti16:$rs1, sexti16:$rs2))),
+            (MACC_H00 GPR:$rd, sexti16:$rs1, sexti16:$rs2)>;
+  def : Pat<(i32 (add GPR:$rd, (mul_oneuse zexti16:$rs1, zexti16:$rs2))),
+            (MACCU_H00 GPR:$rd, zexti16:$rs1, zexti16:$rs2)>;
+  def : Pat<(i32 (add GPR:$rd, (mul_oneuse sexti16:$rs1, zexti16:$rs2))),
+            (MACCSU_H00 GPR:$rd, sexti16:$rs1, zexti16:$rs2)>;
+
   // Narrowing shift patterns (NSRL/NSRA)
   // Immediate shift amount patterns
   def : Pat<(riscv_nsrl GPR:$lo, GPR:$hi, uimm6:$shamt),
@@ -2001,6 +2008,13 @@ let Predicates = [HasStdExtP, IsRV64] in {
             (SATI_RV64 GPR:$rs1, (IncImm timm:$imm))>;
   def : Pat<(XLenVT (riscv_usati GPR:$rs1, timm:$imm)),
             (USATI_RV64 GPR:$rs1, timm:$imm)>;
+
+  def : Pat<(i64 (add GPR:$rd, (mul_oneuse sexti32:$rs1, sexti32:$rs2))),
+            (MACC_W00 GPR:$rd, sexti32:$rs1, sexti32:$rs2)>;
+  def : Pat<(i64 (add GPR:$rd, (mul_oneuse zexti32:$rs1, zexti32:$rs2))),
+            (MACCU_W00 GPR:$rd, zexti32:$rs1, zexti32:$rs2)>;
+  def : Pat<(i64 (add GPR:$rd, (mul_oneuse sexti32:$rs1, zexti32:$rs2))),
+            (MACCSU_W00 GPR:$rd, sexti32:$rs1, zexti32:$rs2)>;
 
   // Match a pattern of 2 bytes being inserted into bits [31:16], with bits
   // bits [15:0] coming from a zero extended value, and bits [63:32] being

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -1075,6 +1075,144 @@ define i64 @wmaccsu_commute(i32 %a, i32 %b, i64 %c) nounwind {
   ret i64 %result
 }
 
+define i32 @macc_h00(i32 %rd, i16 %a, i16 %b) nounwind {
+; CHECK-LABEL: macc_h00:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.h a1, a1
+; CHECK-NEXT:    sext.h a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %aext = sext i16 %a to i32
+  %bext = sext i16 %b to i32
+  %mul = mul i32 %aext, %bext
+  %result = add i32 %rd, %mul
+  ret i32 %result
+}
+
+define i32 @macc_h00_commute(i32 %rd, i16 %a, i16 %b) nounwind {
+; CHECK-LABEL: macc_h00_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.h a1, a1
+; CHECK-NEXT:    sext.h a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    ret
+  %aext = sext i16 %a to i32
+  %bext = sext i16 %b to i32
+  %mul = mul i32 %aext, %bext
+  %result = add i32 %mul, %rd
+  ret i32 %result
+}
+
+define i32 @maccu_h00(i32 %rd, i16 %a, i16 %b) nounwind {
+; CHECK-LABEL: maccu_h00:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.h a1, a1
+; CHECK-NEXT:    zext.h a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %aext = zext i16 %a to i32
+  %bext = zext i16 %b to i32
+  %mul = mul i32 %aext, %bext
+  %result = add i32 %rd, %mul
+  ret i32 %result
+}
+
+define i32 @maccu_h00_commute(i32 %rd, i16 %a, i16 %b) nounwind {
+; CHECK-LABEL: maccu_h00_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.h a1, a1
+; CHECK-NEXT:    zext.h a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    ret
+  %aext = zext i16 %a to i32
+  %bext = zext i16 %b to i32
+  %mul = mul i32 %aext, %bext
+  %result = add i32 %mul, %rd
+  ret i32 %result
+}
+
+define i32 @maccsu_h00(i32 %rd, i16 %a, i16 %b) nounwind {
+; CHECK-LABEL: maccsu_h00:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.h a1, a1
+; CHECK-NEXT:    zext.h a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %aext = sext i16 %a to i32
+  %bext = zext i16 %b to i32
+  %mul = mul i32 %aext, %bext
+  %result = add i32 %rd, %mul
+  ret i32 %result
+}
+
+define i32 @maccsu_h00_commute(i32 %rd, i16 %a, i16 %b) nounwind {
+; CHECK-LABEL: maccsu_h00_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.h a1, a1
+; CHECK-NEXT:    zext.h a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    ret
+  %aext = sext i16 %a to i32
+  %bext = zext i16 %b to i32
+  %mul = mul i32 %aext, %bext
+  %result = add i32 %mul, %rd
+  ret i32 %result
+}
+
+define i32 @maccsu_h00_swap_operands(i32 %rd, i16 %a, i16 %b) nounwind {
+; CHECK-LABEL: maccsu_h00_swap_operands:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.h a1, a1
+; CHECK-NEXT:    sext.h a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %aext = zext i16 %a to i32
+  %bext = sext i16 %b to i32
+  %mul = mul i32 %aext, %bext
+  %result = add i32 %rd, %mul
+  ret i32 %result
+}
+
+define i32 @maccsu_h00_swap_operands_commute(i32 %rd, i16 %a, i16 %b) nounwind {
+; CHECK-LABEL: maccsu_h00_swap_operands_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.h a1, a1
+; CHECK-NEXT:    sext.h a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    ret
+  %aext = zext i16 %a to i32
+  %bext = sext i16 %b to i32
+  %mul = mul i32 %aext, %bext
+  %result = add i32 %mul, %rd
+  ret i32 %result
+}
+
+; Negative test: multiply result has multiple uses, should not combine to macc
+define i32 @macc_h00_multiple_uses(i16 %a, i16 %b, i32 %c, ptr %out) nounwind {
+; CHECK-LABEL: macc_h00_multiple_uses:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.h a0, a0
+; CHECK-NEXT:    sext.h a1, a1
+; CHECK-NEXT:    mul a1, a0, a1
+; CHECK-NEXT:    add a0, a2, a1
+; CHECK-NEXT:    sw a1, 0(a3)
+; CHECK-NEXT:    ret
+  %aext = sext i16 %a to i32
+  %bext = sext i16 %b to i32
+  %mul = mul i32 %aext, %bext
+  %result = add i32 %c, %mul
+  store i32 %mul, ptr %out
+  ret i32 %result
+}
+
 ; Negative test: multiply result has multiple uses, should not combine
 define void @wmaccu_multiple_uses(i32 %a, i32 %b, i64 %c, ptr %out1, ptr %out2) nounwind {
 ; CHECK-LABEL: wmaccu_multiple_uses:

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -1078,10 +1078,7 @@ define i64 @wmaccsu_commute(i32 %a, i32 %b, i64 %c) nounwind {
 define i32 @macc_h00(i32 %rd, i16 %a, i16 %b) nounwind {
 ; CHECK-LABEL: macc_h00:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.h a1, a1
-; CHECK-NEXT:    sext.h a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    macc.h00 a0, a1, a2
 ; CHECK-NEXT:    ret
   %aext = sext i16 %a to i32
   %bext = sext i16 %b to i32
@@ -1093,10 +1090,7 @@ define i32 @macc_h00(i32 %rd, i16 %a, i16 %b) nounwind {
 define i32 @macc_h00_commute(i32 %rd, i16 %a, i16 %b) nounwind {
 ; CHECK-LABEL: macc_h00_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.h a1, a1
-; CHECK-NEXT:    sext.h a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    macc.h00 a0, a1, a2
 ; CHECK-NEXT:    ret
   %aext = sext i16 %a to i32
   %bext = sext i16 %b to i32
@@ -1108,10 +1102,7 @@ define i32 @macc_h00_commute(i32 %rd, i16 %a, i16 %b) nounwind {
 define i32 @maccu_h00(i32 %rd, i16 %a, i16 %b) nounwind {
 ; CHECK-LABEL: maccu_h00:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.h a1, a1
-; CHECK-NEXT:    zext.h a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    maccu.h00 a0, a1, a2
 ; CHECK-NEXT:    ret
   %aext = zext i16 %a to i32
   %bext = zext i16 %b to i32
@@ -1123,10 +1114,7 @@ define i32 @maccu_h00(i32 %rd, i16 %a, i16 %b) nounwind {
 define i32 @maccu_h00_commute(i32 %rd, i16 %a, i16 %b) nounwind {
 ; CHECK-LABEL: maccu_h00_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.h a1, a1
-; CHECK-NEXT:    zext.h a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    maccu.h00 a0, a1, a2
 ; CHECK-NEXT:    ret
   %aext = zext i16 %a to i32
   %bext = zext i16 %b to i32
@@ -1138,10 +1126,7 @@ define i32 @maccu_h00_commute(i32 %rd, i16 %a, i16 %b) nounwind {
 define i32 @maccsu_h00(i32 %rd, i16 %a, i16 %b) nounwind {
 ; CHECK-LABEL: maccsu_h00:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.h a1, a1
-; CHECK-NEXT:    zext.h a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    maccsu.h00 a0, a1, a2
 ; CHECK-NEXT:    ret
   %aext = sext i16 %a to i32
   %bext = zext i16 %b to i32
@@ -1153,10 +1138,7 @@ define i32 @maccsu_h00(i32 %rd, i16 %a, i16 %b) nounwind {
 define i32 @maccsu_h00_commute(i32 %rd, i16 %a, i16 %b) nounwind {
 ; CHECK-LABEL: maccsu_h00_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.h a1, a1
-; CHECK-NEXT:    zext.h a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    maccsu.h00 a0, a1, a2
 ; CHECK-NEXT:    ret
   %aext = sext i16 %a to i32
   %bext = zext i16 %b to i32
@@ -1168,10 +1150,7 @@ define i32 @maccsu_h00_commute(i32 %rd, i16 %a, i16 %b) nounwind {
 define i32 @maccsu_h00_swap_operands(i32 %rd, i16 %a, i16 %b) nounwind {
 ; CHECK-LABEL: maccsu_h00_swap_operands:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.h a1, a1
-; CHECK-NEXT:    sext.h a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    maccsu.h00 a0, a2, a1
 ; CHECK-NEXT:    ret
   %aext = zext i16 %a to i32
   %bext = sext i16 %b to i32
@@ -1183,10 +1162,7 @@ define i32 @maccsu_h00_swap_operands(i32 %rd, i16 %a, i16 %b) nounwind {
 define i32 @maccsu_h00_swap_operands_commute(i32 %rd, i16 %a, i16 %b) nounwind {
 ; CHECK-LABEL: maccsu_h00_swap_operands_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.h a1, a1
-; CHECK-NEXT:    sext.h a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    maccsu.h00 a0, a2, a1
 ; CHECK-NEXT:    ret
   %aext = zext i16 %a to i32
   %bext = sext i16 %b to i32

--- a/llvm/test/CodeGen/RISCV/rv64p.ll
+++ b/llvm/test/CodeGen/RISCV/rv64p.ll
@@ -1035,10 +1035,7 @@ entry:
 define i64 @macc_w00(i64 %rd, i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: macc_w00:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.w a1, a1
-; CHECK-NEXT:    sext.w a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    macc.w00 a0, a1, a2
 ; CHECK-NEXT:    ret
   %aext = sext i32 %a to i64
   %bext = sext i32 %b to i64
@@ -1050,10 +1047,7 @@ define i64 @macc_w00(i64 %rd, i32 %a, i32 %b) nounwind {
 define i64 @macc_w00_commute(i64 %rd, i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: macc_w00_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.w a1, a1
-; CHECK-NEXT:    sext.w a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    macc.w00 a0, a1, a2
 ; CHECK-NEXT:    ret
   %aext = sext i32 %a to i64
   %bext = sext i32 %b to i64
@@ -1065,10 +1059,7 @@ define i64 @macc_w00_commute(i64 %rd, i32 %a, i32 %b) nounwind {
 define i64 @maccu_w00(i64 %rd, i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: maccu_w00:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.w a1, a1
-; CHECK-NEXT:    zext.w a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    maccu.w00 a0, a1, a2
 ; CHECK-NEXT:    ret
   %aext = zext i32 %a to i64
   %bext = zext i32 %b to i64
@@ -1080,10 +1071,7 @@ define i64 @maccu_w00(i64 %rd, i32 %a, i32 %b) nounwind {
 define i64 @maccu_w00_commute(i64 %rd, i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: maccu_w00_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.w a1, a1
-; CHECK-NEXT:    zext.w a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    maccu.w00 a0, a1, a2
 ; CHECK-NEXT:    ret
   %aext = zext i32 %a to i64
   %bext = zext i32 %b to i64
@@ -1095,10 +1083,7 @@ define i64 @maccu_w00_commute(i64 %rd, i32 %a, i32 %b) nounwind {
 define i64 @maccsu_w00(i64 %rd, i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: maccsu_w00:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.w a1, a1
-; CHECK-NEXT:    zext.w a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    maccsu.w00 a0, a1, a2
 ; CHECK-NEXT:    ret
   %aext = sext i32 %a to i64
   %bext = zext i32 %b to i64
@@ -1110,10 +1095,7 @@ define i64 @maccsu_w00(i64 %rd, i32 %a, i32 %b) nounwind {
 define i64 @maccsu_w00_commute(i64 %rd, i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: maccsu_w00_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.w a1, a1
-; CHECK-NEXT:    zext.w a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    maccsu.w00 a0, a1, a2
 ; CHECK-NEXT:    ret
   %aext = sext i32 %a to i64
   %bext = zext i32 %b to i64
@@ -1125,10 +1107,7 @@ define i64 @maccsu_w00_commute(i64 %rd, i32 %a, i32 %b) nounwind {
 define i64 @maccsu_w00_swap_operands(i64 %rd, i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: maccsu_w00_swap_operands:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.w a1, a1
-; CHECK-NEXT:    sext.w a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    maccsu.w00 a0, a2, a1
 ; CHECK-NEXT:    ret
   %aext = zext i32 %a to i64
   %bext = sext i32 %b to i64
@@ -1140,10 +1119,7 @@ define i64 @maccsu_w00_swap_operands(i64 %rd, i32 %a, i32 %b) nounwind {
 define i64 @maccsu_w00_swap_operands_commute(i64 %rd, i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: maccsu_w00_swap_operands_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.w a1, a1
-; CHECK-NEXT:    sext.w a2, a2
-; CHECK-NEXT:    mul a1, a1, a2
-; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    maccsu.w00 a0, a2, a1
 ; CHECK-NEXT:    ret
   %aext = zext i32 %a to i64
   %bext = sext i32 %b to i64

--- a/llvm/test/CodeGen/RISCV/rv64p.ll
+++ b/llvm/test/CodeGen/RISCV/rv64p.ll
@@ -1031,3 +1031,141 @@ entry:
   %3 = or i64 %1, %2
   ret i64 %3
 }
+
+define i64 @macc_w00(i64 %rd, i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: macc_w00:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.w a1, a1
+; CHECK-NEXT:    sext.w a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %aext = sext i32 %a to i64
+  %bext = sext i32 %b to i64
+  %mul = mul i64 %aext, %bext
+  %result = add i64 %rd, %mul
+  ret i64 %result
+}
+
+define i64 @macc_w00_commute(i64 %rd, i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: macc_w00_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.w a1, a1
+; CHECK-NEXT:    sext.w a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    ret
+  %aext = sext i32 %a to i64
+  %bext = sext i32 %b to i64
+  %mul = mul i64 %aext, %bext
+  %result = add i64 %mul, %rd
+  ret i64 %result
+}
+
+define i64 @maccu_w00(i64 %rd, i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: maccu_w00:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.w a1, a1
+; CHECK-NEXT:    zext.w a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %aext = zext i32 %a to i64
+  %bext = zext i32 %b to i64
+  %mul = mul i64 %aext, %bext
+  %result = add i64 %rd, %mul
+  ret i64 %result
+}
+
+define i64 @maccu_w00_commute(i64 %rd, i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: maccu_w00_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.w a1, a1
+; CHECK-NEXT:    zext.w a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    ret
+  %aext = zext i32 %a to i64
+  %bext = zext i32 %b to i64
+  %mul = mul i64 %aext, %bext
+  %result = add i64 %mul, %rd
+  ret i64 %result
+}
+
+define i64 @maccsu_w00(i64 %rd, i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: maccsu_w00:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.w a1, a1
+; CHECK-NEXT:    zext.w a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %aext = sext i32 %a to i64
+  %bext = zext i32 %b to i64
+  %mul = mul i64 %aext, %bext
+  %result = add i64 %rd, %mul
+  ret i64 %result
+}
+
+define i64 @maccsu_w00_commute(i64 %rd, i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: maccsu_w00_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.w a1, a1
+; CHECK-NEXT:    zext.w a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    ret
+  %aext = sext i32 %a to i64
+  %bext = zext i32 %b to i64
+  %mul = mul i64 %aext, %bext
+  %result = add i64 %mul, %rd
+  ret i64 %result
+}
+
+define i64 @maccsu_w00_swap_operands(i64 %rd, i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: maccsu_w00_swap_operands:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.w a1, a1
+; CHECK-NEXT:    sext.w a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %aext = zext i32 %a to i64
+  %bext = sext i32 %b to i64
+  %mul = mul i64 %aext, %bext
+  %result = add i64 %rd, %mul
+  ret i64 %result
+}
+
+define i64 @maccsu_w00_swap_operands_commute(i64 %rd, i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: maccsu_w00_swap_operands_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.w a1, a1
+; CHECK-NEXT:    sext.w a2, a2
+; CHECK-NEXT:    mul a1, a1, a2
+; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    ret
+  %aext = zext i32 %a to i64
+  %bext = sext i32 %b to i64
+  %mul = mul i64 %aext, %bext
+  %result = add i64 %mul, %rd
+  ret i64 %result
+}
+
+; Negative test: multiply result has multiple uses, should not combine to macc
+define i64 @macc_w00_multiple_uses(i32 %a, i32 %b, i64 %c, ptr %out) nounwind {
+; CHECK-LABEL: macc_w00_multiple_uses:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.w a0, a0
+; CHECK-NEXT:    sext.w a1, a1
+; CHECK-NEXT:    mul a1, a0, a1
+; CHECK-NEXT:    add a0, a2, a1
+; CHECK-NEXT:    sd a1, 0(a3)
+; CHECK-NEXT:    ret
+  %aext = sext i32 %a to i64
+  %bext = sext i32 %b to i64
+  %mul = mul i64 %aext, %bext
+  %result = add i64 %c, %mul
+  store i64 %mul, ptr %out
+  ret i64 %result
+}


### PR DESCRIPTION
The RV32 macc*.h00 instructions take the lower half words from rs1 and
rs2, compute the full word product by extending the inputs, and
adds to rd. The RV64 macc*.w00 is similar but operates on words
and produces a double word result.

I've restricted this to case where the multiply has a single use.
We don't have a general macc that multiplies the full xlen bits
of rs1 and rs2, so I'm allowing the input to be sext_inreg/and or
have sufficient sign/zero bits according to ComputeNumSignBits/computeKnownBits.

We should also add mul*.h00/mul.*w00 patterns, but those we should
restrict to at least one input being sext_inreg/and and prefer
regular mul when there are no sext_inreg/and.