### PR TITLE
[MLIR] Fix walk() after PostOrderTraversal change

### DIFF
--- a/mlir/include/mlir/IR/Visitors.h
+++ b/mlir/include/mlir/IR/Visitors.h
@@ -120,8 +120,9 @@ void walk(Operation *op, function_ref<void(Block *)> callback,
           WalkOrder order) {
   for (auto &region : Iterator::makeIterable(*op)) {
     // Early increment here in the case where the block is erased.
-    for (auto &block :
-         llvm::make_early_inc_range(Iterator::makeIterable(region))) {
+    // PostOrderTraversal keeps state outside of iterators, so store it here.
+    auto &&It = Iterator::makeIterable(region);
+    for (auto &block : llvm::make_early_inc_range(It)) {
       if (order == WalkOrder::PreOrder)
         callback(&block);
       for (auto &nestedOp : Iterator::makeIterable(block))
@@ -195,8 +196,9 @@ WalkResult walk(Operation *op, function_ref<WalkResult(Block *)> callback,
                 WalkOrder order) {
   for (auto &region : Iterator::makeIterable(*op)) {
     // Early increment here in the case where the block is erased.
-    for (auto &block :
-         llvm::make_early_inc_range(Iterator::makeIterable(region))) {
+    // PostOrderTraversal keeps state outside of iterators, so store it here.
+    auto &&It = Iterator::makeIterable(region);
+    for (auto &block : llvm::make_early_inc_range(It)) {
       if (order == WalkOrder::PreOrder) {
         WalkResult result = callback(&block);
         if (result.wasSkipped())


### PR DESCRIPTION
make_early_inc_range doesn't keep the range alive, only the iterators.
This breaks with the recent PostOrderTraversal change, which no longer
stores the state in the iterators. Store the range in a variable to keep
it alive for the entire loop.

Fixup of #191047 / 691a130e0f14459d9358a71ffd52a01295e6200a.
