### PR TITLE
[SPIR-V] Add Int64ImageEXT capability for OpTypeImage with 64-bit integer sampled type

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1080,6 +1080,17 @@ static void addOpTypeImageReqs(const MachineInstr &MI,
     break;
   }
 
+  // Check if the sampled type is a 64-bit integer, which requires
+  // Int64ImageEXT capability.
+  assert(MI.getOperand(1).isReg());
+  const MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
+  SPIRVTypeInst SampledTypeDef = MRI.getVRegDef(MI.getOperand(1).getReg());
+  if (SampledTypeDef && SampledTypeDef->getOpcode() == SPIRV::OpTypeInt &&
+      SampledTypeDef->getOperand(1).getImm() == 64) {
+    Reqs.addCapability(SPIRV::Capability::Int64ImageEXT);
+    Reqs.addExtension(SPIRV::Extension::SPV_EXT_shader_image_int64);
+  }
+
   // Has optional access qualifier.
   if (!ST.isShader()) {
     if (MI.getNumOperands() > 8 &&

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1085,8 +1085,7 @@ static void addOpTypeImageReqs(const MachineInstr &MI,
   assert(MI.getOperand(1).isReg());
   const MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
   SPIRVTypeInst SampledTypeDef = MRI.getVRegDef(MI.getOperand(1).getReg());
-  if (SampledTypeDef && SampledTypeDef->getOpcode() == SPIRV::OpTypeInt &&
-      SampledTypeDef->getOperand(1).getImm() == 64) {
+  if (SampledTypeDef.isTypeIntN(64)) {
     Reqs.addCapability(SPIRV::Capability::Int64ImageEXT);
     Reqs.addExtension(SPIRV::Extension::SPV_EXT_shader_image_int64);
   }

--- a/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
+++ b/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
@@ -324,7 +324,7 @@ defm SPV_EXT_shader_atomic_float_add
     : ExtensionOperand<68, [EnvVulkan, EnvOpenCL]>;
 defm SPV_KHR_terminate_invocation : ExtensionOperand<69, [EnvVulkan]>;
 defm SPV_KHR_fragment_shading_rate : ExtensionOperand<70, [EnvVulkan]>;
-defm SPV_EXT_shader_image_int64 : ExtensionOperand<71, [EnvVulkan]>;
+defm SPV_EXT_shader_image_int64 : ExtensionOperand<71, [EnvVulkan, EnvOpenCL]>;
 defm SPV_INTEL_fp_fast_math_mode : ExtensionOperand<72, [EnvOpenCL]>;
 defm SPV_INTEL_fpga_cluster_attributes : ExtensionOperand<73, [EnvOpenCL]>;
 defm SPV_INTEL_loop_fuse : ExtensionOperand<74, [EnvOpenCL]>;
@@ -517,6 +517,7 @@ defm ImageGatherBiasLodAMD : CapabilityOperand<5009, 0, 0, [], [Shader]>;
 defm FragmentMaskAMD : CapabilityOperand<5010, 0, 0, [], [Shader]>;
 defm StencilExportEXT : CapabilityOperand<5013, 0, 0, [], [Shader]>;
 defm ImageReadWriteLodAMD : CapabilityOperand<5015, 0, 0, [], [Shader]>;
+defm Int64ImageEXT : CapabilityOperand<5016, 0, 0, [SPV_EXT_shader_image_int64], [Int64]>;
 defm ShaderClockKHR : CapabilityOperand<5055, 0, 0, [SPV_KHR_shader_clock], []>;
 defm BFloat16TypeKHR : CapabilityOperand<5116, 0, 0, [SPV_KHR_bfloat16], []>;
 defm SampleMaskOverrideCoverageNV : CapabilityOperand<5249, 0, 0, [], [SampleRateShading]>;

--- a/llvm/lib/Target/SPIRV/SPIRVTypeInst.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeInst.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SPIRVTypeInst.h"
+#include "MCTargetDesc/SPIRVMCTargetDesc.h"
 #include "SPIRVInstrInfo.h"
 
 namespace llvm {
@@ -22,5 +23,13 @@ namespace llvm {
 SPIRVTypeInst::SPIRVTypeInst(const MachineInstr *MI) : MI(MI) {
   // A SPIRV Type whose result is not a type is invalid.
   assert(!MI || definesATypeRegister(*MI));
+}
+
+bool SPIRVTypeInst::isTypeIntN(unsigned N) const {
+  if (MI->getOpcode() != SPIRV::OpTypeInt)
+    return false;
+  if (N)
+    return MI->getOperand(1).getImm() == N;
+  return true;
 }
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
@@ -48,6 +48,10 @@ public:
 
   operator bool() const { return MI; }
 
+  // Returns true if this is an OpTypeInt instruction.
+  // If N is non-zero, also checks that the bit width matches N.
+  bool isTypeIntN(unsigned N = 0) const;
+
   friend struct DenseMapInfo<SPIRVTypeInst>;
 };
 

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bindless_images/bindless_images_generic.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bindless_images/bindless_images_generic.ll
@@ -1,11 +1,14 @@
 ; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown %s -o %t.spvt 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
-; RUN: llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bindless_images %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bindless_images,+SPV_EXT_shader_image_int64 %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bindless_images,+SPV_EXT_shader_image_int64 %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-ERROR: LLVM ERROR: OpConvertHandleTo[Image/Sampler/SampledImage]INTEL instruction
 ; CHECK-ERROR-SAME: require the following SPIR-V extension: SPV_INTEL_bindless_images
 
-; CHECK: OpCapability BindlessImagesINTEL
-; CHECK: OpExtension "SPV_INTEL_bindless_images"
+; CHECK-DAG: OpCapability BindlessImagesINTEL
+; CHECK-DAG: OpCapability Int64ImageEXT
+; CHECK-DAG: OpExtension "SPV_INTEL_bindless_images"
+; CHECK-DAG: OpExtension "SPV_EXT_shader_image_int64"
 
 ; CHECK-DAG: %[[#VoidTy:]] = OpTypeVoid
 ; CHECK-DAG: %[[#Int64Ty:]] = OpTypeInt 64


### PR DESCRIPTION
Fix spirv-val failure:
```
error: line 20: Capability Int64ImageEXT is required when using Sampled Type of 64-bit int
  %spirv_Image = OpTypeImage %ulong 3D 0 0 0 0 Unknown ReadOnly
```

Detect when OpTypeImage uses a 64-bit integer as its sampled type and automatically add the Int64ImageEXT capability and SPV_EXT_shader_image_int64 extension

related to https://github.com/llvm/llvm-project/issues/190736