### PR TITLE
[flang] Added a note about Fortran 202X (F202X)

### DIFF
--- a/flang/docs/F202X.md
+++ b/flang/docs/F202X.md
@@ -6,6 +6,12 @@
 
 -->
 
+Note: before Fortran 2023 became an official standard, it was referred to in
+flang documentation as F202X or Fortran 202X. (For this reason, Fortran standard
+post 2023 is sometimes referred to as 202Y.) At this point, 202X should no
+longer be used to refer to Fortran 2023. In this document Fortran 202X means
+Fortran 2023 draft.
+
 # A first take on Fortran 202X features for LLVM Flang
 
 I (Peter Klausler) have been studying the draft PDF of the


### PR DESCRIPTION
Fortran 202X should no longer be used to refer to Fortran 2023 standard.