### PR TITLE
[clang-doc] Add option for compact JSON

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -907,10 +907,10 @@ Error JSONGenerator::serializeIndex(StringRef RootDir) {
   raw_fd_ostream RootOS(IndexFilePath, FileErr, sys::fs::OF_Text);
   if (FileErr)
     return createFileError("cannot open file " + IndexFilePath, FileErr);
-  if (CDCtx->CompactJSON)
-    RootOS << llvm::formatv("{0}", ObjVal);
-  else
+  if (CDCtx->Pretty)
     RootOS << llvm::formatv("{0:2}", ObjVal);
+  else
+    RootOS << llvm::formatv("{0}", ObjVal);
   return Error::success();
 }
 
@@ -1013,10 +1013,10 @@ Error JSONGenerator::generateDocForInfo(Info *I, raw_ostream &OS,
   case InfoType::IT_default:
     return createStringError(inconvertibleErrorCode(), "unexpected info type");
   }
-  if (CDCtx.CompactJSON)
-    OS << llvm::formatv("{0}", llvm::json::Value(std::move(Obj)));
-  else
+  if (CDCtx.Pretty)
     OS << llvm::formatv("{0:2}", llvm::json::Value(std::move(Obj)));
+  else
+    OS << llvm::formatv("{0}", llvm::json::Value(std::move(Obj)));
   return Error::success();
 }
 

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -907,7 +907,10 @@ Error JSONGenerator::serializeIndex(StringRef RootDir) {
   raw_fd_ostream RootOS(IndexFilePath, FileErr, sys::fs::OF_Text);
   if (FileErr)
     return createFileError("cannot open file " + IndexFilePath, FileErr);
-  RootOS << llvm::formatv("{0:2}", ObjVal);
+  if (CDCtx->CompactJSON)
+    RootOS << llvm::formatv("{0}", ObjVal);
+  else
+    RootOS << llvm::formatv("{0:2}", ObjVal);
   return Error::success();
 }
 
@@ -1010,7 +1013,10 @@ Error JSONGenerator::generateDocForInfo(Info *I, raw_ostream &OS,
   case InfoType::IT_default:
     return createStringError(inconvertibleErrorCode(), "unexpected info type");
   }
-  OS << llvm::formatv("{0:2}", llvm::json::Value(std::move(Obj)));
+  if (CDCtx.CompactJSON)
+    OS << llvm::formatv("{0}", llvm::json::Value(std::move(Obj)));
+  else
+    OS << llvm::formatv("{0:2}", llvm::json::Value(std::move(Obj)));
   return Error::success();
 }
 

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -503,11 +503,11 @@ ClangDocContext::ClangDocContext(
     StringRef OutDirectory, StringRef SourceRoot, StringRef RepositoryUrl,
     StringRef RepositoryLinePrefix, StringRef Base,
     std::vector<std::string> UserStylesheets, clang::DiagnosticsEngine &Diags,
-    OutputFormatTy Format, bool FTimeTrace, bool CompactJSON)
+    OutputFormatTy Format, bool FTimeTrace, bool Pretty)
     : ECtx(ECtx), ProjectName(ProjectName), OutDirectory(OutDirectory),
       SourceRoot(std::string(SourceRoot)), UserStylesheets(UserStylesheets),
       Base(Base), Diags(Diags), Format(Format), PublicOnly(PublicOnly),
