### PR TITLE
[libc][stdlib] move abort to a header library and cleanup its usage

### DIFF
--- a/libc/src/assert/generic/CMakeLists.txt
+++ b/libc/src/assert/generic/CMakeLists.txt
@@ -8,5 +8,5 @@ add_entrypoint_object(
   DEPENDS
     libc.include.assert
     libc.src.__support.OSUtil.osutil
-    libc.src.stdlib.abort
+    libc.src.stdlib.abort_utils
 )

--- a/libc/src/assert/generic/__assert_fail.cpp
+++ b/libc/src/assert/generic/__assert_fail.cpp
@@ -10,7 +10,7 @@
 #include "src/__support/OSUtil/io.h"
 #include "src/__support/libc_assert.h"
 #include "src/__support/macros/config.h"
-#include "src/stdlib/abort.h"
+#include "src/stdlib/abort_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -18,7 +18,7 @@ LLVM_LIBC_FUNCTION(void, __assert_fail,
                    (const char *assertion, const char *file, unsigned line,
                     const char *function)) {
   LIBC_NAMESPACE::report_assertion_failure(assertion, file, line, function);
-  LIBC_NAMESPACE::abort();
+  LIBC_NAMESPACE::abort_utils::abort();
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/assert/gpu/CMakeLists.txt
+++ b/libc/src/assert/gpu/CMakeLists.txt
@@ -10,5 +10,5 @@ add_entrypoint_object(
     libc.src.__support.OSUtil.osutil
     libc.src.__support.GPU.utils
     libc.src.__support.CPP.atomic
-    libc.src.stdlib.abort
+    libc.src.stdlib.abort_utils
 )

--- a/libc/src/assert/gpu/__assert_fail.cpp
+++ b/libc/src/assert/gpu/__assert_fail.cpp
@@ -13,7 +13,7 @@
 #include "src/__support/common.h"
 #include "src/__support/libc_assert.h"
 #include "src/__support/macros/config.h"
-#include "src/stdlib/abort.h"
+#include "src/stdlib/abort_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -36,7 +36,7 @@ LLVM_LIBC_FUNCTION(void, __assert_fail,
   if (gpu::is_first_lane(mask))
     LIBC_NAMESPACE::report_assertion_failure(assertion, file, line, function);
   gpu::sync_lane(mask);
-  LIBC_NAMESPACE::abort();
+  LIBC_NAMESPACE::abort_utils::abort();
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/compiler/generic/CMakeLists.txt
+++ b/libc/src/compiler/generic/CMakeLists.txt
@@ -7,5 +7,5 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.stdint_proxy
     libc.src.__support.OSUtil.osutil
-    libc.src.stdlib.abort
+    libc.src.stdlib.abort_utils
 )

--- a/libc/src/compiler/generic/__stack_chk_fail.cpp
+++ b/libc/src/compiler/generic/__stack_chk_fail.cpp
@@ -9,7 +9,7 @@
 #include "src/compiler/__stack_chk_fail.h"
 #include "hdr/stdint_proxy.h" // For uintptr_t
 #include "src/__support/OSUtil/io.h"
-#include "src/stdlib/abort.h"
+#include "src/stdlib/abort_utils.h"
 
 extern "C" {
 
@@ -17,7 +17,7 @@ uintptr_t __stack_chk_guard = static_cast<uintptr_t>(0xa9fff01234);
 
 void __stack_chk_fail(void) {
   LIBC_NAMESPACE::write_to_stderr("stack smashing detected\n");
-  LIBC_NAMESPACE::abort();
+  LIBC_NAMESPACE::abort_utils::abort();
 }
 
 } // extern "C"

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -713,11 +713,22 @@ add_entrypoint_object(
     ${exit_deps}
 )
 
