### PR TITLE
[CIR] Add noundef to memchr declaration and call sites

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4691,10 +4691,25 @@ mlir::LogicalResult CIRToLLVMMemChrOpLowering::matchAndRewrite(
                                         /*isVarArg=*/false);
   llvm::StringRef fnName = "memchr";
   createLLVMFuncOpIfNotExist(rewriter, op, fnName, fnTy);
-  rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(
+
+  mlir::Builder b(rewriter.getContext());
+  auto noundefAttr = b.getNamedAttr("llvm.noundef", b.getUnitAttr());
+  auto noundefDict = mlir::DictionaryAttr::get(rewriter.getContext(),
+                                               llvm::ArrayRef(noundefAttr));
+  SmallVector<mlir::Attribute> argAttrs(3, noundefDict);
+  auto argAttrsArr = mlir::ArrayAttr::get(rewriter.getContext(), argAttrs);
+
+  auto modOp = op->getParentOfType<mlir::ModuleOp>();
+  if (auto fn = mlir::dyn_cast_or_null<mlir::LLVM::LLVMFuncOp>(
+          mlir::SymbolTable::lookupSymbolIn(modOp, fnName)))
+    if (!fn->hasAttr("arg_attrs"))
+      fn->setAttr("arg_attrs", argAttrsArr);
+
+  auto newCall = rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(
       op, mlir::TypeRange{llvmPtrTy}, fnName,
       mlir::ValueRange{adaptor.getSrc(), adaptor.getPattern(),
                        adaptor.getLen()});
+  newCall->setAttr("arg_attrs", argAttrsArr);
   return mlir::success();
 }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -3551,15 +3551,22 @@ mlir::LogicalResult CIRToLLVMUnreachableOpLowering::matchAndRewrite(
 
 void createLLVMFuncOpIfNotExist(mlir::ConversionPatternRewriter &rewriter,
                                 mlir::Operation *srcOp, llvm::StringRef fnName,
-                                mlir::Type fnTy) {
-  auto modOp = srcOp->getParentOfType<mlir::ModuleOp>();
-  auto enclosingFnOp = srcOp->getParentOfType<mlir::LLVM::LLVMFuncOp>();
+                                mlir::Type fnTy,
+                                mlir::ArrayAttr argAttrs = nullptr,
+                                mlir::ArrayAttr resAttrs = nullptr) {
+  mlir::ModuleOp modOp = srcOp->getParentOfType<mlir::ModuleOp>();
   mlir::Operation *sourceSymbol =
       mlir::SymbolTable::lookupSymbolIn(modOp, fnName);
   if (!sourceSymbol) {
     mlir::OpBuilder::InsertionGuard guard(rewriter);
+    auto enclosingFnOp = srcOp->getParentOfType<mlir::LLVM::LLVMFuncOp>();
     rewriter.setInsertionPoint(enclosingFnOp);
-    mlir::LLVM::LLVMFuncOp::create(rewriter, srcOp->getLoc(), fnName, fnTy);
+    auto fn =
+        mlir::LLVM::LLVMFuncOp::create(rewriter, srcOp->getLoc(), fnName, fnTy);
+    if (argAttrs)
+      fn.setArgAttrsAttr(argAttrs);
+    if (resAttrs)
+      fn.setResAttrsAttr(resAttrs);
   }
 }
 
@@ -4690,26 +4697,23 @@ mlir::LogicalResult CIRToLLVMMemChrOpLowering::matchAndRewrite(
       mlir::LLVM::LLVMFunctionType::get(llvmPtrTy, {srcTy, patternTy, lenTy},
                                         /*isVarArg=*/false);
   llvm::StringRef fnName = "memchr";
-  createLLVMFuncOpIfNotExist(rewriter, op, fnName, fnTy);
 
   mlir::Builder b(rewriter.getContext());
-  auto noundefAttr = b.getNamedAttr("llvm.noundef", b.getUnitAttr());
-  auto noundefDict = mlir::DictionaryAttr::get(rewriter.getContext(),
-                                               llvm::ArrayRef(noundefAttr));
-  SmallVector<mlir::Attribute> argAttrs(3, noundefDict);
-  auto argAttrsArr = mlir::ArrayAttr::get(rewriter.getContext(), argAttrs);
+  mlir::NamedAttribute noundefAttr =
+      b.getNamedAttr("llvm.noundef", b.getUnitAttr());
+  mlir::DictionaryAttr noundefDict = mlir::DictionaryAttr::get(
+      rewriter.getContext(), llvm::ArrayRef(noundefAttr));
+  SmallVector<mlir::Attribute> argAttrVec(3, noundefDict);
+  mlir::ArrayAttr argAttrs =
+      mlir::ArrayAttr::get(rewriter.getContext(), argAttrVec);
 
-  auto modOp = op->getParentOfType<mlir::ModuleOp>();
-  if (auto fn = mlir::dyn_cast_or_null<mlir::LLVM::LLVMFuncOp>(
-          mlir::SymbolTable::lookupSymbolIn(modOp, fnName)))
-    if (!fn->hasAttr("arg_attrs"))
-      fn->setAttr("arg_attrs", argAttrsArr);
+  createLLVMFuncOpIfNotExist(rewriter, op, fnName, fnTy, argAttrs);
 
-  auto newCall = rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(
+  mlir::LLVM::CallOp newCall = rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(
       op, mlir::TypeRange{llvmPtrTy}, fnName,
       mlir::ValueRange{adaptor.getSrc(), adaptor.getPattern(),
                        adaptor.getLen()});
-  newCall->setAttr("arg_attrs", argAttrsArr);
+  newCall.setArgAttrsAttr(argAttrs);
   return mlir::success();
 }
 

--- a/clang/test/CIR/CodeGenBuiltins/builtin-memchr.c
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-memchr.c
@@ -15,7 +15,7 @@ void *test_char_memchr(const char arg[32]) {
 // CIR: {{%.*}} = cir.libc.memchr({{%.*}}, %[[PATTERN]], %[[LEN]])
 
 // LLVM-LABEL: @test_char_memchr
-// LLVM: call ptr @memchr(ptr %{{.*}}, i32 123, i64 32)
+// LLVM: call ptr @memchr(ptr noundef %{{.*}}, i32 noundef 123, i64 noundef 32)
 // LLVM: ret ptr
 
 // OGCG-LABEL: @test_char_memchr
@@ -30,7 +30,7 @@ void *test_memchr(const void *ptr, int val, unsigned long size) {
 // CIR: {{%.*}} = cir.libc.memchr({{%.*}}, {{%.*}}, {{%.*}})
 
 // LLVM-LABEL: @test_memchr
-// LLVM: call ptr @memchr(ptr %{{.*}}, i32 %{{.*}}, i64 %{{.*}})
+// LLVM: call ptr @memchr(ptr noundef %{{.*}}, i32 noundef %{{.*}}, i64 noundef %{{.*}})
 // LLVM: ret ptr
 
 // OGCG-LABEL: @test_memchr


### PR DESCRIPTION
The memchr LLVM declaration created by MemChrOp lowering had no
arg_attrs, so the lowered IR was missing `noundef` on all three
parameters.  OGCG emits `noundef` on them.

Adds `noundef` to both the `@memchr` declaration and each
`call @memchr` instruction.

Made with [Cursor](https://cursor.com)