### PR TITLE
[Clang] Diagnose invalid non-dependent calls in dependent contexts.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -451,7 +451,7 @@ Bug Fixes to C++ Support
 - Inherited constructors in ``dllexport`` classes are now exported for ABI-compatible cases, matching 
   MSVC behavior. Constructors with variadic arguments or callee-cleanup parameters are not yet supported 
   and produce a warning. (#GH162640)
-
+- Correctly diagnose invalid non-dependent calls in dependent contexts. (#GH135694)
 - Fix initialization of GRO when GRO-return type mismatches, as part of CWG2563. (#GH98744)
 - Fix an error using an initializer list with array new for a type that is not default-constructible. (#GH81157)
 - We no longer consider conversion operators when copy-initializing from the same type. This was non

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4171,8 +4171,11 @@ void Sema::checkCall(NamedDecl *FDecl, const FunctionProtoType *Proto,
                      const Expr *ThisArg, ArrayRef<const Expr *> Args,
                      bool IsMemberFunction, SourceLocation Loc,
                      SourceRange Range, VariadicCallType CallType) {
-  // FIXME: We should check as much as we can in the template definition.
-  if (CurContext->isDependentContext())
+
+  if ((ThisArg && ThisArg->isInstantiationDependent()) ||
+      llvm::any_of(Args, [](const Expr *E) {
+        return E && E->isInstantiationDependent();
+      }))
     return;
 
   // Printf and scanf checking.

--- a/clang/test/SemaCXX/gh135694.cpp
+++ b/clang/test/SemaCXX/gh135694.cpp
@@ -20,3 +20,12 @@ bool b() {
 bool c() { return b<void>(); }
 
 }
+
+namespace GH135694_3 {
+
+void a(...);
+template<typename T, auto F> void b() {
+  decltype(F(void())) *p; // expected-error {{cannot pass expression of type 'void' to variadic function}}
+}
+void c() { b<void, a>(); } // expected-note {{in instantiation}}
+}

--- a/clang/test/SemaCXX/gh135694.cpp
+++ b/clang/test/SemaCXX/gh135694.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify -std=c++20 %s
+
+namespace GH135694_1 {
+
+void a(...);
+template<typename T> void b() {
+  decltype(a(void())) *p; // expected-error {{cannot pass expression of type 'void' to variadic function}}
+}
+void c() { b<void>(); }
+}
+
+
+namespace GH135694_2 {
+
+void a(...);
+template<typename T>
+bool b() {
+    return requires { a(a(1)); }; // expected-error {{cannot pass expression of type 'void' to variadic function}}
+}
+bool c() { return b<void>(); }
+
+}


### PR DESCRIPTION
We were bailing out from checking calls expressions in a dependent context, but if the expression itself was not dependent it's never checked again.

Fixes #135694