### PR TITLE
[orc-rt] Remove Session::waitForShutdown.

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -28,7 +28,7 @@
 #include "orc-rt-c/WrapperFunction.h"
 
 #include <cassert>
-#include <future>
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <type_traits>
@@ -218,6 +218,10 @@ public:
   Session(Session &&) = delete;
   Session &operator=(Session &&) = delete;
 
+  /// Destroy the session object.
+  ///
+  /// This will trigger shutdown if it has not happened already. Destruction
+  /// will block until the Session lifecycle completes.
   ~Session();
 
   /// Provides information about the host process that the Session is running
@@ -297,15 +301,6 @@ public:
   /// The optional OnShutdown callback is called after step (3), before
   /// the TaskDispatcher is shut down.
   void shutdown(OnShutdownFn OnShutdown = {});
-
-  /// Initiate session shutdown and block until complete.
-  ///
-  /// WARNING: Never call waitForShutdown from an on-detach or on-shutdown
-  ///          handler: this will cause a deadlock, since the Session can't
-  ///          shut down until all such handlers return. (The Session::shutdown
-  ///          method can be called from a handler to initiate shutdown,
-  ///          however).
-  void waitForShutdown();
 
   /// Register a callback to be called when the Session detaches from the
   /// controller. If the Session has already detached, the callback will be
@@ -477,6 +472,7 @@ private:
   ErrorReporterFn ReportError;
 
   mutable std::mutex M;
