### PR TITLE
[flang][acc] Fix collapse(force:N) + reduction producing redundant inner loop

### DIFF
--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -110,6 +110,12 @@ getCollapseSizeAndForce(const Fortran::parser::AccClauseList &);
 /// Checks whether the current insertion point is inside OpenACC loop.
 bool isInOpenACCLoop(fir::FirOpBuilder &);
 
+/// Checks whether the current insertion point is inside a collapsed acc.loop
+/// and there are still collapsed dimensions to consume (i.e., this do-loop
+/// should not generate a separate loop because the parent already distributes
+/// this dimension).
+bool isInsideCollapsedACCLoop(fir::FirOpBuilder &);
+
 /// Checks whether the current insertion point is inside OpenACC compute
 /// construct.
 bool isInsideOpenACCComputeConstruct(fir::FirOpBuilder &);

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -6285,29 +6285,29 @@ private:
   // calls does block management, possibly starting a new block, and possibly
   // generating a branch to end a block. So these calls may still be required
   // for that functionality.
-  void genFIR(const Fortran::parser::AssociateStmt &) {}         // nop
-  void genFIR(const Fortran::parser::BlockStmt &) {}             // nop
-  void genFIR(const Fortran::parser::CaseStmt &) {}              // nop
-  void genFIR(const Fortran::parser::ContinueStmt &) {}          // nop
-  void genFIR(const Fortran::parser::ElseIfStmt &) {}            // nop
-  void genFIR(const Fortran::parser::ElseStmt &) {}              // nop
-  void genFIR(const Fortran::parser::EndAssociateStmt &) {}      // nop
-  void genFIR(const Fortran::parser::EndBlockStmt &) {}          // nop
-  void genFIR(const Fortran::parser::EndDoStmt &) {}             // nop
-  void genFIR(const Fortran::parser::EndFunctionStmt &) {}       // nop
-  void genFIR(const Fortran::parser::EndIfStmt &) {}             // nop
-  void genFIR(const Fortran::parser::EndMpSubprogramStmt &) {}   // nop
-  void genFIR(const Fortran::parser::EndProgramStmt &) {}        // nop
-  void genFIR(const Fortran::parser::EndSelectStmt &) {}         // nop
-  void genFIR(const Fortran::parser::EndSubroutineStmt &) {}     // nop
-  void genFIR(const Fortran::parser::EntryStmt &) {}             // nop
-  void genFIR(const Fortran::parser::IfStmt &) {}                // nop
-  void genFIR(const Fortran::parser::IfThenStmt &) {}            // nop
-  void genFIR(const Fortran::parser::NonLabelDoStmt &) {}        // nop
-  void genFIR(const Fortran::parser::OmpEndLoopDirective &) {}   // nop
-  void genFIR(const Fortran::parser::SelectTypeStmt &) {}        // nop
-  void genFIR(const Fortran::parser::TypeGuardStmt &) {}         // nop
-  void genFIR(const Fortran::parser::ChangeTeamStmt &stmt) {}    // nop
+  void genFIR(const Fortran::parser::AssociateStmt &) {}       // nop
+  void genFIR(const Fortran::parser::BlockStmt &) {}           // nop
+  void genFIR(const Fortran::parser::CaseStmt &) {}            // nop
+  void genFIR(const Fortran::parser::ContinueStmt &) {}        // nop
+  void genFIR(const Fortran::parser::ElseIfStmt &) {}          // nop
+  void genFIR(const Fortran::parser::ElseStmt &) {}            // nop
+  void genFIR(const Fortran::parser::EndAssociateStmt &) {}    // nop
+  void genFIR(const Fortran::parser::EndBlockStmt &) {}        // nop
+  void genFIR(const Fortran::parser::EndDoStmt &) {}           // nop
+  void genFIR(const Fortran::parser::EndFunctionStmt &) {}     // nop
+  void genFIR(const Fortran::parser::EndIfStmt &) {}           // nop
+  void genFIR(const Fortran::parser::EndMpSubprogramStmt &) {} // nop
+  void genFIR(const Fortran::parser::EndProgramStmt &) {}      // nop
+  void genFIR(const Fortran::parser::EndSelectStmt &) {}       // nop
+  void genFIR(const Fortran::parser::EndSubroutineStmt &) {}   // nop
+  void genFIR(const Fortran::parser::EntryStmt &) {}           // nop
+  void genFIR(const Fortran::parser::IfStmt &) {}              // nop
+  void genFIR(const Fortran::parser::IfThenStmt &) {}          // nop
+  void genFIR(const Fortran::parser::NonLabelDoStmt &) {}      // nop
+  void genFIR(const Fortran::parser::OmpEndLoopDirective &) {} // nop
+  void genFIR(const Fortran::parser::SelectTypeStmt &) {}      // nop
+  void genFIR(const Fortran::parser::TypeGuardStmt &) {}       // nop
+  void genFIR(const Fortran::parser::ChangeTeamStmt &stmt) {}  // nop
   void genFIR(const Fortran::parser::EndChangeTeamStmt &stmt) {} // nop
 
   /// Generate FIR for Evaluation \p eval.

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2493,6 +2493,18 @@ private:
     Fortran::lower::pft::Evaluation &eval = getEval();
     bool unstructuredContext = eval.lowerAsUnstructured();
 
