### PR TITLE
[CIR] Implement 'zero attr' creation of method

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -125,6 +125,8 @@ public:
       return cir::ZeroAttr::get(recordTy);
     if (auto dataMemberTy = mlir::dyn_cast<cir::DataMemberType>(ty))
       return getNullDataMemberAttr(dataMemberTy);
+    if (auto methodTy = mlir::dyn_cast<cir::MethodType>(ty))
+      return getNullMethodAttr(methodTy);
     if (mlir::isa<cir::BoolType>(ty)) {
       return getFalseAttr();
     }

--- a/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
@@ -34,6 +34,13 @@ void (Foo::*m2_ptr)(int) = &Foo::m2;
 // LLVM-DAG: @m2_ptr = global { i64, i64 } { i64 1, i64 0 }
 // OGCG: @m2_ptr = global { i64, i64 } { i64 1, i64 0 }
 
+// Self-referencing PMF causes a null method.
+long (Foo::*pmf1)(int) = pmf1;
+// CIR-BEFORE: @pmf1 = ctor : !cir.method<!cir.func<(!cir.ptr<!rec_Foo>, !s32i) -> !s64i> in !rec_Foo> {
+// CIR-AFTER: cir.global external @pmf1 = #cir.const_record<{#cir.int<0> : !s64i, #cir.int<0> : !s64i}> 
+// LLVM: @pmf1 = global { i64, i64 } zeroinitializer, align 8 
+// OGCG: @pmf1 = global { i64, i64 } zeroinitializer, align 8 
+
 auto make_non_virtual() -> void (Foo::*)(int) {
   return &Foo::m1;
 }
@@ -198,3 +205,4 @@ void call(Foo *obj, void (Foo::*func)(int), int arg) {
 // OGCG:   %[[ARG:.*]] = load i32, ptr %{{.+}}
 // OGCG:   call void %[[CALLEE_PTR]](ptr {{.*}} %[[ADJUSTED_THIS]], i32 {{.*}} %[[ARG]])
 // OGCG: }
+


### PR DESCRIPTION
This appears quite a bit in some benchmarks, and is seemingly something we missed at one point.  This patch just implements a 'zero-init' of a pmf.