### PR TITLE
[flang] -fno-integrated-as: set DisableIntegratedAS

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -6693,8 +6693,10 @@ def y : Joined<["-"], "y">;
 
 defm integrated_as : BoolFOption<"integrated-as",
   CodeGenOpts<"DisableIntegratedAS">, DefaultFalse,
-  NegFlag<SetTrue, [], [ClangOption, CC1Option, FlangOption], "Disable">,
-  PosFlag<SetFalse, [], [ClangOption, CC1Option, FlangOption], "Enable">,
+  NegFlag<SetTrue, [], [ClangOption, CC1Option, FlangOption, FC1Option],
+          "Disable">,
+  PosFlag<SetFalse, [], [ClangOption, CC1Option, FlangOption, FC1Option],
+          "Enable">,
   BothFlags<[], [ClangOption], " the integrated assembler">>;
 
 def fintegrated_cc1 : Flag<["-"], "fintegrated-cc1">,
@@ -6717,7 +6719,7 @@ def fno_integrated_objemitter : Flag<["-"], "fno-integrated-objemitter">,
 
 def : Flag<["-"], "integrated-as">, Alias<fintegrated_as>;
 def : Flag<["-"], "no-integrated-as">, Alias<fno_integrated_as>,
-      Visibility<[ClangOption, CC1Option, FlangOption]>;
+      Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>;
 
 def working_directory : Separate<["-"], "working-directory">,
   Visibility<[ClangOption, CC1Option]>,

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -1107,6 +1107,9 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
   // Add target args, features, etc.
   addTargetOptions(Args, CmdArgs);
 
+  if (!TC.useIntegratedAs())
+    CmdArgs.push_back("-no-integrated-as");
+
   llvm::Reloc::Model RelocationModel =
       std::get<0>(ParsePICArgs(getToolChain(), Args));
   // Add MCModel information

--- a/flang/include/flang/Frontend/CodeGenOptions.def
+++ b/flang/include/flang/Frontend/CodeGenOptions.def
@@ -33,6 +33,8 @@ ENUM_CODEGENOPT(ProfileUse, llvm::driver::ProfileInstrKind, 2, llvm::driver::Pro
 CODEGENOPT(InstrumentFunctions, 1, 0) ///< Set when -finstrument_functions is
                                       ///< enabled on the compile step.
 
+CODEGENOPT(DisableIntegratedAS, 1, 0) ///< -no-integrated-as
+
 CODEGENOPT(IsPIE, 1, 0) ///< PIE level is the same as PIC Level.
 CODEGENOPT(PICLevel, 2, 0) ///< PIC level of the LLVM module.
 CODEGENOPT(PrepareForFatLTO , 1, 0) ///<  Set when -ffat-lto-objects is enabled.

--- a/flang/lib/Frontend/CompilerInstance.cpp
+++ b/flang/lib/Frontend/CompilerInstance.cpp
@@ -383,6 +383,7 @@ bool CompilerInstance::setUpTargetMachine() {
   llvm::TargetOptions tOpts = llvm::TargetOptions();
   tOpts.EnableAIXExtendedAltivecABI = targetOpts.EnableAIXExtendedAltivecABI;
   tOpts.VecLib = convertDriverVectorLibraryToVectorLibrary(CGOpts.getVecLib());
+  tOpts.DisableIntegratedAS = CGOpts.DisableIntegratedAS;
 
   targetMachine.reset(theTarget->createTargetMachine(
       triple, /*CPU=*/targetOpts.cpu,

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -352,6 +352,11 @@ static void parseCodeGenArgs(Fortran::frontend::CodeGenOptions &opts,
   if (args.hasArg(clang::options::OPT_finstrument_functions))
     opts.InstrumentFunctions = 1;
 
+  // -fno-integrated-as: emit GNU Assembler compatible assembly.
+  if (!args.hasFlag(clang::options::OPT_fintegrated_as,
+                    clang::options::OPT_fno_integrated_as, true))
+    opts.DisableIntegratedAS = 1;
+
   if (const llvm::opt::Arg *a =
           args.getLastArg(clang::options::OPT_mcode_object_version_EQ)) {
     llvm::StringRef s = a->getValue();

--- a/flang/test/Driver/fintegrated-as.f90
+++ b/flang/test/Driver/fintegrated-as.f90
@@ -5,9 +5,11 @@
 !--------------------------
 ! With `-fno-integrated-as`
 !--------------------------
-! Verify that there _is_ a separate line with an assembler invocation
+! Verify that there _is_ a separate line with an assembler invocation, and
+! that -no-integrated-as is specified to generate GNU Assembler compatible assembly.
 ! RUN: %flang -c -fno-integrated-as %s -### 2>&1 | FileCheck %s
 ! CHECK-LABEL: "-fc1"
+! CHECK-SAME: "-no-integrated-as"
 ! CHECK-SAME: "-o" "[[assembly_file:.*]].s"
 ! CHECK-NEXT: "-o" "{{.*}}.o" "[[assembly_file:.*]].s"
 
@@ -18,4 +20,5 @@
 ! RUN: %flang -c -fintegrated-as %s -### 2>&1 | FileCheck %s -check-prefix=DEFAULT
 ! RUN: %flang -c %s -### 2>&1 | FileCheck %s -check-prefix=DEFAULT
 ! DEFAULT-LABEL: "-fc1"
+! DEFAULT-NOT: "-no-integrated-as"
 ! DEFAULT-SAME: "-o" "{{.*}}.o" "{{.*}}fintegrated-as.f90"


### PR DESCRIPTION
https://reviews.llvm.org/D124669 added -fno-integrated-as driver option
but not the fc1 option.
As a result, the backend kept MCAsmInfo::useIntegratedAssembler() set
and emitted LLVM-only directives such as `.prefalign`
(https://github.com/llvm/llvm-project/pull/155529), which GNU as
rejects:

```
a.s: Assembler messages:
a.s: Error: unknown pseudo-op: `.prefalign'
```

Follow clang and introduce fc1 -no-integrated-as to set
`CodeGenOpts.DisableIntegratedAS` and llvm::TargetOptions::DisableIntegratedAS.