### PR TITLE
[IR] Remove HasMetadata bit from instructions

### DIFF
--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -168,9 +168,9 @@ public:
   LLVM_ABI void handleMarkerRemoval();
 
 protected:
-  // The 15 first bits of `Value::SubclassData` are available for subclasses of
+  // All 16 bits of `Value::SubclassData` are available for subclasses of
   // `Instruction` to use.
-  using OpaqueField = Bitfield::Element<uint16_t, 0, 15>;
+  using OpaqueField = Bitfield::Element<uint16_t, 0, 16>;
 
   // Template alias so that all Instruction storing alignment use the same
   // definiton.
@@ -189,11 +189,6 @@ protected:
   using AtomicOrderingBitfieldElementT =
       typename Bitfield::Element<AtomicOrdering, Offset, 3,
                                  AtomicOrdering::LAST>;
-
-private:
-  // The last bit is used to store whether the instruction has metadata attached
-  // or not.
-  using HasMetadataField = Bitfield::Element<bool, 15, 1>;
 
 protected:
   LLVM_ABI ~Instruction(); // Use deleteValue() to delete a generic Instruction.
@@ -1097,24 +1092,16 @@ private:
   }
 
 protected:
-  // Instruction subclasses can stick up to 15 bits of stuff into the
+  // Instruction subclasses can stick up to 16 bits of stuff into the
   // SubclassData field of instruction with these members.
 
   template <typename BitfieldElement>
   typename BitfieldElement::Type getSubclassData() const {
-    static_assert(
-        std::is_same<BitfieldElement, HasMetadataField>::value ||
-            !Bitfield::isOverlapping<BitfieldElement, HasMetadataField>(),
-        "Must not overlap with the metadata bit");
     return Bitfield::get<BitfieldElement>(getSubclassDataFromValue());
   }
 
   template <typename BitfieldElement>
   void setSubclassData(typename BitfieldElement::Type Value) {
-    static_assert(
-        std::is_same<BitfieldElement, HasMetadataField>::value ||
-            !Bitfield::isOverlapping<BitfieldElement, HasMetadataField>(),
-        "Must not overlap with the metadata bit");
     auto Storage = getSubclassDataFromValue();
     Bitfield::set<BitfieldElement>(Storage, Value);
     setValueSubclassData(Storage);


### PR DESCRIPTION
We were reserving one bit for a HasMetadata flag. However, this flag has long since been moved into Value itself, prior to being removed from there as well recently.