### PR TITLE
[libc] Add generate-libc-headers custom target

### DIFF
--- a/libc/docs/full_host_build.rst
+++ b/libc/docs/full_host_build.rst
@@ -54,6 +54,12 @@ tests with the following command:
 
    ninja -C build libc libm check-libc
 
+To build just the generated headers (useful for troubleshooting):
+
+.. code-block:: sh
+
+   ninja -C build generate-libc-headers
+
 To run a specific unit test for a function, you can target it directly using its
 full name:
 

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -935,6 +935,7 @@ endfunction(get_all_install_header_targets)
 get_all_install_header_targets(all_install_header_targets ${TARGET_PUBLIC_HEADERS})
 add_library(libc-headers INTERFACE)
 add_dependencies(libc-headers ${all_install_header_targets})
+add_custom_target(libc-headers-build DEPENDS libc-headers)
 target_include_directories(libc-headers SYSTEM INTERFACE ${LIBC_INCLUDE_DIR})
 
 foreach(target IN LISTS all_install_header_targets)

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -933,9 +933,9 @@ function(get_all_install_header_targets out_var)
 endfunction(get_all_install_header_targets)
 
 get_all_install_header_targets(all_install_header_targets ${TARGET_PUBLIC_HEADERS})
+add_custom_target(generate-libc-headers DEPENDS ${all_install_header_targets})
 add_library(libc-headers INTERFACE)
-add_dependencies(libc-headers ${all_install_header_targets})
-add_custom_target(libc-headers-build DEPENDS libc-headers)
+add_dependencies(libc-headers generate-libc-headers)
 target_include_directories(libc-headers SYSTEM INTERFACE ${LIBC_INCLUDE_DIR})
 
 foreach(target IN LISTS all_install_header_targets)


### PR DESCRIPTION
Added the libc-headers-build custom target depending on libc-headers.

This allows troubleshooting headers without needing to install them first.