### PR TITLE
[dyndbg] Draft Clang and LLVM support for dynamic debugging

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.h
+++ b/clang/include/clang/Basic/CodeGenOptions.h
@@ -359,6 +359,9 @@ public:
   /// Prefix to use for -save-temps output.
   std::string SaveTempsFilePrefix;
 
+  /// Prefix to use for -save-dynamic-debugging-temps output.
+  std::string SaveDynDbgTempsFilePrefix;
+
   /// Name of file passed with -fcuda-include-gpubinary option to forward to
   /// CUDA runtime back-end for incorporating them into host-side object file.
   std::string CudaGpuBinaryFileName;

--- a/clang/include/clang/Basic/DebugOptions.def
+++ b/clang/include/clang/Basic/DebugOptions.def
@@ -62,6 +62,9 @@ ENUM_DEBUGOPT(AssignmentTrackingMode, AssignmentTrackingOpts, 2,
 /// Whether or not to use Key Instructions to determine breakpoint locations.
 DEBUGOPT(DebugKeyInstructions, 1, 0, Benign)
 
+/// Whether or not to use the Dynamic Debugging feature.
+DEBUGOPT(DynamicDebugging, 1, 0, Benign)
+
 DEBUGOPT(DebugColumnInfo, 1, 0, Compatible) ///< Whether or not to use column information
                                            ///< in debug info.
 

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -390,6 +390,10 @@ def err_drv_optimization_remark_format : Error<
 def err_drv_no_neon_modifier : Error<"[no]neon is not accepted as modifier, please use [no]simd instead">;
 def err_drv_invalid_omp_target : Error<"OpenMP target is invalid: '%0'">;
 def err_drv_incompatible_omp_arch : Error<"OpenMP target architecture '%0' pointer size is incompatible with host '%1'">;
+def err_drv_dyndbg_lto : Error<"'-fdynamic-debugging' incompatible with '-flto'">;
+def err_drv_dyndbg_incompatible : Error<"'-fdynamic-debugging' incompatible with '%0'">;
+def err_drv_dyndbg_ir : Error<"'-fdynamic-debugging' incompatible with IR input">;
+def warn_drv_dyndbg_req_debug : Warning<"'-fdynamic-debugging' ignored: requires debug info">;
 def err_drv_omp_host_target_not_supported : Error<
   "target '%0' is not a supported OpenMP host target">;
 def err_drv_expecting_fopenmp_with_fopenmp_targets : Error<

--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -508,4 +508,8 @@ def err_cir_to_cir_transform_failed : Error<
 def err_cir_verification_failed_pre_passes : Error<
     "CIR module verification error before running CIR-to-CIR passes">,
     DefaultFatal;
+
+def warn_dyndbg_unable_to_create_target : Warning<
+    "ignoring -fdynamic-debugging: unable to create target: '%0'">;
 }
+

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -5182,6 +5182,19 @@ defm key_instructions : BoolGOption<"key-instructions",
         " in some debuggers. DWARF only.">,
     BothFlags<[], [ClangOption, CLOption, CC1Option]>>,
   Group<g_flags_Group>;
+defm dynamic_debugging : BoolOption<"f", "dynamic-debugging",
+    CodeGenOpts<"DynamicDebugging">, DefaultFalse,
+    NegFlag<SetFalse>, PosFlag<SetTrue, [], [],
+        "Enable Dynamic Debugging, which allows runtime switching between"
+        " optimized and unoptimized code in debuggers that support it."
+        " Specified optimization level affects only the optimized code."
+        " This flag inhibits interprocedural optimizations.">,
+    BothFlags<[], [ClangOption, CLOption, CC1Option]>>;
+def save_dynamic_debugging_temps : Flag<["--"], "save-dynamic-debugging-temps">,
+    Visibility<[ClangOption, CLOption, CC1Option]>,
+    HelpText<"Compiler-debugging/testing option to save the intermediate"
+             " states of dynamic debugging in the same directory as the final"
+             " output file">;
 def headerpad__max__install__names : Joined<["-"], "headerpad_max_install_names">;
 def help : Flag<["-", "--"], "help">,
     Visibility<[ClangOption, CC1Option, CC1AsOption,

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -89,6 +89,7 @@
 #include "llvm/Transforms/Scalar/EarlyCSE.h"
 #include "llvm/Transforms/Scalar/GVN.h"
 #include "llvm/Transforms/Scalar/JumpThreading.h"
+#include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/Debugify.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 #include <limits>
@@ -1422,6 +1423,176 @@ runThinLTOBackend(CompilerInstance &CI, ModuleSummaryIndex *CombinedIndex,
   }
 }
 
