### PR TITLE
[clang-tidy] Overloaded Unresolved member function call can't be static

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
@@ -65,8 +65,11 @@ AST_MATCHER(CXXMethodDecl, usesThis) {
     }
 
     bool VisitUnresolvedMemberExpr(const UnresolvedMemberExpr *E) {
-      Used = true;
-      return false;
+      if (E->isImplicitAccess()) {
+        Used = true;
+        return false;
+      }
+      return true; // Continue traversal.
     }
 
     // If we enter a class declaration, don't traverse into it as any usages of

--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
@@ -64,6 +64,11 @@ AST_MATCHER(CXXMethodDecl, usesThis) {
       return false; // Stop traversal.
     }
 
+    bool VisitUnresolvedMemberExpr(const UnresolvedMemberExpr *E) {
+      Used = true;
+      return false;
+    }
+
     // If we enter a class declaration, don't traverse into it as any usages of
     // `this` will correspond to the nested class.
     bool TraverseCXXRecordDecl(CXXRecordDecl *RD) { return true; }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -476,14 +476,13 @@ Changes in existing checks
     ``empty`` function.
 
 - Improved :doc:`readability-convert-member-functions-to-static
-  <clang-tidy/checks/readability/convert-member-functions-to-static>` check by
-  avoiding false positive on ``const`` member functions to static when they are
-  a part of const/non-const overload pair.
+  <clang-tidy/checks/readability/convert-member-functions-to-static>` check:
 
-- Improved :doc:`readability-convert-member-functions-to-static
-  <clang-tidy/checks/readability/convert-member-functions-to-static>` check to
-  correctly detect ``this`` usage within a member function with a call to an
-  overloaded method inside a generic lambda.
+  - Fixing a false positive where ``const`` member functions were incorrectly
+    flagged when they are part of a const/non-const overload pair.
+
+  - Correctly detecting ``this`` usage when a generic lambda calls an overloaded
+    member function.
 
 - Improved :doc:`readability-else-after-return
   <clang-tidy/checks/readability/else-after-return>` check:

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -480,6 +480,11 @@ Changes in existing checks
   avoiding false positive on ``const`` member functions to static when they are
   a part of const/non-const overload pair.
 
+- Improved :doc:`readability-convert-member-functions-to-static
+  <clang-tidy/checks/readability/convert-member-functions-to-static>` check to
+  correctly detect ``this`` usage within a member function with a call to an
+  overloaded method inside a generic lambda.
+
 - Improved :doc:`readability-else-after-return
   <clang-tidy/checks/readability/else-after-return>` check:
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
@@ -26,8 +26,8 @@ class OverloadedUnresolvedWithAutoLambda {
 public:
   void CallsFunctionVar();
   void CallsOverloadedMethodWithArg(int a);
-  void OverloadedMethodWithoutArg();
-  void OverloadedMethodWithArg(int a) { };
+  void OverloadedMethod();
+  void OverloadedMethod(int a) { };
 };
 
 void OverloadedUnresolvedWithAutoLambda::CallsFunctionVar() {
@@ -39,7 +39,7 @@ void OverloadedUnresolvedWithAutoLambda::CallsFunctionVar() {
 
 void OverloadedUnresolvedWithAutoLambda::CallsOverloadedMethodWithArg(int a) {
   auto fun = [&](auto b) {
-    OverloadedMethodWithArg(b);
+    OverloadedMethod(b);
   };
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
@@ -21,25 +21,117 @@ struct Hello {
   void UnnamedExplicitObjectParam(this Hello &) {}
 };
 
-
-class OverloadedUnresolvedWithAutoLambda {
+class BaseOverloadedAutoLambdaTest {
 public:
-  void CallsFunctionVar();
-  void CallsOverloadedMethodWithArg(int a);
-  void OverloadedMethod();
-  void OverloadedMethod(int a) { };
+  void BaseOverloadedMethod();
+  void BaseOverloadedMethod(int a) { };
 };
 
-void OverloadedUnresolvedWithAutoLambda::CallsFunctionVar() {
-  // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: method 'CallsFunctionVar' can be made static [readability-convert-member-functions-to-static]
+
+class OverloadedAutoLambdaTest : public BaseOverloadedAutoLambdaTest {
+public:
+  void CallFunVar();
+  void LambdaUsesThis1(int a);
+  void LambdaUsesThis2(int a);
+  void LambdaUsesThis3(int a);
+  void LambdaUsesThis4();
+  void LambdaUsesThis5();
+
+  void LambdaNoThis1(int a);
+  void LambdaNoThis2(int a);
+  void LambdaNoThis3(int a);
+  void LambdaNoThis4(int a);
+  void LambdaNoThis5(int a);
+
+  void OverloadedMethod();
+  void OverloadedMethod(int a) { };
+
+  template <typename T>
+  void TemplatedOverloadedMethod(T);
+  void TemplatedOverloadedMethod(int);
+};
+
+void OverloadedAutoLambdaTest::CallFunVar() {
+  // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: method 'CallFunVar' can be made static [readability-convert-member-functions-to-static]
   auto fun = [&](auto a) {
     var(a);
   };
 }
 
-void OverloadedUnresolvedWithAutoLambda::CallsOverloadedMethodWithArg(int a) {
+void OverloadedAutoLambdaTest::LambdaUsesThis1(int a) {
   auto fun = [&](auto b) {
     OverloadedMethod(b);
+  };
+}
+
+void OverloadedAutoLambdaTest::LambdaUsesThis2(int a) {
+  auto fun = [&](auto b) {
+    this->OverloadedMethod(b);
+  };
+}
+
+void OverloadedAutoLambdaTest::LambdaNoThis1(int a) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: method 'LambdaNoThis1' can be made static [readability-convert-member-functions-to-static]
+  OverloadedAutoLambdaTest f;
+  auto fun = [&](auto b) {
+    f.OverloadedMethod(b);
+  };
+}
+
+void OverloadedAutoLambdaTest::LambdaUsesThis3(int a) {
+  OverloadedAutoLambdaTest g;
+  auto fun1 = [&](auto a) {
+    auto fun2 = [&](auto b) {
+      OverloadedMethod(b);
+    };
+    fun2(a);
+  };
+}
+
+void OverloadedAutoLambdaTest::LambdaNoThis2(int a) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: method 'LambdaNoThis2' can be made static [readability-convert-member-functions-to-static]
+  OverloadedAutoLambdaTest g;
+  auto fun1 = [&](auto a) {
+    auto fun2 = [&](auto b) {
+      g.OverloadedMethod(b);
+    };
+    fun2(a);
+  };
+}
+
+void OverloadedAutoLambdaTest::LambdaUsesThis4() {
+  auto fun = [&](auto a) {
+    OverloadedMethod(a);
+  };
+}
+
+void OverloadedAutoLambdaTest::LambdaNoThis3(int a) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: method 'LambdaNoThis3' can be made static [readability-convert-member-functions-to-static]
+  OverloadedAutoLambdaTest f;
+  auto fun = [&](auto b) {
+    f.OverloadedMethod(b);
+  };
+}
+
+void OverloadedAutoLambdaTest::LambdaNoThis4(int a) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: method 'LambdaNoThis4' can be made static [readability-convert-member-functions-to-static]
+  BaseOverloadedAutoLambdaTest f;
+  auto fun = [&](auto b) {
+    f.BaseOverloadedMethod(b);
+  };
+}
+
+void OverloadedAutoLambdaTest::LambdaNoThis5(int a) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: method 'LambdaNoThis5' can be made static [readability-convert-member-functions-to-static]
+  OverloadedAutoLambdaTest f;
+  auto fun = [&](auto b) {
+    f.BaseOverloadedMethod(b);
+  };
+}
+
+void OverloadedAutoLambdaTest::LambdaUsesThis5() {
+  auto fun = [&](auto b) {
+    TemplatedOverloadedMethod(b);
   };
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
@@ -20,3 +20,27 @@ struct Hello {
 
   void UnnamedExplicitObjectParam(this Hello &) {}
 };
+
+
+class OverloadedUnresolvedWithAutoLambda {
+public:
+  void CallsFunctionVar();
+  void CallsOverloadedMethodWithArg(int a);
+  void OverloadedMethodWithoutArg();
+  void OverloadedMethodWithArg(int a) { };
+};
+
+void OverloadedUnresolvedWithAutoLambda::CallsFunctionVar() {
+  // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: method 'CallsFunctionVar' can be made static [readability-convert-member-functions-to-static]
+  auto fun = [&](auto a) {
+    var(a);
+  };
+}
+
+void OverloadedUnresolvedWithAutoLambda::CallsOverloadedMethodWithArg(int a) {
+  auto fun = [&](auto b) {
+    OverloadedMethodWithArg(b);
+  };
+}
+
+void Var(int a) { }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static-deducing-this.cpp
@@ -31,6 +31,7 @@ public:
 class OverloadedAutoLambdaTest : public BaseOverloadedAutoLambdaTest {
 public:
   void CallFunVar();
+  // CHECK-FIXES: static void CallFunVar();
   void LambdaUsesThis1(int a);
   void LambdaUsesThis2(int a);
   void LambdaUsesThis3(int a);
@@ -38,10 +39,15 @@ public:
   void LambdaUsesThis5();
 
   void LambdaNoThis1(int a);
+  // CHECK-FIXES: static void LambdaNoThis1(int a);
   void LambdaNoThis2(int a);
+  // CHECK-FIXES: static void LambdaNoThis2(int a);
   void LambdaNoThis3(int a);
+  // CHECK-FIXES: static void LambdaNoThis3(int a);
   void LambdaNoThis4(int a);
+  // CHECK-FIXES: static void LambdaNoThis4(int a);
   void LambdaNoThis5(int a);
+  // CHECK-FIXES: static void LambdaNoThis5(int a);
 
   void OverloadedMethod();
   void OverloadedMethod(int a) { };


### PR DESCRIPTION
readability-convert-member-functions-to-static incorrectly suggests
making overloaded member function, with lambda function call, as
static (false-positive)

Mark usage of "this" as true, when a call to "UnresolveMemberExpr"
is obvserved

Fixes https://github.com/llvm/llvm-project/issues/171626