### PR TITLE
[lld] Add missing include in AArch64ErrataFix (NFC)

### DIFF
--- a/lld/ELF/AArch64ErrataFix.h
+++ b/lld/ELF/AArch64ErrataFix.h
@@ -11,6 +11,7 @@
 
 #include "lld/Common/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
 #include <vector>
 
 namespace lld::elf {


### PR DESCRIPTION
This header assumed SmallVector would be included before it