-      FTimeTrace(FTimeTrace), CompactJSON(CompactJSON) {
+      FTimeTrace(FTimeTrace), Pretty(Pretty) {
   llvm::SmallString<128> SourceRootDir(SourceRoot);
   if (SourceRoot.empty())
     // If no SourceRoot was provided the current path is used as the default

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -498,18 +498,16 @@ void Index::sort() {
     C.sort();
 }
 
-ClangDocContext::ClangDocContext(tooling::ExecutionContext *ECtx,
-                                 StringRef ProjectName, bool PublicOnly,
-                                 StringRef OutDirectory, StringRef SourceRoot,
-                                 StringRef RepositoryUrl,
-                                 StringRef RepositoryLinePrefix, StringRef Base,
-                                 std::vector<std::string> UserStylesheets,
-                                 clang::DiagnosticsEngine &Diags,
-                                 OutputFormatTy Format, bool FTimeTrace)
+ClangDocContext::ClangDocContext(
+    tooling::ExecutionContext *ECtx, StringRef ProjectName, bool PublicOnly,
+    StringRef OutDirectory, StringRef SourceRoot, StringRef RepositoryUrl,
+    StringRef RepositoryLinePrefix, StringRef Base,
+    std::vector<std::string> UserStylesheets, clang::DiagnosticsEngine &Diags,
+    OutputFormatTy Format, bool FTimeTrace, bool CompactJSON)
     : ECtx(ECtx), ProjectName(ProjectName), OutDirectory(OutDirectory),
       SourceRoot(std::string(SourceRoot)), UserStylesheets(UserStylesheets),
       Base(Base), Diags(Diags), Format(Format), PublicOnly(PublicOnly),
-      FTimeTrace(FTimeTrace) {
+      FTimeTrace(FTimeTrace), CompactJSON(CompactJSON) {
   llvm::SmallString<128> SourceRootDir(SourceRoot);
   if (SourceRoot.empty())
     // If no SourceRoot was provided the current path is used as the default

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -727,7 +727,7 @@ struct ClangDocContext {
                   StringRef RepositoryUrl, StringRef RepositoryCodeLinePrefix,
                   StringRef Base, std::vector<std::string> UserStylesheets,
                   clang::DiagnosticsEngine &Diags, OutputFormatTy Format,
-                  bool FTimeTrace = false);
+                  bool FTimeTrace = false, bool CompactJSON = false);
   tooling::ExecutionContext *ECtx;
   std::string ProjectName;  // Name of project clang-doc is documenting.
   std::string OutDirectory; // Directory for outputting generated files.
@@ -755,6 +755,7 @@ struct ClangDocContext {
   int Granularity; // Granularity of ftime trace
   bool PublicOnly; // Indicates if only public declarations are documented.
   bool FTimeTrace; // Indicates if ftime trace is turned on
+  bool CompactJSON; // Indicates if JSON is emitted without whitespace.
 };
 
 // Ensure arena allocated types remain safe to allocate in the arena.

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -727,7 +727,7 @@ struct ClangDocContext {
                   StringRef RepositoryUrl, StringRef RepositoryCodeLinePrefix,
                   StringRef Base, std::vector<std::string> UserStylesheets,
                   clang::DiagnosticsEngine &Diags, OutputFormatTy Format,
-                  bool FTimeTrace = false, bool CompactJSON = false);
+                  bool FTimeTrace = false, bool Pretty = false);
   tooling::ExecutionContext *ECtx;
   std::string ProjectName;  // Name of project clang-doc is documenting.
   std::string OutDirectory; // Directory for outputting generated files.
@@ -755,7 +755,7 @@ struct ClangDocContext {
   int Granularity; // Granularity of ftime trace
   bool PublicOnly; // Indicates if only public declarations are documented.
   bool FTimeTrace; // Indicates if ftime trace is turned on
-  bool CompactJSON; // Indicates if JSON is emitted without whitespace.
+  bool Pretty;     // Indicates if JSON is emitted with whitespace.
 };
 
 // Ensure arena allocated types remain safe to allocate in the arena.

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -113,7 +113,7 @@ Turn on time profiler. Generates clang-doc-tracing.json)"),
                                       llvm::cl::cat(ClangDocCategory));
 
 static llvm::cl::opt<bool>
