### PR TITLE
[llvm-ir2vec] Decoupling Vocab loading from initEmbedding

### DIFF
--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getBBEmbMap.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getBBEmbMap.py
@@ -6,8 +6,9 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
+vocab = ir2vec.loadVocab(vocab_path)
 tool = ir2vec.initEmbedding(
-    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocab=vocab
 )
 
 # Success case

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmb.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmb.py
@@ -6,8 +6,9 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
+vocab = ir2vec.loadVocab(vocab_path)
 tool = ir2vec.initEmbedding(
-    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocab=vocab
 )
 
 # Success case

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmbMap.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmbMap.py
@@ -6,8 +6,9 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
+vocab = ir2vec.loadVocab(vocab_path)
 tool = ir2vec.initEmbedding(
-    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocab=vocab
 )
 
 # Success case

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncNames.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncNames.py
@@ -6,8 +6,9 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
+vocab = ir2vec.loadVocab(vocab_path)
 tool = ir2vec.initEmbedding(
-    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocab=vocab
 )
 
 # Success case

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getInstEmbMap.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getInstEmbMap.py
@@ -6,8 +6,9 @@ import ir2vec
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
+vocab = ir2vec.loadVocab(vocab_path)
 tool = ir2vec.initEmbedding(
-    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocab=vocab
 )
 
 # Success case

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-initEmbedding.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-initEmbedding.py
@@ -2,37 +2,90 @@
 
 import sys
 import ir2vec
+import tempfile
+import os
 
 ll_file = sys.argv[1]
 vocab_path = sys.argv[2]
 
-# Success case
-tool = ir2vec.initEmbedding(
-    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
-)
-print(f"SUCCESS: {type(tool).__name__}")
-# CHECK: SUCCESS: IR2VecTool
+# ============================================================
+# loadVocab tests
+# ============================================================
 
-# Error: Invalid mode
-try:
-    ir2vec.initEmbedding(filename=ll_file, mode="invalid", vocabPath=vocab_path)
-except TypeError:
-    print("ERROR: Invalid mode")
-# CHECK: ERROR: Invalid mode
+# Success: Load a valid vocabulary
+vocab = ir2vec.loadVocab(vocab_path)
+print(f"VOCAB: {type(vocab).__name__}")
+# CHECK: VOCAB: Vocab
 
 # Error: Empty vocab path
 try:
-    ir2vec.initEmbedding(
-        filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=""
-    )
+    ir2vec.loadVocab("")
 except ValueError:
     print("ERROR: Empty vocab path")
 # CHECK: ERROR: Empty vocab path
 
-# Error: Invalid file
+# Error: Non-existent vocab file
+try:
+    ir2vec.loadVocab("/nonexistent/path/bad.json")
+except ValueError:
+    print("ERROR: Invalid vocab path")
+# CHECK: ERROR: Invalid vocab path
+
+# Error: Malformed JSON vocab file
+with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+    f.write("{ this is not valid json }")
+    bad_vocab = f.name
+try:
+    ir2vec.loadVocab(bad_vocab)
+except ValueError:
+    print("ERROR: Malformed vocab file")
+finally:
+    os.unlink(bad_vocab)
+# CHECK: ERROR: Malformed vocab file
+
+# Error: Wrong type for vocab path (not a string)
+try:
+    ir2vec.loadVocab(42)
+except TypeError:
+    print("ERROR: Invalid vocab path type")
+# CHECK: ERROR: Invalid vocab path type
+
+# ============================================================
+# initEmbedding tests
+# ============================================================
+
+# Success: Create embedding tool with valid inputs
+tool = ir2vec.initEmbedding(
+    filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocab=vocab
+)
+print(f"SUCCESS: {type(tool).__name__}")
+# CHECK: SUCCESS: IR2VecTool
+
+# Success: Default mode (Symbolic) when mode is omitted
+tool_default = ir2vec.initEmbedding(filename=ll_file, vocab=vocab)
+print(f"DEFAULT MODE: {type(tool_default).__name__}")
+# CHECK: DEFAULT MODE: IR2VecTool
+
+# Error: Invalid mode (string instead of IR2VecKind enum)
+try:
+    ir2vec.initEmbedding(filename=ll_file, mode="invalid", vocab=vocab)
+except TypeError:
+    print("ERROR: Invalid mode type")
+# CHECK: ERROR: Invalid mode type
+
+# Error: Invalid mode (integer instead of IR2VecKind enum)
+try:
+    ir2vec.initEmbedding(filename=ll_file, mode=99, vocab=vocab)
+except TypeError:
+    print("ERROR: Invalid mode int")
+# CHECK: ERROR: Invalid mode int
+
+# Error: Non-existent IR file
 try:
     ir2vec.initEmbedding(
-        filename="/bad.ll", mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
+        filename="/nonexistent/bad.ll",
+        mode=ir2vec.IR2VecKind.Symbolic,
+        vocab=vocab,
     )
 except ValueError:
     print("ERROR: Invalid file")
