### PR TITLE
[LLVM][CodeGen][AArch64] Improve generated code for SVE VLS truncates.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -17189,6 +17189,10 @@ SDValue AArch64TargetLowering::LowerTRUNCATE(SDValue Op,
                                    !Subtarget->isNeonAvailable()))
     return LowerFixedLengthVectorTruncateToSVE(Op, DAG);
 
+  // We can select these directly.
+  if (VT.is64BitVector() && Op.getOperand(0).getValueType().is128BitVector())
+    return Op;
+
   return SDValue();
 }
 

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-fp-to-int.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-fp-to-int.ll
@@ -325,15 +325,8 @@ define <2 x i16> @fcvtzu_v2f32_v2i16(<2 x float> %op1) vscale_range(2,0) #0 {
 define <4 x i16> @fcvtzu_v4f32_v4i16(<4 x float> %op1) vscale_range(2,0) #0 {
 ; CHECK-LABEL: fcvtzu_v4f32_v4i16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    fcvtzu v1.4s, v0.4s
-; CHECK-NEXT:    mov w8, v1.s[1]
-; CHECK-NEXT:    mov v0.16b, v1.16b
-; CHECK-NEXT:    mov w9, v1.s[2]
-; CHECK-NEXT:    mov v0.h[1], w8
-; CHECK-NEXT:    mov w8, v1.s[3]
-; CHECK-NEXT:    mov v0.h[2], w9
-; CHECK-NEXT:    mov v0.h[3], w8
-; CHECK-NEXT:    // kill: def $d0 killed $d0 killed $q0
+; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    xtn v0.4h, v0.4s
 ; CHECK-NEXT:    ret
   %res = fptoui <4 x float> %op1 to <4 x i16>
   ret <4 x i16> %res
@@ -1219,15 +1212,8 @@ define <2 x i16> @fcvtzs_v2f32_v2i16(<2 x float> %op1) vscale_range(2,0) #0 {
 define <4 x i16> @fcvtzs_v4f32_v4i16(<4 x float> %op1) vscale_range(2,0) #0 {
 ; CHECK-LABEL: fcvtzs_v4f32_v4i16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    fcvtzs v1.4s, v0.4s
-; CHECK-NEXT:    mov w8, v1.s[1]
-; CHECK-NEXT:    mov v0.16b, v1.16b
-; CHECK-NEXT:    mov w9, v1.s[2]
-; CHECK-NEXT:    mov v0.h[1], w8
-; CHECK-NEXT:    mov w8, v1.s[3]
-; CHECK-NEXT:    mov v0.h[2], w9
-; CHECK-NEXT:    mov v0.h[3], w8
-; CHECK-NEXT:    // kill: def $d0 killed $d0 killed $q0
+; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    xtn v0.4h, v0.4s
 ; CHECK-NEXT:    ret
   %res = fptosi <4 x float> %op1 to <4 x i16>
   ret <4 x i16> %res

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-int-div.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-int-div.ll
@@ -11,7 +11,6 @@ target triple = "aarch64-unknown-linux-gnu"
 ;
 
 ; Vector vXi8 sdiv are not legal for NEON so use SVE when available.
-; FIXME: We should be able to improve the codegen for >= 256 bits here.
 define <8 x i8> @sdiv_v8i8(<8 x i8> %op1, <8 x i8> %op2) #0 {
 ; VBITS_GE_128-LABEL: sdiv_v8i8:
 ; VBITS_GE_128:       // %bb.0:
@@ -38,24 +37,8 @@ define <8 x i8> @sdiv_v8i8(<8 x i8> %op1, <8 x i8> %op2) #0 {
 ; VBITS_GE_256-NEXT:    sunpklo z1.s, z1.h
 ; VBITS_GE_256-NEXT:    sunpklo z0.s, z0.h
 ; VBITS_GE_256-NEXT:    sdiv z0.s, p0/m, z0.s, z1.s
-; VBITS_GE_256-NEXT:    uzp1 z1.h, z0.h, z0.h
-; VBITS_GE_256-NEXT:    umov w8, v1.h[0]
-; VBITS_GE_256-NEXT:    umov w9, v1.h[1]
-; VBITS_GE_256-NEXT:    fmov s0, w8
-; VBITS_GE_256-NEXT:    umov w8, v1.h[2]
-; VBITS_GE_256-NEXT:    mov v0.b[1], w9
-; VBITS_GE_256-NEXT:    mov v0.b[2], w8
-; VBITS_GE_256-NEXT:    umov w8, v1.h[3]
-; VBITS_GE_256-NEXT:    mov v0.b[3], w8
-; VBITS_GE_256-NEXT:    umov w8, v1.h[4]
-; VBITS_GE_256-NEXT:    mov v0.b[4], w8
-; VBITS_GE_256-NEXT:    umov w8, v1.h[5]
-; VBITS_GE_256-NEXT:    mov v0.b[5], w8
-; VBITS_GE_256-NEXT:    umov w8, v1.h[6]
-; VBITS_GE_256-NEXT:    mov v0.b[6], w8
-; VBITS_GE_256-NEXT:    umov w8, v1.h[7]
-; VBITS_GE_256-NEXT:    mov v0.b[7], w8
-; VBITS_GE_256-NEXT:    // kill: def $d0 killed $d0 killed $q0
+; VBITS_GE_256-NEXT:    uzp1 z0.h, z0.h, z0.h
+; VBITS_GE_256-NEXT:    xtn v0.8b, v0.8h
 ; VBITS_GE_256-NEXT:    ret
 ;
 ; VBITS_GE_512-LABEL: sdiv_v8i8:
