### PR TITLE
Revert "[IR] Use iteration limit in stripPointerCastsAndOffsets"

### DIFF
--- a/llvm/lib/IR/Value.cpp
+++ b/llvm/lib/IR/Value.cpp
@@ -642,12 +642,11 @@ static const Value *stripPointerCastsAndOffsets(
     return V;
 
   // Even though we don't look through PHI nodes, we could be called on an
-  // instruction in an unreachable block, which may be on a cycle. E.g.:
-  //   %gep = getelementptr inbounds nuw i8, ptr %gep, i64 32
-  //
-  // Bound against that case with a simple iteration counter. Practically, more
-  // than 10 iterations are almost never needed.
-  for (unsigned N = 0; N < 12; ++N) {
+  // instruction in an unreachable block, which may be on a cycle.
+  SmallPtrSet<const Value *, 4> Visited;
+
+  Visited.insert(V);
+  do {
     Func(V);
     if (auto *GEP = dyn_cast<GEPOperator>(V)) {
       switch (StripKind) {
@@ -667,11 +666,7 @@ static const Value *stripPointerCastsAndOffsets(
           return V;
         break;
       }
-      const Value *NewV = GEP->getPointerOperand();
-      // Quick exit for degenerate IR, which can happen in unreachable blocks.
-      if (NewV == V)
-        return V;
-      V = NewV;
+      V = GEP->getPointerOperand();
     } else if (Operator::getOpcode(V) == Instruction::BitCast) {
       Value *NewV = cast<Operator>(V)->getOperand(0);
       if (!NewV->getType()->isPointerTy())
@@ -706,7 +701,7 @@ static const Value *stripPointerCastsAndOffsets(
       return V;
     }
     assert(V->getType()->isPointerTy() && "Unexpected operand type!");
-  }
+  } while (Visited.insert(V).second);
 
   return V;
 }


### PR DESCRIPTION
Reverts llvm/llvm-project#190472

Causes crashes: https://github.com/llvm/llvm-project/pull/190472#issuecomment-4201843466