### PR TITLE
[MLIR][GPU] Add cooperative launch support to gpu.launch_func

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
@@ -619,6 +619,7 @@ def GPU_LaunchFuncOp :GPU_Op<"launch_func", [
                Optional<LaunchIndx>:$clusterSizeY,
                Optional<LaunchIndx>:$clusterSizeZ,
                Optional<I32>:$dynamicSharedMemorySize,
+               UnitAttr:$cooperative,
                Variadic<AnyType>:$kernelOperands,
                Optional<AnyType>:$asyncObject)>,
     Results<(outs Optional<GPU_AsyncToken>:$asyncToken)> {
@@ -660,6 +661,11 @@ def GPU_LaunchFuncOp :GPU_Op<"launch_func", [
     `clusterSizeX`, `clusterSizeY`, and `clusterSizeZ` arguments. When these
     arguments are present, the Op launches a kernel that clusters the given
     thread blocks. This feature is exclusive to certain architectures.
+
+    The `cooperative` attribute indicates that the kernel should be launched
+    cooperatively, guaranteeing that all thread blocks in the grid are
+    co-resident on the GPU simultaneously. This enables grid-wide
+    synchronization patterns.
 
     Example:
 
@@ -787,6 +793,7 @@ def GPU_LaunchFuncOp :GPU_Op<"launch_func", [
       `threads` `in` ` ` `(` $blockSizeX `,` $blockSizeY `,` $blockSizeZ `)`
       custom<LaunchDimType>(type($gridSizeX), ref($clusterSizeX), type($clusterSizeX), type($clusterSizeY), type($clusterSizeZ))
       (`dynamic_shared_memory_size` $dynamicSharedMemorySize^)?
+      (`cooperative` $cooperative^)?
       custom<LaunchFuncOperands>($kernelOperands, type($kernelOperands)) attr-dict
   }];
   let hasVerifier = 1;
@@ -803,6 +810,7 @@ def GPU_LaunchOp : GPU_Op<"launch", [
                Optional<Index>:$clusterSizeY,
                Optional<Index>:$clusterSizeZ,
                Optional<I32>:$dynamicSharedMemorySize,
+               UnitAttr:$cooperative,
                OptionalAttr<FlatSymbolRefAttr>:$module,
                OptionalAttr<FlatSymbolRefAttr>:$function,
                OptionalAttr<ConfinedAttr<I64Attr, [IntNonNegative]>>:$workgroup_attributions)>,

--- a/mlir/lib/Conversion/GPUCommon/GPUToLLVMConversion.cpp
+++ b/mlir/lib/Conversion/GPUCommon/GPUToLLVMConversion.cpp
@@ -1070,7 +1070,7 @@ LogicalResult LegalizeLaunchFuncOpPattern::matchAndRewrite(
         gpu::KernelDim3{adaptor.getClusterSizeX(), adaptor.getClusterSizeY(),
                         adaptor.getClusterSizeZ()};
   }
-  gpu::LaunchFuncOp::create(
+  auto newLaunchOp = gpu::LaunchFuncOp::create(
       rewriter, launchOp.getLoc(), launchOp.getKernelAttr(),
       gpu::KernelDim3{adaptor.getGridSizeX(), adaptor.getGridSizeY(),
                       adaptor.getGridSizeZ()},
@@ -1079,6 +1079,8 @@ LogicalResult LegalizeLaunchFuncOpPattern::matchAndRewrite(
       adaptor.getDynamicSharedMemorySize(),
       llvmArgumentsWithSizes.empty() ? llvmArguments : llvmArgumentsWithSizes,
       stream, clusterSize);
+  if (launchOp.getCooperative())
+    newLaunchOp.setCooperative(true);
   if (launchOp.getAsyncToken())
     rewriter.replaceOp(launchOp, {stream});
   else

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -924,6 +924,9 @@ void LaunchOp::print(OpAsmPrinter &p) {
     p << ')';
   }
 
+  if (getCooperative())
+    p << " cooperative";
+
   printAttributions(p, getWorkgroupKeyword(), getWorkgroupAttributionBBArgs());
   printAttributions(p, getPrivateKeyword(), getPrivateAttributions());
 
@@ -933,7 +936,8 @@ void LaunchOp::print(OpAsmPrinter &p) {
   p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{
                               LaunchOp::getOperandSegmentSizeAttr(),
                               getWorkgroupAttributionsAttrName(),
-                              moduleAttrName, functionAttrName});
+                              getCooperativeAttrName(), moduleAttrName,
+                              functionAttrName});
 }
 
 // Parse the size assignment blocks for blocks and threads.  These have the form
