### PR TITLE
[orc-rt] Add Session::attach convenience overload.

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -274,6 +274,18 @@ public:
   /// take ownership of CA or call its connect method.
   void attach(std::shared_ptr<ControllerAccess> CA, BootstrapInfo BI);
 
+  /// Construct a ControllerAccessT with the given args, then immediately
+  /// attach using the given BootstrapInfo.
+  ///
+  /// This enables one-line attach operations in the common case where the
+  /// ControllerAccess implementation does not require any further
+  /// configuration after construction.
+  template <typename ControllerAccessT, typename... ArgTs>
+  void attach(BootstrapInfo BI, ArgTs &&...Args) {
+    attach(std::make_shared<ControllerAccessT>(std::forward<ArgTs>(Args)...),
+           std::move(BI));
+  }
+
   /// Initiate detach from the controller.
   ///
   /// Signals that controller access is permanently unavailable and notifies

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -697,8 +697,7 @@ TEST(ControllerAccessTest, Basics) {
   std::deque<std::unique_ptr<Task>> Tasks;
   Session S(mockExecutorProcessInfo(),
             std::make_unique<EnqueueingDispatcher>(Tasks), noErrors);
-  auto CA = std::make_shared<MockControllerAccess>(S);
-  S.attach(CA, BootstrapInfo(S));
+  S.attach<MockControllerAccess>(BootstrapInfo(S), S);
 
   EnqueueingDispatcher::runTasksFromFront(Tasks);
 }
@@ -718,8 +717,7 @@ TEST(ControllerAccessTest, ValidCallToController) {
   std::deque<std::unique_ptr<Task>> Tasks;
   Session S(mockExecutorProcessInfo(),
             std::make_unique<EnqueueingDispatcher>(Tasks), noErrors);
-  auto CA = std::make_shared<MockControllerAccess>(S);
-  S.attach(CA, BootstrapInfo(S));
+  S.attach<MockControllerAccess>(BootstrapInfo(S), S);
 
   int32_t Result = 0;
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
@@ -754,8 +752,7 @@ TEST(ControllerAccessTest, CallToControllerAfterDetach) {
   std::deque<std::unique_ptr<Task>> Tasks;
   Session S(mockExecutorProcessInfo(),
             std::make_unique<EnqueueingDispatcher>(Tasks), noErrors);
-  auto CA = std::make_shared<MockControllerAccess>(S);
-  S.attach(CA, BootstrapInfo(S));
+  S.attach<MockControllerAccess>(BootstrapInfo(S), S);
 
   S.detach();
 


### PR DESCRIPTION
This overload enables one-line attach in the common case where the ControllerAccess implementation does not require any configuration after construction.