### PR TITLE
[TSAN][RISCV] Fix kHiAppMemEnd boundary for riscv64

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_platform.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform.h
@@ -404,7 +404,7 @@ struct MappingRiscv64_39 {
   static const uptr kHeapMemBeg = 0x2c00000000ull;
   static const uptr kHeapMemEnd = 0x2c00000000ull;
   static const uptr kHiAppMemBeg = 0x3c00000000ull;
-  static const uptr kHiAppMemEnd = 0x3fffffffffull;
+  static const uptr kHiAppMemEnd = 0x4000000000ull;
   static const uptr kShadowMsk = 0x3800000000ull;
   static const uptr kShadowXor = 0x0800000000ull;
   static const uptr kShadowAdd = 0x0000000000ull;
@@ -434,7 +434,7 @@ struct MappingRiscv64_48 {
   static const uptr kHeapMemBeg = 0x5a0000000000ull;
   static const uptr kHeapMemEnd = 0x5a0000000000ull;
   static const uptr kHiAppMemBeg = 0x7a0000000000ull;
-  static const uptr kHiAppMemEnd = 0x7fffffffffffull;
+  static const uptr kHiAppMemEnd = 0x800000000000ull;
   static const uptr kShadowMsk = 0x700000000000ull;
   static const uptr kShadowXor = 0x100000000000ull;
   static const uptr kShadowAdd = 0x000000000000ull;

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/pie_no_aslr.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/pie_no_aslr.cpp
@@ -1,4 +1,6 @@
-// RUN: %clangxx %s -pie -fPIE -o %t && %run setarch x86_64 -R %t
-// REQUIRES: x86_64-target-arch
+// RUN: %clangxx %s -pie -fPIE -o %t
+// RUN: %if x86_64-target-arch %{ %run setarch x86_64 -R %t %}
+// RUN: %if riscv64-target-arch %{ %run setarch rv64 -R %t %}
+// REQUIRES: x86_64-target-arch || riscv64-target-arch
 
 int main() { return 0; }


### PR DESCRIPTION
This resolves TSan execution failures on riscv64 platforms when Address Space Layout Randomization (ASLR) is disabled. There was an off-by-one error in `tsan_platform.h` that caused the sanitizer to fail when memory is mapped at the edge under non-ASLR environments. We fix this by extending `kHiAppMemEnd` to cover the full allowed memory range:

     `MappingRiscv64_39`: `0x3fffffffffull` -> `0x4000000000ull`                                                                                                                               
     `MappingRiscv64_48`: `0x7fffffffffffull` -> `0x800000000000ull`

We also add riscv64 test support to `pie_no_aslr.cpp`