### PR TITLE
[AArch64][CodeGen] match (or x (not y)) to generate mov+orn

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -3324,6 +3324,10 @@ def : InstAlias<"tst $src1, $src2$sh",
                 (ANDSXrs XZR, GPR64:$src1,
                          (logical_shifted_reg64 GPR64:$src2, logical_shift64:$sh)), 2>;
 
+def : Pat<(or (not GPR32:$Wm), (i32 imm:$x)),
+          (ORNWrr (MOVi32imm imm:$x), GPR32:$Wm)>;
+def : Pat<(or (not GPR64:$Xm), (i64 imm:$x)),
+          (ORNXrr (MOVi64imm imm:$x), GPR64:$Xm)>;
 
 def : Pat<(not GPR32:$Wm), (ORNWrr WZR, GPR32:$Wm)>;
 def : Pat<(not GPR64:$Xm), (ORNXrr XZR, GPR64:$Xm)>;

--- a/llvm/test/CodeGen/AArch64/arm64-atomic.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-atomic.ll
@@ -82,10 +82,10 @@ define i64 @val_compare_and_swap_64(ptr %p, i64 %cmp, i64 %new) #0 {
 
 define i32 @fetch_and_nand(ptr %p) #0 {
 ; CHECK-LABEL: fetch_and_nand:
+; CHECK: mov    [[CST_REG:w[0-9]+]], #-8
 ; CHECK: [[TRYBB:.?LBB[0-9_]+]]:
 ; CHECK: ldxr   w[[DEST_REG:[0-9]+]], [x0]
-; CHECK: mvn    [[TMP_REG:w[0-9]+]], w[[DEST_REG]]
-; CHECK: orr    [[SCRATCH2_REG:w[0-9]+]], [[TMP_REG]], #0xfffffff8
+; CHECK: orn    [[SCRATCH2_REG:w[0-9]+]], [[CST_REG]], w[[DEST_REG]]
 ; CHECK-NOT: stlxr [[SCRATCH2_REG]], [[SCRATCH2_REG]]
 ; CHECK: stlxr   [[SCRATCH_REG:w[0-9]+]], [[SCRATCH2_REG]], [x0]
 ; CHECK: cbnz   [[SCRATCH_REG]], [[TRYBB]]

