### PR TITLE
[RISCV] Fix address type in Zacas seq_cst atomic pattern

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZa.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZa.td
@@ -87,7 +87,7 @@ multiclass AMOCASPat<string AtomicOp, string BaseInst, ValueType vt = XLenVT,
                                                    (vt GPR:$cmp),
                                                    (vt GPR:$new)),
               (!cast<RVInst>(BaseInst#"_AQRL") GPR:$cmp, GPR:$new, GPR:$addr)>;
-    def : Pat<(!cast<PatFrag>(AtomicOp#"_seq_cst") (vt GPR:$addr),
+    def : Pat<(!cast<PatFrag>(AtomicOp#"_seq_cst") (XLenVT GPR:$addr),
                                                    (vt GPR:$cmp),
                                                    (vt GPR:$new)),
               (!cast<RVInst>(BaseInst#"_AQRL") GPR:$cmp, GPR:$new, GPR:$addr)>;


### PR DESCRIPTION
The seq_cst pattern in AMOCASPat used (vt GPR:$addr) for the address operand, while all other patterns (monotonic, acquire, release, acq_rel) consistently use (XLenVT GPR:$addr). This would produce a wrong type for the address when vt differs from XLenVT (e.g., amocas.d on RV32 where vt=i64).