### PR TITLE
[mlir][docs]  Clarity docs of mlir::Value

### DIFF
--- a/mlir/include/mlir/IR/Value.h
+++ b/mlir/include/mlir/IR/Value.h
@@ -86,13 +86,13 @@ protected:
 
 /// This class represents an instance of an SSA value in the MLIR system,
 /// representing a computable value that has a type and a set of users. An SSA
-/// value is either a BlockArgument or the result of an operation. Note: This
-/// class has value-type semantics and is just a simple wrapper around a
-/// ValueImpl that is either owner by a block(in the case of a BlockArgument) or
-/// an Operation(in the case of an OpResult).
-/// As most IR constructs, this isn't const-correct, but we keep method
-/// consistent and as such method that immediately modify this Value aren't
-/// marked `const` (include modifying the Value use-list).
+/// value is either a BlockArgument or the result of an operation.
+/// Note: This class has value-type semantics and is just a simple wrapper
+/// around a ValueImpl that is either owned by a block (in the case of a
+/// BlockArgument) or an Operation (in the case of an OpResult).
+/// As most IR constructs, this isn't const-correct, but we keep the method
+/// consistent, and therefore methods that immediately modify this Value aren't
+/// marked `const` (including modifying the Value's use-list).
 class Value {
 public:
   constexpr Value(detail::ValueImpl *impl = nullptr) : impl(impl) {}


### PR DESCRIPTION
Change phrasing of the docs preceeding `mlir::Value`, to more precisely express the relation of "owned by a block" and "methods that modify this Value"