### PR TITLE
SymbolizableObjectFile: Invalidate Wasm addresses that map outside the code section

### DIFF
--- a/llvm/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
@@ -292,7 +292,7 @@ object::SectionedAddress SymbolizableObjectFile::convertDwarfOffsetForWasm(
   // If the address is not in a text section, or we couldn't find a
   // matching section, invalidate it. This prevents it from incorrectly
   // being interpreted as as section-relative DWARF offset.
-  ModuleOffset.Address = object::SectionedAddress::UndefSection;
+  ModuleOffset.Address = UINT64_MAX;
   return ModuleOffset;
 }
 

--- a/llvm/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
@@ -273,13 +273,26 @@ object::SectionedAddress SymbolizableObjectFile::convertDwarfOffsetForWasm(
     object::SectionedAddress ModuleOffset) const {
   if (!Module->isWasm())
     return ModuleOffset;
+
+  // For Wasm object files, addresses are already section-relative.
+  if (Module->isRelocatableObject())
+    return ModuleOffset;
+
+  // We are dealing with a linked Wasm file, which uses file offsets.
   for (const SectionRef &Sec : Module->sections()) {
     if (Sec.getIndex() == ModuleOffset.SectionIndex) {
-      if (Sec.isText())
+      if (Sec.isText()) {
         ModuleOffset.Address -= Sec.getAddress();
+        return ModuleOffset;
+      }
       break;
     }
   }
+
+  // If the address is not in a text section, or we couldn't find a
+  // matching section, invalidate it. This prevents it from incorrectly
+  // being interpreted as as section-relative DWARF offset.
+  ModuleOffset.Address = object::SectionedAddress::UndefSection;
   return ModuleOffset;
 }
 

--- a/llvm/test/tools/llvm-symbolizer/wasm-basic.s
+++ b/llvm/test/tools/llvm-symbolizer/wasm-basic.s
@@ -1,11 +1,11 @@
 # REQUIRES: webassembly-registered-target, lld
 # RUN: llvm-mc -triple=wasm32-unknown-unknown -filetype=obj %s -o %t.o -g
-# RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.o 1 2 3 4 5 6 7 8 9 10 11 12 13 | FileCheck %s
+# RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.o 0 1 2 3 4 5 6 7 8 9 10 11 12 13 0x44 | FileCheck %s
 
 # This is the same test but on a linked wasm file, using file offsets rather
 # than section offsets.
 # RUN: wasm-ld %t.o -o %t.wasm --no-entry --export=foo --export=bar
-# RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.wasm 0x42 0x43 0x44 0x45 0x46 0x47 0x48 0x49 0x4a 0x4b 0x4c 0x4d 0x4e | FileCheck %s
+# RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.wasm 3 0x42 0x43 0x44 0x45 0x46 0x47 0x48 0x49 0x4a 0x4b 0x4c 0x4d 0x4e 0x100 | FileCheck %s
 
 .globl foo
 foo:
@@ -27,30 +27,34 @@ bar:
 ## way to the next symbol start.
 ## TODO: create a loc for .functype? It could go with the local declarations.
 
+## Byte 0 (or 3, in the case of a linked file) never maps to a code section
+# CHECK: ??
+# CHECK-NEXT: ??:0
+
 ## Byte 1 is the function length, has no loc but the symbol table considers it
 ## the start of the function
 # CHECK: foo
 # CHECK-NEXT: ??:0
-## Byte 2 is the local declaration, but for some reason DWARF is marking it as line 7.
+## Byte 2 is the local declaration, but for some reason DWARF is marking it as line 13.
 ## TODO: figure out why.
 # CHECK-NEXT: foo
 # CHECK-NEXT: wasm-basic.s:13
-## Byte 3 is actually the nop, line 7
+## Byte 3 is actually the nop, line 13
 # CHECK-NEXT: foo
 # CHECK-NEXT: wasm-basic.s:13
-## Byte 4 is the return, line 8
+## Byte 4 is the return, line 14
 # CHECK-NEXT: foo
 # CHECK-NEXT: wasm-basic.s:14
-## Byte 5 is the end_function, line 9
+## Byte 5 is the end_function, line 15
 # CHECK-NEXT: foo
 # CHECK-NEXT: wasm-basic.s:15
 ## Byte 6 is bar's function length, symbol table considers it part of bar
 # CHECK-NEXT: bar
 # CHECK-NEXT: ??:0
-## Byte 7 bar's local declaration, but DWARF marks it as line 13, like above
+## Byte 7 bar's local declaration, but DWARF marks it as line 20, like above
 # CHECK-NEXT: bar
 # CHECK-NEXT: wasm-basic.s:20
