### PR TITLE
[clang][Parser] Improve error recovery for missing semicolons in class members.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -382,6 +382,10 @@ Improvements to Clang's diagnostics
   code can automatically be made portable to other host platforms that don't
   support backslashes.
 
+- Improved error recovery for missing semicolons after class members. Clang now avoids
+  skipping subsequent valid declarations when their previous decl is missing semicolon.
+
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -815,6 +815,13 @@ private:
   /// to the semicolon, consumes that extra token.
   bool ExpectAndConsumeSemi(unsigned DiagID, StringRef TokenUsed = "");
 
+  /// Try to inject a synthetic semicolon if the next token appears to be the
+  /// start of a new declaration (i.e., it starts a new line and is a
+  /// declaration specifier). This is used for error recovery to prevent
+  /// aggressive skipping and preserve subsequent declarations in the AST.
+  /// Returns true if a semicolon was injected.
+  bool TryInjectSemicolon();
+
   /// Consume any extra semi-colons until the end of the line.
   void ConsumeExtraSemi(ExtraSemiKind Kind, DeclSpec::TST T = TST_unspecified);
 

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -815,12 +815,10 @@ private:
   /// to the semicolon, consumes that extra token.
   bool ExpectAndConsumeSemi(unsigned DiagID, StringRef TokenUsed = "");
 
-  /// Try to inject a synthetic semicolon if the next token appears to be the
-  /// start of a new declaration (i.e., it starts a new line and is a
-  /// declaration specifier). This is used for error recovery to prevent
-  /// aggressive skipping and preserve subsequent declarations in the AST.
-  /// Returns true if a semicolon was injected.
-  bool TryInjectSemicolon();
+  /// Returns true if the current token is likely the start of a new
+  /// declaration (e.g., it starts a new line and is a declaration specifier).
+  /// This is a heuristic used for error recovery.
+  bool isLikelyAtStartOfNewDeclaration();
 
   /// Consume any extra semi-colons until the end of the line.
   void ConsumeExtraSemi(ExtraSemiKind Kind, DeclSpec::TST T = TST_unspecified);

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -131,7 +131,8 @@ NamedDecl *Parser::ParseCXXInlineMethodDef(
         << Delete;
       SkipUntil(tok::semi);
     } else if (ExpectAndConsume(tok::semi, diag::err_expected_after,
-                                Delete ? "delete" : "default")) {
+                                Delete ? "delete" : "default") &&
+               !TryInjectSemicolon()) {
       SkipUntil(tok::semi);
     }
 

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -132,7 +132,7 @@ NamedDecl *Parser::ParseCXXInlineMethodDef(
       SkipUntil(tok::semi);
     } else if (ExpectAndConsume(tok::semi, diag::err_expected_after,
                                 Delete ? "delete" : "default") &&
-               !TryInjectSemicolon()) {
+               !isLikelyAtStartOfNewDeclaration()) {
       SkipUntil(tok::semi);
     }
 

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -3245,7 +3245,7 @@ Parser::DeclGroupPtrTy Parser::ParseCXXClassMemberDeclaration(
 
   if (ExpectSemi &&
       ExpectAndConsume(tok::semi, diag::err_expected_semi_decl_list) &&
-      !TryInjectSemicolon()) {
+      !isLikelyAtStartOfNewDeclaration()) {
     // Skip to end of block or statement.
     SkipUntil(tok::r_brace, StopAtSemi | StopBeforeMatch);
     // If we stopped at a ';', eat it.

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -3244,7 +3244,8 @@ Parser::DeclGroupPtrTy Parser::ParseCXXClassMemberDeclaration(
   }
 
   if (ExpectSemi &&
-      ExpectAndConsume(tok::semi, diag::err_expected_semi_decl_list)) {
+      ExpectAndConsume(tok::semi, diag::err_expected_semi_decl_list) &&
+      !TryInjectSemicolon()) {
     // Skip to end of block or statement.
     SkipUntil(tok::r_brace, StopAtSemi | StopBeforeMatch);
     // If we stopped at a ';', eat it.

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -194,15 +194,9 @@ bool Parser::ExpectAndConsumeSemi(unsigned DiagID, StringRef TokenUsed) {
   return ExpectAndConsume(tok::semi, DiagID , TokenUsed);
 }
 
-bool Parser::TryInjectSemicolon() {
-  if (Tok.isAtStartOfLine() &&
-      (isDeclarationSpecifier(ImplicitTypenameContext::No))) {
-    PP.EnterToken(Tok, /*IsReinject=*/true);
-    Tok.setKind(tok::semi);
-    ConsumeToken();
-    return true;
-  }
-  return false;
+bool Parser::isLikelyAtStartOfNewDeclaration() {
+  return Tok.isAtStartOfLine() &&
+         isDeclarationSpecifier(ImplicitTypenameContext::No);
 }
 
 void Parser::ConsumeExtraSemi(ExtraSemiKind Kind, DeclSpec::TST TST) {

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -194,6 +194,17 @@ bool Parser::ExpectAndConsumeSemi(unsigned DiagID, StringRef TokenUsed) {
   return ExpectAndConsume(tok::semi, DiagID , TokenUsed);
 }
 
+bool Parser::TryInjectSemicolon() {
+  if (Tok.isAtStartOfLine() &&
+      (isDeclarationSpecifier(ImplicitTypenameContext::No))) {
+    PP.EnterToken(Tok, /*IsReinject=*/true);
+    Tok.setKind(tok::semi);
+    ConsumeToken();
+    return true;
+  }
+  return false;
+}
+
 void Parser::ConsumeExtraSemi(ExtraSemiKind Kind, DeclSpec::TST TST) {
   if (!Tok.is(tok::semi)) return;
 

--- a/clang/test/AST/ast-dump-decl-recovery.cpp
+++ b/clang/test/AST/ast-dump-decl-recovery.cpp
@@ -1,0 +1,16 @@
+// RUN: not %clang_cc1 -triple x86_64-unknown-unknown -std=c++20 -ast-dump %s | FileCheck -strict-whitespace %s
+
+namespace MissingSemicolon {
+class Foo {
+  void f1() = delete
+  void g1();
+  void f2()
+  void g2();
+};
+// CHECK:      NamespaceDecl {{.*}} MissingSemicolon
+// CHECK:      CXXMethodDecl {{.*}} f1 'void ()' delete
+// CHECK:      CXXMethodDecl {{.*}} g1 'void ()'
+// CHECK:      CXXMethodDecl {{.*}} f2 'void ()'
+// CHECK:      CXXMethodDecl {{.*}} g2 'void ()'
+
+} // namespace MissingSemicolon

--- a/clang/test/Parser/recovery.cpp
+++ b/clang/test/Parser/recovery.cpp
@@ -24,7 +24,7 @@ struct S {
   int a, b, c;
   S();
   int x // expected-error {{expected ';'}}
-  friend void f()
+  friend void f() // expected-error {{expected ';' at end of declaration list}}
 };
 8S::S() : a{ 5 }, b{ 6 }, c{ 2 } { // expected-error {{unqualified-id}}
   return;


### PR DESCRIPTION
This is something I discovered when doing the investigation for https://github.com/llvm/llvm-project/pull/188123#issuecomment-4162665482.

This patch improves recovery when a semicolon is missing after a class member declarations.

When the parser expects a semicolon but encounters a token that is at the start of a line and is a valid declaration specifier, it injects a `;` instead of skipping tokens,  this allows us to preserve the declaration after the missing ";" instead of discarding it.
