### PR TITLE
[AArch64][MachineOutliner] Fix up SP add/sub immediates in outlined sequences

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -10015,6 +10015,63 @@ static bool outliningCandidatesV8_3OpsConsensus(const outliner::Candidate &a,
   return SubtargetA.hasV8_3aOps() == SubtargetB.hasV8_3aOps();
 }
 
+/// If \p MI is an ADD/SUBXri that reads SP but does not write SP (e.g.
+/// "add x0, sp, #48"), try to adjust its signed byte offset by \p Delta and
+/// re-encode the result. On success, returns the new opcode, immediate, and
+/// shift. Returns false if \p MI is not a matching instruction or the adjusted
+/// offset is not encodable.
+static bool adjustSPAddSubImm(const MachineInstr &MI, int64_t Delta,
+                              unsigned &OutOpcode, int64_t &OutImm,
+                              int64_t &OutShift) {
+  bool IsSub;
+  switch (MI.getOpcode()) {
+  case AArch64::ADDXri:
+    IsSub = false;
+    break;
+  case AArch64::SUBXri:
+    IsSub = true;
+    break;
+  default:
+    return false;
+  }
+
+  if (!MI.getOperand(0).isReg() || !MI.getOperand(1).isReg() ||
+      !MI.getOperand(2).isImm() || !MI.getOperand(3).isImm())
+    return false;
+
+  if (MI.getOperand(0).getReg() == AArch64::SP)
+    return false;
+  if (MI.getOperand(1).getReg() != AArch64::SP)
+    return false;
+
+  // ADD/SUBXri encode a 12-bit unsigned immediate with an optional left shift
+  // which can only be 12.
+  int64_t Shift = MI.getOperand(3).getImm();
+  assert((Shift == 0 || Shift == 12) && "Unexpected add/sub immediate shift");
+
+  int64_t Offset = MI.getOperand(2).getImm() << Shift;
+  if (IsSub)
+    Offset = -Offset;
+
+  // Apply the adjustment and try to re-encode.
+  int64_t NewOffset = Offset + Delta;
+  int64_t AbsOffset = std::abs(NewOffset);
+
+  // Try to encode as a 12-bit immediate with shift=0 first.
+  if (AbsOffset <= 0xfff) {
+    OutImm = AbsOffset;
+    OutShift = 0;
+  } else if ((AbsOffset & 0xfff) == 0 && (AbsOffset >> 12) <= 0xfff) {
+    OutImm = AbsOffset >> 12;
+    OutShift = 12;
+  } else {
+    return false;
+  }
+
+  OutOpcode = NewOffset < 0 ? AArch64::SUBXri : AArch64::ADDXri;
+  return true;
+}
+
 std::optional<std::unique_ptr<outliner::OutlinedFunction>>
 AArch64InstrInfo::getOutliningCandidateInfo(
     const MachineModuleInfo &MMI,
@@ -10252,9 +10309,15 @@ AArch64InstrInfo::getOutliningCandidateInfo(
       return true;
     }
 
-    // FIXME: Add handling for instructions like "add x0, sp, #8".
+    {
+      unsigned NewOpcode;
+      int64_t NewImm, NewShift;
+      if (adjustSPAddSubImm(MI, 16, NewOpcode, NewImm, NewShift))
+        return true;
+    }
 
-    // We can't fix it up, so don't outline it.
+    // FIXME: Add handling for other SP-based address calculations that can be
+    // adjusted after outlining.
     return false;
   };
 
