### PR TITLE
[LifetimeSafety] Track origins through std::function

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
@@ -130,7 +130,9 @@ public:
 
 class OriginFlowFact : public Fact {
   OriginID OIDDest;
-  OriginID OIDSrc;
+  // The source origin to flow from. Absent when only clearing the destination's
+  // loans.
+  std::optional<OriginID> OIDSrc;
   // True if the destination origin should be killed (i.e., its current loans
   // cleared) before the source origin's loans are flowed into it.
   bool KillDest;
@@ -140,12 +142,13 @@ public:
     return F->getKind() == Kind::OriginFlow;
   }
 
-  OriginFlowFact(OriginID OIDDest, OriginID OIDSrc, bool KillDest)
+  OriginFlowFact(OriginID OIDDest, std::optional<OriginID> OIDSrc,
+                 bool KillDest)
       : Fact(Kind::OriginFlow), OIDDest(OIDDest), OIDSrc(OIDSrc),
         KillDest(KillDest) {}
 
   OriginID getDestOriginID() const { return OIDDest; }
-  OriginID getSrcOriginID() const { return OIDSrc; }
+  std::optional<OriginID> getSrcOriginID() const { return OIDSrc; }
   bool getKillDest() const { return KillDest; }
 
   void dump(llvm::raw_ostream &OS, const LoanManager &,

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
@@ -55,6 +55,9 @@ public:
     OriginEscapes,
     /// An origin is invalidated (e.g. vector resized).
     InvalidateOrigin,
+    /// All loans are cleared from an origin (e.g., assigning a callable without
+    /// tracked origins to std::function).
+    KillOrigin,
   };
 
 private:
@@ -130,9 +133,7 @@ public:
 
 class OriginFlowFact : public Fact {
   OriginID OIDDest;
-  // The source origin to flow from. Absent when only clearing the destination's
-  // loans.
-  std::optional<OriginID> OIDSrc;
+  OriginID OIDSrc;
   // True if the destination origin should be killed (i.e., its current loans
   // cleared) before the source origin's loans are flowed into it.
   bool KillDest;
@@ -142,13 +143,12 @@ public:
     return F->getKind() == Kind::OriginFlow;
   }
 
-  OriginFlowFact(OriginID OIDDest, std::optional<OriginID> OIDSrc,
-                 bool KillDest)
+  OriginFlowFact(OriginID OIDDest, OriginID OIDSrc, bool KillDest)
       : Fact(Kind::OriginFlow), OIDDest(OIDDest), OIDSrc(OIDSrc),
         KillDest(KillDest) {}
 
   OriginID getDestOriginID() const { return OIDDest; }
-  std::optional<OriginID> getSrcOriginID() const { return OIDSrc; }
+  OriginID getSrcOriginID() const { return OIDSrc; }
   bool getKillDest() const { return KillDest; }
 
   void dump(llvm::raw_ostream &OS, const LoanManager &,
@@ -317,6 +317,22 @@ public:
 
   void dump(llvm::raw_ostream &OS, const LoanManager &,
             const OriginManager &) const override;
+};
+
+class KillOriginFact : public Fact {
+  OriginID OID;
+
+public:
+  static bool classof(const Fact *F) {
+    return F->getKind() == Kind::KillOrigin;
+  }
+
+  KillOriginFact(OriginID OID) : Fact(Kind::KillOrigin), OID(OID) {}
+
+  OriginID getKilledOrigin() const { return OID; }
+
+  void dump(llvm::raw_ostream &OS, const LoanManager &,
+            const OriginManager &OM) const override;
 };
 
 class FactManager {

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
@@ -55,8 +55,7 @@ public:
     OriginEscapes,
     /// An origin is invalidated (e.g. vector resized).
     InvalidateOrigin,
-    /// All loans are cleared from an origin (e.g., assigning a callable without
-    /// tracked origins to std::function).
+    /// All loans of an origin are cleared.
     KillOrigin,
   };
 
@@ -319,6 +318,8 @@ public:
             const OriginManager &) const override;
 };
 
