### PR TITLE
[AArch64] Avoid expensive getStrictlyReservedRegs calls in isAnyArgRegReserved

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
@@ -222,9 +222,6 @@ class AArch64FunctionInfo final : public MachineFunctionInfo {
   /// Whether this function changes streaming mode within the function.
   bool HasStreamingModeChanges = false;
 
-  /// Cache for whether any argument register is reserved.
-  mutable std::optional<bool> AnyArgRegReserved;
-
   /// True if the function need unwind information.
   mutable std::optional<bool> NeedsDwarfUnwindInfo;
 
@@ -631,9 +628,6 @@ public:
     SwiftAsyncContextFrameIdx = FI;
   }
   int getSwiftAsyncContextFrameIdx() const { return SwiftAsyncContextFrameIdx; }
-
-  std::optional<bool> getAnyArgRegReserved() const { return AnyArgRegReserved; }
-  void setAnyArgRegReserved(bool V) const { AnyArgRegReserved = V; }
 
   bool needsDwarfUnwindInfo(const MachineFunction &MF) const;
   bool needsAsyncDwarfUnwindInfo(const MachineFunction &MF) const;

--- a/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
@@ -222,6 +222,9 @@ class AArch64FunctionInfo final : public MachineFunctionInfo {
   /// Whether this function changes streaming mode within the function.
   bool HasStreamingModeChanges = false;
 
+  /// Cache for whether any argument register is reserved.
+  mutable std::optional<bool> AnyArgRegReserved;
+
   /// True if the function need unwind information.
   mutable std::optional<bool> NeedsDwarfUnwindInfo;
 
@@ -628,6 +631,9 @@ public:
     SwiftAsyncContextFrameIdx = FI;
   }
   int getSwiftAsyncContextFrameIdx() const { return SwiftAsyncContextFrameIdx; }
+
+  std::optional<bool> getAnyArgRegReserved() const { return AnyArgRegReserved; }
+  void setAnyArgRegReserved(bool V) const { AnyArgRegReserved = V; }
 
   bool needsDwarfUnwindInfo(const MachineFunction &MF) const;
   bool needsAsyncDwarfUnwindInfo(const MachineFunction &MF) const;

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -577,9 +577,18 @@ bool AArch64RegisterInfo::isStrictlyReservedReg(const MachineFunction &MF,
 }
 
 bool AArch64RegisterInfo::isAnyArgRegReserved(const MachineFunction &MF) const {
-  return llvm::any_of(*AArch64::GPR64argRegClass.MC, [this, &MF](MCPhysReg r) {
-    return isStrictlyReservedReg(MF, r);
-  });
+  auto *AFI = MF.getInfo<AArch64FunctionInfo>();
+  if (std::optional<bool> Cached = AFI->getAnyArgRegReserved())
+    return *Cached;
+
+  bool Any =
+      llvm::any_of(*AArch64::GPR64argRegClass.MC, [this, &MF](MCPhysReg r) {
+        return isStrictlyReservedReg(MF, r);
+      });
+  // Re-computing this in getStrictlyReservedRegs during call lowering for
+  // every call is compile-time expensive, so we avoid by caching the result.
+  AFI->setAnyArgRegReserved(Any);
+  return Any;
 }
 
 void AArch64RegisterInfo::emitReservedArgRegCallError(

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -419,7 +419,6 @@ BitVector
 AArch64RegisterInfo::getStrictlyReservedRegs(const MachineFunction &MF) const {
   const AArch64FrameLowering *TFI = getFrameLowering(MF);
 
-  // FIXME: avoid re-calculating this every time.
   BitVector Reserved(getNumRegs());
   markSuperRegs(Reserved, AArch64::WSP);
   markSuperRegs(Reserved, AArch64::WZR);

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -577,18 +577,11 @@ bool AArch64RegisterInfo::isStrictlyReservedReg(const MachineFunction &MF,
 }
 
 bool AArch64RegisterInfo::isAnyArgRegReserved(const MachineFunction &MF) const {
-  auto *AFI = MF.getInfo<AArch64FunctionInfo>();
-  if (std::optional<bool> Cached = AFI->getAnyArgRegReserved())
-    return *Cached;
-
-  bool Any =
-      llvm::any_of(*AArch64::GPR64argRegClass.MC, [this, &MF](MCPhysReg r) {
-        return isStrictlyReservedReg(MF, r);
-      });
-  // Re-computing this in getStrictlyReservedRegs during call lowering for
-  // every call is compile-time expensive, so we avoid by caching the result.
-  AFI->setAnyArgRegReserved(Any);
-  return Any;
+  for (size_t i = 0; i < AArch64::GPR64argRegClass.getNumRegs(); ++i) {
+    if (MF.getSubtarget<AArch64Subtarget>().isXRegisterReserved(i))
+      return true;
+  }
+  return false;
 }
 
 void AArch64RegisterInfo::emitReservedArgRegCallError(


### PR DESCRIPTION
`AArch64RegisterInfo::isAnyArgRegReserved` is used during call lowering
across all instruction selectors (SDAG, GISel, FastISel) to emit an
error if any of the arg registers (x0-x7) are reserved. This puts
`AArch64RegisterInfo::getStrictlyReservedRegs` which computes this in
the hot-path and it shows up in compile-time profiles since it's
computed for every call.

As the intent was to guard against using +reserve-x{0-7} with function
calls we can instead call `isXRegisterReserved` which is faster since
it's a simple BitVector lookup.

Compile-time improves across all instruction selectors on CTMark:

             geomean
    SDAG     ~ -0.14%
    GISel    ~  -0.6%
    FastISel ~  -0.7% (measured locally)

https://llvm-compile-time-tracker.com/compare.php?from=4d84263b341c3ee1847081c50e1541b62fbcb08c&to=23c4576c01d7d5e0e603366b86239e069410c3a7&stat=instructions%3Au

I also experimented with caching `getStrictlyReservedRegs`, but the
compile-time impact is negligible which suggests this code isn't
particularly hot and worth optimising outside of call-lowering:

https://llvm-compile-time-tracker.com/compare.php?from=4d84263b341c3ee1847081c50e1541b62fbcb08c&to=38166d5afa9dd53320da0d47d4f056d08f0d75ca&stat=instructions%3Au