### PR TITLE
[lldb] Disable TestTsan{CPP}GlobalLocation.py on Linux

### DIFF
--- a/lldb/test/API/functionalities/tsan/cpp_global_location/TestTsanCPPGlobalLocation.py
+++ b/lldb/test/API/functionalities/tsan/cpp_global_location/TestTsanCPPGlobalLocation.py
@@ -11,6 +11,7 @@ import json
 
 class TsanCPPGlobalLocationTestCase(TestBase):
     @expectedFailureNetBSD
+    @skipIfLinux  # https://github.com/llvm/llvm-project/issues/191012
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @skipIfRemote
     @skipUnlessThreadSanitizer

--- a/lldb/test/API/functionalities/tsan/global_location/TestTsanGlobalLocation.py
+++ b/lldb/test/API/functionalities/tsan/global_location/TestTsanGlobalLocation.py
@@ -11,6 +11,7 @@ import json
 
 class TsanGlobalLocationTestCase(TestBase):
     @expectedFailureNetBSD
+    @skipIfLinux  # https://github.com/llvm/llvm-project/issues/191012
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @skipIfRemote
     @skipUnlessThreadSanitizer


### PR DESCRIPTION
Skip `TestTsanGlobalLocation.py` and `TestTsanCPPGlobalLocation.py` on Linux. The tests are failing on GreenDragon and at desk.

Tracked by https://github.com/llvm/llvm-project/issues/191012