@@ -68,24 +51,8 @@ define <8 x i8> @sdiv_v8i8(<8 x i8> %op1, <8 x i8> %op2) #0 {
 ; VBITS_GE_512-NEXT:    sunpklo z1.s, z1.h
 ; VBITS_GE_512-NEXT:    sunpklo z0.s, z0.h
 ; VBITS_GE_512-NEXT:    sdiv z0.s, p0/m, z0.s, z1.s
-; VBITS_GE_512-NEXT:    uzp1 z1.h, z0.h, z0.h
-; VBITS_GE_512-NEXT:    umov w8, v1.h[0]
-; VBITS_GE_512-NEXT:    umov w9, v1.h[1]
-; VBITS_GE_512-NEXT:    fmov s0, w8
-; VBITS_GE_512-NEXT:    umov w8, v1.h[2]
-; VBITS_GE_512-NEXT:    mov v0.b[1], w9
-; VBITS_GE_512-NEXT:    mov v0.b[2], w8
-; VBITS_GE_512-NEXT:    umov w8, v1.h[3]
-; VBITS_GE_512-NEXT:    mov v0.b[3], w8
-; VBITS_GE_512-NEXT:    umov w8, v1.h[4]
-; VBITS_GE_512-NEXT:    mov v0.b[4], w8
-; VBITS_GE_512-NEXT:    umov w8, v1.h[5]
-; VBITS_GE_512-NEXT:    mov v0.b[5], w8
-; VBITS_GE_512-NEXT:    umov w8, v1.h[6]
-; VBITS_GE_512-NEXT:    mov v0.b[6], w8
-; VBITS_GE_512-NEXT:    umov w8, v1.h[7]
-; VBITS_GE_512-NEXT:    mov v0.b[7], w8
-; VBITS_GE_512-NEXT:    // kill: def $d0 killed $d0 killed $q0
+; VBITS_GE_512-NEXT:    uzp1 z0.h, z0.h, z0.h
+; VBITS_GE_512-NEXT:    xtn v0.8b, v0.8h
 ; VBITS_GE_512-NEXT:    ret
   %res = sdiv <8 x i8> %op1, %op2
   ret <8 x i8> %res
@@ -280,48 +247,15 @@ define void @sdiv_v256i8(ptr %a, ptr %b) vscale_range(16,0) #0 {
 }
 
 ; Vector vXi16 sdiv are not legal for NEON so use SVE when available.
-; FIXME: We should be able to improve the codegen for >= 256 bits here.
 define <4 x i16> @sdiv_v4i16(<4 x i16> %op1, <4 x i16> %op2) #0 {
-; VBITS_GE_128-LABEL: sdiv_v4i16:
-; VBITS_GE_128:       // %bb.0:
-; VBITS_GE_128-NEXT:    sshll v1.4s, v1.4h, #0
-; VBITS_GE_128-NEXT:    sshll v0.4s, v0.4h, #0
-; VBITS_GE_128-NEXT:    ptrue p0.s, vl4
-; VBITS_GE_128-NEXT:    sdiv z0.s, p0/m, z0.s, z1.s
-; VBITS_GE_128-NEXT:    xtn v0.4h, v0.4s
-; VBITS_GE_128-NEXT:    ret
-;
-; VBITS_GE_256-LABEL: sdiv_v4i16:
-; VBITS_GE_256:       // %bb.0:
-; VBITS_GE_256-NEXT:    sshll v1.4s, v1.4h, #0
-; VBITS_GE_256-NEXT:    sshll v0.4s, v0.4h, #0
-; VBITS_GE_256-NEXT:    ptrue p0.s, vl4
-; VBITS_GE_256-NEXT:    sdivr z1.s, p0/m, z1.s, z0.s
-; VBITS_GE_256-NEXT:    mov w8, v1.s[1]
-; VBITS_GE_256-NEXT:    mov v0.16b, v1.16b
-; VBITS_GE_256-NEXT:    mov w9, v1.s[2]
-; VBITS_GE_256-NEXT:    mov v0.h[1], w8
-; VBITS_GE_256-NEXT:    mov w8, v1.s[3]
-; VBITS_GE_256-NEXT:    mov v0.h[2], w9
-; VBITS_GE_256-NEXT:    mov v0.h[3], w8
-; VBITS_GE_256-NEXT:    // kill: def $d0 killed $d0 killed $q0
-; VBITS_GE_256-NEXT:    ret
-;
-; VBITS_GE_512-LABEL: sdiv_v4i16:
-; VBITS_GE_512:       // %bb.0:
-; VBITS_GE_512-NEXT:    sshll v1.4s, v1.4h, #0
-; VBITS_GE_512-NEXT:    sshll v0.4s, v0.4h, #0
-; VBITS_GE_512-NEXT:    ptrue p0.s, vl4
-; VBITS_GE_512-NEXT:    sdivr z1.s, p0/m, z1.s, z0.s
-; VBITS_GE_512-NEXT:    mov w8, v1.s[1]
-; VBITS_GE_512-NEXT:    mov v0.16b, v1.16b
-; VBITS_GE_512-NEXT:    mov w9, v1.s[2]
-; VBITS_GE_512-NEXT:    mov v0.h[1], w8
-; VBITS_GE_512-NEXT:    mov w8, v1.s[3]
-; VBITS_GE_512-NEXT:    mov v0.h[2], w9
-; VBITS_GE_512-NEXT:    mov v0.h[3], w8
-; VBITS_GE_512-NEXT:    // kill: def $d0 killed $d0 killed $q0
-; VBITS_GE_512-NEXT:    ret
+; CHECK-LABEL: sdiv_v4i16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    sshll v1.4s, v1.4h, #0
+; CHECK-NEXT:    sshll v0.4s, v0.4h, #0
+; CHECK-NEXT:    ptrue p0.s, vl4
+; CHECK-NEXT:    sdiv z0.s, p0/m, z0.s, z1.s
+; CHECK-NEXT:    xtn v0.4h, v0.4s
+; CHECK-NEXT:    ret
   %res = sdiv <4 x i16> %op1, %op2
   ret <4 x i16> %res
 }