+/// All loans are cleared from an origin (e.g., assigning a callable without
+/// tracked origins to std::function).
 class KillOriginFact : public Fact {
   OriginID OID;
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
@@ -80,6 +80,10 @@ bool isUniquePtrRelease(const CXXMethodDecl &MD);
 // https://en.cppreference.com/w/cpp/container#Iterator_invalidation
 bool isContainerInvalidationMethod(const CXXMethodDecl &MD);
 
+/// Returns true for standard library callable wrappers (e.g., std::function)
+/// that can propagate the stored lambda's origins.
+bool isStdCallableWrapperType(const CXXRecordDecl *RD);
+
 } // namespace clang::lifetimes
 
 #endif // LLVM_CLANG_ANALYSIS_ANALYSES_LIFETIMEANNOTATIONS_H

--- a/clang/lib/Analysis/LifetimeSafety/Dataflow.h
+++ b/clang/lib/Analysis/LifetimeSafety/Dataflow.h
@@ -180,6 +180,8 @@ private:
       return D->transfer(In, *F->getAs<TestPointFact>());
     case Fact::Kind::InvalidateOrigin:
       return D->transfer(In, *F->getAs<InvalidateOriginFact>());
+    case Fact::Kind::KillOrigin:
+      return D->transfer(In, *F->getAs<KillOriginFact>());
     }
     llvm_unreachable("Unknown fact kind");
   }
@@ -193,6 +195,7 @@ public:
   Lattice transfer(Lattice In, const UseFact &) { return In; }
   Lattice transfer(Lattice In, const TestPointFact &) { return In; }
   Lattice transfer(Lattice In, const InvalidateOriginFact &) { return In; }
+  Lattice transfer(Lattice In, const KillOriginFact &) { return In; }
 };
 } // namespace clang::lifetimes::internal
 #endif // LLVM_CLANG_ANALYSIS_ANALYSES_LIFETIMESAFETY_DATAFLOW_H

--- a/clang/lib/Analysis/LifetimeSafety/Facts.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Facts.cpp
@@ -43,10 +43,12 @@ void OriginFlowFact::dump(llvm::raw_ostream &OS, const LoanManager &,
   OS << "\tDest: ";
   OM.dump(getDestOriginID(), OS);
   OS << "\n";
-  OS << "\tSrc:  ";
-  OM.dump(getSrcOriginID(), OS);
-  OS << (getKillDest() ? "" : ", Merge");
-  OS << "\n";
+  if (getSrcOriginID()) {
+    OS << "\tSrc:  ";
+    OM.dump(*getSrcOriginID(), OS);
+    OS << (getKillDest() ? "" : ", Merge");
+    OS << "\n";
+  }
 }
 
 void MovedOriginFact::dump(llvm::raw_ostream &OS, const LoanManager &,

--- a/clang/lib/Analysis/LifetimeSafety/Facts.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Facts.cpp
@@ -43,12 +43,10 @@ void OriginFlowFact::dump(llvm::raw_ostream &OS, const LoanManager &,
   OS << "\tDest: ";
   OM.dump(getDestOriginID(), OS);
   OS << "\n";
-  if (getSrcOriginID()) {
-    OS << "\tSrc:  ";
-    OM.dump(*getSrcOriginID(), OS);
-    OS << (getKillDest() ? "" : ", Merge");
-    OS << "\n";
-  }
+  OS << "\tSrc:  ";
+  OM.dump(getSrcOriginID(), OS);
+  OS << (getKillDest() ? "" : ", Merge");
+  OS << "\n";
 }
 
 void MovedOriginFact::dump(llvm::raw_ostream &OS, const LoanManager &,
@@ -103,6 +101,13 @@ void InvalidateOriginFact::dump(llvm::raw_ostream &OS, const LoanManager &,
 void TestPointFact::dump(llvm::raw_ostream &OS, const LoanManager &,
                          const OriginManager &) const {
   OS << "TestPoint (Annotation: \"" << getAnnotation() << "\")\n";
+}
+
+void KillOriginFact::dump(llvm::raw_ostream &OS, const LoanManager &,
+                          const OriginManager &OM) const {
+  OS << "KillOrigin (";
+  OM.dump(getKilledOrigin(), OS);
+  OS << ")\n";
 }
 
 llvm::StringMap<ProgramPoint> FactManager::getTestPoints() const {

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -410,12 +410,12 @@ void FactsGenerator::handleAssignment(const Expr *LHSExpr,
       markUseAsWrite(DRE_LHS);
   }
   if (!RHSList) {
-    // RHS has no tracked origins (e.g., assigning a non-lambda functor to a
-    // std::function). Emit a kill-only flow to clear old loans.
-    if (OriginList *LHSInner = LHSList->peelOuterOrigin())
-      CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
-          LHSInner->getOuterOriginID(), /*OIDSrc=*/std::nullopt,
-          /*KillDest=*/true));
+    // RHS has no tracked origins (e.g., assigning a callable without origins
+    // to std::function). Clear loans of the destination.
+    for (OriginList *LHSInner = LHSList->peelOuterOrigin(); LHSInner;
+         LHSInner = LHSInner->peelOuterOrigin())
+      CurrentBlockFacts.push_back(
+          FactMgr.createFact<KillOriginFact>(LHSInner->getOuterOriginID()));
     return;
   }
   // Kill the old loans of the destination origin and flow the new loans

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -409,10 +409,15 @@ void FactsGenerator::handleAssignment(const Expr *LHSExpr,
     } else
       markUseAsWrite(DRE_LHS);
   }
-  // RHS may not have tracked origins (e.g., assigning a non-lambda functor
-  // to a std::function). Skip the flow in that case.
-  if (!RHSList)
+  if (!RHSList) {
+    // RHS has no tracked origins (e.g., assigning a non-lambda functor to a
+    // std::function). Emit a kill-only flow to clear old loans.
+    if (OriginList *LHSInner = LHSList->peelOuterOrigin())
+      CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
+          LHSInner->getOuterOriginID(), /*OIDSrc=*/std::nullopt,
+          /*KillDest=*/true));
     return;
