### PR TITLE
[clang-tidy] Add IgnoreMacros option to readability-redundant-member-init

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantMemberInitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantMemberInitCheck.cpp
@@ -33,9 +33,30 @@ getFullInitRangeInclWhitespaces(SourceRange Range, const SourceManager &SM,
       {PrevToken->getLocation(), Range.getEnd()}, SM, LangOpts);
 }
 
+namespace {
+// Matches a ``CXXConstructExpr`` whose written argument list (i.e. the
+// source text between the parentheses or braces) involves a macro.
+AST_MATCHER(CXXConstructExpr, initListContainsMacro) {
+  const SourceRange InitRange = Node.getParenOrBraceRange();
+  if (InitRange.isInvalid())
+    return false;
+  if (InitRange.getBegin().isMacroID() || InitRange.getEnd().isMacroID())
+    return true;
+  const ASTContext &Context = Finder->getASTContext();
+  const std::optional<Token> NextTok =
+      utils::lexer::findNextTokenSkippingComments(InitRange.getBegin(),
+                                                  Context.getSourceManager(),
+                                                  Context.getLangOpts());
+  if (!NextTok)
+    return true;
+  return NextTok->getLocation() != InitRange.getEnd();
+}
+} // namespace
+
 void RedundantMemberInitCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "IgnoreBaseInCopyConstructors",
                 IgnoreBaseInCopyConstructors);
+  Options.store(Opts, "IgnoreMacros", IgnoreMacros);
 }
 
 void RedundantMemberInitCheck::registerMatchers(MatchFinder *Finder) {
@@ -44,7 +65,11 @@ void RedundantMemberInitCheck::registerMatchers(MatchFinder *Finder) {
           argumentCountIs(0),
           hasDeclaration(cxxConstructorDecl(
               ofClass(cxxRecordDecl(unless(isTriviallyDefaultConstructible()))
-                          .bind("class")))))
+                          .bind("class")))),
+          IgnoreMacros
+              ? unless(initListContainsMacro())
+              : static_cast<ast_matchers::internal::Matcher<CXXConstructExpr>>(
+                    anything()))
           .bind("construct");
 
   auto HasUnionAsParent = hasParent(recordDecl(isUnion()));

--- a/clang-tools-extra/clang-tidy/readability/RedundantMemberInitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantMemberInitCheck.cpp
@@ -103,10 +103,12 @@ void RedundantMemberInitCheck::check(const MatchFinder::MatchResult &Result) {
 
   if (const auto *Field = Result.Nodes.getNodeAs<FieldDecl>("field")) {
     const Expr *Init = Field->getInClassInitializer();
-    diag(Construct->getExprLoc(), "initializer for member %0 is redundant")
-        << Field
-        << FixItHint::CreateRemoval(getFullInitRangeInclWhitespaces(
-               Init->getSourceRange(), *Result.SourceManager, getLangOpts()));
+    auto Diag =
+        diag(Construct->getExprLoc(), "initializer for member %0 is redundant")
+        << Field;
+    if (!Init->getBeginLoc().isMacroID() && !Init->getEndLoc().isMacroID())
+      Diag << FixItHint::CreateRemoval(getFullInitRangeInclWhitespaces(
+          Init->getSourceRange(), *Result.SourceManager, getLangOpts()));
     return;
   }
 

--- a/clang-tools-extra/clang-tidy/readability/RedundantMemberInitCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/RedundantMemberInitCheck.h
@@ -23,7 +23,8 @@ public:
   RedundantMemberInitCheck(StringRef Name, ClangTidyContext *Context)
       : ClangTidyCheck(Name, Context),
         IgnoreBaseInCopyConstructors(
-            Options.get("IgnoreBaseInCopyConstructors", false)) {}
+            Options.get("IgnoreBaseInCopyConstructors", false)),
+        IgnoreMacros(Options.getLocalOrGlobal("IgnoreMacros", false)) {}
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus;
   }
@@ -36,6 +37,7 @@ public:
 
 private:
   bool IgnoreBaseInCopyConstructors;
+  bool IgnoreMacros;
 };
 
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -442,6 +442,11 @@ Changes in existing checks
   positives on parameters used in dependent expressions (e.g. inside generic
   lambdas).
 
