### PR TITLE
[Offload] Fix inefficient GNU Hash ELF symbol lookup

### DIFF
--- a/offload/plugins-nextgen/common/src/Utils/ELF.cpp
+++ b/offload/plugins-nextgen/common/src/Utils/ELF.cpp
@@ -134,14 +134,14 @@ getSymbolFromGnuHashTable(StringRef Name, const typename ELFT::GnuHash &HashTab,
        I >= SymOffset && I < SymTab.size(); I = I + 1) {
     const uint32_t ChainHash = Chain[I - SymOffset];
 
-    if ((NameHash | 0x1) != (ChainHash | 0x1))
-      continue;
-
-    if (SymTab[I].st_name >= StrTab.size())
-      return createError("symbol [index " + Twine(I) +
-                         "] has invalid st_name: " + Twine(SymTab[I].st_name));
-    if (StrTab.drop_front(SymTab[I].st_name).data() == Name)
-      return &SymTab[I];
+    if ((NameHash | 0x1) == (ChainHash | 0x1)) {
+      if (SymTab[I].st_name >= StrTab.size())
+        return createError(
+            "symbol [index " + Twine(I) +
+            "] has invalid st_name: " + Twine(SymTab[I].st_name));
+      if (StrTab.drop_front(SymTab[I].st_name).data() == Name)
+        return &SymTab[I];
+    }
 
     if (ChainHash & 0x1)
       return nullptr;


### PR DESCRIPTION
Summary:
This PR fixes the handling of the GNU Hash table. The chain format uses
the lowest bit to indicate the end of the list. Previously we just
continued the loop instead of breaking, meaning we would exhaustively
search the whole list if the symbol was not found instead of just early
existing. This was still correct and worked in practice, but it was
slightly inefficient. Likely not noticed because the symbol tables on
these GPU binaries tend to be relatively small.