+  }
   // Kill the old loans of the destination origin and flow the new loans
   // from the source origin.
   flow(LHSList->peelOuterOrigin(), RHSList, /*Kill=*/true);

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -190,12 +190,21 @@ void FactsGenerator::VisitCXXConstructExpr(const CXXConstructExpr *CCE) {
     return;
   }
   // For defaulted (implicit or `= default`) copy/move constructors, propagate
-  // origins directly. User-defined copy/move constructors have opaque semantics
-  // and fall through to `handleFunctionCall`, where [[clang::lifetimebound]] is
-  // needed to propagate origins.
+  // origins directly. User-defined copy/move constructors are not handled here
+  // as they have opaque semantics.
   if (CCE->getConstructor()->isCopyOrMoveConstructor() &&
       CCE->getConstructor()->isDefaulted() && CCE->getNumArgs() == 1 &&
       hasOrigins(CCE->getType())) {
+    const Expr *Arg = CCE->getArg(0);
+    if (OriginList *ArgList = getRValueOrigins(Arg, getOriginsList(*Arg))) {
+      flow(getOriginsList(*CCE), ArgList, /*Kill=*/true);
+      return;
+    }
+  }
+  // Standard library callable wrappers (e.g., std::function) propagate the
+  // stored lambda's origins.
+  if (const auto *RD = CCE->getType()->getAsCXXRecordDecl();
+      RD && isStdCallableWrapperType(RD) && CCE->getNumArgs() == 1) {
     const Expr *Arg = CCE->getArg(0);
     if (OriginList *ArgList = getRValueOrigins(Arg, getOriginsList(*Arg))) {
       flow(getOriginsList(*CCE), ArgList, /*Kill=*/true);
@@ -400,6 +409,10 @@ void FactsGenerator::handleAssignment(const Expr *LHSExpr,
     } else
       markUseAsWrite(DRE_LHS);
   }
+  // RHS may not have tracked origins (e.g., assigning a non-lambda functor
+  // to a std::function). Skip the flow in that case.
+  if (!RHSList)
+    return;
   // Kill the old loans of the destination origin and flow the new loans
   // from the source origin.
   flow(LHSList->peelOuterOrigin(), RHSList, /*Kill=*/true);
@@ -490,6 +503,13 @@ void FactsGenerator::VisitCXXOperatorCallExpr(const CXXOperatorCallExpr *OCE) {
     // Pointer-like types: assignment inherently propagates origins.
     QualType LHSTy = OCE->getArg(0)->getType();
     if (LHSTy->isPointerOrReferenceType() || isGslPointerType(LHSTy)) {
+      handleAssignment(OCE->getArg(0), OCE->getArg(1));
+      return;
+    }
+    // Standard library callable wrappers (e.g., std::function) can propagate
+    // the stored lambda's origins.
+    if (const auto *RD = LHSTy->getAsCXXRecordDecl();
+        RD && isStdCallableWrapperType(RD)) {
       handleAssignment(OCE->getArg(0), OCE->getArg(1));
       return;
     }

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
@@ -382,4 +382,12 @@ bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
 
   return InvalidatingMethods->contains(MD.getName());
 }
+
+bool isStdCallableWrapperType(const CXXRecordDecl *RD) {
+  if (!RD || !isInStlNamespace(RD))
+    return false;
+  StringRef Name = getName(*RD);
+  return Name == "function" || Name == "move_only_function";
+}
+
 } // namespace clang::lifetimes

