### PR TITLE
[clang-tidy] Fix FP on cppcoreguidelines-pro-type-member-init with forward decl

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/ProTypeMemberInitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/ProTypeMemberInitCheck.cpp
@@ -572,7 +572,8 @@ void ProTypeMemberInitCheck::checkMissingBaseClassInitializer(
 
     for (const CXXCtorInitializer *Init : Ctor->inits())
       if (Init->isBaseInitializer() && Init->isWritten())
-        BasesToInit.erase(Init->getBaseClass()->getAsCXXRecordDecl());
+        BasesToInit.erase(
+            Init->getBaseClass()->getAsCXXRecordDecl()->getCanonicalDecl());
   }
 
   if (BasesToInit.empty())

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -283,6 +283,11 @@ Changes in existing checks
   <clang-tidy/checks/cppcoreguidelines/missing-std-forward>` check by fixing
   a false positive for constrained template parameters.
 
+- Improved :doc:`cppcoreguidelines-pro-type-member-init
+  <clang-tidy/checks/cppcoreguidelines/pro-type-member-init>` check by fixing
+  a false positive when a base class has a forward declaration before its
+  definition.
+
 - Improved :doc:`cppcoreguidelines-pro-type-vararg
   <clang-tidy/checks/cppcoreguidelines/pro-type-vararg>` check by no longer
   warning on builtins with custom type checking (e.g., type-generic builtins

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init.cpp
@@ -611,3 +611,27 @@ namespace PR37250 {
   const V v;
   const S s{v};
 }
+
+namespace PR155416 {
+  struct S;
+
+  struct S {
+    int a;
+  };
+
+  struct C : S {
+    C() : S{0} {}
+  };
+
+  template<typename T>
+  struct St;
+
+  template<typename T>
+  struct St{
+    T a;
+  };
+
+  struct Ct : St<int> {
+    Ct() : St{0} {}
+  };
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/155416.