### PR TITLE
[BOLT] Fix strict weak ordering in getCodeSections comparator

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -4102,6 +4102,9 @@ std::vector<BinarySection *> RewriteInstance::getCodeSections() {
       CodeSections.emplace_back(&Section);
 
   auto compareSections = [&](const BinarySection *A, const BinarySection *B) {
+    if (A == B)
+      return false;
+
     // If both A and B have names starting with ".text.cold", then
     // - if opts::HotFunctionsAtEnd is true, we want order
     //   ".text.cold.T", ".text.cold.T-1", ... ".text.cold.1", ".text.cold"


### PR DESCRIPTION
The compareSections lambda in getCodeSections() violates the strict weak ordering requirement: when A == B, the comparator can return true (e.g. via the HotText mover name check), which triggers a _GLIBCXX_DEBUG assertion on self-comparison.

Add an early identity check to satisfy irreflexivity.