### PR TITLE
[InstCombine] fold (sext(ucmp/scmp(X, Y)) -> ucmp/scmp(X, Y)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -21,8 +21,6 @@
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/Instruction.h"
-#include "llvm/IR/IntrinsicInst.h"
-#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Value.h"

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -21,6 +21,8 @@
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/Instruction.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Value.h"
@@ -1920,6 +1922,18 @@ Instruction *InstCombinerImpl::visitSExt(SExtInst &Sext) {
         if (Log2_32(*MaxVScale) < (SrcBitSize - 1))
           return replaceInstUsesWith(Sext, Builder.CreateVScale(DestTy));
     }
+  }
+
+  // sext(scmp(x, y)) -> scmp(x, y) with a wider result type.
+  // sext(ucmp(x, y)) -> ucmp(x, y) with a wider result type.
+  // scmp/ucmp return only -1, 0, or 1, which sign-extend correctly to any
+  // wider integer type, so we can sink the extension into the intrinsic.
+  if (auto *II = dyn_cast<IntrinsicInst>(Src)) {
+    Intrinsic::ID IID = II->getIntrinsicID();
+    if ((IID == Intrinsic::scmp || IID == Intrinsic::ucmp) && II->hasOneUse())
+      return replaceInstUsesWith(
+          Sext, Builder.CreateIntrinsic(
+                    DestTy, IID, {II->getArgOperand(0), II->getArgOperand(1)}));
   }
 
   return nullptr;

--- a/llvm/test/Transforms/InstCombine/scmp.ll
+++ b/llvm/test/Transforms/InstCombine/scmp.ll
@@ -801,8 +801,7 @@ define i8 @scmp_ashr_slt_pattern_neg(i8 %a) {
 define i64 @sext_scmp(i32 %x, i32 %y) {
 ; CHECK-LABEL: define i64 @sext_scmp(
 ; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
-; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[X]], i32 [[Y]])
-; CHECK-NEXT:    [[TMP1:%.*]] = sext i8 [[CMP]] to i64
+; CHECK-NEXT:    [[TMP1:%.*]] = call i64 @llvm.scmp.i64.i32(i32 [[X]], i32 [[Y]])
 ; CHECK-NEXT:    ret i64 [[TMP1]]
 ;
   %cmp = call i8 @llvm.scmp(i32 %x, i32 %y)

--- a/llvm/test/Transforms/InstCombine/scmp.ll
+++ b/llvm/test/Transforms/InstCombine/scmp.ll
@@ -797,3 +797,31 @@ define i8 @scmp_ashr_slt_pattern_neg(i8 %a) {
   %retval = select i1 %cmp, i8 %a.lobit, i8 1
   ret i8 %retval
 }
+
+define i64 @sext_scmp(i32 %x, i32 %y) {
+; CHECK-LABEL: define i64 @sext_scmp(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[X]], i32 [[Y]])
+; CHECK-NEXT:    [[TMP1:%.*]] = sext i8 [[CMP]] to i64
+; CHECK-NEXT:    ret i64 [[TMP1]]
+;
+  %cmp = call i8 @llvm.scmp(i32 %x, i32 %y)
+  %ext = sext i8 %cmp to i64
+  ret i64 %ext
+}
+
+; Don't fold when scmp has multiple uses: would leave the narrow scmp alive
+; and add a second wider scmp.
+define i64 @sext_scmp_multiuse(i32 %x, i32 %y) {
+; CHECK-LABEL: define i64 @sext_scmp_multiuse(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[X]], i32 [[Y]])
+; CHECK-NEXT:    call void @use(i8 [[CMP]])
+; CHECK-NEXT:    [[EXT:%.*]] = sext i8 [[CMP]] to i64
+; CHECK-NEXT:    ret i64 [[EXT]]
+;
+  %cmp = call i8 @llvm.scmp(i32 %x, i32 %y)
+  call void @use(i8 %cmp)
+  %ext = sext i8 %cmp to i64
+  ret i64 %ext
+}

--- a/llvm/test/Transforms/InstCombine/ucmp.ll
+++ b/llvm/test/Transforms/InstCombine/ucmp.ll
@@ -555,3 +555,31 @@ define i8 @scmp_from_select_eq_and_gt(i32 %x, i32 %y) {
   %r = select i1 %eq, i8 0, i8 %sel1
   ret i8 %r
 }
