### PR TITLE
[lldb][test] Remove libc++ dependency in common libcxx-simulators header

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
+++ b/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
@@ -1,9 +1,6 @@
 #ifndef STD_LLDB_COMPRESSED_PAIR_H
 #define STD_LLDB_COMPRESSED_PAIR_H
 
-#include <type_traits>
-#include <utility> // for std::forward
-
 // COMPRESSED_PAIR_REV versions:
 // 0 -> Post-c88580c layout
 // 1 -> Post-27c83382d83dc layout
@@ -14,6 +11,13 @@
 
 namespace std {
 namespace __lldb {
+
+using size_t = decltype(sizeof(0));
+
+// Stripped down version of std::integral_constant
+template <class _Tp, _Tp __v> struct integral_constant {
+  static inline constexpr const _Tp value = __v;
+};
 
 #if __has_cpp_attribute(msvc::no_unique_address)
 #define _LLDB_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]

--- a/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
+++ b/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
@@ -12,12 +12,24 @@
 namespace std {
 namespace __lldb {
 
+// Type-traits definitions without pulling in STL headers.
+
 using size_t = decltype(sizeof(0));
 
 // Stripped down version of std::integral_constant
 template <class _Tp, _Tp __v> struct integral_constant {
   static inline constexpr const _Tp value = __v;
 };
+
+template <class _Tp> constexpr _Tp &&forward(_Tp &&__t) noexcept {
+  return static_cast<_Tp &&>(__t);
+}
+
+template <class _Tp>
+struct is_empty : integral_constant<bool, __is_empty(_Tp)> {};
+
+template <class _Tp>
+struct is_final : public integral_constant<bool, __is_final(_Tp)> {};
 
 #if __has_cpp_attribute(msvc::no_unique_address)
 #define _LLDB_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
@@ -35,15 +47,11 @@ template <class _Tp>
 inline const size_t __datasizeof_v =
     __builtin_offsetof(_FirstPaddingByte<_Tp>, __first_padding_byte_);
 
-template <class _Tp>
-struct __lldb_is_final : public integral_constant<bool, __is_final(_Tp)> {};
-
 // The legacy layout has been patched, see
 // https://github.com/llvm/llvm-project/pull/142516.
 #if COMPRESSED_PAIR_REV == 1
 template <class _ToPad> class __compressed_pair_padding {
-  char __padding_[((is_empty<_ToPad>::value &&
-                    !__lldb_is_final<_ToPad>::value) ||
+  char __padding_[((is_empty<_ToPad>::value && !is_final<_ToPad>::value) ||
                    is_reference<_ToPad>::value)
                       ? 0
                       : sizeof(_ToPad) - __datasizeof_v<_ToPad>];
@@ -51,7 +59,7 @@ template <class _ToPad> class __compressed_pair_padding {
 #elif COMPRESSED_PAIR_REV > 1 && COMPRESSED_PAIR_REV < 4
 template <class _ToPad>
 inline const bool __is_reference_or_unpadded_object =
-    (std::is_empty<_ToPad>::value && !__lldb_is_final<_ToPad>::value) ||
+    (is_empty<_ToPad>::value && !is_final<_ToPad>::value) ||
     sizeof(_ToPad) == __datasizeof_v<_ToPad>;
 
 template <class _Tp>
@@ -73,8 +81,7 @@ struct __value_init_tag {};
 struct __default_init_tag {};
 
 template <class _Tp, int _Idx,
-          bool _CanBeEmptyBase =
-              std::is_empty<_Tp>::value && !std::is_final<_Tp>::value>
+          bool _CanBeEmptyBase = is_empty<_Tp>::value && !is_final<_Tp>::value>
 struct __compressed_pair_elem {
   explicit __compressed_pair_elem(__default_init_tag) {}
   explicit __compressed_pair_elem(__value_init_tag) : __value_() {}
@@ -109,7 +116,7 @@ public:
 
   template <class _U1, class _U2>
   explicit __compressed_pair(_U1 &&__t1, _U2 &&__t2)
-      : _Base1(std::forward<_U1>(__t1)), _Base2(std::forward<_U2>(__t2)) {}
+      : _Base1(forward<_U1>(__t1)), _Base2(forward<_U2>(__t2)) {}
 
   _T1 &first() { return static_cast<_Base1 &>(*this).__get(); }
 };

--- a/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
+++ b/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
@@ -40,6 +40,9 @@ struct is_empty : integral_constant<bool, __is_empty(_Tp)> {};
 template <class _Tp>
 struct is_final : public integral_constant<bool, __is_final(_Tp)> {};
 
+template <typename T>
+struct is_reference : integral_constant<bool, __is_reference(T)> {};
+
 #if __has_cpp_attribute(msvc::no_unique_address)
 #define _LLDB_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
 #elif __has_cpp_attribute(no_unique_address)

--- a/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
+++ b/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
@@ -21,7 +21,16 @@ template <class _Tp, _Tp __v> struct integral_constant {
   static inline constexpr const _Tp value = __v;
 };
 
-template <class _Tp> constexpr _Tp &&forward(_Tp &&__t) noexcept {
+template <class _Tp>
+using remove_reference_t [[gnu::nodebug]] = __remove_reference_t(_Tp);
+
+template <class _Tp>
+constexpr _Tp &&forward(remove_reference_t<_Tp> &&__t) noexcept {
+  return static_cast<_Tp &&>(__t);
+}
+
+template <class _Tp>
+constexpr _Tp &&forward(remove_reference_t<_Tp> &__t) noexcept {
   return static_cast<_Tp &&>(__t);
 }
 


### PR DESCRIPTION
After we made the test-suite mostly compile against system libc++ (in https://github.com/llvm/llvm-project/pull/190034), the `invalid-vector` test started failing on the macOS bots with:
```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/include/c++/v1 -std=c++20 --driver-mode=g++ -MT main.o -MD -MP -MF main.d -c -o main.o /Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake/llvm-project/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/main.cpp
[2026-04-07T00:09:44.764Z] /Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake/llvm-project/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/main.cpp:6:1: error: too few template parameters in template redeclaration
[2026-04-07T00:09:44.764Z]     6 | template <typename T> struct vector {
[2026-04-07T00:09:44.764Z]       | ^~~~~~~~~~~~~~~~~~~~~
[2026-04-07T00:09:44.764Z] /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/include/c++/v1/iosfwd:167:1: note: previous template declaration is here
[2026-04-07T00:09:44.764Z]   167 | template <class _Tp, class _Alloc = allocator<_Tp> >
[2026-04-07T00:09:44.764Z]       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This patch fixes the error by removing the STL header includes from the `compressed_pair.h` header. Presumably the `vector` forward declaration somehow gets pulled in via one of those headers (via `iosfwd`).

The `libcxx-simulators` tests are supposed to be STL-independent, so removing this dependency works towards that goal.