### PR TITLE
[lldb] Convert AppendWarningWithFormat( calls to AppendWarningWithFormatv(

### DIFF
--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -482,9 +482,8 @@ protected:
 
     if (m_interpreter.AliasExists(alias_command) ||
         m_interpreter.UserCommandExists(alias_command)) {
-      result.AppendWarningWithFormat(
-          "Overwriting existing definition for '%s'.\n",
-          alias_command.str().c_str());
+      result.AppendWarningWithFormatv(
+          "Overwriting existing definition for '{0}'.", alias_command);
     }
     if (CommandAlias *alias = m_interpreter.AddAlias(
             alias_command, cmd_obj_sp, raw_command_string)) {
@@ -579,8 +578,8 @@ protected:
 
     if (m_interpreter.AliasExists(alias_command) ||
         m_interpreter.UserCommandExists(alias_command)) {
-      result.AppendWarningWithFormat(
-          "Overwriting existing definition for '%s'.\n", alias_command.c_str());
+      result.AppendWarningWithFormatv(
+          "Overwriting existing definition for '{0}'.", alias_command);
     }
 
     if (CommandAlias *alias = m_interpreter.AddAlias(

--- a/lldb/source/Commands/CommandObjectDisassemble.cpp
+++ b/lldb/source/Commands/CommandObjectDisassemble.cpp
@@ -498,8 +498,8 @@ void CommandObjectDisassemble::DoExecute(Args &command,
     return;
   } else if (flavor_string != nullptr && !disassembler->FlavorValidForArchSpec(
                                              m_options.arch, flavor_string))
-    result.AppendWarningWithFormat(
-        "invalid disassembler flavor \"%s\", using default.\n", flavor_string);
+    result.AppendWarningWithFormatv(
+        "invalid disassembler flavor \"{0}\", using default.", flavor_string);
 
   result.SetStatus(eReturnStatusSuccessFinishResult);
 

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -670,10 +670,10 @@ protected:
       }
 
       if (bytes_read < total_byte_size)
-        result.AppendWarningWithFormat(
-            "Not all bytes (%" PRIu64 "/%" PRIu64
-            ") were able to be read from 0x%" PRIx64 ".\n",
-            (uint64_t)bytes_read, (uint64_t)total_byte_size, addr);
+        result.AppendWarningWithFormatv("Not all bytes ({0} / {1}) "
+                                        "were able to be read from {2:x}.",
+                                        (uint64_t)bytes_read,
+                                        (uint64_t)total_byte_size, addr);
     } else {
       // we treat c-strings as a special case because they do not have a fixed
       // size
@@ -712,9 +712,9 @@ protected:
         }
 
         if (item_byte_size == read) {
-          result.AppendWarningWithFormat(
-              "unable to find a NULL terminated string at 0x%" PRIx64
-              ". Consider increasing the maximum read length.\n",
+          result.AppendWarningWithFormatv(
+              "unable to find a NULL terminated string at {0:x}"
+              ". Consider increasing the maximum read length.",
               data_addr);
           --read;
           break_on_no_NULL = true;

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -672,8 +672,7 @@ protected:
       if (bytes_read < total_byte_size)
         result.AppendWarningWithFormatv("Not all bytes ({0} / {1}) "
                                         "were able to be read from {2:x}.",
-                                        (uint64_t)bytes_read,
-                                        (uint64_t)total_byte_size, addr);
+                                        bytes_read, total_byte_size, addr);
     } else {
       // we treat c-strings as a special case because they do not have a fixed
       // size

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -392,10 +392,10 @@ protected:
     } else if (old_exec_module_sp->GetFileSpec() !=
                new_exec_module_sp->GetFileSpec()) {
 
-      result.AppendWarningWithFormat(
-          "Executable binary changed from \"%s\" to \"%s\".\n",
-          old_exec_module_sp->GetFileSpec().GetPath().c_str(),
-          new_exec_module_sp->GetFileSpec().GetPath().c_str());
+      result.AppendWarningWithFormatv(
+          "Executable binary changed from \"{0}\" to \"{1}\".",
+          old_exec_module_sp->GetFileSpec().GetPath(),
+          new_exec_module_sp->GetFileSpec().GetPath());
     }
 
     if (!old_arch_spec.IsValid()) {
@@ -403,10 +403,10 @@ protected:
           "Architecture set to: {0}.",
           target->GetArchitecture().GetTriple().getTriple().c_str());
     } else if (!old_arch_spec.IsExactMatch(target->GetArchitecture())) {
-      result.AppendWarningWithFormat(
-          "Architecture changed from %s to %s.\n",
-          old_arch_spec.GetTriple().getTriple().c_str(),
-          target->GetArchitecture().GetTriple().getTriple().c_str());
+      result.AppendWarningWithFormatv(
+          "Architecture changed from {0} to {1}.",
+          old_arch_spec.GetTriple().getTriple(),
+          target->GetArchitecture().GetTriple().getTriple());
     }
 
     // This supports the use-case scenario of immediately continuing the

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -543,8 +543,8 @@ protected:
           ModuleSpec module_spec(module_file_spec);
           target.GetImages().FindModules(module_spec, m_module_list);
           if (m_module_list.IsEmpty())
-            result.AppendWarningWithFormat("No module found for '%s'.\n",
-                                           m_options.modules[i].c_str());
+            result.AppendWarningWithFormatv("No module found for '{0}'.",
+                                            m_options.modules[i]);
         }
       }
       if (!m_module_list.GetSize()) {

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -1929,8 +1929,8 @@ protected:
         size_t num_matched =
             FindModulesByName(&target, arg_cstr, module_list, true);
         if (num_matched == 0) {
-          result.AppendWarningWithFormat(
-              "Unable to find an image that matches '%s'.\n", arg_cstr);
+          result.AppendWarningWithFormatv(
+              "Unable to find an image that matches '{0}'.", arg_cstr);
         }
       }
       // Dump all the modules we found.
