### PR TITLE
[libc++] stop_token uses yield instead of wait in the locking mechanism

### DIFF
--- a/libcxx/include/__stop_token/atomic_unique_lock.h
+++ b/libcxx/include/__stop_token/atomic_unique_lock.h
@@ -12,6 +12,7 @@
 
 #include <__bit/has_single_bit.h>
 #include <__config>
+#include <__thread/this_thread.h>
 #include <atomic>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -81,7 +82,6 @@ public:
     // unset the _LockedBit. `memory_order_release` because we need to make sure all the write operations before calling
     // `__unlock` will be made visible to other threads
     __state_.fetch_and(static_cast<_State>(~_LockedBit), std::memory_order_release);
-    __state_.notify_all();
     __is_locked_ = false;
   }
 
@@ -103,9 +103,8 @@ private:
           return false;
         } else if ((__current_state & _LockedBit) != 0) {
           // another thread has locked the state, we need to wait
-          __state_.wait(__current_state, std::memory_order_relaxed);
-          // when it is woken up by notifyAll or spuriously, the __state_
-          // might have changed. reload the state
+          this_thread::yield();
+          // the __state_ might have changed. reload the state
           // Note that the new state's _LockedBit may or may not equal to 0
           __current_state = __state_.load(std::memory_order_relaxed);
         } else {


### PR DESCRIPTION
Comparing stop_token's benchmark between libstdc++ and libc++ on macOS with M4 MAX CPU

```
Benchmark                                                                     Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------------------------------
BM_stop_token_single_thread_polling_stop_requested/1024                    -0.5691         -0.5692          4319          1861          4288          1847
BM_stop_token_single_thread_polling_stop_requested/131072                  -0.6297         -0.6297        571676        211664        570344        211183
BM_stop_token_single_thread_polling_stop_requested/16777216                -0.5869         -0.5870      65842470      27197096      65724889      27146346
BM_stop_token_multi_thread_polling_stop_requested/1024                     +1.5101         +0.1288        779551       1956721          7155          8077
BM_stop_token_multi_thread_polling_stop_requested/131072                   +0.0052         -0.1709       9394099       9442661         49115         40721
BM_stop_token_multi_thread_polling_stop_requested/16777216                 +0.1478         +1.0269     140723479     161522180        359550        728780
BM_stop_token_single_thread_reg_unreg_callback/1024                        -0.4221         -0.4223         24054         13902         24023         13879
BM_stop_token_single_thread_reg_unreg_callback/131072                      -0.4232         -0.4231       3073968       1772956       3068631       1770264
BM_stop_token_single_thread_reg_unreg_callback/16777216                    -0.4417         -0.4419     409165621     228421458     408654000     228065333
BM_stop_token_async_reg_unreg_callback/1024                                +0.5643         +0.5628        638775        999230        637488        996290
BM_stop_token_async_reg_unreg_callback/131072                              +0.6356         +0.6343      79564595     130135042      79426400     129804000
BM_stop_token_async_reg_unreg_callback/16777216                            +0.6796         +0.6779    9941676617   16698317917    9924915000   16653010000
```

Old is libstdc++, and New is libc++

we see BM_stop_token_async_reg_unreg_callback , libcxx is 60% slower.

We can see in libstdc++, for locking the callback list, it uses the atomic cas with a `yield` in the loop
https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/std/stop_token#L384

In libc++, we do something similar. we use atomic cas with `atomic::wait` in the loop.

Note that I have ran the same benchmark on Linux x86. the benchmark shows that there is no performance diff between libstdc++ and libc++.

This probably means that on Linux, the `atomic::wait` , which is backed by `futex_wait`, has similar performance of `yield`. 

However, on macOS, it seems that replacing `atomic::wait`, which is backed by `__ulock_wait`, is much slower than doing a 'yield'.

With the changes,

```
Benchmark                                                                     Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------------------------------
BM_stop_token_single_thread_polling_stop_requested/1024                    -0.4771         -0.5610          4319          2259          4288          1883
BM_stop_token_single_thread_polling_stop_requested/131072                  -0.6296         -0.6296        571676        211762        570344        211283
BM_stop_token_single_thread_polling_stop_requested/16777216                -0.5901         -0.5899      65842470      26990987      65724889      26954885
BM_stop_token_multi_thread_polling_stop_requested/1024                     -0.4276         -0.5851        779551        446217          7155          2969
BM_stop_token_multi_thread_polling_stop_requested/131072                   +0.0220         -0.2966       9394099       9600421         49115         34547
BM_stop_token_multi_thread_polling_stop_requested/16777216                 +0.0777         +1.9850     140723479     151654897        359550       1073240
BM_stop_token_single_thread_reg_unreg_callback/1024                        -0.5487         -0.5520         24054         10856         24023         10763
BM_stop_token_single_thread_reg_unreg_callback/131072                      -0.5532         -0.5534       3073968       1373350       3068631       1370412
BM_stop_token_single_thread_reg_unreg_callback/16777216                    -0.5733         -0.5734     409165621     174579125     408654000     174330000
BM_stop_token_async_reg_unreg_callback/1024                                -0.0491         -0.0497        638775        607400        637488        605813
BM_stop_token_async_reg_unreg_callback/131072                              +0.0215         +0.0217      79564595      81273629      79426400      81149167
BM_stop_token_async_reg_unreg_callback/16777216                            +0.0627         +0.0629    9941676617   10565137792    9924915000   10548930000
```

old is libstdc++,  new is libcxx with the PR (replacing wait with yield).
We can see with this change, the performance of that test matches libstdc++

btw: I had to change the test from running 20 threads to 10 threads, otherwise my OS is crashing and got rebooted
