### PR TITLE
[clang][analyzer] Fix alignment of entries in -analyzer-help

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/AnalyzerOptions.cpp
+++ b/clang/lib/StaticAnalyzer/Core/AnalyzerOptions.cpp
@@ -37,9 +37,14 @@ void AnalyzerOptions::printFormattedEntry(
 
   const size_t PadForDesc = InitialPad + EntryWidth;
 
-  FOut.PadToColumn(InitialPad) << EntryDescPair.first;
-  // If the buffer's length is greater than PadForDesc, print a newline.
-  if (FOut.getColumn() > PadForDesc)
+  if (InitialPad != 0)
+    FOut.PadToColumn(InitialPad);
+
+  FOut << EntryDescPair.first;
+
+  // If the buffer's length is greater than or equal to PadForDesc,
+  // print a newline.
+  if (FOut.getColumn() >= PadForDesc)
     FOut << '\n';
 
   FOut.PadToColumn(PadForDesc);

--- a/clang/unittests/StaticAnalyzer/AnalyzerFormattingTest.cpp
+++ b/clang/unittests/StaticAnalyzer/AnalyzerFormattingTest.cpp
@@ -70,6 +70,23 @@ TEST(PrintFormattedEntryTest, ExactFillWidth) {
                     "        A description");
 }
 
+// With wrapping after checker's name.
+// With initial pad.
+// Corner case, when checker's name length equal to EntryWidth.
+// This test matches how printFormattedEntry was called
+// in -analyzer-checker-help, which led to a formatting bug.
+TEST(PrintFormattedEntryTest, ExactFillWidthWithInitialPad) {
+  llvm::SmallString<256> Buffer;
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", "A description"},
+                         /*InitialPad=*/2,
+                         /*EntryWidth=*/8,
+                         /*MinLineWidth=*/0,
+                         /*OutBuffer=*/Buffer);
+
+  EXPECT_EQ(Buffer, "  Checkers\n"
+                    "          A description");
+}
+
 // No wrapping after checker's name.
 // With initial pad.
 TEST(PrintFormattedEntryTest, WithInitialPadding) {

--- a/clang/unittests/StaticAnalyzer/AnalyzerFormattingTest.cpp
+++ b/clang/unittests/StaticAnalyzer/AnalyzerFormattingTest.cpp
@@ -105,7 +105,7 @@ TEST(PrintFormattedEntryTest, WrapDescription) {
 
 // No wrapping after checker's name.
 // With initial pad.
-// No wrapping in checker's descriptions (MinLineWdth = 0).
+// No wrapping in checker's descriptions (MinLineWidth = 0).
 TEST(PrintFormattedEntryTest, NoWrap) {
   llvm::SmallString<256> Buffer;
   llvm::StringRef Desc = "This is a very long description that will not be "

--- a/clang/unittests/StaticAnalyzer/AnalyzerFormattingTest.cpp
+++ b/clang/unittests/StaticAnalyzer/AnalyzerFormattingTest.cpp
@@ -15,27 +15,29 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/raw_ostream.h"
 #include "gtest/gtest.h"
+#include <string>
 
 using namespace clang::ento;
 
-static void runPrintFormattedEntry(
+static std::string runPrintFormattedEntry(
     std::pair<llvm::StringRef, llvm::StringRef> EntryDescPair,
-    size_t InitialPad, size_t EntryWidth, size_t MinLineWidth,
-    llvm::SmallString<256> &OutBuffer) {
-  llvm::raw_svector_ostream Out(OutBuffer);
+    size_t InitialPad, size_t EntryWidth, size_t MinLineWidth) {
+
+  std::string OutBuffer;
+  llvm::raw_string_ostream Out(OutBuffer);
   clang::AnalyzerOptions::printFormattedEntry(Out, EntryDescPair, InitialPad,
                                               EntryWidth, MinLineWidth);
+  return OutBuffer;
 }
 
 // No wrapping after checker's name.
 // No initial pad.
 TEST(PrintFormattedEntryTest, SimplePrint) {
-  llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "A description"},
-                         /*InitialPad=*/0,
-                         /*EntryWidth=*/20,
-                         /*MinLineWidth=*/0,
-                         /*OutBuffer=*/Buffer);
+  std::string Buffer =
+      runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "A description"},
+                             /*InitialPad=*/0,
+                             /*EntryWidth=*/20,
+                             /*MinLineWidth=*/0);
 
   EXPECT_EQ(Buffer, "Checker             A description");
 }
