### PR TITLE
[clang] Add diagnostic for friend declaration of closure type member

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -408,6 +408,7 @@ Bug Fixes in This Version
 - Fixed incorrect rejection of ``auto`` with reordered declaration specifiers in C23. (#GH164121)
 - Fixed a crash where constexpr evaluation encountered invalid overrides. (#GH183290)
 - Fixed a crash when assigning to an element of an ``ext_vector_type`` with ``bool`` element type. (#GH189260)
+- Clang now emits an error for friend declarations of lambda members. (#GH26540)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8907,6 +8907,8 @@ let CategoryName = "Lambda Issue" in {
     "capture of variable '%0' as type %1 calls %select{private|protected}3 "
     "%select{default |copy |move |*ERROR* |*ERROR* |*ERROR* |}2constructor">,
     AccessControl;
+  def err_friend_lambda_decl : Error<
+    "a member of a lambda should not be the target of a friend declaration">;
   def note_lambda_to_block_conv : Note<
     "implicit capture of lambda object due to conversion to block pointer "
     "here">;

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -18465,6 +18465,11 @@ NamedDecl *Sema::ActOnFriendFunctionDecl(Scope *S, Declarator &D,
       Diag(Loc, diag::err_introducing_special_friend) << DiagArg;
       return nullptr;
     }
+  } else {
+    CXXRecordDecl *RC = dyn_cast<CXXRecordDecl>(DC);
+    if (RC->isLambda()) {
+      Diag(NameInfo.getBeginLoc(), diag::err_friend_lambda_decl);
+    }
   }
 
   // FIXME: This is an egregious hack to cope with cases where the scope stack

--- a/clang/test/CXX/drs/cwg17xx.cpp
+++ b/clang/test/CXX/drs/cwg17xx.cpp
@@ -222,3 +222,19 @@ template <template <typename> class Template, typename Argument>
 using Bind = Instantiate<Internal<Template>::template Bind, Argument>;
 #endif
 } // namespace cwg1794
+
+namespace cwg1780 { // cwg1780: 22
+#if __cplusplus >= 201103L
+
+auto l = []() -> int { return 5; };
+using L = decltype(l);
+class A {
+#if __cplusplus >= 201703L
+    friend constexpr auto L::operator()() const -> int; // expected-error{{a member of a lambda should not be the target of a friend declaration}}
+#else
+    friend auto L::operator()() const -> int; // expected-error{{a member of a lambda should not be the target of a friend declaration}}
+#endif
+};
+
+#endif
+} // namespace cwg1780

--- a/clang/test/CXX/drs/cwg17xx.cpp
+++ b/clang/test/CXX/drs/cwg17xx.cpp
@@ -236,5 +236,19 @@ class A {
 #endif
 };
 
+#if __cplusplus >= 201402L
+auto gl = [](auto a) { return 5; };
+using GL = decltype(gl);
+
+template <>
+auto GL::operator()(int a) const { // expected-error{{lambda call operator should not be explicitly specialized or instantiated}}
+    return 6;
+}
+
+auto gll = [](auto a) { return 5; }; // expected-error{{lambda call operator should not be explicitly specialized or instantiated}}
+using GLL = decltype(gll);
+template auto GLL::operator()<int>(int a) const; // expected-note{{in instantiation of function template specialization 'cwg1780::(lambda)::operator()<int>' requested here}}
+#endif
+
 #endif
 } // namespace cwg1780

--- a/clang/test/CXX/drs/cwg17xx.cpp
+++ b/clang/test/CXX/drs/cwg17xx.cpp
@@ -223,7 +223,7 @@ using Bind = Instantiate<Internal<Template>::template Bind, Argument>;
 #endif
 } // namespace cwg1794
 
