### PR TITLE
[MC] Simplify code with MCAsmInfo::getOutputAssemblerDialect. NFC

### DIFF
--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -565,6 +565,11 @@ public:
   const char *getInlineAsmStart() const { return InlineAsmStart; }
   const char *getInlineAsmEnd() const { return InlineAsmEnd; }
   unsigned getAssemblerDialect() const { return AssemblerDialect; }
+  // Return the assembler dialect that output printing should use. Used by
+  // createMCInstPrinter.
+  unsigned getOutputAssemblerDialect() const {
+    return TargetOptions->OutputAsmVariant.value_or(AssemblerDialect);
+  }
   bool doesAllowAtInName() const { return AllowAtInName; }
   void setAllowAtInName(bool V) { AllowAtInName = V; }
   bool doesAllowQuestionAtStartOfIdentifier() const {

--- a/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
+++ b/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
@@ -179,9 +179,7 @@ CodeGenTargetMachineImpl::createMCStreamer(raw_pwrite_stream &Out,
   switch (FileType) {
   case CodeGenFileType::AssemblyFile: {
     std::unique_ptr<MCInstPrinter> InstPrinter(getTarget().createMCInstPrinter(
-        getTargetTriple(),
-        Options.MCOptions.OutputAsmVariant.value_or(MAI.getAssemblerDialect()),
-        MAI, MII, MRI));
+        getTargetTriple(), MAI.getOutputAssemblerDialect(), MAI, MII, MRI));
     for (StringRef Opt : Options.MCOptions.InstPrinterOptions)
       if (!InstPrinter->applyTargetSpecificCLOption(Opt))
         return createStringError("invalid InstPrinter option '" + Opt + "'");

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -963,9 +963,8 @@ void X86AsmPrinter::emitStartOfAsmFile(Module &M) {
   }
 
   // TODO: Support prefixed registers for the Intel syntax.
-  unsigned Dialect = TM.Options.MCOptions.OutputAsmVariant.value_or(
-      MAI->getAssemblerDialect());
-  const bool IntelSyntax = Dialect == InlineAsm::AD_Intel;
+  const bool IntelSyntax =
+      MAI->getOutputAssemblerDialect() == InlineAsm::AD_Intel;
   OutStreamer->emitSyntaxDirective(IntelSyntax ? "intel" : "att",
                                    IntelSyntax ? "noprefix" : "");
 

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -413,6 +413,8 @@ int main(int argc, char **argv) {
   MCOptions.MCNoExecStack = NoExecStack;
   MCOptions.MCUseDwarfDirectory = MCTargetOptions::EnableDwarfDirectory;
   MCOptions.InstPrinterOptions = InstPrinterOptions;
+  if (OutputAsmVariant.getNumOccurrences())
+    MCOptions.OutputAsmVariant = OutputAsmVariant;
 
   setDwarfDebugFlags(argc, argv);
   setDwarfDebugProducer();
@@ -586,9 +588,7 @@ int main(int argc, char **argv) {
     TheTarget->createNullTargetStreamer(*FFS);
     Str = std::move(FFS);
   } else if (FileType == OFT_AssemblyFile) {
-    unsigned AsmVariant = OutputAsmVariant.getNumOccurrences()
-                              ? OutputAsmVariant
-                              : MAI->getAssemblerDialect();
+    unsigned AsmVariant = MAI->getOutputAssemblerDialect();
     IP.reset(TheTarget->createMCInstPrinter(Triple(TripleName), AsmVariant,
                                             *MAI, *MCII, *MRI));
 


### PR DESCRIPTION
Add a helper to simplify code.