### PR TITLE
[GlobalISel] Prevent hoisting of CheckIsSameOperand from creating invalid match tables

### DIFF
--- a/llvm/test/TableGen/GlobalISelCombinerEmitter/match-table-hoisting.td
+++ b/llvm/test/TableGen/GlobalISelCombinerEmitter/match-table-hoisting.td
@@ -1,0 +1,92 @@
+// RUN: llvm-tblgen -I %p/../../../include -gen-global-isel-combiner \
+// RUN:     -combiners=MyCombiner %s | \
+// RUN: FileCheck %s
+
+include "llvm/Target/Target.td"
+include "llvm/Target/GlobalISel/Combine.td"
+
+def MyTargetISA : InstrInfo;
+def MyTarget : Target { let InstructionSet = MyTargetISA; }
+
+def SharedPreds0 : GICombineRule<
+   (defs root:$root),
+   (match (G_SUB $sub1, $B, $C),
+          (G_ADD $add1, $A, $sub1),
+          (G_SUB $root, $add1, $B)),
+   (apply (G_SUB $root, $A, $C))>;
+
+def SharedPreds1 : GICombineRule<
+   (defs root:$root),
+   (match (G_ADD $add1, $B, $C),
+          (G_ADD $add2, $A, $add1),
+          (G_SUB $root, $add2, $B)),
+   (apply (G_ADD $root, $A, $C))>;
+
+def MyCombiner: GICombiner<"GenMyCombiner", [
+  SharedPreds0,
+  SharedPreds1
+]>;
+
+
+// CHECK:      const uint8_t *GenMyCombiner::getMatchTable() const {
+// CHECK-NEXT:   constexpr static uint8_t MatchTable0[] = {
+// CHECK-NEXT:      /*   0 */ GIM_Try, /*On fail goto*//*Label 0*/ GIMT_Encode4(100),
+// CHECK-NEXT:      /*   5 */   GIM_CheckOpcode, /*MI*/0, GIMT_Encode2(TargetOpcode::G_SUB),
+// CHECK-NEXT:      /*   9 */   GIM_Try, /*On fail goto*//*Label 1*/ GIMT_Encode4(54), // Rule ID 1 //
+// CHECK-NEXT:      /*  14 */     GIM_CheckSimplePredicate, GIMT_Encode2(GICXXPred_Simple_IsRule1Enabled),
+// CHECK-NEXT:      /*  17 */     // MIs[0] root
+// CHECK-NEXT:      /*  17 */     // No operand predicates
+// CHECK-NEXT:      /*  17 */     // MIs[0] add2
+// CHECK-NEXT:      /*  17 */     GIM_RecordInsnIgnoreCopies, /*DefineMI*/1, /*MI*/0, /*OpIdx*/1, // MIs[1]
+// CHECK-NEXT:      /*  21 */     GIM_CheckOpcode, /*MI*/1, GIMT_Encode2(TargetOpcode::G_ADD),
+// CHECK-NEXT:      /*  25 */     // MIs[1] A
+// CHECK-NEXT:      /*  25 */     // No operand predicates
+// CHECK-NEXT:      /*  25 */     // MIs[1] add1
+// CHECK-NEXT:      /*  25 */     GIM_RecordInsnIgnoreCopies, /*DefineMI*/2, /*MI*/1, /*OpIdx*/2, // MIs[2]
+// CHECK-NEXT:      /*  29 */     GIM_CheckOpcode, /*MI*/2, GIMT_Encode2(TargetOpcode::G_ADD),
+// CHECK-NEXT:      /*  33 */     // MIs[2] B
+// CHECK-NEXT:      /*  33 */     // No operand predicates
+// CHECK-NEXT:      /*  33 */     // MIs[2] C
+// CHECK-NEXT:      /*  33 */     // No operand predicates
+// CHECK-NEXT:      /*  33 */     // MIs[0] B
+// CHECK-NEXT:      /*  33 */     GIM_CheckIsSameOperandIgnoreCopies, /*MI*/0, /*OpIdx*/2, /*OtherMI*/2, /*OtherOpIdx*/1,
+// CHECK-NEXT:      /*  38 */     GIM_CheckIsSafeToFold, /*NumInsns*/2,
+// CHECK-NEXT:      /*  40 */     // Combiner Rule #1: SharedPreds1
+// CHECK-NEXT:      /*  40 */     GIR_BuildRootMI, /*Opcode*/GIMT_Encode2(TargetOpcode::G_ADD),
+// CHECK-NEXT:      /*  43 */     GIR_RootToRootCopy, /*OpIdx*/0, // root
+// CHECK-NEXT:      /*  45 */     GIR_Copy, /*NewInsnID*/0, /*OldInsnID*/1, /*OpIdx*/1, // A
+// CHECK-NEXT:      /*  49 */     GIR_Copy, /*NewInsnID*/0, /*OldInsnID*/2, /*OpIdx*/2, // C
+// CHECK-NEXT:      /*  53 */     GIR_EraseRootFromParent_Done,
+// CHECK-NEXT:      /*  54 */   // Label 1: @54
+// CHECK-NEXT:      /*  54 */   GIM_Try, /*On fail goto*//*Label 2*/ GIMT_Encode4(99), // Rule ID 0 //
+// CHECK-NEXT:      /*  59 */     GIM_CheckSimplePredicate, GIMT_Encode2(GICXXPred_Simple_IsRule0Enabled),
+// CHECK-NEXT:      /*  62 */     // MIs[0] root
+// CHECK-NEXT:      /*  62 */     // No operand predicates
+// CHECK-NEXT:      /*  62 */     // MIs[0] add1
+// CHECK-NEXT:      /*  62 */     GIM_RecordInsnIgnoreCopies, /*DefineMI*/1, /*MI*/0, /*OpIdx*/1, // MIs[1]
+// CHECK-NEXT:      /*  66 */     GIM_CheckOpcode, /*MI*/1, GIMT_Encode2(TargetOpcode::G_ADD),
+// CHECK-NEXT:      /*  70 */     // MIs[1] A
+// CHECK-NEXT:      /*  70 */     // No operand predicates
+// CHECK-NEXT:      /*  70 */     // MIs[1] sub1
+// CHECK-NEXT:      /*  70 */     GIM_RecordInsnIgnoreCopies, /*DefineMI*/2, /*MI*/1, /*OpIdx*/2, // MIs[2]
+// CHECK-NEXT:      /*  74 */     GIM_CheckOpcode, /*MI*/2, GIMT_Encode2(TargetOpcode::G_SUB),
+// CHECK-NEXT:      /*  78 */     // MIs[2] B
+// CHECK-NEXT:      /*  78 */     // No operand predicates
+// CHECK-NEXT:      /*  78 */     // MIs[2] C
+// CHECK-NEXT:      /*  78 */     // No operand predicates
+// CHECK-NEXT:      /*  78 */     // MIs[0] B
+// CHECK-NEXT:      /*  78 */     GIM_CheckIsSameOperandIgnoreCopies, /*MI*/0, /*OpIdx*/2, /*OtherMI*/2, /*OtherOpIdx*/1,
+// CHECK-NEXT:      /*  83 */     GIM_CheckIsSafeToFold, /*NumInsns*/2,
+// CHECK-NEXT:      /*  85 */     // Combiner Rule #0: SharedPreds0
+// CHECK-NEXT:      /*  85 */     GIR_BuildRootMI, /*Opcode*/GIMT_Encode2(TargetOpcode::G_SUB),
+// CHECK-NEXT:      /*  88 */     GIR_RootToRootCopy, /*OpIdx*/0, // root
+// CHECK-NEXT:      /*  90 */     GIR_Copy, /*NewInsnID*/0, /*OldInsnID*/1, /*OpIdx*/1, // A
+// CHECK-NEXT:      /*  94 */     GIR_Copy, /*NewInsnID*/0, /*OldInsnID*/2, /*OpIdx*/2, // C
+// CHECK-NEXT:      /*  98 */     GIR_EraseRootFromParent_Done,
+// CHECK-NEXT:      /*  99 */   // Label 2: @99
+// CHECK-NEXT:      /*  99 */   GIM_Reject,
+// CHECK-NEXT:      /* 100 */ // Label 0: @100
+// CHECK-NEXT:      /* 100 */ GIM_Reject,
+// CHECK-NEXT:      /* 101 */ }; // Size: 101 bytes
+// CHECK-NEXT:   return MatchTable0;
+// CHECK-NEXT: }

