### PR TITLE
[libc][MacOS] Enable wchar conversion and rpc_server

### DIFF
--- a/libc/hdr/types/char32_t.h
+++ b/libc/hdr/types/char32_t.h
@@ -15,8 +15,13 @@
 
 #else // overlay mode
 
+// MacOS doesn't provide uchar.h so we use the types provided by LLVM-libc.
+#ifdef __APPLE__
+#include "include/llvm-libc-types/char32_t.h"
+#else
 #include "hdr/uchar_overlay.h"
+#endif
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_CHAR32_T_H

--- a/libc/shared/rpc_server.h
+++ b/libc/shared/rpc_server.h
@@ -20,6 +20,10 @@
 #define flockfile _lock_file
 #define funlockfile _unlock_file
 #define fwrite_unlocked _fwrite_nolock
+#elif defined(__APPLE__)
+// MacOS doesn't have an equivalent of fwrite_unlocked so we just use
+// fwrite.
+#define fwrite_unlocked fwrite
 #endif
 
 namespace rpc {

--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -452,12 +452,8 @@ add_subdirectory(fixed_point)
 
 add_subdirectory(time)
 
-# Requires access to uchar header which is not on macos
-# Therefore, cannot currently build this on macos in overlay mode
-if(NOT (LIBC_TARGET_OS_IS_DARWIN))
-  add_subdirectory(wchar)
-  add_subdirectory(wctype)
-endif()
+add_subdirectory(wchar)
+add_subdirectory(wctype)
 
 add_subdirectory(math)
 if(LIBC_COMPILER_HAS_EXT_VECTOR_TYPE)

--- a/libc/test/src/__support/CMakeLists.txt
+++ b/libc/test/src/__support/CMakeLists.txt
@@ -311,9 +311,5 @@ add_subdirectory(fixed_point)
 add_subdirectory(HashTable)
 add_subdirectory(time)
 add_subdirectory(threads)
-# Requires access to uchar header which is not on MacOS
-# Cannot currently build this on MacOS in overlay mode
-if(NOT(LIBC_TARGET_OS_IS_DARWIN))
-  add_subdirectory(wchar)
-  add_subdirectory(wctype)
-endif()
+add_subdirectory(wchar)
+add_subdirectory(wctype)


### PR DESCRIPTION
Originally the wchar conversion was disabled due to MacOS not providing
uchar.h. We only needed it for char32_t so this PR just provides it
directly from our headers on MacOS. This also fixes fwrite_unlocked not
being available on MacOS which is needed for rpc_server.h.
