### PR TITLE
[clang-tidy] Fix some false positive in bugprone-move-forwarding-reference

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/MoveForwardingReferenceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/MoveForwardingReferenceCheck.cpp
@@ -19,7 +19,7 @@ AST_MATCHER(DeclRefExpr, refersToEnclosingVariableOrCapture) {
   return Node.refersToEnclosingVariableOrCapture();
 }
 
-}
+} // namespace
 
 static void replaceMoveWithForward(const UnresolvedLookupExpr *Callee,
                                    const ParmVarDecl *ParmVar,
@@ -88,15 +88,16 @@ void MoveForwardingReferenceCheck::registerMatchers(MatchFinder *Finder) {
           .bind("parm-var");
 
   Finder->addMatcher(
-      callExpr(callee(unresolvedLookupExpr(
-                          hasAnyDeclaration(namedDecl(
-                              hasUnderlyingDecl(hasName("::std::move")))))
-                          .bind("lookup")),
-               argumentCountIs(1),
-               hasArgument(0, ignoringParenImpCasts(declRefExpr(
-                                  to(ForwardingReferenceParmMatcher),
-                                  // FIXME: allow capture by reference
-                                  unless(refersToEnclosingVariableOrCapture())))))
+      callExpr(
+          callee(unresolvedLookupExpr(
+                     hasAnyDeclaration(
+                         namedDecl(hasUnderlyingDecl(hasName("::std::move")))))
+                     .bind("lookup")),
+          argumentCountIs(1),
+          hasArgument(0, ignoringParenImpCasts(declRefExpr(
+                             to(ForwardingReferenceParmMatcher),
+                             // FIXME: allow capture by reference
+                             unless(refersToEnclosingVariableOrCapture())))))
           .bind("call-move"),
       this);
 }

--- a/clang-tools-extra/clang-tidy/bugprone/MoveForwardingReferenceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/MoveForwardingReferenceCheck.cpp
@@ -96,7 +96,6 @@ void MoveForwardingReferenceCheck::registerMatchers(MatchFinder *Finder) {
           argumentCountIs(1),
           hasArgument(0, ignoringParenImpCasts(declRefExpr(
                              to(ForwardingReferenceParmMatcher),
-                             // FIXME: allow capture by reference
                              unless(refersToEnclosingVariableOrCapture())))))
           .bind("call-move"),
       this);

--- a/clang-tools-extra/clang-tidy/bugprone/MoveForwardingReferenceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/MoveForwardingReferenceCheck.cpp
@@ -13,6 +13,14 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy::bugprone {
 
+namespace {
+
+AST_MATCHER(DeclRefExpr, refersToEnclosingVariableOrCapture) {
+  return Node.refersToEnclosingVariableOrCapture();
+}
+
+}
+
 static void replaceMoveWithForward(const UnresolvedLookupExpr *Callee,
                                    const ParmVarDecl *ParmVar,
                                    const TemplateTypeParmDecl *TypeParmDecl,
@@ -86,7 +94,9 @@ void MoveForwardingReferenceCheck::registerMatchers(MatchFinder *Finder) {
                           .bind("lookup")),
                argumentCountIs(1),
                hasArgument(0, ignoringParenImpCasts(declRefExpr(
-                                  to(ForwardingReferenceParmMatcher)))))
+                                  to(ForwardingReferenceParmMatcher),
+                                  // FIXME: allow capture by reference
+                                  unless(refersToEnclosingVariableOrCapture())))))
           .bind("call-move"),
       this);
 }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -278,7 +278,7 @@ Changes in existing checks
 
 - Improved :doc:`bugprone-move-forwarding-reference
   <clang-tidy/checks/bugprone/move-forwarding-reference>` check by removing some
-  false positive in the context of moved lambda captures.
+  false positives in the context of moved lambda captures.
 
 - Improved :doc:`bugprone-pointer-arithmetic-on-polymorphic-object
   <clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object>` check

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -276,6 +276,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/narrowing-conversions>` check by fixing a false
   positive when converting a ``bool`` to a signed integer type.
 
+- Improved :doc:`bugprone-move-forwarding-reference
+  <clang-tidy/checks/bugprone/move-forwarding-reference>` check by removing some
+  false positive in the context of moved lambda captures.
+
 - Improved :doc:`bugprone-pointer-arithmetic-on-polymorphic-object
   <clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object>` check
   by fixing a false positive when ``operator[]`` is used in a dependent context.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -272,13 +272,13 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/macro-parentheses>` check by printing the macro
   definition in the warning message if the macro is defined on command line.
 
