### PR TITLE
[clang-tidy] Improve redundant-casting check for binary operation

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.cpp
@@ -75,8 +75,9 @@ static bool binaryOperatorOperandsTypesEqualToOperatorResultType(
     // IgnoreImplicitCasts = false: neither of operands type matches cast type
     // IgnoreImplicitCasts = true: at least one operand type doesn't match cast
     //                             type
-    const bool castIsNeeded = IgnoreImplicitCasts ? (!LHSMatches || !RHSMatches)
-                                                  : (!LHSMatches && !RHSMatches);
+    const bool castIsNeeded = IgnoreImplicitCasts
+                                  ? (!LHSMatches || !RHSMatches)
+                                  : (!LHSMatches && !RHSMatches);
     if (castIsNeeded)
       return false;
   }

--- a/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.cpp
@@ -50,8 +50,8 @@ static bool areTypesEqual(QualType TypeS, QualType TypeD,
                                             TypeD.getLocalUnqualifiedType());
 }
 
-static bool anyBinaryOperatorOperandsTypesEqualToOperatorResultType(
-    const Expr *E, bool IgnoreTypeAliases) {
+static bool BinaryOperatorOperandsTypesEqualToOperatorResultType(
+    const Expr *E, bool IgnoreTypeAliases, bool IgnoreImplicitCasts) {
   if (!E)
     return true;
   const Expr *WithoutImplicitAndParen = E->IgnoreParenImpCasts();
@@ -71,9 +71,13 @@ static bool anyBinaryOperatorOperandsTypesEqualToOperatorResultType(
     const bool RHSMatches =
         !RHSType.isNull() && areTypesEqual(RHSType.getNonReferenceType(),
                                            NonReferenceType, IgnoreTypeAliases);
-    if (!LHSMatches && !RHSMatches)
-      // neither of the operand matches => casting is needed for readability
+    if (!IgnoreImplicitCasts) {
+      if (!LHSMatches && !RHSMatches)
+        // neither of the operand matches => casting is needed for readability
+        return false;
+    } else if (!LHSMatches || !RHSMatches) {
       return false;
+    }
   }
   return true;
 }
@@ -95,11 +99,13 @@ RedundantCastingCheck::RedundantCastingCheck(StringRef Name,
                                              ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       IgnoreMacros(Options.get("IgnoreMacros", true)),
-      IgnoreTypeAliases(Options.get("IgnoreTypeAliases", false)) {}
+      IgnoreTypeAliases(Options.get("IgnoreTypeAliases", false)),
+      IgnoreImplicitCasts(Options.get("IgnoreImplicitCasts", false)) {}
 
 void RedundantCastingCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "IgnoreMacros", IgnoreMacros);
   Options.store(Opts, "IgnoreTypeAliases", IgnoreTypeAliases);
+  Options.store(Opts, "IgnoreImplicitCasts", IgnoreImplicitCasts);
 }
 
 void RedundantCastingCheck::registerMatchers(MatchFinder *Finder) {
@@ -148,8 +154,8 @@ void RedundantCastingCheck::check(const MatchFinder::MatchResult &Result) {
   if (!areTypesEqual(TypeS, TypeD, IgnoreTypeAliases))
     return;
 
-  if (!anyBinaryOperatorOperandsTypesEqualToOperatorResultType(
-          SourceExpr, IgnoreTypeAliases))
+  if (!BinaryOperatorOperandsTypesEqualToOperatorResultType(
+          SourceExpr, IgnoreTypeAliases, IgnoreImplicitCasts))
     return;
 
   const auto *CastExpr = Result.Nodes.getNodeAs<ExplicitCastExpr>("cast");

--- a/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.cpp
@@ -50,7 +50,7 @@ static bool areTypesEqual(QualType TypeS, QualType TypeD,
                                             TypeD.getLocalUnqualifiedType());
 }
 
-static bool areBinaryOperatorOperandsTypesEqualToOperatorResultType(
+static bool anyBinaryOperatorOperandsTypesEqualToOperatorResultType(
     const Expr *E, bool IgnoreTypeAliases) {
   if (!E)
     return true;
@@ -64,12 +64,15 @@ static bool areBinaryOperatorOperandsTypesEqualToOperatorResultType(
 
     const QualType NonReferenceType = Type.getNonReferenceType();
     const QualType LHSType = B->getLHS()->IgnoreImplicit()->getType();
-    if (LHSType.isNull() || !areTypesEqual(LHSType.getNonReferenceType(),
-                                           NonReferenceType, IgnoreTypeAliases))
-      return false;
     const QualType RHSType = B->getRHS()->IgnoreImplicit()->getType();
-    if (RHSType.isNull() || !areTypesEqual(RHSType.getNonReferenceType(),
-                                           NonReferenceType, IgnoreTypeAliases))
+    const bool LHSMatches =
+        !LHSType.isNull() && areTypesEqual(LHSType.getNonReferenceType(),
+                                           NonReferenceType, IgnoreTypeAliases);
+    const bool RHSMatches =
+        !RHSType.isNull() && areTypesEqual(RHSType.getNonReferenceType(),
+                                           NonReferenceType, IgnoreTypeAliases);
+    if (!LHSMatches && !RHSMatches)
+      // neither of the operand matches => casting is needed for readability
       return false;
   }
   return true;
@@ -145,7 +148,7 @@ void RedundantCastingCheck::check(const MatchFinder::MatchResult &Result) {
   if (!areTypesEqual(TypeS, TypeD, IgnoreTypeAliases))
     return;
 
-  if (!areBinaryOperatorOperandsTypesEqualToOperatorResultType(
+  if (!anyBinaryOperatorOperandsTypesEqualToOperatorResultType(
           SourceExpr, IgnoreTypeAliases))
     return;
 

--- a/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.cpp
@@ -75,10 +75,10 @@ static bool binaryOperatorOperandsTypesEqualToOperatorResultType(
     // IgnoreImplicitCasts = false: neither of operands type matches cast type
     // IgnoreImplicitCasts = true: at least one operand type doesn't match cast
     //                             type
-    const bool castIsNeeded = IgnoreImplicitCasts
+    const bool CastIsNeeded = IgnoreImplicitCasts
                                   ? (!LHSMatches || !RHSMatches)
                                   : (!LHSMatches && !RHSMatches);
-    if (castIsNeeded)
+    if (CastIsNeeded)
       return false;
   }
   return true;

--- a/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.cpp
@@ -50,7 +50,7 @@ static bool areTypesEqual(QualType TypeS, QualType TypeD,
                                             TypeD.getLocalUnqualifiedType());
 }
 
-static bool BinaryOperatorOperandsTypesEqualToOperatorResultType(
+static bool binaryOperatorOperandsTypesEqualToOperatorResultType(
     const Expr *E, bool IgnoreTypeAliases, bool IgnoreImplicitCasts) {
   if (!E)
     return true;
@@ -71,13 +71,14 @@ static bool BinaryOperatorOperandsTypesEqualToOperatorResultType(
     const bool RHSMatches =
         !RHSType.isNull() && areTypesEqual(RHSType.getNonReferenceType(),
                                            NonReferenceType, IgnoreTypeAliases);
-    if (!IgnoreImplicitCasts) {
-      if (!LHSMatches && !RHSMatches)
-        // neither of the operand matches => casting is needed for readability
-        return false;
-    } else if (!LHSMatches || !RHSMatches) {
+    // Explicit Cast is needed if:
+    // IgnoreImplicitCasts = false: neither of operands type matches cast type
+    // IgnoreImplicitCasts = true: at least one operand type doesn't match cast
+    //                             type
+    const bool castIsNeeded = IgnoreImplicitCasts ? (!LHSMatches || !RHSMatches)
+                                                  : (!LHSMatches && !RHSMatches);
+    if (castIsNeeded)
       return false;
-    }
   }
   return true;
 }
@@ -154,7 +155,7 @@ void RedundantCastingCheck::check(const MatchFinder::MatchResult &Result) {
   if (!areTypesEqual(TypeS, TypeD, IgnoreTypeAliases))
     return;
 
-  if (!BinaryOperatorOperandsTypesEqualToOperatorResultType(
+  if (!binaryOperatorOperandsTypesEqualToOperatorResultType(
           SourceExpr, IgnoreTypeAliases, IgnoreImplicitCasts))
     return;
 

--- a/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/RedundantCastingCheck.h
@@ -31,6 +31,7 @@ public:
 private:
   const bool IgnoreMacros;
   const bool IgnoreTypeAliases;
+  const bool IgnoreImplicitCasts;
 };
 
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -509,12 +509,6 @@ Changes in existing checks
     implicit conversions of logical operator results (``&&``, ``||``, ``!``)
     to ``bool`` in C.
 
-- Improved :doc:`readability-redundant-casting
-  <clang-tidy/checks/readability/redundant-casting>` check by fixing a false
-  negative where casts were not flagged as redundant when at least one operand
-  of a binary operation had the same type as the cast result type. For example,
-  ``static_cast<float>(1.0f + 1)`` is now correctly identified as redundant.
-
 - Improved :doc:`readability-non-const-parameter
   <clang-tidy/checks/readability/non-const-parameter>` check:
 
@@ -533,6 +527,12 @@ Changes in existing checks
   <clang-tidy/checks/readability/redundant-preprocessor>` check by fixing a
   false positive for nested ``#if`` directives using different builtin
   expressions such as ``__has_builtin`` and ``__has_cpp_attribute``.
+
+- Improved :doc:`readability-redundant-casting
+  <clang-tidy/checks/readability/redundant-casting>` check by fixing a false
+  negative where casts were not flagged as redundant when at least one operand
+  of a binary operation had the same type as the cast result type. For example,
+  ``static_cast<float>(1.0f + 1)`` is now correctly identified as redundant.
 
 - Improved :doc:`readability-simplify-boolean-expr
   <clang-tidy/checks/readability/simplify-boolean-expr>` check to provide valid

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -523,16 +523,16 @@ Changes in existing checks
   `IgnoreMacros` option to suppress warnings when the initializer involves
   macros that may expand differently in other configurations.
 
-- Improved :doc:`readability-redundant-preprocessor
-  <clang-tidy/checks/readability/redundant-preprocessor>` check by fixing a
-  false positive for nested ``#if`` directives using different builtin
-  expressions such as ``__has_builtin`` and ``__has_cpp_attribute``.
-
 - Improved :doc:`readability-redundant-casting
   <clang-tidy/checks/readability/redundant-casting>` check by fixing a false
   negative where casts were not flagged as redundant when at least one operand
   of a binary operation had the same type as the cast result type. For example,
   ``static_cast<float>(1.0f + 1)`` is now correctly identified as redundant.
+
+- Improved :doc:`readability-redundant-preprocessor
+  <clang-tidy/checks/readability/redundant-preprocessor>` check by fixing a
+  false positive for nested ``#if`` directives using different builtin
+  expressions such as ``__has_builtin`` and ``__has_cpp_attribute``.
 
 - Improved :doc:`readability-simplify-boolean-expr
   <clang-tidy/checks/readability/simplify-boolean-expr>` check to provide valid

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -509,6 +509,12 @@ Changes in existing checks
     implicit conversions of logical operator results (``&&``, ``||``, ``!``)
     to ``bool`` in C.
 
+- Improved :doc:`readability-redundant-casting
+  <clang-tidy/checks/readability/redundant-casting>` check by fixing a false
+  negative where casts were not flagged as redundant when at least one operand
+  of a binary operation had the same type as the cast result type. For example,
+  ``static_cast<float>(1.0f + 1)`` is now correctly identified as redundant.
+
 - Improved :doc:`readability-non-const-parameter
   <clang-tidy/checks/readability/non-const-parameter>` check:
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -518,16 +518,16 @@ Changes in existing checks
   - Fixed a false positive in array subscript expressions where the types are
     not yet resolved.
 
-- Improved :doc:`readability-redundant-member-init
-  <clang-tidy/checks/readability/redundant-member-init>` check by adding an
-  `IgnoreMacros` option to suppress warnings when the initializer involves
-  macros that may expand differently in other configurations.
-
 - Improved :doc:`readability-redundant-casting
   <clang-tidy/checks/readability/redundant-casting>` check by fixing a false
   negative where casts were not flagged as redundant when at least one operand
   of a binary operation had the same type as the cast result type. For example,
   ``static_cast<float>(1.0f + 1)`` is now correctly identified as redundant.
+
+- Improved :doc:`readability-redundant-member-init
+  <clang-tidy/checks/readability/redundant-member-init>` check by adding an
+  `IgnoreMacros` option to suppress warnings when the initializer involves
+  macros that may expand differently in other configurations.
 
 - Improved :doc:`readability-redundant-preprocessor
   <clang-tidy/checks/readability/redundant-preprocessor>` check by fixing a

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -522,12 +522,12 @@ Changes in existing checks
   <clang-tidy/checks/readability/redundant-casting>` check
 
   - Fixed a false negative where casts were not flagged as redundant when
-  atleast one operand of a binary operation had the same type as the cast result
-  type. For example, ``static_cast<float>(1.0f + 1)`` is now correctly
-  identified as redundant.
+    atleast one operand of a binary operation had the same type as the cast
+    result type. For example, ``static_cast<float>(1.0f + 1)`` is now correctly
+    identified as redundant.
 
   - Added `IgnoreImplicitCasts` option to control this, which can be opted-out
-  by setting it to ``true``, default is ``false``.
+    by setting it to ``true``, default is ``false``.
 
 - Improved :doc:`readability-redundant-member-init
   <clang-tidy/checks/readability/redundant-member-init>` check by adding an

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -519,10 +519,15 @@ Changes in existing checks
     not yet resolved.
 
 - Improved :doc:`readability-redundant-casting
-  <clang-tidy/checks/readability/redundant-casting>` check by fixing a false
-  negative where casts were not flagged as redundant when at least one operand
-  of a binary operation had the same type as the cast result type. For example,
-  ``static_cast<float>(1.0f + 1)`` is now correctly identified as redundant.
+  <clang-tidy/checks/readability/redundant-casting>` check
+
+  - Fixed a false negative where casts were not flagged as redundant when
+  atleast one operand of a binary operation had the same type as the cast result
+  type. For example, ``static_cast<float>(1.0f + 1)`` is now correctly
+  identified as redundant.
+
+  - Added `IgnoreImplicitCasts` option to control this, which can be opted-out
+  by setting it to ``true``, default is ``false``.
 
 - Improved :doc:`readability-redundant-member-init
   <clang-tidy/checks/readability/redundant-member-init>` check by adding an

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -519,15 +519,12 @@ Changes in existing checks
     not yet resolved.
 
 - Improved :doc:`readability-redundant-casting
-  <clang-tidy/checks/readability/redundant-casting>` check
-
-  - Fixed a false negative where casts were not flagged as redundant when
-    atleast one operand of a binary operation had the same type as the cast
-    result type. For example, ``static_cast<float>(1.0f + 1)`` is now correctly
-    identified as redundant.
-
-  - Added `IgnoreImplicitCasts` option to control this, which can be opted-out
-    by setting it to ``true``, default is ``false``.
+  <clang-tidy/checks/readability/redundant-casting>` check by adding the
+  `IgnoreImplicitCasts` option (default `false`) to flag casts as redundant
+  when at least one operand of a binary operation matches the cast type due to
+  implicit conversion. For example, ``static_cast<float>(1.0f + 1)`` is now
+  identified as redundant since ``1`` is implicitly converted to ``float``.
+  Setting this option to `true` restores the previous behavior.
 
 - Improved :doc:`readability-redundant-member-init
   <clang-tidy/checks/readability/redundant-member-init>` check by adding an

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-casting.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-casting.rst
@@ -27,11 +27,24 @@ Options
 
 .. option:: IgnoreMacros
 
-   If set to `true`, the check will not give warnings inside macros. Default
-   is `true`.
+  If set to `true`, the check will not give warnings inside macros. Default
+  is `true`.
 
 .. option:: IgnoreTypeAliases
 
-   When set to `false`, the check will consider type aliases, and when set to
-   `true`, it will resolve all type aliases and operate on the underlying
-   types. Default is `false`.
+  When set to `false`, the check will consider type aliases, and when set to
+  `true`, it will resolve all type aliases and operate on the underlying types.
+  Default is `false`.
+
+.. option:: IgnoreImplicitCasts
+
+  When set to `false`, the check will flag casts as redundant when atleast one
+  operand in an expression is implicitly cast to match the result type of the
+  explicit cast. When set to `true` the casts will not be flagged. Default is
+  `false`.
+
+  For example, with `IgnoreImplicitCasts = false`:
+
+  .. code-block:: c++
+
+    static_cast<float>(2.0f + 1);  // redundant (1 implicitly converts to float)

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
@@ -15,6 +15,7 @@
 // RUN:   -- -fno-delayed-template-parsing -D CXX_20=1
 
 #include <cstdint>
+#include <cstddef>
 
 struct A {};
 struct B : A {};
@@ -182,6 +183,19 @@ void testBinaryOperatorRedundantCasting() {
   const auto diff_types_operands3 { static_cast<int>(1 + static_cast<uint8_t>(1)) };
   // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: redundant explicit casting to the same type 'int' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-FIXES: const auto diff_types_operands3 { (1 + static_cast<uint8_t>(1)) };
+
+  const auto diff_types_operands4 {
+    static_cast<size_t>(static_cast<size_t>(3) + 2)
+  };
+  // CHECK-MESSAGES: :[[@LINE-2]]:5: warning: redundant explicit casting to the same type 'size_t' (aka 'unsigned long') as the sub-expression, remove this casting [readability-redundant-casting]
+  // CHECK-FIXES: (static_cast<size_t>(3) + 2)
+
+  const auto diff_types_operands5 { unsigned(7 + unsigned(4)) };
+  // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: redundant explicit casting to the same type 'unsigned int' as the sub-expression, remove this casting [readability-redundant-casting]
+  // CHECK-FIXES: const auto diff_types_operands5 { (7 + unsigned(4)) };
+
+  // casting isn't redundant here
+  const auto diff_types_operands6 { (int)(-7 + unsigned(4)) };
 }
 
 void testBinaryOperator(char c) {

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
@@ -14,6 +14,8 @@
 // RUN:   -config='{CheckOptions: { readability-redundant-casting.IgnoreTypeAliases: true }}' \
 // RUN:   -- -fno-delayed-template-parsing -D CXX_20=1
 
+#include <cstdint>
+
 struct A {};
 struct B : A {};
 A getA();
@@ -166,6 +168,20 @@ void testFunctionalCastWithPrimitive(int a) {
 void testFunctionalCastWithInitExpr(unsigned a) {
   unsigned b = ~unsigned{!a};
   unsigned c = unsigned{0};
+}
+
+void testBinaryOperatorRedundantCasting() {
+  const auto diff_types_operands1 { static_cast<float>(1.0f + 1) };
+  // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: redundant explicit casting to the same type 'float' as the sub-expression, remove this casting [readability-redundant-casting]
+  // CHECK-FIXES: const auto diff_types_operands1 { (1.0f + 1) };
+
+  const auto diff_types_operands2 { static_cast<float>(2 + 3.0f) };
+  // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: redundant explicit casting to the same type 'float' as the sub-expression, remove this casting [readability-redundant-casting]
+  // CHECK-FIXES: const auto diff_types_operands2 { (2 + 3.0f) };
+
+  const auto diff_types_operands3 { static_cast<int>(1 + static_cast<uint8_t>(1)) };
+  // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: redundant explicit casting to the same type 'int' as the sub-expression, remove this casting [readability-redundant-casting]
+  // CHECK-FIXES: const auto diff_types_operands3 { (1 + static_cast<uint8_t>(1)) };
 }
 
 void testBinaryOperator(char c) {

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
@@ -5,6 +5,9 @@
 // RUN: %check_clang_tidy -std=c++11,c++14,c++17 -check-suffix=,ALIASES %s readability-redundant-casting %t -- \
 // RUN:   -config='{CheckOptions: { readability-redundant-casting.IgnoreTypeAliases: true }}' \
 // RUN:   -- -fno-delayed-template-parsing
+// RUN: %check_clang_tidy -std=c++11,c++14,c++17 -check-suffix=IMPLICIT %s readability-redundant-casting %t -- \
+// RUN:   -config='{CheckOptions: { readability-redundant-casting.IgnoreImplicitCasts: true }}' \
+// RUN:   -- -fno-delayed-template-parsing
 // RUN: %check_clang_tidy -std=c++20-or-later %s readability-redundant-casting %t -- \
 // RUN:   -- -fno-delayed-template-parsing -D CXX_20=1
 // RUN: %check_clang_tidy -std=c++20-or-later -check-suffix=,MACROS %s readability-redundant-casting %t -- \
@@ -12,6 +15,9 @@
 // RUN:   -- -fno-delayed-template-parsing -D CXX_20=1
 // RUN: %check_clang_tidy -std=c++20-or-later -check-suffix=,ALIASES %s readability-redundant-casting %t -- \
 // RUN:   -config='{CheckOptions: { readability-redundant-casting.IgnoreTypeAliases: true }}' \
+// RUN:   -- -fno-delayed-template-parsing -D CXX_20=1
+// RUN: %check_clang_tidy -std=c++20-or-later -check-suffix=IMPLICIT %s readability-redundant-casting %t -- \
+// RUN:   -config='{CheckOptions: { readability-redundant-casting.IgnoreImplicitCasts: true }}' \
 // RUN:   -- -fno-delayed-template-parsing -D CXX_20=1
 
 #include <cstdint>
@@ -175,24 +181,29 @@ void testBinaryOperatorRedundantCasting() {
   const auto diff_types_operands1 { static_cast<float>(1.0f + 1) };
   // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: redundant explicit casting to the same type 'float' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-FIXES: const auto diff_types_operands1 { (1.0f + 1) };
+  // CHECK-FIXES-IMPLICIT: const auto diff_types_operands1 { static_cast<float>(1.0f + 1) };
 
   const auto diff_types_operands2 { static_cast<float>(2 + 3.0f) };
   // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: redundant explicit casting to the same type 'float' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-FIXES: const auto diff_types_operands2 { (2 + 3.0f) };
+  // CHECK-FIXES-IMPLICIT: const auto diff_types_operands2 { static_cast<float>(2 + 3.0f) };
 
   const auto diff_types_operands3 { static_cast<int>(1 + static_cast<uint8_t>(1)) };
   // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: redundant explicit casting to the same type 'int' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-FIXES: const auto diff_types_operands3 { (1 + static_cast<uint8_t>(1)) };
+  // CHECK-FIXES-IMPLICIT: const auto diff_types_operands3 { static_cast<int>(1 + static_cast<uint8_t>(1)) };
 
   const auto diff_types_operands4 {
     static_cast<size_t>(static_cast<size_t>(3) + 2)
   };
   // CHECK-MESSAGES: :[[@LINE-2]]:5: warning: redundant explicit casting to the same type 'size_t' (aka 'unsigned long{{( long)?}}') as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-FIXES: (static_cast<size_t>(3) + 2)
+  // CHECK-FIXES-IMPLICIT: static_cast<size_t>(static_cast<size_t>(3) + 2)
 
   const auto diff_types_operands5 { unsigned(7 + unsigned(4)) };
   // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: redundant explicit casting to the same type 'unsigned int' as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-FIXES: const auto diff_types_operands5 { (7 + unsigned(4)) };
+  // CHECK-FIXES-IMPLICIT: const auto diff_types_operands5 { unsigned(7 + unsigned(4)) };
 
   // casting isn't redundant here
   const auto diff_types_operands6 { (int)(-7 + unsigned(4)) };

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-casting.cpp
@@ -187,7 +187,7 @@ void testBinaryOperatorRedundantCasting() {
   const auto diff_types_operands4 {
     static_cast<size_t>(static_cast<size_t>(3) + 2)
   };
-  // CHECK-MESSAGES: :[[@LINE-2]]:5: warning: redundant explicit casting to the same type 'size_t' (aka 'unsigned long') as the sub-expression, remove this casting [readability-redundant-casting]
+  // CHECK-MESSAGES: :[[@LINE-2]]:5: warning: redundant explicit casting to the same type 'size_t' (aka 'unsigned long{{( long)?}}') as the sub-expression, remove this casting [readability-redundant-casting]
   // CHECK-FIXES: (static_cast<size_t>(3) + 2)
 
   const auto diff_types_operands5 { unsigned(7 + unsigned(4)) };


### PR DESCRIPTION
Mark explicit casting as readabily redundant for a BinaryOperation with atleast one operand of the same type as the cast type in `RedundantCastingCheck`

E.g.; `static<float>(1 + 2.0f)`  // redundant cast

Fixes #182132