### PR TITLE
[LLD] [COFF] Explicitly prefer def files and export directives over /export-all-symbols

### DIFF
--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -1197,6 +1197,28 @@ static StringRef exportSourceName(ExportSource s) {
   }
 }
 
+static int exportSourcePriority(ExportSource s) {
+  switch (s) {
+  case ExportSource::Directives:
+    return 1;
+  case ExportSource::ExportAll:
+    // Give directives (embedded in object files, from dllexport attributes)
+    // and linker generated exports (from /export-all-symbols) differing
+    // priority, to avoid warnings about conflicts between the two. In
+    // practice, there shouldn't be any conflicts between the two, as both
+    // should set the DATA flag consistently. Both have lower priority than
+    // def files and explicit export arguments.
+    return 2;
+  case ExportSource::Export:
+  case ExportSource::ModuleDefinition:
+    // Give the same priority to export arguments and def files; this produces
+    // warnings if they are duplicate and if they differ.
+    return 3;
+  default:
+    llvm_unreachable("unknown ExportSource");
+  }
+}
+
 // Performs error checking on all /export arguments.
 // It also sets ordinals.
 void SymbolTable::fixupExports() {
@@ -1264,11 +1286,23 @@ void SymbolTable::fixupExports() {
     // If the existing export comes from .OBJ directives, we are allowed to
     // overwrite it with /DEF: or /EXPORT without any warning, as MSVC link.exe
     // does.
-    if (existing->source == ExportSource::Directives) {
+    // Also silently override exports from /export-all-symbols with ones from
+    // def files and /EXPORT.
+    int existingPriority = exportSourcePriority(existing->source);
+    int newPriority = exportSourcePriority(e.source);
+    if (existingPriority < newPriority) {
+      // New definition with higher priority; don't warn, and replace the
+      // existing definition with this one.
       *existing = e;
       v[pair.first->second.second] = e;
       continue;
     }
+    if (existingPriority > newPriority) {
+      // New definition with lower priority; ignore the new one silently
+      // without warning.
+      continue;
+    }
+
     if (existing->source == e.source) {
       Warn(ctx) << "duplicate " << exportSourceName(existing->source)
                 << " option: " << e.name;

--- a/lld/test/COFF/export-all-conflict.test
+++ b/lld/test/COFF/export-all-conflict.test
@@ -3,9 +3,15 @@ RUN: split-file %s %t.dir && cd %t.dir
 
 RUN: llvm-mc -filetype=obj -triple=x86_64-windows datasym.s -o datasym.obj
 
-RUN: lld-link -dll -noentry -out:test.dll datasym.obj -def:exports.def -lldmingw -export-all-symbols 2>&1 | FileCheck %s
+RUN: lld-link -dll -noentry -out:test.dll datasym.obj -def:exports.def -lldmingw -export-all-symbols 2>&1 | count 0
 
-CHECK: warning: duplicate export: datasym first seen in /def, now in /export-all-symbols
+RUN: llvm-readobj --coff-exports test.dll | FileCheck %s
+
+CHECK:      Export {
+CHECK-NEXT:   Ordinal: 7
+CHECK-NEXT:   Name: datasym
+CHECK-NEXT:   RVA: 0x2000
+CHECK-NEXT: }
 
 #--- datasym.s
 	.data
@@ -15,4 +21,4 @@ datasym:
 
 #--- exports.def
 EXPORTS
-datasym
+datasym @7


### PR DESCRIPTION
If a def file is specified (or explicit export directives), they should be preferred over exports from /export-all-symbols. There is no need to warn about conflicts in these cases, just make a clear preference and ignore the export with lower preference.