### PR TITLE
Triple: Add constructor from enum entries

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -375,6 +375,10 @@ public:
                   const Twine &OSStr);
   LLVM_ABI Triple(const Twine &ArchStr, const Twine &VendorStr,
                   const Twine &OSStr, const Twine &EnvironmentStr);
+  LLVM_ABI Triple(ArchType A, SubArchType SA = NoSubArch,
+                  VendorType V = UnknownVendor, OSType OS = UnknownOS,
+                  EnvironmentType E = UnknownEnvironment,
+                  ObjectFormatType OF = UnknownObjectFormat);
 
   bool operator==(const Triple &Other) const {
     return Arch == Other.Arch && SubArch == Other.SubArch &&

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -376,9 +376,11 @@ public:
   LLVM_ABI Triple(const Twine &ArchStr, const Twine &VendorStr,
                   const Twine &OSStr, const Twine &EnvironmentStr);
   LLVM_ABI Triple(ArchType A, SubArchType SA = NoSubArch,
-                  VendorType V = UnknownVendor, OSType OS = UnknownOS,
-                  EnvironmentType E = UnknownEnvironment,
-                  ObjectFormatType OF = UnknownObjectFormat);
+                  VendorType V = UnknownVendor, OSType OS = UnknownOS);
+  LLVM_ABI Triple(ArchType A, SubArchType SA, VendorType V, OSType OS,
+                  EnvironmentType E);
+  LLVM_ABI Triple(ArchType A, SubArchType SA, VendorType V, OSType OS,
+                  EnvironmentType E, ObjectFormatType OF);
 
   bool operator==(const Triple &Other) const {
     return Arch == Other.Arch && SubArch == Other.SubArch &&

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -1144,12 +1144,31 @@ Triple::Triple(const Twine &ArchStr, const Twine &VendorStr, const Twine &OSStr,
     ObjectFormat = getDefaultFormat(*this);
 }
 
+Triple::Triple(ArchType A, SubArchType SA, VendorType V, OSType OS)
+    : Data((getArchName(A, SA) + Twine('-') + getVendorTypeName(V) +
+            Twine('-') + getOSTypeName(OS))
+               .str()),
+      Arch(A), SubArch(SA), Vendor(V), OS(OS),
+      ObjectFormat(getDefaultFormat(*this)) {}
+
+Triple::Triple(ArchType A, SubArchType SA, VendorType V, OSType OS,
+               EnvironmentType E)
+    : Data((getArchName(A, SA) + Twine('-') + getVendorTypeName(V) +
+            Twine('-') + getOSTypeName(OS) + Twine('-') +
+            getEnvironmentTypeName(E))
+               .str()),
+      Arch(A), SubArch(SA), Vendor(V), OS(OS), Environment(E),
+      ObjectFormat(getDefaultFormat(*this)) {}
+
 Triple::Triple(ArchType A, SubArchType SA, VendorType V, OSType OS,
                EnvironmentType E, ObjectFormatType OF)
-    : Triple(getArchName(A, SA), getVendorTypeName(V), getOSTypeName(OS),
-             getEnvironmentTypeName(E)) {
-  setObjectFormat(OF);
-}
+    : Data((getArchName(A, SA) + Twine('-') + getVendorTypeName(V) +
+            Twine('-') + getOSTypeName(OS) + Twine('-') +
+            getEnvironmentTypeName(E) + Twine('-') +
+            getObjectFormatTypeName(OF))
+               .str()),
+      Arch(A), SubArch(SA), Vendor(V), OS(OS), Environment(E),
+      ObjectFormat(OF) {}
 
 static VersionTuple parseVersionFromName(StringRef Name);
 

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -1144,6 +1144,13 @@ Triple::Triple(const Twine &ArchStr, const Twine &VendorStr, const Twine &OSStr,
     ObjectFormat = getDefaultFormat(*this);
 }
 
+Triple::Triple(ArchType A, SubArchType SA, VendorType V, OSType OS,
+               EnvironmentType E, ObjectFormatType OF)
+    : Triple(getArchName(A, SA), getVendorTypeName(V), getOSTypeName(OS),
+             getEnvironmentTypeName(E)) {
+  setObjectFormat(OF);
+}
+
 static VersionTuple parseVersionFromName(StringRef Name);
 
 static StringRef getDXILArchNameFromShaderModel(StringRef ShaderModelStr) {

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -1479,6 +1479,16 @@ TEST(TripleTest, ParsedIDs) {
 
 TEST(TripleTest, EnumConstructor) {
   {
+    Triple T(Triple::amdgcn, Triple::NoSubArch, Triple::AMD, Triple::AMDHSA);
+    EXPECT_EQ(T.getArch(), Triple::amdgcn);
+    EXPECT_EQ(T.getVendor(), Triple::AMD);
+    EXPECT_EQ(T.getOS(), Triple::AMDHSA);
+    EXPECT_EQ(T.getEnvironment(), Triple::UnknownEnvironment);
+    EXPECT_EQ(T.getObjectFormat(), Triple::ELF);
+    EXPECT_EQ(T.str(), "amdgcn-amd-amdhsa");
+  }
+
+  {
     Triple T(Triple::amdgcn, Triple::NoSubArch, Triple::AMD, Triple::AMDHSA,
              Triple::LLVM, Triple::ELF);
     EXPECT_EQ(T.getArch(), Triple::amdgcn);
@@ -1486,6 +1496,18 @@ TEST(TripleTest, EnumConstructor) {
     EXPECT_EQ(T.getOS(), Triple::AMDHSA);
     EXPECT_EQ(T.getEnvironment(), Triple::LLVM);
     EXPECT_EQ(T.getObjectFormat(), Triple::ELF);
+    EXPECT_EQ(T.str(), "amdgcn-amd-amdhsa-llvm-elf");
+  }
+
+  {
+    Triple T(Triple::amdgcn, Triple::NoSubArch, Triple::AMD, Triple::AMDHSA,
+             Triple::LLVM);
+    EXPECT_EQ(T.getArch(), Triple::amdgcn);
+    EXPECT_EQ(T.getVendor(), Triple::AMD);
+    EXPECT_EQ(T.getOS(), Triple::AMDHSA);
+    EXPECT_EQ(T.getEnvironment(), Triple::LLVM);
+    EXPECT_EQ(T.getObjectFormat(), Triple::ELF);
+    EXPECT_EQ(T.str(), "amdgcn-amd-amdhsa-llvm");
   }
 
   {
@@ -1496,6 +1518,17 @@ TEST(TripleTest, EnumConstructor) {
     EXPECT_EQ(T.getOS(), Triple::Linux);
     EXPECT_EQ(T.getEnvironment(), Triple::GNU);
     EXPECT_EQ(T.getObjectFormat(), Triple::COFF);
+    EXPECT_EQ(T.str(), "arm-pc-linux-gnu-coff");
+  }
+
+  {
+    Triple T(Triple::arm, Triple::ARMSubArch_v9_7a);
+    EXPECT_EQ(T.getArch(), Triple::arm);
+    EXPECT_EQ(T.getVendor(), Triple::UnknownVendor);
+    EXPECT_EQ(T.getOS(), Triple::UnknownOS);
+    EXPECT_EQ(T.getEnvironment(), Triple::UnknownEnvironment);
+    EXPECT_EQ(T.getObjectFormat(), Triple::ELF);
+    EXPECT_EQ(T.str(), "arm-unknown-unknown");
   }
 
   {
@@ -1505,6 +1538,7 @@ TEST(TripleTest, EnumConstructor) {
     EXPECT_EQ(T.getOS(), Triple::UnknownOS);
     EXPECT_EQ(T.getEnvironment(), Triple::UnknownEnvironment);
     EXPECT_EQ(T.getObjectFormat(), Triple::ELF);
+    EXPECT_EQ(T.str(), "x86_64-unknown-unknown");
   }
 
   {
@@ -1514,6 +1548,40 @@ TEST(TripleTest, EnumConstructor) {
     EXPECT_EQ(T.getOS(), Triple::UnknownOS);
     EXPECT_EQ(T.getEnvironment(), Triple::UnknownEnvironment);
     EXPECT_EQ(T.getObjectFormat(), Triple::DXContainer);
+    EXPECT_EQ(T.str(), "dxilv1.0-unknown-unknown");
+  }
+
+  {
+    Triple T(Triple::x86_64, Triple::NoSubArch, Triple::UnknownVendor,
+             Triple::UnknownOS, Triple::MSVC);
+    EXPECT_EQ(T.getArch(), Triple::x86_64);
+    EXPECT_EQ(T.getVendor(), Triple::UnknownVendor);
+    EXPECT_EQ(T.getOS(), Triple::UnknownOS);
+    EXPECT_EQ(T.getEnvironment(), Triple::MSVC);
+    EXPECT_EQ(T.getObjectFormat(), Triple::ELF);
+    EXPECT_EQ(T.str(), "x86_64-unknown-unknown-msvc");
+  }
+
+  {
+    Triple T(Triple::x86, Triple::NoSubArch, Triple::UnknownVendor,
+             Triple::Win32);
+    EXPECT_EQ(T.getArch(), Triple::x86);
+    EXPECT_EQ(T.getVendor(), Triple::UnknownVendor);
+    EXPECT_EQ(T.getOS(), Triple::Win32);
+    EXPECT_EQ(T.getEnvironment(), Triple::UnknownEnvironment);
+    EXPECT_EQ(T.getObjectFormat(), Triple::COFF);
+    EXPECT_EQ(T.str(), "i386-unknown-windows");
+  }
+
+  {
+    Triple T(Triple::x86, Triple::NoSubArch, Triple::PC, Triple::Win32,
+             Triple::MSVC);
+    EXPECT_EQ(T.getArch(), Triple::x86);
+    EXPECT_EQ(T.getVendor(), Triple::PC);
+    EXPECT_EQ(T.getOS(), Triple::Win32);
+    EXPECT_EQ(T.getEnvironment(), Triple::MSVC);
+    EXPECT_EQ(T.getObjectFormat(), Triple::COFF);
+    EXPECT_EQ(T.str(), "i386-pc-windows-msvc");
   }
 }
 

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -1477,6 +1477,46 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::ChipStar, T.getOS());
 }
 
+TEST(TripleTest, EnumConstructor) {
+  {
+    Triple T(Triple::amdgcn, Triple::NoSubArch, Triple::AMD, Triple::AMDHSA,
+             Triple::LLVM, Triple::ELF);
+    EXPECT_EQ(T.getArch(), Triple::amdgcn);
+    EXPECT_EQ(T.getVendor(), Triple::AMD);
+    EXPECT_EQ(T.getOS(), Triple::AMDHSA);
+    EXPECT_EQ(T.getEnvironment(), Triple::LLVM);
+    EXPECT_EQ(T.getObjectFormat(), Triple::ELF);
+  }
+
+  {
+    Triple T(Triple::arm, Triple::ARMSubArch_v9_7a, Triple::PC, Triple::Linux,
+             Triple::GNU, Triple::COFF);
+    EXPECT_EQ(T.getArch(), Triple::arm);
+    EXPECT_EQ(T.getVendor(), Triple::PC);
+    EXPECT_EQ(T.getOS(), Triple::Linux);
+    EXPECT_EQ(T.getEnvironment(), Triple::GNU);
+    EXPECT_EQ(T.getObjectFormat(), Triple::COFF);
+  }
+
+  {
+    Triple T(Triple::x86_64);
+    EXPECT_EQ(T.getArch(), Triple::x86_64);
+    EXPECT_EQ(T.getVendor(), Triple::UnknownVendor);
+    EXPECT_EQ(T.getOS(), Triple::UnknownOS);
+    EXPECT_EQ(T.getEnvironment(), Triple::UnknownEnvironment);
+    EXPECT_EQ(T.getObjectFormat(), Triple::ELF);
+  }
+
+  {
+    Triple T(Triple::dxil);
+    EXPECT_EQ(T.getArch(), Triple::dxil);
+    EXPECT_EQ(T.getVendor(), Triple::UnknownVendor);
+    EXPECT_EQ(T.getOS(), Triple::UnknownOS);
+    EXPECT_EQ(T.getEnvironment(), Triple::UnknownEnvironment);
+    EXPECT_EQ(T.getObjectFormat(), Triple::DXContainer);
+  }
+}
+
 static std::string Join(StringRef A, StringRef B, StringRef C) {
   std::string Str = std::string(A);
   Str += '-';


### PR DESCRIPTION
Don't require hardcoding the string names.