### PR TITLE
Strip .llvm. suffix after removing the coroutine suffixes to avoid breaking pseudo probe

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -1227,8 +1227,12 @@ public:
 
   static StringRef getCanonicalCoroFnName(StringRef FnName,
                                           StringRef Attr = "selected") {
+    // A local coroutine function from another CU can be promoted to a global
+    // function during ThinLTO import. This will create a linkage name like
+    // "_Zfoo.llvm.xxxx.cleanup". Remove the ".llvm." suffix after stripping all
+    // the coroutine suffixes to avoid pseudo probe mismatch.
     const SmallVector<StringRef, 3> CoroSuffixes{".cleanup", ".destroy",
-                                                 ".resume"};
+                                                 ".resume", LLVMSuffix};
     return getCanonicalFnName(FnName, CoroSuffixes, Attr);
   }
 


### PR DESCRIPTION
Pseudo probe is currently broken when a coroutine function is promoted with a global name during ThinLTO import. The top-level function GUID in .pseudo_probe section are computed from the promoted name (with ".llvm.xxxx" suffix) instead of the original function name. Then it will cause a dangling top-level GUID that doesn't have any reference in the pseudo probe desc, and potentially hurt profile quality.

The root cause of the issue were:
  1) ThinLTO post-link imports and promotes a local coroutine function, creating a global function with ".llvm.xxxx" suffix.
  2) https://github.com/llvm/llvm-project/pull/141889 introduces a change in CoroSplit pass that updates the coroutine functions linkage name with the ".cleanup", ".destroy", ".resume" suffixes, and this creates top-level functions with ".llvm.xxxx.cleanup", ".llvm.xxxx.destroy", ".llvm.xxxx.resume" suffixes.
  3) PseudoProbePrinter and PseudoProbeInserter only strips coroutine suffix, and didn't consider the ".llvm." suffix.

This patch fixes the issue in step 3)