### PR TITLE
[lldb][windows] recommend building with Python 3.11

### DIFF
--- a/lldb/cmake/modules/FindPythonAndSwig.cmake
+++ b/lldb/cmake/modules/FindPythonAndSwig.cmake
@@ -73,5 +73,5 @@ set(LLDB_RECOMMENDED_PYTHON "3.8")
 endif()
 if(PYTHONANDSWIG_FOUND AND "${Python3_VERSION}" VERSION_LESS "${LLDB_RECOMMENDED_PYTHON}")
   message(WARNING "Using Python ${Python3_VERSION}. ${LLDB_RECOMMENDED_PYTHON} "
-                  "is recommended and will be required from LLDB 21.")
+                  "is recommended and will be required from LLDB 23.")
 endif()

--- a/lldb/cmake/modules/FindPythonAndSwig.cmake
+++ b/lldb/cmake/modules/FindPythonAndSwig.cmake
@@ -66,12 +66,3 @@ else()
                                       Python3_EXECUTABLE
                                       LLDB_ENABLE_SWIG)
 endif()
-if(WIN32)
-set(LLDB_RECOMMENDED_PYTHON "3.11")
-else()
-set(LLDB_RECOMMENDED_PYTHON "3.8")
-endif()
-if(PYTHONANDSWIG_FOUND AND "${Python3_VERSION}" VERSION_LESS "${LLDB_RECOMMENDED_PYTHON}")
-  message(WARNING "Using Python ${Python3_VERSION}. ${LLDB_RECOMMENDED_PYTHON} "
-                  "is recommended and will be required from LLDB 23.")
-endif()

--- a/lldb/cmake/modules/FindPythonAndSwig.cmake
+++ b/lldb/cmake/modules/FindPythonAndSwig.cmake
@@ -66,8 +66,11 @@ else()
                                       Python3_EXECUTABLE
                                       LLDB_ENABLE_SWIG)
 endif()
-
+if(WIN32)
+set(LLDB_RECOMMENDED_PYTHON "3.11")
+else()
 set(LLDB_RECOMMENDED_PYTHON "3.8")
+endif()
 if(PYTHONANDSWIG_FOUND AND "${Python3_VERSION}" VERSION_LESS "${LLDB_RECOMMENDED_PYTHON}")
   message(WARNING "Using Python ${Python3_VERSION}. ${LLDB_RECOMMENDED_PYTHON} "
                   "is recommended and will be required from LLDB 21.")

--- a/lldb/cmake/modules/FindPythonAndSwig.cmake
+++ b/lldb/cmake/modules/FindPythonAndSwig.cmake
@@ -68,9 +68,9 @@ else()
 endif()
 
 if (WIN32)
-set(LLDB_RECOMMENDED_PYTHON "3.11")
-if(PYTHONANDSWIG_FOUND AND "${Python3_VERSION}" VERSION_LESS "${LLDB_RECOMMENDED_PYTHON}")
-  message(WARNING "Using Python ${Python3_VERSION}. ${LLDB_RECOMMENDED_PYTHON} "
-                  "is recommended and will be required from LLDB 24.")
-endif()
+  set(LLDB_RECOMMENDED_PYTHON "3.11")
+  if(PYTHONANDSWIG_FOUND AND "${Python3_VERSION}" VERSION_LESS "${LLDB_RECOMMENDED_PYTHON}")
+    message(WARNING "Using Python ${Python3_VERSION}. ${LLDB_RECOMMENDED_PYTHON} "
+                    "is recommended and will be required from LLDB 24.")
+  endif()
 endif()

--- a/lldb/cmake/modules/FindPythonAndSwig.cmake
+++ b/lldb/cmake/modules/FindPythonAndSwig.cmake
@@ -66,3 +66,11 @@ else()
                                       Python3_EXECUTABLE
                                       LLDB_ENABLE_SWIG)
 endif()
+
+if (WIN32)
+set(LLDB_RECOMMENDED_PYTHON "3.11")
+if(PYTHONANDSWIG_FOUND AND "${Python3_VERSION}" VERSION_LESS "${LLDB_RECOMMENDED_PYTHON}")
+  message(WARNING "Using Python ${Python3_VERSION}. ${LLDB_RECOMMENDED_PYTHON} "
+                  "is recommended and will be required from LLDB 24.")
+endif()
+endif()

