### PR TITLE
[lit] Normalize RLIM_INFINITY to "infinity" in print_limits.py for Python 3.15+

### DIFF
--- a/llvm/utils/lit/tests/Inputs/shtest-ulimit/print_limits.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-ulimit/print_limits.py
@@ -2,7 +2,7 @@ import resource
 
 
 def normalize_limit(limit_value):
-    """Normalize RLIM_INFINITY to -1 for consistency across Python versions.
+    """Normalize RLIM_INFINITY to "infinity" for consistency across Python versions.
 
     Python 3.15+ returns the platform's max value (e.g., 2^64-1) instead of -1.
     """

--- a/llvm/utils/lit/tests/Inputs/shtest-ulimit/print_limits.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-ulimit/print_limits.py
@@ -9,14 +9,7 @@ def normalize_limit(limit_value):
     return "infinity" if limit_value == resource.RLIM_INFINITY else str(limit_value)
 
 
-print("RLIMIT_AS=" + str(normalize_limit(resource.getrlimit(resource.RLIMIT_AS)[0])))
-print(
-    "RLIMIT_NOFILE="
-    + str(normalize_limit(resource.getrlimit(resource.RLIMIT_NOFILE)[0]))
-)
-print(
-    "RLIMIT_STACK=" + str(normalize_limit(resource.getrlimit(resource.RLIMIT_STACK)[0]))
-)
-print(
-    "RLIMIT_FSIZE=" + str(normalize_limit(resource.getrlimit(resource.RLIMIT_FSIZE)[0]))
-)
+print("RLIMIT_AS=" + normalize_limit(resource.getrlimit(resource.RLIMIT_AS)[0]))
+print("RLIMIT_NOFILE=" + normalize_limit(resource.getrlimit(resource.RLIMIT_NOFILE)[0]))
+print("RLIMIT_STACK=" + normalize_limit(resource.getrlimit(resource.RLIMIT_STACK)[0]))
+print("RLIMIT_FSIZE=" + normalize_limit(resource.getrlimit(resource.RLIMIT_FSIZE)[0]))

--- a/llvm/utils/lit/tests/Inputs/shtest-ulimit/print_limits.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-ulimit/print_limits.py
@@ -6,7 +6,7 @@ def normalize_limit(limit_value):
 
     Python 3.15+ returns the platform's max value (e.g., 2^64-1) instead of -1.
     """
-    return -1 if limit_value == resource.RLIM_INFINITY else limit_value
+    return "infinity" if limit_value == resource.RLIM_INFINITY else str(limit_value)
 
 
 print("RLIMIT_AS=" + str(normalize_limit(resource.getrlimit(resource.RLIMIT_AS)[0])))

--- a/llvm/utils/lit/tests/Inputs/shtest-ulimit/print_limits.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-ulimit/print_limits.py
@@ -1,6 +1,22 @@
 import resource
 
-print("RLIMIT_AS=" + str(resource.getrlimit(resource.RLIMIT_AS)[0]))
-print("RLIMIT_NOFILE=" + str(resource.getrlimit(resource.RLIMIT_NOFILE)[0]))
-print("RLIMIT_STACK=" + str(resource.getrlimit(resource.RLIMIT_STACK)[0]))
-print("RLIMIT_FSIZE=" + str(resource.getrlimit(resource.RLIMIT_FSIZE)[0]))
+
+def normalize_limit(limit_value):
+    """Normalize RLIM_INFINITY to -1 for consistency across Python versions.
+
+    Python 3.15+ returns the platform's max value (e.g., 2^64-1) instead of -1.
+    """
+    return -1 if limit_value == resource.RLIM_INFINITY else limit_value
+
+
+print("RLIMIT_AS=" + str(normalize_limit(resource.getrlimit(resource.RLIMIT_AS)[0])))
+print(
+    "RLIMIT_NOFILE="
+    + str(normalize_limit(resource.getrlimit(resource.RLIMIT_NOFILE)[0]))
+)
+print(
+    "RLIMIT_STACK=" + str(normalize_limit(resource.getrlimit(resource.RLIMIT_STACK)[0]))
+)
+print(
+    "RLIMIT_FSIZE=" + str(normalize_limit(resource.getrlimit(resource.RLIMIT_FSIZE)[0]))
+)

--- a/llvm/utils/lit/tests/shtest-ulimit-nondarwin.py
+++ b/llvm/utils/lit/tests/shtest-ulimit-nondarwin.py
@@ -18,4 +18,4 @@
 # CHECK: ulimit -f 5
 # CHECK: RLIMIT_FSIZE=5
 # CHECK: ulimit -f unlimited
-# CHECK: RLIMIT_FSIZE=-1
+# CHECK: RLIMIT_FSIZE=infinity


### PR DESCRIPTION
Python 3.15 changed resource.getrlimit() to return the platform's maximum value (e.g., 18446744073709551615 on 64-bit systems) instead of -1 for RLIM_INFINITY. This breaks lit tests that expect -1 for unlimited resource limits.

This patch normalizes the return value to "infinity" when it equals RLIM_INFINITY to maintain compatibility with existing tests across all Python versions.

Fixes test failure: shtest-ulimit-nondarwin.py
Expected: RLIMIT_FSIZE=-1
Got: RLIMIT_FSIZE=18446744073709551615

Reference: https://github.com/python/cpython/commit/0324c726dea702282a0300225e989b19ae23b759
Reference: https://bugzilla.redhat.com/show_bug.cgi?id=2448969

Analysis and testing assisted by AI.

Assisted-by: Claude Sonnet 4.5