### PR TITLE
[Scheduler][NFC] Don't use set to track visited nodes

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -689,13 +689,14 @@ private:
   /// Return a pointer to the specified value type.
   LLVM_ABI static const EVT *getValueTypeList(MVT VT);
 
-  /// Index in worklist of DAGCombiner, or negative if the node is not in the
-  /// worklist. -1 = not in worklist; -2 = not in worklist, but has already been
-  /// combined at least once.
-  ///
-  /// This field is also used to track the visited state in
-  /// ScheduleDAGSDNodes::BuildSchedUnits.
-  int CombinerWorklistIndex = -1;
+  union {
+    /// Index in worklist of DAGCombiner, or negative if the node is not in the
+    /// worklist. -1 = not in worklist; -2 = not in worklist, but has already
+    /// been combined at least once.
+    int CombinerWorklistIndex = -1;
+    /// Visited state in ScheduleDAGSDNodes::BuildSchedUnits.
+    bool SchedulerWorklistVisited;
+  };
 
   uint32_t CFIType = 0;
 
@@ -797,6 +798,14 @@ public:
 
   /// Set worklist index for DAGCombiner
   void setCombinerWorklistIndex(int Index) { CombinerWorklistIndex = Index; }
+
+  /// Get visited state for ScheduleDAGSDNodes::BuildSchedUnits.
+  bool getSchedulerWorklistVisited() const { return SchedulerWorklistVisited; }
+
+  /// Set visited state for ScheduleDAGSDNodes::BuildSchedUnits.
+  void setSchedulerWorklistVisited(bool Visited) {
+    SchedulerWorklistVisited = Visited;
+  }
 
   /// Return the node ordering.
   unsigned getIROrder() const { return IROrder; }

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -692,6 +692,9 @@ private:
   /// Index in worklist of DAGCombiner, or negative if the node is not in the
   /// worklist. -1 = not in worklist; -2 = not in worklist, but has already been
   /// combined at least once.
+  ///
+  /// This field is also used to track the visited state in
+  /// ScheduleDAGSDNodes::BuildSchedUnits.
   int CombinerWorklistIndex = -1;
 
   uint32_t CFIType = 0;

--- a/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
@@ -329,9 +329,7 @@ void ScheduleDAGSDNodes::BuildSchedUnits() {
   unsigned NumNodes = 0;
   for (SDNode &NI : DAG->allnodes()) {
     NI.setNodeId(-1);
-    // We re-use CominerWorklistIndex as to indicate whether we visited the
-    // node before. Initialize to zero.
-    NI.setCombinerWorklistIndex(0);
+    NI.setSchedulerWorklistVisited(false);
     ++NumNodes;
   }
 
@@ -346,7 +344,7 @@ void ScheduleDAGSDNodes::BuildSchedUnits() {
   SmallVector<SDNode*, 64> Worklist;
   SmallPtrSet<SDNode*, 32> Visited;
   Worklist.push_back(DAG->getRoot().getNode());
-  DAG->getRoot().getNode()->setCombinerWorklistIndex(1);
+  DAG->getRoot().getNode()->setSchedulerWorklistVisited(true);
 
   SmallVector<SUnit*, 8> CallSUnits;
   while (!Worklist.empty()) {
@@ -354,9 +352,9 @@ void ScheduleDAGSDNodes::BuildSchedUnits() {
 
     // Add all operands to the worklist unless they've already been added.
     for (const SDValue &Op : NI->op_values()) {
-      if (Op.getNode()->getCombinerWorklistIndex() != 0)
+      if (Op.getNode()->getSchedulerWorklistVisited())
         continue;
-      Op.getNode()->setCombinerWorklistIndex(1);
+      Op.getNode()->setSchedulerWorklistVisited(true);
       Worklist.push_back(Op.getNode());
     }
 

--- a/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
@@ -329,6 +329,9 @@ void ScheduleDAGSDNodes::BuildSchedUnits() {
   unsigned NumNodes = 0;
   for (SDNode &NI : DAG->allnodes()) {
     NI.setNodeId(-1);
+    // We re-use CominerWorklistIndex as to indicate whether we visited the
+    // node before. Initialize to zero.
+    NI.setCombinerWorklistIndex(0);
     ++NumNodes;
   }
 
@@ -343,16 +346,19 @@ void ScheduleDAGSDNodes::BuildSchedUnits() {
   SmallVector<SDNode*, 64> Worklist;
   SmallPtrSet<SDNode*, 32> Visited;
   Worklist.push_back(DAG->getRoot().getNode());
-  Visited.insert(DAG->getRoot().getNode());
+  DAG->getRoot().getNode()->setCombinerWorklistIndex(1);
 
   SmallVector<SUnit*, 8> CallSUnits;
   while (!Worklist.empty()) {
     SDNode *NI = Worklist.pop_back_val();
 
     // Add all operands to the worklist unless they've already been added.
-    for (const SDValue &Op : NI->op_values())
-      if (Visited.insert(Op.getNode()).second)
-        Worklist.push_back(Op.getNode());
+    for (const SDValue &Op : NI->op_values()) {
+      if (Op.getNode()->getCombinerWorklistIndex() != 0)
+        continue;
+      Op.getNode()->setCombinerWorklistIndex(1);
+      Worklist.push_back(Op.getNode());
+    }
 
     if (isPassiveNode(NI))  // Leaf node, e.g. a TargetImmediate.
       continue;


### PR DESCRIPTION
The visited set can grow rather large and we can use an unused field in
SDNode to store the same information without the use of a hash set.

This improves compile times: stage2-O3 -0.14%.
