### PR TITLE
[AMDGPU] Fix duplicate s_wait_asynccnt on gfx12-plus

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -1745,6 +1745,8 @@ static std::optional<InstCounterType> counterTypeForInstr(unsigned Opcode) {
     return KM_CNT;
   case AMDGPU::S_WAIT_XCNT:
     return X_CNT;
+  case AMDGPU::S_WAIT_ASYNCCNT:
+    return ASYNC_CNT;
   default:
     return {};
   }

--- a/llvm/test/CodeGen/AMDGPU/asyncmark-gfx12plus.ll
+++ b/llvm/test/CodeGen/AMDGPU/asyncmark-gfx12plus.ll
@@ -248,7 +248,6 @@ define amdgpu_kernel void @test_pipelined_loop_with_global(ptr addrspace(1) %foo
 ; GFX1250-NEXT:    ; asyncmark
 ; GFX1250-NEXT:    ; wait_asyncmark(2)
 ; GFX1250-NEXT:    s_wait_asynccnt 0x2
-; GFX1250-NEXT:    s_wait_asynccnt 0x2
 ; GFX1250-NEXT:    s_add_co_i32 s8, s8, 1
 ; GFX1250-NEXT:    s_add_co_i32 s9, s9, 4
 ; GFX1250-NEXT:    ds_load_b32 v9, v9


### PR DESCRIPTION
S_WAIT_ASYNCCNT was missing from counterTypeForInstr(), so isWaitInstr() did not recognize it as a wait instruction. On the fixpoint algorithm's second pass over a loop body, the already-inserted S_WAIT_ASYNCCNT was treated as a normal instruction, causing WAIT_ASYNCMARK to be re-processed and a duplicate S_WAIT_ASYNCCNT to be emitted.

Assisted-By: Claude Opus 4.6