### PR TITLE
[Hexagon] Fix link error with BUILD_SHARED_LIBS=ON

### DIFF
--- a/llvm/lib/Target/Hexagon/CMakeLists.txt
+++ b/llvm/lib/Target/Hexagon/CMakeLists.txt
@@ -89,6 +89,7 @@ add_llvm_target(HexagonCodeGen
   HexagonInfo
   IPO
   MC
+  MIRParser
   Scalar
   SelectionDAG
   Support


### PR DESCRIPTION
/usr/bin/ld: lib/Target/Hexagon/CMakeFiles/LLVMHexagonCodeGen.dir/Hexago nTargetMachine.cpp.o: in function `llvm::HexagonTargetMachine::parseMach ineFunctionInfo(llvm::yaml::MachineFunctionInfo const&, llvm::PerFunctio nMIParsingState&, llvm::SMDiagnostic&, llvm::SMRange&) const': HexagonTargetMachine.cpp:(.text._ZNK4llvm20HexagonTargetMachine24parseMa chineFunctionInfoERKNS_4yaml19MachineFunctionInfoERNS_25PerFunctionMIPar singStateERNS_12SMDiagnosticERNS_7SMRangeE+0x4a): undefined reference to
 `llvm::parseNamedRegisterReference(llvm::PerFunctionMIParsingState&, ll
vm::Register&, llvm::StringRef, llvm::SMDiagnostic&)' clang++: error: linker command failed with exit code 1 (use -v to see in vocation)