### PR TITLE
[clang][test] Modernize 2004-02-13-Memset.c to use FileCheck

### DIFF
--- a/clang/test/CodeGen/2004-02-13-Memset.c
+++ b/clang/test/CodeGen/2004-02-13-Memset.c
@@ -1,12 +1,12 @@
-// RUN: %clang_cc1  %s -emit-llvm -o - | grep llvm.memset | count 3
+// RUN: %clang_cc1  %s -emit-llvm -o - | FileCheck %s
 
 typedef __SIZE_TYPE__ size_t;
 void *memset(void*, int, size_t);
 void bzero(void*, size_t);
 
 void test(int* X, char *Y) {
-  // CHECK: call ptr llvm.memset
+  // CHECK: call void @llvm.memset{{.*}}i8 4, i64 1000
   memset(X, 4, 1000);
-  // CHECK: call void bzero
+  // CHECK: call void @llvm.memset{{.*}}i8 0, i64 100
   bzero(Y, 100);
 }


### PR DESCRIPTION
Replace `grep | count` verification with `FileCheck` and update `CHECK` directives with current codegen output.