### PR TITLE
[Hexagon] Correctly split masked loads/stores after widening

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
@@ -3443,41 +3443,63 @@ HexagonTargetLowering::SplitVectorOp(SDValue Op, SelectionDAG &DAG) const {
 SDValue
 HexagonTargetLowering::SplitHvxMemOp(SDValue Op, SelectionDAG &DAG) const {
   auto *MemN = cast<MemSDNode>(Op.getNode());
+  unsigned MemOpc = MemN->getOpcode();
+  EVT MemTy = MemN->getMemoryVT();
 
-  if (!MemN->getMemoryVT().isSimple())
+  if ((MemOpc == ISD::STORE || MemOpc == ISD::LOAD) &&
+      (!MemTy.isSimple() || !isHvxPairTy(MemTy.getSimpleVT())))
     return Op;
 
-  MVT MemTy = MemN->getMemoryVT().getSimpleVT();
-  if (!isHvxPairTy(MemTy))
-    return Op;
+  EVT ValueType;
+  if (MemOpc == ISD::STORE)
+    ValueType = ty(cast<StoreSDNode>(Op)->getValue());
+  else if (MemOpc == ISD::MSTORE)
+    ValueType = ty(cast<MaskedStoreSDNode>(Op)->getValue());
+  else // ISD::LOAD, ISD::MLOAD.
+    ValueType = MemN->getValueType(0);
+
+  EVT LoVT, HiVT;
+  std::tie(LoVT, HiVT) = DAG.GetSplitDestVTs(ValueType);
+
+  EVT LoMemVT, HiMemVT;
+  bool HiIsEmpty = false;
+  std::tie(LoMemVT, HiMemVT) =
+      DAG.GetDependentSplitDestVTs(MemTy, LoVT, &HiIsEmpty);
+
+  uint64_t LoSize = LoMemVT.getSizeInBits().getFixedValue() / 8;
+  uint64_t HiSize = HiMemVT.getSizeInBits().getFixedValue() / 8;
 
   const SDLoc &dl(Op);
-  unsigned HwLen = Subtarget.getVectorLength();
-  MVT SingleTy = typeSplit(MemTy).first;
   SDValue Chain = MemN->getChain();
   SDValue Base0 = MemN->getBasePtr();
   SDValue Base1 =
-      DAG.getMemBasePlusOffset(Base0, TypeSize::getFixed(HwLen), dl);
-  unsigned MemOpc = MemN->getOpcode();
+      DAG.getMemBasePlusOffset(Base0, TypeSize::getFixed(LoSize), dl);
 
   MachineMemOperand *MOp0 = nullptr, *MOp1 = nullptr;
   if (MachineMemOperand *MMO = MemN->getMemOperand()) {
     MachineFunction &MF = DAG.getMachineFunction();
-    uint64_t MemSize = (MemOpc == ISD::MLOAD || MemOpc == ISD::MSTORE)
-                           ? (uint64_t)MemoryLocation::UnknownSize
-                           : HwLen;
-    MOp0 = MF.getMachineMemOperand(MMO, 0, MemSize);
-    MOp1 = MF.getMachineMemOperand(MMO, HwLen, MemSize);
+    auto MemSize = [=](uint64_t Size) {
+      return (MemOpc == ISD::MLOAD || MemOpc == ISD::MSTORE)
+                 ? (uint64_t)MemoryLocation::UnknownSize
+                 : Size;
+    };
+    // MOp1 will not be used if HiIsEmpty for masked loads and stores (MLOAD and
+    // MSTORE). Non-masked loads and store are always of double-vector size (see
+    // isHvxPairTy() check above).
+    MOp0 = MF.getMachineMemOperand(MMO, 0, MemSize(LoSize));
+    MOp1 = MF.getMachineMemOperand(MMO, LoSize, MemSize(HiSize));
   }
 
   if (MemOpc == ISD::LOAD) {
     assert(cast<LoadSDNode>(Op)->isUnindexed());
-    SDValue Load0 = DAG.getLoad(SingleTy, dl, Chain, Base0, MOp0);
-    SDValue Load1 = DAG.getLoad(SingleTy, dl, Chain, Base1, MOp1);
+    SDValue Load0 = DAG.getLoad(LoVT, dl, Chain, Base0, MOp0);
+    SDValue Load1 = DAG.getLoad(HiVT, dl, Chain, Base1, MOp1);
     return DAG.getMergeValues(
-        { DAG.getNode(ISD::CONCAT_VECTORS, dl, MemTy, Load0, Load1),
-          DAG.getNode(ISD::TokenFactor, dl, MVT::Other,
-                      Load0.getValue(1), Load1.getValue(1)) }, dl);
+        {DAG.getNode(ISD::CONCAT_VECTORS, dl, MemN->getValueType(0), Load0,
+                     Load1),
+         DAG.getNode(ISD::TokenFactor, dl, MVT::Other, Load0.getValue(1),
+                     Load1.getValue(1))},
+        dl);
   }
   if (MemOpc == ISD::STORE) {
     assert(cast<StoreSDNode>(Op)->isUnindexed());
@@ -3497,27 +3519,35 @@ HexagonTargetLowering::SplitHvxMemOp(SDValue Op, SelectionDAG &DAG) const {
   if (MemOpc == ISD::MLOAD) {
     VectorPair Thru =
         opSplit(cast<MaskedLoadSDNode>(Op)->getPassThru(), dl, DAG);
-    SDValue MLoad0 =
-        DAG.getMaskedLoad(SingleTy, dl, Chain, Base0, Offset, Masks.first,
-                          Thru.first, SingleTy, MOp0, ISD::UNINDEXED,
-                          ISD::NON_EXTLOAD, false);
+    SDValue MLoad0 = DAG.getMaskedLoad(LoVT, dl, Chain, Base0, Offset,
+                                       Masks.first, Thru.first, LoMemVT, MOp0,
+                                       ISD::UNINDEXED, ISD::NON_EXTLOAD, false);
+
+    // The hi masked load has zero storage size. We therefore simply set it to
+    // the low masked load and rely on subsequent removal from the chain as it
+    // is unused. See DAGTypeLegalizer::SplitVecRes_MLOAD() for the same logic.
     SDValue MLoad1 =
-        DAG.getMaskedLoad(SingleTy, dl, Chain, Base1, Offset, Masks.second,
-                          Thru.second, SingleTy, MOp1, ISD::UNINDEXED,
-                          ISD::NON_EXTLOAD, false);
+        HiIsEmpty ? MLoad0
+                  : DAG.getMaskedLoad(HiVT, dl, Chain, Base1, Offset,
+                                      Masks.second, Thru.second, HiMemVT, MOp1,
+                                      ISD::UNINDEXED, ISD::NON_EXTLOAD, false);
     return DAG.getMergeValues(
-        { DAG.getNode(ISD::CONCAT_VECTORS, dl, MemTy, MLoad0, MLoad1),
-          DAG.getNode(ISD::TokenFactor, dl, MVT::Other,
-                      MLoad0.getValue(1), MLoad1.getValue(1)) }, dl);
+        {DAG.getNode(ISD::CONCAT_VECTORS, dl, MemN->getValueType(0), MLoad0,
+                     MLoad1),
+         DAG.getNode(ISD::TokenFactor, dl, MVT::Other, MLoad0.getValue(1),
+                     MLoad1.getValue(1))},
+        dl);
   }
   if (MemOpc == ISD::MSTORE) {
     VectorPair Vals = opSplit(cast<MaskedStoreSDNode>(Op)->getValue(), dl, DAG);
-    SDValue MStore0 = DAG.getMaskedStore(Chain, dl, Vals.first, Base0, Offset,
-                                         Masks.first, SingleTy, MOp0,
-                                         ISD::UNINDEXED, false, false);
-    SDValue MStore1 = DAG.getMaskedStore(Chain, dl, Vals.second, Base1, Offset,
-                                         Masks.second, SingleTy, MOp1,
-                                         ISD::UNINDEXED, false, false);
+    SDValue MStore0 =
+        DAG.getMaskedStore(Chain, dl, Vals.first, Base0, Offset, Masks.first,
+                           LoMemVT, MOp0, ISD::UNINDEXED, false, false);
+    if (HiIsEmpty)
+      return MStore0;
+    SDValue MStore1 =
+        DAG.getMaskedStore(Chain, dl, Vals.second, Base1, Offset, Masks.second,
+                           HiMemVT, MOp1, ISD::UNINDEXED, false, false);
     return DAG.getNode(ISD::TokenFactor, dl, MVT::Other, MStore0, MStore1);
   }
 

--- a/llvm/test/CodeGen/Hexagon/autohvx/masked-vmem-multi.ll
+++ b/llvm/test/CodeGen/Hexagon/autohvx/masked-vmem-multi.ll
@@ -1,0 +1,69 @@
+; RUN: llc -mtriple=hexagon < %s | FileCheck %s
+
+; CHECK-LABEL: l48:
+; CHECK: v{{.+}} = vmem({{.+}})
+; CHECK-DAG: v{{.+}} = vmem({{.+}})
+; CHECK-DAG: vmux
+; CHECK: vmux
+define <48 x i32> @l48(ptr align 128 %p, <48 x i32> %v, <48 x i32> %a) #0 {
+  %q = icmp sgt <48 x i32> %a, zeroinitializer
+  %r = call <48 x i32> @llvm.masked.load.vv80i32.p0(ptr %p, <48 x i1> %q, <48 x i32> %v)
+  ret <48 x i32> %r
+}
+
+; CHECK-LABEL: l64:
+; CHECK: v{{.+}} = vmem({{.+}})
+; CHECK-DAG: v{{.+}} = vmem({{.+}})
+; CHECK-DAG: vmux
+; CHECK: vmux
+define <64 x i32> @l64(ptr align 128 %p, <64 x i32> %v, <64 x i32> %a) #0 {
+  %q = icmp sgt <64 x i32> %a, zeroinitializer
+  %r = call <64 x i32> @llvm.masked.load.vv80i32.p0(ptr %p, <64 x i1> %q, <64 x i32> %v)
+  ret <64 x i32> %r
+}
+
+; CHECK-LABEL: l80:
+; CHECK: v{{.+}} = vmem({{.+}})
+; CHECK-DAG: v{{.+}} = vmem({{.+}})
+; CHECK-DAG: v{{.+}} = vmem({{.+}})
+; CHECK-DAG: vmux
+; CHECK-DAG: vmux
+; CHECK: vmux
+define <80 x i32> @l80(ptr align 128 %p, <80 x i32> %v, <80 x i32> %a) #0 {
+  %q = icmp sgt <80 x i32> %a, zeroinitializer
+  %r = call <80 x i32> @llvm.masked.load.vv80i32.p0(ptr %p, <80 x i1> %q, <80 x i32> %v)
+  ret <80 x i32> %r
+}
+
+; CHECK-LABEL: s48:
+; CHECK: if (q{{.}}) vmem{{.*}} = v
+; CHECK: if (q{{.}}) vmem{{.*}} = v
+; CHECK-NOT: vmem
+define void @s48(ptr %p, <48 x i32> %v, <48 x i32> %a) #0 {
+  %q = icmp sgt <48 x i32> %a, zeroinitializer
+  call void @llvm.masked.store.vv80i32.p0(<48 x i32> %v, ptr %p, i32 128, <48 x i1> %q)
+  ret void
+}
+
+; CHECK-LABEL: s64:
+; CHECK: if (q{{.}}) vmem{{.*}} = v
+; CHECK: if (q{{.}}) vmem{{.*}} = v
+; CHECK-NOT: vmem
+define void @s64(ptr %p, <64 x i32> %v, <64 x i32> %a) #0 {
+  %q = icmp sgt <64 x i32> %a, zeroinitializer
+  call void @llvm.masked.store.vv80i32.p0(<64 x i32> %v, ptr %p, i32 128, <64 x i1> %q)
+  ret void
+}
+
+; CHECK-LABEL: s80:
+; CHECK: if (q{{.}}) vmem{{.*}} = v
+; CHECK: if (q{{.}}) vmem{{.*}} = v
+; CHECK: if (q{{.}}) vmem{{.*}} = v
+; CHECK-NOT: vmem
+define void @s80(ptr %p, <80 x i32> %v, <80 x i32> %a) #0 {
+  %q = icmp sgt <80 x i32> %a, zeroinitializer
+  call void @llvm.masked.store.vv80i32.p0(<80 x i32> %v, ptr %p, i32 128, <80 x i1> %q)
+  ret void
+}
+
+attributes #0 = { nounwind "target-features"="+hvxv73,+hvx-length128b" }


### PR DESCRIPTION
Non-power of 2 masked loads and stores are first widened to a power of 2 size. If the original vector was larger than the single HVX register size, they become multiples of the double HVX register size (e.g. v64f32, v128f32). Since double vector types are legal but do not support masked operations, they are split during custom lowering.

MemoryVT is not changed during widening and the original code assumed that MemoryVT is the same as the operand type and always equal to the double HVX register size.

For example, @llvm.masked.store.v80f32.p0 is first widened to v128f32, then split into two v64f32 (MemoryVT = v64f32 and v16f32). The first half was lowered correctly but the second one could not be split due to the unexpected v16f32 MemoryVT.
