### PR TITLE
Mark llvm/test/ExecutionEngine and llvm/test/Examples tests as UNSUPPORTED for zOS

### DIFF
--- a/llvm/test/Examples/lit.local.cfg
+++ b/llvm/test/Examples/lit.local.cfg
@@ -1,4 +1,4 @@
-if not config.include_examples or sys.platform in ["win32", "cygwin", "aix"]:
+if not config.include_examples or sys.platform in ["win32", "cygwin", "aix", "zos"]:
     config.unsupported = True
 
 # Test discovery should ignore subdirectories that contain test inputs.

--- a/llvm/test/Examples/lit.local.cfg
+++ b/llvm/test/Examples/lit.local.cfg
@@ -1,4 +1,4 @@
-if not config.include_examples or sys.platform in ["win32", "cygwin", "aix", "zos"]:
+if not config.include_examples or sys.platform in ["win32", "cygwin", "aix"] or "zos" in config.target_triple:
     config.unsupported = True
 
 # Test discovery should ignore subdirectories that contain test inputs.

--- a/llvm/test/ExecutionEngine/lit.local.cfg
+++ b/llvm/test/ExecutionEngine/lit.local.cfg
@@ -4,3 +4,6 @@ if config.root.native_target in ['Sparc', 'Hexagon']:
 # ExecutionEngine tests are not expected to pass in a cross-compilation setup.
 if "native" not in config.available_features:
     config.unsupported = True
+
+if sys.platform in ["zos"]:
+    config.unsupported = True

--- a/llvm/test/ExecutionEngine/lit.local.cfg
+++ b/llvm/test/ExecutionEngine/lit.local.cfg
@@ -5,5 +5,5 @@ if config.root.native_target in ['Sparc', 'Hexagon']:
 if "native" not in config.available_features:
     config.unsupported = True
 
-if sys.platform in ["zos"]:
+if "zos" in config.target_triple:
     config.unsupported = True


### PR DESCRIPTION
Tests in `llvm/test/Examples` and `llvm/test/ExecutionEngine` use JIT which is unsupported for zOS causing the tests to fail.