### PR TITLE
[Polly] Remove pipeline-level Oz handling for LoopRotate

### DIFF
--- a/polly/lib/Transform/Canonicalization.cpp
+++ b/polly/lib/Transform/Canonicalization.cpp
@@ -83,7 +83,7 @@ polly::buildCanonicalicationPassesForNPM(llvm::ModulePassManager &MPM,
   FPM.addPass(ReassociatePass());
   {
     LoopPassManager LPM;
-    LPM.addPass(LoopRotatePass(Level != OptimizationLevel::Oz));
+    LPM.addPass(LoopRotatePass());
     FPM.addPass(createFunctionToLoopPassAdaptor<LoopPassManager>(
         std::move(LPM), /*UseMemorySSA=*/false));
   }


### PR DESCRIPTION
This handling was moved fully into the pass in
1662c200a5b151ad15b7efc82837076d8967dc11. However, that changed
missed the usage of LoopRotate in polly.