### PR TITLE
[clang] apply clang-tidy's llvm-redundant-casting (NFC)

### DIFF
--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -9364,7 +9364,8 @@ Error ASTNodeImporter::ImportOverriddenMethods(CXXMethodDecl *ToMethod,
   Error ImportErrors = Error::success();
   for (auto *FromOverriddenMethod : FromMethod->overridden_methods()) {
     if (auto ImportedOrErr = import(FromOverriddenMethod))
-      ToMethod->getCanonicalDecl()->addOverriddenMethod((*ImportedOrErr)->getCanonicalDecl());
+      ToMethod->getCanonicalDecl()->addOverriddenMethod(
+          (*ImportedOrErr)->getCanonicalDecl());
     else
       ImportErrors =
           joinErrors(std::move(ImportErrors), ImportedOrErr.takeError());

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -8525,7 +8525,7 @@ ASTNodeImporter::VisitMaterializeTemporaryExpr(MaterializeTemporaryExpr *E) {
     return std::move(Err);
 
   if (!ToTemporaryExpr)
-    ToTemporaryExpr = cast<Expr>(ToMaterializedDecl->getTemporaryExpr());
+    ToTemporaryExpr = ToMaterializedDecl->getTemporaryExpr();
 
   auto *ToMTE = new (Importer.getToContext()) MaterializeTemporaryExpr(
       ToType, ToTemporaryExpr, E->isBoundToLvalueReference(),
@@ -8880,7 +8880,7 @@ ASTNodeImporter::VisitUnresolvedLookupExpr(UnresolvedLookupExpr *E) {
   UnresolvedSet<8> ToDecls;
   for (auto *D : E->decls())
     if (auto ToDOrErr = import(D))
-      ToDecls.addDecl(cast<NamedDecl>(*ToDOrErr));
+      ToDecls.addDecl(*ToDOrErr);
     else
       return ToDOrErr.takeError();
 
@@ -9364,8 +9364,7 @@ Error ASTNodeImporter::ImportOverriddenMethods(CXXMethodDecl *ToMethod,
   Error ImportErrors = Error::success();
   for (auto *FromOverriddenMethod : FromMethod->overridden_methods()) {
     if (auto ImportedOrErr = import(FromOverriddenMethod))
-      ToMethod->getCanonicalDecl()->addOverriddenMethod(cast<CXXMethodDecl>(
-          (*ImportedOrErr)->getCanonicalDecl()));
+      ToMethod->getCanonicalDecl()->addOverriddenMethod((*ImportedOrErr)->getCanonicalDecl());
     else
       ImportErrors =
           joinErrors(std::move(ImportErrors), ImportedOrErr.takeError());
@@ -10033,7 +10032,7 @@ Expected<DeclContext *> ASTImporter::ImportContext(DeclContext *FromDC) {
 }
 
 Expected<Expr *> ASTImporter::Import(Expr *FromE) {
-  if (ExpectedStmt ToSOrErr = Import(cast_or_null<Stmt>(FromE)))
+  if (ExpectedStmt ToSOrErr = Import(FromE))
     return cast_or_null<Expr>(*ToSOrErr);
   else
     return ToSOrErr.takeError();

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -10033,7 +10033,7 @@ Expected<DeclContext *> ASTImporter::ImportContext(DeclContext *FromDC) {
 }
 
 Expected<Expr *> ASTImporter::Import(Expr *FromE) {
-  if (ExpectedStmt ToSOrErr = Import(FromE))
+  if (ExpectedStmt ToSOrErr = Import(cast_or_null<Stmt>(FromE)))
     return cast_or_null<Expr>(*ToSOrErr);
   else
     return ToSOrErr.takeError();

--- a/clang/lib/AST/ASTStructuralEquivalence.cpp
+++ b/clang/lib/AST/ASTStructuralEquivalence.cpp
@@ -2464,7 +2464,8 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
   if (D1->getAccessControl() != D2->getAccessControl())
     return false;
 
-  return IsStructurallyEquivalent(Context, D1, D2, Owner2Type);
+  return IsStructurallyEquivalent(Context, cast<FieldDecl>(D1),
+                                  cast<FieldDecl>(D2), Owner2Type);
 }
 
 static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,

--- a/clang/lib/AST/ASTStructuralEquivalence.cpp
+++ b/clang/lib/AST/ASTStructuralEquivalence.cpp
@@ -2464,8 +2464,7 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
   if (D1->getAccessControl() != D2->getAccessControl())
     return false;
 
-  return IsStructurallyEquivalent(Context, D1,
-                                  D2, Owner2Type);
+  return IsStructurallyEquivalent(Context, D1, D2, Owner2Type);
 }
 
 static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,

--- a/clang/lib/AST/ASTStructuralEquivalence.cpp
+++ b/clang/lib/AST/ASTStructuralEquivalence.cpp
@@ -2464,8 +2464,8 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
   if (D1->getAccessControl() != D2->getAccessControl())
     return false;
 
-  return IsStructurallyEquivalent(Context, cast<FieldDecl>(D1),
-                                  cast<FieldDecl>(D2), Owner2Type);
+  return IsStructurallyEquivalent(Context, D1,
+                                  D2, Owner2Type);
 }
 
 static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -18,6 +18,7 @@
 #include "State.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/CXXInheritance.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
@@ -444,7 +445,7 @@ bool CheckConstant(InterpState &S, CodePtr OpPC, const Descriptor *Desc) {
   // If we're evaluating the initializer for a constexpr variable in C23, we may
   // only read other contexpr variables. Abort here since this one isn't
   // constexpr.
-  if (const auto *VD = S.EvaluatingDecl;
+  if (const VarDecl *VD = S.EvaluatingDecl;
       VD && VD->isConstexpr() && S.getLangOpts().C23)
     return Invalid(S, OpPC);
 
@@ -1772,7 +1773,7 @@ bool CallVirt(InterpState &S, CodePtr OpPC, const Function *Func,
     return false;
   assert(DynamicDecl);
 
-  const auto *StaticDecl = Func->getParentDecl();
+  const CXXRecordDecl *StaticDecl = Func->getParentDecl();
   const auto *InitialFunction = cast<CXXMethodDecl>(Callee);
   const CXXMethodDecl *Overrider;
 

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -444,7 +444,7 @@ bool CheckConstant(InterpState &S, CodePtr OpPC, const Descriptor *Desc) {
   // If we're evaluating the initializer for a constexpr variable in C23, we may
   // only read other contexpr variables. Abort here since this one isn't
   // constexpr.
-  if (const auto *VD = dyn_cast_if_present<VarDecl>(S.EvaluatingDecl);
+  if (const auto *VD = S.EvaluatingDecl;
       VD && VD->isConstexpr() && S.getLangOpts().C23)
     return Invalid(S, OpPC);
 
@@ -1772,7 +1772,7 @@ bool CallVirt(InterpState &S, CodePtr OpPC, const Function *Func,
     return false;
   assert(DynamicDecl);
 
-  const auto *StaticDecl = cast<CXXRecordDecl>(Func->getParentDecl());
+  const auto *StaticDecl = Func->getParentDecl();
   const auto *InitialFunction = cast<CXXMethodDecl>(Callee);
   const CXXMethodDecl *Overrider;
 

--- a/clang/lib/AST/CXXInheritance.cpp
+++ b/clang/lib/AST/CXXInheritance.cpp
@@ -453,7 +453,7 @@ void FinalOverriderCollector::Collect(const CXXRecordDecl *RD,
   unsigned SubobjectNumber = 0;
   if (!VirtualBase)
     SubobjectNumber
-      = ++SubobjectCount[cast<CXXRecordDecl>(RD->getCanonicalDecl())];
+      = ++SubobjectCount[RD->getCanonicalDecl()];
 
   for (const auto &Base : RD->bases()) {
     if (const auto *BaseDecl = Base.getType()->getAsCXXRecordDecl()) {

--- a/clang/lib/AST/CXXInheritance.cpp
+++ b/clang/lib/AST/CXXInheritance.cpp
@@ -452,8 +452,7 @@ void FinalOverriderCollector::Collect(const CXXRecordDecl *RD,
                                       CXXFinalOverriderMap &Overriders) {
   unsigned SubobjectNumber = 0;
   if (!VirtualBase)
-    SubobjectNumber
-      = ++SubobjectCount[RD->getCanonicalDecl()];
+    SubobjectNumber = ++SubobjectCount[RD->getCanonicalDecl()];
 
   for (const auto &Base : RD->bases()) {
     if (const auto *BaseDecl = Base.getType()->getAsCXXRecordDecl()) {

--- a/clang/lib/AST/ComputeDependence.cpp
+++ b/clang/lib/AST/ComputeDependence.cpp
@@ -153,8 +153,7 @@ ExprDependence clang::computeDependence(ExplicitCastExpr *E) {
   // because when the type as written is a deduced type, that type is not
   // dependent, but it may be deduced as a dependent type.
   ExprDependence D =
-      toExprDependenceAsWritten(
-          E->getTypeAsWritten()->getDependence()) |
+      toExprDependenceAsWritten(E->getTypeAsWritten()->getDependence()) |
       toExprDependenceForImpliedType(E->getType()->getDependence());
   if (auto *S = E->getSubExpr())
     D |= S->getDependence() & ~ExprDependence::Type;

--- a/clang/lib/AST/ComputeDependence.cpp
+++ b/clang/lib/AST/ComputeDependence.cpp
@@ -154,7 +154,7 @@ ExprDependence clang::computeDependence(ExplicitCastExpr *E) {
   // dependent, but it may be deduced as a dependent type.
   ExprDependence D =
       toExprDependenceAsWritten(
-          cast<ExplicitCastExpr>(E)->getTypeAsWritten()->getDependence()) |
+          E->getTypeAsWritten()->getDependence()) |
       toExprDependenceForImpliedType(E->getType()->getDependence());
   if (auto *S = E->getSubExpr())
     D |= S->getDependence() & ~ExprDependence::Type;

--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -1778,8 +1778,7 @@ CXXMethodDecl *CXXRecordDecl::getLambdaStaticInvoker(CallingConv CC) const {
   DeclContext::lookup_result Invoker = getLambdaStaticInvokers(*this);
 
   for (NamedDecl *ND : Invoker) {
-    const auto *FTy =
-        ND->getAsFunction()->getType()->castAs<FunctionType>();
+    const auto *FTy = ND->getAsFunction()->getType()->castAs<FunctionType>();
     if (FTy->getCallConv() == CC)
       return getInvokerAsMethod(ND);
   }
@@ -3169,8 +3168,7 @@ void CXXDestructorDecl::setOperatorDelete(FunctionDecl *OD, Expr *ThisArg) {
         this, OD, ASTContext::OperatorDeleteKind::Regular);
     getCanonicalDecl()->OperatorDeleteThisArg = ThisArg;
     if (auto *L = getASTMutationListener())
-      L->ResolvedOperatorDelete(getCanonicalDecl(), OD,
-                                ThisArg);
+      L->ResolvedOperatorDelete(getCanonicalDecl(), OD, ThisArg);
   }
 }
 
@@ -3187,8 +3185,7 @@ void CXXDestructorDecl::setOperatorGlobalDelete(FunctionDecl *OD) {
     getASTContext().addOperatorDeleteForVDtor(
         this, OD, ASTContext::OperatorDeleteKind::GlobalRegular);
     if (auto *L = getASTMutationListener())
-      L->ResolvedOperatorGlobDelete(getCanonicalDecl(),
-                                    OD);
+      L->ResolvedOperatorGlobDelete(getCanonicalDecl(), OD);
   }
 }
 
@@ -3200,8 +3197,7 @@ void CXXDestructorDecl::setOperatorArrayDelete(FunctionDecl *OD) {
     getASTContext().addOperatorDeleteForVDtor(
         this, OD, ASTContext::OperatorDeleteKind::Array);
     if (auto *L = getASTMutationListener())
-      L->ResolvedOperatorArrayDelete(
-          getCanonicalDecl(), OD);
+      L->ResolvedOperatorArrayDelete(getCanonicalDecl(), OD);
   }
 }
 
@@ -3214,8 +3210,7 @@ void CXXDestructorDecl::setGlobalOperatorArrayDelete(FunctionDecl *OD) {
     getASTContext().addOperatorDeleteForVDtor(
         this, OD, ASTContext::OperatorDeleteKind::ArrayGlobal);
     if (auto *L = getASTMutationListener())
-      L->ResolvedOperatorGlobArrayDelete(
-          getCanonicalDecl(), OD);
+      L->ResolvedOperatorGlobArrayDelete(getCanonicalDecl(), OD);
   }
 }
 

--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -1779,7 +1779,7 @@ CXXMethodDecl *CXXRecordDecl::getLambdaStaticInvoker(CallingConv CC) const {
 
   for (NamedDecl *ND : Invoker) {
     const auto *FTy =
-        cast<ValueDecl>(ND->getAsFunction())->getType()->castAs<FunctionType>();
+        ND->getAsFunction()->getType()->castAs<FunctionType>();
     if (FTy->getCallConv() == CC)
       return getInvokerAsMethod(ND);
   }
@@ -3169,7 +3169,7 @@ void CXXDestructorDecl::setOperatorDelete(FunctionDecl *OD, Expr *ThisArg) {
         this, OD, ASTContext::OperatorDeleteKind::Regular);
     getCanonicalDecl()->OperatorDeleteThisArg = ThisArg;
     if (auto *L = getASTMutationListener())
-      L->ResolvedOperatorDelete(cast<CXXDestructorDecl>(getCanonicalDecl()), OD,
+      L->ResolvedOperatorDelete(getCanonicalDecl(), OD,
                                 ThisArg);
   }
 }
@@ -3187,7 +3187,7 @@ void CXXDestructorDecl::setOperatorGlobalDelete(FunctionDecl *OD) {
     getASTContext().addOperatorDeleteForVDtor(
         this, OD, ASTContext::OperatorDeleteKind::GlobalRegular);
     if (auto *L = getASTMutationListener())
-      L->ResolvedOperatorGlobDelete(cast<CXXDestructorDecl>(getCanonicalDecl()),
+      L->ResolvedOperatorGlobDelete(getCanonicalDecl(),
                                     OD);
   }
 }
@@ -3201,7 +3201,7 @@ void CXXDestructorDecl::setOperatorArrayDelete(FunctionDecl *OD) {
         this, OD, ASTContext::OperatorDeleteKind::Array);
     if (auto *L = getASTMutationListener())
       L->ResolvedOperatorArrayDelete(
-          cast<CXXDestructorDecl>(getCanonicalDecl()), OD);
+          getCanonicalDecl(), OD);
   }
 }
 
@@ -3215,7 +3215,7 @@ void CXXDestructorDecl::setGlobalOperatorArrayDelete(FunctionDecl *OD) {
         this, OD, ASTContext::OperatorDeleteKind::ArrayGlobal);
     if (auto *L = getASTMutationListener())
       L->ResolvedOperatorGlobArrayDelete(
-          cast<CXXDestructorDecl>(getCanonicalDecl()), OD);
+          getCanonicalDecl(), OD);
   }
 }
 

--- a/clang/lib/AST/DeclObjC.cpp
+++ b/clang/lib/AST/DeclObjC.cpp
@@ -264,7 +264,7 @@ ObjCPropertyDecl *ObjCContainerDecl::FindPropertyDeclaration(
   }
 
   if (ObjCPropertyDecl *PD =
-        ObjCPropertyDecl::findPropertyDecl(cast<DeclContext>(this), PropertyId,
+        ObjCPropertyDecl::findPropertyDecl(this, PropertyId,
                                            QueryKind))
     return PD;
 
@@ -386,7 +386,7 @@ ObjCPropertyDecl *ObjCInterfaceDecl::FindPropertyVisibleInPrimaryClass(
     LoadExternalDefinition();
 
   if (ObjCPropertyDecl *PD =
-      ObjCPropertyDecl::findPropertyDecl(cast<DeclContext>(this), PropertyId,
+      ObjCPropertyDecl::findPropertyDecl(this, PropertyId,
                                          QueryKind))
     return PD;
 

--- a/clang/lib/AST/DeclObjC.cpp
+++ b/clang/lib/AST/DeclObjC.cpp
@@ -264,8 +264,7 @@ ObjCPropertyDecl *ObjCContainerDecl::FindPropertyDeclaration(
   }
 
   if (ObjCPropertyDecl *PD =
-        ObjCPropertyDecl::findPropertyDecl(this, PropertyId,
-                                           QueryKind))
+          ObjCPropertyDecl::findPropertyDecl(this, PropertyId, QueryKind))
     return PD;
 
   switch (getKind()) {
@@ -386,8 +385,7 @@ ObjCPropertyDecl *ObjCInterfaceDecl::FindPropertyVisibleInPrimaryClass(
     LoadExternalDefinition();
 
   if (ObjCPropertyDecl *PD =
-      ObjCPropertyDecl::findPropertyDecl(this, PropertyId,
-                                         QueryKind))
+          ObjCPropertyDecl::findPropertyDecl(this, PropertyId, QueryKind))
     return PD;
 
   // Look through protocols.

--- a/clang/lib/AST/ExprCXX.cpp
+++ b/clang/lib/AST/ExprCXX.cpp
@@ -1351,7 +1351,7 @@ Stmt *LambdaExpr::getBody() const {
 const CompoundStmt *LambdaExpr::getCompoundStmtBody() const {
   Stmt *Body = getBody();
   if (const auto *CoroBody = dyn_cast<CoroutineBodyStmt>(Body))
-    return cast<CompoundStmt>(CoroBody->getBody());
+    return CoroBody->getBody();
   return cast<CompoundStmt>(Body);
 }
 

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -9392,7 +9392,7 @@ bool LValueExprEvaluator::VisitDeclRefExpr(const DeclRefExpr *E) {
 
   if (isa<FunctionDecl, MSGuidDecl, TemplateParamObjectDecl,
           UnnamedGlobalConstantDecl>(D))
-    return Success(cast<ValueDecl>(D));
+    return Success(D);
   if (const VarDecl *VD = dyn_cast<VarDecl>(D))
     return VisitVarDecl(E, VD);
   if (const BindingDecl *BD = dyn_cast<BindingDecl>(D))

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4655,7 +4655,7 @@ void CXXNameMangler::mangleType(const DependentBitIntType *T) {
 }
 
 void CXXNameMangler::mangleType(const ArrayParameterType *T) {
-  mangleType(cast<ConstantArrayType>(T));
+  mangleType(T);
 }
 
 void CXXNameMangler::mangleType(const HLSLAttributedResourceType *T) {

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4654,7 +4654,9 @@ void CXXNameMangler::mangleType(const DependentBitIntType *T) {
   Out << "_";
 }
 
-void CXXNameMangler::mangleType(const ArrayParameterType *T) { mangleType(T); }
+void CXXNameMangler::mangleType(const ArrayParameterType *T) {
+  mangleType(cast<ConstantArrayType>(T));
+}
 
 void CXXNameMangler::mangleType(const HLSLAttributedResourceType *T) {
   llvm::SmallString<64> Str("_Res");

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4654,9 +4654,7 @@ void CXXNameMangler::mangleType(const DependentBitIntType *T) {
   Out << "_";
 }
 
-void CXXNameMangler::mangleType(const ArrayParameterType *T) {
-  mangleType(T);
-}
+void CXXNameMangler::mangleType(const ArrayParameterType *T) { mangleType(T); }
 
 void CXXNameMangler::mangleType(const HLSLAttributedResourceType *T) {
   llvm::SmallString<64> Str("_Res");

--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -3246,11 +3246,11 @@ void MicrosoftCXXNameMangler::mangleTagTypeKind(TagTypeKind TTK) {
 }
 void MicrosoftCXXNameMangler::mangleType(const EnumType *T, Qualifiers,
                                          SourceRange) {
-  mangleType(cast<TagType>(T)->getDecl());
+  mangleType(T->getDecl());
 }
 void MicrosoftCXXNameMangler::mangleType(const RecordType *T, Qualifiers,
                                          SourceRange) {
-  mangleType(cast<TagType>(T)->getDecl());
+  mangleType(T->getDecl());
 }
 void MicrosoftCXXNameMangler::mangleType(const TagDecl *TD) {
   // MSVC chooses the tag kind of the definition if it exists, otherwise it
@@ -3347,7 +3347,7 @@ void MicrosoftCXXNameMangler::mangleArrayType(const ArrayType *T) {
 
 void MicrosoftCXXNameMangler::mangleType(const ArrayParameterType *T,
                                          Qualifiers, SourceRange) {
-  mangleArrayType(cast<ConstantArrayType>(T));
+  mangleArrayType(T);
 }
 
 // <type>                   ::= <pointer-to-member-type>

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -75,7 +75,7 @@ const Expr *CXXForRangeStmt::getRangeInit() const {
 }
 
 VarDecl *CXXForRangeStmt::getLoopVariable() {
-  Decl *LV = cast<DeclStmt>(getLoopVarStmt())->getSingleDecl();
+  Decl *LV = getLoopVarStmt()->getSingleDecl();
   assert(LV && "No loop variable in CXXForRangeStmt");
   return cast<VarDecl>(LV);
 }

--- a/clang/lib/AST/StmtPrinter.cpp
+++ b/clang/lib/AST/StmtPrinter.cpp
@@ -2121,7 +2121,7 @@ void StmtPrinter::VisitCXXMemberCallExpr(CXXMemberCallExpr *Node) {
     PrintExpr(Node->getImplicitObjectArgument());
     return;
   }
-  VisitCallExpr(cast<CallExpr>(Node));
+  VisitCallExpr(Node);
 }
 
 void StmtPrinter::VisitCUDAKernelCallExpr(CUDAKernelCallExpr *Node) {

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -831,7 +831,7 @@ void TextNodeDumper::Visit(const APValue &Value, QualType Ty) {
     {
       ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
       if (const FieldDecl *FD = Value.getUnionField())
-        OS << " ." << *cast<NamedDecl>(FD);
+        OS << " ." << *FD;
     }
     // If the union value is considered to be simple, fold it into the
     // current line to save some vertical space.

--- a/clang/lib/Analysis/AnalysisDeclContext.cpp
+++ b/clang/lib/Analysis/AnalysisDeclContext.cpp
@@ -119,7 +119,7 @@ Stmt *AnalysisDeclContext::getBody(bool &IsAutosynthesized) const {
     return FunTmpl->getTemplatedDecl()->getBody();
   else if (const auto *VD = dyn_cast_or_null<VarDecl>(D)) {
     if (VD->isFileVarDecl()) {
-      return const_cast<Stmt *>(dyn_cast_or_null<Stmt>(VD->getInit()));
+      return const_cast<Expr *>(VD->getInit());
     }
   }
 

--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -6124,7 +6124,7 @@ static void print_elem(raw_ostream &OS, StmtPrinterHelper &Helper,
       return;
     CXXDeleteExpr *DelExpr =
         const_cast<CXXDeleteExpr*>(DE.getDeleteExpr());
-    Helper.handledStmt(cast<Stmt>(DelExpr->getArgument()), OS);
+    Helper.handledStmt(DelExpr->getArgument(), OS);
     OS << "->~" << RD->getName().str() << "()";
     OS << " (Implicit destructor)";
     break;

--- a/clang/lib/Analysis/Consumed.cpp
+++ b/clang/lib/Analysis/Consumed.cpp
@@ -804,7 +804,7 @@ void ConsumedStmtVisitor::VisitCXXMemberCallExpr(
 
 void ConsumedStmtVisitor::VisitCXXOperatorCallExpr(
     const CXXOperatorCallExpr *Call) {
-  const auto *FunDecl = Call->getDirectCallee();
+  const FunctionDecl *FunDecl = Call->getDirectCallee();
   if (!FunDecl) return;
 
   if (Call->getOperator() == OO_Equal) {

--- a/clang/lib/Analysis/Consumed.cpp
+++ b/clang/lib/Analysis/Consumed.cpp
@@ -804,7 +804,7 @@ void ConsumedStmtVisitor::VisitCXXMemberCallExpr(
 
 void ConsumedStmtVisitor::VisitCXXOperatorCallExpr(
     const CXXOperatorCallExpr *Call) {
-  const auto *FunDecl = dyn_cast_or_null<FunctionDecl>(Call->getDirectCallee());
+  const auto *FunDecl = Call->getDirectCallee();
   if (!FunDecl) return;
 
   if (Call->getOperator() == OO_Equal) {

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -344,7 +344,7 @@ public:
     for (auto [Target, EscapeExpr] : AnnotationWarningsMap) {
       if (const auto *MD = Target.dyn_cast<const CXXMethodDecl *>()) {
         if (!implicitObjectParamIsLifetimeBound(MD))
-          SemaHelper->addLifetimeBoundToImplicitThis(cast<CXXMethodDecl>(MD));
+          SemaHelper->addLifetimeBoundToImplicitThis(MD);
       } else if (const auto *PVD = Target.dyn_cast<const ParmVarDecl *>()) {
         const auto *FD = dyn_cast<FunctionDecl>(PVD->getDeclContext());
         if (!FD)

--- a/clang/lib/Analysis/ThreadSafetyCommon.cpp
+++ b/clang/lib/Analysis/ThreadSafetyCommon.cpp
@@ -480,7 +480,7 @@ til::SExpr *SExprBuilder::translateObjCIVarRefExpr(const ObjCIvarRefExpr *IVRE,
   til::SExpr *BE = translate(IVRE->getBase(), Ctx);
   til::SExpr *E = new (Arena) til::SApply(BE);
 
-  const auto *D = IVRE->getDecl()->getCanonicalDecl();
+  const ObjCIvarDecl *D = IVRE->getDecl()->getCanonicalDecl();
 
   til::Project *P = new (Arena) til::Project(E, D);
   if (hasAnyPointerType(BE))

--- a/clang/lib/Analysis/ThreadSafetyCommon.cpp
+++ b/clang/lib/Analysis/ThreadSafetyCommon.cpp
@@ -526,8 +526,7 @@ til::SExpr *SExprBuilder::translateCXXMemberCallExpr(
       // return E;
     }
   }
-  return translateCallExpr(ME, Ctx,
-                           ME->getImplicitObjectArgument());
+  return translateCallExpr(ME, Ctx, ME->getImplicitObjectArgument());
 }
 
 til::SExpr *SExprBuilder::translateCXXOperatorCallExpr(

--- a/clang/lib/Analysis/ThreadSafetyCommon.cpp
+++ b/clang/lib/Analysis/ThreadSafetyCommon.cpp
@@ -480,7 +480,7 @@ til::SExpr *SExprBuilder::translateObjCIVarRefExpr(const ObjCIvarRefExpr *IVRE,
   til::SExpr *BE = translate(IVRE->getBase(), Ctx);
   til::SExpr *E = new (Arena) til::SApply(BE);
 
-  const auto *D = cast<ObjCIvarDecl>(IVRE->getDecl()->getCanonicalDecl());
+  const auto *D = IVRE->getDecl()->getCanonicalDecl();
 
   til::Project *P = new (Arena) til::Project(E, D);
   if (hasAnyPointerType(BE))
@@ -526,7 +526,7 @@ til::SExpr *SExprBuilder::translateCXXMemberCallExpr(
       // return E;
     }
   }
-  return translateCallExpr(cast<CallExpr>(ME), Ctx,
+  return translateCallExpr(ME, Ctx,
                            ME->getImplicitObjectArgument());
 }
 
@@ -541,7 +541,7 @@ til::SExpr *SExprBuilder::translateCXXOperatorCallExpr(
       // return E;
     }
   }
-  return translateCallExpr(cast<CallExpr>(OCE), Ctx);
+  return translateCallExpr(OCE, Ctx);
 }
 
 til::SExpr *SExprBuilder::translateUnaryOperator(const UnaryOperator *UO,

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -4235,7 +4235,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
       // requires the reassoc FMF flag.
       llvm::FastMathFlags FMF;
       FMF.setAllowReassoc();
-      cast<llvm::CallBase>(Reduce)->setFastMathFlags(FMF);
+      Reduce->setFastMathFlags(FMF);
     }
     return RValue::get(Reduce);
   }

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -2702,7 +2702,7 @@ CGDebugInfo::CollectTemplateParams(std::optional<TemplateArgs> OArgs,
         V = V->stripPointerCasts();
       }
       TemplateParams.push_back(DBuilder.createTemplateValueParameter(
-          TheCU, Name, TTy, defaultParameter, cast_or_null<llvm::Constant>(V)));
+          TheCU, Name, TTy, defaultParameter, V));
     } break;
     case TemplateArgument::NullPtr: {
       QualType T = TA.getNullPtrType();
@@ -3268,7 +3268,7 @@ void CGDebugInfo::completeRequiredType(const RecordDecl *RD) {
 
 llvm::DIType *CGDebugInfo::CreateType(const RecordType *Ty) {
   RecordDecl *RD = Ty->getDecl()->getDefinitionOrSelf();
-  llvm::DIType *T = cast_or_null<llvm::DIType>(getTypeOrNull(QualType(Ty, 0)));
+  llvm::DIType *T = getTypeOrNull(QualType(Ty, 0));
   if (T || shouldOmitDefinition(DebugKind, DebugTypeExtRefs, RD,
                                 CGM.getLangOpts())) {
     if (!T)
@@ -4664,7 +4664,7 @@ CGDebugInfo::getGlobalVariableForwardDeclaration(const VarDecl *VD) {
       !VD->isExternallyVisible(), nullptr, TemplateParameters, Align);
   FwdDeclReplaceMap.emplace_back(
       std::piecewise_construct,
-      std::make_tuple(cast<VarDecl>(VD->getCanonicalDecl())),
+      std::make_tuple(VD->getCanonicalDecl()),
       std::make_tuple(static_cast<llvm::Metadata *>(GV)));
   return GV;
 }
@@ -4694,7 +4694,7 @@ llvm::DINode *CGDebugInfo::getDeclarationOrDefinition(const Decl *D) {
   if (IE != ImportedDeclCache.end()) {
     auto N = IE->second;
     if (auto *GVE = dyn_cast_or_null<llvm::DIImportedEntity>(N))
-      return cast<llvm::DINode>(GVE);
+      return GVE;
     return dyn_cast_or_null<llvm::DINode>(N);
   }
 

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -4663,8 +4663,7 @@ CGDebugInfo::getGlobalVariableForwardDeclaration(const VarDecl *VD) {
       DContext, Name, LinkageName, Unit, Line, getOrCreateType(T, Unit),
       !VD->isExternallyVisible(), nullptr, TemplateParameters, Align);
   FwdDeclReplaceMap.emplace_back(
-      std::piecewise_construct,
-      std::make_tuple(VD->getCanonicalDecl()),
+      std::piecewise_construct, std::make_tuple(VD->getCanonicalDecl()),
       std::make_tuple(static_cast<llvm::Metadata *>(GV)));
   return GV;
 }

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -297,7 +297,7 @@ llvm::Constant *CodeGenModule::getOrCreateStaticVarDecl(
     setTLSMode(GV, D);
 
   setGVProperties(GV, &D);
-  getTargetCodeGenInfo().setTargetAttributes(cast<Decl>(&D), GV, *this);
+  getTargetCodeGenInfo().setTargetAttributes(&D, GV, *this);
 
   // Make sure the result is of the correct type.
   LangAS ExpectedAS = Ty.getAddressSpace();
@@ -1073,7 +1073,7 @@ static llvm::Constant *constStructWithPadding(CodeGenModule &CGM,
     if (constant->isNullValue())
       CurOp = llvm::Constant::getNullValue(STy->getElementType(i));
     else
-      CurOp = cast<llvm::Constant>(constant->getAggregateElement(i));
+      CurOp = constant->getAggregateElement(i);
     auto *NewOp = constWithPadding(CGM, isPattern, CurOp);
     if (CurOp != NewOp)
       NestedIntact = false;

--- a/clang/lib/CodeGen/CGExprConstant.cpp
+++ b/clang/lib/CodeGen/CGExprConstant.cpp
@@ -2410,7 +2410,7 @@ ConstantLValueEmitter::VisitObjCCollectionElement(const Expr *E) {
 
   llvm::Type *DstTy = CGM.getTypes().ConvertType(DestTy);
   ConstantLValue LV = Visit(Elm);
-  llvm::Constant *ConstVal = cast<llvm::Constant>(LV.Value);
+  llvm::Constant *ConstVal = LV.Value;
   llvm::Constant *Val = llvm::ConstantExpr::getBitCast(ConstVal, DstTy);
   return Val;
 }

--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -1990,7 +1990,8 @@ class CGObjCGNUstep2 : public CGObjCGNUstep {
       // we can't import a class struct.
       if (OID->getClassInterface()->hasAttr<DLLExportAttr>()) {
         classStruct->setDLLStorageClass(llvm::GlobalValue::DLLExportStorageClass);
-        classRefSymbol->setDLLStorageClass(llvm::GlobalValue::DLLExportStorageClass);
+        classRefSymbol->setDLLStorageClass(
+            llvm::GlobalValue::DLLExportStorageClass);
       }
 
       if (SuperClass) {

--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -1284,7 +1284,7 @@ class CGObjCGNUstep2 : public CGObjCGNUstep {
         else if (OID->hasAttr<DLLExportAttr>())
           Storage = llvm::GlobalValue::DLLExportStorageClass;
 
-        cast<llvm::GlobalValue>(ClassSymbol)->setDLLStorageClass(Storage);
+        ClassSymbol->setDLLStorageClass(Storage);
       }
     }
     assert(ClassSymbol->getName() == SymbolName);
@@ -1990,7 +1990,7 @@ class CGObjCGNUstep2 : public CGObjCGNUstep {
       // we can't import a class struct.
       if (OID->getClassInterface()->hasAttr<DLLExportAttr>()) {
         classStruct->setDLLStorageClass(llvm::GlobalValue::DLLExportStorageClass);
-        cast<llvm::GlobalValue>(classRefSymbol)->setDLLStorageClass(llvm::GlobalValue::DLLExportStorageClass);
+        classRefSymbol->setDLLStorageClass(llvm::GlobalValue::DLLExportStorageClass);
       }
 
       if (SuperClass) {

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -11274,7 +11274,7 @@ bool CGOpenMPRuntime::emitTargetFunctions(GlobalDecl GD) {
   // the normal code generation.
   if (!CGM.getLangOpts().OpenMPIsTargetDevice) {
     if (const auto *FD = dyn_cast<FunctionDecl>(GD.getDecl()))
-      if (isAssumedToBeNotEmitted(cast<ValueDecl>(FD),
+      if (isAssumedToBeNotEmitted(FD,
                                   CGM.getLangOpts().OpenMPIsTargetDevice))
         return true;
     return false;
@@ -11285,7 +11285,7 @@ bool CGOpenMPRuntime::emitTargetFunctions(GlobalDecl GD) {
   if (const auto *FD = dyn_cast<FunctionDecl>(VD)) {
     StringRef Name = CGM.getMangledName(GD);
     scanForTargetRegionsFunctions(FD->getBody(), Name);
-    if (isAssumedToBeNotEmitted(cast<ValueDecl>(FD),
+    if (isAssumedToBeNotEmitted(FD,
                                 CGM.getLangOpts().OpenMPIsTargetDevice))
       return true;
   }
@@ -12884,7 +12884,7 @@ void CGOpenMPRuntime::emitLastprivateConditionalUpdate(CodeGenFunction &CGF,
   // decltype(priv_a) last_a;
   llvm::GlobalVariable *Last = OMPBuilder.getOrCreateInternalVariable(
       CGF.ConvertTypeForMem(LVal.getType()), UniqueDeclName);
-  cast<llvm::GlobalVariable>(Last)->setAlignment(
+  Last->setAlignment(
       LVal.getAlignment().getAsAlign());
   LValue LastLVal =
       CGF.MakeRawAddrLValue(Last, LVal.getType(), LVal.getAlignment());

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -11274,8 +11274,7 @@ bool CGOpenMPRuntime::emitTargetFunctions(GlobalDecl GD) {
   // the normal code generation.
   if (!CGM.getLangOpts().OpenMPIsTargetDevice) {
     if (const auto *FD = dyn_cast<FunctionDecl>(GD.getDecl()))
-      if (isAssumedToBeNotEmitted(FD,
-                                  CGM.getLangOpts().OpenMPIsTargetDevice))
+      if (isAssumedToBeNotEmitted(FD, CGM.getLangOpts().OpenMPIsTargetDevice))
         return true;
     return false;
   }
@@ -11285,8 +11284,7 @@ bool CGOpenMPRuntime::emitTargetFunctions(GlobalDecl GD) {
   if (const auto *FD = dyn_cast<FunctionDecl>(VD)) {
     StringRef Name = CGM.getMangledName(GD);
     scanForTargetRegionsFunctions(FD->getBody(), Name);
-    if (isAssumedToBeNotEmitted(FD,
-                                CGM.getLangOpts().OpenMPIsTargetDevice))
+    if (isAssumedToBeNotEmitted(FD, CGM.getLangOpts().OpenMPIsTargetDevice))
       return true;
   }
 
@@ -12884,8 +12882,7 @@ void CGOpenMPRuntime::emitLastprivateConditionalUpdate(CodeGenFunction &CGF,
   // decltype(priv_a) last_a;
   llvm::GlobalVariable *Last = OMPBuilder.getOrCreateInternalVariable(
       CGF.ConvertTypeForMem(LVal.getType()), UniqueDeclName);
-  Last->setAlignment(
-      LVal.getAlignment().getAsAlign());
+  Last->setAlignment(LVal.getAlignment().getAsAlign());
   LValue LastLVal =
       CGF.MakeRawAddrLValue(Last, LVal.getType(), LVal.getAlignment());
 

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -946,7 +946,7 @@ llvm::Function *CGOpenMPRuntimeGPU::emitParallelOutlinedFunction(
   // Emit target region as a standalone region.
   bool PrevIsInTTDRegion = IsInTTDRegion;
   IsInTTDRegion = false;
-  auto *OutlinedFun = CGOpenMPRuntime::emitParallelOutlinedFunction(
+  llvm::Function *OutlinedFun = CGOpenMPRuntime::emitParallelOutlinedFunction(
       CGF, D, ThreadIDVar, InnermostKind, CodeGen);
   IsInTTDRegion = PrevIsInTTDRegion;
   if (getExecutionMode() != CGOpenMPRuntimeGPU::EM_SPMD) {

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -947,8 +947,8 @@ llvm::Function *CGOpenMPRuntimeGPU::emitParallelOutlinedFunction(
   bool PrevIsInTTDRegion = IsInTTDRegion;
   IsInTTDRegion = false;
   auto *OutlinedFun =
-      cast<llvm::Function>(CGOpenMPRuntime::emitParallelOutlinedFunction(
-          CGF, D, ThreadIDVar, InnermostKind, CodeGen));
+      CGOpenMPRuntime::emitParallelOutlinedFunction(
+          CGF, D, ThreadIDVar, InnermostKind, CodeGen);
   IsInTTDRegion = PrevIsInTTDRegion;
   if (getExecutionMode() != CGOpenMPRuntimeGPU::EM_SPMD) {
     llvm::Function *WrapperFun =

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -946,9 +946,8 @@ llvm::Function *CGOpenMPRuntimeGPU::emitParallelOutlinedFunction(
   // Emit target region as a standalone region.
   bool PrevIsInTTDRegion = IsInTTDRegion;
   IsInTTDRegion = false;
-  auto *OutlinedFun =
-      CGOpenMPRuntime::emitParallelOutlinedFunction(
-          CGF, D, ThreadIDVar, InnermostKind, CodeGen);
+  auto *OutlinedFun = CGOpenMPRuntime::emitParallelOutlinedFunction(
+      CGF, D, ThreadIDVar, InnermostKind, CodeGen);
   IsInTTDRegion = PrevIsInTTDRegion;
   if (getExecutionMode() != CGOpenMPRuntimeGPU::EM_SPMD) {
     llvm::Function *WrapperFun =

--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -2453,7 +2453,7 @@ void CodeGenFunction::EmitOMPInnerLoop(
   const SourceRange R = S.getSourceRange();
 
   // If attributes are attached, push to the basic block with them.
-  const auto &OMPED = S;
+  const OMPExecutableDirective &OMPED = S;
   const CapturedStmt *ICS = OMPED.getInnermostCapturedStmt();
   const Stmt *SS = ICS->getCapturedStmt();
   const AttributedStmt *AS = dyn_cast_or_null<AttributedStmt>(SS);
@@ -2699,7 +2699,7 @@ void CodeGenFunction::EmitOMPLinearClause(
   llvm::DenseSet<const VarDecl *> SIMDLCVs;
   OpenMPDirectiveKind EKind = getEffectiveDirectiveKind(D);
   if (isOpenMPSimdDirective(EKind)) {
-    const auto *LoopDirective = &D;
+    const OMPLoopDirective *LoopDirective = &D;
     for (const Expr *C : LoopDirective->counters()) {
       SIMDLCVs.insert(
           cast<VarDecl>(cast<DeclRefExpr>(C)->getDecl())->getCanonicalDecl());

--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -2453,7 +2453,7 @@ void CodeGenFunction::EmitOMPInnerLoop(
   const SourceRange R = S.getSourceRange();
 
   // If attributes are attached, push to the basic block with them.
-  const auto &OMPED = cast<OMPExecutableDirective>(S);
+  const auto &OMPED = S;
   const CapturedStmt *ICS = OMPED.getInnermostCapturedStmt();
   const Stmt *SS = ICS->getCapturedStmt();
   const AttributedStmt *AS = dyn_cast_or_null<AttributedStmt>(SS);
@@ -2699,7 +2699,7 @@ void CodeGenFunction::EmitOMPLinearClause(
   llvm::DenseSet<const VarDecl *> SIMDLCVs;
   OpenMPDirectiveKind EKind = getEffectiveDirectiveKind(D);
   if (isOpenMPSimdDirective(EKind)) {
-    const auto *LoopDirective = cast<OMPLoopDirective>(&D);
+    const auto *LoopDirective = &D;
     for (const Expr *C : LoopDirective->counters()) {
       SIMDLCVs.insert(
           cast<VarDecl>(cast<DeclRefExpr>(C)->getDecl())->getCanonicalDecl());

--- a/clang/lib/CodeGen/CodeGenSYCL.cpp
+++ b/clang/lib/CodeGen/CodeGenSYCL.cpp
@@ -80,6 +80,6 @@ void CodeGenModule::EmitSYCLKernelCaller(const FunctionDecl *KernelEntryPointFn,
                     SourceLocation(), SourceLocation());
   CGF.EmitFunctionBody(OutlinedFnDecl->getBody());
   setDSOLocal(Fn);
-  SetLLVMFunctionAttributesForDefinition(cast<Decl>(OutlinedFnDecl), Fn);
+  SetLLVMFunctionAttributesForDefinition(OutlinedFnDecl, Fn);
   CGF.FinishFunction();
 }

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -3362,8 +3362,7 @@ void ItaniumCXXABI::EmitThreadLocalInitFuncs(
       llvm::Function *Func = llvm::Function::Create(
           InitFnTy, Var->getLinkage(), InitFnName.str(), &CGM.getModule());
       const CGFunctionInfo &FI = CGM.getTypes().arrangeNullaryFunction();
-      CGM.SetLLVMFunctionAttributes(GlobalDecl(), FI,
-                                    Func,
+      CGM.SetLLVMFunctionAttributes(GlobalDecl(), FI, Func,
                                     /*IsThunk=*/false);
       // Create a function body that just returns
       llvm::BasicBlock *Entry = llvm::BasicBlock::Create(Context, "", Func);

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -1069,7 +1069,7 @@ pointerAuthResignMemberFunctionPointer(llvm::Constant *Src, QualType DestType,
   }
 
   llvm::Constant *ConstPtr = pointerAuthResignConstant(
-      cast<llvm::User>(MemFnPtr)->getOperand(0), CurAuthInfo, NewAuthInfo, CGM);
+      MemFnPtr->getOperand(0), CurAuthInfo, NewAuthInfo, CGM);
   ConstPtr = llvm::ConstantExpr::getPtrToInt(ConstPtr, MemFnPtr->getType());
   return ConstantFoldInsertValueInstruction(Src, ConstPtr, 0);
 }
@@ -3363,7 +3363,7 @@ void ItaniumCXXABI::EmitThreadLocalInitFuncs(
           InitFnTy, Var->getLinkage(), InitFnName.str(), &CGM.getModule());
       const CGFunctionInfo &FI = CGM.getTypes().arrangeNullaryFunction();
       CGM.SetLLVMFunctionAttributes(GlobalDecl(), FI,
-                                    cast<llvm::Function>(Func),
+                                    Func,
                                     /*IsThunk=*/false);
       // Create a function body that just returns
       llvm::BasicBlock *Entry = llvm::BasicBlock::Create(Context, "", Func);

--- a/clang/lib/ExtractAPI/DeclarationFragments.cpp
+++ b/clang/lib/ExtractAPI/DeclarationFragments.cpp
@@ -1238,8 +1238,7 @@ DeclarationFragmentsBuilder::getFragmentsForClassTemplateSpecialization(
       .append("<", DeclarationFragments::FragmentKind::Text)
       .append(">", DeclarationFragments::FragmentKind::Text)
       .appendSpace()
-      .append(DeclarationFragmentsBuilder::getFragmentsForCXXClass(
-          Decl))
+      .append(DeclarationFragmentsBuilder::getFragmentsForCXXClass(Decl))
       .pop_back() // there is an extra semicolon now
       .append("<", DeclarationFragments::FragmentKind::Text)
       .append(getFragmentsForTemplateArguments(
@@ -1261,8 +1260,7 @@ DeclarationFragmentsBuilder::getFragmentsForClassTemplatePartialSpecialization(
           Decl->getTemplateParameters()->asArray()))
       .append(">", DeclarationFragments::FragmentKind::Text)
       .appendSpace()
-      .append(DeclarationFragmentsBuilder::getFragmentsForCXXClass(
-          Decl))
+      .append(DeclarationFragmentsBuilder::getFragmentsForCXXClass(Decl))
       .pop_back() // there is an extra semicolon now
       .append("<", DeclarationFragments::FragmentKind::Text)
       .append(getFragmentsForTemplateArguments(

--- a/clang/lib/ExtractAPI/DeclarationFragments.cpp
+++ b/clang/lib/ExtractAPI/DeclarationFragments.cpp
@@ -1239,7 +1239,7 @@ DeclarationFragmentsBuilder::getFragmentsForClassTemplateSpecialization(
       .append(">", DeclarationFragments::FragmentKind::Text)
       .appendSpace()
       .append(DeclarationFragmentsBuilder::getFragmentsForCXXClass(
-          cast<CXXRecordDecl>(Decl)))
+          Decl))
       .pop_back() // there is an extra semicolon now
       .append("<", DeclarationFragments::FragmentKind::Text)
       .append(getFragmentsForTemplateArguments(
@@ -1262,7 +1262,7 @@ DeclarationFragmentsBuilder::getFragmentsForClassTemplatePartialSpecialization(
       .append(">", DeclarationFragments::FragmentKind::Text)
       .appendSpace()
       .append(DeclarationFragmentsBuilder::getFragmentsForCXXClass(
-          cast<CXXRecordDecl>(Decl)))
+          Decl))
       .pop_back() // there is an extra semicolon now
       .append("<", DeclarationFragments::FragmentKind::Text)
       .append(getFragmentsForTemplateArguments(

--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -72,7 +72,7 @@ GetCC1Arguments(DiagnosticsEngine *Diagnostics,
                                    "Unable to create a driver job");
 
   // The one job we find should be to invoke clang again.
-  const driver::Command *Cmd = cast<driver::Command>(&(*Jobs.begin()));
+  const driver::Command *Cmd = &(*Jobs.begin());
   if (llvm::StringRef(Cmd->getCreator().getName()) != "clang")
     return llvm::createStringError(llvm::errc::not_supported,
                                    "Driver initialization failed");

--- a/clang/lib/Interpreter/InterpreterUtils.cpp
+++ b/clang/lib/Interpreter/InterpreterUtils.cpp
@@ -82,7 +82,7 @@ NamedDecl *LookupNamed(Sema &S, llvm::StringRef Name,
   else {
     const DeclContext *PrimaryWithin = nullptr;
     if (const auto *TD = dyn_cast<TagDecl>(Within))
-      PrimaryWithin = dyn_cast_if_present<DeclContext>(TD->getDefinition());
+      PrimaryWithin = TD->getDefinition();
     else
       PrimaryWithin = Within->getPrimaryContext();
 

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -451,7 +451,7 @@ void Parser::ParseLexedMethodDeclaration(LateParsedMethodDeclaration &LM) {
       FunctionDecl *Old;
       if (const auto *FunTmpl = dyn_cast<FunctionTemplateDecl>(LM.Method))
         Old =
-            cast<FunctionDecl>(FunTmpl->getTemplatedDecl())->getPreviousDecl();
+            FunTmpl->getTemplatedDecl()->getPreviousDecl();
       else
         Old = cast<FunctionDecl>(LM.Method)->getPreviousDecl();
       if (Old) {

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -450,8 +450,7 @@ void Parser::ParseLexedMethodDeclaration(LateParsedMethodDeclaration &LM) {
       assert(Param->hasInheritedDefaultArg());
       FunctionDecl *Old;
       if (const auto *FunTmpl = dyn_cast<FunctionTemplateDecl>(LM.Method))
-        Old =
-            FunTmpl->getTemplatedDecl()->getPreviousDecl();
+        Old = FunTmpl->getTemplatedDecl()->getPreviousDecl();
       else
         Old = cast<FunctionDecl>(LM.Method)->getPreviousDecl();
       if (Old) {

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2876,7 +2876,7 @@ public:
   }
 
   bool VisitFunctionDecl(FunctionDecl *Node) override {
-    if (cast<DeclContext>(Node)->isDependentContext())
+    if (Node->isDependentContext())
       return true; // Not to analyze dependent decl
     // `FunctionDecl->hasBody()` returns true if the function has a body
     // somewhere defined.  But we want to know if this `Node` has a body
@@ -2887,14 +2887,14 @@ public:
   }
 
   bool VisitBlockDecl(BlockDecl *Node) override {
-    if (cast<DeclContext>(Node)->isDependentContext())
+    if (Node->isDependentContext())
       return true; // Not to analyze dependent decl
     Callback(Node);
     return true;
   }
 
   bool VisitObjCMethodDecl(ObjCMethodDecl *Node) override {
-    if (cast<DeclContext>(Node)->isDependentContext())
+    if (Node->isDependentContext())
       return true; // Not to analyze dependent decl
     if (Node->hasBody())
       Callback(Node);

--- a/clang/lib/Sema/ScopeInfo.cpp
+++ b/clang/lib/Sema/ScopeInfo.cpp
@@ -238,7 +238,7 @@ void LambdaScopeInfo::visitPotentialCaptures(
     if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
       Callback(cast<ValueDecl>(DRE->getFoundDecl()), E);
     } else if (auto *ME = dyn_cast<MemberExpr>(E)) {
-      Callback(cast<ValueDecl>(ME->getMemberDecl()), E);
+      Callback(ME->getMemberDecl(), E);
     } else if (auto *FP = dyn_cast<FunctionParmPackExpr>(E)) {
       for (ValueDecl *VD : *FP)
         Callback(VD, E);

--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -551,7 +551,7 @@ static void DoEmitAvailabilityWarning(Sema &S, AvailabilityResult K,
   case AR_Deprecated:
     // Suppress -Wdeprecated-declarations in implicit
     // functions.
-    if (const auto *FD = S.getCurFunctionDecl(); FD && FD->isImplicit())
+    if (const FunctionDecl *FD = S.getCurFunctionDecl(); FD && FD->isImplicit())
       return;
 
     if (ObjCPropertyAccess)

--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -551,7 +551,7 @@ static void DoEmitAvailabilityWarning(Sema &S, AvailabilityResult K,
   case AR_Deprecated:
     // Suppress -Wdeprecated-declarations in implicit
     // functions.
-    if (const auto *FD = dyn_cast_or_null<FunctionDecl>(S.getCurFunctionDecl());
+    if (const auto *FD = S.getCurFunctionDecl();
         FD && FD->isImplicit())
       return;
 

--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -551,8 +551,7 @@ static void DoEmitAvailabilityWarning(Sema &S, AvailabilityResult K,
   case AR_Deprecated:
     // Suppress -Wdeprecated-declarations in implicit
     // functions.
-    if (const auto *FD = S.getCurFunctionDecl();
-        FD && FD->isImplicit())
+    if (const auto *FD = S.getCurFunctionDecl(); FD && FD->isImplicit())
       return;
 
     if (ObjCPropertyAccess)

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -366,7 +366,7 @@ bool Sema::BoundsSafetyCheckInitialization(const InitializedEntity &Entity,
 
     if (!CheckAssignmentToCountAttrPtrWithIncompletePointeeTy(
             *this, LHSType, RHSExpr, Action, SL,
-            dyn_cast_or_null<ValueDecl>(Entity.getDecl()),
+            Entity.getDecl(),
             /*ShowFullQualifiedAssigneeName=*/true)) {
       return false;
     }

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -365,8 +365,7 @@ bool Sema::BoundsSafetyCheckInitialization(const InitializedEntity &Entity,
       Entity.getKind() != InitializedEntity::EK_Variable) {
 
     if (!CheckAssignmentToCountAttrPtrWithIncompletePointeeTy(
-            *this, LHSType, RHSExpr, Action, SL,
-            Entity.getDecl(),
+            *this, LHSType, RHSExpr, Action, SL, Entity.getDecl(),
             /*ShowFullQualifiedAssigneeName=*/true)) {
       return false;
     }

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -7198,8 +7198,7 @@ void SemaCodeCompletion::CodeCompleteConstructorInitializer(
       InitializedBases.insert(getASTContext().getCanonicalType(
           QualType(Initializers[I]->getBaseClass(), 0)));
     else
-      InitializedFields.insert(
-          Initializers[I]->getAnyMember());
+      InitializedFields.insert(Initializers[I]->getAnyMember());
   }
 
   // Add completions for base classes.
@@ -7307,8 +7306,7 @@ void SemaCodeCompletion::CodeCompleteConstructorInitializer(
 
   // Add completions for members.
   for (auto *Field : ClassDecl->fields()) {
-    if (!InitializedFields.insert(Field->getCanonicalDecl())
-             .second) {
+    if (!InitializedFields.insert(Field->getCanonicalDecl()).second) {
       SawLastInitializer = !Initializers.empty() &&
                            Initializers.back()->isAnyMemberInitializer() &&
                            Initializers.back()->getAnyMember() == Field;

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -7199,7 +7199,7 @@ void SemaCodeCompletion::CodeCompleteConstructorInitializer(
           QualType(Initializers[I]->getBaseClass(), 0)));
     else
       InitializedFields.insert(
-          cast<FieldDecl>(Initializers[I]->getAnyMember()));
+          Initializers[I]->getAnyMember());
   }
 
   // Add completions for base classes.
@@ -7307,7 +7307,7 @@ void SemaCodeCompletion::CodeCompleteConstructorInitializer(
 
   // Add completions for members.
   for (auto *Field : ClassDecl->fields()) {
-    if (!InitializedFields.insert(cast<FieldDecl>(Field->getCanonicalDecl()))
+    if (!InitializedFields.insert(Field->getCanonicalDecl())
              .second) {
       SawLastInitializer = !Initializers.empty() &&
                            Initializers.back()->isAnyMemberInitializer() &&

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -1600,7 +1600,7 @@ static const Expr *SubstituteConstraintExpressionWithoutSatisfaction(
   }();
   if (auto *RD = dyn_cast<CXXRecordDecl>(DC)) {
     ThisScope.emplace(S, const_cast<CXXRecordDecl *>(RD), Qualifiers());
-    ContextScope.emplace(S, const_cast<DeclContext *>(cast<DeclContext>(RD)),
+    ContextScope.emplace(S, const_cast<CXXRecordDecl *>(RD),
                          /*NewThisContext=*/false);
   }
   EnterExpressionEvaluationContext UnevaluatedContext(

--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -728,7 +728,7 @@ bool Sema::ActOnCoroutineBodyStart(Scope *SC, SourceLocation KWLoc,
       Diag(KWLoc, diag::note_declared_coroutine_here) << Keyword;
       return StmtError();
     }
-    return cast<Stmt>(Suspend.get());
+    return Suspend.get();
   };
 
   StmtResult InitSuspend = buildSuspends("initial_suspend");

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -3507,7 +3507,7 @@ ExprResult Sema::BuildDeclarationNameExpr(
     // potentially-evaluated contexts? Since the variable isn't actually
     // captured in an unevaluated context, it seems that the answer is no.
     if (!isUnevaluatedContext()) {
-      QualType CapturedType = getCapturedDeclRefType(cast<ValueDecl>(VD), Loc);
+      QualType CapturedType = getCapturedDeclRefType(VD, Loc);
       if (!CapturedType.isNull())
         type = CapturedType;
     }

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -4782,7 +4782,7 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
     if (SCS.Second == ICK_Derived_To_Base) {
       SmallVector<Expr*, 8> ConstructorArgs;
       if (CompleteConstructorCall(
-              cast<CXXConstructorDecl>(SCS.CopyConstructor), ToType, From,
+              SCS.CopyConstructor, ToType, From,
               /*FIXME:ConstructLoc*/ SourceLocation(), ConstructorArgs))
         return ExprError();
       return BuildCXXConstructExpr(

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -4781,9 +4781,9 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
     assert(!ToType->isReferenceType());
     if (SCS.Second == ICK_Derived_To_Base) {
       SmallVector<Expr*, 8> ConstructorArgs;
-      if (CompleteConstructorCall(
-              SCS.CopyConstructor, ToType, From,
-              /*FIXME:ConstructLoc*/ SourceLocation(), ConstructorArgs))
+      if (CompleteConstructorCall(SCS.CopyConstructor, ToType, From,
+                                  /*FIXME:ConstructLoc*/ SourceLocation(),
+                                  ConstructorArgs))
         return ExprError();
       return BuildCXXConstructExpr(
           /*FIXME:ConstructLoc*/ SourceLocation(), ToType,

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -12,6 +12,7 @@
 
 #include "CheckExprLifetime.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
@@ -10310,7 +10311,7 @@ QualType Sema::DeduceTemplateSpecializationFromInitializer(
         Pattern = Pattern->getInstantiatedFromMemberTemplate();
       }
 
-      auto *RD = Pattern->getTemplatedDecl();
+      const CXXRecordDecl *RD = Pattern->getTemplatedDecl();
       if (!(RD->getDefinition() && RD->isAggregate()))
         return;
       QualType Ty = Context.getCanonicalTagType(RD);

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -10451,8 +10451,7 @@ QualType Sema::DeduceTemplateSpecializationFromInitializer(
     return QualType();
 
   case OR_No_Viable_Function: {
-    CXXRecordDecl *Primary =
-        Template->getTemplatedDecl();
+    CXXRecordDecl *Primary = Template->getTemplatedDecl();
     bool Complete = isCompleteType(Kind.getLocation(),
                                    Context.getCanonicalTagType(Primary));
     Candidates.NoteCandidates(

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -10310,7 +10310,7 @@ QualType Sema::DeduceTemplateSpecializationFromInitializer(
         Pattern = Pattern->getInstantiatedFromMemberTemplate();
       }
 
-      auto *RD = cast<CXXRecordDecl>(Pattern->getTemplatedDecl());
+      auto *RD = Pattern->getTemplatedDecl();
       if (!(RD->getDefinition() && RD->isAggregate()))
         return;
       QualType Ty = Context.getCanonicalTagType(RD);
@@ -10452,7 +10452,7 @@ QualType Sema::DeduceTemplateSpecializationFromInitializer(
 
   case OR_No_Viable_Function: {
     CXXRecordDecl *Primary =
-        cast<ClassTemplateDecl>(Template)->getTemplatedDecl();
+        Template->getTemplatedDecl();
     bool Complete = isCompleteType(Kind.getLocation(),
                                    Context.getCanonicalTagType(Primary));
     Candidates.NoteCandidates(

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -23010,7 +23010,7 @@ static ExprResult buildImplicitMapper(Sema &S, QualType BaseType,
     S.PushOnScopeChains(DMD, Scope, /*AddToContext=*/false);
   DCT->addDecl(DMD);
   DMD->setAccess(clang::AS_none);
-  auto *VD = MapperVarRef->getDecl();
+  ValueDecl *VD = MapperVarRef->getDecl();
   VD->setDeclContext(DMD);
   VD->setLexicalDeclContext(DMD);
   DMD->addDecl(VD);

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -7830,7 +7830,7 @@ SemaOpenMP::checkOpenMPDeclareVariantFunction(SemaOpenMP::DeclGroupPtrTy DG,
           /*TemplatesSupported=*/true, /*ConstexprSupported=*/false,
           /*CLinkageMayDiffer=*/true))
     return std::nullopt;
-  return std::make_pair(FD, cast<Expr>(DRE));
+  return std::make_pair(FD, DRE);
 }
 
 void SemaOpenMP::ActOnOpenMPDeclareVariantDirective(
@@ -23010,7 +23010,7 @@ static ExprResult buildImplicitMapper(Sema &S, QualType BaseType,
     S.PushOnScopeChains(DMD, Scope, /*AddToContext=*/false);
   DCT->addDecl(DMD);
   DMD->setAccess(clang::AS_none);
-  auto *VD = cast<DeclRefExpr>(MapperVarRef)->getDecl();
+  auto *VD = MapperVarRef->getDecl();
   VD->setDeclContext(DMD);
   VD->setLexicalDeclContext(DMD);
   DMD->addDecl(VD);
@@ -25508,7 +25508,7 @@ OMPClause *SemaOpenMP::ActOnOpenMPUsesAllocatorClause(
              diag::err_omp_predefined_allocator_with_traits)
             << D.AllocatorTraits->getSourceRange();
         Diag(D.Allocator->getExprLoc(), diag::note_omp_predefined_allocator)
-            << cast<NamedDecl>(DRE->getDecl())->getName()
+            << DRE->getDecl()->getName()
             << D.Allocator->getSourceRange();
         continue;
       }

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -25508,8 +25508,7 @@ OMPClause *SemaOpenMP::ActOnOpenMPUsesAllocatorClause(
              diag::err_omp_predefined_allocator_with_traits)
             << D.AllocatorTraits->getSourceRange();
         Diag(D.Allocator->getExprLoc(), diag::note_omp_predefined_allocator)
-            << DRE->getDecl()->getName()
-            << D.Allocator->getSourceRange();
+            << DRE->getDecl()->getName() << D.Allocator->getSourceRange();
         continue;
       }
       // OpenMP [2.12.5, target Construct]

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -13889,8 +13889,7 @@ private:
       // If we're in C, we need to support types that aren't exactly identical.
       if (!S.getLangOpts().CPlusPlus ||
           candidateHasExactlyCorrectType(FunDecl)) {
-        Matches.push_back(
-            std::make_pair(CurAccessFunPair, FunDecl->getCanonicalDecl()));
+        Matches.emplace_back(CurAccessFunPair, FunDecl->getCanonicalDecl());
         FoundNonTemplateFunction = true;
         return true;
       }

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -13890,7 +13890,7 @@ private:
       if (!S.getLangOpts().CPlusPlus ||
           candidateHasExactlyCorrectType(FunDecl)) {
         Matches.push_back(std::make_pair(
-            CurAccessFunPair, cast<FunctionDecl>(FunDecl->getCanonicalDecl())));
+            CurAccessFunPair, FunDecl->getCanonicalDecl()));
         FoundNonTemplateFunction = true;
         return true;
       }

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -13889,8 +13889,8 @@ private:
       // If we're in C, we need to support types that aren't exactly identical.
       if (!S.getLangOpts().CPlusPlus ||
           candidateHasExactlyCorrectType(FunDecl)) {
-        Matches.push_back(std::make_pair(
-            CurAccessFunPair, FunDecl->getCanonicalDecl()));
+        Matches.push_back(
+            std::make_pair(CurAccessFunPair, FunDecl->getCanonicalDecl()));
         FoundNonTemplateFunction = true;
         return true;
       }

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -12,6 +12,7 @@
 #include "clang/AST/ASTConcept.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclFriend.h"
 #include "clang/AST/DeclTemplate.h"
@@ -10165,7 +10166,7 @@ static bool ScopeSpecifierHasTemplateId(const CXXScopeSpec &SS) {
 /// effect.
 static void dllExportImportClassTemplateSpecialization(
     Sema &S, ClassTemplateSpecializationDecl *Def) {
-  auto *A = getDLLAttr(Def);
+  InheritableAttr *A = getDLLAttr(Def);
   assert(A && "dllExportImportClassTemplateSpecialization called "
               "on Def without dllexport or dllimport");
 

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -1169,7 +1169,7 @@ bool Sema::BuildTypeConstraint(const CXXScopeSpec &SS,
     return true;
 
   TemplateName TN = TypeConstr->Template.get();
-  TemplateDecl *CD = cast<TemplateDecl>(TN.getAsTemplateDecl());
+  TemplateDecl *CD = TN.getAsTemplateDecl();
   UsingShadowDecl *USD = TN.getAsUsingShadowDecl();
 
   DeclarationNameInfo ConceptName(DeclarationName(TypeConstr->Name),
@@ -5811,7 +5811,7 @@ static bool diagnoseMissingArgument(Sema &S, SourceLocation Loc,
   // missing a module import.
   llvm::SmallVector<Module*, 8> Modules;
   if (D->hasDefaultArgument() && !S.hasReachableDefaultArgument(D, &Modules)) {
-    S.diagnoseMissingImport(Loc, cast<NamedDecl>(TD),
+    S.diagnoseMissingImport(Loc, TD,
                             D->getDefaultArgumentLoc(), Modules,
                             Sema::MissingImportKind::DefaultArgument,
                             /*Recover*/true);
@@ -10166,7 +10166,7 @@ static bool ScopeSpecifierHasTemplateId(const CXXScopeSpec &SS) {
 /// effect.
 static void dllExportImportClassTemplateSpecialization(
     Sema &S, ClassTemplateSpecializationDecl *Def) {
-  auto *A = cast_or_null<InheritableAttr>(getDLLAttr(Def));
+  auto *A = getDLLAttr(Def);
   assert(A && "dllExportImportClassTemplateSpecialization called "
               "on Def without dllexport or dllimport");
 
@@ -10556,7 +10556,7 @@ Sema::ActOnExplicitInstantiation(Scope *S, SourceLocation ExternLoc,
 
   // Verify that it is okay to explicitly instantiate here.
   CXXRecordDecl *PrevDecl
-    = cast_or_null<CXXRecordDecl>(Record->getPreviousDecl());
+    = Record->getPreviousDecl();
   if (!PrevDecl && Record->getDefinition())
     PrevDecl = Record;
   if (PrevDecl) {
@@ -10574,13 +10574,13 @@ Sema::ActOnExplicitInstantiation(Scope *S, SourceLocation ExternLoc,
   }
 
   CXXRecordDecl *RecordDef
-    = cast_or_null<CXXRecordDecl>(Record->getDefinition());
+    = Record->getDefinition();
   if (!RecordDef) {
     // C++ [temp.explicit]p3:
     //   A definition of a member class of a class template shall be in scope
     //   at the point of an explicit instantiation of the member class.
     CXXRecordDecl *Def
-      = cast_or_null<CXXRecordDecl>(Pattern->getDefinition());
+      = Pattern->getDefinition();
     if (!Def) {
       Diag(TemplateLoc, diag::err_explicit_instantiation_undefined_member)
         << 0 << Record->getDeclName() << Record->getDeclContext();
@@ -10593,7 +10593,7 @@ Sema::ActOnExplicitInstantiation(Scope *S, SourceLocation ExternLoc,
                            TSK))
         return true;
 
-      RecordDef = cast_or_null<CXXRecordDecl>(Record->getDefinition());
+      RecordDef = Record->getDefinition();
       if (!RecordDef)
         return true;
     }
@@ -10923,7 +10923,7 @@ DeclResult Sema::ActOnExplicitInstantiation(Scope *S,
                                                   Best)) {
     case OR_Success:
     case OR_Deleted:
-      Specialization = cast<FunctionDecl>(Best->Function);
+      Specialization = Best->Function;
       break;
     case OR_Ambiguous:
       Msg = diag::err_explicit_instantiation_ambiguous;

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -5811,10 +5811,9 @@ static bool diagnoseMissingArgument(Sema &S, SourceLocation Loc,
   // missing a module import.
   llvm::SmallVector<Module*, 8> Modules;
   if (D->hasDefaultArgument() && !S.hasReachableDefaultArgument(D, &Modules)) {
-    S.diagnoseMissingImport(Loc, TD,
-                            D->getDefaultArgumentLoc(), Modules,
+    S.diagnoseMissingImport(Loc, TD, D->getDefaultArgumentLoc(), Modules,
                             Sema::MissingImportKind::DefaultArgument,
-                            /*Recover*/true);
+                            /*Recover*/ true);
     return true;
   }
 
@@ -10555,8 +10554,7 @@ Sema::ActOnExplicitInstantiation(Scope *S, SourceLocation ExternLoc,
   CheckExplicitInstantiation(*this, Record, NameLoc, true, TSK);
 
   // Verify that it is okay to explicitly instantiate here.
-  CXXRecordDecl *PrevDecl
-    = Record->getPreviousDecl();
+  CXXRecordDecl *PrevDecl = Record->getPreviousDecl();
   if (!PrevDecl && Record->getDefinition())
     PrevDecl = Record;
   if (PrevDecl) {
@@ -10573,14 +10571,12 @@ Sema::ActOnExplicitInstantiation(Scope *S, SourceLocation ExternLoc,
       return TagD;
   }
 
-  CXXRecordDecl *RecordDef
-    = Record->getDefinition();
+  CXXRecordDecl *RecordDef = Record->getDefinition();
   if (!RecordDef) {
     // C++ [temp.explicit]p3:
     //   A definition of a member class of a class template shall be in scope
     //   at the point of an explicit instantiation of the member class.
-    CXXRecordDecl *Def
-      = Pattern->getDefinition();
+    CXXRecordDecl *Def = Pattern->getDefinition();
     if (!Def) {
       Diag(TemplateLoc, diag::err_explicit_instantiation_undefined_member)
         << 0 << Record->getDeclName() << Record->getDeclContext();

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -3522,7 +3522,7 @@ bool Sema::InstantiateClassImpl(
     TemplateSpecializationKind TSK, bool Complain) {
 
   CXXRecordDecl *PatternDef
-    = cast_or_null<CXXRecordDecl>(Pattern->getDefinition());
+    = Pattern->getDefinition();
   if (DiagnoseUninstantiableTemplate(PointOfInstantiation, Instantiation,
                                 Instantiation->getInstantiatedFromMemberClass(),
                                      Pattern, PatternDef, TSK, Complain))
@@ -4309,7 +4309,7 @@ Sema::InstantiateClassMembers(SourceLocation PointOfInstantiation,
         }
       }
 
-      Pattern = cast_or_null<CXXRecordDecl>(Record->getDefinition());
+      Pattern = Record->getDefinition();
       if (Pattern)
         InstantiateClassMembers(PointOfInstantiation, Pattern, TemplateArgs,
                                 TSK);

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -3521,8 +3521,7 @@ bool Sema::InstantiateClassImpl(
     CXXRecordDecl *Pattern, const MultiLevelTemplateArgumentList &TemplateArgs,
     TemplateSpecializationKind TSK, bool Complain) {
 
-  CXXRecordDecl *PatternDef
-    = Pattern->getDefinition();
+  CXXRecordDecl *PatternDef = Pattern->getDefinition();
   if (DiagnoseUninstantiableTemplate(PointOfInstantiation, Instantiation,
                                 Instantiation->getInstantiatedFromMemberClass(),
                                      Pattern, PatternDef, TSK, Complain))

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -3943,8 +3943,8 @@ Decl *TemplateDeclInstantiator::VisitBaseUsingDecls(BaseUsingDecl *D,
       InstTarget = UnresolvedUsingIfExistsDecl::Create(
           SemaRef.Context, Owner, EmptyD->getLocation(), EmptyD->getDeclName());
     } else {
-      InstTarget = SemaRef.FindInstantiatedDecl(
-          Shadow->getLocation(), OldTarget, TemplateArgs);
+      InstTarget = SemaRef.FindInstantiatedDecl(Shadow->getLocation(),
+                                                OldTarget, TemplateArgs);
     }
     if (!InstTarget)
       return nullptr;

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -3943,8 +3943,8 @@ Decl *TemplateDeclInstantiator::VisitBaseUsingDecls(BaseUsingDecl *D,
       InstTarget = UnresolvedUsingIfExistsDecl::Create(
           SemaRef.Context, Owner, EmptyD->getLocation(), EmptyD->getDeclName());
     } else {
-      InstTarget = cast_or_null<NamedDecl>(SemaRef.FindInstantiatedDecl(
-          Shadow->getLocation(), OldTarget, TemplateArgs));
+      InstTarget = SemaRef.FindInstantiatedDecl(
+          Shadow->getLocation(), OldTarget, TemplateArgs);
     }
     if (!InstTarget)
       return nullptr;
@@ -6937,8 +6937,7 @@ NamedDecl *Sema::FindInstantiatedDecl(SourceLocation Loc, NamedDecl *D,
         assert(ArgPackSubstIndex &&
                "found declaration pack but not pack expanding");
         typedef LocalInstantiationScope::DeclArgumentPack DeclArgumentPack;
-        return cast<NamedDecl>(
-            (*cast<DeclArgumentPack *>(*Found))[*ArgPackSubstIndex]);
+        return (*cast<DeclArgumentPack *>(*Found))[*ArgPackSubstIndex];
       }
     }
 

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1324,8 +1324,7 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
     llvm::SmallVector<TemplateArgument, 8> TemplateArgs;
     if (DS.isConstrainedAuto()) {
       if (TemplateIdAnnotation *TemplateId = DS.getRepAsTemplateId()) {
-        TypeConstraintConcept =
-            TemplateId->Template.get().getAsTemplateDecl();
+        TypeConstraintConcept = TemplateId->Template.get().getAsTemplateDecl();
         TemplateArgumentListInfo TemplateArgsInfo;
         TemplateArgsInfo.setLAngleLoc(TemplateId->LAngleLoc);
         TemplateArgsInfo.setRAngleLoc(TemplateId->RAngleLoc);

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1325,7 +1325,7 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
     if (DS.isConstrainedAuto()) {
       if (TemplateIdAnnotation *TemplateId = DS.getRepAsTemplateId()) {
         TypeConstraintConcept =
-            cast<TemplateDecl>(TemplateId->Template.get().getAsTemplateDecl());
+            TemplateId->Template.get().getAsTemplateDecl();
         TemplateArgumentListInfo TemplateArgsInfo;
         TemplateArgsInfo.setLAngleLoc(TemplateId->LAngleLoc);
         TemplateArgsInfo.setRAngleLoc(TemplateId->RAngleLoc);
@@ -6139,9 +6139,9 @@ namespace {
       NamedDecl *FoundDecl;
       if (auto TN = TemplateId->Template.get();
           UsingShadowDecl *USD = TN.getAsUsingShadowDecl())
-        FoundDecl = cast<NamedDecl>(USD);
+        FoundDecl = USD;
       else
-        FoundDecl = cast_if_present<NamedDecl>(TN.getAsTemplateDecl());
+        FoundDecl = TN.getAsTemplateDecl();
 
       auto *CR = ConceptReference::Create(
           Context, NNS, TemplateId->TemplateKWLoc, DNI, FoundDecl,

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -9675,7 +9675,7 @@ void ASTReader::ReadUnusedLocalTypedefNameCandidates(
 void ASTReader::ReadDeclsToCheckForDeferredDiags(
     llvm::SmallSetVector<Decl *, 4> &Decls) {
   for (auto I : DeclsToCheckForDeferredDiags) {
-    auto *D = GetDecl(I);
+    Decl *D = GetDecl(I);
     if (D)
       Decls.insert(D);
   }

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/Serialization/ASTReader.h"
 #include "ASTCommon.h"
 #include "ASTReaderInternals.h"
 #include "TemplateArgumentHasher.h"
@@ -9674,7 +9675,7 @@ void ASTReader::ReadUnusedLocalTypedefNameCandidates(
 void ASTReader::ReadDeclsToCheckForDeferredDiags(
     llvm::SmallSetVector<Decl *, 4> &Decls) {
   for (auto I : DeclsToCheckForDeferredDiags) {
-    auto *D = dyn_cast_or_null<Decl>(GetDecl(I));
+    auto *D = GetDecl(I);
     if (D)
       Decls.insert(D);
   }
@@ -11268,9 +11269,9 @@ void ASTReader::FinishedDeserializing() {
           auto *FPT = Update.second->getType()->castAs<FunctionProtoType>();
           auto ESI = FPT->getExtProtoInfo().ExceptionSpec;
           if (auto *Listener = getContext().getASTMutationListener())
-            Listener->ResolvedExceptionSpec(cast<FunctionDecl>(Update.second));
+            Listener->ResolvedExceptionSpec(Update.second);
           for (auto *Redecl : Update.second->redecls())
-            getContext().adjustExceptionSpec(cast<FunctionDecl>(Redecl), ESI);
+            getContext().adjustExceptionSpec(Redecl, ESI);
         }
 
         auto DTUpdates = std::move(PendingDeducedTypeUpdates);

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -1817,7 +1817,7 @@ void ASTDeclReader::VisitOutlinedFunctionDecl(OutlinedFunctionDecl *D) {
   for (unsigned I = 0; I < D->NumParams; ++I)
     D->setParam(I, readDeclAs<ImplicitParamDecl>());
   D->setNothrow(Record.readInt() != 0);
-  D->setBody(cast_or_null<Stmt>(Record.readStmt()));
+  D->setBody(Record.readStmt());
 }
 
 void ASTDeclReader::VisitCapturedDecl(CapturedDecl *CD) {
@@ -2342,7 +2342,7 @@ void ASTDeclReader::VisitCXXDestructorDecl(CXXDestructorDecl *D) {
   VisitCXXMethodDecl(D);
 
   ASTContext &C = Reader.getContext();
-  CXXDestructorDecl *Canon = cast<CXXDestructorDecl>(D->getCanonicalDecl());
+  CXXDestructorDecl *Canon = D->getCanonicalDecl();
   if (auto *OperatorDelete = readDeclAs<FunctionDecl>()) {
     auto *ThisArg = Record.readExpr();
     // FIXME: Check consistency if we have an old and new operator delete.
@@ -3615,7 +3615,7 @@ void mergeInheritableAttributes(ASTReader &Reader, Decl *D, Decl *Previous) {
   const auto *IA = Previous->getAttr<MSInheritanceAttr>();
 
   if (IA && !D->hasAttr<MSInheritanceAttr>()) {
-    NewAttr = cast<InheritableAttr>(IA->clone(Context));
+    NewAttr = IA->clone(Context);
     NewAttr->setInherited(true);
     D->addAttr(NewAttr);
   }

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -547,7 +547,7 @@ void ASTStmtReader::VisitCXXReflectExpr(CXXReflectExpr *E) {
 void ASTStmtReader::VisitSYCLKernelCallStmt(SYCLKernelCallStmt *S) {
   VisitStmt(S);
   S->setOriginalStmt(cast<CompoundStmt>(Record.readSubStmt()));
-  S->setKernelLaunchStmt(cast<Stmt>(Record.readSubStmt()));
+  S->setKernelLaunchStmt(Record.readSubStmt());
   S->setOutlinedFunctionDecl(readDeclAs<OutlinedFunctionDecl>());
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/IvarInvalidationChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/IvarInvalidationChecker.cpp
@@ -246,8 +246,7 @@ void IvarInvalidationCheckerImpl::containsInvalidationMethod(
   // Check all methods.
   for (const auto *MDI : D->methods())
     if (isInvalidationMethod(MDI, Partial))
-      OutInfo.addInvalidationMethod(
-          MDI->getCanonicalDecl());
+      OutInfo.addInvalidationMethod(MDI->getCanonicalDecl());
 
   // If interface, check all parent protocols and super.
   if (const ObjCInterfaceDecl *InterfD = dyn_cast<ObjCInterfaceDecl>(D)) {

--- a/clang/lib/StaticAnalyzer/Checkers/IvarInvalidationChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/IvarInvalidationChecker.cpp
@@ -247,7 +247,7 @@ void IvarInvalidationCheckerImpl::containsInvalidationMethod(
   for (const auto *MDI : D->methods())
     if (isInvalidationMethod(MDI, Partial))
       OutInfo.addInvalidationMethod(
-          cast<ObjCMethodDecl>(MDI->getCanonicalDecl()));
+          MDI->getCanonicalDecl());
 
   // If interface, check all parent protocols and super.
   if (const ObjCInterfaceDecl *InterfD = dyn_cast<ObjCInterfaceDecl>(D)) {
@@ -286,7 +286,7 @@ bool IvarInvalidationCheckerImpl::trackIvar(const ObjCIvarDecl *Iv,
   InvalidationInfo Info;
   containsInvalidationMethod(IvInterf, Info, /*LookForPartial*/ false);
   if (Info.needsInvalidation()) {
-    const ObjCIvarDecl *I = cast<ObjCIvarDecl>(Iv->getCanonicalDecl());
+    const ObjCIvarDecl *I = Iv->getCanonicalDecl();
     TrackedIvars[I] = std::move(Info);
     if (!*FirstIvarDecl)
       *FirstIvarDecl = I;

--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -3140,7 +3140,7 @@ static bool isSmartPtrType(QualType QT) {
     if (!TD)
       return false;
 
-    const auto *ND = TD->getTemplatedDecl();
+    const NamedDecl *ND = TD->getTemplatedDecl();
     if (!ND)
       return false;
 

--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -3140,7 +3140,7 @@ static bool isSmartPtrType(QualType QT) {
     if (!TD)
       return false;
 
-    const auto *ND = dyn_cast_or_null<NamedDecl>(TD->getTemplatedDecl());
+    const auto *ND = TD->getTemplatedDecl();
     if (!ND)
       return false;
 

--- a/clang/lib/StaticAnalyzer/Checkers/MoveChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MoveChecker.cpp
@@ -581,7 +581,7 @@ void MoveChecker::explainObject(ProgramStateRef State, llvm::raw_ostream &OS,
   // and we never know if we are to explain anything until we try.
   if (const auto DR =
           dyn_cast_or_null<DeclRegion>(unwrapRValueReferenceIndirection(MR))) {
-    const auto *RegionDecl = DR->getDecl();
+    const NamedDecl *RegionDecl = DR->getDecl();
     OS << " '" << RegionDecl->getDeclName() << "'";
   }
 

--- a/clang/lib/StaticAnalyzer/Checkers/MoveChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MoveChecker.cpp
@@ -581,7 +581,7 @@ void MoveChecker::explainObject(ProgramStateRef State, llvm::raw_ostream &OS,
   // and we never know if we are to explain anything until we try.
   if (const auto DR =
           dyn_cast_or_null<DeclRegion>(unwrapRValueReferenceIndirection(MR))) {
-    const auto *RegionDecl = cast<NamedDecl>(DR->getDecl());
+    const auto *RegionDecl = DR->getDecl();
     OS << " '" << RegionDecl->getDeclName() << "'";
   }
 

--- a/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -2433,7 +2433,7 @@ class InlinedFunctionCallHandler final : public ExpressionHandler {
     SVal RetVal = ExprNode->getSVal(E);
 
     // Handle cases where a reference is returned and then immediately used.
-    if (cast<Expr>(E)->isGLValue())
+    if (E->isGLValue())
       if (std::optional<Loc> LValue = RetVal.getAs<Loc>())
         RetVal = State->getSVal(*LValue);
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -973,7 +973,7 @@ void ExprEngine::VisitUnaryOperator(const UnaryOperator* U, ExplodedNode *Pred,
         if (isa<CXXMethodDecl, FieldDecl, IndirectFieldDecl>(VD)) {
           ProgramStateRef State = N->getState();
           const LocationContext *LCtx = N->getLocationContext();
-          SVal SV = svalBuilder.getMemberPointer(cast<NamedDecl>(VD));
+          SVal SV = svalBuilder.getMemberPointer(VD);
           Bldr.generateNode(U, N, State->BindExpr(U, LCtx, SV));
           break;
         }

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1012,7 +1012,7 @@ getStackOrCaptureRegionForDeclContext(const LocationContext *LC,
         const TypedValueRegion *OrigR = Var.getOriginalRegion();
         if (const auto *VR = dyn_cast<VarRegion>(OrigR)) {
           if (VR->getDecl() == VD)
-            return cast<VarRegion>(Var.getCapturedRegion());
+            return Var.getCapturedRegion();
         }
       }
     }

--- a/clang/lib/Tooling/Refactoring/Lookup.cpp
+++ b/clang/lib/Tooling/Refactoring/Lookup.cpp
@@ -74,8 +74,8 @@ usingFromDifferentCanonicalNamespace(const DeclContext *FromContext,
       return false;
     // Now check the names. If they match we have a different canonical
     // namespace with the same name.
-    if (cast<NamespaceDecl>(*FromIter)->getDeclName() ==
-        cast<NamespaceDecl>(*UseIter)->getDeclName())
+    if ((*FromIter)->getDeclName() ==
+        (*UseIter)->getDeclName())
       return true;
   }
   assert(FromIter == FromNamespaces.end() && UseIter == UseNamespaces.end());

--- a/clang/lib/Tooling/Refactoring/Lookup.cpp
+++ b/clang/lib/Tooling/Refactoring/Lookup.cpp
@@ -74,8 +74,7 @@ usingFromDifferentCanonicalNamespace(const DeclContext *FromContext,
       return false;
     // Now check the names. If they match we have a different canonical
     // namespace with the same name.
-    if ((*FromIter)->getDeclName() ==
-        (*UseIter)->getDeclName())
+    if ((*FromIter)->getDeclName() == (*UseIter)->getDeclName())
       return true;
   }
   assert(FromIter == FromNamespaces.end() && UseIter == UseNamespaces.end());


### PR DESCRIPTION
This applies the clang-tidy check recently added in https://github.com/llvm/llvm-project/pull/189274 to the `clang/` subdirectory. A few false positives had to be filtered out:
 - casting the two branches of a ternary expression to match each other
 - casting for an argument that participates in template deduction
I will address those cases in a separate PR to clang-tidy to avoid false positives going forward.