### PR TITLE
[clang-format] treat continuation as indent for aligned lines

### DIFF
--- a/clang/lib/Format/BreakableToken.cpp
+++ b/clang/lib/Format/BreakableToken.cpp
@@ -1048,7 +1048,7 @@ void BreakableLineCommentSection::reflow(unsigned LineIndex,
       // tokens by the empty string.
       Whitespaces.replaceWhitespace(
           *Tokens[LineIndex], /*Newlines=*/0, /*Spaces=*/0,
-          /*StartOfTokenColumn=*/StartColumn, /*IsAligned=*/true,
+          /*StartOfTokenColumn=*/StartColumn, /*AlignedTo=*/nullptr,
           /*InPPDirective=*/false);
     } else {
       // In case we're reflowing after the '\' in:
@@ -1114,12 +1114,13 @@ void BreakableLineCommentSection::adaptStartOfLine(
     // token, even if LineColumn is the same as the original column of the
     // token. This is because WhitespaceManager doesn't align trailing
     // comments if they are untouchable.
-    Whitespaces.replaceWhitespace(*Tokens[LineIndex],
-                                  /*Newlines=*/1,
-                                  /*Spaces=*/LineColumn,
-                                  /*StartOfTokenColumn=*/LineColumn,
-                                  /*IsAligned=*/tokenAt(0).NewlinesBefore == 0,
-                                  /*InPPDirective=*/false);
+    Whitespaces.replaceWhitespace(
+        *Tokens[LineIndex],
+        /*Newlines=*/1,
+        /*Spaces=*/LineColumn,
+        /*StartOfTokenColumn=*/LineColumn,
+        /*AlignedTo=*/tokenAt(0).NewlinesBefore == 0 ? &tokenAt(0) : nullptr,
+        /*InPPDirective=*/false);
   }
   if (OriginalPrefix[LineIndex] != Prefix[LineIndex]) {
     // Adjust the prefix if necessary.

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -879,7 +879,7 @@ void ContinuationIndenter::addTokenOnCurrentLine(LineState &State, bool DryRun,
         State.Line->InMacroBody && Current.isNot(TT_LineComment);
     Whitespaces.replaceWhitespace(Current, /*Newlines=*/0, Spaces,
                                   State.Column + Spaces + PPColumnCorrection,
-                                  /*IsAligned=*/false, ContinuePPDirective);
+                                  /*AlignTo=*/nullptr, ContinuePPDirective);
   }
 
   // If "BreakBeforeInheritanceComma" mode, don't break within the inheritance
@@ -1024,7 +1024,7 @@ void ContinuationIndenter::addTokenOnCurrentLine(LineState &State, bool DryRun,
        Previous.is(TT_VerilogMultiLineListLParen)) &&
       !IsInTemplateString(Current, false)) {
     CurrentState.Indent = State.Column + Spaces;
-    CurrentState.IsAligned = true;
+    CurrentState.AlignedTo = &Previous;
   }
   if (CurrentState.AvoidBinPacking && startsNextParameter(Current, Style))
     CurrentState.NoLineBreak = true;
