### PR TITLE
[X86] Fix Invalid assembly given inverted meaning

### DIFF
--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -453,6 +453,8 @@ private:
     short BracCount = 0;
     bool MemExpr = false;
     bool BracketUsed = false;
+    bool NegativeAdditiveTerm = false;
+    SMLoc NegativeAdditiveTermLoc;
     bool OffsetOperator = false;
     bool AttachToOperandIdx = false;
     bool IsPIC = false;
@@ -504,6 +506,11 @@ private:
     void setPIC() { IsPIC = true; }
 
     bool hadError() const { return State == IES_ERROR; }
+    SMLoc getLocForNegativeScaleError(StringRef ErrMsg, SMLoc DefaultLoc) const {
+      return ErrMsg == "scale factor in address cannot be negative"
+                 ? NegativeAdditiveTermLoc
+                 : DefaultLoc;
+    }
     const InlineAsmIdentifierInfo &getIdentifierInfo() const { return Info; }
 
     bool regsUseUpError(StringRef &ErrMsg) {
@@ -693,6 +700,8 @@ private:
       case IES_OFFSET:
         State = IES_PLUS;
         IC.pushOperator(IC_PLUS);
+        NegativeAdditiveTerm = false;
+        NegativeAdditiveTermLoc = SMLoc();
         if (CurrState == IES_REGISTER && PrevState != IES_MULTIPLY) {
           // If we already have a BaseReg, then assume this is the IndexReg with
           // no explicit scale.
@@ -710,7 +719,7 @@ private:
       PrevState = CurrState;
       return false;
     }
-    bool onMinus(StringRef &ErrMsg) {
+    bool onMinus(SMLoc MinusLoc, StringRef &ErrMsg) {
       IntelExprState CurrState = State;
       switch (State) {
       default:
@@ -744,8 +753,11 @@ private:
         // push minus operator if it is not a negate operator
         if (CurrState == IES_REGISTER || CurrState == IES_RPAREN ||
             CurrState == IES_INTEGER  || CurrState == IES_RBRAC  ||
-            CurrState == IES_OFFSET)
+            CurrState == IES_OFFSET) {
           IC.pushOperator(IC_MINUS);
+          NegativeAdditiveTerm = true;
+          NegativeAdditiveTermLoc = MinusLoc;
+        }
         else if (PrevState == IES_REGISTER && CurrState == IES_MULTIPLY) {
           // We have negate operator for Scale: it's illegal
           ErrMsg = "Scale can't be negative";
@@ -819,6 +831,10 @@ private:
         if (PrevState == IES_INTEGER) {
           if (IndexReg)
             return regsUseUpError(ErrMsg);
+          if (NegativeAdditiveTerm) {
+            ErrMsg = "scale factor in address cannot be negative";
+            return true;
+          }
           State = IES_REGISTER;
           IndexReg = Reg;
           // Get the scale and replace the 'Scale * Register' with '0'.
@@ -901,6 +917,10 @@ private:
           // Index Register - Register * Scale
           if (IndexReg)
             return regsUseUpError(ErrMsg);
+          if (NegativeAdditiveTerm) {
+            ErrMsg = "scale factor in address cannot be negative";
+            return true;
+          }
           IndexReg = TmpReg;
           Scale = TmpInt;
           if (checkScale(Scale, ErrMsg))
@@ -1968,7 +1988,8 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
         if (!Val->evaluateAsAbsolute(Res, getStreamer().getAssemblerPtr()))
           return Error(ValueLoc, "expected absolute value");
         if (SM.onInteger(Res, ErrMsg))
-          return Error(ValueLoc, ErrMsg);
+          return Error(SM.getLocForNegativeScaleError(ErrMsg, ValueLoc),
+                       ErrMsg);
         break;
       }
       [[fallthrough]];
@@ -2015,7 +2036,8 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
       if (Tok.is(AsmToken::Identifier)) {
         if (!ParseRegister(Reg, IdentLoc, End, /*RestoreOnFailure=*/true)) {
           if (SM.onRegister(Reg, ErrMsg))
-            return Error(IdentLoc, ErrMsg);
+            return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
+                         ErrMsg);
           break;
         }
         if (Parser.isParsingMasm()) {
@@ -2026,7 +2048,8 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
           if (!Field.empty() &&
               !MatchRegisterByName(Reg, ID, IdentLoc, IDEndLoc)) {
             if (SM.onRegister(Reg, ErrMsg))
-              return Error(IdentLoc, ErrMsg);
+              return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
+                           ErrMsg);
 
             AsmFieldInfo Info;
             SMLoc FieldStartLoc = SMLoc::getFromPointer(Field.data());
@@ -2035,7 +2058,8 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
             else if (SM.onPlus(ErrMsg))
               return Error(getTok().getLoc(), ErrMsg);
             else if (SM.onInteger(Info.Offset, ErrMsg))
-              return Error(IdentLoc, ErrMsg);
+              return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
+                           ErrMsg);
             SM.setTypeInfo(Info.Type);
 
             End = consumeToken();
@@ -2074,7 +2098,8 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
         if (unsigned OpKind = IdentifyIntelInlineAsmOperator(Identifier)) {
           if (int64_t Val = ParseIntelInlineAsmOperator(OpKind)) {
             if (SM.onInteger(Val, ErrMsg))
-              return Error(IdentLoc, ErrMsg);
+              return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
+                           ErrMsg);
           } else {
             return true;
           }
@@ -2088,7 +2113,8 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
           return true;
         else if (SM.onIdentifierExpr(Val, Identifier, Info, FieldInfo.Type,
                                      true, ErrMsg))
-          return Error(IdentLoc, ErrMsg);
+          return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
+                       ErrMsg);
         break;
       }
       if (Parser.isParsingMasm()) {
@@ -2097,7 +2123,8 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
           if (ParseMasmOperator(OpKind, Val))
             return true;
           if (SM.onInteger(Val, ErrMsg))
-            return Error(IdentLoc, ErrMsg);
+            return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
+                         ErrMsg);
           break;
         }
         if (!getParser().lookUpType(Identifier, FieldInfo.Type)) {
@@ -2121,7 +2148,8 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
               EndDot = parseOptionalToken(AsmToken::Dot);
           }
           if (SM.onInteger(FieldInfo.Offset, ErrMsg))
-            return Error(IdentLoc, ErrMsg);
+            return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
+                         ErrMsg);
           break;
         }
       }
