### PR TITLE
[LV][NFC] Remove llvm.ident, tbaa and other attributes from tests

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/AArch64/scalable-call.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/scalable-call.ll
@@ -234,13 +234,11 @@ attributes #3 = { "vector-function-abi-variant"="_ZGV_LLVM_N2v_llvm.sin.f64(sin_
 
 !llvm.dbg.cu = !{!4}
 !llvm.module.flags = !{!7}
-!llvm.ident = !{!8}
 
 !4 = distinct !DICompileUnit(language: DW_LANG_C99, file: !5, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: NoDebug, enums: !6, splitDebugInlining: false, nameTableKind: None)
 !5 = !DIFile(filename: "t.c", directory: "somedir")
 !6 = !{}
 !7 = !{i32 2, !"Debug Info Version", i32 3}
-!8 = !{!"clang"}
 !9 = distinct !DISubprogram(name: "foo", scope: !5, file: !5, line: 2, type: !10, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !4, retainedNodes: !6)
 !10 = !DISubroutineType(types: !6)
 !11 = !DILocation(line: 3, column: 10, scope: !9)

--- a/llvm/test/Transforms/LoopVectorize/Hexagon/minimum-vf.ll
+++ b/llvm/test/Transforms/LoopVectorize/Hexagon/minimum-vf.ll
@@ -150,9 +150,6 @@ b2:
 
 attributes #1 = { "target-cpu"="hexagonv60" "target-features"="+hvx-length64b,+hvxv60" }
 
-!llvm.module.flags = !{!0}
-
-!0 = !{i32 1, !"wchar_size", i32 4}
 !1 = !{!2, !2, i64 0}
 !2 = !{!"any pointer", !3, i64 0}
 !3 = !{!"omnipotent char", !4, i64 0}

--- a/llvm/test/Transforms/LoopVectorize/Hexagon/minimum-vf.ll
+++ b/llvm/test/Transforms/LoopVectorize/Hexagon/minimum-vf.ll
@@ -23,11 +23,11 @@ b0:
   %v6 = add i32 %a4, -9
   %v7 = icmp ugt i32 %v5, %v6
   %v8 = or i1 %v4, %v7
-  %v9 = load ptr, ptr @g0, align 4, !tbaa !1
+  %v9 = load ptr, ptr @g0, align 4
   %v10 = zext i8 %a5 to i32
   %v11 = getelementptr inbounds ptr, ptr %v9, i32 %v10
-  %v12 = load ptr, ptr %v11, align 4, !tbaa !1
-  %v14 = load ptr, ptr %v12, align 4, !tbaa !5
+  %v12 = load ptr, ptr %v11, align 4
+  %v14 = load ptr, ptr %v12, align 4
   br i1 %v8, label %b1, label %b2
 
 b1:
@@ -40,40 +40,40 @@ b1:
   %v21 = mul i32 %v20, %a3
   %v22 = add i32 97, %v21
   %v23 = getelementptr inbounds i8, ptr %v14, i32 %v22
-  %v24 = load i8, ptr %v23, align 1, !tbaa !8
+  %v24 = load i8, ptr %v23, align 1
   %v25 = zext i8 %v24 to i32
   %v26 = add i32 101, %v21
   %v27 = getelementptr inbounds i8, ptr %v14, i32 %v26
-  %v28 = load i8, ptr %v27, align 1, !tbaa !8
+  %v28 = load i8, ptr %v27, align 1
   %v29 = zext i8 %v28 to i32
   %v30 = mul nsw i32 %v29, -5
   %v31 = add nsw i32 %v30, %v25
   %v32 = add i32 106, %v21
   %v33 = getelementptr inbounds i8, ptr %v14, i32 %v32
-  %v34 = load i8, ptr %v33, align 1, !tbaa !8
+  %v34 = load i8, ptr %v33, align 1
   %v35 = zext i8 %v34 to i32
   %v36 = mul nuw nsw i32 %v35, 20
   %v37 = add nsw i32 %v36, %v31
   %v38 = add i32 111, %v21
   %v39 = getelementptr inbounds i8, ptr %v14, i32 %v38
-  %v40 = load i8, ptr %v39, align 1, !tbaa !8
+  %v40 = load i8, ptr %v39, align 1
   %v41 = zext i8 %v40 to i32
   %v42 = mul nuw nsw i32 %v41, 20
   %v43 = add nsw i32 %v42, %v37
   %v44 = add i32 116, %v21
   %v45 = getelementptr inbounds i8, ptr %v14, i32 %v44
-  %v46 = load i8, ptr %v45, align 1, !tbaa !8
+  %v46 = load i8, ptr %v45, align 1
   %v47 = zext i8 %v46 to i32
   %v48 = mul nsw i32 %v47, -5
   %v49 = add nsw i32 %v48, %v43
   %v50 = add i32 120, %v21
   %v51 = getelementptr inbounds i8, ptr %v14, i32 %v50
-  %v52 = load i8, ptr %v51, align 1, !tbaa !8
+  %v52 = load i8, ptr %v51, align 1
   %v53 = zext i8 %v52 to i32
   %v54 = add nsw i32 %v49, %v53
   %v55 = trunc i32 %v54 to i16
   %v56 = getelementptr inbounds [4 x [9 x i16]], ptr %v0, i32 0, i32 0, i32 %v15
-  store i16 %v55, ptr %v56, align 2, !tbaa !9
+  store i16 %v55, ptr %v56, align 2
   %v57 = mul nsw i32 %v35, -5
   %v58 = add nsw i32 %v57, %v29
   %v59 = add nsw i32 %v42, %v58
@@ -83,12 +83,12 @@ b1:
   %v63 = add nsw i32 %v62, %v61
   %v64 = add i32 125, %v21
   %v65 = getelementptr inbounds i8, ptr %v14, i32 %v64
-  %v66 = load i8, ptr %v65, align 1, !tbaa !8
+  %v66 = load i8, ptr %v65, align 1
   %v67 = zext i8 %v66 to i32
   %v68 = add nsw i32 %v63, %v67
   %v69 = trunc i32 %v68 to i16
   %v70 = getelementptr inbounds [4 x [9 x i16]], ptr %v0, i32 0, i32 1, i32 %v15
-  store i16 %v69, ptr %v70, align 2, !tbaa !9
+  store i16 %v69, ptr %v70, align 2
   %v71 = mul nsw i32 %v41, -5
   %v72 = add nsw i32 %v71, %v35
   %v73 = add nsw i32 %v60, %v72
@@ -98,47 +98,47 @@ b1:
   %v77 = add nsw i32 %v76, %v75
   %v78 = add i32 130, %v21
   %v79 = getelementptr inbounds i8, ptr %v14, i32 %v78
-  %v80 = load i8, ptr %v79, align 1, !tbaa !8
+  %v80 = load i8, ptr %v79, align 1
   %v81 = zext i8 %v80 to i32
   %v82 = add nsw i32 %v77, %v81
   %v83 = trunc i32 %v82 to i16
   %v84 = getelementptr inbounds [4 x [9 x i16]], ptr %v0, i32 0, i32 2, i32 %v15
-  store i16 %v83, ptr %v84, align 2, !tbaa !9
+  store i16 %v83, ptr %v84, align 2
   %v85 = add i32 92, %v21
   %v86 = getelementptr inbounds i8, ptr %v14, i32 %v85
-  %v87 = load i8, ptr %v86, align 1, !tbaa !8
+  %v87 = load i8, ptr %v86, align 1
   %v88 = zext i8 %v87 to i16
   %v89 = add i32 135, %v21
   %v90 = getelementptr inbounds i8, ptr %v14, i32 %v89
-  %v91 = load i8, ptr %v90, align 1, !tbaa !8
+  %v91 = load i8, ptr %v90, align 1
   %v92 = zext i8 %v91 to i16
   %v93 = mul nsw i16 %v92, -5
   %v94 = add nsw i16 %v93, %v88
   %v95 = add i32 140, %v21
   %v96 = getelementptr inbounds i8, ptr %v14, i32 %v95
-  %v97 = load i8, ptr %v96, align 1, !tbaa !8
+  %v97 = load i8, ptr %v96, align 1
   %v98 = zext i8 %v97 to i16
   %v99 = mul nuw nsw i16 %v98, 20
   %v100 = add nsw i16 %v99, %v94
   %v101 = add i32 145, %v21
   %v102 = getelementptr inbounds i8, ptr %v14, i32 %v101
-  %v103 = load i8, ptr %v102, align 1, !tbaa !8
+  %v103 = load i8, ptr %v102, align 1
   %v104 = zext i8 %v103 to i16
   %v105 = mul nuw nsw i16 %v104, 20
   %v106 = add i16 %v105, %v100
   %v107 = add i32 150, %v21
   %v108 = getelementptr inbounds i8, ptr %v14, i32 %v107
-  %v109 = load i8, ptr %v108, align 1, !tbaa !8
+  %v109 = load i8, ptr %v108, align 1
   %v110 = zext i8 %v109 to i16
   %v111 = mul nsw i16 %v110, -5
   %v112 = add i16 %v111, %v106
   %v113 = add i32 154, %v21
   %v114 = getelementptr inbounds i8, ptr %v14, i32 %v113
-  %v115 = load i8, ptr %v114, align 1, !tbaa !8
+  %v115 = load i8, ptr %v114, align 1
   %v116 = zext i8 %v115 to i16
   %v117 = add i16 %v112, %v116
   %v118 = getelementptr inbounds [4 x [9 x i16]], ptr %v0, i32 0, i32 3, i32 %v15
-  store i16 %v117, ptr %v118, align 2, !tbaa !9
+  store i16 %v117, ptr %v118, align 2
   %v119 = add nuw nsw i32 %v15, 1
   %v120 = icmp eq i32 %v119, 19
   br i1 %v120, label %b2, label %b1
@@ -149,14 +149,3 @@ b2:
 }
 
 attributes #1 = { "target-cpu"="hexagonv60" "target-features"="+hvx-length64b,+hvxv60" }
-
-!1 = !{!2, !2, i64 0}
-!2 = !{!"any pointer", !3, i64 0}
-!3 = !{!"omnipotent char", !4, i64 0}
-!4 = !{!"Simple C/C++ TBAA"}
-!5 = !{!6, !2, i64 0}
-!6 = !{!"", !2, i64 0, !7, i64 4, !7, i64 8, !7, i64 12, !7, i64 16}
-!7 = !{!"int", !3, i64 0}
-!8 = !{!3, !3, i64 0}
-!9 = !{!10, !10, i64 0}
-!10 = !{!"short", !3, i64 0}

--- a/llvm/test/Transforms/LoopVectorize/RISCV/riscv-interleaved.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/riscv-interleaved.ll
@@ -27,13 +27,8 @@ for.body:
   %indvars.iv = phi i64 [ 0, %for.body.preheader ], [ %indvars.iv.next, %for.body ]
   %arrayidx = getelementptr inbounds i32, ptr %A, i64 %indvars.iv
   %0 = trunc i64 %indvars.iv to i32
-  store i32 %0, ptr %arrayidx, align 4, !tbaa !4
+  store i32 %0, ptr %arrayidx, align 4
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond.not = icmp eq i64 %indvars.iv.next, %wide.trip.count
   br i1 %exitcond.not, label %for.cond.cleanup.loopexit, label %for.body
 }
-
-!4 = !{!5, !5, i64 0}
-!5 = !{!"int", !6, i64 0}
-!6 = !{!"omnipotent char", !7, i64 0}
-!7 = !{!"Simple C/C++ TBAA"}

--- a/llvm/test/Transforms/LoopVectorize/RISCV/riscv-interleaved.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/riscv-interleaved.ll
@@ -30,19 +30,10 @@ for.body:
   store i32 %0, ptr %arrayidx, align 4, !tbaa !4
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond.not = icmp eq i64 %indvars.iv.next, %wide.trip.count
-  br i1 %exitcond.not, label %for.cond.cleanup.loopexit, label %for.body, !llvm.loop !8
+  br i1 %exitcond.not, label %for.cond.cleanup.loopexit, label %for.body
 }
 
-!llvm.module.flags = !{!0, !1, !2}
-!llvm.ident = !{!3}
-
-!0 = !{i32 1, !"wchar_size", i32 4}
-!1 = !{i32 1, !"target-abi", !"lp64"}
-!2 = !{i32 8, !"SmallDataLimit", i32 8}
-!3 = !{!"clang version 13.0.0"}
 !4 = !{!5, !5, i64 0}
 !5 = !{!"int", !6, i64 0}
 !6 = !{!"omnipotent char", !7, i64 0}
 !7 = !{!"Simple C/C++ TBAA"}
-!8 = distinct !{!8, !9}
-!9 = !{!"llvm.loop.mustprogress"}

--- a/llvm/test/Transforms/LoopVectorize/X86/cost-model-assert.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/cost-model-assert.ll
@@ -73,9 +73,6 @@ Exit:
 
 attributes #0 = { "use-soft-float"="false" }
 
-!llvm.ident = !{!0}
-
-!0 = !{!"clang version 10.0.0 (https://github.com/llvm/llvm-project.git 0fedc26a0dc0066f3968b9fea6a4e1f746c8d5a4)"}
 !1 = !{!2, !2, i64 0}
 !2 = !{!"omnipotent char", !3, i64 0}
 !3 = !{!"Simple C/C++ TBAA"}

--- a/llvm/test/Transforms/LoopVectorize/X86/cost-model-assert.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/cost-model-assert.ll
@@ -11,9 +11,9 @@
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-w64-windows-gnu"
 
-define void @cff_index_load_offsets(i1 %cond, i8 %x, ptr %p, ptr %pend) #0 {
+define void @cff_index_load_offsets(i1 %cond, i8 %x, ptr noalias %p, ptr noalias %pend) #0 {
 ; CHECK-LABEL: define void @cff_index_load_offsets(
-; CHECK-SAME: i1 [[COND:%.*]], i8 [[X:%.*]], ptr [[P:%.*]], ptr [[PEND:%.*]]) #[[ATTR0:[0-9]+]] {
+; CHECK-SAME: i1 [[COND:%.*]], i8 [[X:%.*]], ptr noalias [[P:%.*]], ptr noalias [[PEND:%.*]]) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br i1 [[COND]], label %[[IF_THEN:.*]], label %[[EXIT:.*]]
 ; CHECK:       [[IF_THEN]]:
@@ -22,16 +22,16 @@ define void @cff_index_load_offsets(i1 %cond, i8 %x, ptr %p, ptr %pend) #0 {
 ; CHECK-NEXT:    [[P_359:%.*]] = phi ptr [ [[ADD_PTR86:%.*]], %[[FOR_BODY68]] ], [ null, %[[IF_THEN]] ]
 ; CHECK-NEXT:    [[CONV70:%.*]] = zext i8 [[X]] to i32
 ; CHECK-NEXT:    [[SHL71:%.*]] = shl nuw i32 [[CONV70]], 24
-; CHECK-NEXT:    [[TMP0:%.*]] = load i8, ptr [[P]], align 1, !tbaa [[CHAR_TBAA1:![0-9]+]]
+; CHECK-NEXT:    [[TMP0:%.*]] = load i8, ptr [[P]], align 1
 ; CHECK-NEXT:    [[CONV73:%.*]] = zext i8 [[TMP0]] to i32
 ; CHECK-NEXT:    [[SHL74:%.*]] = shl nuw nsw i32 [[CONV73]], 16
 ; CHECK-NEXT:    [[OR75:%.*]] = or i32 [[SHL74]], [[SHL71]]
-; CHECK-NEXT:    [[TMP1:%.*]] = load i8, ptr [[P]], align 1, !tbaa [[CHAR_TBAA1]]
+; CHECK-NEXT:    [[TMP1:%.*]] = load i8, ptr [[P]], align 1
 ; CHECK-NEXT:    [[SHL78:%.*]] = shl nuw nsw i32 12, 8
 ; CHECK-NEXT:    [[OR79:%.*]] = or i32 [[OR75]], [[SHL78]]
 ; CHECK-NEXT:    [[CONV81:%.*]] = zext i8 [[TMP1]] to i32
 ; CHECK-NEXT:    [[OR83:%.*]] = or i32 [[OR79]], [[CONV81]]
-; CHECK-NEXT:    store i32 [[OR83]], ptr [[P]], align 4, !tbaa [[LONG_TBAA4:![0-9]+]]
+; CHECK-NEXT:    store i32 [[OR83]], ptr [[P]], align 4
 ; CHECK-NEXT:    [[ADD_PTR86]] = getelementptr inbounds i8, ptr [[P_359]], i64 4
 ; CHECK-NEXT:    [[CMP66:%.*]] = icmp ult ptr [[ADD_PTR86]], [[PEND]]
 ; CHECK-NEXT:    br i1 [[CMP66]], label %[[FOR_BODY68]], label %[[SW_EPILOG:.*]]
@@ -50,16 +50,16 @@ for.body68:
   %p.359 = phi ptr [ %add.ptr86, %for.body68 ], [ null, %if.then ]
   %conv70 = zext i8 %x to i32
   %shl71 = shl nuw i32 %conv70, 24
-  %0 = load i8, ptr %p, align 1, !tbaa !1
+  %0 = load i8, ptr %p, align 1
   %conv73 = zext i8 %0 to i32
   %shl74 = shl nuw nsw i32 %conv73, 16
   %or75 = or i32 %shl74, %shl71
-  %1 = load i8, ptr %p, align 1, !tbaa !1
+  %1 = load i8, ptr %p, align 1
   %shl78 = shl nuw nsw i32 12, 8
   %or79 = or i32 %or75, %shl78
   %conv81 = zext i8 %1 to i32
   %or83 = or i32 %or79, %conv81
