### PR TITLE
[orc-rt] Rename ManagedCodeCallsGroup to ManagedCodeTaskGroup. NFC.

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -288,8 +288,8 @@ public:
   /// Shutdown proceeds through the following phases:
   ///   1. Detach: If not already detached, disconnects the controller and
   ///      notifies all Services via onDetach.
-  ///   2. Drain: Waits for all in-flight managed code calls to complete
-  ///      (via ManagedCodeCallsGroup).
+  ///   2. Drain: Waits for all in-flight tasks accessing managed code to
+  ///      complete (via ManagedCodeTaskGroup).
   ///   3. Shutdown services: Calls onShutdown on all Services in reverse
   ///      order.
   ///   4. Shutdown TaskDispatcher.
@@ -310,23 +310,24 @@ public:
   /// Session has already shut down, the callback will be called immediately.
   void addOnShutdown(OnShutdownFn OnShutdown);
 
-  /// Returns a reference to this Session's ManagedCodeCallsGroup.
+  /// Returns a reference to this Session's ManagedCodeTaskGroup.
   ///
   /// When calling code managed by a Session (e.g. JIT'd code, or library code
   /// loaded on behalf of JIT'd code), clients should hold a token for this
   /// group. That token will prevent the Session from shutting down any Services
-  /// (and the Session itself) until calls into managed code have completed.
+  /// (and the Session itself) until tasks accessing managed code have
+  /// completed.
   ///
   /// Clients should prefer using the callManagedCodeSync and
   /// callManagedCodeAsync helpers to automatically acquire and hold a token
   /// for the duration of a call.
