### PR TITLE
[libc] - Add rpc_opcodes.h to list of installed headers

### DIFF
--- a/libc/shared/CMakeLists.txt
+++ b/libc/shared/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_LIBC_SHARED_RPC_EXPORT_HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/rpc_util.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/rpc_dispatch.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/rpc_server.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/rpc_opcodes.h"
 )
 
 # Install the freestanding RPC interface to the compiler tree.


### PR DESCRIPTION
There is a case when building standalone offload via runtimes where LLVM_BINARY_DIR is set to the installed llvm location. Currently, this header is not being installed and results in a build failure.

Fixes issue introduced with #190423.