### PR TITLE
[MLIR] Add  I{8,16}Enum tablegen classes

### DIFF
--- a/mlir/include/mlir/IR/EnumAttr.td
+++ b/mlir/include/mlir/IR/EnumAttr.td
@@ -48,6 +48,10 @@ class IntEnumAttrCaseBase<I intType, string sym, string strVal, int intVal> :
 
 // Cases of integer enums with a specific type. By default, the string
 // representation is the same as the C++ symbol name.
+class I8EnumCase<string sym, int val, string str = sym>
+  : EnumCase<sym, val, str, 8>;
+class I16EnumCase<string sym, int val, string str = sym>
+  : EnumCase<sym, val, str, 16>;
 class I32EnumCase<string sym, int val, string str = sym>
   : EnumCase<sym, val, str, 32>;
 class I64EnumCase<string sym, int val, string str = sym>
@@ -292,6 +296,10 @@ class IntEnum<string name, string summary, list<EnumCase> cases, int width>
           summary),
       cases, width>;
 
+class I8Enum<string name, string summary, list<EnumCase> cases>
+    : IntEnum<name, summary, cases, 8>;
+class I16Enum<string name, string summary, list<EnumCase> cases>
+    : IntEnum<name, summary, cases, 16>;
 class I32Enum<string name, string summary, list<EnumCase> cases>
     : IntEnum<name, summary, cases, 32>;
 class I64Enum<string name, string summary, list<EnumCase> cases>

--- a/mlir/test/lib/Dialect/Test/TestAttrDefs.td
+++ b/mlir/test/lib/Dialect/Test/TestAttrDefs.td
@@ -352,6 +352,13 @@ def TestArrayOfUglyAttrs : ArrayOfAttr<Test_Dialect, "ArrayOfUglyAttrs",
 def TestArrayOfInts : ArrayOfAttr<Test_Dialect, "ArrayOfInts",
     "array_of_ints", "int32_t">;
 
