### PR TITLE
[llvm-dwarfdump] Support R_AARCH64_TLS_DTPREL64 in Object/RelocationResolver.cpp (#187649)

### DIFF
--- a/llvm/lib/Object/RelocationResolver.cpp
+++ b/llvm/lib/Object/RelocationResolver.cpp
@@ -79,6 +79,7 @@ static bool supportsAArch64(uint64_t Type) {
   case ELF::R_AARCH64_PREL16:
   case ELF::R_AARCH64_PREL32:
   case ELF::R_AARCH64_PREL64:
+  case ELF::R_AARCH64_TLS_DTPREL64:
     return true;
   default:
     return false;
@@ -91,6 +92,7 @@ static uint64_t resolveAArch64(uint64_t Type, uint64_t Offset, uint64_t S,
   case ELF::R_AARCH64_ABS32:
     return (S + Addend) & 0xFFFFFFFF;
   case ELF::R_AARCH64_ABS64:
+  case ELF::R_AARCH64_TLS_DTPREL64:
     return S + Addend;
   case ELF::R_AARCH64_PREL16:
     return (S + Addend - Offset) & 0xFFFF;

--- a/llvm/test/DebugInfo/AArch64/tls-at-location.ll
+++ b/llvm/test/DebugInfo/AArch64/tls-at-location.ll
@@ -1,8 +1,33 @@
-; RUN: llc -filetype=obj -mtriple=aarch64--linux-gnu -o - %s | llvm-dwarfdump -v - | FileCheck %s
-;
-; CHECK: .debug_info contents:
-; CHECK: DW_TAG_variable
-; CHECK-NOT: DW_AT_location
+; RUN: llc -O0 -mtriple=aarch64 --aarch64-emit-debug-tls-location -filetype=obj < %s \
+; RUN:     | llvm-dwarfdump - 2>&1 | FileCheck %s --check-prefix=TLS --implicit-check-not=warning:
+
+; RUN: llc -O0 -mtriple=aarch64 --aarch64-emit-debug-tls-location=false -filetype=obj < %s \
+; RUN:     | llvm-dwarfdump - | FileCheck %s --check-prefix=NO-TLS
+
+; RUN: llc -O0 -mtriple=aarch64 -filetype=obj < %s \
+; RUN:     | llvm-dwarfdump - | FileCheck %s --check-prefix=NO-TLS
+
+; RUN: llc -O0 -mtriple=aarch64 --aarch64-emit-debug-tls-location -filetype=obj < %s -o %t
+; RUN: llvm-objdump -r %t | FileCheck %s --check-prefix=OBJDUMP
+; RUN: llvm-readelf -r %t | FileCheck %s --check-prefix=RELOC
+
+; TLS: .debug_info contents:
+; TLS:  DW_TAG_variable
+; TLS-NEXT:   DW_AT_name      ("var")
+; TLS-NEXT:   DW_AT_type      (0x{{.*}} "int")
+; TLS-NEXT:   DW_AT_external  (true)
+; TLS-NEXT:   DW_AT_decl_file ("{{.*}}tls-at-location.c")
+; TLS-NEXT:   DW_AT_decl_line (1)
+; TLS-NEXT:   DW_AT_location  (DW_OP_const8u 0x0, DW_OP_GNU_push_tls_address)
+
+; NO-TLS: .debug_info contents:
+; NO-TLS: DW_TAG_variable
+; NO-TLS-NEXT:  DW_AT_name	("var")
+; NO-TLS-NOT:   DW_AT_location
+
+; OBJDUMP: R_AARCH64_TLS_DTPREL64   var
+
+; RELOC: R_AARCH64_TLS_DTPREL64 {{0+}} var + 0
 
 @var = thread_local global i32 0, align 4, !dbg !0
 


### PR DESCRIPTION


In patch https://github.com/llvm/llvm-project/pull/146572 we have plan to emit R_AARCH64_TLS_DTPREL64. This give us the warning while using llvm-dwarfdump for the object file which has tls variables -

warning: failed to compute relocation: R_AARCH64_TLS_DTPREL64, Invalid data was encountered while parsing the file

To fix this warning we have mark the relocation as supported however final absolute address of a TLS variable is determined at runtime, resolving to the symbol's section-relative offset in the object file is mitigate the warning.

(cherry picked from commit fa136df3e74c1fd0b838352484aa38c471d21cbd)