-## Byte 8 and 9 are actually the local.get on line 13
+## Byte 8 and 9 are the local.get on line 20
 # CHECK-NEXT: bar
 # CHECK-NEXT: wasm-basic.s:20
 # CHECK-NEXT: bar
@@ -64,6 +68,10 @@ bar:
 ## Byte c is end_function
 # CHECK-NEXT: bar
 # CHECK-NEXT: wasm-basic.s:23
-## Byte d is past the function
+## Byte d is past the end of the function
 # CHECK-NEXT: ??
+# CHECK-NEXT: ??:0
+
+## Past the end of the section.
+# CHECK: ??
 # CHECK-NEXT: ??:0

--- a/llvm/test/tools/llvm-symbolizer/wasm-basic.s
+++ b/llvm/test/tools/llvm-symbolizer/wasm-basic.s
@@ -3,9 +3,9 @@
 # RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.o 0 1 2 3 4 5 6 7 8 9 10 11 12 13 16 | FileCheck %s
 
 # This is the same test but on a linked wasm file, using file offsets rather than section offsets.
-# The code section starts at 0x41, so these are equivalent (see below for why the first one is 3).
+# The code section starts at 0x41, so these are equivalent to above (except 3, see below for why).
 # RUN: wasm-ld %t.o -o %t.wasm --no-entry --export=foo --export=bar
-# RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.wasm 3 0x42 0x43 0x44 0x45 0x46 0x47 0x48 0x49 0x4a 0x4b 0x4c 0x4d 0x4e 0x5e | FileCheck %s
+# RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.wasm 3 0x42 0x43 0x44 0x45 0x46 0x47 0x48 0x49 0x4a 0x4b 0x4c 0x4d 0x4e 0x51 | FileCheck %s
 
 .globl foo
 foo:
@@ -74,6 +74,6 @@ bar:
 # CHECK-NEXT: ??
 # CHECK-NEXT: ??:0
 
-## Past the end of the section.
+## Byte 16 is further past the end of the section.
 # CHECK: ??
 # CHECK-NEXT: ??:0

--- a/llvm/test/tools/llvm-symbolizer/wasm-basic.s
+++ b/llvm/test/tools/llvm-symbolizer/wasm-basic.s
@@ -1,11 +1,11 @@
 # REQUIRES: webassembly-registered-target, lld
 # RUN: llvm-mc -triple=wasm32-unknown-unknown -filetype=obj %s -o %t.o -g
-# RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.o 0 1 2 3 4 5 6 7 8 9 10 11 12 13 0x44 | FileCheck %s
+# RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.o 0 1 2 3 4 5 6 7 8 9 10 11 12 13 16 | FileCheck %s
 
-# This is the same test but on a linked wasm file, using file offsets rather
-# than section offsets.
+# This is the same test but on a linked wasm file, using file offsets rather than section offsets.
+# The code section starts at 0x41, so these are equivalent (see below for why the first one is 3).
 # RUN: wasm-ld %t.o -o %t.wasm --no-entry --export=foo --export=bar
-# RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.wasm 3 0x42 0x43 0x44 0x45 0x46 0x47 0x48 0x49 0x4a 0x4b 0x4c 0x4d 0x4e 0x100 | FileCheck %s
+# RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.wasm 3 0x42 0x43 0x44 0x45 0x46 0x47 0x48 0x49 0x4a 0x4b 0x4c 0x4d 0x4e 0x5e | FileCheck %s
 
 .globl foo
 foo:
@@ -27,7 +27,9 @@ bar:
 ## way to the next symbol start.
 ## TODO: create a loc for .functype? It could go with the local declarations.
 
-## Byte 0 (or 3, in the case of a linked file) never maps to a code section
+## For objects, byte 0 doesn't map to a function body.
+## For the linked file, 3 is chosen because if incorrectly interpreted as a
+## section offset, it will match a line.
 # CHECK: ??
 # CHECK-NEXT: ??:0
 
@@ -62,13 +64,13 @@ bar:
 ## Byte 10 is the nop
 # CHECK-NEXT: bar
 # CHECK-NEXT: wasm-basic.s:21
-## Byte b is the return
+## Byte 11 is the return
 # CHECK-NEXT: bar
 # CHECK-NEXT: wasm-basic.s:22
-## Byte c is end_function
+## Byte 12 is end_function
 # CHECK-NEXT: bar
 # CHECK-NEXT: wasm-basic.s:23
-## Byte d is past the end of the function
+## Byte 13 is past the end of the function
 # CHECK-NEXT: ??
 # CHECK-NEXT: ??:0
 


### PR DESCRIPTION
A fix after #191068: For linked files, invalidate any address that
is outside the text section to prevent it from being matched in DWARF as a
section-relative address.

Add test cases that cover the distinction (e.g. address 3 should match in an
object file but not in a linked file).
Also, fix the comments in the test to match the updated line numbers.