-    Pretty("pretty", llvm::cl::desc("Serialize JSON with whitespace."),
+    Pretty("pretty-json", llvm::cl::desc("Serialize JSON with whitespace."),
            llvm::cl::cat(ClangDocCategory));
 
 static llvm::cl::opt<OutputFormatTy> FormatEnum(

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -50,10 +50,6 @@ using clang::doc::OutputFormatTy;
 static llvm::cl::extrahelp CommonHelp(CommonOptionsParser::HelpMessage);
 static llvm::cl::OptionCategory ClangDocCategory("clang-doc options");
 
-static llvm::cl::opt<bool>
-    CompactJSON("compact", llvm::cl::desc("Serialize JSON without whitespace."),
-                llvm::cl::cat(ClangDocCategory));
-
 static llvm::cl::opt<std::string>
     ProjectName("project-name", llvm::cl::desc("Name of project."),
                 llvm::cl::cat(ClangDocCategory));
@@ -115,6 +111,10 @@ static llvm::cl::opt<bool> FTimeTrace("ftime-trace", llvm::cl::desc(R"(
 Turn on time profiler. Generates clang-doc-tracing.json)"),
                                       llvm::cl::init(false),
                                       llvm::cl::cat(ClangDocCategory));
+
+static llvm::cl::opt<bool>
+    Pretty("pretty", llvm::cl::desc("Serialize JSON with whitespace."),
+           llvm::cl::cat(ClangDocCategory));
 
 static llvm::cl::opt<OutputFormatTy> FormatEnum(
     "format", llvm::cl::desc("Format for outputted docs."),
@@ -313,7 +313,7 @@ Example usage for a project using a compile commands database:
         Executor->getExecutionContext(), ProjectName, PublicOnly, OutDirectory,
         SourceRoot, RepositoryUrl, RepositoryCodeLinePrefix, BaseDirectory,
         {UserStylesheets.begin(), UserStylesheets.end()}, Diags, FormatEnum,
-        FTimeTrace, CompactJSON);
+        FTimeTrace, Pretty);
 
     if (Format == "html")
       ExitOnErr(getHtmlFiles(argv[0], CDCtx));

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -50,6 +50,10 @@ using clang::doc::OutputFormatTy;
 static llvm::cl::extrahelp CommonHelp(CommonOptionsParser::HelpMessage);
 static llvm::cl::OptionCategory ClangDocCategory("clang-doc options");
 
+static llvm::cl::opt<bool>
+    CompactJSON("compact", llvm::cl::desc("Serialize JSON without whitespace."),
+                llvm::cl::cat(ClangDocCategory));
+
 static llvm::cl::opt<std::string>
     ProjectName("project-name", llvm::cl::desc("Name of project."),
                 llvm::cl::cat(ClangDocCategory));
@@ -309,7 +313,7 @@ Example usage for a project using a compile commands database:
         Executor->getExecutionContext(), ProjectName, PublicOnly, OutDirectory,
         SourceRoot, RepositoryUrl, RepositoryCodeLinePrefix, BaseDirectory,
         {UserStylesheets.begin(), UserStylesheets.end()}, Diags, FormatEnum,
-        FTimeTrace);
+        FTimeTrace, CompactJSON);
 
     if (Format == "html")
       ExitOnErr(getHtmlFiles(argv[0], CDCtx));

--- a/clang-tools-extra/test/clang-doc/compact.cpp
+++ b/clang-tools-extra/test/clang-doc/compact.cpp
@@ -5,6 +5,6 @@
 
 class Foo {};
 