--- a/llvm/test/CodeGen/AArch64/atomicrmw-O0.ll
+++ b/llvm/test/CodeGen/AArch64/atomicrmw-O0.ll
@@ -303,8 +303,8 @@ define i8 @test_rmw_nand_8(ptr %dst)   {
 ; NOLSE-NEXT:    // Child Loop BB5_2 Depth 2
 ; NOLSE-NEXT:    ldr w9, [sp, #28] // 4-byte Reload
 ; NOLSE-NEXT:    ldr x11, [sp, #16] // 8-byte Reload
-; NOLSE-NEXT:    mvn w8, w9
-; NOLSE-NEXT:    orr w12, w8, #0xfffffffe
+; NOLSE-NEXT:    mov w8, #-2 // =0xfffffffe
+; NOLSE-NEXT:    orn w12, w8, w9
 ; NOLSE-NEXT:  .LBB5_2: // %atomicrmw.start
 ; NOLSE-NEXT:    // Parent Loop BB5_1 Depth=1
 ; NOLSE-NEXT:    // => This Inner Loop Header: Depth=2
@@ -339,8 +339,8 @@ define i8 @test_rmw_nand_8(ptr %dst)   {
 ; LSE-NEXT:    // =>This Inner Loop Header: Depth=1
 ; LSE-NEXT:    ldr w9, [sp, #28] // 4-byte Reload
 ; LSE-NEXT:    ldr x11, [sp, #16] // 8-byte Reload
-; LSE-NEXT:    mvn w8, w9
-; LSE-NEXT:    orr w10, w8, #0xfffffffe
+; LSE-NEXT:    mov w8, #-2 // =0xfffffffe
+; LSE-NEXT:    orn w10, w8, w9
 ; LSE-NEXT:    mov w8, w9
 ; LSE-NEXT:    casalb w8, w10, [x11]
 ; LSE-NEXT:    subs w9, w8, w9, uxtb
@@ -371,8 +371,8 @@ define i16 @test_rmw_nand_16(ptr %dst)   {
 ; NOLSE-NEXT:    // Child Loop BB6_2 Depth 2
 ; NOLSE-NEXT:    ldr w9, [sp, #28] // 4-byte Reload
 ; NOLSE-NEXT:    ldr x11, [sp, #16] // 8-byte Reload
-; NOLSE-NEXT:    mvn w8, w9
-; NOLSE-NEXT:    orr w12, w8, #0xfffffffe
+; NOLSE-NEXT:    mov w8, #-2 // =0xfffffffe
+; NOLSE-NEXT:    orn w12, w8, w9
 ; NOLSE-NEXT:  .LBB6_2: // %atomicrmw.start
 ; NOLSE-NEXT:    // Parent Loop BB6_1 Depth=1
 ; NOLSE-NEXT:    // => This Inner Loop Header: Depth=2
@@ -407,8 +407,8 @@ define i16 @test_rmw_nand_16(ptr %dst)   {
 ; LSE-NEXT:    // =>This Inner Loop Header: Depth=1
 ; LSE-NEXT:    ldr w9, [sp, #28] // 4-byte Reload
 ; LSE-NEXT:    ldr x11, [sp, #16] // 8-byte Reload
-; LSE-NEXT:    mvn w8, w9
-; LSE-NEXT:    orr w10, w8, #0xfffffffe
+; LSE-NEXT:    mov w8, #-2 // =0xfffffffe
+; LSE-NEXT:    orn w10, w8, w9
 ; LSE-NEXT:    mov w8, w9
 ; LSE-NEXT:    casalh w8, w10, [x11]
 ; LSE-NEXT:    subs w9, w8, w9, uxth
@@ -439,8 +439,8 @@ define i32 @test_rmw_nand_32(ptr %dst)   {
 ; NOLSE-NEXT:    // Child Loop BB7_2 Depth 2
 ; NOLSE-NEXT:    ldr w9, [sp, #28] // 4-byte Reload
 ; NOLSE-NEXT:    ldr x11, [sp, #16] // 8-byte Reload
-; NOLSE-NEXT:    mvn w8, w9
-; NOLSE-NEXT:    orr w12, w8, #0xfffffffe
+; NOLSE-NEXT:    mov w8, #-2 // =0xfffffffe
+; NOLSE-NEXT:    orn w12, w8, w9
 ; NOLSE-NEXT:  .LBB7_2: // %atomicrmw.start
 ; NOLSE-NEXT:    // Parent Loop BB7_1 Depth=1
 ; NOLSE-NEXT:    // => This Inner Loop Header: Depth=2
@@ -475,8 +475,8 @@ define i32 @test_rmw_nand_32(ptr %dst)   {
 ; LSE-NEXT:    // =>This Inner Loop Header: Depth=1
 ; LSE-NEXT:    ldr w9, [sp, #28] // 4-byte Reload
 ; LSE-NEXT:    ldr x11, [sp, #16] // 8-byte Reload
-; LSE-NEXT:    mvn w8, w9
-; LSE-NEXT:    orr w10, w8, #0xfffffffe
+; LSE-NEXT:    mov w8, #-2 // =0xfffffffe
+; LSE-NEXT:    orn w10, w8, w9
 ; LSE-NEXT:    mov w8, w9
 ; LSE-NEXT:    casal w8, w10, [x11]
 ; LSE-NEXT:    subs w9, w8, w9

--- a/llvm/test/CodeGen/AArch64/logical-op-with-not.ll
+++ b/llvm/test/CodeGen/AArch64/logical-op-with-not.ll
@@ -17,8 +17,8 @@ define i64 @and_bic(i64 %0, i64 %1) {
 define i64 @and_bic2(i32 %0, i64 %1) {
 ; CHECK-LABEL: and_bic2:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mvn w8, w0
-; CHECK-NEXT:    orr w8, w8, #0xffff00ff
+; CHECK-NEXT:    mov w8, #-65281 // =0xffff00ff
+; CHECK-NEXT:    orn w8, w8, w0
 ; CHECK-NEXT:    and x0, x8, x1
 ; CHECK-NEXT:    ret
   %3 = and i32 %0, 65280
@@ -31,8 +31,8 @@ define i64 @and_bic2(i32 %0, i64 %1) {
 define i32 @and_bic3(i32 %0, i32 %1) {
 ; CHECK-LABEL: and_bic3:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mvn w8, w0
-; CHECK-NEXT:    orr w8, w8, #0xffff00ff
+; CHECK-NEXT:    mov w8, #-65281 // =0xffff00ff
+; CHECK-NEXT:    orn w8, w8, w0
 ; CHECK-NEXT:    and w0, w8, w1
 ; CHECK-NEXT:    ret
   %3 = and i32 %0, 65280
@@ -56,8 +56,8 @@ define i64 @and_eon(i64 %0, i64 %1) {
 define i64 @and_eon2(i32 %0, i64 %1) {
 ; CHECK-LABEL: and_eon2:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mvn w8, w0
-; CHECK-NEXT:    orr w8, w8, #0xffff00ff
+; CHECK-NEXT:    mov w8, #-65281 // =0xffff00ff
+; CHECK-NEXT:    orn w8, w8, w0
 ; CHECK-NEXT:    eor x0, x8, x1
 ; CHECK-NEXT:    ret
   %3 = and i32 %0, 65280
@@ -94,8 +94,8 @@ define i64 @and_orn(i64 %0, i64 %1) {
 define i64 @and_orn2(i32 %0, i64 %1) {
 ; CHECK-LABEL: and_orn2:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mvn w8, w0
-; CHECK-NEXT:    orr w8, w8, #0xffff00ff
+; CHECK-NEXT:    mov w8, #-65281 // =0xffff00ff
+; CHECK-NEXT:    orn w8, w8, w0
 ; CHECK-NEXT:    orr x0, x8, x1
 ; CHECK-NEXT:    ret
   %3 = and i32 %0, 65280
@@ -737,4 +737,28 @@ for.body:
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond.not = icmp eq i64 %indvars.iv.next, 256
   br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+}
+
+; ORN with a constant should use "mov + orn" like BIC does, not "mvn + orr".
+
+define i32 @orn_cst_i32(i32 %c) {
+; CHECK-LABEL: orn_cst_i32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov w8, #4 // =0x4
+; CHECK-NEXT:    orn w0, w8, w0
+; CHECK-NEXT:    ret
+  %not = xor i32 %c, -1
+  %or  = or  i32 %not, 4
+  ret i32 %or
+}
+
+define i64 @orn_cst_i64(i64 %c) {
+; CHECK-LABEL: orn_cst_i64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #4 // =0x4
+; CHECK-NEXT:    orn x0, x8, x0
+; CHECK-NEXT:    ret
+  %not = xor i64 %c, -1
+  %or  = or  i64 %not, 4
+  ret i64 %or
 }


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/100045

Adds a tablegen pattern that matches (or x (not y)) and generates a mov+orn instead of the original mvn+orr.

This patch was reverted as I wanted to change my email associated with the patch. 
Original patch: https://github.com/llvm/llvm-project/pull/190769
Revert patch: https://github.com/llvm/llvm-project/pull/191138