### PR TITLE
[RISCV][P-ext] Add mul*.h00 and mul*.w00 patterns.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1952,6 +1952,18 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def : PatGprGpr<avgfloors, AADD, i32>;
   def : PatGprGpr<avgflooru, AADDU, i32>;
 
+  // Halfword multiply patterns where one operand is a sext.h or zext.h and
+  // the other is a sext.h or zext.h or is known to be sign/zero-extended. We
+  // prefer plain mul when both operands are known to be sign/zero-extended.
+  def : Pat<(i32 (mul sexti16:$rs1, (sext_inreg GPR:$rs2, i16))),
+            (MUL_H00 sexti16:$rs1, GPR:$rs2)>;
+  def : Pat<(i32 (mul zexti16:$rs1, (and GPR:$rs2, 0xffff))),
+            (MULU_H00 zexti16:$rs1, GPR:$rs2)>;
+  def : Pat<(i32 (mul sexti16:$rs1, (and GPR:$rs2, 0xffff))),
+            (MULSU_H00 sexti16:$rs1, GPR:$rs2)>;
+  def : Pat<(i32 (mul (sext_inreg GPR:$rs1, i16), zexti16:$rs2)),
+            (MULSU_H00 GPR:$rs1, zexti16:$rs2)>;
+
   def : Pat<(i32 (add GPR:$rd, (mul_oneuse sexti16:$rs1, sexti16:$rs2))),
             (MACC_H00 GPR:$rd, sexti16:$rs1, sexti16:$rs2)>;
   def : Pat<(i32 (add GPR:$rd, (mul_oneuse zexti16:$rs1, zexti16:$rs2))),
@@ -2015,6 +2027,18 @@ let Predicates = [HasStdExtP, IsRV64] in {
             (SATI_RV64 GPR:$rs1, (IncImm timm:$imm))>;
   def : Pat<(XLenVT (riscv_usati GPR:$rs1, timm:$imm)),
             (USATI_RV64 GPR:$rs1, timm:$imm)>;
+
+  // Word multiply patterns where one operand is a sext.w or zext.w and
+  // the other is a sext.w or zext.w or is known to be sign/zero-extended. We
+  // prefer plain mul when both operands are known to be sign/zero-extended.
+  def : Pat<(i64 (mul sexti32:$rs1, (sext_inreg GPR:$rs2, i32))),
+            (MUL_W00 sexti32:$rs1, GPR:$rs2)>;
+  def : Pat<(i64 (mul zexti32:$rs1, (and GPR:$rs2, 0xffffffff))),
+            (MULU_W00 zexti32:$rs1, GPR:$rs2)>;
+  def : Pat<(i64 (mul sexti32:$rs1, (and GPR:$rs2, 0xffffffff))),
+            (MULSU_W00 sexti32:$rs1, GPR:$rs2)>;
+  def : Pat<(i64 (mul (sext_inreg GPR:$rs1, i32), zexti32:$rs2)),
+            (MULSU_W00 GPR:$rs1, zexti32:$rs2)>;
 
   def : Pat<(i64 (add GPR:$rd, (mul_oneuse sexti32:$rs1, sexti32:$rs2))),
             (MACC_W00 GPR:$rd, sexti32:$rs1, sexti32:$rs2)>;

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -1781,6 +1781,107 @@ entry:
   ret i32 %1
 }
 
