### PR TITLE
[ARM] Fold Or of CSINC into CSINC

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -14877,7 +14877,8 @@ static SDValue PerformORCombine(SDNode *N, TargetLowering::DAGCombinerInfo &DCI,
     std::swap(CSINC, Other);
   if (CSINC.getOpcode() == ARMISD::CSINC &&
       isNullConstant(CSINC.getOperand(0)) &&
-      isNullConstant(CSINC.getOperand(1)))
+      isNullConstant(CSINC.getOperand(1)) &&
+      DAG.MaskedValueIsZero(Other, APInt::getHighBitsSet(32, 31)))
     return DAG.getNode(ARMISD::CSINC, dl, VT, Other, CSINC.getOperand(1),
                        CSINC.getOperand(2), CSINC.getOperand(3));
 

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -14871,6 +14871,7 @@ static SDValue PerformORCombine(SDNode *N, TargetLowering::DAGCombinerInfo &DCI,
     return Result;
 
   // (or x, (csinc 0, 0, cc)) -> (csinc x, 0, cc)
+  // providing that the x is 0 or 1.
   SDValue CSINC = N1;
   SDValue Other = N0;
   if (CSINC.getOpcode() != ARMISD::CSINC)

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -14870,6 +14870,17 @@ static SDValue PerformORCombine(SDNode *N, TargetLowering::DAGCombinerInfo &DCI,
   if (SDValue Result = PerformSHLSimplify(N, DCI, Subtarget))
     return Result;
 
+  // (or x, (csinc 0, 0, cc)) -> (csinc x, 0, cc)
+  SDValue CSINC = N1;
+  SDValue Other = N0;
+  if (CSINC.getOpcode() != ARMISD::CSINC)
+    std::swap(CSINC, Other);
+  if (CSINC.getOpcode() == ARMISD::CSINC &&
+      isNullConstant(CSINC.getOperand(0)) &&
+      isNullConstant(CSINC.getOperand(1)))
+    return DAG.getNode(ARMISD::CSINC, dl, VT, Other, CSINC.getOperand(1),
+                       CSINC.getOperand(2), CSINC.getOperand(3));
+
   return SDValue();
 }
 

--- a/llvm/test/CodeGen/Thumb2/arm_canberra_distance_f32.ll
+++ b/llvm/test/CodeGen/Thumb2/arm_canberra_distance_f32.ll
@@ -15,9 +15,10 @@ define nofpclass(nan inf) float @arm_canberra_distance_f32(ptr noundef readonly 
 ; CHECK-NEXT:    vcmp.f32 s2, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-NEXT:    vcmp.f32 s4, #0
-; CHECK-NEXT:    cset r3, ne
+; CHECK-NEXT:    cset r12, ne
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    csinc r3, r3, zr, eq
+; CHECK-NEXT:    cset r3, ne
+; CHECK-NEXT:    orr.w r3, r3, r12
 ; CHECK-NEXT:    lsls r3, r3, #31
 ; CHECK-NEXT:    beq .LBB0_3
 ; CHECK-NEXT:  @ %bb.2: @ %if.then

--- a/llvm/test/CodeGen/Thumb2/arm_canberra_distance_f32.ll
+++ b/llvm/test/CodeGen/Thumb2/arm_canberra_distance_f32.ll
@@ -15,10 +15,9 @@ define nofpclass(nan inf) float @arm_canberra_distance_f32(ptr noundef readonly 
 ; CHECK-NEXT:    vcmp.f32 s2, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-NEXT:    vcmp.f32 s4, #0
-; CHECK-NEXT:    cset r12, ne
-; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-NEXT:    cset r3, ne
-; CHECK-NEXT:    orr.w r3, r3, r12
+; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-NEXT:    csinc r3, r3, zr, eq
 ; CHECK-NEXT:    lsls r3, r3, #31
 ; CHECK-NEXT:    beq .LBB0_3
 ; CHECK-NEXT:  @ %bb.2: @ %if.then

--- a/llvm/test/CodeGen/Thumb2/csel-andor-onebit.ll
+++ b/llvm/test/CodeGen/Thumb2/csel-andor-onebit.ll
@@ -109,10 +109,9 @@ define i32 @andi32_sgt(i8 %x, i8 %y) {
 define i64 @ori64i32_eq(i64 %x, i32 %y) {
 ; CHECK-LABEL: ori64i32_eq:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    and r0, r0, #1
-; CHECK-NEXT:    cset r1, eq
-; CHECK-NEXT:    orrs r0, r1
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csinc r0, r0, zr, ne
 ; CHECK-NEXT:    movs r1, #0
 ; CHECK-NEXT:    bx lr
   %xa = and i64 %x, 1
@@ -127,8 +126,7 @@ define i64 @ori64i64_eq(i64 %x, i64 %y) {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    orrs.w r1, r2, r3
 ; CHECK-NEXT:    and r0, r0, #1
-; CHECK-NEXT:    cset r1, eq
-; CHECK-NEXT:    orrs r0, r1
+; CHECK-NEXT:    csinc r0, r0, zr, ne
 ; CHECK-NEXT:    movs r1, #0
 ; CHECK-NEXT:    bx lr
   %xa = and i64 %x, 1
@@ -141,10 +139,9 @@ define i64 @ori64i64_eq(i64 %x, i64 %y) {
 define i64 @ori64_eq_c(i64 %x, i32 %y) {
 ; CHECK-LABEL: ori64_eq_c:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    and r0, r0, #1
-; CHECK-NEXT:    cset r1, eq
-; CHECK-NEXT:    orrs r0, r1
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csinc r0, r0, zr, ne
 ; CHECK-NEXT:    movs r1, #0
 ; CHECK-NEXT:    bx lr
   %xa = and i64 %x, 1
@@ -175,14 +172,13 @@ define i64 @andi64_ne(i8 %x, i8 %y) {
 define i32 @t5(i32 %f.0, i32 %call) {
 ; CHECK-LABEL: t5:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    cset r1, ne
 ; CHECK-NEXT:    cmp r0, #13
 ; CHECK-NEXT:    cset r0, eq
-; CHECK-NEXT:    and.w r2, r0, r1
-; CHECK-NEXT:    orrs r0, r1
+; CHECK-NEXT:    cmp r1, #0
+; CHECK-NEXT:    csel r1, zr, r0, eq
+; CHECK-NEXT:    csinc r0, r0, zr, eq
 ; CHECK-NEXT:    eor r0, r0, #1
-; CHECK-NEXT:    orrs r0, r2
+; CHECK-NEXT:    orrs r0, r1
 ; CHECK-NEXT:    bx lr
 entry:
   %tobool1.i = icmp ne i32 %call, 0


### PR DESCRIPTION
This folds (or x, (csinc 0, 0, cc)) -> (csinc x, 0, cc), helping to reduce the number of instructions needed and help with node order changes.