### PR TITLE
[MLIR][Presburger] Make getSubMatrix exclusive on the right end

### DIFF
--- a/mlir/include/mlir/Analysis/Presburger/Matrix.h
+++ b/mlir/include/mlir/Analysis/Presburger/Matrix.h
@@ -196,7 +196,8 @@ public:
 
   // Copy the cells in the intersection of
   // the rows between `fromRows` and `toRows` and
-  // the columns between `fromColumns` and `toColumns`, both inclusive.
+  // the columns between `fromColumns` and `toColumns`, inclusive on the left
+  // but exclusive on the right (same as canonical C++ ranges).
   Matrix<T> getSubMatrix(unsigned fromRow, unsigned toRow, unsigned fromColumn,
                          unsigned toColumn) const;
 

--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -167,9 +167,9 @@ mlir::presburger::detail::solveParametricEquations(FracMatrix equations) {
 
   // If the determinant is zero, there is no unique solution.
   // Thus we return null.
-  if (FracMatrix(equations.getSubMatrix(/*fromRow=*/0, /*toRow=*/d - 1,
+  if (FracMatrix(equations.getSubMatrix(/*fromRow=*/0, /*toRow=*/d,
                                         /*fromColumn=*/0,
-                                        /*toColumn=*/d - 1))
+                                        /*toColumn=*/d))
           .determinant() == 0)
     return std::nullopt;
 
@@ -218,8 +218,8 @@ mlir::presburger::detail::solveParametricEquations(FracMatrix equations) {
   //
   // We copy these columns and return them.
   ParamPoint vertex =
-      equations.getSubMatrix(/*fromRow=*/0, /*toRow=*/d - 1,
-                             /*fromColumn=*/d, /*toColumn=*/numCols - 1);
+      equations.getSubMatrix(/*fromRow=*/0, /*toRow=*/d,
+                             /*fromColumn=*/d, /*toColumn=*/numCols);
   vertex.negateMatrix();
   return vertex;
 }
@@ -345,10 +345,9 @@ mlir::presburger::detail::computePolytopeGeneratingFunction(
     // b2c2 stores the coefficients of the parameters and the constant term.
     FracMatrix a2(numIneqs - numVars, numVars);
     FracMatrix b2c2(numIneqs - numVars, numSymbols + 1);
-    a2 = FracMatrix(
-        remainder.getSubMatrix(0, numIneqs - numVars - 1, 0, numVars - 1));
-    b2c2 = FracMatrix(remainder.getSubMatrix(0, numIneqs - numVars - 1, numVars,
-                                             numVars + numSymbols));
+    a2 = FracMatrix(remainder.getSubMatrix(0, numIneqs - numVars, 0, numVars));
+    b2c2 = FracMatrix(remainder.getSubMatrix(0, numIneqs - numVars, numVars,
+                                             numVars + numSymbols + 1));
 
     // Find the vertex, if any, corresponding to the current subset of
     // inequalities.

--- a/mlir/lib/Analysis/Presburger/Matrix.cpp
+++ b/mlir/lib/Analysis/Presburger/Matrix.cpp
@@ -392,13 +392,13 @@ Matrix<T> Matrix<T>::getSubMatrix(unsigned fromRow, unsigned toRow,
                                   unsigned fromColumn,
                                   unsigned toColumn) const {
   assert(fromRow <= toRow && "end of row range must be after beginning!");
-  assert(toRow < nRows && "end of row range out of bounds!");
+  assert(toRow <= nRows && "end of row range out of bounds!");
   assert(fromColumn <= toColumn &&
          "end of column range must be after beginning!");
-  assert(toColumn < nColumns && "end of column range out of bounds!");
-  Matrix<T> subMatrix(toRow - fromRow + 1, toColumn - fromColumn + 1);
-  for (unsigned i = fromRow; i <= toRow; ++i)
-    for (unsigned j = fromColumn; j <= toColumn; ++j)
+  assert(toColumn <= nColumns && "end of column range out of bounds!");
+  Matrix<T> subMatrix(toRow - fromRow, toColumn - fromColumn);
+  for (unsigned i = fromRow; i < toRow; ++i)
+    for (unsigned j = fromColumn; j < toColumn; ++j)
       subMatrix(i - fromRow, j - fromColumn) = at(i, j);
   return subMatrix;
 }


### PR DESCRIPTION
Currently `getSubMatrix(fromRow, toRow, fromCol, toCol)` forms a submatrix with both ends inclusive. In this way, it's impossible to form an empty submatrix, as the assertions in the function prevents cases where `toRow < fromRow`. However, the functionality is necessary for Barvinok procedures (e.g. we might want to inspect the submatrix for parameters, which will be empty if there's none).

This PR changes it to be inclusive on the left end and exclusive on the right end, making it the same as canonical C++ ranges.