+  std::condition_variable CV;
   State CurrentState = State::Start;
   State TargetState = State::None;
   std::vector<std::unique_ptr<Service>> Services;

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -56,7 +56,13 @@ Session::Session(ExecutorProcessInfo EPI,
       ReportError(std::move(ReportError)),
       Notifiers(createService<NotificationService>()) {}
 
-Session::~Session() { waitForShutdown(); }
+Session::~Session() {
+  shutdown();
+  std::unique_lock<std::mutex> Lock(M);
+  CV.wait(Lock, [&]() {
+    return CurrentState == State::Shutdown && TargetState == State::None;
+  });
+}
 
 void Session::attach(std::shared_ptr<ControllerAccess> CA, BootstrapInfo BI) {
   assert(CA && "attach called with null CA object");
@@ -193,14 +199,6 @@ void Session::shutdown(OnShutdownFn OnShutdown) {
   }
 
   TmpCA->disconnect();
-}
-
-void Session::waitForShutdown() {
-  std::promise<void> P;
-  auto F = P.get_future();
-  addOnShutdown([P = std::move(P)]() mutable { P.set_value(); });
-  shutdown();
-  F.get();
 }
 
 void Session::addOnDetach(OnDetachFn OnDetach) {
@@ -354,10 +352,13 @@ void Session::shutdownServices(std::vector<Service *> ToNotify) {
 void Session::completeShutdown() {
   Dispatcher->shutdown();
 
-  std::unique_lock<std::mutex> Lock(M);
-  assert(CurrentState == State::Shutdown);
-  assert(TargetState == State::Shutdown);
-  TargetState = State::None;
+  {
+    std::scoped_lock<std::mutex> Lock(M);
+    assert(CurrentState == State::Shutdown);
+    assert(TargetState == State::Shutdown);
+    TargetState = State::None;
+  }
+  CV.notify_all();
 }
 
 void Session::wrapperReturn(orc_rt_SessionRef S, uint64_t CallId,

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -285,6 +285,13 @@ private:
   orc_rt_WrapperFunction Fn;
 };
 
+void waitForShutdown(Session &S) {
+  std::promise<void> P;
+  auto F = P.get_future();
+  S.shutdown([P = std::move(P)]() mutable { P.set_value(); });
+  F.get();
+}
+
 TEST(SessionTest, TrivialConstructionAndDestruction) {
   Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
             noErrors);
@@ -390,28 +397,29 @@ TEST(SessionTest, ExpectedShutdownSequenceWithNoActiveManagedCodeCalls) {
   size_t OpIdx = 0;
   std::optional<size_t> DetachOpIdx;
   std::optional<size_t> ShutdownOpIdx;
-
   bool DispatcherShutDown = false;
   bool SessionShutdownComplete = false;
-  std::deque<std::unique_ptr<Task>> Tasks;
-  Session S(mockExecutorProcessInfo(),
-            std::make_unique<EnqueueingDispatcher>(
-                Tasks,
-                [&]() {
-                  EXPECT_TRUE(ShutdownOpIdx);
-                  EXPECT_EQ(*ShutdownOpIdx, 1);
-                  EXPECT_TRUE(SessionShutdownComplete);
-                  DispatcherShutDown = true;
-                }),
-            noErrors);
-  S.addService(
-      std::make_unique<MockService>(DetachOpIdx, ShutdownOpIdx, OpIdx));
 
-  S.shutdown([&]() {
-    EXPECT_FALSE(DispatcherShutDown);
-    SessionShutdownComplete = true;
-  });
-  S.waitForShutdown();
+  {
+    std::deque<std::unique_ptr<Task>> Tasks;
+    Session S(mockExecutorProcessInfo(),
+              std::make_unique<EnqueueingDispatcher>(
+                  Tasks,
+                  [&]() {
+                    EXPECT_TRUE(ShutdownOpIdx);
+                    EXPECT_EQ(*ShutdownOpIdx, 1);
+                    EXPECT_TRUE(SessionShutdownComplete);
+                    DispatcherShutDown = true;
+                  }),
+              noErrors);
+    S.addService(
+        std::make_unique<MockService>(DetachOpIdx, ShutdownOpIdx, OpIdx));
+
+    S.shutdown([&]() {
+      EXPECT_FALSE(DispatcherShutDown);
+      SessionShutdownComplete = true;
+    });
+  }
 
   EXPECT_TRUE(SessionShutdownComplete);
 }
@@ -471,7 +479,7 @@ TEST(SessionTest, SyncCallManagedCodeVoidFn) {
     EXPECT_EQ(X, 42U);
   }
 
-  S.waitForShutdown();
+  waitForShutdown(S);
 
   {
     // Post-shutdown we expect token acquisition to fail, and
@@ -500,7 +508,7 @@ TEST(SessionTest, SyncCallManagedCodeNonVoidFn) {
     EXPECT_EQ(*Result, 42U);
   }
 
-  S.waitForShutdown();
+  waitForShutdown(S);
 
   {
     // Post-shutdown we expect token acquisition to fail, and
@@ -534,7 +542,7 @@ TEST(SessionTest, AsyncCallManagedCodeVoidFn) {
     EXPECT_EQ(X, 42U);
   }
 
-  S.waitForShutdown();
+  waitForShutdown(S);
 
   {
     // Post-shutdown we expect token acquisition to fail. Return should be
@@ -571,7 +579,7 @@ TEST(SessionTest, AsyncCallManagedCodeNonVoidFn) {
     EXPECT_EQ(N, 42U);
   }
 
-  S.waitForShutdown();
+  waitForShutdown(S);
 
   {
     // Post-shutdown we expect token acquisition to fail. Return should be
@@ -677,8 +685,6 @@ TEST(ControllerAccessTest, Basics) {
   S.attach(CA, BootstrapInfo(S));
 
   EnqueueingDispatcher::runTasksFromFront(Tasks);
-
-  S.waitForShutdown();
 }
 
 static void add_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
@@ -707,8 +713,6 @@ TEST(ControllerAccessTest, ValidCallToController) {
   EnqueueingDispatcher::runTasksFromFront(Tasks);
 
   EXPECT_EQ(Result, 42);
-
-  S.waitForShutdown();
 }
 
 TEST(ControllerAccessTest, CallToControllerBeforeAttach) {
@@ -727,8 +731,6 @@ TEST(ControllerAccessTest, CallToControllerBeforeAttach) {
       41, 1);
 
   EXPECT_EQ(toString(std::move(Err)), "no controller attached");
-
-  S.waitForShutdown();
 }
 
 TEST(ControllerAccessTest, CallToControllerAfterDetach) {
@@ -751,8 +753,6 @@ TEST(ControllerAccessTest, CallToControllerAfterDetach) {
       41, 1);
 
   EXPECT_EQ(toString(std::move(Err)), "no controller attached");
-
-  S.waitForShutdown();
 }
 
 TEST(ControllerAccessTest, CallFromController) {
@@ -771,8 +771,6 @@ TEST(ControllerAccessTest, CallFromController) {
   EnqueueingDispatcher::runTasksFromFront(Tasks);
 
   EXPECT_EQ(Result, 42);
-
-  S.waitForShutdown();
 }
 
 TEST(ControllerAccessTest, RedundantAsyncShutdown) {
@@ -780,8 +778,12 @@ TEST(ControllerAccessTest, RedundantAsyncShutdown) {
   std::deque<std::unique_ptr<Task>> Tasks;
   Session S(mockExecutorProcessInfo(),
             std::make_unique<EnqueueingDispatcher>(Tasks), noErrors);
-  S.waitForShutdown();
 
+  // Initiate shutdown here, and wait for the on-shutdown callbacks to start
+  // running.
+  waitForShutdown(S);
+
+  // Now try to add a new on-shutdown callback and verify that it runs.
   bool RedundantCallbackRan = false;
   S.shutdown([&]() { RedundantCallbackRan = true; });
   EXPECT_TRUE(RedundantCallbackRan);
@@ -814,6 +816,4 @@ TEST(ControllerAccessTest, BootstrapInfoPassedToConnect) {
   S.attach(CA, std::move(BI));
 
   ASSERT_TRUE(OnConnectRan);
-
-  S.waitForShutdown();
 }


### PR DESCRIPTION
The existing implementation triggered Session shutdown and then blocked on a std::future that would be unblocked by an on-shutdown callback that waitForShutdown had installed. Since there is no guarantee that this callback would be the last one run, the result was that waitForShutdown only guaranteed that it would not return until the shutdown sequence had started (rather than completed).

This could have been fixed, but the Session destructor is already supposed to block until the Session can be safely destroyed, so a "working" waitForShutdown would be effectively redundant. Since it was also a potential footgun (calling it from an on-detach or on-shutdown callback could deadlock) it was safer to just remove it entirely.

Some Session unit tests do rely on testing properties of the Session after the shutdown sequence has started, so a new utility has been added to SessionTests.cpp to support this.