### PR TITLE
[compiler-rt] Hide dlvsym call behind appropriate guards 

### DIFF
--- a/compiler-rt/lib/interception/interception_linux.cpp
+++ b/compiler-rt/lib/interception/interception_linux.cpp
@@ -54,11 +54,13 @@ void* LookupSymbolNext(const char* symbol) {
   return dlsym(RTLD_NEXT, symbol);
 }
 
+#if SANITIZER_GLIBC || SANITIZER_FREEBSD || SANITIZER_NETBSD
 void* LookupSymbolNextVersioned(const char* symbol, const char* version) {
   if (!DynamicLoaderAvailable() || dlvsym == nullptr)
     return nullptr;
   return dlvsym(RTLD_NEXT, symbol, version);
 }
+#endif  // SANITIZER_GLIBC || SANITIZER_FREEBSD || SANITIZER_NETBSD
 
 }  // namespace __interception
 

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -5935,6 +5935,7 @@ cc_binary(
     deps = [
         ":AllTargetsCodeGens",
         ":AllTargetsDisassemblers",
+        ":BinaryFormat",
         ":Core",
         ":DebugInfoDWARF",
         ":DebugInfoPDB",


### PR DESCRIPTION
#191098 Add some unguarded dlvsym calls. This causes build issues when targeting certain platforms such as iOS.

This change should restore the original behavior.