### PR TITLE
[flang] Reference LLVM RFC process in Flang docs, with caveats

### DIFF
--- a/flang/docs/GettingInvolved.md
+++ b/flang/docs/GettingInvolved.md
@@ -25,7 +25,7 @@ Contributions to Flang are done using GitHub Pull Requests and follow the
 When proposing substantive changes to either the Flang codebase or community practices, please follow the LLVM [Request for Comment (RFC) process](https://llvm.org/docs/RFCProcess.html) with the following caveats:
 -   Currently, there is no Flang Area Team to facilitate decision making. The present best practice is for the RFC author to periodically summarize the discussion to date, clearly state the apparent next steps, and list any outstanding questions needing resolution. If a rough consensus has been reached, please indicate this in the summary comment.
 -   Ideally, if the RFC is discussed on a community call, reference the meeting notes directly in the summary comment, whether to indicate that a decision was reached or simply to point to the relevant discussion. 
--   If the RFC results in a pull request (or series thereof), the author should provide a link to it in the RFC discussion.
+-   If the RFC results in one or more pull requests, the author should provide a link to it in the RFC discussion.
 
 
 ## Forum and Mailing Lists

--- a/flang/docs/GettingInvolved.md
+++ b/flang/docs/GettingInvolved.md
@@ -22,7 +22,7 @@ To understand the status of various developments in Flang please join the respec
 Contributions to Flang are done using GitHub Pull Requests and follow the
 [LLVM contribution process](https://llvm.org/docs/Contributing.html).
 
-In the case of proposing substantive changes to either the Flang codebase or community practices, please follow the LLVM [Request for Comment (RFC) process](https://llvm.org/docs/RFCProcess.html) with the following caveats:
+When proposing substantive changes to either the Flang codebase or community practices, please follow the LLVM [Request for Comment (RFC) process](https://llvm.org/docs/RFCProcess.html) with the following caveats:
 -   Currently, there is no Flang Area Team to facilitate decision making. The present best practice is for the RFC author to periodically summarize the discussion to date, clearly state the apparent next steps, and list any outstanding questions needing resolution. If a rough consensus has been reached, please indicate this in the summary comment.
 -   Ideally, if the RFC is discussed on a community call, reference the meeting notes directly in the summary comment, whether to indicate that a decision was reached or simply to point to the relevant discussion. 
 -   If the RFC results in a pull request (or series thereof), the author should provide a link to it in the RFC discussion.

--- a/flang/docs/GettingInvolved.md
+++ b/flang/docs/GettingInvolved.md
@@ -22,16 +22,17 @@ To understand the status of various developments in Flang please join the respec
 Contributions to Flang are done using GitHub Pull Requests and follow the
 [LLVM contribution process](https://llvm.org/docs/Contributing.html).
 
+In the case of proposing substantive changes to either the Flang codebase or community practices, please follow the LLVM [Request for Comment (RFC) process](https://llvm.org/docs/RFCProcess.html) with the following caveats:
+-   Currently, there is no Flang Area Team to facilitate decision making. The present best practice is for the RFC author to periodically summarize the discussion to date, clearly state the apparent next steps, and list any outstanding questions needing resolution. If a rough consensus has been reached, please indicate this in the summary comment.
+-   Ideally, if the RFC is discussed on a community call, reference the meeting notes directly in the summary comment, whether to indicate that a decision was reached or simply to point to the relevant discussion. 
+-   If the RFC results in a pull request (or series thereof), the author should provide a link to it in the RFC discussion.
+
+
 ## Forum and Mailing Lists
 
 [Forum](https://discourse.llvm.org/c/subprojects/flang)
 
   Flang forums are for technical discussions, questions about writing code for, or using Flang tools.
-
-  In the case of proposing substantive changes to either the Flang codebase or community practices, please follow the LLVM [Request for Comment (RFC) process](https://llvm.org/docs/RFCProcess.html) with the following caveats:
--   Currently, there is no Flang Area Team to facilitate decision making. The present best practice is for the RFC author to periodically summarize the discussion to date, clearly state the apparent next steps, and list any outstanding questions needing resolution. If a rough consensus has been reached, please indicate this in the summary comment.
--   Ideally, if the RFC is discussed on a community call, reference the meeting notes directly in the summary comment, whether to indicate that a decision was reached or simply to point to the relevant discussion. 
--   If the RFC results in a pull request (or series thereof), the author should provide a link to it in the RFC discussion.
 
 [Commits Archive (flang-commits)](http://lists.llvm.org/pipermail/flang-commits)
 

--- a/flang/docs/GettingInvolved.md
+++ b/flang/docs/GettingInvolved.md
@@ -28,6 +28,10 @@ Contributions to Flang are done using GitHub Pull Requests and follow the
 
   Flang forums are for technical discussions, questions about writing code for, or using Flang tools.
 
+  In the case of proposing substantive changes to either the Flang codebase or community practices, please follow the LLVM [Request for Comment (RFC) process](https://llvm.org/docs/RFCProcess.html) with the following caveats:
+-   Currently, there is no Flang Area Team to facilitate decision making. The present best practice is for the RFC author to periodically summarize the discussion to date, clearly state the apparent next steps, and list any outstanding questions needing resolution. If a rough consensus has been reached, please indicate this in the summary comment.
+-   Ideally, if the RFC is discussed on a community call, reference the meeting notes directly in the summary comment, whether to indicate that a decision was reached or simply to point to the relevant discussion. 
+-   If the RFC results in a pull request (or series thereof), the author should provide a link to it in the RFC discussion.
 
 [Commits Archive (flang-commits)](http://lists.llvm.org/pipermail/flang-commits)
 


### PR DESCRIPTION
This PR is pursuant to a discussion held on the March 25th Flang Community Call regarding how to document our community's RFC best practices for the benefit of new contributors and facilitating a smoother decision making process overall.