### PR TITLE
[lldb] Fix initial search path for PDB in PE/COFF

### DIFF
--- a/lldb/source/Plugins/SymbolVendor/PECOFF/SymbolVendorPECOFF.cpp
+++ b/lldb/source/Plugins/SymbolVendor/PECOFF/SymbolVendorPECOFF.cpp
@@ -79,8 +79,11 @@ SymbolVendorPECOFF::CreateInstance(const lldb::ModuleSP &module_sp,
   if (!fspec) {
     if (auto pdb_spec = obj_file->GetPDBPath()) {
       fspec = *pdb_spec;
-      if (ConstString dir = obj_file->GetFileSpec().GetDirectory())
-        search_paths.Insert(0, FileSpec(dir));
+      if (obj_file->GetFileSpec().GetDirectory()) {
+        FileSpec dir_spec = obj_file->GetFileSpec();
+        dir_spec.ClearFilename();
+        search_paths.Insert(0, dir_spec);
+      }
     }
   }
   // Otherwise, try gnu_debuglink, if one exists.


### PR DESCRIPTION
Injecting an initial search path is more complicated than expected. `FileSpec` expects a file name and internally calls `SetFile()`, which splits the input into `filename` and `parent_path`. The original implementation added the parent path which is incorrect.

There is no obvious way to construct a `FileSpec` from a directory. Appending `/.` doesn't work either, because `remove_dots()` will strip the `.` component during normalization. The best way I found is copying the obj's spec and remove the file name.