--- a/clang/lib/Analysis/LifetimeSafety/LiveOrigins.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LiveOrigins.cpp
@@ -166,6 +166,10 @@ public:
     return Lattice(Factory.remove(In.LiveOrigins, OF.getDestOriginID()));
   }
 
+  Lattice transfer(Lattice In, const KillOriginFact &F) {
+    return Lattice(Factory.remove(In.LiveOrigins, F.getKilledOrigin()));
+  }
+
   Lattice transfer(Lattice In, const ExpireFact &F) {
     if (auto OID = F.getOriginID())
       return Lattice(Factory.remove(In.LiveOrigins, *OID));

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -55,7 +55,8 @@ static llvm::BitVector computePersistentOrigins(const FactManager &FactMgr,
       case Fact::Kind::OriginFlow: {
         const auto *OF = F->getAs<OriginFlowFact>();
         CheckOrigin(OF->getDestOriginID());
-        CheckOrigin(OF->getSrcOriginID());
+        if (OF->getSrcOriginID())
+          CheckOrigin(*OF->getSrcOriginID());
         break;
       }
       case Fact::Kind::Use:
@@ -168,14 +169,15 @@ public:
 
   /// A flow from source to destination. If `KillDest` is true, this replaces
   /// the destination's loans with the source's. Otherwise, the source's loans
-  /// are merged into the destination's.
+  /// are merged into the destination's. If the source is nullopt, this is a
+  /// kill-only flow that clears the destination without adding new loans.
   Lattice transfer(Lattice In, const OriginFlowFact &F) {
     OriginID DestOID = F.getDestOriginID();
-    OriginID SrcOID = F.getSrcOriginID();
 
     LoanSet DestLoans =
         F.getKillDest() ? LoanSetFactory.getEmptySet() : getLoans(In, DestOID);
-    LoanSet SrcLoans = getLoans(In, SrcOID);
+    LoanSet SrcLoans = F.getSrcOriginID() ? getLoans(In, *F.getSrcOriginID())
+                                          : LoanSetFactory.getEmptySet();
     LoanSet MergedLoans = utils::join(DestLoans, SrcLoans, LoanSetFactory);
 
     return setLoans(In, DestOID, MergedLoans);

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -55,14 +55,16 @@ static llvm::BitVector computePersistentOrigins(const FactManager &FactMgr,
       case Fact::Kind::OriginFlow: {
         const auto *OF = F->getAs<OriginFlowFact>();
         CheckOrigin(OF->getDestOriginID());
-        if (OF->getSrcOriginID())
-          CheckOrigin(*OF->getSrcOriginID());
+        CheckOrigin(OF->getSrcOriginID());
         break;
       }
       case Fact::Kind::Use:
         for (const OriginList *Cur = F->getAs<UseFact>()->getUsedOrigins(); Cur;
              Cur = Cur->peelOuterOrigin())
           CheckOrigin(Cur->getOuterOriginID());
+        break;
+      case Fact::Kind::KillOrigin:
+        CheckOrigin(F->getAs<KillOriginFact>()->getKilledOrigin());
         break;
       case Fact::Kind::MovedOrigin:
       case Fact::Kind::OriginEscapes:
@@ -169,18 +171,21 @@ public:
 
   /// A flow from source to destination. If `KillDest` is true, this replaces
   /// the destination's loans with the source's. Otherwise, the source's loans
-  /// are merged into the destination's. If the source is nullopt, this is a
-  /// kill-only flow that clears the destination without adding new loans.
+  /// are merged into the destination's.
   Lattice transfer(Lattice In, const OriginFlowFact &F) {
     OriginID DestOID = F.getDestOriginID();
+    OriginID SrcOID = F.getSrcOriginID();
 
     LoanSet DestLoans =
         F.getKillDest() ? LoanSetFactory.getEmptySet() : getLoans(In, DestOID);
-    LoanSet SrcLoans = F.getSrcOriginID() ? getLoans(In, *F.getSrcOriginID())
-                                          : LoanSetFactory.getEmptySet();
+    LoanSet SrcLoans = getLoans(In, SrcOID);
     LoanSet MergedLoans = utils::join(DestLoans, SrcLoans, LoanSetFactory);
 
     return setLoans(In, DestOID, MergedLoans);
+  }
+
+  Lattice transfer(Lattice In, const KillOriginFact &F) {
+    return setLoans(In, F.getKilledOrigin(), LoanSetFactory.getEmptySet());
   }
 
   Lattice transfer(Lattice In, const ExpireFact &F) {

--- a/clang/lib/Analysis/LifetimeSafety/Origins.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Origins.cpp
@@ -107,14 +107,13 @@ bool OriginManager::hasOrigins(QualType QT) const {
   const auto *RD = QT->getAsCXXRecordDecl();
   if (!RD)
     return false;
-  // TODO: Limit to lambdas for now. This will be extended to user-defined
-  // structs with pointer-like fields.
-  if (!RD->isLambda())
-    return false;
-  for (const auto *FD : RD->fields())
-    if (hasOrigins(FD->getType()))
-      return true;
-  return false;
+  // Standard library callable wrappers (e.g., std::function) can propagate the
+  // stored lambda's origins.
+  if (isStdCallableWrapperType(RD))
+    return true;
+  // TODO: Extend origin tracking to user-defined structs that may carry
+  // origins.
+  return RD->isLambda();
 }
 
 /// Determines if an expression has origins that need to be tracked.

--- a/clang/lib/Analysis/LifetimeSafety/Origins.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Origins.cpp
@@ -111,9 +111,14 @@ bool OriginManager::hasOrigins(QualType QT) const {
   // stored lambda's origins.
   if (isStdCallableWrapperType(RD))
     return true;
-  // TODO: Extend origin tracking to user-defined structs that may carry
-  // origins.
-  return RD->isLambda();
+  // TODO: Limit to lambdas for now. This will be extended to user-defined
+  // structs with pointer-like fields.
+  if (!RD->isLambda())
+    return false;
+  for (const auto *FD : RD->fields())
+    if (hasOrigins(FD->getType()))
+      return true;
+  return false;
 }
 
 /// Determines if an expression has origins that need to be tracked.

--- a/clang/test/Sema/Inputs/lifetime-analysis.h
+++ b/clang/test/Sema/Inputs/lifetime-analysis.h
@@ -274,7 +274,11 @@ template<class R, class... Args>
 class function<R(Args...)> {
 public:
   template<class F> function(F) {}
+  function(const function&) {}
+  function(function&&) {}
   template<class F> function& operator=(F) { return *this; }
+  function& operator=(const function&) { return *this; }
+  function& operator=(function&&) { return *this; }
   ~function();
 };
 

--- a/clang/test/Sema/Inputs/lifetime-analysis.h
+++ b/clang/test/Sema/Inputs/lifetime-analysis.h
@@ -268,4 +268,14 @@ struct true_type {
 template<class T> struct is_pointer : false_type {};
 template<class T> struct is_pointer<T*> : true_type {};
 template<class T> struct is_pointer<T* const> : true_type {};
+
+template<class> class function;
+template<class R, class... Args>
+class function<R(Args...)> {
+public:
+  template<class F> function(F) {}
+  template<class F> function& operator=(F) { return *this; }
+  ~function();
+};
+
 }

--- a/clang/test/Sema/warn-lifetime-safety-dangling-field.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-dangling-field.cpp
@@ -196,3 +196,16 @@ struct DerivedWithCtor : BaseWithPointer {
   }
 };
 } // namespace DanglingPointerFieldInBaseClass
+
+namespace callable_wrappers {
+
+struct HasCallback {
+  std::function<void()> callback; // expected-note {{this field dangles}}
+
+  void set_callback() {
+    int local;
+    callback = [&local]() { (void)local; }; // expected-warning {{address of stack memory escapes to a field}}
+  }
+};
+
+} // namespace callable_wrappers

--- a/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
@@ -527,3 +527,15 @@ struct S {
   }
 };
 } // namespace method_call_uses_field_invalidation
+
+namespace callable_wrappers {
+
+void function_captured_ref_invalidated() {
+  std::vector<int> v;
+  v.push_back(1);
+  std::function<void()> f = [&r = v[0]]() { (void)r; }; // expected-warning {{object whose reference is captured is later invalidated}}
+  v.push_back(2); // expected-note {{invalidated here}}
+  (void)f; // expected-note {{later used here}}
+}
+
+} // namespace callable_wrappers

--- a/clang/test/Sema/warn-lifetime-safety-noescape.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-noescape.cpp
@@ -191,3 +191,11 @@ MyObj& return_ref_from_noescape_ptr(
 int* return_spaced_brackets(int* p [ [clang::noescape] /*some comment*/ ]) { // expected-warning {{parameter is marked [[clang::noescape]] but escapes}}
   return p; // expected-note {{returned here}}
 }
+
+namespace callable_wrappers {
+
+std::function<void()> escape_noescape_via_function(int &x [[clang::noescape]]) { // expected-warning {{parameter is marked [[clang::noescape]] but escapes}}
+  return [&]() { (void)x; }; // expected-note {{returned here}}
+}
+
+} // namespace callable_wrappers

--- a/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
@@ -62,6 +62,21 @@ struct ReturnThisPointer {
 };
 
 
+namespace std {
+template<class> class function;
+template<class R, class... Args>
+class function<R(Args...)> {
+public:
+  template<class F> function(F) {}
+  function(const function&) {}
+  function(function&&) {}
+  template<class F> function& operator=(F) { return *this; }
+  function& operator=(const function&) { return *this; }
+  function& operator=(function&&) { return *this; }
+  ~function();
+};
+} // namespace std
+
 #endif // TEST_HEADER_H
 
 //--- test_source.cpp
@@ -529,3 +544,11 @@ CaptureRefToBaseView test_ref_to_base_view() {
   return x; // expected-note {{returned here}}
 }
 } // namespace capturing_constructor
+
+namespace callable_wrappers {
+
+std::function<void()> return_lambda_capturing_param(int &x) { // expected-warning {{parameter in intra-TU function should be marked [[clang::lifetimebound]]}}
+  return [&]() { (void)x; }; // expected-note {{param returned here}}
+}
+
+} // namespace callable_wrappers

--- a/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
@@ -537,4 +537,13 @@ std::function<void()> return_lambda_capturing_param(int &x) { // expected-warnin
   return [&]() { (void)x; }; // expected-note {{param returned here}}
 }
 
+void uaf_via_inferred_lifetimebound() {
+  std::function<void()> f = []() {};
+  {
+    int local;
+    f = return_lambda_capturing_param(local); // expected-warning {{object whose reference is captured does not live long enough}}
+  } // expected-note {{destroyed here}}
+  (void)f; // expected-note {{later used here}}
+}
+
 } // namespace callable_wrappers

