### PR TITLE
[SPIR-V] Fix image query and sampler type

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -2180,13 +2180,15 @@ static bool generateImageSizeQueryInst(const SPIRV::IncomingCall *Call,
     GR->assignSPIRVTypeToVReg(QueryResultType, QueryResult, MIRBuilder.getMF());
   }
   bool IsDimBuf = ImgType->getOperand(2).getImm() == SPIRV::Dim::DIM_Buffer;
+  bool IsMultisampled = ImgType->getOperand(5).getImm() != 0;
+  bool UseQuerySize = IsDimBuf || IsMultisampled;
   unsigned Opcode =
-      IsDimBuf ? SPIRV::OpImageQuerySize : SPIRV::OpImageQuerySizeLod;
+      UseQuerySize ? SPIRV::OpImageQuerySize : SPIRV::OpImageQuerySizeLod;
   auto MIB = MIRBuilder.buildInstr(Opcode)
                  .addDef(QueryResult)
                  .addUse(GR->getSPIRVTypeID(QueryResultType))
                  .addUse(Call->Arguments[0]);
-  if (!IsDimBuf)
+  if (!UseQuerySize)
     MIB.addUse(buildConstantIntReg32(0, MIRBuilder, GR)); // Lod id.
   if (NumExpectedRetComponents == NumActualRetComponents)
     return true;

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpImageReadMS.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpImageReadMS.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUNx: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; StorageImageReadWithoutFormat/StorageImageWriteWithoutFormat implicitly
 ; declare Shader, causing a SPIR-V module to be rejected by the OpenCL

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpImageSampleExplicitLod.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpImageSampleExplicitLod.ll
@@ -1,12 +1,12 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUNx: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-SPIRV-DAG: %[[#RetID:]] = OpImageSampleExplicitLod %[[#RetType:]] %[[#]] %[[#]] Lod %[[#]]
 ; CHECK-SPIRV-DAG: %[[#RetType]] = OpTypeVector %[[#]] 4
 ; CHECK-SPIRV:     %[[#]] = OpCompositeExtract %[[#]] %[[#RetID]] 0
 
-define spir_kernel void @sample_kernel(target("spirv.Image", void, 1, 1, 0, 0, 0, 0, 0) %input, i32 %imageSampler, ptr addrspace(1) %xOffsets, ptr addrspace(1) %yOffsets, ptr addrspace(1) %results) {
+define spir_kernel void @sample_kernel(target("spirv.Image", void, 1, 1, 0, 0, 0, 0, 0) %input, target("spirv.Sampler") %imageSampler, ptr addrspace(1) %xOffsets, ptr addrspace(1) %yOffsets, ptr addrspace(1) %results) {
 entry:
   %call = call spir_func i32 @_Z13get_global_idj(i32 0)
   %call1 = call spir_func i32 @_Z13get_global_idj(i32 1)
@@ -22,13 +22,13 @@ entry:
   %1 = load float, ptr addrspace(1) %arrayidx3, align 4
   %conv4 = fptosi float %1 to i32
   %vecinit5 = insertelement <2 x i32> %vecinit, i32 %conv4, i32 1
-  %call6.tmp.tmp = call spir_func float @_Z11read_imagef20ocl_image2d_depth_ro11ocl_samplerDv2_i(target("spirv.Image", void, 1, 1, 0, 0, 0, 0, 0) %input, i32 %imageSampler, <2 x i32> %vecinit5)
+  %call6.tmp.tmp = call spir_func float @_Z11read_imagef20ocl_image2d_depth_ro11ocl_samplerDv2_i(target("spirv.Image", void, 1, 1, 0, 0, 0, 0, 0) %input, target("spirv.Sampler") %imageSampler, <2 x i32> %vecinit5)
   %arrayidx7 = getelementptr inbounds float, ptr addrspace(1) %results, i32 %add
   store float %call6.tmp.tmp, ptr addrspace(1) %arrayidx7, align 4
   ret void
 }
 
-declare spir_func float @_Z11read_imagef20ocl_image2d_depth_ro11ocl_samplerDv2_i(target("spirv.Image", void, 1, 1, 0, 0, 0, 0, 0), i32, <2 x i32>)
+declare spir_func float @_Z11read_imagef20ocl_image2d_depth_ro11ocl_samplerDv2_i(target("spirv.Image", void, 1, 1, 0, 0, 0, 0, 0), target("spirv.Sampler"), <2 x i32>)
 
 declare spir_func i32 @_Z13get_global_idj(i32)
 


### PR DESCRIPTION
- Use OpImageQuerySize instead of OpImageQuerySizeLod for multisampled SPIR-V spec requires MS=0 for OpImageQuerySizeLod
- Use `target("spirv.Sampler")` instead of i32 for non-constant sampler kernel parameters so they produce OpTypeSampler as required by OpSampledImage

related to https://github.com/llvm/llvm-project/issues/190736