### PR TITLE
[lldb] Fix the TestFrameProviderThreadFilter test on Windows

### DIFF
--- a/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/TestFrameProviderThreadFilter.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/TestFrameProviderThreadFilter.py
@@ -59,7 +59,6 @@ class FrameProviderThreadFilterTestCase(TestBase):
             )
             self.assertTrue(error.Success(), f"Should register {cls}: {error}")
 
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
     def test_bt_provider_star_with_thread_filter(self):
         """
         Register EvenThreadProvider, OddThreadProvider, and UpperCaseProvider.

--- a/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/main.cpp
+++ b/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/main.cpp
@@ -1,4 +1,5 @@
 #include <atomic>
+#include <chrono>
 #include <thread>
 #include <vector>
 
@@ -11,6 +12,8 @@ void thread_work() {
   --g_barrier;
   while (g_barrier.load() > 0)
     ;
+  std::this_thread::sleep_for(
+      std::chrono::seconds(1)); // avoid timeout on Windows
   while (g_spin) // break in thread
     std::this_thread::yield();
 }


### PR DESCRIPTION
This is the update for #191025.