### PR TITLE
[clang] NFC: Add test case for #178324 and mark it as fixed

### DIFF
--- a/clang/test/SemaCXX/source_location.cpp
+++ b/clang/test/SemaCXX/source_location.cpp
@@ -1081,3 +1081,13 @@ static_assert(X{}.
 static_assert(X{}.
                 foo() == 10001);
 }
+
+#ifdef MS
+namespace GH178324 {
+  struct a {
+    using e = int;
+  };
+  void current(const char * = __builtin_FUNCSIG());
+  template <class> void c() { decltype(a(current()))::e; }
+} // namespace GH178324
+#endif


### PR DESCRIPTION
Issue #178324 was actually fixed by #187755

We lost the "declaration does not declare anything" warning since the regression was introduced, but that was because:
1) Since #78436 we treat __builtin_FUNCSIG in a dependent context effectivelly as if it contained a template parameter.
2) Our decltype implementation treats eexpressions containing template parameters as if they were completely opaque (but alas this goes against the spec, which says in [temp.type]p4 this should be looking only at type dependence).
3) Since the decltype is opaque, we don't know what lookup will find, so we can't issue the warning because we don't know if we are going to end up with a type or an expression.

Fixes #178324