### PR TITLE
[ObjCopy] Reject compress-debug-sections for non-ELF

### DIFF
--- a/llvm/lib/ObjCopy/ConfigManager.cpp
+++ b/llvm/lib/ObjCopy/ConfigManager.cpp
@@ -29,7 +29,9 @@ Expected<const COFFConfig &> ConfigManager::getCOFFConfig() const {
       !Common.SymbolsToKeepGlobal.empty() || !Common.SectionsToRename.empty() ||
       !Common.SetSectionAlignment.empty() || !Common.SetSectionType.empty() ||
       Common.ExtractDWO || Common.StripDWO || Common.StripNonAlloc ||
-      Common.StripSections || Common.Weaken || Common.DecompressDebugSections ||
+      Common.StripSections || Common.Weaken ||
+      Common.CompressionType != DebugCompressionType::None ||
+      !Common.compressSections.empty() || Common.DecompressDebugSections ||
       Common.DiscardMode == DiscardType::Locals ||
       !Common.SymbolsToAdd.empty() || Common.GapFill != 0 ||
       Common.PadTo != 0 || Common.ChangeSectionLMAValAll != 0 ||
@@ -50,8 +52,9 @@ Expected<const MachOConfig &> ConfigManager::getMachOConfig() const {
       !Common.SetSectionType.empty() || Common.ExtractDWO ||
       Common.PreserveDates || Common.StripAllGNU || Common.StripDWO ||
       Common.StripNonAlloc || Common.StripSections ||
-      Common.DecompressDebugSections || Common.StripUnneeded ||
-      Common.DiscardMode == DiscardType::Locals ||
+      Common.CompressionType != DebugCompressionType::None ||
+      !Common.compressSections.empty() || Common.DecompressDebugSections ||
+      Common.StripUnneeded || Common.DiscardMode == DiscardType::Locals ||
       !Common.SymbolsToAdd.empty() || Common.GapFill != 0 ||
       Common.PadTo != 0 || Common.ChangeSectionLMAValAll != 0 ||
       !Common.ChangeSectionAddress.empty() || !Common.ExtractSection.empty())
@@ -73,8 +76,11 @@ Expected<const WasmConfig &> ConfigManager::getWasmConfig() const {
       !Common.SymbolsToWeaken.empty() || !Common.SymbolsToKeepGlobal.empty() ||
       !Common.SectionsToRename.empty() || !Common.SetSectionAlignment.empty() ||
       !Common.SetSectionFlags.empty() || !Common.SetSectionType.empty() ||
-      !Common.SymbolsToRename.empty() || Common.GapFill != 0 ||
-      Common.PadTo != 0 || Common.ChangeSectionLMAValAll != 0 ||
+      !Common.SymbolsToRename.empty() ||
+      Common.CompressionType != DebugCompressionType::None ||
+      !Common.compressSections.empty() || Common.DecompressDebugSections ||
+      Common.GapFill != 0 || Common.PadTo != 0 ||
+      Common.ChangeSectionLMAValAll != 0 ||
       !Common.ChangeSectionAddress.empty() || !Common.ExtractSection.empty())
     return createStringError(llvm::errc::invalid_argument,
                              "only flags for section dumping, removal, and "
@@ -102,7 +108,9 @@ Expected<const XCOFFConfig &> ConfigManager::getXCOFFConfig() const {
       Common.ExtractMainPartition || Common.OnlyKeepDebug ||
       Common.PreserveDates || Common.StripAllGNU || Common.StripDWO ||
       Common.StripDebug || Common.StripNonAlloc || Common.StripSections ||
-      Common.Weaken || Common.StripUnneeded || Common.DecompressDebugSections ||
+      Common.Weaken || Common.StripUnneeded ||
+      Common.CompressionType != DebugCompressionType::None ||
+      !Common.compressSections.empty() || Common.DecompressDebugSections ||
       Common.GapFill != 0 || Common.PadTo != 0 ||
       Common.ChangeSectionLMAValAll != 0 ||
       !Common.ChangeSectionAddress.empty() || !Common.ExtractSection.empty()) {
@@ -126,7 +134,9 @@ ConfigManager::getDXContainerConfig() const {
       !Common.SetSectionType.empty() || Common.ExtractDWO ||
       Common.OnlyKeepDebug || Common.StripAllGNU || Common.StripDWO ||
       Common.StripDebug || Common.StripNonAlloc || Common.StripSections ||
-      Common.StripUnneeded || Common.DecompressDebugSections ||
+      Common.StripUnneeded ||
+      Common.CompressionType != DebugCompressionType::None ||
+      !Common.compressSections.empty() || Common.DecompressDebugSections ||
       Common.GapFill != 0 || Common.PadTo != 0 ||
       Common.ChangeSectionLMAValAll != 0 ||
       !Common.ChangeSectionAddress.empty()) {


### PR DESCRIPTION
`--compress-debug-sections` is currently an ELF-only option in the [docs](https://llvm.org/docs/CommandGuide/llvm-objcopy.html#cmdoption-llvm-objcopy-compress-debug-sections) but in `llvm-objcopy`, non-ELF backends were silently ignoring it, while `--decompress-debug-sections` already [reports](https://github.com/llvm/llvm-project/blob/89446086eaed6f07e2c122396570f2985cec62e5/llvm/lib/ObjCopy/ConfigManager.cpp#L32) unsupported-option error. This PR makes behavior consistent by treating `--compress-debug-sections` as unsupported for non-ELF formats too.