### PR TITLE
[compiler-rt] Address dlvsym not found compilation error when targeting certain platforms

### DIFF
--- a/compiler-rt/lib/interception/interception_linux.cpp
+++ b/compiler-rt/lib/interception/interception_linux.cpp
@@ -54,11 +54,13 @@ void* LookupSymbolNext(const char* symbol) {
   return dlsym(RTLD_NEXT, symbol);
 }
 
+#if SANITIZER_GLIBC || SANITIZER_FREEBSD || SANITIZER_NETBSD
 void* LookupSymbolNextVersioned(const char* symbol, const char* version) {
   if (!DynamicLoaderAvailable() || dlvsym == nullptr)
     return nullptr;
   return dlvsym(RTLD_NEXT, symbol, version);
 }
+#endif  // SANITIZER_GLIBC || SANITIZER_FREEBSD || SANITIZER_NETBSD
 
 }  // namespace __interception
 


### PR DESCRIPTION
#191098 Add some unguarded dlvsym calls. This causes build issues when targeting certain platforms such as iOS.

This change should restore the original behavior.