@@ -744,7 +678,6 @@ define void @sdiv_v32i64(ptr %a, ptr %b) vscale_range(16,0) #0 {
 ;
 
 ; Vector vXi8 udiv are not legal for NEON so use SVE when available.
-; FIXME: We should be able to improve the codegen for >= 256 bits here.
 define <8 x i8> @udiv_v8i8(<8 x i8> %op1, <8 x i8> %op2) #0 {
 ; VBITS_GE_128-LABEL: udiv_v8i8:
 ; VBITS_GE_128:       // %bb.0:
@@ -771,24 +704,8 @@ define <8 x i8> @udiv_v8i8(<8 x i8> %op1, <8 x i8> %op2) #0 {
 ; VBITS_GE_256-NEXT:    uunpklo z1.s, z1.h
 ; VBITS_GE_256-NEXT:    uunpklo z0.s, z0.h
 ; VBITS_GE_256-NEXT:    udiv z0.s, p0/m, z0.s, z1.s
-; VBITS_GE_256-NEXT:    uzp1 z1.h, z0.h, z0.h
-; VBITS_GE_256-NEXT:    umov w8, v1.h[0]
-; VBITS_GE_256-NEXT:    umov w9, v1.h[1]
-; VBITS_GE_256-NEXT:    fmov s0, w8
-; VBITS_GE_256-NEXT:    umov w8, v1.h[2]
-; VBITS_GE_256-NEXT:    mov v0.b[1], w9
-; VBITS_GE_256-NEXT:    mov v0.b[2], w8
-; VBITS_GE_256-NEXT:    umov w8, v1.h[3]
-; VBITS_GE_256-NEXT:    mov v0.b[3], w8
-; VBITS_GE_256-NEXT:    umov w8, v1.h[4]
-; VBITS_GE_256-NEXT:    mov v0.b[4], w8
-; VBITS_GE_256-NEXT:    umov w8, v1.h[5]
-; VBITS_GE_256-NEXT:    mov v0.b[5], w8
-; VBITS_GE_256-NEXT:    umov w8, v1.h[6]
-; VBITS_GE_256-NEXT:    mov v0.b[6], w8
-; VBITS_GE_256-NEXT:    umov w8, v1.h[7]
-; VBITS_GE_256-NEXT:    mov v0.b[7], w8
-; VBITS_GE_256-NEXT:    // kill: def $d0 killed $d0 killed $q0
+; VBITS_GE_256-NEXT:    uzp1 z0.h, z0.h, z0.h
+; VBITS_GE_256-NEXT:    xtn v0.8b, v0.8h
 ; VBITS_GE_256-NEXT:    ret
 ;
 ; VBITS_GE_512-LABEL: udiv_v8i8:
@@ -801,24 +718,8 @@ define <8 x i8> @udiv_v8i8(<8 x i8> %op1, <8 x i8> %op2) #0 {
 ; VBITS_GE_512-NEXT:    uunpklo z1.s, z1.h
 ; VBITS_GE_512-NEXT:    uunpklo z0.s, z0.h
 ; VBITS_GE_512-NEXT:    udiv z0.s, p0/m, z0.s, z1.s
