### PR TITLE
[clang-format] Update QtPropertyKeywords to Qt 6.11 documentation

### DIFF
--- a/clang/lib/Format/FormatToken.cpp
+++ b/clang/lib/Format/FormatToken.cpp
@@ -33,10 +33,10 @@ const char *getTokenTypeName(TokenType Type) {
   return nullptr;
 }
 
-static constexpr std::array<StringRef, 14> QtPropertyKeywords = {
-    "BINDABLE",   "CONSTANT", "DESIGNABLE", "FINAL", "MEMBER",
-    "NOTIFY",     "READ",     "REQUIRED",   "RESET", "REVISION",
-    "SCRIPTABLE", "STORED",   "USER",       "WRITE",
+static constexpr std::array<StringRef, 16> QtPropertyKeywords = {
+    "BINDABLE", "CONSTANT", "DESIGNABLE", "FINAL", "MEMBER",   "NOTIFY",
+    "OVERRIDE", "READ",     "REQUIRED",   "RESET", "REVISION", "SCRIPTABLE",
+    "STORED",   "USER",     "VIRTUAL",    "WRITE",
 };
 
 bool FormatToken::isQtProperty() const {


### PR DESCRIPTION
Qt 6.11 added `OVERRIDE` and `VIRTUAL` keywords to the [property system](https://doc.qt.io/qt-6.11/properties.html).