### PR TITLE
[AArch64][MachineOutliner] Relax callee stack access check for non-terminal call outlining

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -10694,8 +10694,6 @@ AArch64InstrInfo::getOutliningTypeImpl(const MachineModuleInfo &MMI,
   // plus the call, then we'll break the callee's expectations for the layout
   // of the stack.
   //
-  // FIXME: Allow calls to functions which construct a stack frame, as long
-  // as they don't access arguments on the stack.
   // FIXME: Figure out some way to analyze functions defined in other modules.
   // We should be able to compute the memory usage based on the IR calling
   // convention, even if we can't see the definition.
@@ -10738,13 +10736,20 @@ AArch64InstrInfo::getOutliningTypeImpl(const MachineModuleInfo &MMI,
     // Check if we know anything about the callee saves on the function. If we
     // don't, then don't touch it, since that implies that we haven't
     // computed anything about its stack frame yet.
+    // A variadic callee may read stack arguments at offsets above its entry
+    // SP - some calling conventions always put variadic arguments on stack,
+    // so conservatively reject it.
     MachineFrameInfo &MFI = CalleeMF->getFrameInfo();
-    if (!MFI.isCalleeSavedInfoValid() || MFI.getStackSize() > 0 ||
-        MFI.getNumObjects() > 0)
+    if (!MFI.isCalleeSavedInfoValid() || CalleeMF->getFunction().isVarArg())
       return UnknownCallOutlineType;
 
-    // At this point, we can say that CalleeMF ought to not pass anything on the
-    // stack. Therefore, we can outline it.
+    // If the callee has fixed incoming stack arguments, outlining is unsafe
+    // except for tail calls.
+    if (MFI.getNumFixedObjects() > 0)
+      return UnknownCallOutlineType;
+
+    // At this point, we can say that CalleeMF does not access incoming stack
+    // arguments above its entry SP. Therefore, it is safe to outline.
     return outliner::InstrType::Legal;
   }
 

--- a/llvm/test/CodeGen/AArch64/machine-outliner-calls-stack.mir
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-calls-stack.mir
@@ -1,0 +1,182 @@
+# RUN: llc -mtriple=aarch64--- -run-pass=prologepilog -run-pass=machine-outliner -verify-machineinstrs %s -o - | FileCheck %s
+--- |
+  define void @callee_with_locals() #0 {
+    ret void
+  }
+
+  define void @callee_with_stack_args(i64 %a, i64 %b, i64 %c, i64 %d, i64 %e, i64 %f, i64 %g, i64 %h, i64 %i) #0 {
+    ret void
+  }
+
+  define void @callee_variadic(...) #0 {
+    ret void
+  }
+
+  define void @caller1() #0 {
+    ret void
+  }
+
+  define void @caller2() #0 {
+    ret void
+  }
+
+  define void @caller3() #0 {
+    ret void
+  }
+
+  attributes #0 = { noredzone nounwind }
+...
+---
+
+# Callee clobbers callee-saved registers, has no incoming stack arguments. The
+# call should be outlined as Legal.
+
+name:            callee_with_locals
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $lr
+    $x19 = MOVZXi 1, 0
+    $x20 = MOVZXi 2, 0
+    RET undef $lr
+...
+---
+
+# Callee has incoming stack arguments. The call should NOT be outlined as Legal.
+
+name:            callee_with_stack_args
+tracksRegLiveness: true
+fixedStack:
+  - { id: 0, offset: 0, size: 8, alignment: 8 }
+body:             |
+  bb.0:
+    liveins: $lr
+    RET undef $lr
+...
+---
+
+# Callee has variadic arguments. The call should NOT be outlined as Legal.
+
+name:            callee_variadic
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $lr
+    RET undef $lr
+...
+---
+
+# CHECK-LABEL: name:            caller1
+name:            caller1
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $lr, $w8
+
+  ; CHECK-LABEL: bb.1:
+  ; CHECK-NOT: BL @callee_with_locals
+  ; CHECK: BL @[[LOCALS_FUNC:OUTLINED_FUNCTION_[0-9]+]]
+  bb.1:
+    BL @callee_with_locals, implicit-def dead $lr, implicit $sp
+    $w17 = ORRWri $wzr, 1
+    $w17 = ORRWri $wzr, 1
+    $w0 = ORRWri $wzr, 4
+
+    BL @callee_with_locals, implicit-def dead $lr, implicit $sp
+    $w17 = ORRWri $wzr, 1
+    $w17 = ORRWri $wzr, 1
+    $w0 = ORRWri $wzr, 3
+
+    BL @callee_with_locals, implicit-def dead $lr, implicit $sp
+    $w17 = ORRWri $wzr, 1
+    $w17 = ORRWri $wzr, 1
+    $w0 = ORRWri $wzr, 2
+
+    BL @callee_with_locals, implicit-def dead $lr, implicit $sp
+    $w17 = ORRWri $wzr, 1
+    $w17 = ORRWri $wzr, 1
+    $w0 = ORRWri $wzr, 1
+
+  bb.2:
+    RET undef $lr
+...
+---
+
+# CHECK-LABEL: name:            caller2
+name:            caller2
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $lr, $w8
+
+  ; CHECK-LABEL: bb.1:
+  ; CHECK: BL @callee_with_stack_args
+  ; CHECK-NEXT: BL @[[STACK_ARGS_FUNC:OUTLINED_FUNCTION_[0-9]+]]
+  bb.1:
+    BL @callee_with_stack_args, implicit-def dead $lr, implicit $sp
+    $w16 = ORRWri $wzr, 2
+    $w16 = ORRWri $wzr, 2
+    $w0 = ORRWri $wzr, 4
+
+    BL @callee_with_stack_args, implicit-def dead $lr, implicit $sp
+    $w16 = ORRWri $wzr, 2
+    $w16 = ORRWri $wzr, 2
+    $w0 = ORRWri $wzr, 3
+
+    BL @callee_with_stack_args, implicit-def dead $lr, implicit $sp
+    $w16 = ORRWri $wzr, 2
+    $w16 = ORRWri $wzr, 2
+    $w0 = ORRWri $wzr, 2
+
+    BL @callee_with_stack_args, implicit-def dead $lr, implicit $sp
+    $w16 = ORRWri $wzr, 2
+    $w16 = ORRWri $wzr, 2
+    $w0 = ORRWri $wzr, 1
+
+  bb.2:
+    RET undef $lr
+
+---
+
+# CHECK-LABEL: name:            caller3
+name:            caller3
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $lr, $w8
+
+  ; CHECK-LABEL: bb.1:
+  ; CHECK: BL @callee_variadic
+  ; CHECK-NEXT: BL @[[VARIADIC_FUNC:OUTLINED_FUNCTION_[0-9]+]]
+  bb.1:
+    BL @callee_variadic, implicit-def dead $lr, implicit $sp
+    $w15 = ORRWri $wzr, 3
+    $w15 = ORRWri $wzr, 3
+    $w0 = ORRWri $wzr, 4
+
+    BL @callee_variadic, implicit-def dead $lr, implicit $sp
+    $w15 = ORRWri $wzr, 3
+    $w15 = ORRWri $wzr, 3
+    $w0 = ORRWri $wzr, 3
+
+    BL @callee_variadic, implicit-def dead $lr, implicit $sp
+    $w15 = ORRWri $wzr, 3
+    $w15 = ORRWri $wzr, 3
+    $w0 = ORRWri $wzr, 2
+
+    BL @callee_variadic, implicit-def dead $lr, implicit $sp
+    $w15 = ORRWri $wzr, 3
+    $w15 = ORRWri $wzr, 3
+    $w0 = ORRWri $wzr, 1
+
+  bb.2:
+    RET undef $lr
+
+# CHECK: name: [[LOCALS_FUNC]]
+# CHECK: BL @callee_with_locals
+
+# CHECK: name: [[STACK_ARGS_FUNC]]
+# CHECK-NOT: BL @callee_with_stack_args
+
+# CHECK: name: [[VARIADIC_FUNC]]
+# CHECK-NOT: BL @callee_variadic

