### PR TITLE
[MLIR][XeGPU] Add uArch defintion for CRI - Crescent Island

### DIFF
--- a/mlir/include/mlir/Dialect/XeGPU/uArch/IntelGpuXe2.h
+++ b/mlir/include/mlir/Dialect/XeGPU/uArch/IntelGpuXe2.h
@@ -279,11 +279,41 @@ struct BMGuArch : public Xe2Plus {
   }
 };
 
+struct CRIuArch : public Xe2Plus {
+  static llvm::ArrayRef<const Instruction *> getInstructionRegistryArr() {
+    static const SubgroupMatrixMultiplyAcc dpasInst{16, 32};
+    static const Subgroup2DBlockLoadInstruction loadNdInst;
+    static const Subgroup2DBlockStoreInstruction storeNdInst;
+    static const Subgroup2DBlockPrefetchInstruction prefetchNdInst;
+    static const SpirvStoreScatterInstruction storeScatterInst;
+    static const SpirvLoadGatherInstruction loadGatherInst;
+    static const Instruction *arr[] = {&dpasInst,         &loadNdInst,
+                                       &storeNdInst,      &prefetchNdInst,
+                                       &storeScatterInst, &loadGatherInst};
+    return arr;
+  }
+
+  CRIuArch()
+      : Xe2Plus("cri",                     // archName
+                "Crescent Island Architecture", // archDescription
+                getInstructionRegistryArr(),
+                // Using bmg config as placeholder
+                // TODO: Update to actual XeCore and SharedMemory config
+                XeCoreInfo(8, SharedMemory(256 * 1024, 4), 8, 8) // xeCore
+        ) {}
+  static const uArch *getInstance() {
+    static const CRIuArch instance;
+    return reinterpret_cast<const uArch *>(&instance);
+  }
+};
+
 inline const uArch *getUArch(llvm::StringRef archName) {
   if (archName.equals_insensitive("pvc"))
     return PVCuArch::getInstance();
   if (archName.equals_insensitive("bmg"))
     return BMGuArch::getInstance();
+  if (archName.equals_insensitive("cri"))
+    return CRIuArch::getInstance();
   return nullptr;
 }
 

--- a/mlir/include/mlir/Dialect/XeGPU/uArch/IntelGpuXe2.h
+++ b/mlir/include/mlir/Dialect/XeGPU/uArch/IntelGpuXe2.h
@@ -294,7 +294,7 @@ struct CRIuArch : public Xe2Plus {
   }
 
   CRIuArch()
-      : Xe2Plus("cri",                     // archName
+      : Xe2Plus("cri",                          // archName
                 "Crescent Island Architecture", // archDescription
                 getInstructionRegistryArr(),
                 // Using bmg config as placeholder


### PR DESCRIPTION
XeGPU lowering relies on uArch definition and lowering fails if a chip does not have uArch definition entry.
Add preliminary uArch definition for CRI.
This is a place holder for now and current defintion is identical to BMG.