### PR TITLE
[lldb][test] Fix dsym-auto-load-modules-multiple.test

### DIFF
--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-multiple.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-multiple.test
@@ -4,13 +4,13 @@
 # auto-loaded.
 
 # RUN: split-file %s %t
-# RUN: %clang_host -shared %t/lib.c -o %t/libFoo.dylib
-# RUN: %clang_host %t/main.c -o %t/TestModule.out %t/libFoo.dylib
+# RUN: %clang_host -g -shared %t/lib.c -o %t/libFoo.dylib
+# RUN: %clang_host -g %t/main.c -o %t/TestModule.out %t/libFoo.dylib
 # RUN: mkdir -p %t/TestModule.out.dSYM/Contents/Resources/Python
-# RUN: mkdir -p %t/libFoo.out.dSYM/Contents/Resources/Python
-#
+# RUN: mkdir -p %t/libFoo.dylib.dSYM/Contents/Resources/Python
+
 # RUN: cp %t/main_script.py %t/TestModule.out.dSYM/Contents/Resources/Python/TestModule.py
-# RUN: cp %t/lib_script.py %t/libFoo.out.dSYM/Contents/Resources/Python/libFoo.py
+# RUN: cp %t/lib_script.py %t/libFoo.dylib.dSYM/Contents/Resources/Python/libFoo.py
 
 # RUN: %lldb -b \
 # RUN:   -o 'settings set target.load-script-from-symbol-file false' \


### PR DESCRIPTION
We were compiling without debug-info causing the test to fail on macOS. This was a silly oversight because I was mainly working on Linux when working on the last iterations of the patch that added this test.