@@ -2067,8 +2067,8 @@ protected:
             }
           }
         } else
-          result.AppendWarningWithFormat(
-              "Unable to find an image that matches '%s'.\n", arg_cstr);
+          result.AppendWarningWithFormatv(
+              "Unable to find an image that matches '{0}'.", arg_cstr);
       }
     }
 
@@ -2152,8 +2152,8 @@ protected:
           std::lock_guard<std::recursive_mutex> guard(
               Module::GetAllocationModuleCollectionMutex());
 
-          result.AppendWarningWithFormat(
-              "Unable to find an image that matches '%s'.\n", arg_cstr);
+          result.AppendWarningWithFormatv(
+              "Unable to find an image that matches '{0}'.", arg_cstr);
         }
       }
     }
@@ -2285,8 +2285,8 @@ protected:
         std::lock_guard<std::recursive_mutex> guard(
             Module::GetAllocationModuleCollectionMutex());
 
-        result.AppendWarningWithFormat(
-            "Unable to find an image that matches '%s'.\n", arg.c_str());
+        result.AppendWarningWithFormatv(
+            "Unable to find an image that matches '{0}'.", arg.c_str());
         continue;
       }
 
@@ -2369,8 +2369,8 @@ protected:
             }
           }
         } else
-          result.AppendWarningWithFormat(
-              "Unable to find an image that matches '%s'.\n", arg_cstr);
+          result.AppendWarningWithFormatv(
+              "Unable to find an image that matches '{0}'.", arg_cstr);
       }
     }
 
@@ -2437,8 +2437,8 @@ protected:
               num_dumped++;
           }
           if (num_dumped == 0)
-            result.AppendWarningWithFormat(
-                "No source filenames matched '%s'.\n", arg_cstr);
+            result.AppendWarningWithFormatv(
+                "No source filenames matched '{0}'.\n", arg_cstr);
           else
             total_num_dumped += num_dumped;
         }
@@ -2596,8 +2596,8 @@ protected:
               num_dumped++;
           }
         } else
-          result.AppendWarningWithFormat(
-              "Unable to find an image that matches '%s'.\n", arg_cstr);
+          result.AppendWarningWithFormatv(
+              "Unable to find an image that matches '{0}'.", arg_cstr);
       }
     }
 
@@ -2645,9 +2645,8 @@ protected:
               } else if (type == "oso") {
                 DumpOsoFilesTable(strm, *files);
               } else {
-                result.AppendWarningWithFormat(
-                    "Found unsupported debug info type '%s'.\n",
-                    type.str().c_str());
+                result.AppendWarningWithFormatv(
+                    "Found unsupported debug info type '{0}'.", type);
               }
               return true;
             });
@@ -4123,8 +4122,8 @@ protected:
             }
           }
         } else
-          result.AppendWarningWithFormat(
-              "Unable to find an image that matches '%s'.\n", arg_cstr);
+          result.AppendWarningWithFormatv(
+              "Unable to find an image that matches '{0}'.", arg_cstr);
       }
     }
 

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -2438,7 +2438,7 @@ protected:
           }
           if (num_dumped == 0)
             result.AppendWarningWithFormatv(
-                "No source filenames matched '{0}'.\n", arg_cstr);
+                "No source filenames matched '{0}'.", arg_cstr);
           else
             total_num_dumped += num_dumped;
         }

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -91,11 +91,10 @@ static bool WarnOnPotentialUnquotedUnsignedType(Args &command,
       continue;
     auto next = command.entries()[entry.index() + 1].ref();
     if (next == "int" || next == "short" || next == "char" || next == "long") {
-      result.AppendWarningWithFormat(
-          "unsigned %s being treated as two types. if you meant the combined "
-          "type "
-          "name use  quotes, as in \"unsigned %s\"\n",
-          next.str().c_str(), next.str().c_str());
+      result.AppendWarningWithFormatv(
+          "unsigned {0} being treated as two types. if you meant the combined "
+          "type name use quotes, as in \"unsigned {0}\"",
+          next);
       return true;
     }
   }
@@ -1293,9 +1292,9 @@ bool CommandObjectTypeSummaryAdd::Execute_ScriptSummary(
     ScriptInterpreter *interpreter = GetDebugger().GetScriptInterpreter();
 
     if (interpreter && !interpreter->CheckObjectExists(funct_name))
-      result.AppendWarningWithFormat(
-          "The provided function \"%s\" does not exist - "
-          "please define it before attempting to use this summary.\n",
+      result.AppendWarningWithFormatv(
+          "The provided function \"{0}\" does not exist - "
+          "please define it before attempting to use this summary.",
           funct_name);
   } else if (!m_options.m_python_script
                   .empty()) // we have a quick 1-line script, just use it


### PR DESCRIPTION
The former does not automatically add a newline like the majority of the other AppendSomethingWithSomething calls do.

So this PR changes all but 1 use of that function to the Formatv version and removes the explicit newline from the format strings. I also took advantage of Formatv's ability to handle StringRef and std::string automatically.

There is one use of AppendWarningWithFormat left, which I will address in a follow up since it's not so straightforward.