### PR TITLE
[Polly] Correct integer comparison bit width

### DIFF
--- a/polly/lib/CodeGen/IslExprBuilder.cpp
+++ b/polly/lib/CodeGen/IslExprBuilder.cpp
@@ -794,6 +794,7 @@ Value *IslExprBuilder::create(__isl_take isl_ast_expr *Expr) {
 llvm::Value *IslExprBuilder::createBool(__isl_take isl_ast_expr *Expr) {
   Value *Result = create(Expr);
   if (!Result->getType()->isIntegerTy(1))
-    Result = Builder.CreateICmpNE(Result, Builder.getInt1(false));
+    Result =
+        Builder.CreateICmpNE(Result, ConstantInt::get(Result->getType(), 0));
   return Result;
 }

--- a/polly/test/CodeGen/issue190459_1.ll
+++ b/polly/test/CodeGen/issue190459_1.ll
@@ -3,6 +3,7 @@
 ; https://github.com/llvm/llvm-project/issues/190459
 ; Avoid a crash due to comparing integers with different widths
 
+; "i1 false" is the result of the comparison with the fixed width
 ; CHECK: br i1 false, label %polly.preload.exec, label %polly.preload.merge
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"

--- a/polly/test/CodeGen/issue190459_1.ll
+++ b/polly/test/CodeGen/issue190459_1.ll
@@ -1,0 +1,26 @@
+; RUN: opt  %loadNPMPolly '-passes=polly-custom<codegen>' -polly-invariant-load-hoisting -S < %s | FileCheck %s
+
+; https://github.com/llvm/llvm-project/issues/190459
+; Avoid a crash due to comparing integers with different widths
+
+; CHECK: br i1 false, label %polly.preload.exec, label %polly.preload.merge
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+
+define i32 @func(i32 %arg) {
+bb:
+  br label %bb1
+
+bb1:                                              ; preds = %bb
+  store i16 0, ptr null, align 2
+  %i = icmp eq i32 %arg, 0
+  br i1 %i, label %bb2, label %bb5
+
+bb2:                                              ; preds = %bb1
+  %i3 = load ptr, ptr null, align 8
+  %i4 = load i16, ptr %i3, align 2
+  br label %bb5
+
+bb5:                                              ; preds = %bb2, %bb1
+  ret i32 0
+}


### PR DESCRIPTION
For making an integer compareable to bool, don't compare it to bool.

Bug occured during the reduction of #190459