@@ -1241,19 +1241,20 @@ unsigned ContinuationIndenter::addTokenOnNewLine(LineState &State,
   switch (Style.BreakInheritanceList) {
   case FormatStyle::BILS_BeforeColon:
   case FormatStyle::BILS_AfterComma:
-    CurrentState.IsAligned = CurrentState.IsAligned ||
-                             Current.is(TT_InheritanceColon) ||
-                             Previous.is(TT_InheritanceComma);
+    if (Current.is(TT_InheritanceColon) || Previous.is(TT_InheritanceComma)) {
+      CurrentState.AlignedTo = Previous.getPreviousOneOf(
+          tok::kw_class, tok::kw_struct, tok::kw_union);
+    }
     break;
   case FormatStyle::BILS_BeforeComma:
-    CurrentState.IsAligned =
-        CurrentState.IsAligned ||
-        Current.isOneOf(TT_InheritanceColon, TT_InheritanceComma);
+    if (Current.isOneOf(TT_InheritanceColon, TT_InheritanceComma)) {
+      CurrentState.AlignedTo = Previous.getPreviousOneOf(
+          tok::kw_class, tok::kw_struct, tok::kw_union);
+    }
     break;
   case FormatStyle::BILS_AfterColon:
-    CurrentState.IsAligned =
-        CurrentState.IsAligned ||
-        Previous.isOneOf(TT_InheritanceColon, TT_InheritanceComma);
+    if (Previous.isOneOf(TT_InheritanceColon, TT_InheritanceComma))
+      CurrentState.AlignedTo = &Previous;
     break;
   }
 
@@ -1275,7 +1276,7 @@ unsigned ContinuationIndenter::addTokenOnNewLine(LineState &State,
   }
   if (Current.is(TT_BinaryOperator) && Current.CanBreakBefore) {
     CurrentState.BreakBeforeParameter = false;
-    CurrentState.IsAligned = true;
+    CurrentState.AlignedTo = &Current;
   }
 
   if (!DryRun) {
@@ -1295,7 +1296,7 @@ unsigned ContinuationIndenter::addTokenOnNewLine(LineState &State,
                                      State.Line->Type != LT_ImportStatement &&
                                      Current.isNot(TT_LineComment);
     Whitespaces.replaceWhitespace(Current, Newlines, State.Column, State.Column,
-                                  CurrentState.IsAligned, ContinuePPDirective,
+                                  CurrentState.AlignedTo, ContinuePPDirective,
                                   IndentedFromColumn);
   }
 
@@ -2007,7 +2008,7 @@ void ContinuationIndenter::moveStatePastFakeLParens(LineState &State,
         NewParenState.UnindentOperator = true;
       // Mark indentation as alignment if the expression is aligned.
       if (Style.AlignOperands != FormatStyle::OAS_DontAlign)
-        NewParenState.IsAligned = true;
+        NewParenState.AlignedTo = Previous;
     }
 
     // Do not indent relative to the fake parentheses inserted for "." or "->".

--- a/clang/lib/Format/ContinuationIndenter.h
+++ b/clang/lib/Format/ContinuationIndenter.h
@@ -232,18 +232,17 @@ private:
 struct ParenState {
   ParenState(const FormatToken *Tok, IndentationAndAlignment Indent,
              unsigned LastSpace, bool AvoidBinPacking, bool NoLineBreak)
-      : Tok(Tok), Indent(Indent), LastSpace(LastSpace),
-        NestedBlockIndent(Indent.Total), IsAligned(false),
-        BreakBeforeClosingBrace(false), BreakBeforeClosingParen(false),
-        BreakBeforeClosingAngle(false), AvoidBinPacking(AvoidBinPacking),
-        BreakBeforeParameter(false), NoLineBreak(NoLineBreak),
-        NoLineBreakInOperand(false), LastOperatorWrapped(true),
-        ContainsLineBreak(false), ContainsUnwrappedBuilder(false),
-        AlignColons(true), ObjCSelectorNameFound(false),
-        HasMultipleNestedBlocks(false), NestedBlockInlined(false),
-        IsInsideObjCArrayLiteral(false), IsCSharpGenericTypeConstraint(false),
-        IsChainedConditional(false), IsWrappedConditional(false),
-        UnindentOperator(false) {}
+      : Tok(Tok), Indent(Indent), AlignedTo(nullptr), LastSpace(LastSpace),
+        NestedBlockIndent(Indent.Total), BreakBeforeClosingBrace(false),
+        BreakBeforeClosingParen(false), BreakBeforeClosingAngle(false),
+        AvoidBinPacking(AvoidBinPacking), BreakBeforeParameter(false),
+        NoLineBreak(NoLineBreak), NoLineBreakInOperand(false),
+        LastOperatorWrapped(true), ContainsLineBreak(false),
+        ContainsUnwrappedBuilder(false), AlignColons(true),
+        ObjCSelectorNameFound(false), HasMultipleNestedBlocks(false),
+        NestedBlockInlined(false), IsInsideObjCArrayLiteral(false),
+        IsCSharpGenericTypeConstraint(false), IsChainedConditional(false),
+        IsWrappedConditional(false), UnindentOperator(false) {}
 
   /// The token opening this parenthesis level, or nullptr if this level is
   /// opened by fake parenthesis.
@@ -255,6 +254,9 @@ struct ParenState {
   /// The position to which a specific parenthesis level needs to be
   /// indented.
   IndentationAndAlignment Indent;
+
+  /// The token in one of the previous lines this state wants to align to.
+  const FormatToken *AlignedTo;
 
   /// The position of the last space on each level.
   ///
@@ -298,9 +300,6 @@ struct ParenState {
   ///
   /// Used to align further variables if necessary.
   unsigned VariablePos = 0;
-
-  /// Whether this block's indentation is used for alignment.
-  bool IsAligned : 1;
 
   /// Whether a newline needs to be inserted before the block's closing
   /// brace.
@@ -399,8 +398,8 @@ struct ParenState {
       return NestedBlockIndent < Other.NestedBlockIndent;
     if (FirstLessLess != Other.FirstLessLess)
       return FirstLessLess < Other.FirstLessLess;
-    if (IsAligned != Other.IsAligned)
-      return IsAligned;
+    if (AlignedTo != Other.AlignedTo)
+      return AlignedTo < Other.AlignedTo;
     if (BreakBeforeClosingBrace != Other.BreakBeforeClosingBrace)
       return BreakBeforeClosingBrace;
     if (BreakBeforeClosingParen != Other.BreakBeforeClosingParen)

--- a/clang/lib/Format/FormatToken.h
+++ b/clang/lib/Format/FormatToken.h
@@ -546,7 +546,7 @@ public:
   unsigned IndentLevel = 0;
 
   /// Block + continuation indent level, applied by the WhitespaceManager to
-  /// this toke.
+  /// this token.
   mutable unsigned AppliedIndentLevel = 0;
 
   /// Penalty for inserting a line break before this token.
@@ -866,7 +866,7 @@ public:
 
   template <typename T> [[nodiscard]] FormatToken *getPrevious(T A1) const {
     FormatToken *Tok = Previous;
-    while (Tok && !Tok->is(A1))
+    while (Tok && Tok->isNot(A1))
       Tok = Tok->Previous;
     return Tok;
   }
@@ -874,7 +874,7 @@ public:
   template <typename... Ts>
   [[nodiscard]] FormatToken *getPreviousOneOf(Ts... Ks) const {
     FormatToken *Tok = Previous;
-    while (Tok && !((Tok->is(Ks) || ...)))
+    while (Tok && (Tok->isNot(Ks) && ...))
       Tok = Tok->Previous;
     return Tok;
   }

--- a/clang/lib/Format/FormatToken.h
+++ b/clang/lib/Format/FormatToken.h
@@ -545,6 +545,10 @@ public:
   /// The indent level of this token. Copied from the surrounding line.
   unsigned IndentLevel = 0;
 
+  /// Block + continuation indent level, applied by the WhitespaceManager to
+  /// this toke.
+  mutable unsigned AppliedIndentLevel = 0;
+
   /// Penalty for inserting a line break before this token.
   unsigned SplitPenalty = 0;
 
@@ -858,6 +862,21 @@ public:
       return ForcedPrecedence;
     return getBinOpPrecedence(Tok.getKind(), /*GreaterThanIsOperator=*/true,
                               /*CPlusPlus11=*/true);
+  }
+
+  template <typename T> [[nodiscard]] FormatToken *getPrevious(T A1) const {
+    FormatToken *Tok = Previous;
+    while (Tok && !Tok->is(A1))
+      Tok = Tok->Previous;
+    return Tok;
+  }
+
+  template <typename... Ts>
+  [[nodiscard]] FormatToken *getPreviousOneOf(Ts... Ks) const {
+    FormatToken *Tok = Previous;
+    while (Tok && !((Tok->is(Ks) || ...)))
+      Tok = Tok->Previous;
+    return Tok;
   }
 
   /// Returns the previous token ignoring comments.

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -1244,7 +1244,7 @@ protected:
     if (!DryRun) {
       Whitespaces->replaceWhitespace(
           *Child->First, /*Newlines=*/0, /*Spaces=*/1,
-          /*StartOfTokenColumn=*/State.Column, /*IsAligned=*/false,
+          /*StartOfTokenColumn=*/State.Column, /*AlignedTo=*/nullptr,
           State.Line->InPPDirective);
     }
     Penalty +=
@@ -1771,7 +1771,7 @@ void UnwrappedLineFormatter::formatFirstToken(
   }
 
   Whitespaces->replaceWhitespace(RootToken, RootToken.Newlines, Indent, Indent,
-                                 /*IsAligned=*/false,
+                                 /*AlignedTo=*/nullptr,
                                  Line.InPPDirective &&
                                      !RootToken.HasUnescapedNewline);
 }

--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -21,6 +21,22 @@
 namespace clang {
 namespace format {
 
+static const FormatToken &getLineStart(const FormatToken &Tok) {
+  const FormatToken *Result = &Tok;
+  while (Result->getDecision() != FormatDecision::FD_Break && Result->Previous)
+    Result = Result->Previous;
+  return *Result;
+}
+
+static unsigned indentLevelFor(WhitespaceManager::Change const &C,
+                               FormatStyle const &Style) {
+  if (!C.AlignedTo)
+    return C.Tok->IndentLevel;
+
+  const FormatToken &LineStart = getLineStart(*C.AlignedTo);
+  return std::max(LineStart.IndentLevel, LineStart.AppliedIndentLevel);
+}
+
 bool WhitespaceManager::Change::IsBeforeInFile::operator()(
     const Change &C1, const Change &C2) const {
   return SourceMgr.isBeforeInTranslationUnit(
@@ -33,21 +49,19 @@ bool WhitespaceManager::Change::IsBeforeInFile::operator()(
               C2.OriginalWhitespaceRange.getEnd()));
 }
 
-WhitespaceManager::Change::Change(const FormatToken &Tok,
-                                  bool CreateReplacement,
-                                  SourceRange OriginalWhitespaceRange,
-                                  int Spaces, unsigned StartOfTokenColumn,
-                                  unsigned IndentedFromColumn,
-                                  unsigned NewlinesBefore,
-                                  StringRef PreviousLinePostfix,
-                                  StringRef CurrentLinePrefix, bool IsAligned,
-                                  bool ContinuesPPDirective, bool IsInsideToken)
+WhitespaceManager::Change::Change(
+    const FormatToken &Tok, bool CreateReplacement,
+    SourceRange OriginalWhitespaceRange, int Spaces,
+    unsigned StartOfTokenColumn, unsigned IndentedFromColumn,
+    unsigned NewlinesBefore, StringRef PreviousLinePostfix,
+    StringRef CurrentLinePrefix, const FormatToken *AlignedTo,
+    bool ContinuesPPDirective, bool IsInsideToken)
     : Tok(&Tok), CreateReplacement(CreateReplacement),
       OriginalWhitespaceRange(OriginalWhitespaceRange),
       StartOfTokenColumn(StartOfTokenColumn),
       IndentedFromColumn(IndentedFromColumn), NewlinesBefore(NewlinesBefore),
       PreviousLinePostfix(PreviousLinePostfix),
-      CurrentLinePrefix(CurrentLinePrefix), IsAligned(IsAligned),
+      CurrentLinePrefix(CurrentLinePrefix), AlignedTo(AlignedTo),
       ContinuesPPDirective(ContinuesPPDirective), Spaces(Spaces),
       IsInsideToken(IsInsideToken), IsTrailingComment(false), TokenLength(0),
       PreviousEndOfTokenColumn(0), EscapedNewlineColumn(0),
@@ -57,14 +71,15 @@ WhitespaceManager::Change::Change(const FormatToken &Tok,
 void WhitespaceManager::replaceWhitespace(FormatToken &Tok, unsigned Newlines,
                                           unsigned Spaces,
                                           unsigned StartOfTokenColumn,
-                                          bool IsAligned, bool InPPDirective,
+                                          const FormatToken *AlignedTo,
+                                          bool InPPDirective,
                                           unsigned IndentedFromColumn) {
   if (Tok.Finalized || (Tok.MacroCtx && Tok.MacroCtx->Role == MR_ExpandedArg))
     return;
   Tok.setDecision((Newlines > 0) ? FD_Break : FD_Continue);
   Changes.push_back(Change(Tok, /*CreateReplacement=*/true, Tok.WhitespaceRange,
                            Spaces, StartOfTokenColumn, IndentedFromColumn,
-                           Newlines, "", "", IsAligned,
+                           Newlines, "", "", AlignedTo,
                            InPPDirective && !Tok.IsFirst,
                            /*IsInsideToken=*/false));
 }
@@ -76,7 +91,7 @@ void WhitespaceManager::addUntouchableToken(const FormatToken &Tok,
   Changes.push_back(Change(
       Tok, /*CreateReplacement=*/false, Tok.WhitespaceRange, /*Spaces=*/0,
       Tok.OriginalColumn, /*IndentedFromColumn=*/0, Tok.NewlinesBefore, "", "",
-      /*IsAligned=*/false, InPPDirective && !Tok.IsFirst,
+      /*AlignedTo=*/nullptr, InPPDirective && !Tok.IsFirst,
       /*IsInsideToken=*/false));
 }
 
@@ -103,7 +118,7 @@ void WhitespaceManager::replaceWhitespaceInToken(
              SourceRange(Start, Start.getLocWithOffset(ReplaceChars)), Spaces,
              std::max(0, Spaces), /*IndentedFromColumn=*/0, Newlines,
              PreviousPostfix, CurrentPrefix,
-             /*IsAligned=*/true, InPPDirective && !Tok.IsFirst,
+             /*AlignedTo=*/&Tok, InPPDirective && !Tok.IsFirst,
              /*IsInsideToken=*/true));
 }
 
@@ -678,7 +693,7 @@ static unsigned AlignTokens(const FormatStyle &Style, F &&Matches,
       const FormatToken *MatchingParenToEncounter = nullptr;
       for (unsigned J = IndexToAlign + 1;
            J != E && (Changes[J].NewlinesBefore == 0 ||
-                      MatchingParenToEncounter || Changes[J].IsAligned);
+                      MatchingParenToEncounter || Changes[J].AlignedTo);
            ++J) {
         const auto &Change = Changes[J];
         const auto *Tok = Change.Tok;
@@ -1055,6 +1070,8 @@ void WhitespaceManager::alignTrailingComments() {
         if (Changes[J].Tok->is(tok::comment))
           continue;
 
+        if (!C.AlignedTo)
+          C.AlignedTo = C.Tok->getPrevious(tok::comment);
         const auto NextColumn = SourceMgr.getSpellingColumnNumber(
             Changes[J].OriginalWhitespaceRange.getEnd());
         // The start of the next token was previously aligned with the
@@ -1598,10 +1615,13 @@ void WhitespaceManager::generateChanges() {
       }
       // FIXME: This assert should hold if we computed the column correctly.
       // assert((int)C.StartOfTokenColumn >= C.Spaces);
-      appendIndentText(
-          ReplacementText, C.Tok->IndentLevel, std::max(0, C.Spaces),
-          std::max((int)C.StartOfTokenColumn, C.Spaces) - std::max(0, C.Spaces),
-          C.IsAligned);
+      unsigned IndentLevel = indentLevelFor(C, Style);
+      appendIndentText(ReplacementText, IndentLevel, std::max(0, C.Spaces),
+                       std::max((int)C.StartOfTokenColumn, C.Spaces) -
+                           std::max(0, C.Spaces),
+                       C.AlignedTo);
+      C.Tok->AppliedIndentLevel =
+          C.AlignedTo ? IndentLevel : std::max(0, C.Spaces) / Style.IndentWidth;
       ReplacementText.append(C.CurrentLinePrefix);
       storeReplacement(C.OriginalWhitespaceRange, ReplacementText);
     }

--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -28,8 +28,7 @@ static const FormatToken &getLineStart(const FormatToken &Tok) {
   return *Result;
 }
 
-static unsigned indentLevelFor(WhitespaceManager::Change const &C,
-                               FormatStyle const &Style) {
+static unsigned indentLevelFor(const WhitespaceManager::Change &C) {
   if (!C.AlignedTo)
     return C.Tok->IndentLevel;
 
@@ -1615,7 +1614,7 @@ void WhitespaceManager::generateChanges() {
       }
       // FIXME: This assert should hold if we computed the column correctly.
       // assert((int)C.StartOfTokenColumn >= C.Spaces);
-      unsigned IndentLevel = indentLevelFor(C, Style);
+      unsigned IndentLevel = indentLevelFor(C);
       appendIndentText(ReplacementText, IndentLevel, std::max(0, C.Spaces),
                        std::max((int)C.StartOfTokenColumn, C.Spaces) -
                            std::max(0, C.Spaces),

--- a/clang/lib/Format/WhitespaceManager.h
+++ b/clang/lib/Format/WhitespaceManager.h
@@ -55,7 +55,8 @@ public:
   /// from. It is used for determining what lines the alignment process should
   /// move.
   void replaceWhitespace(FormatToken &Tok, unsigned Newlines, unsigned Spaces,
-                         unsigned StartOfTokenColumn, bool IsAligned = false,
+                         unsigned StartOfTokenColumn,
+                         const FormatToken *AlignedTo = nullptr,
                          bool InPPDirective = false,
                          unsigned IndentedFromColumn = 0);
 
@@ -117,7 +118,7 @@ public:
            SourceRange OriginalWhitespaceRange, int Spaces,
            unsigned StartOfTokenColumn, unsigned IndentedFromColumn,
            unsigned NewlinesBefore, StringRef PreviousLinePostfix,
-           StringRef CurrentLinePrefix, bool IsAligned,
+           StringRef CurrentLinePrefix, const FormatToken *AlignedTo,
            bool ContinuesPPDirective, bool IsInsideToken);
 
     // The kind of the token whose whitespace this change replaces, or in which
@@ -139,7 +140,7 @@ public:
     unsigned NewlinesBefore;
     std::string PreviousLinePostfix;
     std::string CurrentLinePrefix;
-    bool IsAligned;
+    const FormatToken *AlignedTo;
     bool ContinuesPPDirective;
 
     // The number of spaces in front of the token or broken part of the token.

--- a/clang/unittests/Format/AlignmentTest.cpp
+++ b/clang/unittests/Format/AlignmentTest.cpp
@@ -3560,6 +3560,40 @@ TEST_F(AlignmentTest, AlignInsidePreprocessorElseBlock) {
                Style);
 }
 
+TEST_F(AlignmentTest, ContinuedAligned) {
+  FormatStyle Style = getLLVMStyleWithColumns(60);
+  Style.UseTab = FormatStyle::UT_AlignWithSpaces;
+  Style.TabWidth = Style.IndentWidth = Style.ContinuationIndentWidth = 4;
+
+  verifyFormat("for (;;) {\n"
+               "\tif (bar(aaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbb,\n"
+               "\t        cccccccccccccccccccccccccccccc)) {\n"
+               "\t\treturn {};\n"
+               "\t}\n"
+               "}",
+               Style);
+  verifyFormat("bar([]() {\n"
+               "\tconst AAAAAA aaaaa =\n"
+               "\t\tAAAAAAAAAA(foo(bbbbbbbbbbbbbbbbbbbbbbbbbb),\n"
+               "\t\t           foo(cccccccccccccccccccccccccc),\n"
+               "\t\t           foo(ddddddddddddddddddddddddd)) +\n"
+               "\t\teeeeeeeee;\n"
+               "});",
+               Style);
+
+  Style.AlignTrailingComments.Kind = FormatStyle::TCAS_Always;
+  verifyFormat("bar(\n"
+               "\t[]() {\n"
+               "\t\tif constexpr (std::is_same_v<aaaaaa,\n"
+               "\t\t                             T>) // comment line 1\n"
+               "\t\t                                 // comment line 2\n"
+               "\t\t{\n"
+               "\t\t}\n"
+               "\t},\n"
+               "\tvariant);",
+               Style);
+}
+
 } // namespace
 } // namespace test
 } // namespace format


### PR DESCRIPTION
This allows to inherit tabbed indent from the lines we break by the lines we want to align. Thus in the AlignWithSpaces mode aligned lines do not generate smaller indent than those they are aligned to.