### PR TITLE
[lldb] Fix a couple of return type / return value mismatches

### DIFF
--- a/lldb/include/lldb/Core/EmulateInstruction.h
+++ b/lldb/include/lldb/Core/EmulateInstruction.h
@@ -452,8 +452,8 @@ public:
                              lldb::RegisterKind reg_kind, uint32_t reg_num,
                              uint64_t reg_value);
 
-  size_t ReadMemory(const Context &context, lldb::addr_t addr, void *dst,
-                    size_t dst_len);
+  bool ReadMemory(const Context &context, lldb::addr_t addr, void *dst,
+                  size_t dst_len);
 
   uint64_t ReadMemoryUnsigned(const Context &context, lldb::addr_t addr,
                               size_t byte_size, uint64_t fail_value,

--- a/lldb/source/Core/EmulateInstruction.cpp
+++ b/lldb/source/Core/EmulateInstruction.cpp
@@ -160,8 +160,8 @@ bool EmulateInstruction::WriteRegisterUnsigned(const Context &context,
   return false;
 }
 
-size_t EmulateInstruction::ReadMemory(const Context &context, lldb::addr_t addr,
-                                      void *dst, size_t dst_len) {
+bool EmulateInstruction::ReadMemory(const Context &context, lldb::addr_t addr,
+                                    void *dst, size_t dst_len) {
   if (m_read_mem_callback != nullptr)
     return m_read_mem_callback(this, m_baton, context, addr, dst, dst_len) ==
            dst_len;

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -620,7 +620,7 @@ addr_t ClangExpressionDeclMap::GetSymbolAddress(ConstString name,
   assert(m_parser_vars.get());
 
   if (!m_parser_vars->m_exe_ctx.GetTargetPtr())
-    return false;
+    return LLDB_INVALID_ADDRESS;
 
   return GetSymbolAddress(m_parser_vars->m_exe_ctx.GetTargetRef(),
                           m_parser_vars->m_exe_ctx.GetProcessPtr(), name,

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
@@ -247,7 +247,8 @@ public:
   ///     The module to limit the search to. This can be NULL
   ///
   /// \return
-  ///     Valid load address for the symbol
+  ///     The load address of the symbol if it was resolved,
+  ///     LLDB_INVALID_ADDRESS otherwise.
   lldb::addr_t GetSymbolAddress(Target &target, Process *process,
                                 ConstString name, lldb::SymbolType symbol_type,
                                 Module *module = nullptr);

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -706,7 +706,6 @@ size_t ValueObject::GetPointeeData(DataExtractor &data, uint32_t item_idx,
       Status error;
       return child_sp->GetData(data, error);
     }
-    return true;
   } else /* (items > 1) */
   {
     Status error;

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -706,6 +706,7 @@ size_t ValueObject::GetPointeeData(DataExtractor &data, uint32_t item_idx,
       Status error;
       return child_sp->GetData(data, error);
     }
+    return 0;
   } else /* (items > 1) */
   {
     Status error;


### PR DESCRIPTION
* `EmulateInstruction::ReadMemory()` returns a boolean value and is used in boolean contexts, but the return type is specified as `size_t`. Change it to `bool`. This also aligns it with `WriteMemory()`.
* `ClangExpressionDeclMap::GetSymbolAddress()` returns `false` if `Target` is not available, but it is expected to return an address. Change it to return `LLDB_INVALID_ADDRESS`.
* `ValueObject::GetPointeeData()` returns `true`, whereas a return value of type `size_t` is expected. Change it to return 0 (this code is unreachable).