@@ -43,13 +45,11 @@ TEST(PrintFormattedEntryTest, SimplePrint) {
 // With wrapping after checker's name.
 // No initial pad.
 TEST(PrintFormattedEntryTest, EntryLongerThanWidth) {
-  llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(
+  std::string Buffer = runPrintFormattedEntry(
       {/*EntryDescPair=*/"VeryLongCheckerName", "A description"},
       /*InitialPad=*/0,
       /*EntryWidth=*/10,
-      /*MinLineWidth=*/0,
-      /*OutBuffer=*/Buffer);
+      /*MinLineWidth=*/0);
 
   EXPECT_EQ(Buffer, "VeryLongCheckerName\n"
                     "          A description");
@@ -59,12 +59,11 @@ TEST(PrintFormattedEntryTest, EntryLongerThanWidth) {
 // No initial pad.
 // Corner case, when checker's name length equal to EntryWidth.
 TEST(PrintFormattedEntryTest, ExactFillWidth) {
-  llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "A description"},
-                         /*InitialPad=*/0,
-                         /*EntryWidth=*/7,
-                         /*MinLineWidth=*/0,
-                         /*OutBuffer=*/Buffer);
+  std::string Buffer =
+      runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "A description"},
+                             /*InitialPad=*/0,
+                             /*EntryWidth=*/7,
+                             /*MinLineWidth=*/0);
 
   EXPECT_EQ(Buffer, "Checker\n"
                     "       A description");
@@ -76,12 +75,11 @@ TEST(PrintFormattedEntryTest, ExactFillWidth) {
 // This test matches how printFormattedEntry was called
 // in -analyzer-checker-help, which led to a formatting bug.
 TEST(PrintFormattedEntryTest, ExactFillWidthWithInitialPad) {
-  llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "A description"},
-                         /*InitialPad=*/2,
-                         /*EntryWidth=*/7,
-                         /*MinLineWidth=*/0,
-                         /*OutBuffer=*/Buffer);
+  std::string Buffer =
+      runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "A description"},
+                             /*InitialPad=*/2,
+                             /*EntryWidth=*/7,
+                             /*MinLineWidth=*/0);
 
   EXPECT_EQ(Buffer, "  Checker\n"
                     "         A description");
@@ -90,12 +88,11 @@ TEST(PrintFormattedEntryTest, ExactFillWidthWithInitialPad) {
 // No wrapping after checker's name.
 // With initial pad.
 TEST(PrintFormattedEntryTest, WithInitialPadding) {
-  llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "A description"},
-                         /*InitialPad=*/2,
-                         /*EntryWidth=*/20,
-                         /*MinLineWidth=*/0,
-                         /*OutBuffer=*/Buffer);
+  std::string Buffer =
+      runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "A description"},
+                             /*InitialPad=*/2,
+                             /*EntryWidth=*/20,
+                             /*MinLineWidth=*/0);
 
   EXPECT_EQ(Buffer, "  Checker             A description");
 }
@@ -104,19 +101,18 @@ TEST(PrintFormattedEntryTest, WithInitialPadding) {
 // With initial pad.
 // With wrapping in checker's description (MinLineWidth > 0).
 TEST(PrintFormattedEntryTest, WrapDescription) {
-  llvm::SmallString<256> Buffer;
-  llvm::StringRef Desc =
+  std::string Desc =
       "This is a long description that should be wrapped into multiple lines.";
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", Desc},
-                         /*InitialPad=*/2,
-                         /*EntryWidth=*/20,
-                         /*MinLineWidth=*/40,
-                         /*OutBuffer=*/Buffer);
 
-  llvm::StringRef Expected =
-      "  Checker             This is a long description\n"
-      "                      that should be wrapped\n"
-      "                      into multiple lines.";
+  std::string Buffer =
+      runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", Desc},
+                             /*InitialPad=*/2,
+                             /*EntryWidth=*/20,
+                             /*MinLineWidth=*/40);
+
+  std::string Expected = "  Checker             This is a long description\n"
+                         "                      that should be wrapped\n"
+                         "                      into multiple lines.";
   EXPECT_EQ(Buffer, Expected);
 }
 
