### PR TITLE
[llvm-ir2vec] Added Enum for ir2vec embedding mode

### DIFF
--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getBBEmbMap.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getBBEmbMap.py
@@ -6,7 +6,9 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
-tool = ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
+tool = ir2vec.initEmbedding(
+    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+)
 
 # Success case
 bb_map = tool.getBBEmbMap("conditional")

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getBBEmbMap.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getBBEmbMap.py
@@ -6,7 +6,7 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
-tool = ir2vec.initEmbedding(filename=ll_file, mode="sym", vocabPath=vocab_path)
+tool = ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
 
 # Success case
 bb_map = tool.getBBEmbMap("conditional")

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmb.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmb.py
@@ -6,7 +6,9 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
-tool = ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
+tool = ir2vec.initEmbedding(
+    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+)
 
 # Success case
 emb = tool.getFuncEmb("add")

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmb.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmb.py
@@ -6,7 +6,7 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
-tool = ir2vec.initEmbedding(filename=ll_file, mode="sym", vocabPath=vocab_path)
+tool = ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
 
 # Success case
 emb = tool.getFuncEmb("add")

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmbMap.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmbMap.py
@@ -6,7 +6,9 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
-tool = ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
+tool = ir2vec.initEmbedding(
+    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+)
 
 # Success case
 emb_map = tool.getFuncEmbMap()

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmbMap.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmbMap.py
@@ -6,7 +6,7 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
-tool = ir2vec.initEmbedding(filename=ll_file, mode="sym", vocabPath=vocab_path)
+tool = ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
 
 # Success case
 emb_map = tool.getFuncEmbMap()

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncNames.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncNames.py
@@ -6,7 +6,9 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
-tool = ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
+tool = ir2vec.initEmbedding(
+    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+)
 
 # Success case
 func_names = tool.getFuncNames()

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncNames.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncNames.py
@@ -6,7 +6,7 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
-tool = ir2vec.initEmbedding(filename=ll_file, mode="sym", vocabPath=vocab_path)
+tool = ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
 
 # Success case
 func_names = tool.getFuncNames()

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getInstEmbMap.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getInstEmbMap.py
@@ -6,7 +6,9 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
-tool = ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
+tool = ir2vec.initEmbedding(
+    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+)
 
 # Success case
 inst_map = tool.getInstEmbMap("add")

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getInstEmbMap.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getInstEmbMap.py
@@ -6,7 +6,7 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
-tool = ir2vec.initEmbedding(filename=ll_file, mode="sym", vocabPath=vocab_path)
+tool = ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
 
 # Success case
 inst_map = tool.getInstEmbMap("add")

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-initEmbedding.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-initEmbedding.py
@@ -7,7 +7,9 @@ ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
 # Success case
-tool = ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
+tool = ir2vec.initEmbedding(
+    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+)
 print(f"SUCCESS: {type(tool).__name__}")
 # CHECK: SUCCESS: IR2VecTool
 
@@ -20,28 +22,36 @@ except TypeError:
 
 # Error: Empty vocab path
 try:
-    ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath="")
+    ir2vec.initEmbedding(
+        filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=""
+    )
 except ValueError:
     print("ERROR: Empty vocab path")
 # CHECK: ERROR: Empty vocab path
 
 # Error: Invalid file
 try:
