### PR TITLE
[NFC][RISCV] Fix mismatched closing comment in XSfmm instruction definition

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXSfmm.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXSfmm.td
@@ -255,7 +255,7 @@ let Predicates = [HasVendorXSfmm32a16fOrXSfmm32a32fOrXSfmm64a64f] in {
   let Uses = [FRM], mayRaiseFPException = true in
   def SF_MM_F_F   : SFInstMatmulF<(outs), (ins TRM2:$rd, VR:$vs2, VR:$vs1),
                                   "sf.mm.f.f", "$rd, $vs2, $vs1">;
-} // Predicates = [HasVendorXSfmm32a16fOrXSfmm64a32fOrXSfmm64a64f]
+} // Predicates = [HasVendorXSfmm32a16fOrXSfmm32a32fOrXSfmm64a64f]
 
 let Predicates = [HasVendorXSfmm32a8i] in {
   foreach a = I8Encodes in


### PR DESCRIPTION
The closing comment had XSfmm64a32f but the opening predicate uses XSfmm32a32f.