### PR TITLE
[Hexagon] Add missing MIRParser link dependency

### DIFF
--- a/llvm/lib/Target/Hexagon/CMakeLists.txt
+++ b/llvm/lib/Target/Hexagon/CMakeLists.txt
@@ -89,6 +89,7 @@ add_llvm_target(HexagonCodeGen
   HexagonInfo
   IPO
   MC
+  MIRParser
   Scalar
   SelectionDAG
   Support


### PR DESCRIPTION
cd66d79be19b added parseMachineFunctionInfo to HexagonTargetMachine which calls parseNamedRegisterReference from LLVMMIRParser, but did not add the library dependency. This causes link failures for executables like dsymutil and llvm-split when building with BUILD_SHARED_LIBS=OFF.

Add MIRParser to LINK_COMPONENTS.