### PR TITLE
[NewPM] Port AArch64RedundantCopyElimination

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.h
+++ b/llvm/lib/Target/AArch64/AArch64.h
@@ -121,7 +121,7 @@ void initializeAArch64PostLegalizerLoweringPass(PassRegistry &);
 void initializeAArch64PostSelectOptimizePass(PassRegistry &);
 void initializeAArch64PreLegalizerCombinerPass(PassRegistry &);
 void initializeAArch64PromoteConstantPass(PassRegistry&);
-void initializeAArch64RedundantCopyEliminationPass(PassRegistry&);
+void initializeAArch64RedundantCopyEliminationLegacyPass(PassRegistry &);
 void initializeAArch64RedundantCondBranchPass(PassRegistry &);
 void initializeAArch64SIMDInstrOptPass(PassRegistry &);
 void initializeAArch64SLSHardeningPass(PassRegistry &);
@@ -213,6 +213,13 @@ public:
 
 class AArch64PostCoalescerPass
     : public PassInfoMixin<AArch64PostCoalescerPass> {
+public:
+  PreservedAnalyses run(MachineFunction &MF,
+                        MachineFunctionAnalysisManager &MFAM);
+};
+
+class AArch64RedundantCopyEliminationPass
+    : public PassInfoMixin<AArch64RedundantCopyEliminationPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/AArch64/AArch64PassRegistry.def
+++ b/llvm/lib/Target/AArch64/AArch64PassRegistry.def
@@ -29,6 +29,7 @@
 MACHINE_FUNCTION_PASS("aarch64-branch-targets", AArch64BranchTargetsPass())
 MACHINE_FUNCTION_PASS("aarch64-collect-loh", AArch64CollectLOHPass())
 MACHINE_FUNCTION_PASS("aarch64-condopt", AArch64ConditionOptimizerPass())
+MACHINE_FUNCTION_PASS("aarch64-copyelim", AArch64RedundantCopyEliminationPass())
 MACHINE_FUNCTION_PASS("aarch64-dead-defs", AArch64DeadRegisterDefinitionsPass())
 MACHINE_FUNCTION_PASS("aarch64-expand-pseudo", AArch64ExpandPseudoPass())
 MACHINE_FUNCTION_PASS("aarch64-fix-cortex-a53-835769", AArch64A53Fix835769Pass())

--- a/llvm/lib/Target/AArch64/AArch64RedundantCopyElimination.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RedundantCopyElimination.cpp
@@ -280,7 +280,8 @@ bool AArch64RedundantCopyEliminationImpl::knownRegValInBlock(
   return false;
 }
 
