### PR TITLE
[lldb] Remove last use of AppendWarningWithFormat(

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -118,9 +118,6 @@ public:
 
   void AppendWarning(llvm::StringRef in_string);
 
-  void AppendWarningWithFormat(const char *format, ...)
-      __attribute__((format(printf, 2, 3)));
-
   void AppendError(llvm::StringRef in_string);
 
   void AppendErrorWithFormat(const char *format, ...)

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -388,7 +388,7 @@ protected:
             new_exec_module_sp->GetFileSpec().GetPath().c_str());
       }
     } else if (!new_exec_module_sp) {
-      result.AppendWarningWithFormat("No executable binary.");
+      result.AppendWarning("No executable binary.");
     } else if (old_exec_module_sp->GetFileSpec() !=
                new_exec_module_sp->GetFileSpec()) {
 

--- a/lldb/source/Interpreter/CommandReturnObject.cpp
+++ b/lldb/source/Interpreter/CommandReturnObject.cpp
@@ -68,18 +68,6 @@ void CommandReturnObject::AppendErrorWithFormat(const char *format, ...) {
   }
 }
 
-void CommandReturnObject::AppendWarningWithFormat(const char *format, ...) {
-  if (!format)
-    return;
-  va_list args;
-  va_start(args, format);
-  StreamString sstrm;
-  sstrm.PrintfVarArg(format, args);
-  va_end(args);
-
-  warning(GetErrorStream()) << sstrm.GetString();
-}
-
 void CommandReturnObject::AppendMessage(llvm::StringRef in_string) {
   if (in_string.empty())
     return;


### PR DESCRIPTION
And remove the function entirely as there are now no
callers.

This last use of AppendWarningWithFormat does not 
include a newline in the format string, but I suspect
that it should have done, so I am ok to convert it. 

It was added by 56535a090d91ff10a60c884bacbd314dcf9659db,
and the other branches of the if/else will add newlines.
Also it seems like an important message that would benefit
from being on its own line.

There are no tests that expect this specific message,
which makes some sense as it seems to have been added
to cover a race condition that only sometimes happens.