### PR TITLE
[llvm-exegesis] Pass data layout explicitly to LLJIT

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/Assembler.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Assembler.cpp
@@ -381,7 +381,8 @@ Expected<ExecutableFunction> ExecutableFunction::create(
          "Cannot find the symbol for FunctionID");
   uintptr_t CodeSize = SymbolIt->second;
 
-  auto EJITOrErr = orc::LLJITBuilder().create();
+  auto EJITOrErr =
+      orc::LLJITBuilder().setDataLayout(TM->createDataLayout()).create();
   if (!EJITOrErr)
     return EJITOrErr.takeError();
 


### PR DESCRIPTION
This is a defesive change that aims to make sure the target data layout of both the object compilation and LLJIT is the same, by passing it explicitly rather than relying similar auto-detection implicitly.

The patch doesnt add a new test but relies on existing ones, as a test case of different layouts would require to exhibit a misuse of the tool, doing cross-compilation to change the layout of the compilation. The tool is not designed to work this way.