+- Improved :doc:`readability-redundant-member-init
+  <clang-tidy/checks/readability/redundant-member-init>` check by adding an
+  `IgnoreMacros` option to suppress warnings when the initializer involves
+  macros that may expand differently in other configurations.
+
 - Improved :doc:`readability-redundant-preprocessor
   <clang-tidy/checks/readability/redundant-preprocessor>` check by fixing a
   false positive for nested ``#if`` directives using different builtin

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-member-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-member-init.rst
@@ -24,6 +24,11 @@ Example
 Options
 -------
 
+.. option:: IgnoreMacros
+
+    When `true`, the check will ignore member initializations where the
+    initializer involves a macro expansion. Default is `false`.
+
 .. option:: IgnoreBaseInCopyConstructors
 
     Default is `false`.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-member-init-ignore-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-member-init-ignore-macros.cpp
@@ -1,0 +1,79 @@
+// RUN: %check_clang_tidy %s readability-redundant-member-init %t \
+// RUN:   -config="{CheckOptions: \
+// RUN:             {readability-redundant-member-init.IgnoreMacros: true}}"
+
+struct S {
+  S() = default;
+  S(int i) : i(i) {}
+  S(const char *s) : s(s) {}
+  int i = 1;
+  const char *s = nullptr;
+};
+
+#define BRACES {}
+#define EMPTY
+#define NUMBER 1
+#define NAME
+
+struct WithMacro1 {
+  S s BRACES;
+};
+
+struct WithMacro2 {
+  S s {EMPTY};
+};
+
+struct WithMacro3 {
+  S s {NUMBER};
+};
+
+struct WithMacro4 {
+  WithMacro4() : s(EMPTY) {};
+
+  S s;
+};
+
+struct WithMacro5 {
+  S s{NAME};
+};
+
+struct WithoutMacro {
+  S s {};
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: initializer for member 's' is redundant
+  // CHECK-FIXES: S s;
+};
+
+struct WithBlockCommentInInit {
+  S s {/* default-construct */};
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: initializer for member 's' is redundant
+  // CHECK-FIXES: S s;
+};
+
+struct WithCommentInCtorInit {
+  WithCommentInCtorInit() : s(/* default */) {};
+  // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: initializer for member 's' is redundant
+  // CHECK-FIXES: WithCommentInCtorInit() {};
+
+  S s;
+};
+struct WithCommentBeforeMacro {
+  S s {/* leading */ EMPTY};
+};
+
+struct WithCommentAfterMacro {
+  S s {EMPTY /* trailing */};
+};
+
+struct WithCommentAroundMacroCtor {
+  WithCommentAroundMacroCtor() : s(/* begin */ EMPTY /* end */) {};
+
+  S s;
+};
+
+struct WithoutMacroCtor {
+  WithoutMacroCtor() : s() {};
+  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: initializer for member 's' is redundant
+  // CHECK-FIXES: WithoutMacroCtor() {};
+
+  S s;
+};

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-member-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-member-init.cpp
@@ -318,3 +318,24 @@ struct D9 {
   D9() : ss(S()) {}
   SS ss;
 };
+
+#define EMPTY
+#define BRACES {}
+
+struct WithMacro1 {
+  S s BRACES;
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: initializer for member 's' is redundant
+};
+
+struct WithoutMacroCtor {
+  WithoutMacroCtor() : s(EMPTY) {};
+  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: initializer for member 's' is redundant
+  // CHECK-FIXES: WithoutMacroCtor()  {};
+  S s;
+};
+
+struct WithBlockCommentInInit {
+  S s {/* default-construct */};
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: initializer for member 's' is redundant
+  // CHECK-FIXES: S s;
+};

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-member-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-member-init.cpp
@@ -339,3 +339,24 @@ struct WithBlockCommentInInit {
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: initializer for member 's' is redundant
   // CHECK-FIXES: S s;
 };
+
+#define CTOR_INIT s(S())
+struct WithMacroCtorInit {
+  WithMacroCtorInit() : CTOR_INIT {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: initializer for member 's' is redundant
+  S s;
+};
+
+struct WithMacroBracesInCtorInit {
+  WithMacroBracesInCtorInit() : s BRACES {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: initializer for member 's' is redundant
+  // CHECK-FIXES: WithMacroBracesInCtorInit()  {}
+  S s;
+};
+
+#define MEMBER_NAME s
+struct WithMacroMemberName {
+  WithMacroMemberName() : MEMBER_NAME(S()) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: initializer for member 's' is redundant
+  S s;
+};


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/152024.