### PR TITLE
[flang][NFC] remove ambiguous fir::unwrapInnerType helper

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -427,9 +427,6 @@ inline bool boxHasAddendum(fir::BaseBoxType boxTy) {
 /// Get the rank from a !fir.box type.
 unsigned getBoxRank(mlir::Type boxTy);
 
-/// Return the inner type of the given type.
-mlir::Type unwrapInnerType(mlir::Type ty);
-
 /// Return true iff `ty` is a RecordType with members that are allocatable.
 bool isRecordWithAllocatableMember(mlir::Type ty);
 

--- a/flang/lib/Optimizer/Builder/Runtime/Allocatable.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Allocatable.cpp
@@ -28,7 +28,7 @@ mlir::Value fir::runtime::genMoveAlloc(fir::FirOpBuilder &builder,
       !fir::isUnlimitedPolymorphicType(from.getType())) {
     fir::ClassType clTy =
         mlir::dyn_cast<fir::ClassType>(fir::dyn_cast_ptrEleTy(from.getType()));
-    mlir::Type derivedType = fir::unwrapInnerType(clTy.getEleTy());
+    mlir::Type derivedType = clTy.unwrapInnerType();
     declaredTypeDesc =
         fir::TypeDescOp::create(builder, loc, mlir::TypeAttr::get(derivedType));
   } else {

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -1753,8 +1753,8 @@ struct EmboxCommonConversion : public fir::FIROpConversion<OP> {
       unsigned typeDescFieldId = getTypeDescFieldId(boxTy);
       if (!typeDesc) {
         if (useInputType) {
-          mlir::Type innerType = fir::unwrapInnerType(inputType);
-          if (innerType && mlir::isa<fir::RecordType>(innerType)) {
+          mlir::Type innerType = fir::getFortranElementType(inputType);
+          if (mlir::isa<fir::RecordType>(innerType)) {
             auto recTy = mlir::dyn_cast<fir::RecordType>(innerType);
             typeDesc =
                 getTypeDescriptor(mod, rewriter, loc, recTy, this->options);

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -332,8 +332,7 @@ bool isBoxedRecordType(mlir::Type ty) {
   if (auto boxTy = mlir::dyn_cast<fir::BoxType>(ty)) {
     if (mlir::isa<fir::RecordType>(boxTy.getEleTy()))
       return true;
-    mlir::Type innerType = boxTy.unwrapInnerType();
-    return innerType && mlir::isa<fir::RecordType>(innerType);
+    return mlir::isa<fir::RecordType>(boxTy.unwrapInnerType());
   }
   return false;
 }
@@ -343,8 +342,7 @@ bool isClassStarType(mlir::Type ty) {
   if (auto clTy = mlir::dyn_cast<fir::ClassType>(fir::unwrapRefType(ty))) {
     if (mlir::isa<mlir::NoneType>(clTy.getEleTy()))
       return true;
-    mlir::Type innerType = clTy.unwrapInnerType();
-    return innerType && mlir::isa<mlir::NoneType>(innerType);
+    return mlir::isa<mlir::NoneType>(clTy.unwrapInnerType());
   }
   return false;
 }
@@ -415,18 +413,6 @@ bool isUnlimitedPolymorphicType(mlir::Type ty) {
     return true;
   // TYPE(*)
   return isAssumedType(ty);
-}
-
-mlir::Type unwrapInnerType(mlir::Type ty) {
-  return llvm::TypeSwitch<mlir::Type, mlir::Type>(ty)
-      .Case<fir::PointerType, fir::HeapType, fir::SequenceType>([](auto t) {
-        mlir::Type eleTy = t.getEleTy();
-        if (auto seqTy = mlir::dyn_cast<fir::SequenceType>(eleTy))
-          return seqTy.getEleTy();
-        return eleTy;
-      })
-      .Case([](fir::RecordType t) { return t; })
-      .Default([](mlir::Type) { return mlir::Type{}; });
 }
 
 bool isRecordWithAllocatableMember(mlir::Type ty) {
@@ -1455,7 +1441,14 @@ mlir::Type BaseBoxType::getBaseAddressType(bool dropHeapOrPtr) const {
 }
 
 mlir::Type BaseBoxType::unwrapInnerType() const {
-  return fir::unwrapInnerType(getEleTy());
+  return llvm::TypeSwitch<mlir::Type, mlir::Type>(getEleTy())
+      .Case<fir::PointerType, fir::HeapType, fir::SequenceType>([](auto t) {
+        mlir::Type eleTy = t.getEleTy();
+        if (auto seqTy = mlir::dyn_cast<fir::SequenceType>(eleTy))
+          return seqTy.getEleTy();
+        return eleTy;
+      })
+      .Default([](mlir::Type t) { return t; });
 }
 
 mlir::Type BaseBoxType::getElementOrSequenceType() const {

--- a/flang/lib/Optimizer/Transforms/CUDA/CUFOpConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFOpConversion.cpp
@@ -236,7 +236,7 @@ struct CUFDataTransferOpConversion
         // Initialization of an array from a scalar value should be implemented
         // via a kernel launch. Use the flang runtime via the Assign function
         // until we have more infrastructure.
-        mlir::Type dstEleTy = fir::unwrapInnerType(fir::unwrapRefType(dstTy));
+        mlir::Type dstEleTy = fir::getFortranElementType(dstTy);
         mlir::Value src = emboxSrc(rewriter, op, symtab, dstEleTy);
         mlir::Value dst = emboxDst(rewriter, op, symtab);
         mlir::func::FuncOp func =
@@ -319,7 +319,7 @@ struct CUFDataTransferOpConversion
       mlir::Value dst = op.getDst();
       mlir::Value src = op.getSrc();
       if (!mlir::isa<fir::BaseBoxType>(srcTy)) {
-        mlir::Type dstEleTy = fir::unwrapInnerType(dstBoxTy.getEleTy());
+        mlir::Type dstEleTy = dstBoxTy.unwrapInnerType();
         src = emboxSrc(rewriter, op, symtab, dstEleTy);
         if (fir::isa_trivial(srcTy))
           func = fir::runtime::getRuntimeFunc<mkRTKey(CUFDataTransferCstDesc)>(


### PR DESCRIPTION
`fir::unwrapInnerType` has the odd behavior of returning an empty type for things like i32, causing BaseBoxType::unwrapInnerType to return a null type for fir.box<i32> which was not intended.

Remove the helper, no user really needed the null type behavior, replace its few usage by fir::getFortranElementType and update BaseBoxType::unwrapInnerType to do the intended behavior.