### PR TITLE
[Clang-Tidy] Fixed `cppcoreguidelines-init-variables` to handle ObjC for-in loops.

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/InitVariablesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/InitVariablesCheck.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/LexerUtils.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/StmtObjC.h"
 #include "clang/AST/Type.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/Lex/Preprocessor.h"
@@ -21,6 +22,9 @@ namespace clang::tidy::cppcoreguidelines {
 
 namespace {
 AST_MATCHER(VarDecl, isLocalVarDecl) { return Node.isLocalVarDecl(); }
+AST_MATCHER(Stmt, isObjCForCollectionStmt) {
+  return isa<ObjCForCollectionStmt>(&Node);
+}
 } // namespace
 
 InitVariablesCheck::InitVariablesCheck(StringRef Name,
@@ -42,6 +46,7 @@ void InitVariablesCheck::registerMatchers(MatchFinder *Finder) {
       varDecl(unless(hasInitializer(anything())), unless(isInstantiated()),
               isLocalVarDecl(), unless(isStaticLocal()), isDefinition(),
               unless(hasParent(cxxCatchStmt())),
+              unless(hasParent(declStmt(hasParent(isObjCForCollectionStmt())))),
               optionally(hasParent(declStmt(hasParent(
                   cxxForRangeStmt(hasLoopVariable(varDecl().bind(BadDecl))))))),
               unless(equalsBoundNode(BadDecl)))

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -328,6 +328,10 @@ Changes in existing checks
   <clang-tidy/checks/cppcoreguidelines/init-variables>` check by ensuring that
   member pointers are correctly flagged as uninitialized.
 
+- Fixed :doc:`cppcoreguidelines-init-variables
+  <clang-tidy/checks/cppcoreguidelines/init-variables>` check by excluding
+  Objective-C for-in loop variable declaration.
+
 - Improved :doc:`cppcoreguidelines-missing-std-forward
   <clang-tidy/checks/cppcoreguidelines/missing-std-forward>` check:
   

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/init-variables-objcxx.mm
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/init-variables-objcxx.mm
@@ -1,0 +1,34 @@
+// RUN: %check_clang_tidy %s cppcoreguidelines-init-variables %t -- -- -fno-objc-arc
+
+@interface NSObject
+@end
+
+@interface NSString : NSObject
+@end
+
+@interface NSURL : NSObject
+- (NSString *)absoluteString;
+@end
+
+@interface NSArray : NSObject
+@end
+
+void objc_for_in_no_false_positive(NSArray *urls) {
+  for (NSURL *url in urls) {
+    {
+      // 'url' should NOT be flagged - it is a for-in loop variable.
+      NSString *urlString = [url absoluteString];
+    }
+  }
+}
+
+void objc_for_in_body_uninit(NSArray *urls) {
+  for (NSURL *url in urls) {
+    (void)url;
+
+    // CHECK-MESSAGES: :[[@LINE+2]]:15: warning: variable 'str' is not initialized [cppcoreguidelines-init-variables]
+    // CHECK-FIXES: NSString *str = nullptr;
+    NSString *str;
+    (void)str;
+  }
+}


### PR DESCRIPTION
The check used to report false positive in case of for-in loop in Objective-C[++]:
```
for (NSString *value in values) {
   ...
}
```
With the report message:
```
...: warning: variable 'value' is not initialized [cppcoreguidelines-init-variables]
for (NSString *value in values) {
               ^
                     = NULL
```

This PR exclude the for-in loop from the the matcher in order to avoid the false-positive.

Fixes #62106