@@ -10769,27 +10832,37 @@ void AArch64InstrInfo::fixupPostOutline(MachineBasicBlock &MBB) const {
     bool OffsetIsScalable;
 
     // Is this a load or store with an immediate offset with SP as the base?
-    if (!MI.mayLoadOrStore() ||
-        !getMemOperandWithOffsetWidth(MI, Base, Offset, OffsetIsScalable, Width,
-                                      &RI) ||
-        (Base->isReg() && Base->getReg() != AArch64::SP))
+    if (MI.mayLoadOrStore() &&
+        getMemOperandWithOffsetWidth(MI, Base, Offset, OffsetIsScalable, Width,
+                                     &RI) &&
+        Base->isReg() && Base->getReg() == AArch64::SP) {
+      TypeSize Scale(0U, false);
+      int64_t Dummy1, Dummy2;
+
+      MachineOperand &StackOffsetOperand =
+          getMemOpBaseRegImmOfsOffsetOperand(MI);
+      assert(StackOffsetOperand.isImm() && "Stack offset wasn't immediate!");
+      getMemOpInfo(MI.getOpcode(), Scale, Width, Dummy1, Dummy2);
+      assert(Scale != 0 && "Unexpected opcode!");
+      assert(!OffsetIsScalable && "Expected offset to be a byte offset");
+
+      // We've pushed the return address to the stack, so add 16 to the offset.
+      // This is safe, since we already checked if it would overflow when we
+      // checked if this instruction was legal to outline.
+      int64_t NewImm = (Offset + 16) / (int64_t)Scale.getFixedValue();
+      StackOffsetOperand.setImm(NewImm);
       continue;
+    }
 
-    // It is, so we have to fix it up.
-    TypeSize Scale(0U, false);
-    int64_t Dummy1, Dummy2;
-
-    MachineOperand &StackOffsetOperand = getMemOpBaseRegImmOfsOffsetOperand(MI);
-    assert(StackOffsetOperand.isImm() && "Stack offset wasn't immediate!");
-    getMemOpInfo(MI.getOpcode(), Scale, Width, Dummy1, Dummy2);
-    assert(Scale != 0 && "Unexpected opcode!");
-    assert(!OffsetIsScalable && "Expected offset to be a byte offset");
-
-    // We've pushed the return address to the stack, so add 16 to the offset.
-    // This is safe, since we already checked if it would overflow when we
-    // checked if this instruction was legal to outline.
-    int64_t NewImm = (Offset + 16) / (int64_t)Scale.getFixedValue();
-    StackOffsetOperand.setImm(NewImm);
+    {
+      unsigned NewOpcode;
+      int64_t NewImm, NewShift;
+      if (adjustSPAddSubImm(MI, 16, NewOpcode, NewImm, NewShift)) {
+        MI.setDesc(get(NewOpcode));
+        MI.getOperand(2).setImm(NewImm);
+        MI.getOperand(3).setImm(NewShift);
+      }
+    }
   }
 }
 