@@ -1074,6 +1078,10 @@ ParseResult LaunchOp::parse(OpAsmParser &parser, OperationState &result) {
         parser.parseRParen())
       return failure();
   }
+
+  // Parse optional cooperative keyword.
+  if (succeeded(parser.parseOptionalKeyword("cooperative")))
+    result.addAttribute("cooperative", parser.getBuilder().getUnitAttr());
 
   // Create the region arguments: fixed launch-config args (`index`), then
   // workgroup / private attribution args. The workgroup count is stored in the

--- a/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
@@ -296,6 +296,8 @@ static void convertToLaunchFuncOp(gpu::LaunchOp launchOp,
       launchOp.getDynamicSharedMemorySize(), operands,
       asyncToken ? asyncToken.getType() : nullptr,
       launchOp.getAsyncDependencies(), clusterSize);
+  if (launchOp.getCooperative())
+    launchFunc.setCooperative(true);
   launchOp.replaceAllUsesWith(launchFunc);
   launchOp.erase();
 }

--- a/mlir/lib/ExecutionEngine/CudaRuntimeWrappers.cpp
+++ b/mlir/lib/ExecutionEngine/CudaRuntimeWrappers.cpp
@@ -362,6 +362,76 @@ extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuSetDefaultDevice(int32_t device) {
 
 #if (CUDA_VERSION >= 12000)
 
+extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuLaunchKernelEx(
+    CUfunction function, intptr_t gridX, intptr_t gridY, intptr_t gridZ,
+    intptr_t blockX, intptr_t blockY, intptr_t blockZ, int32_t smem,
+    CUstream stream, void **params, void **extra, intptr_t clusterX,
+    intptr_t clusterY, intptr_t clusterZ, int32_t cooperative) {
+  ScopedContext scopedContext;
+  if (smem > 0) {
+    int32_t maxShmem = 0;
+    CUdevice device = getDefaultCuDevice();
+    CUDA_REPORT_IF_ERROR(cuDeviceGet(&device, /*ordinal=*/defaultDevice));
+    CUDA_REPORT_IF_ERROR(cuDeviceGetAttribute(
+        &maxShmem, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
+        device));
+    if (maxShmem < smem) {
+      fprintf(stderr,
+              "Requested shared memory (%dkb) is larger than maximum allowed "
+              "shared memory (%dkb) for this device\n",
+              smem, maxShmem);
+    }
+    CUDA_REPORT_IF_ERROR(cuFuncSetAttribute(
+        function, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, smem));
+  }
+
+  CUlaunchConfig config;
+  config.gridDimX = gridX;
+  config.gridDimY = gridY;
+  config.gridDimZ = gridZ;
+  config.blockDimX = blockX;
+  config.blockDimY = blockY;
+  config.blockDimZ = blockZ;
+  config.sharedMemBytes = smem;
+  config.hStream = stream;
+
+  CUlaunchAttribute launchAttrs[3];
+  int numAttrs = 0;
+
+  bool hasCluster = clusterX > 0 && clusterY > 0 && clusterZ > 0;
+  if (hasCluster) {
+    launchAttrs[numAttrs].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+    launchAttrs[numAttrs].value.clusterDim.x = clusterX;
+    launchAttrs[numAttrs].value.clusterDim.y = clusterY;
+    launchAttrs[numAttrs].value.clusterDim.z = clusterZ;
+    numAttrs++;
+
+    launchAttrs[numAttrs].id =
+        CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
+    launchAttrs[numAttrs].value.clusterSchedulingPolicyPreference =
+        CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
+    numAttrs++;
+  }
+
+  if (cooperative) {
+    launchAttrs[numAttrs].id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
+    launchAttrs[numAttrs].value.cooperative = 1;
+    numAttrs++;
+  }
+
+  config.numAttrs = numAttrs;
+  config.attrs = launchAttrs;
+
+  debug_print("Launching kernel (cooperative=%d, cluster=%d),"
+              "grid=%ld,%ld,%ld, "
+              "threads: %ld, %ld, %ld, "
+              "smem: %dkb\n",
+              cooperative, hasCluster, gridX, gridY, gridZ, blockX, blockY,
+              blockZ, smem);
+
+  CUDA_REPORT_IF_ERROR(cuLaunchKernelEx(&config, function, params, extra));
+}
+
 extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuLaunchClusterKernel(
     CUfunction function, intptr_t clusterX, intptr_t clusterY,
     intptr_t clusterZ, intptr_t gridX, intptr_t gridY, intptr_t gridZ,

--- a/mlir/lib/ExecutionEngine/CudaRuntimeWrappers.cpp
+++ b/mlir/lib/ExecutionEngine/CudaRuntimeWrappers.cpp
@@ -362,14 +362,11 @@ extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuSetDefaultDevice(int32_t device) {
 
 #if (CUDA_VERSION >= 12000)
 
-// Cooperative launch entry point, optionally with a cluster. Pass
-// `clusterX/Y/Z = 0` to launch cooperatively without a cluster.
-extern "C" MLIR_CUDA_WRAPPERS_EXPORT void
-mgpuLaunchKernelEx(CUfunction function, intptr_t gridX, intptr_t gridY,
-                   intptr_t gridZ, intptr_t blockX, intptr_t blockY,
-                   intptr_t blockZ, int32_t smem, CUstream stream,
-                   void **params, void **extra, intptr_t clusterX,
-                   intptr_t clusterY, intptr_t clusterZ, int32_t cooperative) {
+extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuLaunchKernelCooperative(
+    CUfunction function, intptr_t gridX, intptr_t gridY, intptr_t gridZ,
+    intptr_t clusterX, intptr_t clusterY, intptr_t clusterZ, intptr_t blockX,
+    intptr_t blockY, intptr_t blockZ, int32_t smem, CUstream stream,
+    void **params, void **extra) {
   ScopedContext scopedContext;
   if (smem > 0) {
     int32_t maxShmem = 0;
@@ -416,21 +413,18 @@ mgpuLaunchKernelEx(CUfunction function, intptr_t gridX, intptr_t gridY,
     numAttrs++;
   }
 
-  if (cooperative) {
-    launchAttrs[numAttrs].id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
-    launchAttrs[numAttrs].value.cooperative = 1;
-    numAttrs++;
-  }
+  launchAttrs[numAttrs].id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
+  launchAttrs[numAttrs].value.cooperative = 1;
+  numAttrs++;
 
   config.numAttrs = numAttrs;
   config.attrs = launchAttrs;
 
-  debug_print("Launching kernel (cooperative=%d, cluster=%d),"
+  debug_print("Launching cooperative kernel (cluster=%d), "
               "grid=%ld,%ld,%ld, "
               "threads: %ld, %ld, %ld, "
               "smem: %dkb\n",
-              cooperative, hasCluster, gridX, gridY, gridZ, blockX, blockY,
-              blockZ, smem);
+              hasCluster, gridX, gridY, gridZ, blockX, blockY, blockZ, smem);
 
   CUDA_REPORT_IF_ERROR(cuLaunchKernelEx(&config, function, params, extra));
 }

--- a/mlir/lib/ExecutionEngine/CudaRuntimeWrappers.cpp
+++ b/mlir/lib/ExecutionEngine/CudaRuntimeWrappers.cpp
@@ -362,11 +362,14 @@ extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuSetDefaultDevice(int32_t device) {
 
 #if (CUDA_VERSION >= 12000)
 
-extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuLaunchKernelEx(
-    CUfunction function, intptr_t gridX, intptr_t gridY, intptr_t gridZ,
-    intptr_t blockX, intptr_t blockY, intptr_t blockZ, int32_t smem,
-    CUstream stream, void **params, void **extra, intptr_t clusterX,
-    intptr_t clusterY, intptr_t clusterZ, int32_t cooperative) {
+// Cooperative launch entry point, optionally with a cluster. Pass
+// `clusterX/Y/Z = 0` to launch cooperatively without a cluster.
+extern "C" MLIR_CUDA_WRAPPERS_EXPORT void
+mgpuLaunchKernelEx(CUfunction function, intptr_t gridX, intptr_t gridY,
+                   intptr_t gridZ, intptr_t blockX, intptr_t blockY,
+                   intptr_t blockZ, int32_t smem, CUstream stream,
+                   void **params, void **extra, intptr_t clusterX,
+                   intptr_t clusterY, intptr_t clusterZ, int32_t cooperative) {
   ScopedContext scopedContext;
   if (smem > 0) {
     int32_t maxShmem = 0;

--- a/mlir/lib/ExecutionEngine/RocmRuntimeWrappers.cpp
+++ b/mlir/lib/ExecutionEngine/RocmRuntimeWrappers.cpp
@@ -69,6 +69,26 @@ extern "C" void mgpuLaunchKernel(hipFunction_t function, intptr_t gridX,
                                             stream, params, extra));
 }
 
+// Cooperative launch entry point. The cluster dimensions are accepted to
+// match the CUDA wrapper signature, but HIP does not support thread block
+// clusters; passing nonzero cluster dimensions is a usage error.
+extern "C" void mgpuLaunchKernelCooperative(
+    hipFunction_t function, intptr_t gridX, intptr_t gridY, intptr_t gridZ,
+    intptr_t clusterX, intptr_t clusterY, intptr_t clusterZ, intptr_t blockX,
+    intptr_t blockY, intptr_t blockZ, int32_t smem, hipStream_t stream,
+    void **params, void ** /*extra*/) {
+  if (clusterX != 0 || clusterY != 0 || clusterZ != 0) {
+    fprintf(stderr,
+            "mgpuLaunchKernelCooperative: HIP does not support thread block "
+            "clusters (got cluster=%ld,%ld,%ld)\n",
+            clusterX, clusterY, clusterZ);
+    abort();
+  }
+  HIP_REPORT_IF_ERROR(
+      hipModuleLaunchCooperativeKernel(function, gridX, gridY, gridZ, blockX,
+                                       blockY, blockZ, smem, stream, params));
+}
+
 extern "C" hipStream_t mgpuStreamCreate() {
   hipStream_t stream = nullptr;
   HIP_REPORT_IF_ERROR(hipStreamCreate(&stream));

--- a/mlir/lib/Target/LLVMIR/Dialect/GPU/SelectObjectAttr.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GPU/SelectObjectAttr.cpp
@@ -215,6 +215,9 @@ public:
   // Get the kernel launch callee.
   FunctionCallee getClusterKernelLaunchFn();
 
+  // Get the extended kernel launch callee (cooperative and/or cluster).
+  FunctionCallee getKernelLaunchExFn();
+
   // Get the module function callee.
   FunctionCallee getModuleFunctionFn();
 
@@ -308,6 +311,20 @@ llvm::FunctionCallee llvm::LaunchKernel::getClusterKernelLaunchFn() {
           ArrayRef<Type *>({ptrTy, intPtrTy, intPtrTy, intPtrTy, intPtrTy,
                             intPtrTy, intPtrTy, intPtrTy, intPtrTy, intPtrTy,
                             i32Ty, ptrTy, ptrTy, ptrTy}),
+          false));
+}
+
+llvm::FunctionCallee llvm::LaunchKernel::getKernelLaunchExFn() {
+  // mgpuLaunchKernelEx(function, gridX, gridY, gridZ, blockX, blockY, blockZ,
+  //   smem, stream, params, extra,
+  //   clusterX, clusterY, clusterZ, cooperative)
+  return module.getOrInsertFunction(
+      "mgpuLaunchKernelEx",
+      FunctionType::get(
+          voidTy,
+          ArrayRef<Type *>({ptrTy, intPtrTy, intPtrTy, intPtrTy, intPtrTy,
+                            intPtrTy, intPtrTy, i32Ty, ptrTy, ptrTy, ptrTy,
+                            intPtrTy, intPtrTy, intPtrTy, i32Ty}),
           false));
 }
 
@@ -452,15 +469,24 @@ llvm::LaunchKernel::createKernelLaunch(mlir::gpu::LaunchFuncOp op,
   // Create the launch call.
   Value *nullPtr = ConstantPointerNull::get(ptrTy);
 
-  // Launch kernel with clusters if cluster size is specified.
-  if (op.hasClusterSize()) {
-    mlir::gpu::KernelDim3 cluster = op.getClusterSizeOperandValues();
-    Value *cx = llvmValue(cluster.x), *cy = llvmValue(cluster.y),
-          *cz = llvmValue(cluster.z);
+  // Use mgpuLaunchKernelEx when cooperative or cluster launch is requested.
+  if (op.getCooperative() || op.hasClusterSize()) {
+    Value *cx = ConstantInt::get(intPtrTy, 0);
+    Value *cy = ConstantInt::get(intPtrTy, 0);
+    Value *cz = ConstantInt::get(intPtrTy, 0);
+    if (op.hasClusterSize()) {
+      mlir::gpu::KernelDim3 cluster = op.getClusterSizeOperandValues();
+      cx = llvmValue(cluster.x);
+      cy = llvmValue(cluster.y);
+      cz = llvmValue(cluster.z);
+    }
+    Value *cooperativeFlag =
+        ConstantInt::get(i32Ty, op.getCooperative() ? 1 : 0);
     builder.CreateCall(
-        getClusterKernelLaunchFn(),
-        ArrayRef<Value *>({moduleFunction, cx, cy, cz, gx, gy, gz, bx, by, bz,
-                           dynamicMemorySize, stream, argArray, nullPtr}));
+        getKernelLaunchExFn(),
+        ArrayRef<Value *>({moduleFunction, gx, gy, gz, bx, by, bz,
+                           dynamicMemorySize, stream, argArray, nullPtr,
+                           cx, cy, cz, cooperativeFlag}));
   } else {
     builder.CreateCall(getKernelLaunchFn(),
                        ArrayRef<Value *>({moduleFunction, gx, gy, gz, bx, by,

--- a/mlir/lib/Target/LLVMIR/Dialect/GPU/SelectObjectAttr.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GPU/SelectObjectAttr.cpp
@@ -215,8 +215,8 @@ public:
   // Get the kernel launch callee.
   FunctionCallee getClusterKernelLaunchFn();
 
-  // Get the extended kernel launch callee (cooperative and/or cluster).
-  FunctionCallee getKernelLaunchExFn();
+  // Get the cooperative kernel launch callee.
+  FunctionCallee getKernelLaunchCooperativeFn();
 
   // Get the module function callee.
   FunctionCallee getModuleFunctionFn();
@@ -314,17 +314,14 @@ llvm::FunctionCallee llvm::LaunchKernel::getClusterKernelLaunchFn() {
           false));
 }
 
-llvm::FunctionCallee llvm::LaunchKernel::getKernelLaunchExFn() {
-  // mgpuLaunchKernelEx(function, gridX, gridY, gridZ, blockX, blockY, blockZ,
-  //   smem, stream, params, extra,
-  //   clusterX, clusterY, clusterZ, cooperative)
+llvm::FunctionCallee llvm::LaunchKernel::getKernelLaunchCooperativeFn() {
   return module.getOrInsertFunction(
-      "mgpuLaunchKernelEx",
+      "mgpuLaunchKernelCooperative",
       FunctionType::get(
           voidTy,
           ArrayRef<Type *>({ptrTy, intPtrTy, intPtrTy, intPtrTy, intPtrTy,
-                            intPtrTy, intPtrTy, i32Ty, ptrTy, ptrTy, ptrTy,
-                            intPtrTy, intPtrTy, intPtrTy, i32Ty}),
+                            intPtrTy, intPtrTy, intPtrTy, intPtrTy, intPtrTy,
+                            i32Ty, ptrTy, ptrTy, ptrTy}),
           false));
 }
 
@@ -469,10 +466,10 @@ llvm::LaunchKernel::createKernelLaunch(mlir::gpu::LaunchFuncOp op,
   // Create the launch call.
   Value *nullPtr = ConstantPointerNull::get(ptrTy);
 
-  // Cooperative launches go through mgpuLaunchKernelEx, which also handles
-  // an optional cluster. Cluster-only (non-cooperative) launches keep their
-  // existing path through mgpuLaunchClusterKernel. Plain launches go through
-  // mgpuLaunchKernel.
+  // Cooperative launches go through mgpuLaunchKernelCooperative, which also
+  // handles an optional cluster. Cluster-only (non-cooperative) launches keep
+  // their existing path through mgpuLaunchClusterKernel. Plain launches go
+  // through mgpuLaunchKernel.
   if (op.getCooperative()) {
     Value *cx = ConstantInt::get(intPtrTy, 0);
     Value *cy = ConstantInt::get(intPtrTy, 0);
@@ -483,12 +480,10 @@ llvm::LaunchKernel::createKernelLaunch(mlir::gpu::LaunchFuncOp op,
       cy = llvmValue(cluster.y);
       cz = llvmValue(cluster.z);
     }
-    Value *cooperativeFlag = ConstantInt::get(i32Ty, 1);
     builder.CreateCall(
-        getKernelLaunchExFn(),
-        ArrayRef<Value *>({moduleFunction, gx, gy, gz, bx, by, bz,
-                           dynamicMemorySize, stream, argArray, nullPtr, cx, cy,
-                           cz, cooperativeFlag}));
+        getKernelLaunchCooperativeFn(),
+        ArrayRef<Value *>({moduleFunction, gx, gy, gz, cx, cy, cz, bx, by, bz,
+                           dynamicMemorySize, stream, argArray, nullPtr}));
   } else if (op.hasClusterSize()) {
     mlir::gpu::KernelDim3 cluster = op.getClusterSizeOperandValues();
     Value *cx = llvmValue(cluster.x), *cy = llvmValue(cluster.y),

--- a/mlir/lib/Target/LLVMIR/Dialect/GPU/SelectObjectAttr.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GPU/SelectObjectAttr.cpp
@@ -469,8 +469,11 @@ llvm::LaunchKernel::createKernelLaunch(mlir::gpu::LaunchFuncOp op,
   // Create the launch call.
   Value *nullPtr = ConstantPointerNull::get(ptrTy);
 
-  // Use mgpuLaunchKernelEx when cooperative or cluster launch is requested.
-  if (op.getCooperative() || op.hasClusterSize()) {
+  // Cooperative launches go through mgpuLaunchKernelEx, which also handles
+  // an optional cluster. Cluster-only (non-cooperative) launches keep their
+  // existing path through mgpuLaunchClusterKernel. Plain launches go through
+  // mgpuLaunchKernel.
+  if (op.getCooperative()) {
     Value *cx = ConstantInt::get(intPtrTy, 0);
     Value *cy = ConstantInt::get(intPtrTy, 0);
     Value *cz = ConstantInt::get(intPtrTy, 0);
@@ -480,13 +483,20 @@ llvm::LaunchKernel::createKernelLaunch(mlir::gpu::LaunchFuncOp op,
       cy = llvmValue(cluster.y);
       cz = llvmValue(cluster.z);
     }
-    Value *cooperativeFlag =
-        ConstantInt::get(i32Ty, op.getCooperative() ? 1 : 0);
+    Value *cooperativeFlag = ConstantInt::get(i32Ty, 1);
     builder.CreateCall(
         getKernelLaunchExFn(),
         ArrayRef<Value *>({moduleFunction, gx, gy, gz, bx, by, bz,
-                           dynamicMemorySize, stream, argArray, nullPtr,
-                           cx, cy, cz, cooperativeFlag}));
+                           dynamicMemorySize, stream, argArray, nullPtr, cx, cy,
+                           cz, cooperativeFlag}));
+  } else if (op.hasClusterSize()) {
+    mlir::gpu::KernelDim3 cluster = op.getClusterSizeOperandValues();
+    Value *cx = llvmValue(cluster.x), *cy = llvmValue(cluster.y),
+          *cz = llvmValue(cluster.z);
+    builder.CreateCall(
+        getClusterKernelLaunchFn(),
+        ArrayRef<Value *>({moduleFunction, cx, cy, cz, gx, gy, gz, bx, by, bz,
+                           dynamicMemorySize, stream, argArray, nullPtr}));
   } else {
     builder.CreateCall(getKernelLaunchFn(),
                        ArrayRef<Value *>({moduleFunction, gx, gy, gz, bx, by,

--- a/mlir/test/Dialect/GPU/ops.mlir
+++ b/mlir/test/Dialect/GPU/ops.mlir
@@ -17,6 +17,18 @@ module attributes {gpu.container_module} {
     return
   }
 
+  // CHECK-LABEL:func @launch_cooperative(%{{.*}}: index)
+  func.func @launch_cooperative(%sz : index) {
+    // CHECK: gpu.launch blocks(%{{.*}}, %{{.*}}, %{{.*}}) in (%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) threads(%{{.*}}, %{{.*}}, %{{.*}}) in (%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) cooperative
+    gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %sz, %grid_y = %sz, %grid_z = %sz)
+               threads(%tx, %ty, %tz) in (%block_x = %sz, %block_y = %sz, %block_z = %sz)
+               cooperative {
+      // CHECK: gpu.terminator
+      gpu.terminator
+    }
+    return
+  }
+
   // CHECK-LABEL:func @launch_with_module_func_attr(%{{.*}}: index)
   func.func @launch_with_module_func_attr(%sz : index) {
     // CHECK: gpu.launch blocks(%{{.*}}, %{{.*}}, %{{.*}}) in (%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) threads(%{{.*}}, %{{.*}}, %{{.*}}) in (%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) module(@test_module) function(@test_kernel_func)
@@ -232,6 +244,12 @@ module attributes {gpu.container_module} {
 
     // CHECK: gpu.launch_func @kernels::@kernel_1 clusters in (%{{.*}}, %{{.*}}, %{{.*}}) blocks in (%{{.*}}, %{{.*}}, %{{.*}}) threads in (%{{.*}}, %{{.*}}, %{{.*}}) args(%{{.*}} : f32, %{{.*}} : memref<?xf32, 1>)
     gpu.launch_func @kernels::@kernel_1 clusters in (%cst, %cst, %cst) blocks in (%cst, %cst, %cst) threads in (%cst, %cst, %cst) args(%0 : f32, %1 : memref<?xf32, 1>)
+
+    // CHECK: gpu.launch_func @kernels::@kernel_1 blocks in (%{{.*}}, %{{.*}}, %{{.*}}) threads in (%{{.*}}, %{{.*}}, %{{.*}}) cooperative args(%{{.*}} : f32, %{{.*}} : memref<?xf32, 1>)
+    gpu.launch_func @kernels::@kernel_1 blocks in (%cst, %cst, %cst) threads in (%cst, %cst, %cst) cooperative args(%0 : f32, %1 : memref<?xf32, 1>)
+
+    // CHECK: gpu.launch_func @kernels::@kernel_1 clusters in (%{{.*}}, %{{.*}}, %{{.*}}) blocks in (%{{.*}}, %{{.*}}, %{{.*}}) threads in (%{{.*}}, %{{.*}}, %{{.*}}) cooperative args(%{{.*}} : f32, %{{.*}} : memref<?xf32, 1>)
+    gpu.launch_func @kernels::@kernel_1 clusters in (%cst, %cst, %cst) blocks in (%cst, %cst, %cst) threads in (%cst, %cst, %cst) cooperative args(%0 : f32, %1 : memref<?xf32, 1>)
 
     gpu.launch_func @kernels::@kernel_1 blocks in (%cst, %cst, %cst) threads in (%cst, %cst, %cst) dynamic_shared_memory_size %c0 args(%0 : f32, %1 : memref<?xf32, 1>)
 

--- a/mlir/test/Dialect/GPU/outlining.mlir
+++ b/mlir/test/Dialect/GPU/outlining.mlir
@@ -705,3 +705,17 @@ module attributes {gpu.container_module} {
     return
   }
 }
+
+// -----
+
+// CHECK-LABEL: func @launch_cooperative
+func.func @launch_cooperative() {
+  %cst = arith.constant 8 : index
+  // CHECK: gpu.launch_func @launch_cooperative_kernel::@launch_cooperative_kernel blocks in (%{{.*}}, %{{.*}}, %{{.*}}) threads in (%{{.*}}, %{{.*}}, %{{.*}}) cooperative
+  gpu.launch blocks(%bx, %by, %bz) in (%gx = %cst, %gy = %cst, %gz = %cst)
+             threads(%tx, %ty, %tz) in (%bxs = %cst, %bys = %cst, %bzs = %cst)
+             cooperative {
+    gpu.terminator
+  }
+  return
+}

--- a/mlir/test/Target/LLVMIR/gpu.mlir
+++ b/mlir/test/Target/LLVMIR/gpu.mlir
@@ -93,10 +93,54 @@ module attributes {gpu.container_module} {
     %c1 = llvm.mlir.constant(1 : index) : i64
     %c2 = llvm.mlir.constant(2 : index) : i64
     %c3 = llvm.mlir.constant(3 : index) : i64
-    gpu.launch_func @kernel_module::@kernel 
+    gpu.launch_func @kernel_module::@kernel
         clusters in (%c1, %c1, %c1)
         blocks in (%c2, %c2, %c2)
         threads in (%c3, %c3, %c3) : i64
+    llvm.return
+  }
+}
+
+// -----
+
+// Test cooperative launch without a cluster: lowers to mgpuLaunchKernelEx
+// with cluster dims = 0 and the cooperative flag set to 1.
+module attributes {gpu.container_module} {
+  gpu.binary @kernel_module  [#gpu.object<#nvvm.target, "BLOB">]
+  llvm.func @cooperative_no_cluster() {
+  // CHECK: call void @mgpuLaunchKernelEx(
+  // CHECK-SAME: i64 2, i64 2, i64 2,
+  // CHECK-SAME: i64 3, i64 3, i64 3,
+  // CHECK-SAME: i64 0, i64 0, i64 0, i32 1)
+    %c2 = llvm.mlir.constant(2 : index) : i64
+    %c3 = llvm.mlir.constant(3 : index) : i64
+    gpu.launch_func @kernel_module::@kernel
+        blocks in (%c2, %c2, %c2)
+        threads in (%c3, %c3, %c3) : i64
+        cooperative
+    llvm.return
+  }
+}
+
+// -----
+
+// Test cooperative launch combined with a cluster: lowers to
+// mgpuLaunchKernelEx with the real cluster dims and the cooperative flag.
+module attributes {gpu.container_module} {
+  gpu.binary @kernel_module  [#gpu.object<#nvvm.target, "BLOB">]
+  llvm.func @cooperative_with_cluster() {
+  // CHECK: call void @mgpuLaunchKernelEx(
+  // CHECK-SAME: i64 2, i64 2, i64 2,
+  // CHECK-SAME: i64 3, i64 3, i64 3,
+  // CHECK-SAME: i64 1, i64 1, i64 1, i32 1)
+    %c1 = llvm.mlir.constant(1 : index) : i64
+    %c2 = llvm.mlir.constant(2 : index) : i64
+    %c3 = llvm.mlir.constant(3 : index) : i64
+    gpu.launch_func @kernel_module::@kernel
+        clusters in (%c1, %c1, %c1)
+        blocks in (%c2, %c2, %c2)
+        threads in (%c3, %c3, %c3) : i64
+        cooperative
     llvm.return
   }
 }

--- a/mlir/test/Target/LLVMIR/gpu.mlir
+++ b/mlir/test/Target/LLVMIR/gpu.mlir
@@ -103,15 +103,15 @@ module attributes {gpu.container_module} {
 
 // -----
 
-// Test cooperative launch without a cluster: lowers to mgpuLaunchKernelEx
-// with cluster dims = 0 and the cooperative flag set to 1.
+// Test cooperative launch without a cluster: lowers to
+// mgpuLaunchKernelCooperative with cluster dims = 0.
 module attributes {gpu.container_module} {
   gpu.binary @kernel_module  [#gpu.object<#nvvm.target, "BLOB">]
   llvm.func @cooperative_no_cluster() {
-  // CHECK: call void @mgpuLaunchKernelEx(
+  // CHECK: call void @mgpuLaunchKernelCooperative(
   // CHECK-SAME: i64 2, i64 2, i64 2,
+  // CHECK-SAME: i64 0, i64 0, i64 0,
   // CHECK-SAME: i64 3, i64 3, i64 3,
-  // CHECK-SAME: i64 0, i64 0, i64 0, i32 1)
     %c2 = llvm.mlir.constant(2 : index) : i64
     %c3 = llvm.mlir.constant(3 : index) : i64
     gpu.launch_func @kernel_module::@kernel
@@ -125,14 +125,14 @@ module attributes {gpu.container_module} {
 // -----
 
 // Test cooperative launch combined with a cluster: lowers to
-// mgpuLaunchKernelEx with the real cluster dims and the cooperative flag.
+// mgpuLaunchKernelCooperative with the real cluster dims.
 module attributes {gpu.container_module} {
   gpu.binary @kernel_module  [#gpu.object<#nvvm.target, "BLOB">]
   llvm.func @cooperative_with_cluster() {
-  // CHECK: call void @mgpuLaunchKernelEx(
+  // CHECK: call void @mgpuLaunchKernelCooperative(
   // CHECK-SAME: i64 2, i64 2, i64 2,
+  // CHECK-SAME: i64 1, i64 1, i64 1,
   // CHECK-SAME: i64 3, i64 3, i64 3,
-  // CHECK-SAME: i64 1, i64 1, i64 1, i32 1)
     %c1 = llvm.mlir.constant(1 : index) : i64
     %c2 = llvm.mlir.constant(2 : index) : i64
     %c3 = llvm.mlir.constant(3 : index) : i64


### PR DESCRIPTION
Add a `cooperative` UnitAttr to `gpu.launch_func` that enables cooperative kernel launch semantics. Cooperative launches guarantee that all thread blocks in the grid are co-resident on the GPU simultaneously, enabling grid-wide synchronization patterns.

## Implementation

When `cooperative` is set (with or without cluster sizes), the lowering emits a call to the new `mgpuLaunchKernelCooperative` runtime function, which uses `cuLaunchKernelEx` with a `CUlaunchConfig` and `CU_LAUNCH_ATTRIBUTE_COOPERATIVE`. This API is guarded behind `CUDA_VERSION >= 12000`. The HIP path funnels through `hipModuleLaunchCooperativeKernel`.

## Changes

- **GPUOps.td**: add `cooperative` UnitAttr and assembly format keyword
- **SelectObjectAttr.cpp**: add `getKernelLaunchExFn()`, route cooperative and/or cluster launches through `mgpuLaunchKernelEx`
- **CudaRuntimeWrappers.cpp**: implement `mgpuLaunchKernelCooperative` via `cuLaunchKernelEx` or `hipModuleLaunchCooperativeKernel`, depending on platform
- **GPUToLLVMConversion.cpp**: propagate cooperative attribute through the legalization pattern
- **test/Dialect/GPU/ops.mlir**: round-trip tests for cooperative keyword with and without clusters

## Context

MLIR currently has no support for cooperative kernel launches. Flang works around this with a CUF-specific attribute (PRs #124325, #124362), but there is no first-class support in the GPU dialect. This patch adds it at the `gpu.launch_func` level so all frontends can use it.

Assisted-by: Claude (Anthropic)