### PR TITLE
Fix ml inliner tests after PR #190168

### DIFF
--- a/llvm/test/Transforms/Inline/ML/Inputs/test-module.ll
+++ b/llvm/test/Transforms/Inline/ML/Inputs/test-module.ll
@@ -63,6 +63,6 @@ define i32 @switcher(i32) minsize {
   ret i32 %13
 }
 
-; CHECK-NOT: @adder
-; DEFAULT-LABEL:        @adder
+; CHECK-NOT: @multiplier
+; DEFAULT-LABEL:        define internal i32 @adder
 ; DEFAULT-NEXT:         %2 = mul

--- a/llvm/test/Transforms/Inline/ML/ml-test-development-mode.ll
+++ b/llvm/test/Transforms/Inline/ML/ml-test-development-mode.ll
@@ -20,4 +20,4 @@ CHECK-LOG-NEXT: {{^sroa_savings:}} 0
 CHECK-LOG: {{^cost_estimate:}} -30
 CHECK-LOG: {{^inlining_decision:}} 1
 CHECK-LOG-NEXT: observation: 1
-CHECK-LOG: observation: 6
+CHECK-LOG: observation: 5


### PR DESCRIPTION
The default inliner policy changed slighlty, which was expected after PR #190168.