+add_header_library(
+  abort_utils
+  HDRS
+    abort_utils.h
+  DEPENDS
+    .${LIBC_TARGET_OS}.abort_utils
+)
+
 add_entrypoint_object(
   abort
-  ALIAS
+  SRCS
+    abort.cpp
+  HDRS
+    abort.h
   DEPENDS
-    .${LIBC_TARGET_OS}.abort
+    .abort_utils
 )
 
 add_entrypoint_object(

--- a/libc/src/stdlib/abort.cpp
+++ b/libc/src/stdlib/abort.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdlib/abort.h"
-#include "src/stdlib/linux/abort_utils.h"
+#include "src/stdlib/abort_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdlib/abort_utils.h
+++ b/libc/src/stdlib/abort_utils.h
@@ -1,0 +1,25 @@
+//===-- Internal header for abort --------------------------------*- C++
+//-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDLIB_ABORT_UTILS_H
+#define LLVM_LIBC_SRC_STDLIB_ABORT_UTILS_H
+
+#include "src/__support/macros/properties/architectures.h"
+
+#if defined(LIBC_TARGET_ARCH_IS_GPU)
+#include "src/stdlib/gpu/abort_utils.h"
+#elif defined(__linux__)
+#include "src/stdlib/linux/abort_utils.h"
+#elif defined(__ELF__)
+// TODO:ELF detection logic is borrowed from io.h (as we are still missing
+// LIBC_TARGET_OS_IS_BAREMETAL).
+#include "src/stdlib/baremetal/abort_utils.h"
+#endif
+
+#endif // LLVM_LIBC_SRC_STDLIB_ABORT_UTILS_H

--- a/libc/src/stdlib/abort_utils.h
+++ b/libc/src/stdlib/abort_utils.h
@@ -1,5 +1,4 @@
-//===-- Internal header for abort --------------------------------*- C++
-//-*-===//
+//===-- Internal header for abort -----------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/src/stdlib/baremetal/CMakeLists.txt
+++ b/libc/src/stdlib/baremetal/CMakeLists.txt
@@ -1,9 +1,7 @@
-add_entrypoint_object(
-  abort
-  SRCS
-    abort.cpp
+add_header_library(
+  abort_utils
   HDRS
-    ../abort.h
+    abort_utils.h
 )
 
 add_entrypoint_object(

--- a/libc/src/stdlib/baremetal/abort_utils.h
+++ b/libc/src/stdlib/baremetal/abort_utils.h
@@ -1,4 +1,4 @@
-//===-- Internal header for baremetal abort ----------------------*- C++ -*-===//
+//===-- Internal header for baremetal abort -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/src/stdlib/baremetal/abort_utils.h
+++ b/libc/src/stdlib/baremetal/abort_utils.h
@@ -1,4 +1,4 @@
-//===-- Implementation of abort -------------------------------------------===//
+//===-- Internal header for baremetal abort ----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,13 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef LLVM_LIBC_SRC_STDLIB_BAREMETAL_ABORT_UTILS_H
+#define LLVM_LIBC_SRC_STDLIB_BAREMETAL_ABORT_UTILS_H
+
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
-#include "src/stdlib/abort.h"
-
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(void, abort, ()) { __builtin_trap(); }
+namespace abort_utils {
+[[noreturn]] LIBC_INLINE void abort() { __builtin_trap(); }
+} // namespace abort_utils
 
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDLIB_BAREMETAL_ABORT_UTILS_H

--- a/libc/src/stdlib/gpu/CMakeLists.txt
+++ b/libc/src/stdlib/gpu/CMakeLists.txt
@@ -53,14 +53,12 @@ add_entrypoint_object(
     libc.src.__support.GPU.allocator
 )
 
-add_entrypoint_object(
-  abort
-  SRCS
-    abort.cpp
+add_header_library(
+  abort_utils
   HDRS
-    ../abort.h
+    abort_utils.h
   DEPENDS
-    libc.include.stdlib
+    libc.src.__support.GPU.utils
     libc.src.__support.RPC.rpc_client
 )
 

--- a/libc/src/stdlib/gpu/abort_utils.h
+++ b/libc/src/stdlib/gpu/abort_utils.h
@@ -1,4 +1,4 @@
-//===-- Internal header for GPU abort ----------------------------*- C++ -*-===//
+//===-- Internal header for GPU abort -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/src/stdlib/gpu/abort_utils.h
+++ b/libc/src/stdlib/gpu/abort_utils.h
@@ -1,4 +1,4 @@
-//===-- GPU implementation of abort ---------------------------------------===//
+//===-- Internal header for GPU abort ----------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,16 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef LLVM_LIBC_SRC_STDLIB_GPU_ABORT_UTILS_H
+#define LLVM_LIBC_SRC_STDLIB_GPU_ABORT_UTILS_H
+
 #include "src/__support/GPU/utils.h"
 #include "src/__support/RPC/rpc_client.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
-#include "src/stdlib/abort.h"
-
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(void, abort, ()) {
+namespace abort_utils {
+[[noreturn]] LIBC_INLINE void abort() {
   // We want to first make sure the server is listening before we abort.
   rpc::Client::Port port = rpc::client.open<LIBC_ABORT>();
   port.send_and_recv([](rpc::Buffer *, uint32_t) {},
@@ -24,5 +26,8 @@ LLVM_LIBC_FUNCTION(void, abort, ()) {
 
   gpu::end_program();
 }
+} // namespace abort_utils
 
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDLIB_GPU_ABORT_UTILS_H

--- a/libc/src/stdlib/linux/CMakeLists.txt
+++ b/libc/src/stdlib/linux/CMakeLists.txt
@@ -8,15 +8,3 @@ add_header_library(
     libc.src.signal.linux.__restore
     libc.src.signal.linux.signal_utils
 )
-
-add_entrypoint_object(
-  abort
-  SRCS
-    abort.cpp
-  HDRS
-    ../abort.h
-  DEPENDS
-    .abort_utils
-    libc.src.signal.linux.__restore
-    libc.include.stdlib
-)

--- a/libc/src/stdlib/linux/abort_utils.h
+++ b/libc/src/stdlib/linux/abort_utils.h
@@ -1,4 +1,4 @@
-//===-- Internal header for Linux abort -------------------------*- C++ -*-===//
+//===-- Internal header for Linux abort -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/test/integration/src/stdlib/abort_test.cpp
+++ b/libc/test/integration/src/stdlib/abort_test.cpp
@@ -9,7 +9,7 @@
 #include "src/signal/signal.h"
 #include "src/stdlib/_Exit.h"
 #include "src/stdlib/abort.h"
-#include "src/stdlib/linux/abort_utils.h"
+#include "src/stdlib/abort_utils.h"
 #include "src/sys/wait/waitpid.h"
 #include "src/unistd/close.h"
 #include "src/unistd/fork.h"

--- a/libc/test/src/assert/assert_test.cpp
+++ b/libc/test/src/assert/assert_test.cpp
@@ -7,21 +7,21 @@
 //===----------------------------------------------------------------------===//
 
 #undef NDEBUG
+#include "hdr/signal_macros.h"
 #include "src/assert/assert.h"
 #include "test/UnitTest/Test.h"
 
 extern "C" int close(int);
 
 TEST(LlvmLibcAssert, Enabled) {
-  // -1 matches against any signal, which is necessary for now until
-  // LIBC_NAMESPACE::abort() unblocks SIGABRT. Close standard error for the
-  // child process so we don't print the assertion failure message.
+  // Close standard error for the child process so we don't print the assertion
+  // failure message.
   EXPECT_DEATH(
       [] {
         close(2);
         assert(0);
       },
-      WITH_SIGNAL(-1));
+      WITH_SIGNAL(SIGABRT));
 }
 
 #define NDEBUG


### PR DESCRIPTION
This PR moves abort implementation to a header library so that internal dependency no longer relies on the entrypoint object.
Additionally, it clean up prior dependency to the entrypoint object and update staled tests.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>