### PR TITLE
[flang] Make more [HL]FIR operations Pure.

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -3605,7 +3605,7 @@ def fir_DeclareValueOp
   let hasVerifier = 1;
 }
 
-def fir_BoxOffsetOp : fir_Op<"box_offset", [NoMemoryEffect]> {
+def fir_BoxOffsetOp : fir_Op<"box_offset", [Pure]> {
 
   let summary = "Get the address of a field in a fir.ref<fir.box>";
 

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -549,7 +549,7 @@ def fir_UndefOp : fir_OneResultOp<"undefined", [Pure]> {
   let hasVerifier = 0;
 }
 
-def fir_ZeroOp : fir_OneResultOp<"zero_bits", [NoMemoryEffect]> {
+def fir_ZeroOp : fir_OneResultOp<"zero_bits", [Pure]> {
   let summary = "explicit polymorphic zero value of some type";
   let description = [{
     Constructs an ssa-value of the specified type with a value of zero for all

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1965,7 +1965,7 @@ def fir_CoordinateOp
   }];
 }
 
-def fir_ExtractValueOp : fir_OneResultOp<"extract_value", [NoMemoryEffect]> {
+def fir_ExtractValueOp : fir_OneResultOp<"extract_value", [Pure]> {
   let summary = "Extract a value from an aggregate SSA-value";
 
   let description = [{

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1333,7 +1333,7 @@ def fir_IsAssumedSizeOp : fir_SimpleOp<"is_assumed_size", [NoMemoryEffect]> {
   let results = (outs BoolLike);
 }
 
-def fir_AssumedSizeExtentOp : fir_SimpleOneResultOp<"assumed_size_extent", [NoMemoryEffect]> {
+def fir_AssumedSizeExtentOp : fir_SimpleOneResultOp<"assumed_size_extent", [Pure]> {
   let summary = "get the assumed-size last extent sentinel";
 
   let description = [{

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1030,7 +1030,7 @@ def fir_ReboxAssumedRankOp : fir_Op<"rebox_assumed_rank",
   let hasVerifier = 1;
 }
 
-def fir_EmboxCharOp : fir_Op<"emboxchar", [NoMemoryEffect]> {
+def fir_EmboxCharOp : fir_Op<"emboxchar", [Pure]> {
   let summary = "boxes a given CHARACTER reference and its LEN parameter";
 
   let description = [{

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1351,7 +1351,7 @@ def fir_AssumedSizeExtentOp : fir_SimpleOneResultOp<"assumed_size_extent", [Pure
   let assemblyFormat = "attr-dict `:` type(results)";
 }
 
-def fir_IsAssumedSizeExtentOp : fir_SimpleOp<"is_assumed_size_extent", [NoMemoryEffect]> {
+def fir_IsAssumedSizeExtentOp : fir_SimpleOp<"is_assumed_size_extent", [Pure]> {
   let summary = "is value the assumed-size last extent sentinel";
 
   let description = [{

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -3085,7 +3085,7 @@ def FortranTypeAttr : Attr<And<[CPred<"mlir::isa<mlir::TypeAttr>($_self)">,
   let convertFromStorage = "mlir::cast<mlir::Type>($_self.getValue())";
 }
 
-def fir_TypeDescOp : fir_OneResultOp<"type_desc", [NoMemoryEffect]> {
+def fir_TypeDescOp : fir_OneResultOp<"type_desc", [Pure]> {
   let summary = "get type descriptor for a given type";
   let description = [{
     Generates a constant object that is an abstract type descriptor of the

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -3106,7 +3106,7 @@ def fir_TypeDescOp : fir_OneResultOp<"type_desc", [Pure]> {
 }
 
 def fir_NoReassocOp : fir_OneResultOp<"no_reassoc",
-    [NoMemoryEffect, SameOperandsAndResultType]> {
+    [Pure, SameOperandsAndResultType]> {
   let summary = "synthetic op to prevent reassociation";
   let description = [{
     Primitive operation meant to intrusively prevent operator reassociation.

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -526,7 +526,7 @@ def fir_CharConvertOp : fir_Op<"char_convert", []> {
   let hasVerifier = 1;
 }
 
-def fir_UndefOp : fir_OneResultOp<"undefined", [NoMemoryEffect]> {
+def fir_UndefOp : fir_OneResultOp<"undefined", [Pure]> {
   let summary = "explicit undefined value of some type";
   let description = [{
     Constructs an ssa-value of the specified type with an undefined value.
@@ -2199,7 +2199,7 @@ def fir_SliceOp : fir_Op<"slice", [Pure, AttrSizedOperandSegments]> {
   }];
 }
 
-def fir_InsertValueOp : fir_OneResultOp<"insert_value", [NoMemoryEffect]> {
+def fir_InsertValueOp : fir_OneResultOp<"insert_value", [Pure]> {
   let summary = "insert a new sub-value into a copy of an existing aggregate";
 
   let description = [{

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -3444,7 +3444,7 @@ def fir_DTComponentOp : fir_Op<"dt_component", [HasParent<"TypeInfoOp">]> {
   let assemblyFormat = "$name (`lbs` $lower_bounds^)? (`init` $init_val^)? attr-dict";
 }
 
-def fir_AbsentOp : fir_OneResultOp<"absent", [NoMemoryEffect]> {
+def fir_AbsentOp : fir_OneResultOp<"absent", [Pure]> {
   let summary = "create value to be passed for absent optional function argument";
   let description = [{
     Given the type of a function argument, create a value that will signal that

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2755,7 +2755,7 @@ def fir_DispatchOp : fir_Op<"dispatch", []> {
 
 // Constant operations that support Fortran
 
-def fir_StringLitOp : fir_Op<"string_lit", [NoMemoryEffect]> {
+def fir_StringLitOp : fir_Op<"string_lit", [Pure]> {
   let summary = "create a string literal constant";
 
   let description = [{

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2955,7 +2955,7 @@ def fir_CmpcOp : fir_Op<"cmpc",
 
 // Other misc. operations
 
-def fir_AddrOfOp : fir_OneResultOp<"address_of", [NoMemoryEffect]> {
+def fir_AddrOfOp : fir_OneResultOp<"address_of", [Pure]> {
   let summary = "convert a symbol to an SSA value";
 
   let description = [{

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2231,7 +2231,7 @@ def fir_InsertValueOp : fir_OneResultOp<"insert_value", [Pure]> {
   let hasCanonicalizer = 1;
 }
 
-def fir_InsertOnRangeOp : fir_OneResultOp<"insert_on_range", [NoMemoryEffect]> {
+def fir_InsertOnRangeOp : fir_OneResultOp<"insert_on_range", [Pure]> {
   let summary = "insert sub-value into a range on an existing sequence";
 
   let description = [{

--- a/flang/include/flang/Optimizer/HLFIR/HLFIROps.td
+++ b/flang/include/flang/Optimizer/HLFIR/HLFIROps.td
@@ -1184,7 +1184,7 @@ def hlfir_ApplyOp : hlfir_Op<"apply", [NoMemoryEffect, AttrSizedOperandSegments]
   ];
 }
 
-def hlfir_NullOp : hlfir_Op<"null", [NoMemoryEffect, fir_FortranVariableOpInterface]> {
+def hlfir_NullOp : hlfir_Op<"null", [Pure, fir_FortranVariableOpInterface]> {
   let summary = "create a NULL() address";
 
   let description = [{

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2597,3 +2597,21 @@ func.func @test_hoist_absent(%arg0: !fir.ref<!fir.box<!fir.array<?xf32>>>) {
   }
   return
 }
+
+// -----
+// Test that fir.box_offset is hoisted as a pure operation.
+// CHECK-LABEL:   func.func @test_hoist_box_offset(
+// CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>>,
+// CHECK-SAME:      %[[ARG1:.*]]: !fir.ref<!fir.llvm_ptr<!fir.ref<i32>>>)
+// CHECK:           %[[OFF:.*]] = fir.box_offset %[[ARG0]] base_addr : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.llvm_ptr<!fir.ref<i32>>
+// CHECK:           fir.do_loop
+// CHECK:             fir.store %[[OFF]] to %[[ARG1]] : !fir.ref<!fir.llvm_ptr<!fir.ref<i32>>>
+func.func @test_hoist_box_offset(%arg0: !fir.ref<!fir.box<!fir.heap<i32>>>, %arg1: !fir.ref<!fir.llvm_ptr<!fir.ref<i32>>>) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg2 = %c1 to %c10 step %c1 {
+    %0 = fir.box_offset %arg0 base_addr : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.llvm_ptr<!fir.ref<i32>>
+    fir.store %0 to %arg1 : !fir.ref<!fir.llvm_ptr<!fir.ref<i32>>>
+  }
+  return
+}

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2506,3 +2506,23 @@ func.func @test_hoist_extract_value(%arg0: !fir.type<derived{f:f32}>, %arg1: !fi
   }
   return
 }
+
+// -----
+// Test that fir.insert_on_range is hoisted as a pure operation.
+// CHECK-LABEL:   func.func @test_hoist_insert_on_range(
+// CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<!fir.array<10xi32>>)
+// CHECK:           %[[C1:.*]] = arith.constant 1 : i32
+// CHECK:           %[[ARR:.*]] = fir.zero_bits !fir.array<10xi32>
+// CHECK:           %[[INS:.*]] = fir.insert_on_range %[[ARR]], %[[C1]] from (0) to (9) : (!fir.array<10xi32>, i32) -> !fir.array<10xi32>
+// CHECK:           fir.do_loop
+func.func @test_hoist_insert_on_range(%arg0: !fir.ref<!fir.array<10xi32>>) {
+  %c1_i32 = arith.constant 1 : i32
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg1 = %c1 to %c10 step %c1 {
+    %0 = fir.zero_bits !fir.array<10xi32>
+    %1 = fir.insert_on_range %0, %c1_i32 from (0) to (9) : (!fir.array<10xi32>, i32) -> !fir.array<10xi32>
+    fir.store %1 to %arg0 : !fir.ref<!fir.array<10xi32>>
+  }
+  return
+}

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2543,3 +2543,21 @@ func.func @test_hoist_string_lit(%arg0: !fir.ref<!fir.char<1,5>>) {
   }
   return
 }
+
+// -----
+// Test that fir.address_of is hoisted as a pure operation.
+// CHECK-LABEL:   func.func @test_hoist_address_of(
+// CHECK-SAME:      %[[ARG0:.*]]: f32)
+// CHECK:           %[[ADDR:.*]] = fir.address_of(@_QMtestEglobal) : !fir.ref<f32>
+// CHECK:           fir.do_loop
+// CHECK:             fir.store %[[ARG0]] to %[[ADDR]] : !fir.ref<f32>
+fir.global @_QMtestEglobal : f32
+func.func @test_hoist_address_of(%arg0: f32) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg1 = %c1 to %c10 step %c1 {
+    %0 = fir.address_of(@_QMtestEglobal) : !fir.ref<f32>
+    fir.store %arg0 to %0 : !fir.ref<f32>
+  }
+  return
+}

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2488,3 +2488,21 @@ func.func @test_hoist_emboxchar(%arg0: !fir.ref<!fir.char<1>>, %arg1: i32, %arg2
   }
   return
 }
+
+// -----
+// Test that fir.extract_value is hoisted as a pure operation.
+// CHECK-LABEL:   func.func @test_hoist_extract_value(
+// CHECK-SAME:      %[[ARG0:.*]]: !fir.type<derived{f:f32}>,
+// CHECK-SAME:      %[[ARG1:.*]]: !fir.ref<f32>)
+// CHECK:           %[[EV:.*]] = fir.extract_value %[[ARG0]], ["f", !fir.type<derived{f:f32}>] : (!fir.type<derived{f:f32}>) -> f32
+// CHECK:           fir.do_loop
+// CHECK:             fir.store %[[EV]] to %[[ARG1]] : !fir.ref<f32>
+func.func @test_hoist_extract_value(%arg0: !fir.type<derived{f:f32}>, %arg1: !fir.ref<f32>) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg2 = %c1 to %c10 step %c1 {
+    %0 = fir.extract_value %arg0, ["f", !fir.type<derived{f:f32}>] : (!fir.type<derived{f:f32}>) -> f32
+    fir.store %0 to %arg1 : !fir.ref<f32>
+  }
+  return
+}

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2428,3 +2428,27 @@ func.func @test_omp_wsloop_nested_canMoveFromDescendant(%arg0: !fir.ref<!fir.arr
   }
   return
 }
+
+// -----
+// Test that fir.undefined and fir.insert_value (used for complex constant
+// creation) are hoisted out of loops as pure operations.
+// CHECK-LABEL:   func.func @test_hoist_complex_constant(
+// CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<complex<f32>>)
+// CHECK:           %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[UNDEF:.*]] = fir.undefined complex<f32>
+// CHECK:           %[[INS0:.*]] = fir.insert_value %[[UNDEF]], %[[CST]], [0 : index] : (complex<f32>, f32) -> complex<f32>
+// CHECK:           %[[INS1:.*]] = fir.insert_value %[[INS0]], %[[CST]], [1 : index] : (complex<f32>, f32) -> complex<f32>
+// CHECK:           fir.do_loop
+// CHECK:             fir.store %[[INS1]] to %[[ARG0]] : !fir.ref<complex<f32>>
+func.func @test_hoist_complex_constant(%arg0: !fir.ref<complex<f32>>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg1 = %c1 to %c10 step %c1 {
+    %0 = fir.undefined complex<f32>
+    %1 = fir.insert_value %0, %cst, [0 : index] : (complex<f32>, f32) -> complex<f32>
+    %2 = fir.insert_value %1, %cst, [1 : index] : (complex<f32>, f32) -> complex<f32>
+    fir.store %2 to %arg0 : !fir.ref<complex<f32>>
+  }
+  return
+}

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2452,3 +2452,20 @@ func.func @test_hoist_complex_constant(%arg0: !fir.ref<complex<f32>>) {
   }
   return
 }
+
+// -----
+// Test that fir.zero_bits is hoisted as a pure operation.
+// CHECK-LABEL:   func.func @test_hoist_zero_bits(
+// CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<!fir.ptr<f32>>)
+// CHECK:           %[[ZERO:.*]] = fir.zero_bits !fir.ptr<f32>
+// CHECK:           fir.do_loop
+// CHECK:             fir.store %[[ZERO]] to %[[ARG0]] : !fir.ref<!fir.ptr<f32>>
+func.func @test_hoist_zero_bits(%arg0: !fir.ref<!fir.ptr<f32>>) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg1 = %c1 to %c10 step %c1 {
+    %0 = fir.zero_bits !fir.ptr<f32>
+    fir.store %0 to %arg0 : !fir.ref<!fir.ptr<f32>>
+  }
+  return
+}

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2580,3 +2580,20 @@ func.func @test_hoist_type_desc(%arg0: !fir.ref<i64>) {
   }
   return
 }
+
+// -----
+// Test that fir.absent is hoisted as a pure operation.
+// CHECK-LABEL:   func.func @test_hoist_absent(
+// CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.array<?xf32>>>)
+// CHECK:           %[[ABS:.*]] = fir.absent !fir.box<!fir.array<?xf32>>
+// CHECK:           fir.do_loop
+// CHECK:             fir.store %[[ABS]] to %[[ARG0]] : !fir.ref<!fir.box<!fir.array<?xf32>>>
+func.func @test_hoist_absent(%arg0: !fir.ref<!fir.box<!fir.array<?xf32>>>) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg1 = %c1 to %c10 step %c1 {
+    %0 = fir.absent !fir.box<!fir.array<?xf32>>
+    fir.store %0 to %arg0 : !fir.ref<!fir.box<!fir.array<?xf32>>>
+  }
+  return
+}

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2615,3 +2615,20 @@ func.func @test_hoist_box_offset(%arg0: !fir.ref<!fir.box<!fir.heap<i32>>>, %arg
   }
   return
 }
+
+// -----
+// Test that fir.assumed_size_extent is hoisted as a pure operation.
+// CHECK-LABEL:   func.func @test_hoist_assumed_size_extent(
+// CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<index>)
+// CHECK:           %[[EXT:.*]] = fir.assumed_size_extent : index
+// CHECK:           fir.do_loop
+// CHECK:             fir.store %[[EXT]] to %[[ARG0]] : !fir.ref<index>
+func.func @test_hoist_assumed_size_extent(%arg0: !fir.ref<index>) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg1 = %c1 to %c10 step %c1 {
+    %0 = fir.assumed_size_extent : index
+    fir.store %0 to %arg0 : !fir.ref<index>
+  }
+  return
+}

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2632,3 +2632,21 @@ func.func @test_hoist_assumed_size_extent(%arg0: !fir.ref<index>) {
   }
   return
 }
+
+// -----
+// Test that fir.is_assumed_size_extent is hoisted as a pure operation.
+// CHECK-LABEL:   func.func @test_hoist_is_assumed_size_extent(
+// CHECK-SAME:      %[[ARG0:.*]]: index,
+// CHECK-SAME:      %[[ARG1:.*]]: !fir.ref<i1>)
+// CHECK:           %[[RES:.*]] = fir.is_assumed_size_extent %[[ARG0]] : (index) -> i1
+// CHECK:           fir.do_loop
+// CHECK:             fir.store %[[RES]] to %[[ARG1]] : !fir.ref<i1>
+func.func @test_hoist_is_assumed_size_extent(%arg0: index, %arg1: !fir.ref<i1>) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg2 = %c1 to %c10 step %c1 {
+    %0 = fir.is_assumed_size_extent %arg0 : (index) -> i1
+    fir.store %0 to %arg1 : !fir.ref<i1>
+  }
+  return
+}

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2561,3 +2561,22 @@ func.func @test_hoist_address_of(%arg0: f32) {
   }
   return
 }
+
+// -----
+// Test that fir.type_desc is hoisted as a pure operation.
+// CHECK-LABEL:   func.func @test_hoist_type_desc(
+// CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<i64>)
+// CHECK:           %[[TD:.*]] = fir.type_desc !fir.type<t>
+// CHECK:           %[[CVT:.*]] = fir.convert %[[TD]] : (!fir.tdesc<!fir.type<t>>) -> i64
+// CHECK:           fir.do_loop
+// CHECK:             fir.store %[[CVT]] to %[[ARG0]] : !fir.ref<i64>
+func.func @test_hoist_type_desc(%arg0: !fir.ref<i64>) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg1 = %c1 to %c10 step %c1 {
+    %0 = fir.type_desc !fir.type<t>
+    %1 = fir.convert %0 : (!fir.tdesc<!fir.type<t>>) -> i64
+    fir.store %1 to %arg0 : !fir.ref<i64>
+  }
+  return
+}

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2650,3 +2650,21 @@ func.func @test_hoist_is_assumed_size_extent(%arg0: index, %arg1: !fir.ref<i1>) 
   }
   return
 }
+
+// -----
+// Test that fir.no_reassoc is hoisted as a pure operation.
+// CHECK-LABEL:   func.func @test_hoist_no_reassoc(
+// CHECK-SAME:      %[[ARG0:.*]]: f64,
+// CHECK-SAME:      %[[ARG1:.*]]: !fir.ref<f64>)
+// CHECK:           %[[NR:.*]] = fir.no_reassoc %[[ARG0]] : f64
+// CHECK:           fir.do_loop
+// CHECK:             fir.store %[[NR]] to %[[ARG1]] : !fir.ref<f64>
+func.func @test_hoist_no_reassoc(%arg0: f64, %arg1: !fir.ref<f64>) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg2 = %c1 to %c10 step %c1 {
+    %0 = fir.no_reassoc %arg0 : f64
+    fir.store %0 to %arg1 : !fir.ref<f64>
+  }
+  return
+}

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2668,3 +2668,22 @@ func.func @test_hoist_no_reassoc(%arg0: f64, %arg1: !fir.ref<f64>) {
   }
   return
 }
+
+// -----
+// Test that hlfir.null is hoisted as a pure operation.
+// CHECK-LABEL:   func.func @test_hoist_hlfir_null(
+// CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<i64>)
+// CHECK:           %[[NULL:.*]] = hlfir.null !fir.ref<none>
+// CHECK:           %[[CVT:.*]] = fir.convert %[[NULL]] : (!fir.ref<none>) -> i64
+// CHECK:           fir.do_loop
+// CHECK:             fir.store %[[CVT]] to %[[ARG0]] : !fir.ref<i64>
+func.func @test_hoist_hlfir_null(%arg0: !fir.ref<i64>) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg1 = %c1 to %c10 step %c1 {
+    %0 = hlfir.null !fir.ref<none>
+    %1 = fir.convert %0 : (!fir.ref<none>) -> i64
+    fir.store %1 to %arg0 : !fir.ref<i64>
+  }
+  return
+}

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2469,3 +2469,22 @@ func.func @test_hoist_zero_bits(%arg0: !fir.ref<!fir.ptr<f32>>) {
   }
   return
 }
+
+// -----
+// Test that fir.emboxchar is hoisted as a pure operation.
+// CHECK-LABEL:   func.func @test_hoist_emboxchar(
+// CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<!fir.char<1>>,
+// CHECK-SAME:      %[[ARG1:.*]]: i32,
+// CHECK-SAME:      %[[ARG2:.*]]: !fir.ref<!fir.boxchar<1>>)
+// CHECK:           %[[BC:.*]] = fir.emboxchar %[[ARG0]], %[[ARG1]] : (!fir.ref<!fir.char<1>>, i32) -> !fir.boxchar<1>
+// CHECK:           fir.do_loop
+// CHECK:             fir.store %[[BC]] to %[[ARG2]] : !fir.ref<!fir.boxchar<1>>
+func.func @test_hoist_emboxchar(%arg0: !fir.ref<!fir.char<1>>, %arg1: i32, %arg2: !fir.ref<!fir.boxchar<1>>) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg3 = %c1 to %c10 step %c1 {
+    %0 = fir.emboxchar %arg0, %arg1 : (!fir.ref<!fir.char<1>>, i32) -> !fir.boxchar<1>
+    fir.store %0 to %arg2 : !fir.ref<!fir.boxchar<1>>
+  }
+  return
+}

--- a/flang/test/Transforms/licm.fir
+++ b/flang/test/Transforms/licm.fir
@@ -2526,3 +2526,20 @@ func.func @test_hoist_insert_on_range(%arg0: !fir.ref<!fir.array<10xi32>>) {
   }
   return
 }
+
+// -----
+// Test that fir.string_lit is hoisted as a pure operation.
+// CHECK-LABEL:   func.func @test_hoist_string_lit(
+// CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<!fir.char<1,5>>)
+// CHECK:           %[[STR:.*]] = fir.string_lit "hello"(5) : !fir.char<1,5>
+// CHECK:           fir.do_loop
+// CHECK:             fir.store %[[STR]] to %[[ARG0]] : !fir.ref<!fir.char<1,5>>
+func.func @test_hoist_string_lit(%arg0: !fir.ref<!fir.char<1,5>>) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  fir.do_loop %arg1 = %c1 to %c10 step %c1 {
+    %0 = fir.string_lit "hello"(5) : !fir.char<1,5>
+    fir.store %0 to %arg0 : !fir.ref<!fir.char<1,5>>
+  }
+  return
+}


### PR DESCRIPTION
This patch addresses cases where an operation seems obviously Pure to me.

Made-with: Cursor