### PR TITLE
[llvm-profgen] Link with BinaryFormat for #190862

### DIFF
--- a/llvm/tools/llvm-profgen/CMakeLists.txt
+++ b/llvm/tools/llvm-profgen/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_LINK_COMPONENTS
   AllTargetsDescs
   AllTargetsDisassemblers
   AllTargetsInfos
+  BinaryFormat
   DebugInfoDWARF
   DebugInfoPDB
   Core


### PR DESCRIPTION
`identify_magic` requires specifying `BinaryFormat` component when
building in shared build mode. Similar to BOLT support (#190902).
