### PR TITLE
[clang-tidy] Enhance container-data-pointer-check to suggest `c_str` for consts

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -158,15 +158,11 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
   ReplacementText += CE->getType()->isPointerType() ? "->" : ".";
   ReplacementText += UseCStr ? "c_str()" : "data()";
 
-  llvm::StringRef Description = UseCStr
-                                    ? "'c_str' should be used for accessing "
-                                      "the data pointer instead of taking "
-                                      "the address of the 0-th element"
-                                    : "'data' should be used for accessing the "
-                                      "data pointer instead of taking "
-                                      "the address of the 0-th element";
   const FixItHint Hint =
       FixItHint::CreateReplacement(ReplacementRange, ReplacementText);
-  diag(UO->getBeginLoc(), Description) << Hint;
+  diag(UO->getBeginLoc(),
+       "'%select{data|c_str}0' should be used for accessing the data pointer "
+       "instead of taking the address of the 0-th element")
+      << UseCStr << Hint;
 }
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -86,7 +86,7 @@ void ContainerDataPointerCheck::registerMatchers(MatchFinder *Finder) {
       this);
 }
 
-static bool isContainerConst(const Expr* ContainerExpr) {
+static bool isContainerConst(const Expr *ContainerExpr) {
   QualType ContainerType = ContainerExpr->getType();
   if (ContainerType->isPointerType())
     ContainerType = ContainerType->getPointeeType();
@@ -118,7 +118,7 @@ static bool shouldUseCStr(const MatchFinder::MatchResult &Result) {
     if (isConstPointer(Cast->getType()))
       return true;
   } else if (const auto *RetStmt = Parents[0].get<ReturnStmt>()) {
-    const Expr* RetValue = RetStmt->getRetValue();
+    const Expr *RetValue = RetStmt->getRetValue();
     if (isConstPointer(RetValue->getType()))
       return true;
   }
@@ -140,7 +140,7 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
   else if (ACE)
     CE = ACE;
 
-  bool UseCStr = shouldUseCStr(Result);
+  const auto UseCStr = shouldUseCStr(Result);
 
   const SourceRange SrcRange = CE->getSourceRange();
 

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -108,15 +108,15 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
 
     if (!Parents.empty()) {
       if (const auto *VD = Parents[0].get<VarDecl>()) {
-        QualType VarType = VD->getType();
+        const QualType VarType = VD->getType();
         if (VarType->isPointerType()) {
-          QualType PointeeType = VarType->getPointeeType();
+          const QualType PointeeType = VarType->getPointeeType();
           UseCStr = PointeeType.isConstQualified();
         }
       } else if (const auto *Cast = Parents[0].get<CastExpr>()) {
-        QualType CastType = Cast->getType();
+        const QualType CastType = Cast->getType();
         if (CastType->isPointerType()) {
-          QualType PointeeType = CastType->getPointeeType();
+          const QualType PointeeType = CastType->getPointeeType();
           UseCStr = PointeeType.isConstQualified();
         }
       }

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -102,7 +102,6 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
   else if (ACE)
     CE = ACE;
 
-  SourceRange ReplacementRange = UO->getSourceRange();
   bool UseCStr = false;
   if (CStrDecl) {
     auto Parents = Result.Context->getParents(*UO);
@@ -114,22 +113,11 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
           QualType PointeeType = VarType->getPointeeType();
           UseCStr = PointeeType.isConstQualified();
         }
-      } else if (const auto *ICE = Parents[0].get<ImplicitCastExpr>()) {
-        QualType CastType = ICE->getType();
-        if (CastType->isPointerType()) {
-          QualType PointeeType = CastType->getPointeeType();
-          UseCStr = PointeeType.isConstQualified();
-        }
       } else if (const auto *Cast = Parents[0].get<CastExpr>()) {
         QualType CastType = Cast->getType();
         if (CastType->isPointerType()) {
           QualType PointeeType = CastType->getPointeeType();
           UseCStr = PointeeType.isConstQualified();
-          if (UseCStr) {
-            // if it's a const cast, use the Cast range as replacement range
-            // e.g. (const char*)&s[0] -> s.c_str()
-            ReplacementRange = Cast->getSourceRange();
-          }
         }
       }
     }
@@ -159,7 +147,7 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
   ReplacementText += UseCStr ? "c_str()" : "data()";
 
   const FixItHint Hint =
-      FixItHint::CreateReplacement(ReplacementRange, ReplacementText);
+      FixItHint::CreateReplacement(UO->getSourceRange(), ReplacementText);
   diag(UO->getBeginLoc(),
        "'%select{data|c_str}0' should be used for accessing the data pointer "
        "instead of taking the address of the 0-th element")

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -86,13 +86,51 @@ void ContainerDataPointerCheck::registerMatchers(MatchFinder *Finder) {
       this);
 }
 