--- a/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %clang_cc1 -fsyntax-only -flifetime-safety-inference -fexperimental-lifetime-safety-tu-analysis -Wlifetime-safety-suggestions -Wlifetime-safety -Wno-dangling -I%t -verify %t/test_source.cpp
-// RUN: %clang_cc1 -flifetime-safety-inference -fexperimental-lifetime-safety-tu-analysis -Wlifetime-safety-suggestions -Wlifetime-safety -Wno-dangling -I%t -fixit %t/test_source.cpp
-// RUN: %clang_cc1 -fsyntax-only -flifetime-safety-inference -fexperimental-lifetime-safety-tu-analysis -Wlifetime-safety-suggestions -Wno-dangling -I%t -Werror=lifetime-safety-suggestions %t/test_source.cpp
+// RUN: %clang_cc1 -fsyntax-only -flifetime-safety-inference -fexperimental-lifetime-safety-tu-analysis -Wlifetime-safety-suggestions -Wlifetime-safety -Wno-dangling -I%t -I%S -verify %t/test_source.cpp
+// RUN: %clang_cc1 -flifetime-safety-inference -fexperimental-lifetime-safety-tu-analysis -Wlifetime-safety-suggestions -Wlifetime-safety -Wno-dangling -I%t -I%S -fixit %t/test_source.cpp
+// RUN: %clang_cc1 -fsyntax-only -flifetime-safety-inference -fexperimental-lifetime-safety-tu-analysis -Wlifetime-safety-suggestions -Wno-dangling -I%t -I%S -Werror=lifetime-safety-suggestions %t/test_source.cpp
 
 View definition_before_header(View a);
 
