### PR TITLE
[compiler-rt] Address dlvsym not found compilation error when targeting certain platforms (try 2)

### DIFF
--- a/compiler-rt/lib/interception/interception_linux.cpp
+++ b/compiler-rt/lib/interception/interception_linux.cpp
@@ -24,7 +24,9 @@
 
 #  pragma weak dlopen
 #  pragma weak dlsym
+#if SANITIZER_GLIBC || SANITIZER_FREEBSD || SANITIZER_NETBSD
 #  pragma weak dlvsym
+#endif
 
 namespace __interception {
 


### PR DESCRIPTION
The previous attempt was incomplete. #191444 