--- a/llvm/test/DebugInfo/AArch64/machine-outliner.ll
+++ b/llvm/test/DebugInfo/AArch64/machine-outliner.ll
@@ -27,6 +27,13 @@
 ; CHECK-NEXT: DW_AT_artificial	(0x01)
 ; CHECK-NEXT: DW_AT_external	(0x01)
 
+; Both foo and bar call an external function without a visible definition so
+; the BL is classified as LegalTerminator and the outliner does not bail out
+; because of CFI instructions in a non-tail-call candidate. The specific
+; callee does not matter for this test; it only checks that the outlined
+; function gets valid DWARF.
+declare void @baz()
+
 define void @foo() #0 !dbg !8 {
 entry:
   %p = alloca ptr, align 8
@@ -34,7 +41,7 @@ entry:
   %0 = load ptr, ptr %p, align 8, !dbg !15
   %incdec.ptr = getelementptr inbounds i32, ptr %0, i32 1, !dbg !15
   store ptr %incdec.ptr, ptr %p, align 8, !dbg !15
-  call void @foo(), !dbg !16
+  call void @baz(), !dbg !16
   ret void, !dbg !17
 }
 
@@ -47,7 +54,7 @@ entry:
   %0 = load ptr, ptr %p, align 8, !dbg !21
   %incdec.ptr = getelementptr inbounds i32, ptr %0, i32 1, !dbg !21
   store ptr %incdec.ptr, ptr %p, align 8, !dbg !21
