### PR TITLE
[NFC][AArch64] Add getNonStrictBranchCondition TII hook

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
@@ -309,30 +309,6 @@ static int getComplementOpc(int Opc) {
   }
 }
 
-// Changes form of comparison inclusive <-> exclusive.
-static AArch64CC::CondCode getAdjustedCmp(AArch64CC::CondCode Cmp) {
-  switch (Cmp) {
-  case AArch64CC::GT:
-    return AArch64CC::GE;
-  case AArch64CC::GE:
-    return AArch64CC::GT;
-  case AArch64CC::LT:
-    return AArch64CC::LE;
-  case AArch64CC::LE:
-    return AArch64CC::LT;
-  case AArch64CC::HI:
-    return AArch64CC::HS;
-  case AArch64CC::HS:
-    return AArch64CC::HI;
-  case AArch64CC::LO:
-    return AArch64CC::LS;
-  case AArch64CC::LS:
-    return AArch64CC::LO;
-  default:
-    llvm_unreachable("Unexpected condition code");
-  }
-}
-
 // Returns the adjusted immediate, opcode, and condition code for switching
 // between inclusive/exclusive forms (GT <-> GE, LT <-> LE).
 CmpInfo
@@ -371,7 +347,9 @@ AArch64ConditionOptimizerImpl::getAdjustedCmpInfo(MachineInstr *CmpMI,
     Opc = getComplementOpc(Opc);
   }
 
-  return {NewImm, Opc, getAdjustedCmp(Cmp)};
+  int RelaxedCC = TII->getRelaxedBranchCondition((int)Cmp);
+  assert(RelaxedCC != -1 && "Expected a strict condition code");
+  return {NewImm, Opc, (AArch64CC::CondCode)RelaxedCC};
 }
 
 // Modifies a comparison instruction's immediate and opcode.

--- a/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
@@ -347,7 +347,7 @@ AArch64ConditionOptimizerImpl::getAdjustedCmpInfo(MachineInstr *CmpMI,
     Opc = getComplementOpc(Opc);
   }
 
-  int RelaxedCC = TII->getRelaxedBranchCondition((int)Cmp);
+  int RelaxedCC = TII->getNonStrictBranchCondition((int)Cmp);
   assert(RelaxedCC != -1 && "Expected a strict condition code");
   return {NewImm, Opc, (AArch64CC::CondCode)RelaxedCC};
 }

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -653,7 +653,7 @@ bool AArch64InstrInfo::reverseBranchCondition(
   return false;
 }
 
-int AArch64InstrInfo::getRelaxedBranchCondition(int CC) const {
+int AArch64InstrInfo::getNonStrictBranchCondition(int CC) const {
   switch (static_cast<AArch64CC::CondCode>(CC)) {
   case AArch64CC::GT:
     return AArch64CC::GE;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -653,6 +653,21 @@ bool AArch64InstrInfo::reverseBranchCondition(
   return false;
 }
 
+int AArch64InstrInfo::getRelaxedBranchCondition(int CC) const {
+  switch (static_cast<AArch64CC::CondCode>(CC)) {
+  case AArch64CC::GT:
+    return AArch64CC::GE;
+  case AArch64CC::LT:
+    return AArch64CC::LE;
+  case AArch64CC::HI:
+    return AArch64CC::HS;
+  case AArch64CC::LO:
+    return AArch64CC::LS;
+  default:
+    return -1;
+  }
+}
+
 unsigned AArch64InstrInfo::removeBranch(MachineBasicBlock &MBB,
                                         int *BytesRemoved) const {
   MachineBasicBlock::iterator I = MBB.getLastNonDebugInstr();

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -420,6 +420,7 @@ public:
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;
+  int getRelaxedBranchCondition(int CC) const;
   bool canInsertSelect(const MachineBasicBlock &, ArrayRef<MachineOperand> Cond,
                        Register, Register, Register, int &, int &,
                        int &) const override;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -420,7 +420,7 @@ public:
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;
-  int getRelaxedBranchCondition(int CC) const;
+  int getNonStrictBranchCondition(int CC) const;
   bool canInsertSelect(const MachineBasicBlock &, ArrayRef<MachineOperand> Cond,
                        Register, Register, Register, int &, int &,
                        int &) const override;


### PR DESCRIPTION
Add a getNonStrictBranchCondition hook to AArch64InstrInfo that returns the non-strict form of a strict branch condition (GT->GE, LT->LE, HI->HS, LO->LS), or -1 if the condition has no such form. Update AArch64ConditionOptimizer to use it, and remove the local getAdjustedCmp helper.