--- a/lldb/docs/resources/build.rst
+++ b/lldb/docs/resources/build.rst
@@ -112,9 +112,9 @@ Please follow the steps below if you only want to **build** lldb.
    ``dirname`` are available from your terminal.
 3. Install `make <https://sourceforge.net/projects/ezwinports/files/>`_ and
    verify that it's in your ``PATH``.
-4. Install `Python 3 <https://www.python.org/downloads/windows/>`_. Either using
-   the "Windows Installer" or "Python Install Manager". Make sure ``python`` is
-   added to your ``PATH``.
+4. Install `Python 3.11 <https://www.python.org/downloads/windows/>`_ or newer.
+   Either using the "Windows Installer" or "Python Install Manager". Make sure
+   ``python`` is added to your ``PATH``.
 
    .. note::
       Building LLDB in debug mode requires a debug version of Python (because

--- a/lldb/docs/resources/build.rst
+++ b/lldb/docs/resources/build.rst
@@ -52,19 +52,19 @@ disabled. When a dependency is set to ``On`` and can't be found it will cause a
 CMake configuration error.
 
 +-------------------+--------------------------------------------------------------+--------------------------+
-| Feature           | Description                                                           | CMake Flag               |
+| Feature           | Description                                                  | CMake Flag               |
 +===================+==============================================================+==========================+
-| Editline          | Generic line editing, history, Emacs and Vi bindings                  | ``LLDB_ENABLE_LIBEDIT``  |
+| Editline          | Generic line editing, history, Emacs and Vi bindings         | ``LLDB_ENABLE_LIBEDIT``  |
 +-------------------+--------------------------------------------------------------+--------------------------+
-| Curses            | Text user interface                                                   | ``LLDB_ENABLE_CURSES``   |
+| Curses            | Text user interface                                          | ``LLDB_ENABLE_CURSES``   |
 +-------------------+--------------------------------------------------------------+--------------------------+
-| LZMA              | Lossless data compression                                             | ``LLDB_ENABLE_LZMA``     |
+| LZMA              | Lossless data compression                                    | ``LLDB_ENABLE_LZMA``     |
 +-------------------+--------------------------------------------------------------+--------------------------+
-| Libxml2           | XML                                                                   | ``LLDB_ENABLE_LIBXML2``  |
+| Libxml2           | XML                                                          | ``LLDB_ENABLE_LIBXML2``  |
 +-------------------+--------------------------------------------------------------+--------------------------+
-| Python            | Python scripting. >= 3.8 is required (3.11 or later on Windows).      | ``LLDB_ENABLE_PYTHON``   |
+| Python            | Python scripting. 3.8 or later (3.11 or later on Windows).   | ``LLDB_ENABLE_PYTHON``   |
 +-------------------+--------------------------------------------------------------+--------------------------+
-| Lua               | Lua scripting. Lua 5.3 and 5.4 are supported.                         | ``LLDB_ENABLE_LUA``      |
+| Lua               | Lua scripting. Lua 5.3 and 5.4 are supported.                | ``LLDB_ENABLE_LUA``      |
 +-------------------+--------------------------------------------------------------+--------------------------+
 
 Depending on your platform and package manager, one might run any of the

--- a/lldb/docs/resources/build.rst
+++ b/lldb/docs/resources/build.rst
@@ -30,7 +30,7 @@ The following requirements are shared on all platforms.
 If you want to run the test suite, you'll need to build LLDB with Python
 scripting support.
 
-* `Python <http://www.python.org/>`_ 3.8 or later.
+* `Python <http://www.python.org/>`_ 3.8 or later (3.11 or later on Windows).
 * `SWIG <http://swig.org/>`_ 4 or later.
 
 If you are on FreeBSD or NetBSD, you will need to install ``gmake`` for building
@@ -52,19 +52,19 @@ disabled. When a dependency is set to ``On`` and can't be found it will cause a
 CMake configuration error.
 
 +-------------------+--------------------------------------------------------------+--------------------------+
-| Feature           | Description                                                  | CMake Flag               |
+| Feature           | Description                                                           | CMake Flag               |
 +===================+==============================================================+==========================+
-| Editline          | Generic line editing, history, Emacs and Vi bindings         | ``LLDB_ENABLE_LIBEDIT``  |
+| Editline          | Generic line editing, history, Emacs and Vi bindings                  | ``LLDB_ENABLE_LIBEDIT``  |
 +-------------------+--------------------------------------------------------------+--------------------------+
-| Curses            | Text user interface                                          | ``LLDB_ENABLE_CURSES``   |
+| Curses            | Text user interface                                                   | ``LLDB_ENABLE_CURSES``   |
 +-------------------+--------------------------------------------------------------+--------------------------+
-| LZMA              | Lossless data compression                                    | ``LLDB_ENABLE_LZMA``     |
+| LZMA              | Lossless data compression                                             | ``LLDB_ENABLE_LZMA``     |
 +-------------------+--------------------------------------------------------------+--------------------------+
-| Libxml2           | XML                                                          | ``LLDB_ENABLE_LIBXML2``  |
+| Libxml2           | XML                                                                   | ``LLDB_ENABLE_LIBXML2``  |
 +-------------------+--------------------------------------------------------------+--------------------------+
-| Python            | Python scripting. >= 3.8 is required.                        | ``LLDB_ENABLE_PYTHON``   |
+| Python            | Python scripting. >= 3.8 is required (3.11 or later on Windows).      | ``LLDB_ENABLE_PYTHON``   |
 +-------------------+--------------------------------------------------------------+--------------------------+
-| Lua               | Lua scripting. Lua 5.3 and 5.4 are supported.                | ``LLDB_ENABLE_LUA``      |
+| Lua               | Lua scripting. Lua 5.3 and 5.4 are supported.                         | ``LLDB_ENABLE_LUA``      |
 +-------------------+--------------------------------------------------------------+--------------------------+
 
 Depending on your platform and package manager, one might run any of the
@@ -112,7 +112,7 @@ Please follow the steps below if you only want to **build** lldb.
    ``dirname`` are available from your terminal.
 3. Install `make <https://sourceforge.net/projects/ezwinports/files/>`_ and
    verify that it's in your ``PATH``.
-4. Install `Python 3.11 <https://www.python.org/downloads/windows/>`_ or newer.
+4. Install `Python 3.11 <https://www.python.org/downloads/windows/>`_ or later.
    Either using the "Windows Installer" or "Python Install Manager". Make sure
    ``python`` is added to your ``PATH``.
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
@@ -50,7 +50,7 @@ static llvm::Expected<bool> *g_fcxx_modules_workaround [[maybe_unused]];
 #if LLDB_ENABLE_PYTHON_LIMITED_API
 // If defined, LLDB will be ABI-compatible with all Python 3 releases from the
 // specified one onward, and can use Limited API introduced up to that version.
-#define Py_LIMITED_API LLDB_MINIMUM_PYTHON_VERSION
+#define Py_LIMITED_API LLDB_MINIMUM_PYTHON_VERSION_HEX
 #endif
 
 // Include python for non windows machines

--- a/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
@@ -39,18 +39,12 @@ static llvm::Expected<bool> *g_fcxx_modules_workaround [[maybe_unused]];
 #include <locale>
 #endif
 
-#ifdef _WIN32
-#define LLDB_MINIMUM_PYTHON_VERSION_HEX 0x030b0000
-#define LLDB_MINIMUM_PYTHON_VERSION "3.11"
-#else
-#define LLDB_MINIMUM_PYTHON_VERSION_HEX 0x03080000
-#define LLDB_MINIMUM_PYTHON_VERSION "3.8"
-#endif
+#define LLDB_MINIMUM_PYTHON_VERSION 0x03080000
 
 #if LLDB_ENABLE_PYTHON_LIMITED_API
 // If defined, LLDB will be ABI-compatible with all Python 3 releases from the
 // specified one onward, and can use Limited API introduced up to that version.
-#define Py_LIMITED_API LLDB_MINIMUM_PYTHON_VERSION_HEX
+#define Py_LIMITED_API LLDB_MINIMUM_PYTHON_VERSION
 #endif
 
 // Include python for non windows machines
@@ -58,8 +52,8 @@ static llvm::Expected<bool> *g_fcxx_modules_workaround [[maybe_unused]];
 
 // Provide a meaningful diagnostic error if someone tries to compile this file
 // with a version of Python we don't support.
-static_assert(PY_VERSION_HEX >= LLDB_MINIMUM_PYTHON_VERSION_HEX,
-              "LLDB requires at least Python " LLDB_MINIMUM_PYTHON_VERSION);
+static_assert(PY_VERSION_HEX >= LLDB_MINIMUM_PYTHON_VERSION,
+              "LLDB requires at least Python 3.8");
 
 // PyMemoryView_FromMemory is part of stable ABI but the flag constants are not.
 // See https://github.com/python/cpython/issues/98680

--- a/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
@@ -39,7 +39,13 @@ static llvm::Expected<bool> *g_fcxx_modules_workaround [[maybe_unused]];
 #include <locale>
 #endif
 
-#define LLDB_MINIMUM_PYTHON_VERSION 0x03080000
+#ifdef _WIN32
+#define LLDB_MINIMUM_PYTHON_VERSION_HEX 0x030b0000
+#define LLDB_MINIMUM_PYTHON_VERSION "3.11"
+#else
+#define LLDB_MINIMUM_PYTHON_VERSION_HEX 0x03080000
+#define LLDB_MINIMUM_PYTHON_VERSION "3.8"
+#endif
 
 #if LLDB_ENABLE_PYTHON_LIMITED_API
 // If defined, LLDB will be ABI-compatible with all Python 3 releases from the
@@ -52,8 +58,8 @@ static llvm::Expected<bool> *g_fcxx_modules_workaround [[maybe_unused]];
 
 // Provide a meaningful diagnostic error if someone tries to compile this file
 // with a version of Python we don't support.
-static_assert(PY_VERSION_HEX >= LLDB_MINIMUM_PYTHON_VERSION,
-              "LLDB requires at least Python 3.8");
+static_assert(PY_VERSION_HEX >= LLDB_MINIMUM_PYTHON_VERSION_HEX,
+              "LLDB requires at least Python " LLDB_MINIMUM_PYTHON_VERSION);
 
 // PyMemoryView_FromMemory is part of stable ABI but the flag constants are not.
 // See https://github.com/python/cpython/issues/98680

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -294,7 +294,7 @@ Changes to LLDB
 
 ### Windows
 
-* Python 3.11 will become the minimum required version to build lldb on Windows.
+* Python 3.11 or later is now recommended for building LLDB 23 on Windows. From LLDB 24, Python 3.11 or later will be required.
 
 Changes to BOLT
 ---------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -294,7 +294,7 @@ Changes to LLDB
 
 ### Windows
 
-* Python 3.11 is now the minimum required version to build lldb on Windows.
+* Python 3.11 will become the minimum required version to build lldb on Windows.
 
 Changes to BOLT
 ---------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -292,6 +292,9 @@ Changes to LLDB
   an affected version in a way that is compatible with these systems, the issue
   contains details of backports that could be done to fix the affected versions.
 
+### Windows
+
+* Python 3.11 is now the minimum required version to build lldb on Windows.
 
 Changes to BOLT
 ---------------


### PR DESCRIPTION
As of https://github.com/llvm/llvm-project/pull/176387 and release 22, official builds of lldb on Windows use Python 3.11 both on x64 and arm64.

The Windows lldb build bots use 3.11+ versions of Python:

[lldb-x86_64-win](https://lab.llvm.org/buildbot/#/builders/211) - `3.12.7`
[lldb-remote-linux-win](https://lab.llvm.org/buildbot/#/builders/197) - `3.12.7`
[lldb-aarch64-windows](https://lab.llvm.org/buildbot/#/builders/141) - `3.11.9`

This patch changes the cmake config and documentation to recommend building lldb on Windows with Python 3.11 or more recent.

In the future, given the reduced number of lldb maintainers on Windows compared to other platforms, bumping the Python version on Windows would help reduce the surface area of Python related bugs.