### PR TITLE
[Hexagon] Add LTO options to Hexagon driver link args

### DIFF
--- a/clang/lib/Driver/ToolChains/Hexagon.cpp
+++ b/clang/lib/Driver/ToolChains/Hexagon.cpp
@@ -358,6 +358,10 @@ constructHexagonLinkArgs(Compilation &C, const JobAction &JA,
                               options::OPT_t, options::OPT_u_Group});
     AddLinkerInputs(HTC, Inputs, Args, CmdArgs, JA);
 
+    if (D.isUsingLTO())
+      addLTOOptions(HTC, Args, CmdArgs, Output, Inputs,
+                    D.getLTOMode() == LTOK_Thin);
+
     ToolChain::UnwindLibType UNW = HTC.GetUnwindLibType(Args);
 
     if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs)) {
@@ -437,6 +441,10 @@ constructHexagonLinkArgs(Compilation &C, const JobAction &JA,
                             options::OPT_t, options::OPT_u_Group});
 
   AddLinkerInputs(HTC, Inputs, Args, CmdArgs, JA);
+
+  if (D.isUsingLTO())
+    addLTOOptions(HTC, Args, CmdArgs, Output, Inputs,
+                  D.getLTOMode() == LTOK_Thin);
 
   //----------------------------------------------------------------------------
   // Libraries

--- a/clang/test/Driver/hexagon-toolchain-elf.c
+++ b/clang/test/Driver/hexagon-toolchain-elf.c
@@ -598,3 +598,15 @@
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv60 %s 2>&1 | FileCheck -check-prefix=CHECK384 %s
 // CHECK384:          "-fno-use-init-array"
+// -----------------------------------------------------------------------------
+// ThinLTO passes LTO options to the linker
+// -----------------------------------------------------------------------------
+// RUN: touch %t.o
+// RUN: %clang -### --target=hexagon-unknown-elf \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
+// RUN:   -mcpu=hexagonv60 \
+// RUN:   -fuse-ld=lld \
+// RUN:   -flto=thin -fenable-matrix \
+// RUN:   %t.o 2>&1 | FileCheck -check-prefix=CHECK-LTO %s
+// CHECK-LTO: "-plugin-opt=thinlto"
+// CHECK-LTO: "-plugin-opt=-enable-matrix"

--- a/clang/test/Driver/hexagon-toolchain-linux.c
+++ b/clang/test/Driver/hexagon-toolchain-linux.c
@@ -213,3 +213,16 @@
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree %s 2>&1 | FileCheck -check-prefix=CHECK-NOSAN %s
 // CHECK-NOSAN-NOT: "-L{{.*}}{{/|\\\\}}msan"
 // CHECK-NOSAN-NOT: "-L{{.*}}{{/|\\\\}}asan"
+// -----------------------------------------------------------------------------
+// ThinLTO passes LTO options to the linker
+// -----------------------------------------------------------------------------
+// RUN: touch %t.o
+// RUN: %clang -### --target=hexagon-unknown-linux-musl \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
+// RUN:   -mcpu=hexagonv60 \
+// RUN:   -fuse-ld=lld \
+// RUN:   -flto=thin -fenable-matrix \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree %t.o 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-LTO %s
+// CHECK-LTO: "-plugin-opt=thinlto"
+// CHECK-LTO: "-plugin-opt=-enable-matrix"


### PR DESCRIPTION
The Hexagon driver's constructHexagonLinkArgs() was not calling addLTOOptions(). This meant that LTO plugin options weren't forwarded to the linker.

This caused a crash when using ThinLTO with -fenable-matrix on llvm-test-suite/SingleSource/UnitTests/matrix-types-spec.cpp: LowerMatrixIntrinsicsPass did not run in the LTO backend because -enable-matrix was not forwarded via -plugin-opt.

Add the addLTOOptions() call to both the musl and bare-metal code paths in constructHexagonLinkArgs().