### PR TITLE
[lldb][NFC] Adapt missed call-sites to AsCString changes

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
@@ -625,7 +625,7 @@ bool PlatformDarwinKernel::KextHasdSYMSibling(
       kext_bundle_filepath.GetFileNameStrippingExtension();
   std::string deep_bundle_str =
       kext_bundle_filepath.GetPath() + "/Contents/MacOS/";
-  deep_bundle_str += executable_name.AsCString();
+  deep_bundle_str += executable_name.GetStringRef();
   deep_bundle_str += ".dSYM";
   dsym_fspec.SetFile(deep_bundle_str, FileSpec::Style::native);
   FileSystem::Instance().Resolve(dsym_fspec);
@@ -636,7 +636,7 @@ bool PlatformDarwinKernel::KextHasdSYMSibling(
   // look for a shallow bundle format
   //
   std::string shallow_bundle_str = kext_bundle_filepath.GetPath() + "/";
-  shallow_bundle_str += executable_name.AsCString();
+  shallow_bundle_str += executable_name.GetStringRef();
   shallow_bundle_str += ".dSYM";
   dsym_fspec.SetFile(shallow_bundle_str, FileSpec::Style::native);
   FileSystem::Instance().Resolve(dsym_fspec);

--- a/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
+++ b/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
@@ -413,7 +413,7 @@ static bool LookForDsymNextToExecutablePath(const ModuleSpec &mod_spec,
     // See if the binary name exists in the dSYM DWARF
     // subdir.
     dsym_fspec = dsym_directory;
-    dsym_fspec.AppendPathComponent(filename.AsCString());
+    dsym_fspec.AppendPathComponent(filename.AsCString(nullptr));
     if (FileSystem::Instance().Exists(dsym_fspec) &&
         FileAtPathContainsArchAndUUID(dsym_fspec, mod_spec.GetArchitecturePtr(),
                                       mod_spec.GetUUIDPtr())) {
@@ -424,7 +424,7 @@ static bool LookForDsymNextToExecutablePath(const ModuleSpec &mod_spec,
     // CF.framework.dSYM/Contents/Resources/DWARF/CF
     // We need to drop the last suffix after '.' to match
     // 'CF' in the DWARF subdir.
-    std::string binary_name(filename.AsCString());
+    std::string binary_name = filename.GetString();
     auto last_dot = binary_name.find_last_of('.');
     if (last_dot != std::string::npos) {
       binary_name.erase(last_dot);
@@ -502,7 +502,7 @@ static bool LocateDSYMInVincinityOfExecutable(const ModuleSpec &module_spec,
       for (int i = 0; i < 4; i++) {
         // Does this part of the path have a "." character - could it be a
         // bundle's top level directory?
-        const char *fn = parent_dirs.GetFilename().AsCString();
+        const char *fn = parent_dirs.GetFilename().AsCString(nullptr);
         if (fn == nullptr)
           break;
         if (::strchr(fn, '.') != nullptr) {

--- a/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
+++ b/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
@@ -633,6 +633,7 @@ TEST_F(SymbolFilePDBTests, TestFindSymbolsWithNameAndType) {
 
   SymbolContext sc;
   EXPECT_TRUE(sc_list.GetContextAtIndex(0, sc));
-  EXPECT_STREQ("int foo(int)",
-               sc.GetFunctionName(Mangled::ePreferDemangled).AsCString());
+  EXPECT_STREQ(
+      "int foo(int)",
+      sc.GetFunctionName(Mangled::ePreferDemangled).AsCString(nullptr));
 }


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/190183 made the `ConstString::AsCString` explicit. This patch adjusts some callsites which now fail to compile but were missed in that PR.