+
+define i64 @sext_ucmp(i32 %x, i32 %y) {
+; CHECK-LABEL: define i64 @sext_ucmp(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[X]], i32 [[Y]])
+; CHECK-NEXT:    [[TMP1:%.*]] = sext i8 [[CMP]] to i64
+; CHECK-NEXT:    ret i64 [[TMP1]]
+;
+  %cmp = call i8 @llvm.ucmp(i32 %x, i32 %y)
+  %ext = sext i8 %cmp to i64
+  ret i64 %ext
+}
+
+; Don't fold when ucmp has multiple uses: would leave the narrow ucmp alive
+; and add a second wider ucmp.
+define i64 @sext_ucmp_multiuse(i32 %x, i32 %y) {
+; CHECK-LABEL: define i64 @sext_ucmp_multiuse(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[X]], i32 [[Y]])
+; CHECK-NEXT:    call void @use(i8 [[CMP]])
+; CHECK-NEXT:    [[EXT:%.*]] = sext i8 [[CMP]] to i64
+; CHECK-NEXT:    ret i64 [[EXT]]
+;
+  %cmp = call i8 @llvm.ucmp(i32 %x, i32 %y)
+  call void @use(i8 %cmp)
+  %ext = sext i8 %cmp to i64
+  ret i64 %ext
+}

--- a/llvm/test/Transforms/InstCombine/ucmp.ll
+++ b/llvm/test/Transforms/InstCombine/ucmp.ll
@@ -559,8 +559,7 @@ define i8 @scmp_from_select_eq_and_gt(i32 %x, i32 %y) {
 define i64 @sext_ucmp(i32 %x, i32 %y) {
 ; CHECK-LABEL: define i64 @sext_ucmp(
 ; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
-; CHECK-NEXT:    [[CMP:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[X]], i32 [[Y]])
-; CHECK-NEXT:    [[TMP1:%.*]] = sext i8 [[CMP]] to i64
+; CHECK-NEXT:    [[TMP1:%.*]] = call i64 @llvm.ucmp.i64.i32(i32 [[X]], i32 [[Y]])
 ; CHECK-NEXT:    ret i64 [[TMP1]]
 ;
   %cmp = call i8 @llvm.ucmp(i32 %x, i32 %y)


### PR DESCRIPTION
relates: https://github.com/llvm/llvm-project/issues/190538
related PR: https://github.com/llvm/llvm-project/pull/190787

This PR folds (sext(ucmp/scmp(X, Y)) -> ucmp/scmp(X, Y). Since ucmp/scmp return -1, 0, 1, if you see the sequence:

```llvm
%_3 = tail call i8 @llvm.ucmp.i8.i64(i64 %a, i64 %b)
%_0 = sext i8 %_3 to i64
```

It's fine to turn this into:

```llvm
%_0 = tail call i64 @llvm.ucmp.i64.i64(i64 %a, i64 %b)
```

[Alive Proof](https://alive2.llvm.org/ce/z/VmeKM2)

Likewise for scmp:

```llvm
%_3 = tail call i8 @llvm.scmp.i8.i64(i64 %a, i64 %b)
%_0 = sext i8 %_3 to i64
```

```llvm
%_0 = tail call i64 @llvm.scmp.i64.i64(i64 %a, i64 %b)
```

[Alive Proof](https://alive2.llvm.org/ce/z/WSm7YS)

For ucmp, a simple way to get this is to cmp two rust unsigned integers:

```rust
pub fn compare(a: u64, b: u64) -> i64 {
    a.cmp(&b) as i64
}
```

Which gets this:

```llvm
define noundef range(i64 -1, 2) i64 @compare(i64 noundef %a, i64 noundef %b) unnamed_addr {
start:
  %_3 = tail call i8 @llvm.ucmp.i8.i64(i64 %a, i64 %b)
  %_0 = sext i8 %_3 to i64
  ret i64 %_0
}

declare range(i8 -1, 2) i8 @llvm.ucmp.i8.i64(i64, i64)
```

For scmp, swapping to i64s will suffice:

```rust
pub fn compare(a: i64, b: i64) -> i64 {
    a.cmp(&b) as i64
}
```

```llvm
define noundef range(i64 -1, 2) i64 @compare(i64 noundef %a, i64 noundef %b) unnamed_addr {
start:
  %_3 = tail call i8 @llvm.scmp.i8.i64(i64 %a, i64 %b)
  %_0 = sext i8 %_3 to i64
  ret i64 %_0
}

declare range(i8 -1, 2) i8 @llvm.scmp.i8.i64(i64, i64)
```

