### PR TITLE
Disable MSVC-incompatible portions of `disable_container_overflow_checks` for MSVC

### DIFF
--- a/compiler-rt/test/asan/TestCases/disable_container_overflow_checks.c
+++ b/compiler-rt/test/asan/TestCases/disable_container_overflow_checks.c
@@ -21,7 +21,7 @@
 
 // compilers such as MSVC do not support `__has_feature`
 #ifndef __has_feature
-#define __has_feature(x) 0
+#  define __has_feature(x) 0
 #endif
 
 static volatile int one = 1;
@@ -29,6 +29,9 @@ static volatile int one = 1;
 int TestCrash() {
   long t[100];
   t[60] = 0;
+
+// MSVC defines __SANITIZE_ADDRESS__,
+// see :https://learn.microsoft.com/en-us/cpp/sanitizers/asan-building#language-specification
 #if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
   __sanitizer_annotate_contiguous_container(&t[0], &t[0] + 100, &t[0] + 100,
                                             &t[0] + 50);

--- a/compiler-rt/test/asan/TestCases/disable_container_overflow_checks.c
+++ b/compiler-rt/test/asan/TestCases/disable_container_overflow_checks.c
@@ -9,8 +9,8 @@
 //
 // Illustrate use of -D__SANITIZER_DISABLE_CONTAINER_OVERFLOW__ flag to suppress
 // overflow checks at compile time.
-// RUN: %clang_asan -D__SANITIZER_DISABLE_CONTAINER_OVERFLOW__ -O %s -o %t-no-overflow
-// RUN: %run %t-no-overflow 2>&1 | FileCheck --check-prefix=CHECK-NOCRASH %s
+// RUN: %if !MSVC %{ %clang_asan -D__SANITIZER_DISABLE_CONTAINER_OVERFLOW__ -O %s -o %t-no-overflow %}
+// RUN: %if !MSVC %{ %run %t-no-overflow 2>&1 | FileCheck --check-prefix=CHECK-NOCRASH %s %}
 
 #include <assert.h>
 #include <stdio.h>
@@ -19,12 +19,17 @@
 // public definition of __sanitizer_annotate_contiguous_container
 #include "sanitizer/common_interface_defs.h"
 
+// compilers such as MSVC do not support `__has_feature`
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
 static volatile int one = 1;
 
 int TestCrash() {
   long t[100];
   t[60] = 0;
-#if __has_feature(address_sanitizer)
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
   __sanitizer_annotate_contiguous_container(&t[0], &t[0] + 100, &t[0] + 100,
                                             &t[0] + 50);
 #endif


### PR DESCRIPTION
**Context:**

The test `disable_container_overflow_checks` recently started running on Windows, as per: https://github.com/llvm/llvm-project/pull/181721/changes

As a result, the MSVC ASan fork of LLVM ASan started executing this test, which has been failing for 2 reasons.

1) MSVC does not support the `__has_feature` syntax.
2) The `__SANITIZER_DISABLE_CONTAINER_OVERFLOW__` macro is not supported in MSVC ASan (we have an equivalent in `_DISABLE_STL_ANNOTATION`) because `__SANITIZER_DISABLE_CONTAINER_OVERFLOW__` also invokes MSVC-incompatible syntax.

**This PR** addresses these two failures.

For (1), we replace:

```C++
#if __has_feature(address_sanitizer)
```

with

```C++
// compilers such as MSVC do not support `__has_feature`
#ifndef __has_feature
#define __has_feature(x) 0
#endif

// MSVC defines `__SANITIZE_ADDRESS__`
#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
```

and for (2), we disable the tests for `__SANITIZER_DISABLE_CONTAINER_OVERFLOW__` for MSVC.