-  call void @foo(), !dbg !22
+  call void @baz(), !dbg !22
   ret void, !dbg !23
 }
 


### PR DESCRIPTION
The outliner currently rejects non-terminal outlining of calls to functions with any stack usage, which is overly conservative: the only unsafe case is when the callee reads incoming stack arguments above its entry SP, since the outlined function's LR save shifts SP down by 16.

Relax the check to only reject calls to callees that have:
- Fixed stack objects (incoming stack arguments), or
- Variadic parameters

Depends on #191120. Promoting BL from LegalTerminator to Legal means candidate sequences containing add/sub SP instructions now require LR save/restore, which shifts SP. Without the fixup, IsSafeToFixup rejects these SP-reading instructions, preventing outlining of sequences that were previously outlinable as thunks and causing code size regressions.

CTMark Oz AArch64 code size diff (with both patches):
Non-LTO:
```
  Program                                     size.__text                 size
                                              baseline    modified  diff  baseline   modified   diff
  ClamAV/clamscan                             336388.00   336432.00  0.0%  622816.00  622560.00 -0.0%
  consumer-typeset/consumer-typeset           323184.00   323224.00  0.0%  487904.00  487808.00 -0.0%
  mafft/pairlocalalign                        205440.00   205452.00  0.0%  325520.00  325456.00 -0.0%
  sqlite3/sqlite3                             229124.00   229136.00  0.0%  382720.00  382672.00 -0.0%
  kimwitu++/kc                                301412.00   301408.00 -0.0% 1261152.00 1260944.00 -0.0%
  lencod/lencod                               381364.00   381344.00 -0.0%  616400.00  616272.00 -0.0%
  7zip/7zip-benchmark                         487008.00   486964.00 -0.0% 1095616.00 1095472.00 -0.0%
  SPASS/SPASS                                 299864.00   299748.00 -0.0%  519808.00  519264.00 -0.1%
  Bullet/bullet                               375036.00   374824.00 -0.1% 1596688.00 1596176.00 -0.0%
  tramp3d-v4/tramp3d-v4                       346700.00   346480.00 -0.1% 1206560.00 1205680.00 -0.1%
                             Geomean difference                     -0.0%                       -0.0%
```
FullLTO:
```
  Program                                     size.__text                 size
                                              baseline    modified  diff  baseline  modified   diff
  sqlite3/sqlite3                             220776.00   220820.00  0.0% 358240.00 358080.00 -0.0%
  consumer-typeset/consumer-typeset           262448.00   262492.00  0.0% 428624.00 427840.00 -0.2%
  mafft/pairlocalalign                         70796.00    70796.00  0.0% 163056.00 163056.00  0.0%
  lencod/lencod                               341208.00   341108.00 -0.0% 538080.00 537824.00 -0.0%
  ClamAV/clamscan                             284096.00   284008.00 -0.0% 556400.00 555552.00 -0.2%
  Bullet/bullet                               137292.00   137168.00 -0.1% 708848.00 708528.00 -0.0%
  kimwitu++/kc                                238384.00   238092.00 -0.1% 876800.00 874320.00 -0.3%
  7zip/7zip-benchmark                         393576.00   393072.00 -0.1% 849888.00 849840.00 -0.0%
  SPASS/SPASS                                 213692.00   213400.00 -0.1% 409168.00 407456.00 -0.4%
  tramp3d-v4/tramp3d-v4                       179028.00   177840.00 -0.7% 538944.00 531376.00 -1.4%
                             Geomean difference                     -0.1%                     -0.3%
```