### PR TITLE
[clang][Lex] don't run -Wnonportable-include-path-separator if disabled

### DIFF
--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2733,6 +2733,7 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
     }
 
     bool SuppressBackslashDiag =
+        // The diagnostic logic is expensive, so only run it if it's enabled.
         Diags->isIgnored(diag::pp_nonportable_path_separator, FilenameLoc) ||
         FilenameLoc.isMacroID() ||
         SourceMgr.isWrittenInBuiltinFile(FilenameLoc) ||

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2733,6 +2733,7 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
     }
 
     bool SuppressBackslashDiag =
+        Diags->isIgnored(diag::pp_nonportable_path_separator, FilenameLoc) ||
         FilenameLoc.isMacroID() ||
         SourceMgr.isWrittenInBuiltinFile(FilenameLoc) ||
         SourceMgr.isWrittenInModuleIncludes(FilenameLoc);

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2733,8 +2733,9 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
     }
 
     bool SuppressBackslashDiag =
-        // The diagnostic logic is expensive, so only run it if it's enabled.
+        // The diagnostic logic is expensive, so only run it if it's enabled...
         Diags->isIgnored(diag::pp_nonportable_path_separator, FilenameLoc) ||
+        // ...and try to only trigger on paths that appear in source.
         FilenameLoc.isMacroID() ||
         SourceMgr.isWrittenInBuiltinFile(FilenameLoc) ||
         SourceMgr.isWrittenInModuleIncludes(FilenameLoc);


### PR DESCRIPTION
The diagnostic's addition caused a perf regression: https://llvm-compile-time-tracker.com/compare.php?from=b9149823d85891044bf34e8654d1a45870e55174&to=e2294efaabcc745bf6beacbefbd371595cf3e87f&stat=instructions:u

So, only run its logic if it's actually enabled:
https://llvm-compile-time-tracker.com/compare.php?from=e2294efaabcc745bf6beacbefbd371595cf3e87f&to=52bd4e1441b75b617cf81dfffcb149966616a34a&stat=instructions:u