@@ -124,16 +120,16 @@ TEST(PrintFormattedEntryTest, WrapDescription) {
 // With initial pad.
 // No wrapping in checker's descriptions (MinLineWidth = 0).
 TEST(PrintFormattedEntryTest, NoWrap) {
-  llvm::SmallString<256> Buffer;
-  llvm::StringRef Desc = "This is a very long description that will not be "
-                         "wrapped because MinLineWidth=0.";
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", Desc},
-                         /*InitialPad=*/2,
-                         /*EntryWidth=*/20,
-                         /*MinLineWidth=*/0,
-                         /*OutBuffer=*/Buffer);
+  std::string Desc = "This is a very long description that will not be "
+                     "wrapped because MinLineWidth=0.";
 
-  std::string Expected = "  Checker             " + Desc.str();
+  std::string Buffer =
+      runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", Desc},
+                             /*InitialPad=*/2,
+                             /*EntryWidth=*/20,
+                             /*MinLineWidth=*/0);
+
+  std::string Expected = "  Checker             " + Desc;
   EXPECT_EQ(Buffer, Expected);
 }
 
@@ -141,12 +137,10 @@ TEST(PrintFormattedEntryTest, NoWrap) {
 // No initial pad.
 // Corner case with empty descriptions.
 TEST(PrintFormattedEntryTest, EmptyDescription) {
-  llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", ""},
-                         /*InitialPad=*/0,
-                         /*EntryWidth=*/20,
-                         /*MinLineWidth=*/0,
-                         /*OutBuffer=*/Buffer);
+  std::string Buffer = runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", ""},
+                                              /*InitialPad=*/0,
+                                              /*EntryWidth=*/20,
+                                              /*MinLineWidth=*/0);
 
   EXPECT_EQ(Buffer, "Checker             ");
 }
@@ -155,12 +149,11 @@ TEST(PrintFormattedEntryTest, EmptyDescription) {
 // No initial pad.
 // Corner case with empty checker's name.
 TEST(PrintFormattedEntryTest, EmptyEntry) {
-  llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(/*EntryDescPair=*/{"", "Some description"},
-                         /*InitialPad=*/0,
-                         /*EntryWidth=*/20,
-                         /*MinLineWidth=*/0,
-                         /*OutBuffer=*/Buffer);
+  std::string Buffer =
+      runPrintFormattedEntry(/*EntryDescPair=*/{"", "Some description"},
+                             /*InitialPad=*/0,
+                             /*EntryWidth=*/20,
+                             /*MinLineWidth=*/0);
 
   EXPECT_EQ(Buffer, "                    Some description");
 }
@@ -169,13 +162,11 @@ TEST(PrintFormattedEntryTest, EmptyEntry) {
 // With initial pad.
 // Narrow MinLineWidth with a word without spaces (no break).
 TEST(PrintFormattedEntryTest, NarrowMinLineWidthNoSpaces) {
-  llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(
+  std::string Buffer = runPrintFormattedEntry(
       /*EntryDescPair=*/{"Checker", "This_is_a_long_word_without_spaces"},
       /*InitialPad=*/2,
       /*EntryWidth=*/20,
-      /*MinLineWidth=*/10,
-      /*OutBuffer=*/Buffer);
+      /*MinLineWidth=*/10);
 
   EXPECT_EQ(Buffer, "  Checker             This_is_a_long_word_without_spaces");
 }
@@ -184,12 +175,11 @@ TEST(PrintFormattedEntryTest, NarrowMinLineWidthNoSpaces) {
 // With initial pad.
 // With wrapping in checker's description.
 TEST(PrintFormattedEntryTest, MinLineWidthLessThanPad) {
-  llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "short phrase"},
-                         /*InitialPad=*/2,
-                         /*EntryWidth=*/20,
-                         /*MinLineWidth=*/15,
-                         /*OutBuffer=*/Buffer);
+  std::string Buffer =
+      runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "short phrase"},
+                             /*InitialPad=*/2,
+                             /*EntryWidth=*/20,
+                             /*MinLineWidth=*/15);
 
   llvm::StringRef Expected = "  Checker             short\n"
                              "                      phrase";