-// CLASS: {"Contexts":[{"DocumentationFileName":"index","End":true,"Name":"Global Namespace","QualName":"GlobalNamespace","RelativePath":"{{.*}}","USR":"0000000000000000000000000000000000000000"}],"DocumentationFileName":"_ZTV3Foo","HasContexts":true,"InfoType":"record","IsTypedef":false,"Location":{"Filename":"/home/erick/code/llvm/clang-tools-extra/test/clang-doc/compact.cpp","LineNumber":6},"MangledName":"_ZTV3Foo","Name":"Foo","Namespace":["GlobalNamespace"],"Path":"GlobalNamespace","TagType":"class","USR":"{{([0-9A-F]{40})}}"}
+// CLASS: {"Contexts":[{"DocumentationFileName":"index","End":true,"Name":"Global Namespace","QualName":"GlobalNamespace","RelativePath":"{{.*}}","USR":"0000000000000000000000000000000000000000"}],"DocumentationFileName":"_ZTV3Foo","HasContexts":true,"InfoType":"record","IsTypedef":false,"Location":{"Filename":"{{.*}}compact.cpp","LineNumber":6},"MangledName":"_ZTV3Foo","Name":"Foo","Namespace":["GlobalNamespace"],"Path":"GlobalNamespace","TagType":"class","USR":"{{([0-9A-F]{40})}}"}
 
 // INDEX: {"Index":[{"Name":"GlobalNamespace","QualName":"GlobalNamespace","Type":"namespace","USR":"0000000000000000000000000000000000000000"}]}

--- a/clang-tools-extra/test/clang-doc/compact.cpp
+++ b/clang-tools-extra/test/clang-doc/compact.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --compact --doxygen --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --doxygen --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV3Foo.json --check-prefix=CLASS
 // RUN: FileCheck %s < %t/json/index.json --check-prefix=INDEX
 

--- a/clang-tools-extra/test/clang-doc/compact.cpp
+++ b/clang-tools-extra/test/clang-doc/compact.cpp
@@ -1,0 +1,10 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --compact --doxygen --output=%t --format=json --executor=standalone %s
+// RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV3Foo.json --check-prefix=CLASS
+// RUN: FileCheck %s < %t/json/index.json --check-prefix=INDEX
+
+class Foo {};
+
+// CLASS: {"Contexts":[{"DocumentationFileName":"index","End":true,"Name":"Global Namespace","QualName":"GlobalNamespace","RelativePath":"{{.*}}","USR":"0000000000000000000000000000000000000000"}],"DocumentationFileName":"_ZTV3Foo","HasContexts":true,"InfoType":"record","IsTypedef":false,"Location":{"Filename":"/home/erick/code/llvm/clang-tools-extra/test/clang-doc/compact.cpp","LineNumber":6},"MangledName":"_ZTV3Foo","Name":"Foo","Namespace":["GlobalNamespace"],"Path":"GlobalNamespace","TagType":"class","USR":"{{([0-9A-F]{40})}}"}
+
+// INDEX: {"Index":[{"Name":"GlobalNamespace","QualName":"GlobalNamespace","Type":"namespace","USR":"0000000000000000000000000000000000000000"}]}

--- a/clang-tools-extra/test/clang-doc/compact.cpp
+++ b/clang-tools-extra/test/clang-doc/compact.cpp
@@ -5,6 +5,27 @@
 
 class Foo {};
 
-// CLASS: {"Contexts":[{"DocumentationFileName":"index","End":true,"Name":"Global Namespace","QualName":"GlobalNamespace","RelativePath":"{{.*}}","USR":"0000000000000000000000000000000000000000"}],"DocumentationFileName":"_ZTV3Foo","HasContexts":true,"InfoType":"record","IsTypedef":false,"Location":{"Filename":"{{.*}}compact.cpp","LineNumber":6},"MangledName":"_ZTV3Foo","Name":"Foo","Namespace":["GlobalNamespace"],"Path":"GlobalNamespace","TagType":"class","USR":"{{([0-9A-F]{40})}}"}
+// CLASS:      {
+// CLASS-SAME: "Contexts":
+// CLASS-SAME: [{"DocumentationFileName":"index",
+// CLASS-SAME: "End":true,
+// CLASS-SAME: "Name":"Global Namespace",
+// CLASS-SAME: "QualName":"GlobalNamespace",
+// CLASS-SAME: "RelativePath":"{{.*}}","USR":"0000000000000000000000000000000000000000"}],
+// CLASS-SAME: "DocumentationFileName":"_ZTV3Foo",
+// CLASS-SAME: "HasContexts":true,
+// CLASS-SAME: "InfoType":"record",
+// CLASS-SAME: "IsTypedef":false,
+// CLASS-SAME: "Location":{"Filename":"{{.*}}compact.cpp","LineNumber":6},
+// CLASS-SAME: "MangledName":"_ZTV3Foo",
+// CLASS-SAME: "Name":"Foo",
+// CLASS-SAME: "Namespace":["GlobalNamespace"],
+// CLASS-SAME: "Path":"GlobalNamespace",
+// CLASS-SAME: "TagType":"class",
+// CLASS-SAME: "USR":"{{([0-9A-F]{40})}}"}
 
