### PR TITLE
[LLD] [COFF] Fix crashes for conflicting exports with -export-all-symbols

### DIFF
--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -48,6 +48,7 @@ enum class ExportSource {
   Directives,
   Export,
   ModuleDefinition,
+  ExportAll,
 };
 
 enum class EmitKind { Obj, LLVM, ASM };

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -1487,6 +1487,7 @@ void LinkerDriver::maybeExportMinGWSymbols(const opt::InputArgList &args) {
       Export e;
       e.name = def->getName();
       e.sym = def;
+      e.source = ExportSource::ExportAll;
       if (Chunk *c = def->getChunk())
         if (!(c->getOutputCharacteristics() & IMAGE_SCN_MEM_EXECUTE))
           e.data = true;

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -1190,6 +1190,8 @@ static StringRef exportSourceName(ExportSource s) {
     return "/export";
   case ExportSource::ModuleDefinition:
     return "/def";
+  case ExportSource::ExportAll:
+    return "/export-all-symbols";
   default:
     llvm_unreachable("unknown ExportSource");
   }

--- a/lld/test/COFF/export-all-conflict.test
+++ b/lld/test/COFF/export-all-conflict.test
@@ -1,0 +1,18 @@
+REQUIRES: x86
+RUN: split-file %s %t.dir && cd %t.dir
+
+RUN: llvm-mc -filetype=obj -triple=x86_64-windows datasym.s -o datasym.obj
+
+RUN: lld-link -dll -noentry -out:test.dll datasym.obj -def:exports.def -lldmingw -export-all-symbols 2>&1 | FileCheck %s
+
+CHECK: warning: duplicate export: datasym first seen in /def, now in /export-all-symbols
+
+#--- datasym.s
+	.data
+	.globl	datasym
+datasym:
+	.long	42
+
+#--- exports.def
+EXPORTS
+datasym


### PR DESCRIPTION
Commit adcdc9cc3740adba3577b328fa3ba492cbccd3a5 (since LLD 17) added a warning message if there are conflicting attempts to export a specific symbol.

That commit missed one source of exports, from the LLD specific -export-all-symbols flag (which only has an effect in mingw mode).

To trigger this case, one needs to have an export set by a def file, combined with the -export-all-symbols flag (which attempts to export all global symbols, despite explicit exports through embedded directives or a def file).

To trigger the warning (and the previous crash), one would have to have some difference between the export produced by -export-all-symbols and the one from the def file. That difference could be e.g. that the def file contained an explicit ordinal, or that the def file lacked a DATA marking for a symbol that the automatic export of all symbols decides to export as a data symbol.

This fixes https://github.com/llvm/llvm-project/issues/187318. (In the repro case in that bug, the def file lacked DATA markings for a data symbol.)