### PR TITLE
[lldb] Remove "AppendNoteWithFormat("

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -116,9 +116,6 @@ public:
 
   void AppendNote(llvm::StringRef in_string);
 
-  void AppendNoteWithFormat(const char *format, ...)
-      __attribute__((format(printf, 2, 3)));
-
   void AppendWarning(llvm::StringRef in_string);
 
   void AppendWarningWithFormat(const char *format, ...)

--- a/lldb/source/Interpreter/CommandReturnObject.cpp
+++ b/lldb/source/Interpreter/CommandReturnObject.cpp
@@ -68,18 +68,6 @@ void CommandReturnObject::AppendErrorWithFormat(const char *format, ...) {
   }
 }
 
-void CommandReturnObject::AppendNoteWithFormat(const char *format, ...) {
-  if (!format)
-    return;
-  va_list args;
-  va_start(args, format);
-  StreamString sstrm;
-  sstrm.PrintfVarArg(format, args);
-  va_end(args);
-
-  note(GetOutputStream()) << sstrm.GetString();
-}
-
 void CommandReturnObject::AppendWarningWithFormat(const char *format, ...) {
   if (!format)
     return;


### PR DESCRIPTION
This method is surprising because it does not automatically add a newline like AppendNoteWithFormatv and other AppendNote... functions.

If you need to manage the newlines yourself, you should add an equivalent of GetOutputStream for notes. See
efc0bcdf542475301805ed8478a5d5845f44dc53 for examples of that done for messages.

AppendNoteWithFormat( is not used at all either (there are a few callers of `AppendNoteWithFormatv(`).