### PR TITLE
[llvm-objopy]: Add elf64-amdgpu

### DIFF
--- a/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
+++ b/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
@@ -333,6 +333,8 @@ static const StringMap<MachineInfo> TargetMap{
     {"elf64-loongarch", {ELF::EM_LOONGARCH, true, true}},
     // SystemZ
     {"elf64-s390", {ELF::EM_S390, true, false}},
+    // AMDGPU
+    {"elf64-amdgpu", {ELF::EM_AMDGPU, true, true}},
 };
 
 static Expected<TargetInfo>


### PR DESCRIPTION
If I assemble something with llvm-mc -arch amdgcn I get elf64-amdgpu, so make it possible to go elf->binary->elf.