### PR TITLE
[CodeGenPrepare] Use Instruction::comesBefore instead of manual ordering

### DIFF
--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -7968,17 +7968,12 @@ bool CodeGenPrepare::tryToSinkFreeOperands(Instruction *I) {
   bool Changed = false;
   SmallVector<Use *, 4> ToReplace;
   Instruction *InsertPoint = I;
-  DenseMap<const Instruction *, unsigned long> InstOrdering;
-  unsigned long InstNumber = 0;
-  for (const auto &I : *TargetBB)
-    InstOrdering[&I] = InstNumber++;
-
   for (Use *U : reverse(OpsToSink)) {
     auto *UI = cast<Instruction>(U->get());
     if (isa<PHINode>(UI) || UI->mayHaveSideEffects() || UI->mayReadFromMemory())
       continue;
     if (UI->getParent() == TargetBB) {
-      if (InstOrdering[UI] < InstOrdering[InsertPoint])
+      if (UI->comesBefore(InsertPoint))
         InsertPoint = UI;
       continue;
     }


### PR DESCRIPTION
After #172329, we noticed that some sources compiled with MSan take
1000x longer to compile. This is caused by quadratic complexity in
tryToSinkFreeOperands, which can be called on a significant number
of instructions within huge basic blocks.

This inefficiency was introduced in 9cfa9b4, which manually iterates
and creates a DenseMap of entire basic blocks for each interesting
instruction.

This patch avoids the manual ordering by using
Instruction::comesBefore(), which provides the exact same
ordering much more efficiently.