### PR TITLE
[WebAssembly] Have source order as final tie breaker in register pressure sched module

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGRRList.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGRRList.cpp
@@ -2636,6 +2636,13 @@ static bool BURRSort(SUnit *left, SUnit *right, RegReductionPQBase *SPQ) {
       return left->getDepth() < right->getDepth();
   }
 
+  // Prefer source order as tie-breaker to avoid arbitrary reversal of
+  // independent instructions (e.g. sequential stores).
+  unsigned LOrder = SPQ->getNodeOrdering(left);
+  unsigned ROrder = SPQ->getNodeOrdering(right);
+  if (LOrder && ROrder && LOrder != ROrder)
+    return LOrder < ROrder;
+
   assert(left->NodeQueueId && right->NodeQueueId &&
          "NodeQueueId cannot be zero");
   return (left->NodeQueueId > right->NodeQueueId);

--- a/llvm/test/CodeGen/WebAssembly/atomic-rmw.ll
+++ b/llvm/test/CodeGen/WebAssembly/atomic-rmw.ll
@@ -716,9 +716,9 @@ define i64 @cmpxchg_sext_i16_i64(ptr %p, i64 %exp, i64 %new) {
 ; 32->64 sext rmw gets selected as i32.atomic.rmw.cmpxchg, i64.extend_i32_s
 ; CHECK-LABEL: cmpxchg_sext_i32_i64:
 ; CHECK-NEXT: .functype cmpxchg_sext_i32_i64 (i32, i64, i64) -> (i64){{$}}
-; CHECK: i32.wrap_i64 $push1=, $1{{$}}
-; CHECK-NEXT: i32.wrap_i64 $push0=, $2{{$}}
-; CHECK-NEXT: i32.atomic.rmw.cmpxchg $push2=, 0($0), $pop1, $pop0{{$}}
+; CHECK: i32.wrap_i64 $push0=, $1{{$}}
+; CHECK-NEXT: i32.wrap_i64 $push1=, $2{{$}}
+; CHECK-NEXT: i32.atomic.rmw.cmpxchg $push2=, 0($0), $pop0, $pop1{{$}}
 ; CHECK-NEXT: i64.extend_i32_s $push3=, $pop2{{$}}
 ; CHECK-NEXT: return $pop3{{$}}
 define i64 @cmpxchg_sext_i32_i64(ptr %p, i64 %exp, i64 %new) {

--- a/llvm/test/CodeGen/WebAssembly/extend-shuffles.ll
+++ b/llvm/test/CodeGen/WebAssembly/extend-shuffles.ll
@@ -215,9 +215,9 @@ define <2 x i64> @multi_use_ext_v2i32(<4 x i32> %in) {
 ; SIMD128-LABEL: multi_use_ext_v2i32:
 ; SIMD128:         .functype multi_use_ext_v2i32 (v128) -> (v128)
 ; SIMD128-NEXT:  # %bb.0:
-; SIMD128-NEXT:    i64x2.extend_high_i32x4_u $push1=, $0
-; SIMD128-NEXT:    i64x2.extend_high_i32x4_s $push0=, $0
-; SIMD128-NEXT:    i64x2.add $push2=, $pop1, $pop0
+; SIMD128-NEXT:    i64x2.extend_high_i32x4_u $push0=, $0
+; SIMD128-NEXT:    i64x2.extend_high_i32x4_s $push1=, $0
+; SIMD128-NEXT:    i64x2.add $push2=, $pop0, $pop1
 ; SIMD128-NEXT:    return $pop2
  %shuffle = shufflevector <4 x i32> %in, <4 x i32> poison, <2 x i32> <i32 2, i32 3>
  %zext = zext <2 x i32> %shuffle to <2 x i64>

--- a/llvm/test/CodeGen/WebAssembly/i128.ll
+++ b/llvm/test/CodeGen/WebAssembly/i128.ll
@@ -98,7 +98,7 @@ define i128 @sdiv128(i128 %x, i128 %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    global.get $push2=, __stack_pointer
 ; CHECK-NEXT:    i32.const $push3=, 16
-; CHECK-NEXT:    i32.sub  $push7=, $pop2, $pop3
+; CHECK-NEXT:    i32.sub $push7=, $pop2, $pop3
 ; CHECK-NEXT:    local.tee $push6=, 5, $pop7
 ; CHECK-NEXT:    global.set __stack_pointer, $pop6
 ; CHECK-NEXT:    local.get $push12=, 5
@@ -117,7 +117,7 @@ define i128 @sdiv128(i128 %x, i128 %y) {
 ; CHECK-NEXT:    i64.store 0($pop16), $pop1
 ; CHECK-NEXT:    local.get $push17=, 5
 ; CHECK-NEXT:    i32.const $push4=, 16
-; CHECK-NEXT:    i32.add  $push5=, $pop17, $pop4
+; CHECK-NEXT:    i32.add $push5=, $pop17, $pop4
 ; CHECK-NEXT:    global.set __stack_pointer, $pop5
 ; CHECK-NEXT:    return
   %a = sdiv i128 %x, %y
@@ -131,7 +131,7 @@ define i128 @udiv128(i128 %x, i128 %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    global.get $push2=, __stack_pointer
 ; CHECK-NEXT:    i32.const $push3=, 16
-; CHECK-NEXT:    i32.sub  $push7=, $pop2, $pop3
+; CHECK-NEXT:    i32.sub $push7=, $pop2, $pop3
 ; CHECK-NEXT:    local.tee $push6=, 5, $pop7
 ; CHECK-NEXT:    global.set __stack_pointer, $pop6
 ; CHECK-NEXT:    local.get $push12=, 5
@@ -150,7 +150,7 @@ define i128 @udiv128(i128 %x, i128 %y) {
 ; CHECK-NEXT:    i64.store 0($pop16), $pop1
 ; CHECK-NEXT:    local.get $push17=, 5
 ; CHECK-NEXT:    i32.const $push4=, 16
-; CHECK-NEXT:    i32.add  $push5=, $pop17, $pop4
+; CHECK-NEXT:    i32.add $push5=, $pop17, $pop4
 ; CHECK-NEXT:    global.set __stack_pointer, $pop5
 ; CHECK-NEXT:    return
   %a = udiv i128 %x, %y
@@ -164,7 +164,7 @@ define i128 @srem128(i128 %x, i128 %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    global.get $push2=, __stack_pointer
 ; CHECK-NEXT:    i32.const $push3=, 16
-; CHECK-NEXT:    i32.sub  $push7=, $pop2, $pop3
+; CHECK-NEXT:    i32.sub $push7=, $pop2, $pop3
 ; CHECK-NEXT:    local.tee $push6=, 5, $pop7
 ; CHECK-NEXT:    global.set __stack_pointer, $pop6
 ; CHECK-NEXT:    local.get $push12=, 5
@@ -183,7 +183,7 @@ define i128 @srem128(i128 %x, i128 %y) {
 ; CHECK-NEXT:    i64.store 0($pop16), $pop1
 ; CHECK-NEXT:    local.get $push17=, 5
 ; CHECK-NEXT:    i32.const $push4=, 16
-; CHECK-NEXT:    i32.add  $push5=, $pop17, $pop4
+; CHECK-NEXT:    i32.add $push5=, $pop17, $pop4
 ; CHECK-NEXT:    global.set __stack_pointer, $pop5
 ; CHECK-NEXT:    return
   %a = srem i128 %x, %y
@@ -197,7 +197,7 @@ define i128 @urem128(i128 %x, i128 %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    global.get $push2=, __stack_pointer
 ; CHECK-NEXT:    i32.const $push3=, 16
-; CHECK-NEXT:    i32.sub  $push7=, $pop2, $pop3
+; CHECK-NEXT:    i32.sub $push7=, $pop2, $pop3
 ; CHECK-NEXT:    local.tee $push6=, 5, $pop7
 ; CHECK-NEXT:    global.set __stack_pointer, $pop6
 ; CHECK-NEXT:    local.get $push12=, 5
@@ -216,7 +216,7 @@ define i128 @urem128(i128 %x, i128 %y) {
 ; CHECK-NEXT:    i64.store 0($pop16), $pop1
 ; CHECK-NEXT:    local.get $push17=, 5
 ; CHECK-NEXT:    i32.const $push4=, 16
-; CHECK-NEXT:    i32.add  $push5=, $pop17, $pop4
+; CHECK-NEXT:    i32.add $push5=, $pop17, $pop4
 ; CHECK-NEXT:    global.set __stack_pointer, $pop5
 ; CHECK-NEXT:    return
   %a = urem i128 %x, %y
@@ -287,7 +287,7 @@ define i128 @shl128(i128 %x, i128 %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    global.get $push3=, __stack_pointer
 ; CHECK-NEXT:    i32.const $push4=, 16
-; CHECK-NEXT:    i32.sub  $push8=, $pop3, $pop4
+; CHECK-NEXT:    i32.sub $push8=, $pop3, $pop4
 ; CHECK-NEXT:    local.tee $push7=, 5, $pop8
 ; CHECK-NEXT:    global.set __stack_pointer, $pop7
 ; CHECK-NEXT:    local.get $push12=, 5
@@ -306,7 +306,7 @@ define i128 @shl128(i128 %x, i128 %y) {
 ; CHECK-NEXT:    i64.store 0($pop16), $pop2
 ; CHECK-NEXT:    local.get $push17=, 5
 ; CHECK-NEXT:    i32.const $push5=, 16
-; CHECK-NEXT:    i32.add  $push6=, $pop17, $pop5
+; CHECK-NEXT:    i32.add $push6=, $pop17, $pop5
 ; CHECK-NEXT:    global.set __stack_pointer, $pop6
 ; CHECK-NEXT:    return
   %a = shl i128 %x, %y
@@ -320,7 +320,7 @@ define i128 @shr128(i128 %x, i128 %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    global.get $push3=, __stack_pointer
 ; CHECK-NEXT:    i32.const $push4=, 16
-; CHECK-NEXT:    i32.sub  $push8=, $pop3, $pop4
+; CHECK-NEXT:    i32.sub $push8=, $pop3, $pop4
 ; CHECK-NEXT:    local.tee $push7=, 5, $pop8
 ; CHECK-NEXT:    global.set __stack_pointer, $pop7
 ; CHECK-NEXT:    local.get $push12=, 5
@@ -339,7 +339,7 @@ define i128 @shr128(i128 %x, i128 %y) {
 ; CHECK-NEXT:    i64.store 0($pop16), $pop2
 ; CHECK-NEXT:    local.get $push17=, 5
 ; CHECK-NEXT:    i32.const $push5=, 16
-; CHECK-NEXT:    i32.add  $push6=, $pop17, $pop5
+; CHECK-NEXT:    i32.add $push6=, $pop17, $pop5
 ; CHECK-NEXT:    global.set __stack_pointer, $pop6
 ; CHECK-NEXT:    return
   %a = lshr i128 %x, %y
@@ -353,7 +353,7 @@ define i128 @sar128(i128 %x, i128 %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    global.get $push3=, __stack_pointer
 ; CHECK-NEXT:    i32.const $push4=, 16
-; CHECK-NEXT:    i32.sub  $push8=, $pop3, $pop4
+; CHECK-NEXT:    i32.sub $push8=, $pop3, $pop4
 ; CHECK-NEXT:    local.tee $push7=, 5, $pop8
 ; CHECK-NEXT:    global.set __stack_pointer, $pop7
 ; CHECK-NEXT:    local.get $push12=, 5
@@ -372,7 +372,7 @@ define i128 @sar128(i128 %x, i128 %y) {
 ; CHECK-NEXT:    i64.store 0($pop16), $pop2
 ; CHECK-NEXT:    local.get $push17=, 5
 ; CHECK-NEXT:    i32.const $push5=, 16
-; CHECK-NEXT:    i32.add  $push6=, $pop17, $pop5
+; CHECK-NEXT:    i32.add $push6=, $pop17, $pop5
 ; CHECK-NEXT:    global.set __stack_pointer, $pop6
 ; CHECK-NEXT:    return
   %a = ashr i128 %x, %y
@@ -515,12 +515,12 @@ define i128 @rotl(i128 %x, i128 %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    global.get $push8=, __stack_pointer
 ; CHECK-NEXT:    i32.const $push9=, 32
-; CHECK-NEXT:    i32.sub  $push17=, $pop8, $pop9
+; CHECK-NEXT:    i32.sub $push17=, $pop8, $pop9
 ; CHECK-NEXT:    local.tee $push16=, 5, $pop17
 ; CHECK-NEXT:    global.set __stack_pointer, $pop16
 ; CHECK-NEXT:    local.get $push18=, 5
 ; CHECK-NEXT:    i32.const $push12=, 16
-; CHECK-NEXT:    i32.add  $push13=, $pop18, $pop12
+; CHECK-NEXT:    i32.add $push13=, $pop18, $pop12
 ; CHECK-NEXT:    local.get $push21=, 1
 ; CHECK-NEXT:    local.get $push20=, 2
 ; CHECK-NEXT:    local.get $push19=, 3
@@ -532,25 +532,25 @@ define i128 @rotl(i128 %x, i128 %y) {
 ; CHECK-NEXT:    local.get $push23=, 2
 ; CHECK-NEXT:    i32.const $push0=, 128
 ; CHECK-NEXT:    local.get $push22=, 6
-; CHECK-NEXT:    i32.sub  $push1=, $pop0, $pop22
+; CHECK-NEXT:    i32.sub $push1=, $pop0, $pop22
 ; CHECK-NEXT:    call __lshrti3, $pop25, $pop24, $pop23, $pop1
 ; CHECK-NEXT:    local.get $push28=, 0
 ; CHECK-NEXT:    local.get $push26=, 5
 ; CHECK-NEXT:    i64.load $push2=, 24($pop26)
 ; CHECK-NEXT:    local.get $push27=, 5
 ; CHECK-NEXT:    i64.load $push3=, 8($pop27)
-; CHECK-NEXT:    i64.or   $push4=, $pop2, $pop3
+; CHECK-NEXT:    i64.or $push4=, $pop2, $pop3
 ; CHECK-NEXT:    i64.store 8($pop28), $pop4
 ; CHECK-NEXT:    local.get $push31=, 0
 ; CHECK-NEXT:    local.get $push29=, 5
 ; CHECK-NEXT:    i64.load $push5=, 16($pop29)
 ; CHECK-NEXT:    local.get $push30=, 5
 ; CHECK-NEXT:    i64.load $push6=, 0($pop30)
-; CHECK-NEXT:    i64.or   $push7=, $pop5, $pop6
+; CHECK-NEXT:    i64.or $push7=, $pop5, $pop6
 ; CHECK-NEXT:    i64.store 0($pop31), $pop7
 ; CHECK-NEXT:    local.get $push32=, 5
 ; CHECK-NEXT:    i32.const $push10=, 32
-; CHECK-NEXT:    i32.add  $push11=, $pop32, $pop10
+; CHECK-NEXT:    i32.add $push11=, $pop32, $pop10
 ; CHECK-NEXT:    global.set __stack_pointer, $pop11
 ; CHECK-NEXT:    return
   %z = sub i128 128, %y
@@ -567,18 +567,18 @@ define i128 @masked_rotl(i128 %x, i128 %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    global.get $push10=, __stack_pointer
 ; CHECK-NEXT:    i32.const $push11=, 32
-; CHECK-NEXT:    i32.sub  $push19=, $pop10, $pop11
+; CHECK-NEXT:    i32.sub $push19=, $pop10, $pop11
 ; CHECK-NEXT:    local.tee $push18=, 5, $pop19
 ; CHECK-NEXT:    global.set __stack_pointer, $pop18
 ; CHECK-NEXT:    local.get $push20=, 5
 ; CHECK-NEXT:    i32.const $push14=, 16
-; CHECK-NEXT:    i32.add  $push15=, $pop20, $pop14
+; CHECK-NEXT:    i32.add $push15=, $pop20, $pop14
 ; CHECK-NEXT:    local.get $push23=, 1
 ; CHECK-NEXT:    local.get $push22=, 2
 ; CHECK-NEXT:    local.get $push21=, 3
 ; CHECK-NEXT:    i32.wrap_i64 $push0=, $pop21
 ; CHECK-NEXT:    i32.const $push1=, 127
-; CHECK-NEXT:    i32.and  $push17=, $pop0, $pop1
+; CHECK-NEXT:    i32.and $push17=, $pop0, $pop1
 ; CHECK-NEXT:    local.tee $push16=, 6, $pop17
 ; CHECK-NEXT:    call __ashlti3, $pop15, $pop23, $pop22, $pop16
 ; CHECK-NEXT:    local.get $push27=, 5
@@ -586,25 +586,25 @@ define i128 @masked_rotl(i128 %x, i128 %y) {
 ; CHECK-NEXT:    local.get $push25=, 2
 ; CHECK-NEXT:    i32.const $push2=, 128
 ; CHECK-NEXT:    local.get $push24=, 6
-; CHECK-NEXT:    i32.sub  $push3=, $pop2, $pop24
+; CHECK-NEXT:    i32.sub $push3=, $pop2, $pop24
 ; CHECK-NEXT:    call __lshrti3, $pop27, $pop26, $pop25, $pop3
 ; CHECK-NEXT:    local.get $push30=, 0
 ; CHECK-NEXT:    local.get $push28=, 5
 ; CHECK-NEXT:    i64.load $push4=, 24($pop28)
 ; CHECK-NEXT:    local.get $push29=, 5
 ; CHECK-NEXT:    i64.load $push5=, 8($pop29)
-; CHECK-NEXT:    i64.or   $push6=, $pop4, $pop5
+; CHECK-NEXT:    i64.or $push6=, $pop4, $pop5
 ; CHECK-NEXT:    i64.store 8($pop30), $pop6
 ; CHECK-NEXT:    local.get $push33=, 0
 ; CHECK-NEXT:    local.get $push31=, 5
 ; CHECK-NEXT:    i64.load $push7=, 16($pop31)
 ; CHECK-NEXT:    local.get $push32=, 5
 ; CHECK-NEXT:    i64.load $push8=, 0($pop32)
-; CHECK-NEXT:    i64.or   $push9=, $pop7, $pop8
+; CHECK-NEXT:    i64.or $push9=, $pop7, $pop8
 ; CHECK-NEXT:    i64.store 0($pop33), $pop9
 ; CHECK-NEXT:    local.get $push34=, 5
 ; CHECK-NEXT:    i32.const $push12=, 32
-; CHECK-NEXT:    i32.add  $push13=, $pop34, $pop12
+; CHECK-NEXT:    i32.add $push13=, $pop34, $pop12
 ; CHECK-NEXT:    global.set __stack_pointer, $pop13
 ; CHECK-NEXT:    return
   %a = and i128 %y, 127
@@ -622,12 +622,12 @@ define i128 @rotr(i128 %x, i128 %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    global.get $push8=, __stack_pointer
 ; CHECK-NEXT:    i32.const $push9=, 32
-; CHECK-NEXT:    i32.sub  $push17=, $pop8, $pop9
+; CHECK-NEXT:    i32.sub $push17=, $pop8, $pop9
 ; CHECK-NEXT:    local.tee $push16=, 5, $pop17
 ; CHECK-NEXT:    global.set __stack_pointer, $pop16
 ; CHECK-NEXT:    local.get $push18=, 5
 ; CHECK-NEXT:    i32.const $push12=, 16
-; CHECK-NEXT:    i32.add  $push13=, $pop18, $pop12
+; CHECK-NEXT:    i32.add $push13=, $pop18, $pop12
 ; CHECK-NEXT:    local.get $push21=, 1
 ; CHECK-NEXT:    local.get $push20=, 2
 ; CHECK-NEXT:    local.get $push19=, 3
@@ -639,25 +639,25 @@ define i128 @rotr(i128 %x, i128 %y) {
 ; CHECK-NEXT:    local.get $push23=, 2
 ; CHECK-NEXT:    i32.const $push0=, 128
 ; CHECK-NEXT:    local.get $push22=, 6
-; CHECK-NEXT:    i32.sub  $push1=, $pop0, $pop22
+; CHECK-NEXT:    i32.sub $push1=, $pop0, $pop22
 ; CHECK-NEXT:    call __ashlti3, $pop25, $pop24, $pop23, $pop1
 ; CHECK-NEXT:    local.get $push28=, 0
 ; CHECK-NEXT:    local.get $push26=, 5
 ; CHECK-NEXT:    i64.load $push2=, 24($pop26)
 ; CHECK-NEXT:    local.get $push27=, 5
 ; CHECK-NEXT:    i64.load $push3=, 8($pop27)
-; CHECK-NEXT:    i64.or   $push4=, $pop2, $pop3
+; CHECK-NEXT:    i64.or $push4=, $pop2, $pop3
 ; CHECK-NEXT:    i64.store 8($pop28), $pop4
 ; CHECK-NEXT:    local.get $push31=, 0
 ; CHECK-NEXT:    local.get $push29=, 5
 ; CHECK-NEXT:    i64.load $push5=, 16($pop29)
 ; CHECK-NEXT:    local.get $push30=, 5
 ; CHECK-NEXT:    i64.load $push6=, 0($pop30)
-; CHECK-NEXT:    i64.or   $push7=, $pop5, $pop6
+; CHECK-NEXT:    i64.or $push7=, $pop5, $pop6
 ; CHECK-NEXT:    i64.store 0($pop31), $pop7
 ; CHECK-NEXT:    local.get $push32=, 5
 ; CHECK-NEXT:    i32.const $push10=, 32
-; CHECK-NEXT:    i32.add  $push11=, $pop32, $pop10
+; CHECK-NEXT:    i32.add $push11=, $pop32, $pop10
 ; CHECK-NEXT:    global.set __stack_pointer, $pop11
 ; CHECK-NEXT:    return
   %z = sub i128 128, %y
@@ -674,18 +674,18 @@ define i128 @masked_rotr(i128 %x, i128 %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    global.get $push10=, __stack_pointer
 ; CHECK-NEXT:    i32.const $push11=, 32
-; CHECK-NEXT:    i32.sub  $push19=, $pop10, $pop11
+; CHECK-NEXT:    i32.sub $push19=, $pop10, $pop11
 ; CHECK-NEXT:    local.tee $push18=, 5, $pop19
 ; CHECK-NEXT:    global.set __stack_pointer, $pop18
 ; CHECK-NEXT:    local.get $push20=, 5
 ; CHECK-NEXT:    i32.const $push14=, 16
-; CHECK-NEXT:    i32.add  $push15=, $pop20, $pop14
+; CHECK-NEXT:    i32.add $push15=, $pop20, $pop14
 ; CHECK-NEXT:    local.get $push23=, 1
 ; CHECK-NEXT:    local.get $push22=, 2
 ; CHECK-NEXT:    local.get $push21=, 3
 ; CHECK-NEXT:    i32.wrap_i64 $push0=, $pop21
 ; CHECK-NEXT:    i32.const $push1=, 127
-; CHECK-NEXT:    i32.and  $push17=, $pop0, $pop1
+; CHECK-NEXT:    i32.and $push17=, $pop0, $pop1
 ; CHECK-NEXT:    local.tee $push16=, 6, $pop17
 ; CHECK-NEXT:    call __lshrti3, $pop15, $pop23, $pop22, $pop16
 ; CHECK-NEXT:    local.get $push27=, 5
@@ -693,25 +693,25 @@ define i128 @masked_rotr(i128 %x, i128 %y) {
 ; CHECK-NEXT:    local.get $push25=, 2
 ; CHECK-NEXT:    i32.const $push2=, 128
 ; CHECK-NEXT:    local.get $push24=, 6
-; CHECK-NEXT:    i32.sub  $push3=, $pop2, $pop24
+; CHECK-NEXT:    i32.sub $push3=, $pop2, $pop24
 ; CHECK-NEXT:    call __ashlti3, $pop27, $pop26, $pop25, $pop3
 ; CHECK-NEXT:    local.get $push30=, 0
 ; CHECK-NEXT:    local.get $push28=, 5
 ; CHECK-NEXT:    i64.load $push4=, 24($pop28)
 ; CHECK-NEXT:    local.get $push29=, 5
 ; CHECK-NEXT:    i64.load $push5=, 8($pop29)
-; CHECK-NEXT:    i64.or   $push6=, $pop4, $pop5
+; CHECK-NEXT:    i64.or $push6=, $pop4, $pop5
 ; CHECK-NEXT:    i64.store 8($pop30), $pop6
 ; CHECK-NEXT:    local.get $push33=, 0
 ; CHECK-NEXT:    local.get $push31=, 5
 ; CHECK-NEXT:    i64.load $push7=, 16($pop31)
 ; CHECK-NEXT:    local.get $push32=, 5
 ; CHECK-NEXT:    i64.load $push8=, 0($pop32)
-; CHECK-NEXT:    i64.or   $push9=, $pop7, $pop8
+; CHECK-NEXT:    i64.or $push9=, $pop7, $pop8
 ; CHECK-NEXT:    i64.store 0($pop33), $pop9
 ; CHECK-NEXT:    local.get $push34=, 5
 ; CHECK-NEXT:    i32.const $push12=, 32
-; CHECK-NEXT:    i32.add  $push13=, $pop34, $pop12
+; CHECK-NEXT:    i32.add $push13=, $pop34, $pop12
 ; CHECK-NEXT:    global.set __stack_pointer, $pop13
 ; CHECK-NEXT:    return
   %a = and i128 %y, 127

--- a/llvm/test/CodeGen/WebAssembly/interleave.ll
+++ b/llvm/test/CodeGen/WebAssembly/interleave.ll
@@ -17,11 +17,11 @@ define hidden void @accumulate8x2(ptr dead_on_unwind noalias writable sret(%stru
 ; CHECK-LABEL: accumulate8x2:
 ; CHECK: loop
 ; CHECK: v128.load64_zero
-; CHECK: i8x16.shuffle 1, 3, 5, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i8x16.shuffle 0, 2, 4, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: i16x8.extend_low_i8x16_u
 ; CHECK: i32x4.extend_low_i16x8_u
 ; CHECK: i32x4.add
-; CHECK: i8x16.shuffle 0, 2, 4, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i8x16.shuffle 1, 3, 5, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: i16x8.extend_low_i8x16_u
 ; CHECK: i32x4.extend_low_i16x8_u
 ; CHECK: i32x4.add
@@ -65,11 +65,7 @@ define hidden void @accumulate8x4(ptr dead_on_unwind noalias writable sret(%stru
 ; CHECK-LABEL: accumulate8x4
 ; CHECK: loop
 ; CHECK: v128.load
-; CHECK: i8x16.shuffle 3, 7, 11, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-; CHECK: i16x8.extend_low_i8x16_u
-; CHECK: i32x4.extend_low_i16x8_u
-; CHECK: i32x4.add
-; CHECK: i8x16.shuffle 2, 6, 10, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i8x16.shuffle 0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: i16x8.extend_low_i8x16_u
 ; CHECK: i32x4.extend_low_i16x8_u
 ; CHECK: i32x4.add
@@ -77,7 +73,11 @@ define hidden void @accumulate8x4(ptr dead_on_unwind noalias writable sret(%stru
 ; CHECK: i16x8.extend_low_i8x16_u
 ; CHECK: i32x4.extend_low_i16x8_u
 ; CHECK: i32x4.add
-; CHECK: i8x16.shuffle 0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i8x16.shuffle 2, 6, 10, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i16x8.extend_low_i8x16_u
+; CHECK: i32x4.extend_low_i16x8_u
+; CHECK: i32x4.add
+; CHECK: i8x16.shuffle 3, 7, 11, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: i16x8.extend_low_i8x16_u
 ; CHECK: i32x4.extend_low_i16x8_u
 ; CHECK: i32x4.add
@@ -137,10 +137,10 @@ define hidden void @accumulate16x2(ptr dead_on_unwind noalias writable sret(%str
 ; CHECK-LABEL: accumulate16x2
 ; CHECK: loop
 ; CHECK: v128.load
-; CHECK: i8x16.shuffle 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 0, 1, 0, 1, 0, 1
+; CHECK: i8x16.shuffle 0, 1, 4, 5, 8, 9, 12, 13, 0, 1, 0, 1, 0, 1, 0, 1
 ; CHECK: i32x4.extend_low_i16x8_u
 ; CHECK: i32x4.add
-; CHECK: i8x16.shuffle 0, 1, 4, 5, 8, 9, 12, 13, 0, 1, 0, 1, 0, 1, 0, 1
+; CHECK: i8x16.shuffle 2, 3, 6, 7, 10, 11, 14, 15, 0, 1, 0, 1, 0, 1, 0, 1
 ; CHECK: i32x4.extend_low_i16x8_u
 ; CHECK: i32x4.add
   %4 = load i32, ptr %0, align 4
@@ -184,16 +184,16 @@ define hidden void @accumulate16x4(ptr dead_on_unwind noalias writable sret(%str
 ; CHECK: loop
 ; CHECK: v128.load 0:p2align=1
 ; CHECK: v128.load 16:p2align=1
-; CHECK: i8x16.shuffle 6, 7, 14, 15, 22, 23, 30, 31, 0, 1, 0, 1, 0, 1, 0, 1
-; CHECK: i32x4.extend_low_i16x8_u
-; CHECK: i32x4.add
-; CHECK: i8x16.shuffle 4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
+; CHECK: i8x16.shuffle 0, 1, 8, 9, 16, 17, 24, 25, 0, 1, 0, 1, 0, 1, 0, 1
 ; CHECK: i32x4.extend_low_i16x8_u
 ; CHECK: i32x4.add
 ; CHECK: i8x16.shuffle 2, 3, 10, 11, 18, 19, 26, 27, 0, 1, 0, 1, 0, 1, 0, 1
 ; CHECK: i32x4.extend_low_i16x8_u
 ; CHECK: i32x4.add
-; CHECK: i8x16.shuffle 0, 1, 8, 9, 16, 17, 24, 25, 0, 1, 0, 1, 0, 1, 0, 1
+; CHECK: i8x16.shuffle 4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
+; CHECK: i32x4.extend_low_i16x8_u
+; CHECK: i32x4.add
+; CHECK: i8x16.shuffle 6, 7, 14, 15, 22, 23, 30, 31, 0, 1, 0, 1, 0, 1, 0, 1
 ; CHECK: i32x4.extend_low_i16x8_u
 ; CHECK: i32x4.add
   %4 = load i32, ptr %0, align 4
@@ -253,9 +253,9 @@ define hidden void @accumulate32x2(ptr dead_on_unwind noalias writable sret(%str
 ; CHECK: loop
 ; CHECK: v128.load 0:p2align=2
 ; CHECK: v128.load 16:p2align=2
-; CHECK: i8x16.shuffle 4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31
-; CHECK: i32x4.add
 ; CHECK: i8x16.shuffle 0, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27
+; CHECK: i32x4.add
+; CHECK: i8x16.shuffle 4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31
 ; CHECK: i32x4.add
   %4 = load i32, ptr %0, align 4
   %5 = icmp eq i32 %2, 0
@@ -295,22 +295,22 @@ define hidden void @accumulate32x4(ptr dead_on_unwind noalias writable sret(%str
 ; CHECK-LABEL: accumulate32x4
 ; CHECK: v128.load 0:p2align=2
 ; CHECK: v128.load 16:p2align=2
-; CHECK: i8x16.shuffle 12, 13, 14, 15, 28, 29, 30, 31, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK: i8x16.shuffle 0, 1, 2, 3, 16, 17, 18, 19, 0, 1, 2, 3, 0, 1, 2, 3
 ; CHECK: v128.load 32:p2align=2
 ; CHECK: v128.load 48:p2align=2
-; CHECK: i8x16.shuffle 0, 1, 2, 3, 0, 1, 2, 3, 12, 13, 14, 15, 28, 29, 30, 31
-; CHECK: i8x16.shuffle 0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
-; CHECK: i32x4.add
-; CHECK: i8x16.shuffle 8, 9, 10, 11, 24, 25, 26, 27, 0, 1, 2, 3, 0, 1, 2, 3
-; CHECK: i8x16.shuffle 0, 1, 2, 3, 0, 1, 2, 3, 8, 9, 10, 11, 24, 25, 26, 27
+; CHECK: i8x16.shuffle 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 16, 17, 18, 19
 ; CHECK: i8x16.shuffle 0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
 ; CHECK: i32x4.add
 ; CHECK: i8x16.shuffle 4, 5, 6, 7, 20, 21, 22, 23, 0, 1, 2, 3, 0, 1, 2, 3
 ; CHECK: i8x16.shuffle 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 20, 21, 22, 23
 ; CHECK: i8x16.shuffle 0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
 ; CHECK: i32x4.add
-; CHECK: i8x16.shuffle 0, 1, 2, 3, 16, 17, 18, 19, 0, 1, 2, 3, 0, 1, 2, 3
-; CHECK: i8x16.shuffle 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 16, 17, 18, 19
+; CHECK: i8x16.shuffle 8, 9, 10, 11, 24, 25, 26, 27, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK: i8x16.shuffle 0, 1, 2, 3, 0, 1, 2, 3, 8, 9, 10, 11, 24, 25, 26, 27
+; CHECK: i8x16.shuffle 0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
+; CHECK: i32x4.add
+; CHECK: i8x16.shuffle 12, 13, 14, 15, 28, 29, 30, 31, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK: i8x16.shuffle 0, 1, 2, 3, 0, 1, 2, 3, 12, 13, 14, 15, 28, 29, 30, 31
 ; CHECK: i8x16.shuffle 0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
 ; CHECK: i32x4.add
   %4 = load i32, ptr %0, align 4

--- a/llvm/test/CodeGen/WebAssembly/libcalls-trig.ll
+++ b/llvm/test/CodeGen/WebAssembly/libcalls-trig.ll
@@ -47,18 +47,18 @@ define fp128 @fp128libcalls(fp128 %x) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    global.get $push20=, __stack_pointer
 ; CHECK-NEXT:    i32.const $push21=, 160
-; CHECK-NEXT:    i32.sub  $push43=, $pop20, $pop21
+; CHECK-NEXT:    i32.sub $push43=, $pop20, $pop21
 ; CHECK-NEXT:    local.tee $push42=, 3, $pop43
 ; CHECK-NEXT:    global.set __stack_pointer, $pop42
 ; CHECK-NEXT:    local.get $push44=, 3
 ; CHECK-NEXT:    i32.const $push40=, 144
-; CHECK-NEXT:    i32.add  $push41=, $pop44, $pop40
+; CHECK-NEXT:    i32.add $push41=, $pop44, $pop40
 ; CHECK-NEXT:    local.get $push46=, 1
 ; CHECK-NEXT:    local.get $push45=, 2
 ; CHECK-NEXT:    call sinl, $pop41, $pop46, $pop45
 ; CHECK-NEXT:    local.get $push47=, 3
 ; CHECK-NEXT:    i32.const $push38=, 128
-; CHECK-NEXT:    i32.add  $push39=, $pop47, $pop38
+; CHECK-NEXT:    i32.add $push39=, $pop47, $pop38
 ; CHECK-NEXT:    local.get $push48=, 3
 ; CHECK-NEXT:    i64.load $push1=, 144($pop48)
 ; CHECK-NEXT:    local.get $push49=, 3
@@ -66,7 +66,7 @@ define fp128 @fp128libcalls(fp128 %x) {
 ; CHECK-NEXT:    call cosl, $pop39, $pop1, $pop0
 ; CHECK-NEXT:    local.get $push50=, 3
 ; CHECK-NEXT:    i32.const $push36=, 112
-; CHECK-NEXT:    i32.add  $push37=, $pop50, $pop36
+; CHECK-NEXT:    i32.add $push37=, $pop50, $pop36
 ; CHECK-NEXT:    local.get $push51=, 3
 ; CHECK-NEXT:    i64.load $push3=, 128($pop51)
 ; CHECK-NEXT:    local.get $push52=, 3
@@ -74,7 +74,7 @@ define fp128 @fp128libcalls(fp128 %x) {
 ; CHECK-NEXT:    call tanl, $pop37, $pop3, $pop2
 ; CHECK-NEXT:    local.get $push53=, 3
 ; CHECK-NEXT:    i32.const $push34=, 96
-; CHECK-NEXT:    i32.add  $push35=, $pop53, $pop34
+; CHECK-NEXT:    i32.add $push35=, $pop53, $pop34
 ; CHECK-NEXT:    local.get $push54=, 3
 ; CHECK-NEXT:    i64.load $push5=, 112($pop54)
 ; CHECK-NEXT:    local.get $push55=, 3
@@ -82,7 +82,7 @@ define fp128 @fp128libcalls(fp128 %x) {
 ; CHECK-NEXT:    call asinl, $pop35, $pop5, $pop4
 ; CHECK-NEXT:    local.get $push56=, 3
 ; CHECK-NEXT:    i32.const $push32=, 80
-; CHECK-NEXT:    i32.add  $push33=, $pop56, $pop32
+; CHECK-NEXT:    i32.add $push33=, $pop56, $pop32
 ; CHECK-NEXT:    local.get $push57=, 3
 ; CHECK-NEXT:    i64.load $push7=, 96($pop57)
 ; CHECK-NEXT:    local.get $push58=, 3
@@ -90,7 +90,7 @@ define fp128 @fp128libcalls(fp128 %x) {
 ; CHECK-NEXT:    call acosl, $pop33, $pop7, $pop6
 ; CHECK-NEXT:    local.get $push59=, 3
 ; CHECK-NEXT:    i32.const $push30=, 64
-; CHECK-NEXT:    i32.add  $push31=, $pop59, $pop30
+; CHECK-NEXT:    i32.add $push31=, $pop59, $pop30
 ; CHECK-NEXT:    local.get $push60=, 3
 ; CHECK-NEXT:    i64.load $push9=, 80($pop60)
 ; CHECK-NEXT:    local.get $push61=, 3
@@ -98,7 +98,7 @@ define fp128 @fp128libcalls(fp128 %x) {
 ; CHECK-NEXT:    call atanl, $pop31, $pop9, $pop8
 ; CHECK-NEXT:    local.get $push62=, 3
 ; CHECK-NEXT:    i32.const $push28=, 48
-; CHECK-NEXT:    i32.add  $push29=, $pop62, $pop28
+; CHECK-NEXT:    i32.add $push29=, $pop62, $pop28
 ; CHECK-NEXT:    local.get $push63=, 3
 ; CHECK-NEXT:    i64.load $push11=, 64($pop63)
 ; CHECK-NEXT:    local.get $push64=, 3
@@ -106,7 +106,7 @@ define fp128 @fp128libcalls(fp128 %x) {
 ; CHECK-NEXT:    call sinhl, $pop29, $pop11, $pop10
 ; CHECK-NEXT:    local.get $push65=, 3
 ; CHECK-NEXT:    i32.const $push26=, 32
-; CHECK-NEXT:    i32.add  $push27=, $pop65, $pop26
+; CHECK-NEXT:    i32.add $push27=, $pop65, $pop26
 ; CHECK-NEXT:    local.get $push66=, 3
 ; CHECK-NEXT:    i64.load $push13=, 48($pop66)
 ; CHECK-NEXT:    local.get $push67=, 3
@@ -114,7 +114,7 @@ define fp128 @fp128libcalls(fp128 %x) {
 ; CHECK-NEXT:    call coshl, $pop27, $pop13, $pop12
 ; CHECK-NEXT:    local.get $push68=, 3
 ; CHECK-NEXT:    i32.const $push24=, 16
-; CHECK-NEXT:    i32.add  $push25=, $pop68, $pop24
+; CHECK-NEXT:    i32.add $push25=, $pop68, $pop24
 ; CHECK-NEXT:    local.get $push69=, 3
 ; CHECK-NEXT:    i64.load $push15=, 32($pop69)
 ; CHECK-NEXT:    local.get $push70=, 3
@@ -138,7 +138,7 @@ define fp128 @fp128libcalls(fp128 %x) {
 ; CHECK-NEXT:    i64.store 0($pop79), $pop19
 ; CHECK-NEXT:    local.get $push80=, 3
 ; CHECK-NEXT:    i32.const $push22=, 160
-; CHECK-NEXT:    i32.add  $push23=, $pop80, $pop22
+; CHECK-NEXT:    i32.add $push23=, $pop80, $pop22
 ; CHECK-NEXT:    global.set __stack_pointer, $pop23
 ; CHECK-NEXT:    return
   ; libm calls

--- a/llvm/test/CodeGen/WebAssembly/libcalls.ll
+++ b/llvm/test/CodeGen/WebAssembly/libcalls.ll
@@ -206,13 +206,13 @@ define i1 @unordd(double %x, double %y) {
 ; CHECK-LABEL: unordd:
 ; CHECK:         .functype unordd (f64, f64) -> (i32)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    f64.ne $push4=, $0, $0
-; CHECK-NEXT:    f64.ne $push3=, $1, $1
-; CHECK-NEXT:    i32.or $push5=, $pop4, $pop3
-; CHECK-NEXT:    f64.eq $push1=, $0, $0
-; CHECK-NEXT:    f64.eq $push0=, $1, $1
-; CHECK-NEXT:    i32.and $push2=, $pop1, $pop0
-; CHECK-NEXT:    i32.xor $push6=, $pop5, $pop2
+; CHECK-NEXT:    f64.ne $push1=, $0, $0
+; CHECK-NEXT:    f64.ne $push0=, $1, $1
+; CHECK-NEXT:    i32.or $push2=, $pop1, $pop0
+; CHECK-NEXT:    f64.eq $push4=, $0, $0
+; CHECK-NEXT:    f64.eq $push3=, $1, $1
+; CHECK-NEXT:    i32.and $push5=, $pop4, $pop3
+; CHECK-NEXT:    i32.xor $push6=, $pop2, $pop5
 ; CHECK-NEXT:    return $pop6
  %a = fcmp uno double %x, %y
  %b = fcmp ord double %x, %y
@@ -224,13 +224,13 @@ define i1 @unordf(float %x, float %y) {
 ; CHECK-LABEL: unordf:
 ; CHECK:         .functype unordf (f32, f32) -> (i32)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    f32.ne $push4=, $0, $0
-; CHECK-NEXT:    f32.ne $push3=, $1, $1
-; CHECK-NEXT:    i32.or $push5=, $pop4, $pop3
-; CHECK-NEXT:    f32.eq $push1=, $0, $0
-; CHECK-NEXT:    f32.eq $push0=, $1, $1
-; CHECK-NEXT:    i32.and $push2=, $pop1, $pop0
-; CHECK-NEXT:    i32.xor $push6=, $pop5, $pop2
+; CHECK-NEXT:    f32.ne $push1=, $0, $0
+; CHECK-NEXT:    f32.ne $push0=, $1, $1
+; CHECK-NEXT:    i32.or $push2=, $pop1, $pop0
+; CHECK-NEXT:    f32.eq $push4=, $0, $0
+; CHECK-NEXT:    f32.eq $push3=, $1, $1
+; CHECK-NEXT:    i32.and $push5=, $pop4, $pop3
+; CHECK-NEXT:    i32.xor $push6=, $pop2, $pop5
 ; CHECK-NEXT:    return $pop6
  %a = fcmp uno float %x, %y
  %b = fcmp ord float %x, %y

--- a/llvm/test/CodeGen/WebAssembly/libcalls64.ll
+++ b/llvm/test/CodeGen/WebAssembly/libcalls64.ll
@@ -274,19 +274,19 @@ define i1 @unordd(double %x, double %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get $push8=, 0
 ; CHECK-NEXT:    local.get $push7=, 0
-; CHECK-NEXT:    f64.ne $push4=, $pop8, $pop7
+; CHECK-NEXT:    f64.ne $push1=, $pop8, $pop7
 ; CHECK-NEXT:    local.get $push10=, 1
 ; CHECK-NEXT:    local.get $push9=, 1
-; CHECK-NEXT:    f64.ne $push3=, $pop10, $pop9
-; CHECK-NEXT:    i32.or $push5=, $pop4, $pop3
+; CHECK-NEXT:    f64.ne $push0=, $pop10, $pop9
+; CHECK-NEXT:    i32.or $push2=, $pop1, $pop0
 ; CHECK-NEXT:    local.get $push12=, 0
 ; CHECK-NEXT:    local.get $push11=, 0
-; CHECK-NEXT:    f64.eq $push1=, $pop12, $pop11
+; CHECK-NEXT:    f64.eq $push4=, $pop12, $pop11
 ; CHECK-NEXT:    local.get $push14=, 1
 ; CHECK-NEXT:    local.get $push13=, 1
-; CHECK-NEXT:    f64.eq $push0=, $pop14, $pop13
-; CHECK-NEXT:    i32.and $push2=, $pop1, $pop0
-; CHECK-NEXT:    i32.xor $push6=, $pop5, $pop2
+; CHECK-NEXT:    f64.eq $push3=, $pop14, $pop13
+; CHECK-NEXT:    i32.and $push5=, $pop4, $pop3
+; CHECK-NEXT:    i32.xor $push6=, $pop2, $pop5
 ; CHECK-NEXT:    return $pop6
  %a = fcmp uno double %x, %y
  %b = fcmp ord double %x, %y
@@ -300,19 +300,19 @@ define i1 @unordf(float %x, float %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get $push8=, 0
 ; CHECK-NEXT:    local.get $push7=, 0
-; CHECK-NEXT:    f32.ne $push4=, $pop8, $pop7
+; CHECK-NEXT:    f32.ne $push1=, $pop8, $pop7
 ; CHECK-NEXT:    local.get $push10=, 1
 ; CHECK-NEXT:    local.get $push9=, 1
-; CHECK-NEXT:    f32.ne $push3=, $pop10, $pop9
-; CHECK-NEXT:    i32.or $push5=, $pop4, $pop3
+; CHECK-NEXT:    f32.ne $push0=, $pop10, $pop9
+; CHECK-NEXT:    i32.or $push2=, $pop1, $pop0
 ; CHECK-NEXT:    local.get $push12=, 0
 ; CHECK-NEXT:    local.get $push11=, 0
-; CHECK-NEXT:    f32.eq $push1=, $pop12, $pop11
+; CHECK-NEXT:    f32.eq $push4=, $pop12, $pop11
 ; CHECK-NEXT:    local.get $push14=, 1
 ; CHECK-NEXT:    local.get $push13=, 1
-; CHECK-NEXT:    f32.eq $push0=, $pop14, $pop13
-; CHECK-NEXT:    i32.and $push2=, $pop1, $pop0
-; CHECK-NEXT:    i32.xor $push6=, $pop5, $pop2
+; CHECK-NEXT:    f32.eq $push3=, $pop14, $pop13
+; CHECK-NEXT:    i32.and $push5=, $pop4, $pop3
+; CHECK-NEXT:    i32.xor $push6=, $pop2, $pop5
 ; CHECK-NEXT:    return $pop6
  %a = fcmp uno float %x, %y
  %b = fcmp ord float %x, %y

--- a/llvm/test/CodeGen/WebAssembly/memcmp-expand.ll
+++ b/llvm/test/CodeGen/WebAssembly/memcmp-expand.ll
@@ -9,16 +9,16 @@ define i1 @memcmp_expand_3(ptr %a, ptr %b) {
 ; CHECK-LABEL: memcmp_expand_3:
 ; CHECK:         .functype memcmp_expand_3 (i32, i32) -> (i32)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    i32.load16_u $push7=, 0($0):p2align=0
-; CHECK-NEXT:    i32.load16_u $push6=, 0($1):p2align=0
-; CHECK-NEXT:    i32.xor $push8=, $pop7, $pop6
+; CHECK-NEXT:    i32.load16_u $push6=, 0($0):p2align=0
+; CHECK-NEXT:    i32.load16_u $push7=, 0($1):p2align=0
+; CHECK-NEXT:    i32.xor $push8=, $pop6, $pop7
 ; CHECK-NEXT:    i32.const $push0=, 2
-; CHECK-NEXT:    i32.add $push3=, $0, $pop0
-; CHECK-NEXT:    i32.load8_u $push4=, 0($pop3)
-; CHECK-NEXT:    i32.const $push13=, 2
-; CHECK-NEXT:    i32.add $push1=, $1, $pop13
+; CHECK-NEXT:    i32.add $push1=, $0, $pop0
 ; CHECK-NEXT:    i32.load8_u $push2=, 0($pop1)
-; CHECK-NEXT:    i32.xor $push5=, $pop4, $pop2
+; CHECK-NEXT:    i32.const $push13=, 2
+; CHECK-NEXT:    i32.add $push3=, $1, $pop13
+; CHECK-NEXT:    i32.load8_u $push4=, 0($pop3)
+; CHECK-NEXT:    i32.xor $push5=, $pop2, $pop4
 ; CHECK-NEXT:    i32.or $push9=, $pop8, $pop5
 ; CHECK-NEXT:    i32.const $push10=, 65535
 ; CHECK-NEXT:    i32.and $push11=, $pop9, $pop10
@@ -33,16 +33,16 @@ define i1 @memcmp_expand_5(ptr %a, ptr %b) {
 ; CHECK-LABEL: memcmp_expand_5:
 ; CHECK:         .functype memcmp_expand_5 (i32, i32) -> (i32)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    i32.load $push7=, 0($0):p2align=0
-; CHECK-NEXT:    i32.load $push6=, 0($1):p2align=0
-; CHECK-NEXT:    i32.xor $push8=, $pop7, $pop6
+; CHECK-NEXT:    i32.load $push6=, 0($0):p2align=0
+; CHECK-NEXT:    i32.load $push7=, 0($1):p2align=0
+; CHECK-NEXT:    i32.xor $push8=, $pop6, $pop7
 ; CHECK-NEXT:    i32.const $push0=, 4
-; CHECK-NEXT:    i32.add $push3=, $0, $pop0
-; CHECK-NEXT:    i32.load8_u $push4=, 0($pop3)
-; CHECK-NEXT:    i32.const $push11=, 4
-; CHECK-NEXT:    i32.add $push1=, $1, $pop11
+; CHECK-NEXT:    i32.add $push1=, $0, $pop0
 ; CHECK-NEXT:    i32.load8_u $push2=, 0($pop1)
-; CHECK-NEXT:    i32.xor $push5=, $pop4, $pop2
+; CHECK-NEXT:    i32.const $push11=, 4
+; CHECK-NEXT:    i32.add $push3=, $1, $pop11
+; CHECK-NEXT:    i32.load8_u $push4=, 0($pop3)
+; CHECK-NEXT:    i32.xor $push5=, $pop2, $pop4
 ; CHECK-NEXT:    i32.or $push9=, $pop8, $pop5
 ; CHECK-NEXT:    i32.eqz $push10=, $pop9
 ; CHECK-NEXT:    return $pop10
@@ -55,16 +55,16 @@ define i1 @memcmp_expand_7(ptr %a, ptr %b) {
 ; CHECK-LABEL: memcmp_expand_7:
 ; CHECK:         .functype memcmp_expand_7 (i32, i32) -> (i32)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    i32.load $push7=, 0($0):p2align=0
-; CHECK-NEXT:    i32.load $push6=, 0($1):p2align=0
-; CHECK-NEXT:    i32.xor $push8=, $pop7, $pop6
+; CHECK-NEXT:    i32.load $push6=, 0($0):p2align=0
+; CHECK-NEXT:    i32.load $push7=, 0($1):p2align=0
+; CHECK-NEXT:    i32.xor $push8=, $pop6, $pop7
 ; CHECK-NEXT:    i32.const $push0=, 3
-; CHECK-NEXT:    i32.add $push3=, $0, $pop0
-; CHECK-NEXT:    i32.load $push4=, 0($pop3):p2align=0
-; CHECK-NEXT:    i32.const $push11=, 3
-; CHECK-NEXT:    i32.add $push1=, $1, $pop11
+; CHECK-NEXT:    i32.add $push1=, $0, $pop0
 ; CHECK-NEXT:    i32.load $push2=, 0($pop1):p2align=0
-; CHECK-NEXT:    i32.xor $push5=, $pop4, $pop2
+; CHECK-NEXT:    i32.const $push11=, 3
+; CHECK-NEXT:    i32.add $push3=, $1, $pop11
+; CHECK-NEXT:    i32.load $push4=, 0($pop3):p2align=0
+; CHECK-NEXT:    i32.xor $push5=, $pop2, $pop4
 ; CHECK-NEXT:    i32.or $push9=, $pop8, $pop5
 ; CHECK-NEXT:    i32.eqz $push10=, $pop9
 ; CHECK-NEXT:    return $pop10
@@ -92,9 +92,9 @@ define i1 @memcmp_expand_2(ptr %a, ptr %b) {
 ; CHECK-LABEL: memcmp_expand_2:
 ; CHECK:         .functype memcmp_expand_2 (i32, i32) -> (i32)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    i32.load16_u $push1=, 0($0):p2align=0
-; CHECK-NEXT:    i32.load16_u $push0=, 0($1):p2align=0
-; CHECK-NEXT:    i32.eq $push2=, $pop1, $pop0
+; CHECK-NEXT:    i32.load16_u $push0=, 0($0):p2align=0
+; CHECK-NEXT:    i32.load16_u $push1=, 0($1):p2align=0
+; CHECK-NEXT:    i32.eq $push2=, $pop0, $pop1
 ; CHECK-NEXT:    return $pop2
   %cmp_2 = call i32 @memcmp(ptr %a, ptr %b, i32 2)
   %res = icmp eq i32 %cmp_2, 0
@@ -105,9 +105,9 @@ define i1 @memcmp_expand_2_align(ptr align(2) %a, ptr align(2) %b) {
 ; CHECK-LABEL: memcmp_expand_2_align:
 ; CHECK:         .functype memcmp_expand_2_align (i32, i32) -> (i32)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    i32.load16_u $push1=, 0($0)
-; CHECK-NEXT:    i32.load16_u $push0=, 0($1)
-; CHECK-NEXT:    i32.eq $push2=, $pop1, $pop0
+; CHECK-NEXT:    i32.load16_u $push0=, 0($0)
+; CHECK-NEXT:    i32.load16_u $push1=, 0($1)
+; CHECK-NEXT:    i32.eq $push2=, $pop0, $pop1
 ; CHECK-NEXT:    return $pop2
   %cmp_2 = call i32 @memcmp(ptr %a, ptr %b, i32 2)
   %res = icmp eq i32 %cmp_2, 0
@@ -118,9 +118,9 @@ define i1 @memcmp_expand_8(ptr %a, ptr %b) {
 ; CHECK-LABEL: memcmp_expand_8:
 ; CHECK:         .functype memcmp_expand_8 (i32, i32) -> (i32)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    i64.load $push1=, 0($0):p2align=0
-; CHECK-NEXT:    i64.load $push0=, 0($1):p2align=0
-; CHECK-NEXT:    i64.eq $push2=, $pop1, $pop0
+; CHECK-NEXT:    i64.load $push0=, 0($0):p2align=0
+; CHECK-NEXT:    i64.load $push1=, 0($1):p2align=0
+; CHECK-NEXT:    i64.eq $push2=, $pop0, $pop1
 ; CHECK-NEXT:    return $pop2
   %cmp_8 = call i32 @memcmp(ptr %a, ptr %b, i32 8)
   %res = icmp eq i32 %cmp_8, 0
@@ -131,9 +131,9 @@ define i1 @memcmp_expand_16(ptr %a, ptr %b) {
 ; CHECK-LABEL: memcmp_expand_16:
 ; CHECK:         .functype memcmp_expand_16 (i32, i32) -> (i32)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    v128.load $push1=, 0($0):p2align=0
-; CHECK-NEXT:    v128.load $push0=, 0($1):p2align=0
-; CHECK-NEXT:    i8x16.eq $push2=, $pop1, $pop0
+; CHECK-NEXT:    v128.load $push0=, 0($0):p2align=0
+; CHECK-NEXT:    v128.load $push1=, 0($1):p2align=0
+; CHECK-NEXT:    i8x16.eq $push2=, $pop0, $pop1
 ; CHECK-NEXT:    i8x16.all_true $push3=, $pop2
 ; CHECK-NEXT:    return $pop3
   %cmp_16 = call i32 @memcmp(ptr %a, ptr %b, i32 16)

--- a/llvm/test/CodeGen/WebAssembly/memory-interleave.ll
+++ b/llvm/test/CodeGen/WebAssembly/memory-interleave.ll
@@ -2750,15 +2750,10 @@ define hidden void @mac_3d_i8(ptr dead_on_unwind noalias writable writeonly sret
 ; CHECK: loop
 ; CHECK: v128.load
 ; CHECK: v128.load
-; CHECK: i8x16.shuffle	3, 7, 11, 15, 19, 23, 27, 31, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i8x16.shuffle	0, 4, 8, 12, 16, 20, 24, 28, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: v128.load
 ; CHECK: v128.load
-; CHECK: i8x16.shuffle	3, 7, 11, 15, 19, 23, 27, 31, 0, 0, 0, 0, 0, 0, 0, 0
-; CHECK: i16x8.extmul_low_i8x16_u
-; CHECK: i8x16.shuffle	0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0
-; CHECK: i8x16.add
-; CHECK: i8x16.shuffle	2, 6, 10, 14, 18, 22, 26, 30, 0, 0, 0, 0, 0, 0, 0, 0
-; CHECK: i8x16.shuffle	2, 6, 10, 14, 18, 22, 26, 30, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i8x16.shuffle	0, 4, 8, 12, 16, 20, 24, 28, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: i16x8.extmul_low_i8x16_u
 ; CHECK: i8x16.shuffle	0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: i8x16.add
@@ -2767,8 +2762,13 @@ define hidden void @mac_3d_i8(ptr dead_on_unwind noalias writable writeonly sret
 ; CHECK: i16x8.extmul_low_i8x16_u
 ; CHECK: i8x16.shuffle	0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: i8x16.add
-; CHECK: i8x16.shuffle	0, 4, 8, 12, 16, 20, 24, 28, 0, 0, 0, 0, 0, 0, 0, 0
-; CHECK: i8x16.shuffle	0, 4, 8, 12, 16, 20, 24, 28, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i8x16.shuffle	2, 6, 10, 14, 18, 22, 26, 30, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i8x16.shuffle	2, 6, 10, 14, 18, 22, 26, 30, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i16x8.extmul_low_i8x16_u
+; CHECK: i8x16.shuffle	0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i8x16.add
+; CHECK: i8x16.shuffle	3, 7, 11, 15, 19, 23, 27, 31, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i8x16.shuffle	3, 7, 11, 15, 19, 23, 27, 31, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: i16x8.extmul_low_i8x16_u
 ; CHECK: i8x16.shuffle	0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: i8x16.add
@@ -2832,16 +2832,16 @@ define hidden void @mac_4d_i8(ptr dead_on_unwind noalias writable writeonly sret
 ; CHECK-LABEL: mac_2d_i64
 ; CHECK: loop
 ; CHECK: v128.load
-; CHECK: i8x16.shuffle	4, 5, 6, 7, 12, 13, 14, 15, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK: i8x16.shuffle	0, 1, 2, 3, 8, 9, 10, 11, 0, 1, 2, 3, 0, 1, 2, 3
 ; CHECK: i64x2.extend_low_i32x4_u
 ; CHECK: v128.load
-; CHECK: i8x16.shuffle	4, 5, 6, 7, 12, 13, 14, 15, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK: i8x16.shuffle	0, 1, 2, 3, 8, 9, 10, 11, 0, 1, 2, 3, 0, 1, 2, 3
 ; CHECK: i64x2.extend_low_i32x4_s
 ; CHECK: i64x2.mul
 ; CHECK: i64x2.add
-; CHECK: i8x16.shuffle	0, 1, 2, 3, 8, 9, 10, 11, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK: i8x16.shuffle	4, 5, 6, 7, 12, 13, 14, 15, 0, 1, 2, 3, 0, 1, 2, 3
 ; CHECK: i64x2.extend_low_i32x4_u
-; CHECK: i8x16.shuffle	0, 1, 2, 3, 8, 9, 10, 11, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK: i8x16.shuffle	4, 5, 6, 7, 12, 13, 14, 15, 0, 1, 2, 3, 0, 1, 2, 3
 ; CHECK: i64x2.extend_low_i32x4_s
 ; CHECK: i64x2.mul
 ; CHECK: i64x2.add
@@ -2894,17 +2894,11 @@ for.body:                                         ; preds = %for.body.lr.ph, %fo
 ; CHECK: loop
 ; CHECK: v128.load
 ; CHECK: v128.load
-; CHECK: i8x16.shuffle	12, 13, 14, 15, 28, 29, 30, 31, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK: i8x16.shuffle	0, 1, 2, 3, 16, 17, 18, 19, 0, 1, 2, 3, 0, 1, 2, 3
 ; CHECK: i64x2.extend_low_i32x4_u
 ; CHECK: v128.load
 ; CHECK: v128.load
-; CHECK: i8x16.shuffle	12, 13, 14, 15, 28, 29, 30, 31, 0, 1, 2, 3, 0, 1, 2, 3
-; CHECK: i64x2.extend_low_i32x4_s
-; CHECK: i64x2.mul
-; CHECK: i64x2.add
-; CHECK: i8x16.shuffle	8, 9, 10, 11, 24, 25, 26, 27, 0, 1, 2, 3, 0, 1, 2, 3
-; CHECK: i64x2.extend_low_i32x4_u
-; CHECK: i8x16.shuffle	8, 9, 10, 11, 24, 25, 26, 27, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK: i8x16.shuffle	0, 1, 2, 3, 16, 17, 18, 19, 0, 1, 2, 3, 0, 1, 2, 3
 ; CHECK: i64x2.extend_low_i32x4_s
 ; CHECK: i64x2.mul
 ; CHECK: i64x2.add
@@ -2914,9 +2908,15 @@ for.body:                                         ; preds = %for.body.lr.ph, %fo
 ; CHECK: i64x2.extend_low_i32x4_s
 ; CHECK: i64x2.mul
 ; CHECK: i64x2.add
-; CHECK: i8x16.shuffle	0, 1, 2, 3, 16, 17, 18, 19, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK: i8x16.shuffle	8, 9, 10, 11, 24, 25, 26, 27, 0, 1, 2, 3, 0, 1, 2, 3
 ; CHECK: i64x2.extend_low_i32x4_u
-; CHECK: i8x16.shuffle	0, 1, 2, 3, 16, 17, 18, 19, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK: i8x16.shuffle	8, 9, 10, 11, 24, 25, 26, 27, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK: i64x2.extend_low_i32x4_s
+; CHECK: i64x2.mul
+; CHECK: i64x2.add
+; CHECK: i8x16.shuffle	12, 13, 14, 15, 28, 29, 30, 31, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK: i64x2.extend_low_i32x4_u
+; CHECK: i8x16.shuffle	12, 13, 14, 15, 28, 29, 30, 31, 0, 1, 2, 3, 0, 1, 2, 3
 ; CHECK: i64x2.extend_low_i32x4_s
 ; CHECK: i64x2.mul
 ; CHECK: i64x2.add

--- a/llvm/test/CodeGen/WebAssembly/offset-atomics.ll
+++ b/llvm/test/CodeGen/WebAssembly/offset-atomics.ll
@@ -1307,9 +1307,9 @@ define i32 @cmpxchg_i8_i32_s_with_folded_offset(ptr %p, i32 %exp, i32 %new) {
 
 ; 32->64 sext rmw gets selected as i32.atomic.rmw.cmpxchg, i64.extend_i32_s
 ; CHECK-LABEL: cmpxchg_i32_i64_s_with_folded_offset:
-; CHECK: i32.wrap_i64 $push1=, $1
-; CHECK-NEXT: i32.wrap_i64 $push0=, $2
-; CHECK-NEXT: i32.atomic.rmw.cmpxchg $push2=, 24($0), $pop1, $pop0{{$}}
+; CHECK: i32.wrap_i64 $push0=, $1
+; CHECK-NEXT: i32.wrap_i64 $push1=, $2
+; CHECK-NEXT: i32.atomic.rmw.cmpxchg $push2=, 24($0), $pop0, $pop1{{$}}
 ; CHECK-NEXT: i64.extend_i32_s $push3=, $pop2{{$}}
 define i64 @cmpxchg_i32_i64_s_with_folded_offset(ptr %p, i64 %exp, i64 %new) {
   %q = ptrtoint ptr %p to i32

--- a/llvm/test/CodeGen/WebAssembly/simd-arith.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-arith.ll
@@ -1633,160 +1633,160 @@ define <16 x i8> @avgr_u_v16i8_zext(<16 x i8> %x, <16 x i8> %y) {
 ; NO-SIMD128-FAST:         .functype avgr_u_v16i8_zext (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
 ; NO-SIMD128-FAST-NEXT:    i32.const $push0=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $1, $pop0
+; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $1, $pop0
 ; NO-SIMD128-FAST-NEXT:    i32.const $push143=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $17, $pop143
-; NO-SIMD128-FAST-NEXT:    i32.add $push3=, $pop2, $pop1
+; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $17, $pop143
+; NO-SIMD128-FAST-NEXT:    i32.add $push3=, $pop1, $pop2
 ; NO-SIMD128-FAST-NEXT:    i32.const $push4=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push5=, $pop3, $pop4
 ; NO-SIMD128-FAST-NEXT:    i32.const $push142=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push6=, $pop5, $pop142
 ; NO-SIMD128-FAST-NEXT:    i32.store8 0($0), $pop6
 ; NO-SIMD128-FAST-NEXT:    i32.const $push141=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $2, $pop141
+; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $2, $pop141
 ; NO-SIMD128-FAST-NEXT:    i32.const $push140=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $18, $pop140
-; NO-SIMD128-FAST-NEXT:    i32.add $push9=, $pop8, $pop7
+; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $18, $pop140
+; NO-SIMD128-FAST-NEXT:    i32.add $push9=, $pop7, $pop8
 ; NO-SIMD128-FAST-NEXT:    i32.const $push139=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push10=, $pop9, $pop139
 ; NO-SIMD128-FAST-NEXT:    i32.const $push138=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push11=, $pop10, $pop138
 ; NO-SIMD128-FAST-NEXT:    i32.store8 1($0), $pop11
 ; NO-SIMD128-FAST-NEXT:    i32.const $push137=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push13=, $3, $pop137
+; NO-SIMD128-FAST-NEXT:    i32.and $push12=, $3, $pop137
 ; NO-SIMD128-FAST-NEXT:    i32.const $push136=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push12=, $19, $pop136
-; NO-SIMD128-FAST-NEXT:    i32.add $push14=, $pop13, $pop12
+; NO-SIMD128-FAST-NEXT:    i32.and $push13=, $19, $pop136
+; NO-SIMD128-FAST-NEXT:    i32.add $push14=, $pop12, $pop13
 ; NO-SIMD128-FAST-NEXT:    i32.const $push135=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push15=, $pop14, $pop135
 ; NO-SIMD128-FAST-NEXT:    i32.const $push134=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push16=, $pop15, $pop134
 ; NO-SIMD128-FAST-NEXT:    i32.store8 2($0), $pop16
 ; NO-SIMD128-FAST-NEXT:    i32.const $push133=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push18=, $4, $pop133
+; NO-SIMD128-FAST-NEXT:    i32.and $push17=, $4, $pop133
 ; NO-SIMD128-FAST-NEXT:    i32.const $push132=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push17=, $20, $pop132
-; NO-SIMD128-FAST-NEXT:    i32.add $push19=, $pop18, $pop17
+; NO-SIMD128-FAST-NEXT:    i32.and $push18=, $20, $pop132
+; NO-SIMD128-FAST-NEXT:    i32.add $push19=, $pop17, $pop18
 ; NO-SIMD128-FAST-NEXT:    i32.const $push131=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push20=, $pop19, $pop131
 ; NO-SIMD128-FAST-NEXT:    i32.const $push130=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push21=, $pop20, $pop130
 ; NO-SIMD128-FAST-NEXT:    i32.store8 3($0), $pop21
 ; NO-SIMD128-FAST-NEXT:    i32.const $push129=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $5, $pop129
+; NO-SIMD128-FAST-NEXT:    i32.and $push22=, $5, $pop129
 ; NO-SIMD128-FAST-NEXT:    i32.const $push128=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push22=, $21, $pop128
-; NO-SIMD128-FAST-NEXT:    i32.add $push24=, $pop23, $pop22
+; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $21, $pop128
+; NO-SIMD128-FAST-NEXT:    i32.add $push24=, $pop22, $pop23
 ; NO-SIMD128-FAST-NEXT:    i32.const $push127=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push25=, $pop24, $pop127
 ; NO-SIMD128-FAST-NEXT:    i32.const $push126=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push26=, $pop25, $pop126
 ; NO-SIMD128-FAST-NEXT:    i32.store8 4($0), $pop26
 ; NO-SIMD128-FAST-NEXT:    i32.const $push125=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push28=, $6, $pop125
+; NO-SIMD128-FAST-NEXT:    i32.and $push27=, $6, $pop125
 ; NO-SIMD128-FAST-NEXT:    i32.const $push124=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push27=, $22, $pop124
-; NO-SIMD128-FAST-NEXT:    i32.add $push29=, $pop28, $pop27
+; NO-SIMD128-FAST-NEXT:    i32.and $push28=, $22, $pop124
+; NO-SIMD128-FAST-NEXT:    i32.add $push29=, $pop27, $pop28
 ; NO-SIMD128-FAST-NEXT:    i32.const $push123=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push30=, $pop29, $pop123
 ; NO-SIMD128-FAST-NEXT:    i32.const $push122=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push31=, $pop30, $pop122
 ; NO-SIMD128-FAST-NEXT:    i32.store8 5($0), $pop31
 ; NO-SIMD128-FAST-NEXT:    i32.const $push121=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push33=, $7, $pop121
+; NO-SIMD128-FAST-NEXT:    i32.and $push32=, $7, $pop121
 ; NO-SIMD128-FAST-NEXT:    i32.const $push120=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push32=, $23, $pop120
-; NO-SIMD128-FAST-NEXT:    i32.add $push34=, $pop33, $pop32
+; NO-SIMD128-FAST-NEXT:    i32.and $push33=, $23, $pop120
+; NO-SIMD128-FAST-NEXT:    i32.add $push34=, $pop32, $pop33
 ; NO-SIMD128-FAST-NEXT:    i32.const $push119=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push35=, $pop34, $pop119
 ; NO-SIMD128-FAST-NEXT:    i32.const $push118=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push36=, $pop35, $pop118
 ; NO-SIMD128-FAST-NEXT:    i32.store8 6($0), $pop36
 ; NO-SIMD128-FAST-NEXT:    i32.const $push117=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push38=, $8, $pop117
+; NO-SIMD128-FAST-NEXT:    i32.and $push37=, $8, $pop117
 ; NO-SIMD128-FAST-NEXT:    i32.const $push116=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push37=, $24, $pop116
-; NO-SIMD128-FAST-NEXT:    i32.add $push39=, $pop38, $pop37
+; NO-SIMD128-FAST-NEXT:    i32.and $push38=, $24, $pop116
+; NO-SIMD128-FAST-NEXT:    i32.add $push39=, $pop37, $pop38
 ; NO-SIMD128-FAST-NEXT:    i32.const $push115=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push40=, $pop39, $pop115
 ; NO-SIMD128-FAST-NEXT:    i32.const $push114=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push41=, $pop40, $pop114
 ; NO-SIMD128-FAST-NEXT:    i32.store8 7($0), $pop41
 ; NO-SIMD128-FAST-NEXT:    i32.const $push113=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push43=, $9, $pop113
+; NO-SIMD128-FAST-NEXT:    i32.and $push42=, $9, $pop113
 ; NO-SIMD128-FAST-NEXT:    i32.const $push112=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push42=, $25, $pop112
-; NO-SIMD128-FAST-NEXT:    i32.add $push44=, $pop43, $pop42
+; NO-SIMD128-FAST-NEXT:    i32.and $push43=, $25, $pop112
+; NO-SIMD128-FAST-NEXT:    i32.add $push44=, $pop42, $pop43
 ; NO-SIMD128-FAST-NEXT:    i32.const $push111=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push45=, $pop44, $pop111
 ; NO-SIMD128-FAST-NEXT:    i32.const $push110=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push46=, $pop45, $pop110
 ; NO-SIMD128-FAST-NEXT:    i32.store8 8($0), $pop46
 ; NO-SIMD128-FAST-NEXT:    i32.const $push109=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push48=, $10, $pop109
+; NO-SIMD128-FAST-NEXT:    i32.and $push47=, $10, $pop109
 ; NO-SIMD128-FAST-NEXT:    i32.const $push108=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push47=, $26, $pop108
-; NO-SIMD128-FAST-NEXT:    i32.add $push49=, $pop48, $pop47
+; NO-SIMD128-FAST-NEXT:    i32.and $push48=, $26, $pop108
+; NO-SIMD128-FAST-NEXT:    i32.add $push49=, $pop47, $pop48
 ; NO-SIMD128-FAST-NEXT:    i32.const $push107=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push50=, $pop49, $pop107
 ; NO-SIMD128-FAST-NEXT:    i32.const $push106=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push51=, $pop50, $pop106
 ; NO-SIMD128-FAST-NEXT:    i32.store8 9($0), $pop51
 ; NO-SIMD128-FAST-NEXT:    i32.const $push105=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push53=, $11, $pop105
+; NO-SIMD128-FAST-NEXT:    i32.and $push52=, $11, $pop105
 ; NO-SIMD128-FAST-NEXT:    i32.const $push104=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push52=, $27, $pop104
-; NO-SIMD128-FAST-NEXT:    i32.add $push54=, $pop53, $pop52
+; NO-SIMD128-FAST-NEXT:    i32.and $push53=, $27, $pop104
+; NO-SIMD128-FAST-NEXT:    i32.add $push54=, $pop52, $pop53
 ; NO-SIMD128-FAST-NEXT:    i32.const $push103=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push55=, $pop54, $pop103
 ; NO-SIMD128-FAST-NEXT:    i32.const $push102=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push56=, $pop55, $pop102
 ; NO-SIMD128-FAST-NEXT:    i32.store8 10($0), $pop56
 ; NO-SIMD128-FAST-NEXT:    i32.const $push101=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push58=, $12, $pop101
+; NO-SIMD128-FAST-NEXT:    i32.and $push57=, $12, $pop101
 ; NO-SIMD128-FAST-NEXT:    i32.const $push100=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push57=, $28, $pop100
-; NO-SIMD128-FAST-NEXT:    i32.add $push59=, $pop58, $pop57
+; NO-SIMD128-FAST-NEXT:    i32.and $push58=, $28, $pop100
+; NO-SIMD128-FAST-NEXT:    i32.add $push59=, $pop57, $pop58
 ; NO-SIMD128-FAST-NEXT:    i32.const $push99=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push60=, $pop59, $pop99
 ; NO-SIMD128-FAST-NEXT:    i32.const $push98=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push61=, $pop60, $pop98
 ; NO-SIMD128-FAST-NEXT:    i32.store8 11($0), $pop61
 ; NO-SIMD128-FAST-NEXT:    i32.const $push97=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push63=, $13, $pop97
+; NO-SIMD128-FAST-NEXT:    i32.and $push62=, $13, $pop97
 ; NO-SIMD128-FAST-NEXT:    i32.const $push96=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push62=, $29, $pop96
-; NO-SIMD128-FAST-NEXT:    i32.add $push64=, $pop63, $pop62
+; NO-SIMD128-FAST-NEXT:    i32.and $push63=, $29, $pop96
+; NO-SIMD128-FAST-NEXT:    i32.add $push64=, $pop62, $pop63
 ; NO-SIMD128-FAST-NEXT:    i32.const $push95=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push65=, $pop64, $pop95
 ; NO-SIMD128-FAST-NEXT:    i32.const $push94=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push66=, $pop65, $pop94
 ; NO-SIMD128-FAST-NEXT:    i32.store8 12($0), $pop66
 ; NO-SIMD128-FAST-NEXT:    i32.const $push93=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push68=, $14, $pop93
+; NO-SIMD128-FAST-NEXT:    i32.and $push67=, $14, $pop93
 ; NO-SIMD128-FAST-NEXT:    i32.const $push92=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push67=, $30, $pop92
-; NO-SIMD128-FAST-NEXT:    i32.add $push69=, $pop68, $pop67
+; NO-SIMD128-FAST-NEXT:    i32.and $push68=, $30, $pop92
+; NO-SIMD128-FAST-NEXT:    i32.add $push69=, $pop67, $pop68
 ; NO-SIMD128-FAST-NEXT:    i32.const $push91=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push70=, $pop69, $pop91
 ; NO-SIMD128-FAST-NEXT:    i32.const $push90=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push71=, $pop70, $pop90
 ; NO-SIMD128-FAST-NEXT:    i32.store8 13($0), $pop71
 ; NO-SIMD128-FAST-NEXT:    i32.const $push89=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push73=, $15, $pop89
+; NO-SIMD128-FAST-NEXT:    i32.and $push72=, $15, $pop89
 ; NO-SIMD128-FAST-NEXT:    i32.const $push88=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push72=, $31, $pop88
-; NO-SIMD128-FAST-NEXT:    i32.add $push74=, $pop73, $pop72
+; NO-SIMD128-FAST-NEXT:    i32.and $push73=, $31, $pop88
+; NO-SIMD128-FAST-NEXT:    i32.add $push74=, $pop72, $pop73
 ; NO-SIMD128-FAST-NEXT:    i32.const $push87=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push75=, $pop74, $pop87
 ; NO-SIMD128-FAST-NEXT:    i32.const $push86=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push76=, $pop75, $pop86
 ; NO-SIMD128-FAST-NEXT:    i32.store8 14($0), $pop76
 ; NO-SIMD128-FAST-NEXT:    i32.const $push85=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push78=, $16, $pop85
+; NO-SIMD128-FAST-NEXT:    i32.and $push77=, $16, $pop85
 ; NO-SIMD128-FAST-NEXT:    i32.const $push84=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push77=, $32, $pop84
-; NO-SIMD128-FAST-NEXT:    i32.add $push79=, $pop78, $pop77
+; NO-SIMD128-FAST-NEXT:    i32.and $push78=, $32, $pop84
+; NO-SIMD128-FAST-NEXT:    i32.add $push79=, $pop77, $pop78
 ; NO-SIMD128-FAST-NEXT:    i32.const $push83=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push80=, $pop79, $pop83
 ; NO-SIMD128-FAST-NEXT:    i32.const $push82=, 1
@@ -1904,80 +1904,80 @@ define <8 x i16> @avgr_u_v8i16_zext(<8 x i16> %x, <8 x i16> %y) {
 ; NO-SIMD128-FAST:         .functype avgr_u_v8i16_zext (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
 ; NO-SIMD128-FAST-NEXT:    i32.const $push0=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $1, $pop0
+; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $1, $pop0
 ; NO-SIMD128-FAST-NEXT:    i32.const $push71=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $9, $pop71
-; NO-SIMD128-FAST-NEXT:    i32.add $push3=, $pop2, $pop1
+; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $9, $pop71
+; NO-SIMD128-FAST-NEXT:    i32.add $push3=, $pop1, $pop2
 ; NO-SIMD128-FAST-NEXT:    i32.const $push4=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push5=, $pop3, $pop4
 ; NO-SIMD128-FAST-NEXT:    i32.const $push70=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push6=, $pop5, $pop70
 ; NO-SIMD128-FAST-NEXT:    i32.store16 0($0), $pop6
 ; NO-SIMD128-FAST-NEXT:    i32.const $push69=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $2, $pop69
+; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $2, $pop69
 ; NO-SIMD128-FAST-NEXT:    i32.const $push68=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $10, $pop68
-; NO-SIMD128-FAST-NEXT:    i32.add $push9=, $pop8, $pop7
+; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $10, $pop68
+; NO-SIMD128-FAST-NEXT:    i32.add $push9=, $pop7, $pop8
 ; NO-SIMD128-FAST-NEXT:    i32.const $push67=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push10=, $pop9, $pop67
 ; NO-SIMD128-FAST-NEXT:    i32.const $push66=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push11=, $pop10, $pop66
 ; NO-SIMD128-FAST-NEXT:    i32.store16 2($0), $pop11
 ; NO-SIMD128-FAST-NEXT:    i32.const $push65=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push13=, $3, $pop65
+; NO-SIMD128-FAST-NEXT:    i32.and $push12=, $3, $pop65
 ; NO-SIMD128-FAST-NEXT:    i32.const $push64=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push12=, $11, $pop64
-; NO-SIMD128-FAST-NEXT:    i32.add $push14=, $pop13, $pop12
+; NO-SIMD128-FAST-NEXT:    i32.and $push13=, $11, $pop64
+; NO-SIMD128-FAST-NEXT:    i32.add $push14=, $pop12, $pop13
 ; NO-SIMD128-FAST-NEXT:    i32.const $push63=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push15=, $pop14, $pop63
 ; NO-SIMD128-FAST-NEXT:    i32.const $push62=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push16=, $pop15, $pop62
 ; NO-SIMD128-FAST-NEXT:    i32.store16 4($0), $pop16
 ; NO-SIMD128-FAST-NEXT:    i32.const $push61=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push18=, $4, $pop61
+; NO-SIMD128-FAST-NEXT:    i32.and $push17=, $4, $pop61
 ; NO-SIMD128-FAST-NEXT:    i32.const $push60=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push17=, $12, $pop60
-; NO-SIMD128-FAST-NEXT:    i32.add $push19=, $pop18, $pop17
+; NO-SIMD128-FAST-NEXT:    i32.and $push18=, $12, $pop60
+; NO-SIMD128-FAST-NEXT:    i32.add $push19=, $pop17, $pop18
 ; NO-SIMD128-FAST-NEXT:    i32.const $push59=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push20=, $pop19, $pop59
 ; NO-SIMD128-FAST-NEXT:    i32.const $push58=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push21=, $pop20, $pop58
 ; NO-SIMD128-FAST-NEXT:    i32.store16 6($0), $pop21
 ; NO-SIMD128-FAST-NEXT:    i32.const $push57=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $5, $pop57
+; NO-SIMD128-FAST-NEXT:    i32.and $push22=, $5, $pop57
 ; NO-SIMD128-FAST-NEXT:    i32.const $push56=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push22=, $13, $pop56
-; NO-SIMD128-FAST-NEXT:    i32.add $push24=, $pop23, $pop22
+; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $13, $pop56
+; NO-SIMD128-FAST-NEXT:    i32.add $push24=, $pop22, $pop23
 ; NO-SIMD128-FAST-NEXT:    i32.const $push55=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push25=, $pop24, $pop55
 ; NO-SIMD128-FAST-NEXT:    i32.const $push54=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push26=, $pop25, $pop54
 ; NO-SIMD128-FAST-NEXT:    i32.store16 8($0), $pop26
 ; NO-SIMD128-FAST-NEXT:    i32.const $push53=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push28=, $6, $pop53
+; NO-SIMD128-FAST-NEXT:    i32.and $push27=, $6, $pop53
 ; NO-SIMD128-FAST-NEXT:    i32.const $push52=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push27=, $14, $pop52
-; NO-SIMD128-FAST-NEXT:    i32.add $push29=, $pop28, $pop27
+; NO-SIMD128-FAST-NEXT:    i32.and $push28=, $14, $pop52
+; NO-SIMD128-FAST-NEXT:    i32.add $push29=, $pop27, $pop28
 ; NO-SIMD128-FAST-NEXT:    i32.const $push51=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push30=, $pop29, $pop51
 ; NO-SIMD128-FAST-NEXT:    i32.const $push50=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push31=, $pop30, $pop50
 ; NO-SIMD128-FAST-NEXT:    i32.store16 10($0), $pop31
 ; NO-SIMD128-FAST-NEXT:    i32.const $push49=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push33=, $7, $pop49
+; NO-SIMD128-FAST-NEXT:    i32.and $push32=, $7, $pop49
 ; NO-SIMD128-FAST-NEXT:    i32.const $push48=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push32=, $15, $pop48
-; NO-SIMD128-FAST-NEXT:    i32.add $push34=, $pop33, $pop32
+; NO-SIMD128-FAST-NEXT:    i32.and $push33=, $15, $pop48
+; NO-SIMD128-FAST-NEXT:    i32.add $push34=, $pop32, $pop33
 ; NO-SIMD128-FAST-NEXT:    i32.const $push47=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push35=, $pop34, $pop47
 ; NO-SIMD128-FAST-NEXT:    i32.const $push46=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push36=, $pop35, $pop46
 ; NO-SIMD128-FAST-NEXT:    i32.store16 12($0), $pop36
 ; NO-SIMD128-FAST-NEXT:    i32.const $push45=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push38=, $8, $pop45
+; NO-SIMD128-FAST-NEXT:    i32.and $push37=, $8, $pop45
 ; NO-SIMD128-FAST-NEXT:    i32.const $push44=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push37=, $16, $pop44
-; NO-SIMD128-FAST-NEXT:    i32.add $push39=, $pop38, $pop37
+; NO-SIMD128-FAST-NEXT:    i32.and $push38=, $16, $pop44
+; NO-SIMD128-FAST-NEXT:    i32.add $push39=, $pop37, $pop38
 ; NO-SIMD128-FAST-NEXT:    i32.const $push43=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push40=, $pop39, $pop43
 ; NO-SIMD128-FAST-NEXT:    i32.const $push42=, 1
@@ -1996,14 +1996,14 @@ define void @avgr_undef_shuffle_lanes(ptr %res, <8 x i8> %a, <8 x i8> %b, <8 x i
 ; SIMD128-LABEL: avgr_undef_shuffle_lanes:
 ; SIMD128:         .functype avgr_undef_shuffle_lanes (i32, v128, v128, v128, v128) -> ()
 ; SIMD128-NEXT:  # %bb.0:
-; SIMD128-NEXT:    i8x16.avgr_u $push1=, $1, $2
-; SIMD128-NEXT:    i16x8.extend_low_i8x16_u $push8=, $pop1
+; SIMD128-NEXT:    i8x16.avgr_u $push0=, $1, $2
+; SIMD128-NEXT:    i16x8.extend_low_i8x16_u $push8=, $pop0
 ; SIMD128-NEXT:    local.tee $push7=, $2=, $pop8
-; SIMD128-NEXT:    i8x16.avgr_u $push0=, $3, $4
-; SIMD128-NEXT:    i16x8.extend_low_i8x16_u $push6=, $pop0
-; SIMD128-NEXT:    local.tee $push5=, $4=, $pop6
+; SIMD128-NEXT:    i8x16.avgr_u $push1=, $3, $4
+; SIMD128-NEXT:    i16x8.extend_low_i8x16_u $push6=, $pop1
+; SIMD128-NEXT:    local.tee $push5=, $1=, $pop6
 ; SIMD128-NEXT:    i8x16.shuffle $push3=, $pop7, $pop5, 0, 1, 16, 17, 2, 3, 18, 19, 4, 5, 20, 21, 6, 7, 22, 23
-; SIMD128-NEXT:    i8x16.shuffle $push2=, $2, $4, 8, 9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31
+; SIMD128-NEXT:    i8x16.shuffle $push2=, $2, $1, 8, 9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31
 ; SIMD128-NEXT:    i8x16.narrow_i16x8_u $push4=, $pop3, $pop2
 ; SIMD128-NEXT:    v128.store 0($0):p2align=0, $pop4
 ; SIMD128-NEXT:    return
@@ -2011,11 +2011,11 @@ define void @avgr_undef_shuffle_lanes(ptr %res, <8 x i8> %a, <8 x i8> %b, <8 x i
 ; SIMD128-FAST-LABEL: avgr_undef_shuffle_lanes:
 ; SIMD128-FAST:         .functype avgr_undef_shuffle_lanes (i32, v128, v128, v128, v128) -> ()
 ; SIMD128-FAST-NEXT:  # %bb.0:
-; SIMD128-FAST-NEXT:    i8x16.avgr_u $push1=, $1, $2
-; SIMD128-FAST-NEXT:    i16x8.extend_low_i8x16_u $push8=, $pop1
+; SIMD128-FAST-NEXT:    i8x16.avgr_u $push0=, $1, $2
+; SIMD128-FAST-NEXT:    i16x8.extend_low_i8x16_u $push8=, $pop0
 ; SIMD128-FAST-NEXT:    local.tee $push7=, $2=, $pop8
-; SIMD128-FAST-NEXT:    i8x16.avgr_u $push0=, $3, $4
-; SIMD128-FAST-NEXT:    i16x8.extend_low_i8x16_u $push6=, $pop0
+; SIMD128-FAST-NEXT:    i8x16.avgr_u $push1=, $3, $4
+; SIMD128-FAST-NEXT:    i16x8.extend_low_i8x16_u $push6=, $pop1
 ; SIMD128-FAST-NEXT:    local.tee $push5=, $4=, $pop6
 ; SIMD128-FAST-NEXT:    i8x16.shuffle $push3=, $pop7, $pop5, 0, 1, 16, 17, 2, 3, 18, 19, 4, 5, 20, 21, 6, 7, 22, 23
 ; SIMD128-FAST-NEXT:    i8x16.shuffle $push2=, $2, $4, 8, 9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31
@@ -2192,160 +2192,160 @@ define void @avgr_undef_shuffle_lanes(ptr %res, <8 x i8> %a, <8 x i8> %b, <8 x i
 ; NO-SIMD128-FAST:         .functype avgr_undef_shuffle_lanes (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
 ; NO-SIMD128-FAST-NEXT:    i32.const $push0=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $17, $pop0
+; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $17, $pop0
 ; NO-SIMD128-FAST-NEXT:    i32.const $push143=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $25, $pop143
-; NO-SIMD128-FAST-NEXT:    i32.add $push3=, $pop2, $pop1
+; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $25, $pop143
+; NO-SIMD128-FAST-NEXT:    i32.add $push3=, $pop1, $pop2
 ; NO-SIMD128-FAST-NEXT:    i32.const $push4=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push5=, $pop3, $pop4
 ; NO-SIMD128-FAST-NEXT:    i32.const $push142=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push6=, $pop5, $pop142
 ; NO-SIMD128-FAST-NEXT:    i32.store8 1($0), $pop6
 ; NO-SIMD128-FAST-NEXT:    i32.const $push141=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $1, $pop141
+; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $1, $pop141
 ; NO-SIMD128-FAST-NEXT:    i32.const $push140=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $9, $pop140
-; NO-SIMD128-FAST-NEXT:    i32.add $push9=, $pop8, $pop7
+; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $9, $pop140
+; NO-SIMD128-FAST-NEXT:    i32.add $push9=, $pop7, $pop8
 ; NO-SIMD128-FAST-NEXT:    i32.const $push139=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push10=, $pop9, $pop139
 ; NO-SIMD128-FAST-NEXT:    i32.const $push138=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push11=, $pop10, $pop138
 ; NO-SIMD128-FAST-NEXT:    i32.store8 0($0), $pop11
 ; NO-SIMD128-FAST-NEXT:    i32.const $push137=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push13=, $18, $pop137
+; NO-SIMD128-FAST-NEXT:    i32.and $push12=, $18, $pop137
 ; NO-SIMD128-FAST-NEXT:    i32.const $push136=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push12=, $26, $pop136
-; NO-SIMD128-FAST-NEXT:    i32.add $push14=, $pop13, $pop12
+; NO-SIMD128-FAST-NEXT:    i32.and $push13=, $26, $pop136
+; NO-SIMD128-FAST-NEXT:    i32.add $push14=, $pop12, $pop13
 ; NO-SIMD128-FAST-NEXT:    i32.const $push135=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push15=, $pop14, $pop135
 ; NO-SIMD128-FAST-NEXT:    i32.const $push134=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push16=, $pop15, $pop134
 ; NO-SIMD128-FAST-NEXT:    i32.store8 3($0), $pop16
 ; NO-SIMD128-FAST-NEXT:    i32.const $push133=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push18=, $2, $pop133
+; NO-SIMD128-FAST-NEXT:    i32.and $push17=, $2, $pop133
 ; NO-SIMD128-FAST-NEXT:    i32.const $push132=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push17=, $10, $pop132
-; NO-SIMD128-FAST-NEXT:    i32.add $push19=, $pop18, $pop17
+; NO-SIMD128-FAST-NEXT:    i32.and $push18=, $10, $pop132
+; NO-SIMD128-FAST-NEXT:    i32.add $push19=, $pop17, $pop18
 ; NO-SIMD128-FAST-NEXT:    i32.const $push131=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push20=, $pop19, $pop131
 ; NO-SIMD128-FAST-NEXT:    i32.const $push130=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push21=, $pop20, $pop130
 ; NO-SIMD128-FAST-NEXT:    i32.store8 2($0), $pop21
 ; NO-SIMD128-FAST-NEXT:    i32.const $push129=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $19, $pop129
+; NO-SIMD128-FAST-NEXT:    i32.and $push22=, $19, $pop129
 ; NO-SIMD128-FAST-NEXT:    i32.const $push128=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push22=, $27, $pop128
-; NO-SIMD128-FAST-NEXT:    i32.add $push24=, $pop23, $pop22
+; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $27, $pop128
+; NO-SIMD128-FAST-NEXT:    i32.add $push24=, $pop22, $pop23
 ; NO-SIMD128-FAST-NEXT:    i32.const $push127=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push25=, $pop24, $pop127
 ; NO-SIMD128-FAST-NEXT:    i32.const $push126=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push26=, $pop25, $pop126
 ; NO-SIMD128-FAST-NEXT:    i32.store8 5($0), $pop26
 ; NO-SIMD128-FAST-NEXT:    i32.const $push125=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push28=, $3, $pop125
+; NO-SIMD128-FAST-NEXT:    i32.and $push27=, $3, $pop125
 ; NO-SIMD128-FAST-NEXT:    i32.const $push124=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push27=, $11, $pop124
-; NO-SIMD128-FAST-NEXT:    i32.add $push29=, $pop28, $pop27
+; NO-SIMD128-FAST-NEXT:    i32.and $push28=, $11, $pop124
+; NO-SIMD128-FAST-NEXT:    i32.add $push29=, $pop27, $pop28
 ; NO-SIMD128-FAST-NEXT:    i32.const $push123=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push30=, $pop29, $pop123
 ; NO-SIMD128-FAST-NEXT:    i32.const $push122=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push31=, $pop30, $pop122
 ; NO-SIMD128-FAST-NEXT:    i32.store8 4($0), $pop31
 ; NO-SIMD128-FAST-NEXT:    i32.const $push121=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push33=, $20, $pop121
+; NO-SIMD128-FAST-NEXT:    i32.and $push32=, $20, $pop121
 ; NO-SIMD128-FAST-NEXT:    i32.const $push120=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push32=, $28, $pop120
-; NO-SIMD128-FAST-NEXT:    i32.add $push34=, $pop33, $pop32
+; NO-SIMD128-FAST-NEXT:    i32.and $push33=, $28, $pop120
+; NO-SIMD128-FAST-NEXT:    i32.add $push34=, $pop32, $pop33
 ; NO-SIMD128-FAST-NEXT:    i32.const $push119=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push35=, $pop34, $pop119
 ; NO-SIMD128-FAST-NEXT:    i32.const $push118=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push36=, $pop35, $pop118
 ; NO-SIMD128-FAST-NEXT:    i32.store8 7($0), $pop36
 ; NO-SIMD128-FAST-NEXT:    i32.const $push117=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push38=, $4, $pop117
+; NO-SIMD128-FAST-NEXT:    i32.and $push37=, $4, $pop117
 ; NO-SIMD128-FAST-NEXT:    i32.const $push116=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push37=, $12, $pop116
-; NO-SIMD128-FAST-NEXT:    i32.add $push39=, $pop38, $pop37
+; NO-SIMD128-FAST-NEXT:    i32.and $push38=, $12, $pop116
+; NO-SIMD128-FAST-NEXT:    i32.add $push39=, $pop37, $pop38
 ; NO-SIMD128-FAST-NEXT:    i32.const $push115=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push40=, $pop39, $pop115
 ; NO-SIMD128-FAST-NEXT:    i32.const $push114=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push41=, $pop40, $pop114
 ; NO-SIMD128-FAST-NEXT:    i32.store8 6($0), $pop41
 ; NO-SIMD128-FAST-NEXT:    i32.const $push113=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push43=, $21, $pop113
+; NO-SIMD128-FAST-NEXT:    i32.and $push42=, $21, $pop113
 ; NO-SIMD128-FAST-NEXT:    i32.const $push112=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push42=, $29, $pop112
-; NO-SIMD128-FAST-NEXT:    i32.add $push44=, $pop43, $pop42
+; NO-SIMD128-FAST-NEXT:    i32.and $push43=, $29, $pop112
+; NO-SIMD128-FAST-NEXT:    i32.add $push44=, $pop42, $pop43
 ; NO-SIMD128-FAST-NEXT:    i32.const $push111=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push45=, $pop44, $pop111
 ; NO-SIMD128-FAST-NEXT:    i32.const $push110=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push46=, $pop45, $pop110
 ; NO-SIMD128-FAST-NEXT:    i32.store8 9($0), $pop46
 ; NO-SIMD128-FAST-NEXT:    i32.const $push109=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push48=, $5, $pop109
+; NO-SIMD128-FAST-NEXT:    i32.and $push47=, $5, $pop109
 ; NO-SIMD128-FAST-NEXT:    i32.const $push108=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push47=, $13, $pop108
-; NO-SIMD128-FAST-NEXT:    i32.add $push49=, $pop48, $pop47
+; NO-SIMD128-FAST-NEXT:    i32.and $push48=, $13, $pop108
+; NO-SIMD128-FAST-NEXT:    i32.add $push49=, $pop47, $pop48
 ; NO-SIMD128-FAST-NEXT:    i32.const $push107=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push50=, $pop49, $pop107
 ; NO-SIMD128-FAST-NEXT:    i32.const $push106=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push51=, $pop50, $pop106
 ; NO-SIMD128-FAST-NEXT:    i32.store8 8($0), $pop51
 ; NO-SIMD128-FAST-NEXT:    i32.const $push105=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push53=, $22, $pop105
+; NO-SIMD128-FAST-NEXT:    i32.and $push52=, $22, $pop105
 ; NO-SIMD128-FAST-NEXT:    i32.const $push104=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push52=, $30, $pop104
-; NO-SIMD128-FAST-NEXT:    i32.add $push54=, $pop53, $pop52
+; NO-SIMD128-FAST-NEXT:    i32.and $push53=, $30, $pop104
+; NO-SIMD128-FAST-NEXT:    i32.add $push54=, $pop52, $pop53
 ; NO-SIMD128-FAST-NEXT:    i32.const $push103=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push55=, $pop54, $pop103
 ; NO-SIMD128-FAST-NEXT:    i32.const $push102=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push56=, $pop55, $pop102
 ; NO-SIMD128-FAST-NEXT:    i32.store8 11($0), $pop56
 ; NO-SIMD128-FAST-NEXT:    i32.const $push101=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push58=, $6, $pop101
+; NO-SIMD128-FAST-NEXT:    i32.and $push57=, $6, $pop101
 ; NO-SIMD128-FAST-NEXT:    i32.const $push100=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push57=, $14, $pop100
-; NO-SIMD128-FAST-NEXT:    i32.add $push59=, $pop58, $pop57
+; NO-SIMD128-FAST-NEXT:    i32.and $push58=, $14, $pop100
+; NO-SIMD128-FAST-NEXT:    i32.add $push59=, $pop57, $pop58
 ; NO-SIMD128-FAST-NEXT:    i32.const $push99=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push60=, $pop59, $pop99
 ; NO-SIMD128-FAST-NEXT:    i32.const $push98=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push61=, $pop60, $pop98
 ; NO-SIMD128-FAST-NEXT:    i32.store8 10($0), $pop61
 ; NO-SIMD128-FAST-NEXT:    i32.const $push97=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push63=, $23, $pop97
+; NO-SIMD128-FAST-NEXT:    i32.and $push62=, $23, $pop97
 ; NO-SIMD128-FAST-NEXT:    i32.const $push96=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push62=, $31, $pop96
-; NO-SIMD128-FAST-NEXT:    i32.add $push64=, $pop63, $pop62
+; NO-SIMD128-FAST-NEXT:    i32.and $push63=, $31, $pop96
+; NO-SIMD128-FAST-NEXT:    i32.add $push64=, $pop62, $pop63
 ; NO-SIMD128-FAST-NEXT:    i32.const $push95=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push65=, $pop64, $pop95
 ; NO-SIMD128-FAST-NEXT:    i32.const $push94=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push66=, $pop65, $pop94
 ; NO-SIMD128-FAST-NEXT:    i32.store8 13($0), $pop66
 ; NO-SIMD128-FAST-NEXT:    i32.const $push93=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push68=, $7, $pop93
+; NO-SIMD128-FAST-NEXT:    i32.and $push67=, $7, $pop93
 ; NO-SIMD128-FAST-NEXT:    i32.const $push92=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push67=, $15, $pop92
-; NO-SIMD128-FAST-NEXT:    i32.add $push69=, $pop68, $pop67
+; NO-SIMD128-FAST-NEXT:    i32.and $push68=, $15, $pop92
+; NO-SIMD128-FAST-NEXT:    i32.add $push69=, $pop67, $pop68
 ; NO-SIMD128-FAST-NEXT:    i32.const $push91=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push70=, $pop69, $pop91
 ; NO-SIMD128-FAST-NEXT:    i32.const $push90=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push71=, $pop70, $pop90
 ; NO-SIMD128-FAST-NEXT:    i32.store8 12($0), $pop71
 ; NO-SIMD128-FAST-NEXT:    i32.const $push89=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push73=, $24, $pop89
+; NO-SIMD128-FAST-NEXT:    i32.and $push72=, $24, $pop89
 ; NO-SIMD128-FAST-NEXT:    i32.const $push88=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push72=, $32, $pop88
-; NO-SIMD128-FAST-NEXT:    i32.add $push74=, $pop73, $pop72
+; NO-SIMD128-FAST-NEXT:    i32.and $push73=, $32, $pop88
+; NO-SIMD128-FAST-NEXT:    i32.add $push74=, $pop72, $pop73
 ; NO-SIMD128-FAST-NEXT:    i32.const $push87=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push75=, $pop74, $pop87
 ; NO-SIMD128-FAST-NEXT:    i32.const $push86=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.shr_u $push76=, $pop75, $pop86
 ; NO-SIMD128-FAST-NEXT:    i32.store8 15($0), $pop76
 ; NO-SIMD128-FAST-NEXT:    i32.const $push85=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push78=, $8, $pop85
+; NO-SIMD128-FAST-NEXT:    i32.and $push77=, $8, $pop85
 ; NO-SIMD128-FAST-NEXT:    i32.const $push84=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push77=, $16, $pop84
-; NO-SIMD128-FAST-NEXT:    i32.add $push79=, $pop78, $pop77
+; NO-SIMD128-FAST-NEXT:    i32.and $push78=, $16, $pop84
+; NO-SIMD128-FAST-NEXT:    i32.add $push79=, $pop77, $pop78
 ; NO-SIMD128-FAST-NEXT:    i32.const $push83=, 1
 ; NO-SIMD128-FAST-NEXT:    i32.add $push80=, $pop79, $pop83
 ; NO-SIMD128-FAST-NEXT:    i32.const $push82=, 1
@@ -5579,100 +5579,100 @@ define <16 x i8> @bitselect_xor_reversed_v16i8(<16 x i8> %c, <16 x i8> %v1, <16 
 ; NO-SIMD128-LABEL: bitselect_xor_reversed_v16i8:
 ; NO-SIMD128:         .functype bitselect_xor_reversed_v16i8 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    i32.xor $push2=, $32, $48
-; NO-SIMD128-NEXT:    i32.const $push0=, -1
-; NO-SIMD128-NEXT:    i32.xor $push1=, $16, $pop0
-; NO-SIMD128-NEXT:    i32.and $push3=, $pop2, $pop1
+; NO-SIMD128-NEXT:    i32.xor $push0=, $32, $48
+; NO-SIMD128-NEXT:    i32.const $push1=, -1
+; NO-SIMD128-NEXT:    i32.xor $push2=, $16, $pop1
+; NO-SIMD128-NEXT:    i32.and $push3=, $pop0, $pop2
 ; NO-SIMD128-NEXT:    i32.xor $push4=, $pop3, $48
 ; NO-SIMD128-NEXT:    i32.store8 15($0), $pop4
-; NO-SIMD128-NEXT:    i32.xor $push6=, $31, $47
+; NO-SIMD128-NEXT:    i32.xor $push5=, $31, $47
 ; NO-SIMD128-NEXT:    i32.const $push79=, -1
-; NO-SIMD128-NEXT:    i32.xor $push5=, $15, $pop79
-; NO-SIMD128-NEXT:    i32.and $push7=, $pop6, $pop5
+; NO-SIMD128-NEXT:    i32.xor $push6=, $15, $pop79
+; NO-SIMD128-NEXT:    i32.and $push7=, $pop5, $pop6
 ; NO-SIMD128-NEXT:    i32.xor $push8=, $pop7, $47
 ; NO-SIMD128-NEXT:    i32.store8 14($0), $pop8
-; NO-SIMD128-NEXT:    i32.xor $push10=, $30, $46
+; NO-SIMD128-NEXT:    i32.xor $push9=, $30, $46
 ; NO-SIMD128-NEXT:    i32.const $push78=, -1
-; NO-SIMD128-NEXT:    i32.xor $push9=, $14, $pop78
-; NO-SIMD128-NEXT:    i32.and $push11=, $pop10, $pop9
+; NO-SIMD128-NEXT:    i32.xor $push10=, $14, $pop78
+; NO-SIMD128-NEXT:    i32.and $push11=, $pop9, $pop10
 ; NO-SIMD128-NEXT:    i32.xor $push12=, $pop11, $46
 ; NO-SIMD128-NEXT:    i32.store8 13($0), $pop12
-; NO-SIMD128-NEXT:    i32.xor $push14=, $29, $45
+; NO-SIMD128-NEXT:    i32.xor $push13=, $29, $45
 ; NO-SIMD128-NEXT:    i32.const $push77=, -1
-; NO-SIMD128-NEXT:    i32.xor $push13=, $13, $pop77
-; NO-SIMD128-NEXT:    i32.and $push15=, $pop14, $pop13
+; NO-SIMD128-NEXT:    i32.xor $push14=, $13, $pop77
+; NO-SIMD128-NEXT:    i32.and $push15=, $pop13, $pop14
 ; NO-SIMD128-NEXT:    i32.xor $push16=, $pop15, $45
 ; NO-SIMD128-NEXT:    i32.store8 12($0), $pop16
-; NO-SIMD128-NEXT:    i32.xor $push18=, $28, $44
+; NO-SIMD128-NEXT:    i32.xor $push17=, $28, $44
 ; NO-SIMD128-NEXT:    i32.const $push76=, -1
-; NO-SIMD128-NEXT:    i32.xor $push17=, $12, $pop76
-; NO-SIMD128-NEXT:    i32.and $push19=, $pop18, $pop17
+; NO-SIMD128-NEXT:    i32.xor $push18=, $12, $pop76
+; NO-SIMD128-NEXT:    i32.and $push19=, $pop17, $pop18
 ; NO-SIMD128-NEXT:    i32.xor $push20=, $pop19, $44
 ; NO-SIMD128-NEXT:    i32.store8 11($0), $pop20
-; NO-SIMD128-NEXT:    i32.xor $push22=, $27, $43
+; NO-SIMD128-NEXT:    i32.xor $push21=, $27, $43
 ; NO-SIMD128-NEXT:    i32.const $push75=, -1
-; NO-SIMD128-NEXT:    i32.xor $push21=, $11, $pop75
-; NO-SIMD128-NEXT:    i32.and $push23=, $pop22, $pop21
+; NO-SIMD128-NEXT:    i32.xor $push22=, $11, $pop75
+; NO-SIMD128-NEXT:    i32.and $push23=, $pop21, $pop22
 ; NO-SIMD128-NEXT:    i32.xor $push24=, $pop23, $43
 ; NO-SIMD128-NEXT:    i32.store8 10($0), $pop24
-; NO-SIMD128-NEXT:    i32.xor $push26=, $26, $42
+; NO-SIMD128-NEXT:    i32.xor $push25=, $26, $42
 ; NO-SIMD128-NEXT:    i32.const $push74=, -1
-; NO-SIMD128-NEXT:    i32.xor $push25=, $10, $pop74
-; NO-SIMD128-NEXT:    i32.and $push27=, $pop26, $pop25
+; NO-SIMD128-NEXT:    i32.xor $push26=, $10, $pop74
+; NO-SIMD128-NEXT:    i32.and $push27=, $pop25, $pop26
 ; NO-SIMD128-NEXT:    i32.xor $push28=, $pop27, $42
 ; NO-SIMD128-NEXT:    i32.store8 9($0), $pop28
-; NO-SIMD128-NEXT:    i32.xor $push30=, $25, $41
+; NO-SIMD128-NEXT:    i32.xor $push29=, $25, $41
 ; NO-SIMD128-NEXT:    i32.const $push73=, -1
-; NO-SIMD128-NEXT:    i32.xor $push29=, $9, $pop73
-; NO-SIMD128-NEXT:    i32.and $push31=, $pop30, $pop29
+; NO-SIMD128-NEXT:    i32.xor $push30=, $9, $pop73
+; NO-SIMD128-NEXT:    i32.and $push31=, $pop29, $pop30
 ; NO-SIMD128-NEXT:    i32.xor $push32=, $pop31, $41
 ; NO-SIMD128-NEXT:    i32.store8 8($0), $pop32
-; NO-SIMD128-NEXT:    i32.xor $push34=, $24, $40
+; NO-SIMD128-NEXT:    i32.xor $push33=, $24, $40
 ; NO-SIMD128-NEXT:    i32.const $push72=, -1
-; NO-SIMD128-NEXT:    i32.xor $push33=, $8, $pop72
-; NO-SIMD128-NEXT:    i32.and $push35=, $pop34, $pop33
+; NO-SIMD128-NEXT:    i32.xor $push34=, $8, $pop72
+; NO-SIMD128-NEXT:    i32.and $push35=, $pop33, $pop34
 ; NO-SIMD128-NEXT:    i32.xor $push36=, $pop35, $40
 ; NO-SIMD128-NEXT:    i32.store8 7($0), $pop36
-; NO-SIMD128-NEXT:    i32.xor $push38=, $23, $39
+; NO-SIMD128-NEXT:    i32.xor $push37=, $23, $39
 ; NO-SIMD128-NEXT:    i32.const $push71=, -1
-; NO-SIMD128-NEXT:    i32.xor $push37=, $7, $pop71
-; NO-SIMD128-NEXT:    i32.and $push39=, $pop38, $pop37
+; NO-SIMD128-NEXT:    i32.xor $push38=, $7, $pop71
+; NO-SIMD128-NEXT:    i32.and $push39=, $pop37, $pop38
 ; NO-SIMD128-NEXT:    i32.xor $push40=, $pop39, $39
 ; NO-SIMD128-NEXT:    i32.store8 6($0), $pop40
-; NO-SIMD128-NEXT:    i32.xor $push42=, $22, $38
+; NO-SIMD128-NEXT:    i32.xor $push41=, $22, $38
 ; NO-SIMD128-NEXT:    i32.const $push70=, -1
-; NO-SIMD128-NEXT:    i32.xor $push41=, $6, $pop70
-; NO-SIMD128-NEXT:    i32.and $push43=, $pop42, $pop41
+; NO-SIMD128-NEXT:    i32.xor $push42=, $6, $pop70
+; NO-SIMD128-NEXT:    i32.and $push43=, $pop41, $pop42
 ; NO-SIMD128-NEXT:    i32.xor $push44=, $pop43, $38
 ; NO-SIMD128-NEXT:    i32.store8 5($0), $pop44
-; NO-SIMD128-NEXT:    i32.xor $push46=, $21, $37
+; NO-SIMD128-NEXT:    i32.xor $push45=, $21, $37
 ; NO-SIMD128-NEXT:    i32.const $push69=, -1
-; NO-SIMD128-NEXT:    i32.xor $push45=, $5, $pop69
-; NO-SIMD128-NEXT:    i32.and $push47=, $pop46, $pop45
+; NO-SIMD128-NEXT:    i32.xor $push46=, $5, $pop69
+; NO-SIMD128-NEXT:    i32.and $push47=, $pop45, $pop46
 ; NO-SIMD128-NEXT:    i32.xor $push48=, $pop47, $37
 ; NO-SIMD128-NEXT:    i32.store8 4($0), $pop48
-; NO-SIMD128-NEXT:    i32.xor $push50=, $20, $36
+; NO-SIMD128-NEXT:    i32.xor $push49=, $20, $36
 ; NO-SIMD128-NEXT:    i32.const $push68=, -1
-; NO-SIMD128-NEXT:    i32.xor $push49=, $4, $pop68
-; NO-SIMD128-NEXT:    i32.and $push51=, $pop50, $pop49
+; NO-SIMD128-NEXT:    i32.xor $push50=, $4, $pop68
+; NO-SIMD128-NEXT:    i32.and $push51=, $pop49, $pop50
 ; NO-SIMD128-NEXT:    i32.xor $push52=, $pop51, $36
 ; NO-SIMD128-NEXT:    i32.store8 3($0), $pop52
-; NO-SIMD128-NEXT:    i32.xor $push54=, $19, $35
+; NO-SIMD128-NEXT:    i32.xor $push53=, $19, $35
 ; NO-SIMD128-NEXT:    i32.const $push67=, -1
-; NO-SIMD128-NEXT:    i32.xor $push53=, $3, $pop67
-; NO-SIMD128-NEXT:    i32.and $push55=, $pop54, $pop53
+; NO-SIMD128-NEXT:    i32.xor $push54=, $3, $pop67
+; NO-SIMD128-NEXT:    i32.and $push55=, $pop53, $pop54
 ; NO-SIMD128-NEXT:    i32.xor $push56=, $pop55, $35
 ; NO-SIMD128-NEXT:    i32.store8 2($0), $pop56
-; NO-SIMD128-NEXT:    i32.xor $push58=, $18, $34
+; NO-SIMD128-NEXT:    i32.xor $push57=, $18, $34
 ; NO-SIMD128-NEXT:    i32.const $push66=, -1
-; NO-SIMD128-NEXT:    i32.xor $push57=, $2, $pop66
-; NO-SIMD128-NEXT:    i32.and $push59=, $pop58, $pop57
+; NO-SIMD128-NEXT:    i32.xor $push58=, $2, $pop66
+; NO-SIMD128-NEXT:    i32.and $push59=, $pop57, $pop58
 ; NO-SIMD128-NEXT:    i32.xor $push60=, $pop59, $34
 ; NO-SIMD128-NEXT:    i32.store8 1($0), $pop60
-; NO-SIMD128-NEXT:    i32.xor $push62=, $17, $33
+; NO-SIMD128-NEXT:    i32.xor $push61=, $17, $33
 ; NO-SIMD128-NEXT:    i32.const $push65=, -1
-; NO-SIMD128-NEXT:    i32.xor $push61=, $1, $pop65
-; NO-SIMD128-NEXT:    i32.and $push63=, $pop62, $pop61
+; NO-SIMD128-NEXT:    i32.xor $push62=, $1, $pop65
+; NO-SIMD128-NEXT:    i32.and $push63=, $pop61, $pop62
 ; NO-SIMD128-NEXT:    i32.xor $push64=, $pop63, $33
 ; NO-SIMD128-NEXT:    i32.store8 0($0), $pop64
 ; NO-SIMD128-NEXT:    return
@@ -5680,100 +5680,100 @@ define <16 x i8> @bitselect_xor_reversed_v16i8(<16 x i8> %c, <16 x i8> %v1, <16 
 ; NO-SIMD128-FAST-LABEL: bitselect_xor_reversed_v16i8:
 ; NO-SIMD128-FAST:         .functype bitselect_xor_reversed_v16i8 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    i32.xor $push2=, $17, $33
-; NO-SIMD128-FAST-NEXT:    i32.const $push0=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push1=, $1, $pop0
-; NO-SIMD128-FAST-NEXT:    i32.and $push3=, $pop2, $pop1
+; NO-SIMD128-FAST-NEXT:    i32.xor $push0=, $17, $33
+; NO-SIMD128-FAST-NEXT:    i32.const $push1=, -1
+; NO-SIMD128-FAST-NEXT:    i32.xor $push2=, $1, $pop1
+; NO-SIMD128-FAST-NEXT:    i32.and $push3=, $pop0, $pop2
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push4=, $pop3, $33
 ; NO-SIMD128-FAST-NEXT:    i32.store8 0($0), $pop4
-; NO-SIMD128-FAST-NEXT:    i32.xor $push6=, $18, $34
+; NO-SIMD128-FAST-NEXT:    i32.xor $push5=, $18, $34
 ; NO-SIMD128-FAST-NEXT:    i32.const $push79=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push5=, $2, $pop79
-; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $pop6, $pop5
+; NO-SIMD128-FAST-NEXT:    i32.xor $push6=, $2, $pop79
+; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $pop5, $pop6
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push8=, $pop7, $34
 ; NO-SIMD128-FAST-NEXT:    i32.store8 1($0), $pop8
-; NO-SIMD128-FAST-NEXT:    i32.xor $push10=, $19, $35
+; NO-SIMD128-FAST-NEXT:    i32.xor $push9=, $19, $35
 ; NO-SIMD128-FAST-NEXT:    i32.const $push78=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push9=, $3, $pop78
-; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $pop10, $pop9
+; NO-SIMD128-FAST-NEXT:    i32.xor $push10=, $3, $pop78
+; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $pop9, $pop10
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push12=, $pop11, $35
 ; NO-SIMD128-FAST-NEXT:    i32.store8 2($0), $pop12
-; NO-SIMD128-FAST-NEXT:    i32.xor $push14=, $20, $36
+; NO-SIMD128-FAST-NEXT:    i32.xor $push13=, $20, $36
 ; NO-SIMD128-FAST-NEXT:    i32.const $push77=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push13=, $4, $pop77
-; NO-SIMD128-FAST-NEXT:    i32.and $push15=, $pop14, $pop13
+; NO-SIMD128-FAST-NEXT:    i32.xor $push14=, $4, $pop77
+; NO-SIMD128-FAST-NEXT:    i32.and $push15=, $pop13, $pop14
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push16=, $pop15, $36
 ; NO-SIMD128-FAST-NEXT:    i32.store8 3($0), $pop16
-; NO-SIMD128-FAST-NEXT:    i32.xor $push18=, $21, $37
+; NO-SIMD128-FAST-NEXT:    i32.xor $push17=, $21, $37
 ; NO-SIMD128-FAST-NEXT:    i32.const $push76=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push17=, $5, $pop76
-; NO-SIMD128-FAST-NEXT:    i32.and $push19=, $pop18, $pop17
+; NO-SIMD128-FAST-NEXT:    i32.xor $push18=, $5, $pop76
+; NO-SIMD128-FAST-NEXT:    i32.and $push19=, $pop17, $pop18
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push20=, $pop19, $37
 ; NO-SIMD128-FAST-NEXT:    i32.store8 4($0), $pop20
-; NO-SIMD128-FAST-NEXT:    i32.xor $push22=, $22, $38
+; NO-SIMD128-FAST-NEXT:    i32.xor $push21=, $22, $38
 ; NO-SIMD128-FAST-NEXT:    i32.const $push75=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push21=, $6, $pop75
-; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $pop22, $pop21
+; NO-SIMD128-FAST-NEXT:    i32.xor $push22=, $6, $pop75
+; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $pop21, $pop22
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push24=, $pop23, $38
 ; NO-SIMD128-FAST-NEXT:    i32.store8 5($0), $pop24
-; NO-SIMD128-FAST-NEXT:    i32.xor $push26=, $23, $39
+; NO-SIMD128-FAST-NEXT:    i32.xor $push25=, $23, $39
 ; NO-SIMD128-FAST-NEXT:    i32.const $push74=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push25=, $7, $pop74
-; NO-SIMD128-FAST-NEXT:    i32.and $push27=, $pop26, $pop25
+; NO-SIMD128-FAST-NEXT:    i32.xor $push26=, $7, $pop74
+; NO-SIMD128-FAST-NEXT:    i32.and $push27=, $pop25, $pop26
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push28=, $pop27, $39
 ; NO-SIMD128-FAST-NEXT:    i32.store8 6($0), $pop28
-; NO-SIMD128-FAST-NEXT:    i32.xor $push30=, $24, $40
+; NO-SIMD128-FAST-NEXT:    i32.xor $push29=, $24, $40
 ; NO-SIMD128-FAST-NEXT:    i32.const $push73=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push29=, $8, $pop73
-; NO-SIMD128-FAST-NEXT:    i32.and $push31=, $pop30, $pop29
+; NO-SIMD128-FAST-NEXT:    i32.xor $push30=, $8, $pop73
+; NO-SIMD128-FAST-NEXT:    i32.and $push31=, $pop29, $pop30
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push32=, $pop31, $40
 ; NO-SIMD128-FAST-NEXT:    i32.store8 7($0), $pop32
-; NO-SIMD128-FAST-NEXT:    i32.xor $push34=, $25, $41
+; NO-SIMD128-FAST-NEXT:    i32.xor $push33=, $25, $41
 ; NO-SIMD128-FAST-NEXT:    i32.const $push72=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push33=, $9, $pop72
-; NO-SIMD128-FAST-NEXT:    i32.and $push35=, $pop34, $pop33
+; NO-SIMD128-FAST-NEXT:    i32.xor $push34=, $9, $pop72
+; NO-SIMD128-FAST-NEXT:    i32.and $push35=, $pop33, $pop34
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push36=, $pop35, $41
 ; NO-SIMD128-FAST-NEXT:    i32.store8 8($0), $pop36
-; NO-SIMD128-FAST-NEXT:    i32.xor $push38=, $26, $42
+; NO-SIMD128-FAST-NEXT:    i32.xor $push37=, $26, $42
 ; NO-SIMD128-FAST-NEXT:    i32.const $push71=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push37=, $10, $pop71
-; NO-SIMD128-FAST-NEXT:    i32.and $push39=, $pop38, $pop37
+; NO-SIMD128-FAST-NEXT:    i32.xor $push38=, $10, $pop71
+; NO-SIMD128-FAST-NEXT:    i32.and $push39=, $pop37, $pop38
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push40=, $pop39, $42
 ; NO-SIMD128-FAST-NEXT:    i32.store8 9($0), $pop40
-; NO-SIMD128-FAST-NEXT:    i32.xor $push42=, $27, $43
+; NO-SIMD128-FAST-NEXT:    i32.xor $push41=, $27, $43
 ; NO-SIMD128-FAST-NEXT:    i32.const $push70=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push41=, $11, $pop70
-; NO-SIMD128-FAST-NEXT:    i32.and $push43=, $pop42, $pop41
+; NO-SIMD128-FAST-NEXT:    i32.xor $push42=, $11, $pop70
+; NO-SIMD128-FAST-NEXT:    i32.and $push43=, $pop41, $pop42
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push44=, $pop43, $43
 ; NO-SIMD128-FAST-NEXT:    i32.store8 10($0), $pop44
-; NO-SIMD128-FAST-NEXT:    i32.xor $push46=, $28, $44
+; NO-SIMD128-FAST-NEXT:    i32.xor $push45=, $28, $44
 ; NO-SIMD128-FAST-NEXT:    i32.const $push69=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push45=, $12, $pop69
-; NO-SIMD128-FAST-NEXT:    i32.and $push47=, $pop46, $pop45
+; NO-SIMD128-FAST-NEXT:    i32.xor $push46=, $12, $pop69
+; NO-SIMD128-FAST-NEXT:    i32.and $push47=, $pop45, $pop46
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push48=, $pop47, $44
 ; NO-SIMD128-FAST-NEXT:    i32.store8 11($0), $pop48
-; NO-SIMD128-FAST-NEXT:    i32.xor $push50=, $29, $45
+; NO-SIMD128-FAST-NEXT:    i32.xor $push49=, $29, $45
 ; NO-SIMD128-FAST-NEXT:    i32.const $push68=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push49=, $13, $pop68
-; NO-SIMD128-FAST-NEXT:    i32.and $push51=, $pop50, $pop49
+; NO-SIMD128-FAST-NEXT:    i32.xor $push50=, $13, $pop68
+; NO-SIMD128-FAST-NEXT:    i32.and $push51=, $pop49, $pop50
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push52=, $pop51, $45
 ; NO-SIMD128-FAST-NEXT:    i32.store8 12($0), $pop52
-; NO-SIMD128-FAST-NEXT:    i32.xor $push54=, $30, $46
+; NO-SIMD128-FAST-NEXT:    i32.xor $push53=, $30, $46
 ; NO-SIMD128-FAST-NEXT:    i32.const $push67=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push53=, $14, $pop67
-; NO-SIMD128-FAST-NEXT:    i32.and $push55=, $pop54, $pop53
+; NO-SIMD128-FAST-NEXT:    i32.xor $push54=, $14, $pop67
+; NO-SIMD128-FAST-NEXT:    i32.and $push55=, $pop53, $pop54
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push56=, $pop55, $46
 ; NO-SIMD128-FAST-NEXT:    i32.store8 13($0), $pop56
-; NO-SIMD128-FAST-NEXT:    i32.xor $push58=, $31, $47
+; NO-SIMD128-FAST-NEXT:    i32.xor $push57=, $31, $47
 ; NO-SIMD128-FAST-NEXT:    i32.const $push66=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push57=, $15, $pop66
-; NO-SIMD128-FAST-NEXT:    i32.and $push59=, $pop58, $pop57
+; NO-SIMD128-FAST-NEXT:    i32.xor $push58=, $15, $pop66
+; NO-SIMD128-FAST-NEXT:    i32.and $push59=, $pop57, $pop58
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push60=, $pop59, $47
 ; NO-SIMD128-FAST-NEXT:    i32.store8 14($0), $pop60
-; NO-SIMD128-FAST-NEXT:    i32.xor $push62=, $32, $48
+; NO-SIMD128-FAST-NEXT:    i32.xor $push61=, $32, $48
 ; NO-SIMD128-FAST-NEXT:    i32.const $push65=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push61=, $16, $pop65
-; NO-SIMD128-FAST-NEXT:    i32.and $push63=, $pop62, $pop61
+; NO-SIMD128-FAST-NEXT:    i32.xor $push62=, $16, $pop65
+; NO-SIMD128-FAST-NEXT:    i32.and $push63=, $pop61, $pop62
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push64=, $pop63, $48
 ; NO-SIMD128-FAST-NEXT:    i32.store8 15($0), $pop64
 ; NO-SIMD128-FAST-NEXT:    return
@@ -8468,52 +8468,52 @@ define <8 x i16> @bitselect_xor_reversed_v8i16(<8 x i16> %c, <8 x i16> %v1, <8 x
 ; NO-SIMD128-LABEL: bitselect_xor_reversed_v8i16:
 ; NO-SIMD128:         .functype bitselect_xor_reversed_v8i16 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    i32.xor $push2=, $16, $24
-; NO-SIMD128-NEXT:    i32.const $push0=, -1
-; NO-SIMD128-NEXT:    i32.xor $push1=, $8, $pop0
-; NO-SIMD128-NEXT:    i32.and $push3=, $pop2, $pop1
+; NO-SIMD128-NEXT:    i32.xor $push0=, $16, $24
+; NO-SIMD128-NEXT:    i32.const $push1=, -1
+; NO-SIMD128-NEXT:    i32.xor $push2=, $8, $pop1
+; NO-SIMD128-NEXT:    i32.and $push3=, $pop0, $pop2
 ; NO-SIMD128-NEXT:    i32.xor $push4=, $pop3, $24
 ; NO-SIMD128-NEXT:    i32.store16 14($0), $pop4
-; NO-SIMD128-NEXT:    i32.xor $push6=, $15, $23
+; NO-SIMD128-NEXT:    i32.xor $push5=, $15, $23
 ; NO-SIMD128-NEXT:    i32.const $push39=, -1
-; NO-SIMD128-NEXT:    i32.xor $push5=, $7, $pop39
-; NO-SIMD128-NEXT:    i32.and $push7=, $pop6, $pop5
+; NO-SIMD128-NEXT:    i32.xor $push6=, $7, $pop39
+; NO-SIMD128-NEXT:    i32.and $push7=, $pop5, $pop6
 ; NO-SIMD128-NEXT:    i32.xor $push8=, $pop7, $23
 ; NO-SIMD128-NEXT:    i32.store16 12($0), $pop8
-; NO-SIMD128-NEXT:    i32.xor $push10=, $14, $22
+; NO-SIMD128-NEXT:    i32.xor $push9=, $14, $22
 ; NO-SIMD128-NEXT:    i32.const $push38=, -1
-; NO-SIMD128-NEXT:    i32.xor $push9=, $6, $pop38
-; NO-SIMD128-NEXT:    i32.and $push11=, $pop10, $pop9
+; NO-SIMD128-NEXT:    i32.xor $push10=, $6, $pop38
+; NO-SIMD128-NEXT:    i32.and $push11=, $pop9, $pop10
 ; NO-SIMD128-NEXT:    i32.xor $push12=, $pop11, $22
 ; NO-SIMD128-NEXT:    i32.store16 10($0), $pop12
-; NO-SIMD128-NEXT:    i32.xor $push14=, $13, $21
+; NO-SIMD128-NEXT:    i32.xor $push13=, $13, $21
 ; NO-SIMD128-NEXT:    i32.const $push37=, -1
-; NO-SIMD128-NEXT:    i32.xor $push13=, $5, $pop37
-; NO-SIMD128-NEXT:    i32.and $push15=, $pop14, $pop13
+; NO-SIMD128-NEXT:    i32.xor $push14=, $5, $pop37
+; NO-SIMD128-NEXT:    i32.and $push15=, $pop13, $pop14
 ; NO-SIMD128-NEXT:    i32.xor $push16=, $pop15, $21
 ; NO-SIMD128-NEXT:    i32.store16 8($0), $pop16
-; NO-SIMD128-NEXT:    i32.xor $push18=, $12, $20
+; NO-SIMD128-NEXT:    i32.xor $push17=, $12, $20
 ; NO-SIMD128-NEXT:    i32.const $push36=, -1
-; NO-SIMD128-NEXT:    i32.xor $push17=, $4, $pop36
-; NO-SIMD128-NEXT:    i32.and $push19=, $pop18, $pop17
+; NO-SIMD128-NEXT:    i32.xor $push18=, $4, $pop36
+; NO-SIMD128-NEXT:    i32.and $push19=, $pop17, $pop18
 ; NO-SIMD128-NEXT:    i32.xor $push20=, $pop19, $20
 ; NO-SIMD128-NEXT:    i32.store16 6($0), $pop20
-; NO-SIMD128-NEXT:    i32.xor $push22=, $11, $19
+; NO-SIMD128-NEXT:    i32.xor $push21=, $11, $19
 ; NO-SIMD128-NEXT:    i32.const $push35=, -1
-; NO-SIMD128-NEXT:    i32.xor $push21=, $3, $pop35
-; NO-SIMD128-NEXT:    i32.and $push23=, $pop22, $pop21
+; NO-SIMD128-NEXT:    i32.xor $push22=, $3, $pop35
+; NO-SIMD128-NEXT:    i32.and $push23=, $pop21, $pop22
 ; NO-SIMD128-NEXT:    i32.xor $push24=, $pop23, $19
 ; NO-SIMD128-NEXT:    i32.store16 4($0), $pop24
-; NO-SIMD128-NEXT:    i32.xor $push26=, $10, $18
+; NO-SIMD128-NEXT:    i32.xor $push25=, $10, $18
 ; NO-SIMD128-NEXT:    i32.const $push34=, -1
-; NO-SIMD128-NEXT:    i32.xor $push25=, $2, $pop34
-; NO-SIMD128-NEXT:    i32.and $push27=, $pop26, $pop25
+; NO-SIMD128-NEXT:    i32.xor $push26=, $2, $pop34
+; NO-SIMD128-NEXT:    i32.and $push27=, $pop25, $pop26
 ; NO-SIMD128-NEXT:    i32.xor $push28=, $pop27, $18
 ; NO-SIMD128-NEXT:    i32.store16 2($0), $pop28
-; NO-SIMD128-NEXT:    i32.xor $push30=, $9, $17
+; NO-SIMD128-NEXT:    i32.xor $push29=, $9, $17
 ; NO-SIMD128-NEXT:    i32.const $push33=, -1
-; NO-SIMD128-NEXT:    i32.xor $push29=, $1, $pop33
-; NO-SIMD128-NEXT:    i32.and $push31=, $pop30, $pop29
+; NO-SIMD128-NEXT:    i32.xor $push30=, $1, $pop33
+; NO-SIMD128-NEXT:    i32.and $push31=, $pop29, $pop30
 ; NO-SIMD128-NEXT:    i32.xor $push32=, $pop31, $17
 ; NO-SIMD128-NEXT:    i32.store16 0($0), $pop32
 ; NO-SIMD128-NEXT:    return
@@ -8521,52 +8521,52 @@ define <8 x i16> @bitselect_xor_reversed_v8i16(<8 x i16> %c, <8 x i16> %v1, <8 x
 ; NO-SIMD128-FAST-LABEL: bitselect_xor_reversed_v8i16:
 ; NO-SIMD128-FAST:         .functype bitselect_xor_reversed_v8i16 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    i32.xor $push2=, $9, $17
-; NO-SIMD128-FAST-NEXT:    i32.const $push0=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push1=, $1, $pop0
-; NO-SIMD128-FAST-NEXT:    i32.and $push3=, $pop2, $pop1
+; NO-SIMD128-FAST-NEXT:    i32.xor $push0=, $9, $17
+; NO-SIMD128-FAST-NEXT:    i32.const $push1=, -1
+; NO-SIMD128-FAST-NEXT:    i32.xor $push2=, $1, $pop1
+; NO-SIMD128-FAST-NEXT:    i32.and $push3=, $pop0, $pop2
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push4=, $pop3, $17
 ; NO-SIMD128-FAST-NEXT:    i32.store16 0($0), $pop4
-; NO-SIMD128-FAST-NEXT:    i32.xor $push6=, $10, $18
+; NO-SIMD128-FAST-NEXT:    i32.xor $push5=, $10, $18
 ; NO-SIMD128-FAST-NEXT:    i32.const $push39=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push5=, $2, $pop39
-; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $pop6, $pop5
+; NO-SIMD128-FAST-NEXT:    i32.xor $push6=, $2, $pop39
+; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $pop5, $pop6
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push8=, $pop7, $18
 ; NO-SIMD128-FAST-NEXT:    i32.store16 2($0), $pop8
-; NO-SIMD128-FAST-NEXT:    i32.xor $push10=, $11, $19
+; NO-SIMD128-FAST-NEXT:    i32.xor $push9=, $11, $19
 ; NO-SIMD128-FAST-NEXT:    i32.const $push38=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push9=, $3, $pop38
-; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $pop10, $pop9
+; NO-SIMD128-FAST-NEXT:    i32.xor $push10=, $3, $pop38
+; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $pop9, $pop10
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push12=, $pop11, $19
 ; NO-SIMD128-FAST-NEXT:    i32.store16 4($0), $pop12
-; NO-SIMD128-FAST-NEXT:    i32.xor $push14=, $12, $20
+; NO-SIMD128-FAST-NEXT:    i32.xor $push13=, $12, $20
 ; NO-SIMD128-FAST-NEXT:    i32.const $push37=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push13=, $4, $pop37
-; NO-SIMD128-FAST-NEXT:    i32.and $push15=, $pop14, $pop13
+; NO-SIMD128-FAST-NEXT:    i32.xor $push14=, $4, $pop37
+; NO-SIMD128-FAST-NEXT:    i32.and $push15=, $pop13, $pop14
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push16=, $pop15, $20
 ; NO-SIMD128-FAST-NEXT:    i32.store16 6($0), $pop16
-; NO-SIMD128-FAST-NEXT:    i32.xor $push18=, $13, $21
+; NO-SIMD128-FAST-NEXT:    i32.xor $push17=, $13, $21
 ; NO-SIMD128-FAST-NEXT:    i32.const $push36=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push17=, $5, $pop36
-; NO-SIMD128-FAST-NEXT:    i32.and $push19=, $pop18, $pop17
+; NO-SIMD128-FAST-NEXT:    i32.xor $push18=, $5, $pop36
+; NO-SIMD128-FAST-NEXT:    i32.and $push19=, $pop17, $pop18
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push20=, $pop19, $21
 ; NO-SIMD128-FAST-NEXT:    i32.store16 8($0), $pop20
-; NO-SIMD128-FAST-NEXT:    i32.xor $push22=, $14, $22
+; NO-SIMD128-FAST-NEXT:    i32.xor $push21=, $14, $22
 ; NO-SIMD128-FAST-NEXT:    i32.const $push35=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push21=, $6, $pop35
-; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $pop22, $pop21
+; NO-SIMD128-FAST-NEXT:    i32.xor $push22=, $6, $pop35
+; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $pop21, $pop22
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push24=, $pop23, $22
 ; NO-SIMD128-FAST-NEXT:    i32.store16 10($0), $pop24
-; NO-SIMD128-FAST-NEXT:    i32.xor $push26=, $15, $23
+; NO-SIMD128-FAST-NEXT:    i32.xor $push25=, $15, $23
 ; NO-SIMD128-FAST-NEXT:    i32.const $push34=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push25=, $7, $pop34
-; NO-SIMD128-FAST-NEXT:    i32.and $push27=, $pop26, $pop25
+; NO-SIMD128-FAST-NEXT:    i32.xor $push26=, $7, $pop34
+; NO-SIMD128-FAST-NEXT:    i32.and $push27=, $pop25, $pop26
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push28=, $pop27, $23
 ; NO-SIMD128-FAST-NEXT:    i32.store16 12($0), $pop28
-; NO-SIMD128-FAST-NEXT:    i32.xor $push30=, $16, $24
+; NO-SIMD128-FAST-NEXT:    i32.xor $push29=, $16, $24
 ; NO-SIMD128-FAST-NEXT:    i32.const $push33=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push29=, $8, $pop33
-; NO-SIMD128-FAST-NEXT:    i32.and $push31=, $pop30, $pop29
+; NO-SIMD128-FAST-NEXT:    i32.xor $push30=, $8, $pop33
+; NO-SIMD128-FAST-NEXT:    i32.and $push31=, $pop29, $pop30
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push32=, $pop31, $24
 ; NO-SIMD128-FAST-NEXT:    i32.store16 14($0), $pop32
 ; NO-SIMD128-FAST-NEXT:    return
@@ -8596,74 +8596,74 @@ define <8 x i16> @extmul_low_s_v8i16(<16 x i8> %v1, <16 x i8> %v2) {
 ; NO-SIMD128-LABEL: extmul_low_s_v8i16:
 ; NO-SIMD128:         .functype extmul_low_s_v8i16 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    i32.extend8_s $push1=, $8
-; NO-SIMD128-NEXT:    i32.extend8_s $push0=, $24
-; NO-SIMD128-NEXT:    i32.mul $push2=, $pop1, $pop0
+; NO-SIMD128-NEXT:    i32.extend8_s $push0=, $8
+; NO-SIMD128-NEXT:    i32.extend8_s $push1=, $24
+; NO-SIMD128-NEXT:    i32.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-NEXT:    i32.store16 14($0), $pop2
-; NO-SIMD128-NEXT:    i32.extend8_s $push4=, $7
-; NO-SIMD128-NEXT:    i32.extend8_s $push3=, $23
-; NO-SIMD128-NEXT:    i32.mul $push5=, $pop4, $pop3
+; NO-SIMD128-NEXT:    i32.extend8_s $push3=, $7
+; NO-SIMD128-NEXT:    i32.extend8_s $push4=, $23
+; NO-SIMD128-NEXT:    i32.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-NEXT:    i32.store16 12($0), $pop5
-; NO-SIMD128-NEXT:    i32.extend8_s $push7=, $6
-; NO-SIMD128-NEXT:    i32.extend8_s $push6=, $22
-; NO-SIMD128-NEXT:    i32.mul $push8=, $pop7, $pop6
+; NO-SIMD128-NEXT:    i32.extend8_s $push6=, $6
+; NO-SIMD128-NEXT:    i32.extend8_s $push7=, $22
+; NO-SIMD128-NEXT:    i32.mul $push8=, $pop6, $pop7
 ; NO-SIMD128-NEXT:    i32.store16 10($0), $pop8
-; NO-SIMD128-NEXT:    i32.extend8_s $push10=, $5
-; NO-SIMD128-NEXT:    i32.extend8_s $push9=, $21
-; NO-SIMD128-NEXT:    i32.mul $push11=, $pop10, $pop9
+; NO-SIMD128-NEXT:    i32.extend8_s $push9=, $5
+; NO-SIMD128-NEXT:    i32.extend8_s $push10=, $21
+; NO-SIMD128-NEXT:    i32.mul $push11=, $pop9, $pop10
 ; NO-SIMD128-NEXT:    i32.store16 8($0), $pop11
-; NO-SIMD128-NEXT:    i32.extend8_s $push13=, $4
-; NO-SIMD128-NEXT:    i32.extend8_s $push12=, $20
-; NO-SIMD128-NEXT:    i32.mul $push14=, $pop13, $pop12
+; NO-SIMD128-NEXT:    i32.extend8_s $push12=, $4
+; NO-SIMD128-NEXT:    i32.extend8_s $push13=, $20
+; NO-SIMD128-NEXT:    i32.mul $push14=, $pop12, $pop13
 ; NO-SIMD128-NEXT:    i32.store16 6($0), $pop14
-; NO-SIMD128-NEXT:    i32.extend8_s $push16=, $3
-; NO-SIMD128-NEXT:    i32.extend8_s $push15=, $19
-; NO-SIMD128-NEXT:    i32.mul $push17=, $pop16, $pop15
+; NO-SIMD128-NEXT:    i32.extend8_s $push15=, $3
+; NO-SIMD128-NEXT:    i32.extend8_s $push16=, $19
+; NO-SIMD128-NEXT:    i32.mul $push17=, $pop15, $pop16
 ; NO-SIMD128-NEXT:    i32.store16 4($0), $pop17
-; NO-SIMD128-NEXT:    i32.extend8_s $push19=, $2
-; NO-SIMD128-NEXT:    i32.extend8_s $push18=, $18
-; NO-SIMD128-NEXT:    i32.mul $push20=, $pop19, $pop18
+; NO-SIMD128-NEXT:    i32.extend8_s $push18=, $2
+; NO-SIMD128-NEXT:    i32.extend8_s $push19=, $18
+; NO-SIMD128-NEXT:    i32.mul $push20=, $pop18, $pop19
 ; NO-SIMD128-NEXT:    i32.store16 2($0), $pop20
-; NO-SIMD128-NEXT:    i32.extend8_s $push22=, $1
-; NO-SIMD128-NEXT:    i32.extend8_s $push21=, $17
-; NO-SIMD128-NEXT:    i32.mul $push23=, $pop22, $pop21
+; NO-SIMD128-NEXT:    i32.extend8_s $push21=, $1
+; NO-SIMD128-NEXT:    i32.extend8_s $push22=, $17
+; NO-SIMD128-NEXT:    i32.mul $push23=, $pop21, $pop22
 ; NO-SIMD128-NEXT:    i32.store16 0($0), $pop23
 ; NO-SIMD128-NEXT:    return
 ;
 ; NO-SIMD128-FAST-LABEL: extmul_low_s_v8i16:
 ; NO-SIMD128-FAST:         .functype extmul_low_s_v8i16 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push1=, $1
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push0=, $17
-; NO-SIMD128-FAST-NEXT:    i32.mul $push2=, $pop1, $pop0
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push0=, $1
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push1=, $17
+; NO-SIMD128-FAST-NEXT:    i32.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-FAST-NEXT:    i32.store16 0($0), $pop2
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push4=, $2
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push3=, $18
-; NO-SIMD128-FAST-NEXT:    i32.mul $push5=, $pop4, $pop3
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push3=, $2
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push4=, $18
+; NO-SIMD128-FAST-NEXT:    i32.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-FAST-NEXT:    i32.store16 2($0), $pop5
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push7=, $3
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push6=, $19
-; NO-SIMD128-FAST-NEXT:    i32.mul $push8=, $pop7, $pop6
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push6=, $3
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push7=, $19
+; NO-SIMD128-FAST-NEXT:    i32.mul $push8=, $pop6, $pop7
 ; NO-SIMD128-FAST-NEXT:    i32.store16 4($0), $pop8
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push10=, $4
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push9=, $20
-; NO-SIMD128-FAST-NEXT:    i32.mul $push11=, $pop10, $pop9
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push9=, $4
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push10=, $20
+; NO-SIMD128-FAST-NEXT:    i32.mul $push11=, $pop9, $pop10
 ; NO-SIMD128-FAST-NEXT:    i32.store16 6($0), $pop11
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push13=, $5
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push12=, $21
-; NO-SIMD128-FAST-NEXT:    i32.mul $push14=, $pop13, $pop12
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push12=, $5
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push13=, $21
+; NO-SIMD128-FAST-NEXT:    i32.mul $push14=, $pop12, $pop13
 ; NO-SIMD128-FAST-NEXT:    i32.store16 8($0), $pop14
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push16=, $6
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push15=, $22
-; NO-SIMD128-FAST-NEXT:    i32.mul $push17=, $pop16, $pop15
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push15=, $6
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push16=, $22
+; NO-SIMD128-FAST-NEXT:    i32.mul $push17=, $pop15, $pop16
 ; NO-SIMD128-FAST-NEXT:    i32.store16 10($0), $pop17
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push19=, $7
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push18=, $23
-; NO-SIMD128-FAST-NEXT:    i32.mul $push20=, $pop19, $pop18
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push18=, $7
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push19=, $23
+; NO-SIMD128-FAST-NEXT:    i32.mul $push20=, $pop18, $pop19
 ; NO-SIMD128-FAST-NEXT:    i32.store16 12($0), $pop20
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push22=, $8
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push21=, $24
-; NO-SIMD128-FAST-NEXT:    i32.mul $push23=, $pop22, $pop21
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push21=, $8
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push22=, $24
+; NO-SIMD128-FAST-NEXT:    i32.mul $push23=, $pop21, $pop22
 ; NO-SIMD128-FAST-NEXT:    i32.store16 14($0), $pop23
 ; NO-SIMD128-FAST-NEXT:    return
   %low1 = shufflevector <16 x i8> %v1, <16 x i8> undef,
@@ -8694,74 +8694,74 @@ define <8 x i16> @extmul_high_s_v8i16(<16 x i8> %v1, <16 x i8> %v2) {
 ; NO-SIMD128-LABEL: extmul_high_s_v8i16:
 ; NO-SIMD128:         .functype extmul_high_s_v8i16 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    i32.extend8_s $push1=, $16
-; NO-SIMD128-NEXT:    i32.extend8_s $push0=, $32
-; NO-SIMD128-NEXT:    i32.mul $push2=, $pop1, $pop0
+; NO-SIMD128-NEXT:    i32.extend8_s $push0=, $16
+; NO-SIMD128-NEXT:    i32.extend8_s $push1=, $32
+; NO-SIMD128-NEXT:    i32.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-NEXT:    i32.store16 14($0), $pop2
-; NO-SIMD128-NEXT:    i32.extend8_s $push4=, $15
-; NO-SIMD128-NEXT:    i32.extend8_s $push3=, $31
-; NO-SIMD128-NEXT:    i32.mul $push5=, $pop4, $pop3
+; NO-SIMD128-NEXT:    i32.extend8_s $push3=, $15
+; NO-SIMD128-NEXT:    i32.extend8_s $push4=, $31
+; NO-SIMD128-NEXT:    i32.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-NEXT:    i32.store16 12($0), $pop5
-; NO-SIMD128-NEXT:    i32.extend8_s $push7=, $14
-; NO-SIMD128-NEXT:    i32.extend8_s $push6=, $30
-; NO-SIMD128-NEXT:    i32.mul $push8=, $pop7, $pop6
+; NO-SIMD128-NEXT:    i32.extend8_s $push6=, $14
+; NO-SIMD128-NEXT:    i32.extend8_s $push7=, $30
+; NO-SIMD128-NEXT:    i32.mul $push8=, $pop6, $pop7
 ; NO-SIMD128-NEXT:    i32.store16 10($0), $pop8
-; NO-SIMD128-NEXT:    i32.extend8_s $push10=, $13
-; NO-SIMD128-NEXT:    i32.extend8_s $push9=, $29
-; NO-SIMD128-NEXT:    i32.mul $push11=, $pop10, $pop9
+; NO-SIMD128-NEXT:    i32.extend8_s $push9=, $13
+; NO-SIMD128-NEXT:    i32.extend8_s $push10=, $29
+; NO-SIMD128-NEXT:    i32.mul $push11=, $pop9, $pop10
 ; NO-SIMD128-NEXT:    i32.store16 8($0), $pop11
-; NO-SIMD128-NEXT:    i32.extend8_s $push13=, $12
-; NO-SIMD128-NEXT:    i32.extend8_s $push12=, $28
-; NO-SIMD128-NEXT:    i32.mul $push14=, $pop13, $pop12
+; NO-SIMD128-NEXT:    i32.extend8_s $push12=, $12
+; NO-SIMD128-NEXT:    i32.extend8_s $push13=, $28
+; NO-SIMD128-NEXT:    i32.mul $push14=, $pop12, $pop13
 ; NO-SIMD128-NEXT:    i32.store16 6($0), $pop14
-; NO-SIMD128-NEXT:    i32.extend8_s $push16=, $11
-; NO-SIMD128-NEXT:    i32.extend8_s $push15=, $27
-; NO-SIMD128-NEXT:    i32.mul $push17=, $pop16, $pop15
+; NO-SIMD128-NEXT:    i32.extend8_s $push15=, $11
+; NO-SIMD128-NEXT:    i32.extend8_s $push16=, $27
+; NO-SIMD128-NEXT:    i32.mul $push17=, $pop15, $pop16
 ; NO-SIMD128-NEXT:    i32.store16 4($0), $pop17
-; NO-SIMD128-NEXT:    i32.extend8_s $push19=, $10
-; NO-SIMD128-NEXT:    i32.extend8_s $push18=, $26
-; NO-SIMD128-NEXT:    i32.mul $push20=, $pop19, $pop18
+; NO-SIMD128-NEXT:    i32.extend8_s $push18=, $10
+; NO-SIMD128-NEXT:    i32.extend8_s $push19=, $26
+; NO-SIMD128-NEXT:    i32.mul $push20=, $pop18, $pop19
 ; NO-SIMD128-NEXT:    i32.store16 2($0), $pop20
-; NO-SIMD128-NEXT:    i32.extend8_s $push22=, $9
-; NO-SIMD128-NEXT:    i32.extend8_s $push21=, $25
-; NO-SIMD128-NEXT:    i32.mul $push23=, $pop22, $pop21
+; NO-SIMD128-NEXT:    i32.extend8_s $push21=, $9
+; NO-SIMD128-NEXT:    i32.extend8_s $push22=, $25
+; NO-SIMD128-NEXT:    i32.mul $push23=, $pop21, $pop22
 ; NO-SIMD128-NEXT:    i32.store16 0($0), $pop23
 ; NO-SIMD128-NEXT:    return
 ;
 ; NO-SIMD128-FAST-LABEL: extmul_high_s_v8i16:
 ; NO-SIMD128-FAST:         .functype extmul_high_s_v8i16 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push1=, $9
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push0=, $25
-; NO-SIMD128-FAST-NEXT:    i32.mul $push2=, $pop1, $pop0
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push0=, $9
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push1=, $25
+; NO-SIMD128-FAST-NEXT:    i32.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-FAST-NEXT:    i32.store16 0($0), $pop2
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push4=, $10
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push3=, $26
-; NO-SIMD128-FAST-NEXT:    i32.mul $push5=, $pop4, $pop3
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push3=, $10
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push4=, $26
+; NO-SIMD128-FAST-NEXT:    i32.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-FAST-NEXT:    i32.store16 2($0), $pop5
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push7=, $11
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push6=, $27
-; NO-SIMD128-FAST-NEXT:    i32.mul $push8=, $pop7, $pop6
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push6=, $11
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push7=, $27
+; NO-SIMD128-FAST-NEXT:    i32.mul $push8=, $pop6, $pop7
 ; NO-SIMD128-FAST-NEXT:    i32.store16 4($0), $pop8
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push10=, $12
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push9=, $28
-; NO-SIMD128-FAST-NEXT:    i32.mul $push11=, $pop10, $pop9
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push9=, $12
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push10=, $28
+; NO-SIMD128-FAST-NEXT:    i32.mul $push11=, $pop9, $pop10
 ; NO-SIMD128-FAST-NEXT:    i32.store16 6($0), $pop11
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push13=, $13
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push12=, $29
-; NO-SIMD128-FAST-NEXT:    i32.mul $push14=, $pop13, $pop12
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push12=, $13
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push13=, $29
+; NO-SIMD128-FAST-NEXT:    i32.mul $push14=, $pop12, $pop13
 ; NO-SIMD128-FAST-NEXT:    i32.store16 8($0), $pop14
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push16=, $14
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push15=, $30
-; NO-SIMD128-FAST-NEXT:    i32.mul $push17=, $pop16, $pop15
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push15=, $14
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push16=, $30
+; NO-SIMD128-FAST-NEXT:    i32.mul $push17=, $pop15, $pop16
 ; NO-SIMD128-FAST-NEXT:    i32.store16 10($0), $pop17
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push19=, $15
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push18=, $31
-; NO-SIMD128-FAST-NEXT:    i32.mul $push20=, $pop19, $pop18
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push18=, $15
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push19=, $31
+; NO-SIMD128-FAST-NEXT:    i32.mul $push20=, $pop18, $pop19
 ; NO-SIMD128-FAST-NEXT:    i32.store16 12($0), $pop20
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push22=, $16
-; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push21=, $32
-; NO-SIMD128-FAST-NEXT:    i32.mul $push23=, $pop22, $pop21
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push21=, $16
+; NO-SIMD128-FAST-NEXT:    i32.extend8_s $push22=, $32
+; NO-SIMD128-FAST-NEXT:    i32.mul $push23=, $pop21, $pop22
 ; NO-SIMD128-FAST-NEXT:    i32.store16 14($0), $pop23
 ; NO-SIMD128-FAST-NEXT:    return
   %high1 = shufflevector <16 x i8> %v1, <16 x i8> undef,
@@ -8793,52 +8793,52 @@ define <8 x i16> @extmul_low_u_v8i16(<16 x i8> %v1, <16 x i8> %v2) {
 ; NO-SIMD128:         .functype extmul_low_u_v8i16 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
 ; NO-SIMD128-NEXT:    i32.const $push0=, 255
-; NO-SIMD128-NEXT:    i32.and $push2=, $8, $pop0
+; NO-SIMD128-NEXT:    i32.and $push1=, $8, $pop0
 ; NO-SIMD128-NEXT:    i32.const $push39=, 255
-; NO-SIMD128-NEXT:    i32.and $push1=, $24, $pop39
-; NO-SIMD128-NEXT:    i32.mul $push3=, $pop2, $pop1
+; NO-SIMD128-NEXT:    i32.and $push2=, $24, $pop39
+; NO-SIMD128-NEXT:    i32.mul $push3=, $pop1, $pop2
 ; NO-SIMD128-NEXT:    i32.store16 14($0), $pop3
 ; NO-SIMD128-NEXT:    i32.const $push38=, 255
-; NO-SIMD128-NEXT:    i32.and $push5=, $7, $pop38
+; NO-SIMD128-NEXT:    i32.and $push4=, $7, $pop38
 ; NO-SIMD128-NEXT:    i32.const $push37=, 255
-; NO-SIMD128-NEXT:    i32.and $push4=, $23, $pop37
-; NO-SIMD128-NEXT:    i32.mul $push6=, $pop5, $pop4
+; NO-SIMD128-NEXT:    i32.and $push5=, $23, $pop37
+; NO-SIMD128-NEXT:    i32.mul $push6=, $pop4, $pop5
 ; NO-SIMD128-NEXT:    i32.store16 12($0), $pop6
 ; NO-SIMD128-NEXT:    i32.const $push36=, 255
-; NO-SIMD128-NEXT:    i32.and $push8=, $6, $pop36
+; NO-SIMD128-NEXT:    i32.and $push7=, $6, $pop36
 ; NO-SIMD128-NEXT:    i32.const $push35=, 255
-; NO-SIMD128-NEXT:    i32.and $push7=, $22, $pop35
-; NO-SIMD128-NEXT:    i32.mul $push9=, $pop8, $pop7
+; NO-SIMD128-NEXT:    i32.and $push8=, $22, $pop35
+; NO-SIMD128-NEXT:    i32.mul $push9=, $pop7, $pop8
 ; NO-SIMD128-NEXT:    i32.store16 10($0), $pop9
 ; NO-SIMD128-NEXT:    i32.const $push34=, 255
-; NO-SIMD128-NEXT:    i32.and $push11=, $5, $pop34
+; NO-SIMD128-NEXT:    i32.and $push10=, $5, $pop34
 ; NO-SIMD128-NEXT:    i32.const $push33=, 255
-; NO-SIMD128-NEXT:    i32.and $push10=, $21, $pop33
-; NO-SIMD128-NEXT:    i32.mul $push12=, $pop11, $pop10
+; NO-SIMD128-NEXT:    i32.and $push11=, $21, $pop33
+; NO-SIMD128-NEXT:    i32.mul $push12=, $pop10, $pop11
 ; NO-SIMD128-NEXT:    i32.store16 8($0), $pop12
 ; NO-SIMD128-NEXT:    i32.const $push32=, 255
-; NO-SIMD128-NEXT:    i32.and $push14=, $4, $pop32
+; NO-SIMD128-NEXT:    i32.and $push13=, $4, $pop32
 ; NO-SIMD128-NEXT:    i32.const $push31=, 255
-; NO-SIMD128-NEXT:    i32.and $push13=, $20, $pop31
-; NO-SIMD128-NEXT:    i32.mul $push15=, $pop14, $pop13
+; NO-SIMD128-NEXT:    i32.and $push14=, $20, $pop31
+; NO-SIMD128-NEXT:    i32.mul $push15=, $pop13, $pop14
 ; NO-SIMD128-NEXT:    i32.store16 6($0), $pop15
 ; NO-SIMD128-NEXT:    i32.const $push30=, 255
-; NO-SIMD128-NEXT:    i32.and $push17=, $3, $pop30
+; NO-SIMD128-NEXT:    i32.and $push16=, $3, $pop30
 ; NO-SIMD128-NEXT:    i32.const $push29=, 255
-; NO-SIMD128-NEXT:    i32.and $push16=, $19, $pop29
-; NO-SIMD128-NEXT:    i32.mul $push18=, $pop17, $pop16
+; NO-SIMD128-NEXT:    i32.and $push17=, $19, $pop29
+; NO-SIMD128-NEXT:    i32.mul $push18=, $pop16, $pop17
 ; NO-SIMD128-NEXT:    i32.store16 4($0), $pop18
 ; NO-SIMD128-NEXT:    i32.const $push28=, 255
-; NO-SIMD128-NEXT:    i32.and $push20=, $2, $pop28
+; NO-SIMD128-NEXT:    i32.and $push19=, $2, $pop28
 ; NO-SIMD128-NEXT:    i32.const $push27=, 255
-; NO-SIMD128-NEXT:    i32.and $push19=, $18, $pop27
-; NO-SIMD128-NEXT:    i32.mul $push21=, $pop20, $pop19
+; NO-SIMD128-NEXT:    i32.and $push20=, $18, $pop27
+; NO-SIMD128-NEXT:    i32.mul $push21=, $pop19, $pop20
 ; NO-SIMD128-NEXT:    i32.store16 2($0), $pop21
 ; NO-SIMD128-NEXT:    i32.const $push26=, 255
-; NO-SIMD128-NEXT:    i32.and $push23=, $1, $pop26
+; NO-SIMD128-NEXT:    i32.and $push22=, $1, $pop26
 ; NO-SIMD128-NEXT:    i32.const $push25=, 255
-; NO-SIMD128-NEXT:    i32.and $push22=, $17, $pop25
-; NO-SIMD128-NEXT:    i32.mul $push24=, $pop23, $pop22
+; NO-SIMD128-NEXT:    i32.and $push23=, $17, $pop25
+; NO-SIMD128-NEXT:    i32.mul $push24=, $pop22, $pop23
 ; NO-SIMD128-NEXT:    i32.store16 0($0), $pop24
 ; NO-SIMD128-NEXT:    return
 ;
@@ -8846,52 +8846,52 @@ define <8 x i16> @extmul_low_u_v8i16(<16 x i8> %v1, <16 x i8> %v2) {
 ; NO-SIMD128-FAST:         .functype extmul_low_u_v8i16 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
 ; NO-SIMD128-FAST-NEXT:    i32.const $push0=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $1, $pop0
+; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $1, $pop0
 ; NO-SIMD128-FAST-NEXT:    i32.const $push39=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $17, $pop39
-; NO-SIMD128-FAST-NEXT:    i32.mul $push3=, $pop2, $pop1
+; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $17, $pop39
+; NO-SIMD128-FAST-NEXT:    i32.mul $push3=, $pop1, $pop2
 ; NO-SIMD128-FAST-NEXT:    i32.store16 0($0), $pop3
 ; NO-SIMD128-FAST-NEXT:    i32.const $push38=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push5=, $2, $pop38
+; NO-SIMD128-FAST-NEXT:    i32.and $push4=, $2, $pop38
 ; NO-SIMD128-FAST-NEXT:    i32.const $push37=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push4=, $18, $pop37
-; NO-SIMD128-FAST-NEXT:    i32.mul $push6=, $pop5, $pop4
+; NO-SIMD128-FAST-NEXT:    i32.and $push5=, $18, $pop37
+; NO-SIMD128-FAST-NEXT:    i32.mul $push6=, $pop4, $pop5
 ; NO-SIMD128-FAST-NEXT:    i32.store16 2($0), $pop6
 ; NO-SIMD128-FAST-NEXT:    i32.const $push36=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $3, $pop36
+; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $3, $pop36
 ; NO-SIMD128-FAST-NEXT:    i32.const $push35=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $19, $pop35
-; NO-SIMD128-FAST-NEXT:    i32.mul $push9=, $pop8, $pop7
+; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $19, $pop35
+; NO-SIMD128-FAST-NEXT:    i32.mul $push9=, $pop7, $pop8
 ; NO-SIMD128-FAST-NEXT:    i32.store16 4($0), $pop9
 ; NO-SIMD128-FAST-NEXT:    i32.const $push34=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $4, $pop34
+; NO-SIMD128-FAST-NEXT:    i32.and $push10=, $4, $pop34
 ; NO-SIMD128-FAST-NEXT:    i32.const $push33=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push10=, $20, $pop33
-; NO-SIMD128-FAST-NEXT:    i32.mul $push12=, $pop11, $pop10
+; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $20, $pop33
+; NO-SIMD128-FAST-NEXT:    i32.mul $push12=, $pop10, $pop11
 ; NO-SIMD128-FAST-NEXT:    i32.store16 6($0), $pop12
 ; NO-SIMD128-FAST-NEXT:    i32.const $push32=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push14=, $5, $pop32
+; NO-SIMD128-FAST-NEXT:    i32.and $push13=, $5, $pop32
 ; NO-SIMD128-FAST-NEXT:    i32.const $push31=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push13=, $21, $pop31
-; NO-SIMD128-FAST-NEXT:    i32.mul $push15=, $pop14, $pop13
+; NO-SIMD128-FAST-NEXT:    i32.and $push14=, $21, $pop31
+; NO-SIMD128-FAST-NEXT:    i32.mul $push15=, $pop13, $pop14
 ; NO-SIMD128-FAST-NEXT:    i32.store16 8($0), $pop15
 ; NO-SIMD128-FAST-NEXT:    i32.const $push30=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push17=, $6, $pop30
+; NO-SIMD128-FAST-NEXT:    i32.and $push16=, $6, $pop30
 ; NO-SIMD128-FAST-NEXT:    i32.const $push29=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push16=, $22, $pop29
-; NO-SIMD128-FAST-NEXT:    i32.mul $push18=, $pop17, $pop16
+; NO-SIMD128-FAST-NEXT:    i32.and $push17=, $22, $pop29
+; NO-SIMD128-FAST-NEXT:    i32.mul $push18=, $pop16, $pop17
 ; NO-SIMD128-FAST-NEXT:    i32.store16 10($0), $pop18
 ; NO-SIMD128-FAST-NEXT:    i32.const $push28=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push20=, $7, $pop28
+; NO-SIMD128-FAST-NEXT:    i32.and $push19=, $7, $pop28
 ; NO-SIMD128-FAST-NEXT:    i32.const $push27=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push19=, $23, $pop27
-; NO-SIMD128-FAST-NEXT:    i32.mul $push21=, $pop20, $pop19
+; NO-SIMD128-FAST-NEXT:    i32.and $push20=, $23, $pop27
+; NO-SIMD128-FAST-NEXT:    i32.mul $push21=, $pop19, $pop20
 ; NO-SIMD128-FAST-NEXT:    i32.store16 12($0), $pop21
 ; NO-SIMD128-FAST-NEXT:    i32.const $push26=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $8, $pop26
+; NO-SIMD128-FAST-NEXT:    i32.and $push22=, $8, $pop26
 ; NO-SIMD128-FAST-NEXT:    i32.const $push25=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push22=, $24, $pop25
-; NO-SIMD128-FAST-NEXT:    i32.mul $push24=, $pop23, $pop22
+; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $24, $pop25
+; NO-SIMD128-FAST-NEXT:    i32.mul $push24=, $pop22, $pop23
 ; NO-SIMD128-FAST-NEXT:    i32.store16 14($0), $pop24
 ; NO-SIMD128-FAST-NEXT:    return
   %low1 = shufflevector <16 x i8> %v1, <16 x i8> undef,
@@ -8923,52 +8923,52 @@ define <8 x i16> @extmul_high_u_v8i16(<16 x i8> %v1, <16 x i8> %v2) {
 ; NO-SIMD128:         .functype extmul_high_u_v8i16 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
 ; NO-SIMD128-NEXT:    i32.const $push0=, 255
-; NO-SIMD128-NEXT:    i32.and $push2=, $16, $pop0
+; NO-SIMD128-NEXT:    i32.and $push1=, $16, $pop0
 ; NO-SIMD128-NEXT:    i32.const $push39=, 255
-; NO-SIMD128-NEXT:    i32.and $push1=, $32, $pop39
-; NO-SIMD128-NEXT:    i32.mul $push3=, $pop2, $pop1
+; NO-SIMD128-NEXT:    i32.and $push2=, $32, $pop39
+; NO-SIMD128-NEXT:    i32.mul $push3=, $pop1, $pop2
 ; NO-SIMD128-NEXT:    i32.store16 14($0), $pop3
 ; NO-SIMD128-NEXT:    i32.const $push38=, 255
-; NO-SIMD128-NEXT:    i32.and $push5=, $15, $pop38
+; NO-SIMD128-NEXT:    i32.and $push4=, $15, $pop38
 ; NO-SIMD128-NEXT:    i32.const $push37=, 255
-; NO-SIMD128-NEXT:    i32.and $push4=, $31, $pop37
-; NO-SIMD128-NEXT:    i32.mul $push6=, $pop5, $pop4
+; NO-SIMD128-NEXT:    i32.and $push5=, $31, $pop37
+; NO-SIMD128-NEXT:    i32.mul $push6=, $pop4, $pop5
 ; NO-SIMD128-NEXT:    i32.store16 12($0), $pop6
 ; NO-SIMD128-NEXT:    i32.const $push36=, 255
-; NO-SIMD128-NEXT:    i32.and $push8=, $14, $pop36
+; NO-SIMD128-NEXT:    i32.and $push7=, $14, $pop36
 ; NO-SIMD128-NEXT:    i32.const $push35=, 255
-; NO-SIMD128-NEXT:    i32.and $push7=, $30, $pop35
-; NO-SIMD128-NEXT:    i32.mul $push9=, $pop8, $pop7
+; NO-SIMD128-NEXT:    i32.and $push8=, $30, $pop35
+; NO-SIMD128-NEXT:    i32.mul $push9=, $pop7, $pop8
 ; NO-SIMD128-NEXT:    i32.store16 10($0), $pop9
 ; NO-SIMD128-NEXT:    i32.const $push34=, 255
-; NO-SIMD128-NEXT:    i32.and $push11=, $13, $pop34
+; NO-SIMD128-NEXT:    i32.and $push10=, $13, $pop34
 ; NO-SIMD128-NEXT:    i32.const $push33=, 255
-; NO-SIMD128-NEXT:    i32.and $push10=, $29, $pop33
-; NO-SIMD128-NEXT:    i32.mul $push12=, $pop11, $pop10
+; NO-SIMD128-NEXT:    i32.and $push11=, $29, $pop33
+; NO-SIMD128-NEXT:    i32.mul $push12=, $pop10, $pop11
 ; NO-SIMD128-NEXT:    i32.store16 8($0), $pop12
 ; NO-SIMD128-NEXT:    i32.const $push32=, 255
-; NO-SIMD128-NEXT:    i32.and $push14=, $12, $pop32
+; NO-SIMD128-NEXT:    i32.and $push13=, $12, $pop32
 ; NO-SIMD128-NEXT:    i32.const $push31=, 255
-; NO-SIMD128-NEXT:    i32.and $push13=, $28, $pop31
-; NO-SIMD128-NEXT:    i32.mul $push15=, $pop14, $pop13
+; NO-SIMD128-NEXT:    i32.and $push14=, $28, $pop31
+; NO-SIMD128-NEXT:    i32.mul $push15=, $pop13, $pop14
 ; NO-SIMD128-NEXT:    i32.store16 6($0), $pop15
 ; NO-SIMD128-NEXT:    i32.const $push30=, 255
-; NO-SIMD128-NEXT:    i32.and $push17=, $11, $pop30
+; NO-SIMD128-NEXT:    i32.and $push16=, $11, $pop30
 ; NO-SIMD128-NEXT:    i32.const $push29=, 255
-; NO-SIMD128-NEXT:    i32.and $push16=, $27, $pop29
-; NO-SIMD128-NEXT:    i32.mul $push18=, $pop17, $pop16
+; NO-SIMD128-NEXT:    i32.and $push17=, $27, $pop29
+; NO-SIMD128-NEXT:    i32.mul $push18=, $pop16, $pop17
 ; NO-SIMD128-NEXT:    i32.store16 4($0), $pop18
 ; NO-SIMD128-NEXT:    i32.const $push28=, 255
-; NO-SIMD128-NEXT:    i32.and $push20=, $10, $pop28
+; NO-SIMD128-NEXT:    i32.and $push19=, $10, $pop28
 ; NO-SIMD128-NEXT:    i32.const $push27=, 255
-; NO-SIMD128-NEXT:    i32.and $push19=, $26, $pop27
-; NO-SIMD128-NEXT:    i32.mul $push21=, $pop20, $pop19
+; NO-SIMD128-NEXT:    i32.and $push20=, $26, $pop27
+; NO-SIMD128-NEXT:    i32.mul $push21=, $pop19, $pop20
 ; NO-SIMD128-NEXT:    i32.store16 2($0), $pop21
 ; NO-SIMD128-NEXT:    i32.const $push26=, 255
-; NO-SIMD128-NEXT:    i32.and $push23=, $9, $pop26
+; NO-SIMD128-NEXT:    i32.and $push22=, $9, $pop26
 ; NO-SIMD128-NEXT:    i32.const $push25=, 255
-; NO-SIMD128-NEXT:    i32.and $push22=, $25, $pop25
-; NO-SIMD128-NEXT:    i32.mul $push24=, $pop23, $pop22
+; NO-SIMD128-NEXT:    i32.and $push23=, $25, $pop25
+; NO-SIMD128-NEXT:    i32.mul $push24=, $pop22, $pop23
 ; NO-SIMD128-NEXT:    i32.store16 0($0), $pop24
 ; NO-SIMD128-NEXT:    return
 ;
@@ -8976,52 +8976,52 @@ define <8 x i16> @extmul_high_u_v8i16(<16 x i8> %v1, <16 x i8> %v2) {
 ; NO-SIMD128-FAST:         .functype extmul_high_u_v8i16 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
 ; NO-SIMD128-FAST-NEXT:    i32.const $push0=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $9, $pop0
+; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $9, $pop0
 ; NO-SIMD128-FAST-NEXT:    i32.const $push39=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $25, $pop39
-; NO-SIMD128-FAST-NEXT:    i32.mul $push3=, $pop2, $pop1
+; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $25, $pop39
+; NO-SIMD128-FAST-NEXT:    i32.mul $push3=, $pop1, $pop2
 ; NO-SIMD128-FAST-NEXT:    i32.store16 0($0), $pop3
 ; NO-SIMD128-FAST-NEXT:    i32.const $push38=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push5=, $10, $pop38
+; NO-SIMD128-FAST-NEXT:    i32.and $push4=, $10, $pop38
 ; NO-SIMD128-FAST-NEXT:    i32.const $push37=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push4=, $26, $pop37
-; NO-SIMD128-FAST-NEXT:    i32.mul $push6=, $pop5, $pop4
+; NO-SIMD128-FAST-NEXT:    i32.and $push5=, $26, $pop37
+; NO-SIMD128-FAST-NEXT:    i32.mul $push6=, $pop4, $pop5
 ; NO-SIMD128-FAST-NEXT:    i32.store16 2($0), $pop6
 ; NO-SIMD128-FAST-NEXT:    i32.const $push36=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $11, $pop36
+; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $11, $pop36
 ; NO-SIMD128-FAST-NEXT:    i32.const $push35=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $27, $pop35
-; NO-SIMD128-FAST-NEXT:    i32.mul $push9=, $pop8, $pop7
+; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $27, $pop35
+; NO-SIMD128-FAST-NEXT:    i32.mul $push9=, $pop7, $pop8
 ; NO-SIMD128-FAST-NEXT:    i32.store16 4($0), $pop9
 ; NO-SIMD128-FAST-NEXT:    i32.const $push34=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $12, $pop34
+; NO-SIMD128-FAST-NEXT:    i32.and $push10=, $12, $pop34
 ; NO-SIMD128-FAST-NEXT:    i32.const $push33=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push10=, $28, $pop33
-; NO-SIMD128-FAST-NEXT:    i32.mul $push12=, $pop11, $pop10
+; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $28, $pop33
+; NO-SIMD128-FAST-NEXT:    i32.mul $push12=, $pop10, $pop11
 ; NO-SIMD128-FAST-NEXT:    i32.store16 6($0), $pop12
 ; NO-SIMD128-FAST-NEXT:    i32.const $push32=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push14=, $13, $pop32
+; NO-SIMD128-FAST-NEXT:    i32.and $push13=, $13, $pop32
 ; NO-SIMD128-FAST-NEXT:    i32.const $push31=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push13=, $29, $pop31
-; NO-SIMD128-FAST-NEXT:    i32.mul $push15=, $pop14, $pop13
+; NO-SIMD128-FAST-NEXT:    i32.and $push14=, $29, $pop31
+; NO-SIMD128-FAST-NEXT:    i32.mul $push15=, $pop13, $pop14
 ; NO-SIMD128-FAST-NEXT:    i32.store16 8($0), $pop15
 ; NO-SIMD128-FAST-NEXT:    i32.const $push30=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push17=, $14, $pop30
+; NO-SIMD128-FAST-NEXT:    i32.and $push16=, $14, $pop30
 ; NO-SIMD128-FAST-NEXT:    i32.const $push29=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push16=, $30, $pop29
-; NO-SIMD128-FAST-NEXT:    i32.mul $push18=, $pop17, $pop16
+; NO-SIMD128-FAST-NEXT:    i32.and $push17=, $30, $pop29
+; NO-SIMD128-FAST-NEXT:    i32.mul $push18=, $pop16, $pop17
 ; NO-SIMD128-FAST-NEXT:    i32.store16 10($0), $pop18
 ; NO-SIMD128-FAST-NEXT:    i32.const $push28=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push20=, $15, $pop28
+; NO-SIMD128-FAST-NEXT:    i32.and $push19=, $15, $pop28
 ; NO-SIMD128-FAST-NEXT:    i32.const $push27=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push19=, $31, $pop27
-; NO-SIMD128-FAST-NEXT:    i32.mul $push21=, $pop20, $pop19
+; NO-SIMD128-FAST-NEXT:    i32.and $push20=, $31, $pop27
+; NO-SIMD128-FAST-NEXT:    i32.mul $push21=, $pop19, $pop20
 ; NO-SIMD128-FAST-NEXT:    i32.store16 12($0), $pop21
 ; NO-SIMD128-FAST-NEXT:    i32.const $push26=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $16, $pop26
+; NO-SIMD128-FAST-NEXT:    i32.and $push22=, $16, $pop26
 ; NO-SIMD128-FAST-NEXT:    i32.const $push25=, 255
-; NO-SIMD128-FAST-NEXT:    i32.and $push22=, $32, $pop25
-; NO-SIMD128-FAST-NEXT:    i32.mul $push24=, $pop23, $pop22
+; NO-SIMD128-FAST-NEXT:    i32.and $push23=, $32, $pop25
+; NO-SIMD128-FAST-NEXT:    i32.mul $push24=, $pop22, $pop23
 ; NO-SIMD128-FAST-NEXT:    i32.store16 14($0), $pop24
 ; NO-SIMD128-FAST-NEXT:    return
   %high1 = shufflevector <16 x i8> %v1, <16 x i8> undef,
@@ -10277,28 +10277,28 @@ define <4 x i32> @bitselect_xor_reversed_v4i32(<4 x i32> %c, <4 x i32> %v1, <4 x
 ; NO-SIMD128-LABEL: bitselect_xor_reversed_v4i32:
 ; NO-SIMD128:         .functype bitselect_xor_reversed_v4i32 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    i32.xor $push2=, $8, $12
-; NO-SIMD128-NEXT:    i32.const $push0=, -1
-; NO-SIMD128-NEXT:    i32.xor $push1=, $4, $pop0
-; NO-SIMD128-NEXT:    i32.and $push3=, $pop2, $pop1
+; NO-SIMD128-NEXT:    i32.xor $push0=, $8, $12
+; NO-SIMD128-NEXT:    i32.const $push1=, -1
+; NO-SIMD128-NEXT:    i32.xor $push2=, $4, $pop1
+; NO-SIMD128-NEXT:    i32.and $push3=, $pop0, $pop2
 ; NO-SIMD128-NEXT:    i32.xor $push4=, $pop3, $12
 ; NO-SIMD128-NEXT:    i32.store 12($0), $pop4
-; NO-SIMD128-NEXT:    i32.xor $push6=, $7, $11
+; NO-SIMD128-NEXT:    i32.xor $push5=, $7, $11
 ; NO-SIMD128-NEXT:    i32.const $push19=, -1
-; NO-SIMD128-NEXT:    i32.xor $push5=, $3, $pop19
-; NO-SIMD128-NEXT:    i32.and $push7=, $pop6, $pop5
+; NO-SIMD128-NEXT:    i32.xor $push6=, $3, $pop19
+; NO-SIMD128-NEXT:    i32.and $push7=, $pop5, $pop6
 ; NO-SIMD128-NEXT:    i32.xor $push8=, $pop7, $11
 ; NO-SIMD128-NEXT:    i32.store 8($0), $pop8
-; NO-SIMD128-NEXT:    i32.xor $push10=, $6, $10
+; NO-SIMD128-NEXT:    i32.xor $push9=, $6, $10
 ; NO-SIMD128-NEXT:    i32.const $push18=, -1
-; NO-SIMD128-NEXT:    i32.xor $push9=, $2, $pop18
-; NO-SIMD128-NEXT:    i32.and $push11=, $pop10, $pop9
+; NO-SIMD128-NEXT:    i32.xor $push10=, $2, $pop18
+; NO-SIMD128-NEXT:    i32.and $push11=, $pop9, $pop10
 ; NO-SIMD128-NEXT:    i32.xor $push12=, $pop11, $10
 ; NO-SIMD128-NEXT:    i32.store 4($0), $pop12
-; NO-SIMD128-NEXT:    i32.xor $push14=, $5, $9
+; NO-SIMD128-NEXT:    i32.xor $push13=, $5, $9
 ; NO-SIMD128-NEXT:    i32.const $push17=, -1
-; NO-SIMD128-NEXT:    i32.xor $push13=, $1, $pop17
-; NO-SIMD128-NEXT:    i32.and $push15=, $pop14, $pop13
+; NO-SIMD128-NEXT:    i32.xor $push14=, $1, $pop17
+; NO-SIMD128-NEXT:    i32.and $push15=, $pop13, $pop14
 ; NO-SIMD128-NEXT:    i32.xor $push16=, $pop15, $9
 ; NO-SIMD128-NEXT:    i32.store 0($0), $pop16
 ; NO-SIMD128-NEXT:    return
@@ -10306,28 +10306,28 @@ define <4 x i32> @bitselect_xor_reversed_v4i32(<4 x i32> %c, <4 x i32> %v1, <4 x
 ; NO-SIMD128-FAST-LABEL: bitselect_xor_reversed_v4i32:
 ; NO-SIMD128-FAST:         .functype bitselect_xor_reversed_v4i32 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    i32.xor $push2=, $5, $9
-; NO-SIMD128-FAST-NEXT:    i32.const $push0=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push1=, $1, $pop0
-; NO-SIMD128-FAST-NEXT:    i32.and $push3=, $pop2, $pop1
+; NO-SIMD128-FAST-NEXT:    i32.xor $push0=, $5, $9
+; NO-SIMD128-FAST-NEXT:    i32.const $push1=, -1
+; NO-SIMD128-FAST-NEXT:    i32.xor $push2=, $1, $pop1
+; NO-SIMD128-FAST-NEXT:    i32.and $push3=, $pop0, $pop2
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push4=, $pop3, $9
 ; NO-SIMD128-FAST-NEXT:    i32.store 0($0), $pop4
-; NO-SIMD128-FAST-NEXT:    i32.xor $push6=, $6, $10
+; NO-SIMD128-FAST-NEXT:    i32.xor $push5=, $6, $10
 ; NO-SIMD128-FAST-NEXT:    i32.const $push19=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push5=, $2, $pop19
-; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $pop6, $pop5
+; NO-SIMD128-FAST-NEXT:    i32.xor $push6=, $2, $pop19
+; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $pop5, $pop6
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push8=, $pop7, $10
 ; NO-SIMD128-FAST-NEXT:    i32.store 4($0), $pop8
-; NO-SIMD128-FAST-NEXT:    i32.xor $push10=, $7, $11
+; NO-SIMD128-FAST-NEXT:    i32.xor $push9=, $7, $11
 ; NO-SIMD128-FAST-NEXT:    i32.const $push18=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push9=, $3, $pop18
-; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $pop10, $pop9
+; NO-SIMD128-FAST-NEXT:    i32.xor $push10=, $3, $pop18
+; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $pop9, $pop10
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push12=, $pop11, $11
 ; NO-SIMD128-FAST-NEXT:    i32.store 8($0), $pop12
-; NO-SIMD128-FAST-NEXT:    i32.xor $push14=, $8, $12
+; NO-SIMD128-FAST-NEXT:    i32.xor $push13=, $8, $12
 ; NO-SIMD128-FAST-NEXT:    i32.const $push17=, -1
-; NO-SIMD128-FAST-NEXT:    i32.xor $push13=, $4, $pop17
-; NO-SIMD128-FAST-NEXT:    i32.and $push15=, $pop14, $pop13
+; NO-SIMD128-FAST-NEXT:    i32.xor $push14=, $4, $pop17
+; NO-SIMD128-FAST-NEXT:    i32.and $push15=, $pop13, $pop14
 ; NO-SIMD128-FAST-NEXT:    i32.xor $push16=, $pop15, $12
 ; NO-SIMD128-FAST-NEXT:    i32.store 12($0), $pop16
 ; NO-SIMD128-FAST-NEXT:    return
@@ -10356,42 +10356,42 @@ define <4 x i32> @extmul_low_s_v4i32(<8 x i16> %v1, <8 x i16> %v2) {
 ; NO-SIMD128-LABEL: extmul_low_s_v4i32:
 ; NO-SIMD128:         .functype extmul_low_s_v4i32 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    i32.extend16_s $push1=, $4
-; NO-SIMD128-NEXT:    i32.extend16_s $push0=, $12
-; NO-SIMD128-NEXT:    i32.mul $push2=, $pop1, $pop0
+; NO-SIMD128-NEXT:    i32.extend16_s $push0=, $4
+; NO-SIMD128-NEXT:    i32.extend16_s $push1=, $12
+; NO-SIMD128-NEXT:    i32.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-NEXT:    i32.store 12($0), $pop2
-; NO-SIMD128-NEXT:    i32.extend16_s $push4=, $3
-; NO-SIMD128-NEXT:    i32.extend16_s $push3=, $11
-; NO-SIMD128-NEXT:    i32.mul $push5=, $pop4, $pop3
+; NO-SIMD128-NEXT:    i32.extend16_s $push3=, $3
+; NO-SIMD128-NEXT:    i32.extend16_s $push4=, $11
+; NO-SIMD128-NEXT:    i32.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-NEXT:    i32.store 8($0), $pop5
-; NO-SIMD128-NEXT:    i32.extend16_s $push7=, $2
-; NO-SIMD128-NEXT:    i32.extend16_s $push6=, $10
-; NO-SIMD128-NEXT:    i32.mul $push8=, $pop7, $pop6
+; NO-SIMD128-NEXT:    i32.extend16_s $push6=, $2
+; NO-SIMD128-NEXT:    i32.extend16_s $push7=, $10
+; NO-SIMD128-NEXT:    i32.mul $push8=, $pop6, $pop7
 ; NO-SIMD128-NEXT:    i32.store 4($0), $pop8
-; NO-SIMD128-NEXT:    i32.extend16_s $push10=, $1
-; NO-SIMD128-NEXT:    i32.extend16_s $push9=, $9
-; NO-SIMD128-NEXT:    i32.mul $push11=, $pop10, $pop9
+; NO-SIMD128-NEXT:    i32.extend16_s $push9=, $1
+; NO-SIMD128-NEXT:    i32.extend16_s $push10=, $9
+; NO-SIMD128-NEXT:    i32.mul $push11=, $pop9, $pop10
 ; NO-SIMD128-NEXT:    i32.store 0($0), $pop11
 ; NO-SIMD128-NEXT:    return
 ;
 ; NO-SIMD128-FAST-LABEL: extmul_low_s_v4i32:
 ; NO-SIMD128-FAST:         .functype extmul_low_s_v4i32 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push1=, $1
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push0=, $9
-; NO-SIMD128-FAST-NEXT:    i32.mul $push2=, $pop1, $pop0
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push0=, $1
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push1=, $9
+; NO-SIMD128-FAST-NEXT:    i32.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-FAST-NEXT:    i32.store 0($0), $pop2
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push4=, $2
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push3=, $10
-; NO-SIMD128-FAST-NEXT:    i32.mul $push5=, $pop4, $pop3
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push3=, $2
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push4=, $10
+; NO-SIMD128-FAST-NEXT:    i32.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-FAST-NEXT:    i32.store 4($0), $pop5
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push7=, $3
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push6=, $11
-; NO-SIMD128-FAST-NEXT:    i32.mul $push8=, $pop7, $pop6
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push6=, $3
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push7=, $11
+; NO-SIMD128-FAST-NEXT:    i32.mul $push8=, $pop6, $pop7
 ; NO-SIMD128-FAST-NEXT:    i32.store 8($0), $pop8
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push10=, $4
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push9=, $12
-; NO-SIMD128-FAST-NEXT:    i32.mul $push11=, $pop10, $pop9
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push9=, $4
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push10=, $12
+; NO-SIMD128-FAST-NEXT:    i32.mul $push11=, $pop9, $pop10
 ; NO-SIMD128-FAST-NEXT:    i32.store 12($0), $pop11
 ; NO-SIMD128-FAST-NEXT:    return
   %low1 = shufflevector <8 x i16> %v1, <8 x i16> undef,
@@ -10422,42 +10422,42 @@ define <4 x i32> @extmul_high_s_v4i32(<8 x i16> %v1, <8 x i16> %v2) {
 ; NO-SIMD128-LABEL: extmul_high_s_v4i32:
 ; NO-SIMD128:         .functype extmul_high_s_v4i32 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    i32.extend16_s $push1=, $8
-; NO-SIMD128-NEXT:    i32.extend16_s $push0=, $16
-; NO-SIMD128-NEXT:    i32.mul $push2=, $pop1, $pop0
+; NO-SIMD128-NEXT:    i32.extend16_s $push0=, $8
+; NO-SIMD128-NEXT:    i32.extend16_s $push1=, $16
+; NO-SIMD128-NEXT:    i32.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-NEXT:    i32.store 12($0), $pop2
-; NO-SIMD128-NEXT:    i32.extend16_s $push4=, $7
-; NO-SIMD128-NEXT:    i32.extend16_s $push3=, $15
-; NO-SIMD128-NEXT:    i32.mul $push5=, $pop4, $pop3
+; NO-SIMD128-NEXT:    i32.extend16_s $push3=, $7
+; NO-SIMD128-NEXT:    i32.extend16_s $push4=, $15
+; NO-SIMD128-NEXT:    i32.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-NEXT:    i32.store 8($0), $pop5
-; NO-SIMD128-NEXT:    i32.extend16_s $push7=, $6
-; NO-SIMD128-NEXT:    i32.extend16_s $push6=, $14
-; NO-SIMD128-NEXT:    i32.mul $push8=, $pop7, $pop6
+; NO-SIMD128-NEXT:    i32.extend16_s $push6=, $6
+; NO-SIMD128-NEXT:    i32.extend16_s $push7=, $14
+; NO-SIMD128-NEXT:    i32.mul $push8=, $pop6, $pop7
 ; NO-SIMD128-NEXT:    i32.store 4($0), $pop8
-; NO-SIMD128-NEXT:    i32.extend16_s $push10=, $5
-; NO-SIMD128-NEXT:    i32.extend16_s $push9=, $13
-; NO-SIMD128-NEXT:    i32.mul $push11=, $pop10, $pop9
+; NO-SIMD128-NEXT:    i32.extend16_s $push9=, $5
+; NO-SIMD128-NEXT:    i32.extend16_s $push10=, $13
+; NO-SIMD128-NEXT:    i32.mul $push11=, $pop9, $pop10
 ; NO-SIMD128-NEXT:    i32.store 0($0), $pop11
 ; NO-SIMD128-NEXT:    return
 ;
 ; NO-SIMD128-FAST-LABEL: extmul_high_s_v4i32:
 ; NO-SIMD128-FAST:         .functype extmul_high_s_v4i32 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push1=, $5
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push0=, $13
-; NO-SIMD128-FAST-NEXT:    i32.mul $push2=, $pop1, $pop0
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push0=, $5
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push1=, $13
+; NO-SIMD128-FAST-NEXT:    i32.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-FAST-NEXT:    i32.store 0($0), $pop2
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push4=, $6
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push3=, $14
-; NO-SIMD128-FAST-NEXT:    i32.mul $push5=, $pop4, $pop3
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push3=, $6
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push4=, $14
+; NO-SIMD128-FAST-NEXT:    i32.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-FAST-NEXT:    i32.store 4($0), $pop5
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push7=, $7
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push6=, $15
-; NO-SIMD128-FAST-NEXT:    i32.mul $push8=, $pop7, $pop6
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push6=, $7
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push7=, $15
+; NO-SIMD128-FAST-NEXT:    i32.mul $push8=, $pop6, $pop7
 ; NO-SIMD128-FAST-NEXT:    i32.store 8($0), $pop8
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push10=, $8
-; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push9=, $16
-; NO-SIMD128-FAST-NEXT:    i32.mul $push11=, $pop10, $pop9
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push9=, $8
+; NO-SIMD128-FAST-NEXT:    i32.extend16_s $push10=, $16
+; NO-SIMD128-FAST-NEXT:    i32.mul $push11=, $pop9, $pop10
 ; NO-SIMD128-FAST-NEXT:    i32.store 12($0), $pop11
 ; NO-SIMD128-FAST-NEXT:    return
   %high1 = shufflevector <8 x i16> %v1, <8 x i16> undef,
@@ -10489,28 +10489,28 @@ define <4 x i32> @extmul_low_u_v4i32(<8 x i16> %v1, <8 x i16> %v2) {
 ; NO-SIMD128:         .functype extmul_low_u_v4i32 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
 ; NO-SIMD128-NEXT:    i32.const $push0=, 65535
-; NO-SIMD128-NEXT:    i32.and $push2=, $4, $pop0
+; NO-SIMD128-NEXT:    i32.and $push1=, $4, $pop0
 ; NO-SIMD128-NEXT:    i32.const $push19=, 65535
-; NO-SIMD128-NEXT:    i32.and $push1=, $12, $pop19
-; NO-SIMD128-NEXT:    i32.mul $push3=, $pop2, $pop1
+; NO-SIMD128-NEXT:    i32.and $push2=, $12, $pop19
+; NO-SIMD128-NEXT:    i32.mul $push3=, $pop1, $pop2
 ; NO-SIMD128-NEXT:    i32.store 12($0), $pop3
 ; NO-SIMD128-NEXT:    i32.const $push18=, 65535
-; NO-SIMD128-NEXT:    i32.and $push5=, $3, $pop18
+; NO-SIMD128-NEXT:    i32.and $push4=, $3, $pop18
 ; NO-SIMD128-NEXT:    i32.const $push17=, 65535
-; NO-SIMD128-NEXT:    i32.and $push4=, $11, $pop17
-; NO-SIMD128-NEXT:    i32.mul $push6=, $pop5, $pop4
+; NO-SIMD128-NEXT:    i32.and $push5=, $11, $pop17
+; NO-SIMD128-NEXT:    i32.mul $push6=, $pop4, $pop5
 ; NO-SIMD128-NEXT:    i32.store 8($0), $pop6
 ; NO-SIMD128-NEXT:    i32.const $push16=, 65535
-; NO-SIMD128-NEXT:    i32.and $push8=, $2, $pop16
+; NO-SIMD128-NEXT:    i32.and $push7=, $2, $pop16
 ; NO-SIMD128-NEXT:    i32.const $push15=, 65535
-; NO-SIMD128-NEXT:    i32.and $push7=, $10, $pop15
-; NO-SIMD128-NEXT:    i32.mul $push9=, $pop8, $pop7
+; NO-SIMD128-NEXT:    i32.and $push8=, $10, $pop15
+; NO-SIMD128-NEXT:    i32.mul $push9=, $pop7, $pop8
 ; NO-SIMD128-NEXT:    i32.store 4($0), $pop9
 ; NO-SIMD128-NEXT:    i32.const $push14=, 65535
-; NO-SIMD128-NEXT:    i32.and $push11=, $1, $pop14
+; NO-SIMD128-NEXT:    i32.and $push10=, $1, $pop14
 ; NO-SIMD128-NEXT:    i32.const $push13=, 65535
-; NO-SIMD128-NEXT:    i32.and $push10=, $9, $pop13
-; NO-SIMD128-NEXT:    i32.mul $push12=, $pop11, $pop10
+; NO-SIMD128-NEXT:    i32.and $push11=, $9, $pop13
+; NO-SIMD128-NEXT:    i32.mul $push12=, $pop10, $pop11
 ; NO-SIMD128-NEXT:    i32.store 0($0), $pop12
 ; NO-SIMD128-NEXT:    return
 ;
@@ -10518,28 +10518,28 @@ define <4 x i32> @extmul_low_u_v4i32(<8 x i16> %v1, <8 x i16> %v2) {
 ; NO-SIMD128-FAST:         .functype extmul_low_u_v4i32 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
 ; NO-SIMD128-FAST-NEXT:    i32.const $push0=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $1, $pop0
+; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $1, $pop0
 ; NO-SIMD128-FAST-NEXT:    i32.const $push19=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $9, $pop19
-; NO-SIMD128-FAST-NEXT:    i32.mul $push3=, $pop2, $pop1
+; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $9, $pop19
+; NO-SIMD128-FAST-NEXT:    i32.mul $push3=, $pop1, $pop2
 ; NO-SIMD128-FAST-NEXT:    i32.store 0($0), $pop3
 ; NO-SIMD128-FAST-NEXT:    i32.const $push18=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push5=, $2, $pop18
+; NO-SIMD128-FAST-NEXT:    i32.and $push4=, $2, $pop18
 ; NO-SIMD128-FAST-NEXT:    i32.const $push17=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push4=, $10, $pop17
-; NO-SIMD128-FAST-NEXT:    i32.mul $push6=, $pop5, $pop4
+; NO-SIMD128-FAST-NEXT:    i32.and $push5=, $10, $pop17
+; NO-SIMD128-FAST-NEXT:    i32.mul $push6=, $pop4, $pop5
 ; NO-SIMD128-FAST-NEXT:    i32.store 4($0), $pop6
 ; NO-SIMD128-FAST-NEXT:    i32.const $push16=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $3, $pop16
+; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $3, $pop16
 ; NO-SIMD128-FAST-NEXT:    i32.const $push15=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $11, $pop15
-; NO-SIMD128-FAST-NEXT:    i32.mul $push9=, $pop8, $pop7
+; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $11, $pop15
+; NO-SIMD128-FAST-NEXT:    i32.mul $push9=, $pop7, $pop8
 ; NO-SIMD128-FAST-NEXT:    i32.store 8($0), $pop9
 ; NO-SIMD128-FAST-NEXT:    i32.const $push14=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $4, $pop14
+; NO-SIMD128-FAST-NEXT:    i32.and $push10=, $4, $pop14
 ; NO-SIMD128-FAST-NEXT:    i32.const $push13=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push10=, $12, $pop13
-; NO-SIMD128-FAST-NEXT:    i32.mul $push12=, $pop11, $pop10
+; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $12, $pop13
+; NO-SIMD128-FAST-NEXT:    i32.mul $push12=, $pop10, $pop11
 ; NO-SIMD128-FAST-NEXT:    i32.store 12($0), $pop12
 ; NO-SIMD128-FAST-NEXT:    return
   %low1 = shufflevector <8 x i16> %v1, <8 x i16> undef,
@@ -10571,28 +10571,28 @@ define <4 x i32> @extmul_high_u_v4i32(<8 x i16> %v1, <8 x i16> %v2) {
 ; NO-SIMD128:         .functype extmul_high_u_v4i32 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
 ; NO-SIMD128-NEXT:    i32.const $push0=, 65535
-; NO-SIMD128-NEXT:    i32.and $push2=, $8, $pop0
+; NO-SIMD128-NEXT:    i32.and $push1=, $8, $pop0
 ; NO-SIMD128-NEXT:    i32.const $push19=, 65535
-; NO-SIMD128-NEXT:    i32.and $push1=, $16, $pop19
-; NO-SIMD128-NEXT:    i32.mul $push3=, $pop2, $pop1
+; NO-SIMD128-NEXT:    i32.and $push2=, $16, $pop19
+; NO-SIMD128-NEXT:    i32.mul $push3=, $pop1, $pop2
 ; NO-SIMD128-NEXT:    i32.store 12($0), $pop3
 ; NO-SIMD128-NEXT:    i32.const $push18=, 65535
-; NO-SIMD128-NEXT:    i32.and $push5=, $7, $pop18
+; NO-SIMD128-NEXT:    i32.and $push4=, $7, $pop18
 ; NO-SIMD128-NEXT:    i32.const $push17=, 65535
-; NO-SIMD128-NEXT:    i32.and $push4=, $15, $pop17
-; NO-SIMD128-NEXT:    i32.mul $push6=, $pop5, $pop4
+; NO-SIMD128-NEXT:    i32.and $push5=, $15, $pop17
+; NO-SIMD128-NEXT:    i32.mul $push6=, $pop4, $pop5
 ; NO-SIMD128-NEXT:    i32.store 8($0), $pop6
 ; NO-SIMD128-NEXT:    i32.const $push16=, 65535
-; NO-SIMD128-NEXT:    i32.and $push8=, $6, $pop16
+; NO-SIMD128-NEXT:    i32.and $push7=, $6, $pop16
 ; NO-SIMD128-NEXT:    i32.const $push15=, 65535
-; NO-SIMD128-NEXT:    i32.and $push7=, $14, $pop15
-; NO-SIMD128-NEXT:    i32.mul $push9=, $pop8, $pop7
+; NO-SIMD128-NEXT:    i32.and $push8=, $14, $pop15
+; NO-SIMD128-NEXT:    i32.mul $push9=, $pop7, $pop8
 ; NO-SIMD128-NEXT:    i32.store 4($0), $pop9
 ; NO-SIMD128-NEXT:    i32.const $push14=, 65535
-; NO-SIMD128-NEXT:    i32.and $push11=, $5, $pop14
+; NO-SIMD128-NEXT:    i32.and $push10=, $5, $pop14
 ; NO-SIMD128-NEXT:    i32.const $push13=, 65535
-; NO-SIMD128-NEXT:    i32.and $push10=, $13, $pop13
-; NO-SIMD128-NEXT:    i32.mul $push12=, $pop11, $pop10
+; NO-SIMD128-NEXT:    i32.and $push11=, $13, $pop13
+; NO-SIMD128-NEXT:    i32.mul $push12=, $pop10, $pop11
 ; NO-SIMD128-NEXT:    i32.store 0($0), $pop12
 ; NO-SIMD128-NEXT:    return
 ;
@@ -10600,28 +10600,28 @@ define <4 x i32> @extmul_high_u_v4i32(<8 x i16> %v1, <8 x i16> %v2) {
 ; NO-SIMD128-FAST:         .functype extmul_high_u_v4i32 (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
 ; NO-SIMD128-FAST-NEXT:    i32.const $push0=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $5, $pop0
+; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $5, $pop0
 ; NO-SIMD128-FAST-NEXT:    i32.const $push19=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push1=, $13, $pop19
-; NO-SIMD128-FAST-NEXT:    i32.mul $push3=, $pop2, $pop1
+; NO-SIMD128-FAST-NEXT:    i32.and $push2=, $13, $pop19
+; NO-SIMD128-FAST-NEXT:    i32.mul $push3=, $pop1, $pop2
 ; NO-SIMD128-FAST-NEXT:    i32.store 0($0), $pop3
 ; NO-SIMD128-FAST-NEXT:    i32.const $push18=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push5=, $6, $pop18
+; NO-SIMD128-FAST-NEXT:    i32.and $push4=, $6, $pop18
 ; NO-SIMD128-FAST-NEXT:    i32.const $push17=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push4=, $14, $pop17
-; NO-SIMD128-FAST-NEXT:    i32.mul $push6=, $pop5, $pop4
+; NO-SIMD128-FAST-NEXT:    i32.and $push5=, $14, $pop17
+; NO-SIMD128-FAST-NEXT:    i32.mul $push6=, $pop4, $pop5
 ; NO-SIMD128-FAST-NEXT:    i32.store 4($0), $pop6
 ; NO-SIMD128-FAST-NEXT:    i32.const $push16=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $7, $pop16
+; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $7, $pop16
 ; NO-SIMD128-FAST-NEXT:    i32.const $push15=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push7=, $15, $pop15
-; NO-SIMD128-FAST-NEXT:    i32.mul $push9=, $pop8, $pop7
+; NO-SIMD128-FAST-NEXT:    i32.and $push8=, $15, $pop15
+; NO-SIMD128-FAST-NEXT:    i32.mul $push9=, $pop7, $pop8
 ; NO-SIMD128-FAST-NEXT:    i32.store 8($0), $pop9
 ; NO-SIMD128-FAST-NEXT:    i32.const $push14=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $8, $pop14
+; NO-SIMD128-FAST-NEXT:    i32.and $push10=, $8, $pop14
 ; NO-SIMD128-FAST-NEXT:    i32.const $push13=, 65535
-; NO-SIMD128-FAST-NEXT:    i32.and $push10=, $16, $pop13
-; NO-SIMD128-FAST-NEXT:    i32.mul $push12=, $pop11, $pop10
+; NO-SIMD128-FAST-NEXT:    i32.and $push11=, $16, $pop13
+; NO-SIMD128-FAST-NEXT:    i32.mul $push12=, $pop10, $pop11
 ; NO-SIMD128-FAST-NEXT:    i32.store 12($0), $pop12
 ; NO-SIMD128-FAST-NEXT:    return
   %high1 = shufflevector <8 x i16> %v1, <8 x i16> undef,
@@ -11750,16 +11750,16 @@ define <2 x i64> @bitselect_xor_reversed_v2i64(<2 x i64> %c, <2 x i64> %v1, <2 x
 ; NO-SIMD128-LABEL: bitselect_xor_reversed_v2i64:
 ; NO-SIMD128:         .functype bitselect_xor_reversed_v2i64 (i32, i64, i64, i64, i64, i64, i64) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    i64.xor $push2=, $4, $6
-; NO-SIMD128-NEXT:    i64.const $push0=, -1
-; NO-SIMD128-NEXT:    i64.xor $push1=, $2, $pop0
-; NO-SIMD128-NEXT:    i64.and $push3=, $pop2, $pop1
+; NO-SIMD128-NEXT:    i64.xor $push0=, $4, $6
+; NO-SIMD128-NEXT:    i64.const $push1=, -1
+; NO-SIMD128-NEXT:    i64.xor $push2=, $2, $pop1
+; NO-SIMD128-NEXT:    i64.and $push3=, $pop0, $pop2
 ; NO-SIMD128-NEXT:    i64.xor $push4=, $pop3, $6
 ; NO-SIMD128-NEXT:    i64.store 8($0), $pop4
-; NO-SIMD128-NEXT:    i64.xor $push6=, $3, $5
+; NO-SIMD128-NEXT:    i64.xor $push5=, $3, $5
 ; NO-SIMD128-NEXT:    i64.const $push9=, -1
-; NO-SIMD128-NEXT:    i64.xor $push5=, $1, $pop9
-; NO-SIMD128-NEXT:    i64.and $push7=, $pop6, $pop5
+; NO-SIMD128-NEXT:    i64.xor $push6=, $1, $pop9
+; NO-SIMD128-NEXT:    i64.and $push7=, $pop5, $pop6
 ; NO-SIMD128-NEXT:    i64.xor $push8=, $pop7, $5
 ; NO-SIMD128-NEXT:    i64.store 0($0), $pop8
 ; NO-SIMD128-NEXT:    return
@@ -11767,16 +11767,16 @@ define <2 x i64> @bitselect_xor_reversed_v2i64(<2 x i64> %c, <2 x i64> %v1, <2 x
 ; NO-SIMD128-FAST-LABEL: bitselect_xor_reversed_v2i64:
 ; NO-SIMD128-FAST:         .functype bitselect_xor_reversed_v2i64 (i32, i64, i64, i64, i64, i64, i64) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    i64.xor $push2=, $3, $5
-; NO-SIMD128-FAST-NEXT:    i64.const $push0=, -1
-; NO-SIMD128-FAST-NEXT:    i64.xor $push1=, $1, $pop0
-; NO-SIMD128-FAST-NEXT:    i64.and $push3=, $pop2, $pop1
+; NO-SIMD128-FAST-NEXT:    i64.xor $push0=, $3, $5
+; NO-SIMD128-FAST-NEXT:    i64.const $push1=, -1
+; NO-SIMD128-FAST-NEXT:    i64.xor $push2=, $1, $pop1
+; NO-SIMD128-FAST-NEXT:    i64.and $push3=, $pop0, $pop2
 ; NO-SIMD128-FAST-NEXT:    i64.xor $push4=, $pop3, $5
 ; NO-SIMD128-FAST-NEXT:    i64.store 0($0), $pop4
-; NO-SIMD128-FAST-NEXT:    i64.xor $push6=, $4, $6
+; NO-SIMD128-FAST-NEXT:    i64.xor $push5=, $4, $6
 ; NO-SIMD128-FAST-NEXT:    i64.const $push9=, -1
-; NO-SIMD128-FAST-NEXT:    i64.xor $push5=, $2, $pop9
-; NO-SIMD128-FAST-NEXT:    i64.and $push7=, $pop6, $pop5
+; NO-SIMD128-FAST-NEXT:    i64.xor $push6=, $2, $pop9
+; NO-SIMD128-FAST-NEXT:    i64.and $push7=, $pop5, $pop6
 ; NO-SIMD128-FAST-NEXT:    i64.xor $push8=, $pop7, $6
 ; NO-SIMD128-FAST-NEXT:    i64.store 8($0), $pop8
 ; NO-SIMD128-FAST-NEXT:    return
@@ -11805,26 +11805,26 @@ define <2 x i64> @extmul_low_s_v2i64(<4 x i32> %v1, <4 x i32> %v2) {
 ; NO-SIMD128-LABEL: extmul_low_s_v2i64:
 ; NO-SIMD128:         .functype extmul_low_s_v2i64 (i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    i64.extend_i32_s $push1=, $2
-; NO-SIMD128-NEXT:    i64.extend_i32_s $push0=, $6
-; NO-SIMD128-NEXT:    i64.mul $push2=, $pop1, $pop0
+; NO-SIMD128-NEXT:    i64.extend_i32_s $push0=, $2
+; NO-SIMD128-NEXT:    i64.extend_i32_s $push1=, $6
+; NO-SIMD128-NEXT:    i64.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-NEXT:    i64.store 8($0), $pop2
-; NO-SIMD128-NEXT:    i64.extend_i32_s $push4=, $1
-; NO-SIMD128-NEXT:    i64.extend_i32_s $push3=, $5
-; NO-SIMD128-NEXT:    i64.mul $push5=, $pop4, $pop3
+; NO-SIMD128-NEXT:    i64.extend_i32_s $push3=, $1
+; NO-SIMD128-NEXT:    i64.extend_i32_s $push4=, $5
+; NO-SIMD128-NEXT:    i64.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-NEXT:    i64.store 0($0), $pop5
 ; NO-SIMD128-NEXT:    return
 ;
 ; NO-SIMD128-FAST-LABEL: extmul_low_s_v2i64:
 ; NO-SIMD128-FAST:         .functype extmul_low_s_v2i64 (i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push1=, $1
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push0=, $5
-; NO-SIMD128-FAST-NEXT:    i64.mul $push2=, $pop1, $pop0
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push0=, $1
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push1=, $5
+; NO-SIMD128-FAST-NEXT:    i64.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-FAST-NEXT:    i64.store 0($0), $pop2
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push4=, $2
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push3=, $6
-; NO-SIMD128-FAST-NEXT:    i64.mul $push5=, $pop4, $pop3
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push3=, $2
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push4=, $6
+; NO-SIMD128-FAST-NEXT:    i64.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-FAST-NEXT:    i64.store 8($0), $pop5
 ; NO-SIMD128-FAST-NEXT:    return
   %low1 = shufflevector <4 x i32> %v1, <4 x i32> undef, <2 x i32> <i32 0, i32 1>
@@ -11853,26 +11853,26 @@ define <2 x i64> @extmul_high_s_v2i64(<4 x i32> %v1, <4 x i32> %v2) {
 ; NO-SIMD128-LABEL: extmul_high_s_v2i64:
 ; NO-SIMD128:         .functype extmul_high_s_v2i64 (i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    i64.extend_i32_s $push1=, $4
-; NO-SIMD128-NEXT:    i64.extend_i32_s $push0=, $8
-; NO-SIMD128-NEXT:    i64.mul $push2=, $pop1, $pop0
+; NO-SIMD128-NEXT:    i64.extend_i32_s $push0=, $4
+; NO-SIMD128-NEXT:    i64.extend_i32_s $push1=, $8
+; NO-SIMD128-NEXT:    i64.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-NEXT:    i64.store 8($0), $pop2
-; NO-SIMD128-NEXT:    i64.extend_i32_s $push4=, $3
-; NO-SIMD128-NEXT:    i64.extend_i32_s $push3=, $7
-; NO-SIMD128-NEXT:    i64.mul $push5=, $pop4, $pop3
+; NO-SIMD128-NEXT:    i64.extend_i32_s $push3=, $3
+; NO-SIMD128-NEXT:    i64.extend_i32_s $push4=, $7
+; NO-SIMD128-NEXT:    i64.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-NEXT:    i64.store 0($0), $pop5
 ; NO-SIMD128-NEXT:    return
 ;
 ; NO-SIMD128-FAST-LABEL: extmul_high_s_v2i64:
 ; NO-SIMD128-FAST:         .functype extmul_high_s_v2i64 (i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push1=, $3
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push0=, $7
-; NO-SIMD128-FAST-NEXT:    i64.mul $push2=, $pop1, $pop0
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push0=, $3
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push1=, $7
+; NO-SIMD128-FAST-NEXT:    i64.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-FAST-NEXT:    i64.store 0($0), $pop2
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push4=, $4
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push3=, $8
-; NO-SIMD128-FAST-NEXT:    i64.mul $push5=, $pop4, $pop3
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push3=, $4
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_s $push4=, $8
+; NO-SIMD128-FAST-NEXT:    i64.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-FAST-NEXT:    i64.store 8($0), $pop5
 ; NO-SIMD128-FAST-NEXT:    return
   %high1 = shufflevector <4 x i32> %v1, <4 x i32> undef, <2 x i32> <i32 2, i32 3>
@@ -11901,26 +11901,26 @@ define <2 x i64> @extmul_low_u_v2i64(<4 x i32> %v1, <4 x i32> %v2) {
 ; NO-SIMD128-LABEL: extmul_low_u_v2i64:
 ; NO-SIMD128:         .functype extmul_low_u_v2i64 (i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    i64.extend_i32_u $push1=, $2
-; NO-SIMD128-NEXT:    i64.extend_i32_u $push0=, $6
-; NO-SIMD128-NEXT:    i64.mul $push2=, $pop1, $pop0
+; NO-SIMD128-NEXT:    i64.extend_i32_u $push0=, $2
+; NO-SIMD128-NEXT:    i64.extend_i32_u $push1=, $6
+; NO-SIMD128-NEXT:    i64.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-NEXT:    i64.store 8($0), $pop2
-; NO-SIMD128-NEXT:    i64.extend_i32_u $push4=, $1
-; NO-SIMD128-NEXT:    i64.extend_i32_u $push3=, $5
-; NO-SIMD128-NEXT:    i64.mul $push5=, $pop4, $pop3
+; NO-SIMD128-NEXT:    i64.extend_i32_u $push3=, $1
+; NO-SIMD128-NEXT:    i64.extend_i32_u $push4=, $5
+; NO-SIMD128-NEXT:    i64.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-NEXT:    i64.store 0($0), $pop5
 ; NO-SIMD128-NEXT:    return
 ;
 ; NO-SIMD128-FAST-LABEL: extmul_low_u_v2i64:
 ; NO-SIMD128-FAST:         .functype extmul_low_u_v2i64 (i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push1=, $1
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push0=, $5
-; NO-SIMD128-FAST-NEXT:    i64.mul $push2=, $pop1, $pop0
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push0=, $1
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push1=, $5
+; NO-SIMD128-FAST-NEXT:    i64.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-FAST-NEXT:    i64.store 0($0), $pop2
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push4=, $2
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push3=, $6
-; NO-SIMD128-FAST-NEXT:    i64.mul $push5=, $pop4, $pop3
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push3=, $2
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push4=, $6
+; NO-SIMD128-FAST-NEXT:    i64.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-FAST-NEXT:    i64.store 8($0), $pop5
 ; NO-SIMD128-FAST-NEXT:    return
   %low1 = shufflevector <4 x i32> %v1, <4 x i32> undef, <2 x i32> <i32 0, i32 1>
@@ -11949,26 +11949,26 @@ define <2 x i64> @extmul_high_u_v2i64(<4 x i32> %v1, <4 x i32> %v2) {
 ; NO-SIMD128-LABEL: extmul_high_u_v2i64:
 ; NO-SIMD128:         .functype extmul_high_u_v2i64 (i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    i64.extend_i32_u $push1=, $4
-; NO-SIMD128-NEXT:    i64.extend_i32_u $push0=, $8
-; NO-SIMD128-NEXT:    i64.mul $push2=, $pop1, $pop0
+; NO-SIMD128-NEXT:    i64.extend_i32_u $push0=, $4
+; NO-SIMD128-NEXT:    i64.extend_i32_u $push1=, $8
+; NO-SIMD128-NEXT:    i64.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-NEXT:    i64.store 8($0), $pop2
-; NO-SIMD128-NEXT:    i64.extend_i32_u $push4=, $3
-; NO-SIMD128-NEXT:    i64.extend_i32_u $push3=, $7
-; NO-SIMD128-NEXT:    i64.mul $push5=, $pop4, $pop3
+; NO-SIMD128-NEXT:    i64.extend_i32_u $push3=, $3
+; NO-SIMD128-NEXT:    i64.extend_i32_u $push4=, $7
+; NO-SIMD128-NEXT:    i64.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-NEXT:    i64.store 0($0), $pop5
 ; NO-SIMD128-NEXT:    return
 ;
 ; NO-SIMD128-FAST-LABEL: extmul_high_u_v2i64:
 ; NO-SIMD128-FAST:         .functype extmul_high_u_v2i64 (i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push1=, $3
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push0=, $7
-; NO-SIMD128-FAST-NEXT:    i64.mul $push2=, $pop1, $pop0
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push0=, $3
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push1=, $7
+; NO-SIMD128-FAST-NEXT:    i64.mul $push2=, $pop0, $pop1
 ; NO-SIMD128-FAST-NEXT:    i64.store 0($0), $pop2
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push4=, $4
-; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push3=, $8
-; NO-SIMD128-FAST-NEXT:    i64.mul $push5=, $pop4, $pop3
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push3=, $4
+; NO-SIMD128-FAST-NEXT:    i64.extend_i32_u $push4=, $8
+; NO-SIMD128-FAST-NEXT:    i64.mul $push5=, $pop3, $pop4
 ; NO-SIMD128-FAST-NEXT:    i64.store 8($0), $pop5
 ; NO-SIMD128-FAST-NEXT:    return
   %high1 = shufflevector <4 x i32> %v1, <4 x i32> undef, <2 x i32> <i32 2, i32 3>
@@ -13481,24 +13481,24 @@ define <4 x i32> @pmax_int_v4f32(<4 x i32> %x, <4 x i32> %y) {
 ; NO-SIMD128-LABEL: pmax_int_v4f32:
 ; NO-SIMD128:         .functype pmax_int_v4f32 (i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push1=, $4
-; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push0=, $8
-; NO-SIMD128-NEXT:    f32.lt $push2=, $pop1, $pop0
+; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push0=, $4
+; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push1=, $8
+; NO-SIMD128-NEXT:    f32.lt $push2=, $pop0, $pop1
 ; NO-SIMD128-NEXT:    i32.select $push3=, $8, $4, $pop2
 ; NO-SIMD128-NEXT:    i32.store 12($0), $pop3
-; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push5=, $3
-; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push4=, $7
-; NO-SIMD128-NEXT:    f32.lt $push6=, $pop5, $pop4
+; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push4=, $3
+; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push5=, $7
+; NO-SIMD128-NEXT:    f32.lt $push6=, $pop4, $pop5
 ; NO-SIMD128-NEXT:    i32.select $push7=, $7, $3, $pop6
 ; NO-SIMD128-NEXT:    i32.store 8($0), $pop7
-; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push9=, $2
-; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push8=, $6
-; NO-SIMD128-NEXT:    f32.lt $push10=, $pop9, $pop8
+; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push8=, $2
+; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push9=, $6
+; NO-SIMD128-NEXT:    f32.lt $push10=, $pop8, $pop9
 ; NO-SIMD128-NEXT:    i32.select $push11=, $6, $2, $pop10
 ; NO-SIMD128-NEXT:    i32.store 4($0), $pop11
-; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push13=, $1
-; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push12=, $5
-; NO-SIMD128-NEXT:    f32.lt $push14=, $pop13, $pop12
+; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push12=, $1
+; NO-SIMD128-NEXT:    f32.reinterpret_i32 $push13=, $5
+; NO-SIMD128-NEXT:    f32.lt $push14=, $pop12, $pop13
 ; NO-SIMD128-NEXT:    i32.select $push15=, $5, $1, $pop14
 ; NO-SIMD128-NEXT:    i32.store 0($0), $pop15
 ; NO-SIMD128-NEXT:    return
@@ -13506,24 +13506,24 @@ define <4 x i32> @pmax_int_v4f32(<4 x i32> %x, <4 x i32> %y) {
 ; NO-SIMD128-FAST-LABEL: pmax_int_v4f32:
 ; NO-SIMD128-FAST:         .functype pmax_int_v4f32 (i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push1=, $1
-; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push0=, $5
-; NO-SIMD128-FAST-NEXT:    f32.lt $push2=, $pop1, $pop0
+; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push0=, $1
+; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push1=, $5
+; NO-SIMD128-FAST-NEXT:    f32.lt $push2=, $pop0, $pop1
 ; NO-SIMD128-FAST-NEXT:    i32.select $push3=, $5, $1, $pop2
 ; NO-SIMD128-FAST-NEXT:    i32.store 0($0), $pop3
-; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push5=, $2
-; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push4=, $6
-; NO-SIMD128-FAST-NEXT:    f32.lt $push6=, $pop5, $pop4
+; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push4=, $2
+; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push5=, $6
+; NO-SIMD128-FAST-NEXT:    f32.lt $push6=, $pop4, $pop5
 ; NO-SIMD128-FAST-NEXT:    i32.select $push7=, $6, $2, $pop6
 ; NO-SIMD128-FAST-NEXT:    i32.store 4($0), $pop7
-; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push9=, $3
-; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push8=, $7
-; NO-SIMD128-FAST-NEXT:    f32.lt $push10=, $pop9, $pop8
+; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push8=, $3
+; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push9=, $7
+; NO-SIMD128-FAST-NEXT:    f32.lt $push10=, $pop8, $pop9
 ; NO-SIMD128-FAST-NEXT:    i32.select $push11=, $7, $3, $pop10
 ; NO-SIMD128-FAST-NEXT:    i32.store 8($0), $pop11
-; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push13=, $4
-; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push12=, $8
-; NO-SIMD128-FAST-NEXT:    f32.lt $push14=, $pop13, $pop12
+; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push12=, $4
+; NO-SIMD128-FAST-NEXT:    f32.reinterpret_i32 $push13=, $8
+; NO-SIMD128-FAST-NEXT:    f32.lt $push14=, $pop12, $pop13
 ; NO-SIMD128-FAST-NEXT:    i32.select $push15=, $8, $4, $pop14
 ; NO-SIMD128-FAST-NEXT:    i32.store 12($0), $pop15
 ; NO-SIMD128-FAST-NEXT:    return
@@ -14305,14 +14305,14 @@ define <2 x i64> @pmax_int_v2f64(<2 x i64> %x, <2 x i64> %y) {
 ; NO-SIMD128-LABEL: pmax_int_v2f64:
 ; NO-SIMD128:         .functype pmax_int_v2f64 (i32, i64, i64, i64, i64) -> ()
 ; NO-SIMD128-NEXT:  # %bb.0:
-; NO-SIMD128-NEXT:    f64.reinterpret_i64 $push1=, $2
-; NO-SIMD128-NEXT:    f64.reinterpret_i64 $push0=, $4
-; NO-SIMD128-NEXT:    f64.lt $push2=, $pop1, $pop0
+; NO-SIMD128-NEXT:    f64.reinterpret_i64 $push0=, $2
+; NO-SIMD128-NEXT:    f64.reinterpret_i64 $push1=, $4
+; NO-SIMD128-NEXT:    f64.lt $push2=, $pop0, $pop1
 ; NO-SIMD128-NEXT:    i64.select $push3=, $4, $2, $pop2
 ; NO-SIMD128-NEXT:    i64.store 8($0), $pop3
-; NO-SIMD128-NEXT:    f64.reinterpret_i64 $push5=, $1
-; NO-SIMD128-NEXT:    f64.reinterpret_i64 $push4=, $3
-; NO-SIMD128-NEXT:    f64.lt $push6=, $pop5, $pop4
+; NO-SIMD128-NEXT:    f64.reinterpret_i64 $push4=, $1
+; NO-SIMD128-NEXT:    f64.reinterpret_i64 $push5=, $3
+; NO-SIMD128-NEXT:    f64.lt $push6=, $pop4, $pop5
 ; NO-SIMD128-NEXT:    i64.select $push7=, $3, $1, $pop6
 ; NO-SIMD128-NEXT:    i64.store 0($0), $pop7
 ; NO-SIMD128-NEXT:    return
@@ -14320,14 +14320,14 @@ define <2 x i64> @pmax_int_v2f64(<2 x i64> %x, <2 x i64> %y) {
 ; NO-SIMD128-FAST-LABEL: pmax_int_v2f64:
 ; NO-SIMD128-FAST:         .functype pmax_int_v2f64 (i32, i64, i64, i64, i64) -> ()
 ; NO-SIMD128-FAST-NEXT:  # %bb.0:
-; NO-SIMD128-FAST-NEXT:    f64.reinterpret_i64 $push1=, $1
-; NO-SIMD128-FAST-NEXT:    f64.reinterpret_i64 $push0=, $3
-; NO-SIMD128-FAST-NEXT:    f64.lt $push2=, $pop1, $pop0
+; NO-SIMD128-FAST-NEXT:    f64.reinterpret_i64 $push0=, $1
+; NO-SIMD128-FAST-NEXT:    f64.reinterpret_i64 $push1=, $3
+; NO-SIMD128-FAST-NEXT:    f64.lt $push2=, $pop0, $pop1
 ; NO-SIMD128-FAST-NEXT:    i64.select $push3=, $3, $1, $pop2
 ; NO-SIMD128-FAST-NEXT:    i64.store 0($0), $pop3
-; NO-SIMD128-FAST-NEXT:    f64.reinterpret_i64 $push5=, $2
-; NO-SIMD128-FAST-NEXT:    f64.reinterpret_i64 $push4=, $4
-; NO-SIMD128-FAST-NEXT:    f64.lt $push6=, $pop5, $pop4
+; NO-SIMD128-FAST-NEXT:    f64.reinterpret_i64 $push4=, $2
+; NO-SIMD128-FAST-NEXT:    f64.reinterpret_i64 $push5=, $4
+; NO-SIMD128-FAST-NEXT:    f64.lt $push6=, $pop4, $pop5
 ; NO-SIMD128-FAST-NEXT:    i64.select $push7=, $4, $2, $pop6
 ; NO-SIMD128-FAST-NEXT:    i64.store 8($0), $pop7
 ; NO-SIMD128-FAST-NEXT:    return

--- a/llvm/test/CodeGen/WebAssembly/simd-relaxed-dot.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-relaxed-dot.ll
@@ -71,9 +71,9 @@ define <8 x i16> @relaxed_dot_zext(<16 x i8> %a, <16 x i8> %b) {
 ; CHECK-NEXT:    local.tee $push5=, $2=, $pop6
 ; CHECK-NEXT:    i16x8.extmul_high_i8x16_u $push4=, $0, $1
 ; CHECK-NEXT:    local.tee $push3=, $1=, $pop4
-; CHECK-NEXT:    i8x16.shuffle $push1=, $pop5, $pop3, 0, 1, 4, 5, 8, 9, 12, 13, 16, 17, 20, 21, 24, 25, 28, 29
-; CHECK-NEXT:    i8x16.shuffle $push0=, $2, $1, 2, 3, 6, 7, 10, 11, 14, 15, 18, 19, 22, 23, 26, 27, 30, 31
-; CHECK-NEXT:    i16x8.add $push2=, $pop1, $pop0
+; CHECK-NEXT:    i8x16.shuffle $push0=, $pop5, $pop3, 0, 1, 4, 5, 8, 9, 12, 13, 16, 17, 20, 21, 24, 25, 28, 29
+; CHECK-NEXT:    i8x16.shuffle $push1=, $2, $1, 2, 3, 6, 7, 10, 11, 14, 15, 18, 19, 22, 23, 26, 27, 30, 31
+; CHECK-NEXT:    i16x8.add $push2=, $pop0, $pop1
 ; CHECK-NEXT:    return $pop2
   %zext1 = zext <16 x i8> %a to <16 x i16>
   %zext2 = zext <16 x i8> %b to <16 x i16>

--- a/llvm/test/CodeGen/WebAssembly/simd-setcc.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-setcc.ll
@@ -9,9 +9,9 @@ define i1 @setcc_load(ptr %a, ptr %b) {
 ; CHECK-LABEL: setcc_load:
 ; CHECK:         .functype setcc_load (i32, i32) -> (i32)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    v128.load $push1=, 0($0):p2align=0
-; CHECK-NEXT:    v128.load $push0=, 0($1):p2align=0
-; CHECK-NEXT:    i8x16.eq $push2=, $pop1, $pop0
+; CHECK-NEXT:    v128.load $push0=, 0($0):p2align=0
+; CHECK-NEXT:    v128.load $push1=, 0($1):p2align=0
+; CHECK-NEXT:    i8x16.eq $push2=, $pop0, $pop1
 ; CHECK-NEXT:    i8x16.all_true $push3=, $pop2
 ; CHECK-NEXT:    return $pop3
   %cmp_16 = call i32 @memcmp(ptr %a, ptr %b, i32 16)
@@ -24,12 +24,12 @@ define i1 @setcc_load_should_not_vectorize(ptr %a, ptr %b) noimplicitfloat {
 ; CHECK-LABEL: setcc_load_should_not_vectorize:
 ; CHECK:         .functype setcc_load_should_not_vectorize (i32, i32) -> (i32)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    i64.load $push4=, 0($0):p2align=0
-; CHECK-NEXT:    i64.load $push3=, 0($1):p2align=0
-; CHECK-NEXT:    i64.xor $push5=, $pop4, $pop3
-; CHECK-NEXT:    i64.load $push1=, 8($0):p2align=0
-; CHECK-NEXT:    i64.load $push0=, 8($1):p2align=0
-; CHECK-NEXT:    i64.xor $push2=, $pop1, $pop0
+; CHECK-NEXT:    i64.load $push3=, 0($0):p2align=0
+; CHECK-NEXT:    i64.load $push4=, 0($1):p2align=0
+; CHECK-NEXT:    i64.xor $push5=, $pop3, $pop4
+; CHECK-NEXT:    i64.load $push0=, 8($0):p2align=0
+; CHECK-NEXT:    i64.load $push1=, 8($1):p2align=0
+; CHECK-NEXT:    i64.xor $push2=, $pop0, $pop1
 ; CHECK-NEXT:    i64.or $push6=, $pop5, $pop2
 ; CHECK-NEXT:    i64.eqz $push7=, $pop6
 ; CHECK-NEXT:    return $pop7

--- a/llvm/test/CodeGen/WebAssembly/strided-int-mac.ll
+++ b/llvm/test/CodeGen/WebAssembly/strided-int-mac.ll
@@ -7,6 +7,9 @@ target triple = "wasm32"
 ; CHECK-LABEL: bb2053_inner_loop:
 ; CHECK: loop
 ; CHECK: v128.load
+; CHECK: i8x16.shuffle	0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i16x8.extend_low_i8x16_s
+; CHECK: v128.load
 ; CHECK: i32x4.extract_lane	3
 ; CHECK: i32x4.extract_lane	2
 ; CHECK: i32x4.extract_lane	1
@@ -16,25 +19,22 @@ target triple = "wasm32"
 ; CHECK: v128.load8_lane	0, 2
 ; CHECK: v128.load8_lane	0, 3
 ; CHECK: i16x8.extend_low_i8x16_s
-; CHECK: v128.load
-; CHECK: i8x16.shuffle	1, 5, 9, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-; CHECK: i16x8.extend_low_i8x16_s
 ; CHECK: i32x4.extmul_low_i16x8_s
 ; CHECK: i32x4.add
+; CHECK: i8x16.shuffle	2, 6, 10, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i16x8.extend_low_i8x16_s
 ; CHECK: v128.load8_splat	0
 ; CHECK: v128.load8_lane	0, 1
 ; CHECK: v128.load8_lane	0, 2
 ; CHECK: v128.load8_lane	0, 3
 ; CHECK: i16x8.extend_low_i8x16_s
+; CHECK: i32x4.extmul_low_i16x8_s
+; CHECK: i32x4.add
+; CHECK: i8x16.shuffle	1, 5, 9, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i16x8.extend_low_i8x16_s
+; CHECK: i32x4.extmul_low_i16x8_s
+; CHECK: i32x4.add
 ; CHECK: i8x16.shuffle	3, 7, 11, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-; CHECK: i16x8.extend_low_i8x16_s
-; CHECK: i32x4.extmul_low_i16x8_s
-; CHECK: i32x4.add
-; CHECK: i8x16.shuffle	0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-; CHECK: i16x8.extend_low_i8x16_s
-; CHECK: i32x4.extmul_low_i16x8_s
-; CHECK: i32x4.add
-; CHECK: i8x16.shuffle	2, 6, 10, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: i16x8.extend_low_i8x16_s
 ; CHECK: i32x4.extmul_low_i16x8_s
 ; CHECK: i32x4.add
@@ -59,82 +59,48 @@ target triple = "wasm32"
 
 ; MAX-BANDWIDTH: loop
 ; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: i32x4.extract_lane	3
-; MAX-BANDWIDTH: i32x4.extract_lane	2
-; MAX-BANDWIDTH: i32x4.extract_lane	1
-; MAX-BANDWIDTH: i32x4.extract_lane	0
 ; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: i32x4.extract_lane	3
-; MAX-BANDWIDTH: i32x4.extract_lane	2
-; MAX-BANDWIDTH: i32x4.extract_lane	1
-; MAX-BANDWIDTH: i32x4.extract_lane	0
-; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: i32x4.extract_lane	3
-; MAX-BANDWIDTH: i32x4.extract_lane	2
-; MAX-BANDWIDTH: i32x4.extract_lane	1
-; MAX-BANDWIDTH: i32x4.extract_lane	0
-; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: i32x4.extract_lane	3
-; MAX-BANDWIDTH: i32x4.extract_lane	2
-; MAX-BANDWIDTH: i32x4.extract_lane	1
-; MAX-BANDWIDTH: i32x4.extract_lane	0
-; MAX-BANDWIDTH: v128.load8_splat	0
-; MAX-BANDWIDTH: v128.load8_lane	0, 1
-; MAX-BANDWIDTH: v128.load8_lane	0, 2
-; MAX-BANDWIDTH: v128.load8_lane	0, 3
-; MAX-BANDWIDTH: v128.load8_lane	0, 4
-; MAX-BANDWIDTH: v128.load8_lane	0, 5
-; MAX-BANDWIDTH: v128.load8_lane	0, 6
-; MAX-BANDWIDTH: v128.load8_lane	0, 7
-; MAX-BANDWIDTH: v128.load8_lane	0, 8
-; MAX-BANDWIDTH: v128.load8_lane	0, 9
-; MAX-BANDWIDTH: v128.load8_lane	0, 10
-; MAX-BANDWIDTH: v128.load8_lane	0, 11
-; MAX-BANDWIDTH: v128.load8_lane	0, 12
-; MAX-BANDWIDTH: v128.load8_lane	0, 13
-; MAX-BANDWIDTH: v128.load8_lane	0, 14
-; MAX-BANDWIDTH: v128.load8_lane	0, 15
-; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: i8x16.shuffle	3, 7, 11, 15, 19, 23, 27, 31, 0, 0, 0, 0, 0, 0, 0, 0
-; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: i8x16.shuffle	0, 0, 0, 0, 0, 0, 0, 0, 3, 7, 11, 15, 19, 23, 27, 31
-; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
-; MAX-BANDWIDTH: i16x8.extmul_low_i8x16_s
-; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
-; MAX-BANDWIDTH: i16x8.extmul_high_i8x16_s
-; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
-; MAX-BANDWIDTH: i32x4.add
-; MAX-BANDWIDTH: v128.load8_splat	0
-; MAX-BANDWIDTH: v128.load8_lane	0, 1
-; MAX-BANDWIDTH: v128.load8_lane	0, 2
-; MAX-BANDWIDTH: v128.load8_lane	0, 3
-; MAX-BANDWIDTH: v128.load8_lane	0, 4
-; MAX-BANDWIDTH: v128.load8_lane	0, 5
-; MAX-BANDWIDTH: v128.load8_lane	0, 6
-; MAX-BANDWIDTH: v128.load8_lane	0, 7
-; MAX-BANDWIDTH: v128.load8_lane	0, 8
-; MAX-BANDWIDTH: v128.load8_lane	0, 9
-; MAX-BANDWIDTH: v128.load8_lane	0, 10
-; MAX-BANDWIDTH: v128.load8_lane	0, 11
-; MAX-BANDWIDTH: v128.load8_lane	0, 12
-; MAX-BANDWIDTH: v128.load8_lane	0, 13
-; MAX-BANDWIDTH: v128.load8_lane	0, 14
-; MAX-BANDWIDTH: v128.load8_lane	0, 15
-; MAX-BANDWIDTH: i8x16.shuffle	1, 5, 9, 13, 17, 21, 25, 29, 0, 0, 0, 0, 0, 0, 0, 0
-; MAX-BANDWIDTH: i8x16.shuffle	0, 0, 0, 0, 0, 0, 0, 0, 1, 5, 9, 13, 17, 21, 25, 29
-; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
-; MAX-BANDWIDTH: i16x8.extmul_low_i8x16_s
-; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
-; MAX-BANDWIDTH: i16x8.extmul_high_i8x16_s
-; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
-; MAX-BANDWIDTH: i32x4.add
-; MAX-BANDWIDTH: i32x4.add
-; MAX-BANDWIDTH: i32x4.add
 ; MAX-BANDWIDTH: i8x16.shuffle	2, 6, 10, 14, 18, 22, 26, 30, 0, 0, 0, 0, 0, 0, 0, 0
+; MAX-BANDWIDTH: v128.load
+; MAX-BANDWIDTH: v128.load
 ; MAX-BANDWIDTH: i8x16.shuffle	0, 0, 0, 0, 0, 0, 0, 0, 2, 6, 10, 14, 18, 22, 26, 30
 ; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
+; MAX-BANDWIDTH: v128.load
+; MAX-BANDWIDTH: i32x4.extract_lane	3
+; MAX-BANDWIDTH: i32x4.extract_lane	2
+; MAX-BANDWIDTH: i32x4.extract_lane	1
+; MAX-BANDWIDTH: i32x4.extract_lane	0
+; MAX-BANDWIDTH: v128.load
+; MAX-BANDWIDTH: i32x4.extract_lane	3
+; MAX-BANDWIDTH: i32x4.extract_lane	2
+; MAX-BANDWIDTH: i32x4.extract_lane	1
+; MAX-BANDWIDTH: i32x4.extract_lane	0
+; MAX-BANDWIDTH: v128.load
+; MAX-BANDWIDTH: i32x4.extract_lane	3
+; MAX-BANDWIDTH: i32x4.extract_lane	2
+; MAX-BANDWIDTH: i32x4.extract_lane	1
+; MAX-BANDWIDTH: i32x4.extract_lane	0
+; MAX-BANDWIDTH: v128.load
+; MAX-BANDWIDTH: i32x4.extract_lane	3
+; MAX-BANDWIDTH: i32x4.extract_lane	2
+; MAX-BANDWIDTH: i32x4.extract_lane	1
+; MAX-BANDWIDTH: i32x4.extract_lane	0
+; MAX-BANDWIDTH: v128.load8_splat	0
+; MAX-BANDWIDTH: v128.load8_lane	0, 1
+; MAX-BANDWIDTH: v128.load8_lane	0, 2
+; MAX-BANDWIDTH: v128.load8_lane	0, 3
+; MAX-BANDWIDTH: v128.load8_lane	0, 4
+; MAX-BANDWIDTH: v128.load8_lane	0, 5
+; MAX-BANDWIDTH: v128.load8_lane	0, 6
+; MAX-BANDWIDTH: v128.load8_lane	0, 7
+; MAX-BANDWIDTH: v128.load8_lane	0, 8
+; MAX-BANDWIDTH: v128.load8_lane	0, 9
+; MAX-BANDWIDTH: v128.load8_lane	0, 10
+; MAX-BANDWIDTH: v128.load8_lane	0, 11
+; MAX-BANDWIDTH: v128.load8_lane	0, 12
+; MAX-BANDWIDTH: v128.load8_lane	0, 13
+; MAX-BANDWIDTH: v128.load8_lane	0, 14
+; MAX-BANDWIDTH: v128.load8_lane	0, 15
 ; MAX-BANDWIDTH: i16x8.extmul_low_i8x16_s
 ; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
 ; MAX-BANDWIDTH: i16x8.extmul_high_i8x16_s
@@ -142,6 +108,40 @@ target triple = "wasm32"
 ; MAX-BANDWIDTH: i32x4.add
 ; MAX-BANDWIDTH: i8x16.shuffle	0, 4, 8, 12, 16, 20, 24, 28, 0, 0, 0, 0, 0, 0, 0, 0
 ; MAX-BANDWIDTH: i8x16.shuffle	0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 8, 12, 16, 20, 24, 28
+; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
+; MAX-BANDWIDTH: v128.load8_splat	0
+; MAX-BANDWIDTH: v128.load8_lane	0, 1
+; MAX-BANDWIDTH: v128.load8_lane	0, 2
+; MAX-BANDWIDTH: v128.load8_lane	0, 3
+; MAX-BANDWIDTH: v128.load8_lane	0, 4
+; MAX-BANDWIDTH: v128.load8_lane	0, 5
+; MAX-BANDWIDTH: v128.load8_lane	0, 6
+; MAX-BANDWIDTH: v128.load8_lane	0, 7
+; MAX-BANDWIDTH: v128.load8_lane	0, 8
+; MAX-BANDWIDTH: v128.load8_lane	0, 9
+; MAX-BANDWIDTH: v128.load8_lane	0, 10
+; MAX-BANDWIDTH: v128.load8_lane	0, 11
+; MAX-BANDWIDTH: v128.load8_lane	0, 12
+; MAX-BANDWIDTH: v128.load8_lane	0, 13
+; MAX-BANDWIDTH: v128.load8_lane	0, 14
+; MAX-BANDWIDTH: v128.load8_lane	0, 15
+; MAX-BANDWIDTH: i16x8.extmul_low_i8x16_s
+; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
+; MAX-BANDWIDTH: i16x8.extmul_high_i8x16_s
+; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
+; MAX-BANDWIDTH: i32x4.add
+; MAX-BANDWIDTH: i32x4.add
+; MAX-BANDWIDTH: i32x4.add
+; MAX-BANDWIDTH: i8x16.shuffle	3, 7, 11, 15, 19, 23, 27, 31, 0, 0, 0, 0, 0, 0, 0, 0
+; MAX-BANDWIDTH: i8x16.shuffle	0, 0, 0, 0, 0, 0, 0, 0, 3, 7, 11, 15, 19, 23, 27, 31
+; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
+; MAX-BANDWIDTH: i16x8.extmul_low_i8x16_s
+; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
+; MAX-BANDWIDTH: i16x8.extmul_high_i8x16_s
+; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
+; MAX-BANDWIDTH: i32x4.add
+; MAX-BANDWIDTH: i8x16.shuffle	1, 5, 9, 13, 17, 21, 25, 29, 0, 0, 0, 0, 0, 0, 0, 0
+; MAX-BANDWIDTH: i8x16.shuffle	0, 0, 0, 0, 0, 0, 0, 0, 1, 5, 9, 13, 17, 21, 25, 29
 ; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
 ; MAX-BANDWIDTH: i16x8.extmul_low_i8x16_s
 ; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
@@ -207,74 +207,74 @@ target triple = "wasm32"
 
 ; RELAXED-MAX-BANDWIDTH: loop
 ; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	3
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	2
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	1
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	0
 ; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	3
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	2
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	1
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	0
-; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	3
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	2
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	1
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	0
-; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	3
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	2
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	1
-; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	0
-; RELAXED-MAX-BANDWIDTH: v128.load8_splat	0
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 1
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 2
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 3
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 4
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 5
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 6
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 7
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 8
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 9
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 10
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 11
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 12
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 13
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 14
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 15
-; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	3, 7, 11, 15, 19, 23, 27, 31, 0, 0, 0, 0, 0, 0, 0, 0
-; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 0, 0, 0, 0, 0, 0, 0, 3, 7, 11, 15, 19, 23, 27, 31
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
-; RELAXED-MAX-BANDWIDTH: v128.load8_splat	0
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 1
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 2
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 3
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 4
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 5
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 6
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 7
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 8
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 9
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 10
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 11
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 12
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 13
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 14
-; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 15
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	1, 5, 9, 13, 17, 21, 25, 29, 0, 0, 0, 0, 0, 0, 0, 0
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 0, 0, 0, 0, 0, 0, 0, 1, 5, 9, 13, 17, 21, 25, 29
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
-; RELAXED-MAX-BANDWIDTH: i32x4.relaxed_dot_i8x16_i7x16_add_s
-; RELAXED-MAX-BANDWIDTH: i32x4.relaxed_dot_i8x16_i7x16_add_s
 ; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	2, 6, 10, 14, 18, 22, 26, 30, 0, 0, 0, 0, 0, 0, 0, 0
+; RELAXED-MAX-BANDWIDTH: v128.load
+; RELAXED-MAX-BANDWIDTH: v128.load
 ; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 0, 0, 0, 0, 0, 0, 0, 2, 6, 10, 14, 18, 22, 26, 30
 ; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
+; RELAXED-MAX-BANDWIDTH: v128.load
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	3
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	2
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	1
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	0
+; RELAXED-MAX-BANDWIDTH: v128.load
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	3
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	2
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	1
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	0
+; RELAXED-MAX-BANDWIDTH: v128.load
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	3
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	2
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	1
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	0
+; RELAXED-MAX-BANDWIDTH: v128.load
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	3
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	2
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	1
+; RELAXED-MAX-BANDWIDTH: i32x4.extract_lane	0
+; RELAXED-MAX-BANDWIDTH: v128.load8_splat	0
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 1
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 2
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 3
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 4
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 5
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 6
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 7
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 8
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 9
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 10
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 11
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 12
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 13
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 14
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 15
 ; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 4, 8, 12, 16, 20, 24, 28, 0, 0, 0, 0, 0, 0, 0, 0
 ; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 8, 12, 16, 20, 24, 28
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
+; RELAXED-MAX-BANDWIDTH: v128.load8_splat	0
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 1
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 2
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 3
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 4
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 5
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 6
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 7
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 8
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 9
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 10
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 11
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 12
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 13
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 14
+; RELAXED-MAX-BANDWIDTH: v128.load8_lane	0, 15
+; RELAXED-MAX-BANDWIDTH: i32x4.relaxed_dot_i8x16_i7x16_add_s
+; RELAXED-MAX-BANDWIDTH: i32x4.relaxed_dot_i8x16_i7x16_add_s
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	3, 7, 11, 15, 19, 23, 27, 31, 0, 0, 0, 0, 0, 0, 0, 0
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 0, 0, 0, 0, 0, 0, 0, 3, 7, 11, 15, 19, 23, 27, 31
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	1, 5, 9, 13, 17, 21, 25, 29, 0, 0, 0, 0, 0, 0, 0, 0
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 0, 0, 0, 0, 0, 0, 0, 1, 5, 9, 13, 17, 21, 25, 29
 ; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
 ; RELAXED-MAX-BANDWIDTH: i32x4.relaxed_dot_i8x16_i7x16_add_s
 ; RELAXED-MAX-BANDWIDTH: i32x4.relaxed_dot_i8x16_i7x16_add_s
@@ -382,18 +382,18 @@ bb2053.exit:
 ; CHECK-LABEL: bb41_inner_loop:
 ; CHECK: loop
 ; CHECK: v128.load64_zero
-; CHECK: i8x16.shuffle	1, 3, 5, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i8x16.shuffle	0, 2, 4, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: i16x8.extend_low_i8x16_s
 ; CHECK: v128.load64_zero
+; CHECK: i8x16.shuffle	0, 2, 4, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i16x8.extend_low_i8x16_s
+; CHECK: i32x4.extmul_low_i16x8_s
+; CHECK: i32x4.add
 ; CHECK: i8x16.shuffle	1, 3, 5, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: i16x8.extend_low_i8x16_s
 ; CHECK: i32x4.extmul_low_i16x8_s
 ; CHECK: i32x4.add
-; CHECK: i8x16.shuffle	0, 2, 4, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-; CHECK: i16x8.extend_low_i8x16_s
-; CHECK: i32x4.extmul_low_i16x8_s
-; CHECK: i32x4.add
-; CHECK: i8x16.shuffle	0, 2, 4, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+; CHECK: i8x16.shuffle	1, 3, 5, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK: i16x8.extend_low_i8x16_s
 ; CHECK: i32x4.extmul_low_i16x8_s
 ; CHECK: i32x4.add
@@ -403,16 +403,9 @@ bb2053.exit:
 ; MAX-BANDWIDTH: loop
 ; MAX-BANDWIDTH: v128.load
 ; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: i8x16.shuffle	1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31
+; MAX-BANDWIDTH: i8x16.shuffle	0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30
 ; MAX-BANDWIDTH: v128.load
 ; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: i8x16.shuffle	1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31
-; MAX-BANDWIDTH: i16x8.extmul_low_i8x16_s
-; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
-; MAX-BANDWIDTH: i16x8.extmul_high_i8x16_s
-; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
-; MAX-BANDWIDTH: i32x4.add
-; MAX-BANDWIDTH: i32x4.add
 ; MAX-BANDWIDTH: i8x16.shuffle	0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30
 ; MAX-BANDWIDTH: i16x8.extmul_low_i8x16_s
 ; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
@@ -420,7 +413,14 @@ bb2053.exit:
 ; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
 ; MAX-BANDWIDTH: i32x4.add
 ; MAX-BANDWIDTH: i32x4.add
-; MAX-BANDWIDTH: i8x16.shuffle	0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30
+; MAX-BANDWIDTH: i8x16.shuffle	1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31
+; MAX-BANDWIDTH: i16x8.extmul_low_i8x16_s
+; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
+; MAX-BANDWIDTH: i16x8.extmul_high_i8x16_s
+; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
+; MAX-BANDWIDTH: i32x4.add
+; MAX-BANDWIDTH: i32x4.add
+; MAX-BANDWIDTH: i8x16.shuffle	1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31
 ; MAX-BANDWIDTH: i16x8.extmul_low_i8x16_s
 ; MAX-BANDWIDTH: i32x4.extadd_pairwise_i16x8_s
 ; MAX-BANDWIDTH: i16x8.extmul_high_i8x16_s
@@ -437,14 +437,14 @@ bb2053.exit:
 ; RELAXED-MAX-BANDWIDTH: loop
 ; RELAXED-MAX-BANDWIDTH: v128.load
 ; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30
 ; RELAXED-MAX-BANDWIDTH: v128.load
 ; RELAXED-MAX-BANDWIDTH: v128.load
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30
+; RELAXED-MAX-BANDWIDTH: i32x4.relaxed_dot_i8x16_i7x16_add_s
 ; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31
 ; RELAXED-MAX-BANDWIDTH: i32x4.relaxed_dot_i8x16_i7x16_add_s
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30
-; RELAXED-MAX-BANDWIDTH: i32x4.relaxed_dot_i8x16_i7x16_add_s
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31
 ; RELAXED-MAX-BANDWIDTH: i32x4.relaxed_dot_i8x16_i7x16_add_s
 ; RELAXED-MAX-BANDWIDTH: i32x4.relaxed_dot_i8x16_i7x16_add_s
 define hidden { i32, i32, i32, i32 } @bb41_inner_loop(ptr nocapture %lhs, ptr nocapture %rhs, i32 %len, i32 %acc00, i32 %acc01, i32 %acc10, i32 %acc11) local_unnamed_addr {
@@ -495,16 +495,16 @@ bb41.exit:
 ; CHECK: loop
 ; CHECK: v128.load
 ; CHECK: v128.load
-; CHECK: i8x16.shuffle	4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
+; CHECK: i8x16.shuffle	0, 1, 8, 9, 16, 17, 24, 25, 0, 1, 0, 1, 0, 1, 0, 1
 ; CHECK: v128.load
 ; CHECK: v128.load
-; CHECK: i8x16.shuffle	4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
-; CHECK: i32x4.extmul_low_i16x8_s
-; CHECK: i32x4.add
 ; CHECK: i8x16.shuffle	0, 1, 8, 9, 16, 17, 24, 25, 0, 1, 0, 1, 0, 1, 0, 1
 ; CHECK: i32x4.extmul_low_i16x8_s
 ; CHECK: i32x4.add
-; CHECK: i8x16.shuffle	0, 1, 8, 9, 16, 17, 24, 25, 0, 1, 0, 1, 0, 1, 0, 1
+; CHECK: i8x16.shuffle	4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
+; CHECK: i32x4.extmul_low_i16x8_s
+; CHECK: i32x4.add
+; CHECK: i8x16.shuffle	4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
 ; CHECK: i32x4.extmul_low_i16x8_s
 ; CHECK: i32x4.add
 ; CHECK: i32x4.extmul_low_i16x8_s
@@ -513,27 +513,27 @@ bb41.exit:
 ; MAX-BANDWIDTH: loop
 ; MAX-BANDWIDTH: v128.load
 ; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: i8x16.shuffle	4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
-; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 4, 5, 12, 13, 20, 21, 28, 29
-; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
-; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: i8x16.shuffle	4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
-; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: v128.load
-; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 4, 5, 12, 13, 20, 21, 28, 29
-; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
-; MAX-BANDWIDTH: i32x4.dot_i16x8_s
-; MAX-BANDWIDTH: i32x4.add
 ; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 8, 9, 16, 17, 24, 25, 0, 1, 0, 1, 0, 1, 0, 1
+; MAX-BANDWIDTH: v128.load
+; MAX-BANDWIDTH: v128.load
+; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 8, 9, 16, 17, 24, 25
+; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
+; MAX-BANDWIDTH: v128.load
+; MAX-BANDWIDTH: v128.load
+; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 8, 9, 16, 17, 24, 25, 0, 1, 0, 1, 0, 1, 0, 1
+; MAX-BANDWIDTH: v128.load
+; MAX-BANDWIDTH: v128.load
 ; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 8, 9, 16, 17, 24, 25
 ; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
 ; MAX-BANDWIDTH: i32x4.dot_i16x8_s
 ; MAX-BANDWIDTH: i32x4.add
-; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 8, 9, 16, 17, 24, 25, 0, 1, 0, 1, 0, 1, 0, 1
-; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 8, 9, 16, 17, 24, 25
+; MAX-BANDWIDTH: i8x16.shuffle	4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
+; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 4, 5, 12, 13, 20, 21, 28, 29
+; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
+; MAX-BANDWIDTH: i32x4.dot_i16x8_s
+; MAX-BANDWIDTH: i32x4.add
+; MAX-BANDWIDTH: i8x16.shuffle	4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
+; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 4, 5, 12, 13, 20, 21, 28, 29
 ; MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
 ; MAX-BANDWIDTH: i32x4.dot_i16x8_s
 ; MAX-BANDWIDTH: i32x4.add
@@ -543,27 +543,27 @@ bb41.exit:
 ; RELAXED-MAX-BANDWIDTH: loop
 ; RELAXED-MAX-BANDWIDTH: v128.load
 ; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
-; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 4, 5, 12, 13, 20, 21, 28, 29
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
-; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
-; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: v128.load
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 4, 5, 12, 13, 20, 21, 28, 29
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
-; RELAXED-MAX-BANDWIDTH: i32x4.dot_i16x8_s
-; RELAXED-MAX-BANDWIDTH: i32x4.add
 ; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 8, 9, 16, 17, 24, 25, 0, 1, 0, 1, 0, 1, 0, 1
+; RELAXED-MAX-BANDWIDTH: v128.load
+; RELAXED-MAX-BANDWIDTH: v128.load
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 8, 9, 16, 17, 24, 25
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
+; RELAXED-MAX-BANDWIDTH: v128.load
+; RELAXED-MAX-BANDWIDTH: v128.load
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 8, 9, 16, 17, 24, 25, 0, 1, 0, 1, 0, 1, 0, 1
+; RELAXED-MAX-BANDWIDTH: v128.load
+; RELAXED-MAX-BANDWIDTH: v128.load
 ; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 8, 9, 16, 17, 24, 25
 ; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
 ; RELAXED-MAX-BANDWIDTH: i32x4.dot_i16x8_s
 ; RELAXED-MAX-BANDWIDTH: i32x4.add
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 8, 9, 16, 17, 24, 25, 0, 1, 0, 1, 0, 1, 0, 1
-; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 8, 9, 16, 17, 24, 25
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 4, 5, 12, 13, 20, 21, 28, 29
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
+; RELAXED-MAX-BANDWIDTH: i32x4.dot_i16x8_s
+; RELAXED-MAX-BANDWIDTH: i32x4.add
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	4, 5, 12, 13, 20, 21, 28, 29, 0, 1, 0, 1, 0, 1, 0, 1
+; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 0, 1, 0, 1, 0, 1, 4, 5, 12, 13, 20, 21, 28, 29
 ; RELAXED-MAX-BANDWIDTH: i8x16.shuffle	0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31
 ; RELAXED-MAX-BANDWIDTH: i32x4.dot_i16x8_s
 ; RELAXED-MAX-BANDWIDTH: i32x4.add

--- a/llvm/test/CodeGen/WebAssembly/unrolled-mem-indices.ll
+++ b/llvm/test/CodeGen/WebAssembly/unrolled-mem-indices.ll
@@ -178,24 +178,24 @@ define hidden void @two_dims(ptr nocapture noundef readonly %arg, ptr nocapture 
 ; CHECK-NEXT:    # =>This Loop Header: Depth=1
 ; CHECK-NEXT:    # Child Loop BB2_2 Depth 2
 ; CHECK-NEXT:    loop # label2:
-; CHECK-NEXT:    local.get $push50=, 2
+; CHECK-NEXT:    local.get $push50=, 0
 ; CHECK-NEXT:    local.get $push49=, 3
 ; CHECK-NEXT:    i32.const $push29=, 2
 ; CHECK-NEXT:    i32.shl $push28=, $pop49, $pop29
 ; CHECK-NEXT:    local.tee $push27=, 4, $pop28
-; CHECK-NEXT:    i32.add $push26=, $pop50, $pop27
-; CHECK-NEXT:    local.tee $push25=, 5, $pop26
-; CHECK-NEXT:    i32.load $push51=, 0($pop25)
-; CHECK-NEXT:    local.set 6, $pop51
+; CHECK-NEXT:    i32.add $push0=, $pop50, $pop27
+; CHECK-NEXT:    i32.load $push51=, 0($pop0)
+; CHECK-NEXT:    local.set 5, $pop51
 ; CHECK-NEXT:    local.get $push53=, 1
 ; CHECK-NEXT:    local.get $push52=, 4
-; CHECK-NEXT:    i32.add $push0=, $pop53, $pop52
-; CHECK-NEXT:    i32.load $push54=, 0($pop0)
-; CHECK-NEXT:    local.set 7, $pop54
-; CHECK-NEXT:    local.get $push56=, 0
+; CHECK-NEXT:    i32.add $push1=, $pop53, $pop52
+; CHECK-NEXT:    i32.load $push54=, 0($pop1)
+; CHECK-NEXT:    local.set 6, $pop54
+; CHECK-NEXT:    local.get $push56=, 2
 ; CHECK-NEXT:    local.get $push55=, 4
-; CHECK-NEXT:    i32.add $push1=, $pop56, $pop55
-; CHECK-NEXT:    i32.load $push57=, 0($pop1)
+; CHECK-NEXT:    i32.add $push26=, $pop56, $pop55
+; CHECK-NEXT:    local.tee $push25=, 7, $pop26
+; CHECK-NEXT:    i32.load $push57=, 0($pop25)
 ; CHECK-NEXT:    local.set 8, $pop57
 ; CHECK-NEXT:    i32.const $push58=, 0
 ; CHECK-NEXT:    local.set 4, $pop58
@@ -203,14 +203,14 @@ define hidden void @two_dims(ptr nocapture noundef readonly %arg, ptr nocapture 
 ; CHECK-NEXT:    # Parent Loop BB2_1 Depth=1
 ; CHECK-NEXT:    # => This Inner Loop Header: Depth=2
 ; CHECK-NEXT:    loop # label3:
-; CHECK-NEXT:    local.get $push60=, 7
+; CHECK-NEXT:    local.get $push60=, 6
 ; CHECK-NEXT:    local.get $push59=, 4
 ; CHECK-NEXT:    i32.add $push43=, $pop60, $pop59
 ; CHECK-NEXT:    local.tee $push42=, 9, $pop43
 ; CHECK-NEXT:    i32.const $push41=, 6
 ; CHECK-NEXT:    i32.add $push20=, $pop42, $pop41
 ; CHECK-NEXT:    i32.load16_s $push21=, 0($pop20)
-; CHECK-NEXT:    local.get $push62=, 8
+; CHECK-NEXT:    local.get $push62=, 5
 ; CHECK-NEXT:    local.get $push61=, 4
 ; CHECK-NEXT:    i32.add $push40=, $pop62, $pop61
 ; CHECK-NEXT:    local.tee $push39=, 10, $pop40
@@ -241,12 +241,12 @@ define hidden void @two_dims(ptr nocapture noundef readonly %arg, ptr nocapture 
 ; CHECK-NEXT:    local.get $push68=, 10
 ; CHECK-NEXT:    i32.load16_s $push2=, 0($pop68)
 ; CHECK-NEXT:    i32.add $push4=, $pop3, $pop2
-; CHECK-NEXT:    local.get $push69=, 6
+; CHECK-NEXT:    local.get $push69=, 8
 ; CHECK-NEXT:    i32.add $push5=, $pop4, $pop69
 ; CHECK-NEXT:    i32.add $push11=, $pop10, $pop5
 ; CHECK-NEXT:    i32.add $push17=, $pop16, $pop11
 ; CHECK-NEXT:    i32.add $push70=, $pop22, $pop17
-; CHECK-NEXT:    local.set 6, $pop70
+; CHECK-NEXT:    local.set 8, $pop70
 ; CHECK-NEXT:    local.get $push71=, 4
 ; CHECK-NEXT:    i32.const $push33=, 8
 ; CHECK-NEXT:    i32.add $push32=, $pop71, $pop33
@@ -257,8 +257,8 @@ define hidden void @two_dims(ptr nocapture noundef readonly %arg, ptr nocapture 
 ; CHECK-NEXT:  # %bb.3: # %bb11
 ; CHECK-NEXT:    # in Loop: Header=BB2_1 Depth=1
 ; CHECK-NEXT:    end_loop
-; CHECK-NEXT:    local.get $push73=, 5
-; CHECK-NEXT:    local.get $push72=, 6
+; CHECK-NEXT:    local.get $push73=, 7
+; CHECK-NEXT:    local.get $push72=, 8
 ; CHECK-NEXT:    i32.store 0($pop73), $pop72
 ; CHECK-NEXT:    local.get $push74=, 3
 ; CHECK-NEXT:    i32.const $push47=, 1
@@ -374,36 +374,36 @@ define hidden void @runtime(ptr nocapture noundef readonly %arg, ptr nocapture n
 ; CHECK-NEXT:    loop # label6:
 ; CHECK-NEXT:    local.get $push45=, 8
 ; CHECK-NEXT:    local.get $push43=, 3
-; CHECK-NEXT:    f32.load $push4=, 0($pop43)
+; CHECK-NEXT:    f32.load $push3=, 0($pop43)
 ; CHECK-NEXT:    local.get $push44=, 7
-; CHECK-NEXT:    f32.load $push3=, 0($pop44)
-; CHECK-NEXT:    f32.add $push5=, $pop4, $pop3
+; CHECK-NEXT:    f32.load $push4=, 0($pop44)
+; CHECK-NEXT:    f32.add $push5=, $pop3, $pop4
 ; CHECK-NEXT:    f32.store 0($pop45), $pop5
 ; CHECK-NEXT:    local.get $push46=, 8
 ; CHECK-NEXT:    i32.const $push29=, 4
 ; CHECK-NEXT:    i32.add $push11=, $pop46, $pop29
 ; CHECK-NEXT:    local.get $push47=, 3
 ; CHECK-NEXT:    i32.const $push28=, 4
-; CHECK-NEXT:    i32.add $push8=, $pop47, $pop28
-; CHECK-NEXT:    f32.load $push9=, 0($pop8)
+; CHECK-NEXT:    i32.add $push6=, $pop47, $pop28
+; CHECK-NEXT:    f32.load $push7=, 0($pop6)
 ; CHECK-NEXT:    local.get $push48=, 7
 ; CHECK-NEXT:    i32.const $push27=, 4
-; CHECK-NEXT:    i32.add $push6=, $pop48, $pop27
-; CHECK-NEXT:    f32.load $push7=, 0($pop6)
-; CHECK-NEXT:    f32.add $push10=, $pop9, $pop7
+; CHECK-NEXT:    i32.add $push8=, $pop48, $pop27
+; CHECK-NEXT:    f32.load $push9=, 0($pop8)
+; CHECK-NEXT:    f32.add $push10=, $pop7, $pop9
 ; CHECK-NEXT:    f32.store 0($pop11), $pop10
-; CHECK-NEXT:    local.get $push50=, 3
+; CHECK-NEXT:    local.get $push50=, 8
 ; CHECK-NEXT:    i32.const $push26=, 8
 ; CHECK-NEXT:    i32.add $push49=, $pop50, $pop26
-; CHECK-NEXT:    local.set 3, $pop49
+; CHECK-NEXT:    local.set 8, $pop49
 ; CHECK-NEXT:    local.get $push52=, 7
 ; CHECK-NEXT:    i32.const $push25=, 8
 ; CHECK-NEXT:    i32.add $push51=, $pop52, $pop25
 ; CHECK-NEXT:    local.set 7, $pop51
-; CHECK-NEXT:    local.get $push54=, 8
+; CHECK-NEXT:    local.get $push54=, 3
 ; CHECK-NEXT:    i32.const $push24=, 8
 ; CHECK-NEXT:    i32.add $push53=, $pop54, $pop24
-; CHECK-NEXT:    local.set 8, $pop53
+; CHECK-NEXT:    local.set 3, $pop53
 ; CHECK-NEXT:    local.get $push56=, 6
 ; CHECK-NEXT:    local.get $push55=, 5
 ; CHECK-NEXT:    i32.const $push23=, 2
@@ -426,13 +426,13 @@ define hidden void @runtime(ptr nocapture noundef readonly %arg, ptr nocapture n
 ; CHECK-NEXT:    i32.add $push19=, $pop59, $pop30
 ; CHECK-NEXT:    local.get $push61=, 0
 ; CHECK-NEXT:    local.get $push60=, 3
-; CHECK-NEXT:    i32.add $push16=, $pop61, $pop60
-; CHECK-NEXT:    f32.load $push17=, 0($pop16)
+; CHECK-NEXT:    i32.add $push14=, $pop61, $pop60
+; CHECK-NEXT:    f32.load $push15=, 0($pop14)
 ; CHECK-NEXT:    local.get $push63=, 1
 ; CHECK-NEXT:    local.get $push62=, 3
-; CHECK-NEXT:    i32.add $push14=, $pop63, $pop62
-; CHECK-NEXT:    f32.load $push15=, 0($pop14)
-; CHECK-NEXT:    f32.add $push18=, $pop17, $pop15
+; CHECK-NEXT:    i32.add $push16=, $pop63, $pop62
+; CHECK-NEXT:    f32.load $push17=, 0($pop16)
+; CHECK-NEXT:    f32.add $push18=, $pop15, $pop17
 ; CHECK-NEXT:    f32.store 0($pop19), $pop18
 ; CHECK-NEXT:  .LBB3_6: # %bb19
 ; CHECK-NEXT:    end_block # label4:

--- a/llvm/test/CodeGen/WebAssembly/userstack.ll
+++ b/llvm/test/CodeGen/WebAssembly/userstack.ll
@@ -56,11 +56,11 @@ define void @alloca3264() {
 ; CHECK-32-NEXT:    i32.const $push3=, 16
 ; CHECK-32-NEXT:    i32.sub $push5=, $pop2, $pop3
 ; CHECK-32-NEXT:    local.tee $push4=, 0, $pop5
-; CHECK-32-NEXT:    i64.const $push0=, 0
-; CHECK-32-NEXT:    i64.store 0($pop4), $pop0
+; CHECK-32-NEXT:    i32.const $push0=, 0
+; CHECK-32-NEXT:    i32.store 12($pop4), $pop0
 ; CHECK-32-NEXT:    local.get $push6=, 0
-; CHECK-32-NEXT:    i32.const $push1=, 0
-; CHECK-32-NEXT:    i32.store 12($pop6), $pop1
+; CHECK-32-NEXT:    i64.const $push1=, 0
+; CHECK-32-NEXT:    i64.store 0($pop6), $pop1
 ; CHECK-32-NEXT:    return
 ;
 ; CHECK-64-LABEL: alloca3264:
@@ -71,11 +71,11 @@ define void @alloca3264() {
 ; CHECK-64-NEXT:    i64.const $push3=, 16
 ; CHECK-64-NEXT:    i64.sub $push5=, $pop2, $pop3
 ; CHECK-64-NEXT:    local.tee $push4=, 0, $pop5
-; CHECK-64-NEXT:    i64.const $push0=, 0
-; CHECK-64-NEXT:    i64.store 0($pop4), $pop0
+; CHECK-64-NEXT:    i32.const $push0=, 0
+; CHECK-64-NEXT:    i32.store 12($pop4), $pop0
 ; CHECK-64-NEXT:    local.get $push6=, 0
-; CHECK-64-NEXT:    i32.const $push1=, 0
-; CHECK-64-NEXT:    i32.store 12($pop6), $pop1
+; CHECK-64-NEXT:    i64.const $push1=, 0
+; CHECK-64-NEXT:    i64.store 0($pop6), $pop1
 ; CHECK-64-NEXT:    return
  %r1 = alloca i32
  %r2 = alloca double
@@ -214,10 +214,10 @@ define void @allocarray_inbounds() {
 ; CHECK-32-NEXT:    global.set __stack_pointer, $pop7
 ; CHECK-32-NEXT:    local.get $push9=, 0
 ; CHECK-32-NEXT:    i32.const $push0=, 1
-; CHECK-32-NEXT:    i32.store 24($pop9), $pop0
+; CHECK-32-NEXT:    i32.store 12($pop9), $pop0
 ; CHECK-32-NEXT:    local.get $push10=, 0
 ; CHECK-32-NEXT:    i32.const $push6=, 1
-; CHECK-32-NEXT:    i32.store 12($pop10), $pop6
+; CHECK-32-NEXT:    i32.store 24($pop10), $pop6
 ; CHECK-32-NEXT:    i32.const $push1=, 0
 ; CHECK-32-NEXT:    call ext_func, $pop1
 ; CHECK-32-NEXT:    local.get $push11=, 0
@@ -237,10 +237,10 @@ define void @allocarray_inbounds() {
 ; CHECK-64-NEXT:    global.set __stack_pointer, $pop7
 ; CHECK-64-NEXT:    local.get $push9=, 0
 ; CHECK-64-NEXT:    i32.const $push0=, 1
-; CHECK-64-NEXT:    i32.store 24($pop9), $pop0
+; CHECK-64-NEXT:    i32.store 12($pop9), $pop0
 ; CHECK-64-NEXT:    local.get $push10=, 0
 ; CHECK-64-NEXT:    i32.const $push6=, 1
-; CHECK-64-NEXT:    i32.store 12($pop10), $pop6
+; CHECK-64-NEXT:    i32.store 24($pop10), $pop6
 ; CHECK-64-NEXT:    i64.const $push1=, 0
 ; CHECK-64-NEXT:    call ext_func, $pop1
 ; CHECK-64-NEXT:    local.get $push11=, 0
@@ -629,7 +629,7 @@ define void @copytoreg_fi(i1 %cond, ptr %b) {
 ; CHECK-32-NEXT:    i32.const $push4=, 1
 ; CHECK-32-NEXT:    i32.and $push7=, $pop8, $pop4
 ; CHECK-32-NEXT:    local.set 0, $pop7
-; CHECK-32-NEXT:  # %body
+; CHECK-32-NEXT:  .LBB11_1: # %body
 ; CHECK-32-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CHECK-32-NEXT:    loop # label0:
 ; CHECK-32-NEXT:    local.get $push9=, 2
@@ -657,7 +657,7 @@ define void @copytoreg_fi(i1 %cond, ptr %b) {
 ; CHECK-64-NEXT:    i32.const $push4=, 1
 ; CHECK-64-NEXT:    i32.and $push7=, $pop8, $pop4
 ; CHECK-64-NEXT:    local.set 0, $pop7
-; CHECK-64-NEXT:  # %body
+; CHECK-64-NEXT:  .LBB11_1: # %body
 ; CHECK-64-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CHECK-64-NEXT:    loop # label0:
 ; CHECK-64-NEXT:    local.get $push9=, 2

--- a/llvm/test/CodeGen/WebAssembly/vector-reduce.ll
+++ b/llvm/test/CodeGen/WebAssembly/vector-reduce.ll
@@ -628,9 +628,9 @@ define double @pairwise_add_v2f64(<2 x double> %arg) {
 ; SIMD128-LABEL: pairwise_add_v2f64:
 ; SIMD128:         .functype pairwise_add_v2f64 (v128) -> (f64)
 ; SIMD128-NEXT:  # %bb.0:
-; SIMD128-NEXT:    f64x2.extract_lane $push1=, $0, 0
-; SIMD128-NEXT:    f64x2.extract_lane $push0=, $0, 1
-; SIMD128-NEXT:    f64.add $push2=, $pop1, $pop0
+; SIMD128-NEXT:    f64x2.extract_lane $push0=, $0, 0
+; SIMD128-NEXT:    f64x2.extract_lane $push1=, $0, 1
+; SIMD128-NEXT:    f64.add $push2=, $pop0, $pop1
 ; SIMD128-NEXT:    return $pop2
   %res = tail call double @llvm.vector.reduce.fadd.v2f64(double -0.0, <2 x double> %arg)
   ret double%res
@@ -652,9 +652,9 @@ define float @pairwise_add_v4f32(<4 x float> %arg) {
 ; SIMD128-LABEL: pairwise_add_v4f32:
 ; SIMD128:         .functype pairwise_add_v4f32 (v128) -> (f32)
 ; SIMD128-NEXT:  # %bb.0:
-; SIMD128-NEXT:    f32x4.extract_lane $push1=, $0, 0
-; SIMD128-NEXT:    f32x4.extract_lane $push0=, $0, 1
-; SIMD128-NEXT:    f32.add $push2=, $pop1, $pop0
+; SIMD128-NEXT:    f32x4.extract_lane $push0=, $0, 0
+; SIMD128-NEXT:    f32x4.extract_lane $push1=, $0, 1
+; SIMD128-NEXT:    f32.add $push2=, $pop0, $pop1
 ; SIMD128-NEXT:    f32x4.extract_lane $push3=, $0, 2
 ; SIMD128-NEXT:    f32.add $push4=, $pop2, $pop3
 ; SIMD128-NEXT:    f32x4.extract_lane $push5=, $0, 3

--- a/llvm/test/CodeGen/WebAssembly/wide-simd-mul.ll
+++ b/llvm/test/CodeGen/WebAssembly/wide-simd-mul.ll
@@ -115,19 +115,19 @@ define <8 x i32> @sext_zext_mul_v8i8(<8 x i8> %a, <8 x i8> %b) {
 ; CHECK-LABEL: sext_zext_mul_v8i8:
 ; CHECK:         .functype sext_zext_mul_v8i8 (i32, v128, v128) -> ()
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    i16x8.extend_low_i8x16_s $push2=, $1
-; CHECK-NEXT:    i32x4.extend_low_i16x8_s $push3=, $pop2
-; CHECK-NEXT:    i16x8.extend_low_i8x16_u $push0=, $1
-; CHECK-NEXT:    i32x4.extend_low_i16x8_u $push1=, $pop0
-; CHECK-NEXT:    i32x4.mul $push4=, $pop3, $pop1
+; CHECK-NEXT:    i16x8.extend_low_i8x16_s $push0=, $1
+; CHECK-NEXT:    i32x4.extend_low_i16x8_s $push1=, $pop0
+; CHECK-NEXT:    i16x8.extend_low_i8x16_u $push2=, $1
+; CHECK-NEXT:    i32x4.extend_low_i16x8_u $push3=, $pop2
+; CHECK-NEXT:    i32x4.mul $push4=, $pop1, $pop3
 ; CHECK-NEXT:    v128.store 0($0), $pop4
 ; CHECK-NEXT:    i8x16.shuffle $push11=, $1, $1, 4, 5, 6, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ; CHECK-NEXT:    local.tee $push10=, $1=, $pop11
-; CHECK-NEXT:    i16x8.extend_low_i8x16_s $push7=, $pop10
-; CHECK-NEXT:    i32x4.extend_low_i16x8_s $push8=, $pop7
-; CHECK-NEXT:    i16x8.extend_low_i8x16_u $push5=, $1
-; CHECK-NEXT:    i32x4.extend_low_i16x8_u $push6=, $pop5
-; CHECK-NEXT:    i32x4.mul $push9=, $pop8, $pop6
+; CHECK-NEXT:    i16x8.extend_low_i8x16_s $push5=, $pop10
+; CHECK-NEXT:    i32x4.extend_low_i16x8_s $push6=, $pop5
+; CHECK-NEXT:    i16x8.extend_low_i8x16_u $push7=, $1
+; CHECK-NEXT:    i32x4.extend_low_i16x8_u $push8=, $pop7
+; CHECK-NEXT:    i32x4.mul $push9=, $pop6, $pop8
 ; CHECK-NEXT:    v128.store 16($0), $pop9
 ; CHECK-NEXT:    return
   %wide.a = sext <8 x i8> %a to <8 x i32>
@@ -141,28 +141,28 @@ define <16 x i32> @sext_zext_mul_v16i8(<16 x i8> %a, <16 x i8> %b) {
 ; CHECK:         .functype sext_zext_mul_v16i8 (i32, v128, v128) -> ()
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    i16x8.extend_high_i8x16_s $push19=, $1
-; CHECK-NEXT:    local.tee $push18=, $4=, $pop19
-; CHECK-NEXT:    i32x4.extend_high_i16x8_s $push1=, $pop18
+; CHECK-NEXT:    local.tee $push18=, $3=, $pop19
+; CHECK-NEXT:    i32x4.extend_high_i16x8_s $push0=, $pop18
 ; CHECK-NEXT:    i16x8.extend_high_i8x16_u $push17=, $1
-; CHECK-NEXT:    local.tee $push16=, $3=, $pop17
-; CHECK-NEXT:    i32x4.extend_high_i16x8_u $push0=, $pop16
-; CHECK-NEXT:    i32x4.mul $push2=, $pop1, $pop0
+; CHECK-NEXT:    local.tee $push16=, $4=, $pop17
+; CHECK-NEXT:    i32x4.extend_high_i16x8_u $push1=, $pop16
+; CHECK-NEXT:    i32x4.mul $push2=, $pop0, $pop1
 ; CHECK-NEXT:    v128.store 48($0), $pop2
-; CHECK-NEXT:    i32x4.extend_low_i16x8_s $push4=, $4
-; CHECK-NEXT:    i32x4.extend_low_i16x8_u $push3=, $3
-; CHECK-NEXT:    i32x4.mul $push5=, $pop4, $pop3
+; CHECK-NEXT:    i32x4.extend_low_i16x8_s $push3=, $3
+; CHECK-NEXT:    i32x4.extend_low_i16x8_u $push4=, $4
+; CHECK-NEXT:    i32x4.mul $push5=, $pop3, $pop4
 ; CHECK-NEXT:    v128.store 32($0), $pop5
 ; CHECK-NEXT:    i16x8.extend_low_i8x16_s $push15=, $1
-; CHECK-NEXT:    local.tee $push14=, $4=, $pop15
-; CHECK-NEXT:    i32x4.extend_high_i16x8_s $push7=, $pop14
+; CHECK-NEXT:    local.tee $push14=, $3=, $pop15
+; CHECK-NEXT:    i32x4.extend_high_i16x8_s $push6=, $pop14
 ; CHECK-NEXT:    i16x8.extend_low_i8x16_u $push13=, $1
 ; CHECK-NEXT:    local.tee $push12=, $1=, $pop13
-; CHECK-NEXT:    i32x4.extend_high_i16x8_u $push6=, $pop12
-; CHECK-NEXT:    i32x4.mul $push8=, $pop7, $pop6
+; CHECK-NEXT:    i32x4.extend_high_i16x8_u $push7=, $pop12
+; CHECK-NEXT:    i32x4.mul $push8=, $pop6, $pop7
 ; CHECK-NEXT:    v128.store 16($0), $pop8
-; CHECK-NEXT:    i32x4.extend_low_i16x8_s $push10=, $4
-; CHECK-NEXT:    i32x4.extend_low_i16x8_u $push9=, $1
-; CHECK-NEXT:    i32x4.mul $push11=, $pop10, $pop9
+; CHECK-NEXT:    i32x4.extend_low_i16x8_s $push9=, $3
+; CHECK-NEXT:    i32x4.extend_low_i16x8_u $push10=, $1
+; CHECK-NEXT:    i32x4.mul $push11=, $pop9, $pop10
 ; CHECK-NEXT:    v128.store 0($0), $pop11
 ; CHECK-NEXT:    return
   %wide.a = sext <16 x i8> %a to <16 x i32>
@@ -179,9 +179,9 @@ define <8 x i32> @zext_sext_mul_v8i16(<8 x i16> %a, <8 x i16> %b) {
 ; CHECK-NEXT:    i32x4.extend_high_i16x8_s $push0=, $1
 ; CHECK-NEXT:    i32x4.mul $push2=, $pop1, $pop0
 ; CHECK-NEXT:    v128.store 16($0), $pop2
-; CHECK-NEXT:    i32x4.extend_low_i16x8_u $push4=, $1
-; CHECK-NEXT:    i32x4.extend_low_i16x8_s $push3=, $1
-; CHECK-NEXT:    i32x4.mul $push5=, $pop4, $pop3
+; CHECK-NEXT:    i32x4.extend_low_i16x8_u $push3=, $1
+; CHECK-NEXT:    i32x4.extend_low_i16x8_s $push4=, $1
+; CHECK-NEXT:    i32x4.mul $push5=, $pop3, $pop4
 ; CHECK-NEXT:    v128.store 0($0), $pop5
 ; CHECK-NEXT:    return
   %wide.a = zext <8 x i16> %a to <8 x i32>
@@ -349,9 +349,9 @@ define <4 x i32> @combine_with_shl_signed_non_overflow(<8 x i16> %v) {
 ; CHECK-NEXT:    i32.shl $push2=, $pop0, $pop16
 ; CHECK-NEXT:    i32x4.replace_lane $push15=, $pop5, 3, $pop2
 ; CHECK-NEXT:    local.tee $push14=, $0=, $pop15
-; CHECK-NEXT:    i8x16.shuffle $push12=, $pop20, $pop14, 0, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27
-; CHECK-NEXT:    i8x16.shuffle $push11=, $1, $0, 4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31
-; CHECK-NEXT:    i32x4.add $push13=, $pop12, $pop11
+; CHECK-NEXT:    i8x16.shuffle $push11=, $pop20, $pop14, 0, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27
+; CHECK-NEXT:    i8x16.shuffle $push12=, $1, $0, 4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31
+; CHECK-NEXT:    i32x4.add $push13=, $pop11, $pop12
 ; CHECK-NEXT:    return $pop13
   %sext = sext <8 x i16> %v to <8 x i32>
   %1 = mul <8 x i32> %sext, <i32 1, i32 32768, i32 1, i32 32768, i32 1, i32 32768, i32 1, i32 32768>
@@ -388,9 +388,9 @@ define <4 x i32> @combine_with_shl_unsigned_non_overflow(<8 x i16> %v) {
 ; CHECK-NEXT:    i32.shl $push2=, $pop0, $pop16
 ; CHECK-NEXT:    i32x4.replace_lane $push15=, $pop5, 3, $pop2
 ; CHECK-NEXT:    local.tee $push14=, $0=, $pop15
-; CHECK-NEXT:    i8x16.shuffle $push12=, $pop20, $pop14, 0, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27
-; CHECK-NEXT:    i8x16.shuffle $push11=, $1, $0, 4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31
-; CHECK-NEXT:    v128.or $push13=, $pop12, $pop11
+; CHECK-NEXT:    i8x16.shuffle $push11=, $pop20, $pop14, 0, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27
+; CHECK-NEXT:    i8x16.shuffle $push12=, $1, $0, 4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31
+; CHECK-NEXT:    v128.or $push13=, $pop11, $pop12
 ; CHECK-NEXT:    return $pop13
   %zext = zext <8 x i16> %v to <8 x i32>
   %1 = mul <8 x i32> %zext, <i32 1, i32 65536, i32 1, i32 65536, i32 1, i32 65536, i32 1, i32 65536>

--- a/llvm/test/CodeGen/X86/abi-isel.ll
+++ b/llvm/test/CodeGen/X86/abi-isel.ll
@@ -380,18 +380,18 @@ entry:
 define dso_local void @foo02() nounwind {
 ; LINUX-64-STATIC-LABEL: foo02:
 ; LINUX-64-STATIC:       # %bb.0: # %entry
-; LINUX-64-STATIC-NEXT:    movq src@GOTPCREL(%rip), %rax
-; LINUX-64-STATIC-NEXT:    movl (%rax), %eax
-; LINUX-64-STATIC-NEXT:    movq ptr@GOTPCREL(%rip), %rcx
-; LINUX-64-STATIC-NEXT:    movq (%rcx), %rcx
-; LINUX-64-STATIC-NEXT:    movl %eax, (%rcx)
+; LINUX-64-STATIC-NEXT:    movq ptr@GOTPCREL(%rip), %rax
+; LINUX-64-STATIC-NEXT:    movq (%rax), %rax
+; LINUX-64-STATIC-NEXT:    movq src@GOTPCREL(%rip), %rcx
+; LINUX-64-STATIC-NEXT:    movl (%rcx), %ecx
+; LINUX-64-STATIC-NEXT:    movl %ecx, (%rax)
 ; LINUX-64-STATIC-NEXT:    retq
 ;
 ; LINUX-32-STATIC-LABEL: foo02:
 ; LINUX-32-STATIC:       # %bb.0: # %entry
-; LINUX-32-STATIC-NEXT:    movl src, %eax
-; LINUX-32-STATIC-NEXT:    movl ptr, %ecx
-; LINUX-32-STATIC-NEXT:    movl %eax, (%ecx)
+; LINUX-32-STATIC-NEXT:    movl ptr, %eax
+; LINUX-32-STATIC-NEXT:    movl src, %ecx
+; LINUX-32-STATIC-NEXT:    movl %ecx, (%eax)
 ; LINUX-32-STATIC-NEXT:    retl
 ;
 ; LINUX-32-PIC-LABEL: foo02:
@@ -401,36 +401,36 @@ define dso_local void @foo02() nounwind {
 ; LINUX-32-PIC-NEXT:    popl %eax
 ; LINUX-32-PIC-NEXT:  .Ltmp4:
 ; LINUX-32-PIC-NEXT:    addl $_GLOBAL_OFFSET_TABLE_+(.Ltmp4-.L4$pb), %eax
-; LINUX-32-PIC-NEXT:    movl src@GOT(%eax), %ecx
+; LINUX-32-PIC-NEXT:    movl ptr@GOT(%eax), %ecx
 ; LINUX-32-PIC-NEXT:    movl (%ecx), %ecx
-; LINUX-32-PIC-NEXT:    movl ptr@GOT(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl src@GOT(%eax), %eax
 ; LINUX-32-PIC-NEXT:    movl (%eax), %eax
-; LINUX-32-PIC-NEXT:    movl %ecx, (%eax)
+; LINUX-32-PIC-NEXT:    movl %eax, (%ecx)
 ; LINUX-32-PIC-NEXT:    retl
 ;
 ; LINUX-64-PIC-LABEL: foo02:
 ; LINUX-64-PIC:       # %bb.0: # %entry
-; LINUX-64-PIC-NEXT:    movq src@GOTPCREL(%rip), %rax
-; LINUX-64-PIC-NEXT:    movl (%rax), %eax
-; LINUX-64-PIC-NEXT:    movq ptr@GOTPCREL(%rip), %rcx
-; LINUX-64-PIC-NEXT:    movq (%rcx), %rcx
-; LINUX-64-PIC-NEXT:    movl %eax, (%rcx)
+; LINUX-64-PIC-NEXT:    movq ptr@GOTPCREL(%rip), %rax
+; LINUX-64-PIC-NEXT:    movq (%rax), %rax
+; LINUX-64-PIC-NEXT:    movq src@GOTPCREL(%rip), %rcx
+; LINUX-64-PIC-NEXT:    movl (%rcx), %ecx
+; LINUX-64-PIC-NEXT:    movl %ecx, (%rax)
 ; LINUX-64-PIC-NEXT:    retq
 ;
 ; DARWIN-32-STATIC-LABEL: foo02:
 ; DARWIN-32-STATIC:       ## %bb.0: ## %entry
-; DARWIN-32-STATIC-NEXT:    movl _src, %eax
-; DARWIN-32-STATIC-NEXT:    movl _ptr, %ecx
-; DARWIN-32-STATIC-NEXT:    movl %eax, (%ecx)
+; DARWIN-32-STATIC-NEXT:    movl _ptr, %eax
+; DARWIN-32-STATIC-NEXT:    movl _src, %ecx
+; DARWIN-32-STATIC-NEXT:    movl %ecx, (%eax)
 ; DARWIN-32-STATIC-NEXT:    retl
 ;
 ; DARWIN-32-DYNAMIC-LABEL: foo02:
 ; DARWIN-32-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-32-DYNAMIC-NEXT:    movl L_src$non_lazy_ptr, %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl L_ptr$non_lazy_ptr, %eax
 ; DARWIN-32-DYNAMIC-NEXT:    movl (%eax), %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl L_ptr$non_lazy_ptr, %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl L_src$non_lazy_ptr, %ecx
 ; DARWIN-32-DYNAMIC-NEXT:    movl (%ecx), %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl %eax, (%ecx)
+; DARWIN-32-DYNAMIC-NEXT:    movl %ecx, (%eax)
 ; DARWIN-32-DYNAMIC-NEXT:    retl
 ;
 ; DARWIN-32-PIC-LABEL: foo02:
@@ -438,38 +438,38 @@ define dso_local void @foo02() nounwind {
 ; DARWIN-32-PIC-NEXT:    calll L4$pb
 ; DARWIN-32-PIC-NEXT:  L4$pb:
 ; DARWIN-32-PIC-NEXT:    popl %eax
-; DARWIN-32-PIC-NEXT:    movl L_src$non_lazy_ptr-L4$pb(%eax), %ecx
+; DARWIN-32-PIC-NEXT:    movl L_ptr$non_lazy_ptr-L4$pb(%eax), %ecx
 ; DARWIN-32-PIC-NEXT:    movl (%ecx), %ecx
-; DARWIN-32-PIC-NEXT:    movl L_ptr$non_lazy_ptr-L4$pb(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl L_src$non_lazy_ptr-L4$pb(%eax), %eax
 ; DARWIN-32-PIC-NEXT:    movl (%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl %ecx, (%eax)
+; DARWIN-32-PIC-NEXT:    movl %eax, (%ecx)
 ; DARWIN-32-PIC-NEXT:    retl
 ;
 ; DARWIN-64-STATIC-LABEL: foo02:
 ; DARWIN-64-STATIC:       ## %bb.0: ## %entry
-; DARWIN-64-STATIC-NEXT:    movq _src@GOTPCREL(%rip), %rax
-; DARWIN-64-STATIC-NEXT:    movl (%rax), %eax
-; DARWIN-64-STATIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-STATIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-STATIC-NEXT:    movl %eax, (%rcx)
+; DARWIN-64-STATIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-STATIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-STATIC-NEXT:    movq _src@GOTPCREL(%rip), %rcx
+; DARWIN-64-STATIC-NEXT:    movl (%rcx), %ecx
+; DARWIN-64-STATIC-NEXT:    movl %ecx, (%rax)
 ; DARWIN-64-STATIC-NEXT:    retq
 ;
 ; DARWIN-64-DYNAMIC-LABEL: foo02:
 ; DARWIN-64-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-64-DYNAMIC-NEXT:    movq _src@GOTPCREL(%rip), %rax
-; DARWIN-64-DYNAMIC-NEXT:    movl (%rax), %eax
-; DARWIN-64-DYNAMIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movl %eax, (%rcx)
+; DARWIN-64-DYNAMIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movq _src@GOTPCREL(%rip), %rcx
+; DARWIN-64-DYNAMIC-NEXT:    movl (%rcx), %ecx
+; DARWIN-64-DYNAMIC-NEXT:    movl %ecx, (%rax)
 ; DARWIN-64-DYNAMIC-NEXT:    retq
 ;
 ; DARWIN-64-PIC-LABEL: foo02:
 ; DARWIN-64-PIC:       ## %bb.0: ## %entry
-; DARWIN-64-PIC-NEXT:    movq _src@GOTPCREL(%rip), %rax
-; DARWIN-64-PIC-NEXT:    movl (%rax), %eax
-; DARWIN-64-PIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-PIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-PIC-NEXT:    movl %eax, (%rcx)
+; DARWIN-64-PIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-PIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-PIC-NEXT:    movq _src@GOTPCREL(%rip), %rcx
+; DARWIN-64-PIC-NEXT:    movl (%rcx), %ecx
+; DARWIN-64-PIC-NEXT:    movl %ecx, (%rax)
 ; DARWIN-64-PIC-NEXT:    retq
 
 entry:
@@ -482,18 +482,18 @@ entry:
 define dso_local void @fxo02() nounwind {
 ; LINUX-64-STATIC-LABEL: fxo02:
 ; LINUX-64-STATIC:       # %bb.0: # %entry
-; LINUX-64-STATIC-NEXT:    movq xsrc@GOTPCREL(%rip), %rax
-; LINUX-64-STATIC-NEXT:    movl (%rax), %eax
-; LINUX-64-STATIC-NEXT:    movq ptr@GOTPCREL(%rip), %rcx
-; LINUX-64-STATIC-NEXT:    movq (%rcx), %rcx
-; LINUX-64-STATIC-NEXT:    movl %eax, (%rcx)
+; LINUX-64-STATIC-NEXT:    movq ptr@GOTPCREL(%rip), %rax
+; LINUX-64-STATIC-NEXT:    movq (%rax), %rax
+; LINUX-64-STATIC-NEXT:    movq xsrc@GOTPCREL(%rip), %rcx
+; LINUX-64-STATIC-NEXT:    movl (%rcx), %ecx
+; LINUX-64-STATIC-NEXT:    movl %ecx, (%rax)
 ; LINUX-64-STATIC-NEXT:    retq
 ;
 ; LINUX-32-STATIC-LABEL: fxo02:
 ; LINUX-32-STATIC:       # %bb.0: # %entry
-; LINUX-32-STATIC-NEXT:    movl xsrc, %eax
-; LINUX-32-STATIC-NEXT:    movl ptr, %ecx
-; LINUX-32-STATIC-NEXT:    movl %eax, (%ecx)
+; LINUX-32-STATIC-NEXT:    movl ptr, %eax
+; LINUX-32-STATIC-NEXT:    movl xsrc, %ecx
+; LINUX-32-STATIC-NEXT:    movl %ecx, (%eax)
 ; LINUX-32-STATIC-NEXT:    retl
 ;
 ; LINUX-32-PIC-LABEL: fxo02:
@@ -503,36 +503,36 @@ define dso_local void @fxo02() nounwind {
 ; LINUX-32-PIC-NEXT:    popl %eax
 ; LINUX-32-PIC-NEXT:  .Ltmp5:
 ; LINUX-32-PIC-NEXT:    addl $_GLOBAL_OFFSET_TABLE_+(.Ltmp5-.L5$pb), %eax
-; LINUX-32-PIC-NEXT:    movl xsrc@GOT(%eax), %ecx
+; LINUX-32-PIC-NEXT:    movl ptr@GOT(%eax), %ecx
 ; LINUX-32-PIC-NEXT:    movl (%ecx), %ecx
-; LINUX-32-PIC-NEXT:    movl ptr@GOT(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl xsrc@GOT(%eax), %eax
 ; LINUX-32-PIC-NEXT:    movl (%eax), %eax
-; LINUX-32-PIC-NEXT:    movl %ecx, (%eax)
+; LINUX-32-PIC-NEXT:    movl %eax, (%ecx)
 ; LINUX-32-PIC-NEXT:    retl
 ;
 ; LINUX-64-PIC-LABEL: fxo02:
 ; LINUX-64-PIC:       # %bb.0: # %entry
-; LINUX-64-PIC-NEXT:    movq xsrc@GOTPCREL(%rip), %rax
-; LINUX-64-PIC-NEXT:    movl (%rax), %eax
-; LINUX-64-PIC-NEXT:    movq ptr@GOTPCREL(%rip), %rcx
-; LINUX-64-PIC-NEXT:    movq (%rcx), %rcx
-; LINUX-64-PIC-NEXT:    movl %eax, (%rcx)
+; LINUX-64-PIC-NEXT:    movq ptr@GOTPCREL(%rip), %rax
+; LINUX-64-PIC-NEXT:    movq (%rax), %rax
+; LINUX-64-PIC-NEXT:    movq xsrc@GOTPCREL(%rip), %rcx
+; LINUX-64-PIC-NEXT:    movl (%rcx), %ecx
+; LINUX-64-PIC-NEXT:    movl %ecx, (%rax)
 ; LINUX-64-PIC-NEXT:    retq
 ;
 ; DARWIN-32-STATIC-LABEL: fxo02:
 ; DARWIN-32-STATIC:       ## %bb.0: ## %entry
-; DARWIN-32-STATIC-NEXT:    movl _xsrc, %eax
-; DARWIN-32-STATIC-NEXT:    movl _ptr, %ecx
-; DARWIN-32-STATIC-NEXT:    movl %eax, (%ecx)
+; DARWIN-32-STATIC-NEXT:    movl _ptr, %eax
+; DARWIN-32-STATIC-NEXT:    movl _xsrc, %ecx
+; DARWIN-32-STATIC-NEXT:    movl %ecx, (%eax)
 ; DARWIN-32-STATIC-NEXT:    retl
 ;
 ; DARWIN-32-DYNAMIC-LABEL: fxo02:
 ; DARWIN-32-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-32-DYNAMIC-NEXT:    movl L_xsrc$non_lazy_ptr, %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl L_ptr$non_lazy_ptr, %eax
 ; DARWIN-32-DYNAMIC-NEXT:    movl (%eax), %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl L_ptr$non_lazy_ptr, %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl L_xsrc$non_lazy_ptr, %ecx
 ; DARWIN-32-DYNAMIC-NEXT:    movl (%ecx), %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl %eax, (%ecx)
+; DARWIN-32-DYNAMIC-NEXT:    movl %ecx, (%eax)
 ; DARWIN-32-DYNAMIC-NEXT:    retl
 ;
 ; DARWIN-32-PIC-LABEL: fxo02:
@@ -540,38 +540,38 @@ define dso_local void @fxo02() nounwind {
 ; DARWIN-32-PIC-NEXT:    calll L5$pb
 ; DARWIN-32-PIC-NEXT:  L5$pb:
 ; DARWIN-32-PIC-NEXT:    popl %eax
-; DARWIN-32-PIC-NEXT:    movl L_xsrc$non_lazy_ptr-L5$pb(%eax), %ecx
+; DARWIN-32-PIC-NEXT:    movl L_ptr$non_lazy_ptr-L5$pb(%eax), %ecx
 ; DARWIN-32-PIC-NEXT:    movl (%ecx), %ecx
-; DARWIN-32-PIC-NEXT:    movl L_ptr$non_lazy_ptr-L5$pb(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl L_xsrc$non_lazy_ptr-L5$pb(%eax), %eax
 ; DARWIN-32-PIC-NEXT:    movl (%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl %ecx, (%eax)
+; DARWIN-32-PIC-NEXT:    movl %eax, (%ecx)
 ; DARWIN-32-PIC-NEXT:    retl
 ;
 ; DARWIN-64-STATIC-LABEL: fxo02:
 ; DARWIN-64-STATIC:       ## %bb.0: ## %entry
-; DARWIN-64-STATIC-NEXT:    movq _xsrc@GOTPCREL(%rip), %rax
-; DARWIN-64-STATIC-NEXT:    movl (%rax), %eax
-; DARWIN-64-STATIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-STATIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-STATIC-NEXT:    movl %eax, (%rcx)
+; DARWIN-64-STATIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-STATIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-STATIC-NEXT:    movq _xsrc@GOTPCREL(%rip), %rcx
+; DARWIN-64-STATIC-NEXT:    movl (%rcx), %ecx
+; DARWIN-64-STATIC-NEXT:    movl %ecx, (%rax)
 ; DARWIN-64-STATIC-NEXT:    retq
 ;
 ; DARWIN-64-DYNAMIC-LABEL: fxo02:
 ; DARWIN-64-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-64-DYNAMIC-NEXT:    movq _xsrc@GOTPCREL(%rip), %rax
-; DARWIN-64-DYNAMIC-NEXT:    movl (%rax), %eax
-; DARWIN-64-DYNAMIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movl %eax, (%rcx)
+; DARWIN-64-DYNAMIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movq _xsrc@GOTPCREL(%rip), %rcx
+; DARWIN-64-DYNAMIC-NEXT:    movl (%rcx), %ecx
+; DARWIN-64-DYNAMIC-NEXT:    movl %ecx, (%rax)
 ; DARWIN-64-DYNAMIC-NEXT:    retq
 ;
 ; DARWIN-64-PIC-LABEL: fxo02:
 ; DARWIN-64-PIC:       ## %bb.0: ## %entry
-; DARWIN-64-PIC-NEXT:    movq _xsrc@GOTPCREL(%rip), %rax
-; DARWIN-64-PIC-NEXT:    movl (%rax), %eax
-; DARWIN-64-PIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-PIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-PIC-NEXT:    movl %eax, (%rcx)
+; DARWIN-64-PIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-PIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-PIC-NEXT:    movq _xsrc@GOTPCREL(%rip), %rcx
+; DARWIN-64-PIC-NEXT:    movl (%rcx), %ecx
+; DARWIN-64-PIC-NEXT:    movl %ecx, (%rax)
 ; DARWIN-64-PIC-NEXT:    retq
 
 entry:
@@ -729,16 +729,16 @@ entry:
 define dso_local void @foo05() nounwind {
 ; LINUX-64-STATIC-LABEL: foo05:
 ; LINUX-64-STATIC:       # %bb.0: # %entry
-; LINUX-64-STATIC-NEXT:    movl dsrc(%rip), %eax
-; LINUX-64-STATIC-NEXT:    movq dptr(%rip), %rcx
-; LINUX-64-STATIC-NEXT:    movl %eax, (%rcx)
+; LINUX-64-STATIC-NEXT:    movq dptr(%rip), %rax
+; LINUX-64-STATIC-NEXT:    movl dsrc(%rip), %ecx
+; LINUX-64-STATIC-NEXT:    movl %ecx, (%rax)
 ; LINUX-64-STATIC-NEXT:    retq
 ;
 ; LINUX-32-STATIC-LABEL: foo05:
 ; LINUX-32-STATIC:       # %bb.0: # %entry
-; LINUX-32-STATIC-NEXT:    movl dsrc, %eax
-; LINUX-32-STATIC-NEXT:    movl dptr, %ecx
-; LINUX-32-STATIC-NEXT:    movl %eax, (%ecx)
+; LINUX-32-STATIC-NEXT:    movl dptr, %eax
+; LINUX-32-STATIC-NEXT:    movl dsrc, %ecx
+; LINUX-32-STATIC-NEXT:    movl %ecx, (%eax)
 ; LINUX-32-STATIC-NEXT:    retl
 ;
 ; LINUX-32-PIC-LABEL: foo05:
@@ -748,30 +748,30 @@ define dso_local void @foo05() nounwind {
 ; LINUX-32-PIC-NEXT:    popl %eax
 ; LINUX-32-PIC-NEXT:  .Ltmp8:
 ; LINUX-32-PIC-NEXT:    addl $_GLOBAL_OFFSET_TABLE_+(.Ltmp8-.L8$pb), %eax
-; LINUX-32-PIC-NEXT:    movl .Ldsrc$local@GOTOFF(%eax), %ecx
-; LINUX-32-PIC-NEXT:    movl .Ldptr$local@GOTOFF(%eax), %eax
-; LINUX-32-PIC-NEXT:    movl %ecx, (%eax)
+; LINUX-32-PIC-NEXT:    movl .Ldptr$local@GOTOFF(%eax), %ecx
+; LINUX-32-PIC-NEXT:    movl .Ldsrc$local@GOTOFF(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl %eax, (%ecx)
 ; LINUX-32-PIC-NEXT:    retl
 ;
 ; LINUX-64-PIC-LABEL: foo05:
 ; LINUX-64-PIC:       # %bb.0: # %entry
-; LINUX-64-PIC-NEXT:    movl .Ldsrc$local(%rip), %eax
-; LINUX-64-PIC-NEXT:    movq .Ldptr$local(%rip), %rcx
-; LINUX-64-PIC-NEXT:    movl %eax, (%rcx)
+; LINUX-64-PIC-NEXT:    movq .Ldptr$local(%rip), %rax
+; LINUX-64-PIC-NEXT:    movl .Ldsrc$local(%rip), %ecx
+; LINUX-64-PIC-NEXT:    movl %ecx, (%rax)
 ; LINUX-64-PIC-NEXT:    retq
 ;
 ; DARWIN-32-STATIC-LABEL: foo05:
 ; DARWIN-32-STATIC:       ## %bb.0: ## %entry
-; DARWIN-32-STATIC-NEXT:    movl _dsrc, %eax
-; DARWIN-32-STATIC-NEXT:    movl _dptr, %ecx
-; DARWIN-32-STATIC-NEXT:    movl %eax, (%ecx)
+; DARWIN-32-STATIC-NEXT:    movl _dptr, %eax
+; DARWIN-32-STATIC-NEXT:    movl _dsrc, %ecx
+; DARWIN-32-STATIC-NEXT:    movl %ecx, (%eax)
 ; DARWIN-32-STATIC-NEXT:    retl
 ;
 ; DARWIN-32-DYNAMIC-LABEL: foo05:
 ; DARWIN-32-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-32-DYNAMIC-NEXT:    movl _dsrc, %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl _dptr, %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl %eax, (%ecx)
+; DARWIN-32-DYNAMIC-NEXT:    movl _dptr, %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl _dsrc, %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl %ecx, (%eax)
 ; DARWIN-32-DYNAMIC-NEXT:    retl
 ;
 ; DARWIN-32-PIC-LABEL: foo05:
@@ -779,30 +779,30 @@ define dso_local void @foo05() nounwind {
 ; DARWIN-32-PIC-NEXT:    calll L8$pb
 ; DARWIN-32-PIC-NEXT:  L8$pb:
 ; DARWIN-32-PIC-NEXT:    popl %eax
-; DARWIN-32-PIC-NEXT:    movl _dsrc-L8$pb(%eax), %ecx
-; DARWIN-32-PIC-NEXT:    movl _dptr-L8$pb(%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl %ecx, (%eax)
+; DARWIN-32-PIC-NEXT:    movl _dptr-L8$pb(%eax), %ecx
+; DARWIN-32-PIC-NEXT:    movl _dsrc-L8$pb(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl %eax, (%ecx)
 ; DARWIN-32-PIC-NEXT:    retl
 ;
 ; DARWIN-64-STATIC-LABEL: foo05:
 ; DARWIN-64-STATIC:       ## %bb.0: ## %entry
-; DARWIN-64-STATIC-NEXT:    movl _dsrc(%rip), %eax
-; DARWIN-64-STATIC-NEXT:    movq _dptr(%rip), %rcx
-; DARWIN-64-STATIC-NEXT:    movl %eax, (%rcx)
+; DARWIN-64-STATIC-NEXT:    movq _dptr(%rip), %rax
+; DARWIN-64-STATIC-NEXT:    movl _dsrc(%rip), %ecx
+; DARWIN-64-STATIC-NEXT:    movl %ecx, (%rax)
 ; DARWIN-64-STATIC-NEXT:    retq
 ;
 ; DARWIN-64-DYNAMIC-LABEL: foo05:
 ; DARWIN-64-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-64-DYNAMIC-NEXT:    movl _dsrc(%rip), %eax
-; DARWIN-64-DYNAMIC-NEXT:    movq _dptr(%rip), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movl %eax, (%rcx)
+; DARWIN-64-DYNAMIC-NEXT:    movq _dptr(%rip), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movl _dsrc(%rip), %ecx
+; DARWIN-64-DYNAMIC-NEXT:    movl %ecx, (%rax)
 ; DARWIN-64-DYNAMIC-NEXT:    retq
 ;
 ; DARWIN-64-PIC-LABEL: foo05:
 ; DARWIN-64-PIC:       ## %bb.0: ## %entry
-; DARWIN-64-PIC-NEXT:    movl _dsrc(%rip), %eax
-; DARWIN-64-PIC-NEXT:    movq _dptr(%rip), %rcx
-; DARWIN-64-PIC-NEXT:    movl %eax, (%rcx)
+; DARWIN-64-PIC-NEXT:    movq _dptr(%rip), %rax
+; DARWIN-64-PIC-NEXT:    movl _dsrc(%rip), %ecx
+; DARWIN-64-PIC-NEXT:    movl %ecx, (%rax)
 ; DARWIN-64-PIC-NEXT:    retq
 
 entry:
@@ -960,16 +960,16 @@ entry:
 define dso_local void @foo08() nounwind {
 ; LINUX-64-STATIC-LABEL: foo08:
 ; LINUX-64-STATIC:       # %bb.0: # %entry
-; LINUX-64-STATIC-NEXT:    movl lsrc(%rip), %eax
-; LINUX-64-STATIC-NEXT:    movq lptr(%rip), %rcx
-; LINUX-64-STATIC-NEXT:    movl %eax, (%rcx)
+; LINUX-64-STATIC-NEXT:    movq lptr(%rip), %rax
+; LINUX-64-STATIC-NEXT:    movl lsrc(%rip), %ecx
+; LINUX-64-STATIC-NEXT:    movl %ecx, (%rax)
 ; LINUX-64-STATIC-NEXT:    retq
 ;
 ; LINUX-32-STATIC-LABEL: foo08:
 ; LINUX-32-STATIC:       # %bb.0: # %entry
-; LINUX-32-STATIC-NEXT:    movl lsrc, %eax
-; LINUX-32-STATIC-NEXT:    movl lptr, %ecx
-; LINUX-32-STATIC-NEXT:    movl %eax, (%ecx)
+; LINUX-32-STATIC-NEXT:    movl lptr, %eax
+; LINUX-32-STATIC-NEXT:    movl lsrc, %ecx
+; LINUX-32-STATIC-NEXT:    movl %ecx, (%eax)
 ; LINUX-32-STATIC-NEXT:    retl
 ;
 ; LINUX-32-PIC-LABEL: foo08:
@@ -979,30 +979,30 @@ define dso_local void @foo08() nounwind {
 ; LINUX-32-PIC-NEXT:    popl %eax
 ; LINUX-32-PIC-NEXT:  .Ltmp11:
 ; LINUX-32-PIC-NEXT:    addl $_GLOBAL_OFFSET_TABLE_+(.Ltmp11-.L11$pb), %eax
-; LINUX-32-PIC-NEXT:    movl lsrc@GOTOFF(%eax), %ecx
-; LINUX-32-PIC-NEXT:    movl lptr@GOTOFF(%eax), %eax
-; LINUX-32-PIC-NEXT:    movl %ecx, (%eax)
+; LINUX-32-PIC-NEXT:    movl lptr@GOTOFF(%eax), %ecx
+; LINUX-32-PIC-NEXT:    movl lsrc@GOTOFF(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl %eax, (%ecx)
 ; LINUX-32-PIC-NEXT:    retl
 ;
 ; LINUX-64-PIC-LABEL: foo08:
 ; LINUX-64-PIC:       # %bb.0: # %entry
-; LINUX-64-PIC-NEXT:    movl lsrc(%rip), %eax
-; LINUX-64-PIC-NEXT:    movq lptr(%rip), %rcx
-; LINUX-64-PIC-NEXT:    movl %eax, (%rcx)
+; LINUX-64-PIC-NEXT:    movq lptr(%rip), %rax
+; LINUX-64-PIC-NEXT:    movl lsrc(%rip), %ecx
+; LINUX-64-PIC-NEXT:    movl %ecx, (%rax)
 ; LINUX-64-PIC-NEXT:    retq
 ;
 ; DARWIN-32-STATIC-LABEL: foo08:
 ; DARWIN-32-STATIC:       ## %bb.0: ## %entry
-; DARWIN-32-STATIC-NEXT:    movl _lsrc, %eax
-; DARWIN-32-STATIC-NEXT:    movl _lptr, %ecx
-; DARWIN-32-STATIC-NEXT:    movl %eax, (%ecx)
+; DARWIN-32-STATIC-NEXT:    movl _lptr, %eax
+; DARWIN-32-STATIC-NEXT:    movl _lsrc, %ecx
+; DARWIN-32-STATIC-NEXT:    movl %ecx, (%eax)
 ; DARWIN-32-STATIC-NEXT:    retl
 ;
 ; DARWIN-32-DYNAMIC-LABEL: foo08:
 ; DARWIN-32-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-32-DYNAMIC-NEXT:    movl _lsrc, %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl _lptr, %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl %eax, (%ecx)
+; DARWIN-32-DYNAMIC-NEXT:    movl _lptr, %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl _lsrc, %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl %ecx, (%eax)
 ; DARWIN-32-DYNAMIC-NEXT:    retl
 ;
 ; DARWIN-32-PIC-LABEL: foo08:
@@ -1010,30 +1010,30 @@ define dso_local void @foo08() nounwind {
 ; DARWIN-32-PIC-NEXT:    calll L11$pb
 ; DARWIN-32-PIC-NEXT:  L11$pb:
 ; DARWIN-32-PIC-NEXT:    popl %eax
-; DARWIN-32-PIC-NEXT:    movl _lsrc-L11$pb(%eax), %ecx
-; DARWIN-32-PIC-NEXT:    movl _lptr-L11$pb(%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl %ecx, (%eax)
+; DARWIN-32-PIC-NEXT:    movl _lptr-L11$pb(%eax), %ecx
+; DARWIN-32-PIC-NEXT:    movl _lsrc-L11$pb(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl %eax, (%ecx)
 ; DARWIN-32-PIC-NEXT:    retl
 ;
 ; DARWIN-64-STATIC-LABEL: foo08:
 ; DARWIN-64-STATIC:       ## %bb.0: ## %entry
-; DARWIN-64-STATIC-NEXT:    movl _lsrc(%rip), %eax
-; DARWIN-64-STATIC-NEXT:    movq _lptr(%rip), %rcx
-; DARWIN-64-STATIC-NEXT:    movl %eax, (%rcx)
+; DARWIN-64-STATIC-NEXT:    movq _lptr(%rip), %rax
+; DARWIN-64-STATIC-NEXT:    movl _lsrc(%rip), %ecx
+; DARWIN-64-STATIC-NEXT:    movl %ecx, (%rax)
 ; DARWIN-64-STATIC-NEXT:    retq
 ;
 ; DARWIN-64-DYNAMIC-LABEL: foo08:
 ; DARWIN-64-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-64-DYNAMIC-NEXT:    movl _lsrc(%rip), %eax
-; DARWIN-64-DYNAMIC-NEXT:    movq _lptr(%rip), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movl %eax, (%rcx)
+; DARWIN-64-DYNAMIC-NEXT:    movq _lptr(%rip), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movl _lsrc(%rip), %ecx
+; DARWIN-64-DYNAMIC-NEXT:    movl %ecx, (%rax)
 ; DARWIN-64-DYNAMIC-NEXT:    retq
 ;
 ; DARWIN-64-PIC-LABEL: foo08:
 ; DARWIN-64-PIC:       ## %bb.0: ## %entry
-; DARWIN-64-PIC-NEXT:    movl _lsrc(%rip), %eax
-; DARWIN-64-PIC-NEXT:    movq _lptr(%rip), %rcx
-; DARWIN-64-PIC-NEXT:    movl %eax, (%rcx)
+; DARWIN-64-PIC-NEXT:    movq _lptr(%rip), %rax
+; DARWIN-64-PIC-NEXT:    movl _lsrc(%rip), %ecx
+; DARWIN-64-PIC-NEXT:    movl %ecx, (%rax)
 ; DARWIN-64-PIC-NEXT:    retq
 
 entry:
@@ -1406,18 +1406,18 @@ entry:
 define dso_local void @qux02() nounwind {
 ; LINUX-64-STATIC-LABEL: qux02:
 ; LINUX-64-STATIC:       # %bb.0: # %entry
-; LINUX-64-STATIC-NEXT:    movq src@GOTPCREL(%rip), %rax
-; LINUX-64-STATIC-NEXT:    movl 64(%rax), %eax
-; LINUX-64-STATIC-NEXT:    movq ptr@GOTPCREL(%rip), %rcx
-; LINUX-64-STATIC-NEXT:    movq (%rcx), %rcx
-; LINUX-64-STATIC-NEXT:    movl %eax, 64(%rcx)
+; LINUX-64-STATIC-NEXT:    movq ptr@GOTPCREL(%rip), %rax
+; LINUX-64-STATIC-NEXT:    movq (%rax), %rax
+; LINUX-64-STATIC-NEXT:    movq src@GOTPCREL(%rip), %rcx
+; LINUX-64-STATIC-NEXT:    movl 64(%rcx), %ecx
+; LINUX-64-STATIC-NEXT:    movl %ecx, 64(%rax)
 ; LINUX-64-STATIC-NEXT:    retq
 ;
 ; LINUX-32-STATIC-LABEL: qux02:
 ; LINUX-32-STATIC:       # %bb.0: # %entry
-; LINUX-32-STATIC-NEXT:    movl src+64, %eax
-; LINUX-32-STATIC-NEXT:    movl ptr, %ecx
-; LINUX-32-STATIC-NEXT:    movl %eax, 64(%ecx)
+; LINUX-32-STATIC-NEXT:    movl ptr, %eax
+; LINUX-32-STATIC-NEXT:    movl src+64, %ecx
+; LINUX-32-STATIC-NEXT:    movl %ecx, 64(%eax)
 ; LINUX-32-STATIC-NEXT:    retl
 ;
 ; LINUX-32-PIC-LABEL: qux02:
@@ -1427,36 +1427,36 @@ define dso_local void @qux02() nounwind {
 ; LINUX-32-PIC-NEXT:    popl %eax
 ; LINUX-32-PIC-NEXT:  .Ltmp16:
 ; LINUX-32-PIC-NEXT:    addl $_GLOBAL_OFFSET_TABLE_+(.Ltmp16-.L16$pb), %eax
-; LINUX-32-PIC-NEXT:    movl src@GOT(%eax), %ecx
-; LINUX-32-PIC-NEXT:    movl 64(%ecx), %ecx
-; LINUX-32-PIC-NEXT:    movl ptr@GOT(%eax), %eax
-; LINUX-32-PIC-NEXT:    movl (%eax), %eax
-; LINUX-32-PIC-NEXT:    movl %ecx, 64(%eax)
+; LINUX-32-PIC-NEXT:    movl ptr@GOT(%eax), %ecx
+; LINUX-32-PIC-NEXT:    movl (%ecx), %ecx
+; LINUX-32-PIC-NEXT:    movl src@GOT(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl 64(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl %eax, 64(%ecx)
 ; LINUX-32-PIC-NEXT:    retl
 ;
 ; LINUX-64-PIC-LABEL: qux02:
 ; LINUX-64-PIC:       # %bb.0: # %entry
-; LINUX-64-PIC-NEXT:    movq src@GOTPCREL(%rip), %rax
-; LINUX-64-PIC-NEXT:    movl 64(%rax), %eax
-; LINUX-64-PIC-NEXT:    movq ptr@GOTPCREL(%rip), %rcx
-; LINUX-64-PIC-NEXT:    movq (%rcx), %rcx
-; LINUX-64-PIC-NEXT:    movl %eax, 64(%rcx)
+; LINUX-64-PIC-NEXT:    movq ptr@GOTPCREL(%rip), %rax
+; LINUX-64-PIC-NEXT:    movq (%rax), %rax
+; LINUX-64-PIC-NEXT:    movq src@GOTPCREL(%rip), %rcx
+; LINUX-64-PIC-NEXT:    movl 64(%rcx), %ecx
+; LINUX-64-PIC-NEXT:    movl %ecx, 64(%rax)
 ; LINUX-64-PIC-NEXT:    retq
 ;
 ; DARWIN-32-STATIC-LABEL: qux02:
 ; DARWIN-32-STATIC:       ## %bb.0: ## %entry
-; DARWIN-32-STATIC-NEXT:    movl _src+64, %eax
-; DARWIN-32-STATIC-NEXT:    movl _ptr, %ecx
-; DARWIN-32-STATIC-NEXT:    movl %eax, 64(%ecx)
+; DARWIN-32-STATIC-NEXT:    movl _ptr, %eax
+; DARWIN-32-STATIC-NEXT:    movl _src+64, %ecx
+; DARWIN-32-STATIC-NEXT:    movl %ecx, 64(%eax)
 ; DARWIN-32-STATIC-NEXT:    retl
 ;
 ; DARWIN-32-DYNAMIC-LABEL: qux02:
 ; DARWIN-32-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-32-DYNAMIC-NEXT:    movl L_src$non_lazy_ptr, %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl 64(%eax), %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl L_ptr$non_lazy_ptr, %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl (%ecx), %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl %eax, 64(%ecx)
+; DARWIN-32-DYNAMIC-NEXT:    movl L_ptr$non_lazy_ptr, %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl (%eax), %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl L_src$non_lazy_ptr, %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl 64(%ecx), %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl %ecx, 64(%eax)
 ; DARWIN-32-DYNAMIC-NEXT:    retl
 ;
 ; DARWIN-32-PIC-LABEL: qux02:
@@ -1464,38 +1464,38 @@ define dso_local void @qux02() nounwind {
 ; DARWIN-32-PIC-NEXT:    calll L16$pb
 ; DARWIN-32-PIC-NEXT:  L16$pb:
 ; DARWIN-32-PIC-NEXT:    popl %eax
-; DARWIN-32-PIC-NEXT:    movl L_src$non_lazy_ptr-L16$pb(%eax), %ecx
-; DARWIN-32-PIC-NEXT:    movl 64(%ecx), %ecx
-; DARWIN-32-PIC-NEXT:    movl L_ptr$non_lazy_ptr-L16$pb(%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl (%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl %ecx, 64(%eax)
+; DARWIN-32-PIC-NEXT:    movl L_ptr$non_lazy_ptr-L16$pb(%eax), %ecx
+; DARWIN-32-PIC-NEXT:    movl (%ecx), %ecx
+; DARWIN-32-PIC-NEXT:    movl L_src$non_lazy_ptr-L16$pb(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl 64(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl %eax, 64(%ecx)
 ; DARWIN-32-PIC-NEXT:    retl
 ;
 ; DARWIN-64-STATIC-LABEL: qux02:
 ; DARWIN-64-STATIC:       ## %bb.0: ## %entry
-; DARWIN-64-STATIC-NEXT:    movq _src@GOTPCREL(%rip), %rax
-; DARWIN-64-STATIC-NEXT:    movl 64(%rax), %eax
-; DARWIN-64-STATIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-STATIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-STATIC-NEXT:    movl %eax, 64(%rcx)
+; DARWIN-64-STATIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-STATIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-STATIC-NEXT:    movq _src@GOTPCREL(%rip), %rcx
+; DARWIN-64-STATIC-NEXT:    movl 64(%rcx), %ecx
+; DARWIN-64-STATIC-NEXT:    movl %ecx, 64(%rax)
 ; DARWIN-64-STATIC-NEXT:    retq
 ;
 ; DARWIN-64-DYNAMIC-LABEL: qux02:
 ; DARWIN-64-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-64-DYNAMIC-NEXT:    movq _src@GOTPCREL(%rip), %rax
-; DARWIN-64-DYNAMIC-NEXT:    movl 64(%rax), %eax
-; DARWIN-64-DYNAMIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movl %eax, 64(%rcx)
+; DARWIN-64-DYNAMIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movq _src@GOTPCREL(%rip), %rcx
+; DARWIN-64-DYNAMIC-NEXT:    movl 64(%rcx), %ecx
+; DARWIN-64-DYNAMIC-NEXT:    movl %ecx, 64(%rax)
 ; DARWIN-64-DYNAMIC-NEXT:    retq
 ;
 ; DARWIN-64-PIC-LABEL: qux02:
 ; DARWIN-64-PIC:       ## %bb.0: ## %entry
-; DARWIN-64-PIC-NEXT:    movq _src@GOTPCREL(%rip), %rax
-; DARWIN-64-PIC-NEXT:    movl 64(%rax), %eax
-; DARWIN-64-PIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-PIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-PIC-NEXT:    movl %eax, 64(%rcx)
+; DARWIN-64-PIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-PIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-PIC-NEXT:    movq _src@GOTPCREL(%rip), %rcx
+; DARWIN-64-PIC-NEXT:    movl 64(%rcx), %ecx
+; DARWIN-64-PIC-NEXT:    movl %ecx, 64(%rax)
 ; DARWIN-64-PIC-NEXT:    retq
 
 entry:
@@ -1509,18 +1509,18 @@ entry:
 define dso_local void @qxx02() nounwind {
 ; LINUX-64-STATIC-LABEL: qxx02:
 ; LINUX-64-STATIC:       # %bb.0: # %entry
-; LINUX-64-STATIC-NEXT:    movq xsrc@GOTPCREL(%rip), %rax
-; LINUX-64-STATIC-NEXT:    movl 64(%rax), %eax
-; LINUX-64-STATIC-NEXT:    movq ptr@GOTPCREL(%rip), %rcx
-; LINUX-64-STATIC-NEXT:    movq (%rcx), %rcx
-; LINUX-64-STATIC-NEXT:    movl %eax, 64(%rcx)
+; LINUX-64-STATIC-NEXT:    movq ptr@GOTPCREL(%rip), %rax
+; LINUX-64-STATIC-NEXT:    movq (%rax), %rax
+; LINUX-64-STATIC-NEXT:    movq xsrc@GOTPCREL(%rip), %rcx
+; LINUX-64-STATIC-NEXT:    movl 64(%rcx), %ecx
+; LINUX-64-STATIC-NEXT:    movl %ecx, 64(%rax)
 ; LINUX-64-STATIC-NEXT:    retq
 ;
 ; LINUX-32-STATIC-LABEL: qxx02:
 ; LINUX-32-STATIC:       # %bb.0: # %entry
-; LINUX-32-STATIC-NEXT:    movl xsrc+64, %eax
-; LINUX-32-STATIC-NEXT:    movl ptr, %ecx
-; LINUX-32-STATIC-NEXT:    movl %eax, 64(%ecx)
+; LINUX-32-STATIC-NEXT:    movl ptr, %eax
+; LINUX-32-STATIC-NEXT:    movl xsrc+64, %ecx
+; LINUX-32-STATIC-NEXT:    movl %ecx, 64(%eax)
 ; LINUX-32-STATIC-NEXT:    retl
 ;
 ; LINUX-32-PIC-LABEL: qxx02:
@@ -1530,36 +1530,36 @@ define dso_local void @qxx02() nounwind {
 ; LINUX-32-PIC-NEXT:    popl %eax
 ; LINUX-32-PIC-NEXT:  .Ltmp17:
 ; LINUX-32-PIC-NEXT:    addl $_GLOBAL_OFFSET_TABLE_+(.Ltmp17-.L17$pb), %eax
-; LINUX-32-PIC-NEXT:    movl xsrc@GOT(%eax), %ecx
-; LINUX-32-PIC-NEXT:    movl 64(%ecx), %ecx
-; LINUX-32-PIC-NEXT:    movl ptr@GOT(%eax), %eax
-; LINUX-32-PIC-NEXT:    movl (%eax), %eax
-; LINUX-32-PIC-NEXT:    movl %ecx, 64(%eax)
+; LINUX-32-PIC-NEXT:    movl ptr@GOT(%eax), %ecx
+; LINUX-32-PIC-NEXT:    movl (%ecx), %ecx
+; LINUX-32-PIC-NEXT:    movl xsrc@GOT(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl 64(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl %eax, 64(%ecx)
 ; LINUX-32-PIC-NEXT:    retl
 ;
 ; LINUX-64-PIC-LABEL: qxx02:
 ; LINUX-64-PIC:       # %bb.0: # %entry
-; LINUX-64-PIC-NEXT:    movq xsrc@GOTPCREL(%rip), %rax
-; LINUX-64-PIC-NEXT:    movl 64(%rax), %eax
-; LINUX-64-PIC-NEXT:    movq ptr@GOTPCREL(%rip), %rcx
-; LINUX-64-PIC-NEXT:    movq (%rcx), %rcx
-; LINUX-64-PIC-NEXT:    movl %eax, 64(%rcx)
+; LINUX-64-PIC-NEXT:    movq ptr@GOTPCREL(%rip), %rax
+; LINUX-64-PIC-NEXT:    movq (%rax), %rax
+; LINUX-64-PIC-NEXT:    movq xsrc@GOTPCREL(%rip), %rcx
+; LINUX-64-PIC-NEXT:    movl 64(%rcx), %ecx
+; LINUX-64-PIC-NEXT:    movl %ecx, 64(%rax)
 ; LINUX-64-PIC-NEXT:    retq
 ;
 ; DARWIN-32-STATIC-LABEL: qxx02:
 ; DARWIN-32-STATIC:       ## %bb.0: ## %entry
-; DARWIN-32-STATIC-NEXT:    movl _xsrc+64, %eax
-; DARWIN-32-STATIC-NEXT:    movl _ptr, %ecx
-; DARWIN-32-STATIC-NEXT:    movl %eax, 64(%ecx)
+; DARWIN-32-STATIC-NEXT:    movl _ptr, %eax
+; DARWIN-32-STATIC-NEXT:    movl _xsrc+64, %ecx
+; DARWIN-32-STATIC-NEXT:    movl %ecx, 64(%eax)
 ; DARWIN-32-STATIC-NEXT:    retl
 ;
 ; DARWIN-32-DYNAMIC-LABEL: qxx02:
 ; DARWIN-32-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-32-DYNAMIC-NEXT:    movl L_xsrc$non_lazy_ptr, %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl 64(%eax), %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl L_ptr$non_lazy_ptr, %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl (%ecx), %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl %eax, 64(%ecx)
+; DARWIN-32-DYNAMIC-NEXT:    movl L_ptr$non_lazy_ptr, %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl (%eax), %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl L_xsrc$non_lazy_ptr, %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl 64(%ecx), %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl %ecx, 64(%eax)
 ; DARWIN-32-DYNAMIC-NEXT:    retl
 ;
 ; DARWIN-32-PIC-LABEL: qxx02:
@@ -1567,38 +1567,38 @@ define dso_local void @qxx02() nounwind {
 ; DARWIN-32-PIC-NEXT:    calll L17$pb
 ; DARWIN-32-PIC-NEXT:  L17$pb:
 ; DARWIN-32-PIC-NEXT:    popl %eax
-; DARWIN-32-PIC-NEXT:    movl L_xsrc$non_lazy_ptr-L17$pb(%eax), %ecx
-; DARWIN-32-PIC-NEXT:    movl 64(%ecx), %ecx
-; DARWIN-32-PIC-NEXT:    movl L_ptr$non_lazy_ptr-L17$pb(%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl (%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl %ecx, 64(%eax)
+; DARWIN-32-PIC-NEXT:    movl L_ptr$non_lazy_ptr-L17$pb(%eax), %ecx
+; DARWIN-32-PIC-NEXT:    movl (%ecx), %ecx
+; DARWIN-32-PIC-NEXT:    movl L_xsrc$non_lazy_ptr-L17$pb(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl 64(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl %eax, 64(%ecx)
 ; DARWIN-32-PIC-NEXT:    retl
 ;
 ; DARWIN-64-STATIC-LABEL: qxx02:
 ; DARWIN-64-STATIC:       ## %bb.0: ## %entry
-; DARWIN-64-STATIC-NEXT:    movq _xsrc@GOTPCREL(%rip), %rax
-; DARWIN-64-STATIC-NEXT:    movl 64(%rax), %eax
-; DARWIN-64-STATIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-STATIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-STATIC-NEXT:    movl %eax, 64(%rcx)
+; DARWIN-64-STATIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-STATIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-STATIC-NEXT:    movq _xsrc@GOTPCREL(%rip), %rcx
+; DARWIN-64-STATIC-NEXT:    movl 64(%rcx), %ecx
+; DARWIN-64-STATIC-NEXT:    movl %ecx, 64(%rax)
 ; DARWIN-64-STATIC-NEXT:    retq
 ;
 ; DARWIN-64-DYNAMIC-LABEL: qxx02:
 ; DARWIN-64-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-64-DYNAMIC-NEXT:    movq _xsrc@GOTPCREL(%rip), %rax
-; DARWIN-64-DYNAMIC-NEXT:    movl 64(%rax), %eax
-; DARWIN-64-DYNAMIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movl %eax, 64(%rcx)
+; DARWIN-64-DYNAMIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movq _xsrc@GOTPCREL(%rip), %rcx
+; DARWIN-64-DYNAMIC-NEXT:    movl 64(%rcx), %ecx
+; DARWIN-64-DYNAMIC-NEXT:    movl %ecx, 64(%rax)
 ; DARWIN-64-DYNAMIC-NEXT:    retq
 ;
 ; DARWIN-64-PIC-LABEL: qxx02:
 ; DARWIN-64-PIC:       ## %bb.0: ## %entry
-; DARWIN-64-PIC-NEXT:    movq _xsrc@GOTPCREL(%rip), %rax
-; DARWIN-64-PIC-NEXT:    movl 64(%rax), %eax
-; DARWIN-64-PIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-PIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-PIC-NEXT:    movl %eax, 64(%rcx)
+; DARWIN-64-PIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-PIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-PIC-NEXT:    movq _xsrc@GOTPCREL(%rip), %rcx
+; DARWIN-64-PIC-NEXT:    movl 64(%rcx), %ecx
+; DARWIN-64-PIC-NEXT:    movl %ecx, 64(%rax)
 ; DARWIN-64-PIC-NEXT:    retq
 
 entry:
@@ -1757,16 +1757,16 @@ entry:
 define dso_local void @qux05() nounwind {
 ; LINUX-64-STATIC-LABEL: qux05:
 ; LINUX-64-STATIC:       # %bb.0: # %entry
-; LINUX-64-STATIC-NEXT:    movl dsrc+64(%rip), %eax
-; LINUX-64-STATIC-NEXT:    movq dptr(%rip), %rcx
-; LINUX-64-STATIC-NEXT:    movl %eax, 64(%rcx)
+; LINUX-64-STATIC-NEXT:    movq dptr(%rip), %rax
+; LINUX-64-STATIC-NEXT:    movl dsrc+64(%rip), %ecx
+; LINUX-64-STATIC-NEXT:    movl %ecx, 64(%rax)
 ; LINUX-64-STATIC-NEXT:    retq
 ;
 ; LINUX-32-STATIC-LABEL: qux05:
 ; LINUX-32-STATIC:       # %bb.0: # %entry
-; LINUX-32-STATIC-NEXT:    movl dsrc+64, %eax
-; LINUX-32-STATIC-NEXT:    movl dptr, %ecx
-; LINUX-32-STATIC-NEXT:    movl %eax, 64(%ecx)
+; LINUX-32-STATIC-NEXT:    movl dptr, %eax
+; LINUX-32-STATIC-NEXT:    movl dsrc+64, %ecx
+; LINUX-32-STATIC-NEXT:    movl %ecx, 64(%eax)
 ; LINUX-32-STATIC-NEXT:    retl
 ;
 ; LINUX-32-PIC-LABEL: qux05:
@@ -1776,30 +1776,30 @@ define dso_local void @qux05() nounwind {
 ; LINUX-32-PIC-NEXT:    popl %eax
 ; LINUX-32-PIC-NEXT:  .Ltmp20:
 ; LINUX-32-PIC-NEXT:    addl $_GLOBAL_OFFSET_TABLE_+(.Ltmp20-.L20$pb), %eax
-; LINUX-32-PIC-NEXT:    movl .Ldsrc$local@GOTOFF+64(%eax), %ecx
-; LINUX-32-PIC-NEXT:    movl .Ldptr$local@GOTOFF(%eax), %eax
-; LINUX-32-PIC-NEXT:    movl %ecx, 64(%eax)
+; LINUX-32-PIC-NEXT:    movl .Ldptr$local@GOTOFF(%eax), %ecx
+; LINUX-32-PIC-NEXT:    movl .Ldsrc$local@GOTOFF+64(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl %eax, 64(%ecx)
 ; LINUX-32-PIC-NEXT:    retl
 ;
 ; LINUX-64-PIC-LABEL: qux05:
 ; LINUX-64-PIC:       # %bb.0: # %entry
-; LINUX-64-PIC-NEXT:    movl .Ldsrc$local+64(%rip), %eax
-; LINUX-64-PIC-NEXT:    movq .Ldptr$local(%rip), %rcx
-; LINUX-64-PIC-NEXT:    movl %eax, 64(%rcx)
+; LINUX-64-PIC-NEXT:    movq .Ldptr$local(%rip), %rax
+; LINUX-64-PIC-NEXT:    movl .Ldsrc$local+64(%rip), %ecx
+; LINUX-64-PIC-NEXT:    movl %ecx, 64(%rax)
 ; LINUX-64-PIC-NEXT:    retq
 ;
 ; DARWIN-32-STATIC-LABEL: qux05:
 ; DARWIN-32-STATIC:       ## %bb.0: ## %entry
-; DARWIN-32-STATIC-NEXT:    movl _dsrc+64, %eax
-; DARWIN-32-STATIC-NEXT:    movl _dptr, %ecx
-; DARWIN-32-STATIC-NEXT:    movl %eax, 64(%ecx)
+; DARWIN-32-STATIC-NEXT:    movl _dptr, %eax
+; DARWIN-32-STATIC-NEXT:    movl _dsrc+64, %ecx
+; DARWIN-32-STATIC-NEXT:    movl %ecx, 64(%eax)
 ; DARWIN-32-STATIC-NEXT:    retl
 ;
 ; DARWIN-32-DYNAMIC-LABEL: qux05:
 ; DARWIN-32-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-32-DYNAMIC-NEXT:    movl _dsrc+64, %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl _dptr, %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl %eax, 64(%ecx)
+; DARWIN-32-DYNAMIC-NEXT:    movl _dptr, %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl _dsrc+64, %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl %ecx, 64(%eax)
 ; DARWIN-32-DYNAMIC-NEXT:    retl
 ;
 ; DARWIN-32-PIC-LABEL: qux05:
@@ -1807,30 +1807,30 @@ define dso_local void @qux05() nounwind {
 ; DARWIN-32-PIC-NEXT:    calll L20$pb
 ; DARWIN-32-PIC-NEXT:  L20$pb:
 ; DARWIN-32-PIC-NEXT:    popl %eax
-; DARWIN-32-PIC-NEXT:    movl _dsrc-L20$pb+64(%eax), %ecx
-; DARWIN-32-PIC-NEXT:    movl _dptr-L20$pb(%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl %ecx, 64(%eax)
+; DARWIN-32-PIC-NEXT:    movl _dptr-L20$pb(%eax), %ecx
+; DARWIN-32-PIC-NEXT:    movl _dsrc-L20$pb+64(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl %eax, 64(%ecx)
 ; DARWIN-32-PIC-NEXT:    retl
 ;
 ; DARWIN-64-STATIC-LABEL: qux05:
 ; DARWIN-64-STATIC:       ## %bb.0: ## %entry
-; DARWIN-64-STATIC-NEXT:    movl _dsrc+64(%rip), %eax
-; DARWIN-64-STATIC-NEXT:    movq _dptr(%rip), %rcx
-; DARWIN-64-STATIC-NEXT:    movl %eax, 64(%rcx)
+; DARWIN-64-STATIC-NEXT:    movq _dptr(%rip), %rax
+; DARWIN-64-STATIC-NEXT:    movl _dsrc+64(%rip), %ecx
+; DARWIN-64-STATIC-NEXT:    movl %ecx, 64(%rax)
 ; DARWIN-64-STATIC-NEXT:    retq
 ;
 ; DARWIN-64-DYNAMIC-LABEL: qux05:
 ; DARWIN-64-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-64-DYNAMIC-NEXT:    movl _dsrc+64(%rip), %eax
-; DARWIN-64-DYNAMIC-NEXT:    movq _dptr(%rip), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movl %eax, 64(%rcx)
+; DARWIN-64-DYNAMIC-NEXT:    movq _dptr(%rip), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movl _dsrc+64(%rip), %ecx
+; DARWIN-64-DYNAMIC-NEXT:    movl %ecx, 64(%rax)
 ; DARWIN-64-DYNAMIC-NEXT:    retq
 ;
 ; DARWIN-64-PIC-LABEL: qux05:
 ; DARWIN-64-PIC:       ## %bb.0: ## %entry
-; DARWIN-64-PIC-NEXT:    movl _dsrc+64(%rip), %eax
-; DARWIN-64-PIC-NEXT:    movq _dptr(%rip), %rcx
-; DARWIN-64-PIC-NEXT:    movl %eax, 64(%rcx)
+; DARWIN-64-PIC-NEXT:    movq _dptr(%rip), %rax
+; DARWIN-64-PIC-NEXT:    movl _dsrc+64(%rip), %ecx
+; DARWIN-64-PIC-NEXT:    movl %ecx, 64(%rax)
 ; DARWIN-64-PIC-NEXT:    retq
 
 entry:
@@ -1989,16 +1989,16 @@ entry:
 define dso_local void @qux08() nounwind {
 ; LINUX-64-STATIC-LABEL: qux08:
 ; LINUX-64-STATIC:       # %bb.0: # %entry
-; LINUX-64-STATIC-NEXT:    movl lsrc+64(%rip), %eax
-; LINUX-64-STATIC-NEXT:    movq lptr(%rip), %rcx
-; LINUX-64-STATIC-NEXT:    movl %eax, 64(%rcx)
+; LINUX-64-STATIC-NEXT:    movq lptr(%rip), %rax
+; LINUX-64-STATIC-NEXT:    movl lsrc+64(%rip), %ecx
+; LINUX-64-STATIC-NEXT:    movl %ecx, 64(%rax)
 ; LINUX-64-STATIC-NEXT:    retq
 ;
 ; LINUX-32-STATIC-LABEL: qux08:
 ; LINUX-32-STATIC:       # %bb.0: # %entry
-; LINUX-32-STATIC-NEXT:    movl lsrc+64, %eax
-; LINUX-32-STATIC-NEXT:    movl lptr, %ecx
-; LINUX-32-STATIC-NEXT:    movl %eax, 64(%ecx)
+; LINUX-32-STATIC-NEXT:    movl lptr, %eax
+; LINUX-32-STATIC-NEXT:    movl lsrc+64, %ecx
+; LINUX-32-STATIC-NEXT:    movl %ecx, 64(%eax)
 ; LINUX-32-STATIC-NEXT:    retl
 ;
 ; LINUX-32-PIC-LABEL: qux08:
@@ -2008,30 +2008,30 @@ define dso_local void @qux08() nounwind {
 ; LINUX-32-PIC-NEXT:    popl %eax
 ; LINUX-32-PIC-NEXT:  .Ltmp23:
 ; LINUX-32-PIC-NEXT:    addl $_GLOBAL_OFFSET_TABLE_+(.Ltmp23-.L23$pb), %eax
-; LINUX-32-PIC-NEXT:    movl lsrc@GOTOFF+64(%eax), %ecx
-; LINUX-32-PIC-NEXT:    movl lptr@GOTOFF(%eax), %eax
-; LINUX-32-PIC-NEXT:    movl %ecx, 64(%eax)
+; LINUX-32-PIC-NEXT:    movl lptr@GOTOFF(%eax), %ecx
+; LINUX-32-PIC-NEXT:    movl lsrc@GOTOFF+64(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl %eax, 64(%ecx)
 ; LINUX-32-PIC-NEXT:    retl
 ;
 ; LINUX-64-PIC-LABEL: qux08:
 ; LINUX-64-PIC:       # %bb.0: # %entry
-; LINUX-64-PIC-NEXT:    movl lsrc+64(%rip), %eax
-; LINUX-64-PIC-NEXT:    movq lptr(%rip), %rcx
-; LINUX-64-PIC-NEXT:    movl %eax, 64(%rcx)
+; LINUX-64-PIC-NEXT:    movq lptr(%rip), %rax
+; LINUX-64-PIC-NEXT:    movl lsrc+64(%rip), %ecx
+; LINUX-64-PIC-NEXT:    movl %ecx, 64(%rax)
 ; LINUX-64-PIC-NEXT:    retq
 ;
 ; DARWIN-32-STATIC-LABEL: qux08:
 ; DARWIN-32-STATIC:       ## %bb.0: ## %entry
-; DARWIN-32-STATIC-NEXT:    movl _lsrc+64, %eax
-; DARWIN-32-STATIC-NEXT:    movl _lptr, %ecx
-; DARWIN-32-STATIC-NEXT:    movl %eax, 64(%ecx)
+; DARWIN-32-STATIC-NEXT:    movl _lptr, %eax
+; DARWIN-32-STATIC-NEXT:    movl _lsrc+64, %ecx
+; DARWIN-32-STATIC-NEXT:    movl %ecx, 64(%eax)
 ; DARWIN-32-STATIC-NEXT:    retl
 ;
 ; DARWIN-32-DYNAMIC-LABEL: qux08:
 ; DARWIN-32-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-32-DYNAMIC-NEXT:    movl _lsrc+64, %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl _lptr, %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl %eax, 64(%ecx)
+; DARWIN-32-DYNAMIC-NEXT:    movl _lptr, %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl _lsrc+64, %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl %ecx, 64(%eax)
 ; DARWIN-32-DYNAMIC-NEXT:    retl
 ;
 ; DARWIN-32-PIC-LABEL: qux08:
@@ -2039,30 +2039,30 @@ define dso_local void @qux08() nounwind {
 ; DARWIN-32-PIC-NEXT:    calll L23$pb
 ; DARWIN-32-PIC-NEXT:  L23$pb:
 ; DARWIN-32-PIC-NEXT:    popl %eax
-; DARWIN-32-PIC-NEXT:    movl _lsrc-L23$pb+64(%eax), %ecx
-; DARWIN-32-PIC-NEXT:    movl _lptr-L23$pb(%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl %ecx, 64(%eax)
+; DARWIN-32-PIC-NEXT:    movl _lptr-L23$pb(%eax), %ecx
+; DARWIN-32-PIC-NEXT:    movl _lsrc-L23$pb+64(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl %eax, 64(%ecx)
 ; DARWIN-32-PIC-NEXT:    retl
 ;
 ; DARWIN-64-STATIC-LABEL: qux08:
 ; DARWIN-64-STATIC:       ## %bb.0: ## %entry
-; DARWIN-64-STATIC-NEXT:    movl _lsrc+64(%rip), %eax
-; DARWIN-64-STATIC-NEXT:    movq _lptr(%rip), %rcx
-; DARWIN-64-STATIC-NEXT:    movl %eax, 64(%rcx)
+; DARWIN-64-STATIC-NEXT:    movq _lptr(%rip), %rax
+; DARWIN-64-STATIC-NEXT:    movl _lsrc+64(%rip), %ecx
+; DARWIN-64-STATIC-NEXT:    movl %ecx, 64(%rax)
 ; DARWIN-64-STATIC-NEXT:    retq
 ;
 ; DARWIN-64-DYNAMIC-LABEL: qux08:
 ; DARWIN-64-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-64-DYNAMIC-NEXT:    movl _lsrc+64(%rip), %eax
-; DARWIN-64-DYNAMIC-NEXT:    movq _lptr(%rip), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movl %eax, 64(%rcx)
+; DARWIN-64-DYNAMIC-NEXT:    movq _lptr(%rip), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movl _lsrc+64(%rip), %ecx
+; DARWIN-64-DYNAMIC-NEXT:    movl %ecx, 64(%rax)
 ; DARWIN-64-DYNAMIC-NEXT:    retq
 ;
 ; DARWIN-64-PIC-LABEL: qux08:
 ; DARWIN-64-PIC:       ## %bb.0: ## %entry
-; DARWIN-64-PIC-NEXT:    movl _lsrc+64(%rip), %eax
-; DARWIN-64-PIC-NEXT:    movq _lptr(%rip), %rcx
-; DARWIN-64-PIC-NEXT:    movl %eax, 64(%rcx)
+; DARWIN-64-PIC-NEXT:    movq _lptr(%rip), %rax
+; DARWIN-64-PIC-NEXT:    movl _lsrc+64(%rip), %ecx
+; DARWIN-64-PIC-NEXT:    movl %ecx, 64(%rax)
 ; DARWIN-64-PIC-NEXT:    retq
 
 entry:
@@ -4564,18 +4564,18 @@ entry:
 define dso_local void @moo02(i64 %i) nounwind {
 ; LINUX-64-STATIC-LABEL: moo02:
 ; LINUX-64-STATIC:       # %bb.0: # %entry
-; LINUX-64-STATIC-NEXT:    movq src@GOTPCREL(%rip), %rax
-; LINUX-64-STATIC-NEXT:    movl 262144(%rax), %eax
-; LINUX-64-STATIC-NEXT:    movq ptr@GOTPCREL(%rip), %rcx
-; LINUX-64-STATIC-NEXT:    movq (%rcx), %rcx
-; LINUX-64-STATIC-NEXT:    movl %eax, 262144(%rcx)
+; LINUX-64-STATIC-NEXT:    movq ptr@GOTPCREL(%rip), %rax
+; LINUX-64-STATIC-NEXT:    movq (%rax), %rax
+; LINUX-64-STATIC-NEXT:    movq src@GOTPCREL(%rip), %rcx
+; LINUX-64-STATIC-NEXT:    movl 262144(%rcx), %ecx
+; LINUX-64-STATIC-NEXT:    movl %ecx, 262144(%rax)
 ; LINUX-64-STATIC-NEXT:    retq
 ;
 ; LINUX-32-STATIC-LABEL: moo02:
 ; LINUX-32-STATIC:       # %bb.0: # %entry
-; LINUX-32-STATIC-NEXT:    movl src+262144, %eax
-; LINUX-32-STATIC-NEXT:    movl ptr, %ecx
-; LINUX-32-STATIC-NEXT:    movl %eax, 262144(%ecx)
+; LINUX-32-STATIC-NEXT:    movl ptr, %eax
+; LINUX-32-STATIC-NEXT:    movl src+262144, %ecx
+; LINUX-32-STATIC-NEXT:    movl %ecx, 262144(%eax)
 ; LINUX-32-STATIC-NEXT:    retl
 ;
 ; LINUX-32-PIC-LABEL: moo02:
@@ -4585,36 +4585,36 @@ define dso_local void @moo02(i64 %i) nounwind {
 ; LINUX-32-PIC-NEXT:    popl %eax
 ; LINUX-32-PIC-NEXT:  .Ltmp50:
 ; LINUX-32-PIC-NEXT:    addl $_GLOBAL_OFFSET_TABLE_+(.Ltmp50-.L50$pb), %eax
-; LINUX-32-PIC-NEXT:    movl src@GOT(%eax), %ecx
-; LINUX-32-PIC-NEXT:    movl 262144(%ecx), %ecx
-; LINUX-32-PIC-NEXT:    movl ptr@GOT(%eax), %eax
-; LINUX-32-PIC-NEXT:    movl (%eax), %eax
-; LINUX-32-PIC-NEXT:    movl %ecx, 262144(%eax)
+; LINUX-32-PIC-NEXT:    movl ptr@GOT(%eax), %ecx
+; LINUX-32-PIC-NEXT:    movl (%ecx), %ecx
+; LINUX-32-PIC-NEXT:    movl src@GOT(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl 262144(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl %eax, 262144(%ecx)
 ; LINUX-32-PIC-NEXT:    retl
 ;
 ; LINUX-64-PIC-LABEL: moo02:
 ; LINUX-64-PIC:       # %bb.0: # %entry
-; LINUX-64-PIC-NEXT:    movq src@GOTPCREL(%rip), %rax
-; LINUX-64-PIC-NEXT:    movl 262144(%rax), %eax
-; LINUX-64-PIC-NEXT:    movq ptr@GOTPCREL(%rip), %rcx
-; LINUX-64-PIC-NEXT:    movq (%rcx), %rcx
-; LINUX-64-PIC-NEXT:    movl %eax, 262144(%rcx)
+; LINUX-64-PIC-NEXT:    movq ptr@GOTPCREL(%rip), %rax
+; LINUX-64-PIC-NEXT:    movq (%rax), %rax
+; LINUX-64-PIC-NEXT:    movq src@GOTPCREL(%rip), %rcx
+; LINUX-64-PIC-NEXT:    movl 262144(%rcx), %ecx
+; LINUX-64-PIC-NEXT:    movl %ecx, 262144(%rax)
 ; LINUX-64-PIC-NEXT:    retq
 ;
 ; DARWIN-32-STATIC-LABEL: moo02:
 ; DARWIN-32-STATIC:       ## %bb.0: ## %entry
-; DARWIN-32-STATIC-NEXT:    movl _src+262144, %eax
-; DARWIN-32-STATIC-NEXT:    movl _ptr, %ecx
-; DARWIN-32-STATIC-NEXT:    movl %eax, 262144(%ecx)
+; DARWIN-32-STATIC-NEXT:    movl _ptr, %eax
+; DARWIN-32-STATIC-NEXT:    movl _src+262144, %ecx
+; DARWIN-32-STATIC-NEXT:    movl %ecx, 262144(%eax)
 ; DARWIN-32-STATIC-NEXT:    retl
 ;
 ; DARWIN-32-DYNAMIC-LABEL: moo02:
 ; DARWIN-32-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-32-DYNAMIC-NEXT:    movl L_src$non_lazy_ptr, %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl 262144(%eax), %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl L_ptr$non_lazy_ptr, %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl (%ecx), %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl %eax, 262144(%ecx)
+; DARWIN-32-DYNAMIC-NEXT:    movl L_ptr$non_lazy_ptr, %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl (%eax), %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl L_src$non_lazy_ptr, %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl 262144(%ecx), %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl %ecx, 262144(%eax)
 ; DARWIN-32-DYNAMIC-NEXT:    retl
 ;
 ; DARWIN-32-PIC-LABEL: moo02:
@@ -4622,38 +4622,38 @@ define dso_local void @moo02(i64 %i) nounwind {
 ; DARWIN-32-PIC-NEXT:    calll L50$pb
 ; DARWIN-32-PIC-NEXT:  L50$pb:
 ; DARWIN-32-PIC-NEXT:    popl %eax
-; DARWIN-32-PIC-NEXT:    movl L_src$non_lazy_ptr-L50$pb(%eax), %ecx
-; DARWIN-32-PIC-NEXT:    movl 262144(%ecx), %ecx
-; DARWIN-32-PIC-NEXT:    movl L_ptr$non_lazy_ptr-L50$pb(%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl (%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl %ecx, 262144(%eax)
+; DARWIN-32-PIC-NEXT:    movl L_ptr$non_lazy_ptr-L50$pb(%eax), %ecx
+; DARWIN-32-PIC-NEXT:    movl (%ecx), %ecx
+; DARWIN-32-PIC-NEXT:    movl L_src$non_lazy_ptr-L50$pb(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl 262144(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl %eax, 262144(%ecx)
 ; DARWIN-32-PIC-NEXT:    retl
 ;
 ; DARWIN-64-STATIC-LABEL: moo02:
 ; DARWIN-64-STATIC:       ## %bb.0: ## %entry
-; DARWIN-64-STATIC-NEXT:    movq _src@GOTPCREL(%rip), %rax
-; DARWIN-64-STATIC-NEXT:    movl 262144(%rax), %eax
-; DARWIN-64-STATIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-STATIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-STATIC-NEXT:    movl %eax, 262144(%rcx)
+; DARWIN-64-STATIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-STATIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-STATIC-NEXT:    movq _src@GOTPCREL(%rip), %rcx
+; DARWIN-64-STATIC-NEXT:    movl 262144(%rcx), %ecx
+; DARWIN-64-STATIC-NEXT:    movl %ecx, 262144(%rax)
 ; DARWIN-64-STATIC-NEXT:    retq
 ;
 ; DARWIN-64-DYNAMIC-LABEL: moo02:
 ; DARWIN-64-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-64-DYNAMIC-NEXT:    movq _src@GOTPCREL(%rip), %rax
-; DARWIN-64-DYNAMIC-NEXT:    movl 262144(%rax), %eax
-; DARWIN-64-DYNAMIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movl %eax, 262144(%rcx)
+; DARWIN-64-DYNAMIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movq _src@GOTPCREL(%rip), %rcx
+; DARWIN-64-DYNAMIC-NEXT:    movl 262144(%rcx), %ecx
+; DARWIN-64-DYNAMIC-NEXT:    movl %ecx, 262144(%rax)
 ; DARWIN-64-DYNAMIC-NEXT:    retq
 ;
 ; DARWIN-64-PIC-LABEL: moo02:
 ; DARWIN-64-PIC:       ## %bb.0: ## %entry
-; DARWIN-64-PIC-NEXT:    movq _src@GOTPCREL(%rip), %rax
-; DARWIN-64-PIC-NEXT:    movl 262144(%rax), %eax
-; DARWIN-64-PIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rcx
-; DARWIN-64-PIC-NEXT:    movq (%rcx), %rcx
-; DARWIN-64-PIC-NEXT:    movl %eax, 262144(%rcx)
+; DARWIN-64-PIC-NEXT:    movq _ptr@GOTPCREL(%rip), %rax
+; DARWIN-64-PIC-NEXT:    movq (%rax), %rax
+; DARWIN-64-PIC-NEXT:    movq _src@GOTPCREL(%rip), %rcx
+; DARWIN-64-PIC-NEXT:    movl 262144(%rcx), %ecx
+; DARWIN-64-PIC-NEXT:    movl %ecx, 262144(%rax)
 ; DARWIN-64-PIC-NEXT:    retq
 
 entry:
@@ -4812,16 +4812,16 @@ entry:
 define dso_local void @moo05(i64 %i) nounwind {
 ; LINUX-64-STATIC-LABEL: moo05:
 ; LINUX-64-STATIC:       # %bb.0: # %entry
-; LINUX-64-STATIC-NEXT:    movl dsrc+262144(%rip), %eax
-; LINUX-64-STATIC-NEXT:    movq dptr(%rip), %rcx
-; LINUX-64-STATIC-NEXT:    movl %eax, 262144(%rcx)
+; LINUX-64-STATIC-NEXT:    movq dptr(%rip), %rax
+; LINUX-64-STATIC-NEXT:    movl dsrc+262144(%rip), %ecx
+; LINUX-64-STATIC-NEXT:    movl %ecx, 262144(%rax)
 ; LINUX-64-STATIC-NEXT:    retq
 ;
 ; LINUX-32-STATIC-LABEL: moo05:
 ; LINUX-32-STATIC:       # %bb.0: # %entry
-; LINUX-32-STATIC-NEXT:    movl dsrc+262144, %eax
-; LINUX-32-STATIC-NEXT:    movl dptr, %ecx
-; LINUX-32-STATIC-NEXT:    movl %eax, 262144(%ecx)
+; LINUX-32-STATIC-NEXT:    movl dptr, %eax
+; LINUX-32-STATIC-NEXT:    movl dsrc+262144, %ecx
+; LINUX-32-STATIC-NEXT:    movl %ecx, 262144(%eax)
 ; LINUX-32-STATIC-NEXT:    retl
 ;
 ; LINUX-32-PIC-LABEL: moo05:
@@ -4831,30 +4831,30 @@ define dso_local void @moo05(i64 %i) nounwind {
 ; LINUX-32-PIC-NEXT:    popl %eax
 ; LINUX-32-PIC-NEXT:  .Ltmp53:
 ; LINUX-32-PIC-NEXT:    addl $_GLOBAL_OFFSET_TABLE_+(.Ltmp53-.L53$pb), %eax
-; LINUX-32-PIC-NEXT:    movl .Ldsrc$local@GOTOFF+262144(%eax), %ecx
-; LINUX-32-PIC-NEXT:    movl .Ldptr$local@GOTOFF(%eax), %eax
-; LINUX-32-PIC-NEXT:    movl %ecx, 262144(%eax)
+; LINUX-32-PIC-NEXT:    movl .Ldptr$local@GOTOFF(%eax), %ecx
+; LINUX-32-PIC-NEXT:    movl .Ldsrc$local@GOTOFF+262144(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl %eax, 262144(%ecx)
 ; LINUX-32-PIC-NEXT:    retl
 ;
 ; LINUX-64-PIC-LABEL: moo05:
 ; LINUX-64-PIC:       # %bb.0: # %entry
-; LINUX-64-PIC-NEXT:    movl .Ldsrc$local+262144(%rip), %eax
-; LINUX-64-PIC-NEXT:    movq .Ldptr$local(%rip), %rcx
-; LINUX-64-PIC-NEXT:    movl %eax, 262144(%rcx)
+; LINUX-64-PIC-NEXT:    movq .Ldptr$local(%rip), %rax
+; LINUX-64-PIC-NEXT:    movl .Ldsrc$local+262144(%rip), %ecx
+; LINUX-64-PIC-NEXT:    movl %ecx, 262144(%rax)
 ; LINUX-64-PIC-NEXT:    retq
 ;
 ; DARWIN-32-STATIC-LABEL: moo05:
 ; DARWIN-32-STATIC:       ## %bb.0: ## %entry
-; DARWIN-32-STATIC-NEXT:    movl _dsrc+262144, %eax
-; DARWIN-32-STATIC-NEXT:    movl _dptr, %ecx
-; DARWIN-32-STATIC-NEXT:    movl %eax, 262144(%ecx)
+; DARWIN-32-STATIC-NEXT:    movl _dptr, %eax
+; DARWIN-32-STATIC-NEXT:    movl _dsrc+262144, %ecx
+; DARWIN-32-STATIC-NEXT:    movl %ecx, 262144(%eax)
 ; DARWIN-32-STATIC-NEXT:    retl
 ;
 ; DARWIN-32-DYNAMIC-LABEL: moo05:
 ; DARWIN-32-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-32-DYNAMIC-NEXT:    movl _dsrc+262144, %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl _dptr, %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl %eax, 262144(%ecx)
+; DARWIN-32-DYNAMIC-NEXT:    movl _dptr, %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl _dsrc+262144, %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl %ecx, 262144(%eax)
 ; DARWIN-32-DYNAMIC-NEXT:    retl
 ;
 ; DARWIN-32-PIC-LABEL: moo05:
@@ -4862,30 +4862,30 @@ define dso_local void @moo05(i64 %i) nounwind {
 ; DARWIN-32-PIC-NEXT:    calll L53$pb
 ; DARWIN-32-PIC-NEXT:  L53$pb:
 ; DARWIN-32-PIC-NEXT:    popl %eax
-; DARWIN-32-PIC-NEXT:    movl _dsrc-L53$pb+262144(%eax), %ecx
-; DARWIN-32-PIC-NEXT:    movl _dptr-L53$pb(%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl %ecx, 262144(%eax)
+; DARWIN-32-PIC-NEXT:    movl _dptr-L53$pb(%eax), %ecx
+; DARWIN-32-PIC-NEXT:    movl _dsrc-L53$pb+262144(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl %eax, 262144(%ecx)
 ; DARWIN-32-PIC-NEXT:    retl
 ;
 ; DARWIN-64-STATIC-LABEL: moo05:
 ; DARWIN-64-STATIC:       ## %bb.0: ## %entry
-; DARWIN-64-STATIC-NEXT:    movl _dsrc+262144(%rip), %eax
-; DARWIN-64-STATIC-NEXT:    movq _dptr(%rip), %rcx
-; DARWIN-64-STATIC-NEXT:    movl %eax, 262144(%rcx)
+; DARWIN-64-STATIC-NEXT:    movq _dptr(%rip), %rax
+; DARWIN-64-STATIC-NEXT:    movl _dsrc+262144(%rip), %ecx
+; DARWIN-64-STATIC-NEXT:    movl %ecx, 262144(%rax)
 ; DARWIN-64-STATIC-NEXT:    retq
 ;
 ; DARWIN-64-DYNAMIC-LABEL: moo05:
 ; DARWIN-64-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-64-DYNAMIC-NEXT:    movl _dsrc+262144(%rip), %eax
-; DARWIN-64-DYNAMIC-NEXT:    movq _dptr(%rip), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movl %eax, 262144(%rcx)
+; DARWIN-64-DYNAMIC-NEXT:    movq _dptr(%rip), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movl _dsrc+262144(%rip), %ecx
+; DARWIN-64-DYNAMIC-NEXT:    movl %ecx, 262144(%rax)
 ; DARWIN-64-DYNAMIC-NEXT:    retq
 ;
 ; DARWIN-64-PIC-LABEL: moo05:
 ; DARWIN-64-PIC:       ## %bb.0: ## %entry
-; DARWIN-64-PIC-NEXT:    movl _dsrc+262144(%rip), %eax
-; DARWIN-64-PIC-NEXT:    movq _dptr(%rip), %rcx
-; DARWIN-64-PIC-NEXT:    movl %eax, 262144(%rcx)
+; DARWIN-64-PIC-NEXT:    movq _dptr(%rip), %rax
+; DARWIN-64-PIC-NEXT:    movl _dsrc+262144(%rip), %ecx
+; DARWIN-64-PIC-NEXT:    movl %ecx, 262144(%rax)
 ; DARWIN-64-PIC-NEXT:    retq
 
 entry:
@@ -5044,16 +5044,16 @@ entry:
 define dso_local void @moo08(i64 %i) nounwind {
 ; LINUX-64-STATIC-LABEL: moo08:
 ; LINUX-64-STATIC:       # %bb.0: # %entry
-; LINUX-64-STATIC-NEXT:    movl lsrc+262144(%rip), %eax
-; LINUX-64-STATIC-NEXT:    movq lptr(%rip), %rcx
-; LINUX-64-STATIC-NEXT:    movl %eax, 262144(%rcx)
+; LINUX-64-STATIC-NEXT:    movq lptr(%rip), %rax
+; LINUX-64-STATIC-NEXT:    movl lsrc+262144(%rip), %ecx
+; LINUX-64-STATIC-NEXT:    movl %ecx, 262144(%rax)
 ; LINUX-64-STATIC-NEXT:    retq
 ;
 ; LINUX-32-STATIC-LABEL: moo08:
 ; LINUX-32-STATIC:       # %bb.0: # %entry
-; LINUX-32-STATIC-NEXT:    movl lsrc+262144, %eax
-; LINUX-32-STATIC-NEXT:    movl lptr, %ecx
-; LINUX-32-STATIC-NEXT:    movl %eax, 262144(%ecx)
+; LINUX-32-STATIC-NEXT:    movl lptr, %eax
+; LINUX-32-STATIC-NEXT:    movl lsrc+262144, %ecx
+; LINUX-32-STATIC-NEXT:    movl %ecx, 262144(%eax)
 ; LINUX-32-STATIC-NEXT:    retl
 ;
 ; LINUX-32-PIC-LABEL: moo08:
@@ -5063,30 +5063,30 @@ define dso_local void @moo08(i64 %i) nounwind {
 ; LINUX-32-PIC-NEXT:    popl %eax
 ; LINUX-32-PIC-NEXT:  .Ltmp56:
 ; LINUX-32-PIC-NEXT:    addl $_GLOBAL_OFFSET_TABLE_+(.Ltmp56-.L56$pb), %eax
-; LINUX-32-PIC-NEXT:    movl lsrc@GOTOFF+262144(%eax), %ecx
-; LINUX-32-PIC-NEXT:    movl lptr@GOTOFF(%eax), %eax
-; LINUX-32-PIC-NEXT:    movl %ecx, 262144(%eax)
+; LINUX-32-PIC-NEXT:    movl lptr@GOTOFF(%eax), %ecx
+; LINUX-32-PIC-NEXT:    movl lsrc@GOTOFF+262144(%eax), %eax
+; LINUX-32-PIC-NEXT:    movl %eax, 262144(%ecx)
 ; LINUX-32-PIC-NEXT:    retl
 ;
 ; LINUX-64-PIC-LABEL: moo08:
 ; LINUX-64-PIC:       # %bb.0: # %entry
-; LINUX-64-PIC-NEXT:    movl lsrc+262144(%rip), %eax
-; LINUX-64-PIC-NEXT:    movq lptr(%rip), %rcx
-; LINUX-64-PIC-NEXT:    movl %eax, 262144(%rcx)
+; LINUX-64-PIC-NEXT:    movq lptr(%rip), %rax
+; LINUX-64-PIC-NEXT:    movl lsrc+262144(%rip), %ecx
+; LINUX-64-PIC-NEXT:    movl %ecx, 262144(%rax)
 ; LINUX-64-PIC-NEXT:    retq
 ;
 ; DARWIN-32-STATIC-LABEL: moo08:
 ; DARWIN-32-STATIC:       ## %bb.0: ## %entry
-; DARWIN-32-STATIC-NEXT:    movl _lsrc+262144, %eax
-; DARWIN-32-STATIC-NEXT:    movl _lptr, %ecx
-; DARWIN-32-STATIC-NEXT:    movl %eax, 262144(%ecx)
+; DARWIN-32-STATIC-NEXT:    movl _lptr, %eax
+; DARWIN-32-STATIC-NEXT:    movl _lsrc+262144, %ecx
+; DARWIN-32-STATIC-NEXT:    movl %ecx, 262144(%eax)
 ; DARWIN-32-STATIC-NEXT:    retl
 ;
 ; DARWIN-32-DYNAMIC-LABEL: moo08:
 ; DARWIN-32-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-32-DYNAMIC-NEXT:    movl _lsrc+262144, %eax
-; DARWIN-32-DYNAMIC-NEXT:    movl _lptr, %ecx
-; DARWIN-32-DYNAMIC-NEXT:    movl %eax, 262144(%ecx)
+; DARWIN-32-DYNAMIC-NEXT:    movl _lptr, %eax
+; DARWIN-32-DYNAMIC-NEXT:    movl _lsrc+262144, %ecx
+; DARWIN-32-DYNAMIC-NEXT:    movl %ecx, 262144(%eax)
 ; DARWIN-32-DYNAMIC-NEXT:    retl
 ;
 ; DARWIN-32-PIC-LABEL: moo08:
@@ -5094,30 +5094,30 @@ define dso_local void @moo08(i64 %i) nounwind {
 ; DARWIN-32-PIC-NEXT:    calll L56$pb
 ; DARWIN-32-PIC-NEXT:  L56$pb:
 ; DARWIN-32-PIC-NEXT:    popl %eax
-; DARWIN-32-PIC-NEXT:    movl _lsrc-L56$pb+262144(%eax), %ecx
-; DARWIN-32-PIC-NEXT:    movl _lptr-L56$pb(%eax), %eax
-; DARWIN-32-PIC-NEXT:    movl %ecx, 262144(%eax)
+; DARWIN-32-PIC-NEXT:    movl _lptr-L56$pb(%eax), %ecx
+; DARWIN-32-PIC-NEXT:    movl _lsrc-L56$pb+262144(%eax), %eax
+; DARWIN-32-PIC-NEXT:    movl %eax, 262144(%ecx)
 ; DARWIN-32-PIC-NEXT:    retl
 ;
 ; DARWIN-64-STATIC-LABEL: moo08:
 ; DARWIN-64-STATIC:       ## %bb.0: ## %entry
-; DARWIN-64-STATIC-NEXT:    movl _lsrc+262144(%rip), %eax
-; DARWIN-64-STATIC-NEXT:    movq _lptr(%rip), %rcx
-; DARWIN-64-STATIC-NEXT:    movl %eax, 262144(%rcx)
+; DARWIN-64-STATIC-NEXT:    movq _lptr(%rip), %rax
+; DARWIN-64-STATIC-NEXT:    movl _lsrc+262144(%rip), %ecx
+; DARWIN-64-STATIC-NEXT:    movl %ecx, 262144(%rax)
 ; DARWIN-64-STATIC-NEXT:    retq
 ;
 ; DARWIN-64-DYNAMIC-LABEL: moo08:
 ; DARWIN-64-DYNAMIC:       ## %bb.0: ## %entry
-; DARWIN-64-DYNAMIC-NEXT:    movl _lsrc+262144(%rip), %eax
-; DARWIN-64-DYNAMIC-NEXT:    movq _lptr(%rip), %rcx
-; DARWIN-64-DYNAMIC-NEXT:    movl %eax, 262144(%rcx)
+; DARWIN-64-DYNAMIC-NEXT:    movq _lptr(%rip), %rax
+; DARWIN-64-DYNAMIC-NEXT:    movl _lsrc+262144(%rip), %ecx
+; DARWIN-64-DYNAMIC-NEXT:    movl %ecx, 262144(%rax)
 ; DARWIN-64-DYNAMIC-NEXT:    retq
 ;
 ; DARWIN-64-PIC-LABEL: moo08:
 ; DARWIN-64-PIC:       ## %bb.0: ## %entry
-; DARWIN-64-PIC-NEXT:    movl _lsrc+262144(%rip), %eax
-; DARWIN-64-PIC-NEXT:    movq _lptr(%rip), %rcx
-; DARWIN-64-PIC-NEXT:    movl %eax, 262144(%rcx)
+; DARWIN-64-PIC-NEXT:    movq _lptr(%rip), %rax
+; DARWIN-64-PIC-NEXT:    movl _lsrc+262144(%rip), %ecx
+; DARWIN-64-PIC-NEXT:    movl %ecx, 262144(%rax)
 ; DARWIN-64-PIC-NEXT:    retq
 
 entry:

--- a/llvm/test/CodeGen/X86/break-anti-dependencies.ll
+++ b/llvm/test/CodeGen/X86/break-anti-dependencies.ll
@@ -22,7 +22,7 @@ define void @goo(ptr %r, ptr %p, ptr %q) nounwind {
 ; none-NEXT:    mulsd {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
 ; none-NEXT:    addsd {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
 ; none-NEXT:    cvttsd2si %xmm0, %ecx
-; none-NEXT:    cmpl %eax, %ecx
+; none-NEXT:    cmpl %ecx, %eax
 ; none-NEXT:    jge .LBB0_2
 ; none-NEXT:  # %bb.1: # %bb
 ; none-NEXT:    movabsq $4621425052621576602, %rax # imm = 0x402299999999999A

--- a/llvm/test/DebugInfo/WebAssembly/dbg-value-move-2.ll
+++ b/llvm/test/DebugInfo/WebAssembly/dbg-value-move-2.ll
@@ -4,7 +4,8 @@
 ; CHECK: {{.*}}After WebAssembly Register Stackify
 ; CHECK: bb.2.for.body:
 ; CHECK: [[TEEREG:%[0-9]+]]:i32, %{{[0-9]+}}:i32 = TEE_I32 {{.*}} fib2.c:6:7
-; CHECK-NEXT: DBG_VALUE [[TEEREG]]:i32, $noreg, !"a", {{.*}} fib2.c:2:13
+; CHECK-NEXT: %{{[0-9]+}}:i32 = nsw ADD_I32 %{{[0-9]+}}:i32, [[TEEREG]]:i32{{.*}} fib2.c:6:7
+; CHECK-NEXT: DBG_VALUE $noreg, $noreg, !"a", {{.*}} fib2.c:2:13
 
 ; ModuleID = 'fib2.bc'
 ; The test generated via: clang --target=wasm32-unknown-unknown-wasm fib2.c -g -O2

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/wasm_generated_funcs.ll.generated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/wasm_generated_funcs.ll.generated.expected
@@ -75,21 +75,21 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    global.set __stack_pointer
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 0
-; CHECK-NEXT:    i32.store 24
+; CHECK-NEXT:    i32.store 28
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 0
-; CHECK-NEXT:    i32.store 28
+; CHECK-NEXT:    i32.store 24
 ; CHECK-NEXT:    block
 ; CHECK-NEXT:    block
 ; CHECK-NEXT:    i32.const 0
 ; CHECK-NEXT:    br_if 0 # 0: down to label1
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i32.const 2
-; CHECK-NEXT:    i32.store 20
-; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 1
 ; CHECK-NEXT:    i32.store 24
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    i32.const 2
+; CHECK-NEXT:    i32.store 20
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 3
 ; CHECK-NEXT:    i32.store 16
@@ -111,11 +111,11 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    br_if 0 # 0: down to label3
 ; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i32.const 2
-; CHECK-NEXT:    i32.store 20
-; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 1
 ; CHECK-NEXT:    i32.store 24
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    i32.const 2
+; CHECK-NEXT:    i32.store 20
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 3
 ; CHECK-NEXT:    i32.store 16
@@ -167,11 +167,11 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    #APP
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i32.const 2
-; CHECK-NEXT:    i32.store 20
-; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 1
 ; CHECK-NEXT:    i32.store 24
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    i32.const 2
+; CHECK-NEXT:    i32.store 20
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 3
 ; CHECK-NEXT:    i32.store 16

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/wasm_generated_funcs.ll.nogenerated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/wasm_generated_funcs.ll.nogenerated.expected
@@ -16,21 +16,21 @@ define dso_local i32 @check_boundaries() #0 {
 ; CHECK-NEXT:    global.set __stack_pointer
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 0
-; CHECK-NEXT:    i32.store 24
+; CHECK-NEXT:    i32.store 28
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 0
-; CHECK-NEXT:    i32.store 28
+; CHECK-NEXT:    i32.store 24
 ; CHECK-NEXT:    block
 ; CHECK-NEXT:    block
 ; CHECK-NEXT:    i32.const 0
 ; CHECK-NEXT:    br_if 0 # 0: down to label1
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i32.const 2
-; CHECK-NEXT:    i32.store 20
-; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 1
 ; CHECK-NEXT:    i32.store 24
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    i32.const 2
+; CHECK-NEXT:    i32.store 20
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 3
 ; CHECK-NEXT:    i32.store 16
@@ -52,11 +52,11 @@ define dso_local i32 @check_boundaries() #0 {
 ; CHECK-NEXT:    br_if 0 # 0: down to label3
 ; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i32.const 2
-; CHECK-NEXT:    i32.store 20
-; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 1
 ; CHECK-NEXT:    i32.store 24
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    i32.const 2
+; CHECK-NEXT:    i32.store 20
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32.const 3
 ; CHECK-NEXT:    i32.store 16


### PR DESCRIPTION
Changes are specific to https://github.com/llvm/llvm-project/issues/55248 but since this change is in `llvm/lib/CodeGen/SelectionDAG/ScheduleDAGRRList.cpp`, its breaking a lot of test cases


Benchmarking on [wasm-perf](https://gitlab.arm.com/runtimes/wasm-perf) on O0 (wasmtime) shows 0.3 mean improvement and 0.19 geomean improvement.
```
Results for:  jjasmine
threshold filtered results: 0
outlying filtered results: 0
stat test mismatch filtered benchmarks: 0
statistically filtered benchmarks: 35
faster benchmarks: 21
slower benchmarks: 5
benchmarks affected (%): 42.62
Execution time change: positive is faster, negative is slower.

-- Using stat: min
Metric                    Execution Time Change(%)
----------------------  --------------------------
Mean (filtered)                              0.366
Median (filtered)                            0.248
Max (filtered)                               3.234
Min (filtered)                              -0.987
Geomean (non-filtered)                       0.188

Execution Time Changes (ETC)

Benchmark                                              ETC %
-------------------------------------------  ------  -------  --------------------
llama2c-stories15M-run_times                 ******   -0.987
libyuv-UVScaleDownBy4_Linear-run_times            *   -0.182
ggml-quantize_row_q-run_times                         -0.098
xnnpack-shufflenet_v1_g2-run_times                    -0.045
xnnpack-mobilenet_v3_small-run_times                  -0.03
xnnpack-shufflenet_v1_g8-run_times                     0.026
xnnpack-mobilenet_v2-run_times                         0.063
xnnpack-shufflenet_v1_g4-run_times                     0.097
ggml-quantize_row_q_dot-run_times                      0.127
libyuv-ARGBScaleDownBy3by4_Linear-run_times            0.154
ggml-vec_dot_q-run_times                               0.158
libyuv-UVScaleDownBy4_None-run_times                   0.196  *
xxhash-marty_bench_64-run_times                        0.215  *
meshoptimizer-codecbench-run_times                     0.282  *
xnnpack-shufflenet_v2_x10-run_times                    0.304  *
xnnpack-shufflenet_v2_x05-run_times                    0.315  *
libyuv-MM21ToI420-run_times                            0.333  **
entt-benchmark-run_times                               0.449  **
libyuv-ARGBScaleDownBy4_None-run_times                 0.505  ***
libyuv-P012ToI012-run_times                            0.62   ***
microkernels-3d-run_times                              0.645  ***
libyuv-ARGBScaleDownBy2_None-run_times                 0.649  ****
microkernels-1d-run_times                              0.751  ****
xxhash-marty_bench_128-run_times                       0.779  ****
libyuv-ARGBScaleDownBy3by4_None-run_times              0.949  *****
xxhash-secret_and_seed_128-run_times                   3.234  ********************
```

Benchmarking on wasm-perf on O2 (wasmtime) shows -0.4 mean improvement and -0.14 geomean improvement
```
Results for:  jjasmine
threshold filtered results: 0
outlying filtered results: 0
stat test mismatch filtered benchmarks: 0
statistically filtered benchmarks: 37
faster benchmarks: 5
slower benchmarks: 19
benchmarks affected (%): 39.34
Execution time change: positive is faster, negative is slower.

-- Using stat: min
Metric                    Execution Time Change(%)
----------------------  --------------------------
Mean (filtered)                             -0.399
Median (filtered)                           -0.182
Max (filtered)                               2.977
Min (filtered)                              -8.07
Geomean (non-filtered)                      -0.139

Execution Time Changes (ETC)

Benchmark                                                              ETC %
---------------------------------------------  --------------------  -------  -------
microkernels-2d-run_times                      ********************   -8.07
libyuv-UVScaleDownBy2_None-run_times                             **   -1.193
xxhash-marty_bench_64-run_times                                   *   -0.534
xnnpack-shufflenet_v1_g8-run_times                                *   -0.523
xnnpack-shufflenet_v2_x15-run_times                                   -0.38
libyuv-ARGBScaleDownBy4_Box-run_times                                 -0.373
xnnpack-shufflenet_v2_x05-run_times                                   -0.347
libyuv-UVScaleDownBy2_Box-run_times                                   -0.34
libyuv-UVScaleDownBy2_Bilinear-run_times                              -0.33
xxhash-marty_bench_128-run_times                                      -0.303
libyuv-ColourI420-run_times                                           -0.278
libyuv-ARGBScaleDownBy2_Linear-run_times                              -0.211
meshoptimizer-codecbench-run_times                                    -0.152
xnnpack-shufflenet_v2_x10-run_times                                   -0.142
xnnpack-shufflenet_v1_g4-run_times                                    -0.129
xnnpack-mobilenet_v3_small-run_times                                  -0.116
libyuv-ARGBScaleDownBy3by4_Bilinear-run_times                         -0.104
libyuv-ARGBScaleDownBy2_Box-run_times                                 -0.099
libyuv-P012ToI012-run_times                                           -0.049
libyuv-UVScaleDownBy3by4_Box-run_times                                 0.059
libyuv-UVScaleDownBy3by4_Bilinear-run_times                            0.178
llama2c-stories15M-run_times                                           0.398
ggml-quantize_row_q_dot-run_times                                      0.495  *
libyuv-ARGBScaleDownBy4_Bilinear-run_times                             2.977  *******
```

I'm not sure how reliable these benchmarks are given that `llama2c-stories15M-run_times` degraded on O0 but is an improvement on O2, and microkernels 2d shows no improvement but then is degraded on O2