### PR TITLE
[lldb] Rally around triple rather than arch in the API tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -25,7 +25,6 @@ class Builder:
         return os.path.abspath(compiler)
 
     def getTriple(self):
-        """Returns the triple."""
         return configuration.triple
 
     def getExtraMakeArgs(self):

--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -24,8 +24,8 @@ class Builder:
         compiler = lldbutil.which(compiler)
         return os.path.abspath(compiler)
 
-    def getTriple(self, arch):
-        """Returns the triple for the given architecture or None."""
+    def getTriple(self):
+        """Returns the triple."""
         return configuration.triple
 
     def getExtraMakeArgs(self):
@@ -35,11 +35,15 @@ class Builder:
         """
         return []
 
-    def getArchCFlags(self, architecture):
-        """Returns the ARCH_CFLAGS for the make system."""
-        triple = self.getTriple(architecture)
+    def getTripleSpec(self):
+        """Returns the TRIPLE for the make system."""
+        triple = self.getTriple()
         if triple:
-            return ["ARCH_CFLAGS=-target {}".format(triple)]
+            return ["TRIPLE=" + triple]
+        return []
+
+    def getArchCFlags(self):
+        """Returns the ARCH_CFLAGS for the make system."""
         return []
 
     def getMake(self, test_subdir, test_name):
@@ -94,13 +98,6 @@ class Builder:
         cmdline = [setOrAppendVariable(k, v) for k, v in list(d.items())]
 
         return cmdline
-
-    def getArchSpec(self, architecture):
-        """
-        Helper function to return the key-value string to specify the architecture
-        used for the make system.
-        """
-        return ["ARCH=" + architecture] if architecture else []
 
     def getToolchainSpec(self, compiler):
         """
@@ -294,8 +291,8 @@ class Builder:
             self.getMake(testdir, testname),
             debug_info_args,
             make_targets,
-            self.getArchCFlags(architecture),
-            self.getArchSpec(architecture),
+            self.getArchCFlags(),
+            self.getTripleSpec(),
             self.getToolchainSpec(compiler),
             self.getExtraMakeArgs(),
             self.getSDKRootSpec(),

--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -60,7 +60,6 @@ class BuilderDarwin(Builder):
         return ["{}={}".format(key, value) for key, value in args.items()]
 
     def getArchCFlags(self):
-        # Get the triple components.
         triple = self.getTriple()
         if not triple:
             return []

--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -6,69 +6,23 @@ from .builder import Builder
 from lldbsuite.test import configuration
 import lldbsuite.test.lldbutil as lldbutil
 
-REMOTE_PLATFORM_NAME_RE = re.compile(r"^remote-(.+)$")
-SIMULATOR_PLATFORM_RE = re.compile(r"^(.+)-simulator$")
+TRIPLE_RE = re.compile(
+    r"^(?P<arch>[a-zA-Z0-9_]+)"  # arch (required)
+    r"(?:-(?P<vendor>[a-zA-Z0-9_]+))?"  # vendor (optional)
+    r"(?:-(?P<os>[a-zA-Z_]+)(?P<os_version>[\d.]+)?)?"  # os + version (optional)
+    r"(?:-(?P<env>[a-zA-Z0-9_]+))?"  # env/abi (optional)
+    r"$"
+)
 
 
-def get_os_env_from_platform(platform):
-    match = REMOTE_PLATFORM_NAME_RE.match(platform)
-    if match:
-        return match.group(1), ""
-    match = SIMULATOR_PLATFORM_RE.match(platform)
-    if match:
-        return match.group(1), "simulator"
-    return None, None
-
-
-def get_os_from_sdk(sdk):
-    return sdk[: sdk.find(".")], ""
-
-
-def get_os_and_env():
-    if configuration.lldb_platform_name:
-        return get_os_env_from_platform(configuration.lldb_platform_name)
-    if configuration.apple_sdk:
-        return get_os_from_sdk(configuration.apple_sdk)
-    return None, None
-
-
-def get_triple():
-    # Construct the vendor component.
-    vendor = "apple"
-
-    # Construct the os component.
-    os, env = get_os_and_env()
-    if os is None or env is None:
-        return None, None, None, None
-
-    # Get the SDK from the os and env.
-    sdk = lldbutil.get_xcode_sdk(os, env)
-    if sdk is None:
-        return None, None, None, None
-
-    # Get the version from the SDK.
-    version = lldbutil.get_xcode_sdk_version(sdk)
-    if version is None:
-        return None, None, None, None
-
-    return vendor, os, version, env
-
-
-def get_triple_str(arch, vendor, os, version, env):
-    if None in [arch, vendor, os, version, env]:
-        return None
-
-    component = [arch, vendor, os + version]
-    if env:
-        component.append(env)
-    return "-".join(component)
+def split_triple(triple):
+    m = TRIPLE_RE.match(triple)
+    if m:
+        return m["arch"], m["vendor"], m["os"], m["os_version"], m["env"]
+    return None, None, None, None, None
 
 
 class BuilderDarwin(Builder):