-  store i32 %or83, ptr %p, align 4, !tbaa !4
+  store i32 %or83, ptr %p, align 4
   %add.ptr86 = getelementptr inbounds i8, ptr %p.359, i64 4
   %cmp66 = icmp ult ptr %add.ptr86, %pend
   br i1 %cmp66, label %for.body68, label %sw.epilog
@@ -72,16 +72,3 @@ Exit:
 }
 
 attributes #0 = { "use-soft-float"="false" }
-
-!1 = !{!2, !2, i64 0}
-!2 = !{!"omnipotent char", !3, i64 0}
-!3 = !{!"Simple C/C++ TBAA"}
-!4 = !{!5, !5, i64 0}
-!5 = !{!"long", !2, i64 0}
-;.
-; CHECK: [[CHAR_TBAA1]] = !{[[META2:![0-9]+]], [[META2]], i64 0}
-; CHECK: [[META2]] = !{!"omnipotent char", [[META3:![0-9]+]], i64 0}
-; CHECK: [[META3]] = !{!"Simple C/C++ TBAA"}
-; CHECK: [[LONG_TBAA4]] = !{[[META5:![0-9]+]], [[META5]], i64 0}
-; CHECK: [[META5]] = !{!"long", [[META2]], i64 0}
-;.

--- a/llvm/test/Transforms/LoopVectorize/X86/no_fpmath.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/no_fpmath.ll
@@ -27,7 +27,7 @@ for.body:
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %for.body.preheader ]
   %a.08 = phi double [ %add, %for.body ], [ 0.000000e+00, %for.body.preheader ]
   %arrayidx = getelementptr inbounds i32, ptr %v, i64 %indvars.iv, !dbg !9
-  %0 = load i32, ptr %arrayidx, align 4, !dbg !9, !tbaa !11
+  %0 = load i32, ptr %arrayidx, align 4, !dbg !9
   %cmp1 = icmp eq i32 %0, 0, !dbg !15
   %cond = select i1 %cmp1, double 3.400000e+00, double 1.150000e+00, !dbg !9
   %add = fadd double %a.08, %cond, !dbg !16
@@ -57,7 +57,7 @@ for.body:
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %for.body.preheader ]
   %a.08 = phi double [ %add, %for.body ], [ 0.000000e+00, %for.body.preheader ]
   %arrayidx = getelementptr inbounds i32, ptr %v, i64 %indvars.iv, !dbg !22
-  %0 = load i32, ptr %arrayidx, align 4, !dbg !22, !tbaa !11
+  %0 = load i32, ptr %arrayidx, align 4, !dbg !22
   %cmp1 = icmp eq i32 %0, 0, !dbg !24
   %cond = select i1 %cmp1, double 3.400000e+00, double 1.150000e+00, !dbg !22
   %add = fadd double %a.08, %cond, !dbg !25
@@ -80,10 +80,6 @@ for.body:
 !8 = !DILocation(line: 5, column: 3, scope: !4)
 !9 = !DILocation(line: 6, column: 14, scope: !4)
 !10 = !DILocation(line: 9, column: 3, scope: !4)
-!11 = !{!12, !12, i64 0}
-!12 = !{!"int", !13, i64 0}
-!13 = !{!"omnipotent char", !14, i64 0}
-!14 = !{!"Simple C/C++ TBAA"}
 !15 = !DILocation(line: 6, column: 19, scope: !4)
 !16 = !DILocation(line: 6, column: 11, scope: !4)
 !19 = !DILocation(line: 16, column: 20, scope: !20)

--- a/llvm/test/Transforms/LoopVectorize/X86/no_fpmath.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/no_fpmath.ll
@@ -69,11 +69,9 @@ for.body:
 
 !llvm.dbg.cu = !{!28}
 !llvm.module.flags = !{!0, !1}
-!llvm.ident = !{!2}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
 !1 = !{i32 1, !"PIC Level", i32 2}
-!2 = !{!"clang version 3.7.0"}
 !3 = !DILocation(line: 5, column: 20, scope: !4)
 !4 = distinct !DISubprogram(name: "cond_sum", scope: !5, file: !5, line: 1, type: !6, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: true, unit: !28, retainedNodes: !7)
 !5 = !DIFile(filename: "no_fpmath.c", directory: "")

--- a/llvm/test/Transforms/LoopVectorize/X86/no_fpmath_with_hotness.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/no_fpmath_with_hotness.ll
@@ -27,7 +27,7 @@ for.body:
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %for.body.preheader ]
   %a.08 = phi double [ %add, %for.body ], [ 0.000000e+00, %for.body.preheader ]
   %arrayidx = getelementptr inbounds i32, ptr %v, i64 %indvars.iv, !dbg !9
-  %0 = load i32, ptr %arrayidx, align 4, !dbg !9, !tbaa !11
+  %0 = load i32, ptr %arrayidx, align 4, !dbg !9
   %cmp1 = icmp eq i32 %0, 0, !dbg !15
   %cond = select i1 %cmp1, double 3.400000e+00, double 1.150000e+00, !dbg !9
   %add = fadd double %a.08, %cond, !dbg !16
@@ -57,7 +57,7 @@ for.body:
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %for.body.preheader ]
   %a.08 = phi double [ %add, %for.body ], [ 0.000000e+00, %for.body.preheader ]
   %arrayidx = getelementptr inbounds i32, ptr %v, i64 %indvars.iv, !dbg !22
-  %0 = load i32, ptr %arrayidx, align 4, !dbg !22, !tbaa !11
+  %0 = load i32, ptr %arrayidx, align 4, !dbg !22
   %cmp1 = icmp eq i32 %0, 0, !dbg !24
   %cond = select i1 %cmp1, double 3.400000e+00, double 1.150000e+00, !dbg !22
   %add = fadd double %a.08, %cond, !dbg !25
@@ -80,10 +80,6 @@ for.body:
 !8 = !DILocation(line: 5, column: 3, scope: !4)
 !9 = !DILocation(line: 6, column: 14, scope: !4)
 !10 = !DILocation(line: 9, column: 3, scope: !4)
-!11 = !{!12, !12, i64 0}
-!12 = !{!"int", !13, i64 0}
-!13 = !{!"omnipotent char", !14, i64 0}
-!14 = !{!"Simple C/C++ TBAA"}
 !15 = !DILocation(line: 6, column: 19, scope: !4)
 !16 = !DILocation(line: 6, column: 11, scope: !4)
 !17 = distinct !{!17, !18}

--- a/llvm/test/Transforms/LoopVectorize/X86/no_fpmath_with_hotness.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/no_fpmath_with_hotness.ll
@@ -69,11 +69,9 @@ for.body:
 
 !llvm.dbg.cu = !{!28}
 !llvm.module.flags = !{!0, !1}
-!llvm.ident = !{!2}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
 !1 = !{i32 1, !"PIC Level", i32 2}
-!2 = !{!"clang version 3.7.0"}
 !3 = !DILocation(line: 5, column: 20, scope: !4)
 !4 = distinct !DISubprogram(name: "cond_sum", scope: !5, file: !5, line: 1, type: !6, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: true, unit: !28, retainedNodes: !7)
 !5 = !DIFile(filename: "no_fpmath.c", directory: "")

--- a/llvm/test/Transforms/LoopVectorize/X86/strided_load_cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/strided_load_cost.ll
@@ -665,9 +665,6 @@ for.cond.cleanup:
 
 attributes #0 = { "target-cpu"="core-avx2" "target-features"="+avx,+avx2,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3" }
 
-!llvm.ident = !{!0}
-
-!0 = !{!"clang version 4.0.0 (cfe/trunk 284570)"}
 !1 = !{!2, !2, i64 0}
 !2 = !{!"int", !3, i64 0}
 !3 = !{!"omnipotent char", !4, i64 0}

--- a/llvm/test/Transforms/LoopVectorize/X86/strided_load_cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/strided_load_cost.ll
@@ -5,7 +5,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; This test checks that the given loop still beneficial for vecotization
+; This test checks that the given loop still beneficial for vectorization
 ; even if it contains scalarized load (gather on AVX2)
 
 define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
@@ -60,10 +60,10 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; CHECK-NEXT:    [[TMP33:%.*]] = getelementptr inbounds i32, ptr [[TMP32]], i64 8
 ; CHECK-NEXT:    [[TMP34:%.*]] = getelementptr inbounds i32, ptr [[TMP32]], i64 16
 ; CHECK-NEXT:    [[TMP35:%.*]] = getelementptr inbounds i32, ptr [[TMP32]], i64 24
-; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <8 x i32>, ptr [[TMP32]], align 4, !tbaa [[INT_TBAA1:![0-9]+]]
-; CHECK-NEXT:    [[WIDE_LOAD4:%.*]] = load <8 x i32>, ptr [[TMP33]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[WIDE_LOAD5:%.*]] = load <8 x i32>, ptr [[TMP34]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[WIDE_LOAD6:%.*]] = load <8 x i32>, ptr [[TMP35]], align 4, !tbaa [[INT_TBAA1]]
+; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <8 x i32>, ptr [[TMP32]], align 4
+; CHECK-NEXT:    [[WIDE_LOAD4:%.*]] = load <8 x i32>, ptr [[TMP33]], align 4
+; CHECK-NEXT:    [[WIDE_LOAD5:%.*]] = load <8 x i32>, ptr [[TMP34]], align 4
+; CHECK-NEXT:    [[WIDE_LOAD6:%.*]] = load <8 x i32>, ptr [[TMP35]], align 4
 ; CHECK-NEXT:    [[TMP40:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[INDEX]], i64 [[IDXPROM5]]
 ; CHECK-NEXT:    [[TMP41:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP1]], i64 [[IDXPROM5]]
 ; CHECK-NEXT:    [[TMP42:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP2]], i64 [[IDXPROM5]]
@@ -96,14 +96,14 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; CHECK-NEXT:    [[TMP69:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP29]], i64 [[IDXPROM5]]
 ; CHECK-NEXT:    [[TMP70:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP30]], i64 [[IDXPROM5]]
 ; CHECK-NEXT:    [[TMP71:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP31]], i64 [[IDXPROM5]]
-; CHECK-NEXT:    [[TMP72:%.*]] = load i32, ptr [[TMP40]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP73:%.*]] = load i32, ptr [[TMP41]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP74:%.*]] = load i32, ptr [[TMP42]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP75:%.*]] = load i32, ptr [[TMP43]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP76:%.*]] = load i32, ptr [[TMP44]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP77:%.*]] = load i32, ptr [[TMP45]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP78:%.*]] = load i32, ptr [[TMP46]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP79:%.*]] = load i32, ptr [[TMP47]], align 4, !tbaa [[INT_TBAA1]]
+; CHECK-NEXT:    [[TMP72:%.*]] = load i32, ptr [[TMP40]], align 4
+; CHECK-NEXT:    [[TMP73:%.*]] = load i32, ptr [[TMP41]], align 4
+; CHECK-NEXT:    [[TMP74:%.*]] = load i32, ptr [[TMP42]], align 4
+; CHECK-NEXT:    [[TMP75:%.*]] = load i32, ptr [[TMP43]], align 4
+; CHECK-NEXT:    [[TMP76:%.*]] = load i32, ptr [[TMP44]], align 4
+; CHECK-NEXT:    [[TMP77:%.*]] = load i32, ptr [[TMP45]], align 4
+; CHECK-NEXT:    [[TMP78:%.*]] = load i32, ptr [[TMP46]], align 4
+; CHECK-NEXT:    [[TMP79:%.*]] = load i32, ptr [[TMP47]], align 4
 ; CHECK-NEXT:    [[TMP80:%.*]] = insertelement <8 x i32> poison, i32 [[TMP72]], i32 0
 ; CHECK-NEXT:    [[TMP81:%.*]] = insertelement <8 x i32> [[TMP80]], i32 [[TMP73]], i32 1
 ; CHECK-NEXT:    [[TMP82:%.*]] = insertelement <8 x i32> [[TMP81]], i32 [[TMP74]], i32 2
@@ -112,14 +112,14 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; CHECK-NEXT:    [[TMP85:%.*]] = insertelement <8 x i32> [[TMP84]], i32 [[TMP77]], i32 5
 ; CHECK-NEXT:    [[TMP86:%.*]] = insertelement <8 x i32> [[TMP85]], i32 [[TMP78]], i32 6
 ; CHECK-NEXT:    [[TMP87:%.*]] = insertelement <8 x i32> [[TMP86]], i32 [[TMP79]], i32 7
-; CHECK-NEXT:    [[TMP88:%.*]] = load i32, ptr [[TMP48]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP89:%.*]] = load i32, ptr [[TMP49]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP90:%.*]] = load i32, ptr [[TMP50]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP91:%.*]] = load i32, ptr [[TMP51]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP92:%.*]] = load i32, ptr [[TMP52]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP93:%.*]] = load i32, ptr [[TMP53]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP94:%.*]] = load i32, ptr [[TMP54]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP95:%.*]] = load i32, ptr [[TMP55]], align 4, !tbaa [[INT_TBAA1]]
+; CHECK-NEXT:    [[TMP88:%.*]] = load i32, ptr [[TMP48]], align 4
+; CHECK-NEXT:    [[TMP89:%.*]] = load i32, ptr [[TMP49]], align 4
+; CHECK-NEXT:    [[TMP90:%.*]] = load i32, ptr [[TMP50]], align 4
+; CHECK-NEXT:    [[TMP91:%.*]] = load i32, ptr [[TMP51]], align 4
+; CHECK-NEXT:    [[TMP92:%.*]] = load i32, ptr [[TMP52]], align 4
+; CHECK-NEXT:    [[TMP93:%.*]] = load i32, ptr [[TMP53]], align 4
+; CHECK-NEXT:    [[TMP94:%.*]] = load i32, ptr [[TMP54]], align 4
+; CHECK-NEXT:    [[TMP95:%.*]] = load i32, ptr [[TMP55]], align 4
 ; CHECK-NEXT:    [[TMP96:%.*]] = insertelement <8 x i32> poison, i32 [[TMP88]], i32 0
 ; CHECK-NEXT:    [[TMP97:%.*]] = insertelement <8 x i32> [[TMP96]], i32 [[TMP89]], i32 1
 ; CHECK-NEXT:    [[TMP98:%.*]] = insertelement <8 x i32> [[TMP97]], i32 [[TMP90]], i32 2
@@ -128,14 +128,14 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; CHECK-NEXT:    [[TMP101:%.*]] = insertelement <8 x i32> [[TMP100]], i32 [[TMP93]], i32 5
 ; CHECK-NEXT:    [[TMP102:%.*]] = insertelement <8 x i32> [[TMP101]], i32 [[TMP94]], i32 6
 ; CHECK-NEXT:    [[TMP103:%.*]] = insertelement <8 x i32> [[TMP102]], i32 [[TMP95]], i32 7
-; CHECK-NEXT:    [[TMP104:%.*]] = load i32, ptr [[TMP56]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP105:%.*]] = load i32, ptr [[TMP57]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP106:%.*]] = load i32, ptr [[TMP58]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP107:%.*]] = load i32, ptr [[TMP59]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP108:%.*]] = load i32, ptr [[TMP60]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP109:%.*]] = load i32, ptr [[TMP61]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP110:%.*]] = load i32, ptr [[TMP62]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP111:%.*]] = load i32, ptr [[TMP63]], align 4, !tbaa [[INT_TBAA1]]
+; CHECK-NEXT:    [[TMP104:%.*]] = load i32, ptr [[TMP56]], align 4
+; CHECK-NEXT:    [[TMP105:%.*]] = load i32, ptr [[TMP57]], align 4
+; CHECK-NEXT:    [[TMP106:%.*]] = load i32, ptr [[TMP58]], align 4
+; CHECK-NEXT:    [[TMP107:%.*]] = load i32, ptr [[TMP59]], align 4
+; CHECK-NEXT:    [[TMP108:%.*]] = load i32, ptr [[TMP60]], align 4
+; CHECK-NEXT:    [[TMP109:%.*]] = load i32, ptr [[TMP61]], align 4
+; CHECK-NEXT:    [[TMP110:%.*]] = load i32, ptr [[TMP62]], align 4
+; CHECK-NEXT:    [[TMP111:%.*]] = load i32, ptr [[TMP63]], align 4
 ; CHECK-NEXT:    [[TMP112:%.*]] = insertelement <8 x i32> poison, i32 [[TMP104]], i32 0
 ; CHECK-NEXT:    [[TMP113:%.*]] = insertelement <8 x i32> [[TMP112]], i32 [[TMP105]], i32 1
 ; CHECK-NEXT:    [[TMP114:%.*]] = insertelement <8 x i32> [[TMP113]], i32 [[TMP106]], i32 2
@@ -144,14 +144,14 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; CHECK-NEXT:    [[TMP117:%.*]] = insertelement <8 x i32> [[TMP116]], i32 [[TMP109]], i32 5
 ; CHECK-NEXT:    [[TMP118:%.*]] = insertelement <8 x i32> [[TMP117]], i32 [[TMP110]], i32 6
 ; CHECK-NEXT:    [[TMP119:%.*]] = insertelement <8 x i32> [[TMP118]], i32 [[TMP111]], i32 7
