### PR TITLE
[mlir][CSE] Fix CSE markAnalysesPreserved<DominanceInfo, PostDominanceInfo> comment

### DIFF
--- a/mlir/lib/Transforms/CSE.cpp
+++ b/mlir/lib/Transforms/CSE.cpp
@@ -433,7 +433,8 @@ void CSE::runOnOperation() {
   if (!changed)
     return markAllAnalysesPreserved();
 
-  // We currently don't remove region operations, so mark dominance as
-  // preserved.
+  // We only delete redundant operations without moving any operation to a
+  // different block, so the dominance tree structure remains unchanged and
+  // DominanceInfo/PostDominanceInfo can be safely preserved.
   markAnalysesPreserved<DominanceInfo, PostDominanceInfo>();
 }


### PR DESCRIPTION
The original comment claimed that DominanceInfo and PostDominanceInfo could be preserved because region operations are not removed. However, the real reason was that the original CSE only deleted redundant operations without moving any operation to a different block, leaving the dominance tree structure unchanged. Part of https://github.com/llvm/llvm-project/pull/180556.