@@ -40,35 +93,44 @@ except ValueError:
 
 # Error: Empty filename
 try:
-    ir2vec.initEmbedding(
-        filename="", mode=ir2vec.IR2VecKind.Symbolic, vocabPath=vocab_path
-    )
+    ir2vec.initEmbedding(filename="", mode=ir2vec.IR2VecKind.Symbolic, vocab=vocab)
 except ValueError:
     print("ERROR: Empty filename")
 # CHECK: ERROR: Empty filename
 
-# Error: Invalid vocab file
+# Error: Wrong type for vocab (string instead of Vocab object)
 try:
     ir2vec.initEmbedding(
-        filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath="/bad.json"
+        filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocab="vocab.json"
     )
-except ValueError:
-    print("ERROR: Invalid vocab")
-# CHECK: ERROR: Invalid vocab
+except TypeError:
+    print("ERROR: Vocab is string")
+# CHECK: ERROR: Vocab is string
 
-# Error: Malformed JSON vocab
-import tempfile
-import os
-
-with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-    f.write("{ this is not valid json }")
-    bad_vocab = f.name
+# Error: Wrong type for vocab (None)
 try:
-    ir2vec.initEmbedding(
-        filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocabPath=bad_vocab
-    )
-except ValueError:
-    print("ERROR: Invalid vocab file")
-finally:
-    os.unlink(bad_vocab)
-# CHECK: ERROR: Invalid vocab file
+    ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocab=None)
+except TypeError:
+    print("ERROR: Vocab is None")
+# CHECK: ERROR: Vocab is None
+
+# Error: Wrong type for vocab (integer)
+try:
+    ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic, vocab=123)
+except TypeError:
+    print("ERROR: Vocab is int")
+# CHECK: ERROR: Vocab is int
+
+# Error: Missing vocab argument entirely
+try:
+    ir2vec.initEmbedding(filename=ll_file, mode=ir2vec.IR2VecKind.Symbolic)
+except TypeError:
+    print("ERROR: Vocab missing")
+# CHECK: ERROR: Vocab missing
+
+# Error: Wrong type for filename (not a string)
+try:
+    ir2vec.initEmbedding(filename=42, mode=ir2vec.IR2VecKind.Symbolic, vocab=vocab)
+except TypeError:
+    print("ERROR: Filename is int")
+# CHECK: ERROR: Filename is int

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-initEmbedding.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-initEmbedding.py
@@ -61,11 +61,6 @@ tool = ir2vec.initEmbedding(
 print(f"SUCCESS: {type(tool).__name__}")
 # CHECK: SUCCESS: IR2VecTool
 
-# Success: Default mode (Symbolic) when mode is omitted
-tool_default = ir2vec.initEmbedding(filename=ll_file, vocab=vocab)
-print(f"DEFAULT MODE: {type(tool_default).__name__}")
-# CHECK: DEFAULT MODE: IR2VecTool
-
 # Error: Invalid mode (string instead of IR2VecKind enum)
 try:
     ir2vec.initEmbedding(filename=ll_file, mode="invalid", vocab=vocab)

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -43,7 +43,7 @@ private:
   std::shared_ptr<Vocabulary> Vocab;
 
 public:
-  PyVocab(const std::string &VocabPath) {
+  explicit PyVocab(const std::string &VocabPath) {
     if (VocabPath.empty())
       throw nb::value_error("Empty vocabulary path not allowed");
     auto VocabOrErr = ir2vec::loadVocabulary(VocabPath);

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -77,7 +77,8 @@ public:
     Ctx = std::make_unique<LLVMContext>();
     M = getLLVMIR(Filename, *Ctx);
     Tool = std::make_unique<IR2VecTool>(*M);
-    Tool->setVocabulary(Vocab.getVocab());
+    if (auto Err = Tool->setVocabulary(Vocab.getVocab()))
+      throw nb::value_error(toString(std::move(Err)).c_str());
   }
 
   nb::list getFuncNames() {
@@ -257,6 +258,6 @@ NB_MODULE(ir2vec, m) {
       [](const std::string &filename, IR2VecKind mode, PyVocab &vocab) {
         return std::make_unique<PyIR2VecTool>(filename, mode, vocab);
       },
-      nb::arg("filename"), nb::arg("mode"), nb::arg("vocabPath"),
+      nb::arg("filename"), nb::arg("mode"), nb::arg("vocab"),
       nb::rv_policy::take_ownership);
 }

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -65,10 +65,9 @@ private:
   IR2VecKind OutputEmbeddingMode;
 
 public:
-
   /// \note
-  /// In the currently exposed API, the vocabulary is set once at construction and there is no
-  /// public interface to call this again. Callers should treat
+  /// In the currently exposed API, the vocabulary is set once at construction
+  /// and there is no public interface to call this again. Callers should treat
   /// the vocabulary as immutable for the lifetime of the tool instance.
   PyIR2VecTool(const std::string &Filename, IR2VecKind Mode, PyVocab &Vocab) {
     if (!Vocab.getVocab())

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -38,6 +38,25 @@ std::unique_ptr<Module> getLLVMIR(const std::string &Filename,
   return M;
 }
 
+class PyVocab {
+private:
+  std::shared_ptr<Vocabulary> Vocab;
+
+public:
+  PyVocab(const std::string &VocabPath) {
+    if (VocabPath.empty())
+      throw nb::value_error("Empty vocabulary path not allowed");
+    auto VocabOrErr = ir2vec::loadVocabulary(VocabPath);
+    if (!VocabOrErr)
+      throw nb::value_error(
+          ("Failed to load vocabulary: " + toString(VocabOrErr.takeError()))
+              .c_str());
+    Vocab = std::move(*VocabOrErr);
+  }
+
+  std::shared_ptr<Vocabulary> getVocab() const { return Vocab; }
+};
+
 class PyIR2VecTool {
 private:
   std::unique_ptr<LLVMContext> Ctx;
@@ -46,22 +65,19 @@ private:
   IR2VecKind OutputEmbeddingMode;
 
 public:
-  PyIR2VecTool(const std::string &Filename, IR2VecKind Mode,
-               const std::string &VocabPath) {
-    OutputEmbeddingMode = Mode;
+  PyIR2VecTool(const std::string &Filename, IR2VecKind Mode, PyVocab &Vocab) {
+    if (!Vocab.getVocab())
+      throw nb::value_error("Vocabulary object is not initialized");
 
-    if (VocabPath.empty())
-      throw nb::value_error("Empty Vocab Path not allowed");
+    if (Filename.empty())
+      throw nb::value_error("Empty filename not allowed");
+
+    OutputEmbeddingMode = Mode;
 
     Ctx = std::make_unique<LLVMContext>();
     M = getLLVMIR(Filename, *Ctx);
     Tool = std::make_unique<IR2VecTool>(*M);
-
-    if (auto Err = Tool->initializeVocabulary(VocabPath)) {
-      throw nb::value_error(("Failed to initialize IR2Vec vocabulary: " +
-                             toString(std::move(Err)))
-                                .c_str());
-    }
+    Tool->setVocabulary(Vocab.getVocab());
   }
 
   nb::list getFuncNames() {
@@ -201,9 +217,19 @@ NB_MODULE(ir2vec, m) {
              "Flow-aware encodings (includes data/control flow)")
       .export_values();
 
+  nb::class_<PyVocab>(m, "Vocab");
+
+  m.def(
+      "loadVocab",
+      [](const std::string &vocabPath) {
+        return std::make_unique<PyVocab>(vocabPath);
+      },
+      nb::arg("vocabPath"), "Load an IR2Vec vocabulary from a JSON file",
+      nb::rv_policy::take_ownership);
+
   nb::class_<PyIR2VecTool>(m, "IR2VecTool")
-      .def(nb::init<const std::string &, IR2VecKind, const std::string &>(),
-           nb::arg("filename"), nb::arg("mode"), nb::arg("vocabPath"))
+      .def(nb::init<const std::string &, IR2VecKind, PyVocab &>(),
+           nb::arg("filename"), nb::arg("mode"), nb::arg("vocab"))
       .def("getFuncNames", &PyIR2VecTool::getFuncNames,
            "Get list of all defined functions in the module\n"
            "Returns: list[str] - Function names")
@@ -228,9 +254,8 @@ NB_MODULE(ir2vec, m) {
 
   m.def(
       "initEmbedding",
-      [](const std::string &filename, IR2VecKind mode,
-         const std::string &vocabPath) {
-        return std::make_unique<PyIR2VecTool>(filename, mode, vocabPath);
+      [](const std::string &filename, IR2VecKind mode, PyVocab &vocab) {
+        return std::make_unique<PyIR2VecTool>(filename, mode, vocab);
       },
       nb::arg("filename"), nb::arg("mode"), nb::arg("vocabPath"),
       nb::rv_policy::take_ownership);

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -65,6 +65,11 @@ private:
   IR2VecKind OutputEmbeddingMode;
 
 public:
+
+  /// \note
+  /// In the currently exposed API, the vocabulary is set once at construction and there is no
+  /// public interface to call this again. Callers should treat
+  /// the vocabulary as immutable for the lifetime of the tool instance.
   PyIR2VecTool(const std::string &Filename, IR2VecKind Mode, PyVocab &Vocab) {
     if (!Vocab.getVocab())
       throw nb::value_error("Vocabulary object is not initialized");
@@ -77,6 +82,7 @@ public:
     Ctx = std::make_unique<LLVMContext>();
     M = getLLVMIR(Filename, *Ctx);
     Tool = std::make_unique<IR2VecTool>(*M);
+
     if (auto Err = Tool->setVocabulary(Vocab.getVocab()))
       throw nb::value_error(toString(std::move(Err)).c_str());
   }

--- a/llvm/tools/llvm-ir2vec/lib/Utils.cpp
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.cpp
@@ -56,8 +56,15 @@ Expected<std::shared_ptr<Vocabulary>> loadVocabulary(StringRef VocabPath) {
   return V;
 }
 
-void IR2VecTool::setVocabulary(std::shared_ptr<Vocabulary> V) {
+Error IR2VecTool::setVocabulary(std::shared_ptr<Vocabulary> V) {
+  if (!V)
+    return createStringError(errc::invalid_argument,
+                             "Null pointer provided for vocabulary. Will not set IR2VecTool vocabulary.");
+  if (!V->isValid())
+    return createStringError(errc::invalid_argument,
+                             "Vocabulary is not valid. Will not set IR2VecTool vocabulary.");
   Vocab = std::move(V);
+  return Error::success();
 }
 
 TripletResult IR2VecTool::generateTriplets(const Function &F) const {

--- a/llvm/tools/llvm-ir2vec/lib/Utils.cpp
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.cpp
@@ -43,17 +43,21 @@ namespace llvm {
 
 namespace ir2vec {
 
-Error IR2VecTool::initializeVocabulary(StringRef VocabPath) {
+Expected<std::shared_ptr<Vocabulary>> loadVocabulary(StringRef VocabPath) {
   auto VocabOrErr = Vocabulary::fromFile(VocabPath);
   if (!VocabOrErr)
     return VocabOrErr.takeError();
 
-  Vocab = std::make_unique<Vocabulary>(std::move(*VocabOrErr));
+  auto V = std::make_shared<Vocabulary>(std::move(*VocabOrErr));
 
-  if (!Vocab->isValid())
+  if (!V->isValid())
     return createStringError(errc::invalid_argument,
                              "Failed to initialize IR2Vec vocabulary");
-  return Error::success();
+  return V;
+}
+
+void IR2VecTool::setVocabulary(std::shared_ptr<Vocabulary> V) {
+  Vocab = std::move(V);
 }
 
 TripletResult IR2VecTool::generateTriplets(const Function &F) const {

--- a/llvm/tools/llvm-ir2vec/lib/Utils.cpp
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.cpp
@@ -59,10 +59,12 @@ Expected<std::shared_ptr<Vocabulary>> loadVocabulary(StringRef VocabPath) {
 Error IR2VecTool::setVocabulary(std::shared_ptr<Vocabulary> V) {
   if (!V)
     return createStringError(errc::invalid_argument,
-                             "Null pointer provided for vocabulary. Will not set IR2VecTool vocabulary.");
+                             "Null pointer provided for vocabulary. Will not "
+                             "set IR2VecTool vocabulary.");
   if (!V->isValid())
-    return createStringError(errc::invalid_argument,
-                             "Vocabulary is not valid. Will not set IR2VecTool vocabulary.");
+    return createStringError(
+        errc::invalid_argument,
+        "Vocabulary is not valid. Will not set IR2VecTool vocabulary.");
   Vocab = std::move(V);
   return Error::success();
 }

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -107,9 +107,9 @@ public:
   createIR2VecEmbedder(const Function &F, IR2VecKind Kind) const;
 
   /// Sets the vocabulary for this tool instance.
-  /// This allows sharing the same vocabulary instance across multiple IR2VecTool
-  /// instances, which is useful for generating embeddings for multiple functions
-  /// without needing to reload the vocabulary each time.
+  /// This allows sharing the same vocabulary instance across multiple
+  /// IR2VecTool instances, which is useful for generating embeddings for
+  /// multiple functions without needing to reload the vocabulary each time.
   Error setVocabulary(std::shared_ptr<Vocabulary> V);
 
   /// Generate triplets for a single function

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -92,6 +92,11 @@ class IR2VecTool {
 private:
   Module &M;
   ModuleAnalysisManager MAM;
+
+  /// \note The API around vocab object is not thread-safe.
+  /// Specifically, calling setVocabulary() on an instance while
+  /// another thread reading the Vocab object with the same instance
+  /// can cause a data race on this internal shared_ptr<Vocabulary> member.
   std::shared_ptr<Vocabulary> Vocab;
 
 public:
@@ -101,10 +106,10 @@ public:
   Expected<std::unique_ptr<Embedder>>
   createIR2VecEmbedder(const Function &F, IR2VecKind Kind) const;
 
-  /// Load vocabulary from a shared pointer. This allows sharing the same
-  /// vocabulary instance across multiple IR2VecTool instances, which is useful
-  /// for generating embeddings for multiple functions without needing to reload
-  /// the vocabulary each time.
+  /// Sets the vocabulary for this tool instance.
+  /// This allows sharing the same vocabulary instance across multiple IR2VecTool
+  /// instances, which is useful for generating embeddings for multiple functions
+  /// without needing to reload the vocabulary each time.
   Error setVocabulary(std::shared_ptr<Vocabulary> V);
 
   /// Generate triplets for a single function

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -105,7 +105,7 @@ public:
   /// vocabulary instance across multiple IR2VecTool instances, which is useful
   /// for generating embeddings for multiple functions without needing to reload
   /// the vocabulary each time.
-  void setVocabulary(std::shared_ptr<Vocabulary> V);
+  Error setVocabulary(std::shared_ptr<Vocabulary> V);
 
   /// Generate triplets for a single function
   /// Returns a TripletResult with:

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -84,12 +84,15 @@ enum RelationType {
   ArgRelation = 2   ///< Instruction to operand relationship (ArgRelation + N)
 };
 
+/// Load an IR2Vec vocabulary from a JSON file on disk.
+Expected<std::shared_ptr<Vocabulary>> loadVocabulary(StringRef VocabPath);
+
 /// Helper class for collecting IR triplets and generating embeddings
 class IR2VecTool {
 private:
   Module &M;
   ModuleAnalysisManager MAM;
-  std::unique_ptr<Vocabulary> Vocab;
+  std::shared_ptr<Vocabulary> Vocab;
 
 public:
   explicit IR2VecTool(Module &M) : M(M) {}
@@ -98,8 +101,11 @@ public:
   Expected<std::unique_ptr<Embedder>>
   createIR2VecEmbedder(const Function &F, IR2VecKind Kind) const;
 
-  /// Initialize the IR2Vec vocabulary from the specified file path.
-  Error initializeVocabulary(StringRef VocabPath);
+  /// Load vocabulary from a shared pointer. This allows sharing the same
+  /// vocabulary instance across multiple IR2VecTool instances, which is useful
+  /// for generating embeddings for multiple functions without needing to reload
+  /// the vocabulary each time.
+  void setVocabulary(std::shared_ptr<Vocabulary> V);
 
   /// Generate triplets for a single function
   /// Returns a TripletResult with:

--- a/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
+++ b/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
@@ -161,8 +161,10 @@ static Error processModule(Module &M, raw_ostream &OS) {
           "You may need to set it using --ir2vec-vocab-path");
     }
 
-    if (Error Err = Tool.initializeVocabulary(VocabFile))
-      return Err;
+    auto VocabOrErr = ir2vec::loadVocabulary(VocabFile);
+    if (!VocabOrErr)
+      return VocabOrErr.takeError();
+    Tool.setVocabulary(std::move(*VocabOrErr));
 
     if (!FunctionName.empty()) {
       // Process single function

--- a/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
+++ b/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
@@ -161,10 +161,11 @@ static Error processModule(Module &M, raw_ostream &OS) {
           "You may need to set it using --ir2vec-vocab-path");
     }
 
-    auto VocabOrErr = ir2vec::loadVocabulary(VocabFile);
-    if (!VocabOrErr)
-      return VocabOrErr.takeError();
-    Tool.setVocabulary(std::move(*VocabOrErr));
+    std::shared_ptr<Vocabulary> Vocab;
+    if (auto Err = ir2vec::loadVocabulary(VocabFile).moveInto(Vocab))
+      return Err;
+    if (auto Err = Tool.setVocabulary(std::move(Vocab)))
+      return Err;
 
     if (!FunctionName.empty()) {
       // Process single function


### PR DESCRIPTION
 This has been done in order to save time during entire dataset processing. vocab loading should only happen once. 

@svkeerthy 