### PR TITLE
[SPIR-V] Fix type mismatch in scalar-to-vector promotion for mixed-type builtins

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -1217,7 +1217,8 @@ getBuiltinCallArguments(const SPIRV::IncomingCall *Call, uint32_t BuiltinNumber,
   for (Register Argument : Call->Arguments) {
     Register VecArg = Argument;
     SPIRVTypeInst ArgumentType = GR->getSPIRVTypeForVReg(Argument);
-    if (ArgumentType != Call->ReturnType) {
+    if (GR->getScalarOrVectorComponentCount(ArgumentType) == 1 &&
+        ArgumentType != Call->ReturnType) {
       SPIRVTypeInst VecType = GR->getOrCreateSPIRVVectorType(
           ArgumentType, ResultElementCount, MIRBuilder, /*EmitIR=*/true);
       VecArg = createVirtualRegister(VecType, GR, MIRBuilder);

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -1186,6 +1186,9 @@ static bool builtinMayNeedPromotionToVec(uint32_t BuiltinNumber) {
   case SPIRV::OpenCLExtInst::mix:
   case SPIRV::OpenCLExtInst::step:
   case SPIRV::OpenCLExtInst::smoothstep:
+  case SPIRV::OpenCLExtInst::ldexp:
+  case SPIRV::OpenCLExtInst::pown:
+  case SPIRV::OpenCLExtInst::rootn:
     return true;
   default:
     break;
@@ -1215,10 +1218,13 @@ getBuiltinCallArguments(const SPIRV::IncomingCall *Call, uint32_t BuiltinNumber,
     Register VecArg = Argument;
     SPIRVTypeInst ArgumentType = GR->getSPIRVTypeForVReg(Argument);
     if (ArgumentType != Call->ReturnType) {
-      VecArg = createVirtualRegister(Call->ReturnType, GR, MIRBuilder);
+      SPIRVTypeInst VecType = GR->getOrCreateSPIRVVectorType(
+          ArgumentType, ResultElementCount, MIRBuilder, /*EmitIR=*/true);
+      VecArg = createVirtualRegister(VecType, GR, MIRBuilder);
+      Register VecTypeId = GR->getSPIRVTypeID(VecType);
       auto VecSplat = MIRBuilder.buildInstr(SPIRV::OpCompositeConstruct)
                           .addDef(VecArg)
-                          .addUse(ReturnTypeId);
+                          .addUse(VecTypeId);
       for (unsigned I = 0; I != ResultElementCount; ++I)
         VecSplat.addUse(Argument);
     }

--- a/llvm/test/CodeGen/SPIRV/transcoding/ldexp.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/ldexp.ll
@@ -1,7 +1,7 @@
 ;; Check that backend converts scalar arg to vector for ldexp math instructions.
 
-; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ;; #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 ;; #pragma OPENCL EXTENSION cl_khr_fp64 : enable

--- a/llvm/test/CodeGen/SPIRV/transcoding/ldexp.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/ldexp.ll
@@ -1,4 +1,4 @@
-;; Check that backend converts scalar arg to vector for ldexp math instructions
+;; Check that backend converts scalar arg to vector for ldexp math instructions.
 
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}

--- a/llvm/test/CodeGen/SPIRV/transcoding/ldexp.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/ldexp.ll
@@ -1,6 +1,7 @@
 ;; Check that backend converts scalar arg to vector for ldexp math instructions
 
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ;; #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 ;; #pragma OPENCL EXTENSION cl_khr_fp64 : enable

--- a/llvm/test/CodeGen/SPIRV/transcoding/pown.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/pown.ll
@@ -3,6 +3,8 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
+;; #pragma OPENCL EXTENSION cl_khr_fp64 : enable
+
 ;; __kernel void test_kernel_float(float3 x, int n, __global float3* ret) {
 ;;    *ret = pown(x, n);
 ;; }

--- a/llvm/test/CodeGen/SPIRV/transcoding/pown.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/pown.ll
@@ -1,7 +1,7 @@
 ;; Check that backend converts scalar arg to vector for pown math instructions.
 
-; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ;; __kernel void test_kernel_float(float3 x, int n, __global float3* ret) {
 ;;    *ret = pown(x, n);

--- a/llvm/test/CodeGen/SPIRV/transcoding/pown.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/pown.ll
@@ -1,4 +1,4 @@
-;; Check that backend converts scalar arg to vector for pown math instructions
+;; Check that backend converts scalar arg to vector for pown math instructions.
 
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}

--- a/llvm/test/CodeGen/SPIRV/transcoding/pown.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/pown.ll
@@ -1,0 +1,38 @@
+;; Check that backend converts scalar arg to vector for pown math instructions
+
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+;; __kernel void test_kernel_float(float3 x, int n, __global float3* ret) {
+;;    *ret = pown(x, n);
+;; }
+
+; CHECK-SPIRV: %{{.*}} pown
+
+define dso_local spir_kernel void @test_kernel_float(<3 x float> noundef %x, i32 noundef %n, ptr addrspace(1) nocapture noundef writeonly %ret) local_unnamed_addr {
+entry:
+  %call = call spir_func <3 x float> @_Z4pownDv3_fi(<3 x float> noundef %x, i32 noundef %n)
+  %extractVec2 = shufflevector <3 x float> %call, <3 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 poison>
+  %storetmp3 = bitcast ptr addrspace(1) %ret to ptr addrspace(1)
+  store <4 x float> %extractVec2, ptr addrspace(1) %storetmp3, align 16
+  ret void
+}
+
+declare spir_func <3 x float> @_Z4pownDv3_fi(<3 x float> noundef, i32 noundef) local_unnamed_addr
+
+;; __kernel void test_kernel_double(double3 x, int n, __global double3* ret) {
+;;    *ret = pown(x, n);
+;; }
+
+; CHECK-SPIRV: %{{.*}} pown
+
+define dso_local spir_kernel void @test_kernel_double(<3 x double> noundef %x, i32 noundef %n, ptr addrspace(1) nocapture noundef writeonly %ret) local_unnamed_addr {
+entry:
+  %call = call spir_func <3 x double> @_Z4pownDv3_di(<3 x double> noundef %x, i32 noundef %n)
+  %extractVec2 = shufflevector <3 x double> %call, <3 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 poison>
+  %storetmp3 = bitcast ptr addrspace(1) %ret to ptr addrspace(1)
+  store <4 x double> %extractVec2, ptr addrspace(1) %storetmp3, align 32
+  ret void
+}
+
+declare spir_func <3 x double> @_Z4pownDv3_di(<3 x double> noundef, i32 noundef) local_unnamed_addr

--- a/llvm/test/CodeGen/SPIRV/transcoding/rootn.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/rootn.ll
@@ -1,7 +1,7 @@
 ;; Check that backend converts scalar arg to vector for rootn math instructions.
 
-; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ;; __kernel void test_kernel_float(float3 x, int n, __global float3* ret) {
 ;;    *ret = rootn(x, n);

--- a/llvm/test/CodeGen/SPIRV/transcoding/rootn.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/rootn.ll
@@ -1,4 +1,4 @@
-;; Check that backend converts scalar arg to vector for rootn math instructions
+;; Check that backend converts scalar arg to vector for rootn math instructions.
 
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}

--- a/llvm/test/CodeGen/SPIRV/transcoding/rootn.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/rootn.ll
@@ -3,6 +3,8 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
+;; #pragma OPENCL EXTENSION cl_khr_fp64 : enable
+
 ;; __kernel void test_kernel_float(float3 x, int n, __global float3* ret) {
 ;;    *ret = rootn(x, n);
 ;; }

--- a/llvm/test/CodeGen/SPIRV/transcoding/rootn.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/rootn.ll
@@ -1,0 +1,38 @@
+;; Check that backend converts scalar arg to vector for rootn math instructions
+
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+;; __kernel void test_kernel_float(float3 x, int n, __global float3* ret) {
+;;    *ret = rootn(x, n);
+;; }
+
+; CHECK-SPIRV: %{{.*}} rootn
+
+define dso_local spir_kernel void @test_kernel_float(<3 x float> noundef %x, i32 noundef %n, ptr addrspace(1) nocapture noundef writeonly %ret) local_unnamed_addr {
+entry:
+  %call = call spir_func <3 x float> @_Z5rootnDv3_fi(<3 x float> noundef %x, i32 noundef %n)
+  %extractVec2 = shufflevector <3 x float> %call, <3 x float> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 poison>
+  %storetmp3 = bitcast ptr addrspace(1) %ret to ptr addrspace(1)
+  store <4 x float> %extractVec2, ptr addrspace(1) %storetmp3, align 16
+  ret void
+}
+
+declare spir_func <3 x float> @_Z5rootnDv3_fi(<3 x float> noundef, i32 noundef) local_unnamed_addr
+
+;; __kernel void test_kernel_double(double3 x, int n, __global double3* ret) {
+;;    *ret = rootn(x, n);
+;; }
+
+; CHECK-SPIRV: %{{.*}} rootn
+
+define dso_local spir_kernel void @test_kernel_double(<3 x double> noundef %x, i32 noundef %n, ptr addrspace(1) nocapture noundef writeonly %ret) local_unnamed_addr {
+entry:
+  %call = call spir_func <3 x double> @_Z5rootnDv3_di(<3 x double> noundef %x, i32 noundef %n)
+  %extractVec2 = shufflevector <3 x double> %call, <3 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 poison>
+  %storetmp3 = bitcast ptr addrspace(1) %ret to ptr addrspace(1)
+  store <4 x double> %extractVec2, ptr addrspace(1) %storetmp3, align 32
+  ret void
+}
+
+declare spir_func <3 x double> @_Z5rootnDv3_di(<3 x double> noundef, i32 noundef) local_unnamed_addr


### PR DESCRIPTION
When promoting scalar arguments to vectors for builtins like `ldexp`, `pown`, and `rootn`, use the correct vector type matching the argument element type instead of always using the return type: these builtins take an integer argument but at the same time have floating point return type

Fix `ldexp` test that does not pass spirv-val and add similar tests for `pown` and `rootn`

related to https://github.com/llvm/llvm-project/issues/190736