### PR TITLE
[lldb][PlatformDarwin] Make PlatformDarwin define a safe-path for auto-loading scripting resources

### DIFF
--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -1009,6 +1009,13 @@ public:
 
   LocateModuleCallback GetLocateModuleCallback() const;
 
+  /// Returns a \c FileSpecList of safe paths to auto-load scripting resources
+  /// from for a particular platform.
+  virtual llvm::Expected<FileSpecList>
+  GetSafeAutoLoadPaths(const Target &target) const {
+    return FileSpecList();
+  }
+
 protected:
   /// Create a list of ArchSpecs with the given OS and a architectures. The
   /// vendor field is left as an "unspecified unknown".

--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -14,6 +14,7 @@
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/DataBuffer.h"
 #include "lldb/Utility/DataExtractor.h"
+#include "lldb/Utility/FileSpecList.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Timer.h"

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1564,3 +1564,36 @@ PlatformDarwin::ResolveSDKPathFromDebugInfo(CompileUnit &unit) {
 
   return path_or_err->str();
 }
+
+llvm::Expected<FileSpecList>
+PlatformDarwin::GetSafeAutoLoadPaths(const Target &target) const {
+  Log *log = GetLog(LLDBLog::Modules | LLDBLog::Platform);
+
+  XcodeSDK::Type sdk_type =
+      XcodeSDK::GetSDKTypeForTriple(target.GetArchitecture().GetTriple());
+  XcodeSDK sdk(XcodeSDK::Info{sdk_type, {}});
+
+  auto sdk_root_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
+  if (!sdk_root_or_err) {
+    LLDB_LOG_ERROR(log, sdk_root_or_err.takeError(),
+                   "Failed to resolve SDK root for triple '{1}': {0}",
+                   target.GetArchitecture().GetTriple().str());
+
+    // Fall back to any macOS SDK.
+    sdk = XcodeSDK::GetAnyMacOS();
+    LLDB_LOG(log, "Falling back to SDK '{0}'", sdk.GetString());
+    sdk_root_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
+  }
+
+  if (!sdk_root_or_err)
+    return sdk_root_or_err.takeError();
+
+  // $SDKROOT/usr/share/lldb is an auto-loadable path.
+  llvm::SmallString<256> resolved(*sdk_root_or_err);
+  llvm::sys::path::append(resolved, "usr", "share", "lldb");
+
+  FileSpecList fspecs;
+  fspecs.Append(FileSpec(resolved));
+
+  return fspecs;
+}

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -159,6 +159,9 @@ public:
                                              const Target &target,
                                              const FileSpec &symfile_spec);
 
+  llvm::Expected<FileSpecList>
+  GetSafeAutoLoadPaths(const Target &target) const override;
+
 protected:
   static const char *GetCompatibleArch(ArchSpec::Core core, size_t idx);
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -5443,7 +5443,7 @@ FileSpecList Target::GetSafeAutoLoadPaths() const {
     else
       LLDB_LOG_ERROR(GetLog(LLDBLog::Modules | LLDBLog::Platform),
                      platform_fspecs_or_err.takeError(),
-                     "Skipping safe auto-load path: {0}");
+                     "Skipping safe auto-load: {0}");
   }
 
   // Properties for testing get added last so they take priority.

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -5435,6 +5435,18 @@ void Target::NotifyBreakpointChanged(
 FileSpecList Target::GetSafeAutoLoadPaths() const {
   FileSpecList fspecs = Debugger::GetDefaultSafeAutoLoadPaths();
 
+  // Add platform-specific safe-paths.
+  if (m_platform_sp) {
+    if (auto platform_fspecs_or_err =
+            m_platform_sp->GetSafeAutoLoadPaths(*this))
+      fspecs.Append(*platform_fspecs_or_err);
+    else
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Modules | LLDBLog::Platform),
+                     platform_fspecs_or_err.takeError(),
+                     "Skipping safe auto-load path: {0}");
+  }
+
+  // Properties for testing get added last so they take priority.
 #ifndef NDEBUG
   for (const auto &fspec :
        TestingProperties::GetGlobalTestingProperties().GetSafeAutoLoadPaths())

--- a/lldb/unittests/Platform/CMakeLists.txt
+++ b/lldb/unittests/Platform/CMakeLists.txt
@@ -14,6 +14,7 @@ add_lldb_unittest(LLDBPlatformTests
     lldbPluginPlatformMacOSX
     lldbPluginPlatformNetBSD
     lldbUtilityHelpers
+    LLVMTestingSupport
   )
 
 add_subdirectory(Android)

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "llvm/Testing/Support/Error.h"
 
 #include <memory>
 #include <tuple>
@@ -767,3 +768,20 @@ INSTANTIATE_TEST_SUITE_P(PlatformDarwinLocateWithSpecialCharsTest,
                          PlatformDarwinLocateWithSpecialCharsTestFixture,
                          testing::ValuesIn(std::vector<SpecialCharTestCase>{
                              {' ', '_'}, {'.', '_'}, {'-', '_'}, {'+', 'x'}}));
+
+TEST_F(PlatformDarwinLocateTest, GetSafeAutoLoadPaths) {
+  // Tests PlatformDarwin::GetSafeAutoLoadPaths returns a path into the SDK on
+  // Darwin platforms.
+
+  auto paths_or_err = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                          ->GetSafeAutoLoadPaths(*m_target_sp);
+
+  ASSERT_THAT_EXPECTED(paths_or_err, llvm::Succeeded());
+
+  ASSERT_EQ(paths_or_err->GetSize(), 1u);
+
+  // The returned path should be $SDKROOT/usr/share/lldb.
+  FileSpec path = paths_or_err->GetFileSpecAtIndex(0);
+  EXPECT_TRUE(llvm::StringRef(path.GetPath()).ends_with("/usr/share/lldb"))
+      << "Unexpected path: " << path.GetPath();
+}


### PR DESCRIPTION
This patch adds a new API (`Platform::GetSafeAutoLoadPaths`) which gives platforms a chance to advertise their safe-paths. We have a `LLDB_SAFE_AUTO_LOAD_PATHS` CMake variable for this that vendors can set, but for sensible defaults we wanted to bake them into LLDB for convenience. We could set the defaults of the CMake variable per-platform, but for Apple platforms that's trickier because the path isn't statically known (it's the SDK path derived from the target's triple).

Depends on:
* https://github.com/llvm/llvm-project/pull/191446
* https://github.com/llvm/llvm-project/pull/192703

Assisted-by: Claude
- Used Claude to write the skeleton of the test before manually cleaning it up.