### PR TITLE
[SampleProf] Check probe-based profile in isProfileUnused

### DIFF
--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -187,6 +187,7 @@ bool SampleProfileMatcher::isProfileUnused(const FunctionId &ProfileFuncName) {
   // module. Check if the function name exists in the pseudo_probe descriptors.
   return (SymbolMap->find(ProfileFuncName) == SymbolMap->end()) &&
          (LTOPhase == ThinOrFullLTOPhase::ThinLTOPreLink ||
+          !FunctionSamples::ProfileIsProbeBased ||
           !ProfileFuncName.isStringRef() ||
           (ProbeManager->getDesc(ProfileFuncName.stringRef()) == nullptr));
 }


### PR DESCRIPTION
`ProbeManager` is only initialized for probe based profile. Add proper check in `isProfileUnused`.

This fixes: https://github.com/llvm/llvm-project/issues/188897