### PR TITLE
[clang-repl] Use canonical types in QualTypeToString

### DIFF
--- a/clang/lib/AST/QualTypeNames.cpp
+++ b/clang/lib/AST/QualTypeNames.cpp
@@ -369,11 +369,6 @@ NestedNameSpecifier createNestedNameSpecifier(const ASTContext &Ctx,
 /// versions of any template parameters.
 QualType getFullyQualifiedType(QualType QT, const ASTContext &Ctx,
                                bool WithGlobalNsPrefix) {
-  // Use the underlying deduced type for AutoType
-  if (const auto *AT = dyn_cast<AutoType>(QT.getTypePtr()))
-    if (AT->isDeduced())
-      QT = AT->getDeducedType();
-
   // In case of myType* we need to strip the pointer first, fully
   // qualify and attach the pointer once again.
   if (isa<PointerType>(QT.getTypePtr())) {

--- a/clang/lib/AST/QualTypeNames.cpp
+++ b/clang/lib/AST/QualTypeNames.cpp
@@ -370,15 +370,9 @@ NestedNameSpecifier createNestedNameSpecifier(const ASTContext &Ctx,
 QualType getFullyQualifiedType(QualType QT, const ASTContext &Ctx,
                                bool WithGlobalNsPrefix) {
   // Use the underlying deduced type for AutoType
-  if (const auto *AT = dyn_cast<AutoType>(QT.getTypePtr())) {
-    if (AT->isDeduced()) {
-      // Get the qualifiers.
-      Qualifiers Quals = QT.getQualifiers();
+  if (const auto *AT = dyn_cast<AutoType>(QT.getTypePtr()))
+    if (AT->isDeduced())
       QT = AT->getDeducedType();
-      // Add back the qualifiers.
-      QT = Ctx.getQualifiedType(QT, Quals);
-    }
-  }
 
   // In case of myType* we need to strip the pointer first, fully
   // qualify and attach the pointer once again.

--- a/clang/lib/AST/QualTypeNames.cpp
+++ b/clang/lib/AST/QualTypeNames.cpp
@@ -450,17 +450,6 @@ QualType getFullyQualifiedType(QualType QT, const ASTContext &Ctx,
     QT = Ctx.getQualifiedType(QT, Quals);
   }
 
-  // Try to get to the underlying type for DecltypeType
-  while (const auto *DT = dyn_cast<DecltypeType>(QT.getTypePtr())) {
-    // Get the qualifiers.
-    Qualifiers Quals = QT.getQualifiers();
-    QualType Underlying = DT->getUnderlyingType();
-    if (Underlying.isNull() || Underlying->isDependentType())
-      break;
-    // Add back the qualifiers.
-    QT = Ctx.getQualifiedType(Underlying, Quals);
-  }
-
   if (const auto *TST =
           dyn_cast<const TemplateSpecializationType>(QT.getTypePtr())) {
 

--- a/clang/lib/Interpreter/InterpreterValuePrinter.cpp
+++ b/clang/lib/Interpreter/InterpreterValuePrinter.cpp
@@ -78,7 +78,7 @@ static std::string QualTypeToString(ASTContext &Ctx, QualType QT) {
       !NonRefTy->isMemberPointerType())
     return Canon.getAsString(Ctx.getPrintingPolicy());
 
-  if (const auto *TDTy = dyn_cast<TypedefType>(NonRefTy)) {
+  if (const auto *TDTy = dyn_cast<TypedefType>(Canon)) {
     // FIXME: TemplateSpecializationType & SubstTemplateTypeParmType checks
     // are predominately to get STL containers to print nicer and might be
     // better handled in GetFullyQualifiedName.
@@ -87,13 +87,12 @@ static std::string QualTypeToString(ASTContext &Ctx, QualType QT) {
     // std::vector<Type>::value_type is a SubstTemplateTypeParmType
     //
     QualType SSDesugar = TDTy->getLocallyUnqualifiedSingleStepDesugaredType();
-    if (llvm::isa<SubstTemplateTypeParmType>(SSDesugar))
+    if (llvm::isa<SubstTemplateTypeParmType>(SSDesugar) ||
+        llvm::isa<TemplateSpecializationType>(SSDesugar))
       return GetFullTypeName(Ctx, Canon);
-    else if (llvm::isa<TemplateSpecializationType>(SSDesugar))
-      return GetFullTypeName(Ctx, NonRefTy);
-    return DeclTypeToString(NonRefTy, TDTy->getDecl());
+    return DeclTypeToString(Canon, TDTy->getDecl());
   }
-  return GetFullTypeName(Ctx, NonRefTy);
+  return GetFullTypeName(Ctx, Canon);
 }
 
 static std::string EnumToString(const Value &V) {

--- a/clang/test/Interpreter/pretty-print.cpp
+++ b/clang/test/Interpreter/pretty-print.cpp
@@ -60,6 +60,35 @@ struct S5 { int foo() { return 42; }};
 &S5::foo
 // CHECK-NEXT: (int (S5::*)()) Function @0x{{[0-9a-f]+}}
 
+// Namespaced types deduced via auto
+namespace Outer { struct Foo {}; }
+auto x = Outer::Foo(); x
+// CHECK-NEXT: (Outer::Foo &) @0x{{[0-9a-f]+}}
+
+namespace Outer { template<class T> struct Bar {}; }
+auto y = Outer::Bar<int>(); y
+// CHECK-NEXT: (Outer::Bar<int> &) @0x{{[0-9a-f]+}}
+
+// Check that const is preserved
+const auto z = Outer::Foo(); z
+// CHECK-NEXT: (const Outer::Foo &) @0x{{[0-9a-f]+}}
+
+// Check printing of DecltypeTypes (this used to assert)
+namespace N { struct D {}; }
+decltype(N::D()) decl1; decl1
+// CHECK-NEXT: (N::D &) @0x{{[0-9a-f]+}}
+
+// double-nested DecltypeType
+decltype(decl1) decl2; decl2
+// CHECK-NEXT: (N::D &) @0x{{[0-9a-f]+}}
+
+const decltype(N::D()) decl3; decl3
+// CHECK-NEXT: (const N::D &) @0x{{[0-9a-f]+}}
+
+// Check printing of UnaryTransformType (this used to assert)
+__remove_extent(N::D)* decl4; decl4
+// CHECK-NEXT: (N::D *)
+
 // int i = 12;
 // int &iref = i;
 // iref

--- a/clang/test/Interpreter/pretty-print.cpp
+++ b/clang/test/Interpreter/pretty-print.cpp
@@ -73,18 +73,6 @@ auto y = Outer::Bar<int>(); y
 const auto z = Outer::Foo(); z
 // CHECK-NEXT: (const Outer::Foo &) @0x{{[0-9a-f]+}}
 
-// Check printing of DecltypeTypes (this used to assert)
-namespace N { struct D {}; }
-decltype(N::D()) decl1; decl1
-// CHECK-NEXT: (N::D &) @0x{{[0-9a-f]+}}
-
-// double-nested DecltypeType
-decltype(decl1) decl2; decl2
-// CHECK-NEXT: (N::D &) @0x{{[0-9a-f]+}}
-
-const decltype(N::D()) decl3; decl3
-// CHECK-NEXT: (const N::D &) @0x{{[0-9a-f]+}}
-
 // int i = 12;
 // int &iref = i;
 // iref

--- a/clang/test/Interpreter/pretty-print.cpp
+++ b/clang/test/Interpreter/pretty-print.cpp
@@ -69,10 +69,6 @@ namespace Outer { template<class T> struct Bar {}; }
 auto y = Outer::Bar<int>(); y
 // CHECK-NEXT: (Outer::Bar<int> &) @0x{{[0-9a-f]+}}
 
-// Check that const is preserved
-const auto z = Outer::Foo(); z
-// CHECK-NEXT: (const Outer::Foo &) @0x{{[0-9a-f]+}}
-
 // int i = 12;
 // int &iref = i;
 // iref

--- a/clang/test/Interpreter/pretty-print.cpp
+++ b/clang/test/Interpreter/pretty-print.cpp
@@ -60,15 +60,6 @@ struct S5 { int foo() { return 42; }};
 &S5::foo
 // CHECK-NEXT: (int (S5::*)()) Function @0x{{[0-9a-f]+}}
 
-// Namespaced types deduced via auto
-namespace Outer { struct Foo {}; }
-auto x = Outer::Foo(); x
-// CHECK-NEXT: (Outer::Foo &) @0x{{[0-9a-f]+}}
-
-namespace Outer { template<class T> struct Bar {}; }
-auto y = Outer::Bar<int>(); y
-// CHECK-NEXT: (Outer::Bar<int> &) @0x{{[0-9a-f]+}}
-
 // int i = 12;
 // int &iref = i;
 // iref


### PR DESCRIPTION
Use the canonical type when generating type strings to ensure sugared  (e.g. `AutoType`, `DecltypeType`) are resolved before calling getFullyQualifiedType.

This will revert a few commits that were added to fix these assertions.