@@ -2129,7 +2157,8 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
         return Error(Tok.getLoc(), "Unexpected identifier!");
       } else if (SM.onIdentifierExpr(Val, Identifier, Info, FieldInfo.Type,
                                      false, ErrMsg)) {
-        return Error(IdentLoc, ErrMsg);
+        return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
+                     ErrMsg);
       }
       break;
     }
@@ -2154,15 +2183,18 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
           AsmTypeInfo Type;
           if (SM.onIdentifierExpr(Val, Identifier, Info, Type,
                                   isParsingMSInlineAsm(), ErrMsg))
-            return Error(Loc, ErrMsg);
+            return Error(SM.getLocForNegativeScaleError(ErrMsg, Loc),
+                         ErrMsg);
           End = consumeToken();
         } else {
           if (SM.onInteger(IntVal, ErrMsg))
-            return Error(Loc, ErrMsg);
+            return Error(SM.getLocForNegativeScaleError(ErrMsg, Loc),
+                         ErrMsg);
         }
       } else {
         if (SM.onInteger(IntVal, ErrMsg))
-          return Error(Loc, ErrMsg);
+          return Error(SM.getLocForNegativeScaleError(ErrMsg, Loc),
+                       ErrMsg);
       }
       break;
     }
@@ -2171,8 +2203,9 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
         return Error(getTok().getLoc(), ErrMsg);
       break;
     case AsmToken::Minus:
-      if (SM.onMinus(ErrMsg))
-        return Error(getTok().getLoc(), ErrMsg);
+      if (SM.onMinus(getTok().getLoc(), ErrMsg))
+        return Error(SM.getLocForNegativeScaleError(ErrMsg, getTok().getLoc()),
+                     ErrMsg);
       break;
     case AsmToken::Tilde:   SM.onNot(); break;
     case AsmToken::Star:    SM.onStar(); break;

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -830,12 +830,12 @@ private:
       case IES_MULTIPLY:
         // Index Register - Scale * Register
         if (PrevState == IES_INTEGER) {
+          if (IndexReg)
+            return regsUseUpError(ErrMsg);
           if (NegativeAdditiveTerm) {
             ErrMsg = "scale factor in address cannot be negative";
             return true;
           }
-          if (IndexReg)
-            return regsUseUpError(ErrMsg);
           State = IES_REGISTER;
           IndexReg = Reg;
           // Get the scale and replace the 'Scale * Register' with '0'.
@@ -916,12 +916,12 @@ private:
         State = IES_INTEGER;
         if (PrevState == IES_REGISTER && CurrState == IES_MULTIPLY) {
           // Index Register - Register * Scale
+          if (IndexReg)
+            return regsUseUpError(ErrMsg);
           if (NegativeAdditiveTerm) {
             ErrMsg = "scale factor in address cannot be negative";
             return true;
           }
-          if (IndexReg)
-            return regsUseUpError(ErrMsg);
           IndexReg = TmpReg;
           Scale = TmpInt;
           if (checkScale(Scale, ErrMsg))
@@ -2234,7 +2234,8 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
       break;
     case AsmToken::RBrac:
       if (SM.onRBrac(ErrMsg)) {
-        return Error(Tok.getLoc(), ErrMsg);
+        return Error(SM.getLocForNegativeScaleError(ErrMsg, Tok.getLoc()),
+                     ErrMsg);
       }
       break;
     case AsmToken::LParen:  SM.onLParen(); break;

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -506,7 +506,8 @@ private:
     void setPIC() { IsPIC = true; }
 
     bool hadError() const { return State == IES_ERROR; }
-    SMLoc getLocForNegativeScaleError(StringRef ErrMsg, SMLoc DefaultLoc) const {
+    SMLoc getLocForNegativeScaleError(StringRef ErrMsg,
+                                      SMLoc DefaultLoc) const {
       return ErrMsg == "scale factor in address cannot be negative"
                  ? NegativeAdditiveTermLoc
                  : DefaultLoc;
@@ -752,13 +753,12 @@ private:
         State = IES_MINUS;
         // push minus operator if it is not a negate operator
         if (CurrState == IES_REGISTER || CurrState == IES_RPAREN ||
-            CurrState == IES_INTEGER  || CurrState == IES_RBRAC  ||
+            CurrState == IES_INTEGER || CurrState == IES_RBRAC ||
             CurrState == IES_OFFSET) {
           IC.pushOperator(IC_MINUS);
           NegativeAdditiveTerm = true;
           NegativeAdditiveTermLoc = MinusLoc;
-        }
-        else if (PrevState == IES_REGISTER && CurrState == IES_MULTIPLY) {
+        } else if (PrevState == IES_REGISTER && CurrState == IES_MULTIPLY) {
           // We have negate operator for Scale: it's illegal
           ErrMsg = "Scale can't be negative";
           return true;
@@ -2166,8 +2166,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
         return Error(Tok.getLoc(), "Unexpected identifier!");
       } else if (SM.onIdentifierExpr(Val, Identifier, Info, FieldInfo.Type,
                                      false, ErrMsg)) {
-        return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
-                     ErrMsg);
+        return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc), ErrMsg);
       }
       break;
     }
@@ -2192,18 +2191,15 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
           AsmTypeInfo Type;
           if (SM.onIdentifierExpr(Val, Identifier, Info, Type,
                                   isParsingMSInlineAsm(), ErrMsg))
-            return Error(SM.getLocForNegativeScaleError(ErrMsg, Loc),
-                         ErrMsg);
+            return Error(SM.getLocForNegativeScaleError(ErrMsg, Loc), ErrMsg);
           End = consumeToken();
         } else {
           if (SM.onInteger(IntVal, ErrMsg))
-            return Error(SM.getLocForNegativeScaleError(ErrMsg, Loc),
-                         ErrMsg);
+            return Error(SM.getLocForNegativeScaleError(ErrMsg, Loc), ErrMsg);
         }
       } else {
         if (SM.onInteger(IntVal, ErrMsg))
-          return Error(SM.getLocForNegativeScaleError(ErrMsg, Loc),
-                       ErrMsg);
+          return Error(SM.getLocForNegativeScaleError(ErrMsg, Loc), ErrMsg);
       }
       break;
     }

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -506,11 +506,8 @@ private:
     void setPIC() { IsPIC = true; }
 
     bool hadError() const { return State == IES_ERROR; }
