### PR TITLE
[AArch64][SPIR-V] Support SPIR_FUNC and SPIR_KERNEL calling conventions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -8610,6 +8610,8 @@ CCAssignFn *AArch64TargetLowering::CCAssignFnForCall(CallingConv::ID CC,
     [[fallthrough]];
   case CallingConv::C:
   case CallingConv::Fast:
+  case CallingConv::SPIR_FUNC:
+  case CallingConv::SPIR_KERNEL:
   case CallingConv::PreserveMost:
   case CallingConv::PreserveAll:
   case CallingConv::CXX_FAST_TLS:

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -690,6 +690,8 @@ bool AArch64RegisterInfo::isArgumentRegister(const MachineFunction &MF,
     [[fallthrough]];
   case CallingConv::C:
   case CallingConv::Fast:
+  case CallingConv::SPIR_FUNC:
+  case CallingConv::SPIR_KERNEL:
   case CallingConv::PreserveMost:
   case CallingConv::PreserveAll:
   case CallingConv::CXX_FAST_TLS:

--- a/llvm/test/CodeGen/AArch64/spir-func.ll
+++ b/llvm/test/CodeGen/AArch64/spir-func.ll
@@ -1,0 +1,31 @@
+; RUN: llc -verify-machineinstrs < %s -mtriple=aarch64-none-linux-gnu | FileCheck %s
+; RUN: llc -verify-machineinstrs -global-isel < %s -mtriple=aarch64-none-linux-gnu | FileCheck %s
+
+; Check the SPIR call conventions work.
+
+define spir_func i32 @callee(i32 %a, i32 %b) {
+; CHECK-LABEL: callee:
+; CHECK: add w0, w0, w1
+; CHECK: ret
+  %sum = add i32 %a, %b
+  ret i32 %sum
+}
+
+define spir_func i32 @caller(i32 %x) {
+; CHECK-LABEL: caller:
+; CHECK: mov w1, #7
+; CHECK: bl callee
+; CHECK: ret
+  %call = call spir_func i32 @callee(i32 %x, i32 7)
+  ret i32 %call
+}
+
+declare spir_func i64 @_Z13get_global_idj(i32)
+
+define spir_kernel void @addVectors(ptr %a, ptr %b, ptr %c) {
+; CHECK-LABEL: addVectors:
+; CHECK: bl _Z13get_global_idj
+; CHECK: ret
+  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  ret void
+}


### PR DESCRIPTION
Accept SPIR_FUNC and SPIR_KERNEL in AArch64 call lowering and argument-register classification

This fixes lowering for OpenCL kernels on AArch64, including the reproducer from #69197 on RISC-V (fixed there in #69282), also enables support for part of target triple sensitive tests for [SPIRV-LLVM-Translator](https://github.com/KhronosGroup/SPIRV-LLVM-Translator) on AArch64 (tested on M1)