### PR TITLE
[AMDGPU][ASAN] Preserve assumed stack size for ASan-instrumented functions -O0

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUResourceUsageAnalysis.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUResourceUsageAnalysis.cpp
@@ -83,12 +83,19 @@ bool AMDGPUResourceUsageAnalysisWrapperPass::runOnMachineFunction(
   uint32_t AssumedStackSizeForDynamicSizeObjects =
       clAssumedStackSizeForDynamicSizeObjects;
   uint32_t AssumedStackSizeForExternalCall = clAssumedStackSizeForExternalCall;
+  // At -O0 with ASan, external callbacks (e.g. __asan_load) are not inlined
+  // and need stack space reserved.
+  bool AsanNeedsStack =
+      TM.getOptLevel() == CodeGenOptLevel::None &&
+      MF.getFunction().hasFnAttribute(Attribute::SanitizeAddress);
   if (AMDGPU::getAMDHSACodeObjectVersion(*MF.getFunction().getParent()) >=
           AMDGPU::AMDHSA_COV5 ||
       STI.getTargetTriple().getOS() == Triple::AMDPAL) {
-    if (!clAssumedStackSizeForDynamicSizeObjects.getNumOccurrences())
+    if (!clAssumedStackSizeForDynamicSizeObjects.getNumOccurrences() &&
+        !AsanNeedsStack)
       AssumedStackSizeForDynamicSizeObjects = 0;
-    if (!clAssumedStackSizeForExternalCall.getNumOccurrences())
+    if (!clAssumedStackSizeForExternalCall.getNumOccurrences() &&
+        !AsanNeedsStack)
       AssumedStackSizeForExternalCall = 0;
   }
 
@@ -110,12 +117,19 @@ AMDGPUResourceUsageAnalysis::run(MachineFunction &MF,
   uint32_t AssumedStackSizeForDynamicSizeObjects =
       clAssumedStackSizeForDynamicSizeObjects;
   uint32_t AssumedStackSizeForExternalCall = clAssumedStackSizeForExternalCall;
+  // At -O0 with ASan, external callbacks (e.g. __asan_load) are not inlined
+  // and need stack space reserved.
+  bool AsanNeedsStack =
+      TM.getOptLevel() == CodeGenOptLevel::None &&
+      MF.getFunction().hasFnAttribute(Attribute::SanitizeAddress);
   if (AMDGPU::getAMDHSACodeObjectVersion(*MF.getFunction().getParent()) >=
           AMDGPU::AMDHSA_COV5 ||
       STI.getTargetTriple().getOS() == Triple::AMDPAL) {
-    if (!clAssumedStackSizeForDynamicSizeObjects.getNumOccurrences())
+    if (!clAssumedStackSizeForDynamicSizeObjects.getNumOccurrences() &&
+        !AsanNeedsStack)
       AssumedStackSizeForDynamicSizeObjects = 0;
-    if (!clAssumedStackSizeForExternalCall.getNumOccurrences())
+    if (!clAssumedStackSizeForExternalCall.getNumOccurrences() &&
+        !AsanNeedsStack)
       AssumedStackSizeForExternalCall = 0;
   }
 

--- a/llvm/test/CodeGen/AMDGPU/resource-usage-asan-O0.ll
+++ b/llvm/test/CodeGen/AMDGPU/resource-usage-asan-O0.ll
@@ -1,0 +1,29 @@
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 < %s | FileCheck -check-prefixes=O0 %s
+; RUN: llc -O2 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 < %s | FileCheck -check-prefixes=O2 %s
+
+; Test that at -O0 with sanitize_address on COV5, the assumed external call
+; stack size (16384) is preserved so ASan callbacks get enough scratch space.
+; Without sanitize_address, or at -O2, the assumed stack stays at 0.
+
+declare void @extern_func()
+
+; O0-LABEL: {{^}}kernel_with_asan:
+; O0: .set kernel_with_asan.private_seg_size, {{[0-9]+}}+max(16384)
+; O2-LABEL: {{^}}kernel_with_asan:
+; O2: .set kernel_with_asan.private_seg_size, {{[0-9]+$}}
+define amdgpu_kernel void @kernel_with_asan() sanitize_address {
+  call void @extern_func()
+  ret void
+}
+
+; O0-LABEL: {{^}}kernel_without_asan:
+; O0: .set kernel_without_asan.private_seg_size, {{[0-9]+$}}
+; O2-LABEL: {{^}}kernel_without_asan:
+; O2: .set kernel_without_asan.private_seg_size, {{[0-9]+$}}
+define amdgpu_kernel void @kernel_without_asan() {
+  call void @extern_func()
+  ret void
+}
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"amdhsa_code_object_version", i32 500}


### PR DESCRIPTION
At -O0 with sanitize_address, ASan external callbacks (__asan_load*, __asan_store*) are not inlined and require stack space. 
On COV5+, the assumed external call stack size defaults to 0, leaving insufficient scratch space for these callbacks and causing stack overflows.

This PR skips zeroing out AssumedStackSizeForExternalCall and AssumedStackSizeForDynamicSizeObjects when asan is enabled and at -O0 opt level.