--- a/llvm/test/TableGen/GlobalISelCombinerEmitter/match-table-hoisting.td
+++ b/llvm/test/TableGen/GlobalISelCombinerEmitter/match-table-hoisting.td
@@ -5,9 +5,14 @@
 include "llvm/Target/Target.td"
 include "llvm/Target/GlobalISel/Combine.td"
 
+
 def MyTargetISA : InstrInfo;
 def MyTarget : Target { let InstructionSet = MyTargetISA; }
 
+// These two combine rules both use GIM_CheckIsSameOperandIgnoreCopies.
+// Check that the match table does not try to combine them by hoisting them in the GroupMatcher,
+// which would cause a runtime crash as the "other inst" used by the predicate is
+// only defined in the leaf RuleMatcher.
 def SharedPreds0 : GICombineRule<
    (defs root:$root),
    (match (G_SUB $sub1, $B, $C),

--- a/llvm/test/TableGen/GlobalISelEmitter/MatchTableOptimizerSameOperand-invalid.td
+++ b/llvm/test/TableGen/GlobalISelEmitter/MatchTableOptimizerSameOperand-invalid.td
@@ -5,14 +5,13 @@ include "GlobalISelEmitterCommon.td"
 
 def InstTwoOperands : I<(outs GPR32:$dst), (ins GPR32:$src1, GPR32:$src2), []>;
 def InstThreeOperands : I<(outs GPR32:$dst), (ins GPR32:$cond, GPR32:$src,GPR32:$src2), []>;
-// CHECK:      GIM_Try, /*On fail goto*//*Label 0*/ GIMT_Encode4(229),
+// CHECK:      GIM_Try, /*On fail goto*//*Label 0*/ GIMT_Encode4(234),
 // CHECK-NEXT:   GIM_CheckOpcode, /*MI*/0, GIMT_Encode2(TargetOpcode::G_SELECT),
 // CHECK-NEXT:   GIM_RootCheckType, /*Op*/0, /*Type*/GILLT_s32,
 // CHECK-NEXT:   GIM_RootCheckType, /*Op*/1, /*Type*/GILLT_s32,
 // CHECK-NEXT:   GIM_RootCheckType, /*Op*/2, /*Type*/GILLT_s32,
-// CHECK-NEXT:   GIM_Try, /*On fail goto*//*Label 1*/ GIMT_Encode4(197),
+// CHECK-NEXT:   GIM_Try, /*On fail goto*//*Label 1*/ GIMT_Encode4(202),
 // CHECK-NEXT:     GIM_RootCheckRegBankForClass, /*Op*/0, /*RC*/GIMT_Encode2(MyTarget::GPR32RegClassID),
-// CHECK-NEXT:     GIM_CheckIsSameOperand, /*MI*/0, /*OpIdx*/3, /*OtherMI*/2, /*OtherOpIdx*/2,
 // CHECK-NEXT:     GIM_Try, /*On fail goto*//*Label 2*/ GIMT_Encode4(114), // Rule ID 1 //
 // CHECK-NEXT:       GIM_RecordInsn, /*DefineMI*/1, /*MI*/0, /*OpIdx*/1, // MIs[1]
 // CHECK-NEXT:       GIM_CheckOpcode, /*MI*/1, GIMT_Encode2(TargetOpcode::G_ICMP),
@@ -28,6 +27,8 @@ def InstThreeOperands : I<(outs GPR32:$dst), (ins GPR32:$cond, GPR32:$src,GPR32:
 // CHECK-NEXT:       GIM_CheckType, /*MI*/2, /*Op*/2, /*Type*/GILLT_s32,
 // CHECK-NEXT:       GIM_CheckRegBankForClass, /*MI*/2, /*Op*/1, /*RC*/GIMT_Encode2(MyTarget::GPR32RegClassID),
 // CHECK-NEXT:       GIM_CheckRegBankForClass, /*MI*/2, /*Op*/2, /*RC*/GIMT_Encode2(MyTarget::GPR32RegClassID),
+// CHECK-NEXT:       // MIs[0] src2
+// CHECK-NEXT:       GIM_CheckIsSameOperand, /*MI*/0, /*OpIdx*/3, /*OtherMI*/2, /*OtherOpIdx*/2,
 // CHECK-NEXT:       GIM_CheckIsSafeToFold, /*NumInsns*/2,
 // CHECK-NEXT:       // (select:{ *:[i32] } (setcc:{ *:[i32] } GPR32:{ *:[i32] }:$cond, 0:{ *:[i32] }, SETEQ:{ *:[Other] }), (sub:{ *:[i32] } GPR32:{ *:[i32] }:$src1, GPR32:{ *:[i32] }:$src2), GPR32:{ *:[i32] }:$src2)  =>  (InstThreeOperands:{ *:[i32] } GPR32:{ *:[i32] }:$cond, GPR32:{ *:[i32] }:$src1, GPR32:{ *:[i32] }:$src2)
 // CHECK-NEXT:       GIR_BuildRootMI, /*Opcode*/GIMT_Encode2(MyTarget::InstThreeOperands),
@@ -39,7 +40,7 @@ def InstThreeOperands : I<(outs GPR32:$dst), (ins GPR32:$cond, GPR32:$src,GPR32:
 // CHECK-NEXT:       // GIR_Coverage, 1,
 // CHECK-NEXT:       GIR_EraseRootFromParent_Done,
 // CHECK-NEXT:     // Label 2: @114
-// CHECK-NEXT:     GIM_Try, /*On fail goto*//*Label 3*/ GIMT_Encode4(196), // Rule ID 2 //
+// CHECK-NEXT:     GIM_Try, /*On fail goto*//*Label 3*/ GIMT_Encode4(201), // Rule ID 2 //
 // CHECK-NEXT:       GIM_RecordInsn, /*DefineMI*/1, /*MI*/0, /*OpIdx*/1, // MIs[1]
 // CHECK-NEXT:       GIM_CheckOpcode, /*MI*/1, GIMT_Encode2(TargetOpcode::G_ICMP),
 // CHECK-NEXT:       GIM_CheckType, /*MI*/1, /*Op*/2, /*Type*/GILLT_s32,
@@ -54,6 +55,8 @@ def InstThreeOperands : I<(outs GPR32:$dst), (ins GPR32:$cond, GPR32:$src,GPR32:
 // CHECK-NEXT:       GIM_CheckType, /*MI*/2, /*Op*/2, /*Type*/GILLT_s32,
 // CHECK-NEXT:       GIM_CheckRegBankForClass, /*MI*/2, /*Op*/1, /*RC*/GIMT_Encode2(MyTarget::GPR32RegClassID),
 // CHECK-NEXT:       GIM_CheckRegBankForClass, /*MI*/2, /*Op*/2, /*RC*/GIMT_Encode2(MyTarget::GPR32RegClassID),
+// CHECK-NEXT:       // MIs[0] src2
+// CHECK-NEXT:       GIM_CheckIsSameOperand, /*MI*/0, /*OpIdx*/3, /*OtherMI*/2, /*OtherOpIdx*/2,
 // CHECK-NEXT:       GIM_CheckIsSafeToFold, /*NumInsns*/2,
 // CHECK-NEXT:       // (select:{ *:[i32] } (setcc:{ *:[i32] } GPR32:{ *:[i32] }:$cond, 0:{ *:[i32] }, SETNE:{ *:[Other] }), (sub:{ *:[i32] } GPR32:{ *:[i32] }:$src1, GPR32:{ *:[i32] }:$src2), GPR32:{ *:[i32] }:$src2)  =>  (InstThreeOperands:{ *:[i32] } GPR32:{ *:[i32] }:$cond, GPR32:{ *:[i32] }:$src1, GPR32:{ *:[i32] }:$src2)
 // CHECK-NEXT:       GIR_BuildRootMI, /*Opcode*/GIMT_Encode2(MyTarget::InstThreeOperands),
@@ -64,10 +67,10 @@ def InstThreeOperands : I<(outs GPR32:$dst), (ins GPR32:$cond, GPR32:$src,GPR32:
 // CHECK-NEXT:       GIR_RootConstrainSelectedInstOperands,
 // CHECK-NEXT:       // GIR_Coverage, 2,
 // CHECK-NEXT:       GIR_EraseRootFromParent_Done,
-// CHECK-NEXT:     // Label 3: @196
+// CHECK-NEXT:     // Label 3: @201
 // CHECK-NEXT:     GIM_Reject,
-// CHECK-NEXT:   // Label 1: @197
-// CHECK-NEXT:   GIM_Try, /*On fail goto*//*Label 4*/ GIMT_Encode4(228), // Rule ID 0 //
+// CHECK-NEXT:   // Label 1: @202
+// CHECK-NEXT:   GIM_Try, /*On fail goto*//*Label 4*/ GIMT_Encode4(233), // Rule ID 0 //
 // CHECK-NEXT:     GIM_RootCheckType, /*Op*/3, /*Type*/GILLT_s32,
 // CHECK-NEXT:     GIM_RootCheckRegBankForClass, /*Op*/0, /*RC*/GIMT_Encode2(MyTarget::GPR32RegClassID),
 // CHECK-NEXT:     GIM_RootCheckRegBankForClass, /*Op*/1, /*RC*/GIMT_Encode2(MyTarget::GPR32RegClassID),
@@ -78,9 +81,9 @@ def InstThreeOperands : I<(outs GPR32:$dst), (ins GPR32:$cond, GPR32:$src,GPR32:
 // CHECK-NEXT:     GIR_RootConstrainSelectedInstOperands,
 // CHECK-NEXT:     // GIR_Coverage, 0,
 // CHECK-NEXT:     GIR_Done,
-// CHECK-NEXT:   // Label 4: @228
+// CHECK-NEXT:   // Label 4: @233
 // CHECK-NEXT:   GIM_Reject,
-// CHECK-NEXT: // Label 0: @229
+// CHECK-NEXT: // Label 0: @234
 // CHECK-NEXT: GIM_Reject,
 def : Pat<(i32 (select GPR32:$cond, GPR32:$src1, GPR32:$src2)),
           (InstThreeOperands GPR32:$cond, GPR32:$src1, GPR32:$src2)>;

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -517,15 +517,6 @@ std::unique_ptr<PredicateMatcher> GroupMatcher::popFirstCondition() {
   return P;
 }
 
-/// Check if the Condition, which is a predicate of M, cannot be hoisted outside
-/// of (i.e., checked before) M.
-static bool cannotHoistCondition(const PredicateMatcher &Condition,
-                                 const Matcher &M) {
-  // The condition can't be hoisted if it is a C++ predicate that refers to
-  // operands and the operands are registered within the matcher.
-  return Condition.dependsOnOperands() && M.recordsOperand();
-}
-
 bool GroupMatcher::addMatcher(Matcher &Candidate) {
   if (!Candidate.hasFirstCondition())
     return false;
@@ -534,7 +525,7 @@ bool GroupMatcher::addMatcher(Matcher &Candidate) {
   // hoisted into the GroupMatcher.
   const PredicateMatcher &Predicate = Candidate.getFirstCondition();
   if (!candidateConditionMatches(Predicate) ||
-      cannotHoistCondition(Predicate, Candidate))
+      !Predicate.canHoistOutsideOf(Candidate))
     return false;
 
   Matchers.push_back(&Candidate);
@@ -555,12 +546,12 @@ void GroupMatcher::finalize() {
     // Hoist the first condition if it is identical in all matchers in the group
     // and it can be hoisted in every matcher.
     const auto &FirstCondition = FirstRule.getFirstCondition();
-    if (cannotHoistCondition(FirstCondition, FirstRule))
+    if (!FirstCondition.canHoistOutsideOf(FirstRule))
       return;
     for (unsigned I = 1, E = Matchers.size(); I < E; ++I) {
       const auto &OtherFirstCondition = Matchers[I]->getFirstCondition();
       if (!OtherFirstCondition.isIdentical(FirstCondition) ||
-          cannotHoistCondition(OtherFirstCondition, *Matchers[I]))
+          !OtherFirstCondition.canHoistOutsideOf(*Matchers[I]))
         return;
     }
 
@@ -757,7 +748,7 @@ void SwitchMatcher::emit(MatchTable &Table) {
 //===- RuleMatcher --------------------------------------------------------===//
 
 RuleMatcher::RuleMatcher(ArrayRef<SMLoc> SrcLoc)
-    : SrcLoc(SrcLoc), RuleID(NextRuleID++) {}
+    : Matcher(Matcher::MK_Rule), SrcLoc(SrcLoc), RuleID(NextRuleID++) {}
 
 uint64_t RuleMatcher::NextRuleID = 0;
 
@@ -1224,6 +1215,11 @@ void SameOperandMatcher::emitPredicateOpcodes(MatchTable &Table,
         << MatchTable::Comment("OtherOpIdx")
         << MatchTable::ULEB128Value(OtherOM.getOpIdx())
         << MatchTable::LineBreak;
+}
+
+bool SameOperandMatcher::canHoistOutsideOf(const Matcher &M) const {
+  const auto *RM = dyn_cast<RuleMatcher>(&M);
+  return !RM || !RM->hasOperand(MatchingName);
 }
 
 //===- LLTOperandMatcher --------------------------------------------------===//
@@ -1839,8 +1835,8 @@ void InstructionMatcher::emitPredicateOpcodes(MatchTable &Table,
   // First emit all instruction level predicates need to be verified before we
   // can verify operands.
   emitFilteredPredicateListOpcodes(
-      [](const PredicateMatcher &P) { return !P.dependsOnOperands(); }, Table,
-      Rule);
+      [](const PredicateMatcher &P) { return !P.dependsOnRecordedOperands(); },
+      Table, Rule);
 
   // Emit all operand constraints.
   for (const auto &Operand : Operands)
@@ -1849,8 +1845,8 @@ void InstructionMatcher::emitPredicateOpcodes(MatchTable &Table,
   // All of the tablegen defined predicates should now be matched. Now emit
   // any custom predicates that rely on all generated checks.
   emitFilteredPredicateListOpcodes(
-      [](const PredicateMatcher &P) { return P.dependsOnOperands(); }, Table,
-      Rule);
+      [](const PredicateMatcher &P) { return P.dependsOnRecordedOperands(); },
+      Table, Rule);
 }
 
 bool InstructionMatcher::isHigherPriorityThan(InstructionMatcher &B) {

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
@@ -306,7 +306,17 @@ inline MatchTable &operator<<(MatchTable &Table,
 //===- Matchers -----------------------------------------------------------===//
 class Matcher {
 public:
+  enum MatcherKind {
+    MK_Group,
+    MK_Switch,
+    MK_Rule,
+  };
+
+  Matcher(MatcherKind Kind) : Kind(Kind) {}
   virtual ~Matcher();
+
+  MatcherKind getKind() const { return Kind; }
+
   virtual void optimize();
   virtual void emit(MatchTable &Table) = 0;
 
@@ -317,6 +327,9 @@ public:
   /// Check recursively if the matcher records named operands for use in C++
   /// predicates.
   virtual bool recordsOperand() const = 0;
+
+private:
+  MatcherKind Kind;
 };
 
 class GroupMatcher final : public Matcher {
@@ -331,6 +344,10 @@ class GroupMatcher final : public Matcher {
   std::vector<std::unique_ptr<Matcher>> MatcherStorage;
 
 public:
+  GroupMatcher() : Matcher(MK_Group) {}
+
+  static bool classof(const Matcher *M) { return M->getKind() == MK_Group; }
+
   /// Add a matcher to the collection of nested matchers if it meets the
   /// requirements, and return true. If it doesn't, do nothing and return false.
   ///
@@ -421,6 +438,10 @@ class SwitchMatcher : public Matcher {
   std::vector<std::unique_ptr<Matcher>> MatcherStorage;
 
 public:
+  SwitchMatcher() : Matcher(MK_Switch) {}
+
+  static bool classof(const Matcher *M) { return M->getKind() == MK_Switch; }
+
   bool addMatcher(Matcher &Candidate);
 
   void finalize();
@@ -550,6 +571,8 @@ public:
   RuleMatcher(ArrayRef<SMLoc> SrcLoc);
   RuleMatcher(RuleMatcher &&Other) = default;
   RuleMatcher &operator=(RuleMatcher &&Other) = default;
+
+  static bool classof(const Matcher *M) { return M->getKind() == MK_Rule; }
 
   TempTypeIdx getNextTempTypeIdx() { return NextTempTypeIdx--; }
 
@@ -858,12 +881,16 @@ public:
 
   PredicateKind getKind() const { return Kind; }
 
-  bool dependsOnOperands() const {
+  bool dependsOnRecordedOperands() const {
     // Custom predicates really depend on the context pattern of the
     // instruction, not just the individual instruction. This therefore
     // implicitly depends on all other pattern constraints.
     return Kind == IPM_GenericPredicate;
   }
+
+  /// \param M A Matcher that contains this PredicateMatcher.
+  /// \returns true if this PredicateMatcher can be hoisted outside of \p M.
+  virtual bool canHoistOutsideOf(const Matcher &M) const { return true; }
 
   bool recordsOperand() const { return Kind == OPM_RecordNamedOperand; }
 
@@ -938,6 +965,8 @@ public:
            OrigOpIdx == cast<SameOperandMatcher>(&B)->OrigOpIdx &&
            MatchingName == cast<SameOperandMatcher>(&B)->MatchingName;
   }
+
+  virtual bool canHoistOutsideOf(const Matcher &M) const override;
 };
 
 /// Generates code to check that an operand is a particular LLT.
@@ -1698,6 +1727,14 @@ public:
   bool isIdentical(const PredicateMatcher &B) const override;
   void emitPredicateOpcodes(MatchTable &Table,
                             RuleMatcher &Rule) const override;
+
+  bool canHoistOutsideOf(const Matcher &M) const override {
+    // We can only hoist C++ code if the parent Matcher does not define any
+    // symbol that may be used by C++ code.
+    // TODO?: Could we be more precise, e.g. hoist if the Matcher records
+    // operands, but the operands aren't used by this bit of C++.
+    return !M.recordsOperand();
+  }
 };
 
 class MIFlagsInstructionPredicateMatcher : public InstructionPredicateMatcher {


### PR DESCRIPTION
Fixes #188513

This patch adds logic to ask PredicateMatchers whether they'd like to be hoisted out of a specific Matcher or not.
SameOperandMatcher can use it to check if it's being hoisted out of the RuleMatcher that defines the operand it relies on.

Assisted-By: Claude Opus 4.6
Context of Use: Claude was only used to add LLVM-style RTTI to the matcher class (repetitive work). I then reviewed and cleaned up the code it generated.