### PR TITLE
[Analysis][NFC] Remove BPI::getEdgeProbability(iterator)

### DIFF
--- a/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
+++ b/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
@@ -1464,12 +1464,12 @@ void BlockFrequencyInfoImpl<BT>::findReachableBlocks(
   while (!Queue.empty()) {
     const BlockT *SrcBB = Queue.front();
     Queue.pop();
-    for (const BlockT *DstBB : children<const BlockT *>(SrcBB)) {
-      auto EP = BPI->getEdgeProbability(SrcBB, DstBB);
+    for (auto It : enumerate(children<const BlockT *>(SrcBB))) {
+      auto EP = BPI->getEdgeProbability(SrcBB, It.index());
       if (EP.isZero())
         continue;
-      if (Reachable.insert(DstBB).second)
-        Queue.push(DstBB);
+      if (Reachable.insert(It.value()).second)
+        Queue.push(It.value());
     }
   }
 
@@ -1518,7 +1518,8 @@ void BlockFrequencyInfoImpl<BT>::initTransitionProbabilities(
   for (size_t Src = 0; Src < NumBlocks; Src++) {
     const BlockT *BB = Blocks[Src];
     SmallPtrSet<const BlockT *, 2> UniqueSuccs;
-    for (const auto SI : children<const BlockT *>(BB)) {
+    for (auto It : enumerate(children<const BlockT *>(BB))) {
+      const BlockT *SI = It.value();
       // Ignore cold blocks
       auto BlockIndexIt = BlockIndex.find(SI);
       if (BlockIndexIt == BlockIndex.end())
@@ -1527,7 +1528,7 @@ void BlockFrequencyInfoImpl<BT>::initTransitionProbabilities(
       if (!UniqueSuccs.insert(SI).second)
         continue;
       // Ignore jumps with zero probability
-      auto EP = BPI->getEdgeProbability(BB, SI);
+      auto EP = BPI->getEdgeProbability(BB, It.index());
       if (EP.isZero())
         continue;
 
@@ -1626,12 +1627,10 @@ BlockFrequencyInfoImpl<BT>::propagateMassToSuccessors(LoopData *OuterLoop,
       return false;
   } else {
     const BlockT *BB = getBlock(Node);
-    for (auto SI = GraphTraits<const BlockT *>::child_begin(BB),
-              SE = GraphTraits<const BlockT *>::child_end(BB);
-         SI != SE; ++SI)
+    for (auto It : enumerate(children<const BlockT *>(BB)))
       if (!addToDist(
-              Dist, OuterLoop, Node, getNode(*SI),
-              getWeightFromBranchProb(BPI->getEdgeProbability(BB, SI))))
+              Dist, OuterLoop, Node, getNode(It.value()),
+              getWeightFromBranchProb(BPI->getEdgeProbability(BB, It.index()))))
         // Irreducible backedge.
         return false;
   }
@@ -1808,7 +1807,8 @@ struct BFIDOTGraphTraitsBase : public DefaultDOTGraphTraits {
     if (!BPI)
       return Str;
 
-    BranchProbability BP = BPI->getEdgeProbability(Node, EI);
+    unsigned SuccIdx = std::distance(succ_begin(Node), EI);
+    BranchProbability BP = BPI->getEdgeProbability(Node, SuccIdx);
     uint32_t N = BP.getNumerator();
     uint32_t D = BP.getDenominator();
     double Percent = 100.0 * N / D;

--- a/llvm/include/llvm/Analysis/BranchProbabilityInfo.h
+++ b/llvm/include/llvm/Analysis/BranchProbabilityInfo.h
@@ -137,9 +137,6 @@ public:
   LLVM_ABI BranchProbability getEdgeProbability(const BasicBlock *Src,
                                                 const BasicBlock *Dst) const;
 
-  LLVM_ABI BranchProbability getEdgeProbability(const BasicBlock *Src,
-                                                const_succ_iterator Dst) const;
-
   /// Test if an edge is hot relative to other out-edges of the Src.
   ///
   /// Check whether this edge out of the source block is 'hot'. We define hot

--- a/llvm/include/llvm/CodeGen/MachineBranchProbabilityInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineBranchProbabilityInfo.h
@@ -37,11 +37,9 @@ public:
   BranchProbability getEdgeProbability(const MachineBasicBlock *Src,
                                        const MachineBasicBlock *Dst) const;
 
-  // Same as above, but using a const_succ_iterator from Src. This is faster
-  // when the iterator is already available.
-  BranchProbability
-  getEdgeProbability(const MachineBasicBlock *Src,
-                     MachineBasicBlock::const_succ_iterator Dst) const;
+  // Same as above, but using the successor index from Src. This is faster.
+  BranchProbability getEdgeProbability(const MachineBasicBlock *Src,
+                                       unsigned SuccIdx) const;
 
   // A 'Hot' edge is an edge which probability is >= 80%.
   bool isEdgeHot(const MachineBasicBlock *Src,

--- a/llvm/lib/Analysis/BranchProbabilityInfo.cpp
+++ b/llvm/lib/Analysis/BranchProbabilityInfo.cpp
@@ -1357,12 +1357,6 @@ BranchProbabilityInfo::getEdgeProbability(const BasicBlock *Src,
   return {1, static_cast<uint32_t>(succ_size(Src))};
 }
 
-BranchProbability
-BranchProbabilityInfo::getEdgeProbability(const BasicBlock *Src,
-                                          const_succ_iterator Dst) const {
-  return getEdgeProbability(Src, std::distance(succ_begin(Src), Dst));
-}
-
 /// Get the raw edge probability calculated for the block pair. This returns the
 /// sum of all raw edge probabilities from Src to Dst.
 BranchProbability

--- a/llvm/lib/CodeGen/MIRSampleProfile.cpp
+++ b/llvm/lib/CodeGen/MIRSampleProfile.cpp
@@ -248,7 +248,7 @@ void MIRProfileLoader::setBranchProbs(MachineFunction &F) {
       assert(BBWeight >= EdgeWeight &&
              "BBweight is larger than EdgeWeight -- should not happen.\n");
 
-      BranchProbability OldProb = BFI->getMBPI()->getEdgeProbability(BB, SI);
+      BranchProbability OldProb = BB->getSuccProbability(SI);
       BranchProbability NewProb(EdgeWeight, BBWeight);
       if (OldProb == NewProb)
         continue;

--- a/llvm/lib/CodeGen/MachineBranchProbabilityInfo.cpp
+++ b/llvm/lib/CodeGen/MachineBranchProbabilityInfo.cpp
@@ -71,17 +71,17 @@ bool MachineBranchProbabilityInfo::invalidate(
   return !PAC.preservedWhenStateless();
 }
 
-BranchProbability MachineBranchProbabilityInfo::getEdgeProbability(
-    const MachineBasicBlock *Src,
-    MachineBasicBlock::const_succ_iterator Dst) const {
-  return Src->getSuccProbability(Dst);
+BranchProbability
+MachineBranchProbabilityInfo::getEdgeProbability(const MachineBasicBlock *Src,
+                                                 unsigned SuccIdx) const {
+  return Src->getSuccProbability(Src->succ_begin() + SuccIdx);
 }
 
 BranchProbability MachineBranchProbabilityInfo::getEdgeProbability(
     const MachineBasicBlock *Src, const MachineBasicBlock *Dst) const {
   // This is a linear search. Try to use the const_succ_iterator version when
   // possible.
-  return getEdgeProbability(Src, find(Src->successors(), Dst));
+  return Src->getSuccProbability(find(Src->successors(), Dst));
 }
 
 bool MachineBranchProbabilityInfo::isEdgeHot(


### PR DESCRIPTION
Now that successor iterators are Use iterators, it is no longer cheap to
get the successor index. Replace uses with the variant that takes the
successor index, which in all cases is easily available.

This is primarily cleanup after the somewhat recent successor changes.
There's also a minor (barely measurable) performance improvement here.
