### PR TITLE
[bazel] Add missing linkopt for macOS tests

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -2029,6 +2029,10 @@ cc_library(
         "include",
         "lib/DirectoryWatcher",
     ],
+    linkopts = select({
+        "@platforms//os:macos": ["-Wl,-framework,CoreServices"],
+        "//conditions:default": [],
+    }),
     deps = [
         "//llvm:Support",
     ],


### PR DESCRIPTION
Mirrors https://github.com/llvm/llvm-project/blob/228b6ae5608baea7120fc4d5d611b3fbd30ce0cb/clang/lib/DirectoryWatcher/CMakeLists.txt#L12
