### PR TITLE
[InstCombine] fold fabs(uitofp(i16 a) - uitofp(i16 b)) < 1.0 to a == b

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8787,6 +8787,7 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I, InstCombinerImpl &IC) {
 
   FCmpInst::Predicate Pred = I.getPredicate();
   bool IsStrictLt = Pred == FCmpInst::FCMP_OLT || Pred == FCmpInst::FCMP_ULT;
+  bool IsLe = Pred == FCmpInst::FCMP_OLE || Pred == FCmpInst::FCMP_ULE;
   bool IsStrictGt = Pred == FCmpInst::FCMP_OGT || Pred == FCmpInst::FCMP_UGT;
   bool IsGe = Pred == FCmpInst::FCMP_OGE || Pred == FCmpInst::FCMP_UGE;
   if (!IsStrictLt && !IsStrictGt && !IsGe)
@@ -8804,6 +8805,8 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I, InstCombinerImpl &IC) {
     return nullptr;
   if (IsGe && Cmp == APFloat::cmpGreaterThan)
     return nullptr;
+  if (IsLe && Cmp == APFloat::cmpGreaterThan)
+    return nullptr;
   if (IsStrictGt && Cmp != APFloat::cmpLessThan)
     return nullptr;
 
@@ -8817,12 +8820,18 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I, InstCombinerImpl &IC) {
   if (A->getType() != B->getType())
     return nullptr;
 
-  auto *FPCast = cast<CastInst>(cast<Instruction>(FAbsArg)->getOperand(0));
-  if (!IC.isKnownExactCastIntToFP(*FPCast))
+  auto *FPCastOp0 = cast<CastInst>(cast<Instruction>(FAbsArg)->getOperand(0));
+  auto *FPCastOp1 = cast<CastInst>(cast<Instruction>(FAbsArg)->getOperand(1));
+  bool is_signed = FPCastOp0->getOpcode() == CastInst::SIToFP &&
+                   FPCastOp1->getOpcode() == CastInst::SIToFP;
+  Type *FPTy = FPCastOp0->getType();
+  if (!IC.canBeCastedExactlyIntToFP(FPCastOp0->getOperand(0), FPTy, is_signed,
+                                    &I) ||
+      !IC.canBeCastedExactlyIntToFP(FPCastOp1->getOperand(0), FPTy, is_signed,
+                                    &I))
     return nullptr;
-
   ICmpInst::Predicate ResultPred =
-      (IsStrictLt) ? ICmpInst::ICMP_EQ : ICmpInst::ICMP_NE;
+      IsStrictLt ? ICmpInst::ICMP_EQ : ICmpInst::ICMP_NE;
   return new ICmpInst(ResultPred, A, B);
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8776,7 +8776,7 @@ static Instruction *foldFCmpFSubIntoFCmp(FCmpInst &I, Instruction *LHSI,
 //    fabs(..) >= C where C >= 1.0 -> a != b
 ///
 /// The same logic applies to sitofp.
-static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I) {
+static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I, InstCombinerImpl &IC) {
   Value *FAbsArg;
   if (!match(I.getOperand(0), m_FAbs(m_Value(FAbsArg))))
     return nullptr;
@@ -8817,19 +8817,9 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I) {
   if (A->getType() != B->getType())
     return nullptr;
 
-  // The int-to-fp cast must be exact (no precision loss).
-  // For uitofp: we need MantissaWidth >= IntWidth (all bits representable).
-  // For sitofp: we need MantissaWidth >= IntWidth (sign bit + magnitude).
-  // getFPMantissaWidth() returns the number of bits in the mantissa including
-  // the implicit leading 1 bit (i.e., the precision).
-  Type *FPTy = I.getOperand(0)->getType()->getScalarType();
-  int MantissaWidth = FPTy->getFPMantissaWidth();
-  if (MantissaWidth < 0)
-    return nullptr; // Unknown FP type.
-  unsigned IntWidth = A->getType()->getScalarSizeInBits();
-  // For unsigned: need MantissaWidth >= IntWidth
-  // For signed: need MantissaWidth >= IntWidth (to represent most negative val)
-  if ((unsigned)MantissaWidth < IntWidth)
+  Value *Src = I.getOperand(0);
+  auto *FPCast = cast<CastInst>(cast<Instruction>(FAbsArg)->getOperand(0));
+  if (!IC.isKnownExactCastIntToFP(*FPCast))
     return nullptr;
 
   ICmpInst::Predicate ResultPred =
@@ -9150,7 +9140,7 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
   if (Instruction *R = foldFabsWithFcmpZero(I, *this))
     return R;
 
-  if (Instruction *R = foldFCmpFAbsFSubIntToFP(I))
+  if (Instruction *R = foldFCmpFAbsFSubIntToFP(I, *this))
     return R;
 
   if (Instruction *R = foldSqrtWithFcmpZero(I, *this))

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8766,16 +8766,14 @@ static Instruction *foldFCmpFSubIntoFCmp(FCmpInst &I, Instruction *LHSI,
 }
 
 /// Fold: fabs(uitofp(a) - uitofp(b)) pred C --> a == b
-/// where 'pred' is olt, ole, ult, or ule, and C is a positive, Non-NaN float
+/// where 'pred' is olt, ult, ogt, ugt, oge or uge and C is a positive, Non-NaN float
 /// when the uitofp casts are exact and C is in the valid range.
 ///
 /// Since exact uitofp means distinct integers map to distinct floats, the only
 /// values fabs(uitofp(a) - uitofp(b)) can take are {0.0, 1.0, 2.0, ...}.
 /// There are no values in the open interval (0, 1), so:
 ///   fabs(...) <  C  where 0 < C <= 1.0  -->  a == b  (strict lt: C=1.0 ok)
-///   fabs(...) <= C  where 0 < C <  1.0  -->  a == b  (le: C must be < 1.0,
-///                                             since le 1.0 is true when
-///                                             diff=1)
+//    fabs(..) >= C where C >= 1.0 -> a != b 
 ///
 /// The same logic applies to sitofp.
 static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I) {
@@ -8789,8 +8787,9 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I) {
 
   FCmpInst::Predicate Pred = I.getPredicate();
   bool IsStrictLt = Pred == FCmpInst::FCMP_OLT || Pred == FCmpInst::FCMP_ULT;
-  bool IsLe = Pred == FCmpInst::FCMP_OLE || Pred == FCmpInst::FCMP_ULE;
-  if (!IsStrictLt && !IsLe)
+  bool IsStrictGt = Pred == FCmpInst::FCMP_OGT || Pred == FCmpInst::FCMP_UGT;
+  bool IsGe       = Pred == FCmpInst::FCMP_OGE || Pred == FCmpInst::FCMP_UGE;
+  if (!IsStrictLt && !IsStrictGt && !IsGe)
     return nullptr;
 
   if (C->isNaN() || C->isZero() || C->isNegative())
@@ -8801,11 +8800,11 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I) {
 
   // For strict-lt (olt/ult): C must be in (0, 1.0] -- C == 1.0 is fine since
   //   the next possible value after 0.0 is 1.0, and < 1.0 excludes it.
-  // For le (ole/ule): C must be in (0, 1.0) -- C == 1.0 is NOT valid since
-  //   fabs(...) == 1.0 when a and b differ by 1, and <= 1.0 would be true.
   if (IsStrictLt && Cmp == APFloat::cmpGreaterThan)
     return nullptr;
-  if (IsLe && Cmp != APFloat::cmpLessThan)
+  if (IsGe && Cmp == APFloat::cmpGreaterThan)
+    return nullptr;
+  if (IsStrictGt && Cmp != APFloat::cmpLessThan)
     return nullptr;
 
   // Match: fsub(uitofp(A), uitofp(B)) where both casts are uitofp or sitofp
@@ -8833,8 +8832,9 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I) {
   if ((unsigned)MantissaWidth < IntWidth)
     return nullptr;
 
-  // fabs(uitofp(a) - uitofp(b)) < C (0 < C <= 1) --> a == b
-  return new ICmpInst(ICmpInst::ICMP_EQ, A, B);
+  ICmpInst::Predicate ResultPred =
+    (IsStrictLt) ? ICmpInst::ICMP_EQ : ICmpInst::ICMP_NE;
+  return new ICmpInst(ResultPred, A, B);
 }
 
 static Instruction *foldFCmpWithFloorAndCeil(FCmpInst &I,

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8817,7 +8817,6 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I, InstCombinerImpl &IC) {
   if (A->getType() != B->getType())
     return nullptr;
 
-  Value *Src = I.getOperand(0);
   auto *FPCast = cast<CastInst>(cast<Instruction>(FAbsArg)->getOperand(0));
   if (!IC.isKnownExactCastIntToFP(*FPCast))
     return nullptr;

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8766,14 +8766,14 @@ static Instruction *foldFCmpFSubIntoFCmp(FCmpInst &I, Instruction *LHSI,
 }
 
 /// Fold: fabs(uitofp(a) - uitofp(b)) pred C --> a == b
-/// where 'pred' is olt, ult, ogt, ugt, oge or uge and C is a positive, Non-NaN float
-/// when the uitofp casts are exact and C is in the valid range.
+/// where 'pred' is olt, ult, ogt, ugt, oge or uge and C is a positive, Non-NaN
+/// float when the uitofp casts are exact and C is in the valid range.
 ///
 /// Since exact uitofp means distinct integers map to distinct floats, the only
 /// values fabs(uitofp(a) - uitofp(b)) can take are {0.0, 1.0, 2.0, ...}.
 /// There are no values in the open interval (0, 1), so:
 ///   fabs(...) <  C  where 0 < C <= 1.0  -->  a == b  (strict lt: C=1.0 ok)
-//    fabs(..) >= C where C >= 1.0 -> a != b 
+//    fabs(..) >= C where C >= 1.0 -> a != b
 ///
 /// The same logic applies to sitofp.
 static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I) {
@@ -8788,7 +8788,7 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I) {
   FCmpInst::Predicate Pred = I.getPredicate();
   bool IsStrictLt = Pred == FCmpInst::FCMP_OLT || Pred == FCmpInst::FCMP_ULT;
   bool IsStrictGt = Pred == FCmpInst::FCMP_OGT || Pred == FCmpInst::FCMP_UGT;
-  bool IsGe       = Pred == FCmpInst::FCMP_OGE || Pred == FCmpInst::FCMP_UGE;
+  bool IsGe = Pred == FCmpInst::FCMP_OGE || Pred == FCmpInst::FCMP_UGE;
   if (!IsStrictLt && !IsStrictGt && !IsGe)
     return nullptr;
 
@@ -8833,7 +8833,7 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I) {
     return nullptr;
 
   ICmpInst::Predicate ResultPred =
-    (IsStrictLt) ? ICmpInst::ICMP_EQ : ICmpInst::ICMP_NE;
+      (IsStrictLt) ? ICmpInst::ICMP_EQ : ICmpInst::ICMP_NE;
   return new ICmpInst(ResultPred, A, B);
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8785,15 +8785,15 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I, InstCombinerImpl &IC) {
   if (!match(I.getOperand(1), m_APFloat(C)))
     return nullptr;
 
+  if (!match(I.getOperand(1), PatternMatch::m_FiniteNonZero()))
+    return nullptr;
+
   FCmpInst::Predicate Pred = I.getPredicate();
   bool IsStrictLt = Pred == FCmpInst::FCMP_OLT || Pred == FCmpInst::FCMP_ULT;
   bool IsLe = Pred == FCmpInst::FCMP_OLE || Pred == FCmpInst::FCMP_ULE;
   bool IsStrictGt = Pred == FCmpInst::FCMP_OGT || Pred == FCmpInst::FCMP_UGT;
   bool IsGe = Pred == FCmpInst::FCMP_OGE || Pred == FCmpInst::FCMP_UGE;
   if (!IsStrictLt && !IsStrictGt && !IsGe)
-    return nullptr;
-
-  if (C->isNaN() || C->isZero() || C->isNegative())
     return nullptr;
 
   APFloat One = APFloat::getOne(C->getSemantics());
@@ -8812,23 +8812,23 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I, InstCombinerImpl &IC) {
 
   // Match: fsub(uitofp(A), uitofp(B)) where both casts are uitofp or sitofp
   Value *A, *B;
-  if (!match(FAbsArg, m_FSub(m_UIToFP(m_Value(A)), m_UIToFP(m_Value(B)))) &&
-      !match(FAbsArg, m_FSub(m_SIToFP(m_Value(A)), m_SIToFP(m_Value(B)))))
+  bool IsSigned;
+  if (match(FAbsArg, m_FSub(m_UIToFP(m_Value(A)), m_UIToFP(m_Value(B))))) {
+    IsSigned = false;
+  } else if (match(FAbsArg,
+                   m_FSub(m_SIToFP(m_Value(A)), m_SIToFP(m_Value(B))))) {
+    IsSigned = true;
+  } else {
     return nullptr;
+  }
 
   // A and B must have the same integer type
   if (A->getType() != B->getType())
     return nullptr;
 
-  auto *FPCastOp0 = cast<CastInst>(cast<Instruction>(FAbsArg)->getOperand(0));
-  auto *FPCastOp1 = cast<CastInst>(cast<Instruction>(FAbsArg)->getOperand(1));
-  bool is_signed = FPCastOp0->getOpcode() == CastInst::SIToFP &&
-                   FPCastOp1->getOpcode() == CastInst::SIToFP;
-  Type *FPTy = FPCastOp0->getType();
-  if (!IC.canBeCastedExactlyIntToFP(FPCastOp0->getOperand(0), FPTy, is_signed,
-                                    &I) ||
-      !IC.canBeCastedExactlyIntToFP(FPCastOp1->getOperand(0), FPTy, is_signed,
-                                    &I))
+  Type *FPTy = FAbsArg->getType();
+  if (!IC.canBeCastedExactlyIntToFP(A, FPTy, IsSigned, &I) ||
+      !IC.canBeCastedExactlyIntToFP(B, FPTy, IsSigned, &I))
     return nullptr;
   ICmpInst::Predicate ResultPred =
       IsStrictLt ? ICmpInst::ICMP_EQ : ICmpInst::ICMP_NE;

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8782,10 +8782,7 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I, InstCombinerImpl &IC) {
     return nullptr;
 
   const APFloat *C;
-  if (!match(I.getOperand(1), m_APFloat(C)))
-    return nullptr;
-
-  if (!match(I.getOperand(1), PatternMatch::m_FiniteNonZero()))
+  if (!match(I.getOperand(1), PatternMatch::m_FiniteNonZero(C)))
     return nullptr;
 
   FCmpInst::Predicate Pred = I.getPredicate();
@@ -8805,7 +8802,7 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I, InstCombinerImpl &IC) {
     return nullptr;
   if (IsGe && Cmp == APFloat::cmpGreaterThan)
     return nullptr;
-  if (IsLe && Cmp == APFloat::cmpGreaterThan)
+  if (IsLe && Cmp != APFloat::cmpGreaterThan)
     return nullptr;
   if (IsStrictGt && Cmp != APFloat::cmpLessThan)
     return nullptr;
@@ -8831,7 +8828,7 @@ static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I, InstCombinerImpl &IC) {
       !IC.canBeCastedExactlyIntToFP(B, FPTy, IsSigned, &I))
     return nullptr;
   ICmpInst::Predicate ResultPred =
-      IsStrictLt ? ICmpInst::ICMP_EQ : ICmpInst::ICMP_NE;
+      IsStrictLt || IsLe ? ICmpInst::ICMP_EQ : ICmpInst::ICMP_NE;
   return new ICmpInst(ResultPred, A, B);
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8774,7 +8774,8 @@ static Instruction *foldFCmpFSubIntoFCmp(FCmpInst &I, Instruction *LHSI,
 /// There are no values in the open interval (0, 1), so:
 ///   fabs(...) <  C  where 0 < C <= 1.0  -->  a == b  (strict lt: C=1.0 ok)
 ///   fabs(...) <= C  where 0 < C <  1.0  -->  a == b  (le: C must be < 1.0,
-///                                             since le 1.0 is true when diff=1)
+///                                             since le 1.0 is true when
+///                                             diff=1)
 ///
 /// The same logic applies to sitofp.
 static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8765,6 +8765,77 @@ static Instruction *foldFCmpFSubIntoFCmp(FCmpInst &I, Instruction *LHSI,
   return nullptr;
 }
 
+/// Fold: fabs(uitofp(a) - uitofp(b)) pred C --> a == b
+/// where 'pred' is olt, ole, ult, or ule, and C is a positive, Non-NaN float
+/// when the uitofp casts are exact and C is in the valid range.
+///
+/// Since exact uitofp means distinct integers map to distinct floats, the only
+/// values fabs(uitofp(a) - uitofp(b)) can take are {0.0, 1.0, 2.0, ...}.
+/// There are no values in the open interval (0, 1), so:
+///   fabs(...) <  C  where 0 < C <= 1.0  -->  a == b  (strict lt: C=1.0 ok)
+///   fabs(...) <= C  where 0 < C <  1.0  -->  a == b  (le: C must be < 1.0,
+///                                             since le 1.0 is true when diff=1)
+///
+/// The same logic applies to sitofp.
+static Instruction *foldFCmpFAbsFSubIntToFP(FCmpInst &I) {
+  Value *FAbsArg;
+  if (!match(I.getOperand(0), m_FAbs(m_Value(FAbsArg))))
+    return nullptr;
+
+  const APFloat *C;
+  if (!match(I.getOperand(1), m_APFloat(C)))
+    return nullptr;
+
+  FCmpInst::Predicate Pred = I.getPredicate();
+  bool IsStrictLt = Pred == FCmpInst::FCMP_OLT || Pred == FCmpInst::FCMP_ULT;
+  bool IsLe = Pred == FCmpInst::FCMP_OLE || Pred == FCmpInst::FCMP_ULE;
+  if (!IsStrictLt && !IsLe)
+    return nullptr;
+
+  if (C->isNaN() || C->isZero() || C->isNegative())
+    return nullptr;
+
+  APFloat One = APFloat::getOne(C->getSemantics());
+  APFloat::cmpResult Cmp = C->compare(One);
+
+  // For strict-lt (olt/ult): C must be in (0, 1.0] -- C == 1.0 is fine since
+  //   the next possible value after 0.0 is 1.0, and < 1.0 excludes it.
+  // For le (ole/ule): C must be in (0, 1.0) -- C == 1.0 is NOT valid since
+  //   fabs(...) == 1.0 when a and b differ by 1, and <= 1.0 would be true.
+  if (IsStrictLt && Cmp == APFloat::cmpGreaterThan)
+    return nullptr;
+  if (IsLe && Cmp != APFloat::cmpLessThan)
+    return nullptr;
+
+  // Match: fsub(uitofp(A), uitofp(B)) where both casts are uitofp or sitofp
+  Value *A, *B;
+  if (!match(FAbsArg, m_FSub(m_UIToFP(m_Value(A)), m_UIToFP(m_Value(B)))) &&
+      !match(FAbsArg, m_FSub(m_SIToFP(m_Value(A)), m_SIToFP(m_Value(B)))))
+    return nullptr;
+
+  // A and B must have the same integer type
+  if (A->getType() != B->getType())
+    return nullptr;
+
+  // The int-to-fp cast must be exact (no precision loss).
+  // For uitofp: we need MantissaWidth >= IntWidth (all bits representable).
+  // For sitofp: we need MantissaWidth >= IntWidth (sign bit + magnitude).
+  // getFPMantissaWidth() returns the number of bits in the mantissa including
+  // the implicit leading 1 bit (i.e., the precision).
+  Type *FPTy = I.getOperand(0)->getType()->getScalarType();
+  int MantissaWidth = FPTy->getFPMantissaWidth();
+  if (MantissaWidth < 0)
+    return nullptr; // Unknown FP type.
+  unsigned IntWidth = A->getType()->getScalarSizeInBits();
+  // For unsigned: need MantissaWidth >= IntWidth
+  // For signed: need MantissaWidth >= IntWidth (to represent most negative val)
+  if ((unsigned)MantissaWidth < IntWidth)
+    return nullptr;
+
+  // fabs(uitofp(a) - uitofp(b)) < C (0 < C <= 1) --> a == b
+  return new ICmpInst(ICmpInst::ICMP_EQ, A, B);
+}
+
 static Instruction *foldFCmpWithFloorAndCeil(FCmpInst &I,
                                              InstCombinerImpl &IC) {
   Value *LHS = I.getOperand(0), *RHS = I.getOperand(1);
@@ -9076,6 +9147,9 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
   }
 
   if (Instruction *R = foldFabsWithFcmpZero(I, *this))
+    return R;
+
+  if (Instruction *R = foldFCmpFAbsFSubIntToFP(I))
     return R;
 
   if (Instruction *R = foldSqrtWithFcmpZero(I, *this))

--- a/llvm/test/Transforms/InstCombine/fcmp.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp.ll
@@ -1813,145 +1813,6 @@ define i1 @fcmp_oeq_fsub_const(float %x, float %y) {
   ret i1 %cmp
 }
 
-define i1 @pr185561(i32 %arg0) {
-; CHECK-LABEL: @pr185561(
-; CHECK-NEXT:    [[V0:%.*]] = add i32 [[ARG0:%.*]], -1
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[V0]], 0
-; CHECK-NEXT:    ret i1 [[CMP]]
-;
-  %v0 = add i32 %arg0, -1
-  %v1 = sitofp i32 %v0 to float
-  %v2 = fsub float 1.000000e+00, %v1
-  %v3 = fcmp olt float %v2, 1.000000e+00
-  ret i1 %v3
-}
-
-define i1 @same_const_sub_sitofp_eq(i32 %x) {
-; CHECK-LABEL: @same_const_sub_sitofp_eq(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X:%.*]], 0
-; CHECK-NEXT:    ret i1 [[CMP]]
-;
-  %f = sitofp i32 %x to float
-  %s = fsub float 1.000000e+00, %f
-  %cmp = fcmp oeq float %s, 1.000000e+00
-  ret i1 %cmp
-}
-
-define i1 @same_const_sub_uitofp_olt(i32 %x) {
-; CHECK-LABEL: @same_const_sub_uitofp_olt(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[X:%.*]], 0
-; CHECK-NEXT:    ret i1 [[CMP]]
-;
-  %f = uitofp i32 %x to float
-  %s = fsub float 2.000000e+00, %f
-  %cmp = fcmp olt float %s, 2.000000e+00
-  ret i1 %cmp
-}
-
-define i1 @same_const_sub_no_fold_large_c(i32 %x) {
-; CHECK-LABEL: @same_const_sub_no_fold_large_c(
-; CHECK-NOT:    icmp
-; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[X:%.*]] to float
-; CHECK-NEXT:    [[S:%.*]] = fsub float 0x417FFFFFE0000000, [[F]]
-; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq float [[S]], 0x417FFFFFE0000000
-; CHECK-NEXT:    ret i1 [[CMP]]
-;
-  %f = sitofp i32 %x to float
-  %s = fsub float 3.355443e+07, %f
-  %cmp = fcmp oeq float %s, 3.355443e+07
-  ret i1 %cmp
-}
-
-define <2 x i1> @same_const_sub_sitofp_vec_eq(<2 x i32> %x) {
-; CHECK-LABEL: @same_const_sub_sitofp_vec_eq(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <2 x i32> [[X:%.*]], zeroinitializer
-; CHECK-NEXT:    ret <2 x i1> [[CMP]]
-;
-  %f = sitofp <2 x i32> %x to <2 x float>
-  %s = fsub <2 x float> <float 1.000000e+00, float 1.000000e+00>, %f
-  %cmp = fcmp oeq <2 x float> %s,
-                   <float 1.000000e+00, float 1.000000e+00>
-  ret <2 x i1> %cmp
-}
-
-define <2 x i1> @same_const_sub_uitofp_vec_olt(<2 x i32> %x) {
-; CHECK-LABEL: @same_const_sub_uitofp_vec_olt(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne <2 x i32> [[X:%.*]], zeroinitializer
-; CHECK-NEXT:    ret <2 x i1> [[CMP]]
-;
-  %f = uitofp <2 x i32> %x to <2 x float>
-  %s = fsub <2 x float> <float 2.000000e+00, float 2.000000e+00>, %f
-  %cmp = fcmp olt <2 x float> %s,
-                   <float 2.000000e+00, float 2.000000e+00>
-  ret <2 x i1> %cmp
-}
-
-define i1 @same_const_sub_no_fold_subnormal_c(i32 %x) {
-; CHECK-LABEL: @same_const_sub_no_fold_subnormal_c(
-; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[X:%.*]] to float
-; CHECK-NEXT:    [[S:%.*]] = fsub float 0x36A0000000000000, [[F]]
-; CHECK-NEXT:    [[CMP:%.*]] = fcmp olt float [[S]], 0x36A0000000000000
-; CHECK-NEXT:    ret i1 [[CMP]]
-;
-  %f = sitofp i32 %x to float
-  %s = fsub float 0x36A0000000000000, %f
-  %cmp = fcmp olt float %s, 0x36A0000000000000
-  ret i1 %cmp
-}
-
-define i1 @same_const_sub_no_fold_wrong_mantissa_width(i32 %x) {
-; CHECK-LABEL: @same_const_sub_no_fold_wrong_mantissa_width(
-; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[X:%.*]] to float
-; CHECK-NEXT:    [[S:%.*]] = fsub float 0x4180000000000000, [[F]]
-; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq float [[S]], 0x4180000000000000
-; CHECK-NEXT:    ret i1 [[CMP]]
-;
-  %f = sitofp i32 %x to float
-  %s = fsub float 3.3554432e+07, %f
-  %cmp = fcmp oeq float %s, 3.3554432e+07
-  ret i1 %cmp
-}
-
-define i1 @same_const_sub_sitofp_x86_fp80_eq(i32 %x) {
-; CHECK-LABEL: @same_const_sub_sitofp_x86_fp80_eq(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X:%.*]], 0
-; CHECK-NEXT:    ret i1 [[CMP]]
-;
-  %f = sitofp i32 %x to x86_fp80
-  %s = fsub x86_fp80 0xK3FFF8000000000000000, %f
-  %cmp = fcmp oeq x86_fp80 %s, 0xK3FFF8000000000000000
-  ret i1 %cmp
-}
-
-define i1 @same_const_sub_no_fold_x86_fp80_large_c(i32 %x) {
-; CHECK-LABEL: @same_const_sub_no_fold_x86_fp80_large_c(
-; CHECK-NOT:    icmp
-; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[X:%.*]] to x86_fp80
-; CHECK-NEXT:    [[S:%.*]] = fsub x86_fp80 0xK403F8000000000000000, [[F]]
-; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq x86_fp80 [[S]], 0xK403F8000000000000000
-; CHECK-NEXT:    ret i1 [[CMP]]
-;
-  %f = sitofp i32 %x to x86_fp80
-  ; 2^64, so ilogb(C) == 64, which should fail `ilogb(C) < MantissaWidth`
-  %s = fsub x86_fp80 0xK403F8000000000000000, %f
-  %cmp = fcmp oeq x86_fp80 %s, 0xK403F8000000000000000
-  ret i1 %cmp
-}
-
-define i1 @same_const_sub_no_fold_ppcfp128(i32 %x) {
-; CHECK-LABEL: @same_const_sub_no_fold_ppcfp128(
-; CHECK-NOT:    icmp
-; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[X:%.*]] to ppc_fp128
-; CHECK-NEXT:    [[S:%.*]] = fsub ppc_fp128 0xM3FF00000000000000000000000000000, [[F]]
-; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq ppc_fp128 [[S]], 0xM3FF00000000000000000000000000000
-; CHECK-NEXT:    ret i1 [[CMP]]
-;
-  %f = sitofp i32 %x to ppc_fp128
-  %s = fsub ppc_fp128 0xM3FF00000000000000000000000000000, %f
-  %cmp = fcmp oeq ppc_fp128 %s, 0xM3FF00000000000000000000000000000
-  ret i1 %cmp
-}
-
 define i1 @fcmp_oge_fsub_const(float %x, float %y) {
 ; CHECK-LABEL: @fcmp_oge_fsub_const(
 ; CHECK-NEXT:    [[FS:%.*]] = fsub float [[X:%.*]], [[Y:%.*]]
@@ -2611,48 +2472,6 @@ define i1 @fabs_uitofp_sub_ult_one(i16 %x, i16 %y) {
   ret i1 %cmp
 }
 
-; fabs(uitofp(a) - uitofp(b)) <= 0.5 --> a == b
-define i1 @fabs_uitofp_sub_ole_half(i16 %x, i16 %y) {
-; CHECK-LABEL: @fabs_uitofp_sub_ole_half(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
-; CHECK-NEXT:    ret i1 [[CMP]]
-;
-  %fx = uitofp i16 %x to float
-  %fy = uitofp i16 %y to float
-  %sub = fsub float %fx, %fy
-  %abs = call float @llvm.fabs.f32(float %sub)
-  %cmp = fcmp ole float %abs, 0.5
-  ret i1 %cmp
-}
-
-; fabs(sitofp(a) - sitofp(b)) <= 0.5 --> a == b
-define i1 @fabs_sitofp_sub_ole_half(i16 %x, i16 %y) {
-; CHECK-LABEL: @fabs_sitofp_sub_ole_half(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
-; CHECK-NEXT:    ret i1 [[CMP]]
-;
-  %fx = sitofp i16 %x to float
-  %fy = sitofp i16 %y to float
-  %sub = fsub float %fx, %fy
-  %abs = call float @llvm.fabs.f32(float %sub)
-  %cmp = fcmp ole float %abs, 0.5
-  ret i1 %cmp
-}
-
-
-define i1 @fabs_uitofp_sub_ule_half(i16 %x, i16 %y) {
-; CHECK-LABEL: @fabs_uitofp_sub_ule_half(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
-; CHECK-NEXT:    ret i1 [[CMP]]
-;
-  %fx = uitofp i16 %x to float
-  %fy = uitofp i16 %y to float
-  %sub = fsub float %fx, %fy
-  %abs = call float @llvm.fabs.f32(float %sub)
-  %cmp = fcmp ule float %abs, 0.5
-  ret i1 %cmp
-}
-
 define i1 @fabs_sitofp_sub_olt_one(i16 %x, i16 %y) {
 ; CHECK-LABEL: @fabs_sitofp_sub_olt_one(
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
@@ -2666,25 +2485,33 @@ define i1 @fabs_sitofp_sub_olt_one(i16 %x, i16 %y) {
   ret i1 %cmp
 }
 
-
-; negative tests
-
-define i1 @fabs_uitofp_sub_ole_one_no_fold(i16 %x, i16 %y) {
-; CHECK-LABEL: @fabs_uitofp_sub_ole_one_no_fold(
-; CHECK-NEXT:    [[FX:%.*]] = uitofp i16 [[X:%.*]] to float
-; CHECK-NEXT:    [[FY:%.*]] = uitofp i16 [[Y:%.*]] to float
-; CHECK-NEXT:    [[SUB:%.*]] = fsub float [[FX]], [[FY]]
-; CHECK-NEXT:    [[ABS:%.*]] = call float @llvm.fabs.f32(float [[SUB]])
-; CHECK-NEXT:    [[CMP:%.*]] = fcmp ole float [[ABS]], 1.000000e+00
+define i1 @fabs_sitofp_sub_ogt_half(i16 %x, i16 %y) {
+; CHECK-LABEL: @fabs_sitofp_sub_ogt_half(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i16 [[X:%.*]], [[Y:%.*]]
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %fx = uitofp i16 %x to float
-  %fy = uitofp i16 %y to float
+  %fx = sitofp i16 %x to float
+  %fy = sitofp i16 %y to float
   %sub = fsub float %fx, %fy
   %abs = call float @llvm.fabs.f32(float %sub)
-  %cmp = fcmp ole float %abs, 1.0
+  %cmp = fcmp ogt float %abs, 0.5
   ret i1 %cmp
 }
+
+define i1 @fabs_sitofp_sub_oge_one(i16 %x, i16 %y) {
+; CHECK-LABEL: @fabs_sitofp_sub_oge_one(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i16 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = sitofp i16 %x to float
+  %fy = sitofp i16 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp oge float %abs, 1.0
+  ret i1 %cmp
+}
+
+; negative tests
 
 define i1 @fabs_uitofp_sub_olt_two_no_fold(i16 %x, i16 %y) {
 ; CHECK-LABEL: @fabs_uitofp_sub_olt_two_no_fold(
@@ -2717,5 +2544,23 @@ define i1 @fabs_sitofp_sub_olt_one_i32_no_fold(i32 %x, i32 %y) {
   %sub = fsub float %fx, %fy
   %abs = call float @llvm.fabs.f32(float %sub)
   %cmp = fcmp olt float %abs, 1.0
+  ret i1 %cmp
+}
+
+; For StrictGt, C ought to be strictly less than 1.0
+define i1 @fabs_sitofp_sub_ogt_one(i16 %x, i16 %y) {
+; CHECK-LABEL: @fabs_sitofp_sub_ogt_one(
+; CHECK-NEXT:    [[FX:%.*]] = sitofp i16 [[X:%.*]] to float
+; CHECK-NEXT:    [[FY:%.*]] = sitofp i16 [[Y:%.*]] to float
+; CHECK-NEXT:    [[SUB:%.*]] = fsub float [[FX]], [[FY]]
+; CHECK-NEXT:    [[ABS:%.*]] = call float @llvm.fabs.f32(float [[SUB]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp ogt float [[ABS]], 1.000000e+00
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = sitofp i16 %x to float
+  %fy = sitofp i16 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp ogt float %abs, 1.0
   ret i1 %cmp
 }

--- a/llvm/test/Transforms/InstCombine/fcmp.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp.ll
@@ -1850,7 +1850,6 @@ define i1 @same_const_sub_uitofp_olt(i32 %x) {
 
 define i1 @same_const_sub_no_fold_large_c(i32 %x) {
 ; CHECK-LABEL: @same_const_sub_no_fold_large_c(
-; CHECK-NOT:    icmp
 ; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[X:%.*]] to float
 ; CHECK-NEXT:    [[S:%.*]] = fsub float 0x417FFFFFE0000000, [[F]]
 ; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq float [[S]], 0x417FFFFFE0000000
@@ -1870,7 +1869,7 @@ define <2 x i1> @same_const_sub_sitofp_vec_eq(<2 x i32> %x) {
   %f = sitofp <2 x i32> %x to <2 x float>
   %s = fsub <2 x float> <float 1.000000e+00, float 1.000000e+00>, %f
   %cmp = fcmp oeq <2 x float> %s,
-                   <float 1.000000e+00, float 1.000000e+00>
+  <float 1.000000e+00, float 1.000000e+00>
   ret <2 x i1> %cmp
 }
 
@@ -1882,7 +1881,7 @@ define <2 x i1> @same_const_sub_uitofp_vec_olt(<2 x i32> %x) {
   %f = uitofp <2 x i32> %x to <2 x float>
   %s = fsub <2 x float> <float 2.000000e+00, float 2.000000e+00>, %f
   %cmp = fcmp olt <2 x float> %s,
-                   <float 2.000000e+00, float 2.000000e+00>
+  <float 2.000000e+00, float 2.000000e+00>
   ret <2 x i1> %cmp
 }
 
@@ -1925,7 +1924,6 @@ define i1 @same_const_sub_sitofp_x86_fp80_eq(i32 %x) {
 
 define i1 @same_const_sub_no_fold_x86_fp80_large_c(i32 %x) {
 ; CHECK-LABEL: @same_const_sub_no_fold_x86_fp80_large_c(
-; CHECK-NOT:    icmp
 ; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[X:%.*]] to x86_fp80
 ; CHECK-NEXT:    [[S:%.*]] = fsub x86_fp80 0xK403F8000000000000000, [[F]]
 ; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq x86_fp80 [[S]], 0xK403F8000000000000000
@@ -1940,7 +1938,6 @@ define i1 @same_const_sub_no_fold_x86_fp80_large_c(i32 %x) {
 
 define i1 @same_const_sub_no_fold_ppcfp128(i32 %x) {
 ; CHECK-LABEL: @same_const_sub_no_fold_ppcfp128(
-; CHECK-NOT:    icmp
 ; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[X:%.*]] to ppc_fp128
 ; CHECK-NEXT:    [[S:%.*]] = fsub ppc_fp128 0xM3FF00000000000000000000000000000, [[F]]
 ; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq ppc_fp128 [[S]], 0xM3FF00000000000000000000000000000
@@ -2597,7 +2594,7 @@ define i1 @fabs_uitofp_sub_olt_one(i16 %x, i16 %y) {
   ret i1 %cmp
 }
 
-; fabs(uitofp(a) - uitofp(b)) u< 1.0 --> a == b
+; fabs(uitofp(a) - uitofp(b)) < 1.0 --> a == b
 define i1 @fabs_uitofp_sub_ult_one(i16 %x, i16 %y) {
 ; CHECK-LABEL: @fabs_uitofp_sub_ult_one(
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
@@ -2621,6 +2618,40 @@ define i1 @fabs_sitofp_sub_olt_one(i16 %x, i16 %y) {
   %sub = fsub float %fx, %fy
   %abs = call float @llvm.fabs.f32(float %sub)
   %cmp = fcmp olt float %abs, 1.0
+  ret i1 %cmp
+}
+
+define i1 @fabs_uitofp_sub_ule_one(i16 %x, i16 %y) {
+; CHECK-LABEL: @fabs_uitofp_sub_ule_one(
+; CHECK-NEXT:    [[FX:%.*]] = uitofp i16 [[X:%.*]] to float
+; CHECK-NEXT:    [[FY:%.*]] = uitofp i16 [[Y:%.*]] to float
+; CHECK-NEXT:    [[SUB:%.*]] = fsub float [[FX]], [[FY]]
+; CHECK-NEXT:    [[ABS:%.*]] = call float @llvm.fabs.f32(float [[SUB]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp ule float [[ABS]], 1.000000e+00
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = uitofp i16 %x to float
+  %fy = uitofp i16 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp ule float %abs, 1.0
+  ret i1 %cmp
+}
+
+define i1 @fabs_sitofp_sub_ole_one(i16 %x, i16 %y) {
+; CHECK-LABEL: @fabs_sitofp_sub_ole_one(
+; CHECK-NEXT:    [[FX:%.*]] = sitofp i16 [[X:%.*]] to float
+; CHECK-NEXT:    [[FY:%.*]] = sitofp i16 [[Y:%.*]] to float
+; CHECK-NEXT:    [[SUB:%.*]] = fsub float [[FX]], [[FY]]
+; CHECK-NEXT:    [[ABS:%.*]] = call float @llvm.fabs.f32(float [[SUB]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp ole float [[ABS]], 1.000000e+00
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = sitofp i16 %x to float
+  %fy = sitofp i16 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp ole float %abs, 1.0
   ret i1 %cmp
 }
 

--- a/llvm/test/Transforms/InstCombine/fcmp.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp.ll
@@ -1813,6 +1813,145 @@ define i1 @fcmp_oeq_fsub_const(float %x, float %y) {
   ret i1 %cmp
 }
 
+define i1 @pr185561(i32 %arg0) {
+; CHECK-LABEL: @pr185561(
+; CHECK-NEXT:    [[V0:%.*]] = add i32 [[ARG0:%.*]], -1
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[V0]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %v0 = add i32 %arg0, -1
+  %v1 = sitofp i32 %v0 to float
+  %v2 = fsub float 1.000000e+00, %v1
+  %v3 = fcmp olt float %v2, 1.000000e+00
+  ret i1 %v3
+}
+
+define i1 @same_const_sub_sitofp_eq(i32 %x) {
+; CHECK-LABEL: @same_const_sub_sitofp_eq(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X:%.*]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %f = sitofp i32 %x to float
+  %s = fsub float 1.000000e+00, %f
+  %cmp = fcmp oeq float %s, 1.000000e+00
+  ret i1 %cmp
+}
+
+define i1 @same_const_sub_uitofp_olt(i32 %x) {
+; CHECK-LABEL: @same_const_sub_uitofp_olt(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[X:%.*]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %f = uitofp i32 %x to float
+  %s = fsub float 2.000000e+00, %f
+  %cmp = fcmp olt float %s, 2.000000e+00
+  ret i1 %cmp
+}
+
+define i1 @same_const_sub_no_fold_large_c(i32 %x) {
+; CHECK-LABEL: @same_const_sub_no_fold_large_c(
+; CHECK-NOT:    icmp
+; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[X:%.*]] to float
+; CHECK-NEXT:    [[S:%.*]] = fsub float 0x417FFFFFE0000000, [[F]]
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq float [[S]], 0x417FFFFFE0000000
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %f = sitofp i32 %x to float
+  %s = fsub float 3.355443e+07, %f
+  %cmp = fcmp oeq float %s, 3.355443e+07
+  ret i1 %cmp
+}
+
+define <2 x i1> @same_const_sub_sitofp_vec_eq(<2 x i32> %x) {
+; CHECK-LABEL: @same_const_sub_sitofp_vec_eq(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <2 x i32> [[X:%.*]], zeroinitializer
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %f = sitofp <2 x i32> %x to <2 x float>
+  %s = fsub <2 x float> <float 1.000000e+00, float 1.000000e+00>, %f
+  %cmp = fcmp oeq <2 x float> %s,
+                   <float 1.000000e+00, float 1.000000e+00>
+  ret <2 x i1> %cmp
+}
+
+define <2 x i1> @same_const_sub_uitofp_vec_olt(<2 x i32> %x) {
+; CHECK-LABEL: @same_const_sub_uitofp_vec_olt(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne <2 x i32> [[X:%.*]], zeroinitializer
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %f = uitofp <2 x i32> %x to <2 x float>
+  %s = fsub <2 x float> <float 2.000000e+00, float 2.000000e+00>, %f
+  %cmp = fcmp olt <2 x float> %s,
+                   <float 2.000000e+00, float 2.000000e+00>
+  ret <2 x i1> %cmp
+}
+
+define i1 @same_const_sub_no_fold_subnormal_c(i32 %x) {
+; CHECK-LABEL: @same_const_sub_no_fold_subnormal_c(
+; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[X:%.*]] to float
+; CHECK-NEXT:    [[S:%.*]] = fsub float 0x36A0000000000000, [[F]]
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp olt float [[S]], 0x36A0000000000000
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %f = sitofp i32 %x to float
+  %s = fsub float 0x36A0000000000000, %f
+  %cmp = fcmp olt float %s, 0x36A0000000000000
+  ret i1 %cmp
+}
+
+define i1 @same_const_sub_no_fold_wrong_mantissa_width(i32 %x) {
+; CHECK-LABEL: @same_const_sub_no_fold_wrong_mantissa_width(
+; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[X:%.*]] to float
+; CHECK-NEXT:    [[S:%.*]] = fsub float 0x4180000000000000, [[F]]
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq float [[S]], 0x4180000000000000
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %f = sitofp i32 %x to float
+  %s = fsub float 3.3554432e+07, %f
+  %cmp = fcmp oeq float %s, 3.3554432e+07
+  ret i1 %cmp
+}
+
+define i1 @same_const_sub_sitofp_x86_fp80_eq(i32 %x) {
+; CHECK-LABEL: @same_const_sub_sitofp_x86_fp80_eq(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X:%.*]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %f = sitofp i32 %x to x86_fp80
+  %s = fsub x86_fp80 0xK3FFF8000000000000000, %f
+  %cmp = fcmp oeq x86_fp80 %s, 0xK3FFF8000000000000000
+  ret i1 %cmp
+}
+
+define i1 @same_const_sub_no_fold_x86_fp80_large_c(i32 %x) {
+; CHECK-LABEL: @same_const_sub_no_fold_x86_fp80_large_c(
+; CHECK-NOT:    icmp
+; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[X:%.*]] to x86_fp80
+; CHECK-NEXT:    [[S:%.*]] = fsub x86_fp80 0xK403F8000000000000000, [[F]]
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq x86_fp80 [[S]], 0xK403F8000000000000000
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %f = sitofp i32 %x to x86_fp80
+  ; 2^64, so ilogb(C) == 64, which should fail `ilogb(C) < MantissaWidth`
+  %s = fsub x86_fp80 0xK403F8000000000000000, %f
+  %cmp = fcmp oeq x86_fp80 %s, 0xK403F8000000000000000
+  ret i1 %cmp
+}
+
+define i1 @same_const_sub_no_fold_ppcfp128(i32 %x) {
+; CHECK-LABEL: @same_const_sub_no_fold_ppcfp128(
+; CHECK-NOT:    icmp
+; CHECK-NEXT:    [[F:%.*]] = sitofp i32 [[X:%.*]] to ppc_fp128
+; CHECK-NEXT:    [[S:%.*]] = fsub ppc_fp128 0xM3FF00000000000000000000000000000, [[F]]
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq ppc_fp128 [[S]], 0xM3FF00000000000000000000000000000
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %f = sitofp i32 %x to ppc_fp128
+  %s = fsub ppc_fp128 0xM3FF00000000000000000000000000000, %f
+  %cmp = fcmp oeq ppc_fp128 %s, 0xM3FF00000000000000000000000000000
+  ret i1 %cmp
+}
+
 define i1 @fcmp_oge_fsub_const(float %x, float %y) {
 ; CHECK-LABEL: @fcmp_oge_fsub_const(
 ; CHECK-NEXT:    [[FS:%.*]] = fsub float [[X:%.*]], [[Y:%.*]]

--- a/llvm/test/Transforms/InstCombine/fcmp.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp.ll
@@ -2782,7 +2782,7 @@ define <2 x i1> @fabs_uitofp_sub_vec_olt_one(<2 x i16> %x, <2 x i16> %y) {
   %fy = uitofp <2 x i16> %y to <2 x float>
   %sub = fsub <2 x float> %fx, %fy
   %abs = call <2 x float> @llvm.fabs.v2f32(<2 x float> %sub)
-  %cmp = fcmp olt <2 x float> %abs, splat(float 1.0)
+  %cmp = fcmp olt <2 x float> %abs, splat (float 1.0)
   ret <2 x i1> %cmp
 }
 
@@ -2796,7 +2796,7 @@ define <2 x i1> @fabs_sitofp_sub_vec_ult_one(<2 x i16> %x, <2 x i16> %y) {
   %fy = sitofp <2 x i16> %y to <2 x float>
   %sub = fsub <2 x float> %fx, %fy
   %abs = call <2 x float> @llvm.fabs.v2f32(<2 x float> %sub)
-  %cmp = fcmp ult <2 x float> %abs, splat(float 1.0)
+  %cmp = fcmp ult <2 x float> %abs, splat (float 1.0)
   ret <2 x i1> %cmp
 }
 
@@ -2814,7 +2814,7 @@ define <2 x i1> @fabs_uitofp_sub_vec_half_no_fold(<2 x i32> %x, <2 x i32> %y) {
   %fy = uitofp <2 x i32> %y to <2 x half>
   %sub = fsub <2 x half> %fx, %fy
   %abs = call <2 x half> @llvm.fabs.v2f16(<2 x half> %sub)
-  %cmp = fcmp olt <2 x half> %abs, splat(half 0xH3C00)
+  %cmp = fcmp olt <2 x half> %abs, splat (half 0xH3C00)
   ret <2 x i1> %cmp
 }
 
@@ -2832,6 +2832,6 @@ define <2 x i1> @fabs_uitofp_sub_vec_bf16_no_fold(<2 x i16> %x, <2 x i16> %y) {
   %fy = uitofp <2 x i16> %y to <2 x bfloat>
   %sub = fsub <2 x bfloat> %fx, %fy
   %abs = call <2 x bfloat> @llvm.fabs.v2bf16(<2 x bfloat> %sub)
-  %cmp = fcmp olt <2 x bfloat> %abs, splat(bfloat 0xR3F80)
+  %cmp = fcmp olt <2 x bfloat> %abs, splat (bfloat 0xR3F80)
   ret <2 x i1> %cmp
 }

--- a/llvm/test/Transforms/InstCombine/fcmp.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp.ll
@@ -2771,3 +2771,69 @@ define i1 @fabs_no_fold_i32_half(i32 %a, i32 %b) {
   %cmp = fcmp olt half %abs, 1.0
   ret i1 %cmp
 }
+
+; Vector case, unsigned fold
+define <2 x i1> @fabs_uitofp_sub_vec_olt_one(<2 x i16> %x, <2 x i16> %y) {
+; CHECK-LABEL: @fabs_uitofp_sub_vec_olt_one(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <2 x i16> [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %fx = uitofp <2 x i16> %x to <2 x float>
+  %fy = uitofp <2 x i16> %y to <2 x float>
+  %sub = fsub <2 x float> %fx, %fy
+  %abs = call <2 x float> @llvm.fabs.v2f32(<2 x float> %sub)
+  %cmp = fcmp olt <2 x float> %abs, <float 1.0, float 1.0>
+  ret <2 x i1> %cmp
+}
+
+; Vector case, signed fold
+define <2 x i1> @fabs_sitofp_sub_vec_ult_one(<2 x i16> %x, <2 x i16> %y) {
+; CHECK-LABEL: @fabs_sitofp_sub_vec_ult_one(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <2 x i16> [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %fx = sitofp <2 x i16> %x to <2 x float>
+  %fy = sitofp <2 x i16> %y to <2 x float>
+  %sub = fsub <2 x float> %fx, %fy
+  %abs = call <2 x float> @llvm.fabs.v2f32(<2 x float> %sub)
+  %cmp = fcmp ult <2 x float> %abs, <float 1.0, float 1.0>
+  ret <2 x i1> %cmp
+}
+
+; Vector case, exactness test with small mantissa FP type
+define <2 x i1> @fabs_uitofp_sub_vec_half_no_fold(<2 x i32> %x, <2 x i32> %y) {
+; CHECK-LABEL: @fabs_uitofp_sub_vec_half_no_fold(
+; CHECK-NEXT:    [[FX:%.*]] = uitofp <2 x i32> [[X:%.*]] to <2 x half>
+; CHECK-NEXT:    [[FY:%.*]] = uitofp <2 x i32> [[Y:%.*]] to <2 x half>
+; CHECK-NEXT:    [[SUB:%.*]] = fsub <2 x half> [[FX]], [[FY]]
+; CHECK-NEXT:    [[ABS:%.*]] = call <2 x half> @llvm.fabs.v2f16(<2 x half> [[SUB]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp olt <2 x half> [[ABS]], splat (half 0xH3C00)
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %fx = uitofp <2 x i32> %x to <2 x half>
+  %fy = uitofp <2 x i32> %y to <2 x half>
+  %sub = fsub <2 x half> %fx, %fy
+  %abs = call <2 x half> @llvm.fabs.v2f16(<2 x half> %sub)
+  %cmp = fcmp olt <2 x half> %abs, <half 0xH3C00, half 0xH3C00>
+  ret <2 x i1> %cmp
+}
+
+; Vector case, no fold due to failed exactness
+define <2 x i1> @fabs_uitofp_sub_vec_bf16_no_fold(<2 x i16> %x, <2 x i16> %y) {
+; CHECK-LABEL: @fabs_uitofp_sub_vec_bf16_no_fold(
+; CHECK-NEXT:    [[FX:%.*]] = uitofp <2 x i16> [[X:%.*]] to <2 x bfloat>
+; CHECK-NEXT:    [[FY:%.*]] = uitofp <2 x i16> [[Y:%.*]] to <2 x bfloat>
+; CHECK-NEXT:    [[SUB:%.*]] = fsub <2 x bfloat> [[FX]], [[FY]]
+; CHECK-NEXT:    [[ABS:%.*]] = call <2 x bfloat> @llvm.fabs.v2bf16(<2 x bfloat> [[SUB]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp olt <2 x bfloat> [[ABS]], splat (bfloat 0xR3F80)
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %fx = uitofp <2 x i16> %x to <2 x bfloat>
+  %fy = uitofp <2 x i16> %y to <2 x bfloat>
+  %sub = fsub <2 x bfloat> %fx, %fy
+  %abs = call <2 x bfloat> @llvm.fabs.v2bf16(<2 x bfloat> %sub)
+  %cmp = fcmp olt <2 x bfloat> %abs, <bfloat 0xR3F80, bfloat 0xR3F80>
+  ret <2 x i1> %cmp
+}
+
+

--- a/llvm/test/Transforms/InstCombine/fcmp.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp.ll
@@ -2734,3 +2734,40 @@ define i1 @fabs_sitofp_sub_ogt_one(i16 %x, i16 %y) {
   %cmp = fcmp ogt float %abs, 1.0
   ret i1 %cmp
 }
+
+define i1 @fabs_argstype_mismatch(i16 %x, i32 %y) {
+; CHECK-LABEL: @fabs_argstype_mismatch(
+; CHECK-NEXT:    [[FY:%.*]] = sitofp i16 [[Y:%.*]] to float
+; CHECK-NEXT:    [[FY1:%.*]] = sitofp i32 [[Y1:%.*]] to float
+; CHECK-NEXT:    [[SUB:%.*]] = fsub float [[FY]], [[FY1]]
+; CHECK-NEXT:    [[ABS:%.*]] = call float @llvm.fabs.f32(float [[SUB]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp ogt float [[ABS]], 1.000000e+00
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = sitofp i16 %x to float
+  %fy = sitofp i32 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp ogt float %abs, 1.0
+  ret i1 %cmp
+}
+
+; negative test for canBeCastedExactlyIntToFP()
+
+define i1 @fabs_no_fold_i32_half(i32 %a, i32 %b) {
+; CHECK-LABEL: @fabs_no_fold_i32_half(
+; CHECK-NEXT:    [[FA:%.*]] = uitofp i32 [[A:%.*]] to half
+; CHECK-NEXT:    [[FB:%.*]] = uitofp i32 [[B:%.*]] to half
+; CHECK-NEXT:    [[SUB:%.*]] = fsub half [[FA]], [[FB]]
+; CHECK-NEXT:    [[ABS:%.*]] = call half @llvm.fabs.f16(half [[SUB]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp olt half [[ABS]], 0xH3C00
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+
+  %fa = uitofp i32 %a to half
+  %fb = uitofp i32 %b to half
+  %sub = fsub half %fa, %fb
+  %abs = call half @llvm.fabs.f16(half %sub)
+  %cmp = fcmp olt half %abs, 1.0
+  ret i1 %cmp
+}

--- a/llvm/test/Transforms/InstCombine/fcmp.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp.ll
@@ -2782,7 +2782,7 @@ define <2 x i1> @fabs_uitofp_sub_vec_olt_one(<2 x i16> %x, <2 x i16> %y) {
   %fy = uitofp <2 x i16> %y to <2 x float>
   %sub = fsub <2 x float> %fx, %fy
   %abs = call <2 x float> @llvm.fabs.v2f32(<2 x float> %sub)
-  %cmp = fcmp olt <2 x float> %abs, <float 1.0, float 1.0>
+  %cmp = fcmp olt <2 x float> %abs, splat(float 1.0)
   ret <2 x i1> %cmp
 }
 
@@ -2796,7 +2796,7 @@ define <2 x i1> @fabs_sitofp_sub_vec_ult_one(<2 x i16> %x, <2 x i16> %y) {
   %fy = sitofp <2 x i16> %y to <2 x float>
   %sub = fsub <2 x float> %fx, %fy
   %abs = call <2 x float> @llvm.fabs.v2f32(<2 x float> %sub)
-  %cmp = fcmp ult <2 x float> %abs, <float 1.0, float 1.0>
+  %cmp = fcmp ult <2 x float> %abs, splat(float 1.0)
   ret <2 x i1> %cmp
 }
 
@@ -2814,7 +2814,7 @@ define <2 x i1> @fabs_uitofp_sub_vec_half_no_fold(<2 x i32> %x, <2 x i32> %y) {
   %fy = uitofp <2 x i32> %y to <2 x half>
   %sub = fsub <2 x half> %fx, %fy
   %abs = call <2 x half> @llvm.fabs.v2f16(<2 x half> %sub)
-  %cmp = fcmp olt <2 x half> %abs, <half 0xH3C00, half 0xH3C00>
+  %cmp = fcmp olt <2 x half> %abs, splat(half 0xH3C00)
   ret <2 x i1> %cmp
 }
 
@@ -2832,8 +2832,6 @@ define <2 x i1> @fabs_uitofp_sub_vec_bf16_no_fold(<2 x i16> %x, <2 x i16> %y) {
   %fy = uitofp <2 x i16> %y to <2 x bfloat>
   %sub = fsub <2 x bfloat> %fx, %fy
   %abs = call <2 x bfloat> @llvm.fabs.v2bf16(<2 x bfloat> %sub)
-  %cmp = fcmp olt <2 x bfloat> %abs, <bfloat 0xR3F80, bfloat 0xR3F80>
+  %cmp = fcmp olt <2 x bfloat> %abs, splat(bfloat 0xR3F80)
   ret <2 x i1> %cmp
 }
-
-

--- a/llvm/test/Transforms/InstCombine/fcmp.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp.ll
@@ -2,6 +2,7 @@
 ; RUN: opt -S -passes=instcombine < %s | FileCheck %s
 
 declare half @llvm.fabs.f16(half)
+declare float @llvm.fabs.f32(float)
 declare double @llvm.fabs.f64(double)
 declare <2 x float> @llvm.fabs.v2f32(<2 x float>)
 declare double @llvm.copysign.f64(double, double)
@@ -2579,5 +2580,142 @@ define i1 @fcmp_sqrt_zero_ult_nonzero(half %x) {
 ;
   %sqrt = call half @llvm.sqrt.f16(half %x)
   %cmp = fcmp ult half %sqrt, 1.000000e+00
+  ret i1 %cmp
+}
+
+; fabs(uitofp(a) - uitofp(b)) < 1.0 --> a == b
+define i1 @fabs_uitofp_sub_olt_one(i16 %x, i16 %y) {
+; CHECK-LABEL: @fabs_uitofp_sub_olt_one(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = uitofp i16 %x to float
+  %fy = uitofp i16 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp olt float %abs, 1.0
+  ret i1 %cmp
+}
+
+; fabs(uitofp(a) - uitofp(b)) u< 1.0 --> a == b
+define i1 @fabs_uitofp_sub_ult_one(i16 %x, i16 %y) {
+; CHECK-LABEL: @fabs_uitofp_sub_ult_one(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = uitofp i16 %x to float
+  %fy = uitofp i16 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp ult float %abs, 1.0
+  ret i1 %cmp
+}
+
+; fabs(uitofp(a) - uitofp(b)) <= 0.5 --> a == b
+define i1 @fabs_uitofp_sub_ole_half(i16 %x, i16 %y) {
+; CHECK-LABEL: @fabs_uitofp_sub_ole_half(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = uitofp i16 %x to float
+  %fy = uitofp i16 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp ole float %abs, 0.5
+  ret i1 %cmp
+}
+
+; fabs(sitofp(a) - sitofp(b)) <= 0.5 --> a == b
+define i1 @fabs_sitofp_sub_ole_half(i16 %x, i16 %y) {
+; CHECK-LABEL: @fabs_sitofp_sub_ole_half(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = sitofp i16 %x to float
+  %fy = sitofp i16 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp ole float %abs, 0.5
+  ret i1 %cmp
+}
+
+
+define i1 @fabs_uitofp_sub_ule_half(i16 %x, i16 %y) {
+; CHECK-LABEL: @fabs_uitofp_sub_ule_half(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = uitofp i16 %x to float
+  %fy = uitofp i16 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp ule float %abs, 0.5
+  ret i1 %cmp
+}
+
+define i1 @fabs_sitofp_sub_olt_one(i16 %x, i16 %y) {
+; CHECK-LABEL: @fabs_sitofp_sub_olt_one(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = sitofp i16 %x to float
+  %fy = sitofp i16 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp olt float %abs, 1.0
+  ret i1 %cmp
+}
+
+
+; negative tests
+
+define i1 @fabs_uitofp_sub_ole_one_no_fold(i16 %x, i16 %y) {
+; CHECK-LABEL: @fabs_uitofp_sub_ole_one_no_fold(
+; CHECK-NEXT:    [[FX:%.*]] = uitofp i16 [[X:%.*]] to float
+; CHECK-NEXT:    [[FY:%.*]] = uitofp i16 [[Y:%.*]] to float
+; CHECK-NEXT:    [[SUB:%.*]] = fsub float [[FX]], [[FY]]
+; CHECK-NEXT:    [[ABS:%.*]] = call float @llvm.fabs.f32(float [[SUB]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp ole float [[ABS]], 1.000000e+00
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = uitofp i16 %x to float
+  %fy = uitofp i16 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp ole float %abs, 1.0
+  ret i1 %cmp
+}
+
+define i1 @fabs_uitofp_sub_olt_two_no_fold(i16 %x, i16 %y) {
+; CHECK-LABEL: @fabs_uitofp_sub_olt_two_no_fold(
+; CHECK-NEXT:    [[FX:%.*]] = uitofp i16 [[X:%.*]] to float
+; CHECK-NEXT:    [[FY:%.*]] = uitofp i16 [[Y:%.*]] to float
+; CHECK-NEXT:    [[SUB:%.*]] = fsub float [[FX]], [[FY]]
+; CHECK-NEXT:    [[ABS:%.*]] = call float @llvm.fabs.f32(float [[SUB]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp olt float [[ABS]], 2.000000e+00
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = uitofp i16 %x to float
+  %fy = uitofp i16 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp olt float %abs, 2.0
+  ret i1 %cmp
+}
+
+define i1 @fabs_sitofp_sub_olt_one_i32_no_fold(i32 %x, i32 %y) {
+; CHECK-LABEL: @fabs_sitofp_sub_olt_one_i32_no_fold(
+; CHECK-NEXT:    [[FX:%.*]] = sitofp i32 [[X:%.*]] to float
+; CHECK-NEXT:    [[FY:%.*]] = sitofp i32 [[Y:%.*]] to float
+; CHECK-NEXT:    [[SUB:%.*]] = fsub float [[FX]], [[FY]]
+; CHECK-NEXT:    [[ABS:%.*]] = call float @llvm.fabs.f32(float [[SUB]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp olt float [[ABS]], 1.000000e+00
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %fx = sitofp i32 %x to float
+  %fy = sitofp i32 %y to float
+  %sub = fsub float %fx, %fy
+  %abs = call float @llvm.fabs.f32(float %sub)
+  %cmp = fcmp olt float %abs, 1.0
   ret i1 %cmp
 }


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/187088

When a and b are types with bitwidth (16 bits) smaller than the mantissa for float32 (24 bits), they will be exact and their absolute difference would be integral ±1 or greater if a != b. On the corollary, if their difference is < 1.0, this implies that a = b.

This patch exploits this fact to fold the expression to just a single icmp.