### PR TITLE
[mlir] [dataflow] avoid hash collisions

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlowFramework.h
+++ b/mlir/include/mlir/Analysis/DataFlowFramework.h
@@ -798,6 +798,8 @@ struct DenseMapInfo<mlir::ProgramPoint> {
         mlir::Block::iterator((mlir::Operation *)pointer));
   }
   static unsigned getHashValue(mlir::ProgramPoint pp) {
+    if (mlir::Operation *op = pp.getOperation())
+      return hash_value(op);
     return hash_combine(pp.getBlock(), pp.getPoint().getNodePtr());
   }
   static bool isEqual(mlir::ProgramPoint lhs, mlir::ProgramPoint rhs) {
@@ -805,7 +807,7 @@ struct DenseMapInfo<mlir::ProgramPoint> {
   }
 };
 
-// Allow llvm::cast style functions.
+/// Allow llvm::cast style functions.
 template <typename To>
 struct CastInfo<To, mlir::LatticeAnchor>
     : public CastInfo<To, mlir::LatticeAnchor::PointerUnion> {};


### PR DESCRIPTION
This patch fixes potential hash collisions when using ProgramPoint as a DenseMap key. For program points without a parent block, the Operation* should be used to compute the hash value.