### PR TITLE
[clang-tidy] Fix false positive in readability-non-const-parameter with dependent array subscripts

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
@@ -216,6 +216,12 @@ void NonConstParameterCheck::markCanNotBeConst(const Expr *E,
     }
   } else if (const auto *A = dyn_cast<ArraySubscriptExpr>(E)) {
     markCanNotBeConst(A->getBase(), true);
+    if (A->isInstantiationDependent()) {
+      markCanNotBeConst(A->getLHS(), true);
+      markCanNotBeConst(A->getRHS(), true);
+    } else {
+      markCanNotBeConst(A->getBase(), true);
+    }
   } else if (const auto *CLE = dyn_cast<CompoundLiteralExpr>(E)) {
     markCanNotBeConst(CLE->getInitializer(), true);
   } else if (const auto *Constr = dyn_cast<CXXConstructExpr>(E)) {

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -226,7 +226,7 @@ Changes in existing checks
   C++ files because suggested ``reinterpret_cast`` is not available in pure C.
 
 - Improved :doc:`bugprone-derived-method-shadowing-base-method
-  <clang-tidy/checks/bugprone/derived-method-shadowing-base-method>` check by 
+  <clang-tidy/checks/bugprone/derived-method-shadowing-base-method>` check by
   correctly ignoring function templates.
 
 - Improved :doc:`bugprone-exception-escape
@@ -257,7 +257,7 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/std-namespace-modification>` check by fixing
   false positives when extending the standard library with a specialization of
   user-defined type and by removing detection of the compiler generated ``std``
-  namespace extensions. 
+  namespace extensions.
 
 - Improved :doc:`bugprone-string-constructor
   <clang-tidy/checks/bugprone/string-constructor>` check to detect suspicious
@@ -475,9 +475,13 @@ Changes in existing checks
     to ``bool`` in C.
 
 - Improved :doc:`readability-non-const-parameter
-  <clang-tidy/checks/readability/non-const-parameter>` check by avoiding false
-  positives on parameters used in dependent expressions (e.g. inside generic
-  lambdas).
+  <clang-tidy/checks/readability/non-const-parameter>` check:
+
+  - Avoid false positives on parameters used in dependent expressions
+    (e.g. inside generic lambdas).
+
+  - Fixed a false positive in array subscript expressions where the types are
+    not yet resolved.
 
 - Improved :doc:`readability-redundant-preprocessor
   <clang-tidy/checks/readability/redundant-preprocessor>` check by fixing a

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
@@ -372,3 +372,19 @@ void testGenericLambdaIssue177354() {
     T x(*p);
   };
 }
+
+template <typename Index>
+void dependentArray1(double *ToFill, Index I, double FillValue) {
+  ToFill[I] = FillValue;
+}
+
+template <typename Index>
+void dependentArray2(double *ToFill, Index I, double FillValue) {
+  I[ToFill] = FillValue;
+}
+
+void useDependentArray() {
+  double ToFill[2] = {};
+  dependentArray1(ToFill, 0, 1.0);
+  dependentArray2(ToFill, 0, 1.0);
+}


### PR DESCRIPTION
Fixes #60163