-; VBITS_GE_512-NEXT:    uzp1 z1.h, z0.h, z0.h
-; VBITS_GE_512-NEXT:    umov w8, v1.h[0]
-; VBITS_GE_512-NEXT:    umov w9, v1.h[1]
-; VBITS_GE_512-NEXT:    fmov s0, w8
-; VBITS_GE_512-NEXT:    umov w8, v1.h[2]
-; VBITS_GE_512-NEXT:    mov v0.b[1], w9
-; VBITS_GE_512-NEXT:    mov v0.b[2], w8
-; VBITS_GE_512-NEXT:    umov w8, v1.h[3]
-; VBITS_GE_512-NEXT:    mov v0.b[3], w8
-; VBITS_GE_512-NEXT:    umov w8, v1.h[4]
-; VBITS_GE_512-NEXT:    mov v0.b[4], w8
-; VBITS_GE_512-NEXT:    umov w8, v1.h[5]
-; VBITS_GE_512-NEXT:    mov v0.b[5], w8
-; VBITS_GE_512-NEXT:    umov w8, v1.h[6]
-; VBITS_GE_512-NEXT:    mov v0.b[6], w8
-; VBITS_GE_512-NEXT:    umov w8, v1.h[7]
-; VBITS_GE_512-NEXT:    mov v0.b[7], w8
-; VBITS_GE_512-NEXT:    // kill: def $d0 killed $d0 killed $q0
+; VBITS_GE_512-NEXT:    uzp1 z0.h, z0.h, z0.h
+; VBITS_GE_512-NEXT:    xtn v0.8b, v0.8h
 ; VBITS_GE_512-NEXT:    ret
   %res = udiv <8 x i8> %op1, %op2
   ret <8 x i8> %res
@@ -1000,48 +901,15 @@ define void @udiv_v256i8(ptr %a, ptr %b) vscale_range(16,0) #0 {
 }
 
 ; Vector vXi16 udiv are not legal for NEON so use SVE when available.
-; FIXME: We should be able to improve the codegen for >= 256 bits here.
 define <4 x i16> @udiv_v4i16(<4 x i16> %op1, <4 x i16> %op2) #0 {
-; VBITS_GE_128-LABEL: udiv_v4i16:
-; VBITS_GE_128:       // %bb.0:
-; VBITS_GE_128-NEXT:    ushll v1.4s, v1.4h, #0
-; VBITS_GE_128-NEXT:    ushll v0.4s, v0.4h, #0
-; VBITS_GE_128-NEXT:    ptrue p0.s, vl4
-; VBITS_GE_128-NEXT:    udiv z0.s, p0/m, z0.s, z1.s
-; VBITS_GE_128-NEXT:    xtn v0.4h, v0.4s
-; VBITS_GE_128-NEXT:    ret
-;
-; VBITS_GE_256-LABEL: udiv_v4i16:
-; VBITS_GE_256:       // %bb.0:
-; VBITS_GE_256-NEXT:    ushll v1.4s, v1.4h, #0
-; VBITS_GE_256-NEXT:    ushll v0.4s, v0.4h, #0
-; VBITS_GE_256-NEXT:    ptrue p0.s, vl4
-; VBITS_GE_256-NEXT:    udivr z1.s, p0/m, z1.s, z0.s
-; VBITS_GE_256-NEXT:    mov w8, v1.s[1]
-; VBITS_GE_256-NEXT:    mov v0.16b, v1.16b
-; VBITS_GE_256-NEXT:    mov w9, v1.s[2]
-; VBITS_GE_256-NEXT:    mov v0.h[1], w8
-; VBITS_GE_256-NEXT:    mov w8, v1.s[3]
-; VBITS_GE_256-NEXT:    mov v0.h[2], w9
-; VBITS_GE_256-NEXT:    mov v0.h[3], w8
-; VBITS_GE_256-NEXT:    // kill: def $d0 killed $d0 killed $q0
-; VBITS_GE_256-NEXT:    ret
-;
-; VBITS_GE_512-LABEL: udiv_v4i16:
-; VBITS_GE_512:       // %bb.0:
-; VBITS_GE_512-NEXT:    ushll v1.4s, v1.4h, #0
-; VBITS_GE_512-NEXT:    ushll v0.4s, v0.4h, #0
-; VBITS_GE_512-NEXT:    ptrue p0.s, vl4
-; VBITS_GE_512-NEXT:    udivr z1.s, p0/m, z1.s, z0.s
-; VBITS_GE_512-NEXT:    mov w8, v1.s[1]
-; VBITS_GE_512-NEXT:    mov v0.16b, v1.16b
-; VBITS_GE_512-NEXT:    mov w9, v1.s[2]
-; VBITS_GE_512-NEXT:    mov v0.h[1], w8
-; VBITS_GE_512-NEXT:    mov w8, v1.s[3]
-; VBITS_GE_512-NEXT:    mov v0.h[2], w9
-; VBITS_GE_512-NEXT:    mov v0.h[3], w8
-; VBITS_GE_512-NEXT:    // kill: def $d0 killed $d0 killed $q0
-; VBITS_GE_512-NEXT:    ret
+; CHECK-LABEL: udiv_v4i16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ushll v1.4s, v1.4h, #0
+; CHECK-NEXT:    ushll v0.4s, v0.4h, #0
+; CHECK-NEXT:    ptrue p0.s, vl4
+; CHECK-NEXT:    udiv z0.s, p0/m, z0.s, z1.s
+; CHECK-NEXT:    xtn v0.4h, v0.4s
+; CHECK-NEXT:    ret
   %res = udiv <4 x i16> %op1, %op2
   ret <4 x i16> %res
 }

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-int-rem.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-int-rem.ll
@@ -11,7 +11,6 @@ target triple = "aarch64-unknown-linux-gnu"
 ;
 
 ; Vector vXi8 sdiv are not legal for NEON so use SVE when available.
