### PR TITLE
[lldb][windows] re-enable unicode tests on Windows

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -499,7 +499,7 @@ def unicode_test(func):
             return unittest.skip(
                 "Unicode test requires an interactive console (stderr is redirected)"
             )
-        return
+        return func
 
     def unicode_wrapped(*args, **kwargs):
         import os

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -480,15 +480,25 @@ def unicode_test(func):
     """Decorate the item as a test which requires Unicode to be enabled.
 
     lldb checks the value of the `LANG` environment variable for the substring "utf-8"
-    to determine if the terminal supports Unicode (except on Windows, where we assume
-    it's always supported).
+    to determine if the terminal supports Unicode (except on Windows, where stdout
+    being connected to an interactive console is used as the signal instead).
     This decorator sets LANG to `utf-8` before running the test and resets it to its
     previous value afterwards.
     """
 
     if sys.platform == "win32":
-        # Unicode support on Windows is flaky in CI.
-        return expectedFailureWindows
+        import ctypes
+
+        STD_OUTPUT_HANDLE = -11
+        FILE_TYPE_CHAR = 0x0002
+        handle = ctypes.windll.kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+        file_type = ctypes.windll.kernel32.GetFileType(handle)
+        # Mirror Terminal::SupportsUnicode(): Unicode is supported only when
+        # stdout is connected to a real console.
+        if file_type != FILE_TYPE_CHAR:
+            return unittest.skip(
+                "Unicode test requires an interactive console (stderr is redirected)"
+            )
 
     def unicode_wrapped(*args, **kwargs):
         import os

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -499,6 +499,7 @@ def unicode_test(func):
             return unittest.skip(
                 "Unicode test requires an interactive console (stderr is redirected)"
             )
+        return
 
     def unicode_wrapped(*args, **kwargs):
         import os

--- a/lldb/source/Host/common/Terminal.cpp
+++ b/lldb/source/Host/common/Terminal.cpp
@@ -20,6 +20,10 @@
 #include <termios.h>
 #endif
 
+#ifdef _WIN32
+#include "lldb/Host/windows/windows.h"
+#endif
+
 using namespace lldb_private;
 
 struct Terminal::Data {
@@ -402,7 +406,7 @@ llvm::Error Terminal::SetHardwareFlowControl(bool enabled) {
 
 bool Terminal::SupportsUnicode() {
 #ifdef _WIN32
-  return true;
+  return ::GetFileType(GetStdHandle(STD_OUTPUT_HANDLE)) == FILE_TYPE_CHAR;
 #else
   static std::optional<bool> g_result;
   if (g_result)

--- a/lldb/test/API/terminal/hidden_frame_markers/TestHiddenFrameMarkers.py
+++ b/lldb/test/API/terminal/hidden_frame_markers/TestHiddenFrameMarkers.py
@@ -10,7 +10,9 @@ from lldbsuite.test import lldbutil
 
 class HiddenFrameMarkerTest(TestBase):
     @unicode_test
-    @expectedFailureWindows(bugnumber="https://github.com/llvm/llvm-project/issues/191459")
+    @expectedFailureWindows(
+        bugnumber="https://github.com/llvm/llvm-project/issues/191459"
+    )
     def test_hidden_frame_markers(self):
         """Test that hidden frame markers are rendered in backtraces"""
         self.build()
@@ -50,7 +52,9 @@ class HiddenFrameMarkerTest(TestBase):
         )
 
     @unicode_test
-    @expectedFailureWindows(bugnumber="https://github.com/llvm/llvm-project/issues/191459")
+    @expectedFailureWindows(
+        bugnumber="https://github.com/llvm/llvm-project/issues/191459"
+    )
     def test_nested_hidden_frame_markers(self):
         """Test that nested hidden frame markers are rendered in backtraces"""
         self.build()

--- a/lldb/test/API/terminal/hidden_frame_markers/TestHiddenFrameMarkers.py
+++ b/lldb/test/API/terminal/hidden_frame_markers/TestHiddenFrameMarkers.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 class HiddenFrameMarkerTest(TestBase):
     @unicode_test
+    @expectedFailureWindows(bugnumber="https://github.com/llvm/llvm-project/issues/191459")
     def test_hidden_frame_markers(self):
         """Test that hidden frame markers are rendered in backtraces"""
         self.build()
@@ -49,6 +50,7 @@ class HiddenFrameMarkerTest(TestBase):
         )
 
     @unicode_test
+    @expectedFailureWindows(bugnumber="https://github.com/llvm/llvm-project/issues/191459")
     def test_nested_hidden_frame_markers(self):
         """Test that nested hidden frame markers are rendered in backtraces"""
         self.build()


### PR DESCRIPTION
This patch re-enables unicode tests on Windows by improving the `Terminal::SupportsUnicode` check.

Checking that the stdout handle is a `FILE_TYPE_CHAR` is a better heuristic than always returning true, which assumed we were always using a terminal and never piping the output.