### PR TITLE
[clang][ssaf] Rework NestedBuildNamespaces of TU and LU summaries

### DIFF
--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/EntityLinker.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/EntityLinker.h
@@ -60,7 +60,8 @@ private:
   /// \param Linkage The linkage determining namespace resolution strategy.
   /// \returns The resolved LU EntityId.
   EntityId resolveEntity(const EntityName &OldName,
-                         const EntityLinkage &Linkage);
+                         const EntityLinkage &Linkage,
+                         const NestedBuildNamespace &TUNamespace);
 
   /// Resolves each TU EntityId to its corresponding LU EntityId.
   ///

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat.h
@@ -109,19 +109,30 @@ private:
   Array nestedBuildNamespaceToJSON(const NestedBuildNamespace &NBN) const;
 
   llvm::Expected<EntityName>
-  entityNameFromJSON(const Object &EntityNameObject) const;
-  Object entityNameToJSON(const EntityName &EN) const;
+  tuEntityNameFromJSON(const Object &EntityNameObject) const;
+  Object tuEntityNameToJSON(const EntityName &EN) const;
+
+  llvm::Expected<EntityName>
+  luEntityNameFromJSON(const Object &EntityNameObject) const;
+  Object luEntityNameToJSON(const EntityName &EN) const;
 
   llvm::Expected<EntityLinkage>
   entityLinkageFromJSON(const Object &EntityLinkageObject) const;
   Object entityLinkageToJSON(const EntityLinkage &EL) const;
 
   llvm::Expected<std::pair<EntityName, EntityId>>
-  entityIdTableEntryFromJSON(const Object &EntityIdTableEntryObject) const;
+  tuEntityIdTableEntryFromJSON(const Object &EntityIdTableEntryObject) const;
   llvm::Expected<EntityIdTable>
-  entityIdTableFromJSON(const Array &EntityIdTableArray) const;
-  Object entityIdTableEntryToJSON(const EntityName &EN, EntityId EI) const;
-  Array entityIdTableToJSON(const EntityIdTable &IdTable) const;
+  tuEntityIdTableFromJSON(const Array &EntityIdTableArray) const;
+  Object tuEntityIdTableEntryToJSON(const EntityName &EN, EntityId EI) const;
+  Array tuEntityIdTableToJSON(const EntityIdTable &IdTable) const;
+
+  llvm::Expected<std::pair<EntityName, EntityId>>
+  luEntityIdTableEntryFromJSON(const Object &EntityIdTableEntryObject) const;
+  llvm::Expected<EntityIdTable>
+  luEntityIdTableFromJSON(const Array &EntityIdTableArray) const;
+  Object luEntityIdTableEntryToJSON(const EntityName &EN, EntityId EI) const;
+  Array luEntityIdTableToJSON(const EntityIdTable &IdTable) const;
 
   llvm::Expected<std::pair<EntityId, EntityLinkage>>
   linkageTableEntryFromJSON(const Object &LinkageTableEntryObject) const;

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/EntityLinker/EntityLinker.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/EntityLinker/EntityLinker.cpp
@@ -56,8 +56,8 @@ resolveNamespace(const NestedBuildNamespace &LUNamespace,
   case EntityLinkageType::Internal:
     // Qualify with the TU namespace first (to disambiguate across TUs),
     // then with the LU namespace.
-    return EntityNamespace.makeQualified(TUNamespace).makeQualified(
-        LUNamespace);
+    return EntityNamespace.makeQualified(TUNamespace)
+        .makeQualified(LUNamespace);
   case EntityLinkageType::External:
     return NestedBuildNamespace(LUNamespace);
   }
@@ -69,8 +69,7 @@ EntityId EntityLinker::resolveEntity(const EntityName &OldName,
                                      const EntityLinkage &Linkage,
                                      const NestedBuildNamespace &TUNamespace) {
   NestedBuildNamespace NewNamespace = resolveNamespace(
-      Output.LUNamespace, TUNamespace, OldName.Namespace,
-      Linkage.getLinkage());
+      Output.LUNamespace, TUNamespace, OldName.Namespace, Linkage.getLinkage());
 
   EntityName NewName(OldName.USR, OldName.Suffix, NewNamespace);
 
