### PR TITLE
[libc] Fix 'finish()' being called by the client instead of the server

### DIFF
--- a/libc/shared/rpc.h
+++ b/libc/shared/rpc.h
@@ -417,7 +417,7 @@ private:
     if (owns_buffer && T)
       out = process.invert_outbox(lane_mask, index, out);
     process.unlock(lane_mask, index);
-    if constexpr (!T)
+    if constexpr (T)
       process.finish(lane_mask);
   }
 


### PR DESCRIPTION
Summary:
This function is supposed to manage the doorbell interrupts. The flow
that was intended was that the client notified work to wake the server
and the server finished the work so it didn't go back to sleep until
everything was done. This was reversed and we had the client finishing
work and then stalling on it.
