### PR TITLE
[lldb][test] Fix call signature in TestAppleSimulatorOSType

### DIFF
--- a/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -13,9 +13,6 @@ import re
 class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
     SHARED_BUILD_TESTCASE = False
 
-    # Number of stderr lines to read from the simctl output.
-    READ_LINES = 10
-
     def check_simulator_ostype(self, sdk, platform_name, arch=platform.machine()):
         # Get simulator
         deviceUDID = None
@@ -59,7 +56,6 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
             deviceUDID,
             self.getBuildArtifact(exe_name),
             ["print-pid", "sleep:10"],
-            self.READ_LINES,
             [r"PID: (.*)"],
             self.trace,
         )


### PR DESCRIPTION
Commit 918e446ef28ac97df20d6ef2bd50c78e2fe903ac removed the stderr_lines_to_read argument but didn't adjust the call site in TestAppleSimulatorOSType. This patch just removes the extra arg here too.