-; FIXME: We should be able to improve the codegen for >= 256 bits here.
 define <8 x i8> @srem_v8i8(<8 x i8> %op1, <8 x i8> %op2) #0 {
 ; VBITS_GE_128-LABEL: srem_v8i8:
 ; VBITS_GE_128:       // %bb.0:
@@ -40,23 +39,8 @@ define <8 x i8> @srem_v8i8(<8 x i8> %op1, <8 x i8> %op2) #0 {
 ; VBITS_GE_256-NEXT:    sunpklo z3.s, z3.h
 ; VBITS_GE_256-NEXT:    sdivr z2.s, p0/m, z2.s, z3.s
 ; VBITS_GE_256-NEXT:    uzp1 z2.h, z2.h, z2.h
-; VBITS_GE_256-NEXT:    umov w8, v2.h[0]
-; VBITS_GE_256-NEXT:    umov w9, v2.h[1]
-; VBITS_GE_256-NEXT:    fmov s3, w8
-; VBITS_GE_256-NEXT:    umov w8, v2.h[2]
-; VBITS_GE_256-NEXT:    mov v3.b[1], w9
-; VBITS_GE_256-NEXT:    mov v3.b[2], w8
-; VBITS_GE_256-NEXT:    umov w8, v2.h[3]
-; VBITS_GE_256-NEXT:    mov v3.b[3], w8
-; VBITS_GE_256-NEXT:    umov w8, v2.h[4]
-; VBITS_GE_256-NEXT:    mov v3.b[4], w8
-; VBITS_GE_256-NEXT:    umov w8, v2.h[5]
-; VBITS_GE_256-NEXT:    mov v3.b[5], w8
-; VBITS_GE_256-NEXT:    umov w8, v2.h[6]
-; VBITS_GE_256-NEXT:    mov v3.b[6], w8
-; VBITS_GE_256-NEXT:    umov w8, v2.h[7]
-; VBITS_GE_256-NEXT:    mov v3.b[7], w8
-; VBITS_GE_256-NEXT:    mls v0.8b, v3.8b, v1.8b
+; VBITS_GE_256-NEXT:    xtn v2.8b, v2.8h
+; VBITS_GE_256-NEXT:    mls v0.8b, v2.8b, v1.8b
 ; VBITS_GE_256-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; VBITS_GE_256-NEXT:    ret
 ;
@@ -71,23 +55,8 @@ define <8 x i8> @srem_v8i8(<8 x i8> %op1, <8 x i8> %op2) #0 {
 ; VBITS_GE_512-NEXT:    sunpklo z3.s, z3.h
 ; VBITS_GE_512-NEXT:    sdivr z2.s, p0/m, z2.s, z3.s
 ; VBITS_GE_512-NEXT:    uzp1 z2.h, z2.h, z2.h
-; VBITS_GE_512-NEXT:    umov w8, v2.h[0]
-; VBITS_GE_512-NEXT:    umov w9, v2.h[1]
-; VBITS_GE_512-NEXT:    fmov s3, w8
-; VBITS_GE_512-NEXT:    umov w8, v2.h[2]
-; VBITS_GE_512-NEXT:    mov v3.b[1], w9
-; VBITS_GE_512-NEXT:    mov v3.b[2], w8
-; VBITS_GE_512-NEXT:    umov w8, v2.h[3]
-; VBITS_GE_512-NEXT:    mov v3.b[3], w8
-; VBITS_GE_512-NEXT:    umov w8, v2.h[4]
-; VBITS_GE_512-NEXT:    mov v3.b[4], w8
-; VBITS_GE_512-NEXT:    umov w8, v2.h[5]
-; VBITS_GE_512-NEXT:    mov v3.b[5], w8
-; VBITS_GE_512-NEXT:    umov w8, v2.h[6]
-; VBITS_GE_512-NEXT:    mov v3.b[6], w8
-; VBITS_GE_512-NEXT:    umov w8, v2.h[7]
-; VBITS_GE_512-NEXT:    mov v3.b[7], w8
-; VBITS_GE_512-NEXT:    mls v0.8b, v3.8b, v1.8b
+; VBITS_GE_512-NEXT:    xtn v2.8b, v2.8h
+; VBITS_GE_512-NEXT:    mls v0.8b, v2.8b, v1.8b
 ; VBITS_GE_512-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; VBITS_GE_512-NEXT:    ret
   %res = srem <8 x i8> %op1, %op2
@@ -296,49 +265,16 @@ define void @srem_v256i8(ptr %a, ptr %b) vscale_range(16,0) #0 {
 }
 
 ; Vector vXi16 sdiv are not legal for NEON so use SVE when available.
