### PR TITLE
[libc] Add cpio.h to Linux target public headers

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -2,6 +2,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.arpa_inet
     libc.include.assert
     libc.include.complex
+    libc.include.cpio
     libc.include.ctype
     libc.include.dirent
     libc.include.dlfcn

--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -1,5 +1,6 @@
 set(TARGET_PUBLIC_HEADERS
     libc.include.complex
+    libc.include.cpio
     libc.include.ctype
     libc.include.errno
     libc.include.fenv

--- a/libc/config/linux/i386/headers.txt
+++ b/libc/config/linux/i386/headers.txt
@@ -1,3 +1,4 @@
 set(TARGET_PUBLIC_HEADERS
   libc.include.assert
+  libc.include.cpio
 )

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -2,6 +2,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.arpa_inet
     libc.include.assert
     libc.include.complex
+    libc.include.cpio
     libc.include.ctype
     libc.include.dirent
     libc.include.dlfcn

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -2,6 +2,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.arpa_inet
     libc.include.assert
     libc.include.complex
+    libc.include.cpio
     libc.include.ctype
     libc.include.dirent
     libc.include.dlfcn


### PR DESCRIPTION
Added libc.include.cpio to TARGET_PUBLIC_HEADERS for all Linux architectures: aarch64, arm, i386, riscv, and x86_64.

This enables generation of cpio.h when building with LLVM_LIBC_FULL_BUILD.