--- a/llvm/test/CodeGen/AArch64/machine-outliner-sp-addsub-fixup.mir
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-sp-addsub-fixup.mir
@@ -1,0 +1,551 @@
+# RUN: llc -mtriple=aarch64--- -run-pass=prologepilog -run-pass=machine-outliner \
+# RUN:   -verify-machineinstrs %s -o - | FileCheck %s
+
+# Check that the outliner fixes up SP-derived add/sub immediates inside an
+# outlined sequence that contains a call and therefore saves LR on the stack.
+# The add/sub immediates must be adjusted by +16.
+#
+# Also check that unencodable cases prevent the call from being included in the
+# outlined sequence.
+
+--- |
+  ; @callee is a leaf function so the outliner treat BL @callee as a legal
+  ; instruction. This would be addressed by relaxed stack access check.
+  define void @callee() #1 { ret void }
+  define void @add_fixup0() #0 { ret void }
+  define void @add_fixup1() #0 { ret void }
+  define void @add_fixup2() #0 { ret void }
+  define void @add_fixup3() #0 { ret void }
+  define void @sub_to_add0() #0 { ret void }
+  define void @sub_to_add1() #0 { ret void }
+  define void @sub_to_add2() #0 { ret void }
+  define void @sub_to_add3() #0 { ret void }
+  define void @sub_fixup0() #0 { ret void }
+  define void @sub_fixup1() #0 { ret void }
+  define void @sub_fixup2() #0 { ret void }
+  define void @sub_fixup3() #0 { ret void }
+  define void @shifted_sub0() #0 { ret void }
+  define void @shifted_sub1() #0 { ret void }
+  define void @shifted_sub2() #0 { ret void }
+  define void @shifted_sub3() #0 { ret void }
+  define void @shifted_add0() #0 { ret void }
+  define void @shifted_add1() #0 { ret void }
+  define void @shifted_add2() #0 { ret void }
+  define void @shifted_add3() #0 { ret void }
+  define void @overflow0() #0 { ret void }
+  define void @overflow1() #0 { ret void }
+  define void @overflow2() #0 { ret void }
+  define void @overflow3() #0 { ret void }
+  attributes #0 = { minsize noinline noredzone "frame-pointer"="all" }
+  attributes #1 = { minsize noinline noredzone "frame-pointer"="none" }
+...
+---
+
+name:            callee
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    RET undef $lr
+
+...
+---
+
+name:            add_fixup0
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            add_fixup0
+    ; CHECK: BL @[[ADD_FUNC:OUTLINED_FUNCTION_[0-9]+]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = ADDXri $sp, 48, 0
+    $x15 = ADDXri $sp, 48, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            add_fixup1
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            add_fixup1
+    ; CHECK: BL @[[ADD_FUNC]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = ADDXri $sp, 48, 0
+    $x15 = ADDXri $sp, 48, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            add_fixup2
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            add_fixup2
+    ; CHECK: BL @[[ADD_FUNC]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = ADDXri $sp, 48, 0
+    $x15 = ADDXri $sp, 48, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            add_fixup3
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            add_fixup3
+    ; CHECK: BL @[[ADD_FUNC]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = ADDXri $sp, 48, 0
+    $x15 = ADDXri $sp, 48, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            sub_to_add0
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            sub_to_add0
+    ; CHECK: BL @[[SUB_TO_ADD_FUNC:OUTLINED_FUNCTION_[0-9]+]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = SUBXri $sp, 8, 0
+    $x15 = SUBXri $sp, 8, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            sub_to_add1
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            sub_to_add1
+    ; CHECK: BL @[[SUB_TO_ADD_FUNC]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = SUBXri $sp, 8, 0
+    $x15 = SUBXri $sp, 8, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            sub_to_add2
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            sub_to_add2
+    ; CHECK: BL @[[SUB_TO_ADD_FUNC]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = SUBXri $sp, 8, 0
+    $x15 = SUBXri $sp, 8, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            sub_to_add3
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            sub_to_add3
+    ; CHECK: BL @[[SUB_TO_ADD_FUNC]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = SUBXri $sp, 8, 0
+    $x15 = SUBXri $sp, 8, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            sub_fixup0
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            sub_fixup0
+    ; CHECK: BL @[[SUB_FUNC:OUTLINED_FUNCTION_[0-9]+]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = SUBXri $sp, 48, 0
+    $x15 = SUBXri $sp, 48, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            sub_fixup1
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            sub_fixup1
+    ; CHECK: BL @[[SUB_FUNC]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = SUBXri $sp, 48, 0
+    $x15 = SUBXri $sp, 48, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            sub_fixup2
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            sub_fixup2
+    ; CHECK: BL @[[SUB_FUNC]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = SUBXri $sp, 48, 0
+    $x15 = SUBXri $sp, 48, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            sub_fixup3
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            sub_fixup3
+    ; CHECK: BL @[[SUB_FUNC]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = SUBXri $sp, 48, 0
+    $x15 = SUBXri $sp, 48, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            shifted_sub0
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            shifted_sub0
+    ; CHECK: BL @[[SHIFTED_SUB_FUNC:OUTLINED_FUNCTION_[0-9]+]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = SUBXri $sp, 1, 12
+    $x15 = SUBXri $sp, 1, 12
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            shifted_sub1
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            shifted_sub1
+    ; CHECK: BL @[[SHIFTED_SUB_FUNC]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = SUBXri $sp, 1, 12
+    $x15 = SUBXri $sp, 1, 12
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            shifted_sub2
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            shifted_sub2
+    ; CHECK: BL @[[SHIFTED_SUB_FUNC]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = SUBXri $sp, 1, 12
+    $x15 = SUBXri $sp, 1, 12
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            shifted_sub3
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            shifted_sub3
+    ; CHECK: BL @[[SHIFTED_SUB_FUNC]]
+    ; CHECK-NOT: BL @callee
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = SUBXri $sp, 1, 12
+    $x15 = SUBXri $sp, 1, 12
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            shifted_add0
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            shifted_add0
+    ; CHECK: BL @callee
+    ; CHECK-NEXT: BL @[[SHIFTED_ADD_FUNC:OUTLINED_FUNCTION_[0-9]+]]
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = ADDXri $sp, 1, 12
+    $x15 = ADDXri $sp, 1, 12
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            shifted_add1
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            shifted_add1
+    ; CHECK: BL @callee
+    ; CHECK-NEXT: BL @[[SHIFTED_ADD_FUNC]]
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = ADDXri $sp, 1, 12
+    $x15 = ADDXri $sp, 1, 12
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            shifted_add2
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            shifted_add2
+    ; CHECK: BL @callee
+    ; CHECK-NEXT: BL @[[SHIFTED_ADD_FUNC]]
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = ADDXri $sp, 1, 12
+    $x15 = ADDXri $sp, 1, 12
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            shifted_add3
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            shifted_add3
+    ; CHECK: BL @callee
+    ; CHECK-NEXT: BL @[[SHIFTED_ADD_FUNC]]
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = ADDXri $sp, 1, 12
+    $x15 = ADDXri $sp, 1, 12
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            overflow0
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            overflow0
+    ; CHECK: BL @callee
+    ; CHECK-NEXT: BL @[[OVERFLOW_FUNC:OUTLINED_FUNCTION_[0-9]+]]
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = ADDXri $sp, 4095, 0
+    $x15 = ADDXri $sp, 4095, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            overflow1
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            overflow1
+    ; CHECK: BL @callee
+    ; CHECK-NEXT: BL @[[OVERFLOW_FUNC]]
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = ADDXri $sp, 4095, 0
+    $x15 = ADDXri $sp, 4095, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            overflow2
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            overflow2
+    ; CHECK: BL @callee
+    ; CHECK-NEXT: BL @[[OVERFLOW_FUNC]]
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = ADDXri $sp, 4095, 0
+    $x15 = ADDXri $sp, 4095, 0
+  bb.2:
+    RET undef $lr
+
+...
+---
+
+name:            overflow3
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $lr
+    $lr = ORRXri $xzr, 1
+  bb.1:
+    ; CHECK-LABEL: name:            overflow3
+    ; CHECK: BL @callee
+    ; CHECK-NEXT: BL @[[OVERFLOW_FUNC]]
+    BL @callee, implicit-def dead $lr, implicit $sp
+    $x15 = ADDXri $sp, 4095, 0
+    $x15 = ADDXri $sp, 4095, 0
+  bb.2:
+    RET undef $lr
+
+...
+
+# CHECK:       name:            [[ADD_FUNC]]
+# CHECK:       early-clobber $sp = STRXpre $lr, $sp, -16
+# CHECK-NEXT:  BL @callee
+# CHECK-NEXT:  $x15 = ADDXri $sp, 64, 0
+# CHECK-NEXT:  $x15 = ADDXri $sp, 64, 0
+# CHECK-NEXT:  early-clobber $sp, $lr = LDRXpost $sp, 16
+# CHECK-NEXT:  RET $lr
+
+# CHECK:       name:            [[SUB_FUNC]]
+# CHECK:       early-clobber $sp = STRXpre $lr, $sp, -16
+# CHECK-NEXT:  BL @callee
+# CHECK-NEXT:  $x15 = SUBXri $sp, 32, 0
+# CHECK-NEXT:  $x15 = SUBXri $sp, 32, 0
+# CHECK-NEXT:  early-clobber $sp, $lr = LDRXpost $sp, 16
+# CHECK-NEXT:  RET $lr
+
+# CHECK:       name:            [[SHIFTED_SUB_FUNC]]
+# CHECK:       early-clobber $sp = STRXpre $lr, $sp, -16
+# CHECK-NEXT:  BL @callee
+# CHECK-NEXT:  $x15 = SUBXri $sp, 4080, 0
+# CHECK-NEXT:  $x15 = SUBXri $sp, 4080, 0
+# CHECK-NEXT:  early-clobber $sp, $lr = LDRXpost $sp, 16
+# CHECK-NEXT:  RET $lr
+
+# CHECK:       name:            [[SUB_TO_ADD_FUNC]]
+# CHECK:       early-clobber $sp = STRXpre $lr, $sp, -16
+# CHECK-NEXT:  BL @callee
+# CHECK-NEXT:  $x15 = ADDXri $sp, 8, 0
+# CHECK-NEXT:  $x15 = ADDXri $sp, 8, 0
+# CHECK-NEXT:  early-clobber $sp, $lr = LDRXpost $sp, 16
+# CHECK-NEXT:  RET $lr
+
+# CHECK:       name:            [[SHIFTED_ADD_FUNC]]
+# CHECK-NOT:   STRXpre
+# CHECK:       $x15 = ADDXri $sp, 1, 12
+# CHECK-NEXT:  $x15 = ADDXri $sp, 1, 12
+# CHECK-NEXT:  RET $lr
+
+# CHECK:       name:            [[OVERFLOW_FUNC]]
+# CHECK-NOT:   STRXpre
+# CHECK:       $x15 = ADDXri $sp, 4095, 0
+# CHECK-NEXT:  $x15 = ADDXri $sp, 4095, 0
+# CHECK-NEXT:  RET $lr


### PR DESCRIPTION
Extend the AArch64 machine outliner to handle ADDXri/SUBXri instructions that read SP when the outlined function saves LR on the stack, shifting SP down by 16.

Previously only loads/stores with an SP base were adjusted. This patch adds support for ADDXri and SUBXri with an SP source operand, correctly re-encoding the adjusted offset and changing the opcode when the sign flips. Unencodable adjusted offsets cause the candidate to be rejected during the safety check, preventing illegal outlining.