### PR TITLE
[Clang] Pass toolchain paths unconditionally in linker wrapper

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9391,8 +9391,6 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
   // compilation job.
   const llvm::DenseSet<unsigned> CompilerOptions{
       OPT_v,
-      OPT_cuda_path_EQ,
-      OPT_rocm_path_EQ,
       OPT_hip_path_EQ,
       OPT_O_Group,
       OPT_g_Group,
@@ -9549,9 +9547,16 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
   // also `ld.lld`.
   if (Args.hasArg(options::OPT_v) && JA.getType() != types::TY_HIP_FATBIN)
     CmdArgs.push_back("--wrapper-verbose");
-  if (Arg *A = Args.getLastArg(options::OPT_cuda_path_EQ))
+  if (Arg *A = Args.getLastArg(options::OPT_cuda_path_EQ)) {
     CmdArgs.push_back(
         Args.MakeArgString(Twine("--cuda-path=") + A->getValue()));
+    CmdArgs.push_back(Args.MakeArgString(
+        Twine("--device-compiler=--cuda-path=") + A->getValue()));
+  }
+  if (Arg *A = Args.getLastArg(options::OPT_rocm_path_EQ)) {
+    CmdArgs.push_back(Args.MakeArgString(
+        Twine("--device-compiler=--rocm-path=") + A->getValue()));
+  }
 
   // Construct the link job so we can wrap around it.
   Linker->ConstructJob(C, JA, Output, Inputs, Args, LinkingOutput);

--- a/clang/test/Driver/openmp-offload-gpu.c
+++ b/clang/test/Driver/openmp-offload-gpu.c
@@ -428,3 +428,12 @@
 // RUN:   | FileCheck --check-prefix=NO-PROFILE %s
 //
 // NO-PROFILE-NOT: --device-compiler=amdgcn-amd-amdhsa=-fprofile-generate
+
+//
+// Check that --cuda-path and --rocm-path are forwarded unconditionally
+//
+// RUN:   %clang -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp \
+// RUN:     --cuda-path=%S/Inputs/CUDA_102/usr/local/cuda --rocm-path=%S/Inputs/rocm \
+// RUN:     --offload-arch=sm_89 --offload-arch=gfx906 -nogpulib -nogpuinc %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CUDA-PATH %s
+// CUDA-PATH: clang-linker-wrapper{{.*}} "--device-compiler=--cuda-path={{.*}}"{{.*}}"--device-compiler=--rocm-path={{.*}}"


### PR DESCRIPTION
Summary:
Previously we used the auto-forwarding mechanism to handle options like
forwarding --cuda-path. The problem is that this went over the toolchain
options and that meant if someone used just bare `--offload-link` there
would be no CUDA or ROCm toolchain to figure out if we should forward
it. Just do this unconditionally for all toolchains, there's no harm in
setting it if it's unused.

Fixes: https://github.com/llvm/llvm-project/issues/190979
