### PR TITLE
Add extra handling to compute constant range

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -9936,10 +9936,12 @@ std::optional<bool> llvm::isImpliedByDomCondition(CmpPredicate Pred,
   return std::nullopt;
 }
 
-static void setLimitsForBinOp(const BinaryOperator &BO, APInt &Lower,
-                              APInt &Upper, const InstrInfoQuery &IIQ,
-                              bool PreferSignedRange) {
-  unsigned Width = Lower.getBitWidth();
+static ConstantRange getRangeForBinOp(const BinaryOperator &BO,
+                                      const InstrInfoQuery &IIQ,
+                                      bool PreferSignedRange) {
+  unsigned Width = BO.getType()->getScalarSizeInBits();
+  APInt Lower(Width, 0);
+  APInt Upper(Width, 0);
   const APInt *C;
   switch (BO.getOpcode()) {
   case Instruction::Sub:
@@ -10159,6 +10161,7 @@ static void setLimitsForBinOp(const BinaryOperator &BO, APInt &Lower,
   default:
     break;
   }
+  return ConstantRange::getNonEmpty(Lower, Upper);
 }
 
 static ConstantRange getRangeForIntrinsic(const IntrinsicInst &II,
@@ -10321,12 +10324,14 @@ static ConstantRange getRangeForSelectPattern(const SelectInst &SI,
   }
 }
 
-static void setLimitForFPToI(const Instruction *I, APInt &Lower, APInt &Upper) {
+static ConstantRange getRangeForFPToI(const Instruction *I) {
   // The maximum representable value of a half is 65504. For floats the maximum
   // value is 3.4e38 which requires roughly 129 bits.
   unsigned BitWidth = I->getType()->getScalarSizeInBits();
   if (!I->getOperand(0)->getType()->getScalarType()->isHalfTy())
-    return;
+    return ConstantRange::getFull(BitWidth);
+  APInt Lower(BitWidth, 0);
+  APInt Upper(BitWidth, 0);
   if (isa<FPToSIInst>(I) && BitWidth >= 17) {
     Lower = APInt(BitWidth, -65504, true);
     Upper = APInt(BitWidth, 65505);
@@ -10336,6 +10341,7 @@ static void setLimitForFPToI(const Instruction *I, APInt &Lower, APInt &Upper) {
     // For a fptoui the lower limit is left as 0.
     Upper = APInt(BitWidth, 65505);
   }
+  return ConstantRange::getNonEmpty(Lower, Upper);
 }
 
 ConstantRange llvm::computeConstantRange(const Value *V, bool ForSigned,
@@ -10354,13 +10360,9 @@ ConstantRange llvm::computeConstantRange(const Value *V, bool ForSigned,
   unsigned BitWidth = V->getType()->getScalarSizeInBits();
   InstrInfoQuery IIQ(UseInstrInfo);
   ConstantRange CR = ConstantRange::getFull(BitWidth);
-  if (auto *BO = dyn_cast<BinaryOperator>(V)) {
-    APInt Lower = APInt(BitWidth, 0);
-    APInt Upper = APInt(BitWidth, 0);
-    // TODO: Return ConstantRange.
-    setLimitsForBinOp(*BO, Lower, Upper, IIQ, ForSigned);
-    CR = ConstantRange::getNonEmpty(Lower, Upper);
-  } else if (auto *II = dyn_cast<IntrinsicInst>(V))
+  if (auto *BO = dyn_cast<BinaryOperator>(V))
+    CR = getRangeForBinOp(*BO, IIQ, ForSigned);
+  else if (auto *II = dyn_cast<IntrinsicInst>(V))
     CR = getRangeForIntrinsic(*II, UseInstrInfo);
   else if (auto *SI = dyn_cast<SelectInst>(V)) {
     ConstantRange CRTrue = computeConstantRange(
@@ -10369,13 +10371,9 @@ ConstantRange llvm::computeConstantRange(const Value *V, bool ForSigned,
         SI->getFalseValue(), ForSigned, UseInstrInfo, AC, CtxI, DT, Depth + 1);
     CR = CRTrue.unionWith(CRFalse);
     CR = CR.intersectWith(getRangeForSelectPattern(*SI, IIQ));
-  } else if (isa<FPToUIInst>(V) || isa<FPToSIInst>(V)) {
-    APInt Lower = APInt(BitWidth, 0);
-    APInt Upper = APInt(BitWidth, 0);
-    // TODO: Return ConstantRange.
-    setLimitForFPToI(cast<Instruction>(V), Lower, Upper);
-    CR = ConstantRange::getNonEmpty(Lower, Upper);
-  } else if (const auto *A = dyn_cast<Argument>(V))
+  } else if (isa<FPToUIInst>(V) || isa<FPToSIInst>(V))
+    CR = getRangeForFPToI(cast<Instruction>(V));
+  else if (const auto *A = dyn_cast<Argument>(V))
     if (std::optional<ConstantRange> Range = A->getRange())
       CR = *Range;
 

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -10360,9 +10360,95 @@ ConstantRange llvm::computeConstantRange(const Value *V, bool ForSigned,
   unsigned BitWidth = V->getType()->getScalarSizeInBits();
   InstrInfoQuery IIQ(UseInstrInfo);
   ConstantRange CR = ConstantRange::getFull(BitWidth);
-  if (auto *BO = dyn_cast<BinaryOperator>(V))
+  if (auto *BO = dyn_cast<BinaryOperator>(V)) {
     CR = getRangeForBinOp(*BO, IIQ, ForSigned);
-  else if (auto *II = dyn_cast<IntrinsicInst>(V))
+    // For these opcodes, recurse into operands to get a tighter range than
+    // getRangeForBinOp can produce with constant-only operand matching.
+    switch (BO->getOpcode()) {
+    case Instruction::UDiv: {
+      ConstantRange LHS =
+          computeConstantRange(BO->getOperand(0), /*ForSigned=*/false,
+                               UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      ConstantRange RHS =
+          computeConstantRange(BO->getOperand(1), /*ForSigned=*/false,
+                               UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      CR = CR.intersectWith(LHS.udiv(RHS));
+      break;
+    }
+    case Instruction::SDiv: {
+      ConstantRange LHS =
+          computeConstantRange(BO->getOperand(0), /*ForSigned=*/true,
+                               UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      ConstantRange RHS =
+          computeConstantRange(BO->getOperand(1), /*ForSigned=*/true,
+                               UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      CR = CR.intersectWith(LHS.sdiv(RHS));
+      break;
+    }
+    case Instruction::URem: {
+      ConstantRange LHS =
+          computeConstantRange(BO->getOperand(0), /*ForSigned=*/false,
+                               UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      ConstantRange RHS =
+          computeConstantRange(BO->getOperand(1), /*ForSigned=*/false,
+                               UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      CR = CR.intersectWith(LHS.urem(RHS));
+      break;
+    }
+    case Instruction::SRem: {
+      ConstantRange LHS =
+          computeConstantRange(BO->getOperand(0), /*ForSigned=*/true,
+                               UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      ConstantRange RHS =
+          computeConstantRange(BO->getOperand(1), /*ForSigned=*/true,
+                               UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      CR = CR.intersectWith(LHS.srem(RHS));
+      break;
+    }
+    case Instruction::Mul: {
+      ConstantRange LHS =
+          computeConstantRange(BO->getOperand(0), /*ForSigned=*/false,
+                               UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      ConstantRange RHS =
+          computeConstantRange(BO->getOperand(1), /*ForSigned=*/false,
+                               UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      CR = CR.intersectWith(LHS.multiply(RHS));
+      break;
+    }
+    case Instruction::Add: {
+      ConstantRange LHS = computeConstantRange(
+          BO->getOperand(0), ForSigned, UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      ConstantRange RHS = computeConstantRange(
+          BO->getOperand(1), ForSigned, UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      unsigned NoWrapKind =
+          cast<OverflowingBinaryOperator>(BO)->getNoWrapKind();
+      ConstantRange::PreferredRangeType RangeType =
+          ForSigned ? ConstantRange::Signed : ConstantRange::Unsigned;
+      ConstantRange Res = NoWrapKind
+                              ? LHS.addWithNoWrap(RHS, NoWrapKind, RangeType)
+                              : LHS.add(RHS);
+      CR = CR.intersectWith(Res);
+      break;
+    }
+    case Instruction::Sub: {
+      ConstantRange LHS = computeConstantRange(
+          BO->getOperand(0), ForSigned, UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      ConstantRange RHS = computeConstantRange(
+          BO->getOperand(1), ForSigned, UseInstrInfo, AC, CtxI, DT, Depth + 1);
+      unsigned NoWrapKind =
+          cast<OverflowingBinaryOperator>(BO)->getNoWrapKind();
+      ConstantRange::PreferredRangeType RangeType =
+          ForSigned ? ConstantRange::Signed : ConstantRange::Unsigned;
+      ConstantRange Res = NoWrapKind
+                              ? LHS.subWithNoWrap(RHS, NoWrapKind, RangeType)
+                              : LHS.sub(RHS);
+      CR = CR.intersectWith(Res);
+      break;
+    }
+    default:
+      break;
+    }
+  } else if (auto *II = dyn_cast<IntrinsicInst>(V))
     CR = getRangeForIntrinsic(*II, UseInstrInfo);
   else if (auto *SI = dyn_cast<SelectInst>(V)) {
     ConstantRange CRTrue = computeConstantRange(
@@ -10371,6 +10457,10 @@ ConstantRange llvm::computeConstantRange(const Value *V, bool ForSigned,
         SI->getFalseValue(), ForSigned, UseInstrInfo, AC, CtxI, DT, Depth + 1);
     CR = CRTrue.unionWith(CRFalse);
     CR = CR.intersectWith(getRangeForSelectPattern(*SI, IIQ));
+  } else if (auto *TI = dyn_cast<TruncInst>(V)) {
+    ConstantRange SrcCR = computeConstantRange(
+        TI->getOperand(0), ForSigned, UseInstrInfo, AC, CtxI, DT, Depth + 1);
+    CR = SrcCR.truncate(BitWidth, TI->getNoWrapKind());
   } else if (isa<FPToUIInst>(V) || isa<FPToSIInst>(V))
     CR = getRangeForFPToI(cast<Instruction>(V));
   else if (const auto *A = dyn_cast<Argument>(V))
@@ -10404,9 +10494,8 @@ ConstantRange llvm::computeConstantRange(const Value *V, bool ForSigned,
       // Currently we just use information from comparisons.
       if (!Cmp || Cmp->getOperand(0) != V)
         continue;
-      // TODO: Set "ForSigned" parameter via Cmp->isSigned()?
       ConstantRange RHS =
-          computeConstantRange(Cmp->getOperand(1), /* ForSigned */ false,
+          computeConstantRange(Cmp->getOperand(1), Cmp->isSigned(),
                                UseInstrInfo, AC, I, DT, Depth + 1);
       CR = CR.intersectWith(
           ConstantRange::makeAllowedICmpRegion(Cmp->getPredicate(), RHS));

--- a/llvm/test/CodeGen/AMDGPU/sdiv64.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdiv64.ll
@@ -1275,12 +1275,11 @@ define amdgpu_kernel void @s_test_sdiv_k_num_i64(ptr addrspace(1) %out, i64 %x) 
 ; GCN-IR-NEXT:    s_addc_u32 s11, 0, -1
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[2:3], 0
 ; GCN-IR-NEXT:    v_cmp_gt_u64_e64 s[12:13], s[10:11], 63
-; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[14:15], s[10:11], 63
-; GCN-IR-NEXT:    s_or_b64 s[12:13], s[8:9], s[12:13]
-; GCN-IR-NEXT:    s_and_b64 s[8:9], s[12:13], exec
+; GCN-IR-NEXT:    s_or_b64 s[8:9], s[8:9], s[12:13]
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[8:9]
+; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GCN-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v0
 ; GCN-IR-NEXT:    s_cselect_b32 s8, 0, 24
-; GCN-IR-NEXT:    s_or_b64 s[12:13], s[12:13], s[14:15]
-; GCN-IR-NEXT:    s_andn2_b64 vcc, exec, s[12:13]
 ; GCN-IR-NEXT:    s_mov_b32 s9, 0
 ; GCN-IR-NEXT:    s_cbranch_vccz .LBB10_5
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
@@ -1462,13 +1461,11 @@ define i64 @v_test_sdiv_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_addc_u32_e64 v3, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]
-; GCN-IR-NEXT:    v_cmp_ne_u64_e64 s[6:7], 63, v[2:3]
+; GCN-IR-NEXT:    v_mov_b32_e32 v11, v10
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], vcc
+; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, 24, 0, s[4:5]
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[4:5], -1
-; GCN-IR-NEXT:    v_mov_b32_e32 v11, v10
-; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], s[6:7]
 ; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
 ; GCN-IR-NEXT:    s_cbranch_execz .LBB11_6
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
@@ -1653,14 +1650,12 @@ define i64 @v_test_sdiv_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_addc_u32_e64 v3, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]
-; GCN-IR-NEXT:    v_cmp_ne_u64_e64 s[6:7], 63, v[2:3]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0x8000
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], vcc
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[4:5], -1
 ; GCN-IR-NEXT:    v_mov_b32_e32 v11, v10
 ; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], s[6:7]
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
+; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[4:5], -1
 ; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
 ; GCN-IR-NEXT:    s_cbranch_execz .LBB12_6
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
@@ -1755,12 +1750,10 @@ define i64 @v_test_sdiv_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e64 s[4:5], 63, v[0:1]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, v8
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
-; GCN-IR-NEXT:    v_cmp_ne_u64_e32 vcc, 63, v[0:1]
-; GCN-IR-NEXT:    s_xor_b64 s[6:7], s[4:5], -1
 ; GCN-IR-NEXT:    v_cndmask_b32_e64 v3, v5, 0, s[4:5]
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[4:5], -1
 ; GCN-IR-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[6:7], vcc
-; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
+; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[8:9]
 ; GCN-IR-NEXT:    s_cbranch_execz .LBB13_6
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
 ; GCN-IR-NEXT:    v_add_i32_e32 v7, vcc, 1, v0

--- a/llvm/test/CodeGen/AMDGPU/srem64.ll
+++ b/llvm/test/CodeGen/AMDGPU/srem64.ll
@@ -1414,73 +1414,72 @@ define amdgpu_kernel void @s_test_srem_k_num_i64(ptr addrspace(1) %out, i64 %x) 
 ; GCN-IR-LABEL: s_test_srem_k_num_i64:
 ; GCN-IR:       ; %bb.0: ; %_udiv-special-cases
 ; GCN-IR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
-; GCN-IR-NEXT:    s_mov_b64 s[6:7], 0
 ; GCN-IR-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-IR-NEXT:    s_ashr_i32 s8, s3, 31
-; GCN-IR-NEXT:    s_mov_b32 s9, s8
-; GCN-IR-NEXT:    s_xor_b64 s[2:3], s[2:3], s[8:9]
-; GCN-IR-NEXT:    s_sub_u32 s4, s2, s8
-; GCN-IR-NEXT:    s_subb_u32 s5, s3, s8
+; GCN-IR-NEXT:    s_ashr_i32 s6, s3, 31
+; GCN-IR-NEXT:    s_mov_b32 s7, s6
+; GCN-IR-NEXT:    s_xor_b64 s[2:3], s[2:3], s[6:7]
+; GCN-IR-NEXT:    s_sub_u32 s4, s2, s6
+; GCN-IR-NEXT:    s_subb_u32 s5, s3, s6
 ; GCN-IR-NEXT:    s_flbit_i32_b64 s14, s[4:5]
-; GCN-IR-NEXT:    s_add_u32 s2, s14, 0xffffffc5
-; GCN-IR-NEXT:    s_addc_u32 s3, 0, -1
-; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[4:5], 0
-; GCN-IR-NEXT:    v_cmp_gt_u64_e64 s[10:11], s[2:3], 63
-; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[12:13], s[2:3], 63
-; GCN-IR-NEXT:    s_or_b64 s[10:11], s[8:9], s[10:11]
-; GCN-IR-NEXT:    s_and_b64 s[8:9], s[10:11], exec
-; GCN-IR-NEXT:    s_cselect_b32 s8, 0, 24
-; GCN-IR-NEXT:    s_or_b64 s[10:11], s[10:11], s[12:13]
-; GCN-IR-NEXT:    s_andn2_b64 vcc, exec, s[10:11]
-; GCN-IR-NEXT:    s_mov_b32 s9, 0
+; GCN-IR-NEXT:    s_add_u32 s8, s14, 0xffffffc5
+; GCN-IR-NEXT:    s_addc_u32 s9, 0, -1
+; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[6:7], s[4:5], 0
+; GCN-IR-NEXT:    v_cmp_gt_u64_e64 s[10:11], s[8:9], 63
+; GCN-IR-NEXT:    s_mov_b64 s[2:3], 0
+; GCN-IR-NEXT:    s_or_b64 s[6:7], s[6:7], s[10:11]
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[6:7]
+; GCN-IR-NEXT:    s_and_b64 s[6:7], s[6:7], exec
+; GCN-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v0
+; GCN-IR-NEXT:    s_cselect_b32 s6, 0, 24
+; GCN-IR-NEXT:    s_mov_b32 s7, 0
 ; GCN-IR-NEXT:    s_cbranch_vccz .LBB10_5
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
-; GCN-IR-NEXT:    s_add_u32 s8, s2, 1
-; GCN-IR-NEXT:    s_addc_u32 s3, s3, 0
-; GCN-IR-NEXT:    s_cselect_b64 s[10:11], -1, 0
-; GCN-IR-NEXT:    s_sub_i32 s2, 63, s2
-; GCN-IR-NEXT:    s_andn2_b64 vcc, exec, s[10:11]
-; GCN-IR-NEXT:    s_lshl_b64 s[2:3], 24, s2
+; GCN-IR-NEXT:    s_add_u32 s10, s8, 1
+; GCN-IR-NEXT:    s_addc_u32 s6, s9, 0
+; GCN-IR-NEXT:    s_cselect_b64 s[6:7], -1, 0
+; GCN-IR-NEXT:    s_sub_i32 s8, 63, s8
+; GCN-IR-NEXT:    s_andn2_b64 vcc, exec, s[6:7]
+; GCN-IR-NEXT:    s_lshl_b64 s[6:7], 24, s8
 ; GCN-IR-NEXT:    s_cbranch_vccz .LBB10_4
 ; GCN-IR-NEXT:  ; %bb.2: ; %udiv-preheader
-; GCN-IR-NEXT:    s_lshr_b64 s[10:11], 24, s8
+; GCN-IR-NEXT:    s_lshr_b64 s[10:11], 24, s10
 ; GCN-IR-NEXT:    s_add_u32 s12, s4, -1
 ; GCN-IR-NEXT:    s_addc_u32 s13, s5, -1
 ; GCN-IR-NEXT:    s_sub_u32 s14, 58, s14
 ; GCN-IR-NEXT:    s_subb_u32 s15, 0, 0
 ; GCN-IR-NEXT:    s_mov_b64 s[8:9], 0
-; GCN-IR-NEXT:    s_mov_b32 s7, 0
+; GCN-IR-NEXT:    s_mov_b32 s3, 0
 ; GCN-IR-NEXT:  .LBB10_3: ; %udiv-do-while
 ; GCN-IR-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN-IR-NEXT:    s_lshl_b64 s[10:11], s[10:11], 1
-; GCN-IR-NEXT:    s_lshr_b32 s6, s3, 31
-; GCN-IR-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
-; GCN-IR-NEXT:    s_or_b64 s[10:11], s[10:11], s[6:7]
-; GCN-IR-NEXT:    s_or_b64 s[2:3], s[8:9], s[2:3]
-; GCN-IR-NEXT:    s_sub_u32 s6, s12, s10
-; GCN-IR-NEXT:    s_subb_u32 s6, s13, s11
-; GCN-IR-NEXT:    s_ashr_i32 s8, s6, 31
+; GCN-IR-NEXT:    s_lshr_b32 s2, s7, 31
+; GCN-IR-NEXT:    s_lshl_b64 s[6:7], s[6:7], 1
+; GCN-IR-NEXT:    s_or_b64 s[10:11], s[10:11], s[2:3]
+; GCN-IR-NEXT:    s_or_b64 s[6:7], s[8:9], s[6:7]
+; GCN-IR-NEXT:    s_sub_u32 s2, s12, s10
+; GCN-IR-NEXT:    s_subb_u32 s2, s13, s11
+; GCN-IR-NEXT:    s_ashr_i32 s8, s2, 31
 ; GCN-IR-NEXT:    s_mov_b32 s9, s8
-; GCN-IR-NEXT:    s_and_b32 s6, s8, 1
+; GCN-IR-NEXT:    s_and_b32 s2, s8, 1
 ; GCN-IR-NEXT:    s_and_b64 s[16:17], s[8:9], s[4:5]
 ; GCN-IR-NEXT:    s_sub_u32 s10, s10, s16
 ; GCN-IR-NEXT:    s_subb_u32 s11, s11, s17
 ; GCN-IR-NEXT:    s_add_u32 s14, s14, 1
 ; GCN-IR-NEXT:    s_addc_u32 s15, s15, 0
 ; GCN-IR-NEXT:    s_cselect_b64 s[16:17], -1, 0
-; GCN-IR-NEXT:    s_mov_b64 s[8:9], s[6:7]
+; GCN-IR-NEXT:    s_mov_b64 s[8:9], s[2:3]
 ; GCN-IR-NEXT:    s_and_b64 vcc, exec, s[16:17]
 ; GCN-IR-NEXT:    s_cbranch_vccz .LBB10_3
 ; GCN-IR-NEXT:  .LBB10_4: ; %Flow6
-; GCN-IR-NEXT:    s_lshl_b64 s[2:3], s[2:3], 1
-; GCN-IR-NEXT:    s_or_b64 s[8:9], s[6:7], s[2:3]
+; GCN-IR-NEXT:    s_lshl_b64 s[6:7], s[6:7], 1
+; GCN-IR-NEXT:    s_or_b64 s[6:7], s[2:3], s[6:7]
 ; GCN-IR-NEXT:  .LBB10_5: ; %udiv-end
-; GCN-IR-NEXT:    v_mov_b32_e32 v0, s8
+; GCN-IR-NEXT:    v_mov_b32_e32 v0, s6
 ; GCN-IR-NEXT:    v_mul_hi_u32 v0, s4, v0
-; GCN-IR-NEXT:    s_mul_i32 s6, s4, s9
-; GCN-IR-NEXT:    s_mul_i32 s5, s5, s8
-; GCN-IR-NEXT:    s_mul_i32 s4, s4, s8
-; GCN-IR-NEXT:    v_add_i32_e32 v0, vcc, s6, v0
+; GCN-IR-NEXT:    s_mul_i32 s7, s4, s7
+; GCN-IR-NEXT:    s_mul_i32 s5, s5, s6
+; GCN-IR-NEXT:    s_mul_i32 s4, s4, s6
+; GCN-IR-NEXT:    v_add_i32_e32 v0, vcc, s7, v0
 ; GCN-IR-NEXT:    v_add_i32_e32 v1, vcc, s5, v0
 ; GCN-IR-NEXT:    v_sub_i32_e64 v0, vcc, 24, s4
 ; GCN-IR-NEXT:    s_mov_b32 s3, 0xf000
@@ -1612,12 +1611,10 @@ define i64 @v_test_srem_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_addc_u32_e64 v3, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]
-; GCN-IR-NEXT:    v_cmp_ne_u64_e64 s[6:7], 63, v[2:3]
+; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], vcc
 ; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, 24, 0, s[4:5]
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[4:5], -1
-; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], s[6:7]
 ; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
 ; GCN-IR-NEXT:    s_cbranch_execz .LBB11_6
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
@@ -1801,13 +1798,11 @@ define i64 @v_test_srem_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_addc_u32_e64 v3, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]
-; GCN-IR-NEXT:    v_cmp_ne_u64_e64 s[6:7], 63, v[2:3]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0x8000
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], vcc
+; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[4:5], -1
-; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], s[6:7]
 ; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
 ; GCN-IR-NEXT:    s_cbranch_execz .LBB12_6
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
@@ -1908,12 +1903,10 @@ define i64 @v_test_srem_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e64 s[4:5], 63, v[2:3]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v11, v10
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
-; GCN-IR-NEXT:    v_cmp_ne_u64_e32 vcc, 63, v[2:3]
-; GCN-IR-NEXT:    s_xor_b64 s[6:7], s[4:5], -1
 ; GCN-IR-NEXT:    v_cndmask_b32_e64 v5, v1, 0, s[4:5]
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[4:5], -1
 ; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, v0, 0, s[4:5]
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[6:7], vcc
-; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
+; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[8:9]
 ; GCN-IR-NEXT:    s_cbranch_execz .LBB13_6
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
 ; GCN-IR-NEXT:    v_add_i32_e32 v6, vcc, 1, v2

--- a/llvm/test/CodeGen/AMDGPU/udiv64.ll
+++ b/llvm/test/CodeGen/AMDGPU/udiv64.ll
@@ -912,12 +912,11 @@ define amdgpu_kernel void @s_test_udiv_k_num_i64(ptr addrspace(1) %out, i64 %x) 
 ; GCN-IR-NEXT:    s_addc_u32 s9, 0, -1
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[6:7], s[2:3], 0
 ; GCN-IR-NEXT:    v_cmp_gt_u64_e64 s[10:11], s[8:9], 63
-; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[12:13], s[8:9], 63
-; GCN-IR-NEXT:    s_or_b64 s[10:11], s[6:7], s[10:11]
-; GCN-IR-NEXT:    s_and_b64 s[6:7], s[10:11], exec
+; GCN-IR-NEXT:    s_or_b64 s[6:7], s[6:7], s[10:11]
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[6:7]
+; GCN-IR-NEXT:    s_and_b64 s[6:7], s[6:7], exec
+; GCN-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v0
 ; GCN-IR-NEXT:    s_cselect_b32 s6, 0, 24
-; GCN-IR-NEXT:    s_or_b64 s[10:11], s[10:11], s[12:13]
-; GCN-IR-NEXT:    s_andn2_b64 vcc, exec, s[10:11]
 ; GCN-IR-NEXT:    s_mov_b32 s7, 0
 ; GCN-IR-NEXT:    s_cbranch_vccz .LBB8_5
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
@@ -1083,13 +1082,11 @@ define i64 @v_test_udiv_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_addc_u32_e64 v5, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[4:5]
-; GCN-IR-NEXT:    v_cmp_ne_u64_e64 s[6:7], 63, v[4:5]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v3, 0x8000
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], vcc
+; GCN-IR-NEXT:    v_mov_b32_e32 v2, 0
 ; GCN-IR-NEXT:    v_cndmask_b32_e64 v3, v3, 0, s[4:5]
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[4:5], -1
-; GCN-IR-NEXT:    v_mov_b32_e32 v2, 0
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], s[6:7]
 ; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
 ; GCN-IR-NEXT:    s_cbranch_execz .LBB9_6
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
@@ -1173,12 +1170,10 @@ define i64 @v_test_udiv_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e64 s[4:5], 63, v[4:5]
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
-; GCN-IR-NEXT:    v_cmp_ne_u64_e32 vcc, 63, v[4:5]
-; GCN-IR-NEXT:    s_xor_b64 s[6:7], s[4:5], -1
 ; GCN-IR-NEXT:    v_cndmask_b32_e64 v2, v1, 0, s[4:5]
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[4:5], -1
 ; GCN-IR-NEXT:    v_cndmask_b32_e64 v3, v0, 0, s[4:5]
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[6:7], vcc
-; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
+; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[8:9]
 ; GCN-IR-NEXT:    s_cbranch_execz .LBB10_6
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
 ; GCN-IR-NEXT:    v_add_i32_e32 v7, vcc, 1, v4
@@ -1277,13 +1272,12 @@ define amdgpu_kernel void @s_test_udiv_k_den_i64(ptr addrspace(1) %out, i64 %x) 
 ; GCN-IR-NEXT:    s_subb_u32 s9, 0, 0
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], s[2:3], 0
 ; GCN-IR-NEXT:    v_cmp_gt_u64_e64 s[6:7], s[8:9], 63
-; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[12:13], s[8:9], 63
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
-; GCN-IR-NEXT:    s_and_b64 s[6:7], s[4:5], exec
-; GCN-IR-NEXT:    s_cselect_b32 s7, 0, s3
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[4:5]
+; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
+; GCN-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v0
 ; GCN-IR-NEXT:    s_cselect_b32 s6, 0, s2
-; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[12:13]
-; GCN-IR-NEXT:    s_andn2_b64 vcc, exec, s[4:5]
+; GCN-IR-NEXT:    s_cselect_b32 s7, 0, s3
 ; GCN-IR-NEXT:    s_mov_b64 s[4:5], 0
 ; GCN-IR-NEXT:    s_cbranch_vccz .LBB11_5
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
@@ -1372,12 +1366,10 @@ define i64 @v_test_udiv_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e64 s[4:5], 63, v[4:5]
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
-; GCN-IR-NEXT:    v_cmp_ne_u64_e32 vcc, 63, v[4:5]
-; GCN-IR-NEXT:    s_xor_b64 s[6:7], s[4:5], -1
 ; GCN-IR-NEXT:    v_cndmask_b32_e64 v2, v1, 0, s[4:5]
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[4:5], -1
 ; GCN-IR-NEXT:    v_cndmask_b32_e64 v3, v0, 0, s[4:5]
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[6:7], vcc
-; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
+; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[8:9]
 ; GCN-IR-NEXT:    s_cbranch_execz .LBB12_6
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
 ; GCN-IR-NEXT:    v_add_i32_e32 v7, vcc, 1, v4

--- a/llvm/test/CodeGen/AMDGPU/urem64.ll
+++ b/llvm/test/CodeGen/AMDGPU/urem64.ll
@@ -926,12 +926,11 @@ define amdgpu_kernel void @s_test_urem_k_num_i64(ptr addrspace(1) %out, i64 %x) 
 ; GCN-IR-NEXT:    s_addc_u32 s9, 0, -1
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[6:7], s[2:3], 0
 ; GCN-IR-NEXT:    v_cmp_gt_u64_e64 s[10:11], s[8:9], 63
-; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[12:13], s[8:9], 63
-; GCN-IR-NEXT:    s_or_b64 s[10:11], s[6:7], s[10:11]
-; GCN-IR-NEXT:    s_and_b64 s[6:7], s[10:11], exec
+; GCN-IR-NEXT:    s_or_b64 s[6:7], s[6:7], s[10:11]
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[6:7]
+; GCN-IR-NEXT:    s_and_b64 s[6:7], s[6:7], exec
+; GCN-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v0
 ; GCN-IR-NEXT:    s_cselect_b32 s6, 0, 24
-; GCN-IR-NEXT:    s_or_b64 s[10:11], s[10:11], s[12:13]
-; GCN-IR-NEXT:    s_andn2_b64 vcc, exec, s[10:11]
 ; GCN-IR-NEXT:    s_mov_b32 s7, 0
 ; GCN-IR-NEXT:    s_cbranch_vccz .LBB6_5
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
@@ -1042,13 +1041,12 @@ define amdgpu_kernel void @s_test_urem_k_den_i64(ptr addrspace(1) %out, i64 %x) 
 ; GCN-IR-NEXT:    s_subb_u32 s9, 0, 0
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], s[2:3], 0
 ; GCN-IR-NEXT:    v_cmp_gt_u64_e64 s[6:7], s[8:9], 63
-; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[12:13], s[8:9], 63
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
-; GCN-IR-NEXT:    s_and_b64 s[6:7], s[4:5], exec
-; GCN-IR-NEXT:    s_cselect_b32 s7, 0, s3
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[4:5]
+; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
+; GCN-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v0
 ; GCN-IR-NEXT:    s_cselect_b32 s6, 0, s2
-; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[12:13]
-; GCN-IR-NEXT:    s_andn2_b64 vcc, exec, s[4:5]
+; GCN-IR-NEXT:    s_cselect_b32 s7, 0, s3
 ; GCN-IR-NEXT:    s_mov_b64 s[4:5], 0
 ; GCN-IR-NEXT:    s_cbranch_vccz .LBB7_5
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
@@ -1219,13 +1217,11 @@ define i64 @v_test_urem_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_addc_u32_e64 v3, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]
-; GCN-IR-NEXT:    v_cmp_ne_u64_e64 s[6:7], 63, v[2:3]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0x8000
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], vcc
+; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[4:5], -1
-; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], s[6:7]
 ; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
 ; GCN-IR-NEXT:    s_cbranch_execz .LBB8_6
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
@@ -1310,22 +1306,20 @@ define i64 @v_test_urem_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_add_i32_e64 v2, s[4:5], 32, v2
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v3, v1
 ; GCN-IR-NEXT:    v_min_u32_e32 v8, v2, v3
-; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 48, v8
-; GCN-IR-NEXT:    v_subb_u32_e64 v3, s[4:5], 0, 0, s[4:5]
+; GCN-IR-NEXT:    v_sub_i32_e64 v4, s[4:5], 48, v8
+; GCN-IR-NEXT:    v_subb_u32_e64 v5, s[4:5], 0, 0, s[4:5]
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[0:1]
-; GCN-IR-NEXT:    v_cmp_lt_u64_e64 s[4:5], 63, v[2:3]
+; GCN-IR-NEXT:    v_cmp_lt_u64_e64 s[4:5], 63, v[4:5]
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
-; GCN-IR-NEXT:    v_cmp_ne_u64_e32 vcc, 63, v[2:3]
-; GCN-IR-NEXT:    s_xor_b64 s[6:7], s[4:5], -1
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v5, v1, 0, s[4:5]
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, v0, 0, s[4:5]
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[6:7], vcc
-; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v3, v1, 0, s[4:5]
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[4:5], -1
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v2, v0, 0, s[4:5]
+; GCN-IR-NEXT:    s_and_saveexec_b64 s[6:7], s[8:9]
 ; GCN-IR-NEXT:    s_cbranch_execz .LBB9_6
 ; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
-; GCN-IR-NEXT:    v_add_i32_e32 v6, vcc, 1, v2
-; GCN-IR-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
-; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v2
+; GCN-IR-NEXT:    v_add_i32_e32 v6, vcc, 1, v4
+; GCN-IR-NEXT:    v_addc_u32_e32 v2, vcc, 0, v5, vcc
+; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v4
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[0:1], v2
 ; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
@@ -1369,11 +1363,11 @@ define i64 @v_test_urem_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:  .LBB9_5: ; %Flow4
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[2:3], 1
-; GCN-IR-NEXT:    v_or_b32_e32 v5, v5, v3
-; GCN-IR-NEXT:    v_or_b32_e32 v4, v4, v2
+; GCN-IR-NEXT:    v_or_b32_e32 v3, v5, v3
+; GCN-IR-NEXT:    v_or_b32_e32 v2, v4, v2
 ; GCN-IR-NEXT:  .LBB9_6: ; %Flow5
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[4:5], 15
+; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[2:3], 15
 ; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, v0, v2
 ; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, v1, v3, vcc
 ; GCN-IR-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/PowerPC/add_cmp.ll
+++ b/llvm/test/CodeGen/PowerPC/add_cmp.ll
@@ -36,9 +36,7 @@ entry:
 
 ; CHECK: === addiCmpiUnsignedOverflow
 ; CHECK: Optimized lowered selection DAG: %bb.0 'addiCmpiUnsignedOverflow:entry'
-; CHECK:   [[REG1:t[0-9]+]]: i32 = truncate {{t[0-9]+}}
-; CHECK:   [[REG2:t[0-9]+]]: i32 = add nuw [[REG1]], Constant:i32<110>
-; CHECK:   {{t[0-9]+}}: i1 = setcc [[REG2]], Constant:i32<100>, setugt:ch
+; CHECK:   {{t[0-9]+}}: ch,glue = CopyToReg {{t[0-9]+}}, Register:i64 $x3, Constant:i64<1>
 }
 
 define zeroext i1 @addiCmpiSignedOverflow(i16 signext %x) {
@@ -49,8 +47,5 @@ entry:
 
 ; CHECK: === addiCmpiSignedOverflow
 ; CHECK: Optimized lowered selection DAG: %bb.0 'addiCmpiSignedOverflow:entry'
-; CHECK:   [[REG1:t[0-9]+]]: i16 = truncate {{t[0-9]+}}
-; CHECK:   [[REG2:t[0-9]+]]: i16 = add nsw [[REG1]], Constant:i16<16>
-; CHECK:   {{t[0-9]+}}: i1 = setcc [[REG2]], Constant:i16<-32767>, setgt:ch
+; CHECK:   {{t[0-9]+}}: ch,glue = CopyToReg {{t[0-9]+}}, Register:i64 $x3, Constant:i64<1>
 }
-

--- a/llvm/test/Transforms/AggressiveInstCombine/umulh_carry4.ll
+++ b/llvm/test/Transforms/AggressiveInstCombine/umulh_carry4.ll
@@ -572,7 +572,7 @@ define i64 @umulh_notcarry(i64 %x, i64 %y) {
 ; CHECK-NEXT:    [[LOW_ACCUM:%.*]] = add nuw nsw i64 [[CROSS_SUM_LO]], [[Y_LO_X_LO_HI]]
 ; CHECK-NEXT:    [[INTERMEDIATE:%.*]] = add nuw i64 [[CROSS_SUM_HI]], [[Y_HI_X_HI]]
 ; CHECK-NEXT:    [[LOW_ACCUM_HI:%.*]] = lshr i64 [[LOW_ACCUM]], 32
-; CHECK-NEXT:    [[INTERMEDIATE_PLUS_CARRY:%.*]] = add i64 [[INTERMEDIATE]], [[CARRY]]
+; CHECK-NEXT:    [[INTERMEDIATE_PLUS_CARRY:%.*]] = add nuw i64 [[INTERMEDIATE]], [[CARRY]]
 ; CHECK-NEXT:    [[HW64:%.*]] = add i64 [[INTERMEDIATE_PLUS_CARRY]], [[LOW_ACCUM_HI]]
 ; CHECK-NEXT:    ret i64 [[HW64]]
 ;

--- a/llvm/test/Transforms/Attributor/range.ll
+++ b/llvm/test/Transforms/Attributor/range.ll
@@ -888,29 +888,13 @@ define dso_local i64 @select_int2ptr_bitcast_ptr2int(i32 %a) local_unnamed_addr 
 ; TUNIT-LABEL: define {{[^@]+}}@select_int2ptr_bitcast_ptr2int
 ; TUNIT-SAME: (i32 [[A:%.*]]) local_unnamed_addr #[[ATTR1]] {
 ; TUNIT-NEXT:  entry:
-; TUNIT-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[A]], 5
-; TUNIT-NEXT:    [[DOT:%.*]] = select i1 [[CMP]], i32 1, i32 2
-; TUNIT-NEXT:    [[CMP1:%.*]] = icmp sgt i32 [[A]], 10
-; TUNIT-NEXT:    [[Y_0_V:%.*]] = select i1 [[CMP1]], i32 1, i32 2
-; TUNIT-NEXT:    [[Y_0:%.*]] = add nuw nsw i32 [[DOT]], [[Y_0_V]]
-; TUNIT-NEXT:    [[CMP6:%.*]] = icmp eq i32 [[Y_0]], 5
-; TUNIT-NEXT:    [[I2P:%.*]] = inttoptr i1 [[CMP6]] to ptr
-; TUNIT-NEXT:    [[P2I:%.*]] = ptrtoint ptr [[I2P]] to i64
-; TUNIT-NEXT:    ret i64 [[P2I]]
+; TUNIT-NEXT:    ret i64 0
 ;
 ; CGSCC: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 ; CGSCC-LABEL: define {{[^@]+}}@select_int2ptr_bitcast_ptr2int
 ; CGSCC-SAME: (i32 [[A:%.*]]) local_unnamed_addr #[[ATTR2]] {
 ; CGSCC-NEXT:  entry:
-; CGSCC-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[A]], 5
-; CGSCC-NEXT:    [[DOT:%.*]] = select i1 [[CMP]], i32 1, i32 2
-; CGSCC-NEXT:    [[CMP1:%.*]] = icmp sgt i32 [[A]], 10
-; CGSCC-NEXT:    [[Y_0_V:%.*]] = select i1 [[CMP1]], i32 1, i32 2
-; CGSCC-NEXT:    [[Y_0:%.*]] = add nuw nsw i32 [[DOT]], [[Y_0_V]]
-; CGSCC-NEXT:    [[CMP6:%.*]] = icmp eq i32 [[Y_0]], 5
-; CGSCC-NEXT:    [[I2P:%.*]] = inttoptr i1 [[CMP6]] to ptr
-; CGSCC-NEXT:    [[P2I:%.*]] = ptrtoint ptr [[I2P]] to i64
-; CGSCC-NEXT:    ret i64 [[P2I]]
+; CGSCC-NEXT:    ret i64 0
 ;
 entry:
   %cmp = icmp sgt i32 %a, 5

--- a/llvm/test/Transforms/InstCombine/add.ll
+++ b/llvm/test/Transforms/InstCombine/add.ll
@@ -3274,9 +3274,7 @@ define <2 x i32> @dec_zext_add_nonzero_vec_poison1(<2 x i8> %x) {
 define <2 x i32> @dec_zext_add_nonzero_vec_poison2(<2 x i8> %x) {
 ; CHECK-LABEL: @dec_zext_add_nonzero_vec_poison2(
 ; CHECK-NEXT:    [[O:%.*]] = or <2 x i8> [[X:%.*]], splat (i8 8)
-; CHECK-NEXT:    [[A:%.*]] = add nsw <2 x i8> [[O]], splat (i8 -1)
-; CHECK-NEXT:    [[B:%.*]] = zext <2 x i8> [[A]] to <2 x i32>
-; CHECK-NEXT:    [[C:%.*]] = add nuw nsw <2 x i32> [[B]], <i32 1, i32 poison>
+; CHECK-NEXT:    [[C:%.*]] = zext <2 x i8> [[O]] to <2 x i32>
 ; CHECK-NEXT:    ret <2 x i32> [[C]]
 ;
   %o = or <2 x i8> %x, <i8 8, i8 8>

--- a/llvm/test/Transforms/InstCombine/div.ll
+++ b/llvm/test/Transforms/InstCombine/div.ll
@@ -933,7 +933,7 @@ define <2 x i8> @negate_sdiv_vec_one_element(<2 x i8> %x) {
 define <2 x i8> @negate_sdiv_vec_signed_min_elt(<2 x i8> %x) {
 ; CHECK-LABEL: @negate_sdiv_vec_signed_min_elt(
 ; CHECK-NEXT:    [[DIV:%.*]] = sdiv <2 x i8> [[X:%.*]], <i8 -1, i8 -128>
-; CHECK-NEXT:    [[NEG:%.*]] = sub <2 x i8> zeroinitializer, [[DIV]]
+; CHECK-NEXT:    [[NEG:%.*]] = sub nsw <2 x i8> zeroinitializer, [[DIV]]
 ; CHECK-NEXT:    ret <2 x i8> [[NEG]]
 ;
   %div = sdiv <2 x i8> %x, <i8 -1, i8 -128>

--- a/llvm/test/Transforms/InstCombine/fls.ll
+++ b/llvm/test/Transforms/InstCombine/fls.ll
@@ -33,7 +33,7 @@ define i32 @flsnotconst(i64 %z) {
 ; CHECK-LABEL: @flsnotconst(
 ; CHECK-NEXT:    [[CTLZ:%.*]] = call range(i64 0, 65) i64 @llvm.ctlz.i64(i64 [[Z:%.*]], i1 false)
 ; CHECK-NEXT:    [[TMP1:%.*]] = trunc nuw nsw i64 [[CTLZ]] to i32
-; CHECK-NEXT:    [[GOO:%.*]] = sub nsw i32 64, [[TMP1]]
+; CHECK-NEXT:    [[GOO:%.*]] = sub nuw nsw i32 64, [[TMP1]]
 ; CHECK-NEXT:    ret i32 [[GOO]]
 ;
   %goo = call i32 @flsl(i64 %z)

--- a/llvm/test/Transforms/InstCombine/icmp-add.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-add.ll
@@ -3162,9 +3162,7 @@ define i1 @icmp_add_constant_with_constant_ult_to_slt_neg2(i8 range(i8 -4, 120) 
 ; Negative test: C2 is negative
 define i1 @icmp_add_constant_with_constant_ult_to_slt_neg3(i32 range(i32 -4, 10) %x) {
 ; CHECK-LABEL: @icmp_add_constant_with_constant_ult_to_slt_neg3(
-; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[X:%.*]], 4
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[ADD]], -6
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
   %add = add nsw i32 %x, 4
   %cmp = icmp ult i32 %add, -6

--- a/llvm/test/Transforms/InstCombine/icmp-mul.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-mul.ll
@@ -949,11 +949,7 @@ define i1 @not_mul_of_pow2(i32 %x, i8 %y) {
 
 define i1 @not_mul_of_pow2_commute(i32 %x, i32 %y) {
 ; CHECK-LABEL: @not_mul_of_pow2_commute(
-; CHECK-NEXT:    [[X30:%.*]] = and i32 [[X:%.*]], 12
-; CHECK-NEXT:    [[Y8:%.*]] = and i32 [[Y:%.*]], 255
-; CHECK-NEXT:    [[M:%.*]] = mul nuw nsw i32 [[Y8]], [[X30]]
-; CHECK-NEXT:    [[R:%.*]] = icmp samesign ugt i32 [[M]], 3060
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %x30 = and i32 %x, 12
   %y8 = and i32 %y, 255

--- a/llvm/test/Transforms/InstCombine/icmp-srem.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-srem.ll
@@ -122,7 +122,7 @@ define i1 @icmp_ugt_srem5_m5(i32 %x) {
 define i64 @srem_zero_ult_poison(i1 %c) {
 ; CHECK-LABEL: define i64 @srem_zero_ult_poison(
 ; CHECK-SAME: i1 [[C:%.*]]) {
-; CHECK-NEXT:    ret i64 poison
+; CHECK-NEXT:    ret i64 1
 ;
   %sel = select i1 %c, i64 3, i64 0
   %trunc = trunc i64 %sel to i8

--- a/llvm/test/Transforms/InstCombine/mul-inseltpoison.ll
+++ b/llvm/test/Transforms/InstCombine/mul-inseltpoison.ll
@@ -781,7 +781,7 @@ define <2 x i8> @negate_if_true_commute(<2 x i8> %px, i1 %cond) {
 define <2 x i8> @negate_if_false_commute(<2 x i8> %px, <2 x i1> %cond) {
 ; CHECK-LABEL: @negate_if_false_commute(
 ; CHECK-NEXT:    [[X:%.*]] = sdiv <2 x i8> <i8 42, i8 5>, [[PX:%.*]]
-; CHECK-NEXT:    [[TMP1:%.*]] = sub <2 x i8> zeroinitializer, [[X]]
+; CHECK-NEXT:    [[TMP1:%.*]] = sub nsw <2 x i8> zeroinitializer, [[X]]
 ; CHECK-NEXT:    [[R:%.*]] = select <2 x i1> [[COND:%.*]], <2 x i8> [[X]], <2 x i8> [[TMP1]]
 ; CHECK-NEXT:    ret <2 x i8> [[R]]
 ;

--- a/llvm/test/Transforms/InstCombine/mul.ll
+++ b/llvm/test/Transforms/InstCombine/mul.ll
@@ -323,7 +323,7 @@ define <2 x i8> @shl1_decrement_vec(<2 x i8> %x) {
 
 define i32 @mul_bool(i32 %x, i1 %y) !prof !0 {
 ; CHECK-LABEL: @mul_bool(
-; CHECK-NEXT:    [[M:%.*]] = select i1 [[Y:%.*]], i32 [[X:%.*]], i32 0
+; CHECK-NEXT:    [[M:%.*]] = select i1 [[Y:%.*]], i32 [[X:%.*]], i32 0, !prof [[PROF1]]
 ; CHECK-NEXT:    ret i32 [[M]]
 ;
   %z = zext i1 %y to i32
@@ -357,7 +357,7 @@ define <2 x i32> @mul_bool_vec_commute(<2 x i32> %px, <2 x i1> %y) {
 
 define i32 @mul_sext_bool(i1 %x) !prof !0 {
 ; CHECK-LABEL: @mul_sext_bool(
-; CHECK-NEXT:    [[M:%.*]] = select i1 [[X:%.*]], i32 -42, i32 0
+; CHECK-NEXT:    [[M:%.*]] = select i1 [[X:%.*]], i32 -42, i32 0, !prof [[PROF1]]
 ; CHECK-NEXT:    ret i32 [[M]]
 ;
   %s = sext i1 %x to i32
@@ -369,7 +369,7 @@ define i32 @mul_sext_bool_use(i1 %x) !prof !0 {
 ; CHECK-LABEL: @mul_sext_bool_use(
 ; CHECK-NEXT:    [[S:%.*]] = sext i1 [[X:%.*]] to i32
 ; CHECK-NEXT:    call void @use32(i32 [[S]])
-; CHECK-NEXT:    [[M:%.*]] = select i1 [[X]], i32 -42, i32 0
+; CHECK-NEXT:    [[M:%.*]] = select i1 [[X]], i32 -42, i32 0, !prof [[PROF1]]
 ; CHECK-NEXT:    ret i32 [[M]]
 ;
   %s = sext i1 %x to i32
@@ -436,7 +436,7 @@ define i32 @mul_bools_use3(i1 %x, i1 %y) !prof !0 {
 ; CHECK-NEXT:    call void @use32(i32 [[ZX]])
 ; CHECK-NEXT:    [[ZY:%.*]] = zext i1 [[Y:%.*]] to i32
 ; CHECK-NEXT:    call void @use32(i32 [[ZY]])
-; CHECK-NEXT:    [[R:%.*]] = select i1 [[X]], i32 [[ZY]], i32 0
+; CHECK-NEXT:    [[R:%.*]] = select i1 [[X]], i32 [[ZY]], i32 0, !prof [[PROF1]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %zx = zext i1 %x to i32
@@ -745,7 +745,7 @@ define i32 @not_lowbit_mul(i32 %a, i32 %b) {
 define i32 @signsplat_mul(i32 %x) !prof !0 {
 ; CHECK-LABEL: @signsplat_mul(
 ; CHECK-NEXT:    [[ISNEG:%.*]] = icmp slt i32 [[X:%.*]], 0
-; CHECK-NEXT:    [[MUL:%.*]] = select i1 [[ISNEG]], i32 -42, i32 0
+; CHECK-NEXT:    [[MUL:%.*]] = select i1 [[ISNEG]], i32 -42, i32 0, !prof [[PROF1]]
 ; CHECK-NEXT:    ret i32 [[MUL]]
 ;
   %ash = ashr i32 %x, 31
@@ -1499,7 +1499,7 @@ define <2 x i8> @negate_if_true_commute(<2 x i8> %px, i1 %cond) {
 define <2 x i8> @negate_if_false_commute(<2 x i8> %px, <2 x i1> %cond) {
 ; CHECK-LABEL: @negate_if_false_commute(
 ; CHECK-NEXT:    [[X:%.*]] = sdiv <2 x i8> <i8 42, i8 5>, [[PX:%.*]]
-; CHECK-NEXT:    [[TMP1:%.*]] = sub <2 x i8> zeroinitializer, [[X]]
+; CHECK-NEXT:    [[TMP1:%.*]] = sub nsw <2 x i8> zeroinitializer, [[X]]
 ; CHECK-NEXT:    [[R:%.*]] = select <2 x i1> [[COND:%.*]], <2 x i8> [[X]], <2 x i8> [[TMP1]]
 ; CHECK-NEXT:    ret <2 x i8> [[R]]
 ;

--- a/llvm/test/Transforms/InstCombine/mul_full_32.ll
+++ b/llvm/test/Transforms/InstCombine/mul_full_32.ll
@@ -16,15 +16,15 @@ define { i64, i64 } @mul_full_64(i64 %x, i64 %y) {
 ; CHECK-NEXT:    [[T3:%.*]] = mul nuw i64 [[YH]], [[XH]]
 ; CHECK-NEXT:    [[T0L:%.*]] = and i64 [[T0]], 4294967295
 ; CHECK-NEXT:    [[T0H:%.*]] = lshr i64 [[T0]], 32
-; CHECK-NEXT:    [[U0:%.*]] = add i64 [[T0H]], [[T1]]
+; CHECK-NEXT:    [[U0:%.*]] = add nuw i64 [[T0H]], [[T1]]
 ; CHECK-NEXT:    [[U0L:%.*]] = and i64 [[U0]], 4294967295
 ; CHECK-NEXT:    [[U0H:%.*]] = lshr i64 [[U0]], 32
-; CHECK-NEXT:    [[U1:%.*]] = add i64 [[U0L]], [[T2]]
+; CHECK-NEXT:    [[U1:%.*]] = add nuw i64 [[U0L]], [[T2]]
 ; CHECK-NEXT:    [[U1LS:%.*]] = shl i64 [[U1]], 32
 ; CHECK-NEXT:    [[U1H:%.*]] = lshr i64 [[U1]], 32
-; CHECK-NEXT:    [[U2:%.*]] = add i64 [[U0H]], [[T3]]
+; CHECK-NEXT:    [[U2:%.*]] = add nuw i64 [[U0H]], [[T3]]
 ; CHECK-NEXT:    [[LO:%.*]] = or disjoint i64 [[U1LS]], [[T0L]]
-; CHECK-NEXT:    [[HI:%.*]] = add i64 [[U2]], [[U1H]]
+; CHECK-NEXT:    [[HI:%.*]] = add nuw i64 [[U2]], [[U1H]]
 ; CHECK-NEXT:    [[RES_LO:%.*]] = insertvalue { i64, i64 } undef, i64 [[LO]], 0
 ; CHECK-NEXT:    [[RES:%.*]] = insertvalue { i64, i64 } [[RES_LO]], i64 [[HI]], 1
 ; CHECK-NEXT:    ret { i64, i64 } [[RES]]
@@ -72,15 +72,15 @@ define { i32, i32 } @mul_full_32(i32 %x, i32 %y) {
 ; CHECK-NEXT:    [[T3:%.*]] = mul nuw i32 [[YH]], [[XH]]
 ; CHECK-NEXT:    [[T0L:%.*]] = and i32 [[T0]], 65535
 ; CHECK-NEXT:    [[T0H:%.*]] = lshr i32 [[T0]], 16
-; CHECK-NEXT:    [[U0:%.*]] = add i32 [[T0H]], [[T1]]
+; CHECK-NEXT:    [[U0:%.*]] = add nuw i32 [[T0H]], [[T1]]
 ; CHECK-NEXT:    [[U0L:%.*]] = and i32 [[U0]], 65535
 ; CHECK-NEXT:    [[U0H:%.*]] = lshr i32 [[U0]], 16
-; CHECK-NEXT:    [[U1:%.*]] = add i32 [[U0L]], [[T2]]
+; CHECK-NEXT:    [[U1:%.*]] = add nuw i32 [[U0L]], [[T2]]
 ; CHECK-NEXT:    [[U1LS:%.*]] = shl i32 [[U1]], 16
 ; CHECK-NEXT:    [[U1H:%.*]] = lshr i32 [[U1]], 16
-; CHECK-NEXT:    [[U2:%.*]] = add i32 [[U0H]], [[T3]]
+; CHECK-NEXT:    [[U2:%.*]] = add nuw i32 [[U0H]], [[T3]]
 ; CHECK-NEXT:    [[LO:%.*]] = or disjoint i32 [[U1LS]], [[T0L]]
-; CHECK-NEXT:    [[HI:%.*]] = add i32 [[U2]], [[U1H]]
+; CHECK-NEXT:    [[HI:%.*]] = add nuw i32 [[U2]], [[U1H]]
 ; CHECK-NEXT:    [[RES_LO:%.*]] = insertvalue { i32, i32 } undef, i32 [[LO]], 0
 ; CHECK-NEXT:    [[RES:%.*]] = insertvalue { i32, i32 } [[RES_LO]], i32 [[HI]], 1
 ; CHECK-NEXT:    ret { i32, i32 } [[RES]]

--- a/llvm/test/Transforms/InstCombine/mul_full_64.ll
+++ b/llvm/test/Transforms/InstCombine/mul_full_64.ll
@@ -16,15 +16,15 @@ define { i64, i64 } @mul_full_64_variant0(i64 %x, i64 %y) {
 ; CHECK-NEXT:    [[T3:%.*]] = mul nuw i64 [[YH]], [[XH]]
 ; CHECK-NEXT:    [[T0L:%.*]] = and i64 [[T0]], 4294967295
 ; CHECK-NEXT:    [[T0H:%.*]] = lshr i64 [[T0]], 32
-; CHECK-NEXT:    [[U0:%.*]] = add i64 [[T0H]], [[T1]]
+; CHECK-NEXT:    [[U0:%.*]] = add nuw i64 [[T0H]], [[T1]]
 ; CHECK-NEXT:    [[U0L:%.*]] = and i64 [[U0]], 4294967295
 ; CHECK-NEXT:    [[U0H:%.*]] = lshr i64 [[U0]], 32
-; CHECK-NEXT:    [[U1:%.*]] = add i64 [[U0L]], [[T2]]
+; CHECK-NEXT:    [[U1:%.*]] = add nuw i64 [[U0L]], [[T2]]
 ; CHECK-NEXT:    [[U1LS:%.*]] = shl i64 [[U1]], 32
 ; CHECK-NEXT:    [[U1H:%.*]] = lshr i64 [[U1]], 32
-; CHECK-NEXT:    [[U2:%.*]] = add i64 [[U0H]], [[T3]]
+; CHECK-NEXT:    [[U2:%.*]] = add nuw i64 [[U0H]], [[T3]]
 ; CHECK-NEXT:    [[LO:%.*]] = or disjoint i64 [[U1LS]], [[T0L]]
-; CHECK-NEXT:    [[HI:%.*]] = add i64 [[U2]], [[U1H]]
+; CHECK-NEXT:    [[HI:%.*]] = add nuw i64 [[U2]], [[U1H]]
 ; CHECK-NEXT:    [[RES_LO:%.*]] = insertvalue { i64, i64 } undef, i64 [[LO]], 0
 ; CHECK-NEXT:    [[RES:%.*]] = insertvalue { i64, i64 } [[RES_LO]], i64 [[HI]], 1
 ; CHECK-NEXT:    ret { i64, i64 } [[RES]]
@@ -98,13 +98,13 @@ define i64 @mul_full_64_variant1(i64 %a, i64 %b, ptr nocapture %rhi) {
 ; CHECK-NEXT:    [[MUL6:%.*]] = mul nuw i64 [[SHR_I41]], [[CONV]]
 ; CHECK-NEXT:    [[MUL7:%.*]] = mul nuw i64 [[CONV3]], [[CONV]]
 ; CHECK-NEXT:    [[SHR_I40:%.*]] = lshr i64 [[MUL7]], 32
-; CHECK-NEXT:    [[ADD:%.*]] = add i64 [[SHR_I40]], [[MUL5]]
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw i64 [[SHR_I40]], [[MUL5]]
 ; CHECK-NEXT:    [[SHR_I39:%.*]] = lshr i64 [[ADD]], 32
-; CHECK-NEXT:    [[ADD10:%.*]] = add i64 [[SHR_I39]], [[MUL]]
+; CHECK-NEXT:    [[ADD10:%.*]] = add nuw i64 [[SHR_I39]], [[MUL]]
 ; CHECK-NEXT:    [[CONV14:%.*]] = and i64 [[ADD]], 4294967295
-; CHECK-NEXT:    [[ADD15:%.*]] = add i64 [[CONV14]], [[MUL6]]
+; CHECK-NEXT:    [[ADD15:%.*]] = add nuw i64 [[CONV14]], [[MUL6]]
 ; CHECK-NEXT:    [[SHR_I:%.*]] = lshr i64 [[ADD15]], 32
-; CHECK-NEXT:    [[ADD17:%.*]] = add i64 [[ADD10]], [[SHR_I]]
+; CHECK-NEXT:    [[ADD17:%.*]] = add nuw i64 [[ADD10]], [[SHR_I]]
 ; CHECK-NEXT:    store i64 [[ADD17]], ptr [[RHI:%.*]], align 8
 ; CHECK-NEXT:    [[MULLO:%.*]] = mul i64 [[B]], [[A]]
 ; CHECK-NEXT:    ret i64 [[MULLO]]
@@ -141,13 +141,13 @@ define i64 @mul_full_64_variant2(i64 %a, i64 %b, ptr nocapture %rhi) {
 ; CHECK-NEXT:    [[MUL6:%.*]] = mul nuw i64 [[SHR_I56]], [[CONV]]
 ; CHECK-NEXT:    [[MUL7:%.*]] = mul nuw i64 [[CONV3]], [[CONV]]
 ; CHECK-NEXT:    [[SHR_I55:%.*]] = lshr i64 [[MUL7]], 32
-; CHECK-NEXT:    [[ADD:%.*]] = add i64 [[SHR_I55]], [[MUL5]]
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw i64 [[SHR_I55]], [[MUL5]]
 ; CHECK-NEXT:    [[SHR_I54:%.*]] = lshr i64 [[ADD]], 32
-; CHECK-NEXT:    [[ADD10:%.*]] = add i64 [[SHR_I54]], [[MUL]]
+; CHECK-NEXT:    [[ADD10:%.*]] = add nuw i64 [[SHR_I54]], [[MUL]]
 ; CHECK-NEXT:    [[CONV14:%.*]] = and i64 [[ADD]], 4294967295
-; CHECK-NEXT:    [[ADD15:%.*]] = add i64 [[CONV14]], [[MUL6]]
+; CHECK-NEXT:    [[ADD15:%.*]] = add nuw i64 [[CONV14]], [[MUL6]]
 ; CHECK-NEXT:    [[SHR_I51:%.*]] = lshr i64 [[ADD15]], 32
-; CHECK-NEXT:    [[ADD17:%.*]] = add i64 [[ADD10]], [[SHR_I51]]
+; CHECK-NEXT:    [[ADD17:%.*]] = add nuw i64 [[ADD10]], [[SHR_I51]]
 ; CHECK-NEXT:    store i64 [[ADD17]], ptr [[RHI:%.*]], align 8
 ; CHECK-NEXT:    [[CONV24:%.*]] = shl i64 [[ADD15]], 32
 ; CHECK-NEXT:    [[CONV26:%.*]] = and i64 [[MUL7]], 4294967295
@@ -189,13 +189,13 @@ define i64 @mul_full_64_variant3(i64 %a, i64 %b, ptr nocapture %rhi) {
 ; CHECK-NEXT:    [[MUL6:%.*]] = mul nuw i64 [[SHR_I43]], [[CONV]]
 ; CHECK-NEXT:    [[MUL7:%.*]] = mul nuw i64 [[CONV3]], [[CONV]]
 ; CHECK-NEXT:    [[SHR_I42:%.*]] = lshr i64 [[MUL7]], 32
-; CHECK-NEXT:    [[ADD:%.*]] = add i64 [[SHR_I42]], [[MUL5]]
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw i64 [[SHR_I42]], [[MUL5]]
 ; CHECK-NEXT:    [[SHR_I41:%.*]] = lshr i64 [[ADD]], 32
-; CHECK-NEXT:    [[ADD10:%.*]] = add i64 [[SHR_I41]], [[MUL]]
+; CHECK-NEXT:    [[ADD10:%.*]] = add nuw i64 [[SHR_I41]], [[MUL]]
 ; CHECK-NEXT:    [[CONV14:%.*]] = and i64 [[ADD]], 4294967295
-; CHECK-NEXT:    [[ADD15:%.*]] = add i64 [[CONV14]], [[MUL6]]
+; CHECK-NEXT:    [[ADD15:%.*]] = add nuw i64 [[CONV14]], [[MUL6]]
 ; CHECK-NEXT:    [[SHR_I:%.*]] = lshr i64 [[ADD15]], 32
-; CHECK-NEXT:    [[ADD17:%.*]] = add i64 [[ADD10]], [[SHR_I]]
+; CHECK-NEXT:    [[ADD17:%.*]] = add nuw i64 [[ADD10]], [[SHR_I]]
 ; CHECK-NEXT:    store i64 [[ADD17]], ptr [[RHI:%.*]], align 8
 ; CHECK-NEXT:    [[ADD18:%.*]] = add i64 [[MUL6]], [[MUL5]]
 ; CHECK-NEXT:    [[SHL:%.*]] = shl i64 [[ADD18]], 32
@@ -238,15 +238,15 @@ define { i32, i32 } @mul_full_32(i32 %x, i32 %y) {
 ; CHECK-NEXT:    [[T3:%.*]] = mul nuw i32 [[YH]], [[XH]]
 ; CHECK-NEXT:    [[T0L:%.*]] = and i32 [[T0]], 65535
 ; CHECK-NEXT:    [[T0H:%.*]] = lshr i32 [[T0]], 16
-; CHECK-NEXT:    [[U0:%.*]] = add i32 [[T0H]], [[T1]]
+; CHECK-NEXT:    [[U0:%.*]] = add nuw i32 [[T0H]], [[T1]]
 ; CHECK-NEXT:    [[U0L:%.*]] = and i32 [[U0]], 65535
 ; CHECK-NEXT:    [[U0H:%.*]] = lshr i32 [[U0]], 16
-; CHECK-NEXT:    [[U1:%.*]] = add i32 [[U0L]], [[T2]]
+; CHECK-NEXT:    [[U1:%.*]] = add nuw i32 [[U0L]], [[T2]]
 ; CHECK-NEXT:    [[U1LS:%.*]] = shl i32 [[U1]], 16
 ; CHECK-NEXT:    [[U1H:%.*]] = lshr i32 [[U1]], 16
-; CHECK-NEXT:    [[U2:%.*]] = add i32 [[U0H]], [[T3]]
+; CHECK-NEXT:    [[U2:%.*]] = add nuw i32 [[U0H]], [[T3]]
 ; CHECK-NEXT:    [[LO:%.*]] = or disjoint i32 [[U1LS]], [[T0L]]
-; CHECK-NEXT:    [[HI:%.*]] = add i32 [[U2]], [[U1H]]
+; CHECK-NEXT:    [[HI:%.*]] = add nuw i32 [[U2]], [[U1H]]
 ; CHECK-NEXT:    [[RES_LO:%.*]] = insertvalue { i32, i32 } undef, i32 [[LO]], 0
 ; CHECK-NEXT:    [[RES:%.*]] = insertvalue { i32, i32 } [[RES_LO]], i32 [[HI]], 1
 ; CHECK-NEXT:    ret { i32, i32 } [[RES]]
@@ -302,13 +302,13 @@ define { i64, i64 } @mul_full_64_variant0_1() {
 ; CHECK-NEXT:    [[T2:%.*]] = mul nuw i64 [[YH]], [[XL]]
 ; CHECK-NEXT:    [[T0:%.*]] = mul nuw i64 [[YL]], [[XL]]
 ; CHECK-NEXT:    [[T0H:%.*]] = lshr i64 [[T0]], 32
-; CHECK-NEXT:    [[U0:%.*]] = add i64 [[T0H]], [[T1]]
+; CHECK-NEXT:    [[U0:%.*]] = add nuw i64 [[T0H]], [[T1]]
 ; CHECK-NEXT:    [[U0L:%.*]] = and i64 [[U0]], 4294967295
-; CHECK-NEXT:    [[U1:%.*]] = add i64 [[U0L]], [[T2]]
+; CHECK-NEXT:    [[U1:%.*]] = add nuw i64 [[U0L]], [[T2]]
 ; CHECK-NEXT:    [[U0H:%.*]] = lshr i64 [[U0]], 32
-; CHECK-NEXT:    [[U2:%.*]] = add i64 [[U0H]], [[T3]]
+; CHECK-NEXT:    [[U2:%.*]] = add nuw i64 [[U0H]], [[T3]]
 ; CHECK-NEXT:    [[U1H:%.*]] = lshr i64 [[U1]], 32
-; CHECK-NEXT:    [[HI:%.*]] = add i64 [[U2]], [[U1H]]
+; CHECK-NEXT:    [[HI:%.*]] = add nuw i64 [[U2]], [[U1H]]
 ; CHECK-NEXT:    [[U1LS:%.*]] = shl i64 [[U1]], 32
 ; CHECK-NEXT:    [[T0L:%.*]] = and i64 [[T0]], 4294967295
 ; CHECK-NEXT:    [[LO:%.*]] = or disjoint i64 [[U1LS]], [[T0L]]
@@ -360,13 +360,13 @@ define { i64, i64 } @mul_full_64_variant0_2() {
 ; CHECK-NEXT:    [[T1:%.*]] = mul nuw i64 [[XH]], [[YL]]
 ; CHECK-NEXT:    [[T0:%.*]] = mul nuw i64 [[XL]], [[YL]]
 ; CHECK-NEXT:    [[T0H:%.*]] = lshr i64 [[T0]], 32
-; CHECK-NEXT:    [[U0:%.*]] = add i64 [[T1]], [[T0H]]
+; CHECK-NEXT:    [[U0:%.*]] = add nuw i64 [[T1]], [[T0H]]
 ; CHECK-NEXT:    [[U0L:%.*]] = and i64 [[U0]], 4294967295
-; CHECK-NEXT:    [[U1:%.*]] = add i64 [[T2]], [[U0L]]
+; CHECK-NEXT:    [[U1:%.*]] = add nuw i64 [[T2]], [[U0L]]
 ; CHECK-NEXT:    [[U0H:%.*]] = lshr i64 [[U0]], 32
-; CHECK-NEXT:    [[U2:%.*]] = add i64 [[U0H]], [[T3]]
+; CHECK-NEXT:    [[U2:%.*]] = add nuw i64 [[U0H]], [[T3]]
 ; CHECK-NEXT:    [[U1H:%.*]] = lshr i64 [[U1]], 32
-; CHECK-NEXT:    [[HI:%.*]] = add i64 [[U1H]], [[U2]]
+; CHECK-NEXT:    [[HI:%.*]] = add nuw i64 [[U1H]], [[U2]]
 ; CHECK-NEXT:    [[U1LS:%.*]] = shl i64 [[U1]], 32
 ; CHECK-NEXT:    [[T0L:%.*]] = and i64 [[T0]], 4294967295
 ; CHECK-NEXT:    [[LO:%.*]] = or disjoint i64 [[T0L]], [[U1LS]]
@@ -417,13 +417,13 @@ define i64 @umulh_64(i64 %x, i64 %y) {
 ; CHECK-NEXT:    [[T2:%.*]] = mul nuw i64 [[YH]], [[XL]]
 ; CHECK-NEXT:    [[T3:%.*]] = mul nuw i64 [[YH]], [[XH]]
 ; CHECK-NEXT:    [[T0H:%.*]] = lshr i64 [[T0]], 32
-; CHECK-NEXT:    [[U0:%.*]] = add i64 [[T0H]], [[T1]]
+; CHECK-NEXT:    [[U0:%.*]] = add nuw i64 [[T0H]], [[T1]]
 ; CHECK-NEXT:    [[U0L:%.*]] = and i64 [[U0]], 4294967295
 ; CHECK-NEXT:    [[U0H:%.*]] = lshr i64 [[U0]], 32
-; CHECK-NEXT:    [[U1:%.*]] = add i64 [[U0L]], [[T2]]
+; CHECK-NEXT:    [[U1:%.*]] = add nuw i64 [[U0L]], [[T2]]
 ; CHECK-NEXT:    [[U1H:%.*]] = lshr i64 [[U1]], 32
-; CHECK-NEXT:    [[U2:%.*]] = add i64 [[U0H]], [[T3]]
-; CHECK-NEXT:    [[HI:%.*]] = add i64 [[U2]], [[U1H]]
+; CHECK-NEXT:    [[U2:%.*]] = add nuw i64 [[U0H]], [[T3]]
+; CHECK-NEXT:    [[HI:%.*]] = add nuw i64 [[U2]], [[U1H]]
 ; CHECK-NEXT:    ret i64 [[HI]]
 ;
   %xl = and i64 %x, 4294967295
@@ -577,15 +577,15 @@ define { i64, i64 } @mul_full_64_duplicate(i64 %x, i64 %y) {
 ; CHECK-NEXT:    [[T3:%.*]] = mul nuw i64 [[YH]], [[XH]]
 ; CHECK-NEXT:    [[T0L:%.*]] = and i64 [[T0]], 4294967295
 ; CHECK-NEXT:    [[T0H:%.*]] = lshr i64 [[T0]], 32
-; CHECK-NEXT:    [[U0:%.*]] = add i64 [[T0H]], [[T1]]
+; CHECK-NEXT:    [[U0:%.*]] = add nuw i64 [[T0H]], [[T1]]
 ; CHECK-NEXT:    [[U0L:%.*]] = and i64 [[U0]], 4294967295
 ; CHECK-NEXT:    [[U0H:%.*]] = lshr i64 [[U0]], 32
-; CHECK-NEXT:    [[U1:%.*]] = add i64 [[U0L]], [[T2]]
+; CHECK-NEXT:    [[U1:%.*]] = add nuw i64 [[U0L]], [[T2]]
 ; CHECK-NEXT:    [[U1LS:%.*]] = shl i64 [[U1]], 32
 ; CHECK-NEXT:    [[U1H:%.*]] = lshr i64 [[U1]], 32
-; CHECK-NEXT:    [[U2:%.*]] = add i64 [[U0H]], [[T3]]
+; CHECK-NEXT:    [[U2:%.*]] = add nuw i64 [[U0H]], [[T3]]
 ; CHECK-NEXT:    [[LO:%.*]] = or disjoint i64 [[U1LS]], [[T0L]]
-; CHECK-NEXT:    [[HI:%.*]] = add i64 [[U2]], [[U1H]]
+; CHECK-NEXT:    [[HI:%.*]] = add nuw i64 [[U2]], [[U1H]]
 ; CHECK-NEXT:    [[RES_LO:%.*]] = insertvalue { i64, i64 } undef, i64 [[LO]], 0
 ; CHECK-NEXT:    [[RES:%.*]] = insertvalue { i64, i64 } [[RES_LO]], i64 [[HI]], 1
 ; CHECK-NEXT:    ret { i64, i64 } [[RES]]
@@ -640,13 +640,13 @@ define i64 @umulhi_64_v2() {
 ; CHECK-NEXT:    [[T1:%.*]] = mul nuw i64 [[XH]], [[YL]]
 ; CHECK-NEXT:    [[T0:%.*]] = mul nuw i64 [[XL]], [[YL]]
 ; CHECK-NEXT:    [[T0H:%.*]] = lshr i64 [[T0]], 32
-; CHECK-NEXT:    [[U0:%.*]] = add i64 [[T1]], [[T0H]]
+; CHECK-NEXT:    [[U0:%.*]] = add nuw i64 [[T1]], [[T0H]]
 ; CHECK-NEXT:    [[U0L:%.*]] = and i64 [[U0]], 4294967295
-; CHECK-NEXT:    [[U1:%.*]] = add i64 [[T2]], [[U0L]]
+; CHECK-NEXT:    [[U1:%.*]] = add nuw i64 [[T2]], [[U0L]]
 ; CHECK-NEXT:    [[U0H:%.*]] = lshr i64 [[U0]], 32
-; CHECK-NEXT:    [[U2:%.*]] = add i64 [[U0H]], [[T3]]
+; CHECK-NEXT:    [[U2:%.*]] = add nuw i64 [[U0H]], [[T3]]
 ; CHECK-NEXT:    [[U1H:%.*]] = lshr i64 [[U1]], 32
-; CHECK-NEXT:    [[HI:%.*]] = add i64 [[U1H]], [[U2]]
+; CHECK-NEXT:    [[HI:%.*]] = add nuw i64 [[U1H]], [[U2]]
 ; CHECK-NEXT:    ret i64 [[HI]]
 ;
   %x = call i64 @get_number()
@@ -688,13 +688,13 @@ define i64 @umulhi_64_v3() {
 ; CHECK-NEXT:    [[T1:%.*]] = mul nuw i64 [[XH]], [[YL]]
 ; CHECK-NEXT:    [[T0:%.*]] = mul nuw i64 [[XL]], [[YL]]
 ; CHECK-NEXT:    [[T0H:%.*]] = lshr i64 [[T0]], 32
-; CHECK-NEXT:    [[U0:%.*]] = add i64 [[T1]], [[T0H]]
+; CHECK-NEXT:    [[U0:%.*]] = add nuw i64 [[T1]], [[T0H]]
 ; CHECK-NEXT:    [[U0L:%.*]] = and i64 [[U0]], 4294967295
-; CHECK-NEXT:    [[U1:%.*]] = add i64 [[T2]], [[U0L]]
+; CHECK-NEXT:    [[U1:%.*]] = add nuw i64 [[T2]], [[U0L]]
 ; CHECK-NEXT:    [[U0H:%.*]] = lshr i64 [[U0]], 32
-; CHECK-NEXT:    [[U2:%.*]] = add i64 [[U0H]], [[T3]]
+; CHECK-NEXT:    [[U2:%.*]] = add nuw i64 [[U0H]], [[T3]]
 ; CHECK-NEXT:    [[U1H:%.*]] = lshr i64 [[U1]], 32
-; CHECK-NEXT:    [[HI:%.*]] = add i64 [[U1H]], [[U2]]
+; CHECK-NEXT:    [[HI:%.*]] = add nuw i64 [[U1H]], [[U2]]
 ; CHECK-NEXT:    ret i64 [[HI]]
 ;
   %x = call i64 @get_number()

--- a/llvm/test/Transforms/InstCombine/pr80597.ll
+++ b/llvm/test/Transforms/InstCombine/pr80597.ll
@@ -5,14 +5,9 @@ define i64 @pr80597(i1 %cond) {
 ; CHECK-LABEL: define i64 @pr80597(
 ; CHECK-SAME: i1 [[COND:%.*]]) {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[ADD:%.*]] = select i1 [[COND]], i64 0, i64 -12884901888
-; CHECK-NEXT:    [[SEXT1:%.*]] = add nsw i64 [[ADD]], 8836839514384105472
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i64 [[SEXT1]], -34359738368
-; CHECK-NEXT:    br i1 [[CMP]], label [[IF_THEN:%.*]], label [[IF_ELSE:%.*]]
+; CHECK-NEXT:    br i1 true, label [[IF_THEN:%.*]], label [[IF_ELSE:%.*]]
 ; CHECK:       if.else:
-; CHECK-NEXT:    [[SEXT2:%.*]] = ashr exact i64 [[ADD]], 1
-; CHECK-NEXT:    [[ASHR:%.*]] = or disjoint i64 [[SEXT2]], 4418419761487020032
-; CHECK-NEXT:    ret i64 [[ASHR]]
+; CHECK-NEXT:    ret i64 poison
 ; CHECK:       if.then:
 ; CHECK-NEXT:    ret i64 0
 ;

--- a/llvm/test/Transforms/InstCombine/saturating-add-sub.ll
+++ b/llvm/test/Transforms/InstCombine/saturating-add-sub.ll
@@ -1111,8 +1111,7 @@ define <3 x i8> @test_vector_usub_add_nuw_no_ov_nonsplat1_poison(<3 x i8> %a) {
 ; Can be optimized if the add nuw RHS constant range handles non-splat vectors.
 define <2 x i8> @test_vector_usub_add_nuw_no_ov_nonsplat2(<2 x i8> %a) {
 ; CHECK-LABEL: @test_vector_usub_add_nuw_no_ov_nonsplat2(
-; CHECK-NEXT:    [[B:%.*]] = add nuw <2 x i8> [[A:%.*]], <i8 10, i8 9>
-; CHECK-NEXT:    [[R:%.*]] = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> [[B]], <2 x i8> splat (i8 9))
+; CHECK-NEXT:    [[R:%.*]] = add <2 x i8> [[A:%.*]], <i8 1, i8 0>
 ; CHECK-NEXT:    ret <2 x i8> [[R]]
 ;
   %b = add nuw <2 x i8> %a, <i8 10, i8 9>
@@ -1188,7 +1187,7 @@ define <2 x i8> @test_vector_ssub_add_nsw_no_ov_nonsplat2(<2 x i8> %a, <2 x i8> 
 ; CHECK-LABEL: @test_vector_ssub_add_nsw_no_ov_nonsplat2(
 ; CHECK-NEXT:    [[AA:%.*]] = add nsw <2 x i8> [[A:%.*]], <i8 7, i8 8>
 ; CHECK-NEXT:    [[BB:%.*]] = and <2 x i8> [[B:%.*]], splat (i8 7)
-; CHECK-NEXT:    [[R:%.*]] = call <2 x i8> @llvm.ssub.sat.v2i8(<2 x i8> [[AA]], <2 x i8> [[BB]])
+; CHECK-NEXT:    [[R:%.*]] = sub nsw <2 x i8> [[AA]], [[BB]]
 ; CHECK-NEXT:    ret <2 x i8> [[R]]
 ;
   %aa = add nsw <2 x i8> %a, <i8 7, i8 8>

--- a/llvm/test/Transforms/PhaseOrdering/X86/scalarization-inseltpoison.ll
+++ b/llvm/test/Transforms/PhaseOrdering/X86/scalarization-inseltpoison.ll
@@ -22,7 +22,7 @@ define <4 x i32> @square(<4 x i32> %num, i32 %y, i32 %x, i32 %h, i32 %k, i32 %w,
 ; CHECK-NEXT:    [[OP_RDX9:%.*]] = add nsw i32 [[DIV]], [[DIV9]]
 ; CHECK-NEXT:    [[OP_RDX10:%.*]] = add i32 [[MUL5]], [[MUL13]]
 ; CHECK-NEXT:    [[OP_RDX11:%.*]] = add i32 [[MUL]], [[MUL21]]
-; CHECK-NEXT:    [[OP_RDX12:%.*]] = add i32 [[OP_RDX]], [[OP_RDX9]]
+; CHECK-NEXT:    [[OP_RDX12:%.*]] = add nsw i32 [[OP_RDX]], [[OP_RDX9]]
 ; CHECK-NEXT:    [[OP_RDX13:%.*]] = add i32 [[OP_RDX10]], [[OP_RDX11]]
 ; CHECK-NEXT:    [[OP_RDX14:%.*]] = add i32 [[OP_RDX12]], [[OP_RDX13]]
 ; CHECK-NEXT:    [[OP_RDX15:%.*]] = add i32 [[OP_RDX14]], [[Y:%.*]]

--- a/llvm/test/Transforms/PhaseOrdering/X86/scalarization.ll
+++ b/llvm/test/Transforms/PhaseOrdering/X86/scalarization.ll
@@ -22,7 +22,7 @@ define <4 x i32> @square(<4 x i32> %num, i32 %y, i32 %x, i32 %h, i32 %k, i32 %w,
 ; CHECK-NEXT:    [[OP_RDX9:%.*]] = add nsw i32 [[DIV]], [[DIV9]]
 ; CHECK-NEXT:    [[OP_RDX10:%.*]] = add i32 [[MUL5]], [[MUL13]]
 ; CHECK-NEXT:    [[OP_RDX11:%.*]] = add i32 [[MUL]], [[MUL21]]
-; CHECK-NEXT:    [[OP_RDX12:%.*]] = add i32 [[OP_RDX]], [[OP_RDX9]]
+; CHECK-NEXT:    [[OP_RDX12:%.*]] = add nsw i32 [[OP_RDX]], [[OP_RDX9]]
 ; CHECK-NEXT:    [[OP_RDX13:%.*]] = add i32 [[OP_RDX10]], [[OP_RDX11]]
 ; CHECK-NEXT:    [[OP_RDX14:%.*]] = add i32 [[OP_RDX12]], [[OP_RDX13]]
 ; CHECK-NEXT:    [[OP_RDX15:%.*]] = add i32 [[OP_RDX14]], [[Y:%.*]]

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -3561,6 +3561,237 @@ TEST_F(ValueTrackingTest, ComputeConstantRange) {
     // If we don't know the value of x.2, we don't know the value of x.1.
     EXPECT_TRUE(CR1.isFullSet());
   }
+  {
+    // udiv with bounded operands:
+    //  * x in [4, 8), y in [2, 4)
+    //  * udiv x, y = [4/3, 8/2) = [1, 4)
+    auto M = parseModule(R"(
+  declare void @llvm.assume(i1)
+
+  define i32 @test(i32 %x, i32 %y) {
+    %x.lo = icmp uge i32 %x, 4
+    call void @llvm.assume(i1 %x.lo)
+    %x.hi = icmp ult i32 %x, 8
+    call void @llvm.assume(i1 %x.hi)
+    %y.lo = icmp uge i32 %y, 2
+    call void @llvm.assume(i1 %y.lo)
+    %y.hi = icmp ult i32 %y, 4
+    call void @llvm.assume(i1 %y.hi)
+    %div = udiv i32 %x, %y
+    ret i32 %div
+  })");
+    Function *F = M->getFunction("test");
+    AssumptionCache AC(*F);
+    Instruction *Div = &findInstructionByName(F, "div");
+    ConstantRange CR = computeConstantRange(Div, false, true, &AC, Div);
+    EXPECT_EQ(1, CR.getLower());
+    EXPECT_EQ(4, CR.getUpper());
+  }
+  {
+    // mul with bounded operands:
+    //  * x in [2, 5), y in [3, 7)
+    //  * mul x, y = [2*3, 4*6+1) = [6, 25)
+    auto M = parseModule(R"(
+  declare void @llvm.assume(i1)
+
+  define i32 @test(i32 %x, i32 %y) {
+    %x.lo = icmp uge i32 %x, 2
+    call void @llvm.assume(i1 %x.lo)
+    %x.hi = icmp ult i32 %x, 5
+    call void @llvm.assume(i1 %x.hi)
+    %y.lo = icmp uge i32 %y, 3
+    call void @llvm.assume(i1 %y.lo)
+    %y.hi = icmp ult i32 %y, 7
+    call void @llvm.assume(i1 %y.hi)
+    %mul = mul i32 %x, %y
+    ret i32 %mul
+  })");
+    Function *F = M->getFunction("test");
+    AssumptionCache AC(*F);
+    Instruction *Mul = &findInstructionByName(F, "mul");
+    ConstantRange CR = computeConstantRange(Mul, false, true, &AC, Mul);
+    EXPECT_EQ(6, CR.getLower());
+    EXPECT_EQ(25, CR.getUpper());
+  }
+  {
+    // sdiv with bounded signed operands:
+    //  * x in [-8, -1], y in [2, 4)
+    //  * sdiv x, y = [-4, 0)  (most negative: -8/2=-4, most positive: -1/3=0)
+    auto M = parseModule(R"(
+  declare void @llvm.assume(i1)
+
+  define i32 @test(i32 %x, i32 %y) {
+    %x.lo = icmp sge i32 %x, -8
+    call void @llvm.assume(i1 %x.lo)
+    %x.hi = icmp sle i32 %x, -1
+    call void @llvm.assume(i1 %x.hi)
+    %y.lo = icmp sge i32 %y, 2
+    call void @llvm.assume(i1 %y.lo)
+    %y.hi = icmp slt i32 %y, 4
+    call void @llvm.assume(i1 %y.hi)
+    %div = sdiv i32 %x, %y
+    ret i32 %div
+  })");
+    Function *F = M->getFunction("test");
+    AssumptionCache AC(*F);
+    Instruction *Div = &findInstructionByName(F, "div");
+    ConstantRange CR = computeConstantRange(Div, true, true, &AC, Div);
+    // ConstantRange upper bound is exclusive: range is [-4, 0] = [-4, 1).
+    EXPECT_EQ(APInt(32, -4, true), CR.getLower());
+    EXPECT_EQ(APInt(32, 1, true), CR.getUpper());
+  }
+  {
+    // urem with bounded operands:
+    //  * x in [5, 10), y in [3, 6)
+    //  * urem x, y in [0, 5)  (max remainder < max divisor)
+    auto M = parseModule(R"(
+  declare void @llvm.assume(i1)
+
+  define i32 @test(i32 %x, i32 %y) {
+    %x.lo = icmp uge i32 %x, 5
+    call void @llvm.assume(i1 %x.lo)
+    %x.hi = icmp ult i32 %x, 10
+    call void @llvm.assume(i1 %x.hi)
+    %y.lo = icmp uge i32 %y, 3
+    call void @llvm.assume(i1 %y.lo)
+    %y.hi = icmp ult i32 %y, 6
+    call void @llvm.assume(i1 %y.hi)
+    %rem = urem i32 %x, %y
+    ret i32 %rem
+  })");
+    Function *F = M->getFunction("test");
+    AssumptionCache AC(*F);
+    Instruction *Rem = &findInstructionByName(F, "rem");
+    ConstantRange CR = computeConstantRange(Rem, false, true, &AC, Rem);
+    EXPECT_FALSE(CR.isFullSet());
+    EXPECT_TRUE(CR.contains(APInt(32, 0)));
+    EXPECT_FALSE(CR.contains(APInt(32, 5)));
+  }
+  {
+    // srem with bounded signed operands:
+    //  * x in [5, 10), y in [3, 6)
+    //  * srem x, y in [0, 5)
+    auto M = parseModule(R"(
+  declare void @llvm.assume(i1)
+
+  define i32 @test(i32 %x, i32 %y) {
+    %x.lo = icmp sge i32 %x, 5
+    call void @llvm.assume(i1 %x.lo)
+    %x.hi = icmp slt i32 %x, 10
+    call void @llvm.assume(i1 %x.hi)
+    %y.lo = icmp sge i32 %y, 3
+    call void @llvm.assume(i1 %y.lo)
+    %y.hi = icmp slt i32 %y, 6
+    call void @llvm.assume(i1 %y.hi)
+    %rem = srem i32 %x, %y
+    ret i32 %rem
+  })");
+    Function *F = M->getFunction("test");
+    AssumptionCache AC(*F);
+    Instruction *Rem = &findInstructionByName(F, "rem");
+    ConstantRange CR = computeConstantRange(Rem, true, true, &AC, Rem);
+    EXPECT_FALSE(CR.isFullSet());
+    EXPECT_TRUE(CR.contains(APInt(32, 0)));
+    EXPECT_FALSE(CR.contains(APInt(32, 5)));
+  }
+  {
+    // add nuw with bounded operands:
+    //  * x in [2, 5), y in [10, 20)
+    //  * add nuw x, y in [12, 24)
+    auto M = parseModule(R"(
+  declare void @llvm.assume(i1)
+
+  define i32 @test(i32 %x, i32 %y) {
+    %x.lo = icmp uge i32 %x, 2
+    call void @llvm.assume(i1 %x.lo)
+    %x.hi = icmp ult i32 %x, 5
+    call void @llvm.assume(i1 %x.hi)
+    %y.lo = icmp uge i32 %y, 10
+    call void @llvm.assume(i1 %y.lo)
+    %y.hi = icmp ult i32 %y, 20
+    call void @llvm.assume(i1 %y.hi)
+    %add = add nuw i32 %x, %y
+    ret i32 %add
+  })");
+    Function *F = M->getFunction("test");
+    AssumptionCache AC(*F);
+    Instruction *Add = &findInstructionByName(F, "add");
+    ConstantRange CR = computeConstantRange(Add, false, true, &AC, Add);
+    EXPECT_EQ(12, CR.getLower());
+    EXPECT_EQ(24, CR.getUpper());
+  }
+  {
+    // sub nuw with bounded operands:
+    //  * x in [10, 20), y in [2, 5)
+    //  * sub nuw x, y in [6, 18)
+    auto M = parseModule(R"(
+  declare void @llvm.assume(i1)
+
+  define i32 @test(i32 %x, i32 %y) {
+    %x.lo = icmp uge i32 %x, 10
+    call void @llvm.assume(i1 %x.lo)
+    %x.hi = icmp ult i32 %x, 20
+    call void @llvm.assume(i1 %x.hi)
+    %y.lo = icmp uge i32 %y, 2
+    call void @llvm.assume(i1 %y.lo)
+    %y.hi = icmp ult i32 %y, 5
+    call void @llvm.assume(i1 %y.hi)
+    %sub = sub nuw i32 %x, %y
+    ret i32 %sub
+  })");
+    Function *F = M->getFunction("test");
+    AssumptionCache AC(*F);
+    Instruction *Sub = &findInstructionByName(F, "sub");
+    ConstantRange CR = computeConstantRange(Sub, false, true, &AC, Sub);
+    EXPECT_EQ(6, CR.getLower());
+    EXPECT_EQ(18, CR.getUpper());
+  }
+  {
+    // trunc propagates range from source:
+    //  * x in [0, 256) (i16), trunc to i8 -> [0, 256) but capped at i8 max
+    //  * actually x in [4, 8) -> trunc gives [4, 8) in i8
+    auto M = parseModule(R"(
+  declare void @llvm.assume(i1)
+
+  define i8 @test(i16 %x) {
+    %lo = icmp uge i16 %x, 4
+    call void @llvm.assume(i1 %lo)
+    %hi = icmp ult i16 %x, 8
+    call void @llvm.assume(i1 %hi)
+    %t = trunc i16 %x to i8
+    ret i8 %t
+  })");
+    Function *F = M->getFunction("test");
+    AssumptionCache AC(*F);
+    Instruction *T = &findInstructionByName(F, "t");
+    ConstantRange CR = computeConstantRange(T, false, true, &AC, T);
+    EXPECT_EQ(4, CR.getLower());
+    EXPECT_EQ(8, CR.getUpper());
+  }
+  {
+    // assume with signed comparison: ForSigned should be propagated.
+    // x in [-10, -1] (signed), stride = add nsw nuw x, 1
+    // With Cmp->isSigned() the RHS range for the signed icmp is computed
+    // in signed form, giving a tighter result.
+    auto M = parseModule(R"(
+  declare void @llvm.assume(i1)
+
+  define i32 @test(i32 %x) {
+    %lo = icmp sge i32 %x, -10
+    call void @llvm.assume(i1 %lo)
+    %hi = icmp slt i32 %x, 0
+    call void @llvm.assume(i1 %hi)
+    %r = add nsw nuw i32 %x, 1
+    ret i32 %r
+  })");
+    Function *F = M->getFunction("test");
+    AssumptionCache AC(*F);
+    Value *X = &*F->arg_begin();
+    Instruction *I = &findInstructionByName(F, "r");
+    ConstantRange CR = computeConstantRange(X, true, true, &AC, I);
+    EXPECT_EQ(APInt(32, -10, true), CR.getLower());
+    EXPECT_EQ(APInt(32, 0, true), CR.getUpper());
+  }
 }
 
 struct FindAllocaForValueTestParams {


### PR DESCRIPTION
Relates: https://github.com/llvm/llvm-project/pull/190565

This PR adds some extra handling to ValueTracking's computeConstantRange. This handles udiv, sdiv, urem, srem, mul, add, sub, trunc.

This allows for recursive handling for those cases. Most of the time (changed tests) nsw or nuw is tacked onto some tests that had defined ranges. This is a pretty minor win in most cases.

Most cases don't change the assembly from what I can see except the first case, so most of the win is earlier folding. 

Here are some interesting cases I found:

InstCombine/add.ll:3274

add, zext, add -> zext because the increment and decrement cancel each other out due to improved range analysis:

```llvm
%a = add nsw <2 x i8> %o, <i8 -1, i8 -1>
%b = zext <2 x i8> %a to <2 x i32>
%c = add nuw nsw <2 x i32> %b, <i32 1, i32 poison>
```

```llvm
%c = zext <2 x i8> %o to <2 x i32>
```

This one does turn into a concrete codegen change:

```asm
  dec_zext_add_nonzero_vec_poison2:       # @dec_zext_add_nonzero_vec_poison2
          por     xmm0, xmmword ptr [rip + .LCPI0_0]
          pcmpeqd xmm1, xmm1
          paddb   xmm0, xmm1
          pxor    xmm1, xmm1
          punpcklbw       xmm0, xmm1
          punpcklwd       xmm0, xmm1
          mov     eax, 1
          movd    xmm1, eax
          paddd   xmm0, xmm1
          ret
```

Turns into:

```asm
  dec_zext_add_nonzero_vec_poison2:       # @dec_zext_add_nonzero_vec_poison2
          por     xmm0, xmmword ptr [rip + .LCPI0_0]
          pxor    xmm1, xmm1
          punpcklbw       xmm0, xmm1
          punpcklwd       xmm0, xmm1
          ret
```

InstCombine/icmp-add.ll:3163

%x is bounded so %x + 4 is always unsigned less than -6. You can delete all of this and return true.

```llvm
%add = add nsw i32 %x, 4
%cmp = icmp ult i32 %add, -6
ret i1 %cmp
```

```llvm
ret i1 true
```

InstCombine/icmp-mul.ll:950

mul range proves that %m cannot be > 3060 so it just deletes the code and replaces it with false:

```llvm
%x30 = and i32 %x, 12
%y8 = and i32 %y, 255
%m = mul nuw nsw i32 %y8, %x30
%r = icmp samesign ugt i32 %m, 3060
ret i1 %r
```

```llvm
ret i1 false
```

InstCombine/saturating-add-sub.ll:1112

Because there's proof that saturating subtraction is unnecessary and that sub(add(...), C) can fold into just an add, instcombine does that: 

```llvm
%b = add nuw <2 x i8> %a, <i8 10, i8 9>
%r = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> %b, <2 x i8> <i8 9, i8 9>)
ret <2 x i8> %r
```

```llvm
%r = add <2 x i8> %a, <i8 1, i8 0>
ret <2 x i8> %r
```

llvm/test/Transforms/InstCombine/pr80597.ll:4

```llvm
entry:
  %add = select i1 %cond, i64 0, i64 -12884901888
  %sext1 = add nsw i64 %add, 8836839514384105472
  %cmp = icmp ult i64 %sext1, -34359738368
  br i1 %cmp, label %if.then, label %if.else

if.else:
  %sext2 = ashr exact i64 %add, 1
  %ashr = or disjoint i64 %sext2, 4418419761487020032
  ret i64 %ashr

if.then:
  ret i64 0
```

Turns into this in instcombine, which is an improvement. The codegen doesn't change but it's folded away faster.

```llvm
entry:
  br i1 true, label %if.then, label %if.else

if.else:
  ret i64 poison

if.then:
  ret i64 0
```
