### PR TITLE
[Clang] Warn about ignored dllimport on explicit instantiations

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3810,6 +3810,9 @@ def warn_dllimport_dropped_from_inline_function : Warning<
 def warn_nothrow_attribute_ignored : Warning<"'nothrow' attribute conflicts with"
   " exception specification; attribute ignored">,
   InGroup<IgnoredAttributes>;
+def warn_dllattr_ignored_already_instantiated : Warning<
+  "%0 attribute ignored; class template is already instantiated">,
+  InGroup<IgnoredAttributes>;
 def warn_dllattr_ignored_exclusion_takes_precedence : Warning<
   "%0 attribute ignored; %1 takes precedence">,
   InGroup<IgnoredAttributes>;
@@ -3933,6 +3936,9 @@ def err_attribute_dllimport_static_field_definition : Error<
 def warn_attribute_dllimport_static_field_definition : Warning<
   "definition of dllimport static field">,
   InGroup<DiagGroup<"dllimport-static-field-def">>;
+def warn_attribute_dllimport_explicit_instantiation_def : Warning<
+  "'dllimport' attribute ignored on explicit instantiation definition">,
+  InGroup<IgnoredAttributes>;
 def warn_attribute_dllexport_explicit_instantiation_decl : Warning<
   "explicit instantiation declaration should not be 'dllexport'">,
   InGroup<DllexportExplicitInstantiationDecl>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3874,6 +3874,9 @@ def warn_dllimport_dropped_from_inline_function : Warning<
 def warn_nothrow_attribute_ignored : Warning<"'nothrow' attribute conflicts with"
   " exception specification; attribute ignored">,
   InGroup<IgnoredAttributes>;
+def warn_dllattr_ignored_already_instantiated : Warning<
+  "%0 attribute ignored; class template is already instantiated">,
+  InGroup<IgnoredAttributes>;
 def warn_dllattr_ignored_exclusion_takes_precedence : Warning<
   "%0 attribute ignored; %1 takes precedence">,
   InGroup<IgnoredAttributes>;
@@ -3997,6 +4000,9 @@ def err_attribute_dllimport_static_field_definition : Error<
 def warn_attribute_dllimport_static_field_definition : Warning<
   "definition of dllimport static field">,
   InGroup<DiagGroup<"dllimport-static-field-def">>;
