### PR TITLE
[libc] Add ftw and nftw headers, macros, and types

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -13,6 +13,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.features
     libc.include.fenv
     libc.include.float
+    libc.include.ftw
     libc.include.inttypes
     libc.include.limits
     libc.include.link

--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -5,6 +5,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.errno
     libc.include.fenv
     libc.include.float
+    libc.include.ftw
     libc.include.inttypes
     libc.include.malloc
     libc.include.math

--- a/libc/config/linux/i386/headers.txt
+++ b/libc/config/linux/i386/headers.txt
@@ -1,4 +1,5 @@
 set(TARGET_PUBLIC_HEADERS
   libc.include.assert
   libc.include.cpio
+  libc.include.ftw
 )

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -13,6 +13,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.features
     libc.include.fenv
     libc.include.float
+    libc.include.ftw
     libc.include.inttypes
     libc.include.limits
     libc.include.link

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -13,6 +13,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.features
     libc.include.fenv
     libc.include.float
+    libc.include.ftw
     libc.include.inttypes
     libc.include.limits
     libc.include.link

--- a/libc/hdr/ftw_macros.h
+++ b/libc/hdr/ftw_macros.h
@@ -1,0 +1,22 @@
+//===-- Definition of macros from ftw.h -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_FTW_MACROS_H
+#define LLVM_LIBC_HDR_FTW_MACROS_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-macros/ftw-macros.h"
+
+#else // Overlay mode
+
+#include <ftw.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_FTW_MACROS_H

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -130,6 +130,18 @@ add_header_macro(
 )
 
 add_header_macro(
+  ftw
+  ../libc/include/ftw.yaml
+  ftw.h
+  DEPENDS
+    .llvm_libc_common_h
+    .llvm-libc-macros.ftw_macros
+    .llvm-libc-types.struct_FTW
+    .llvm-libc-types.__ftw_func_t
+    .llvm-libc-types.__nftw_func_t
+)
+
+add_header_macro(
   limits
   ../libc/include/limits.yaml
   limits.h

--- a/libc/include/ftw.h.def
+++ b/libc/include/ftw.h.def
@@ -1,0 +1,18 @@
+//===-- C standard library header ftw.h -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_FTW_H
+#define LLVM_LIBC_FTW_H
+
+#include "__llvm-libc-common.h"
+
+#include "llvm-libc-macros/ftw-macros.h"
+
+%%public_api()
+
+#endif // LLVM_LIBC_FTW_H

--- a/libc/include/ftw.yaml
+++ b/libc/include/ftw.yaml
@@ -1,0 +1,28 @@
+header: ftw.h
+header_template: ftw.h.def
+macros: []
+types:
+  - type_name: struct_FTW
+  - type_name: __ftw_func_t
+  - type_name: __nftw_func_t
+enums: []
+objects: []
+functions:
+  - name: ftw
+    standards:
+      - posix
+    return_type: int
+    arguments:
+      - type: const char *
+      - type: __ftw_func_t
+      - type: int
+  - name: nftw
+    standards:
+      - posix
+      - gnu
+    return_type: int
+    arguments:
+      - type: const char *
+      - type: __nftw_func_t
+      - type: int
+      - type: int

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -106,6 +106,12 @@ add_macro_header(
 )
 
 add_macro_header(
+  ftw_macros
+  HDR
+    ftw-macros.h
+)
+
+add_macro_header(
   file_seek_macros
   HDR
     file-seek-macros.h

--- a/libc/include/llvm-libc-macros/ftw-macros.h
+++ b/libc/include/llvm-libc-macros/ftw-macros.h
@@ -1,0 +1,37 @@
+//===-- Definition of macros from ftw.h -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_FTW_MACROS_H
+#define LLVM_LIBC_MACROS_FTW_MACROS_H
+
+// Values for the typeflag argument to the callback function.
+#define FTW_F 0   // Non-directory file.
+#define FTW_D 1   // Directory.
+#define FTW_DNR 2 // Directory without read permission.
+#define FTW_NS 3  // Unknown type; stat() failed.
+#define FTW_SL 4  // Symbolic link.
+#define FTW_DP 5  // Directory with subdirectories visited.
+#define FTW_SLN 6 // Symbolic link naming non-existing file.
+
+// Flags for the flags argument to nftw().
+#define FTW_PHYS 1  // Physical walk, does not follow symbolic links.
+#define FTW_MOUNT 2 // The walk does not cross a mount point.
+#define FTW_CHDIR 4 // Change to each directory before processing.
+#define FTW_DEPTH 8 // All subdirectories visited before the directory.
+
+#ifdef _GNU_SOURCE
+#define FTW_ACTIONRETVAL 16 // Use FTW_* action return values (GNU extension).
+
+// Return values from callback functions (when FTW_ACTIONRETVAL is set).
+#define FTW_CONTINUE 0      // Continue with next sibling.
+#define FTW_STOP 1          // Return from ftw/nftw with FTW_STOP.
+#define FTW_SKIP_SUBTREE 2  // Don't walk through subtree (FTW_D only).
+#define FTW_SKIP_SIBLINGS 3 // Skip siblings, continue with parent.
+#endif                      // _GNU_SOURCE
+
+#endif // LLVM_LIBC_MACROS_FTW_MACROS_H

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -98,6 +98,7 @@ add_header(dl_info HDR Dl_info.h)
 add_header(struct_f_owner_ex HDR struct_f_owner_ex.h DEPENDS .pid_t)
 add_header(struct_flock HDR struct_flock.h DEPENDS .off_t .pid_t)
 add_header(struct_flock64 HDR struct_flock64.h DEPENDS .off64_t .pid_t)
+add_header(struct_FTW HDR struct_FTW.h)
 add_header(
   struct_ipc_perm
   HDR struct_ipc_perm.h
@@ -138,6 +139,8 @@ add_header(
     .dev_t .ino_t .mode_t .nlink_t .uid_t .gid_t .off_t .struct_timespec
     .blksize_t .blkcnt_t
 )
+add_header(__ftw_func_t HDR __ftw_func_t.h DEPENDS .struct_stat)
+add_header(__nftw_func_t HDR __nftw_func_t.h DEPENDS .struct_stat .struct_FTW)
 add_header(struct_tm HDR struct_tm.h)
 add_header(struct_utsname HDR struct_utsname.h)
 add_header(thrd_start_t HDR thrd_start_t.h)

--- a/libc/include/llvm-libc-types/__ftw_func_t.h
+++ b/libc/include/llvm-libc-types/__ftw_func_t.h
@@ -1,0 +1,16 @@
+//===-- Definition of type __ftw_func_t -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES___FTW_FUNC_T_H
+#define LLVM_LIBC_TYPES___FTW_FUNC_T_H
+
+struct stat;
+
+typedef int (*__ftw_func_t)(const char *, const struct stat *, int);
+
+#endif // LLVM_LIBC_TYPES___FTW_FUNC_T_H

--- a/libc/include/llvm-libc-types/__nftw_func_t.h
+++ b/libc/include/llvm-libc-types/__nftw_func_t.h
@@ -1,0 +1,18 @@
+//===-- Definition of type __nftw_func_t ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES___NFTW_FUNC_T_H
+#define LLVM_LIBC_TYPES___NFTW_FUNC_T_H
+
+struct stat;
+struct FTW;
+
+typedef int (*__nftw_func_t)(const char *, const struct stat *, int,
+                             struct FTW *);
+
+#endif // LLVM_LIBC_TYPES___NFTW_FUNC_T_H

--- a/libc/include/llvm-libc-types/struct_FTW.h
+++ b/libc/include/llvm-libc-types/struct_FTW.h
@@ -1,0 +1,17 @@
+//===-- Definition of struct FTW ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_STRUCT_FTW_H
+#define LLVM_LIBC_TYPES_STRUCT_FTW_H
+
+struct FTW {
+  int base;  // Offset of the filename in the pathname.
+  int level; // Depth of the file in the tree.
+};
+
+#endif // LLVM_LIBC_TYPES_STRUCT_FTW_H


### PR DESCRIPTION
Added headers, macros, and types for POSIX ftw and nftw support:
* libc/include/ftw.h.def
* libc/include/ftw.yaml
* libc/include/llvm-libc-macros/ftw-macros.h
* libc/include/llvm-libc-types/struct_FTW.h
* libc/include/llvm-libc-types/__ftw_func_t.h
* libc/include/llvm-libc-types/__nftw_func_t.h
* libc/hdr/ftw_macros.h

Updated corresponding CMakeLists.txt files to include the new targets.