### PR TITLE
[WebAssembly] Fix attributes of exception_grouping_2 test

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyCFGStackify.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyCFGStackify.cpp
@@ -1793,7 +1793,7 @@ bool WebAssemblyCFGStackify::fixCallUnwindMismatches(MachineFunction &MF) {
   //
   // Now if bar() throws, it is going to end up in bb2, when it is supposed
   // throw up to the caller. We solve this problem in the same way, but in this
-  // case 'delegate's immediate argument is the number of block depths + 1,
+  // case 'catch_all_ref's immediate argument is the number of block depths + 1,
   // which means it rethrows to the caller.
   // block exnref                       ;; (new)
   //   block

--- a/llvm/test/CodeGen/WebAssembly/cfg-stackify-eh-legacy.ll
+++ b/llvm/test/CodeGen/WebAssembly/cfg-stackify-eh-legacy.ll
@@ -637,7 +637,7 @@ try.cont:                                         ; preds = %catch.start0
   ret i32 0
 }
 
-; We have two call unwind unwind mismatches:
+; We have two call unwind mismatches:
 ; - A may-throw instruction unwinds to an incorrect EH pad after linearizing the
 ;   CFG, when it is supposed to unwind to another EH pad.
 ; - A may-throw instruction unwinds to an incorrect EH pad after linearizing the
@@ -1654,9 +1654,9 @@ unreachable:                                      ; preds = %rethrow, %rethrow6
 ; should make sure to take out (c)'s exception out of (a)'s exception too.
 define void @exception_grouping_2() personality ptr @__gxx_wasm_personality_v0 {
 entry:
-  %exception = call ptr @__cxa_allocate_exception(i32 4) #1
+  %exception = call ptr @__cxa_allocate_exception(i32 4) #0
   store i32 0, ptr %exception, align 16
-  invoke void @__cxa_throw(ptr %exception, ptr @_ZTIi, ptr null) #3
+  invoke void @__cxa_throw(ptr %exception, ptr @_ZTIi, ptr null) #1
           to label %unreachable unwind label %catch.dispatch
 
 catch.dispatch:                                   ; preds = %entry
@@ -1666,18 +1666,18 @@ catch.start:                                      ; preds = %catch.dispatch
   %1 = catchpad within %0 [ptr @_ZTIi]
   %2 = call ptr @llvm.wasm.get.exception(token %1)
   %3 = call i32 @llvm.wasm.get.ehselector(token %1)
-  %4 = call i32 @llvm.eh.typeid.for(ptr @_ZTIi) #1
+  %4 = call i32 @llvm.eh.typeid.for(ptr @_ZTIi) #0
   %matches = icmp eq i32 %3, %4
   br i1 %matches, label %catch, label %rethrow
 
 catch:                                            ; preds = %catch.start
-  %5 = call ptr @__cxa_begin_catch(ptr %2) #1 [ "funclet"(token %1) ]
+  %5 = call ptr @__cxa_begin_catch(ptr %2) #0 [ "funclet"(token %1) ]
   %6 = load i32, ptr %5, align 4
-  call void @__cxa_end_catch() #1 [ "funclet"(token %1) ]
+  call void @__cxa_end_catch() #0 [ "funclet"(token %1) ]
   catchret from %1 to label %try.cont8
 
 rethrow:                                          ; preds = %catch.start
-  invoke void @llvm.wasm.rethrow() #3 [ "funclet"(token %1) ]
+  invoke void @llvm.wasm.rethrow() #1 [ "funclet"(token %1) ]
           to label %unreachable unwind label %catch.dispatch1
 
 catch.dispatch1:                                  ; preds = %rethrow, %catch.dispatch
@@ -1687,18 +1687,18 @@ catch.start2:                                     ; preds = %catch.dispatch1
   %8 = catchpad within %7 [ptr @_ZTIi]
   %9 = call ptr @llvm.wasm.get.exception(token %8)
   %10 = call i32 @llvm.wasm.get.ehselector(token %8)
-  %11 = call i32 @llvm.eh.typeid.for(ptr @_ZTIi) #1
+  %11 = call i32 @llvm.eh.typeid.for(ptr @_ZTIi) #0
   %matches3 = icmp eq i32 %10, %11
   br i1 %matches3, label %catch5, label %rethrow4
 
 catch5:                                           ; preds = %catch.start2
-  %12 = call ptr @__cxa_begin_catch(ptr %9) #1 [ "funclet"(token %8) ]
+  %12 = call ptr @__cxa_begin_catch(ptr %9) #0 [ "funclet"(token %8) ]
   %13 = load i32, ptr %12, align 4
-  call void @__cxa_end_catch() #1 [ "funclet"(token %8) ]
+  call void @__cxa_end_catch() #0 [ "funclet"(token %8) ]
   catchret from %8 to label %try.cont8
 
 rethrow4:                                         ; preds = %catch.start2
-  call void @llvm.wasm.rethrow() #3 [ "funclet"(token %8) ]
+  call void @llvm.wasm.rethrow() #1 [ "funclet"(token %8) ]
   unreachable
 
 try.cont8:                                        ; preds = %catch, %catch5
@@ -1712,18 +1712,18 @@ catch.start10:                                    ; preds = %catch.dispatch9
   %15 = catchpad within %14 [ptr @_ZTIi]
   %16 = call ptr @llvm.wasm.get.exception(token %15)
   %17 = call i32 @llvm.wasm.get.ehselector(token %15)
-  %18 = call i32 @llvm.eh.typeid.for(ptr @_ZTIi) #1
+  %18 = call i32 @llvm.eh.typeid.for(ptr @_ZTIi) #0
   %matches11 = icmp eq i32 %17, %18
   br i1 %matches11, label %catch13, label %rethrow12
 
 catch13:                                          ; preds = %catch.start10
-  %19 = call ptr @__cxa_begin_catch(ptr %16) #1 [ "funclet"(token %15) ]
+  %19 = call ptr @__cxa_begin_catch(ptr %16) #0 [ "funclet"(token %15) ]
   %20 = load i32, ptr %19, align 4
-  call void @__cxa_end_catch() #1 [ "funclet"(token %15) ]
+  call void @__cxa_end_catch() #0 [ "funclet"(token %15) ]
   catchret from %15 to label %try.cont16
 
 rethrow12:                                        ; preds = %catch.start10
-  call void @llvm.wasm.rethrow() #3 [ "funclet"(token %15) ]
+  call void @llvm.wasm.rethrow() #1 [ "funclet"(token %15) ]
   unreachable
 
 try.cont16:                                       ; preds = %try.cont8, %catch13
@@ -1829,7 +1829,7 @@ declare void @end_cleanup()
 declare void @panic_in_cleanup() #2
 
 ; Check if the unwind destination mismatch stats are correct
-; NOSORT: 25 wasm-cfg-stackify    - Number of call unwind mismatches found
+; NOSORT: 26 wasm-cfg-stackify    - Number of call unwind mismatches found
 ; NOSORT:  7 wasm-cfg-stackify    - Number of catch unwind mismatches found
 
 declare void @foo()

--- a/llvm/test/CodeGen/WebAssembly/cfg-stackify-eh.ll
+++ b/llvm/test/CodeGen/WebAssembly/cfg-stackify-eh.ll
@@ -709,7 +709,7 @@ try.cont:                                         ; preds = %catch.start0
   ret i32 0
 }
 