-// INDEX: {"Index":[{"Name":"GlobalNamespace","QualName":"GlobalNamespace","Type":"namespace","USR":"0000000000000000000000000000000000000000"}]}
+// INDEX:      {"Index":
+// INDEX-SAME: [{"Name":"GlobalNamespace",
+// INDEX-SAME: "QualName":"GlobalNamespace",
+// INDEX-SAME: "Type":"namespace",
+// INDEX-SAME: "USR":"0000000000000000000000000000000000000000"}]}

--- a/clang-tools-extra/test/clang-doc/enum.cpp
+++ b/clang-tools-extra/test/clang-doc/enum.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: clang-doc --format=html --doxygen --output=%t --executor=standalone %S/Inputs/enum.cpp
 // RUN: clang-doc --format=md --doxygen --output=%t --executor=standalone %S/Inputs/enum.cpp
-// RUN: clang-doc --format=md_mustache --pretty --doxygen --output=%t --executor=standalone %S/Inputs/enum.cpp
+// RUN: clang-doc --format=md_mustache --pretty-json --doxygen --output=%t --executor=standalone %S/Inputs/enum.cpp
 // RUN: FileCheck %s < %t/html/GlobalNamespace/index.html --check-prefix=HTML-INDEX
 // RUN: FileCheck %s < %t/html/GlobalNamespace/_ZTV7Animals.html --check-prefix=HTML-ANIMAL
 // RUN: FileCheck %s < %t/html/GlobalNamespace/_ZTV15FilePermissions.html --check-prefix=HTML-PERM

--- a/clang-tools-extra/test/clang-doc/enum.cpp
+++ b/clang-tools-extra/test/clang-doc/enum.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: clang-doc --format=html --doxygen --output=%t --executor=standalone %S/Inputs/enum.cpp
 // RUN: clang-doc --format=md --doxygen --output=%t --executor=standalone %S/Inputs/enum.cpp
-// RUN: clang-doc --format=md_mustache --doxygen --output=%t --executor=standalone %S/Inputs/enum.cpp
+// RUN: clang-doc --format=md_mustache --pretty --doxygen --output=%t --executor=standalone %S/Inputs/enum.cpp
 // RUN: FileCheck %s < %t/html/GlobalNamespace/index.html --check-prefix=HTML-INDEX
 // RUN: FileCheck %s < %t/html/GlobalNamespace/_ZTV7Animals.html --check-prefix=HTML-ANIMAL
 // RUN: FileCheck %s < %t/html/GlobalNamespace/_ZTV15FilePermissions.html --check-prefix=HTML-PERM

--- a/clang-tools-extra/test/clang-doc/index.cpp
+++ b/clang-tools-extra/test/clang-doc/index.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --format=html --pretty --output=%t --executor=standalone %s
+// RUN: clang-doc --format=html --pretty-json --output=%t --executor=standalone %s
 // RUN: FileCheck %s < %t/json/index.json -check-prefix=CHECK-JSON
 // RUN: FileCheck %s < %t/html/index.html -check-prefix=CHECK-HTML
 

