### PR TITLE
[llvm-profgen] Read build ID from binary for perfscript address filtering

### DIFF
--- a/llvm/tools/llvm-profgen/ProfiledBinary.cpp
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.cpp
@@ -11,6 +11,8 @@
 #include "MissingFrameInferrer.h"
 #include "Options.h"
 #include "ProfileGenerator.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/BinaryFormat/Magic.h"
 #include "llvm/DebugInfo/PDB/IPDBSession.h"
 #include "llvm/DebugInfo/PDB/PDB.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolFunc.h"
@@ -245,6 +247,17 @@ void ProfiledBinary::load() {
 
   // Find the preferred load address for text sections.
   setPreferredTextSegmentAddresses(Obj);
+
+  // For shared libraries, read build ID to filter perfscript addresses
+  // in [buildid:]addr format. Main executables use empty FilterBuildID
+  // since their addresses have no buildid prefix.
+  file_magic Magic;
+  if (auto EC = identify_magic(Path, Magic); !EC &&
+      Magic == file_magic::elf_shared_object) {
+    auto BID = object::getBuildID(Obj);
+    if (!BID.empty())
+      FilterBuildID = llvm::toHex(BID, /*LowerCase=*/true);
+  }
 
   // Load debug info of subprograms from DWARF section.
   // If path of debug info binary is specified, use the debug info from it,

--- a/llvm/tools/llvm-profgen/ProfiledBinary.h
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.h
@@ -28,6 +28,7 @@
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/MCTargetOptions.h"
+#include "llvm/Object/BuildID.h"
 #include "llvm/Object/ELFObjectFile.h"
 #include "llvm/ProfileData/SampleProf.h"
 #include "llvm/Support/CommandLine.h"
@@ -337,6 +338,11 @@ class ProfiledBinary {
 
   bool IsCOFF = false;
 
+  // Build ID used to filter perfscript addresses in [buildid:]addr format.
+  // For shared libraries, set to the binary's build ID.
+  // For main executables, kept empty (addresses have no buildid prefix).
+  std::string FilterBuildID;
+
   void setPreferredTextSegmentAddresses(const object::ObjectFile *O);
 
   // LLVMSymbolizer's symbolize{Code, Data} interfaces requires a section index
@@ -424,6 +430,9 @@ public:
   void setBaseAddress(uint64_t Address) { BaseAddress = Address; }
 
   bool isCOFF() const { return IsCOFF; }
+
+  // Return the build ID used for filtering perfscript addresses.
+  StringRef getFilterBuildID() const { return FilterBuildID; }
 
   // Canonicalize to use preferred load address as base address.
   uint64_t canonicalizeVirtualAddress(uint64_t Address) {


### PR DESCRIPTION
For shared libraries (.so), read the binary's build ID during load()
using object::getBuildID() and store it as FilterBuildID. Main
executables keep FilterBuildID empty, matching the convention that
their perfscript addresses have no buildid prefix.

This enables automatic build ID-based filtering of perfscript
addresses in [buildid:]0xaddr format without requiring a CLI option.
