### PR TITLE
[clang][analyzer] Fix crash on LazyCompoundValKind in conditionals

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/SimpleConstraintManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SimpleConstraintManager.cpp
@@ -88,6 +88,9 @@ ProgramStateRef SimpleConstraintManager::assumeAux(ProgramStateRef State,
   case nonloc::LocAsIntegerKind:
     return assumeInternal(State, Cond.castAs<nonloc::LocAsInteger>().getLoc(),
                           Assumption);
+
+  case nonloc::LazyCompoundValKind:
+    return State;
   } // end switch
 }
 
@@ -124,6 +127,9 @@ ProgramStateRef SimpleConstraintManager::assumeInclusiveRangeInternal(
     bool isFeasible = (IsInRange == InRange);
     return isFeasible ? State : nullptr;
   }
+
+  case nonloc::LazyCompoundValKind:
+    return State;
   } // end switch
 }
 

--- a/clang/test/Analysis/lazy-compound-if-no-crash.c
+++ b/clang/test/Analysis/lazy-compound-if-no-crash.c
@@ -1,0 +1,11 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core \
+// RUN:   -triple x86_64-pc-linux-gnu \
+// RUN:   -verify %s
+// The bit-cast dereference produces a LazyCompoundVal which must not crash when handled
+// by the constraint manager.
+
+void foo() {
+  char arr[0];
+  if (*__builtin_bit_cast(int *, &arr)) // expected-warning {{Branch condition evaluates to a garbage value}}
+    ;
+}

--- a/clang/test/Analysis/lazy-compound-switch-no-crash.c
+++ b/clang/test/Analysis/lazy-compound-switch-no-crash.c
@@ -1,0 +1,13 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core \
+// RUN:   -triple x86_64-pc-linux-gnu \
+// RUN:   -verify %s
+// The bit-cast dereference produces a LazyCompoundVal which must not crash when handled
+// by the constraint manager.
+
+void foo() {
+  switch (({ // expected-warning {{Branch condition evaluates to a garbage value}}
+    char arr[0];
+    *__builtin_bit_cast(int *, &arr);
+  }))
+  case 0:;
+}


### PR DESCRIPTION
Avoid reaching a `llvm_unreachable`.