### PR TITLE
[lldb] Remove some unreachable code (NFC)

### DIFF
--- a/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
+++ b/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
@@ -459,7 +459,6 @@ public:
                 lldb::offset_t data_offset) override {
     // All we have to do is read the opcode which can be easy for some
     // architectures
-    bool got_op = false;
     DisassemblerScope disasm(*this);
     if (disasm) {
       const ArchSpec &arch = disasm->GetArchitecture();
@@ -475,37 +474,26 @@ public:
         switch (min_op_byte_size) {
         case 1:
           m_opcode.SetOpcode8(data.GetU8(&data_offset), byte_order);
-          got_op = true;
           break;
 
         case 2:
           m_opcode.SetOpcode16(data.GetU16(&data_offset), byte_order);
-          got_op = true;
           break;
 
         case 4:
           m_opcode.SetOpcode32(data.GetU32(&data_offset), byte_order);
-          got_op = true;
           break;
 
         case 8:
           m_opcode.SetOpcode64(data.GetU64(&data_offset), byte_order);
-          got_op = true;
           break;
 
         default:
-          if (arch.GetTriple().isRISCV())
-            m_opcode.SetOpcode16_32TupleBytes(
-                data.PeekData(data_offset, min_op_byte_size), min_op_byte_size,
-                byte_order);
-          else
-            m_opcode.SetOpcodeBytes(
-                data.PeekData(data_offset, min_op_byte_size), min_op_byte_size);
-          got_op = true;
+          m_opcode.SetOpcodeBytes(data.PeekData(data_offset, min_op_byte_size),
+                                  min_op_byte_size);
           break;
         }
-      }
-      if (!got_op) {
+      } else {
         bool is_alternate_isa = false;
         DisassemblerLLVMC::MCDisasmInstance *mc_disasm_ptr =
             GetDisasmToUse(is_alternate_isa, disasm);


### PR DESCRIPTION
`isRISCV()` check always returns false because we only get here if `min_op_byte_size` and `max_op_byte_size` are equal, which is not true for RISC-V.
Also, replase `if (!got_op)` check with an `else`. The check is equivalent to
`if (min_op_byte_size != max_op_byte_size)`, and the `if` above checks for the opposite condition.
