### PR TITLE
[MC] Track per-section inner relaxation iterations and add convergence test

### DIFF
--- a/llvm/lib/MC/MCAssembler.cpp
+++ b/llvm/lib/MC/MCAssembler.cpp
@@ -1011,20 +1011,19 @@ void MCAssembler::layoutSection(MCSection &Sec) {
 }
 
 unsigned MCAssembler::relaxOnce(unsigned FirstStable) {
-  ++stats::RelaxationSteps;
+  uint64_t MaxIterations = 0;
   PendingErrors.clear();
 
   unsigned Res = 0;
   for (unsigned I = 0; I != FirstStable; ++I) {
-    // Assume each iteration finalizes at least one extra fragment. If the
-    // layout does not converge after N+1 iterations, bail out.
     auto &Sec = *Sections[I];
-    auto MaxIter = Sec.curFragList()->Tail->getLayoutOrder() + 1;
+    uint64_t Iters = 0;
     for (;;) {
       bool Changed = false;
       for (MCFragment &F : Sec)
         if (F.getKind() != MCFragment::FT_Data && relaxFragment(F))
           Changed = true;
+      ++Iters;
 
       if (!Changed)
         break;
@@ -1032,11 +1031,15 @@ unsigned MCAssembler::relaxOnce(unsigned FirstStable) {
       // sections. Therefore, we must re-evaluate all sections.
       FirstStable = Sections.size();
       Res = I;
-      if (--MaxIter == 0)
+      // Assume each iteration finalizes at least one extra fragment. If the
+      // layout does not converge after N+1 iterations, bail out.
+      if (Iters > Sec.curFragList()->Tail->getLayoutOrder())
         break;
       layoutSection(Sec);
     }
+    MaxIterations = std::max(MaxIterations, Iters);
   }
+  stats::RelaxationSteps += MaxIterations;
   // The subsequent relaxOnce call only needs to visit Sections [0,Res) if no
   // change occurred.
   return Res;

--- a/llvm/test/MC/X86/align-branch-convergence.s
+++ b/llvm/test/MC/X86/align-branch-convergence.s
@@ -1,0 +1,71 @@
+# REQUIRES: asserts
+## Verify that boundary alignment converges may require O(N)
+## iterations where N is the number of BoundaryAlign fragments.
+
+# RUN: llvm-mc -filetype=obj -triple=x86_64 --stats \
+# RUN:   --x86-align-branch-boundary=32 --x86-align-branch=jcc+call %s \
+# RUN:   -o %t 2>&1 | FileCheck %s --check-prefix=STATS
+# STATS: 13 assembler - Number of assembler layout and relaxation steps
+
+# RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s
+# CHECK:        0: testl
+# CHECK:        2: je
+# CHECK:        8: callq
+# CHECK:       1c: nop
+# CHECK-NEXT:  20: callq
+# CHECK:       34: testl
+# CHECK-NEXT:  36: jne
+# CHECK:       65: testl
+# CHECK:       67: je
+# CHECK:       a0: jne
+# CHECK:       d1: je
+# CHECK:      100: callq
+# CHECK:      105: testl
+# CHECK-NEXT: 107: jne
+# CHECK:      13b: je
+# CHECK:      160: callq
+# CHECK:      16a: testl
+# CHECK-NEXT: 16c: jne
+# CHECK:      172: retq
+
+  .p2align 5
+func:
+  testl %eax, %eax
+  je .Lend
+  .rept 8
+  callq foo
+  .endr
+  testl %ecx, %ecx
+  jne func
+  .rept 8
+  callq foo
+  .endr
+  testl %edx, %edx
+  je .Lend
+  .rept 8
+  callq foo
+  .endr
+  testl %esi, %esi
+  jne func
+  .rept 8
+  callq foo
+  .endr
+  testl %edi, %edi
+  je .Lend
+  .rept 8
+  callq foo
+  .endr
+  testl %ebp, %ebp
+  jne func
+  .rept 8
+  callq foo
+  .endr
+  testl %eax, %eax
+  je .Lend
+  .rept 8
+  callq foo
+  .endr
+  testl %ecx, %ecx
+  jne func
+.Lend:
+  retq


### PR DESCRIPTION
Count inner iterations (max across sections) instead of outer relaxOnce
calls. This more accurately reflects the work done during relaxation.

Add a test that verifies boundary alignment convergence may require
O(N) iterations where N is the number of BoundaryAlign fragments.
This will be fixed by #190318