### PR TITLE
[LLD][AArch64] Handle R_AARCH64_TLS_DTPREL64 in non-alloc sections

### DIFF
--- a/lld/ELF/Arch/AArch64.cpp
+++ b/lld/ELF/Arch/AArch64.cpp
@@ -237,6 +237,8 @@ RelExpr AArch64::getRelExpr(RelType type, const Symbol &s,
   case R_AARCH64_GOTPCREL32:
   case R_AARCH64_GOT_LD_PREL19:
     return R_GOT_PC;
+  case R_AARCH64_TLS_DTPREL64:
+    return R_DTPREL;
   case R_AARCH64_NONE:
     return R_NONE;
   default:
@@ -543,6 +545,9 @@ void AArch64::relocate(uint8_t *loc, const Relocation &rel,
     // encode the schema.
     checkInt(ctx, loc, val, 32, rel);
     write32(ctx, loc, val);
+    break;
+  case R_AARCH64_TLS_DTPREL64:
+    write64(ctx, loc, val);
     break;
   case R_AARCH64_ADD_ABS_LO12_NC:
   case R_AARCH64_AUTH_GOT_ADD_LO12_NC:

--- a/lld/test/ELF/aarch64-tls-dtprel.s
+++ b/lld/test/ELF/aarch64-tls-dtprel.s
@@ -1,0 +1,23 @@
+# REQUIRES: aarch64
+# RUN: llvm-mc -filetype=obj -triple=aarch64 %s -o %t.o
+# RUN: llvm-readobj -r %t.o | FileCheck %s
+# RUN: ld.lld %t.o -o %t
+
+# CHECK:      .rela.debug_info {
+# CHECK-NEXT:   0x0 R_AARCH64_TLS_DTPREL64 var 0x0
+# CHECK-NEXT:   0x8 R_AARCH64_TLS_DTPREL64 var 0x1
+# CHECK-NEXT:   0x10 R_AARCH64_TLS_DTPREL64 .tdata 0x0
+# CHECK-NEXT:   0x18 R_AARCH64_TLS_DTPREL64 .tdata 0x1
+# CHECK-NEXT: }
+
+.section .tdata,"awT",@progbits
+.skip 8
+.globl var
+var:
+  .word 0
+
+.section        .debug_info,"",@progbits
+  .xword  %dtprel(var)
+  .xword  %dtprel(var+1)
+  .xword  %dtprel(.tdata)
+  .xword  %dtprel(.tdata+1)


### PR DESCRIPTION
Clang plan to emit R_AARCH64_TLS_DTPREL64 in .debug_info (see PR

This prevent the debugger from correctly locating TLS variables when using the DWARF DW_OP_GNU_push_tls_address or DW_AT_location with DTPREL offsets.

This patch adds support for R_AARCH64_TLS_DTPREL64, adds its mapping to R_DTPREL.

(cherry picked from commit https://github.com/llvm/llvm-project/commit/14ce208a45eb0673f8b28409eec0628ad809923b)