-bool AArch64RedundantCopyEliminationImpl::optimizeBlock(MachineBasicBlock *MBB) {
+bool AArch64RedundantCopyEliminationImpl::optimizeBlock(
+    MachineBasicBlock *MBB) {
   // Check if the current basic block has a single predecessor.
   if (MBB->pred_size() != 1)
     return false;

--- a/llvm/lib/Target/AArch64/AArch64RedundantCopyElimination.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RedundantCopyElimination.cpp
@@ -66,7 +66,11 @@ using namespace llvm;
 STATISTIC(NumCopiesRemoved, "Number of copies removed.");
 
 namespace {
-class AArch64RedundantCopyElimination : public MachineFunctionPass {
+class AArch64RedundantCopyEliminationImpl {
+public:
+  bool run(MachineFunction &MF);
+
+private:
   const MachineRegisterInfo *MRI;
   const TargetRegisterInfo *TRI;
 
@@ -76,10 +80,6 @@ class AArch64RedundantCopyElimination : public MachineFunctionPass {
 
   // OptBBClobberedRegs is used when optimizing away redundant copies/moves.
   LiveRegUnits OptBBClobberedRegs, OptBBUsedRegs;
-
-public:
-  static char ID;
-  AArch64RedundantCopyElimination() : MachineFunctionPass(ID) {}
 
   struct RegImm {
     MCPhysReg Reg;
@@ -91,7 +91,15 @@ public:
                           SmallVectorImpl<RegImm> &KnownRegs,
                           MachineBasicBlock::iterator &FirstUse);
   bool optimizeBlock(MachineBasicBlock *MBB);
+};
+
+class AArch64RedundantCopyEliminationLegacy : public MachineFunctionPass {
+public:
+  static char ID;
+  AArch64RedundantCopyEliminationLegacy() : MachineFunctionPass(ID) {}
+
   bool runOnMachineFunction(MachineFunction &MF) override;
+
   MachineFunctionProperties getRequiredProperties() const override {
     return MachineFunctionProperties().setNoVRegs();
   }
@@ -99,10 +107,10 @@ public:
     return "AArch64 Redundant Copy Elimination";
   }
 };
-char AArch64RedundantCopyElimination::ID = 0;
-}
+char AArch64RedundantCopyEliminationLegacy::ID = 0;
+} // end anonymous namespace
 
-INITIALIZE_PASS(AArch64RedundantCopyElimination, "aarch64-copyelim",
+INITIALIZE_PASS(AArch64RedundantCopyEliminationLegacy, "aarch64-copyelim",
                 "AArch64 redundant copy elimination pass", false, false)
 
 /// It's possible to determine the value of a register based on a dominating
@@ -117,7 +125,7 @@ INITIALIZE_PASS(AArch64RedundantCopyElimination, "aarch64-copyelim",
 /// the constant in \p MBB for some cases.  If we find any constant values, push
 /// a physical register and constant value pair onto the KnownRegs vector and
 /// return true.  Otherwise, return false if no known values were found.
-bool AArch64RedundantCopyElimination::knownRegValInBlock(
+bool AArch64RedundantCopyEliminationImpl::knownRegValInBlock(
     MachineInstr &CondBr, MachineBasicBlock *MBB,
     SmallVectorImpl<RegImm> &KnownRegs, MachineBasicBlock::iterator &FirstUse) {
   unsigned Opc = CondBr.getOpcode();
@@ -272,7 +280,7 @@ bool AArch64RedundantCopyElimination::knownRegValInBlock(
   return false;
 }
 
-bool AArch64RedundantCopyElimination::optimizeBlock(MachineBasicBlock *MBB) {
+bool AArch64RedundantCopyEliminationImpl::optimizeBlock(MachineBasicBlock *MBB) {
   // Check if the current basic block has a single predecessor.
   if (MBB->pred_size() != 1)
     return false;
@@ -470,10 +478,7 @@ bool AArch64RedundantCopyElimination::optimizeBlock(MachineBasicBlock *MBB) {
   return true;
 }
 
-bool AArch64RedundantCopyElimination::runOnMachineFunction(
-    MachineFunction &MF) {
-  if (skipFunction(MF.getFunction()))
-    return false;
+bool AArch64RedundantCopyEliminationImpl::run(MachineFunction &MF) {
   TRI = MF.getSubtarget().getRegisterInfo();
   MRI = &MF.getRegInfo();
   const TargetInstrInfo &TII = *MF.getSubtarget().getInstrInfo();
@@ -493,6 +498,24 @@ bool AArch64RedundantCopyElimination::runOnMachineFunction(
   return Changed;
 }
 
+bool AArch64RedundantCopyEliminationLegacy::runOnMachineFunction(
+    MachineFunction &MF) {
+  if (skipFunction(MF.getFunction()))
+    return false;
+  return AArch64RedundantCopyEliminationImpl().run(MF);
+}
+
+PreservedAnalyses
+AArch64RedundantCopyEliminationPass::run(MachineFunction &MF,
+                                         MachineFunctionAnalysisManager &MFAM) {
+  const bool Changed = AArch64RedundantCopyEliminationImpl().run(MF);
+  if (!Changed)
+    return PreservedAnalyses::all();
+  PreservedAnalyses PA = getMachineFunctionPassPreservedAnalyses();
+  PA.preserveSet<CFGAnalyses>();
+  return PA;
+}
+
 FunctionPass *llvm::createAArch64RedundantCopyEliminationPass() {
-  return new AArch64RedundantCopyElimination();
+  return new AArch64RedundantCopyEliminationLegacy();
 }

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -265,7 +265,7 @@ LLVMInitializeAArch64Target() {
   initializeAArch64PostLegalizerLoweringPass(PR);
   initializeAArch64PostSelectOptimizePass(PR);
   initializeAArch64PromoteConstantPass(PR);
-  initializeAArch64RedundantCopyEliminationPass(PR);
+  initializeAArch64RedundantCopyEliminationLegacyPass(PR);
   initializeAArch64RedundantCondBranchPass(PR);
   initializeAArch64StorePairSuppressPass(PR);
   initializeFalkorHWPFFixPass(PR);

--- a/llvm/test/CodeGen/AArch64/machine-copy-remove.mir
+++ b/llvm/test/CodeGen/AArch64/machine-copy-remove.mir
@@ -1,5 +1,5 @@
 # RUN: llc -mtriple=aarch64--linux-gnu -run-pass=aarch64-copyelim %s -verify-machineinstrs -o - | FileCheck %s
-# RUN: llc -mtriple=aarch64--linux-gnu -passes=aarch64-copyelim %s -verify-machineinstrs -o - | FileCheck %s
+# RUN: llc -mtriple=aarch64--linux-gnu -passes=aarch64-copyelim %s -o - | FileCheck %s
 ---
 # Check that bb.0 COPY is seen through to allow the bb.1 COPY of XZR to be removed.
 # CHECK-LABEL: name: test1

--- a/llvm/test/CodeGen/AArch64/machine-copy-remove.mir
+++ b/llvm/test/CodeGen/AArch64/machine-copy-remove.mir
@@ -1,4 +1,5 @@
 # RUN: llc -mtriple=aarch64--linux-gnu -run-pass=aarch64-copyelim %s -verify-machineinstrs -o - | FileCheck %s
+# RUN: llc -mtriple=aarch64--linux-gnu -passes=aarch64-copyelim %s -verify-machineinstrs -o - | FileCheck %s
 ---
 # Check that bb.0 COPY is seen through to allow the bb.1 COPY of XZR to be removed.
 # CHECK-LABEL: name: test1

--- a/llvm/test/CodeGen/AArch64/machine-zero-copy-remove.mir
+++ b/llvm/test/CodeGen/AArch64/machine-zero-copy-remove.mir
@@ -1,4 +1,5 @@
 # RUN: llc -mtriple=aarch64--linux-gnu -run-pass=aarch64-copyelim %s -verify-machineinstrs -o - | FileCheck %s
+# RUN: llc -mtriple=aarch64--linux-gnu -passes=aarch64-copyelim %s -verify-machineinstrs -o - | FileCheck %s
 ---
 # CHECK-LABEL: name: test1
 # CHECK: ANDSWri $w0, 1, implicit-def $nzcv

--- a/llvm/test/CodeGen/AArch64/machine-zero-copy-remove.mir
+++ b/llvm/test/CodeGen/AArch64/machine-zero-copy-remove.mir
@@ -1,5 +1,5 @@
 # RUN: llc -mtriple=aarch64--linux-gnu -run-pass=aarch64-copyelim %s -verify-machineinstrs -o - | FileCheck %s
-# RUN: llc -mtriple=aarch64--linux-gnu -passes=aarch64-copyelim %s -verify-machineinstrs -o - | FileCheck %s
+# RUN: llc -mtriple=aarch64--linux-gnu -passes=aarch64-copyelim %s -o - | FileCheck %s
 ---
 # CHECK-LABEL: name: test1
 # CHECK: ANDSWri $w0, 1, implicit-def $nzcv


### PR DESCRIPTION
Adds a newPM pass for AArch64RedundantCopyElimination
- Refactors base logic into an Impl class
- Renames old pass with the "Legacy" suffix
- Adds the new pass manager pass using refactored logic
- Updated existing .mir tests to also test with the New Pass Manager.

Context and motivation in https://llvm.org/docs/NewPassManager.html#status-of-the-new-and-legacy-pass-managers