### PR TITLE
[CIR] Handle static local var decl constants

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -1402,9 +1402,10 @@ ConstantLValueEmitter::tryEmitBase(const APValue::LValueBase &base) {
           return cgm.getAddrOfGlobalVarAttr(vd);
 
         if (vd->isLocalVarDecl()) {
-          cgm.errorNYI(vd->getSourceRange(),
-                       "ConstantLValueEmitter: local var decl");
-          return {};
+          cir::GlobalLinkageKind linkage =
+              cgm.getCIRLinkageVarDefinition(vd, /*IsConstant=*/false);
+          return cgm.getBuilder().getGlobalViewAttr(
+              cgm.getOrCreateStaticVarDecl(*vd, linkage));
         }
       }
     }

--- a/clang/test/CIR/CodeGen/static-local.cpp
+++ b/clang/test/CIR/CodeGen/static-local.cpp
@@ -3,6 +3,20 @@
 // RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o - | FileCheck %s --check-prefix=LLVM
 // RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o - | FileCheck %s --check-prefix=OGCG
 
+void use_static_decl() {
+  static int x = 42;
+  static int *p = &x;
+}
+
+// CIR-DAG: cir.global "private" internal dso_local @_ZZ15use_static_declvE1p = #cir.global_view<@_ZZ15use_static_declvE1x> : !cir.ptr<!s32i>
+// CIR-DAG: cir.global "private" internal dso_local @_ZZ15use_static_declvE1x = #cir.int<42> : !s32i
+
+// LLVM-DAG: @_ZZ15use_static_declvE1p = internal global ptr @_ZZ15use_static_declvE1x
+// LLVM-DAG: @_ZZ15use_static_declvE1x = internal global i32 42
+
+// OGCG-DAG: @_ZZ15use_static_declvE1x = internal global i32 42
+// OGCG-DAG: @_ZZ15use_static_declvE1p = internal global ptr @_ZZ15use_static_declvE1x
+
 class A {
 public:
   A();
@@ -24,7 +38,7 @@ void f() {
 // CIR-BEFORE-LPP:   cir.call @_Z3useP1A(%[[VAR]])
 // CIR-BEFORE-LPP:   cir.return
 
-// CIR: cir.global "private" internal dso_local @_ZGVZ1fvE1a = #cir.int<0> : !s64i
+// CIR-DAG: cir.global "private" internal dso_local @_ZGVZ1fvE1a = #cir.int<0> : !s64i
 // CIR: cir.func{{.*}}@_Z1fv()
 // CIR:   %[[ADDR:.*]] = cir.get_global static_local @_ZZ1fvE1a : !cir.ptr<!rec_A>
 // CIR:   %[[GUARD:.*]] = cir.get_global @_ZGVZ1fvE1a : !cir.ptr<!s64i>
@@ -40,7 +54,7 @@ void f() {
 // CIR:   cir.call @_Z3useP1A(%[[ADDR]])
 // CIR:   cir.return
 
-// LLVM: @_ZGVZ1fvE1a = internal global i64 0
+// LLVM-DAG: @_ZGVZ1fvE1a = internal global i64 0
 // LLVM: define{{.*}}void @_Z1fv()
 // LLVM:   %[[GUARD:.*]] = load atomic i8, ptr @_ZGVZ1fvE1a acquire
 // LLVM:   %[[IS_UNINIT:.*]] = icmp eq i8 %[[GUARD]], 0
@@ -51,7 +65,7 @@ void f() {
 // LLVM: call void @_Z3useP1A(ptr {{.*}}@_ZZ1fvE1a)
 // LLVM: ret void
 
-// OGCG: @_ZGVZ1fvE1a = internal global i64 0
+// OGCG-DAG: @_ZGVZ1fvE1a = internal global i64 0
 // OGCG: define{{.*}}void @_Z1fv()
 // OGCG:   %[[GUARD:.*]] = load atomic i8, ptr @_ZGVZ1fvE1a acquire
 // OGCG:   %[[IS_UNINIT:.*]] = icmp eq i8 %[[GUARD]], 0


### PR DESCRIPTION
This adds the handling for the case where the address of a static local variable is used to initialize another static local. In this case, the address of the first variable is emitted as a constant in the initializer of the second variable.