### PR TITLE
[NFC] clean up some todos around computeConstantRange

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -9936,10 +9936,12 @@ std::optional<bool> llvm::isImpliedByDomCondition(CmpPredicate Pred,
   return std::nullopt;
 }
 
-static void setLimitsForBinOp(const BinaryOperator &BO, APInt &Lower,
-                              APInt &Upper, const InstrInfoQuery &IIQ,
-                              bool PreferSignedRange) {
-  unsigned Width = Lower.getBitWidth();
+static ConstantRange getRangeForBinOp(const BinaryOperator &BO,
+                                      const InstrInfoQuery &IIQ,
+                                      bool PreferSignedRange) {
+  unsigned Width = BO.getType()->getScalarSizeInBits();
+  APInt Lower(Width, 0);
+  APInt Upper(Width, 0);
   const APInt *C;
   switch (BO.getOpcode()) {
   case Instruction::Sub:
@@ -10159,6 +10161,7 @@ static void setLimitsForBinOp(const BinaryOperator &BO, APInt &Lower,
   default:
     break;
   }
+  return ConstantRange::getNonEmpty(Lower, Upper);
 }
 
 static ConstantRange getRangeForIntrinsic(const IntrinsicInst &II,
@@ -10321,12 +10324,14 @@ static ConstantRange getRangeForSelectPattern(const SelectInst &SI,
   }
 }
 
-static void setLimitForFPToI(const Instruction *I, APInt &Lower, APInt &Upper) {
+static ConstantRange getRangeForFPToI(const Instruction *I) {
   // The maximum representable value of a half is 65504. For floats the maximum
   // value is 3.4e38 which requires roughly 129 bits.
   unsigned BitWidth = I->getType()->getScalarSizeInBits();
   if (!I->getOperand(0)->getType()->getScalarType()->isHalfTy())
-    return;
+    return ConstantRange::getFull(BitWidth);
+  APInt Lower(BitWidth, 0);
+  APInt Upper(BitWidth, 0);
   if (isa<FPToSIInst>(I) && BitWidth >= 17) {
     Lower = APInt(BitWidth, -65504, true);
     Upper = APInt(BitWidth, 65505);
@@ -10336,6 +10341,7 @@ static void setLimitForFPToI(const Instruction *I, APInt &Lower, APInt &Upper) {
     // For a fptoui the lower limit is left as 0.
     Upper = APInt(BitWidth, 65505);
   }
+  return ConstantRange::getNonEmpty(Lower, Upper);
 }
 
 ConstantRange llvm::computeConstantRange(const Value *V, bool ForSigned,
@@ -10354,13 +10360,9 @@ ConstantRange llvm::computeConstantRange(const Value *V, bool ForSigned,
   unsigned BitWidth = V->getType()->getScalarSizeInBits();
   InstrInfoQuery IIQ(UseInstrInfo);
   ConstantRange CR = ConstantRange::getFull(BitWidth);
-  if (auto *BO = dyn_cast<BinaryOperator>(V)) {
-    APInt Lower = APInt(BitWidth, 0);
-    APInt Upper = APInt(BitWidth, 0);
-    // TODO: Return ConstantRange.
-    setLimitsForBinOp(*BO, Lower, Upper, IIQ, ForSigned);
-    CR = ConstantRange::getNonEmpty(Lower, Upper);
-  } else if (auto *II = dyn_cast<IntrinsicInst>(V))
+  if (auto *BO = dyn_cast<BinaryOperator>(V))
+    CR = getRangeForBinOp(*BO, IIQ, ForSigned);
+  else if (auto *II = dyn_cast<IntrinsicInst>(V))
     CR = getRangeForIntrinsic(*II, UseInstrInfo);
   else if (auto *SI = dyn_cast<SelectInst>(V)) {
     ConstantRange CRTrue = computeConstantRange(
@@ -10369,13 +10371,9 @@ ConstantRange llvm::computeConstantRange(const Value *V, bool ForSigned,
         SI->getFalseValue(), ForSigned, UseInstrInfo, AC, CtxI, DT, Depth + 1);
     CR = CRTrue.unionWith(CRFalse);
     CR = CR.intersectWith(getRangeForSelectPattern(*SI, IIQ));
-  } else if (isa<FPToUIInst>(V) || isa<FPToSIInst>(V)) {
-    APInt Lower = APInt(BitWidth, 0);
-    APInt Upper = APInt(BitWidth, 0);
-    // TODO: Return ConstantRange.
-    setLimitForFPToI(cast<Instruction>(V), Lower, Upper);
-    CR = ConstantRange::getNonEmpty(Lower, Upper);
-  } else if (const auto *A = dyn_cast<Argument>(V))
+  } else if (isa<FPToUIInst>(V) || isa<FPToSIInst>(V))
+    CR = getRangeForFPToI(cast<Instruction>(V));
+  else if (const auto *A = dyn_cast<Argument>(V))
     if (std::optional<ConstantRange> Range = A->getRange())
       CR = *Range;
 


### PR DESCRIPTION
This PR cleans up some todos found in `getRangeForFPToI` and `getRangeForBinOp` I found while poking around `computeConstantRange`. 