### PR TITLE
[bazel] Fix TestingSupport layering_check

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -6471,10 +6471,8 @@ cc_library(
     ]),
     hdrs = glob(["include/llvm/Testing/Support/*.h"]),
     copts = llvm_copts,
-    features = ["-layering_check"],
     deps = [
         ":Support",
-        ":config",
         "//third-party/unittest:gmock",
         "//third-party/unittest:gtest",
     ],

--- a/utils/bazel/llvm-project-overlay/third-party/unittest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/third-party/unittest/BUILD.bazel
@@ -54,8 +54,9 @@ cc_library(
     ) + [
     ],
     hdrs = [
-        "googletest/include/gtest/gtest.h",
+        "googletest/include/gtest/gtest-printers.h",
         "googletest/include/gtest/gtest-spi.h",
+        "googletest/include/gtest/gtest.h",
         "googletest/include/gtest/internal/gtest-port.h",
     ],
     copts = llvm_copts,

--- a/utils/bazel/llvm-project-overlay/third-party/unittest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/third-party/unittest/BUILD.bazel
@@ -54,9 +54,9 @@ cc_library(
     ) + [
     ],
     hdrs = [
+        "googletest/include/gtest/gtest.h",
         "googletest/include/gtest/gtest-printers.h",
         "googletest/include/gtest/gtest-spi.h",
-        "googletest/include/gtest/gtest.h",
         "googletest/include/gtest/internal/gtest-port.h",
     ],
     copts = llvm_copts,


### PR DESCRIPTION
I'm not sure if this header is public API upstream but we are using it
that way anyways.
