### PR TITLE
[SPIR-V] Use OpDecorateId instead of OpDecorate for memory aliasing decorations

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
@@ -135,7 +135,7 @@ void SPIRVInstPrinter::printInst(const MCInst *MI, uint64_t Address,
     recordIntType(MI);
   }
 
-  if (OpCode == SPIRV::OpDecorate) {
+  if (OpCode == SPIRV::OpDecorate || OpCode == SPIRV::OpDecorateId) {
     printOpDecorate(MI, OS);
   } else if (OpCode == SPIRV::OpExtInstImport) {
     recordOpExtInstImport(MI);

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -2214,7 +2214,7 @@ void SPIRVGlobalRegistry::buildMemAliasingOpDecorate(
       getOrAddMemAliasingINTELInst(MIRBuilder, AliasingListMD);
   if (!AliasList)
     return;
-  MIRBuilder.buildInstr(SPIRV::OpDecorate)
+  MIRBuilder.buildInstr(SPIRV::OpDecorateId)
       .addUse(Reg)
       .addImm(Dec)
       .addUse(AliasList->getOperand(0).getReg());

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_memory_access_aliasing/alias-load-store-atomic.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_memory_access_aliasing/alias-load-store-atomic.ll
@@ -1,13 +1,14 @@
 ; Check aliasing information translation on atomic load and store
 
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown -verify-machineinstrs --spirv-ext=+SPV_INTEL_memory_access_aliasing %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_memory_access_aliasing %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK: OpCapability MemoryAccessAliasingINTEL
 ; CHECK: OpExtension "SPV_INTEL_memory_access_aliasing"
 ; CHECK: %[[#Domain1:]] = OpAliasDomainDeclINTEL
 ; CHECK: %[[#Scope1:]] = OpAliasScopeDeclINTEL %[[#Domain1]]
 ; CHECK: %[[#List1:]] = OpAliasScopeListDeclINTEL %[[#Scope1]]
-; CHECK: OpDecorate %[[#Load:]] NoAliasINTEL %[[#List1]]
+; CHECK: OpDecorateId %[[#Load:]] NoAliasINTEL %[[#List1]]
 ; CHECK: %[[#Load:]] = OpAtomicLoad
 
 define spir_func i32 @test_load(ptr addrspace(4) %object) #0 {

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_memory_access_aliasing/alias-masked-load-store.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_memory_access_aliasing/alias-masked-load-store.ll
@@ -2,6 +2,7 @@
 
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown -verify-machineinstrs --spirv-ext=+SPV_INTEL_memory_access_aliasing %s -o - | FileCheck %s --check-prefix=CHECK-EXT
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown -verify-machineinstrs %s -o - | FileCheck %s --check-prefix=CHECK-NO-EXT
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_memory_access_aliasing %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-EXT: OpCapability MemoryAccessAliasingINTEL
 ; CHECK-EXT: OpExtension "SPV_INTEL_memory_access_aliasing"
@@ -14,13 +15,13 @@
 ; CHECK-EXT: %[[#Domain3:]] = OpAliasDomainDeclINTEL
 ; CHECK-EXT: %[[#Scope2:]] = OpAliasScopeDeclINTEL %[[#Domain3]]
 ; CHECK-EXT: %[[#List3:]] = OpAliasScopeListDeclINTEL %[[#Scope2]]
-; CHECK-EXT: OpDecorate %[[#Fun1:]] AliasScopeINTEL %[[#List1]]
-; CHECK-EXT: OpDecorate %[[#Fun2:]] AliasScopeINTEL %[[#List1]]
-; CHECK-EXT: OpDecorate %[[#Fun2]] NoAliasINTEL %[[#List2]]
-; CHECK-EXT: OpDecorate %[[#Fun3:]] NoAliasINTEL %[[#List1]]
-; CHECK-EXT: OpDecorate %[[#Fun4:]] AliasScopeINTEL %[[#List3]]
-; CHECK-EXT: OpDecorate %[[#Fun5:]] AliasScopeINTEL %[[#List3]]
-; CHECK-EXT: OpDecorate %[[#Fun6:]] NoAliasINTEL %[[#List3]]
+; CHECK-EXT: OpDecorateId %[[#Fun1:]] AliasScopeINTEL %[[#List1]]
+; CHECK-EXT: OpDecorateId %[[#Fun2:]] AliasScopeINTEL %[[#List1]]
+; CHECK-EXT: OpDecorateId %[[#Fun2]] NoAliasINTEL %[[#List2]]
+; CHECK-EXT: OpDecorateId %[[#Fun3:]] NoAliasINTEL %[[#List1]]
+; CHECK-EXT: OpDecorateId %[[#Fun4:]] AliasScopeINTEL %[[#List3]]
+; CHECK-EXT: OpDecorateId %[[#Fun5:]] AliasScopeINTEL %[[#List3]]
+; CHECK-EXT: OpDecorateId %[[#Fun6:]] NoAliasINTEL %[[#List3]]
 ; CHECK-EXT: %[[#Fun1]] = OpFunctionCall
 ; CHECK-EXT: %[[#Fun2]] = OpFunctionCall
 ; CHECK-EXT: %[[#Fun3]] = OpFunctionCall


### PR DESCRIPTION
AliasScopeINTEL and NoAliasINTEL decorations take ID operands, so they must use OpDecorateId rather than OpDecorate per the SPIR-V spec

related to #190736 