-    def getTriple(self, arch):
-        vendor, os, version, env = get_triple()
-        return get_triple_str(arch, vendor, os, version, env)
-
     def getExtraMakeArgs(self):
         """
         Helper function to return extra argumentsfor the make system. This
@@ -87,39 +41,40 @@ class BuilderDarwin(Builder):
                 )
                 args["FRAMEWORK_INCLUDES"] = "-F{}".format(private_frameworks)
 
-        operating_system, env = get_os_and_env()
+        triple = self.getTriple()
+        if triple:
+            _, _, operating_system, _, env = split_triple(triple)
 
-        builder_dir = os.path.dirname(os.path.abspath(__file__))
-        test_dir = os.path.dirname(builder_dir)
-        if not operating_system:
-            entitlements_file = "entitlements-macos.plist"
-        else:
-            if env == "simulator":
-                entitlements_file = "entitlements-simulator.plist"
+            builder_dir = os.path.dirname(os.path.abspath(__file__))
+            test_dir = os.path.dirname(builder_dir)
+            if operating_system in [None, "darwin", "macos", "macosx"]:
+                entitlements_file = "entitlements-macos.plist"
             else:
-                entitlements_file = "entitlements.plist"
-        entitlements = os.path.join(test_dir, "make", entitlements_file)
-        args["CODESIGN"] = "codesign --entitlements {}".format(entitlements)
+                if env == "simulator":
+                    entitlements_file = "entitlements-simulator.plist"
+                else:
+                    entitlements_file = "entitlements.plist"
+            entitlements = os.path.join(test_dir, "make", entitlements_file)
+            args["CODESIGN"] = "codesign --entitlements {}".format(entitlements)
 
         # Return extra args as a formatted string.
         return ["{}={}".format(key, value) for key, value in args.items()]
 
-    def getArchCFlags(self, arch):
+    def getArchCFlags(self):
         """Returns the ARCH_CFLAGS for the make system."""
         # Get the triple components.
-        vendor, os, version, env = get_triple()
-        triple = get_triple_str(arch, vendor, os, version, env)
+        triple = self.getTriple()
         if not triple:
             return []
 
-        # Construct min version argument
-        version_min = ""
-        if env == "simulator":
-            version_min = "-m{}-simulator-version-min={}".format(os, version)
-        else:
-            version_min = "-m{}-version-min={}".format(os, version)
+        _, _, os, version, _ = split_triple(triple)
 
-        return ["ARCH_CFLAGS=-target {} {}".format(triple, version_min)]
+        if os == "darwin" or not version:
+            return []
+
+        target_os = "-mtargetos={}{}".format(os, version)
+
+        return ["ARCH_CFLAGS={}".format(target_os)]
 
     def _getDebugInfoArgs(self, debug_info):
         if debug_info == "dsym":

--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -7,19 +7,19 @@ from lldbsuite.test import configuration
 import lldbsuite.test.lldbutil as lldbutil
 
 TRIPLE_RE = re.compile(
-    r"^(?P<arch>[a-zA-Z0-9_]+)"  # arch (required)
-    r"(?:-(?P<vendor>[a-zA-Z0-9_]+))?"  # vendor (optional)
-    r"(?:-(?P<os>[a-zA-Z_]+)(?P<os_version>[\d.]+)?)?"  # os + version (optional)
-    r"(?:-(?P<env>[a-zA-Z0-9_]+))?"  # env/abi (optional)
-    r"$"
+    r"""^(?P<arch>[a-zA-Z0-9_]+) # arch (required)
+        (?:-(?P<vendor>[a-zA-Z0-9_]+))? # vendor (optional)
+        (?:-(?P<os>[a-zA-Z_]+)(?P<os_version>[\d.]+)?)? # os + version (optional)
+        (?:-(?P<env>[a-zA-Z0-9_]+))? # env/abi (optional)
+        $""",
+    re.X,
 )
 
 
 def split_triple(triple):
-    m = TRIPLE_RE.match(triple)
-    if m:
-        return m["arch"], m["vendor"], m["os"], m["os_version"], m["env"]
-    return None, None, None, None, None
+    if m := TRIPLE_RE.match(triple):
+        return m.groups()
+    return [None] * TRIPLE_RE.groups
 
 
 class BuilderDarwin(Builder):
@@ -41,8 +41,7 @@ class BuilderDarwin(Builder):
                 )
                 args["FRAMEWORK_INCLUDES"] = "-F{}".format(private_frameworks)
 
-        triple = self.getTriple()
-        if triple:
+        if triple := self.getTriple():
             _, _, operating_system, _, env = split_triple(triple)
 
             builder_dir = os.path.dirname(os.path.abspath(__file__))
@@ -61,7 +60,6 @@ class BuilderDarwin(Builder):
         return ["{}={}".format(key, value) for key, value in args.items()]
 
     def getArchCFlags(self):
-        """Returns the ARCH_CFLAGS for the make system."""
         # Get the triple components.
         triple = self.getTriple()
         if not triple:

--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -39,7 +39,8 @@ lldb_framework_path = None
 # Test suite repeat count.  Can be overwritten with '-# count'.
 count = 1
 
-# The 'arch' and 'compiler' can be specified via command line.
+# The 'arch' is derived from the triple. The 'compiler' can be specified via
+# command line.
 arch = None
 compiler = None
 dsymutil = None

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -338,12 +338,9 @@ def parseOptionsAndInitTestdirs():
     if args.triple:
         configuration.triple = args.triple
 
-    if args.arch:
-        configuration.arch = args.arch
-    elif args.triple:
-        configuration.arch = args.triple.split("-")[0]
-    else:
-        configuration.arch = platform_machine
+    configuration.arch = (
+        configuration.triple.split("-")[0] if configuration.triple else platform_machine
+    )
 
     if args.categories_list:
         configuration.categories_list = set(

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -90,7 +90,7 @@ def create_parser():
         "-E",
         metavar="extra-flags",
         help=textwrap.dedent(
-            """Specify the extra flags to be passed to the toolchain when building the inferior programs to be debugged"""
+            """Specify the extra flags to be passed to the toolchain when building the inferior programs to be debugged."""
         ),
     )
 

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -32,12 +32,11 @@ def create_parser():
     # C and Python toolchain options
     group = parser.add_argument_group("Toolchain options")
     group.add_argument(
-        "-A",
-        "--arch",
-        metavar="arch",
-        dest="arch",
+        "--triple",
+        metavar="triple",
+        dest="triple",
         help=textwrap.dedent(
-            """Specify the architecture(s) to test. This option can be specified more than once"""
+            """Specify the target triple to test with (e.g. x86_64-unknown-linux-gnu, arm64-apple-macosx)."""
         ),
     )
     group.add_argument(
@@ -56,14 +55,6 @@ def create_parser():
         default="",
         help=textwrap.dedent(
             """Specify the path to sysroot. This overrides apple_sdk sysroot."""
-        ),
-    )
-    group.add_argument(
-        "--triple",
-        metavar="triple",
-        dest="triple",
-        help=textwrap.dedent(
-            """Specify the target triple. Used for cross compilation."""
         ),
     )
     if sys.platform == "darwin":
@@ -94,13 +85,12 @@ def create_parser():
             "Specify the path to a custom libc++ library directory. Must be used in conjunction with --libcxx-include-dir."
         ),
     )
-    # FIXME? This won't work for different extra flags according to each arch.
+    # FIXME? This won't work for different extra flags according to each triple.
     group.add_argument(
         "-E",
         metavar="extra-flags",
         help=textwrap.dedent(
-            """Specify the extra flags to be passed to the toolchain when building the inferior programs to be debugged
-                                                           suggestions: do not lump the "-A arch1 -A arch2" together such that the -E option applies to only one of the architectures"""
+            """Specify the extra flags to be passed to the toolchain when building the inferior programs to be debugged"""
         ),
     )
 

--- a/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -345,7 +345,7 @@ def getDwarfVersion():
         return str(configuration.dwarf_version)
     if "clang" in getCompiler():
         try:
-            triple = builder_module().getTriple(getArchitecture())
+            triple = builder_module().getTriple()
             target = ["-target", triple] if triple else []
             driver_output = subprocess.check_output(
                 [getCompiler()] + target + "-g -c -x c - -o - -###".split(),

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -109,24 +109,32 @@ else
 endif
 
 #----------------------------------------------------------------------
-# If TRIPLE is not defined try to set the ARCH, CC, CFLAGS, and more
-# from the triple alone
+# Determine the target triple. The triple is the canonical way to
+# specify the target. When only ARCH is provided we query the compiler
+# for its default triple and replace the arch component.
 #----------------------------------------------------------------------
 ARCH_CFLAGS :=
 ifeq "$(OS)" "Android"
 	include $(THIS_FILE_DIR)/Android.rules
 endif
 
-#----------------------------------------------------------------------
-# If ARCH is not defined, default to x86_64.
-#----------------------------------------------------------------------
+ifeq "$(TRIPLE)" ""
+  ifeq "$(ARCH)" ""
+    # No triple, no arch: query the compiler for its default triple.
+    TRIPLE := $(shell $(CC) --print-target-triple)
+  else
+    # ARCH but no TRIPLE: replace the arch in the compiler's default triple.
+    TRIPLE := $(shell $(CC) --print-target-triple | sed 's/^[^-]*/$(ARCH)/')
+  endif
+endif
+
+# Derive ARCH from the first component of the triple if not already set.
 ifeq "$(ARCH)" ""
-ifeq "$(OS)" "Windows_NT"
-	ARCH = x86
-else
-	ARCH = x86_64
+  ARCH := $(firstword $(subst -, ,$(TRIPLE)))
 endif
-endif
+
+# Use -target to pass the triple to the compiler.
+ARCH_CFLAGS := -target $(TRIPLE)
 
 #----------------------------------------------------------------------
 # CC defaults to clang.
@@ -182,12 +190,10 @@ ifeq "$(HOST_OS)" "Darwin"
 	endif
 endif
 
-
-#----------------------------------------------------------------------
-# ARCHFLAG is the flag used to tell the compiler which architecture
-# to compile for. The default is the flag that clang accepts.
-#----------------------------------------------------------------------
-ARCHFLAG ?= -arch
+# Detect x86 from ARCH.
+ifneq (,$(filter amd64 x86_64 x64 x86 i386 i686,$(ARCH)))
+	IS_X86 := 1
+endif
 
 #----------------------------------------------------------------------
 # Change any build/tool options needed
@@ -198,68 +204,6 @@ ifeq "$(OS)" "Darwin"
 	DSYM = $(EXE).dSYM
 	ARFLAGS := -static -o
 else
-	# On non-Apple platforms, -arch becomes -m
-	ARCHFLAG := -m
-
-	# i386, i686, x86 -> 32
-	# amd64, x86_64, x64 -> 64
-	ifeq "$(ARCH)" "amd64"
-		override ARCH := $(subst amd64,64,$(ARCH))
-		IS_X86 := 1
-	endif
-	ifeq "$(ARCH)" "x86_64"
-		override ARCH := $(subst x86_64,64,$(ARCH))
-		IS_X86 := 1
-	endif
-	ifeq "$(ARCH)" "x64"
-		override ARCH := $(subst x64,64,$(ARCH))
-		IS_X86 := 1
-	endif
-	ifeq "$(ARCH)" "x86"
-		override ARCH := $(subst x86,32,$(ARCH))
-		IS_X86 := 1
-	endif
-	ifeq "$(ARCH)" "i386"
-		override ARCH := $(subst i386,32,$(ARCH))
-		IS_X86 := 1
-	endif
-	ifeq "$(ARCH)" "i686"
-		override ARCH := $(subst i686,32,$(ARCH))
-		IS_X86 := 1
-	endif
-	ifeq "$(ARCH)" "powerpc"
-		override ARCH := $(subst powerpc,32,$(ARCH))
-	endif
-	ifeq "$(ARCH)" "powerpc64"
-		override ARCH := $(subst powerpc64,64,$(ARCH))
-	endif
-	ifeq "$(ARCH)" "powerpc64le"
-		override ARCH := $(subst powerpc64le,64,$(ARCH))
-	endif
-	ifeq "$(ARCH)" "aarch64"
-		override ARCH :=
-		override ARCHFLAG :=
-	endif
-	ifeq "$(findstring arm,$(ARCH))" "arm"
-		override ARCH :=
-		override ARCHFLAG :=
-	endif
-	ifeq "$(ARCH)" "s390x"
-		override ARCH :=
-		override ARCHFLAG :=
-	endif
-	ifeq "$(ARCH)" "riscv"
-		override ARCH :=
-		override ARCHFLAG :=
-	endif
-	ifeq "$(findstring mips,$(ARCH))" "mips"
-		override ARCHFLAG := -
-	endif
-	ifeq "$(findstring loongarch,$(ARCH))" "loongarch"
-		override ARCH :=
-		override ARCHFLAG :=
-	endif
-
 	ifeq "$(SPLIT_DEBUG_SYMBOLS)" "YES"
 		DSYM = $(EXE).debug
 	endif
@@ -296,9 +240,7 @@ CFLAGS ?= $(DEBUG_INFO_FLAG) -O0
 CFLAGS += $(SYSROOT_FLAGS)
 
 ifeq "$(OS)" "Darwin"
-	CFLAGS += $(ARCHFLAG) $(ARCH) $(FRAMEWORK_INCLUDES)
-else
-	CFLAGS += $(ARCHFLAG)$(ARCH)
+	CFLAGS += $(FRAMEWORK_INCLUDES)
 endif
 
 CFLAGS += -I$(LLDB_BASE_DIR)/include -I$(LLDB_OBJ_ROOT)/include
@@ -311,11 +253,7 @@ endif
 CFLAGS += $(NO_LIMIT_DEBUG_INFO_FLAGS) $(ARCH_CFLAGS)
 
 # Use this one if you want to build one part of the result without debug information:
-ifeq "$(OS)" "Darwin"
-	CFLAGS_NO_DEBUG = -O0 $(ARCHFLAG) $(ARCH) $(FRAMEWORK_INCLUDES) $(ARCH_CFLAGS) $(CFLAGS_EXTRAS) $(SYSROOT_FLAGS)
-else
-	CFLAGS_NO_DEBUG = -O0 $(ARCHFLAG)$(ARCH) $(FRAMEWORK_INCLUDES) $(ARCH_CFLAGS) $(CFLAGS_EXTRAS) $(SYSROOT_FLAGS)
-endif
+CFLAGS_NO_DEBUG = -O0 $(FRAMEWORK_INCLUDES) $(ARCH_CFLAGS) $(CFLAGS_EXTRAS) $(SYSROOT_FLAGS)
 
 ifeq "$(MAKE_DWO)" "YES"
 	CFLAGS += -gsplit-dwarf

--- a/lldb/test/API/commands/expression/ptrauth-auth-traps/Makefile
+++ b/lldb/test/API/commands/expression/ptrauth-auth-traps/Makefile
@@ -1,5 +1,5 @@
 C_SOURCES := main.c
 
-override ARCH := arm64e
+override TRIPLE := arm64e-apple-darwin
 
 include Makefile.rules

--- a/lldb/test/API/commands/expression/ptrauth-auth-traps/Makefile
+++ b/lldb/test/API/commands/expression/ptrauth-auth-traps/Makefile
@@ -1,5 +1,3 @@
 C_SOURCES := main.c
 
-override TRIPLE := arm64e-apple-darwin
-
 include Makefile.rules

--- a/lldb/test/API/commands/expression/ptrauth-auth-traps/TestPtrAuthAuthTraps.py
+++ b/lldb/test/API/commands/expression/ptrauth-auth-traps/TestPtrAuthAuthTraps.py
@@ -8,14 +8,21 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
+from lldbsuite.test import configuration
 
 
 class TestPtrAuthAuthTraps(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
+
+    def build_arm64e(self):
+        self.build(
+            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
+        )
 
     @skipUnlessArm64eSupported
     def test_static_function_pointer(self):
-        self.build()
+        self.build_arm64e()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
         )
@@ -32,7 +39,7 @@ class TestPtrAuthAuthTraps(TestBase):
 
     @skipUnlessArm64eSupported
     def test_indirect_call_through_caller(self):
-        self.build()
+        self.build_arm64e()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
         )

--- a/lldb/test/API/commands/expression/ptrauth-objc/Makefile
+++ b/lldb/test/API/commands/expression/ptrauth-objc/Makefile
@@ -1,6 +1,6 @@
 OBJC_SOURCES := main.m
 
-override ARCH := arm64e
+override TRIPLE := arm64e-apple-darwin
 
 # We need an arm64e stdlib.
 USE_SYSTEM_STDLIB := 1

--- a/lldb/test/API/commands/expression/ptrauth-objc/Makefile
+++ b/lldb/test/API/commands/expression/ptrauth-objc/Makefile
@@ -1,7 +1,5 @@
 OBJC_SOURCES := main.m
 
-override TRIPLE := arm64e-apple-darwin
-
 # We need an arm64e stdlib.
 USE_SYSTEM_STDLIB := 1
 

--- a/lldb/test/API/commands/expression/ptrauth-objc/TestPtrAuthObjectiveC.py
+++ b/lldb/test/API/commands/expression/ptrauth-objc/TestPtrAuthObjectiveC.py
@@ -2,14 +2,21 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
+from lldbsuite.test import configuration
 
 
 class TestPtrAuthObjectiveC(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
+
+    def build_arm64e(self):
+        self.build(
+            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
+        )
 
     @skipUnlessArm64eSupported
     def test_objc_message_send(self):
-        self.build()
+        self.build_arm64e()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)
@@ -23,7 +30,7 @@ class TestPtrAuthObjectiveC(TestBase):
 
     @skipUnlessArm64eSupported
     def test_objc_message_send_with_arg(self):
-        self.build()
+        self.build_arm64e()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)
@@ -37,7 +44,7 @@ class TestPtrAuthObjectiveC(TestBase):
 
     @skipUnlessArm64eSupported
     def test_objc_alloc_and_message(self):
-        self.build()
+        self.build_arm64e()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)
@@ -52,7 +59,7 @@ class TestPtrAuthObjectiveC(TestBase):
 
     @skipUnlessArm64eSupported
     def test_objc_derived_class(self):
-        self.build()
+        self.build_arm64e()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)
@@ -72,7 +79,7 @@ class TestPtrAuthObjectiveC(TestBase):
 
     @skipUnlessArm64eSupported
     def test_objc_isa_check(self):
-        self.build()
+        self.build_arm64e()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)

--- a/lldb/test/API/commands/expression/ptrauth-vtable/Makefile
+++ b/lldb/test/API/commands/expression/ptrauth-vtable/Makefile
@@ -1,6 +1,6 @@
 CXX_SOURCES := main.cpp
 
-override ARCH := arm64e
+override TRIPLE := arm64e-apple-darwin
 
 # We need an arm64e stblib.
 USE_SYSTEM_STDLIB := 1

--- a/lldb/test/API/commands/expression/ptrauth-vtable/Makefile
+++ b/lldb/test/API/commands/expression/ptrauth-vtable/Makefile
@@ -1,7 +1,5 @@
 CXX_SOURCES := main.cpp
 
-override TRIPLE := arm64e-apple-darwin
-
 # We need an arm64e stblib.
 USE_SYSTEM_STDLIB := 1
 

--- a/lldb/test/API/commands/expression/ptrauth-vtable/TestPtrAuthVTableExpressions.py
+++ b/lldb/test/API/commands/expression/ptrauth-vtable/TestPtrAuthVTableExpressions.py
@@ -12,10 +12,16 @@ from lldbsuite.test import lldbutil
 
 class TestPtrAuthVTableExpressions(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
+
+    def build_arm64e(self):
+        self.build(
+            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
+        )
 
     @skipUnlessArm64eSupported
     def test_virtual_call_on_debuggee_object(self):
-        self.build()
+        self.build_arm64e()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.cpp", False)
         )
@@ -25,7 +31,7 @@ class TestPtrAuthVTableExpressions(TestBase):
 
     @skipUnlessArm64eSupported
     def test_virtual_call_through_base_pointer(self):
-        self.build()
+        self.build_arm64e()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.cpp", False)
         )
@@ -34,7 +40,7 @@ class TestPtrAuthVTableExpressions(TestBase):
 
     @skipUnlessArm64eSupported
     def test_virtual_call_via_helper(self):
-        self.build()
+        self.build_arm64e()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.cpp", False)
         )

--- a/lldb/test/API/commands/expression/ptrauth/Makefile
+++ b/lldb/test/API/commands/expression/ptrauth/Makefile
@@ -1,5 +1,5 @@
 C_SOURCES := main.c
 
-override ARCH := arm64e
+override TRIPLE := arm64e-apple-darwin
 
 include Makefile.rules

--- a/lldb/test/API/commands/expression/ptrauth/Makefile
+++ b/lldb/test/API/commands/expression/ptrauth/Makefile
@@ -1,5 +1,3 @@
 C_SOURCES := main.c
 
-override TRIPLE := arm64e-apple-darwin
-
 include Makefile.rules

--- a/lldb/test/API/commands/expression/ptrauth/TestPtrAuthExpressions.py
+++ b/lldb/test/API/commands/expression/ptrauth/TestPtrAuthExpressions.py
@@ -2,10 +2,17 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
+from lldbsuite.test import configuration
 
 
 class TestPtrAuthExpressions(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
+
+    def build_arm64e(self):
+        self.build(
+            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
+        )
 
     @skipUnlessArm64eSupported
     def test_static_function_pointer(self):
@@ -13,7 +20,7 @@ class TestPtrAuthExpressions(TestBase):
         Test that we can call a function through a static function pointer
         from the expression evaluator, which requires "fixing up" the pointer
         signing via the InjectPointerSigningFixups pass."""