--- a/clang/unittests/StaticAnalyzer/AnalyzerFormattingTest.cpp
+++ b/clang/unittests/StaticAnalyzer/AnalyzerFormattingTest.cpp
@@ -31,13 +31,13 @@ static void runPrintFormattedEntry(
 // No initial pad.
 TEST(PrintFormattedEntryTest, SimplePrint) {
   llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", "A description"},
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "A description"},
                          /*InitialPad=*/0,
                          /*EntryWidth=*/20,
                          /*MinLineWidth=*/0,
                          /*OutBuffer=*/Buffer);
 
-  EXPECT_EQ(Buffer, "Checkers            A description");
+  EXPECT_EQ(Buffer, "Checker             A description");
 }
 
 // With wrapping after checker's name.
@@ -60,14 +60,14 @@ TEST(PrintFormattedEntryTest, EntryLongerThanWidth) {
 // Corner case, when checker's name length equal to EntryWidth.
 TEST(PrintFormattedEntryTest, ExactFillWidth) {
   llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", "A description"},
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "A description"},
                          /*InitialPad=*/0,
-                         /*EntryWidth=*/8,
+                         /*EntryWidth=*/7,
                          /*MinLineWidth=*/0,
                          /*OutBuffer=*/Buffer);
 
-  EXPECT_EQ(Buffer, "Checkers\n"
-                    "        A description");
+  EXPECT_EQ(Buffer, "Checker\n"
+                    "       A description");
 }
 
 // With wrapping after checker's name.
@@ -77,27 +77,27 @@ TEST(PrintFormattedEntryTest, ExactFillWidth) {
 // in -analyzer-checker-help, which led to a formatting bug.
 TEST(PrintFormattedEntryTest, ExactFillWidthWithInitialPad) {
   llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", "A description"},
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "A description"},
                          /*InitialPad=*/2,
-                         /*EntryWidth=*/8,
+                         /*EntryWidth=*/7,
                          /*MinLineWidth=*/0,
                          /*OutBuffer=*/Buffer);
 
-  EXPECT_EQ(Buffer, "  Checkers\n"
-                    "          A description");
+  EXPECT_EQ(Buffer, "  Checker\n"
+                    "         A description");
 }
 
 // No wrapping after checker's name.
 // With initial pad.
 TEST(PrintFormattedEntryTest, WithInitialPadding) {
   llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", "A description"},
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "A description"},
                          /*InitialPad=*/2,
                          /*EntryWidth=*/20,
                          /*MinLineWidth=*/0,
                          /*OutBuffer=*/Buffer);
 
-  EXPECT_EQ(Buffer, "  Checkers            A description");
+  EXPECT_EQ(Buffer, "  Checker             A description");
 }
 
 // No wrapping after checker's name.
@@ -107,14 +107,14 @@ TEST(PrintFormattedEntryTest, WrapDescription) {
   llvm::SmallString<256> Buffer;
   llvm::StringRef Desc =
       "This is a long description that should be wrapped into multiple lines.";
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", Desc},
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", Desc},
                          /*InitialPad=*/2,
                          /*EntryWidth=*/20,
                          /*MinLineWidth=*/40,
                          /*OutBuffer=*/Buffer);
 
   llvm::StringRef Expected =