+    // If this tightly-nested do-loop is inside a collapsed acc.loop and
+    // its dimension is already covered by the parent's control variables,
+    // skip generating any loop — just lower the body.  The IV value is
+    // already available from the parent acc.loop's block argument (stored
+    // into the private variable by buildACCLoopOp).
+    if (Fortran::lower::isInsideCollapsedACCLoop(*builder)) {
+      auto iter = eval.getNestedEvaluations().begin();
+      for (auto end = --eval.getNestedEvaluations().end(); iter != end; ++iter)
+        genFIR(*iter, unstructuredContext);
+      return;
+    }
+
     // Loops with induction variables inside OpenACC compute constructs
     // need special handling to ensure that the IVs are privatized.
     if (Fortran::lower::isInsideOpenACCComputeConstruct(*builder)) {
@@ -6273,29 +6285,29 @@ private:
   // calls does block management, possibly starting a new block, and possibly
   // generating a branch to end a block. So these calls may still be required
   // for that functionality.
-  void genFIR(const Fortran::parser::AssociateStmt &) {}       // nop
-  void genFIR(const Fortran::parser::BlockStmt &) {}           // nop
-  void genFIR(const Fortran::parser::CaseStmt &) {}            // nop
-  void genFIR(const Fortran::parser::ContinueStmt &) {}        // nop
-  void genFIR(const Fortran::parser::ElseIfStmt &) {}          // nop
-  void genFIR(const Fortran::parser::ElseStmt &) {}            // nop
-  void genFIR(const Fortran::parser::EndAssociateStmt &) {}    // nop
-  void genFIR(const Fortran::parser::EndBlockStmt &) {}        // nop
-  void genFIR(const Fortran::parser::EndDoStmt &) {}           // nop
-  void genFIR(const Fortran::parser::EndFunctionStmt &) {}     // nop
-  void genFIR(const Fortran::parser::EndIfStmt &) {}           // nop
-  void genFIR(const Fortran::parser::EndMpSubprogramStmt &) {} // nop
-  void genFIR(const Fortran::parser::EndProgramStmt &) {}      // nop
-  void genFIR(const Fortran::parser::EndSelectStmt &) {}       // nop
-  void genFIR(const Fortran::parser::EndSubroutineStmt &) {}   // nop
-  void genFIR(const Fortran::parser::EntryStmt &) {}           // nop
-  void genFIR(const Fortran::parser::IfStmt &) {}              // nop
-  void genFIR(const Fortran::parser::IfThenStmt &) {}          // nop
-  void genFIR(const Fortran::parser::NonLabelDoStmt &) {}      // nop
-  void genFIR(const Fortran::parser::OmpEndLoopDirective &) {} // nop
-  void genFIR(const Fortran::parser::SelectTypeStmt &) {}      // nop
-  void genFIR(const Fortran::parser::TypeGuardStmt &) {}       // nop
-  void genFIR(const Fortran::parser::ChangeTeamStmt &stmt) {}  // nop
+  void genFIR(const Fortran::parser::AssociateStmt &) {}         // nop
+  void genFIR(const Fortran::parser::BlockStmt &) {}             // nop
+  void genFIR(const Fortran::parser::CaseStmt &) {}              // nop
+  void genFIR(const Fortran::parser::ContinueStmt &) {}          // nop
+  void genFIR(const Fortran::parser::ElseIfStmt &) {}            // nop
+  void genFIR(const Fortran::parser::ElseStmt &) {}              // nop
+  void genFIR(const Fortran::parser::EndAssociateStmt &) {}      // nop
+  void genFIR(const Fortran::parser::EndBlockStmt &) {}          // nop
+  void genFIR(const Fortran::parser::EndDoStmt &) {}             // nop
+  void genFIR(const Fortran::parser::EndFunctionStmt &) {}       // nop
+  void genFIR(const Fortran::parser::EndIfStmt &) {}             // nop
+  void genFIR(const Fortran::parser::EndMpSubprogramStmt &) {}   // nop
+  void genFIR(const Fortran::parser::EndProgramStmt &) {}        // nop
+  void genFIR(const Fortran::parser::EndSelectStmt &) {}         // nop
+  void genFIR(const Fortran::parser::EndSubroutineStmt &) {}     // nop
+  void genFIR(const Fortran::parser::EntryStmt &) {}             // nop
+  void genFIR(const Fortran::parser::IfStmt &) {}                // nop
+  void genFIR(const Fortran::parser::IfThenStmt &) {}            // nop
+  void genFIR(const Fortran::parser::NonLabelDoStmt &) {}        // nop
+  void genFIR(const Fortran::parser::OmpEndLoopDirective &) {}   // nop
+  void genFIR(const Fortran::parser::SelectTypeStmt &) {}        // nop
+  void genFIR(const Fortran::parser::TypeGuardStmt &) {}         // nop
+  void genFIR(const Fortran::parser::ChangeTeamStmt &stmt) {}    // nop
   void genFIR(const Fortran::parser::EndChangeTeamStmt &stmt) {} // nop
 
   /// Generate FIR for Evaluation \p eval.

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -4546,6 +4546,22 @@ bool Fortran::lower::isInOpenACCLoop(fir::FirOpBuilder &builder) {
   return false;
 }
 
+bool Fortran::lower::isInsideCollapsedACCLoop(fir::FirOpBuilder &builder) {
+  auto parentLoop =
+      builder.getBlock()->getParent()->getParentOfType<mlir::acc::LoopOp>();
+  if (!parentLoop)
+    return false;
+  unsigned numParentIVs = parentLoop.getBody().getNumArguments();
+  if (numParentIVs <= 1)
+    return false;
+
+  // Check that there are still collapsed dimensions to consume:
+  // no inner acc.loop has been generated yet.
+  unsigned innerAccLoops = 0;
+  parentLoop.getBody().walk([&](mlir::acc::LoopOp) { ++innerAccLoops; });
+  return (innerAccLoops + 1 < numParentIVs);
+}
+
 bool Fortran::lower::isInsideOpenACCComputeConstruct(
     fir::FirOpBuilder &builder) {
   return mlir::isa_and_nonnull<ACC_COMPUTE_CONSTRUCT_OPS>(

--- a/flang/test/Lower/OpenACC/acc-loop-collapse-force-lowering.f90
+++ b/flang/test/Lower/OpenACC/acc-loop-collapse-force-lowering.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
 ! Verify collapse(force:2) sinks prologue (between loops) and epilogue (after inner loop)
-! into the acc.loop region body.
+! into the acc.loop region body without generating a redundant inner acc.loop.
 
 subroutine collapse_force_sink(n, m)
   integer, intent(in) :: n, m
@@ -22,20 +22,18 @@ end subroutine
 
 ! CHECK: func.func @_QPcollapse_force_sink(
 ! CHECK: acc.parallel
-! Ensure outer acc.loop is combined(parallel)
+! Ensure outer acc.loop is combined(parallel) with 2 IVs and no inner acc.loop
 ! CHECK: acc.loop combined(parallel)
-! Prologue: constant 4.2 and an assign before inner loop
+! Prologue: constant 4.2 and an assign before inner loop body
 ! CHECK: arith.constant 4.200000e+00
 ! CHECK: hlfir.assign
-! Inner loop and its body include 2.0 add and an assign
-! CHECK: acc.loop
+! Inner loop body (no acc.loop wrapping it): 2.0 add and an assign
 ! CHECK: arith.constant 2.000000e+00
 ! CHECK: arith.addf
 ! CHECK: hlfir.assign
-! Epilogue: constant 7.3 and an assign after inner loop
+! Epilogue: constant 7.3 and an assign after inner loop body
 ! CHECK: arith.constant 7.300000e+00
 ! CHECK: hlfir.assign
-! And the outer acc.loop has collapse = [2]
+! The acc.loop has collapse = [2] and no inner acc.loop
 ! CHECK: } attributes {collapse = [2]
-
-
+! CHECK-NOT: acc.loop

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCComputeLowering.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCComputeLowering.cpp
@@ -255,59 +255,6 @@ assignKnownLaunchArgs<SerialOp>(SerialOp, DeviceType, RewriterBase &,
 // Loop conversion pattern
 //===----------------------------------------------------------------------===//
 
-/// When collapse(force:N) generates an outer acc.loop with N control
-/// variables, the body may still contain inner acc.loop ops that re-iterate
-/// dimensions already covered by the collapse.  Before converting the outer
-/// loop to scf.parallel, eliminate these redundant inner loops by inlining
-/// their bodies and replacing their IVs with the corresponding outer IVs.
-static void eliminateCollapsedInnerLoops(LoopOp outerLoop,
-                                         RewriterBase &rewriter) {
-  auto collapseVal = outerLoop.getCollapseValue();
-  if (!collapseVal || *collapseVal <= 1)
-    return;
-
-  unsigned numOuterIVs = outerLoop.getBody().getNumArguments();
-  if (numOuterIVs <= 1)
-    return;
-
-  SmallVector<LoopOp> innerLoopsToErase;
-
-  outerLoop.getBody().walk([&](LoopOp innerLoop) {
-    if (innerLoop == outerLoop)
-      return WalkResult::advance();
-    if (innerLoop.getBody().getNumArguments() != 1)
-      return WalkResult::advance();
-
-    Value innerLB = innerLoop.getLowerbound()[0];
-    Value innerUB = innerLoop.getUpperbound()[0];
-    Value innerStep = innerLoop.getStep()[0];
-
-    for (unsigned ivIdx = 0; ivIdx < numOuterIVs; ++ivIdx) {
-      if (innerLB != outerLoop.getLowerbound()[ivIdx] ||
-          innerUB != outerLoop.getUpperbound()[ivIdx] ||
-          innerStep != outerLoop.getStep()[ivIdx])
-        continue;
-
-      Value outerIV = outerLoop.getBody().getArgument(ivIdx);
-
-      IRMapping mapping;
-      mapping.map(innerLoop.getBody().getArgument(0), outerIV);
-
-      rewriter.setInsertionPoint(innerLoop);
-      cloneACCRegionInto(&innerLoop.getRegion(), innerLoop->getBlock(),
-                         Block::iterator(innerLoop), mapping,
-                         innerLoop->getResults());
-
-      innerLoopsToErase.push_back(innerLoop);
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
-
-  for (LoopOp loop : innerLoopsToErase)
-    rewriter.eraseOp(loop);
-}
-
 class ACCLoopConversion : public OpRewritePattern<LoopOp> {
 public:
   ACCLoopConversion(MLIRContext *ctx, const ACCToGPUMappingPolicy &policy,
@@ -436,15 +383,6 @@ public:
     auto *context = op.getContext();
 
     DefaultACCToGPUMappingPolicy policy;
-
-    // Pre-pass: eliminate redundant inner acc.loop ops that re-iterate
-    // dimensions already covered by a collapsed outer acc.loop.  This must
-    // happen before the greedy loop conversion because the inner loops
-    // would otherwise be converted to scf.for independently.
-    IRRewriter rewriter(context);
-    op.walk([&](LoopOp outerLoop) {
-      eliminateCollapsedInnerLoops(outerLoop, rewriter);
-    });
 
     // Part 1: Convert acc.loop to scf.parallel/scf.for while the parent
     // compute construct is still present (needed to determine conversion

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCComputeLowering.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCComputeLowering.cpp
@@ -278,26 +278,20 @@ static void eliminateCollapsedInnerLoops(LoopOp outerLoop,
     if (innerLoop.getBody().getNumArguments() != 1)
       return WalkResult::advance();
 
-    // Check if the inner loop's bounds match any of the outer loop's
-    // collapsed dimensions (by comparing the original lb/ub/step values).
     Value innerLB = innerLoop.getLowerbound()[0];
     Value innerUB = innerLoop.getUpperbound()[0];
     Value innerStep = innerLoop.getStep()[0];
 
     for (unsigned ivIdx = 0; ivIdx < numOuterIVs; ++ivIdx) {
-      Value outerLB = outerLoop.getLowerbound()[ivIdx];
-      Value outerUB = outerLoop.getUpperbound()[ivIdx];
-      Value outerStep = outerLoop.getStep()[ivIdx];
-
-      if (innerLB != outerLB || innerUB != outerUB || innerStep != outerStep)
+      if (innerLB != outerLoop.getLowerbound()[ivIdx] ||
+          innerUB != outerLoop.getUpperbound()[ivIdx] ||
+          innerStep != outerLoop.getStep()[ivIdx])
         continue;
 
-      // Match found — replace the inner loop's IV with the outer's.
       Value outerIV = outerLoop.getBody().getArgument(ivIdx);
-      Value innerIV = innerLoop.getBody().getArgument(0);
 
       IRMapping mapping;
-      mapping.map(innerIV, outerIV);
+      mapping.map(innerLoop.getBody().getArgument(0), outerIV);
 
       rewriter.setInsertionPoint(innerLoop);
       cloneACCRegionInto(&innerLoop.getRegion(), innerLoop->getBlock(),

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCComputeLowering.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCComputeLowering.cpp
@@ -255,6 +255,65 @@ assignKnownLaunchArgs<SerialOp>(SerialOp, DeviceType, RewriterBase &,
 // Loop conversion pattern
 //===----------------------------------------------------------------------===//
 
+/// When collapse(force:N) generates an outer acc.loop with N control
+/// variables, the body may still contain inner acc.loop ops that re-iterate
+/// dimensions already covered by the collapse.  Before converting the outer
+/// loop to scf.parallel, eliminate these redundant inner loops by inlining
+/// their bodies and replacing their IVs with the corresponding outer IVs.
+static void eliminateCollapsedInnerLoops(LoopOp outerLoop,
+                                         RewriterBase &rewriter) {
+  auto collapseVal = outerLoop.getCollapseValue();
+  if (!collapseVal || *collapseVal <= 1)
+    return;
+
+  unsigned numOuterIVs = outerLoop.getBody().getNumArguments();
+  if (numOuterIVs <= 1)
+    return;
+
+  SmallVector<LoopOp> innerLoopsToErase;
+
+  outerLoop.getBody().walk([&](LoopOp innerLoop) {
+    if (innerLoop == outerLoop)
+      return WalkResult::advance();
+    if (innerLoop.getBody().getNumArguments() != 1)
+      return WalkResult::advance();
+
+    // Check if the inner loop's bounds match any of the outer loop's
+    // collapsed dimensions (by comparing the original lb/ub/step values).
+    Value innerLB = innerLoop.getLowerbound()[0];
+    Value innerUB = innerLoop.getUpperbound()[0];
+    Value innerStep = innerLoop.getStep()[0];
+
+    for (unsigned ivIdx = 0; ivIdx < numOuterIVs; ++ivIdx) {
+      Value outerLB = outerLoop.getLowerbound()[ivIdx];
+      Value outerUB = outerLoop.getUpperbound()[ivIdx];
+      Value outerStep = outerLoop.getStep()[ivIdx];
+
+      if (innerLB != outerLB || innerUB != outerUB || innerStep != outerStep)
+        continue;
+
+      // Match found — replace the inner loop's IV with the outer's.
+      Value outerIV = outerLoop.getBody().getArgument(ivIdx);
+      Value innerIV = innerLoop.getBody().getArgument(0);
+
+      IRMapping mapping;
+      mapping.map(innerIV, outerIV);
+
+      rewriter.setInsertionPoint(innerLoop);
+      cloneACCRegionInto(&innerLoop.getRegion(), innerLoop->getBlock(),
+                         Block::iterator(innerLoop), mapping,
+                         innerLoop->getResults());
+
+      innerLoopsToErase.push_back(innerLoop);
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+
+  for (LoopOp loop : innerLoopsToErase)
+    rewriter.eraseOp(loop);
+}
+
 class ACCLoopConversion : public OpRewritePattern<LoopOp> {
 public:
   ACCLoopConversion(MLIRContext *ctx, const ACCToGPUMappingPolicy &policy,
@@ -383,6 +442,15 @@ public:
     auto *context = op.getContext();
 
     DefaultACCToGPUMappingPolicy policy;
+
+    // Pre-pass: eliminate redundant inner acc.loop ops that re-iterate
+    // dimensions already covered by a collapsed outer acc.loop.  This must
+    // happen before the greedy loop conversion because the inner loops
+    // would otherwise be converted to scf.for independently.
+    IRRewriter rewriter(context);
+    op.walk([&](LoopOp outerLoop) {
+      eliminateCollapsedInnerLoops(outerLoop, rewriter);
+    });
 
     // Part 1: Convert acc.loop to scf.parallel/scf.for while the parent
     // compute construct is still present (needed to determine conversion

--- a/mlir/test/Dialect/OpenACC/acc-compute-lowering-collapse-reduction.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-compute-lowering-collapse-reduction.mlir
@@ -1,0 +1,69 @@
+// RUN: mlir-opt %s -acc-compute-lowering | FileCheck %s
+
+// Test that collapse(force:2) with a redundant inner acc.loop eliminates
+// the inner loop.  The outer acc.loop has 2 control variables (for the
+// collapsed dimensions) but the body contains an inner acc.loop that
+// re-iterates the second dimension.  The inner loop should be eliminated
+// and its IV replaced with the outer's corresponding IV.
+
+// CHECK-LABEL: func.func @collapse_force_with_redundant_inner
+// CHECK:       acc.compute_region
+// After conversion, the scf.parallel body should NOT contain an scf.for
+// CHECK:       scf.parallel
+// CHECK-NOT:   scf.for
+// CHECK:       scf.reduce
+func.func @collapse_force_with_redundant_inner(%buf: memref<1xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c100 = arith.constant 100 : index
+  %c200 = arith.constant 200 : index
+
+  %dev = acc.copyin varPtr(%buf : memref<1xf32>) -> memref<1xf32>
+  acc.parallel dataOperands(%dev : memref<1xf32>) {
+    acc.loop combined(parallel) control(%i : index, %j : index) = (%c1, %c1 : index, index) to (%c100, %c200 : index, index) step (%c1, %c1 : index, index) {
+      %vi = arith.index_cast %i : index to i32
+      %vj = arith.index_cast %j : index to i32
+      %sum = arith.addi %vi, %vj : i32
+      %valf = arith.sitofp %sum : i32 to f32
+      memref.store %valf, %dev[%c0] : memref<1xf32>
+      acc.loop control(%j_inner : index) = (%c1 : index) to (%c200 : index) step (%c1 : index) {
+        %vj2 = arith.index_cast %j_inner : index to i32
+        %valf2 = arith.sitofp %vj2 : i32 to f32
+        memref.store %valf2, %dev[%c0] : memref<1xf32>
+        acc.yield
+      } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+      acc.yield
+    } attributes {collapse = [2], collapseDeviceType = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true, true>, independent = [#acc.device_type<none>]}
+    acc.yield
+  }
+  acc.copyout accPtr(%dev : memref<1xf32>) to varPtr(%buf : memref<1xf32>)
+  return
+}
+
+// -----
+
+// Verify that a collapsed loop without a redundant inner loop still works.
+// CHECK-LABEL: func.func @collapse_no_redundant_inner
+// CHECK:       acc.compute_region
+// CHECK:       scf.parallel
+// CHECK-NOT:   scf.for
+// CHECK:       scf.reduce
+func.func @collapse_no_redundant_inner(%buf: memref<1xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %c20 = arith.constant 20 : index
+
+  %dev = acc.copyin varPtr(%buf : memref<1xf32>) -> memref<1xf32>
+  acc.parallel dataOperands(%dev : memref<1xf32>) {
+    acc.loop combined(parallel) control(%i : index, %j : index) = (%c1, %c1 : index, index) to (%c10, %c20 : index, index) step (%c1, %c1 : index, index) {
+      %vj = arith.index_cast %j : index to i32
+      %valf = arith.sitofp %vj : i32 to f32
+      memref.store %valf, %dev[%c0] : memref<1xf32>
+      acc.yield
+    } attributes {collapse = [2], collapseDeviceType = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true, true>, independent = [#acc.device_type<none>]}
+    acc.yield
+  }
+  acc.copyout accPtr(%dev : memref<1xf32>) to varPtr(%buf : memref<1xf32>)
+  return
+}

--- a/mlir/test/Dialect/OpenACC/acc-compute-lowering-collapse-reduction.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-compute-lowering-collapse-reduction.mlir
@@ -1,18 +1,14 @@
 // RUN: mlir-opt %s -acc-compute-lowering | FileCheck %s
 
-// Test that collapse(force:2) with a redundant inner acc.loop eliminates
-// the inner loop.  The outer acc.loop has 2 control variables (for the
-// collapsed dimensions) but the body contains an inner acc.loop that
-// re-iterates the second dimension.  The inner loop should be eliminated
-// and its IV replaced with the outer's corresponding IV.
+// Test that a collapsed acc.loop with 2 IVs converts correctly to
+// scf.parallel with 2 dimensions and no redundant inner loops.
 
-// CHECK-LABEL: func.func @collapse_force_with_redundant_inner
+// CHECK-LABEL: func.func @collapse_two_ivs
 // CHECK:       acc.compute_region
-// After conversion, the scf.parallel body should NOT contain an scf.for
 // CHECK:       scf.parallel
 // CHECK-NOT:   scf.for
 // CHECK:       scf.reduce
-func.func @collapse_force_with_redundant_inner(%buf: memref<1xf32>) {
+func.func @collapse_two_ivs(%buf: memref<1xf32>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c100 = arith.constant 100 : index
@@ -25,40 +21,6 @@ func.func @collapse_force_with_redundant_inner(%buf: memref<1xf32>) {
       %vj = arith.index_cast %j : index to i32
       %sum = arith.addi %vi, %vj : i32
       %valf = arith.sitofp %sum : i32 to f32
-      memref.store %valf, %dev[%c0] : memref<1xf32>
-      acc.loop control(%j_inner : index) = (%c1 : index) to (%c200 : index) step (%c1 : index) {
-        %vj2 = arith.index_cast %j_inner : index to i32
-        %valf2 = arith.sitofp %vj2 : i32 to f32
-        memref.store %valf2, %dev[%c0] : memref<1xf32>
-        acc.yield
-      } attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
-      acc.yield
-    } attributes {collapse = [2], collapseDeviceType = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true, true>, independent = [#acc.device_type<none>]}
-    acc.yield
-  }
-  acc.copyout accPtr(%dev : memref<1xf32>) to varPtr(%buf : memref<1xf32>)
-  return
-}
-
-// -----
-
-// Verify that a collapsed loop without a redundant inner loop still works.
-// CHECK-LABEL: func.func @collapse_no_redundant_inner
-// CHECK:       acc.compute_region
-// CHECK:       scf.parallel
-// CHECK-NOT:   scf.for
-// CHECK:       scf.reduce
-func.func @collapse_no_redundant_inner(%buf: memref<1xf32>) {
-  %c0 = arith.constant 0 : index
-  %c1 = arith.constant 1 : index
-  %c10 = arith.constant 10 : index
-  %c20 = arith.constant 20 : index
-
-  %dev = acc.copyin varPtr(%buf : memref<1xf32>) -> memref<1xf32>
-  acc.parallel dataOperands(%dev : memref<1xf32>) {
-    acc.loop combined(parallel) control(%i : index, %j : index) = (%c1, %c1 : index, index) to (%c10, %c20 : index, index) step (%c1, %c1 : index, index) {
-      %vj = arith.index_cast %j : index to i32
-      %valf = arith.sitofp %vj : i32 to f32
       memref.store %valf, %dev[%c0] : memref<1xf32>
       acc.yield
     } attributes {collapse = [2], collapseDeviceType = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true, true>, independent = [#acc.device_type<none>]}


### PR DESCRIPTION
When `collapse(force:2) reduction(+:r)` is applied to a nested loop, Flang's lowering creates an outer `acc.loop` with N control variables covering all collapsed dimensions. However, the PFT evaluation walker still encounters the inner `do` constructs and calls `genOpenACCLoopFromDoConstruct` for each, generating redundant inner `acc.loop` ops that re-iterate dimensions already distributed by the outer.

**Root cause**: `processDoLoopBounds` absorbs N levels of loop bounds into the outer `acc.loop`, but nothing prevents the PFT walker from also generating separate `acc.loop` ops for those same inner `do` constructs.

**Fix**: Add `isInsideCollapsedACCLoop()` which checks if the current insertion point is inside a collapsed `acc.loop` with unconsumed dimensions. In `Bridge.cpp`, when this returns true, skip both `acc.loop` generation and normal loop generation for the inner `do` construct — just lower the body directly. The IV is already available from the parent `acc.loop`'s block argument.