### PR TITLE
[LangRef] Correct description of predicate.enable MD

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -7876,12 +7876,13 @@ main loop. The first operand is the string
 ``llvm.loop.vectorize.predicate.enable`` and the second operand is a bit. If
 the bit operand value is 1 predication is enabled. A value of 0 disables
 predication:
-Additionally, enabling predication implicitly enables vectorization.
 
 .. code-block:: llvm
 
    !0 = !{!"llvm.loop.vectorize.predicate.enable", i1 0}
    !1 = !{!"llvm.loop.vectorize.predicate.enable", i1 1}
+
+Additionally, enabling predication implicitly enables vectorization.
 
 '``llvm.loop.vectorize.scalable.enable``' Metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -7874,8 +7874,9 @@ This metadata selectively enables or disables creating predicated instructions
 for the loop, which can enable folding of the scalar epilogue loop into the
 main loop. The first operand is the string
 ``llvm.loop.vectorize.predicate.enable`` and the second operand is a bit. If
-the bit operand value is 1 vectorization is enabled. A value of 0 disables
-vectorization:
+the bit operand value is 1 predication is enabled. A value of 0 disables
+predication:
+Additionally, enabling predication implicitly enables vectorization.
 
 .. code-block:: llvm
 


### PR DESCRIPTION
The documentation incorrectly stated that this metadata enables/disables vectorization, but it actually controls predication. Also clarify that enabling predication implicitly enables vectorization.