### PR TITLE
Revert "[mlir][CSE] Delete dead code immediately in CSE pass"

### DIFF
--- a/mlir/lib/Transforms/CSE.cpp
+++ b/mlir/lib/Transforms/CSE.cpp
@@ -258,11 +258,9 @@ LogicalResult CSEDriver::simplifyOperation(ScopedMapTy &knownValues,
   if (op->hasTrait<OpTrait::IsTerminator>())
     return failure();
 
-  // If the operation is already trivially dead, erase it immediately.
-  // Retaining dead operations in a region can affect the equivalence check
-  // between two region ops, causing CSE to miss optimization opportunities.
+  // If the operation is already trivially dead just add it to the erase list.
   if (isOpTriviallyDead(op)) {
-    rewriter.eraseOp(op);
+    opsToErase.push_back(op);
     ++numDCE;
     return success();
   }
@@ -310,7 +308,7 @@ LogicalResult CSEDriver::simplifyOperation(ScopedMapTy &knownValues,
 
 void CSEDriver::simplifyBlock(ScopedMapTy &knownValues, Block *bb,
                               bool hasSSADominance) {
-  for (auto &op : llvm::make_early_inc_range(*bb)) {
+  for (auto &op : *bb) {
     // Most operations don't have regions, so fast path that case.
     if (op.getNumRegions() != 0) {
       // If this operation is isolated above, we can't process nested regions
@@ -399,10 +397,8 @@ void CSEDriver::simplify(Operation *op, bool *changed) {
   /// Erase any operations that were marked as dead during simplification.
   for (auto *op : opsToErase)
     rewriter.eraseOp(op);
-  if (changed) {
-    assert(opsToErase.empty() || numDCE || numCSE);
-    *changed = numDCE || numCSE;
-  }
+  if (changed)
+    *changed = !opsToErase.empty();
 
   // Note: CSE does currently not remove ops with regions, so DominanceInfo
   // does not have to be invalidated.

--- a/mlir/test/Transforms/cse.mlir
+++ b/mlir/test/Transforms/cse.mlir
@@ -511,38 +511,6 @@ func.func @cse_multiple_regions(%c: i1, %t: tensor<5xf32>) -> (tensor<5xf32>, te
 
 // -----
 
-// This test is used to verify whether CSE can correctly
-// handle region operations that contain dead ops.
-
-func.func @cse_multiple_regions_with_dead_op(%c: i1, %t: tensor<5xf32>) -> (tensor<5xf32>, tensor<5xf32>) {
-  %r1 = scf.if %c -> (tensor<5xf32>) {
-    %0 = tensor.empty() : tensor<5xf32>
-    %1 = arith.constant 1: index
-    scf.yield %0 : tensor<5xf32>
-  } else {
-    scf.yield %t : tensor<5xf32>
-  }
-  %r2 = scf.if %c -> (tensor<5xf32>) {
-    %0 = tensor.empty() : tensor<5xf32>
-    scf.yield %0 : tensor<5xf32>
-  } else {
-    scf.yield %t : tensor<5xf32>
-  }
-  return %r1, %r2 : tensor<5xf32>, tensor<5xf32>
-}
-
-// CHECK-LABEL: func @cse_multiple_regions_with_dead_op
-//       CHECK:   %[[if:.*]] = scf.if {{.*}} {
-//       CHECK:     tensor.empty
-//       CHECK:     scf.yield
-//       CHECK:   } else {
-//       CHECK:     scf.yield
-//       CHECK:   }
-//   CHECK-NOT:   scf.if
-//       CHECK:   return %[[if]], %[[if]]
-
-// -----
-
 // CHECK-LABEL: @cse_recursive_effects_success
 func.func @cse_recursive_effects_success() -> (i32, i32, i32) {
   // CHECK-NEXT: %[[READ_VALUE:.*]] = "test.op_with_memread"() : () -> i32


### PR DESCRIPTION
Reverts llvm/llvm-project#190926 ; this is crashing on simple examples like:

```
func.func @test(%arg0: i1) {
  %c0_i32 = arith.constant 0 : i32
  %0 = arith.select %arg0, %c0_i32, %c0_i32 : i32
  %1 = scf.if %arg0 -> (i32) {
    %c0_i32_0 = arith.constant 0 : i32
    scf.yield %c0_i32_0 : i32
  } else {
    %c0_i32_0 = arith.constant 0 : i32
    scf.yield %c0_i32_0 : i32
  }
  return
}
```