### PR TITLE
[mlir] Decouple DenseResourceElementsAttr from BuiltinDialect

### DIFF
--- a/mlir/include/mlir/IR/BuiltinAttributes.h
+++ b/mlir/include/mlir/IR/BuiltinAttributes.h
@@ -21,6 +21,7 @@ class AsmResourceBlob;
 class BoolAttr;
 class BuiltinDialect;
 class DenseIntElementsAttr;
+class DenseResourceBlobHandle;
 template <typename T>
 struct DialectResourceBlobHandle;
 class FlatSymbolRefAttr;

--- a/mlir/include/mlir/IR/BuiltinAttributes.td
+++ b/mlir/include/mlir/IR/BuiltinAttributes.td
@@ -474,16 +474,16 @@ def Builtin_DenseResourceElementsAttr : Builtin_Attr<"DenseResourceElements",
     ```
 
     A dense resource elements attribute is an elements attribute backed by a
-    handle to a builtin dialect resource containing a densely packed array of
-    values. This class provides the low-level attribute, which should only be
+    handle to a dialect resource containing a densely packed array of values.
+    The resource blob may be owned by any dialect, not just BuiltinDialect.
+    This class provides the low-level attribute, which should only be
     interacted with in very generic terms, actual access to the underlying
     resource data is intended to be managed through one of the subclasses, such
     as; `DenseBoolResourceElementsAttr`, `DenseUI64ResourceElementsAttr`,
     `DenseI32ResourceElementsAttr`, `DenseF32ResourceElementsAttr`,
     `DenseF64ResourceElementsAttr`, etc.
 
-    Examples:
-
+    For resources owned by BuiltinDialect (the default):
     ```mlir
     "example.user_op"() {attr = dense_resource<blob1> : tensor<3xi64> } : () -> ()
 