-; FIXME: We should be able to improve the codegen for >= 256 bits here.
 define <4 x i16> @srem_v4i16(<4 x i16> %op1, <4 x i16> %op2) #0 {
-; VBITS_GE_128-LABEL: srem_v4i16:
-; VBITS_GE_128:       // %bb.0:
-; VBITS_GE_128-NEXT:    sshll v2.4s, v1.4h, #0
-; VBITS_GE_128-NEXT:    sshll v3.4s, v0.4h, #0
-; VBITS_GE_128-NEXT:    ptrue p0.s, vl4
-; VBITS_GE_128-NEXT:    sdivr z2.s, p0/m, z2.s, z3.s
-; VBITS_GE_128-NEXT:    xtn v2.4h, v2.4s
-; VBITS_GE_128-NEXT:    mls v0.4h, v2.4h, v1.4h
-; VBITS_GE_128-NEXT:    ret
-;
-; VBITS_GE_256-LABEL: srem_v4i16:
-; VBITS_GE_256:       // %bb.0:
-; VBITS_GE_256-NEXT:    sshll v2.4s, v1.4h, #0
-; VBITS_GE_256-NEXT:    sshll v3.4s, v0.4h, #0
-; VBITS_GE_256-NEXT:    ptrue p0.s, vl4
-; VBITS_GE_256-NEXT:    sdivr z2.s, p0/m, z2.s, z3.s
-; VBITS_GE_256-NEXT:    mov w8, v2.s[1]
-; VBITS_GE_256-NEXT:    mov v3.16b, v2.16b
-; VBITS_GE_256-NEXT:    mov w9, v2.s[2]
-; VBITS_GE_256-NEXT:    mov v3.h[1], w8
-; VBITS_GE_256-NEXT:    mov w8, v2.s[3]
-; VBITS_GE_256-NEXT:    mov v3.h[2], w9
-; VBITS_GE_256-NEXT:    mov v3.h[3], w8
-; VBITS_GE_256-NEXT:    mls v0.4h, v3.4h, v1.4h
-; VBITS_GE_256-NEXT:    ret
-;
-; VBITS_GE_512-LABEL: srem_v4i16:
-; VBITS_GE_512:       // %bb.0:
-; VBITS_GE_512-NEXT:    sshll v2.4s, v1.4h, #0
-; VBITS_GE_512-NEXT:    sshll v3.4s, v0.4h, #0
-; VBITS_GE_512-NEXT:    ptrue p0.s, vl4
-; VBITS_GE_512-NEXT:    sdivr z2.s, p0/m, z2.s, z3.s
-; VBITS_GE_512-NEXT:    mov w8, v2.s[1]
-; VBITS_GE_512-NEXT:    mov v3.16b, v2.16b
-; VBITS_GE_512-NEXT:    mov w9, v2.s[2]
-; VBITS_GE_512-NEXT:    mov v3.h[1], w8
-; VBITS_GE_512-NEXT:    mov w8, v2.s[3]
-; VBITS_GE_512-NEXT:    mov v3.h[2], w9
-; VBITS_GE_512-NEXT:    mov v3.h[3], w8
-; VBITS_GE_512-NEXT:    mls v0.4h, v3.4h, v1.4h
-; VBITS_GE_512-NEXT:    ret
+; CHECK-LABEL: srem_v4i16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    sshll v2.4s, v1.4h, #0
+; CHECK-NEXT:    sshll v3.4s, v0.4h, #0
+; CHECK-NEXT:    ptrue p0.s, vl4
+; CHECK-NEXT:    sdivr z2.s, p0/m, z2.s, z3.s
+; CHECK-NEXT:    xtn v2.4h, v2.4s
+; CHECK-NEXT:    mls v0.4h, v2.4h, v1.4h
+; CHECK-NEXT:    ret
   %res = srem <4 x i16> %op1, %op2
   ret <4 x i16> %res
 }
@@ -675,7 +611,6 @@ define void @srem_v64i32(ptr %a, ptr %b) vscale_range(16,0) #0 {
 }
 
 ; Vector i64 sdiv are not legal for NEON so use SVE when available.
-; FIXME: We should be able to improve the codegen for the 128 bits case here.
 define <1 x i64> @srem_v1i64(<1 x i64> %op1, <1 x i64> %op2) vscale_range(1,0) #0 {
 ; CHECK-LABEL: srem_v1i64:
 ; CHECK:       // %bb.0:
@@ -692,7 +627,6 @@ define <1 x i64> @srem_v1i64(<1 x i64> %op1, <1 x i64> %op2) vscale_range(1,0) #
 }
 
 ; Vector i64 sdiv are not legal for NEON so use SVE when available.
-; FIXME: We should be able to improve the codegen for the 128 bits case here.
 define <2 x i64> @srem_v2i64(<2 x i64> %op1, <2 x i64> %op2) vscale_range(1,0) #0 {
 ; CHECK-LABEL: srem_v2i64:
 ; CHECK:       // %bb.0:
