### PR TITLE
[AMDGPU] Do not emit function prologue on naked functions

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -3684,7 +3684,8 @@ bool SIInsertWaitcnts::run() {
 
   MachineBasicBlock &EntryBB = MF.front();
 
-  if (!MFI->isEntryFunction()) {
+  if (!MFI->isEntryFunction() &&
+      !MF.getFunction().hasFnAttribute(Attribute::Naked)) {
     // Wait for any outstanding memory operations that the input registers may
     // depend on. We can't track them and it's better to do the wait after the
     // costly call sequence.

--- a/llvm/test/CodeGen/AMDGPU/naked-fn-with-frame-pointer.ll
+++ b/llvm/test/CodeGen/AMDGPU/naked-fn-with-frame-pointer.ll
@@ -8,7 +8,6 @@ define dso_local void @naked() naked "frame-pointer"="all" {
 ; CHECK:       .Lnaked$local:
 ; CHECK-NEXT:    .type .Lnaked$local,@function
 ; CHECK-NEXT:  ; %bb.0:
-; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    s_getpc_b64 s[16:17]
 ; CHECK-NEXT:    s_add_u32 s16, s16, main@rel32@lo+4
 ; CHECK-NEXT:    s_addc_u32 s17, s17, main@rel32@hi+12


### PR DESCRIPTION
Summary:
Naked functions are intended to allow the user to write the entirety of
the function block, so we shouldn't include the `waitcnt` instructions
for them.
