### PR TITLE
[libcxx][test] Skip cas_non_power_of_2.pass.cpp in Picolibc build

### DIFF
--- a/libcxx/test/std/atomics/atomics.types.generic/cas_non_power_of_2.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/cas_non_power_of_2.pass.cpp
@@ -16,6 +16,10 @@
 // the fix https://github.com/llvm/llvm-project/pull/78707
 // UNSUPPORTED: clang-22
 
+// The ARM Picolibc build does not include implementations of __atomic_load or
+// __atomic_compare_exchange: https://github.com/llvm/llvm-project/issues/191388
+// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+
 #include <atomic>
 #include <cstring>
 #include <cassert>


### PR DESCRIPTION
Relates to #191388

This test is currently being run and failing to link, however this is masked by the XFAIL for clang 21. It is also marked unsupported for 22, for now.

I ran it with 23 and got this linker error:
```
| ld.lld: error: undefined symbol: __atomic_load
<...>
| ld.lld: error: undefined symbol: __atomic_compare_exchange
```

This happens because for 5 and 6 byte variables, we can't simply generate code for the atomic, so we emit a library call, and the picolibc build does not provide implementations of these functions.

Presumably we could fix that, so I opened an issue to track that.

In the meantime, I want to make sure this doesn't start failing when CI is updated to clang 23.

I decided to disable the whole test instead of the alternatives, which are:
* Adding some extra feature like has-atomic-lib-calls. I wasn't sure what was a good name for it, or how to write an accurate check for it.
* ifdef-ing out the 5 and 6 byte part with `__PICOLIBC__`. It's not a problem with picolibc but our specific build type. I don't want to take coverage away from anyone else's build.