### PR TITLE
[llvm] Errorize DebuginfodFetcher for inspection at call-sites

### DIFF
--- a/llvm/include/llvm/Debuginfod/BuildIDFetcher.h
+++ b/llvm/include/llvm/Debuginfod/BuildIDFetcher.h
@@ -16,7 +16,6 @@
 #define LLVM_DEBUGINFOD_DIFETCHER_H
 
 #include "llvm/Object/BuildID.h"
-#include <optional>
 
 namespace llvm {
 
@@ -28,7 +27,7 @@ public:
 
   /// Fetches the given Build ID using debuginfod and returns a local path to
   /// the resulting file.
-  std::optional<std::string> fetch(object::BuildIDRef BuildID) const override;
+  Expected<std::string> fetch(object::BuildIDRef BuildID) const override;
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Object/BuildID.h
+++ b/llvm/include/llvm/Object/BuildID.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/Error.h"
 
 namespace llvm {
 namespace object {
@@ -44,7 +45,7 @@ public:
   virtual ~BuildIDFetcher() = default;
 
   /// Returns the path to the debug file with the given build ID.
-  virtual std::optional<std::string> fetch(BuildIDRef BuildID) const;
+  virtual Expected<std::string> fetch(BuildIDRef BuildID) const;
 
 private:
   const std::vector<std::string> DebugFileDirectories;

--- a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
@@ -498,6 +498,8 @@ bool LLVMSymbolizer::getOrFindDebugBinary(const ArrayRef<uint8_t> BuildID,
     (void)InsertResult;
     return true;
   }
+  // Failure to fetch debuginfod is rarely an error and most users will not care
+  // why this failed.
   consumeError(Path.takeError());
   return false;
 }

--- a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
@@ -490,14 +490,15 @@ bool LLVMSymbolizer::getOrFindDebugBinary(const ArrayRef<uint8_t> BuildID,
   }
   if (!BIDFetcher)
     return false;
-  if (std::optional<std::string> Path = BIDFetcher->fetch(BuildID)) {
+  Expected<std::string> Path = BIDFetcher->fetch(BuildID);
+  if (Path) {
     Result = *Path;
     auto InsertResult = BuildIDPaths.insert({BuildIDStr, Result});
     assert(InsertResult.second);
     (void)InsertResult;
     return true;
   }
-
+  consumeError(Path.takeError());
   return false;
 }
 

--- a/llvm/lib/Debuginfod/BuildIDFetcher.cpp
+++ b/llvm/lib/Debuginfod/BuildIDFetcher.cpp
@@ -15,15 +15,18 @@
 #include "llvm/Debuginfod/BuildIDFetcher.h"
 
 #include "llvm/Debuginfod/Debuginfod.h"
+#include "llvm/Support/Error.h"
 
 using namespace llvm;
 
 Expected<std::string>
 DebuginfodFetcher::fetch(ArrayRef<uint8_t> BuildID) const {
-  if (Expected<std::string> Path = BuildIDFetcher::fetch(BuildID))
-    return std::move(*Path);
-  else
-    consumeError(Path.takeError());
-
+  Expected<std::string> Path = BuildIDFetcher::fetch(BuildID);
+  if (Path)
+    return Path;
+  assert(errorToErrorCode(Path.takeError()) ==
+             std::errc::no_such_file_or_directory &&
+         "BuildIDFetcher::fetch() failed in an unexpected way");
+  consumeError(Path.takeError());
   return getCachedOrDownloadDebuginfo(BuildID);
 }

--- a/llvm/lib/Debuginfod/BuildIDFetcher.cpp
+++ b/llvm/lib/Debuginfod/BuildIDFetcher.cpp
@@ -24,6 +24,7 @@ DebuginfodFetcher::fetch(ArrayRef<uint8_t> BuildID) const {
   Expected<std::string> Path = BuildIDFetcher::fetch(BuildID);
   if (Path)
     return Path;
+  // Most users will not care why this failed.
   assert(errorToErrorCode(Path.takeError()) ==
              std::errc::no_such_file_or_directory &&
          "BuildIDFetcher::fetch() failed in an unexpected way");

--- a/llvm/lib/Debuginfod/BuildIDFetcher.cpp
+++ b/llvm/lib/Debuginfod/BuildIDFetcher.cpp
@@ -18,14 +18,12 @@
 
 using namespace llvm;
 
-std::optional<std::string>
+Expected<std::string>
 DebuginfodFetcher::fetch(ArrayRef<uint8_t> BuildID) const {
-  if (std::optional<std::string> Path = BuildIDFetcher::fetch(BuildID))
+  if (Expected<std::string> Path = BuildIDFetcher::fetch(BuildID))
     return std::move(*Path);
+  else
+    consumeError(Path.takeError());
 
-  Expected<std::string> PathOrErr = getCachedOrDownloadDebuginfo(BuildID);
-  if (PathOrErr)
-    return *PathOrErr;
-  consumeError(PathOrErr.takeError());
-  return std::nullopt;
+  return getCachedOrDownloadDebuginfo(BuildID);
 }

--- a/llvm/lib/Object/BuildID.cpp
+++ b/llvm/lib/Object/BuildID.cpp
@@ -15,6 +15,7 @@
 #include "llvm/Object/BuildID.h"
 
 #include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 
@@ -79,7 +80,7 @@ BuildIDRef llvm::object::getBuildID(const ObjectFile *Obj) {
   return {};
 }
 
-std::optional<std::string> BuildIDFetcher::fetch(BuildIDRef BuildID) const {
+Expected<std::string> BuildIDFetcher::fetch(BuildIDRef BuildID) const {
   auto GetDebugPath = [&](StringRef Directory) {
     SmallString<128> Path{Directory};
     sys::path::append(Path, ".build-id",
@@ -108,5 +109,8 @@ std::optional<std::string> BuildIDFetcher::fetch(BuildIDRef BuildID) const {
         return std::string(Path);
     }
   }
-  return std::nullopt;
+  return createStringError(
+      make_error_code(std::errc::no_such_file_or_directory),
+      "could not find debug file for build ID '" +
+          llvm::toHex(BuildID, /*LowerCase=*/true) + "'");
 }

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -1106,8 +1106,7 @@ Expected<std::unique_ptr<CoverageMapping>> CoverageMapping::load(
     }
 
     for (object::BuildIDRef BinaryID : BinaryIDsToFetch) {
-      Expected<std::string> Path = BIDFetcher->fetch(BinaryID);
-      if (Path) {
+      if (Expected<std::string> Path = BIDFetcher->fetch(BinaryID)) {
         StringRef Arch = Arches.size() == 1 ? Arches.front() : StringRef();
         if (Error E = loadFromFile(*Path, Arch, CompilationDir,
                                    ProfileReaderRef, *Coverage, DataFound))

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -1106,21 +1106,18 @@ Expected<std::unique_ptr<CoverageMapping>> CoverageMapping::load(
     }
 
     for (object::BuildIDRef BinaryID : BinaryIDsToFetch) {
-      if (Expected<std::string> Path = BIDFetcher->fetch(BinaryID)) {
+      Expected<std::string> Path = BIDFetcher->fetch(BinaryID);
+      if (Path) {
         StringRef Arch = Arches.size() == 1 ? Arches.front() : StringRef();
         if (Error E = loadFromFile(*Path, Arch, CompilationDir,
                                    ProfileReaderRef, *Coverage, DataFound))
           return std::move(E);
-      } else if (CheckBinaryIDs) {
-        consumeError(Path.takeError());
-        return createFileError(
-            ProfileFilename.value(),
-            createStringError(errc::no_such_file_or_directory,
-                              "Missing binary ID: " +
-                                  llvm::toHex(BinaryID, /*LowerCase=*/true)));
-      } else {
-        consumeError(Path.takeError());
       }
+      if (CheckBinaryIDs) {
+        return createFileError(ProfileFilename.value(), Path.takeError());
+      }
+      // Ignore error and continue.
+      consumeError(Path.takeError());
     }
   }
 

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -1106,19 +1106,21 @@ Expected<std::unique_ptr<CoverageMapping>> CoverageMapping::load(
     }
 
     for (object::BuildIDRef BinaryID : BinaryIDsToFetch) {
-      std::optional<std::string> PathOpt = BIDFetcher->fetch(BinaryID);
-      if (PathOpt) {
-        std::string Path = std::move(*PathOpt);
+      Expected<std::string> Path = BIDFetcher->fetch(BinaryID);
+      if (Path) {
         StringRef Arch = Arches.size() == 1 ? Arches.front() : StringRef();
-        if (Error E = loadFromFile(Path, Arch, CompilationDir, ProfileReaderRef,
-                                   *Coverage, DataFound))
+        if (Error E = loadFromFile(*Path, Arch, CompilationDir,
+                                   ProfileReaderRef, *Coverage, DataFound))
           return std::move(E);
       } else if (CheckBinaryIDs) {
+        consumeError(Path.takeError());
         return createFileError(
             ProfileFilename.value(),
             createStringError(errc::no_such_file_or_directory,
                               "Missing binary ID: " +
                                   llvm::toHex(BinaryID, /*LowerCase=*/true)));
+      } else {
+        consumeError(Path.takeError());
       }
     }
   }

--- a/llvm/lib/ProfileData/InstrProfCorrelator.cpp
+++ b/llvm/lib/ProfileData/InstrProfCorrelator.cpp
@@ -128,6 +128,10 @@ InstrProfCorrelator::get(StringRef Filename, ProfCorrelatorKind FileKind,
 
     Expected<std::string> Path = BIDFetcher->fetch(BIs.front());
     if (!Path) {
+      // Propagate as InstrProf specific error type.
+      assert(errorToErrorCode(Path.takeError()) ==
+                 std::errc::no_such_file_or_directory &&
+             "BuildIDFetcher::fetch() failed in an unexpected way");
       consumeError(Path.takeError());
       return make_error<InstrProfError>(
           instrprof_error::unable_to_correlate_profile,

--- a/llvm/lib/ProfileData/InstrProfCorrelator.cpp
+++ b/llvm/lib/ProfileData/InstrProfCorrelator.cpp
@@ -114,7 +114,6 @@ llvm::Expected<std::unique_ptr<InstrProfCorrelator>>
 InstrProfCorrelator::get(StringRef Filename, ProfCorrelatorKind FileKind,
                          const object::BuildIDFetcher *BIDFetcher,
                          const ArrayRef<object::BuildID> BIs) {
-  std::optional<std::string> Path;
   if (BIDFetcher) {
     if (BIs.empty())
       return make_error<InstrProfError>(
@@ -127,12 +126,14 @@ InstrProfCorrelator::get(StringRef Filename, ProfCorrelatorKind FileKind,
           "unsupported profile binary correlation when there are multiple "
           "build IDs in a profile");
 
-    Path = BIDFetcher->fetch(BIs.front());
-    if (!Path)
+    Expected<std::string> Path = BIDFetcher->fetch(BIs.front());
+    if (!Path) {
+      consumeError(Path.takeError());
       return make_error<InstrProfError>(
           instrprof_error::unable_to_correlate_profile,
           "Missing build ID: " + llvm::toHex(BIs.front(),
                                              /*LowerCase=*/true));
+    }
     Filename = *Path;
   }
 

--- a/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
+++ b/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
@@ -152,10 +152,12 @@ int llvm_debuginfod_find_main(int argc, char **argv,
 
 // Find a debug file in local build ID directories and via debuginfod.
 std::string fetchDebugInfo(object::BuildIDRef BuildID) {
-  if (std::optional<std::string> Path =
-          DebuginfodFetcher(DebugFileDirectory).fetch(BuildID))
-    return *Path;
-  errs() << "Build ID " << llvm::toHex(BuildID, /*Lowercase=*/true)
+  Expected<std::string> PathOrErr =
+      DebuginfodFetcher(DebugFileDirectory).fetch(BuildID);
+  if (PathOrErr)
+    return *PathOrErr;
+  errs() << "Build ID " << llvm::toHex(BuildID, /*Lowercase=*/true) << ": "
          << " could not be found.\n";
+  consumeError(PathOrErr.takeError());
   exit(1);
 }

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -1745,6 +1745,8 @@ fetchBinaryByBuildID(const ObjectFile &Obj) {
     return std::nullopt;
   Expected<std::string> Path = BIDFetcher->fetch(BuildID);
   if (!Path) {
+    // Failure to fetch debuginfod is rarely an error and most users will not
+    // care why this failed.
     consumeError(Path.takeError());
     return std::nullopt;
   }
@@ -3844,6 +3846,7 @@ static void parseObjdumpOptions(const llvm::opt::InputArgList &InputArgs) {
     object::BuildID BuildID = parseBuildIDArg(A);
     Expected<std::string> Path = BIDFetcher->fetch(BuildID);
     if (!Path) {
+      // Most users will not care why this failed.
       consumeError(Path.takeError());
       reportCmdLineError(A->getSpelling() + ": could not find build ID '" +
                          A->getValue() + "'");

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -1743,9 +1743,11 @@ fetchBinaryByBuildID(const ObjectFile &Obj) {
   object::BuildIDRef BuildID = getBuildID(&Obj);
   if (BuildID.empty())
     return std::nullopt;
-  std::optional<std::string> Path = BIDFetcher->fetch(BuildID);
-  if (!Path)
+  Expected<std::string> Path = BIDFetcher->fetch(BuildID);
+  if (!Path) {
+    consumeError(Path.takeError());
     return std::nullopt;
+  }
   Expected<OwningBinary<Binary>> DebugBinary = createBinary(*Path);
   if (!DebugBinary) {
     reportWarning(toString(DebugBinary.takeError()), *Path);
@@ -3840,8 +3842,9 @@ static void parseObjdumpOptions(const llvm::opt::InputArgList &InputArgs) {
   // Look up any provided build IDs, then append them to the input filenames.
   for (const opt::Arg *A : InputArgs.filtered(OBJDUMP_build_id)) {
     object::BuildID BuildID = parseBuildIDArg(A);
-    std::optional<std::string> Path = BIDFetcher->fetch(BuildID);
+    Expected<std::string> Path = BIDFetcher->fetch(BuildID);
     if (!Path) {
+      consumeError(Path.takeError());
       reportCmdLineError(A->getSpelling() + ": could not find build ID '" +
                          A->getValue() + "'");
     }


### PR DESCRIPTION
Failure to fetch debuginfod is rarely an error, but there are case where we want to distinguish error reasons down the line, for example in order to test connection timeouts.