### PR TITLE
[RISCV] Use EVT instead of MVT in compressShuffleOfShuffles.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -5517,7 +5517,7 @@ static SDValue compressShuffleOfShuffles(ShuffleVectorSDNode *SVN,
     NewMask[Idx] = OrigLane;
   }
 
-  MVT VT = SVN->getSimpleValueType(0);
+  EVT VT = SVN->getValueType(0);
   SDLoc DL(SVN);
 
   return DAG.getVectorShuffle(VT, DL, V1->getOperand(0), V2->getOperand(0),

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-int.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-int.ll
@@ -1480,3 +1480,18 @@ define <8 x i8> @vmerge_vxm3(<8 x i8> %v, i8 %s) {
   ret <8 x i8> %shuf
 }
 
+; This is a non-MVT type that previously crashed due to use of getSimpleValueType
+; in a DAG combine.
+define <4 x i40> @pr190605(<4 x i40> %x) {
+; CHECK-LABEL: pr190605:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
+; CHECK-NEXT:    vmv2r.v v10, v8
+; CHECK-NEXT:    vslideup.vi v10, v8, 2
+; CHECK-NEXT:    vmv.v.v v8, v10
+; CHECK-NEXT:    ret
+  %y = shufflevector <4 x i40> %x, <4 x i40> poison, <4 x i32> <i32 0, i32 0, i32 0, i32 0>
+  %z = shufflevector <4 x i40> %x, <4 x i40> poison, <4 x i32> <i32 1, i32 1, i32 1, i32 1>
+  %w = shufflevector <4 x i40> %y, <4 x i40> %z, <4 x i32> <i32 0, i32 4, i32 1, i32 5>
+  ret <4 x i40> %w
+}


### PR DESCRIPTION
For the test case I just grabbed a test that exercised this code path and made the VT illegal.

Fixes #190605.