### PR TITLE
[clang-doc][NFC] Delete redundant lines in JSONGenerator

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -772,12 +772,6 @@ void JSONGenerator::serializeInfo(const NamespaceInfo &I, json::Object &Obj) {
   if (I.USR == GlobalNamespaceID)
     Obj["Name"] = "Global Namespace";
 
-  if (!I.Children.Namespaces.empty()) {
-    serializeArray(I.Children.Namespaces, Obj, "Namespaces",
-                   serializeReferenceLambda());
-    Obj["HasNamespaces"] = true;
-  }
-
   if (!I.Children.Functions.empty()) {
     serializeArray(I.Children.Functions, Obj, "Functions",
                    serializeInfoLambda());

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -460,8 +460,6 @@ void JSONGenerator::serializeMDReference(const Reference &Ref,
   ReferenceObj["BasePath"] = Path;
 }
 
-typedef std::function<void(const Reference &, Object &)> ReferenceFunc;
-
 // Although namespaces and records both have ScopeChildren, they serialize them
 // differently. Only enums, records, and typedefs are handled here.
 void JSONGenerator::serializeCommonChildren(


### PR DESCRIPTION
During the merging for the Mustache MD backend, I forgot to delete the
earlier, obsolete serialization for namespaces. It's being overwritten
by the correct call later. Also deletes a duplicate typedef.