### PR TITLE
[analyzer] Fix crash in CStringChecker on zero-size element types

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
@@ -507,12 +507,12 @@ ProgramStateRef CStringChecker::checkInit(CheckerContext &C,
                       IdxTy)
           .getAs<NonLoc>();
 
+  if (!Offset)
+    return State;
+
   // Retrieve the index of the last element.
   const NonLoc One = SVB.makeIntVal(1, IdxTy).castAs<NonLoc>();
   SVal LastIdx = SVB.evalBinOpNN(State, BO_Sub, *Offset, One, IdxTy);
-
-  if (!Offset)
-    return State;
 
   SVal LastElementVal =
       State->getLValue(ElemTy, LastIdx, loc::MemRegionVal(SuperR));

--- a/clang/test/Analysis/bstring.c
+++ b/clang/test/Analysis/bstring.c
@@ -532,9 +532,15 @@ void nocrash_on_locint_offset(void *addr, void* from, struct S s) {
 }
 
 // PR#190457 - Crash on memcpy with zero-size element type (empty struct).
+// In the GNU C extension, empty structs have sizeof == 0, which caused a
+// division by zero in checkInit. On MSVC targets, even in C mode, empty
+// structs have nonzero sizeof (due to ABI requirements), so the overflow
+// warnings don't fire there.
 void nocrash_on_empty_struct_memcpy(void) {
   struct {} a[10];
-  __builtin_memcpy(&a[2], a, 2); // should not crash
-  // expected-warning@-1 {{'memcpy' will always overflow; destination buffer has size 0, but size argument is 2}}
-  // expected-warning@-2 {{Memory copy function overflows the destination buffer}}
+  __builtin_memcpy(&a[2], a, 2); // no-crash
+#if !defined(_WIN32)
+  // expected-warning@-2 {{'memcpy' will always overflow; destination buffer has size 0, but size argument is 2}}
+  // expected-warning@-3 {{Memory copy function overflows the destination buffer}}
+#endif
 }

--- a/clang/test/Analysis/bstring.c
+++ b/clang/test/Analysis/bstring.c
@@ -530,3 +530,11 @@ void nocrash_on_locint_offset(void *addr, void* from, struct S s) {
   size_t iAdd = (size_t) addr;
   memcpy(((void *) &(s.f)), from, iAdd);
 }
+
+// PR#190457 - Crash on memcpy with zero-size element type (empty struct).
+void nocrash_on_empty_struct_memcpy(void) {
+  struct {} a[10];
+  __builtin_memcpy(&a[2], a, 2); // should not crash
+  // expected-warning@-1 {{'memcpy' will always overflow; destination buffer has size 0, but size argument is 2}}
+  // expected-warning@-2 {{Memory copy function overflows the destination buffer}}
+}

--- a/clang/test/Analysis/bstring.cpp
+++ b/clang/test/Analysis/bstring.cpp
@@ -249,9 +249,9 @@ void memmove_uninit_without_outofbound() {
                                   // uninit-note@-1{{Other elements might also be undefined}}
 }
 
-// related to PR#190457 - In C++ empty structs have 'sizeof' of 1, so this
-// should not crash and should not warn about overflow (unlike the C case
-// where sizeof(struct{}) is 0).
+// #190457 - In C++ the sizeof of an empty struct is 1, so this should not
+// crash and should not warn about overflow (unlike the C case where it is 0
+// with the GNU extension).
 void nocrash_on_empty_struct_memcpy_cpp() {
   struct {} a[10];
   __builtin_memcpy(&a[2], a, 2); // should not crash

--- a/clang/test/Analysis/bstring.cpp
+++ b/clang/test/Analysis/bstring.cpp
@@ -248,3 +248,12 @@ void memmove_uninit_without_outofbound() {
   memmove(dst, src, sizeof(src)); // uninit-warning{{The first element of the 2nd argument is undefined}}
                                   // uninit-note@-1{{Other elements might also be undefined}}
 }
+
+// related to PR#190457 - In C++ empty structs have 'sizeof' of 1, so this
+// should not crash and should not warn about overflow (unlike the C case
+// where sizeof(struct{}) is 0).
+void nocrash_on_empty_struct_memcpy_cpp() {
+  struct {} a[10];
+  __builtin_memcpy(&a[2], a, 2); // should not crash
+  // no-warning
+}


### PR DESCRIPTION
Move the null check of Offset before its dereference in checkInit. When the element type has zero size (e.g., an empty struct in C), the division returns an empty optional, which was dereferenced unconditionally.

Fixes #190457