-      "  Checkers            This is a long description\n"
+      "  Checker             This is a long description\n"
       "                      that should be wrapped\n"
       "                      into multiple lines.";
   EXPECT_EQ(Buffer, Expected);
@@ -127,13 +127,13 @@ TEST(PrintFormattedEntryTest, NoWrap) {
   llvm::SmallString<256> Buffer;
   llvm::StringRef Desc = "This is a very long description that will not be "
                          "wrapped because MinLineWidth=0.";
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", Desc},
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", Desc},
                          /*InitialPad=*/2,
                          /*EntryWidth=*/20,
                          /*MinLineWidth=*/0,
                          /*OutBuffer=*/Buffer);
 
-  std::string Expected = "  Checkers            " + Desc.str();
+  std::string Expected = "  Checker             " + Desc.str();
   EXPECT_EQ(Buffer, Expected);
 }
 
@@ -142,13 +142,13 @@ TEST(PrintFormattedEntryTest, NoWrap) {
 // Corner case with empty descriptions.
 TEST(PrintFormattedEntryTest, EmptyDescription) {
   llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", ""},
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", ""},
                          /*InitialPad=*/0,
                          /*EntryWidth=*/20,
                          /*MinLineWidth=*/0,
                          /*OutBuffer=*/Buffer);
 
-  EXPECT_EQ(Buffer, "Checkers            ");
+  EXPECT_EQ(Buffer, "Checker             ");
 }
 
 // No wrapping after checker's name.
