### PR TITLE
[WebAssembly][GlobalISel] Fix legalizeCustom return value for Helper.lower()

### DIFF
--- a/llvm/lib/Target/WebAssembly/GISel/WebAssemblyLegalizerInfo.cpp
+++ b/llvm/lib/Target/WebAssembly/GISel/WebAssemblyLegalizerInfo.cpp
@@ -90,7 +90,7 @@ bool WebAssemblyLegalizerInfo::legalizeCustom(
       return true;
     }
 
-    return Helper.lower(MI, 0, DstType);
+    return Helper.lower(MI, 0, DstType) == LegalizerHelper::Legalized;
   }
   default:
     break;

--- a/llvm/lib/Target/WebAssembly/GISel/WebAssemblyLegalizerInfo.cpp
+++ b/llvm/lib/Target/WebAssembly/GISel/WebAssemblyLegalizerInfo.cpp
@@ -90,7 +90,7 @@ bool WebAssemblyLegalizerInfo::legalizeCustom(
       return true;
     }
 
-    return Helper.lower(MI, 0, DstType) == LegalizerHelper::Legalized;
+    return Helper.lower(MI, 0, DstType) != LegalizerHelper::UnableToLegalize;
   }
   default:
     break;


### PR DESCRIPTION
Helper.lower() returns a LegalizerHelper::LegalizeResult enum where UnableToLegalize=2, which implicitly converts to true (success). Compare against LegalizerHelper::Legalized instead so that legalization failures are correctly reported.