### PR TITLE
[libc][docs] Add ftw.yaml for docgen and update index.rst

### DIFF
--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -16,6 +16,7 @@ Implementation Status
    fcntl
    fenv
    float
+   ftw
    glob
    inttypes
    locale

--- a/libc/utils/docgen/ftw.yaml
+++ b/libc/utils/docgen/ftw.yaml
@@ -1,0 +1,39 @@
+macros:
+  FTW_F:
+    in-latest-posix: ''
+  FTW_D:
+    in-latest-posix: ''
+  FTW_DNR:
+    in-latest-posix: ''
+  FTW_NS:
+    in-latest-posix: ''
+  FTW_SL:
+    in-latest-posix: ''
+  FTW_DP:
+    in-latest-posix: ''
+  FTW_SLN:
+    in-latest-posix: ''
+  FTW_PHYS:
+    in-latest-posix: ''
+  FTW_MOUNT:
+    in-latest-posix: ''
+  FTW_CHDIR:
+    in-latest-posix: ''
+  FTW_DEPTH:
+    in-latest-posix: ''
+  FTW_ACTIONRETVAL:
+    in-latest-posix: ''
+  FTW_CONTINUE:
+    c-definition: 'GNU extension'
+  FTW_STOP:
+    c-definition: 'GNU extension'
+  FTW_SKIP_SUBTREE:
+    c-definition: 'GNU extension'
+  FTW_SKIP_SIBLINGS:
+    c-definition: 'GNU extension'
+
+functions:
+  ftw:
+    in-latest-posix: ''
+  nftw:
+    in-latest-posix: ''


### PR DESCRIPTION
Added utils/docgen/ftw.yaml to track implementation status of ftw and nftw. Updated docs/headers/index.rst to include ftw in the list of headers.