-; We have two call unwind unwind mismatches:
+; We have two call unwind mismatches:
 ; - A may-throw instruction unwinds to an incorrect EH pad after linearizing the
 ;   CFG, when it is supposed to unwind to another EH pad.
 ; - A may-throw instruction unwinds to an incorrect EH pad after linearizing the
@@ -1427,9 +1427,9 @@ unreachable:                                      ; preds = %rethrow, %rethrow6
 ; should make sure to take out (c)'s exception out of (a)'s exception too.
 define void @exception_grouping_2() personality ptr @__gxx_wasm_personality_v0 {
 entry:
-  %exception = call ptr @__cxa_allocate_exception(i32 4) #1
+  %exception = call ptr @__cxa_allocate_exception(i32 4) #0
   store i32 0, ptr %exception, align 16
-  invoke void @__cxa_throw(ptr %exception, ptr @_ZTIi, ptr null) #3
+  invoke void @__cxa_throw(ptr %exception, ptr @_ZTIi, ptr null) #1
           to label %unreachable unwind label %catch.dispatch
 
 catch.dispatch:                                   ; preds = %entry
@@ -1439,18 +1439,18 @@ catch.start:                                      ; preds = %catch.dispatch
   %1 = catchpad within %0 [ptr @_ZTIi]
   %2 = call ptr @llvm.wasm.get.exception(token %1)
   %3 = call i32 @llvm.wasm.get.ehselector(token %1)
-  %4 = call i32 @llvm.eh.typeid.for(ptr @_ZTIi) #1
+  %4 = call i32 @llvm.eh.typeid.for(ptr @_ZTIi) #0
   %matches = icmp eq i32 %3, %4
   br i1 %matches, label %catch, label %rethrow
 
 catch:                                            ; preds = %catch.start
-  %5 = call ptr @__cxa_begin_catch(ptr %2) #1 [ "funclet"(token %1) ]
+  %5 = call ptr @__cxa_begin_catch(ptr %2) #0 [ "funclet"(token %1) ]
   %6 = load i32, ptr %5, align 4
-  call void @__cxa_end_catch() #1 [ "funclet"(token %1) ]
+  call void @__cxa_end_catch() #0 [ "funclet"(token %1) ]
   catchret from %1 to label %try.cont8
 
 rethrow:                                          ; preds = %catch.start
-  invoke void @llvm.wasm.rethrow() #3 [ "funclet"(token %1) ]
+  invoke void @llvm.wasm.rethrow() #1 [ "funclet"(token %1) ]
           to label %unreachable unwind label %catch.dispatch1
 
 catch.dispatch1:                                  ; preds = %rethrow, %catch.dispatch
@@ -1460,18 +1460,18 @@ catch.start2:                                     ; preds = %catch.dispatch1
   %8 = catchpad within %7 [ptr @_ZTIi]
   %9 = call ptr @llvm.wasm.get.exception(token %8)
   %10 = call i32 @llvm.wasm.get.ehselector(token %8)
-  %11 = call i32 @llvm.eh.typeid.for(ptr @_ZTIi) #1
+  %11 = call i32 @llvm.eh.typeid.for(ptr @_ZTIi) #0
   %matches3 = icmp eq i32 %10, %11
   br i1 %matches3, label %catch5, label %rethrow4
 
 catch5:                                           ; preds = %catch.start2
-  %12 = call ptr @__cxa_begin_catch(ptr %9) #1 [ "funclet"(token %8) ]
+  %12 = call ptr @__cxa_begin_catch(ptr %9) #0 [ "funclet"(token %8) ]
   %13 = load i32, ptr %12, align 4
-  call void @__cxa_end_catch() #1 [ "funclet"(token %8) ]
+  call void @__cxa_end_catch() #0 [ "funclet"(token %8) ]
   catchret from %8 to label %try.cont8
 
 rethrow4:                                         ; preds = %catch.start2
-  call void @llvm.wasm.rethrow() #3 [ "funclet"(token %8) ]
+  call void @llvm.wasm.rethrow() #1 [ "funclet"(token %8) ]
   unreachable
 
 try.cont8:                                        ; preds = %catch, %catch5
@@ -1485,18 +1485,18 @@ catch.start10:                                    ; preds = %catch.dispatch9
   %15 = catchpad within %14 [ptr @_ZTIi]
   %16 = call ptr @llvm.wasm.get.exception(token %15)
   %17 = call i32 @llvm.wasm.get.ehselector(token %15)
-  %18 = call i32 @llvm.eh.typeid.for(ptr @_ZTIi) #1
+  %18 = call i32 @llvm.eh.typeid.for(ptr @_ZTIi) #0
   %matches11 = icmp eq i32 %17, %18
   br i1 %matches11, label %catch13, label %rethrow12
 
 catch13:                                          ; preds = %catch.start10
-  %19 = call ptr @__cxa_begin_catch(ptr %16) #1 [ "funclet"(token %15) ]
+  %19 = call ptr @__cxa_begin_catch(ptr %16) #0 [ "funclet"(token %15) ]
   %20 = load i32, ptr %19, align 4
-  call void @__cxa_end_catch() #1 [ "funclet"(token %15) ]
+  call void @__cxa_end_catch() #0 [ "funclet"(token %15) ]
   catchret from %15 to label %try.cont16
 
 rethrow12:                                        ; preds = %catch.start10
-  call void @llvm.wasm.rethrow() #3 [ "funclet"(token %15) ]
+  call void @llvm.wasm.rethrow() #1 [ "funclet"(token %15) ]
   unreachable
 
 try.cont16:                                       ; preds = %try.cont8, %catch13
@@ -1507,7 +1507,7 @@ unreachable:                                      ; preds = %rethrow, %entry
 }
 
 ; Check if the unwind destination mismatch stats are correct
-; NOSORT: 24 wasm-cfg-stackify    - Number of call unwind mismatches found
+; NOSORT: 25 wasm-cfg-stackify    - Number of call unwind mismatches found
 ; NOSORT:  4 wasm-cfg-stackify    - Number of catch unwind mismatches found
 
 declare void @foo()


### PR DESCRIPTION
Function calls in `exception_grouping_2` test had incorrect attribute numbers, making many of them incorrectly `noreturn`, rendering many BBs after them unreachable. As a result of them, the function became a trivial single-BB and the test passsed because it didn't have any exceptions in it. I think this happened because I created that test in another file and later pasted the function into these files, which had different attribute numbers.

This also has a few drive-by comment typo fixes.