### PR TITLE
[lldb][Windows] Read/Write PC after suspending thread

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
@@ -507,9 +507,9 @@ NativeProcessWindows::OnDebugException(bool first_chance,
       if (FindSoftwareBreakpoint(exception_addr)) {
         LLDB_LOG(log, "Hit non-loader breakpoint at address {0:x}.",
                  exception_addr);
+        StopThread(thread_id, StopReason::eStopReasonBreakpoint);
         // The current PC is AFTER the BP opcode, on all architectures.
         reg_ctx.SetPC(reg_ctx.GetPC() - GetSoftwareBreakpointPCOffset());
-        StopThread(thread_id, StopReason::eStopReasonBreakpoint);
         SetState(eStateStopped, true);
         return ExceptionResult::MaskException;
       } else {


### PR DESCRIPTION
Currently, we access the PC before suspending the thread in case of a software breakpoint exception. However, we can't reliably read or write the thread context while the thread is running. So, suspend the thread first and then read or write the PC when handling a software breakpoint exception.