### PR TITLE
[lldb] Fix: Disable shared build dir when testing with PDB

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1985,9 +1985,6 @@ class LLDBTestCaseFactory(type):
         if original_testcase.NO_DEBUG_INFO_TESTCASE and not has_variant_tests:
             return original_testcase
 
-        if original_testcase.TEST_WITH_PDB_DEBUG_INFO:
-            original_testcase.SHARED_BUILD_TESTCASE = False
-
         # Default implementation for skip/xfail reason based on the debug category,
         # where "None" means to run the test as usual.
         def no_reason(*args, **kwargs):
@@ -2066,6 +2063,10 @@ class LLDBTestCaseFactory(type):
 
             else:
                 newattrs[attrname] = attrvalue
+
+        if original_testcase.TEST_WITH_PDB_DEBUG_INFO:
+            newattrs["SHARED_BUILD_TESTCASE"] = False
+
         return super(LLDBTestCaseFactory, cls).__new__(cls, name, bases, newattrs)
 
 

--- a/lldb/test/API/symstore/TestSymStore.py
+++ b/lldb/test/API/symstore/TestSymStore.py
@@ -91,7 +91,6 @@ class HTTPServer:
 
 
 class SymStoreTests(TestBase):
-    SHARED_BUILD_TESTCASE = False
     TEST_WITH_PDB_DEBUG_INFO = True
 
     def build_inferior(self):


### PR DESCRIPTION
In a [recent review](https://github.com/llvm/llvm-project/pull/187072#discussion_r2948459704) we found that the mechanism to disable `SHARED_BUILD_TESTCASE` for tests that set `TEST_WITH_PDB_DEBUG_INFO` doesn't work. It turns out that the object where we set the property in line 1989 is just a local variable. What we use eventually is the object that is newly constructed from the `newattrs` dict in the return statement of the `LLDBTestCaseFactory` metaclass constructor. This is where we have to set `SHARED_BUILD_TESTCASE` in order to take effect. I moved the assignment after the for-loop, because in line 1989 the dict doesn't exist yet.