### PR TITLE
[lldb][NFC] Stop using ConstStrings with BroadcastEventSpec

### DIFF
--- a/lldb/source/API/SBListener.cpp
+++ b/lldb/source/API/SBListener.cpp
@@ -80,7 +80,7 @@ uint32_t SBListener::StartListeningForEventClass(SBDebugger &debugger,
     Debugger *lldb_debugger = debugger.get();
     if (!lldb_debugger)
       return 0;
-    BroadcastEventSpec event_spec(ConstString(broadcaster_class), event_mask);
+    BroadcastEventSpec event_spec(broadcaster_class, event_mask);
     return m_opaque_sp->StartListeningForEventSpec(
         lldb_debugger->GetBroadcasterManager(), event_spec);
   } else
@@ -96,7 +96,7 @@ bool SBListener::StopListeningForEventClass(SBDebugger &debugger,
     Debugger *lldb_debugger = debugger.get();
     if (!lldb_debugger)
       return false;
-    BroadcastEventSpec event_spec(ConstString(broadcaster_class), event_mask);
+    BroadcastEventSpec event_spec(broadcaster_class, event_mask);
     return m_opaque_sp->StopListeningForEventSpec(
         lldb_debugger->GetBroadcasterManager(), event_spec);
   } else

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -2190,7 +2190,8 @@ static bool RequiresFollowChildWorkaround(const Process &process) {
 lldb::thread_result_t Debugger::DefaultEventHandler() {
   ListenerSP listener_sp(GetListener());
   llvm::StringRef broadcaster_class_target(Target::GetStaticBroadcasterClass());
-  llvm::StringRef broadcaster_class_process(Process::GetStaticBroadcasterClass());
+  llvm::StringRef broadcaster_class_process(
+      Process::GetStaticBroadcasterClass());
   llvm::StringRef broadcaster_class_thread(Thread::GetStaticBroadcasterClass());
   BroadcastEventSpec target_event_spec(broadcaster_class_target,
                                        Target::eBroadcastBitBreakpointChanged);

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -2189,9 +2189,9 @@ static bool RequiresFollowChildWorkaround(const Process &process) {
 
 lldb::thread_result_t Debugger::DefaultEventHandler() {
   ListenerSP listener_sp(GetListener());
-  ConstString broadcaster_class_target(Target::GetStaticBroadcasterClass());
-  ConstString broadcaster_class_process(Process::GetStaticBroadcasterClass());
-  ConstString broadcaster_class_thread(Thread::GetStaticBroadcasterClass());
+  llvm::StringRef broadcaster_class_target(Target::GetStaticBroadcasterClass());
+  llvm::StringRef broadcaster_class_process(Process::GetStaticBroadcasterClass());
+  llvm::StringRef broadcaster_class_thread(Thread::GetStaticBroadcasterClass());
   BroadcastEventSpec target_event_spec(broadcaster_class_target,
                                        Target::eBroadcastBitBreakpointChanged);
 
@@ -2243,7 +2243,7 @@ lldb::thread_result_t Debugger::DefaultEventHandler() {
         Broadcaster *broadcaster = event_sp->GetBroadcaster();
         if (broadcaster) {
           uint32_t event_type = event_sp->GetType();
-          ConstString broadcaster_class(broadcaster->GetBroadcasterClass());
+          llvm::StringRef broadcaster_class(broadcaster->GetBroadcasterClass());
           if (broadcaster_class == broadcaster_class_process) {
             if (ProcessSP process_sp = HandleProcessEvent(event_sp))
               if (!RequiresFollowChildWorkaround(*process_sp))


### PR DESCRIPTION
BroadcastEventSpec owns the broadcaster class its configured to listen for. Broadcasters usually advertise their broadcast class name with StringRefs so there's no need to put them in the string pool.

The only exception here is SBListener. There are 2 methods that take `const char *` values. However, that's handled when converting them to StringRefs.