### PR TITLE
[Coverage] Skip coverage mapping for consteval member functions

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -453,6 +453,8 @@ Improvements to Coverage Mapping
 - [MC/DC] Nested expressions are handled as individual MC/DC expressions.
 - "Single byte coverage" now supports branch coverage and can be used
   together with ``-fcoverage-mcdc``.
+- Consteval member functions are no longer emitted in coverage mappings,
+  matching the existing behavior for free consteval functions. (#GH164448)
 
 Bug Fixes in This Version
 -------------------------

--- a/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -228,8 +228,9 @@ namespace {
 
       // Provide some coverage mapping even for methods that aren't emitted.
       // Don't do this for templated classes though, as they may not be
-      // instantiable.
-      if (!D->getLexicalDeclContext()->isDependentContext())
+      // instantiable. Also skip consteval methods as they are never emitted.
+      if (!D->getLexicalDeclContext()->isDependentContext() &&
+          !D->getAsFunction()->isImmediateFunction())
         Builder->AddDeferredUnusedCoverageMapping(D);
     }
 

--- a/clang/test/CoverageMapping/consteval.cpp
+++ b/clang/test/CoverageMapping/consteval.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -mllvm -emptyline-comment-coverage=false -fprofile-instrument=clang -fcoverage-mapping -dump-coverage-mapping -emit-llvm-only -std=c++20 -triple %itanium_abi_triple -main-file-name consteval.cpp %s | FileCheck %s
+
+// Consteval functions should not have coverage mappings, as they are evaluated
+// entirely at compile time and produce no runtime code.
+// See https://github.com/llvm/llvm-project/issues/164448.
+
+// CHECK-NOT: _Z1gv:
+consteval int g() { return 0; }
+
+struct S {
+  // CHECK-NOT: _ZN1S1sEv:
+  static consteval int s() { return 1; }
+};
+
+// CHECK-LABEL: main:
+// CHECK-NEXT: File 0, [[@LINE+1]]:12 -> [[@LINE+5]]:2 = #0
+int main() {
+  [[maybe_unused]] auto i = g();
+  [[maybe_unused]] auto j = S::s();
+  return 0;
+}


### PR DESCRIPTION
Static consteval member functions were incorrectly getting a coverage mapping with zero count, making them appear as uncovered lines. Free consteval functions were already correctly excluded because EmitTopLevelDecl returns early for immediate functions.

The fix adds an isImmediateFunction() check in HandleInlineMemberFunction before adding deferred coverage mappings, consistent with the top-level check.

Fixes #164448.