### PR TITLE
[flang][OpenMP] Move check for threadprivate iteration variable

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -610,9 +610,7 @@ public:
   void Post(const parser::OpenMPSimpleStandaloneConstruct &) { PopContext(); }
 
   bool Pre(const parser::OpenMPLoopConstruct &);
-  void Post(const parser::OpenMPLoopConstruct &) {
-    PopContext();
-  }
+  void Post(const parser::OpenMPLoopConstruct &) { PopContext(); }
   void Post(const parser::OmpBeginLoopDirective &) {
     GetContext().withinConstruct = true;
   }

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -611,7 +611,6 @@ public:
 
   bool Pre(const parser::OpenMPLoopConstruct &);
   void Post(const parser::OpenMPLoopConstruct &) {
-    ordCollapseLevel++;
     PopContext();
   }
   void Post(const parser::OmpBeginLoopDirective &) {
@@ -1172,8 +1171,6 @@ private:
     sourceLabels_.clear();
     targetLabels_.clear();
   };
-
-  std::int64_t ordCollapseLevel{0};
 
   void AddOmpRequiresToScope(Scope &,
       const WithOmpDeclarative::RequiresClauses *,
@@ -2097,7 +2094,6 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPLoopConstruct &x) {
   }
 
   PrivatizeAssociatedLoopIndexAndCheckLoopLevel(x);
-  ordCollapseLevel = GetNumAffectedLoopsFromLoopConstruct(x) + 1;
   return true;
 }
 
@@ -2172,22 +2168,11 @@ bool OmpAttributeVisitor::Pre(const parser::DoConstruct &x) {
       if (iv && iv->symbol)
         ivs.push_back(iv);
     }
-    ordCollapseLevel--;
     for (auto iv : ivs) {
       if (!iv->symbol->test(Symbol::Flag::OmpPreDetermined)) {
         ResolveSeqLoopIndexInParallelOrTaskConstruct(*iv);
       } else {
         // TODO: conflict checks with explicitly determined DSA
-      }
-      if (ordCollapseLevel) {
-        if (const auto *details{iv->symbol->detailsIf<HostAssocDetails>()}) {
-          const Symbol *tpSymbol = &details->symbol();
-          if (tpSymbol->test(Symbol::Flag::OmpThreadprivate)) {
-            context_.Say(iv->source,
-                "Loop iteration variable %s is not allowed in THREADPRIVATE."_err_en_US,
-                iv->ToString());
-          }
-        }
       }
     }
   }
@@ -2316,7 +2301,7 @@ void OmpAttributeVisitor::CollectNumAffectedLoopsFromClauses(
 //     construct with multiple associated do-loops are lastprivate.
 void OmpAttributeVisitor::PrivatizeAssociatedLoopIndexAndCheckLoopLevel(
     const parser::OpenMPLoopConstruct &x) {
-  std::int64_t level{GetContext().associatedLoopLevel};
+  int64_t level{GetContext().associatedLoopLevel};
   if (level <= 0) {
     return;
   }
@@ -2341,6 +2326,15 @@ void OmpAttributeVisitor::PrivatizeAssociatedLoopIndexAndCheckLoopLevel(
         if (const parser::Name *iv{GetLoopIndex(*loop)}) {
           if (!iv->symbol || !IsLocalInsideScope(*iv->symbol, currScope())) {
             if (auto *symbol{ResolveOmp(*iv, ivDSA, currScope())}) {
+              if (const auto *details{
+                      iv->symbol->detailsIf<HostAssocDetails>()}) {
+                const Symbol *tpSymbol = &details->symbol();
+                if (tpSymbol->test(Symbol::Flag::OmpThreadprivate)) {
+                  context_.Say(iv->source,
+                      "Loop iteration variable %s is not allowed in THREADPRIVATE."_err_en_US,
+                      iv->ToString());
+                }
+              }
               SetSymbolDSA(*symbol, {Symbol::Flag::OmpPreDetermined, ivDSA});
               iv->symbol = symbol; // adjust the symbol within region
               AddToContextObjectWithDSA(*symbol, ivDSA);


### PR DESCRIPTION
This moves the test of whether the iteration variable of an affected DO loop is marked as threadprivate. This makes the `ordCollapseLevel` member unnecessary.

Issue: https://github.com/llvm/llvm-project/issues/191249