-; CHECK-NEXT:    [[TMP120:%.*]] = load i32, ptr [[TMP64]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP121:%.*]] = load i32, ptr [[TMP65]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP122:%.*]] = load i32, ptr [[TMP66]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP123:%.*]] = load i32, ptr [[TMP67]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP124:%.*]] = load i32, ptr [[TMP68]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP125:%.*]] = load i32, ptr [[TMP69]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP126:%.*]] = load i32, ptr [[TMP70]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP127:%.*]] = load i32, ptr [[TMP71]], align 4, !tbaa [[INT_TBAA1]]
+; CHECK-NEXT:    [[TMP120:%.*]] = load i32, ptr [[TMP64]], align 4
+; CHECK-NEXT:    [[TMP121:%.*]] = load i32, ptr [[TMP65]], align 4
+; CHECK-NEXT:    [[TMP122:%.*]] = load i32, ptr [[TMP66]], align 4
+; CHECK-NEXT:    [[TMP123:%.*]] = load i32, ptr [[TMP67]], align 4
+; CHECK-NEXT:    [[TMP124:%.*]] = load i32, ptr [[TMP68]], align 4
+; CHECK-NEXT:    [[TMP125:%.*]] = load i32, ptr [[TMP69]], align 4
+; CHECK-NEXT:    [[TMP126:%.*]] = load i32, ptr [[TMP70]], align 4
+; CHECK-NEXT:    [[TMP127:%.*]] = load i32, ptr [[TMP71]], align 4
 ; CHECK-NEXT:    [[TMP128:%.*]] = insertelement <8 x i32> poison, i32 [[TMP120]], i32 0
 ; CHECK-NEXT:    [[TMP129:%.*]] = insertelement <8 x i32> [[TMP128]], i32 [[TMP121]], i32 1
 ; CHECK-NEXT:    [[TMP130:%.*]] = insertelement <8 x i32> [[TMP129]], i32 [[TMP122]], i32 2
@@ -174,7 +174,7 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; CHECK-NEXT:    [[TMP147]] = add <8 x i32> [[TMP143]], [[TMP139]]
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 32
 ; CHECK-NEXT:    [[TMP148:%.*]] = icmp eq i64 [[INDEX_NEXT]], 96
-; CHECK-NEXT:    br i1 [[TMP148]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP5:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP148]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP0:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    [[BIN_RDX:%.*]] = add <8 x i32> [[TMP145]], [[TMP144]]
 ; CHECK-NEXT:    [[BIN_RDX7:%.*]] = add <8 x i32> [[TMP146]], [[BIN_RDX]]
@@ -182,7 +182,7 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; CHECK-NEXT:    [[TMP149:%.*]] = call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> [[BIN_RDX8]])
 ; CHECK-NEXT:    br i1 false, label %[[FOR_COND_CLEANUP:.*]], label %[[VEC_EPILOG_ITER_CHECK:.*]]
 ; CHECK:       [[VEC_EPILOG_ITER_CHECK]]:
-; CHECK-NEXT:    br i1 false, label %[[VEC_EPILOG_SCALAR_PH]], label %[[VEC_EPILOG_PH]], !prof [[PROF8:![0-9]+]]
+; CHECK-NEXT:    br i1 false, label %[[VEC_EPILOG_SCALAR_PH]], label %[[VEC_EPILOG_PH]], !prof [[PROF3:![0-9]+]]
 ; CHECK:       [[VEC_EPILOG_PH]]:
 ; CHECK-NEXT:    [[VEC_EPILOG_RESUME_VAL:%.*]] = phi i64 [ 96, %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[VECTOR_MAIN_LOOP_ITER_CHECK]] ]
 ; CHECK-NEXT:    [[BC_MERGE_RDX:%.*]] = phi i32 [ [[TMP149]], %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[VECTOR_MAIN_LOOP_ITER_CHECK]] ]
@@ -195,15 +195,15 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; CHECK-NEXT:    [[TMP174:%.*]] = add i64 [[INDEX9]], 2
 ; CHECK-NEXT:    [[TMP175:%.*]] = add i64 [[INDEX9]], 3
 ; CHECK-NEXT:    [[TMP152:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[IDXPROM]], i64 [[INDEX9]]
-; CHECK-NEXT:    [[WIDE_LOAD11:%.*]] = load <4 x i32>, ptr [[TMP152]], align 4, !tbaa [[INT_TBAA1]]
+; CHECK-NEXT:    [[WIDE_LOAD11:%.*]] = load <4 x i32>, ptr [[TMP152]], align 4
 ; CHECK-NEXT:    [[TMP154:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[INDEX9]], i64 [[IDXPROM5]]
 ; CHECK-NEXT:    [[TMP155:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP173]], i64 [[IDXPROM5]]
 ; CHECK-NEXT:    [[TMP156:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP174]], i64 [[IDXPROM5]]
 ; CHECK-NEXT:    [[TMP157:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP175]], i64 [[IDXPROM5]]
-; CHECK-NEXT:    [[TMP158:%.*]] = load i32, ptr [[TMP154]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP159:%.*]] = load i32, ptr [[TMP155]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP160:%.*]] = load i32, ptr [[TMP156]], align 4, !tbaa [[INT_TBAA1]]
-; CHECK-NEXT:    [[TMP161:%.*]] = load i32, ptr [[TMP157]], align 4, !tbaa [[INT_TBAA1]]
+; CHECK-NEXT:    [[TMP158:%.*]] = load i32, ptr [[TMP154]], align 4
+; CHECK-NEXT:    [[TMP159:%.*]] = load i32, ptr [[TMP155]], align 4
+; CHECK-NEXT:    [[TMP160:%.*]] = load i32, ptr [[TMP156]], align 4
+; CHECK-NEXT:    [[TMP161:%.*]] = load i32, ptr [[TMP157]], align 4
 ; CHECK-NEXT:    [[TMP162:%.*]] = insertelement <4 x i32> poison, i32 [[TMP158]], i32 0
 ; CHECK-NEXT:    [[TMP163:%.*]] = insertelement <4 x i32> [[TMP162]], i32 [[TMP159]], i32 1
 ; CHECK-NEXT:    [[TMP164:%.*]] = insertelement <4 x i32> [[TMP163]], i32 [[TMP160]], i32 2
@@ -213,30 +213,30 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; CHECK-NEXT:    [[TMP168]] = add <4 x i32> [[TMP167]], [[TMP166]]
 ; CHECK-NEXT:    [[INDEX_NEXT12]] = add nuw i64 [[INDEX9]], 4
 ; CHECK-NEXT:    [[TMP169:%.*]] = icmp eq i64 [[INDEX_NEXT12]], 100
-; CHECK-NEXT:    br i1 [[TMP169]], label %[[VEC_EPILOG_MIDDLE_BLOCK:.*]], label %[[VEC_EPILOG_VECTOR_BODY]], !llvm.loop [[LOOP9:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP169]], label %[[VEC_EPILOG_MIDDLE_BLOCK:.*]], label %[[VEC_EPILOG_VECTOR_BODY]], !llvm.loop [[LOOP4:![0-9]+]]
 ; CHECK:       [[VEC_EPILOG_MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    [[TMP170:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> [[TMP168]])
 ; CHECK-NEXT:    br i1 true, label %[[FOR_COND_CLEANUP]], label %[[VEC_EPILOG_SCALAR_PH]]
 ; CHECK:       [[VEC_EPILOG_SCALAR_PH]]:
 ; CHECK-NEXT:    [[BC_RESUME_VAL:%.*]] = phi i64 [ 100, %[[VEC_EPILOG_MIDDLE_BLOCK]] ], [ 96, %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[ITER_CHECK]] ]
-; CHECK-NEXT:    [[BC_MERGE_RDX15:%.*]] = phi i32 [ [[TMP170]], %[[VEC_EPILOG_MIDDLE_BLOCK]] ], [ [[TMP149]], %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[ITER_CHECK]] ]
+; CHECK-NEXT:    [[BC_MERGE_RDX13:%.*]] = phi i32 [ [[TMP170]], %[[VEC_EPILOG_MIDDLE_BLOCK]] ], [ [[TMP149]], %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[ITER_CHECK]] ]
 ; CHECK-NEXT:    br label %[[FOR_BODY:.*]]
 ; CHECK:       [[FOR_COND_CLEANUP]]:
 ; CHECK-NEXT:    [[ADD7_LCSSA:%.*]] = phi i32 [ [[ADD7:%.*]], %[[FOR_BODY]] ], [ [[TMP149]], %[[MIDDLE_BLOCK]] ], [ [[TMP170]], %[[VEC_EPILOG_MIDDLE_BLOCK]] ]
 ; CHECK-NEXT:    ret i32 [[ADD7_LCSSA]]
 ; CHECK:       [[FOR_BODY]]:
 ; CHECK-NEXT:    [[INDVARS_IV:%.*]] = phi i64 [ [[BC_RESUME_VAL]], %[[VEC_EPILOG_SCALAR_PH]] ], [ [[INDVARS_IV_NEXT:%.*]], %[[FOR_BODY]] ]
-; CHECK-NEXT:    [[SUM_015:%.*]] = phi i32 [ [[BC_MERGE_RDX15]], %[[VEC_EPILOG_SCALAR_PH]] ], [ [[ADD7]], %[[FOR_BODY]] ]
+; CHECK-NEXT:    [[SUM_015:%.*]] = phi i32 [ [[BC_MERGE_RDX13]], %[[VEC_EPILOG_SCALAR_PH]] ], [ [[ADD7]], %[[FOR_BODY]] ]
 ; CHECK-NEXT:    [[ARRAYIDX2:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[IDXPROM]], i64 [[INDVARS_IV]]
-; CHECK-NEXT:    [[TMP150:%.*]] = load i32, ptr [[ARRAYIDX2]], align 4, !tbaa [[INT_TBAA1]]
+; CHECK-NEXT:    [[TMP150:%.*]] = load i32, ptr [[ARRAYIDX2]], align 4
 ; CHECK-NEXT:    [[ARRAYIDX6:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[INDVARS_IV]], i64 [[IDXPROM5]]
-; CHECK-NEXT:    [[TMP151:%.*]] = load i32, ptr [[ARRAYIDX6]], align 4, !tbaa [[INT_TBAA1]]
+; CHECK-NEXT:    [[TMP151:%.*]] = load i32, ptr [[ARRAYIDX6]], align 4
 ; CHECK-NEXT:    [[MUL:%.*]] = mul nsw i32 [[TMP151]], [[TMP150]]
 ; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[SUM_015]], 4
 ; CHECK-NEXT:    [[ADD7]] = add i32 [[ADD]], [[MUL]]
 ; CHECK-NEXT:    [[INDVARS_IV_NEXT]] = add nuw nsw i64 [[INDVARS_IV]], 1
 ; CHECK-NEXT:    [[EXITCOND:%.*]] = icmp eq i64 [[INDVARS_IV_NEXT]], 100
-; CHECK-NEXT:    br i1 [[EXITCOND]], label %[[FOR_COND_CLEANUP]], label %[[FOR_BODY]], !llvm.loop [[LOOP10:![0-9]+]]
+; CHECK-NEXT:    br i1 [[EXITCOND]], label %[[FOR_COND_CLEANUP]], label %[[FOR_BODY]], !llvm.loop [[LOOP5:![0-9]+]]
 ;
 ; MAX-BW-LABEL: define i32 @matrix_row_col(
 ; MAX-BW-SAME: ptr readonly captures(none) [[DATA:%.*]], i32 [[I:%.*]], i32 [[J:%.*]]) #[[ATTR0:[0-9]+]] {
@@ -289,10 +289,10 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; MAX-BW-NEXT:    [[TMP33:%.*]] = getelementptr inbounds i32, ptr [[TMP32]], i64 8
 ; MAX-BW-NEXT:    [[TMP34:%.*]] = getelementptr inbounds i32, ptr [[TMP32]], i64 16
 ; MAX-BW-NEXT:    [[TMP35:%.*]] = getelementptr inbounds i32, ptr [[TMP32]], i64 24
-; MAX-BW-NEXT:    [[WIDE_LOAD:%.*]] = load <8 x i32>, ptr [[TMP32]], align 4, !tbaa [[INT_TBAA1:![0-9]+]]
-; MAX-BW-NEXT:    [[WIDE_LOAD4:%.*]] = load <8 x i32>, ptr [[TMP33]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[WIDE_LOAD5:%.*]] = load <8 x i32>, ptr [[TMP34]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[WIDE_LOAD6:%.*]] = load <8 x i32>, ptr [[TMP35]], align 4, !tbaa [[INT_TBAA1]]
+; MAX-BW-NEXT:    [[WIDE_LOAD:%.*]] = load <8 x i32>, ptr [[TMP32]], align 4
+; MAX-BW-NEXT:    [[WIDE_LOAD4:%.*]] = load <8 x i32>, ptr [[TMP33]], align 4
+; MAX-BW-NEXT:    [[WIDE_LOAD5:%.*]] = load <8 x i32>, ptr [[TMP34]], align 4
+; MAX-BW-NEXT:    [[WIDE_LOAD6:%.*]] = load <8 x i32>, ptr [[TMP35]], align 4
 ; MAX-BW-NEXT:    [[TMP40:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[INDEX]], i64 [[IDXPROM5]]
 ; MAX-BW-NEXT:    [[TMP41:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP1]], i64 [[IDXPROM5]]
 ; MAX-BW-NEXT:    [[TMP42:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP2]], i64 [[IDXPROM5]]
@@ -325,14 +325,14 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; MAX-BW-NEXT:    [[TMP69:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP29]], i64 [[IDXPROM5]]
 ; MAX-BW-NEXT:    [[TMP70:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP30]], i64 [[IDXPROM5]]
 ; MAX-BW-NEXT:    [[TMP71:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP31]], i64 [[IDXPROM5]]
-; MAX-BW-NEXT:    [[TMP72:%.*]] = load i32, ptr [[TMP40]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP73:%.*]] = load i32, ptr [[TMP41]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP74:%.*]] = load i32, ptr [[TMP42]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP75:%.*]] = load i32, ptr [[TMP43]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP76:%.*]] = load i32, ptr [[TMP44]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP77:%.*]] = load i32, ptr [[TMP45]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP78:%.*]] = load i32, ptr [[TMP46]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP79:%.*]] = load i32, ptr [[TMP47]], align 4, !tbaa [[INT_TBAA1]]
+; MAX-BW-NEXT:    [[TMP72:%.*]] = load i32, ptr [[TMP40]], align 4
+; MAX-BW-NEXT:    [[TMP73:%.*]] = load i32, ptr [[TMP41]], align 4
+; MAX-BW-NEXT:    [[TMP74:%.*]] = load i32, ptr [[TMP42]], align 4
+; MAX-BW-NEXT:    [[TMP75:%.*]] = load i32, ptr [[TMP43]], align 4
+; MAX-BW-NEXT:    [[TMP76:%.*]] = load i32, ptr [[TMP44]], align 4
+; MAX-BW-NEXT:    [[TMP77:%.*]] = load i32, ptr [[TMP45]], align 4
+; MAX-BW-NEXT:    [[TMP78:%.*]] = load i32, ptr [[TMP46]], align 4
+; MAX-BW-NEXT:    [[TMP79:%.*]] = load i32, ptr [[TMP47]], align 4
 ; MAX-BW-NEXT:    [[TMP80:%.*]] = insertelement <8 x i32> poison, i32 [[TMP72]], i32 0
 ; MAX-BW-NEXT:    [[TMP81:%.*]] = insertelement <8 x i32> [[TMP80]], i32 [[TMP73]], i32 1
 ; MAX-BW-NEXT:    [[TMP82:%.*]] = insertelement <8 x i32> [[TMP81]], i32 [[TMP74]], i32 2
@@ -341,14 +341,14 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; MAX-BW-NEXT:    [[TMP85:%.*]] = insertelement <8 x i32> [[TMP84]], i32 [[TMP77]], i32 5
 ; MAX-BW-NEXT:    [[TMP86:%.*]] = insertelement <8 x i32> [[TMP85]], i32 [[TMP78]], i32 6
 ; MAX-BW-NEXT:    [[TMP87:%.*]] = insertelement <8 x i32> [[TMP86]], i32 [[TMP79]], i32 7
-; MAX-BW-NEXT:    [[TMP88:%.*]] = load i32, ptr [[TMP48]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP89:%.*]] = load i32, ptr [[TMP49]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP90:%.*]] = load i32, ptr [[TMP50]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP91:%.*]] = load i32, ptr [[TMP51]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP92:%.*]] = load i32, ptr [[TMP52]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP93:%.*]] = load i32, ptr [[TMP53]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP94:%.*]] = load i32, ptr [[TMP54]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP95:%.*]] = load i32, ptr [[TMP55]], align 4, !tbaa [[INT_TBAA1]]
+; MAX-BW-NEXT:    [[TMP88:%.*]] = load i32, ptr [[TMP48]], align 4
+; MAX-BW-NEXT:    [[TMP89:%.*]] = load i32, ptr [[TMP49]], align 4
+; MAX-BW-NEXT:    [[TMP90:%.*]] = load i32, ptr [[TMP50]], align 4
+; MAX-BW-NEXT:    [[TMP91:%.*]] = load i32, ptr [[TMP51]], align 4
+; MAX-BW-NEXT:    [[TMP92:%.*]] = load i32, ptr [[TMP52]], align 4
+; MAX-BW-NEXT:    [[TMP93:%.*]] = load i32, ptr [[TMP53]], align 4
+; MAX-BW-NEXT:    [[TMP94:%.*]] = load i32, ptr [[TMP54]], align 4
+; MAX-BW-NEXT:    [[TMP95:%.*]] = load i32, ptr [[TMP55]], align 4
 ; MAX-BW-NEXT:    [[TMP96:%.*]] = insertelement <8 x i32> poison, i32 [[TMP88]], i32 0
 ; MAX-BW-NEXT:    [[TMP97:%.*]] = insertelement <8 x i32> [[TMP96]], i32 [[TMP89]], i32 1
 ; MAX-BW-NEXT:    [[TMP98:%.*]] = insertelement <8 x i32> [[TMP97]], i32 [[TMP90]], i32 2
