### PR TITLE
[RISCV][MCA] Do not use mask instructions that can potentially be optimized by uArch

### DIFF
--- a/llvm/test/tools/llvm-mca/RISCV/Inputs/rvv/mask.s
+++ b/llvm/test/tools/llvm-mca/RISCV/Inputs/rvv/mask.s
@@ -1,94 +1,94 @@
 # Mask operations
 
 vsetvli x28, x0, e8, mf2, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e8, mf4, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e8, mf8, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e8, m1, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e8, m2, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e8, m4, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e8, m8, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e16, mf2, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e16, mf4, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e16, m1, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e16, m2, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e16, m4, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e16, m8, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e32, mf2, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e32, m1, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e32, m2, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e32, m4, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e32, m8, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e64, m1, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e64, m2, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e64, m4, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 vsetvli x28, x0, e64, m8, tu, mu
-vmand.mm v8, v8, v8
+vmand.mm v7, v8, v9
 
 vsetvli x28, x0, e8, mf2, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e8, mf4, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e8, mf8, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e8, m1, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e8, m2, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e8, m4, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e8, m8, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e16, mf2, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e16, mf4, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e16, m1, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e16, m2, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e16, m4, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e16, m8, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e32, mf2, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e32, m1, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e32, m2, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e32, m4, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e32, m8, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e64, m1, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e64, m2, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e64, m4, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 vsetvli x28, x0, e64, m8, tu, mu
-vmnand.mm v8, v8, v8
+vmnand.mm v7, v8, v9
 
 vsetvli x28, x0, e8, mf2, tu, mu
 vmandn.mm v8, v8, v8
@@ -136,49 +136,49 @@ vsetvli x28, x0, e64, m8, tu, mu
 vmandn.mm v8, v8, v8
 
 vsetvli x28, x0, e8, mf2, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e8, mf4, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e8, mf8, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e8, m1, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e8, m2, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e8, m4, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e8, m8, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e16, mf2, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e16, mf4, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e16, m1, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e16, m2, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e16, m4, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e16, m8, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e32, mf2, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e32, m1, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e32, m2, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e32, m4, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e32, m8, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e64, m1, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e64, m2, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e64, m4, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 vsetvli x28, x0, e64, m8, tu, mu
-vmxor.mm v8, v8, v8
+vmxor.mm v7, v8, v9
 
 vsetvli x28, x0, e8, mf2, tu, mu
 vmor.mm v8, v8, v8
@@ -316,49 +316,49 @@ vsetvli x28, x0, e64, m8, tu, mu
 vmorn.mm v8, v8, v8
 
 vsetvli x28, x0, e8, mf2, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e8, mf4, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e8, mf8, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e8, m1, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e8, m2, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e8, m4, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e8, m8, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e16, mf2, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e16, mf4, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e16, m1, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e16, m2, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e16, m4, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e16, m8, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e32, mf2, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e32, m1, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e32, m2, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e32, m4, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e32, m8, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e64, m1, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e64, m2, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e64, m4, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 vsetvli x28, x0, e64, m8, tu, mu
-vmxnor.mm v8, v8, v8
+vmxnor.mm v7, v8, v9
 
 vsetvli x28, x0, e8, mf2, tu, mu
 vmsbf.m v8, v16

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveP400/rvv/mask.test
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveP400/rvv/mask.test
@@ -30,93 +30,93 @@
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
@@ -162,49 +162,49 @@
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
@@ -338,49 +338,49 @@
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      2     1.00                         2     SiFiveP400VEXQ0                            VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP400IEXQ1,SiFiveP400IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
@@ -654,93 +654,93 @@
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   Instructions:
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
@@ -786,49 +786,49 @@
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmor.mm	v8, v8, v8
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
@@ -962,49 +962,49 @@
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -     1.00    -      -      -     vmsbf.m	v8, v16
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveP600/rvv/mask.test
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveP600/rvv/mask.test
@@ -35,93 +35,93 @@
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
@@ -167,49 +167,49 @@
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
@@ -343,49 +343,49 @@
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      2     1.00                         2     SiFiveP600VEXQ0,SiFiveP600VectorArith      VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SiFiveP600IEXQ0,SiFiveP600IntArith         VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
@@ -662,93 +662,93 @@
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8.0]  [8.1]  [9]    [10]   [11]   [12]   [13]   [14]   Instructions:
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
@@ -794,49 +794,49 @@
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmor.mm	v8, v8, v8
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
@@ -970,49 +970,49 @@
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -      -     vmsbf.m	v8, v16
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX100/rvv/mask.test
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX100/rvv/mask.test
@@ -25,93 +25,93 @@
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMAND_MM             vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMAND_MM             vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMNAND_MM            vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMNAND_MM            vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMANDN_MM            vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf4, tu, mu
@@ -157,49 +157,49 @@
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMANDN_MM            vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXOR_MM             vmclr.m	v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXOR_MM             vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMOR_MM              vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf4, tu, mu
@@ -333,49 +333,49 @@
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMORN_MM             vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXNOR_MM            vmset.m	v8
+# CHECK-NEXT:  1      4     2.00                         4     VLEN128X100SiFive7VA1[1,3],VLEN128X100SiFive7VCQ VMXNOR_MM            vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      4     1.00                         4     VLEN128X100SiFive7VA1[1,2],VLEN128X100SiFive7VCQ VMSBF_M              vmsbf.m	v8, v16
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB VSETVLI              vsetvli	t3, zero, e8, mf4, tu, mu
@@ -644,93 +644,93 @@
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
@@ -776,49 +776,49 @@
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmor.mm	v8, v8, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
@@ -952,49 +952,49 @@
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -     3.00   1.00    -      -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vmsbf.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu

--- a/llvm/test/tools/llvm-mca/RISCV/SpacemitX60/rvv/mask.test
+++ b/llvm/test/tools/llvm-mca/RISCV/SpacemitX60/rvv/mask.test
@@ -24,93 +24,93 @@
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMAND_MM                   vmand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMNAND_MM                  vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
@@ -156,49 +156,49 @@
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXOR_MM                   vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
@@ -332,49 +332,49 @@
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMXNOR_MM                  vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
@@ -643,93 +643,93 @@
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3.0]  [3.1]  [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmmv.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnot.m	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmnand.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
@@ -775,49 +775,49 @@
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmclr.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmor.mm	v8, v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
@@ -951,49 +951,49 @@
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmset.m	v8
+# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmxnor.mm	v7, v8, v9
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmsbf.m	v8, v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu


### PR DESCRIPTION
Context: https://github.com/llvm/llvm-project/pull/189785#discussion_r3019282209

Some mask instructions have a form that can potentially be optimized by HW implementation: `vmxor.mm vd, vs, vs` and `vmclr vd, vs`, for instance. This patch avoids using such instructions in MCA tests.
