### PR TITLE
[clang-tidy] Fix FP in cppcoreguidelines-missing-std-forward in lambda init-list

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
@@ -112,8 +112,10 @@ void MissingStdForwardCheck::registerMatchers(MatchFinder *Finder) {
       allOf(hasCaptureKind(LambdaCaptureKind::LCK_ByRef), RefToParm));
 
   auto CapturedInBody = lambdaExpr(anyOf(CaptureInRef, CaptureByRefExplicit));
-  auto CapturedInCaptureList = hasAnyCapture(capturesVar(
-      varDecl(hasInitializer(ignoringParenImpCasts(equalsBoundNode("call"))))));
+  auto IsBoundCall = ignoringParenImpCasts(equalsBoundNode("call"));
+  auto CapturedInCaptureList = hasAnyCapture(capturesVar(varDecl(
+      hasInitializer(anyOf(IsBoundCall, initListExpr(hasInit(0, IsBoundCall)),
+                           parenListExpr(has(expr(IsBoundCall))))))));
 
   auto CapturedInLambda = hasDeclContext(cxxRecordDecl(
       isLambda(),
@@ -143,7 +145,9 @@ void MissingStdForwardCheck::registerMatchers(MatchFinder *Finder) {
           hasAncestor(functionDecl().bind("func")),
           hasAncestor(functionDecl(
               isDefinition(), equalsBoundNode("func"), ToParam,
-              unless(anyOf(isDeleted(), hasDescendant(ForwardCallMatcher)))))),
+              unless(anyOf(
+                  isDeleted(),
+                  traverse(TK_AsIs, hasDescendant(ForwardCallMatcher))))))),
       this);
 }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -280,8 +280,12 @@ Changes in existing checks
   member pointers are correctly flagged as uninitialized.
 
 - Improved :doc:`cppcoreguidelines-missing-std-forward
-  <clang-tidy/checks/cppcoreguidelines/missing-std-forward>` check by fixing
-  a false positive for constrained template parameters.
+  <clang-tidy/checks/cppcoreguidelines/missing-std-forward>` check:
+  
+  - Fixed false positive for constrained template parameters
+  
+  - Fixed false positive with ``std::forward`` in brace-init and paren-init
+    lambda captures such as ``[t{std::forward<T>(t)}]``.
 
 - Improved :doc:`cppcoreguidelines-pro-type-vararg
   <clang-tidy/checks/cppcoreguidelines/pro-type-vararg>` check by no longer

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
@@ -81,6 +81,18 @@ void lambda_value_capture_copy(T&& t) {
   [&,t]() { T other = std::forward<T>(t); };
 }
 
+template <class T>
+void lambda_capture_list_brace_init_no_forward(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:52: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  [t2{t}] { t2(); };
+}
+
+template <class T>
+void lambda_capture_list_paren_init_no_forward(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:52: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  [t2(t)] { t2(); };
+}
+
 template <typename X>
 void use(const X &x) {}
 
@@ -166,6 +178,16 @@ void lambda_value_reference_capture_list(T&& t) {
 template <class T>
 void lambda_value_reference_auxiliary_var(T&& t) {
   [&x = t]() { T other = std::forward<T>(x); };
+}
+
+template <typename T>
+void lambda_value_reference_capture_list_brace_init(T&& t) {
+  [t2{std::forward<T>(t)}] { t2(); };
+}
+
+template <typename T>
+void lambda_value_reference_capture_list_paren_init(T&& t) {
+  [t2(std::forward<T>(t))] { t2(); };
 }
 
 } // namespace negative_cases


### PR DESCRIPTION
In `TK_IgnoreUnlessSpelledInSource` mode [`MatchChildASTVisitor::TraverseLambdaExpr`](https://github.com/llvm/llvm-project/blob/main/clang/lib/ASTMatchers/ASTMatchFinder.cpp#L280) only calls `match()` on each capture-init expression without recursing into its children. So for `[t{std::forward<T>(t)}]` the `CallExpr` nested inside the `InitListExpr` is never visited, and `ForwardCallMatcher` never binds "call".

Fixes https://github.com/llvm/llvm-project/issues/150446.