### PR TITLE
[orc-rt] Add ScheduleShutdownFromOnDetachHandler unit test.

### DIFF
--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -357,6 +357,30 @@ TEST(SessionTest, MultipleServices) {
   }
 }
 
+TEST(SessionTest, ScheduleShutdownFromOnDetachHandler) {
+  // Check that when we schedule a shutdown from an onDetach handler:
+  // 1. The shutdown is scheduled.
+  // 2. All onDetach handlers run before any onShutdown handlers.
+
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            noErrors);
+
+  int OnDetachHandlersRun = 0;
+  bool OnShutdownHandlerRun = false;
+
+  S.addOnDetach([&]() { ++OnDetachHandlersRun; });
+  S.addOnDetach([&]() { S.shutdown(); });
+  S.addOnDetach([&]() { ++OnDetachHandlersRun; });
+  S.addOnShutdown([&]() {
+    EXPECT_EQ(OnDetachHandlersRun, 2);
+    OnShutdownHandlerRun = true;
+  });
+
+  S.detach();
+
+  EXPECT_TRUE(OnShutdownHandlerRun);
+}
+
 TEST(SessionTest, ExpectedShutdownSequenceWithNoActiveManagedCodeCalls) {
   // Check that Session shutdown results in...
   // 1. Services being shut down.


### PR DESCRIPTION
This test checks that it's safe to call Session::shutdown from an on-detach handler, and that:
1. The Session does proceed to shut down.
2. All on-detach handlers run before any on-shutdown handlers.