### PR TITLE
[lldb][test] PlatformDarwinTest: remove redundant usage of TestingProperties

### DIFF
--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -551,8 +551,6 @@ TEST_F(PlatformDarwinLocateTest,
   // target.auto-load-scripts-for-modules setting.
 
   m_target_sp->SetLoadScriptFromSymbolFile(eLoadScriptFromSymFileTrusted);
-  TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
-      FileSpec(m_tmp_root_dir));
 
   auto setup_module = [this](llvm::StringRef module_name) {
     FileSpec module_fspec(


### PR DESCRIPTION
This was failing to compile on Windows bots that built without assertions:
```
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformDarwinTest.cpp
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformDarwinTest.cpp(554,3): error: use of undeclared identifier 'TestingProperties'
  554 |   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
      |   ^
1 error generated.
```

We don't need to set the safe-paths in this particular test, so just remove it.