### PR TITLE
[CIR][NFC] Add OGCG checks to OpenACC atomic tests

### DIFF
--- a/clang/test/CIR/CodeGenOpenACC/atomic-capture.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/atomic-capture.cpp
@@ -1,4 +1,6 @@
 // RUN: %clang_cc1 -fopenacc -triple x86_64-linux-gnu -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir -triple x86_64-linux-pc %s -o - | FileCheck %s
+// RUN: %clang_cc1 -fopenacc -triple x86_64-linux-gnu -Wno-openacc-self-if-potential-conflict -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
 struct HasOps {
   operator float();
@@ -7,6 +9,7 @@ struct HasOps {
   int operator++(int);
 };
 
+// OGCG: define {{.*}} void @_Z3useiif6HasOps(i32 {{.*}}, i32 {{.*}}, float {{.*}})
 void use(int x, int v, float f, HasOps ops) {
   // CHECK: cir.func{{.*}}(%[[X_ARG:.*]]: !s32i{{.*}}, %[[V_ARG:.*]]: !s32i{{.*}}, %[[F_ARG:.*]]: !cir.float{{.*}}){{.*}}, %[[OPS_ARG:.*]]: !rec_HasOps{{.*}}) {{.*}}{
   // CHECK-NEXT: %[[X_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init]

--- a/clang/test/CIR/CodeGenOpenACC/atomic-update.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/atomic-update.cpp
@@ -1,10 +1,13 @@
 // RUN: %clang_cc1 -fopenacc -triple x86_64-linux-gnu -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir -triple x86_64-linux-pc %s -o - | FileCheck %s
+// RUN: %clang_cc1 -fopenacc -triple x86_64-linux-gnu -Wno-openacc-self-if-potential-conflict -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
 struct HasOps {
   operator float();
   int thing();
 };
 
+// OGCG: define {{.*}} void @_Z3useijf6HasOps(i32 {{.*}}, i32 {{.*}}, float {{.*}})
 void use(int x, unsigned int y, float f, HasOps ops) {
   // CHECK: cir.func{{.*}}(%[[X_ARG:.*]]: !s32i{{.*}}, %[[Y_ARG:.*]]: !u32i{{.*}}, %[[F_ARG:.*]]: !cir.float{{.*}}){{.*}}, %[[OPS_ARG:.*]]: !rec_HasOps{{.*}}) {{.*}}{
   // CHECK-NEXT: %[[X_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init]

--- a/clang/test/CIR/CodeGenOpenACC/atomic-write.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/atomic-write.cpp
@@ -1,4 +1,6 @@
 // RUN: %clang_cc1 -fopenacc -triple x86_64-linux-gnu -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir -triple x86_64-linux-pc %s -o - | FileCheck %s
+// RUN: %clang_cc1 -fopenacc -triple x86_64-linux-gnu -Wno-openacc-self-if-potential-conflict -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
 extern "C" bool condition(int x, unsigned int y, float f);
 extern "C" double do_thing(float f);
@@ -7,6 +9,7 @@ struct ConvertsToScalar {
   operator float();
 };
 
+// OGCG: define {{.*}} void @_Z3useijf16ConvertsToScalar(i32 {{.*}}, i32 {{.*}}, float {{.*}})
 void use(int x, unsigned int y, float f, ConvertsToScalar cts) {
   // CHECK: cir.func{{.*}}(%[[X_ARG:.*]]: !s32i{{.*}}, %[[Y_ARG:.*]]: !u32i{{.*}}, %[[F_ARG:.*]]: !cir.float{{.*}}){{.*}}, %[[CTS_ARG:.*]]: !rec_ConvertsToScalar{{.*}}) {{.*}}{
   // CHECK-NEXT: %[[X_ALLOC:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init]


### PR DESCRIPTION
Add OGCG function signature checks to the three OpenACC atomic test files.  Verifies CIR produces compatible output with classic Clang codegen.

Made with [Cursor](https://cursor.com)