@@ -62,26 +62,12 @@ struct ReturnThisPointer {
 };
 
 
-namespace std {
-template<class> class function;
-template<class R, class... Args>
-class function<R(Args...)> {
-public:
-  template<class F> function(F) {}
-  function(const function&) {}
-  function(function&&) {}
-  template<class F> function& operator=(F) { return *this; }
-  function& operator=(const function&) { return *this; }
-  function& operator=(function&&) { return *this; }
-  ~function();
-};
-} // namespace std
-
 #endif // TEST_HEADER_H
 
 //--- test_source.cpp
 
 #include "test_header.h"
+#include "Inputs/lifetime-analysis.h"
 
 View definition_before_header(View a) {
   return a;                               // expected-note {{param returned here}}

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2635,6 +2635,25 @@ std::function<void()> copy_function() {
   return f2; // expected-note {{returned here}}
 }
 
+std::function<void()> copy_assign() {
+  int x;
+  std::function<void()> f = [&x]() { (void)x; }; // expected-warning {{address of stack memory is returned later}}
+  std::function<void()> f2 = []() {};
+  f2 = f;
+  return f2; // expected-note {{returned here}}
+}
+
+// FIXME: False negative. std::move's lifetimebound handling in
+// `handleFunctionCall` only flows the outermost origin, missing inner origins
+// that carry the lambda's loans.
+std::function<void()> move_assign() {
+  int x;
+  std::function<void()> f = [&x]() { (void)x; }; // Should warn.
+  std::function<void()> f2 = []() {};
+  f2 = std::move(f);
+  return f2;
+}
+
 std::function<void()> reassign_safe_then_unsafe() {
   static int safe = 1;
   int local = 2;

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2693,4 +2693,15 @@ std::function<void()> reassign_lambda_to_functor() {
   return f;
 }
 
+struct [[gsl::Pointer]] function_ref {
+  template <typename Callable>
+  function_ref(Callable &&callable [[clang::lifetimebound]]) : ref(callable) {}
+  void (*ref)();
+};
+
+function_ref function_ref_from_non_capturing_lambda() {
+  return []() {}; // expected-warning {{address of stack memory is returned later}} \
+                  // expected-note {{returned here}}
+}
+
 } // namespace callable_wrappers

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2699,14 +2699,10 @@ struct [[gsl::Pointer]] function_ref {
   void (*ref)();
 };
 
-function_ref function_ref_from_non_capturing_lambda() {
-  return []() {}; // expected-warning {{address of stack memory is returned later}} \
-                  // expected-note {{returned here}}
-}
-
 void assign_non_capturing_to_function_ref(function_ref &r) {
-  r = []() {};
-  (void)r;
+  r = []() {}; // expected-warning {{object whose reference is captured does not live long enough}} \
+               // expected-note {{destroyed here}}
+  (void)r; // expected-note {{later used here}}
 }
 
 } // namespace callable_wrappers

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2666,13 +2666,12 @@ std::function<void()> reassign_lambda_to_function_pointer() {
 
 struct Functor { void operator()() const; };
 
-// FIXME: False positive.
 std::function<void()> reassign_lambda_to_functor() {
   int local;
   Functor c;
-  std::function<void()> f = [&local]() { (void)local; }; // expected-warning {{address of stack memory is returned later}}
+  std::function<void()> f = [&local]() { (void)local; };
   f = c;
-  return f; // expected-note {{returned here}}
+  return f;
 }
 
 } // namespace callable_wrappers

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2619,3 +2619,60 @@ struct Y : X {
   }
 };
 } // namespace base_class_fields