+def TestSimpleEnum8Attr : EnumAttr<Test_Dialect, TestSimpleEnum8, "simple_enum_8"> {
+  let assemblyFormat = "`` $value";
+}
+
+def TestSimpleEnum16Attr : EnumAttr<Test_Dialect, TestSimpleEnum16, "simple_enum_16"> {
+  let assemblyFormat = "`` $value";
+}
 // An array of enum attributes.
 def TestSimpleEnumAttr : EnumAttr<Test_Dialect, TestSimpleEnum, "simple_enum"> {
   let assemblyFormat = "`` $value";

--- a/mlir/test/lib/Dialect/Test/TestEnumDefs.td
+++ b/mlir/test/lib/Dialect/Test/TestEnumDefs.td
@@ -65,6 +65,20 @@ def TestSimpleEnum : I32Enum<"SimpleEnum", "", [
   let cppNamespace = "::test";
 }
 
+def TestSimpleEnum8: I8Enum<"SimpleEnum8", "", [
+    I8EnumCase<"a", 254>,
+    I8EnumCase<"b", 255>,
+  ]> {
+  let cppNamespace = "::test";
+}
+
+def TestSimpleEnum16: I16Enum<"SimpleEnum16", "", [
+    I16EnumCase<"a", 65534>,
+    I16EnumCase<"b", 65535>,
+  ]> {
+  let cppNamespace = "::test";
+}
+
 def TestSimpleEnum64 : I64Enum<"SimpleEnum64", "", [
     I64EnumCase<"a", 4294967296>,
     I64EnumCase<"b", 4294967297>

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -489,6 +489,20 @@ def OpWithBitEnumPropNamed : TEST_Op<"op_with_bit_enum_prop_named"> {
   let assemblyFormat = "$value1 ($value2^)? attr-dict";
 }
 
+def TestSimpleEnum8Prop : EnumProp<TestSimpleEnum8>;
+
+def OpWithSimpleEnum8Prop : TEST_Op<"op_with_simple_enum_8_prop"> {
+  let arguments = (ins TestSimpleEnum8Prop:$value);
+  let assemblyFormat = "$value attr-dict";
+}
+
+def TestSimpleEnum16Prop : EnumProp<TestSimpleEnum16>;
+
+def OpWithSimpleEnum16Prop : TEST_Op<"op_with_simple_enum_16_prop"> {
+  let arguments = (ins TestSimpleEnum16Prop:$value);
+  let assemblyFormat = "$value attr-dict";
+}
+
 //===----------------------------------------------------------------------===//
 // Test Bit Enum Attributes
 //===----------------------------------------------------------------------===//

--- a/mlir/test/mlir-tblgen/enums-gen.td
+++ b/mlir/test/mlir-tblgen/enums-gen.td
@@ -63,10 +63,22 @@ def MyBitEnum: I32BitEnumAttr<"MyBitEnum", "An example bit enum",
 // DECL:   b = 255,
 // DECL: };
 
+// DECL: ::std::optional<MyI8Enum> symbolizeMyI8Enum(uint8_t);
+
+// DECL: inline constexpr unsigned getMaxEnumValForMyI8Enum() {
+// DECL:   return 255;
+// DECL: }
+
 // DECL: enum class MyI16Enum : uint16_t {
 // DECL:   a = 65534,
 // DECL:   b = 65535,
 // DECL: };
+
+// DECL: ::std::optional<MyI16Enum> symbolizeMyI16Enum(uint16_t);
+
+// DECL: inline constexpr unsigned getMaxEnumValForMyI16Enum() {
+// DECL:   return 65535;
+// DECL: }
 
 // DEF-LABEL: std::string stringifyMyBitEnum
 // DEF: auto val = static_cast<uint32_t>

--- a/mlir/test/mlir-tblgen/enums-gen.td
+++ b/mlir/test/mlir-tblgen/enums-gen.td
@@ -147,6 +147,6 @@ def MyI8Enum : I8Enum<"MyI8Enum", "Example I8 enum", [
   ]>;
 
 def MyI16Enum : I16Enum<"MyI16Enum", "Example I16 enum", [
-    I8EnumCase<"a", 65534>,
-    I8EnumCase<"b", 65535>
+    I16EnumCase<"a", 65534>,
+    I16EnumCase<"b", 65535>
   ]>;

--- a/mlir/test/mlir-tblgen/enums-gen.td
+++ b/mlir/test/mlir-tblgen/enums-gen.td
@@ -58,6 +58,16 @@ def MyBitEnum: I32BitEnumAttr<"MyBitEnum", "An example bit enum",
 // DECL:     return p << '"' << valueStr << '"';
 // DECL:   return p << valueStr;
 
+// DECL: enum class MyI8Enum : uint8_t {
+// DECL:   a = 254,
+// DECL:   b = 255,
+// DECL: };
+
+// DECL: enum class MyI16Enum : uint16_t {
+// DECL:   a = 65534,
+// DECL:   b = 65535,
+// DECL: };
+
 // DEF-LABEL: std::string stringifyMyBitEnum
 // DEF: auto val = static_cast<uint32_t>
 // DEF: if (val == 0) return "none";
@@ -130,3 +140,13 @@ def MyNonQuotedPrintBitEnum
 // DECL: inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::MyNonQuotedPrintBitEnum value) {
 // DECL:   auto valueStr = stringifyEnum(value);
 // DECL-NEXT:   return p << valueStr;
+
+def MyI8Enum : I8Enum<"MyI8Enum", "Example I8 enum", [
+    I8EnumCase<"a", 254>,
+    I8EnumCase<"b", 255>
+  ]>;
+
+def MyI16Enum : I16Enum<"MyI16Enum", "Example I16 enum", [
+    I8EnumCase<"a", 65534>,
+    I8EnumCase<"b", 65535>
+  ]>;


### PR DESCRIPTION
Add utility tablegen classes for creating 8 and 16 bit enums, simplifying defining enums that fit into smaller types.