### PR TITLE
[Offload] Disable RPC doorbell queries on some ISAs

### DIFF
--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -3880,8 +3880,16 @@ struct AMDGPUPluginTy final : public GenericPluginTy {
 
   /// Create an HSA signal for the RPC doorbell and return the fields needed
   /// for the GPU to fire interrupts that wake the server thread.
-  Error initRPCDoorbell(uint64_t *&Value, uint64_t *&Mailbox,
-                        uint32_t &EventID) override {
+  Error initRPCDoorbell(GenericDeviceTy &Device, uint64_t *&Value,
+                        uint64_t *&Mailbox, uint32_t &EventID) override {
+    // FIXME: The doorbell interrupting hardware does not seem to work on these
+    //        ISAs. This is potentially due to default PRIV settings, disable
+    //        doorbell support pending further investigation.
+    std::string Str = Device.getComputeUnitKind();
+    llvm::StringRef GfxName(Str);
+    if (GfxName.starts_with("gfx90") || GfxName.starts_with("gfx11"))
+      return Plugin::success();
+
     // Lazily initialize the RPC signal on first use so we don't leak an HSA
     // signal when no device uses RPC.
     {

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1365,8 +1365,8 @@ struct GenericPluginTy {
   }
 
   /// Initialize the RPC doorbell if used by the target.
-  virtual Error initRPCDoorbell(uint64_t *&Value, uint64_t *&Mailbox,
-                                uint32_t &EventID) {
+  virtual Error initRPCDoorbell(GenericDeviceTy &Device, uint64_t *&Value,
+                                uint64_t *&Mailbox, uint32_t &EventID) {
     return Plugin::success();
   }
 

--- a/offload/plugins-nextgen/common/src/RPC.cpp
+++ b/offload/plugins-nextgen/common/src/RPC.cpp
@@ -223,8 +223,8 @@ Error RPCServerTy::initDevice(plugin::GenericDeviceTy &Device,
   // The doorbell is used by AMDGPU targets to let the server thread be
   // descheduled. It is optional and will be ignored if the fields are null.
   rpc::Doorbell Doorbell{};
-  if (auto Err = Device.Plugin.initRPCDoorbell(Doorbell.value, Doorbell.mailbox,
-                                               Doorbell.event_id))
+  if (auto Err = Device.Plugin.initRPCDoorbell(
+          Device, Doorbell.value, Doorbell.mailbox, Doorbell.event_id))
     return Err;
 
   auto *DoorbellPtr = reinterpret_cast<rpc::Doorbell *>(


### PR DESCRIPTION
Summary:
These don't seem to be supported on all platforms. I do not know exactly
why these hang on others but I will disable them until I can debug this.
