### PR TITLE
[Clang] Fix handling of references to variable templates with an empty argument list

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -426,6 +426,7 @@ Bug Fixes to C++ Support
   template parameters when one of its parameters is also a pack. (#GH181166)
 - Fixed a crash when a default argument is passed to an explicit object parameter. (#GH176639)
 - Fixed an alias template CTAD crash.
+- Fix handling of ``Var<>`` when refering to a static member variable template. (#GH191016)
 - Fixed a crash when diagnosing an invalid static member function with an explicit object parameter (#GH177741)
 - Fixed a crash when instantiating an invalid out-of-line static data member definition in a local class. (#GH176152)
 - Fixed a crash when pack expansions are used as arguments for non-pack parameters of built-in templates. (#GH180307)

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -426,7 +426,6 @@ Bug Fixes to C++ Support
   template parameters when one of its parameters is also a pack. (#GH181166)
 - Fixed a crash when a default argument is passed to an explicit object parameter. (#GH176639)
 - Fixed an alias template CTAD crash.
-- Fix handling of ``Var<>`` when refering to a static member variable template. (#GH191016)
 - Fixed a crash when diagnosing an invalid static member function with an explicit object parameter (#GH177741)
 - Fixed a crash when instantiating an invalid out-of-line static data member definition in a local class. (#GH176152)
 - Fixed a crash when pack expansions are used as arguments for non-pack parameters of built-in templates. (#GH180307)

--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -3279,16 +3279,10 @@ public:
 
   /// Determines whether this expression had explicit template arguments.
   bool hasExplicitTemplateArgs() const {
-    if (!hasTemplateKWAndArgsInfo())
-      return false;
     if (getLAngleLoc().isValid())
       return true;
-    // FIXME: deduced function types can have "hidden" args and no <
-    // investigate that further, but ultimately maybe we want to model concepts
-    // reference with another kind of expression.
-    if (isConceptReference() || isVarDeclReference())
-      return getTrailingASTTemplateKWAndArgsInfo()->NumTemplateArgs;
-    return false;
+    return hasTemplateKWAndArgsInfo() &&
+           getTrailingASTTemplateKWAndArgsInfo()->NumTemplateArgs;
   }
 
   bool isConceptReference() const {

--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -3281,12 +3281,14 @@ public:
   bool hasExplicitTemplateArgs() const {
     if (!hasTemplateKWAndArgsInfo())
       return false;
+    if (getLAngleLoc().isValid())
+      return true;
     // FIXME: deduced function types can have "hidden" args and no <
     // investigate that further, but ultimately maybe we want to model concepts
     // reference with another kind of expression.
-    return (isConceptReference() || isVarDeclReference())
-               ? getTrailingASTTemplateKWAndArgsInfo()->NumTemplateArgs
-               : getLAngleLoc().isValid();
+    if (isConceptReference() || isVarDeclReference())
+      return getTrailingASTTemplateKWAndArgsInfo()->NumTemplateArgs;
+    return false;
   }
 
   bool isConceptReference() const {

--- a/clang/test/SemaTemplate/concepts.cpp
+++ b/clang/test/SemaTemplate/concepts.cpp
@@ -1824,3 +1824,14 @@ namespace GH176402 {
     recursiveLambda(recursiveLambda, 5);
   }
 }
+namespace GH191016 {
+  template <typename T = int>
+  struct S {
+    template <typename Args = int>
+    constexpr static bool P = true;
+    template <typename... Args>
+    constexpr static bool Q = true;
+    S() requires P<> && Q<> {}
+  };
+  void test(){ S<int> s; }
+}


### PR DESCRIPTION
In some cases they were treated as having no argument list at all.

Fixes #191016.