### PR TITLE
[SPIR-V] Drop initializer for Import linkage type globals

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -6156,6 +6156,9 @@ bool SPIRVInstructionSelector::selectGlobalValue(
   const std::optional<SPIRV::LinkageType::LinkageType> LnkType =
       getSpirvLinkageTypeFor(STI, *GV);
 
+  if (LnkType && *LnkType == SPIRV::LinkageType::Import)
+    Init = nullptr;
+
   const unsigned AddrSpace = GV->getAddressSpace();
   SPIRV::StorageClass::StorageClass StorageClass =
       addressSpaceToStorageClass(AddrSpace, STI);

--- a/llvm/test/CodeGen/SPIRV/linkage/linkage-types.ll
+++ b/llvm/test/CodeGen/SPIRV/linkage/linkage-types.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; SPIRV: OpCapability Linkage
 ; SPIRV: OpEntryPoint Kernel %[[#kern:]] "kern"


### PR DESCRIPTION
Per SPIR-V spec, variable with Import linkage must not have initializer

Fix corresponding spirv-val error:
```
error: A module-scope OpVariable with initialization value cannot be marked with the Import Linkage Type.
```

related to https://github.com/llvm/llvm-project/issues/190736