@@ -357,14 +357,14 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; MAX-BW-NEXT:    [[TMP101:%.*]] = insertelement <8 x i32> [[TMP100]], i32 [[TMP93]], i32 5
 ; MAX-BW-NEXT:    [[TMP102:%.*]] = insertelement <8 x i32> [[TMP101]], i32 [[TMP94]], i32 6
 ; MAX-BW-NEXT:    [[TMP103:%.*]] = insertelement <8 x i32> [[TMP102]], i32 [[TMP95]], i32 7
-; MAX-BW-NEXT:    [[TMP104:%.*]] = load i32, ptr [[TMP56]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP105:%.*]] = load i32, ptr [[TMP57]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP106:%.*]] = load i32, ptr [[TMP58]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP107:%.*]] = load i32, ptr [[TMP59]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP108:%.*]] = load i32, ptr [[TMP60]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP109:%.*]] = load i32, ptr [[TMP61]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP110:%.*]] = load i32, ptr [[TMP62]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP111:%.*]] = load i32, ptr [[TMP63]], align 4, !tbaa [[INT_TBAA1]]
+; MAX-BW-NEXT:    [[TMP104:%.*]] = load i32, ptr [[TMP56]], align 4
+; MAX-BW-NEXT:    [[TMP105:%.*]] = load i32, ptr [[TMP57]], align 4
+; MAX-BW-NEXT:    [[TMP106:%.*]] = load i32, ptr [[TMP58]], align 4
+; MAX-BW-NEXT:    [[TMP107:%.*]] = load i32, ptr [[TMP59]], align 4
+; MAX-BW-NEXT:    [[TMP108:%.*]] = load i32, ptr [[TMP60]], align 4
+; MAX-BW-NEXT:    [[TMP109:%.*]] = load i32, ptr [[TMP61]], align 4
+; MAX-BW-NEXT:    [[TMP110:%.*]] = load i32, ptr [[TMP62]], align 4
+; MAX-BW-NEXT:    [[TMP111:%.*]] = load i32, ptr [[TMP63]], align 4
 ; MAX-BW-NEXT:    [[TMP112:%.*]] = insertelement <8 x i32> poison, i32 [[TMP104]], i32 0
 ; MAX-BW-NEXT:    [[TMP113:%.*]] = insertelement <8 x i32> [[TMP112]], i32 [[TMP105]], i32 1
 ; MAX-BW-NEXT:    [[TMP114:%.*]] = insertelement <8 x i32> [[TMP113]], i32 [[TMP106]], i32 2
@@ -373,14 +373,14 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; MAX-BW-NEXT:    [[TMP117:%.*]] = insertelement <8 x i32> [[TMP116]], i32 [[TMP109]], i32 5
 ; MAX-BW-NEXT:    [[TMP118:%.*]] = insertelement <8 x i32> [[TMP117]], i32 [[TMP110]], i32 6
 ; MAX-BW-NEXT:    [[TMP119:%.*]] = insertelement <8 x i32> [[TMP118]], i32 [[TMP111]], i32 7
-; MAX-BW-NEXT:    [[TMP120:%.*]] = load i32, ptr [[TMP64]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP121:%.*]] = load i32, ptr [[TMP65]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP122:%.*]] = load i32, ptr [[TMP66]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP123:%.*]] = load i32, ptr [[TMP67]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP124:%.*]] = load i32, ptr [[TMP68]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP125:%.*]] = load i32, ptr [[TMP69]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP126:%.*]] = load i32, ptr [[TMP70]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP127:%.*]] = load i32, ptr [[TMP71]], align 4, !tbaa [[INT_TBAA1]]
+; MAX-BW-NEXT:    [[TMP120:%.*]] = load i32, ptr [[TMP64]], align 4
+; MAX-BW-NEXT:    [[TMP121:%.*]] = load i32, ptr [[TMP65]], align 4
+; MAX-BW-NEXT:    [[TMP122:%.*]] = load i32, ptr [[TMP66]], align 4
+; MAX-BW-NEXT:    [[TMP123:%.*]] = load i32, ptr [[TMP67]], align 4
+; MAX-BW-NEXT:    [[TMP124:%.*]] = load i32, ptr [[TMP68]], align 4
+; MAX-BW-NEXT:    [[TMP125:%.*]] = load i32, ptr [[TMP69]], align 4
+; MAX-BW-NEXT:    [[TMP126:%.*]] = load i32, ptr [[TMP70]], align 4
+; MAX-BW-NEXT:    [[TMP127:%.*]] = load i32, ptr [[TMP71]], align 4
 ; MAX-BW-NEXT:    [[TMP128:%.*]] = insertelement <8 x i32> poison, i32 [[TMP120]], i32 0
 ; MAX-BW-NEXT:    [[TMP129:%.*]] = insertelement <8 x i32> [[TMP128]], i32 [[TMP121]], i32 1
 ; MAX-BW-NEXT:    [[TMP130:%.*]] = insertelement <8 x i32> [[TMP129]], i32 [[TMP122]], i32 2
@@ -403,7 +403,7 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; MAX-BW-NEXT:    [[TMP147]] = add <8 x i32> [[TMP143]], [[TMP139]]
 ; MAX-BW-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 32
 ; MAX-BW-NEXT:    [[TMP148:%.*]] = icmp eq i64 [[INDEX_NEXT]], 96
-; MAX-BW-NEXT:    br i1 [[TMP148]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP5:![0-9]+]]
+; MAX-BW-NEXT:    br i1 [[TMP148]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP0:![0-9]+]]
 ; MAX-BW:       [[MIDDLE_BLOCK]]:
 ; MAX-BW-NEXT:    [[BIN_RDX:%.*]] = add <8 x i32> [[TMP145]], [[TMP144]]
 ; MAX-BW-NEXT:    [[BIN_RDX7:%.*]] = add <8 x i32> [[TMP146]], [[BIN_RDX]]
@@ -411,7 +411,7 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; MAX-BW-NEXT:    [[TMP149:%.*]] = call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> [[BIN_RDX8]])
 ; MAX-BW-NEXT:    br i1 false, label %[[FOR_COND_CLEANUP:.*]], label %[[VEC_EPILOG_ITER_CHECK:.*]]
 ; MAX-BW:       [[VEC_EPILOG_ITER_CHECK]]:
-; MAX-BW-NEXT:    br i1 false, label %[[VEC_EPILOG_SCALAR_PH]], label %[[VEC_EPILOG_PH]], !prof [[PROF8:![0-9]+]]
+; MAX-BW-NEXT:    br i1 false, label %[[VEC_EPILOG_SCALAR_PH]], label %[[VEC_EPILOG_PH]], !prof [[PROF3:![0-9]+]]
 ; MAX-BW:       [[VEC_EPILOG_PH]]:
 ; MAX-BW-NEXT:    [[VEC_EPILOG_RESUME_VAL:%.*]] = phi i64 [ 96, %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[VECTOR_MAIN_LOOP_ITER_CHECK]] ]
 ; MAX-BW-NEXT:    [[BC_MERGE_RDX:%.*]] = phi i32 [ [[TMP149]], %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[VECTOR_MAIN_LOOP_ITER_CHECK]] ]
@@ -424,15 +424,15 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; MAX-BW-NEXT:    [[TMP174:%.*]] = add i64 [[INDEX9]], 2
 ; MAX-BW-NEXT:    [[TMP175:%.*]] = add i64 [[INDEX9]], 3
 ; MAX-BW-NEXT:    [[TMP152:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[IDXPROM]], i64 [[INDEX9]]
-; MAX-BW-NEXT:    [[WIDE_LOAD11:%.*]] = load <4 x i32>, ptr [[TMP152]], align 4, !tbaa [[INT_TBAA1]]
+; MAX-BW-NEXT:    [[WIDE_LOAD11:%.*]] = load <4 x i32>, ptr [[TMP152]], align 4
 ; MAX-BW-NEXT:    [[TMP154:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[INDEX9]], i64 [[IDXPROM5]]
 ; MAX-BW-NEXT:    [[TMP155:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP173]], i64 [[IDXPROM5]]
 ; MAX-BW-NEXT:    [[TMP156:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP174]], i64 [[IDXPROM5]]
 ; MAX-BW-NEXT:    [[TMP157:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[TMP175]], i64 [[IDXPROM5]]
-; MAX-BW-NEXT:    [[TMP158:%.*]] = load i32, ptr [[TMP154]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP159:%.*]] = load i32, ptr [[TMP155]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP160:%.*]] = load i32, ptr [[TMP156]], align 4, !tbaa [[INT_TBAA1]]
-; MAX-BW-NEXT:    [[TMP161:%.*]] = load i32, ptr [[TMP157]], align 4, !tbaa [[INT_TBAA1]]
+; MAX-BW-NEXT:    [[TMP158:%.*]] = load i32, ptr [[TMP154]], align 4
+; MAX-BW-NEXT:    [[TMP159:%.*]] = load i32, ptr [[TMP155]], align 4
+; MAX-BW-NEXT:    [[TMP160:%.*]] = load i32, ptr [[TMP156]], align 4
+; MAX-BW-NEXT:    [[TMP161:%.*]] = load i32, ptr [[TMP157]], align 4
 ; MAX-BW-NEXT:    [[TMP162:%.*]] = insertelement <4 x i32> poison, i32 [[TMP158]], i32 0
 ; MAX-BW-NEXT:    [[TMP163:%.*]] = insertelement <4 x i32> [[TMP162]], i32 [[TMP159]], i32 1
 ; MAX-BW-NEXT:    [[TMP164:%.*]] = insertelement <4 x i32> [[TMP163]], i32 [[TMP160]], i32 2
@@ -442,30 +442,30 @@ define i32 @matrix_row_col(ptr nocapture readonly %data, i32 %i, i32 %j) #0 {
 ; MAX-BW-NEXT:    [[TMP168]] = add <4 x i32> [[TMP167]], [[TMP166]]
 ; MAX-BW-NEXT:    [[INDEX_NEXT12]] = add nuw i64 [[INDEX9]], 4
 ; MAX-BW-NEXT:    [[TMP169:%.*]] = icmp eq i64 [[INDEX_NEXT12]], 100
-; MAX-BW-NEXT:    br i1 [[TMP169]], label %[[VEC_EPILOG_MIDDLE_BLOCK:.*]], label %[[VEC_EPILOG_VECTOR_BODY]], !llvm.loop [[LOOP9:![0-9]+]]
+; MAX-BW-NEXT:    br i1 [[TMP169]], label %[[VEC_EPILOG_MIDDLE_BLOCK:.*]], label %[[VEC_EPILOG_VECTOR_BODY]], !llvm.loop [[LOOP4:![0-9]+]]
 ; MAX-BW:       [[VEC_EPILOG_MIDDLE_BLOCK]]:
 ; MAX-BW-NEXT:    [[TMP170:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> [[TMP168]])
 ; MAX-BW-NEXT:    br i1 true, label %[[FOR_COND_CLEANUP]], label %[[VEC_EPILOG_SCALAR_PH]]
 ; MAX-BW:       [[VEC_EPILOG_SCALAR_PH]]:
 ; MAX-BW-NEXT:    [[BC_RESUME_VAL:%.*]] = phi i64 [ 100, %[[VEC_EPILOG_MIDDLE_BLOCK]] ], [ 96, %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[ITER_CHECK]] ]
-; MAX-BW-NEXT:    [[BC_MERGE_RDX15:%.*]] = phi i32 [ [[TMP170]], %[[VEC_EPILOG_MIDDLE_BLOCK]] ], [ [[TMP149]], %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[ITER_CHECK]] ]
+; MAX-BW-NEXT:    [[BC_MERGE_RDX13:%.*]] = phi i32 [ [[TMP170]], %[[VEC_EPILOG_MIDDLE_BLOCK]] ], [ [[TMP149]], %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[ITER_CHECK]] ]
 ; MAX-BW-NEXT:    br label %[[FOR_BODY:.*]]
 ; MAX-BW:       [[FOR_COND_CLEANUP]]:
 ; MAX-BW-NEXT:    [[ADD7_LCSSA:%.*]] = phi i32 [ [[ADD7:%.*]], %[[FOR_BODY]] ], [ [[TMP149]], %[[MIDDLE_BLOCK]] ], [ [[TMP170]], %[[VEC_EPILOG_MIDDLE_BLOCK]] ]
 ; MAX-BW-NEXT:    ret i32 [[ADD7_LCSSA]]
 ; MAX-BW:       [[FOR_BODY]]:
 ; MAX-BW-NEXT:    [[INDVARS_IV:%.*]] = phi i64 [ [[BC_RESUME_VAL]], %[[VEC_EPILOG_SCALAR_PH]] ], [ [[INDVARS_IV_NEXT:%.*]], %[[FOR_BODY]] ]
-; MAX-BW-NEXT:    [[SUM_015:%.*]] = phi i32 [ [[BC_MERGE_RDX15]], %[[VEC_EPILOG_SCALAR_PH]] ], [ [[ADD7]], %[[FOR_BODY]] ]
+; MAX-BW-NEXT:    [[SUM_015:%.*]] = phi i32 [ [[BC_MERGE_RDX13]], %[[VEC_EPILOG_SCALAR_PH]] ], [ [[ADD7]], %[[FOR_BODY]] ]
 ; MAX-BW-NEXT:    [[ARRAYIDX2:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[IDXPROM]], i64 [[INDVARS_IV]]
-; MAX-BW-NEXT:    [[TMP150:%.*]] = load i32, ptr [[ARRAYIDX2]], align 4, !tbaa [[INT_TBAA1]]
+; MAX-BW-NEXT:    [[TMP150:%.*]] = load i32, ptr [[ARRAYIDX2]], align 4
 ; MAX-BW-NEXT:    [[ARRAYIDX6:%.*]] = getelementptr inbounds [100 x i32], ptr [[DATA]], i64 [[INDVARS_IV]], i64 [[IDXPROM5]]
-; MAX-BW-NEXT:    [[TMP151:%.*]] = load i32, ptr [[ARRAYIDX6]], align 4, !tbaa [[INT_TBAA1]]
+; MAX-BW-NEXT:    [[TMP151:%.*]] = load i32, ptr [[ARRAYIDX6]], align 4
 ; MAX-BW-NEXT:    [[MUL:%.*]] = mul nsw i32 [[TMP151]], [[TMP150]]
 ; MAX-BW-NEXT:    [[ADD:%.*]] = add i32 [[SUM_015]], 4
 ; MAX-BW-NEXT:    [[ADD7]] = add i32 [[ADD]], [[MUL]]
 ; MAX-BW-NEXT:    [[INDVARS_IV_NEXT]] = add nuw nsw i64 [[INDVARS_IV]], 1
 ; MAX-BW-NEXT:    [[EXITCOND:%.*]] = icmp eq i64 [[INDVARS_IV_NEXT]], 100
-; MAX-BW-NEXT:    br i1 [[EXITCOND]], label %[[FOR_COND_CLEANUP]], label %[[FOR_BODY]], !llvm.loop [[LOOP10:![0-9]+]]
+; MAX-BW-NEXT:    br i1 [[EXITCOND]], label %[[FOR_COND_CLEANUP]], label %[[FOR_BODY]], !llvm.loop [[LOOP5:![0-9]+]]
 ;
 entry:
   %idxprom = sext i32 %i to i64
@@ -480,10 +480,10 @@ entry:
   %sum.015 = phi i32 [ 0, %entry ], [ %add7, %for.body ]
   ; first consecutive load as vector load
   %arrayidx2 = getelementptr inbounds [100 x i32], ptr %data, i64 %idxprom, i64 %indvars.iv
-  %0 = load i32, ptr %arrayidx2, align 4, !tbaa !1
+  %0 = load i32, ptr %arrayidx2, align 4
   ; second strided load scalarized
   %arrayidx6 = getelementptr inbounds [100 x i32], ptr %data, i64 %indvars.iv, i64 %idxprom5
-  %1 = load i32, ptr %arrayidx6, align 4, !tbaa !1
+  %1 = load i32, ptr %arrayidx6, align 4
   %mul = mul nsw i32 %1, %0
   %add = add i32 %sum.015, 4
   %add7 = add i32 %add, %mul
@@ -541,7 +541,7 @@ define void @test(ptr %A, ptr noalias %B) #0 {
 ; CHECK-NEXT:    store i8 [[TMP35]], ptr [[TMP27]], align 1
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 8
 ; CHECK-NEXT:    [[TMP36:%.*]] = icmp eq i64 [[INDEX_NEXT]], 512
-; CHECK-NEXT:    br i1 [[TMP36]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP11:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP36]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    br label %[[FOR_COND_CLEANUP:.*]]
 ; CHECK:       [[FOR_COND_CLEANUP]]:
@@ -627,7 +627,7 @@ define void @test(ptr %A, ptr noalias %B) #0 {
 ; MAX-BW-NEXT:    store i8 [[TMP67]], ptr [[TMP51]], align 1
 ; MAX-BW-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 16
 ; MAX-BW-NEXT:    [[TMP68:%.*]] = icmp eq i64 [[INDEX_NEXT]], 512
-; MAX-BW-NEXT:    br i1 [[TMP68]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP11:![0-9]+]]
+; MAX-BW-NEXT:    br i1 [[TMP68]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]
 ; MAX-BW:       [[MIDDLE_BLOCK]]:
 ; MAX-BW-NEXT:    br label %[[FOR_COND_CLEANUP:.*]]
 ; MAX-BW:       [[FOR_COND_CLEANUP]]:
@@ -665,32 +665,20 @@ for.cond.cleanup:
 
 attributes #0 = { "target-cpu"="core-avx2" "target-features"="+avx,+avx2,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3" }
 
-!1 = !{!2, !2, i64 0}
-!2 = !{!"int", !3, i64 0}
-!3 = !{!"omnipotent char", !4, i64 0}
-!4 = !{!"Simple C/C++ TBAA"}
 ;.
