### PR TITLE
[Support] Factor PatternMatch m_Combine(And|Or), m_Isa (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/PatternMatchHelpers.h
+++ b/llvm/include/llvm/ADT/PatternMatchHelpers.h
@@ -1,0 +1,69 @@
+//===- PatternMatchHelpers.h - Helpers for PatternMatch -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides helpers that are used across the IR PatternMatch,
+// ScalarEvolutionPatternMatch, and VPlanPatternMatch.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_ADT_PATTERNMATCHHELPERS_H
+#define LLVM_ADT_PATTERNMATCHHELPERS_H
+
+#include "llvm/Support/Casting.h"
+#include <tuple>
+
+namespace llvm::PatternMatchHelpers {
+/// Matching or combinator.
+template <typename... Ty> struct match_combine_or { // NOLINT
+  std::tuple<Ty...> Ps;
+  match_combine_or(const Ty &...Ps) : Ps(Ps...) {}
+  template <typename ITy> bool match(ITy *V) const {
+    return std::apply([V](auto &&...Ps) { return (Ps.match(V) || ...); }, Ps);
+  }
+};
+
+/// Matching and combinator.
+template <typename... Ty> struct match_combine_and { // NOLINT
+  std::tuple<Ty...> Ps;
+  match_combine_and(const Ty &...Ps) : Ps(Ps...) {}
+  template <typename ITy> bool match(ITy *V) const {
+    return std::apply([V](auto &&...Ps) { return (Ps.match(V) && ...); }, Ps);
+  }
+};
+
+/// Combine two pattern matchers matching any of Ps patterns.
+template <typename... Ty>
+inline match_combine_or<Ty...> m_CombineOr(const Ty &...Ps) { // NOLINT
+  return {Ps...};
+}
+
+/// Combine two pattern matchers matching all of Ps patterns.
+template <typename... Ty>
+inline match_combine_and<Ty...> m_CombineAnd(const Ty &...Ps) { // NOLINT
+  return {Ps...};
+}
+
+/// A match-wrapper around isa.
+template <typename... To> struct match_isa { // NOLINT
+  template <typename ArgTy> bool match(const ArgTy *V) const {
+    return isa<To...>(V);
+  }
+};
+
+template <typename... To> inline match_isa<To...> m_Isa() { // NOLINT
+  return match_isa<To...>();
+}
+
+/// A variant of m_Isa that also matches SubPattern.
+template <typename... To, typename SubPattern>
+inline auto m_Isa(const SubPattern &P) { // NOLINT
+  return m_CombineAnd(m_Isa<To...>(), P);
+}
+} // namespace llvm::PatternMatchHelpers
+
+#endif

--- a/llvm/include/llvm/Analysis/ScalarEvolutionPatternMatch.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolutionPatternMatch.h
@@ -13,8 +13,11 @@
 #ifndef LLVM_ANALYSIS_SCALAREVOLUTIONPATTERNMATCH_H
 #define LLVM_ANALYSIS_SCALAREVOLUTIONPATTERNMATCH_H
 
+#include "llvm/ADT/PatternMatchHelpers.h"
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Analysis/ScalarEvolutionExpressions.h"
+
+using namespace llvm::PatternMatchHelpers;
 
 namespace llvm {
 namespace SCEVPatternMatch {
@@ -62,17 +65,9 @@ inline cst_pred_ty<is_all_ones> m_scev_AllOnes() {
   return cst_pred_ty<is_all_ones>();
 }
 
-template <typename Class> struct class_match {
-  template <typename ITy> bool match(ITy *V) const { return isa<Class>(V); }
-};
-
-inline class_match<const SCEV> m_SCEV() { return class_match<const SCEV>(); }
-inline class_match<const SCEVConstant> m_SCEVConstant() {
-  return class_match<const SCEVConstant>();
-}
-inline class_match<const SCEVVScale> m_SCEVVScale() {
-  return class_match<const SCEVVScale>();
-}
+inline auto m_SCEV() { return m_Isa<const SCEV>(); }
+inline auto m_SCEVConstant() { return m_Isa<const SCEVConstant>(); }
+inline auto m_SCEVVScale() { return m_Isa<const SCEVVScale>(); }
 
 template <typename Class> struct bind_ty {
   Class *&VR;
@@ -368,7 +363,7 @@ inline SCEVURem_match<Op0_t, Op1_t> m_scev_URem(Op0_t LHS, Op1_t RHS,
   return SCEVURem_match<Op0_t, Op1_t>(LHS, RHS, SE);
 }
 
-inline class_match<const Loop> m_Loop() { return class_match<const Loop>(); }
+inline auto m_Loop() { return m_Isa<const Loop>(); }
 
 /// Match an affine SCEVAddRecExpr.
 template <typename Op0_t, typename Op1_t, typename Loop_t>
@@ -398,10 +393,10 @@ inline specificloop_ty m_SpecificLoop(const Loop *L) { return L; }
 inline bind_ty<const Loop> m_Loop(const Loop *&L) { return L; }
 
 template <typename Op0_t, typename Op1_t>
-inline SCEVAffineAddRec_match<Op0_t, Op1_t, class_match<const Loop>>
+inline SCEVAffineAddRec_match<Op0_t, Op1_t, match_isa<const Loop>>
 m_scev_AffineAddRec(const Op0_t &Op0, const Op1_t &Op1) {
-  return SCEVAffineAddRec_match<Op0_t, Op1_t, class_match<const Loop>>(
-      Op0, Op1, m_Loop());
+  return SCEVAffineAddRec_match<Op0_t, Op1_t, match_isa<const Loop>>(Op0, Op1,
+                                                                     m_Loop());
 }
 
 template <typename Op0_t, typename Op1_t, typename Loop_t>

--- a/llvm/include/llvm/Analysis/ScalarEvolutionPatternMatch.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolutionPatternMatch.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_ANALYSIS_SCALAREVOLUTIONPATTERNMATCH_H
 #define LLVM_ANALYSIS_SCALAREVOLUTIONPATTERNMATCH_H
 
-#include "llvm/ADT/PatternMatchHelpers.h"
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Analysis/ScalarEvolutionExpressions.h"
+#include "llvm/Support/PatternMatchHelpers.h"
 
 using namespace llvm::PatternMatchHelpers;
 

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -30,6 +30,7 @@
 
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/PatternMatchHelpers.h"
 #include "llvm/IR/Constant.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
@@ -43,6 +44,8 @@
 #include "llvm/IR/Value.h"
 #include "llvm/Support/Casting.h"
 #include <cstdint>
+
+using namespace llvm::PatternMatchHelpers;
 
 namespace llvm {
 namespace PatternMatch {
@@ -128,30 +131,20 @@ m_NoSignedZeros(const T &SubPattern) {
   return SubPattern;
 }
 
-template <typename Class> struct class_match {
-  template <typename ITy> bool match(ITy *V) const { return isa<Class>(V); }
-};
-
 /// Match an arbitrary value and ignore it.
-inline class_match<Value> m_Value() { return class_match<Value>(); }
+inline auto m_Value() { return m_Isa<Value>(); }
 
 /// Match an arbitrary unary operation and ignore it.
-inline class_match<UnaryOperator> m_UnOp() {
-  return class_match<UnaryOperator>();
-}
+inline auto m_UnOp() { return m_Isa<UnaryOperator>(); }
 
 /// Match an arbitrary binary operation and ignore it.
-inline class_match<BinaryOperator> m_BinOp() {
-  return class_match<BinaryOperator>();
-}
+inline auto m_BinOp() { return m_Isa<BinaryOperator>(); }
 
 /// Matches any compare instruction and ignore it.
-inline class_match<CmpInst> m_Cmp() { return class_match<CmpInst>(); }
+inline auto m_Cmp() { return m_Isa<CmpInst>(); }
 
 /// Matches any intrinsic call and ignore it.
-inline class_match<IntrinsicInst> m_AnyIntrinsic() {
-  return class_match<IntrinsicInst>();
-}
+inline auto m_AnyIntrinsic() { return m_Isa<IntrinsicInst>(); }
 
 struct undef_match {
 private:
@@ -174,27 +167,19 @@ public:
 inline auto m_Undef() { return undef_match(); }
 
 /// Match an arbitrary UndefValue constant.
-inline class_match<UndefValue> m_UndefValue() {
-  return class_match<UndefValue>();
-}
+inline auto m_UndefValue() { return m_Isa<UndefValue>(); }
 
 /// Match an arbitrary poison constant.
-inline class_match<PoisonValue> m_Poison() {
-  return class_match<PoisonValue>();
-}
+inline auto m_Poison() { return m_Isa<PoisonValue>(); }
 
 /// Match an arbitrary Constant and ignore it.
-inline class_match<Constant> m_Constant() { return class_match<Constant>(); }
+inline auto m_Constant() { return m_Isa<Constant>(); }
 
 /// Match an arbitrary ConstantInt and ignore it.
-inline class_match<ConstantInt> m_ConstantInt() {
-  return class_match<ConstantInt>();
-}
+inline auto m_ConstantInt() { return m_Isa<ConstantInt>(); }
 
 /// Match an arbitrary ConstantFP and ignore it.
-inline class_match<ConstantFP> m_ConstantFP() {
-  return class_match<ConstantFP>();
-}
+inline auto m_ConstantFP() { return m_Isa<ConstantFP>(); }
 
 struct constantexpr_match {
   template <typename ITy> bool match(ITy *V) const {
@@ -228,9 +213,7 @@ inline Splat_match<T> m_ConstantSplat(const T &SubPattern) {
 }
 
 /// Match an arbitrary basic block value and ignore it.
-inline class_match<BasicBlock> m_BasicBlock() {
-  return class_match<BasicBlock>();
-}
+inline auto m_BasicBlock() { return m_Isa<BasicBlock>(); }
 
 /// Inverting matcher
 template <typename Ty> struct match_unless {
@@ -244,48 +227,6 @@ template <typename Ty> struct match_unless {
 /// Match if the inner matcher does *NOT* match.
 template <typename Ty> inline match_unless<Ty> m_Unless(const Ty &M) {
   return match_unless<Ty>(M);
-}
-
-/// Matching combinators
-template <typename LTy, typename RTy> struct match_combine_or {
-  LTy L;
-  RTy R;
-
-  match_combine_or(const LTy &Left, const RTy &Right) : L(Left), R(Right) {}
-
-  template <typename ITy> bool match(ITy *V) const {
-    if (L.match(V))
-      return true;
-    if (R.match(V))
-      return true;
-    return false;
-  }
-};
-
-template <typename LTy, typename RTy> struct match_combine_and {
-  LTy L;
-  RTy R;
-
-  match_combine_and(const LTy &Left, const RTy &Right) : L(Left), R(Right) {}
-
-  template <typename ITy> bool match(ITy *V) const {
-    if (L.match(V))
-      if (R.match(V))
-        return true;
-    return false;
-  }
-};
-
-/// Combine two pattern matchers matching L || R
-template <typename LTy, typename RTy>
-inline match_combine_or<LTy, RTy> m_CombineOr(const LTy &L, const RTy &R) {
-  return match_combine_or<LTy, RTy>(L, R);
-}
-
-/// Combine two pattern matchers matching L && R
-template <typename LTy, typename RTy>
-inline match_combine_and<LTy, RTy> m_CombineAnd(const LTy &L, const RTy &R) {
-  return match_combine_and<LTy, RTy>(L, R);
 }
 
 template <typename APTy> struct ap_match {
@@ -2369,12 +2310,8 @@ m_ZExtOrSExtOrSelf(const OpTy &Op) {
   return m_CombineOr(m_ZExtOrSExt(Op), Op);
 }
 
-template <typename OpTy>
-inline match_combine_or<match_combine_or<CastInst_match<OpTy, ZExtInst>,
-                                         CastInst_match<OpTy, TruncInst>>,
-                        OpTy>
-m_ZExtOrTruncOrSelf(const OpTy &Op) {
-  return m_CombineOr(m_CombineOr(m_ZExt(Op), m_Trunc(Op)), Op);
+template <typename OpTy> inline auto m_ZExtOrTruncOrSelf(const OpTy &Op) {
+  return m_CombineOr(m_ZExt(Op), m_Trunc(Op), Op);
 }
 
 template <typename CondTy, typename LTy, typename RTy> struct SelectLike_match {
@@ -2654,14 +2591,8 @@ inline MaxMin_match<ICmpInst, LHS, RHS, umin_pred_ty> m_UMin(const LHS &L,
 }
 
 template <typename LHS, typename RHS>
-inline match_combine_or<
-    match_combine_or<MaxMin_match<ICmpInst, LHS, RHS, smax_pred_ty>,
-                     MaxMin_match<ICmpInst, LHS, RHS, smin_pred_ty>>,
-    match_combine_or<MaxMin_match<ICmpInst, LHS, RHS, umax_pred_ty>,
-                     MaxMin_match<ICmpInst, LHS, RHS, umin_pred_ty>>>
-m_MaxOrMin(const LHS &L, const RHS &R) {
-  return m_CombineOr(m_CombineOr(m_SMax(L, R), m_SMin(L, R)),
-                     m_CombineOr(m_UMax(L, R), m_UMin(L, R)));
+inline auto m_MaxOrMin(const LHS &L, const RHS &R) {
+  return m_CombineOr(m_SMax(L, R), m_SMin(L, R), m_UMax(L, R), m_UMin(L, R));
 }
 
 /// Match an 'ordered' floating point maximum function.
@@ -3196,14 +3127,9 @@ m_c_UMax(const LHS &L, const RHS &R) {
 }
 
 template <typename LHS, typename RHS>
-inline match_combine_or<
-    match_combine_or<MaxMin_match<ICmpInst, LHS, RHS, smax_pred_ty, true>,
-                     MaxMin_match<ICmpInst, LHS, RHS, smin_pred_ty, true>>,
-    match_combine_or<MaxMin_match<ICmpInst, LHS, RHS, umax_pred_ty, true>,
-                     MaxMin_match<ICmpInst, LHS, RHS, umin_pred_ty, true>>>
-m_c_MaxOrMin(const LHS &L, const RHS &R) {
-  return m_CombineOr(m_CombineOr(m_c_SMax(L, R), m_c_SMin(L, R)),
-                     m_CombineOr(m_c_UMax(L, R), m_c_UMin(L, R)));
+inline auto m_c_MaxOrMin(const LHS &L, const RHS &R) {
+  return m_CombineOr(m_c_SMax(L, R), m_c_SMin(L, R), m_c_UMax(L, R),
+                     m_c_UMin(L, R));
 }
 
 template <Intrinsic::ID IntrID, typename LHS, typename RHS>

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -30,7 +30,6 @@
 
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
-#include "llvm/ADT/PatternMatchHelpers.h"
 #include "llvm/IR/Constant.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
@@ -43,6 +42,7 @@
 #include "llvm/IR/Operator.h"
 #include "llvm/IR/Value.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/PatternMatchHelpers.h"
 #include <cstdint>
 
 using namespace llvm::PatternMatchHelpers;

--- a/llvm/include/llvm/Support/PatternMatchHelpers.h
+++ b/llvm/include/llvm/Support/PatternMatchHelpers.h
@@ -36,13 +36,13 @@ template <typename... Ty> struct match_combine_and { // NOLINT
   }
 };
 
-/// Combine two pattern matchers matching any of Ps patterns.
+/// Combine pattern matchers matching any of Ps patterns.
 template <typename... Ty>
 inline match_combine_or<Ty...> m_CombineOr(const Ty &...Ps) { // NOLINT
   return {Ps...};
 }
 
-/// Combine two pattern matchers matching all of Ps patterns.
+/// Combine pattern matchers matching all of Ps patterns.
 template <typename... Ty>
 inline match_combine_and<Ty...> m_CombineAnd(const Ty &...Ps) { // NOLINT
   return {Ps...};
@@ -66,4 +66,4 @@ inline auto m_Isa(const SubPattern &P) { // NOLINT
 }
 } // namespace llvm::PatternMatchHelpers
 
-#endif
+#endif // LLVM_SUPPORT_PATTERNMATCHHELPERS_H

--- a/llvm/include/llvm/Support/PatternMatchHelpers.h
+++ b/llvm/include/llvm/Support/PatternMatchHelpers.h
@@ -11,8 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_ADT_PATTERNMATCHHELPERS_H
-#define LLVM_ADT_PATTERNMATCHHELPERS_H
+#ifndef LLVM_SUPPORT_PATTERNMATCHHELPERS_H
+#define LLVM_SUPPORT_PATTERNMATCHHELPERS_H
 
 #include "llvm/Support/Casting.h"
 #include <tuple>

--- a/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
+++ b/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
@@ -146,9 +146,9 @@ public:
     if (isa<Constant>(V))
       return isa<UndefValue>(V) ? 0 : 1;
 
-    if (isa<CastInst>(V) || match(V, m_Neg(PatternMatch::m_Value())) ||
-        match(V, m_Not(PatternMatch::m_Value())) ||
-        match(V, m_FNeg(PatternMatch::m_Value())))
+    using namespace llvm::PatternMatch;
+    if (isa<CastInst>(V) || match(V, m_Neg(m_Value())) ||
+        match(V, m_Not(m_Value())) || match(V, m_FNeg(m_Value())))
       return 2;
 
     return 3;
@@ -262,7 +262,7 @@ public:
         break; // Free to invert by swapping true/false values/destinations.
       case Instruction::Xor: // Can invert 'xor' if it's a 'not', by ignoring
                              // it.
-        if (!match(I, m_Not(PatternMatch::m_Value())))
+        if (!match(I, PatternMatch::m_Not(PatternMatch::m_Value())))
           return false; // Not a 'not'.
         break;
       default:

--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -16,6 +16,9 @@
 #define LLVM_TRANSFORM_VECTORIZE_VPLANPATTERNMATCH_H
 
 #include "VPlan.h"
+#include "llvm/ADT/PatternMatchHelpers.h"
+
+using namespace llvm::PatternMatchHelpers;
 
 namespace llvm::VPlanPatternMatch {
 
@@ -41,17 +44,6 @@ template <typename Pattern> auto match_fn(const Pattern &P) {
 
 template <typename Pattern> bool match(VPSingleDefRecipe *R, const Pattern &P) {
   return P.match(static_cast<const VPRecipeBase *>(R));
-}
-
-/// A match-wrapper around isa.
-template <typename... To> struct match_isapred {
-  template <typename ArgTy> bool match(const ArgTy *V) const {
-    return isa<To...>(V);
-  }
-};
-
-template <typename... To> inline match_isapred<To...> m_Isa() {
-  return match_isapred<To...>();
 }
 
 /// Match an arbitrary VPValue and ignore it.
@@ -230,39 +222,6 @@ inline match_poison m_Poison() { return match_poison(); }
 /// Match a plain integer constant no wider than 64-bits, capturing it if we
 /// match.
 inline bind_const_int m_ConstantInt(uint64_t &C) { return C; }
-
-/// Matching combinators
-template <typename... Ty> struct match_combine_or {
-  std::tuple<Ty...> Ps;
-
-  match_combine_or(const Ty &...Ps) : Ps(Ps...) {}
-
-  template <typename ITy> bool match(ITy *V) const {
-    return std::apply([V](auto &&...Ps) { return (Ps.match(V) || ...); }, Ps);
-  }
-};
-
-template <typename... Ty> struct match_combine_and {
-  std::tuple<Ty...> Ps;
-
-  match_combine_and(const Ty &...Ps) : Ps(Ps...) {}
-
-  template <typename ITy> bool match(ITy *V) const {
-    return std::apply([V](auto &&...Ps) { return (Ps.match(V) && ...); }, Ps);
-  }
-};
-
-/// Combine two pattern matchers matching any of Ps patterns.
-template <typename... Ty>
-inline match_combine_or<Ty...> m_CombineOr(const Ty &...Ps) {
-  return {Ps...};
-}
-
-/// Combine two pattern matchers matching all of Ps patterns.
-template <typename... Ty>
-inline match_combine_and<Ty...> m_CombineAnd(const Ty &...Ps) {
-  return {Ps...};
-}
 
 /// Match a VPValue, capturing it if we match.
 inline bind_ty<VPValue> m_VPValue(VPValue *&V) { return V; }
@@ -599,12 +558,6 @@ inline match_combine_or<AllRecipe_match<Instruction::ZExt, Op0_t>,
                         AllRecipe_match<Instruction::SExt, Op0_t>>
 m_ZExtOrSExt(const Op0_t &Op0) {
   return m_CombineOr(m_ZExt(Op0), m_SExt(Op0));
-}
-
-/// A variant of m_Isa that also matches SubPattern.
-template <typename... To, typename SubPattern>
-inline auto m_Isa(const SubPattern &P) {
-  return m_CombineAnd(m_Isa<To...>(), P);
 }
 
 template <typename Op0_t> inline auto m_WidenAnyExtend(const Op0_t &Op0) {

--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -232,38 +232,36 @@ inline match_poison m_Poison() { return match_poison(); }
 inline bind_const_int m_ConstantInt(uint64_t &C) { return C; }
 
 /// Matching combinators
-template <typename LTy, typename RTy> struct match_combine_or {
-  LTy L;
-  RTy R;
+template <typename... Ty> struct match_combine_or {
+  std::tuple<Ty...> Ps;
 
-  match_combine_or(const LTy &Left, const RTy &Right) : L(Left), R(Right) {}
+  match_combine_or(const Ty &...Ps) : Ps(Ps...) {}
 
   template <typename ITy> bool match(ITy *V) const {
-    return L.match(V) || R.match(V);
+    return std::apply([V](auto &&...Ps) { return (Ps.match(V) || ...); }, Ps);
   }
 };
 
-template <typename LTy, typename RTy> struct match_combine_and {
-  LTy L;
-  RTy R;
+template <typename... Ty> struct match_combine_and {
+  std::tuple<Ty...> Ps;
 
-  match_combine_and(const LTy &Left, const RTy &Right) : L(Left), R(Right) {}
+  match_combine_and(const Ty &...Ps) : Ps(Ps...) {}
 
   template <typename ITy> bool match(ITy *V) const {
-    return L.match(V) && R.match(V);
+    return std::apply([V](auto &&...Ps) { return (Ps.match(V) && ...); }, Ps);
   }
 };
 
-/// Combine two pattern matchers matching L || R
-template <typename LTy, typename RTy>
-inline match_combine_or<LTy, RTy> m_CombineOr(const LTy &L, const RTy &R) {
-  return match_combine_or<LTy, RTy>(L, R);
+/// Combine two pattern matchers matching any of Ps patterns.
+template <typename... Ty>
+inline match_combine_or<Ty...> m_CombineOr(const Ty &...Ps) {
+  return {Ps...};
 }
 
-/// Combine two pattern matchers matching L && R
-template <typename LTy, typename RTy>
-inline match_combine_and<LTy, RTy> m_CombineAnd(const LTy &L, const RTy &R) {
-  return match_combine_and<LTy, RTy>(L, R);
+/// Combine two pattern matchers matching all of Ps patterns.
+template <typename... Ty>
+inline match_combine_and<Ty...> m_CombineAnd(const Ty &...Ps) {
+  return {Ps...};
 }
 
 /// Match a VPValue, capturing it if we match.
@@ -619,13 +617,8 @@ m_ZExtOrSelf(const Op0_t &Op0) {
   return m_CombineOr(m_ZExt(Op0), Op0);
 }
 
-template <typename Op0_t>
-inline match_combine_or<
-    match_combine_or<AllRecipe_match<Instruction::ZExt, Op0_t>,
-                     AllRecipe_match<Instruction::Trunc, Op0_t>>,
-    Op0_t>
-m_ZExtOrTruncOrSelf(const Op0_t &Op0) {
-  return m_CombineOr(m_CombineOr(m_ZExt(Op0), m_Trunc(Op0)), Op0);
+template <typename Op0_t> inline auto m_ZExtOrTruncOrSelf(const Op0_t &Op0) {
+  return m_CombineOr(m_ZExt(Op0), m_Trunc(Op0), Op0);
 }
 
 template <unsigned Opcode, typename Op0_t, typename Op1_t>
@@ -821,10 +814,8 @@ inline auto m_GetElementPtr(const Op0_t &Op0, const Op1_t &Op1) {
       Recipe_match<std::tuple<Op0_t, Op1_t>, Instruction::GetElementPtr,
                    /*Commutative*/ false, VPReplicateRecipe, VPWidenGEPRecipe>(
           Op0, Op1),
-      m_CombineOr(
-          VPInstruction_match<VPInstruction::PtrAdd, Op0_t, Op1_t>(Op0, Op1),
-          VPInstruction_match<VPInstruction::WidePtrAdd, Op0_t, Op1_t>(Op0,
-                                                                       Op1)));
+      VPInstruction_match<VPInstruction::PtrAdd, Op0_t, Op1_t>(Op0, Op1),
+      VPInstruction_match<VPInstruction::WidePtrAdd, Op0_t, Op1_t>(Op0, Op1));
 }
 
 template <typename Op0_t, typename Op1_t, typename Op2_t>

--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -16,7 +16,7 @@
 #define LLVM_TRANSFORM_VECTORIZE_VPLANPATTERNMATCH_H
 
 #include "VPlan.h"
-#include "llvm/ADT/PatternMatchHelpers.h"
+#include "llvm/Support/PatternMatchHelpers.h"
 
 using namespace llvm::PatternMatchHelpers;
 


### PR DESCRIPTION
Introduce a new PatternMatchHelpers with a variant of m_Combine(And|Or) and m_Isa to share across the IR PatternMatch, ScalarEvolutionPatternMatch, and VPlanPatternMatch. m_Combine(And|Or) has been generalized to be variadic. Planned follow-ups include factoring the specific-value matcher.