-        self.build()
+        self.build_arm64e()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
@@ -37,7 +44,7 @@ class TestPtrAuthExpressions(TestBase):
         correctly signed. The caller() function in the debuggee forces a
         genuine indirect call, preventing the compiler from folding the
         function pointer call into a direct call."""
-        self.build()
+        self.build_arm64e()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
@@ -62,7 +69,7 @@ class TestPtrAuthExpressions(TestBase):
         is signed with the IB key (__ptrauth(1, 0, 0)), which is
         process-specific; this verifies that auth succeeds because expressions
         execute in the debuggee's process, not the debugger's."""
-        self.build()
+        self.build_arm64e()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
@@ -79,7 +86,7 @@ class TestPtrAuthExpressions(TestBase):
         """Test that computed gotos (GCC labels-as-values) work in the
         expression evaluator on arm64e, where -fptrauth-indirect-gotos signs
         label addresses and the indirect branch authenticates them."""
-        self.build()
+        self.build_arm64e()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)

--- a/lldb/test/API/lang/c/ptrauth/Makefile
+++ b/lldb/test/API/lang/c/ptrauth/Makefile
@@ -1,5 +1,5 @@
 LEVEL = ../../../make
-override ARCH := arm64e
+override TRIPLE := arm64e-apple-darwin
 CFLAGS_EXTRAS = -fptrauth-calls -fptrauth-intrinsics
 C_SOURCES := main.c
 

