### PR TITLE
[lldb] Inherit Host::GetEnvironment() when launching a wasm runtime

### DIFF
--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
@@ -176,6 +176,7 @@ lldb::ProcessSP PlatformWasm::DebugProcess(ProcessLaunchInfo &launch_info,
   launch_info.SetArguments(args, true);
   launch_info.SetLaunchInSeparateProcessGroup(true);
   launch_info.GetFlags().Clear(eLaunchFlagDebug);
+  launch_info.GetEnvironment() = Host::GetEnvironment();
 
   auto exit_code = std::make_shared<std::optional<int>>();
   launch_info.SetMonitorProcessCallback(


### PR DESCRIPTION
Some WebAssembly runtimes might use environment variables such as `HOME` or `XDG_CONFIG_HOME` to store configuration files, additionally some VMs might allow wasm modules to read environment variables from the host. Currently, if a runtime is launched using the WebAssembly platform it doesn't inherit the environment. As a result wasm runtimes and modules are unable to read from environment variables and might even fail to launch (if the config file is required). This PR aims to resolve this issue, I have tested this with the WARDuino runtime and my WIP gdbstub.