-    ir2vec.initEmbedding(filename="/bad.ll", mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
+    ir2vec.initEmbedding(
+        filename="/bad.ll", mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+    )
 except ValueError:
     print("ERROR: Invalid file")
 # CHECK: ERROR: Invalid file
 
 # Error: Empty filename
 try:
-    ir2vec.initEmbedding(filename="", mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
+    ir2vec.initEmbedding(
+        filename="", mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+    )
 except ValueError:
     print("ERROR: Empty filename")
 # CHECK: ERROR: Empty filename
 
 # Error: Invalid vocab file
 try:
-    ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath="/bad.json")
+    ir2vec.initEmbedding(
+        filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath="/bad.json"
+    )
 except ValueError:
     print("ERROR: Invalid vocab")
 # CHECK: ERROR: Invalid vocab
@@ -54,7 +64,9 @@ with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
     f.write("{ this is not valid json }")
     bad_vocab = f.name
 try:
-    ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=bad_vocab)
+    ir2vec.initEmbedding(
+        filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=bad_vocab
+    )
 except ValueError:
     print("ERROR: Invalid vocab file")
 finally:

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-initEmbedding.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-initEmbedding.py
@@ -7,41 +7,41 @@ ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
 # Success case
-tool = ir2vec.initEmbedding(filename=ll_file, mode="sym", vocabPath=vocab_path)
+tool = ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
 print(f"SUCCESS: {type(tool).__name__}")
 # CHECK: SUCCESS: IR2VecTool
 
 # Error: Invalid mode
 try:
     ir2vec.initEmbedding(filename=ll_file, mode="invalid", vocabPath=vocab_path)
-except ValueError:
+except TypeError:
     print("ERROR: Invalid mode")
 # CHECK: ERROR: Invalid mode
 
 # Error: Empty vocab path
 try:
-    ir2vec.initEmbedding(filename=ll_file, mode="sym", vocabPath="")
+    ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath="")
 except ValueError:
     print("ERROR: Empty vocab path")
 # CHECK: ERROR: Empty vocab path
 
 # Error: Invalid file
 try:
-    ir2vec.initEmbedding(filename="/bad.ll", mode="sym", vocabPath=vocab_path)
+    ir2vec.initEmbedding(filename="/bad.ll", mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
 except ValueError:
     print("ERROR: Invalid file")
 # CHECK: ERROR: Invalid file
 
 # Error: Empty filename
 try:
-    ir2vec.initEmbedding(filename="", mode="sym", vocabPath=vocab_path)
+    ir2vec.initEmbedding(filename="", mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path)
 except ValueError:
     print("ERROR: Empty filename")
 # CHECK: ERROR: Empty filename
 
 # Error: Invalid vocab file
 try:
-    ir2vec.initEmbedding(filename=ll_file, mode="sym", vocabPath="/bad.json")
+    ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath="/bad.json")
 except ValueError:
     print("ERROR: Invalid vocab")
 # CHECK: ERROR: Invalid vocab
@@ -54,7 +54,7 @@ with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
     f.write("{ this is not valid json }")
     bad_vocab = f.name
 try:
-    ir2vec.initEmbedding(filename=ll_file, mode="sym", vocabPath=bad_vocab)
+    ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=bad_vocab)
 except ValueError:
     print("ERROR: Invalid vocab file")
 finally:

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -232,6 +232,6 @@ NB_MODULE(ir2vec, m) {
          const std::string &vocabPath) {
         return std::make_unique<PyIR2VecTool>(filename, mode, vocabPath);
       },
-      nb::arg("filename"), nb::arg("mode") = IR2VecKind::Symbolic,
+      nb::arg("filename"), nb::arg("mode"),
       nb::arg("vocabPath"), nb::rv_policy::take_ownership);
 }

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -232,6 +232,6 @@ NB_MODULE(ir2vec, m) {
          const std::string &vocabPath) {
         return std::make_unique<PyIR2VecTool>(filename, mode, vocabPath);
       },
-      nb::arg("filename"), nb::arg("mode"),
-      nb::arg("vocabPath"), nb::rv_policy::take_ownership);
+      nb::arg("filename"), nb::arg("mode"), nb::arg("vocabPath"),
+      nb::rv_policy::take_ownership);
 }

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -46,15 +46,9 @@ private:
   IR2VecKind OutputEmbeddingMode;
 
 public:
-  PyIR2VecTool(const std::string &Filename, const std::string &Mode,
+  PyIR2VecTool(const std::string &Filename, IR2VecKind Mode,
                const std::string &VocabPath) {
-    OutputEmbeddingMode = [](const std::string &Mode) -> IR2VecKind {
-      if (Mode == "sym")
-        return IR2VecKind::Symbolic;
-      if (Mode == "fa")
-        return IR2VecKind::FlowAware;
-      throw nb::value_error("Invalid mode. Use 'sym' or 'fa'");
-    }(Mode);
+    OutputEmbeddingMode = Mode;
 
     if (VocabPath.empty())
       throw nb::value_error("Empty Vocab Path not allowed");
@@ -200,8 +194,15 @@ public:
 NB_MODULE(ir2vec, m) {
   m.doc() = std::string("Python bindings for ") + ToolName;
 
+  nb::enum_<IR2VecKind>(m, "IR2VecKind",
+                       "Embedding mode for IR2Vec representations")
+      .value("Symbolic", IR2VecKind::Symbolic, "Symbolic encodings only")
+      .value("FlowAware", IR2VecKind::FlowAware,
+            "Flow-aware encodings (includes data/control flow)")
+      .export_values();
+
   nb::class_<PyIR2VecTool>(m, "IR2VecTool")
-      .def(nb::init<const std::string &, const std::string &,
+      .def(nb::init<const std::string &, IR2VecKind,
                     const std::string &>(),
            nb::arg("filename"), nb::arg("mode"), nb::arg("vocabPath"))
       .def("getFuncNames", &PyIR2VecTool::getFuncNames,
@@ -228,10 +229,10 @@ NB_MODULE(ir2vec, m) {
 
   m.def(
       "initEmbedding",
-      [](const std::string &filename, const std::string &mode,
+      [](const std::string &filename, IR2VecKind mode,
          const std::string &vocabPath) {
         return std::make_unique<PyIR2VecTool>(filename, mode, vocabPath);
       },
-      nb::arg("filename"), nb::arg("mode") = "sym", nb::arg("vocabPath"),
+      nb::arg("filename"), nb::arg("mode") = IR2VecKind::Symbolic, nb::arg("vocabPath"),
       nb::rv_policy::take_ownership);
 }

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -195,15 +195,14 @@ NB_MODULE(ir2vec, m) {
   m.doc() = std::string("Python bindings for ") + ToolName;
 
   nb::enum_<IR2VecKind>(m, "IR2VecKind",
-                       "Embedding mode for IR2Vec representations")
+                        "Embedding mode for IR2Vec representations")
       .value("Symbolic", IR2VecKind::Symbolic, "Symbolic encodings only")
       .value("FlowAware", IR2VecKind::FlowAware,
-            "Flow-aware encodings (includes data/control flow)")
+             "Flow-aware encodings (includes data/control flow)")
       .export_values();
 
   nb::class_<PyIR2VecTool>(m, "IR2VecTool")
-      .def(nb::init<const std::string &, IR2VecKind,
-                    const std::string &>(),
+      .def(nb::init<const std::string &, IR2VecKind, const std::string &>(),
            nb::arg("filename"), nb::arg("mode"), nb::arg("vocabPath"))
       .def("getFuncNames", &PyIR2VecTool::getFuncNames,
            "Get list of all defined functions in the module\n"
@@ -233,6 +232,6 @@ NB_MODULE(ir2vec, m) {
          const std::string &vocabPath) {
         return std::make_unique<PyIR2VecTool>(filename, mode, vocabPath);
       },
-      nb::arg("filename"), nb::arg("mode") = IR2VecKind::Symbolic, nb::arg("vocabPath"),
-      nb::rv_policy::take_ownership);
+      nb::arg("filename"), nb::arg("mode") = IR2VecKind::Symbolic,
+      nb::arg("vocabPath"), nb::rv_policy::take_ownership);
 }


### PR DESCRIPTION
Currently, the initEmbedding() takes mode as an input. This input is a string input. This PR introduces a patch to take the input as an enum value. 

@svkeerthy 