### PR TITLE
[test] Make MCTargetOptions a class member in DwarfLineTableHeaders

### DIFF
--- a/llvm/unittests/MC/DwarfLineTableHeaders.cpp
+++ b/llvm/unittests/MC/DwarfLineTableHeaders.cpp
@@ -41,6 +41,7 @@ public:
   std::unique_ptr<MCRegisterInfo> MRI;
   std::unique_ptr<MCAsmInfo> MAI;
   std::unique_ptr<const MCSubtargetInfo> STI;
+  MCTargetOptions MCOptions;
   const Target *TheTarget;
 
   struct StreamerContext {
@@ -62,7 +63,6 @@ public:
       return;
 
     MRI.reset(TheTarget->createMCRegInfo(TT));
-    MCTargetOptions MCOptions;
     MAI.reset(TheTarget->createMCAsmInfo(*MRI, TT, MCOptions));
     STI.reset(TheTarget->createMCSubtargetInfo(TT, "", ""));
   }


### PR DESCRIPTION
Similar to commit 6f0b0ecaba1ba311717f86d8e4d8c6b2b4c4cd4b

createMCAsmInfo will store a pointer to the MCTargetOptions argument in
MCAsmInfo. When MCTargetOptions was a local variable in the constructor,
the pointer dangled after the constructor returned.