### PR TITLE
[libc] Add noexcept to aligned_alloc declaration in full-build mode

### DIFF
--- a/libc/hdr/func/aligned_alloc.h
+++ b/libc/hdr/func/aligned_alloc.h
@@ -11,7 +11,11 @@
 
 #ifdef LIBC_FULL_BUILD
 #include "hdr/types/size_t.h"
+#ifdef __cplusplus
+extern "C" void *aligned_alloc(size_t, size_t) noexcept;
+#else
 extern "C" void *aligned_alloc(size_t, size_t);
+#endif
 
 #else // Overlay mode
 

--- a/libc/hdr/func/aligned_alloc.h
+++ b/libc/hdr/func/aligned_alloc.h
@@ -10,12 +10,13 @@
 #define LLVM_LIBC_HDR_FUNC_ALIGNED_ALLOC_H
 
 #ifdef LIBC_FULL_BUILD
+
 #include "hdr/types/size_t.h"
-#ifdef __cplusplus
-extern "C" void *aligned_alloc(size_t, size_t) noexcept;
-#else
-extern "C" void *aligned_alloc(size_t, size_t);
-#endif
+#include "include/__llvm-libc-common.h"
+
+__BEGIN_C_DECLS
+void *aligned_alloc(size_t, size_t) __NOEXCEPT;
+__END_C_DECLS
 
 #else // Overlay mode
 

--- a/libc/hdr/func/free.h
+++ b/libc/hdr/func/free.h
@@ -11,7 +11,11 @@
 
 #ifdef LIBC_FULL_BUILD
 
-extern "C" void free(void *) noexcept;
+#include "include/__llvm-libc-common.h"
+
+__BEGIN_C_DECLS
+void free(void *) __NOEXCEPT;
+__END_C_DECLS
 
 #else // Overlay mode
 

--- a/libc/hdr/func/malloc.h
+++ b/libc/hdr/func/malloc.h
@@ -12,8 +12,11 @@
 #ifdef LIBC_FULL_BUILD
 
 #include "hdr/types/size_t.h"
+#include "include/__llvm-libc-common.h"
 
-extern "C" void *malloc(size_t) noexcept;
+__BEGIN_C_DECLS
+void *malloc(size_t) __NOEXCEPT;
+__END_C_DECLS
 
 #else // Overlay mode
 

--- a/libc/hdr/func/realloc.h
+++ b/libc/hdr/func/realloc.h
@@ -12,8 +12,11 @@
 #ifdef LIBC_FULL_BUILD
 
 #include "hdr/types/size_t.h"
+#include "include/__llvm-libc-common.h"
 
-extern "C" void *realloc(void *ptr, size_t new_size) noexcept;
+__BEGIN_C_DECLS
+void *realloc(void *ptr, size_t new_size) __NOEXCEPT;
+__END_C_DECLS
 
 #else // Overlay mode
 


### PR DESCRIPTION
The extern "C" declaration of aligned_alloc in the proxy header lacked a noexcept specifier, producing warnings when compiled as C++. Added a __cplusplus guard so C++ gets noexcept while C compilation remains unaffected.