### PR TITLE
[sanitizer] Use close_range on Linux to close FDs in StartSubprocess

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -307,12 +307,12 @@ int internal_madvise(uptr addr, uptr length, int advice) {
 }
 
 uptr internal_close_range(fd_t lowfd, fd_t highfd, int flags) {
-#    if SANITIZER_FREEBSD
+#    if SANITIZER_FREEBSD || (SANITIZER_LINUX && defined(__NR_close_range))
   return internal_syscall(SYSCALL(close_range), lowfd, highfd, flags);
 #    endif
-  // TODO: Add Linux support using __NR_close_range (available since 5.9).
   return -1;  // Not supported.
 }
+
 uptr internal_close(fd_t fd) { return internal_syscall(SYSCALL(close), fd); }
 
 uptr internal_open(const char *filename, int flags) {


### PR DESCRIPTION
Enable the close_range syscall on Linux when __NR_close_range is
available in kernel headers (Linux 5.9+). On older kernels, the
syscall returns ENOSYS and callers fall back gracefully.

This fixes the slow FD closing loop in StartSubprocess when
RLIMIT_NOFILE is high (e.g. 1B in Docker environments).

Fixes https://github.com/llvm/llvm-project/issues/63297.
Fixes https://github.com/llvm/llvm-project/issues/152459.