### PR TITLE
[AArch64] Skip non-pseudo instructions in AArch64ExpandPseudoInsts

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -2004,7 +2004,8 @@ bool AArch64ExpandPseudoImpl::expandMBB(MachineBasicBlock &MBB) {
   MachineBasicBlock::iterator MBBI = MBB.begin(), E = MBB.end();
   while (MBBI != E) {
     MachineBasicBlock::iterator NMBBI = std::next(MBBI);
-    Modified |= expandMI(MBB, MBBI, NMBBI);
+    if (MBBI->isPseudo())
+      Modified |= expandMI(MBB, MBBI, NMBBI);
     MBBI = NMBBI;
   }
 

--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -1375,20 +1375,14 @@ bool AArch64ExpandPseudoImpl::expandMI(MachineBasicBlock &MBB,
                                        MachineBasicBlock::iterator &NextMBBI) {
   MachineInstr &MI = *MBBI;
   unsigned Opcode = MI.getOpcode();
-  const AArch64Subtarget &STI =
-      MBB.getParent()->getSubtarget<AArch64Subtarget>();
 
-  // Check if we can expand the destructive op. We check target features to
-  // avoid compile-time cost of AArch64::getSVEPseudoMap if not required by
-  // target.
-  if (STI.hasSVE() || STI.hasSME()) {
-    int OrigInstr = AArch64::getSVEPseudoMap(MI.getOpcode());
-    if (OrigInstr != -1) {
-      auto &Orig = TII->get(OrigInstr);
-      if ((Orig.TSFlags & AArch64::DestructiveInstTypeMask) !=
-          AArch64::NotDestructive) {
-        return expand_DestructiveOp(MI, MBB, MBBI);
-      }
+  // Check if we can expand the destructive op
+  int OrigInstr = AArch64::getSVEPseudoMap(MI.getOpcode());
+  if (OrigInstr != -1) {
+    auto &Orig = TII->get(OrigInstr);
+    if ((Orig.TSFlags & AArch64::DestructiveInstTypeMask) !=
+        AArch64::NotDestructive) {
+      return expand_DestructiveOp(MI, MBB, MBBI);
     }
   }
 

--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -1375,14 +1375,20 @@ bool AArch64ExpandPseudoImpl::expandMI(MachineBasicBlock &MBB,
                                        MachineBasicBlock::iterator &NextMBBI) {
   MachineInstr &MI = *MBBI;
   unsigned Opcode = MI.getOpcode();
+  const AArch64Subtarget &STI =
+      MBB.getParent()->getSubtarget<AArch64Subtarget>();
 
-  // Check if we can expand the destructive op
-  int OrigInstr = AArch64::getSVEPseudoMap(MI.getOpcode());
-  if (OrigInstr != -1) {
-    auto &Orig = TII->get(OrigInstr);
-    if ((Orig.TSFlags & AArch64::DestructiveInstTypeMask) !=
-        AArch64::NotDestructive) {
-      return expand_DestructiveOp(MI, MBB, MBBI);
+  // Check if we can expand the destructive op. We check target features to
+  // avoid compile-time cost of AArch64::getSVEPseudoMap if not required by
+  // target.
+  if (STI.hasSVE() || STI.hasSME()) {
+    int OrigInstr = AArch64::getSVEPseudoMap(MI.getOpcode());
+    if (OrigInstr != -1) {
+      auto &Orig = TII->get(OrigInstr);
+      if ((Orig.TSFlags & AArch64::DestructiveInstTypeMask) !=
+          AArch64::NotDestructive) {
+        return expand_DestructiveOp(MI, MBB, MBBI);
+      }
     }
   }
 


### PR DESCRIPTION
AArch64::getSVEPseudoMap calls are visible in compile-time profiles even on
non-SVE targets. I think CodeGenMapTable could be improved, it's currently
emitting a constexpr array sorted by opcode and a hand-rolled binary search
over that array, however the AArch64ExpandPseudoInsts pass is missing a simple
check for pseudo instructions before expanding. This avoids the compile-time
cost.

https://llvm-compile-time-tracker.com/compare.php?from=0d42811ea4658b3e86a3801b3bc848324f8540f8&to=9e2434de84577ca1c5e6de8fe8d75c6b8e282b3f&stat=instructions%3Au