### PR TITLE
[BOLT][AArch64] Extend test coverage for TailDuplication in AArch64

### DIFF
--- a/bolt/test/AArch64/tail-duplication-cache.s
+++ b/bolt/test/AArch64/tail-duplication-cache.s
@@ -1,3 +1,6 @@
+## Tests TailDuplication cache mode (--tail-duplication=cache) with two profiles:
+## one that triggers duplication and one that does not.
+
 # REQUIRES: system-linux
 
 # RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o

--- a/bolt/test/AArch64/tail-duplication-cache.s
+++ b/bolt/test/AArch64/tail-duplication-cache.s
@@ -18,6 +18,14 @@
 # FDATA: 1 main #.BB3_br# 1 main #.BB2# 0 50
 # CHECK: BOLT-INFO: tail duplication modified 1 ({{.*}}%) functions; duplicated 1 blocks (20 bytes) responsible for 50 dynamic executions ({{.*}}% of all block executions)
 # CHECK: BB Layout   : .LBB00, .Ltmp0, .Ltmp1, .Ltmp2, .Ltmp3, .Ltmp4, .Ltmp5, .Ltail-dup0, .Ltmp6
+# CHECK-LABEL: .Ltail-dup0 (5 instructions, align : 1)
+# CHECK-NEXT:   Exec Count : {{.*}}
+# CHECK-NEXT:   Predecessors: .Ltmp5
+# CHECK-NEXT:   add x0, x0, #0x1
+# CHECK-NEXT:   add x0, x0, #0x1
+# CHECK-NEXT:   add x0, x0, #0x1
+# CHECK-NEXT:   add x0, x0, #0x1
+# CHECK-NEXT:   ret
 
 ## A test where the tail is not duplicated due to the cache score.
 # FDATA2: 1 main #.BB0_br# 1 main #.BB4# 0 100

--- a/bolt/test/AArch64/tail-duplication-cache.s
+++ b/bolt/test/AArch64/tail-duplication-cache.s
@@ -1,0 +1,59 @@
+# REQUIRES: system-linux
+
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
+# RUN: link_fdata %s %t.o %t.fdata
+# RUN: link_fdata %s %t.o %t.fdata2 "FDATA2"
+# RUN: %clang %cflags --target=aarch64-unknown-linux %t.o -o %t.exe -Wl,-q
+# RUN: llvm-bolt %t.exe --data %t.fdata --reorder-blocks=none \
+# RUN:    --print-finalized --tail-duplication=cache -o %t.out | FileCheck %s
+# RUN: llvm-bolt %t.exe --data %t.fdata2 --reorder-blocks=none \
+# RUN:    --print-finalized --tail-duplication=cache -o %t.out2 \
+# RUN:    | FileCheck %s --check-prefix="CHECK2"
+
+## A test where the tail is duplicated to eliminate an unconditional jump.
+# FDATA: 1 main #.BB0_br# 1 main #.BB4# 0 100
+# FDATA: 1 main #.BB0_br# 1 main #.BB1# 0 100
+# FDATA: 1 main #.BB1_br# 1 main #.BB3# 0 50
+# FDATA: 1 main #.BB1_br# 1 main #.BB2# 0 50
+# FDATA: 1 main #.BB3_br# 1 main #.BB2# 0 50
+# CHECK: BOLT-INFO: tail duplication modified 1 ({{.*}}%) functions; duplicated 1 blocks (20 bytes) responsible for 50 dynamic executions ({{.*}}% of all block executions)
+# CHECK: BB Layout   : .LBB00, .Ltmp0, .Ltmp1, .Ltmp2, .Ltmp3, .Ltmp4, .Ltmp5, .Ltail-dup0, .Ltmp6
+
+## A test where the tail is not duplicated due to the cache score.
+# FDATA2: 1 main #.BB0_br# 1 main #.BB4# 0 100
+# FDATA2: 1 main #.BB0_br# 1 main #.BB1# 0 2
+# FDATA2: 1 main #.BB1_br# 1 main #.BB3# 0 1
+# FDATA2: 1 main #.BB1_br# 1 main #.BB2# 0 1
+# FDATA2: 1 main #.BB3_br# 1 main #.BB2# 0 1
+# CHECK2: BOLT-INFO: tail duplication modified 0 (0.00%) functions; duplicated 0 blocks (0 bytes) responsible for 0 dynamic executions (0.00% of all block executions)
+# CHECK2: BB Layout   : .LBB00, .Ltmp0, .Ltmp1, .Ltmp2, .Ltmp3, .Ltmp4, .Ltmp5, .Ltmp6
+
+    .text
+    .globl main
+    .type main, %function
+    .size main, .Lend-main
+main:
+.BB0:
+    eor w0, w0, w0
+.BB0_br:
+    cbz w0, .BB4
+.BB1:
+    add x0, x0, #1
+.BB1_br:
+    cbz w0, .BB3
+.BB2:
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+    ret
+.BB3:
+    add x0, x0, #1
+.BB3_br:
+    b .BB2
+.BB4:
+    ret
+
+## Force relocation mode against text.
+    .reloc 0, R_AARCH64_NONE
+.Lend:

