### PR TITLE
[lldb/test] Replace pause() with atomic barrier in thread_filter test

### DIFF
--- a/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/TestFrameProviderThreadFilter.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/TestFrameProviderThreadFilter.py
@@ -28,13 +28,13 @@ class FrameProviderThreadFilterTestCase(TestBase):
             only_one_thread=False,
         )
 
-        # The breakpoint is on a one-shot line (fetch_add), so each hit is
-        # from a unique thread. Continue until all 3 have hit it.
+        # All threads synchronize via an atomic barrier, then each one
+        # hits the breakpoint while spinning. Continue until all 3 have hit.
         while bkpt.GetHitCount() < 3:
             process.Continue()
 
-        # After 3 hits, all worker threads are alive: some in the spin loop,
-        # one at the breakpoint. Collect all non-main threads.
+        # After 3 hits, all worker threads are alive in the spin loop.
+        # Collect all non-main threads.
         worker_threads = []
         for t in process:
             for i in range(t.GetNumFrames()):

--- a/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/main.cpp
+++ b/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/main.cpp
@@ -1,11 +1,18 @@
+#include <atomic>
 #include <thread>
-#include <unistd.h>
 #include <vector>
 
 #define NUM_THREADS 3
 
+std::atomic<int> g_barrier(NUM_THREADS);
+volatile bool g_spin = true;
+
 void thread_work() {
-  pause(); // break in thread
+  --g_barrier;
+  while (g_barrier.load() > 0)
+    ;
+  while (g_spin) // break in thread
+    ;
 }
 
 int main() {


### PR DESCRIPTION
The TestFrameProviderThreadFilter test was crashing on the ARM Ubuntu CI with an assertion in StackFrameList::GetFrameAtIndex ("A valid thread has no frames."):

https://lab.llvm.org/buildbot/#/builders/18/builds/25501

On ARM Linux, the debugger's stop/resume cycle can cause pause() to return (EINTR from ptrace signals), letting threads exit before the test accesses their frames.

Replace pause() with an atomic spin-loop barrier that keeps all threads alive in userspace at a known, unwinding-friendly location.