-- Improved :doc:`bugprone-narrowing-conversions
-  <clang-tidy/checks/bugprone/narrowing-conversions>` check by fixing a false
-  positive when converting a ``bool`` to a signed integer type.
-
 - Improved :doc:`bugprone-move-forwarding-reference
   <clang-tidy/checks/bugprone/move-forwarding-reference>` check by removing some
   false positives in the context of moved lambda captures.
+
+- Improved :doc:`bugprone-narrowing-conversions
+  <clang-tidy/checks/bugprone/narrowing-conversions>` check by fixing a false
+  positive when converting a ``bool`` to a signed integer type.
 
 - Improved :doc:`bugprone-pointer-arithmetic-on-polymorphic-object
   <clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object>` check

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -273,7 +273,7 @@ Changes in existing checks
   definition in the warning message if the macro is defined on command line.
 
 - Improved :doc:`bugprone-move-forwarding-reference
-  <clang-tidy/checks/bugprone/move-forwarding-reference>` check by removing some
+  <clang-tidy/checks/bugprone/move-forwarding-reference>` check by fixing some
   false positives in the context of moved lambda captures.
 
 - Improved :doc:`bugprone-narrowing-conversions

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/move-forwarding-reference.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/move-forwarding-reference.cpp
@@ -123,3 +123,13 @@ template <typename T, typename U> void f13(U&& SomeU) {
 template <typename T, typename U> void f14(U&& SomeU) {
   [=] () { T SomeT(std::move(SomeU)); };
 }
+
+// Ignore the case of captured variables by reference. Explicit capture version.
+template <typename T, typename U> void f15(U&& SomeU) {
+  [&SomeU] () { T SomeT(std::move(SomeU)); };
+}
+
+// Ignore the case of captured variables by reference. Implicit capture version.
+template <typename T, typename U> void f16(U&& SomeU) {
+  [&] () { T SomeT(std::move(SomeU)); };
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/move-forwarding-reference.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/move-forwarding-reference.cpp
@@ -124,12 +124,12 @@ template <typename T, typename U> void f14(U&& SomeU) {
   [=] () { T SomeT(std::move(SomeU)); };
 }
 
-// Ignore the case of captured variables by reference. Explicit capture version.
+// FIXME: Do not ignore the case of captured variables by reference. Explicit capture version.
 template <typename T, typename U> void f15(U&& SomeU) {
   [&SomeU] () { T SomeT(std::move(SomeU)); };
 }
 
-// Ignore the case of captured variables by reference. Implicit capture version.
+// FIXME: Do not ignore the case of captured variables by reference. Implicit capture version.
 template <typename T, typename U> void f16(U&& SomeU) {
   [&] () { T SomeT(std::move(SomeU)); };
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/move-forwarding-reference.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/move-forwarding-reference.cpp
@@ -123,13 +123,3 @@ template <typename T, typename U> void f13(U&& SomeU) {
 template <typename T, typename U> void f14(U&& SomeU) {
   [=] () { T SomeT(std::move(SomeU)); };
 }
-
-#if 0
-// FIXME: we currently ignore that case.
-//
-// Handle the case of captured variables where no copy already
-// happened.
-template <typename T, typename U> void f15(U&& SomeU) {
-  [&SomeU] () { T SomeT(std::move(SomeU)); };
-}
-#endif

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/move-forwarding-reference.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/move-forwarding-reference.cpp
@@ -111,3 +111,25 @@ template <typename T> void f12() {
   // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: forwarding reference passed to
   // CHECK-FIXES: [] (auto&& x) { T SomeT(std::forward<decltype(x)>(x)); };
 }
+
+// Ignore the case of captured variables where an implicit copy already
+// happened. Explicit capture version.
+template <typename T, typename U> void f13(U&& SomeU) {
+  [SomeU] () { T SomeT(std::move(SomeU)); };
+}
+
+// Ignore the case of captured variables where an implicit copy already
+// happened. Implicit capture version.
+template <typename T, typename U> void f14(U&& SomeU) {
+  [=] () { T SomeT(std::move(SomeU)); };
+}
+
+#if 0
+// FIXME: we currently ignore that case.
+//
+// Handle the case of captured variables where no copy already
+// happened.
+template <typename T, typename U> void f15(U&& SomeU) {
+  [&SomeU] () { T SomeT(std::move(SomeU)); };
+}
+#endif


### PR DESCRIPTION
In the following case:

template <typename T, typename U>
void shocase(U&& SomeU) {
  [SomeU] () { T SomeT(std::move(SomeU)); };
}

We use to flag the move as a forward, while the lambda captures SomeU by copy, which makes the move valid.