### PR TITLE
[InstCombine] Resolve incorrect submasking in foldIntrinsicIsFPClass

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -1180,7 +1180,7 @@ Instruction *InstCombinerImpl::foldIntrinsicIsFPClass(IntrinsicInst &II) {
   // If none of the tests which can return false are possible, fold to true.
   // fp_class (nnan x), ~(qnan|snan) -> true
   // fp_class (ninf x), ~(ninf|pinf) -> true
-  if (Mask == Known.KnownFPClasses)
+  if ((Known.KnownFPClasses & ~Mask) == fcNone)
     return replaceInstUsesWith(II, ConstantInt::get(II.getType(), true));
 
   return nullptr;

--- a/llvm/test/Transforms/InstCombine/is_fpclass.ll
+++ b/llvm/test/Transforms/InstCombine/is_fpclass.ll
@@ -863,6 +863,37 @@ define i1 @test_class_is_not_nan_nnan_src_strict(float %x) strictfp {
   ret i1 %class
 }
 
+; Fold to true when known classes are a strict subset of the mask
+; nnan ninf -> Known = fcFinite (504), Mask = ~fcNan (1020), Known ⊂ Mask
+define i1 @test_class_is_not_nan_nnan_ninf_src(float %x) {
+; CHECK-LABEL: @test_class_is_not_nan_nnan_ninf_src(
+; CHECK-NEXT:    ret i1 true
+;
+  %nnan_ninf = fadd nnan ninf float %x, 1.0
+  %class = call i1 @llvm.is.fpclass.f32(float %nnan_ninf, i32 1020)
+  ret i1 %class
+}
+
+; nnan ninf -> Known = fcFinite (504), Mask = ~fcInf (507), Known ⊂ Mask
+define i1 @test_class_is_not_inf_nnan_ninf_src(float %x) {
+; CHECK-LABEL: @test_class_is_not_inf_nnan_ninf_src(
+; CHECK-NEXT:    ret i1 true
+;
+  %nnan_ninf = fadd nnan ninf float %x, 1.0
+  %class = call i1 @llvm.is.fpclass.f32(float %nnan_ninf, i32 507)
+  ret i1 %class
+}
+
+; nnan ninf -> Known = fcFinite (504), Mask = fcAllFlags (1023), Known ⊂ Mask
+define i1 @test_class_all_nnan_ninf_src(float %x) {
+; CHECK-LABEL: @test_class_all_nnan_ninf_src(
+; CHECK-NEXT:    ret i1 true
+;
+  %nnan_ninf = fadd nnan ninf float %x, 1.0
+  %class = call i1 @llvm.is.fpclass.f32(float %nnan_ninf, i32 1023)
+  ret i1 %class
+}
+
 ; --------------------------------------------------------------------
 ; llvm.is.fpclass with ninf sources
 ; --------------------------------------------------------------------


### PR DESCRIPTION
Fixes #189949 

Fix incorrect equality check in `foldIntrinsicIsFPClass` to use subset masking instead, so the fold-to-true optimization triggers whenever known FP classes are fully covered by the test mask