### PR TITLE
[DirectX] Fix debug dump of ValueEnumerator

### DIFF
--- a/llvm/lib/Target/DirectX/DXILWriter/DXILValueEnumerator.cpp
+++ b/llvm/lib/Target/DirectX/DXILWriter/DXILValueEnumerator.cpp
@@ -543,22 +543,26 @@ void ValueEnumerator::print(raw_ostream &OS, const ValueMapType &Map,
   for (const auto &I : Map) {
     const Value *V = I.first;
     if (V->hasName())
-      OS << "Value: " << V->getName();
+      OS << "Value: " << V->getName() << '\n';
     else
       OS << "Value: [null]\n";
-    V->print(errs());
-    errs() << '\n';
+    V->print(OS);
+    OS << '\n';
 
-    OS << " Uses(" << V->getNumUses() << "):";
-    for (const Use &U : V->uses()) {
-      if (&U != &*V->use_begin())
-        OS << ",";
-      if (U->hasName())
-        OS << " " << U->getName();
-      else
-        OS << " [null]";
+    if (V->hasUseList()) {
+      OS << " Uses(" << V->getNumUses() << "):";
+      for (const Use &U : V->uses()) {
+        if (&U != &*V->use_begin())
+          OS << ",";
+        if (U->hasName())
+          OS << " " << U->getName();
+        else
+          OS << " [null]";
+      }
+      OS << '\n';
     }
-    OS << "\n\n";
+
+    OS << '\n';
   }
 }
 


### PR DESCRIPTION
Consistently print to OS, and do not try to print uses of values without a use list.