### PR TITLE
[llvm][DebugInfo][DWARF] Use formatv() instead of format() 

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
@@ -32,7 +32,7 @@ static raw_ostream &operator<<(raw_ostream &OS, const Atom &A) {
   StringRef Str = dwarf::AtomTypeString(A.Value);
   if (!Str.empty())
     return OS << Str;
-  return OS << "DW_ATOM_unknown_" << format("%x", A.Value);
+  return OS << "DW_ATOM_unknown_" << formatv("{0:x-}", A.Value);
 }
 } // namespace
 
@@ -185,7 +185,7 @@ bool AppleAcceleratorTable::dumpName(ScopedPrinter &W,
     return false; // End of list
 
   DictScope NameScope(W, ("Name@0x" + Twine::utohexstr(NameOffset)).str());
-  W.startLine() << format("String: 0x%08" PRIx64, StringOffset);
+  W.startLine() << formatv("String: {0:x8}", StringOffset);
   W.getOStream() << " \"" << StringSection.getCStr(&StringOffset) << "\"\n";
 
   unsigned NumData = AccelSection.getU32(DataOffset);
@@ -193,7 +193,7 @@ bool AppleAcceleratorTable::dumpName(ScopedPrinter &W,
     ListScope DataScope(W, ("Data " + Twine(Data)).str());
     unsigned i = 0;
     for (auto &Atom : AtomForms) {
-      W.startLine() << format("Atom[%d]: ", i);
+      W.startLine() << formatv("Atom[{0}]: ", i);
       if (Atom.extractValue(AccelSection, DataOffset, FormParams)) {
         Atom.dump(W.getOStream());
         if (std::optional<uint64_t> Val = Atom.getAsUnsignedConstant()) {
@@ -859,7 +859,7 @@ void DWARFDebugNames::NameIndex::dumpName(ScopedPrinter &W,
   if (Hash)
     W.printHex("Hash", *Hash);
 
-  W.startLine() << format("String: 0x%08" PRIx64, NTE.getStringOffset());
+  W.startLine() << formatv("String: {0:x8}", NTE.getStringOffset());
   W.getOStream() << " \"" << NTE.getString() << "\"\n";
 
   uint64_t EntryOffset = NTE.getEntryOffset();
@@ -870,7 +870,7 @@ void DWARFDebugNames::NameIndex::dumpName(ScopedPrinter &W,
 void DWARFDebugNames::NameIndex::dumpCUs(ScopedPrinter &W) const {
   ListScope CUScope(W, "Compilation Unit offsets");
   for (uint32_t CU = 0; CU < Hdr.CompUnitCount; ++CU)
-    W.startLine() << format("CU[%u]: 0x%08" PRIx64 "\n", CU, getCUOffset(CU));
+    W.startLine() << formatv("CU[{0}]: {1:x8}\n", CU, getCUOffset(CU));
 }
 
 void DWARFDebugNames::NameIndex::dumpLocalTUs(ScopedPrinter &W) const {
@@ -879,8 +879,8 @@ void DWARFDebugNames::NameIndex::dumpLocalTUs(ScopedPrinter &W) const {
 
   ListScope TUScope(W, "Local Type Unit offsets");
   for (uint32_t TU = 0; TU < Hdr.LocalTypeUnitCount; ++TU)
-    W.startLine() << format("LocalTU[%u]: 0x%08" PRIx64 "\n", TU,
-                            getLocalTUOffset(TU));
+    W.startLine() << formatv("LocalTU[{0}]: {1:x8}\n", TU,
+                             getLocalTUOffset(TU));
 }
 
 void DWARFDebugNames::NameIndex::dumpForeignTUs(ScopedPrinter &W) const {
@@ -889,8 +889,8 @@ void DWARFDebugNames::NameIndex::dumpForeignTUs(ScopedPrinter &W) const {
 
   ListScope TUScope(W, "Foreign Type Unit signatures");
   for (uint32_t TU = 0; TU < Hdr.ForeignTypeUnitCount; ++TU) {
-    W.startLine() << format("ForeignTU[%u]: 0x%016" PRIx64 "\n", TU,
-                            getForeignTUSignature(TU));
+    W.startLine() << formatv("ForeignTU[{0}]: {1:x16}\n", TU,
+                             getForeignTUSignature(TU));
   }
 }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFCFIPrinter.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFCFIPrinter.cpp
@@ -52,13 +52,13 @@ static void printOperand(raw_ostream &OS, const DIDumpOptions &DumpOpts,
     if (!OpcodeName.empty())
       OS << " " << OpcodeName;
     else
-      OS << format(" Opcode %x", Opcode);
+      OS << formatv(" Opcode {0:x-}", Opcode);
     break;
   }
   case CFIProgram::OT_None:
     break;
   case CFIProgram::OT_Address:
-    OS << format(" %" PRIx64, Operand);
+    OS << formatv(" {0:x-}", Operand);
     Address = Operand;
     break;
   case CFIProgram::OT_Offset:
@@ -69,32 +69,32 @@ static void printOperand(raw_ostream &OS, const DIDumpOptions &DumpOpts,
     break;
   case CFIProgram::OT_FactoredCodeOffset: // Always Unsigned
     if (P.codeAlign())
-      OS << format(" %" PRId64, Operand * P.codeAlign());
+      OS << formatv(" {0}", Operand * P.codeAlign());
     else
-      OS << format(" %" PRId64 "*code_alignment_factor", Operand);
+      OS << formatv(" {0}*code_alignment_factor", Operand);
     if (Address && P.codeAlign()) {
       *Address += Operand * P.codeAlign();
-      OS << format(" to 0x%" PRIx64, *Address);
+      OS << formatv(" to {0:x+}", *Address);
     }
     break;
   case CFIProgram::OT_SignedFactDataOffset:
     if (P.dataAlign())
-      OS << format(" %" PRId64, int64_t(Operand) * P.dataAlign());
+      OS << formatv(" {0}", int64_t(Operand) * P.dataAlign());
     else
-      OS << format(" %" PRId64 "*data_alignment_factor", int64_t(Operand));
+      OS << formatv(" {0}*data_alignment_factor", int64_t(Operand));
     break;
   case CFIProgram::OT_UnsignedFactDataOffset:
     if (P.dataAlign())
-      OS << format(" %" PRId64, Operand * P.dataAlign());
+      OS << formatv(" {0}", int64_t(Operand * P.dataAlign()));
     else
-      OS << format(" %" PRId64 "*data_alignment_factor", Operand);
+      OS << formatv(" {0}*data_alignment_factor", Operand);
     break;
   case CFIProgram::OT_Register:
     OS << ' ';
     printRegister(OS, DumpOpts, Operand);
     break;
   case CFIProgram::OT_AddressSpace:
-    OS << format(" in addrspace%" PRId64, Operand);
+    OS << formatv(" in addrspace{0}", Operand);
     break;
   case CFIProgram::OT_Expression:
     assert(Instr.Expression && "missing DWARFExpression object");

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -47,6 +47,8 @@
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/LEB128.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -863,10 +865,10 @@ static void dumpStringOffsetsSection(raw_ostream &OS, DIDumpOptions DumpOpts,
     }
     // Report a gap in the table.
     if (Offset < ContributionHeader) {
-      OS << format("0x%8.8" PRIx64 ": Gap, length = ", Offset);
+      OS << formatv("{0:x8}: Gap, length = ", Offset);
       OS << (ContributionHeader - Offset) << "\n";
     }
-    OS << format("0x%8.8" PRIx64 ": ", ContributionHeader);
+    OS << formatv("{0:x8}: ", ContributionHeader);
     // In DWARF v5 the contribution size in the descriptor does not equal
     // the originally encoded length (it does not contain the length of the
     // version field and the padding, a total of 4 bytes). Add them back in
@@ -878,19 +880,20 @@ static void dumpStringOffsetsSection(raw_ostream &OS, DIDumpOptions DumpOpts,
     Offset = Contribution->Base;
     unsigned EntrySize = Contribution->getDwarfOffsetByteSize();
     while (Offset - Contribution->Base < Contribution->Size) {
-      OS << format("0x%8.8" PRIx64 ": ", Offset);
+      OS << formatv("{0:x8}: ", Offset);
       uint64_t StringOffset =
           StrOffsetExt.getRelocatedValue(EntrySize, &Offset);
-      OS << format("%0*" PRIx64 " ", OffsetDumpWidth, StringOffset);
+      OS << formatv("{0:x-} ", fmt_align(StringOffset, AlignStyle::Right,
+                                         OffsetDumpWidth, '0'));
       const char *S = StrData.getCStr(&StringOffset);
       if (S)
-        OS << format("\"%s\"", S);
+        OS << formatv("\"{0}\"", S);
       OS << "\n";
     }
   }
   // Report a gap at the end of the table.
   if (Offset < SectionSize) {
-    OS << format("0x%8.8" PRIx64 ": Gap, length = ", Offset);
+    OS << formatv("{0:x8}: Gap, length = ", Offset);
     OS << (SectionSize - Offset) << "\n";
   }
 }
@@ -1166,8 +1169,7 @@ void DWARFContext::dump(
         Parser.skip(DumpOpts.WarningHandler, DumpOpts.WarningHandler);
         continue;
       }
-      OS << "debug_line[" << format("0x%8.8" PRIx64, Parser.getOffset())
-         << "]\n";
+      OS << "debug_line[" << formatv("{0:x8}", Parser.getOffset()) << "]\n";
       Parser.parseNext(DumpOpts.WarningHandler, DumpOpts.WarningHandler, &OS,
                        DumpOpts.Verbose);
     }
@@ -1184,7 +1186,7 @@ void DWARFContext::dump(
         DumpOpts.WarningHandler(std::move(Err));
         return;
       }
-      OS << format("0x%8.8" PRIx64 ": \"", StrOffset);
+      OS << formatv("{0:x+8}: \"", StrOffset);
       OS.write_escaped(CStr);
       OS << "\"\n";
       StrOffset = Offset;

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugFrame.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugFrame.cpp
@@ -24,6 +24,8 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <cinttypes>
@@ -101,30 +103,31 @@ constexpr uint64_t getCIEId(bool IsDWARF64, bool IsEH) {
 void CIE::dump(raw_ostream &OS, DIDumpOptions DumpOpts) const {
   // A CIE with a zero length is a terminator entry in the .eh_frame section.
   if (DumpOpts.IsEH && Length == 0) {
-    OS << format("%08" PRIx64, Offset) << " ZERO terminator\n";
+    OS << formatv("{0:x-8}", Offset) << " ZERO terminator\n";
     return;
   }
 
-  OS << format("%08" PRIx64, Offset)
-     << format(" %0*" PRIx64, IsDWARF64 ? 16 : 8, Length)
-     << format(" %0*" PRIx64, IsDWARF64 && !DumpOpts.IsEH ? 16 : 8,
-               getCIEId(IsDWARF64, DumpOpts.IsEH))
+  OS << formatv("{0:x-8}", Offset)
+     << formatv(" {0:x-}",
+                fmt_align(Length, AlignStyle::Right, IsDWARF64 ? 16 : 8, '0'))
+     << formatv(" {0:x-}",
+                fmt_align(getCIEId(IsDWARF64, DumpOpts.IsEH), AlignStyle::Right,
+                          IsDWARF64 && !DumpOpts.IsEH ? 16 : 8, '0'))
      << " CIE\n"
      << "  Format:                " << FormatString(IsDWARF64) << "\n";
   if (DumpOpts.IsEH && Version != 1)
     OS << "WARNING: unsupported CIE version\n";
-  OS << format("  Version:               %d\n", Version)
+  OS << formatv("  Version:               {0}\n", Version)
      << "  Augmentation:          \"" << Augmentation << "\"\n";
   if (Version >= 4) {
-    OS << format("  Address size:          %u\n", (uint32_t)AddressSize);
-    OS << format("  Segment desc size:     %u\n",
-                 (uint32_t)SegmentDescriptorSize);
+    OS << formatv("  Address size:          {0}\n", AddressSize);
+    OS << formatv("  Segment desc size:     {0}\n", SegmentDescriptorSize);
   }
-  OS << format("  Code alignment factor: %u\n", (uint32_t)CodeAlignmentFactor);
-  OS << format("  Data alignment factor: %d\n", (int32_t)DataAlignmentFactor);
-  OS << format("  Return address column: %d\n", (int32_t)ReturnAddressRegister);
+  OS << formatv("  Code alignment factor: {0}\n", CodeAlignmentFactor);
+  OS << formatv("  Data alignment factor: {0}\n", DataAlignmentFactor);
+  OS << formatv("  Return address column: {0}\n", ReturnAddressRegister);
   if (Personality)
-    OS << format("  Personality Address: %016" PRIx64 "\n", *Personality);
+    OS << formatv("  Personality Address: {0:x-16}\n", *Personality);
   if (!AugmentationData.empty()) {
     OS << "  Augmentation data:    ";
     for (uint8_t Byte : AugmentationData)
@@ -148,19 +151,21 @@ void CIE::dump(raw_ostream &OS, DIDumpOptions DumpOpts) const {
 }
 
 void FDE::dump(raw_ostream &OS, DIDumpOptions DumpOpts) const {
-  OS << format("%08" PRIx64, Offset)
-     << format(" %0*" PRIx64, IsDWARF64 ? 16 : 8, Length)
-     << format(" %0*" PRIx64, IsDWARF64 && !DumpOpts.IsEH ? 16 : 8, CIEPointer)
+  OS << formatv("{0:x-8}", Offset)
+     << formatv(" {0:x-}",
+                fmt_align(Length, AlignStyle::Right, IsDWARF64 ? 16 : 8, '0'))
+     << formatv(" {0:x-}", fmt_align(CIEPointer, AlignStyle::Right,
+                                     IsDWARF64 && !DumpOpts.IsEH ? 16 : 8, '0'))
      << " FDE cie=";
   if (LinkedCIE)
-    OS << format("%08" PRIx64, LinkedCIE->getOffset());
+    OS << formatv("{0:x-8}", LinkedCIE->getOffset());
   else
     OS << "<invalid offset>";
-  OS << format(" pc=%08" PRIx64 "...%08" PRIx64 "\n", InitialLocation,
-               InitialLocation + AddressRange);
+  OS << formatv(" pc={0:x-8}...{1:x-8}\n", InitialLocation,
+                InitialLocation + AddressRange);
   OS << "  Format:       " << FormatString(IsDWARF64) << "\n";
   if (LSDAAddress)
-    OS << format("  LSDA Address: %016" PRIx64 "\n", *LSDAAddress);
+    OS << formatv("  LSDA Address: {0:x-16}\n", *LSDAAddress);
   printCFIProgram(CFIs, OS, DumpOpts, /*IndentLevel=*/1, InitialLocation);
   OS << "\n";
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -17,6 +17,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFFormValue.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
@@ -121,23 +122,25 @@ void DWARFDebugLine::Prologue::dump(raw_ostream &OS,
     return;
   int OffsetDumpWidth = 2 * dwarf::getDwarfOffsetByteSize(FormParams.Format);
   OS << "Line table prologue:\n"
-     << format("    total_length: 0x%0*" PRIx64 "\n", OffsetDumpWidth,
-               TotalLength)
+     << formatv("    total_length: 0x{0:x-}\n",
+                fmt_align(TotalLength, AlignStyle::Right, OffsetDumpWidth, '0'))
      << "          format: " << dwarf::FormatString(FormParams.Format) << "\n"
-     << format("         version: %u\n", getVersion());
+     << formatv("         version: {0}\n", getVersion());
   if (!versionIsSupported(getVersion()))
     return;
   if (getVersion() >= 5)
-    OS << format("    address_size: %u\n", getAddressSize())
-       << format(" seg_select_size: %u\n", SegSelectorSize);
-  OS << format(" prologue_length: 0x%0*" PRIx64 "\n", OffsetDumpWidth,
-               PrologueLength)
-     << format(" min_inst_length: %u\n", MinInstLength)
-     << format(getVersion() >= 4 ? "max_ops_per_inst: %u\n" : "", MaxOpsPerInst)
-     << format(" default_is_stmt: %u\n", DefaultIsStmt)
-     << format("       line_base: %i\n", LineBase)
-     << format("      line_range: %u\n", LineRange)
-     << format("     opcode_base: %u\n", OpcodeBase);
+    OS << formatv("    address_size: {0}\n", getAddressSize())
+       << formatv(" seg_select_size: {0}\n", SegSelectorSize);
+  OS << formatv(
+            " prologue_length: 0x{0:x-}\n",
+            fmt_align(PrologueLength, AlignStyle::Right, OffsetDumpWidth, '0'))
+     << formatv(" min_inst_length: {0}\n", MinInstLength);
+  if (getVersion() >= 4)
+    OS << formatv("max_ops_per_inst: {0}\n", MaxOpsPerInst);
+  OS << formatv(" default_is_stmt: {0}\n", DefaultIsStmt)
+     << formatv("       line_base: {0}\n", static_cast<int>(LineBase))
+     << formatv("      line_range: {0}\n", LineRange)
+     << formatv("     opcode_base: {0}\n", OpcodeBase);
 
   for (uint32_t I = 0; I != StandardOpcodeLengths.size(); ++I)
     OS << formatv("standard_opcode_lengths[{0}] = {1}\n",
@@ -148,7 +151,7 @@ void DWARFDebugLine::Prologue::dump(raw_ostream &OS,
     // DWARF v5 starts directory indexes at 0.
     uint32_t DirBase = getVersion() >= 5 ? 0 : 1;
     for (uint32_t I = 0; I != IncludeDirectories.size(); ++I) {
-      OS << format("include_directories[%3u] = ", I + DirBase);
+      OS << formatv("include_directories[{0,3}] = ", I + DirBase);
       IncludeDirectories[I].dump(OS, DumpOptions);
       OS << '\n';
     }
@@ -159,16 +162,16 @@ void DWARFDebugLine::Prologue::dump(raw_ostream &OS,
     uint32_t FileBase = getVersion() >= 5 ? 0 : 1;
     for (uint32_t I = 0; I != FileNames.size(); ++I) {
       const FileNameEntry &FileEntry = FileNames[I];
-      OS << format("file_names[%3u]:\n", I + FileBase);
+      OS << formatv("file_names[{0,3}]:\n", I + FileBase);
       OS << "           name: ";
       FileEntry.Name.dump(OS, DumpOptions);
-      OS << '\n' << format("      dir_index: %" PRIu64 "\n", FileEntry.DirIdx);
+      OS << '\n' << formatv("      dir_index: {0}\n", FileEntry.DirIdx);
       if (ContentTypes.HasMD5)
         OS << "   md5_checksum: " << FileEntry.Checksum.digest() << '\n';
       if (ContentTypes.HasModTime)
-        OS << format("       mod_time: 0x%8.8" PRIx64 "\n", FileEntry.ModTime);
+        OS << formatv("       mod_time: {0:x8}\n", FileEntry.ModTime);
       if (ContentTypes.HasLength)
-        OS << format("         length: 0x%8.8" PRIx64 "\n", FileEntry.Length);
+        OS << formatv("         length: {0:x8}\n", FileEntry.Length);
       if (ContentTypes.HasSource) {
         auto Source = FileEntry.Source.getAsCString();
         if (!Source)
@@ -515,8 +518,8 @@ void DWARFDebugLine::Row::dumpTableHeader(raw_ostream &OS, unsigned Indent) {
 }
 
 void DWARFDebugLine::Row::dump(raw_ostream &OS) const {
-  OS << format("0x%16.16" PRIx64 " %6u %6u", Address.Address, Line, Column)
-     << format(" %6u %3u %13u %7u ", File, Isa, Discriminator, OpIndex)
+  OS << formatv("{0:x16} {1,6} {2,6}", Address.Address, Line, Column)
+     << formatv(" {0,6} {1,3} {2,13} {3,7} ", File, Isa, Discriminator, OpIndex)
      << (IsStmt ? " is_stmt" : "") << (BasicBlock ? " basic_block" : "")
      << (PrologueEnd ? " prologue_end" : "")
      << (EpilogueBegin ? " epilogue_begin" : "")
@@ -869,14 +872,14 @@ Error DWARFDebugLine::LineTable::parse(
     DataExtractor::Cursor Cursor(*OffsetPtr);
 
     if (Verbose)
-      *OS << format("0x%08.08" PRIx64 ": ", *OffsetPtr);
+      *OS << formatv("{0:x8}: ", *OffsetPtr);
 
     uint64_t OpcodeOffset = *OffsetPtr;
     uint8_t Opcode = TableData.getU8(Cursor);
     size_t RowCount = Rows.size();
 
     if (Cursor && Verbose)
-      *OS << format("%02.02" PRIx8 " ", Opcode);
+      *OS << formatv("{0:x-2} ", Opcode);
 
     if (Opcode == 0) {
       // Extended Opcodes always start with a zero opcode followed by
@@ -1011,8 +1014,8 @@ Error DWARFDebugLine::LineTable::parse(
           FileEntry.Length = TableData.getULEB128(Cursor);
           Prologue.FileNames.push_back(FileEntry);
           if (Cursor && Verbose)
-            *OS << " (" << Name << ", dir=" << FileEntry.DirIdx << ", mod_time="
-                << format("(0x%16.16" PRIx64 ")", FileEntry.ModTime)
+            *OS << " (" << Name << ", dir=" << FileEntry.DirIdx
+                << ", mod_time=" << formatv("({0:x16})", FileEntry.ModTime)
                 << ", length=" << FileEntry.Length << ")";
         }
         break;
@@ -1025,8 +1028,8 @@ Error DWARFDebugLine::LineTable::parse(
 
       default:
         if (Cursor && Verbose)
-          *OS << format("Unrecognized extended op 0x%02.02" PRIx8, SubOpcode)
-              << format(" length %" PRIx64, Len);
+          *OS << formatv("Unrecognized extended op {0:x2}", SubOpcode)
+              << formatv(" length {0:x-}", Len);
         // Len doesn't include the zero opcode byte or the length itself, but
         // it does include the sub_opcode, so we have to adjust for that.
         TableData.skip(Cursor, Len - 1);
@@ -1049,7 +1052,7 @@ Error DWARFDebugLine::LineTable::parse(
         if (ByteCursor) {
           *OS << " (<parsing error>";
           do {
-            *OS << format(" %2.2" PRIx8, Byte);
+            *OS << formatv(" {0:x-2}", Byte);
             Byte = TableData.getU8(ByteCursor);
           } while (ByteCursor);
           *OS << ")";
@@ -1149,9 +1152,8 @@ Error DWARFDebugLine::LineTable::parse(
           ParsingState::OpcodeAdvanceResults Advance =
               State.advanceForOpcode(Opcode, OpcodeOffset);
           if (Verbose)
-            *OS << format(" (addr += 0x%16.16" PRIx64 ", op-index += %" PRIu8
-                          ")",
-                          Advance.AddrDelta, Advance.OpIndexDelta);
+            *OS << formatv(" (addr += {0:x16}, op-index += {1})",
+                           Advance.AddrDelta, Advance.OpIndexDelta);
         }
         break;
 
@@ -1172,8 +1174,7 @@ Error DWARFDebugLine::LineTable::parse(
             State.Row.Address.Address += PCOffset;
             State.Row.OpIndex = 0;
             if (Verbose)
-              *OS << format(" (addr += 0x%4.4" PRIx16 ", op-index = 0)",
-                            PCOffset);
+              *OS << formatv(" (addr += {0:x4}, op-index = 0)", PCOffset);
           }
         }
         break;
@@ -1222,7 +1223,7 @@ Error DWARFDebugLine::LineTable::parse(
             *OS << " (operands: ";
             ListSeparator LS;
             for (uint64_t Value : Operands)
-              *OS << LS << format("0x%16.16" PRIx64, Value);
+              *OS << LS << formatv("{0:x16}", Value);
             *OS << ')';
           }
         }

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugMacro.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugMacro.cpp
@@ -13,6 +13,8 @@
 #include "llvm/DebugInfo/DWARF/DWARFDie.h"
 #include "llvm/DebugInfo/DWARF/DWARFFormValue.h"
 #include "llvm/Support/Errc.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/WithColor.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdint>
@@ -30,19 +32,20 @@ uint8_t DWARFDebugMacro::MacroHeader::getOffsetByteSize() const {
 
 void DWARFDebugMacro::MacroHeader::dumpMacroHeader(raw_ostream &OS) const {
   // FIXME: Add support for dumping opcode_operands_table
-  OS << format("macro header: version = 0x%04" PRIx16, Version)
-     << format(", flags = 0x%02" PRIx8, Flags)
+  OS << formatv("macro header: version = {0:x4}", Version)
+     << formatv(", flags = {0:x2}", Flags)
      << ", format = " << FormatString(getDwarfFormat());
   if (Flags & MACRO_DEBUG_LINE_OFFSET)
-    OS << format(", debug_line_offset = 0x%0*" PRIx64, 2 * getOffsetByteSize(),
-                 DebugLineOffset);
+    OS << formatv(", debug_line_offset = 0x{0:x-}",
+                  fmt_align(DebugLineOffset, AlignStyle::Right,
+                            2 * getOffsetByteSize(), '0'));
   OS << "\n";
 }
 
 void DWARFDebugMacro::dump(raw_ostream &OS) const {
   unsigned IndLevel = 0;
   for (const auto &Macros : MacroLists) {
-    OS << format("0x%08" PRIx64 ":\n", Macros.Offset);
+    OS << formatv("{0:x8}:\n", Macros.Offset);
     if (Macros.IsDebugMacro)
       Macros.Header.dumpMacroHeader(OS);
     for (const Entry &E : Macros.Macros) {
@@ -89,8 +92,9 @@ void DWARFDebugMacro::dump(raw_ostream &OS) const {
         OS << " filenum: " << E.File;
         break;
       case DW_MACRO_import:
-        OS << format(" - import offset: 0x%0*" PRIx64,
-                     2 * Macros.Header.getOffsetByteSize(), E.ImportOffset);
+        OS << formatv(" - import offset: 0x{0:x-}",
+                      fmt_align(E.ImportOffset, AlignStyle::Right,
+                                2 * Macros.Header.getOffsetByteSize(), '0'));
         break;
       case DW_MACRO_end_file:
         break;

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugPubTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugPubTable.cpp
@@ -7,12 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/DebugInfo/DWARF/DWARFDebugPubTable.h"
-#include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdint>
 
@@ -93,24 +95,30 @@ void DWARFDebugPubTable::extract(
 void DWARFDebugPubTable::dump(raw_ostream &OS) const {
   for (const Set &S : Sets) {
     int OffsetDumpWidth = 2 * dwarf::getDwarfOffsetByteSize(S.Format);
-    OS << "length = " << format("0x%0*" PRIx64, OffsetDumpWidth, S.Length);
+    OS << "length = "
+       << formatv("0x{0:x-}",
+                  fmt_align(S.Length, AlignStyle::Right, OffsetDumpWidth, '0'));
     OS << ", format = " << dwarf::FormatString(S.Format);
-    OS << ", version = " << format("0x%04x", S.Version);
+    OS << ", version = " << formatv("{0:x4}", S.Version);
     OS << ", unit_offset = "
-       << format("0x%0*" PRIx64, OffsetDumpWidth, S.Offset);
-    OS << ", unit_size = " << format("0x%0*" PRIx64, OffsetDumpWidth, S.Size)
+       << formatv("0x{0:x-}",
+                  fmt_align(S.Offset, AlignStyle::Right, OffsetDumpWidth, '0'));
+    OS << ", unit_size = "
+       << formatv("0x{0:x-}",
+                  fmt_align(S.Size, AlignStyle::Right, OffsetDumpWidth, '0'))
        << '\n';
     OS << (GnuStyle ? "Offset     Linkage  Kind     Name\n"
                     : "Offset     Name\n");
 
     for (const Entry &E : S.Entries) {
-      OS << format("0x%0*" PRIx64 " ", OffsetDumpWidth, E.SecOffset);
+      OS << formatv("0x{0:x-} ", fmt_align(E.SecOffset, AlignStyle::Right,
+                                           OffsetDumpWidth, '0'));
       if (GnuStyle) {
         StringRef EntryLinkage =
             GDBIndexEntryLinkageString(E.Descriptor.Linkage);
         StringRef EntryKind = dwarf::GDBIndexEntryKindString(E.Descriptor.Kind);
-        OS << format("%-8s", EntryLinkage.data()) << ' '
-           << format("%-8s", EntryKind.data()) << ' ';
+        OS << formatv("{0, -8}", EntryLinkage.data()) << ' '
+           << formatv("{0, -8}", EntryKind.data()) << ' ';
       }
       OS << '\"' << E.Name << "\"\n";
     }

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugRangeList.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugRangeList.cpp
@@ -10,6 +10,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cinttypes>
 #include <cstdint>
@@ -68,20 +69,20 @@ void DWARFDebugRangeList::dump(raw_ostream &OS) const {
   const char *AddrFmt;
   switch (AddressSize) {
   case 2:
-    AddrFmt = "%08" PRIx64 " %04" PRIx64 " %04" PRIx64 "\n";
+    AddrFmt = "{0:x-8} {1:x-4} {2:x-4}\n";
     break;
   case 4:
-    AddrFmt = "%08" PRIx64 " %08" PRIx64 " %08" PRIx64 "\n";
+    AddrFmt = "{0:x-8} {1:x-8} {2:x-8}\n";
     break;
   case 8:
-    AddrFmt = "%08" PRIx64 " %016" PRIx64 " %016" PRIx64 "\n";
+    AddrFmt = "{0:x-8} {1:x-16} {2:x-16}\n";
     break;
   default:
     llvm_unreachable("unsupported address size");
   }
   for (const RangeListEntry &RLE : Entries)
-    OS << format(AddrFmt, Offset, RLE.StartAddress, RLE.EndAddress);
-  OS << format("%08" PRIx64 " <End of list>\n", Offset);
+    OS << formatv(AddrFmt, Offset, RLE.StartAddress, RLE.EndAddress);
+  OS << formatv("{0:x-8} <End of list>\n", Offset);
 }
 
 DWARFAddressRangesVector DWARFDebugRangeList::getAbsoluteRanges(

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugRnglists.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugRnglists.cpp
@@ -13,6 +13,8 @@
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
@@ -189,12 +191,13 @@ void RangeListEntry::dump(
 
   if (DumpOpts.Verbose) {
     // Print the section offset in verbose mode.
-    OS << format("0x%8.8" PRIx64 ":", Offset);
+    OS << formatv("{0:x8}:", Offset);
     auto EncodingString = dwarf::RangeListEncodingString(EntryKind);
     // Unsupported encodings should have been reported during parsing.
     assert(!EncodingString.empty() && "Unknown range entry encoding");
-    OS << format(" [%s%*c", EncodingString.data(),
-                 MaxEncodingStringLength - EncodingString.size() + 1, ']');
+    OS << formatv(" [{0}]",
+                  fmt_pad(EncodingString.data(), 0,
+                          MaxEncodingStringLength - EncodingString.size()));
     if (EntryKind != dwarf::DW_RLE_end_of_list)
       OS << ": ";
   }

--- a/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
@@ -46,7 +46,7 @@ static void dumpApplePropertyAttribute(raw_ostream &OS, uint64_t Val) {
     if (!PropName.empty())
       OS << PropName;
     else
-      OS << format("DW_APPLE_PROPERTY_0x%" PRIx64, Bit);
+      OS << formatv("DW_APPLE_PROPERTY_{0:x}", Bit);
     if (!(Val ^= Bit))
       break;
     OS << ", ";
@@ -678,7 +678,7 @@ void DWARFDie::dump(raw_ostream &OS, unsigned Indent,
     uint32_t abbrCode = debug_info_data.getULEB128(&offset);
     if (DumpOpts.ShowAddresses)
       WithColor(OS, HighlightColor::Address).get()
-          << format("\n0x%8.8" PRIx64 ": ", Offset);
+          << formatv("\n{0:x8}: ", Offset);
 
     if (abbrCode) {
       auto AbbrevDecl = getAbbreviationDeclarationPtr();
@@ -686,11 +686,11 @@ void DWARFDie::dump(raw_ostream &OS, unsigned Indent,
         WithColor(OS, HighlightColor::Tag).get().indent(Indent)
             << formatv("{0}", getTag());
         if (DumpOpts.Verbose) {
-          OS << format(" [%u] %c", abbrCode,
-                       AbbrevDecl->hasChildren() ? '*' : ' ');
+          OS << formatv(" [{0}] {1}", abbrCode,
+                        AbbrevDecl->hasChildren() ? '*' : ' ');
           if (std::optional<uint32_t> ParentIdx = Die->getParentIdx())
-            OS << format(" (0x%8.8" PRIx64 ")",
-                         U->getDIEAtIndex(*ParentIdx).getOffset());
+            OS << formatv(" ({0:x8})",
+                          U->getDIEAtIndex(*ParentIdx).getOffset());
         }
         OS << '\n';
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFExpressionPrinter.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFExpressionPrinter.cpp
@@ -29,19 +29,19 @@ static void prettyPrintBaseTypeRef(DWARFUnit *U, raw_ostream &OS,
                                    unsigned Operand) {
   assert(Operand < Operands.size() && "operand out of bounds");
   if (!U) {
-    OS << format(" <base_type ref: 0x%" PRIx64 ">", Operands[Operand]);
+    OS << formatv(" <base_type ref: {0:x}>", Operands[Operand]);
     return;
   }
   auto Die = U->getDIEForOffset(U->getOffset() + Operands[Operand]);
   if (Die && Die.getTag() == dwarf::DW_TAG_base_type) {
     OS << " (";
     if (DumpOpts.Verbose)
-      OS << format("0x%08" PRIx64 " -> ", Operands[Operand]);
-    OS << format("0x%08" PRIx64 ")", U->getOffset() + Operands[Operand]);
+      OS << formatv("{0:x8} -> ", Operands[Operand]);
+    OS << formatv("{0:x8})", U->getOffset() + Operands[Operand]);
     if (auto Name = dwarf::toString(Die.find(dwarf::DW_AT_name)))
       OS << " \"" << *Name << "\"";
   } else {
-    OS << format(" <invalid base_type ref: 0x%" PRIx64 ">", Operands[Operand]);
+    OS << formatv(" <invalid base_type ref: {0:x}>", Operands[Operand]);
   }
 }
 
@@ -142,7 +142,7 @@ static bool printOp(const DWARFExpression::Operation *Op, raw_ostream &OS,
         case 2:
         case 3: // global as uint32
         case 4:
-          OS << format(" 0x%" PRIx64, Op->getRawOperand(Operand));
+          OS << formatv(" {0:x}", Op->getRawOperand(Operand));
           break;
         default:
           assert(false);
@@ -150,14 +150,14 @@ static bool printOp(const DWARFExpression::Operation *Op, raw_ostream &OS,
       } else if (Size == DWARFExpression::Operation::SizeBlock) {
         uint64_t Offset = Op->getRawOperand(Operand);
         for (unsigned i = 0; i < Op->getRawOperand(Operand - 1); ++i)
-          OS << format(" 0x%02x",
-                       static_cast<uint8_t>(Expr->getData()[Offset++]));
+          OS << formatv(" {0:x2}",
+                        static_cast<uint8_t>(Expr->getData()[Offset++]));
       } else {
         if (Signed)
           OS << formatv(" {0:+d}", (int64_t)Op->getRawOperand(Operand));
         else if (Op->getCode() != DW_OP_entry_value &&
                  Op->getCode() != DW_OP_GNU_entry_value)
-          OS << format(" 0x%" PRIx64, Op->getRawOperand(Operand));
+          OS << formatv(" {0:x}", Op->getRawOperand(Operand));
       }
     }
   }
@@ -176,7 +176,8 @@ void printDwarfExpression(const DWARFExpression *E, raw_ostream &OS,
     if (!printOp(&Op, OS, DumpOpts, E, U) && !DumpOpts.PrintRegisterOnly) {
       uint64_t FailOffset = Op.getEndOffset();
       while (FailOffset < E->getData().size())
-        OS << format(" %02x", static_cast<uint8_t>(E->getData()[FailOffset++]));
+        OS << formatv(" {0:x-2}",
+                      static_cast<uint8_t>(E->getData()[FailOffset++]));
       return;
     }
     if (!DumpOpts.PrintRegisterOnly) {

--- a/llvm/lib/DebugInfo/DWARF/DWARFGdbIndex.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFGdbIndex.cpp
@@ -24,13 +24,13 @@ using namespace llvm;
 // https://sourceware.org/gdb/onlinedocs/gdb/Index-Section-Format.html
 
 void DWARFGdbIndex::dumpCUList(raw_ostream &OS) const {
-  OS << format("\n  CU list offset = 0x%x, has %" PRId64 " entries:",
-               CuListOffset, (uint64_t)CuList.size())
+  OS << formatv("\n  CU list offset = {0:x}, has {1} entries:", CuListOffset,
+                (uint64_t)CuList.size())
      << '\n';
   uint32_t I = 0;
   for (const CompUnitEntry &CU : CuList)
-    OS << format("    %d: Offset = 0x%llx, Length = 0x%llx\n", I++, CU.Offset,
-                 CU.Length);
+    OS << formatv("    {0}: Offset = {1:x}, Length = {2:x}\n", I++, CU.Offset,
+                  CU.Length);
 }
 
 void DWARFGdbIndex::dumpTUList(raw_ostream &OS) const {
@@ -44,20 +44,19 @@ void DWARFGdbIndex::dumpTUList(raw_ostream &OS) const {
 }
 
 void DWARFGdbIndex::dumpAddressArea(raw_ostream &OS) const {
-  OS << format("\n  Address area offset = 0x%x, has %" PRId64 " entries:",
-               AddressAreaOffset, (uint64_t)AddressArea.size())
+  OS << formatv("\n  Address area offset = {0:x}, has {1} entries:",
+                AddressAreaOffset, (uint64_t)AddressArea.size())
      << '\n';
   for (const AddressEntry &Addr : AddressArea)
-    OS << format(
-        "    Low/High address = [0x%llx, 0x%llx) (Size: 0x%llx), CU id = %d\n",
-        Addr.LowAddress, Addr.HighAddress, Addr.HighAddress - Addr.LowAddress,
-        Addr.CuIndex);
+    OS << formatv("    Low/High address = [{0:x}, {1:x}) (Size: {2:x}), CU "
+                  "id = {3}\n",
+                  Addr.LowAddress, Addr.HighAddress,
+                  Addr.HighAddress - Addr.LowAddress, Addr.CuIndex);
 }
 
 void DWARFGdbIndex::dumpSymbolTable(raw_ostream &OS) const {
-  OS << format("\n  Symbol table offset = 0x%x, size = %" PRId64
-               ", filled slots:",
-               SymbolTableOffset, (uint64_t)SymbolTable.size())
+  OS << formatv("\n  Symbol table offset = {0:x}, size = {1}, filled slots:",
+                SymbolTableOffset, (uint64_t)SymbolTable.size())
      << '\n';
 
   const auto FindCuVectorId = [&](uint32_t VecOffset) {
@@ -79,26 +78,26 @@ void DWARFGdbIndex::dumpSymbolTable(raw_ostream &OS) const {
     if (!E.NameOffset && !E.VecOffset)
       continue;
 
-    OS << format("    %d: Name offset = 0x%x, CU vector offset = 0x%x\n", I,
-                 E.NameOffset, E.VecOffset);
+    OS << formatv("    {0}: Name offset = {1:x}, CU vector offset = {2:x}\n", I,
+                  E.NameOffset, E.VecOffset);
 
     StringRef Name = ConstantPoolStrings.substr(
         ConstantPoolOffset - StringPoolOffset + E.NameOffset);
 
     const uint32_t CuVectorId = FindCuVectorId(E.VecOffset);
-    OS << format("      String name: %s, CU vector index: %d\n", Name.data(),
-                 CuVectorId);
+    OS << formatv("      String name: {0}, CU vector index: {1}\n", Name.data(),
+                  CuVectorId);
   }
 }
 
 void DWARFGdbIndex::dumpConstantPool(raw_ostream &OS) const {
-  OS << format("\n  Constant pool offset = 0x%x, has %" PRId64 " CU vectors:",
-               ConstantPoolOffset, (uint64_t)ConstantPoolVectors.size());
+  OS << formatv("\n  Constant pool offset = {0:x}, has {1} CU vectors:",
+                ConstantPoolOffset, (uint64_t)ConstantPoolVectors.size());
   uint32_t I = 0;
   for (const auto &V : ConstantPoolVectors) {
-    OS << format("\n    %d(0x%x): ", I++, V.first);
+    OS << formatv("\n    {0}({1:x}): ", I++, V.first);
     for (uint32_t Val : V.second)
-      OS << format("0x%x ", Val);
+      OS << formatv("{0:x} ", Val);
   }
   OS << '\n';
 }

--- a/llvm/lib/DebugInfo/DWARF/DWARFListTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFListTable.cpp
@@ -12,6 +12,8 @@
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
@@ -78,25 +80,26 @@ Error DWARFListTableHeader::extract(DWARFDataExtractor Data,
 void DWARFListTableHeader::dump(DataExtractor Data, raw_ostream &OS,
                                 DIDumpOptions DumpOpts) const {
   if (DumpOpts.Verbose)
-    OS << format("0x%8.8" PRIx64 ": ", HeaderOffset);
+    OS << formatv("{0:x8}: ", HeaderOffset);
   int OffsetDumpWidth = 2 * dwarf::getDwarfOffsetByteSize(Format);
-  OS << format("%s list header: length = 0x%0*" PRIx64, ListTypeString.data(),
-               OffsetDumpWidth, HeaderData.Length)
+  OS << formatv("{0} list header: length = 0x{1:x-}", ListTypeString.data(),
+                fmt_align(HeaderData.Length, AlignStyle::Right, OffsetDumpWidth,
+                          '0'))
      << ", format = " << dwarf::FormatString(Format)
-     << format(", version = 0x%4.4" PRIx16 ", addr_size = 0x%2.2" PRIx8
-               ", seg_size = 0x%2.2" PRIx8
-               ", offset_entry_count = 0x%8.8" PRIx32 "\n",
-               HeaderData.Version, HeaderData.AddrSize, HeaderData.SegSize,
-               HeaderData.OffsetEntryCount);
+     << formatv(", version = {0:x4}, addr_size = {1:x2}"
+                ", seg_size = {2:x2}"
+                ", offset_entry_count = {3:x8}\n",
+                HeaderData.Version, HeaderData.AddrSize, HeaderData.SegSize,
+                HeaderData.OffsetEntryCount);
 
   if (HeaderData.OffsetEntryCount > 0) {
     OS << "offsets: [";
     for (uint32_t I = 0; I < HeaderData.OffsetEntryCount; ++I) {
       auto Off = *getOffsetEntry(Data, I);
-      OS << format("\n0x%0*" PRIx64, OffsetDumpWidth, Off);
+      OS << formatv("\n0x{0:x-}",
+                    fmt_align(Off, AlignStyle::Right, OffsetDumpWidth, '0'));
       if (DumpOpts.Verbose)
-        OS << format(" => 0x%08" PRIx64,
-                     Off + HeaderOffset + getHeaderSize(Format));
+        OS << formatv(" => {0:x8}", Off + HeaderOffset + getHeaderSize(Format));
     }
     OS << "\n]\n";
   }

--- a/llvm/lib/DebugInfo/DWARF/DWARFTypeUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFTypeUnit.cpp
@@ -10,6 +10,8 @@
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFDie.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cinttypes>
 
@@ -22,27 +24,30 @@ void DWARFTypeUnit::dump(raw_ostream &OS, DIDumpOptions DumpOpts) {
 
   if (DumpOpts.SummarizeTypes) {
     OS << "name = '" << Name << "'"
-       << ", type_signature = " << format("0x%016" PRIx64, getTypeHash())
-       << ", length = " << format("0x%0*" PRIx64, OffsetDumpWidth, getLength())
+       << ", type_signature = " << formatv("{0:x16}", getTypeHash())
+       << ", length = "
+       << formatv("0x{0:x-}", fmt_align(getLength(), AlignStyle::Right,
+                                        OffsetDumpWidth, '0'))
        << '\n';
     return;
   }
 
-  OS << format("0x%08" PRIx64, getOffset()) << ": Type Unit:"
-     << " length = " << format("0x%0*" PRIx64, OffsetDumpWidth, getLength())
+  OS << formatv("{0:x8}", getOffset()) << ": Type Unit:"
+     << " length = "
+     << formatv("0x{0:x-}",
+                fmt_align(getLength(), AlignStyle::Right, OffsetDumpWidth, '0'))
      << ", format = " << dwarf::FormatString(getFormat())
-     << ", version = " << format("0x%04x", getVersion());
+     << ", version = " << formatv("{0:x4}", getVersion());
   if (getVersion() >= 5)
     OS << ", unit_type = " << dwarf::UnitTypeString(getUnitType());
-  OS << ", abbr_offset = " << format("0x%04" PRIx64, getAbbrOffset());
+  OS << ", abbr_offset = " << formatv("{0:x4}", getAbbrOffset());
   if (!getAbbreviations())
     OS << " (invalid)";
-  OS << ", addr_size = " << format("0x%02x", getAddressByteSize())
+  OS << ", addr_size = " << formatv("{0:x2}", getAddressByteSize())
      << ", name = '" << Name << "'"
-     << ", type_signature = " << format("0x%016" PRIx64, getTypeHash())
-     << ", type_offset = " << format("0x%04" PRIx64, getTypeOffset())
-     << " (next unit at " << format("0x%08" PRIx64, getNextUnitOffset())
-     << ")\n";
+     << ", type_signature = " << formatv("{0:x16}", getTypeHash())
+     << ", type_offset = " << formatv("{0:x4}", getTypeOffset())
+     << " (next unit at " << formatv("{0:x8}", getNextUnitOffset()) << ")\n";
 
   if (DWARFDie TU = getUnitDIE(false))
     TU.dump(OS, 0, DumpOpts);

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnitIndex.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnitIndex.cpp
@@ -12,6 +12,7 @@
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cinttypes>
 #include <cstdint>
@@ -113,7 +114,8 @@ bool DWARFUnitIndex::Header::parse(DataExtractor IndexData,
 }
 
 void DWARFUnitIndex::Header::dump(raw_ostream &OS) const {
-  OS << format("version = %u, units = %u, slots = %u\n\n", Version, NumUnits, NumBuckets);
+  OS << formatv("version = {0}, units = {1}, slots = {2}\n\n", Version,
+                NumUnits, NumBuckets);
 }
 
 bool DWARFUnitIndex::parse(DataExtractor IndexData) {
@@ -226,7 +228,7 @@ void DWARFUnitIndex::dump(raw_ostream &OS) const {
          << left_justify(Name,
                          Kind == DWARFSectionKind::DW_SECT_INFO ? 40 : 24);
     else
-      OS << format(" Unknown: %-15" PRIu32, RawSectionIds[i]);
+      OS << formatv(" Unknown: {0, -15}", RawSectionIds[i]);
   }
   OS << "\n----- ------------------";
   for (unsigned i = 0; i != Header.NumColumns; ++i) {
@@ -241,19 +243,17 @@ void DWARFUnitIndex::dump(raw_ostream &OS) const {
   for (unsigned i = 0; i != Header.NumBuckets; ++i) {
     auto &Row = Rows[i];
     if (auto *Contribs = Row.Contributions.get()) {
-      OS << format("%5u 0x%016" PRIx64 " ", i + 1, Row.Signature);
+      OS << formatv("{0,5} {1:x16} ", i + 1, Row.Signature);
       for (unsigned i = 0; i != Header.NumColumns; ++i) {
         auto &Contrib = Contribs[i];
         DWARFSectionKind Kind = ColumnKinds[i];
         if (Kind == DWARFSectionKind::DW_SECT_INFO ||
             Kind == DWARFSectionKind::DW_SECT_EXT_TYPES)
-          OS << format("[0x%016" PRIx64 ", 0x%016" PRIx64 ") ",
-                       Contrib.getOffset(),
-                       Contrib.getOffset() + Contrib.getLength());
+          OS << formatv("[{0:x16}, {1:x16}) ", Contrib.getOffset(),
+                        Contrib.getOffset() + Contrib.getLength());
         else
-          OS << format("[0x%08" PRIx32 ", 0x%08" PRIx32 ") ",
-                       Contrib.getOffset32(),
-                       Contrib.getOffset32() + Contrib.getLength32());
+          OS << formatv("[{0:x8}, {1:x8}) ", Contrib.getOffset32(),
+                        Contrib.getOffset32() + Contrib.getLength32());
       }
       OS << '\n';
     }

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnwindTablePrinter.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnwindTablePrinter.cpp
@@ -12,6 +12,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFExpressionPrinter.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <cinttypes>
@@ -153,7 +154,7 @@ static void printUnwindRow(const UnwindRow &Row, raw_ostream &OS,
                            DIDumpOptions DumpOpts, unsigned IndentLevel) {
   OS.indent(2 * IndentLevel);
   if (Row.hasAddress())
-    OS << format("0x%" PRIx64 ": ", Row.getAddress());
+    OS << formatv("{0:x}: ", Row.getAddress());
   OS << "CFA=";
   printUnwindLocation(Row.getCFAValue(), OS, DumpOpts);
   if (Row.getRegisterLocations().hasLocations()) {

--- a/llvm/unittests/Support/FormatVariadicTest.cpp
+++ b/llvm/unittests/Support/FormatVariadicTest.cpp
@@ -412,8 +412,54 @@ TEST(FormatAndFormatvTest, EquivalentHexFormatting) {
             formatv("0x{0:x-}", fmt_align(N, AlignStyle::Right, HexDigits, '0'))
                 .str());
 
+  // More examples
+
+  EXPECT_EQ("0x0000000abc",
+            printToString(format("0x%0*" PRIx64, 10, 0xABCULL)));
+  EXPECT_EQ("0x0000000abc",
+            formatv("0x{0:x-}", fmt_align(0xABCULL, AlignStyle::Right, 10, '0'))
+                .str());
+
   EXPECT_EQ("0x000000fe", printToString(format("0x%8.8" PRIx64, 0xfeULL)));
   EXPECT_EQ("0x000000fe", formatv("{0:x+8}", 0xfeULL).str());
+  EXPECT_EQ("0x000000fe", formatv("{0:x8}", 0xfeULL).str());
+
+  EXPECT_EQ("000000fe", printToString(format("%08" PRIx64, 0xfeULL)));
+  EXPECT_EQ("000000fe", formatv("{0:x-8}", 0xfeULL).str());
+
+  EXPECT_EQ("0x000000fb", printToString(format("0x%08.08" PRIx64, 0xfbULL)));
+  EXPECT_EQ("0x000000fb", formatv("{0:x+8}", 0xfbULL).str());
+
+  EXPECT_EQ("123", printToString(format("%x", 0x123)));
+  EXPECT_EQ("123", formatv("{0:x-}", 0x123).str());
+}
+
+TEST(FormatAndFormatvTest, StringPadding) {
+  // The expected string has 9 spaces after "abcd" and a closing bracket.
+  EXPECT_EQ("[abcd         ]",
+            printToString(format("[%s%*c", "abcd", 10, ']')));
+  // With formatv we can use padding but the closing bracket can be included in
+  // the format string and the padding needs to be one off.
+  EXPECT_EQ("[abcd         ]",
+            formatv("[{0}]", fmt_pad("abcd", 0, 10 - 1)).str());
+}
+
+TEST(FormatAndFormatvTest, Alignment) {
+  EXPECT_EQ("250            ", printToString(format("%-15" PRIu32, 0xfa)));
+  EXPECT_EQ("250            ", formatv("{0, -15}", 0xfa).str());
+  EXPECT_EQ("250            ",
+            formatv("{0}", fmt_align(0xfa, AlignStyle::Left, 15)).str());
+
+  EXPECT_EQ("  123", printToString(format("%5u", 123)));
+  EXPECT_EQ("  123", formatv("{0,5:d}", 123).str());
+  EXPECT_EQ("  123",
+            formatv("{0}", fmt_align(123, AlignStyle::Right, 5)).str());
+
+  EXPECT_EQ("001", printToString(format("%03d", 1)));
+  EXPECT_EQ("001", formatv("{0,0+3}", 1).str());
+
+  EXPECT_EQ("foo      ", printToString(format("%-9s", "foo")));
+  EXPECT_EQ("foo      ", formatv("{0,-9}", "foo").str());
 }
 
 TEST(FormatAndFormatvTest, NonNegativePlusInteger) {


### PR DESCRIPTION
This addresses all use-cases in `llvm/lib/DebugInfo/DWARF`.

I've included some test cases to show how to use `formatv()` in order to get the same results as with `format()`.

This relates to #35980.