### PR TITLE
[test] Add MC relaxation stretch tests

### DIFF
--- a/llvm/test/MC/ARM/thumb-ldr-stretch.s
+++ b/llvm/test/MC/ARM/thumb-ldr-stretch.s
@@ -1,0 +1,66 @@
+@ RUN: llvm-mc -triple thumbv7m -filetype=obj -o %t %s
+@ RUN: llvm-objdump -d --no-show-raw-insn --triple=thumbv7m %t | FileCheck %s
+
+@ The three "b external" instructions relax from 2-byte tB to 4-byte t2B
+@ (unresolved fixup). The cumulative size growth must not cause the tLDRpci
+@ instructions to appear misaligned and spuriously relax to 4-byte t2LDRpci.
+@ The .p2align 2 before the constant pool absorbs the upstream growth, keeping
+@ the targets 4-byte aligned.
+@
+@ If tLDRpci spuriously widens, the extra bytes push the cbz target past the
+@ 126-byte range, causing "out of range pc-relative fixup value".
+
+@ CHECK-LABEL: <fn>:
+@ CHECK:        0: cbz r0, 0x7e
+@ CHECK:       4c: ldr r2, [pc, #0x30]
+@ CHECK-NOT:       ldr.w
+@ CHECK:       5e: ldr r2, [pc, #0x24]
+@ CHECK-NOT:       ldr.w
+@ CHECK:       70: ldr r2, [pc, #0x14]
+@ CHECK-NOT:       ldr.w
+@ CHECK:       7e: nop
+
+	.syntax	unified
+	.text
+	.globl	fn
+	.type	fn,%function
+	.thumb_func
+fn:
+	cbz	r0, .LBB0_11
+	.rept 6
+	nop
+	.endr
+	b	.LBB0_11
+	.rept 6
+	nop
+	.endr
+	b	external
+	.rept 14
+	nop
+	.endr
+	b	.LBB0_11
+	.rept 7
+	nop
+	.endr
+	ldr.n	r2, .LCPI0_3
+	.rept 6
+	nop
+	.endr
+	b	external
+	ldr	r2, .LCPI0_4
+	.rept 6
+	nop
+	.endr
+	b	external
+	ldr.n	r2, .LCPI0_5
+	.rept 6
+	nop
+	.endr
+.LBB0_11:
+	.p2align	2
+.LCPI0_3:
+	.long	4
+.LCPI0_4:
+	.long	5
+.LCPI0_5:
+	.long	6

--- a/llvm/test/MC/CSKY/lrw-stretch.s
+++ b/llvm/test/MC/CSKY/lrw-stretch.s
@@ -1,0 +1,35 @@
+# RUN: llvm-mc -triple=csky -mattr=+e2 -filetype=obj -o %t %s
+# RUN: llvm-objdump --mattr=+e2 --no-show-raw-insn -M no-aliases -d %t | FileCheck %s
+
+## The two "br16 external" relax from 2-byte to 4-byte (unresolved symbol).
+## The cumulative size growth must not cause the lrw16 instructions to appear
+## misaligned and spuriously relax to 4-byte lrw32. The .p2align 2 before the
+## constant pool absorbs the upstream growth, keeping the targets 4-byte aligned.
+
+# CHECK-LABEL: <fn>:
+# CHECK:       10: lrw16 r0,
+# CHECK-NOT:       lrw32
+# CHECK:       22: lrw16 r1,
+# CHECK-NOT:       lrw32
+
+    .text
+    .globl fn
+fn:
+    br16 external
+    .rept 6
+    addu16 r0, r0, r1
+    .endr
+    lrw16 r0, [.LCPI0]
+    .rept 6
+    addu16 r0, r0, r1
+    .endr
+    br16 external
+    lrw16 r1, [.LCPI1]
+    .rept 6
+    addu16 r0, r0, r1
+    .endr
+    .p2align 2
+.LCPI0:
+    .long 42
+.LCPI1:
+    .long 43


### PR DESCRIPTION
Verify:

- ARM tLDRpci instructions don't spuriously widen to t2LDRpci when
  upstream branches relax, which would push cbz targets out of range.
  This would catch the #184544 regression.
- CSKY lrw16 instructions don't spuriously widen to lrw32 when
  upstream branches relax. Similar to ARM.