@@ -109,8 +108,8 @@ EntityLinker::resolve(const TUSummaryEncoding &Summary) {
 
     const EntityLinkage &Linkage = Iter->second;
 
-    EntityId NewId =
-        resolveEntity(OldName, Linkage, NestedBuildNamespace(Summary.TUNamespace));
+    EntityId NewId = resolveEntity(OldName, Linkage,
+                                   NestedBuildNamespace(Summary.TUNamespace));
 
     auto [_, Inserted] = EntityResolutionTable.insert({OldId, NewId});
     if (!Inserted) {

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/EntityLinker/EntityLinker.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/EntityLinker/EntityLinker.cpp
@@ -48,12 +48,16 @@ static constexpr const char *DuplicateTUNamespace =
 
 static NestedBuildNamespace
 resolveNamespace(const NestedBuildNamespace &LUNamespace,
+                 const NestedBuildNamespace &TUNamespace,
                  const NestedBuildNamespace &EntityNamespace,
                  EntityLinkageType Linkage) {
   switch (Linkage) {
   case EntityLinkageType::None:
   case EntityLinkageType::Internal:
-    return EntityNamespace.makeQualified(LUNamespace);
+    // Qualify with the TU namespace first (to disambiguate across TUs),
+    // then with the LU namespace.
+    return EntityNamespace.makeQualified(TUNamespace).makeQualified(
+        LUNamespace);
   case EntityLinkageType::External:
     return NestedBuildNamespace(LUNamespace);
   }
@@ -62,9 +66,11 @@ resolveNamespace(const NestedBuildNamespace &LUNamespace,
 }
 
 EntityId EntityLinker::resolveEntity(const EntityName &OldName,
-                                     const EntityLinkage &Linkage) {
+                                     const EntityLinkage &Linkage,
+                                     const NestedBuildNamespace &TUNamespace) {
   NestedBuildNamespace NewNamespace = resolveNamespace(
-      Output.LUNamespace, OldName.Namespace, Linkage.getLinkage());
+      Output.LUNamespace, TUNamespace, OldName.Namespace,
+      Linkage.getLinkage());
 
   EntityName NewName(OldName.USR, OldName.Suffix, NewNamespace);
 
@@ -103,7 +109,8 @@ EntityLinker::resolve(const TUSummaryEncoding &Summary) {
 
     const EntityLinkage &Linkage = Iter->second;
 
-    EntityId NewId = resolveEntity(OldName, Linkage);
+    EntityId NewId =
+        resolveEntity(OldName, Linkage, NestedBuildNamespace(Summary.TUNamespace));
 
     auto [_, Inserted] = EntityResolutionTable.insert({OldId, NewId});
     if (!Inserted) {

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/JSONFormatImpl.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/JSONFormatImpl.cpp
@@ -550,8 +550,8 @@ Object JSONFormat::luEntityIdTableEntryToJSON(const EntityName &EN,
 /// (EntityName, EntityId) pair.
 static llvm::Expected<EntityIdTable> entityIdTableFromJSONImpl(
     const Array &EntityIdTableArray,
-    llvm::function_ref<llvm::Expected<std::pair<EntityName, EntityId>>(
-        const Object &)>
+    llvm::function_ref<
+        llvm::Expected<std::pair<EntityName, EntityId>>(const Object &)>
         EntryReader,
     llvm::function_ref<std::map<EntityName, EntityId> &(EntityIdTable &)>
         GetEntities) {
@@ -569,8 +569,7 @@ static llvm::Expected<EntityIdTable> entityIdTableFromJSONImpl(
           .build();
     }
 
-    auto ExpectedEntityIdTableEntry =
-        EntryReader(*OptEntityIdTableEntryObject);
+    auto ExpectedEntityIdTableEntry = EntryReader(*OptEntityIdTableEntryObject);
     if (!ExpectedEntityIdTableEntry) {
       return ErrorBuilder::wrap(ExpectedEntityIdTableEntry.takeError())
           .context(ErrorMessages::ReadingFromIndex, "EntityIdTable entry",

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/JSONFormatImpl.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/JSONFormatImpl.cpp
@@ -311,8 +311,10 @@ Array JSONFormat::nestedBuildNamespaceToJSON(
 // EntityName
 //----------------------------------------------------------------------------
 
-llvm::Expected<EntityName>
-JSONFormat::entityNameFromJSON(const Object &EntityNameObject) const {
+/// Reads "usr" and "suffix" fields from an EntityName JSON object.
+/// Shared core logic for both TU and LU entity name deserialization.
+static llvm::Expected<std::pair<llvm::StringRef, llvm::StringRef>>
+entityNameCoreFromJSON(const Object &EntityNameObject) {
   const auto OptUSR = EntityNameObject.getString("usr");
   if (!OptUSR) {
     return ErrorBuilder::create(std::errc::invalid_argument,
@@ -328,6 +330,34 @@ JSONFormat::entityNameFromJSON(const Object &EntityNameObject) const {
                                 "Suffix", "suffix", "string")
         .build();
   }
+
+  return std::make_pair(*OptUSR, *OptSuffix);
+}
+
+llvm::Expected<EntityName>
+JSONFormat::tuEntityNameFromJSON(const Object &EntityNameObject) const {
+  auto ExpectedCore = entityNameCoreFromJSON(EntityNameObject);
+  if (!ExpectedCore)
+    return ExpectedCore.takeError();
+
+  auto [USR, Suffix] = *ExpectedCore;
+  return EntityName{USR, Suffix, NestedBuildNamespace()};
+}
+
+Object JSONFormat::tuEntityNameToJSON(const EntityName &EN) const {
+  Object Result;
+  Result["usr"] = getUSR(EN);
+  Result["suffix"] = getSuffix(EN);
+  return Result;
+}
+
+llvm::Expected<EntityName>
+JSONFormat::luEntityNameFromJSON(const Object &EntityNameObject) const {
+  auto ExpectedCore = entityNameCoreFromJSON(EntityNameObject);
+  if (!ExpectedCore)
+    return ExpectedCore.takeError();
+
+  auto [USR, Suffix] = *ExpectedCore;
 
   const Array *OptNamespaceArray = EntityNameObject.getArray("namespace");
   if (!OptNamespaceArray) {
@@ -345,10 +375,10 @@ JSONFormat::entityNameFromJSON(const Object &EntityNameObject) const {
         .build();
   }
 
-  return EntityName{*OptUSR, *OptSuffix, std::move(*ExpectedNamespace)};
+  return EntityName{USR, Suffix, std::move(*ExpectedNamespace)};
 }
 
-Object JSONFormat::entityNameToJSON(const EntityName &EN) const {
+Object JSONFormat::luEntityNameToJSON(const EntityName &EN) const {
   Object Result;
   Result["usr"] = getUSR(EN);
   Result["suffix"] = getSuffix(EN);
@@ -411,26 +441,10 @@ Object JSONFormat::entityLinkageToJSON(const EntityLinkage &EL) const {
 // EntityIdTableEntry
 //----------------------------------------------------------------------------
 
-llvm::Expected<std::pair<EntityName, EntityId>>
-JSONFormat::entityIdTableEntryFromJSON(
-    const Object &EntityIdTableEntryObject) const {
-
-  const Object *OptEntityNameObject =
-      EntityIdTableEntryObject.getObject("name");
-  if (!OptEntityNameObject) {
-    return ErrorBuilder::create(std::errc::invalid_argument,
-                                ErrorMessages::FailedToReadObjectAtField,
-                                "EntityName", "name", "object")
-        .build();
-  }
-
-  auto ExpectedEntityName = entityNameFromJSON(*OptEntityNameObject);
-  if (!ExpectedEntityName) {
-    return ErrorBuilder::wrap(ExpectedEntityName.takeError())
-        .context(ErrorMessages::ReadingFromField, "EntityName", "name")
-        .build();
-  }
-
+/// Shared logic for reading the "id" field from an EntityIdTableEntry object.
+static llvm::Expected<EntityId>
+entityIdTableEntryIdFromJSON(const Object &EntityIdTableEntryObject,
+                             llvm::function_ref<EntityId(uint64_t)> MakeId) {
   const Value *EntityIdIntValue = EntityIdTableEntryObject.get("id");
   if (!EntityIdIntValue) {
     return ErrorBuilder::create(std::errc::invalid_argument,
@@ -450,16 +464,80 @@ JSONFormat::entityIdTableEntryFromJSON(
         .build();
   }
 
-  EntityId EI = entityIdFromJSON(*OptEntityIdInt);
-
-  return std::make_pair(std::move(*ExpectedEntityName), std::move(EI));
+  return MakeId(*OptEntityIdInt);
 }
 
-Object JSONFormat::entityIdTableEntryToJSON(const EntityName &EN,
-                                            EntityId EI) const {
+llvm::Expected<std::pair<EntityName, EntityId>>
+JSONFormat::tuEntityIdTableEntryFromJSON(
+    const Object &EntityIdTableEntryObject) const {
+
+  const Object *OptEntityNameObject =
+      EntityIdTableEntryObject.getObject("name");
+  if (!OptEntityNameObject) {
+    return ErrorBuilder::create(std::errc::invalid_argument,
+                                ErrorMessages::FailedToReadObjectAtField,
+                                "EntityName", "name", "object")
+        .build();
+  }
+
+  auto ExpectedEntityName = tuEntityNameFromJSON(*OptEntityNameObject);
+  if (!ExpectedEntityName) {
+    return ErrorBuilder::wrap(ExpectedEntityName.takeError())
+        .context(ErrorMessages::ReadingFromField, "EntityName", "name")
+        .build();
+  }
+
+  auto ExpectedId = entityIdTableEntryIdFromJSON(
+      EntityIdTableEntryObject,
+      [this](uint64_t V) { return entityIdFromJSON(V); });
+  if (!ExpectedId)
+    return ExpectedId.takeError();
+
+  return std::make_pair(std::move(*ExpectedEntityName), std::move(*ExpectedId));
+}
+
+Object JSONFormat::tuEntityIdTableEntryToJSON(const EntityName &EN,
+                                              EntityId EI) const {
   Object Entry;
   Entry["id"] = entityIdToJSON(EI);
-  Entry["name"] = entityNameToJSON(EN);
+  Entry["name"] = tuEntityNameToJSON(EN);
+  return Entry;
+}
+
+llvm::Expected<std::pair<EntityName, EntityId>>
+JSONFormat::luEntityIdTableEntryFromJSON(
+    const Object &EntityIdTableEntryObject) const {
+
+  const Object *OptEntityNameObject =
+      EntityIdTableEntryObject.getObject("name");
+  if (!OptEntityNameObject) {
+    return ErrorBuilder::create(std::errc::invalid_argument,
+                                ErrorMessages::FailedToReadObjectAtField,
+                                "EntityName", "name", "object")
+        .build();
+  }
+
+  auto ExpectedEntityName = luEntityNameFromJSON(*OptEntityNameObject);
+  if (!ExpectedEntityName) {
+    return ErrorBuilder::wrap(ExpectedEntityName.takeError())
+        .context(ErrorMessages::ReadingFromField, "EntityName", "name")
+        .build();
+  }
+
+  auto ExpectedId = entityIdTableEntryIdFromJSON(
+      EntityIdTableEntryObject,
+      [this](uint64_t V) { return entityIdFromJSON(V); });
+  if (!ExpectedId)
+    return ExpectedId.takeError();
+
+  return std::make_pair(std::move(*ExpectedEntityName), std::move(*ExpectedId));
+}
+
+Object JSONFormat::luEntityIdTableEntryToJSON(const EntityName &EN,
+                                              EntityId EI) const {
+  Object Entry;
+  Entry["id"] = entityIdToJSON(EI);
+  Entry["name"] = luEntityNameToJSON(EN);
   return Entry;
 }
 
@@ -467,10 +545,18 @@ Object JSONFormat::entityIdTableEntryToJSON(const EntityName &EN,
 // EntityIdTable
 //----------------------------------------------------------------------------
 
-llvm::Expected<EntityIdTable>
-JSONFormat::entityIdTableFromJSON(const Array &EntityIdTableArray) const {
+/// Shared logic for deserializing an EntityIdTable from a JSON array.
+/// \p EntryReader is called for each entry object to produce an
+/// (EntityName, EntityId) pair.
+static llvm::Expected<EntityIdTable> entityIdTableFromJSONImpl(
+    const Array &EntityIdTableArray,
+    llvm::function_ref<llvm::Expected<std::pair<EntityName, EntityId>>(
+        const Object &)>
+        EntryReader,
+    llvm::function_ref<std::map<EntityName, EntityId> &(EntityIdTable &)>
+        GetEntities) {
   EntityIdTable IdTable;
-  std::map<EntityName, EntityId> &Entities = getEntities(IdTable);
+  std::map<EntityName, EntityId> &Entities = GetEntities(IdTable);
 
   for (const auto &[Index, EntityIdTableEntryValue] :
        llvm::enumerate(EntityIdTableArray)) {
@@ -484,7 +570,7 @@ JSONFormat::entityIdTableFromJSON(const Array &EntityIdTableArray) const {
     }
 
     auto ExpectedEntityIdTableEntry =
-        entityIdTableEntryFromJSON(*OptEntityIdTableEntryObject);
+        EntryReader(*OptEntityIdTableEntryObject);
     if (!ExpectedEntityIdTableEntry) {
       return ErrorBuilder::wrap(ExpectedEntityIdTableEntry.takeError())
           .context(ErrorMessages::ReadingFromIndex, "EntityIdTable entry",
@@ -506,14 +592,47 @@ JSONFormat::entityIdTableFromJSON(const Array &EntityIdTableArray) const {
   return IdTable;
 }
 
-Array JSONFormat::entityIdTableToJSON(const EntityIdTable &IdTable) const {
+llvm::Expected<EntityIdTable>
+JSONFormat::tuEntityIdTableFromJSON(const Array &EntityIdTableArray) const {
+  return entityIdTableFromJSONImpl(
+      EntityIdTableArray,
+      [this](const Object &O) { return tuEntityIdTableEntryFromJSON(O); },
+      [](EntityIdTable &T) -> std::map<EntityName, EntityId> & {
+        return getEntities(T);
+      });
+}
+
+Array JSONFormat::tuEntityIdTableToJSON(const EntityIdTable &IdTable) const {
   Array EntityIdTableArray;
   const auto &Entities = getEntities(IdTable);
   EntityIdTableArray.reserve(Entities.size());
 
   for (const auto &[EntityName, EntityId] : Entities) {
     EntityIdTableArray.push_back(
-        entityIdTableEntryToJSON(EntityName, EntityId));
+        tuEntityIdTableEntryToJSON(EntityName, EntityId));
+  }
+
+  return EntityIdTableArray;
+}
+
+llvm::Expected<EntityIdTable>
+JSONFormat::luEntityIdTableFromJSON(const Array &EntityIdTableArray) const {
+  return entityIdTableFromJSONImpl(
+      EntityIdTableArray,
+      [this](const Object &O) { return luEntityIdTableEntryFromJSON(O); },
+      [](EntityIdTable &T) -> std::map<EntityName, EntityId> & {
+        return getEntities(T);
+      });
+}
+
+Array JSONFormat::luEntityIdTableToJSON(const EntityIdTable &IdTable) const {
+  Array EntityIdTableArray;
+  const auto &Entities = getEntities(IdTable);
+  EntityIdTableArray.reserve(Entities.size());
+
+  for (const auto &[EntityName, EntityId] : Entities) {
+    EntityIdTableArray.push_back(
+        luEntityIdTableEntryToJSON(EntityName, EntityId));
   }
 
   return EntityIdTableArray;

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/LUSummary.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/LUSummary.cpp
@@ -67,7 +67,7 @@ llvm::Expected<LUSummary> JSONFormat::readLUSummary(llvm::StringRef Path) {
           .build();
     }
 
-    auto ExpectedIdTable = entityIdTableFromJSON(*IdTableArray);
+    auto ExpectedIdTable = luEntityIdTableFromJSON(*IdTableArray);
     if (!ExpectedIdTable) {
       return ErrorBuilder::wrap(ExpectedIdTable.takeError())
           .context(ErrorMessages::ReadingFromField, "IdTable", "id_table")
@@ -140,7 +140,7 @@ llvm::Error JSONFormat::writeLUSummary(const LUSummary &S,
 
   RootObject["lu_namespace"] = nestedBuildNamespaceToJSON(getLUNamespace(S));
 
-  RootObject["id_table"] = entityIdTableToJSON(getIdTable(S));
+  RootObject["id_table"] = luEntityIdTableToJSON(getIdTable(S));
 
   RootObject["linkage_table"] = linkageTableToJSON(getLinkageTable(S));
 

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/LUSummaryEncoding.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/LUSummaryEncoding.cpp
@@ -68,7 +68,7 @@ JSONFormat::readLUSummaryEncoding(llvm::StringRef Path) {
           .build();
     }
 
-    auto ExpectedIdTable = entityIdTableFromJSON(*IdTableArray);
+    auto ExpectedIdTable = luEntityIdTableFromJSON(*IdTableArray);
     if (!ExpectedIdTable) {
       return ErrorBuilder::wrap(ExpectedIdTable.takeError())
           .context(ErrorMessages::ReadingFromField, "IdTable", "id_table")
@@ -143,7 +143,7 @@ JSONFormat::writeLUSummaryEncoding(const LUSummaryEncoding &SummaryEncoding,
   RootObject["lu_namespace"] =
       nestedBuildNamespaceToJSON(getLUNamespace(SummaryEncoding));
 
-  RootObject["id_table"] = entityIdTableToJSON(getIdTable(SummaryEncoding));
+  RootObject["id_table"] = luEntityIdTableToJSON(getIdTable(SummaryEncoding));
 
   RootObject["linkage_table"] =
       linkageTableToJSON(getLinkageTable(SummaryEncoding));

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/TUSummary.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/TUSummary.cpp
@@ -67,7 +67,7 @@ llvm::Expected<TUSummary> JSONFormat::readTUSummary(llvm::StringRef Path) {
           .build();
     }
 
-    auto ExpectedIdTable = entityIdTableFromJSON(*IdTableArray);
+    auto ExpectedIdTable = tuEntityIdTableFromJSON(*IdTableArray);
     if (!ExpectedIdTable) {
       return ErrorBuilder::wrap(ExpectedIdTable.takeError())
           .context(ErrorMessages::ReadingFromField, "IdTable", "id_table")
@@ -140,7 +140,7 @@ llvm::Error JSONFormat::writeTUSummary(const TUSummary &S,
 
   RootObject["tu_namespace"] = buildNamespaceToJSON(getTUNamespace(S));
 
-  RootObject["id_table"] = entityIdTableToJSON(getIdTable(S));
+  RootObject["id_table"] = tuEntityIdTableToJSON(getIdTable(S));
 
   RootObject["linkage_table"] = linkageTableToJSON(getLinkageTable(S));
 

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/TUSummaryEncoding.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/TUSummaryEncoding.cpp
@@ -68,7 +68,7 @@ JSONFormat::readTUSummaryEncoding(llvm::StringRef Path) {
           .build();
     }
 
-    auto ExpectedIdTable = entityIdTableFromJSON(*IdTableArray);
+    auto ExpectedIdTable = tuEntityIdTableFromJSON(*IdTableArray);
     if (!ExpectedIdTable) {
       return ErrorBuilder::wrap(ExpectedIdTable.takeError())
           .context(ErrorMessages::ReadingFromField, "IdTable", "id_table")
@@ -143,7 +143,7 @@ JSONFormat::writeTUSummaryEncoding(const TUSummaryEncoding &SummaryEncoding,
   RootObject["tu_namespace"] =
       buildNamespaceToJSON(getTUNamespace(SummaryEncoding));
 
-  RootObject["id_table"] = entityIdTableToJSON(getIdTable(SummaryEncoding));
+  RootObject["id_table"] = tuEntityIdTableToJSON(getIdTable(SummaryEncoding));
 
   RootObject["linkage_table"] =
       linkageTableToJSON(getLinkageTable(SummaryEncoding));

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/WPASuite.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat/WPASuite.cpp
@@ -150,7 +150,7 @@ llvm::Expected<WPASuite> JSONFormat::readWPASuite(llvm::StringRef Path) {
           .build();
     }
 
-    auto ExpectedIdTable = entityIdTableFromJSON(*IdTableArray);
+    auto ExpectedIdTable = luEntityIdTableFromJSON(*IdTableArray);
     if (!ExpectedIdTable) {
       return ErrorBuilder::wrap(ExpectedIdTable.takeError())
           .context(ErrorMessages::ReadingFromField, "IdTable", "id_table")
@@ -189,7 +189,7 @@ llvm::Error JSONFormat::writeWPASuite(const WPASuite &Suite,
                                       llvm::StringRef Path) {
   Object RootObject;
 
-  RootObject["id_table"] = entityIdTableToJSON(getIdTable(Suite));
+  RootObject["id_table"] = luEntityIdTableToJSON(getIdTable(Suite));
 
   auto ExpectedResults = analysisResultMapToJSON(getData(Suite));
   if (!ExpectedResults) {

--- a/clang/test/Analysis/Scalable/UnsafeBufferUsage/Inputs/tu-summary-bad-element.json
+++ b/clang/test/Analysis/Scalable/UnsafeBufferUsage/Inputs/tu-summary-bad-element.json
@@ -18,7 +18,6 @@
     {
       "id": 2,
       "name": {
-        "namespace": [],
         "suffix": "",
         "usr": "c:@F@foo#***I#*S0_#I#"
       }
@@ -26,7 +25,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [],
         "suffix": "1",
         "usr": "c:@F@foo#***I#*S0_#I#"
       }

--- a/clang/test/Analysis/Scalable/UnsafeBufferUsage/Inputs/tu-summary-bad-ptr-level.json
+++ b/clang/test/Analysis/Scalable/UnsafeBufferUsage/Inputs/tu-summary-bad-ptr-level.json
@@ -23,7 +23,6 @@
     {
       "id": 2,
       "name": {
-        "namespace": [],
         "suffix": "",
         "usr": "c:@F@foo#***I#*S0_#I#"
       }
@@ -31,7 +30,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [],
         "suffix": "1",
         "usr": "c:@F@foo#***I#*S0_#I#"
       }

--- a/clang/test/Analysis/Scalable/UnsafeBufferUsage/Inputs/tu-summary-no-key.json
+++ b/clang/test/Analysis/Scalable/UnsafeBufferUsage/Inputs/tu-summary-no-key.json
@@ -23,7 +23,6 @@
     {
       "id": 2,
       "name": {
-        "namespace": [],
         "suffix": "",
         "usr": "c:@F@foo#***I#*S0_#I#"
       }
@@ -31,7 +30,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [],
         "suffix": "1",
         "usr": "c:@F@foo#***I#*S0_#I#"
       }

--- a/clang/test/Analysis/Scalable/UnsafeBufferUsage/Inputs/tu-summary.json
+++ b/clang/test/Analysis/Scalable/UnsafeBufferUsage/Inputs/tu-summary.json
@@ -59,7 +59,6 @@
     {
       "id": 2,
       "name": {
-        "namespace": [],
         "suffix": "",
         "usr": "c:@F@foo#***I#*S0_#I#"
       }
@@ -67,7 +66,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [],
         "suffix": "1",
         "usr": "c:@F@foo#***I#*S0_#I#"
       }
@@ -75,7 +73,6 @@
     {
       "id": 1,
       "name": {
-        "namespace": [],
         "suffix": "2",
         "usr": "c:@F@foo#***I#*S0_#I#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/invalid-direct-callee-element.json
+++ b/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/invalid-direct-callee-element.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "test.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@foo#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/invalid-direct-callee-id.json
+++ b/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/invalid-direct-callee-id.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "test.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@foo#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-def-col.json
+++ b/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-def-col.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "test.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@foo#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-def-file.json
+++ b/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-def-file.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "test.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@foo#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-def-line.json
+++ b/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-def-line.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "test.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@foo#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-def.json
+++ b/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-def.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "test.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@foo#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-direct-callees.json
+++ b/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-direct-callees.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "test.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@foo#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-pretty-name.json
+++ b/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-pretty-name.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "test.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@foo#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-virtual-callees.json
+++ b/clang/test/Analysis/Scalable/ssaf-format/Inputs/CallGraph/missing-virtual-callees.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "test.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@foo#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-linker/Inputs/tu-1.json
+++ b/clang/test/Analysis/Scalable/ssaf-linker/Inputs/tu-1.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "tu1.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@shared_ext#"
       }
@@ -20,12 +14,6 @@
     {
       "id": 1,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "tu1.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@shared_int#"
       }
@@ -33,12 +21,6 @@
     {
       "id": 2,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "tu1.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@shared_none#"
       }
@@ -46,12 +28,6 @@
     {
       "id": 3,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "tu1.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@unique_ext_tu1#"
       }
@@ -59,12 +35,6 @@
     {
       "id": 4,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "tu1.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@unique_int_tu1#"
       }
@@ -72,12 +42,6 @@
     {
       "id": 5,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "tu1.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@unique_none_tu1#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-linker/Inputs/tu-2.json
+++ b/clang/test/Analysis/Scalable/ssaf-linker/Inputs/tu-2.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "tu2.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@shared_ext#"
       }
@@ -20,12 +14,6 @@
     {
       "id": 1,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "tu2.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@shared_int#"
       }
@@ -33,12 +21,6 @@
     {
       "id": 2,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "tu2.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@shared_none#"
       }
@@ -46,12 +28,6 @@
     {
       "id": 3,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "tu2.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@unique_ext_tu2#"
       }
@@ -59,12 +35,6 @@
     {
       "id": 4,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "tu2.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@unique_int_tu2#"
       }
@@ -72,12 +42,6 @@
     {
       "id": 5,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "tu2.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@unique_none_tu2#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-linker/Inputs/tu-invalid-entity-id-multikey.json
+++ b/clang/test/Analysis/Scalable/ssaf-linker/Inputs/tu-invalid-entity-id-multikey.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "invalid-entity-id-multikey.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@foo#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-linker/Inputs/tu-invalid-entity-id-ref.json
+++ b/clang/test/Analysis/Scalable/ssaf-linker/Inputs/tu-invalid-entity-id-ref.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "invalid-entity-id-ref.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@foo#"
       }

--- a/clang/test/Analysis/Scalable/ssaf-linker/Inputs/tu-invalid-entity-id-value.json
+++ b/clang/test/Analysis/Scalable/ssaf-linker/Inputs/tu-invalid-entity-id-value.json
@@ -7,12 +7,6 @@
     {
       "id": 0,
       "name": {
-        "namespace": [
-          {
-            "kind": "CompilationUnit",
-            "name": "invalid-entity-id-value.cpp"
-          }
-        ],
         "suffix": "",
         "usr": "c:@F@foo#"
       }

--- a/clang/unittests/ScalableStaticAnalysisFramework/EntityLinkerTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/EntityLinkerTest.cpp
@@ -86,7 +86,7 @@ protected:
 
   EntityId addEntity(TUSummaryEncoding &TU, llvm::StringRef USR,
                      EntityLinkage Linkage) {
-    EntityName Name(USR, "", NestedBuildNamespace(getTUNamespace(TU)));
+    EntityName Name(USR, "", NestedBuildNamespace());
     EntityId Id = getIdTable(TU).getId(Name);
     getLinkageTable(TU).insert({Id, Linkage});
     return Id;
@@ -630,6 +630,35 @@ TEST_F(EntityLinkerTest, RejectsDuplicateTUSummary) {
                     llvm::FailedWithMessage(
                         HasSubstr("failed to link TU summary: duplicate "
                                   "BuildNamespace(CompilationUnit, TU)")));
+}
+
+// Reproduces a crash when linking internal-linkage entities
+// (e.g. "static inline" functions) that share the same USR across TUs.
+TEST_F(EntityLinkerTest, InternalLinkageWithEmptyNamespaceAcrossTUs) {
+  constexpr auto LinkUnit = BuildNamespaceKind::LinkUnit;
+  constexpr auto CompilationUnit = BuildNamespaceKind::CompilationUnit;
+  EntityLinker Linker(NestedBuildNamespace{BuildNamespace(LinkUnit, "LU")});
+
+  auto TU1 = createTUSummaryEncoding(CompilationUnit, "TU1");
+  addEntity(*TU1, "some_static_inline", InternalLinkage);
+  ASSERT_THAT_ERROR(Linker.link(std::move(TU1)), llvm::Succeeded());
+
+  auto TU2 = createTUSummaryEncoding(CompilationUnit, "TU2");
+  addEntity(*TU2, "some_static_inline", InternalLinkage);
+  ASSERT_THAT_ERROR(Linker.link(std::move(TU2)), llvm::Succeeded());
+
+  // Check that the two internal symbols are not merged.
+  const auto Output = std::move(Linker).getOutput();
+  const auto &IdTable = getIdTable(Output);
+
+  NestedBuildNamespace TU1NS{{{CompilationUnit, "TU1"}, {LinkUnit, "LU"}}};
+  NestedBuildNamespace TU2NS{{{CompilationUnit, "TU2"}, {LinkUnit, "LU"}}};
+  EntityName ExpectedTU1Name("some_static_inline", "", TU1NS);
+  EntityName ExpectedTU2Name("some_static_inline", "", TU2NS);
+
+  ASSERT_EQ(IdTable.count(), 2u);
+  EXPECT_THAT(IdTable, ContainsEntity(ExpectedTU1Name));
+  EXPECT_THAT(IdTable, ContainsEntity(ExpectedTU2Name));
 }
 
 } // namespace

--- a/clang/unittests/ScalableStaticAnalysisFramework/Serialization/JSONFormatTest/LUSummaryTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Serialization/JSONFormatTest/LUSummaryTest.cpp
@@ -816,7 +816,7 @@ TEST_P(LUSummaryTest, NamespaceElementMissingName) {
 }
 
 // ============================================================================
-// JSONFormat::entityNameFromJSON() Error Tests
+// JSONFormat::luEntityNameFromJSON() Error Tests
 // ============================================================================
 
 TEST_P(LUSummaryTest, EntityNameMissingUSR) {
@@ -944,7 +944,7 @@ TEST_P(LUSummaryTest, EntityNameMissingNamespace) {
 }
 
 // ============================================================================
-// JSONFormat::entityIdTableEntryFromJSON() Error Tests
+// JSONFormat::luEntityIdTableEntryFromJSON() Error Tests
 // ============================================================================
 
 TEST_P(LUSummaryTest, IDTableEntryMissingID) {
@@ -1056,7 +1056,7 @@ TEST_P(LUSummaryTest, IDTableEntryIDNotUInt64) {
 }
 
 // ============================================================================
-// JSONFormat::entityIdTableFromJSON() Error Tests
+// JSONFormat::luEntityIdTableFromJSON() Error Tests
 // ============================================================================
 
 TEST_P(LUSummaryTest, IDTableNotArray) {

--- a/clang/unittests/ScalableStaticAnalysisFramework/Serialization/JSONFormatTest/TUSummaryTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Serialization/JSONFormatTest/TUSummaryTest.cpp
@@ -446,13 +446,7 @@ TEST_P(TUSummaryTest, LinkageTableMissingId) {
         "id": 0,
         "name": {
           "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       }
     ],
@@ -480,13 +474,7 @@ TEST_P(TUSummaryTest, LinkageTableDuplicateId) {
         "id": 0,
         "name": {
           "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       }
     ],
@@ -580,176 +568,7 @@ TEST_P(TUSummaryTest, MissingName) {
 }
 
 // ============================================================================
-// JSONFormat::nestedBuildNamespaceFromJSON() Error Tests
-// ============================================================================
-
-TEST_P(TUSummaryTest, NamespaceElementNotObject) {
-  auto Result = readFromString(R"({
-    "tu_namespace": {
-      "kind": "CompilationUnit",
-      "name": "test.cpp"
-    },
-    "id_table": [
-      {
-        "id": 0,
-        "name": {
-          "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": ["invalid"]
-        }
-      }
-    ],
-    "linkage_table": [
-      {
-        "id": 0,
-        "linkage": { "type": "None" }
-      }
-    ],
-    "data": []
-  })");
-
-  EXPECT_THAT_ERROR(
-      std::move(Result),
-      FailedWithMessage(AllOf(
-          HasSubstr("reading TUSummary from file"),
-          HasSubstr("reading IdTable from field 'id_table'"),
-          HasSubstr("reading EntityIdTable entry from index '0'"),
-          HasSubstr("reading EntityName from field 'name'"),
-          HasSubstr("reading NestedBuildNamespace from field 'namespace'"),
-          HasSubstr("failed to read BuildNamespace from index '0'"),
-          HasSubstr("expected JSON object"))));
-}
-
-TEST_P(TUSummaryTest, NamespaceElementMissingKind) {
-  auto Result = readFromString(R"({
-    "tu_namespace": {
-      "kind": "CompilationUnit",
-      "name": "test.cpp"
-    },
-    "id_table": [
-      {
-        "id": 0,
-        "name": {
-          "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": [
-            {
-              "name": "test.cpp"
-            }
-          ]
-        }
-      }
-    ],
-    "linkage_table": [
-      {
-        "id": 0,
-        "linkage": { "type": "Internal" }
-      }
-    ],
-    "data": []
-  })");
-
-  EXPECT_THAT_ERROR(
-      std::move(Result),
-      FailedWithMessage(AllOf(
-          HasSubstr("reading TUSummary from file"),
-          HasSubstr("reading IdTable from field 'id_table'"),
-          HasSubstr("reading EntityIdTable entry from index '0'"),
-          HasSubstr("reading EntityName from field 'name'"),
-          HasSubstr("reading NestedBuildNamespace from field 'namespace'"),
-          HasSubstr("reading BuildNamespace from index '0'"),
-          HasSubstr("failed to read BuildNamespaceKind from field 'kind'"),
-          HasSubstr("expected JSON string"))));
-}
-
-TEST_P(TUSummaryTest, NamespaceElementInvalidKind) {
-  auto Result = readFromString(R"({
-    "tu_namespace": {
-      "kind": "CompilationUnit",
-      "name": "test.cpp"
-    },
-    "id_table": [
-      {
-        "id": 0,
-        "name": {
-          "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "invalid_kind",
-              "name": "test.cpp"
-            }
-          ]
-        }
-      }
-    ],
-    "linkage_table": [
-      {
-        "id": 0,
-        "linkage": { "type": "External" }
-      }
-    ],
-    "data": []
-  })");
-
-  EXPECT_THAT_ERROR(
-      std::move(Result),
-      FailedWithMessage(AllOf(
-          HasSubstr("reading TUSummary from file"),
-          HasSubstr("reading IdTable from field 'id_table'"),
-          HasSubstr("reading EntityIdTable entry from index '0'"),
-          HasSubstr("reading EntityName from field 'name'"),
-          HasSubstr("reading NestedBuildNamespace from field 'namespace'"),
-          HasSubstr("reading BuildNamespace from index '0'"),
-          HasSubstr("reading BuildNamespaceKind from field 'kind'"),
-          HasSubstr("invalid BuildNamespaceKind value 'invalid_kind' for field "
-                    "'kind'"))));
-}
-
-TEST_P(TUSummaryTest, NamespaceElementMissingName) {
-  auto Result = readFromString(R"({
-    "tu_namespace": {
-      "kind": "CompilationUnit",
-      "name": "test.cpp"
-    },
-    "id_table": [
-      {
-        "id": 0,
-        "name": {
-          "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit"
-            }
-          ]
-        }
-      }
-    ],
-    "linkage_table": [
-      {
-        "id": 0,
-        "linkage": { "type": "None" }
-      }
-    ],
-    "data": []
-  })");
-
-  EXPECT_THAT_ERROR(
-      std::move(Result),
-      FailedWithMessage(AllOf(
-          HasSubstr("reading TUSummary from file"),
-          HasSubstr("reading IdTable from field 'id_table'"),
-          HasSubstr("reading EntityIdTable entry from index '0'"),
-          HasSubstr("reading EntityName from field 'name'"),
-          HasSubstr("reading NestedBuildNamespace from field 'namespace'"),
-          HasSubstr("reading BuildNamespace from index '0'"),
-          HasSubstr("failed to read BuildNamespaceName from field 'name'"),
-          HasSubstr("expected JSON string"))));
-}
-
-// ============================================================================
-// JSONFormat::entityNameFromJSON() Error Tests
+// JSONFormat::tuEntityNameFromJSON() Error Tests
 // ============================================================================
 
 TEST_P(TUSummaryTest, EntityNameMissingUSR) {
@@ -762,8 +581,7 @@ TEST_P(TUSummaryTest, EntityNameMissingUSR) {
       {
         "id": 0,
         "name": {
-          "suffix": "",
-          "namespace": []
+          "suffix": ""
         }
       }
     ],
@@ -796,8 +614,7 @@ TEST_P(TUSummaryTest, EntityNameMissingSuffix) {
       {
         "id": 0,
         "name": {
-          "usr": "c:@F@foo",
-          "namespace": []
+          "usr": "c:@F@foo"
         }
       }
     ],
@@ -820,44 +637,8 @@ TEST_P(TUSummaryTest, EntityNameMissingSuffix) {
                         HasSubstr("expected JSON string"))));
 }
 
-TEST_P(TUSummaryTest, EntityNameMissingNamespace) {
-  auto Result = readFromString(R"({
-    "tu_namespace": {
-      "kind": "CompilationUnit",
-      "name": "test.cpp"
-    },
-    "id_table": [
-      {
-        "id": 0,
-        "name": {
-          "usr": "c:@F@foo",
-          "suffix": ""
-        }
-      }
-    ],
-    "linkage_table": [
-      {
-        "id": 0,
-        "linkage": { "type": "None" }
-      }
-    ],
-    "data": []
-  })");
-
-  EXPECT_THAT_ERROR(
-      std::move(Result),
-      FailedWithMessage(AllOf(
-          HasSubstr("reading TUSummary from file"),
-          HasSubstr("reading IdTable from field 'id_table'"),
-          HasSubstr("reading EntityIdTable entry from index '0'"),
-          HasSubstr("reading EntityName from field 'name'"),
-          HasSubstr(
-              "failed to read NestedBuildNamespace from field 'namespace'"),
-          HasSubstr("expected JSON array"))));
-}
-
 // ============================================================================
-// JSONFormat::entityIdTableEntryFromJSON() Error Tests
+// JSONFormat::tuEntityIdTableEntryFromJSON() Error Tests
 // ============================================================================
 
 TEST_P(TUSummaryTest, IDTableEntryMissingID) {
@@ -870,8 +651,7 @@ TEST_P(TUSummaryTest, IDTableEntryMissingID) {
       {
         "name": {
           "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": []
+          "suffix": ""
         }
       }
     ],
@@ -930,8 +710,7 @@ TEST_P(TUSummaryTest, IDTableEntryIDNotUInt64) {
         "id": "not_a_number",
         "name": {
           "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": []
+          "suffix": ""
         }
       }
     ],
@@ -950,7 +729,7 @@ TEST_P(TUSummaryTest, IDTableEntryIDNotUInt64) {
 }
 
 // ============================================================================
-// JSONFormat::entityIdTableFromJSON() Error Tests
+// JSONFormat::tuEntityIdTableFromJSON() Error Tests
 // ============================================================================
 
 TEST_P(TUSummaryTest, IDTableNotArray) {
@@ -1003,26 +782,14 @@ TEST_P(TUSummaryTest, DuplicateEntity) {
         "id": 0,
         "name": {
           "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       },
       {
         "id": 1,
         "name": {
           "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       }
     ],
@@ -1618,8 +1385,7 @@ TEST_P(TUSummaryTest, DuplicateEntityIdInDataMap) {
         "id": 0,
         "name": {
           "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": []
+          "suffix": ""
         }
       }
     ],
@@ -1995,65 +1761,35 @@ TEST_P(TUSummaryTest, RoundTripWithTwoSummaryTypes) {
         "id": 3,
         "name": {
           "usr": "c:@F@qux",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       },
       {
         "id": 1,
         "name": {
           "usr": "c:@F@bar",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       },
       {
         "id": 4,
         "name": {
           "usr": "c:@F@quux",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       },
       {
         "id": 0,
         "name": {
           "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       },
       {
         "id": 2,
         "name": {
           "usr": "c:@F@baz",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       }
     ],
@@ -2194,13 +1930,7 @@ TEST_P(TUSummaryTest, RoundTripLinkageTableWithNoneLinkage) {
         "id": 0,
         "name": {
           "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       }
     ],
@@ -2225,13 +1955,7 @@ TEST_P(TUSummaryTest, RoundTripLinkageTableWithInternalLinkage) {
         "id": 0,
         "name": {
           "usr": "c:@F@bar",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       }
     ],
@@ -2256,13 +1980,7 @@ TEST_P(TUSummaryTest, RoundTripLinkageTableWithExternalLinkage) {
         "id": 0,
         "name": {
           "usr": "c:@F@baz",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       }
     ],
@@ -2287,39 +2005,21 @@ TEST_P(TUSummaryTest, RoundTripLinkageTableWithMultipleEntries) {
         "id": 0,
         "name": {
           "usr": "c:@F@foo",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       },
       {
         "id": 1,
         "name": {
           "usr": "c:@F@bar",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       },
       {
         "id": 2,
         "name": {
           "usr": "c:@F@baz",
-          "suffix": "",
-          "namespace": [
-            {
-              "kind": "CompilationUnit",
-              "name": "test.cpp"
-            }
-          ]
+          "suffix": ""
         }
       }
     ],


### PR DESCRIPTION
Problem:

ASTEntityMapping::getEntityName() creates EntityName with an empty NestedBuildNamespace, but the linker expected the TU namespace to already be present in the EntityName. This caused internal linkage symbols to conflict during linking: since their NestedBuildNamespace was empty, they all inherited the same LU namespace during resolution, making internal symbols from different TUs appear identical. For example, two "static inline" functions with the same USR in separate TUs would be incorrectly merged into a single LU entity instead of remaining distinct.

This is now fixed and demonstrated by the
InternalLinkageWithEmptyNamespaceAcrossTUs test, which creates two internal linkage symbols across two TUs and verifies they remain separate after linking.

---

TU summaries now omit the "namespace" field from entity names in JSON, since the linker adds TU namespace qualification at link time. LU (and WPA) summaries retain the "namespace" field as before, since their entity names are fully resolved.

Split entityNameFromJSON/entityNameToJSON into TU and LU variants:
- tuEntityNameFromJSON: reads only "usr" and "suffix"
- tuEntityNameToJSON: writes only "usr" and "suffix"
- luEntityNameFromJSON/luEntityNameToJSON: full behavior with required "namespace" field

Similarly split entityIdTableEntry and entityIdTable functions. Shared helpers (entityNameCoreFromJSON, entityIdTableFromJSONImpl) to avoid code duplication.

Update all TU JSON test inputs to remove the "namespace" field, and update unit tests accordingly.

---

Alternatively, we could choose to populate the NestedBuildNamespace with the TU namespace when creating an EntityName, thus meet the linker expectation. However, this would bloat the representation, and also make it redundant.

Assisted-By: claude