### PR TITLE
[profgen] add --skip-disassembly flag for faster generation

### DIFF
--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -47,6 +47,7 @@ struct DILineInfo {
   uint32_t Column = 0;
   uint32_t StartLine = 0;
   std::optional<uint64_t> StartAddress;
+  std::optional<uint64_t> EndAddress;
 
   // DWARF-specific.
   uint32_t Discriminator = 0;

--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -496,11 +496,16 @@ enum ContextAttributeMask {
 struct SampleContextFrame {
   FunctionId Func;
   LineLocation Location;
+  std::optional<uint64_t> EndAddress;
 
   SampleContextFrame() : Location(0, 0) {}
 
   SampleContextFrame(FunctionId Func, LineLocation Location)
       : Func(Func), Location(Location) {}
+
+  SampleContextFrame(FunctionId Func, LineLocation Location,
+                     std::optional<uint64_t> EndAddress)
+      : Func(Func), Location(Location), EndAddress(EndAddress) {}
 
   bool operator==(const SampleContextFrame &That) const {
     return Location == That.Location && Func == That.Func;

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -1542,6 +1542,8 @@ bool DWARFDebugLine::LineTable::getFileLineInfoForAddress(
   Result.Column = Row.Column;
   Result.Discriminator = Row.Discriminator;
   Result.Source = getSourceByIndex(Row.File, Kind);
+  if (RowIndex + 1 < Rows.size())
+    Result.EndAddress = std::make_optional(Rows[RowIndex + 1].Address.Address);
   return true;
 }
 

--- a/llvm/test/tools/llvm-profgen/skip-disassembly.test
+++ b/llvm/test/tools/llvm-profgen/skip-disassembly.test
@@ -1,0 +1,17 @@
+; RUN: llvm-profgen --format=text --perfscript=%S/Inputs/inline-noprobe.perfscript --binary=%S/Inputs/inline-noprobe.perfbin --output=%t --skip-disassembly
+; RUN: FileCheck %s --input-file %t
+
+CHECK: main:2547:0
+CHECK-NEXT:  0: 0
+CHECK-NEXT:  2: 0
+CHECK-NEXT:  1: foo:2547
+CHECK-NEXT:   2.1: 42
+CHECK-NEXT:   3: 62
+CHECK-NEXT:   3.2: 21
+CHECK-NEXT:   4: 0
+CHECK-NEXT:   65526: 62
+CHECK-NEXT:   3.1: bar:546
+CHECK-NEXT:    1: 42
+CHECK-NEXT:    65533: 42
+CHECK-NEXT:   3.2: bar:189
+CHECK-NEXT:    1: 21

--- a/llvm/tools/llvm-profgen/Options.h
+++ b/llvm/tools/llvm-profgen/Options.h
@@ -16,6 +16,7 @@ extern cl::OptionCategory ProfGenCategory;
 
 extern cl::opt<std::string> OutputFilename;
 extern cl::opt<bool> ShowDisassemblyOnly;
+extern cl::opt<bool> SkipDisassembly;
 extern cl::opt<bool> ShowSourceLocations;
 extern cl::opt<bool> SkipSymbolization;
 extern cl::opt<bool> ShowDetailedWarning;

--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -1023,7 +1023,8 @@ void PerfScriptReader::computeCounterFromLBR(const PerfSample *Sample,
     uint64_t StartAddress = TargetAddress;
     if (Binary->addressIsCode(StartAddress) &&
         Binary->addressIsCode(EndAddress) &&
-        isValidFallThroughRange(StartAddress, EndAddress, Binary))
+        (SkipDisassembly ||
+         isValidFallThroughRange(StartAddress, EndAddress, Binary)))
       Counter.recordRangeCount(StartAddress, EndAddress, Repeat);
     EndAddress = SourceAddress;
   }
@@ -1309,8 +1310,10 @@ void PerfScriptReader::warnInvalidRange() {
         !Binary->addressIsCode(EndAddress))
       continue;
 
-    if (!Binary->addressIsCode(StartAddress) ||
-        !Binary->addressIsTransfer(EndAddress)) {
+    // addressIsTransfer relies on disassembly info, so we can't run this check
+    // with --skip-disassembly.
+    if (!SkipDisassembly && (!Binary->addressIsCode(StartAddress) ||
+                             !Binary->addressIsTransfer(EndAddress))) {
       InstNotBoundary += I.second;
       WarnInvalidRange(StartAddress, EndAddress, EndNotBoundaryMsg);
     }
@@ -1330,7 +1333,9 @@ void PerfScriptReader::warnInvalidRange() {
       WarnInvalidRange(StartAddress, EndAddress, RangeCrossFuncMsg);
     }
 
-    if (Binary->addressIsCode(StartAddress) &&
+    // isValidFallThroughRange relies on disassembly info, so we can't run this
+    // check with --skip-disassembly either.
+    if (!SkipDisassembly && Binary->addressIsCode(StartAddress) &&
         Binary->addressIsCode(EndAddress) &&
         !isValidFallThroughRange(StartAddress, EndAddress, Binary)) {
       BogusRange += I.second;

--- a/llvm/tools/llvm-profgen/ProfileGenerator.cpp
+++ b/llvm/tools/llvm-profgen/ProfileGenerator.cpp
@@ -703,27 +703,50 @@ void ProfileGenerator::populateBodySamplesForAllFunctions(
     uint64_t RangeEnd = Range.first.second;
     uint64_t Count = Range.second;
 
-    InstructionPointer IP(Binary, RangeBegin, true);
-    // Disjoint ranges may have range in the middle of two instr,
-    // e.g. If Instr1 at Addr1, and Instr2 at Addr2, disjoint range
-    // can be Addr1+1 to Addr2-1. We should ignore such range.
-    if (IP.Address > RangeEnd)
-      continue;
+    if (!SkipDisassembly) {
+      InstructionPointer IP(Binary, RangeBegin, true);
+      // Disjoint ranges may have range in the middle of two instr,
+      // e.g. If Instr1 at Addr1, and Instr2 at Addr2, disjoint range
+      // can be Addr1+1 to Addr2-1. We should ignore such range.
+      if (IP.Address > RangeEnd)
+        continue;
 
-    do {
-      const SampleContextFrameVector FrameVec =
-          Binary->getFrameLocationStack(IP.Address);
-      if (!FrameVec.empty()) {
-        // FIXME: As accumulating total count per instruction caused some
-        // regression, we changed to accumulate total count per byte as a
-        // workaround. Tuning hotness threshold on the compiler side might be
-        // necessary in the future.
-        FunctionSamples &FunctionProfile = getLeafProfileAndAddTotalSamples(
-            FrameVec, Count * Binary->getInstSize(IP.Address));
-        updateBodySamplesforFunctionProfile(FunctionProfile, FrameVec.back(),
-                                            Count);
-      }
-    } while (IP.advance() && IP.Address <= RangeEnd);
+      do {
+        const SampleContextFrameVector FrameVec =
+            Binary->getFrameLocationStack(IP.Address);
+        if (!FrameVec.empty()) {
+          // FIXME: As accumulating total count per instruction caused some
+          // regression, we changed to accumulate total count per byte as a
+          // workaround. Tuning hotness threshold on the compiler side might be
+          // necessary in the future.
+          FunctionSamples &FunctionProfile = getLeafProfileAndAddTotalSamples(
+              FrameVec, Count * Binary->getInstSize(IP.Address));
+          updateBodySamplesforFunctionProfile(FunctionProfile, FrameVec.back(),
+                                              Count);
+        }
+      } while (IP.advance() && IP.Address <= RangeEnd);
+    } else {
+      uint64_t IP = RangeBegin;
+      do {
+        const SampleContextFrameVector FrameVec =
+            Binary->getFrameLocationStack(IP);
+
+        if (!FrameVec.empty()) {
+          auto DISequenceEnd = FrameVec.back().EndAddress.value_or(UINT64_MAX);
+          // Sometimes the profile is more granular than the debug info.
+          // Ensure we don't drop this granularity.
+          auto SequenceEnd = std::min({DISequenceEnd, RangeEnd + 1});
+          auto SequenceLength = SequenceEnd - IP;
+          FunctionSamples &FunctionProfile = getLeafProfileAndAddTotalSamples(
+              FrameVec, Count * SequenceLength);
+          updateBodySamplesforFunctionProfile(FunctionProfile, FrameVec.back(),
+                                              Count);
+          IP += SequenceLength;
+        } else {
+          IP += 1;
+        }
+      } while (IP <= RangeEnd);
+    }
   }
 }
 

--- a/llvm/tools/llvm-profgen/ProfiledBinary.cpp
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.cpp
@@ -38,6 +38,12 @@ cl::opt<bool> ShowDisassemblyOnly("show-disassembly-only",
                                   cl::desc("Print disassembled code."),
                                   cl::cat(ProfGenCategory));
 
+cl::opt<bool> SkipDisassembly(
+    "skip-disassembly",
+    cl::desc("Skip disassembly. Disables some profile quality warnings. "
+             "Incompatible with CSSPGO."),
+    cl::cat(ProfGenCategory));
+
 cl::opt<bool> ShowSourceLocations("show-source-locations",
                                   cl::desc("Print source locations."),
                                   cl::cat(ProfGenCategory));
@@ -294,7 +300,7 @@ void ProfiledBinary::load(StringRef TripleStr) {
     loadSymbolsFromSymtab(Obj);
 
   // Disassemble the text sections.
-  disassemble(Obj);
+  analyze(Obj);
 
   // Use function start and return address to infer prolog and epilog
   ProEpilogTracker.inferPrologAddresses(StartAddrToFuncRangeMap);
@@ -591,7 +597,6 @@ bool ProfiledBinary::dissassembleSymbol(std::size_t SI, ArrayRef<uint8_t> Bytes,
   uint64_t NextStartAddress =
       (SI + 1 < SE) ? Symbols[SI + 1].Addr : SectionAddress + SectSize;
   FuncRange *FRange = findFuncRange(StartAddress);
-  setIsFuncEntry(FRange, FunctionSamples::getCanonicalFnName(Symbols[SI].Name));
   StringRef SymbolName =
       ShowCanonicalFnName
           ? FunctionSamples::getCanonicalFnName(Symbols[SI].Name)
@@ -771,7 +776,7 @@ void ProfiledBinary::setUpDisassembler(const ObjectFile *Obj) {
   IPrinter->setPrintBranchImmAsAddress(true);
 }
 
-void ProfiledBinary::disassemble(const ObjectFile *Obj) {
+void ProfiledBinary::analyze(const ObjectFile *Obj) {
   // Set up disassembler and related components.
   setUpDisassembler(Obj);
 
@@ -811,9 +816,6 @@ void ProfiledBinary::disassemble(const ObjectFile *Obj) {
     if (!SectSize)
       continue;
 
-    // Register the text section.
-    TextSections.insert({SectionAddress, SectSize});
-
     StringRef SectionName = unwrapOrError(Section.getName(), FileName);
 
     if (ShowDisassemblyOnly) {
@@ -826,6 +828,9 @@ void ProfiledBinary::disassemble(const ObjectFile *Obj) {
     if (isa<ELFObjectFileBase>(Obj) && SectionName == ".plt")
       continue;
 
+    // Register the text section.
+    TextSections.emplace(SectionAddress, SectSize);
+
     // Get the section data.
     ArrayRef<uint8_t> Bytes =
         arrayRefFromStringRef(unwrapOrError(Section.getContents(), FileName));
@@ -833,10 +838,15 @@ void ProfiledBinary::disassemble(const ObjectFile *Obj) {
     // Get the list of all the symbols in this section.
     SectionSymbolsTy &Symbols = AllSymbols[Section];
 
-    // Disassemble symbol by symbol.
     for (std::size_t SI = 0, SE = Symbols.size(); SI != SE; ++SI) {
-      if (!dissassembleSymbol(SI, Bytes, Symbols, Section))
-        exitWithError("disassembling error", FileName);
+      uint64_t StartAddress = Symbols[SI].Addr;
+      FuncRange *FRange = findFuncRange(StartAddress);
+      setIsFuncEntry(FRange,
+                     FunctionSamples::getCanonicalFnName(Symbols[SI].Name));
+
+      if (!SkipDisassembly)
+        if (!dissassembleSymbol(SI, Bytes, Symbols, Section))
+          exitWithError("disassembling error", FileName);
     }
   }
 
@@ -1166,7 +1176,8 @@ SampleContextFrameVector ProfiledBinary::symbolize(const InstructionPointer &IP,
 
     LineLocation Line(LineOffset, Discriminator);
     auto It = NameStrings.insert(FunctionName.str());
-    CallStack.emplace_back(FunctionId(StringRef(*It.first)), Line);
+    CallStack.emplace_back(FunctionId(StringRef(*It.first)), Line,
+                           CallerFrame.EndAddress);
   }
 
   return CallStack;

--- a/llvm/tools/llvm-profgen/ProfiledBinary.h
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.h
@@ -11,6 +11,7 @@
 
 #include "CallContext.h"
 #include "ErrorHandling.h"
+#include "Options.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
@@ -233,7 +234,7 @@ class ProfiledBinary {
   std::unique_ptr<MCInstPrinter> IPrinter;
   // A list of text sections sorted by start RVA and size. Used to check
   // if a given RVA is a valid code address.
-  std::set<std::pair<uint64_t, uint64_t>> TextSections;
+  std::map<uint64_t, uint64_t> TextSections;
 
   // A map of mapping function name to BinaryFunction info.
   std::unordered_map<std::string, BinaryFunction> BinaryFunctions;
@@ -406,7 +407,7 @@ class ProfiledBinary {
   void warnNoFuncEntry();
 
   /// Dissassemble the text section and build various address maps.
-  void disassemble(const object::ObjectFile *O);
+  void analyze(const object::ObjectFile *O);
 
   /// Helper function to dissassemble the symbol and extract info for unwinding
   bool dissassembleSymbol(std::size_t SI, ArrayRef<uint8_t> Bytes,
@@ -475,16 +476,32 @@ public:
   }
 
   bool addressIsCode(uint64_t Address) const {
-    return AddressToInstSizeMap.find(Address) != AddressToInstSizeMap.end();
+    if (!SkipDisassembly)
+      return AddressToInstSizeMap.find(Address) != AddressToInstSizeMap.end();
+
+    // If we haven't disassembled, we don't know where instr boundaries are,
+    // but we guess that Address lies on one because we can't do any better.
+    Address -= getPreferredBaseAddress();
+    auto Section = TextSections.upper_bound(Address);
+    if (Section == TextSections.begin())
+      return false;
+    Section--;
+    return Address - Section->first < Section->second;
   }
 
+  // These functions are only used by CSSPGO which is incompatible with
+  // SkipDisassembly anyway, so they don't need to handle that flag
+  // even though they use data from disassembly.
   bool addressIsCall(uint64_t Address) const {
+    assert(!SkipDisassembly);
     return CallAddressSet.count(Address);
   }
   bool addressIsReturn(uint64_t Address) const {
+    assert(!SkipDisassembly);
     return RetAddressSet.count(Address);
   }
   bool addressInPrologEpilog(uint64_t Address) const {
+    assert(!SkipDisassembly);
     return ProEpilogTracker.PrologEpilogSet.count(Address);
   }
 
@@ -495,11 +512,13 @@ public:
     return IndirectBranchAddressSet.count(Address);
   }
   bool addressIsTransfer(uint64_t Address) {
+    assert(!SkipDisassembly);
     return BranchAddressSet.count(Address) || RetAddressSet.count(Address) ||
            CallAddressSet.count(Address);
   }
 
   bool rangeCrossUncondBranch(uint64_t Start, uint64_t End) {
+    assert(!SkipDisassembly && "can't find branches without disassembly!");
     if (Start >= End)
       return false;
     auto R = UncondBranchAddrSet.lower_bound(Start);

--- a/llvm/tools/llvm-profgen/llvm-profgen.cpp
+++ b/llvm/tools/llvm-profgen/llvm-profgen.cpp
@@ -225,6 +225,9 @@ int main(int argc, const char *argv[]) {
       Counters = &EtmReader->getSampleCounters();
     } else {
       PerfReader = PerfReaderBase::create(Binary.get(), File, PIDFilter);
+      if (PerfReader->profileIsCS() && SkipDisassembly)
+        exitWithError("--skip-disassembly is not compatible with CSSPGO.");
+
       // Parse perf events and samples
       PerfReader->parsePerfTraces();
 


### PR DESCRIPTION
We're already recording numbers as if we're iterating per-byte (as the FIXME comment says) and not per-instruction. Add an option to skip some instruction-level logic so we can work much faster.

This allows us to skip the disassembly step entirely, if we give up on a couple of warning messages and safety nets against broken profiles. Notably, there is no way to know if an address is instruction-aligned, or how long an instruction is. If we look up how long a sequence of instructions from the same source line is in the debug info then we can still see to the end of the terminating branch instruction of a bb - without this info, since the LBR only tells us where this branch starts, we wouldn't be able to count its full length.

Incidentally, since getLeafProfileAndAddTotalSamples and updateBodySamplesforFunctionProfile are expensive, this gives us a modest performance boost.

Also only record a text section if it's not the PLT. We weren't using this table before, but now we're using it to determine if code is internal or external, and we need to skip the PLT for that.

The generated profile is still good. Clangs built from the same perf.data with and without --skip-disassembly build clang at very similiar speeds:

|  --s-d  | no --s-d |
|---------|----------|
| 3:35.86 | 3:36.15  |
| 3:36.88 | 3:37.61  |
| 3:37.97 | 3:38.43  |
|---------|----------|
| 3:36.90 | 3:37.40  |