@@ -171,13 +171,13 @@ TEST(PrintFormattedEntryTest, EmptyEntry) {
 TEST(PrintFormattedEntryTest, NarrowMinLineWidthNoSpaces) {
   llvm::SmallString<256> Buffer;
   runPrintFormattedEntry(
-      /*EntryDescPair=*/{"Checkers", "This_is_a_long_word_without_spaces"},
+      /*EntryDescPair=*/{"Checker", "This_is_a_long_word_without_spaces"},
       /*InitialPad=*/2,
       /*EntryWidth=*/20,
       /*MinLineWidth=*/10,
       /*OutBuffer=*/Buffer);
 
-  EXPECT_EQ(Buffer, "  Checkers            This_is_a_long_word_without_spaces");
+  EXPECT_EQ(Buffer, "  Checker             This_is_a_long_word_without_spaces");
 }
 
 // No wrapping after checker's name.
@@ -185,13 +185,13 @@ TEST(PrintFormattedEntryTest, NarrowMinLineWidthNoSpaces) {
 // With wrapping in checker's description.
 TEST(PrintFormattedEntryTest, MinLineWidthLessThanPad) {
   llvm::SmallString<256> Buffer;
-  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", "short phrase"},
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checker", "short phrase"},
                          /*InitialPad=*/2,
                          /*EntryWidth=*/20,
                          /*MinLineWidth=*/15,
                          /*OutBuffer=*/Buffer);
 
-  llvm::StringRef Expected = "  Checkers            short\n"
+  llvm::StringRef Expected = "  Checker             short\n"
                              "                      phrase";
   EXPECT_EQ(Buffer, Expected);
 }

--- a/clang/unittests/StaticAnalyzer/AnalyzerFormattingTest.cpp
+++ b/clang/unittests/StaticAnalyzer/AnalyzerFormattingTest.cpp
@@ -1,0 +1,180 @@
+//===- AnalyzerFormattingTest.cpp - SA Formatting test --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains tests for printFormattedEntry function, which is used for
+// printing available analyzers and their descriptions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/StaticAnalyzer/Core/AnalyzerOptions.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/raw_ostream.h"
+#include "gtest/gtest.h"
+
+using namespace clang::ento;
+
+static void runPrintFormattedEntry(
+    std::pair<llvm::StringRef, llvm::StringRef> EntryDescPair,
+    size_t InitialPad, size_t EntryWidth, size_t MinLineWidth,
+    llvm::SmallString<256> &OutBuffer) {
+  llvm::raw_svector_ostream Out(OutBuffer);
+  clang::AnalyzerOptions::printFormattedEntry(Out, EntryDescPair, InitialPad,
+                                              EntryWidth, MinLineWidth);
+}
+
+// No wrapping after checker's name.
+// No initial pad.
+TEST(PrintFormattedEntryTest, SimplePrint) {
+  llvm::SmallString<256> Buffer;
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", "A description"},
+                         /*InitialPad=*/0,
+                         /*EntryWidth=*/20,
+                         /*MinLineWidth=*/0,
+                         /*OutBuffer=*/Buffer);
+
+  EXPECT_EQ(Buffer, "Checkers            A description");
+}
+
+// With wrapping after checker's name.
+// No initial pad.
+TEST(PrintFormattedEntryTest, EntryLongerThanWidth) {
+  llvm::SmallString<256> Buffer;
+  runPrintFormattedEntry(
+      {/*EntryDescPair=*/"VeryLongCheckerName", "A description"},
+      /*InitialPad=*/0,
+      /*EntryWidth=*/10,
+      /*MinLineWidth=*/0,
+      /*OutBuffer=*/Buffer);
+
+  EXPECT_EQ(Buffer, "VeryLongCheckerName\n"
+                    "          A description");
+}
+
+// With wrapping after checker's name.
+// No initial pad.
+// Corner case, when checker's name length equal to EntryWidth.
+TEST(PrintFormattedEntryTest, ExactFillWidth) {
+  llvm::SmallString<256> Buffer;
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", "A description"},
+                         /*InitialPad=*/0,
+                         /*EntryWidth=*/8,
+                         /*MinLineWidth=*/0,
+                         /*OutBuffer=*/Buffer);
+
+  EXPECT_EQ(Buffer, "Checkers\n"
+                    "        A description");
+}
+
+// No wrapping after checker's name.
+// With initial pad.
+TEST(PrintFormattedEntryTest, WithInitialPadding) {
+  llvm::SmallString<256> Buffer;
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", "A description"},
+                         /*InitialPad=*/2,
+                         /*EntryWidth=*/20,
+                         /*MinLineWidth=*/0,
+                         /*OutBuffer=*/Buffer);
+
+  EXPECT_EQ(Buffer, "  Checkers            A description");
+}
+
+// No wrapping after checker's name.
+// With initial pad.
+// With wrapping in checker's description (MinLineWidth > 0).
+TEST(PrintFormattedEntryTest, WrapDescription) {
+  llvm::SmallString<256> Buffer;
+  llvm::StringRef Desc =
+      "This is a long description that should be wrapped into multiple lines.";
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", Desc},
+                         /*InitialPad=*/2,
+                         /*EntryWidth=*/20,
+                         /*MinLineWidth=*/40,
+                         /*OutBuffer=*/Buffer);
+
+  llvm::StringRef Expected =
+      "  Checkers            This is a long description\n"
+      "                      that should be wrapped\n"
+      "                      into multiple lines.";
+  EXPECT_EQ(Buffer, Expected);
+}
+
+// No wrapping after checker's name.
+// With initial pad.
+// No wrapping in checker's descriptions (MinLineWdth = 0).
+TEST(PrintFormattedEntryTest, NoWrap) {
+  llvm::SmallString<256> Buffer;
+  llvm::StringRef Desc = "This is a very long description that will not be "
+                         "wrapped because MinLineWidth=0.";
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", Desc},
+                         /*InitialPad=*/2,
+                         /*EntryWidth=*/20,
+                         /*MinLineWidth=*/0,
+                         /*OutBuffer=*/Buffer);
+
+  std::string Expected = "  Checkers            " + Desc.str();
+  EXPECT_EQ(Buffer, Expected);
+}
+
+// No wrapping after checker's name.
+// No initial pad.
+// Corner case with empty descriptions.
+TEST(PrintFormattedEntryTest, EmptyDescription) {
+  llvm::SmallString<256> Buffer;
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", ""},
+                         /*InitialPad=*/0,
+                         /*EntryWidth=*/20,
+                         /*MinLineWidth=*/0,
+                         /*OutBuffer=*/Buffer);
+
+  EXPECT_EQ(Buffer, "Checkers            ");
+}
+
+// No wrapping after checker's name.
+// No initial pad.
+// Corner case with empty checker's name.
+TEST(PrintFormattedEntryTest, EmptyEntry) {
+  llvm::SmallString<256> Buffer;
+  runPrintFormattedEntry(/*EntryDescPair=*/{"", "Some description"},
+                         /*InitialPad=*/0,
+                         /*EntryWidth=*/20,
+                         /*MinLineWidth=*/0,
+                         /*OutBuffer=*/Buffer);
+
+  EXPECT_EQ(Buffer, "                    Some description");
+}
+
+// No wrapping after checker's name.
+// With initial pad.
+// Narrow MinLineWidth with a word without spaces (no break).
+TEST(PrintFormattedEntryTest, NarrowMinLineWidthNoSpaces) {
+  llvm::SmallString<256> Buffer;
+  runPrintFormattedEntry(
+      /*EntryDescPair=*/{"Checkers", "This_is_a_long_word_without_spaces"},
+      /*InitialPad=*/2,
+      /*EntryWidth=*/20,
+      /*MinLineWidth=*/10,
+      /*OutBuffer=*/Buffer);
+
+  EXPECT_EQ(Buffer, "  Checkers            This_is_a_long_word_without_spaces");
+}
+
+// No wrapping after checker's name.
+// With initial pad.
+// With wrapping in checker's description.
+TEST(PrintFormattedEntryTest, MinLineWidthLessThanPad) {
+  llvm::SmallString<256> Buffer;
+  runPrintFormattedEntry(/*EntryDescPair=*/{"Checkers", "short phrase"},
+                         /*InitialPad=*/2,
+                         /*EntryWidth=*/20,
+                         /*MinLineWidth=*/15,
+                         /*OutBuffer=*/Buffer);
+
+  llvm::StringRef Expected = "  Checkers            short\n"
+                             "                      phrase";
+  EXPECT_EQ(Buffer, Expected);
+}

