### PR TITLE
[clang][ssaf][test] Fix the extraction-works-alongside-compilation.cpp test

### DIFF
--- a/clang/test/Analysis/Scalable/extraction-works-alongside-compilation.cpp
+++ b/clang/test/Analysis/Scalable/extraction-works-alongside-compilation.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: asserts
 // DEFINE: %{filecheck} = FileCheck %s --match-full-lines --check-prefix
 // DEFINE: %{codegen} = %clang -c %s -o %t.o -mllvm -debug-only=codegenaction 2>&1
 


### PR DESCRIPTION
I forgot that we need this `REQUIRES: asserts` for the test.

Fixes build bots not setting `LLVM_ENABLE_ASSERTIONS=ON`.
For example:
https://lab.llvm.org/buildbot/#/builders/11/builds/37623

This fixes up #191058