-; CHECK: [[INT_TBAA1]] = !{[[META2:![0-9]+]], [[META2]], i64 0}
-; CHECK: [[META2]] = !{!"int", [[META3:![0-9]+]], i64 0}
-; CHECK: [[META3]] = !{!"omnipotent char", [[META4:![0-9]+]], i64 0}
-; CHECK: [[META4]] = !{!"Simple C/C++ TBAA"}
-; CHECK: [[LOOP5]] = distinct !{[[LOOP5]], [[META6:![0-9]+]], [[META7:![0-9]+]]}
-; CHECK: [[META6]] = !{!"llvm.loop.isvectorized", i32 1}
-; CHECK: [[META7]] = !{!"llvm.loop.unroll.runtime.disable"}
-; CHECK: [[PROF8]] = !{!"branch_weights", i32 4, i32 28}
-; CHECK: [[LOOP9]] = distinct !{[[LOOP9]], [[META6]], [[META7]]}
-; CHECK: [[LOOP10]] = distinct !{[[LOOP10]], [[META7]], [[META6]]}
-; CHECK: [[LOOP11]] = distinct !{[[LOOP11]], [[META6]], [[META7]]}
+; CHECK: [[LOOP0]] = distinct !{[[LOOP0]], [[META1:![0-9]+]], [[META2:![0-9]+]]}
+; CHECK: [[META1]] = !{!"llvm.loop.isvectorized", i32 1}
+; CHECK: [[META2]] = !{!"llvm.loop.unroll.runtime.disable"}
+; CHECK: [[PROF3]] = !{!"branch_weights", i32 4, i32 28}
+; CHECK: [[LOOP4]] = distinct !{[[LOOP4]], [[META1]], [[META2]]}
+; CHECK: [[LOOP5]] = distinct !{[[LOOP5]], [[META2]], [[META1]]}
+; CHECK: [[LOOP6]] = distinct !{[[LOOP6]], [[META1]], [[META2]]}
 ;.
-; MAX-BW: [[INT_TBAA1]] = !{[[META2:![0-9]+]], [[META2]], i64 0}
-; MAX-BW: [[META2]] = !{!"int", [[META3:![0-9]+]], i64 0}
-; MAX-BW: [[META3]] = !{!"omnipotent char", [[META4:![0-9]+]], i64 0}
-; MAX-BW: [[META4]] = !{!"Simple C/C++ TBAA"}
-; MAX-BW: [[LOOP5]] = distinct !{[[LOOP5]], [[META6:![0-9]+]], [[META7:![0-9]+]]}
-; MAX-BW: [[META6]] = !{!"llvm.loop.isvectorized", i32 1}
-; MAX-BW: [[META7]] = !{!"llvm.loop.unroll.runtime.disable"}
-; MAX-BW: [[PROF8]] = !{!"branch_weights", i32 4, i32 28}
-; MAX-BW: [[LOOP9]] = distinct !{[[LOOP9]], [[META6]], [[META7]]}
-; MAX-BW: [[LOOP10]] = distinct !{[[LOOP10]], [[META7]], [[META6]]}
-; MAX-BW: [[LOOP11]] = distinct !{[[LOOP11]], [[META6]], [[META7]]}
+; MAX-BW: [[LOOP0]] = distinct !{[[LOOP0]], [[META1:![0-9]+]], [[META2:![0-9]+]]}
+; MAX-BW: [[META1]] = !{!"llvm.loop.isvectorized", i32 1}
+; MAX-BW: [[META2]] = !{!"llvm.loop.unroll.runtime.disable"}
+; MAX-BW: [[PROF3]] = !{!"branch_weights", i32 4, i32 28}
+; MAX-BW: [[LOOP4]] = distinct !{[[LOOP4]], [[META1]], [[META2]]}
+; MAX-BW: [[LOOP5]] = distinct !{[[LOOP5]], [[META2]], [[META1]]}
+; MAX-BW: [[LOOP6]] = distinct !{[[LOOP6]], [[META1]], [[META2]]}
 ;.

--- a/llvm/test/Transforms/LoopVectorize/X86/tail_folding_and_assume_safety.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/tail_folding_and_assume_safety.ll
@@ -140,13 +140,8 @@ for.inc:
   br i1 %exitcond, label %for.cond.cleanup, label %for.body, !llvm.loop !11
 }
 
-attributes #0 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "use-soft-float"="false" }
+attributes #0 = { "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "use-soft-float"="false" }
 
-!llvm.module.flags = !{!0}
-!llvm.ident = !{!1}
-
-!0 = !{i32 1, !"wchar_size", i32 4}
-!1 = !{!"clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final)"}
 !2 = !{!3, !3, i64 0}
 !3 = !{!"int", !4, i64 0}
 !4 = !{!"omnipotent char", !5, i64 0}

--- a/llvm/test/Transforms/LoopVectorize/X86/tail_folding_and_assume_safety.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/tail_folding_and_assume_safety.ll
@@ -36,12 +36,12 @@ for.body:
 
 if.then:
   %arrayidx = getelementptr inbounds i32, ptr %q1, i64 %indvars.iv
-  %1 = load i32, ptr %arrayidx, align 4, !tbaa !2
+  %1 = load i32, ptr %arrayidx, align 4
   %arrayidx3 = getelementptr inbounds i32, ptr %q2, i64 %indvars.iv
-  %2 = load i32, ptr %arrayidx3, align 4, !tbaa !2
+  %2 = load i32, ptr %arrayidx3, align 4
   %add = add nsw i32 %2, %1
   %arrayidx5 = getelementptr inbounds i32, ptr %p, i64 %indvars.iv
-  store i32 %add, ptr %arrayidx5, align 4, !tbaa !2
+  store i32 %add, ptr %arrayidx5, align 4
   br label %for.inc
 
 for.inc:
@@ -79,12 +79,12 @@ define void @assume_safety(ptr nocapture, ptr nocapture readonly, ptr nocapture 
 
 ; <label>:10:
   %11 = getelementptr inbounds i32, ptr %1, i64 %8
-  %12 = load i32, ptr %11, align 4, !tbaa !2, !llvm.mem.parallel_loop_access !6
+  %12 = load i32, ptr %11, align 4, !llvm.mem.parallel_loop_access !6
   %13 = getelementptr inbounds i32, ptr %2, i64 %8
-  %14 = load i32, ptr %13, align 4, !tbaa !2, !llvm.mem.parallel_loop_access !6
+  %14 = load i32, ptr %13, align 4, !llvm.mem.parallel_loop_access !6
   %15 = add nsw i32 %14, %12
   %16 = getelementptr inbounds i32, ptr %0, i64 %8
-  store i32 %15, ptr %16, align 4, !tbaa !2, !llvm.mem.parallel_loop_access !6
+  store i32 %15, ptr %16, align 4, !llvm.mem.parallel_loop_access !6
   br label %17
 
 ; <label>:17:
@@ -126,12 +126,12 @@ for.body:
 
 if.then:
   %arrayidx = getelementptr inbounds i32, ptr %q1, i64 %indvars.iv
-  %1 = load i32, ptr %arrayidx, align 4, !tbaa !2, !llvm.access.group !10
+  %1 = load i32, ptr %arrayidx, align 4, !llvm.access.group !10
   %arrayidx3 = getelementptr inbounds i32, ptr %q2, i64 %indvars.iv
-  %2 = load i32, ptr %arrayidx3, align 4, !tbaa !2, !llvm.access.group !10
+  %2 = load i32, ptr %arrayidx3, align 4, !llvm.access.group !10
   %add = add nsw i32 %2, %1
   %arrayidx5 = getelementptr inbounds i32, ptr %p, i64 %indvars.iv
-  store i32 %add, ptr %arrayidx5, align 4, !tbaa !2, !llvm.access.group !10
+  store i32 %add, ptr %arrayidx5, align 4, !llvm.access.group !10
   br label %for.inc
 
 for.inc:
@@ -142,10 +142,6 @@ for.inc:
 
 attributes #0 = { "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "use-soft-float"="false" }
 
-!2 = !{!3, !3, i64 0}
-!3 = !{!"int", !4, i64 0}
-!4 = !{!"omnipotent char", !5, i64 0}
-!5 = !{!"Simple C/C++ TBAA"}
 !6 = distinct !{!6, !7}
 !7 = !{!"llvm.loop.vectorize.enable", i1 true}
 

--- a/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-loopid-dbg.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-loopid-dbg.ll
@@ -40,7 +40,6 @@ for.end:
 declare void @ibar(ptr) #1
 
 !llvm.module.flags = !{!7, !8}
-!llvm.ident = !{!9}
 !llvm.dbg.cu = !{!24}
 
 !1 = !DIFile(filename: "vectorization-remarks.c", directory: ".")
@@ -51,7 +50,6 @@ declare void @ibar(ptr) #1
 !6 = !DISubroutineType(types: !2)
 !7 = !{i32 2, !"Dwarf Version", i32 4}
 !8 = !{i32 1, !"Debug Info Version", i32 3}
-!9 = !{!"clang version 3.5.0 "}
 !10 = !DILocation(line: 8, column: 3, scope: !4)
 !11 = !{!12, !12, i64 0}
 !12 = !{!"int", !13, i64 0}

--- a/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-loopid-dbg.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-loopid-dbg.ll
@@ -13,17 +13,17 @@ entry:
   %diff = alloca i32, align 4
   %cb = alloca [16 x i8], align 16
   %cc = alloca [16 x i8], align 16
-  store i32 0, ptr %diff, align 4, !tbaa !11
+  store i32 0, ptr %diff, align 4
   br label %for.body
 
 for.body:
   %indvars.iv = phi i64 [ 0, %entry ], [ %indvars.iv.next, %for.body ]
   %add8 = phi i32 [ 0, %entry ], [ %add, %for.body ]
   %arrayidx = getelementptr inbounds [16 x i8], ptr %cb, i64 0, i64 %indvars.iv
-  %0 = load i8, ptr %arrayidx, align 1, !tbaa !21
+  %0 = load i8, ptr %arrayidx, align 1
   %conv = sext i8 %0 to i32
   %arrayidx2 = getelementptr inbounds [16 x i8], ptr %cc, i64 0, i64 %indvars.iv
-  %1 = load i8, ptr %arrayidx2, align 1, !tbaa !21
+  %1 = load i8, ptr %arrayidx2, align 1
   %conv3 = sext i8 %1 to i32
   %sub = sub i32 %conv, %conv3
   %add = add nsw i32 %sub, %add8
@@ -32,7 +32,7 @@ for.body:
   br i1 %exitcond, label %for.end, label %for.body, !llvm.loop !25
 
 for.end:
-  store i32 %add, ptr %diff, align 4, !tbaa !11
+  store i32 %add, ptr %diff, align 4
   call void @ibar(ptr %diff) #2
   ret i32 0
 }
@@ -51,17 +51,12 @@ declare void @ibar(ptr) #1
 !7 = !{i32 2, !"Dwarf Version", i32 4}
 !8 = !{i32 1, !"Debug Info Version", i32 3}
 !10 = !DILocation(line: 8, column: 3, scope: !4)
-!11 = !{!12, !12, i64 0}
-!12 = !{!"int", !13, i64 0}
-!13 = !{!"omnipotent char", !14, i64 0}
-!14 = !{!"Simple C/C++ TBAA"}
 !15 = !DILocation(line: 17, column: 8, scope: !16)
 !16 = distinct !DILexicalBlock(line: 17, column: 8, file: !1, scope: !17)
 !17 = distinct !DILexicalBlock(line: 17, column: 8, file: !1, scope: !18)
 !18 = distinct !DILexicalBlock(line: 17, column: 3, file: !1, scope: !4)
 !19 = !DILocation(line: 18, column: 5, scope: !20)
 !20 = distinct !DILexicalBlock(line: 17, column: 27, file: !1, scope: !18)
-!21 = !{!13, !13, i64 0}
 !22 = !DILocation(line: 20, column: 3, scope: !4)
 !23 = !DILocation(line: 21, column: 3, scope: !4)
 !24 = distinct !DICompileUnit(language: DW_LANG_C89, file: !1, emissionKind: NoDebug)

--- a/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-missed.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-missed.ll
@@ -306,7 +306,6 @@ declare i32 @foo(...)
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!9, !10}
-!llvm.ident = !{!11}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, producer: "clang version 3.5.0", isOptimized: true, runtimeVersion: 6, emissionKind: LineTablesOnly, file: !1, enums: !2, retainedTypes: !2, globals: !2, imports: !2)
 !1 = !DIFile(filename: "source.cpp", directory: ".")
@@ -318,7 +317,6 @@ declare i32 @foo(...)
 !8 = distinct !DISubprogram(name: "test_array_bounds", line: 16, isLocal: false, isDefinition: true, virtualIndex: 6, flags: DIFlagPrototyped, isOptimized: true, unit: !0, scopeLine: 16, file: !1, scope: !5, type: !6, retainedNodes: !2)
 !9 = !{i32 2, !"Dwarf Version", i32 2}
 !10 = !{i32 2, !"Debug Info Version", i32 3}
-!11 = !{!"clang version 3.5.0"}
 !12 = !DILocation(line: 3, column: 8, scope: !13)
 !13 = distinct !DILexicalBlock(line: 3, column: 3, file: !1, scope: !4)
 !14 = !{!14, !15, !15}

--- a/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-missed.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-missed.ll
@@ -181,7 +181,7 @@ loop:
   %arrayidx = getelementptr inbounds i32, ptr %A, i64 %iv, !dbg !16
   %0 = trunc i64 %iv to i32, !dbg !16
   %ld = load i32, ptr %arrayidx, align 4
-  store i32 %0, ptr %arrayidx, align 4, !dbg !16, !tbaa !18
+  store i32 %0, ptr %arrayidx, align 4, !dbg !16
   %cmp3 = icmp sle i32 %ld, %Length, !dbg !22
   %iv.next = add nuw nsw i64 %iv, 1, !dbg !12
   %1 = trunc i64 %iv.next to i32
@@ -206,7 +206,7 @@ loop:
   %iv = phi i64 [ %iv.next, %loop ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds i32, ptr %A, i64 %iv, !dbg !30
   %0 = trunc i64 %iv to i32, !dbg !30
-  store i32 %0, ptr %arrayidx, align 4, !dbg !30, !tbaa !18
+  store i32 %0, ptr %arrayidx, align 4, !dbg !30
   %iv.next = add nuw nsw i64 %iv, 1, !dbg !25
   %lftr.wideiv = trunc i64 %iv.next to i32, !dbg !25
   %exitcond = icmp eq i32 %lftr.wideiv, %Length, !dbg !25
@@ -231,12 +231,12 @@ loop.preheader:
 loop:
   %iv = phi i64 [ %iv.next, %loop ], [ 0, %loop.preheader ]
   %arrayidx = getelementptr inbounds i32, ptr %B, i64 %iv, !dbg !35
-  %0 = load i32, ptr %arrayidx, align 4, !dbg !35, !tbaa !18
+  %0 = load i32, ptr %arrayidx, align 4, !dbg !35
   %idxprom1 = sext i32 %0 to i64, !dbg !35
   %arrayidx2 = getelementptr inbounds i32, ptr %A, i64 %idxprom1, !dbg !35
-  %1 = load i32, ptr %arrayidx2, align 4, !dbg !35, !tbaa !18
+  %1 = load i32, ptr %arrayidx2, align 4, !dbg !35
   %arrayidx4 = getelementptr inbounds i32, ptr %A, i64 %iv, !dbg !35
-  store i32 %1, ptr %arrayidx4, align 4, !dbg !35, !tbaa !18
+  store i32 %1, ptr %arrayidx4, align 4, !dbg !35
   %iv.next = add nuw nsw i64 %iv, 1, !dbg !32
   %lftr.wideiv = trunc i64 %iv.next to i32, !dbg !32
   %exitcond = icmp eq i32 %lftr.wideiv, %Length, !dbg !32
@@ -323,10 +323,6 @@ declare i32 @foo(...)
 !15 = !{!"llvm.loop.vectorize.enable", i1 true}
 !16 = !DILocation(line: 4, column: 5, scope: !17)
 !17 = distinct !DILexicalBlock(line: 3, column: 36, file: !1, scope: !13)
-!18 = !{!19, !19, i64 0}
-!19 = !{!"int", !20, i64 0}
-!20 = !{!"omnipotent char", !21, i64 0}
-!21 = !{!"Simple C/C++ TBAA"}
 !22 = !DILocation(line: 5, column: 9, scope: !23)
 !23 = distinct !DILexicalBlock(line: 5, column: 9, file: !1, scope: !17)
 !24 = !DILocation(line: 8, column: 1, scope: !4)

--- a/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-profitable.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-profitable.ll
@@ -22,7 +22,7 @@
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-apple-macosx10.10.0"
 
-define void @do_not_interleave(ptr noalias nocapture readonly %in, ptr noalias nocapture %out, i32 %size) #0 !dbg !4 {
+define void @do_not_interleave(ptr noalias nocapture readonly %in, ptr noalias nocapture %out, i32 %size) !dbg !4 {
 entry:
   %cmp.4 = icmp eq i32 %size, 0, !dbg !10
   br i1 %cmp.4, label %for.end, label %for.body.preheader, !dbg !11
@@ -70,11 +70,8 @@ for.end:
   ret void, !dbg !27
 }
 
-attributes #0 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+mmx,+sse,+sse2" "use-soft-float"="false" }
-
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!7, !8}
-!llvm.ident = !{!9}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 3.8.0 (trunk 250016)", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !2)
 !1 = !DIFile(filename: "vectorization-remarks-profitable.c", directory: "")
