### PR TITLE
[InstCombine] Fold (X + C) + (Y & ~C) to X + (Y | C)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1528,23 +1528,35 @@ foldAddWithMaskedOverwrite(BinaryOperator &Add,
                            InstCombiner::BuilderTy &Builder) {
   Value *LHS = Add.getOperand(0), *RHS = Add.getOperand(1);
   Value *X, *Y;
-  const APInt *C, *Mask;
+  const APInt *C;
 
   auto Match = [&](Value *AddOp, Value *AndOp) -> Instruction * {
     if (!match(AddOp, m_c_Add(m_Value(X), m_APInt(C))) ||
-        !match(AndOp, m_c_And(m_Value(Y), m_APInt(Mask))) || *Mask != ~(*C))
+        !match(AndOp, m_c_And(m_Value(Y), m_SpecificInt(~*C))))
       return nullptr;
 
     // Replacing one add with {or, add}. Avoid growth if both sides are shared.
     if (!AddOp->hasOneUse() && !AndOp->hasOneUse())
       return nullptr;
 
+    bool PreserveNSW = false;
+    bool PreserveNUW = false;
+    if (auto *InnerAdd = dyn_cast<OverflowingBinaryOperator>(AddOp)) {
+      PreserveNSW = Add.hasNoSignedWrap() && InnerAdd->hasNoSignedWrap();
+      PreserveNUW = Add.hasNoUnsignedWrap() && InnerAdd->hasNoUnsignedWrap();
+    }
+
     Value *NewOr =
         Builder.CreateOr(Y, Constant::getIntegerValue(Add.getType(), *C));
-    Instruction *NewAdd = cast<Instruction>(Builder.CreateAdd(X, NewOr));
-    NewAdd->setHasNoSignedWrap(Add.hasNoSignedWrap());
-    NewAdd->setHasNoUnsignedWrap(Add.hasNoUnsignedWrap());
-    return NewAdd;
+    Value *NewAdd = Builder.CreateAdd(X, NewOr);
+    if (auto *NewAddInst = dyn_cast<Instruction>(NewAdd)) {
+      NewAddInst->setHasNoSignedWrap(PreserveNSW);
+      NewAddInst->setHasNoUnsignedWrap(PreserveNUW);
+
+      return NewAddInst;
+    }
+
+    return nullptr;
   };
 
   if (Instruction *I = Match(LHS, RHS))

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1523,6 +1523,36 @@ static Instruction *foldBoxMultiply(BinaryOperator &I) {
   return nullptr;
 }
 