-    SMLoc getLocForNegativeScaleError(StringRef ErrMsg,
-                                      SMLoc DefaultLoc) const {
-      return ErrMsg == "scale factor in address cannot be negative"
-                 ? NegativeAdditiveTermLoc
-                 : DefaultLoc;
+    SMLoc getErrorLoc(SMLoc DefaultLoc) const {
+      return NegativeAdditiveTerm ? NegativeAdditiveTermLoc : DefaultLoc;
     }
     const InlineAsmIdentifierInfo &getIdentifierInfo() const { return Info; }
 
@@ -833,7 +830,7 @@ private:
           if (IndexReg)
             return regsUseUpError(ErrMsg);
           if (NegativeAdditiveTerm) {
-            ErrMsg = "scale factor in address cannot be negative";
+            ErrMsg = "Scale can't be negative";
             return true;
           }
           State = IES_REGISTER;
@@ -919,7 +916,7 @@ private:
           if (IndexReg)
             return regsUseUpError(ErrMsg);
           if (NegativeAdditiveTerm) {
-            ErrMsg = "scale factor in address cannot be negative";
+            ErrMsg = "Scale can't be negative";
             return true;
           }
           IndexReg = TmpReg;
@@ -1027,7 +1024,7 @@ private:
             if (IndexReg)
               return regsUseUpError(ErrMsg);
             if (NegativeAdditiveTerm) {
-              ErrMsg = "scale factor in address cannot be negative";
+              ErrMsg = "Scale can't be negative";
               return true;
             }
             IndexReg = TmpReg;
@@ -1098,7 +1095,7 @@ private:
             if (IndexReg)
               return regsUseUpError(ErrMsg);
             if (NegativeAdditiveTerm) {
-              ErrMsg = "scale factor in address cannot be negative";
+              ErrMsg = "Scale can't be negative";
               return true;
             }
             IndexReg = TmpReg;
@@ -1999,8 +1996,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
         if (!Val->evaluateAsAbsolute(Res, getStreamer().getAssemblerPtr()))
           return Error(ValueLoc, "expected absolute value");
         if (SM.onInteger(Res, ErrMsg))
-          return Error(SM.getLocForNegativeScaleError(ErrMsg, ValueLoc),
-                       ErrMsg);
+          return Error(SM.getErrorLoc(ValueLoc), ErrMsg);
         break;
       }
       [[fallthrough]];
@@ -2047,8 +2043,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
       if (Tok.is(AsmToken::Identifier)) {
         if (!ParseRegister(Reg, IdentLoc, End, /*RestoreOnFailure=*/true)) {
           if (SM.onRegister(Reg, ErrMsg))
-            return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
-                         ErrMsg);
+            return Error(SM.getErrorLoc(IdentLoc), ErrMsg);
           break;
         }
         if (Parser.isParsingMasm()) {
@@ -2059,8 +2054,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
           if (!Field.empty() &&
               !MatchRegisterByName(Reg, ID, IdentLoc, IDEndLoc)) {
             if (SM.onRegister(Reg, ErrMsg))
-              return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
-                           ErrMsg);
+              return Error(SM.getErrorLoc(IdentLoc), ErrMsg);
 
             AsmFieldInfo Info;
             SMLoc FieldStartLoc = SMLoc::getFromPointer(Field.data());
@@ -2069,8 +2063,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
             else if (SM.onPlus(ErrMsg))
               return Error(getTok().getLoc(), ErrMsg);
             else if (SM.onInteger(Info.Offset, ErrMsg))
-              return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
-                           ErrMsg);
+              return Error(SM.getErrorLoc(IdentLoc), ErrMsg);
             SM.setTypeInfo(Info.Type);
 
             End = consumeToken();
@@ -2109,8 +2102,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
         if (unsigned OpKind = IdentifyIntelInlineAsmOperator(Identifier)) {
           if (int64_t Val = ParseIntelInlineAsmOperator(OpKind)) {
             if (SM.onInteger(Val, ErrMsg))
-              return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
-                           ErrMsg);
+              return Error(SM.getErrorLoc(IdentLoc), ErrMsg);
           } else {
             return true;
           }
@@ -2124,8 +2116,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
           return true;
         else if (SM.onIdentifierExpr(Val, Identifier, Info, FieldInfo.Type,
                                      true, ErrMsg))
-          return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
-                       ErrMsg);
+          return Error(SM.getErrorLoc(IdentLoc), ErrMsg);
         break;
       }
       if (Parser.isParsingMasm()) {
@@ -2134,8 +2125,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
           if (ParseMasmOperator(OpKind, Val))
             return true;
           if (SM.onInteger(Val, ErrMsg))
-            return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
-                         ErrMsg);
+            return Error(SM.getErrorLoc(IdentLoc), ErrMsg);
           break;
         }
         if (!getParser().lookUpType(Identifier, FieldInfo.Type)) {
@@ -2159,8 +2149,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
               EndDot = parseOptionalToken(AsmToken::Dot);
           }
           if (SM.onInteger(FieldInfo.Offset, ErrMsg))