@@ -826,7 +760,6 @@ define void @srem_v32i64(ptr %a, ptr %b) vscale_range(16,0) #0 {
 ;
 
 ; Vector vXi8 udiv are not legal for NEON so use SVE when available.
-; FIXME: We should be able to improve the codegen for >= 256 bits here.
 define <8 x i8> @urem_v8i8(<8 x i8> %op1, <8 x i8> %op2) #0 {
 ; VBITS_GE_128-LABEL: urem_v8i8:
 ; VBITS_GE_128:       // %bb.0:
@@ -855,23 +788,8 @@ define <8 x i8> @urem_v8i8(<8 x i8> %op1, <8 x i8> %op2) #0 {
 ; VBITS_GE_256-NEXT:    uunpklo z3.s, z3.h
 ; VBITS_GE_256-NEXT:    udivr z2.s, p0/m, z2.s, z3.s
 ; VBITS_GE_256-NEXT:    uzp1 z2.h, z2.h, z2.h
-; VBITS_GE_256-NEXT:    umov w8, v2.h[0]
-; VBITS_GE_256-NEXT:    umov w9, v2.h[1]
-; VBITS_GE_256-NEXT:    fmov s3, w8
-; VBITS_GE_256-NEXT:    umov w8, v2.h[2]
-; VBITS_GE_256-NEXT:    mov v3.b[1], w9
-; VBITS_GE_256-NEXT:    mov v3.b[2], w8
-; VBITS_GE_256-NEXT:    umov w8, v2.h[3]
-; VBITS_GE_256-NEXT:    mov v3.b[3], w8
-; VBITS_GE_256-NEXT:    umov w8, v2.h[4]
-; VBITS_GE_256-NEXT:    mov v3.b[4], w8
-; VBITS_GE_256-NEXT:    umov w8, v2.h[5]
-; VBITS_GE_256-NEXT:    mov v3.b[5], w8
-; VBITS_GE_256-NEXT:    umov w8, v2.h[6]
-; VBITS_GE_256-NEXT:    mov v3.b[6], w8
-; VBITS_GE_256-NEXT:    umov w8, v2.h[7]
-; VBITS_GE_256-NEXT:    mov v3.b[7], w8
-; VBITS_GE_256-NEXT:    mls v0.8b, v3.8b, v1.8b
+; VBITS_GE_256-NEXT:    xtn v2.8b, v2.8h
+; VBITS_GE_256-NEXT:    mls v0.8b, v2.8b, v1.8b
 ; VBITS_GE_256-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; VBITS_GE_256-NEXT:    ret
 ;
@@ -886,23 +804,8 @@ define <8 x i8> @urem_v8i8(<8 x i8> %op1, <8 x i8> %op2) #0 {
 ; VBITS_GE_512-NEXT:    uunpklo z3.s, z3.h
 ; VBITS_GE_512-NEXT:    udivr z2.s, p0/m, z2.s, z3.s
 ; VBITS_GE_512-NEXT:    uzp1 z2.h, z2.h, z2.h
-; VBITS_GE_512-NEXT:    umov w8, v2.h[0]
-; VBITS_GE_512-NEXT:    umov w9, v2.h[1]
-; VBITS_GE_512-NEXT:    fmov s3, w8
-; VBITS_GE_512-NEXT:    umov w8, v2.h[2]
-; VBITS_GE_512-NEXT:    mov v3.b[1], w9
-; VBITS_GE_512-NEXT:    mov v3.b[2], w8
-; VBITS_GE_512-NEXT:    umov w8, v2.h[3]
-; VBITS_GE_512-NEXT:    mov v3.b[3], w8
-; VBITS_GE_512-NEXT:    umov w8, v2.h[4]
-; VBITS_GE_512-NEXT:    mov v3.b[4], w8
-; VBITS_GE_512-NEXT:    umov w8, v2.h[5]
-; VBITS_GE_512-NEXT:    mov v3.b[5], w8
-; VBITS_GE_512-NEXT:    umov w8, v2.h[6]
-; VBITS_GE_512-NEXT:    mov v3.b[6], w8
-; VBITS_GE_512-NEXT:    umov w8, v2.h[7]
-; VBITS_GE_512-NEXT:    mov v3.b[7], w8
-; VBITS_GE_512-NEXT:    mls v0.8b, v3.8b, v1.8b
+; VBITS_GE_512-NEXT:    xtn v2.8b, v2.8h
+; VBITS_GE_512-NEXT:    mls v0.8b, v2.8b, v1.8b
 ; VBITS_GE_512-NEXT:    // kill: def $d0 killed $d0 killed $z0
 ; VBITS_GE_512-NEXT:    ret
   %res = urem <8 x i8> %op1, %op2
@@ -1111,49 +1014,16 @@ define void @urem_v256i8(ptr %a, ptr %b) vscale_range(16,0) #0 {
 }
 
 ; Vector vXi16 udiv are not legal for NEON so use SVE when available.
-; FIXME: We should be able to improve the codegen for >= 256 bits here.
 define <4 x i16> @urem_v4i16(<4 x i16> %op1, <4 x i16> %op2) #0 {
