### PR TITLE
[RISCV] Remove NoVendorXMIPSCBOP from the Zicbop instructions.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZicbo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZicbo.td
@@ -62,7 +62,7 @@ let Predicates = [HasStdExtZicbop] in {
 def PREFETCH_I : Prefetch_ri<0b00000, "prefetch.i">, Sched<[]>;
 def PREFETCH_R : Prefetch_ri<0b00001, "prefetch.r">, Sched<[]>;
 def PREFETCH_W : Prefetch_ri<0b00011, "prefetch.w">, Sched<[]>;
-} // Predicates = [HasStdExtZicbop, NoVendorXMIPSCBOP]
+} // Predicates = [HasStdExtZicbop]
 
 //===----------------------------------------------------------------------===//
 // Patterns

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZicbo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZicbo.td
@@ -58,7 +58,7 @@ let Predicates = [HasStdExtZicboz] in {
 def CBO_ZERO : CBO_r<0b000000000100, "cbo.zero">, Sched<[]>;
 } // Predicates = [HasStdExtZicboz]
 
-let Predicates = [HasStdExtZicbop, NoVendorXMIPSCBOP] in {
+let Predicates = [HasStdExtZicbop] in {
 def PREFETCH_I : Prefetch_ri<0b00000, "prefetch.i">, Sched<[]>;
 def PREFETCH_R : Prefetch_ri<0b00001, "prefetch.r">, Sched<[]>;
 def PREFETCH_W : Prefetch_ri<0b00011, "prefetch.w">, Sched<[]>;


### PR DESCRIPTION
The XMIPSCBOP encodings use OP-CUSTOM-0 so there's no encoding overlap here. Presence of a vendor extension should not disable parsing or disassembly of a standard extension that doesn't overlap.