-            return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc),
-                         ErrMsg);
+            return Error(SM.getErrorLoc(IdentLoc), ErrMsg);
           break;
         }
       }
@@ -2168,7 +2157,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
         return Error(Tok.getLoc(), "Unexpected identifier!");
       } else if (SM.onIdentifierExpr(Val, Identifier, Info, FieldInfo.Type,
                                      false, ErrMsg)) {
-        return Error(SM.getLocForNegativeScaleError(ErrMsg, IdentLoc), ErrMsg);
+        return Error(SM.getErrorLoc(IdentLoc), ErrMsg);
       }
       break;
     }
@@ -2193,15 +2182,15 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
           AsmTypeInfo Type;
           if (SM.onIdentifierExpr(Val, Identifier, Info, Type,
                                   isParsingMSInlineAsm(), ErrMsg))
-            return Error(SM.getLocForNegativeScaleError(ErrMsg, Loc), ErrMsg);
+            return Error(SM.getErrorLoc(Loc), ErrMsg);
           End = consumeToken();
         } else {
           if (SM.onInteger(IntVal, ErrMsg))
-            return Error(SM.getLocForNegativeScaleError(ErrMsg, Loc), ErrMsg);
+            return Error(SM.getErrorLoc(Loc), ErrMsg);
         }
       } else {
         if (SM.onInteger(IntVal, ErrMsg))
-          return Error(SM.getLocForNegativeScaleError(ErrMsg, Loc), ErrMsg);
+          return Error(SM.getErrorLoc(Loc), ErrMsg);
       }
       break;
     }
@@ -2211,8 +2200,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
       break;
     case AsmToken::Minus:
       if (SM.onMinus(getTok().getLoc(), ErrMsg))
-        return Error(SM.getLocForNegativeScaleError(ErrMsg, getTok().getLoc()),
-                     ErrMsg);
+        return Error(SM.getErrorLoc(getTok().getLoc()), ErrMsg);
       break;
     case AsmToken::Tilde:   SM.onNot(); break;
     case AsmToken::Star:    SM.onStar(); break;
@@ -2232,14 +2220,13 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
       break;
     case AsmToken::RBrac:
       if (SM.onRBrac(ErrMsg)) {
-        return Error(SM.getLocForNegativeScaleError(ErrMsg, Tok.getLoc()),
-                     ErrMsg);
+        return Error(SM.getErrorLoc(Tok.getLoc()), ErrMsg);
       }
       break;
     case AsmToken::LParen:  SM.onLParen(); break;
     case AsmToken::RParen:
       if (SM.onRParen(ErrMsg)) {
-        return Error(Tok.getLoc(), ErrMsg);
+        return Error(SM.getErrorLoc(Tok.getLoc()), ErrMsg);
       }
       break;
     }

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -1034,6 +1034,8 @@ private:
             Scale = 0;
           }
         }
+        NegativeAdditiveTerm = false;
+        NegativeAdditiveTermLoc = SMLoc();
         break;
       }
       PrevState = CurrState;

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -820,6 +820,7 @@ private:
         State = IES_ERROR;
         break;
       case IES_PLUS:
+      case IES_MINUS:
       case IES_LPAREN:
       case IES_LBRAC:
         State = IES_REGISTER;