--- a/clang-tools-extra/test/clang-doc/index.cpp
+++ b/clang-tools-extra/test/clang-doc/index.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --format=html --output=%t --executor=standalone %s
+// RUN: clang-doc --format=html --pretty --output=%t --executor=standalone %s
 // RUN: FileCheck %s < %t/json/index.json -check-prefix=CHECK-JSON
 // RUN: FileCheck %s < %t/html/index.html -check-prefix=CHECK-HTML
 

--- a/clang-tools-extra/test/clang-doc/json/class-requires.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class-requires.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --pretty --extra-arg -std=c++20 --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty-json --extra-arg -std=c++20 --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClass.json
 
 template<typename T>

--- a/clang-tools-extra/test/clang-doc/json/class-requires.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class-requires.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --extra-arg -std=c++20 --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty --extra-arg -std=c++20 --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClass.json
 
 template<typename T>

--- a/clang-tools-extra/test/clang-doc/json/class-specialization.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class-specialization.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty-json --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClass.json --check-prefix=BASE
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClassIiE.json --check-prefix=SPECIALIZATION
 

--- a/clang-tools-extra/test/clang-doc/json/class-specialization.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class-specialization.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClass.json --check-prefix=BASE
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClassIiE.json --check-prefix=SPECIALIZATION
 

