### PR TITLE
[libc] Add missing errno_macros.h include to pthread schedparam

### DIFF
--- a/libc/src/pthread/pthread_attr_getschedparam.cpp
+++ b/libc/src/pthread/pthread_attr_getschedparam.cpp
@@ -11,6 +11,7 @@
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
+#include "hdr/errno_macros.h"
 #include <pthread.h>
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/pthread/pthread_attr_setschedparam.cpp
+++ b/libc/src/pthread/pthread_attr_setschedparam.cpp
@@ -11,6 +11,7 @@
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
+#include "hdr/errno_macros.h"
 #include <pthread.h>
 
 namespace LIBC_NAMESPACE_DECL {


### PR DESCRIPTION
Both pthread_attr_getschedparam and pthread_attr_setschedparam use ENOTSUP but relied on getting it transitively through <pthread.h>. Added the explicit include so these files compile in standalone builds with -nostdinc.