+// Alters M and creates new Unopt module.
+static std::unique_ptr<llvm::Module> createUnoptModule(llvm::Module &M,
+                                                       CodeGenOptions &CGOpts) {
+  using namespace llvm;
+  assert(M.getNamedMetadata("llvm.dbg.cu") &&
+         "Expected module with debug info");
+
+  auto ShouldPromoteGlobal = [](const GlobalValue &GV) {
+    if (!GV.hasLocalLinkage())
+      return false;
+
+    // Local symbols in a comdat shouldn't be promoted either.
+    // This can happen with (at least) __cxx_global_var_init (which is local
+    // and may initialize an ODR-weak global variable).
+    if (GV.hasComdat())
+      return false;
+
+    return true;
+  };
+
+  // Compute a hash suffix for promoting static globals (once per TU).
+  std::string PromotionSuffix;
+  {
+    // LLVM's hash/hash_combine is not guaranteed to be stable.
+    MD5 Hash;
+    // Include args in the hash else preprocessor definitions used to alter
+    // the same source file compiled twice won't generate unique hashes.
+    Hash.update(CGOpts.CmdArgs);
+    for (auto *CU : M.debug_compile_units()) {
+      Hash.update(CU->getDirectory());
+      Hash.update(CU->getFilename());
+    }
+
+    MD5::MD5Result Result;
+    Hash.final(Result);
+    PromotionSuffix = ".dyndbg." + utohexstr(Result.low());
+  }
+
+  // Clone functions definitions only - CloneModule will clone data definitions
+  // as declarations. We rename these and explicitly set their linkage later.
+  auto ShouldCloneDefinition = [](const GlobalValue *GV) {
+    return isa<Function>(GV);
+  };
+  ValueToValueMapTy VMap;
+  std::unique_ptr<llvm::Module> UnoptM =
+      CloneModule(M, VMap, ShouldCloneDefinition);
+
+  // Insert declarations into Inner that point to Outer, apply attributes to
+  // Outer functions.
+  DenseMap<Function *, Function *> OuterDefToInnerDecl;
+  for (Function &OuterDef : M.functions()) {
+    if (OuterDef.isDeclaration())
+      continue;
+
+    // Find the Inner version of Outer's function.
+    Function *InnerDef = cast<Function>(VMap[&OuterDef]);
+
+    // Apply some attributes to both Inner and Outer defs.
+    {
+      // Unoptimized module wants no inlining at all.
+      InnerDef->addFnAttr(llvm::Attribute::NoInline);
+      InnerDef->removeFnAttr(llvm::Attribute::AlwaysInline);
+
+      // Apply optnone, remove clashing attributes.
+      InnerDef->addFnAttr(llvm::Attribute::OptimizeNone);
+      InnerDef->removeFnAttr(llvm::Attribute::OptimizeForSize);
+      InnerDef->removeFnAttr(llvm::Attribute::MinSize);
+
+      // Add attributes to the outer-object functions to ensure they're
+      // always patchable.
+      OuterDef.addFnAttr("tail-pad-to-size", "5");
+      OuterDef.addFnAttr("tail-pad-value", "144"); // 0x90
+      OuterDef.addFnAttr("no-func-spec");
+    }
+
+    // Apply COMDAT grouping to the clone if OuterDef is in one.
+    if (OuterDef.hasComdat()) {
+      std::string NewComdat =
+          Twine("__dyndbg." + OuterDef.getComdat()->getName()).str();
+      llvm::Comdat *C = M.getOrInsertComdat(NewComdat);
+      C->setSelectionKind(OuterDef.getComdat()->getSelectionKind());
+      InnerDef->setComdat(C);
+    }
+
+    // Rename Inner's copy and set appropriate linkage depending on whether
+    // it'll get promoted in Outer or not.
+    if (ShouldPromoteGlobal(OuterDef)) {
+      InnerDef->setName("__dyndbg." + InnerDef->getName() + PromotionSuffix);
+      InnerDef->setLinkage(GlobalValue::ExternalLinkage);
+      InnerDef->setVisibility(GlobalValue::HiddenVisibility);
+    } else {
+      InnerDef->setName("__dyndbg." + InnerDef->getName());
+      InnerDef->setLinkage(OuterDef.getLinkage());
+      InnerDef->setVisibility(OuterDef.getVisibility());
+    }
+
+    // Create Inner's external reference to Outer's version.
+    Function *InnerDeclOfOuterDef =
+        Function::Create(cast<llvm::FunctionType>(OuterDef.getValueType()),
+                         OuterDef.getLinkage(), OuterDef.getAddressSpace(),
+                         OuterDef.getName(), UnoptM.get());
+    InnerDeclOfOuterDef->copyAttributesFrom(&OuterDef);
+    // Re-set linkage and visibility after copyAttributesFrom.
+    InnerDeclOfOuterDef->setLinkage(GlobalValue::ExternalLinkage);
+    InnerDeclOfOuterDef->setPersonalityFn(nullptr);
+
+    // Replace Inner uses of function with that external reference.
+    InnerDef->replaceAllUsesWith(InnerDeclOfOuterDef);
+
+    VMap[&OuterDef] = InnerDeclOfOuterDef;
+  }
+
+  // Add Outer aliases for globals with internal linkage, adding
+  // ".dyndbg.<TU-unique-hash>" suffix. Update Inner's external references to
+  // these promoted functions to use their new names.
+  SmallVector<GlobalValue *> GlobalsToPreserve;
+  for (GlobalValue &GV : M.global_values()) {
+    assert(GV.getSection() != ".debug_llvm_dyndbg" && "Double dyndbg nesting?");
+
+    // If the global is used but may be discarded after optimizations
+    // (e.g. inlining) then ensure it's marked as compiler-used to prevent
+    // that. It may be referenced from the inner module.
+    if (GV.isDiscardableIfUnused()) {
+      if (GV.getNumUses()) {
+        GlobalsToPreserve.push_back(&GV);
+      } else {
+        // No uses, so the inner module doesn't need a reference nor do we need
+        // to produce an alias.
+        // Remove the inner module reference.
+        auto GVAndUnoptPair = VMap.find(&GV);
+        assert(GVAndUnoptPair != VMap.end() && "Unmapped global?");
+        // Delete the external reference - VMap shold only contain mappings to
+        // those declarations now.
+        assert(cast<GlobalValue>(GVAndUnoptPair->second)->isDeclaration() &&
+               "expected only declarations in VMap now");
+        cast<GlobalValue>(GVAndUnoptPair->second)->eraseFromParent();
+        GVAndUnoptPair->second = nullptr;
+        // Nothing else to do for this global.
+        continue;
+      }
+    }
+
+    if (!ShouldPromoteGlobal(GV))
+      continue;
+
+    // We need external aliases with a mangled name and hidden visability.
+    auto *Alias = GlobalAlias::create(GlobalValue::ExternalLinkage,
+                                      GV.getName() + PromotionSuffix, &GV);
+    Alias->setVisibility(GlobalValue::HiddenVisibility);
+
+    // Update the Inner external reference that corresponds to the promoted
+    // Outer global (created just now as an alias in opt) to reference the new
+    // alias.
+    GlobalValue *UnoptGV = cast<GlobalValue>(VMap[&GV]);
+    UnoptGV->setName(Alias->getName());
+    UnoptGV->setVisibility(GlobalValue::HiddenVisibility);
+    assert(UnoptGV->getLinkage() == GlobalValue::ExternalLinkage &&
+           "Expected ExternalLinkage from CloneModule or inserted decl");
+  }
+
+  // Preserve functions that may be discarded after optimizing away call sites
+  // (e.g. ODR-weak). Another desirable effect of this is that it prevents
+  // GlobalOpt promoting the alias. If the function-preservation mechanism
+  // changes in the future GlobalOpt alias promotion must be handled another
+  // way.
+  llvm::appendToCompilerUsed(M, GlobalsToPreserve);
+
+  return UnoptM;
+}
+
 void clang::emitBackendOutput(CompilerInstance &CI, CodeGenOptions &CGOpts,
                               StringRef TDesc, llvm::Module *M,
                               BackendAction Action,
@@ -1469,6 +1640,70 @@ void clang::emitBackendOutput(CompilerInstance &CI, CodeGenOptions &CGOpts,
       EmptyModule->setTargetTriple(M->getTargetTriple());
       M = EmptyModule.get();
     }
+  }
+
+
+  bool EnableDynamicDebugging = CGOpts.DynamicDebugging;
+  // Disable dyndbg if the target isn't available as we're compiling to the
+  // inner module to object regardless of other options. (This may change).
+  if (EnableDynamicDebugging) {
+    std::string Error;
+    const llvm::Target *TheTarget =
+        TargetRegistry::lookupTarget(M->getTargetTriple(), Error);
+    if (!TheTarget) {
+      Diags.Report(diag::warn_dyndbg_unable_to_create_target) << Error;
+      EnableDynamicDebugging = false;
+    }
+  }
+
+  if (EnableDynamicDebugging) {
+    /// Helper for saving the module(s) at various dyndbg stages.
+    auto SaveModule = [&](StringRef Name, llvm::Module &M) {
+      if (CGOpts.SaveDynDbgTempsFilePrefix == "")
+        return;
+      std::error_code EC;
+      std::string Path =
+          Twine(CGOpts.SaveDynDbgTempsFilePrefix + "." + Name + ".ll").str();
+      raw_fd_ostream OS(Path, EC, sys::fs::OpenFlags::OF_None);
+      if (EC) {
+        // Copy -save-temps behaviour: this is a debugging option so we simply
+        // exit if there's an issue.
+        errs() << "failed to open " << Path << ": " << EC.message() << '\n';
+        errs().flush();
+        exit(1);
+      }
+      M.print(OS, nullptr);
+    };
+
+    SaveModule("dyndbg.0.input", *M);
+    // Modify M as needed and create an "unoptimized" clone.
+    auto UnoptM = createUnoptModule(*M, CGOpts);
+    SaveModule("dyndbg.1.inner", *UnoptM);
+
+    CodeGenOptions UnoptOpts = CGOpts;
+    UnoptOpts.OptimizationLevel = 0;
+    UnoptOpts.OptimizeSize = 0;
+    EmitAssemblyHelper AsmHelper(CI, UnoptOpts, UnoptM.get(), VFS);
+
+    // Create a buffer and ostream for the inner ELF.
+    SmallVector<char, 0> UnoptBuf;
+    std::unique_ptr<llvm::raw_pwrite_stream> UnoptOS =
+        std::make_unique<llvm::raw_svector_ostream>(UnoptBuf);
+
+    // Always run the full codegen pipeline (Backend_EmitObj). This causes
+    // assertion failures if there's no registered backend which is why we
+    // disable the feature if that's the case (see
+    // warn_dyndbg_unable_to_create_target above).
+    AsmHelper.emitAssembly(Backend_EmitObj, std::move(UnoptOS), BC);
+    assert(!UnoptBuf.empty() && "Expected emitAssembly to fill UnoptBuf");
+
+    // Inject the inner ELF into the outer module.
+    StringRef SR(UnoptBuf.data(), UnoptBuf.size());
+    std::unique_ptr<MemoryBuffer> Buf =
+        MemoryBuffer::getMemBuffer(SR, "", false);
+
+    llvm::embedBufferInModule(*M, *Buf, ".debug_llvm_dyndbg");
+    SaveModule("dyndbg.2.outer", *M);
   }
 
   EmitAssemblyHelper AsmHelper(CI, CGOpts, M, VFS);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4665,6 +4665,30 @@ renderDebugOptions(const ToolChain &TC, const Driver &D, const llvm::Triple &T,
                     options::OPT_gno_structor_decl_linkage_names, true))
     CmdArgs.push_back("-gno-structor-decl-linkage-names");
 