@@ -495,14 +495,27 @@ def Builtin_DenseResourceElementsAttr : Builtin_Attr<"DenseResourceElements",
       }
     #-}
     ```
+
+    For resources owned by a custom dialect:
+    ```mlir
+    "example.user_op"() {attr = dense_resource<"my_dialect::blob1"> : tensor<3xi64> } : () -> ()
+
+    {-#
+    dialect_resources: {
+        my_dialect: {
+          blob1: "0x08000000010000000000000002000000000000000300000000000000"
+        }
+      }
+    #-}
+    ```
   }];
   let parameters = (ins
     AttributeSelfTypeParameter<"", "ShapedType">:$type,
-    ResourceHandleParameter<"DenseResourceElementsHandle">:$rawHandle
+    ResourceHandleParameter<"DenseResourceBlobHandle">:$resourceHandle
   );
   let builders = [
     AttrBuilderWithInferredContext<(ins
-      "ShapedType":$type, "DenseResourceElementsHandle":$handle
+      "ShapedType":$type, "DenseResourceBlobHandle":$handle
     )>,
     /// A builder that inserts a new resource into the builtin dialect's blob
     /// manager using the provided blob. The handle of the inserted blob is used
@@ -514,11 +527,24 @@ def Builtin_DenseResourceElementsAttr : Builtin_Attr<"DenseResourceElements",
     /// generic operations.
     AttrBuilderWithInferredContext<(ins
       "ShapedType":$type, "StringRef":$blobName, "AsmResourceBlob":$blob
+    )>,
+    /// A builder that inserts a new resource into the specified dialect's blob
+    /// manager. The dialect must have registered a
+    /// ResourceBlobManagerDialectInterface.
+    AttrBuilderWithInferredContext<(ins
+      "ShapedType":$type, "StringRef":$blobName, "AsmResourceBlob":$blob,
+      "Dialect *":$dialect
     )>
   ];
   let extraClassDeclaration = [{
     /// BlobAttrInterface method.
     ArrayRef<char> getData();
+
+    /// Legacy accessor. Returns the handle cast to DenseResourceElementsHandle
+    /// (DialectResourceBlobHandle<BuiltinDialect>). Asserts that the owning
+    /// dialect is BuiltinDialect; use getResourceHandle() for dialect-generic
+    /// access.
+    DenseResourceElementsHandle getRawHandle() const;
   }];
 
   let skipDefaultBuilders = 1;

--- a/mlir/include/mlir/IR/BuiltinDialectBytecode.td
+++ b/mlir/include/mlir/IR/BuiltinDialectBytecode.td
@@ -145,10 +145,10 @@ def UnknownLoc : DialectAttribute<(attr)>;
 
 def DenseResourceElementsAttr : DialectAttribute<(attr
   ShapedType:$type,
-  ResourceHandle<"DenseResourceElementsHandle">:$rawHandle
+  ResourceHandle<"DenseResourceBlobHandle">:$resourceHandle
 )> {
   // Note: order of serialization does not match order of builder.
-  let cBuilder = "getChecked<$_resultType>([&]() { return reader.emitError(); }, context, type, *rawHandle)";
+  let cBuilder = "getChecked<$_resultType>([&]() { return reader.emitError(); }, context, type, *resourceHandle)";
 }
 
 let cType = "RankedTensorType" in {

--- a/mlir/include/mlir/IR/DialectResourceBlobManager.h
+++ b/mlir/include/mlir/IR/DialectResourceBlobManager.h
@@ -216,6 +216,55 @@ struct DialectResourceBlobHandle
   }
 };
 
+//===----------------------------------------------------------------------===//
+// DenseResourceBlobHandle
+//===----------------------------------------------------------------------===//
+
+/// A dialect-generic handle to a resource blob entry. Unlike
+/// DialectResourceBlobHandle<T>, this is not parameterized on a specific
+/// dialect, allowing it to reference resource blobs owned by any dialect.
+/// This is used by DenseResourceElementsAttr to decouple the attribute from
+/// BuiltinDialect.
+class DenseResourceBlobHandle : public AsmDialectResourceHandle {
+public:
+  using BlobEntry = DialectResourceBlobManager::BlobEntry;
+
+  DenseResourceBlobHandle() = default;
+
+  /// Direct construction with an explicit dialect owner. Uses its own TypeID.
+  DenseResourceBlobHandle(BlobEntry *entry, Dialect *dialect)
+      : AsmDialectResourceHandle(entry, TypeID::get<DenseResourceBlobHandle>(),
+                                 dialect) {}
+
+  /// Implicit conversion from any dialect-specific blob handle. Preserves the
+  /// original handle's TypeID so that dyn_cast to the original type still
+  /// works.
+  template <typename DialectT>
+  DenseResourceBlobHandle(DialectResourceBlobHandle<DialectT> handle)
+      : AsmDialectResourceHandle(handle) {}
+
+  /// Construct from a type-erased base handle (used by the bytecode reader).
+  DenseResourceBlobHandle(AsmDialectResourceHandle handle)
+      : AsmDialectResourceHandle(handle) {}
+
+  /// Return the underlying blob entry.
+  BlobEntry *getEntry() const {
+    return static_cast<BlobEntry *>(AsmDialectResourceHandle::getResource());
+  }
+
+  /// Return the human-readable string key for this handle.
+  StringRef getKey() const { return getEntry()->getKey(); }
+
+  /// Return the blob referenced by this handle, or nullptr if uninitialized.
+  AsmResourceBlob *getBlob() { return getEntry()->getBlob(); }
+  const AsmResourceBlob *getBlob() const { return getEntry()->getBlob(); }
+
+  /// DenseResourceBlobHandle is a type-erased wrapper that accepts any
+  /// resource handle. Code needing dialect-specific checks should use
+  /// dyn_cast<DialectResourceBlobHandle<SpecificDialect>> instead.
+  static bool classof(const AsmDialectResourceHandle *) { return true; }
+};
+
 } // namespace mlir
 
 #endif // MLIR_IR_DIALECTRESOURCEBLOBMANAGER_H

--- a/mlir/lib/AsmParser/AttributeParser.cpp
+++ b/mlir/lib/AsmParser/AttributeParser.cpp
@@ -1103,15 +1103,56 @@ Attribute Parser::parseDenseResourceElementsAttr(Type attrType) {
   if (parseToken(Token::less, "expected '<' after 'dense_resource'"))
     return nullptr;
 
-  // Parse the resource handle.
-  FailureOr<AsmDialectResourceHandle> rawHandle =
-      parseResourceHandle(getContext()->getLoadedDialect<BuiltinDialect>());
-  if (failed(rawHandle) || parseToken(Token::greater, "expected '>'"))
-    return nullptr;
+  // Parse the resource key. This may be a bare identifier or a quoted string.
+  // If the key contains "::", the prefix identifies the dialect that owns the
+  // resource blob; otherwise BuiltinDialect is used as the default.
+  std::string keyStr;
+  if (failed(parseOptionalKeywordOrString(&keyStr)))
+    return emitError("expected resource key for 'dense_resource'"), nullptr;
 
-  auto *handle = dyn_cast<DenseResourceElementsHandle>(&*rawHandle);
-  if (!handle)
-    return emitError(loc, "invalid `dense_resource` handle type"), nullptr;
+  Dialect *dialect = nullptr;
+  StringRef blobKey = keyStr;
+  size_t sepPos = keyStr.find("::");
+  if (sepPos != std::string::npos) {
+    StringRef dialectName = StringRef(keyStr).take_front(sepPos);
+    blobKey = StringRef(keyStr).drop_front(sepPos + 2);
+    dialect = getContext()->getOrLoadDialect(dialectName);
+    if (!dialect)
+      return emitError(loc, "unknown dialect '" + dialectName +
+                                "' in dense_resource handle"),
+             nullptr;
+  } else {
+    dialect = getContext()->getOrLoadDialect<BuiltinDialect>();
+  }
+
+  // Resolve the resource handle through the dialect's OpAsmDialectInterface.
+  const auto *interface = dyn_cast<OpAsmDialectInterface>(dialect);
+  if (!interface)
+    return emitError(loc, "dialect '" + dialect->getNamespace() +
+                              "' does not support resource handles"),
+           nullptr;
+
+  // Declare the resource and cache the handle.
+  auto &resources = getState().symbols.dialectResources;
+  std::string resolvedKey(blobKey);
+  std::pair<std::string, AsmDialectResourceHandle> &entry =
+      resources[interface][resolvedKey];
+  if (entry.first.empty()) {
+    FailureOr<AsmDialectResourceHandle> result =
+        interface->declareResource(blobKey);
+    if (failed(result))
+      return emitError(loc, "unknown 'resource' key '" + Twine(blobKey) +
+                                "' for dialect '" + dialect->getNamespace() +
+                                "'"),
+             nullptr;
+    entry.first = interface->getResourceKey(*result);
+    entry.second = *result;
+  }
+
+  DenseResourceBlobHandle handle(entry.second);
+
+  if (parseToken(Token::greater, "expected '>'"))
+    return nullptr;
 
   // Parse the type of the attribute if the user didn't provide one.
   SMLoc typeLoc = loc;
@@ -1127,7 +1168,7 @@ Attribute Parser::parseDenseResourceElementsAttr(Type attrType) {
     return nullptr;
   }
 
-  return DenseResourceElementsAttr::get(shapedType, *handle);
+  return DenseResourceElementsAttr::get(shapedType, handle);
 }
 
 /// Shaped type for elements attribute.

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -2572,7 +2572,20 @@ void AsmPrinter::Impl::printAttributeImpl(Attribute attr,
   } else if (auto resourceAttr =
                  llvm::dyn_cast<DenseResourceElementsAttr>(attr)) {
     os << "dense_resource<";
-    printResourceHandle(resourceAttr.getRawHandle());
+    auto handle = resourceAttr.getResourceHandle();
+    Dialect *dialect = handle.getDialect();
+    if (!llvm::isa<BuiltinDialect>(dialect)) {
+      // Print as a quoted "dialect::key" string for non-builtin dialects.
+      os << '"';
+      llvm::printEscapedString(
+          (dialect->getNamespace() + "::" + handle.getKey()).str(), os);
+      os << '"';
+      // Register the resource with the correct dialect for the resource
+      // section.
+      state.getDialectResources()[dialect].insert(handle);
+    } else {
+      printResourceHandle(handle);
+    }
     os << ">";
   } else if (auto locAttr = llvm::dyn_cast<LocationAttr>(attr)) {
     printLocation(locAttr);

--- a/mlir/lib/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/IR/BuiltinAttributes.cpp
@@ -1396,7 +1396,7 @@ bool DenseIntElementsAttr::classof(Attribute attr) {
 
 DenseResourceElementsAttr
 DenseResourceElementsAttr::get(ShapedType type,
-                               DenseResourceElementsHandle handle) {
+                               DenseResourceBlobHandle handle) {
   return Base::get(type.getContext(), type, handle);
 }
 
@@ -1410,8 +1410,32 @@ DenseResourceElementsAttr DenseResourceElementsAttr::get(ShapedType type,
   return get(type, manager.insert(blobName, std::move(blob)));
 }
 
+DenseResourceElementsAttr DenseResourceElementsAttr::get(ShapedType type,
+                                                         StringRef blobName,
+                                                         AsmResourceBlob blob,
+                                                         Dialect *dialect) {
+  assert(dialect && "dialect must not be null");
+  auto *iface =
+      dialect->getRegisteredInterface<ResourceBlobManagerDialectInterface>();
+  assert(iface &&
+         "dialect does not provide ResourceBlobManagerDialectInterface");
+  auto &blobMgr = iface->getBlobManager();
+  auto &entry = blobMgr.insert(blobName, std::move(blob));
+  return get(type, DenseResourceBlobHandle(&entry, dialect));
+}
+
+DenseResourceElementsHandle DenseResourceElementsAttr::getRawHandle() const {
+  auto handle = getResourceHandle();
+  assert(isa<DenseResourceElementsHandle>(
+             static_cast<AsmDialectResourceHandle>(handle)) &&
+         "getRawHandle() called on non-BuiltinDialect resource; use "
+         "getResourceHandle() instead");
+  return DenseResourceElementsHandle(
+      static_cast<AsmDialectResourceHandle>(handle));
+}
+
 ArrayRef<char> DenseResourceElementsAttr::getData() {
-  if (AsmResourceBlob *blob = this->getRawHandle().getBlob())
+  if (AsmResourceBlob *blob = this->getResourceHandle().getBlob())
     return blob->getDataAs<char>();
   return {};
 }
@@ -1492,7 +1516,7 @@ DenseResourceElementsAttrBase<T>::get(ShapedType type, StringRef blobName,
 template <typename T>
 std::optional<ArrayRef<T>>
 DenseResourceElementsAttrBase<T>::tryGetAsArrayRef() const {
-  if (AsmResourceBlob *blob = this->getRawHandle().getBlob())
+  if (AsmResourceBlob *blob = this->getResourceHandle().getBlob())
     return blob->template getDataAs<T>();
   return std::nullopt;
 }

--- a/mlir/lib/IR/BuiltinDialect.cpp
+++ b/mlir/lib/IR/BuiltinDialect.cpp
@@ -74,7 +74,7 @@ struct BuiltinOpAsmDialectInterface : public OpAsmDialectInterface {
 
   std::string
   getResourceKey(const AsmDialectResourceHandle &handle) const override {
-    return cast<DenseResourceElementsHandle>(handle).getKey().str();
+    return DenseResourceBlobHandle(handle).getKey().str();
   }
   FailureOr<AsmDialectResourceHandle>
   declareResource(StringRef key) const final {

--- a/mlir/test/Bytecode/dense-resource-custom-dialect.mlir
+++ b/mlir/test/Bytecode/dense-resource-custom-dialect.mlir
@@ -1,0 +1,30 @@
+// Verify text -> bytecode -> text roundtrip for dense_resource with custom
+// dialect resource handles.
+
+// RUN: mlir-opt -emit-bytecode %s | mlir-opt | FileCheck %s
+
+// CHECK-LABEL: @CustomDialectResources
+module @CustomDialectResources attributes {
+  // Custom dialect resource uses "dialect::key" syntax.
+  // CHECK: bytecode.test1 = dense_resource<"test::custom_blob"> : tensor<3xi64>
+  bytecode.test1 = dense_resource<"test::custom_blob"> : tensor<3xi64>,
+
+  // Builtin dialect resource uses bare key syntax (backward compatible).
+  // CHECK: bytecode.test2 = dense_resource<builtin_blob> : tensor<2xi32>
+  bytecode.test2 = dense_resource<builtin_blob> : tensor<2xi32>
+} {}
+
+// Verify resource data roundtrips correctly for both dialects.
+// CHECK-DAG: custom_blob: "0x08000000010000000000000002000000000000000300000000000000"
+// CHECK-DAG: builtin_blob: "0x04000000AABBCCDDAABBCCDD"
+
+{-#
+  dialect_resources: {
+    test: {
+      custom_blob: "0x08000000010000000000000002000000000000000300000000000000"
+    },
+    builtin: {
+      builtin_blob: "0x04000000AABBCCDDAABBCCDD"
+    }
+  }
+#-}

--- a/mlir/test/IR/dense-resource-custom-dialect.mlir
+++ b/mlir/test/IR/dense-resource-custom-dialect.mlir
@@ -1,0 +1,32 @@
+// Verify text -> text roundtrip.
+// RUN: mlir-opt %s -verify-diagnostics -split-input-file | FileCheck %s
+
+// Test that dense_resource can reference blobs owned by a custom dialect using
+// the "dialect::key" syntax.
+
+// CHECK: attr = dense_resource<"test::blob1"> : tensor<3xi64>
+"test.op_with_result_shape"() {attr = dense_resource<"test::blob1"> : tensor<3xi64> } : () -> ()
+
+{-#
+  dialect_resources: {
+    test: {
+      // CHECK: blob1: "0x08000000010000000000000002000000000000000300000000000000"
+      blob1: "0x08000000010000000000000002000000000000000300000000000000"
+    }
+  }
+#-}
+
+// -----
+
+// Verify that BuiltinDialect resources still work without a prefix.
+// CHECK: attr = dense_resource<blob2> : tensor<2xi32>
+"test.op_with_result_shape"() {attr = dense_resource<blob2> : tensor<2xi32> } : () -> ()
+
+{-#
+  dialect_resources: {
+    builtin: {
+      // CHECK: blob2: "0x0400000001000000020000000300000004000000"
+      blob2: "0x0400000001000000020000000300000004000000"
+    }
+  }
+#-}

--- a/mlir/unittests/IR/BlobManagerTest.cpp
+++ b/mlir/unittests/IR/BlobManagerTest.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "../../test/lib/Dialect/Test/TestDialect.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectResourceBlobManager.h"
 #include "mlir/Parser/Parser.h"
 
@@ -69,6 +71,36 @@ TEST(DialectResourceBlobManagerTest, GetBlobMap) {
       [&](const llvm::StringMap<DialectResourceBlobManager::BlobEntry>
               &blobMap) { blobsArePresent = blobMap.contains("blob1"); });
   ASSERT_TRUE(blobsArePresent);
+}
+
+TEST(DialectResourceBlobManagerTest, CustomDialectResource) {
+  MLIRContext context;
+  context.loadDialect<test::TestDialect>();
+
+  // Create a resource blob owned by the test dialect (not BuiltinDialect).
+  auto *testDialect = context.getLoadedDialect<test::TestDialect>();
+  ASSERT_NE(testDialect, nullptr);
+
+  auto type = RankedTensorType::get({2}, IntegerType::get(&context, 32));
+  std::vector<int32_t> data = {42, 43};
+  AsmResourceBlob blob =
+      HeapAsmResourceBlob::allocateAndCopyInferAlign(ArrayRef<int32_t>(data));
+
+  auto attr = DenseResourceElementsAttr::get(type, "test_blob", std::move(blob),
+                                             testDialect);
+  ASSERT_TRUE(attr);
+
+  // The resource handle should point to the test dialect, not BuiltinDialect.
+  auto handle = attr.getResourceHandle();
+  EXPECT_EQ(handle.getDialect(), testDialect);
+  EXPECT_EQ(handle.getKey(), "test_blob");
+  ASSERT_NE(handle.getBlob(), nullptr);
+
+  // Verify data is accessible.
+  auto blobData = handle.getBlob()->getDataAs<int32_t>();
+  ASSERT_EQ(blobData.size(), 2u);
+  EXPECT_EQ(blobData[0], 42);
+  EXPECT_EQ(blobData[1], 43);
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
DenseResourceElementsAttr was hardcoded to use BuiltinDialect's blob manager via the DenseResourceElementsHandle type alias (DialectResourceBlobHandle<BuiltinDialect>). This prevented custom dialects from owning resource blobs referenced by this attribute.

Introduce DenseResourceBlobHandle, a dialect-generic handle that wraps (BlobEntry*, Dialect*) without being templated on a specific dialect. The attribute's internal parameter is renamed from rawHandle to resourceHandle and now stores DenseResourceBlobHandle, with a new getResourceHandle() accessor. The legacy getRawHandle() is preserved and asserts that the owning dialect is BuiltinDialect.

New factory: DenseResourceElementsAttr::get(type, blobName, blob, dialect) allows inserting a resource into any dialect's blob manager.

Parser/printer extended with "dialect::key" syntax for non-builtin resources (e.g. dense_resource<"test::blob1">), while bare keys continue to default to BuiltinDialect for backward compatibility.