### PR TITLE
[CIR] Add restrict→noalias on non-builtin pointer params

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -483,7 +483,8 @@ void CIRGenModule::constructAttributeList(
   // TODO(cir): Add loader-replaceable attribute here.
 
   constructFunctionReturnAttributes(info, targetDecl, isThunk, retAttrs);
-  constructFunctionArgumentAttributes(info, isThunk, argAttrs);
+  constructFunctionArgumentAttributes(info, targetDecl, isThunk, attrOnCallSite,
+                                      argAttrs);
 }
 
 bool CIRGenModule::hasStrictReturn(QualType retTy, const Decl *targetDecl) {
@@ -630,13 +631,11 @@ void CIRGenModule::constructFunctionReturnAttributes(
 }
 
 void CIRGenModule::constructFunctionArgumentAttributes(
-    const CIRGenFunctionInfo &info, bool isThunk,
-    llvm::MutableArrayRef<mlir::NamedAttrList> argAttrs) {
+    const CIRGenFunctionInfo &info, const Decl *targetDecl, bool isThunk,
+    bool attrOnCallSite, llvm::MutableArrayRef<mlir::NamedAttrList> argAttrs) {
   assert(!cir::MissingFeatures::abiArgInfo());
   // TODO(cir): classic codegen does a lot of work here based on the ABIArgInfo
   // to set things based on calling convention.
-  // At the moment, only nonnull, dereferenceable, align, and noundef are being
-  // implemented here, using similar logic to how we do so for return types.
 
   if (info.isInstanceMethod() && !isThunk) {
     QualType thisPtrTy = info.arguments()[0];
@@ -680,8 +679,22 @@ void CIRGenModule::constructFunctionArgumentAttributes(
   // that seems risky at the moment. At one point we should evaluate if at least
   // dereferenceable, nonnull, and align can be combined.
   const cir::CIRDataLayout &layout = getDataLayout();
-  for (const auto &[argAttrList, argCanType] :
-       llvm::zip_equal(argAttrs, info.arguments())) {
+  const auto *fd = dyn_cast_or_null<FunctionDecl>(targetDecl);
+
+  // Build a parallel array of ParmVarDecls aligned with argAttrs so we can
+  // access parameter-level qualifiers (e.g. restrict) without manual index
+  // arithmetic in the loop.
+  SmallVector<const ParmVarDecl *> parmDecls;
+  parmDecls.reserve(argAttrs.size());
+  if (fd) {
+    if (info.isInstanceMethod())
+      parmDecls.push_back(nullptr);
+    parmDecls.insert(parmDecls.end(), fd->param_begin(), fd->param_end());
+  }
+  parmDecls.resize(argAttrs.size(), nullptr);
+
+  for (const auto &[argAttrList, argCanType, pvd] :
+       llvm::zip_equal(argAttrs, info.arguments(), parmDecls)) {
     assert(!cir::MissingFeatures::abiArgInfo());
     QualType argType = argCanType;
     const cir::ABIArgInfo argInfo = cir::ABIArgInfo::getDirect();
@@ -717,6 +730,13 @@ void CIRGenModule::constructFunctionArgumentAttributes(
       if (unsigned mask = getNoFPClassTestMask(getLangOpts()))
         argAttrList.set(mlir::LLVM::LLVMDialect::getNoFPClassAttrName(),
                         builder.getI64IntegerAttr(mask));
+
+    // restrict -> noalias on definitions only (not call sites).  Skip
+    // builtins: OGCG applies restrict->noalias in EmitFunctionProlog.
+    if (!attrOnCallSite && pvd && pvd->getType()->isPointerType() &&
+        pvd->getType().isRestrictQualified() && !fd->getBuiltinID())
+      argAttrList.set(mlir::LLVM::LLVMDialect::getNoAliasAttrName(),
+                      mlir::UnitAttr::get(&getMLIRContext()));
   }
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -120,7 +120,8 @@ private:
                                          mlir::NamedAttrList &retAttrs);
   /// A helper for constructAttributeList that handles argument attributes.
   void constructFunctionArgumentAttributes(
-      const CIRGenFunctionInfo &info, bool isThunk,
+      const CIRGenFunctionInfo &info, const clang::Decl *targetDecl,
+      bool isThunk, bool attrOnCallSite,
       llvm::MutableArrayRef<mlir::NamedAttrList> argAttrs);
   /// A helper function for constructAttributeList that determines whether a
   /// return value might have been discarded.

--- a/clang/test/CIR/CodeGen/restrict-noalias.c
+++ b/clang/test/CIR/CodeGen/restrict-noalias.c
@@ -1,0 +1,38 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+void user_func(int *__restrict p);
+
+void test_user(int *__restrict p) {
+  user_func(p);
+}
+
+// CIR: cir.func private @user_func(!cir.ptr<!s32i> {llvm.noalias, llvm.noundef})
+// CIR: cir.func {{.*}} @test_user(%arg0: !cir.ptr<!s32i> {llvm.noalias, llvm.noundef}
+// CIR:   cir.call @user_func(%{{.*}}) : (!cir.ptr<!s32i> {llvm.noundef}) -> ()
+
+// LLVM: define dso_local void @test_user(ptr noalias noundef %{{.*}})
+// LLVM:   call void @user_func(ptr noundef %{{.*}})
+
+// OGCG: define dso_local void @test_user(ptr noalias noundef %{{.*}})
+// OGCG:   call void @user_func(ptr noundef %{{.*}})
+
+int printf(const char *__restrict fmt, ...);
+
+void test_builtin(const char *__restrict fmt) {
+  printf(fmt);
+}
+
+// Builtins must NOT get noalias from restrict (matching OGCG behavior).
+// CIR: cir.func {{.*}} @test_builtin(%arg0: !cir.ptr<!s8i> {llvm.noalias, llvm.noundef}
+// CIR:   cir.call @printf(%{{.*}}) : (!cir.ptr<!s8i> {llvm.noundef}) -> !s32i
+
+// LLVM: define dso_local void @test_builtin(ptr noalias noundef %{{.*}})
+// LLVM:   call i32 (ptr, ...) @printf(ptr noundef %{{.*}})
+
+// OGCG: define dso_local void @test_builtin(ptr noalias noundef %{{.*}})
+// OGCG:   call i32 (ptr, ...) @printf(ptr noundef %{{.*}})


### PR DESCRIPTION
Map `restrict`-qualified pointer parameters to `noalias`, skipping builtins (e.g. `printf`) where OGCG doesn't apply it.  OGCG only adds `noalias` from `restrict` through its calling-convention lowering path, which builtins bypass, so the `!fd->getBuiltinID()` guard keeps CIR in line.

`constructFunctionArgumentAttributes` now takes `targetDecl` so it can look up `ParmVarDecl` qualifiers.

Updated `asm-label-inline-builtins.c` checks to reflect the new `noalias` on the non-builtin `__vfprintf_chkieee128` call.  New test: `restrict-noalias.c` (CIR / LLVM / OGCG).

Made with [Cursor](https://cursor.com)