### PR TITLE
[LoopUnroll] Preserve SCEV MaxTripCount for sibling loops via new metadata

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -772,6 +772,28 @@ static unsigned unrollCountPragmaValue(const Loop *L) {
   return 0;
 }
 
+static const char *LoopUnrollMaxTripCountMetadata =
+    "llvm.loop.unroll.max_trip_count";
+
+static std::optional<unsigned>
+getLoopUnrollMaxTripCountMetadata(const Loop *L) {
+  if (auto MaxTripCount =
+          getOptionalIntLoopAttribute(L, LoopUnrollMaxTripCountMetadata))
+    return static_cast<unsigned>(*MaxTripCount);
+  return std::nullopt;
+}
+
+static void setLoopUnrollMaxTripCountMetadata(Loop *L, unsigned MaxTripCount) {
+  addStringMetadataToLoop(L, LoopUnrollMaxTripCountMetadata, MaxTripCount);
+}
+
+static void eraseLoopUnrollMaxTripCountMetadata(Loop *L) {
+  if (getLoopUnrollMaxTripCountMetadata(L))
+    L->setLoopID(makePostTransformationMetadata(
+        L->getHeader()->getContext(), L->getLoopID(),
+        {LoopUnrollMaxTripCountMetadata}, {}));
+}
+
 UnrollPragmaInfo::UnrollPragmaInfo(const Loop *L)
     : UserUnrollCount(UnrollCount.getNumOccurrences() > 0),
       PragmaFullUnroll(hasUnrollFullPragma(L)),
@@ -780,6 +802,51 @@ UnrollPragmaInfo::UnrollPragmaInfo(const Loop *L)
       PragmaRuntimeUnrollDisable(hasRuntimeUnrollDisablePragma(L)),
       ExplicitUnroll(PragmaCount > 0 || PragmaFullUnroll ||
                      PragmaEnableUnroll || UserUnrollCount) {}
+
+// Preserve max trip count as metadata for sibling loops. The information can be
+// restored later when SCEV can't recompute it after unrolling the current loop.
+static void preserveSiblingMaxTripCounts(Loop *L, LoopInfo &LI,
+                                         ScalarEvolution &SE) {
+  SmallPtrSet<Loop *, 4> Visited;
+  SmallVector<BasicBlock *, 4> ExitingBlocks;
+  L->getExitingBlocks(ExitingBlocks);
+
+  for (BasicBlock *ExitingBlock : ExitingBlocks) {
+    for (BasicBlock *ExitSucc : successors(ExitingBlock)) {
+      if (L->contains(ExitSucc))
+        continue;
+
+      BasicBlock *CandidateBlock = ExitSucc;
+      for (unsigned Depth = 0; Depth != 4; ++Depth) {
+        Loop *CandidateLoop = LI.getLoopFor(CandidateBlock);
+        if (CandidateLoop && CandidateLoop->getHeader() == CandidateBlock) {
+          if (CandidateLoop != L &&
+              CandidateLoop->getParentLoop() == L->getParentLoop() &&
+              Visited.insert(CandidateLoop).second) {
+            unsigned MaxTripCount =
+                SE.getSmallConstantMaxTripCount(CandidateLoop);
+            if (MaxTripCount) {
+              const SCEV *MaxBackedgeTakenCount =
+                  SE.getConstantMaxBackedgeTakenCount(CandidateLoop);
+              if (!isa<SCEVCouldNotCompute>(MaxBackedgeTakenCount) &&
+                  SE.isLoopInvariant(MaxBackedgeTakenCount, L))
+                setLoopUnrollMaxTripCountMetadata(CandidateLoop, MaxTripCount);
+            }
+          }
+          break;
+        }
+
+        BasicBlock *NextBlock = CandidateBlock->getUniqueSuccessor();
+        if (!NextBlock || NextBlock == CandidateBlock)
+          break;
+        if (NextBlock->getUniquePredecessor() != CandidateBlock &&
+            !LI.isLoopHeader(NextBlock))
+          break;
+        CandidateBlock = NextBlock;
+      }
+    }
+  }
+}
 
 // Computes the boosting factor for complete unrolling.
 // If fully unrolling the loop would save a lot of RolledDynamicCost, it would