--- a/lldb/test/API/lang/c/ptrauth/Makefile
+++ b/lldb/test/API/lang/c/ptrauth/Makefile
@@ -1,5 +1,4 @@
 LEVEL = ../../../make
-override TRIPLE := arm64e-apple-darwin
 CFLAGS_EXTRAS = -fptrauth-calls -fptrauth-intrinsics
 C_SOURCES := main.c
 

--- a/lldb/test/API/lang/c/ptrauth/TestPtrAuth.py
+++ b/lldb/test/API/lang/c/ptrauth/TestPtrAuth.py
@@ -4,12 +4,21 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
+from lldbsuite.test import configuration
 
 
 class TestPtrAuth(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
+
+    def build_arm64e(self):
+        self.build(
+            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
+        )
+
     @skipUnlessArm64eSupported
     def test(self):
-        self.build()
+        self.build_arm64e()
         _, process, _, _ = lldbutil.run_to_source_breakpoint(
             self, "// break in main", lldb.SBFileSpec("main.c")
         )


### PR DESCRIPTION
This PR removes as much uses of arch as possible, in favor of using triple directly. Most of the changes are in the builder, which no longer passes `ARCH` to Make, and of course in Makefile.rules. 

This significantly simplifies the remote Darwin test suite, as it previously had to try and piece together the triple from the platform and the arch. As an added benefit, we now go through the same code path for host and remote test runs.

I have tested this on Darwin and Linux and made the changes with the remote test suites in mind, but it's possible I missed something not caught by my local testing.