### PR TITLE
[RISCV] Fix typo in ImmPlus1 SDNodeXForm

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVGISel.td
+++ b/llvm/lib/Target/RISCV/RISCVGISel.td
@@ -32,7 +32,7 @@ def simm12Minus1NonzeroNonNeg1 : ImmLeaf<XLenVT, [{
 // Return an immediate value plus 1.
 def ImmPlus1 : SDNodeXForm<imm, [{
   return CurDAG->getTargetConstant(N->getSExtValue() + 1, SDLoc(N),
-                                   N->getValuePtrVTpe(0));}]>;
+                                   N->getValueType(0));}]>;
 def GIImmPlus1 :
   GICustomOperandRenderer<"renderImmPlus1">,
   GISDNodeXFormEquiv<ImmPlus1>;


### PR DESCRIPTION
getValuePtrVTpe -> getValueType. Currently dead code since GlobalISel uses a custom renderer instead of the SDNodeXForm body, but should be correct in case the SDAG path ever picks up these patterns.