+; Test multiply patterns with one extended operand
+define i32 @mul_h00_sexti16_sext_inreg(i16 signext %a, i32 %b) nounwind {
+; CHECK-LABEL: mul_h00_sexti16_sext_inreg:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.h a1, a1
+; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    ret
+  %b_sext = sext i16 %a to i32
+  %b_ext = trunc i32 %b to i16
+  %b_ext2 = sext i16 %b_ext to i32
+  %mul = mul i32 %b_sext, %b_ext2
+  ret i32 %mul
+}
+
+define i32 @mul_h00_sexti16_sext_inreg_commute(i16 signext %a, i32 %b) nounwind {
+; CHECK-LABEL: mul_h00_sexti16_sext_inreg_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.h a1, a1
+; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    ret
+  %b_sext = sext i16 %a to i32
+  %b_ext = trunc i32 %b to i16
+  %b_ext2 = sext i16 %b_ext to i32
+  %mul = mul i32 %b_ext2, %b_sext
+  ret i32 %mul
+}
+
+define i32 @mulu_h00_zexti16_and(i16 zeroext %a, i32 %b) nounwind {
+; CHECK-LABEL: mulu_h00_zexti16_and:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.h a1, a1
+; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    ret
+  %a_zext = zext i16 %a to i32
+  %b_and = and i32 %b, 65535
+  %mul = mul i32 %a_zext, %b_and
+  ret i32 %mul
+}
+
+define i32 @mulu_h00_zexti16_and_commute(i16 zeroext %a, i32 %b) nounwind {
+; CHECK-LABEL: mulu_h00_zexti16_and_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.h a1, a1
+; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    ret
+  %a_zext = zext i16 %a to i32
+  %b_and = and i32 %b, 65535
+  %mul = mul i32 %b_and, %a_zext
+  ret i32 %mul
+}
+
+define i32 @mulsu_h00_sexti16_and(i16 signext %a, i32 %b) nounwind {
+; CHECK-LABEL: mulsu_h00_sexti16_and:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.h a1, a1
+; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    ret
+  %a_sext = sext i16 %a to i32
+  %b_and = and i32 %b, 65535
+  %mul = mul i32 %a_sext, %b_and
+  ret i32 %mul
+}
+
+define i32 @mulsu_h00_sexti16_and_commute(i16 signext %a, i32 %b) nounwind {
+; CHECK-LABEL: mulsu_h00_sexti16_and_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.h a1, a1
+; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    ret
+  %a_sext = sext i16 %a to i32
+  %b_and = and i32 %b, 65535
+  %mul = mul i32 %b_and, %a_sext
+  ret i32 %mul
+}
+
+define i32 @mulsu_h00_sext_inreg_zexti16(i32 %a, i16 zeroext %b) nounwind {
+; CHECK-LABEL: mulsu_h00_sext_inreg_zexti16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.h a0, a0
+; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    ret
+  %a_trunc = trunc i32 %a to i16
+  %a_sext = sext i16 %a_trunc to i32
+  %b_zext = zext i16 %b to i32
+  %mul = mul i32 %a_sext, %b_zext
+  ret i32 %mul
+}
+
+define i32 @mulsu_h00_sext_inreg_zexti16_commute(i32 %a, i16 zeroext %b) nounwind {
+; CHECK-LABEL: mulsu_h00_sext_inreg_zexti16_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.h a0, a0
+; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    ret
+  %a_trunc = trunc i32 %a to i16
+  %a_sext = sext i16 %a_trunc to i32
+  %b_zext = zext i16 %b to i32
+  %mul = mul i32 %b_zext, %a_sext
+  ret i32 %mul
+}
+
 ; Test that we select pack.
 define i32 @mm_usati_32_knownbits_i32(i32 %x, i32 %y) {
 ; CHECK-LABEL: mm_usati_32_knownbits_i32:

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -1175,9 +1175,7 @@ define i32 @maccsu_h00_swap_operands_commute(i32 %rd, i16 %a, i16 %b) nounwind {
 define i32 @macc_h00_multiple_uses(i16 %a, i16 %b, i32 %c, ptr %out) nounwind {
 ; CHECK-LABEL: macc_h00_multiple_uses:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.h a0, a0
-; CHECK-NEXT:    sext.h a1, a1
-; CHECK-NEXT:    mul a1, a0, a1
+; CHECK-NEXT:    mul.h00 a1, a0, a1
 ; CHECK-NEXT:    add a0, a2, a1
 ; CHECK-NEXT:    sw a1, 0(a3)
 ; CHECK-NEXT:    ret
@@ -1785,8 +1783,7 @@ entry:
 define i32 @mul_h00_sexti16_sext_inreg(i16 signext %a, i32 %b) nounwind {
 ; CHECK-LABEL: mul_h00_sexti16_sext_inreg:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.h a1, a1
-; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    mul.h00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %b_sext = sext i16 %a to i32
   %b_ext = trunc i32 %b to i16
@@ -1798,8 +1795,7 @@ define i32 @mul_h00_sexti16_sext_inreg(i16 signext %a, i32 %b) nounwind {
 define i32 @mul_h00_sexti16_sext_inreg_commute(i16 signext %a, i32 %b) nounwind {
 ; CHECK-LABEL: mul_h00_sexti16_sext_inreg_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.h a1, a1
-; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    mul.h00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %b_sext = sext i16 %a to i32
   %b_ext = trunc i32 %b to i16
@@ -1811,8 +1807,7 @@ define i32 @mul_h00_sexti16_sext_inreg_commute(i16 signext %a, i32 %b) nounwind 
 define i32 @mulu_h00_zexti16_and(i16 zeroext %a, i32 %b) nounwind {
 ; CHECK-LABEL: mulu_h00_zexti16_and:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.h a1, a1
-; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    mulu.h00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_zext = zext i16 %a to i32
   %b_and = and i32 %b, 65535
@@ -1823,8 +1818,7 @@ define i32 @mulu_h00_zexti16_and(i16 zeroext %a, i32 %b) nounwind {
 define i32 @mulu_h00_zexti16_and_commute(i16 zeroext %a, i32 %b) nounwind {
 ; CHECK-LABEL: mulu_h00_zexti16_and_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.h a1, a1
-; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    mulu.h00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_zext = zext i16 %a to i32
   %b_and = and i32 %b, 65535
@@ -1835,8 +1829,7 @@ define i32 @mulu_h00_zexti16_and_commute(i16 zeroext %a, i32 %b) nounwind {
 define i32 @mulsu_h00_sexti16_and(i16 signext %a, i32 %b) nounwind {
 ; CHECK-LABEL: mulsu_h00_sexti16_and:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.h a1, a1
-; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    mulsu.h00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_sext = sext i16 %a to i32
   %b_and = and i32 %b, 65535
@@ -1847,8 +1840,7 @@ define i32 @mulsu_h00_sexti16_and(i16 signext %a, i32 %b) nounwind {
 define i32 @mulsu_h00_sexti16_and_commute(i16 signext %a, i32 %b) nounwind {
 ; CHECK-LABEL: mulsu_h00_sexti16_and_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.h a1, a1
-; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    mulsu.h00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_sext = sext i16 %a to i32
   %b_and = and i32 %b, 65535
@@ -1859,8 +1851,7 @@ define i32 @mulsu_h00_sexti16_and_commute(i16 signext %a, i32 %b) nounwind {
 define i32 @mulsu_h00_sext_inreg_zexti16(i32 %a, i16 zeroext %b) nounwind {
 ; CHECK-LABEL: mulsu_h00_sext_inreg_zexti16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.h a0, a0
-; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    mulsu.h00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_trunc = trunc i32 %a to i16
   %a_sext = sext i16 %a_trunc to i32
@@ -1872,8 +1863,7 @@ define i32 @mulsu_h00_sext_inreg_zexti16(i32 %a, i16 zeroext %b) nounwind {
 define i32 @mulsu_h00_sext_inreg_zexti16_commute(i32 %a, i16 zeroext %b) nounwind {
 ; CHECK-LABEL: mulsu_h00_sext_inreg_zexti16_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.h a0, a0
-; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    mulsu.h00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_trunc = trunc i32 %a to i16
   %a_sext = sext i16 %a_trunc to i32

--- a/llvm/test/CodeGen/RISCV/rv64p.ll
+++ b/llvm/test/CodeGen/RISCV/rv64p.ll
@@ -1021,8 +1021,7 @@ entry:
 define i64 @mul_w00_sexti32_sext_inreg(i32 signext %a, i64 %b) nounwind {
 ; CHECK-LABEL: mul_w00_sexti32_sext_inreg:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.w a1, a1
-; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    mul.w00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_sext = sext i32 %a to i64
   %b_trunc = trunc i64 %b to i32
@@ -1034,8 +1033,7 @@ define i64 @mul_w00_sexti32_sext_inreg(i32 signext %a, i64 %b) nounwind {
 define i64 @mul_w00_sexti32_sext_inreg_commute(i32 signext %a, i64 %b) nounwind {
 ; CHECK-LABEL: mul_w00_sexti32_sext_inreg_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.w a1, a1
-; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    mul.w00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_sext = sext i32 %a to i64
   %b_trunc = trunc i64 %b to i32
@@ -1047,8 +1045,7 @@ define i64 @mul_w00_sexti32_sext_inreg_commute(i32 signext %a, i64 %b) nounwind 
 define i64 @mulu_w00_zexti32_and(i32 zeroext %a, i64 %b) nounwind {
 ; CHECK-LABEL: mulu_w00_zexti32_and:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.w a1, a1
-; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    mulu.w00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_zext = zext i32 %a to i64
   %b_and = and i64 %b, 4294967295
@@ -1059,8 +1056,7 @@ define i64 @mulu_w00_zexti32_and(i32 zeroext %a, i64 %b) nounwind {
 define i64 @mulu_w00_zexti32_and_commute(i32 zeroext %a, i64 %b) nounwind {
 ; CHECK-LABEL: mulu_w00_zexti32_and_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.w a1, a1
-; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    mulu.w00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_zext = zext i32 %a to i64
   %b_and = and i64 %b, 4294967295
@@ -1071,8 +1067,7 @@ define i64 @mulu_w00_zexti32_and_commute(i32 zeroext %a, i64 %b) nounwind {
 define i64 @mulsu_w00_sexti32_and(i32 signext %a, i64 %b) nounwind {
 ; CHECK-LABEL: mulsu_w00_sexti32_and:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.w a1, a1
-; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    mulsu.w00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_sext = sext i32 %a to i64
   %b_and = and i64 %b, 4294967295
@@ -1083,8 +1078,7 @@ define i64 @mulsu_w00_sexti32_and(i32 signext %a, i64 %b) nounwind {
 define i64 @mulsu_w00_sexti32_and_commute(i32 signext %a, i64 %b) nounwind {
 ; CHECK-LABEL: mulsu_w00_sexti32_and_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.w a1, a1
-; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    mulsu.w00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_sext = sext i32 %a to i64
   %b_and = and i64 %b, 4294967295
@@ -1095,8 +1089,7 @@ define i64 @mulsu_w00_sexti32_and_commute(i32 signext %a, i64 %b) nounwind {
 define i64 @mulsu_w00_sext_inreg_zexti32(i64 %a, i32 zeroext %b) nounwind {
 ; CHECK-LABEL: mulsu_w00_sext_inreg_zexti32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.w a0, a0
-; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    mulsu.w00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_trunc = trunc i64 %a to i32
   %a_sext = sext i32 %a_trunc to i64
@@ -1108,8 +1101,7 @@ define i64 @mulsu_w00_sext_inreg_zexti32(i64 %a, i32 zeroext %b) nounwind {
 define i64 @mulsu_w00_sext_inreg_zexti32_commute(i64 %a, i32 zeroext %b) nounwind {
 ; CHECK-LABEL: mulsu_w00_sext_inreg_zexti32_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.w a0, a0
-; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    mulsu.w00 a0, a0, a1
 ; CHECK-NEXT:    ret
   %a_trunc = trunc i64 %a to i32
   %a_sext = sext i32 %a_trunc to i64
@@ -1233,9 +1225,7 @@ define i64 @maccsu_w00_swap_operands_commute(i64 %rd, i32 %a, i32 %b) nounwind {
 define i64 @macc_w00_multiple_uses(i32 %a, i32 %b, i64 %c, ptr %out) nounwind {
 ; CHECK-LABEL: macc_w00_multiple_uses:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    sext.w a0, a0
-; CHECK-NEXT:    sext.w a1, a1
-; CHECK-NEXT:    mul a1, a0, a1
+; CHECK-NEXT:    mul.w00 a1, a0, a1
 ; CHECK-NEXT:    add a0, a2, a1
 ; CHECK-NEXT:    sd a1, 0(a3)
 ; CHECK-NEXT:    ret

--- a/llvm/test/CodeGen/RISCV/rv64p.ll
+++ b/llvm/test/CodeGen/RISCV/rv64p.ll
@@ -1017,6 +1017,107 @@ entry:
   ret i32 %4
 }
 
+; Test multiply patterns with one extended operand
+define i64 @mul_w00_sexti32_sext_inreg(i32 signext %a, i64 %b) nounwind {
+; CHECK-LABEL: mul_w00_sexti32_sext_inreg:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.w a1, a1
+; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    ret
+  %a_sext = sext i32 %a to i64
+  %b_trunc = trunc i64 %b to i32
+  %b_sext = sext i32 %b_trunc to i64
+  %mul = mul i64 %a_sext, %b_sext
+  ret i64 %mul
+}
+
+define i64 @mul_w00_sexti32_sext_inreg_commute(i32 signext %a, i64 %b) nounwind {
+; CHECK-LABEL: mul_w00_sexti32_sext_inreg_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.w a1, a1
+; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    ret
+  %a_sext = sext i32 %a to i64
+  %b_trunc = trunc i64 %b to i32
+  %b_sext = sext i32 %b_trunc to i64
+  %mul = mul i64 %b_sext, %a_sext
+  ret i64 %mul
+}
+
+define i64 @mulu_w00_zexti32_and(i32 zeroext %a, i64 %b) nounwind {
+; CHECK-LABEL: mulu_w00_zexti32_and:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.w a1, a1
+; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    ret
+  %a_zext = zext i32 %a to i64
+  %b_and = and i64 %b, 4294967295
+  %mul = mul i64 %a_zext, %b_and
+  ret i64 %mul
+}
+
+define i64 @mulu_w00_zexti32_and_commute(i32 zeroext %a, i64 %b) nounwind {
+; CHECK-LABEL: mulu_w00_zexti32_and_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.w a1, a1
+; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    ret
+  %a_zext = zext i32 %a to i64
+  %b_and = and i64 %b, 4294967295
+  %mul = mul i64 %b_and, %a_zext
+  ret i64 %mul
+}
+
+define i64 @mulsu_w00_sexti32_and(i32 signext %a, i64 %b) nounwind {
+; CHECK-LABEL: mulsu_w00_sexti32_and:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.w a1, a1
+; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    ret
+  %a_sext = sext i32 %a to i64
+  %b_and = and i64 %b, 4294967295
+  %mul = mul i64 %a_sext, %b_and
+  ret i64 %mul
+}
+
+define i64 @mulsu_w00_sexti32_and_commute(i32 signext %a, i64 %b) nounwind {
+; CHECK-LABEL: mulsu_w00_sexti32_and_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.w a1, a1
+; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    ret
+  %a_sext = sext i32 %a to i64
+  %b_and = and i64 %b, 4294967295
+  %mul = mul i64 %b_and, %a_sext
+  ret i64 %mul
+}
+
+define i64 @mulsu_w00_sext_inreg_zexti32(i64 %a, i32 zeroext %b) nounwind {
+; CHECK-LABEL: mulsu_w00_sext_inreg_zexti32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.w a0, a0
+; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    ret
+  %a_trunc = trunc i64 %a to i32
+  %a_sext = sext i32 %a_trunc to i64
+  %b_zext = zext i32 %b to i64
+  %mul = mul i64 %a_sext, %b_zext
+  ret i64 %mul
+}
+
+define i64 @mulsu_w00_sext_inreg_zexti32_commute(i64 %a, i32 zeroext %b) nounwind {
+; CHECK-LABEL: mulsu_w00_sext_inreg_zexti32_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    sext.w a0, a0
+; CHECK-NEXT:    mul a0, a1, a0
+; CHECK-NEXT:    ret
+  %a_trunc = trunc i64 %a to i32
+  %a_sext = sext i32 %a_trunc to i64
+  %b_zext = zext i32 %b to i64
+  %mul = mul i64 %b_zext, %a_sext
+  ret i64 %mul
+}
+
 ; Test that we select pack.
 define i64 @mm_usati_32_knownbits_i64(i64 %x, i64 %y) {
 ; CHECK-LABEL: mm_usati_32_knownbits_i64:


### PR DESCRIPTION
The instructions take the low halfword/word from each input, extends
them and multiplies to produce a word/dword result.

We can use these instead of plain MUL if it would allow us to avoid
a sext/zext for at least one of the operands.

Tests were written by Claude Sonnet 4.5.