### PR TITLE
DAGCombine: Prefer to keep cond_loop argument as a setcc.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -14182,11 +14182,12 @@ SDValue DAGCombiner::visitSELECT_CC(SDNode *N) {
 }
 
 SDValue DAGCombiner::visitSETCC(SDNode *N) {
-  // setcc is very commonly used as an argument to brcond. This pattern
-  // also lend itself to numerous combines and, as a result, it is desired
-  // we keep the argument to a brcond as a setcc as much as possible.
+  // setcc is very commonly used as an argument to brcond or cond_loop. This
+  // pattern also lend itself to numerous combines and, as a result, it is
+  // desired we keep the argument to a brcond as a setcc as much as possible.
   bool PreferSetCC =
-      N->hasOneUse() && N->user_begin()->getOpcode() == ISD::BRCOND;
+      N->hasOneUse() && (N->user_begin()->getOpcode() == ISD::BRCOND ||
+                         N->user_begin()->getOpcode() == ISD::COND_LOOP);
 
   ISD::CondCode Cond = cast<CondCodeSDNode>(N->getOperand(2))->get();
   EVT VT = N->getValueType(0);

--- a/llvm/test/CodeGen/X86/cond-loop.ll
+++ b/llvm/test/CodeGen/X86/cond-loop.ll
@@ -48,3 +48,18 @@ define void @f4(i32 %a, i32 %b) {
   tail call void @llvm.cond.loop(i1 %overflow)
   ret void
 }
+
+define void @f5(ptr %p) {
+; CHECK-LABEL: f5:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    testb $4, 10(%rdi)
+; CHECK-NEXT:  .Ltmp4:
+; CHECK-NEXT:    jne .Ltmp4
+; CHECK-NEXT:    retq
+  %gep = getelementptr inbounds nuw i8, ptr %p, i64 10
+  %load = load i8, ptr %gep, align 2
+  %and = and i8 %load, 4
+  %cmp = icmp ne i8 %and, 0
+  call void @llvm.cond.loop(i1 %cmp)
+  ret void
+}


### PR DESCRIPTION
As with brcond, combines for cond_loop want to see setcc as the direct
argument, so prefer to keep it in that form.
