### PR TITLE
[bazel] Make nanobind link on macOS

### DIFF
--- a/utils/bazel/third_party_build/nanobind.BUILD
+++ b/utils/bazel/third_party_build/nanobind.BUILD
@@ -8,11 +8,21 @@ cc_library(
         ],
         exclude = ["src/nb_combined.cpp"],
     ),
+    additional_linker_inputs = select({
+        "@platforms//os:macos": [":cmake/darwin-ld-cpython.sym"],
+        "//conditions:default": [],
+    }),
     defines = [
         "NB_BUILD=1",
         "NB_SHARED=1",
     ],
     includes = ["include"],
+    linkopts = select({
+        "@platforms//os:macos": [
+            "-Wl,@$(location :cmake/darwin-ld-cpython.sym)",
+        ],
+        "//conditions:default": [],
+    }),
     textual_hdrs = glob(
         [
             "include/**/*.h",


### PR DESCRIPTION
Previously the mlir libraries that are marked as shared didn't link on
macOS since undefined symbols error by default. This uses nanobind's
list of acceptable undefined python symbols to make these link.
