### PR TITLE
[AMDGPU] Propagate demanded bits through RET_GLUE in performDAGCombine

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -5560,6 +5560,28 @@ bool AMDGPUTargetLowering::isInt64ImmLegal(SDNode *N, SelectionDAG &DAG) const {
   return isUInt<32>(Val.getZExtValue()) || TII->isInlineConstant(Val);
 }
 
+SDValue
+AMDGPUTargetLowering::performRetGlueCombine(SDNode *N,
+                                            DAGCombinerInfo &DCI) const {
+  Type *RetTy = DCI.DAG.getMachineFunction().getFunction().getReturnType();
+  if (RetTy->isVoidTy() || !RetTy->isIntegerTy())
+    return SDValue();
+
+  const TargetLowering &TLI = DCI.DAG.getTargetLoweringInfo();
+  TargetLoweringOpt TLO(DCI.DAG, !DCI.isBeforeLegalize(),
+                        !DCI.isBeforeLegalizeOps());
+  unsigned DemandedBitsVal = RetTy->getScalarSizeInBits();
+
+  APInt DemandedBits = APInt::getAllOnes(DemandedBitsVal);
+  SDValue Op = N->getOperand(0);
+  if (Op.getOpcode() == ISD::CopyToReg &&
+      Op.getOperand(2).getOpcode() == ISD::ANY_EXTEND) {
+    Op = Op.getOperand(2).getOperand(0);
+    TLI.SimplifyDemandedBits(Op, DemandedBits, DCI);
+  }
+  return SDValue();
+}
+
 SDValue AMDGPUTargetLowering::PerformDAGCombine(SDNode *N,
                                                 DAGCombinerInfo &DCI) const {
   SelectionDAG &DAG = DCI.DAG;
@@ -5772,6 +5794,8 @@ SDValue AMDGPUTargetLowering::PerformDAGCombine(SDNode *N,
     return performAssertSZExtCombine(N, DCI);
   case ISD::INTRINSIC_WO_CHAIN:
     return performIntrinsicWOChainCombine(N, DCI);
+  case AMDGPUISD::RET_GLUE:
+    return performRetGlueCombine(N, DCI);
   case AMDGPUISD::FMAD_FTZ: {
     SDValue N0 = N->getOperand(0);
     SDValue N1 = N->getOperand(1);

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.h
@@ -128,6 +128,7 @@ protected:
   SDValue performMulLoHiCombine(SDNode *N, DAGCombinerInfo &DCI) const;
   SDValue performMulhsCombine(SDNode *N, DAGCombinerInfo &DCI) const;
   SDValue performMulhuCombine(SDNode *N, DAGCombinerInfo &DCI) const;
+  SDValue performRetGlueCombine(SDNode *N, DAGCombinerInfo &DCI) const;
   SDValue performCtlz_CttzCombine(const SDLoc &SL, SDValue Cond, SDValue LHS,
                              SDValue RHS, DAGCombinerInfo &DCI) const;
 

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-demanded-bits-for-target-node.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-demanded-bits-for-target-node.ll
@@ -33,6 +33,19 @@ define void @readfirstlane_demanded_i8_sext_store(i8 %src, ptr addrspace(1) %ptr
   ret void
 }
 
+define i8 @readfirstlane_demanded_i8_sext_ret(i8 %src) nounwind {
+; GCN-LABEL: readfirstlane_demanded_i8_sext_ret:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GCN-NEXT:    v_readfirstlane_b32 s4, v0
+; GCN-NEXT:    v_mov_b32_e32 v0, s4
+; GCN-NEXT:    s_setpc_b64 s[30:31]
+  %sext = sext i8 %src to i32
+  %readfirstlane = call i32 @llvm.amdgcn.readfirstlane.i32(i32 %sext)
+  %trunc = trunc i32 %readfirstlane to i8
+  ret i8 %trunc
+}
+
 define i16 @readfirstlane_demanded_i16_zext(i16 %src) nounwind {
 ; GCN-LABEL: readfirstlane_demanded_i16_zext:
 ; GCN:       ; %bb.0:
@@ -89,6 +102,19 @@ define void @readlane_demanded_i8_sext_store(i8 %src, ptr addrspace(1) %ptr) nou
   %trunc = trunc i32 %readlane to i8
   store i8 %trunc, ptr addrspace(1) %ptr
   ret void
+}
+
+define i8 @readlane_demanded_i8_sext_ret(i8 %src) nounwind {
+; GCN-LABEL: readlane_demanded_i8_sext_ret:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GCN-NEXT:    v_readlane_b32 s4, v0, 0
+; GCN-NEXT:    v_mov_b32_e32 v0, s4
+; GCN-NEXT:    s_setpc_b64 s[30:31]
+  %sext = sext i8 %src to i32
+  %readlane = call i32 @llvm.amdgcn.readlane.i32(i32 %sext, i32 0)
+  %trunc = trunc i32 %readlane to i8
+  ret i8 %trunc
 }
 
 define i16 @readlane_demanded_i16_zext(i16 %src) nounwind {
@@ -165,6 +191,28 @@ define void @wwm_demanded_i8_sext_store(i8 %src, ptr addrspace(1) %ptr) nounwind
   ret void
 }
 
+define i8 @wwm_demanded_i8_sext_ret(i8 %src) nounwind {
+; GCN-LABEL: wwm_demanded_i8_sext_ret:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GCN-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GCN-NEXT:    buffer_store_dword v1, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-NEXT:    s_mov_b64 exec, s[4:5]
+; GCN-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GCN-NEXT:    v_mov_b32_e32 v1, v0
+; GCN-NEXT:    s_mov_b64 exec, s[4:5]
+; GCN-NEXT:    v_mov_b32_e32 v0, v1
+; GCN-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GCN-NEXT:    buffer_load_dword v1, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-NEXT:    s_mov_b64 exec, s[4:5]
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    s_setpc_b64 s[30:31]
+  %sext = sext i8 %src to i32
+  %wwm = call i32 @llvm.amdgcn.wwm(i32 %sext)
+  %trunc = trunc i32 %wwm to i8
+  ret i8 %trunc
+}
+
 define i16 @wwm_demanded_i16_zext(i16 %src) nounwind {
 ; GCN-LABEL: wwm_demanded_i16_zext:
 ; GCN:       ; %bb.0:
@@ -237,6 +285,18 @@ define void @set.inactive_demanded_i8_sext_store(i8 %src, ptr addrspace(1) %ptr)
   %trunc = trunc i32 %set.inactive to i8
   store i8 %trunc, ptr addrspace(1) %ptr
   ret void
+}
+
+define i8 @set.inactive_demanded_i8_sext_ret(i8 %src) nounwind {
+; GCN-LABEL: set.inactive_demanded_i8_sext_ret:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    ; kill: def $vgpr0 killed $vgpr0 killed $exec
+; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GCN-NEXT:    s_setpc_b64 s[30:31]
+  %sext = sext i8 %src to i32
+  %set.inactive = call i32 @llvm.amdgcn.set.inactive.i32(i32 %sext, i32 0)
+  %trunc = trunc i32 %set.inactive to i8
+  ret i8 %trunc
 }
 
 define i16 @set.inactive_demanded_i16_zext(i16 %src) nounwind {


### PR DESCRIPTION
Generic combines transform trunc i8 to trunc i16 before ISD::INTRINSIC_WO_CHAIN is reached when the value is used in return, so SimplifyDemandedBits cannot eliminate trunc in this case. 

This adds a SimplifyDemandedBits call in RET_GLUE case of performDAGCombine to handle this pattern.

Partially addresses https://github.com/llvm/llvm-project/issues/128390.

