### PR TITLE
[pdb] Store symbol names without null terminators in PublicsStreamTest

### DIFF
--- a/llvm/unittests/DebugInfo/PDB/PublicsStreamTest.cpp
+++ b/llvm/unittests/DebugInfo/PDB/PublicsStreamTest.cpp
@@ -29,8 +29,9 @@ struct PublicSym {
   PublicSym(StringRef N, uint16_t Seg, uint32_t Off)
       : NameData(new char[N.size()]), Name(NameData.get(), N.size()),
         Segment(Seg), Offset(Off) {
-    // Store the name without null terminator on the heap to help catch issues
-    // with code assuming there is a null terminator.
+    // Store the name without null terminator on the heap to help catch
+    // out-of-bounds accesses with ASan in case Name.data() is used as a
+    // null-terminated string.
     memcpy(NameData.get(), N.data(), N.size());
   }
 

--- a/llvm/unittests/DebugInfo/PDB/PublicsStreamTest.cpp
+++ b/llvm/unittests/DebugInfo/PDB/PublicsStreamTest.cpp
@@ -16,8 +16,8 @@
 #include "llvm/DebugInfo/PDB/Native/PDBFileBuilder.h"
 #include "llvm/DebugInfo/PDB/Native/SymbolStream.h"
 #include "llvm/Support/BinaryByteStream.h"
-#include <memory>
 #include <cstring>
+#include <memory>
 
 #include "gtest/gtest.h"
 

--- a/llvm/unittests/DebugInfo/PDB/PublicsStreamTest.cpp
+++ b/llvm/unittests/DebugInfo/PDB/PublicsStreamTest.cpp
@@ -16,6 +16,8 @@
 #include "llvm/DebugInfo/PDB/Native/PDBFileBuilder.h"
 #include "llvm/DebugInfo/PDB/Native/SymbolStream.h"
 #include "llvm/Support/BinaryByteStream.h"
+#include <memory>
+#include <cstring>
 
 #include "gtest/gtest.h"
 
@@ -24,6 +26,15 @@ using namespace llvm::pdb;
 
 namespace {
 struct PublicSym {
+  PublicSym(StringRef N, uint16_t Seg, uint32_t Off)
+      : NameData(new char[N.size()]), Name(NameData.get(), N.size()),
+        Segment(Seg), Offset(Off) {
+    // Store the name without null terminator on the heap to help catch issues
+    // with code assuming there is a null terminator.
+    memcpy(NameData.get(), N.data(), N.size());
+  }
+
+  std::unique_ptr<char[]> NameData;
   llvm::StringRef Name;
   uint16_t Segment;
   uint32_t Offset;


### PR DESCRIPTION
to catch any bugs where code assumes these names are null terminated.

This would have caught (at least in ASan builds) #163755 and the bug fixed in #190133.