+static Instruction *
+foldAddWithMaskedOverwrite(BinaryOperator &Add,
+                           InstCombiner::BuilderTy &Builder) {
+  Value *LHS = Add.getOperand(0), *RHS = Add.getOperand(1);
+  Value *X, *Y;
+  const APInt *C, *Mask;
+
+  auto Match = [&](Value *AddOp, Value *AndOp) -> Instruction * {
+    if (!match(AddOp, m_c_Add(m_Value(X), m_APInt(C))) ||
+        !match(AndOp, m_c_And(m_Value(Y), m_APInt(Mask))) || *Mask != ~(*C))
+      return nullptr;
+
+    // Replacing one add with {or, add}. Avoid growth if both sides are shared.
+    if (!AddOp->hasOneUse() && !AndOp->hasOneUse())
+      return nullptr;
+
+
+    Value *NewOr =
+        Builder.CreateOr(Y, Constant::getIntegerValue(Add.getType(), *C));
+    Instruction *NewAdd = cast<Instruction>(Builder.CreateAdd(X, NewOr));
+    NewAdd->setHasNoSignedWrap(Add.hasNoSignedWrap());
+    NewAdd->setHasNoUnsignedWrap(Add.hasNoUnsignedWrap());
+    return NewAdd;
+  };
+
+  if (Instruction *I = Match(LHS, RHS))
+    return I;
+  return Match(RHS, LHS);
+}
+
 Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
   if (Value *V = simplifyAddInst(I.getOperand(0), I.getOperand(1),
                                  I.hasNoSignedWrap(), I.hasNoUnsignedWrap(),
@@ -1602,6 +1632,10 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
   }
 
   if (Value *V = checkForNegativeOperand(I, Builder))
+    return replaceInstUsesWith(I, V);
+
+  // (X + C) + (Y & ~C) == X + (Y | C)
+  if (Value *V = foldAddWithMaskedOverwrite(I, Builder))
     return replaceInstUsesWith(I, V);
 
   // (A + 1) + ~B --> A - B

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1539,7 +1539,6 @@ foldAddWithMaskedOverwrite(BinaryOperator &Add,
     if (!AddOp->hasOneUse() && !AndOp->hasOneUse())
       return nullptr;
 
-
     Value *NewOr =
         Builder.CreateOr(Y, Constant::getIntegerValue(Add.getType(), *C));
     Instruction *NewAdd = cast<Instruction>(Builder.CreateAdd(X, NewOr));

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1354,8 +1354,8 @@ Instruction *InstCombinerImpl::foldAddLikeCommutative(Value *LHS, Value *RHS,
 
     bool NSWOut = NSW && match(LHS, m_NSWAdd(m_Value(), m_Value()));
     bool NUWOut = NUW && match(LHS, m_NUWAdd(m_Value(), m_Value()));
-    Value *NewOr = Builder.CreateOr(
-        B, Constant::getIntegerValue(LHS->getType(), *C1));
+    Value *NewOr =
+        Builder.CreateOr(B, Constant::getIntegerValue(LHS->getType(), *C1));
     Instruction *NewAdd = BinaryOperator::CreateAdd(A, NewOr);
     NewAdd->setHasNoSignedWrap(NSWOut);
     NewAdd->setHasNoUnsignedWrap(NUWOut);

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1345,6 +1345,23 @@ Instruction *InstCombinerImpl::foldAddLikeCommutative(Value *LHS, Value *RHS,
     }
   }
 
+  // (A + C) + (B & ~C) == A + (B | C)
+  if (match(LHS, m_c_Add(m_Value(A), m_APInt(C1))) &&
+      match(RHS, m_c_And(m_Value(B), m_SpecificInt(~*C1)))) {
+    // Replacing one add with {or, add}. Avoid growth if both sides are shared.
+    if (!LHS->hasOneUse() && !RHS->hasOneUse())
+      return nullptr;
+
+    bool NSWOut = NSW && match(LHS, m_NSWAdd(m_Value(), m_Value()));
+    bool NUWOut = NUW && match(LHS, m_NUWAdd(m_Value(), m_Value()));
+    Value *NewOr = Builder.CreateOr(
+        B, Constant::getIntegerValue(LHS->getType(), *C1));
+    Instruction *NewAdd = BinaryOperator::CreateAdd(A, NewOr);
+    NewAdd->setHasNoSignedWrap(NSWOut);
+    NewAdd->setHasNoUnsignedWrap(NUWOut);
+    return NewAdd;
+  }
+
   return nullptr;
 }
 
@@ -1523,47 +1540,6 @@ static Instruction *foldBoxMultiply(BinaryOperator &I) {
   return nullptr;
 }
 
-static Instruction *
-foldAddWithMaskedOverwrite(BinaryOperator &Add,
-                           InstCombiner::BuilderTy &Builder) {
-  Value *LHS = Add.getOperand(0), *RHS = Add.getOperand(1);
-  Value *X, *Y;
-  const APInt *C;
-
-  auto Match = [&](Value *AddOp, Value *AndOp) -> Instruction * {
-    if (!match(AddOp, m_c_Add(m_Value(X), m_APInt(C))) ||
-        !match(AndOp, m_c_And(m_Value(Y), m_SpecificInt(~*C))))
-      return nullptr;
-
-    // Replacing one add with {or, add}. Avoid growth if both sides are shared.
-    if (!AddOp->hasOneUse() && !AndOp->hasOneUse())
-      return nullptr;
-
-    bool PreserveNSW = false;
-    bool PreserveNUW = false;
-    if (auto *InnerAdd = dyn_cast<OverflowingBinaryOperator>(AddOp)) {
-      PreserveNSW = Add.hasNoSignedWrap() && InnerAdd->hasNoSignedWrap();
-      PreserveNUW = Add.hasNoUnsignedWrap() && InnerAdd->hasNoUnsignedWrap();
-    }
-
-    Value *NewOr =
-        Builder.CreateOr(Y, Constant::getIntegerValue(Add.getType(), *C));
-    Value *NewAdd = Builder.CreateAdd(X, NewOr);
-    if (auto *NewAddInst = dyn_cast<Instruction>(NewAdd)) {
-      NewAddInst->setHasNoSignedWrap(PreserveNSW);
-      NewAddInst->setHasNoUnsignedWrap(PreserveNUW);
-
-      return NewAddInst;
-    }
-
-    return nullptr;
-  };
-
-  if (Instruction *I = Match(LHS, RHS))
-    return I;
-  return Match(RHS, LHS);
-}
-
 Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
   if (Value *V = simplifyAddInst(I.getOperand(0), I.getOperand(1),
                                  I.hasNoSignedWrap(), I.hasNoUnsignedWrap(),
@@ -1643,10 +1619,6 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
   }
 
   if (Value *V = checkForNegativeOperand(I, Builder))
-    return replaceInstUsesWith(I, V);
-
-  // (X + C) + (Y & ~C) == X + (Y | C)
-  if (Value *V = foldAddWithMaskedOverwrite(I, Builder))
     return replaceInstUsesWith(I, V);
 
   // (A + 1) + ~B --> A - B

--- a/llvm/test/Transforms/InstCombine/add.ll
+++ b/llvm/test/Transforms/InstCombine/add.ll
@@ -6,7 +6,6 @@ declare void @use(i8)
 declare void @use_i1(i1)
 
 ; fold (X + C) + (Y & ~C) -> X + (Y | C)
-
 define i32 @add_masked_overwrite_basic(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_basic(
 ; CHECK-NEXT:    [[X:%.*]] = add i32 [[X1:%.*]], 1
@@ -33,17 +32,367 @@ define i32 @add_masked_overwrite_commuted(i32 %x, i32 %y) {
   ret i32 %r
 }
 
-define <4 x i32> @add_masked_overwrite_vec_splat(<4 x i32> %x, <4 x i32> %y) {
-; CHECK-LABEL: @add_masked_overwrite_vec_splat(
-; CHECK-NEXT:    [[X:%.*]] = add <4 x i32> [[X1:%.*]], splat (i32 1)
-; CHECK-NEXT:    [[OR:%.*]] = and <4 x i32> [[Y:%.*]], splat (i32 -2)
-; CHECK-NEXT:    [[ADD:%.*]] = add <4 x i32> [[X]], [[OR]]
-; CHECK-NEXT:    ret <4 x i32> [[ADD]]
+define i32 @add_masked_overwrite_preserve_nsw(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_preserve_nsw(
+; CHECK-NEXT:    [[X:%.*]] = add nsw i32 [[X1:%.*]], 1
+; CHECK-NEXT:    [[OR:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[X]], [[OR]]
+; CHECK-NEXT:    ret i32 [[ADD]]
 ;
-  %a = add <4 x i32> %x, splat (i32 1)
-  %b = and <4 x i32> %y, splat (i32 -2)
-  %r = add <4 x i32> %a, %b
-  ret <4 x i32> %r
+  %a = add nsw i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add nsw i32 %a, %m
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_preserve_nuw(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_preserve_nuw(
+; CHECK-NEXT:    [[X:%.*]] = add nuw i32 [[X1:%.*]], 1
+; CHECK-NEXT:    [[OR:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw i32 [[X]], [[OR]]
+; CHECK-NEXT:    ret i32 [[ADD]]
+;
+  %a = add nuw i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add nuw i32 %a, %m
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_preserve_nuw_nsw(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_preserve_nuw_nsw(
+; CHECK-NEXT:    [[X:%.*]] = add nuw nsw i32 [[X1:%.*]], 1
+; CHECK-NEXT:    [[OR:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[X]], [[OR]]
+; CHECK-NEXT:    ret i32 [[ADD]]
+;
+  %a = add nuw nsw i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add nuw nsw i32 %a, %m
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_do_not_preserve_outer_nsw_only(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_do_not_preserve_outer_nsw_only(
+; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[A]], [[M]]
+; CHECK-NEXT:    ret i32 [[ADD]]
+;
+  %a = add i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add nsw i32 %a, %m
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_do_not_preserve_outer_nuw_only(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_do_not_preserve_outer_nuw_only(
+; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw i32 [[A]], [[M]]
+; CHECK-NEXT:    ret i32 [[ADD]]
+;
+  %a = add i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add nuw i32 %a, %m
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_do_not_preserve_inner_nsw_only(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_do_not_preserve_inner_nsw_only(
+; CHECK-NEXT:    [[A:%.*]] = add nsw i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[A]], [[M]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add nsw i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add i32 %a, %m
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_do_not_preserve_inner_nuw_only(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_do_not_preserve_inner_nuw_only(
+; CHECK-NEXT:    [[A:%.*]] = add nuw i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[A]], [[M]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add nuw i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add i32 %a, %m
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_commuted_preserve_nsw(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_commuted_preserve_nsw(
+; CHECK-NEXT:    [[A:%.*]] = add nsw i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add nsw i32 [[M]], [[A]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add nsw i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add nsw i32 %m, %a
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_commuted_preserve_nuw(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_commuted_preserve_nuw(
+; CHECK-NEXT:    [[A:%.*]] = add nuw i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add nuw i32 [[M]], [[A]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add nuw i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add nuw i32 %m, %a
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_commuted_preserve_nuw_nsw(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_commuted_preserve_nuw_nsw(
+; CHECK-NEXT:    [[A:%.*]] = add nuw nsw i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add nuw nsw i32 [[M]], [[A]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add nuw nsw i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add nuw nsw i32 %m, %a
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_commuted_do_not_preserve_outer_nsw_only(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_commuted_do_not_preserve_outer_nsw_only(
+; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add nsw i32 [[M]], [[A]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add nsw i32 %m, %a
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_commuted_do_not_preserve_outer_nuw_only(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_commuted_do_not_preserve_outer_nuw_only(
+; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add nuw i32 [[M]], [[A]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add nuw i32 %m, %a
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_commuted_do_not_preserve_inner_nsw_only(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_commuted_do_not_preserve_inner_nsw_only(
+; CHECK-NEXT:    [[A:%.*]] = add nsw i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[M]], [[A]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add nsw i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add i32 %m, %a
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_commuted_do_not_preserve_inner_nuw_only(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_commuted_do_not_preserve_inner_nuw_only(
+; CHECK-NEXT:    [[A:%.*]] = add nuw i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[M]], [[A]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add nuw i32 %x, 1
+  %m = and i32 %y, -2
+  %r = add i32 %m, %a
+  ret i32 %r
+}
+
+; only AndOp is multi-use -> fold is still OK
+define i32 @add_masked_overwrite_one_side_multiuse_and(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_one_side_multiuse_and(
+; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[B:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    call void @use(i32 [[B]])
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[A]], [[B]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add i32 %x, 1
+  %b = and i32 %y, -2
+  call void @use(i32 %b)
+  %r = add i32 %a, %b
+  ret i32 %r
+}
+
+; non-trivial constant: fold (X + 5) + (Y & ~5)
+define i32 @add_masked_overwrite_const_5(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_const_5(
+; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 5
+; CHECK-NEXT:    [[B:%.*]] = and i32 [[Y:%.*]], -6
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[A]], [[B]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add i32 %x, 5
+  %b = and i32 %y, -6
+  %r = add i32 %a, %b
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_const_5_preserve_nsw(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_const_5_preserve_nsw(
+; CHECK-NEXT:    [[A:%.*]] = add nsw i32 [[X:%.*]], 5
+; CHECK-NEXT:    [[B:%.*]] = and i32 [[Y:%.*]], -6
+; CHECK-NEXT:    [[R:%.*]] = add nsw i32 [[A]], [[B]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add nsw i32 %x, 5
+  %b = and i32 %y, -6
+  %r = add nsw i32 %a, %b
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_const_5_preserve_nuw(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_const_5_preserve_nuw(
+; CHECK-NEXT:    [[A:%.*]] = add nuw i32 [[X:%.*]], 5
+; CHECK-NEXT:    [[B:%.*]] = and i32 [[Y:%.*]], -6
+; CHECK-NEXT:    [[R:%.*]] = add nuw i32 [[A]], [[B]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add nuw i32 %x, 5
+  %b = and i32 %y, -6
+  %r = add nuw i32 %a, %b
+  ret i32 %r
+}
+
+; boundary case: C = 0, ~C = -1
+define i32 @add_masked_overwrite_const_0(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_const_0(
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add i32 %x, 0
+  %b = and i32 %y, -1
+  %r = add i32 %a, %b
+  ret i32 %r
+}
+
+define i8 @add_masked_overwrite_i8(i8 %x, i8 %y) {
+; CHECK-LABEL: @add_masked_overwrite_i8(
+; CHECK-NEXT:    [[A:%.*]] = add i8 [[X:%.*]], 1
+; CHECK-NEXT:    [[B:%.*]] = and i8 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add i8 [[A]], [[B]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %a = add i8 %x, 1
+  %b = and i8 %y, -2
+  %r = add i8 %a, %b
+  ret i8 %r
+}
+
+define i8 @add_masked_overwrite_i8_preserve_nuw_nsw(i8 %x, i8 %y) {
+; CHECK-LABEL: @add_masked_overwrite_i8_preserve_nuw_nsw(
+; CHECK-NEXT:    [[A:%.*]] = add nuw nsw i8 [[X:%.*]], 1
+; CHECK-NEXT:    [[B:%.*]] = and i8 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add nuw nsw i8 [[A]], [[B]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %a = add nuw nsw i8 %x, 1
+  %b = and i8 %y, -2
+  %r = add nuw nsw i8 %a, %b
+  ret i8 %r
+}
+
+define i64 @add_masked_overwrite_i64(i64 %x, i64 %y) {
+; CHECK-LABEL: @add_masked_overwrite_i64(
+; CHECK-NEXT:    [[A:%.*]] = add i64 [[X:%.*]], 1
+; CHECK-NEXT:    [[B:%.*]] = and i64 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add i64 [[A]], [[B]]
+; CHECK-NEXT:    ret i64 [[R]]
+;
+  %a = add i64 %x, 1
+  %b = and i64 %y, -2
+  %r = add i64 %a, %b
+  ret i64 %r
+}
+
+define i64 @add_masked_overwrite_i64_preserve_nsw(i64 %x, i64 %y) {
+; CHECK-LABEL: @add_masked_overwrite_i64_preserve_nsw(
+; CHECK-NEXT:    [[A:%.*]] = add nsw i64 [[X:%.*]], 1
+; CHECK-NEXT:    [[B:%.*]] = and i64 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add nsw i64 [[A]], [[B]]
+; CHECK-NEXT:    ret i64 [[R]]
+;
+  %a = add nsw i64 %x, 1
+  %b = and i64 %y, -2
+  %r = add nsw i64 %a, %b
+  ret i64 %r
+}
+
+define i64 @add_masked_overwrite_i64_preserve_nuw(i64 %x, i64 %y) {
+; CHECK-LABEL: @add_masked_overwrite_i64_preserve_nuw(
+; CHECK-NEXT:    [[A:%.*]] = add nuw i64 [[X:%.*]], 1
+; CHECK-NEXT:    [[B:%.*]] = and i64 [[Y:%.*]], -2
+; CHECK-NEXT:    [[R:%.*]] = add nuw i64 [[A]], [[B]]
+; CHECK-NEXT:    ret i64 [[R]]
+;
+  %a = add nuw i64 %x, 1
+  %b = and i64 %y, -2
+  %r = add nuw i64 %a, %b
+  ret i64 %r
+}
+
+; both AddOp and AndOp are multi-use -> do not fold
+define i32 @add_masked_overwrite_multiuse_both(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_multiuse_both(
+; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[B:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    call void @use(i32 [[A]])
+; CHECK-NEXT:    call void @use(i32 [[B]])
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[A]], [[B]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add i32 %x, 1
+  %b = and i32 %y, -2
+  call void @use(i32 %a)
+  call void @use(i32 %b)
+  %r = add i32 %a, %b
+  ret i32 %r
+}
+
+; exact-mask mismatch -> do not fold
+define i32 @add_masked_overwrite_mask_mismatch(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_mask_mismatch(
+; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[B:%.*]] = and i32 [[Y:%.*]], -4
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[A]], [[B]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add i32 %x, 1
+  %b = and i32 %y, -4
+  %r = add i32 %a, %b
+  ret i32 %r
+}
+
+; optional: only one side multi-use -> fold is still OK
+define i32 @add_masked_overwrite_one_side_multiuse(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_one_side_multiuse(
+; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[B:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    call void @use(i32 [[A]])
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[A]], [[B]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = add i32 %x, 1
+  %b = and i32 %y, -2
+  call void @use(i32 %a)
+  %r = add i32 %a, %b
+  ret i32 %r
 }
 
 define i32 @select_0_or_1_from_bool(i1 %x) {

--- a/llvm/test/Transforms/InstCombine/add.ll
+++ b/llvm/test/Transforms/InstCombine/add.ll
@@ -69,7 +69,7 @@ define i32 @add_masked_overwrite_preserve_nuw_nsw(i32 %x, i32 %y) {
 define i32 @add_masked_overwrite_do_not_preserve_outer_nsw_only(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_do_not_preserve_outer_nsw_only(
 ; CHECK-NEXT:    [[M:%.*]] = or i32 [[Y:%.*]], 1
-; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[A:%.*]], [[M]]
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X:%.*]], [[M]]
 ; CHECK-NEXT:    ret i32 [[ADD]]
 ;
   %a = add i32 %x, 1
@@ -81,7 +81,7 @@ define i32 @add_masked_overwrite_do_not_preserve_outer_nsw_only(i32 %x, i32 %y) 
 define i32 @add_masked_overwrite_do_not_preserve_outer_nuw_only(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_do_not_preserve_outer_nuw_only(
 ; CHECK-NEXT:    [[M:%.*]] = or i32 [[Y:%.*]], 1
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw i32 [[A:%.*]], [[M]]
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X:%.*]], [[M]]
 ; CHECK-NEXT:    ret i32 [[ADD]]
 ;
   %a = add i32 %x, 1
@@ -153,7 +153,7 @@ define i32 @add_masked_overwrite_commuted_preserve_nuw_nsw(i32 %x, i32 %y) {
 define i32 @add_masked_overwrite_commuted_do_not_preserve_outer_nsw_only(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_commuted_do_not_preserve_outer_nsw_only(
 ; CHECK-NEXT:    [[A:%.*]] = or i32 [[Y:%.*]], 1
-; CHECK-NEXT:    [[R:%.*]] = add nsw i32 [[M:%.*]], [[A]]
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[X:%.*]], [[A]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add i32 %x, 1
@@ -165,7 +165,7 @@ define i32 @add_masked_overwrite_commuted_do_not_preserve_outer_nsw_only(i32 %x,
 define i32 @add_masked_overwrite_commuted_do_not_preserve_outer_nuw_only(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_commuted_do_not_preserve_outer_nuw_only(
 ; CHECK-NEXT:    [[A:%.*]] = or i32 [[Y:%.*]], 1
-; CHECK-NEXT:    [[R:%.*]] = add nuw i32 [[M:%.*]], [[A]]
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[X:%.*]], [[A]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add i32 %x, 1

--- a/llvm/test/Transforms/InstCombine/add.ll
+++ b/llvm/test/Transforms/InstCombine/add.ll
@@ -8,9 +8,8 @@ declare void @use_i1(i1)
 ; fold (X + C) + (Y & ~C) -> X + (Y | C)
 define i32 @add_masked_overwrite_basic(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_basic(
-; CHECK-NEXT:    [[X:%.*]] = add i32 [[X1:%.*]], 1
-; CHECK-NEXT:    [[OR:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X]], [[OR]]
+; CHECK-NEXT:    [[OR:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X:%.*]], [[OR]]
 ; CHECK-NEXT:    ret i32 [[ADD]]
 ;
   %a = add i32 %x, 1
@@ -21,9 +20,8 @@ define i32 @add_masked_overwrite_basic(i32 %x, i32 %y) {
 
 define i32 @add_masked_overwrite_commuted(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_commuted(
-; CHECK-NEXT:    [[OR:%.*]] = add i32 [[X1:%.*]], 1
-; CHECK-NEXT:    [[X:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X]], [[OR]]
+; CHECK-NEXT:    [[OR:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X:%.*]], [[OR]]
 ; CHECK-NEXT:    ret i32 [[ADD]]
 ;
   %a = add i32 %x, 1
@@ -34,9 +32,8 @@ define i32 @add_masked_overwrite_commuted(i32 %x, i32 %y) {
 
 define i32 @add_masked_overwrite_preserve_nsw(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_preserve_nsw(
-; CHECK-NEXT:    [[X:%.*]] = add nsw i32 [[X1:%.*]], 1
-; CHECK-NEXT:    [[OR:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[X]], [[OR]]
+; CHECK-NEXT:    [[OR:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[X:%.*]], [[OR]]
 ; CHECK-NEXT:    ret i32 [[ADD]]
 ;
   %a = add nsw i32 %x, 1
@@ -47,9 +44,8 @@ define i32 @add_masked_overwrite_preserve_nsw(i32 %x, i32 %y) {
 
 define i32 @add_masked_overwrite_preserve_nuw(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_preserve_nuw(
-; CHECK-NEXT:    [[X:%.*]] = add nuw i32 [[X1:%.*]], 1
-; CHECK-NEXT:    [[OR:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw i32 [[X]], [[OR]]
+; CHECK-NEXT:    [[OR:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw i32 [[X:%.*]], [[OR]]
 ; CHECK-NEXT:    ret i32 [[ADD]]
 ;
   %a = add nuw i32 %x, 1
@@ -60,9 +56,8 @@ define i32 @add_masked_overwrite_preserve_nuw(i32 %x, i32 %y) {
 
 define i32 @add_masked_overwrite_preserve_nuw_nsw(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_preserve_nuw_nsw(
-; CHECK-NEXT:    [[X:%.*]] = add nuw nsw i32 [[X1:%.*]], 1
-; CHECK-NEXT:    [[OR:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[X]], [[OR]]
+; CHECK-NEXT:    [[OR:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[X:%.*]], [[OR]]
 ; CHECK-NEXT:    ret i32 [[ADD]]
 ;
   %a = add nuw nsw i32 %x, 1
@@ -73,9 +68,8 @@ define i32 @add_masked_overwrite_preserve_nuw_nsw(i32 %x, i32 %y) {
 
 define i32 @add_masked_overwrite_do_not_preserve_outer_nsw_only(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_do_not_preserve_outer_nsw_only(
-; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
-; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[A]], [[M]]
+; CHECK-NEXT:    [[M:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[A:%.*]], [[M]]
 ; CHECK-NEXT:    ret i32 [[ADD]]
 ;
   %a = add i32 %x, 1
@@ -86,9 +80,8 @@ define i32 @add_masked_overwrite_do_not_preserve_outer_nsw_only(i32 %x, i32 %y) 
 
 define i32 @add_masked_overwrite_do_not_preserve_outer_nuw_only(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_do_not_preserve_outer_nuw_only(
-; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
-; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw i32 [[A]], [[M]]
+; CHECK-NEXT:    [[M:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw i32 [[A:%.*]], [[M]]
 ; CHECK-NEXT:    ret i32 [[ADD]]
 ;
   %a = add i32 %x, 1
@@ -99,9 +92,8 @@ define i32 @add_masked_overwrite_do_not_preserve_outer_nuw_only(i32 %x, i32 %y) 
 
 define i32 @add_masked_overwrite_do_not_preserve_inner_nsw_only(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_do_not_preserve_inner_nsw_only(
-; CHECK-NEXT:    [[A:%.*]] = add nsw i32 [[X:%.*]], 1
-; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[A]], [[M]]
+; CHECK-NEXT:    [[M:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[A:%.*]], [[M]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add nsw i32 %x, 1
@@ -112,9 +104,8 @@ define i32 @add_masked_overwrite_do_not_preserve_inner_nsw_only(i32 %x, i32 %y) 
 
 define i32 @add_masked_overwrite_do_not_preserve_inner_nuw_only(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_do_not_preserve_inner_nuw_only(
-; CHECK-NEXT:    [[A:%.*]] = add nuw i32 [[X:%.*]], 1
-; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[A]], [[M]]
+; CHECK-NEXT:    [[M:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[A:%.*]], [[M]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add nuw i32 %x, 1
@@ -125,9 +116,8 @@ define i32 @add_masked_overwrite_do_not_preserve_inner_nuw_only(i32 %x, i32 %y) 
 
 define i32 @add_masked_overwrite_commuted_preserve_nsw(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_commuted_preserve_nsw(
-; CHECK-NEXT:    [[A:%.*]] = add nsw i32 [[X:%.*]], 1
-; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add nsw i32 [[M]], [[A]]
+; CHECK-NEXT:    [[A:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add nsw i32 [[M:%.*]], [[A]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add nsw i32 %x, 1
@@ -138,9 +128,8 @@ define i32 @add_masked_overwrite_commuted_preserve_nsw(i32 %x, i32 %y) {
 
 define i32 @add_masked_overwrite_commuted_preserve_nuw(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_commuted_preserve_nuw(
-; CHECK-NEXT:    [[A:%.*]] = add nuw i32 [[X:%.*]], 1
-; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add nuw i32 [[M]], [[A]]
+; CHECK-NEXT:    [[A:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add nuw i32 [[M:%.*]], [[A]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add nuw i32 %x, 1
@@ -151,9 +140,8 @@ define i32 @add_masked_overwrite_commuted_preserve_nuw(i32 %x, i32 %y) {
 
 define i32 @add_masked_overwrite_commuted_preserve_nuw_nsw(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_commuted_preserve_nuw_nsw(
-; CHECK-NEXT:    [[A:%.*]] = add nuw nsw i32 [[X:%.*]], 1
-; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add nuw nsw i32 [[M]], [[A]]
+; CHECK-NEXT:    [[A:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add nuw nsw i32 [[M:%.*]], [[A]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add nuw nsw i32 %x, 1
@@ -164,9 +152,8 @@ define i32 @add_masked_overwrite_commuted_preserve_nuw_nsw(i32 %x, i32 %y) {
 
 define i32 @add_masked_overwrite_commuted_do_not_preserve_outer_nsw_only(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_commuted_do_not_preserve_outer_nsw_only(
-; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
-; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add nsw i32 [[M]], [[A]]
+; CHECK-NEXT:    [[A:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add nsw i32 [[M:%.*]], [[A]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add i32 %x, 1
@@ -177,9 +164,8 @@ define i32 @add_masked_overwrite_commuted_do_not_preserve_outer_nsw_only(i32 %x,
 
 define i32 @add_masked_overwrite_commuted_do_not_preserve_outer_nuw_only(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_commuted_do_not_preserve_outer_nuw_only(
-; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
-; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add nuw i32 [[M]], [[A]]
+; CHECK-NEXT:    [[A:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add nuw i32 [[M:%.*]], [[A]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add i32 %x, 1
@@ -190,9 +176,8 @@ define i32 @add_masked_overwrite_commuted_do_not_preserve_outer_nuw_only(i32 %x,
 
 define i32 @add_masked_overwrite_commuted_do_not_preserve_inner_nsw_only(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_commuted_do_not_preserve_inner_nsw_only(
-; CHECK-NEXT:    [[A:%.*]] = add nsw i32 [[X:%.*]], 1
-; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[M]], [[A]]
+; CHECK-NEXT:    [[A:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[M:%.*]], [[A]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add nsw i32 %x, 1
@@ -203,9 +188,8 @@ define i32 @add_masked_overwrite_commuted_do_not_preserve_inner_nsw_only(i32 %x,
 
 define i32 @add_masked_overwrite_commuted_do_not_preserve_inner_nuw_only(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_commuted_do_not_preserve_inner_nuw_only(
-; CHECK-NEXT:    [[A:%.*]] = add nuw i32 [[X:%.*]], 1
-; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[M]], [[A]]
+; CHECK-NEXT:    [[A:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[M:%.*]], [[A]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add nuw i32 %x, 1
@@ -217,10 +201,10 @@ define i32 @add_masked_overwrite_commuted_do_not_preserve_inner_nuw_only(i32 %x,
 ; only AndOp is multi-use -> fold is still OK
 define i32 @add_masked_overwrite_one_side_multiuse_and(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_one_side_multiuse_and(
-; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
 ; CHECK-NEXT:    [[B:%.*]] = and i32 [[Y:%.*]], -2
 ; CHECK-NEXT:    call void @use(i32 [[B]])
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[A]], [[B]]
+; CHECK-NEXT:    [[TMP1:%.*]] = or i32 [[Y]], 1
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[X:%.*]], [[TMP1]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add i32 %x, 1
@@ -233,9 +217,8 @@ define i32 @add_masked_overwrite_one_side_multiuse_and(i32 %x, i32 %y) {
 ; non-trivial constant: fold (X + 5) + (Y & ~5)
 define i32 @add_masked_overwrite_const_5(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_const_5(
-; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 5
-; CHECK-NEXT:    [[B:%.*]] = and i32 [[Y:%.*]], -6
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[A]], [[B]]
+; CHECK-NEXT:    [[B:%.*]] = or i32 [[Y:%.*]], 5
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[A:%.*]], [[B]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add i32 %x, 5
@@ -246,9 +229,8 @@ define i32 @add_masked_overwrite_const_5(i32 %x, i32 %y) {
 
 define i32 @add_masked_overwrite_const_5_preserve_nsw(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_const_5_preserve_nsw(
-; CHECK-NEXT:    [[A:%.*]] = add nsw i32 [[X:%.*]], 5
-; CHECK-NEXT:    [[B:%.*]] = and i32 [[Y:%.*]], -6
-; CHECK-NEXT:    [[R:%.*]] = add nsw i32 [[A]], [[B]]
+; CHECK-NEXT:    [[B:%.*]] = or i32 [[Y:%.*]], 5
+; CHECK-NEXT:    [[R:%.*]] = add nsw i32 [[A:%.*]], [[B]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add nsw i32 %x, 5
@@ -259,9 +241,8 @@ define i32 @add_masked_overwrite_const_5_preserve_nsw(i32 %x, i32 %y) {
 
 define i32 @add_masked_overwrite_const_5_preserve_nuw(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_const_5_preserve_nuw(
-; CHECK-NEXT:    [[A:%.*]] = add nuw i32 [[X:%.*]], 5
-; CHECK-NEXT:    [[B:%.*]] = and i32 [[Y:%.*]], -6
-; CHECK-NEXT:    [[R:%.*]] = add nuw i32 [[A]], [[B]]
+; CHECK-NEXT:    [[B:%.*]] = or i32 [[Y:%.*]], 5
+; CHECK-NEXT:    [[R:%.*]] = add nuw i32 [[A:%.*]], [[B]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add nuw i32 %x, 5
@@ -284,9 +265,8 @@ define i32 @add_masked_overwrite_const_0(i32 %x, i32 %y) {
 
 define i8 @add_masked_overwrite_i8(i8 %x, i8 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_i8(
-; CHECK-NEXT:    [[A:%.*]] = add i8 [[X:%.*]], 1
-; CHECK-NEXT:    [[B:%.*]] = and i8 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add i8 [[A]], [[B]]
+; CHECK-NEXT:    [[B:%.*]] = or i8 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add i8 [[A:%.*]], [[B]]
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %a = add i8 %x, 1
@@ -297,9 +277,8 @@ define i8 @add_masked_overwrite_i8(i8 %x, i8 %y) {
 
 define i8 @add_masked_overwrite_i8_preserve_nuw_nsw(i8 %x, i8 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_i8_preserve_nuw_nsw(
-; CHECK-NEXT:    [[A:%.*]] = add nuw nsw i8 [[X:%.*]], 1
-; CHECK-NEXT:    [[B:%.*]] = and i8 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add nuw nsw i8 [[A]], [[B]]
+; CHECK-NEXT:    [[B:%.*]] = or i8 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add nuw nsw i8 [[A:%.*]], [[B]]
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %a = add nuw nsw i8 %x, 1
@@ -310,9 +289,8 @@ define i8 @add_masked_overwrite_i8_preserve_nuw_nsw(i8 %x, i8 %y) {
 
 define i64 @add_masked_overwrite_i64(i64 %x, i64 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_i64(
-; CHECK-NEXT:    [[A:%.*]] = add i64 [[X:%.*]], 1
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add i64 [[A]], [[B]]
+; CHECK-NEXT:    [[B:%.*]] = or i64 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add i64 [[A:%.*]], [[B]]
 ; CHECK-NEXT:    ret i64 [[R]]
 ;
   %a = add i64 %x, 1
@@ -323,9 +301,8 @@ define i64 @add_masked_overwrite_i64(i64 %x, i64 %y) {
 
 define i64 @add_masked_overwrite_i64_preserve_nsw(i64 %x, i64 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_i64_preserve_nsw(
-; CHECK-NEXT:    [[A:%.*]] = add nsw i64 [[X:%.*]], 1
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add nsw i64 [[A]], [[B]]
+; CHECK-NEXT:    [[B:%.*]] = or i64 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add nsw i64 [[A:%.*]], [[B]]
 ; CHECK-NEXT:    ret i64 [[R]]
 ;
   %a = add nsw i64 %x, 1
@@ -336,9 +313,8 @@ define i64 @add_masked_overwrite_i64_preserve_nsw(i64 %x, i64 %y) {
 
 define i64 @add_masked_overwrite_i64_preserve_nuw(i64 %x, i64 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_i64_preserve_nuw(
-; CHECK-NEXT:    [[A:%.*]] = add nuw i64 [[X:%.*]], 1
-; CHECK-NEXT:    [[B:%.*]] = and i64 [[Y:%.*]], -2
-; CHECK-NEXT:    [[R:%.*]] = add nuw i64 [[A]], [[B]]
+; CHECK-NEXT:    [[B:%.*]] = or i64 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add nuw i64 [[A:%.*]], [[B]]
 ; CHECK-NEXT:    ret i64 [[R]]
 ;
   %a = add nuw i64 %x, 1
@@ -383,9 +359,9 @@ define i32 @add_masked_overwrite_mask_mismatch(i32 %x, i32 %y) {
 define i32 @add_masked_overwrite_one_side_multiuse(i32 %x, i32 %y) {
 ; CHECK-LABEL: @add_masked_overwrite_one_side_multiuse(
 ; CHECK-NEXT:    [[A:%.*]] = add i32 [[X:%.*]], 1
-; CHECK-NEXT:    [[B:%.*]] = and i32 [[Y:%.*]], -2
 ; CHECK-NEXT:    call void @use(i32 [[A]])
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[A]], [[B]]
+; CHECK-NEXT:    [[TMP1:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[X]], [[TMP1]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %a = add i32 %x, 1

--- a/llvm/test/Transforms/InstCombine/add.ll
+++ b/llvm/test/Transforms/InstCombine/add.ll
@@ -5,6 +5,47 @@
 declare void @use(i8)
 declare void @use_i1(i1)
 
+; fold (X + C) + (Y & ~C) -> X + (Y | C)
+
+define i32 @add_masked_overwrite_basic(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_basic(
+; CHECK-NEXT:    [[X:%.*]] = add i32 [[X1:%.*]], 1
+; CHECK-NEXT:    [[OR:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X]], [[OR]]
+; CHECK-NEXT:    ret i32 [[ADD]]
+;
+  %a = add i32 %x, 1
+  %b = and i32 %y, -2
+  %r = add i32 %a, %b
+  ret i32 %r
+}
+
+define i32 @add_masked_overwrite_commuted(i32 %x, i32 %y) {
+; CHECK-LABEL: @add_masked_overwrite_commuted(
+; CHECK-NEXT:    [[OR:%.*]] = add i32 [[X1:%.*]], 1
+; CHECK-NEXT:    [[X:%.*]] = and i32 [[Y:%.*]], -2
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X]], [[OR]]
+; CHECK-NEXT:    ret i32 [[ADD]]
+;
+  %a = add i32 %x, 1
+  %b = and i32 %y, -2
+  %r = add i32 %b, %a
+  ret i32 %r
+}
+
+define <4 x i32> @add_masked_overwrite_vec_splat(<4 x i32> %x, <4 x i32> %y) {
+; CHECK-LABEL: @add_masked_overwrite_vec_splat(
+; CHECK-NEXT:    [[X:%.*]] = add <4 x i32> [[X1:%.*]], splat (i32 1)
+; CHECK-NEXT:    [[OR:%.*]] = and <4 x i32> [[Y:%.*]], splat (i32 -2)
+; CHECK-NEXT:    [[ADD:%.*]] = add <4 x i32> [[X]], [[OR]]
+; CHECK-NEXT:    ret <4 x i32> [[ADD]]
+;
+  %a = add <4 x i32> %x, splat (i32 1)
+  %b = and <4 x i32> %y, splat (i32 -2)
+  %r = add <4 x i32> %a, %b
+  ret <4 x i32> %r
+}
+
 define i32 @select_0_or_1_from_bool(i1 %x) {
 ; CHECK-LABEL: @select_0_or_1_from_bool(
 ; CHECK-NEXT:    [[NOT_X:%.*]] = xor i1 [[X:%.*]], true


### PR DESCRIPTION
Add an InstCombine fold for masked overwrite patterns where the add
constant matches the cleared bits in the mask:

  (X + C) + (Y & ~C) -> X + (Y | C)

Since `Y & ~C` clears all bits set in C, adding C cannot generate carry
through those bits and is equivalent to setting them with `or`.

Proof: https://alive2.llvm.org/ce/z/277UFK
Fixed: https://github.com/llvm/llvm-project/issues/191171