### PR TITLE
[WebAssembly] Remove MULO_I128 libcall to avoid __muloti4 infinite recursion

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -3552,7 +3552,7 @@ def isOSEmscripten : RuntimeLibcallPredicate<[{TT.isOSEmscripten()}]>;
 def WasmSystemLibrary
     : SystemRuntimeLibrary<isWasm,
       (add DefaultRuntimeLibcallImpls, Int128RTLibcalls,
-           CompilerRTOnlyInt64Libcalls, CompilerRTOnlyInt128Libcalls,
+           CompilerRTOnlyInt64Libcalls,
            exp10f, exp10,
            _Unwind_CallPersonality,
            emscripten_return_address,

--- a/llvm/lib/Target/WebAssembly/WebAssemblyRuntimeLibcallSignatures.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyRuntimeLibcallSignatures.cpp
@@ -116,7 +116,6 @@ struct RuntimeLibcallSignatureTable {
     Table[RTLIB::MUL_I128] = i64_i64_func_i64_i64_i64_i64;
     Table[RTLIB::MULO_I32] = i32_func_i32_i32_iPTR;
     Table[RTLIB::MULO_I64] = i64_func_i64_i64_iPTR;
-    Table[RTLIB::MULO_I128] = i64_i64_func_i64_i64_i64_i64_iPTR;
     Table[RTLIB::SDIV_I8] = i8_func_i8_i8;
     Table[RTLIB::SDIV_I16] = i16_func_i16_i16;
     Table[RTLIB::SDIV_I32] = i32_func_i32_i32;

--- a/llvm/test/CodeGen/WebAssembly/muloti4.ll
+++ b/llvm/test/CodeGen/WebAssembly/muloti4.ll
@@ -1,6 +1,10 @@
 ; RUN: llc -asm-verbose=false < %s -wasm-keep-registers | FileCheck %s
 
-; Test that 128-bit smul.with.overflow assembles as expected.
+; Test that 128-bit smul.with.overflow is expanded inline rather than emitting
+; a call to __muloti4. The MULO_I128 libcall was removed from WebAssembly to
+; avoid infinite recursion when compiling custom implementations of __muloti4
+; (e.g. Zig's compiler-rt).
+; See https://github.com/llvm/llvm-project/issues/189173
 
 target triple = "wasm32-unknown-unknown"
 
@@ -13,6 +17,6 @@ entry:
   ret i128 %X
 }
 
-; CHECK: call __muloti4, $pop{{[0-9]*}}, $pop{{[0-9]*}}, $pop{{[0-9]*}}, $pop{{[0-9]*}}, $pop{{[0-9]*}}, $pop{{[0-9]*}}{{$}}
+; CHECK-NOT: call __muloti4
 
 declare { i128, i1 } @llvm.smul.with.overflow.i128(i128, i128) nounwind readnone


### PR DESCRIPTION
## Summary

Remove the `__muloti4` (`MULO_I128`) libcall from WebAssembly's system runtime library. This causes 128-bit `smul.with.overflow` to always be expanded inline rather than emitting a call to `__muloti4`.

### How this differs from #191020

Both PRs fix the same bug, but take fundamentally different approaches:

**PR #191020** (original) added a runtime check in codegen:
```cpp
// In LegalizeIntegerTypes.cpp ExpandIntRes_XMULO:
+ DAG.getMachineFunction().getFunction().hasFnAttribute("no-builtins")
```
When codegen is about to emit `call __muloti4`, it checks if the function has `no-builtins` and expands inline instead. [@arsenm objected](https://github.com/llvm/llvm-project/pull/191020#issuecomment-4209482620) because `no-builtins` belongs to `TargetLibraryInfo` (middle-end), not `RuntimeLibcallInfo` (codegen) — it's the wrong abstraction layer.

**This PR** removes the libcall registration entirely:
```
- CompilerRTOnlyInt128Libcalls  // removed from WasmSystemLibrary
```
WebAssembly never registers `__muloti4` as available, so codegen always uses inline expansion for i128 SMULO. No attribute checks needed. The existing `if (LCImpl == RTLIB::Unsupported)` guard handles it automatically.

In short: the old PR added a special-case check at call time; this PR removes the libcall so there's nothing to call. This approach is cleaner, addresses arsenm's architectural concern, and aligns with [@topperc's suggestion](https://github.com/llvm/llvm-project/pull/191020#issuecomment-4208403177) to kill the libcall.

## Problem

When compiling a custom implementation of `__muloti4` (e.g. Zig's compiler-rt) that has a different name in the IR (exposed via alias) and is compiled with `no-builtins`, the generated code recurses infinitely at **runtime** (stack overflow):

1. **instcombine** recognizes the multiply-with-overflow pattern inside `custom_muloti4` and replaces it with `@llvm.smul.with.overflow.i128`
2. **codegen** (SelectionDAG) can't lower that intrinsic natively on WebAssembly, so it emits `call __muloti4`
3. The existing same-name guard doesn't trigger because the function is named `custom_muloti4`, not `__muloti4`
4. The compiler finishes successfully, but at **runtime**: `__muloti4` (alias) → `custom_muloti4` → `call __muloti4` → `custom_muloti4` → … → stack overflow

## Why not check `no-builtins` in codegen?

The [previous approach](https://github.com/llvm/llvm-project/pull/191020) checked the `no-builtins` function attribute in codegen's SMULO expansion. As [@arsenm pointed out](https://github.com/llvm/llvm-project/pull/191020#issuecomment-4209482620), this is architecturally wrong:

- `no-builtins` was designed for `TargetLibraryInfo` (middle-end optimizations)
- `RuntimeLibcallInfo` (codegen) is an entirely separate library call system
- Applying `no-builtins` to codegen conflates two independent systems

## This approach

Instead, **remove the libcall entirely** from WebAssembly. As [@topperc noted](https://github.com/llvm/llvm-project/pull/191020#issuecomment-4208403177), WebAssembly appears to be the only target still using `__muloti4`. The inline expansion (wide multiply + overflow check via sign-extension comparison) is always correct and avoids the recursion issue regardless of function naming or attributes.

## Changes

1. **`RuntimeLibcalls.td`** — removed `CompilerRTOnlyInt128Libcalls` from `WasmSystemLibrary`
2. **`WebAssemblyRuntimeLibcallSignatures.cpp`** — removed `MULO_I128` signature entry
3. **`muloti4.ll`** — updated test to verify `__muloti4` is NOT called (inline expansion used instead)

## Testing

Verified with the original reproduction case from the issue:

```
opt -passes=instcombine repro.ll | llc -O0
```

- **Before:** emits `call __muloti4` → runtime infinite recursion (stack overflow)
- **After:** emits `call __multi3` (plain wide multiply) with inline overflow detection → no recursion

Fixes https://github.com/llvm/llvm-project/issues/189173
Supersedes #191020

---

**Disclosure (per [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html)):** This patch was drafted with assistance from GitHub Copilot. It was reviewed, tested, and validated locally by @cataggar, who takes full responsibility for the submission and is available to answer reviewer questions.