@@ -84,7 +81,6 @@ attributes #0 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "fra
 !6 = distinct !DISubprogram(name: "interleave_not_profitable", scope: !1, file: !1, line: 8, type: !5, isLocal: false, isDefinition: true, scopeLine: 8, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !2)
 !7 = !{i32 2, !"Dwarf Version", i32 4}
 !8 = !{i32 2, !"Debug Info Version", i32 3}
-!9 = !{!"clang version 3.8.0 (trunk 250016)"}
 !10 = !DILocation(line: 4, column: 23, scope: !4)
 !11 = !DILocation(line: 4, column: 3, scope: !4)
 !12 = !DILocation(line: 5, column: 17, scope: !4)

--- a/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks.ll
@@ -13,17 +13,17 @@ entry:
   %diff = alloca i32, align 4
   %cb = alloca [16 x i8], align 16
   %cc = alloca [16 x i8], align 16
-  store i32 0, ptr %diff, align 4, !dbg !10, !tbaa !11
+  store i32 0, ptr %diff, align 4, !dbg !10
   br label %for.body, !dbg !15
 
 for.body:
   %indvars.iv = phi i64 [ 0, %entry ], [ %indvars.iv.next, %for.body ]
   %add8 = phi i32 [ 0, %entry ], [ %add, %for.body ], !dbg !19
   %arrayidx = getelementptr inbounds [16 x i8], ptr %cb, i64 0, i64 %indvars.iv, !dbg !19
-  %0 = load i8, ptr %arrayidx, align 1, !dbg !19, !tbaa !21
+  %0 = load i8, ptr %arrayidx, align 1, !dbg !19
   %conv = sext i8 %0 to i32, !dbg !19
   %arrayidx2 = getelementptr inbounds [16 x i8], ptr %cc, i64 0, i64 %indvars.iv, !dbg !19
-  %1 = load i8, ptr %arrayidx2, align 1, !dbg !19, !tbaa !21
+  %1 = load i8, ptr %arrayidx2, align 1, !dbg !19
   %conv3 = sext i8 %1 to i32, !dbg !19
   %sub = sub i32 %conv, %conv3, !dbg !19
   %add = add nsw i32 %sub, %add8, !dbg !19
@@ -32,7 +32,7 @@ for.body:
   br i1 %exitcond, label %for.end, label %for.body, !dbg !15
 
 for.end:
-  store i32 %add, ptr %diff, align 4, !dbg !19, !tbaa !11
+  store i32 %add, ptr %diff, align 4, !dbg !19
   call void @ibar(ptr %diff) #2, !dbg !22
   ret i32 0, !dbg !23
 }
@@ -51,17 +51,12 @@ declare void @ibar(ptr)
 !7 = !{i32 2, !"Dwarf Version", i32 4}
 !8 = !{i32 1, !"Debug Info Version", i32 3}
 !10 = !DILocation(line: 8, column: 3, scope: !4)
-!11 = !{!12, !12, i64 0}
-!12 = !{!"int", !13, i64 0}
-!13 = !{!"omnipotent char", !14, i64 0}
-!14 = !{!"Simple C/C++ TBAA"}
 !15 = !DILocation(line: 17, column: 8, scope: !16)
 !16 = distinct !DILexicalBlock(line: 17, column: 8, file: !1, scope: !17)
 !17 = distinct !DILexicalBlock(line: 17, column: 8, file: !1, scope: !18)
 !18 = distinct !DILexicalBlock(line: 17, column: 3, file: !1, scope: !4)
 !19 = !DILocation(line: 18, column: 5, scope: !20)
 !20 = distinct !DILexicalBlock(line: 17, column: 27, file: !1, scope: !18)
-!21 = !{!13, !13, i64 0}
 !22 = !DILocation(line: 20, column: 3, scope: !4)
 !23 = !DILocation(line: 21, column: 3, scope: !4)
 !24 = distinct !DICompileUnit(language: DW_LANG_C89, file: !1, emissionKind: NoDebug)

--- a/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks.ll
@@ -37,10 +37,9 @@ for.end:
   ret i32 0, !dbg !23
 }
 
-declare void @ibar(ptr) #1
+declare void @ibar(ptr)
 
 !llvm.module.flags = !{!7, !8}
-!llvm.ident = !{!9}
 !llvm.dbg.cu = !{!24}
 
 !1 = !DIFile(filename: "vectorization-remarks.c", directory: ".")
@@ -51,7 +50,6 @@ declare void @ibar(ptr) #1
 !6 = !DISubroutineType(types: !2)
 !7 = !{i32 2, !"Dwarf Version", i32 4}
 !8 = !{i32 1, !"Debug Info Version", i32 3}
-!9 = !{!"clang version 3.5.0 "}
 !10 = !DILocation(line: 8, column: 3, scope: !4)
 !11 = !{!12, !12, i64 0}
 !12 = !{!"int", !13, i64 0}

--- a/llvm/test/Transforms/LoopVectorize/conditional-assignment.ll
+++ b/llvm/test/Transforms/LoopVectorize/conditional-assignment.ll
@@ -11,12 +11,12 @@ entry:
 for.body:
   %indvars.iv = phi i64 [ 0, %entry ], [ %indvars.iv.next, %for.inc ]
   %arrayidx = getelementptr inbounds i32, ptr %indices, i64 %indvars.iv, !dbg !12
-  %0 = load i32, ptr %arrayidx, align 4, !dbg !12, !tbaa !14
+  %0 = load i32, ptr %arrayidx, align 4, !dbg !12
   %cmp1 = icmp eq i32 %0, 1024, !dbg !12
   br i1 %cmp1, label %if.then, label %for.inc, !dbg !12
 
 if.then:
-  store i32 0, ptr %arrayidx, align 4, !dbg !18, !tbaa !14
+  store i32 0, ptr %arrayidx, align 4, !dbg !18
   br label %for.inc, !dbg !18
 
 for.inc:
@@ -43,9 +43,5 @@ for.end:
 !11 = distinct !DILexicalBlock(line: 2, column: 3, file: !1, scope: !4)
 !12 = !DILocation(line: 3, column: 9, scope: !13)
 !13 = distinct !DILexicalBlock(line: 3, column: 9, file: !1, scope: !11)
-!14 = !{!15, !15, i64 0}
-!15 = !{!"int", !16, i64 0}
-!16 = !{!"omnipotent char", !17, i64 0}
-!17 = !{!"Simple C/C++ TBAA"}
 !18 = !DILocation(line: 3, column: 29, scope: !13)
 !19 = !DILocation(line: 4, column: 1, scope: !4)

--- a/llvm/test/Transforms/LoopVectorize/conditional-assignment.ll
+++ b/llvm/test/Transforms/LoopVectorize/conditional-assignment.ll
@@ -30,7 +30,6 @@ for.end:
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!7, !8}
-!llvm.ident = !{!9}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C99, producer: "clang version 3.6.0", isOptimized: true, emissionKind: LineTablesOnly, file: !1, enums: !2, retainedTypes: !2, globals: !2, imports: !2)
 !1 = !DIFile(filename: "source.c", directory: ".")
@@ -40,7 +39,6 @@ for.end:
 !6 = !DISubroutineType(types: !2)
 !7 = !{i32 2, !"Dwarf Version", i32 2}
 !8 = !{i32 2, !"Debug Info Version", i32 3}
-!9 = !{!"clang version 3.6.0"}
 !10 = !DILocation(line: 2, column: 8, scope: !11)
 !11 = distinct !DILexicalBlock(line: 2, column: 3, file: !1, scope: !4)
 !12 = !DILocation(line: 3, column: 9, scope: !13)

--- a/llvm/test/Transforms/LoopVectorize/control-flow.ll
+++ b/llvm/test/Transforms/LoopVectorize/control-flow.ll
@@ -50,7 +50,6 @@ end:
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!7, !8}
-!llvm.ident = !{!9}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, producer: "clang version 3.5.0", isOptimized: true, runtimeVersion: 6, emissionKind: LineTablesOnly, file: !1, enums: !2, retainedTypes: !2, globals: !2, imports: !2)
 !1 = !DIFile(filename: "source.cpp", directory: ".")
@@ -60,7 +59,6 @@ end:
 !6 = !DISubroutineType(types: !2)
 !7 = !{i32 2, !"Dwarf Version", i32 2}
 !8 = !{i32 2, !"Debug Info Version", i32 3}
-!9 = !{!"clang version 3.5.0"}
 !10 = !DILocation(line: 3, column: 8, scope: !11)
 !11 = distinct !DILexicalBlock(line: 3, column: 3, file: !1, scope: !4)
 !12 = !DILocation(line: 5, column: 9, scope: !13)

--- a/llvm/test/Transforms/LoopVectorize/control-flow.ll
+++ b/llvm/test/Transforms/LoopVectorize/control-flow.ll
@@ -30,12 +30,12 @@ for.body.preheader:
 for.body:
   %indvars.iv = phi i64 [ %indvars.iv.next, %if.else ], [ 0, %for.body.preheader ]
   %arrayidx = getelementptr inbounds i32, ptr %A, i64 %indvars.iv, !dbg !12
-  %0 = load i32, ptr %arrayidx, align 4, !dbg !12, !tbaa !15
+  %0 = load i32, ptr %arrayidx, align 4, !dbg !12
   %cmp1 = icmp sgt i32 %0, 10, !dbg !12
   br i1 %cmp1, label %end.loopexit, label %if.else, !dbg !12
 
 if.else:
-  store i32 0, ptr %arrayidx, align 4, !dbg !19, !tbaa !15
+  store i32 0, ptr %arrayidx, align 4, !dbg !19
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1, !dbg !10
   %1 = trunc i64 %indvars.iv.next to i32, !dbg !10
   %cmp = icmp slt i32 %1, %Length, !dbg !10
@@ -64,9 +64,5 @@ end:
 !12 = !DILocation(line: 5, column: 9, scope: !13)
 !13 = distinct !DILexicalBlock(line: 5, column: 9, file: !1, scope: !14)
 !14 = distinct !DILexicalBlock(line: 4, column: 3, file: !1, scope: !11)
-!15 = !{!16, !16, i64 0}
-!16 = !{!"int", !17, i64 0}
-!17 = !{!"omnipotent char", !18, i64 0}
-!18 = !{!"Simple C/C++ TBAA"}
 !19 = !DILocation(line: 8, column: 7, scope: !13)
 !20 = !DILocation(line: 12, column: 3, scope: !4)

--- a/llvm/test/Transforms/LoopVectorize/diag-missing-instr-debug-loc.ll
+++ b/llvm/test/Transforms/LoopVectorize/diag-missing-instr-debug-loc.ll
@@ -40,10 +40,10 @@ for.body:
   %a.addr.08 = phi i32 [ %0, %for.body ], [ %a, %for.body.preheader ]
 
   %arrayidx = getelementptr inbounds [0 x i32], ptr @out, i64 0, i64 %indvars.iv, !dbg !10
-  store i32 %a.addr.08, ptr %arrayidx, align 4, !dbg !12, !tbaa !13
+  store i32 %a.addr.08, ptr %arrayidx, align 4, !dbg !12
   %idxprom1 = sext i32 %a.addr.08 to i64, !dbg !17
   %arrayidx2 = getelementptr inbounds [0 x i32], ptr @map, i64 0, i64 %idxprom1, !dbg !17
-  %0 = load i32, ptr %arrayidx2, align 4, !dbg !17, !tbaa !13
+  %0 = load i32, ptr %arrayidx2, align 4, !dbg !17
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1, !dbg !9
   %exitcond = icmp eq i64 %indvars.iv.next, %wide.trip.count, !dbg !9
   br i1 %exitcond, label %for.cond.cleanup, label %for.body, !dbg !9, !llvm.loop !18
@@ -66,9 +66,5 @@ attributes #0 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 !10 = !DILocation(line: 6, column: 5, scope: !6)
 !11 = !DILocation(line: 9, column: 1, scope: !6)
 !12 = !DILocation(line: 6, column: 12, scope: !6)
-!13 = !{!14, !14, i64 0}
-!14 = !{!"int", !15, i64 0}
-!15 = !{!"omnipotent char", !16, i64 0}
-!16 = !{!"Simple C/C++ TBAA"}
 !17 = !DILocation(line: 7, column: 9, scope: !6)
 !18 = distinct !{!18, !9}

--- a/llvm/test/Transforms/LoopVectorize/diag-missing-instr-debug-loc.ll
+++ b/llvm/test/Transforms/LoopVectorize/diag-missing-instr-debug-loc.ll
@@ -53,14 +53,12 @@ attributes #0 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4}
-!llvm.ident = !{!5}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 4.0.0 (trunk 281293) (llvm/trunk 281290)", isOptimized: true, runtimeVersion: 0, emissionKind: NoDebug, enums: !2)
 !1 = !DIFile(filename: "/tmp/s.c", directory: "/tmp")
 !2 = !{}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
 !4 = !{i32 1, !"PIC Level", i32 2}
-!5 = !{!"clang version 4.0.0 (trunk 281293) (llvm/trunk 281290)"}
 !6 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 4, type: !7, isLocal: false, isDefinition: true, scopeLine: 4, flags: DIFlagPrototyped, isOptimized: true, unit: !0, retainedNodes: !2)
 !7 = !DISubroutineType(types: !2)
 !8 = !DILocation(line: 5, column: 21, scope: !6)

--- a/llvm/test/Transforms/LoopVectorize/diag-with-hotness-info-2.ll
+++ b/llvm/test/Transforms/LoopVectorize/diag-with-hotness-info-2.ll
@@ -43,20 +43,20 @@ ph:
 for.body:
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %ph ]
   %arrayidx = getelementptr inbounds i8, ptr %A, i64 %indvars.iv, !dbg !12
-  %0 = load i8, ptr %arrayidx, align 1, !dbg !12, !tbaa !13
+  %0 = load i8, ptr %arrayidx, align 1, !dbg !12
   %arrayidx2 = getelementptr inbounds i8, ptr %B, i64 %indvars.iv, !dbg !16
-  %1 = load i8, ptr %arrayidx2, align 1, !dbg !16, !tbaa !13
+  %1 = load i8, ptr %arrayidx2, align 1, !dbg !16
   %add = add i8 %1, %0, !dbg !17
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1, !dbg !10
   %arrayidx7 = getelementptr inbounds i8, ptr %A, i64 %indvars.iv.next, !dbg !18
-  store i8 %add, ptr %arrayidx7, align 1, !dbg !19, !tbaa !13
+  store i8 %add, ptr %arrayidx7, align 1, !dbg !19
   %arrayidx9 = getelementptr inbounds i8, ptr %D, i64 %indvars.iv, !dbg !20
-  %2 = load i8, ptr %arrayidx9, align 1, !dbg !20, !tbaa !13
+  %2 = load i8, ptr %arrayidx9, align 1, !dbg !20
   %arrayidx12 = getelementptr inbounds i8, ptr %E, i64 %indvars.iv, !dbg !21
-  %3 = load i8, ptr %arrayidx12, align 1, !dbg !21, !tbaa !13
+  %3 = load i8, ptr %arrayidx12, align 1, !dbg !21
   %mul = mul i8 %3, %2, !dbg !22
   %arrayidx16 = getelementptr inbounds i8, ptr %C, i64 %indvars.iv, !dbg !23
-  store i8 %mul, ptr %arrayidx16, align 1, !dbg !24, !tbaa !13
+  store i8 %mul, ptr %arrayidx16, align 1, !dbg !24
   %lftr.wideiv = trunc i64 %indvars.iv.next to i32, !dbg !10
   %exitcond = icmp eq i32 %lftr.wideiv, %N, !dbg !10
   br i1 %exitcond, label %for.cond.cleanup, label %for.body, !dbg !10, !llvm.loop !25, !prof !59
@@ -76,20 +76,20 @@ ph:
 for.body:
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %ph ]
   %arrayidx = getelementptr inbounds i8, ptr %A, i64 %indvars.iv, !dbg !30
-  %0 = load i8, ptr %arrayidx, align 1, !dbg !30, !tbaa !13
+  %0 = load i8, ptr %arrayidx, align 1, !dbg !30
   %arrayidx2 = getelementptr inbounds i8, ptr %B, i64 %indvars.iv, !dbg !31
-  %1 = load i8, ptr %arrayidx2, align 1, !dbg !31, !tbaa !13
+  %1 = load i8, ptr %arrayidx2, align 1, !dbg !31
   %add = add i8 %1, %0, !dbg !32
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1, !dbg !28
   %arrayidx7 = getelementptr inbounds i8, ptr %A, i64 %indvars.iv.next, !dbg !33
-  store i8 %add, ptr %arrayidx7, align 1, !dbg !34, !tbaa !13
+  store i8 %add, ptr %arrayidx7, align 1, !dbg !34
   %arrayidx9 = getelementptr inbounds i8, ptr %D, i64 %indvars.iv, !dbg !35
-  %2 = load i8, ptr %arrayidx9, align 1, !dbg !35, !tbaa !13
+  %2 = load i8, ptr %arrayidx9, align 1, !dbg !35
   %arrayidx12 = getelementptr inbounds i8, ptr %E, i64 %indvars.iv, !dbg !36
-  %3 = load i8, ptr %arrayidx12, align 1, !dbg !36, !tbaa !13
+  %3 = load i8, ptr %arrayidx12, align 1, !dbg !36
   %mul = mul i8 %3, %2, !dbg !37
   %arrayidx16 = getelementptr inbounds i8, ptr %C, i64 %indvars.iv, !dbg !38
-  store i8 %mul, ptr %arrayidx16, align 1, !dbg !39, !tbaa !13
+  store i8 %mul, ptr %arrayidx16, align 1, !dbg !39
   %lftr.wideiv = trunc i64 %indvars.iv.next to i32, !dbg !28
   %exitcond = icmp eq i32 %lftr.wideiv, %N, !dbg !28
   br i1 %exitcond, label %for.cond.cleanup, label %for.body, !dbg !28, !llvm.loop !40, !prof !59