+  if (Args.hasFlag(options::OPT_fdynamic_debugging,
+                   options::OPT_fno_dynamic_debugging, false)) {
+    // As this is an experimental feature we can afford to be strict about
+    // supported configurations.
+    if (!TC.getTriple().isX86())
+      D.Diag(diag::err_drv_unsupported_opt_for_target)
+          << Args.getLastArg(options::OPT_fdynamic_debugging)->getAsString(Args)
+          << T.getTriple();
+    if (D.isUsingLTO())
+      D.Diag(diag::err_drv_dyndbg_lto);
+    if (DwarfFission != DwarfFissionKind::None)
+      D.Diag(diag::err_drv_dyndbg_incompatible)
+          << Args.getLastArg(options::OPT_gsplit_dwarf)->getAsString(Args);
+    // There's no fundamental reason why IR input should be incompatible, but
+    // it would add some complexity, and reducing the test matrix is valuable.
+    if (IRInput)
+      D.Diag(diag::err_drv_dyndbg_ir);
+
+    if (!EmitDwarf)
+      D.Diag(diag::warn_drv_dyndbg_req_debug);
+    else
+      CmdArgs.push_back("-fdynamic-debugging");
+  }
+
   if (EmitCodeView) {
     CmdArgs.push_back("-gcodeview");
 
@@ -5357,6 +5381,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (Args.getLastArg(options::OPT_save_temps_EQ))
     Args.AddLastArg(CmdArgs, options::OPT_save_temps_EQ);
+
+  if (Args.getLastArg(options::OPT_save_dynamic_debugging_temps))
+    Args.AddLastArg(CmdArgs, options::OPT_save_dynamic_debugging_temps);
 
   auto *MemProfArg = Args.getLastArg(options::OPT_fmemory_profile,
                                      options::OPT_fmemory_profile_EQ,

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1670,6 +1670,9 @@ void CompilerInvocationBase::GenerateCodeGenArgs(const CodeGenOptions &Opts,
   if (Opts.SaveTempsFilePrefix == OutputFile)
     GenerateArg(Consumer, OPT_save_temps_EQ, "obj");
 
+  if (!Opts.SaveDynDbgTempsFilePrefix.empty())
+    GenerateArg(Consumer, OPT_save_dynamic_debugging_temps);
+
   StringRef MemProfileBasename("memprof.profraw");
   if (!Opts.MemoryProfileOutput.empty()) {
     if (Opts.MemoryProfileOutput == MemProfileBasename) {
@@ -2003,6 +2006,9 @@ bool CompilerInvocation::ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args,
         llvm::StringSwitch<std::string>(A->getValue())
             .Case("obj", OutputFile)
             .Default(llvm::sys::path::filename(OutputFile).str());
+
+  if (Arg *A = Args.getLastArg(OPT_save_dynamic_debugging_temps))
+    Opts.SaveDynDbgTempsFilePrefix = OutputFile;
 
   // The memory profile runtime appends the pid to make this name more unique.
   const char *MemProfileBasename = "memprof.profraw";

--- a/clang/test/DebugInfo/DynamicDebugging/EndToEnd/X86/globalopt.c
+++ b/clang/test/DebugInfo/DynamicDebugging/EndToEnd/X86/globalopt.c
@@ -1,0 +1,24 @@
+// Check `a` and `d` have aliases while keeping their original symbols.
+// GlobalOpt would usually replace these internal-linkage functions with
+// their external-linkage aliases. That's currently prevented as a side effect
+// of adding discardable functions to the compiler-used global.
+
+// RUN: %clang -cc1 %s -emit-obj -O3 -debug-info-kind=limited -fdynamic-debugging -o - -triple x86_64-unknown-unknown | llvm-nm - | FileCheck %s
+// CHECK: t a
+// CHECK: T a.dyndbg.[[hash:[A-Z0-9]+]]
+// CHECK: T b
+// CHECK: U c
+// CHECK: t d
+// CHECK: T d.dyndbg.[[hash]]
+// CHECK: B g
+
+int g;
+int c();
+
+__attribute__((always_inline))
+static inline int d() { return c(); }
+
+__attribute__((always_inline))
+static int a() { return g; }
+
+int b() { return a() + d() ;}

--- a/clang/test/DebugInfo/DynamicDebugging/EndToEnd/X86/lit.local.cfg
+++ b/clang/test/DebugInfo/DynamicDebugging/EndToEnd/X86/lit.local.cfg
@@ -1,0 +1,4 @@
+# These tests require x86 in order to inspect the inner object.
+# FIXME: These tests are quite broad.
+if "x86-registered-target" not in config.available_features:
+    config.unsupported = True

--- a/clang/test/DebugInfo/DynamicDebugging/EndToEnd/X86/obj-emission-target/lit.local.cfg
+++ b/clang/test/DebugInfo/DynamicDebugging/EndToEnd/X86/obj-emission-target/lit.local.cfg
@@ -1,0 +1,3 @@
+# This test wants X86 support without aarch64 support.
+if "x86-registered-target" not in config.available_features or "aarch64-registered-target" in config.available_features:
+    config.unsupported = True

--- a/clang/test/DebugInfo/DynamicDebugging/EndToEnd/X86/obj-emission-target/no-target.c
+++ b/clang/test/DebugInfo/DynamicDebugging/EndToEnd/X86/obj-emission-target/no-target.c
@@ -1,0 +1,14 @@
+// Check we get a warning if -fdynamic-debugging is specified for an
+// unsupported target. Dynamic debugging currently emits the inner module as
+// an object regardless of output flags (e.g. -emit-llvm).
+
+// RUN: %clang -cc1 %s -emit-llvm -debug-info-kind=limited -fdynamic-debugging -o - -triple aarch64-unknown-unknown 2>&1  | FileCheck %s --check-prefix=WITHOUT_TARGET
+// WITHOUT_TARGET: warning: ignoring -fdynamic-debugging: unable to create target: 'No available targets are compatible with triple "aarch64-unknown-unknown"'
+// WITHOUT_TARGET-NOT: .debug_llvm_dyndbg
+
+// Prevent rotten green test by checking we do see .debug_llvm_dyndbg otherwise.
+// RUN: %clang -cc1 %s -emit-obj -debug-info-kind=limited -fdynamic-debugging -o - -triple x86_64-unknown-unknown 2>&1 | FileCheck %s --check-prefix=WITH_TARGET
+// WITH_TARGET-NOT: ignoring -fdynamic-debugging:
+// WITH_TARGET: .debug_llvm_dyndbg
+
+int g;

--- a/clang/test/DebugInfo/DynamicDebugging/EndToEnd/X86/section.c
+++ b/clang/test/DebugInfo/DynamicDebugging/EndToEnd/X86/section.c
@@ -1,0 +1,13 @@
+// By default LLVM gives this section SHF_EXCLUDE, which we don't want.
+
+// RUN: %clang -cc1 %s -emit-obj -debug-info-kind=limited -fdynamic-debugging -o - -triple x86_64-unknown-unknown | llvm-readelf --section-details - \
+// RUN: | FileCheck %s
+//             [Nr] Name
+// CHECK:      .debug_llvm_dyndbg
+//             Type     Address          Off           Size          ES Lk Inf Al
+// CHECK-NEXT: PROGBITS 0000000000000000 {{[0-9a-z]+}} {{[0-9a-z]+}} 00 0  0   1
+//             Flags
+// CHECK-NEXT: [0000000000000000]: {{$}}
+
+int g;
+int b() { return g; }

--- a/clang/test/DebugInfo/DynamicDebugging/attr-outer-no-specialization.c
+++ b/clang/test/DebugInfo/DynamicDebugging/attr-outer-no-specialization.c
@@ -1,0 +1,5 @@
+// RUN: %clang -cc1 -triple %itanium_abi_triple %s -debug-info-kind=limited -fdynamic-debugging -o - -emit-llvm  | FileCheck %s
+
+// CHECK: define dso_local i32 @f() #0
+// CHECK: attributes #0 = {{{.*}}"no-func-spec"{{.*}}}
+int f() { return 0; }

--- a/clang/test/DebugInfo/DynamicDebugging/attr-outer-tail-pad.c
+++ b/clang/test/DebugInfo/DynamicDebugging/attr-outer-tail-pad.c
@@ -1,0 +1,10 @@
+// REQUIRES: target=x86_64-sie-ps5
+/// Requires target because object emission occurs (FIXME: add option to not).
+
+// RUN: %clang %s -c -O1 -Xclang -disable-llvm-passes -g -fdynamic-debugging -o - -emit-llvm -S --target=x86_64-sie-ps5 | FileCheck %s --check-prefix=PS5
+/// FIXME: Add negative tests for other targets (if in doubt, don't tail-pad).
+
+/// Pad functions to minimum of 5 bytes for insertion of 32 rel jump.
+// PS5: define hidden i32 @f() #0
+// PS5: attributes #0 = {{{.*}}"tail-pad-to-size"="5"{{.*}}"tail-pad-value"="144"{{.*}}}
+int f() { return 0; }

--- a/clang/test/DebugInfo/DynamicDebugging/compiler-used.cpp
+++ b/clang/test/DebugInfo/DynamicDebugging/compiler-used.cpp
@@ -1,0 +1,37 @@
+// RUN: %clang -cc1 -triple %itanium_abi_triple %s -debug-info-kind=limited -fdynamic-debugging -o %t --save-dynamic-debugging-temps
+// RUN: FileCheck %s --check-prefix=OUTER < %t.dyndbg.2.outer.ll
+
+// Test discardable symbols are added to the @llvm.compiler.used global,
+// which prevents them being discarded (including by globalopt replacing) them
+// with their external linkage aliases.
+
+// OUTER: @llvm.compiler.used = appending global [[[#]] x ptr]
+// OUTER-SAME: [
+// OUTER-SAME:  ptr @__cxx_global_var_init,
+// OUTER-SAME:  ptr @_ZL12internal_funv,
+// OUTER-SAME:  ptr @_Z14internal_fun_2v,
+// OUTER-SAME:  ptr @_GLOBAL__sub_I_compiler_used.cpp,
+// OUTER-SAME:  ptr @_ZL12used_by_init,
+// OUTER-SAME:  ptr @odrweak,
+// OUTER-SAME:  ptr @_ZL8internal,
+// OUTER-SAME:  ptr @_ZZ14internal_fun_2vE8internal,
+// OUTER-SAME:  ptr @llvm.embedded.object
+// OUTER-SAME: ],
+// OUTER-SAME: section "llvm.metadata"
+
+// 'external' has external linkage; it's not discardable if unused, so it
+// doesn't need to be added to compiler-used.
+int external = 1;
+// 'odrweak' and 'internal' are both discardable and may be only referenced
+// from the inner module, so we must keep them.
+inline int odrweak = 2;
+static int internal = 1;
+// 'unused_internal' has internal linkage and is unused so we don't need to
+// preserve it (it isn't referenced by the outer or inner module).
+static int internal_fun() { static int unused_internal = 0; return 0; }
+inline int internal_fun_2() { static int internal = 0; return internal; }
+
+// Use those globals so they're not omitted by Clang. Don't use [[gnu::used]]
+// because that populates the compiler-used global. This global itself is
+// unused in user code but it _is_ used in __cxx_global_var_init.
+static int used_by_init = external + odrweak + internal + internal_fun() + internal_fun_2();

--- a/clang/test/DebugInfo/DynamicDebugging/embed.c
+++ b/clang/test/DebugInfo/DynamicDebugging/embed.c
@@ -1,0 +1,10 @@
+// RUN: %clang -cc1 -triple %itanium_abi_triple %s -debug-info-kind=limited -fdynamic-debugging -o %t --save-dynamic-debugging-temps
+// RUN: FileCheck %s < %t.dyndbg.2.outer.ll
+
+// Test that a dynamic debugging section is embedded in the outer module. Note
+// that !exclude is ignored by LLVM as this section's flags are chosen based
+// on its name. FIXME: We could introduce new metadata like !exclude to avoid
+// the special casing in LLVM.
+int e() { return 0; }
+
+// CHECK: @llvm.embedded.object = private constant {{.*}}, section ".debug_llvm_dyndbg", align 1, !exclude

--- a/clang/test/DebugInfo/DynamicDebugging/inner-attrs.c
+++ b/clang/test/DebugInfo/DynamicDebugging/inner-attrs.c
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -triple %itanium_abi_triple %s -Os -emit-llvm -debug-info-kind=constructor -fdynamic-debugging -o %t --save-dynamic-debugging-temps
+// RUN: FileCheck %s --check-prefix=INPUT < %t.dyndbg.0.input.ll
+// RUN: FileCheck %s --check-prefix=INNER < %t.dyndbg.1.inner.ll
+
+/// always_inline should be removed from the inner module.
+__attribute__((always_inline)) void a() { }
+__attribute__((minsize)) void b() { }
+
+/// Confirm the input module has alwaysinline, minsize, optsize.
+// INPUT: define dso_local void @a() #0
+// INPUT: define dso_local void @b() #1
+// INPUT: attributes #0 = { alwaysinline nounwind optsize "
+// INPUT: attributes #1 = { minsize nounwind optsize "
+
+/// Check the inner module has noinline and optnone added to its copies of the
+/// outer functions, removing alwaysinline, minsize, optsize.
+// INNER: define dso_local void @__dyndbg.a() #0
+// INNER: define dso_local void @__dyndbg.b() #0
+// INNER: declare dso_local void @a() #1
+// INNER: declare dso_local void @b() #2
+// INNER: attributes #0 = { noinline nounwind optnone "
+/// Inner's references to outer's functions keep their original attributes.
+// INNER: attributes #1 = { alwaysinline nounwind optsize "
+// INNER: attributes #2 = { minsize nounwind optsize "

--- a/clang/test/DebugInfo/DynamicDebugging/lit.local.cfg
+++ b/clang/test/DebugInfo/DynamicDebugging/lit.local.cfg
@@ -1,0 +1,5 @@
+# These tests require x86 because dynamic debugging (currently) always tries
+# to run the LLVM codegen pipeline and emit an object.
+# FIXME: We should add an escape hatch for tests.
+if "x86-registered-target" not in config.available_features:
+    config.unsupported = True

--- a/clang/test/DebugInfo/DynamicDebugging/symbols-functions.cpp
+++ b/clang/test/DebugInfo/DynamicDebugging/symbols-functions.cpp
@@ -1,0 +1,32 @@
+// RUN: %clang -cc1 -triple %itanium_abi_triple %s -debug-info-kind=limited -fdynamic-debugging -o %t --save-dynamic-debugging-temps
+// RUN: FileCheck %s --check-prefix=INNER < %t.dyndbg.1.inner.ll
+// RUN: FileCheck %s --check-prefix=OUTER < %t.dyndbg.2.outer.ll
+
+/// Test functions get expected linkage and names in the dyndbg inner
+/// and outer modules. Each outer (to-be-optimized) function should have a
+/// corresponding inner (unoptimized) version.
+///
+/// The internal functions get external aliases in outer.
+
+// OUTER: $_Z7odrweakv = comdat any
+// INNER: $__dyndbg._Z7odrweakv = comdat any
+
+/// Outer: as input. Inner: external reference, __dyndbg copy.
+void external() {}
+// OUTER-DAG: define  dso_local void @_Z8externalv()
+// INNER-DAG: declare dso_local void @_Z8externalv()
+// INNER-DAG: define  dso_local void @__dyndbg._Z8externalv()
+
+/// Outer: add external linkage alias. Inner: external reference to alias,
+/// __dyndbg copy.
+[[gnu::used]] static void internal() {}
+// OUTER-DAG: @_ZL8internalv.dyndbg.[[hash:[0-9A-Z]+]] = hidden alias void (), ptr @_ZL8internalv
+// OUTER-DAG: define  internal void @_ZL8internalv()
+// INNER-DAG: declare hidden void @_ZL8internalv.dyndbg.[[hash:[0-9A-Z]+]]()
+// INNER-DAG: define  hidden void @__dyndbg._ZL8internalv.dyndbg.[[hash]]
+
+/// Outer: as input. Inner: external reference, __dyndbg copy.
+[[gnu::used]] inline void odrweak() {}
+// OUTER-DAG: define  linkonce_odr dso_local void @_Z7odrweakv()
+// INNER-DAG: declare dso_local void @_Z7odrweakv()
+// INNER-DAG: define  linkonce_odr dso_local void @__dyndbg._Z7odrweakv()

--- a/clang/test/DebugInfo/DynamicDebugging/symbols-globals.cpp
+++ b/clang/test/DebugInfo/DynamicDebugging/symbols-globals.cpp
@@ -1,0 +1,71 @@
+// RUN: %clang -cc1 -triple %itanium_abi_triple %s -debug-info-kind=limited -fdynamic-debugging -o %t --save-dynamic-debugging-temps
+// RUN: FileCheck %s --check-prefix=INNER < %t.dyndbg.1.inner.ll
+// RUN: FileCheck %s --check-prefix=OUTER < %t.dyndbg.2.outer.ll
+
+// Test global variables get expected linkage and names in the dyndbg inner
+// and outer modules. Global data is stored in the outer module and referenced
+// from the inner module.
+//
+// The external global variables are simply referenced by inner.
+//
+// The internal (static) global variables get external aliases in outer
+// and those are referenced from inner.
+//
+// The internal functions _ZTW1d (thread-local wrapper routine for d) and
+// _GLOBAL__sub_I_symbols_globals, __cxx_global_var_init are promoted too (get
+// global aliases).
+
+int a = 1;
+// OUTER-DAG: @a = dso_local global i32 1, align 4
+// INNER-DAG: @a = external dso_local global i32, align 4
+
+extern int b;
+// OUTER-DAG: @b = external global i32, align 4
+// INNER-DAG: @b = external global i32, align 4
+
+inline int c = 2;
+// OUTER-DAG: $c = comdat any
+// OUTER-DAG: @c = linkonce_odr dso_local global i32 2, comdat, align 4
+// INNER-DAG: @c = external dso_local global i32, align 4
+
+thread_local int d = 3;
+// OUTER-DAG: @d = dso_local thread_local global i32 3, align 4
+// INNER-DAG: @d = external dso_local thread_local global i32, align 4
+//
+// OUTER-DAG: $_ZTW1d = comdat any
+// OUTER-DAG: define weak_odr hidden noundef ptr @_ZTW1d() #[[#]] comdat
+// INNER-DAG: $__dyndbg._ZTW1d = comdat any
+// INNER-DAG: declare hidden noundef ptr @_ZTW1d()
+// INNER-DAG: define weak_odr hidden noundef ptr @__dyndbg._ZTW1d() #[[#]] comdat
+
+struct S { int a, b; float c, d; } e {0, 100, 4.f, 5.f};
+// OUTER-DAG: @e = dso_local global %struct.S { i32 0, i32 100, float 4.000000e+00, float 5.000000e+00 }, align 4
+// INNER-DAG: @e = external dso_local global %struct.S, align 4
+
+inline S f {0, 100, 4.f, 5.f};
+// OUTER-DAG: $f = comdat any
+// OUTER-DAG: @f = linkonce_odr dso_local global %struct.S { i32 0, i32 100, float 4.000000e+00, float 5.000000e+00 }, comdat, align 4
+// INNER-DAG: @f = external dso_local global %struct.S, align 4
+
+int fun() {
+    static int g = 0;
+    return g;
+}
+// OUTER-DAG: @_ZZ3funvE1g = internal global i32 0, align 4
+// OUTER-DAG: @_ZZ3funvE1g.dyndbg.[[hash:[0-9A-Z]+]] = hidden alias i32, ptr @_ZZ3funvE1g
+// INNER-DAG: @_ZZ3funvE1g.dyndbg.[[hash:[0-9A-Z]+]] = external hidden global i32, align 4
+
+static int h = 1;
+// OUTER-DAG: @_ZL1h = internal global i32 1, align 4
+// OUTER-DAG: @_ZL1h.dyndbg.[[hash]] = hidden alias i32, ptr @_ZL1h
+// INNER-DAG: @_ZL1h.dyndbg.[[hash]] = external hidden global i32, align 4
+
+__attribute__((nodebug)) int use = a + b + c + d + e.a + f.a + h;
+
+// OUTER-DAG: define internal void @__cxx_global_var_init()
+// OUTER-DAG: @__cxx_global_var_init.dyndbg.[[hash]] = hidden alias void (), ptr @__cxx_global_var_init
+// INNER-DAG: declare hidden void @__cxx_global_var_init.dyndbg.[[hash]]()
+
+// OUTER-DAG: define internal void @_GLOBAL__sub_I_symbols_globals.cpp()
+// OUTER-DAG: @_GLOBAL__sub_I_symbols_globals.cpp.dyndbg.[[hash]] = hidden alias void (), ptr @_GLOBAL__sub_I_symbols_globals.cpp
+// INNER-DAG: define hidden void @__dyndbg._GLOBAL__sub_I_symbols_globals.cpp.dyndbg.[[hash]]() #[[#]]

--- a/clang/test/DebugInfo/DynamicDebugging/symbols-internal-comdat.cpp
+++ b/clang/test/DebugInfo/DynamicDebugging/symbols-internal-comdat.cpp
@@ -1,0 +1,26 @@
+// RUN: %clang -cc1 -triple %itanium_abi_triple %s -debug-info-kind=limited -fdynamic-debugging -o %t --save-dynamic-debugging-temps
+// RUN: FileCheck %s --check-prefix=INNER < %t.dyndbg.1.inner.ll --implicit-check-not=@__dyndbg._ZN1X5weirdE
+// RUN: FileCheck %s --check-prefix=OUTER < %t.dyndbg.2.outer.ll
+
+/// Check that internal symbols in comdats, __cxx_global_var_init in this case,
+/// are not promoted (no external alias is produced).
+///
+/// --implicit-check-not=@__dyndbg._ZN1X5weirdE:
+/// The innner cxx_global_var_init gets a comdat, '$__dyndbg._ZN1X5weirdE', but
+/// unlike the one in the outer module, this one has no associated global data.
+
+// OUTER: @_ZN1X5weirdE = linkonce_odr dso_local global %struct.X zeroinitializer, comdat, align 4
+// INNER: @_ZN1X5weirdE = external dso_local global %struct.X, align 4
+
+// OUTER: define  internal void @__cxx_global_var_init() {{.*}} comdat($_ZN1X5weirdE)
+// INNER: define  internal void @__dyndbg.__cxx_global_var_init() {{.*}} comdat($__dyndbg._ZN1X5weirdE)
+// INNER: declare dso_local void @__cxx_global_var_init()
+
+struct X {
+public:
+  X(int a) : a(a) {}
+  int a;
+  static const X weird;
+};
+
+inline const X X::weird = X(5);

--- a/clang/test/Driver/dynamic-debugging-flags.c
+++ b/clang/test/Driver/dynamic-debugging-flags.c
@@ -1,0 +1,28 @@
+// Only support x86_64 targets initially.
+// RUN: not %clang -c -target aarch64-unknown-unknown -g -fdynamic-debugging -### -o /dev/null %s 2>&1 | FileCheck %s -check-prefix=CHECK-TARGET-ERR
+// RUN: %clang -c -target x86_64-unknown-unknown -g -fdynamic-debugging -### -o /dev/null %s 2>&1 | FileCheck %s -check-prefix=CHECK-OK
+// CHECK-TARGET-ERR: error: unsupported option '-fdynamic-debugging' for target 'aarch64-unknown-unknown'
+
+// Do not support LTO initially.
+// RUN: not %clang -c -target x86_64-unknown-unknown -g -fdynamic-debugging -flto -### -o /dev/null %s 2>&1 | FileCheck %s -check-prefix=CHECK-LTO-ERR
+// RUN: not %clang -c -target x86_64-unknown-unknown -g -fdynamic-debugging -flto=full -### -o /dev/null %s 2>&1 | FileCheck %s -check-prefix=CHECK-LTO-ERR
+// RUN: not %clang -c -target x86_64-unknown-unknown -g -fdynamic-debugging -flto=thin -### -o /dev/null %s 2>&1 | FileCheck %s -check-prefix=CHECK-LTO-ERR
+// RUN: %clang -c -target x86_64-unknown-unknown -g -fdynamic-debugging -flto -fno-lto -### -o /dev/null %s 2>&1 | FileCheck %s -check-prefix=CHECK-OK
+// CHECK-LTO-ERR: clang: error: '-fdynamic-debugging' incompatible with '-flto'
+
+// Do not support split dwarf.
+// RUN: not %clang -c -target x86_64-unknown-unknown -fdynamic-debugging -g -gsplit-dwarf -### -o /dev/null %s 2>&1 | FileCheck %s -check-prefix=CHECK-DWO-ERR
+// RUN: %clang -c -target x86_64-unknown-unknown -fdynamic-debugging -g -gsplit-dwarf -gno-split-dwarf -### -o /dev/null %s 2>&1 | FileCheck %s -check-prefix=CHECK-OK
+// CHECK-DWO-ERR: clang: error: '-fdynamic-debugging' incompatible with '-gsplit-dwarf'
+
+// Do not support llvm IR input.
+// RUN: not %clang -c -target x86_64-unknown-unknown -fdynamic-debugging -gsplit-dwarf -### -o /dev/null -x ir %s 2>&1 | FileCheck %s -check-prefix=CHECK-LL-ERR
+// CHECK-LL-ERR: clang: error: '-fdynamic-debugging' incompatible with IR input
+
+// Warning - requires debug info.
+// RUN: %clang -c -target x86_64-unknown-unknown -fdynamic-debugging -gsplit-dwarf -### -o /dev/null %s 2>&1 | FileCheck %s -check-prefix=CHECK-DBG-WARN
+// CHECK-DBG-WARN: clang: warning: '-fdynamic-debugging' ignored: requires debug info
+// CHECK-DBG-WARN-NOT: -fdynamic-debugging
+
+// CHECK-OK-NOT: error:
+// CHECK-OK-NOT: warning:

--- a/clang/test/Misc/warning-flags.c
+++ b/clang/test/Misc/warning-flags.c
@@ -18,7 +18,7 @@ This test serves two purposes:
 
 The list of warnings below should NEVER grow.  It should gradually shrink to 0.
 
-CHECK: Warnings without flags (56):
+CHECK: Warnings without flags (58):
 
 CHECK-NEXT:   ext_expected_semi_decl_list
 CHECK-NEXT:   ext_missing_whitespace_after_macro_name
@@ -42,7 +42,9 @@ CHECK-NEXT:   warn_delete_array_type
 CHECK-NEXT:   warn_double_const_requires_fp64
 CHECK-NEXT:   warn_drv_assuming_mfloat_abi_is
 CHECK-NEXT:   warn_drv_clang_unsupported
+CHECK-NEXT:   warn_drv_dyndbg_req_debug
 CHECK-NEXT:   warn_drv_pch_not_first_include
+CHECK-NEXT:   warn_dyndbg_unable_to_create_target
 CHECK-NEXT:   warn_expected_qualified_after_typename
 CHECK-NEXT:   warn_fe_backend_unsupported
 CHECK-NEXT:   warn_fe_cc_log_diagnostics_failure

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2476,6 +2476,32 @@ void AsmPrinter::emitFunctionBody() {
     OutStreamer->emitELFSize(CurrentFnSym, SizeExp);
     if (CurrentFnBeginLocal)
       OutStreamer->emitELFSize(CurrentFnBeginLocal, SizeExp);
+
+    // Tail-pad functions that want it.
+    if (F.hasFnAttribute("tail-pad-to-size")) {
+      uint64_t PadToSize;
+      if (F.getFnAttribute("tail-pad-to-size")
+              .getValueAsString()
+              .getAsInteger(10, PadToSize))
+        PadToSize = 0;
+      uint64_t FillValue;
+      if (!F.hasFnAttribute("tail-pad-value") ||
+          F.getFnAttribute("tail-pad-value")
+              .getValueAsString()
+              .getAsInteger(10, FillValue))
+        FillValue = 0;
+
+      // Emit: .fill ((PadToSize - FuncSize) & (PadToSize - FuncSize >= 0))
+      // FillValue
+      const MCExpr *SizeConst = MCConstantExpr::create(PadToSize, OutContext);
+      const MCExpr *Zero = MCConstantExpr::create(0, OutContext);
+      const MCExpr *SubExpr =
+          MCBinaryExpr::createSub(SizeConst, SizeExp, OutContext);
+      const MCExpr *Cmp = MCBinaryExpr::createGTE(SubExpr, Zero, OutContext);
+      const MCExpr *FillExpr =
+          MCBinaryExpr::createAnd(SubExpr, Cmp, OutContext);
+      OutStreamer->emitFill(*FillExpr, FillValue);
+    }
   }
 
   // Call endBasicBlockSection on the last block now, if it wasn't already
@@ -3220,7 +3246,8 @@ void AsmPrinter::SetupMachineFunction(MachineFunction &MF) {
   MBBSectionRanges.clear();
   MBBSectionExceptionSyms.clear();
   bool NeedsLocalForSize = MAI->needsLocalForSize();
-  if (F.hasFnAttribute("patchable-function-entry") ||
+  if (F.hasFnAttribute("tail-pad-to-size") ||
+      F.hasFnAttribute("patchable-function-entry") ||
       F.hasFnAttribute("function-instrument") ||
       F.hasFnAttribute("xray-instruction-threshold") ||
       needFuncLabels(MF, *this) || NeedsLocalForSize ||

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -492,6 +492,12 @@ static SectionKind getELFKindForNamedSection(StringRef Name, SectionKind K) {
       Name.starts_with(".llvm.linkonce.tb."))
     return SectionKind::getThreadBSS();
 
+  // TODO: We could avoid a magic name by adding metadata similar to MD_exclude
+  // to the embedded object global, to choose SectionKind::Metadata earlier
+  // without checking the section name (in getKindForGlobal for example).
+  if (Name == ".debug_llvm_dyndbg")
+    return SectionKind::getMetadata();
+
   return K;
 }
 

--- a/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
@@ -1047,6 +1047,14 @@ bool FunctionSpecializer::isCandidateFunction(Function *F) {
   if (F->hasOptSize())
     return false;
 
+  // FIXME: We could disable function specialization in the pass builder
+  // (see IPSCCPOptions). An attribute is easier to test and requires fewer
+  // changes so go with it for now. Another advantage is it can be used
+  // in other passes, though it doesn't seem there are others we need to
+  // suppress in this way with the current implementaiton.
+  if (F->hasFnAttribute("no-func-spec"))
+    return false;
+
   // Do not specialize the cloned function again.
   if (Specializations.contains(F))
     return false;

--- a/llvm/test/CodeGen/X86/attr-tail-pad.ll
+++ b/llvm/test/CodeGen/X86/attr-tail-pad.ll
@@ -1,0 +1,16 @@
+; RUN: llc -mtriple=x86_64-unknown-linux %s -o - | FileCheck %s
+
+;; FIXME: Do we want .size to include the fill?
+
+; CHECK:      a:                                      # @a
+; CHECK:              retq
+; CHECK-NEXT: .Lfunc_end0:
+; CHECK-NEXT:         .size   a, .Lfunc_end0-a
+; CHECK-NEXT:         .zero   (5-(.Lfunc_end0-a))&((5-(.Lfunc_end0-a))>=0),144
+
+define hidden void @a() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "tail-pad-to-size"="5" "tail-pad-value"="144" }

--- a/llvm/test/CodeGen/X86/metadata-section-type.ll
+++ b/llvm/test/CodeGen/X86/metadata-section-type.ll
@@ -1,0 +1,13 @@
+; RUN: llc -mtriple=x86_64-unknown-linux %s -o - | FileCheck %s
+
+; Check that the section '.debug_llvm_dyndbg' is created without flags.
+; FIXME: A more flexible approach would be to add metadata (like !exclude) to
+; signal this, rather than checking for a specific section name.
+
+@llvm.embedded.object = private constant [1 x i8] c"\00", section ".debug_llvm_dyndbg", align 1
+@llvm.compiler.used = appending global [1 x ptr] [ptr @llvm.embedded.object], section "llvm.metadata"
+
+; CHECK: .section .debug_llvm_dyndbg,"",@progbits
+; CHECK-NEXT: .Lllvm.embedded.object:
+; CHECK-NEXT: .zero  1
+; CHECK-NEXT: .size .Lllvm.embedded.object, 1

--- a/llvm/test/Transforms/FunctionSpecialization/attr-no-func-spec.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/attr-no-func-spec.ll
@@ -1,0 +1,37 @@
+; RUN: opt -passes="ipsccp<func-spec>" -funcspec-min-function-size=3 -S < %s \
+; RUN: | FileCheck %s --implicit-check-not=specialized
+
+; Check the attribute "no-func-spec" blocks function specialization. 'do_spec'
+; gets specialized but 'no_spec' which is identical except for the attribute
+; shouldn't (--implicit-check-not) .
+
+; CHECK: %call = tail call i32 @do_spec.specialized.1(i32 noundef 0)
+; CHECK: define internal i32 @do_spec.specialized.1(i32 noundef %a)
+
+declare i32 @ext(i32 noundef)
+
+define hidden i32 @do_spec(i32 noundef %a) {
+entry:
+  %call = tail call i32 @ext(i32 noundef %a)
+  ret i32 %call
+}
+
+define hidden void @a() {
+entry:
+  %call = tail call i32 @do_spec(i32 noundef 0)
+  ret void
+}
+
+define hidden i32 @no_spec(i32 noundef %a) #0 {
+entry:
+  %call = tail call i32 @ext(i32 noundef %a)
+  ret i32 %call
+}
+
+define hidden void @b() {
+entry:
+  %call = tail call i32 @no_spec(i32 noundef 0)
+  ret void
+}
+
+attributes #0 = { "no-func-spec" }


### PR DESCRIPTION
A clone of the module is compiled without optimisations and embedded into the
to-be-optimised module using embedBufferInModule, similarly to how
-ffat-lto-objects and -fembed-offload-object work.

That unoptimised-code object is embedded in the optimised-code object in a
section called .debug_llvm_dyndbg.

The optimised ELF/module may be referred to as the "outer" ELF/module, and the
unoptimized one the "inner" ELF/module.

The outer module holds global data referred to by both modules and all calls in
the inner module are to outer module functions. To facilitate this the outer
module is modified, adding external-linkage aliases for local symbols.

See https://discourse.llvm.org/t/90113 for more detail (including a diagram).

---

The first 3 patches are the changes to LLVM and the 4th patch contains the
Clang changes. `createUnoptModule` does most of the work - it clones and
modifies the module as needed for the feature.

Linker changes in https://github.com/llvm/llvm-project/pull/190939