### PR TITLE
[lldb][Platform] Use the module's FileSpec instead of the script's FileSpec when checking LoadScriptFromSymFile setting

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -207,6 +207,7 @@ PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
          "available.");
 
   llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile> file_specs;
+  const FileSpec original_module_spec = module_spec;
   while (module_spec.GetFilename()) {
     ScriptInterpreter::SanitizedScriptingModuleName sanitized_name =
         target.GetDebugger()
@@ -237,7 +238,7 @@ PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
 
     if (FileSystem::Instance().Exists(script_fspec)) {
       LoadScriptFromSymFile load_style =
-          Platform::GetScriptLoadStyleForModule(script_fspec, target);
+          Platform::GetScriptLoadStyleForModule(original_module_spec, target);
       file_specs.try_emplace(std::move(script_fspec), load_style);
       break;
     }

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -215,7 +215,7 @@ Platform::LocateExecutableScriptingResourcesFromSafePaths(
 
     if (FileSystem::Instance().Exists(script_fspec)) {
       LoadScriptFromSymFile load_style =
-          Platform::GetScriptLoadStyleForModule(script_fspec, target);
+          Platform::GetScriptLoadStyleForModule(module_spec, target);
       file_specs.try_emplace(std::move(script_fspec), load_style);
     }
 

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -672,6 +672,55 @@ TEST_F(PlatformDarwinLocateTest,
   }
 }
 
+TEST_F(PlatformDarwinLocateTest,
+       LocateExecutableScriptingResourcesFromDSYM_AutoLoadUsesModuleName) {
+  // Test that the auto-load-scripts-for-modules setting uses the module
+  // name (not the sanitized script name) for lookup. The module is named
+  // "TestModule.1" (with a dot), and the script is "TestModule_1.py"
+  // (sanitized). Setting "TestModule_1=true" should NOT affect loading
+  // because the lookup key should be "TestModule.1".
+
+  // Create dummy module file at <test-root>/TestModule.1.o
+  FileSpec module_fspec(CreateFile("TestModule.1.o", m_tmp_root_dir));
+  ASSERT_TRUE(module_fspec);
+
+  FileSpec dsym_module_fspec(
+      CreateFile("TestModule.1.o", m_tmp_dsym_dwarf_dir));
+  ASSERT_TRUE(dsym_module_fspec);
+
+  CreateFile("TestModule_1.py", m_tmp_dsym_python_dir);
+
+  m_target_sp->SetLoadScriptFromSymbolFile(eLoadScriptFromSymFileFalse);
+
+  // Setting the sanitized script name should NOT cause loading.
+  m_target_sp->SetAutoLoadScriptsForModule("TestModule_1",
+                                           eLoadScriptFromSymFileTrue);
+
+  {
+    StreamString ss;
+    auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                      ->LocateExecutableScriptingResourcesFromDSYM(
+                          ss, module_fspec, *m_target_sp, dsym_module_fspec);
+
+    ASSERT_EQ(fspecs.size(), 1u);
+    EXPECT_EQ(fspecs.begin()->second, eLoadScriptFromSymFileFalse);
+  }
+
+  // Now set the actual module name. This should override the default.
+  m_target_sp->SetAutoLoadScriptsForModule("TestModule.1",
+                                           eLoadScriptFromSymFileTrue);
+
+  {
+    StreamString ss;
+    auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                      ->LocateExecutableScriptingResourcesFromDSYM(
+                          ss, module_fspec, *m_target_sp, dsym_module_fspec);
+
+    ASSERT_EQ(fspecs.size(), 1u);
+    EXPECT_EQ(fspecs.begin()->second, eLoadScriptFromSymFileTrue);
+  }
+}
+
 struct SpecialCharTestCase {
   char special_char;
   char replacement;

--- a/lldb/unittests/Platform/PlatformTest.cpp
+++ b/lldb/unittests/Platform/PlatformTest.cpp
@@ -784,4 +784,56 @@ TEST_F(PlatformLocateSafePathTest,
     EXPECT_EQ(file_specs[script_default_fspec], eLoadScriptFromSymFileTrusted);
   }
 }
+
+TEST_F(PlatformLocateSafePathTest,
+       LocateScriptingResourcesFromSafePaths_AutoLoadUsesModuleName) {
+  // Test that the auto-load-scripts-for-modules setting uses the module
+  // name (not the sanitized script name) for lookup. The module is named
+  // "TestModule.1" (with a dot), and the script is "TestModule_1.py"
+  // (sanitized). Setting "TestModule_1=true" should NOT affect loading
+  // because the lookup key should be "TestModule.1".
+
+  TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
+      FileSpec(m_tmp_root_dir));
+
+  // Create dummy module file at <test-root>/TestModule.1.o
+  FileSpec module_fspec(CreateFile("TestModule.1.o", m_tmp_root_dir));
+  ASSERT_TRUE(module_fspec);
+
+  llvm::SmallString<128> module_dir(m_tmp_root_dir);
+  llvm::sys::path::append(module_dir, "TestModule.1");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(module_dir));
+
+  CreateFile("TestModule_1.py", module_dir);
+
+  m_target_sp->SetLoadScriptFromSymbolFile(eLoadScriptFromSymFileFalse);
+
+  // Setting the sanitized script name should NOT affect the module's load
+  // style.
+  m_target_sp->SetAutoLoadScriptsForModule("TestModule_1",
+                                           eLoadScriptFromSymFileTrue);
+
+  {
+    StreamString ss;
+    auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+        ss, module_fspec, *m_target_sp);
+
+    ASSERT_EQ(file_specs.size(), 1u);
+    EXPECT_EQ(file_specs.begin()->second, eLoadScriptFromSymFileFalse);
+  }
+
+  // Now set the actual module name. This should override the default.
+  m_target_sp->SetAutoLoadScriptsForModule("TestModule.1",
+                                           eLoadScriptFromSymFileTrue);
+
+  {
+    StreamString ss;
+    auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+        ss, module_fspec, *m_target_sp);
+
+    ASSERT_EQ(file_specs.size(), 1u);
+    EXPECT_EQ(file_specs.begin()->second, eLoadScriptFromSymFileTrue);
+  }
+}
+
 #endif // NDEBUG


### PR DESCRIPTION
We were incorrectly passing the script's `FileSpec` into `GetScriptLoadStyleForModule`. Meaning if a script name wasn't actually the same as the module name, the `target.auto-load-scripts-for-modules` didn't take effect.

This patch passes the module's `FileSpec` instead. For `dSYM`s we save the original `FileSpec` because the loop tries to strip extensions until it finds a script. But we still want to use the module's name.

**AI Usage**:
- Used Claude to write the unit-test skeletons. Then reviewed/adjusted them manually