### PR TITLE
[clang-tidy] [Modules] Skip checking decls in clang-tidy (#145630)

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -434,6 +434,9 @@ ClangTidyASTConsumerFactory::createASTConsumer(CompilerInstance &Compiler,
 
   ast_matchers::MatchFinder::MatchFinderOptions FinderOptions;
 
+  // We should always skip the declarations in modules.
+  FinderOptions.SkipDeclsInModules = true;
+
   std::unique_ptr<ClangTidyProfiling> Profiling;
   if (Context.getEnableProfiling()) {
     Profiling =

--- a/clang-tools-extra/test/clang-tidy/infrastructure/cxx20-modules.cppm
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/cxx20-modules.cppm
@@ -1,0 +1,29 @@
+// RUN: rm -fr %t
+// RUN: mkdir %t
+// RUN: split-file %s %t
+// RUN: mkdir %t/tmp
+//
+// RUN: %check_clang_tidy -std=c++20 -check-suffix=DEFAULT %t/a.cpp \
+// RUN:   cppcoreguidelines-narrowing-conversions %t/a.cpp -- \
+// RUN:   -config='{}'
+
+// RUN: %clang -std=c++20 -x c++-module %t/a.cpp --precompile -o %t/a.pcm
+
+// RUN: %check_clang_tidy -std=c++20 -check-suffix=DEFAULT %t/use.cpp \
+// RUN:   cppcoreguidelines-narrowing-conversions %t/a.cpp -- \
+// RUN:   -config='{}' -- -fmodule-file=a=%t/a.pcm 
+
+//--- a.cpp
+export module a;
+export void most_narrowing_is_not_ok() {
+  int i;
+  long long ui;
+  i = ui;
+  // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:7: warning: narrowing conversion from 'long long' to signed type 'int' is implementation-defined [cppcoreguidelines-narrowing-conversions]
+}
+
+//--- use.cpp
+import a;
+void use() {
+  most_narrowing_is_not_ok();
+}

--- a/clang-tools-extra/test/lit.cfg.py
+++ b/clang-tools-extra/test/lit.cfg.py
@@ -27,6 +27,7 @@ config.test_format = lit.formats.ShTest(not use_lit_shell)
 config.suffixes = [
     ".c",
     ".cpp",
+    ".cppm",
     ".hpp",
     ".m",
     ".mm",

--- a/clang/include/clang/ASTMatchers/ASTMatchFinder.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchFinder.h
@@ -144,6 +144,8 @@ public:
 
     /// Avoids matching declarations in system headers.
     bool IgnoreSystemHeaders{false};
+
+    bool SkipDeclsInModules{false};
   };
 
   MatchFinder(MatchFinderOptions Options = MatchFinderOptions());

--- a/clang/lib/ASTMatchers/ASTMatchFinder.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchFinder.cpp
@@ -20,6 +20,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Basic/Module.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringMap.h"
@@ -1509,6 +1510,9 @@ bool MatchASTVisitor::objcClassIsDerivedFrom(
 
 bool MatchASTVisitor::TraverseDecl(Decl *DeclNode) {
   if (shouldSkipNode(DeclNode))
+    return true;
+
+  if (Options.SkipDeclsInModules && DeclNode->isInAnotherModuleUnit())
     return true;
 
   bool ScopedTraversal =


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/issues/145628

Note that I am not sure if this is the proper fix. On the one hand, the fix lives in ASTMachers instead of clang-tidy. On the other hand, I feel this may be a more general fix.