-  const std::shared_ptr<TaskGroup> &managedCodeCallsGroup() const {
-    return ManagedCodeCallsGroup;
+  const std::shared_ptr<TaskGroup> &managedCodeTaskGroup() const {
+    return ManagedCodeTaskGroup;
   }
 
   /// Synchronously call managed code.
   ///
-  /// This helper tries to acquire a ManagedCodeCallsGroup token and then call
+  /// This helper tries to acquire a ManagedCodeTaskGroup token and then call
   /// the given function object with the given arguments while holding the
   /// token.
   ///
@@ -340,7 +341,7 @@ public:
   template <typename FnT, typename... ArgTs>
   decltype(auto) callManagedCodeSync(FnT &&Fn, ArgTs &&...Args) {
     return ManagedCodeSyncCaller<std::invoke_result_t<FnT, ArgTs...>>::call(
-        TaskGroup::Token(ManagedCodeCallsGroup), std::forward<FnT>(Fn),
+        TaskGroup::Token(ManagedCodeTaskGroup), std::forward<FnT>(Fn),
         std::forward<ArgTs>(Args)...);
   }
 
@@ -349,7 +350,7 @@ public:
   /// ReturnT must be a function object that takes either a boolean or a
   /// std::optional<T>.
   ///
-  /// callManagedCodeAsync tries to acquire a ManagedCodeCallsGroup token and
+  /// callManagedCodeAsync tries to acquire a ManagedCodeTaskGroup token and
   /// then call the given async function object while holding that token.
   ///
   /// If the token is successfully acquired then this function will call Fn,
@@ -363,7 +364,7 @@ public:
   template <typename ReturnT, typename FnT, typename... ArgTs>
   void callManagedCodeAsync(ReturnT &&Return, FnT &&Fn, ArgTs &&...Args) {
     ManagedCodeAsyncCaller<typename CallableArgInfo<ReturnT>::args_tuple_type>::
-        call(TaskGroup::Token(ManagedCodeCallsGroup),
+        call(TaskGroup::Token(ManagedCodeTaskGroup),
              std::forward<ReturnT>(Return), std::forward<FnT>(Fn),
              std::forward<ArgTs>(Args)...);
   }
@@ -435,15 +436,15 @@ private:
   void detachServices(std::vector<Service *> ToNotify, bool ShutdownRequested);
   void completeDetach();
 
-  void waitForManagedCodeCallsThenShutdown();
+  void waitForManagedCodeTasksThenShutdown();
   void proceedToShutdown();
   void shutdownServices(std::vector<Service *> ToNotify);
   void completeShutdown();
 
   void handleWrapperCall(uint64_t CallId, orc_rt_WrapperFunction Fn,
                          WrapperFunctionBuffer ArgBytes) {
-    if (!ManagedCodeCallsGroup->acquireToken()) {
-      // The ManagedCodeCallsGroup is only closed after detach, so if token
+    if (!ManagedCodeTaskGroup->acquireToken()) {
+      // The ManagedCodeTaskGroup is only closed after detach, so if token
       // acquisition fails we don't try to return an error: the controller
       // should already have signalled error to the caller, and we have no
       // way to transmit an error anyway.
@@ -458,7 +459,7 @@ private:
   void sendWrapperResult(uint64_t CallId, WrapperFunctionBuffer ResultBytes) {
     if (auto TmpCA = std::atomic_load(&CA))
       TmpCA->sendWrapperResult(CallId, std::move(ResultBytes));
-    ManagedCodeCallsGroup->releaseToken();
+    ManagedCodeTaskGroup->releaseToken();
   }
 
   static void wrapperReturn(orc_rt_SessionRef S, uint64_t CallId,
@@ -466,7 +467,7 @@ private:
 
   ExecutorProcessInfo EPI;
   std::unique_ptr<TaskDispatcher> Dispatcher;
-  std::shared_ptr<TaskGroup> ManagedCodeCallsGroup = TaskGroup::Create();
+  std::shared_ptr<TaskGroup> ManagedCodeTaskGroup = TaskGroup::Create();
   std::shared_ptr<ControllerAccess> CA;
   ErrorReporterFn ReportError;
 

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -184,7 +184,7 @@ void Session::shutdown(OnShutdownFn OnShutdown) {
       break;
     case State::Detached:
       Lock.unlock();
-      waitForManagedCodeCallsThenShutdown();
+      waitForManagedCodeTasksThenShutdown();
       return;
     default:
       assert(false && "Illegal state");
@@ -326,12 +326,12 @@ void Session::completeDetach() {
     assert(TargetState == State::Shutdown);
   }
 
-  waitForManagedCodeCallsThenShutdown();
+  waitForManagedCodeTasksThenShutdown();
 }
 
-void Session::waitForManagedCodeCallsThenShutdown() {
-  ManagedCodeCallsGroup->addOnComplete([this]() { proceedToShutdown(); });
-  ManagedCodeCallsGroup->close();
+void Session::waitForManagedCodeTasksThenShutdown() {
+  ManagedCodeTaskGroup->addOnComplete([this]() { proceedToShutdown(); });
+  ManagedCodeTaskGroup->close();
 }
 
 void Session::proceedToShutdown() {

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -406,7 +406,7 @@ TEST(SessionTest, ActiveManagedCallsDelayShutdown) {
   ASSERT_FALSE(ShutdownOpIdx);
 
   // Take a managed code call token. This should succeed.
-  auto Tok = TaskGroup::Token(S.managedCodeCallsGroup());
+  auto Tok = TaskGroup::Token(S.managedCodeTaskGroup());
   ASSERT_TRUE(Tok);
 
   // We expect shutdown to wait for any active managed calls to complete.
@@ -420,7 +420,7 @@ TEST(SessionTest, ActiveManagedCallsDelayShutdown) {
 
   // The managed calls code group should have been closed. Assert that we
   // can't get a new token.
-  ASSERT_FALSE(TaskGroup::Token(S.managedCodeCallsGroup()));
+  ASSERT_FALSE(TaskGroup::Token(S.managedCodeTaskGroup()));
 
   Tok = TaskGroup::Token(); // Reset token.
 
@@ -433,7 +433,7 @@ static void managedSyncVoidFunction(int *P) { *P = 42; }
 
 TEST(SessionTest, SyncCallManagedCodeVoidFn) {
   // Test synchronous calls to a void function while holding a
-  // ManagedCodeCallsGroup token.
+  // ManagedCodeTaskGroup token.
   Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
             noErrors);
 
@@ -463,7 +463,7 @@ static int managedSyncNonVoidFunction(int N) { return N + 1; }
 
 TEST(SessionTest, SyncCallManagedCodeNonVoidFn) {
   // Test synchronous calls to a non-void function while holding a
-  // ManagedCodeCallsGroup token.
+  // ManagedCodeTaskGroup token.
   Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
             noErrors);
 
@@ -495,7 +495,7 @@ static void managedAsyncVoidFunction(move_only_function<void()> Return,
 
 TEST(SessionTest, AsyncCallManagedCodeVoidFn) {
   // Test asynchronous calls to a void function while holding a
-  // ManagedCodeCallsGroup token.
+  // ManagedCodeTaskGroup token.
   Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
             noErrors);
 
@@ -531,7 +531,7 @@ static void managedAsyncNonVoidFunction(move_only_function<void(int)> Return,
 
 TEST(SessionTest, AsyncCallManagedCodeNonVoidFn) {
   // Test asynchronous calls to a non-void function while holding a
-  // ManagedCodeCallsGroup token.
+  // ManagedCodeTaskGroup token.
   Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
             noErrors);
 
@@ -562,7 +562,7 @@ TEST(SessionTest, AsyncCallManagedCodeNonVoidFn) {
 }
 
 TEST(SessionTest, AsyncCallManagedCodeHoldsTokenAcrossAsyncGap) {
-  // Verify that the ManagedCodeCallsGroup token is held until the async
+  // Verify that the ManagedCodeTaskGroup token is held until the async
   // continuation runs, not just until callManagedCodeAsync returns. This
   // ensures shutdown blocks for the duration of the actual async work.
   Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),


### PR DESCRIPTION
The new name better reflects this group's purpose: Tokens are needed for any task that wants to access managed code, whether to call it or access data.