### PR TITLE
[NFC][SPIR-V] Remove unnecessary 'REQUIRES: asserts' from tests

### DIFF
--- a/llvm/test/CodeGen/SPIRV/GlobalISel/InstCombine/prelegalizercombiner-length-to-distance.mir
+++ b/llvm/test/CodeGen/SPIRV/GlobalISel/InstCombine/prelegalizercombiner-length-to-distance.mir
@@ -1,5 +1,4 @@
 # RUN: llc -verify-machineinstrs -O0 -mtriple spirv-unknown-unknown -run-pass=spirv-prelegalizer-combiner %s -o - | FileCheck %s
-# REQUIRES: asserts
 ---
 name:            distance_instcombine_float4
 tracksRegLiveness: true

--- a/llvm/test/CodeGen/SPIRV/GlobalISel/InstCombine/prelegalizercombiner-select-to-faceforward.mir
+++ b/llvm/test/CodeGen/SPIRV/GlobalISel/InstCombine/prelegalizercombiner-select-to-faceforward.mir
@@ -1,5 +1,4 @@
 # RUN: llc -verify-machineinstrs -O0 -mtriple spirv-vulkan1.3-unknown -run-pass=spirv-prelegalizer-combiner %s -o - | FileCheck %s
-# REQUIRES: asserts
 ---
 name:            faceforward_instcombine_float
 tracksRegLiveness: true

--- a/llvm/test/CodeGen/SPIRV/llc-pipeline.ll
+++ b/llvm/test/CodeGen/SPIRV/llc-pipeline.ll
@@ -7,8 +7,6 @@
 ; RUN:   | FileCheck -match-full-lines -strict-whitespace -check-prefix=SPIRV-Opt %s
 ; RUN:llc -O3 -mtriple=spirv-- -disable-verify -debug-pass=Structure < %s 2>&1 \
 ; RUN:   | FileCheck -match-full-lines -strict-whitespace -check-prefix=SPIRV-Opt %s
-;
-; REQUIRES:asserts
 
 ; SPIRV-O0:Target Library Information
 ; SPIRV-O0-NEXT:Runtime Library Function Analysis

--- a/llvm/test/CodeGen/SPIRV/opencl/device_execution/execute_block.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/device_execution/execute_block.ll
@@ -1,7 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
 
-; REQUIRES: asserts
-
 ; CHECK: %[[#bool:]] = OpTypeBool
 ; CHECK: %[[#true:]] = OpConstantTrue %[[#bool]]
 ; CHECK: OpBranchConditional %[[#true]]


### PR DESCRIPTION
Remove `REQUIRES: asserts` from tests that don't use any assertions-only functionality and should run for all build configurations