### PR TITLE
[libc][test] Fix getcwd test for symlinked paths

### DIFF
--- a/libc/test/integration/src/unistd/CMakeLists.txt
+++ b/libc/test/integration/src/unistd/CMakeLists.txt
@@ -10,7 +10,7 @@ add_integration_test(
   DEPENDS
     libc.src.__support.CPP.string_view
     libc.src.errno.errno
-    libc.src.stdlib.getenv
+    libc.src.sys.stat.stat
     libc.src.unistd.getcwd
 )
 

--- a/libc/test/integration/src/unistd/getcwd_test.cpp
+++ b/libc/test/integration/src/unistd/getcwd_test.cpp
@@ -6,26 +6,33 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/CPP/string_view.h"
-#include "src/stdlib/getenv.h"
+#include "src/sys/stat/stat.h"
 #include "src/unistd/getcwd.h"
-
 #include "test/IntegrationTest/test.h"
 
 #include <errno.h>
 #include <stdlib.h> // For malloc and free
 
-using LIBC_NAMESPACE::cpp::string_view;
-
 TEST_MAIN([[maybe_unused]] int argc, [[maybe_unused]] char **argv,
           [[maybe_unused]] char **envp) {
   char buffer[1024];
-  ASSERT_TRUE(string_view(LIBC_NAMESPACE::getenv("PWD")) ==
-              LIBC_NAMESPACE::getcwd(buffer, 1024));
+  char *cwd = LIBC_NAMESPACE::getcwd(buffer, sizeof(buffer));
+  ASSERT_TRUE(cwd != nullptr);
+
+  struct stat st_dot;
+  struct stat st_cwd;
+
+  ASSERT_EQ(LIBC_NAMESPACE::stat(".", &st_dot), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::stat(cwd, &st_cwd), 0);
+
+  ASSERT_EQ(st_dot.st_dev, st_cwd.st_dev);
+  ASSERT_EQ(st_dot.st_ino, st_cwd.st_ino);
 
   // nullptr buffer
-  char *cwd = LIBC_NAMESPACE::getcwd(nullptr, 0);
-  ASSERT_TRUE(string_view(LIBC_NAMESPACE::getenv("PWD")) == cwd);
+  cwd = LIBC_NAMESPACE::getcwd(nullptr, 0);
+  ASSERT_EQ(LIBC_NAMESPACE::stat(cwd, &st_cwd), 0);
+  ASSERT_EQ(st_dot.st_dev, st_cwd.st_dev);
+  ASSERT_EQ(st_dot.st_ino, st_cwd.st_ino);
   free(cwd);
 
   // Bad size


### PR DESCRIPTION
The test compared getcwd() with getenv("PWD"), which is not reliable under symlinked paths: PWD may preserve the logical path while getcwd() returns the physical path.

Use stat(2) to verify directory identity instead.