--- a/clang/unittests/StaticAnalyzer/CMakeLists.txt
+++ b/clang/unittests/StaticAnalyzer/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_clang_unittest(StaticAnalysisTests
+  AnalyzerFormattingTest.cpp
   AnalyzerOptionsTest.cpp
   APSIntTypeTest.cpp
   BlockEntranceCallbackTest.cpp


### PR DESCRIPTION
Fix a formatting bug in `AnalyzerOptions::printFormattedEntry` (used by `clang -cc1 -print-analyzer-options`), which led to misalignment of a checker description. It happened when a checker name was exactly `EntryWidth` — a redundant space was inserted.

**Before the fix (misaligned entry is underlined with a red line):**
<img width="2205" height="729" alt="image" src="https://github.com/user-attachments/assets/74df3791-37ea-4522-b052-0925136c080c" />

# Changes
This small PR fixes issues with alignment in `AnalyzerOptions::printFormattedEntry`:
- Make `printFormattedEntry` correctly handle the corner case, when a checker's name equals exactly `EntryWidth` (as shown in the "Before the fix" image). I replaced `<` with `<=` to insert `'\n'` in the corner case.
- Make `printFormattedEntry` correctly handle corner case, when pad before checker's name (specified by `InitialPad`) equals 0. Before the fix, due to `llvm::raw_formatted_ostream::PadToColumn` logic, when `InitialPad = 0`, it still pads to 1. Since `InitialPad = 0` is never used in the program, this bug is not visible to the user. I added a test that explicitly checks for this. 
- I believe that the easiest way to check for these behaviours is by leveraging the unittest system. I could instead write the usual test to check for exact formatting of `-print-analyzer-options`, but I thought that it would be too fragile. 

**After the fix (now underlined entry aligned correctly):**
<img width="2187" height="757" alt="image" src="https://github.com/user-attachments/assets/6896c386-8525-4bc8-a032-9833699cfccf" />

What do you think about the changes? I am happy to answer any questions or make adjustments.