### PR TITLE
[clang] Mark CWG2708, CWG2713, CWG2792 as resolved; sync CWG2947 status

### DIFF
--- a/clang/test/CXX/drs/cwg27xx.cpp
+++ b/clang/test/CXX/drs/cwg27xx.cpp
@@ -58,6 +58,25 @@ A b = {3, 4, 5};
 
 } // namespace cwg2707
 
+namespace cwg2708 { // cwg2708: yes
+#if __cplusplus >= 202002L
+void f() {
+  const int a[2](1, 2);
+  (void)a;
+}
+#endif
+} // namespace cwg2708
+
+namespace cwg2713 { // cwg2713: yes
+#if __cplusplus >= 202002L
+struct A { int x; int y; };
+void f() {
+  A const& r = {.x = 1, .y = 2};
+  (void)r;
+}
+#endif
+} // namespace cwg2713
+
 namespace cwg2718 { // cwg2718: 2.7
 struct B {};
 struct D;
@@ -225,6 +244,8 @@ void test() {
 }
 #endif
 } // namespace cwg2789
+
+// cwg2792: na
 
 namespace cwg2798 { // cwg2798: 17
 #if __cplusplus > 202302L

--- a/clang/test/CXX/drs/cwg2947.cpp
+++ b/clang/test/CXX/drs/cwg2947.cpp
@@ -32,7 +32,7 @@
 // RUN: %clang_cc1 -std=c++26 -fsyntax-only -verify %t/cwg2947_ext2.cpp
 // RUN: %clang_cc1 -std=c++26 -fsyntax-only -verify %t/cwg2947_ext3.cpp
 
-// cwg2947: 23 tentatively ready 2026-03-06
+// cwg2947: 23 ready 2026-03-06
 
 //--- cwg2947_example1.cpp
 // #define DOT_BAR .bar

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -18066,7 +18066,7 @@
   <tr class="open" id="2609">
     <td><a href="https://cplusplus.github.io/CWG/issues/2609.html">2609</a></td>
     <td>[<a href="https://wg21.link/expr.sizeof">expr.sizeof</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Padding in class types</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -18761,7 +18761,7 @@
     <td>[<a href="https://wg21.link/dcl.init.general">dcl.init.general</a>]</td>
     <td>CD7</td>
     <td>Parenthesized initialization of arrays</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Yes</td>
   </tr>
   <tr id="2709">
     <td><a href="https://cplusplus.github.io/CWG/issues/2709.html">2709</a></td>
@@ -18796,7 +18796,7 @@
     <td>[<a href="https://wg21.link/dcl.init.list">dcl.init.list</a>]</td>
     <td>CD7</td>
     <td>Initialization of reference-to-aggregate from designated initializer list</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Yes</td>
   </tr>
   <tr id="2714">
     <td><a href="https://cplusplus.github.io/CWG/issues/2714.html">2714</a></td>
@@ -19011,7 +19011,7 @@
   <tr class="open" id="2744">
     <td><a href="https://cplusplus.github.io/CWG/issues/2744.html">2744</a></td>
     <td>[<a href="https://wg21.link/intro.object">intro.object</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Multiple objects of the same type at the same address</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -19158,7 +19158,7 @@
   <tr class="open" id="2765">
     <td><a href="https://cplusplus.github.io/CWG/issues/2765.html">2765</a></td>
     <td>[<a href="https://wg21.link/intro.object">intro.object</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Address comparisons between potentially non-unique objects during constant evaluation</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -19353,7 +19353,7 @@
     <td>[<a href="https://wg21.link/expr.unary.noexcept">expr.unary.noexcept</a>]</td>
     <td>CD7</td>
     <td>Clean up specification of <TT>noexcept</TT> operator</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="na" align="center">N/A</td>
   </tr>
   <tr id="2793">
     <td><a href="https://cplusplus.github.io/CWG/issues/2793.html">2793</a></td>
@@ -19400,7 +19400,7 @@
   <tr class="open" id="2799">
     <td><a href="https://cplusplus.github.io/CWG/issues/2799.html">2799</a></td>
     <td>[<a href="https://wg21.link/class.default.ctor">class.default.ctor</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Inheriting default constructors</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -20444,7 +20444,7 @@
   <tr class="open" id="2947">
     <td><a href="https://cplusplus.github.io/CWG/issues/2947.html">2947</a></td>
     <td>[<a href="https://wg21.link/cpp.module">cpp.module</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Limiting macro expansion in <I>pp-module</I></td>
     <td align="center">
       <details>
@@ -20581,7 +20581,7 @@
   <tr class="open" id="2966">
     <td><a href="https://cplusplus.github.io/CWG/issues/2966.html">2966</a></td>
     <td>[<a href="https://wg21.link/basic.fundamental">basic.fundamental</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Alignment and value representation of <TT>std::nullptr_t</TT></td>
     <td align="center">Not resolved</td>
   </tr>
@@ -20651,7 +20651,7 @@
   <tr class="open" id="2976">
     <td><a href="https://cplusplus.github.io/CWG/issues/2976.html">2976</a></td>
     <td>[<a href="https://wg21.link/stmt.dcl">stmt.dcl</a>]</td>
-    <td>review</td>
+    <td>ready</td>
     <td>Transferring control out of a function</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -20700,7 +20700,7 @@
   <tr class="open" id="2983">
     <td><a href="https://cplusplus.github.io/CWG/issues/2983.html">2983</a></td>
     <td>[<a href="https://wg21.link/basic.pre">basic.pre</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Non-type template parameters are not variables</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -20763,7 +20763,7 @@
   <tr class="open" id="2992">
     <td><a href="https://cplusplus.github.io/CWG/issues/2992.html">2992</a></td>
     <td>[<a href="https://wg21.link/basic.pre">basic.pre</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Labels do not have names</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -20784,14 +20784,14 @@
   <tr class="open" id="2995">
     <td><a href="https://cplusplus.github.io/CWG/issues/2995.html">2995</a></td>
     <td>[<a href="https://wg21.link/stmt.return">stmt.return</a>]</td>
-    <td>tentatively ready</td>
+    <td>open</td>
     <td>Meaning of flowing off the end of a function</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2996">
     <td><a href="https://cplusplus.github.io/CWG/issues/2996.html">2996</a></td>
     <td>[<a href="https://wg21.link/temp.constr.atomic">temp.constr.atomic</a>]</td>
-    <td>tentatively ready</td>
+    <td>review</td>
     <td>Impenetrable definition of atomic constraint</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -20889,7 +20889,7 @@
   <tr class="open" id="3010">
     <td><a href="https://cplusplus.github.io/CWG/issues/3010.html">3010</a></td>
     <td>[<a href="https://wg21.link/expr.const">expr.const</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>constexpr placement-new should require transparent replaceability</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21022,7 +21022,7 @@
   <tr class="open" id="3029">
     <td><a href="https://cplusplus.github.io/CWG/issues/3029.html">3029</a></td>
     <td>[<a href="https://wg21.link/basic.align">basic.align</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Confusing note about ordinary character types for aligned memory areas</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21064,7 +21064,7 @@
   <tr class="open" id="3035">
     <td><a href="https://cplusplus.github.io/CWG/issues/3035.html">3035</a></td>
     <td>[<a href="https://wg21.link/class.union.anon">class.union.anon</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Lambda expressions in anonymous unions</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21225,7 +21225,7 @@
   <tr class="open" id="3058">
     <td><a href="https://cplusplus.github.io/CWG/issues/3058.html">3058</a></td>
     <td>[<a href="https://wg21.link/basic.lookup.general">basic.lookup.general</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>"Program point" is not defined</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21303,7 +21303,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/3069.html">3069</a></td>
     <td>[<a href="https://wg21.link/temp.constr.normal">temp.constr.normal</a>]</td>
     <td>open</td>
-    <td>Reference to wrong placeholder</td>
+    <td>Default template arguments in constraint normalization</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr id="3070">
@@ -21435,7 +21435,7 @@
   <tr class="open" id="3088">
     <td><a href="https://cplusplus.github.io/CWG/issues/3088.html">3088</a></td>
     <td>[<a href="https://wg21.link/cpp.replace.general">cpp.replace.general</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Clarify macro treatment of identifiers with special meaning</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21652,7 +21652,7 @@
   <tr class="open" id="3119">
     <td><a href="https://cplusplus.github.io/CWG/issues/3119.html">3119</a></td>
     <td>[<a href="https://wg21.link/temp.pre">temp.pre</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td><I>for-range-declaration</I> of an <I>expansion-statement</I> as a templated entity</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21673,49 +21673,49 @@
   <tr class="open" id="3122">
     <td><a href="https://cplusplus.github.io/CWG/issues/3122.html">3122</a></td>
     <td>[<a href="https://wg21.link/temp.dep.constexpr">temp.dep.constexpr</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Inadequate value-dependence for <I>reflect-expression</I>s</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3123">
     <td><a href="https://cplusplus.github.io/CWG/issues/3123.html">3123</a></td>
     <td>[<a href="https://wg21.link/stmt.expand">stmt.expand</a>]</td>
-    <td>review</td>
+    <td>ready</td>
     <td>Global lookup for <TT>begin</TT> and <TT>end</TT> for expansion statements</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3124">
     <td><a href="https://cplusplus.github.io/CWG/issues/3124.html">3124</a></td>
     <td>[<a href="https://wg21.link/dcl.attr.annotation">dcl.attr.annotation</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Disallow annotations on block-scope externs and non-unique friend declarations</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3125">
     <td><a href="https://cplusplus.github.io/CWG/issues/3125.html">3125</a></td>
     <td>[<a href="https://wg21.link/cpp.cond">cpp.cond</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Token convertibility requirement in <TT>#if</TT></td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3126">
     <td><a href="https://cplusplus.github.io/CWG/issues/3126.html">3126</a></td>
     <td>[<a href="https://wg21.link/lex.token">lex.token</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>A module import needs a <I>header-name</I> as a <I>token</I></td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3127">
     <td><a href="https://cplusplus.github.io/CWG/issues/3127.html">3127</a></td>
     <td>[<a href="https://wg21.link/expr.const">expr.const</a>]</td>
-    <td>review</td>
+    <td>ready</td>
     <td>Evaluation context is missing synthesized points</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3128">
     <td><a href="https://cplusplus.github.io/CWG/issues/3128.html">3128</a></td>
     <td>[<a href="https://wg21.link/except.spec">except.spec</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Potentially-throwing unevaluated operands</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21729,28 +21729,28 @@
   <tr class="open" id="3130">
     <td><a href="https://cplusplus.github.io/CWG/issues/3130.html">3130</a></td>
     <td>[<a href="https://wg21.link/expr.prim.id.general">expr.prim.id.general</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Naming function members of anonymous unions</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3131">
     <td><a href="https://cplusplus.github.io/CWG/issues/3131.html">3131</a></td>
     <td>[<a href="https://wg21.link/stmt.expand">stmt.expand</a>]</td>
-    <td>open</td>
+    <td>ready</td>
     <td>Value categories and types for the range in iterable expansion statements</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3132">
     <td><a href="https://cplusplus.github.io/CWG/issues/3132.html">3132</a></td>
     <td>[<a href="https://wg21.link/stmt.pre">stmt.pre</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Unclear disambiguation rule for <I>condition</I></td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3133">
     <td><a href="https://cplusplus.github.io/CWG/issues/3133.html">3133</a></td>
     <td>[<a href="https://wg21.link/over.built">over.built</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Cv-qualified types in built-in operator candidates</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21764,14 +21764,14 @@
   <tr class="open" id="3135">
     <td><a href="https://cplusplus.github.io/CWG/issues/3135.html">3135</a></td>
     <td>[<a href="https://wg21.link/dcl.struct.bind">dcl.struct.bind</a>]</td>
-    <td>open</td>
-    <td>Structured bindings with prvalues from tuples</td>
+    <td>ready</td>
+    <td>constexpr structured bindings with prvalues from tuples</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3136">
     <td><a href="https://cplusplus.github.io/CWG/issues/3136.html">3136</a></td>
     <td>[<a href="https://wg21.link/expr.const">expr.const</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Constant expressions of type void</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21799,21 +21799,21 @@
   <tr class="open" id="3140">
     <td><a href="https://cplusplus.github.io/CWG/issues/3140.html">3140</a></td>
     <td>[<a href="https://wg21.link/stmt.expand">stmt.expand</a>]</td>
-    <td>open</td>
+    <td>ready</td>
     <td>Allowing expansion over non-constant <TT>std::array</TT></td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3141">
     <td><a href="https://cplusplus.github.io/CWG/issues/3141.html">3141</a></td>
     <td>[<a href="https://wg21.link/intro.object">intro.object</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Unique objects from <TT>define_static_array</TT></td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3142">
     <td><a href="https://cplusplus.github.io/CWG/issues/3142.html">3142</a></td>
     <td>[<a href="https://wg21.link/cpp.predefined">cpp.predefined</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Possible expansions of <TT>__LINE__</TT> changing over time</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21855,42 +21855,42 @@
   <tr class="open" id="3148">
     <td><a href="https://cplusplus.github.io/CWG/issues/3148.html">3148</a></td>
     <td>[<a href="https://wg21.link/class.mem.general">class.mem.general</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Definition of "user-declared" special member function</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3149">
     <td><a href="https://cplusplus.github.io/CWG/issues/3149.html">3149</a></td>
     <td>[<a href="https://wg21.link/stmt.expand">stmt.expand</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Rvalues in destructuring expansion statements</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3150">
     <td><a href="https://cplusplus.github.io/CWG/issues/3150.html">3150</a></td>
     <td>[<a href="https://wg21.link/basic.types.general">basic.types.general</a>]</td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Incomplete consteval-only class types</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3151">
     <td><a href="https://cplusplus.github.io/CWG/issues/3151.html">3151</a></td>
     <td>[<a href="https://wg21.link/expr.prim.lambda.closure">expr.prim.lambda.closure</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Closure types that are <TT>final</TT></td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="3152">
+  <tr id="3152">
     <td><a href="https://cplusplus.github.io/CWG/issues/3152.html">3152</a></td>
     <td>[<a href="https://wg21.link/intro.object">intro.object</a>]</td>
-    <td>tentatively ready</td>
+    <td>NAD</td>
     <td>Placement of an unrelated complete object in the padding of another complete object</td>
-    <td align="center">Not resolved</td>
+    <td class="unknown" align="center">Unknown</td>
   </tr>
   <tr class="open" id="3153">
     <td><a href="https://cplusplus.github.io/CWG/issues/3153.html">3153</a></td>
     <td>[<a href="https://wg21.link/expr.const">expr.const</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Immediate-escalating defaulted comparison</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21904,28 +21904,28 @@
   <tr class="open" id="3155">
     <td><a href="https://cplusplus.github.io/CWG/issues/3155.html">3155</a></td>
     <td>[<a href="https://wg21.link/class.virtual">class.virtual</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Escalation of virtual functions</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3156">
     <td><a href="https://cplusplus.github.io/CWG/issues/3156.html">3156</a></td>
     <td>[<a href="https://wg21.link/expr.prim.lambda.capture">expr.prim.lambda.capture</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Handling of deleted functions in unevaluated <I>lambda-capture</I>s</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3157">
     <td><a href="https://cplusplus.github.io/CWG/issues/3157.html">3157</a></td>
     <td>[<a href="https://wg21.link/temp.deduct.decl">temp.deduct.decl</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Missing handling of <TT>operator new[]</TT> for deallocation function template matching</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3158">
     <td><a href="https://cplusplus.github.io/CWG/issues/3158.html">3158</a></td>
     <td>[<a href="https://wg21.link/expr.prim.splice">expr.prim.splice</a>]</td>
-    <td>open</td>
+    <td>review</td>
     <td>Constification for <I>splice-expression</I>s</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21953,8 +21953,78 @@
   <tr class="open" id="3162">
     <td><a href="https://cplusplus.github.io/CWG/issues/3162.html">3162</a></td>
     <td>[<a href="https://wg21.link/expr.const">expr.const</a>]</td>
-    <td>open</td>
+    <td>ready</td>
     <td>Evaluation context of manifestly constant-evaluated expressions</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3163">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3163.html">3163</a></td>
+    <td>[<a href="https://wg21.link/dcl.pre">dcl.pre</a>]</td>
+    <td>open</td>
+    <td>Grammar ambiguity for <I>nodeclspec-function-declaration</I></td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3164">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3164.html">3164</a></td>
+    <td>[<a href="https://wg21.link/cpp.predefined">cpp.predefined</a>]</td>
+    <td>open</td>
+    <td>Location of specification of <TT>__STDCPP_FLOAT16_T__</TT> macro</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3165">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3165.html">3165</a></td>
+    <td>[<a href="https://wg21.link/basic.link">basic.link</a>]</td>
+    <td>open</td>
+    <td>Use "equivalent type" to support templated entities</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3166">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3166.html">3166</a></td>
+    <td>[<a href="https://wg21.link/expr.reflect">expr.reflect</a>]</td>
+    <td>open</td>
+    <td>Protected access rule for a pointer-to-member from a <I>reflect-expression</I></td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3167">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3167.html">3167</a></td>
+    <td>[<a href="https://wg21.link/dcl.init">dcl.init</a>]</td>
+    <td>open</td>
+    <td>Initializing typedefs</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3168">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3168.html">3168</a></td>
+    <td>[<a href="https://wg21.link/conv.rank">conv.rank</a>]</td>
+    <td>open</td>
+    <td>Issues with integer conversion ranks</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3169">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3169.html">3169</a></td>
+    <td>[<a href="https://wg21.link/class.mem.general">class.mem.general</a>]</td>
+    <td>open</td>
+    <td>Issues with layout-compatible structs and unions</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr id="3170">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3170.html">3170</a></td>
+    <td>[<a href="https://wg21.link/basic.contract.eval">basic.contract.eval</a>]</td>
+    <td>NAD</td>
+    <td>Failed consteval contracts while constructing a candidate set</td>
+    <td class="unknown" align="center">Unknown</td>
+  </tr>
+  <tr class="open" id="3171">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3171.html">3171</a></td>
+    <td>[<a href="https://wg21.link/basic.link">basic.link</a>]</td>
+    <td>ready</td>
+    <td>Codify the strong ownership for modules</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3172">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3172.html">3172</a></td>
+    <td>[<a href="https://wg21.link/temp.constr.normal">temp.constr.normal</a>]</td>
+    <td>ready</td>
+    <td>Reference to wrong placeholder</td>
     <td align="center">Not resolved</td>
   </tr></table>
 


### PR DESCRIPTION
While going through the unresolved entries in cxx_dr_status.html I noticed three DRs that Clang already handles correctly but are still listed as Unknown. This adds the corresponding test entries so the status page reflects reality.

- **CWG2708** — Parenthesized initialization of arrays. `const int a[2](1, 2);` is accepted in C++20.
- **CWG2713** — Reference-to-aggregate from a designated initializer list. `const A& r = {.x = 1, .y = 2};` works in C++20.
- **CWG2792** — Cleanup of the noexcept operator wording. Wording-only, marked `na`.

Also includes a small drive-by fix: `cwg2947` was tagged `tentatively ready` but the CWG index has since moved it to `ready`. Without this update, `make_cxx_dr_status` aborts before regenerating the page. The HTML file is regenerated accordingly.

Happy to drop CWG2947 into a separate PR if preferred.