--- a/clang-tools-extra/test/clang-doc/json/class-template.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class-template.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty-json --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClass.json
 
 template<typename T> struct MyClass {

--- a/clang-tools-extra/test/clang-doc/json/class-template.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class-template.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClass.json
 
 template<typename T> struct MyClass {

--- a/clang-tools-extra/test/clang-doc/json/class.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --pretty --output=%t --format=html --executor=standalone %s
+// RUN: clang-doc --pretty-json --output=%t --format=html --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClass.json
 // RUN: FileCheck %s < %t/html/GlobalNamespace/_ZTV7MyClass.html -check-prefix=HTML
 

--- a/clang-tools-extra/test/clang-doc/json/class.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --output=%t --format=html --executor=standalone %s
+// RUN: clang-doc --pretty --output=%t --format=html --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClass.json
 // RUN: FileCheck %s < %t/html/GlobalNamespace/_ZTV7MyClass.html -check-prefix=HTML
 

--- a/clang-tools-extra/test/clang-doc/json/compound-constraints.cpp
+++ b/clang-tools-extra/test/clang-doc/json/compound-constraints.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --pretty --extra-arg -std=c++20 --output=%t --doxygen --format=html --executor=standalone %s
+// RUN: clang-doc --pretty-json --extra-arg -std=c++20 --output=%t --doxygen --format=html --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
 // RUN: FileCheck %s < %t/html/GlobalNamespace/index.html -check-prefix=CHECK-HTML
 

--- a/clang-tools-extra/test/clang-doc/json/compound-constraints.cpp
+++ b/clang-tools-extra/test/clang-doc/json/compound-constraints.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --extra-arg -std=c++20 --output=%t --doxygen --format=html --executor=standalone %s
+// RUN: clang-doc --pretty --extra-arg -std=c++20 --output=%t --doxygen --format=html --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
 // RUN: FileCheck %s < %t/html/GlobalNamespace/index.html -check-prefix=CHECK-HTML
 

--- a/clang-tools-extra/test/clang-doc/json/concept.cpp
+++ b/clang-tools-extra/test/clang-doc/json/concept.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --pretty --extra-arg -std=c++20 --output=%t --format=html --executor=standalone %s
+// RUN: clang-doc --pretty-json --extra-arg -std=c++20 --output=%t --format=html --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
 
 // Requires that T suports post and pre-incrementing.

--- a/clang-tools-extra/test/clang-doc/json/concept.cpp
+++ b/clang-tools-extra/test/clang-doc/json/concept.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --extra-arg -std=c++20 --output=%t --format=html --executor=standalone %s
+// RUN: clang-doc --pretty --extra-arg -std=c++20 --output=%t --format=html --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
 
 // Requires that T suports post and pre-incrementing.

--- a/clang-tools-extra/test/clang-doc/json/function-requires.cpp
+++ b/clang-tools-extra/test/clang-doc/json/function-requires.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --pretty --extra-arg -std=c++20 --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty-json --extra-arg -std=c++20 --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
 
 template<typename T>

--- a/clang-tools-extra/test/clang-doc/json/function-requires.cpp
+++ b/clang-tools-extra/test/clang-doc/json/function-requires.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --extra-arg -std=c++20 --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty --extra-arg -std=c++20 --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
 
 template<typename T>

--- a/clang-tools-extra/test/clang-doc/json/function-specifiers.cpp
+++ b/clang-tools-extra/test/clang-doc/json/function-specifiers.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty-json --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
 
 static void myFunction() {}

--- a/clang-tools-extra/test/clang-doc/json/function-specifiers.cpp
+++ b/clang-tools-extra/test/clang-doc/json/function-specifiers.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
 
 static void myFunction() {}

--- a/clang-tools-extra/test/clang-doc/json/inheritance.cpp
+++ b/clang-tools-extra/test/clang-doc/json/inheritance.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty-json --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClass.json
 
 class Virtual {};

--- a/clang-tools-extra/test/clang-doc/json/inheritance.cpp
+++ b/clang-tools-extra/test/clang-doc/json/inheritance.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClass.json
 
 class Virtual {};

--- a/clang-tools-extra/test/clang-doc/json/method-template.cpp
+++ b/clang-tools-extra/test/clang-doc/json/method-template.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty-json --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClass.json
 
 struct MyClass {

--- a/clang-tools-extra/test/clang-doc/json/method-template.cpp
+++ b/clang-tools-extra/test/clang-doc/json/method-template.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClass.json
 
 struct MyClass {

--- a/clang-tools-extra/test/clang-doc/json/multiple-namespaces.cpp
+++ b/clang-tools-extra/test/clang-doc/json/multiple-namespaces.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty-json --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/foo/tools/index.json --check-prefix=CHECK-FOO
 // RUN: FileCheck %s < %t/json/bar/tools/index.json --check-prefix=CHECK-BAR
 

--- a/clang-tools-extra/test/clang-doc/json/multiple-namespaces.cpp
+++ b/clang-tools-extra/test/clang-doc/json/multiple-namespaces.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/foo/tools/index.json --check-prefix=CHECK-FOO
 // RUN: FileCheck %s < %t/json/bar/tools/index.json --check-prefix=CHECK-BAR
 

--- a/clang-tools-extra/test/clang-doc/json/namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/json/namespace.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --pretty --output=%t --format=html --executor=standalone %s
+// RUN: clang-doc --pretty-json --output=%t --format=html --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
 // RUN: FileCheck %s < %t/html/GlobalNamespace/index.html -check-prefix=HTML-CHECK
 

--- a/clang-tools-extra/test/clang-doc/json/namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/json/namespace.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --output=%t --format=html --executor=standalone %s
+// RUN: clang-doc --pretty --output=%t --format=html --executor=standalone %s
 // RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
 // RUN: FileCheck %s < %t/html/GlobalNamespace/index.html -check-prefix=HTML-CHECK
 

--- a/clang-tools-extra/test/clang-doc/json/nested-namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/json/nested-namespace.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
+// RUN: clang-doc --pretty-json --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/nested/index.json --check-prefix=NESTED
 // RUN: FileCheck %s < %t/json/nested/inner/index.json --check-prefix=INNER
 

--- a/clang-tools-extra/test/clang-doc/json/nested-namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/json/nested-namespace.cpp
@@ -1,6 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --output=%t --format=json --executor=standalone %s
-// RUN: clang-doc --output=%t --format=html --executor=standalone %s
+// RUN: clang-doc --pretty --output=%t --format=json --executor=standalone %s
 // RUN: FileCheck %s < %t/json/nested/index.json --check-prefix=NESTED
 // RUN: FileCheck %s < %t/json/nested/inner/index.json --check-prefix=INNER
 
@@ -19,7 +18,7 @@ namespace nested {
 // NESTED-NEXT:      "IsStatic": false,
 // NESTED-NEXT:      "Location": {
 // NESTED-NEXT:        "Filename": "{{.*}}nested-namespace.cpp",
-// NESTED-NEXT:        "LineNumber": 8
+// NESTED-NEXT:        "LineNumber": 7
 // NESTED-NEXT:      },
 // NESTED-NEXT:      "Name": "Global",
 // NESTED-NEXT:      "Namespace": [
@@ -33,7 +32,7 @@ namespace nested {
 // INNER-NEXT:      "IsStatic": false,
 // INNER-NEXT:      "Location": {
 // INNER-NEXT:        "Filename": "{{.*}}nested-namespace.cpp",
-// INNER-NEXT:        "LineNumber": 10
+// INNER-NEXT:        "LineNumber": 9
 // INNER-NEXT:      },
 // INNER-NEXT:      "Name": "InnerGlobal",
 // INNER-NEXT:      "Namespace": [

--- a/clang-tools-extra/test/clang-doc/templates.cpp
+++ b/clang-tools-extra/test/clang-doc/templates.cpp
@@ -7,7 +7,7 @@
 // RUN: clang-doc --doxygen --executor=standalone %s -output=%t/docs --format=md
 // RUN: cat %t/docs/GlobalNamespace/index.md | FileCheck %s --check-prefix=MD
 
-// RUN: clang-doc --pretty --doxygen --executor=standalone %s -output=%t/docs --format=html
+// RUN: clang-doc --pretty-json --doxygen --executor=standalone %s -output=%t/docs --format=html
 // RUN: cat %t/docs/json/GlobalNamespace/index.json | FileCheck %s --check-prefix=JSON
 // RUN: cat %t/docs/html/GlobalNamespace/_ZTV5tuple.html | FileCheck %s --check-prefix=HTML-STRUCT
 // RUN: cat %t/docs/html/GlobalNamespace/index.html | FileCheck %s --check-prefix=HTML

--- a/clang-tools-extra/test/clang-doc/templates.cpp
+++ b/clang-tools-extra/test/clang-doc/templates.cpp
@@ -7,7 +7,7 @@
 // RUN: clang-doc --doxygen --executor=standalone %s -output=%t/docs --format=md
 // RUN: cat %t/docs/GlobalNamespace/index.md | FileCheck %s --check-prefix=MD
 
-// RUN: clang-doc --doxygen --executor=standalone %s -output=%t/docs --format=html
+// RUN: clang-doc --pretty --doxygen --executor=standalone %s -output=%t/docs --format=html
 // RUN: cat %t/docs/json/GlobalNamespace/index.json | FileCheck %s --check-prefix=JSON
 // RUN: cat %t/docs/html/GlobalNamespace/_ZTV5tuple.html | FileCheck %s --check-prefix=HTML-STRUCT
 // RUN: cat %t/docs/html/GlobalNamespace/index.html | FileCheck %s --check-prefix=HTML

--- a/clang-tools-extra/unittests/clang-doc/ClangDocTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/ClangDocTest.cpp
@@ -26,7 +26,7 @@ ClangDocContext ClangDocContextTest::getClangDocContext(
     StringRef RepositoryLinePrefix, StringRef Base) {
   return ClangDocContext(nullptr, "test-project", false, "", "", RepositoryUrl,
                          RepositoryLinePrefix, Base, UserStylesheets, Diags,
-                         OutputFormatTy::html, false);
+                         OutputFormatTy::html, false, true);
 }
 
 NamespaceInfo *InfoAsNamespace(Info *I) {


### PR DESCRIPTION
By default all JSON is serialized "pretty" with whitespace. This patch
adds an option to serialize JSON without whitespace. This trims the size
of the JSON folder for clang from around 1.3 GB to 785 MB, which is a 39.6% decrease.
