### PR TITLE
[gold] Handle duplicate archives gracefully in LTO plugin

### DIFF
--- a/llvm/test/tools/gold/X86/Inputs/duplicate-archive.ll
+++ b/llvm/test/tools/gold/X86/Inputs/duplicate-archive.ll
@@ -1,0 +1,7 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @foo() {
+entry:
+  ret void
+}

--- a/llvm/test/tools/gold/X86/Inputs/duplicate-archive.ll
+++ b/llvm/test/tools/gold/X86/Inputs/duplicate-archive.ll
@@ -1,7 +1,10 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-define void @foo() {
+; Weak so that pulling this member from the archive twice (via
+; --whole-archive) does not cause a multiple-definition error; the link
+; must still succeed, exercising only the duplicate-module code path.
+define weak void @foo() {
 entry:
   ret void
 }

--- a/llvm/test/tools/gold/X86/duplicate-archive.ll
+++ b/llvm/test/tools/gold/X86/duplicate-archive.ll
@@ -1,28 +1,30 @@
-; Test that passing the same archive twice to the LTO gold plugin does not
-; crash. This is a common pattern used to resolve circular dependencies
-; between archives (e.g., "ld -la -lb -la"). Previously this triggered an
-; assertion failure in gold-plugin.cpp because duplicate archive members
-; produced identical module identifiers in ObjectToIndexFileState.
+; Test that the gold LTO plugin does not crash when the same archive is
+; passed more than once on the command line and a member ends up claimed
+; multiple times. With --whole-archive the linker pulls the member from
+; every occurrence of the archive, so the plugin sees the same module
+; twice. Previously this triggered an assertion failure in gold-plugin.cpp
+; because the duplicate modules produced identical identifiers in
+; ObjectToIndexFileState.
 
 ; RUN: llvm-as %s -o %t.o
 ; RUN: llvm-as %p/Inputs/duplicate-archive.ll -o %t2.o
 ; RUN: llvm-ar rcs %t.a %t2.o
 
-; Full LTO: same archive passed twice should not crash.
+; Full LTO: archive claimed twice via --whole-archive must not crash.
 ; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 -shared \
-; RUN:    -o %t.so %t.o %t.a %t.a
+; RUN:    -o %t.so %t.o --whole-archive %t.a %t.a --no-whole-archive
 ; RUN: llvm-nm %t.so | FileCheck %s
 
-; ThinLTO: same archive passed twice should also not crash.
+; ThinLTO: same scenario must not crash.
 ; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 -shared \
 ; RUN:    --plugin-opt=thinlto \
-; RUN:    -o %t.thinlto.so %t.o %t.a %t.a
+; RUN:    -o %t.thinlto.so %t.o --whole-archive %t.a %t.a --no-whole-archive
 ; RUN: llvm-nm %t.thinlto.so | FileCheck %s
 
-; CHECK-DAG: T foo
 ; CHECK-DAG: T bar
+; CHECK-DAG: W foo
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/llvm/test/tools/gold/X86/duplicate-archive.ll
+++ b/llvm/test/tools/gold/X86/duplicate-archive.ll
@@ -1,0 +1,35 @@
+; Test that passing the same archive twice to the LTO gold plugin does not
+; crash. This is a common pattern used to resolve circular dependencies
+; between archives (e.g., "ld -la -lb -la"). Previously this triggered an
+; assertion failure in gold-plugin.cpp because duplicate archive members
+; produced identical module identifiers in ObjectToIndexFileState.
+
+; RUN: llvm-as %s -o %t.o
+; RUN: llvm-as %p/Inputs/duplicate-archive.ll -o %t2.o
+; RUN: llvm-ar rcs %t.a %t2.o
+
+; Full LTO: same archive passed twice should not crash.
+; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN:    -m elf_x86_64 -shared \
+; RUN:    -o %t.so %t.o %t.a %t.a
+; RUN: llvm-nm %t.so | FileCheck %s
+
+; ThinLTO: same archive passed twice should also not crash.
+; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN:    -m elf_x86_64 -shared \
+; RUN:    --plugin-opt=thinlto \
+; RUN:    -o %t.thinlto.so %t.o %t.a %t.a
+; RUN: llvm-nm %t.thinlto.so | FileCheck %s
+
+; CHECK-DAG: T foo
+; CHECK-DAG: T bar
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @foo()
+
+define void @bar() {
+  call void @foo()
+  ret void
+}

--- a/llvm/tools/gold/gold-plugin.cpp
+++ b/llvm/tools/gold/gold-plugin.cpp
@@ -1084,7 +1084,7 @@ static std::vector<std::pair<SmallString<128>, bool>> runLTO() {
         getThinLTOObjectFileName(F.name, OldSuffix, NewSuffix);
     auto ObjFilename = ObjectToIndexFileState.insert({Identifier, false});
     // get_symbols must be called for every claimed file; skipping it causes
-    // gold to crash when processing the file handle during linking.
+    // the LTO plugin to crash when processing the file handle during linking.
     const void *View = getSymbolsAndView(F);
     // The same archive may be specified multiple times on the command line to
     // handle circular dependencies between archives. Skip duplicate modules

--- a/llvm/tools/gold/gold-plugin.cpp
+++ b/llvm/tools/gold/gold-plugin.cpp
@@ -1083,8 +1083,15 @@ static std::vector<std::pair<SmallString<128>, bool>> runLTO() {
     std::string Identifier =
         getThinLTOObjectFileName(F.name, OldSuffix, NewSuffix);
     auto ObjFilename = ObjectToIndexFileState.insert({Identifier, false});
-    assert(ObjFilename.second);
-    if (const void *View = getSymbolsAndView(F))
+    // get_symbols must be called for every claimed file; skipping it causes
+    // gold to crash when processing the file handle during linking.
+    const void *View = getSymbolsAndView(F);
+    // The same archive may be specified multiple times on the command line to
+    // handle circular dependencies between archives. Skip duplicate modules
+    // rather than asserting, since each module only needs to be processed once.
+    if (!ObjFilename.second)
+      continue;
+    if (View)
       addModule(*Lto, F, View, ObjFilename.first->first());
     else if (options::thinlto_index_only) {
       ObjFilename.first->second = true;


### PR DESCRIPTION
When the same archive is specified more than once on the command line and 
a member ends up being claimed multiple times, the LTO plugin crashed with
an assertion failure because the duplicate modules produced identical
identifiers in ObjectToIndexFileState.

This happens, for example, when the same archive is passed twice under
--whole-archive (which pulls every member from every occurrence of the 
archive), or when ld.bfd processes a duplicated archive in a -static link.
In these cases the linker invokes the plugin's claim_file hook more than
once for the same archive member.

The assert(ObjFilename.second) introduced in 0c6a4ff8dcd3 assumed each
identifier would be unique. That holds for a single pass over distinct
inputs, but the linker plugin interface does not guarantee that claim_file
is called at most once per logical module, so the assumption is too strong.

Fix this by calling getSymbolsAndView() before the duplicate check, so
get_symbols is still invoked for every claimed file (required by the plugin
internals), then skipping duplicate modules with continue instead of
asserting.

Add a regression test covering both Full LTO and ThinLTO modes. The test
uses --whole-archive with the archive listed twice, since that reliably
reproduces the duplicate-module path on ld.gold (which the gold plugin
tests run against); a plain duplicated archive is de-duplicated during
symbol resolution and does not exercise the bug.