-namespace cwg1780 { // cwg1780: 22
+namespace cwg1780 { // cwg1780: 23
 #if __cplusplus >= 201103L
 
 auto l = []() -> int { return 5; };

--- a/clang/test/SemaCXX/cxx1z-constexpr-lambdas.cpp
+++ b/clang/test/SemaCXX/cxx1z-constexpr-lambdas.cpp
@@ -57,8 +57,8 @@ struct test_never_constant {
   // expected-error@+3 {{non-constexpr declaration of 'operator()' follows constexpr declaration}}
   // expected-error@+3 {{non-constexpr declaration of 'operator()' follows constexpr declaration}}
   #endif
-  friend auto decltype(never_constant_1)::operator()() const;
-  friend int decltype(never_constant_2)::operator()() const;
+  friend auto decltype(never_constant_1)::operator()() const; // expected-error {{a member of a lambda should not be the target of a friend declaration}}
+  friend int decltype(never_constant_2)::operator()() const; // expected-error {{a member of a lambda should not be the target of a friend declaration}}
 };
 
 } // end ns test_constexpr_checking

--- a/clang/test/SemaCXX/lambda-expressions.cpp
+++ b/clang/test/SemaCXX/lambda-expressions.cpp
@@ -657,26 +657,29 @@ namespace ConversionOperatorDoesNotHaveDeducedReturnType {
 
   struct X {
 #if __cplusplus > 201402L
-    friend constexpr auto T::operator()(int) const;
-    friend constexpr T::operator ExpectedTypeT() const noexcept;
+    friend constexpr auto T::operator()(int) const; // expected-error {{a member of a lambda should not be the target of a friend declaration}}
+    friend constexpr T::operator ExpectedTypeT() const noexcept; // expected-error {{a member of a lambda should not be the target of a friend declaration}}
 
     template<typename T>
-      friend constexpr void U::operator()(T&) const;
+      friend constexpr void U::operator()(T&) const; // expected-error {{a member of a lambda should not be the target of a friend declaration}}
     // FIXME: This should not match; the return type is specified as behaving
     // "as if it were a decltype-specifier denoting the return type of
     // [operator()]", which is not equivalent to this alias template.
     template<typename T>
-      friend constexpr U::operator ExpectedTypeU<T>() const noexcept;
+      friend constexpr U::operator ExpectedTypeU<T>() const noexcept; // expected-error {{a member of a lambda should not be the target of a friend declaration}}
 #else
     friend auto T::operator()(int) const; // cxx11-error {{'auto' return without trailing return type; deduced return types are a C++14 extension}} \
-                                             cxx03-error {{'auto' not allowed in function return type}}
-    friend T::operator ExpectedTypeT() const;
+                                             cxx03-error {{'auto' not allowed in function return type}} \
+                                             expected-error {{a member of a lambda should not be the target of a friend declaration}}
+    friend T::operator ExpectedTypeT() const; // expected-error {{a member of a lambda should not be the target of a friend declaration}}
 
     template<typename T>
-      friend void U::operator()(T&) const; // cxx03-cxx11-error {{friend declaration of 'operator()' does not match any declaration}}
+      friend void U::operator()(T&) const; // cxx03-cxx11-error {{friend declaration of 'operator()' does not match any declaration}} \
+                                              expected-error {{a member of a lambda should not be the target of a friend declaration}}
     // FIXME: This should not match, as above.
     template<typename T>
-      friend U::operator ExpectedTypeU<T>() const; // cxx03-cxx11-error {{friend declaration of 'operator void (*)(type-parameter-0-0 &)' does not match any declaration}}
+      friend U::operator ExpectedTypeU<T>() const; // cxx03-cxx11-error {{friend declaration of 'operator void (*)(type-parameter-0-0 &)' does not match any declaration}} \
+                                                      expected-error {{a member of a lambda should not be the target of a friend declaration}}
 #endif
 
   private:
@@ -811,4 +814,43 @@ void test_lambda_return_type() {
     return y2;                   // expected-warning{{reference to stack memory associated with local variable 'y1' returned}}
   };
 }
+}
+
+namespace GH26540 {
+#if __cplusplus >= 201703L
+#define CONSTEXPR17 constexpr
+#define NOEXCEPT17 noexcept
+#else
+#define CONSTEXPR17
+#define NOEXCEPT17
+#endif
+    auto l = []() -> int {
+        return 5;
+    };
+    using L = decltype(l);
+    using ConvertL = int(*)();
+
+    class NonGenericLambdaFriend {
+        friend CONSTEXPR17 int L::operator()() const; // expected-error{{a member of a lambda should not be the target of a friend declaration}}
+        friend CONSTEXPR17 L::operator ConvertL() const NOEXCEPT17; // expected-error{{a member of a lambda should not be the target of a friend declaration}}
+    };
+
+#if __cplusplus > 201103L
+    auto gl = [](auto t) -> int {
+        return t.x;
+    };
+    using GL = decltype(gl);
+    template <typename T>
+    using ConvertGL = int(*)(T);
+
+    class GenericLambdaFriend {
+        int x{2};
+        template <typename T>
+        friend CONSTEXPR17 auto GL::operator()(T t) const -> int; // expected-error{{a member of a lambda should not be the target of a friend declaration}}
+        template <typename T>
+        friend CONSTEXPR17 GL::operator ConvertGL<T>() const NOEXCEPT17; // expected-error{{a member of a lambda should not be the target of a friend declaration}}
+    };
+#endif
+#undef NOEXCEPT17
+#undef CONSTEXPR17
 }

--- a/clang/test/SemaTemplate/GH75426.cpp
+++ b/clang/test/SemaTemplate/GH75426.cpp
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
-// expected-no-diagnostics
 
 template<typename T> concept C = true;
 
@@ -12,5 +11,5 @@ auto L = []<C T>{};
 template<typename X>
 class Friends {
     template<C T> friend void A::f();
-    template<C T> friend void decltype(L)::operator()();
+    template<C T> friend void decltype(L)::operator()(); // expected-error {{a member of a lambda should not be the target of a friend declaration}}
 };

--- a/clang/test/SemaTemplate/concepts.cpp
+++ b/clang/test/SemaTemplate/concepts.cpp
@@ -849,7 +849,7 @@ template<typename T, typename U> concept C = true;
 template<typename T> auto L = []<C<T> U>() {};
 
 struct Q {
-  template<C<int> U> friend constexpr auto decltype(L<int>)::operator()() const;
+  template<C<int> U> friend constexpr auto decltype(L<int>)::operator()() const; // expected-error {{a member of a lambda should not be the target of a friend declaration}}
 };
 
 template <class T>

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -12245,7 +12245,7 @@
     <td>[<a href="https://wg21.link/expr.prim.lambda.closure">expr.prim.lambda.closure</a>]</td>
     <td>CD4</td>
     <td>Explicit instantiation/specialization of generic lambda <TT>operator()</TT></td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="unreleased" align="center">Clang 22</td>
   </tr>
   <tr id="1781">
     <td><a href="https://cplusplus.github.io/CWG/issues/1781.html">1781</a></td>

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -12245,7 +12245,7 @@
     <td>[<a href="https://wg21.link/expr.prim.lambda.closure">expr.prim.lambda.closure</a>]</td>
     <td>CD4</td>
     <td>Explicit instantiation/specialization of generic lambda <TT>operator()</TT></td>
-    <td class="unreleased" align="center">Clang 22</td>
+    <td class="unreleased" align="center">Clang 23</td>
   </tr>
   <tr id="1781">
     <td><a href="https://cplusplus.github.io/CWG/issues/1781.html">1781</a></td>


### PR DESCRIPTION
Clang allows friend declarations of closure type members, which is disallowed per CWG 1780 (Issue #26540). 

Added a new diagnostic when the friend declaration targets a member of a `CXXRecordDecl` that is a lambda.