### PR TITLE
[AArch64][SVE] Use SUBR for unpredicated bitwise NOT.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -677,6 +677,10 @@ let Predicates = [HasSVE_or_SME] in {
   defm SQSUB_ZI : sve_int_arith_imm0_ssat<0b110, "sqsub", ssubsat, saddsat>;
   defm UQSUB_ZI : sve_int_arith_imm0<0b111, "uqsub", usubsat>;
 
+  // NOT (x) = SUBR (x, -1).
+  foreach VT = [nxv16i8, nxv8i16, nxv4i32, nxv2i64] in
+    def : Pat<(VT (vnot VT:$op)), (SUBR_ZI_B_PSEUDO ZPR8:$op, (i32 255), (i32 0))>;
+
   defm MAD_ZPmZZ : sve_int_mladdsub_vvv_pred<0b0, "mad", AArch64mad_m1, "MLA_ZPmZZ", /*isReverseInstr*/ 1>;
   defm MSB_ZPmZZ : sve_int_mladdsub_vvv_pred<0b1, "msb", AArch64msb_m1, "MLS_ZPmZZ", /*isReverseInstr*/ 1>;
   defm MLA_ZPmZZ : sve_int_mlas_vvv_pred<0b0, "mla", AArch64mla_m1, "MLA_ZPZZZ", "MAD_ZPmZZ">;

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-fp-compares.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-fp-compares.ll
@@ -442,9 +442,8 @@ define void @fcmp_ugt_v16f16(ptr %a, ptr %b, ptr %c) vscale_range(2,0) #0 {
 ; CHECK-NEXT:    ld1h { z0.h }, p0/z, [x0]
 ; CHECK-NEXT:    ld1h { z1.h }, p0/z, [x1]
 ; CHECK-NEXT:    fcmge p1.h, p0/z, z1.h, z0.h
-; CHECK-NEXT:    mov z1.h, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    mov z0.h, p1/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    eor z0.d, z0.d, z1.d
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; CHECK-NEXT:    st1h { z0.h }, p0, [x2]
 ; CHECK-NEXT:    ret
   %op1 = load <16 x half>, ptr %a
@@ -488,9 +487,8 @@ define void @fcmp_ult_v16f16(ptr %a, ptr %b, ptr %c) vscale_range(2,0) #0 {
 ; CHECK-NEXT:    ld1h { z0.h }, p0/z, [x0]
 ; CHECK-NEXT:    ld1h { z1.h }, p0/z, [x1]
 ; CHECK-NEXT:    fcmge p1.h, p0/z, z0.h, z1.h
-; CHECK-NEXT:    mov z1.h, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    mov z0.h, p1/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    eor z0.d, z0.d, z1.d
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; CHECK-NEXT:    st1h { z0.h }, p0, [x2]
 ; CHECK-NEXT:    ret
   %op1 = load <16 x half>, ptr %a
@@ -534,9 +532,8 @@ define void @fcmp_uge_v16f16(ptr %a, ptr %b, ptr %c) vscale_range(2,0) #0 {
 ; CHECK-NEXT:    ld1h { z0.h }, p0/z, [x0]
 ; CHECK-NEXT:    ld1h { z1.h }, p0/z, [x1]
 ; CHECK-NEXT:    fcmgt p1.h, p0/z, z1.h, z0.h
-; CHECK-NEXT:    mov z1.h, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    mov z0.h, p1/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    eor z0.d, z0.d, z1.d
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; CHECK-NEXT:    st1h { z0.h }, p0, [x2]
 ; CHECK-NEXT:    ret
   %op1 = load <16 x half>, ptr %a
@@ -580,9 +577,8 @@ define void @fcmp_ule_v16f16(ptr %a, ptr %b, ptr %c) vscale_range(2,0) #0 {
 ; CHECK-NEXT:    ld1h { z0.h }, p0/z, [x0]
 ; CHECK-NEXT:    ld1h { z1.h }, p0/z, [x1]
 ; CHECK-NEXT:    fcmgt p1.h, p0/z, z0.h, z1.h
-; CHECK-NEXT:    mov z1.h, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    mov z0.h, p1/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    eor z0.d, z0.d, z1.d
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; CHECK-NEXT:    st1h { z0.h }, p0, [x2]
 ; CHECK-NEXT:    ret
   %op1 = load <16 x half>, ptr %a
@@ -626,9 +622,8 @@ define void @fcmp_ord_v16f16(ptr %a, ptr %b, ptr %c) vscale_range(2,0) #0 {
 ; CHECK-NEXT:    ld1h { z0.h }, p0/z, [x0]
 ; CHECK-NEXT:    ld1h { z1.h }, p0/z, [x1]
 ; CHECK-NEXT:    fcmuo p1.h, p0/z, z0.h, z1.h
-; CHECK-NEXT:    mov z1.h, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    mov z0.h, p1/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    eor z0.d, z0.d, z1.d
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; CHECK-NEXT:    st1h { z0.h }, p0, [x2]
 ; CHECK-NEXT:    ret
   %op1 = load <16 x half>, ptr %a

--- a/llvm/test/CodeGen/AArch64/sve-hadd.ll
+++ b/llvm/test/CodeGen/AArch64/sve-hadd.ll
@@ -698,10 +698,9 @@ define <vscale x 2 x i32> @rhadds_v2i32(<vscale x 2 x i32> %s0, <vscale x 2 x i3
 ; SVE-LABEL: rhadds_v2i32:
 ; SVE:       // %bb.0: // %entry
 ; SVE-NEXT:    ptrue p0.d
-; SVE-NEXT:    mov z2.d, #-1 // =0xffffffffffffffff
 ; SVE-NEXT:    sxtw z0.d, p0/m, z0.d
 ; SVE-NEXT:    sxtw z1.d, p0/m, z1.d
-; SVE-NEXT:    eor z0.d, z0.d, z2.d
+; SVE-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; SVE-NEXT:    sub z0.d, z1.d, z0.d
 ; SVE-NEXT:    asr z0.d, z0.d, #1
 ; SVE-NEXT:    ret
@@ -727,10 +726,9 @@ define <vscale x 2 x i32> @rhadds_v2i32_lsh(<vscale x 2 x i32> %s0, <vscale x 2 
 ; CHECK-LABEL: rhadds_v2i32_lsh:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z2.d, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    sxtw z0.d, p0/m, z0.d
 ; CHECK-NEXT:    sxtw z1.d, p0/m, z1.d
-; CHECK-NEXT:    eor z0.d, z0.d, z2.d
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; CHECK-NEXT:    sub z0.d, z1.d, z0.d
 ; CHECK-NEXT:    lsr z0.d, z0.d, #1
 ; CHECK-NEXT:    ret
@@ -747,10 +745,9 @@ entry:
 define <vscale x 2 x i32> @rhaddu_v2i32(<vscale x 2 x i32> %s0, <vscale x 2 x i32> %s1) {
 ; SVE-LABEL: rhaddu_v2i32:
 ; SVE:       // %bb.0: // %entry
-; SVE-NEXT:    mov z2.d, #-1 // =0xffffffffffffffff
 ; SVE-NEXT:    and z0.d, z0.d, #0xffffffff
 ; SVE-NEXT:    and z1.d, z1.d, #0xffffffff
-; SVE-NEXT:    eor z0.d, z0.d, z2.d
+; SVE-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; SVE-NEXT:    sub z0.d, z1.d, z0.d
 ; SVE-NEXT:    lsr z0.d, z0.d, #1
 ; SVE-NEXT:    ret
@@ -848,10 +845,9 @@ define <vscale x 2 x i16> @rhadds_v2i16(<vscale x 2 x i16> %s0, <vscale x 2 x i1
 ; SVE-LABEL: rhadds_v2i16:
 ; SVE:       // %bb.0: // %entry
 ; SVE-NEXT:    ptrue p0.d
-; SVE-NEXT:    mov z2.d, #-1 // =0xffffffffffffffff
 ; SVE-NEXT:    sxth z0.d, p0/m, z0.d
 ; SVE-NEXT:    sxth z1.d, p0/m, z1.d
-; SVE-NEXT:    eor z0.d, z0.d, z2.d
+; SVE-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; SVE-NEXT:    sub z0.d, z1.d, z0.d
 ; SVE-NEXT:    asr z0.d, z0.d, #1
 ; SVE-NEXT:    ret
@@ -877,10 +873,9 @@ define <vscale x 2 x i16> @rhadds_v2i16_lsh(<vscale x 2 x i16> %s0, <vscale x 2 
 ; CHECK-LABEL: rhadds_v2i16_lsh:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z2.d, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    sxth z0.d, p0/m, z0.d
 ; CHECK-NEXT:    sxth z1.d, p0/m, z1.d
-; CHECK-NEXT:    eor z0.d, z0.d, z2.d
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; CHECK-NEXT:    sub z0.d, z1.d, z0.d
 ; CHECK-NEXT:    and z0.d, z0.d, #0xffffffff
 ; CHECK-NEXT:    lsr z0.d, z0.d, #1
@@ -898,10 +893,9 @@ entry:
 define <vscale x 2 x i16> @rhaddu_v2i16(<vscale x 2 x i16> %s0, <vscale x 2 x i16> %s1) {
 ; SVE-LABEL: rhaddu_v2i16:
 ; SVE:       // %bb.0: // %entry
-; SVE-NEXT:    mov z2.d, #-1 // =0xffffffffffffffff
 ; SVE-NEXT:    and z0.d, z0.d, #0xffff
 ; SVE-NEXT:    and z1.d, z1.d, #0xffff
-; SVE-NEXT:    eor z0.d, z0.d, z2.d
+; SVE-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; SVE-NEXT:    sub z0.d, z1.d, z0.d
 ; SVE-NEXT:    lsr z0.d, z0.d, #1
 ; SVE-NEXT:    ret
@@ -927,10 +921,9 @@ define <vscale x 4 x i16> @rhadds_v4i16(<vscale x 4 x i16> %s0, <vscale x 4 x i1
 ; SVE-LABEL: rhadds_v4i16:
 ; SVE:       // %bb.0: // %entry
 ; SVE-NEXT:    ptrue p0.s
-; SVE-NEXT:    mov z2.s, #-1 // =0xffffffffffffffff
 ; SVE-NEXT:    sxth z0.s, p0/m, z0.s
 ; SVE-NEXT:    sxth z1.s, p0/m, z1.s
-; SVE-NEXT:    eor z0.d, z0.d, z2.d
+; SVE-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; SVE-NEXT:    sub z0.s, z1.s, z0.s
 ; SVE-NEXT:    asr z0.s, z0.s, #1
 ; SVE-NEXT:    ret
@@ -956,10 +949,9 @@ define <vscale x 4 x i16> @rhadds_v4i16_lsh(<vscale x 4 x i16> %s0, <vscale x 4 
 ; CHECK-LABEL: rhadds_v4i16_lsh:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    ptrue p0.s
-; CHECK-NEXT:    mov z2.s, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    sxth z0.s, p0/m, z0.s
 ; CHECK-NEXT:    sxth z1.s, p0/m, z1.s
-; CHECK-NEXT:    eor z0.d, z0.d, z2.d
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; CHECK-NEXT:    sub z0.s, z1.s, z0.s
 ; CHECK-NEXT:    lsr z0.s, z0.s, #1
 ; CHECK-NEXT:    ret
@@ -976,10 +968,9 @@ entry:
 define <vscale x 4 x i16> @rhaddu_v4i16(<vscale x 4 x i16> %s0, <vscale x 4 x i16> %s1) {
 ; SVE-LABEL: rhaddu_v4i16:
 ; SVE:       // %bb.0: // %entry
-; SVE-NEXT:    mov z2.s, #-1 // =0xffffffffffffffff
 ; SVE-NEXT:    and z0.s, z0.s, #0xffff
 ; SVE-NEXT:    and z1.s, z1.s, #0xffff
-; SVE-NEXT:    eor z0.d, z0.d, z2.d
+; SVE-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; SVE-NEXT:    sub z0.s, z1.s, z0.s
 ; SVE-NEXT:    lsr z0.s, z0.s, #1
 ; SVE-NEXT:    ret
@@ -1077,10 +1068,9 @@ define <vscale x 4 x i8> @rhadds_v4i8(<vscale x 4 x i8> %s0, <vscale x 4 x i8> %
 ; SVE-LABEL: rhadds_v4i8:
 ; SVE:       // %bb.0: // %entry
 ; SVE-NEXT:    ptrue p0.s
-; SVE-NEXT:    mov z2.s, #-1 // =0xffffffffffffffff
 ; SVE-NEXT:    sxtb z0.s, p0/m, z0.s
 ; SVE-NEXT:    sxtb z1.s, p0/m, z1.s
-; SVE-NEXT:    eor z0.d, z0.d, z2.d
+; SVE-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; SVE-NEXT:    sub z0.s, z1.s, z0.s
 ; SVE-NEXT:    asr z0.s, z0.s, #1
 ; SVE-NEXT:    ret
@@ -1106,10 +1096,9 @@ define <vscale x 4 x i8> @rhadds_v4i8_lsh(<vscale x 4 x i8> %s0, <vscale x 4 x i
 ; CHECK-LABEL: rhadds_v4i8_lsh:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    ptrue p0.s
-; CHECK-NEXT:    mov z2.s, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    sxtb z0.s, p0/m, z0.s
 ; CHECK-NEXT:    sxtb z1.s, p0/m, z1.s
-; CHECK-NEXT:    eor z0.d, z0.d, z2.d
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; CHECK-NEXT:    sub z0.s, z1.s, z0.s
 ; CHECK-NEXT:    and z0.s, z0.s, #0xffff
 ; CHECK-NEXT:    lsr z0.s, z0.s, #1
@@ -1127,10 +1116,9 @@ entry:
 define <vscale x 4 x i8> @rhaddu_v4i8(<vscale x 4 x i8> %s0, <vscale x 4 x i8> %s1) {
 ; SVE-LABEL: rhaddu_v4i8:
 ; SVE:       // %bb.0: // %entry
-; SVE-NEXT:    mov z2.s, #-1 // =0xffffffffffffffff
 ; SVE-NEXT:    and z0.s, z0.s, #0xff
 ; SVE-NEXT:    and z1.s, z1.s, #0xff
-; SVE-NEXT:    eor z0.d, z0.d, z2.d
+; SVE-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; SVE-NEXT:    sub z0.s, z1.s, z0.s
 ; SVE-NEXT:    lsr z0.s, z0.s, #1
 ; SVE-NEXT:    ret
@@ -1156,10 +1144,9 @@ define <vscale x 8 x i8> @rhadds_v8i8(<vscale x 8 x i8> %s0, <vscale x 8 x i8> %
 ; SVE-LABEL: rhadds_v8i8:
 ; SVE:       // %bb.0: // %entry
 ; SVE-NEXT:    ptrue p0.h
-; SVE-NEXT:    mov z2.h, #-1 // =0xffffffffffffffff
 ; SVE-NEXT:    sxtb z0.h, p0/m, z0.h
 ; SVE-NEXT:    sxtb z1.h, p0/m, z1.h
-; SVE-NEXT:    eor z0.d, z0.d, z2.d
+; SVE-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; SVE-NEXT:    sub z0.h, z1.h, z0.h
 ; SVE-NEXT:    asr z0.h, z0.h, #1
 ; SVE-NEXT:    ret
@@ -1185,10 +1172,9 @@ define <vscale x 8 x i8> @rhadds_v8i8_lsh(<vscale x 8 x i8> %s0, <vscale x 8 x i
 ; CHECK-LABEL: rhadds_v8i8_lsh:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    ptrue p0.h
-; CHECK-NEXT:    mov z2.h, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    sxtb z0.h, p0/m, z0.h
 ; CHECK-NEXT:    sxtb z1.h, p0/m, z1.h
-; CHECK-NEXT:    eor z0.d, z0.d, z2.d
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; CHECK-NEXT:    sub z0.h, z1.h, z0.h
 ; CHECK-NEXT:    lsr z0.h, z0.h, #1
 ; CHECK-NEXT:    ret
@@ -1205,10 +1191,9 @@ entry:
 define <vscale x 8 x i8> @rhaddu_v8i8(<vscale x 8 x i8> %s0, <vscale x 8 x i8> %s1) {
 ; SVE-LABEL: rhaddu_v8i8:
 ; SVE:       // %bb.0: // %entry
-; SVE-NEXT:    mov z2.h, #-1 // =0xffffffffffffffff
 ; SVE-NEXT:    and z0.h, z0.h, #0xff
 ; SVE-NEXT:    and z1.h, z1.h, #0xff
-; SVE-NEXT:    eor z0.d, z0.d, z2.d
+; SVE-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; SVE-NEXT:    sub z0.h, z1.h, z0.h
 ; SVE-NEXT:    lsr z0.h, z0.h, #1
 ; SVE-NEXT:    ret
@@ -1375,10 +1360,9 @@ define void @zext_mload_avgceilu(ptr %p1, ptr %p2, <vscale x 8 x i1> %mask) {
 ; SVE-LABEL: zext_mload_avgceilu:
 ; SVE:       // %bb.0:
 ; SVE-NEXT:    ld1b { z0.h }, p0/z, [x0]
-; SVE-NEXT:    mov z1.h, #-1 // =0xffffffffffffffff
-; SVE-NEXT:    ld1b { z2.h }, p0/z, [x1]
-; SVE-NEXT:    eor z0.d, z0.d, z1.d
-; SVE-NEXT:    sub z0.h, z2.h, z0.h
+; SVE-NEXT:    ld1b { z1.h }, p0/z, [x1]
+; SVE-NEXT:    subr z0.b, z0.b, #255 // =0xff
+; SVE-NEXT:    sub z0.h, z1.h, z0.h
 ; SVE-NEXT:    lsr z0.h, z0.h, #1
 ; SVE-NEXT:    st1b { z0.h }, p0, [x0]
 ; SVE-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/sve-int-log.ll
+++ b/llvm/test/CodeGen/AArch64/sve-int-log.ll
@@ -572,11 +572,10 @@ for.cond.cleanup:
 define void @array_or_not_nxv4i32(ptr %a, <vscale x 4 x i32> %m) {
 ; SVE-LABEL: array_or_not_nxv4i32:
 ; SVE:       // %bb.0: // %entry
-; SVE-NEXT:    mov z1.s, #-1 // =0xffffffffffffffff
+; SVE-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; SVE-NEXT:    ptrue p0.s
 ; SVE-NEXT:    mov x8, xzr
 ; SVE-NEXT:    cntw x9
-; SVE-NEXT:    eor z0.d, z0.d, z1.d
 ; SVE-NEXT:  .LBB43_1: // %vector.body
 ; SVE-NEXT:    // =>This Inner Loop Header: Depth=1
 ; SVE-NEXT:    ld1w { z1.s }, p0/z, [x0, x8, lsl #2]
@@ -590,10 +589,9 @@ define void @array_or_not_nxv4i32(ptr %a, <vscale x 4 x i32> %m) {
 ;
 ; SVE2-LABEL: array_or_not_nxv4i32:
 ; SVE2:       // %bb.0: // %entry
-; SVE2-NEXT:    mov z1.s, #-1 // =0xffffffffffffffff
+; SVE2-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; SVE2-NEXT:    ptrue p0.s
 ; SVE2-NEXT:    mov x8, xzr
-; SVE2-NEXT:    eor z0.d, z0.d, z1.d
 ; SVE2-NEXT:  .LBB43_1: // %vector.body
 ; SVE2-NEXT:    // =>This Inner Loop Header: Depth=1
 ; SVE2-NEXT:    ld1w { z1.s }, p0/z, [x0, x8, lsl #2]
@@ -627,11 +625,10 @@ for.cond.cleanup:
 define void @array_xor_not_nxv4i32(ptr %a, <vscale x 4 x i32> %m) {
 ; SVE-LABEL: array_xor_not_nxv4i32:
 ; SVE:       // %bb.0: // %entry
-; SVE-NEXT:    mov z1.s, #-1 // =0xffffffffffffffff
+; SVE-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; SVE-NEXT:    ptrue p0.s
 ; SVE-NEXT:    mov x8, xzr
 ; SVE-NEXT:    cntw x9
-; SVE-NEXT:    eor z0.d, z0.d, z1.d
 ; SVE-NEXT:  .LBB44_1: // %vector.body
 ; SVE-NEXT:    // =>This Inner Loop Header: Depth=1
 ; SVE-NEXT:    ld1w { z1.s }, p0/z, [x0, x8, lsl #2]

--- a/llvm/test/CodeGen/AArch64/sve-streaming-mode-fixed-length-fp-compares.ll
+++ b/llvm/test/CodeGen/AArch64/sve-streaming-mode-fixed-length-fp-compares.ll
@@ -1180,13 +1180,12 @@ define void @fcmp_ugt_v16f16(ptr %a, ptr %b, ptr %c) {
 ; CHECK-NEXT:    ptrue p0.h, vl8
 ; CHECK-NEXT:    ldp q1, q2, [x0]
 ; CHECK-NEXT:    fcmge p1.h, p0/z, z0.h, z1.h
-; CHECK-NEXT:    mov z0.h, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    fcmge p0.h, p0/z, z3.h, z2.h
-; CHECK-NEXT:    mov z1.h, p1/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    mov z2.h, p0/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    eor z1.d, z1.d, z0.d
-; CHECK-NEXT:    eor z0.d, z2.d, z0.d
-; CHECK-NEXT:    stp q1, q0, [x2]
+; CHECK-NEXT:    mov z0.h, p1/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    mov z1.h, p0/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
+; CHECK-NEXT:    subr z1.b, z1.b, #255 // =0xff
+; CHECK-NEXT:    stp q0, q1, [x2]
 ; CHECK-NEXT:    ret
 ;
 ; NONEON-NOSVE-LABEL: fcmp_ugt_v16f16:
@@ -1481,13 +1480,12 @@ define void @fcmp_ult_v16f16(ptr %a, ptr %b, ptr %c) {
 ; CHECK-NEXT:    ptrue p0.h, vl8
 ; CHECK-NEXT:    ldp q1, q2, [x0]
 ; CHECK-NEXT:    fcmge p1.h, p0/z, z1.h, z0.h
-; CHECK-NEXT:    mov z0.h, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    fcmge p0.h, p0/z, z2.h, z3.h
-; CHECK-NEXT:    mov z1.h, p1/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    mov z2.h, p0/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    eor z1.d, z1.d, z0.d
-; CHECK-NEXT:    eor z0.d, z2.d, z0.d
-; CHECK-NEXT:    stp q1, q0, [x2]
+; CHECK-NEXT:    mov z0.h, p1/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    mov z1.h, p0/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
+; CHECK-NEXT:    subr z1.b, z1.b, #255 // =0xff
+; CHECK-NEXT:    stp q0, q1, [x2]
 ; CHECK-NEXT:    ret
 ;
 ; NONEON-NOSVE-LABEL: fcmp_ult_v16f16:
@@ -1782,13 +1780,12 @@ define void @fcmp_uge_v16f16(ptr %a, ptr %b, ptr %c) {
 ; CHECK-NEXT:    ptrue p0.h, vl8
 ; CHECK-NEXT:    ldp q1, q2, [x0]
 ; CHECK-NEXT:    fcmgt p1.h, p0/z, z0.h, z1.h
-; CHECK-NEXT:    mov z0.h, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    fcmgt p0.h, p0/z, z3.h, z2.h
-; CHECK-NEXT:    mov z1.h, p1/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    mov z2.h, p0/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    eor z1.d, z1.d, z0.d
-; CHECK-NEXT:    eor z0.d, z2.d, z0.d
-; CHECK-NEXT:    stp q1, q0, [x2]
+; CHECK-NEXT:    mov z0.h, p1/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    mov z1.h, p0/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
+; CHECK-NEXT:    subr z1.b, z1.b, #255 // =0xff
+; CHECK-NEXT:    stp q0, q1, [x2]
 ; CHECK-NEXT:    ret
 ;
 ; NONEON-NOSVE-LABEL: fcmp_uge_v16f16:
@@ -2083,13 +2080,12 @@ define void @fcmp_ule_v16f16(ptr %a, ptr %b, ptr %c) {
 ; CHECK-NEXT:    ptrue p0.h, vl8
 ; CHECK-NEXT:    ldp q1, q2, [x0]
 ; CHECK-NEXT:    fcmgt p1.h, p0/z, z1.h, z0.h
-; CHECK-NEXT:    mov z0.h, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    fcmgt p0.h, p0/z, z2.h, z3.h
-; CHECK-NEXT:    mov z1.h, p1/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    mov z2.h, p0/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    eor z1.d, z1.d, z0.d
-; CHECK-NEXT:    eor z0.d, z2.d, z0.d
-; CHECK-NEXT:    stp q1, q0, [x2]
+; CHECK-NEXT:    mov z0.h, p1/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    mov z1.h, p0/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
+; CHECK-NEXT:    subr z1.b, z1.b, #255 // =0xff
+; CHECK-NEXT:    stp q0, q1, [x2]
 ; CHECK-NEXT:    ret
 ;
 ; NONEON-NOSVE-LABEL: fcmp_ule_v16f16:
@@ -2384,13 +2380,12 @@ define void @fcmp_ord_v16f16(ptr %a, ptr %b, ptr %c) {
 ; CHECK-NEXT:    ptrue p0.h, vl8
 ; CHECK-NEXT:    ldp q1, q2, [x0]
 ; CHECK-NEXT:    fcmuo p1.h, p0/z, z1.h, z0.h
-; CHECK-NEXT:    mov z0.h, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    fcmuo p0.h, p0/z, z2.h, z3.h
-; CHECK-NEXT:    mov z1.h, p1/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    mov z2.h, p0/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    eor z1.d, z1.d, z0.d
-; CHECK-NEXT:    eor z0.d, z2.d, z0.d
-; CHECK-NEXT:    stp q1, q0, [x2]
+; CHECK-NEXT:    mov z0.h, p1/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    mov z1.h, p0/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
+; CHECK-NEXT:    subr z1.b, z1.b, #255 // =0xff
+; CHECK-NEXT:    stp q0, q1, [x2]
 ; CHECK-NEXT:    ret
 ;
 ; NONEON-NOSVE-LABEL: fcmp_ord_v16f16:

--- a/llvm/test/CodeGen/AArch64/sve2-bsl.ll
+++ b/llvm/test/CodeGen/AArch64/sve2-bsl.ll
@@ -314,14 +314,11 @@ entry:
   ret <vscale x 4 x i32> %t3
 }
 
-; NOT (a) = NBSL (a, a, a).
-; We don't have a pattern for this right now because the tied register
-; constraint can lead to worse code gen.
+; NOT (a) = NBSL (a, a, a) = SUBR (a, -1).
 define <vscale x 2 x i64> @not(<vscale x 2 x i64> %0) #0 {
 ; CHECK-LABEL: not:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov z1.d, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    eor z0.d, z0.d, z1.d
+; CHECK-NEXT:    subr z0.b, z0.b, #255 // =0xff
 ; CHECK-NEXT:    ret
   %2 = xor <vscale x 2 x i64> %0, splat (i64 -1)
   ret <vscale x 2 x i64> %2


### PR DESCRIPTION
This relies on the identity NOT (x) = -1 - x, which can be lowered as byte SUBR (x, 255). The recently added pseudos for SUBR (immediate) should automatically avoid cases where we would risk emitting a MOV.