### PR TITLE
[clang][deps] Simplify scanner VFS

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyScanningFilesystem.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningFilesystem.h
@@ -382,12 +382,6 @@ public:
 
   std::error_code setCurrentWorkingDirectory(const Twine &Path) override;
 
-  /// Make it so that no paths bypass this VFS.
-  void resetBypassedPathPrefix() { BypassedPathPrefix.reset(); }
-  /// Set the prefix for paths that should bypass this VFS and go straight to
-  /// the underlying VFS.
-  void setBypassedPathPrefix(StringRef Prefix) { BypassedPathPrefix = Prefix; }
-
   /// Returns entry for the given filename.
   ///
   /// Attempts to use the local and shared caches first, then falls back to
@@ -495,18 +489,11 @@ private:
     getUnderlyingFS().print(OS, Type, IndentLevel + 1);
   }
 
-  /// Whether this path should bypass this VFS and go straight to the underlying
-  /// VFS.
-  bool shouldBypass(StringRef Path) const;
-
   /// The global cache shared between worker threads.
   DependencyScanningFilesystemSharedCache &SharedCache;
   /// The local cache is used by the worker thread to cache file system queries
   /// locally instead of querying the global cache every time.
   DependencyScanningFilesystemLocalCache LocalCache;
-
-  /// Prefix of paths that should go straight to the underlying VFS.
-  std::optional<std::string> BypassedPathPrefix;
 
   /// The working directory to use for making relative paths absolute before
   /// using them for cache lookups.

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -426,19 +426,10 @@ void dependencies::initializeScanCompilerInstance(
   ScanInstance.createSourceManager();
 
   // Use DepFS for getting the dependency directives if requested to do so.
-  if (Service.getOpts().Mode == ScanningMode::DependencyDirectivesScan) {
-    DepFS->resetBypassedPathPrefix();
-    SmallString<256> ModulesCachePath;
-    normalizeModuleCachePath(ScanInstance.getFileManager(),
-                             ScanInstance.getHeaderSearchOpts().ModuleCachePath,
-                             ModulesCachePath);
-    if (!ModulesCachePath.empty())
-      DepFS->setBypassedPathPrefix(ModulesCachePath);
-
+  if (Service.getOpts().Mode == ScanningMode::DependencyDirectivesScan)
     ScanInstance.setDependencyDirectivesGetter(
         std::make_unique<ScanningDependencyDirectivesGetter>(
             ScanInstance.getFileManager()));
-  }
 }
 
 std::shared_ptr<CompilerInvocation> dependencies::createScanCompilerInvocation(

--- a/clang/lib/DependencyScanning/DependencyScanningFilesystem.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningFilesystem.cpp
@@ -243,10 +243,6 @@ const CachedRealPath &DependencyScanningFilesystemSharedCache::CacheShard::
   return *StoredRealPath;
 }
 
-bool DependencyScanningWorkerFilesystem::shouldBypass(StringRef Path) const {
-  return BypassedPathPrefix && Path.starts_with(*BypassedPathPrefix);
-}
-
 DependencyScanningWorkerFilesystem::DependencyScanningWorkerFilesystem(
     DependencyScanningFilesystemSharedCache &SharedCache,
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS)
@@ -328,9 +324,6 @@ DependencyScanningWorkerFilesystem::status(const Twine &Path) {
   SmallString<256> OwnedFilename;
   StringRef Filename = Path.toStringRef(OwnedFilename);
 
-  if (shouldBypass(Filename))
-    return getUnderlyingFS().status(Path);
-
   llvm::ErrorOr<EntryRef> Result = getOrCreateFileSystemEntry(Filename);
   if (!Result)
     return Result.getError();
@@ -400,9 +393,6 @@ DependencyScanningWorkerFilesystem::openFileForRead(const Twine &Path) {
   SmallString<256> OwnedFilename;
   StringRef Filename = Path.toStringRef(OwnedFilename);
 
-  if (shouldBypass(Filename))
-    return getUnderlyingFS().openFileForRead(Path);
-
   llvm::ErrorOr<EntryRef> Result = getOrCreateFileSystemEntry(Filename);
   if (!Result)
     return Result.getError();
@@ -414,9 +404,6 @@ DependencyScanningWorkerFilesystem::getRealPath(const Twine &Path,
                                                 SmallVectorImpl<char> &Output) {
   SmallString<256> OwnedFilename;
   StringRef OriginalFilename = Path.toStringRef(OwnedFilename);
-
-  if (shouldBypass(OriginalFilename))
-    return getUnderlyingFS().getRealPath(Path, Output);
 
   SmallString<256> PathBuf;
   auto FilenameForLookup = tryGetFilenameForLookup(OriginalFilename, PathBuf);

--- a/clang/unittests/DependencyScanning/DependencyScanningFilesystemTest.cpp
+++ b/clang/unittests/DependencyScanning/DependencyScanningFilesystemTest.cpp
@@ -199,17 +199,6 @@ TEST(DependencyScanningFilesystem, CacheStatFailures) {
   DepFS.status("/dir/vector");
   DepFS.status("/dir/vector");
   EXPECT_EQ(InstrumentingFS->NumStatusCalls, 2u);
-
-  DepFS.setBypassedPathPrefix("/cache");
-  DepFS.exists("/cache/a.pcm");
-  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 3u);
-  DepFS.exists("/cache/a.pcm");
-  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 4u);
-
-  DepFS.resetBypassedPathPrefix();
-  DepFS.exists("/cache/a.pcm");
-  DepFS.exists("/cache/a.pcm");
-  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 5u);
 }
 
 TEST(DependencyScanningFilesystem, DiagnoseStaleStatFailures) {


### PR DESCRIPTION
This PR removes a hack from the scanning VFS that introduced a bypass mechanism for module cache queries. Now that we go through the `ModuleCache` interface for implicitly-built modules, this is no longer necessary.

However, since `ModuleFileKey` still used `DirectoryEntry` for representing the module cache, the scanning VFS would cache its non-existence at the start of the scan and would never see it being created (on the first write into the module cache). I decided to change the representation to `llvm::sys::fs::UniqueID` and get it straight from the real file system. I'm not sure this is the best solution. Maybe the `ModuleCache` should have some interface that would return `void *` that'd get used in `ModuleFileKey`? And `ModuleCache` would handle the inode representation internally? Happy to hear suggestions.