@@ -1377,8 +1444,12 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
   bool MaxOrZero = false;
   if (!TripCount) {
     MaxTripCount = SE.getSmallConstantMaxTripCount(L);
+    if (!MaxTripCount)
+      MaxTripCount = getLoopUnrollMaxTripCountMetadata(L).value_or(0);
     MaxOrZero = SE.isBackedgeTakenCountMaxOrZero(L);
   }
+
+  eraseLoopUnrollMaxTripCountMetadata(L);
 
   // computeUnrollCount() decides whether it is beneficial to use upper bound to
   // fully unroll the loop.
@@ -1432,6 +1503,8 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
   // Save loop properties before it is transformed.
   MDNode *OrigLoopID = L->getLoopID();
   UnrollPragmaInfo PInfo(L);
+
+  preserveSiblingMaxTripCounts(L, *LI, SE);
 
   // Unroll the loop.
   Loop *RemainderLoop = nullptr;

--- a/llvm/test/Transforms/LoopUnroll/unroll-preserve-successor-max-count.ll
+++ b/llvm/test/Transforms/LoopUnroll/unroll-preserve-successor-max-count.ll
@@ -1,0 +1,41 @@
+; RUN: opt -passes='loop-unroll<upperbound>' -S < %s | FileCheck %s
+
+; Test that unrolling the first loop preserves the max trip count of the sibling
+; successor loop via metadata, preventing SCEV info loss.
+
+; CHECK-LABEL: @test_upperbound(
+; CHECK-COUNT-4: store i64 0, ptr %results
+; CHECK-COUNT-4: load i64, ptr %results
+
+declare i32 @llvm.umin.i32(i32, i32)
+
+declare void @use(i64)
+
+define void @test_upperbound(i32 %x) {
+entry:
+  %results = alloca i64, align 8
+  %trip.count = tail call i32 @llvm.umin.i32(i32 %x, i32 4)
+  %cmp0 = icmp eq i32 %trip.count, 0
+  br i1 %cmp0, label %for.end, label %for.body
+
+for.body:
+  %i = phi i32 [ %inc, %for.body ], [ 0, %entry ]
+  store i64 0, ptr %results, align 8
+  %inc = add i32 %i, 1
+  %cmp = icmp eq i32 %inc, %trip.count
+  br i1 %cmp, label %for.body2, label %for.body
+
+for.cond:
+  %inc2 = add nuw nsw i32 %i2, 1
+  %cmp2 = icmp eq i32 %inc2, %trip.count
+  br i1 %cmp2, label %for.end, label %for.body2
+
+for.body2:
+  %i2 = phi i32 [ %inc2, %for.cond ], [ 0, %for.body ]
+  %tmp = load i64, ptr %results, align 8
+  tail call void @use(i64 %tmp)
+  br label %for.cond
+
+for.end:
+  ret void
+}

--- a/llvm/test/Transforms/PhaseOrdering/SystemZ/sub-xor.ll
+++ b/llvm/test/Transforms/PhaseOrdering/SystemZ/sub-xor.ll
@@ -93,7 +93,7 @@ define dso_local zeroext i32 @foo(ptr noundef %a) #0 {
 ; CHECK-NEXT:    [[ADD_1_7]] = add i32 [[TMP23]], [[SUM_11_1]]
 ; CHECK-NEXT:    [[INDVARS_IV_NEXT_1_7]] = add nuw nsw i64 [[INDVARS_IV_1]], 8
 ; CHECK-NEXT:    [[EXITCOND_1_NOT_7:%.*]] = icmp eq i64 [[INDVARS_IV_NEXT_1_7]], 32
-; CHECK-NEXT:    br i1 [[EXITCOND_1_NOT_7]], label %[[FOR_BODY4_2:.*]], label %[[FOR_BODY4_1]], !llvm.loop [[LOOP7]]
+; CHECK-NEXT:    br i1 [[EXITCOND_1_NOT_7]], label %[[FOR_BODY4_2:.*]], label %[[FOR_BODY4_1]], !llvm.loop [[LOOP9:![0-9]+]]
 ; CHECK:       [[FOR_BODY4_2]]:
 ; CHECK-NEXT:    [[INDVARS_IV_2:%.*]] = phi i64 [ [[INDVARS_IV_NEXT_2_7:%.*]], %[[FOR_BODY4_2]] ], [ 0, %[[FOR_BODY4_1]] ]
 ; CHECK-NEXT:    [[SUM_11_2:%.*]] = phi i32 [ [[ADD_2_7:%.*]], %[[FOR_BODY4_2]] ], [ [[ADD_1_7]], %[[FOR_BODY4_1]] ]
@@ -139,7 +139,7 @@ define dso_local zeroext i32 @foo(ptr noundef %a) #0 {
 ; CHECK-NEXT:    [[ADD_2_7]] = add i32 [[MUL_2_7]], [[ADD_2_6]]
 ; CHECK-NEXT:    [[INDVARS_IV_NEXT_2_7]] = add nuw nsw i64 [[INDVARS_IV_2]], 8
 ; CHECK-NEXT:    [[EXITCOND_2_NOT_7:%.*]] = icmp eq i64 [[INDVARS_IV_NEXT_2_7]], 32
-; CHECK-NEXT:    br i1 [[EXITCOND_2_NOT_7]], label %[[FOR_INC5_2:.*]], label %[[FOR_BODY4_2]], !llvm.loop [[LOOP7]]
+; CHECK-NEXT:    br i1 [[EXITCOND_2_NOT_7]], label %[[FOR_INC5_2:.*]], label %[[FOR_BODY4_2]], !llvm.loop [[LOOP10:![0-9]+]]
 ; CHECK:       [[FOR_INC5_2]]:
 ; CHECK-NEXT:    ret i32 [[ADD_2_7]]
 ;
@@ -218,4 +218,6 @@ attributes #2 = { argmemonly nocallback nofree nosync nounwind willreturn }
 ; CHECK: [[META6]] = !{!"Simple C/C++ TBAA"}
 ; CHECK: [[LOOP7]] = distinct !{[[LOOP7]], [[META8:![0-9]+]]}
 ; CHECK: [[META8]] = !{!"llvm.loop.mustprogress"}
+; CHECK: [[LOOP9]] = distinct !{[[LOOP9]], [[META8]]}
+; CHECK: [[LOOP10]] = distinct !{[[LOOP10]], [[META8]]}
 ;.


### PR DESCRIPTION
In a test of two consecutive loops with eq compare predidate, SCEV computes constant trip counts for them before unrolling. However, after unrolling the first loop, the second loop's header is a merge block. isBasicBlockEntryGuardedByCond stops at the merge block, preventing SCEV from re-computing constant trip count for the second loop. This causes the second loop failing to fully unroll and a perf regression from 183K to 405K cycles on a downstream gpu target.

There was an attemp #190602 that enhanced isBasicBlockEntryGuardedByCond but was abandoned due to significant compile-time regressions.

This PR saves a proven max trip count as new llvm.loop.unroll.max_trip_count metadata before unrolling the current loop. LoopUnroll still prefers SCEV. Fall back to the preserved metadata when SCEV fails to compute small constant max trip count. The metadata is erased after retrieving.

This PR also improves llvm-test-suite/CTMark/ClamAV/libclamav_unarj.c:245:2:
[old] remark: unrolled loop by a factor of 4 with run-time trip count
===>
[new] remark: completely unrolled loop with 8 iterations