### PR TITLE
[NVPTX][NFC] Update NVPTXLowerAlloca comments to use opaque pointer syntax

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXLowerAlloca.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXLowerAlloca.cpp
@@ -6,18 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// For all alloca instructions, and add a pair of cast to local address for
+// For all alloca instructions, add a pair of casts to local address for
 // each of them. For example,
 //
 //   %A = alloca i32
-//   store i32 0, i32* %A ; emits st.u32
+//   store i32 0, ptr %A ; emits st.u32
 //
 // will be transformed to
 //
 //   %A = alloca i32
-//   %Local = addrspacecast i32* %A to i32 addrspace(5)*
-//   %Generic = addrspacecast i32 addrspace(5)* %A to i32*
-//   store i32 0, i32 addrspace(5)* %Generic ; emits st.local.u32
+//   %Local = addrspacecast ptr %A to ptr addrspace(5)
+//   %Generic = addrspacecast ptr addrspace(5) %Local to ptr
+//   store i32 0, ptr %Generic ; emits st.local.u32
 //
 // And we will rely on NVPTXInferAddressSpaces to combine the last two
 // instructions.


### PR DESCRIPTION
Modernize the header comment IR examples in `NVPTXLowerAlloca.cpp` to use opaque pointer syntax (`ptr` instead of `i32*`, `i32 addrspace(5)*`, etc.), matching the LLVM-wide move to opaque pointers in LLVM 17+.

**Changes:**
- Update IR examples from typed pointers (`i32*`, `i32 addrspace(5)*`) to opaque pointer syntax (`ptr`, `ptr addrspace(5)`)
- Fix grammar: "For all alloca instructions, **and** add a pair of cast" → "add a pair of **casts**"
- Fix incorrect variable reference: second `addrspacecast` was using `%A` (the alloca result) instead of `%Local` (the result of the first addrspacecast to local address space)

**Flow:**
```
 ┌──────────┐    ┌──────────────────┐    ┌──────────────────┐
 │ Frontend │--->│ NVPTXLowerAlloca  │--->│ InferAddrSpaces  │
 └──────────┘    │  (comments only)  │    └──────────────────┘
                 │    <- MODIFIED    │
                 └──────────────────┘
```

**IR (comment fix — before vs after):**
```
Before (typed pointers, incorrect variable):
  %A     = alloca i32
  %Local = addrspacecast i32* %A to i32 addrspace(5)*
  %Generic = addrspacecast i32 addrspace(5)* %A to i32*
                                              ^^ wrong: should be %Local

After (opaque pointers, correct variable):
  %A     = alloca i32
  %Local = addrspacecast ptr %A to ptr addrspace(5)
  %Generic = addrspacecast ptr addrspace(5) %Local to ptr
                                            ^^^^^^ fixed
```

**Files changed:** 1 file, +5/-5 lines

Comment-only change, no functional impact.