### PR TITLE
[lldb][Process/FreeBSDKernelCore] Switch to LLDBLog::Process

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -540,7 +540,7 @@ void ProcessFreeBSDKernelCore::PrintUnreadMessage() {
 
     if (field_found != 4) {
       LLDB_LOGF(
-          GetLog(LLDBLog::Object),
+          GetLog(LLDBLog::Process),
           "FreeBSD-Kernel-Core: Could not find all required fields for msgbuf");
       return;
     }


### PR DESCRIPTION
Failure to read all required fields for msgbuf isn't ObjectFile's fault but FreeBSD-Kernel-Core plugin specific. Thus this should be logged through `LLDBLog::Process` rather than `LLDBLog::Object`.