@@ -109,20 +109,20 @@ ph:
 for.body:
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %ph ]
   %arrayidx = getelementptr inbounds i8, ptr %A, i64 %indvars.iv, !dbg !45
-  %0 = load i8, ptr %arrayidx, align 1, !dbg !45, !tbaa !13
+  %0 = load i8, ptr %arrayidx, align 1, !dbg !45
   %arrayidx2 = getelementptr inbounds i8, ptr %B, i64 %indvars.iv, !dbg !46
-  %1 = load i8, ptr %arrayidx2, align 1, !dbg !46, !tbaa !13
+  %1 = load i8, ptr %arrayidx2, align 1, !dbg !46
   %add = add i8 %1, %0, !dbg !47
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1, !dbg !43
   %arrayidx7 = getelementptr inbounds i8, ptr %A, i64 %indvars.iv.next, !dbg !48
-  store i8 %add, ptr %arrayidx7, align 1, !dbg !49, !tbaa !13
+  store i8 %add, ptr %arrayidx7, align 1, !dbg !49
   %arrayidx9 = getelementptr inbounds i8, ptr %D, i64 %indvars.iv, !dbg !50
-  %2 = load i8, ptr %arrayidx9, align 1, !dbg !50, !tbaa !13
+  %2 = load i8, ptr %arrayidx9, align 1, !dbg !50
   %arrayidx12 = getelementptr inbounds i8, ptr %E, i64 %indvars.iv, !dbg !51
-  %3 = load i8, ptr %arrayidx12, align 1, !dbg !51, !tbaa !13
+  %3 = load i8, ptr %arrayidx12, align 1, !dbg !51
   %mul = mul i8 %3, %2, !dbg !52
   %arrayidx16 = getelementptr inbounds i8, ptr %C, i64 %indvars.iv, !dbg !53
-  store i8 %mul, ptr %arrayidx16, align 1, !dbg !54, !tbaa !13
+  store i8 %mul, ptr %arrayidx16, align 1, !dbg !54
   %lftr.wideiv = trunc i64 %indvars.iv.next to i32, !dbg !43
   %exitcond = icmp eq i32 %lftr.wideiv, %N, !dbg !43
   br i1 %exitcond, label %for.cond.cleanup, label %for.body, !dbg !43, !llvm.loop !55
@@ -148,9 +148,6 @@ attributes #0 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "fra
 !10 = !DILocation(line: 2, column: 3, scope: !7)
 !11 = !DILocation(line: 6, column: 1, scope: !7)
 !12 = !DILocation(line: 3, column: 16, scope: !7)
-!13 = !{!14, !14, i64 0}
-!14 = !{!"omnipotent char", !15, i64 0}
-!15 = !{!"Simple C/C++ TBAA"}
 !16 = !DILocation(line: 3, column: 23, scope: !7)
 !17 = !DILocation(line: 3, column: 21, scope: !7)
 !18 = !DILocation(line: 3, column: 5, scope: !7)

--- a/llvm/test/Transforms/LoopVectorize/diag-with-hotness-info-2.ll
+++ b/llvm/test/Transforms/LoopVectorize/diag-with-hotness-info-2.ll
@@ -135,7 +135,6 @@ attributes #0 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "fra
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4, !5}
-!llvm.ident = !{!6}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 3.9.0 (trunk 273572) (llvm/trunk 273585)", isOptimized: true, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !2)
 !1 = !DIFile(filename: "/tmp/s.c", directory: "/tmp")
@@ -143,7 +142,6 @@ attributes #0 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "fra
 !3 = !{i32 2, !"Dwarf Version", i32 2}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"PIC Level", i32 2}
-!6 = !{!"clang version 3.9.0 (trunk 273572) (llvm/trunk 273585)"}
 !7 = distinct !DISubprogram(name: "cold", scope: !1, file: !1, line: 1, type: !8, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: true, unit: !0, retainedNodes: !2)
 !8 = !DISubroutineType(types: !2)
 !9 = !DILocation(line: 2, column: 20, scope: !7)

--- a/llvm/test/Transforms/LoopVectorize/diag-with-hotness-info.ll
+++ b/llvm/test/Transforms/LoopVectorize/diag-with-hotness-info.ll
@@ -57,20 +57,20 @@ ph:
 for.body:
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %ph ]
   %arrayidx = getelementptr inbounds i8, ptr %A, i64 %indvars.iv, !dbg !12
-  %0 = load i8, ptr %arrayidx, align 1, !dbg !12, !tbaa !13
+  %0 = load i8, ptr %arrayidx, align 1, !dbg !12
   %arrayidx2 = getelementptr inbounds i8, ptr %B, i64 %indvars.iv, !dbg !16
-  %1 = load i8, ptr %arrayidx2, align 1, !dbg !16, !tbaa !13
+  %1 = load i8, ptr %arrayidx2, align 1, !dbg !16
   %add = add i8 %1, %0, !dbg !17
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1, !dbg !10
   %arrayidx7 = getelementptr inbounds i8, ptr %A, i64 %indvars.iv.next, !dbg !18
-  store i8 %add, ptr %arrayidx7, align 1, !dbg !19, !tbaa !13
+  store i8 %add, ptr %arrayidx7, align 1, !dbg !19
   %arrayidx9 = getelementptr inbounds i8, ptr %D, i64 %indvars.iv, !dbg !20
-  %2 = load i8, ptr %arrayidx9, align 1, !dbg !20, !tbaa !13
+  %2 = load i8, ptr %arrayidx9, align 1, !dbg !20
   %arrayidx12 = getelementptr inbounds i8, ptr %E, i64 %indvars.iv, !dbg !21
-  %3 = load i8, ptr %arrayidx12, align 1, !dbg !21, !tbaa !13
+  %3 = load i8, ptr %arrayidx12, align 1, !dbg !21
   %mul = mul i8 %3, %2, !dbg !22
   %arrayidx16 = getelementptr inbounds i8, ptr %C, i64 %indvars.iv, !dbg !23
-  store i8 %mul, ptr %arrayidx16, align 1, !dbg !24, !tbaa !13
+  store i8 %mul, ptr %arrayidx16, align 1, !dbg !24
   %lftr.wideiv = trunc i64 %indvars.iv.next to i32, !dbg !10
   %exitcond = icmp eq i32 %lftr.wideiv, %N, !dbg !10
   br i1 %exitcond, label %for.cond.cleanup, label %for.body, !dbg !10, !llvm.loop !25, !prof !59
@@ -90,20 +90,20 @@ ph:
 for.body:
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %ph ]
   %arrayidx = getelementptr inbounds i8, ptr %A, i64 %indvars.iv, !dbg !30
-  %0 = load i8, ptr %arrayidx, align 1, !dbg !30, !tbaa !13
+  %0 = load i8, ptr %arrayidx, align 1, !dbg !30
   %arrayidx2 = getelementptr inbounds i8, ptr %B, i64 %indvars.iv, !dbg !31
-  %1 = load i8, ptr %arrayidx2, align 1, !dbg !31, !tbaa !13
+  %1 = load i8, ptr %arrayidx2, align 1, !dbg !31
   %add = add i8 %1, %0, !dbg !32
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1, !dbg !28
   %arrayidx7 = getelementptr inbounds i8, ptr %A, i64 %indvars.iv.next, !dbg !33
-  store i8 %add, ptr %arrayidx7, align 1, !dbg !34, !tbaa !13
+  store i8 %add, ptr %arrayidx7, align 1, !dbg !34
   %arrayidx9 = getelementptr inbounds i8, ptr %D, i64 %indvars.iv, !dbg !35
-  %2 = load i8, ptr %arrayidx9, align 1, !dbg !35, !tbaa !13
+  %2 = load i8, ptr %arrayidx9, align 1, !dbg !35
   %arrayidx12 = getelementptr inbounds i8, ptr %E, i64 %indvars.iv, !dbg !36
-  %3 = load i8, ptr %arrayidx12, align 1, !dbg !36, !tbaa !13
+  %3 = load i8, ptr %arrayidx12, align 1, !dbg !36
   %mul = mul i8 %3, %2, !dbg !37
   %arrayidx16 = getelementptr inbounds i8, ptr %C, i64 %indvars.iv, !dbg !38
-  store i8 %mul, ptr %arrayidx16, align 1, !dbg !39, !tbaa !13
+  store i8 %mul, ptr %arrayidx16, align 1, !dbg !39
   %lftr.wideiv = trunc i64 %indvars.iv.next to i32, !dbg !28
   %exitcond = icmp eq i32 %lftr.wideiv, %N, !dbg !28
   br i1 %exitcond, label %for.cond.cleanup, label %for.body, !dbg !28, !llvm.loop !40, !prof !59
@@ -123,20 +123,20 @@ for.cond.cleanup:
 for.body:
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds i8, ptr %A, i64 %indvars.iv, !dbg !45
-  %0 = load i8, ptr %arrayidx, align 1, !dbg !45, !tbaa !13
+  %0 = load i8, ptr %arrayidx, align 1, !dbg !45
   %arrayidx2 = getelementptr inbounds i8, ptr %B, i64 %indvars.iv, !dbg !46
-  %1 = load i8, ptr %arrayidx2, align 1, !dbg !46, !tbaa !13
+  %1 = load i8, ptr %arrayidx2, align 1, !dbg !46
   %add = add i8 %1, %0, !dbg !47
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1, !dbg !43
   %arrayidx7 = getelementptr inbounds i8, ptr %A, i64 %indvars.iv.next, !dbg !48
-  store i8 %add, ptr %arrayidx7, align 1, !dbg !49, !tbaa !13
+  store i8 %add, ptr %arrayidx7, align 1, !dbg !49
   %arrayidx9 = getelementptr inbounds i8, ptr %D, i64 %indvars.iv, !dbg !50
-  %2 = load i8, ptr %arrayidx9, align 1, !dbg !50, !tbaa !13
+  %2 = load i8, ptr %arrayidx9, align 1, !dbg !50
   %arrayidx12 = getelementptr inbounds i8, ptr %E, i64 %indvars.iv, !dbg !51
-  %3 = load i8, ptr %arrayidx12, align 1, !dbg !51, !tbaa !13
+  %3 = load i8, ptr %arrayidx12, align 1, !dbg !51
   %mul = mul i8 %3, %2, !dbg !52
   %arrayidx16 = getelementptr inbounds i8, ptr %C, i64 %indvars.iv, !dbg !53
-  store i8 %mul, ptr %arrayidx16, align 1, !dbg !54, !tbaa !13
+  store i8 %mul, ptr %arrayidx16, align 1, !dbg !54
   %lftr.wideiv = trunc i64 %indvars.iv.next to i32, !dbg !43
   %exitcond = icmp eq i32 %lftr.wideiv, %N, !dbg !43
   br i1 %exitcond, label %for.cond.cleanup, label %for.body, !dbg !43, !llvm.loop !55
@@ -159,9 +159,6 @@ attributes #0 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "fra
 !10 = !DILocation(line: 2, column: 3, scope: !7)
 !11 = !DILocation(line: 6, column: 1, scope: !7)
 !12 = !DILocation(line: 3, column: 16, scope: !7)
-!13 = !{!14, !14, i64 0}
-!14 = !{!"omnipotent char", !15, i64 0}
-!15 = !{!"Simple C/C++ TBAA"}
 !16 = !DILocation(line: 3, column: 23, scope: !7)
 !17 = !DILocation(line: 3, column: 21, scope: !7)
 !18 = !DILocation(line: 3, column: 5, scope: !7)

--- a/llvm/test/Transforms/LoopVectorize/diag-with-hotness-info.ll
+++ b/llvm/test/Transforms/LoopVectorize/diag-with-hotness-info.ll
@@ -146,7 +146,6 @@ attributes #0 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "fra
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4, !5}
-!llvm.ident = !{!6}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 3.9.0 (trunk 273572) (llvm/trunk 273585)", isOptimized: true, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !2)
 !1 = !DIFile(filename: "/tmp/s.c", directory: "/tmp")
@@ -154,7 +153,6 @@ attributes #0 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "fra
 !3 = !{i32 2, !"Dwarf Version", i32 2}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"PIC Level", i32 2}
-!6 = !{!"clang version 3.9.0 (trunk 273572) (llvm/trunk 273585)"}
 !7 = distinct !DISubprogram(name: "cold", scope: !1, file: !1, line: 1, type: !8, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: true, unit: !0, retainedNodes: !2)
 !8 = !DISubroutineType(types: !2)
 !9 = !DILocation(line: 2, column: 20, scope: !7)

--- a/llvm/test/Transforms/LoopVectorize/explicit_outer_detection.ll
+++ b/llvm/test/Transforms/LoopVectorize/explicit_outer_detection.ll
@@ -51,10 +51,10 @@ inner.body:
   %indvars.iv = phi i64 [ 0, %inner.ph ], [ %indvars.iv.next, %inner.body ]
   %2 = add nsw i64 %indvars.iv, %1
   %arrayidx = getelementptr inbounds i32, ptr %b, i64 %2
-  %3 = load i32, ptr %arrayidx, align 4, !tbaa !2
+  %3 = load i32, ptr %arrayidx, align 4
   %mul8 = mul nsw i32 %3, %3
   %arrayidx12 = getelementptr inbounds i32, ptr %a, i64 %2
-  store i32 %mul8, ptr %arrayidx12, align 4, !tbaa !2
+  store i32 %mul8, ptr %arrayidx12, align 4
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond = icmp eq i64 %indvars.iv.next, %wide.trip.count
   br i1 %exitcond, label %outer.inc, label %inner.body
@@ -99,10 +99,10 @@ inner.body:
   %indvars.iv = phi i64 [ 0, %inner.ph ], [ %indvars.iv.next, %inner.body ]
   %2 = add nsw i64 %indvars.iv, %1
   %arrayidx = getelementptr inbounds i32, ptr %b, i64 %2
-  %3 = load i32, ptr %arrayidx, align 4, !tbaa !2
+  %3 = load i32, ptr %arrayidx, align 4
   %mul8 = mul nsw i32 %3, %3
   %arrayidx12 = getelementptr inbounds i32, ptr %a, i64 %2
-  store i32 %mul8, ptr %arrayidx12, align 4, !tbaa !2
+  store i32 %mul8, ptr %arrayidx12, align 4
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond = icmp eq i64 %indvars.iv.next, %wide.trip.count
   br i1 %exitcond, label %outer.inc, label %inner.body
@@ -149,10 +149,10 @@ inner.body:
   %indvars.iv = phi i64 [ 0, %inner.ph ], [ %indvars.iv.next, %inner.body ]
   %2 = add nsw i64 %indvars.iv, %1
   %arrayidx = getelementptr inbounds i32, ptr %b, i64 %2
-  %3 = load i32, ptr %arrayidx, align 4, !tbaa !2
+  %3 = load i32, ptr %arrayidx, align 4
   %mul8 = mul nsw i32 %3, %3
   %arrayidx12 = getelementptr inbounds i32, ptr %a, i64 %2
-  store i32 %mul8, ptr %arrayidx12, align 4, !tbaa !2
+  store i32 %mul8, ptr %arrayidx12, align 4
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond = icmp eq i64 %indvars.iv.next, %wide.trip.count
   br i1 %exitcond, label %outer.inc, label %inner.body
@@ -199,10 +199,10 @@ inner.body:
   %indvars.iv = phi i64 [ 0, %inner.ph ], [ %indvars.iv.next, %inner.body ]
   %2 = add nsw i64 %indvars.iv, %1
   %arrayidx = getelementptr inbounds i32, ptr %b, i64 %2
-  %3 = load i32, ptr %arrayidx, align 4, !tbaa !2
+  %3 = load i32, ptr %arrayidx, align 4
   %mul8 = mul nsw i32 %3, %3
   %arrayidx12 = getelementptr inbounds i32, ptr %a, i64 %2
-  store i32 %mul8, ptr %arrayidx12, align 4, !tbaa !2
+  store i32 %mul8, ptr %arrayidx12, align 4
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond = icmp eq i64 %indvars.iv.next, %wide.trip.count
   br i1 %exitcond, label %outer.inc, label %inner.body
@@ -216,10 +216,6 @@ for.end15:
   ret void
 }
 
-!2 = !{!3, !3, i64 0}
-!3 = !{!"int", !4, i64 0}
-!4 = !{!"omnipotent char", !5, i64 0}
-!5 = !{!"Simple C/C++ TBAA"}
 ; Case 1
 !6 = distinct !{!6, !7, !8}
 !7 = !{!"llvm.loop.vectorize.width", i32 4}

--- a/llvm/test/Transforms/LoopVectorize/explicit_outer_detection.ll
+++ b/llvm/test/Transforms/LoopVectorize/explicit_outer_detection.ll
@@ -216,11 +216,6 @@ for.end15:
   ret void
 }
 
-!llvm.module.flags = !{!0}
-!llvm.ident = !{!1}
-
-!0 = !{i32 1, !"wchar_size", i32 4}
-!1 = !{!"clang version 6.0.0"}
 !2 = !{!3, !3, i64 0}
 !3 = !{!"int", !4, i64 0}
 !4 = !{!"omnipotent char", !5, i64 0}

--- a/llvm/test/Transforms/LoopVectorize/explicit_outer_nonuniform_inner.ll
+++ b/llvm/test/Transforms/LoopVectorize/explicit_outer_nonuniform_inner.ll
@@ -49,10 +49,10 @@ inner.body:
   %indvars.iv35 = phi i64 [ %indvars.iv38, %inner.ph ], [ %indvars.iv.next36, %inner.body ]
   %2 = add nsw i64 %indvars.iv35, %1
   %arrayidx = getelementptr inbounds i32, ptr %b, i64 %2