@@ -829,12 +830,12 @@ private:
       case IES_MULTIPLY:
         // Index Register - Scale * Register
         if (PrevState == IES_INTEGER) {
-          if (IndexReg)
-            return regsUseUpError(ErrMsg);
           if (NegativeAdditiveTerm) {
             ErrMsg = "scale factor in address cannot be negative";
             return true;
           }
+          if (IndexReg)
+            return regsUseUpError(ErrMsg);
           State = IES_REGISTER;
           IndexReg = Reg;
           // Get the scale and replace the 'Scale * Register' with '0'.
@@ -915,12 +916,12 @@ private:
         State = IES_INTEGER;
         if (PrevState == IES_REGISTER && CurrState == IES_MULTIPLY) {
           // Index Register - Register * Scale
-          if (IndexReg)
-            return regsUseUpError(ErrMsg);
           if (NegativeAdditiveTerm) {
             ErrMsg = "scale factor in address cannot be negative";
             return true;
           }
+          if (IndexReg)
+            return regsUseUpError(ErrMsg);
           IndexReg = TmpReg;
           Scale = TmpInt;
           if (checkScale(Scale, ErrMsg))
@@ -1025,6 +1026,10 @@ private:
           } else {
             if (IndexReg)
               return regsUseUpError(ErrMsg);
+            if (NegativeAdditiveTerm) {
+              ErrMsg = "scale factor in address cannot be negative";
+              return true;
+            }
             IndexReg = TmpReg;
             Scale = 0;
           }
@@ -1090,6 +1095,10 @@ private:
           } else {
             if (IndexReg)
               return regsUseUpError(ErrMsg);
+            if (NegativeAdditiveTerm) {
+              ErrMsg = "scale factor in address cannot be negative";
+              return true;
+            }
             IndexReg = TmpReg;
             Scale = 0;
           }

--- a/llvm/test/CodeGen/X86/inline-asm-intel-negative-scale.ll
+++ b/llvm/test/CodeGen/X86/inline-asm-intel-negative-scale.ll
@@ -1,0 +1,14 @@
+; RUN: not llc -mtriple=x86_64-unknown-linux-gnu %s -o /dev/null 2>&1 | FileCheck %s
+
+; Verify that inline asm with inteldialect correctly rejects a negative scale
+; factor in an address expression (e.g. [rax - 8 * rdx]) instead of silently
+; inverting the sign and producing [rax + 8*rdx].
+
+; CHECK: error: scale factor in address cannot be negative
+
+define i64 @test_neg_scale(i64 %0) {
+  %result = call i64 asm sideeffect alignstack inteldialect
+    "xor rax, rax\0Alea rax, [rax - 8 * rdx]",
+    "=&{ax},{dx},~{dirflag},~{fpsr},~{flags},~{memory}"(i64 %0)
+  ret i64 %result
+}

--- a/llvm/test/CodeGen/X86/inline-asm-intel-negative-scale.ll
+++ b/llvm/test/CodeGen/X86/inline-asm-intel-negative-scale.ll
@@ -4,7 +4,7 @@
 ; factor in an address expression (e.g. [rax - 8 * rdx]) instead of silently
 ; inverting the sign and producing [rax + 8*rdx].
 
