### PR TITLE
[Clang][Docs] Fix malformed code-block directive in MSan and TSan docs

### DIFF
--- a/clang/docs/MemorySanitizer.rst
+++ b/clang/docs/MemorySanitizer.rst
@@ -108,7 +108,7 @@ Interaction of Inlining with Disabling Sanitizer Instrumentation
 * An `always_inline` function will adopt the instrumentation status of the function it is inlined into.
 * Forcibly combining `no_sanitize` and ``__attribute__((always_inline))`` is not supported, and will often lead to unexpected results. To avoid mixing these attributes, use:
 
-. code-block:: c
+.. code-block:: c
 
     // Note, __has_feature test for sanitizers is deprecated, and Clang will support __SANITIZE_<sanitizer>__ similar to GCC.
     #if __has_feature(memory_sanitizer) || defined(__SANITIZE_MEMORY__) || ... <other sanitizers>

--- a/clang/docs/ThreadSanitizer.rst
+++ b/clang/docs/ThreadSanitizer.rst
@@ -117,7 +117,7 @@ Interaction of Inlining with Disabling Sanitizer Instrumentation
 * An `always_inline` function will adopt the instrumentation status of the function it is inlined into.
 * Forcibly combining `no_sanitize` and ``__attribute__((always_inline))`` is not supported, and will often lead to unexpected results. To avoid mixing these attributes, use:
 
-. code-block:: c
+.. code-block:: c
 
     // Note, __has_feature test for sanitizers is deprecated, and Clang will support __SANITIZE_<sanitizer>__ similar to GCC.
     #if __has_feature(thread_sanitizer) || defined(__SANITIZE_THREAD__) || ... <other sanitizers>


### PR DESCRIPTION
The `code-block` directives in MemorySanitizer.rst and ThreadSanitizer.rst were missing a leading period (`. code-block` instead of `.. code-block`). This syntax error caused Sphinx to fail to recognize the directives, resulting in the the subsequent C code being rendered as plain text rather than a syntax-highlighted block.

The currently broken rendering on the official docs can be seen [here](https://clang.llvm.org/docs/MemorySanitizer.html#interaction-of-inlining-with-disabling-sanitizer-instrumentation) and [here](https://clang.llvm.org/docs/ThreadSanitizer.html#interaction-of-inlining-with-disabling-sanitizer-instrumentation).

Fixed the typos to ensure proper HTML rendering.