### PR TITLE
[TargetLowering] Prevent expandVectorFindLastActive from creating illegal vector types during vector op legalization.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -10154,10 +10154,7 @@ SDValue TargetLowering::expandVectorFindLastActive(SDNode *N,
 
     // Split the mask
     auto [LoVT, HiVT] = DAG.GetSplitDestVTs(MaskVT);
-    std::pair<SDValue, SDValue> SplitMask =
-        DAG.SplitVector(N->getOperand(0), DL);
-    SDValue MaskLo = SplitMask.first;
-    SDValue MaskHi = SplitMask.second;
+    auto [MaskLo, MaskHi] = DAG.SplitVector(N->getOperand(0), DL);
 
     // Create split VECTOR_FIND_LAST_ACTIVE operations
     SDValue LoResult =

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -10081,6 +10081,8 @@ SDValue TargetLowering::expandVPCTTZElements(SDNode *N,
 /// Returns a type-legalized version of \p Mask as the first item in the
 /// pair. The second item contains a type-legalized step vector that's
 /// guaranteed to fit the number of elements in \p Mask.
+/// If the stepvector would require splitting, returns an empty SDValue
+/// as the second item to signal that the operation should be split instead.
 static std::pair<SDValue, SDValue>
 getLegalMaskAndStepVector(SDValue Mask, bool ZeroIsPoison, SDLoc DL,
                           SelectionDAG &DAG) {
@@ -10107,7 +10109,7 @@ getLegalMaskAndStepVector(SDValue Mask, bool ZeroIsPoison, SDLoc DL,
   // the same size but with a smaller number of larger elements, not the usual
   // larger size with the same number of larger elements.
   TargetLowering::LegalizeTypeAction TypeAction =
-      TLI.getTypeAction(StepVecVT.getSimpleVT());
+      TLI.getTypeAction(*DAG.getContext(), StepVecVT);
   SDValue StepVec;
   if (TypeAction == TargetLowering::TypePromoteInteger) {
     StepVecVT = TLI.getTypeToTransformTo(*DAG.getContext(), StepVecVT);
@@ -10127,6 +10129,10 @@ getLegalMaskAndStepVector(SDValue Mask, bool ZeroIsPoison, SDLoc DL,
     EVT WideMaskVT = EVT::getVectorVT(*DAG.getContext(), BoolVT, WideNumElts);
     SDValue ZeroMask = DAG.getConstant(0, DL, WideMaskVT);
     Mask = DAG.getInsertSubvector(DL, ZeroMask, Mask, 0);
+  } else if (TypeAction == TargetLowering::TypeSplitVector) {
+    // The stepvector type would require splitting. Signal to the caller
+    // that the operation should be split instead of expanded.
+    return {Mask, SDValue()};
   } else {
     StepVec = DAG.getStepVector(DL, StepVecVT);
   }
@@ -10139,6 +10145,44 @@ SDValue TargetLowering::expandVectorFindLastActive(SDNode *N,
   SDLoc DL(N);
   auto [Mask, StepVec] = getLegalMaskAndStepVector(
       N->getOperand(0), /*ZeroIsPoison=*/true, DL, DAG);
+
+  // If StepVec is empty, the stepvector would require splitting.
+  // Split the operation instead and let it be recursively legalized.
+  if (!StepVec) {
+    EVT MaskVT = N->getOperand(0).getValueType();
+    EVT ResVT = N->getValueType(0);
+
+    // Split the mask
+    auto [LoVT, HiVT] = DAG.GetSplitDestVTs(MaskVT);
+    std::pair<SDValue, SDValue> SplitMask =
+        DAG.SplitVector(N->getOperand(0), DL);
+    SDValue MaskLo = SplitMask.first;
+    SDValue MaskHi = SplitMask.second;
+
+    // Create split VECTOR_FIND_LAST_ACTIVE operations
+    SDValue LoResult =
+        DAG.getNode(ISD::VECTOR_FIND_LAST_ACTIVE, DL, ResVT, MaskLo);
+    SDValue HiResult =
+        DAG.getNode(ISD::VECTOR_FIND_LAST_ACTIVE, DL, ResVT, MaskHi);
+
+    // Check if any lane is active in the high mask.
+    SDValue AnyHiActive = DAG.getNode(ISD::VECREDUCE_OR, DL, MVT::i1, MaskHi);
+    SDValue Cond = DAG.getBoolExtOrTrunc(
+        AnyHiActive, DL,
+        getSetCCResultType(DAG.getDataLayout(), *DAG.getContext(), MVT::i1),
+        MVT::i1);
+
+    // Adjust HiResult by adding the number of elements in Lo
+    SDValue LoNumElts =
+        DAG.getElementCount(DL, ResVT, LoVT.getVectorElementCount());
+    SDValue AdjustedHiResult =
+        DAG.getNode(ISD::ADD, DL, ResVT, HiResult, LoNumElts);
+
+    // Return: AnyHiActive ? AdjustedHiResult : LoResult;
+    return DAG.getNode(ISD::SELECT, DL, ResVT, Cond, AdjustedHiResult,
+                       LoResult);
+  }
+
   EVT StepVecVT = StepVec.getValueType();
   EVT StepVT = StepVec.getValueType().getVectorElementType();
 

--- a/llvm/test/CodeGen/RISCV/rvv/vector-extract-last-active.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-extract-last-active.ll
@@ -188,28 +188,36 @@ define i8 @extract_last_i8_scalable(<vscale x 16 x i8> %data, <vscale x 16 x i1>
 ;
 ; RV64-LABEL: extract_last_i8_scalable:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
-; RV64-NEXT:    vcpop.m a1, v0
-; RV64-NEXT:    beqz a1, .LBB6_2
-; RV64-NEXT:  # %bb.1:
-; RV64-NEXT:    vmv2r.v v6, v8
-; RV64-NEXT:    vsetvli a0, zero, e64, m8, ta, ma
+; RV64-NEXT:    vsetvli a1, zero, e64, m8, ta, ma
+; RV64-NEXT:    vmv1r.v v10, v0
 ; RV64-NEXT:    vid.v v16
+; RV64-NEXT:    csrr a1, vlenb
+; RV64-NEXT:    srli a2, a1, 3
+; RV64-NEXT:    vsetvli a3, zero, e8, mf4, ta, ma
+; RV64-NEXT:    vslidedown.vx v0, v0, a2
+; RV64-NEXT:    vsetvli a2, zero, e64, m8, ta, ma
+; RV64-NEXT:    vcpop.m a2, v0
 ; RV64-NEXT:    vmv.v.i v24, 0
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    vmerge.vvm v8, v24, v16, v0
-; RV64-NEXT:    srli a1, a0, 3
-; RV64-NEXT:    vsetvli a2, zero, e8, mf4, ta, ma
-; RV64-NEXT:    vslidedown.vx v0, v0, a1
-; RV64-NEXT:    vsetvli a1, zero, e64, m8, ta, mu
-; RV64-NEXT:    vadd.vx v24, v16, a0, v0.t
-; RV64-NEXT:    vmaxu.vv v8, v8, v24
-; RV64-NEXT:    vredmaxu.vs v8, v8, v8
-; RV64-NEXT:    vmv.x.s a0, v8
-; RV64-NEXT:    vsetivli zero, 1, e8, m2, ta, ma
-; RV64-NEXT:    vslidedown.vx v8, v6, a0
-; RV64-NEXT:    vmv.x.s a0, v8
+; RV64-NEXT:    bnez a2, .LBB6_2
+; RV64-NEXT:  # %bb.1:
+; RV64-NEXT:    vmv1r.v v0, v10
+; RV64-NEXT:    vmerge.vvm v16, v24, v16, v0
+; RV64-NEXT:    vredmaxu.vs v11, v16, v16
+; RV64-NEXT:    vmv.x.s a1, v11
+; RV64-NEXT:    j .LBB6_3
 ; RV64-NEXT:  .LBB6_2:
+; RV64-NEXT:    vmerge.vvm v16, v24, v16, v0
+; RV64-NEXT:    vredmaxu.vs v11, v16, v16
+; RV64-NEXT:    vmv.x.s a2, v11
+; RV64-NEXT:    add a1, a2, a1
+; RV64-NEXT:  .LBB6_3:
+; RV64-NEXT:    vsetvli a2, zero, e8, m2, ta, ma
+; RV64-NEXT:    vcpop.m a2, v10
+; RV64-NEXT:    beqz a2, .LBB6_5
+; RV64-NEXT:  # %bb.4:
+; RV64-NEXT:    vslidedown.vx v8, v8, a1
+; RV64-NEXT:    vmv.x.s a0, v8
+; RV64-NEXT:  .LBB6_5:
 ; RV64-NEXT:    ret
   %res = call i8 @llvm.experimental.vector.extract.last.active.nxv16i8(<vscale x 16 x i8> %data, <vscale x 16 x i1> %mask, i8 %passthru)
   ret i8 %res
@@ -451,3 +459,226 @@ define i8 @extract_last_i8_scalable_vscale(<vscale x 16 x i8> %data, <vscale x 1
   ret i8 %res
 }
 
+define i8 @pr187458(<vscale x 64 x i8> %0, <vscale x 64 x i1> %mask) {
+; RV32-LABEL: pr187458:
+; RV32:       # %bb.0: # %entry
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    csrr a0, vlenb
+; RV32-NEXT:    slli a0, a0, 3
+; RV32-NEXT:    sub sp, sp, a0
+; RV32-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x08, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 8 * vlenb
+; RV32-NEXT:    vsetvli a0, zero, e32, m8, ta, ma
+; RV32-NEXT:    vmv1r.v v7, v0
+; RV32-NEXT:    addi a0, sp, 16
+; RV32-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
+; RV32-NEXT:    vid.v v8
+; RV32-NEXT:    vmv.v.i v16, 0
+; RV32-NEXT:    csrr a0, vlenb
+; RV32-NEXT:    srli a3, a0, 2
+; RV32-NEXT:    vsetvli a1, zero, e8, mf2, ta, ma
+; RV32-NEXT:    vslidedown.vx v0, v0, a3
+; RV32-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
+; RV32-NEXT:    vcpop.m a1, v0
+; RV32-NEXT:    slli a2, a0, 1
+; RV32-NEXT:    bnez a1, .LBB13_2
+; RV32-NEXT:  # %bb.1: # %entry
+; RV32-NEXT:    vmv1r.v v0, v7
+; RV32-NEXT:    vsetvli zero, zero, e32, m8, ta, ma
+; RV32-NEXT:    vmerge.vvm v24, v16, v8, v0
+; RV32-NEXT:    vredmaxu.vs v24, v24, v24
+; RV32-NEXT:    vmv.x.s a1, v24
+; RV32-NEXT:    j .LBB13_3
+; RV32-NEXT:  .LBB13_2:
+; RV32-NEXT:    vsetvli zero, zero, e32, m8, ta, ma
+; RV32-NEXT:    vmerge.vvm v24, v16, v8, v0
+; RV32-NEXT:    vredmaxu.vs v24, v24, v24
+; RV32-NEXT:    vmv.x.s a1, v24
+; RV32-NEXT:    add a1, a1, a2
+; RV32-NEXT:  .LBB13_3: # %entry
+; RV32-NEXT:    srli a4, a0, 1
+; RV32-NEXT:    vsetvli a5, zero, e8, m1, ta, ma
+; RV32-NEXT:    vslidedown.vx v6, v7, a4
+; RV32-NEXT:    vsetvli a4, zero, e8, mf2, ta, ma
+; RV32-NEXT:    vslidedown.vx v0, v6, a3
+; RV32-NEXT:    vsetvli a3, zero, e8, m2, ta, ma
+; RV32-NEXT:    vcpop.m a3, v0
+; RV32-NEXT:    bnez a3, .LBB13_5
+; RV32-NEXT:  # %bb.4: # %entry
+; RV32-NEXT:    vmv1r.v v0, v6
+; RV32-NEXT:    vsetvli zero, zero, e32, m8, ta, ma
+; RV32-NEXT:    vmerge.vvm v8, v16, v8, v0
+; RV32-NEXT:    vredmaxu.vs v8, v8, v8
+; RV32-NEXT:    vmv.x.s a2, v8
+; RV32-NEXT:    j .LBB13_6
+; RV32-NEXT:  .LBB13_5:
+; RV32-NEXT:    vsetvli zero, zero, e32, m8, ta, ma
+; RV32-NEXT:    vmerge.vvm v8, v16, v8, v0
+; RV32-NEXT:    vredmaxu.vs v8, v8, v8
+; RV32-NEXT:    vmv.x.s a3, v8
+; RV32-NEXT:    add a2, a3, a2
+; RV32-NEXT:  .LBB13_6: # %entry
+; RV32-NEXT:    vsetvli a3, zero, e8, m4, ta, ma
+; RV32-NEXT:    vcpop.m a3, v6
+; RV32-NEXT:    beqz a3, .LBB13_8
+; RV32-NEXT:  # %bb.7:
+; RV32-NEXT:    slli a0, a0, 2
+; RV32-NEXT:    add a1, a2, a0
+; RV32-NEXT:  .LBB13_8: # %entry
+; RV32-NEXT:    addi a0, sp, 16
+; RV32-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV32-NEXT:    vsetivli zero, 1, e8, m8, ta, ma
+; RV32-NEXT:    vslidedown.vx v8, v8, a1
+; RV32-NEXT:    vsetvli a0, zero, e8, m8, ta, ma
+; RV32-NEXT:    vcpop.m a0, v7
+; RV32-NEXT:    vmv.x.s a1, v8
+; RV32-NEXT:    seqz a0, a0
+; RV32-NEXT:    addi a0, a0, -1
+; RV32-NEXT:    and a0, a0, a1
+; RV32-NEXT:    csrr a1, vlenb
+; RV32-NEXT:    slli a1, a1, 3
+; RV32-NEXT:    add sp, sp, a1
+; RV32-NEXT:    .cfi_def_cfa sp, 16
+; RV32-NEXT:    addi sp, sp, 16
+; RV32-NEXT:    .cfi_def_cfa_offset 0
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: pr187458:
+; RV64:       # %bb.0: # %entry
+; RV64-NEXT:    addi sp, sp, -16
+; RV64-NEXT:    .cfi_def_cfa_offset 16
+; RV64-NEXT:    csrr a0, vlenb
+; RV64-NEXT:    slli a0, a0, 3
+; RV64-NEXT:    sub sp, sp, a0
+; RV64-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x08, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 8 * vlenb
+; RV64-NEXT:    vsetvli a0, zero, e64, m8, ta, ma
+; RV64-NEXT:    vmv1r.v v7, v0
+; RV64-NEXT:    addi a0, sp, 16
+; RV64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
+; RV64-NEXT:    vid.v v8
+; RV64-NEXT:    csrr a0, vlenb
+; RV64-NEXT:    srli a2, a0, 3
+; RV64-NEXT:    vsetvli a1, zero, e8, mf4, ta, ma
+; RV64-NEXT:    vslidedown.vx v0, v0, a2
+; RV64-NEXT:    vsetvli a1, zero, e64, m8, ta, ma
+; RV64-NEXT:    vcpop.m a1, v0
+; RV64-NEXT:    vmv.v.i v16, 0
+; RV64-NEXT:    bnez a1, .LBB13_2
+; RV64-NEXT:  # %bb.1: # %entry
+; RV64-NEXT:    vmv1r.v v0, v7
+; RV64-NEXT:    vmerge.vvm v24, v16, v8, v0
+; RV64-NEXT:    vredmaxu.vs v24, v24, v24
+; RV64-NEXT:    vmv.x.s a1, v24
+; RV64-NEXT:    j .LBB13_3
+; RV64-NEXT:  .LBB13_2:
+; RV64-NEXT:    vmerge.vvm v24, v16, v8, v0
+; RV64-NEXT:    vredmaxu.vs v24, v24, v24
+; RV64-NEXT:    vmv.x.s a1, v24
+; RV64-NEXT:    add a1, a1, a0
+; RV64-NEXT:  .LBB13_3: # %entry
+; RV64-NEXT:    srli a3, a0, 2
+; RV64-NEXT:    vsetvli a4, zero, e8, mf2, ta, ma
+; RV64-NEXT:    vslidedown.vx v6, v7, a3
+; RV64-NEXT:    vsetvli a4, zero, e8, mf4, ta, ma
+; RV64-NEXT:    vslidedown.vx v0, v6, a2
+; RV64-NEXT:    vsetvli a4, zero, e8, m1, ta, ma
+; RV64-NEXT:    vcpop.m a4, v0
+; RV64-NEXT:    bnez a4, .LBB13_5
+; RV64-NEXT:  # %bb.4: # %entry
+; RV64-NEXT:    vmv1r.v v0, v6
+; RV64-NEXT:    vsetvli zero, zero, e64, m8, ta, ma
+; RV64-NEXT:    vmerge.vvm v24, v16, v8, v0
+; RV64-NEXT:    vredmaxu.vs v24, v24, v24
+; RV64-NEXT:    vmv.x.s a5, v24
+; RV64-NEXT:    j .LBB13_6
+; RV64-NEXT:  .LBB13_5:
+; RV64-NEXT:    vsetvli zero, zero, e64, m8, ta, ma
+; RV64-NEXT:    vmerge.vvm v24, v16, v8, v0
+; RV64-NEXT:    vredmaxu.vs v24, v24, v24
+; RV64-NEXT:    vmv.x.s a5, v24
+; RV64-NEXT:    add a5, a5, a0
+; RV64-NEXT:  .LBB13_6: # %entry
+; RV64-NEXT:    vsetvli a4, zero, e8, m2, ta, ma
+; RV64-NEXT:    vcpop.m a6, v6
+; RV64-NEXT:    slli a4, a0, 1
+; RV64-NEXT:    beqz a6, .LBB13_8
+; RV64-NEXT:  # %bb.7:
+; RV64-NEXT:    add a1, a5, a4
+; RV64-NEXT:  .LBB13_8: # %entry
+; RV64-NEXT:    srli a5, a0, 1
+; RV64-NEXT:    vsetvli a6, zero, e8, m1, ta, ma
+; RV64-NEXT:    vslidedown.vx v6, v7, a5
+; RV64-NEXT:    vsetvli a5, zero, e8, mf4, ta, ma
+; RV64-NEXT:    vslidedown.vx v0, v6, a2
+; RV64-NEXT:    vsetvli a5, zero, e8, m1, ta, ma
+; RV64-NEXT:    vcpop.m a5, v0
+; RV64-NEXT:    bnez a5, .LBB13_10
+; RV64-NEXT:  # %bb.9: # %entry
+; RV64-NEXT:    vmv1r.v v0, v6
+; RV64-NEXT:    vsetvli zero, zero, e64, m8, ta, ma
+; RV64-NEXT:    vmerge.vvm v24, v16, v8, v0
+; RV64-NEXT:    vredmaxu.vs v24, v24, v24
+; RV64-NEXT:    vmv.x.s a5, v24
+; RV64-NEXT:    j .LBB13_11
+; RV64-NEXT:  .LBB13_10:
+; RV64-NEXT:    vsetvli zero, zero, e64, m8, ta, ma
+; RV64-NEXT:    vmerge.vvm v24, v16, v8, v0
+; RV64-NEXT:    vredmaxu.vs v24, v24, v24
+; RV64-NEXT:    vmv.x.s a5, v24
+; RV64-NEXT:    add a5, a5, a0
+; RV64-NEXT:  .LBB13_11: # %entry
+; RV64-NEXT:    vsetvli a6, zero, e8, mf2, ta, ma
+; RV64-NEXT:    vslidedown.vx v5, v6, a3
+; RV64-NEXT:    vsetvli a3, zero, e8, mf4, ta, ma
+; RV64-NEXT:    vslidedown.vx v0, v5, a2
+; RV64-NEXT:    vsetvli a2, zero, e8, m1, ta, ma
+; RV64-NEXT:    vcpop.m a2, v0
+; RV64-NEXT:    bnez a2, .LBB13_13
+; RV64-NEXT:  # %bb.12: # %entry
+; RV64-NEXT:    vmv1r.v v0, v5
+; RV64-NEXT:    vsetvli zero, zero, e64, m8, ta, ma
+; RV64-NEXT:    vmerge.vvm v8, v16, v8, v0
+; RV64-NEXT:    vredmaxu.vs v8, v8, v8
+; RV64-NEXT:    vmv.x.s a2, v8
+; RV64-NEXT:    j .LBB13_14
+; RV64-NEXT:  .LBB13_13:
+; RV64-NEXT:    vsetvli zero, zero, e64, m8, ta, ma
+; RV64-NEXT:    vmerge.vvm v8, v16, v8, v0
+; RV64-NEXT:    vredmaxu.vs v8, v8, v8
+; RV64-NEXT:    vmv.x.s a2, v8
+; RV64-NEXT:    add a2, a2, a0
+; RV64-NEXT:  .LBB13_14: # %entry
+; RV64-NEXT:    vsetvli a3, zero, e8, m2, ta, ma
+; RV64-NEXT:    vcpop.m a3, v5
+; RV64-NEXT:    beqz a3, .LBB13_16
+; RV64-NEXT:  # %bb.15:
+; RV64-NEXT:    add a5, a2, a4
+; RV64-NEXT:  .LBB13_16: # %entry
+; RV64-NEXT:    vsetvli a2, zero, e8, m4, ta, ma
+; RV64-NEXT:    vcpop.m a2, v6
+; RV64-NEXT:    beqz a2, .LBB13_18
+; RV64-NEXT:  # %bb.17:
+; RV64-NEXT:    slli a0, a0, 2
+; RV64-NEXT:    add a1, a5, a0
+; RV64-NEXT:  .LBB13_18: # %entry
+; RV64-NEXT:    addi a0, sp, 16
+; RV64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV64-NEXT:    vsetivli zero, 1, e8, m8, ta, ma
+; RV64-NEXT:    vslidedown.vx v8, v8, a1
+; RV64-NEXT:    vsetvli a0, zero, e8, m8, ta, ma
+; RV64-NEXT:    vcpop.m a0, v7
+; RV64-NEXT:    vmv.x.s a1, v8
+; RV64-NEXT:    seqz a0, a0
+; RV64-NEXT:    addi a0, a0, -1
+; RV64-NEXT:    and a0, a0, a1
+; RV64-NEXT:    csrr a1, vlenb
+; RV64-NEXT:    slli a1, a1, 3
+; RV64-NEXT:    add sp, sp, a1
+; RV64-NEXT:    .cfi_def_cfa sp, 16
+; RV64-NEXT:    addi sp, sp, 16
+; RV64-NEXT:    .cfi_def_cfa_offset 0
+; RV64-NEXT:    ret
+entry:
+  %1 = call i8 @llvm.experimental.vector.extract.last.active.nxv64i8(<vscale x 64 x i8> %0, <vscale x 64 x i1> %mask, i8 0)
+  ret i8 %1
+}


### PR DESCRIPTION
This code needs to create a step vector but we only have a mask vector type. If the step vector is too large it might not be an MVT. This causes the getSimpleVT() call for getTypeAction to fail. We can replace that with the EVT version of getTypeAction, but we'll still fail trying to legalize the vselect. The getOperationAction query will return Expand for non-simple VTs. ExpandVSELECT will try to unroll the vselect which will fail for scalable vectors. We could hack that to not unroll scalable vectors, but that would be a hack.

To fix this, split the FIND_LAST_ACTIVE into two if the step vector needs to be split. Those will recursively legalize and eventually arrive at a size we can create a valid step vector for.

One existing test changes because it created an illegal type which happened to still be an MVT. This allowed getOperationAction to return Legal, even though the type isn't legal.

Fixes the assertion mentioned in #187458.

Assisted-by: Claude Sonnet 4.5