### PR TITLE
[NFC][SPIR-V] Fix spirv_param_decorations test to use valid parameter types and decorations

### DIFF
--- a/llvm/test/CodeGen/SPIRV/spirv_param_decorations.ll
+++ b/llvm/test/CodeGen/SPIRV/spirv_param_decorations.ll
@@ -1,18 +1,22 @@
-; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; Test that !spirv.ParameterDecorations metadata is correctly translated
+; into OpDecorate instructions on function parameters.
 
-define spir_kernel void @k(float %a, float %b, float %c) !spirv.ParameterDecorations !14 {
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+define spir_kernel void @k(ptr addrspace(1) %a, float %b, ptr addrspace(1) %c) !spirv.ParameterDecorations !14 {
 entry:
   ret void
 }
 
 ; CHECK-SPIRV: OpDecorate %[[#PId1:]] Restrict
-; CHECK-SPIRV: OpDecorate %[[#PId1]] FPRoundingMode RTP
+; CHECK-SPIRV: OpDecorate %[[#PId1]] Alignment 4
 ; CHECK-SPIRV: OpDecorate %[[#PId2:]] Volatile
 ; CHECK-SPIRV: %[[#PId1]] = OpFunctionParameter %[[#]]
 ; CHECK-SPIRV: %[[#PId2]] = OpFunctionParameter %[[#]]
 
 !8 = !{i32 19}
-!9 = !{i32 39, i32 2}
+!9 = !{i32 44, i32 4}
 !10 = !{i32 21}
 !11 = !{!8, !9}
 !12 = !{}


### PR DESCRIPTION
Update the test logic:
- Change float parameters to ptr, because `Restrict` and `Volatile` decorations are only valid on pointer types, not scalars, like float
- Replaced FPRoundingMode (39) with Alignment (44), because FPRoundingMode can only be applied to conversion instructions not to function parameters