### PR TITLE
[UnitTests] Enable PCH

### DIFF
--- a/clang/unittests/Basic/CharInfoTest.cpp
+++ b/clang/unittests/Basic/CharInfoTest.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Basic/CharInfo.h"
-#include "clang/Basic/CharInfo.h"
 #include "gtest/gtest.h"
 
 using namespace clang;

--- a/clang/unittests/Basic/CharInfoTest.cpp
+++ b/clang/unittests/Basic/CharInfoTest.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Basic/CharInfo.h"
+#include "clang/Basic/CharInfo.h"
 #include "gtest/gtest.h"
 
-using namespace llvm;
 using namespace clang;
 
 // Check that the CharInfo table has been constructed reasonably.

--- a/clang/unittests/Frontend/CompilerInstanceTest.cpp
+++ b/clang/unittests/Frontend/CompilerInstanceTest.cpp
@@ -173,7 +173,7 @@ TEST(CompilerInstance, SingleModuleParseModeCallback) {
     std::vector<std::string> &SkippedModules;
     ModuleLoadSkippedCallback(std::vector<std::string> &SkippedModules)
         : SkippedModules(SkippedModules) {}
-    void moduleLoadSkipped(Module *Skipped) override {
+    void moduleLoadSkipped(clang::Module *Skipped) override {
       SkippedModules.emplace_back(Skipped->getFullModuleName());
     }
   };

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -1906,7 +1906,7 @@ function(add_unittest test_suite test_name)
   endif()
 
   list(APPEND LLVM_LINK_COMPONENTS Support) # gtest needs it for raw_ostream
-  add_llvm_executable(${test_name} IGNORE_EXTERNALIZE_DEBUGINFO NO_INSTALL_RPATH DISABLE_PCH_REUSE ${ARGN})
+  add_llvm_executable(${test_name} IGNORE_EXTERNALIZE_DEBUGINFO NO_INSTALL_RPATH ${ARGN})
   get_subproject_title(subproject_title)
   set_target_properties(${test_name} PROPERTIES FOLDER "${subproject_title}/Tests/Unit")
 

--- a/llvm/unittests/Support/raw_sha1_ostream_test.cpp
+++ b/llvm/unittests/Support/raw_sha1_ostream_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_sha1_ostream.h"
 #include "gtest/gtest.h"
@@ -13,20 +14,6 @@
 #include <string>
 
 using namespace llvm;
-
-static std::string toHex(ArrayRef<uint8_t> Input) {
-  static const char *const LUT = "0123456789ABCDEF";
-  size_t Length = Input.size();
-
-  std::string Output;
-  Output.reserve(2 * Length);
-  for (size_t i = 0; i < Length; ++i) {
-    const unsigned char c = Input[i];
-    Output.push_back(LUT[c >> 4]);
-    Output.push_back(LUT[c & 15]);
-  }
-  return Output;
-}
 
 TEST(raw_sha1_ostreamTest, Basic) {
   llvm::raw_sha1_ostream Sha1Stream;


### PR DESCRIPTION
I originally didn't enable PCH for unit tests, because I intended to
build a gtest PCH. But while gtest.h is slow, having many large standard
library headers already pre-compiled via the LLVMSupport PCH already
helps a lot, leaving ~250ms for parsing gtest.h (+ a fair amount of time
for template instantiation). Additionally, for unit tests that include
IR or AST headers, re-using the PCHs that include these is more
beneficial than gtest.h. Therefore, no longer disable PCH on unit tests.
