### PR TITLE
[Clang] Fix SFINAE access check for protected in a dependent context

### DIFF
--- a/clang/include/clang/AST/DependentDiagnostic.h
+++ b/clang/include/clang/AST/DependentDiagnostic.h
@@ -48,6 +48,7 @@ public:
                                      QualType BaseObjectType,
                                      const PartialDiagnostic &PDiag) {
     DependentDiagnostic *DD = Create(Context, Parent, PDiag);
+    DD->IsActive = true;
     DD->AccessData.Loc = Loc;
     DD->AccessData.IsMember = IsMemberAccess;
     DD->AccessData.Access = AS;
@@ -65,6 +66,10 @@ public:
     assert(getKind() == Access);
     return AccessData.IsMember;
   }
+
+  bool isActive() const { return IsActive; }
+
+  void setActive(bool active) { IsActive = active; }
 
   AccessSpecifier getAccess() const {
     assert(getKind() == Access);
@@ -110,6 +115,9 @@ private:
   DependentDiagnostic *NextDiagnostic;
 
   PartialDiagnostic Diag;
+
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned IsActive : 1;
 
   struct {
     SourceLocation Loc;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -14415,7 +14415,8 @@ public:
 
   void PerformDependentDiagnostics(
       const DeclContext *Pattern,
-      const MultiLevelTemplateArgumentList &TemplateArgs);
+      const MultiLevelTemplateArgumentList &TemplateArgs,
+      bool MarkInactive = false);
 
 private:
   /// Introduce the instantiated local variables into the local

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -3899,6 +3899,12 @@ bool Sema::usesPartialOrExplicitSpecialization(
   return false;
 }
 
+static DeclContext *getAsDeclContextOrEnclosing(Decl *D) {
+  if (auto *DC = dyn_cast<DeclContext>(D))
+    return DC;
+  return D->getDeclContext();
+}
+
 /// Get the instantiation pattern to use to instantiate the definition of a
 /// given ClassTemplateSpecializationDecl (either the pattern of the primary
 /// template or of a partial specialization).
@@ -3953,11 +3959,15 @@ static ActionResult<CXXRecordDecl *> getPatternForClassTemplateSpecialization(
 
       if (Result == TemplateDeductionResult::Success) {
         // Handle any dependent diags that might have been created for access
-        // checks Reject Candidate if it fails access checks.
-        if (Partial->isDependentContext()) {
+        // checks. Reject Candidate if it fails access checks.
+        if (!Partial->ddiags().empty()) {
+          auto *Decl = Partial->hasDefinition()
+                           ? Partial
+                           : Partial->getInstantiatedFromMember();
+          Sema::ContextRAII SavedContext(S, getAsDeclContextOrEnclosing(Decl));
           Sema::SFINAETrap Trap(S, Info);
           S.PerformDependentDiagnostics(
-              Partial, S.getTemplateInstantiationArgs(ClassTemplateSpec), true);
+              Partial, S.getTemplateInstantiationArgs(Partial), true);
           if (Trap.hasErrorOccurred()) {
             Result = TemplateDeductionResult::SubstitutionFailure;
           }

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -16,6 +16,7 @@
 #include "clang/AST/ASTMutationListener.h"
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/DependentDiagnostic.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprConcepts.h"
@@ -3946,9 +3947,24 @@ static ActionResult<CXXRecordDecl *> getPatternForClassTemplateSpecialization(
         continue;
 
       TemplateDeductionInfo Info(FailedCandidates.getLocation());
-      if (TemplateDeductionResult Result = S.DeduceTemplateArguments(
-              Partial, ClassTemplateSpec->getTemplateArgs().asArray(), Info);
-          Result != TemplateDeductionResult::Success) {
+
+      TemplateDeductionResult Result = S.DeduceTemplateArguments(
+          Partial, ClassTemplateSpec->getTemplateArgs().asArray(), Info);
+
+      if (Result == TemplateDeductionResult::Success) {
+        // Handle any dependent diags that might have been created for access
+        // checks Reject Candidate if it fails access checks.
+        if (Partial->isDependentContext()) {
+          Sema::SFINAETrap Trap(S, Info);
+          S.PerformDependentDiagnostics(
+              Partial, S.getTemplateInstantiationArgs(ClassTemplateSpec), true);
+          if (Trap.hasErrorOccurred()) {
+            Result = TemplateDeductionResult::SubstitutionFailure;
+          }
+        }
+      }
+
+      if (Result != TemplateDeductionResult::Success) {
         // Store the failed-deduction information for use in diagnostics, later.
         // TODO: Actually use the failed-deduction info?
         FailedCandidates.addCandidate().set(
@@ -3960,6 +3976,7 @@ static ActionResult<CXXRecordDecl *> getPatternForClassTemplateSpecialization(
         List.push_back(MatchResult{Partial, Info.takeCanonical()});
       }
     }
+
     if (Matched.empty() && PrimaryStrictPackMatch)
       Matched = std::move(ExtraMatched);
 

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -7292,13 +7292,16 @@ void Sema::PerformPendingInstantiations(bool LocalOnly, bool AtEndOfTU) {
     PendingInstantiations.swap(DelayedImplicitInstantiations);
 }
 
-void Sema::PerformDependentDiagnostics(const DeclContext *Pattern,
-                       const MultiLevelTemplateArgumentList &TemplateArgs) {
+void Sema::PerformDependentDiagnostics(
+    const DeclContext *Pattern,
+    const MultiLevelTemplateArgumentList &TemplateArgs, bool MarkInactive) {
   for (auto *DD : Pattern->ddiags()) {
-    switch (DD->getKind()) {
-    case DependentDiagnostic::Access:
+    if (DD->getKind() == DependentDiagnostic::Access && DD->isActive()) {
       HandleDependentAccessCheck(*DD, TemplateArgs);
-      break;
+
+      if (MarkInactive) {
+        DD->setActive(false);
+      }
     }
   }
 }

--- a/clang/test/SemaCXX/dependent-context-SFINAE.cpp
+++ b/clang/test/SemaCXX/dependent-context-SFINAE.cpp
@@ -1,0 +1,71 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+// expected-no-diagnostics
+
+class PublicBase {
+    public:
+    PublicBase(int i);
+    using type = int;
+};
+
+class ProtectedBase {
+    protected:
+    ProtectedBase(int i);
+    using type = int;
+};
+
+class FriendProtectedBase {
+    template <typename U> friend class Derived;
+
+    protected:
+    FriendProtectedBase(int i);
+    using type = int;
+};
+
+class PrivateBase {
+    private:
+    PrivateBase(int i);
+    using type = int;
+};
+
+template <typename... Ts>
+using void_t = void;
+
+template <typename U>
+class Derived {
+    public:
+    // SFINAE Pattern 1 - Checks whether constructor is accessible
+    template <typename T, typename = void>
+    struct ConstructsBase {
+        static constexpr int value = 0;
+    };
+
+    template <typename T>
+    struct ConstructsBase<
+        T, void_t<decltype(T(0))>> {
+            static constexpr int value = 1;
+        };
+
+    // SFINAE Pattern 2 - Checks whether type alias is accessible
+    template <typename T, typename = void>
+    struct HasAccessibleType {
+        static constexpr int value = 0;
+    };
+
+    template <typename T>
+    struct HasAccessibleType<
+        T,
+        void_t<typename T::type>> 
+    {
+        static constexpr int value = 1;
+    };
+};
+
+static_assert(Derived<int>::ConstructsBase<PublicBase>::value);
+static_assert(!Derived<int>::ConstructsBase<ProtectedBase>::value);
+static_assert(Derived<int>::ConstructsBase<FriendProtectedBase>::value);
+static_assert(!Derived<int>::ConstructsBase<PrivateBase>::value);
+
+static_assert(Derived<int>::HasAccessibleType<PublicBase>::value);
+static_assert(!Derived<int>::HasAccessibleType<ProtectedBase>::value);
+static_assert(Derived<int>::HasAccessibleType<FriendProtectedBase>::value);
+static_assert(!Derived<int>::HasAccessibleType<PrivateBase>::value);


### PR DESCRIPTION
`getPatternForClassTemplateSpecialization()` eventually calls `CheckConstructorAccess()` for a partial spec which adds a `DependentDiagnostic()` to the partial in case of a dependent context. However, this was not getting handled due to which the current partial was chosen as a viable candidate, ignoring the protected access specifier. 

Furthermore, the `DependentDiagnostic()` gets lost when `PartialSpec = PartialSpec->getInstantiatedFromMember();` is called.

Fix this by modifying `getPatternForClassTemplateSpecialization()` to explicitly handle a dependent diagnostic (delayed access check) which might be attached to a partial spec.

Fixes #103895. Fixes #62053.

E: Its DependentDiagnostic and not DelayedDiagnostic.