### PR TITLE
[libc] Add a redirecting <syscall.h> header.

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -52,6 +52,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_un
     libc.include.sys_utsname
     libc.include.sys_wait
+    libc.include.syscall
     libc.include.sysexits
     libc.include.termios
     libc.include.threads

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -51,6 +51,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_types
     libc.include.sys_utsname
     libc.include.sys_wait
+    libc.include.syscall
     libc.include.sysexits
     libc.include.termios
     libc.include.threads

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -55,6 +55,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_un
     libc.include.sys_utsname
     libc.include.sys_wait
+    libc.include.syscall
     libc.include.sysexits
     libc.include.termios
     libc.include.threads

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -180,6 +180,11 @@ add_header_macro(
     .llvm-libc-types.uint_ur_t
 )
 
+add_header(
+  syscall
+  HDR
+    syscall.h
+)
 
 add_header_macro(
   sysexits

--- a/libc/include/syscall.h
+++ b/libc/include/syscall.h
@@ -1,0 +1,1 @@
+#include <sys/syscall.h>


### PR DESCRIPTION
The amount of legacy code including `<syscall.h>` header instead of `<sys/syscall.h>` (which is the regular header location on Linux systems) out there is large.

Add a simple one-liner redirecting header to fix this compatibility issues. In this PR I omit the regular licensing blurb at the top, given the transient nature of this file, but I'm happy to add this if needed. Also, given that it's effectively a compatibility shim, YAML generation is not used.