--- a/bolt/test/AArch64/tail-duplication-pass.s
+++ b/bolt/test/AArch64/tail-duplication-pass.s
@@ -1,3 +1,6 @@
+## Tests TailDuplication for moderate (--tail-duplication=moderate) and aggressive (--tail-duplication=aggressive) modes.
+## The test uses a hot edge to a tail block and checks that a duplicated tail block is created and has the correct predecessor.
+
 # REQUIRES: system-linux
 
 # RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o

--- a/bolt/test/AArch64/tail-duplication-pass.s
+++ b/bolt/test/AArch64/tail-duplication-pass.s
@@ -14,6 +14,11 @@
 # FDATA: 1 main 4 1 main #.BB2# 0 10
 # CHECK: BOLT-INFO: tail duplication modified 1 ({{.*}}%) functions; duplicated 1 blocks (4 bytes) responsible for {{.*}} dynamic executions ({{.*}}% of all block executions)
 # CHECK: BB Layout   : .LBB00, .Ltail-dup0, .Ltmp0, .Ltmp1
+# CHECK-LABEL: .LBB00 (1 instructions, align : 1)
+# CHECK-NEXT:   Entry Point
+# CHECK-NEXT:   Exec Count : {{.*}}
+# CHECK-NEXT:   eor w0, w0, w0
+# CHECK-NEXT:   Successors: .Ltail-dup0
 
 ## Check that the predecessor of Ltail-dup0 is .LBB00, not itself.
 # CHECK-NOLOOP-LABEL: .Ltail-dup0 (1 instructions, align : 1)

--- a/bolt/test/AArch64/tail-duplication-pass.s
+++ b/bolt/test/AArch64/tail-duplication-pass.s
@@ -17,6 +17,7 @@
 
 ## Check that the predecessor of Ltail-dup0 is .LBB00, not itself.
 # CHECK-NOLOOP-LABEL: .Ltail-dup0 (1 instructions, align : 1)
+# CHECK-NOLOOP-NEXT:   Exec Count : {{.*}}
 # CHECK-NOLOOP-NEXT:   Predecessors: .LBB00
 # CHECK-NOLOOP-NEXT:   ret
     .text

--- a/bolt/test/AArch64/tail-duplication-pass.s
+++ b/bolt/test/AArch64/tail-duplication-pass.s
@@ -1,0 +1,36 @@
+# REQUIRES: system-linux
+
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
+# RUN: link_fdata %s %t.o %t.fdata
+# RUN: %clang %cflags --target=aarch64-unknown-linux %t.o -o %t.exe -Wl,-q
+# RUN: llvm-bolt %t.exe --data %t.fdata --reorder-blocks=none \
+# RUN:    --print-finalized --tail-duplication=moderate \
+# RUN:    --tail-duplication-minimum-offset=1 -o %t.out | FileCheck %s
+# RUN: llvm-bolt %t.exe --data %t.fdata --reorder-blocks=none \
+# RUN:    --print-finalized --tail-duplication=aggressive \
+# RUN:    --tail-duplication-minimum-offset=1 -o %t.out \
+# RUN:    | FileCheck %s --check-prefix=CHECK-NOLOOP
+
+# FDATA: 1 main 4 1 main #.BB2# 0 10
+# CHECK: BOLT-INFO: tail duplication modified 1 ({{.*}}%) functions; duplicated 1 blocks (4 bytes) responsible for {{.*}} dynamic executions ({{.*}}% of all block executions)
+# CHECK: BB Layout   : .LBB00, .Ltail-dup0, .Ltmp0, .Ltmp1
+
+## Check that the predecessor of Ltail-dup0 is .LBB00, not itself.
+# CHECK-NOLOOP-LABEL: .Ltail-dup0 (1 instructions, align : 1)
+# CHECK-NOLOOP-NEXT:   Predecessors: .LBB00
+# CHECK-NOLOOP-NEXT:   ret
+    .text
+    .globl main
+    .type main, %function
+main:
+.BB0:
+    eor w0, w0, w0
+    b .BB2
+.BB1:
+    add x0, x0, #1
+.BB2:
+    ret
+
+## Force relocation mode against text.
+    .reloc 0, R_AARCH64_NONE
+.Lend:

--- a/bolt/test/X86/tail-duplication-pass.s
+++ b/bolt/test/X86/tail-duplication-pass.s
@@ -16,7 +16,7 @@
 # CHECK: BOLT-INFO: tail duplication modified 1 ({{.*}}%) functions; duplicated 1 blocks (1 bytes) responsible for {{.*}} dynamic executions ({{.*}}% of all block executions)
 # CHECK: BB Layout   : .LBB00, .Ltail-dup0, .Ltmp0, .Ltmp1
 
-## Check that the successor of Ltail-dup0 is .LBB00, not itself.
+## Check that the predecessor of Ltail-dup0 is .LBB00, not itself.
 # CHECK-NOLOOP: .Ltail-dup0 (1 instructions, align : 1)
 # CHECK-NOLOOP: Predecessors: .LBB00
 # CHECK-NOLOOP: retq


### PR DESCRIPTION
Adds tests for tail duplication with modes aggressive/cache/moderate for AArch64.

Edit: Based on respective X86 tests.
Edit 2: Also fixed up comment on X86/tail-duplication-pass.s.