-  %3 = load i32, ptr %arrayidx, align 4, !tbaa !2
+  %3 = load i32, ptr %arrayidx, align 4
   %mul8 = mul nsw i32 %3, %3
   %arrayidx12 = getelementptr inbounds i32, ptr %a, i64 %2
-  store i32 %mul8, ptr %arrayidx12, align 4, !tbaa !2
+  store i32 %mul8, ptr %arrayidx12, align 4
   %indvars.iv.next36 = add nuw nsw i64 %indvars.iv35, 1
   %exitcond = icmp eq i64 %indvars.iv.next36, %wide.trip.count
   br i1 %exitcond, label %outer.inc, label %inner.body
@@ -96,10 +96,10 @@ inner.body:
   %indvars.iv = phi i64 [ 0, %inner.ph ], [ %indvars.iv.next, %inner.body ]
   %2 = add nsw i64 %indvars.iv, %1
   %arrayidx = getelementptr inbounds i32, ptr %b, i64 %2
-  %3 = load i32, ptr %arrayidx, align 4, !tbaa !2
+  %3 = load i32, ptr %arrayidx, align 4
   %mul8 = mul nsw i32 %3, %3
   %arrayidx12 = getelementptr inbounds i32, ptr %a, i64 %2
-  store i32 %mul8, ptr %arrayidx12, align 4, !tbaa !2
+  store i32 %mul8, ptr %arrayidx12, align 4
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond = icmp eq i64 %indvars.iv.next, %indvars.iv38
   br i1 %exitcond, label %outer.inc, label %inner.body
@@ -142,10 +142,10 @@ inner.body:
   %indvars.iv36 = phi i64 [ 0, %inner.ph ], [ %indvars.iv.next37, %inner.body ]
   %2 = add nsw i64 %indvars.iv36, %1
   %arrayidx = getelementptr inbounds i32, ptr %b, i64 %2
-  %3 = load i32, ptr %arrayidx, align 4, !tbaa !2
+  %3 = load i32, ptr %arrayidx, align 4
   %mul8 = mul nsw i32 %3, %3
   %arrayidx12 = getelementptr inbounds i32, ptr %a, i64 %2
-  store i32 %mul8, ptr %arrayidx12, align 4, !tbaa !2
+  store i32 %mul8, ptr %arrayidx12, align 4
   %indvars.iv.next37 = add nuw nsw i64 %indvars.iv36, %indvars.iv39
   %cmp2 = icmp slt i64 %indvars.iv.next37, %0
   br i1 %cmp2, label %inner.body, label %for.inc14
@@ -159,10 +159,6 @@ for.end15:
   ret void
 }
 
-!2 = !{!3, !3, i64 0}
-!3 = !{!"int", !4, i64 0}
-!4 = !{!"omnipotent char", !5, i64 0}
-!5 = !{!"Simple C/C++ TBAA"}
 !6 = distinct !{!6, !7, !8}
 !7 = !{!"llvm.loop.vectorize.width", i32 8}
 !8 = !{!"llvm.loop.vectorize.enable", i1 true}

--- a/llvm/test/Transforms/LoopVectorize/explicit_outer_nonuniform_inner.ll
+++ b/llvm/test/Transforms/LoopVectorize/explicit_outer_nonuniform_inner.ll
@@ -159,11 +159,6 @@ for.end15:
   ret void
 }
 
-!llvm.module.flags = !{!0}
-!llvm.ident = !{!1}
-
-!0 = !{i32 1, !"wchar_size", i32 4}
-!1 = !{!"clang version 6.0.0"}
 !2 = !{!3, !3, i64 0}
 !3 = !{!"int", !4, i64 0}
 !4 = !{!"omnipotent char", !5, i64 0}

--- a/llvm/test/Transforms/LoopVectorize/explicit_outer_uniform_diverg_branch.ll
+++ b/llvm/test/Transforms/LoopVectorize/explicit_outer_uniform_diverg_branch.ll
@@ -43,7 +43,7 @@ outer.body:
   %indvars.iv42 = phi i64 [ 0, %outer.ph ], [ %indvars.iv.next43, %outer.inc ]
   %1 = mul nsw i64 %indvars.iv42, %0
   %arrayidx = getelementptr inbounds i32, ptr %b, i64 %1
-  %2 = load i32, ptr %arrayidx, align 4, !tbaa !2
+  %2 = load i32, ptr %arrayidx, align 4
   br i1 %brmerge, label %outer.inc, label %inner.ph ; Supported uniform branch
 
 inner.ph:
@@ -53,10 +53,10 @@ inner.body:
   %indvars.iv = phi i64 [ %indvars.iv.next, %inner.body ], [ 0, %inner.ph ]
   %3 = add nsw i64 %indvars.iv, %1
   %arrayidx7 = getelementptr inbounds i32, ptr %b, i64 %3
-  %4 = load i32, ptr %arrayidx7, align 4, !tbaa !2
+  %4 = load i32, ptr %arrayidx7, align 4
   %mul12 = mul nsw i32 %4, %4
   %arrayidx16 = getelementptr inbounds i32, ptr %a, i64 %3
-  store i32 %mul12, ptr %arrayidx16, align 4, !tbaa !2
+  store i32 %mul12, ptr %arrayidx16, align 4
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond = icmp eq i64 %indvars.iv.next, %M64
   br i1 %exitcond, label %outer.inc, label %inner.body
@@ -93,7 +93,7 @@ outer.body:
   %indvars.iv42 = phi i64 [ 0, %outer.ph ], [ %indvars.iv.next43, %outer.inc ]
   %1 = mul nsw i64 %indvars.iv42, %0
   %arrayidx = getelementptr inbounds i32, ptr %b, i64 %1
-  %2 = load i32, ptr %arrayidx, align 4, !tbaa !2
+  %2 = load i32, ptr %arrayidx, align 4
   %cmp1 = icmp ne i32 %2, 0 ; Divergent condition
   %brmerge = or i1 %cmp1, %cmp337 ; Divergent condition
   br i1 %brmerge, label %outer.inc, label %inner.ph ; Unsupported divergent branch.
@@ -105,10 +105,10 @@ inner.body:
   %indvars.iv = phi i64 [ %indvars.iv.next, %inner.body ], [ 0, %inner.ph ]
   %3 = add nsw i64 %indvars.iv, %1
   %arrayidx7 = getelementptr inbounds i32, ptr %b, i64 %3
-  %4 = load i32, ptr %arrayidx7, align 4, !tbaa !2
+  %4 = load i32, ptr %arrayidx7, align 4
   %mul12 = mul nsw i32 %4, %4
   %arrayidx16 = getelementptr inbounds i32, ptr %a, i64 %3
-  store i32 %mul12, ptr %arrayidx16, align 4, !tbaa !2
+  store i32 %mul12, ptr %arrayidx16, align 4
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond = icmp eq i64 %indvars.iv.next, %M64
   br i1 %exitcond, label %outer.inc, label %inner.body
@@ -122,10 +122,6 @@ for.end19:
   ret void
 }
 
-!2 = !{!3, !3, i64 0}
-!3 = !{!"int", !4, i64 0}
-!4 = !{!"omnipotent char", !5, i64 0}
-!5 = !{!"Simple C/C++ TBAA"}
 !6 = distinct !{!6, !7, !8}
 !7 = !{!"llvm.loop.vectorize.width", i32 8}
 !8 = !{!"llvm.loop.vectorize.enable", i1 true}

--- a/llvm/test/Transforms/LoopVectorize/explicit_outer_uniform_diverg_branch.ll
+++ b/llvm/test/Transforms/LoopVectorize/explicit_outer_uniform_diverg_branch.ll
@@ -122,11 +122,6 @@ for.end19:
   ret void
 }
 
-!llvm.module.flags = !{!0}
-!llvm.ident = !{!1}
-
-!0 = !{i32 1, !"wchar_size", i32 4}
-!1 = !{!"clang version 6.0.0"}
 !2 = !{!3, !3, i64 0}
 !3 = !{!"int", !4, i64 0}
 !4 = !{!"omnipotent char", !5, i64 0}

--- a/llvm/test/Transforms/LoopVectorize/fix-reduction-dbg.ll
+++ b/llvm/test/Transforms/LoopVectorize/fix-reduction-dbg.ll
@@ -57,17 +57,12 @@ for.body:
 }
 
 !llvm.dbg.cu = !{!0}
-!llvm.module.flags = !{!3, !4, !5, !6}
-!llvm.ident = !{!7}
+!llvm.module.flags = !{!4}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "", isOptimized: true, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !2, nameTableKind: None)
 !1 = !DIFile(filename: "src.cpp", directory: "")
 !2 = !{}
-!3 = !{i32 2, !"CodeView", i32 1}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
-!5 = !{i32 1, !"wchar_size", i32 2}
-!6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!""}
 !8 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !9, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
 !9 = !DISubroutineType(types: !2)
 !10 = !DILocation(line: 5, scope: !8)

--- a/llvm/test/Transforms/LoopVectorize/fix-reduction-dbg.ll
+++ b/llvm/test/Transforms/LoopVectorize/fix-reduction-dbg.ll
@@ -49,7 +49,7 @@ for.body:
   %indvars.iv = phi i64 [ 0, %for.body.preheader ], [ %indvars.iv.next, %for.body ]
   %ret.09 = phi i32 [ %count, %for.body.preheader ], [ %add, %for.body ]
   %arrayidx = getelementptr inbounds i32, ptr %bar, i64 %indvars.iv, !dbg !11
-  %0 = load i32, ptr %arrayidx, align 4, !dbg !11, !tbaa !15
+  %0 = load i32, ptr %arrayidx, align 4, !dbg !11
   %add = add nsw i32 %0, %ret.09, !dbg !12
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1, !dbg !10
   %exitcond = icmp eq i64 %indvars.iv.next, %wide.trip.count, !dbg !10
@@ -70,9 +70,5 @@ for.body:
 !12 = !DILocation(line: 7, scope: !8)
 !13 = !DILocation(line: 10, scope: !8)
 !14 = !DILocation(line: 0, scope: !8)
-!15 = !{!16, !16, i64 0}
-!16 = !{!"int", !17, i64 0}
-!17 = !{!"omnipotent char", !18, i64 0}
-!18 = !{!"Simple C++ TBAA"}
 !19 = distinct !{!19, !10, !20}
 !20 = !DILocation(line: 8, scope: !8)

--- a/llvm/test/Transforms/LoopVectorize/incorrect-dom-info.ll
+++ b/llvm/test/Transforms/LoopVectorize/incorrect-dom-info.ll
@@ -5,7 +5,7 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 @PL_utf8skip = external constant [0 x i8]
 
-define void @Perl_pp_quotemeta(i1 %arg) #0 {
+define void @Perl_pp_quotemeta(i1 %arg) {
   %len = alloca i64, align 8
   br i1 %arg, label %2, label %1
 
@@ -133,9 +133,3 @@ thread-pre-split5:
 ; <label>:
   ret void
 }
-
-attributes #0 = { "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "use-soft-float"="false" }
-
-!llvm.ident = !{!0}
-
-!0 = !{!"clang version 3.6.0 "}

--- a/llvm/test/Transforms/LoopVectorize/middle-block-dbg.ll
+++ b/llvm/test/Transforms/LoopVectorize/middle-block-dbg.ll
@@ -67,17 +67,14 @@ for.body:
 }
 
 !llvm.dbg.cu = !{!0}
-!llvm.module.flags = !{!3, !4, !5, !6}
-!llvm.ident = !{!7}
+!llvm.module.flags = !{!3, !4, !6}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (https://github.com/llvm/llvm-project.git 045b8544fd2c4e14f7e72e0df2bc681d823b0838)", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None)
 !1 = !DIFile(filename: "vec.cpp", directory: "C:\5CUsers\5Cgbhyamso\5Cdev\5Cllvm\5Csamples", checksumkind: CSK_MD5, checksum: "fed997f50117f5514a69caf1c2fb2c49")
 !2 = !{}
 !3 = !{i32 2, !"CodeView", i32 1}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
-!5 = !{i32 1, !"wchar_size", i32 2}
 !6 = !{i32 7, !"PIC Level", i32 2}
-!7 = !{!"clang version 9.0.0 (https://github.com/llvm/llvm-project.git 045b8544fd2c4e14f7e72e0df2bc681d823b0838)"}
 !8 = distinct !DISubprogram(name: "a", linkageName: "?a@@YAXXZ", scope: !1, file: !1, line: 3, type: !9, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
 !9 = !DISubroutineType(types: !10)
 !10 = !{null}

--- a/llvm/test/Transforms/LoopVectorize/mixed-precision-remarks.ll
+++ b/llvm/test/Transforms/LoopVectorize/mixed-precision-remarks.ll
@@ -54,13 +54,12 @@ for.cond.cleanup:
 }
 
 !llvm.dbg.cu = !{!0}
-!llvm.module.flags = !{!3, !4}
+!llvm.module.flags = !{!3}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 12.0.0", isOptimized: true, runtimeVersion: 0, emissionKind: NoDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
 !1 = !DIFile(filename: "mixed-precision.c", directory: "/tmp/mixed-precision.c")
 !2 = !{}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
-!4 = !{i32 1, !"wchar_size", i32 4}
 !6 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
 !7 = distinct !DISubprogram(name: "g", scope: !1, file: !1, line: 5, type: !8, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
 !8 = !DISubroutineType(types: !2)

--- a/llvm/test/Transforms/LoopVectorize/no_array_bounds.ll
+++ b/llvm/test/Transforms/LoopVectorize/no_array_bounds.ll
@@ -67,7 +67,6 @@ for.end15:
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!7, !8}
-!llvm.ident = !{!9}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, producer: "clang version 3.5.0", isOptimized: true, emissionKind: LineTablesOnly, file: !1, enums: !2, retainedTypes: !2, globals: !2, imports: !2)
 !1 = !DIFile(filename: "no_array_bounds.cpp", directory: ".")
@@ -77,7 +76,6 @@ for.end15:
 !6 = !DISubroutineType(types: !2)
 !7 = !{i32 2, !"Dwarf Version", i32 2}
 !8 = !{i32 2, !"Debug Info Version", i32 3}
-!9 = !{!"clang version 3.5.0"}
 !10 = !DILocation(line: 4, column: 8, scope: !11)
 !11 = distinct !DILexicalBlock(line: 4, column: 3, file: !1, scope: !4)
 !12 = !{!12, !13}

--- a/llvm/test/Transforms/LoopVectorize/no_switch.ll
+++ b/llvm/test/Transforms/LoopVectorize/no_switch.ll
@@ -60,7 +60,6 @@ for.end:
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!7, !8}
-!llvm.ident = !{!9}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, producer: "clang version 3.5.0", isOptimized: true, runtimeVersion: 6, emissionKind: LineTablesOnly, file: !1, enums: !2, retainedTypes: !2, globals: !2, imports: !2)
 !1 = !DIFile(filename: "source.cpp", directory: ".")
@@ -70,7 +69,6 @@ for.end:
 !6 = !DISubroutineType(types: !2)
 !7 = !{i32 2, !"Dwarf Version", i32 2}
 !8 = !{i32 2, !"Debug Info Version", i32 3}
-!9 = !{!"clang version 3.5.0"}
 !10 = !DILocation(line: 3, column: 8, scope: !11)
 !11 = distinct !DILexicalBlock(line: 3, column: 3, file: !1, scope: !4)
 !12 = !{!12, !13, !13}

--- a/llvm/test/Transforms/LoopVectorize/no_switch_disable_vectorization.ll
+++ b/llvm/test/Transforms/LoopVectorize/no_switch_disable_vectorization.ll
@@ -64,7 +64,6 @@ for.end:
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!7, !8}
-!llvm.ident = !{!9}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, producer: "clang version 3.5.0", isOptimized: true, runtimeVersion: 6, emissionKind: LineTablesOnly, file: !1, enums: !2, retainedTypes: !2, globals: !2, imports: !2)
 !1 = !DIFile(filename: "source.cpp", directory: ".")
@@ -74,7 +73,6 @@ for.end:
 !6 = !DISubroutineType(types: !2)
 !7 = !{i32 2, !"Dwarf Version", i32 2}
 !8 = !{i32 2, !"Debug Info Version", i32 3}
-!9 = !{!"clang version 3.5.0"}
 !10 = !DILocation(line: 3, column: 8, scope: !11)
 !11 = distinct !DILexicalBlock(line: 3, column: 3, file: !1, scope: !4)
 !12 = !{!12, !13, !13}

--- a/llvm/test/Transforms/LoopVectorize/unsafe-dep-remark.ll
+++ b/llvm/test/Transforms/LoopVectorize/unsafe-dep-remark.ll
@@ -45,14 +45,12 @@ for.cond.cleanup:
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4}
-!llvm.ident = !{!5}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 3.9.0 ", isOptimized: true, runtimeVersion: 0, emissionKind: NoDebug, enums: !2)
 !1 = !DIFile(filename: "/tmp/kk.c", directory: "/tmp")
 !2 = !{}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
 !4 = !{i32 1, !"PIC Level", i32 2}
-!5 = !{!"clang version 3.9.0 "}
 !6 = distinct !DISubprogram(name: "success", scope: !1, file: !1, line: 1, type: !7, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: true, unit: !0, retainedNodes: !2)
 !7 = !DISubroutineType(types: !2)
 !8 = !DILocation(line: 2, column: 20, scope: !6)


### PR DESCRIPTION
While in this area I also removed unnecessary annotations for wchar_size and also cleaned up some more function attributes.