-; VBITS_GE_128-LABEL: urem_v4i16:
-; VBITS_GE_128:       // %bb.0:
-; VBITS_GE_128-NEXT:    ushll v2.4s, v1.4h, #0
-; VBITS_GE_128-NEXT:    ushll v3.4s, v0.4h, #0
-; VBITS_GE_128-NEXT:    ptrue p0.s, vl4
-; VBITS_GE_128-NEXT:    udivr z2.s, p0/m, z2.s, z3.s
-; VBITS_GE_128-NEXT:    xtn v2.4h, v2.4s
-; VBITS_GE_128-NEXT:    mls v0.4h, v2.4h, v1.4h
-; VBITS_GE_128-NEXT:    ret
-;
-; VBITS_GE_256-LABEL: urem_v4i16:
-; VBITS_GE_256:       // %bb.0:
-; VBITS_GE_256-NEXT:    ushll v2.4s, v1.4h, #0
-; VBITS_GE_256-NEXT:    ushll v3.4s, v0.4h, #0
-; VBITS_GE_256-NEXT:    ptrue p0.s, vl4
-; VBITS_GE_256-NEXT:    udivr z2.s, p0/m, z2.s, z3.s
-; VBITS_GE_256-NEXT:    mov w8, v2.s[1]
-; VBITS_GE_256-NEXT:    mov v3.16b, v2.16b
-; VBITS_GE_256-NEXT:    mov w9, v2.s[2]
-; VBITS_GE_256-NEXT:    mov v3.h[1], w8
-; VBITS_GE_256-NEXT:    mov w8, v2.s[3]
-; VBITS_GE_256-NEXT:    mov v3.h[2], w9
-; VBITS_GE_256-NEXT:    mov v3.h[3], w8
-; VBITS_GE_256-NEXT:    mls v0.4h, v3.4h, v1.4h
-; VBITS_GE_256-NEXT:    ret
-;
-; VBITS_GE_512-LABEL: urem_v4i16:
-; VBITS_GE_512:       // %bb.0:
-; VBITS_GE_512-NEXT:    ushll v2.4s, v1.4h, #0
-; VBITS_GE_512-NEXT:    ushll v3.4s, v0.4h, #0
-; VBITS_GE_512-NEXT:    ptrue p0.s, vl4
-; VBITS_GE_512-NEXT:    udivr z2.s, p0/m, z2.s, z3.s
-; VBITS_GE_512-NEXT:    mov w8, v2.s[1]
-; VBITS_GE_512-NEXT:    mov v3.16b, v2.16b
-; VBITS_GE_512-NEXT:    mov w9, v2.s[2]
-; VBITS_GE_512-NEXT:    mov v3.h[1], w8
-; VBITS_GE_512-NEXT:    mov w8, v2.s[3]
-; VBITS_GE_512-NEXT:    mov v3.h[2], w9
-; VBITS_GE_512-NEXT:    mov v3.h[3], w8
-; VBITS_GE_512-NEXT:    mls v0.4h, v3.4h, v1.4h
-; VBITS_GE_512-NEXT:    ret
+; CHECK-LABEL: urem_v4i16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ushll v2.4s, v1.4h, #0
+; CHECK-NEXT:    ushll v3.4s, v0.4h, #0
+; CHECK-NEXT:    ptrue p0.s, vl4
+; CHECK-NEXT:    udivr z2.s, p0/m, z2.s, z3.s
+; CHECK-NEXT:    xtn v2.4h, v2.4s
+; CHECK-NEXT:    mls v0.4h, v2.4h, v1.4h
+; CHECK-NEXT:    ret
   %res = urem <4 x i16> %op1, %op2
   ret <4 x i16> %res
 }
@@ -1490,7 +1360,6 @@ define void @urem_v64i32(ptr %a, ptr %b) vscale_range(16,0) #0 {
 }
 
 ; Vector i64 udiv are not legal for NEON so use SVE when available.
-; FIXME: We should be able to improve the codegen for the 128 bits case here.
 define <1 x i64> @urem_v1i64(<1 x i64> %op1, <1 x i64> %op2) vscale_range(1,0) #0 {
 ; CHECK-LABEL: urem_v1i64:
 ; CHECK:       // %bb.0:
@@ -1507,7 +1376,6 @@ define <1 x i64> @urem_v1i64(<1 x i64> %op1, <1 x i64> %op2) vscale_range(1,0) #
 }
 
 ; Vector i64 udiv are not legal for NEON so use SVE when available.
-; FIXME: We should be able to improve the codegen for the 128 bits case here.
 define <2 x i64> @urem_v2i64(<2 x i64> %op1, <2 x i64> %op2) vscale_range(1,0) #0 {
 ; CHECK-LABEL: urem_v2i64:
 ; CHECK:       // %bb.0:


### PR DESCRIPTION
When SVE VLS is enabled we request custom lowering for all ISD::TRUNCATE operations involving legal types. However, we only custom lower all of them when NEON is not available and so there are variants that do not require SVE and can be done via NEON but we are instead falling back to default expansion, which is this case means scalarisation. This patch updates custom lowering to mark the variants that have isel patterns available.