### PR TITLE
[libc] Add LIBC_FULL_BUILD guard to stdint_proxy.h

### DIFF
--- a/libc/hdr/stdint_proxy.h
+++ b/libc/hdr/stdint_proxy.h
@@ -13,6 +13,10 @@
 // that is `libc.include.stdint` is added to the dependency of all targets
 // that use <stdint.h> header.
 
+#ifdef LIBC_FULL_BUILD
+#include "include/llvm-libc-macros/stdint-macros.h"
+#else
 #include <stdint.h>
+#endif
 
 #endif // LLVM_LIBC_HDR_STDINT_PROXY_H


### PR DESCRIPTION
In full-build mode with -nostdinc, the system <stdint.h> is unavailable. Use the internal stdint-macros.h header instead, falling back to the system header in overlay mode.