### PR TITLE
 [clang-tidy] Fix `bugprone-incorrect-enable-if` inserting duplicate `typename`

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/IncorrectEnableIfCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/IncorrectEnableIfCheck.cpp
@@ -47,8 +47,8 @@ void IncorrectEnableIfCheck::check(const MatchFinder::MatchResult &Result) {
       Result.Nodes.getNodeAs<TemplateSpecializationTypeLoc>(
           "enable_if_specialization");
 
-  if (!EnableIf || !EnableIfSpecializationLoc)
-    return;
+  assert(EnableIf);
+  assert(EnableIfSpecializationLoc);
 
   const SourceManager &SM = *Result.SourceManager;
   const SourceLocation RAngleLoc =
@@ -57,9 +57,8 @@ void IncorrectEnableIfCheck::check(const MatchFinder::MatchResult &Result) {
   auto Diag = diag(EnableIf->getBeginLoc(),
                    "incorrect std::enable_if usage detected; use "
                    "'typename std::enable_if<...>::type'");
-  // FIXME: This should handle the enable_if specialization already having an
-  // elaborated keyword.
-  if (!getLangOpts().CPlusPlus20) {
+  if (!getLangOpts().CPlusPlus20 &&
+      EnableIfSpecializationLoc->getElaboratedKeywordLoc().isInvalid()) {
     Diag << FixItHint::CreateInsertion(EnableIfSpecializationLoc->getBeginLoc(),
                                        "typename ");
   }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -224,6 +224,12 @@ Changes in existing checks
   positive when increment/decrement operators appear inside lambda bodies that
   are part of a condition expression.
 
+- Improved :doc:`bugprone-incorrect-enable-if
+  <clang-tidy/checks/bugprone/incorrect-enable-if>` check to not
+  insert an extraneous ``typename`` on code like
+  ``typename std::enable_if<...>``, where there's already a
+  ``typename`` and only the ``::type`` at the end is missing.
+
 - Improved :doc:`bugprone-macro-parentheses
   <clang-tidy/checks/bugprone/macro-parentheses>` check by printing the macro
   definition in the warning message if the macro is defined on command line.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -227,8 +227,8 @@ Changes in existing checks
 - Improved :doc:`bugprone-incorrect-enable-if
   <clang-tidy/checks/bugprone/incorrect-enable-if>` check to not
   insert an extraneous ``typename`` on code like
-  ``typename std::enable_if<...>``, where there's already a
-  ``typename`` and only the ``::type`` at the end is missing.
+  ``typename std::enable_if<...>``, where there's already a ``typename`` and
+  only the ``::type`` at the end is missing.
 
 - Improved :doc:`bugprone-macro-parentheses
   <clang-tidy/checks/bugprone/macro-parentheses>` check by printing the macro

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/incorrect-enable-if.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/incorrect-enable-if.cpp
@@ -42,6 +42,12 @@ void invalid_multiple() {}
 // CHECK-FIXES: template <typename T, typename = typename std::enable_if<T::some_value>::type, typename = typename std::enable_if<T::other_value>::type>
 // CHECK-FIXES-CXX20: template <typename T, typename = std::enable_if<T::some_value>::type, typename = std::enable_if<T::other_value>::type>
 
+template <typename T, typename = typename std::enable_if<T::some_value>>
+void invalid_typename_keyword() {}
+// CHECK-MESSAGES: [[@LINE-2]]:23: warning: incorrect std::enable_if usage detected; use 'typename std::enable_if<...>::type' [bugprone-incorrect-enable-if]
+// CHECK-FIXES: template <typename T, typename = typename std::enable_if<T::some_value>::type>
+// CHECK-FIXES-CXX20: template <typename T, typename = typename std::enable_if<T::some_value>::type>
+
 template <typename T, typename = std::enable_if<T::some_value>>
 struct InvalidClass {};
 // CHECK-MESSAGES: [[@LINE-2]]:23: warning: incorrect std::enable_if usage detected; use 'typename std::enable_if<...>::type' [bugprone-incorrect-enable-if]


### PR DESCRIPTION
This PR resolves one of our FIXME's. Pre-C++20, this check turns
```cpp
typename std::enable_if<...>
```
into
```cpp
typename typename std::enable_if<...>::type
```
instead of 
```cpp
typename std::enable_if<...>::type
```
https://godbolt.org/z/4s4ozPsM3