### PR TITLE
[analyzer][NFC] Document getVarRegion shortcomings

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -1007,6 +1007,10 @@ public:
   }
 };
 
+// TODO: Currently MemRegionManager::getVarRegion returns NonParamVarRegion
+// instances to represent the parameters of the entrypoint stack frame and
+// parameters of outer stack frames that appear as captured within a lambda or
+// a block. This should be overhauled.
 class NonParamVarRegion : public VarRegion {
   friend class MemRegionManager;
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -1056,7 +1056,8 @@ public:
 /// ParamVarRegion - Represents a region for parameters. Only parameters of the
 /// function in the current stack frame are represented as `ParamVarRegion`s.
 /// Parameters of top-level analyzed functions as well as captured paremeters
-/// by lambdas and blocks are repesented as `VarRegion`s.
+/// by lambdas and blocks are repesented as `NonParamVarRegion`s.
+/// TODO: It would be nice to make this more consistent.
 
 // FIXME: `ParamVarRegion` only supports parameters of functions, C++
 // constructors, blocks and Objective-C methods with existing `Decl`. Upon

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1047,23 +1047,36 @@ const VarRegion *MemRegionManager::getVarRegion(const VarDecl *D,
     const Expr *CallSite = SFC->getCallSite();
     if (CallSite) {
       const Decl *CalleeDecl = SFC->getDecl();
-      bool ValidParam = true;
+      bool CurrentParam = true;
       if (const auto *FD = dyn_cast<FunctionDecl>(CalleeDecl)) {
-        ValidParam =
+        CurrentParam =
             (Index < FD->param_size() && FD->getParamDecl(Index) == PVD);
+        assert(CurrentParam);
       } else if (const auto *BD = dyn_cast<BlockDecl>(CalleeDecl)) {
-        ValidParam =
+        CurrentParam =
             (Index < BD->param_size() && BD->getParamDecl(Index) == PVD);
       }
 
-      if (ValidParam) {
+      if (CurrentParam) {
+        // If this is a parameter of the *current* stack frame, we can
+        // represent it with a `ParamVarRegion`.
         return getSubRegion<ParamVarRegion>(CallSite, Index,
                                             getStackArgumentsRegion(SFC));
+      } else {
+        // TODO: Parameters of other stack frames (which may have been be
+        // captured by a lambda or a block) are currently represented by
+        // `NonParamVarRegion`s. This behavior is present since commit
+        // 98db1f990fc273adc1ae36d4ce97ce66fd27ac30 which introduced
+        // `ParamVarRegion` in 2020; and appears to work (at least to some
+        // extent); but it would be nice to clean this up (if somebody has time
+        // and knowledge for a proper investigation).
       }
-      // FIXME: If ValidParam was false, this method would "fall through" and
-      // eventually return a NonParamVarRegion for this ParamVarDecl. That
-      // seems to be buggy, so I strongly suspect that ValidParam always ends
-      // up being true.
+    } else {
+      // TODO: Parameters of the entrypoint stack frame (where `CallSite` is
+      // null) are currently represented by `NonParamVarRegion`s. This behavior
+      // is also present since 98db1f990fc273adc1ae36d4ce97ce66fd27ac30 which
+      // introduced `ParamVarRegion` in 2020, but it would be nice ot clean it
+      // up for the sake of clarity and consistency.
     }
   }
 

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1051,7 +1051,6 @@ const VarRegion *MemRegionManager::getVarRegion(const VarDecl *D,
       if (const auto *FD = dyn_cast<FunctionDecl>(CalleeDecl)) {
         CurrentParam =
             (Index < FD->param_size() && FD->getParamDecl(Index) == PVD);
-        assert(CurrentParam);
       } else if (const auto *BD = dyn_cast<BlockDecl>(CalleeDecl)) {
         CurrentParam =
             (Index < BD->param_size() && BD->getParamDecl(Index) == PVD);

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1074,7 +1074,7 @@ const VarRegion *MemRegionManager::getVarRegion(const VarDecl *D,
       // TODO: Parameters of the entrypoint stack frame (where `CallSite` is
       // null) are currently represented by `NonParamVarRegion`s. This behavior
       // is also present since 98db1f990fc273adc1ae36d4ce97ce66fd27ac30 which
-      // introduced `ParamVarRegion` in 2020, but it would be nice ot clean it
+      // introduced `ParamVarRegion` in 2020, but it would be nice to clean it
       // up for the sake of clarity and consistency.
     }
   }


### PR DESCRIPTION
... more precisely, that the analyzer currently uses `NonParamVarRegion` instances to represent parameters of the entrypoint stack frame and parameters that are captured by inner lambdas or blocks.

In my recent commit f40c234191802154d5b3fc3209908c3f2d6e1649 I added a FIXME note to the method `MemRegionManager::getVarRegion`, but now, as I tried to implement that I realized that the situation is more complex and would need a more through change.

As I don't have time to do this right now, I'm pushing this commit to remove the inaccurate FIXME and replace it with more accurate TODO notes that explain the current (problematic) behavior of the codebase.