### PR TITLE
[BOLT] Fix null pointer dereference in DWP processing with split DWARF

### DIFF
--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -665,8 +665,13 @@ void DWARFRewriter::updateDebugInfo() {
 
     updateUnitDebugInfo(SplitCU, DWODIEBuilder, DebugLocDWoWriter,
                         TempRangesSectionWriter, AddressWriter);
-    DebugLocDWoWriter.finalize(DWODIEBuilder,
-                               *DWODIEBuilder.getUnitDIEbyUnit(SplitCU));
+    DIE *UnitDIE = DWODIEBuilder.getUnitDIEbyUnit(SplitCU);
+    if (!UnitDIE) {
+      errs() << "BOLT-WARNING: failed to construct DIE for split CU "
+             << Twine::utohexstr(*Unit.getDWOId()) << "\n";
+      return;
+    }
+    DebugLocDWoWriter.finalize(DWODIEBuilder, *UnitDIE);
     if (Unit.getVersion() >= 5)
       TempRangesSectionWriter.finalizeSection();
 
@@ -1811,6 +1816,8 @@ std::optional<StringRef> updateDebugData(
                           uint64_t &DWPOffset) -> StringRef {
     if (DWOEntry) {
       DWOSectionContribution *DWOContrubution = DWOEntry->getContribution(Sec);
+      if (!DWOContrubution)
+        return OutData;
       DWPOffset = DWOContrubution->getOffset();
       OutData = OutData.substr(DWPOffset, DWOContrubution->getLength());
     }

--- a/bolt/test/X86/dwarf4-dwp-x86.s
+++ b/bolt/test/X86/dwarf4-dwp-x86.s
@@ -4,7 +4,17 @@
 # RUN: %clangxx %cxxflags -g -gdwarf-4 -gsplit-dwarf %t/main.s %t/callee.s -o main.exe
 # RUN: llvm-dwp -e %t/main.exe -o %t/main.exe.dwp
 # RUN: llvm-bolt %t/main.exe -o %t/main.exe.bolt -update-debug-sections  2>&1 | FileCheck %s
-
+## Test that BOLT does not crash when a DWP file contains a section (e.g.
+## .debug_line.dwo) whose kind is not tracked as a column in the CU index.
+## This triggers a null pointer dereference in getSliceData() where
+## getContribution() returns nullptr because the section kind has no column.
+# RUN: rm -rf %t && mkdir -p %t && cd %t
+# RUN: split-file %p/dwarf4-dwp-x86.s %t
+# RUN: %clangxx %cxxflags -g -gdwarf-4 -gsplit-dwarf %t/main.s %t/callee.s -o %t/main.exe
+# RUN: llvm-dwp -e %t/main.exe -o %t/main.exe.dwp
+# RUN: printf '\x00' > %t/line.bin
+# RUN: llvm-objcopy --add-section=.debug_line.dwo=%t/line.bin %t/main.exe.dwp
+# RUN: llvm-bolt %t/main.exe -o %t/main.exe.bolt -update-debug-sections  2>&1 | FileCheck %s
 # CHECK-NOT: Assertion
 
 #--- main.s


### PR DESCRIPTION
Fix two null pointer dereferences in BOLT's DWP processing path that cause SIGSEGV in worker threads when -update-debug-sections is used with a co-located .dwp file.

1. getSliceData() in updateDebugData() dereferences the result of getContribution() without checking for null. getContribution() returns nullptr when the requested section kind (e.g. DW_SECT_LINE) is not present as a column in the DWP CU index. When BOLT processes a DWP where certain section kinds are absent from the index, every worker thread that hits this path crashes simultaneously.

2. processSplitCU() dereferences getUnitDIEbyUnit() without checking for null. If buildDWOUnit() fails for a CU, the returned DIE* is null and the dereference crashes.

Crash signature from dmesg:
```
  llvm-worker-*: segfault at 8 ip <offset> error 4 in llvm-bolt
  (multiple worker threads crash at the same instruction)
```
The faulting address 0x8 corresponds to accessing the Length field (offset 8) of a null `DWARFUnitIndex::Entry::SectionContribution*`.

At Meta, I reproduced this building hhvm with a co-located .dwp file and the flags `update-debug-sections -debug-thread-count=80 -lite=0` with profile data. 

I confirmed that the unfixed BOLT crashes deterministically whereas the fixed BOLT completes successfully.