### PR TITLE
[LLD] [COFF] Remove a now incorrect comment in a test. NFC.

### DIFF
--- a/lld/test/COFF/gnu-weak.test
+++ b/lld/test/COFF/gnu-weak.test
@@ -13,9 +13,6 @@ For each of the weak definitions, GNU tools produce a regular symbol
 named .weak.<weaksymbol>.<othersymbol>, where the other symbol name is
 another symbol defined close by.
 
-This can't be reproduced by assembling with llvm-mc, as llvm-mc always
-produces similar regular symbols named .weak.<weaksymbol>.default.
-
 The bundled object files can be produced from test code that looks like
 this:
 


### PR DESCRIPTION
This comment was added in 26572002749ee2e7d734e4e0aed4cca0e1c623c3 in 2018. Later in 8f540dad6120d00e3ad896b98cd32bcf00623ccd in 2020, the LLVM MC layer was adjusted to do essentially the same as GNU binutils do.

Therefore, I think that this test now technically could be done with object files generated by llvm-mc as well, instead of bundled binary object files.