### PR TITLE
[CIR] Exclude _BitInt from fundamental integer type constraints

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypeConstraints.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypeConstraints.td
@@ -110,21 +110,27 @@ def CIR_SInt128 : CIR_SInt<128>;
 
 // Fundamental integer types represent standard source-level integer types that
 // have a specified set of admissible bitwidths (8, 16, 32, 64).
+// _BitInt types are excluded even when their width matches a fundamental width.
+
+def CIR_IsNotBitIntPred : CPred<"!$_self.getIsBitInt()">;
 
 def CIR_AnyFundamentalIntType
-    : CIR_ConfinedType<CIR_AnyIntType, [CIR_HasFundamentalIntWidthPred],
+    : CIR_ConfinedType<CIR_AnyIntType,
+        [CIR_HasFundamentalIntWidthPred, CIR_IsNotBitIntPred],
         "fundamental integer type"> {
     let cppFunctionName = "isFundamentalIntType";
 }
 
 def CIR_AnyFundamentalUIntType
-    : CIR_ConfinedType<CIR_AnyUIntType, [CIR_HasFundamentalIntWidthPred],
+    : CIR_ConfinedType<CIR_AnyUIntType,
+        [CIR_HasFundamentalIntWidthPred, CIR_IsNotBitIntPred],
         "fundamental unsigned integer type"> {
     let cppFunctionName = "isFundamentalUIntType";
 }
 
 def CIR_AnyFundamentalSIntType
-    : CIR_ConfinedType<CIR_AnySIntType, [CIR_HasFundamentalIntWidthPred],
+    : CIR_ConfinedType<CIR_AnySIntType,
+        [CIR_HasFundamentalIntWidthPred, CIR_IsNotBitIntPred],
         "fundamental signed integer type"> {
     let cppFunctionName = "isFundamentalSIntType";
 }

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -79,7 +79,7 @@ def CIR_IntType : CIR_Type<"Int", "int", [
     /// unsigned integer types whose bit width is 8, 16, 32, or 64).
     /// _BitInt types are never fundamental even if their width matches.
     bool isFundamental() const {
-      return !isBitInt() && isFundamentalIntType(*this);
+      return isFundamentalIntType(*this);
     }
     bool isSignedFundamental() const {
       return isFundamentalSIntType(*this);

--- a/clang/test/CIR/IR/invalid-bitint.cir
+++ b/clang/test/CIR/IR/invalid-bitint.cir
@@ -1,0 +1,13 @@
+// RUN: cir-opt %s -verify-diagnostics -split-input-file
+
+// _BitInt types with fundamental widths should not satisfy fundamental type
+// constraints.  Verify that cir.libc.memcpy rejects a _BitInt(32) length.
+
+module {
+  cir.func @bitint_not_fundamental_memcpy(%src : !cir.ptr<!cir.void>,
+                                          %len : !cir.int<u, 32, bitint>) {
+    // expected-error@+1 {{'cir.libc.memcpy' op operand #2 must be fundamental unsigned integer type, but got '!cir.int<u, 32, bitint>'}}
+    cir.libc.memcpy %len bytes from %src to %src : !cir.int<u, 32, bitint>, !cir.ptr<!cir.void> -> !cir.ptr<!cir.void>
+    cir.return
+  }
+}


### PR DESCRIPTION
Follow-up to #188113 per @erichkeane's feedback: `isFundamentalIntType` and `isFundamental()` should not disagree.

The previous patch added `!isBitInt()` only inside `IntType::isFundamental()`, leaving the underlying TableGen predicates (`CIR_AnyFundamentalIntType` etc.) unaware of `_BitInt`.  That meant `isSignedFundamental()` and `isUnsignedFundamental()` were silently wrong — a `_BitInt(32)` would pass them.

This patch adds a `CIR_IsNotBitIntPred` to the three fundamental-int constraint defs so everything stays consistent.  `isFundamental()` now just forwards to `isFundamentalIntType()` with no extra logic.

Includes an `invalid-bitint.cir` test that checks a `_BitInt(32)` is rejected where a fundamental unsigned int is required.

Made with [Cursor](https://cursor.com)