-; CHECK: error: scale factor in address cannot be negative
+; CHECK: error: Scale can't be negative
 
 define i64 @test_neg_scale(i64 %0) {
   %result = call i64 asm sideeffect alignstack inteldialect

--- a/llvm/test/MC/X86/intel-syntax-invalid-scale.s
+++ b/llvm/test/MC/X86/intel-syntax-invalid-scale.s
@@ -13,13 +13,19 @@
     lea rax, [rdi + rdx*-8]
 // CHECK: error: scale factor in address must be 1, 2, 4 or 8
     lea rax, [rdi + -1*rdx]
-// CHECK: error: scale factor in address cannot be negative
+// CHECK: [[#@LINE+3]]:19: error: scale factor in address cannot be negative
+// CHECK-NEXT:     lea rax, [rax - 8 * rdx]
+// CHECK-NEXT:                   ^
     lea rax, [rax - 8 * rdx]
-// CHECK: error: scale factor in address cannot be negative
+// CHECK: [[#@LINE+3]]:19: error: scale factor in address cannot be negative
+// CHECK-NEXT:     lea rax, [rax - 2 * rdx]
+// CHECK-NEXT:                   ^
     lea rax, [rax - 2 * rdx]
-// CHECK: error: scale factor in address cannot be negative
-    lea rax, [rdx * 4 + rax - 2 * rcx]
-// CHECK: error: scale factor in address cannot be negative
+// CHECK: [[#@LINE+3]]:19: error: scale factor in address cannot be negative
+// CHECK-NEXT:     lea rax, [rax - rdx * 8]
+// CHECK-NEXT:                   ^
     lea rax, [rax - rdx * 8]
-// CHECK: error: scale factor in address cannot be negative
+// CHECK: [[#@LINE+3]]:19: error: scale factor in address cannot be negative
+// CHECK-NEXT:     lea rax, [rax - rdx]
+// CHECK-NEXT:                   ^
     lea rax, [rax - rdx]

--- a/llvm/test/MC/X86/intel-syntax-invalid-scale.s
+++ b/llvm/test/MC/X86/intel-syntax-invalid-scale.s
@@ -13,19 +13,19 @@
     lea rax, [rdi + rdx*-8]
 // CHECK: error: scale factor in address must be 1, 2, 4 or 8
     lea rax, [rdi + -1*rdx]
-// CHECK: [[#@LINE+3]]:19: error: scale factor in address cannot be negative
+// CHECK: [[#@LINE+3]]:19: error: Scale can't be negative
 // CHECK-NEXT:     lea rax, [rax - 8 * rdx]
 // CHECK-NEXT:                   ^
     lea rax, [rax - 8 * rdx]
-// CHECK: [[#@LINE+3]]:19: error: scale factor in address cannot be negative
+// CHECK: [[#@LINE+3]]:19: error: Scale can't be negative
 // CHECK-NEXT:     lea rax, [rax - 2 * rdx]
 // CHECK-NEXT:                   ^
     lea rax, [rax - 2 * rdx]
-// CHECK: [[#@LINE+3]]:19: error: scale factor in address cannot be negative
+// CHECK: [[#@LINE+3]]:19: error: Scale can't be negative
 // CHECK-NEXT:     lea rax, [rax - rdx * 8]
 // CHECK-NEXT:                   ^
     lea rax, [rax - rdx * 8]
-// CHECK: [[#@LINE+3]]:19: error: scale factor in address cannot be negative
+// CHECK: [[#@LINE+3]]:19: error: Scale can't be negative
 // CHECK-NEXT:     lea rax, [rax - rdx]
 // CHECK-NEXT:                   ^
     lea rax, [rax - rdx]

--- a/llvm/test/MC/X86/intel-syntax-invalid-scale.s
+++ b/llvm/test/MC/X86/intel-syntax-invalid-scale.s
@@ -13,3 +13,13 @@
     lea rax, [rdi + rdx*-8]
 // CHECK: error: scale factor in address must be 1, 2, 4 or 8
     lea rax, [rdi + -1*rdx]
+// CHECK: error: scale factor in address cannot be negative
+    lea rax, [rax - 8 * rdx]
+// CHECK: error: scale factor in address cannot be negative
+    lea rax, [rax - 2 * rdx]
+// CHECK: error: scale factor in address cannot be negative
+    lea rax, [rdx * 4 + rax - 2 * rcx]
+// CHECK: error: scale factor in address cannot be negative
+    lea rax, [rax - rdx * 8]
+// CHECK: error: scale factor in address cannot be negative
+    lea rax, [rax - rdx]


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/96427

The issue shows that `lea rax, [rax - 8 * rdx]` would be assembled as `lea rax, [rax + 8 * rdx]`. This is invalid according to binutils: https://godbolt.org/z/z6jrzasYv. 

The first commit fixes the case in the issue by rejecting `[rax - 8 * rdx]` completely with an error message, and has the caret point to the minus sign for the diagnostic.

So for that case we get:

```
test.s:2:15: error: scale factor in address cannot be negative
lea rax, [rax - 8 * rdx]
              ^
```

Instead of 

```
leaq    (%rax,%rdx,8), %rax # which is incorrectly assembled
```

There are two extra cases I fixed the diagnostic for:

```
test.s:4:21: error: unknown token in expression
lea rax, [rax - rdx * 8]
                    ^
test.s:5:20: error: unknown token in expression
lea rax, [rax - rdx]
                   ^
```

The first case doesn't make sense to me (why is the * an invalid token in a lea? You can change this to:

```
lea rax, [rax + rdx * 8]
```

and now * is valid. So is the * valid or not? Or is it the - sign?

I changed the error message to point to the - sign since I think that gives you more information about what's actually invalid here.

```
test.s:4:15: error: scale factor in address cannot be negative
lea rax, [rax - rdx * 8]
                     ^
```

For the second case:

```
test.s:5:20: error: unknown token in expression
lea rax, [rax - rdx]
                   ^
```

The right bracket being unknown is bizarre to say the least. binutils' default "invalid use of register" is much better, but we can do one better since the - sign is incorrect here and should be a + sign so I changed it to:

```
test.s:5:15: error: scale factor in address cannot be negative
lea rax, [rax - rdx]
              ^
```

I'm not too happy about how the code looks but other error diagnostics to special case had the same shape so I followed convention here. 