### PR TITLE
[flang][OpenMP] Rename GetRequiredCount to GetMinimumSequenceCount

### DIFF
--- a/flang/include/flang/Semantics/openmp-utils.h
+++ b/flang/include/flang/Semantics/openmp-utils.h
@@ -229,11 +229,12 @@ WithReason<int64_t> GetRectangularNestDepthWithReason(
     const parser::OmpDirectiveSpecification &spec, unsigned version,
     SemanticsContext *semaCtx = nullptr);
 
-// Count the required loop count from range. If count == -1, return -1,
-// indicating all loops in the sequence.
-std::optional<int64_t> GetRequiredCount(
+/// Calculate the minimum length of a sequence that contains the specified
+/// range. If the range's count is -1, return -1 indicating all loops in the
+/// sequence.
+std::optional<int64_t> GetMinimumSequenceCount(
     std::optional<int64_t> first, std::optional<int64_t> count);
-std::optional<int64_t> GetRequiredCount(
+std::optional<int64_t> GetMinimumSequenceCount(
     std::optional<std::pair<int64_t, int64_t>> range);
 
 struct LoopSequence {

--- a/flang/lib/Semantics/check-omp-loop.cpp
+++ b/flang/lib/Semantics/check-omp-loop.cpp
@@ -364,10 +364,10 @@ void OmpStructureChecker::CheckNestedConstruct(
         auto &msg{context_.Say(beginSource, MsgRequiresCanonical, "sequence")};
         whyNot.AttachTo(msg);
       }
-      if (auto requiredCount{GetRequiredCount(needRange.value)}) {
+      if (auto requiredCount{GetMinimumSequenceCount(needRange.value)}) {
         if (*requiredCount > 0 && haveLength.value < *requiredCount) {
           auto &msg{context_.Say(beginSource,
-              "This construct requires a sequence of %" PRId64
+              "This construct requires a sequence of at least %" PRId64
               " loops, but the loop sequence has a length of %" PRId64
               ""_err_en_US,
               *requiredCount, *haveLength.value)};

--- a/flang/lib/Semantics/openmp-utils.cpp
+++ b/flang/lib/Semantics/openmp-utils.cpp
@@ -1139,7 +1139,7 @@ WithReason<int64_t> GetRectangularNestDepthWithReason(
   return {0, Reason()};
 }
 
-std::optional<int64_t> GetRequiredCount(
+std::optional<int64_t> GetMinimumSequenceCount(
     std::optional<int64_t> first, std::optional<int64_t> count) {
   if (first && count && *first > 0) {
     if (*count > 0) {
@@ -1151,12 +1151,12 @@ std::optional<int64_t> GetRequiredCount(
   return std::nullopt;
 }
 
-std::optional<int64_t> GetRequiredCount(
+std::optional<int64_t> GetMinimumSequenceCount(
     std::optional<std::pair<int64_t, int64_t>> range) {
   if (range) {
-    return GetRequiredCount(range->first, range->second);
+    return GetMinimumSequenceCount(range->first, range->second);
   }
-  return GetRequiredCount(std::nullopt, std::nullopt);
+  return GetMinimumSequenceCount(std::nullopt, std::nullopt);
 }
 
 #ifdef EXPENSIVE_CHECKS
@@ -1482,7 +1482,7 @@ LoopSequence::Depth LoopSequence::calculateDepths() const {
       if (value && nestedLength.value) {
         auto range{
             GetAffectedLoopRangeWithReason(beginSpec, version_, semaCtx_)};
-        if (auto required{GetRequiredCount(range.value)}) {
+        if (auto required{GetMinimumSequenceCount(range.value)}) {
           if (*required == -1 || *required == *nestedLength.value) {
             return Depth{value, value};
           }

--- a/flang/test/Semantics/OpenMP/fuse1.f90
+++ b/flang/test/Semantics/OpenMP/fuse1.f90
@@ -7,7 +7,7 @@ subroutine f
   integer :: i
 
   !$omp do
-  !ERROR: This construct requires a sequence of 2 loops, but the loop sequence has a length of 1
+  !ERROR: This construct requires a sequence of at least 2 loops, but the loop sequence has a length of 1
   !BECAUSE: LOOPRANGE clause was specified with a count of 2 starting at loop 1
   !$omp fuse looprange(1, 2)
   !BECAUSE: LOOPRANGE clause was not specified, the entire loop sequence is assumed

--- a/flang/test/Semantics/OpenMP/loop-transformation-clauses01.f90
+++ b/flang/test/Semantics/OpenMP/loop-transformation-clauses01.f90
@@ -20,7 +20,7 @@ subroutine loop_transformation_construct1
   end do
   !$omp end fuse
 
-  !ERROR: This construct requires a sequence of 6 loops, but the loop sequence has a length of 2
+  !ERROR: This construct requires a sequence of at least 6 loops, but the loop sequence has a length of 2
   !BECAUSE: LOOPRANGE clause was specified with a count of 2 starting at loop 5
   !$omp fuse looprange(5,2)
   do x = 1, i


### PR DESCRIPTION
The new name better describes the calculated value.

Also adjust a diagnostic message to say that *at least* N loops are expected in the sequence.