+
+namespace callable_wrappers {
+
+std::function<void()> direct_return() {
+  int x;
+  return [&x]() { (void)x; }; // expected-warning {{address of stack memory is returned later}} \
+                              // expected-note {{returned here}}
+}
+
+std::function<void()> copy_function() {
+  int x;
+  std::function<void()> f = [&x]() { (void)x; }; // expected-warning {{address of stack memory is returned later}}
+  std::function<void()> f2 = f;
+  return f2; // expected-note {{returned here}}
+}
+
+std::function<void()> reassign_safe_then_unsafe() {
+  static int safe = 1;
+  int local = 2;
+  std::function<void()> f = []() { (void)safe; };
+  f = [&local]() { (void)local; }; // expected-warning {{address of stack memory is returned later}}
+  return f; // expected-note {{returned here}}
+}
+
+std::function<void()> reassign_unsafe_then_safe() {
+  static int safe = 1;
+  int local = 2;
+  std::function<void()> f = [&local]() { (void)local; };
+  f = []() { (void)safe; };
+  return f;
+}
+
+std::function<void()> non_capturing_lambda() {
+  return []() {};
+}
+
+void free_function();
+
+std::function<void()> reassign_lambda_to_function_pointer() {
+  int local;
+  std::function<void()> f = [&local]() { (void)local; };
+  f = &free_function;
+  return f;
+}
+
+struct Functor { void operator()() const; };
+
+// FIXME: False positive.
+std::function<void()> reassign_lambda_to_functor() {
+  int local;
+  Functor c;
+  std::function<void()> f = [&local]() { (void)local; }; // expected-warning {{address of stack memory is returned later}}
+  f = c;
+  return f; // expected-note {{returned here}}
+}
+
+} // namespace callable_wrappers

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2693,10 +2693,22 @@ std::function<void()> reassign_lambda_to_functor() {
   return f;
 }
 