+def warn_attribute_dllimport_explicit_instantiation_def : Warning<
+  "'dllimport' attribute ignored on explicit instantiation definition">,
+  InGroup<IgnoredAttributes>;
 def warn_attribute_dllexport_explicit_instantiation_decl : Warning<
   "explicit instantiation declaration should not be 'dllexport'">,
   InGroup<DllexportExplicitInstantiationDecl>;

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -10230,23 +10230,32 @@ DeclResult Sema::ActOnExplicitInstantiation(
                                        ? TSK_ExplicitInstantiationDefinition
                                        : TSK_ExplicitInstantiationDeclaration;
 
+  bool DLLAttrAffected = false;
+  const ParsedAttr *AttachedExportAttr = nullptr;
+  const ParsedAttr *AttachedImportAttr = nullptr;
+  for (const ParsedAttr &AL : Attr) {
+    if (AL.getKind() == ParsedAttr::AT_DLLExport)
+      AttachedExportAttr = &AL;
+    else if (AL.getKind() == ParsedAttr::AT_DLLImport)
+      AttachedImportAttr = &AL;
+  }
+
   if (TSK == TSK_ExplicitInstantiationDeclaration &&
       !Context.getTargetInfo().getTriple().isOSCygMing()) {
     // Check for dllexport class template instantiation declarations,
     // except for MinGW mode.
-    for (const ParsedAttr &AL : Attr) {
-      if (AL.getKind() == ParsedAttr::AT_DLLExport) {
-        Diag(ExternLoc,
-             diag::warn_attribute_dllexport_explicit_instantiation_decl);
-        Diag(AL.getLoc(), diag::note_attribute);
-        break;
-      }
+    if (AttachedExportAttr) {
+      Diag(ExternLoc,
+           diag::warn_attribute_dllexport_explicit_instantiation_decl);
+      Diag(AttachedExportAttr->getLoc(), diag::note_attribute);
+      DLLAttrAffected = true;
     }
 
     if (auto *A = ClassTemplate->getTemplatedDecl()->getAttr<DLLExportAttr>()) {
       Diag(ExternLoc,
            diag::warn_attribute_dllexport_explicit_instantiation_decl);
       Diag(A->getLocation(), diag::note_attribute);
+      DLLAttrAffected = true;
     }
   }
 
@@ -10254,20 +10263,11 @@ DeclResult Sema::ActOnExplicitInstantiation(
   // instantiation declarations for most purposes.
   bool DLLImportExplicitInstantiationDef = false;
   if (TSK == TSK_ExplicitInstantiationDefinition &&
-      Context.getTargetInfo().getCXXABI().isMicrosoft()) {
+      Context.getTargetInfo().shouldDLLImportComdatSymbols()) {
     // Check for dllimport class template instantiation definitions.
     bool DLLImport =
         ClassTemplate->getTemplatedDecl()->getAttr<DLLImportAttr>();
-    for (const ParsedAttr &AL : Attr) {
-      if (AL.getKind() == ParsedAttr::AT_DLLImport)
-        DLLImport = true;
-      if (AL.getKind() == ParsedAttr::AT_DLLExport) {
-        // dllexport trumps dllimport here.
-        DLLImport = false;
-        break;
-      }
-    }
-    if (DLLImport) {
+    if ((DLLImport || AttachedImportAttr) && !AttachedExportAttr) {
       TSK = TSK_ExplicitInstantiationDeclaration;
       DLLImportExplicitInstantiationDef = true;
     }
@@ -10299,28 +10299,30 @@ DeclResult Sema::ActOnExplicitInstantiation(
       Context.getTargetInfo().getTriple().isOSCygMing()) {
     // Check for dllexport class template instantiation definitions in MinGW
     // mode, if a previous declaration of the instantiation was seen.
-    for (const ParsedAttr &AL : Attr) {
-      if (AL.getKind() == ParsedAttr::AT_DLLExport) {
-        if (PrevDecl->hasAttr<DLLExportAttr>()) {
-          Diag(AL.getLoc(), diag::warn_attr_dllexport_explicit_inst_def);
-        } else {
-          Diag(AL.getLoc(),
-               diag::warn_attr_dllexport_explicit_inst_def_mismatch);
-          Diag(PrevDecl->getLocation(), diag::note_prev_decl_missing_dllexport);
-        }
-        break;
+    if (AttachedExportAttr) {
+      if (PrevDecl->hasAttr<DLLExportAttr>()) {
+        Diag(AttachedExportAttr->getLoc(),
+             diag::warn_attr_dllexport_explicit_inst_def);
+      } else {
+        Diag(AttachedExportAttr->getLoc(),
+             diag::warn_attr_dllexport_explicit_inst_def_mismatch);
+        Diag(PrevDecl->getLocation(), diag::note_prev_decl_missing_dllexport);
       }
+      DLLAttrAffected = true;
+    } else if (AttachedImportAttr) {
+      Diag(AttachedImportAttr->getLoc(),
+           diag::warn_attribute_dllimport_explicit_instantiation_def);
+      DLLAttrAffected = true;
     }
   }
 
   if (TSK == TSK_ExplicitInstantiationDefinition && PrevDecl &&
       !Context.getTargetInfo().getTriple().isWindowsGNUEnvironment() &&
-      llvm::none_of(Attr, [](const ParsedAttr &AL) {
-        return AL.getKind() == ParsedAttr::AT_DLLExport;
-      })) {
+      !AttachedExportAttr) {
     if (const auto *DEA = PrevDecl->getAttr<DLLExportOnDeclAttr>()) {
       Diag(TemplateLoc, diag::warn_dllexport_on_decl_ignored);
       Diag(DEA->getLoc(), diag::note_dllexport_on_decl);
+      DLLAttrAffected = true;
     }
   }
 
@@ -10392,7 +10394,10 @@ DeclResult Sema::ActOnExplicitInstantiation(
   Specialization->setTemplateKeywordLoc(TemplateLoc);
   Specialization->setBraceRange(SourceRange());
 
-  bool PreviouslyDLLExported = Specialization->hasAttr<DLLExportAttr>();
+  bool PreviouslyDLLExported = Specialization->hasAttr<DLLExportAttr>() ||
+                               (PrevDecl && PrevDecl->hasAttr<DLLExportAttr>());
+  bool PreviouslyDLLImported = Specialization->hasAttr<DLLImportAttr>() ||
+                               (PrevDecl && PrevDecl->hasAttr<DLLImportAttr>());
   ProcessDeclAttributeList(S, Specialization, Attr);
   ProcessAPINotes(Specialization);
 
@@ -10419,11 +10424,12 @@ DeclResult Sema::ActOnExplicitInstantiation(
   ClassTemplateSpecializationDecl *Def
     = cast_or_null<ClassTemplateSpecializationDecl>(
                                               Specialization->getDefinition());
-  if (!Def)
+  if (!Def) {
     InstantiateClassTemplateSpecialization(TemplateNameLoc, Specialization, TSK,
                                            /*Complain=*/true,
                                            CTAI.StrictPackMatch);
-  else if (TSK == TSK_ExplicitInstantiationDefinition) {
+    DLLAttrAffected = true;
+  } else if (TSK == TSK_ExplicitInstantiationDefinition) {
     MarkVTableUsed(TemplateNameLoc, Specialization, true);
     Specialization->setPointOfInstantiation(Def->getPointOfInstantiation());
   }
@@ -10451,13 +10457,16 @@ DeclResult Sema::ActOnExplicitInstantiation(
         A->setInherited(true);
         Def->addAttr(A);
         dllExportImportClassTemplateSpecialization(*this, Def);
+        DLLAttrAffected = true;
       }
     }
 
     // Fix a TSK_ImplicitInstantiation followed by a
     // TSK_ExplicitInstantiationDefinition
-    bool NewlyDLLExported =
-        !PreviouslyDLLExported && Specialization->hasAttr<DLLExportAttr>();
+    bool NewlyDLLExported = !PreviouslyDLLExported && AttachedExportAttr &&
+                            Specialization->hasAttr<DLLExportAttr>();
+    bool NewlyDLLImported = !PreviouslyDLLImported && AttachedImportAttr &&
+                            Specialization->hasAttr<DLLImportAttr>();
     if (Old_TSK == TSK_ImplicitInstantiation && NewlyDLLExported &&
         Context.getTargetInfo().shouldDLLImportComdatSymbols()) {
       // An explicit instantiation definition can add a dll attribute to a
@@ -10475,6 +10484,7 @@ DeclResult Sema::ActOnExplicitInstantiation(
       assert(Def == Specialization &&
              "Def and Specialization should match for implicit instantiation");
       dllExportImportClassTemplateSpecialization(*this, Def);
+      DLLAttrAffected = true;
     }
 
     // In MinGW mode, export the template instantiation if the declaration
@@ -10483,6 +10493,23 @@ DeclResult Sema::ActOnExplicitInstantiation(
         Context.getTargetInfo().getTriple().isOSCygMing() &&
         PrevDecl->hasAttr<DLLExportAttr>()) {
       dllExportImportClassTemplateSpecialization(*this, Def);
+      DLLAttrAffected = true;
+    }
+
+    if (!DLLAttrAffected && (NewlyDLLExported || NewlyDLLImported)) {
+      if (Context.getTargetInfo().getTriple().isOSCygMing() &&
+          TSK == TSK_ExplicitInstantiationDeclaration && NewlyDLLImported) {
+        // In MinGW mode, all undefined symbols are also searched from DLLs
+        // even if they were not declared with dllimport, so doesn't warn
+        // about ignoring dllimport.
+      } else {
+        const ParsedAttr *A =
+            AttachedExportAttr ? AttachedExportAttr : AttachedImportAttr;
+        Diag(A->getLoc(), diag::warn_dllattr_ignored_already_instantiated) << A;
+        Diag(Def->getPointOfInstantiation(),
+             diag::note_instantiation_required_here)
+            << /*implicit|explicit=*/0;
+      }
     }
 
     // Set the template specialization kind. Make sure it is set before

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -10331,6 +10331,7 @@ DeclResult Sema::ActOnExplicitInstantiation(
     // Check for dllimport class template instantiation definitions.
     bool DLLImport =
         ClassTemplate->getTemplatedDecl()->getAttr<DLLImportAttr>();
+    // dllexport trumps dllimport.
     if ((DLLImport || AttachedImportAttr) && !AttachedExportAttr) {
       TSK = TSK_ExplicitInstantiationDeclaration;
       DLLImportExplicitInstantiationDef = true;

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -10294,23 +10294,32 @@ DeclResult Sema::ActOnExplicitInstantiation(
                                        ? TSK_ExplicitInstantiationDefinition
                                        : TSK_ExplicitInstantiationDeclaration;
 
+  bool DLLAttrAffected = false;
+  const ParsedAttr *AttachedExportAttr = nullptr;
+  const ParsedAttr *AttachedImportAttr = nullptr;
+  for (const ParsedAttr &AL : Attr) {
+    if (AL.getKind() == ParsedAttr::AT_DLLExport)
+      AttachedExportAttr = &AL;
+    else if (AL.getKind() == ParsedAttr::AT_DLLImport)
+      AttachedImportAttr = &AL;
+  }
+
   if (TSK == TSK_ExplicitInstantiationDeclaration &&
       !Context.getTargetInfo().getTriple().isOSCygMing()) {
     // Check for dllexport class template instantiation declarations,
     // except for MinGW mode.
-    for (const ParsedAttr &AL : Attr) {
-      if (AL.getKind() == ParsedAttr::AT_DLLExport) {
-        Diag(ExternLoc,
-             diag::warn_attribute_dllexport_explicit_instantiation_decl);
-        Diag(AL.getLoc(), diag::note_attribute);
-        break;
-      }
+    if (AttachedExportAttr) {
+      Diag(ExternLoc,
+           diag::warn_attribute_dllexport_explicit_instantiation_decl);
+      Diag(AttachedExportAttr->getLoc(), diag::note_attribute);
+      DLLAttrAffected = true;
     }
 
     if (auto *A = ClassTemplate->getTemplatedDecl()->getAttr<DLLExportAttr>()) {
       Diag(ExternLoc,
            diag::warn_attribute_dllexport_explicit_instantiation_decl);
       Diag(A->getLocation(), diag::note_attribute);
+      DLLAttrAffected = true;
     }
   }
 
@@ -10318,20 +10327,11 @@ DeclResult Sema::ActOnExplicitInstantiation(
   // instantiation declarations for most purposes.
   bool DLLImportExplicitInstantiationDef = false;
   if (TSK == TSK_ExplicitInstantiationDefinition &&
-      Context.getTargetInfo().getCXXABI().isMicrosoft()) {
+      Context.getTargetInfo().shouldDLLImportComdatSymbols()) {
     // Check for dllimport class template instantiation definitions.
     bool DLLImport =
         ClassTemplate->getTemplatedDecl()->getAttr<DLLImportAttr>();
-    for (const ParsedAttr &AL : Attr) {
-      if (AL.getKind() == ParsedAttr::AT_DLLImport)
-        DLLImport = true;
-      if (AL.getKind() == ParsedAttr::AT_DLLExport) {
-        // dllexport trumps dllimport here.
-        DLLImport = false;
-        break;
-      }
-    }
-    if (DLLImport) {
+    if ((DLLImport || AttachedImportAttr) && !AttachedExportAttr) {
       TSK = TSK_ExplicitInstantiationDeclaration;
       DLLImportExplicitInstantiationDef = true;
     }
@@ -10363,28 +10363,30 @@ DeclResult Sema::ActOnExplicitInstantiation(
       Context.getTargetInfo().getTriple().isOSCygMing()) {
     // Check for dllexport class template instantiation definitions in MinGW
     // mode, if a previous declaration of the instantiation was seen.
-    for (const ParsedAttr &AL : Attr) {
-      if (AL.getKind() == ParsedAttr::AT_DLLExport) {
-        if (PrevDecl->hasAttr<DLLExportAttr>()) {
-          Diag(AL.getLoc(), diag::warn_attr_dllexport_explicit_inst_def);
-        } else {
-          Diag(AL.getLoc(),
-               diag::warn_attr_dllexport_explicit_inst_def_mismatch);
-          Diag(PrevDecl->getLocation(), diag::note_prev_decl_missing_dllexport);
-        }
-        break;
+    if (AttachedExportAttr) {
+      if (PrevDecl->hasAttr<DLLExportAttr>()) {
+        Diag(AttachedExportAttr->getLoc(),
+             diag::warn_attr_dllexport_explicit_inst_def);
+      } else {
+        Diag(AttachedExportAttr->getLoc(),
+             diag::warn_attr_dllexport_explicit_inst_def_mismatch);
+        Diag(PrevDecl->getLocation(), diag::note_prev_decl_missing_dllexport);
       }
+      DLLAttrAffected = true;
+    } else if (AttachedImportAttr) {
+      Diag(AttachedImportAttr->getLoc(),
+           diag::warn_attribute_dllimport_explicit_instantiation_def);
+      DLLAttrAffected = true;
     }
   }
 
   if (TSK == TSK_ExplicitInstantiationDefinition && PrevDecl &&
       !Context.getTargetInfo().getTriple().isWindowsGNUEnvironment() &&
-      llvm::none_of(Attr, [](const ParsedAttr &AL) {
-        return AL.getKind() == ParsedAttr::AT_DLLExport;
-      })) {
+      !AttachedExportAttr) {
     if (const auto *DEA = PrevDecl->getAttr<DLLExportOnDeclAttr>()) {
       Diag(TemplateLoc, diag::warn_dllexport_on_decl_ignored);
       Diag(DEA->getLoc(), diag::note_dllexport_on_decl);
+      DLLAttrAffected = true;
     }
   }
 
@@ -10456,7 +10458,10 @@ DeclResult Sema::ActOnExplicitInstantiation(
   Specialization->setTemplateKeywordLoc(TemplateLoc);
   Specialization->setBraceRange(SourceRange());
 
-  bool PreviouslyDLLExported = Specialization->hasAttr<DLLExportAttr>();
+  bool PreviouslyDLLExported = Specialization->hasAttr<DLLExportAttr>() ||
+                               (PrevDecl && PrevDecl->hasAttr<DLLExportAttr>());
+  bool PreviouslyDLLImported = Specialization->hasAttr<DLLImportAttr>() ||
+                               (PrevDecl && PrevDecl->hasAttr<DLLImportAttr>());
   ProcessDeclAttributeList(S, Specialization, Attr);
   ProcessAPINotes(Specialization);
 
@@ -10492,11 +10497,12 @@ DeclResult Sema::ActOnExplicitInstantiation(
   ClassTemplateSpecializationDecl *Def
     = cast_or_null<ClassTemplateSpecializationDecl>(
                                               Specialization->getDefinition());
-  if (!Def)
+  if (!Def) {
     InstantiateClassTemplateSpecialization(TemplateNameLoc, Specialization, TSK,
                                            /*Complain=*/true,
                                            CTAI.StrictPackMatch);
-  else if (TSK == TSK_ExplicitInstantiationDefinition) {
+    DLLAttrAffected = true;
+  } else if (TSK == TSK_ExplicitInstantiationDefinition) {
     MarkVTableUsed(TemplateNameLoc, Specialization, true);
     Specialization->setPointOfInstantiation(Def->getPointOfInstantiation());
   }
@@ -10524,13 +10530,16 @@ DeclResult Sema::ActOnExplicitInstantiation(
         A->setInherited(true);
         Def->addAttr(A);
         dllExportImportClassTemplateSpecialization(*this, Def);
+        DLLAttrAffected = true;
       }
     }
 
     // Fix a TSK_ImplicitInstantiation followed by a
     // TSK_ExplicitInstantiationDefinition
-    bool NewlyDLLExported =
-        !PreviouslyDLLExported && Specialization->hasAttr<DLLExportAttr>();
+    bool NewlyDLLExported = !PreviouslyDLLExported && AttachedExportAttr &&
+                            Specialization->hasAttr<DLLExportAttr>();
+    bool NewlyDLLImported = !PreviouslyDLLImported && AttachedImportAttr &&
+                            Specialization->hasAttr<DLLImportAttr>();
     if (Old_TSK == TSK_ImplicitInstantiation && NewlyDLLExported &&
         Context.getTargetInfo().shouldDLLImportComdatSymbols()) {
       // An explicit instantiation definition can add a dll attribute to a
@@ -10548,6 +10557,7 @@ DeclResult Sema::ActOnExplicitInstantiation(
       assert(Def == Specialization &&
              "Def and Specialization should match for implicit instantiation");
       dllExportImportClassTemplateSpecialization(*this, Def);
+      DLLAttrAffected = true;
     }
 
     // In MinGW mode, export the template instantiation if the declaration
@@ -10556,6 +10566,23 @@ DeclResult Sema::ActOnExplicitInstantiation(
         Context.getTargetInfo().getTriple().isOSCygMing() &&
         PrevDecl->hasAttr<DLLExportAttr>()) {
       dllExportImportClassTemplateSpecialization(*this, Def);
+      DLLAttrAffected = true;
+    }
+
+    if (!DLLAttrAffected && (NewlyDLLExported || NewlyDLLImported)) {
+      if (Context.getTargetInfo().getTriple().isOSCygMing() &&
+          TSK == TSK_ExplicitInstantiationDeclaration && NewlyDLLImported) {
+        // In MinGW mode, all undefined symbols are also searched from DLLs
+        // even if they were not declared with dllimport, so doesn't warn
+        // about ignoring dllimport.
+      } else {
+        const ParsedAttr *A =
+            AttachedExportAttr ? AttachedExportAttr : AttachedImportAttr;
+        Diag(A->getLoc(), diag::warn_dllattr_ignored_already_instantiated) << A;
+        Diag(Def->getPointOfInstantiation(),
+             diag::note_instantiation_required_here)
+            << /*implicit|explicit=*/0;
+      }
     }
 
     // Set the template specialization kind. Make sure it is set before

--- a/clang/test/SemaCXX/dllexport.cpp
+++ b/clang/test/SemaCXX/dllexport.cpp
@@ -1049,6 +1049,56 @@ template<typename T> __declspec(dllexport) constexpr int CTMR<T>::ConstexprField
 // dllexport.
 template <> void ExportClassTmplMembers<int>::normalDecl() = delete; // non-gnu-error {{attribute 'dllexport' cannot be applied to a deleted function}}
 
+struct InstTrig {
+    struct Spec;
+    struct Impl;
+    struct Decl;
+};
+template<bool InstDef, typename... Triggers>
+struct ClassTmplSpecializedMember { // gnu-note 5 {{'dllexport' attribute is missing on previous declaration}}
+  void specializedMember1();
+  void specializedMember2();
+  void instantiatedMember1();
+  void instantiatedMember2();
+  void member() {}
+};
+
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec>::specializedMember1();
+extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Spec>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
+                                                                                                   non-gnu-note{{attribute is here}}
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec>::specializedMember1();
+template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Spec>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
+
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Impl>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
+                                                                                                   non-gnu-note{{attribute is here}}
+void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Impl>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
+
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember1();
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember2();
+extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
+                                                                                                                   non-gnu-note{{attribute is here}}
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>::specializedMember1();
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>::specializedMember2();
+template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
+
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>::specializedMember1();
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
+                                                                                                                   non-gnu-note{{attribute is here}}
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>::specializedMember1();
+void anchor(ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
+
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }
+template <> void ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec>::specializedMember1();
+extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
+                                                                                                                   non-gnu-note{{attribute is here}}
+void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }
+template <> void ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec>::specializedMember1();
+template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
+
 
 //===----------------------------------------------------------------------===//
 // Class template member templates

--- a/clang/test/SemaCXX/dllexport.cpp
+++ b/clang/test/SemaCXX/dllexport.cpp
@@ -1063,38 +1063,43 @@ struct ClassTmplSpecializedMember { // gnu-note 5 {{'dllexport' attribute is mis
   void member() {}
 };
 
-template <> void ClassTmplSpecializedMember<false, InstTrig::Spec>::specializedMember1();
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec>::specializedMember1();       // gnu-note{{implicit instantiation first required here}}
 extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Spec>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
-                                                                                                   non-gnu-note{{attribute is here}}
+                                                                                                   non-gnu-note{{attribute is here}} \
+                                                                                                   gnu-warning{{'dllexport' attribute ignored; class template is already instantiated}}
 template <> void ClassTmplSpecializedMember<true, InstTrig::Spec>::specializedMember1();
 template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Spec>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
 
-void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl> &x) { x.instantiatedMember1(); }  // gnu-note{{implicit instantiation first required here}}
 extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Impl>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
-                                                                                                   non-gnu-note{{attribute is here}}
+                                                                                                   non-gnu-note{{attribute is here}} \
+                                                                                                   gnu-warning{{'dllexport' attribute ignored; class template is already instantiated}}
 void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl> &x) { x.instantiatedMember1(); }
 template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Impl>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
 
-template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember1();
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember1();       // gnu-note{{implicit instantiation first required here}}
 template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember2();
 extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
-                                                                                                                   non-gnu-note{{attribute is here}}
+                                                                                                                   non-gnu-note{{attribute is here}} \
+                                                                                                                   gnu-warning{{'dllexport' attribute ignored; class template is already instantiated}}
 template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>::specializedMember1();
 template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>::specializedMember2();
 template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
 
-template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>::specializedMember1();
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>::specializedMember1();       // gnu-note{{implicit instantiation first required here}}
 void anchor(ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl> &x) { x.instantiatedMember1(); }
 extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
-                                                                                                                   non-gnu-note{{attribute is here}}
+                                                                                                                   non-gnu-note{{attribute is here}} \
+                                                                                                                   gnu-warning{{'dllexport' attribute ignored; class template is already instantiated}}
 template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>::specializedMember1();
 void anchor(ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl> &x) { x.instantiatedMember1(); }
 template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
 
-void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }  // gnu-note{{implicit instantiation first required here}}
 template <> void ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec>::specializedMember1();
 extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
-                                                                                                                   non-gnu-note{{attribute is here}}
+                                                                                                                   non-gnu-note{{attribute is here}} \
+                                                                                                                   gnu-warning{{'dllexport' attribute ignored; class template is already instantiated}}
 void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }
 template <> void ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec>::specializedMember1();
 template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}

--- a/clang/test/SemaCXX/dllexport.cpp
+++ b/clang/test/SemaCXX/dllexport.cpp
@@ -1077,38 +1077,43 @@ struct ClassTmplSpecializedMember { // gnu-note 5 {{'dllexport' attribute is mis
   void member() {}
 };
 
-template <> void ClassTmplSpecializedMember<false, InstTrig::Spec>::specializedMember1();
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec>::specializedMember1();       // gnu-note{{implicit instantiation first required here}}
 extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Spec>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
-                                                                                                   non-gnu-note{{attribute is here}}
+                                                                                                   non-gnu-note{{attribute is here}} \
+                                                                                                   gnu-warning{{'dllexport' attribute ignored; class template is already instantiated}}
 template <> void ClassTmplSpecializedMember<true, InstTrig::Spec>::specializedMember1();
 template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Spec>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
 
-void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl> &x) { x.instantiatedMember1(); }  // gnu-note{{implicit instantiation first required here}}
 extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Impl>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
-                                                                                                   non-gnu-note{{attribute is here}}
+                                                                                                   non-gnu-note{{attribute is here}} \
+                                                                                                   gnu-warning{{'dllexport' attribute ignored; class template is already instantiated}}
 void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl> &x) { x.instantiatedMember1(); }
 template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Impl>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
 
-template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember1();
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember1();       // gnu-note{{implicit instantiation first required here}}
 template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember2();
 extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
-                                                                                                                   non-gnu-note{{attribute is here}}
+                                                                                                                   non-gnu-note{{attribute is here}} \
+                                                                                                                   gnu-warning{{'dllexport' attribute ignored; class template is already instantiated}}
 template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>::specializedMember1();
 template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>::specializedMember2();
 template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
 
-template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>::specializedMember1();
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>::specializedMember1();       // gnu-note{{implicit instantiation first required here}}
 void anchor(ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl> &x) { x.instantiatedMember1(); }
 extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
-                                                                                                                   non-gnu-note{{attribute is here}}
+                                                                                                                   non-gnu-note{{attribute is here}} \
+                                                                                                                   gnu-warning{{'dllexport' attribute ignored; class template is already instantiated}}
 template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>::specializedMember1();
 void anchor(ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl> &x) { x.instantiatedMember1(); }
 template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
 
-void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }  // gnu-note{{implicit instantiation first required here}}
 template <> void ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec>::specializedMember1();
 extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
-                                                                                                                   non-gnu-note{{attribute is here}}
+                                                                                                                   non-gnu-note{{attribute is here}} \
+                                                                                                                   gnu-warning{{'dllexport' attribute ignored; class template is already instantiated}}
 void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }
 template <> void ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec>::specializedMember1();
 template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}

--- a/clang/test/SemaCXX/dllexport.cpp
+++ b/clang/test/SemaCXX/dllexport.cpp
@@ -1063,6 +1063,56 @@ template<typename T> __declspec(dllexport) constexpr int CTMR<T>::ConstexprField
 // dllexport.
 template <> void ExportClassTmplMembers<int>::normalDecl() = delete; // non-gnu-error {{attribute 'dllexport' cannot be applied to a deleted function}}
 
+struct InstTrig {
+    struct Spec;
+    struct Impl;
+    struct Decl;
+};
+template<bool InstDef, typename... Triggers>
+struct ClassTmplSpecializedMember { // gnu-note 5 {{'dllexport' attribute is missing on previous declaration}}
+  void specializedMember1();
+  void specializedMember2();
+  void instantiatedMember1();
+  void instantiatedMember2();
+  void member() {}
+};
+
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec>::specializedMember1();
+extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Spec>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
+                                                                                                   non-gnu-note{{attribute is here}}
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec>::specializedMember1();
+template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Spec>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
+
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Impl>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
+                                                                                                   non-gnu-note{{attribute is here}}
+void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Impl>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
+
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember1();
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember2();
+extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
+                                                                                                                   non-gnu-note{{attribute is here}}
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>::specializedMember1();
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>::specializedMember2();
+template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
+
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>::specializedMember1();
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
+                                                                                                                   non-gnu-note{{attribute is here}}
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>::specializedMember1();
+void anchor(ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
+
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }
+template <> void ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec>::specializedMember1();
+extern template struct __declspec(dllexport) ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec>; // non-gnu-warning{{explicit instantiation declaration should not be 'dllexport'}} \
+                                                                                                                   non-gnu-note{{attribute is here}}
+void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }
+template <> void ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec>::specializedMember1();
+template struct __declspec(dllexport) ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec>;         // gnu-warning{{'dllexport' attribute ignored on explicit instantiation definition}}
+
 
 //===----------------------------------------------------------------------===//
 // Class template member templates

--- a/clang/test/SemaCXX/dllimport.cpp
+++ b/clang/test/SemaCXX/dllimport.cpp
@@ -1,16 +1,16 @@
-// RUN: %clang_cc1 -triple i686-win32             -fsyntax-only -fms-extensions -verify -std=c++11 -Wunsupported-dll-base-class-template -DMS %s
-// RUN: %clang_cc1 -triple x86_64-win32           -fsyntax-only -fms-extensions -verify -std=c++1y -Wunsupported-dll-base-class-template -DMS %s
-// RUN: %clang_cc1 -triple i686-mingw32           -fsyntax-only -fms-extensions -verify -std=c++1y -Wunsupported-dll-base-class-template -DGNU %s
-// RUN: %clang_cc1 -triple x86_64-mingw32         -fsyntax-only -fms-extensions -verify -std=c++11 -Wunsupported-dll-base-class-template -DGNU %s
-// RUN: %clang_cc1 -triple x86_64-mingw32         -fsyntax-only -fms-extensions -verify -std=c++17 -Wunsupported-dll-base-class-template -DGNU %s
-// RUN: %clang_cc1 -triple i686-pc-cygwin         -fsyntax-only -fms-extensions -verify -std=c++1y -Wunsupported-dll-base-class-template -DGNU %s
-// RUN: %clang_cc1 -triple x86_64-pc-cygwin       -fsyntax-only -fms-extensions -verify -std=c++11 -Wunsupported-dll-base-class-template -DGNU %s
-// RUN: %clang_cc1 -triple x86_64-pc-cygwin       -fsyntax-only -fms-extensions -verify -std=c++17 -Wunsupported-dll-base-class-template -DGNU %s
-// RUN: %clang_cc1 -triple i686-windows-itanium   -fsyntax-only -fms-extensions -verify -std=c++11 -Wunsupported-dll-base-class-template -DWI %s
-// RUN: %clang_cc1 -triple x86_64-windows-itanium -fsyntax-only -fms-extensions -verify -std=c++17 -Wunsupported-dll-base-class-template -DWI %s
-// RUN: %clang_cc1 -triple x86_64-scei-ps4        -fsyntax-only -fdeclspec      -verify -std=c++11 -Wunsupported-dll-base-class-template -DPS %s
-// RUN: %clang_cc1 -triple x86_64-scei-ps4        -fsyntax-only -fdeclspec      -verify -std=c++17 -Wunsupported-dll-base-class-template -DPS %s
-// RUN: %clang_cc1 -triple x86_64-sie-ps5         -fsyntax-only -fdeclspec      -verify -std=c++17 -Wunsupported-dll-base-class-template -DPS %s
+// RUN: %clang_cc1 -triple i686-win32             -fsyntax-only -fms-extensions -verify=expected,ms,non-gnu,ms-ps                 -std=c++11 -Wunsupported-dll-base-class-template %s
+// RUN: %clang_cc1 -triple x86_64-win32           -fsyntax-only -fms-extensions -verify=expected,ms,non-gnu,ms-ps                 -std=c++17 -Wunsupported-dll-base-class-template %s
+// RUN: %clang_cc1 -triple i686-mingw32           -fsyntax-only -fms-extensions -verify=expected,non-ms,gnu,win-gnu,non-ms-17     -std=c++17 -Wunsupported-dll-base-class-template %s
+// RUN: %clang_cc1 -triple x86_64-mingw32         -fsyntax-only -fms-extensions -verify=expected,non-ms,gnu,win-gnu,non-ms-11     -std=c++11 -Wunsupported-dll-base-class-template %s
+// RUN: %clang_cc1 -triple x86_64-mingw32         -fsyntax-only -fms-extensions -verify=expected,non-ms,gnu,win-gnu,non-ms-17     -std=c++17 -Wunsupported-dll-base-class-template %s
+// RUN: %clang_cc1 -triple i686-pc-cygwin         -fsyntax-only -fms-extensions -verify=expected,non-ms,gnu,win-gnu,non-ms-17     -std=c++17 -Wunsupported-dll-base-class-template %s
+// RUN: %clang_cc1 -triple x86_64-pc-cygwin       -fsyntax-only -fms-extensions -verify=expected,non-ms,gnu,win-gnu,non-ms-11     -std=c++11 -Wunsupported-dll-base-class-template %s
+// RUN: %clang_cc1 -triple x86_64-pc-cygwin       -fsyntax-only -fms-extensions -verify=expected,non-ms,gnu,win-gnu,non-ms-17     -std=c++17 -Wunsupported-dll-base-class-template %s
+// RUN: %clang_cc1 -triple i686-windows-itanium   -fsyntax-only -fms-extensions -verify=expected,non-ms,non-gnu,win-gnu,non-ms-11 -std=c++11 -Wunsupported-dll-base-class-template %s
+// RUN: %clang_cc1 -triple x86_64-windows-itanium -fsyntax-only -fms-extensions -verify=expected,non-ms,non-gnu,win-gnu,non-ms-17 -std=c++17 -Wunsupported-dll-base-class-template %s
+// RUN: %clang_cc1 -triple x86_64-scei-ps4        -fsyntax-only -fdeclspec      -verify=expected,non-ms,non-gnu,ms-ps,non-ms-11   -std=c++11 -Wunsupported-dll-base-class-template %s
+// RUN: %clang_cc1 -triple x86_64-scei-ps4        -fsyntax-only -fdeclspec      -verify=expected,non-ms,non-gnu,ms-ps,non-ms-17   -std=c++17 -Wunsupported-dll-base-class-template %s
+// RUN: %clang_cc1 -triple x86_64-sie-ps5         -fsyntax-only -fdeclspec      -verify=expected,non-ms,non-gnu,ms-ps,non-ms-17   -std=c++17 -Wunsupported-dll-base-class-template %s
 
 // Helper structs to make templates more expressive.
 struct ImplicitInst_Imported {};
@@ -59,49 +59,27 @@ __declspec(dllimport) int GlobalInit1 = 1; // expected-error{{definition of dlli
 int __declspec(dllimport) GlobalInit2 = 1; // expected-error{{definition of dllimport data}}
 
 // Declare, then reject definition.
-#ifdef GNU
-// expected-note@+2{{previous attribute is here}}
-#endif
-__declspec(dllimport) extern int ExternGlobalDeclInit; // expected-note{{previous declaration is here}}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+4{{'ExternGlobalDeclInit' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-// expected-warning@+2{{'ExternGlobalDeclInit' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
-int ExternGlobalDeclInit = 1;
+__declspec(dllimport) extern int ExternGlobalDeclInit; // expected-note{{previous declaration is here}} \
+                                                          gnu-note{{previous attribute is here}}
+int ExternGlobalDeclInit = 1;// non-gnu-warning{{'ExternGlobalDeclInit' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                gnu-warning{{'ExternGlobalDeclInit' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 
-#ifdef GNU
-// expected-note@+2{{previous attribute is here}}
-#endif
-__declspec(dllimport) int GlobalDeclInit; // expected-note{{previous declaration is here}}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+4{{'GlobalDeclInit' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-// expected-warning@+2{{'GlobalDeclInit' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
-int GlobalDeclInit = 1;
+__declspec(dllimport) int GlobalDeclInit; // expected-note{{previous declaration is here}} \
+                                          // gnu-note{{previous attribute is here}}
 
-#ifdef GNU
-// expected-note@+2{{previous attribute is here}}
-#endif
-int *__attribute__((dllimport)) GlobalDeclChunkAttrInit; // expected-note{{previous declaration is here}}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+4{{'GlobalDeclChunkAttrInit' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-// expected-warning@+2{{'GlobalDeclChunkAttrInit' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
-int *GlobalDeclChunkAttrInit = 0;
+int GlobalDeclInit = 1;// non-gnu-warning{{'GlobalDeclInit' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                       // gnu-warning{{'GlobalDeclInit' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 
-#ifdef GNU
-// expected-note@+2{{previous attribute is here}}
-#endif
-int GlobalDeclAttrInit __attribute__((dllimport)); // expected-note{{previous declaration is here}}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+4{{'GlobalDeclAttrInit' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-// expected-warning@+2{{'GlobalDeclAttrInit' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
-int GlobalDeclAttrInit = 1;
+int *__attribute__((dllimport)) GlobalDeclChunkAttrInit; // expected-note{{previous declaration is here}} \
+                                                            gnu-note{{previous attribute is here}}
+
+int *GlobalDeclChunkAttrInit = 0; // non-gnu-warning{{'GlobalDeclChunkAttrInit' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                     gnu-warning{{'GlobalDeclChunkAttrInit' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
+
+int GlobalDeclAttrInit __attribute__((dllimport)); // expected-note{{previous declaration is here}} \
+                                                      gnu-note{{previous attribute is here}}
+int GlobalDeclAttrInit = 1; // non-gnu-warning{{'GlobalDeclAttrInit' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                               gnu-warning{{'GlobalDeclAttrInit' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 
 // Redeclarations
 __declspec(dllimport) extern int GlobalRedecl1;
@@ -130,22 +108,18 @@ __declspec(dllimport) extern int GlobalRedecl5; // expected-warning{{redeclarati
 // External linkage is required.
 __declspec(dllimport) static int StaticGlobal; // expected-error{{'StaticGlobal' must have external linkage when declared 'dllimport'}}
 __declspec(dllimport) Internal InternalTypeGlobal; // expected-error{{'InternalTypeGlobal' must have external linkage when declared 'dllimport'}}
-#ifndef MS
-namespace    { __declspec(dllimport) int InternalGlobal; } // expected-error{{'(anonymous namespace)::InternalGlobal' must have external linkage when declared 'dllimport'}}
-#endif
+namespace    { __declspec(dllimport) int InternalGlobal; } // non-ms-error{{'(anonymous namespace)::InternalGlobal' must have external linkage when declared 'dllimport'}}
 namespace ns { __declspec(dllimport) int ExternalGlobal; }
 
-__declspec(dllimport) auto InternalAutoTypeGlobal = Internal(); // expected-error{{'InternalAutoTypeGlobal' must have external linkage when declared 'dllimport'}}
-                                                                // expected-error@-1{{definition of dllimport data}}
+__declspec(dllimport) auto InternalAutoTypeGlobal = Internal(); // expected-error{{'InternalAutoTypeGlobal' must have external linkage when declared 'dllimport'}} \
+                                                                   expected-error{{definition of dllimport data}}
 
 // Thread local variables are invalid.
 __declspec(dllimport) __thread int ThreadLocalGlobal; // expected-error{{'ThreadLocalGlobal' cannot be thread local when declared 'dllimport'}}
 // This doesn't work on MinGW, because there, dllimport on the inline function is ignored.
-#ifndef GNU
-inline void __declspec(dllimport) ImportedInlineWithThreadLocal() {
+inline void __declspec(dllimport) ImportedInlineWithThreadLocal() { // gnu-warning{{'dllimport' attribute ignored on inline function}}
   static __thread int OK; // no-error
 }
-#endif
 
 // Import in local scope.
 __declspec(dllimport) float LocalRedecl1; // expected-note{{previous declaration is here}}
@@ -182,31 +156,19 @@ template<typename T> __declspec(dllimport) int VarTmplInit1 = 1; // expected-err
 template<typename T> int __declspec(dllimport) VarTmplInit2 = 1; // expected-error{{definition of dllimport data}}
 
 // Declare, then reject definition.
-#ifdef GNU
-// expected-note@+3{{previous attribute is here}}
-#endif
 template <typename T>
-__declspec(dllimport) extern int ExternVarTmplDeclInit; // expected-note{{previous declaration is here}}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+5{{'ExternVarTmplDeclInit' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-// expected-warning@+3{{'ExternVarTmplDeclInit' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
+__declspec(dllimport) extern int ExternVarTmplDeclInit; // expected-note{{previous declaration is here}} \
+                                                           gnu-note{{previous attribute is here}}
 template <typename T>
-int ExternVarTmplDeclInit = 1;
+int ExternVarTmplDeclInit = 1; // non-gnu-warning{{'ExternVarTmplDeclInit' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                  gnu-warning{{'ExternVarTmplDeclInit' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 
-#ifdef GNU
-// expected-note@+3{{previous attribute is here}}
-#endif
 template <typename T>
-__declspec(dllimport) int VarTmplDeclInit; // expected-note{{previous declaration is here}}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+5{{'VarTmplDeclInit' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-// expected-warning@+3{{'VarTmplDeclInit' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
+__declspec(dllimport) int VarTmplDeclInit; // expected-note{{previous declaration is here}} \
+                                              gnu-note{{previous attribute is here}}
 template <typename T>
-int VarTmplDeclInit = 1;
+int VarTmplDeclInit = 1; // non-gnu-warning{{'VarTmplDeclInit' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                            gnu-warning{{'VarTmplDeclInit' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 
 // Redeclarations
 template<typename T> __declspec(dllimport) extern int VarTmplRedecl1;
@@ -224,9 +186,7 @@ template<typename T> __declspec(dllimport) extern int VarTmplRedecl4; // expecte
 // External linkage is required.
 template<typename T> __declspec(dllimport) static int StaticVarTmpl; // expected-error{{'StaticVarTmpl' must have external linkage when declared 'dllimport'}}
 template<typename T> __declspec(dllimport) Internal InternalTypeVarTmpl; // expected-error{{'InternalTypeVarTmpl' must have external linkage when declared 'dllimport'}}
-#ifndef MS
-namespace    { template<typename T> __declspec(dllimport) int InternalVarTmpl; } // expected-error{{'(anonymous namespace)::InternalVarTmpl' must have external linkage when declared 'dllimport'}}
-#endif
+namespace    { template<typename T> __declspec(dllimport) int InternalVarTmpl; } // non-ms-error{{'(anonymous namespace)::InternalVarTmpl' must have external linkage when declared 'dllimport'}}
 namespace ns { template<typename T> __declspec(dllimport) int ExternalVarTmpl; }
 
 template<typename T> __declspec(dllimport) auto InternalAutoTypeVarTmpl = Internal(); // expected-error{{definition of dllimport data}} // expected-error{{'InternalAutoTypeVarTmpl' must have external linkage when declared 'dllimport'}}
@@ -284,24 +244,14 @@ __declspec(dllimport) void def() {} // expected-error{{dllimport cannot be appli
 extern "C" __declspec(dllimport) void externC();
 
 // Import inline function.
-#ifdef GNU
-// expected-warning@+3{{'dllimport' attribute ignored on inline function}}
-// expected-warning@+3{{'dllimport' attribute ignored on inline function}}
-#endif
-__declspec(dllimport) inline void inlineFunc1() {}
-inline void __attribute__((dllimport)) inlineFunc2() {}
+__declspec(dllimport) inline void inlineFunc1() {}      // gnu-warning{{'dllimport' attribute ignored on inline function}}
+inline void __attribute__((dllimport)) inlineFunc2() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
-#ifdef GNU
-// expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-__declspec(dllimport) inline void inlineDecl();
+__declspec(dllimport) inline void inlineDecl(); // gnu-warning{{'dllimport' attribute ignored on inline function}}
                              void inlineDecl() {}
 
 __declspec(dllimport) void inlineDef();
-#ifdef GNU
-// expected-warning@+2{{'inlineDef' redeclared inline; 'dllimport' attribute ignored}}
-#endif
-               inline void inlineDef() {}
+               inline void inlineDef() {} // gnu-warning{{'inlineDef' redeclared inline; 'dllimport' attribute ignored}}
 
 // Redeclarations
 __declspec(dllimport) void redecl1();
@@ -310,17 +260,11 @@ __declspec(dllimport) void redecl1();
 __declspec(dllimport) void redecl2(); // expected-note{{previous declaration is here}} expected-note{{previous attribute is here}}
                       void redecl2(); // expected-warning{{'redecl2' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 
-#ifdef GNU
-                      // expected-note@+2{{previous attribute is here}}
-#endif
-                      __declspec(dllimport) void redecl3(); // expected-note{{previous declaration is here}}
+__declspec(dllimport) void redecl3(); // expected-note{{previous declaration is here}} \
+                                         gnu-note{{previous attribute is here}}
                       // NB: Both MSVC and Clang issue a warning and make redecl3 dllexport.
-#if defined(MS) || defined(WI) || defined(PS)
-                      // expected-warning@+4{{'redecl3' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-                      // expected-warning@+2{{'redecl3' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
-                      void redecl3() {}
+                      void redecl3() {} // non-gnu-warning{{'redecl3' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                           gnu-warning{{'redecl3' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 
                       void redecl4(); // expected-note{{previous declaration is here}}
 __declspec(dllimport) void redecl4(); // expected-warning{{redeclaration of 'redecl4' should not add 'dllimport' attribute}}
@@ -330,43 +274,26 @@ extern "C" {
 __declspec(dllimport) void redecl5(); // expected-warning{{redeclaration of 'redecl5' should not add 'dllimport' attribute}}
 }
 
-#if defined(MS) || defined(WI) || defined(PS)
-                      void redecl6(); // expected-note{{previous declaration is here}}
-__declspec(dllimport) inline void redecl6() {} // expected-warning{{redeclaration of 'redecl6' should not add 'dllimport' attribute}}
-#else
-                      void redecl6();
-__declspec(dllimport) inline void redecl6() {} // expected-warning{{'dllimport' attribute ignored on inline function}}
-#endif
+                      void redecl6(); // non-gnu-note{{previous declaration is here}}
+__declspec(dllimport) inline void redecl6() {} // non-gnu-warning{{redeclaration of 'redecl6' should not add 'dllimport' attribute}} \
+                                                  gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 // Friend functions
 struct FuncFriend {
   friend __declspec(dllimport) void friend1();
   friend __declspec(dllimport) void friend2(); // expected-note{{previous declaration is here}} expected-note{{previous attribute is here}}
-#ifdef GNU
-// expected-note@+2{{previous attribute is here}}
-#endif
-  friend __declspec(dllimport) void friend3(); // expected-note{{previous declaration is here}}
+  friend __declspec(dllimport) void friend3(); // expected-note{{previous declaration is here}} \
+                                                  gnu-note{{previous attribute is here}}
   friend                       void friend4(); // expected-note{{previous declaration is here}}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-note@+2{{previous declaration is here}}
-#endif
-  friend                       void friend5();
+  friend                       void friend5(); // non-gnu-note{{previous declaration is here}}
 };
 __declspec(dllimport) void friend1();
-                      void friend2(); // expected-warning{{'friend2' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#if defined(MS) || defined(WI) || defined(PS)
-                      // expected-warning@+4{{'friend3' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-                      // expected-warning@+2{{'friend3' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
-                      void friend3() {}
-__declspec(dllimport) void friend4(); // expected-warning{{redeclaration of 'friend4' should not add 'dllimport' attribute}}
-#if defined(MS) || defined(WI) || defined(PS)
-__declspec(dllimport) inline void friend5() {} // expected-warning{{redeclaration of 'friend5' should not add 'dllimport' attribute}}
-#else
-__declspec(dllimport) inline void friend5() {} // expected-warning{{'dllimport' attribute ignored on inline function}}
-#endif
-
+                      void friend2();          // expected-warning{{'friend2' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
+                      void friend3() {}        // non-gnu-warning{{'friend3' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                                  gnu-warning{{'friend3' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
+__declspec(dllimport) void friend4();          // expected-warning{{redeclaration of 'friend4' should not add 'dllimport' attribute}}
+__declspec(dllimport) inline void friend5() {} // non-gnu-warning{{redeclaration of 'friend5' should not add 'dllimport' attribute}} \
+                                                  gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 void __declspec(dllimport) friend6(); // expected-note{{previous declaration is here}} expected-note{{previous attribute is here}}
 void __declspec(dllimport) friend7();
@@ -389,12 +316,8 @@ namespace ns { __declspec(dllimport) void externalFunc(); }
 // here which is irrelevant. But because the delete keyword is parsed later
 // there is currently no straight-forward way to avoid this diagnostic.
 __declspec(dllimport) void deletedFunc() = delete; // expected-error{{attribute 'dllimport' cannot be applied to a deleted function}} expected-error{{dllimport cannot be applied to non-inline function definition}}
-#if defined(MS) || defined(WI) || defined(PS)
-__declspec(dllimport) inline void deletedInlineFunc() = delete; // expected-error{{attribute 'dllimport' cannot be applied to a deleted function}}
-#else
-__declspec(dllimport) inline void deletedInlineFunc() = delete; // expected-warning{{'dllimport' attribute ignored on inline function}}
-#endif
-
+__declspec(dllimport) inline void deletedInlineFunc() = delete; // non-gnu-error{{attribute 'dllimport' cannot be applied to a deleted function}} \
+                                                                   gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 
 //===----------------------------------------------------------------------===//
@@ -409,28 +332,20 @@ template<typename T> void __declspec(dllimport) funcTmplDecl2();
 template<typename T> __declspec(dllimport) void funcTmplDef() {} // expected-error{{dllimport cannot be applied to non-inline function definition}}
 
 // Import inline function template.
-#ifdef GNU // MinGW always ignores dllimport on inline functions.
+// MinGW always ignores dllimport on inline functions.
+// MSVC drops dllimport when the function template is redeclared without it. (It doesn't warn, but we do.)
+template<typename T> __declspec(dllimport) inline void inlineFuncTmpl1() {}      // gnu-warning{{'dllimport' attribute ignored on inline function}}
+template<typename T> inline void __attribute__((dllimport)) inlineFuncTmpl2() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
-template<typename T> __declspec(dllimport) inline void inlineFuncTmpl1() {} // expected-warning{{'dllimport' attribute ignored on inline function}}
-template<typename T> inline void __attribute__((dllimport)) inlineFuncTmpl2() {} // expected-warning{{'dllimport' attribute ignored on inline function}}
+template<typename T> __declspec(dllimport) inline void inlineFuncTmplDecl(); // non-gnu-note{{previous declaration is here}} \
+                                                                                non-gnu-note{{previous attribute is here}} \
+                                                                                gnu-warning{{'dllimport' attribute ignored on inline function}}
+template<typename T>                              void inlineFuncTmplDecl() {} // non-gnu-warning{{'inlineFuncTmplDecl' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 
-template<typename T> __declspec(dllimport) inline void inlineFuncTmplDecl(); // expected-warning{{'dllimport' attribute ignored on inline function}}
-template<typename T>                              void inlineFuncTmplDecl() {}
-
-template<typename T> __declspec(dllimport) void inlineFuncTmplDef();
-template<typename T>                inline void inlineFuncTmplDef() {} // expected-warning{{'inlineFuncTmplDef' redeclared inline; 'dllimport' attribute ignored}}
-
-#else // MSVC drops dllimport when the function template is redeclared without it. (It doesn't warn, but we do.)
-
-template<typename T> __declspec(dllimport) inline void inlineFuncTmpl1() {}
-template<typename T> inline void __attribute__((dllimport)) inlineFuncTmpl2() {}
-
-template<typename T> __declspec(dllimport) inline void inlineFuncTmplDecl(); // expected-note{{previous declaration is here}} expected-note{{previous attribute is here}}
-template<typename T>                              void inlineFuncTmplDecl() {} // expected-warning{{'inlineFuncTmplDecl' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-
-template<typename T> __declspec(dllimport) void inlineFuncTmplDef(); // expected-note{{previous declaration is here}} expected-note{{previous attribute is here}}
-template<typename T>                inline void inlineFuncTmplDef() {} // expected-warning{{'inlineFuncTmplDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
+template<typename T> __declspec(dllimport) void inlineFuncTmplDef(); // non-gnu-note{{previous declaration is here}} \
+                                                                        non-gnu-note{{previous attribute is here}}
+template<typename T>                inline void inlineFuncTmplDef() {} // non-gnu-warning{{'inlineFuncTmplDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}} \
+                                                                          gnu-warning{{'inlineFuncTmplDef' redeclared inline; 'dllimport' attribute ignored}}
 
 // Redeclarations
 template<typename T> __declspec(dllimport) void funcTmplRedecl1();
@@ -445,10 +360,9 @@ template<typename T>                       void funcTmplRedecl3() {} // expected
 template<typename T>                       void funcTmplRedecl4(); // expected-note{{previous declaration is here}}
 template<typename T> __declspec(dllimport) void funcTmplRedecl4(); // expected-error{{redeclaration of 'funcTmplRedecl4' cannot add 'dllimport' attribute}}
 
-#ifdef MS
-template<typename T>                       void funcTmplRedecl5(); // expected-note{{previous declaration is here}}
-template<typename T> __declspec(dllimport) inline void funcTmplRedecl5() {} // expected-error{{redeclaration of 'funcTmplRedecl5' cannot add 'dllimport' attribute}}
-#endif
+template<typename T>                       void funcTmplRedecl5(); // non-gnu-note{{previous declaration is here}}
+template<typename T> __declspec(dllimport) inline void funcTmplRedecl5() {} // non-gnu-error{{redeclaration of 'funcTmplRedecl5' cannot add 'dllimport' attribute}} \
+                                                                               gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 // Function template friends
 struct FuncTmplFriend {
@@ -456,21 +370,15 @@ struct FuncTmplFriend {
   template<typename T> friend __declspec(dllimport) void funcTmplFriend2(); // expected-note{{previous declaration is here}} expected-note{{previous attribute is here}}
   template<typename T> friend __declspec(dllimport) void funcTmplFriend3(); // expected-note{{previous declaration is here}} expected-note{{previous attribute is here}}
   template<typename T> friend                       void funcTmplFriend4(); // expected-note{{previous declaration is here}}
-#ifdef GNU
-// expected-warning@+4{{'dllimport' attribute ignored on inline function}}
-#else
-// expected-note@+2{{previous declaration is here}} expected-note@+2{{previous attribute is here}}
-#endif
-  template<typename T> friend __declspec(dllimport) inline void funcTmplFriend5();
+  template<typename T> friend __declspec(dllimport) inline void funcTmplFriend5(); // non-gnu-note{{previous declaration is here}} \
+                                                                                      non-gnu-note{{previous attribute is here}} \
+                                                                                      gnu-warning{{'dllimport' attribute ignored on inline function}}
 };
 template<typename T> __declspec(dllimport) void funcTmplFriend1();
 template<typename T>                       void funcTmplFriend2(); // expected-warning{{'funcTmplFriend2' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 template<typename T>                       void funcTmplFriend3() {} // expected-warning{{'funcTmplFriend3' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 template<typename T> __declspec(dllimport) void funcTmplFriend4(); // expected-error{{redeclaration of 'funcTmplFriend4' cannot add 'dllimport' attribute}}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+2{{'funcTmplFriend5' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
-template<typename T>                       inline void funcTmplFriend5() {}
+template<typename T>                       inline void funcTmplFriend5() {} // non-gnu-warning{{'funcTmplFriend5' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 
 // External linkage is required.
 template<typename T> __declspec(dllimport) static int staticFuncTmpl(); // expected-error{{'staticFuncTmpl' must have external linkage when declared 'dllimport'}}
@@ -482,10 +390,7 @@ namespace ns { template<typename T> __declspec(dllimport) void externalFuncTmpl(
 template<typename T> void funcTmpl() {}
 template<typename T> inline void inlineFuncTmpl() {}
 template<typename T> __declspec(dllimport) void importedFuncTmplDecl();
-#ifdef GNU
-// expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-template<typename T> __declspec(dllimport) inline void importedFuncTmpl() {}
+template<typename T> __declspec(dllimport) inline void importedFuncTmpl() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 // Import implicit instantiation of an imported function template.
 void useFunTmplDecl() { importedFuncTmplDecl<ImplicitInst_Imported>(); }
@@ -503,9 +408,7 @@ template void importedFuncTmpl<ExplicitInst_Imported>();
 // declared inline.
 template<> __declspec(dllimport) void importedFuncTmpl<ExplicitSpec_Imported>();
 template<> __declspec(dllimport) void importedFuncTmpl<ExplicitSpec_Def_Imported>() {} // expected-error{{dllimport cannot be applied to non-inline function definition}}
-#ifdef MS
-template<> __declspec(dllimport) inline void importedFuncTmpl<ExplicitSpec_InlineDef_Imported>() {}
-#endif
+template<> __declspec(dllimport) inline void importedFuncTmpl<ExplicitSpec_InlineDef_Imported>() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 // Not importing specialization of an imported function template without
 // explicit dllimport.
@@ -514,26 +417,17 @@ template<> void importedFuncTmpl<ExplicitSpec_NotImported>() {}
 
 // Import explicit instantiation declaration of a non-imported function template.
 extern template __declspec(dllimport) void funcTmpl<ExplicitDecl_Imported>();
-#ifdef GNU
-// expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-extern template __declspec(dllimport) void inlineFuncTmpl<ExplicitDecl_Imported>();
+extern template __declspec(dllimport) void inlineFuncTmpl<ExplicitDecl_Imported>(); // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 // Import explicit instantiation definition of a non-imported function template.
 template __declspec(dllimport) void funcTmpl<ExplicitInst_Imported>();
-#ifdef GNU
-// expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-template __declspec(dllimport) void inlineFuncTmpl<ExplicitInst_Imported>();
+template __declspec(dllimport) void inlineFuncTmpl<ExplicitInst_Imported>(); // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 // Import specialization of a non-imported function template. A definition must
 // be declared inline.
 template<> __declspec(dllimport) void funcTmpl<ExplicitSpec_Imported>();
 template<> __declspec(dllimport) void funcTmpl<ExplicitSpec_Def_Imported>() {} // expected-error{{dllimport cannot be applied to non-inline function definition}}
-#ifdef GNU
-// expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-template<> __declspec(dllimport) inline void funcTmpl<ExplicitSpec_InlineDef_Imported>() {}
+template<> __declspec(dllimport) inline void funcTmpl<ExplicitSpec_InlineDef_Imported>() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 
 //===----------------------------------------------------------------------===//
@@ -544,42 +438,28 @@ template<> __declspec(dllimport) inline void funcTmpl<ExplicitSpec_InlineDef_Imp
 struct ImportMembers {
   struct Nested {
     __declspec(dllimport) void normalDecl();
-#ifdef GNU
-// expected-note@+2{{previous attribute is here}}
-#endif
-    __declspec(dllimport) void normalDef(); // expected-note{{previous declaration is here}}
+    __declspec(dllimport) void normalDef(); // expected-note{{previous declaration is here}} \
+                                               gnu-note{{previous attribute is here}}
   };
 
-#ifdef GNU
-// expected-note@+5{{previous attribute is here}}
-// expected-warning@+5{{'dllimport' attribute ignored on inline function}}
-// expected-warning@+6{{'dllimport' attribute ignored on inline function}}
-#endif
   __declspec(dllimport)                void normalDecl();
-  __declspec(dllimport) void normalDef(); // expected-note{{previous declaration is here}}
-  __declspec(dllimport)                void normalInclass() {}
+  __declspec(dllimport)                void normalDef();        // expected-note{{previous declaration is here}} \
+                                                                   gnu-note{{previous attribute is here}}
+  __declspec(dllimport)                void normalInclass() {}  // gnu-warning{{'dllimport' attribute ignored on inline function}}
   __declspec(dllimport)                void normalInlineDef();
-  __declspec(dllimport)         inline void normalInlineDecl();
-#ifdef GNU
-// expected-note@+5{{previous attribute is here}}
-// expected-warning@+5{{'dllimport' attribute ignored on inline function}}
-// expected-warning@+6{{'dllimport' attribute ignored on inline function}}
-#endif
+  __declspec(dllimport)         inline void normalInlineDecl();  // gnu-warning{{'dllimport' attribute ignored on inline function}}
   __declspec(dllimport) virtual        void virtualDecl();
-  __declspec(dllimport) virtual void virtualDef(); // expected-note{{previous declaration is here}}
-  __declspec(dllimport) virtual        void virtualInclass() {}
+  __declspec(dllimport) virtual        void virtualDef();        // expected-note{{previous declaration is here}} \
+                                                                    gnu-note{{previous attribute is here}}
+  __declspec(dllimport) virtual        void virtualInclass() {}  // gnu-warning{{'dllimport' attribute ignored on inline function}}
   __declspec(dllimport) virtual        void virtualInlineDef();
-  __declspec(dllimport) virtual inline void virtualInlineDecl();
-#ifdef GNU
-// expected-note@+5{{previous attribute is here}}
-// expected-warning@+5{{'dllimport' attribute ignored on inline function}}
-// expected-warning@+6{{'dllimport' attribute ignored on inline function}}
-#endif
+  __declspec(dllimport) virtual inline void virtualInlineDecl(); // gnu-warning{{'dllimport' attribute ignored on inline function}}
   __declspec(dllimport) static         void staticDecl();
-  __declspec(dllimport) static void staticDef(); // expected-note{{previous declaration is here}}
-  __declspec(dllimport) static         void staticInclass() {}
+  __declspec(dllimport) static         void staticDef();         // expected-note{{previous declaration is here}} \
+                                                                    gnu-note{{previous attribute is here}}
+  __declspec(dllimport) static         void staticInclass() {}   // gnu-warning{{'dllimport' attribute ignored on inline function}}
   __declspec(dllimport) static         void staticInlineDef();
-  __declspec(dllimport) static  inline void staticInlineDecl();
+  __declspec(dllimport) static  inline void staticInlineDecl();  // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 protected:
   __declspec(dllimport)                void protectedDecl();
@@ -595,58 +475,27 @@ public:
   __declspec(dllimport) static  const  int  StaticConstFieldEqualInit = 1;
   __declspec(dllimport) static  const  int  StaticConstFieldBraceInit{1};
   __declspec(dllimport) constexpr static int ConstexprField = 1;
-#if __cplusplus < 201703L && !defined(MS)
-  // expected-note@+2{{attribute is here}}
-#endif
-  __declspec(dllimport) constexpr static int ConstexprFieldDef = 1;
+  __declspec(dllimport) constexpr static int ConstexprFieldDef = 1; // non-ms-11-note{{attribute is here}}
 };
 
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+4{{'ImportMembers::Nested::normalDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-                                                                                 // expected-warning@+2{{'ImportMembers::Nested::normalDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
-void ImportMembers::Nested::normalDef() {}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+4{{'ImportMembers::normalDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-                                                                                 // expected-warning@+2{{'ImportMembers::normalDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
-void ImportMembers::normalDef() {}
-#ifdef GNU
-// expected-warning@+2{{'ImportMembers::normalInlineDef' redeclared inline; 'dllimport' attribute ignored}}
-#endif
-inline void ImportMembers::normalInlineDef() {}
+void ImportMembers::Nested::normalDef() {} // non-gnu-warning{{'ImportMembers::Nested::normalDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                              gnu-warning{{'ImportMembers::Nested::normalDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
+void ImportMembers::normalDef() {} // non-gnu-warning{{'ImportMembers::normalDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                      gnu-warning{{'ImportMembers::normalDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
+inline void ImportMembers::normalInlineDef() {} // gnu-warning{{'ImportMembers::normalInlineDef' redeclared inline; 'dllimport' attribute ignored}}
        void ImportMembers::normalInlineDecl() {}
-#if defined(MS) || defined(WI) || defined(PS)
-       // expected-warning@+4{{'ImportMembers::virtualDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-                                                                                 // expected-warning@+2{{'ImportMembers::virtualDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
-       void ImportMembers::virtualDef() {}
-#ifdef GNU
-// expected-warning@+2{{'ImportMembers::virtualInlineDef' redeclared inline; 'dllimport' attribute ignored}}
-#endif
-inline void ImportMembers::virtualInlineDef() {}
+       void ImportMembers::virtualDef() {} // non-gnu-warning{{'ImportMembers::virtualDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                              gnu-warning{{'ImportMembers::virtualDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
+inline void ImportMembers::virtualInlineDef() {} // gnu-warning{{'ImportMembers::virtualInlineDef' redeclared inline; 'dllimport' attribute ignored}}
        void ImportMembers::virtualInlineDecl() {}
-#if defined(MS) || defined(WI) || defined(PS)
-       // expected-warning@+4{{'ImportMembers::staticDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-                                                                                 // expected-warning@+2{{'ImportMembers::staticDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
-       void ImportMembers::staticDef() {}
-#ifdef GNU
-// expected-warning@+2{{'ImportMembers::staticInlineDef' redeclared inline; 'dllimport' attribute ignored}}
-#endif
-inline void ImportMembers::staticInlineDef() {}
+       void ImportMembers::staticDef() {} // non-gnu-warning{{'ImportMembers::staticDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                             gnu-warning{{'ImportMembers::staticDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
+inline void ImportMembers::staticInlineDef() {} // gnu-warning{{'ImportMembers::staticInlineDef' redeclared inline; 'dllimport' attribute ignored}}
        void ImportMembers::staticInlineDecl() {}
 
        int  ImportMembers::StaticFieldDef; // expected-error{{definition of dllimport static field not allowed}}
 const  int  ImportMembers::StaticConstFieldDef = 1; // expected-error{{definition of dllimport static field not allowed}}
-#if __cplusplus < 201703L && !defined(MS)
-// expected-error@+2{{definition of dllimport static field not allowed}}
-#endif
-constexpr int ImportMembers::ConstexprFieldDef;
+constexpr int ImportMembers::ConstexprFieldDef; // non-ms-11-error{{definition of dllimport static field not allowed}}
 
 
 // Import on member definitions.
@@ -657,11 +506,12 @@ struct ImportMemberDefs {
   __declspec(dllimport) virtual        void virtualInlineDef();
   __declspec(dllimport) static         void staticDef();
   __declspec(dllimport) static         void staticInlineDef();
-#ifdef MS
-  __declspec(dllimport)         inline void normalInlineDecl();
-  __declspec(dllimport) virtual inline void virtualInlineDecl();
-  __declspec(dllimport) static  inline void staticInlineDecl();
-#endif
+  __declspec(dllimport)         inline void normalInlineDecl(); // gnu-warning{{'dllimport' attribute ignored on inline function}} \
+                                                                   gnu-note{{previous declaration is here}}
+  __declspec(dllimport) virtual inline void virtualInlineDecl(); // gnu-warning{{'dllimport' attribute ignored on inline function}} \
+                                                                    gnu-note{{previous declaration is here}}
+  __declspec(dllimport) static  inline void staticInlineDecl(); // gnu-warning{{'dllimport' attribute ignored on inline function}} \
+                                                                   gnu-note{{previous declaration is here}}
 
   __declspec(dllimport) static         int  StaticField;
   __declspec(dllimport) static  const  int  StaticConstField;
@@ -671,23 +521,20 @@ struct ImportMemberDefs {
 __declspec(dllimport)        void ImportMemberDefs::normalDef() {} // expected-error{{dllimport cannot be applied to non-inline function definition}}
 __declspec(dllimport)        void ImportMemberDefs::virtualDef() {} // expected-error{{dllimport cannot be applied to non-inline function definition}}
 __declspec(dllimport)        void ImportMemberDefs::staticDef() {} // expected-error{{dllimport cannot be applied to non-inline function definition}}
-#ifdef MS
-__declspec(dllimport) inline void ImportMemberDefs::normalInlineDef() {}
-__declspec(dllimport)        void ImportMemberDefs::normalInlineDecl() {}
-__declspec(dllimport) inline void ImportMemberDefs::virtualInlineDef() {}
-__declspec(dllimport)        void ImportMemberDefs::virtualInlineDecl() {}
-__declspec(dllimport) inline void ImportMemberDefs::staticInlineDef() {}
-__declspec(dllimport)        void ImportMemberDefs::staticInlineDecl() {}
-#endif
+__declspec(dllimport) inline void ImportMemberDefs::normalInlineDef() {} // gnu-warning{{'ImportMemberDefs::normalInlineDef' redeclared inline; 'dllimport' attribute ignored}} \
+                                                                            gnu-warning{{'dllimport' attribute ignored on inline function}}
+__declspec(dllimport)        void ImportMemberDefs::normalInlineDecl() {} // gnu-error{{redeclaration of 'ImportMemberDefs::normalInlineDecl' cannot add 'dllimport' attribute}}
+__declspec(dllimport) inline void ImportMemberDefs::virtualInlineDef() {} // gnu-warning{{'ImportMemberDefs::virtualInlineDef' redeclared inline; 'dllimport' attribute ignored}} \
+                                                                             gnu-warning{{'dllimport' attribute ignored on inline function}}
+__declspec(dllimport)        void ImportMemberDefs::virtualInlineDecl() {} // gnu-error{{redeclaration of 'ImportMemberDefs::virtualInlineDecl' cannot add 'dllimport' attribute}}
+__declspec(dllimport) inline void ImportMemberDefs::staticInlineDef() {} // gnu-warning{{'ImportMemberDefs::staticInlineDef' redeclared inline; 'dllimport' attribute ignored}} \
+                                                                            gnu-warning{{'dllimport' attribute ignored on inline function}}
+__declspec(dllimport)        void ImportMemberDefs::staticInlineDecl() {} // gnu-error{{redeclaration of 'ImportMemberDefs::staticInlineDecl' cannot add 'dllimport' attribute}}
 
 __declspec(dllimport)        int  ImportMemberDefs::StaticField; // expected-error{{definition of dllimport static field not allowed}} expected-note{{attribute is here}}
 __declspec(dllimport) const  int  ImportMemberDefs::StaticConstField = 1; // expected-error{{definition of dllimport static field not allowed}} expected-note{{attribute is here}}
-#if __cplusplus < 201703L && !defined(MS)
-// expected-error@+3{{definition of dllimport static field not allowed}}
-// expected-note@+2{{attribute is here}}
-#endif
-__declspec(dllimport) constexpr int ImportMemberDefs::ConstexprField;
-
+__declspec(dllimport) constexpr int ImportMemberDefs::ConstexprField; // non-ms-11-error{{definition of dllimport static field not allowed}} \
+                                                                         non-ms-11-note{{attribute is here}}
 
 // Import special member functions.
 struct ImportSpecials {
@@ -702,23 +549,20 @@ struct ImportSpecials {
 
 // Import deleted member functions.
 struct ImportDeleted {
-#if defined(MS) || defined(WI) || defined(PS)
-  __declspec(dllimport) ImportDeleted() = delete; // expected-error{{attribute 'dllimport' cannot be applied to a deleted function}}
-  __declspec(dllimport) ~ImportDeleted() = delete; // expected-error{{attribute 'dllimport' cannot be applied to a deleted function}}
-  __declspec(dllimport) ImportDeleted(const ImportDeleted&) = delete; // expected-error{{attribute 'dllimport' cannot be applied to a deleted function}}
-  __declspec(dllimport) ImportDeleted& operator=(const ImportDeleted&) = delete; // expected-error{{attribute 'dllimport' cannot be applied to a deleted function}}
-  __declspec(dllimport) ImportDeleted(ImportDeleted&&) = delete; // expected-error{{attribute 'dllimport' cannot be applied to a deleted function}}
-  __declspec(dllimport) ImportDeleted& operator=(ImportDeleted&&) = delete; // expected-error{{attribute 'dllimport' cannot be applied to a deleted function}}
-  __declspec(dllimport) void deleted() = delete; // expected-error{{attribute 'dllimport' cannot be applied to a deleted function}}
-#else
-  __declspec(dllimport) ImportDeleted() = delete; // expected-warning{{'dllimport' attribute ignored on inline function}}
-  __declspec(dllimport) ~ImportDeleted() = delete; // expected-warning{{'dllimport' attribute ignored on inline function}}
-  __declspec(dllimport) ImportDeleted(const ImportDeleted&) = delete; // expected-warning{{'dllimport' attribute ignored on inline function}}
-  __declspec(dllimport) ImportDeleted& operator=(const ImportDeleted&) = delete; // expected-warning{{'dllimport' attribute ignored on inline function}}
-  __declspec(dllimport) ImportDeleted(ImportDeleted&&) = delete; // expected-warning{{'dllimport' attribute ignored on inline function}}
-  __declspec(dllimport) ImportDeleted& operator=(ImportDeleted&&) = delete; // expected-warning{{'dllimport' attribute ignored on inline function}}
-  __declspec(dllimport) void deleted() = delete; // expected-warning{{'dllimport' attribute ignored on inline function}}
-#endif
+  __declspec(dllimport) ImportDeleted() = delete; // non-gnu-error{{attribute 'dllimport' cannot be applied to a deleted function}} \
+                                                     gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) ~ImportDeleted() = delete; // non-gnu-error{{attribute 'dllimport' cannot be applied to a deleted function}} \
+                                                      gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) ImportDeleted(const ImportDeleted&) = delete; // non-gnu-error{{attribute 'dllimport' cannot be applied to a deleted function}} \
+                                                                         gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) ImportDeleted& operator=(const ImportDeleted&) = delete; // non-gnu-error{{attribute 'dllimport' cannot be applied to a deleted function}} \
+                                                                                    gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) ImportDeleted(ImportDeleted&&) = delete; // non-gnu-error{{attribute 'dllimport' cannot be applied to a deleted function}} \
+                                                                    gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) ImportDeleted& operator=(ImportDeleted&&) = delete; // non-gnu-error{{attribute 'dllimport' cannot be applied to a deleted function}} \
+                                                                               gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) void deleted() = delete; // non-gnu-error{{attribute 'dllimport' cannot be applied to a deleted function}} \
+                                                    gnu-warning{{'dllimport' attribute ignored on inline function}}
 };
 
 
@@ -733,71 +577,44 @@ struct ImportAlloc {
 
 // Import defaulted member functions.
 struct ImportDefaulted {
-#ifdef GNU
-  // expected-warning@+7{{'dllimport' attribute ignored on inline function}}
-  // expected-warning@+7{{'dllimport' attribute ignored on inline function}}
-  // expected-warning@+7{{'dllimport' attribute ignored on inline function}}
-  // expected-warning@+7{{'dllimport' attribute ignored on inline function}}
-  // expected-warning@+7{{'dllimport' attribute ignored on inline function}}
-  // expected-warning@+7{{'dllimport' attribute ignored on inline function}}
-#endif
-  __declspec(dllimport) ImportDefaulted() = default;
-  __declspec(dllimport) ~ImportDefaulted() = default;
-  __declspec(dllimport) ImportDefaulted(const ImportDefaulted&) = default;
-  __declspec(dllimport) ImportDefaulted& operator=(const ImportDefaulted&) = default;
-  __declspec(dllimport) ImportDefaulted(ImportDefaulted&&) = default;
-  __declspec(dllimport) ImportDefaulted& operator=(ImportDefaulted&&) = default;
+  __declspec(dllimport) ImportDefaulted() = default; // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) ~ImportDefaulted() = default; // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) ImportDefaulted(const ImportDefaulted&) = default; // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) ImportDefaulted& operator=(const ImportDefaulted&) = default; // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) ImportDefaulted(ImportDefaulted&&) = default; // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) ImportDefaulted& operator=(ImportDefaulted&&) = default; // gnu-warning{{'dllimport' attribute ignored on inline function}}
 };
 
 
 // Import defaulted member function definitions.
 struct ImportDefaultedDefs {
   __declspec(dllimport) ImportDefaultedDefs();
-#ifdef GNU
-// expected-note@+2{{previous attribute is here}}
-#endif
-  __declspec(dllimport) ~ImportDefaultedDefs(); // expected-note{{previous declaration is here}}
+  __declspec(dllimport) ~ImportDefaultedDefs(); // expected-note{{previous declaration is here}} \
+                                                   gnu-note{{previous attribute is here}}
 
-#ifdef GNU
-// expected-warning@+3{{'dllimport' attribute ignored on inline function}}
-// expected-note@+2{{previous declaration is here}}
-#endif
-  __declspec(dllimport) inline ImportDefaultedDefs(const ImportDefaultedDefs&);
+  __declspec(dllimport) inline ImportDefaultedDefs(const ImportDefaultedDefs&); // gnu-warning{{'dllimport' attribute ignored on inline function}} \
+                                                                                   gnu-note{{previous declaration is here}}
   __declspec(dllimport) ImportDefaultedDefs& operator=(const ImportDefaultedDefs&);
 
   __declspec(dllimport) ImportDefaultedDefs(ImportDefaultedDefs&&);
-#ifdef GNU
-// expected-note@+2{{previous attribute is here}}
-#endif
-  __declspec(dllimport) ImportDefaultedDefs &operator=(ImportDefaultedDefs &&); // expected-note{{previous declaration is here}}
+  __declspec(dllimport) ImportDefaultedDefs &operator=(ImportDefaultedDefs &&); // expected-note{{previous declaration is here}} \
+                                                                                   gnu-note{{previous attribute is here}}
 };
 
 // Not allowed on definitions.
 __declspec(dllimport) ImportDefaultedDefs::ImportDefaultedDefs() = default; // expected-error{{dllimport cannot be applied to non-inline function definition}}
 
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+5{{'ImportDefaultedDefs::~ImportDefaultedDefs' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-// expected-warning@+3{{'ImportDefaultedDefs::~ImportDefaultedDefs' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
 // dllimport cannot be dropped.
-ImportDefaultedDefs::~ImportDefaultedDefs() = default;
+ImportDefaultedDefs::~ImportDefaultedDefs() = default; // non-gnu-warning{{'ImportDefaultedDefs::~ImportDefaultedDefs' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                                          gnu-warning{{'ImportDefaultedDefs::~ImportDefaultedDefs' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 
 // Import inline declaration and definition.
-#ifdef GNU
-// expected-error@+3{{redeclaration of 'ImportDefaultedDefs::ImportDefaultedDefs' cannot add 'dllimport' attribute}}
-// expected-warning@+3{{'ImportDefaultedDefs::operator=' redeclared inline; 'dllimport' attribute ignored}}
-#endif
-__declspec(dllimport) ImportDefaultedDefs::ImportDefaultedDefs(const ImportDefaultedDefs&) = default;
-inline ImportDefaultedDefs& ImportDefaultedDefs::operator=(const ImportDefaultedDefs&) = default;
+__declspec(dllimport) ImportDefaultedDefs::ImportDefaultedDefs(const ImportDefaultedDefs&) = default; // gnu-error{{redeclaration of 'ImportDefaultedDefs::ImportDefaultedDefs' cannot add 'dllimport' attribute}}
+inline ImportDefaultedDefs& ImportDefaultedDefs::operator=(const ImportDefaultedDefs&) = default; // gnu-warning{{'ImportDefaultedDefs::operator=' redeclared inline; 'dllimport' attribute ignored}}
 
 __declspec(dllimport) ImportDefaultedDefs::ImportDefaultedDefs(ImportDefaultedDefs&&) = default; // expected-error{{dllimport cannot be applied to non-inline function definition}}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+4{{'ImportDefaultedDefs::operator=' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-// expected-warning@+2{{'ImportDefaultedDefs::operator=' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
-ImportDefaultedDefs &ImportDefaultedDefs::operator=(ImportDefaultedDefs &&) = default;
+ImportDefaultedDefs &ImportDefaultedDefs::operator=(ImportDefaultedDefs &&) = default; // non-gnu-warning{{'ImportDefaultedDefs::operator=' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                                                                          gnu-warning{{'ImportDefaultedDefs::operator=' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 
 // Redeclarations cannot add dllimport.
 struct MemberRedecl {
@@ -808,59 +625,49 @@ struct MemberRedecl {
   static         void staticDef();         // expected-note{{previous declaration is here}}
   static  inline void staticInlineDecl();  // expected-note{{previous declaration is here}}
 
-#if defined(MS) || defined(WI) || defined(PS)
-  // expected-note@+4{{previous declaration is here}}
-  // expected-note@+4{{previous declaration is here}}
-  // expected-note@+4{{previous declaration is here}}
-#endif
-                 void normalInlineDef();
-  virtual        void virtualInlineDef();
-  static         void staticInlineDef();
+                 void normalInlineDef();   // non-gnu-note{{previous declaration is here}}
+  virtual        void virtualInlineDef();  // non-gnu-note{{previous declaration is here}}
+  static         void staticInlineDef();   // non-gnu-note{{previous declaration is here}}
 
   static         int  StaticField;         // expected-note{{previous declaration is here}}
   static  const  int  StaticConstField;    // expected-note{{previous declaration is here}}
-  constexpr static int ConstexprField = 1; // expected-note-re{{previous {{(declaration|definition)}} is here}}
+  constexpr static int ConstexprField = 1; // ms-note{{previous definition is here}} \
+                                              non-ms-17-note{{previous definition is here}} \
+                                              non-ms-11-note{{previous declaration is here}}
 };
 
-__declspec(dllimport)        void MemberRedecl::normalDef() {}         // expected-error{{redeclaration of 'MemberRedecl::normalDef' cannot add 'dllimport' attribute}}
-                                                                       // expected-error@-1{{dllimport cannot be applied to non-inline function definition}}
+__declspec(dllimport)        void MemberRedecl::normalDef() {}         // expected-error{{redeclaration of 'MemberRedecl::normalDef' cannot add 'dllimport' attribute}} \
+                                                                          expected-error{{dllimport cannot be applied to non-inline function definition}}
 __declspec(dllimport)        void MemberRedecl::normalInlineDecl() {}  // expected-error{{redeclaration of 'MemberRedecl::normalInlineDecl' cannot add 'dllimport' attribute}}
-__declspec(dllimport)        void MemberRedecl::virtualDef() {}        // expected-error{{redeclaration of 'MemberRedecl::virtualDef' cannot add 'dllimport' attribute}}
-                                                                       // expected-error@-1{{dllimport cannot be applied to non-inline function definition}}
+__declspec(dllimport)        void MemberRedecl::virtualDef() {}        // expected-error{{redeclaration of 'MemberRedecl::virtualDef' cannot add 'dllimport' attribute}} \
+                                                                          expected-error{{dllimport cannot be applied to non-inline function definition}}
 __declspec(dllimport)        void MemberRedecl::virtualInlineDecl() {} // expected-error{{redeclaration of 'MemberRedecl::virtualInlineDecl' cannot add 'dllimport' attribute}}
-__declspec(dllimport)        void MemberRedecl::staticDef() {}         // expected-error{{redeclaration of 'MemberRedecl::staticDef' cannot add 'dllimport' attribute}}
-                                                                       // expected-error@-1{{dllimport cannot be applied to non-inline function definition}}
+__declspec(dllimport)        void MemberRedecl::staticDef() {}         // expected-error{{redeclaration of 'MemberRedecl::staticDef' cannot add 'dllimport' attribute}} \
+                                                                          expected-error{{dllimport cannot be applied to non-inline function definition}}
 __declspec(dllimport)        void MemberRedecl::staticInlineDecl() {}  // expected-error{{redeclaration of 'MemberRedecl::staticInlineDecl' cannot add 'dllimport' attribute}}
 
-#if defined(MS) || defined(WI) || defined(PS)
-__declspec(dllimport) inline void MemberRedecl::normalInlineDef() {}   // expected-error{{redeclaration of 'MemberRedecl::normalInlineDef' cannot add 'dllimport' attribute}}
-__declspec(dllimport) inline void MemberRedecl::virtualInlineDef() {}  // expected-error{{redeclaration of 'MemberRedecl::virtualInlineDef' cannot add 'dllimport' attribute}}
-__declspec(dllimport) inline void MemberRedecl::staticInlineDef() {}   // expected-error{{redeclaration of 'MemberRedecl::staticInlineDef' cannot add 'dllimport' attribute}}
-#else
-__declspec(dllimport) inline void MemberRedecl::normalInlineDef() {}   // expected-warning{{'dllimport' attribute ignored on inline function}}
-__declspec(dllimport) inline void MemberRedecl::virtualInlineDef() {}  // expected-warning{{'dllimport' attribute ignored on inline function}}
-__declspec(dllimport) inline void MemberRedecl::staticInlineDef() {}   // expected-warning{{'dllimport' attribute ignored on inline function}}
-#endif
+__declspec(dllimport) inline void MemberRedecl::normalInlineDef() {}   // non-gnu-error{{redeclaration of 'MemberRedecl::normalInlineDef' cannot add 'dllimport' attribute}} \
+                                                                          gnu-warning{{'dllimport' attribute ignored on inline function}}
+__declspec(dllimport) inline void MemberRedecl::virtualInlineDef() {}  // non-gnu-error{{redeclaration of 'MemberRedecl::virtualInlineDef' cannot add 'dllimport' attribute}} \
+                                                                          gnu-warning{{'dllimport' attribute ignored on inline function}}
+__declspec(dllimport) inline void MemberRedecl::staticInlineDef() {}   // non-gnu-error{{redeclaration of 'MemberRedecl::staticInlineDef' cannot add 'dllimport' attribute}} \
+                                                                          gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 
 
-__declspec(dllimport)        int  MemberRedecl::StaticField = 1;       // expected-error{{redeclaration of 'MemberRedecl::StaticField' cannot add 'dllimport' attribute}}
-                                                                       // expected-error@-1{{definition of dllimport static field not allowed}}
-                                                                       // expected-note@-2{{attribute is here}}
-__declspec(dllimport) const  int  MemberRedecl::StaticConstField = 1;  // expected-error{{redeclaration of 'MemberRedecl::StaticConstField' cannot add 'dllimport' attribute}}
-                                                                       // expected-error@-1{{definition of dllimport static field not allowed}}
-                                                                       // expected-note@-2{{attribute is here}}
-
-#if __cplusplus < 201703L && !defined(MS)
-// expected-error@+6{{redeclaration of 'MemberRedecl::ConstexprField' cannot add 'dllimport' attribute}}
-// expected-error@+5{{definition of dllimport static field not allowed}}
-// expected-note@+4{{attribute is here}}
-#else
-// expected-warning@+2{{attribute declaration must precede definition}}
-#endif
-__declspec(dllimport) constexpr int MemberRedecl::ConstexprField;
+__declspec(dllimport)        int  MemberRedecl::StaticField = 1;       // expected-error{{redeclaration of 'MemberRedecl::StaticField' cannot add 'dllimport' attribute}} \
+                                                                          expected-error{{definition of dllimport static field not allowed}} \
+                                                                          expected-note{{attribute is here}}
+__declspec(dllimport) const  int  MemberRedecl::StaticConstField = 1;  // expected-error{{redeclaration of 'MemberRedecl::StaticConstField' cannot add 'dllimport' attribute}} \
+                                                                          expected-error{{definition of dllimport static field not allowed}} \
+                                                                          expected-note{{attribute is here}}
 
 
+__declspec(dllimport) constexpr int MemberRedecl::ConstexprField; // non-ms-11-error{{redeclaration of 'MemberRedecl::ConstexprField' cannot add 'dllimport' attribute}} \
+                                                                     non-ms-11-error{{definition of dllimport static field not allowed}} \
+                                                                     non-ms-11-note{{attribute is here}} \
+                                                                     non-ms-17-warning{{attribute declaration must precede definition}} \
+                                                                     ms-warning{{attribute declaration must precede definition}}
 
 //===----------------------------------------------------------------------===//
 // Class member templates
@@ -868,29 +675,23 @@ __declspec(dllimport) constexpr int MemberRedecl::ConstexprField;
 
 struct ImportMemberTmpl {
   template<typename T> __declspec(dllimport)               void normalDecl();
-  template<typename T> __declspec(dllimport)               void normalDef(); // expected-note{{previous declaration is here}} expected-note{{previous attribute is here}}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-note@+2{{previous declaration is here}} expected-note@+2{{previous attribute is here}}
-#endif
-  template<typename T> __declspec(dllimport)               void normalInlineDef();
+  template<typename T> __declspec(dllimport)               void normalDef(); // expected-note{{previous declaration is here}} \
+                                                                                expected-note{{previous attribute is here}}
+  template<typename T> __declspec(dllimport)               void normalInlineDef(); // non-gnu-note{{previous declaration is here}} \
+                                                                                      non-gnu-note{{previous attribute is here}}
   template<typename T> __declspec(dllimport) static        void staticDecl();
   template<typename T> __declspec(dllimport) static        void staticDef(); // expected-note{{previous declaration is here}} expected-note{{previous attribute is here}}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-note@+2{{previous declaration is here}} expected-note@+2{{previous attribute is here}}
-#endif
-  template<typename T> __declspec(dllimport) static        void staticInlineDef();
+  template<typename T> __declspec(dllimport) static        void staticInlineDef(); // non-gnu-note{{previous declaration is here}} \
+                                                                                      non-gnu-note{{previous attribute is here}}
 
-#ifdef GNU
-  template<typename T> __declspec(dllimport)               void normalInclass() {} // expected-warning{{'dllimport' attribute ignored on inline function}}
-  template<typename T> __declspec(dllimport)        inline void normalInlineDecl(); // expected-warning{{'dllimport' attribute ignored on inline function}}
-  template<typename T> __declspec(dllimport) static        void staticInclass() {} // expected-warning{{'dllimport' attribute ignored on inline function}}
-  template<typename T> __declspec(dllimport) static inline void staticInlineDecl(); // expected-warning{{'dllimport' attribute ignored on inline function}}
-#else
-  template<typename T> __declspec(dllimport)               void normalInclass() {}
-  template<typename T> __declspec(dllimport)        inline void normalInlineDecl(); // expected-note{{previous declaration is here}} expected-note{{previous attribute is here}}
-  template<typename T> __declspec(dllimport) static        void staticInclass() {}
-  template<typename T> __declspec(dllimport) static inline void staticInlineDecl(); // expected-note{{previous declaration is here}} expected-note{{previous attribute is here}}
-#endif
+  template<typename T> __declspec(dllimport)               void normalInclass() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  template<typename T> __declspec(dllimport)        inline void normalInlineDecl(); // non-gnu-note{{previous declaration is here}} \
+                                                                                       non-gnu-note{{previous attribute is here}} \
+                                                                                       gnu-warning{{'dllimport' attribute ignored on inline function}}
+  template<typename T> __declspec(dllimport) static        void staticInclass() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  template<typename T> __declspec(dllimport) static inline void staticInlineDecl(); // non-gnu-note{{previous declaration is here}} \
+                                                                                       non-gnu-note{{previous attribute is here}} \
+                                                                                       gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 #if __has_feature(cxx_variable_templates)
   template<typename T> __declspec(dllimport) static        int  StaticField;
@@ -906,28 +707,18 @@ struct ImportMemberTmpl {
 
 template<typename T>        void ImportMemberTmpl::normalDef() {} // expected-warning{{'ImportMemberTmpl::normalDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 template<typename T>        void ImportMemberTmpl::staticDef() {} // expected-warning{{'ImportMemberTmpl::staticDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#ifdef GNU // dllimport was ignored above
-template<typename T>        void ImportMemberTmpl::normalInlineDecl() {}
-template<typename T>        void ImportMemberTmpl::staticInlineDecl() {}
-#else // dllimport dropped here
-template<typename T>        void ImportMemberTmpl::normalInlineDecl() {} // expected-warning{{'ImportMemberTmpl::normalInlineDecl' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-template<typename T>        void ImportMemberTmpl::staticInlineDecl() {} // expected-warning{{'ImportMemberTmpl::staticInlineDecl' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
+template<typename T>        void ImportMemberTmpl::normalInlineDecl() {} // non-gnu-warning{{'ImportMemberTmpl::normalInlineDecl' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
+template<typename T>        void ImportMemberTmpl::staticInlineDecl() {} // non-gnu-warning{{'ImportMemberTmpl::staticInlineDecl' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 
-#ifdef GNU
-template<typename T> inline void ImportMemberTmpl::normalInlineDef() {} // expected-warning{{ImportMemberTmpl::normalInlineDef' redeclared inline; 'dllimport' attribute ignored}}
-template<typename T> inline void ImportMemberTmpl::staticInlineDef() {} // expected-warning{{ImportMemberTmpl::staticInlineDef' redeclared inline; 'dllimport' attribute ignored}}
-#else
-template<typename T> inline void ImportMemberTmpl::normalInlineDef() {} // expected-warning{{ImportMemberTmpl::normalInlineDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-template<typename T> inline void ImportMemberTmpl::staticInlineDef() {} // expected-warning{{ImportMemberTmpl::staticInlineDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
+template<typename T> inline void ImportMemberTmpl::normalInlineDef() {} // non-gnu-warning{{ImportMemberTmpl::normalInlineDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}} \
+                                                                           gnu-warning{{ImportMemberTmpl::normalInlineDef' redeclared inline; 'dllimport' attribute ignored}} 
+template<typename T> inline void ImportMemberTmpl::staticInlineDef() {} // non-gnu-warning{{ImportMemberTmpl::staticInlineDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}} \
+                                                                           gnu-warning{{ImportMemberTmpl::staticInlineDef' redeclared inline; 'dllimport' attribute ignored}}
 
 #if __has_feature(cxx_variable_templates)
 template<typename T>        int  ImportMemberTmpl::StaticFieldDef; // expected-error{{definition of dllimport static field not allowed}}
 template<typename T> const  int  ImportMemberTmpl::StaticConstFieldDef = 1; // expected-error{{definition of dllimport static field not allowed}}
-#ifdef MS
 template<typename T> constexpr int ImportMemberTmpl::ConstexprFieldDef;
-#endif
 #endif // __has_feature(cxx_variable_templates)
 
 
@@ -938,65 +729,44 @@ struct MemTmplRedecl {
   template<typename T> static        void staticDef();         // expected-note{{previous declaration is here}}
   template<typename T> static inline void staticInlineDecl();  // expected-note{{previous declaration is here}}
 
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-note@+3{{previous declaration is here}}
-// expected-note@+3{{previous declaration is here}}
-#endif
-  template<typename T>               void normalInlineDef();
-  template<typename T> static        void staticInlineDef();
+  template<typename T>               void normalInlineDef(); // non-gnu-note{{previous declaration is here}}
+  template<typename T> static        void staticInlineDef(); // non-gnu-note{{previous declaration is here}}
 
 #if __has_feature(cxx_variable_templates)
   template<typename T> static        int  StaticField;         // expected-note{{previous declaration is here}}
   template<typename T> static const  int  StaticConstField;    // expected-note{{previous declaration is here}}
-#ifdef MS
   template<typename T> constexpr static int ConstexprField = 1; // expected-note{{previous definition is here}}
-#endif
 #endif // __has_feature(cxx_variable_templates)
 };
 
-template<typename T> __declspec(dllimport)        void MemTmplRedecl::normalDef() {}        // expected-error{{redeclaration of 'MemTmplRedecl::normalDef' cannot add 'dllimport' attribute}}
-                                                                                            // expected-error@-1{{dllimport cannot be applied to non-inline function definition}}
-#if defined(MS) || defined(WI) || defined(PS)
-template<typename T> __declspec(dllimport) inline void MemTmplRedecl::normalInlineDef() {}  // expected-error{{redeclaration of 'MemTmplRedecl::normalInlineDef' cannot add 'dllimport' attribute}}
-#else
-template<typename T> __declspec(dllimport) inline void MemTmplRedecl::normalInlineDef() {}  // expected-warning{{'dllimport' attribute ignored on inline function}}
-#endif
+template<typename T> __declspec(dllimport)        void MemTmplRedecl::normalDef() {}        // expected-error{{redeclaration of 'MemTmplRedecl::normalDef' cannot add 'dllimport' attribute}} \
+                                                                                               expected-error{{dllimport cannot be applied to non-inline function definition}}
+template<typename T> __declspec(dllimport) inline void MemTmplRedecl::normalInlineDef() {}  // non-gnu-error{{redeclaration of 'MemTmplRedecl::normalInlineDef' cannot add 'dllimport' attribute}} \
+                                                                                               gnu-warning{{'dllimport' attribute ignored on inline function}}
 template<typename T> __declspec(dllimport)        void MemTmplRedecl::normalInlineDecl() {} // expected-error{{redeclaration of 'MemTmplRedecl::normalInlineDecl' cannot add 'dllimport' attribute}}
-template<typename T> __declspec(dllimport)        void MemTmplRedecl::staticDef() {}        // expected-error{{redeclaration of 'MemTmplRedecl::staticDef' cannot add 'dllimport' attribute}}
-                                                                                            // expected-error@-1{{dllimport cannot be applied to non-inline function definition}}
-#if defined(MS) || defined(WI) || defined(PS)
-template<typename T> __declspec(dllimport) inline void MemTmplRedecl::staticInlineDef() {}  // expected-error{{redeclaration of 'MemTmplRedecl::staticInlineDef' cannot add 'dllimport' attribute}}
-#else
-template<typename T> __declspec(dllimport) inline void MemTmplRedecl::staticInlineDef() {}  // expected-warning{{'dllimport' attribute ignored on inline function}}
-#endif
+template<typename T> __declspec(dllimport)        void MemTmplRedecl::staticDef() {}        // expected-error{{redeclaration of 'MemTmplRedecl::staticDef' cannot add 'dllimport' attribute}} \
+                                                                                               expected-error{{dllimport cannot be applied to non-inline function definition}}
+template<typename T> __declspec(dllimport) inline void MemTmplRedecl::staticInlineDef() {}  // non-gnu-error{{redeclaration of 'MemTmplRedecl::staticInlineDef' cannot add 'dllimport' attribute}} \
+                                                                                               gnu-warning{{'dllimport' attribute ignored on inline function}}
 template<typename T> __declspec(dllimport)        void MemTmplRedecl::staticInlineDecl() {} // expected-error{{redeclaration of 'MemTmplRedecl::staticInlineDecl' cannot add 'dllimport' attribute}}
 
 #if __has_feature(cxx_variable_templates)
-template<typename T> __declspec(dllimport)        int  MemTmplRedecl::StaticField = 1;      // expected-error{{redeclaration of 'MemTmplRedecl::StaticField' cannot add 'dllimport' attribute}}
-                                                                                            // expected-error@-1{{definition of dllimport static field not allowed}}
-                                                                                            // expected-note@-2{{attribute is here}}
-template<typename T> __declspec(dllimport) const  int  MemTmplRedecl::StaticConstField = 1; // expected-error{{redeclaration of 'MemTmplRedecl::StaticConstField' cannot add 'dllimport' attribute}}
-                                                                                            // expected-error@-1{{definition of dllimport static field not allowed}}
-                                                                                            // expected-note@-2{{attribute is here}}
-#ifdef MS
-// expected-warning@+1{{attribute declaration must precede definition}}
-template<typename T> __declspec(dllimport) constexpr int MemTmplRedecl::ConstexprField;
-#endif
+template<typename T> __declspec(dllimport)        int  MemTmplRedecl::StaticField = 1;      // expected-error{{redeclaration of 'MemTmplRedecl::StaticField' cannot add 'dllimport' attribute}} \
+                                                                                               expected-error{{definition of dllimport static field not allowed}} \
+                                                                                               expected-note{{attribute is here}}
+template<typename T> __declspec(dllimport) const  int  MemTmplRedecl::StaticConstField = 1; // expected-error{{redeclaration of 'MemTmplRedecl::StaticConstField' cannot add 'dllimport' attribute}} \
+                                                                                               expected-error{{definition of dllimport static field not allowed}} \
+                                                                                               expected-note{{attribute is here}}
+template<typename T> __declspec(dllimport) constexpr int MemTmplRedecl::ConstexprField;     // expected-warning{{attribute declaration must precede definition}}
 #endif // __has_feature(cxx_variable_templates)
 
 
 
 struct MemFunTmpl {
   template<typename T>                              void normalDef() {}
-#ifdef GNU
-  // expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-  template<typename T> __declspec(dllimport)        void importedNormal() {}
+  template<typename T> __declspec(dllimport)        void importedNormal() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
   template<typename T>                       static void staticDef() {}
-#ifdef GNU
-  // expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-  template<typename T> __declspec(dllimport) static void importedStatic() {}
+  template<typename T> __declspec(dllimport) static void importedStatic() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
 };
 
 // Import implicit instantiation of an imported member function template.
@@ -1018,26 +788,14 @@ template void MemFunTmpl::importedStatic<ExplicitInst_Imported>();
 
 // Import specialization of an imported member function template.
 template<> __declspec(dllimport) void MemFunTmpl::importedNormal<ExplicitSpec_Imported>();
-template<> __declspec(dllimport) void MemFunTmpl::importedNormal<ExplicitSpec_Def_Imported>() {} // error on mingw
-#ifdef GNU
-  // expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-template<> __declspec(dllimport) inline void MemFunTmpl::importedNormal<ExplicitSpec_InlineDef_Imported>() {}
-#if 1
 // FIXME: This should not be an error when targeting MSVC. (PR21406)
-// expected-error@-7{{dllimport cannot be applied to non-inline function definition}}
-#endif
+template<> __declspec(dllimport) void MemFunTmpl::importedNormal<ExplicitSpec_Def_Imported>() {} // expected-error{{dllimport cannot be applied to non-inline function definition}}
+template<> __declspec(dllimport) inline void MemFunTmpl::importedNormal<ExplicitSpec_InlineDef_Imported>() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 template<> __declspec(dllimport) void MemFunTmpl::importedStatic<ExplicitSpec_Imported>();
-template<> __declspec(dllimport) void MemFunTmpl::importedStatic<ExplicitSpec_Def_Imported>() {} // error on mingw
-#ifdef GNU
-  // expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-template<> __declspec(dllimport) inline void MemFunTmpl::importedStatic<ExplicitSpec_InlineDef_Imported>() {}
-#if 1
 // FIXME: This should not be an error when targeting MSVC. (PR21406)
-// expected-error@-7{{dllimport cannot be applied to non-inline function definition}}
-#endif
+template<> __declspec(dllimport) void MemFunTmpl::importedStatic<ExplicitSpec_Def_Imported>() {} // expected-error{{dllimport cannot be applied to non-inline function definition}}
+template<> __declspec(dllimport) inline void MemFunTmpl::importedStatic<ExplicitSpec_InlineDef_Imported>() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 // Not importing specialization of an imported member function template without
 // explicit dllimport.
@@ -1047,45 +805,24 @@ template<> void MemFunTmpl::importedStatic<ExplicitSpec_NotImported>() {}
 
 // Import explicit instantiation declaration of a non-imported member function
 // template.
-#ifdef GNU
-// expected-warning@+3{{'dllimport' attribute ignored on inline function}}
-// expected-warning@+3{{'dllimport' attribute ignored on inline function}}
-#endif
-extern template __declspec(dllimport) void MemFunTmpl::normalDef<ExplicitDecl_Imported>();
-extern template __declspec(dllimport) void MemFunTmpl::staticDef<ExplicitDecl_Imported>();
+extern template __declspec(dllimport) void MemFunTmpl::normalDef<ExplicitDecl_Imported>(); // gnu-warning{{'dllimport' attribute ignored on inline function}}
+extern template __declspec(dllimport) void MemFunTmpl::staticDef<ExplicitDecl_Imported>(); // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 // Import explicit instantiation definition of a non-imported member function
 // template.
-#ifdef GNU
-// expected-warning@+3{{'dllimport' attribute ignored on inline function}}
-// expected-warning@+3{{'dllimport' attribute ignored on inline function}}
-#endif
-template __declspec(dllimport) void MemFunTmpl::normalDef<ExplicitInst_Imported>();
-template __declspec(dllimport) void MemFunTmpl::staticDef<ExplicitInst_Imported>();
+template __declspec(dllimport) void MemFunTmpl::normalDef<ExplicitInst_Imported>(); // gnu-warning{{'dllimport' attribute ignored on inline function}}
+template __declspec(dllimport) void MemFunTmpl::staticDef<ExplicitInst_Imported>(); // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 // Import specialization of a non-imported member function template.
 template<> __declspec(dllimport) void MemFunTmpl::normalDef<ExplicitSpec_Imported>();
-template<> __declspec(dllimport) void MemFunTmpl::normalDef<ExplicitSpec_Def_Imported>() {} // error on mingw
-#ifdef GNU
-  // expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-template<> __declspec(dllimport) inline void MemFunTmpl::normalDef<ExplicitSpec_InlineDef_Imported>() {}
-#if 1
 // FIXME: This should not be an error when targeting MSVC. (PR21406)
-// expected-error@-7{{dllimport cannot be applied to non-inline function definition}}
-#endif
+template<> __declspec(dllimport) void MemFunTmpl::normalDef<ExplicitSpec_Def_Imported>() {} // expected-error{{dllimport cannot be applied to non-inline function definition}}
+template<> __declspec(dllimport) inline void MemFunTmpl::normalDef<ExplicitSpec_InlineDef_Imported>() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 template<> __declspec(dllimport) void MemFunTmpl::staticDef<ExplicitSpec_Imported>();
-template<> __declspec(dllimport) void MemFunTmpl::staticDef<ExplicitSpec_Def_Imported>() {} // error on mingw
-#ifdef GNU
-  // expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-template<> __declspec(dllimport) inline void MemFunTmpl::staticDef<ExplicitSpec_InlineDef_Imported>() {}
-#if 1
 // FIXME: This should not be an error when targeting MSVC. (PR21406)
-// expected-error@-7{{dllimport cannot be applied to non-inline function definition}}
-#endif
-
+template<> __declspec(dllimport) void MemFunTmpl::staticDef<ExplicitSpec_Def_Imported>() {} // expected-error{{dllimport cannot be applied to non-inline function definition}}
+template<> __declspec(dllimport) inline void MemFunTmpl::staticDef<ExplicitSpec_InlineDef_Imported>() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 
 #if __has_feature(cxx_variable_templates)
@@ -1107,9 +844,8 @@ extern template const int MemVarTmpl::ImportedStaticVar<ExplicitDecl_Imported>;
 
 // Import specialization of an imported member variable template.
 template<> __declspec(dllimport) const int MemVarTmpl::ImportedStaticVar<ExplicitSpec_Imported>;
-template<> __declspec(dllimport) const int MemVarTmpl::ImportedStaticVar<ExplicitSpec_Def_Imported> = 1;
-                                                                                // expected-error@-1{{definition of dllimport static field not allowed}}
-                                                                                // expected-note@-2{{attribute is here}}
+template<> __declspec(dllimport) const int MemVarTmpl::ImportedStaticVar<ExplicitSpec_Def_Imported> = 1; // expected-error{{definition of dllimport static field not allowed}} \
+                                                                                                            expected-note{{attribute is here}}
 
 // Not importing specialization of a member variable template without explicit
 // dllimport.
@@ -1126,9 +862,8 @@ extern template __declspec(dllimport) const int MemVarTmpl::StaticVar<ExplicitDe
 
 // Import specialization of a non-imported member variable template.
 template<> __declspec(dllimport) const int MemVarTmpl::StaticVar<ExplicitSpec_Imported>;
-template<> __declspec(dllimport) const int MemVarTmpl::StaticVar<ExplicitSpec_Def_Imported> = 1;
-                                                                                // expected-error@-1{{definition of dllimport static field not allowed}}
-                                                                                // expected-note@-2{{attribute is here}}
+template<> __declspec(dllimport) const int MemVarTmpl::StaticVar<ExplicitSpec_Def_Imported> = 1;  // expected-error{{definition of dllimport static field not allowed}} \
+                                                                                                     expected-note{{attribute is here}}
 
 #endif // __has_feature(cxx_variable_templates)
 
@@ -1141,42 +876,25 @@ template<> __declspec(dllimport) const int MemVarTmpl::StaticVar<ExplicitSpec_De
 // Import individual members of a class template.
 template<typename T>
 struct ImportClassTmplMembers {
-#ifndef GNU
-// expected-note@+2{{attribute is here}}
-#endif
-  __declspec(dllimport)                void normalDecl();
-#ifdef GNU
-// expected-note@+2{{previous attribute is here}}
-#endif
-  __declspec(dllimport) void normalDef(); // expected-note{{previous declaration is here}}
+  __declspec(dllimport)                void normalDecl(); // non-gnu-note{{attribute is here}}
+  __declspec(dllimport) void normalDef(); // expected-note{{previous declaration is here}} \
+                                             gnu-note{{previous attribute is here}}
   __declspec(dllimport)                void normalInlineDef();
   __declspec(dllimport) virtual        void virtualDecl();
-#ifdef GNU
-// expected-note@+2{{previous attribute is here}}
-#endif
-  __declspec(dllimport) virtual void virtualDef(); // expected-note{{previous declaration is here}}
+  __declspec(dllimport) virtual void virtualDef(); // expected-note{{previous declaration is here}} \
+                                                      gnu-note{{previous attribute is here}}
   __declspec(dllimport) virtual        void virtualInlineDef();
   __declspec(dllimport) static         void staticDecl();
-#ifdef GNU
-// expected-note@+2{{previous attribute is here}}
-#endif
-  __declspec(dllimport) static void staticDef(); // expected-note{{previous declaration is here}}
+  __declspec(dllimport) static void staticDef(); // expected-note{{previous declaration is here}} \
+                                                    gnu-note{{previous attribute is here}}
   __declspec(dllimport) static         void staticInlineDef();
 
-#ifdef GNU
-// expected-warning@+7{{'dllimport' attribute ignored on inline function}}
-// expected-warning@+7{{'dllimport' attribute ignored on inline function}}
-// expected-warning@+7{{'dllimport' attribute ignored on inline function}}
-// expected-warning@+7{{'dllimport' attribute ignored on inline function}}
-// expected-warning@+7{{'dllimport' attribute ignored on inline function}}
-// expected-warning@+7{{'dllimport' attribute ignored on inline function}}
-#endif
-  __declspec(dllimport)                void normalInclass() {}
-  __declspec(dllimport)         inline void normalInlineDecl();
-  __declspec(dllimport) virtual        void virtualInclass() {}
-  __declspec(dllimport) virtual inline void virtualInlineDecl();
-  __declspec(dllimport) static         void staticInclass() {}
-  __declspec(dllimport) static  inline void staticInlineDecl();
+  __declspec(dllimport)                void normalInclass() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport)         inline void normalInlineDecl(); // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) virtual        void virtualInclass() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) virtual inline void virtualInlineDecl(); // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) static         void staticInclass() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  __declspec(dllimport) static  inline void staticInlineDecl(); // gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 protected:
   __declspec(dllimport)                void protectedDecl();
@@ -1192,57 +910,30 @@ public:
   __declspec(dllimport) static  const  int  StaticConstFieldEqualInit = 1;
   __declspec(dllimport) static  const  int  StaticConstFieldBraceInit{1};
   __declspec(dllimport) constexpr static int ConstexprField = 1;
-#if __cplusplus < 201703L && !defined(MS)
-  // expected-note@+2{{attribute is here}}
-#endif
-  __declspec(dllimport) constexpr static int ConstexprFieldDef = 1;
+  __declspec(dllimport) constexpr static int ConstexprFieldDef = 1; // non-ms-11-note{{attribute is here}}
 };
 
 // NB: MSVC is inconsistent here and disallows *InlineDef on class templates,
 // but allows it on classes. We allow both.
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+5{{'ImportClassTmplMembers::normalDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-// expected-warning@+3{{'ImportClassTmplMembers::normalDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
 template <typename T>
-void ImportClassTmplMembers<T>::normalDef() {}
-#ifdef GNU
-// expected-warning@+2{{'ImportClassTmplMembers::normalInlineDef' redeclared inline; 'dllimport' attribute ignored}}
-#endif
-template<typename T> inline void ImportClassTmplMembers<T>::normalInlineDef() {}
+void ImportClassTmplMembers<T>::normalDef() {} // non-gnu-warning{{'ImportClassTmplMembers::normalDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                                  gnu-warning{{'ImportClassTmplMembers::normalDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
+template<typename T> inline void ImportClassTmplMembers<T>::normalInlineDef() {} // gnu-warning{{'ImportClassTmplMembers::normalInlineDef' redeclared inline; 'dllimport' attribute ignored}}
 template<typename T>        void ImportClassTmplMembers<T>::normalInlineDecl() {}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+5{{'ImportClassTmplMembers::virtualDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-// expected-warning@+3{{'ImportClassTmplMembers::virtualDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
 template <typename T>
-void ImportClassTmplMembers<T>::virtualDef() {}
-#ifdef GNU
-// expected-warning@+2{{'ImportClassTmplMembers::virtualInlineDef' redeclared inline; 'dllimport' attribute ignored}}
-#endif
-template<typename T> inline void ImportClassTmplMembers<T>::virtualInlineDef() {}
+void ImportClassTmplMembers<T>::virtualDef() {} // non-gnu-warning{{'ImportClassTmplMembers::virtualDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                                   gnu-warning{{'ImportClassTmplMembers::virtualDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
+template<typename T> inline void ImportClassTmplMembers<T>::virtualInlineDef() {} // gnu-warning{{'ImportClassTmplMembers::virtualInlineDef' redeclared inline; 'dllimport' attribute ignored}}
 template<typename T>        void ImportClassTmplMembers<T>::virtualInlineDecl() {}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+5{{'ImportClassTmplMembers::staticDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}}
-#else
-// expected-warning@+3{{'ImportClassTmplMembers::staticDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
 template <typename T>
-void ImportClassTmplMembers<T>::staticDef() {}
-#ifdef GNU
-// expected-warning@+2{{'ImportClassTmplMembers::staticInlineDef' redeclared inline; 'dllimport' attribute ignored}}
-#endif
-template<typename T> inline void ImportClassTmplMembers<T>::staticInlineDef() {}
+void ImportClassTmplMembers<T>::staticDef() {} // non-gnu-warning{{'ImportClassTmplMembers::staticDef' redeclared without 'dllimport' attribute: 'dllexport' attribute added}} \
+                                                  gnu-warning{{'ImportClassTmplMembers::staticDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
+template<typename T> inline void ImportClassTmplMembers<T>::staticInlineDef() {} // gnu-warning{{'ImportClassTmplMembers::staticInlineDef' redeclared inline; 'dllimport' attribute ignored}}
 template<typename T>        void ImportClassTmplMembers<T>::staticInlineDecl() {}
 
 template<typename T>        int  ImportClassTmplMembers<T>::StaticFieldDef; // expected-warning{{definition of dllimport static field}}
 template<typename T> const  int  ImportClassTmplMembers<T>::StaticConstFieldDef = 1; // expected-warning{{definition of dllimport static field}}
-#if __cplusplus < 201703L && !defined(MS)
-// expected-warning@+2{{definition of dllimport static field}}
-#endif
-template<typename T> constexpr int ImportClassTmplMembers<T>::ConstexprFieldDef;
+template<typename T> constexpr int ImportClassTmplMembers<T>::ConstexprFieldDef; // non-ms-11-warning{{definition of dllimport static field}}
 
 
 // Redeclarations cannot add dllimport.
@@ -1255,85 +946,59 @@ struct CTMR /*ClassTmplMemberRedecl*/ {
   static         void staticDef();         // expected-note{{previous declaration is here}}
   static  inline void staticInlineDecl();  // expected-note{{previous declaration is here}}
 
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-note@+4{{previous declaration is here}}
-// expected-note@+4{{previous declaration is here}}
-// expected-note@+4{{previous declaration is here}}
-#endif
-                 void normalInlineDef();
-  virtual        void virtualInlineDef();
-  static         void staticInlineDef();
+                 void normalInlineDef(); // non-gnu-note{{previous declaration is here}}
+  virtual        void virtualInlineDef(); // non-gnu-note{{previous declaration is here}}
+  static         void staticInlineDef(); // non-gnu-note{{previous declaration is here}}
 
   static         int  StaticField;         // expected-note{{previous declaration is here}}
   static  const  int  StaticConstField;    // expected-note{{previous declaration is here}}
-  constexpr static int ConstexprField = 1; // expected-note-re{{previous {{(declaration|definition)}} is here}}
+  constexpr static int ConstexprField = 1; // ms-note{{previous definition is here}} \
+                                              non-ms-17-note{{previous definition is here}} \
+                                              non-ms-11-note{{previous declaration is here}}
 };
 
-template<typename T> __declspec(dllimport)        void CTMR<T>::normalDef() {}         // expected-error{{redeclaration of 'CTMR::normalDef' cannot add 'dllimport' attribute}}
-                                                                                       // expected-error@-1{{dllimport cannot be applied to non-inline function definition}}
+template<typename T> __declspec(dllimport)        void CTMR<T>::normalDef() {}         // expected-error{{redeclaration of 'CTMR::normalDef' cannot add 'dllimport' attribute}} \
+                                                                                          expected-error{{dllimport cannot be applied to non-inline function definition}}
 template<typename T> __declspec(dllimport)        void CTMR<T>::normalInlineDecl() {}  // expected-error{{redeclaration of 'CTMR::normalInlineDecl' cannot add 'dllimport' attribute}}
-template<typename T> __declspec(dllimport)        void CTMR<T>::virtualDef() {}        // expected-error{{redeclaration of 'CTMR::virtualDef' cannot add 'dllimport' attribute}}
-                                                                                       // expected-error@-1{{dllimport cannot be applied to non-inline function definition}}
+template<typename T> __declspec(dllimport)        void CTMR<T>::virtualDef() {}        // expected-error{{redeclaration of 'CTMR::virtualDef' cannot add 'dllimport' attribute}} \
+                                                                                          expected-error{{dllimport cannot be applied to non-inline function definition}}
 template<typename T> __declspec(dllimport)        void CTMR<T>::virtualInlineDecl() {} // expected-error{{redeclaration of 'CTMR::virtualInlineDecl' cannot add 'dllimport' attribute}}
-template<typename T> __declspec(dllimport)        void CTMR<T>::staticDef() {}         // expected-error{{redeclaration of 'CTMR::staticDef' cannot add 'dllimport' attribute}}
-                                                                                       // expected-error@-1{{dllimport cannot be applied to non-inline function definition}}
+template<typename T> __declspec(dllimport)        void CTMR<T>::staticDef() {}         // expected-error{{redeclaration of 'CTMR::staticDef' cannot add 'dllimport' attribute}} \
+                                                                                          expected-error{{dllimport cannot be applied to non-inline function definition}}
 template<typename T> __declspec(dllimport)        void CTMR<T>::staticInlineDecl() {}  // expected-error{{redeclaration of 'CTMR::staticInlineDecl' cannot add 'dllimport' attribute}}
 
-#if defined(MS) || defined(WI) || defined(PS)
-template<typename T> __declspec(dllimport) inline void CTMR<T>::normalInlineDef() {}   // expected-error{{redeclaration of 'CTMR::normalInlineDef' cannot add 'dllimport' attribute}}
-template<typename T> __declspec(dllimport) inline void CTMR<T>::virtualInlineDef() {}  // expected-error{{redeclaration of 'CTMR::virtualInlineDef' cannot add 'dllimport' attribute}}
-template<typename T> __declspec(dllimport) inline void CTMR<T>::staticInlineDef() {}   // expected-error{{redeclaration of 'CTMR::staticInlineDef' cannot add 'dllimport' attribute}}
-#else
-template<typename T> __declspec(dllimport) inline void CTMR<T>::normalInlineDef() {}   // expected-warning{{'dllimport' attribute ignored on inline function}}
-template<typename T> __declspec(dllimport) inline void CTMR<T>::virtualInlineDef() {}  // expected-warning{{'dllimport' attribute ignored on inline function}}
-template<typename T> __declspec(dllimport) inline void CTMR<T>::staticInlineDef() {}   // expected-warning{{'dllimport' attribute ignored on inline function}}
-#endif
+template<typename T> __declspec(dllimport) inline void CTMR<T>::normalInlineDef() {}   // non-gnu-error{{redeclaration of 'CTMR::normalInlineDef' cannot add 'dllimport' attribute}} \
+                                                                                          gnu-warning{{'dllimport' attribute ignored on inline function}}
+template<typename T> __declspec(dllimport) inline void CTMR<T>::virtualInlineDef() {}  // non-gnu-error{{redeclaration of 'CTMR::virtualInlineDef' cannot add 'dllimport' attribute}} \
+                                                                                          gnu-warning{{'dllimport' attribute ignored on inline function}}
+template<typename T> __declspec(dllimport) inline void CTMR<T>::staticInlineDef() {}   // non-gnu-error{{redeclaration of 'CTMR::staticInlineDef' cannot add 'dllimport' attribute}} \
+                                                                                          gnu-warning{{'dllimport' attribute ignored on inline function}}
 
-template<typename T> __declspec(dllimport)        int  CTMR<T>::StaticField = 1;       // expected-error{{redeclaration of 'CTMR::StaticField' cannot add 'dllimport' attribute}}
-                                                                                       // expected-warning@-1{{definition of dllimport static field}}
-                                                                                       // expected-note@-2{{attribute is here}}
-template<typename T> __declspec(dllimport) const  int  CTMR<T>::StaticConstField = 1;  // expected-error{{redeclaration of 'CTMR::StaticConstField' cannot add 'dllimport' attribute}}
-                                                                                       // expected-warning@-1{{definition of dllimport static field}}
-                                                                                       // expected-note@-2{{attribute is here}}
+template<typename T> __declspec(dllimport)        int  CTMR<T>::StaticField = 1;       // expected-error{{redeclaration of 'CTMR::StaticField' cannot add 'dllimport' attribute}} \
+                                                                                          expected-warning{{definition of dllimport static field}} \
+                                                                                          expected-note{{attribute is here}}
+template<typename T> __declspec(dllimport) const  int  CTMR<T>::StaticConstField = 1;  // expected-error{{redeclaration of 'CTMR::StaticConstField' cannot add 'dllimport' attribute}} \
+                                                                                          expected-warning{{definition of dllimport static field}} \
+                                                                                          expected-note{{attribute is here}}
 
-#if __cplusplus < 201703L && !defined(MS)
-// expected-error@+6{{redeclaration of 'CTMR::ConstexprField' cannot add 'dllimport' attribute}}
-// expected-warning@+5{{definition of dllimport static field}}
-// expected-note@+4{{attribute is here}}
-#else
-// expected-warning@+2{{attribute declaration must precede definition}}
-#endif
-template<typename T> __declspec(dllimport) constexpr int CTMR<T>::ConstexprField;
-
+template<typename T> __declspec(dllimport) constexpr int CTMR<T>::ConstexprField; // non-ms-11-error{{redeclaration of 'CTMR::ConstexprField' cannot add 'dllimport' attribute}} \
+                                                                                     non-ms-11-warning{{definition of dllimport static field}} \
+                                                                                     non-ms-11-note{{attribute is here}} \
+                                                                                     non-ms-17-warning{{attribute declaration must precede definition}} \
+                                                                                     ms-warning{{attribute declaration must precede definition}}
 
 // MSVC imports explicit specialization of imported class template member
 // function, and errors on such definitions. MinGW does not treat them as
 // dllimport.
 template <typename> struct ClassTmpl {
-#if !defined(GNU)
-// expected-note@+2{{attribute is here}}
-#endif
-  void __declspec(dllimport) importedNormal();
-#if !defined(GNU)
-// expected-note@+2{{attribute is here}}
-#endif
-  static void __declspec(dllimport) importedStatic();
+  void __declspec(dllimport) importedNormal(); // non-gnu-note{{attribute is here}}
+  static void __declspec(dllimport) importedStatic(); // non-gnu-note{{attribute is here}}
 };
-#if !defined(GNU)
-// expected-error@+2{{cannot define non-inline dllimport template specialization}}
-#endif
-template<> void ClassTmpl<int>::importedNormal() {}
-#if !defined(GNU)
-// expected-error@+2{{cannot define non-inline dllimport template specialization}}
-#endif
-template<> void ClassTmpl<int>::importedStatic() {}
+template<> void ClassTmpl<int>::importedNormal() {} // non-gnu-error{{cannot define non-inline dllimport template specialization}}
+template<> void ClassTmpl<int>::importedStatic() {} // non-gnu-error{{cannot define non-inline dllimport template specialization}}
 
-#if !defined(GNU)
-// expected-error@+3{{cannot define non-inline dllimport template specialization}}
-// expected-error@+2{{attribute 'dllimport' cannot be applied to a deleted function}}
-#endif
-template <> void ImportClassTmplMembers<int>::normalDecl() = delete;
-
+template <> void ImportClassTmplMembers<int>::normalDecl() = delete; // non-gnu-error{{cannot define non-inline dllimport template specialization}} \
+                                                                        non-gnu-error{{attribute 'dllimport' cannot be applied to a deleted function}}
 
 //===----------------------------------------------------------------------===//
 // Class template member templates
@@ -1342,34 +1007,23 @@ template <> void ImportClassTmplMembers<int>::normalDecl() = delete;
 template<typename T>
 struct ImportClsTmplMemTmpl {
   template<typename U> __declspec(dllimport)               void normalDecl();
-  template<typename U> __declspec(dllimport)               void normalDef(); // expected-note{{previous declaration is here}} expected-note{{previous attribute is here}}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-note@+2{{previous declaration is here}} expected-note@+2{{previous attribute is here}}
-#endif
-  template<typename U> __declspec(dllimport)               void normalInlineDef();
+  template<typename U> __declspec(dllimport)               void normalDef(); // expected-note{{previous declaration is here}} \
+                                                                                expected-note{{previous attribute is here}}
+  template<typename U> __declspec(dllimport)               void normalInlineDef(); // non-gnu-note{{previous declaration is here}} \
+                                                                                      non-gnu-note{{previous attribute is here}}
   template<typename U> __declspec(dllimport) static        void staticDecl();
   template<typename U> __declspec(dllimport) static        void staticDef(); // expected-note{{previous declaration is here}} expected-note{{previous attribute is here}}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-note@+2{{previous declaration is here}} expected-note@+2{{previous attribute is here}}
-#endif
-  template<typename U> __declspec(dllimport) static        void staticInlineDef();
+  template<typename U> __declspec(dllimport) static        void staticInlineDef(); // non-gnu-note{{previous declaration is here}} \
+                                                                                      non-gnu-note{{previous attribute is here}}
 
-#ifdef GNU
-  // expected-warning@+5{{'dllimport' attribute ignored on inline function}}
-  // expected-warning@+8{{'dllimport' attribute ignored on inline function}}
-  // expected-warning@+8{{'dllimport' attribute ignored on inline function}}
-  // expected-warning@+11{{'dllimport' attribute ignored on inline function}}
-#endif
-  template<typename U> __declspec(dllimport)               void normalInclass() {}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-note@+2{{previous declaration is here}} expected-note@+2{{previous attribute is here}}
-#endif
-  template<typename U> __declspec(dllimport)        inline void normalInlineDecl();
-  template<typename U> __declspec(dllimport) static        void staticInclass() {}
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-note@+2{{previous declaration is here}} expected-note@+2{{previous attribute is here}}
-#endif
-  template<typename U> __declspec(dllimport) static inline void staticInlineDecl();
+  template<typename U> __declspec(dllimport)               void normalInclass() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  template<typename U> __declspec(dllimport)        inline void normalInlineDecl();  // non-gnu-note{{previous declaration is here}} \
+                                                                                      non-gnu-note{{previous attribute is here}} \
+                                                                                      gnu-warning{{'dllimport' attribute ignored on inline function}}
+  template<typename U> __declspec(dllimport) static        void staticInclass() {} // gnu-warning{{'dllimport' attribute ignored on inline function}}
+  template<typename U> __declspec(dllimport) static inline void staticInlineDecl();  // non-gnu-note{{previous declaration is here}} \
+                                                                                      non-gnu-note{{previous attribute is here}} \
+                                                                                      gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 #if __has_feature(cxx_variable_templates)
   template<typename U> __declspec(dllimport) static        int  StaticField;
@@ -1379,36 +1033,24 @@ struct ImportClsTmplMemTmpl {
   template<typename U> __declspec(dllimport) static const  int  StaticConstFieldEqualInit = 1;
   template<typename U> __declspec(dllimport) static const  int  StaticConstFieldBraceInit{1};
   template<typename U> __declspec(dllimport) constexpr static int ConstexprField = 1;
-#ifdef MS
   template<typename U> __declspec(dllimport) constexpr static int ConstexprFieldDef = 1;
-#endif
 #endif // __has_feature(cxx_variable_templates)
 };
 
 template<typename T> template<typename U>        void ImportClsTmplMemTmpl<T>::normalDef() {} // expected-warning{{'ImportClsTmplMemTmpl::normalDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 template<typename T> template<typename U>        void ImportClsTmplMemTmpl<T>::staticDef() {} // expected-warning{{'ImportClsTmplMemTmpl::staticDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#ifdef GNU
-template<typename T> template<typename U>        void ImportClsTmplMemTmpl<T>::normalInlineDecl() {}
-template<typename T> template<typename U>        void ImportClsTmplMemTmpl<T>::staticInlineDecl() {}
-#else
-template<typename T> template<typename U>        void ImportClsTmplMemTmpl<T>::normalInlineDecl() {} // expected-warning{{'ImportClsTmplMemTmpl::normalInlineDecl' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-template<typename T> template<typename U>        void ImportClsTmplMemTmpl<T>::staticInlineDecl() {} // expected-warning{{'ImportClsTmplMemTmpl::staticInlineDecl' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
+template<typename T> template<typename U>        void ImportClsTmplMemTmpl<T>::normalInlineDecl() {} // non-gnu-warning{{'ImportClsTmplMemTmpl::normalInlineDecl' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
+template<typename T> template<typename U>        void ImportClsTmplMemTmpl<T>::staticInlineDecl() {} // non-gnu-warning{{'ImportClsTmplMemTmpl::staticInlineDecl' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
 
-#ifdef GNU
-template<typename T> template<typename U> inline void ImportClsTmplMemTmpl<T>::normalInlineDef() {} // expected-warning{{'ImportClsTmplMemTmpl::normalInlineDef' redeclared inline; 'dllimport' attribute ignored}}
-template<typename T> template<typename U> inline void ImportClsTmplMemTmpl<T>::staticInlineDef() {} // expected-warning{{'ImportClsTmplMemTmpl::staticInlineDef' redeclared inline; 'dllimport' attribute ignored}}
-#else
-template<typename T> template<typename U> inline void ImportClsTmplMemTmpl<T>::normalInlineDef() {} // expected-warning{{'ImportClsTmplMemTmpl::normalInlineDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-template<typename T> template<typename U> inline void ImportClsTmplMemTmpl<T>::staticInlineDef() {} // expected-warning{{'ImportClsTmplMemTmpl::staticInlineDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
-#endif
+template<typename T> template<typename U> inline void ImportClsTmplMemTmpl<T>::normalInlineDef() {} // non-gnu-warning{{'ImportClsTmplMemTmpl::normalInlineDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}} \
+                                                                                                       gnu-warning{{'ImportClsTmplMemTmpl::normalInlineDef' redeclared inline; 'dllimport' attribute ignored}}
+template<typename T> template<typename U> inline void ImportClsTmplMemTmpl<T>::staticInlineDef() {} // non-gnu-warning{{'ImportClsTmplMemTmpl::staticInlineDef' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}} \
+                                                                                                       gnu-warning{{'ImportClsTmplMemTmpl::staticInlineDef' redeclared inline; 'dllimport' attribute ignored}}
 
 #if __has_feature(cxx_variable_templates)
 template<typename T> template<typename U>        int  ImportClsTmplMemTmpl<T>::StaticFieldDef; // expected-warning{{definition of dllimport static field}}
 template<typename T> template<typename U> const  int  ImportClsTmplMemTmpl<T>::StaticConstFieldDef = 1; // expected-warning{{definition of dllimport static field}}
-#ifdef MS
 template<typename T> template<typename U> constexpr int ImportClsTmplMemTmpl<T>::ConstexprFieldDef;
-#endif
 #endif // __has_feature(cxx_variable_templates)
 
 
@@ -1420,48 +1062,37 @@ struct CTMTR /*ClassTmplMemberTmplRedecl*/ {
   template<typename U> static        void staticDef();         // expected-note{{previous declaration is here}}
   template<typename U> static inline void staticInlineDecl();  // expected-note{{previous declaration is here}}
 
-#if defined(MS) || defined(WI) || defined(PS)
-  // expected-note@+3{{previous declaration is here}}
-  // expected-note@+3{{previous declaration is here}}
-#endif
-  template<typename U>               void normalInlineDef();
-  template<typename U> static        void staticInlineDef();
+  template<typename U>               void normalInlineDef(); // non-gnu-note{{previous declaration is here}}
+  template<typename U> static        void staticInlineDef(); // non-gnu-note{{previous declaration is here}} 
 
 #if __has_feature(cxx_variable_templates)
   template<typename U> static        int  StaticField;         // expected-note{{previous declaration is here}}
   template<typename U> static const  int  StaticConstField;    // expected-note{{previous declaration is here}}
-#ifdef MS
   template<typename U> constexpr static int ConstexprField = 1; // expected-note{{previous definition is here}}
-#endif
 #endif // __has_feature(cxx_variable_templates)
 };
 
-template<typename T> template<typename U> __declspec(dllimport)        void CTMTR<T>::normalDef() {}         // expected-error{{redeclaration of 'CTMTR::normalDef' cannot add 'dllimport' attribute}}
-                                                                                                             // expected-error@-1{{dllimport cannot be applied to non-inline function definition}}
+template<typename T> template<typename U> __declspec(dllimport)        void CTMTR<T>::normalDef() {}         // expected-error{{redeclaration of 'CTMTR::normalDef' cannot add 'dllimport' attribute}} \
+                                                                                                                expected-error{{dllimport cannot be applied to non-inline function definition}}
 template<typename T> template<typename U> __declspec(dllimport)        void CTMTR<T>::normalInlineDecl() {}  // expected-error{{redeclaration of 'CTMTR::normalInlineDecl' cannot add 'dllimport' attribute}}
-template<typename T> template<typename U> __declspec(dllimport)        void CTMTR<T>::staticDef() {}         // expected-error{{redeclaration of 'CTMTR::staticDef' cannot add 'dllimport' attribute}}
-                                                                                                             // expected-error@-1{{dllimport cannot be applied to non-inline function definition}}
+template<typename T> template<typename U> __declspec(dllimport)        void CTMTR<T>::staticDef() {}         // expected-error{{redeclaration of 'CTMTR::staticDef' cannot add 'dllimport' attribute}} \
+                                                                                                                expected-error{{dllimport cannot be applied to non-inline function definition}}
 template<typename T> template<typename U> __declspec(dllimport)        void CTMTR<T>::staticInlineDecl() {}  // expected-error{{redeclaration of 'CTMTR::staticInlineDecl' cannot add 'dllimport' attribute}}
 
-#if defined(MS) || defined(WI) || defined(PS)
-template<typename T> template<typename U> __declspec(dllimport) inline void CTMTR<T>::normalInlineDef() {}   // expected-error{{redeclaration of 'CTMTR::normalInlineDef' cannot add 'dllimport' attribute}}
-template<typename T> template<typename U> __declspec(dllimport) inline void CTMTR<T>::staticInlineDef() {}   // expected-error{{redeclaration of 'CTMTR::staticInlineDef' cannot add 'dllimport' attribute}}
-#else
-template<typename T> template<typename U> __declspec(dllimport) inline void CTMTR<T>::normalInlineDef() {}   // expected-warning{{'dllimport' attribute ignored on inline function}}
-template<typename T> template<typename U> __declspec(dllimport) inline void CTMTR<T>::staticInlineDef() {}   // expected-warning{{'dllimport' attribute ignored on inline function}}
-#endif
+template<typename T> template<typename U> __declspec(dllimport) inline void CTMTR<T>::normalInlineDef() {}   // non-gnu-error{{redeclaration of 'CTMTR::normalInlineDef' cannot add 'dllimport' attribute}} \
+                                                                                                                gnu-warning{{'dllimport' attribute ignored on inline function}}
+template<typename T> template<typename U> __declspec(dllimport) inline void CTMTR<T>::staticInlineDef() {}   // non-gnu-error{{redeclaration of 'CTMTR::staticInlineDef' cannot add 'dllimport' attribute}} \
+                                                                                                                gnu-warning{{'dllimport' attribute ignored on inline function}}
 
 #if __has_feature(cxx_variable_templates)
-template<typename T> template<typename U> __declspec(dllimport)        int  CTMTR<T>::StaticField = 1;       // expected-error{{redeclaration of 'CTMTR::StaticField' cannot add 'dllimport' attribute}}
-                                                                                                             // expected-warning@-1{{definition of dllimport static field}}
-                                                                                                             // expected-note@-2{{attribute is here}}
-template<typename T> template<typename U> __declspec(dllimport) const  int  CTMTR<T>::StaticConstField = 1;  // expected-error{{redeclaration of 'CTMTR::StaticConstField' cannot add 'dllimport' attribute}}
-                                                                                                             // expected-warning@-1{{definition of dllimport static field}}
-                                                                                                             // expected-note@-2{{attribute is here}}
-#ifdef MS
-// expected-warning@+1{{attribute declaration must precede definition}}
-template<typename T> template<typename U> __declspec(dllimport) constexpr int CTMTR<T>::ConstexprField;
-#endif
+template<typename T> template<typename U> __declspec(dllimport)        int  CTMTR<T>::StaticField = 1;       // expected-error{{redeclaration of 'CTMTR::StaticField' cannot add 'dllimport' attribute}} \
+                                                                                                                expected-warning{{definition of dllimport static field}} \
+                                                                                                                expected-note{{attribute is here}}
+template<typename T> template<typename U> __declspec(dllimport) const  int  CTMTR<T>::StaticConstField = 1;  // expected-error{{redeclaration of 'CTMTR::StaticConstField' cannot add 'dllimport' attribute}} \
+                                                                                                                expected-warning{{definition of dllimport static field}} \
+                                                                                                                expected-note{{attribute is here}}
+
+template<typename T> template<typename U> __declspec(dllimport) constexpr int CTMTR<T>::ConstexprField;      // expected-warning{{attribute declaration must precede definition}}
 #endif // __has_feature(cxx_variable_templates)
 
 
@@ -1480,26 +1111,14 @@ class __declspec(dllimport) ClassDef { };
 
 template <typename T> class ClassTemplate {};
 
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-note@+5{{previous attribute is here}}
-// expected-note@+4{{previous attribute is here}}
-// expected-error@+4{{attribute 'dllexport' cannot be applied to member of 'dllimport' class}}
-// expected-error@+4{{attribute 'dllimport' cannot be applied to member of 'dllimport' class}}
-#endif
-class __declspec(dllimport) ImportClassWithDllMember {
-  void __declspec(dllexport) foo();
-  void __declspec(dllimport) bar();
+class __declspec(dllimport) ImportClassWithDllMember { // non-gnu-note 2 {{previous attribute is here}}
+  void __declspec(dllexport) foo(); // non-gnu-error{{attribute 'dllexport' cannot be applied to member of 'dllimport' class}}
+  void __declspec(dllimport) bar(); // non-gnu-error{{attribute 'dllimport' cannot be applied to member of 'dllimport' class}}
 };
 
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-note@+5{{previous attribute is here}}
-// expected-note@+4{{previous attribute is here}}
-// expected-error@+4{{attribute 'dllimport' cannot be applied to member of 'dllexport' class}}
-// expected-error@+4{{attribute 'dllexport' cannot be applied to member of 'dllexport' class}}
-#endif
-template <typename T> class __declspec(dllexport) ExportClassWithDllMember {
-  void __declspec(dllimport) foo();
-  void __declspec(dllexport) bar();
+template <typename T> class __declspec(dllexport) ExportClassWithDllMember { // non-gnu-note 2 {{previous attribute is here}}
+  void __declspec(dllimport) foo(); // non-gnu-error{{attribute 'dllimport' cannot be applied to member of 'dllexport' class}}
+  void __declspec(dllexport) bar(); // non-gnu-error{{attribute 'dllexport' cannot be applied to member of 'dllexport' class}}
 };
 
 namespace ImportedExplicitSpecialization {
@@ -1517,20 +1136,14 @@ template <typename> struct __declspec(dllimport) S {
 S<int> s;
 }
 
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-warning@+3{{'dllimport' attribute ignored}}
-#endif
 template <typename T> struct PartiallySpecializedClassTemplate {};
-template <typename T> struct __declspec(dllimport) PartiallySpecializedClassTemplate<T*> { void f() {} };
+template <typename T> struct __declspec(dllimport) PartiallySpecializedClassTemplate<T*> { void f() {} }; // non-gnu-warning{{'dllimport' attribute ignored}}
 
 template <typename T> struct ExpliciallySpecializedClassTemplate {};
 template <> struct __declspec(dllimport) ExpliciallySpecializedClassTemplate<int> { void f() {} };
 
 // Function-local static constexpr in dllimport function (or class).
-#if defined(GNU)
-// expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-__declspec(dllimport) inline const int *dLLImportFuncWithConstexprStatic() {
+__declspec(dllimport) inline const int *dLLImportFuncWithConstexprStatic() { // gnu-warning{{'dllimport' attribute ignored on inline function}}
   static constexpr int value = 42;
   static constexpr const int *p = &value;
   static_assert(*p == 42, "");
@@ -1541,11 +1154,8 @@ bool UsedDLLImportFuncWithConstexprStatic() {
   return pFunc() == dLLImportFuncWithConstexprStatic();
 }
 
-#if !defined(PS)
-#if defined(GNU)
-  // expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-__declspec(dllimport) __forceinline const int* dLLImportInlineFuncWithConstexprStatic() {
+#ifndef __SCE__ // PS doesn't support __forceinline
+__declspec(dllimport) __forceinline const int* dLLImportInlineFuncWithConstexprStatic() { // gnu-warning{{'dllimport' attribute ignored on inline function}}
   static constexpr int value = 42;
   static constexpr const int* p = &value;
   static_assert(*p == 42, "");
@@ -1555,7 +1165,7 @@ const int* (*pFuncForceInline)() = &dLLImportInlineFuncWithConstexprStatic;
 bool UsedDLLImportInlineFuncWithConstexprStatic() {
   return pFuncForceInline() == dLLImportInlineFuncWithConstexprStatic();
 }
-#endif // !PS
+#endif // !__SCE__
 
 //===----------------------------------------------------------------------===//
 // Classes with template base classes
@@ -1566,10 +1176,7 @@ class __declspec(dllimport) ImportedClass {};
 
 template <typename T> class __declspec(dllexport) ExportedClassTemplate {};
 
-#if !defined(MS) && !defined(PS)
-// expected-error@+2{{'ImportedClassTemplate<LocalCRTP>' must have external linkage when declared 'dllimport'}}
-#endif
-template <typename T> class __declspec(dllimport) ImportedClassTemplate {};
+template <typename T> class __declspec(dllimport) ImportedClassTemplate {}; // win-gnu-error{{'ImportedClassTemplate<LocalCRTP>' must have external linkage when declared 'dllimport'}}
 
 // ClassTemplate<int> gets imported.
 class __declspec(dllimport) DerivedFromTemplate : public ClassTemplate<int> {};
@@ -1596,30 +1203,21 @@ class __declspec(dllimport) DerivedFromTemplateB : public ClassTemplate<bool> {}
 class __declspec(dllexport) DerivedFromTemplateB2 : public ClassTemplate<bool> {};
 
 template <typename T> struct ExplicitlySpecializedTemplate { void func() {} };
-#if defined(MS) || defined(PS)
-// expected-note@+2{{class template 'ExplicitlySpecializedTemplate<int>' was explicitly specialized here}}
-#endif
-template <> struct ExplicitlySpecializedTemplate<int> { void func() {} };
+template <> struct ExplicitlySpecializedTemplate<int> { void func() {} }; // ms-ps-note{{class template 'ExplicitlySpecializedTemplate<int>' was explicitly specialized here}}
 template <typename T> struct ExplicitlyExportSpecializedTemplate { void func() {} };
 template <> struct __declspec(dllexport) ExplicitlyExportSpecializedTemplate<int> { void func() {} };
 template <typename T> struct ExplicitlyImportSpecializedTemplate { void func() {} };
 template <> struct __declspec(dllimport) ExplicitlyImportSpecializedTemplate<int> { void func() {} };
 
 template <typename T> struct ExplicitlyInstantiatedTemplate { void func() {} };
-#if defined(MS) || defined(PS)
-// expected-note@+2{{class template 'ExplicitlyInstantiatedTemplate<int>' was instantiated here}}
-#endif
-template struct ExplicitlyInstantiatedTemplate<int>;
+template struct ExplicitlyInstantiatedTemplate<int>; // ms-ps-note{{class template 'ExplicitlyInstantiatedTemplate<int>' was instantiated here}}
 template <typename T> struct ExplicitlyExportInstantiatedTemplate { void func() {} };
 template struct __declspec(dllexport) ExplicitlyExportInstantiatedTemplate<int>;
 template <typename T> struct ExplicitlyImportInstantiatedTemplate { void func() {} };
 template struct __declspec(dllimport) ExplicitlyImportInstantiatedTemplate<int>;
 
-#if defined(MS) || defined(PS)
-// expected-warning@+3{{propagating dll attribute to explicitly specialized base class template without dll attribute is not supported}}
-// expected-note@+2{{attribute is here}}
-#endif
-struct __declspec(dllimport) DerivedFromExplicitlySpecializedTemplate : public ExplicitlySpecializedTemplate<int> {};
+struct __declspec(dllimport) DerivedFromExplicitlySpecializedTemplate : public ExplicitlySpecializedTemplate<int> {}; // ms-ps-warning{{propagating dll attribute to explicitly specialized base class template without dll attribute is not supported}} \
+                                                                                                                         ms-ps-note{{attribute is here}}
 
 // Base class already specialized with export attribute.
 struct __declspec(dllimport) DerivedFromExplicitlyExportSpecializedTemplate : public ExplicitlyExportSpecializedTemplate<int> {};
@@ -1627,11 +1225,8 @@ struct __declspec(dllimport) DerivedFromExplicitlyExportSpecializedTemplate : pu
 // Base class already specialized with import attribute.
 struct __declspec(dllimport) DerivedFromExplicitlyImportSpecializedTemplate : public ExplicitlyImportSpecializedTemplate<int> {};
 
-#if defined(MS) || defined(PS)
-// expected-warning@+3{{propagating dll attribute to already instantiated base class template without dll attribute is not supported}}
-// expected-note@+2{{attribute is here}}
-#endif
-struct __declspec(dllimport) DerivedFromExplicitlyInstantiatedTemplate : public ExplicitlyInstantiatedTemplate<int> {};
+struct __declspec(dllimport) DerivedFromExplicitlyInstantiatedTemplate : public ExplicitlyInstantiatedTemplate<int> {}; // ms-ps-warning{{propagating dll attribute to already instantiated base class template without dll attribute is not supported}} \
+                                                                                                                           ms-ps-note{{attribute is here}}
 
 // Base class already instantiated with export attribute.
 struct __declspec(dllimport) DerivedFromExplicitlyExportInstantiatedTemplate : public ExplicitlyExportInstantiatedTemplate<int> {};
@@ -1647,19 +1242,12 @@ void func() {
   // MSVC propagates dllimport to derived classes even if they don't have external linkage.
   class LocalDerivedFromImportedClass : public ImportedClass {};
   class LocalDerivedFromImportedTemplate : public ImportedClassTemplate<int> {};
-#if defined(GNU) || defined(WI)
-  // expected-note@+2{{in instantiation of template class 'ImportedClassTemplate<LocalCRTP>' requested here}}
-#endif
-  class LocalCRTP : public ImportedClassTemplate<LocalCRTP> {};
+  class LocalCRTP : public ImportedClassTemplate<LocalCRTP> {}; // win-gnu-note{{in instantiation of template class 'ImportedClassTemplate<LocalCRTP>' requested here}}
 }
 
 //===----------------------------------------------------------------------===//
 // Lambdas
 //===----------------------------------------------------------------------===//
 // The MS ABI doesn't provide a stable mangling for lambdas, so they can't be imported or exported.
-#if defined(MS) || defined(WI) || defined(PS)
-// expected-error@+4{{lambda cannot be declared 'dllimport'}}
-#else
-// expected-warning@+2{{'dllimport' attribute ignored on inline function}}
-#endif
-auto Lambda = []() __declspec(dllimport) -> bool { return true; };
+auto Lambda = []() __declspec(dllimport) -> bool { return true; }; // non-gnu-error{{lambda cannot be declared 'dllimport'}} \
+                                                                      gnu-warning{{'dllimport' attribute ignored on inline function}}

--- a/clang/test/SemaCXX/dllimport.cpp
+++ b/clang/test/SemaCXX/dllimport.cpp
@@ -1013,36 +1013,41 @@ struct ClassTmplSpecializedMember {
   void member() {}
 };
 
-template <> void ClassTmplSpecializedMember<false, InstTrig::Spec>::specializedMember1();
-extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Spec>;
-template <> void ClassTmplSpecializedMember<true, InstTrig::Spec>::specializedMember1();
-template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Spec>;
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec>::specializedMember1(); // non-gnu-note{{implicit instantiation first required here}}
+extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Spec>; // non-gnu-warning{{'dllimport' attribute ignored; class template is already instantiated}}
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec>::specializedMember1(); // non-gnu-note{{implicit instantiation first required here}}
+template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Spec>; // non-gnu-warning{{'dllimport' attribute ignored; class template is already instantiated}} \
+                                                                                           gnu-warning{{'dllimport' attribute ignored on explicit instantiation definition}}
 
-void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl> &x) { x.instantiatedMember1(); }
-extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Impl>;
-void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl> &x) { x.instantiatedMember1(); }
-template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Impl>;
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl> &x) { x.instantiatedMember1(); } // non-gnu-note{{implicit instantiation first required here}}
+extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Impl>; // non-gnu-warning{{'dllimport' attribute ignored; class template is already instantiated}}
+void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl> &x) { x.instantiatedMember1(); } // non-gnu-note{{implicit instantiation first required here}}
+template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Impl>; // non-gnu-warning{{'dllimport' attribute ignored; class template is already instantiated}} \
+                                                                                           gnu-warning{{'dllimport' attribute ignored on explicit instantiation definition}}
 
-template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember1();
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember1(); // non-gnu-note{{implicit instantiation first required here}}
 template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember2();
-extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>;
-template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>::specializedMember1();
+extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>; // non-gnu-warning{{'dllimport' attribute ignored; class template is already instantiated}}
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>::specializedMember1(); // non-gnu-note{{implicit instantiation first required here}}
 template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>::specializedMember2();
-template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>;
+template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>; // non-gnu-warning{{'dllimport' attribute ignored; class template is already instantiated}} \
+                                                                                                           gnu-warning{{'dllimport' attribute ignored on explicit instantiation definition}}
 
-template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>::specializedMember1();
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>::specializedMember1(); // non-gnu-note{{implicit instantiation first required here}}
 void anchor(ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl> &x) { x.instantiatedMember1(); }
-extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>;
-template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>::specializedMember1();
+extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>; // non-gnu-warning{{'dllimport' attribute ignored; class template is already instantiated}}
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>::specializedMember1(); // non-gnu-note{{implicit instantiation first required here}}
 void anchor(ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl> &x) { x.instantiatedMember1(); }
-template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>;
+template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>; // non-gnu-warning{{'dllimport' attribute ignored; class template is already instantiated}} \
+                                                                                                           gnu-warning{{'dllimport' attribute ignored on explicit instantiation definition}}
 
-void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); } // non-gnu-note{{implicit instantiation first required here}}
 template <> void ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec>::specializedMember1();
-extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec>;
-void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }
+extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec>; // non-gnu-warning{{'dllimport' attribute ignored; class template is already instantiated}}
+void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); } // non-gnu-note{{implicit instantiation first required here}}
 template <> void ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec>::specializedMember1();
-template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec>;
+template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec>; // non-gnu-warning{{'dllimport' attribute ignored; class template is already instantiated}} \
+                                                                                                           gnu-warning{{'dllimport' attribute ignored on explicit instantiation definition}}
 
 
 //===----------------------------------------------------------------------===//

--- a/clang/test/SemaCXX/dllimport.cpp
+++ b/clang/test/SemaCXX/dllimport.cpp
@@ -999,6 +999,51 @@ template<> void ClassTmpl<int>::importedStatic() {} // non-gnu-error{{cannot def
 
 template <> void ImportClassTmplMembers<int>::normalDecl() = delete; // non-gnu-error{{cannot define non-inline dllimport template specialization}} \
                                                                         non-gnu-error{{attribute 'dllimport' cannot be applied to a deleted function}}
+struct InstTrig {
+    struct Spec;
+    struct Impl;
+    struct Decl;
+};
+template<bool InstDef, typename... Triggers>
+struct ClassTmplSpecializedMember {
+  void specializedMember1();
+  void specializedMember2();
+  void instantiatedMember1();
+  void instantiatedMember2();
+  void member() {}
+};
+
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec>::specializedMember1();
+extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Spec>;
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec>::specializedMember1();
+template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Spec>;
+
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Impl>;
+void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Impl>;
+
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember1();
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>::specializedMember2();
+extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Spec>;
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>::specializedMember1();
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>::specializedMember2();
+template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Spec>;
+
+template <> void ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>::specializedMember1();
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Spec, InstTrig::Impl>;
+template <> void ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>::specializedMember1();
+void anchor(ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl> &x) { x.instantiatedMember1(); }
+template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Spec, InstTrig::Impl>;
+
+void anchor(ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }
+template <> void ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec>::specializedMember1();
+extern template struct __declspec(dllimport) ClassTmplSpecializedMember<false, InstTrig::Impl, InstTrig::Spec>;
+void anchor(ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec> &x) { x.instantiatedMember1(); }
+template <> void ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec>::specializedMember1();
+template struct __declspec(dllimport) ClassTmplSpecializedMember<true, InstTrig::Impl, InstTrig::Spec>;
+
 
 //===----------------------------------------------------------------------===//
 // Class template member templates


### PR DESCRIPTION
Diagnose about a non-effective dllimport attribute on an explicit instantiation declaration for a specialization which
was already (implicitly) instantiated somewhere, rather than ignoring it silently.

related to #21132