### PR TITLE
[RISC-V] Add support for cheriot ABI in DataLayout

### DIFF
--- a/llvm/lib/TargetParser/TargetDataLayout.cpp
+++ b/llvm/lib/TargetParser/TargetDataLayout.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/TargetParser/ARMTargetParser.h"
 #include "llvm/TargetParser/Triple.h"
@@ -298,19 +299,19 @@ static std::string computeRISCVDataLayout(const Triple &TT, StringRef ABIName) {
 
   // TODO: Maybe we should move RISCVABI to TargetParser, so we can reuse that
   // logic here instead of duplicating the string handling?
-  bool IsRVYPurecapABI =
-      ABIName.starts_with("il32pc64") || ABIName.starts_with("l64pc128");
+  bool IsPureCapABI = ABIName.starts_with("il32pc64") ||
+                      ABIName.starts_with("l64pc128") ||
+                      ABIName.starts_with("cheriot");
 
-  // Pointer and integer sizes.
   if (TT.isRISCV64()) {
     Ret += "-p:64:64";
-    if (IsRVYPurecapABI)
+    if (IsPureCapABI)
       Ret += "-pe200:128:128:128:64";
     Ret += "-i64:64-i128:128-n32:64";
   } else {
     assert(TT.isRISCV32() && "only RV32 and RV64 are currently supported");
     Ret += "-p:32:32";
-    if (IsRVYPurecapABI)
+    if (IsPureCapABI)
       Ret += "-pe200:64:64:64:32";
     Ret += "-i64:64-n32";
   }
@@ -323,7 +324,8 @@ static std::string computeRISCVDataLayout(const Triple &TT, StringRef ABIName) {
   else
     Ret += "-S128";
 
-  if (IsRVYPurecapABI)
+  // TODO: Support non-purecap CHERI ABIs.
+  if (IsPureCapABI)
     Ret += "-A200-P200-G200";
 
   return Ret;

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -3529,4 +3529,17 @@ TEST(TripleTest, DefaultWCharSize) {
   EXPECT_EQ(1u, Triple("xcore-unknown-unknown").getDefaultWCharSize());
 }
 
+TEST(DataLayoutTest, CheriRISCV32) {
+  Triple TT = Triple("riscv32-unknown-unknown");
+
+  EXPECT_THAT(TT.computeDataLayout(""),
+              testing::Not(testing::HasSubstr("pe200")));
+  EXPECT_THAT(TT.computeDataLayout(""),
+              testing::Not(testing::HasSubstr("A200-P200-G200")));
+  EXPECT_THAT(TT.computeDataLayout("cheriot"),
+              testing::HasSubstr("pe200:64:64:64:32"));
+  EXPECT_THAT(TT.computeDataLayout("cheriot"),
+              testing::HasSubstr("A200-P200-G200"));
+}
+
 } // end anonymous namespace


### PR DESCRIPTION
addrspace(200) is used to represent CHERI capabilities across both pure capability and hybrid modes. For the purposes of supporting pure modes, it suffices to gate the DataLayout setup on the ABI string. While support for hybrid modes is not planned for upstreaming to LLVM at this time, the code is structured to make them straightforward to add and/or maintain downstream.