+std::function<void()> capture_lifetimebound_param(int &x [[clang::lifetimebound]]) {
+  return [&]() { (void)x; };
+}
+
+void uaf_via_lifetimebound() {
+  std::function<void()> f = []() {};
+  {
+    int local;
+    f = capture_lifetimebound_param(local); // expected-warning {{object whose reference is captured does not live long enough}}
+  } // expected-note {{destroyed here}}
+  (void)f; // expected-note {{later used here}}
+}
+
 } // namespace callable_wrappers
 
 namespace GH126600 {
-// https://github.com/llvm/llvm-project/issues/126600
 struct [[gsl::Pointer]] function_ref {
   template <typename Callable>
   function_ref(Callable &&callable [[clang::lifetimebound]]) : ref(callable) {}

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2704,4 +2704,9 @@ function_ref function_ref_from_non_capturing_lambda() {
                   // expected-note {{returned here}}
 }
 
+void assign_non_capturing_to_function_ref(function_ref &r) {
+  r = []() {};
+  (void)r;
+}
+
 } // namespace callable_wrappers

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2693,16 +2693,24 @@ std::function<void()> reassign_lambda_to_functor() {
   return f;
 }
 
+} // namespace callable_wrappers
+
+namespace GH126600 {
+// https://github.com/llvm/llvm-project/issues/126600
 struct [[gsl::Pointer]] function_ref {
   template <typename Callable>
   function_ref(Callable &&callable [[clang::lifetimebound]]) : ref(callable) {}
   void (*ref)();
 };
 
+// FIXME: The lifetimebound annotation tracks the outer callable object's
+// storage rather than what the callable captures. A mechanism like
+// lifetimebound(2) could enable tracking inner lifetimes, which would
+// avoid this warning for non-capturing lambdas.
 void assign_non_capturing_to_function_ref(function_ref &r) {
   r = []() {}; // expected-warning {{object whose reference is captured does not live long enough}} \
                // expected-note {{destroyed here}}
   (void)r; // expected-note {{later used here}}
 }
 
-} // namespace callable_wrappers
+} // namespace GH126600


### PR DESCRIPTION
1. Recognizes `std::function` and `std::move_only_function` as types that can carry origins from a wrapped lambda's captures, propagating origins through both construction and assignment.
2. Adds a kill-only mechanism (i.e., a new `KillOriginFact`) to clear old loans when the RHS has no origins.

Fixes #186009