+static bool isContainerConst(const Expr* ContainerExpr) {
+  QualType ContainerType = ContainerExpr->getType();
+  if (ContainerType->isPointerType())
+    ContainerType = ContainerType->getPointeeType();
+  return ContainerType.isConstQualified();
+}
+
+static bool isConstPointer(const QualType Type) {
+  if (!Type->isPointerType())
+    return false;
+  return Type->getPointeeType().isConstQualified();
+}
+
+static bool shouldUseCStr(const MatchFinder::MatchResult &Result) {
+  const auto *CStrDecl = Result.Nodes.getNodeAs<CXXMethodDecl>("c_str");
+  const auto *UO = Result.Nodes.getNodeAs<UnaryOperator>(AddressOfName);
+  const auto *CE = Result.Nodes.getNodeAs<Expr>(ContainerExprName);
+
+  if (!CStrDecl)
+    return false;
+
+  auto Parents = Result.Context->getParents(*UO);
+  if (Parents.empty())
+    return isContainerConst(CE);
+
+  if (const auto *VD = Parents[0].get<VarDecl>()) {
+    if (isConstPointer(VD->getType()))
+      return true;
+  } else if (const auto *Cast = Parents[0].get<CastExpr>()) {
+    if (isConstPointer(Cast->getType()))
+      return true;
+  } else if (const auto *RetStmt = Parents[0].get<ReturnStmt>()) {
+    const Expr* RetValue = RetStmt->getRetValue();
+    if (isConstPointer(RetValue->getType()))
+      return true;
+  }
+
+  return isContainerConst(CE);
+}
+
 void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *UO = Result.Nodes.getNodeAs<UnaryOperator>(AddressOfName);
   const auto *CE = Result.Nodes.getNodeAs<Expr>(ContainerExprName);
   const auto *DCE = Result.Nodes.getNodeAs<Expr>(DerefContainerExprName);
   const auto *ACE = Result.Nodes.getNodeAs<Expr>(AddrOfContainerExprName);
-
-  const auto *CStrDecl = Result.Nodes.getNodeAs<CXXMethodDecl>("c_str");
 
   if (!UO || !CE)
     return;
@@ -102,33 +140,7 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
   else if (ACE)
     CE = ACE;
 
