### PR TITLE
[PowerPC] fixed issue "Failure to optimize (x == 0) ? 0xFF : 0 to addic+subfe instead of cntlzw+srwi+neg"

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -15896,8 +15896,22 @@ static SDValue ConvertSETCCToXori(SDNode *N, SelectionDAG &DAG) {
   llvm_unreachable("Should not reach here.");
 }
 
+// Match `sext(setcc X, 0, eq)` and turn it into an ADDIC/SUBFE sequence.
+//
+// This generates code for:
+//   X == 0 ? -1 : 0
+//
+// On pre-ISA 3.1 targets, this is better than the longer CNTLZW/SRWI/NEG
+// sequence. This is useful for cases like:
+//   uint8_t f(uint8_t x) { return (x == 0) ? -1 : 0; }
+//
+// ISA 3.1+ is skipped because those targets can use SETBC.
+
 SDValue PPCTargetLowering::combineSignExtendSetCC(SDNode *N,
                                                   DAGCombinerInfo &DCI) const {
+  if (Subtarget.isISA3_1())
+    return SDValue();
+
   if (N->getValueType(0) != MVT::i32 && N->getValueType(0) != MVT::i64)
     return SDValue();
 

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -15896,6 +15896,44 @@ static SDValue ConvertSETCCToXori(SDNode *N, SelectionDAG &DAG) {
   llvm_unreachable("Should not reach here.");
 }
 
+SDValue PPCTargetLowering::combineSignExtendSetCC(SDNode *N,
+                                                  DAGCombinerInfo &DCI) const {
+  if (N->getValueType(0) != MVT::i32 && N->getValueType(0) != MVT::i64)
+    return SDValue();
+
+  SDValue N0 = N->getOperand(0);
+  if (N0.getOpcode() == ISD::SETCC) {
+    ISD::CondCode CC = cast<CondCodeSDNode>(N0.getOperand(2))->get();
+    SDValue LHS = N0.getOperand(0);
+    SDValue RHS = N0.getOperand(1);
+    // Match: sext (setcc x, 0, eq) or sext (setcc 0, x, eq)
+    if (CC == ISD::SETEQ && (isNullConstant(LHS) || isNullConstant(RHS))) {
+      SDLoc dl(N);
+      SelectionDAG &DAG = DCI.DAG;
+
+      EVT VT = N->getValueType(0);
+
+      SDValue X = isNullConstant(LHS) ? RHS : LHS;
+      EVT XVT = X.getValueType(); // The type of x in the setcc x, 0, eq.
+
+      // If input is i32 but result is i64, we need to extend first
+      if (XVT != VT) {
+        // Zero-extend i32 to i64 before ADDC
+        X = DAG.getNode(ISD::ZERO_EXTEND, dl, VT, X);
+      }
+
+      // Generate: rlwinm(subfe(addic(x, -1), addic(x, -1)), 0, mask)
+      SDValue MinusOne = DAG.getAllOnesConstant(dl, VT);
+      SDValue Addic = DAG.getNode(PPCISD::ADDC, dl, DAG.getVTList(VT, MVT::i32),
+                                  X, MinusOne);
+      SDValue Carry = Addic.getValue(1);
+      return DAG.getNode(PPCISD::SUBE, dl, DAG.getVTList(VT, MVT::i32), Addic,
+                         Addic, Carry);
+    }
+  }
+  return SDValue();
+}
+
 SDValue PPCTargetLowering::combineSetCC(SDNode *N,
                                         DAGCombinerInfo &DCI) const {
   assert(N->getOpcode() == ISD::SETCC &&
@@ -17491,11 +17529,14 @@ SDValue PPCTargetLowering::PerformDAGCombine(SDNode *N,
         return N->getOperand(0);
     }
     break;
+  case ISD::SIGN_EXTEND:
+    if (SDValue SECC = combineSignExtendSetCC(N, DCI))
+      return SECC;
+    [[fallthrough]];
   case ISD::ZERO_EXTEND:
     if (SDValue RetV = combineZextSetccWithZero(N, DCI.DAG))
       return RetV;
     [[fallthrough]];
-  case ISD::SIGN_EXTEND:
   case ISD::ANY_EXTEND:
     return DAGCombineExtBoolTrunc(N, DCI);
   case ISD::TRUNCATE:

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -15916,36 +15916,34 @@ SDValue PPCTargetLowering::combineSignExtendSetCC(SDNode *N,
     return SDValue();
 
   SDValue N0 = N->getOperand(0);
-  if (N0.getOpcode() == ISD::SETCC) {
-    ISD::CondCode CC = cast<CondCodeSDNode>(N0.getOperand(2))->get();
-    SDValue LHS = N0.getOperand(0);
-    SDValue RHS = N0.getOperand(1);
-    // Match: sext (setcc x, 0, eq) or sext (setcc 0, x, eq)
-    if (CC == ISD::SETEQ && (isNullConstant(LHS) || isNullConstant(RHS))) {
-      SDLoc dl(N);
-      SelectionDAG &DAG = DCI.DAG;
+  if (N0.getOpcode() != ISD::SETCC)
+    return SDValue();
 
-      EVT VT = N->getValueType(0);
+  ISD::CondCode CC = cast<CondCodeSDNode>(N0.getOperand(2))->get();
+  SDValue LHS = N0.getOperand(0);
+  SDValue RHS = N0.getOperand(1);
 
-      SDValue X = isNullConstant(LHS) ? RHS : LHS;
-      EVT XVT = X.getValueType(); // The type of x in the setcc x, 0, eq.
+  // Not match: sext (setcc x, 0, eq) or sext (setcc 0, x, eq)
+  if (CC != ISD::SETEQ || (!isNullConstant(LHS) && !isNullConstant(RHS)))
+    return SDValue();
 
-      // If input is i32 but result is i64, we need to extend first
-      if (XVT != VT) {
-        // Zero-extend i32 to i64 before ADDC
-        X = DAG.getNode(ISD::ZERO_EXTEND, dl, VT, X);
-      }
+  SDLoc dl(N);
+  SelectionDAG &DAG = DCI.DAG;
+  EVT VT = N->getValueType(0);
+  SDValue X = isNullConstant(LHS) ? RHS : LHS;
+  EVT XVT = X.getValueType(); // The type of x in the setcc x, 0, eq.
 
-      // Generate: rlwinm(subfe(addic(x, -1), addic(x, -1)), 0, mask)
-      SDValue MinusOne = DAG.getAllOnesConstant(dl, VT);
-      SDValue Addic = DAG.getNode(PPCISD::ADDC, dl, DAG.getVTList(VT, MVT::i32),
-                                  X, MinusOne);
-      SDValue Carry = Addic.getValue(1);
-      return DAG.getNode(PPCISD::SUBE, dl, DAG.getVTList(VT, MVT::i32), Addic,
-                         Addic, Carry);
-    }
-  }
-  return SDValue();
+  // Zero-extend if input type differs from result type.
+  if (XVT != VT)
+    X = DAG.getNode(ISD::ZERO_EXTEND, dl, VT, X);
+
+  // Generate: SUBFE(ADDC(X, -1)).
+  SDValue MinusOne = DAG.getAllOnesConstant(dl, VT);
+  SDValue Addc =
+      DAG.getNode(PPCISD::ADDC, dl, DAG.getVTList(VT, MVT::i32), X, MinusOne);
+  SDValue Carry = Addc.getValue(1);
+  return DAG.getNode(PPCISD::SUBE, dl, DAG.getVTList(VT, MVT::i32), Addc, Addc,
+                     Carry);
 }
 
 SDValue PPCTargetLowering::combineSetCC(SDNode *N,

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -15933,17 +15933,30 @@ SDValue PPCTargetLowering::combineSignExtendSetCC(SDNode *N,
   SDValue X = isNullConstant(LHS) ? RHS : LHS;
   EVT XVT = X.getValueType(); // The type of x in the setcc x, 0, eq.
 
-  // Zero-extend if input type differs from result type.
-  if (XVT != VT)
-    X = DAG.getNode(ISD::ZERO_EXTEND, dl, VT, X);
+  // On PPC64, i32 carry operations use the full 64-bit XER register,
+  // so we must use i64 operations to avoid incorrect results.
+  // Use i64 operations and truncate the result if needed.
+  EVT OpVT = VT;
+  if (Subtarget.isPPC64() && VT == MVT::i32)
+    OpVT = MVT::i64;
+
+  // Zero-extend if input type differs from operation type.
+  if (XVT != OpVT)
+    X = DAG.getNode(ISD::ZERO_EXTEND, dl, OpVT, X);
 
   // Generate: SUBFE(ADDC(X, -1)).
-  SDValue MinusOne = DAG.getAllOnesConstant(dl, VT);
+  SDValue MinusOne = DAG.getAllOnesConstant(dl, OpVT);
   SDValue Addc =
-      DAG.getNode(PPCISD::ADDC, dl, DAG.getVTList(VT, MVT::i32), X, MinusOne);
+      DAG.getNode(PPCISD::ADDC, dl, DAG.getVTList(OpVT, MVT::i32), X, MinusOne);
   SDValue Carry = Addc.getValue(1);
-  return DAG.getNode(PPCISD::SUBE, dl, DAG.getVTList(VT, MVT::i32), Addc, Addc,
-                     Carry);
+  SDValue Sube = DAG.getNode(PPCISD::SUBE, dl, DAG.getVTList(OpVT, MVT::i32),
+                             Addc, Addc, Carry);
+
+  // Truncate back to i32 if we used i64 operations.
+  if (OpVT != VT)
+    return DAG.getNode(ISD::TRUNCATE, dl, VT, Sube);
+
+  return Sube;
 }
 
 SDValue PPCTargetLowering::combineSetCC(SDNode *N,

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.h
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.h
@@ -874,6 +874,7 @@ namespace llvm {
     SDValue combineADD(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineFMALike(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineTRUNCATE(SDNode *N, DAGCombinerInfo &DCI) const;
+    SDValue combineSignExtendSetCC(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineSetCC(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineVectorShuffle(ShuffleVectorSDNode *SVN,
                                  SelectionDAG &DAG) const;

--- a/llvm/test/CodeGen/PowerPC/testComparesieqsc.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesieqsc.ll
@@ -231,16 +231,18 @@ define dso_local void @test_ieqsc_sext_z_store(i8 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_ieqsc_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    clrldi r3, r3, 32
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_ieqsc_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    clrldi r3, r3, 32
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr

--- a/llvm/test/CodeGen/PowerPC/testComparesieqsc.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesieqsc.ll
@@ -100,16 +100,16 @@ define dso_local signext i32 @test_ieqsc_sext_z(i8 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_ieqsc_sext_z:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    clrldi r3, r3, 56
+; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_ieqsc_sext_z:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    clrldi r3, r3, 56
+; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    blr
 entry:
   %cmp = icmp eq i8 %a, 0
@@ -231,19 +231,17 @@ define dso_local void @test_ieqsc_sext_z_store(i8 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_ieqsc_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_ieqsc_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesieqsi.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesieqsi.ll
@@ -100,16 +100,16 @@ define dso_local signext i32 @test_ieqsi_sext_z(i32 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_ieqsi_sext_z:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    clrldi r3, r3, 32
+; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_ieqsi_sext_z:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    clrldi r3, r3, 32
+; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    blr
 entry:
   %cmp = icmp eq i32 %a, 0
@@ -231,19 +231,17 @@ define dso_local void @test_ieqsi_sext_z_store(i32 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_ieqsi_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_ieqsi_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesieqsi.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesieqsi.ll
@@ -231,16 +231,18 @@ define dso_local void @test_ieqsi_sext_z_store(i32 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_ieqsi_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    clrldi r3, r3, 32
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_ieqsi_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    clrldi r3, r3, 32
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr

--- a/llvm/test/CodeGen/PowerPC/testComparesieqss.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesieqss.ll
@@ -100,16 +100,16 @@ define dso_local signext i32 @test_ieqss_sext_z(i16 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_ieqss_sext_z:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    clrldi r3, r3, 48
+; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_ieqss_sext_z:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    clrldi r3, r3, 48
+; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    blr
 entry:
   %cmp = icmp eq i16 %a, 0
@@ -231,19 +231,17 @@ define dso_local void @test_ieqss_sext_z_store(i16 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_ieqss_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_ieqss_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesieqss.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesieqss.ll
@@ -231,16 +231,18 @@ define dso_local void @test_ieqss_sext_z_store(i16 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_ieqss_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    clrldi r3, r3, 32
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_ieqss_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    clrldi r3, r3, 32
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr

--- a/llvm/test/CodeGen/PowerPC/testComparesiequc.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesiequc.ll
@@ -100,16 +100,14 @@ define dso_local signext i32 @test_iequc_sext_z(i8 zeroext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_iequc_sext_z:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_iequc_sext_z:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    blr
 entry:
   %cmp = icmp eq i8 %a, 0
@@ -231,19 +229,17 @@ define dso_local void @test_iequc_sext_z_store(i8 zeroext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_iequc_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_iequc_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesiequi.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesiequi.ll
@@ -100,16 +100,14 @@ define dso_local signext i32 @test_iequi_sext_z(i32 zeroext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_iequi_sext_z:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_iequi_sext_z:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    blr
 entry:
   %cmp = icmp eq i32 %a, 0
@@ -231,19 +229,17 @@ define dso_local void @test_iequi_sext_z_store(i32 zeroext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_iequi_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_iequi_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesiequs.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesiequs.ll
@@ -100,16 +100,14 @@ define dso_local signext i32 @test_iequs_sext_z(i16 zeroext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_iequs_sext_z:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_iequs_sext_z:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    blr
 entry:
   %cmp = icmp eq i16 %a, 0
@@ -231,19 +229,17 @@ define dso_local void @test_iequs_sext_z_store(i16 zeroext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_iequs_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_iequs_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesileuc.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesileuc.ll
@@ -53,9 +53,8 @@ entry:
 define dso_local signext i32 @test_ileuc_sext_z(i8 zeroext %a) {
 ; CHECK-LABEL: test_ileuc_sext_z:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    cntlzw r3, r3
-; CHECK-NEXT:    srwi r3, r3, 5
-; CHECK-NEXT:    neg r3, r3
+; CHECK-NEXT:    addic r3, r3, -1
+; CHECK-NEXT:    subfe r3, r3, r3
 ; CHECK-NEXT:    blr
 entry:
   %cmp = icmp ule i8 %a, 0
@@ -117,10 +116,9 @@ entry:
 define dso_local void @test_ileuc_sext_z_store(i8 zeroext %a) {
 ; CHECK-LABEL: test_ileuc_sext_z_store:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    cntlzw r3, r3
+; CHECK-NEXT:    addic r3, r3, -1
 ; CHECK-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-NEXT:    srwi r3, r3, 5
-; CHECK-NEXT:    neg r3, r3
+; CHECK-NEXT:    subfe r3, r3, r3
 ; CHECK-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesileui.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesileui.ll
@@ -53,9 +53,8 @@ entry:
 define dso_local signext i32 @test_ileui_sext_z(i32 zeroext %a) {
 ; CHECK-LABEL: test_ileui_sext_z:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    cntlzw r3, r3
-; CHECK-NEXT:    srwi r3, r3, 5
-; CHECK-NEXT:    neg r3, r3
+; CHECK-NEXT:    addic r3, r3, -1
+; CHECK-NEXT:    subfe r3, r3, r3
 ; CHECK-NEXT:    blr
 entry:
   %cmp = icmp eq i32 %a, 0
@@ -117,10 +116,9 @@ entry:
 define dso_local void @test_ileui_sext_z_store(i32 zeroext %a) {
 ; CHECK-LABEL: test_ileui_sext_z_store:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    cntlzw r3, r3
+; CHECK-NEXT:    addic r3, r3, -1
 ; CHECK-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-NEXT:    srwi r3, r3, 5
-; CHECK-NEXT:    neg r3, r3
+; CHECK-NEXT:    subfe r3, r3, r3
 ; CHECK-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesileus.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesileus.ll
@@ -53,9 +53,8 @@ entry:
 define dso_local signext i32 @test_ileus_sext_z(i16 zeroext %a) {
 ; CHECK-LABEL: test_ileus_sext_z:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    cntlzw r3, r3
-; CHECK-NEXT:    srwi r3, r3, 5
-; CHECK-NEXT:    neg r3, r3
+; CHECK-NEXT:    addic r3, r3, -1
+; CHECK-NEXT:    subfe r3, r3, r3
 ; CHECK-NEXT:    blr
 entry:
   %cmp = icmp ule i16 %a, 0
@@ -117,10 +116,9 @@ entry:
 define dso_local void @test_ileus_sext_z_store(i16 zeroext %a) {
 ; CHECK-LABEL: test_ileus_sext_z_store:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    cntlzw r3, r3
+; CHECK-NEXT:    addic r3, r3, -1
 ; CHECK-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-NEXT:    srwi r3, r3, 5
-; CHECK-NEXT:    neg r3, r3
+; CHECK-NEXT:    subfe r3, r3, r3
 ; CHECK-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testCompareslleqsc.ll
+++ b/llvm/test/CodeGen/PowerPC/testCompareslleqsc.ll
@@ -231,16 +231,18 @@ define dso_local void @test_lleqsc_sext_z_store(i8 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_lleqsc_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    clrldi r3, r3, 32
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_lleqsc_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    clrldi r3, r3, 32
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr

--- a/llvm/test/CodeGen/PowerPC/testCompareslleqsc.ll
+++ b/llvm/test/CodeGen/PowerPC/testCompareslleqsc.ll
@@ -100,16 +100,16 @@ define i64 @test_lleqsc_sext_z(i8 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_lleqsc_sext_z:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    clrldi r3, r3, 56
+; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_lleqsc_sext_z:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    clrldi r3, r3, 56
+; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    blr
 entry:
   %cmp = icmp eq i8 %a, 0
@@ -231,19 +231,17 @@ define dso_local void @test_lleqsc_sext_z_store(i8 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_lleqsc_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_lleqsc_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testCompareslleqsi.ll
+++ b/llvm/test/CodeGen/PowerPC/testCompareslleqsi.ll
@@ -230,16 +230,18 @@ define dso_local void @test_lleqsi_sext_z_store(i32 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_lleqsi_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    clrldi r3, r3, 32
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_lleqsi_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    clrldi r3, r3, 32
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr

--- a/llvm/test/CodeGen/PowerPC/testCompareslleqsi.ll
+++ b/llvm/test/CodeGen/PowerPC/testCompareslleqsi.ll
@@ -99,16 +99,16 @@ define i64 @test_lleqsi_sext_z(i32 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_lleqsi_sext_z:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    clrldi r3, r3, 32
+; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_lleqsi_sext_z:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    clrldi r3, r3, 32
+; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    blr
 entry:
   %cmp = icmp eq i32 %a, 0
@@ -230,19 +230,17 @@ define dso_local void @test_lleqsi_sext_z_store(i32 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_lleqsi_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_lleqsi_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testCompareslleqss.ll
+++ b/llvm/test/CodeGen/PowerPC/testCompareslleqss.ll
@@ -230,16 +230,18 @@ define dso_local void @test_lleqss_sext_z_store(i16 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_lleqss_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    clrldi r3, r3, 32
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_lleqss_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    clrldi r3, r3, 32
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr

--- a/llvm/test/CodeGen/PowerPC/testCompareslleqss.ll
+++ b/llvm/test/CodeGen/PowerPC/testCompareslleqss.ll
@@ -99,16 +99,16 @@ define i64 @test_lleqss_sext_z(i16 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_lleqss_sext_z:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    clrldi r3, r3, 48
+; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_lleqss_sext_z:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    clrldi r3, r3, 48
+; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    blr
 entry:
   %cmp = icmp eq i16 %a, 0
@@ -230,19 +230,17 @@ define dso_local void @test_lleqss_sext_z_store(i16 signext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_lleqss_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_lleqss_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesllequc.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesllequc.ll
@@ -99,16 +99,14 @@ define i64 @test_llequc_sext_z(i8 zeroext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_llequc_sext_z:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_llequc_sext_z:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    blr
 entry:
   %cmp = icmp eq i8 %a, 0
@@ -230,19 +228,17 @@ define dso_local void @test_llequc_sext_z_store(i8 zeroext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_llequc_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_llequc_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesllequi.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesllequi.ll
@@ -99,16 +99,14 @@ define i64 @test_llequi_sext_z(i32 zeroext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_llequi_sext_z:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_llequi_sext_z:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    blr
 entry:
   %cmp = icmp eq i32 %a, 0
@@ -230,19 +228,17 @@ define dso_local void @test_llequi_sext_z_store(i32 zeroext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_llequi_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_llequi_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesllequs.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesllequs.ll
@@ -99,16 +99,14 @@ define i64 @test_llequs_sext_z(i16 zeroext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_llequs_sext_z:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_llequs_sext_z:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    blr
 entry:
   %cmp = icmp eq i16 %a, 0
@@ -230,19 +228,17 @@ define dso_local void @test_llequs_sext_z_store(i16 zeroext %a) {
 ; CHECK-NEXT:    blr
 ; CHECK-BE-LABEL: test_llequs_sext_z_store:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    cntlzw r3, r3
+; CHECK-BE-NEXT:    addic r3, r3, -1
 ; CHECK-BE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-BE-NEXT:    srwi r3, r3, 5
-; CHECK-BE-NEXT:    neg r3, r3
+; CHECK-BE-NEXT:    subfe r3, r3, r3
 ; CHECK-BE-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-LE-LABEL: test_llequs_sext_z_store:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    cntlzw r3, r3
+; CHECK-LE-NEXT:    addic r3, r3, -1
 ; CHECK-LE-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-LE-NEXT:    srwi r3, r3, 5
-; CHECK-LE-NEXT:    neg r3, r3
+; CHECK-LE-NEXT:    subfe r3, r3, r3
 ; CHECK-LE-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-LE-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesllleuc.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesllleuc.ll
@@ -53,9 +53,8 @@ entry:
 define i64 @test_llleuc_sext_z(i8 zeroext %a) {
 ; CHECK-LABEL: test_llleuc_sext_z:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    cntlzw r3, r3
-; CHECK-NEXT:    srwi r3, r3, 5
-; CHECK-NEXT:    neg r3, r3
+; CHECK-NEXT:    addic r3, r3, -1
+; CHECK-NEXT:    subfe r3, r3, r3
 ; CHECK-NEXT:    blr
 entry:
   %cmp = icmp ule i8 %a, 0
@@ -117,10 +116,9 @@ entry:
 define dso_local void @test_llleuc_sext_z_store(i8 zeroext %a) {
 ; CHECK-LABEL: test_llleuc_sext_z_store:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    cntlzw r3, r3
+; CHECK-NEXT:    addic r3, r3, -1
 ; CHECK-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-NEXT:    srwi r3, r3, 5
-; CHECK-NEXT:    neg r3, r3
+; CHECK-NEXT:    subfe r3, r3, r3
 ; CHECK-NEXT:    stb r3, glob@toc@l(r4)
 ; CHECK-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesllleui.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesllleui.ll
@@ -53,9 +53,8 @@ entry:
 define i64 @test_llleui_sext_z(i32 zeroext %a) {
 ; CHECK-LABEL: test_llleui_sext_z:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    cntlzw r3, r3
-; CHECK-NEXT:    srwi r3, r3, 5
-; CHECK-NEXT:    neg r3, r3
+; CHECK-NEXT:    addic r3, r3, -1
+; CHECK-NEXT:    subfe r3, r3, r3
 ; CHECK-NEXT:    blr
 entry:
   %cmp = icmp ule i32 %a, 0
@@ -117,10 +116,9 @@ entry:
 define dso_local void @test_llleui_sext_z_store(i32 zeroext %a) {
 ; CHECK-LABEL: test_llleui_sext_z_store:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    cntlzw r3, r3
+; CHECK-NEXT:    addic r3, r3, -1
 ; CHECK-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-NEXT:    srwi r3, r3, 5
-; CHECK-NEXT:    neg r3, r3
+; CHECK-NEXT:    subfe r3, r3, r3
 ; CHECK-NEXT:    stw r3, glob@toc@l(r4)
 ; CHECK-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/testComparesllleus.ll
+++ b/llvm/test/CodeGen/PowerPC/testComparesllleus.ll
@@ -53,9 +53,8 @@ entry:
 define i64 @test_llleus_sext_z(i16 zeroext %a) {
 ; CHECK-LABEL: test_llleus_sext_z:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    cntlzw r3, r3
-; CHECK-NEXT:    srwi r3, r3, 5
-; CHECK-NEXT:    neg r3, r3
+; CHECK-NEXT:    addic r3, r3, -1
+; CHECK-NEXT:    subfe r3, r3, r3
 ; CHECK-NEXT:    blr
 entry:
   %cmp = icmp ule i16 %a, 0
@@ -117,10 +116,9 @@ entry:
 define dso_local void @test_llleus_sext_z_store(i16 zeroext %a) {
 ; CHECK-LABEL: test_llleus_sext_z_store:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    cntlzw r3, r3
+; CHECK-NEXT:    addic r3, r3, -1
 ; CHECK-NEXT:    addis r4, r2, glob@toc@ha
-; CHECK-NEXT:    srwi r3, r3, 5
-; CHECK-NEXT:    neg r3, r3
+; CHECK-NEXT:    subfe r3, r3, r3
 ; CHECK-NEXT:    sth r3, glob@toc@l(r4)
 ; CHECK-NEXT:    blr
 entry:


### PR DESCRIPTION
The patch fixed issue [[PowerPC] Failure to optimize (x == 0) ? 0xFF : 0 to addic+subfe instead of cntlzw+srwi+neg ](https://github.com/llvm/llvm-project/issues/98598)