### PR TITLE
[lldb/test] Add yield to spin loop in thread_filter test

### DIFF
--- a/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/main.cpp
+++ b/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/main.cpp
@@ -12,7 +12,7 @@ void thread_work() {
   while (g_barrier.load() > 0)
     ;
   while (g_spin) // break in thread
-    ;
+    std::this_thread::yield();
 }
 
 int main() {


### PR DESCRIPTION
This should fix: https://lab.llvm.org/buildbot/#/builders/211/builds/7439

The timeout might be caused by three threads busy-spinning at 100% CPU, starving the CI machine.

Add std::this_thread::yield() to the spin loop to reduce CPU pressure while keeping threads alive at a debugger-friendly location.