-  bool UseCStr = false;
-  if (CStrDecl) {
-    auto Parents = Result.Context->getParents(*UO);
-
-    if (!Parents.empty()) {
-      if (const auto *VD = Parents[0].get<VarDecl>()) {
-        const QualType VarType = VD->getType();
-        if (VarType->isPointerType()) {
-          const QualType PointeeType = VarType->getPointeeType();
-          UseCStr = PointeeType.isConstQualified();
-        }
-      } else if (const auto *Cast = Parents[0].get<CastExpr>()) {
-        const QualType CastType = Cast->getType();
-        if (CastType->isPointerType()) {
-          const QualType PointeeType = CastType->getPointeeType();
-          UseCStr = PointeeType.isConstQualified();
-        }
-      }
-    }
-
-    if (!UseCStr) {
-      QualType ContainerType = CE->getType();
-      if (ContainerType->isPointerType())
-        ContainerType = ContainerType->getPointeeType();
-      UseCStr = ContainerType.isConstQualified();
-    }
-  }
+  bool UseCStr = shouldUseCStr(Result);
 
   const SourceRange SrcRange = CE->getSourceRange();
 

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -38,8 +38,9 @@ void ContainerDataPointerCheck::registerMatchers(MatchFinder *Finder) {
       cxxRecordDecl(
           unless(matchers::matchesAnyListedRegexName(IgnoredContainers)),
           isSameOrDerivedFrom(
-              namedDecl(
-                  has(cxxMethodDecl(isPublic(), hasName("data")).bind("data")))
+              namedDecl(anyOf(has(cxxMethodDecl(isPublic(), hasName("c_str"))
+                                      .bind("c_str")),
+                              has(cxxMethodDecl(isPublic(), hasName("data")))))
                   .bind("container")))
           .bind("record");
 
@@ -91,6 +92,8 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *DCE = Result.Nodes.getNodeAs<Expr>(DerefContainerExprName);
   const auto *ACE = Result.Nodes.getNodeAs<Expr>(AddrOfContainerExprName);
 
+  const auto *CStrDecl = Result.Nodes.getNodeAs<CXXMethodDecl>("c_str");
+
   if (!UO || !CE)
     return;
 
@@ -98,6 +101,46 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
     CE = DCE;
   else if (ACE)
     CE = ACE;
+
+  SourceRange ReplacementRange = UO->getSourceRange();
+  bool UseCStr = false;
+  if (CStrDecl) {
+    auto Parents = Result.Context->getParents(*UO);
+
+    if (!Parents.empty()) {
+      if (const auto *VD = Parents[0].get<VarDecl>()) {
+        QualType VarType = VD->getType();
+        if (VarType->isPointerType()) {
+          QualType PointeeType = VarType->getPointeeType();
+          UseCStr = PointeeType.isConstQualified();
+        }
+      } else if (const auto *ICE = Parents[0].get<ImplicitCastExpr>()) {
+        QualType CastType = ICE->getType();
+        if (CastType->isPointerType()) {
+          QualType PointeeType = CastType->getPointeeType();
+          UseCStr = PointeeType.isConstQualified();
+        }
+      } else if (const auto *Cast = Parents[0].get<CastExpr>()) {
+        QualType CastType = Cast->getType();
+        if (CastType->isPointerType()) {
+          QualType PointeeType = CastType->getPointeeType();
+          UseCStr = PointeeType.isConstQualified();
+          if (UseCStr) {
+            // if it's a const cast, use the Cast range as replacement range
+            // e.g. (const char*)&s[0] -> s.c_str()
+            ReplacementRange = Cast->getSourceRange();
+          }
+        }
+      }
+    }
+
+    if (!UseCStr) {
+      QualType ContainerType = CE->getType();
+      if (ContainerType->isPointerType())
+        ContainerType = ContainerType->getPointeeType();
+      UseCStr = ContainerType.isConstQualified();
+    }
+  }
 
   const SourceRange SrcRange = CE->getSourceRange();
 
@@ -112,16 +155,18 @@ void ContainerDataPointerCheck::check(const MatchFinder::MatchResult &Result) {
   if (NeedsParens)
     ReplacementText = "(" + ReplacementText + ")";
 
-  if (CE->getType()->isPointerType())
-    ReplacementText += "->data()";
-  else
-    ReplacementText += ".data()";
+  ReplacementText += CE->getType()->isPointerType() ? "->" : ".";
+  ReplacementText += UseCStr ? "c_str()" : "data()";
 
+  llvm::StringRef Description = UseCStr
+                                    ? "'c_str' should be used for accessing "
+                                      "the data pointer instead of taking "
+                                      "the address of the 0-th element"
+                                    : "'data' should be used for accessing the "
+                                      "data pointer instead of taking "
+                                      "the address of the 0-th element";
   const FixItHint Hint =
-      FixItHint::CreateReplacement(UO->getSourceRange(), ReplacementText);
-  diag(UO->getBeginLoc(),
-       "'data' should be used for accessing the data pointer instead of taking "
-       "the address of the 0-th element")
-      << Hint;
+      FixItHint::CreateReplacement(ReplacementRange, ReplacementText);
+  diag(UO->getBeginLoc(), Description) << Hint;
 }
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.h
@@ -13,7 +13,7 @@
 
 namespace clang::tidy::readability {
 /// Checks whether a call to `operator[]` and `&` can be replaced with a call to
-/// `data()`.
+/// `data()` or (for consts, when available) `c_str()`.
 ///
 /// This only replaces the case where the offset being accessed through the
 /// subscript operation is a known constant 0.  This avoids a potential invalid

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -278,8 +278,8 @@ Changes in existing checks
   - Do not report explicit call to destructor after move as an invalid use.
 
 - Improved :doc:`container-data-pointer
-  <clang-tidy/checks/readability/container-data-pointer>` check
-  to use ``c_str()`` for ``const``'s when available and present on a container.
+  <clang-tidy/checks/readability/container-data-pointer>` check to use
+  ``c_str()`` for ``const``'s when available and present on a container.
 
 - Improved :doc:`cppcoreguidelines-avoid-capturing-lambda-coroutines
   <clang-tidy/checks/cppcoreguidelines/avoid-capturing-lambda-coroutines>`

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -277,6 +277,10 @@ Changes in existing checks
 
   - Do not report explicit call to destructor after move as an invalid use.
 
+- Improved :doc:`container-data-pointer
+  <clang-tidy/checks/readability/container-data-pointer>` check
+  to use ``c_str()`` for const's when available and present on a container.
+
 - Improved :doc:`cppcoreguidelines-avoid-capturing-lambda-coroutines
   <clang-tidy/checks/cppcoreguidelines/avoid-capturing-lambda-coroutines>`
   check by adding the `AllowExplicitObjectParameters` option. When enabled,

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -279,7 +279,7 @@ Changes in existing checks
 
 - Improved :doc:`container-data-pointer
   <clang-tidy/checks/readability/container-data-pointer>` check
-  to use ``c_str()`` for const's when available and present on a container.
+  to use ``c_str()`` for ``const``'s when available and present on a container.
 
 - Improved :doc:`cppcoreguidelines-avoid-capturing-lambda-coroutines
   <clang-tidy/checks/cppcoreguidelines/avoid-capturing-lambda-coroutines>`

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/container-data-pointer.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/container-data-pointer.rst
@@ -3,14 +3,34 @@
 readability-container-data-pointer
 ==================================
 
-Finds cases where code could use ``data()`` rather than the address of the
-element at index 0 in a container. This pattern is commonly used to materialize
-a pointer to the backing data of a container. ``std::vector`` and
+Finds cases where code could use ``data()`` or ``c_str()`` rather than the
+address of the element at index 0 in a container. This pattern is commonly used
+to materialize a pointer to the backing data of a container. ``std::vector`` and
 ``std::string`` provide a ``data()`` accessor to retrieve the data pointer
 which should be preferred.
 
+This check suggests ``data()`` for non-const pointer contexts and ``c_str()``
+for const pointer contexts when available. This provides better semantic
+clarity: ``c_str()`` explicitly indicates read-only access to string data,
+while ``data()`` may allow modifications.
+
 This also ensures that in the case that the container is empty, the data
 pointer access does not perform an errant memory access.
+
+Examples
+--------
+
+.. code-block: c++
+
+  std::string s;
+  std::vector<int> v;
+
+  char* p1 = &s[0];           // Warning: use s.data()
+  const char* p2 = &s[0]      // Warning: use s.c_str()
+  int* p3 = &v[0];            // Warning: use v.data()
+
+  const std::string cs;
+  const char* p4 = &cs[0];    // Warning: use cs.c_str()
 
 Options
 -------

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
@@ -43,7 +43,7 @@ void h() {
 
   f((const char*)&((s).operator[]((z))));
   // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:18: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
-  // CHECK-FIXES-CLASSIC: f(s.c_str());
+  // CHECK-FIXES-CLASSIC: f((const char*)s.c_str());
   // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:18: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
 
   const std::string cs;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
@@ -35,6 +35,11 @@ void h() {
   // CHECK-FIXES-CLASSIC: const char* p2 = s.c_str();
   // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:20: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
 
+  const auto* auto_p2 = &s[0];
+  // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:25: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+  // CHECK-FIXES-CLASSIC: const auto* auto_p2 = s.c_str();
+  // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:25: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+
   std::wstring w;
   f(&((&(w))->operator[]((z))));
   // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
@@ -56,6 +61,17 @@ void h() {
   // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:20: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
   // CHECK-FIXES-CLASSIC: const char* p3 = cs.c_str();
   // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:20: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+
+  const auto* auto_p3 = &cs[0];
+  // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:25: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+  // CHECK-FIXES-CLASSIC: const auto* auto_p3 = cs.c_str();
+  // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:25: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+
+  auto char_lambda = [](std::string s) -> const char* {
+    return &s[0];
+    // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:12: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+    // CHECK-FIXES-CLASSIC: return s.c_str();
+  };
 }
 
 template <typename T, typename U,

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-data-pointer.cpp
@@ -25,11 +25,37 @@ void h() {
   // CHECK-FIXES-CLASSIC: f(s.data());
   // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
 
+  char* p1 = &s[0];
+  // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:14: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+  // CHECK-FIXES-CLASSIC: char* p1 = s.data();
+  // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:14: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+
+  const char* p2 = &s[0];
+  // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:20: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+  // CHECK-FIXES-CLASSIC: const char* p2 = s.c_str();
+  // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:20: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+
   std::wstring w;
   f(&((&(w))->operator[]((z))));
   // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
   // CHECK-FIXES-CLASSIC: f(w.data());
   // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:5: warning: 'data' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+
+  f((const char*)&((s).operator[]((z))));
+  // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:18: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+  // CHECK-FIXES-CLASSIC: f(s.c_str());
+  // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:18: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+
+  const std::string cs;
+  f(&((&(cs))->operator[]((z))));
+  // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:5: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+  // CHECK-FIXES-CLASSIC: f(cs.c_str());
+  // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:5: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+
+  const char* p3 = &cs[0];
+  // CHECK-MESSAGES-CLASSIC: :[[@LINE-1]]:20: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
+  // CHECK-FIXES-CLASSIC: const char* p3 = cs.c_str();
+  // CHECK-MESSAGES-WITH-CONFIG-NOT: :[[@LINE-3]]:20: warning: 'c_str' should be used for accessing the data pointer instead of taking the address of the 0-th element [readability-container-data-pointer]
 }
 
 template <typename T, typename U,


### PR DESCRIPTION
## Description

Fixes #55026 

I took inspiration from earlier closed PR: https://github.com/llvm/llvm-project/pull/71304, which guided me to a good solution here.

With an aim to get my first PR into the llvm-project, kindly let me know if this needs more work.