### PR TITLE
[LLVMABI] Fix build for GCC < 8

### DIFF
--- a/llvm/include/llvm/ABI/FunctionInfo.h
+++ b/llvm/include/llvm/ABI/FunctionInfo.h
@@ -45,14 +45,19 @@ public:
 
 private:
   const Type *CoercionType = nullptr;
+  // Alignment is optional for direct arguments, but required for indirect
+  // arguments. This invariant is enforced by the methods of this class.
+  //
+  // The field is not part of DirectAttrInfo/IndirectAttrInfo because it would
+  // make the union non-trivial, disabling implicit copy/move constructors and
+  // assignment operators for the entire class.
+  MaybeAlign Alignment;
 
   struct DirectAttrInfo {
     unsigned Offset;
-    MaybeAlign Alignment;
   };
 
   struct IndirectAttrInfo {
-    Align Alignment;
     unsigned AddrSpace;
   };
 
@@ -84,8 +89,8 @@ public:
                            MaybeAlign Align = std::nullopt) {
     ArgInfo AI(Direct);
     AI.CoercionType = T;
+    AI.Alignment = Align;
     AI.DirectAttr.Offset = Offset;
-    AI.DirectAttr.Alignment = Align;
     return AI;
   }
 
@@ -95,8 +100,8 @@ public:
 
     ArgInfo AI(Extend);
     AI.CoercionType = T;
+    AI.Alignment = std::nullopt;
     AI.DirectAttr.Offset = 0;
-    AI.DirectAttr.Alignment = std::nullopt;
 
     const IntegerType *IntTy = cast<IntegerType>(T);
     if (IntTy->isSigned())
@@ -112,7 +117,7 @@ public:
   static ArgInfo getIndirect(Align Align, bool ByVal, unsigned AddrSpace = 0,
                              bool Realign = false) {
     ArgInfo AI(Indirect);
-    AI.IndirectAttr.Alignment = Align;
+    AI.Alignment = Align;
     AI.IndirectAttr.AddrSpace = AddrSpace;
     AI.IndirectByVal = ByVal;
     AI.IndirectRealign = Realign;
@@ -148,12 +153,13 @@ public:
 
   MaybeAlign getDirectAlign() const {
     assert((isDirect() || isExtend()) && "Not a direct or extend kind");
-    return DirectAttr.Alignment;
+    return Alignment;
   }
 
   Align getIndirectAlign() const {
     assert(isIndirect() && "Invalid Kind!");
-    return IndirectAttr.Alignment;
+    assert(Alignment && "Indirect arguments must have an alignment");
+    return *Alignment;
   }
 
   unsigned getIndirectAddrSpace() const {

--- a/llvm/include/llvm/ABI/FunctionInfo.h
+++ b/llvm/include/llvm/ABI/FunctionInfo.h
@@ -158,7 +158,8 @@ public:
 
   Align getIndirectAlign() const {
     assert(isIndirect() && "Invalid Kind!");
-    assert(Alignment && "Indirect arguments must have an alignment");
+    assert(Alignment.has_value() &&
+           "Indirect arguments must have an alignment");
     return *Alignment;
   }
 


### PR DESCRIPTION
`llvm::abi::ArgInfo::get*` functions return `llvm::abi::ArgInfo` by value, so we need the type to be copyable. It is not though, because of the non trivially copyable member `MaybeAlign` (`std::optional<Align>`) in a union, which deletes the implicit copy/move constructors and assignment operators.
For modern GCC versions and for clang this does not present as a problem due to named return value optimization (NRVO). It is however not a bug in old GCC versions, because NRVO is not guaranteed. Similary `std::optional`
could be trivially copyable, but that is also not guaranteed by the standard.

Instead of depending on these details of the C++ implementation, move the `MaybeAlign` member out of the union, and make it a separate member of `abi::ArgInfo`. We lose the expressiveness from the type system that `IndirectAttrInfo` always has a defined alignment, but we can get that back in practice by placing asserts in the code that uses it. Therefore `llvm::abi::ArgInfo` can still maintain this invariant.

Fixes: #190972