### PR TITLE
[lldb] Support comparing FileSpec against Python strings

### DIFF
--- a/lldb/bindings/interface/SBFileSpecExtensions.i
+++ b/lldb/bindings/interface/SBFileSpecExtensions.i
@@ -6,7 +6,18 @@ STRING_EXTENSION_OUTSIDE(SBFileSpec)
         # operator== is a free function, which swig does not handle, so we inject
         # our own equality operator here
         def __eq__(self, other):
+            if isinstance(other, str):
+                other = SBFileSpec(other)
+            if not isinstance(other, SBFileSpec):
+                return NotImplemented
             return not self.__ne__(other)
+
+        def __ne__(self, other):
+            if isinstance(other, str):
+                other = SBFileSpec(other)
+            if not isinstance(other, SBFileSpec):
+                return NotImplemented
+            return _lldb.SBFileSpec___ne__(self, other)
 
         fullpath = property(str, None, doc='''A read only property that returns the fullpath as a python string.''')
         basename = property(GetFilename, None, doc='''A read only property that returns the path basename as a python string.''')

--- a/lldb/test/API/python_api/filespec/TestFileSpecAPI.py
+++ b/lldb/test/API/python_api/filespec/TestFileSpecAPI.py
@@ -1,0 +1,35 @@
+"""
+Test SBFileSpec APIs, with emphasis on equality comparisons against strings.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+class FileSpecAPITestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_filespec_eq(self):
+        """Test SBFileSpec equality comparisons."""
+        empty = lldb.SBFileSpec()
+        self.assertTrue(empty == lldb.SBFileSpec())
+        self.assertTrue(empty == "")
+        self.assertTrue(empty == lldb.SBFileSpec(""))
+        self.assertFalse(empty != "")
+        self.assertTrue(not empty)
+        self.assertFalse(empty is None)
+
+    def test_filespec_eq_path(self):
+        """Test SBFileSpec equality with non-empty path strings."""
+        spec = lldb.SBFileSpec("/a/b")
+        self.assertTrue(spec == "/a/b")
+        self.assertFalse(spec == "/a/c")
+        self.assertFalse(spec != "/a/b")
+        self.assertTrue(spec != "/a/c")
+
+    def test_filespec_eq_other_type(self):
+        """Test SBFileSpec equality with unsupported types returns False."""
+        spec = lldb.SBFileSpec()
+        self.assertFalse(spec == 42)
+        self.assertFalse(spec == [])


### PR DESCRIPTION
We got a bug report where someone was iterating over the modules and wanted to verify that the module name was empty and noticed it didn't trigger.

```
for module in target.module_iter():
  if module.file is None or module.file == "":
    # Do something
```

My initial hypothesis was that we were somehow skipping modules, but upon further investigation, it was the string comparison that was the culprit. The reporter (reasonably) expected the `file` property to return a string, but in reality it returns a SBFileSpec.

This could be avoided by explicitly comparing with an empty FileSpec, but that seems needlessly tedious.

```
for module in target.module_iter():
  if module.file is None or module.file == lldb.SBFileSpec(""):
    # Do something
```

Instead, add support for comparing a SBFileSpec against a string.

rdar://174166420