### PR TITLE
[AMDGPU] Use WriteSALUDummy for v_mad_u64_u32

### DIFF
--- a/llvm/lib/Target/AMDGPU/SISchedule.td
+++ b/llvm/lib/Target/AMDGPU/SISchedule.td
@@ -201,8 +201,8 @@ multiclass SICommonWriteRes {
   def : HWWriteRes<Write16PassMAI, [HWXDL], 16>;
 
   let NumMicroOps = 0 in {
-  def : HWWriteRes<WriteVALUDummy, [HWVALU],  0>;
-  def : HWWriteRes<WriteSALUDummy, [HWSALU],  0>;
+  def : HWWriteRes<WriteVALUDummy, [HWVALU],  1>;
+  def : HWWriteRes<WriteSALUDummy, [HWSALU],  1>;
   }
 
   def : UnsupportedWriteRes<WriteSFPU>;
@@ -413,8 +413,8 @@ def : UnsupportedWriteRes<WriteSFPU>;
 def : UnsupportedWriteRes<WritePseudoScalarTrans>;
 
 let NumMicroOps = 0 in {
-def : HWWriteRes<WriteVALUDummy, [HWVALU],  0>;
-def : HWWriteRes<WriteSALUDummy, [HWSALU],  0>;
+def : HWWriteRes<WriteVALUDummy, [HWVALU],  5>;
+def : HWWriteRes<WriteSALUDummy, [HWSALU],  2>;
 }
 
 } // End RetireOOO = 1
@@ -455,8 +455,8 @@ def : UnsupportedWriteRes<WritePseudoScalarTrans>;
 def : InstRW<[WriteCopy], (instrs COPY)>;
 
 let NumMicroOps = 0 in {
-def : HWWriteRes<WriteVALUDummy, [HWVALU],  0>;
-def : HWWriteRes<WriteSALUDummy, [HWSALU],  0>;
+def : HWWriteRes<WriteVALUDummy, [HWVALU],  5>;
+def : HWWriteRes<WriteSALUDummy, [HWSALU],  2>;
 }
 
 }  // End SchedModel = GFX11SpeedModel
@@ -488,8 +488,8 @@ def : HWWriteRes<WriteBarrier,           [HWBranch],       2000>;
 def : InstRW<[WriteCopy], (instrs COPY)>;
 
 let NumMicroOps = 0 in {
-def : HWWriteRes<WriteVALUDummy, [HWVALU],  0>;
-def : HWWriteRes<WriteSALUDummy, [HWSALU],  0>;
+def : HWWriteRes<WriteVALUDummy, [HWVALU],  5>;
+def : HWWriteRes<WriteSALUDummy, [HWSALU],  2>;
 }
 
 }  // End SchedModel = GFX12SpeedModel
@@ -544,8 +544,8 @@ def : InstRW<[Write4PassWMMA],    (instregex "^V_WMMA_F32_16X16X4_F32_w32")>;
 def : InstRW<[WriteXDL2PassWMMA], (instregex "^V_WMMA.*_F32_32X16X128_F4")>;
 
 let NumMicroOps = 0 in {
-def : HWWriteRes<WriteVALUDummy, [HWVALU],  0>;
-def : HWWriteRes<WriteSALUDummy, [HWSALU],  0>;
+def : HWWriteRes<WriteVALUDummy, [HWVALU],  5>;
+def : HWWriteRes<WriteSALUDummy, [HWSALU],  2>;
 }
 
 } // End GFX125xCommonWriteRes

--- a/llvm/lib/Target/AMDGPU/VOP3Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3Instructions.td
@@ -433,7 +433,7 @@ defm V_MQSAD_U32_U8 : VOP3Inst <"v_mqsad_u32_u8", VOPProfileMQSAD>;
 } // End Constraints = "@earlyclobber $vdst", SchedRW = [WriteQuarterRate32]
 } // End SubtargetPredicate = isGFX7Plus
 
-let isCommutable = 1, SchedRW = [WriteIntMul, WriteSALU] in {
+let isCommutable = 1, SchedRW = [WriteIntMul, WriteSALUDummy] in {
   let SubtargetPredicate = isGFX7Plus in {
     defm V_MAD_U64_U32 : VOP3Inst <"v_mad_u64_u32", VOP3b_I64_I1_I32_I32_I64_DPP, null_frag, [NotHasMADIntraFwdBug]>;
     defm V_MAD_I64_I32 : VOP3Inst <"v_mad_i64_i32", VOP3b_I64_I1_I32_I32_I64_DPP, null_frag, [NotHasMADIntraFwdBug]>;

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/mul.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/mul.ll
@@ -1219,19 +1219,19 @@ define i128 @v_mul_i128(i128 %num, i128 %den) {
 ; GFX7-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX7-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v6, 0
 ; GFX7-NEXT:    v_mov_b32_e32 v10, v2
-; GFX7-NEXT:    v_mov_b32_e32 v12, v4
+; GFX7-NEXT:    v_mov_b32_e32 v11, v4
+; GFX7-NEXT:    v_mov_b32_e32 v12, v3
 ; GFX7-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v9, v5, v[0:1]
-; GFX7-NEXT:    v_mov_b32_e32 v11, v3
-; GFX7-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v12, 0
-; GFX7-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v10, v12, v[13:14]
+; GFX7-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v11, 0
 ; GFX7-NEXT:    v_mul_lo_u32 v4, v9, v6
 ; GFX7-NEXT:    v_mul_lo_u32 v6, v8, v7
+; GFX7-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v10, v11, v[13:14]
 ; GFX7-NEXT:    v_mad_u64_u32 v[13:14], vcc, v8, v5, v[1:2]
-; GFX7-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v9, v12, v[13:14]
+; GFX7-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v9, v11, v[13:14]
 ; GFX7-NEXT:    v_addc_u32_e64 v3, s[4:5], v3, v6, s[4:5]
 ; GFX7-NEXT:    v_addc_u32_e32 v3, vcc, v3, v4, vcc
 ; GFX7-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v10, v5, v[3:4]
-; GFX7-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v11, v12, v[6:7]
+; GFX7-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v12, v11, v[6:7]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_mul_i128:
@@ -1241,19 +1241,19 @@ define i128 @v_mul_i128(i128 %num, i128 %den) {
 ; GFX8-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v6, 0
 ; GFX8-NEXT:    v_mov_b32_e32 v10, v2
-; GFX8-NEXT:    v_mov_b32_e32 v12, v4
+; GFX8-NEXT:    v_mov_b32_e32 v11, v4
+; GFX8-NEXT:    v_mov_b32_e32 v12, v3
 ; GFX8-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v9, v5, v[0:1]
-; GFX8-NEXT:    v_mov_b32_e32 v11, v3
-; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v12, 0
-; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v10, v12, v[13:14]
+; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v11, 0
 ; GFX8-NEXT:    v_mul_lo_u32 v4, v9, v6
 ; GFX8-NEXT:    v_mul_lo_u32 v6, v8, v7
+; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v10, v11, v[13:14]
 ; GFX8-NEXT:    v_mad_u64_u32 v[13:14], vcc, v8, v5, v[1:2]
-; GFX8-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v9, v12, v[13:14]
+; GFX8-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v9, v11, v[13:14]
 ; GFX8-NEXT:    v_addc_u32_e64 v3, s[4:5], v3, v6, s[4:5]
 ; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, v3, v4, vcc
 ; GFX8-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v10, v5, v[3:4]
-; GFX8-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v11, v12, v[6:7]
+; GFX8-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v12, v11, v[6:7]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_mul_i128:
@@ -1263,19 +1263,19 @@ define i128 @v_mul_i128(i128 %num, i128 %den) {
 ; GFX9-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v6, 0
 ; GFX9-NEXT:    v_mov_b32_e32 v10, v2
-; GFX9-NEXT:    v_mov_b32_e32 v12, v4
+; GFX9-NEXT:    v_mov_b32_e32 v11, v4
+; GFX9-NEXT:    v_mov_b32_e32 v12, v3
 ; GFX9-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v9, v5, v[0:1]
-; GFX9-NEXT:    v_mov_b32_e32 v11, v3
-; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v12, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v10, v12, v[13:14]
+; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v11, 0
 ; GFX9-NEXT:    v_mul_lo_u32 v4, v9, v6
 ; GFX9-NEXT:    v_mul_lo_u32 v6, v8, v7
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v10, v11, v[13:14]
 ; GFX9-NEXT:    v_mad_u64_u32 v[13:14], vcc, v8, v5, v[1:2]
-; GFX9-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v9, v12, v[13:14]
+; GFX9-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v9, v11, v[13:14]
 ; GFX9-NEXT:    v_addc_co_u32_e64 v3, s[4:5], v3, v6, s[4:5]
 ; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v4, vcc
 ; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v10, v5, v[3:4]
-; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v11, v12, v[6:7]
+; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v12, v11, v[6:7]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_mul_i128:
@@ -2599,18 +2599,16 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v14, 0
-; GFX7-NEXT:    v_mul_lo_u32 v28, v4, v11
+; GFX7-NEXT:    v_mul_lo_u32 v27, v5, v10
 ; GFX7-NEXT:    v_mul_lo_u32 v29, v3, v12
 ; GFX7-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v1, v13, v[16:17]
-; GFX7-NEXT:    v_mul_lo_u32 v30, v2, v13
-; GFX7-NEXT:    v_mul_lo_u32 v27, v5, v10
 ; GFX7-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v2, v12, v[18:19]
 ; GFX7-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v3, v11, v[16:17]
 ; GFX7-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v10, 0
 ; GFX7-NEXT:    v_mad_u64_u32 v[20:21], s[4:5], v4, v10, v[18:19]
 ; GFX7-NEXT:    v_mad_u64_u32 v[22:23], s[4:5], v1, v9, v[16:17]
-; GFX7-NEXT:    v_mad_u64_u32 v[16:17], s[6:7], v5, v9, v[20:21]
 ; GFX7-NEXT:    v_cndmask_b32_e64 v26, 0, 1, s[4:5]
+; GFX7-NEXT:    v_mad_u64_u32 v[16:17], s[6:7], v5, v9, v[20:21]
 ; GFX7-NEXT:    v_mad_u64_u32 v[18:19], vcc, v2, v8, v[22:23]
 ; GFX7-NEXT:    v_mad_u64_u32 v[22:23], s[4:5], v6, v8, v[16:17]
 ; GFX7-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v12, 0
@@ -2622,37 +2620,39 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX7-NEXT:    v_addc_u32_e64 v16, s[4:5], 0, v20, s[4:5]
 ; GFX7-NEXT:    v_mad_u64_u32 v[20:21], s[4:5], v4, v8, v[24:25]
 ; GFX7-NEXT:    v_addc_u32_e64 v24, s[4:5], 0, v16, s[4:5]
-; GFX7-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v13, v[21:22]
 ; GFX7-NEXT:    v_mul_lo_u32 v25, v6, v9
+; GFX7-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v13, v[21:22]
+; GFX7-NEXT:    v_addc_u32_e32 v6, vcc, 0, v26, vcc
+; GFX7-NEXT:    v_mul_lo_u32 v26, v4, v11
 ; GFX7-NEXT:    v_mad_u64_u32 v[21:22], s[6:7], v1, v12, v[16:17]
-; GFX7-NEXT:    v_mad_u64_u32 v[16:17], s[8:9], v2, v11, v[21:22]
-; GFX7-NEXT:    v_mad_u64_u32 v[21:22], s[10:11], v3, v10, v[16:17]
-; GFX7-NEXT:    v_mad_u64_u32 v[16:17], s[14:15], v0, v11, v[19:20]
-; GFX7-NEXT:    v_mad_u64_u32 v[12:13], s[12:13], v4, v9, v[21:22]
-; GFX7-NEXT:    v_addc_u32_e32 v4, vcc, 0, v26, vcc
-; GFX7-NEXT:    v_mad_u64_u32 v[19:20], vcc, v1, v10, v[16:17]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s[14:15]
-; GFX7-NEXT:    v_addc_u32_e32 v6, vcc, 0, v6, vcc
-; GFX7-NEXT:    v_mad_u64_u32 v[10:11], vcc, v2, v9, v[19:20]
+; GFX7-NEXT:    v_mad_u64_u32 v[16:17], vcc, v2, v11, v[21:22]
+; GFX7-NEXT:    v_mad_u64_u32 v[21:22], s[8:9], v0, v11, v[19:20]
+; GFX7-NEXT:    v_cndmask_b32_e64 v28, 0, 1, s[8:9]
+; GFX7-NEXT:    v_mad_u64_u32 v[11:12], s[10:11], v3, v10, v[16:17]
+; GFX7-NEXT:    v_mad_u64_u32 v[19:20], s[8:9], v1, v10, v[21:22]
+; GFX7-NEXT:    v_addc_u32_e64 v10, s[8:9], 0, v28, s[8:9]
+; GFX7-NEXT:    v_mul_lo_u32 v28, v2, v13
+; GFX7-NEXT:    v_mad_u64_u32 v[16:17], s[8:9], v2, v9, v[19:20]
+; GFX7-NEXT:    v_mad_u64_u32 v[19:20], s[12:13], v4, v9, v[11:12]
+; GFX7-NEXT:    v_addc_u32_e64 v2, s[8:9], 0, v10, s[8:9]
+; GFX7-NEXT:    v_mad_u64_u32 v[21:22], s[8:9], v3, v8, v[16:17]
 ; GFX7-NEXT:    v_mad_u64_u32 v[16:17], s[16:17], v0, v8, 0
-; GFX7-NEXT:    v_addc_u32_e32 v2, vcc, 0, v6, vcc
-; GFX7-NEXT:    v_mad_u64_u32 v[19:20], vcc, v3, v8, v[10:11]
-; GFX7-NEXT:    v_mad_u64_u32 v[21:22], s[14:15], v5, v8, v[12:13]
-; GFX7-NEXT:    v_addc_u32_e32 v5, vcc, 0, v2, vcc
-; GFX7-NEXT:    v_mad_u64_u32 v[2:3], s[16:17], v0, v9, v[17:18]
-; GFX7-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s[16:17]
-; GFX7-NEXT:    v_mul_lo_u32 v0, v0, v15
-; GFX7-NEXT:    v_mad_u64_u32 v[11:12], vcc, v1, v8, v[2:3]
-; GFX7-NEXT:    v_addc_u32_e32 v3, vcc, v6, v19, vcc
 ; GFX7-NEXT:    v_mul_lo_u32 v10, v1, v14
-; GFX7-NEXT:    v_addc_u32_e32 v4, vcc, v4, v20, vcc
-; GFX7-NEXT:    v_addc_u32_e32 v5, vcc, v5, v21, vcc
-; GFX7-NEXT:    v_addc_u32_e32 v6, vcc, v24, v22, vcc
-; GFX7-NEXT:    v_addc_u32_e32 v0, vcc, v23, v0, vcc
-; GFX7-NEXT:    v_addc_u32_e64 v0, vcc, v0, v10, s[14:15]
-; GFX7-NEXT:    v_addc_u32_e64 v0, vcc, v0, v30, s[12:13]
-; GFX7-NEXT:    v_addc_u32_e64 v0, vcc, v0, v29, s[10:11]
-; GFX7-NEXT:    v_addc_u32_e64 v0, vcc, v0, v28, s[8:9]
+; GFX7-NEXT:    v_mad_u64_u32 v[13:14], s[14:15], v5, v8, v[19:20]
+; GFX7-NEXT:    v_addc_u32_e64 v5, s[8:9], 0, v2, s[8:9]
+; GFX7-NEXT:    v_mad_u64_u32 v[2:3], s[8:9], v0, v9, v[17:18]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s[8:9]
+; GFX7-NEXT:    v_mul_lo_u32 v0, v0, v15
+; GFX7-NEXT:    v_mad_u64_u32 v[11:12], s[8:9], v1, v8, v[2:3]
+; GFX7-NEXT:    v_addc_u32_e64 v3, s[8:9], v4, v21, s[8:9]
+; GFX7-NEXT:    v_addc_u32_e64 v4, s[8:9], v6, v22, s[8:9]
+; GFX7-NEXT:    v_addc_u32_e64 v5, s[8:9], v5, v13, s[8:9]
+; GFX7-NEXT:    v_addc_u32_e64 v6, s[8:9], v24, v14, s[8:9]
+; GFX7-NEXT:    v_addc_u32_e64 v0, s[8:9], v23, v0, s[8:9]
+; GFX7-NEXT:    v_addc_u32_e64 v0, s[8:9], v0, v10, s[14:15]
+; GFX7-NEXT:    v_addc_u32_e64 v0, s[8:9], v0, v28, s[12:13]
+; GFX7-NEXT:    v_addc_u32_e64 v0, s[8:9], v0, v29, s[10:11]
+; GFX7-NEXT:    v_addc_u32_e32 v0, vcc, v0, v26, vcc
 ; GFX7-NEXT:    v_addc_u32_e64 v0, vcc, v0, v27, s[6:7]
 ; GFX7-NEXT:    v_addc_u32_e64 v0, vcc, v0, v25, s[4:5]
 ; GFX7-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v7, v8, v[0:1]
@@ -2666,18 +2666,16 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v14, 0
-; GFX8-NEXT:    v_mul_lo_u32 v28, v4, v11
+; GFX8-NEXT:    v_mul_lo_u32 v27, v5, v10
 ; GFX8-NEXT:    v_mul_lo_u32 v29, v3, v12
 ; GFX8-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v1, v13, v[16:17]
-; GFX8-NEXT:    v_mul_lo_u32 v30, v2, v13
-; GFX8-NEXT:    v_mul_lo_u32 v27, v5, v10
 ; GFX8-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v2, v12, v[18:19]
 ; GFX8-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v3, v11, v[16:17]
 ; GFX8-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v10, 0
 ; GFX8-NEXT:    v_mad_u64_u32 v[20:21], s[4:5], v4, v10, v[18:19]
 ; GFX8-NEXT:    v_mad_u64_u32 v[22:23], s[4:5], v1, v9, v[16:17]
-; GFX8-NEXT:    v_mad_u64_u32 v[16:17], s[6:7], v5, v9, v[20:21]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v26, 0, 1, s[4:5]
+; GFX8-NEXT:    v_mad_u64_u32 v[16:17], s[6:7], v5, v9, v[20:21]
 ; GFX8-NEXT:    v_mad_u64_u32 v[18:19], vcc, v2, v8, v[22:23]
 ; GFX8-NEXT:    v_mad_u64_u32 v[22:23], s[4:5], v6, v8, v[16:17]
 ; GFX8-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v12, 0
@@ -2689,37 +2687,39 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX8-NEXT:    v_addc_u32_e64 v16, s[4:5], 0, v20, s[4:5]
 ; GFX8-NEXT:    v_mad_u64_u32 v[20:21], s[4:5], v4, v8, v[24:25]
 ; GFX8-NEXT:    v_addc_u32_e64 v24, s[4:5], 0, v16, s[4:5]
-; GFX8-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v13, v[21:22]
 ; GFX8-NEXT:    v_mul_lo_u32 v25, v6, v9
+; GFX8-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v13, v[21:22]
+; GFX8-NEXT:    v_addc_u32_e32 v6, vcc, 0, v26, vcc
+; GFX8-NEXT:    v_mul_lo_u32 v26, v4, v11
 ; GFX8-NEXT:    v_mad_u64_u32 v[21:22], s[6:7], v1, v12, v[16:17]
-; GFX8-NEXT:    v_mad_u64_u32 v[16:17], s[8:9], v2, v11, v[21:22]
-; GFX8-NEXT:    v_mad_u64_u32 v[21:22], s[10:11], v3, v10, v[16:17]
-; GFX8-NEXT:    v_mad_u64_u32 v[16:17], s[14:15], v0, v11, v[19:20]
-; GFX8-NEXT:    v_mad_u64_u32 v[12:13], s[12:13], v4, v9, v[21:22]
-; GFX8-NEXT:    v_addc_u32_e32 v4, vcc, 0, v26, vcc
-; GFX8-NEXT:    v_mad_u64_u32 v[19:20], vcc, v1, v10, v[16:17]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s[14:15]
-; GFX8-NEXT:    v_addc_u32_e32 v6, vcc, 0, v6, vcc
-; GFX8-NEXT:    v_mad_u64_u32 v[10:11], vcc, v2, v9, v[19:20]
+; GFX8-NEXT:    v_mad_u64_u32 v[16:17], vcc, v2, v11, v[21:22]
+; GFX8-NEXT:    v_mad_u64_u32 v[21:22], s[8:9], v0, v11, v[19:20]
+; GFX8-NEXT:    v_cndmask_b32_e64 v28, 0, 1, s[8:9]
+; GFX8-NEXT:    v_mad_u64_u32 v[11:12], s[10:11], v3, v10, v[16:17]
+; GFX8-NEXT:    v_mad_u64_u32 v[19:20], s[8:9], v1, v10, v[21:22]
+; GFX8-NEXT:    v_addc_u32_e64 v10, s[8:9], 0, v28, s[8:9]
+; GFX8-NEXT:    v_mul_lo_u32 v28, v2, v13
+; GFX8-NEXT:    v_mad_u64_u32 v[16:17], s[8:9], v2, v9, v[19:20]
+; GFX8-NEXT:    v_mad_u64_u32 v[19:20], s[12:13], v4, v9, v[11:12]
+; GFX8-NEXT:    v_addc_u32_e64 v2, s[8:9], 0, v10, s[8:9]
+; GFX8-NEXT:    v_mad_u64_u32 v[21:22], s[8:9], v3, v8, v[16:17]
 ; GFX8-NEXT:    v_mad_u64_u32 v[16:17], s[16:17], v0, v8, 0
-; GFX8-NEXT:    v_addc_u32_e32 v2, vcc, 0, v6, vcc
-; GFX8-NEXT:    v_mad_u64_u32 v[19:20], vcc, v3, v8, v[10:11]
-; GFX8-NEXT:    v_mad_u64_u32 v[21:22], s[14:15], v5, v8, v[12:13]
-; GFX8-NEXT:    v_addc_u32_e32 v5, vcc, 0, v2, vcc
-; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[16:17], v0, v9, v[17:18]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s[16:17]
-; GFX8-NEXT:    v_mul_lo_u32 v0, v0, v15
-; GFX8-NEXT:    v_mad_u64_u32 v[11:12], vcc, v1, v8, v[2:3]
-; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, v6, v19, vcc
 ; GFX8-NEXT:    v_mul_lo_u32 v10, v1, v14
-; GFX8-NEXT:    v_addc_u32_e32 v4, vcc, v4, v20, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v5, vcc, v5, v21, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v6, vcc, v24, v22, vcc
-; GFX8-NEXT:    v_addc_u32_e32 v0, vcc, v23, v0, vcc
-; GFX8-NEXT:    v_addc_u32_e64 v0, vcc, v0, v10, s[14:15]
-; GFX8-NEXT:    v_addc_u32_e64 v0, vcc, v0, v30, s[12:13]
-; GFX8-NEXT:    v_addc_u32_e64 v0, vcc, v0, v29, s[10:11]
-; GFX8-NEXT:    v_addc_u32_e64 v0, vcc, v0, v28, s[8:9]
+; GFX8-NEXT:    v_mad_u64_u32 v[13:14], s[14:15], v5, v8, v[19:20]
+; GFX8-NEXT:    v_addc_u32_e64 v5, s[8:9], 0, v2, s[8:9]
+; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[8:9], v0, v9, v[17:18]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s[8:9]
+; GFX8-NEXT:    v_mul_lo_u32 v0, v0, v15
+; GFX8-NEXT:    v_mad_u64_u32 v[11:12], s[8:9], v1, v8, v[2:3]
+; GFX8-NEXT:    v_addc_u32_e64 v3, s[8:9], v4, v21, s[8:9]
+; GFX8-NEXT:    v_addc_u32_e64 v4, s[8:9], v6, v22, s[8:9]
+; GFX8-NEXT:    v_addc_u32_e64 v5, s[8:9], v5, v13, s[8:9]
+; GFX8-NEXT:    v_addc_u32_e64 v6, s[8:9], v24, v14, s[8:9]
+; GFX8-NEXT:    v_addc_u32_e64 v0, s[8:9], v23, v0, s[8:9]
+; GFX8-NEXT:    v_addc_u32_e64 v0, s[8:9], v0, v10, s[14:15]
+; GFX8-NEXT:    v_addc_u32_e64 v0, s[8:9], v0, v28, s[12:13]
+; GFX8-NEXT:    v_addc_u32_e64 v0, s[8:9], v0, v29, s[10:11]
+; GFX8-NEXT:    v_addc_u32_e32 v0, vcc, v0, v26, vcc
 ; GFX8-NEXT:    v_addc_u32_e64 v0, vcc, v0, v27, s[6:7]
 ; GFX8-NEXT:    v_addc_u32_e64 v0, vcc, v0, v25, s[4:5]
 ; GFX8-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v7, v8, v[0:1]
@@ -2733,18 +2733,16 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v14, 0
-; GFX9-NEXT:    v_mul_lo_u32 v28, v4, v11
+; GFX9-NEXT:    v_mul_lo_u32 v27, v5, v10
 ; GFX9-NEXT:    v_mul_lo_u32 v29, v3, v12
 ; GFX9-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v1, v13, v[16:17]
-; GFX9-NEXT:    v_mul_lo_u32 v30, v2, v13
-; GFX9-NEXT:    v_mul_lo_u32 v27, v5, v10
 ; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v2, v12, v[18:19]
 ; GFX9-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v3, v11, v[16:17]
 ; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v10, 0
 ; GFX9-NEXT:    v_mad_u64_u32 v[20:21], s[4:5], v4, v10, v[18:19]
 ; GFX9-NEXT:    v_mad_u64_u32 v[22:23], s[4:5], v1, v9, v[16:17]
-; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[6:7], v5, v9, v[20:21]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v26, 0, 1, s[4:5]
+; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[6:7], v5, v9, v[20:21]
 ; GFX9-NEXT:    v_mad_u64_u32 v[18:19], vcc, v2, v8, v[22:23]
 ; GFX9-NEXT:    v_mad_u64_u32 v[22:23], s[4:5], v6, v8, v[16:17]
 ; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v12, 0
@@ -2756,37 +2754,39 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX9-NEXT:    v_addc_co_u32_e64 v16, s[4:5], 0, v20, s[4:5]
 ; GFX9-NEXT:    v_mad_u64_u32 v[20:21], s[4:5], v4, v8, v[24:25]
 ; GFX9-NEXT:    v_addc_co_u32_e64 v24, s[4:5], 0, v16, s[4:5]
-; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v13, v[21:22]
 ; GFX9-NEXT:    v_mul_lo_u32 v25, v6, v9
+; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v0, v13, v[21:22]
+; GFX9-NEXT:    v_addc_co_u32_e32 v6, vcc, 0, v26, vcc
+; GFX9-NEXT:    v_mul_lo_u32 v26, v4, v11
 ; GFX9-NEXT:    v_mad_u64_u32 v[21:22], s[6:7], v1, v12, v[16:17]
-; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[8:9], v2, v11, v[21:22]
-; GFX9-NEXT:    v_mad_u64_u32 v[21:22], s[10:11], v3, v10, v[16:17]
-; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[14:15], v0, v11, v[19:20]
-; GFX9-NEXT:    v_mad_u64_u32 v[12:13], s[12:13], v4, v9, v[21:22]
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, 0, v26, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[19:20], vcc, v1, v10, v[16:17]
-; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s[14:15]
-; GFX9-NEXT:    v_addc_co_u32_e32 v6, vcc, 0, v6, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[10:11], vcc, v2, v9, v[19:20]
+; GFX9-NEXT:    v_mad_u64_u32 v[16:17], vcc, v2, v11, v[21:22]
+; GFX9-NEXT:    v_mad_u64_u32 v[21:22], s[8:9], v0, v11, v[19:20]
+; GFX9-NEXT:    v_cndmask_b32_e64 v28, 0, 1, s[8:9]
+; GFX9-NEXT:    v_mad_u64_u32 v[11:12], s[10:11], v3, v10, v[16:17]
+; GFX9-NEXT:    v_mad_u64_u32 v[19:20], s[8:9], v1, v10, v[21:22]
+; GFX9-NEXT:    v_addc_co_u32_e64 v10, s[8:9], 0, v28, s[8:9]
+; GFX9-NEXT:    v_mul_lo_u32 v28, v2, v13
+; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[8:9], v2, v9, v[19:20]
+; GFX9-NEXT:    v_mad_u64_u32 v[19:20], s[12:13], v4, v9, v[11:12]
+; GFX9-NEXT:    v_addc_co_u32_e64 v2, s[8:9], 0, v10, s[8:9]
+; GFX9-NEXT:    v_mad_u64_u32 v[21:22], s[8:9], v3, v8, v[16:17]
 ; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[16:17], v0, v8, 0
-; GFX9-NEXT:    v_addc_co_u32_e32 v2, vcc, 0, v6, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[19:20], vcc, v3, v8, v[10:11]
-; GFX9-NEXT:    v_mad_u64_u32 v[21:22], s[14:15], v5, v8, v[12:13]
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v2, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[16:17], v0, v9, v[17:18]
-; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s[16:17]
-; GFX9-NEXT:    v_mul_lo_u32 v0, v0, v15
-; GFX9-NEXT:    v_mad_u64_u32 v[11:12], vcc, v1, v8, v[2:3]
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v6, v19, vcc
 ; GFX9-NEXT:    v_mul_lo_u32 v10, v1, v14
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v4, v20, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, v5, v21, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v6, vcc, v24, v22, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v0, vcc, v23, v0, vcc
-; GFX9-NEXT:    v_addc_co_u32_e64 v0, vcc, v0, v10, s[14:15]
-; GFX9-NEXT:    v_addc_co_u32_e64 v0, vcc, v0, v30, s[12:13]
-; GFX9-NEXT:    v_addc_co_u32_e64 v0, vcc, v0, v29, s[10:11]
-; GFX9-NEXT:    v_addc_co_u32_e64 v0, vcc, v0, v28, s[8:9]
+; GFX9-NEXT:    v_mad_u64_u32 v[13:14], s[14:15], v5, v8, v[19:20]
+; GFX9-NEXT:    v_addc_co_u32_e64 v5, s[8:9], 0, v2, s[8:9]
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[8:9], v0, v9, v[17:18]
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s[8:9]
+; GFX9-NEXT:    v_mul_lo_u32 v0, v0, v15
+; GFX9-NEXT:    v_mad_u64_u32 v[11:12], s[8:9], v1, v8, v[2:3]
+; GFX9-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v4, v21, s[8:9]
+; GFX9-NEXT:    v_addc_co_u32_e64 v4, s[8:9], v6, v22, s[8:9]
+; GFX9-NEXT:    v_addc_co_u32_e64 v5, s[8:9], v5, v13, s[8:9]
+; GFX9-NEXT:    v_addc_co_u32_e64 v6, s[8:9], v24, v14, s[8:9]
+; GFX9-NEXT:    v_addc_co_u32_e64 v0, s[8:9], v23, v0, s[8:9]
+; GFX9-NEXT:    v_addc_co_u32_e64 v0, s[8:9], v0, v10, s[14:15]
+; GFX9-NEXT:    v_addc_co_u32_e64 v0, s[8:9], v0, v28, s[12:13]
+; GFX9-NEXT:    v_addc_co_u32_e64 v0, s[8:9], v0, v29, s[10:11]
+; GFX9-NEXT:    v_addc_co_u32_e32 v0, vcc, v0, v26, vcc
 ; GFX9-NEXT:    v_addc_co_u32_e64 v0, vcc, v0, v27, s[6:7]
 ; GFX9-NEXT:    v_addc_co_u32_e64 v0, vcc, v0, v25, s[4:5]
 ; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v7, v8, v[0:1]
@@ -2808,12 +2808,11 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX10-NEXT:    v_mov_b32_e32 v21, v5
 ; GFX10-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX10-NEXT:    v_mov_b32_e32 v22, v7
-; GFX10-NEXT:    v_mul_lo_u32 v31, v17, v14
 ; GFX10-NEXT:    v_mul_lo_u32 v29, v20, v11
-; GFX10-NEXT:    v_mul_lo_u32 v30, v16, v15
+; GFX10-NEXT:    v_mul_lo_u32 v30, v19, v12
+; GFX10-NEXT:    v_mul_lo_u32 v27, v0, v9
 ; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s4, v17, v13, v[1:2]
 ; GFX10-NEXT:    v_mad_u64_u32 v[1:2], s4, v16, v12, 0
-; GFX10-NEXT:    v_mul_lo_u32 v27, v0, v9
 ; GFX10-NEXT:    v_mad_u64_u32 v[5:6], s4, v18, v12, v[3:4]
 ; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s4, v17, v11, v[1:2]
 ; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0, 1, s4
@@ -2829,38 +2828,39 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX10-NEXT:    v_mad_u64_u32 v[6:7], s4, v0, v8, v[23:24]
 ; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s4, v17, v9, v[25:26]
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v25, vcc_lo, 0, v3, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v28, 0, 1, s4
 ; GFX10-NEXT:    v_mul_lo_u32 v26, v21, v10
 ; GFX10-NEXT:    v_mad_u64_u32 v[23:24], vcc_lo, v16, v13, v[5:6]
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s4
 ; GFX10-NEXT:    v_mad_u64_u32 v[2:3], s4, v18, v8, v[0:1]
-; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s6, v16, v8, 0
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v28, s4, 0, v28, s4
-; GFX10-NEXT:    v_mad_u64_u32 v[5:6], s5, v17, v12, v[23:24]
-; GFX10-NEXT:    v_mad_u64_u32 v[23:24], s6, v16, v11, v[3:4]
-; GFX10-NEXT:    v_cndmask_b32_e64 v14, 0, 1, s6
-; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s4, v18, v11, v[5:6]
-; GFX10-NEXT:    v_mad_u64_u32 v[5:6], s6, v17, v10, v[23:24]
-; GFX10-NEXT:    v_mul_lo_u32 v23, v19, v12
-; GFX10-NEXT:    v_mul_lo_u32 v24, v18, v13
-; GFX10-NEXT:    v_mad_u64_u32 v[11:12], s7, v19, v10, v[3:4]
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v10, s6, 0, v14, s6
-; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s6, v18, v9, v[5:6]
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v14, s6, 0, v10, s6
-; GFX10-NEXT:    v_mad_u64_u32 v[5:6], s6, v20, v9, v[11:12]
-; GFX10-NEXT:    v_mad_u64_u32 v[10:11], s8, v16, v9, v[1:2]
-; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s8
-; GFX10-NEXT:    v_mad_u64_u32 v[12:13], s8, v19, v8, v[3:4]
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v16, s8, 0, v14, s8
-; GFX10-NEXT:    v_mad_u64_u32 v[14:15], s8, v21, v8, v[5:6]
-; GFX10-NEXT:    v_mad_u64_u32 v[1:2], s9, v17, v8, v[10:11]
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v3, s9, v9, v12, s9
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v4, s9, v28, v13, s9
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v5, s9, v16, v14, s9
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v6, s9, v25, v15, s9
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v7, s9, v7, v30, s9
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v7, s8, v7, v31, s8
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v7, s6, v7, v24, s6
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v7, s6, v7, v23, s7
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v28, s4, 0, v5, s4
+; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s5, v17, v12, v[23:24]
+; GFX10-NEXT:    v_mad_u64_u32 v[5:6], s6, v16, v11, v[3:4]
+; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s4, v18, v11, v[0:1]
+; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s6
+; GFX10-NEXT:    v_mad_u64_u32 v[23:24], s6, v17, v10, v[5:6]
+; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s8, v16, v8, 0
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v12, s6, 0, v11, s6
+; GFX10-NEXT:    v_mad_u64_u32 v[5:6], s7, v19, v10, v[3:4]
+; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s6, v18, v9, v[23:24]
+; GFX10-NEXT:    v_mul_lo_u32 v18, v18, v13
+; GFX10-NEXT:    v_mad_u64_u32 v[10:11], s8, v20, v9, v[5:6]
+; GFX10-NEXT:    v_mad_u64_u32 v[5:6], s9, v16, v9, v[1:2]
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v1, s6, 0, v12, s6
+; GFX10-NEXT:    v_mad_u64_u32 v[12:13], s6, v19, v8, v[3:4]
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s9
+; GFX10-NEXT:    v_mul_lo_u32 v20, v16, v15
+; GFX10-NEXT:    v_mul_lo_u32 v9, v17, v14
+; GFX10-NEXT:    v_mad_u64_u32 v[14:15], s9, v21, v8, v[10:11]
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v10, s6, 0, v1, s6
+; GFX10-NEXT:    v_mad_u64_u32 v[1:2], s6, v17, v8, v[5:6]
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v3, s6, v3, v12, s6
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v4, s6, v28, v13, s6
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v5, s6, v10, v14, s6
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v6, s6, v25, v15, s6
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v7, s6, v7, v20, s6
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v7, s6, v7, v9, s9
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v7, s6, v7, v18, s8
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v7, s6, v7, v30, s7
 ; GFX10-NEXT:    v_add_co_ci_u32_e64 v7, s4, v7, v29, s4
 ; GFX10-NEXT:    v_add_co_ci_u32_e64 v7, s4, v7, v26, s5
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v7, vcc_lo, v7, v27, vcc_lo
@@ -2877,10 +2877,11 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX11-NEXT:    v_dual_mov_b32 v0, v6 :: v_dual_mov_b32 v23, v7
 ; GFX11-NEXT:    v_mov_b32_e32 v22, v8
 ; GFX11-NEXT:    v_mad_u64_u32 v[26:27], null, v16, v10, 0
+; GFX11-NEXT:    v_mul_lo_u32 v30, v20, v11
 ; GFX11-NEXT:    v_mul_lo_u32 v28, v0, v9
+; GFX11-NEXT:    v_mul_lo_u32 v31, v19, v12
 ; GFX11-NEXT:    v_mad_u64_u32 v[3:4], null, v17, v13, v[1:2]
 ; GFX11-NEXT:    v_mad_u64_u32 v[1:2], null, v16, v12, 0
-; GFX11-NEXT:    v_mul_lo_u32 v30, v20, v11
 ; GFX11-NEXT:    v_mul_lo_u32 v15, v16, v15
 ; GFX11-NEXT:    v_mul_lo_u32 v14, v17, v14
 ; GFX11-NEXT:    v_mad_u64_u32 v[5:6], null, v18, v12, v[3:4]
@@ -2897,38 +2898,37 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX11-NEXT:    v_mad_u64_u32 v[6:7], null, v0, v22, v[24:25]
 ; GFX11-NEXT:    v_mad_u64_u32 v[0:1], s0, v17, v9, v[26:27]
 ; GFX11-NEXT:    v_add_co_ci_u32_e64 v26, null, 0, v3, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v8, 0, 1, s0
 ; GFX11-NEXT:    v_mul_lo_u32 v27, v21, v10
 ; GFX11-NEXT:    v_mad_u64_u32 v[24:25], vcc_lo, v16, v13, v[5:6]
+; GFX11-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s0
 ; GFX11-NEXT:    v_mad_u64_u32 v[2:3], s0, v18, v22, v[0:1]
-; GFX11-NEXT:    v_add_co_ci_u32_e64 v29, null, 0, v8, s0
-; GFX11-NEXT:    v_mad_u64_u32 v[0:1], null, v16, v22, 0
-; GFX11-NEXT:    v_mad_u64_u32 v[5:6], s1, v17, v12, v[24:25]
-; GFX11-NEXT:    v_mad_u64_u32 v[24:25], s2, v16, v11, v[3:4]
+; GFX11-NEXT:    v_add_co_ci_u32_e64 v29, null, 0, v5, s0
+; GFX11-NEXT:    v_mad_u64_u32 v[0:1], s1, v17, v12, v[24:25]
+; GFX11-NEXT:    v_mad_u64_u32 v[5:6], s2, v16, v11, v[3:4]
 ; GFX11-NEXT:    v_cndmask_b32_e64 v8, 0, 1, s2
-; GFX11-NEXT:    v_mad_u64_u32 v[3:4], s0, v18, v11, v[5:6]
-; GFX11-NEXT:    v_mad_u64_u32 v[5:6], s2, v17, v10, v[24:25]
-; GFX11-NEXT:    v_mul_lo_u32 v24, v19, v12
+; GFX11-NEXT:    v_mad_u64_u32 v[3:4], s0, v18, v11, v[0:1]
+; GFX11-NEXT:    v_mad_u64_u32 v[0:1], null, v16, v22, 0
+; GFX11-NEXT:    v_mad_u64_u32 v[24:25], s2, v17, v10, v[5:6]
 ; GFX11-NEXT:    v_add_co_ci_u32_e64 v8, null, 0, v8, s2
-; GFX11-NEXT:    v_mul_lo_u32 v25, v18, v13
-; GFX11-NEXT:    v_mad_u64_u32 v[11:12], s3, v19, v10, v[3:4]
-; GFX11-NEXT:    v_mad_u64_u32 v[3:4], s2, v18, v9, v[5:6]
-; GFX11-NEXT:    v_add_co_ci_u32_e64 v13, null, 0, v8, s2
-; GFX11-NEXT:    v_mad_u64_u32 v[5:6], s2, v20, v9, v[11:12]
-; GFX11-NEXT:    v_mad_u64_u32 v[10:11], s4, v16, v9, v[1:2]
-; GFX11-NEXT:    v_cndmask_b32_e64 v16, 0, 1, s4
-; GFX11-NEXT:    v_mad_u64_u32 v[8:9], s4, v19, v22, v[3:4]
-; GFX11-NEXT:    v_add_co_ci_u32_e64 v18, null, 0, v13, s4
-; GFX11-NEXT:    v_mad_u64_u32 v[12:13], s4, v21, v22, v[5:6]
-; GFX11-NEXT:    v_mad_u64_u32 v[1:2], s5, v17, v22, v[10:11]
-; GFX11-NEXT:    v_add_co_ci_u32_e64 v3, s5, v16, v8, s5
-; GFX11-NEXT:    v_add_co_ci_u32_e64 v4, s5, v29, v9, s5
-; GFX11-NEXT:    v_add_co_ci_u32_e64 v5, s5, v18, v12, s5
-; GFX11-NEXT:    v_add_co_ci_u32_e64 v6, s5, v26, v13, s5
-; GFX11-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v15, s5
-; GFX11-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v14, s4
-; GFX11-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v25, s2
-; GFX11-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v24, s3
+; GFX11-NEXT:    v_mad_u64_u32 v[5:6], s3, v19, v10, v[3:4]
+; GFX11-NEXT:    v_mad_u64_u32 v[3:4], s2, v18, v9, v[24:25]
+; GFX11-NEXT:    v_mul_lo_u32 v18, v18, v13
+; GFX11-NEXT:    v_mad_u64_u32 v[10:11], s4, v20, v9, v[5:6]
+; GFX11-NEXT:    v_mad_u64_u32 v[5:6], s5, v16, v9, v[1:2]
+; GFX11-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v8, s2
+; GFX11-NEXT:    v_mad_u64_u32 v[8:9], s2, v19, v22, v[3:4]
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s5
+; GFX11-NEXT:    v_mad_u64_u32 v[12:13], s5, v21, v22, v[10:11]
+; GFX11-NEXT:    v_add_co_ci_u32_e64 v10, null, 0, v1, s2
+; GFX11-NEXT:    v_mad_u64_u32 v[1:2], s2, v17, v22, v[5:6]
+; GFX11-NEXT:    v_add_co_ci_u32_e64 v3, s2, v3, v8, s2
+; GFX11-NEXT:    v_add_co_ci_u32_e64 v4, s2, v29, v9, s2
+; GFX11-NEXT:    v_add_co_ci_u32_e64 v5, s2, v10, v12, s2
+; GFX11-NEXT:    v_add_co_ci_u32_e64 v6, s2, v26, v13, s2
+; GFX11-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v15, s2
+; GFX11-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v14, s5
+; GFX11-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v18, s4
+; GFX11-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v31, s3
 ; GFX11-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v30, s0
 ; GFX11-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v27, s1
 ; GFX11-NEXT:    v_add_co_ci_u32_e64 v9, null, v7, v28, vcc_lo
@@ -2945,18 +2945,17 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX12-NEXT:    v_dual_mov_b32 v16, v0 :: v_dual_mov_b32 v17, v1
 ; GFX12-NEXT:    v_dual_mov_b32 v18, v2 :: v_dual_mov_b32 v19, v3
 ; GFX12-NEXT:    v_dual_mov_b32 v20, v4 :: v_dual_mov_b32 v21, v5
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_4) | instid1(VALU_DEP_4)
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[1:2], null, v16, v14, 0
 ; GFX12-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX12-NEXT:    v_mov_b32_e32 v22, v7
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[25:26], null, v16, v10, 0
-; GFX12-NEXT:    v_mul_lo_u32 v31, v17, v14
+; GFX12-NEXT:    v_mul_lo_u32 v29, v20, v11
+; GFX12-NEXT:    v_mul_lo_u32 v30, v19, v12
 ; GFX12-NEXT:    v_mul_lo_u32 v27, v0, v9
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[3:4], null, v17, v13, v[1:2]
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[1:2], null, v16, v12, 0
-; GFX12-NEXT:    v_mul_lo_u32 v29, v20, v11
-; GFX12-NEXT:    v_mul_lo_u32 v30, v16, v15
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[5:6], null, v18, v12, v[3:4]
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[3:4], s0, v17, v11, v[1:2]
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
@@ -2979,57 +2978,57 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[0:1], s0, v17, v9, v[25:26]
 ; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
 ; GFX12-NEXT:    v_add_co_ci_u32_e64 v25, null, 0, v3, vcc_lo
-; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-NEXT:    v_cndmask_b32_e64 v28, 0, 1, s0
 ; GFX12-NEXT:    v_mul_lo_u32 v26, v21, v10
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_4) | instid1(VALU_DEP_2)
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[23:24], vcc_lo, v16, v13, v[5:6]
+; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s0
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[2:3], s0, v18, v8, v[0:1]
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-NEXT:    v_add_co_ci_u32_e64 v28, null, 0, v28, s0
+; GFX12-NEXT:    v_add_co_ci_u32_e64 v28, null, 0, v5, s0
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX12-NEXT:    v_mad_co_u64_u32 v[0:1], s1, v17, v12, v[23:24]
+; GFX12-NEXT:    v_mad_co_u64_u32 v[5:6], s2, v16, v11, v[3:4]
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_3)
+; GFX12-NEXT:    v_mad_co_u64_u32 v[3:4], s0, v18, v11, v[0:1]
+; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s2
+; GFX12-NEXT:    v_mad_co_u64_u32 v[23:24], s2, v17, v10, v[5:6]
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[0:1], null, v16, v8, 0
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX12-NEXT:    v_mad_co_u64_u32 v[5:6], s1, v17, v12, v[23:24]
-; GFX12-NEXT:    v_mad_co_u64_u32 v[23:24], s2, v16, v11, v[3:4]
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-NEXT:    v_cndmask_b32_e64 v14, 0, 1, s2
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX12-NEXT:    v_mad_co_u64_u32 v[3:4], s0, v18, v11, v[5:6]
-; GFX12-NEXT:    v_mad_co_u64_u32 v[5:6], s2, v17, v10, v[23:24]
-; GFX12-NEXT:    v_mul_lo_u32 v23, v19, v12
-; GFX12-NEXT:    v_mul_lo_u32 v24, v18, v13
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_4) | instid1(VALU_DEP_2)
-; GFX12-NEXT:    v_mad_co_u64_u32 v[11:12], s3, v19, v10, v[3:4]
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX12-NEXT:    v_add_co_ci_u32_e64 v12, null, 0, v11, s2
+; GFX12-NEXT:    v_mad_co_u64_u32 v[5:6], s3, v19, v10, v[3:4]
+; GFX12-NEXT:    v_mad_co_u64_u32 v[3:4], s2, v18, v9, v[23:24]
+; GFX12-NEXT:    v_mul_lo_u32 v18, v18, v13
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX12-NEXT:    v_mad_co_u64_u32 v[10:11], s4, v20, v9, v[5:6]
+; GFX12-NEXT:    v_mad_co_u64_u32 v[5:6], s5, v16, v9, v[1:2]
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-NEXT:    v_add_co_ci_u32_e64 v10, null, 0, v14, s2
-; GFX12-NEXT:    v_mad_co_u64_u32 v[3:4], s2, v18, v9, v[5:6]
+; GFX12-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v12, s2
+; GFX12-NEXT:    v_mad_co_u64_u32 v[12:13], s2, v19, v8, v[3:4]
+; GFX12-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s5
+; GFX12-NEXT:    v_mul_lo_u32 v20, v16, v15
+; GFX12-NEXT:    v_mul_lo_u32 v9, v17, v14
+; GFX12-NEXT:    v_mad_co_u64_u32 v[14:15], s5, v21, v8, v[10:11]
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-NEXT:    v_add_co_ci_u32_e64 v14, null, 0, v10, s2
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX12-NEXT:    v_mad_co_u64_u32 v[5:6], s2, v20, v9, v[11:12]
-; GFX12-NEXT:    v_mad_co_u64_u32 v[10:11], s4, v16, v9, v[1:2]
+; GFX12-NEXT:    v_add_co_ci_u32_e64 v10, null, 0, v1, s2
+; GFX12-NEXT:    v_mad_co_u64_u32 v[1:2], s2, v17, v8, v[5:6]
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s4
-; GFX12-NEXT:    v_mad_co_u64_u32 v[12:13], s4, v19, v8, v[3:4]
+; GFX12-NEXT:    v_add_co_ci_u32_e64 v3, s2, v3, v12, s2
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-NEXT:    v_add_co_ci_u32_e64 v16, null, 0, v14, s4
-; GFX12-NEXT:    v_mad_co_u64_u32 v[14:15], s4, v21, v8, v[5:6]
-; GFX12-NEXT:    v_mad_co_u64_u32 v[1:2], s5, v17, v8, v[10:11]
+; GFX12-NEXT:    v_add_co_ci_u32_e64 v4, s2, v28, v13, s2
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_3) | instid1(VALU_DEP_4)
-; GFX12-NEXT:    v_add_co_ci_u32_e64 v3, s5, v9, v12, s5
+; GFX12-NEXT:    v_add_co_ci_u32_e64 v5, s2, v10, v14, s2
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-NEXT:    v_add_co_ci_u32_e64 v4, s5, v28, v13, s5
+; GFX12-NEXT:    v_add_co_ci_u32_e64 v6, s2, v25, v15, s2
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-NEXT:    v_add_co_ci_u32_e64 v5, s5, v16, v14, s5
-; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-NEXT:    v_add_co_ci_u32_e64 v6, s5, v25, v15, s5
-; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v30, s5
+; GFX12-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v20, s2
 ; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX12-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v31, s4
-; GFX12-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v24, s2
+; GFX12-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v9, s5
+; GFX12-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v18, s4
 ; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX12-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v23, s3
+; GFX12-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v30, s3
 ; GFX12-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v29, s0
 ; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
 ; GFX12-NEXT:    v_add_co_ci_u32_e64 v7, null, v7, v26, s1
@@ -3044,12 +3043,11 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX1250-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_dual_mov_b32 v16, v0 :: v_dual_mov_b32 v17, v1
-; GFX1250-NEXT:    v_mul_lo_u32 v29, v4, v11
-; GFX1250-NEXT:    v_mul_lo_u32 v30, v2, v13
+; GFX1250-NEXT:    v_mul_lo_u32 v29, v5, v10
+; GFX1250-NEXT:    v_mul_lo_u32 v30, v4, v11
 ; GFX1250-NEXT:    v_mul_lo_u32 v31, v3, v12
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1250-NEXT:    v_mad_nc_u64_u32 v[0:1], v16, v14, 0
-; GFX1250-NEXT:    v_mul_lo_u32 v28, v5, v10
 ; GFX1250-NEXT:    v_mad_nc_u64_u32 v[18:19], v17, v13, v[0:1]
 ; GFX1250-NEXT:    v_mad_nc_u64_u32 v[0:1], v16, v12, 0
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
@@ -3070,65 +3068,65 @@ define i256 @v_mul_i256(i256 %num, i256 %den) {
 ; GFX1250-NEXT:    v_mad_nc_u64_u32 v[18:19], v16, v10, 0
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1250-NEXT:    v_mad_co_u64_u32 v[22:23], vcc_lo, v4, v8, v[0:1]
-; GFX1250-NEXT:    v_add_co_ci_u32_e64 v26, null, 0, v26, vcc_lo
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v28, null, 0, v26, vcc_lo
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GFX1250-NEXT:    v_mad_nc_u64_u32 v[24:25], v6, v8, v[20:21]
 ; GFX1250-NEXT:    v_mad_co_u64_u32 v[0:1], s0, v17, v9, v[18:19]
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX1250-NEXT:    v_mov_b32_e32 v18, v23
-; GFX1250-NEXT:    v_cndmask_b32_e64 v27, 0, 1, s0
-; GFX1250-NEXT:    v_mov_b32_e32 v19, v24
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1250-NEXT:    v_dual_mov_b32 v18, v23 :: v_dual_mov_b32 v19, v24
 ; GFX1250-NEXT:    v_mad_co_u64_u32 v[20:21], vcc_lo, v2, v8, v[0:1]
 ; GFX1250-NEXT:    v_mul_lo_u32 v24, v6, v9
-; GFX1250-NEXT:    v_add_co_ci_u32_e64 v6, null, 0, v27, vcc_lo
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1250-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s0
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
 ; GFX1250-NEXT:    v_mad_co_u64_u32 v[0:1], s0, v16, v13, v[18:19]
-; GFX1250-NEXT:    v_dual_mov_b32 v19, v22 :: v_dual_mov_b32 v18, v21
-; GFX1250-NEXT:    v_mul_lo_u32 v21, v16, v15
-; GFX1250-NEXT:    v_mul_lo_u32 v27, v17, v14
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX1250-NEXT:    v_mad_co_u64_u32 v[22:23], vcc_lo, v17, v12, v[0:1]
-; GFX1250-NEXT:    v_mad_co_u64_u32 v[14:15], s2, v16, v11, v[18:19]
+; GFX1250-NEXT:    v_mov_b32_e32 v19, v22
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v6, null, 0, v6, vcc_lo
+; GFX1250-NEXT:    v_mov_b32_e32 v18, v21
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1250-NEXT:    v_mad_co_u64_u32 v[26:27], vcc_lo, v17, v12, v[0:1]
 ; GFX1250-NEXT:    v_mad_nc_u64_u32 v[0:1], v16, v8, 0
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX1250-NEXT:    v_mad_co_u64_u32 v[18:19], s1, v2, v11, v[22:23]
-; GFX1250-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s2
-; GFX1250-NEXT:    v_mad_co_u64_u32 v[12:13], s2, v17, v10, v[14:15]
+; GFX1250-NEXT:    v_mad_co_u64_u32 v[22:23], s2, v16, v11, v[18:19]
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1250-NEXT:    v_cndmask_b32_e64 v21, 0, 1, s2
+; GFX1250-NEXT:    v_mad_co_u64_u32 v[18:19], s1, v2, v11, v[26:27]
+; GFX1250-NEXT:    v_mov_b32_e32 v11, v20
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX1250-NEXT:    v_dual_mov_b32 v14, v1 :: v_dual_mov_b32 v15, v20
-; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v11, s2
+; GFX1250-NEXT:    v_mad_co_u64_u32 v[26:27], s2, v17, v10, v[22:23]
 ; GFX1250-NEXT:    v_mad_co_u64_u32 v[22:23], s3, v3, v10, v[18:19]
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-NEXT:    v_mad_co_u64_u32 v[10:11], s2, v2, v9, v[12:13]
+; GFX1250-NEXT:    v_mov_b32_e32 v10, v1
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v21, s2
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX1250-NEXT:    v_mad_co_u64_u32 v[18:19], s2, v2, v9, v[26:27]
+; GFX1250-NEXT:    v_mul_lo_u32 v2, v2, v13
+; GFX1250-NEXT:    v_mad_co_u64_u32 v[20:21], s5, v16, v9, v[10:11]
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4)
 ; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, s2
-; GFX1250-NEXT:    v_mad_co_u64_u32 v[18:19], s4, v16, v9, v[14:15]
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX1250-NEXT:    v_mad_co_u64_u32 v[12:13], s2, v4, v9, v[22:23]
-; GFX1250-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s4
-; GFX1250-NEXT:    v_mad_co_u64_u32 v[14:15], s4, v3, v8, v[10:11]
-; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, s4
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX1250-NEXT:    v_mad_co_u64_u32 v[10:11], s4, v5, v8, v[12:13]
-; GFX1250-NEXT:    v_mad_co_u64_u32 v[12:13], s5, v17, v8, v[18:19]
-; GFX1250-NEXT:    v_add_co_ci_u32_e64 v3, s5, v2, v14, s5
+; GFX1250-NEXT:    v_mad_co_u64_u32 v[12:13], s4, v4, v9, v[22:23]
+; GFX1250-NEXT:    v_mul_lo_u32 v22, v16, v15
+; GFX1250-NEXT:    v_mul_lo_u32 v9, v17, v14
+; GFX1250-NEXT:    v_mad_co_u64_u32 v[10:11], s2, v3, v8, v[18:19]
+; GFX1250-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s5
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, s2
+; GFX1250-NEXT:    v_mad_co_u64_u32 v[14:15], s5, v5, v8, v[12:13]
+; GFX1250-NEXT:    v_mad_co_u64_u32 v[12:13], s2, v17, v8, v[20:21]
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-NEXT:    v_add_co_ci_u32_e64 v4, s5, v6, v15, s5
-; GFX1250-NEXT:    v_add_co_ci_u32_e64 v5, s5, v1, v10, s5
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v3, s2, v3, v10, s2
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v4, s2, v6, v11, s2
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-NEXT:    v_add_co_ci_u32_e64 v6, s5, v26, v11, s5
-; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, v25, v21, s5
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v5, s2, v1, v14, s2
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v6, s2, v28, v15, s2
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, v25, v22, s2
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v9, s5
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v2, s4
 ; GFX1250-NEXT:    v_mov_b32_e32 v2, v13
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v27, s4
-; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v30, s2
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v31, s3
-; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v29, s1
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v28, vcc_lo
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v30, s1
+; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v29, vcc_lo
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1250-NEXT:    v_add_co_ci_u32_e64 v1, null, v1, v24, s0
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1250-NEXT:    v_mad_u32 v7, v7, v8, v1
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v12
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/sdiv.i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/sdiv.i64.ll
@@ -20,7 +20,7 @@ define i64 @v_sdiv_i64(i64 %num, i64 %den) {
 ; CHECK-NEXT:  ; %bb.1: ; %Flow
 ; CHECK-NEXT:    s_andn2_saveexec_b64 s[6:7], s[6:7]
 ; CHECK-NEXT:    s_cbranch_execnz .LBB0_4
-; CHECK-NEXT:  .LBB0_2:
+; CHECK-NEXT:  .LBB0_2: ; %.split
 ; CHECK-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
 ; CHECK-NEXT:  .LBB0_3:
@@ -49,17 +49,17 @@ define i64 @v_sdiv_i64(i64 %num, i64 %den) {
 ; CHECK-NEXT:    v_mul_hi_u32 v6, v12, v6
 ; CHECK-NEXT:    v_mul_lo_u32 v9, v3, v10
 ; CHECK-NEXT:    v_mul_lo_u32 v11, v12, v10
+; CHECK-NEXT:    v_mul_hi_u32 v15, v3, v10
 ; CHECK-NEXT:    v_add_i32_e32 v7, vcc, v7, v9
 ; CHECK-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v7, vcc, v7, v8
-; CHECK-NEXT:    v_mul_hi_u32 v8, v3, v10
 ; CHECK-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v7, vcc, v9, v7
 ; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v11, v6
-; CHECK-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v6, v8
 ; CHECK-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v8, vcc, v9, v8
+; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v6, v15
+; CHECK-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v8, vcc, v8, v9
 ; CHECK-NEXT:    v_mul_hi_u32 v9, v12, v10
 ; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v6, v7
 ; CHECK-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
@@ -115,11 +115,11 @@ define i64 @v_sdiv_i64(i64 %num, i64 %den) {
 ; CHECK-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v7, v6
 ; CHECK-NEXT:    v_add_i32_e32 v10, vcc, v3, v5
-; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v6, v3
-; CHECK-NEXT:    v_mul_hi_u32 v6, v11, v4
+; CHECK-NEXT:    v_mul_hi_u32 v7, v11, v4
 ; CHECK-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v2, v10, 0
-; CHECK-NEXT:    v_add_i32_e32 v12, vcc, v6, v5
+; CHECK-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
+; CHECK-NEXT:    v_add_i32_e32 v12, vcc, v7, v5
 ; CHECK-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v2, v12, v[4:5]
 ; CHECK-NEXT:    v_sub_i32_e32 v3, vcc, v9, v3
 ; CHECK-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v1, v10, v[5:6]
@@ -231,14 +231,14 @@ define amdgpu_ps i64 @s_sdiv_i64(i64 inreg %num, i64 inreg %den) {
 ; CHECK-NEXT:    v_mul_hi_u32 v8, v6, v4
 ; CHECK-NEXT:    v_add_i32_e32 v1, vcc, v1, v3
 ; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
+; CHECK-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v1, vcc, v1, v2
 ; CHECK-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v1, vcc, v3, v1
-; CHECK-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
-; CHECK-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v0, vcc, v0, v8
-; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v2, v3
+; CHECK-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v5, v2
 ; CHECK-NEXT:    v_mul_hi_u32 v3, v7, v4
 ; CHECK-NEXT:    v_add_i32_e32 v0, vcc, v0, v1
 ; CHECK-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
@@ -290,15 +290,15 @@ define amdgpu_ps i64 @s_sdiv_i64(i64 inreg %num, i64 inreg %den) {
 ; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v4, v3
 ; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v0, v2
-; CHECK-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v3, v0
-; CHECK-NEXT:    v_mul_hi_u32 v3, s13, v1
+; CHECK-NEXT:    v_mul_hi_u32 v4, s13, v1
 ; CHECK-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s10, v6, 0
-; CHECK-NEXT:    v_add_i32_e32 v4, vcc, v3, v2
+; CHECK-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v3, v2
+; CHECK-NEXT:    v_add_i32_e32 v4, vcc, v4, v2
 ; CHECK-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s10, v4, v[1:2]
 ; CHECK-NEXT:    v_sub_i32_e32 v0, vcc, s12, v0
-; CHECK-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s11, v6, v[2:3]
 ; CHECK-NEXT:    v_mov_b32_e32 v1, s11
+; CHECK-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s11, v6, v[2:3]
 ; CHECK-NEXT:    v_subb_u32_e64 v2, s[0:1], v7, v4, vcc
 ; CHECK-NEXT:    v_sub_i32_e64 v3, s[0:1], s13, v4
 ; CHECK-NEXT:    v_cmp_le_u32_e64 s[0:1], s11, v2
@@ -353,7 +353,7 @@ define amdgpu_ps i64 @s_sdiv_i64(i64 inreg %num, i64 inreg %den) {
 ; CHECK-NEXT:    v_add_i32_e32 v2, vcc, 1, v0
 ; CHECK-NEXT:    v_cmp_le_u32_e32 vcc, s4, v1
 ; CHECK-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; CHECK-NEXT:  .LBB1_5:
+; CHECK-NEXT:  .LBB1_5: ; %.split
 ; CHECK-NEXT:    v_readfirstlane_b32 s0, v0
 ; CHECK-NEXT:    s_mov_b32 s1, s0
 ; CHECK-NEXT:    ; return to shader part epilog
@@ -377,260 +377,260 @@ define <2 x i64> @v_sdiv_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v8
 ; GISEL-NEXT:    v_addc_u32_e32 v5, vcc, v5, v8, vcc
 ; GISEL-NEXT:    v_xor_b32_e32 v10, v4, v8
-; GISEL-NEXT:    v_xor_b32_e32 v9, v5, v8
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v4, v10
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v5, v9
+; GISEL-NEXT:    v_xor_b32_e32 v4, v5, v8
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v5, v10
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v9, v4
 ; GISEL-NEXT:    v_sub_i32_e32 v17, vcc, 0, v10
-; GISEL-NEXT:    v_subb_u32_e32 v18, vcc, 0, v9, vcc
-; GISEL-NEXT:    v_mac_f32_e32 v4, 0x4f800000, v5
-; GISEL-NEXT:    v_rcp_iflag_f32_e32 v4, v4
-; GISEL-NEXT:    v_mul_f32_e32 v4, 0x5f7ffffc, v4
-; GISEL-NEXT:    v_mul_f32_e32 v5, 0x2f800000, v4
-; GISEL-NEXT:    v_trunc_f32_e32 v5, v5
-; GISEL-NEXT:    v_mac_f32_e32 v4, 0xcf800000, v5
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v15, v4
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v16, v5
-; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v17, v15, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v17, v16, v[5:6]
-; GISEL-NEXT:    v_mul_lo_u32 v5, v16, v4
-; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v18, v15, v[11:12]
-; GISEL-NEXT:    v_mul_lo_u32 v11, v15, v13
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v11
-; GISEL-NEXT:    v_mul_hi_u32 v11, v15, v4
+; GISEL-NEXT:    v_subb_u32_e32 v18, vcc, 0, v4, vcc
+; GISEL-NEXT:    v_mac_f32_e32 v5, 0x4f800000, v9
+; GISEL-NEXT:    v_rcp_iflag_f32_e32 v5, v5
+; GISEL-NEXT:    v_mul_f32_e32 v5, 0x5f7ffffc, v5
+; GISEL-NEXT:    v_mul_f32_e32 v9, 0x2f800000, v5
+; GISEL-NEXT:    v_trunc_f32_e32 v9, v9
+; GISEL-NEXT:    v_mac_f32_e32 v5, 0xcf800000, v9
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v5, v5
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v9, v9
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v17, v5, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v17, v9, v[12:13]
+; GISEL-NEXT:    v_mul_lo_u32 v12, v9, v11
+; GISEL-NEXT:    v_mad_u64_u32 v[15:16], s[4:5], v18, v5, v[13:14]
+; GISEL-NEXT:    v_mul_lo_u32 v13, v5, v15
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v13
+; GISEL-NEXT:    v_mul_hi_u32 v13, v5, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
+; GISEL-NEXT:    v_mul_hi_u32 v11, v9, v11
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v13
 ; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
-; GISEL-NEXT:    v_mul_hi_u32 v4, v16, v4
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v11, v16, v13
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v12, v5
-; GISEL-NEXT:    v_mul_hi_u32 v12, v15, v13
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v11, v4
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v12
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v13, v9, v15
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v14, v12
+; GISEL-NEXT:    v_mul_hi_u32 v14, v5, v15
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v13, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v14
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v13, v14
+; GISEL-NEXT:    v_mul_hi_u32 v14, v9, v15
 ; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v12
-; GISEL-NEXT:    v_mul_hi_u32 v12, v16, v13
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v5
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v11, v5
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v12, v5
-; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v15, v4
-; GISEL-NEXT:    v_addc_u32_e32 v16, vcc, v16, v5, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v17, v15, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v17, v16, v[5:6]
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v13, v12
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v14, v12
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v5, v11
+; GISEL-NEXT:    v_addc_u32_e32 v9, vcc, v9, v12, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v17, v19, 0
 ; GISEL-NEXT:    v_ashrrev_i32_e32 v5, 31, v1
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v5
-; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v18, v15, v[11:12]
+; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v17, v9, v[12:13]
 ; GISEL-NEXT:    v_addc_u32_e32 v1, vcc, v1, v5, vcc
-; GISEL-NEXT:    v_xor_b32_e32 v17, v0, v5
-; GISEL-NEXT:    v_mul_lo_u32 v0, v16, v4
-; GISEL-NEXT:    v_mul_lo_u32 v11, v15, v13
-; GISEL-NEXT:    v_xor_b32_e32 v18, v1, v5
-; GISEL-NEXT:    v_mul_hi_u32 v1, v15, v4
-; GISEL-NEXT:    v_mul_hi_u32 v4, v16, v4
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v17, v1, v5
+; GISEL-NEXT:    v_mad_u64_u32 v[15:16], s[4:5], v18, v19, v[13:14]
+; GISEL-NEXT:    v_xor_b32_e32 v16, v0, v5
+; GISEL-NEXT:    v_mul_lo_u32 v0, v9, v11
+; GISEL-NEXT:    v_mul_hi_u32 v1, v19, v11
+; GISEL-NEXT:    v_mul_lo_u32 v12, v19, v15
+; GISEL-NEXT:    v_mul_hi_u32 v11, v9, v11
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v1
 ; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v1, v16, v13
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v11, v0
-; GISEL-NEXT:    v_mul_hi_u32 v11, v15, v13
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v1, v4
-; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v1, v9, v15
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v12, v0
+; GISEL-NEXT:    v_mul_hi_u32 v12, v19, v15
 ; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v1, v11
 ; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v11
-; GISEL-NEXT:    v_mul_hi_u32 v11, v16, v13
+; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v1, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v12
+; GISEL-NEXT:    v_mul_hi_u32 v12, v9, v15
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v4, v1
 ; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v11, v1
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v15, v0
-; GISEL-NEXT:    v_addc_u32_e32 v1, vcc, v16, v1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v4, v18, v0
-; GISEL-NEXT:    v_mul_lo_u32 v11, v17, v1
-; GISEL-NEXT:    v_mul_hi_u32 v12, v17, v0
-; GISEL-NEXT:    v_mul_hi_u32 v0, v18, v0
-; GISEL-NEXT:    v_xor_b32_e32 v5, v5, v8
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v11
+; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v12, v1
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v19, v0
+; GISEL-NEXT:    v_addc_u32_e32 v1, vcc, v9, v1, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v9, v17, v0
+; GISEL-NEXT:    v_mul_lo_u32 v11, v16, v1
+; GISEL-NEXT:    v_mul_hi_u32 v12, v16, v0
+; GISEL-NEXT:    v_mul_hi_u32 v0, v17, v0
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v11
 ; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v12
-; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v12, v18, v1
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v11, v4
-; GISEL-NEXT:    v_mul_hi_u32 v11, v17, v1
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v12, v17, v1
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v11, v9
+; GISEL-NEXT:    v_mul_hi_u32 v11, v16, v1
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v12, v0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v11
 ; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v12, v11
-; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v0, v4
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v11, v0
-; GISEL-NEXT:    v_mul_hi_u32 v11, v18, v1
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v0, v9
+; GISEL-NEXT:    v_mul_hi_u32 v12, v17, v1
 ; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v10, v15, 0
-; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v11, v4
-; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v10, v16, v[1:2]
-; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v17, v0
-; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v9, v15, v[11:12]
-; GISEL-NEXT:    v_subb_u32_e64 v1, s[4:5], v18, v13, vcc
-; GISEL-NEXT:    v_sub_i32_e64 v4, s[4:5], v18, v13
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v1, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, -1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v11, v9
+; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v12, v9
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v10, v18, v[1:2]
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v16, v0
+; GISEL-NEXT:    v_ashrrev_i32_e32 v9, 31, v7
+; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v4, v15, v[11:12]
+; GISEL-NEXT:    v_subb_u32_e64 v14, s[4:5], v17, v13, vcc
+; GISEL-NEXT:    v_sub_i32_e64 v1, s[4:5], v17, v13
+; GISEL-NEXT:    v_add_i32_e64 v6, s[4:5], v6, v9
+; GISEL-NEXT:    v_addc_u32_e64 v11, s[4:5], v7, v9, s[4:5]
+; GISEL-NEXT:    v_xor_b32_e32 v7, v6, v9
+; GISEL-NEXT:    v_xor_b32_e32 v6, v11, v9
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v11, v7
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v12, v6
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v4, vcc
 ; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v0, v10
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v1, v9
-; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v4, v9, vcc
+; GISEL-NEXT:    v_mac_f32_e32 v11, 0x4f800000, v12
+; GISEL-NEXT:    v_rcp_iflag_f32_e32 v11, v11
 ; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v0, v10
-; GISEL-NEXT:    v_subbrev_u32_e32 v1, vcc, 0, v1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, v11, v12, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, 1, v15
-; GISEL-NEXT:    v_addc_u32_e32 v13, vcc, 0, v16, vcc
-; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v9
-; GISEL-NEXT:    v_ashrrev_i32_e32 v4, 31, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, -1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v4
-; GISEL-NEXT:    v_addc_u32_e32 v17, vcc, v7, v4, vcc
-; GISEL-NEXT:    v_xor_b32_e32 v7, v6, v4
-; GISEL-NEXT:    v_xor_b32_e32 v6, v17, v4
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v17, v7
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v18, v6
+; GISEL-NEXT:    v_subbrev_u32_e32 v16, vcc, 0, v1, vcc
 ; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v10
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
-; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v9
-; GISEL-NEXT:    v_mac_f32_e32 v17, 0x4f800000, v18
-; GISEL-NEXT:    v_rcp_iflag_f32_e32 v1, v17
-; GISEL-NEXT:    v_cndmask_b32_e32 v0, v14, v0, vcc
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, 1, v12
-; GISEL-NEXT:    v_addc_u32_e32 v14, vcc, 0, v13, vcc
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
-; GISEL-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v1
+; GISEL-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v11
 ; GISEL-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; GISEL-NEXT:    v_trunc_f32_e32 v1, v1
 ; GISEL-NEXT:    v_mac_f32_e32 v0, 0xcf800000, v1
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v17, v0
-; GISEL-NEXT:    v_sub_i32_e64 v19, s[4:5], 0, v7
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v18, v1
-; GISEL-NEXT:    v_subb_u32_e64 v20, s[4:5], 0, v6, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v19, v17, 0
-; GISEL-NEXT:    v_cndmask_b32_e32 v12, v12, v9, vcc
-; GISEL-NEXT:    v_cndmask_b32_e32 v13, v13, v14, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v19, v18, v[1:2]
-; GISEL-NEXT:    v_mul_lo_u32 v21, v18, v0
-; GISEL-NEXT:    v_mul_hi_u32 v22, v17, v0
-; GISEL-NEXT:    v_mul_hi_u32 v23, v18, v0
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v20, v17, v[9:10]
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
-; GISEL-NEXT:    v_cndmask_b32_e32 v10, v15, v12, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v1, v17, v0
-; GISEL-NEXT:    v_mul_lo_u32 v11, v18, v0
+; GISEL-NEXT:    v_sub_i32_e64 v20, s[6:7], 0, v7
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v19, v1
+; GISEL-NEXT:    v_subb_u32_e64 v21, s[6:7], 0, v6, s[6:7]
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v20, v17, 0
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[8:9], v16, v4
+; GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[6:7], v20, v19, v[1:2]
+; GISEL-NEXT:    v_mul_lo_u32 v1, v19, v0
+; GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[6:7], v21, v17, v[10:11]
+; GISEL-NEXT:    v_mul_lo_u32 v10, v17, v12
+; GISEL-NEXT:    v_add_i32_e64 v1, s[6:7], v1, v10
+; GISEL-NEXT:    v_mul_hi_u32 v10, v17, v0
+; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s[6:7]
+; GISEL-NEXT:    v_mul_hi_u32 v0, v19, v0
+; GISEL-NEXT:    v_add_i32_e64 v1, s[6:7], v1, v10
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[8:9]
+; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, -1, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v16, v4
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[8:9], v14, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, -1, s[8:9]
+; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, -1, s[4:5]
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v14, v4
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v1, v10, vcc
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, 1, v15
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, v13, v16, s[4:5]
+; GISEL-NEXT:    v_addc_u32_e32 v13, vcc, 0, v18, vcc
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, 1, v10
+; GISEL-NEXT:    v_addc_u32_e32 v16, vcc, 0, v13, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[6:7]
+; GISEL-NEXT:    v_cndmask_b32_e32 v10, v10, v14, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v13, v13, v16, vcc
+; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v11, v1
+; GISEL-NEXT:    v_mul_lo_u32 v11, v19, v12
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v11, v0
+; GISEL-NEXT:    v_mul_hi_u32 v11, v17, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
+; GISEL-NEXT:    v_mul_hi_u32 v12, v19, v12
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v14, v11
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v11, v1
+; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v12, v1
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v17, v0
+; GISEL-NEXT:    v_addc_u32_e32 v14, vcc, v19, v1, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v20, v12, 0
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; GISEL-NEXT:    v_cndmask_b32_e32 v4, v15, v10, vcc
 ; GISEL-NEXT:    v_ashrrev_i32_e32 v15, 31, v3
-; GISEL-NEXT:    v_cndmask_b32_e32 v13, v16, v13, vcc
-; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v21, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v1, v22
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v9, v1
-; GISEL-NEXT:    v_mul_hi_u32 v9, v17, v0
-; GISEL-NEXT:    v_add_i32_e64 v11, s[4:5], v11, v23
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v9, s[4:5], v11, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v11, s[4:5], v12, v11
-; GISEL-NEXT:    v_mul_hi_u32 v0, v18, v0
-; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v9, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v9, s[4:5], v11, v9
-; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v9
-; GISEL-NEXT:    v_add_i32_e64 v12, s[4:5], v17, v1
-; GISEL-NEXT:    v_addc_u32_e64 v14, s[4:5], v18, v0, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v19, v12, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v19, v14, v[1:2]
-; GISEL-NEXT:    v_xor_b32_e32 v1, v10, v5
+; GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v20, v14, v[1:2]
+; GISEL-NEXT:    v_xor_b32_e32 v1, v5, v8
+; GISEL-NEXT:    v_xor_b32_e32 v8, v4, v1
+; GISEL-NEXT:    v_cndmask_b32_e32 v13, v18, v13, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v21, v12, v[10:11]
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v15
-; GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v20, v12, v[8:9]
 ; GISEL-NEXT:    v_addc_u32_e32 v3, vcc, v3, v15, vcc
 ; GISEL-NEXT:    v_xor_b32_e32 v16, v2, v15
 ; GISEL-NEXT:    v_mul_lo_u32 v2, v14, v0
-; GISEL-NEXT:    v_mul_lo_u32 v8, v12, v10
+; GISEL-NEXT:    v_mul_lo_u32 v5, v12, v4
 ; GISEL-NEXT:    v_xor_b32_e32 v17, v3, v15
 ; GISEL-NEXT:    v_mul_hi_u32 v3, v12, v0
 ; GISEL-NEXT:    v_mul_hi_u32 v0, v14, v0
-; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v8
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v3
 ; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v3, v14, v10
-; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v8, v2
-; GISEL-NEXT:    v_mul_hi_u32 v8, v12, v10
+; GISEL-NEXT:    v_mul_lo_u32 v3, v14, v4
+; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v5, v2
+; GISEL-NEXT:    v_mul_hi_u32 v5, v12, v4
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v3, v0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v8
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v8
-; GISEL-NEXT:    v_mul_hi_u32 v8, v14, v10
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v5
+; GISEL-NEXT:    v_mul_hi_u32 v4, v14, v4
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v2
 ; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v3, v2
-; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v8, v2
+; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v4, v2
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v12, v0
 ; GISEL-NEXT:    v_addc_u32_e32 v2, vcc, v14, v2, vcc
 ; GISEL-NEXT:    v_mul_lo_u32 v3, v17, v0
-; GISEL-NEXT:    v_mul_lo_u32 v8, v16, v2
-; GISEL-NEXT:    v_mul_hi_u32 v9, v16, v0
+; GISEL-NEXT:    v_mul_lo_u32 v4, v16, v2
+; GISEL-NEXT:    v_mul_hi_u32 v5, v16, v0
 ; GISEL-NEXT:    v_mul_hi_u32 v0, v17, v0
-; GISEL-NEXT:    v_xor_b32_e32 v10, v13, v5
-; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v8
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v9
+; GISEL-NEXT:    v_xor_b32_e32 v10, v13, v1
+; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v9, v17, v2
-; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v8, v3
-; GISEL-NEXT:    v_mul_hi_u32 v8, v16, v2
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v9, v0
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v8
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v9, v8
+; GISEL-NEXT:    v_mul_lo_u32 v5, v17, v2
+; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v4, v3
+; GISEL-NEXT:    v_mul_hi_u32 v4, v16, v2
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v5, v4
 ; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v0, v3
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v8, v0
-; GISEL-NEXT:    v_mul_hi_u32 v8, v17, v2
+; GISEL-NEXT:    v_mul_hi_u32 v5, v17, v2
 ; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v7, v12, 0
-; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v8, v0
-; GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v7, v13, v[3:4]
-; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v1, v5
-; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v10, v5, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v6, v12, v[8:9]
+; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v4, v0
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v5, v0
+; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v7, v13, v[3:4]
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v8, v1
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v10, v1, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v6, v12, v[4:5]
 ; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v16, v2
 ; GISEL-NEXT:    v_subb_u32_e64 v3, s[4:5], v17, v10, vcc
-; GISEL-NEXT:    v_sub_i32_e64 v5, s[4:5], v17, v10
+; GISEL-NEXT:    v_sub_i32_e64 v4, s[4:5], v17, v10
 ; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v3, v6
-; GISEL-NEXT:    v_subb_u32_e32 v5, vcc, v5, v6, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, -1, s[4:5]
+; GISEL-NEXT:    v_subb_u32_e32 v4, vcc, v4, v6, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, -1, s[4:5]
 ; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v2, v7
 ; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v2, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, -1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, -1, s[4:5]
 ; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v3, v6
-; GISEL-NEXT:    v_subbrev_u32_e32 v5, vcc, 0, v5, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v8, v9, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v8, vcc, 1, v12
-; GISEL-NEXT:    v_addc_u32_e32 v9, vcc, 0, v13, vcc
-; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v5, v6
+; GISEL-NEXT:    v_subbrev_u32_e32 v4, vcc, 0, v4, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v3, v5, v8, s[4:5]
+; GISEL-NEXT:    v_add_i32_e32 v5, vcc, 1, v12
+; GISEL-NEXT:    v_addc_u32_e32 v8, vcc, 0, v13, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v4, v6
 ; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, -1, vcc
 ; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v2, v7
 ; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, -1, vcc
-; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v5, v6
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v4, v6
 ; GISEL-NEXT:    v_cndmask_b32_e32 v2, v10, v2, vcc
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, 1, v8
-; GISEL-NEXT:    v_addc_u32_e32 v6, vcc, 0, v9, vcc
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, 1, v5
+; GISEL-NEXT:    v_addc_u32_e32 v6, vcc, 0, v8, vcc
 ; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GISEL-NEXT:    v_cndmask_b32_e32 v2, v8, v5, vcc
-; GISEL-NEXT:    v_cndmask_b32_e32 v5, v9, v6, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v2, v5, v4, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v4, v8, v6, vcc
 ; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
 ; GISEL-NEXT:    v_cndmask_b32_e32 v2, v12, v2, vcc
-; GISEL-NEXT:    v_xor_b32_e32 v4, v15, v4
-; GISEL-NEXT:    v_cndmask_b32_e32 v3, v13, v5, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v13, v4, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v4, v15, v9
 ; GISEL-NEXT:    v_xor_b32_e32 v2, v2, v4
 ; GISEL-NEXT:    v_xor_b32_e32 v3, v3, v4
 ; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v2, v4
@@ -674,21 +674,21 @@ define <2 x i64> @v_sdiv_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v17, v15, v[12:13]
 ; CGP-NEXT:    v_mul_lo_u32 v5, v14, v3
 ; CGP-NEXT:    v_mul_hi_u32 v12, v15, v3
-; CGP-NEXT:    v_mul_lo_u32 v13, v15, v4
 ; CGP-NEXT:    v_mul_hi_u32 v3, v14, v3
+; CGP-NEXT:    v_mul_lo_u32 v13, v15, v4
 ; CGP-NEXT:    v_mul_lo_u32 v18, v14, v4
+; CGP-NEXT:    v_mul_hi_u32 v19, v15, v4
+; CGP-NEXT:    v_mul_hi_u32 v4, v14, v4
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v13
 ; CGP-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v12
-; CGP-NEXT:    v_mul_hi_u32 v12, v15, v4
 ; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v13, v5
 ; CGP-NEXT:    v_add_i32_e32 v3, vcc, v18, v3
-; CGP-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v3, vcc, v3, v12
 ; CGP-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v12, vcc, v13, v12
-; CGP-NEXT:    v_mul_hi_u32 v4, v14, v4
+; CGP-NEXT:    v_add_i32_e32 v3, vcc, v3, v19
+; CGP-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v12, vcc, v12, v13
 ; CGP-NEXT:    v_add_i32_e32 v3, vcc, v3, v5
 ; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v12, v5
@@ -743,11 +743,11 @@ define <2 x i64> @v_sdiv_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v10, vcc, v11, v10
 ; CGP-NEXT:    v_add_i32_e32 v14, vcc, v3, v5
-; CGP-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v5, vcc, v10, v3
-; CGP-NEXT:    v_mul_hi_u32 v10, v13, v4
+; CGP-NEXT:    v_mul_hi_u32 v11, v13, v4
 ; CGP-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v2, v14, 0
-; CGP-NEXT:    v_add_i32_e32 v15, vcc, v10, v5
+; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v5, vcc, v10, v5
+; CGP-NEXT:    v_add_i32_e32 v15, vcc, v11, v5
 ; CGP-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v2, v15, v[4:5]
 ; CGP-NEXT:    v_sub_i32_e32 v3, vcc, v12, v3
 ; CGP-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v14, v[10:11]
@@ -809,7 +809,7 @@ define <2 x i64> @v_sdiv_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-NEXT:    v_add_i32_e32 v3, vcc, 1, v0
 ; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v2, v4
 ; CGP-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc
-; CGP-NEXT:  .LBB2_4:
+; CGP-NEXT:  .LBB2_4: ; %.split
 ; CGP-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; CGP-NEXT:    v_or_b32_e32 v3, v9, v7
 ; CGP-NEXT:    v_mov_b32_e32 v2, 0
@@ -821,7 +821,7 @@ define <2 x i64> @v_sdiv_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-NEXT:  ; %bb.5: ; %Flow
 ; CGP-NEXT:    s_andn2_saveexec_b64 s[6:7], s[6:7]
 ; CGP-NEXT:    s_cbranch_execnz .LBB2_8
-; CGP-NEXT:  .LBB2_6:
+; CGP-NEXT:  .LBB2_6: ; %.split.split
 ; CGP-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; CGP-NEXT:    s_setpc_b64 s[30:31]
 ; CGP-NEXT:  .LBB2_7:
@@ -847,21 +847,21 @@ define <2 x i64> @v_sdiv_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v15, v13, v[10:11]
 ; CGP-NEXT:    v_mul_lo_u32 v7, v12, v5
 ; CGP-NEXT:    v_mul_hi_u32 v10, v13, v5
-; CGP-NEXT:    v_mul_lo_u32 v11, v13, v6
 ; CGP-NEXT:    v_mul_hi_u32 v5, v12, v5
+; CGP-NEXT:    v_mul_lo_u32 v11, v13, v6
 ; CGP-NEXT:    v_mul_lo_u32 v16, v12, v6
+; CGP-NEXT:    v_mul_hi_u32 v17, v13, v6
+; CGP-NEXT:    v_mul_hi_u32 v6, v12, v6
 ; CGP-NEXT:    v_add_i32_e32 v7, vcc, v7, v11
 ; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v7, vcc, v7, v10
-; CGP-NEXT:    v_mul_hi_u32 v10, v13, v6
 ; CGP-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v7, vcc, v11, v7
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v16, v5
-; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v10
 ; CGP-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v10, vcc, v11, v10
-; CGP-NEXT:    v_mul_hi_u32 v6, v12, v6
+; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v17
+; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v10, vcc, v10, v11
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v7
 ; CGP-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v7, vcc, v10, v7
@@ -916,11 +916,11 @@ define <2 x i64> @v_sdiv_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v8, vcc, v9, v8
 ; CGP-NEXT:    v_add_i32_e32 v12, vcc, v5, v7
-; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v7, vcc, v8, v5
-; CGP-NEXT:    v_mul_hi_u32 v8, v15, v6
+; CGP-NEXT:    v_mul_hi_u32 v9, v15, v6
 ; CGP-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v12, 0
-; CGP-NEXT:    v_add_i32_e32 v13, vcc, v8, v7
+; CGP-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v7, vcc, v8, v7
+; CGP-NEXT:    v_add_i32_e32 v13, vcc, v9, v7
 ; CGP-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v4, v13, v[6:7]
 ; CGP-NEXT:    v_sub_i32_e32 v5, vcc, v11, v5
 ; CGP-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v3, v12, v[7:8]
@@ -1065,9 +1065,9 @@ define i64 @v_sdiv_i64_oddk_denom(i64 %num) {
 ; CHECK-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v3, v4
 ; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v5, v3
 ; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v2, v11
 ; CHECK-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v5, v3
 ; CHECK-NEXT:    v_add_i32_e32 v4, vcc, v7, v4
 ; CHECK-NEXT:    v_mul_hi_u32 v5, v10, v6
 ; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v2, v3
@@ -1125,11 +1125,11 @@ define i64 @v_sdiv_i64_oddk_denom(i64 %num) {
 ; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v7, v3
 ; CHECK-NEXT:    v_add_i32_e32 v7, vcc, v0, v2
-; CHECK-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v3, v0
-; CHECK-NEXT:    v_mul_hi_u32 v3, v5, v1
+; CHECK-NEXT:    v_mul_hi_u32 v8, v5, v1
 ; CHECK-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v7, 0
-; CHECK-NEXT:    v_add_i32_e32 v8, vcc, v3, v2
+; CHECK-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v3, v2
+; CHECK-NEXT:    v_add_i32_e32 v8, vcc, v8, v2
 ; CHECK-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v6, v8, v[1:2]
 ; CHECK-NEXT:    v_sub_i32_e32 v0, vcc, v4, v0
 ; CHECK-NEXT:    v_subb_u32_e64 v1, s[4:5], v5, v2, vcc
@@ -1171,11 +1171,8 @@ define <2 x i64> @v_sdiv_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v4, 0x12d8fb
 ; GISEL-NEXT:    v_cvt_f32_ubyte0_e32 v5, 0
 ; GISEL-NEXT:    v_mov_b32_e32 v6, 0xffed2705
-; GISEL-NEXT:    s_mov_b32 s6, 1
 ; GISEL-NEXT:    v_mac_f32_e32 v4, 0x4f800000, v5
 ; GISEL-NEXT:    v_rcp_iflag_f32_e32 v4, v4
-; GISEL-NEXT:    s_cmp_lg_u32 s6, 0
-; GISEL-NEXT:    s_subb_u32 s6, 0, 0
 ; GISEL-NEXT:    v_mul_f32_e32 v4, 0x5f7ffffc, v4
 ; GISEL-NEXT:    v_mul_f32_e32 v5, 0x2f800000, v4
 ; GISEL-NEXT:    v_trunc_f32_e32 v5, v5
@@ -1184,25 +1181,28 @@ define <2 x i64> @v_sdiv_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v8, v5
 ; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v6, v7, 0
 ; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v6, v8, v[5:6]
-; GISEL-NEXT:    v_mul_hi_u32 v11, v7, v4
-; GISEL-NEXT:    v_mul_hi_u32 v12, v8, v4
+; GISEL-NEXT:    s_mov_b32 s4, 1
+; GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GISEL-NEXT:    s_subb_u32 s6, 0, 0
 ; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], s6, v7, v[9:10]
 ; GISEL-NEXT:    v_mul_lo_u32 v10, v8, v4
-; GISEL-NEXT:    v_mul_lo_u32 v9, v7, v13
-; GISEL-NEXT:    v_mul_lo_u32 v4, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v10, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v14, v9
+; GISEL-NEXT:    v_mul_hi_u32 v11, v7, v4
+; GISEL-NEXT:    v_mul_hi_u32 v12, v8, v4
+; GISEL-NEXT:    v_mul_lo_u32 v4, v7, v13
+; GISEL-NEXT:    v_mul_lo_u32 v9, v8, v13
 ; GISEL-NEXT:    v_mul_hi_u32 v14, v7, v13
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v12
+; GISEL-NEXT:    v_mul_hi_u32 v13, v8, v13
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v10, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v14
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v15, v4
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v14
 ; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v15, v14
-; GISEL-NEXT:    v_mul_hi_u32 v13, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v9
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v9, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v14, v9
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v13, v9
@@ -1214,11 +1214,8 @@ define <2 x i64> @v_sdiv_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_mul_hi_u32 v18, v4, v13
 ; GISEL-NEXT:    v_mul_hi_u32 v19, v17, v13
 ; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], s6, v4, v[15:16]
-; GISEL-NEXT:    s_mov_b32 s6, 1
-; GISEL-NEXT:    s_cmp_lg_u32 s6, 0
 ; GISEL-NEXT:    v_mul_lo_u32 v14, v4, v13
 ; GISEL-NEXT:    v_mul_hi_u32 v15, v4, v13
-; GISEL-NEXT:    s_subb_u32 s6, 0, 0
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v14
 ; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v18
@@ -1271,7 +1268,7 @@ define <2 x i64> @v_sdiv_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_subb_u32_e64 v1, s[4:5], v19, v15, vcc
 ; GISEL-NEXT:    v_sub_i32_e64 v13, s[4:5], v19, v15
 ; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v0, v4
-; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, -1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, -1, s[4:5]
 ; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v1
 ; GISEL-NEXT:    v_subbrev_u32_e32 v1, vcc, 0, v13, vcc
 ; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v0, v4
@@ -1281,44 +1278,46 @@ define <2 x i64> @v_sdiv_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
 ; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, -1, v14, s[4:5]
 ; GISEL-NEXT:    v_cndmask_b32_e32 v19, -1, v0, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v8, v[5:6]
-; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], s6, v7, v[0:1]
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v6, v8, v[5:6]
+; GISEL-NEXT:    s_mov_b32 s6, 1
+; GISEL-NEXT:    s_cmp_lg_u32 s6, 0
+; GISEL-NEXT:    s_subb_u32 s8, 0, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[6:7], s8, v7, v[0:1]
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, 1, v16
-; GISEL-NEXT:    v_mul_lo_u32 v5, v7, v13
-; GISEL-NEXT:    v_addc_u32_e32 v1, vcc, 0, v18, vcc
+; GISEL-NEXT:    v_addc_u32_e32 v5, vcc, 0, v18, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v1, v7, v13
 ; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v19
-; GISEL-NEXT:    v_cndmask_b32_e32 v14, v16, v0, vcc
-; GISEL-NEXT:    v_cndmask_b32_e32 v16, v18, v1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v10, v5
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v5, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, -1, v15, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e32 v15, v16, v0, vcc
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v10, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[4:5]
+; GISEL-NEXT:    v_mul_lo_u32 v10, v8, v13
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v1, v0
 ; GISEL-NEXT:    v_mul_hi_u32 v1, v7, v13
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v12
-; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v5, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v10, v5
-; GISEL-NEXT:    v_mul_hi_u32 v10, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v5, v1
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v10, v1
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v7, v0
-; GISEL-NEXT:    v_addc_u32_e32 v11, vcc, v8, v1, vcc
+; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v10, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v10, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v11, v10
+; GISEL-NEXT:    v_mul_hi_u32 v11, v8, v13
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v1, v0
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v10, v1
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v11, v1
+; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v7, v0
+; GISEL-NEXT:    v_addc_u32_e64 v11, s[4:5], v8, v1, s[4:5]
 ; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v10, 0
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v15
-; GISEL-NEXT:    v_cndmask_b32_e32 v5, v17, v14, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v6, v11, v[1:2]
-; GISEL-NEXT:    v_xor_b32_e32 v1, v5, v9
+; GISEL-NEXT:    v_cndmask_b32_e32 v5, v18, v5, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
 ; GISEL-NEXT:    v_ashrrev_i32_e32 v13, 31, v3
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], s6, v10, v[7:8]
-; GISEL-NEXT:    v_cndmask_b32_e32 v12, v20, v16, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v6, v11, v[1:2]
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v20, v5, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v12, v17, v15, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v13
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], s8, v10, v[7:8]
 ; GISEL-NEXT:    v_addc_u32_e32 v3, vcc, v3, v13, vcc
 ; GISEL-NEXT:    v_xor_b32_e32 v14, v2, v13
 ; GISEL-NEXT:    v_mul_lo_u32 v2, v11, v0
@@ -1349,7 +1348,7 @@ define <2 x i64> @v_sdiv_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_mul_lo_u32 v5, v14, v2
 ; GISEL-NEXT:    v_mul_hi_u32 v6, v14, v0
 ; GISEL-NEXT:    v_mul_hi_u32 v0, v15, v0
-; GISEL-NEXT:    v_xor_b32_e32 v7, v12, v9
+; GISEL-NEXT:    v_xor_b32_e32 v12, v12, v9
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v6
@@ -1363,15 +1362,16 @@ define <2 x i64> @v_sdiv_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
 ; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v0, v3
+; GISEL-NEXT:    v_mul_hi_u32 v6, v15, v2
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v10, 0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
-; GISEL-NEXT:    v_mul_hi_u32 v5, v15, v2
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v10, 0
-; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v5, v0
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v6, v0
 ; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v11, v[3:4]
-; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v1, v9
-; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v7, v9, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v1, v1, v9
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v12, v9
 ; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], 0, v10, v[5:6]
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v9, vcc
 ; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v14, v2
 ; GISEL-NEXT:    v_sub_i32_e64 v5, s[4:5], v15, v7
 ; GISEL-NEXT:    v_subb_u32_e64 v3, s[4:5], v15, v7, vcc
@@ -1428,14 +1428,14 @@ define <2 x i64> @v_sdiv_v2i64_oddk_denom(<2 x i64> %num) {
 ; CGP-NEXT:    v_mul_hi_u32 v12, v8, v12
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v9, v4
 ; CGP-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v13, vcc, v13, v11
+; CGP-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v4, v10
 ; CGP-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v15, v4
-; CGP-NEXT:    v_add_i32_e32 v13, vcc, v13, v11
-; CGP-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v13, vcc, v13, v14
 ; CGP-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v14, vcc, v15, v14
+; CGP-NEXT:    v_add_i32_e32 v14, vcc, v16, v14
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v13, v4
 ; CGP-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v13, vcc, v14, v13
@@ -1504,49 +1504,49 @@ define <2 x i64> @v_sdiv_v2i64_oddk_denom(<2 x i64> %num) {
 ; CGP-NEXT:    v_cndmask_b32_e64 v14, 0, -1, s[4:5]
 ; CGP-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v1
 ; CGP-NEXT:    v_subbrev_u32_e32 v1, vcc, 0, v13, vcc
-; CGP-NEXT:    v_sub_i32_e32 v0, vcc, v0, v4
-; CGP-NEXT:    v_subbrev_u32_e32 v1, vcc, 0, v1, vcc
+; CGP-NEXT:    v_sub_i32_e32 v13, vcc, v0, v4
+; CGP-NEXT:    v_cndmask_b32_e64 v17, -1, v14, s[4:5]
+; CGP-NEXT:    v_subbrev_u32_e32 v14, vcc, 0, v1, vcc
+; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v8, v[5:6]
 ; CGP-NEXT:    v_add_i32_e32 v18, vcc, 1, v15
 ; CGP-NEXT:    v_addc_u32_e32 v19, vcc, 0, v16, vcc
-; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v4
-; CGP-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
-; CGP-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v1
-; CGP-NEXT:    v_cndmask_b32_e64 v17, -1, v14, s[4:5]
-; CGP-NEXT:    v_cndmask_b32_e32 v20, -1, v0, vcc
-; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v8, v[5:6]
-; CGP-NEXT:    v_add_i32_e32 v5, vcc, 1, v18
+; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v13, v4
+; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc
+; CGP-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v14
 ; CGP-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], -1, v7, v[0:1]
-; CGP-NEXT:    v_addc_u32_e32 v21, vcc, 0, v19, vcc
-; CGP-NEXT:    v_mul_lo_u32 v1, v7, v13
-; CGP-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v20
-; CGP-NEXT:    v_cndmask_b32_e32 v0, v18, v5, vcc
-; CGP-NEXT:    v_cndmask_b32_e32 v5, v19, v21, vcc
-; CGP-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v17
-; CGP-NEXT:    v_cndmask_b32_e32 v14, v15, v0, vcc
-; CGP-NEXT:    v_add_i32_e64 v0, s[4:5], v9, v1
-; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
-; CGP-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v10
-; CGP-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[4:5]
-; CGP-NEXT:    v_mul_lo_u32 v9, v8, v13
-; CGP-NEXT:    v_add_i32_e64 v0, s[4:5], v1, v0
+; CGP-NEXT:    v_cndmask_b32_e32 v5, -1, v5, vcc
+; CGP-NEXT:    v_add_i32_e32 v0, vcc, 1, v18
+; CGP-NEXT:    v_addc_u32_e32 v1, vcc, 0, v19, vcc
+; CGP-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; CGP-NEXT:    v_mul_lo_u32 v5, v7, v13
+; CGP-NEXT:    v_cndmask_b32_e32 v14, v18, v0, vcc
+; CGP-NEXT:    v_cndmask_b32_e32 v18, v19, v1, vcc
+; CGP-NEXT:    v_add_i32_e32 v0, vcc, v9, v5
+; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v0, vcc, v0, v10
+; CGP-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
+; CGP-NEXT:    v_mul_lo_u32 v5, v8, v13
+; CGP-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
 ; CGP-NEXT:    v_mul_hi_u32 v1, v7, v13
-; CGP-NEXT:    v_add_i32_e64 v9, s[4:5], v9, v11
-; CGP-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s[4:5]
-; CGP-NEXT:    v_add_i32_e64 v1, s[4:5], v9, v1
-; CGP-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s[4:5]
-; CGP-NEXT:    v_add_i32_e64 v9, s[4:5], v10, v9
-; CGP-NEXT:    v_mul_hi_u32 v10, v8, v13
-; CGP-NEXT:    v_add_i32_e64 v0, s[4:5], v1, v0
-; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
-; CGP-NEXT:    v_add_i32_e64 v1, s[4:5], v9, v1
-; CGP-NEXT:    v_add_i32_e64 v1, s[4:5], v10, v1
-; CGP-NEXT:    v_add_i32_e64 v9, s[4:5], v7, v0
-; CGP-NEXT:    v_addc_u32_e64 v10, s[4:5], v8, v1, s[4:5]
+; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v11
+; CGP-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v1, vcc, v5, v1
+; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v5, vcc, v9, v5
+; CGP-NEXT:    v_mul_hi_u32 v9, v8, v13
+; CGP-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
+; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v1, vcc, v5, v1
+; CGP-NEXT:    v_add_i32_e32 v1, vcc, v9, v1
+; CGP-NEXT:    v_add_i32_e32 v9, vcc, v7, v0
+; CGP-NEXT:    v_addc_u32_e32 v10, vcc, v8, v1, vcc
 ; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v9, 0
-; CGP-NEXT:    v_cndmask_b32_e32 v5, v16, v5, vcc
+; CGP-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v17
+; CGP-NEXT:    v_cndmask_b32_e32 v5, v15, v14, vcc
 ; CGP-NEXT:    v_ashrrev_i32_e32 v13, 31, v3
 ; CGP-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v6, v10, v[1:2]
 ; CGP-NEXT:    v_xor_b32_e32 v1, v5, v12
+; CGP-NEXT:    v_cndmask_b32_e32 v11, v16, v18, vcc
 ; CGP-NEXT:    v_add_i32_e32 v2, vcc, v2, v13
 ; CGP-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], -1, v9, v[7:8]
 ; CGP-NEXT:    v_addc_u32_e32 v3, vcc, v3, v13, vcc
@@ -1577,10 +1577,10 @@ define <2 x i64> @v_sdiv_v2i64_oddk_denom(<2 x i64> %num) {
 ; CGP-NEXT:    v_addc_u32_e32 v2, vcc, v10, v2, vcc
 ; CGP-NEXT:    v_mul_lo_u32 v5, v8, v3
 ; CGP-NEXT:    v_mul_lo_u32 v6, v7, v2
-; CGP-NEXT:    v_xor_b32_e32 v11, v14, v12
 ; CGP-NEXT:    v_mul_hi_u32 v9, v7, v3
-; CGP-NEXT:    v_sub_i32_e32 v0, vcc, v11, v12
-; CGP-NEXT:    v_subb_u32_e32 v1, vcc, v1, v12, vcc
+; CGP-NEXT:    v_xor_b32_e32 v11, v11, v12
+; CGP-NEXT:    v_sub_i32_e32 v0, vcc, v1, v12
+; CGP-NEXT:    v_subb_u32_e32 v1, vcc, v11, v12, vcc
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v6
 ; CGP-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v9
@@ -1595,11 +1595,11 @@ define <2 x i64> @v_sdiv_v2i64_oddk_denom(<2 x i64> %num) {
 ; CGP-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v6, vcc, v9, v6
 ; CGP-NEXT:    v_add_i32_e32 v9, vcc, v3, v5
-; CGP-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v5, vcc, v6, v3
-; CGP-NEXT:    v_mul_hi_u32 v6, v8, v2
+; CGP-NEXT:    v_mul_hi_u32 v10, v8, v2
 ; CGP-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v9, 0
-; CGP-NEXT:    v_add_i32_e32 v10, vcc, v6, v5
+; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
+; CGP-NEXT:    v_add_i32_e32 v10, vcc, v10, v5
 ; CGP-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v10, v[3:4]
 ; CGP-NEXT:    v_sub_i32_e32 v2, vcc, v7, v2
 ; CGP-NEXT:    v_subb_u32_e64 v3, s[4:5], v8, v5, vcc
@@ -1653,7 +1653,7 @@ define i64 @v_sdiv_i64_pow2_shl_denom(i64 %x, i64 %y) {
 ; CHECK-NEXT:  ; %bb.1: ; %Flow
 ; CHECK-NEXT:    s_andn2_saveexec_b64 s[6:7], s[6:7]
 ; CHECK-NEXT:    s_cbranch_execnz .LBB7_4
-; CHECK-NEXT:  .LBB7_2:
+; CHECK-NEXT:  .LBB7_2: ; %.split
 ; CHECK-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
 ; CHECK-NEXT:  .LBB7_3:
@@ -1682,17 +1682,17 @@ define i64 @v_sdiv_i64_pow2_shl_denom(i64 %x, i64 %y) {
 ; CHECK-NEXT:    v_mul_hi_u32 v5, v11, v5
 ; CHECK-NEXT:    v_mul_lo_u32 v8, v12, v9
 ; CHECK-NEXT:    v_mul_lo_u32 v10, v11, v9
+; CHECK-NEXT:    v_mul_hi_u32 v15, v12, v9
 ; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v6, v8
 ; CHECK-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v6, v7
-; CHECK-NEXT:    v_mul_hi_u32 v7, v12, v9
 ; CHECK-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v8, v6
 ; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v10, v5
-; CHECK-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v5, v7
 ; CHECK-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v7, vcc, v8, v7
+; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v5, v15
+; CHECK-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v7, vcc, v7, v8
 ; CHECK-NEXT:    v_mul_hi_u32 v8, v11, v9
 ; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v5, v6
 ; CHECK-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
@@ -1748,11 +1748,11 @@ define i64 @v_sdiv_i64_pow2_shl_denom(i64 %x, i64 %y) {
 ; CHECK-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v7, v6
 ; CHECK-NEXT:    v_add_i32_e32 v9, vcc, v3, v5
-; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v6, v3
-; CHECK-NEXT:    v_mul_hi_u32 v6, v14, v4
+; CHECK-NEXT:    v_mul_hi_u32 v7, v14, v4
 ; CHECK-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v2, v9, 0
-; CHECK-NEXT:    v_add_i32_e32 v11, vcc, v6, v5
+; CHECK-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
+; CHECK-NEXT:    v_add_i32_e32 v11, vcc, v7, v5
 ; CHECK-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v2, v11, v[4:5]
 ; CHECK-NEXT:    v_sub_i32_e32 v3, vcc, v10, v3
 ; CHECK-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v1, v9, v[5:6]
@@ -1824,268 +1824,268 @@ define <2 x i64> @v_sdiv_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; GISEL-LABEL: v_sdiv_v2i64_pow2_shl_denom:
 ; GISEL:       ; %bb.0:
 ; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    v_mov_b32_e32 v12, 0x1000
-; GISEL-NEXT:    v_mov_b32_e32 v13, 0
-; GISEL-NEXT:    v_lshl_b64 v[7:8], v[12:13], v4
+; GISEL-NEXT:    v_mov_b32_e32 v11, 0x1000
+; GISEL-NEXT:    v_mov_b32_e32 v12, 0
+; GISEL-NEXT:    v_lshl_b64 v[7:8], v[11:12], v4
 ; GISEL-NEXT:    v_ashrrev_i32_e32 v4, 31, v8
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v7, v4
 ; GISEL-NEXT:    v_addc_u32_e32 v7, vcc, v8, v4, vcc
 ; GISEL-NEXT:    v_xor_b32_e32 v8, v5, v4
-; GISEL-NEXT:    v_xor_b32_e32 v7, v7, v4
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v5, v8
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v9, v7
+; GISEL-NEXT:    v_xor_b32_e32 v5, v7, v4
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v7, v8
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v9, v5
 ; GISEL-NEXT:    v_sub_i32_e32 v16, vcc, 0, v8
-; GISEL-NEXT:    v_subb_u32_e32 v18, vcc, 0, v7, vcc
-; GISEL-NEXT:    v_mac_f32_e32 v5, 0x4f800000, v9
-; GISEL-NEXT:    v_rcp_iflag_f32_e32 v5, v5
-; GISEL-NEXT:    v_mul_f32_e32 v5, 0x5f7ffffc, v5
-; GISEL-NEXT:    v_mul_f32_e32 v9, 0x2f800000, v5
+; GISEL-NEXT:    v_subb_u32_e32 v17, vcc, 0, v5, vcc
+; GISEL-NEXT:    v_mac_f32_e32 v7, 0x4f800000, v9
+; GISEL-NEXT:    v_rcp_iflag_f32_e32 v7, v7
+; GISEL-NEXT:    v_mul_f32_e32 v7, 0x5f7ffffc, v7
+; GISEL-NEXT:    v_mul_f32_e32 v9, 0x2f800000, v7
 ; GISEL-NEXT:    v_trunc_f32_e32 v9, v9
-; GISEL-NEXT:    v_mac_f32_e32 v5, 0xcf800000, v9
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v5, v5
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v11, v9
-; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v16, v5, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[14:15], s[4:5], v16, v11, v[10:11]
-; GISEL-NEXT:    v_mul_lo_u32 v17, v11, v9
-; GISEL-NEXT:    v_mul_hi_u32 v19, v5, v9
-; GISEL-NEXT:    v_mul_hi_u32 v20, v11, v9
-; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v18, v5, v[14:15]
-; GISEL-NEXT:    v_mul_lo_u32 v10, v5, v9
-; GISEL-NEXT:    v_mul_lo_u32 v15, v11, v9
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v17, v10
-; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
+; GISEL-NEXT:    v_mac_f32_e32 v7, 0xcf800000, v9
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v7, v7
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v15, v9
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v16, v7, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v16, v15, v[10:11]
+; GISEL-NEXT:    v_mul_lo_u32 v18, v15, v9
+; GISEL-NEXT:    v_mul_hi_u32 v19, v7, v9
+; GISEL-NEXT:    v_mul_hi_u32 v20, v15, v9
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v17, v7, v[13:14]
+; GISEL-NEXT:    v_mul_lo_u32 v10, v7, v9
+; GISEL-NEXT:    v_mul_lo_u32 v14, v15, v9
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v18, v10
+; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v19
 ; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v14, v10
-; GISEL-NEXT:    v_mul_hi_u32 v14, v5, v9
-; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v15, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v15, v14
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v17, v15
-; GISEL-NEXT:    v_mul_hi_u32 v9, v11, v9
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v14, v10
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v13, v10
+; GISEL-NEXT:    v_mul_hi_u32 v13, v7, v9
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v14, v20
+; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v14, v13
 ; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v15, v14
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v14
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v10
-; GISEL-NEXT:    v_addc_u32_e32 v19, vcc, v11, v9, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v16, v5, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[14:15], s[4:5], v16, v19, v[11:12]
-; GISEL-NEXT:    v_mul_lo_u32 v9, v19, v10
-; GISEL-NEXT:    v_lshl_b64 v[12:13], v[12:13], v6
-; GISEL-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v18, v5, v[14:15]
-; GISEL-NEXT:    v_mul_hi_u32 v14, v5, v10
-; GISEL-NEXT:    v_mul_lo_u32 v11, v5, v16
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v14
-; GISEL-NEXT:    v_ashrrev_i32_e32 v9, 31, v1
-; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v9
-; GISEL-NEXT:    v_addc_u32_e64 v1, s[4:5], v1, v9, s[4:5]
-; GISEL-NEXT:    v_xor_b32_e32 v14, v0, v9
-; GISEL-NEXT:    v_xor_b32_e32 v15, v1, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_mul_hi_u32 v1, v19, v10
-; GISEL-NEXT:    v_mul_lo_u32 v10, v19, v16
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v11, v0
-; GISEL-NEXT:    v_mul_hi_u32 v11, v5, v16
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v10, v1
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v18, v14
+; GISEL-NEXT:    v_mul_hi_u32 v9, v15, v9
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v13, v10
+; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v14, v13
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v13
+; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v7, v10
+; GISEL-NEXT:    v_addc_u32_e32 v19, vcc, v15, v9, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v16, v18, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v16, v19, v[10:11]
+; GISEL-NEXT:    v_mul_lo_u32 v7, v19, v9
+; GISEL-NEXT:    v_lshl_b64 v[11:12], v[11:12], v6
+; GISEL-NEXT:    v_mad_u64_u32 v[15:16], s[4:5], v17, v18, v[13:14]
+; GISEL-NEXT:    v_mul_hi_u32 v13, v18, v9
+; GISEL-NEXT:    v_ashrrev_i32_e32 v6, 31, v12
+; GISEL-NEXT:    v_mul_lo_u32 v10, v18, v15
+; GISEL-NEXT:    v_add_i32_e32 v7, vcc, v7, v10
 ; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v1, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v11
-; GISEL-NEXT:    v_mul_hi_u32 v11, v19, v16
+; GISEL-NEXT:    v_add_i32_e32 v7, vcc, v7, v13
+; GISEL-NEXT:    v_ashrrev_i32_e32 v7, 31, v1
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v7
+; GISEL-NEXT:    v_addc_u32_e64 v1, s[4:5], v1, v7, s[4:5]
+; GISEL-NEXT:    v_xor_b32_e32 v16, v0, v7
+; GISEL-NEXT:    v_xor_b32_e32 v17, v1, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
+; GISEL-NEXT:    v_mul_hi_u32 v1, v19, v9
+; GISEL-NEXT:    v_mul_lo_u32 v9, v19, v15
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v10, v0
+; GISEL-NEXT:    v_mul_hi_u32 v10, v18, v15
+; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v9, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v1, v10
+; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v10
+; GISEL-NEXT:    v_mul_hi_u32 v10, v19, v15
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v9, v1
 ; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v10, v1
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v11, v1
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v18, v0
 ; GISEL-NEXT:    v_addc_u32_e32 v1, vcc, v19, v1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v5, v15, v0
-; GISEL-NEXT:    v_mul_lo_u32 v10, v14, v1
-; GISEL-NEXT:    v_mul_hi_u32 v11, v14, v0
-; GISEL-NEXT:    v_mul_hi_u32 v0, v15, v0
-; GISEL-NEXT:    v_xor_b32_e32 v4, v9, v4
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v10
+; GISEL-NEXT:    v_mul_lo_u32 v9, v17, v0
+; GISEL-NEXT:    v_mul_lo_u32 v10, v16, v1
+; GISEL-NEXT:    v_mul_hi_u32 v13, v16, v0
+; GISEL-NEXT:    v_mul_hi_u32 v0, v17, v0
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v10
 ; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v11, v15, v1
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v10, v5
-; GISEL-NEXT:    v_mul_hi_u32 v10, v14, v1
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v11, v0
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v13
+; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v13, v17, v1
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v10, v9
+; GISEL-NEXT:    v_mul_hi_u32 v10, v16, v1
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v13, v0
+; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v10
 ; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v11, v10
-; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v0, v5
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v10, v0
-; GISEL-NEXT:    v_mul_hi_u32 v10, v15, v1
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v16, 0
-; GISEL-NEXT:    v_ashrrev_i32_e32 v9, 31, v3
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v10, v5
-; GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v8, v17, v[1:2]
-; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v14, v0
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v16, v[10:11]
-; GISEL-NEXT:    v_subb_u32_e64 v1, s[4:5], v15, v5, vcc
-; GISEL-NEXT:    v_sub_i32_e64 v5, s[4:5], v15, v5
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v1, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, -1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v13, v10
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v0, v9
+; GISEL-NEXT:    v_mul_hi_u32 v13, v17, v1
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v15, 0
+; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v10, v9
+; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v13, v9
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v8, v18, v[1:2]
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v16, v0
+; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v5, v15, v[9:10]
+; GISEL-NEXT:    v_subb_u32_e64 v16, s[4:5], v17, v13, vcc
+; GISEL-NEXT:    v_sub_i32_e64 v1, s[4:5], v17, v13
+; GISEL-NEXT:    v_add_i32_e64 v9, s[4:5], v11, v6
+; GISEL-NEXT:    v_addc_u32_e64 v11, s[4:5], v12, v6, s[4:5]
+; GISEL-NEXT:    v_xor_b32_e32 v10, v9, v6
+; GISEL-NEXT:    v_xor_b32_e32 v9, v11, v6
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v11, v10
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v12, v9
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v5, vcc
 ; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v0, v8
-; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v1, v7
-; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v5, v7, vcc
+; GISEL-NEXT:    v_mac_f32_e32 v11, 0x4f800000, v12
+; GISEL-NEXT:    v_rcp_iflag_f32_e32 v11, v11
 ; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v0, v8
-; GISEL-NEXT:    v_subbrev_u32_e32 v1, vcc, 0, v1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v14, vcc, 1, v16
-; GISEL-NEXT:    v_addc_u32_e32 v15, vcc, 0, v17, vcc
-; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v7
-; GISEL-NEXT:    v_ashrrev_i32_e32 v5, 31, v13
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, v6, v10, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, -1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v12, v5
-; GISEL-NEXT:    v_addc_u32_e32 v12, vcc, v13, v5, vcc
-; GISEL-NEXT:    v_xor_b32_e32 v10, v6, v5
-; GISEL-NEXT:    v_xor_b32_e32 v6, v12, v5
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v12, v10
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v13, v6
+; GISEL-NEXT:    v_subbrev_u32_e32 v17, vcc, 0, v1, vcc
 ; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v8
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
-; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v7
-; GISEL-NEXT:    v_mac_f32_e32 v12, 0x4f800000, v13
-; GISEL-NEXT:    v_rcp_iflag_f32_e32 v1, v12
-; GISEL-NEXT:    v_cndmask_b32_e32 v0, v18, v0, vcc
-; GISEL-NEXT:    v_add_i32_e32 v7, vcc, 1, v14
-; GISEL-NEXT:    v_addc_u32_e32 v12, vcc, 0, v15, vcc
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
-; GISEL-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v1
+; GISEL-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v11
 ; GISEL-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; GISEL-NEXT:    v_trunc_f32_e32 v1, v1
 ; GISEL-NEXT:    v_mac_f32_e32 v0, 0xcf800000, v1
-; GISEL-NEXT:    v_cndmask_b32_e32 v13, v14, v7, vcc
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v14, v0
-; GISEL-NEXT:    v_sub_i32_e64 v19, s[4:5], 0, v10
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v18, v1
-; GISEL-NEXT:    v_subb_u32_e64 v20, s[4:5], 0, v6, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v19, v14, 0
-; GISEL-NEXT:    v_cndmask_b32_e32 v12, v15, v12, vcc
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v19, v18, v[1:2]
-; GISEL-NEXT:    v_mul_lo_u32 v21, v18, v0
-; GISEL-NEXT:    v_mul_hi_u32 v22, v14, v0
-; GISEL-NEXT:    v_mul_hi_u32 v23, v18, v0
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v20, v14, v[7:8]
-; GISEL-NEXT:    v_cndmask_b32_e32 v11, v16, v13, vcc
-; GISEL-NEXT:    v_cndmask_b32_e32 v15, v17, v12, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v1, v14, v0
-; GISEL-NEXT:    v_mul_lo_u32 v8, v18, v0
-; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v21, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v1, v22
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v7, v1
-; GISEL-NEXT:    v_mul_hi_u32 v7, v14, v0
-; GISEL-NEXT:    v_add_i32_e64 v8, s[4:5], v8, v23
-; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v7, s[4:5], v8, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v8, s[4:5], v13, v8
-; GISEL-NEXT:    v_mul_hi_u32 v0, v18, v0
-; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v7, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v7, s[4:5], v8, v7
-; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v7
-; GISEL-NEXT:    v_add_i32_e64 v13, s[4:5], v14, v1
-; GISEL-NEXT:    v_addc_u32_e64 v14, s[4:5], v18, v0, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v19, v13, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v19, v14, v[1:2]
-; GISEL-NEXT:    v_xor_b32_e32 v1, v11, v4
-; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v9
-; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v20, v13, v[7:8]
-; GISEL-NEXT:    v_addc_u32_e32 v3, vcc, v3, v9, vcc
-; GISEL-NEXT:    v_xor_b32_e32 v12, v2, v9
-; GISEL-NEXT:    v_mul_lo_u32 v2, v14, v0
-; GISEL-NEXT:    v_mul_lo_u32 v7, v13, v11
-; GISEL-NEXT:    v_xor_b32_e32 v16, v3, v9
-; GISEL-NEXT:    v_mul_hi_u32 v3, v13, v0
-; GISEL-NEXT:    v_mul_hi_u32 v0, v14, v0
-; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v8, v0
+; GISEL-NEXT:    v_sub_i32_e64 v20, s[6:7], 0, v10
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v19, v1
+; GISEL-NEXT:    v_subb_u32_e64 v21, s[6:7], 0, v9, s[6:7]
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v20, v8, 0
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[8:9], v17, v5
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[6:7], v20, v19, v[1:2]
+; GISEL-NEXT:    v_mul_lo_u32 v1, v19, v0
+; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[6:7], v21, v8, v[11:12]
+; GISEL-NEXT:    v_mul_lo_u32 v11, v8, v13
+; GISEL-NEXT:    v_add_i32_e64 v1, s[6:7], v1, v11
+; GISEL-NEXT:    v_mul_hi_u32 v11, v8, v0
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s[6:7]
+; GISEL-NEXT:    v_mul_hi_u32 v0, v19, v0
+; GISEL-NEXT:    v_add_i32_e64 v1, s[6:7], v1, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[8:9]
+; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, -1, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v17, v5
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[8:9], v16, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, -1, s[8:9]
+; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s[4:5]
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v16, v5
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v1, v11, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, 1, v15
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, v14, v17, s[4:5]
+; GISEL-NEXT:    v_addc_u32_e32 v14, vcc, 0, v18, vcc
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, 1, v11
+; GISEL-NEXT:    v_addc_u32_e32 v17, vcc, 0, v14, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[6:7]
+; GISEL-NEXT:    v_cndmask_b32_e32 v11, v11, v16, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v14, v14, v17, vcc
+; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v12, v1
+; GISEL-NEXT:    v_mul_lo_u32 v12, v19, v13
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v12, v0
+; GISEL-NEXT:    v_mul_hi_u32 v12, v8, v13
+; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc
+; GISEL-NEXT:    v_mul_hi_u32 v13, v19, v13
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v16, v12
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v12, v1
+; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v13, v1
+; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v8, v0
+; GISEL-NEXT:    v_addc_u32_e32 v13, vcc, v19, v1, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v20, v8, 0
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; GISEL-NEXT:    v_cndmask_b32_e32 v5, v15, v11, vcc
+; GISEL-NEXT:    v_ashrrev_i32_e32 v15, 31, v3
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v20, v13, v[1:2]
+; GISEL-NEXT:    v_xor_b32_e32 v1, v7, v4
+; GISEL-NEXT:    v_xor_b32_e32 v7, v5, v1
+; GISEL-NEXT:    v_cndmask_b32_e32 v14, v18, v14, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v21, v8, v[11:12]
+; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v15
+; GISEL-NEXT:    v_addc_u32_e32 v3, vcc, v3, v15, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v11, v2, v15
+; GISEL-NEXT:    v_mul_lo_u32 v2, v13, v0
+; GISEL-NEXT:    v_mul_lo_u32 v5, v8, v4
+; GISEL-NEXT:    v_xor_b32_e32 v12, v3, v15
+; GISEL-NEXT:    v_mul_hi_u32 v3, v8, v0
+; GISEL-NEXT:    v_mul_hi_u32 v0, v13, v0
+; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v3
 ; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v3, v14, v11
-; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v7, v2
-; GISEL-NEXT:    v_mul_hi_u32 v7, v13, v11
+; GISEL-NEXT:    v_mul_lo_u32 v3, v13, v4
+; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v5, v2
+; GISEL-NEXT:    v_mul_hi_u32 v5, v8, v4
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v3, v0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v7
-; GISEL-NEXT:    v_mul_hi_u32 v7, v14, v11
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v5
+; GISEL-NEXT:    v_mul_hi_u32 v4, v13, v4
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v2
 ; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v3, v2
-; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v7, v2
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v13, v0
-; GISEL-NEXT:    v_addc_u32_e32 v2, vcc, v14, v2, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v3, v16, v0
-; GISEL-NEXT:    v_mul_lo_u32 v7, v12, v2
-; GISEL-NEXT:    v_mul_hi_u32 v8, v12, v0
-; GISEL-NEXT:    v_mul_hi_u32 v0, v16, v0
-; GISEL-NEXT:    v_xor_b32_e32 v11, v15, v4
-; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v8
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v8, v16, v2
-; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v7, v3
-; GISEL-NEXT:    v_mul_hi_u32 v7, v12, v2
+; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v4, v2
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v8, v0
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v7, vcc, v8, v7
+; GISEL-NEXT:    v_addc_u32_e32 v2, vcc, v13, v2, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v3, v12, v0
+; GISEL-NEXT:    v_mul_lo_u32 v4, v11, v2
+; GISEL-NEXT:    v_mul_hi_u32 v5, v11, v0
+; GISEL-NEXT:    v_mul_hi_u32 v0, v12, v0
+; GISEL-NEXT:    v_xor_b32_e32 v8, v14, v1
+; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v5, v12, v2
+; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v4, v3
+; GISEL-NEXT:    v_mul_hi_u32 v4, v11, v2
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v5, v4
 ; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v0, v3
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v7, v0
-; GISEL-NEXT:    v_mul_hi_u32 v7, v16, v2
+; GISEL-NEXT:    v_mul_hi_u32 v5, v12, v2
 ; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v10, v13, 0
-; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v7, v0
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v10, v14, v[3:4]
-; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v1, v4
-; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v11, v4, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v6, v13, v[7:8]
-; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v12, v2
-; GISEL-NEXT:    v_subb_u32_e64 v4, s[4:5], v16, v3, vcc
-; GISEL-NEXT:    v_sub_i32_e64 v3, s[4:5], v16, v3
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v4, v6
-; GISEL-NEXT:    v_subb_u32_e32 v3, vcc, v3, v6, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, -1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v4, v0
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v5, v0
+; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v10, v14, v[3:4]
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v7, v1
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v8, v1, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v9, v13, v[4:5]
+; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v11, v2
+; GISEL-NEXT:    v_subb_u32_e64 v3, s[4:5], v12, v7, vcc
+; GISEL-NEXT:    v_sub_i32_e64 v4, s[4:5], v12, v7
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v3, v9
+; GISEL-NEXT:    v_subb_u32_e32 v4, vcc, v4, v9, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, -1, s[4:5]
 ; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v2, v10
 ; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v2, v10
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v4, v6
-; GISEL-NEXT:    v_subbrev_u32_e32 v3, vcc, 0, v3, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v4, v7, v8, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v7, vcc, 1, v13
-; GISEL-NEXT:    v_addc_u32_e32 v8, vcc, 0, v14, vcc
-; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v3, v6
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, -1, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, -1, s[4:5]
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v3, v9
+; GISEL-NEXT:    v_subbrev_u32_e32 v4, vcc, 0, v4, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v3, v5, v7, s[4:5]
+; GISEL-NEXT:    v_add_i32_e32 v5, vcc, 1, v13
+; GISEL-NEXT:    v_addc_u32_e32 v7, vcc, 0, v14, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v4, v9
+; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v2, v10
 ; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, -1, vcc
-; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v3, v6
-; GISEL-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
-; GISEL-NEXT:    v_add_i32_e32 v3, vcc, 1, v7
-; GISEL-NEXT:    v_addc_u32_e32 v6, vcc, 0, v8, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v4, v9
+; GISEL-NEXT:    v_cndmask_b32_e32 v2, v8, v2, vcc
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, 1, v5
+; GISEL-NEXT:    v_addc_u32_e32 v8, vcc, 0, v7, vcc
 ; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GISEL-NEXT:    v_cndmask_b32_e32 v2, v7, v3, vcc
-; GISEL-NEXT:    v_cndmask_b32_e32 v3, v8, v6, vcc
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; GISEL-NEXT:    v_cndmask_b32_e32 v2, v5, v4, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v4, v7, v8, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
 ; GISEL-NEXT:    v_cndmask_b32_e32 v2, v13, v2, vcc
-; GISEL-NEXT:    v_xor_b32_e32 v4, v9, v5
-; GISEL-NEXT:    v_cndmask_b32_e32 v3, v14, v3, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v14, v4, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v4, v15, v6
 ; GISEL-NEXT:    v_xor_b32_e32 v2, v2, v4
 ; GISEL-NEXT:    v_xor_b32_e32 v3, v3, v4
 ; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v2, v4
@@ -2135,17 +2135,17 @@ define <2 x i64> @v_sdiv_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; CGP-NEXT:    v_mul_hi_u32 v10, v16, v10
 ; CGP-NEXT:    v_mul_lo_u32 v13, v17, v14
 ; CGP-NEXT:    v_mul_lo_u32 v15, v16, v14
+; CGP-NEXT:    v_mul_hi_u32 v20, v17, v14
 ; CGP-NEXT:    v_add_i32_e32 v11, vcc, v11, v13
 ; CGP-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v11, vcc, v11, v12
-; CGP-NEXT:    v_mul_hi_u32 v12, v17, v14
 ; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v11, vcc, v13, v11
 ; CGP-NEXT:    v_add_i32_e32 v10, vcc, v15, v10
-; CGP-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v10, vcc, v10, v12
 ; CGP-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v12, vcc, v13, v12
+; CGP-NEXT:    v_add_i32_e32 v10, vcc, v10, v20
+; CGP-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v12, vcc, v12, v13
 ; CGP-NEXT:    v_mul_hi_u32 v13, v16, v14
 ; CGP-NEXT:    v_add_i32_e32 v10, vcc, v10, v11
 ; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
@@ -2201,11 +2201,11 @@ define <2 x i64> @v_sdiv_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v11, vcc, v12, v11
 ; CGP-NEXT:    v_add_i32_e32 v14, vcc, v8, v10
-; CGP-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v10, vcc, v11, v8
-; CGP-NEXT:    v_mul_hi_u32 v11, v19, v9
+; CGP-NEXT:    v_mul_hi_u32 v12, v19, v9
 ; CGP-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v4, v14, 0
-; CGP-NEXT:    v_add_i32_e32 v16, vcc, v11, v10
+; CGP-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v10, vcc, v11, v10
+; CGP-NEXT:    v_add_i32_e32 v16, vcc, v12, v10
 ; CGP-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v4, v16, v[9:10]
 ; CGP-NEXT:    v_sub_i32_e32 v8, vcc, v15, v8
 ; CGP-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v1, v14, v[10:11]
@@ -2269,7 +2269,7 @@ define <2 x i64> @v_sdiv_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; CGP-NEXT:    v_add_i32_e32 v3, vcc, 1, v0
 ; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v2, v11
 ; CGP-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc
-; CGP-NEXT:  .LBB8_4:
+; CGP-NEXT:  .LBB8_4: ; %.split
 ; CGP-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; CGP-NEXT:    v_or_b32_e32 v3, v7, v10
 ; CGP-NEXT:    v_mov_b32_e32 v2, 0
@@ -2281,7 +2281,7 @@ define <2 x i64> @v_sdiv_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; CGP-NEXT:  ; %bb.5: ; %Flow
 ; CGP-NEXT:    s_andn2_saveexec_b64 s[6:7], s[6:7]
 ; CGP-NEXT:    s_cbranch_execnz .LBB8_8
-; CGP-NEXT:  .LBB8_6:
+; CGP-NEXT:  .LBB8_6: ; %.split.split
 ; CGP-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; CGP-NEXT:    s_setpc_b64 s[30:31]
 ; CGP-NEXT:  .LBB8_7:
@@ -2310,17 +2310,17 @@ define <2 x i64> @v_sdiv_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; CGP-NEXT:    v_mul_hi_u32 v8, v14, v8
 ; CGP-NEXT:    v_mul_lo_u32 v11, v6, v12
 ; CGP-NEXT:    v_mul_lo_u32 v13, v14, v12
+; CGP-NEXT:    v_mul_hi_u32 v17, v6, v12
 ; CGP-NEXT:    v_add_i32_e32 v9, vcc, v9, v11
 ; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v9, vcc, v9, v10
-; CGP-NEXT:    v_mul_hi_u32 v10, v6, v12
 ; CGP-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v9, vcc, v11, v9
 ; CGP-NEXT:    v_add_i32_e32 v8, vcc, v13, v8
-; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v8, vcc, v8, v10
 ; CGP-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v10, vcc, v11, v10
+; CGP-NEXT:    v_add_i32_e32 v8, vcc, v8, v17
+; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v10, vcc, v10, v11
 ; CGP-NEXT:    v_mul_hi_u32 v11, v14, v12
 ; CGP-NEXT:    v_add_i32_e32 v8, vcc, v8, v9
 ; CGP-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
@@ -2376,11 +2376,11 @@ define <2 x i64> @v_sdiv_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; CGP-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v8, vcc, v9, v8
 ; CGP-NEXT:    v_add_i32_e32 v12, vcc, v5, v7
-; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v7, vcc, v8, v5
-; CGP-NEXT:    v_mul_hi_u32 v8, v13, v6
+; CGP-NEXT:    v_mul_hi_u32 v9, v13, v6
 ; CGP-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v12, 0
-; CGP-NEXT:    v_add_i32_e32 v14, vcc, v8, v7
+; CGP-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v7, vcc, v8, v7
+; CGP-NEXT:    v_add_i32_e32 v14, vcc, v9, v7
 ; CGP-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v4, v14, v[6:7]
 ; CGP-NEXT:    v_sub_i32_e32 v5, vcc, v11, v5
 ; CGP-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v3, v12, v[7:8]
@@ -2514,144 +2514,144 @@ define <2 x i64> @v_sdiv_v2i64_24bit(<2 x i64> %num, <2 x i64> %den) {
 ; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GISEL-NEXT:    v_and_b32_e32 v1, 0xffffff, v4
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v3, v1
-; GISEL-NEXT:    v_cvt_f32_ubyte0_e32 v10, 0
-; GISEL-NEXT:    v_sub_i32_e32 v12, vcc, 0, v1
-; GISEL-NEXT:    v_mac_f32_e32 v3, 0x4f800000, v10
+; GISEL-NEXT:    v_cvt_f32_ubyte0_e32 v9, 0
+; GISEL-NEXT:    v_sub_i32_e32 v11, vcc, 0, v1
+; GISEL-NEXT:    v_mac_f32_e32 v3, 0x4f800000, v9
 ; GISEL-NEXT:    v_rcp_iflag_f32_e32 v3, v3
-; GISEL-NEXT:    v_subb_u32_e64 v13, s[4:5], 0, 0, vcc
+; GISEL-NEXT:    v_subb_u32_e64 v12, s[4:5], 0, 0, vcc
 ; GISEL-NEXT:    v_and_b32_e32 v2, 0xffffff, v2
 ; GISEL-NEXT:    v_mul_f32_e32 v3, 0x5f7ffffc, v3
 ; GISEL-NEXT:    v_mul_f32_e32 v4, 0x2f800000, v3
 ; GISEL-NEXT:    v_trunc_f32_e32 v4, v4
 ; GISEL-NEXT:    v_mac_f32_e32 v3, 0xcf800000, v4
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v11, v3
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v9, v4
-; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v12, v11, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v12, v9, v[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v13, v11, v[7:8]
-; GISEL-NEXT:    v_mul_lo_u32 v5, v9, v3
-; GISEL-NEXT:    v_mul_hi_u32 v7, v11, v3
-; GISEL-NEXT:    v_mul_lo_u32 v8, v11, v4
-; GISEL-NEXT:    v_mul_hi_u32 v3, v9, v3
-; GISEL-NEXT:    v_mul_lo_u32 v14, v9, v4
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v10, v3
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v13, v4
+; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v11, v10, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v11, v13, v[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v12, v10, v[7:8]
+; GISEL-NEXT:    v_mul_lo_u32 v5, v13, v3
+; GISEL-NEXT:    v_mul_hi_u32 v7, v10, v3
+; GISEL-NEXT:    v_mul_hi_u32 v3, v13, v3
+; GISEL-NEXT:    v_mul_lo_u32 v8, v10, v4
+; GISEL-NEXT:    v_mul_lo_u32 v14, v13, v4
+; GISEL-NEXT:    v_mul_hi_u32 v15, v10, v4
+; GISEL-NEXT:    v_mul_hi_u32 v4, v13, v4
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v8
 ; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v7
-; GISEL-NEXT:    v_mul_hi_u32 v7, v11, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v8, v5
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v14, v3
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v7
 ; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v7, vcc, v8, v7
-; GISEL-NEXT:    v_mul_hi_u32 v4, v9, v4
+; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v15
+; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v7, vcc, v7, v8
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v7, v5
 ; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v5
-; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v3
-; GISEL-NEXT:    v_addc_u32_e32 v9, vcc, v9, v4, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v12, v11, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v12, v9, v[4:5]
-; GISEL-NEXT:    v_and_b32_e32 v12, 0xffffff, v0
-; GISEL-NEXT:    v_mul_hi_u32 v0, v11, v3
-; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v13, v11, v[7:8]
-; GISEL-NEXT:    v_mul_lo_u32 v5, v9, v3
-; GISEL-NEXT:    v_mul_hi_u32 v3, v9, v3
-; GISEL-NEXT:    v_mul_lo_u32 v7, v11, v4
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v3
+; GISEL-NEXT:    v_addc_u32_e32 v13, vcc, v13, v4, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v11, v10, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v11, v13, v[4:5]
+; GISEL-NEXT:    v_and_b32_e32 v11, 0xffffff, v0
+; GISEL-NEXT:    v_mul_hi_u32 v0, v10, v3
+; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v12, v10, v[7:8]
+; GISEL-NEXT:    v_mul_lo_u32 v5, v13, v3
+; GISEL-NEXT:    v_mul_hi_u32 v3, v13, v3
+; GISEL-NEXT:    v_mul_lo_u32 v7, v10, v4
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v7
 ; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v5, v9, v4
+; GISEL-NEXT:    v_mul_lo_u32 v5, v13, v4
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v7, v0
-; GISEL-NEXT:    v_mul_hi_u32 v7, v11, v4
+; GISEL-NEXT:    v_mul_hi_u32 v7, v10, v4
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v5, v3
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v7
 ; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v7
-; GISEL-NEXT:    v_mul_hi_u32 v4, v9, v4
+; GISEL-NEXT:    v_mul_hi_u32 v4, v13, v4
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v3, v0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v5, v3
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v4, v3
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v11, v0
-; GISEL-NEXT:    v_addc_u32_e32 v3, vcc, v9, v3, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v4, 0, v0
-; GISEL-NEXT:    v_mul_lo_u32 v5, v12, v3
-; GISEL-NEXT:    v_mul_hi_u32 v7, v12, v0
-; GISEL-NEXT:    v_mul_hi_u32 v0, 0, v0
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v5
-; GISEL-NEXT:    v_mul_lo_u32 v5, 0, v3
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v7
-; GISEL-NEXT:    v_mul_hi_u32 v7, v12, v3
-; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v7
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v4
-; GISEL-NEXT:    v_mul_hi_u32 v4, 0, v3
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v1, v0, 0
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v10, v0
+; GISEL-NEXT:    v_addc_u32_e32 v4, vcc, v13, v3, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v5, 0, v0
+; GISEL-NEXT:    v_mul_lo_u32 v7, v11, v4
 ; GISEL-NEXT:    v_and_b32_e32 v3, 0xffffff, v6
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v11, v3
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v1, v4, v[8:9]
-; GISEL-NEXT:    v_mac_f32_e32 v11, 0x4f800000, v10
-; GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], 0, v0, v[5:6]
-; GISEL-NEXT:    v_rcp_iflag_f32_e32 v5, v11
-; GISEL-NEXT:    v_sub_i32_e32 v11, vcc, v12, v7
-; GISEL-NEXT:    v_subb_u32_e64 v12, s[4:5], 0, v8, vcc
-; GISEL-NEXT:    v_mul_f32_e32 v5, 0x5f7ffffc, v5
-; GISEL-NEXT:    v_mul_f32_e32 v6, 0x2f800000, v5
-; GISEL-NEXT:    v_trunc_f32_e32 v6, v6
-; GISEL-NEXT:    v_mac_f32_e32 v5, 0xcf800000, v6
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v13, v5
-; GISEL-NEXT:    v_sub_i32_e64 v15, s[4:5], 0, v3
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v14, v6
-; GISEL-NEXT:    v_subb_u32_e64 v16, s[4:5], 0, 0, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v15, v13, 0
-; GISEL-NEXT:    v_sub_i32_e64 v17, s[4:5], 0, v8
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v15, v14, v[6:7]
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v11, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, -1, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v16, v13, v[7:8]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v12
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, -1, v6, s[4:5]
-; GISEL-NEXT:    v_mul_lo_u32 v6, v14, v5
-; GISEL-NEXT:    v_mul_lo_u32 v7, v13, v9
-; GISEL-NEXT:    v_mul_hi_u32 v10, v13, v5
-; GISEL-NEXT:    v_subbrev_u32_e32 v8, vcc, 0, v17, vcc
-; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v10
-; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v10, v14, v9
-; GISEL-NEXT:    v_mul_hi_u32 v5, v14, v5
-; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v7, v6
-; GISEL-NEXT:    v_mul_hi_u32 v7, v13, v9
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v10, v5
-; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
+; GISEL-NEXT:    v_mul_hi_u32 v6, v11, v0
+; GISEL-NEXT:    v_mul_hi_u32 v0, 0, v0
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v7, vcc, v10, v7
-; GISEL-NEXT:    v_mul_hi_u32 v9, v14, v9
+; GISEL-NEXT:    v_mul_lo_u32 v7, 0, v4
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v6
+; GISEL-NEXT:    v_mul_hi_u32 v6, v11, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v7, v0
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v6
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v5
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v10, v3
+; GISEL-NEXT:    v_mul_hi_u32 v4, 0, v4
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v1, v0, 0
+; GISEL-NEXT:    v_sub_i32_e32 v14, vcc, 0, v3
+; GISEL-NEXT:    v_mac_f32_e32 v10, 0x4f800000, v9
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v1, v4, v[6:7]
+; GISEL-NEXT:    v_rcp_iflag_f32_e32 v6, v10
+; GISEL-NEXT:    v_subb_u32_e64 v15, s[4:5], 0, 0, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], 0, v0, v[7:8]
+; GISEL-NEXT:    v_mul_f32_e32 v6, 0x5f7ffffc, v6
+; GISEL-NEXT:    v_mul_f32_e32 v7, 0x2f800000, v6
+; GISEL-NEXT:    v_trunc_f32_e32 v7, v7
+; GISEL-NEXT:    v_mac_f32_e32 v6, 0xcf800000, v7
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v12, v6
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v13, v7
+; GISEL-NEXT:    v_sub_i32_e32 v16, vcc, v11, v5
+; GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v14, v12, 0
+; GISEL-NEXT:    v_subb_u32_e64 v5, s[4:5], 0, v9, vcc
+; GISEL-NEXT:    v_sub_i32_e64 v9, s[4:5], 0, v9
+; GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v14, v13, v[7:8]
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v16, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s[4:5]
+; GISEL-NEXT:    v_subbrev_u32_e32 v9, vcc, 0, v9, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v15, v12, v[10:11]
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v5
+; GISEL-NEXT:    v_mul_lo_u32 v5, v13, v6
+; GISEL-NEXT:    v_mul_hi_u32 v10, v12, v6
+; GISEL-NEXT:    v_mul_lo_u32 v8, v12, v7
+; GISEL-NEXT:    v_mul_hi_u32 v6, v13, v6
+; GISEL-NEXT:    v_cndmask_b32_e64 v11, -1, v17, s[4:5]
+; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v8
+; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v10
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v10, v13, v7
+; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v8, v5
+; GISEL-NEXT:    v_mul_hi_u32 v8, v12, v7
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v10, v6
+; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v8
+; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v10, v8
+; GISEL-NEXT:    v_mul_hi_u32 v7, v13, v7
+; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v8, v6
 ; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v7, v6
-; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v9, v6
-; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v13, v5
-; GISEL-NEXT:    v_addc_u32_e32 v14, vcc, v14, v6, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v15, v13, 0
-; GISEL-NEXT:    v_sub_i32_e32 v11, vcc, v11, v1
-; GISEL-NEXT:    v_subbrev_u32_e32 v17, vcc, 0, v8, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v15, v14, v[6:7]
-; GISEL-NEXT:    v_add_i32_e32 v15, vcc, 1, v0
-; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v16, v13, v[7:8]
-; GISEL-NEXT:    v_mul_lo_u32 v6, v14, v5
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v5
+; GISEL-NEXT:    v_addc_u32_e32 v13, vcc, v13, v6, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v14, v12, 0
+; GISEL-NEXT:    v_sub_i32_e32 v16, vcc, v16, v1
+; GISEL-NEXT:    v_subbrev_u32_e32 v17, vcc, 0, v9, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v14, v13, v[6:7]
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, 1, v0
+; GISEL-NEXT:    v_mul_lo_u32 v6, v13, v5
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v15, v12, v[7:8]
 ; GISEL-NEXT:    v_addc_u32_e32 v18, vcc, 0, v4, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v7, v13, v9
-; GISEL-NEXT:    v_mul_hi_u32 v8, v13, v5
-; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v11, v1
+; GISEL-NEXT:    v_mul_hi_u32 v8, v12, v5
+; GISEL-NEXT:    v_mul_lo_u32 v7, v12, v9
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v16, v1
 ; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
 ; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v17
 ; GISEL-NEXT:    v_cndmask_b32_e32 v1, -1, v1, vcc
@@ -2659,46 +2659,46 @@ define <2 x i64> @v_sdiv_v2i64_24bit(<2 x i64> %num, <2 x i64> %den) {
 ; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v8
 ; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v8, v14, v9
-; GISEL-NEXT:    v_mul_hi_u32 v5, v14, v5
+; GISEL-NEXT:    v_mul_lo_u32 v8, v13, v9
+; GISEL-NEXT:    v_mul_hi_u32 v5, v13, v5
 ; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v7, v6
-; GISEL-NEXT:    v_mul_hi_u32 v7, v13, v9
+; GISEL-NEXT:    v_mul_hi_u32 v7, v12, v9
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v8, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v7
 ; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v7, vcc, v8, v7
-; GISEL-NEXT:    v_mul_hi_u32 v8, v14, v9
+; GISEL-NEXT:    v_mul_hi_u32 v8, v13, v9
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v6
 ; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v7, v6
 ; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v8, v6
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v13, v5
-; GISEL-NEXT:    v_addc_u32_e32 v6, vcc, v14, v6, vcc
+; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v12, v5
+; GISEL-NEXT:    v_addc_u32_e32 v6, vcc, v13, v6, vcc
 ; GISEL-NEXT:    v_mul_lo_u32 v7, 0, v5
 ; GISEL-NEXT:    v_mul_lo_u32 v8, v2, v6
-; GISEL-NEXT:    v_mul_hi_u32 v11, v2, v5
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, 1, v15
+; GISEL-NEXT:    v_mul_hi_u32 v12, v2, v5
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, 1, v14
 ; GISEL-NEXT:    v_addc_u32_e32 v10, vcc, 0, v18, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v7, vcc, v7, v8
 ; GISEL-NEXT:    v_mul_lo_u32 v8, 0, v6
 ; GISEL-NEXT:    v_mul_hi_u32 v5, 0, v5
-; GISEL-NEXT:    v_add_i32_e32 v7, vcc, v7, v11
-; GISEL-NEXT:    v_mul_hi_u32 v11, v2, v6
+; GISEL-NEXT:    v_add_i32_e32 v7, vcc, v7, v12
+; GISEL-NEXT:    v_mul_hi_u32 v12, v2, v6
 ; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v8, v5
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v11
-; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v5, v7
+; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v12
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v5, v7
 ; GISEL-NEXT:    v_mul_hi_u32 v13, 0, v6
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v3, v11, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v3, v12, 0
 ; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
-; GISEL-NEXT:    v_cndmask_b32_e32 v1, v15, v9, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v3, v13, v[6:7]
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v14, v9, vcc
 ; GISEL-NEXT:    v_cndmask_b32_e32 v9, v18, v10, vcc
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v3, v13, v[6:7]
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
 ; GISEL-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
 ; GISEL-NEXT:    v_cndmask_b32_e32 v1, v4, v9, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], 0, v11, v[7:8]
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], 0, v12, v[7:8]
 ; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v2, v5
 ; GISEL-NEXT:    v_sub_i32_e64 v5, s[4:5], 0, v9
 ; GISEL-NEXT:    v_subb_u32_e64 v4, s[4:5], 0, v9, vcc
@@ -2709,7 +2709,7 @@ define <2 x i64> @v_sdiv_v2i64_24bit(<2 x i64> %num, <2 x i64> %den) {
 ; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v4
 ; GISEL-NEXT:    v_subbrev_u32_e32 v5, vcc, 0, v5, vcc
 ; GISEL-NEXT:    v_cndmask_b32_e64 v4, -1, v6, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v6, vcc, 1, v11
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, 1, v12
 ; GISEL-NEXT:    v_addc_u32_e32 v7, vcc, 0, v13, vcc
 ; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v2, v3
 ; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, -1, vcc
@@ -2721,48 +2721,47 @@ define <2 x i64> @v_sdiv_v2i64_24bit(<2 x i64> %num, <2 x i64> %den) {
 ; GISEL-NEXT:    v_cndmask_b32_e32 v2, v6, v3, vcc
 ; GISEL-NEXT:    v_cndmask_b32_e32 v3, v7, v5, vcc
 ; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
-; GISEL-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v2, v12, v2, vcc
 ; GISEL-NEXT:    v_cndmask_b32_e32 v3, v13, v3, vcc
 ; GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; CGP-LABEL: v_sdiv_v2i64_24bit:
 ; CGP:       ; %bb.0:
 ; CGP-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; CGP-NEXT:    v_and_b32_e32 v3, 0xffffff, v4
-; CGP-NEXT:    v_cvt_f32_u32_e32 v1, v3
-; CGP-NEXT:    v_and_b32_e32 v4, 0xffffff, v0
+; CGP-NEXT:    v_and_b32_e32 v4, 0xffffff, v4
+; CGP-NEXT:    v_cvt_f32_u32_e32 v1, v4
 ; CGP-NEXT:    v_and_b32_e32 v5, 0xffffff, v6
-; CGP-NEXT:    v_and_b32_e32 v9, 0xffffff, v2
+; CGP-NEXT:    v_cvt_f32_u32_e32 v3, v5
+; CGP-NEXT:    v_and_b32_e32 v7, 0xffffff, v0
 ; CGP-NEXT:    v_rcp_f32_e32 v1, v1
+; CGP-NEXT:    v_mul_f32_e32 v1, 0x4f7ffffe, v1
+; CGP-NEXT:    v_cvt_u32_f32_e32 v6, v1
+; CGP-NEXT:    v_rcp_f32_e32 v1, v3
+; CGP-NEXT:    v_sub_i32_e32 v3, vcc, 0, v4
+; CGP-NEXT:    v_mul_lo_u32 v3, v3, v6
 ; CGP-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v1
-; CGP-NEXT:    v_cvt_u32_f32_e32 v6, v0
-; CGP-NEXT:    v_sub_i32_e32 v1, vcc, 0, v3
-; CGP-NEXT:    v_cvt_f32_u32_e32 v0, v5
-; CGP-NEXT:    v_mul_lo_u32 v7, v1, v6
-; CGP-NEXT:    v_rcp_f32_e32 v8, v0
-; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v7, 0
-; CGP-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v8
-; CGP-NEXT:    v_add_i32_e32 v6, vcc, v6, v1
-; CGP-NEXT:    v_cvt_u32_f32_e32 v2, v0
-; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v4, v6, 0
+; CGP-NEXT:    v_cvt_u32_f32_e32 v8, v0
+; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v3, 0
 ; CGP-NEXT:    v_sub_i32_e32 v0, vcc, 0, v5
-; CGP-NEXT:    v_mul_lo_u32 v6, v0, v2
-; CGP-NEXT:    v_mul_lo_u32 v0, v1, v3
-; CGP-NEXT:    v_add_i32_e32 v7, vcc, 1, v1
-; CGP-NEXT:    v_sub_i32_e32 v4, vcc, v4, v0
-; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v4, v3
-; CGP-NEXT:    v_cndmask_b32_e32 v7, v1, v7, vcc
-; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v2, v6, 0
-; CGP-NEXT:    v_sub_i32_e64 v0, s[4:5], v4, v3
-; CGP-NEXT:    v_add_i32_e64 v6, s[4:5], v2, v1
-; CGP-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v9, v6, 0
-; CGP-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; CGP-NEXT:    v_mul_lo_u32 v9, v0, v8
+; CGP-NEXT:    v_add_i32_e32 v3, vcc, v6, v1
+; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v7, v3, 0
+; CGP-NEXT:    v_and_b32_e32 v6, 0xffffff, v2
+; CGP-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v8, v9, 0
+; CGP-NEXT:    v_mul_lo_u32 v0, v1, v4
+; CGP-NEXT:    v_add_i32_e32 v2, vcc, 1, v1
+; CGP-NEXT:    v_add_i32_e64 v3, s[4:5], v8, v3
+; CGP-NEXT:    v_sub_i32_e32 v0, vcc, v7, v0
+; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v4
+; CGP-NEXT:    v_cndmask_b32_e32 v7, v1, v2, vcc
+; CGP-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v6, v3, 0
+; CGP-NEXT:    v_sub_i32_e64 v9, s[4:5], v0, v4
+; CGP-NEXT:    v_cndmask_b32_e32 v0, v0, v9, vcc
+; CGP-NEXT:    v_mul_lo_u32 v3, v2, v5
 ; CGP-NEXT:    v_add_i32_e32 v1, vcc, 1, v7
-; CGP-NEXT:    v_mul_lo_u32 v4, v2, v5
-; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v3
+; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v4
 ; CGP-NEXT:    v_cndmask_b32_e32 v0, v7, v1, vcc
-; CGP-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
-; CGP-NEXT:    v_sub_i32_e32 v3, vcc, v9, v4
+; CGP-NEXT:    v_sub_i32_e32 v3, vcc, v6, v3
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, 1, v2
 ; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v3, v5
 ; CGP-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
@@ -2771,6 +2770,7 @@ define <2 x i64> @v_sdiv_v2i64_24bit(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, 1, v2
 ; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v3, v5
 ; CGP-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
+; CGP-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
 ; CGP-NEXT:    v_ashrrev_i32_e32 v3, 31, v2
 ; CGP-NEXT:    s_setpc_b64 s[30:31]
   %num.mask = and <2 x i64> %num, <i64 16777215, i64 16777215>

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/sdivrem.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/sdivrem.ll
@@ -192,9 +192,9 @@ define amdgpu_kernel void @sdivrem_i64(ptr addrspace(1) %out0, ptr addrspace(1) 
 ; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
 ; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v0, v8
 ; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v5, v2
 ; GFX8-NEXT:    v_mul_hi_u32 v3, v7, v4
 ; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v0, v1
@@ -247,15 +247,15 @@ define amdgpu_kernel void @sdivrem_i64(ptr addrspace(1) %out0, ptr addrspace(1) 
 ; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v3, vcc, v4, v3
 ; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v0, v2
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v3, v0
-; GFX8-NEXT:    v_mul_hi_u32 v3, s11, v1
+; GFX8-NEXT:    v_mul_hi_u32 v4, s11, v1
 ; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s8, v6, 0
-; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v3, v2
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v3, v2
+; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v4, v2
 ; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s8, v7, v[1:2]
 ; GFX8-NEXT:    v_sub_u32_e32 v0, vcc, s10, v0
-; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s9, v6, v[2:3]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s9
+; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s9, v6, v[2:3]
 ; GFX8-NEXT:    v_subb_u32_e64 v2, s[0:1], v8, v4, vcc
 ; GFX8-NEXT:    v_sub_u32_e64 v3, s[0:1], s11, v4
 ; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s9, v2
@@ -312,7 +312,6 @@ define amdgpu_kernel void @sdivrem_i64(ptr addrspace(1) %out0, ptr addrspace(1) 
 ; GFX9-LABEL: sdivrem_i64:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_load_dwordx8 s[12:19], s[8:9], 0x0
-; GFX9-NEXT:    v_mov_b32_e32 v9, 0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    s_ashr_i32 s2, s17, 31
 ; GFX9-NEXT:    s_ashr_i32 s4, s19, 31
@@ -331,6 +330,7 @@ define amdgpu_kernel void @sdivrem_i64(ptr addrspace(1) %out0, ptr addrspace(1) 
 ; GFX9-NEXT:    v_rcp_iflag_f32_e32 v0, v0
 ; GFX9-NEXT:    s_sub_u32 s10, 0, s6
 ; GFX9-NEXT:    s_subb_u32 s11, 0, s7
+; GFX9-NEXT:    v_mov_b32_e32 v9, s9
 ; GFX9-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v0
 ; GFX9-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; GFX9-NEXT:    v_trunc_f32_e32 v1, v1
@@ -347,23 +347,24 @@ define amdgpu_kernel void @sdivrem_i64(ptr addrspace(1) %out0, ptr addrspace(1) 
 ; GFX9-NEXT:    v_mul_lo_u32 v3, v6, v4
 ; GFX9-NEXT:    v_mul_lo_u32 v5, v7, v4
 ; GFX9-NEXT:    v_mul_hi_u32 v8, v6, v4
+; GFX9-NEXT:    v_mul_hi_u32 v4, v7, v4
 ; GFX9-NEXT:    v_add_co_u32_e32 v1, vcc, v1, v3
 ; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v5, v0
 ; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v1, vcc, v1, v2
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX9-NEXT:    v_add_u32_e32 v1, v3, v1
-; GFX9-NEXT:    v_mul_hi_u32 v3, v7, v4
 ; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v8
+; GFX9-NEXT:    v_add_u32_e32 v1, v3, v1
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v1
 ; GFX9-NEXT:    v_add_u32_e32 v2, v5, v2
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX9-NEXT:    v_add3_u32 v1, v2, v1, v3
+; GFX9-NEXT:    v_add3_u32 v1, v2, v1, v4
 ; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v6, v0
 ; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, v7, v1, vcc
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s10, v6, 0
+; GFX9-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s10, v7, v[1:2]
 ; GFX9-NEXT:    v_mul_lo_u32 v1, v7, v0
 ; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s11, v6, v[2:3]
@@ -400,67 +401,66 @@ define amdgpu_kernel void @sdivrem_i64(ptr addrspace(1) %out0, ptr addrspace(1) 
 ; GFX9-NEXT:    v_mul_lo_u32 v4, s9, v1
 ; GFX9-NEXT:    v_add_u32_e32 v2, v3, v2
 ; GFX9-NEXT:    v_mul_hi_u32 v3, s8, v1
-; GFX9-NEXT:    v_mov_b32_e32 v6, s7
 ; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v4, v0
 ; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v3
 ; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v7, vcc, v0, v2
-; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s6, v7, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v0, v2
+; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s6, v6, 0
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX9-NEXT:    v_add_u32_e32 v3, v4, v3
-; GFX9-NEXT:    v_add3_u32 v8, v3, v2, v5
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s6, v8, v[1:2]
-; GFX9-NEXT:    v_mov_b32_e32 v1, s9
+; GFX9-NEXT:    v_add3_u32 v7, v3, v2, v5
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s6, v7, v[1:2]
 ; GFX9-NEXT:    v_sub_co_u32_e32 v0, vcc, s8, v0
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s7, v7, v[2:3]
-; GFX9-NEXT:    v_subb_co_u32_e64 v1, s[0:1], v1, v4, vcc
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s7, v1
-; GFX9-NEXT:    v_sub_u32_e32 v2, s9, v4
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s6, v0
+; GFX9-NEXT:    v_mov_b32_e32 v1, s7
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s7, v6, v[2:3]
+; GFX9-NEXT:    v_subb_co_u32_e64 v2, s[0:1], v9, v4, vcc
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s7, v2
+; GFX9-NEXT:    v_sub_u32_e32 v3, s9, v4
 ; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s7, v1
-; GFX9-NEXT:    v_subb_co_u32_e32 v2, vcc, v2, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, v3, v4, s[0:1]
-; GFX9-NEXT:    v_subrev_co_u32_e32 v4, vcc, s6, v0
-; GFX9-NEXT:    v_subbrev_co_u32_e64 v5, s[0:1], 0, v2, vcc
-; GFX9-NEXT:    v_add_co_u32_e64 v10, s[0:1], 1, v7
-; GFX9-NEXT:    v_addc_co_u32_e64 v11, s[0:1], 0, v8, s[0:1]
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s7, v5
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s6, v0
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, -1, s[0:1]
+; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s7, v2
+; GFX9-NEXT:    v_subb_co_u32_e32 v3, vcc, v3, v1, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, v5, s[0:1]
+; GFX9-NEXT:    v_subrev_co_u32_e32 v5, vcc, s6, v0
+; GFX9-NEXT:    v_subbrev_co_u32_e64 v9, s[0:1], 0, v3, vcc
+; GFX9-NEXT:    v_add_co_u32_e64 v10, s[0:1], 1, v6
+; GFX9-NEXT:    v_addc_co_u32_e64 v11, s[0:1], 0, v7, s[0:1]
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s7, v9
 ; GFX9-NEXT:    v_cndmask_b32_e64 v12, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s6, v4
-; GFX9-NEXT:    v_subb_co_u32_e32 v2, vcc, v2, v6, vcc
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s6, v5
+; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v3, v1, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e64 v13, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s7, v5
-; GFX9-NEXT:    v_subrev_co_u32_e32 v6, vcc, s6, v4
+; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s7, v9
+; GFX9-NEXT:    v_subrev_co_u32_e32 v3, vcc, s6, v5
 ; GFX9-NEXT:    v_cndmask_b32_e64 v12, v12, v13, s[0:1]
 ; GFX9-NEXT:    v_add_co_u32_e64 v13, s[0:1], 1, v10
-; GFX9-NEXT:    v_subbrev_co_u32_e32 v2, vcc, 0, v2, vcc
+; GFX9-NEXT:    v_subbrev_co_u32_e32 v1, vcc, 0, v1, vcc
 ; GFX9-NEXT:    v_addc_co_u32_e64 v14, s[0:1], 0, v11, s[0:1]
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
 ; GFX9-NEXT:    v_cndmask_b32_e32 v10, v10, v13, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v11, v11, v14, vcc
-; GFX9-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v5, v2, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, v7, v10, s[0:1]
-; GFX9-NEXT:    v_cndmask_b32_e64 v7, v8, v11, s[0:1]
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v0, v4, s[0:1]
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v1, v2, s[0:1]
+; GFX9-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v4
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v9, v1, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, v6, v10, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, v7, v11, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v3, v0, v3, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, v1, s[0:1]
 ; GFX9-NEXT:    s_xor_b64 s[0:1], s[2:3], s[4:5]
-; GFX9-NEXT:    v_xor_b32_e32 v0, s0, v3
-; GFX9-NEXT:    v_xor_b32_e32 v1, s1, v7
-; GFX9-NEXT:    v_mov_b32_e32 v3, s1
+; GFX9-NEXT:    v_xor_b32_e32 v0, s0, v4
+; GFX9-NEXT:    v_xor_b32_e32 v1, s1, v6
+; GFX9-NEXT:    v_mov_b32_e32 v4, s1
 ; GFX9-NEXT:    v_subrev_co_u32_e32 v0, vcc, s0, v0
-; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v1, v3, vcc
-; GFX9-NEXT:    v_xor_b32_e32 v3, s2, v4
+; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v1, v4, vcc
+; GFX9-NEXT:    v_xor_b32_e32 v3, s2, v3
 ; GFX9-NEXT:    v_xor_b32_e32 v4, s2, v2
 ; GFX9-NEXT:    v_mov_b32_e32 v5, s2
 ; GFX9-NEXT:    v_subrev_co_u32_e32 v2, vcc, s2, v3
 ; GFX9-NEXT:    v_subb_co_u32_e32 v3, vcc, v4, v5, vcc
-; GFX9-NEXT:    global_store_dwordx2 v9, v[0:1], s[12:13]
-; GFX9-NEXT:    global_store_dwordx2 v9, v[2:3], s[14:15]
+; GFX9-NEXT:    global_store_dwordx2 v8, v[0:1], s[12:13]
+; GFX9-NEXT:    global_store_dwordx2 v8, v[2:3], s[14:15]
 ; GFX9-NEXT:    s_endpgm
 ;
 ; GFX10-LABEL: sdivrem_i64:
@@ -1290,22 +1290,23 @@ define amdgpu_kernel void @sdivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX8-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x20
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8-NEXT:    s_ashr_i32 s4, s17, 31
-; GFX8-NEXT:    s_ashr_i32 s6, s1, 31
+; GFX8-NEXT:    s_ashr_i32 s8, s1, 31
 ; GFX8-NEXT:    s_add_u32 s10, s16, s4
 ; GFX8-NEXT:    s_addc_u32 s11, s17, s4
-; GFX8-NEXT:    s_add_u32 s0, s0, s6
-; GFX8-NEXT:    s_mov_b32 s7, s6
-; GFX8-NEXT:    s_addc_u32 s1, s1, s6
-; GFX8-NEXT:    s_xor_b64 s[8:9], s[0:1], s[6:7]
-; GFX8-NEXT:    v_cvt_f32_u32_e32 v0, s9
-; GFX8-NEXT:    v_cvt_f32_u32_e32 v1, s8
+; GFX8-NEXT:    s_add_u32 s0, s0, s8
+; GFX8-NEXT:    s_mov_b32 s9, s8
+; GFX8-NEXT:    s_addc_u32 s1, s1, s8
+; GFX8-NEXT:    s_xor_b64 s[6:7], s[0:1], s[8:9]
+; GFX8-NEXT:    v_cvt_f32_u32_e32 v0, s7
+; GFX8-NEXT:    v_cvt_f32_u32_e32 v1, s6
 ; GFX8-NEXT:    s_mov_b32 s5, s4
 ; GFX8-NEXT:    s_xor_b64 s[10:11], s[10:11], s[4:5]
 ; GFX8-NEXT:    v_mul_f32_e32 v0, 0x4f800000, v0
 ; GFX8-NEXT:    v_add_f32_e32 v0, v0, v1
 ; GFX8-NEXT:    v_rcp_iflag_f32_e32 v0, v0
-; GFX8-NEXT:    s_sub_u32 s16, 0, s8
-; GFX8-NEXT:    s_subb_u32 s17, 0, s9
+; GFX8-NEXT:    s_sub_u32 s16, 0, s6
+; GFX8-NEXT:    s_subb_u32 s17, 0, s7
+; GFX8-NEXT:    s_xor_b64 s[20:21], s[4:5], s[8:9]
 ; GFX8-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v0
 ; GFX8-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; GFX8-NEXT:    v_trunc_f32_e32 v1, v1
@@ -1313,6 +1314,8 @@ define amdgpu_kernel void @sdivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX8-NEXT:    v_add_f32_e32 v0, v2, v0
 ; GFX8-NEXT:    v_cvt_u32_f32_e32 v6, v0
 ; GFX8-NEXT:    v_cvt_u32_f32_e32 v7, v1
+; GFX8-NEXT:    s_ashr_i32 s8, s19, 31
+; GFX8-NEXT:    s_mov_b32 s9, s8
 ; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s16, v6, 0
 ; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s16, v7, v[1:2]
 ; GFX8-NEXT:    v_mul_lo_u32 v1, v7, v0
@@ -1328,9 +1331,9 @@ define amdgpu_kernel void @sdivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
 ; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v0, v8
 ; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v5, v2
 ; GFX8-NEXT:    v_mul_hi_u32 v3, v7, v4
 ; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v0, v1
@@ -1347,9 +1350,6 @@ define amdgpu_kernel void @sdivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX8-NEXT:    v_mul_hi_u32 v3, v6, v0
 ; GFX8-NEXT:    v_mul_hi_u32 v0, v7, v0
 ; GFX8-NEXT:    v_mul_lo_u32 v2, v6, v4
-; GFX8-NEXT:    s_xor_b64 s[16:17], s[4:5], s[6:7]
-; GFX8-NEXT:    s_ashr_i32 s6, s19, 31
-; GFX8-NEXT:    s_mov_b32 s7, s6
 ; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
 ; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v1, v3
@@ -1386,176 +1386,176 @@ define amdgpu_kernel void @sdivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v3, vcc, v4, v3
 ; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v0, v2
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v3, v0
-; GFX8-NEXT:    v_mul_hi_u32 v3, s11, v1
-; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s8, v6, 0
-; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v3, v2
-; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s8, v7, v[1:2]
-; GFX8-NEXT:    v_sub_u32_e32 v9, vcc, s10, v0
-; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s9, v6, v[2:3]
-; GFX8-NEXT:    v_mov_b32_e32 v1, s9
-; GFX8-NEXT:    v_subb_u32_e64 v8, s[0:1], v8, v4, vcc
-; GFX8-NEXT:    v_sub_u32_e64 v0, s[0:1], s11, v4
-; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s9, v8
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[0:1]
-; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s8, v9
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[0:1]
-; GFX8-NEXT:    v_cmp_eq_u32_e64 s[0:1], s9, v8
-; GFX8-NEXT:    v_subb_u32_e32 v0, vcc, v0, v1, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v2, v3, s[0:1]
-; GFX8-NEXT:    v_subrev_u32_e32 v3, vcc, s8, v9
-; GFX8-NEXT:    v_subbrev_u32_e64 v4, s[0:1], 0, v0, vcc
-; GFX8-NEXT:    v_add_u32_e64 v5, s[0:1], 1, v6
-; GFX8-NEXT:    v_addc_u32_e64 v10, s[0:1], 0, v7, s[0:1]
-; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s9, v4
-; GFX8-NEXT:    v_cndmask_b32_e64 v11, 0, -1, s[0:1]
-; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s8, v3
-; GFX8-NEXT:    v_subb_u32_e32 v0, vcc, v0, v1, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v12, 0, -1, s[0:1]
-; GFX8-NEXT:    v_cmp_eq_u32_e64 s[0:1], s9, v4
-; GFX8-NEXT:    v_subrev_u32_e32 v14, vcc, s8, v3
-; GFX8-NEXT:    s_ashr_i32 s8, s3, 31
-; GFX8-NEXT:    v_cndmask_b32_e64 v11, v11, v12, s[0:1]
-; GFX8-NEXT:    v_add_u32_e64 v12, s[0:1], 1, v5
-; GFX8-NEXT:    s_add_u32 s10, s18, s6
-; GFX8-NEXT:    v_addc_u32_e64 v13, s[0:1], 0, v10, s[0:1]
-; GFX8-NEXT:    s_addc_u32 s11, s19, s6
-; GFX8-NEXT:    s_add_u32 s0, s2, s8
-; GFX8-NEXT:    s_mov_b32 s9, s8
-; GFX8-NEXT:    s_addc_u32 s1, s3, s8
-; GFX8-NEXT:    s_xor_b64 s[2:3], s[0:1], s[8:9]
-; GFX8-NEXT:    v_cvt_f32_u32_e32 v1, s3
-; GFX8-NEXT:    v_subbrev_u32_e32 v15, vcc, 0, v0, vcc
-; GFX8-NEXT:    v_cvt_f32_u32_e32 v0, s2
-; GFX8-NEXT:    v_mul_f32_e32 v1, 0x4f800000, v1
-; GFX8-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v2
-; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
-; GFX8-NEXT:    v_add_f32_e32 v0, v1, v0
-; GFX8-NEXT:    v_rcp_iflag_f32_e32 v0, v0
-; GFX8-NEXT:    s_xor_b64 s[10:11], s[10:11], s[6:7]
-; GFX8-NEXT:    s_sub_u32 s5, 0, s2
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v5, v12, vcc
-; GFX8-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v0
-; GFX8-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
-; GFX8-NEXT:    v_trunc_f32_e32 v1, v1
-; GFX8-NEXT:    v_mul_f32_e32 v2, 0xcf800000, v1
-; GFX8-NEXT:    v_add_f32_e32 v0, v2, v0
-; GFX8-NEXT:    v_cvt_u32_f32_e32 v11, v0
-; GFX8-NEXT:    v_cvt_u32_f32_e32 v12, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v10, v13, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v7, v10, s[0:1]
-; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[18:19], s5, v11, 0
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v3, v14, vcc
-; GFX8-NEXT:    s_subb_u32 s20, 0, s3
-; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[18:19], s5, v12, v[1:2]
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v6, v5, s[0:1]
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v4, v15, vcc
-; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[18:19], s20, v11, v[2:3]
-; GFX8-NEXT:    v_cndmask_b32_e64 v8, v8, v1, s[0:1]
-; GFX8-NEXT:    v_mul_lo_u32 v1, v12, v0
-; GFX8-NEXT:    v_mul_lo_u32 v2, v11, v4
-; GFX8-NEXT:    v_mul_hi_u32 v3, v11, v0
-; GFX8-NEXT:    v_mul_hi_u32 v0, v12, v0
-; GFX8-NEXT:    v_cndmask_b32_e64 v9, v9, v10, s[0:1]
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v1, v3
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX8-NEXT:    v_mul_lo_u32 v3, v12, v4
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v2, v1
-; GFX8-NEXT:    v_mul_hi_u32 v2, v11, v4
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v3, v0
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v0, v2
+; GFX8-NEXT:    v_mul_hi_u32 v4, s11, v1
+; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s6, v6, 0
 ; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v3, v2
-; GFX8-NEXT:    v_mul_hi_u32 v3, v12, v4
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v0, v1
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v2, v1
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
-; GFX8-NEXT:    v_add_u32_e32 v10, vcc, v11, v0
-; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s5, v10, 0
-; GFX8-NEXT:    v_addc_u32_e32 v11, vcc, v12, v1, vcc
-; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s5, v11, v[3:4]
-; GFX8-NEXT:    v_xor_b32_e32 v6, s16, v6
-; GFX8-NEXT:    v_xor_b32_e32 v1, s17, v7
-; GFX8-NEXT:    v_mov_b32_e32 v7, s17
-; GFX8-NEXT:    v_subrev_u32_e32 v0, vcc, s16, v6
-; GFX8-NEXT:    v_subb_u32_e32 v1, vcc, v1, v7, vcc
-; GFX8-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s20, v10, v[4:5]
-; GFX8-NEXT:    v_mul_lo_u32 v4, v11, v2
-; GFX8-NEXT:    v_xor_b32_e32 v3, s4, v9
-; GFX8-NEXT:    v_mul_lo_u32 v7, v10, v6
-; GFX8-NEXT:    v_mul_hi_u32 v9, v10, v2
+; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v4, v2
+; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s6, v7, v[1:2]
+; GFX8-NEXT:    v_sub_u32_e32 v9, vcc, s10, v0
+; GFX8-NEXT:    v_mov_b32_e32 v1, s7
+; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s7, v6, v[2:3]
+; GFX8-NEXT:    s_ashr_i32 s10, s3, 31
+; GFX8-NEXT:    s_add_u32 s18, s18, s8
+; GFX8-NEXT:    s_addc_u32 s19, s19, s8
+; GFX8-NEXT:    v_subb_u32_e64 v8, s[0:1], v8, v4, vcc
+; GFX8-NEXT:    v_sub_u32_e64 v0, s[0:1], s11, v4
+; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s7, v8
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[0:1]
+; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s6, v9
+; GFX8-NEXT:    v_subb_u32_e32 v0, vcc, v0, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[0:1]
+; GFX8-NEXT:    v_cmp_eq_u32_e64 s[0:1], s7, v8
+; GFX8-NEXT:    v_subrev_u32_e32 v11, vcc, s6, v9
+; GFX8-NEXT:    v_cndmask_b32_e64 v10, v2, v3, s[0:1]
+; GFX8-NEXT:    v_subbrev_u32_e64 v12, s[0:1], 0, v0, vcc
+; GFX8-NEXT:    v_add_u32_e64 v4, s[0:1], 1, v6
+; GFX8-NEXT:    v_addc_u32_e64 v5, s[0:1], 0, v7, s[0:1]
+; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s7, v12
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[0:1]
+; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s6, v11
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[0:1]
+; GFX8-NEXT:    v_cmp_eq_u32_e64 s[0:1], s7, v12
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, v2, v3, s[0:1]
+; GFX8-NEXT:    s_add_u32 s0, s2, s10
+; GFX8-NEXT:    s_mov_b32 s11, s10
+; GFX8-NEXT:    s_addc_u32 s1, s3, s10
+; GFX8-NEXT:    s_xor_b64 s[16:17], s[0:1], s[10:11]
+; GFX8-NEXT:    v_cvt_f32_u32_e32 v13, s17
+; GFX8-NEXT:    v_cvt_f32_u32_e32 v3, s16
+; GFX8-NEXT:    s_xor_b64 s[18:19], s[18:19], s[8:9]
+; GFX8-NEXT:    v_add_u32_e64 v14, s[0:1], 1, v4
+; GFX8-NEXT:    v_mul_f32_e32 v13, 0x4f800000, v13
+; GFX8-NEXT:    v_add_f32_e32 v3, v13, v3
+; GFX8-NEXT:    v_rcp_iflag_f32_e32 v3, v3
+; GFX8-NEXT:    v_subb_u32_e32 v13, vcc, v0, v1, vcc
+; GFX8-NEXT:    s_sub_u32 s5, 0, s16
+; GFX8-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v3
+; GFX8-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
+; GFX8-NEXT:    v_trunc_f32_e32 v1, v1
+; GFX8-NEXT:    v_mul_f32_e32 v3, 0xcf800000, v1
+; GFX8-NEXT:    v_add_f32_e32 v0, v3, v0
+; GFX8-NEXT:    v_cvt_u32_f32_e32 v16, v0
+; GFX8-NEXT:    v_addc_u32_e64 v15, s[0:1], 0, v5, s[0:1]
+; GFX8-NEXT:    v_cvt_u32_f32_e32 v17, v1
+; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s5, v16, 0
+; GFX8-NEXT:    v_subrev_u32_e32 v18, vcc, s6, v11
+; GFX8-NEXT:    v_subbrev_u32_e32 v13, vcc, 0, v13, vcc
+; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
+; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s5, v17, v[1:2]
+; GFX8-NEXT:    s_subb_u32 s6, 0, s17
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v4, v14, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v14, v5, v15, vcc
+; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s6, v16, v[2:3]
+; GFX8-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v10
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v6, v1, s[0:1]
+; GFX8-NEXT:    v_mul_lo_u32 v1, v17, v0
+; GFX8-NEXT:    v_mul_lo_u32 v2, v16, v4
+; GFX8-NEXT:    v_mul_hi_u32 v3, v16, v0
+; GFX8-NEXT:    v_mul_hi_u32 v0, v17, v0
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, v7, v14, s[0:1]
+; GFX8-NEXT:    v_add_u32_e64 v1, s[2:3], v1, v2
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[2:3]
+; GFX8-NEXT:    v_add_u32_e64 v1, s[2:3], v1, v3
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[2:3]
+; GFX8-NEXT:    v_mul_lo_u32 v3, v17, v4
+; GFX8-NEXT:    v_add_u32_e64 v1, s[2:3], v2, v1
+; GFX8-NEXT:    v_mul_hi_u32 v2, v16, v4
+; GFX8-NEXT:    v_add_u32_e64 v0, s[2:3], v3, v0
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s[2:3]
+; GFX8-NEXT:    v_add_u32_e64 v0, s[2:3], v0, v2
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[2:3]
+; GFX8-NEXT:    v_add_u32_e64 v2, s[2:3], v3, v2
+; GFX8-NEXT:    v_mul_hi_u32 v3, v17, v4
+; GFX8-NEXT:    v_add_u32_e64 v0, s[2:3], v0, v1
+; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[2:3]
+; GFX8-NEXT:    v_add_u32_e64 v1, s[2:3], v2, v1
+; GFX8-NEXT:    v_add_u32_e64 v1, s[2:3], v3, v1
+; GFX8-NEXT:    v_add_u32_e64 v10, s[2:3], v16, v0
+; GFX8-NEXT:    v_cndmask_b32_e32 v7, v11, v18, vcc
+; GFX8-NEXT:    v_addc_u32_e64 v11, s[2:3], v17, v1, s[2:3]
+; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[2:3], s5, v10, 0
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v12, v13, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v9, v7, s[0:1]
+; GFX8-NEXT:    v_cndmask_b32_e64 v8, v8, v0, s[0:1]
+; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s5, v11, v[3:4]
+; GFX8-NEXT:    v_xor_b32_e32 v5, s20, v5
+; GFX8-NEXT:    v_xor_b32_e32 v6, s21, v6
+; GFX8-NEXT:    v_mov_b32_e32 v9, s21
+; GFX8-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], s6, v10, v[0:1]
+; GFX8-NEXT:    v_subrev_u32_e32 v0, vcc, s20, v5
+; GFX8-NEXT:    v_subb_u32_e32 v1, vcc, v6, v9, vcc
+; GFX8-NEXT:    v_mul_lo_u32 v5, v11, v2
+; GFX8-NEXT:    v_mul_lo_u32 v6, v10, v3
+; GFX8-NEXT:    v_xor_b32_e32 v4, s4, v7
+; GFX8-NEXT:    v_mul_hi_u32 v7, v10, v2
 ; GFX8-NEXT:    v_mul_hi_u32 v2, v11, v2
-; GFX8-NEXT:    v_xor_b32_e32 v5, s4, v8
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v4, v7
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v4, v9
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
-; GFX8-NEXT:    v_mul_lo_u32 v9, v11, v6
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v7, v4
-; GFX8-NEXT:    v_mul_hi_u32 v7, v10, v6
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v9, v2
-; GFX8-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v2, v7
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v9, v7
-; GFX8-NEXT:    v_mul_hi_u32 v6, v11, v6
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v2, v4
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v7, v4
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v6, v4
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v10, v2
-; GFX8-NEXT:    v_addc_u32_e32 v6, vcc, v11, v4, vcc
-; GFX8-NEXT:    v_mul_lo_u32 v7, s11, v2
-; GFX8-NEXT:    v_mul_lo_u32 v9, s10, v6
-; GFX8-NEXT:    v_subrev_u32_e32 v4, vcc, s4, v3
-; GFX8-NEXT:    v_mul_hi_u32 v3, s10, v2
-; GFX8-NEXT:    v_mov_b32_e32 v8, s4
-; GFX8-NEXT:    v_subb_u32_e32 v5, vcc, v5, v8, vcc
-; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v7, v9
-; GFX8-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v3, vcc, v7, v3
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; GFX8-NEXT:    v_mul_lo_u32 v7, s11, v6
-; GFX8-NEXT:    v_mul_hi_u32 v2, s11, v2
-; GFX8-NEXT:    v_add_u32_e32 v3, vcc, v8, v3
-; GFX8-NEXT:    v_mul_hi_u32 v8, s10, v6
+; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v5, v6
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v5, v7
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; GFX8-NEXT:    v_mul_lo_u32 v7, v11, v3
+; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v6, v5
+; GFX8-NEXT:    v_mul_hi_u32 v6, v10, v3
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v7, v2
 ; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v2, v8
-; GFX8-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v7, v8
-; GFX8-NEXT:    v_add_u32_e32 v10, vcc, v2, v3
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
-; GFX8-NEXT:    v_mul_hi_u32 v6, s11, v6
-; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v7, v2
-; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s2, v10, 0
-; GFX8-NEXT:    v_add_u32_e32 v11, vcc, v6, v7
-; GFX8-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s2, v11, v[3:4]
-; GFX8-NEXT:    v_mov_b32_e32 v12, s11
-; GFX8-NEXT:    v_sub_u32_e32 v2, vcc, s10, v2
-; GFX8-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], s3, v10, v[6:7]
-; GFX8-NEXT:    v_mov_b32_e32 v3, s3
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v2, v6
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v7, v6
+; GFX8-NEXT:    v_mul_hi_u32 v3, v11, v3
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v2, v5
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v6, v5
+; GFX8-NEXT:    v_add_u32_e32 v3, vcc, v3, v5
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v10, v2
+; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, v11, v3, vcc
+; GFX8-NEXT:    v_mul_lo_u32 v5, s19, v2
+; GFX8-NEXT:    v_mul_lo_u32 v6, s18, v3
+; GFX8-NEXT:    v_mul_hi_u32 v7, s18, v2
+; GFX8-NEXT:    v_mul_hi_u32 v2, s19, v2
+; GFX8-NEXT:    v_xor_b32_e32 v8, s4, v8
+; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v5, v6
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v5, v7
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; GFX8-NEXT:    v_mul_lo_u32 v7, s19, v3
+; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v6, v5
+; GFX8-NEXT:    v_mul_hi_u32 v6, s18, v3
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v7, v2
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v2, v6
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v7, v6
+; GFX8-NEXT:    v_add_u32_e32 v10, vcc, v2, v5
+; GFX8-NEXT:    v_mul_hi_u32 v7, s19, v3
+; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s16, v10, 0
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v6, v5
+; GFX8-NEXT:    v_add_u32_e32 v11, vcc, v7, v5
+; GFX8-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s16, v11, v[3:4]
+; GFX8-NEXT:    v_mov_b32_e32 v9, s4
+; GFX8-NEXT:    v_subrev_u32_e32 v4, vcc, s4, v4
+; GFX8-NEXT:    v_subb_u32_e32 v5, vcc, v8, v9, vcc
+; GFX8-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], s17, v10, v[6:7]
+; GFX8-NEXT:    v_mov_b32_e32 v12, s19
+; GFX8-NEXT:    v_sub_u32_e32 v2, vcc, s18, v2
 ; GFX8-NEXT:    v_subb_u32_e64 v6, s[0:1], v12, v8, vcc
-; GFX8-NEXT:    v_sub_u32_e64 v7, s[0:1], s11, v8
-; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s3, v6
+; GFX8-NEXT:    v_sub_u32_e64 v7, s[0:1], s19, v8
+; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s17, v6
+; GFX8-NEXT:    v_mov_b32_e32 v3, s17
 ; GFX8-NEXT:    v_cndmask_b32_e64 v8, 0, -1, s[0:1]
-; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s2, v2
+; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s16, v2
 ; GFX8-NEXT:    v_cndmask_b32_e64 v9, 0, -1, s[0:1]
-; GFX8-NEXT:    v_cmp_eq_u32_e64 s[0:1], s3, v6
+; GFX8-NEXT:    v_cmp_eq_u32_e64 s[0:1], s17, v6
 ; GFX8-NEXT:    v_subb_u32_e32 v7, vcc, v7, v3, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e64 v8, v8, v9, s[0:1]
-; GFX8-NEXT:    v_subrev_u32_e32 v9, vcc, s2, v2
+; GFX8-NEXT:    v_subrev_u32_e32 v9, vcc, s16, v2
 ; GFX8-NEXT:    v_subbrev_u32_e64 v12, s[0:1], 0, v7, vcc
-; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s3, v12
+; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s17, v12
 ; GFX8-NEXT:    v_cndmask_b32_e64 v13, 0, -1, s[0:1]
-; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s2, v9
+; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s16, v9
 ; GFX8-NEXT:    v_cndmask_b32_e64 v14, 0, -1, s[0:1]
-; GFX8-NEXT:    v_cmp_eq_u32_e64 s[0:1], s3, v12
+; GFX8-NEXT:    v_cmp_eq_u32_e64 s[0:1], s17, v12
 ; GFX8-NEXT:    v_cndmask_b32_e64 v13, v13, v14, s[0:1]
 ; GFX8-NEXT:    v_add_u32_e64 v14, s[0:1], 1, v10
 ; GFX8-NEXT:    v_subb_u32_e32 v3, vcc, v7, v3, vcc
@@ -1563,7 +1563,7 @@ define amdgpu_kernel void @sdivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX8-NEXT:    v_add_u32_e32 v7, vcc, 1, v14
 ; GFX8-NEXT:    v_addc_u32_e32 v16, vcc, 0, v15, vcc
 ; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v13
-; GFX8-NEXT:    v_subrev_u32_e64 v13, s[0:1], s2, v9
+; GFX8-NEXT:    v_subrev_u32_e64 v13, s[0:1], s16, v9
 ; GFX8-NEXT:    v_subbrev_u32_e64 v3, s[0:1], 0, v3, s[0:1]
 ; GFX8-NEXT:    v_cndmask_b32_e32 v7, v14, v7, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v14, v15, v16, vcc
@@ -1574,16 +1574,16 @@ define amdgpu_kernel void @sdivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v8, v11, v14, s[0:1]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v9, v2, v9, s[0:1]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v6, v6, v3, s[0:1]
-; GFX8-NEXT:    s_xor_b64 s[0:1], s[6:7], s[8:9]
+; GFX8-NEXT:    s_xor_b64 s[0:1], s[8:9], s[10:11]
 ; GFX8-NEXT:    v_xor_b32_e32 v2, s0, v7
 ; GFX8-NEXT:    v_xor_b32_e32 v3, s1, v8
 ; GFX8-NEXT:    v_mov_b32_e32 v7, s1
 ; GFX8-NEXT:    v_subrev_u32_e32 v2, vcc, s0, v2
 ; GFX8-NEXT:    v_subb_u32_e32 v3, vcc, v3, v7, vcc
-; GFX8-NEXT:    v_xor_b32_e32 v7, s6, v9
-; GFX8-NEXT:    v_xor_b32_e32 v8, s6, v6
-; GFX8-NEXT:    v_mov_b32_e32 v9, s6
-; GFX8-NEXT:    v_subrev_u32_e32 v6, vcc, s6, v7
+; GFX8-NEXT:    v_xor_b32_e32 v7, s8, v9
+; GFX8-NEXT:    v_xor_b32_e32 v8, s8, v6
+; GFX8-NEXT:    v_mov_b32_e32 v9, s8
+; GFX8-NEXT:    v_subrev_u32_e32 v6, vcc, s8, v7
 ; GFX8-NEXT:    v_subb_u32_e32 v7, vcc, v8, v9, vcc
 ; GFX8-NEXT:    v_mov_b32_e32 v8, s12
 ; GFX8-NEXT:    v_mov_b32_e32 v9, s13
@@ -1600,22 +1600,23 @@ define amdgpu_kernel void @sdivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX9-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x20
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    s_ashr_i32 s4, s17, 31
-; GFX9-NEXT:    s_ashr_i32 s6, s1, 31
+; GFX9-NEXT:    s_ashr_i32 s8, s1, 31
 ; GFX9-NEXT:    s_add_u32 s10, s16, s4
 ; GFX9-NEXT:    s_addc_u32 s11, s17, s4
-; GFX9-NEXT:    s_add_u32 s0, s0, s6
-; GFX9-NEXT:    s_mov_b32 s7, s6
-; GFX9-NEXT:    s_addc_u32 s1, s1, s6
-; GFX9-NEXT:    s_xor_b64 s[8:9], s[0:1], s[6:7]
-; GFX9-NEXT:    v_cvt_f32_u32_e32 v0, s9
-; GFX9-NEXT:    v_cvt_f32_u32_e32 v1, s8
+; GFX9-NEXT:    s_add_u32 s0, s0, s8
+; GFX9-NEXT:    s_mov_b32 s9, s8
+; GFX9-NEXT:    s_addc_u32 s1, s1, s8
+; GFX9-NEXT:    s_xor_b64 s[6:7], s[0:1], s[8:9]
+; GFX9-NEXT:    v_cvt_f32_u32_e32 v0, s7
+; GFX9-NEXT:    v_cvt_f32_u32_e32 v1, s6
 ; GFX9-NEXT:    s_mov_b32 s5, s4
 ; GFX9-NEXT:    s_xor_b64 s[10:11], s[10:11], s[4:5]
 ; GFX9-NEXT:    v_mul_f32_e32 v0, 0x4f800000, v0
 ; GFX9-NEXT:    v_add_f32_e32 v0, v0, v1
 ; GFX9-NEXT:    v_rcp_iflag_f32_e32 v0, v0
-; GFX9-NEXT:    s_sub_u32 s16, 0, s8
-; GFX9-NEXT:    s_subb_u32 s17, 0, s9
+; GFX9-NEXT:    s_sub_u32 s16, 0, s6
+; GFX9-NEXT:    s_subb_u32 s17, 0, s7
+; GFX9-NEXT:    s_xor_b64 s[20:21], s[4:5], s[8:9]
 ; GFX9-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v0
 ; GFX9-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; GFX9-NEXT:    v_trunc_f32_e32 v1, v1
@@ -1623,6 +1624,8 @@ define amdgpu_kernel void @sdivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX9-NEXT:    v_add_f32_e32 v0, v2, v0
 ; GFX9-NEXT:    v_cvt_u32_f32_e32 v6, v0
 ; GFX9-NEXT:    v_cvt_u32_f32_e32 v7, v1
+; GFX9-NEXT:    s_ashr_i32 s8, s19, 31
+; GFX9-NEXT:    s_mov_b32 s9, s8
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s16, v6, 0
 ; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s16, v7, v[1:2]
 ; GFX9-NEXT:    v_mul_lo_u32 v1, v7, v0
@@ -1656,9 +1659,6 @@ define amdgpu_kernel void @sdivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX9-NEXT:    v_mul_hi_u32 v3, v6, v0
 ; GFX9-NEXT:    v_mul_hi_u32 v0, v7, v0
 ; GFX9-NEXT:    v_mul_lo_u32 v2, v6, v4
-; GFX9-NEXT:    s_xor_b64 s[16:17], s[4:5], s[6:7]
-; GFX9-NEXT:    s_ashr_i32 s6, s19, 31
-; GFX9-NEXT:    s_mov_b32 s7, s6
 ; GFX9-NEXT:    v_add_co_u32_e32 v1, vcc, v1, v2
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v1, vcc, v1, v3
@@ -1694,201 +1694,201 @@ define amdgpu_kernel void @sdivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v3
 ; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v0, v2
-; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s8, v6, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s6, v6, 0
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX9-NEXT:    v_add_u32_e32 v3, v4, v3
 ; GFX9-NEXT:    v_add3_u32 v7, v3, v2, v5
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s8, v7, v[1:2]
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s6, v7, v[1:2]
 ; GFX9-NEXT:    v_sub_co_u32_e32 v9, vcc, s10, v0
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s9, v6, v[2:3]
-; GFX9-NEXT:    v_mov_b32_e32 v1, s9
+; GFX9-NEXT:    v_mov_b32_e32 v1, s7
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s7, v6, v[2:3]
+; GFX9-NEXT:    s_ashr_i32 s10, s3, 31
+; GFX9-NEXT:    s_add_u32 s18, s18, s8
+; GFX9-NEXT:    s_addc_u32 s19, s19, s8
 ; GFX9-NEXT:    v_subb_co_u32_e64 v8, s[0:1], v8, v4, vcc
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s9, v8
 ; GFX9-NEXT:    v_sub_u32_e32 v0, s11, v4
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s7, v8
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s8, v9
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s6, v9
+; GFX9-NEXT:    v_subb_co_u32_e32 v0, vcc, v0, v1, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s9, v8
-; GFX9-NEXT:    v_subb_co_u32_e32 v0, vcc, v0, v1, vcc
+; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s7, v8
+; GFX9-NEXT:    v_subrev_co_u32_e32 v11, vcc, s6, v9
+; GFX9-NEXT:    v_cndmask_b32_e64 v10, v2, v3, s[0:1]
+; GFX9-NEXT:    v_subbrev_co_u32_e64 v12, s[0:1], 0, v0, vcc
+; GFX9-NEXT:    v_add_co_u32_e64 v4, s[0:1], 1, v6
+; GFX9-NEXT:    v_addc_co_u32_e64 v5, s[0:1], 0, v7, s[0:1]
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s7, v12
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[0:1]
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s6, v11
+; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[0:1]
+; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s7, v12
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, v3, s[0:1]
-; GFX9-NEXT:    v_subrev_co_u32_e32 v3, vcc, s8, v9
-; GFX9-NEXT:    v_subbrev_co_u32_e64 v4, s[0:1], 0, v0, vcc
-; GFX9-NEXT:    v_add_co_u32_e64 v5, s[0:1], 1, v6
-; GFX9-NEXT:    v_addc_co_u32_e64 v10, s[0:1], 0, v7, s[0:1]
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s9, v4
-; GFX9-NEXT:    v_cndmask_b32_e64 v11, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s8, v3
-; GFX9-NEXT:    v_subb_co_u32_e32 v0, vcc, v0, v1, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v12, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s9, v4
-; GFX9-NEXT:    v_subrev_co_u32_e32 v14, vcc, s8, v3
-; GFX9-NEXT:    s_ashr_i32 s8, s3, 31
-; GFX9-NEXT:    v_cndmask_b32_e64 v11, v11, v12, s[0:1]
-; GFX9-NEXT:    v_add_co_u32_e64 v12, s[0:1], 1, v5
-; GFX9-NEXT:    s_add_u32 s10, s18, s6
-; GFX9-NEXT:    v_addc_co_u32_e64 v13, s[0:1], 0, v10, s[0:1]
-; GFX9-NEXT:    s_addc_u32 s11, s19, s6
-; GFX9-NEXT:    s_add_u32 s0, s2, s8
-; GFX9-NEXT:    s_mov_b32 s9, s8
-; GFX9-NEXT:    s_addc_u32 s1, s3, s8
-; GFX9-NEXT:    s_xor_b64 s[2:3], s[0:1], s[8:9]
-; GFX9-NEXT:    v_cvt_f32_u32_e32 v1, s3
-; GFX9-NEXT:    v_subbrev_co_u32_e32 v15, vcc, 0, v0, vcc
-; GFX9-NEXT:    v_cvt_f32_u32_e32 v0, s2
-; GFX9-NEXT:    v_mul_f32_e32 v1, 0x4f800000, v1
-; GFX9-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v2
-; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
-; GFX9-NEXT:    v_add_f32_e32 v0, v1, v0
-; GFX9-NEXT:    v_rcp_iflag_f32_e32 v0, v0
-; GFX9-NEXT:    s_xor_b64 s[10:11], s[10:11], s[6:7]
-; GFX9-NEXT:    s_sub_u32 s5, 0, s2
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v5, v12, vcc
-; GFX9-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v0
+; GFX9-NEXT:    s_add_u32 s0, s2, s10
+; GFX9-NEXT:    s_mov_b32 s11, s10
+; GFX9-NEXT:    s_addc_u32 s1, s3, s10
+; GFX9-NEXT:    s_xor_b64 s[16:17], s[0:1], s[10:11]
+; GFX9-NEXT:    v_cvt_f32_u32_e32 v13, s17
+; GFX9-NEXT:    v_cvt_f32_u32_e32 v3, s16
+; GFX9-NEXT:    s_xor_b64 s[18:19], s[18:19], s[8:9]
+; GFX9-NEXT:    v_add_co_u32_e64 v14, s[0:1], 1, v4
+; GFX9-NEXT:    v_mul_f32_e32 v13, 0x4f800000, v13
+; GFX9-NEXT:    v_add_f32_e32 v3, v13, v3
+; GFX9-NEXT:    v_rcp_iflag_f32_e32 v3, v3
+; GFX9-NEXT:    v_subb_co_u32_e32 v13, vcc, v0, v1, vcc
+; GFX9-NEXT:    s_sub_u32 s5, 0, s16
+; GFX9-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v3
 ; GFX9-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; GFX9-NEXT:    v_trunc_f32_e32 v1, v1
-; GFX9-NEXT:    v_mul_f32_e32 v2, 0xcf800000, v1
-; GFX9-NEXT:    v_add_f32_e32 v0, v2, v0
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v11, v0
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v12, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v10, v10, v13, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v7, v7, v10, s[0:1]
-; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[18:19], s5, v11, 0
-; GFX9-NEXT:    v_cndmask_b32_e32 v10, v3, v14, vcc
-; GFX9-NEXT:    s_subb_u32 s20, 0, s3
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[18:19], s5, v12, v[1:2]
-; GFX9-NEXT:    v_cndmask_b32_e64 v6, v6, v5, s[0:1]
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v15, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[18:19], s20, v11, v[2:3]
-; GFX9-NEXT:    v_cndmask_b32_e64 v8, v8, v1, s[0:1]
-; GFX9-NEXT:    v_mul_lo_u32 v1, v12, v0
-; GFX9-NEXT:    v_mul_lo_u32 v2, v11, v4
-; GFX9-NEXT:    v_mul_hi_u32 v3, v11, v0
-; GFX9-NEXT:    v_mul_hi_u32 v0, v12, v0
-; GFX9-NEXT:    v_cndmask_b32_e64 v9, v9, v10, s[0:1]
-; GFX9-NEXT:    v_add_co_u32_e32 v1, vcc, v1, v2
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v1, vcc, v1, v3
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v3, v12, v4
+; GFX9-NEXT:    v_mul_f32_e32 v3, 0xcf800000, v1
+; GFX9-NEXT:    v_add_f32_e32 v0, v3, v0
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v16, v0
+; GFX9-NEXT:    v_addc_co_u32_e64 v15, s[0:1], 0, v5, s[0:1]
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v17, v1
+; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s5, v16, 0
+; GFX9-NEXT:    v_subrev_co_u32_e32 v18, vcc, s6, v11
+; GFX9-NEXT:    v_subbrev_co_u32_e32 v13, vcc, 0, v13, vcc
+; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s5, v17, v[1:2]
+; GFX9-NEXT:    s_subb_u32 s6, 0, s17
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v14, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v14, v5, v15, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s6, v16, v[2:3]
+; GFX9-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v10
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, v6, v1, s[0:1]
+; GFX9-NEXT:    v_mul_lo_u32 v1, v17, v0
+; GFX9-NEXT:    v_mul_lo_u32 v2, v16, v4
+; GFX9-NEXT:    v_mul_hi_u32 v3, v16, v0
+; GFX9-NEXT:    v_mul_hi_u32 v0, v17, v0
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, v7, v14, s[0:1]
+; GFX9-NEXT:    v_add_co_u32_e64 v1, s[2:3], v1, v2
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[2:3]
+; GFX9-NEXT:    v_add_co_u32_e64 v1, s[2:3], v1, v3
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[2:3]
+; GFX9-NEXT:    v_mul_lo_u32 v3, v17, v4
 ; GFX9-NEXT:    v_add_u32_e32 v1, v2, v1
-; GFX9-NEXT:    v_mul_hi_u32 v2, v11, v4
-; GFX9-NEXT:    v_xor_b32_e32 v6, s16, v6
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v3, v0
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v2
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; GFX9-NEXT:    v_mul_hi_u32 v2, v16, v4
+; GFX9-NEXT:    v_cndmask_b32_e32 v7, v11, v18, vcc
+; GFX9-NEXT:    v_add_co_u32_e64 v0, s[2:3], v3, v0
+; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s[2:3]
+; GFX9-NEXT:    v_add_co_u32_e64 v0, s[2:3], v0, v2
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[2:3]
 ; GFX9-NEXT:    v_add_u32_e32 v2, v3, v2
-; GFX9-NEXT:    v_mul_hi_u32 v3, v12, v4
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v10, vcc, v11, v0
+; GFX9-NEXT:    v_mul_hi_u32 v3, v17, v4
+; GFX9-NEXT:    v_add_co_u32_e64 v0, s[2:3], v0, v1
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[2:3]
 ; GFX9-NEXT:    v_add3_u32 v1, v2, v1, v3
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s5, v10, 0
-; GFX9-NEXT:    v_addc_co_u32_e32 v11, vcc, v12, v1, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s5, v11, v[3:4]
-; GFX9-NEXT:    v_xor_b32_e32 v1, s17, v7
-; GFX9-NEXT:    v_mov_b32_e32 v7, s17
-; GFX9-NEXT:    v_subrev_co_u32_e32 v0, vcc, s16, v6
-; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v1, v7, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s20, v10, v[4:5]
+; GFX9-NEXT:    v_add_co_u32_e64 v10, s[2:3], v16, v0
+; GFX9-NEXT:    v_addc_co_u32_e64 v11, s[2:3], v17, v1, s[2:3]
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[2:3], s5, v10, 0
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v12, v13, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v7, v9, v7, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v8, v8, v0, s[0:1]
+; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s5, v11, v[3:4]
+; GFX9-NEXT:    v_xor_b32_e32 v5, s20, v5
+; GFX9-NEXT:    v_xor_b32_e32 v6, s21, v6
+; GFX9-NEXT:    v_mov_b32_e32 v9, s21
+; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], s6, v10, v[0:1]
+; GFX9-NEXT:    v_subrev_co_u32_e32 v0, vcc, s20, v5
 ; GFX9-NEXT:    v_mul_lo_u32 v4, v11, v2
-; GFX9-NEXT:    v_xor_b32_e32 v3, s4, v9
-; GFX9-NEXT:    v_mul_lo_u32 v7, v10, v6
-; GFX9-NEXT:    v_mul_hi_u32 v9, v10, v2
+; GFX9-NEXT:    v_mul_lo_u32 v5, v10, v3
+; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v6, v9, vcc
+; GFX9-NEXT:    v_mul_hi_u32 v6, v10, v2
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v5
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v6
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; GFX9-NEXT:    v_mul_lo_u32 v6, v11, v3
 ; GFX9-NEXT:    v_mul_hi_u32 v2, v11, v2
-; GFX9-NEXT:    v_xor_b32_e32 v5, s4, v8
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v7
-; GFX9-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v9
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v9, v11, v6
-; GFX9-NEXT:    v_add_u32_e32 v4, v7, v4
-; GFX9-NEXT:    v_mul_hi_u32 v7, v10, v6
-; GFX9-NEXT:    v_mul_hi_u32 v6, v11, v6
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v9, v2
-; GFX9-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v7
-; GFX9-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
+; GFX9-NEXT:    v_add_u32_e32 v4, v5, v4
+; GFX9-NEXT:    v_mul_hi_u32 v5, v10, v3
+; GFX9-NEXT:    v_mul_hi_u32 v3, v11, v3
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v6, v2
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v5
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v4
-; GFX9-NEXT:    v_add_u32_e32 v7, v9, v7
+; GFX9-NEXT:    v_add_u32_e32 v5, v6, v5
 ; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
-; GFX9-NEXT:    v_add3_u32 v4, v7, v4, v6
+; GFX9-NEXT:    v_add3_u32 v3, v5, v4, v3
 ; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v10, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v6, vcc, v11, v4, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v7, s11, v2
-; GFX9-NEXT:    v_mul_lo_u32 v9, s10, v6
-; GFX9-NEXT:    v_subrev_co_u32_e32 v4, vcc, s4, v3
-; GFX9-NEXT:    v_mul_hi_u32 v3, s10, v2
-; GFX9-NEXT:    v_mov_b32_e32 v8, s4
-; GFX9-NEXT:    v_subb_co_u32_e32 v5, vcc, v5, v8, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v7, vcc, v7, v9
-; GFX9-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v3, vcc, v7, v3
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v7, s11, v6
-; GFX9-NEXT:    v_mul_hi_u32 v2, s11, v2
-; GFX9-NEXT:    v_add_u32_e32 v3, v8, v3
-; GFX9-NEXT:    v_mul_hi_u32 v8, s10, v6
-; GFX9-NEXT:    v_mul_hi_u32 v6, s11, v6
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v7, v2
-; GFX9-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v8
-; GFX9-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v10, vcc, v2, v3
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s2, v10, 0
-; GFX9-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GFX9-NEXT:    v_add_u32_e32 v7, v7, v8
-; GFX9-NEXT:    v_add3_u32 v11, v7, v9, v6
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s2, v11, v[3:4]
-; GFX9-NEXT:    v_mov_b32_e32 v12, s11
-; GFX9-NEXT:    v_sub_co_u32_e32 v2, vcc, s10, v2
-; GFX9-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], s3, v10, v[6:7]
-; GFX9-NEXT:    v_mov_b32_e32 v3, s3
-; GFX9-NEXT:    v_subb_co_u32_e64 v6, s[0:1], v12, v8, vcc
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s3, v6
-; GFX9-NEXT:    v_sub_u32_e32 v7, s11, v8
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v11, v3, vcc
+; GFX9-NEXT:    v_mul_lo_u32 v4, s19, v2
+; GFX9-NEXT:    v_mul_lo_u32 v5, s18, v3
+; GFX9-NEXT:    v_mul_hi_u32 v6, s18, v2
+; GFX9-NEXT:    v_mul_hi_u32 v2, s19, v2
+; GFX9-NEXT:    v_xor_b32_e32 v9, s4, v7
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v5
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v6
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; GFX9-NEXT:    v_mul_lo_u32 v6, s19, v3
+; GFX9-NEXT:    v_add_u32_e32 v4, v5, v4
+; GFX9-NEXT:    v_mul_hi_u32 v5, s18, v3
+; GFX9-NEXT:    v_mul_hi_u32 v7, s19, v3
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v6, v2
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v5
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v10, vcc, v2, v4
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s16, v10, 0
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; GFX9-NEXT:    v_add_u32_e32 v5, v6, v5
+; GFX9-NEXT:    v_add3_u32 v12, v5, v4, v7
+; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s16, v12, v[3:4]
+; GFX9-NEXT:    v_xor_b32_e32 v8, s4, v8
+; GFX9-NEXT:    v_mov_b32_e32 v11, s4
+; GFX9-NEXT:    v_subrev_co_u32_e32 v4, vcc, s4, v9
+; GFX9-NEXT:    v_subb_co_u32_e32 v5, vcc, v8, v11, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], s17, v10, v[6:7]
+; GFX9-NEXT:    v_mov_b32_e32 v11, s19
+; GFX9-NEXT:    v_sub_co_u32_e32 v2, vcc, s18, v2
+; GFX9-NEXT:    v_subb_co_u32_e64 v6, s[0:1], v11, v8, vcc
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s17, v6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s17
+; GFX9-NEXT:    v_sub_u32_e32 v7, s19, v8
 ; GFX9-NEXT:    v_cndmask_b32_e64 v8, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s2, v2
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s16, v2
 ; GFX9-NEXT:    v_cndmask_b32_e64 v9, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s3, v6
+; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s17, v6
 ; GFX9-NEXT:    v_subb_co_u32_e32 v7, vcc, v7, v3, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e64 v8, v8, v9, s[0:1]
-; GFX9-NEXT:    v_subrev_co_u32_e32 v9, vcc, s2, v2
-; GFX9-NEXT:    v_subbrev_co_u32_e64 v12, s[0:1], 0, v7, vcc
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s3, v12
+; GFX9-NEXT:    v_subrev_co_u32_e32 v9, vcc, s16, v2
+; GFX9-NEXT:    v_subbrev_co_u32_e64 v11, s[0:1], 0, v7, vcc
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s17, v11
 ; GFX9-NEXT:    v_cndmask_b32_e64 v13, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s2, v9
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s16, v9
 ; GFX9-NEXT:    v_cndmask_b32_e64 v14, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s3, v12
+; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s17, v11
 ; GFX9-NEXT:    v_cndmask_b32_e64 v13, v13, v14, s[0:1]
 ; GFX9-NEXT:    v_add_co_u32_e64 v14, s[0:1], 1, v10
 ; GFX9-NEXT:    v_subb_co_u32_e32 v3, vcc, v7, v3, vcc
-; GFX9-NEXT:    v_addc_co_u32_e64 v15, s[0:1], 0, v11, s[0:1]
+; GFX9-NEXT:    v_addc_co_u32_e64 v15, s[0:1], 0, v12, s[0:1]
 ; GFX9-NEXT:    v_add_co_u32_e32 v7, vcc, 1, v14
 ; GFX9-NEXT:    v_addc_co_u32_e32 v16, vcc, 0, v15, vcc
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v13
 ; GFX9-NEXT:    v_cndmask_b32_e32 v7, v14, v7, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v14, v15, v16, vcc
-; GFX9-NEXT:    v_subrev_co_u32_e64 v15, s[0:1], s2, v9
+; GFX9-NEXT:    v_subrev_co_u32_e64 v15, s[0:1], s16, v9
 ; GFX9-NEXT:    v_subbrev_co_u32_e64 v3, s[0:1], 0, v3, s[0:1]
 ; GFX9-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v8
 ; GFX9-NEXT:    v_cndmask_b32_e32 v9, v9, v15, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v12, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v11, v3, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e64 v7, v10, v7, s[0:1]
-; GFX9-NEXT:    v_cndmask_b32_e64 v8, v11, v14, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v8, v12, v14, s[0:1]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v9, v2, v9, s[0:1]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v6, v6, v3, s[0:1]
-; GFX9-NEXT:    s_xor_b64 s[0:1], s[6:7], s[8:9]
+; GFX9-NEXT:    s_xor_b64 s[0:1], s[8:9], s[10:11]
 ; GFX9-NEXT:    v_xor_b32_e32 v2, s0, v7
 ; GFX9-NEXT:    v_xor_b32_e32 v3, s1, v8
 ; GFX9-NEXT:    v_mov_b32_e32 v7, s1
 ; GFX9-NEXT:    v_subrev_co_u32_e32 v2, vcc, s0, v2
 ; GFX9-NEXT:    v_subb_co_u32_e32 v3, vcc, v3, v7, vcc
-; GFX9-NEXT:    v_xor_b32_e32 v7, s6, v9
+; GFX9-NEXT:    v_xor_b32_e32 v7, s8, v9
 ; GFX9-NEXT:    v_mov_b32_e32 v13, 0
-; GFX9-NEXT:    v_xor_b32_e32 v8, s6, v6
-; GFX9-NEXT:    v_mov_b32_e32 v9, s6
-; GFX9-NEXT:    v_subrev_co_u32_e32 v6, vcc, s6, v7
+; GFX9-NEXT:    v_xor_b32_e32 v8, s8, v6
+; GFX9-NEXT:    v_mov_b32_e32 v9, s8
+; GFX9-NEXT:    v_subrev_co_u32_e32 v6, vcc, s8, v7
 ; GFX9-NEXT:    v_subb_co_u32_e32 v7, vcc, v8, v9, vcc
 ; GFX9-NEXT:    global_store_dwordx4 v13, v[0:3], s[12:13]
 ; GFX9-NEXT:    global_store_dwordx4 v13, v[4:7], s[14:15]
@@ -1918,18 +1918,17 @@ define amdgpu_kernel void @sdivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX10-NEXT:    v_cvt_f32_u32_e32 v0, s6
 ; GFX10-NEXT:    s_ashr_i32 s10, s3, 31
 ; GFX10-NEXT:    v_mul_f32_e32 v1, 0x4f800000, v1
-; GFX10-NEXT:    s_add_u32 s18, s18, s8
-; GFX10-NEXT:    s_addc_u32 s19, s19, s8
+; GFX10-NEXT:    s_add_u32 s22, s18, s8
+; GFX10-NEXT:    s_addc_u32 s23, s19, s8
 ; GFX10-NEXT:    s_add_u32 s2, s2, s10
 ; GFX10-NEXT:    s_mov_b32 s11, s10
 ; GFX10-NEXT:    s_addc_u32 s3, s3, s10
 ; GFX10-NEXT:    v_add_f32_e32 v0, v1, v0
-; GFX10-NEXT:    s_xor_b64 s[2:3], s[2:3], s[10:11]
+; GFX10-NEXT:    s_xor_b64 s[18:19], s[2:3], s[10:11]
 ; GFX10-NEXT:    s_mov_b32 s9, s8
-; GFX10-NEXT:    v_cvt_f32_u32_e32 v1, s3
-; GFX10-NEXT:    v_cvt_f32_u32_e32 v2, s2
+; GFX10-NEXT:    v_cvt_f32_u32_e32 v1, s19
+; GFX10-NEXT:    v_cvt_f32_u32_e32 v2, s18
 ; GFX10-NEXT:    v_rcp_iflag_f32_e32 v0, v0
-; GFX10-NEXT:    s_xor_b64 s[18:19], s[18:19], s[8:9]
 ; GFX10-NEXT:    v_mul_f32_e32 v1, 0x4f800000, v1
 ; GFX10-NEXT:    v_add_f32_e32 v1, v1, v2
 ; GFX10-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v0
@@ -1945,244 +1944,245 @@ define amdgpu_kernel void @sdivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX10-NEXT:    v_cvt_u32_f32_e32 v6, v0
 ; GFX10-NEXT:    v_mul_f32_e32 v4, 0xcf800000, v5
 ; GFX10-NEXT:    v_cvt_u32_f32_e32 v9, v5
-; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s5, s21, v6, 0
+; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s2, s21, v6, 0
 ; GFX10-NEXT:    v_add_f32_e32 v3, v4, v3
 ; GFX10-NEXT:    v_cvt_u32_f32_e32 v8, v3
-; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s5, s21, v7, v[1:2]
-; GFX10-NEXT:    s_sub_u32 s5, 0, s2
+; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s2, s21, v7, v[1:2]
+; GFX10-NEXT:    s_xor_b64 s[2:3], s[22:23], s[8:9]
+; GFX10-NEXT:    s_sub_u32 s5, 0, s18
 ; GFX10-NEXT:    v_mul_lo_u32 v10, v7, v0
-; GFX10-NEXT:    v_mad_u64_u32 v[1:2], s23, s5, v8, 0
-; GFX10-NEXT:    s_subb_u32 s22, 0, s3
-; GFX10-NEXT:    v_mul_hi_u32 v12, v7, v0
-; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s23, s20, v6, v[3:4]
+; GFX10-NEXT:    v_mad_u64_u32 v[1:2], s22, s5, v8, 0
 ; GFX10-NEXT:    v_mul_hi_u32 v11, v6, v0
+; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s22, s20, v6, v[3:4]
+; GFX10-NEXT:    s_subb_u32 s22, 0, s19
+; GFX10-NEXT:    v_mul_hi_u32 v13, v8, v1
 ; GFX10-NEXT:    v_mul_hi_u32 v14, v9, v1
 ; GFX10-NEXT:    v_mad_u64_u32 v[4:5], s23, s5, v9, v[2:3]
-; GFX10-NEXT:    v_mul_hi_u32 v5, v8, v1
-; GFX10-NEXT:    v_mul_lo_u32 v13, v6, v3
+; GFX10-NEXT:    v_mul_lo_u32 v5, v9, v1
+; GFX10-NEXT:    v_mul_lo_u32 v12, v6, v3
+; GFX10-NEXT:    v_mul_hi_u32 v2, v7, v0
 ; GFX10-NEXT:    v_mul_lo_u32 v15, v7, v3
-; GFX10-NEXT:    v_mul_lo_u32 v2, v9, v1
 ; GFX10-NEXT:    v_mul_hi_u32 v16, v6, v3
 ; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s23, s22, v8, v[4:5]
 ; GFX10-NEXT:    v_mul_hi_u32 v1, v7, v3
-; GFX10-NEXT:    v_add_co_u32 v3, s23, v10, v13
+; GFX10-NEXT:    v_add_co_u32 v3, s23, v10, v12
 ; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s23
-; GFX10-NEXT:    v_add_co_u32 v10, s23, v15, v12
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s23
-; GFX10-NEXT:    v_mul_lo_u32 v13, v8, v0
+; GFX10-NEXT:    v_add_co_u32 v2, s23, v15, v2
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s23
+; GFX10-NEXT:    v_mul_lo_u32 v12, v8, v0
 ; GFX10-NEXT:    v_add_co_u32 v3, s23, v3, v11
 ; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s23
 ; GFX10-NEXT:    v_mul_lo_u32 v15, v9, v0
-; GFX10-NEXT:    v_add_co_u32 v10, s23, v10, v16
+; GFX10-NEXT:    v_add_co_u32 v2, s23, v2, v16
 ; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s23
 ; GFX10-NEXT:    v_mul_hi_u32 v16, v8, v0
 ; GFX10-NEXT:    v_mul_hi_u32 v17, v9, v0
 ; GFX10-NEXT:    v_add_nc_u32_e32 v0, v4, v3
-; GFX10-NEXT:    v_add_co_u32 v2, s23, v2, v13
-; GFX10-NEXT:    v_add_nc_u32_e32 v3, v12, v11
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s23
-; GFX10-NEXT:    v_add_co_u32 v11, s23, v15, v14
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s23
-; GFX10-NEXT:    v_add_co_u32 v0, s23, v10, v0
-; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s23
-; GFX10-NEXT:    v_add_co_u32 v2, s23, v2, v5
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s23
-; GFX10-NEXT:    v_add_co_u32 v6, vcc_lo, v6, v0
-; GFX10-NEXT:    v_add3_u32 v1, v3, v10, v1
-; GFX10-NEXT:    v_add_co_u32 v5, s23, v11, v16
-; GFX10-NEXT:    v_add_nc_u32_e32 v2, v4, v2
+; GFX10-NEXT:    v_add_co_u32 v4, s23, v5, v12
+; GFX10-NEXT:    v_add_nc_u32_e32 v3, v10, v11
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s23
+; GFX10-NEXT:    v_add_co_u32 v10, s23, v15, v14
 ; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s23
+; GFX10-NEXT:    v_add_co_u32 v0, s23, v2, v0
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s23
+; GFX10-NEXT:    v_add_co_u32 v4, s23, v4, v13
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s23
+; GFX10-NEXT:    v_add_co_u32 v6, vcc_lo, v6, v0
+; GFX10-NEXT:    v_add3_u32 v1, v3, v2, v1
+; GFX10-NEXT:    v_add_co_u32 v10, s23, v10, v16
+; GFX10-NEXT:    v_add_nc_u32_e32 v2, v5, v4
+; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s23
 ; GFX10-NEXT:    v_add_co_ci_u32_e32 v7, vcc_lo, v7, v1, vcc_lo
 ; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s23, s21, v6, 0
-; GFX10-NEXT:    v_add_co_u32 v2, s23, v5, v2
-; GFX10-NEXT:    v_add_nc_u32_e32 v3, v12, v11
+; GFX10-NEXT:    v_add_co_u32 v2, s23, v10, v2
+; GFX10-NEXT:    v_add_nc_u32_e32 v3, v11, v12
 ; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s23
 ; GFX10-NEXT:    v_add_co_u32 v8, vcc_lo, v8, v2
 ; GFX10-NEXT:    v_mul_lo_u32 v10, v7, v0
 ; GFX10-NEXT:    v_add3_u32 v5, v3, v4, v17
 ; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s21, s21, v7, v[1:2]
 ; GFX10-NEXT:    v_mad_u64_u32 v[1:2], s21, s5, v8, 0
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v9, vcc_lo, v9, v5, vcc_lo
-; GFX10-NEXT:    v_mul_hi_u32 v12, v7, v0
 ; GFX10-NEXT:    v_mul_hi_u32 v11, v6, v0
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v9, vcc_lo, v9, v5, vcc_lo
 ; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s20, s20, v6, v[3:4]
+; GFX10-NEXT:    v_mul_hi_u32 v13, v8, v1
 ; GFX10-NEXT:    v_mul_hi_u32 v14, v9, v1
 ; GFX10-NEXT:    v_mad_u64_u32 v[4:5], s5, s5, v9, v[2:3]
-; GFX10-NEXT:    v_mul_hi_u32 v5, v8, v1
-; GFX10-NEXT:    v_mul_lo_u32 v13, v6, v3
+; GFX10-NEXT:    v_mul_lo_u32 v5, v9, v1
+; GFX10-NEXT:    v_mul_lo_u32 v12, v6, v3
+; GFX10-NEXT:    v_mul_hi_u32 v2, v7, v0
 ; GFX10-NEXT:    v_mul_lo_u32 v15, v7, v3
-; GFX10-NEXT:    v_mul_lo_u32 v2, v9, v1
 ; GFX10-NEXT:    v_mul_hi_u32 v16, v6, v3
 ; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s5, s22, v8, v[4:5]
 ; GFX10-NEXT:    v_mul_hi_u32 v1, v7, v3
-; GFX10-NEXT:    v_add_co_u32 v3, s5, v10, v13
+; GFX10-NEXT:    v_add_co_u32 v3, s5, v10, v12
 ; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s5
-; GFX10-NEXT:    v_add_co_u32 v10, s5, v15, v12
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s5
-; GFX10-NEXT:    v_mul_lo_u32 v13, v8, v0
+; GFX10-NEXT:    v_add_co_u32 v2, s5, v15, v2
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s5
+; GFX10-NEXT:    v_mul_lo_u32 v12, v8, v0
 ; GFX10-NEXT:    v_add_co_u32 v3, s5, v3, v11
 ; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s5
 ; GFX10-NEXT:    v_mul_lo_u32 v15, v9, v0
-; GFX10-NEXT:    v_add_co_u32 v10, s5, v10, v16
+; GFX10-NEXT:    v_add_co_u32 v2, s5, v2, v16
 ; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s5
 ; GFX10-NEXT:    v_add_nc_u32_e32 v3, v4, v3
-; GFX10-NEXT:    v_add_co_u32 v2, s5, v2, v13
+; GFX10-NEXT:    v_add_co_u32 v5, s5, v5, v12
 ; GFX10-NEXT:    v_mul_hi_u32 v16, v8, v0
-; GFX10-NEXT:    v_add_nc_u32_e32 v4, v12, v11
-; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s5
-; GFX10-NEXT:    v_add_co_u32 v12, s5, v15, v14
-; GFX10-NEXT:    v_cndmask_b32_e64 v13, 0, 1, s5
-; GFX10-NEXT:    v_add_co_u32 v3, s5, v10, v3
+; GFX10-NEXT:    v_add_nc_u32_e32 v4, v10, v11
 ; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s5
-; GFX10-NEXT:    v_add_co_u32 v2, s5, v2, v5
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s5
-; GFX10-NEXT:    v_add_co_u32 v3, vcc_lo, v6, v3
-; GFX10-NEXT:    v_add3_u32 v1, v4, v10, v1
-; GFX10-NEXT:    v_add_co_u32 v5, s5, v12, v16
-; GFX10-NEXT:    v_add_nc_u32_e32 v2, v11, v2
+; GFX10-NEXT:    v_add_co_u32 v11, s5, v15, v14
 ; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s5
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v1, vcc_lo, v7, v1, vcc_lo
+; GFX10-NEXT:    v_add_co_u32 v2, s5, v2, v3
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s5
+; GFX10-NEXT:    v_add_co_u32 v5, s5, v5, v13
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s5
+; GFX10-NEXT:    v_add_co_u32 v11, s5, v11, v16
+; GFX10-NEXT:    v_add3_u32 v1, v4, v3, v1
+; GFX10-NEXT:    v_cndmask_b32_e64 v13, 0, 1, s5
+; GFX10-NEXT:    v_add_nc_u32_e32 v3, v10, v5
+; GFX10-NEXT:    v_add_co_u32 v2, vcc_lo, v6, v2
 ; GFX10-NEXT:    v_mul_hi_u32 v0, v9, v0
-; GFX10-NEXT:    v_mul_lo_u32 v6, s1, v3
-; GFX10-NEXT:    v_add_co_u32 v2, s5, v5, v2
-; GFX10-NEXT:    v_mul_lo_u32 v10, s0, v1
-; GFX10-NEXT:    v_add_nc_u32_e32 v4, v13, v12
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s5
-; GFX10-NEXT:    v_mul_hi_u32 v7, s0, v3
-; GFX10-NEXT:    v_mul_hi_u32 v3, s1, v3
-; GFX10-NEXT:    v_mul_lo_u32 v11, s1, v1
-; GFX10-NEXT:    v_add_co_u32 v2, vcc_lo, v8, v2
-; GFX10-NEXT:    v_add3_u32 v0, v4, v5, v0
-; GFX10-NEXT:    v_mul_hi_u32 v4, s0, v1
-; GFX10-NEXT:    v_mul_hi_u32 v5, s1, v1
-; GFX10-NEXT:    v_add_co_u32 v1, s5, v6, v10
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s5
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v1, vcc_lo, v7, v1, vcc_lo
 ; GFX10-NEXT:    v_add_co_u32 v3, s5, v11, v3
+; GFX10-NEXT:    v_add_nc_u32_e32 v4, v12, v13
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s5
+; GFX10-NEXT:    v_mul_lo_u32 v5, s1, v2
+; GFX10-NEXT:    v_mul_lo_u32 v10, s0, v1
+; GFX10-NEXT:    v_mul_hi_u32 v7, s0, v2
+; GFX10-NEXT:    v_mul_hi_u32 v2, s1, v2
+; GFX10-NEXT:    v_mul_lo_u32 v11, s1, v1
+; GFX10-NEXT:    v_add3_u32 v0, v4, v6, v0
+; GFX10-NEXT:    v_add_co_u32 v3, vcc_lo, v8, v3
+; GFX10-NEXT:    v_mul_hi_u32 v4, s0, v1
+; GFX10-NEXT:    v_add_co_u32 v5, s5, v5, v10
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v0, vcc_lo, v9, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s5
+; GFX10-NEXT:    v_add_co_u32 v2, s5, v11, v2
+; GFX10-NEXT:    v_mul_hi_u32 v6, s1, v1
+; GFX10-NEXT:    v_mul_lo_u32 v1, s3, v3
 ; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s5
-; GFX10-NEXT:    v_add_co_u32 v1, s5, v1, v7
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v8, vcc_lo, v9, v0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s5
-; GFX10-NEXT:    v_mul_lo_u32 v0, s19, v2
-; GFX10-NEXT:    v_add_co_u32 v3, s5, v3, v4
-; GFX10-NEXT:    v_mul_lo_u32 v7, s18, v8
-; GFX10-NEXT:    v_add_nc_u32_e32 v1, v6, v1
-; GFX10-NEXT:    v_mul_hi_u32 v9, s18, v2
-; GFX10-NEXT:    v_mul_hi_u32 v2, s19, v2
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s5
-; GFX10-NEXT:    v_mul_lo_u32 v6, s19, v8
-; GFX10-NEXT:    v_add_co_u32 v3, s5, v3, v1
-; GFX10-NEXT:    v_add_co_u32 v7, s20, v0, v7
-; GFX10-NEXT:    v_add_nc_u32_e32 v4, v10, v4
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s5
-; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s5, s6, v3, 0
-; GFX10-NEXT:    v_mul_hi_u32 v11, s18, v8
-; GFX10-NEXT:    v_add_co_u32 v6, s5, v6, v2
-; GFX10-NEXT:    v_cndmask_b32_e64 v13, 0, 1, s5
-; GFX10-NEXT:    v_add3_u32 v4, v4, v12, v5
-; GFX10-NEXT:    v_add_co_u32 v2, s5, v7, v9
+; GFX10-NEXT:    v_mul_lo_u32 v11, s2, v0
+; GFX10-NEXT:    v_add_co_u32 v5, s5, v5, v7
+; GFX10-NEXT:    v_mul_hi_u32 v8, s2, v3
 ; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s20
-; GFX10-NEXT:    v_mul_hi_u32 v7, s19, v8
-; GFX10-NEXT:    v_mad_u64_u32 v[1:2], s5, s6, v4, v[1:2]
-; GFX10-NEXT:    v_add_co_u32 v6, s5, v6, v11
+; GFX10-NEXT:    v_mul_hi_u32 v3, s3, v3
+; GFX10-NEXT:    v_mul_lo_u32 v7, s3, v0
+; GFX10-NEXT:    v_add_co_u32 v2, s5, v2, v4
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s5
+; GFX10-NEXT:    v_add_nc_u32_e32 v5, v9, v5
+; GFX10-NEXT:    v_add_co_u32 v1, s5, v1, v11
+; GFX10-NEXT:    v_mul_hi_u32 v12, s2, v0
+; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s5
+; GFX10-NEXT:    v_add_co_u32 v3, s5, v7, v3
+; GFX10-NEXT:    v_add_nc_u32_e32 v4, v10, v4
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0, 1, s5
+; GFX10-NEXT:    v_add_co_u32 v10, s5, v2, v5
 ; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s5
-; GFX10-NEXT:    v_add_nc_u32_e32 v5, v10, v5
-; GFX10-NEXT:    v_add_co_u32 v10, vcc_lo, v3, 1
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v11, vcc_lo, 0, v4, vcc_lo
-; GFX10-NEXT:    v_add_nc_u32_e32 v8, v13, v2
-; GFX10-NEXT:    v_mad_u64_u32 v[1:2], s5, s7, v3, v[1:2]
-; GFX10-NEXT:    v_add_co_u32 v5, s5, v6, v5
-; GFX10-NEXT:    v_sub_co_u32 v12, vcc_lo, s0, v0
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s5
+; GFX10-NEXT:    v_add_co_u32 v1, s5, v1, v8
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s5
+; GFX10-NEXT:    v_add_co_u32 v3, s5, v3, v12
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s5
+; GFX10-NEXT:    v_mul_hi_u32 v8, s3, v0
+; GFX10-NEXT:    v_add_nc_u32_e32 v9, v9, v1
+; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s5, s6, v10, 0
+; GFX10-NEXT:    v_add3_u32 v6, v4, v2, v6
+; GFX10-NEXT:    v_add_nc_u32_e32 v2, v7, v5
+; GFX10-NEXT:    v_add_co_u32 v11, vcc_lo, v10, 1
+; GFX10-NEXT:    v_add_co_u32 v7, s5, v3, v9
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s5
+; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s5, s6, v6, v[1:2]
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v12, vcc_lo, 0, v6, vcc_lo
+; GFX10-NEXT:    v_sub_co_u32 v0, vcc_lo, s0, v0
+; GFX10-NEXT:    v_add3_u32 v8, v2, v5, v8
+; GFX10-NEXT:    v_mad_u64_u32 v[1:2], s5, s18, v7, 0
 ; GFX10-NEXT:    v_mov_b32_e32 v9, 0
-; GFX10-NEXT:    v_sub_nc_u32_e32 v6, s1, v1
-; GFX10-NEXT:    v_sub_co_ci_u32_e64 v13, s0, s1, v1, vcc_lo
-; GFX10-NEXT:    v_add3_u32 v7, v8, v2, v7
-; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v6, vcc_lo, s7, v6, vcc_lo
-; GFX10-NEXT:    v_cmp_le_u32_e32 vcc_lo, s6, v12
-; GFX10-NEXT:    v_cndmask_b32_e64 v14, 0, -1, vcc_lo
-; GFX10-NEXT:    v_sub_co_u32 v15, vcc_lo, v12, s6
-; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v16, s0, 0, v6, vcc_lo
-; GFX10-NEXT:    v_cmp_le_u32_e64 s0, s7, v13
-; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v6, vcc_lo, s7, v6, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s0
-; GFX10-NEXT:    v_cmp_le_u32_e64 s0, s6, v15
-; GFX10-NEXT:    v_cndmask_b32_e64 v18, 0, -1, s0
-; GFX10-NEXT:    v_cmp_le_u32_e64 s0, s7, v16
-; GFX10-NEXT:    v_cndmask_b32_e64 v19, 0, -1, s0
-; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s0, s2, v5, 0
-; GFX10-NEXT:    v_cmp_eq_u32_e64 s0, s7, v13
-; GFX10-NEXT:    v_cndmask_b32_e64 v14, v17, v14, s0
-; GFX10-NEXT:    v_cmp_eq_u32_e64 s0, s7, v16
+; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s5, s7, v10, v[3:4]
+; GFX10-NEXT:    v_mad_u64_u32 v[4:5], s0, s18, v8, v[2:3]
+; GFX10-NEXT:    v_add_co_u32 v5, s0, v11, 1
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v13, s0, 0, v12, s0
+; GFX10-NEXT:    v_sub_co_ci_u32_e64 v14, s0, s1, v3, vcc_lo
+; GFX10-NEXT:    v_cmp_le_u32_e64 s0, s6, v0
+; GFX10-NEXT:    v_sub_nc_u32_e32 v15, s1, v3
+; GFX10-NEXT:    v_cndmask_b32_e64 v16, 0, -1, s0
+; GFX10-NEXT:    v_mad_u64_u32 v[2:3], s0, s19, v7, v[4:5]
+; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v3, vcc_lo, s7, v15, vcc_lo
+; GFX10-NEXT:    v_sub_co_u32 v4, vcc_lo, s2, v1
+; GFX10-NEXT:    v_sub_co_u32 v1, s0, v0, s6
+; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v15, s1, 0, v3, s0
+; GFX10-NEXT:    v_cmp_le_u32_e64 s1, s7, v14
+; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v3, s0, s7, v3, s0
+; GFX10-NEXT:    v_cmp_eq_u32_e64 s0, s7, v15
+; GFX10-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s1
+; GFX10-NEXT:    v_cmp_le_u32_e64 s1, s6, v1
+; GFX10-NEXT:    v_cndmask_b32_e64 v18, 0, -1, s1
+; GFX10-NEXT:    v_cmp_le_u32_e64 s1, s7, v15
+; GFX10-NEXT:    v_cndmask_b32_e64 v19, 0, -1, s1
+; GFX10-NEXT:    v_cmp_eq_u32_e64 s1, s7, v14
+; GFX10-NEXT:    v_cndmask_b32_e64 v16, v17, v16, s1
 ; GFX10-NEXT:    v_cndmask_b32_e64 v17, v19, v18, s0
-; GFX10-NEXT:    v_add_co_u32 v18, s0, v10, 1
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v19, s0, 0, v11, s0
-; GFX10-NEXT:    v_mad_u64_u32 v[1:2], s0, s2, v7, v[1:2]
-; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v17
-; GFX10-NEXT:    v_sub_co_u32 v2, s0, v15, s6
-; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v6, s0, 0, v6, s0
-; GFX10-NEXT:    v_cndmask_b32_e32 v8, v10, v18, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v10, v11, v19, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v11, v15, v2, vcc_lo
-; GFX10-NEXT:    v_mad_u64_u32 v[1:2], s1, s3, v5, v[1:2]
-; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v14
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v3, v8, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v4, v10, s0
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, v16, v6, vcc_lo
-; GFX10-NEXT:    v_sub_co_u32 v8, vcc_lo, s18, v0
-; GFX10-NEXT:    v_sub_co_ci_u32_e64 v10, s1, s19, v1, vcc_lo
-; GFX10-NEXT:    v_sub_nc_u32_e32 v1, s19, v1
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v12, v11, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v13, v4, s0
-; GFX10-NEXT:    v_cmp_le_u32_e64 s0, s3, v10
-; GFX10-NEXT:    v_xor_b32_e32 v0, s16, v2
-; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v11, vcc_lo, s3, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_le_u32_e32 vcc_lo, s2, v8
-; GFX10-NEXT:    v_xor_b32_e32 v2, s17, v3
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, -1, vcc_lo
-; GFX10-NEXT:    v_sub_co_u32 v13, vcc_lo, v8, s2
-; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v14, s0, 0, v11, vcc_lo
+; GFX10-NEXT:    v_sub_co_ci_u32_e64 v18, s0, s3, v2, vcc_lo
+; GFX10-NEXT:    v_cmp_le_u32_e64 s0, s18, v4
+; GFX10-NEXT:    v_sub_nc_u32_e32 v2, s3, v2
+; GFX10-NEXT:    v_cmp_le_u32_e64 s2, s19, v18
+; GFX10-NEXT:    v_cndmask_b32_e64 v19, 0, -1, s0
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v17
+; GFX10-NEXT:    v_sub_co_u32 v17, s1, v1, s6
+; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v3, s1, 0, v3, s1
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, v11, v5, s0
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s1, 0, v16
+; GFX10-NEXT:    v_cndmask_b32_e64 v11, v12, v13, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, v17, s0
+; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v2, vcc_lo, s19, v2, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, v10, v5, s1
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, v6, v11, s1
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, v0, v1, s1
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, v15, v3, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, -1, s2
+; GFX10-NEXT:    v_xor_b32_e32 v0, s16, v5
+; GFX10-NEXT:    v_xor_b32_e32 v1, s17, v6
+; GFX10-NEXT:    v_sub_co_u32 v5, vcc_lo, v4, s18
+; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v6, s0, 0, v2, vcc_lo
 ; GFX10-NEXT:    v_sub_co_u32 v0, s0, v0, s16
-; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v1, s0, s17, v2, s0
-; GFX10-NEXT:    v_cmp_eq_u32_e64 s0, s3, v10
-; GFX10-NEXT:    v_xor_b32_e32 v2, s4, v6
-; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v11, vcc_lo, s3, v11, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v3, v12, s0
-; GFX10-NEXT:    v_cmp_le_u32_e64 s0, s3, v14
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, -1, s0
-; GFX10-NEXT:    v_cmp_le_u32_e64 s0, s2, v13
+; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v1, s0, s17, v1, s0
+; GFX10-NEXT:    v_cmp_eq_u32_e64 s0, s19, v18
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, v14, v3, s1
+; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v2, vcc_lo, s19, v2, vcc_lo
+; GFX10-NEXT:    v_xor_b32_e32 v10, s4, v10
+; GFX10-NEXT:    v_cndmask_b32_e64 v11, v12, v19, s0
+; GFX10-NEXT:    v_cmp_le_u32_e64 s0, s19, v6
+; GFX10-NEXT:    v_xor_b32_e32 v3, s4, v3
 ; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, -1, s0
-; GFX10-NEXT:    v_add_co_u32 v15, s0, v5, 1
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v16, s0, 0, v7, s0
-; GFX10-NEXT:    v_cmp_eq_u32_e64 s0, s3, v14
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v6, v12, s0
-; GFX10-NEXT:    v_add_co_u32 v12, s0, v15, 1
-; GFX10-NEXT:    v_add_co_ci_u32_e64 v17, s0, 0, v16, s0
-; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v6
-; GFX10-NEXT:    v_sub_co_u32 v6, s0, v13, s2
-; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v11, s0, 0, v11, s0
-; GFX10-NEXT:    v_cndmask_b32_e32 v12, v15, v12, vcc_lo
-; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v3
-; GFX10-NEXT:    v_cndmask_b32_e32 v15, v16, v17, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v13, v6, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v14, v11, vcc_lo
-; GFX10-NEXT:    v_xor_b32_e32 v11, s4, v4
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, v5, v12, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v7, v15, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v8, v3, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v10, v6, s0
+; GFX10-NEXT:    v_cmp_le_u32_e64 s0, s18, v5
+; GFX10-NEXT:    v_cndmask_b32_e64 v13, 0, -1, s0
+; GFX10-NEXT:    v_add_co_u32 v14, s0, v7, 1
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v15, s0, 0, v8, s0
+; GFX10-NEXT:    v_cmp_eq_u32_e64 s0, s19, v6
+; GFX10-NEXT:    v_cndmask_b32_e64 v12, v12, v13, s0
+; GFX10-NEXT:    v_add_co_u32 v13, s0, v14, 1
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v16, s0, 0, v15, s0
+; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v12
+; GFX10-NEXT:    v_sub_co_u32 v12, s0, v5, s18
+; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v2, s0, 0, v2, s0
+; GFX10-NEXT:    v_cndmask_b32_e32 v13, v14, v13, vcc_lo
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v11
+; GFX10-NEXT:    v_cndmask_b32_e32 v14, v15, v16, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v5, v5, v12, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, v7, v13, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, v8, v14, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, v4, v5, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, v18, v2, s0
 ; GFX10-NEXT:    s_xor_b64 s[0:1], s[8:9], s[10:11]
-; GFX10-NEXT:    v_sub_co_u32 v4, vcc_lo, v2, s4
-; GFX10-NEXT:    v_xor_b32_e32 v2, s0, v12
-; GFX10-NEXT:    v_xor_b32_e32 v7, s1, v7
-; GFX10-NEXT:    v_xor_b32_e32 v8, s8, v3
-; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v5, vcc_lo, s4, v11, vcc_lo
-; GFX10-NEXT:    v_xor_b32_e32 v10, s8, v6
-; GFX10-NEXT:    v_sub_co_u32 v2, vcc_lo, v2, s0
-; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v3, vcc_lo, s1, v7, vcc_lo
-; GFX10-NEXT:    v_sub_co_u32 v6, vcc_lo, v8, s8
-; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v7, vcc_lo, s8, v10, vcc_lo
+; GFX10-NEXT:    v_sub_co_u32 v4, vcc_lo, v10, s4
+; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v5, vcc_lo, s4, v3, vcc_lo
+; GFX10-NEXT:    v_xor_b32_e32 v3, s0, v6
+; GFX10-NEXT:    v_xor_b32_e32 v6, s1, v7
+; GFX10-NEXT:    v_xor_b32_e32 v7, s8, v8
+; GFX10-NEXT:    v_xor_b32_e32 v8, s8, v2
+; GFX10-NEXT:    v_sub_co_u32 v2, vcc_lo, v3, s0
+; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v3, vcc_lo, s1, v6, vcc_lo
+; GFX10-NEXT:    v_sub_co_u32 v6, vcc_lo, v7, s8
+; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v7, vcc_lo, s8, v8, vcc_lo
 ; GFX10-NEXT:    global_store_dwordx4 v9, v[0:3], s[12:13]
 ; GFX10-NEXT:    global_store_dwordx4 v9, v[4:7], s[14:15]
 ; GFX10-NEXT:    s_endpgm

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/srem.i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/srem.i64.ll
@@ -20,7 +20,7 @@ define i64 @v_srem_i64(i64 %num, i64 %den) {
 ; CHECK-NEXT:  ; %bb.1: ; %Flow
 ; CHECK-NEXT:    s_andn2_saveexec_b64 s[4:5], s[6:7]
 ; CHECK-NEXT:    s_cbranch_execnz .LBB0_4
-; CHECK-NEXT:  .LBB0_2:
+; CHECK-NEXT:  .LBB0_2: ; %.split
 ; CHECK-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
 ; CHECK-NEXT:  .LBB0_3:
@@ -49,17 +49,17 @@ define i64 @v_srem_i64(i64 %num, i64 %den) {
 ; CHECK-NEXT:    v_mul_hi_u32 v2, v10, v2
 ; CHECK-NEXT:    v_mul_lo_u32 v7, v11, v8
 ; CHECK-NEXT:    v_mul_lo_u32 v9, v10, v8
+; CHECK-NEXT:    v_mul_hi_u32 v14, v11, v8
 ; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v3, v7
 ; CHECK-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v3, v6
-; CHECK-NEXT:    v_mul_hi_u32 v6, v11, v8
 ; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v7, v3
 ; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v9, v2
-; CHECK-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v2, v6
 ; CHECK-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v7, v6
+; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v2, v14
+; CHECK-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v6, v7
 ; CHECK-NEXT:    v_mul_hi_u32 v7, v10, v8
 ; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v2, v3
 ; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
@@ -115,11 +115,11 @@ define i64 @v_srem_i64(i64 %num, i64 %den) {
 ; CHECK-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
 ; CHECK-NEXT:    v_add_i32_e32 v8, vcc, v2, v4
-; CHECK-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v4, vcc, v5, v2
-; CHECK-NEXT:    v_mul_hi_u32 v5, v13, v3
+; CHECK-NEXT:    v_mul_hi_u32 v6, v13, v3
 ; CHECK-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v0, v8, 0
-; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v5, v4
+; CHECK-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v4, vcc, v5, v4
+; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v6, v4
 ; CHECK-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, v6, v[3:4]
 ; CHECK-NEXT:    v_sub_i32_e32 v2, vcc, v9, v2
 ; CHECK-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v1, v8, v[4:5]
@@ -227,14 +227,14 @@ define amdgpu_ps i64 @s_srem_i64(i64 inreg %num, i64 inreg %den) {
 ; CHECK-NEXT:    v_mul_hi_u32 v8, v6, v4
 ; CHECK-NEXT:    v_add_i32_e32 v1, vcc, v1, v3
 ; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
+; CHECK-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v1, vcc, v1, v2
 ; CHECK-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v1, vcc, v3, v1
-; CHECK-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
-; CHECK-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v0, vcc, v0, v8
-; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v2, v3
+; CHECK-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v5, v2
 ; CHECK-NEXT:    v_mul_hi_u32 v3, v7, v4
 ; CHECK-NEXT:    v_add_i32_e32 v0, vcc, v0, v1
 ; CHECK-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
@@ -286,11 +286,11 @@ define amdgpu_ps i64 @s_srem_i64(i64 inreg %num, i64 inreg %den) {
 ; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v4, v3
 ; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v0, v2
-; CHECK-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v3, v0
-; CHECK-NEXT:    v_mul_hi_u32 v3, s11, v1
+; CHECK-NEXT:    v_mul_hi_u32 v4, s11, v1
 ; CHECK-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s8, v6, 0
-; CHECK-NEXT:    v_add_i32_e32 v4, vcc, v3, v2
+; CHECK-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v3, v2
+; CHECK-NEXT:    v_add_i32_e32 v4, vcc, v4, v2
 ; CHECK-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s8, v4, v[1:2]
 ; CHECK-NEXT:    v_mov_b32_e32 v1, s9
 ; CHECK-NEXT:    v_sub_i32_e32 v0, vcc, s10, v0
@@ -345,7 +345,7 @@ define amdgpu_ps i64 @s_srem_i64(i64 inreg %num, i64 inreg %den) {
 ; CHECK-NEXT:    v_subrev_i32_e32 v1, vcc, s4, v0
 ; CHECK-NEXT:    v_cmp_le_u32_e32 vcc, s4, v0
 ; CHECK-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; CHECK-NEXT:  .LBB1_5:
+; CHECK-NEXT:  .LBB1_5: ; %.split
 ; CHECK-NEXT:    v_readfirstlane_b32 s0, v0
 ; CHECK-NEXT:    s_mov_b32 s1, s0
 ; CHECK-NEXT:    ; return to shader part epilog
@@ -413,12 +413,12 @@ define <2 x i64> @v_srem_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v4
 ; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v16, v15, v[10:11]
 ; GISEL-NEXT:    v_addc_u32_e32 v1, vcc, v1, v4, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v16, v1, v4
 ; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v17, v18, v[11:12]
 ; GISEL-NEXT:    v_xor_b32_e32 v14, v0, v4
 ; GISEL-NEXT:    v_mul_lo_u32 v0, v15, v9
-; GISEL-NEXT:    v_mul_lo_u32 v10, v18, v13
-; GISEL-NEXT:    v_xor_b32_e32 v16, v1, v4
 ; GISEL-NEXT:    v_mul_hi_u32 v1, v18, v9
+; GISEL-NEXT:    v_mul_lo_u32 v10, v18, v13
 ; GISEL-NEXT:    v_mul_hi_u32 v9, v15, v9
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v10
 ; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
@@ -458,123 +458,122 @@ define <2 x i64> @v_srem_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v0, v9
 ; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v10, v0
+; GISEL-NEXT:    v_ashrrev_i32_e32 v11, 31, v7
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v11
+; GISEL-NEXT:    v_addc_u32_e32 v7, vcc, v7, v11, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v6, v6, v11
+; GISEL-NEXT:    v_xor_b32_e32 v7, v7, v11
 ; GISEL-NEXT:    v_mul_hi_u32 v10, v16, v1
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v11, v6
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v12, v7
 ; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v13, 0
-; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v10, v9
-; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v5, v11, v[1:2]
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v10, v9
+; GISEL-NEXT:    v_mac_f32_e32 v11, 0x4f800000, v12
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v5, v15, v[1:2]
+; GISEL-NEXT:    v_rcp_iflag_f32_e32 v1, v11
 ; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v8, v13, v[9:10]
-; GISEL-NEXT:    v_sub_i32_e32 v10, vcc, v14, v0
-; GISEL-NEXT:    v_subb_u32_e64 v12, s[4:5], v16, v11, vcc
-; GISEL-NEXT:    v_sub_i32_e64 v0, s[4:5], v16, v11
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v12, v8
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v10, v5
-; GISEL-NEXT:    v_subb_u32_e32 v0, vcc, v0, v8, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v12, v8
-; GISEL-NEXT:    v_sub_i32_e32 v13, vcc, v10, v5
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, v1, v9, s[4:5]
-; GISEL-NEXT:    v_subbrev_u32_e64 v14, s[4:5], 0, v0, vcc
-; GISEL-NEXT:    v_ashrrev_i32_e32 v1, 31, v7
-; GISEL-NEXT:    v_add_i32_e64 v6, s[4:5], v6, v1
-; GISEL-NEXT:    v_addc_u32_e64 v7, s[4:5], v7, v1, s[4:5]
-; GISEL-NEXT:    v_xor_b32_e32 v6, v6, v1
-; GISEL-NEXT:    v_xor_b32_e32 v7, v7, v1
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v1, v6
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v9, v7
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v14, v8
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v13, v5
-; GISEL-NEXT:    v_mac_f32_e32 v1, 0x4f800000, v9
-; GISEL-NEXT:    v_rcp_iflag_f32_e32 v1, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v14, v8
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, v15, v16, s[4:5]
-; GISEL-NEXT:    v_subb_u32_e32 v16, vcc, v0, v8, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v13, vcc, v14, v0
 ; GISEL-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v1
 ; GISEL-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; GISEL-NEXT:    v_trunc_f32_e32 v1, v1
 ; GISEL-NEXT:    v_mac_f32_e32 v0, 0xcf800000, v1
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v17, v0
-; GISEL-NEXT:    v_sub_i32_e32 v19, vcc, 0, v6
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v18, v1
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v19, v17, 0
-; GISEL-NEXT:    v_subb_u32_e32 v20, vcc, 0, v7, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v19, v18, v[1:2]
-; GISEL-NEXT:    v_mul_lo_u32 v21, v18, v0
-; GISEL-NEXT:    v_mul_hi_u32 v22, v17, v0
-; GISEL-NEXT:    v_mul_hi_u32 v23, v18, v0
-; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v13, v5
-; GISEL-NEXT:    v_subbrev_u32_e32 v5, vcc, 0, v16, vcc
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v15
-; GISEL-NEXT:    v_cndmask_b32_e32 v13, v13, v0, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v20, v17, v[8:9]
-; GISEL-NEXT:    v_cndmask_b32_e32 v5, v14, v5, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v1, v17, v0
-; GISEL-NEXT:    v_mul_lo_u32 v9, v18, v0
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v21, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v1, v22
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v8, v1
-; GISEL-NEXT:    v_mul_hi_u32 v8, v17, v0
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v23
-; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v9, v8
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v14, v9
-; GISEL-NEXT:    v_mul_hi_u32 v0, v18, v0
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v8, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v9, v8
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v8
-; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v17, v1
-; GISEL-NEXT:    v_addc_u32_e32 v15, vcc, v18, v0, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v19, v14, 0
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
-; GISEL-NEXT:    v_cndmask_b32_e32 v10, v10, v13, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v19, v15, v[1:2]
-; GISEL-NEXT:    v_xor_b32_e32 v1, v10, v4
-; GISEL-NEXT:    v_cndmask_b32_e32 v5, v12, v5, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v20, v14, v[8:9]
-; GISEL-NEXT:    v_ashrrev_i32_e32 v12, 31, v3
-; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v12
-; GISEL-NEXT:    v_addc_u32_e32 v3, vcc, v3, v12, vcc
-; GISEL-NEXT:    v_xor_b32_e32 v11, v2, v12
-; GISEL-NEXT:    v_mul_lo_u32 v2, v15, v0
-; GISEL-NEXT:    v_mul_lo_u32 v8, v14, v10
-; GISEL-NEXT:    v_xor_b32_e32 v13, v3, v12
-; GISEL-NEXT:    v_mul_hi_u32 v3, v14, v0
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v14, v0
+; GISEL-NEXT:    v_sub_i32_e64 v17, s[4:5], 0, v6
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v15, v1
+; GISEL-NEXT:    v_subb_u32_e64 v18, s[4:5], 0, v7, s[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v17, v14, 0
+; GISEL-NEXT:    v_subb_u32_e64 v19, s[4:5], v16, v11, vcc
+; GISEL-NEXT:    v_sub_i32_e64 v16, s[4:5], v16, v11
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v17, v15, v[1:2]
+; GISEL-NEXT:    v_mul_lo_u32 v1, v15, v0
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v19, v8
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v18, v14, v[9:10]
+; GISEL-NEXT:    v_mul_lo_u32 v9, v14, v11
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v1, v9
+; GISEL-NEXT:    v_mul_hi_u32 v9, v14, v0
+; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s[4:5]
 ; GISEL-NEXT:    v_mul_hi_u32 v0, v15, v0
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v1, v9
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[6:7]
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v13, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, -1, s[6:7]
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], v19, v8
+; GISEL-NEXT:    v_cndmask_b32_e64 v9, v1, v9, s[6:7]
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v16, v8, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v12, vcc, v13, v5
+; GISEL-NEXT:    v_subbrev_u32_e64 v16, s[6:7], 0, v1, vcc
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v8, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v12, v5
+; GISEL-NEXT:    v_sub_i32_e32 v5, vcc, v12, v5
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[8:9], v16, v8
+; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, -1, s[6:7]
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], v16, v8
+; GISEL-NEXT:    v_subbrev_u32_e32 v8, vcc, 0, v1, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v10, v1
+; GISEL-NEXT:    v_mul_lo_u32 v10, v15, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, -1, s[8:9]
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, v20, v21, s[6:7]
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v20
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v10, v0
+; GISEL-NEXT:    v_mul_hi_u32 v10, v14, v11
+; GISEL-NEXT:    v_cndmask_b32_e32 v5, v12, v5, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s[4:5]
+; GISEL-NEXT:    v_mul_hi_u32 v11, v15, v11
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v10
+; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v12, v10
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v10, v1
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v11, v1
+; GISEL-NEXT:    v_add_i32_e64 v12, s[4:5], v14, v0
+; GISEL-NEXT:    v_addc_u32_e64 v14, s[4:5], v15, v1, s[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v17, v12, 0
+; GISEL-NEXT:    v_cndmask_b32_e32 v10, v16, v8, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
+; GISEL-NEXT:    v_cndmask_b32_e32 v5, v13, v5, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v17, v14, v[1:2]
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v19, v10, vcc
+; GISEL-NEXT:    v_ashrrev_i32_e32 v13, 31, v3
+; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v13
+; GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v18, v12, v[8:9]
+; GISEL-NEXT:    v_addc_u32_e32 v3, vcc, v3, v13, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v11, v2, v13
+; GISEL-NEXT:    v_mul_lo_u32 v2, v14, v0
+; GISEL-NEXT:    v_mul_lo_u32 v8, v12, v10
+; GISEL-NEXT:    v_xor_b32_e32 v15, v3, v13
+; GISEL-NEXT:    v_mul_hi_u32 v3, v12, v0
+; GISEL-NEXT:    v_mul_hi_u32 v0, v14, v0
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v8
 ; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v3
 ; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v3, v15, v10
+; GISEL-NEXT:    v_mul_lo_u32 v3, v14, v10
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v8, v2
-; GISEL-NEXT:    v_mul_hi_u32 v8, v14, v10
+; GISEL-NEXT:    v_mul_hi_u32 v8, v12, v10
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v3, v0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v8
 ; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v8
-; GISEL-NEXT:    v_mul_hi_u32 v8, v15, v10
+; GISEL-NEXT:    v_mul_hi_u32 v8, v14, v10
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v2
 ; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v3, v2
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v8, v2
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v14, v0
-; GISEL-NEXT:    v_addc_u32_e32 v2, vcc, v15, v2, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v3, v13, v0
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v12, v0
+; GISEL-NEXT:    v_addc_u32_e32 v2, vcc, v14, v2, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v3, v15, v0
 ; GISEL-NEXT:    v_mul_lo_u32 v8, v11, v2
 ; GISEL-NEXT:    v_mul_hi_u32 v9, v11, v0
-; GISEL-NEXT:    v_mul_hi_u32 v0, v13, v0
+; GISEL-NEXT:    v_mul_hi_u32 v0, v15, v0
 ; GISEL-NEXT:    v_xor_b32_e32 v5, v5, v4
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v8
 ; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v9
 ; GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v9, v13, v2
+; GISEL-NEXT:    v_mul_lo_u32 v9, v15, v2
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v8, v3
 ; GISEL-NEXT:    v_mul_hi_u32 v8, v11, v2
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v9, v0
@@ -583,18 +582,19 @@ define <2 x i64> @v_srem_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v9, v8
 ; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v0, v3
+; GISEL-NEXT:    v_mul_hi_u32 v9, v15, v2
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v6, v10, 0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v8, v0
-; GISEL-NEXT:    v_mul_hi_u32 v8, v13, v2
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v6, v10, 0
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v8, v0
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v9, v0
 ; GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v6, v0, v[3:4]
-; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v1, v4
-; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v5, v4, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v1, v1, v4
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v5, v4
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v4, vcc
 ; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v7, v10, v[8:9]
 ; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v11, v2
-; GISEL-NEXT:    v_subb_u32_e64 v4, s[4:5], v13, v3, vcc
-; GISEL-NEXT:    v_sub_i32_e64 v3, s[4:5], v13, v3
+; GISEL-NEXT:    v_subb_u32_e64 v4, s[4:5], v15, v3, vcc
+; GISEL-NEXT:    v_sub_i32_e64 v3, s[4:5], v15, v3
 ; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v4, v7
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, -1, s[4:5]
 ; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v2, v6
@@ -619,10 +619,10 @@ define <2 x i64> @v_srem_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
 ; GISEL-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
 ; GISEL-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
-; GISEL-NEXT:    v_xor_b32_e32 v2, v2, v12
-; GISEL-NEXT:    v_xor_b32_e32 v3, v3, v12
-; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v2, v12
-; GISEL-NEXT:    v_subb_u32_e32 v3, vcc, v3, v12, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v2, v2, v13
+; GISEL-NEXT:    v_xor_b32_e32 v3, v3, v13
+; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v2, v13
+; GISEL-NEXT:    v_subb_u32_e32 v3, vcc, v3, v13, vcc
 ; GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; CGP-LABEL: v_srem_v2i64:
@@ -665,17 +665,17 @@ define <2 x i64> @v_srem_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-NEXT:    v_mul_hi_u32 v2, v14, v2
 ; CGP-NEXT:    v_mul_lo_u32 v5, v15, v12
 ; CGP-NEXT:    v_mul_lo_u32 v13, v14, v12
+; CGP-NEXT:    v_mul_hi_u32 v18, v15, v12
 ; CGP-NEXT:    v_add_i32_e32 v3, vcc, v3, v5
 ; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v3, vcc, v3, v4
-; CGP-NEXT:    v_mul_hi_u32 v4, v15, v12
 ; CGP-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v3, vcc, v5, v3
 ; CGP-NEXT:    v_add_i32_e32 v2, vcc, v13, v2
-; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v2, vcc, v2, v4
 ; CGP-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v4, vcc, v5, v4
+; CGP-NEXT:    v_add_i32_e32 v2, vcc, v2, v18
+; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v4, vcc, v4, v5
 ; CGP-NEXT:    v_mul_hi_u32 v5, v14, v12
 ; CGP-NEXT:    v_add_i32_e32 v2, vcc, v2, v3
 ; CGP-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
@@ -731,11 +731,11 @@ define <2 x i64> @v_srem_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v10, v5
 ; CGP-NEXT:    v_add_i32_e32 v12, vcc, v2, v4
-; CGP-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v4, vcc, v5, v2
-; CGP-NEXT:    v_mul_hi_u32 v5, v17, v3
+; CGP-NEXT:    v_mul_hi_u32 v10, v17, v3
 ; CGP-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v0, v12, 0
-; CGP-NEXT:    v_add_i32_e32 v10, vcc, v5, v4
+; CGP-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v4, vcc, v5, v4
+; CGP-NEXT:    v_add_i32_e32 v10, vcc, v10, v4
 ; CGP-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, v10, v[3:4]
 ; CGP-NEXT:    v_sub_i32_e32 v2, vcc, v13, v2
 ; CGP-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v1, v12, v[4:5]
@@ -793,7 +793,7 @@ define <2 x i64> @v_srem_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-NEXT:    v_sub_i32_e32 v2, vcc, v0, v4
 ; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v4
 ; CGP-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; CGP-NEXT:  .LBB2_4:
+; CGP-NEXT:  .LBB2_4: ; %.split
 ; CGP-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; CGP-NEXT:    v_or_b32_e32 v3, v9, v7
 ; CGP-NEXT:    v_mov_b32_e32 v2, 0
@@ -805,7 +805,7 @@ define <2 x i64> @v_srem_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-NEXT:  ; %bb.5: ; %Flow
 ; CGP-NEXT:    s_andn2_saveexec_b64 s[4:5], s[6:7]
 ; CGP-NEXT:    s_cbranch_execnz .LBB2_8
-; CGP-NEXT:  .LBB2_6:
+; CGP-NEXT:  .LBB2_6: ; %.split.split
 ; CGP-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; CGP-NEXT:    s_setpc_b64 s[30:31]
 ; CGP-NEXT:  .LBB2_7:
@@ -834,17 +834,17 @@ define <2 x i64> @v_srem_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-NEXT:    v_mul_hi_u32 v4, v12, v4
 ; CGP-NEXT:    v_mul_lo_u32 v7, v13, v10
 ; CGP-NEXT:    v_mul_lo_u32 v11, v12, v10
+; CGP-NEXT:    v_mul_hi_u32 v16, v13, v10
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v7
 ; CGP-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v6
-; CGP-NEXT:    v_mul_hi_u32 v6, v13, v10
 ; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v7, v5
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v11, v4
-; CGP-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v4, vcc, v4, v6
 ; CGP-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v6, vcc, v7, v6
+; CGP-NEXT:    v_add_i32_e32 v4, vcc, v4, v16
+; CGP-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v6, vcc, v6, v7
 ; CGP-NEXT:    v_mul_hi_u32 v7, v12, v10
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v4, v5
 ; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
@@ -900,11 +900,11 @@ define <2 x i64> @v_srem_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v7, vcc, v8, v7
 ; CGP-NEXT:    v_add_i32_e32 v10, vcc, v4, v6
-; CGP-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v6, vcc, v7, v4
-; CGP-NEXT:    v_mul_hi_u32 v7, v15, v5
+; CGP-NEXT:    v_mul_hi_u32 v8, v15, v5
 ; CGP-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v10, 0
-; CGP-NEXT:    v_add_i32_e32 v8, vcc, v7, v6
+; CGP-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v6, vcc, v7, v6
+; CGP-NEXT:    v_add_i32_e32 v8, vcc, v8, v6
 ; CGP-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v2, v8, v[5:6]
 ; CGP-NEXT:    v_sub_i32_e32 v4, vcc, v11, v4
 ; CGP-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v3, v10, v[6:7]
@@ -997,9 +997,9 @@ define i64 @v_srem_i64_pow2k_denom(i64 %num) {
 ; CHECK-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v3, v4
 ; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v5, v3
 ; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v2, v11
 ; CHECK-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v5, v3
 ; CHECK-NEXT:    v_add_i32_e32 v4, vcc, v7, v4
 ; CHECK-NEXT:    v_mul_hi_u32 v5, v10, v6
 ; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v2, v3
@@ -1057,11 +1057,11 @@ define i64 @v_srem_i64_pow2k_denom(i64 %num) {
 ; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v7, v3
 ; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v0, v2
-; CHECK-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; CHECK-NEXT:    v_mul_hi_u32 v7, v5, v1
-; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v3, v0
+; CHECK-NEXT:    v_mul_hi_u32 v8, v5, v1
 ; CHECK-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v2, 0
-; CHECK-NEXT:    v_add_i32_e32 v7, vcc, v7, v3
+; CHECK-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v3, v7
+; CHECK-NEXT:    v_add_i32_e32 v7, vcc, v8, v2
 ; CHECK-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v6, v7, v[1:2]
 ; CHECK-NEXT:    v_sub_i32_e32 v0, vcc, v4, v0
 ; CHECK-NEXT:    v_subb_u32_e64 v1, s[4:5], v5, v2, vcc
@@ -1101,11 +1101,8 @@ define <2 x i64> @v_srem_v2i64_pow2k_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v4, 0x1000
 ; GISEL-NEXT:    v_cvt_f32_ubyte0_e32 v5, 0
 ; GISEL-NEXT:    v_mov_b32_e32 v6, 0xfffff000
-; GISEL-NEXT:    s_mov_b32 s6, 1
 ; GISEL-NEXT:    v_mac_f32_e32 v4, 0x4f800000, v5
 ; GISEL-NEXT:    v_rcp_iflag_f32_e32 v4, v4
-; GISEL-NEXT:    s_cmp_lg_u32 s6, 0
-; GISEL-NEXT:    s_subb_u32 s6, 0, 0
 ; GISEL-NEXT:    v_mul_f32_e32 v4, 0x5f7ffffc, v4
 ; GISEL-NEXT:    v_mul_f32_e32 v5, 0x2f800000, v4
 ; GISEL-NEXT:    v_trunc_f32_e32 v5, v5
@@ -1114,25 +1111,28 @@ define <2 x i64> @v_srem_v2i64_pow2k_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v8, v5
 ; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v6, v7, 0
 ; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v6, v8, v[5:6]
-; GISEL-NEXT:    v_mul_hi_u32 v11, v7, v4
-; GISEL-NEXT:    v_mul_hi_u32 v12, v8, v4
+; GISEL-NEXT:    s_mov_b32 s4, 1
+; GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GISEL-NEXT:    s_subb_u32 s6, 0, 0
 ; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], s6, v7, v[9:10]
 ; GISEL-NEXT:    v_mul_lo_u32 v10, v8, v4
-; GISEL-NEXT:    v_mul_lo_u32 v9, v7, v13
-; GISEL-NEXT:    v_mul_lo_u32 v4, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v10, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v14, v9
+; GISEL-NEXT:    v_mul_hi_u32 v11, v7, v4
+; GISEL-NEXT:    v_mul_hi_u32 v12, v8, v4
+; GISEL-NEXT:    v_mul_lo_u32 v4, v7, v13
+; GISEL-NEXT:    v_mul_lo_u32 v9, v8, v13
 ; GISEL-NEXT:    v_mul_hi_u32 v14, v7, v13
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v12
+; GISEL-NEXT:    v_mul_hi_u32 v13, v8, v13
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v10, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v14
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v15, v4
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v14
 ; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v15, v14
-; GISEL-NEXT:    v_mul_hi_u32 v13, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v9
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v9, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v14, v9
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v13, v9
@@ -1144,11 +1144,8 @@ define <2 x i64> @v_srem_v2i64_pow2k_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_mul_hi_u32 v18, v4, v13
 ; GISEL-NEXT:    v_mul_hi_u32 v19, v17, v13
 ; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], s6, v4, v[15:16]
-; GISEL-NEXT:    s_mov_b32 s6, 1
-; GISEL-NEXT:    s_cmp_lg_u32 s6, 0
 ; GISEL-NEXT:    v_mul_lo_u32 v14, v4, v13
 ; GISEL-NEXT:    v_mul_hi_u32 v15, v4, v13
-; GISEL-NEXT:    s_subb_u32 s6, 0, 0
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v14
 ; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v18
@@ -1203,50 +1200,52 @@ define <2 x i64> @v_srem_v2i64_pow2k_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_subbrev_u32_e32 v0, vcc, 0, v0, vcc
 ; GISEL-NEXT:    v_sub_i32_e32 v18, vcc, v16, v4
 ; GISEL-NEXT:    v_subbrev_u32_e32 v19, vcc, 0, v0, vcc
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v16, v4
 ; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v18, v4
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v17
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v16, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
 ; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v19
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, -1, v1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, -1, s[4:5]
 ; GISEL-NEXT:    v_cndmask_b32_e32 v20, -1, v0, vcc
 ; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v8, v[5:6]
+; GISEL-NEXT:    s_mov_b32 s4, 1
+; GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GISEL-NEXT:    s_subb_u32 s6, 0, 0
 ; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], s6, v7, v[0:1]
 ; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v18, v4
-; GISEL-NEXT:    v_mul_lo_u32 v5, v7, v13
-; GISEL-NEXT:    v_subbrev_u32_e32 v1, vcc, 0, v19, vcc
+; GISEL-NEXT:    v_subbrev_u32_e32 v5, vcc, 0, v19, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v1, v7, v13
 ; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v20
-; GISEL-NEXT:    v_cndmask_b32_e32 v14, v18, v0, vcc
-; GISEL-NEXT:    v_cndmask_b32_e32 v18, v19, v1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v10, v5
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v5, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v17
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, -1, v15, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e32 v15, v18, v0, vcc
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v10, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[4:5]
+; GISEL-NEXT:    v_mul_lo_u32 v10, v8, v13
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v1, v0
 ; GISEL-NEXT:    v_mul_hi_u32 v1, v7, v13
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v12
-; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v5, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v10, v5
-; GISEL-NEXT:    v_mul_hi_u32 v10, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v5, v1
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v10, v1
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v7, v0
-; GISEL-NEXT:    v_addc_u32_e32 v11, vcc, v8, v1, vcc
+; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v10, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v10, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v11, v10
+; GISEL-NEXT:    v_mul_hi_u32 v11, v8, v13
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v1, v0
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v10, v1
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v11, v1
+; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v7, v0
+; GISEL-NEXT:    v_addc_u32_e64 v11, s[4:5], v8, v1, s[4:5]
 ; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v10, 0
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v15
-; GISEL-NEXT:    v_cndmask_b32_e32 v5, v16, v14, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v6, v11, v[1:2]
-; GISEL-NEXT:    v_xor_b32_e32 v1, v5, v9
+; GISEL-NEXT:    v_cndmask_b32_e32 v5, v19, v5, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
 ; GISEL-NEXT:    v_ashrrev_i32_e32 v13, 31, v3
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], s6, v10, v[7:8]
-; GISEL-NEXT:    v_cndmask_b32_e32 v12, v17, v18, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v6, v11, v[1:2]
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v17, v5, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v12, v16, v15, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v13
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], s6, v10, v[7:8]
 ; GISEL-NEXT:    v_addc_u32_e32 v3, vcc, v3, v13, vcc
 ; GISEL-NEXT:    v_xor_b32_e32 v14, v2, v13
 ; GISEL-NEXT:    v_mul_lo_u32 v2, v11, v0
@@ -1277,7 +1276,7 @@ define <2 x i64> @v_srem_v2i64_pow2k_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_mul_lo_u32 v5, v14, v2
 ; GISEL-NEXT:    v_mul_hi_u32 v6, v14, v0
 ; GISEL-NEXT:    v_mul_hi_u32 v0, v15, v0
-; GISEL-NEXT:    v_xor_b32_e32 v7, v12, v9
+; GISEL-NEXT:    v_xor_b32_e32 v12, v12, v9
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v6
@@ -1291,15 +1290,16 @@ define <2 x i64> @v_srem_v2i64_pow2k_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
 ; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v0, v3
+; GISEL-NEXT:    v_mul_hi_u32 v6, v15, v2
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v10, 0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
-; GISEL-NEXT:    v_mul_hi_u32 v5, v15, v2
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v10, 0
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v6, v0
 ; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v0, v[3:4]
-; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v1, v9
-; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v7, v9, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v1, v1, v9
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v12, v9
 ; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], 0, v10, v[5:6]
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v9, vcc
 ; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v14, v2
 ; GISEL-NEXT:    v_sub_i32_e64 v5, s[4:5], v15, v7
 ; GISEL-NEXT:    v_subb_u32_e64 v3, s[4:5], v15, v7, vcc
@@ -1354,14 +1354,14 @@ define <2 x i64> @v_srem_v2i64_pow2k_denom(<2 x i64> %num) {
 ; CGP-NEXT:    v_mul_hi_u32 v12, v8, v12
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v9, v4
 ; CGP-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v13, vcc, v13, v11
+; CGP-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v4, v10
 ; CGP-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v15, v4
-; CGP-NEXT:    v_add_i32_e32 v13, vcc, v13, v11
-; CGP-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v13, vcc, v13, v14
 ; CGP-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v14, vcc, v15, v14
+; CGP-NEXT:    v_add_i32_e32 v14, vcc, v16, v14
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v13, v4
 ; CGP-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v13, vcc, v14, v13
@@ -1424,53 +1424,53 @@ define <2 x i64> @v_srem_v2i64_pow2k_denom(<2 x i64> %num) {
 ; CGP-NEXT:    v_add_i32_e32 v15, vcc, v15, v14
 ; CGP-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v4, v15, v[1:2]
 ; CGP-NEXT:    v_sub_i32_e32 v15, vcc, v18, v0
-; CGP-NEXT:    v_sub_i32_e64 v0, s[4:5], v19, v13
 ; CGP-NEXT:    v_subb_u32_e64 v16, s[4:5], v19, v13, vcc
-; CGP-NEXT:    v_subbrev_u32_e32 v0, vcc, 0, v0, vcc
-; CGP-NEXT:    v_sub_i32_e32 v18, vcc, v15, v4
-; CGP-NEXT:    v_subbrev_u32_e32 v19, vcc, 0, v0, vcc
+; CGP-NEXT:    v_sub_i32_e64 v0, s[4:5], v19, v13
 ; CGP-NEXT:    v_cmp_ge_u32_e64 s[4:5], v15, v4
-; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v18, v4
+; CGP-NEXT:    v_subbrev_u32_e32 v0, vcc, 0, v0, vcc
 ; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[4:5]
 ; CGP-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v16
-; CGP-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
-; CGP-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v19
+; CGP-NEXT:    v_sub_i32_e32 v18, vcc, v15, v4
 ; CGP-NEXT:    v_cndmask_b32_e64 v17, -1, v1, s[4:5]
-; CGP-NEXT:    v_cndmask_b32_e32 v20, -1, v0, vcc
+; CGP-NEXT:    v_subbrev_u32_e32 v19, vcc, 0, v0, vcc
 ; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v8, v[5:6]
-; CGP-NEXT:    v_sub_i32_e32 v5, vcc, v18, v4
+; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v18, v4
+; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc
+; CGP-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v19
 ; CGP-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], -1, v7, v[0:1]
-; CGP-NEXT:    v_subbrev_u32_e32 v21, vcc, 0, v19, vcc
-; CGP-NEXT:    v_mul_lo_u32 v1, v7, v13
-; CGP-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v20
-; CGP-NEXT:    v_cndmask_b32_e32 v0, v18, v5, vcc
-; CGP-NEXT:    v_cndmask_b32_e32 v5, v19, v21, vcc
-; CGP-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v17
-; CGP-NEXT:    v_cndmask_b32_e32 v14, v15, v0, vcc
-; CGP-NEXT:    v_add_i32_e64 v0, s[4:5], v9, v1
-; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
-; CGP-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v10
-; CGP-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[4:5]
-; CGP-NEXT:    v_mul_lo_u32 v9, v8, v13
-; CGP-NEXT:    v_add_i32_e64 v0, s[4:5], v1, v0
+; CGP-NEXT:    v_cndmask_b32_e32 v5, -1, v5, vcc
+; CGP-NEXT:    v_sub_i32_e32 v0, vcc, v18, v4
+; CGP-NEXT:    v_subbrev_u32_e32 v1, vcc, 0, v19, vcc
+; CGP-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; CGP-NEXT:    v_mul_lo_u32 v5, v7, v13
+; CGP-NEXT:    v_cndmask_b32_e32 v14, v18, v0, vcc
+; CGP-NEXT:    v_cndmask_b32_e32 v18, v19, v1, vcc
+; CGP-NEXT:    v_add_i32_e32 v0, vcc, v9, v5
+; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v0, vcc, v0, v10
+; CGP-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
+; CGP-NEXT:    v_mul_lo_u32 v5, v8, v13
+; CGP-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
 ; CGP-NEXT:    v_mul_hi_u32 v1, v7, v13
-; CGP-NEXT:    v_add_i32_e64 v9, s[4:5], v9, v11
-; CGP-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s[4:5]
-; CGP-NEXT:    v_add_i32_e64 v1, s[4:5], v9, v1
-; CGP-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s[4:5]
-; CGP-NEXT:    v_add_i32_e64 v9, s[4:5], v10, v9
-; CGP-NEXT:    v_mul_hi_u32 v10, v8, v13
-; CGP-NEXT:    v_add_i32_e64 v0, s[4:5], v1, v0
-; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
-; CGP-NEXT:    v_add_i32_e64 v1, s[4:5], v9, v1
-; CGP-NEXT:    v_add_i32_e64 v1, s[4:5], v10, v1
-; CGP-NEXT:    v_add_i32_e64 v9, s[4:5], v7, v0
-; CGP-NEXT:    v_addc_u32_e64 v10, s[4:5], v8, v1, s[4:5]
+; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v11
+; CGP-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v1, vcc, v5, v1
+; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v5, vcc, v9, v5
+; CGP-NEXT:    v_mul_hi_u32 v9, v8, v13
+; CGP-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
+; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v1, vcc, v5, v1
+; CGP-NEXT:    v_add_i32_e32 v1, vcc, v9, v1
+; CGP-NEXT:    v_add_i32_e32 v9, vcc, v7, v0
+; CGP-NEXT:    v_addc_u32_e32 v10, vcc, v8, v1, vcc
 ; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v9, 0
-; CGP-NEXT:    v_cndmask_b32_e32 v5, v16, v5, vcc
+; CGP-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v17
+; CGP-NEXT:    v_cndmask_b32_e32 v5, v15, v14, vcc
 ; CGP-NEXT:    v_ashrrev_i32_e32 v13, 31, v3
 ; CGP-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v6, v10, v[1:2]
 ; CGP-NEXT:    v_xor_b32_e32 v1, v5, v12
+; CGP-NEXT:    v_cndmask_b32_e32 v11, v16, v18, vcc
 ; CGP-NEXT:    v_add_i32_e32 v2, vcc, v2, v13
 ; CGP-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], -1, v9, v[7:8]
 ; CGP-NEXT:    v_addc_u32_e32 v3, vcc, v3, v13, vcc
@@ -1501,10 +1501,10 @@ define <2 x i64> @v_srem_v2i64_pow2k_denom(<2 x i64> %num) {
 ; CGP-NEXT:    v_addc_u32_e32 v2, vcc, v10, v2, vcc
 ; CGP-NEXT:    v_mul_lo_u32 v5, v8, v3
 ; CGP-NEXT:    v_mul_lo_u32 v6, v7, v2
-; CGP-NEXT:    v_xor_b32_e32 v11, v14, v12
 ; CGP-NEXT:    v_mul_hi_u32 v9, v7, v3
-; CGP-NEXT:    v_sub_i32_e32 v0, vcc, v11, v12
-; CGP-NEXT:    v_subb_u32_e32 v1, vcc, v1, v12, vcc
+; CGP-NEXT:    v_xor_b32_e32 v11, v11, v12
+; CGP-NEXT:    v_sub_i32_e32 v0, vcc, v1, v12
+; CGP-NEXT:    v_subb_u32_e32 v1, vcc, v11, v12, vcc
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v6
 ; CGP-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v9
@@ -1519,11 +1519,11 @@ define <2 x i64> @v_srem_v2i64_pow2k_denom(<2 x i64> %num) {
 ; CGP-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v6, vcc, v9, v6
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v3, v5
-; CGP-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; CGP-NEXT:    v_mul_hi_u32 v9, v8, v2
-; CGP-NEXT:    v_add_i32_e32 v6, vcc, v6, v3
+; CGP-NEXT:    v_mul_hi_u32 v10, v8, v2
 ; CGP-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v5, 0
-; CGP-NEXT:    v_add_i32_e32 v9, vcc, v9, v6
+; CGP-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v5, vcc, v6, v9
+; CGP-NEXT:    v_add_i32_e32 v9, vcc, v10, v5
 ; CGP-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v9, v[3:4]
 ; CGP-NEXT:    v_sub_i32_e32 v2, vcc, v7, v2
 ; CGP-NEXT:    v_subb_u32_e64 v3, s[4:5], v8, v5, vcc
@@ -1586,9 +1586,9 @@ define i64 @v_srem_i64_oddk_denom(i64 %num) {
 ; CHECK-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v3, v4
 ; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v5, v3
 ; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v2, v11
 ; CHECK-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v5, v3
 ; CHECK-NEXT:    v_add_i32_e32 v4, vcc, v7, v4
 ; CHECK-NEXT:    v_mul_hi_u32 v5, v10, v6
 ; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v2, v3
@@ -1646,11 +1646,11 @@ define i64 @v_srem_i64_oddk_denom(i64 %num) {
 ; CHECK-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v7, v3
 ; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v0, v2
-; CHECK-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; CHECK-NEXT:    v_mul_hi_u32 v7, v5, v1
-; CHECK-NEXT:    v_add_i32_e32 v3, vcc, v3, v0
+; CHECK-NEXT:    v_mul_hi_u32 v8, v5, v1
 ; CHECK-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v2, 0
-; CHECK-NEXT:    v_add_i32_e32 v7, vcc, v7, v3
+; CHECK-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v2, vcc, v3, v7
+; CHECK-NEXT:    v_add_i32_e32 v7, vcc, v8, v2
 ; CHECK-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v6, v7, v[1:2]
 ; CHECK-NEXT:    v_sub_i32_e32 v0, vcc, v4, v0
 ; CHECK-NEXT:    v_subb_u32_e64 v1, s[4:5], v5, v2, vcc
@@ -1690,11 +1690,8 @@ define <2 x i64> @v_srem_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v4, 0x12d8fb
 ; GISEL-NEXT:    v_cvt_f32_ubyte0_e32 v5, 0
 ; GISEL-NEXT:    v_mov_b32_e32 v6, 0xffed2705
-; GISEL-NEXT:    s_mov_b32 s6, 1
 ; GISEL-NEXT:    v_mac_f32_e32 v4, 0x4f800000, v5
 ; GISEL-NEXT:    v_rcp_iflag_f32_e32 v4, v4
-; GISEL-NEXT:    s_cmp_lg_u32 s6, 0
-; GISEL-NEXT:    s_subb_u32 s6, 0, 0
 ; GISEL-NEXT:    v_mul_f32_e32 v4, 0x5f7ffffc, v4
 ; GISEL-NEXT:    v_mul_f32_e32 v5, 0x2f800000, v4
 ; GISEL-NEXT:    v_trunc_f32_e32 v5, v5
@@ -1703,25 +1700,28 @@ define <2 x i64> @v_srem_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v8, v5
 ; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v6, v7, 0
 ; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v6, v8, v[5:6]
-; GISEL-NEXT:    v_mul_hi_u32 v11, v7, v4
-; GISEL-NEXT:    v_mul_hi_u32 v12, v8, v4
+; GISEL-NEXT:    s_mov_b32 s4, 1
+; GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GISEL-NEXT:    s_subb_u32 s6, 0, 0
 ; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], s6, v7, v[9:10]
 ; GISEL-NEXT:    v_mul_lo_u32 v10, v8, v4
-; GISEL-NEXT:    v_mul_lo_u32 v9, v7, v13
-; GISEL-NEXT:    v_mul_lo_u32 v4, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v10, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v14, v9
+; GISEL-NEXT:    v_mul_hi_u32 v11, v7, v4
+; GISEL-NEXT:    v_mul_hi_u32 v12, v8, v4
+; GISEL-NEXT:    v_mul_lo_u32 v4, v7, v13
+; GISEL-NEXT:    v_mul_lo_u32 v9, v8, v13
 ; GISEL-NEXT:    v_mul_hi_u32 v14, v7, v13
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v12
+; GISEL-NEXT:    v_mul_hi_u32 v13, v8, v13
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v10, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v14
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v15, v4
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v14
 ; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v15, v14
-; GISEL-NEXT:    v_mul_hi_u32 v13, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v9
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v9, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v14, v9
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v13, v9
@@ -1733,11 +1733,8 @@ define <2 x i64> @v_srem_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_mul_hi_u32 v18, v4, v13
 ; GISEL-NEXT:    v_mul_hi_u32 v19, v17, v13
 ; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], s6, v4, v[15:16]
-; GISEL-NEXT:    s_mov_b32 s6, 1
-; GISEL-NEXT:    s_cmp_lg_u32 s6, 0
 ; GISEL-NEXT:    v_mul_lo_u32 v14, v4, v13
 ; GISEL-NEXT:    v_mul_hi_u32 v15, v4, v13
-; GISEL-NEXT:    s_subb_u32 s6, 0, 0
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v14
 ; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v18
@@ -1792,50 +1789,52 @@ define <2 x i64> @v_srem_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_subbrev_u32_e32 v0, vcc, 0, v0, vcc
 ; GISEL-NEXT:    v_sub_i32_e32 v18, vcc, v16, v4
 ; GISEL-NEXT:    v_subbrev_u32_e32 v19, vcc, 0, v0, vcc
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v16, v4
 ; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v18, v4
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v17
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v16, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
 ; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v19
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, -1, v1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, -1, s[4:5]
 ; GISEL-NEXT:    v_cndmask_b32_e32 v20, -1, v0, vcc
 ; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v8, v[5:6]
+; GISEL-NEXT:    s_mov_b32 s4, 1
+; GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GISEL-NEXT:    s_subb_u32 s6, 0, 0
 ; GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], s6, v7, v[0:1]
 ; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v18, v4
-; GISEL-NEXT:    v_mul_lo_u32 v5, v7, v13
-; GISEL-NEXT:    v_subbrev_u32_e32 v1, vcc, 0, v19, vcc
+; GISEL-NEXT:    v_subbrev_u32_e32 v5, vcc, 0, v19, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v1, v7, v13
 ; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v20
-; GISEL-NEXT:    v_cndmask_b32_e32 v14, v18, v0, vcc
-; GISEL-NEXT:    v_cndmask_b32_e32 v18, v19, v1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v10, v5
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v5, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v17
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, -1, v15, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e32 v15, v18, v0, vcc
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v10, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[4:5]
+; GISEL-NEXT:    v_mul_lo_u32 v10, v8, v13
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v1, v0
 ; GISEL-NEXT:    v_mul_hi_u32 v1, v7, v13
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v12
-; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v5, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v10, v5
-; GISEL-NEXT:    v_mul_hi_u32 v10, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v5, v1
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v10, v1
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v7, v0
-; GISEL-NEXT:    v_addc_u32_e32 v11, vcc, v8, v1, vcc
+; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v10, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v10, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v11, v10
+; GISEL-NEXT:    v_mul_hi_u32 v11, v8, v13
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v1, v0
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v10, v1
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v11, v1
+; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v7, v0
+; GISEL-NEXT:    v_addc_u32_e64 v11, s[4:5], v8, v1, s[4:5]
 ; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v10, 0
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v15
-; GISEL-NEXT:    v_cndmask_b32_e32 v5, v16, v14, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v6, v11, v[1:2]
-; GISEL-NEXT:    v_xor_b32_e32 v1, v5, v9
+; GISEL-NEXT:    v_cndmask_b32_e32 v5, v19, v5, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
 ; GISEL-NEXT:    v_ashrrev_i32_e32 v13, 31, v3
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], s6, v10, v[7:8]
-; GISEL-NEXT:    v_cndmask_b32_e32 v12, v17, v18, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v6, v11, v[1:2]
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v17, v5, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v12, v16, v15, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v13
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], s6, v10, v[7:8]
 ; GISEL-NEXT:    v_addc_u32_e32 v3, vcc, v3, v13, vcc
 ; GISEL-NEXT:    v_xor_b32_e32 v14, v2, v13
 ; GISEL-NEXT:    v_mul_lo_u32 v2, v11, v0
@@ -1866,7 +1865,7 @@ define <2 x i64> @v_srem_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_mul_lo_u32 v5, v14, v2
 ; GISEL-NEXT:    v_mul_hi_u32 v6, v14, v0
 ; GISEL-NEXT:    v_mul_hi_u32 v0, v15, v0
-; GISEL-NEXT:    v_xor_b32_e32 v7, v12, v9
+; GISEL-NEXT:    v_xor_b32_e32 v12, v12, v9
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v6
@@ -1880,15 +1879,16 @@ define <2 x i64> @v_srem_v2i64_oddk_denom(<2 x i64> %num) {
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
 ; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v0, v3
+; GISEL-NEXT:    v_mul_hi_u32 v6, v15, v2
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v10, 0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
-; GISEL-NEXT:    v_mul_hi_u32 v5, v15, v2
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v10, 0
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v5, v0
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v6, v0
 ; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v0, v[3:4]
-; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v1, v9
-; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v7, v9, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v1, v1, v9
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v12, v9
 ; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], 0, v10, v[5:6]
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v9, vcc
 ; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v14, v2
 ; GISEL-NEXT:    v_sub_i32_e64 v5, s[4:5], v15, v7
 ; GISEL-NEXT:    v_subb_u32_e64 v3, s[4:5], v15, v7, vcc
@@ -1943,14 +1943,14 @@ define <2 x i64> @v_srem_v2i64_oddk_denom(<2 x i64> %num) {
 ; CGP-NEXT:    v_mul_hi_u32 v12, v8, v12
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v9, v4
 ; CGP-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v13, vcc, v13, v11
+; CGP-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v4, v10
 ; CGP-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v15, v4
-; CGP-NEXT:    v_add_i32_e32 v13, vcc, v13, v11
-; CGP-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v13, vcc, v13, v14
 ; CGP-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v14, vcc, v15, v14
+; CGP-NEXT:    v_add_i32_e32 v14, vcc, v16, v14
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v13, v4
 ; CGP-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v13, vcc, v14, v13
@@ -2013,53 +2013,53 @@ define <2 x i64> @v_srem_v2i64_oddk_denom(<2 x i64> %num) {
 ; CGP-NEXT:    v_add_i32_e32 v15, vcc, v15, v14
 ; CGP-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v4, v15, v[1:2]
 ; CGP-NEXT:    v_sub_i32_e32 v15, vcc, v18, v0
-; CGP-NEXT:    v_sub_i32_e64 v0, s[4:5], v19, v13
 ; CGP-NEXT:    v_subb_u32_e64 v16, s[4:5], v19, v13, vcc
-; CGP-NEXT:    v_subbrev_u32_e32 v0, vcc, 0, v0, vcc
-; CGP-NEXT:    v_sub_i32_e32 v18, vcc, v15, v4
-; CGP-NEXT:    v_subbrev_u32_e32 v19, vcc, 0, v0, vcc
+; CGP-NEXT:    v_sub_i32_e64 v0, s[4:5], v19, v13
 ; CGP-NEXT:    v_cmp_ge_u32_e64 s[4:5], v15, v4
-; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v18, v4
+; CGP-NEXT:    v_subbrev_u32_e32 v0, vcc, 0, v0, vcc
 ; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[4:5]
 ; CGP-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v16
-; CGP-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
-; CGP-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v19
+; CGP-NEXT:    v_sub_i32_e32 v18, vcc, v15, v4
 ; CGP-NEXT:    v_cndmask_b32_e64 v17, -1, v1, s[4:5]
-; CGP-NEXT:    v_cndmask_b32_e32 v20, -1, v0, vcc
+; CGP-NEXT:    v_subbrev_u32_e32 v19, vcc, 0, v0, vcc
 ; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v8, v[5:6]
-; CGP-NEXT:    v_sub_i32_e32 v5, vcc, v18, v4
+; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v18, v4
+; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc
+; CGP-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v19
 ; CGP-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], -1, v7, v[0:1]
-; CGP-NEXT:    v_subbrev_u32_e32 v21, vcc, 0, v19, vcc
-; CGP-NEXT:    v_mul_lo_u32 v1, v7, v13
-; CGP-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v20
-; CGP-NEXT:    v_cndmask_b32_e32 v0, v18, v5, vcc
-; CGP-NEXT:    v_cndmask_b32_e32 v5, v19, v21, vcc
-; CGP-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v17
-; CGP-NEXT:    v_cndmask_b32_e32 v14, v15, v0, vcc
-; CGP-NEXT:    v_add_i32_e64 v0, s[4:5], v9, v1
-; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
-; CGP-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v10
-; CGP-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[4:5]
-; CGP-NEXT:    v_mul_lo_u32 v9, v8, v13
-; CGP-NEXT:    v_add_i32_e64 v0, s[4:5], v1, v0
+; CGP-NEXT:    v_cndmask_b32_e32 v5, -1, v5, vcc
+; CGP-NEXT:    v_sub_i32_e32 v0, vcc, v18, v4
+; CGP-NEXT:    v_subbrev_u32_e32 v1, vcc, 0, v19, vcc
+; CGP-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; CGP-NEXT:    v_mul_lo_u32 v5, v7, v13
+; CGP-NEXT:    v_cndmask_b32_e32 v14, v18, v0, vcc
+; CGP-NEXT:    v_cndmask_b32_e32 v18, v19, v1, vcc
+; CGP-NEXT:    v_add_i32_e32 v0, vcc, v9, v5
+; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v0, vcc, v0, v10
+; CGP-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
+; CGP-NEXT:    v_mul_lo_u32 v5, v8, v13
+; CGP-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
 ; CGP-NEXT:    v_mul_hi_u32 v1, v7, v13
-; CGP-NEXT:    v_add_i32_e64 v9, s[4:5], v9, v11
-; CGP-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s[4:5]
-; CGP-NEXT:    v_add_i32_e64 v1, s[4:5], v9, v1
-; CGP-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s[4:5]
-; CGP-NEXT:    v_add_i32_e64 v9, s[4:5], v10, v9
-; CGP-NEXT:    v_mul_hi_u32 v10, v8, v13
-; CGP-NEXT:    v_add_i32_e64 v0, s[4:5], v1, v0
-; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
-; CGP-NEXT:    v_add_i32_e64 v1, s[4:5], v9, v1
-; CGP-NEXT:    v_add_i32_e64 v1, s[4:5], v10, v1
-; CGP-NEXT:    v_add_i32_e64 v9, s[4:5], v7, v0
-; CGP-NEXT:    v_addc_u32_e64 v10, s[4:5], v8, v1, s[4:5]
+; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v11
+; CGP-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v1, vcc, v5, v1
+; CGP-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v5, vcc, v9, v5
+; CGP-NEXT:    v_mul_hi_u32 v9, v8, v13
+; CGP-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
+; CGP-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v1, vcc, v5, v1
+; CGP-NEXT:    v_add_i32_e32 v1, vcc, v9, v1
+; CGP-NEXT:    v_add_i32_e32 v9, vcc, v7, v0
+; CGP-NEXT:    v_addc_u32_e32 v10, vcc, v8, v1, vcc
 ; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v9, 0
-; CGP-NEXT:    v_cndmask_b32_e32 v5, v16, v5, vcc
+; CGP-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v17
+; CGP-NEXT:    v_cndmask_b32_e32 v5, v15, v14, vcc
 ; CGP-NEXT:    v_ashrrev_i32_e32 v13, 31, v3
 ; CGP-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v6, v10, v[1:2]
 ; CGP-NEXT:    v_xor_b32_e32 v1, v5, v12
+; CGP-NEXT:    v_cndmask_b32_e32 v11, v16, v18, vcc
 ; CGP-NEXT:    v_add_i32_e32 v2, vcc, v2, v13
 ; CGP-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], -1, v9, v[7:8]
 ; CGP-NEXT:    v_addc_u32_e32 v3, vcc, v3, v13, vcc
@@ -2090,10 +2090,10 @@ define <2 x i64> @v_srem_v2i64_oddk_denom(<2 x i64> %num) {
 ; CGP-NEXT:    v_addc_u32_e32 v2, vcc, v10, v2, vcc
 ; CGP-NEXT:    v_mul_lo_u32 v5, v8, v3
 ; CGP-NEXT:    v_mul_lo_u32 v6, v7, v2
-; CGP-NEXT:    v_xor_b32_e32 v11, v14, v12
 ; CGP-NEXT:    v_mul_hi_u32 v9, v7, v3
-; CGP-NEXT:    v_sub_i32_e32 v0, vcc, v11, v12
-; CGP-NEXT:    v_subb_u32_e32 v1, vcc, v1, v12, vcc
+; CGP-NEXT:    v_xor_b32_e32 v11, v11, v12
+; CGP-NEXT:    v_sub_i32_e32 v0, vcc, v1, v12
+; CGP-NEXT:    v_subb_u32_e32 v1, vcc, v11, v12, vcc
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v6
 ; CGP-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v9
@@ -2108,11 +2108,11 @@ define <2 x i64> @v_srem_v2i64_oddk_denom(<2 x i64> %num) {
 ; CGP-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v6, vcc, v9, v6
 ; CGP-NEXT:    v_add_i32_e32 v5, vcc, v3, v5
-; CGP-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; CGP-NEXT:    v_mul_hi_u32 v9, v8, v2
-; CGP-NEXT:    v_add_i32_e32 v6, vcc, v6, v3
+; CGP-NEXT:    v_mul_hi_u32 v10, v8, v2
 ; CGP-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v5, 0
-; CGP-NEXT:    v_add_i32_e32 v9, vcc, v9, v6
+; CGP-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v5, vcc, v6, v9
+; CGP-NEXT:    v_add_i32_e32 v9, vcc, v10, v5
 ; CGP-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v9, v[3:4]
 ; CGP-NEXT:    v_sub_i32_e32 v2, vcc, v7, v2
 ; CGP-NEXT:    v_subb_u32_e64 v3, s[4:5], v8, v5, vcc
@@ -2164,7 +2164,7 @@ define i64 @v_srem_i64_pow2_shl_denom(i64 %x, i64 %y) {
 ; CHECK-NEXT:  ; %bb.1: ; %Flow
 ; CHECK-NEXT:    s_andn2_saveexec_b64 s[4:5], s[6:7]
 ; CHECK-NEXT:    s_cbranch_execnz .LBB7_4
-; CHECK-NEXT:  .LBB7_2:
+; CHECK-NEXT:  .LBB7_2: ; %.split
 ; CHECK-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
 ; CHECK-NEXT:  .LBB7_3:
@@ -2193,17 +2193,17 @@ define i64 @v_srem_i64_pow2_shl_denom(i64 %x, i64 %y) {
 ; CHECK-NEXT:    v_mul_hi_u32 v5, v11, v5
 ; CHECK-NEXT:    v_mul_lo_u32 v8, v2, v9
 ; CHECK-NEXT:    v_mul_lo_u32 v10, v11, v9
+; CHECK-NEXT:    v_mul_hi_u32 v14, v2, v9
 ; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v6, v8
 ; CHECK-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v6, v7
-; CHECK-NEXT:    v_mul_hi_u32 v7, v2, v9
 ; CHECK-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v8, v6
 ; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v10, v5
-; CHECK-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v5, v7
 ; CHECK-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v7, vcc, v8, v7
+; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v5, v14
+; CHECK-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v7, vcc, v7, v8
 ; CHECK-NEXT:    v_mul_hi_u32 v8, v11, v9
 ; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v5, v6
 ; CHECK-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
@@ -2259,11 +2259,11 @@ define i64 @v_srem_i64_pow2_shl_denom(i64 %x, i64 %y) {
 ; CHECK-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; CHECK-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
 ; CHECK-NEXT:    v_add_i32_e32 v9, vcc, v2, v4
-; CHECK-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
-; CHECK-NEXT:    v_add_i32_e32 v4, vcc, v5, v2
-; CHECK-NEXT:    v_mul_hi_u32 v5, v10, v3
+; CHECK-NEXT:    v_mul_hi_u32 v6, v10, v3
 ; CHECK-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v0, v9, 0
-; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v5, v4
+; CHECK-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; CHECK-NEXT:    v_add_i32_e32 v4, vcc, v5, v4
+; CHECK-NEXT:    v_add_i32_e32 v6, vcc, v6, v4
 ; CHECK-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, v6, v[3:4]
 ; CHECK-NEXT:    v_sub_i32_e32 v2, vcc, v8, v2
 ; CHECK-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v1, v9, v[4:5]
@@ -2355,11 +2355,11 @@ define <2 x i64> @v_srem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v17, v16, v[9:10]
 ; GISEL-NEXT:    v_mul_lo_u32 v9, v16, v8
 ; GISEL-NEXT:    v_mad_u64_u32 v[14:15], s[4:5], v18, v4, v[12:13]
-; GISEL-NEXT:    v_mul_lo_u32 v12, v4, v14
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v12
 ; GISEL-NEXT:    v_mul_hi_u32 v12, v4, v8
-; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
 ; GISEL-NEXT:    v_mul_hi_u32 v8, v16, v8
+; GISEL-NEXT:    v_mul_lo_u32 v13, v4, v14
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v13
+; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v12
 ; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
 ; GISEL-NEXT:    v_mul_lo_u32 v12, v16, v14
@@ -2383,10 +2383,10 @@ define <2 x i64> @v_srem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v17, v16, v[9:10]
 ; GISEL-NEXT:    v_addc_u32_e32 v1, vcc, v1, v4, vcc
 ; GISEL-NEXT:    v_mad_u64_u32 v[14:15], s[4:5], v18, v19, v[12:13]
-; GISEL-NEXT:    v_xor_b32_e32 v15, v0, v4
+; GISEL-NEXT:    v_xor_b32_e32 v13, v0, v4
 ; GISEL-NEXT:    v_mul_lo_u32 v0, v16, v8
+; GISEL-NEXT:    v_xor_b32_e32 v15, v1, v4
 ; GISEL-NEXT:    v_mul_lo_u32 v9, v19, v14
-; GISEL-NEXT:    v_xor_b32_e32 v17, v1, v4
 ; GISEL-NEXT:    v_mul_hi_u32 v1, v19, v8
 ; GISEL-NEXT:    v_mul_hi_u32 v8, v16, v8
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v9
@@ -2408,113 +2408,112 @@ define <2 x i64> @v_srem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v9, v1
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v19, v0
 ; GISEL-NEXT:    v_addc_u32_e32 v1, vcc, v16, v1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v8, v17, v0
-; GISEL-NEXT:    v_mul_lo_u32 v9, v15, v1
-; GISEL-NEXT:    v_mul_hi_u32 v12, v15, v0
-; GISEL-NEXT:    v_mul_hi_u32 v0, v17, v0
-; GISEL-NEXT:    v_lshl_b64 v[10:11], v[10:11], v6
-; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v8, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v8, v12
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v12, v17, v1
-; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v9, v8
-; GISEL-NEXT:    v_mul_hi_u32 v9, v15, v1
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v12, v0
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v12, v9
-; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v0, v8
+; GISEL-NEXT:    v_mul_lo_u32 v12, v15, v0
+; GISEL-NEXT:    v_mul_lo_u32 v14, v13, v1
+; GISEL-NEXT:    v_lshl_b64 v[8:9], v[10:11], v6
+; GISEL-NEXT:    v_mul_hi_u32 v6, v13, v0
+; GISEL-NEXT:    v_mul_hi_u32 v0, v15, v0
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v12, v14
+; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v10, v6
+; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v10, v15, v1
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v11, v6
+; GISEL-NEXT:    v_mul_hi_u32 v11, v13, v1
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v10, v0
+; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v11
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v0, v6
 ; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v9, v0
-; GISEL-NEXT:    v_mul_hi_u32 v9, v17, v1
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v0
+; GISEL-NEXT:    v_ashrrev_i32_e32 v12, 31, v9
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v8, v12
+; GISEL-NEXT:    v_addc_u32_e32 v8, vcc, v9, v12, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v6, v6, v12
+; GISEL-NEXT:    v_xor_b32_e32 v8, v8, v12
+; GISEL-NEXT:    v_mul_hi_u32 v11, v15, v1
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v12, v6
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v16, v8
 ; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v14, 0
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v9, v8
-; GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v5, v12, v[1:2]
-; GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v7, v14, v[8:9]
-; GISEL-NEXT:    v_sub_i32_e32 v13, vcc, v15, v0
-; GISEL-NEXT:    v_subb_u32_e64 v14, s[4:5], v17, v12, vcc
-; GISEL-NEXT:    v_sub_i32_e64 v0, s[4:5], v17, v12
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v14, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v13, v5
-; GISEL-NEXT:    v_subb_u32_e32 v0, vcc, v0, v7, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v14, v7
-; GISEL-NEXT:    v_sub_i32_e32 v15, vcc, v13, v5
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, v1, v6, s[4:5]
-; GISEL-NEXT:    v_subbrev_u32_e64 v16, s[4:5], 0, v0, vcc
-; GISEL-NEXT:    v_ashrrev_i32_e32 v1, 31, v11
-; GISEL-NEXT:    v_add_i32_e64 v6, s[4:5], v10, v1
-; GISEL-NEXT:    v_addc_u32_e64 v8, s[4:5], v11, v1, s[4:5]
-; GISEL-NEXT:    v_xor_b32_e32 v6, v6, v1
-; GISEL-NEXT:    v_xor_b32_e32 v8, v8, v1
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v1, v6
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v9, v8
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v16, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v15, v5
-; GISEL-NEXT:    v_mac_f32_e32 v1, 0x4f800000, v9
-; GISEL-NEXT:    v_rcp_iflag_f32_e32 v1, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v16, v7
-; GISEL-NEXT:    v_subb_u32_e32 v7, vcc, v0, v7, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v10
+; GISEL-NEXT:    v_mac_f32_e32 v12, 0x4f800000, v16
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v5, v11, v[1:2]
+; GISEL-NEXT:    v_rcp_iflag_f32_e32 v1, v12
+; GISEL-NEXT:    v_sub_i32_e32 v13, vcc, v13, v0
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v7, v14, v[9:10]
 ; GISEL-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v1
 ; GISEL-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; GISEL-NEXT:    v_trunc_f32_e32 v1, v1
 ; GISEL-NEXT:    v_mac_f32_e32 v0, 0xcf800000, v1
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v17, v0
-; GISEL-NEXT:    v_sub_i32_e32 v19, vcc, 0, v6
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, v10, v11, s[4:5]
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v18, v1
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v19, v17, 0
-; GISEL-NEXT:    v_subb_u32_e32 v20, vcc, 0, v8, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v19, v18, v[1:2]
-; GISEL-NEXT:    v_mul_lo_u32 v21, v18, v0
-; GISEL-NEXT:    v_mul_hi_u32 v22, v17, v0
-; GISEL-NEXT:    v_mul_hi_u32 v23, v18, v0
-; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v15, v5
-; GISEL-NEXT:    v_subbrev_u32_e32 v5, vcc, 0, v7, vcc
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
-; GISEL-NEXT:    v_cndmask_b32_e32 v7, v15, v0, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v20, v17, v[9:10]
-; GISEL-NEXT:    v_cndmask_b32_e32 v5, v16, v5, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v1, v17, v0
-; GISEL-NEXT:    v_mul_lo_u32 v10, v18, v0
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v21, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v1, v22
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v9, v1
-; GISEL-NEXT:    v_mul_hi_u32 v9, v17, v0
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v23
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v10, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v11, v10
-; GISEL-NEXT:    v_mul_hi_u32 v0, v18, v0
-; GISEL-NEXT:    v_add_i32_e32 v1, vcc, v9, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v10, v9
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v9
-; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v17, v1
-; GISEL-NEXT:    v_addc_u32_e32 v16, vcc, v18, v0, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v19, v15, 0
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
-; GISEL-NEXT:    v_cndmask_b32_e32 v7, v13, v7, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v19, v16, v[1:2]
-; GISEL-NEXT:    v_xor_b32_e32 v1, v7, v4
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v14, v0
+; GISEL-NEXT:    v_sub_i32_e64 v17, s[4:5], 0, v6
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v16, v1
+; GISEL-NEXT:    v_subb_u32_e64 v18, s[4:5], 0, v8, s[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v17, v14, 0
+; GISEL-NEXT:    v_subb_u32_e64 v19, s[4:5], v15, v11, vcc
+; GISEL-NEXT:    v_sub_i32_e64 v15, s[4:5], v15, v11
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v17, v16, v[1:2]
+; GISEL-NEXT:    v_mul_lo_u32 v1, v16, v0
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v19, v7
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v18, v14, v[9:10]
+; GISEL-NEXT:    v_mul_lo_u32 v9, v14, v11
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v1, v9
+; GISEL-NEXT:    v_mul_hi_u32 v9, v14, v0
+; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s[4:5]
+; GISEL-NEXT:    v_mul_hi_u32 v0, v16, v0
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v1, v9
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[6:7]
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v13, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, -1, s[6:7]
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], v19, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v9, v1, v9, s[6:7]
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v15, v7, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v12, vcc, v13, v5
+; GISEL-NEXT:    v_subbrev_u32_e64 v15, s[6:7], 0, v1, vcc
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v7, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v12, v5
+; GISEL-NEXT:    v_sub_i32_e32 v5, vcc, v12, v5
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[8:9], v15, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, -1, s[6:7]
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], v15, v7
+; GISEL-NEXT:    v_subbrev_u32_e32 v7, vcc, 0, v1, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v10, v1
+; GISEL-NEXT:    v_mul_lo_u32 v10, v16, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, -1, s[8:9]
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, v20, v21, s[6:7]
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v20
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v10, v0
+; GISEL-NEXT:    v_mul_hi_u32 v10, v14, v11
+; GISEL-NEXT:    v_cndmask_b32_e32 v5, v12, v5, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s[4:5]
+; GISEL-NEXT:    v_mul_hi_u32 v11, v16, v11
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v10
+; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v12, v10
+; GISEL-NEXT:    v_add_i32_e64 v0, s[4:5], v0, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v10, v1
+; GISEL-NEXT:    v_add_i32_e64 v1, s[4:5], v11, v1
+; GISEL-NEXT:    v_add_i32_e64 v14, s[4:5], v14, v0
+; GISEL-NEXT:    v_addc_u32_e64 v16, s[4:5], v16, v1, s[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v17, v14, 0
+; GISEL-NEXT:    v_cndmask_b32_e32 v7, v15, v7, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
+; GISEL-NEXT:    v_cndmask_b32_e32 v5, v13, v5, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v17, v16, v[1:2]
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v19, v7, vcc
 ; GISEL-NEXT:    v_ashrrev_i32_e32 v7, 31, v3
-; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v20, v15, v[9:10]
-; GISEL-NEXT:    v_cndmask_b32_e32 v5, v14, v5, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v7
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v18, v14, v[9:10]
 ; GISEL-NEXT:    v_addc_u32_e32 v3, vcc, v3, v7, vcc
 ; GISEL-NEXT:    v_xor_b32_e32 v12, v2, v7
 ; GISEL-NEXT:    v_mul_lo_u32 v2, v16, v0
-; GISEL-NEXT:    v_mul_lo_u32 v9, v15, v11
+; GISEL-NEXT:    v_mul_lo_u32 v9, v14, v11
 ; GISEL-NEXT:    v_xor_b32_e32 v13, v3, v7
-; GISEL-NEXT:    v_mul_hi_u32 v3, v15, v0
+; GISEL-NEXT:    v_mul_hi_u32 v3, v14, v0
 ; GISEL-NEXT:    v_mul_hi_u32 v0, v16, v0
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v9
 ; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
@@ -2522,7 +2521,7 @@ define <2 x i64> @v_srem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GISEL-NEXT:    v_mul_lo_u32 v3, v16, v11
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v9, v2
-; GISEL-NEXT:    v_mul_hi_u32 v9, v15, v11
+; GISEL-NEXT:    v_mul_hi_u32 v9, v14, v11
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v3, v0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v0, v9
@@ -2533,7 +2532,7 @@ define <2 x i64> @v_srem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v3, v2
 ; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v9, v2
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v15, v0
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v14, v0
 ; GISEL-NEXT:    v_addc_u32_e32 v2, vcc, v16, v2, vcc
 ; GISEL-NEXT:    v_mul_lo_u32 v3, v13, v0
 ; GISEL-NEXT:    v_mul_lo_u32 v9, v12, v2
@@ -2553,14 +2552,15 @@ define <2 x i64> @v_srem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v10, v9
 ; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v0, v3
+; GISEL-NEXT:    v_mul_hi_u32 v10, v13, v2
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v6, v11, 0
 ; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v9, v0
-; GISEL-NEXT:    v_mul_hi_u32 v9, v13, v2
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v6, v11, 0
-; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v9, v0
+; GISEL-NEXT:    v_add_i32_e32 v0, vcc, v10, v0
 ; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v6, v0, v[3:4]
-; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v1, v4
-; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v5, v4, vcc
+; GISEL-NEXT:    v_xor_b32_e32 v1, v1, v4
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v5, v4
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v4, vcc
 ; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v8, v11, v[9:10]
 ; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v12, v2
 ; GISEL-NEXT:    v_subb_u32_e64 v4, s[4:5], v13, v3, vcc
@@ -2638,17 +2638,17 @@ define <2 x i64> @v_srem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; CGP-NEXT:    v_mul_hi_u32 v10, v16, v10
 ; CGP-NEXT:    v_mul_lo_u32 v13, v4, v14
 ; CGP-NEXT:    v_mul_lo_u32 v15, v16, v14
+; CGP-NEXT:    v_mul_hi_u32 v19, v4, v14
 ; CGP-NEXT:    v_add_i32_e32 v11, vcc, v11, v13
 ; CGP-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v11, vcc, v11, v12
-; CGP-NEXT:    v_mul_hi_u32 v12, v4, v14
 ; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v11, vcc, v13, v11
 ; CGP-NEXT:    v_add_i32_e32 v10, vcc, v15, v10
-; CGP-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v10, vcc, v10, v12
 ; CGP-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v12, vcc, v13, v12
+; CGP-NEXT:    v_add_i32_e32 v10, vcc, v10, v19
+; CGP-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v12, vcc, v12, v13
 ; CGP-NEXT:    v_mul_hi_u32 v13, v16, v14
 ; CGP-NEXT:    v_add_i32_e32 v10, vcc, v10, v11
 ; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
@@ -2691,6 +2691,7 @@ define <2 x i64> @v_srem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; CGP-NEXT:    v_mul_lo_u32 v10, v15, v8
 ; CGP-NEXT:    v_mul_hi_u32 v11, v15, v4
 ; CGP-NEXT:    v_mul_hi_u32 v4, v18, v4
+; CGP-NEXT:    v_mul_hi_u32 v12, v18, v8
 ; CGP-NEXT:    v_add_i32_e32 v9, vcc, v9, v10
 ; CGP-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v9, vcc, v9, v11
@@ -2704,11 +2705,10 @@ define <2 x i64> @v_srem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; CGP-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v10, vcc, v11, v10
 ; CGP-NEXT:    v_add_i32_e32 v4, vcc, v4, v9
-; CGP-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; CGP-NEXT:    v_mul_hi_u32 v11, v18, v8
-; CGP-NEXT:    v_add_i32_e32 v10, vcc, v10, v9
 ; CGP-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v0, v4, 0
-; CGP-NEXT:    v_add_i32_e32 v12, vcc, v11, v10
+; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v10, vcc, v10, v11
+; CGP-NEXT:    v_add_i32_e32 v12, vcc, v12, v10
 ; CGP-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v0, v12, v[9:10]
 ; CGP-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v1, v4, v[10:11]
 ; CGP-NEXT:    v_sub_i32_e32 v4, vcc, v15, v8
@@ -2768,7 +2768,7 @@ define <2 x i64> @v_srem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; CGP-NEXT:    v_sub_i32_e32 v2, vcc, v0, v11
 ; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v11
 ; CGP-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; CGP-NEXT:  .LBB8_4:
+; CGP-NEXT:  .LBB8_4: ; %.split
 ; CGP-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; CGP-NEXT:    v_or_b32_e32 v3, v7, v10
 ; CGP-NEXT:    v_mov_b32_e32 v2, 0
@@ -2780,7 +2780,7 @@ define <2 x i64> @v_srem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; CGP-NEXT:  ; %bb.5: ; %Flow
 ; CGP-NEXT:    s_andn2_saveexec_b64 s[4:5], s[6:7]
 ; CGP-NEXT:    s_cbranch_execnz .LBB8_8
-; CGP-NEXT:  .LBB8_6:
+; CGP-NEXT:  .LBB8_6: ; %.split.split
 ; CGP-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; CGP-NEXT:    s_setpc_b64 s[30:31]
 ; CGP-NEXT:  .LBB8_7:
@@ -2809,17 +2809,17 @@ define <2 x i64> @v_srem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; CGP-NEXT:    v_mul_hi_u32 v8, v6, v8
 ; CGP-NEXT:    v_mul_lo_u32 v11, v4, v12
 ; CGP-NEXT:    v_mul_lo_u32 v13, v6, v12
+; CGP-NEXT:    v_mul_hi_u32 v16, v4, v12
 ; CGP-NEXT:    v_add_i32_e32 v9, vcc, v9, v11
 ; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v9, vcc, v9, v10
-; CGP-NEXT:    v_mul_hi_u32 v10, v4, v12
 ; CGP-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v9, vcc, v11, v9
 ; CGP-NEXT:    v_add_i32_e32 v8, vcc, v13, v8
-; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v8, vcc, v8, v10
 ; CGP-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v10, vcc, v11, v10
+; CGP-NEXT:    v_add_i32_e32 v8, vcc, v8, v16
+; CGP-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v10, vcc, v10, v11
 ; CGP-NEXT:    v_mul_hi_u32 v11, v6, v12
 ; CGP-NEXT:    v_add_i32_e32 v8, vcc, v8, v9
 ; CGP-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
@@ -2875,11 +2875,11 @@ define <2 x i64> @v_srem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; CGP-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; CGP-NEXT:    v_add_i32_e32 v7, vcc, v8, v7
 ; CGP-NEXT:    v_add_i32_e32 v12, vcc, v4, v6
-; CGP-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
-; CGP-NEXT:    v_add_i32_e32 v6, vcc, v7, v4
-; CGP-NEXT:    v_mul_hi_u32 v7, v11, v5
+; CGP-NEXT:    v_mul_hi_u32 v8, v11, v5
 ; CGP-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v12, 0
-; CGP-NEXT:    v_add_i32_e32 v8, vcc, v7, v6
+; CGP-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
+; CGP-NEXT:    v_add_i32_e32 v6, vcc, v7, v6
+; CGP-NEXT:    v_add_i32_e32 v8, vcc, v8, v6
 ; CGP-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v2, v8, v[5:6]
 ; CGP-NEXT:    v_sub_i32_e32 v4, vcc, v10, v4
 ; CGP-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v3, v12, v[6:7]
@@ -3006,70 +3006,70 @@ define <2 x i64> @v_srem_v2i64_24bit(<2 x i64> %num, <2 x i64> %den) {
 ; GISEL-NEXT:    v_and_b32_e32 v1, 0xffffff, v4
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v3, v1
 ; GISEL-NEXT:    v_cvt_f32_ubyte0_e32 v9, 0
-; GISEL-NEXT:    v_sub_i32_e32 v12, vcc, 0, v1
+; GISEL-NEXT:    v_sub_i32_e32 v11, vcc, 0, v1
 ; GISEL-NEXT:    v_mac_f32_e32 v3, 0x4f800000, v9
 ; GISEL-NEXT:    v_rcp_iflag_f32_e32 v3, v3
-; GISEL-NEXT:    v_subb_u32_e64 v13, s[4:5], 0, 0, vcc
+; GISEL-NEXT:    v_subb_u32_e64 v12, s[4:5], 0, 0, vcc
 ; GISEL-NEXT:    v_and_b32_e32 v0, 0xffffff, v0
 ; GISEL-NEXT:    v_mul_f32_e32 v3, 0x5f7ffffc, v3
 ; GISEL-NEXT:    v_mul_f32_e32 v4, 0x2f800000, v3
 ; GISEL-NEXT:    v_trunc_f32_e32 v4, v4
 ; GISEL-NEXT:    v_mac_f32_e32 v3, 0xcf800000, v4
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v11, v3
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v10, v4
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v10, v3
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v13, v4
 ; GISEL-NEXT:    v_and_b32_e32 v2, 0xffffff, v2
-; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v12, v11, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v12, v10, v[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v13, v11, v[7:8]
-; GISEL-NEXT:    v_mul_lo_u32 v5, v10, v3
-; GISEL-NEXT:    v_mul_hi_u32 v7, v11, v3
-; GISEL-NEXT:    v_mul_lo_u32 v8, v11, v4
-; GISEL-NEXT:    v_mul_hi_u32 v3, v10, v3
-; GISEL-NEXT:    v_mul_lo_u32 v14, v10, v4
+; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v11, v10, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v11, v13, v[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v12, v10, v[7:8]
+; GISEL-NEXT:    v_mul_lo_u32 v5, v13, v3
+; GISEL-NEXT:    v_mul_hi_u32 v7, v10, v3
+; GISEL-NEXT:    v_mul_hi_u32 v3, v13, v3
+; GISEL-NEXT:    v_mul_lo_u32 v8, v10, v4
+; GISEL-NEXT:    v_mul_lo_u32 v14, v13, v4
+; GISEL-NEXT:    v_mul_hi_u32 v15, v10, v4
+; GISEL-NEXT:    v_mul_hi_u32 v4, v13, v4
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v8
 ; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v7
-; GISEL-NEXT:    v_mul_hi_u32 v7, v11, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v8, v5
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v14, v3
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v7
 ; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v7, vcc, v8, v7
-; GISEL-NEXT:    v_mul_hi_u32 v4, v10, v4
+; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v15
+; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v7, vcc, v7, v8
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v7, v5
 ; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v5
-; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v3
-; GISEL-NEXT:    v_addc_u32_e32 v10, vcc, v10, v4, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v12, v11, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v12, v10, v[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v13, v11, v[7:8]
-; GISEL-NEXT:    v_mul_lo_u32 v5, v10, v3
-; GISEL-NEXT:    v_mul_hi_u32 v8, v11, v3
-; GISEL-NEXT:    v_mul_lo_u32 v7, v11, v4
-; GISEL-NEXT:    v_mul_hi_u32 v3, v10, v3
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v3
+; GISEL-NEXT:    v_addc_u32_e32 v13, vcc, v13, v4, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v11, v10, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v11, v13, v[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v12, v10, v[7:8]
+; GISEL-NEXT:    v_mul_lo_u32 v5, v13, v3
+; GISEL-NEXT:    v_mul_hi_u32 v8, v10, v3
+; GISEL-NEXT:    v_mul_hi_u32 v3, v13, v3
+; GISEL-NEXT:    v_mul_lo_u32 v7, v10, v4
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v7
 ; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v8
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v8, v10, v4
+; GISEL-NEXT:    v_mul_lo_u32 v8, v13, v4
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v7, v5
-; GISEL-NEXT:    v_mul_hi_u32 v7, v11, v4
+; GISEL-NEXT:    v_mul_hi_u32 v7, v10, v4
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v8, v3
 ; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v7
 ; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v7, vcc, v8, v7
-; GISEL-NEXT:    v_mul_hi_u32 v4, v10, v4
+; GISEL-NEXT:    v_mul_hi_u32 v4, v13, v4
 ; GISEL-NEXT:    v_add_i32_e32 v3, vcc, v3, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v7, v5
 ; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v5
-; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v11, v3
-; GISEL-NEXT:    v_addc_u32_e32 v4, vcc, v10, v4, vcc
+; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v10, v3
+; GISEL-NEXT:    v_addc_u32_e32 v4, vcc, v13, v4, vcc
 ; GISEL-NEXT:    v_mul_lo_u32 v7, 0, v5
 ; GISEL-NEXT:    v_mul_lo_u32 v8, v0, v4
 ; GISEL-NEXT:    v_and_b32_e32 v3, 0xffffff, v6
@@ -3082,112 +3082,112 @@ define <2 x i64> @v_srem_v2i64_24bit(<2 x i64> %num, <2 x i64> %den) {
 ; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v8, v5
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v5, v7
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v5, v6
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v11, v3
-; GISEL-NEXT:    v_mul_hi_u32 v8, 0, v4
-; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v10, 0
-; GISEL-NEXT:    v_mac_f32_e32 v11, 0x4f800000, v9
-; GISEL-NEXT:    v_sub_i32_e32 v13, vcc, 0, v3
-; GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v1, v8, v[5:6]
-; GISEL-NEXT:    v_rcp_iflag_f32_e32 v5, v11
-; GISEL-NEXT:    v_subb_u32_e64 v14, s[4:5], 0, 0, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], 0, v10, v[6:7]
-; GISEL-NEXT:    v_mul_f32_e32 v5, 0x5f7ffffc, v5
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v7, v3
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v5, v6
+; GISEL-NEXT:    v_mul_hi_u32 v6, 0, v4
+; GISEL-NEXT:    v_mac_f32_e32 v7, 0x4f800000, v9
+; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v11, 0
+; GISEL-NEXT:    v_rcp_iflag_f32_e32 v9, v7
+; GISEL-NEXT:    v_sub_i32_e32 v14, vcc, 0, v3
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v1, v6, v[5:6]
+; GISEL-NEXT:    v_mul_f32_e32 v5, 0x5f7ffffc, v9
 ; GISEL-NEXT:    v_mul_f32_e32 v6, 0x2f800000, v5
 ; GISEL-NEXT:    v_trunc_f32_e32 v6, v6
 ; GISEL-NEXT:    v_mac_f32_e32 v5, 0xcf800000, v6
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v11, v5
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v12, v6
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v12, v5
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v13, v6
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], 0, v11, v[7:8]
+; GISEL-NEXT:    v_subb_u32_e64 v15, s[4:5], 0, 0, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v14, v12, 0
 ; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v0, v4
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v13, v11, 0
-; GISEL-NEXT:    v_subb_u32_e64 v15, s[4:5], 0, v8, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v13, v12, v[6:7]
-; GISEL-NEXT:    v_sub_i32_e64 v8, s[4:5], 0, v8
-; GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v14, v11, v[9:10]
+; GISEL-NEXT:    v_subb_u32_e64 v16, s[4:5], 0, v9, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v14, v13, v[6:7]
+; GISEL-NEXT:    v_mul_lo_u32 v4, v13, v5
+; GISEL-NEXT:    v_sub_i32_e64 v6, s[4:5], 0, v9
+; GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v15, v12, v[7:8]
+; GISEL-NEXT:    v_mul_hi_u32 v9, v12, v5
 ; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v0, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, -1, s[4:5]
-; GISEL-NEXT:    v_mul_lo_u32 v7, v12, v5
-; GISEL-NEXT:    v_mul_lo_u32 v9, v11, v6
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v15
-; GISEL-NEXT:    v_cndmask_b32_e64 v10, -1, v4, s[4:5]
-; GISEL-NEXT:    v_mul_hi_u32 v4, v11, v5
-; GISEL-NEXT:    v_add_i32_e64 v7, s[4:5], v7, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v4, s[4:5], v7, v4
-; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s[4:5]
-; GISEL-NEXT:    v_mul_lo_u32 v7, v12, v6
-; GISEL-NEXT:    v_mul_hi_u32 v5, v12, v5
-; GISEL-NEXT:    v_add_i32_e64 v4, s[4:5], v9, v4
-; GISEL-NEXT:    v_mul_hi_u32 v9, v11, v6
-; GISEL-NEXT:    v_add_i32_e64 v5, s[4:5], v7, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, -1, s[4:5]
+; GISEL-NEXT:    v_mul_lo_u32 v7, v12, v10
+; GISEL-NEXT:    v_mul_hi_u32 v5, v13, v5
+; GISEL-NEXT:    v_add_i32_e64 v4, s[4:5], v4, v7
 ; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v5, s[4:5], v5, v9
+; GISEL-NEXT:    v_add_i32_e64 v4, s[4:5], v4, v9
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s[4:5]
+; GISEL-NEXT:    v_mul_lo_u32 v9, v13, v10
+; GISEL-NEXT:    v_add_i32_e64 v4, s[4:5], v7, v4
+; GISEL-NEXT:    v_mul_hi_u32 v7, v12, v10
+; GISEL-NEXT:    v_add_i32_e64 v5, s[4:5], v9, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v7, s[4:5], v7, v9
-; GISEL-NEXT:    v_mul_hi_u32 v6, v12, v6
+; GISEL-NEXT:    v_add_i32_e64 v5, s[4:5], v5, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v7, s[4:5], v9, v7
+; GISEL-NEXT:    v_mul_hi_u32 v9, v13, v10
 ; GISEL-NEXT:    v_add_i32_e64 v4, s[4:5], v5, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s[4:5]
 ; GISEL-NEXT:    v_add_i32_e64 v5, s[4:5], v7, v5
-; GISEL-NEXT:    v_add_i32_e64 v5, s[4:5], v6, v5
-; GISEL-NEXT:    v_add_i32_e64 v11, s[4:5], v11, v4
-; GISEL-NEXT:    v_addc_u32_e64 v12, s[4:5], v12, v5, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v13, v11, 0
-; GISEL-NEXT:    v_subbrev_u32_e32 v8, vcc, 0, v8, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v13, v12, v[5:6]
+; GISEL-NEXT:    v_add_i32_e64 v5, s[4:5], v9, v5
+; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v12, v4
+; GISEL-NEXT:    v_addc_u32_e64 v11, s[4:5], v13, v5, s[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v14, v10, 0
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v16
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, -1, v8, s[4:5]
+; GISEL-NEXT:    v_subbrev_u32_e32 v8, vcc, 0, v6, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v14, v11, v[5:6]
 ; GISEL-NEXT:    v_sub_i32_e32 v13, vcc, v0, v1
-; GISEL-NEXT:    v_subbrev_u32_e32 v16, vcc, 0, v8, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v14, v11, v[6:7]
+; GISEL-NEXT:    v_subbrev_u32_e32 v14, vcc, 0, v8, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v15, v10, v[6:7]
 ; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v13, v1
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v6, v12, v4
-; GISEL-NEXT:    v_mul_lo_u32 v7, v11, v8
-; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v16
+; GISEL-NEXT:    v_mul_lo_u32 v6, v11, v4
+; GISEL-NEXT:    v_mul_lo_u32 v7, v10, v8
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v14
 ; GISEL-NEXT:    v_cndmask_b32_e32 v9, -1, v5, vcc
-; GISEL-NEXT:    v_mul_hi_u32 v5, v11, v4
+; GISEL-NEXT:    v_mul_hi_u32 v5, v10, v4
 ; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v7
 ; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v6, v12, v8
-; GISEL-NEXT:    v_mul_hi_u32 v4, v12, v4
+; GISEL-NEXT:    v_mul_lo_u32 v6, v11, v8
+; GISEL-NEXT:    v_mul_hi_u32 v4, v11, v4
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v7, v5
-; GISEL-NEXT:    v_mul_hi_u32 v7, v11, v8
+; GISEL-NEXT:    v_mul_hi_u32 v7, v10, v8
 ; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v6, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v7
 ; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v7
-; GISEL-NEXT:    v_mul_hi_u32 v7, v12, v8
+; GISEL-NEXT:    v_mul_hi_u32 v7, v11, v8
 ; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
 ; GISEL-NEXT:    v_add_i32_e32 v5, vcc, v7, v5
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v11, v4
-; GISEL-NEXT:    v_addc_u32_e32 v5, vcc, v12, v5, vcc
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v10, v4
+; GISEL-NEXT:    v_addc_u32_e32 v5, vcc, v11, v5, vcc
 ; GISEL-NEXT:    v_mul_lo_u32 v6, 0, v4
 ; GISEL-NEXT:    v_mul_lo_u32 v7, v2, v5
-; GISEL-NEXT:    v_mul_hi_u32 v11, v2, v4
+; GISEL-NEXT:    v_mul_hi_u32 v10, v2, v4
 ; GISEL-NEXT:    v_sub_i32_e32 v1, vcc, v13, v1
-; GISEL-NEXT:    v_subbrev_u32_e32 v8, vcc, 0, v16, vcc
+; GISEL-NEXT:    v_subbrev_u32_e32 v8, vcc, 0, v14, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v7
 ; GISEL-NEXT:    v_mul_lo_u32 v7, 0, v5
 ; GISEL-NEXT:    v_mul_hi_u32 v4, 0, v4
-; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v11
-; GISEL-NEXT:    v_mul_hi_u32 v11, v2, v5
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v10
+; GISEL-NEXT:    v_mul_hi_u32 v10, v2, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v7, v4
-; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v11
-; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v4, v6
-; GISEL-NEXT:    v_mul_hi_u32 v12, 0, v5
-; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v3, v11, 0
+; GISEL-NEXT:    v_add_i32_e32 v4, vcc, v4, v10
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v4, v6
+; GISEL-NEXT:    v_mul_hi_u32 v11, 0, v5
+; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v3, v10, 0
 ; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
 ; GISEL-NEXT:    v_cndmask_b32_e32 v1, v13, v1, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v3, v12, v[5:6]
-; GISEL-NEXT:    v_cndmask_b32_e32 v8, v16, v8, vcc
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
+; GISEL-NEXT:    v_cndmask_b32_e32 v8, v14, v8, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v3, v11, v[5:6]
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
 ; GISEL-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e32 v1, v15, v8, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], 0, v11, v[6:7]
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v16, v8, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], 0, v10, v[6:7]
 ; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v2, v4
 ; GISEL-NEXT:    v_sub_i32_e64 v5, s[4:5], 0, v8
 ; GISEL-NEXT:    v_subb_u32_e64 v4, s[4:5], 0, v8, vcc
@@ -3215,43 +3215,43 @@ define <2 x i64> @v_srem_v2i64_24bit(<2 x i64> %num, <2 x i64> %den) {
 ; CGP-LABEL: v_srem_v2i64_24bit:
 ; CGP:       ; %bb.0:
 ; CGP-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; CGP-NEXT:    v_and_b32_e32 v3, 0xffffff, v4
-; CGP-NEXT:    v_cvt_f32_u32_e32 v1, v3
-; CGP-NEXT:    v_and_b32_e32 v4, 0xffffff, v6
-; CGP-NEXT:    v_sub_i32_e32 v6, vcc, 0, v3
+; CGP-NEXT:    v_and_b32_e32 v5, 0xffffff, v4
+; CGP-NEXT:    v_cvt_f32_u32_e32 v1, v5
+; CGP-NEXT:    v_and_b32_e32 v6, 0xffffff, v6
+; CGP-NEXT:    v_cvt_f32_u32_e32 v3, v6
+; CGP-NEXT:    v_and_b32_e32 v7, 0xffffff, v0
 ; CGP-NEXT:    v_rcp_f32_e32 v1, v1
-; CGP-NEXT:    v_and_b32_e32 v8, 0xffffff, v0
 ; CGP-NEXT:    v_and_b32_e32 v2, 0xffffff, v2
 ; CGP-NEXT:    v_mul_f32_e32 v1, 0x4f7ffffe, v1
-; CGP-NEXT:    v_cvt_u32_f32_e32 v5, v1
-; CGP-NEXT:    v_cvt_f32_u32_e32 v1, v4
-; CGP-NEXT:    v_mul_lo_u32 v6, v6, v5
-; CGP-NEXT:    v_rcp_f32_e32 v7, v1
-; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v6, 0
-; CGP-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v7
-; CGP-NEXT:    v_cvt_u32_f32_e32 v6, v0
-; CGP-NEXT:    v_add_i32_e32 v5, vcc, v5, v1
-; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v5, 0
-; CGP-NEXT:    v_sub_i32_e32 v0, vcc, 0, v4
-; CGP-NEXT:    v_mul_lo_u32 v5, v0, v6
-; CGP-NEXT:    v_mul_lo_u32 v7, v1, v3
-; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v5, 0
-; CGP-NEXT:    v_sub_i32_e32 v5, vcc, v8, v7
-; CGP-NEXT:    v_add_i32_e32 v6, vcc, v6, v1
-; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v2, v6, 0
-; CGP-NEXT:    v_sub_i32_e32 v7, vcc, v5, v3
-; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v5, v3
-; CGP-NEXT:    v_mul_lo_u32 v6, v1, v4
-; CGP-NEXT:    v_cndmask_b32_e32 v0, v5, v7, vcc
-; CGP-NEXT:    v_sub_i32_e32 v5, vcc, v0, v3
-; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v3
-; CGP-NEXT:    v_cndmask_b32_e32 v0, v0, v5, vcc
-; CGP-NEXT:    v_sub_i32_e32 v2, vcc, v2, v6
-; CGP-NEXT:    v_sub_i32_e32 v3, vcc, v2, v4
-; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v2, v4
+; CGP-NEXT:    v_cvt_u32_f32_e32 v4, v1
+; CGP-NEXT:    v_rcp_f32_e32 v1, v3
+; CGP-NEXT:    v_sub_i32_e32 v3, vcc, 0, v5
+; CGP-NEXT:    v_mul_lo_u32 v3, v3, v4
+; CGP-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v1
+; CGP-NEXT:    v_cvt_u32_f32_e32 v8, v0
+; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v4, v3, 0
+; CGP-NEXT:    v_sub_i32_e32 v0, vcc, 0, v6
+; CGP-NEXT:    v_mul_lo_u32 v9, v0, v8
+; CGP-NEXT:    v_add_i32_e32 v3, vcc, v4, v1
+; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v7, v3, 0
+; CGP-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v8, v9, 0
+; CGP-NEXT:    v_mul_lo_u32 v0, v1, v5
+; CGP-NEXT:    v_add_i32_e32 v3, vcc, v8, v4
+; CGP-NEXT:    v_sub_i32_e32 v4, vcc, v7, v0
+; CGP-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v2, v3, 0
+; CGP-NEXT:    v_sub_i32_e32 v7, vcc, v4, v5
+; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v4, v5
+; CGP-NEXT:    v_cndmask_b32_e32 v0, v4, v7, vcc
+; CGP-NEXT:    v_mul_lo_u32 v4, v1, v6
+; CGP-NEXT:    v_sub_i32_e32 v3, vcc, v0, v5
+; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v5
+; CGP-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc
+; CGP-NEXT:    v_sub_i32_e32 v2, vcc, v2, v4
+; CGP-NEXT:    v_sub_i32_e32 v3, vcc, v2, v6
+; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v2, v6
 ; CGP-NEXT:    v_cndmask_b32_e32 v2, v2, v3, vcc
-; CGP-NEXT:    v_sub_i32_e32 v3, vcc, v2, v4
-; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v2, v4
+; CGP-NEXT:    v_sub_i32_e32 v3, vcc, v2, v6
+; CGP-NEXT:    v_cmp_ge_u32_e32 vcc, v2, v6
 ; CGP-NEXT:    v_cndmask_b32_e32 v2, v2, v3, vcc
 ; CGP-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
 ; CGP-NEXT:    v_ashrrev_i32_e32 v3, 31, v2

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/udivrem.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/udivrem.ll
@@ -143,6 +143,7 @@ define amdgpu_kernel void @udivrem_i64(ptr addrspace(1) %out0, ptr addrspace(1) 
 ; GFX8-NEXT:    v_mul_lo_u32 v3, v6, v4
 ; GFX8-NEXT:    v_mul_lo_u32 v5, v7, v4
 ; GFX8-NEXT:    v_mul_hi_u32 v8, v6, v4
+; GFX8-NEXT:    v_mul_hi_u32 v4, v7, v4
 ; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v1, v3
 ; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v5, v0
@@ -153,11 +154,10 @@ define amdgpu_kernel void @udivrem_i64(ptr addrspace(1) %out0, ptr addrspace(1) 
 ; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v5, v2
-; GFX8-NEXT:    v_mul_hi_u32 v3, v7, v4
 ; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v0, v1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v2, v1
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
+; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v4, v1
 ; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v6, v0
 ; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, v7, v1, vcc
 ; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s2, v6, 0
@@ -203,11 +203,11 @@ define amdgpu_kernel void @udivrem_i64(ptr addrspace(1) %out0, ptr addrspace(1) 
 ; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v3, vcc, v4, v3
 ; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v0, v2
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v3, v0
-; GFX8-NEXT:    v_mul_hi_u32 v3, s9, v1
+; GFX8-NEXT:    v_mul_hi_u32 v4, s9, v1
 ; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s10, v6, 0
-; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v3, v2
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v3, v2
+; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v4, v2
 ; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s10, v7, v[1:2]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s11
 ; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s11, v6, v[2:3]
@@ -299,25 +299,24 @@ define amdgpu_kernel void @udivrem_i64(ptr addrspace(1) %out0, ptr addrspace(1) 
 ; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v6, v0
 ; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, v7, v1, vcc
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s2, v6, 0
-; GFX9-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s2, v7, v[1:2]
 ; GFX9-NEXT:    v_mul_lo_u32 v1, v7, v0
 ; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s3, v6, v[2:3]
-; GFX9-NEXT:    v_mul_hi_u32 v3, v6, v0
+; GFX9-NEXT:    v_mul_hi_u32 v2, v6, v0
 ; GFX9-NEXT:    v_mul_hi_u32 v0, v7, v0
-; GFX9-NEXT:    v_mul_lo_u32 v2, v6, v4
-; GFX9-NEXT:    v_add_co_u32_e32 v1, vcc, v1, v2
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; GFX9-NEXT:    v_mul_lo_u32 v3, v6, v4
+; GFX9-NEXT:    v_mul_lo_u32 v5, v7, v4
+; GFX9-NEXT:    v_mul_hi_u32 v8, v6, v4
 ; GFX9-NEXT:    v_add_co_u32_e32 v1, vcc, v1, v3
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v3, v7, v4
-; GFX9-NEXT:    v_add_u32_e32 v1, v2, v1
-; GFX9-NEXT:    v_mul_hi_u32 v2, v6, v4
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v3, v0
 ; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v2
+; GFX9-NEXT:    v_add_co_u32_e32 v1, vcc, v1, v2
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v5, v0
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
-; GFX9-NEXT:    v_add_u32_e32 v2, v3, v2
+; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v8
+; GFX9-NEXT:    v_add_u32_e32 v1, v3, v1
+; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
+; GFX9-NEXT:    v_add_u32_e32 v2, v2, v3
 ; GFX9-NEXT:    v_mul_hi_u32 v3, v7, v4
 ; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v1
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
@@ -336,6 +335,7 @@ define amdgpu_kernel void @udivrem_i64(ptr addrspace(1) %out0, ptr addrspace(1) 
 ; GFX9-NEXT:    v_mul_lo_u32 v4, s17, v1
 ; GFX9-NEXT:    v_add_u32_e32 v2, v3, v2
 ; GFX9-NEXT:    v_mul_hi_u32 v3, s16, v1
+; GFX9-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v4, v0
 ; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v3
@@ -1005,7 +1005,7 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX8-NEXT:    v_mul_f32_e32 v0, 0x4f800000, v0
 ; GFX8-NEXT:    v_add_f32_e32 v0, v0, v1
 ; GFX8-NEXT:    v_rcp_iflag_f32_e32 v0, v0
-; GFX8-NEXT:    v_mov_b32_e32 v9, s13
+; GFX8-NEXT:    v_mov_b32_e32 v10, s13
 ; GFX8-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v0
 ; GFX8-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; GFX8-NEXT:    v_trunc_f32_e32 v1, v1
@@ -1022,6 +1022,7 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX8-NEXT:    v_mul_lo_u32 v3, v6, v4
 ; GFX8-NEXT:    v_mul_lo_u32 v5, v7, v4
 ; GFX8-NEXT:    v_mul_hi_u32 v8, v6, v4
+; GFX8-NEXT:    v_mul_hi_u32 v4, v7, v4
 ; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v1, v3
 ; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v5, v0
@@ -1032,19 +1033,20 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v5, v2
-; GFX8-NEXT:    v_mul_hi_u32 v3, v7, v4
 ; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v0, v1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v2, v1
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
+; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v4, v1
 ; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v6, v0
 ; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, v7, v1, vcc
 ; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s2, v6, 0
 ; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s2, v7, v[1:2]
 ; GFX8-NEXT:    v_mul_lo_u32 v1, v7, v0
+; GFX8-NEXT:    s_sub_u32 s2, 0, s14
 ; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s3, v6, v[2:3]
 ; GFX8-NEXT:    v_mul_hi_u32 v3, v6, v0
 ; GFX8-NEXT:    v_mul_hi_u32 v0, v7, v0
+; GFX8-NEXT:    s_subb_u32 s3, 0, s15
 ; GFX8-NEXT:    v_mul_lo_u32 v2, v6, v4
 ; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
 ; GFX8-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
@@ -1069,6 +1071,7 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX8-NEXT:    v_mul_lo_u32 v3, s8, v1
 ; GFX8-NEXT:    v_mul_hi_u32 v4, s8, v0
 ; GFX8-NEXT:    v_mul_hi_u32 v0, s9, v0
+; GFX8-NEXT:    v_mul_hi_u32 v5, s9, v1
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v2, v3
 ; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v2, v4
@@ -1081,146 +1084,143 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v0, v3
 ; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v3, vcc, v4, v3
-; GFX8-NEXT:    v_add_u32_e32 v8, vcc, v0, v2
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v3, v0
-; GFX8-NEXT:    v_mul_hi_u32 v3, s9, v1
-; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s12, v8, 0
-; GFX8-NEXT:    v_add_u32_e64 v17, s[2:3], 1, v8
-; GFX8-NEXT:    v_add_u32_e32 v10, vcc, v3, v2
-; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s12, v10, v[1:2]
-; GFX8-NEXT:    v_sub_u32_e32 v1, vcc, s8, v0
-; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s13, v8, v[2:3]
-; GFX8-NEXT:    v_mov_b32_e32 v2, s9
-; GFX8-NEXT:    v_cvt_f32_u32_e32 v5, s14
-; GFX8-NEXT:    v_subb_u32_e64 v0, s[0:1], v2, v4, vcc
-; GFX8-NEXT:    v_sub_u32_e64 v2, s[0:1], s9, v4
-; GFX8-NEXT:    v_cvt_f32_u32_e32 v4, s15
-; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s13, v0
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[0:1]
-; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s12, v1
-; GFX8-NEXT:    v_mul_f32_e32 v4, 0x4f800000, v4
-; GFX8-NEXT:    v_add_f32_e32 v4, v4, v5
-; GFX8-NEXT:    v_rcp_iflag_f32_e32 v4, v4
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v0, v2
+; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s12, v2, 0
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v3, vcc, v3, v4
+; GFX8-NEXT:    v_add_u32_e32 v3, vcc, v5, v3
+; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s12, v3, v[1:2]
+; GFX8-NEXT:    v_mov_b32_e32 v1, s9
+; GFX8-NEXT:    v_sub_u32_e32 v0, vcc, s8, v0
+; GFX8-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s13, v2, v[4:5]
+; GFX8-NEXT:    v_cvt_f32_u32_e32 v5, s15
+; GFX8-NEXT:    v_subb_u32_e64 v1, s[0:1], v1, v6, vcc
+; GFX8-NEXT:    v_sub_u32_e64 v4, s[0:1], s9, v6
+; GFX8-NEXT:    v_cvt_f32_u32_e32 v6, s14
+; GFX8-NEXT:    v_mul_f32_e32 v5, 0x4f800000, v5
+; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s13, v1
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, -1, s[0:1]
+; GFX8-NEXT:    v_add_f32_e32 v5, v5, v6
+; GFX8-NEXT:    v_rcp_iflag_f32_e32 v5, v5
+; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s12, v0
 ; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, -1, s[0:1]
-; GFX8-NEXT:    v_cmp_eq_u32_e64 s[0:1], s13, v0
-; GFX8-NEXT:    v_subb_u32_e32 v12, vcc, v2, v9, vcc
-; GFX8-NEXT:    v_mul_f32_e32 v2, 0x5f7ffffc, v4
-; GFX8-NEXT:    v_cndmask_b32_e64 v11, v3, v6, s[0:1]
-; GFX8-NEXT:    v_mul_f32_e32 v3, 0x2f800000, v2
-; GFX8-NEXT:    v_trunc_f32_e32 v3, v3
-; GFX8-NEXT:    v_mul_f32_e32 v4, 0xcf800000, v3
-; GFX8-NEXT:    v_add_f32_e32 v2, v4, v2
-; GFX8-NEXT:    v_cvt_u32_f32_e32 v13, v2
-; GFX8-NEXT:    s_sub_u32 s8, 0, s14
-; GFX8-NEXT:    v_cvt_u32_f32_e32 v14, v3
-; GFX8-NEXT:    v_subrev_u32_e32 v15, vcc, s12, v1
-; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s8, v13, 0
-; GFX8-NEXT:    v_subbrev_u32_e64 v16, s[0:1], 0, v12, vcc
-; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s8, v14, v[3:4]
+; GFX8-NEXT:    v_cmp_eq_u32_e64 s[0:1], s13, v1
+; GFX8-NEXT:    v_mul_f32_e32 v5, 0x5f7ffffc, v5
+; GFX8-NEXT:    v_cndmask_b32_e64 v11, v7, v6, s[0:1]
+; GFX8-NEXT:    v_mul_f32_e32 v6, 0x2f800000, v5
+; GFX8-NEXT:    v_trunc_f32_e32 v6, v6
+; GFX8-NEXT:    v_mul_f32_e32 v7, 0xcf800000, v6
+; GFX8-NEXT:    v_add_f32_e32 v5, v7, v5
+; GFX8-NEXT:    v_cvt_u32_f32_e32 v12, v5
+; GFX8-NEXT:    v_subb_u32_e32 v13, vcc, v4, v10, vcc
+; GFX8-NEXT:    v_cvt_u32_f32_e32 v14, v6
+; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s2, v12, 0
+; GFX8-NEXT:    v_subrev_u32_e32 v15, vcc, s12, v0
+; GFX8-NEXT:    v_subbrev_u32_e64 v16, s[0:1], 0, v13, vcc
 ; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s13, v16
-; GFX8-NEXT:    s_subb_u32 s9, 0, s15
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[0:1]
-; GFX8-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s9, v13, v[4:5]
+; GFX8-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s[0:1]
+; GFX8-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s2, v14, v[5:6]
 ; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s12, v15
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, -1, s[0:1]
-; GFX8-NEXT:    v_mul_lo_u32 v5, v14, v2
-; GFX8-NEXT:    v_mul_lo_u32 v7, v13, v6
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, -1, s[0:1]
+; GFX8-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], s3, v12, v[6:7]
 ; GFX8-NEXT:    v_cmp_eq_u32_e64 s[0:1], s13, v16
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v3, v4, s[0:1]
-; GFX8-NEXT:    v_mul_hi_u32 v4, v13, v2
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, v17, v5, s[0:1]
+; GFX8-NEXT:    v_mul_lo_u32 v5, v14, v4
+; GFX8-NEXT:    v_mul_lo_u32 v7, v12, v8
+; GFX8-NEXT:    v_mul_hi_u32 v9, v12, v4
+; GFX8-NEXT:    v_add_u32_e64 v17, s[0:1], 1, v2
+; GFX8-NEXT:    v_addc_u32_e64 v18, s[0:1], 0, v3, s[0:1]
 ; GFX8-NEXT:    v_add_u32_e64 v5, s[0:1], v5, v7
 ; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, 1, s[0:1]
-; GFX8-NEXT:    v_add_u32_e64 v4, s[0:1], v5, v4
-; GFX8-NEXT:    v_subb_u32_e32 v4, vcc, v12, v9, vcc
+; GFX8-NEXT:    v_add_u32_e64 v5, s[0:1], v5, v9
+; GFX8-NEXT:    v_mul_hi_u32 v4, v14, v4
 ; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s[0:1]
-; GFX8-NEXT:    v_mul_hi_u32 v2, v14, v2
-; GFX8-NEXT:    v_mul_lo_u32 v9, v14, v6
-; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v7, v5
-; GFX8-NEXT:    v_mul_hi_u32 v7, v13, v6
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v9, v2
-; GFX8-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v2, v7
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v9, v7
-; GFX8-NEXT:    v_addc_u32_e64 v18, s[2:3], 0, v10, s[2:3]
-; GFX8-NEXT:    v_add_u32_e32 v9, vcc, 1, v17
-; GFX8-NEXT:    v_addc_u32_e32 v12, vcc, 0, v18, vcc
-; GFX8-NEXT:    v_subrev_u32_e32 v19, vcc, s12, v15
-; GFX8-NEXT:    v_mul_hi_u32 v6, v14, v6
-; GFX8-NEXT:    v_subbrev_u32_e32 v20, vcc, 0, v4, vcc
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v2, v5
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v7, v4
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v6, v4
-; GFX8-NEXT:    v_add_u32_e32 v13, vcc, v13, v2
-; GFX8-NEXT:    v_addc_u32_e32 v14, vcc, v14, v4, vcc
-; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s8, v13, 0
-; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v17, v9, vcc
-; GFX8-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s8, v14, v[5:6]
-; GFX8-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v11
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v8, v2, s[0:1]
-; GFX8-NEXT:    v_mad_u64_u32 v[8:9], s[2:3], s9, v13, v[6:7]
+; GFX8-NEXT:    v_mul_lo_u32 v9, v14, v8
+; GFX8-NEXT:    v_add_u32_e64 v5, s[0:1], v7, v5
+; GFX8-NEXT:    v_mul_hi_u32 v7, v12, v8
+; GFX8-NEXT:    v_add_u32_e64 v4, s[0:1], v9, v4
+; GFX8-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s[0:1]
+; GFX8-NEXT:    v_add_u32_e64 v4, s[0:1], v4, v7
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, 1, s[0:1]
+; GFX8-NEXT:    v_add_u32_e64 v7, s[0:1], v9, v7
+; GFX8-NEXT:    v_add_u32_e64 v9, s[0:1], 1, v17
+; GFX8-NEXT:    v_mul_hi_u32 v8, v14, v8
+; GFX8-NEXT:    v_addc_u32_e64 v19, s[0:1], 0, v18, s[0:1]
+; GFX8-NEXT:    v_add_u32_e64 v4, s[0:1], v4, v5
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s[0:1]
+; GFX8-NEXT:    v_add_u32_e64 v5, s[0:1], v7, v5
+; GFX8-NEXT:    v_add_u32_e64 v5, s[0:1], v8, v5
+; GFX8-NEXT:    v_add_u32_e64 v12, s[0:1], v12, v4
+; GFX8-NEXT:    v_addc_u32_e64 v14, s[0:1], v14, v5, s[0:1]
+; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s2, v12, 0
+; GFX8-NEXT:    v_subb_u32_e32 v8, vcc, v13, v10, vcc
+; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
+; GFX8-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s2, v14, v[5:6]
+; GFX8-NEXT:    v_subrev_u32_e64 v5, s[0:1], s12, v15
+; GFX8-NEXT:    v_subbrev_u32_e64 v10, s[0:1], 0, v8, s[0:1]
+; GFX8-NEXT:    v_cndmask_b32_e32 v13, v17, v9, vcc
+; GFX8-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], s3, v12, v[6:7]
 ; GFX8-NEXT:    v_mul_lo_u32 v6, v14, v4
-; GFX8-NEXT:    v_mul_hi_u32 v9, v13, v4
-; GFX8-NEXT:    v_mul_lo_u32 v7, v13, v8
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v18, v12, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v3, v10, v3, s[0:1]
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v15, v19, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v16, v20, vcc
+; GFX8-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v11
+; GFX8-NEXT:    v_cndmask_b32_e32 v11, v15, v5, vcc
+; GFX8-NEXT:    v_mul_lo_u32 v7, v12, v8
+; GFX8-NEXT:    v_mul_hi_u32 v5, v12, v4
+; GFX8-NEXT:    v_mul_hi_u32 v4, v14, v4
+; GFX8-NEXT:    v_cndmask_b32_e32 v17, v18, v19, vcc
+; GFX8-NEXT:    v_add_u32_e64 v6, s[2:3], v6, v7
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, 1, s[2:3]
+; GFX8-NEXT:    v_add_u32_e64 v5, s[2:3], v6, v5
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s[2:3]
+; GFX8-NEXT:    v_mul_lo_u32 v6, v14, v8
+; GFX8-NEXT:    v_add_u32_e64 v5, s[2:3], v7, v5
+; GFX8-NEXT:    v_mul_hi_u32 v7, v12, v8
+; GFX8-NEXT:    v_add_u32_e64 v4, s[2:3], v6, v4
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s[2:3]
+; GFX8-NEXT:    v_add_u32_e64 v4, s[2:3], v4, v7
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, 1, s[2:3]
+; GFX8-NEXT:    v_add_u32_e64 v6, s[2:3], v6, v7
+; GFX8-NEXT:    v_mul_hi_u32 v7, v14, v8
+; GFX8-NEXT:    v_add_u32_e64 v4, s[2:3], v4, v5
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s[2:3]
+; GFX8-NEXT:    v_add_u32_e64 v5, s[2:3], v6, v5
+; GFX8-NEXT:    v_add_u32_e64 v5, s[2:3], v7, v5
+; GFX8-NEXT:    v_add_u32_e64 v4, s[2:3], v12, v4
+; GFX8-NEXT:    v_addc_u32_e64 v5, s[2:3], v14, v5, s[2:3]
+; GFX8-NEXT:    v_mul_lo_u32 v6, s11, v4
+; GFX8-NEXT:    v_mul_lo_u32 v7, s10, v5
+; GFX8-NEXT:    v_mul_hi_u32 v8, s10, v4
+; GFX8-NEXT:    v_cndmask_b32_e32 v10, v16, v10, vcc
+; GFX8-NEXT:    v_mul_hi_u32 v4, s11, v4
 ; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v6, v7
 ; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v6, v9
+; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v6, v8
 ; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
-; GFX8-NEXT:    v_mul_lo_u32 v9, v14, v8
-; GFX8-NEXT:    v_mul_hi_u32 v4, v14, v4
+; GFX8-NEXT:    v_mul_lo_u32 v8, s11, v5
 ; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v7, v6
-; GFX8-NEXT:    v_mul_hi_u32 v7, v13, v8
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v9, v4
-; GFX8-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
+; GFX8-NEXT:    v_mul_hi_u32 v7, s10, v5
+; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v8, v4
+; GFX8-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v4, v7
 ; GFX8-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v9, v7
-; GFX8-NEXT:    v_mul_hi_u32 v8, v14, v8
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v4, v6
+; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v8, v7
+; GFX8-NEXT:    v_add_u32_e32 v12, vcc, v4, v6
+; GFX8-NEXT:    v_mul_hi_u32 v8, s11, v5
+; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[2:3], s14, v12, 0
 ; GFX8-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v7, v6
-; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v8, v6
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v13, v4
-; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, v14, v6, vcc
-; GFX8-NEXT:    v_mul_lo_u32 v8, s11, v4
-; GFX8-NEXT:    v_mul_lo_u32 v9, s10, v7
-; GFX8-NEXT:    v_cndmask_b32_e64 v6, v1, v5, s[0:1]
-; GFX8-NEXT:    v_mul_hi_u32 v1, s10, v4
-; GFX8-NEXT:    v_mul_hi_u32 v4, s11, v4
-; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v8, v9
-; GFX8-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v5, v1
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX8-NEXT:    v_mul_lo_u32 v5, s11, v7
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v8, v1
-; GFX8-NEXT:    v_mul_hi_u32 v8, s10, v7
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v5, v4
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v4, v8
-; GFX8-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v5, v8
-; GFX8-NEXT:    v_add_u32_e32 v11, vcc, v4, v1
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX8-NEXT:    v_mul_hi_u32 v7, s11, v7
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v5, v1
-; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[2:3], s14, v11, 0
-; GFX8-NEXT:    v_add_u32_e32 v12, vcc, v7, v1
-; GFX8-NEXT:    v_mad_u64_u32 v[8:9], s[2:3], s14, v12, v[5:6]
-; GFX8-NEXT:    v_cndmask_b32_e64 v7, v0, v10, s[0:1]
-; GFX8-NEXT:    v_mov_b32_e32 v5, s15
-; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s15, v11, v[8:9]
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, v2, v13, s[0:1]
+; GFX8-NEXT:    v_add_u32_e32 v13, vcc, v8, v6
+; GFX8-NEXT:    v_mad_u64_u32 v[8:9], s[2:3], s14, v13, v[5:6]
+; GFX8-NEXT:    v_cndmask_b32_e64 v3, v3, v17, s[0:1]
+; GFX8-NEXT:    v_cndmask_b32_e64 v6, v0, v11, s[0:1]
+; GFX8-NEXT:    v_cndmask_b32_e64 v7, v1, v10, s[0:1]
+; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s15, v12, v[8:9]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s11
 ; GFX8-NEXT:    v_sub_u32_e32 v8, vcc, s10, v4
 ; GFX8-NEXT:    v_subb_u32_e64 v1, s[0:1], v1, v0, vcc
 ; GFX8-NEXT:    v_sub_u32_e64 v0, s[0:1], s11, v0
 ; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s15, v1
+; GFX8-NEXT:    v_mov_b32_e32 v5, s15
 ; GFX8-NEXT:    v_cndmask_b32_e64 v4, 0, -1, s[0:1]
 ; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s14, v8
 ; GFX8-NEXT:    v_cndmask_b32_e64 v9, 0, -1, s[0:1]
@@ -1230,29 +1230,29 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX8-NEXT:    v_subrev_u32_e32 v9, vcc, s14, v8
 ; GFX8-NEXT:    v_subbrev_u32_e64 v10, s[0:1], 0, v0, vcc
 ; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s15, v10
-; GFX8-NEXT:    v_cndmask_b32_e64 v13, 0, -1, s[0:1]
+; GFX8-NEXT:    v_cndmask_b32_e64 v11, 0, -1, s[0:1]
 ; GFX8-NEXT:    v_cmp_le_u32_e64 s[0:1], s14, v9
 ; GFX8-NEXT:    v_cndmask_b32_e64 v14, 0, -1, s[0:1]
 ; GFX8-NEXT:    v_cmp_eq_u32_e64 s[0:1], s15, v10
-; GFX8-NEXT:    v_cndmask_b32_e64 v13, v13, v14, s[0:1]
-; GFX8-NEXT:    v_add_u32_e64 v14, s[0:1], 1, v11
+; GFX8-NEXT:    v_cndmask_b32_e64 v11, v11, v14, s[0:1]
+; GFX8-NEXT:    v_add_u32_e64 v14, s[0:1], 1, v12
 ; GFX8-NEXT:    v_subb_u32_e32 v0, vcc, v0, v5, vcc
-; GFX8-NEXT:    v_addc_u32_e64 v15, s[0:1], 0, v12, s[0:1]
+; GFX8-NEXT:    v_addc_u32_e64 v15, s[0:1], 0, v13, s[0:1]
 ; GFX8-NEXT:    v_add_u32_e32 v5, vcc, 1, v14
 ; GFX8-NEXT:    v_addc_u32_e32 v16, vcc, 0, v15, vcc
-; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v13
-; GFX8-NEXT:    v_subrev_u32_e64 v13, s[0:1], s14, v9
+; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
+; GFX8-NEXT:    v_subrev_u32_e64 v11, s[0:1], s14, v9
 ; GFX8-NEXT:    v_subbrev_u32_e64 v0, s[0:1], 0, v0, s[0:1]
 ; GFX8-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v4
-; GFX8-NEXT:    v_cndmask_b32_e32 v9, v9, v13, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v9, v9, v11, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, v10, v0, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v5, v14, v5, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v14, v15, v16, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e64 v8, v8, v9, s[0:1]
 ; GFX8-NEXT:    v_cndmask_b32_e64 v9, v1, v0, s[0:1]
 ; GFX8-NEXT:    v_mov_b32_e32 v0, s4
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v11, v5, s[0:1]
-; GFX8-NEXT:    v_cndmask_b32_e64 v5, v12, v14, s[0:1]
+; GFX8-NEXT:    v_cndmask_b32_e64 v4, v12, v5, s[0:1]
+; GFX8-NEXT:    v_cndmask_b32_e64 v5, v13, v14, s[0:1]
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX8-NEXT:    flat_store_dwordx4 v[0:1], v[2:5]
 ; GFX8-NEXT:    v_mov_b32_e32 v0, s6
@@ -1273,8 +1273,6 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX9-NEXT:    v_add_f32_e32 v0, v0, v1
 ; GFX9-NEXT:    v_rcp_iflag_f32_e32 v0, v0
 ; GFX9-NEXT:    v_mov_b32_e32 v9, s5
-; GFX9-NEXT:    s_sub_u32 s8, 0, s6
-; GFX9-NEXT:    s_subb_u32 s9, 0, s7
 ; GFX9-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v0
 ; GFX9-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; GFX9-NEXT:    v_trunc_f32_e32 v1, v1
@@ -1310,22 +1308,24 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s2, v6, 0
 ; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s2, v7, v[1:2]
 ; GFX9-NEXT:    v_mul_lo_u32 v1, v7, v0
+; GFX9-NEXT:    s_sub_u32 s2, 0, s6
 ; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s3, v6, v[2:3]
-; GFX9-NEXT:    v_mul_hi_u32 v3, v6, v0
+; GFX9-NEXT:    v_mul_hi_u32 v2, v6, v0
 ; GFX9-NEXT:    v_mul_hi_u32 v0, v7, v0
-; GFX9-NEXT:    v_mul_lo_u32 v2, v6, v4
-; GFX9-NEXT:    v_add_co_u32_e32 v1, vcc, v1, v2
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; GFX9-NEXT:    s_subb_u32 s3, 0, s7
+; GFX9-NEXT:    v_mul_lo_u32 v3, v6, v4
+; GFX9-NEXT:    v_mul_lo_u32 v5, v7, v4
+; GFX9-NEXT:    v_mul_hi_u32 v8, v6, v4
 ; GFX9-NEXT:    v_add_co_u32_e32 v1, vcc, v1, v3
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v3, v7, v4
-; GFX9-NEXT:    v_add_u32_e32 v1, v2, v1
-; GFX9-NEXT:    v_mul_hi_u32 v2, v6, v4
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v3, v0
 ; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v2
+; GFX9-NEXT:    v_add_co_u32_e32 v1, vcc, v1, v2
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v5, v0
 ; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
-; GFX9-NEXT:    v_add_u32_e32 v2, v3, v2
+; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v8
+; GFX9-NEXT:    v_add_u32_e32 v1, v3, v1
+; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
+; GFX9-NEXT:    v_add_u32_e32 v2, v2, v3
 ; GFX9-NEXT:    v_mul_hi_u32 v3, v7, v4
 ; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v1
 ; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
@@ -1336,7 +1336,7 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX9-NEXT:    v_mul_lo_u32 v3, s16, v1
 ; GFX9-NEXT:    v_mul_hi_u32 v4, s16, v0
 ; GFX9-NEXT:    v_mul_hi_u32 v0, s17, v0
-; GFX9-NEXT:    v_mul_hi_u32 v5, s17, v1
+; GFX9-NEXT:    v_mul_hi_u32 v6, s17, v1
 ; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v3
 ; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v4
@@ -1348,133 +1348,133 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v3
 ; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v8, vcc, v0, v2
-; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s4, v8, 0
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v0, v2
+; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s4, v2, 0
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, vcc
 ; GFX9-NEXT:    v_add_u32_e32 v3, v4, v3
-; GFX9-NEXT:    v_add3_u32 v10, v3, v2, v5
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s4, v10, v[1:2]
-; GFX9-NEXT:    v_sub_co_u32_e32 v1, vcc, s16, v0
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s5, v8, v[2:3]
-; GFX9-NEXT:    v_mov_b32_e32 v2, s17
-; GFX9-NEXT:    v_cvt_f32_u32_e32 v5, s6
-; GFX9-NEXT:    v_subb_co_u32_e64 v0, s[0:1], v2, v4, vcc
-; GFX9-NEXT:    v_sub_u32_e32 v2, s17, v4
+; GFX9-NEXT:    v_add3_u32 v10, v3, v5, v6
+; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], s4, v10, v[1:2]
+; GFX9-NEXT:    v_mov_b32_e32 v1, s17
+; GFX9-NEXT:    v_sub_co_u32_e32 v0, vcc, s16, v0
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[0:1], s5, v2, v[3:4]
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v4, s7
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s5, v0
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s4, v1
+; GFX9-NEXT:    v_subb_co_u32_e64 v1, s[0:1], v1, v5, vcc
+; GFX9-NEXT:    v_sub_u32_e32 v3, s17, v5
+; GFX9-NEXT:    v_cvt_f32_u32_e32 v5, s6
 ; GFX9-NEXT:    v_mul_f32_e32 v4, 0x4f800000, v4
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s5, v1
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, -1, s[0:1]
 ; GFX9-NEXT:    v_add_f32_e32 v4, v4, v5
 ; GFX9-NEXT:    v_rcp_iflag_f32_e32 v4, v4
-; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s5, v0
-; GFX9-NEXT:    v_subb_co_u32_e32 v12, vcc, v2, v9, vcc
-; GFX9-NEXT:    v_mul_f32_e32 v2, 0x5f7ffffc, v4
-; GFX9-NEXT:    v_cndmask_b32_e64 v11, v3, v6, s[0:1]
-; GFX9-NEXT:    v_mul_f32_e32 v3, 0x2f800000, v2
-; GFX9-NEXT:    v_trunc_f32_e32 v3, v3
-; GFX9-NEXT:    v_mul_f32_e32 v4, 0xcf800000, v3
-; GFX9-NEXT:    v_add_f32_e32 v2, v4, v2
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v13, v2
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v14, v3
-; GFX9-NEXT:    v_subrev_co_u32_e32 v15, vcc, s4, v1
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s8, v13, 0
-; GFX9-NEXT:    v_subbrev_co_u32_e64 v16, s[0:1], 0, v12, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s8, v14, v[3:4]
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s4, v0
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, -1, s[0:1]
+; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s5, v1
+; GFX9-NEXT:    v_mul_f32_e32 v4, 0x5f7ffffc, v4
+; GFX9-NEXT:    v_cndmask_b32_e64 v11, v6, v5, s[0:1]
+; GFX9-NEXT:    v_mul_f32_e32 v5, 0x2f800000, v4
+; GFX9-NEXT:    v_trunc_f32_e32 v5, v5
+; GFX9-NEXT:    v_mul_f32_e32 v6, 0xcf800000, v5
+; GFX9-NEXT:    v_add_f32_e32 v4, v6, v4
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v12, v4
+; GFX9-NEXT:    v_subb_co_u32_e32 v13, vcc, v3, v9, vcc
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v14, v5
+; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], s2, v12, 0
+; GFX9-NEXT:    v_subrev_co_u32_e32 v15, vcc, s4, v0
+; GFX9-NEXT:    v_subbrev_co_u32_e64 v16, s[0:1], 0, v13, vcc
 ; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s5, v16
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[0:1]
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s9, v13, v[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s[0:1]
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[0:1], s2, v14, v[4:5]
 ; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s4, v15
 ; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, -1, s[0:1]
-; GFX9-NEXT:    v_mul_lo_u32 v5, v14, v2
-; GFX9-NEXT:    v_mul_lo_u32 v7, v13, v6
+; GFX9-NEXT:    v_subb_co_u32_e32 v13, vcc, v13, v9, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[0:1], s3, v12, v[5:6]
 ; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s5, v16
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, v3, v4, s[0:1]
-; GFX9-NEXT:    v_mul_hi_u32 v4, v13, v2
-; GFX9-NEXT:    v_add_co_u32_e64 v5, s[0:1], v5, v7
-; GFX9-NEXT:    v_cndmask_b32_e64 v7, 0, 1, s[0:1]
-; GFX9-NEXT:    v_add_co_u32_e64 v4, s[0:1], v5, v4
-; GFX9-NEXT:    v_subb_co_u32_e32 v4, vcc, v12, v9, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v8, v17, v4, s[0:1]
+; GFX9-NEXT:    v_mul_lo_u32 v4, v14, v3
+; GFX9-NEXT:    v_mul_lo_u32 v5, v12, v7
+; GFX9-NEXT:    v_mul_hi_u32 v6, v12, v3
+; GFX9-NEXT:    v_add_co_u32_e64 v17, s[0:1], 1, v2
+; GFX9-NEXT:    v_addc_co_u32_e64 v18, s[0:1], 0, v10, s[0:1]
+; GFX9-NEXT:    v_add_co_u32_e64 v4, s[0:1], v4, v5
 ; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s[0:1]
-; GFX9-NEXT:    v_mul_hi_u32 v2, v14, v2
-; GFX9-NEXT:    v_mul_lo_u32 v9, v14, v6
-; GFX9-NEXT:    v_add_u32_e32 v5, v7, v5
-; GFX9-NEXT:    v_mul_hi_u32 v7, v13, v6
-; GFX9-NEXT:    v_add_co_u32_e64 v17, s[2:3], 1, v8
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v9, v2
-; GFX9-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v7
-; GFX9-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GFX9-NEXT:    v_addc_co_u32_e64 v18, s[2:3], 0, v10, s[2:3]
-; GFX9-NEXT:    v_add_u32_e32 v7, v9, v7
-; GFX9-NEXT:    v_add_co_u32_e32 v9, vcc, 1, v17
-; GFX9-NEXT:    v_addc_co_u32_e32 v12, vcc, 0, v18, vcc
-; GFX9-NEXT:    v_mul_hi_u32 v6, v14, v6
-; GFX9-NEXT:    v_subrev_co_u32_e32 v19, vcc, s4, v15
-; GFX9-NEXT:    v_subbrev_co_u32_e32 v20, vcc, 0, v4, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v5
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
-; GFX9-NEXT:    v_add3_u32 v4, v7, v4, v6
-; GFX9-NEXT:    v_add_co_u32_e32 v13, vcc, v13, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v14, vcc, v14, v4, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s8, v13, 0
-; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v17, v9, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s8, v14, v[5:6]
+; GFX9-NEXT:    v_add_co_u32_e64 v4, s[0:1], v4, v6
+; GFX9-NEXT:    v_mul_hi_u32 v3, v14, v3
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s[0:1]
+; GFX9-NEXT:    v_mul_lo_u32 v6, v14, v7
+; GFX9-NEXT:    v_add_u32_e32 v4, v5, v4
+; GFX9-NEXT:    v_mul_hi_u32 v5, v12, v7
+; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
+; GFX9-NEXT:    v_add_co_u32_e64 v3, s[0:1], v6, v3
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s[0:1]
+; GFX9-NEXT:    v_add_co_u32_e64 v3, s[0:1], v3, v5
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s[0:1]
+; GFX9-NEXT:    v_add_u32_e32 v5, v6, v5
+; GFX9-NEXT:    v_mul_hi_u32 v6, v14, v7
+; GFX9-NEXT:    v_add_co_u32_e64 v3, s[0:1], v3, v4
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s[0:1]
+; GFX9-NEXT:    v_add3_u32 v4, v5, v4, v6
+; GFX9-NEXT:    v_add_co_u32_e64 v12, s[0:1], v12, v3
+; GFX9-NEXT:    v_addc_co_u32_e64 v14, s[0:1], v14, v4, s[0:1]
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], s2, v12, 0
+; GFX9-NEXT:    v_add_co_u32_e64 v3, s[0:1], 1, v17
+; GFX9-NEXT:    v_addc_co_u32_e64 v19, s[0:1], 0, v18, s[0:1]
+; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], s2, v14, v[5:6]
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v17, v3, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, v18, v19, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], s3, v12, v[6:7]
 ; GFX9-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v11
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v8, v2, s[0:1]
-; GFX9-NEXT:    v_mad_u64_u32 v[8:9], s[2:3], s9, v13, v[6:7]
-; GFX9-NEXT:    v_mul_lo_u32 v6, v14, v4
-; GFX9-NEXT:    v_mul_hi_u32 v9, v13, v4
-; GFX9-NEXT:    v_mul_lo_u32 v7, v13, v8
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v18, v12, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, v10, v3, s[0:1]
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v15, v19, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v10, v16, v20, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v6, v7
-; GFX9-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v6, v9
-; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v9, v14, v8
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, v3, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v3, v10, v5, s[0:1]
+; GFX9-NEXT:    v_mul_lo_u32 v5, v14, v4
+; GFX9-NEXT:    v_mul_lo_u32 v6, v12, v8
+; GFX9-NEXT:    v_mul_hi_u32 v10, v12, v4
+; GFX9-NEXT:    v_subrev_co_u32_e64 v7, s[2:3], s4, v15
+; GFX9-NEXT:    v_subbrev_co_u32_e64 v9, s[2:3], 0, v13, s[2:3]
+; GFX9-NEXT:    v_add_co_u32_e64 v5, s[2:3], v5, v6
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s[2:3]
+; GFX9-NEXT:    v_add_co_u32_e64 v5, s[2:3], v5, v10
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s[2:3]
+; GFX9-NEXT:    v_mul_lo_u32 v10, v14, v8
 ; GFX9-NEXT:    v_mul_hi_u32 v4, v14, v4
-; GFX9-NEXT:    v_add_u32_e32 v6, v7, v6
-; GFX9-NEXT:    v_mul_hi_u32 v7, v13, v8
+; GFX9-NEXT:    v_add_u32_e32 v5, v6, v5
+; GFX9-NEXT:    v_mul_hi_u32 v6, v12, v8
 ; GFX9-NEXT:    v_mul_hi_u32 v8, v14, v8
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v9, v4
-; GFX9-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v7
-; GFX9-NEXT:    v_cndmask_b32_e64 v7, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v6
-; GFX9-NEXT:    v_add_u32_e32 v7, v9, v7
-; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
-; GFX9-NEXT:    v_add3_u32 v6, v7, v6, v8
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v13, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, v14, v6, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v8, s19, v4
-; GFX9-NEXT:    v_mul_lo_u32 v9, s18, v7
-; GFX9-NEXT:    v_cndmask_b32_e64 v6, v1, v5, s[0:1]
-; GFX9-NEXT:    v_mul_hi_u32 v1, s18, v4
+; GFX9-NEXT:    v_add_co_u32_e64 v4, s[2:3], v10, v4
+; GFX9-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s[2:3]
+; GFX9-NEXT:    v_add_co_u32_e64 v4, s[2:3], v4, v6
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s[2:3]
+; GFX9-NEXT:    v_add_co_u32_e64 v4, s[2:3], v4, v5
+; GFX9-NEXT:    v_add_u32_e32 v6, v10, v6
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s[2:3]
+; GFX9-NEXT:    v_add3_u32 v5, v6, v5, v8
+; GFX9-NEXT:    v_add_co_u32_e64 v4, s[2:3], v12, v4
+; GFX9-NEXT:    v_addc_co_u32_e64 v5, s[2:3], v14, v5, s[2:3]
+; GFX9-NEXT:    v_mul_lo_u32 v6, s19, v4
+; GFX9-NEXT:    v_mul_lo_u32 v8, s18, v5
+; GFX9-NEXT:    v_mul_hi_u32 v10, s18, v4
 ; GFX9-NEXT:    v_mul_hi_u32 v4, s19, v4
-; GFX9-NEXT:    v_add_co_u32_e32 v5, vcc, v8, v9
-; GFX9-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v1, vcc, v5, v1
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v5, s19, v7
-; GFX9-NEXT:    v_add_u32_e32 v1, v8, v1
-; GFX9-NEXT:    v_mul_hi_u32 v8, s18, v7
-; GFX9-NEXT:    v_mul_hi_u32 v7, s19, v7
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v5, v4
-; GFX9-NEXT:    v_cndmask_b32_e64 v9, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v8
-; GFX9-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v11, vcc, v4, v1
+; GFX9-NEXT:    v_mul_hi_u32 v12, s19, v5
+; GFX9-NEXT:    v_add_co_u32_e64 v6, s[2:3], v6, v8
+; GFX9-NEXT:    v_cndmask_b32_e64 v8, 0, 1, s[2:3]
+; GFX9-NEXT:    v_add_co_u32_e64 v6, s[2:3], v6, v10
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s[2:3]
+; GFX9-NEXT:    v_mul_lo_u32 v10, s19, v5
+; GFX9-NEXT:    v_add_u32_e32 v6, v8, v6
+; GFX9-NEXT:    v_mul_hi_u32 v8, s18, v5
+; GFX9-NEXT:    v_cndmask_b32_e32 v13, v16, v9, vcc
+; GFX9-NEXT:    v_add_co_u32_e64 v4, s[2:3], v10, v4
+; GFX9-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s[2:3]
+; GFX9-NEXT:    v_add_co_u32_e64 v4, s[2:3], v4, v8
+; GFX9-NEXT:    v_cndmask_b32_e64 v8, 0, 1, s[2:3]
+; GFX9-NEXT:    v_add_co_u32_e64 v11, s[2:3], v4, v6
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s[2:3]
 ; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[2:3], s6, v11, 0
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
-; GFX9-NEXT:    v_add_u32_e32 v8, v9, v8
-; GFX9-NEXT:    v_add3_u32 v12, v8, v1, v7
-; GFX9-NEXT:    v_mad_u64_u32 v[8:9], s[2:3], s6, v12, v[5:6]
-; GFX9-NEXT:    v_cndmask_b32_e64 v7, v0, v10, s[0:1]
+; GFX9-NEXT:    v_add_u32_e32 v8, v10, v8
+; GFX9-NEXT:    v_add3_u32 v10, v8, v6, v12
+; GFX9-NEXT:    v_cndmask_b32_e32 v7, v15, v7, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[8:9], s[2:3], s6, v10, v[5:6]
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, v0, v7, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v7, v1, v13, s[0:1]
 ; GFX9-NEXT:    v_mov_b32_e32 v5, s7
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s7, v11, v[8:9]
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s19
@@ -1489,16 +1489,16 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX9-NEXT:    v_subb_co_u32_e32 v0, vcc, v0, v5, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, v9, s[0:1]
 ; GFX9-NEXT:    v_subrev_co_u32_e32 v9, vcc, s6, v8
-; GFX9-NEXT:    v_subbrev_co_u32_e64 v10, s[0:1], 0, v0, vcc
-; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s7, v10
+; GFX9-NEXT:    v_subbrev_co_u32_e64 v12, s[0:1], 0, v0, vcc
+; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s7, v12
 ; GFX9-NEXT:    v_cndmask_b32_e64 v13, 0, -1, s[0:1]
 ; GFX9-NEXT:    v_cmp_le_u32_e64 s[0:1], s6, v9
 ; GFX9-NEXT:    v_cndmask_b32_e64 v14, 0, -1, s[0:1]
-; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s7, v10
+; GFX9-NEXT:    v_cmp_eq_u32_e64 s[0:1], s7, v12
 ; GFX9-NEXT:    v_cndmask_b32_e64 v13, v13, v14, s[0:1]
 ; GFX9-NEXT:    v_add_co_u32_e64 v14, s[0:1], 1, v11
 ; GFX9-NEXT:    v_subb_co_u32_e32 v0, vcc, v0, v5, vcc
-; GFX9-NEXT:    v_addc_co_u32_e64 v15, s[0:1], 0, v12, s[0:1]
+; GFX9-NEXT:    v_addc_co_u32_e64 v15, s[0:1], 0, v10, s[0:1]
 ; GFX9-NEXT:    v_add_co_u32_e32 v5, vcc, 1, v14
 ; GFX9-NEXT:    v_addc_co_u32_e32 v16, vcc, 0, v15, vcc
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v13
@@ -1509,9 +1509,9 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX9-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v4
 ; GFX9-NEXT:    v_mov_b32_e32 v13, 0
 ; GFX9-NEXT:    v_cndmask_b32_e64 v4, v11, v5, s[0:1]
-; GFX9-NEXT:    v_cndmask_b32_e64 v5, v12, v14, s[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, v10, v14, s[0:1]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v9, v9, v15, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v10, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v12, v0, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e64 v8, v8, v9, s[0:1]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v9, v1, v0, s[0:1]
 ; GFX9-NEXT:    global_store_dwordx4 v13, v[2:5], s[12:13]
@@ -1525,17 +1525,17 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX10-NEXT:    s_load_dwordx8 s[12:19], s[8:9], 0x0
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX10-NEXT:    v_cvt_f32_u32_e32 v0, s5
-; GFX10-NEXT:    v_cvt_f32_u32_e32 v1, s7
-; GFX10-NEXT:    v_cvt_f32_u32_e32 v2, s4
+; GFX10-NEXT:    v_cvt_f32_u32_e32 v2, s7
+; GFX10-NEXT:    v_cvt_f32_u32_e32 v1, s4
 ; GFX10-NEXT:    v_cvt_f32_u32_e32 v3, s6
 ; GFX10-NEXT:    s_sub_u32 s1, 0, s4
 ; GFX10-NEXT:    v_mul_f32_e32 v0, 0x4f800000, v0
-; GFX10-NEXT:    v_mul_f32_e32 v1, 0x4f800000, v1
+; GFX10-NEXT:    v_mul_f32_e32 v2, 0x4f800000, v2
 ; GFX10-NEXT:    s_subb_u32 s2, 0, s5
 ; GFX10-NEXT:    s_sub_u32 s3, 0, s6
 ; GFX10-NEXT:    s_subb_u32 s10, 0, s7
-; GFX10-NEXT:    v_add_f32_e32 v0, v0, v2
-; GFX10-NEXT:    v_add_f32_e32 v1, v1, v3
+; GFX10-NEXT:    v_add_f32_e32 v0, v0, v1
+; GFX10-NEXT:    v_add_f32_e32 v1, v2, v3
 ; GFX10-NEXT:    v_rcp_iflag_f32_e32 v0, v0
 ; GFX10-NEXT:    v_rcp_iflag_f32_e32 v1, v1
 ; GFX10-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v0
@@ -1557,22 +1557,22 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX10-NEXT:    v_mul_hi_u32 v11, v9, v0
 ; GFX10-NEXT:    v_mad_u64_u32 v[4:5], s0, s1, v9, v[1:2]
 ; GFX10-NEXT:    v_mad_u64_u32 v[5:6], s0, s3, v10, v[3:4]
-; GFX10-NEXT:    v_mul_lo_u32 v6, v9, v0
+; GFX10-NEXT:    v_mul_hi_u32 v6, v7, v0
 ; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s0, s2, v7, v[4:5]
-; GFX10-NEXT:    v_mul_hi_u32 v4, v7, v0
+; GFX10-NEXT:    v_mul_lo_u32 v4, v9, v0
 ; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s0, s10, v8, v[5:6]
 ; GFX10-NEXT:    v_mul_lo_u32 v1, v10, v2
 ; GFX10-NEXT:    v_mul_hi_u32 v5, v8, v2
 ; GFX10-NEXT:    v_mul_hi_u32 v2, v10, v2
 ; GFX10-NEXT:    v_mul_lo_u32 v12, v7, v3
 ; GFX10-NEXT:    v_mul_lo_u32 v13, v9, v3
-; GFX10-NEXT:    v_mul_hi_u32 v14, v7, v3
 ; GFX10-NEXT:    v_mul_lo_u32 v15, v8, v0
 ; GFX10-NEXT:    v_mul_lo_u32 v16, v10, v0
+; GFX10-NEXT:    v_mul_hi_u32 v14, v7, v3
 ; GFX10-NEXT:    v_mul_hi_u32 v17, v8, v0
 ; GFX10-NEXT:    v_mul_hi_u32 v3, v9, v3
 ; GFX10-NEXT:    v_mul_hi_u32 v0, v10, v0
-; GFX10-NEXT:    v_add_co_u32 v6, s0, v6, v12
+; GFX10-NEXT:    v_add_co_u32 v4, s0, v4, v12
 ; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s0
 ; GFX10-NEXT:    v_add_co_u32 v11, s0, v13, v11
 ; GFX10-NEXT:    v_cndmask_b32_e64 v13, 0, 1, s0
@@ -1580,7 +1580,7 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX10-NEXT:    v_cndmask_b32_e64 v15, 0, 1, s0
 ; GFX10-NEXT:    v_add_co_u32 v2, s0, v16, v2
 ; GFX10-NEXT:    v_cndmask_b32_e64 v16, 0, 1, s0
-; GFX10-NEXT:    v_add_co_u32 v4, s0, v6, v4
+; GFX10-NEXT:    v_add_co_u32 v4, s0, v4, v6
 ; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s0
 ; GFX10-NEXT:    v_add_co_u32 v6, s0, v11, v14
 ; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s0
@@ -1607,22 +1607,22 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX10-NEXT:    v_mul_hi_u32 v11, v9, v0
 ; GFX10-NEXT:    v_mad_u64_u32 v[4:5], s0, s1, v9, v[1:2]
 ; GFX10-NEXT:    v_mad_u64_u32 v[5:6], s0, s3, v10, v[3:4]
-; GFX10-NEXT:    v_mul_lo_u32 v6, v9, v0
+; GFX10-NEXT:    v_mul_hi_u32 v6, v7, v0
 ; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s0, s2, v7, v[4:5]
-; GFX10-NEXT:    v_mul_hi_u32 v4, v7, v0
+; GFX10-NEXT:    v_mul_lo_u32 v4, v9, v0
 ; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s0, s10, v8, v[5:6]
 ; GFX10-NEXT:    v_mul_lo_u32 v1, v10, v2
 ; GFX10-NEXT:    v_mul_hi_u32 v5, v8, v2
 ; GFX10-NEXT:    v_mul_hi_u32 v2, v10, v2
 ; GFX10-NEXT:    v_mul_lo_u32 v12, v7, v3
 ; GFX10-NEXT:    v_mul_lo_u32 v13, v9, v3
-; GFX10-NEXT:    v_mul_hi_u32 v14, v7, v3
 ; GFX10-NEXT:    v_mul_lo_u32 v15, v8, v0
 ; GFX10-NEXT:    v_mul_lo_u32 v16, v10, v0
+; GFX10-NEXT:    v_mul_hi_u32 v14, v7, v3
 ; GFX10-NEXT:    v_mul_hi_u32 v17, v8, v0
 ; GFX10-NEXT:    v_mul_hi_u32 v3, v9, v3
 ; GFX10-NEXT:    v_mul_hi_u32 v0, v10, v0
-; GFX10-NEXT:    v_add_co_u32 v6, s0, v6, v12
+; GFX10-NEXT:    v_add_co_u32 v4, s0, v4, v12
 ; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s0
 ; GFX10-NEXT:    v_add_co_u32 v11, s0, v13, v11
 ; GFX10-NEXT:    v_cndmask_b32_e64 v13, 0, 1, s0
@@ -1630,7 +1630,7 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX10-NEXT:    v_cndmask_b32_e64 v15, 0, 1, s0
 ; GFX10-NEXT:    v_add_co_u32 v2, s0, v16, v2
 ; GFX10-NEXT:    v_cndmask_b32_e64 v16, 0, 1, s0
-; GFX10-NEXT:    v_add_co_u32 v4, s0, v6, v4
+; GFX10-NEXT:    v_add_co_u32 v4, s0, v4, v6
 ; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s0
 ; GFX10-NEXT:    v_add_co_u32 v6, s0, v11, v14
 ; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s0
@@ -1659,118 +1659,118 @@ define amdgpu_kernel void @udivrem_v2i64(ptr addrspace(1) %out0, ptr addrspace(1
 ; GFX10-NEXT:    v_mul_lo_u32 v9, s17, v2
 ; GFX10-NEXT:    v_mul_lo_u32 v6, s19, v1
 ; GFX10-NEXT:    v_mul_lo_u32 v11, s18, v0
+; GFX10-NEXT:    v_mul_lo_u32 v12, s19, v0
+; GFX10-NEXT:    v_mul_hi_u32 v13, s18, v0
+; GFX10-NEXT:    v_mul_hi_u32 v14, s19, v0
+; GFX10-NEXT:    v_add_co_u32 v0, s0, v3, v8
 ; GFX10-NEXT:    v_mul_hi_u32 v7, s18, v1
 ; GFX10-NEXT:    v_mul_hi_u32 v1, s19, v1
-; GFX10-NEXT:    v_mul_lo_u32 v12, s19, v0
-; GFX10-NEXT:    v_add_co_u32 v3, s0, v3, v8
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s0
+; GFX10-NEXT:    v_add_co_u32 v4, s0, v9, v4
 ; GFX10-NEXT:    v_mul_hi_u32 v10, s16, v2
 ; GFX10-NEXT:    v_cndmask_b32_e64 v8, 0, 1, s0
-; GFX10-NEXT:    v_add_co_u32 v4, s0, v9, v4
-; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s0
 ; GFX10-NEXT:    v_add_co_u32 v6, s0, v6, v11
-; GFX10-NEXT:    v_cndmask_b32_e64 v11, 0, 1, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s0
+; GFX10-NEXT:    v_add_co_u32 v0, s0, v0, v5
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s0
 ; GFX10-NEXT:    v_add_co_u32 v1, s0, v12, v1
-; GFX10-NEXT:    v_mul_hi_u32 v13, s18, v0
-; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s0
-; GFX10-NEXT:    v_add_co_u32 v3, s0, v3, v5
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s0
 ; GFX10-NEXT:    v_add_co_u32 v4, s0, v4, v10
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s0
-; GFX10-NEXT:    v_add_co_u32 v6, s0, v6, v7
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, 0, 1, s0
-; GFX10-NEXT:    v_add_co_u32 v1, s0, v1, v13
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, 0, 1, s0
-; GFX10-NEXT:    v_mul_hi_u32 v10, s19, v0
-; GFX10-NEXT:    v_add_nc_u32_e32 v0, v8, v3
-; GFX10-NEXT:    v_add_nc_u32_e32 v3, v9, v5
-; GFX10-NEXT:    v_add_nc_u32_e32 v5, v11, v6
+; GFX10-NEXT:    v_cndmask_b32_e64 v10, 0, 1, s0
+; GFX10-NEXT:    v_add_nc_u32_e32 v0, v3, v0
+; GFX10-NEXT:    v_add_co_u32 v3, s0, v6, v7
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s0
+; GFX10-NEXT:    v_add_co_u32 v6, s0, v1, v13
+; GFX10-NEXT:    v_add_co_u32 v7, s1, v4, v0
+; GFX10-NEXT:    v_add_nc_u32_e32 v3, v9, v3
 ; GFX10-NEXT:    v_mul_hi_u32 v2, s17, v2
-; GFX10-NEXT:    v_add_nc_u32_e32 v6, v12, v7
-; GFX10-NEXT:    v_add_co_u32 v7, s0, v4, v0
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s0
-; GFX10-NEXT:    v_add_co_u32 v8, s0, v1, v5
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, 1, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s0
 ; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s0, s4, v7, 0
-; GFX10-NEXT:    v_add3_u32 v9, v3, v4, v2
-; GFX10-NEXT:    v_mad_u64_u32 v[2:3], s0, s6, v8, 0
-; GFX10-NEXT:    v_add3_u32 v10, v6, v5, v10
-; GFX10-NEXT:    v_mov_b32_e32 v12, 0
-; GFX10-NEXT:    v_mad_u64_u32 v[4:5], s0, s4, v9, v[1:2]
-; GFX10-NEXT:    v_add_co_u32 v1, vcc_lo, v7, 1
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v11, vcc_lo, 0, v9, vcc_lo
-; GFX10-NEXT:    v_mad_u64_u32 v[5:6], s0, s6, v10, v[3:4]
-; GFX10-NEXT:    v_add_co_u32 v6, vcc_lo, v1, 1
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v13, vcc_lo, 0, v11, vcc_lo
-; GFX10-NEXT:    v_sub_co_u32 v14, vcc_lo, s16, v0
+; GFX10-NEXT:    v_add_nc_u32_e32 v4, v8, v10
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, 0, 1, s1
+; GFX10-NEXT:    v_add_co_u32 v10, s0, v6, v3
+; GFX10-NEXT:    v_add_nc_u32_e32 v6, v5, v9
+; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, 1, s0
+; GFX10-NEXT:    v_add3_u32 v8, v4, v8, v2
+; GFX10-NEXT:    v_mad_u64_u32 v[2:3], s0, s6, v10, 0
+; GFX10-NEXT:    v_add_co_u32 v12, vcc_lo, v7, 1
+; GFX10-NEXT:    v_add3_u32 v9, v6, v9, v14
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v13, vcc_lo, 0, v8, vcc_lo
+; GFX10-NEXT:    v_mov_b32_e32 v11, 0
+; GFX10-NEXT:    v_mad_u64_u32 v[4:5], s0, s4, v8, v[1:2]
+; GFX10-NEXT:    v_mad_u64_u32 v[5:6], s0, s6, v9, v[3:4]
 ; GFX10-NEXT:    v_mad_u64_u32 v[3:4], s0, s5, v7, v[4:5]
-; GFX10-NEXT:    v_mad_u64_u32 v[4:5], s0, s7, v8, v[5:6]
-; GFX10-NEXT:    v_sub_nc_u32_e32 v5, s17, v3
-; GFX10-NEXT:    v_sub_co_ci_u32_e64 v3, s0, s17, v3, vcc_lo
-; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v0, vcc_lo, s5, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_le_u32_e32 vcc_lo, s4, v14
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc_lo
-; GFX10-NEXT:    v_sub_co_u32 v15, vcc_lo, v14, s4
-; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v16, s0, 0, v0, vcc_lo
-; GFX10-NEXT:    v_sub_co_u32 v17, s0, s18, v2
-; GFX10-NEXT:    v_sub_co_ci_u32_e64 v18, s1, s19, v4, s0
-; GFX10-NEXT:    v_cmp_le_u32_e64 s1, s4, v15
-; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v0, vcc_lo, s5, v0, vcc_lo
-; GFX10-NEXT:    v_sub_nc_u32_e32 v4, s19, v4
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s1
-; GFX10-NEXT:    v_cmp_le_u32_e64 s1, s5, v16
-; GFX10-NEXT:    v_cndmask_b32_e64 v19, 0, -1, s1
-; GFX10-NEXT:    v_cmp_le_u32_e64 s1, s5, v3
-; GFX10-NEXT:    v_cndmask_b32_e64 v20, 0, -1, s1
-; GFX10-NEXT:    v_cmp_eq_u32_e64 s1, s5, v16
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v19, v2, s1
-; GFX10-NEXT:    v_cmp_eq_u32_e64 s1, s5, v3
-; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v20, v5, s1
-; GFX10-NEXT:    v_sub_co_u32 v2, s1, v15, s4
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v6, vcc_lo
-; GFX10-NEXT:    v_cmp_ne_u32_e64 s2, 0, v5
-; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v6, s1, 0, v0, s1
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v11, v13, vcc_lo
-; GFX10-NEXT:    v_cmp_le_u32_e64 s1, s7, v18
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v7, v1, s2
-; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v7, s0, s7, v4, s0
-; GFX10-NEXT:    v_cmp_le_u32_e64 s0, s6, v17
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v9, v5, s2
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v15, v2, vcc_lo
+; GFX10-NEXT:    v_add_co_u32 v4, vcc_lo, v12, 1
+; GFX10-NEXT:    v_add_co_ci_u32_e32 v6, vcc_lo, 0, v13, vcc_lo
+; GFX10-NEXT:    v_sub_co_u32 v14, vcc_lo, s16, v0
+; GFX10-NEXT:    v_mad_u64_u32 v[0:1], s0, s7, v10, v[5:6]
+; GFX10-NEXT:    v_sub_co_u32 v15, s0, s18, v2
+; GFX10-NEXT:    v_sub_co_ci_u32_e64 v2, s1, s17, v3, vcc_lo
+; GFX10-NEXT:    v_cmp_le_u32_e64 s1, s4, v14
+; GFX10-NEXT:    v_sub_nc_u32_e32 v1, s17, v3
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s1
+; GFX10-NEXT:    v_sub_co_ci_u32_e64 v16, s1, s19, v0, s0
+; GFX10-NEXT:    v_cmp_le_u32_e64 s1, s6, v15
+; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v1, vcc_lo, s5, v1, vcc_lo
+; GFX10-NEXT:    v_sub_nc_u32_e32 v0, s19, v0
+; GFX10-NEXT:    v_cmp_le_u32_e32 vcc_lo, s7, v16
 ; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, -1, s1
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v16, v6, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, -1, s0
-; GFX10-NEXT:    v_sub_co_u32 v11, s0, v17, s6
-; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v13, s1, 0, v7, s0
-; GFX10-NEXT:    v_cmp_eq_u32_e32 vcc_lo, s7, v18
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v14, v2, s2
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v5, v9, vcc_lo
-; GFX10-NEXT:    v_cmp_le_u32_e32 vcc_lo, s7, v13
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc_lo
-; GFX10-NEXT:    v_cmp_le_u32_e32 vcc_lo, s6, v11
-; GFX10-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc_lo
-; GFX10-NEXT:    v_add_co_u32 v14, vcc_lo, v8, 1
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v15, vcc_lo, 0, v10, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_u32_e32 vcc_lo, s7, v13
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v5, v9, vcc_lo
-; GFX10-NEXT:    v_add_co_u32 v9, vcc_lo, v14, 1
-; GFX10-NEXT:    v_add_co_ci_u32_e32 v16, vcc_lo, 0, v15, vcc_lo
-; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v7, vcc_lo, s7, v7, s0
-; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v5
-; GFX10-NEXT:    v_sub_co_u32 v5, s0, v11, s6
-; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v7, s0, 0, v7, s0
-; GFX10-NEXT:    v_cndmask_b32_e32 v9, v14, v9, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v14, v15, v16, vcc_lo
-; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v11, v11, v5, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v13, v7, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v3, v6, s2
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v8, v9, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v10, v14, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v6, v17, v11, s0
-; GFX10-NEXT:    v_cndmask_b32_e64 v7, v18, v7, s0
-; GFX10-NEXT:    global_store_dwordx4 v12, v[0:3], s[12:13]
-; GFX10-NEXT:    global_store_dwordx4 v12, v[4:7], s[14:15]
+; GFX10-NEXT:    v_cmp_le_u32_e64 s1, s5, v2
+; GFX10-NEXT:    v_cndmask_b32_e64 v18, 0, -1, vcc_lo
+; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v19, vcc_lo, s7, v0, s0
+; GFX10-NEXT:    v_sub_co_u32 v0, s0, v14, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s1
+; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v21, s1, 0, v1, s0
+; GFX10-NEXT:    v_cmp_eq_u32_e64 s1, s5, v2
+; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v1, s0, s5, v1, s0
+; GFX10-NEXT:    v_cmp_eq_u32_e64 s0, s7, v16
+; GFX10-NEXT:    v_sub_co_u32 v20, vcc_lo, v15, s6
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, v17, v3, s1
+; GFX10-NEXT:    v_cmp_le_u32_e64 s1, s4, v0
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, v18, v5, s0
+; GFX10-NEXT:    v_cmp_eq_u32_e64 s0, s5, v21
+; GFX10-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s1
+; GFX10-NEXT:    v_cmp_le_u32_e64 s1, s5, v21
+; GFX10-NEXT:    v_cndmask_b32_e64 v22, 0, -1, s1
+; GFX10-NEXT:    v_cndmask_b32_e64 v17, v22, v17, s0
+; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v18, s0, 0, v19, vcc_lo
+; GFX10-NEXT:    v_cmp_le_u32_e64 s0, s6, v20
+; GFX10-NEXT:    v_cmp_le_u32_e64 s2, s7, v18
+; GFX10-NEXT:    v_cndmask_b32_e64 v22, 0, -1, s0
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v17
+; GFX10-NEXT:    v_sub_co_u32 v17, s1, v0, s4
+; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v1, s1, 0, v1, s1
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, v12, v4, s0
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s1, 0, v3
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, v13, v6, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, v0, v17, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v12, 0, -1, s2
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v7, v4, s1
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, v21, v1, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v8, v3, s1
+; GFX10-NEXT:    v_add_co_u32 v3, s0, v10, 1
+; GFX10-NEXT:    v_cndmask_b32_e64 v4, v14, v6, s1
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v6, s0, 0, v9, s0
+; GFX10-NEXT:    v_cmp_eq_u32_e64 s0, s7, v18
+; GFX10-NEXT:    v_subrev_co_ci_u32_e32 v14, vcc_lo, s7, v19, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v8, v12, v22, s0
+; GFX10-NEXT:    v_add_co_u32 v12, s0, v3, 1
+; GFX10-NEXT:    v_add_co_ci_u32_e64 v13, s0, 0, v6, s0
+; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v8
+; GFX10-NEXT:    v_sub_co_u32 v8, s0, v20, s6
+; GFX10-NEXT:    v_subrev_co_ci_u32_e64 v14, s0, 0, v14, s0
+; GFX10-NEXT:    v_cndmask_b32_e32 v3, v3, v12, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v6, v6, v13, vcc_lo
+; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v5
+; GFX10-NEXT:    v_cndmask_b32_e32 v8, v20, v8, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v12, v18, v14, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v5, v2, v7, s1
+; GFX10-NEXT:    v_cndmask_b32_e64 v2, v10, v3, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v3, v9, v6, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v6, v15, v8, s0
+; GFX10-NEXT:    v_cndmask_b32_e64 v7, v16, v12, s0
+; GFX10-NEXT:    global_store_dwordx4 v11, v[0:3], s[12:13]
+; GFX10-NEXT:    global_store_dwordx4 v11, v[4:7], s[14:15]
 ; GFX10-NEXT:    s_endpgm
   %div = udiv <2 x i64> %x, %y
   store <2 x i64> %div, ptr addrspace(1) %out0

--- a/llvm/test/CodeGen/AMDGPU/atomic_optimizations_global_pointer.ll
+++ b/llvm/test/CodeGen/AMDGPU/atomic_optimizations_global_pointer.ll
@@ -6112,8 +6112,8 @@ define amdgpu_kernel void @sub_i64_uniform(ptr addrspace(1) %out, ptr addrspace(
 ; GFX8-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], s8, v0, 0
 ; GFX8-NEXT:    s_load_dwordx2 s[4:5], s[2:3], 0x0
 ; GFX8-NEXT:    s_mul_i32 s6, s9, s6
-; GFX8-NEXT:    v_add_u32_e32 v5, vcc, s6, v5
 ; GFX8-NEXT:    s_mov_b64 s[12:13], 0
+; GFX8-NEXT:    v_add_u32_e32 v5, vcc, s6, v5
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s5
@@ -6147,10 +6147,10 @@ define amdgpu_kernel void @sub_i64_uniform(ptr addrspace(1) %out, ptr addrspace(
 ; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], s8, v6, 0
 ; GFX8-NEXT:    v_readfirstlane_b32 s4, v1
 ; GFX8-NEXT:    v_readfirstlane_b32 s5, v0
+; GFX8-NEXT:    s_mov_b32 s3, 0xf000
 ; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v3, v4
 ; GFX8-NEXT:    v_mov_b32_e32 v3, s4
 ; GFX8-NEXT:    v_sub_u32_e32 v0, vcc, s5, v2
-; GFX8-NEXT:    s_mov_b32 s3, 0xf000
 ; GFX8-NEXT:    s_mov_b32 s2, -1
 ; GFX8-NEXT:    v_subb_u32_e32 v1, vcc, v3, v1, vcc
 ; GFX8-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
@@ -6209,10 +6209,10 @@ define amdgpu_kernel void @sub_i64_uniform(ptr addrspace(1) %out, ptr addrspace(
 ; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], s8, v4, 0
 ; GFX9-NEXT:    v_readfirstlane_b32 s6, v1
 ; GFX9-NEXT:    v_readfirstlane_b32 s7, v0
+; GFX9-NEXT:    s_mov_b32 s3, 0xf000
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], s9, v4, v[3:4]
 ; GFX9-NEXT:    v_mov_b32_e32 v3, s6
 ; GFX9-NEXT:    v_sub_co_u32_e32 v1, vcc, s7, v2
-; GFX9-NEXT:    s_mov_b32 s3, 0xf000
 ; GFX9-NEXT:    s_mov_b32 s2, -1
 ; GFX9-NEXT:    v_subb_co_u32_e32 v2, vcc, v3, v0, vcc
 ; GFX9-NEXT:    buffer_store_dwordx2 v[1:2], off, s[0:3], 0

--- a/llvm/test/CodeGen/AMDGPU/atomic_optimizations_local_pointer.ll
+++ b/llvm/test/CodeGen/AMDGPU/atomic_optimizations_local_pointer.ll
@@ -1731,8 +1731,8 @@ define amdgpu_kernel void @add_i64_uniform(ptr addrspace(1) %out, i64 %additive)
 ; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], s2, v0, 0
 ; GFX8-NEXT:    s_mul_i32 s6, s3, s8
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, s6, v1
 ; GFX8-NEXT:    s_mov_b32 m0, -1
+; GFX8-NEXT:    v_add_u32_e32 v1, vcc, s6, v1
 ; GFX8-NEXT:    ds_add_rtn_u64 v[0:1], v3, v[0:1]
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8-NEXT:  .LBB5_2:
@@ -1784,8 +1784,8 @@ define amdgpu_kernel void @add_i64_uniform(ptr addrspace(1) %out, i64 %additive)
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], s2, v2, v[0:1]
 ; GFX9-NEXT:    s_mov_b32 s7, 0xf000
 ; GFX9-NEXT:    s_mov_b32 s6, -1
-; GFX9-NEXT:    v_mad_u64_u32 v[1:2], s[2:3], s3, v2, v[1:2]
 ; GFX9-NEXT:    s_mov_b32 s4, s0
+; GFX9-NEXT:    v_mad_u64_u32 v[1:2], s[2:3], s3, v2, v[1:2]
 ; GFX9-NEXT:    s_mov_b32 s5, s1
 ; GFX9-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
 ; GFX9-NEXT:    s_endpgm
@@ -5135,8 +5135,8 @@ define amdgpu_kernel void @sub_i64_uniform(ptr addrspace(1) %out, i64 %subitive)
 ; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], s2, v0, 0
 ; GFX8-NEXT:    s_mul_i32 s6, s3, s8
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, s6, v1
 ; GFX8-NEXT:    s_mov_b32 m0, -1
+; GFX8-NEXT:    v_add_u32_e32 v1, vcc, s6, v1
 ; GFX8-NEXT:    ds_sub_rtn_u64 v[0:1], v3, v[0:1]
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8-NEXT:  .LBB13_2:
@@ -5148,10 +5148,10 @@ define amdgpu_kernel void @sub_i64_uniform(ptr addrspace(1) %out, i64 %subitive)
 ; GFX8-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], s2, v2, 0
 ; GFX8-NEXT:    v_readfirstlane_b32 s0, v1
 ; GFX8-NEXT:    v_readfirstlane_b32 s1, v0
+; GFX8-NEXT:    s_mov_b32 s7, 0xf000
 ; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v3, v4
 ; GFX8-NEXT:    v_mov_b32_e32 v3, s0
 ; GFX8-NEXT:    v_sub_u32_e32 v0, vcc, s1, v2
-; GFX8-NEXT:    s_mov_b32 s7, 0xf000
 ; GFX8-NEXT:    s_mov_b32 s6, -1
 ; GFX8-NEXT:    v_subb_u32_e32 v1, vcc, v3, v1, vcc
 ; GFX8-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
@@ -5182,9 +5182,9 @@ define amdgpu_kernel void @sub_i64_uniform(ptr addrspace(1) %out, i64 %subitive)
 ; GFX9-NEXT:  .LBB13_2:
 ; GFX9-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[8:9], s2, v2, 0
 ; GFX9-NEXT:    s_mov_b32 s4, s0
 ; GFX9-NEXT:    s_mov_b32 s5, s1
-; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], s2, v2, 0
 ; GFX9-NEXT:    v_readfirstlane_b32 s2, v1
 ; GFX9-NEXT:    v_readfirstlane_b32 s8, v0
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], s3, v2, v[4:5]

--- a/llvm/test/CodeGen/AMDGPU/bypass-div.ll
+++ b/llvm/test/CodeGen/AMDGPU/bypass-div.ll
@@ -22,99 +22,99 @@ define i64 @sdiv64(i64 %a, i64 %b) {
 ; GFX9-NEXT:    v_xor_b32_e32 v11, v2, v9
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v2, v11
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v3, v10
-; GFX9-NEXT:    v_sub_co_u32_e32 v7, vcc, 0, v11
-; GFX9-NEXT:    v_subb_co_u32_e32 v8, vcc, 0, v10, vcc
+; GFX9-NEXT:    v_sub_co_u32_e32 v12, vcc, 0, v11
+; GFX9-NEXT:    v_subb_co_u32_e32 v13, vcc, 0, v10, vcc
 ; GFX9-NEXT:    v_madmk_f32 v2, v3, 0x4f800000, v2
 ; GFX9-NEXT:    v_rcp_f32_e32 v2, v2
 ; GFX9-NEXT:    v_mul_f32_e32 v2, 0x5f7ffffc, v2
 ; GFX9-NEXT:    v_mul_f32_e32 v3, 0x2f800000, v2
 ; GFX9-NEXT:    v_trunc_f32_e32 v3, v3
 ; GFX9-NEXT:    v_madmk_f32 v2, v3, 0xcf800000, v2
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v6, v2
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v12, v3
-; GFX9-NEXT:    v_mul_lo_u32 v4, v8, v6
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v7, v6, 0
-; GFX9-NEXT:    v_mul_lo_u32 v5, v7, v12
-; GFX9-NEXT:    v_mul_hi_u32 v13, v6, v2
-; GFX9-NEXT:    v_add3_u32 v5, v3, v5, v4
-; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v6, v5, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v13, vcc, v13, v3
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v12, v2, 0
-; GFX9-NEXT:    v_addc_co_u32_e32 v14, vcc, 0, v4, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v12, v5, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v13, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v2, vcc, v14, v3, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v5, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v3, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v13, vcc, v6, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v12, vcc, v12, v3, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v4, v7, v12
-; GFX9-NEXT:    v_mul_lo_u32 v5, v8, v13
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v7, v13, 0
-; GFX9-NEXT:    v_add3_u32 v5, v3, v4, v5
-; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v12, v5, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v13, v5, 0
-; GFX9-NEXT:    v_mul_hi_u32 v14, v13, v2
-; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v12, v2, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v14, v5
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v6, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v7
-; GFX9-NEXT:    v_addc_co_u32_e32 v2, vcc, v5, v8, vcc
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v7, v3
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v8, v2
+; GFX9-NEXT:    v_mul_lo_u32 v5, v12, v7
+; GFX9-NEXT:    v_mul_lo_u32 v4, v13, v8
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v12, v8, 0
+; GFX9-NEXT:    v_add3_u32 v14, v3, v5, v4
+; GFX9-NEXT:    v_mul_hi_u32 v15, v8, v2
+; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v8, v14, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v2, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v15, vcc, v15, v3
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v7, v14, 0
 ; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, 0, v4, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v3
+; GFX9-NEXT:    v_add_co_u32_e32 v5, vcc, v15, v5
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v4, v6, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v4, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v14, vcc, v8, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v15, vcc, v7, v3, vcc
+; GFX9-NEXT:    v_mul_lo_u32 v4, v12, v15
+; GFX9-NEXT:    v_mul_lo_u32 v5, v13, v14
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v12, v14, 0
+; GFX9-NEXT:    v_add3_u32 v5, v3, v4, v5
+; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v14, v5, 0
+; GFX9-NEXT:    v_mul_hi_u32 v12, v14, v2
+; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v15, v2, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v15, v5, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v12, v3
 ; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v4, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v13, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v12, v3, vcc
-; GFX9-NEXT:    v_ashrrev_i32_e32 v4, 31, v1
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v4
-; GFX9-NEXT:    v_xor_b32_e32 v6, v0, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, v1, v4, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v3, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v7
+; GFX9-NEXT:    v_addc_co_u32_e32 v2, vcc, v3, v8, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v6, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v5
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v14, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v15, v3, vcc
+; GFX9-NEXT:    v_ashrrev_i32_e32 v5, 31, v1
+; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v5
+; GFX9-NEXT:    v_xor_b32_e32 v6, v0, v5
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v1, v5, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v4, 0
 ; GFX9-NEXT:    v_mul_hi_u32 v7, v6, v2
-; GFX9-NEXT:    v_xor_b32_e32 v5, v5, v4
+; GFX9-NEXT:    v_xor_b32_e32 v8, v3, v5
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v8, v2, 0
 ; GFX9-NEXT:    v_add_co_u32_e32 v7, vcc, v7, v0
-; GFX9-NEXT:    v_addc_co_u32_e32 v8, vcc, 0, v1, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v2, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v5, v3, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v7, v0
-; GFX9-NEXT:    v_addc_co_u32_e32 v0, vcc, v8, v1, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v3, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v0, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v12, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v4, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v7, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v2, vcc, v12, v3, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v0
 ; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v1, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v7, v10, v2
-; GFX9-NEXT:    v_mul_lo_u32 v8, v11, v3
+; GFX9-NEXT:    v_mul_lo_u32 v4, v10, v2
+; GFX9-NEXT:    v_mul_lo_u32 v7, v11, v3
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v11, v2, 0
-; GFX9-NEXT:    v_add3_u32 v1, v1, v8, v7
-; GFX9-NEXT:    v_sub_u32_e32 v7, v5, v1
+; GFX9-NEXT:    v_add3_u32 v1, v1, v7, v4
+; GFX9-NEXT:    v_sub_u32_e32 v4, v8, v1
 ; GFX9-NEXT:    v_sub_co_u32_e32 v0, vcc, v6, v0
-; GFX9-NEXT:    v_subb_co_u32_e64 v6, s[4:5], v7, v10, vcc
-; GFX9-NEXT:    v_sub_co_u32_e64 v7, s[4:5], v0, v11
-; GFX9-NEXT:    v_subbrev_co_u32_e64 v6, s[4:5], 0, v6, s[4:5]
-; GFX9-NEXT:    v_cmp_ge_u32_e64 s[4:5], v6, v10
-; GFX9-NEXT:    v_cndmask_b32_e64 v8, 0, -1, s[4:5]
-; GFX9-NEXT:    v_cmp_ge_u32_e64 s[4:5], v7, v11
+; GFX9-NEXT:    v_subb_co_u32_e64 v4, s[4:5], v4, v10, vcc
+; GFX9-NEXT:    v_sub_co_u32_e64 v6, s[4:5], v0, v11
+; GFX9-NEXT:    v_subbrev_co_u32_e64 v4, s[4:5], 0, v4, s[4:5]
+; GFX9-NEXT:    v_cmp_ge_u32_e64 s[4:5], v4, v10
 ; GFX9-NEXT:    v_cndmask_b32_e64 v7, 0, -1, s[4:5]
-; GFX9-NEXT:    v_cmp_eq_u32_e64 s[4:5], v6, v10
-; GFX9-NEXT:    v_cndmask_b32_e64 v6, v8, v7, s[4:5]
-; GFX9-NEXT:    v_add_co_u32_e64 v7, s[4:5], 2, v2
-; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v5, v1, vcc
-; GFX9-NEXT:    v_addc_co_u32_e64 v8, s[4:5], 0, v3, s[4:5]
-; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v10
+; GFX9-NEXT:    v_cmp_ge_u32_e64 s[4:5], v6, v11
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, -1, s[4:5]
+; GFX9-NEXT:    v_cmp_eq_u32_e64 s[4:5], v4, v10
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, v7, v6, s[4:5]
+; GFX9-NEXT:    v_add_co_u32_e64 v6, s[4:5], 2, v2
+; GFX9-NEXT:    v_addc_co_u32_e64 v7, s[4:5], 0, v3, s[4:5]
 ; GFX9-NEXT:    v_add_co_u32_e64 v12, s[4:5], 1, v2
-; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc
-; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v11
 ; GFX9-NEXT:    v_addc_co_u32_e64 v13, s[4:5], 0, v3, s[4:5]
+; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v8, v1, vcc
+; GFX9-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v4
+; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v10
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, v13, v7, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v7, 0, -1, vcc
+; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v11
 ; GFX9-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v10
-; GFX9-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v7, v0, vcc
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v12, v7, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v6, v13, v8, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, v12, v6, s[4:5]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX9-NEXT:    v_xor_b32_e32 v2, v4, v9
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v6, vcc
+; GFX9-NEXT:    v_xor_b32_e32 v2, v5, v9
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v4, vcc
 ; GFX9-NEXT:    v_xor_b32_e32 v1, v1, v2
 ; GFX9-NEXT:    v_xor_b32_e32 v0, v0, v2
 ; GFX9-NEXT:    v_sub_co_u32_e32 v4, vcc, v1, v2
@@ -145,7 +145,7 @@ define i64 @sdiv64(i64 %a, i64 %b) {
 ; GFX9-NEXT:    v_add_u32_e32 v3, 1, v1
 ; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v2
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v1, v3, vcc
-; GFX9-NEXT:  .LBB0_4:
+; GFX9-NEXT:  .LBB0_4: ; %.split
 ; GFX9-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, v5
@@ -167,60 +167,60 @@ define i64 @udiv64(i64 %a, i64 %b) {
 ; GFX9-NEXT:  ; %bb.1:
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v4, v2
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v5, v3
-; GFX9-NEXT:    v_sub_co_u32_e32 v10, vcc, 0, v2
-; GFX9-NEXT:    v_subb_co_u32_e32 v11, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_sub_co_u32_e32 v13, vcc, 0, v2
+; GFX9-NEXT:    v_subb_co_u32_e32 v14, vcc, 0, v3, vcc
 ; GFX9-NEXT:    v_madmk_f32 v4, v5, 0x4f800000, v4
 ; GFX9-NEXT:    v_rcp_f32_e32 v4, v4
 ; GFX9-NEXT:    v_mul_f32_e32 v4, 0x5f7ffffc, v4
 ; GFX9-NEXT:    v_mul_f32_e32 v5, 0x2f800000, v4
 ; GFX9-NEXT:    v_trunc_f32_e32 v5, v5
 ; GFX9-NEXT:    v_madmk_f32 v4, v5, 0xcf800000, v4
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v8, v5
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v9, v4
-; GFX9-NEXT:    v_mul_lo_u32 v6, v10, v8
-; GFX9-NEXT:    v_mul_lo_u32 v7, v11, v9
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v10, v9, 0
-; GFX9-NEXT:    v_add3_u32 v7, v5, v6, v7
-; GFX9-NEXT:    v_mul_hi_u32 v12, v9, v4
-; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v9, v7, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v12, v5
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v8, v4, 0
-; GFX9-NEXT:    v_addc_co_u32_e32 v13, vcc, 0, v6, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v8, v7, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v12, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v13, v5, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v7, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v6
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v9, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v13, vcc, v8, v5, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v6, v10, v13
-; GFX9-NEXT:    v_mul_lo_u32 v7, v11, v12
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v10, v12, 0
-; GFX9-NEXT:    v_add3_u32 v7, v5, v6, v7
-; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v13, v7, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v12, v7, 0
-; GFX9-NEXT:    v_mul_hi_u32 v11, v12, v4
-; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v13, v4, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v11, v7
-; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v8, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v9
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v7, v10, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v6, vcc, 0, v6, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v5
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v11, v5
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v12, v4
+; GFX9-NEXT:    v_mul_lo_u32 v6, v13, v11
+; GFX9-NEXT:    v_mul_lo_u32 v7, v14, v12
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v13, v12, 0
+; GFX9-NEXT:    v_add3_u32 v9, v5, v6, v7
+; GFX9-NEXT:    v_mul_hi_u32 v15, v12, v4
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v12, v9, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v11, v4, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v9, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v15, v5
 ; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v6, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v7
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v5, v8, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v10, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v9
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v12, v4
+; GFX9-NEXT:    v_addc_co_u32_e32 v11, vcc, v11, v5, vcc
+; GFX9-NEXT:    v_mul_lo_u32 v6, v13, v11
+; GFX9-NEXT:    v_mul_lo_u32 v7, v14, v12
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v13, v12, 0
+; GFX9-NEXT:    v_add3_u32 v7, v5, v6, v7
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v12, v7, 0
+; GFX9-NEXT:    v_mul_hi_u32 v13, v12, v4
+; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v4, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v11, v7, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v13, v5
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v6, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v9
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v5, v10, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v8, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v7
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v12, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, v13, v5, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, v7, 0
-; GFX9-NEXT:    v_mul_hi_u32 v8, v0, v6
-; GFX9-NEXT:    v_add_co_u32_e32 v8, vcc, v8, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, 0, v5, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v6, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v1, v7, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v8, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v9, v5, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v7, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v4, v6
+; GFX9-NEXT:    v_addc_co_u32_e32 v8, vcc, v11, v5, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, v8, 0
+; GFX9-NEXT:    v_mul_hi_u32 v9, v0, v6
+; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v1, v6, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v9, vcc, v9, v4
+; GFX9-NEXT:    v_addc_co_u32_e32 v10, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v8, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v9, v6
+; GFX9-NEXT:    v_addc_co_u32_e32 v6, vcc, v10, v7, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v6, v4
 ; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v5, vcc
 ; GFX9-NEXT:    v_mul_lo_u32 v8, v3, v6
 ; GFX9-NEXT:    v_mul_lo_u32 v9, v2, v7
@@ -280,7 +280,7 @@ define i64 @udiv64(i64 %a, i64 %b) {
 ; GFX9-NEXT:    v_add_u32_e32 v3, 1, v1
 ; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v2
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v1, v3, vcc
-; GFX9-NEXT:  .LBB1_4:
+; GFX9-NEXT:  .LBB1_4: ; %.split
 ; GFX9-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, v5
@@ -307,96 +307,96 @@ define i64 @srem64(i64 %a, i64 %b) {
 ; GFX9-NEXT:    v_xor_b32_e32 v10, v2, v4
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v2, v10
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v3, v9
-; GFX9-NEXT:    v_sub_co_u32_e32 v7, vcc, 0, v10
-; GFX9-NEXT:    v_subb_co_u32_e32 v8, vcc, 0, v9, vcc
+; GFX9-NEXT:    v_sub_co_u32_e32 v11, vcc, 0, v10
+; GFX9-NEXT:    v_subb_co_u32_e32 v12, vcc, 0, v9, vcc
 ; GFX9-NEXT:    v_madmk_f32 v2, v3, 0x4f800000, v2
 ; GFX9-NEXT:    v_rcp_f32_e32 v2, v2
 ; GFX9-NEXT:    v_mul_f32_e32 v2, 0x5f7ffffc, v2
 ; GFX9-NEXT:    v_mul_f32_e32 v3, 0x2f800000, v2
 ; GFX9-NEXT:    v_trunc_f32_e32 v3, v3
 ; GFX9-NEXT:    v_madmk_f32 v2, v3, 0xcf800000, v2
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v6, v2
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v11, v3
-; GFX9-NEXT:    v_mul_lo_u32 v4, v8, v6
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v7, v6, 0
-; GFX9-NEXT:    v_mul_lo_u32 v5, v7, v11
-; GFX9-NEXT:    v_mul_hi_u32 v12, v6, v2
-; GFX9-NEXT:    v_add3_u32 v5, v3, v5, v4
-; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v6, v5, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v12, v3
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v11, v2, 0
-; GFX9-NEXT:    v_addc_co_u32_e32 v13, vcc, 0, v4, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v11, v5, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v12, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v2, vcc, v13, v3, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v5, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v3, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v6, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v11, vcc, v11, v3, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v4, v7, v11
-; GFX9-NEXT:    v_mul_lo_u32 v5, v8, v12
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v7, v12, 0
-; GFX9-NEXT:    v_add3_u32 v5, v3, v4, v5
-; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v11, v5, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v12, v5, 0
-; GFX9-NEXT:    v_mul_hi_u32 v13, v12, v2
-; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v11, v2, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v13, v5
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v6, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v7
-; GFX9-NEXT:    v_addc_co_u32_e32 v2, vcc, v5, v8, vcc
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v7, v3
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v8, v2
+; GFX9-NEXT:    v_mul_lo_u32 v5, v11, v7
+; GFX9-NEXT:    v_mul_lo_u32 v4, v12, v8
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v11, v8, 0
+; GFX9-NEXT:    v_add3_u32 v13, v3, v5, v4
+; GFX9-NEXT:    v_mul_hi_u32 v14, v8, v2
+; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v8, v13, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v2, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v14, vcc, v14, v3
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v7, v13, 0
 ; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, 0, v4, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v3
+; GFX9-NEXT:    v_add_co_u32_e32 v5, vcc, v14, v5
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v4, v6, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v4, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v13, vcc, v8, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v14, vcc, v7, v3, vcc
+; GFX9-NEXT:    v_mul_lo_u32 v4, v11, v14
+; GFX9-NEXT:    v_mul_lo_u32 v5, v12, v13
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v11, v13, 0
+; GFX9-NEXT:    v_add3_u32 v5, v3, v4, v5
+; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v13, v5, 0
+; GFX9-NEXT:    v_mul_hi_u32 v11, v13, v2
+; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v14, v2, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v14, v5, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v11, v3
 ; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v4, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v12, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v11, v3, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v7
+; GFX9-NEXT:    v_addc_co_u32_e32 v2, vcc, v3, v8, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v6, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v5
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v13, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v14, v3, vcc
 ; GFX9-NEXT:    v_ashrrev_i32_e32 v5, 31, v1
 ; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v5
 ; GFX9-NEXT:    v_xor_b32_e32 v6, v0, v5
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v1, v5, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v3, 0
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v1, v5, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v4, 0
 ; GFX9-NEXT:    v_mul_hi_u32 v7, v6, v2
-; GFX9-NEXT:    v_xor_b32_e32 v4, v4, v5
+; GFX9-NEXT:    v_xor_b32_e32 v8, v3, v5
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v8, v2, 0
 ; GFX9-NEXT:    v_add_co_u32_e32 v7, vcc, v7, v0
-; GFX9-NEXT:    v_addc_co_u32_e32 v8, vcc, 0, v1, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v4, v2, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v3, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v7, v0
-; GFX9-NEXT:    v_addc_co_u32_e32 v0, vcc, v8, v1, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v3, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v11, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v4, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v7, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v2, vcc, v11, v3, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v2, v0
 ; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
 ; GFX9-NEXT:    v_mul_lo_u32 v2, v9, v0
 ; GFX9-NEXT:    v_mul_lo_u32 v3, v10, v1
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v10, v0, 0
 ; GFX9-NEXT:    v_add3_u32 v1, v1, v3, v2
-; GFX9-NEXT:    v_sub_u32_e32 v2, v4, v1
+; GFX9-NEXT:    v_sub_u32_e32 v2, v8, v1
 ; GFX9-NEXT:    v_sub_co_u32_e32 v0, vcc, v6, v0
 ; GFX9-NEXT:    v_subb_co_u32_e64 v2, s[4:5], v2, v9, vcc
 ; GFX9-NEXT:    v_sub_co_u32_e64 v3, s[4:5], v0, v10
-; GFX9-NEXT:    v_subbrev_co_u32_e64 v6, s[6:7], 0, v2, s[4:5]
-; GFX9-NEXT:    v_cmp_ge_u32_e64 s[6:7], v6, v9
-; GFX9-NEXT:    v_cndmask_b32_e64 v7, 0, -1, s[6:7]
+; GFX9-NEXT:    v_subbrev_co_u32_e64 v4, s[6:7], 0, v2, s[4:5]
+; GFX9-NEXT:    v_cmp_ge_u32_e64 s[6:7], v4, v9
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, -1, s[6:7]
 ; GFX9-NEXT:    v_cmp_ge_u32_e64 s[6:7], v3, v10
-; GFX9-NEXT:    v_cndmask_b32_e64 v8, 0, -1, s[6:7]
-; GFX9-NEXT:    v_cmp_eq_u32_e64 s[6:7], v6, v9
+; GFX9-NEXT:    v_cndmask_b32_e64 v7, 0, -1, s[6:7]
+; GFX9-NEXT:    v_cmp_eq_u32_e64 s[6:7], v4, v9
 ; GFX9-NEXT:    v_subb_co_u32_e64 v2, s[4:5], v2, v9, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v7, v7, v8, s[6:7]
-; GFX9-NEXT:    v_sub_co_u32_e64 v8, s[4:5], v3, v10
-; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v4, v1, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v6, v6, v7, s[6:7]
+; GFX9-NEXT:    v_sub_co_u32_e64 v7, s[4:5], v3, v10
 ; GFX9-NEXT:    v_subbrev_co_u32_e64 v2, s[4:5], 0, v2, s[4:5]
+; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v8, v1, vcc
+; GFX9-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v6
 ; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v9
-; GFX9-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v7
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v4, v2, s[4:5]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
 ; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v10
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s[4:5]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v6, 0, -1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v9
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v6, vcc
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v3, v8, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v3, v7, s[4:5]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX9-NEXT:    v_xor_b32_e32 v0, v0, v5
 ; GFX9-NEXT:    v_xor_b32_e32 v1, v1, v5
@@ -426,7 +426,7 @@ define i64 @srem64(i64 %a, i64 %b) {
 ; GFX9-NEXT:    v_sub_u32_e32 v1, v0, v2
 ; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v2
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v0, v1, vcc
-; GFX9-NEXT:  .LBB2_4:
+; GFX9-NEXT:  .LBB2_4: ; %.split
 ; GFX9-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, v5
@@ -448,60 +448,60 @@ define i64 @urem64(i64 %a, i64 %b) {
 ; GFX9-NEXT:  ; %bb.1:
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v4, v2
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v5, v3
-; GFX9-NEXT:    v_sub_co_u32_e32 v10, vcc, 0, v2
-; GFX9-NEXT:    v_subb_co_u32_e32 v11, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_sub_co_u32_e32 v13, vcc, 0, v2
+; GFX9-NEXT:    v_subb_co_u32_e32 v14, vcc, 0, v3, vcc
 ; GFX9-NEXT:    v_madmk_f32 v4, v5, 0x4f800000, v4
 ; GFX9-NEXT:    v_rcp_f32_e32 v4, v4
 ; GFX9-NEXT:    v_mul_f32_e32 v4, 0x5f7ffffc, v4
 ; GFX9-NEXT:    v_mul_f32_e32 v5, 0x2f800000, v4
 ; GFX9-NEXT:    v_trunc_f32_e32 v5, v5
 ; GFX9-NEXT:    v_madmk_f32 v4, v5, 0xcf800000, v4
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v8, v5
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v9, v4
-; GFX9-NEXT:    v_mul_lo_u32 v6, v10, v8
-; GFX9-NEXT:    v_mul_lo_u32 v7, v11, v9
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v10, v9, 0
-; GFX9-NEXT:    v_add3_u32 v7, v5, v6, v7
-; GFX9-NEXT:    v_mul_hi_u32 v12, v9, v4
-; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v9, v7, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v12, v5
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v8, v4, 0
-; GFX9-NEXT:    v_addc_co_u32_e32 v13, vcc, 0, v6, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v8, v7, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v12, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v13, v5, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v7, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v6
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v9, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v13, vcc, v8, v5, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v6, v10, v13
-; GFX9-NEXT:    v_mul_lo_u32 v7, v11, v12
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v10, v12, 0
-; GFX9-NEXT:    v_add3_u32 v7, v5, v6, v7
-; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v13, v7, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v12, v7, 0
-; GFX9-NEXT:    v_mul_hi_u32 v11, v12, v4
-; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v13, v4, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v11, v7
-; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v8, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v9
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v7, v10, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v6, vcc, 0, v6, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v5
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v11, v5
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v12, v4
+; GFX9-NEXT:    v_mul_lo_u32 v6, v13, v11
+; GFX9-NEXT:    v_mul_lo_u32 v7, v14, v12
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v13, v12, 0
+; GFX9-NEXT:    v_add3_u32 v9, v5, v6, v7
+; GFX9-NEXT:    v_mul_hi_u32 v15, v12, v4
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v12, v9, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v11, v4, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v9, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v15, v5
 ; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v6, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v7
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v5, v8, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v10, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v9
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v12, v4
+; GFX9-NEXT:    v_addc_co_u32_e32 v11, vcc, v11, v5, vcc
+; GFX9-NEXT:    v_mul_lo_u32 v6, v13, v11
+; GFX9-NEXT:    v_mul_lo_u32 v7, v14, v12
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v13, v12, 0
+; GFX9-NEXT:    v_add3_u32 v7, v5, v6, v7
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v12, v7, 0
+; GFX9-NEXT:    v_mul_hi_u32 v13, v12, v4
+; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v4, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v11, v7, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v13, v5
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v6, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v9
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v5, v10, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v8, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v7
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v12, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, v13, v5, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, v7, 0
-; GFX9-NEXT:    v_mul_hi_u32 v8, v0, v6
-; GFX9-NEXT:    v_add_co_u32_e32 v8, vcc, v8, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, 0, v5, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v6, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v1, v7, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v8, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v9, v5, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v7, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v6
+; GFX9-NEXT:    v_addc_co_u32_e32 v8, vcc, v11, v5, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, v8, 0
+; GFX9-NEXT:    v_mul_hi_u32 v9, v0, v6
+; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v1, v6, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v9, vcc, v9, v4
+; GFX9-NEXT:    v_addc_co_u32_e32 v10, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v8, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v9, v6
+; GFX9-NEXT:    v_addc_co_u32_e32 v6, vcc, v10, v7, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v6, v4
 ; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
 ; GFX9-NEXT:    v_mul_lo_u32 v6, v3, v4
 ; GFX9-NEXT:    v_mul_lo_u32 v7, v2, v5
@@ -558,7 +558,7 @@ define i64 @urem64(i64 %a, i64 %b) {
 ; GFX9-NEXT:    v_sub_u32_e32 v1, v0, v2
 ; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v2
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v0, v1, vcc
-; GFX9-NEXT:  .LBB3_4:
+; GFX9-NEXT:  .LBB3_4: ; %.split
 ; GFX9-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, v5
@@ -709,97 +709,97 @@ define <2 x i64> @sdivrem64(i64 %a, i64 %b) {
 ; GFX9-NEXT:    v_xor_b32_e32 v11, v2, v9
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v2, v11
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v3, v10
-; GFX9-NEXT:    v_sub_co_u32_e32 v7, vcc, 0, v11
-; GFX9-NEXT:    v_subb_co_u32_e32 v8, vcc, 0, v10, vcc
+; GFX9-NEXT:    v_sub_co_u32_e32 v12, vcc, 0, v11
+; GFX9-NEXT:    v_subb_co_u32_e32 v13, vcc, 0, v10, vcc
 ; GFX9-NEXT:    v_madmk_f32 v2, v3, 0x4f800000, v2
 ; GFX9-NEXT:    v_rcp_f32_e32 v2, v2
 ; GFX9-NEXT:    v_mul_f32_e32 v2, 0x5f7ffffc, v2
 ; GFX9-NEXT:    v_mul_f32_e32 v3, 0x2f800000, v2
 ; GFX9-NEXT:    v_trunc_f32_e32 v3, v3
 ; GFX9-NEXT:    v_madmk_f32 v2, v3, 0xcf800000, v2
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v6, v2
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v12, v3
-; GFX9-NEXT:    v_mul_lo_u32 v4, v8, v6
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v7, v6, 0
-; GFX9-NEXT:    v_mul_lo_u32 v5, v7, v12
-; GFX9-NEXT:    v_mul_hi_u32 v13, v6, v2
-; GFX9-NEXT:    v_add3_u32 v5, v3, v5, v4
-; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v6, v5, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v13, vcc, v13, v3
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v12, v2, 0
-; GFX9-NEXT:    v_addc_co_u32_e32 v14, vcc, 0, v4, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v12, v5, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v13, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v2, vcc, v14, v3, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v5, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v3, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v13, vcc, v6, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v12, vcc, v12, v3, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v4, v7, v12
-; GFX9-NEXT:    v_mul_lo_u32 v5, v8, v13
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v7, v13, 0
-; GFX9-NEXT:    v_add3_u32 v5, v3, v4, v5
-; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v12, v5, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v13, v5, 0
-; GFX9-NEXT:    v_mul_hi_u32 v14, v13, v2
-; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v12, v2, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v14, v5
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v6, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v7
-; GFX9-NEXT:    v_addc_co_u32_e32 v2, vcc, v5, v8, vcc
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v7, v3
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v8, v2
+; GFX9-NEXT:    v_mul_lo_u32 v5, v12, v7
+; GFX9-NEXT:    v_mul_lo_u32 v4, v13, v8
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v12, v8, 0
+; GFX9-NEXT:    v_add3_u32 v14, v3, v5, v4
+; GFX9-NEXT:    v_mul_hi_u32 v15, v8, v2
+; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v8, v14, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v2, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v15, vcc, v15, v3
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v7, v14, 0
 ; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, 0, v4, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v3
+; GFX9-NEXT:    v_add_co_u32_e32 v5, vcc, v15, v5
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v4, v6, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v4, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v14, vcc, v8, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v15, vcc, v7, v3, vcc
+; GFX9-NEXT:    v_mul_lo_u32 v4, v12, v15
+; GFX9-NEXT:    v_mul_lo_u32 v5, v13, v14
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v12, v14, 0
+; GFX9-NEXT:    v_add3_u32 v5, v3, v4, v5
+; GFX9-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v14, v5, 0
+; GFX9-NEXT:    v_mul_hi_u32 v12, v14, v2
+; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v15, v2, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v15, v5, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v12, v3
 ; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v4, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v13, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v12, v3, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v7
+; GFX9-NEXT:    v_addc_co_u32_e32 v2, vcc, v3, v8, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v6, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v5
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v14, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v15, v3, vcc
 ; GFX9-NEXT:    v_ashrrev_i32_e32 v7, 31, v1
 ; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v0, v7
 ; GFX9-NEXT:    v_xor_b32_e32 v5, v0, v7
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v1, v7, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v3, 0
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v1, v7, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v4, 0
 ; GFX9-NEXT:    v_mul_hi_u32 v6, v5, v2
-; GFX9-NEXT:    v_xor_b32_e32 v4, v4, v7
+; GFX9-NEXT:    v_xor_b32_e32 v8, v3, v7
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v8, v2, 0
 ; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v6, v0
-; GFX9-NEXT:    v_addc_co_u32_e32 v8, vcc, 0, v1, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v4, v2, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v3, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, v6, v0
-; GFX9-NEXT:    v_addc_co_u32_e32 v0, vcc, v8, v1, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v3, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v0, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v12, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v4, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v6, v2
+; GFX9-NEXT:    v_addc_co_u32_e32 v2, vcc, v12, v3, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v0
 ; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v1, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v6, v10, v2
-; GFX9-NEXT:    v_mul_lo_u32 v8, v11, v3
+; GFX9-NEXT:    v_mul_lo_u32 v4, v10, v2
+; GFX9-NEXT:    v_mul_lo_u32 v6, v11, v3
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v11, v2, 0
-; GFX9-NEXT:    v_add3_u32 v1, v1, v8, v6
-; GFX9-NEXT:    v_sub_u32_e32 v6, v4, v1
+; GFX9-NEXT:    v_add3_u32 v1, v1, v6, v4
+; GFX9-NEXT:    v_sub_u32_e32 v4, v8, v1
 ; GFX9-NEXT:    v_sub_co_u32_e32 v0, vcc, v5, v0
-; GFX9-NEXT:    v_subb_co_u32_e64 v6, s[4:5], v6, v10, vcc
-; GFX9-NEXT:    v_sub_co_u32_e64 v8, s[4:5], v0, v11
-; GFX9-NEXT:    v_subbrev_co_u32_e64 v12, s[6:7], 0, v6, s[4:5]
-; GFX9-NEXT:    v_cmp_ge_u32_e64 s[6:7], v12, v10
+; GFX9-NEXT:    v_subb_co_u32_e64 v6, s[4:5], v4, v10, vcc
+; GFX9-NEXT:    v_sub_co_u32_e64 v12, s[4:5], v0, v11
+; GFX9-NEXT:    v_subbrev_co_u32_e64 v13, s[6:7], 0, v6, s[4:5]
+; GFX9-NEXT:    v_cmp_ge_u32_e64 s[6:7], v13, v10
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, -1, s[6:7]
+; GFX9-NEXT:    v_cmp_ge_u32_e64 s[6:7], v12, v11
 ; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, -1, s[6:7]
-; GFX9-NEXT:    v_cmp_ge_u32_e64 s[6:7], v8, v11
-; GFX9-NEXT:    v_cndmask_b32_e64 v13, 0, -1, s[6:7]
-; GFX9-NEXT:    v_cmp_eq_u32_e64 s[6:7], v12, v10
-; GFX9-NEXT:    v_cndmask_b32_e64 v5, v5, v13, s[6:7]
-; GFX9-NEXT:    v_add_co_u32_e64 v13, s[6:7], 2, v2
+; GFX9-NEXT:    v_cmp_eq_u32_e64 s[6:7], v13, v10
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, v5, s[6:7]
+; GFX9-NEXT:    v_add_co_u32_e64 v5, s[6:7], 2, v2
 ; GFX9-NEXT:    v_addc_co_u32_e64 v14, s[6:7], 0, v3, s[6:7]
 ; GFX9-NEXT:    v_add_co_u32_e64 v15, s[6:7], 1, v2
-; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v4, v1, vcc
+; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v8, v1, vcc
 ; GFX9-NEXT:    v_addc_co_u32_e64 v16, s[6:7], 0, v3, s[6:7]
 ; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v10
-; GFX9-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v5
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
+; GFX9-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v4
+; GFX9-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v11
-; GFX9-NEXT:    v_cndmask_b32_e64 v5, v16, v14, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, v16, v14, s[6:7]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v14, 0, -1, vcc
 ; GFX9-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v10
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v14, vcc
-; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v15, v13, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v8, v8, v14, vcc
+; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v3, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, v15, v5, s[6:7]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
 ; GFX9-NEXT:    v_xor_b32_e32 v5, v7, v9
 ; GFX9-NEXT:    v_xor_b32_e32 v2, v2, v5
@@ -807,11 +807,11 @@ define <2 x i64> @sdivrem64(i64 %a, i64 %b) {
 ; GFX9-NEXT:    v_sub_co_u32_e64 v4, s[8:9], v2, v5
 ; GFX9-NEXT:    v_subb_co_u32_e64 v2, s[4:5], v6, v10, s[4:5]
 ; GFX9-NEXT:    v_subb_co_u32_e64 v5, s[8:9], v3, v5, s[8:9]
-; GFX9-NEXT:    v_sub_co_u32_e64 v3, s[4:5], v8, v11
+; GFX9-NEXT:    v_sub_co_u32_e64 v3, s[4:5], v12, v11
 ; GFX9-NEXT:    v_subbrev_co_u32_e64 v2, s[4:5], 0, v2, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v12, v2, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v13, v2, s[6:7]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v2, v8, v3, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v12, v3, s[6:7]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; GFX9-NEXT:    v_xor_b32_e32 v0, v0, v7
 ; GFX9-NEXT:    v_xor_b32_e32 v1, v1, v7
@@ -846,7 +846,7 @@ define <2 x i64> @sdivrem64(i64 %a, i64 %b) {
 ; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v2
 ; GFX9-NEXT:    v_cndmask_b32_e32 v6, v0, v3, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v1, v4, vcc
-; GFX9-NEXT:  .LBB8_4:
+; GFX9-NEXT:  .LBB8_4: ; %.split
 ; GFX9-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, v5
@@ -874,60 +874,60 @@ define <2 x i64> @udivrem64(i64 %a, i64 %b) {
 ; GFX9-NEXT:  ; %bb.1:
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v4, v2
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v5, v3
-; GFX9-NEXT:    v_sub_co_u32_e32 v10, vcc, 0, v2
-; GFX9-NEXT:    v_subb_co_u32_e32 v11, vcc, 0, v3, vcc
+; GFX9-NEXT:    v_sub_co_u32_e32 v13, vcc, 0, v2
+; GFX9-NEXT:    v_subb_co_u32_e32 v14, vcc, 0, v3, vcc
 ; GFX9-NEXT:    v_madmk_f32 v4, v5, 0x4f800000, v4
 ; GFX9-NEXT:    v_rcp_f32_e32 v4, v4
 ; GFX9-NEXT:    v_mul_f32_e32 v4, 0x5f7ffffc, v4
 ; GFX9-NEXT:    v_mul_f32_e32 v5, 0x2f800000, v4
 ; GFX9-NEXT:    v_trunc_f32_e32 v5, v5
 ; GFX9-NEXT:    v_madmk_f32 v4, v5, 0xcf800000, v4
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v8, v5
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v9, v4
-; GFX9-NEXT:    v_mul_lo_u32 v6, v10, v8
-; GFX9-NEXT:    v_mul_lo_u32 v7, v11, v9
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v10, v9, 0
-; GFX9-NEXT:    v_add3_u32 v7, v5, v6, v7
-; GFX9-NEXT:    v_mul_hi_u32 v12, v9, v4
-; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v9, v7, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v12, v5
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v8, v4, 0
-; GFX9-NEXT:    v_addc_co_u32_e32 v13, vcc, 0, v6, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v8, v7, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v12, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v13, v5, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v7, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v6
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v9, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v13, vcc, v8, v5, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v6, v10, v13
-; GFX9-NEXT:    v_mul_lo_u32 v7, v11, v12
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v10, v12, 0
-; GFX9-NEXT:    v_add3_u32 v7, v5, v6, v7
-; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v13, v7, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v12, v7, 0
-; GFX9-NEXT:    v_mul_hi_u32 v11, v12, v4
-; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v13, v4, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v11, v7
-; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v8, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v9
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v7, v10, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v6, vcc, 0, v6, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v5
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v11, v5
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v12, v4
+; GFX9-NEXT:    v_mul_lo_u32 v6, v13, v11
+; GFX9-NEXT:    v_mul_lo_u32 v7, v14, v12
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v13, v12, 0
+; GFX9-NEXT:    v_add3_u32 v9, v5, v6, v7
+; GFX9-NEXT:    v_mul_hi_u32 v15, v12, v4
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v12, v9, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v11, v4, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v9, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v15, v5
 ; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v6, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v7
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v5, v8, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v10, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v9
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v12, v4
+; GFX9-NEXT:    v_addc_co_u32_e32 v11, vcc, v11, v5, vcc
+; GFX9-NEXT:    v_mul_lo_u32 v6, v13, v11
+; GFX9-NEXT:    v_mul_lo_u32 v7, v14, v12
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v13, v12, 0
+; GFX9-NEXT:    v_add3_u32 v7, v5, v6, v7
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v12, v7, 0
+; GFX9-NEXT:    v_mul_hi_u32 v13, v12, v4
+; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v4, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v11, v7, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v13, v5
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v6, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v9
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v5, v10, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v8, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v7
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v12, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, v13, v5, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, v7, 0
-; GFX9-NEXT:    v_mul_hi_u32 v8, v0, v6
-; GFX9-NEXT:    v_add_co_u32_e32 v8, vcc, v8, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, 0, v5, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v6, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v1, v7, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v8, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v9, v5, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v7, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v4, v6
+; GFX9-NEXT:    v_addc_co_u32_e32 v8, vcc, v11, v5, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, v8, 0
+; GFX9-NEXT:    v_mul_hi_u32 v9, v0, v6
+; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v1, v6, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v9, vcc, v9, v4
+; GFX9-NEXT:    v_addc_co_u32_e32 v10, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v8, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v9, v6
+; GFX9-NEXT:    v_addc_co_u32_e32 v6, vcc, v10, v7, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v6, v4
 ; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v5, vcc
 ; GFX9-NEXT:    v_mul_lo_u32 v8, v3, v6
 ; GFX9-NEXT:    v_mul_lo_u32 v9, v2, v7
@@ -997,7 +997,7 @@ define <2 x i64> @udivrem64(i64 %a, i64 %b) {
 ; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v2
 ; GFX9-NEXT:    v_cndmask_b32_e32 v6, v0, v3, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v1, v4, vcc
-; GFX9-NEXT:  .LBB9_4:
+; GFX9-NEXT:  .LBB9_4: ; %.split
 ; GFX9-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, v5
@@ -1026,60 +1026,60 @@ define i64 @sdiv64_known32(i64 %a, i64 %b) {
 ; GFX9-NEXT:  ; %bb.1:
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v4, v3
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v5, v0
-; GFX9-NEXT:    v_sub_co_u32_e32 v10, vcc, 0, v3
-; GFX9-NEXT:    v_subb_co_u32_e32 v11, vcc, 0, v0, vcc
+; GFX9-NEXT:    v_sub_co_u32_e32 v13, vcc, 0, v3
+; GFX9-NEXT:    v_subb_co_u32_e32 v14, vcc, 0, v0, vcc
 ; GFX9-NEXT:    v_madmk_f32 v4, v5, 0x4f800000, v4
 ; GFX9-NEXT:    v_rcp_f32_e32 v4, v4
 ; GFX9-NEXT:    v_mul_f32_e32 v4, 0x5f7ffffc, v4
 ; GFX9-NEXT:    v_mul_f32_e32 v5, 0x2f800000, v4
 ; GFX9-NEXT:    v_trunc_f32_e32 v5, v5
 ; GFX9-NEXT:    v_madmk_f32 v4, v5, 0xcf800000, v4
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v8, v5
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v9, v4
-; GFX9-NEXT:    v_mul_lo_u32 v6, v10, v8
-; GFX9-NEXT:    v_mul_lo_u32 v7, v11, v9
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v10, v9, 0
-; GFX9-NEXT:    v_add3_u32 v7, v5, v6, v7
-; GFX9-NEXT:    v_mul_hi_u32 v12, v9, v4
-; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v9, v7, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v12, v5
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v8, v4, 0
-; GFX9-NEXT:    v_addc_co_u32_e32 v13, vcc, 0, v6, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v8, v7, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v12, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v13, v5, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v7, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v6
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v9, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v13, vcc, v8, v5, vcc
-; GFX9-NEXT:    v_mul_lo_u32 v6, v10, v13
-; GFX9-NEXT:    v_mul_lo_u32 v7, v11, v12
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v10, v12, 0
-; GFX9-NEXT:    v_add3_u32 v7, v5, v6, v7
-; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v13, v7, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v12, v7, 0
-; GFX9-NEXT:    v_mul_hi_u32 v11, v12, v4
-; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v13, v4, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v11, v7
-; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v8, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v9
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v7, v10, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v6, vcc, 0, v6, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v5
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v11, v5
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v12, v4
+; GFX9-NEXT:    v_mul_lo_u32 v6, v13, v11
+; GFX9-NEXT:    v_mul_lo_u32 v7, v14, v12
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v13, v12, 0
+; GFX9-NEXT:    v_add3_u32 v9, v5, v6, v7
+; GFX9-NEXT:    v_mul_hi_u32 v15, v12, v4
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v12, v9, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v11, v4, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v9, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v15, v5
 ; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v6, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v7
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v5, v8, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v10, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v9
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v12, v4
+; GFX9-NEXT:    v_addc_co_u32_e32 v11, vcc, v11, v5, vcc
+; GFX9-NEXT:    v_mul_lo_u32 v6, v13, v11
+; GFX9-NEXT:    v_mul_lo_u32 v7, v14, v12
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v13, v12, 0
+; GFX9-NEXT:    v_add3_u32 v7, v5, v6, v7
+; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v12, v7, 0
+; GFX9-NEXT:    v_mul_hi_u32 v13, v12, v4
+; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v4, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v11, v7, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v13, v5
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v6, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v9
+; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v5, v10, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v8, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v7
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v12, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, v13, v5, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v7, 0
-; GFX9-NEXT:    v_mul_hi_u32 v8, v1, v6
-; GFX9-NEXT:    v_add_co_u32_e32 v8, vcc, v8, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v9, vcc, 0, v5, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v6, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v2, v7, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v8, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v9, v5, vcc
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v7, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v4, v6
+; GFX9-NEXT:    v_addc_co_u32_e32 v8, vcc, v11, v5, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v8, 0
+; GFX9-NEXT:    v_mul_hi_u32 v9, v1, v6
+; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v2, v6, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v9, vcc, v9, v4
+; GFX9-NEXT:    v_addc_co_u32_e32 v10, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v8, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v9, v6
+; GFX9-NEXT:    v_addc_co_u32_e32 v6, vcc, v10, v7, vcc
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v5, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v6, v4
 ; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v5, vcc
 ; GFX9-NEXT:    v_mul_lo_u32 v8, v0, v6
 ; GFX9-NEXT:    v_mul_lo_u32 v9, v3, v7
@@ -1139,7 +1139,7 @@ define i64 @sdiv64_known32(i64 %a, i64 %b) {
 ; GFX9-NEXT:    v_add_u32_e32 v2, 1, v0
 ; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v3
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v0, v2, vcc
-; GFX9-NEXT:  .LBB10_4:
+; GFX9-NEXT:  .LBB10_4: ; %.split
 ; GFX9-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, v5

--- a/llvm/test/CodeGen/AMDGPU/carryout-selection.ll
+++ b/llvm/test/CodeGen/AMDGPU/carryout-selection.ll
@@ -11,10 +11,6 @@
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 < %s | FileCheck -enable-var-scope -check-prefixes=GFX11 %s
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 < %s | FileCheck -enable-var-scope -check-prefixes=GFX1250 %s
 
-; GCN-ISEL-LABEL: name:   sadd64rr
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0.entry:
-; GCN-ISEL: S_ADD_U64_PSEUDO
 
 define amdgpu_kernel void @sadd64rr(ptr addrspace(1) %out, i64 %a, i64 %b) {
 ; CISI-LABEL: sadd64rr:
@@ -117,7 +113,7 @@ define amdgpu_kernel void @sadd64rr(ptr addrspace(1) %out, i64 %a, i64 %b) {
 ;
 ; GFX1250-LABEL: sadd64rr:
 ; GFX1250:       ; %bb.0: ; %entry
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_clause 0x1
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
 ; GFX1250-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34 nv
@@ -128,16 +124,36 @@ define amdgpu_kernel void @sadd64rr(ptr addrspace(1) %out, i64 %a, i64 %b) {
 ; GFX1250-NEXT:    v_mov_b64_e32 v[0:1], s[2:3]
 ; GFX1250-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: sadd64rr
+; GCN-ISEL: bb.0.entry:
+; GCN-ISEL-NEXT:   liveins: $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX4_IMM:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s128) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 13, 0 :: (dereferenceable invariant load (s64) from %ir.out.kernarg.offset + 16, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub0
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY6]], %subreg.sub0, killed [[COPY5]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub1
+; GCN-ISEL-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY8]], %subreg.sub0, killed [[COPY7]], %subreg.sub1, killed [[S_MOV_B32_1]], %subreg.sub2, killed [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY4]], %subreg.sub0, killed [[COPY3]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY2]], %subreg.sub0, killed [[COPY1]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_ADD_U:%[0-9]+]]:sreg_64 = S_ADD_U64_PSEUDO killed [[REG_SEQUENCE2]], killed [[REG_SEQUENCE3]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY9:%[0-9]+]]:vreg_64 = COPY [[S_ADD_U]]
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORDX2_OFFSET killed [[COPY9]], killed [[REG_SEQUENCE1]], 0, 0, 0, 0, implicit $exec :: (store (s64) into %ir.1, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
 entry:
   %add = add i64 %a, %b
   store i64 %add, ptr addrspace(1) %out
   ret void
 }
-
-; GCN-ISEL-LABEL: name:   sadd64ri
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0.entry:
-; GCN-ISEL: S_ADD_U64_PSEUDO
 
 define amdgpu_kernel void @sadd64ri(ptr addrspace(1) %out, i64 %a) {
 ; CISI-LABEL: sadd64ri:
@@ -229,7 +245,7 @@ define amdgpu_kernel void @sadd64ri(ptr addrspace(1) %out, i64 %a) {
 ;
 ; GFX1250-LABEL: sadd64ri:
 ; GFX1250:       ; %bb.0: ; %entry
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
 ; GFX1250-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
@@ -238,16 +254,35 @@ define amdgpu_kernel void @sadd64ri(ptr addrspace(1) %out, i64 %a) {
 ; GFX1250-NEXT:    v_mov_b64_e32 v[0:1], s[2:3]
 ; GFX1250-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: sadd64ri
+; GCN-ISEL: bb.0.entry:
+; GCN-ISEL-NEXT:   liveins: $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX4_IMM:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s128) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY2]], %subreg.sub0, killed [[COPY1]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub1
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY4]], %subreg.sub0, killed [[COPY3]], %subreg.sub1, killed [[S_MOV_B32_1]], %subreg.sub2, killed [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+; GCN-ISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY6]], %subreg.sub0, killed [[COPY5]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 4660
+; GCN-ISEL-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 1450743926
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_MOV_B32_3]], %subreg.sub0, killed [[S_MOV_B32_2]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_ADD_U:%[0-9]+]]:sreg_64 = S_ADD_U64_PSEUDO killed [[REG_SEQUENCE2]], killed [[REG_SEQUENCE3]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY7:%[0-9]+]]:vreg_64 = COPY [[S_ADD_U]]
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORDX2_OFFSET killed [[COPY7]], killed [[REG_SEQUENCE1]], 0, 0, 0, 0, implicit $exec :: (store (s64) into %ir.1, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
 entry:
   %add = add i64 20015998343286, %a
   store i64 %add, ptr addrspace(1) %out
   ret void
 }
-
-; GCN-ISEL-LABEL: name:   vadd64rr
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0.entry:
-; GCN-ISEL: V_ADD_U64_PSEUDO
 
 define amdgpu_kernel void @vadd64rr(ptr addrspace(1) %out, i64 %a) {
 ; CISI-LABEL: vadd64rr:
@@ -331,7 +366,7 @@ define amdgpu_kernel void @vadd64rr(ptr addrspace(1) %out, i64 %a) {
 ;
 ; GFX1250-LABEL: vadd64rr:
 ; GFX1250:       ; %bb.0: ; %entry
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX1250-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
@@ -340,6 +375,29 @@ define amdgpu_kernel void @vadd64rr(ptr addrspace(1) %out, i64 %a) {
 ; GFX1250-NEXT:    v_add_nc_u64_e32 v[2:3], s[2:3], v[0:1]
 ; GFX1250-NEXT:    global_store_b64 v1, v[2:3], s[0:1]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: vadd64rr
+; GCN-ISEL: bb.0.entry:
+; GCN-ISEL-NEXT:   liveins: $vgpr0, $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32(s32) = COPY $vgpr0
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX4_IMM:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s128) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY3]], %subreg.sub0, killed [[COPY2]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub1
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY5]], %subreg.sub0, killed [[COPY4]], %subreg.sub1, killed [[S_MOV_B32_1]], %subreg.sub2, killed [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+; GCN-ISEL-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY7]], %subreg.sub0, killed [[COPY6]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY1]](s32), %subreg.sub0, killed [[V_MOV_B32_e32_]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[V_ADD_U:%[0-9]+]]:vreg_64 = V_ADD_U64_PSEUDO killed [[REG_SEQUENCE2]], killed [[REG_SEQUENCE3]], implicit-def dead $vcc, implicit $exec
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORDX2_OFFSET killed [[V_ADD_U]], killed [[REG_SEQUENCE1]], 0, 0, 0, 0, implicit $exec :: (store (s64) into %ir.1, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
 entry:
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid.ext = sext i32 %tid to i64
@@ -347,11 +405,6 @@ entry:
   store i64 %add, ptr addrspace(1) %out
   ret void
 }
-
-; GCN-ISEL-LABEL: name:   vadd64ri
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0.entry:
-; GCN-ISEL: V_ADD_U64_PSEUDO
 
 define amdgpu_kernel void @vadd64ri(ptr addrspace(1) %out) {
 ; CISI-LABEL: vadd64ri:
@@ -433,7 +486,7 @@ define amdgpu_kernel void @vadd64ri(ptr addrspace(1) %out) {
 ;
 ; GFX1250-LABEL: vadd64ri:
 ; GFX1250:       ; %bb.0: ; %entry
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX1250-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
@@ -442,6 +495,26 @@ define amdgpu_kernel void @vadd64ri(ptr addrspace(1) %out) {
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    global_store_b64 v1, v[2:3], s[0:1]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: vadd64ri
+; GCN-ISEL: bb.0.entry:
+; GCN-ISEL-NEXT:   liveins: $vgpr0, $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32(s32) = COPY $vgpr0
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s64) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY3]], %subreg.sub0, killed [[COPY2]], %subreg.sub1, killed [[S_MOV_B32_1]], %subreg.sub2, killed [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY1]](s32), %subreg.sub0, killed [[V_MOV_B32_e32_]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 4660
+; GCN-ISEL-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 1450743926
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_MOV_B32_3]], %subreg.sub0, killed [[S_MOV_B32_2]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[V_ADD_U:%[0-9]+]]:vreg_64 = V_ADD_U64_PSEUDO killed [[REG_SEQUENCE1]], killed [[REG_SEQUENCE2]], implicit-def dead $vcc, implicit $exec
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORDX2_OFFSET killed [[V_ADD_U]], killed [[REG_SEQUENCE]], 0, 0, 0, 0, implicit $exec :: (store (s64) into %ir.out.load, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
 entry:
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid.ext = sext i32 %tid to i64
@@ -450,10 +523,6 @@ entry:
   ret void
 }
 
-; GCN-ISEL-LABEL: name:   suaddo32
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0
-; GCN-ISEL: S_ADD_I32
 define amdgpu_kernel void @suaddo32(ptr addrspace(1) %out, ptr addrspace(1) %carryout, i32 %a, i32 %b) #0 {
 ; CISI-LABEL: suaddo32:
 ; CISI:       ; %bb.0:
@@ -540,7 +609,7 @@ define amdgpu_kernel void @suaddo32(ptr addrspace(1) %out, ptr addrspace(1) %car
 ;
 ; GFX1250-LABEL: suaddo32:
 ; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_clause 0x1
 ; GFX1250-NEXT:    s_load_b64 s[0:1], s[4:5], 0x34 nv
 ; GFX1250-NEXT:    s_load_b64 s[2:3], s[4:5], 0x24 nv
@@ -550,18 +619,30 @@ define amdgpu_kernel void @suaddo32(ptr addrspace(1) %out, ptr addrspace(1) %car
 ; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s0
 ; GFX1250-NEXT:    global_store_b32 v0, v1, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: suaddo32
+; GCN-ISEL: bb.0 (%ir-block.0):
+; GCN-ISEL-NEXT:   liveins: $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s64) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX2_IMM1:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 13, 0 :: (dereferenceable invariant load (s64) from %ir.a.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY2]], %subreg.sub0, killed [[COPY1]], %subreg.sub1, killed [[S_MOV_B32_1]], %subreg.sub2, killed [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM1]].sub0
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM1]].sub1
+; GCN-ISEL-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = S_ADD_I32 killed [[COPY3]], killed [[COPY4]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:vgpr_32 = COPY [[S_ADD_I32_]]
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORD_OFFSET killed [[COPY5]], killed [[REG_SEQUENCE]], 0, 0, 0, 0, implicit $exec :: (store (s32) into %ir.out.load, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
   %uadd = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
   %val = extractvalue { i32, i1 } %uadd, 0
   %carry = extractvalue { i32, i1 } %uadd, 1
   store i32 %val, ptr addrspace(1) %out, align 4
   ret void
 }
-
-
-; GCN-ISEL-LABEL: name:   uaddo32_vcc_user
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0
-; GCN-ISEL: V_ADD_CO_U32_e64
 
 ; below we check selection to v_add/addc
 ; because the only user of VCC produced by the UADDOis v_cndmask.
@@ -673,7 +754,7 @@ define amdgpu_kernel void @uaddo32_vcc_user(ptr addrspace(1) %out, ptr addrspace
 ;
 ; GFX1250-LABEL: uaddo32_vcc_user:
 ; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_clause 0x1
 ; GFX1250-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34 nv
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
@@ -686,6 +767,35 @@ define amdgpu_kernel void @uaddo32_vcc_user(ptr addrspace(1) %out, ptr addrspace
 ; GFX1250-NEXT:    global_store_b32 v0, v1, s[0:1]
 ; GFX1250-NEXT:    global_store_b8 v0, v2, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: uaddo32_vcc_user
+; GCN-ISEL: bb.0 (%ir-block.0):
+; GCN-ISEL-NEXT:   liveins: $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX4_IMM:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s128) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 13, 0 :: (dereferenceable invariant load (s64) from %ir.a.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY2]], %subreg.sub0, killed [[COPY1]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub1
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY4]], %subreg.sub0, killed [[COPY3]], %subreg.sub1, [[S_MOV_B32_1]], %subreg.sub2, [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+; GCN-ISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY6]], %subreg.sub0, killed [[COPY5]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE2]].sub1
+; GCN-ISEL-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE2]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY8]], %subreg.sub0, killed [[COPY7]], %subreg.sub1, [[S_MOV_B32_1]], %subreg.sub2, [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub0
+; GCN-ISEL-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY killed [[COPY10]]
+; GCN-ISEL-NEXT:   [[V_ADD_CO_U32_e64_:%[0-9]+]]:vgpr_32, [[V_ADD_CO_U32_e64_1:%[0-9]+]]:sreg_64_xexec = V_ADD_CO_U32_e64 killed [[COPY9]], [[COPY11]], 0, implicit $exec
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORD_OFFSET killed [[V_ADD_CO_U32_e64_]], killed [[REG_SEQUENCE1]], 0, 0, 0, 0, implicit $exec :: (store (s32) into %ir.2, addrspace 1)
+; GCN-ISEL-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, killed [[V_ADD_CO_U32_e64_1]], implicit $exec
+; GCN-ISEL-NEXT:   BUFFER_STORE_BYTE_OFFSET killed [[V_CNDMASK_B32_e64_]], killed [[REG_SEQUENCE3]], 0, 0, 0, 0, implicit $exec :: (store (s8) into %ir.3, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
   %uadd = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
   %val = extractvalue { i32, i1 } %uadd, 0
   %carry = extractvalue { i32, i1 } %uadd, 1
@@ -693,12 +803,6 @@ define amdgpu_kernel void @uaddo32_vcc_user(ptr addrspace(1) %out, ptr addrspace
   store i1 %carry, ptr addrspace(1) %carryout
   ret void
 }
-
-; GCN-ISEL-LABEL: name:   suaddo64
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0
-; GCN-ISEL: S_UADDO_PSEUDO
-; GCN-ISEL: S_ADD_CO_PSEUDO
 
 define amdgpu_kernel void @suaddo64(ptr addrspace(1) %out, ptr addrspace(1) %carryout, i64 %a, i64 %b) #0 {
 ; CISI-LABEL: suaddo64:
@@ -819,7 +923,7 @@ define amdgpu_kernel void @suaddo64(ptr addrspace(1) %out, ptr addrspace(1) %car
 ;
 ; GFX1250-LABEL: suaddo64:
 ; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_load_b256 s[8:15], s[4:5], 0x24 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    s_add_co_u32 s0, s12, s14
@@ -832,6 +936,38 @@ define amdgpu_kernel void @suaddo64(ptr addrspace(1) %out, ptr addrspace(1) %car
 ; GFX1250-NEXT:    global_store_b64 v2, v[0:1], s[8:9]
 ; GFX1250-NEXT:    global_store_b8 v2, v3, s[10:11]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: suaddo64
+; GCN-ISEL: bb.0 (%ir-block.0):
+; GCN-ISEL-NEXT:   liveins: $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX8_IMM:%[0-9]+]]:sgpr_256 = S_LOAD_DWORDX8_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s256) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY2]], %subreg.sub0, killed [[COPY1]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub1
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY4]], %subreg.sub0, killed [[COPY3]], %subreg.sub1, [[S_MOV_B32_1]], %subreg.sub2, [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub3
+; GCN-ISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub2
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY6]], %subreg.sub0, killed [[COPY5]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE2]].sub1
+; GCN-ISEL-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE2]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY8]], %subreg.sub0, killed [[COPY7]], %subreg.sub1, [[S_MOV_B32_1]], %subreg.sub2, [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub5
+; GCN-ISEL-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub4
+; GCN-ISEL-NEXT:   [[COPY11:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub7
+; GCN-ISEL-NEXT:   [[COPY12:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub6
+; GCN-ISEL-NEXT:   [[S_UADDO:%[0-9]+]]:sreg_32, [[S_UADDO1:%[0-9]+]]:sreg_64_xexec = S_UADDO_PSEUDO killed [[COPY10]], killed [[COPY12]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[S_ADD_C:%[0-9]+]]:sreg_32, [[S_ADD_C1:%[0-9]+]]:sreg_64_xexec = S_ADD_CO_PSEUDO killed [[COPY9]], killed [[COPY11]], killed [[S_UADDO1]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE4:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_UADDO]], %subreg.sub0, killed [[S_ADD_C]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY13:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE4]]
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORDX2_OFFSET killed [[COPY13]], killed [[REG_SEQUENCE1]], 0, 0, 0, 0, implicit $exec :: (store (s64) into %ir.2, addrspace 1)
+; GCN-ISEL-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, killed [[S_ADD_C1]], implicit $exec
+; GCN-ISEL-NEXT:   BUFFER_STORE_BYTE_OFFSET killed [[V_CNDMASK_B32_e64_]], killed [[REG_SEQUENCE3]], 0, 0, 0, 0, implicit $exec :: (store (s8) into %ir.3, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
   %uadd = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
   %val = extractvalue { i64, i1 } %uadd, 0
   %carry = extractvalue { i64, i1 } %uadd, 1
@@ -839,12 +975,6 @@ define amdgpu_kernel void @suaddo64(ptr addrspace(1) %out, ptr addrspace(1) %car
   store i1 %carry, ptr addrspace(1) %carryout
   ret void
 }
-
-; GCN-ISEL-LABEL: name:   vuaddo64
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0
-; GCN-ISEL: V_ADD_CO_U32_e64
-; GCN-ISEL: V_ADDC_U32_e64
 
 define amdgpu_kernel void @vuaddo64(ptr addrspace(1) %out, ptr addrspace(1) %carryout, i64 %a) #0 {
 ; CISI-LABEL: vuaddo64:
@@ -962,7 +1092,7 @@ define amdgpu_kernel void @vuaddo64(ptr addrspace(1) %out, ptr addrspace(1) %car
 ;
 ; GFX1250-LABEL: vuaddo64:
 ; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_clause 0x1
 ; GFX1250-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34 nv
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
@@ -978,6 +1108,40 @@ define amdgpu_kernel void @vuaddo64(ptr addrspace(1) %out, ptr addrspace(1) %car
 ; GFX1250-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
 ; GFX1250-NEXT:    global_store_b8 v2, v3, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: vuaddo64
+; GCN-ISEL: bb.0 (%ir-block.0):
+; GCN-ISEL-NEXT:   liveins: $vgpr0, $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32(s32) = COPY $vgpr0
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX4_IMM:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s128) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 13, 0 :: (dereferenceable invariant load (s64) from %ir.out.kernarg.offset + 16, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub0
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+; GCN-ISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY7]], %subreg.sub0, killed [[COPY6]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub1
+; GCN-ISEL-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, [[S_MOV_B32_1]], %subreg.sub2, [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY5]], %subreg.sub0, killed [[COPY4]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE2]].sub1
+; GCN-ISEL-NEXT:   [[COPY11:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE2]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, [[S_MOV_B32_1]], %subreg.sub2, [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[V_ADD_CO_U32_e64_:%[0-9]+]]:vgpr_32, [[V_ADD_CO_U32_e64_1:%[0-9]+]]:sreg_64_xexec = V_ADD_CO_U32_e64 killed [[COPY3]], [[COPY1]](s32), 0, implicit $exec
+; GCN-ISEL-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
+; GCN-ISEL-NEXT:   [[COPY12:%[0-9]+]]:vgpr_32 = COPY killed [[COPY2]]
+; GCN-ISEL-NEXT:   [[COPY13:%[0-9]+]]:vgpr_32 = COPY killed [[S_MOV_B32_2]]
+; GCN-ISEL-NEXT:   [[V_ADDC_U32_e64_:%[0-9]+]]:vgpr_32, [[V_ADDC_U32_e64_1:%[0-9]+]]:sreg_64_xexec = V_ADDC_U32_e64 [[COPY12]], [[COPY13]], killed [[V_ADD_CO_U32_e64_1]], 0, implicit $exec
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE4:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_ADD_CO_U32_e64_]], %subreg.sub0, killed [[V_ADDC_U32_e64_]], %subreg.sub1
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORDX2_OFFSET killed [[REG_SEQUENCE4]], killed [[REG_SEQUENCE1]], 0, 0, 0, 0, implicit $exec :: (store (s64) into %ir.2, addrspace 1)
+; GCN-ISEL-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, killed [[V_ADDC_U32_e64_1]], implicit $exec
+; GCN-ISEL-NEXT:   BUFFER_STORE_BYTE_OFFSET killed [[V_CNDMASK_B32_e64_]], killed [[REG_SEQUENCE3]], 0, 0, 0, 0, implicit $exec :: (store (s8) into %ir.3, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid.ext = sext i32 %tid to i64
   %uadd = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 %a, i64 %tid.ext)
@@ -987,11 +1151,6 @@ define amdgpu_kernel void @vuaddo64(ptr addrspace(1) %out, ptr addrspace(1) %car
   store i1 %carry, ptr addrspace(1) %carryout
   ret void
 }
-
-; GCN-ISEL-LABEL: name:   ssub64rr
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0.entry:
-; GCN-ISEL: S_SUB_U64_PSEUDO
 
 define amdgpu_kernel void @ssub64rr(ptr addrspace(1) %out, i64 %a, i64 %b) {
 ; CISI-LABEL: ssub64rr:
@@ -1094,7 +1253,7 @@ define amdgpu_kernel void @ssub64rr(ptr addrspace(1) %out, i64 %a, i64 %b) {
 ;
 ; GFX1250-LABEL: ssub64rr:
 ; GFX1250:       ; %bb.0: ; %entry
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_clause 0x1
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
 ; GFX1250-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34 nv
@@ -1105,16 +1264,36 @@ define amdgpu_kernel void @ssub64rr(ptr addrspace(1) %out, i64 %a, i64 %b) {
 ; GFX1250-NEXT:    v_mov_b64_e32 v[0:1], s[2:3]
 ; GFX1250-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: ssub64rr
+; GCN-ISEL: bb.0.entry:
+; GCN-ISEL-NEXT:   liveins: $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX4_IMM:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s128) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 13, 0 :: (dereferenceable invariant load (s64) from %ir.out.kernarg.offset + 16, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub0
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY6]], %subreg.sub0, killed [[COPY5]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub1
+; GCN-ISEL-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY8]], %subreg.sub0, killed [[COPY7]], %subreg.sub1, killed [[S_MOV_B32_1]], %subreg.sub2, killed [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY4]], %subreg.sub0, killed [[COPY3]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY2]], %subreg.sub0, killed [[COPY1]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_SUB_U:%[0-9]+]]:sreg_64 = S_SUB_U64_PSEUDO killed [[REG_SEQUENCE2]], killed [[REG_SEQUENCE3]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY9:%[0-9]+]]:vreg_64 = COPY [[S_SUB_U]]
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORDX2_OFFSET killed [[COPY9]], killed [[REG_SEQUENCE1]], 0, 0, 0, 0, implicit $exec :: (store (s64) into %ir.1, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
 entry:
   %sub = sub i64 %a, %b
   store i64 %sub, ptr addrspace(1) %out
   ret void
 }
-
-; GCN-ISEL-LABEL: name:   ssub64ri
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0.entry:
-; GCN-ISEL: S_SUB_U64_PSEUDO
 
 define amdgpu_kernel void @ssub64ri(ptr addrspace(1) %out, i64 %a) {
 ; CISI-LABEL: ssub64ri:
@@ -1206,7 +1385,7 @@ define amdgpu_kernel void @ssub64ri(ptr addrspace(1) %out, i64 %a) {
 ;
 ; GFX1250-LABEL: ssub64ri:
 ; GFX1250:       ; %bb.0: ; %entry
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
 ; GFX1250-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
@@ -1215,16 +1394,35 @@ define amdgpu_kernel void @ssub64ri(ptr addrspace(1) %out, i64 %a) {
 ; GFX1250-NEXT:    v_mov_b64_e32 v[0:1], s[2:3]
 ; GFX1250-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: ssub64ri
+; GCN-ISEL: bb.0.entry:
+; GCN-ISEL-NEXT:   liveins: $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX4_IMM:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s128) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY2]], %subreg.sub0, killed [[COPY1]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub1
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY4]], %subreg.sub0, killed [[COPY3]], %subreg.sub1, killed [[S_MOV_B32_1]], %subreg.sub2, killed [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+; GCN-ISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY6]], %subreg.sub0, killed [[COPY5]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 4660
+; GCN-ISEL-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 1450743926
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_MOV_B32_3]], %subreg.sub0, killed [[S_MOV_B32_2]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_SUB_U:%[0-9]+]]:sreg_64 = S_SUB_U64_PSEUDO killed [[REG_SEQUENCE3]], killed [[REG_SEQUENCE2]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY7:%[0-9]+]]:vreg_64 = COPY [[S_SUB_U]]
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORDX2_OFFSET killed [[COPY7]], killed [[REG_SEQUENCE1]], 0, 0, 0, 0, implicit $exec :: (store (s64) into %ir.1, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
 entry:
   %sub = sub i64 20015998343286, %a
   store i64 %sub, ptr addrspace(1) %out
   ret void
 }
-
-; GCN-ISEL-LABEL: name:   vsub64rr
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0.entry:
-; GCN-ISEL: V_SUB_U64_PSEUDO
 
 define amdgpu_kernel void @vsub64rr(ptr addrspace(1) %out, i64 %a) {
 ; CISI-LABEL: vsub64rr:
@@ -1308,7 +1506,7 @@ define amdgpu_kernel void @vsub64rr(ptr addrspace(1) %out, i64 %a) {
 ;
 ; GFX1250-LABEL: vsub64rr:
 ; GFX1250:       ; %bb.0: ; %entry
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX1250-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
@@ -1317,6 +1515,29 @@ define amdgpu_kernel void @vsub64rr(ptr addrspace(1) %out, i64 %a) {
 ; GFX1250-NEXT:    v_sub_nc_u64_e32 v[2:3], s[2:3], v[0:1]
 ; GFX1250-NEXT:    global_store_b64 v1, v[2:3], s[0:1]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: vsub64rr
+; GCN-ISEL: bb.0.entry:
+; GCN-ISEL-NEXT:   liveins: $vgpr0, $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32(s32) = COPY $vgpr0
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX4_IMM:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s128) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY3]], %subreg.sub0, killed [[COPY2]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub1
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY5]], %subreg.sub0, killed [[COPY4]], %subreg.sub1, killed [[S_MOV_B32_1]], %subreg.sub2, killed [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+; GCN-ISEL-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY7]], %subreg.sub0, killed [[COPY6]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY1]](s32), %subreg.sub0, killed [[V_MOV_B32_e32_]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[V_SUB_U:%[0-9]+]]:vreg_64 = V_SUB_U64_PSEUDO killed [[REG_SEQUENCE2]], killed [[REG_SEQUENCE3]], implicit-def dead $vcc, implicit $exec
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORDX2_OFFSET killed [[V_SUB_U]], killed [[REG_SEQUENCE1]], 0, 0, 0, 0, implicit $exec :: (store (s64) into %ir.1, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
 entry:
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid.ext = sext i32 %tid to i64
@@ -1324,11 +1545,6 @@ entry:
   store i64 %sub, ptr addrspace(1) %out
   ret void
 }
-
-; GCN-ISEL-LABEL: name:   vsub64ri
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0.entry:
-; GCN-ISEL: V_SUB_U64_PSEUDO
 
 define amdgpu_kernel void @vsub64ri(ptr addrspace(1) %out) {
 ; CISI-LABEL: vsub64ri:
@@ -1410,7 +1626,7 @@ define amdgpu_kernel void @vsub64ri(ptr addrspace(1) %out) {
 ;
 ; GFX1250-LABEL: vsub64ri:
 ; GFX1250:       ; %bb.0: ; %entry
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX1250-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
@@ -1419,6 +1635,26 @@ define amdgpu_kernel void @vsub64ri(ptr addrspace(1) %out) {
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    global_store_b64 v1, v[2:3], s[0:1]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: vsub64ri
+; GCN-ISEL: bb.0.entry:
+; GCN-ISEL-NEXT:   liveins: $vgpr0, $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32(s32) = COPY $vgpr0
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s64) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY3]], %subreg.sub0, killed [[COPY2]], %subreg.sub1, killed [[S_MOV_B32_1]], %subreg.sub2, killed [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY1]](s32), %subreg.sub0, killed [[V_MOV_B32_e32_]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 4660
+; GCN-ISEL-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 1450743926
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_MOV_B32_3]], %subreg.sub0, killed [[S_MOV_B32_2]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[V_SUB_U:%[0-9]+]]:vreg_64 = V_SUB_U64_PSEUDO killed [[REG_SEQUENCE2]], killed [[REG_SEQUENCE1]], implicit-def dead $vcc, implicit $exec
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORDX2_OFFSET killed [[V_SUB_U]], killed [[REG_SEQUENCE]], 0, 0, 0, 0, implicit $exec :: (store (s64) into %ir.out.load, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
 entry:
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid.ext = sext i32 %tid to i64
@@ -1426,11 +1662,6 @@ entry:
   store i64 %sub, ptr addrspace(1) %out
   ret void
 }
-
-; GCN-ISEL-LABEL: name:   susubo32
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0
-; GCN-ISEL: S_SUB_I32
 
 define amdgpu_kernel void @susubo32(ptr addrspace(1) %out, ptr addrspace(1) %carryout, i32 %a, i32 %b) #0 {
 ; CISI-LABEL: susubo32:
@@ -1518,7 +1749,7 @@ define amdgpu_kernel void @susubo32(ptr addrspace(1) %out, ptr addrspace(1) %car
 ;
 ; GFX1250-LABEL: susubo32:
 ; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_clause 0x1
 ; GFX1250-NEXT:    s_load_b64 s[0:1], s[4:5], 0x34 nv
 ; GFX1250-NEXT:    s_load_b64 s[2:3], s[4:5], 0x24 nv
@@ -1528,6 +1759,24 @@ define amdgpu_kernel void @susubo32(ptr addrspace(1) %out, ptr addrspace(1) %car
 ; GFX1250-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, s0
 ; GFX1250-NEXT:    global_store_b32 v0, v1, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: susubo32
+; GCN-ISEL: bb.0 (%ir-block.0):
+; GCN-ISEL-NEXT:   liveins: $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s64) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX2_IMM1:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 13, 0 :: (dereferenceable invariant load (s64) from %ir.a.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY2]], %subreg.sub0, killed [[COPY1]], %subreg.sub1, killed [[S_MOV_B32_1]], %subreg.sub2, killed [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM1]].sub0
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM1]].sub1
+; GCN-ISEL-NEXT:   [[S_SUB_I32_:%[0-9]+]]:sreg_32 = S_SUB_I32 killed [[COPY3]], killed [[COPY4]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:vgpr_32 = COPY [[S_SUB_I32_]]
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORD_OFFSET killed [[COPY5]], killed [[REG_SEQUENCE]], 0, 0, 0, 0, implicit $exec :: (store (s32) into %ir.out.load, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
   %usub = call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %a, i32 %b)
   %val = extractvalue { i32, i1 } %usub, 0
   %carry = extractvalue { i32, i1 } %usub, 1
@@ -1535,11 +1784,6 @@ define amdgpu_kernel void @susubo32(ptr addrspace(1) %out, ptr addrspace(1) %car
   ret void
 }
 
-
-; GCN-ISEL-LABEL: name:   usubo32_vcc_user
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0
-; GCN-ISEL: V_SUB_CO_U32_e64
 
 ; below we check selection to v_sub/subb
 ; because the only user of VCC produced by the USUBOis v_cndmask.
@@ -1651,7 +1895,7 @@ define amdgpu_kernel void @usubo32_vcc_user(ptr addrspace(1) %out, ptr addrspace
 ;
 ; GFX1250-LABEL: usubo32_vcc_user:
 ; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_clause 0x1
 ; GFX1250-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34 nv
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
@@ -1664,6 +1908,35 @@ define amdgpu_kernel void @usubo32_vcc_user(ptr addrspace(1) %out, ptr addrspace
 ; GFX1250-NEXT:    global_store_b32 v0, v1, s[0:1]
 ; GFX1250-NEXT:    global_store_b8 v0, v2, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: usubo32_vcc_user
+; GCN-ISEL: bb.0 (%ir-block.0):
+; GCN-ISEL-NEXT:   liveins: $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX4_IMM:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s128) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 13, 0 :: (dereferenceable invariant load (s64) from %ir.a.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY2]], %subreg.sub0, killed [[COPY1]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub1
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY4]], %subreg.sub0, killed [[COPY3]], %subreg.sub1, [[S_MOV_B32_1]], %subreg.sub2, [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+; GCN-ISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY6]], %subreg.sub0, killed [[COPY5]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE2]].sub1
+; GCN-ISEL-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE2]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY8]], %subreg.sub0, killed [[COPY7]], %subreg.sub1, [[S_MOV_B32_1]], %subreg.sub2, [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub0
+; GCN-ISEL-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY killed [[COPY10]]
+; GCN-ISEL-NEXT:   [[V_SUB_CO_U32_e64_:%[0-9]+]]:vgpr_32, [[V_SUB_CO_U32_e64_1:%[0-9]+]]:sreg_64_xexec = V_SUB_CO_U32_e64 killed [[COPY9]], [[COPY11]], 0, implicit $exec
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORD_OFFSET killed [[V_SUB_CO_U32_e64_]], killed [[REG_SEQUENCE1]], 0, 0, 0, 0, implicit $exec :: (store (s32) into %ir.2, addrspace 1)
+; GCN-ISEL-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, killed [[V_SUB_CO_U32_e64_1]], implicit $exec
+; GCN-ISEL-NEXT:   BUFFER_STORE_BYTE_OFFSET killed [[V_CNDMASK_B32_e64_]], killed [[REG_SEQUENCE3]], 0, 0, 0, 0, implicit $exec :: (store (s8) into %ir.3, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
   %usub = call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %a, i32 %b)
   %val = extractvalue { i32, i1 } %usub, 0
   %carry = extractvalue { i32, i1 } %usub, 1
@@ -1671,12 +1944,6 @@ define amdgpu_kernel void @usubo32_vcc_user(ptr addrspace(1) %out, ptr addrspace
   store i1 %carry, ptr addrspace(1) %carryout
   ret void
 }
-
-; GCN-ISEL-LABEL: name:   susubo64
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0
-; GCN-ISEL: S_USUBO_PSEUDO
-; GCN-ISEL: S_SUB_CO_PSEUDO
 
 define amdgpu_kernel void @susubo64(ptr addrspace(1) %out, ptr addrspace(1) %carryout, i64 %a, i64 %b) #0 {
 ; CISI-LABEL: susubo64:
@@ -1797,7 +2064,7 @@ define amdgpu_kernel void @susubo64(ptr addrspace(1) %out, ptr addrspace(1) %car
 ;
 ; GFX1250-LABEL: susubo64:
 ; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_load_b256 s[8:15], s[4:5], 0x24 nv
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    s_sub_co_u32 s0, s12, s14
@@ -1810,6 +2077,38 @@ define amdgpu_kernel void @susubo64(ptr addrspace(1) %out, ptr addrspace(1) %car
 ; GFX1250-NEXT:    global_store_b64 v2, v[0:1], s[8:9]
 ; GFX1250-NEXT:    global_store_b8 v2, v3, s[10:11]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: susubo64
+; GCN-ISEL: bb.0 (%ir-block.0):
+; GCN-ISEL-NEXT:   liveins: $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX8_IMM:%[0-9]+]]:sgpr_256 = S_LOAD_DWORDX8_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s256) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY2]], %subreg.sub0, killed [[COPY1]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub1
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY4]], %subreg.sub0, killed [[COPY3]], %subreg.sub1, [[S_MOV_B32_1]], %subreg.sub2, [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub3
+; GCN-ISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub2
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY6]], %subreg.sub0, killed [[COPY5]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE2]].sub1
+; GCN-ISEL-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE2]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY8]], %subreg.sub0, killed [[COPY7]], %subreg.sub1, [[S_MOV_B32_1]], %subreg.sub2, [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub5
+; GCN-ISEL-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub4
+; GCN-ISEL-NEXT:   [[COPY11:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub7
+; GCN-ISEL-NEXT:   [[COPY12:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX8_IMM]].sub6
+; GCN-ISEL-NEXT:   [[S_USUBO:%[0-9]+]]:sreg_32, [[S_USUBO1:%[0-9]+]]:sreg_64_xexec = S_USUBO_PSEUDO killed [[COPY10]], killed [[COPY12]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[S_SUB_C:%[0-9]+]]:sreg_32, [[S_SUB_C1:%[0-9]+]]:sreg_64_xexec = S_SUB_CO_PSEUDO killed [[COPY9]], killed [[COPY11]], killed [[S_USUBO1]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE4:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_USUBO]], %subreg.sub0, killed [[S_SUB_C]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY13:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE4]]
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORDX2_OFFSET killed [[COPY13]], killed [[REG_SEQUENCE1]], 0, 0, 0, 0, implicit $exec :: (store (s64) into %ir.2, addrspace 1)
+; GCN-ISEL-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, killed [[S_SUB_C1]], implicit $exec
+; GCN-ISEL-NEXT:   BUFFER_STORE_BYTE_OFFSET killed [[V_CNDMASK_B32_e64_]], killed [[REG_SEQUENCE3]], 0, 0, 0, 0, implicit $exec :: (store (s8) into %ir.3, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
   %usub = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
   %val = extractvalue { i64, i1 } %usub, 0
   %carry = extractvalue { i64, i1 } %usub, 1
@@ -1817,12 +2116,6 @@ define amdgpu_kernel void @susubo64(ptr addrspace(1) %out, ptr addrspace(1) %car
   store i1 %carry, ptr addrspace(1) %carryout
   ret void
 }
-
-; GCN-ISEL-LABEL: name:   vusubo64
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.0
-; GCN-ISEL: V_SUB_CO_U32_e64
-; GCN-ISEL: V_SUBB_U32_e64
 
 define amdgpu_kernel void @vusubo64(ptr addrspace(1) %out, ptr addrspace(1) %carryout, i64 %a) #0 {
 ; CISI-LABEL: vusubo64:
@@ -1940,7 +2233,7 @@ define amdgpu_kernel void @vusubo64(ptr addrspace(1) %out, ptr addrspace(1) %car
 ;
 ; GFX1250-LABEL: vusubo64:
 ; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_clause 0x1
 ; GFX1250-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34 nv
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
@@ -1956,6 +2249,40 @@ define amdgpu_kernel void @vusubo64(ptr addrspace(1) %out, ptr addrspace(1) %car
 ; GFX1250-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
 ; GFX1250-NEXT:    global_store_b8 v2, v3, s[2:3]
 ; GFX1250-NEXT:    s_endpgm
+; GCN-ISEL-LABEL: name: vusubo64
+; GCN-ISEL: bb.0 (%ir-block.0):
+; GCN-ISEL-NEXT:   liveins: $vgpr0, $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32(s32) = COPY $vgpr0
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX4_IMM:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s128) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 13, 0 :: (dereferenceable invariant load (s64) from %ir.out.kernarg.offset + 16, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub0
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+; GCN-ISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY7]], %subreg.sub0, killed [[COPY6]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub1
+; GCN-ISEL-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, [[S_MOV_B32_1]], %subreg.sub2, [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY5]], %subreg.sub0, killed [[COPY4]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE2]].sub1
+; GCN-ISEL-NEXT:   [[COPY11:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE2]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, [[S_MOV_B32_1]], %subreg.sub2, [[S_MOV_B32_]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[V_SUB_CO_U32_e64_:%[0-9]+]]:vgpr_32, [[V_SUB_CO_U32_e64_1:%[0-9]+]]:sreg_64_xexec = V_SUB_CO_U32_e64 killed [[COPY3]], [[COPY1]](s32), 0, implicit $exec
+; GCN-ISEL-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
+; GCN-ISEL-NEXT:   [[COPY12:%[0-9]+]]:vgpr_32 = COPY killed [[COPY2]]
+; GCN-ISEL-NEXT:   [[COPY13:%[0-9]+]]:vgpr_32 = COPY killed [[S_MOV_B32_2]]
+; GCN-ISEL-NEXT:   [[V_SUBB_U32_e64_:%[0-9]+]]:vgpr_32, [[V_SUBB_U32_e64_1:%[0-9]+]]:sreg_64_xexec = V_SUBB_U32_e64 [[COPY12]], [[COPY13]], killed [[V_SUB_CO_U32_e64_1]], 0, implicit $exec
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE4:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_SUB_CO_U32_e64_]], %subreg.sub0, killed [[V_SUBB_U32_e64_]], %subreg.sub1
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORDX2_OFFSET killed [[REG_SEQUENCE4]], killed [[REG_SEQUENCE1]], 0, 0, 0, 0, implicit $exec :: (store (s64) into %ir.2, addrspace 1)
+; GCN-ISEL-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, killed [[V_SUBB_U32_e64_1]], implicit $exec
+; GCN-ISEL-NEXT:   BUFFER_STORE_BYTE_OFFSET killed [[V_CNDMASK_B32_e64_]], killed [[REG_SEQUENCE3]], 0, 0, 0, 0, implicit $exec :: (store (s8) into %ir.3, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid.ext = sext i32 %tid to i64
   %usub = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %tid.ext)
@@ -1965,14 +2292,6 @@ define amdgpu_kernel void @vusubo64(ptr addrspace(1) %out, ptr addrspace(1) %car
   store i1 %carry, ptr addrspace(1) %carryout
   ret void
 }
-
-; GCN-ISEL-LABEL: name:   sudiv64
-; GCN-ISEL-LABEL: body:
-; GCN-ISEL-LABEL: bb.3
-; GCN-ISEL: %[[CARRY:[0-9]+]]:sreg_64_xexec = S_UADDO_PSEUDO
-; GCN-ISEL: S_ADD_CO_PSEUDO %{{[0-9]+}}, killed %{{[0-9]+}}, killed %[[CARRY]]
-; GCN-ISEL: %[[CARRY:[0-9]+]]:sreg_64_xexec = S_USUBO_PSEUDO
-; GCN-ISEL: S_SUB_CO_PSEUDO killed %{{[0-9]+}}, %{{[0-9]+}}, %[[CARRY]]
 
 define amdgpu_kernel void @sudiv64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; CISI-LABEL: sudiv64:
@@ -2115,7 +2434,7 @@ define amdgpu_kernel void @sudiv64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; CISI-NEXT:    s_cselect_b64 vcc, -1, 0
 ; CISI-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
 ; CISI-NEXT:    v_mov_b32_e32 v1, 0
-; CISI-NEXT:  .LBB16_3:
+; CISI-NEXT:  .LBB16_3: ; %.split
 ; CISI-NEXT:    s_mov_b32 s11, 0xf000
 ; CISI-NEXT:    s_mov_b32 s10, -1
 ; CISI-NEXT:    buffer_store_dwordx2 v[0:1], off, s[8:11], 0
@@ -2143,43 +2462,43 @@ define amdgpu_kernel void @sudiv64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; VI-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; VI-NEXT:    v_trunc_f32_e32 v1, v1
 ; VI-NEXT:    v_madmk_f32 v0, v1, 0xcf800000, v0
-; VI-NEXT:    v_cvt_u32_f32_e32 v4, v1
-; VI-NEXT:    v_cvt_u32_f32_e32 v5, v0
-; VI-NEXT:    v_mul_lo_u32 v2, s8, v4
-; VI-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], s8, v5, 0
-; VI-NEXT:    v_mul_lo_u32 v3, s9, v5
+; VI-NEXT:    v_cvt_u32_f32_e32 v7, v1
+; VI-NEXT:    v_cvt_u32_f32_e32 v8, v0
+; VI-NEXT:    v_mul_lo_u32 v2, s8, v7
+; VI-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], s8, v8, 0
+; VI-NEXT:    v_mul_lo_u32 v3, s9, v8
 ; VI-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
-; VI-NEXT:    v_add_u32_e32 v3, vcc, v1, v3
-; VI-NEXT:    v_mul_hi_u32 v6, v5, v0
-; VI-NEXT:    v_mad_u64_u32 v[1:2], s[6:7], v5, v3, 0
-; VI-NEXT:    v_add_u32_e32 v6, vcc, v6, v1
-; VI-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v4, v0, 0
-; VI-NEXT:    v_addc_u32_e32 v7, vcc, 0, v2, vcc
-; VI-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v4, v3, 0
-; VI-NEXT:    v_add_u32_e32 v0, vcc, v6, v0
-; VI-NEXT:    v_addc_u32_e32 v0, vcc, v7, v1, vcc
-; VI-NEXT:    v_addc_u32_e32 v1, vcc, 0, v3, vcc
-; VI-NEXT:    v_add_u32_e32 v0, vcc, v0, v2
+; VI-NEXT:    v_add_u32_e32 v5, vcc, v1, v3
+; VI-NEXT:    v_mul_hi_u32 v9, v8, v0
+; VI-NEXT:    v_mad_u64_u32 v[1:2], s[6:7], v8, v5, 0
+; VI-NEXT:    v_mad_u64_u32 v[3:4], s[6:7], v7, v0, 0
+; VI-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v7, v5, 0
+; VI-NEXT:    v_add_u32_e32 v0, vcc, v9, v1
+; VI-NEXT:    v_addc_u32_e32 v1, vcc, 0, v2, vcc
+; VI-NEXT:    v_add_u32_e32 v0, vcc, v0, v3
+; VI-NEXT:    v_addc_u32_e32 v0, vcc, v1, v4, vcc
+; VI-NEXT:    v_addc_u32_e32 v1, vcc, 0, v6, vcc
+; VI-NEXT:    v_add_u32_e32 v0, vcc, v0, v5
 ; VI-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; VI-NEXT:    v_add_u32_e32 v6, vcc, v5, v0
-; VI-NEXT:    v_addc_u32_e32 v7, vcc, v4, v1, vcc
-; VI-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], s8, v6, 0
-; VI-NEXT:    v_mul_lo_u32 v4, s8, v7
-; VI-NEXT:    v_mul_lo_u32 v5, s9, v6
-; VI-NEXT:    v_mul_hi_u32 v8, v6, v0
-; VI-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v7, v0, 0
-; VI-NEXT:    v_add_u32_e32 v1, vcc, v4, v1
-; VI-NEXT:    v_add_u32_e32 v1, vcc, v5, v1
-; VI-NEXT:    v_mad_u64_u32 v[4:5], s[6:7], v6, v1, 0
-; VI-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v7, v1, 0
-; VI-NEXT:    v_add_u32_e32 v4, vcc, v8, v4
-; VI-NEXT:    v_addc_u32_e32 v5, vcc, 0, v5, vcc
-; VI-NEXT:    v_add_u32_e32 v2, vcc, v4, v2
-; VI-NEXT:    v_addc_u32_e32 v2, vcc, v5, v3, vcc
+; VI-NEXT:    v_add_u32_e32 v8, vcc, v8, v0
+; VI-NEXT:    v_addc_u32_e32 v7, vcc, v7, v1, vcc
+; VI-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], s8, v8, 0
+; VI-NEXT:    v_mul_lo_u32 v2, s8, v7
+; VI-NEXT:    v_mul_lo_u32 v3, s9, v8
+; VI-NEXT:    v_mul_hi_u32 v9, v8, v0
+; VI-NEXT:    v_add_u32_e32 v1, vcc, v2, v1
+; VI-NEXT:    v_add_u32_e32 v5, vcc, v3, v1
+; VI-NEXT:    v_mad_u64_u32 v[1:2], s[6:7], v8, v5, 0
+; VI-NEXT:    v_mad_u64_u32 v[3:4], s[6:7], v7, v0, 0
+; VI-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v7, v5, 0
+; VI-NEXT:    v_add_u32_e32 v0, vcc, v9, v1
+; VI-NEXT:    v_addc_u32_e32 v1, vcc, 0, v2, vcc
+; VI-NEXT:    v_add_u32_e32 v0, vcc, v0, v3
+; VI-NEXT:    v_addc_u32_e32 v0, vcc, v1, v4, vcc
+; VI-NEXT:    v_addc_u32_e32 v1, vcc, 0, v6, vcc
+; VI-NEXT:    v_add_u32_e32 v0, vcc, v0, v5
 ; VI-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; VI-NEXT:    v_add_u32_e32 v0, vcc, v2, v0
-; VI-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; VI-NEXT:    v_add_u32_e32 v2, vcc, v6, v0
+; VI-NEXT:    v_add_u32_e32 v2, vcc, v8, v0
 ; VI-NEXT:    v_addc_u32_e32 v3, vcc, v7, v1, vcc
 ; VI-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], s2, v3, 0
 ; VI-NEXT:    v_mul_hi_u32 v4, s2, v2
@@ -2269,7 +2588,7 @@ define amdgpu_kernel void @sudiv64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; VI-NEXT:  .LBB16_4:
 ; VI-NEXT:    v_mov_b32_e32 v0, s8
 ; VI-NEXT:    v_mov_b32_e32 v1, s9
-; VI-NEXT:  .LBB16_5:
+; VI-NEXT:  .LBB16_5: ; %.split
 ; VI-NEXT:    v_mov_b32_e32 v2, s0
 ; VI-NEXT:    v_mov_b32_e32 v3, s1
 ; VI-NEXT:    flat_store_dwordx2 v[2:3], v[0:1]
@@ -2415,7 +2734,7 @@ define amdgpu_kernel void @sudiv64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; GFX9-NEXT:    s_add_i32 s4, s3, 1
 ; GFX9-NEXT:    s_cmp_ge_u32 s2, s6
 ; GFX9-NEXT:    s_cselect_b32 s8, s4, s3
-; GFX9-NEXT:  .LBB16_3:
+; GFX9-NEXT:  .LBB16_3: ; %.split
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX9-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s9
@@ -2568,7 +2887,7 @@ define amdgpu_kernel void @sudiv64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; GFX1010-NEXT:    s_cmp_ge_u32 s2, s6
 ; GFX1010-NEXT:    s_mov_b32 s5, 0
 ; GFX1010-NEXT:    s_cselect_b32 s4, s4, s3
-; GFX1010-NEXT:  .LBB16_3:
+; GFX1010-NEXT:  .LBB16_3: ; %.split
 ; GFX1010-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1010-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1010-NEXT:    v_mov_b32_e32 v1, s5
@@ -2721,7 +3040,7 @@ define amdgpu_kernel void @sudiv64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; GFX1030W32-NEXT:    s_add_i32 s5, s3, 1
 ; GFX1030W32-NEXT:    s_cmp_ge_u32 s2, s4
 ; GFX1030W32-NEXT:    s_cselect_b32 s6, s5, s3
-; GFX1030W32-NEXT:  .LBB16_3:
+; GFX1030W32-NEXT:  .LBB16_3: ; %.split
 ; GFX1030W32-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1030W32-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1030W32-NEXT:    v_mov_b32_e32 v1, s7
@@ -2872,7 +3191,7 @@ define amdgpu_kernel void @sudiv64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; GFX1030W64-NEXT:    s_add_i32 s5, s3, 1
 ; GFX1030W64-NEXT:    s_cmp_ge_u32 s2, s4
 ; GFX1030W64-NEXT:    s_cselect_b32 s6, s5, s3
-; GFX1030W64-NEXT:  .LBB16_3:
+; GFX1030W64-NEXT:  .LBB16_3: ; %.split
 ; GFX1030W64-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1030W64-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1030W64-NEXT:    v_mov_b32_e32 v1, s7
@@ -3040,7 +3359,7 @@ define amdgpu_kernel void @sudiv64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; GFX11-NEXT:    s_add_i32 s5, s3, 1
 ; GFX11-NEXT:    s_cmp_ge_u32 s2, s4
 ; GFX11-NEXT:    s_cselect_b32 s6, s5, s3
-; GFX11-NEXT:  .LBB16_3:
+; GFX11-NEXT:  .LBB16_3: ; %.split
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX11-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_mov_b32 v1, s7
@@ -3052,7 +3371,7 @@ define amdgpu_kernel void @sudiv64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ;
 ; GFX1250-LABEL: sudiv64:
 ; GFX1250:       ; %bb.0:
-; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+; GFX1250-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; GFX1250-NEXT:    s_clause 0x1
 ; GFX1250-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24 nv
 ; GFX1250-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34 nv
@@ -3192,7 +3511,7 @@ define amdgpu_kernel void @sudiv64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; GFX1250-NEXT:    s_add_co_i32 s4, s3, 1
 ; GFX1250-NEXT:    s_cmp_ge_u32 s2, s6
 ; GFX1250-NEXT:    s_cselect_b32 s8, s4, s3
-; GFX1250-NEXT:  .LBB16_3:
+; GFX1250-NEXT:  .LBB16_3: ; %.split
 ; GFX1250-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX1250-NEXT:    v_mov_b64_e32 v[0:1], s[8:9]
 ; GFX1250-NEXT:    v_mov_b32_e32 v2, 0
@@ -3201,6 +3520,287 @@ define amdgpu_kernel void @sudiv64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; GFX1250-NEXT:  .LBB16_4:
 ; GFX1250-NEXT:    ; implicit-def: $sgpr8_sgpr9
 ; GFX1250-NEXT:    s_branch .LBB16_2
+; GCN-ISEL-LABEL: name: sudiv64
+; GCN-ISEL: bb.0 (%ir-block.0):
+; GCN-ISEL-NEXT:   successors: %bb.3(0x50000000), %bb.1(0x30000000)
+; GCN-ISEL-NEXT:   liveins: $sgpr4_sgpr5
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr4_sgpr5
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX4_IMM:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[COPY]](p4), 9, 0 :: (dereferenceable invariant load (s128) from %ir.out.kernarg.offset, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 13, 0 :: (dereferenceable invariant load (s64) from %ir.out.kernarg.offset + 16, align 4, addrspace 4)
+; GCN-ISEL-NEXT:   [[COPY1:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX2_IMM]].sub0
+; GCN-ISEL-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+; GCN-ISEL-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+; GCN-ISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub1
+; GCN-ISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sgpr_192 = REG_SEQUENCE killed [[COPY6]], %subreg.sub0, killed [[COPY5]], %subreg.sub1, [[COPY4]], %subreg.sub2, [[COPY3]], %subreg.sub3, [[COPY2]], %subreg.sub4, [[COPY1]], %subreg.sub5
+; GCN-ISEL-NEXT:   [[COPY7:%[0-9]+]]:sgpr_192 = COPY [[REG_SEQUENCE]]
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sreg_64 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY8:%[0-9]+]]:sreg_64 = COPY [[REG_SEQUENCE1]]
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE [[COPY2]], %subreg.sub0, [[COPY1]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY9:%[0-9]+]]:sreg_64 = COPY [[REG_SEQUENCE2]]
+; GCN-ISEL-NEXT:   [[S_OR_B64_:%[0-9]+]]:sreg_64 = S_OR_B64 [[REG_SEQUENCE1]], [[REG_SEQUENCE2]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[S_OR_B64_]].sub1
+; GCN-ISEL-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64 = S_MOV_B64 -1
+; GCN-ISEL-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
+; GCN-ISEL-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
+; GCN-ISEL-NEXT:   S_CMP_LG_U32 killed [[COPY10]], killed [[S_MOV_B32_]], implicit-def $scc
+; GCN-ISEL-NEXT:   S_CBRANCH_SCC1 %bb.3, implicit $scc
+; GCN-ISEL-NEXT:   S_BRANCH %bb.1
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT: bb.1.Flow:
+; GCN-ISEL-NEXT:   successors: %bb.2(0x40000000), %bb.4(0x40000000)
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[PHI:%[0-9]+]]:sreg_64 = PHI [[DEF]], %bb.0, %6, %bb.3
+; GCN-ISEL-NEXT:   [[PHI1:%[0-9]+]]:sreg_64_xexec = PHI [[S_MOV_B64_]], %bb.0, %35, %bb.3
+; GCN-ISEL-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, [[PHI1]], implicit $exec
+; GCN-ISEL-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 1
+; GCN-ISEL-NEXT:   [[COPY11:%[0-9]+]]:sreg_32 = COPY [[V_CNDMASK_B32_e64_]]
+; GCN-ISEL-NEXT:   S_CMP_LG_U32 killed [[COPY11]], killed [[S_MOV_B32_1]], implicit-def $scc
+; GCN-ISEL-NEXT:   S_CBRANCH_SCC1 %bb.4, implicit $scc
+; GCN-ISEL-NEXT:   S_BRANCH %bb.2
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT: bb.2 (%ir-block.7):
+; GCN-ISEL-NEXT:   successors: %bb.4(0x80000000)
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY12:%[0-9]+]]:sreg_32 = COPY [[COPY9]].sub0
+; GCN-ISEL-NEXT:   [[COPY13:%[0-9]+]]:sreg_32 = COPY [[COPY8]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
+; GCN-ISEL-NEXT:   [[S_SUB_I32_:%[0-9]+]]:sreg_32 = S_SUB_I32 killed [[S_MOV_B32_2]], [[COPY12]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[V_CVT_F32_U32_e32_:%[0-9]+]]:vgpr_32 = V_CVT_F32_U32_e32 [[COPY12]], implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[V_RCP_IFLAG_F32_e32_:%[0-9]+]]:vgpr_32 = nofpexcept V_RCP_IFLAG_F32_e32 killed [[V_CVT_F32_U32_e32_]], implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[V_MUL_F32_e32_:%[0-9]+]]:vgpr_32 = nofpexcept V_MUL_F32_e32 1333788670, killed [[V_RCP_IFLAG_F32_e32_]], implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[V_CVT_U32_F32_e32_:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_U32_F32_e32 killed [[V_MUL_F32_e32_]], implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[COPY14:%[0-9]+]]:sreg_32 = COPY [[V_CVT_U32_F32_e32_]]
+; GCN-ISEL-NEXT:   [[S_MUL_I32_:%[0-9]+]]:sreg_32 = S_MUL_I32 killed [[S_SUB_I32_]], [[COPY14]]
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[V_CVT_U32_F32_e32_]], killed [[S_MUL_I32_]], implicit $exec
+; GCN-ISEL-NEXT:   [[COPY15:%[0-9]+]]:sreg_32 = COPY [[V_CVT_U32_F32_e32_]]
+; GCN-ISEL-NEXT:   [[COPY16:%[0-9]+]]:sreg_32 = COPY [[V_MUL_HI_U32_e64_]]
+; GCN-ISEL-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = S_ADD_I32 [[COPY15]], killed [[COPY16]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY17:%[0-9]+]]:vgpr_32 = COPY killed [[S_ADD_I32_]]
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_1:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[COPY13]], [[COPY17]], implicit $exec
+; GCN-ISEL-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 1
+; GCN-ISEL-NEXT:   [[COPY18:%[0-9]+]]:sreg_32 = COPY [[V_MUL_HI_U32_e64_1]]
+; GCN-ISEL-NEXT:   [[S_ADD_I32_1:%[0-9]+]]:sreg_32 = S_ADD_I32 [[COPY18]], [[S_MOV_B32_3]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY19:%[0-9]+]]:sreg_32 = COPY [[V_MUL_HI_U32_e64_1]]
+; GCN-ISEL-NEXT:   [[S_MUL_I32_1:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY19]], [[COPY12]]
+; GCN-ISEL-NEXT:   [[S_SUB_I32_1:%[0-9]+]]:sreg_32 = S_SUB_I32 [[COPY13]], killed [[S_MUL_I32_1]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[S_SUB_I32_2:%[0-9]+]]:sreg_32 = S_SUB_I32 [[S_SUB_I32_1]], [[COPY12]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   S_CMP_GE_U32 [[S_SUB_I32_1]], [[COPY12]], implicit-def $scc
+; GCN-ISEL-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32 = S_CSELECT_B32 killed [[S_SUB_I32_2]], [[S_SUB_I32_1]], implicit $scc
+; GCN-ISEL-NEXT:   [[COPY20:%[0-9]+]]:sreg_32 = COPY [[V_MUL_HI_U32_e64_1]]
+; GCN-ISEL-NEXT:   [[S_CSELECT_B32_1:%[0-9]+]]:sreg_32 = S_CSELECT_B32 killed [[S_ADD_I32_1]], [[COPY20]], implicit $scc
+; GCN-ISEL-NEXT:   [[S_ADD_I32_2:%[0-9]+]]:sreg_32 = S_ADD_I32 [[S_CSELECT_B32_1]], [[S_MOV_B32_3]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   S_CMP_GE_U32 killed [[S_CSELECT_B32_]], [[COPY12]], implicit-def $scc
+; GCN-ISEL-NEXT:   [[S_CSELECT_B32_2:%[0-9]+]]:sreg_32 = S_CSELECT_B32 killed [[S_ADD_I32_2]], [[S_CSELECT_B32_1]], implicit $scc
+; GCN-ISEL-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_CSELECT_B32_2]], %subreg.sub0, killed [[S_MOV_B32_4]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY21:%[0-9]+]]:sreg_64 = COPY [[REG_SEQUENCE3]]
+; GCN-ISEL-NEXT:   S_BRANCH %bb.4
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT: bb.3 (%ir-block.12):
+; GCN-ISEL-NEXT:   successors: %bb.1(0x80000000)
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT:   [[COPY22:%[0-9]+]]:sreg_32 = COPY [[COPY9]].sub0
+; GCN-ISEL-NEXT:   [[V_CVT_F32_U32_e64_:%[0-9]+]]:vgpr_32 = V_CVT_F32_U32_e64 [[COPY22]], 0, 0, implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[COPY23:%[0-9]+]]:sreg_32 = COPY [[COPY9]].sub1
+; GCN-ISEL-NEXT:   [[V_CVT_F32_U32_e64_1:%[0-9]+]]:vgpr_32 = V_CVT_F32_U32_e64 [[COPY23]], 0, 0, implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sgpr_32 = S_MOV_B32 1333788672
+; GCN-ISEL-NEXT:   [[V_FMA_F32_e64_:%[0-9]+]]:vgpr_32 = nofpexcept V_FMA_F32_e64 0, killed [[V_CVT_F32_U32_e64_1]], 0, killed [[S_MOV_B32_5]], 0, killed [[V_CVT_F32_U32_e64_]], 0, 0, implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[V_RCP_F32_e64_:%[0-9]+]]:vgpr_32 = nofpexcept V_RCP_F32_e64 0, killed [[V_FMA_F32_e64_]], 0, 0, implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sgpr_32 = S_MOV_B32 1602224124
+; GCN-ISEL-NEXT:   [[V_MUL_F32_e64_:%[0-9]+]]:vgpr_32 = nofpexcept V_MUL_F32_e64 0, killed [[V_RCP_F32_e64_]], 0, killed [[S_MOV_B32_6]], 0, 0, implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[S_MOV_B32_7:%[0-9]+]]:sgpr_32 = S_MOV_B32 796917760
+; GCN-ISEL-NEXT:   [[V_MUL_F32_e64_1:%[0-9]+]]:vgpr_32 = nofpexcept V_MUL_F32_e64 0, [[V_MUL_F32_e64_]], 0, killed [[S_MOV_B32_7]], 0, 0, implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[V_TRUNC_F32_e64_:%[0-9]+]]:vgpr_32 = nofpexcept V_TRUNC_F32_e64 0, killed [[V_MUL_F32_e64_1]], 0, 0, implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sgpr_32 = S_MOV_B32 -813694976
+; GCN-ISEL-NEXT:   [[V_FMA_F32_e64_1:%[0-9]+]]:vgpr_32 = nofpexcept V_FMA_F32_e64 0, [[V_TRUNC_F32_e64_]], 0, killed [[S_MOV_B32_8]], 0, [[V_MUL_F32_e64_]], 0, 0, implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[V_CVT_U32_F32_e64_:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_U32_F32_e64 0, killed [[V_FMA_F32_e64_1]], 0, 0, implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[S_MOV_B64_1:%[0-9]+]]:sreg_64 = S_MOV_B64 0
+; GCN-ISEL-NEXT:   [[S_SUB_U:%[0-9]+]]:sreg_64 = S_SUB_U64_PSEUDO killed [[S_MOV_B64_1]], [[COPY9]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY24:%[0-9]+]]:sreg_32 = COPY [[S_SUB_U]].sub1
+; GCN-ISEL-NEXT:   [[COPY25:%[0-9]+]]:sreg_32 = COPY [[V_CVT_U32_F32_e64_]]
+; GCN-ISEL-NEXT:   [[S_MUL_I32_2:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY24]], [[COPY25]]
+; GCN-ISEL-NEXT:   [[COPY26:%[0-9]+]]:sreg_32 = COPY [[S_SUB_U]].sub0
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_2:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[COPY26]], [[V_CVT_U32_F32_e64_]], implicit $exec
+; GCN-ISEL-NEXT:   [[V_CVT_U32_F32_e64_1:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_U32_F32_e64 0, [[V_TRUNC_F32_e64_]], 0, 0, implicit $mode, implicit $exec
+; GCN-ISEL-NEXT:   [[COPY27:%[0-9]+]]:sreg_32 = COPY [[V_CVT_U32_F32_e64_1]]
+; GCN-ISEL-NEXT:   [[S_MUL_I32_3:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY26]], [[COPY27]]
+; GCN-ISEL-NEXT:   [[COPY28:%[0-9]+]]:sreg_32 = COPY [[V_MUL_HI_U32_e64_2]]
+; GCN-ISEL-NEXT:   [[S_ADD_I32_3:%[0-9]+]]:sreg_32 = S_ADD_I32 killed [[COPY28]], killed [[S_MUL_I32_3]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[S_ADD_I32_4:%[0-9]+]]:sreg_32 = S_ADD_I32 killed [[S_ADD_I32_3]], killed [[S_MUL_I32_2]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_3:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[V_CVT_U32_F32_e64_]], [[S_ADD_I32_4]], implicit $exec
+; GCN-ISEL-NEXT:   [[COPY29:%[0-9]+]]:sreg_32 = COPY [[V_CVT_U32_F32_e64_]]
+; GCN-ISEL-NEXT:   [[S_MUL_I32_4:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY29]], [[S_ADD_I32_4]]
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE4:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_MUL_I32_4]], %subreg.sub0, killed [[V_MUL_HI_U32_e64_3]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY30:%[0-9]+]]:sreg_32 = COPY [[V_CVT_U32_F32_e64_]]
+; GCN-ISEL-NEXT:   [[S_MUL_I32_5:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY26]], [[COPY30]]
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_4:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[V_CVT_U32_F32_e64_]], [[S_MUL_I32_5]], implicit $exec
+; GCN-ISEL-NEXT:   [[S_MOV_B32_9:%[0-9]+]]:sreg_32 = S_MOV_B32 0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE5:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[V_MUL_HI_U32_e64_4]], %subreg.sub0, [[S_MOV_B32_9]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_ADD_U:%[0-9]+]]:sreg_64 = S_ADD_U64_PSEUDO killed [[REG_SEQUENCE5]], killed [[REG_SEQUENCE4]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY31:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U]].sub0
+; GCN-ISEL-NEXT:   [[COPY32:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U]].sub1
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_5:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[V_CVT_U32_F32_e64_1]], [[S_ADD_I32_4]], implicit $exec
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_6:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[V_CVT_U32_F32_e64_1]], [[S_MUL_I32_5]], implicit $exec
+; GCN-ISEL-NEXT:   [[COPY33:%[0-9]+]]:sreg_32 = COPY [[V_CVT_U32_F32_e64_1]]
+; GCN-ISEL-NEXT:   [[S_MUL_I32_6:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY33]], [[S_MUL_I32_5]]
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE6:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_MUL_I32_6]], %subreg.sub0, killed [[V_MUL_HI_U32_e64_6]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY34:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE6]].sub0
+; GCN-ISEL-NEXT:   [[COPY35:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE6]].sub1
+; GCN-ISEL-NEXT:   [[S_MOV_B32_10:%[0-9]+]]:sreg_32 = S_MOV_B32 0
+; GCN-ISEL-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 killed [[COPY31]], killed [[COPY34]], implicit-def $scc
+; GCN-ISEL-NEXT:   [[S_ADDC_U32_:%[0-9]+]]:sreg_32 = S_ADDC_U32 killed [[COPY32]], killed [[COPY35]], implicit-def $scc, implicit $scc
+; GCN-ISEL-NEXT:   [[COPY36:%[0-9]+]]:sreg_32 = COPY [[V_MUL_HI_U32_e64_5]]
+; GCN-ISEL-NEXT:   [[S_ADDC_U32_1:%[0-9]+]]:sreg_32 = S_ADDC_U32 killed [[COPY36]], [[S_MOV_B32_10]], implicit-def dead $scc, implicit $scc
+; GCN-ISEL-NEXT:   [[COPY37:%[0-9]+]]:sreg_32 = COPY [[V_CVT_U32_F32_e64_1]]
+; GCN-ISEL-NEXT:   [[S_MUL_I32_7:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY37]], [[S_ADD_I32_4]]
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE7:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_MUL_I32_7]], %subreg.sub0, killed [[S_ADDC_U32_1]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE8:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_ADD_U32_]], %subreg.sub0, killed [[S_ADDC_U32_]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY38:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE8]].sub1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE9:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY38]], %subreg.sub0, [[S_MOV_B32_10]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_ADD_U1:%[0-9]+]]:sreg_64 = S_ADD_U64_PSEUDO killed [[REG_SEQUENCE9]], killed [[REG_SEQUENCE7]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY39:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U1]].sub0
+; GCN-ISEL-NEXT:   [[COPY40:%[0-9]+]]:sreg_32 = COPY [[V_CVT_U32_F32_e64_]]
+; GCN-ISEL-NEXT:   [[S_UADDO:%[0-9]+]]:sreg_32, [[S_UADDO1:%[0-9]+]]:sreg_64_xexec = S_UADDO_PSEUDO [[COPY40]], killed [[COPY39]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY41:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U1]].sub1
+; GCN-ISEL-NEXT:   [[COPY42:%[0-9]+]]:sreg_32 = COPY [[V_CVT_U32_F32_e64_1]]
+; GCN-ISEL-NEXT:   [[S_ADD_C:%[0-9]+]]:sreg_32, [[S_ADD_C1:%[0-9]+]]:sreg_64_xexec = S_ADD_CO_PSEUDO [[COPY42]], killed [[COPY41]], killed [[S_UADDO1]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[S_MUL_I32_8:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY26]], [[S_ADD_C]]
+; GCN-ISEL-NEXT:   [[COPY43:%[0-9]+]]:vgpr_32 = COPY [[S_UADDO]]
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_7:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[COPY26]], [[COPY43]], implicit $exec
+; GCN-ISEL-NEXT:   [[COPY44:%[0-9]+]]:sreg_32 = COPY [[V_MUL_HI_U32_e64_7]]
+; GCN-ISEL-NEXT:   [[S_ADD_I32_5:%[0-9]+]]:sreg_32 = S_ADD_I32 killed [[COPY44]], killed [[S_MUL_I32_8]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[S_MUL_I32_9:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY24]], [[S_UADDO]]
+; GCN-ISEL-NEXT:   [[S_ADD_I32_6:%[0-9]+]]:sreg_32 = S_ADD_I32 killed [[S_ADD_I32_5]], killed [[S_MUL_I32_9]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY45:%[0-9]+]]:vgpr_32 = COPY [[S_ADD_I32_6]]
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_8:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[S_ADD_C]], [[COPY45]], implicit $exec
+; GCN-ISEL-NEXT:   [[S_MUL_I32_10:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY26]], [[S_UADDO]]
+; GCN-ISEL-NEXT:   [[COPY46:%[0-9]+]]:vgpr_32 = COPY [[S_MUL_I32_10]]
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_9:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[S_ADD_C]], [[COPY46]], implicit $exec
+; GCN-ISEL-NEXT:   [[S_MUL_I32_11:%[0-9]+]]:sreg_32 = S_MUL_I32 [[S_ADD_C]], [[S_MUL_I32_10]]
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE10:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_MUL_I32_11]], %subreg.sub0, killed [[V_MUL_HI_U32_e64_9]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY47:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE10]].sub0
+; GCN-ISEL-NEXT:   [[COPY48:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE10]].sub1
+; GCN-ISEL-NEXT:   [[COPY49:%[0-9]+]]:vgpr_32 = COPY [[S_ADD_I32_6]]
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_10:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[S_UADDO]], [[COPY49]], implicit $exec
+; GCN-ISEL-NEXT:   [[S_MUL_I32_12:%[0-9]+]]:sreg_32 = S_MUL_I32 [[S_UADDO]], [[S_ADD_I32_6]]
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE11:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_MUL_I32_12]], %subreg.sub0, killed [[V_MUL_HI_U32_e64_10]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY50:%[0-9]+]]:vgpr_32 = COPY [[S_MUL_I32_10]]
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_11:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[S_UADDO]], [[COPY50]], implicit $exec
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE12:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[V_MUL_HI_U32_e64_11]], %subreg.sub0, [[S_MOV_B32_9]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_ADD_U2:%[0-9]+]]:sreg_64 = S_ADD_U64_PSEUDO killed [[REG_SEQUENCE12]], killed [[REG_SEQUENCE11]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY51:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U2]].sub0
+; GCN-ISEL-NEXT:   [[COPY52:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U2]].sub1
+; GCN-ISEL-NEXT:   [[S_ADD_U32_1:%[0-9]+]]:sreg_32 = S_ADD_U32 killed [[COPY51]], killed [[COPY47]], implicit-def $scc
+; GCN-ISEL-NEXT:   [[S_ADDC_U32_2:%[0-9]+]]:sreg_32 = S_ADDC_U32 killed [[COPY52]], killed [[COPY48]], implicit-def $scc, implicit $scc
+; GCN-ISEL-NEXT:   [[COPY53:%[0-9]+]]:sreg_32 = COPY [[V_MUL_HI_U32_e64_8]]
+; GCN-ISEL-NEXT:   [[S_ADDC_U32_3:%[0-9]+]]:sreg_32 = S_ADDC_U32 killed [[COPY53]], [[S_MOV_B32_10]], implicit-def dead $scc, implicit $scc
+; GCN-ISEL-NEXT:   [[S_MUL_I32_13:%[0-9]+]]:sreg_32 = S_MUL_I32 [[S_ADD_C]], [[S_ADD_I32_6]]
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE13:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_MUL_I32_13]], %subreg.sub0, killed [[S_ADDC_U32_3]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE14:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_ADD_U32_1]], %subreg.sub0, killed [[S_ADDC_U32_2]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY54:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE14]].sub1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE15:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY54]], %subreg.sub0, [[S_MOV_B32_10]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_ADD_U3:%[0-9]+]]:sreg_64 = S_ADD_U64_PSEUDO killed [[REG_SEQUENCE15]], killed [[REG_SEQUENCE13]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY55:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U3]].sub0
+; GCN-ISEL-NEXT:   [[S_UADDO2:%[0-9]+]]:sreg_32, [[S_UADDO3:%[0-9]+]]:sreg_64_xexec = S_UADDO_PSEUDO [[S_UADDO]], killed [[COPY55]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY56:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U3]].sub1
+; GCN-ISEL-NEXT:   [[S_ADD_C2:%[0-9]+]]:sreg_32, [[S_ADD_C3:%[0-9]+]]:sreg_64_xexec = S_ADD_CO_PSEUDO [[S_ADD_C]], killed [[COPY56]], killed [[S_UADDO3]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY57:%[0-9]+]]:sreg_32 = COPY [[COPY8]].sub0
+; GCN-ISEL-NEXT:   [[COPY58:%[0-9]+]]:vgpr_32 = COPY [[S_ADD_C2]]
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_12:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[COPY57]], [[COPY58]], implicit $exec
+; GCN-ISEL-NEXT:   [[S_MUL_I32_14:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY57]], [[S_ADD_C2]]
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE16:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_MUL_I32_14]], %subreg.sub0, killed [[V_MUL_HI_U32_e64_12]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY59:%[0-9]+]]:vgpr_32 = COPY [[S_UADDO2]]
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_13:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[COPY57]], [[COPY59]], implicit $exec
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE17:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[V_MUL_HI_U32_e64_13]], %subreg.sub0, [[S_MOV_B32_9]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_ADD_U4:%[0-9]+]]:sreg_64 = S_ADD_U64_PSEUDO killed [[REG_SEQUENCE17]], killed [[REG_SEQUENCE16]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY60:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U4]].sub0
+; GCN-ISEL-NEXT:   [[COPY61:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U4]].sub1
+; GCN-ISEL-NEXT:   [[COPY62:%[0-9]+]]:sreg_32 = COPY [[COPY8]].sub1
+; GCN-ISEL-NEXT:   [[COPY63:%[0-9]+]]:vgpr_32 = COPY [[S_ADD_C2]]
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_14:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[COPY62]], [[COPY63]], implicit $exec
+; GCN-ISEL-NEXT:   [[COPY64:%[0-9]+]]:vgpr_32 = COPY [[S_UADDO2]]
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_15:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[COPY62]], [[COPY64]], implicit $exec
+; GCN-ISEL-NEXT:   [[S_MUL_I32_15:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY62]], [[S_UADDO2]]
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE18:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_MUL_I32_15]], %subreg.sub0, killed [[V_MUL_HI_U32_e64_15]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY65:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE18]].sub0
+; GCN-ISEL-NEXT:   [[COPY66:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE18]].sub1
+; GCN-ISEL-NEXT:   [[S_ADD_U32_2:%[0-9]+]]:sreg_32 = S_ADD_U32 killed [[COPY60]], killed [[COPY65]], implicit-def $scc
+; GCN-ISEL-NEXT:   [[S_ADDC_U32_4:%[0-9]+]]:sreg_32 = S_ADDC_U32 killed [[COPY61]], killed [[COPY66]], implicit-def $scc, implicit $scc
+; GCN-ISEL-NEXT:   [[COPY67:%[0-9]+]]:sreg_32 = COPY [[V_MUL_HI_U32_e64_14]]
+; GCN-ISEL-NEXT:   [[S_ADDC_U32_5:%[0-9]+]]:sreg_32 = S_ADDC_U32 killed [[COPY67]], [[S_MOV_B32_10]], implicit-def dead $scc, implicit $scc
+; GCN-ISEL-NEXT:   [[S_MUL_I32_16:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY62]], [[S_ADD_C2]]
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE19:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_MUL_I32_16]], %subreg.sub0, killed [[S_ADDC_U32_5]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE20:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_ADD_U32_2]], %subreg.sub0, killed [[S_ADDC_U32_4]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY68:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE20]].sub1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE21:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY68]], %subreg.sub0, [[S_MOV_B32_10]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_ADD_U5:%[0-9]+]]:sreg_64 = S_ADD_U64_PSEUDO killed [[REG_SEQUENCE21]], killed [[REG_SEQUENCE19]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY69:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U5]].sub1
+; GCN-ISEL-NEXT:   [[S_MUL_I32_17:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY22]], [[COPY69]]
+; GCN-ISEL-NEXT:   [[COPY70:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U5]].sub0
+; GCN-ISEL-NEXT:   [[COPY71:%[0-9]+]]:vgpr_32 = COPY [[COPY70]]
+; GCN-ISEL-NEXT:   [[V_MUL_HI_U32_e64_16:%[0-9]+]]:vgpr_32 = V_MUL_HI_U32_e64 [[COPY22]], [[COPY71]], implicit $exec
+; GCN-ISEL-NEXT:   [[COPY72:%[0-9]+]]:sreg_32 = COPY [[V_MUL_HI_U32_e64_16]]
+; GCN-ISEL-NEXT:   [[S_ADD_I32_7:%[0-9]+]]:sreg_32 = S_ADD_I32 killed [[COPY72]], killed [[S_MUL_I32_17]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[S_MUL_I32_18:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY23]], [[COPY70]]
+; GCN-ISEL-NEXT:   [[S_ADD_I32_8:%[0-9]+]]:sreg_32 = S_ADD_I32 killed [[S_ADD_I32_7]], killed [[S_MUL_I32_18]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[S_SUB_I32_3:%[0-9]+]]:sreg_32 = S_SUB_I32 [[COPY62]], [[S_ADD_I32_8]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[S_MUL_I32_19:%[0-9]+]]:sreg_32 = S_MUL_I32 [[COPY22]], [[COPY70]]
+; GCN-ISEL-NEXT:   [[S_USUBO:%[0-9]+]]:sreg_32, [[S_USUBO1:%[0-9]+]]:sreg_64_xexec = S_USUBO_PSEUDO [[COPY57]], killed [[S_MUL_I32_19]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[S_SUB_C:%[0-9]+]]:sreg_32, [[S_SUB_C1:%[0-9]+]]:sreg_64_xexec = S_SUB_CO_PSEUDO killed [[S_SUB_I32_3]], [[COPY23]], [[S_USUBO1]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[S_USUBO2:%[0-9]+]]:sreg_32, [[S_USUBO3:%[0-9]+]]:sreg_64_xexec = S_USUBO_PSEUDO [[S_USUBO]], [[COPY22]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[S_SUB_C2:%[0-9]+]]:sreg_32, [[S_SUB_C3:%[0-9]+]]:sreg_64_xexec = S_SUB_CO_PSEUDO killed [[S_SUB_C]], [[S_MOV_B32_10]], killed [[S_USUBO3]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   S_CMP_GE_U32 [[S_SUB_C2]], [[COPY23]], implicit-def $scc
+; GCN-ISEL-NEXT:   [[S_MOV_B32_11:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[S_CSELECT_B32_3:%[0-9]+]]:sreg_32 = S_CSELECT_B32 [[S_MOV_B32_11]], [[S_MOV_B32_10]], implicit $scc
+; GCN-ISEL-NEXT:   S_CMP_GE_U32 killed [[S_USUBO2]], [[COPY22]], implicit-def $scc
+; GCN-ISEL-NEXT:   [[S_CSELECT_B32_4:%[0-9]+]]:sreg_32 = S_CSELECT_B32 [[S_MOV_B32_11]], [[S_MOV_B32_10]], implicit $scc
+; GCN-ISEL-NEXT:   S_CMP_EQ_U32 [[S_SUB_C2]], [[COPY23]], implicit-def $scc
+; GCN-ISEL-NEXT:   [[S_CSELECT_B32_5:%[0-9]+]]:sreg_32 = S_CSELECT_B32 killed [[S_CSELECT_B32_4]], killed [[S_CSELECT_B32_3]], implicit $scc
+; GCN-ISEL-NEXT:   [[COPY73:%[0-9]+]]:sreg_32 = COPY killed [[S_CSELECT_B32_5]]
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE22:%[0-9]+]]:sreg_64 = REG_SEQUENCE [[COPY70]], %subreg.sub0, [[COPY69]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_MOV_B64_2:%[0-9]+]]:sreg_64 = S_MOV_B64 1
+; GCN-ISEL-NEXT:   [[S_ADD_U6:%[0-9]+]]:sreg_64 = S_ADD_U64_PSEUDO [[REG_SEQUENCE22]], killed [[S_MOV_B64_2]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY74:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U6]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B64_3:%[0-9]+]]:sreg_64 = S_MOV_B64 2
+; GCN-ISEL-NEXT:   [[S_ADD_U7:%[0-9]+]]:sreg_64 = S_ADD_U64_PSEUDO [[REG_SEQUENCE22]], killed [[S_MOV_B64_3]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   [[COPY75:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U7]].sub0
+; GCN-ISEL-NEXT:   S_CMP_LG_U32 killed [[COPY73]], [[S_MOV_B32_10]], implicit-def $scc
+; GCN-ISEL-NEXT:   [[S_CSELECT_B32_6:%[0-9]+]]:sreg_32 = S_CSELECT_B32 killed [[COPY75]], killed [[COPY74]], implicit $scc
+; GCN-ISEL-NEXT:   [[COPY76:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U6]].sub1
+; GCN-ISEL-NEXT:   [[COPY77:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U7]].sub1
+; GCN-ISEL-NEXT:   [[S_CSELECT_B32_7:%[0-9]+]]:sreg_32 = S_CSELECT_B32 killed [[COPY77]], killed [[COPY76]], implicit $scc
+; GCN-ISEL-NEXT:   [[S_SUB_C4:%[0-9]+]]:sreg_32, [[S_SUB_C5:%[0-9]+]]:sreg_64_xexec = S_SUB_CO_PSEUDO [[COPY62]], [[S_ADD_I32_8]], [[S_USUBO1]], implicit-def dead $scc
+; GCN-ISEL-NEXT:   S_CMP_GE_U32 [[S_SUB_C4]], [[COPY23]], implicit-def $scc
+; GCN-ISEL-NEXT:   [[S_CSELECT_B32_8:%[0-9]+]]:sreg_32 = S_CSELECT_B32 [[S_MOV_B32_11]], [[S_MOV_B32_10]], implicit $scc
+; GCN-ISEL-NEXT:   S_CMP_GE_U32 [[S_USUBO]], [[COPY22]], implicit-def $scc
+; GCN-ISEL-NEXT:   [[S_CSELECT_B32_9:%[0-9]+]]:sreg_32 = S_CSELECT_B32 [[S_MOV_B32_11]], [[S_MOV_B32_10]], implicit $scc
+; GCN-ISEL-NEXT:   S_CMP_EQ_U32 [[S_SUB_C4]], [[COPY23]], implicit-def $scc
+; GCN-ISEL-NEXT:   [[S_CSELECT_B32_10:%[0-9]+]]:sreg_32 = S_CSELECT_B32 killed [[S_CSELECT_B32_9]], killed [[S_CSELECT_B32_8]], implicit $scc
+; GCN-ISEL-NEXT:   [[COPY78:%[0-9]+]]:sreg_32 = COPY killed [[S_CSELECT_B32_10]]
+; GCN-ISEL-NEXT:   S_CMP_LG_U32 killed [[COPY78]], [[S_MOV_B32_10]], implicit-def $scc
+; GCN-ISEL-NEXT:   [[S_CSELECT_B32_11:%[0-9]+]]:sreg_32 = S_CSELECT_B32 killed [[S_CSELECT_B32_7]], [[COPY69]], implicit $scc
+; GCN-ISEL-NEXT:   [[S_CSELECT_B32_12:%[0-9]+]]:sreg_32 = S_CSELECT_B32 killed [[S_CSELECT_B32_6]], [[COPY70]], implicit $scc
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE23:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[S_CSELECT_B32_12]], %subreg.sub0, killed [[S_CSELECT_B32_11]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[S_MOV_B64_4:%[0-9]+]]:sreg_64 = S_MOV_B64 0
+; GCN-ISEL-NEXT:   [[COPY79:%[0-9]+]]:sreg_64 = COPY [[REG_SEQUENCE23]]
+; GCN-ISEL-NEXT:   S_BRANCH %bb.1
+; GCN-ISEL-NEXT: {{  $}}
+; GCN-ISEL-NEXT: bb.4..split:
+; GCN-ISEL-NEXT:   [[PHI2:%[0-9]+]]:sreg_64 = PHI [[PHI]], %bb.1, [[COPY21]], %bb.2
+; GCN-ISEL-NEXT:   [[COPY80:%[0-9]+]]:sreg_32 = COPY [[COPY7]].sub1
+; GCN-ISEL-NEXT:   [[COPY81:%[0-9]+]]:sreg_32 = COPY [[COPY7]].sub0
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE24:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY81]], %subreg.sub0, killed [[COPY80]], %subreg.sub1
+; GCN-ISEL-NEXT:   [[COPY82:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE24]].sub1
+; GCN-ISEL-NEXT:   [[COPY83:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE24]].sub0
+; GCN-ISEL-NEXT:   [[S_MOV_B32_12:%[0-9]+]]:sreg_32 = S_MOV_B32 61440
+; GCN-ISEL-NEXT:   [[S_MOV_B32_13:%[0-9]+]]:sreg_32 = S_MOV_B32 -1
+; GCN-ISEL-NEXT:   [[REG_SEQUENCE25:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY83]], %subreg.sub0, killed [[COPY82]], %subreg.sub1, killed [[S_MOV_B32_13]], %subreg.sub2, killed [[S_MOV_B32_12]], %subreg.sub3
+; GCN-ISEL-NEXT:   [[COPY84:%[0-9]+]]:vreg_64 = COPY [[PHI2]]
+; GCN-ISEL-NEXT:   BUFFER_STORE_DWORDX2_OFFSET [[COPY84]], killed [[REG_SEQUENCE25]], 0, 0, 0, 0, implicit $exec :: (store (s64) into %ir.15, addrspace 1)
+; GCN-ISEL-NEXT:   S_ENDPGM 0
   %result = udiv i64 %x, %y
   store i64 %result, ptr addrspace(1) %out
   ret void
@@ -3221,5 +3821,3 @@ declare i32 @llvm.amdgcn.workitem.id.x() #1
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readnone }
 
-;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GCN-ISEL: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/div-rem-by-constant-64.ll
+++ b/llvm/test/CodeGen/AMDGPU/div-rem-by-constant-64.ll
@@ -1007,25 +1007,25 @@ define noundef i64 @srem64_i32max(i64 noundef %i)  {
 ; GFX9:       ; %bb.0: ; %entry
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_mul_hi_u32 v2, v0, 3
-; GFX9-NEXT:    v_ashrrev_i32_e32 v8, 31, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v8, 3, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v1, 3, v[2:3]
-; GFX9-NEXT:    v_lshl_add_u32 v2, v8, 31, v8
-; GFX9-NEXT:    v_add3_u32 v5, v5, v2, v4
-; GFX9-NEXT:    v_mov_b32_e32 v2, v6
 ; GFX9-NEXT:    s_mov_b32 s6, 0x80000001
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, 3, v[2:3]
+; GFX9-NEXT:    v_ashrrev_i32_e32 v2, 31, v1
+; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v2, 3, 0
+; GFX9-NEXT:    v_lshl_add_u32 v8, v2, 31, v2
+; GFX9-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v0, s6, v[2:3]
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, -1, v[4:5]
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v7, v3
+; GFX9-NEXT:    v_add3_u32 v7, v7, v8, v6
+; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v0, -1, v[6:7]
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v5, v3
 ; GFX9-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, vcc
 ; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v1, s6, v[2:3]
-; GFX9-NEXT:    v_sub_u32_e32 v5, v5, v1
-; GFX9-NEXT:    v_sub_u32_e32 v5, v5, v0
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v5, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v0, 1, v[2:3]
+; GFX9-NEXT:    v_sub_u32_e32 v4, v7, v1
+; GFX9-NEXT:    v_sub_u32_e32 v4, v4, v0
 ; GFX9-NEXT:    s_brev_b32 s6, -2
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v6
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v4, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v0, 1, v[2:3]
 ; GFX9-NEXT:    v_add_u32_e32 v3, v1, v3
 ; GFX9-NEXT:    v_ashrrev_i64 v[4:5], 30, v[2:3]
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v2, 31, v3
@@ -1081,16 +1081,16 @@ define noundef i64 @srem64_i32max(i64 noundef %i)  {
 ; GFX1030-NEXT:    v_ashrrev_i32_e32 v8, 31, v1
 ; GFX1030-NEXT:    v_mad_u64_u32 v[6:7], null, v8, 3, 0
 ; GFX1030-NEXT:    v_mad_u64_u32 v[4:5], null, v1, 3, v[2:3]
-; GFX1030-NEXT:    v_lshl_add_u32 v8, v8, 31, v8
-; GFX1030-NEXT:    v_add3_u32 v7, v7, v8, v6
 ; GFX1030-NEXT:    v_mov_b32_e32 v2, v4
-; GFX1030-NEXT:    v_mad_u64_u32 v[6:7], null, v0, -1, v[6:7]
+; GFX1030-NEXT:    v_lshl_add_u32 v4, v8, 31, v8
 ; GFX1030-NEXT:    v_mad_u64_u32 v[2:3], null, 0x80000001, v0, v[2:3]
-; GFX1030-NEXT:    v_sub_nc_u32_e32 v4, v7, v1
+; GFX1030-NEXT:    v_add3_u32 v7, v7, v4, v6
+; GFX1030-NEXT:    v_mad_u64_u32 v[6:7], null, v0, -1, v[6:7]
 ; GFX1030-NEXT:    v_add_co_u32 v2, s4, v5, v3
 ; GFX1030-NEXT:    v_add_co_ci_u32_e64 v3, null, 0, 0, s4
-; GFX1030-NEXT:    v_sub_nc_u32_e32 v4, v4, v0
+; GFX1030-NEXT:    v_sub_nc_u32_e32 v4, v7, v1
 ; GFX1030-NEXT:    v_mad_u64_u32 v[2:3], null, 0x80000001, v1, v[2:3]
+; GFX1030-NEXT:    v_sub_nc_u32_e32 v4, v4, v0
 ; GFX1030-NEXT:    v_add_co_u32 v2, vcc_lo, v2, v6
 ; GFX1030-NEXT:    v_add_co_ci_u32_e64 v3, null, v3, v4, vcc_lo
 ; GFX1030-NEXT:    v_mad_u64_u32 v[2:3], null, v0, 1, v[2:3]
@@ -1114,23 +1114,23 @@ define noundef i64 @sdiv64_i32max(i64 noundef %i)  {
 ; GFX9:       ; %bb.0: ; %entry
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_mul_hi_u32 v2, v0, 3
-; GFX9-NEXT:    v_ashrrev_i32_e32 v8, 31, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v8, 3, 0
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v1, 3, v[2:3]
-; GFX9-NEXT:    v_lshl_add_u32 v2, v8, 31, v8
-; GFX9-NEXT:    v_add3_u32 v5, v5, v2, v4
-; GFX9-NEXT:    v_mov_b32_e32 v2, v6
 ; GFX9-NEXT:    s_mov_b32 s6, 0x80000001
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, 3, v[2:3]
+; GFX9-NEXT:    v_ashrrev_i32_e32 v2, 31, v1
+; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v2, 3, 0
+; GFX9-NEXT:    v_lshl_add_u32 v8, v2, 31, v2
+; GFX9-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v0, s6, v[2:3]
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, -1, v[4:5]
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v7, v3
+; GFX9-NEXT:    v_add3_u32 v7, v7, v8, v6
+; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v0, -1, v[6:7]
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v5, v3
 ; GFX9-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, vcc
 ; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v1, s6, v[2:3]
-; GFX9-NEXT:    v_sub_u32_e32 v5, v5, v1
-; GFX9-NEXT:    v_sub_u32_e32 v5, v5, v0
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v4
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v5, vcc
+; GFX9-NEXT:    v_sub_u32_e32 v4, v7, v1
+; GFX9-NEXT:    v_sub_u32_e32 v4, v4, v0
+; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v6
+; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v4, vcc
 ; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v0, 1, v[2:3]
 ; GFX9-NEXT:    v_add_u32_e32 v3, v1, v3
 ; GFX9-NEXT:    v_ashrrev_i64 v[0:1], 30, v[2:3]
@@ -1176,16 +1176,16 @@ define noundef i64 @sdiv64_i32max(i64 noundef %i)  {
 ; GFX1030-NEXT:    v_ashrrev_i32_e32 v8, 31, v1
 ; GFX1030-NEXT:    v_mad_u64_u32 v[6:7], null, v8, 3, 0
 ; GFX1030-NEXT:    v_mad_u64_u32 v[4:5], null, v1, 3, v[2:3]
-; GFX1030-NEXT:    v_lshl_add_u32 v8, v8, 31, v8
-; GFX1030-NEXT:    v_add3_u32 v7, v7, v8, v6
 ; GFX1030-NEXT:    v_mov_b32_e32 v2, v4
-; GFX1030-NEXT:    v_mad_u64_u32 v[6:7], null, v0, -1, v[6:7]
+; GFX1030-NEXT:    v_lshl_add_u32 v4, v8, 31, v8
 ; GFX1030-NEXT:    v_mad_u64_u32 v[2:3], null, 0x80000001, v0, v[2:3]
-; GFX1030-NEXT:    v_sub_nc_u32_e32 v4, v7, v1
+; GFX1030-NEXT:    v_add3_u32 v7, v7, v4, v6
+; GFX1030-NEXT:    v_mad_u64_u32 v[6:7], null, v0, -1, v[6:7]
 ; GFX1030-NEXT:    v_add_co_u32 v2, s4, v5, v3
 ; GFX1030-NEXT:    v_add_co_ci_u32_e64 v3, null, 0, 0, s4
-; GFX1030-NEXT:    v_sub_nc_u32_e32 v4, v4, v0
+; GFX1030-NEXT:    v_sub_nc_u32_e32 v4, v7, v1
 ; GFX1030-NEXT:    v_mad_u64_u32 v[2:3], null, 0x80000001, v1, v[2:3]
+; GFX1030-NEXT:    v_sub_nc_u32_e32 v4, v4, v0
 ; GFX1030-NEXT:    v_add_co_u32 v2, vcc_lo, v2, v6
 ; GFX1030-NEXT:    v_add_co_ci_u32_e64 v3, null, v3, v4, vcc_lo
 ; GFX1030-NEXT:    v_mad_u64_u32 v[2:3], null, v0, 1, v[2:3]

--- a/llvm/test/CodeGen/AMDGPU/fptoi.i128.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoi.i128.ll
@@ -31,42 +31,42 @@ define i128 @fptosi_f64_to_i128(double %x) {
 ; SDAG-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
 ; SDAG-NEXT:    s_cbranch_execz .LBB0_3
 ; SDAG-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
+; SDAG-NEXT:    v_add_u32_e32 v3, 0xfffffbcd, v6
 ; SDAG-NEXT:    v_sub_u32_e32 v0, 0x473, v6
 ; SDAG-NEXT:    v_add_u32_e32 v2, 0xfffffb8d, v6
-; SDAG-NEXT:    v_add_u32_e32 v3, 0xfffffbcd, v6
 ; SDAG-NEXT:    v_lshrrev_b64 v[0:1], v0, v[4:5]
 ; SDAG-NEXT:    v_lshlrev_b64 v[6:7], v2, v[4:5]
 ; SDAG-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v3
 ; SDAG-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v3
 ; SDAG-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
 ; SDAG-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
-; SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, v1, s[4:5]
 ; SDAG-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
-; SDAG-NEXT:    v_cndmask_b32_e32 v7, 0, v3, vcc
+; SDAG-NEXT:    v_cndmask_b32_e32 v10, 0, v3, vcc
+; SDAG-NEXT:    v_cndmask_b32_e64 v7, 0, v1, s[4:5]
 ; SDAG-NEXT:    v_cndmask_b32_e64 v5, 0, v0, s[4:5]
-; SDAG-NEXT:    v_mul_lo_u32 v11, v9, v1
-; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v7, v9, 0
+; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v10, v9, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
 ; SDAG-NEXT:    v_cndmask_b32_e32 v12, 0, v4, vcc
+; SDAG-NEXT:    v_mul_lo_u32 v11, v8, v5
 ; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v12, v9, v[1:2]
-; SDAG-NEXT:    v_mul_lo_u32 v10, v8, v5
+; SDAG-NEXT:    v_mul_lo_u32 v7, v9, v7
 ; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v9, v5, 0
+; SDAG-NEXT:    v_mul_lo_u32 v9, v8, v10
 ; SDAG-NEXT:    v_mov_b32_e32 v1, v3
-; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v7, v8, v[1:2]
-; SDAG-NEXT:    v_add3_u32 v6, v6, v11, v10
-; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v8, v7, v[5:6]
+; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v10, v8, v[1:2]
+; SDAG-NEXT:    v_add3_u32 v6, v6, v7, v11
+; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v8, v10, v[5:6]
+; SDAG-NEXT:    v_mul_lo_u32 v7, v8, v12
 ; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v4, v2
 ; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, vcc
-; SDAG-NEXT:    v_mul_lo_u32 v9, v8, v12
-; SDAG-NEXT:    v_mul_lo_u32 v7, v8, v7
 ; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v12, v8, v[2:3]
+; SDAG-NEXT:    v_add3_u32 v4, v9, v6, v7
+; SDAG-NEXT:    ; implicit-def: $vgpr6_vgpr7
+; SDAG-NEXT:    ; implicit-def: $vgpr9
 ; SDAG-NEXT:    ; implicit-def: $vgpr8
-; SDAG-NEXT:    v_add3_u32 v4, v7, v6, v9
 ; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v5
 ; SDAG-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v4, vcc
-; SDAG-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; SDAG-NEXT:    ; implicit-def: $vgpr4_vgpr5
-; SDAG-NEXT:    ; implicit-def: $vgpr9
 ; SDAG-NEXT:  .LBB0_3: ; %Flow
 ; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[8:9]
 ; SDAG-NEXT:    s_cbranch_execz .LBB0_5
@@ -177,37 +177,37 @@ define i128 @fptosi_f64_to_i128(double %x) {
 ; GISEL-NEXT:    s_xor_b64 s[12:13], exec, s[4:5]
 ; GISEL-NEXT:    s_cbranch_execz .LBB0_3
 ; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
-; GISEL-NEXT:    v_add_u32_e32 v2, 0xfffffbcd, v6
-; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v2, v[4:5]
-; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v2
-; GISEL-NEXT:    v_cndmask_b32_e32 v11, 0, v0, vcc
-; GISEL-NEXT:    v_cndmask_b32_e32 v12, 0, v1, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v11, v10, 0
-; GISEL-NEXT:    v_add_u32_e32 v3, 0xfffffb8d, v6
-; GISEL-NEXT:    v_sub_u32_e32 v6, 64, v2
-; GISEL-NEXT:    v_lshrrev_b64 v[6:7], v6, v[4:5]
-; GISEL-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v2
-; GISEL-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v12, v9, v[0:1]
-; GISEL-NEXT:    v_cndmask_b32_e64 v13, v3, 0, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v11, v8, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v13, v8, v[5:6]
-; GISEL-NEXT:    v_mul_lo_u32 v14, v12, v10
-; GISEL-NEXT:    v_mul_lo_u32 v10, v11, v10
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v11, v9, v[1:2]
-; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[8:9], v12, v8, v[5:6]
+; GISEL-NEXT:    v_add_u32_e32 v13, 0xfffffbcd, v6
+; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v13, v[4:5]
+; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v13
+; GISEL-NEXT:    v_sub_u32_e32 v2, 64, v13
+; GISEL-NEXT:    v_cndmask_b32_e32 v14, 0, v0, vcc
+; GISEL-NEXT:    v_add_u32_e32 v11, 0xfffffb8d, v6
+; GISEL-NEXT:    v_lshrrev_b64 v[6:7], v2, v[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v14, v10, 0
+; GISEL-NEXT:    v_cndmask_b32_e32 v15, 0, v1, vcc
+; GISEL-NEXT:    v_lshlrev_b64 v[4:5], v11, v[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v15, v9, v[2:3]
+; GISEL-NEXT:    v_cndmask_b32_e32 v0, v4, v6, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v13
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, v0, 0, s[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v14, v8, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v4, v8, v[11:12]
+; GISEL-NEXT:    v_mul_lo_u32 v6, v15, v10
+; GISEL-NEXT:    v_mul_lo_u32 v10, v14, v10
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[6:7], v14, v9, v[1:2]
+; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[8:9], v15, v8, v[11:12]
 ; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v3, v10, s[8:9]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[6:7], v3, v14, s[6:7]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v13, v9, v[3:4]
-; GISEL-NEXT:    v_cndmask_b32_e32 v3, v4, v7, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, v3, 0, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v7, v8, v[5:6]
+; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[6:7], v3, v6, s[6:7]
+; GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[6:7], v4, v9, v[3:4]
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v5, v7, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, v3, 0, s[4:5]
 ; GISEL-NEXT:    ; implicit-def: $vgpr6
+; GISEL-NEXT:    ; implicit-def: $vgpr9
+; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v5, v8, v[10:11]
 ; GISEL-NEXT:    ; implicit-def: $vgpr4_vgpr5
 ; GISEL-NEXT:    ; implicit-def: $vgpr8
 ; GISEL-NEXT:    ; implicit-def: $vgpr10
-; GISEL-NEXT:    ; implicit-def: $vgpr9
 ; GISEL-NEXT:  .LBB0_3: ; %Flow
 ; GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[12:13]
 ; GISEL-NEXT:    s_cbranch_execz .LBB0_5
@@ -216,8 +216,8 @@ define i128 @fptosi_f64_to_i128(double %x) {
 ; GISEL-NEXT:    v_lshrrev_b64 v[4:5], v0, v[4:5]
 ; GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v4, v10, 0
 ; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v4, v8, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v5, v9, v[6:7]
 ; GISEL-NEXT:    v_mul_lo_u32 v11, v5, v10
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v5, v9, v[6:7]
 ; GISEL-NEXT:    v_mad_u64_u32 v[6:7], vcc, v4, v9, v[1:2]
 ; GISEL-NEXT:    v_mul_lo_u32 v4, v4, v10
 ; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v5, v8, v[6:7]
@@ -395,16 +395,16 @@ define i128 @fptosi_f32_to_i128(float %x) {
 ; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v11, v8, 0
 ; SDAG-NEXT:    v_cndmask_b32_e32 v13, 0, v4, vcc
 ; SDAG-NEXT:    v_mul_lo_u32 v12, v7, v9
-; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v13, v8, v[1:2]
 ; SDAG-NEXT:    v_mul_lo_u32 v6, v8, v6
+; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v13, v8, v[1:2]
 ; SDAG-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v8, v9, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v1, v3
 ; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v11, v7, v[1:2]
 ; SDAG-NEXT:    v_add3_u32 v10, v10, v6, v12
 ; SDAG-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v5, v11, v[9:10]
+; SDAG-NEXT:    v_mul_lo_u32 v6, v5, v13
 ; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v4, v2
 ; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, vcc
-; SDAG-NEXT:    v_mul_lo_u32 v6, v5, v13
 ; SDAG-NEXT:    v_mul_lo_u32 v5, v5, v11
 ; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v13, v7, v[2:3]
 ; SDAG-NEXT:    ; implicit-def: $vgpr7
@@ -514,37 +514,37 @@ define i128 @fptosi_f32_to_i128(float %x) {
 ; GISEL-NEXT:    s_xor_b64 s[12:13], exec, s[4:5]
 ; GISEL-NEXT:    s_cbranch_execz .LBB2_3
 ; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
-; GISEL-NEXT:    v_add_u32_e32 v2, 0xffffff6a, v6
-; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v2, v[4:5]
-; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v2
-; GISEL-NEXT:    v_cndmask_b32_e32 v12, 0, v0, vcc
-; GISEL-NEXT:    v_cndmask_b32_e32 v13, 0, v1, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v12, v9, 0
-; GISEL-NEXT:    v_add_u32_e32 v3, 0xffffff2a, v6
-; GISEL-NEXT:    v_sub_u32_e32 v6, 64, v2
-; GISEL-NEXT:    v_lshrrev_b64 v[10:11], v6, v[4:5]
-; GISEL-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v13, v8, v[0:1]
-; GISEL-NEXT:    v_cndmask_b32_e32 v3, v3, v10, vcc
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v2
-; GISEL-NEXT:    v_cndmask_b32_e64 v10, v3, 0, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v12, v7, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v10, v7, v[5:6]
-; GISEL-NEXT:    v_mul_lo_u32 v14, v13, v9
-; GISEL-NEXT:    v_mul_lo_u32 v9, v12, v9
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v12, v8, v[1:2]
-; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[8:9], v13, v7, v[5:6]
+; GISEL-NEXT:    v_add_u32_e32 v14, 0xffffff6a, v6
+; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v14, v[4:5]
+; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v14
+; GISEL-NEXT:    v_sub_u32_e32 v2, 64, v14
+; GISEL-NEXT:    v_cndmask_b32_e32 v15, 0, v0, vcc
+; GISEL-NEXT:    v_lshrrev_b64 v[10:11], v2, v[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v15, v9, 0
+; GISEL-NEXT:    v_add_u32_e32 v6, 0xffffff2a, v6
+; GISEL-NEXT:    v_lshlrev_b64 v[4:5], v6, v[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e32 v6, 0, v1, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v6, v8, v[2:3]
+; GISEL-NEXT:    v_cndmask_b32_e32 v0, v4, v10, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v14
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, v0, 0, s[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v15, v7, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v4, v7, v[12:13]
+; GISEL-NEXT:    v_mul_lo_u32 v10, v6, v9
+; GISEL-NEXT:    v_mul_lo_u32 v9, v15, v9
+; GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[6:7], v15, v8, v[1:2]
+; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[8:9], v6, v7, v[12:13]
 ; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v3, v9, s[8:9]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[6:7], v3, v14, s[6:7]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v10, v8, v[3:4]
-; GISEL-NEXT:    v_cndmask_b32_e32 v3, v4, v11, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, v3, 0, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v8, v7, v[5:6]
+; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[6:7], v3, v10, s[6:7]
+; GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[6:7], v4, v8, v[3:4]
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v5, v11, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, v3, 0, s[4:5]
 ; GISEL-NEXT:    ; implicit-def: $vgpr6
+; GISEL-NEXT:    ; implicit-def: $vgpr8
+; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v5, v7, v[9:10]
 ; GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GISEL-NEXT:    ; implicit-def: $vgpr7
 ; GISEL-NEXT:    ; implicit-def: $vgpr9
-; GISEL-NEXT:    ; implicit-def: $vgpr8
 ; GISEL-NEXT:  .LBB2_3: ; %Flow
 ; GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[12:13]
 ; GISEL-NEXT:    s_cbranch_execz .LBB2_5
@@ -769,25 +769,25 @@ define i128 @fptosi_bf16_to_i128(bfloat %x) {
 ; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v10, v5, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
 ; SDAG-NEXT:    v_cndmask_b32_e32 v13, 0, v4, vcc
-; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v13, v5, v[1:2]
 ; SDAG-NEXT:    v_mul_lo_u32 v11, v6, v8
+; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v13, v5, v[1:2]
 ; SDAG-NEXT:    v_mul_lo_u32 v12, v5, v9
+; SDAG-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v5, v8, 0
+; SDAG-NEXT:    v_mul_lo_u32 v5, v7, v13
 ; SDAG-NEXT:    v_mov_b32_e32 v1, v3
 ; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v10, v6, v[1:2]
-; SDAG-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v5, v8, 0
-; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v4, v2
 ; SDAG-NEXT:    v_add3_u32 v9, v9, v12, v11
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, vcc
 ; SDAG-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v7, v10, v[8:9]
-; SDAG-NEXT:    v_mul_lo_u32 v5, v7, v13
 ; SDAG-NEXT:    v_mul_lo_u32 v7, v7, v10
+; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v4, v2
+; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, vcc
 ; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v13, v6, v[2:3]
 ; SDAG-NEXT:    v_add3_u32 v4, v7, v9, v5
+; SDAG-NEXT:    ; implicit-def: $vgpr5
 ; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v8
 ; SDAG-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v4, vcc
 ; SDAG-NEXT:    ; implicit-def: $vgpr8
 ; SDAG-NEXT:    ; implicit-def: $vgpr4
-; SDAG-NEXT:    ; implicit-def: $vgpr5
 ; SDAG-NEXT:  .LBB6_3: ; %Flow
 ; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[8:9]
 ; SDAG-NEXT:  ; %bb.4: ; %fp-to-i-if-exp.small
@@ -884,35 +884,35 @@ define i128 @fptosi_bf16_to_i128(bfloat %x) {
 ; GISEL-NEXT:    s_cbranch_execz .LBB6_3
 ; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
 ; GISEL-NEXT:    v_mov_b32_e32 v0, 0xffffff7a
-; GISEL-NEXT:    v_add_u16_sdwa v2, v6, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GISEL-NEXT:    v_add_u16_sdwa v6, v6, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GISEL-NEXT:    v_and_b32_e32 v4, 0xffff, v4
-; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v2, v[4:5]
-; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v2
-; GISEL-NEXT:    v_lshl_or_b32 v11, v9, 16, v9
-; GISEL-NEXT:    v_cndmask_b32_e32 v12, 0, v0, vcc
-; GISEL-NEXT:    v_cndmask_b32_e32 v13, 0, v1, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v12, v11, 0
-; GISEL-NEXT:    v_add_u32_e32 v3, 0xffffffc0, v2
-; GISEL-NEXT:    v_sub_u32_e32 v6, 64, v2
-; GISEL-NEXT:    v_lshrrev_b64 v[9:10], v6, v[4:5]
-; GISEL-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v13, v8, v[0:1]
-; GISEL-NEXT:    v_cndmask_b32_e32 v3, v3, v9, vcc
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v2
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, v3, 0, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v12, v7, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v9, v7, v[5:6]
-; GISEL-NEXT:    v_mul_lo_u32 v14, v13, v11
-; GISEL-NEXT:    v_mul_lo_u32 v11, v12, v11
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v12, v8, v[1:2]
-; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[8:9], v13, v7, v[5:6]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v3, v11, s[8:9]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[6:7], v3, v14, s[6:7]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v9, v8, v[3:4]
-; GISEL-NEXT:    v_cndmask_b32_e32 v3, v4, v10, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, v3, 0, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v8, v7, v[5:6]
+; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v6, v[4:5]
+; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v6
+; GISEL-NEXT:    v_lshl_or_b32 v13, v9, 16, v9
+; GISEL-NEXT:    v_sub_u32_e32 v2, 64, v6
+; GISEL-NEXT:    v_cndmask_b32_e32 v14, 0, v0, vcc
+; GISEL-NEXT:    v_lshrrev_b64 v[9:10], v2, v[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v14, v13, 0
+; GISEL-NEXT:    v_add_u32_e32 v11, 0xffffffc0, v6
+; GISEL-NEXT:    v_cndmask_b32_e32 v15, 0, v1, vcc
+; GISEL-NEXT:    v_lshlrev_b64 v[4:5], v11, v[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v15, v8, v[2:3]
+; GISEL-NEXT:    v_cndmask_b32_e32 v0, v4, v9, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v6
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, v0, 0, s[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v14, v7, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v4, v7, v[11:12]
+; GISEL-NEXT:    v_mul_lo_u32 v9, v14, v13
+; GISEL-NEXT:    v_mul_lo_u32 v6, v15, v13
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[6:7], v14, v8, v[1:2]
+; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[8:9], v15, v7, v[11:12]
+; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v3, v9, s[8:9]
+; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[6:7], v3, v6, s[6:7]
+; GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[6:7], v4, v8, v[3:4]
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v5, v10, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, v3, 0, s[4:5]
 ; GISEL-NEXT:    ; implicit-def: $vgpr6
+; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v5, v7, v[11:12]
 ; GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GISEL-NEXT:    ; implicit-def: $vgpr7
 ; GISEL-NEXT:  .LBB6_3: ; %Flow

--- a/llvm/test/CodeGen/AMDGPU/integer-mad-patterns.ll
+++ b/llvm/test/CodeGen/AMDGPU/integer-mad-patterns.ll
@@ -3877,24 +3877,24 @@ define <3 x i32> @clpeak_imad_pat_v3i32(<3 x i32> %x, <3 x i32> %y) {
 ; GFX900-SDAG-LABEL: clpeak_imad_pat_v3i32:
 ; GFX900-SDAG:       ; %bb.0: ; %entry
 ; GFX900-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, 1, v2
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v6, v2, v5
 ; GFX900-SDAG-NEXT:    v_add_u32_e32 v0, 1, v0
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v8, v0, v3
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, 1, v2
 ; GFX900-SDAG-NEXT:    v_add_u32_e32 v1, 1, v1
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v7, v0, v3
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v8, v1, v4
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, v6, v2
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v5, v2, v5
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v0, v7, v0
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v1, v8, v1
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v7, v2, v5
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v6, v1, v4
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v0, v8, v0
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v0, v0, v3
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v9, v7, v2
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v1, v6, v1
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v2, v1, v4
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v5, v6, v[5:6]
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v0, v7, v[0:1]
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v2, v8, v[2:3]
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v0, v[6:7]
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v7, v2, v[7:8]
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v3, v5, v[3:4]
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v3, v9, v5
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, v8, v[0:1]
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v2, v6, v[2:3]
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v3, v7, v[3:4]
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v4, v0, v[4:5]
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v5, v2, v[5:6]
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v6, v3, v[6:7]
 ; GFX900-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-GISEL-LABEL: clpeak_imad_pat_v3i32:
@@ -4476,30 +4476,30 @@ define <4 x i32> @clpeak_imad_pat_v4i32(<4 x i32> %x, <4 x i32> %y) {
 ; GFX900-SDAG-LABEL: clpeak_imad_pat_v4i32:
 ; GFX900-SDAG:       ; %bb.0: ; %entry
 ; GFX900-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v3, 1, v3
 ; GFX900-SDAG-NEXT:    v_add_u32_e32 v0, 1, v0
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, 1, v2
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v8, v3, v7
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v11, v0, v4
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v9, v2, v6
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v3, 1, v3
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, 1, v2
 ; GFX900-SDAG-NEXT:    v_add_u32_e32 v1, 1, v1
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v9, v3, v7
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v8, v2, v6
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v10, v1, v5
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v3, v8, v3
 ; GFX900-SDAG-NEXT:    v_add_u32_e32 v0, v11, v0
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v12, v9, v2
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v0, v0, v4
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v4, v3, v7
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v3, v12, v6
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v12, v9, v3
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v3, v8, v2
 ; GFX900-SDAG-NEXT:    v_add_u32_e32 v1, v10, v1
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v2, v1, v5
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v8, v[4:5]
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v3, v9, v[3:4]
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v0, v11, v[0:1]
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v2, v10, v[2:3]
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v7, v0, v[7:8]
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v8, v2, v[8:9]
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v6, v3, v[6:7]
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v5, v4, v[5:6]
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v3, v3, v6
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v4, v12, v7
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v0, v11, v[0:1]
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v2, v10, v[2:3]
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v3, v8, v[3:4]
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v4, v9, v[4:5]
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v0, v[5:6]
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v6, v2, v[6:7]
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v7, v3, v[7:8]
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v8, v4, v[8:9]
 ; GFX900-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-GISEL-LABEL: clpeak_imad_pat_v4i32:
@@ -4584,11 +4584,11 @@ define <4 x i32> @clpeak_imad_pat_v4i32(<4 x i32> %x, <4 x i32> %y) {
 ; GFX10-SDAG-NEXT:    v_add_nc_u32_e32 v0, v8, v0
 ; GFX10-SDAG-NEXT:    v_add_nc_u32_e32 v1, v9, v1
 ; GFX10-SDAG-NEXT:    v_add_nc_u32_e32 v12, v10, v2
+; GFX10-SDAG-NEXT:    v_add_nc_u32_e32 v13, v11, v3
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v0, v0, v4
-; GFX10-SDAG-NEXT:    v_add_nc_u32_e32 v4, v11, v3
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v2, v1, v5
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v3, v12, v6
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v4, v4, v7
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v4, v13, v7
 ; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[5:6], null, v0, v8, v[0:1]
 ; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[6:7], null, v2, v9, v[2:3]
 ; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[7:8], null, v3, v10, v[3:4]
@@ -4652,26 +4652,26 @@ define <4 x i32> @clpeak_imad_pat_v4i32(<4 x i32> %x, <4 x i32> %y) {
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GFX11-SDAG-NEXT:    v_add_nc_u32_e32 v0, v8, v0
 ; GFX11-SDAG-NEXT:    v_add_nc_u32_e32 v1, v9, v1
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-SDAG-NEXT:    v_add_nc_u32_e32 v12, v10, v2
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v2, v0, v4
-; GFX11-SDAG-NEXT:    v_add_nc_u32_e32 v0, v11, v3
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-SDAG-NEXT:    v_add_nc_u32_e32 v12, v10, v2
+; GFX11-SDAG-NEXT:    v_add_nc_u32_e32 v13, v11, v3
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v2, v0, v4
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v3, v1, v5
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v4, v12, v6
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v5, v13, v7
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v5, v0, v7
 ; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[6:7], null, v2, v8, v[2:3]
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[7:8], null, v3, v9, v[3:4]
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[8:9], null, v4, v10, v[4:5]
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[9:10], null, v5, v11, v[5:6]
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[0:1], null, v6, v2, v[6:7]
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[0:1], null, v6, v2, v[6:7]
 ; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[1:2], null, v7, v3, v[7:8]
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[2:3], null, v8, v4, v[8:9]
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4)
 ; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[3:4], null, v9, v5, v[9:10]
 ; GFX11-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4740,15 +4740,16 @@ define <4 x i32> @clpeak_imad_pat_v4i32(<4 x i32> %x, <4 x i32> %y) {
 ; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GFX1200-SDAG-NEXT:    v_add_nc_u32_e32 v0, v8, v0
 ; GFX1200-SDAG-NEXT:    v_add_nc_u32_e32 v1, v9, v1
-; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX1200-SDAG-NEXT:    v_add_nc_u32_e32 v12, v10, v2
-; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v0, v0, v4
-; GFX1200-SDAG-NEXT:    v_add_nc_u32_e32 v4, v11, v3
 ; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-SDAG-NEXT:    v_add_nc_u32_e32 v12, v10, v2
+; GFX1200-SDAG-NEXT:    v_add_nc_u32_e32 v13, v11, v3
+; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v0, v0, v4
 ; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v2, v1, v5
+; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v3, v12, v6
-; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v4, v4, v7
+; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v4, v13, v7
+; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1200-SDAG-NEXT:    v_mad_co_u64_u32 v[5:6], null, v0, v8, v[0:1]
 ; GFX1200-SDAG-NEXT:    v_mad_co_u64_u32 v[6:7], null, v2, v9, v[2:3]
 ; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
@@ -6564,17 +6565,17 @@ define i64 @clpeak_imad_pat_i64(i64 %x, i64 %y) {
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v2, 0
 ; GFX7-GISEL-NEXT:    v_addc_u32_e32 v11, vcc, v6, v9, vcc
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v1, v3, v[5:6]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v2, v[7:8]
-; GFX7-GISEL-NEXT:    v_add_i32_e32 v7, vcc, 1, v0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v7, 0
+; GFX7-GISEL-NEXT:    v_add_i32_e32 v12, vcc, 1, v0
 ; GFX7-GISEL-NEXT:    v_addc_u32_e32 v0, vcc, 0, v6, vcc
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v12, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v2, v[7:8]
 ; GFX7-GISEL-NEXT:    v_add_i32_e32 v8, vcc, 1, v4
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v0, v[3:4]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v2, v8, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v0, v[6:7]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v8, 0
 ; GFX7-GISEL-NEXT:    v_addc_u32_e32 v10, vcc, 0, v9, vcc
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v9, v7, v[5:6]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v10, v[1:2]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v3, v8, v[4:5]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v9, v12, v[2:3]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v5, v10, v[1:2]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v6, v8, v[3:4]
 ; GFX7-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-SDAG-LABEL: clpeak_imad_pat_i64:
@@ -6618,17 +6619,17 @@ define i64 @clpeak_imad_pat_i64(i64 %x, i64 %y) {
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v2, 0
 ; GFX8-GISEL-NEXT:    v_addc_u32_e32 v11, vcc, v6, v9, vcc
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v1, v3, v[5:6]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v2, v[7:8]
-; GFX8-GISEL-NEXT:    v_add_u32_e32 v7, vcc, 1, v0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v7, 0
+; GFX8-GISEL-NEXT:    v_add_u32_e32 v12, vcc, 1, v0
 ; GFX8-GISEL-NEXT:    v_addc_u32_e32 v0, vcc, 0, v6, vcc
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v12, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v2, v[7:8]
 ; GFX8-GISEL-NEXT:    v_add_u32_e32 v8, vcc, 1, v4
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v0, v[3:4]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v2, v8, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v0, v[6:7]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v8, 0
 ; GFX8-GISEL-NEXT:    v_addc_u32_e32 v10, vcc, 0, v9, vcc
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v9, v7, v[5:6]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v10, v[1:2]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v3, v8, v[4:5]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v9, v12, v[2:3]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v5, v10, v[1:2]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v6, v8, v[3:4]
 ; GFX8-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-SDAG-LABEL: clpeak_imad_pat_i64:
@@ -6668,17 +6669,17 @@ define i64 @clpeak_imad_pat_i64(i64 %x, i64 %y) {
 ; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v1, v2, 0
 ; GFX900-GISEL-NEXT:    v_addc_co_u32_e32 v11, vcc, v6, v9, vcc
 ; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v1, v3, v[5:6]
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v2, v[7:8]
-; GFX900-GISEL-NEXT:    v_add_co_u32_e32 v7, vcc, 1, v0
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v7, 0
+; GFX900-GISEL-NEXT:    v_add_co_u32_e32 v12, vcc, 1, v0
 ; GFX900-GISEL-NEXT:    v_addc_co_u32_e32 v0, vcc, 0, v6, vcc
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v12, 0
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v11, v2, v[7:8]
 ; GFX900-GISEL-NEXT:    v_add_co_u32_e32 v8, vcc, 1, v4
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v0, v[3:4]
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v2, v8, 0
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v0, v[6:7]
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v8, 0
 ; GFX900-GISEL-NEXT:    v_addc_co_u32_e32 v10, vcc, 0, v9, vcc
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v9, v7, v[5:6]
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v10, v[1:2]
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v3, v8, v[4:5]
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v9, v12, v[2:3]
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v5, v10, v[1:2]
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v6, v8, v[3:4]
 ; GFX900-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX90A-SDAG-LABEL: clpeak_imad_pat_i64:
@@ -6778,8 +6779,8 @@ define i64 @clpeak_imad_pat_i64(i64 %x, i64 %y) {
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v9, v2, v[7:8]
 ; GFX10-GISEL-NEXT:    v_add_co_u32 v7, vcc_lo, v4, 1
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[3:4], null, v4, v0, v[6:7]
-; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v4, null, 0, v2, vcc_lo
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v5, v7, 0
+; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v4, null, 0, v2, vcc_lo
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v2, v8, v[3:4]
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[3:4], null, v5, v4, v[1:2]
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[1:2], null, v2, v7, v[3:4]
@@ -7189,10 +7190,10 @@ define <2 x i64> @clpeak_imad_pat_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v9, v9, v4
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v4, v10, v6
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v5, vcc, v8, v5
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v3, vcc, v3, v9
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v8, vcc, v5, v4
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v6, v8, v1
 ; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v7, v1, v[7:8]
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v3, vcc, v3, v9
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v1, v3, v0
 ; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v2, v0, v[2:3]
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
@@ -7235,27 +7236,27 @@ define <2 x i64> @clpeak_imad_pat_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v9, v6, 0
 ; GFX7-GISEL-NEXT:    v_addc_u32_e32 v12, vcc, v11, v17, vcc
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v9, v7, v[3:4]
-; GFX7-GISEL-NEXT:    v_add_i32_e32 v9, vcc, 1, v0
-; GFX7-GISEL-NEXT:    v_addc_u32_e32 v7, vcc, 0, v10, vcc
-; GFX7-GISEL-NEXT:    v_add_i32_e32 v10, vcc, 1, v1
+; GFX7-GISEL-NEXT:    v_add_i32_e32 v3, vcc, 1, v1
+; GFX7-GISEL-NEXT:    v_addc_u32_e32 v1, vcc, 0, v11, vcc
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[14:15], s[4:5], v12, v6, v[4:5]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v10, 0
-; GFX7-GISEL-NEXT:    v_addc_u32_e32 v3, vcc, 0, v11, vcc
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v2, v3, v[5:6]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v8, v9, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v3, 0
+; GFX7-GISEL-NEXT:    v_add_i32_e32 v11, vcc, 1, v0
+; GFX7-GISEL-NEXT:    v_addc_u32_e32 v7, vcc, 0, v10, vcc
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v2, v1, v[5:6]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v8, v11, 0
 ; GFX7-GISEL-NEXT:    v_add_i32_e32 v15, vcc, 1, v2
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v8, v7, v[6:7]
+; GFX7-GISEL-NEXT:    v_addc_u32_e32 v17, vcc, 0, v14, vcc
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v7, v[6:7]
 ; GFX7-GISEL-NEXT:    v_add_i32_e64 v16, s[4:5], 1, v8
 ; GFX7-GISEL-NEXT:    v_addc_u32_e64 v6, s[4:5], 0, v13, s[4:5]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v13, v9, v[2:3]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v14, v10, v[0:1]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v13, v11, v[0:1]
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v16, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v14, v3, v[9:10]
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v15, 0
-; GFX7-GISEL-NEXT:    v_addc_u32_e32 v17, vcc, 0, v14, vcc
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v5, v6, v[1:2]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v4, v17, v[3:4]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v16, v[9:10]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v8, v15, v[11:12]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v5, v6, v[1:2]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v4, v17, v[3:4]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v16, v[8:9]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v11, v15, v[12:13]
 ; GFX7-GISEL-NEXT:    v_mov_b32_e32 v1, v5
 ; GFX7-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -7288,10 +7289,10 @@ define <2 x i64> @clpeak_imad_pat_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v9, v9, v4
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v4, v10, v6
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v5, vcc, v8, v5
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v3, vcc, v3, v9
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v8, vcc, v5, v4
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v6, v8, v1
 ; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v7, v1, v[7:8]
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v3, vcc, v3, v9
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v1, v3, v0
 ; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v2, v0, v[2:3]
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v5, vcc, v6, v5
@@ -7334,27 +7335,27 @@ define <2 x i64> @clpeak_imad_pat_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v9, v6, 0
 ; GFX8-GISEL-NEXT:    v_addc_u32_e32 v12, vcc, v11, v17, vcc
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v9, v7, v[3:4]
-; GFX8-GISEL-NEXT:    v_add_u32_e32 v9, vcc, 1, v0
-; GFX8-GISEL-NEXT:    v_addc_u32_e32 v7, vcc, 0, v10, vcc
-; GFX8-GISEL-NEXT:    v_add_u32_e32 v10, vcc, 1, v1
+; GFX8-GISEL-NEXT:    v_add_u32_e32 v3, vcc, 1, v1
+; GFX8-GISEL-NEXT:    v_addc_u32_e32 v1, vcc, 0, v11, vcc
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[14:15], s[4:5], v12, v6, v[4:5]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v10, 0
-; GFX8-GISEL-NEXT:    v_addc_u32_e32 v3, vcc, 0, v11, vcc
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v2, v3, v[5:6]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v8, v9, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v3, 0
+; GFX8-GISEL-NEXT:    v_add_u32_e32 v11, vcc, 1, v0
+; GFX8-GISEL-NEXT:    v_addc_u32_e32 v7, vcc, 0, v10, vcc
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v2, v1, v[5:6]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v8, v11, 0
 ; GFX8-GISEL-NEXT:    v_add_u32_e32 v15, vcc, 1, v2
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v8, v7, v[6:7]
+; GFX8-GISEL-NEXT:    v_addc_u32_e32 v17, vcc, 0, v14, vcc
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v7, v[6:7]
 ; GFX8-GISEL-NEXT:    v_add_u32_e64 v16, s[4:5], 1, v8
 ; GFX8-GISEL-NEXT:    v_addc_u32_e64 v6, s[4:5], 0, v13, s[4:5]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v13, v9, v[2:3]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v14, v10, v[0:1]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v13, v11, v[0:1]
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v16, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v14, v3, v[9:10]
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v15, 0
-; GFX8-GISEL-NEXT:    v_addc_u32_e32 v17, vcc, 0, v14, vcc
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v5, v6, v[1:2]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v4, v17, v[3:4]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v16, v[9:10]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v8, v15, v[11:12]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v5, v6, v[1:2]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v4, v17, v[3:4]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v16, v[8:9]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v11, v15, v[12:13]
 ; GFX8-GISEL-NEXT:    v_mov_b32_e32 v1, v5
 ; GFX8-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -7385,16 +7386,16 @@ define <2 x i64> @clpeak_imad_pat_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v8, v6, 0
 ; GFX900-SDAG-NEXT:    v_add3_u32 v4, v4, v11, v10
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v10, v4, v0
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v11, v3, v12
 ; GFX900-SDAG-NEXT:    v_add3_u32 v6, v6, v7, v9
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v9, v6, v2
 ; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v5, v2, v[5:6]
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v2, v5, v1
 ; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v3, v0, v[3:4]
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v11, v3, v12
-; GFX900-SDAG-NEXT:    v_add3_u32 v8, v9, v8, v2
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v4, v0, v4
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v6, v7, v6
+; GFX900-SDAG-NEXT:    v_add3_u32 v8, v9, v8, v2
 ; GFX900-SDAG-NEXT:    v_add3_u32 v1, v10, v1, v11
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v4, v0, v4
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v9, v1, v3
 ; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, v3, v[0:1]
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v10, v8, v5
@@ -7425,27 +7426,27 @@ define <2 x i64> @clpeak_imad_pat_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v9, v6, 0
 ; GFX900-GISEL-NEXT:    v_addc_co_u32_e32 v12, vcc, v11, v17, vcc
 ; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v9, v7, v[3:4]
-; GFX900-GISEL-NEXT:    v_add_co_u32_e32 v9, vcc, 1, v0
-; GFX900-GISEL-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v10, vcc
-; GFX900-GISEL-NEXT:    v_add_co_u32_e32 v10, vcc, 1, v1
+; GFX900-GISEL-NEXT:    v_add_co_u32_e32 v3, vcc, 1, v1
+; GFX900-GISEL-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v11, vcc
 ; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[14:15], s[4:5], v12, v6, v[4:5]
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v10, 0
-; GFX900-GISEL-NEXT:    v_addc_co_u32_e32 v3, vcc, 0, v11, vcc
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v2, v3, v[5:6]
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v8, v9, 0
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v3, 0
+; GFX900-GISEL-NEXT:    v_add_co_u32_e32 v11, vcc, 1, v0
+; GFX900-GISEL-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v10, vcc
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v2, v1, v[5:6]
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v8, v11, 0
 ; GFX900-GISEL-NEXT:    v_add_co_u32_e32 v15, vcc, 1, v2
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v8, v7, v[6:7]
+; GFX900-GISEL-NEXT:    v_addc_co_u32_e32 v17, vcc, 0, v14, vcc
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v7, v[6:7]
 ; GFX900-GISEL-NEXT:    v_add_co_u32_e64 v16, s[4:5], 1, v8
 ; GFX900-GISEL-NEXT:    v_addc_co_u32_e64 v6, s[4:5], 0, v13, s[4:5]
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v13, v9, v[2:3]
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v14, v10, v[0:1]
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v13, v11, v[0:1]
 ; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v16, 0
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v14, v3, v[9:10]
 ; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v15, 0
-; GFX900-GISEL-NEXT:    v_addc_co_u32_e32 v17, vcc, 0, v14, vcc
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v5, v6, v[1:2]
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v4, v17, v[3:4]
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v16, v[9:10]
-; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v8, v15, v[11:12]
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v5, v6, v[1:2]
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v4, v17, v[3:4]
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v16, v[8:9]
+; GFX900-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v11, v15, v[12:13]
 ; GFX900-GISEL-NEXT:    v_mov_b32_e32 v1, v5
 ; GFX900-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -7575,15 +7576,15 @@ define <2 x i64> @clpeak_imad_pat_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; GFX10-SDAG-NEXT:    v_add3_u32 v6, v6, v7, v9
 ; GFX10-SDAG-NEXT:    v_add3_u32 v4, v4, v11, v10
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v11, v3, v12
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v12, v5, v13
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v9, v6, v2
-; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[7:8], null, v5, v2, v[5:6]
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v10, v4, v0
 ; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[0:1], null, v3, v0, v[3:4]
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v2, v5, v13
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v6, v7, v6
+; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[7:8], null, v5, v2, v[5:6]
 ; GFX10-SDAG-NEXT:    v_add3_u32 v1, v10, v1, v11
+; GFX10-SDAG-NEXT:    v_add3_u32 v8, v9, v8, v12
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v4, v0, v4
-; GFX10-SDAG-NEXT:    v_add3_u32 v8, v9, v8, v2
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v6, v7, v6
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v9, v1, v3
 ; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[0:1], null, v0, v3, v[0:1]
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v10, v8, v5
@@ -7596,45 +7597,45 @@ define <2 x i64> @clpeak_imad_pat_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; GFX10-GISEL:       ; %bb.0: ; %entry
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-GISEL-NEXT:    v_add_co_u32 v11, vcc_lo, v0, 1
-; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v15, null, 0, v1, vcc_lo
-; GFX10-GISEL-NEXT:    v_add_co_u32 v16, vcc_lo, v2, 1
+; GFX10-GISEL-NEXT:    v_add_co_u32 v15, s4, v2, 1
+; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v16, null, 0, v1, vcc_lo
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v11, v4, 0
-; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v17, null, 0, v3, vcc_lo
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v16, v6, 0
+; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v17, null, 0, v3, s4
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v15, v6, 0
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v11, v5, v[1:2]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v16, v7, v[3:4]
-; GFX10-GISEL-NEXT:    v_add_co_u32 v1, vcc_lo, v0, v11
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[12:13], null, v15, v4, v[8:9]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v15, v7, v[3:4]
+; GFX10-GISEL-NEXT:    v_add_co_u32 v3, vcc_lo, v2, v15
+; GFX10-GISEL-NEXT:    v_add_co_u32 v1, s4, v0, v11
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[12:13], null, v16, v4, v[8:9]
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[13:14], null, v17, v6, v[9:10]
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v1, v4, 0
-; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v3, null, v12, v15, vcc_lo
-; GFX10-GISEL-NEXT:    v_add_co_u32 v16, vcc_lo, v2, v16
-; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v18, null, v13, v17, vcc_lo
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[10:11], null, v16, v6, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[14:15], null, v1, v5, v[9:10]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[15:16], null, v16, v7, v[11:12]
-; GFX10-GISEL-NEXT:    v_add_co_u32 v11, vcc_lo, v0, 1
-; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v0, null, 0, v12, vcc_lo
-; GFX10-GISEL-NEXT:    v_add_co_u32 v12, vcc_lo, v2, 1
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[16:17], null, v3, v4, v[14:15]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[4:5], null, v8, v11, 0
-; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v13, vcc_lo
-; GFX10-GISEL-NEXT:    v_add_co_u32 v13, vcc_lo, v8, 1
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[14:15], null, v18, v6, v[15:16]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[6:7], null, v10, v12, 0
-; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v15, null, 0, v16, vcc_lo
-; GFX10-GISEL-NEXT:    v_add_co_u32 v17, vcc_lo, v10, 1
-; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v18, null, 0, v14, vcc_lo
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v8, v0, v[5:6]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v6, v17, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v10, v1, v[7:8]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v4, v13, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[7:8], null, v16, v11, v[8:9]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[4:5], null, v4, v15, v[1:2]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v14, v12, v[9:10]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v6, v18, v[3:4]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[5:6], null, v7, v13, v[4:5]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[3:4], null, v8, v17, v[9:10]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[10:11], null, v3, v6, 0
+; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v15, null, v12, v16, s4
+; GFX10-GISEL-NEXT:    v_add_co_u32 v18, s4, v0, 1
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v1, v5, v[9:10]
+; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v16, null, v13, v17, vcc_lo
+; GFX10-GISEL-NEXT:    v_add_co_u32 v17, vcc_lo, v2, 1
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[1:2], null, v3, v7, v[11:12]
+; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v19, null, 0, v12, s4
+; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v2, null, 0, v13, vcc_lo
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[11:12], null, v8, v18, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[13:14], null, v10, v17, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[4:5], null, v15, v4, v[0:1]
+; GFX10-GISEL-NEXT:    v_add_co_u32 v15, vcc_lo, v10, 1
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[5:6], null, v16, v6, v[1:2]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[6:7], null, v8, v19, v[12:13]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v10, v2, v[14:15]
+; GFX10-GISEL-NEXT:    v_add_co_u32 v10, s4, v8, 1
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v13, v15, 0
+; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v8, null, 0, v4, s4
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v11, v10, 0
+; GFX10-GISEL-NEXT:    v_add_co_ci_u32_e64 v12, null, 0, v5, vcc_lo
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[6:7], null, v4, v18, v[6:7]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[4:5], null, v5, v17, v[9:10]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[7:8], null, v11, v8, v[1:2]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v13, v12, v[3:4]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[5:6], null, v6, v10, v[7:8]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[3:4], null, v4, v15, v[8:9]
 ; GFX10-GISEL-NEXT:    v_mov_b32_e32 v1, v5
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -7673,84 +7674,80 @@ define <2 x i64> @clpeak_imad_pat_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-SDAG-NEXT:    v_add3_u32 v6, v6, v13, v11
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v11, v8, v2
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[9:10], null, v7, v2, v[7:8]
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_4) | instid1(VALU_DEP_4)
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v13, v6, v0
 ; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[3:4], null, v5, v0, v[5:6]
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v0, v5, v1
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v1, v7, v12
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[9:10], null, v7, v2, v[7:8]
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v6, v3, v6
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-SDAG-NEXT:    v_add3_u32 v4, v13, v4, v0
 ; GFX11-SDAG-NEXT:    v_add3_u32 v10, v11, v10, v1
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_4)
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v8, v9, v8
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v11, v4, v5
 ; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[0:1], null, v3, v5, v[3:4]
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v4, v9, v8
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v5, v10, v7
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v4, v10, v7
 ; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[2:3], null, v9, v7, v[9:10]
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-SDAG-NEXT:    v_add3_u32 v1, v11, v1, v6
-; GFX11-SDAG-NEXT:    v_add3_u32 v3, v5, v3, v4
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-SDAG-NEXT:    v_add3_u32 v3, v4, v3, v8
 ; GFX11-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-LABEL: clpeak_imad_pat_v2i64:
 ; GFX11-GISEL:       ; %bb.0: ; %entry
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-GISEL-NEXT:    v_add_co_u32 v11, vcc_lo, v0, 1
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v15, null, 0, v1, vcc_lo
-; GFX11-GISEL-NEXT:    v_add_co_u32 v16, vcc_lo, v2, 1
+; GFX11-GISEL-NEXT:    v_add_co_u32 v15, s0, v2, 1
+; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v16, null, 0, v1, vcc_lo
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
 ; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v11, v4, 0
-; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v17, null, 0, v3, vcc_lo
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v16, v6, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v11, v5, v[1:2]
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v16, v7, v[3:4]
-; GFX11-GISEL-NEXT:    v_add_co_u32 v1, vcc_lo, v0, v11
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[12:13], null, v15, v4, v[8:9]
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[13:14], null, v17, v6, v[9:10]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v1, v4, 0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v3, null, v12, v15, vcc_lo
-; GFX11-GISEL-NEXT:    v_add_co_u32 v18, vcc_lo, v2, v16
-; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v19, null, v13, v17, vcc_lo
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[10:11], null, v18, v6, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[14:15], null, v1, v5, v[9:10]
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[15:16], null, v18, v7, v[11:12]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[16:17], null, v3, v4, v[14:15]
-; GFX11-GISEL-NEXT:    v_add_co_u32 v14, vcc_lo, v0, 1
+; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v17, null, 0, v3, s0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v15, v6, 0
 ; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v0, null, 0, v12, vcc_lo
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[4:5], null, v8, v14, 0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[17:18], null, v19, v6, v[15:16]
-; GFX11-GISEL-NEXT:    v_add_co_u32 v15, vcc_lo, v2, 1
-; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v13, vcc_lo
-; GFX11-GISEL-NEXT:    v_add_co_u32 v13, vcc_lo, v8, 1
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[6:7], null, v10, v15, 0
-; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v18, null, 0, v16, vcc_lo
-; GFX11-GISEL-NEXT:    v_add_co_u32 v19, vcc_lo, v10, 1
-; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v20, null, 0, v17, vcc_lo
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_3) | instid1(VALU_DEP_4)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[11:12], null, v8, v0, v[5:6]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v10, v1, v[7:8]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v4, v13, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v6, v19, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v16, v14, v[11:12]
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[10:11], null, v17, v15, v[8:9]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[7:8], null, v4, v18, v[1:2]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v11, v5, v[1:2]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v15, v7, v[3:4]
+; GFX11-GISEL-NEXT:    v_add_co_u32 v3, vcc_lo, v2, v15
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[12:13], null, v16, v4, v[8:9]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[13:14], null, v17, v6, v[9:10]
+; GFX11-GISEL-NEXT:    v_add_co_u32 v14, s0, v0, v11
 ; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[11:12], null, v6, v20, v[3:4]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[5:6], null, v9, v13, v[7:8]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[10:11], null, v3, v6, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v14, v4, 0
+; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v18, null, v12, v16, s0
+; GFX11-GISEL-NEXT:    v_add_co_u32 v20, s0, v0, 1
+; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v17, null, v13, v17, vcc_lo
+; GFX11-GISEL-NEXT:    v_add_co_u32 v19, vcc_lo, v2, 1
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v14, v5, v[9:10]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[1:2], null, v3, v7, v[11:12]
+; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v21, null, 0, v12, s0
+; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v2, null, 0, v13, vcc_lo
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[11:12], null, v8, v20, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[13:14], null, v10, v19, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[15:16], null, v18, v4, v[0:1]
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[4:5], null, v17, v6, v[1:2]
+; GFX11-GISEL-NEXT:    v_add_co_u32 v16, vcc_lo, v10, 1
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[5:6], null, v8, v21, v[12:13]
+; GFX11-GISEL-NEXT:    v_add_co_u32 v12, s0, v8, 1
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[6:7], null, v10, v2, v[14:15]
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v13, v16, 0
+; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v10, null, 0, v15, s0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v11, v12, 0
+; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v14, null, 0, v4, vcc_lo
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[7:8], null, v15, v20, v[5:6]
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v4, v19, v[6:7]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[4:5], null, v11, v10, v[1:2]
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v13, v14, v[3:4]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[5:6], null, v7, v12, v[4:5]
 ; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[3:4], null, v10, v19, v[11:12]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[3:4], null, v8, v16, v[9:10]
 ; GFX11-GISEL-NEXT:    v_mov_b32_e32 v1, v5
 ; GFX11-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -7795,25 +7792,25 @@ define <2 x i64> @clpeak_imad_pat_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX1200-SDAG-NEXT:    v_add3_u32 v4, v4, v11, v10
 ; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v11, v3, v12
-; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v12, v5, v13
+; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v9, v6, v2
-; GFX1200-SDAG-NEXT:    v_mad_co_u64_u32 v[7:8], null, v5, v2, v[5:6]
 ; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v10, v4, v0
 ; GFX1200-SDAG-NEXT:    v_mad_co_u64_u32 v[0:1], null, v3, v0, v[3:4]
-; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v2, v5, v13
-; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v6, v7, v6
+; GFX1200-SDAG-NEXT:    v_mad_co_u64_u32 v[7:8], null, v5, v2, v[5:6]
+; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1200-SDAG-NEXT:    v_add3_u32 v1, v10, v1, v11
+; GFX1200-SDAG-NEXT:    v_add3_u32 v8, v9, v8, v12
 ; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v4, v0, v4
-; GFX1200-SDAG-NEXT:    v_add3_u32 v8, v9, v8, v2
-; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v6, v7, v6
+; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_3) | instid1(VALU_DEP_3)
 ; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v9, v1, v3
 ; GFX1200-SDAG-NEXT:    v_mad_co_u64_u32 v[0:1], null, v0, v3, v[0:1]
 ; GFX1200-SDAG-NEXT:    v_mul_lo_u32 v10, v8, v5
 ; GFX1200-SDAG-NEXT:    v_mad_co_u64_u32 v[2:3], null, v7, v5, v[7:8]
-; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1200-SDAG-NEXT:    v_add3_u32 v1, v9, v1, v4
+; GFX1200-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1200-SDAG-NEXT:    v_add3_u32 v3, v10, v3, v6
 ; GFX1200-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -9286,30 +9283,30 @@ define <2 x i32> @clpeak_imad_pat_v2i32_x2(<2 x i32> %x, <2 x i32> %y) {
 ; GFX900-SDAG:       ; %bb.0: ; %entry
 ; GFX900-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-SDAG-NEXT:    v_add_u32_e32 v0, 1, v0
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v4, v0, v2
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v5, v0, v2
 ; GFX900-SDAG-NEXT:    v_add_u32_e32 v1, 1, v1
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v5, v1, v3
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v0, v4, v0
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v4, v1, v3
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v0, v5, v0
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v0, v0, v2
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v1, v5, v1
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v1, v4, v1
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v1, v1, v3
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, 1, v4
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v3, v0, v2
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v4, 1, v5
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v5, v1, v4
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, v3, v2
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, 1, v5
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v3, 1, v4
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v4, v0, v2
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v5, v1, v3
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, v4, v2
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v0, v2, v0
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, v5, v4
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v1, v2, v1
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, 1, v3
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v3, v0, v2
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v4, 1, v5
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v5, v1, v4
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, v3, v2
-; GFX900-SDAG-NEXT:    v_mul_lo_u32 v0, v2, v0
-; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, v5, v4
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v3, v5, v3
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v1, v3, v1
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v3, 1, v4
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v4, v0, v3
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, 1, v5
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v5, v1, v2
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v3, v4, v3
+; GFX900-SDAG-NEXT:    v_mul_lo_u32 v0, v3, v0
+; GFX900-SDAG-NEXT:    v_add_u32_e32 v2, v5, v2
 ; GFX900-SDAG-NEXT:    v_mul_lo_u32 v2, v2, v1
-; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v0, v3, v[0:1]
+; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v0, v4, v[0:1]
 ; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v5, v[2:3]
 ; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v3, v0, v[3:4]
 ; GFX900-SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v4, v2, v[4:5]

--- a/llvm/test/CodeGen/AMDGPU/llvm.mulo.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.mulo.ll
@@ -36,8 +36,8 @@ define { i64, i1 } @umulo_i64_v_v(i64 %x, i64 %y) {
 ; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v0, v3, 0
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, v2, 0
 ; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v4, v2, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v9, vcc, v1, v5
 ; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v4, v3, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v9, vcc, v1, v5
 ; GFX9-NEXT:    v_addc_co_u32_e32 v6, vcc, 0, v6, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v9, v7
 ; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v6, v8, vcc
@@ -177,8 +177,8 @@ define { i64, i1 } @smulo_i64_v_v(i64 %x, i64 %y) {
 ; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v5, v3, 0
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v2, 0
 ; GFX9-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v4, v2, 0
-; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v1, v6
 ; GFX9-NEXT:    v_mad_i64_i32 v[10:11], s[4:5], v4, v3, 0
+; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v1, v6
 ; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v7, vcc
 ; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v12, v8
 ; GFX9-NEXT:    v_addc_co_u32_e32 v7, vcc, v7, v9, vcc

--- a/llvm/test/CodeGen/AMDGPU/machine-sink-temporal-divergence-swdev407790.ll
+++ b/llvm/test/CodeGen/AMDGPU/machine-sink-temporal-divergence-swdev407790.ll
@@ -418,21 +418,21 @@ define protected amdgpu_kernel void @kernel_round1(ptr addrspace(1) nocapture no
 ; CHECK-NEXT:    global_load_dwordx4 v[4:7], v[0:1], off offset:8
 ; CHECK-NEXT:    global_load_dwordx4 v[8:11], v[2:3], off offset:8
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
-; CHECK-NEXT:    v_xor_b32_e32 v46, v9, v5
-; CHECK-NEXT:    v_xor_b32_e32 v45, v8, v4
-; CHECK-NEXT:    v_xor_b32_e32 v57, v11, v7
-; CHECK-NEXT:    v_xor_b32_e32 v56, v10, v6
-; CHECK-NEXT:    v_or_b32_e32 v5, v46, v57
-; CHECK-NEXT:    v_or_b32_e32 v4, v45, v56
+; CHECK-NEXT:    v_xor_b32_e32 v57, v9, v5
+; CHECK-NEXT:    v_xor_b32_e32 v56, v8, v4
+; CHECK-NEXT:    v_xor_b32_e32 v46, v11, v7
+; CHECK-NEXT:    v_xor_b32_e32 v45, v10, v6
+; CHECK-NEXT:    v_or_b32_e32 v5, v57, v46
+; CHECK-NEXT:    v_or_b32_e32 v4, v56, v45
 ; CHECK-NEXT:    v_cmpx_ne_u64_e32 0, v[4:5]
 ; CHECK-NEXT:    s_cbranch_execz .LBB0_27
 ; CHECK-NEXT:  ; %bb.29: ; in Loop: Header=BB0_28 Depth=1
 ; CHECK-NEXT:    s_clause 0x1
 ; CHECK-NEXT:    global_load_dwordx2 v[58:59], v[2:3], off offset:24
 ; CHECK-NEXT:    global_load_dwordx2 v[60:61], v[0:1], off offset:24
-; CHECK-NEXT:    v_lshlrev_b32_e32 v0, 4, v45
-; CHECK-NEXT:    v_alignbit_b32 v1, v46, v45, 12
-; CHECK-NEXT:    v_and_b32_e32 v2, 0xf0000, v45
+; CHECK-NEXT:    v_lshlrev_b32_e32 v0, 4, v56
+; CHECK-NEXT:    v_alignbit_b32 v1, v57, v56, 12
+; CHECK-NEXT:    v_and_b32_e32 v2, 0xf0000, v56
 ; CHECK-NEXT:    v_mov_b32_e32 v31, v40
 ; CHECK-NEXT:    s_add_u32 s8, s34, 40
 ; CHECK-NEXT:    v_and_b32_e32 v3, 0xf000, v0
@@ -469,28 +469,28 @@ define protected amdgpu_kernel void @kernel_round1(ptr addrspace(1) nocapture no
 ; CHECK-NEXT:    s_xor_b32 s4, exec_lo, s4
 ; CHECK-NEXT:    s_cbranch_execz .LBB0_31
 ; CHECK-NEXT:  ; %bb.30: ; in Loop: Header=BB0_28 Depth=1
-; CHECK-NEXT:    v_xor_b32_e32 v4, v60, v58
-; CHECK-NEXT:    v_lshrrev_b64 v[2:3], 16, v[56:57]
-; CHECK-NEXT:    v_mad_u64_u32 v[6:7], null, 0x180, v73, s[66:67]
-; CHECK-NEXT:    v_lshlrev_b32_e32 v10, 5, v0
-; CHECK-NEXT:    v_lshlrev_b32_e32 v1, 16, v4
-; CHECK-NEXT:    v_lshlrev_b32_e32 v8, 6, v72
-; CHECK-NEXT:    v_lshlrev_b32_e32 v9, 12, v63
-; CHECK-NEXT:    v_xor_b32_e32 v5, v61, v59
-; CHECK-NEXT:    v_lshlrev_b32_e32 v11, 16, v56
-; CHECK-NEXT:    v_or_b32_e32 v3, v1, v3
-; CHECK-NEXT:    v_lshrrev_b64 v[0:1], 16, v[45:46]
-; CHECK-NEXT:    v_add_co_u32 v6, vcc_lo, v6, v10
-; CHECK-NEXT:    v_or3_b32 v8, v8, v9, v62
-; CHECK-NEXT:    v_add_co_ci_u32_e64 v7, null, 0, v7, vcc_lo
-; CHECK-NEXT:    v_lshrrev_b64 v[4:5], 16, v[4:5]
-; CHECK-NEXT:    v_or_b32_e32 v1, v11, v1
+; CHECK-NEXT:    v_xor_b32_e32 v5, v60, v58
+; CHECK-NEXT:    v_lshrrev_b64 v[3:4], 16, v[45:46]
+; CHECK-NEXT:    v_mad_u64_u32 v[7:8], null, 0x180, v73, s[66:67]
+; CHECK-NEXT:    v_lshlrev_b32_e32 v0, 5, v0
+; CHECK-NEXT:    v_lshrrev_b64 v[1:2], 16, v[56:57]
+; CHECK-NEXT:    v_lshlrev_b32_e32 v10, 16, v5
+; CHECK-NEXT:    v_lshlrev_b32_e32 v9, 6, v72
+; CHECK-NEXT:    v_lshlrev_b32_e32 v11, 12, v63
+; CHECK-NEXT:    v_xor_b32_e32 v6, v61, v59
 ; CHECK-NEXT:    ; implicit-def: $vgpr42
 ; CHECK-NEXT:    ; implicit-def: $vgpr43
 ; CHECK-NEXT:    ; implicit-def: $vgpr44
-; CHECK-NEXT:    global_store_dword v[6:7], v8, off offset:4
-; CHECK-NEXT:    global_store_dwordx4 v[6:7], v[0:3], off offset:8
-; CHECK-NEXT:    global_store_dwordx2 v[6:7], v[4:5], off offset:24
+; CHECK-NEXT:    v_add_co_u32 v7, vcc_lo, v7, v0
+; CHECK-NEXT:    v_or_b32_e32 v4, v10, v4
+; CHECK-NEXT:    v_lshlrev_b32_e32 v10, 16, v45
+; CHECK-NEXT:    v_or3_b32 v9, v9, v11, v62
+; CHECK-NEXT:    v_add_co_ci_u32_e64 v8, null, 0, v8, vcc_lo
+; CHECK-NEXT:    v_lshrrev_b64 v[5:6], 16, v[5:6]
+; CHECK-NEXT:    v_or_b32_e32 v2, v10, v2
+; CHECK-NEXT:    global_store_dword v[7:8], v9, off offset:4
+; CHECK-NEXT:    global_store_dwordx4 v[7:8], v[1:4], off offset:8
+; CHECK-NEXT:    global_store_dwordx2 v[7:8], v[5:6], off offset:24
 ; CHECK-NEXT:  .LBB0_31: ; %Flow
 ; CHECK-NEXT:    ; in Loop: Header=BB0_28 Depth=1
 ; CHECK-NEXT:    s_andn2_saveexec_b32 s4, s4

--- a/llvm/test/CodeGen/AMDGPU/mad_64_32.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad_64_32.ll
@@ -251,17 +251,17 @@ define i128 @mad_i64_i32_sextops_i32_i128(i32 %arg0, i32 %arg1, i128 %arg2) #0 {
 ; CI:       ; %bb.0:
 ; CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CI-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v0, v1, 0
-; CI-NEXT:    v_ashrrev_i32_e32 v12, 31, v0
+; CI-NEXT:    v_ashrrev_i32_e32 v13, 31, v0
 ; CI-NEXT:    v_mov_b32_e32 v8, 0
-; CI-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v12, v1, v[7:8]
-; CI-NEXT:    v_ashrrev_i32_e32 v13, 31, v1
+; CI-NEXT:    v_ashrrev_i32_e32 v14, 31, v1
+; CI-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v13, v1, v[7:8]
+; CI-NEXT:    v_mad_i64_i32 v[11:12], s[4:5], v1, v13, 0
 ; CI-NEXT:    v_mov_b32_e32 v7, v9
-; CI-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v0, v13, v[7:8]
+; CI-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v0, v14, v[7:8]
+; CI-NEXT:    v_mad_i64_i32 v[0:1], s[4:5], v14, v0, v[11:12]
 ; CI-NEXT:    v_add_i32_e32 v8, vcc, v10, v8
-; CI-NEXT:    v_mad_i64_i32 v[10:11], s[4:5], v1, v12, 0
 ; CI-NEXT:    v_addc_u32_e64 v9, s[4:5], 0, 0, vcc
-; CI-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v12, v13, v[8:9]
-; CI-NEXT:    v_mad_i64_i32 v[0:1], s[4:5], v13, v0, v[10:11]
+; CI-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v13, v14, v[8:9]
 ; CI-NEXT:    v_add_i32_e32 v8, vcc, v8, v0
 ; CI-NEXT:    v_addc_u32_e32 v9, vcc, v9, v1, vcc
 ; CI-NEXT:    v_add_i32_e32 v0, vcc, v6, v2
@@ -2291,11 +2291,11 @@ define <2 x i64> @lshr_mad_i64_vec(<2 x i64> %arg0) #0 {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_mad_u64_u32 v[4:5], null, 0xffff1c18, v1, v[0:1]
 ; GFX11-NEXT:    v_mad_u64_u32 v[6:7], null, 0xffff1118, v3, v[2:3]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_sub_nc_u32_e32 v1, v5, v1
-; GFX11-NEXT:    v_mov_b32_e32 v0, v4
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GFX11-NEXT:    v_sub_nc_u32_e32 v3, v7, v3
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX11-NEXT:    v_mov_b32_e32 v2, v6
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2308,11 +2308,11 @@ define <2 x i64> @lshr_mad_i64_vec(<2 x i64> %arg0) #0 {
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[4:5], null, 0xffff1c18, v1, v[0:1]
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[6:7], null, 0xffff1118, v3, v[2:3]
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12-NEXT:    v_sub_nc_u32_e32 v1, v5, v1
-; GFX12-NEXT:    v_mov_b32_e32 v0, v4
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GFX12-NEXT:    v_sub_nc_u32_e32 v3, v7, v3
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX12-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX12-NEXT:    v_mov_b32_e32 v2, v6
 ; GFX12-NEXT:    s_setpc_b64 s[30:31]
 ;

--- a/llvm/test/CodeGen/AMDGPU/mul.ll
+++ b/llvm/test/CodeGen/AMDGPU/mul.ll
@@ -2708,9 +2708,9 @@ define amdgpu_kernel void @mul64_in_branch(ptr addrspace(1) %out, ptr addrspace(
 ; VI-NEXT:    v_mov_b32_e32 v0, s6
 ; VI-NEXT:    v_mad_u64_u32 v[0:1], s[10:11], s4, v0, 0
 ; VI-NEXT:    s_mul_i32 s4, s4, s7
+; VI-NEXT:    s_mul_i32 s5, s5, s6
 ; VI-NEXT:    v_add_u32_e32 v1, vcc, s4, v1
-; VI-NEXT:    s_mul_i32 s4, s5, s6
-; VI-NEXT:    v_add_u32_e32 v1, vcc, s4, v1
+; VI-NEXT:    v_add_u32_e32 v1, vcc, s5, v1
 ; VI-NEXT:    s_andn2_b64 vcc, exec, s[8:9]
 ; VI-NEXT:    s_cbranch_vccnz .LBB16_3
 ; VI-NEXT:  .LBB16_2: ; %if
@@ -3006,24 +3006,25 @@ define amdgpu_kernel void @s_mul_i128(ptr addrspace(1) %out, [8 x i32], i128 %a,
 ; VI-NEXT:    s_load_dwordx4 s[8:11], s[4:5], 0x4c
 ; VI-NEXT:    s_load_dwordx4 s[12:15], s[4:5], 0x7c
 ; VI-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
-; VI-NEXT:    v_mov_b32_e32 v2, 0
 ; VI-NEXT:    s_mov_b32 s3, 0xf000
+; VI-NEXT:    s_mov_b32 s2, -1
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    v_mov_b32_e32 v0, s10
 ; VI-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], s12, v0, 0
 ; VI-NEXT:    s_mul_i32 s4, s12, s11
 ; VI-NEXT:    v_mov_b32_e32 v5, s12
-; VI-NEXT:    v_add_u32_e32 v0, vcc, s4, v4
-; VI-NEXT:    s_mul_i32 s4, s13, s10
-; VI-NEXT:    v_add_u32_e32 v4, vcc, s4, v0
+; VI-NEXT:    s_mul_i32 s6, s13, s10
+; VI-NEXT:    v_add_u32_e32 v2, vcc, s4, v4
 ; VI-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], s8, v5, 0
-; VI-NEXT:    v_mov_b32_e32 v7, s8
-; VI-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], s14, v7, v[3:4]
+; VI-NEXT:    v_add_u32_e32 v4, vcc, s6, v2
+; VI-NEXT:    v_mov_b32_e32 v2, 0
 ; VI-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], s9, v5, v[1:2]
+; VI-NEXT:    v_mov_b32_e32 v1, s8
+; VI-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], s14, v1, v[3:4]
 ; VI-NEXT:    v_mov_b32_e32 v7, s13
-; VI-NEXT:    s_mul_i32 s6, s15, s8
 ; VI-NEXT:    v_mov_b32_e32 v1, v5
 ; VI-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], s8, v7, v[1:2]
+; VI-NEXT:    s_mul_i32 s6, s15, s8
 ; VI-NEXT:    v_add_u32_e32 v8, vcc, s6, v4
 ; VI-NEXT:    v_add_u32_e32 v4, vcc, v6, v2
 ; VI-NEXT:    v_addc_u32_e64 v5, s[4:5], 0, 0, vcc
@@ -3031,7 +3032,6 @@ define amdgpu_kernel void @s_mul_i128(ptr addrspace(1) %out, [8 x i32], i128 %a,
 ; VI-NEXT:    s_mul_i32 s6, s14, s9
 ; VI-NEXT:    v_add_u32_e32 v6, vcc, s6, v8
 ; VI-NEXT:    v_add_u32_e32 v2, vcc, v4, v3
-; VI-NEXT:    s_mov_b32 s2, -1
 ; VI-NEXT:    v_addc_u32_e32 v3, vcc, v5, v6, vcc
 ; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0
 ; VI-NEXT:    s_endpgm
@@ -3387,37 +3387,37 @@ define amdgpu_kernel void @v_mul_i128(ptr addrspace(1) %out, ptr addrspace(1) %a
 ; VI:       ; %bb.0: ; %entry
 ; VI-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x2c
 ; VI-NEXT:    v_lshlrev_b32_e32 v2, 4, v0
-; VI-NEXT:    v_mov_b32_e32 v9, 0
+; VI-NEXT:    v_mov_b32_e32 v10, 0
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    v_mov_b32_e32 v1, s1
 ; VI-NEXT:    v_add_u32_e32 v0, vcc, s0, v2
 ; VI-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
 ; VI-NEXT:    v_mov_b32_e32 v3, s3
-; VI-NEXT:    v_add_u32_e32 v11, vcc, s2, v2
-; VI-NEXT:    v_addc_u32_e32 v12, vcc, 0, v3, vcc
+; VI-NEXT:    v_add_u32_e32 v12, vcc, s2, v2
+; VI-NEXT:    v_addc_u32_e32 v13, vcc, 0, v3, vcc
 ; VI-NEXT:    flat_load_dwordx4 v[0:3], v[0:1]
-; VI-NEXT:    flat_load_dwordx4 v[4:7], v[11:12]
+; VI-NEXT:    flat_load_dwordx4 v[4:7], v[12:13]
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    v_mul_lo_u32 v3, v4, v3
-; VI-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v4, v2, 0
-; VI-NEXT:    v_mul_lo_u32 v2, v5, v2
-; VI-NEXT:    v_mul_lo_u32 v10, v7, v0
-; VI-NEXT:    v_mad_u64_u32 v[7:8], s[0:1], v0, v4, 0
-; VI-NEXT:    v_add_u32_e32 v3, vcc, v14, v3
-; VI-NEXT:    v_add_u32_e32 v14, vcc, v3, v2
-; VI-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v1, v4, v[8:9]
-; VI-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v6, v0, v[13:14]
-; VI-NEXT:    v_mov_b32_e32 v8, v2
-; VI-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v0, v5, v[8:9]
-; VI-NEXT:    v_mul_lo_u32 v4, v6, v1
-; VI-NEXT:    v_add_u32_e32 v6, vcc, v10, v14
-; VI-NEXT:    v_add_u32_e32 v2, vcc, v3, v9
+; VI-NEXT:    v_mad_u64_u32 v[14:15], s[0:1], v4, v2, 0
+; VI-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v0, v4, 0
+; VI-NEXT:    v_mul_lo_u32 v11, v5, v2
+; VI-NEXT:    v_add_u32_e32 v15, vcc, v15, v3
+; VI-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v1, v4, v[9:10]
+; VI-NEXT:    v_add_u32_e32 v15, vcc, v15, v11
+; VI-NEXT:    v_mul_lo_u32 v4, v7, v0
+; VI-NEXT:    v_mul_lo_u32 v11, v6, v1
+; VI-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], v6, v0, v[14:15]
+; VI-NEXT:    v_mov_b32_e32 v9, v2
+; VI-NEXT:    v_mad_u64_u32 v[9:10], s[0:1], v0, v5, v[9:10]
+; VI-NEXT:    v_add_u32_e32 v4, vcc, v4, v7
+; VI-NEXT:    v_add_u32_e32 v2, vcc, v3, v10
 ; VI-NEXT:    v_addc_u32_e64 v3, s[0:1], 0, 0, vcc
 ; VI-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v1, v5, v[2:3]
-; VI-NEXT:    v_add_u32_e32 v2, vcc, v4, v6
-; VI-NEXT:    v_add_u32_e32 v9, vcc, v0, v13
-; VI-NEXT:    v_addc_u32_e32 v10, vcc, v1, v2, vcc
-; VI-NEXT:    flat_store_dwordx4 v[11:12], v[7:10]
+; VI-NEXT:    v_add_u32_e32 v2, vcc, v11, v4
+; VI-NEXT:    v_add_u32_e32 v10, vcc, v0, v6
+; VI-NEXT:    v_addc_u32_e32 v11, vcc, v1, v2, vcc
+; VI-NEXT:    flat_store_dwordx4 v[12:13], v[8:11]
 ; VI-NEXT:    s_endpgm
 ;
 ; GFX9-LABEL: v_mul_i128:
@@ -3432,18 +3432,18 @@ define amdgpu_kernel void @v_mul_i128(ptr addrspace(1) %out, ptr addrspace(1) %a
 ; GFX9-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v0, v4, 0
 ; GFX9-NEXT:    v_mul_lo_u32 v14, v5, v2
 ; GFX9-NEXT:    v_mul_lo_u32 v15, v4, v3
-; GFX9-NEXT:    v_mad_u64_u32 v[11:12], s[0:1], v1, v4, v[9:10]
 ; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v4, v2, 0
+; GFX9-NEXT:    v_mad_u64_u32 v[11:12], s[0:1], v1, v4, v[9:10]
+; GFX9-NEXT:    v_mul_lo_u32 v4, v6, v1
+; GFX9-NEXT:    v_add3_u32 v3, v3, v15, v14
 ; GFX9-NEXT:    v_mov_b32_e32 v9, v11
 ; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[0:1], v0, v5, v[9:10]
-; GFX9-NEXT:    v_add3_u32 v3, v3, v15, v14
-; GFX9-NEXT:    v_mul_lo_u32 v4, v6, v1
 ; GFX9-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v6, v0, v[2:3]
+; GFX9-NEXT:    v_mul_lo_u32 v11, v7, v0
 ; GFX9-NEXT:    v_add_co_u32_e32 v6, vcc, v12, v10
-; GFX9-NEXT:    v_mul_lo_u32 v14, v7, v0
 ; GFX9-NEXT:    v_addc_co_u32_e64 v7, s[0:1], 0, 0, vcc
 ; GFX9-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v1, v5, v[6:7]
-; GFX9-NEXT:    v_add3_u32 v3, v14, v3, v4
+; GFX9-NEXT:    v_add3_u32 v3, v11, v3, v4
 ; GFX9-NEXT:    v_add_co_u32_e32 v10, vcc, v0, v2
 ; GFX9-NEXT:    v_addc_co_u32_e32 v11, vcc, v1, v3, vcc
 ; GFX9-NEXT:    global_store_dwordx4 v13, v[8:11], s[2:3]
@@ -3460,15 +3460,15 @@ define amdgpu_kernel void @v_mul_i128(ptr addrspace(1) %out, ptr addrspace(1) %a
 ; GFX10-NEXT:    global_load_dwordx4 v[4:7], v13, s[2:3]
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    v_mad_u64_u32 v[8:9], s0, v0, v4, 0
-; GFX10-NEXT:    v_mul_lo_u32 v14, v5, v2
+; GFX10-NEXT:    v_mul_lo_u32 v14, v4, v3
 ; GFX10-NEXT:    v_mul_lo_u32 v7, v7, v0
 ; GFX10-NEXT:    v_mad_u64_u32 v[11:12], s0, v1, v4, v[9:10]
 ; GFX10-NEXT:    v_mov_b32_e32 v9, v11
-; GFX10-NEXT:    v_mul_lo_u32 v11, v4, v3
+; GFX10-NEXT:    v_mul_lo_u32 v11, v5, v2
 ; GFX10-NEXT:    v_mad_u64_u32 v[2:3], s0, v4, v2, 0
 ; GFX10-NEXT:    v_mul_lo_u32 v4, v6, v1
 ; GFX10-NEXT:    v_mad_u64_u32 v[9:10], s0, v0, v5, v[9:10]
-; GFX10-NEXT:    v_add3_u32 v3, v3, v11, v14
+; GFX10-NEXT:    v_add3_u32 v3, v3, v14, v11
 ; GFX10-NEXT:    v_add_co_u32 v10, s0, v12, v10
 ; GFX10-NEXT:    v_add_co_ci_u32_e64 v11, s0, 0, 0, s0
 ; GFX10-NEXT:    v_mad_u64_u32 v[2:3], s0, v6, v0, v[2:3]
@@ -3491,26 +3491,27 @@ define amdgpu_kernel void @v_mul_i128(ptr addrspace(1) %out, ptr addrspace(1) %a
 ; GFX11-NEXT:    global_load_b128 v[4:7], v15, s[2:3]
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    v_mad_u64_u32 v[8:9], null, v0, v4, 0
-; GFX11-NEXT:    v_mul_lo_u32 v16, v5, v2
+; GFX11-NEXT:    v_mul_lo_u32 v16, v4, v3
 ; GFX11-NEXT:    v_mad_u64_u32 v[13:14], null, v4, v2, 0
 ; GFX11-NEXT:    v_mul_lo_u32 v17, v6, v1
-; GFX11-NEXT:    v_mul_lo_u32 v18, v7, v0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-NEXT:    v_mad_u64_u32 v[11:12], null, v1, v4, v[9:10]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_mov_b32_e32 v9, v11
-; GFX11-NEXT:    v_mul_lo_u32 v11, v4, v3
+; GFX11-NEXT:    v_mul_lo_u32 v11, v5, v2
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_mad_u64_u32 v[2:3], null, v0, v5, v[9:10]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_add3_u32 v14, v14, v11, v16
+; GFX11-NEXT:    v_add3_u32 v14, v14, v16, v11
+; GFX11-NEXT:    v_mul_lo_u32 v11, v7, v0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-NEXT:    v_add_co_u32 v3, s0, v12, v3
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-NEXT:    v_add_co_ci_u32_e64 v4, null, 0, 0, s0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_mad_u64_u32 v[9:10], null, v6, v0, v[13:14]
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_mad_u64_u32 v[6:7], null, v1, v5, v[3:4]
-; GFX11-NEXT:    v_add3_u32 v0, v18, v10, v17
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_add3_u32 v0, v11, v10, v17
 ; GFX11-NEXT:    v_add_co_u32 v10, vcc_lo, v6, v9
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-NEXT:    v_add_co_ci_u32_e64 v11, null, v7, v0, vcc_lo
 ; GFX11-NEXT:    v_mov_b32_e32 v9, v2
 ; GFX11-NEXT:    global_store_b128 v15, v[8:11], s[2:3]
@@ -3528,17 +3529,17 @@ define amdgpu_kernel void @v_mul_i128(ptr addrspace(1) %out, ptr addrspace(1) %a
 ; GFX12-NEXT:    global_load_b128 v[4:7], v13, s[2:3]
 ; GFX12-NEXT:    s_wait_loadcnt 0x0
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[8:9], null, v0, v4, 0
-; GFX12-NEXT:    v_mul_lo_u32 v14, v5, v2
+; GFX12-NEXT:    v_mul_lo_u32 v14, v4, v3
 ; GFX12-NEXT:    v_mul_lo_u32 v7, v7, v0
 ; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[11:12], null, v1, v4, v[9:10]
 ; GFX12-NEXT:    v_mov_b32_e32 v9, v11
-; GFX12-NEXT:    v_mul_lo_u32 v11, v4, v3
+; GFX12-NEXT:    v_mul_lo_u32 v11, v5, v2
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[2:3], null, v4, v2, 0
 ; GFX12-NEXT:    v_mul_lo_u32 v4, v6, v1
 ; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX12-NEXT:    v_mad_co_u64_u32 v[9:10], null, v0, v5, v[9:10]
-; GFX12-NEXT:    v_add3_u32 v3, v3, v11, v14
+; GFX12-NEXT:    v_add3_u32 v3, v3, v14, v11
 ; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-NEXT:    v_add_co_u32 v10, s0, v12, v10
 ; GFX12-NEXT:    v_add_co_ci_u32_e64 v11, null, 0, 0, s0

--- a/llvm/test/CodeGen/AMDGPU/reassoc-mul-add-1-to-mad.ll
+++ b/llvm/test/CodeGen/AMDGPU/reassoc-mul-add-1-to-mad.ll
@@ -3866,30 +3866,30 @@ define i64 @v_mul_284_add_82_i64(i64 %arg) {
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    s_movk_i32 s4, 0x11c
-; GFX7-NEXT:    v_mul_lo_u32 v3, v1, s4
-; GFX7-NEXT:    v_mov_b32_e32 v1, 0x52
-; GFX7-NEXT:    v_mov_b32_e32 v2, 0
-; GFX7-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, s4, v[1:2]
-; GFX7-NEXT:    v_add_i32_e32 v1, vcc, v3, v1
+; GFX7-NEXT:    v_mov_b32_e32 v2, 0x52
+; GFX7-NEXT:    v_mov_b32_e32 v3, 0
+; GFX7-NEXT:    v_mul_lo_u32 v4, v1, s4
+; GFX7-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, s4, v[2:3]
+; GFX7-NEXT:    v_add_i32_e32 v1, vcc, v4, v1
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_mul_284_add_82_i64:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    s_movk_i32 s4, 0x11c
-; GFX8-NEXT:    v_mul_lo_u32 v3, v1, s4
-; GFX8-NEXT:    v_mov_b32_e32 v1, 0x52
-; GFX8-NEXT:    v_mov_b32_e32 v2, 0
-; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, s4, v[1:2]
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
+; GFX8-NEXT:    v_mov_b32_e32 v2, 0x52
+; GFX8-NEXT:    v_mov_b32_e32 v3, 0
+; GFX8-NEXT:    v_mul_lo_u32 v4, v1, s4
+; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, s4, v[2:3]
+; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v4, v1
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mul_284_add_82_i64:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX900-NEXT:    s_movk_i32 s6, 0x11c
 ; GFX900-NEXT:    v_mov_b32_e32 v3, 0x52
 ; GFX900-NEXT:    v_mov_b32_e32 v4, 0
+; GFX900-NEXT:    s_movk_i32 s6, 0x11c
 ; GFX900-NEXT:    v_mov_b32_e32 v2, v1
 ; GFX900-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, s6, v[3:4]
 ; GFX900-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v2, s6, v[1:2]
@@ -3949,30 +3949,30 @@ define i64 @v_mul_934584645_add_8234599_i64(i64 %arg) {
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    s_mov_b32 s4, 0x37b4a145
-; GFX7-NEXT:    v_mul_lo_u32 v3, v1, s4
-; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7da667
-; GFX7-NEXT:    v_mov_b32_e32 v2, 0
-; GFX7-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, s4, v[1:2]
-; GFX7-NEXT:    v_add_i32_e32 v1, vcc, v3, v1
+; GFX7-NEXT:    v_mov_b32_e32 v2, 0x7da667
+; GFX7-NEXT:    v_mov_b32_e32 v3, 0
+; GFX7-NEXT:    v_mul_lo_u32 v4, v1, s4
+; GFX7-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, s4, v[2:3]
+; GFX7-NEXT:    v_add_i32_e32 v1, vcc, v4, v1
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_mul_934584645_add_8234599_i64:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    s_mov_b32 s4, 0x37b4a145
-; GFX8-NEXT:    v_mul_lo_u32 v3, v1, s4
-; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7da667
-; GFX8-NEXT:    v_mov_b32_e32 v2, 0
-; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, s4, v[1:2]
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
+; GFX8-NEXT:    v_mov_b32_e32 v2, 0x7da667
+; GFX8-NEXT:    v_mov_b32_e32 v3, 0
+; GFX8-NEXT:    v_mul_lo_u32 v4, v1, s4
+; GFX8-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, s4, v[2:3]
+; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v4, v1
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mul_934584645_add_8234599_i64:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX900-NEXT:    s_mov_b32 s6, 0x37b4a145
 ; GFX900-NEXT:    v_mov_b32_e32 v3, 0x7da667
 ; GFX900-NEXT:    v_mov_b32_e32 v4, 0
+; GFX900-NEXT:    s_mov_b32 s6, 0x37b4a145
 ; GFX900-NEXT:    v_mov_b32_e32 v2, v1
 ; GFX900-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, s6, v[3:4]
 ; GFX900-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v2, s6, v[1:2]
@@ -4106,22 +4106,22 @@ define amdgpu_kernel void @compute_mad(ptr addrspace(4) %i18, ptr addrspace(4) %
 ; GFX900-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x10
 ; GFX900-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX900-NEXT:    s_load_dword s9, s[2:3], 0x4
-; GFX900-NEXT:    s_load_dwordx2 s[4:5], s[0:1], 0x0
 ; GFX900-NEXT:    v_mul_lo_u32 v3, v2, v1
+; GFX900-NEXT:    s_load_dwordx2 s[0:1], s[0:1], 0x0
 ; GFX900-NEXT:    v_mov_b32_e32 v5, s7
-; GFX900-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX900-NEXT:    s_and_b32 s0, s9, 0xffff
 ; GFX900-NEXT:    v_add_u32_e32 v1, v3, v1
 ; GFX900-NEXT:    v_mul_lo_u32 v1, v1, v2
 ; GFX900-NEXT:    v_add_u32_e32 v2, 1, v3
-; GFX900-NEXT:    s_mul_i32 s8, s8, s0
-; GFX900-NEXT:    v_add_u32_e32 v0, s8, v0
+; GFX900-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX900-NEXT:    s_and_b32 s2, s9, 0xffff
+; GFX900-NEXT:    s_mul_i32 s8, s8, s2
 ; GFX900-NEXT:    v_mul_lo_u32 v3, v1, v2
-; GFX900-NEXT:    v_mov_b32_e32 v4, s5
+; GFX900-NEXT:    v_add_u32_e32 v0, s8, v0
+; GFX900-NEXT:    v_mov_b32_e32 v4, s1
 ; GFX900-NEXT:    v_add_u32_e32 v2, v3, v2
 ; GFX900-NEXT:    v_mul_lo_u32 v1, v2, v1
-; GFX900-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v1, v3, v[1:2]
-; GFX900-NEXT:    v_add_co_u32_e32 v3, vcc, s4, v0
+; GFX900-NEXT:    v_mad_u64_u32 v[2:3], s[2:3], v1, v3, v[1:2]
+; GFX900-NEXT:    v_add_co_u32_e32 v3, vcc, s0, v0
 ; GFX900-NEXT:    v_addc_co_u32_e32 v4, vcc, 0, v4, vcc
 ; GFX900-NEXT:    v_lshlrev_b64 v[3:4], 2, v[3:4]
 ; GFX900-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v2, v1, v[2:3]

--- a/llvm/test/CodeGen/AMDGPU/rem_i128.ll
+++ b/llvm/test/CodeGen/AMDGPU/rem_i128.ll
@@ -200,28 +200,28 @@ define i128 @v_srem_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-NEXT:    v_or_b32_e32 v10, v10, v6
 ; GFX9-NEXT:  .LBB0_6: ; %Flow3
 ; GFX9-NEXT:    s_or_b64 exec, exec, s[8:9]
-; GFX9-NEXT:    v_mul_lo_u32 v17, v10, v5
-; GFX9-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v23, v10, 0
-; GFX9-NEXT:    v_mov_b32_e32 v7, 0
-; GFX9-NEXT:    v_mul_lo_u32 v16, v11, v4
-; GFX9-NEXT:    v_mad_u64_u32 v[14:15], s[4:5], v22, v10, v[6:7]
-; GFX9-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v10, v4, 0
-; GFX9-NEXT:    v_mov_b32_e32 v6, v14
-; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v23, v11, v[6:7]
-; GFX9-NEXT:    v_add3_u32 v9, v9, v17, v16
-; GFX9-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v12, v23, v[8:9]
-; GFX9-NEXT:    v_mul_lo_u32 v4, v12, v22
-; GFX9-NEXT:    v_add_co_u32_e32 v12, vcc, v15, v7
-; GFX9-NEXT:    v_mul_lo_u32 v14, v13, v23
-; GFX9-NEXT:    v_addc_co_u32_e64 v13, s[4:5], 0, 0, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v22, v11, v[12:13]
-; GFX9-NEXT:    v_add3_u32 v4, v14, v9, v4
-; GFX9-NEXT:    v_add_co_u32_e32 v7, vcc, v10, v8
-; GFX9-NEXT:    v_addc_co_u32_e32 v4, vcc, v11, v4, vcc
-; GFX9-NEXT:    v_sub_co_u32_e32 v0, vcc, v0, v5
-; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v1, v6, vcc
-; GFX9-NEXT:    v_subb_co_u32_e32 v2, vcc, v2, v7, vcc
-; GFX9-NEXT:    v_subb_co_u32_e32 v3, vcc, v3, v4, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v23, v10, 0
+; GFX9-NEXT:    v_mov_b32_e32 v8, 0
+; GFX9-NEXT:    v_mul_lo_u32 v9, v11, v4
+; GFX9-NEXT:    v_mul_lo_u32 v16, v10, v5
+; GFX9-NEXT:    v_mad_u64_u32 v[14:15], s[4:5], v22, v10, v[7:8]
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v10, v4, 0
+; GFX9-NEXT:    v_mul_lo_u32 v10, v12, v22
+; GFX9-NEXT:    v_mul_lo_u32 v13, v13, v23
+; GFX9-NEXT:    v_mov_b32_e32 v7, v14
+; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v23, v11, v[7:8]
+; GFX9-NEXT:    v_add3_u32 v5, v5, v16, v9
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v12, v23, v[4:5]
+; GFX9-NEXT:    v_add_co_u32_e32 v8, vcc, v15, v8
+; GFX9-NEXT:    v_addc_co_u32_e64 v9, s[4:5], 0, 0, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v22, v11, v[8:9]
+; GFX9-NEXT:    v_add3_u32 v5, v13, v5, v10
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v8, v4
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, v9, v5, vcc
+; GFX9-NEXT:    v_sub_co_u32_e32 v0, vcc, v0, v6
+; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v1, v7, vcc
+; GFX9-NEXT:    v_subb_co_u32_e32 v2, vcc, v2, v4, vcc
+; GFX9-NEXT:    v_subb_co_u32_e32 v3, vcc, v3, v5, vcc
 ; GFX9-NEXT:    v_xor_b32_e32 v0, v0, v20
 ; GFX9-NEXT:    v_xor_b32_e32 v1, v1, v21
 ; GFX9-NEXT:    v_sub_co_u32_e32 v0, vcc, v0, v20
@@ -1633,26 +1633,26 @@ define i128 @v_urem_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-NEXT:    v_or_b32_e32 v12, v12, v8
 ; GFX9-NEXT:  .LBB1_6: ; %Flow3
 ; GFX9-NEXT:    s_or_b64 exec, exec, s[8:9]
-; GFX9-NEXT:    v_mul_lo_u32 v19, v12, v7
-; GFX9-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v4, v12, 0
-; GFX9-NEXT:    v_mov_b32_e32 v9, 0
-; GFX9-NEXT:    v_mul_lo_u32 v18, v13, v6
-; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v5, v12, v[8:9]
-; GFX9-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v12, v6, 0
-; GFX9-NEXT:    v_mov_b32_e32 v8, v16
-; GFX9-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v4, v13, v[8:9]
-; GFX9-NEXT:    v_add3_u32 v11, v11, v19, v18
-; GFX9-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v14, v4, v[10:11]
-; GFX9-NEXT:    v_mul_lo_u32 v6, v14, v5
-; GFX9-NEXT:    v_add_co_u32_e32 v14, vcc, v17, v9
-; GFX9-NEXT:    v_mul_lo_u32 v12, v15, v4
-; GFX9-NEXT:    v_addc_co_u32_e64 v15, s[4:5], 0, 0, vcc
-; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v5, v13, v[14:15]
-; GFX9-NEXT:    v_add3_u32 v6, v12, v11, v6
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v10
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, v5, v6, vcc
-; GFX9-NEXT:    v_sub_co_u32_e32 v0, vcc, v0, v7
-; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v1, v8, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v4, v12, 0
+; GFX9-NEXT:    v_mov_b32_e32 v10, 0
+; GFX9-NEXT:    v_mul_lo_u32 v11, v13, v6
+; GFX9-NEXT:    v_mul_lo_u32 v18, v12, v7
+; GFX9-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v5, v12, v[9:10]
+; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v12, v6, 0
+; GFX9-NEXT:    v_mul_lo_u32 v12, v14, v5
+; GFX9-NEXT:    v_mul_lo_u32 v15, v15, v4
+; GFX9-NEXT:    v_mov_b32_e32 v9, v16
+; GFX9-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v4, v13, v[9:10]
+; GFX9-NEXT:    v_add3_u32 v7, v7, v18, v11
+; GFX9-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v14, v4, v[6:7]
+; GFX9-NEXT:    v_add_co_u32_e32 v10, vcc, v17, v10
+; GFX9-NEXT:    v_addc_co_u32_e64 v11, s[4:5], 0, 0, vcc
+; GFX9-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v5, v13, v[10:11]
+; GFX9-NEXT:    v_add3_u32 v7, v15, v7, v12
+; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, v4, v6
+; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, v5, v7, vcc
+; GFX9-NEXT:    v_sub_co_u32_e32 v0, vcc, v0, v8
+; GFX9-NEXT:    v_subb_co_u32_e32 v1, vcc, v1, v9, vcc
 ; GFX9-NEXT:    v_subb_co_u32_e32 v2, vcc, v2, v4, vcc
 ; GFX9-NEXT:    v_subb_co_u32_e32 v3, vcc, v3, v5, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/srem.ll
+++ b/llvm/test/CodeGen/AMDGPU/srem.ll
@@ -1647,7 +1647,7 @@ define amdgpu_kernel void @srem_i64(ptr addrspace(1) %out, ptr addrspace(1) %in)
 ; GCN-NEXT:    s_sub_i32 s4, s3, s2
 ; GCN-NEXT:    s_cmp_ge_u32 s3, s2
 ; GCN-NEXT:    s_cselect_b32 s8, s4, s3
-; GCN-NEXT:  .LBB8_3:
+; GCN-NEXT:  .LBB8_3: ; %.split
 ; GCN-NEXT:    v_mov_b32_e32 v0, s8
 ; GCN-NEXT:    v_mov_b32_e32 v2, 0
 ; GCN-NEXT:    v_mov_b32_e32 v1, s9
@@ -1808,7 +1808,7 @@ define amdgpu_kernel void @srem_i64(ptr addrspace(1) %out, ptr addrspace(1) %in)
 ; TAHITI-NEXT:    v_sub_i32_e32 v1, vcc, v0, v2
 ; TAHITI-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v2
 ; TAHITI-NEXT:    v_cndmask_b32_e32 v3, v0, v1, vcc
-; TAHITI-NEXT:  .LBB8_3:
+; TAHITI-NEXT:  .LBB8_3: ; %.split
 ; TAHITI-NEXT:    s_mov_b32 s7, 0xf000
 ; TAHITI-NEXT:    s_mov_b32 s6, -1
 ; TAHITI-NEXT:    buffer_store_dwordx2 v[3:4], off, s[4:7], 0
@@ -1848,45 +1848,45 @@ define amdgpu_kernel void @srem_i64(ptr addrspace(1) %out, ptr addrspace(1) %in)
 ; TONGA-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; TONGA-NEXT:    v_trunc_f32_e32 v1, v1
 ; TONGA-NEXT:    v_madmk_f32 v0, v1, 0xcf800000, v0
-; TONGA-NEXT:    v_cvt_u32_f32_e32 v4, v1
-; TONGA-NEXT:    v_cvt_u32_f32_e32 v5, v0
-; TONGA-NEXT:    v_mul_lo_u32 v2, s3, v4
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], s3, v5, 0
-; TONGA-NEXT:    v_mul_lo_u32 v3, s10, v5
+; TONGA-NEXT:    v_cvt_u32_f32_e32 v7, v1
+; TONGA-NEXT:    v_cvt_u32_f32_e32 v8, v0
+; TONGA-NEXT:    v_mul_lo_u32 v2, s3, v7
+; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], s3, v8, 0
+; TONGA-NEXT:    v_mul_lo_u32 v3, s10, v8
 ; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
-; TONGA-NEXT:    v_add_u32_e32 v3, vcc, v1, v3
-; TONGA-NEXT:    v_mul_hi_u32 v6, v5, v0
-; TONGA-NEXT:    v_mad_u64_u32 v[1:2], s[8:9], v5, v3, 0
-; TONGA-NEXT:    v_add_u32_e32 v6, vcc, v6, v1
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v4, v0, 0
-; TONGA-NEXT:    v_addc_u32_e32 v7, vcc, 0, v2, vcc
-; TONGA-NEXT:    v_mad_u64_u32 v[2:3], s[8:9], v4, v3, 0
-; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v6, v0
-; TONGA-NEXT:    v_addc_u32_e32 v0, vcc, v7, v1, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v3, vcc
-; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v0, v2
+; TONGA-NEXT:    v_add_u32_e32 v5, vcc, v1, v3
+; TONGA-NEXT:    v_mul_hi_u32 v9, v8, v0
+; TONGA-NEXT:    v_mad_u64_u32 v[1:2], s[8:9], v8, v5, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[8:9], v7, v0, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v7, v5, 0
+; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v9, v1
+; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v2, vcc
+; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v0, v3
+; TONGA-NEXT:    v_addc_u32_e32 v0, vcc, v1, v4, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v6, vcc
+; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v0, v5
 ; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; TONGA-NEXT:    v_add_u32_e32 v6, vcc, v5, v0
-; TONGA-NEXT:    v_addc_u32_e32 v7, vcc, v4, v1, vcc
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], s3, v6, 0
-; TONGA-NEXT:    v_mul_lo_u32 v4, s3, v7
-; TONGA-NEXT:    v_mul_lo_u32 v5, s10, v6
-; TONGA-NEXT:    v_mul_hi_u32 v8, v6, v0
-; TONGA-NEXT:    v_mad_u64_u32 v[2:3], s[8:9], v7, v0, 0
-; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v4, v1
-; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v5, v1
-; TONGA-NEXT:    v_mad_u64_u32 v[4:5], s[8:9], v6, v1, 0
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v7, v1, 0
-; TONGA-NEXT:    v_add_u32_e32 v4, vcc, v8, v4
-; TONGA-NEXT:    v_addc_u32_e32 v5, vcc, 0, v5, vcc
-; TONGA-NEXT:    v_add_u32_e32 v2, vcc, v4, v2
-; TONGA-NEXT:    v_addc_u32_e32 v2, vcc, v5, v3, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v2, v0
+; TONGA-NEXT:    v_add_u32_e32 v8, vcc, v8, v0
+; TONGA-NEXT:    v_addc_u32_e32 v7, vcc, v7, v1, vcc
+; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], s3, v8, 0
+; TONGA-NEXT:    v_mul_lo_u32 v2, s3, v7
+; TONGA-NEXT:    v_mul_lo_u32 v3, s10, v8
 ; TONGA-NEXT:    s_ashr_i32 s10, s5, 31
-; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; TONGA-NEXT:    v_mul_hi_u32 v9, v8, v0
+; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v2, v1
+; TONGA-NEXT:    v_add_u32_e32 v5, vcc, v3, v1
+; TONGA-NEXT:    v_mad_u64_u32 v[1:2], s[8:9], v8, v5, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[8:9], v7, v0, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v7, v5, 0
 ; TONGA-NEXT:    s_add_u32 s8, s4, s10
-; TONGA-NEXT:    v_add_u32_e32 v2, vcc, v6, v0
+; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v9, v1
+; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v2, vcc
+; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v0, v3
+; TONGA-NEXT:    v_addc_u32_e32 v0, vcc, v1, v4, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v6, vcc
+; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v0, v5
+; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; TONGA-NEXT:    v_add_u32_e32 v2, vcc, v8, v0
 ; TONGA-NEXT:    s_mov_b32 s11, s10
 ; TONGA-NEXT:    s_addc_u32 s9, s5, s10
 ; TONGA-NEXT:    v_addc_u32_e32 v3, vcc, v7, v1, vcc
@@ -1912,9 +1912,9 @@ define amdgpu_kernel void @srem_i64(ptr addrspace(1) %out, ptr addrspace(1) %in)
 ; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], s6, v0, 0
 ; TONGA-NEXT:    s_addc_u32 s5, 0, s5
 ; TONGA-NEXT:    s_mul_i32 s5, s6, s5
+; TONGA-NEXT:    s_mul_i32 s3, s7, s3
 ; TONGA-NEXT:    v_readfirstlane_b32 s14, v1
 ; TONGA-NEXT:    s_add_i32 s5, s14, s5
-; TONGA-NEXT:    s_mul_i32 s3, s7, s3
 ; TONGA-NEXT:    s_add_i32 s5, s5, s3
 ; TONGA-NEXT:    s_sub_i32 s3, s13, s5
 ; TONGA-NEXT:    v_readfirstlane_b32 s14, v0
@@ -1978,7 +1978,7 @@ define amdgpu_kernel void @srem_i64(ptr addrspace(1) %out, ptr addrspace(1) %in)
 ; TONGA-NEXT:  .LBB8_4:
 ; TONGA-NEXT:    v_mov_b32_e32 v0, s6
 ; TONGA-NEXT:    v_mov_b32_e32 v1, s7
-; TONGA-NEXT:  .LBB8_5:
+; TONGA-NEXT:  .LBB8_5: ; %.split
 ; TONGA-NEXT:    v_mov_b32_e32 v2, s0
 ; TONGA-NEXT:    v_mov_b32_e32 v3, s1
 ; TONGA-NEXT:    flat_store_dwordx2 v[2:3], v[0:1]
@@ -2849,7 +2849,7 @@ define amdgpu_kernel void @srem_v2i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GCN-NEXT:    s_sub_i32 s9, s6, s8
 ; GCN-NEXT:    s_cmp_ge_u32 s6, s8
 ; GCN-NEXT:    s_cselect_b32 s6, s9, s6
-; GCN-NEXT:  .LBB10_3:
+; GCN-NEXT:  .LBB10_3: ; %.split
 ; GCN-NEXT:    s_or_b64 s[8:9], s[4:5], s[2:3]
 ; GCN-NEXT:    s_cmp_lg_u32 s9, 0
 ; GCN-NEXT:    s_cbranch_scc0 .LBB10_7
@@ -3006,7 +3006,7 @@ define amdgpu_kernel void @srem_v2i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GCN-NEXT:  .LBB10_8:
 ; GCN-NEXT:    v_mov_b32_e32 v2, s10
 ; GCN-NEXT:    v_mov_b32_e32 v3, s11
-; GCN-NEXT:  .LBB10_9:
+; GCN-NEXT:  .LBB10_9: ; %.split.split
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0
 ; GCN-NEXT:    v_mov_b32_e32 v0, s6
 ; GCN-NEXT:    v_mov_b32_e32 v1, s7
@@ -3165,7 +3165,7 @@ define amdgpu_kernel void @srem_v2i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TAHITI-NEXT:    v_sub_i32_e32 v4, vcc, v1, v0
 ; TAHITI-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v0
 ; TAHITI-NEXT:    v_cndmask_b32_e32 v8, v1, v4, vcc
-; TAHITI-NEXT:  .LBB10_3:
+; TAHITI-NEXT:  .LBB10_3: ; %.split
 ; TAHITI-NEXT:    v_or_b32_e32 v0, v7, v3
 ; TAHITI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
 ; TAHITI-NEXT:    s_cbranch_vccz .LBB10_8
@@ -3307,7 +3307,7 @@ define amdgpu_kernel void @srem_v2i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TAHITI-NEXT:    v_subrev_i32_e32 v1, vcc, v2, v0
 ; TAHITI-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v2
 ; TAHITI-NEXT:    v_cndmask_b32_e32 v10, v0, v1, vcc
-; TAHITI-NEXT:  .LBB10_6:
+; TAHITI-NEXT:  .LBB10_6: ; %.split.split
 ; TAHITI-NEXT:    s_mov_b32 s7, 0xf000
 ; TAHITI-NEXT:    s_mov_b32 s6, -1
 ; TAHITI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
@@ -3355,48 +3355,48 @@ define amdgpu_kernel void @srem_v2i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
 ; TONGA-NEXT:    v_trunc_f32_e32 v1, v1
 ; TONGA-NEXT:    v_madmk_f32 v0, v1, 0xcf800000, v0
-; TONGA-NEXT:    v_cvt_u32_f32_e32 v8, v1
-; TONGA-NEXT:    v_cvt_u32_f32_e32 v9, v0
-; TONGA-NEXT:    v_mul_lo_u32 v4, s1, v8
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], s1, v9, 0
-; TONGA-NEXT:    v_mul_lo_u32 v5, s10, v9
+; TONGA-NEXT:    v_cvt_u32_f32_e32 v10, v1
+; TONGA-NEXT:    v_cvt_u32_f32_e32 v11, v0
+; TONGA-NEXT:    v_mul_lo_u32 v4, s1, v10
+; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], s1, v11, 0
+; TONGA-NEXT:    v_mul_lo_u32 v5, s10, v11
 ; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v1, v4
-; TONGA-NEXT:    v_add_u32_e32 v11, vcc, v1, v5
-; TONGA-NEXT:    v_mul_hi_u32 v10, v9, v0
-; TONGA-NEXT:    v_mad_u64_u32 v[4:5], s[8:9], v9, v11, 0
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v8, v0, 0
-; TONGA-NEXT:    v_add_u32_e32 v10, vcc, v10, v4
-; TONGA-NEXT:    v_addc_u32_e32 v12, vcc, 0, v5, vcc
-; TONGA-NEXT:    v_mad_u64_u32 v[4:5], s[8:9], v8, v11, 0
-; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v10, v0
-; TONGA-NEXT:    v_addc_u32_e32 v0, vcc, v12, v1, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v5, vcc
-; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v0, v4
-; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; TONGA-NEXT:    v_add_u32_e32 v10, vcc, v9, v0
-; TONGA-NEXT:    v_addc_u32_e32 v11, vcc, v8, v1, vcc
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], s1, v10, 0
-; TONGA-NEXT:    v_mul_lo_u32 v8, s1, v11
-; TONGA-NEXT:    v_mul_lo_u32 v9, s10, v10
-; TONGA-NEXT:    v_mul_hi_u32 v12, v10, v0
-; TONGA-NEXT:    v_mad_u64_u32 v[4:5], s[8:9], v11, v0, 0
-; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v8, v1
-; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v9, v1
-; TONGA-NEXT:    v_mad_u64_u32 v[8:9], s[8:9], v10, v1, 0
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v11, v1, 0
-; TONGA-NEXT:    v_add_u32_e32 v8, vcc, v12, v8
-; TONGA-NEXT:    v_addc_u32_e32 v9, vcc, 0, v9, vcc
-; TONGA-NEXT:    v_add_u32_e32 v4, vcc, v8, v4
-; TONGA-NEXT:    v_addc_u32_e32 v4, vcc, v9, v5, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; TONGA-NEXT:    v_add_u32_e32 v8, vcc, v1, v5
+; TONGA-NEXT:    v_mul_hi_u32 v12, v11, v0
+; TONGA-NEXT:    v_mad_u64_u32 v[4:5], s[8:9], v11, v8, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v10, v0, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[8:9], s[8:9], v10, v8, 0
+; TONGA-NEXT:    v_add_u32_e32 v4, vcc, v12, v4
+; TONGA-NEXT:    v_addc_u32_e32 v5, vcc, 0, v5, vcc
 ; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v4, v0
-; TONGA-NEXT:    s_ashr_i32 s10, s3, 31
+; TONGA-NEXT:    v_addc_u32_e32 v0, vcc, v5, v1, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v9, vcc
+; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v0, v8
 ; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; TONGA-NEXT:    v_add_u32_e32 v11, vcc, v11, v0
+; TONGA-NEXT:    v_addc_u32_e32 v10, vcc, v10, v1, vcc
+; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], s1, v11, 0
+; TONGA-NEXT:    v_mul_lo_u32 v4, s1, v10
+; TONGA-NEXT:    v_mul_lo_u32 v5, s10, v11
+; TONGA-NEXT:    s_ashr_i32 s10, s3, 31
+; TONGA-NEXT:    v_mul_hi_u32 v12, v11, v0
+; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v4, v1
+; TONGA-NEXT:    v_add_u32_e32 v8, vcc, v5, v1
+; TONGA-NEXT:    v_mad_u64_u32 v[4:5], s[8:9], v11, v8, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v10, v0, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[8:9], s[8:9], v10, v8, 0
 ; TONGA-NEXT:    s_add_u32 s8, s2, s10
-; TONGA-NEXT:    v_add_u32_e32 v4, vcc, v10, v0
+; TONGA-NEXT:    v_add_u32_e32 v4, vcc, v12, v4
+; TONGA-NEXT:    v_addc_u32_e32 v5, vcc, 0, v5, vcc
+; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v4, v0
+; TONGA-NEXT:    v_addc_u32_e32 v0, vcc, v5, v1, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v9, vcc
+; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v0, v8
+; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; TONGA-NEXT:    v_add_u32_e32 v4, vcc, v11, v0
 ; TONGA-NEXT:    s_mov_b32 s11, s10
 ; TONGA-NEXT:    s_addc_u32 s9, s3, s10
-; TONGA-NEXT:    v_addc_u32_e32 v5, vcc, v11, v1, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v5, vcc, v10, v1, vcc
 ; TONGA-NEXT:    s_xor_b64 s[12:13], s[8:9], s[10:11]
 ; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], s12, v5, 0
 ; TONGA-NEXT:    v_mul_hi_u32 v8, s12, v4
@@ -3419,9 +3419,9 @@ define amdgpu_kernel void @srem_v2i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], s6, v0, 0
 ; TONGA-NEXT:    s_addc_u32 s3, 0, s3
 ; TONGA-NEXT:    s_mul_i32 s3, s6, s3
+; TONGA-NEXT:    s_mul_i32 s1, s7, s1
 ; TONGA-NEXT:    v_readfirstlane_b32 s14, v1
 ; TONGA-NEXT:    s_add_i32 s3, s14, s3
-; TONGA-NEXT:    s_mul_i32 s1, s7, s1
 ; TONGA-NEXT:    s_add_i32 s3, s3, s1
 ; TONGA-NEXT:    s_sub_i32 s1, s13, s3
 ; TONGA-NEXT:    v_readfirstlane_b32 s14, v0
@@ -3485,7 +3485,7 @@ define amdgpu_kernel void @srem_v2i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:  .LBB10_4:
 ; TONGA-NEXT:    v_mov_b32_e32 v9, s7
 ; TONGA-NEXT:    v_mov_b32_e32 v8, s6
-; TONGA-NEXT:  .LBB10_5:
+; TONGA-NEXT:  .LBB10_5: ; %.split
 ; TONGA-NEXT:    v_or_b32_e32 v0, v7, v3
 ; TONGA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
 ; TONGA-NEXT:    s_cbranch_vccz .LBB10_9
@@ -3513,9 +3513,9 @@ define amdgpu_kernel void @srem_v2i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v1, v3
 ; TONGA-NEXT:    v_add_u32_e32 v15, vcc, v1, v4
 ; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], v11, v15, 0
-; TONGA-NEXT:    v_mul_hi_u32 v1, v11, v0
-; TONGA-NEXT:    v_add_u32_e32 v16, vcc, v1, v3
+; TONGA-NEXT:    v_mul_hi_u32 v16, v11, v0
 ; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v10, v0, 0
+; TONGA-NEXT:    v_add_u32_e32 v16, vcc, v16, v3
 ; TONGA-NEXT:    v_addc_u32_e32 v17, vcc, 0, v4, vcc
 ; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], v10, v15, 0
 ; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v16, v0
@@ -3526,69 +3526,69 @@ define amdgpu_kernel void @srem_v2i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_add_u32_e32 v15, vcc, v11, v0
 ; TONGA-NEXT:    v_addc_u32_e32 v16, vcc, v10, v1, vcc
 ; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v13, v15, 0
-; TONGA-NEXT:    v_mul_lo_u32 v10, v13, v16
-; TONGA-NEXT:    v_mul_lo_u32 v11, v14, v15
+; TONGA-NEXT:    v_mul_lo_u32 v3, v13, v16
+; TONGA-NEXT:    v_mul_lo_u32 v4, v14, v15
 ; TONGA-NEXT:    v_mul_hi_u32 v13, v15, v0
-; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], v16, v0, 0
-; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v10, v1
-; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v11, v1
-; TONGA-NEXT:    v_mad_u64_u32 v[10:11], s[0:1], v15, v1, 0
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v16, v1, 0
-; TONGA-NEXT:    v_add_u32_e32 v10, vcc, v13, v10
-; TONGA-NEXT:    v_addc_u32_e32 v11, vcc, 0, v11, vcc
-; TONGA-NEXT:    v_add_u32_e32 v3, vcc, v10, v3
-; TONGA-NEXT:    v_addc_u32_e32 v3, vcc, v11, v4, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
+; TONGA-NEXT:    v_add_u32_e32 v10, vcc, v4, v1
+; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], v15, v10, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v16, v0, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[10:11], s[0:1], v16, v10, 0
+; TONGA-NEXT:    v_add_u32_e32 v3, vcc, v13, v3
+; TONGA-NEXT:    v_addc_u32_e32 v4, vcc, 0, v4, vcc
 ; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v3, v0
+; TONGA-NEXT:    v_addc_u32_e32 v0, vcc, v4, v1, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v11, vcc
+; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v0, v10
 ; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
 ; TONGA-NEXT:    v_add_u32_e32 v3, vcc, v15, v0
-; TONGA-NEXT:    v_addc_u32_e32 v4, vcc, v16, v1, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v10, vcc, v16, v1, vcc
 ; TONGA-NEXT:    v_ashrrev_i32_e32 v11, 31, v7
 ; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v6, v11
-; TONGA-NEXT:    v_xor_b32_e32 v10, v0, v11
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v10, v4, 0
-; TONGA-NEXT:    v_mul_hi_u32 v13, v10, v3
-; TONGA-NEXT:    v_addc_u32_e32 v7, vcc, v7, v11, vcc
-; TONGA-NEXT:    v_xor_b32_e32 v7, v7, v11
+; TONGA-NEXT:    v_addc_u32_e32 v4, vcc, v7, v11, vcc
+; TONGA-NEXT:    v_xor_b32_e32 v7, v0, v11
+; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v7, v10, 0
+; TONGA-NEXT:    v_mul_hi_u32 v13, v7, v3
+; TONGA-NEXT:    v_xor_b32_e32 v14, v4, v11
+; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], v14, v3, 0
 ; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v13, v0
-; TONGA-NEXT:    v_addc_u32_e32 v14, vcc, 0, v1, vcc
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v7, v3, 0
-; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], v7, v4, 0
-; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v13, v0
-; TONGA-NEXT:    v_addc_u32_e32 v0, vcc, v14, v1, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v4, vcc
-; TONGA-NEXT:    v_add_u32_e32 v3, vcc, v0, v3
+; TONGA-NEXT:    v_addc_u32_e32 v15, vcc, 0, v1, vcc
+; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v14, v10, 0
+; TONGA-NEXT:    v_add_u32_e32 v3, vcc, v13, v3
+; TONGA-NEXT:    v_addc_u32_e32 v3, vcc, v15, v4, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; TONGA-NEXT:    v_add_u32_e32 v3, vcc, v3, v0
 ; TONGA-NEXT:    v_addc_u32_e32 v0, vcc, 0, v1, vcc
 ; TONGA-NEXT:    v_mul_lo_u32 v4, v5, v0
 ; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v5, v3, 0
 ; TONGA-NEXT:    v_mul_lo_u32 v3, v12, v3
 ; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v4, v1
 ; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
-; TONGA-NEXT:    v_sub_u32_e32 v3, vcc, v7, v1
-; TONGA-NEXT:    v_sub_u32_e32 v0, vcc, v10, v0
+; TONGA-NEXT:    v_sub_u32_e32 v3, vcc, v14, v1
+; TONGA-NEXT:    v_sub_u32_e32 v0, vcc, v7, v0
 ; TONGA-NEXT:    v_subb_u32_e64 v3, s[0:1], v3, v12, vcc
 ; TONGA-NEXT:    v_sub_u32_e64 v4, s[0:1], v0, v5
-; TONGA-NEXT:    v_subbrev_u32_e64 v10, s[2:3], 0, v3, s[0:1]
-; TONGA-NEXT:    v_cmp_ge_u32_e64 s[2:3], v10, v12
-; TONGA-NEXT:    v_cndmask_b32_e64 v13, 0, -1, s[2:3]
+; TONGA-NEXT:    v_subbrev_u32_e64 v7, s[2:3], 0, v3, s[0:1]
+; TONGA-NEXT:    v_cmp_ge_u32_e64 s[2:3], v7, v12
+; TONGA-NEXT:    v_cndmask_b32_e64 v10, 0, -1, s[2:3]
 ; TONGA-NEXT:    v_cmp_ge_u32_e64 s[2:3], v4, v5
-; TONGA-NEXT:    v_subb_u32_e32 v1, vcc, v7, v1, vcc
-; TONGA-NEXT:    v_cndmask_b32_e64 v14, 0, -1, s[2:3]
-; TONGA-NEXT:    v_cmp_eq_u32_e64 s[2:3], v10, v12
+; TONGA-NEXT:    v_cndmask_b32_e64 v13, 0, -1, s[2:3]
+; TONGA-NEXT:    v_cmp_eq_u32_e64 s[2:3], v7, v12
 ; TONGA-NEXT:    v_subb_u32_e64 v3, s[0:1], v3, v12, s[0:1]
+; TONGA-NEXT:    v_cndmask_b32_e64 v10, v10, v13, s[2:3]
+; TONGA-NEXT:    v_sub_u32_e64 v13, s[0:1], v4, v5
+; TONGA-NEXT:    v_subbrev_u32_e64 v3, s[0:1], 0, v3, s[0:1]
+; TONGA-NEXT:    v_subb_u32_e32 v1, vcc, v14, v1, vcc
+; TONGA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v10
 ; TONGA-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v12
-; TONGA-NEXT:    v_cndmask_b32_e64 v13, v13, v14, s[2:3]
-; TONGA-NEXT:    v_sub_u32_e64 v14, s[0:1], v4, v5
+; TONGA-NEXT:    v_cndmask_b32_e64 v3, v7, v3, s[0:1]
 ; TONGA-NEXT:    v_cndmask_b32_e64 v7, 0, -1, vcc
 ; TONGA-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v5
-; TONGA-NEXT:    v_subbrev_u32_e64 v3, s[0:1], 0, v3, s[0:1]
 ; TONGA-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc
 ; TONGA-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v12
-; TONGA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v13
 ; TONGA-NEXT:    v_cndmask_b32_e32 v5, v7, v5, vcc
-; TONGA-NEXT:    v_cndmask_b32_e64 v4, v4, v14, s[0:1]
+; TONGA-NEXT:    v_cndmask_b32_e64 v4, v4, v13, s[0:1]
 ; TONGA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
-; TONGA-NEXT:    v_cndmask_b32_e64 v3, v10, v3, s[0:1]
 ; TONGA-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
 ; TONGA-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; TONGA-NEXT:    v_xor_b32_e32 v0, v0, v11
@@ -3615,7 +3615,7 @@ define amdgpu_kernel void @srem_v2i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_subrev_u32_e32 v1, vcc, v2, v0
 ; TONGA-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v2
 ; TONGA-NEXT:    v_cndmask_b32_e32 v10, v0, v1, vcc
-; TONGA-NEXT:  .LBB10_8:
+; TONGA-NEXT:  .LBB10_8: ; %.split.split
 ; TONGA-NEXT:    v_mov_b32_e32 v0, s4
 ; TONGA-NEXT:    v_mov_b32_e32 v1, s5
 ; TONGA-NEXT:    flat_store_dwordx4 v[0:1], v[8:11]
@@ -5027,7 +5027,7 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GCN-NEXT:    s_sub_i32 s17, s6, s16
 ; GCN-NEXT:    s_cmp_ge_u32 s6, s16
 ; GCN-NEXT:    s_cselect_b32 s6, s17, s6
-; GCN-NEXT:  .LBB12_3:
+; GCN-NEXT:  .LBB12_3: ; %.split
 ; GCN-NEXT:    s_or_b64 s[16:17], s[14:15], s[12:13]
 ; GCN-NEXT:    s_cmp_lg_u32 s17, 0
 ; GCN-NEXT:    s_cbranch_scc0 .LBB12_7
@@ -5184,7 +5184,7 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GCN-NEXT:  .LBB12_8:
 ; GCN-NEXT:    v_mov_b32_e32 v2, s18
 ; GCN-NEXT:    v_mov_b32_e32 v3, s19
-; GCN-NEXT:  .LBB12_9:
+; GCN-NEXT:  .LBB12_9: ; %.split.split
 ; GCN-NEXT:    s_or_b64 s[12:13], s[10:11], s[8:9]
 ; GCN-NEXT:    s_cmp_lg_u32 s13, 0
 ; GCN-NEXT:    s_cbranch_scc0 .LBB12_12
@@ -5338,7 +5338,7 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GCN-NEXT:  .LBB12_13:
 ; GCN-NEXT:    v_mov_b32_e32 v4, s14
 ; GCN-NEXT:    v_mov_b32_e32 v5, s15
-; GCN-NEXT:  .LBB12_14:
+; GCN-NEXT:  .LBB12_14: ; %.split.split.split
 ; GCN-NEXT:    s_or_b64 s[8:9], s[4:5], s[2:3]
 ; GCN-NEXT:    s_cmp_lg_u32 s9, 0
 ; GCN-NEXT:    s_cbranch_scc0 .LBB12_17
@@ -5492,7 +5492,7 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; GCN-NEXT:  .LBB12_18:
 ; GCN-NEXT:    v_mov_b32_e32 v6, s10
 ; GCN-NEXT:    v_mov_b32_e32 v7, s11
-; GCN-NEXT:  .LBB12_19:
+; GCN-NEXT:  .LBB12_19: ; %.split.split.split.split
 ; GCN-NEXT:    v_mov_b32_e32 v8, 0
 ; GCN-NEXT:    v_mov_b32_e32 v0, s6
 ; GCN-NEXT:    v_mov_b32_e32 v1, s7
@@ -5654,7 +5654,7 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TAHITI-NEXT:    v_cmp_ge_u32_e32 vcc, v8, v10
 ; TAHITI-NEXT:    v_cndmask_b32_e32 v8, v8, v9, vcc
 ; TAHITI-NEXT:    v_mov_b32_e32 v9, 0
-; TAHITI-NEXT:  .LBB12_3:
+; TAHITI-NEXT:  .LBB12_3: ; %.split
 ; TAHITI-NEXT:    v_or_b32_e32 v10, v17, v13
 ; TAHITI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
 ; TAHITI-NEXT:    s_cbranch_vccz .LBB12_14
@@ -5796,7 +5796,7 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TAHITI-NEXT:    v_cmp_ge_u32_e32 vcc, v10, v12
 ; TAHITI-NEXT:    v_cndmask_b32_e32 v10, v10, v11, vcc
 ; TAHITI-NEXT:    v_mov_b32_e32 v11, 0
-; TAHITI-NEXT:  .LBB12_6:
+; TAHITI-NEXT:  .LBB12_6: ; %.split.split
 ; TAHITI-NEXT:    s_waitcnt vmcnt(0)
 ; TAHITI-NEXT:    v_or_b32_e32 v12, v5, v1
 ; TAHITI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
@@ -5939,7 +5939,7 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TAHITI-NEXT:    v_subrev_i32_e32 v4, vcc, v0, v1
 ; TAHITI-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v0
 ; TAHITI-NEXT:    v_cndmask_b32_e32 v12, v1, v4, vcc
-; TAHITI-NEXT:  .LBB12_9:
+; TAHITI-NEXT:  .LBB12_9: ; %.split.split.split
 ; TAHITI-NEXT:    v_or_b32_e32 v0, v7, v3
 ; TAHITI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
 ; TAHITI-NEXT:    s_cbranch_vccz .LBB12_16
@@ -6081,7 +6081,7 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TAHITI-NEXT:    v_subrev_i32_e32 v1, vcc, v2, v0
 ; TAHITI-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v2
 ; TAHITI-NEXT:    v_cndmask_b32_e32 v14, v0, v1, vcc
-; TAHITI-NEXT:  .LBB12_12:
+; TAHITI-NEXT:  .LBB12_12: ; %.split.split.split.split
 ; TAHITI-NEXT:    s_mov_b32 s7, 0xf000
 ; TAHITI-NEXT:    s_mov_b32 s6, -1
 ; TAHITI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0 offset:16
@@ -6145,48 +6145,48 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_mul_f32_e32 v9, 0x2f800000, v8
 ; TONGA-NEXT:    v_trunc_f32_e32 v9, v9
 ; TONGA-NEXT:    v_madmk_f32 v8, v9, 0xcf800000, v8
-; TONGA-NEXT:    v_cvt_u32_f32_e32 v14, v9
-; TONGA-NEXT:    v_cvt_u32_f32_e32 v15, v8
-; TONGA-NEXT:    v_mul_lo_u32 v10, s1, v14
-; TONGA-NEXT:    v_mad_u64_u32 v[8:9], s[8:9], s1, v15, 0
-; TONGA-NEXT:    v_mul_lo_u32 v11, s10, v15
+; TONGA-NEXT:    v_cvt_u32_f32_e32 v11, v9
+; TONGA-NEXT:    v_cvt_u32_f32_e32 v20, v8
+; TONGA-NEXT:    v_mul_lo_u32 v10, s1, v11
+; TONGA-NEXT:    v_mad_u64_u32 v[8:9], s[8:9], s1, v20, 0
+; TONGA-NEXT:    v_mul_lo_u32 v14, s10, v20
 ; TONGA-NEXT:    v_add_u32_e32 v9, vcc, v9, v10
-; TONGA-NEXT:    v_add_u32_e32 v11, vcc, v9, v11
-; TONGA-NEXT:    v_mul_hi_u32 v18, v15, v8
-; TONGA-NEXT:    v_mad_u64_u32 v[9:10], s[8:9], v15, v11, 0
-; TONGA-NEXT:    v_add_u32_e32 v18, vcc, v18, v9
-; TONGA-NEXT:    v_mad_u64_u32 v[8:9], s[8:9], v14, v8, 0
-; TONGA-NEXT:    v_addc_u32_e32 v19, vcc, 0, v10, vcc
-; TONGA-NEXT:    v_mad_u64_u32 v[10:11], s[8:9], v14, v11, 0
-; TONGA-NEXT:    v_add_u32_e32 v8, vcc, v18, v8
-; TONGA-NEXT:    v_addc_u32_e32 v8, vcc, v19, v9, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v9, vcc, 0, v11, vcc
-; TONGA-NEXT:    v_add_u32_e32 v8, vcc, v8, v10
+; TONGA-NEXT:    v_add_u32_e32 v18, vcc, v9, v14
+; TONGA-NEXT:    v_mul_hi_u32 v21, v20, v8
+; TONGA-NEXT:    v_mad_u64_u32 v[9:10], s[8:9], v20, v18, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[14:15], s[8:9], v11, v8, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[18:19], s[8:9], v11, v18, 0
+; TONGA-NEXT:    v_add_u32_e32 v8, vcc, v21, v9
+; TONGA-NEXT:    v_addc_u32_e32 v9, vcc, 0, v10, vcc
+; TONGA-NEXT:    v_add_u32_e32 v8, vcc, v8, v14
+; TONGA-NEXT:    v_addc_u32_e32 v8, vcc, v9, v15, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v9, vcc, 0, v19, vcc
+; TONGA-NEXT:    v_add_u32_e32 v8, vcc, v8, v18
 ; TONGA-NEXT:    v_addc_u32_e32 v9, vcc, 0, v9, vcc
-; TONGA-NEXT:    v_add_u32_e32 v18, vcc, v15, v8
-; TONGA-NEXT:    v_addc_u32_e32 v19, vcc, v14, v9, vcc
-; TONGA-NEXT:    v_mad_u64_u32 v[8:9], s[8:9], s1, v18, 0
-; TONGA-NEXT:    v_mul_lo_u32 v14, s1, v19
-; TONGA-NEXT:    v_mul_lo_u32 v15, s10, v18
-; TONGA-NEXT:    v_mul_hi_u32 v20, v18, v8
-; TONGA-NEXT:    v_mad_u64_u32 v[10:11], s[8:9], v19, v8, 0
-; TONGA-NEXT:    v_add_u32_e32 v9, vcc, v14, v9
-; TONGA-NEXT:    v_add_u32_e32 v9, vcc, v15, v9
-; TONGA-NEXT:    v_mad_u64_u32 v[14:15], s[8:9], v18, v9, 0
-; TONGA-NEXT:    v_mad_u64_u32 v[8:9], s[8:9], v19, v9, 0
-; TONGA-NEXT:    v_add_u32_e32 v14, vcc, v20, v14
-; TONGA-NEXT:    v_addc_u32_e32 v15, vcc, 0, v15, vcc
-; TONGA-NEXT:    v_add_u32_e32 v10, vcc, v14, v10
-; TONGA-NEXT:    v_addc_u32_e32 v10, vcc, v15, v11, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v9, vcc, 0, v9, vcc
-; TONGA-NEXT:    v_add_u32_e32 v8, vcc, v10, v8
+; TONGA-NEXT:    v_add_u32_e32 v20, vcc, v20, v8
+; TONGA-NEXT:    v_addc_u32_e32 v11, vcc, v11, v9, vcc
+; TONGA-NEXT:    v_mad_u64_u32 v[8:9], s[8:9], s1, v20, 0
+; TONGA-NEXT:    v_mul_lo_u32 v10, s1, v11
+; TONGA-NEXT:    v_mul_lo_u32 v14, s10, v20
 ; TONGA-NEXT:    s_ashr_i32 s10, s3, 31
-; TONGA-NEXT:    v_addc_u32_e32 v9, vcc, 0, v9, vcc
+; TONGA-NEXT:    v_mul_hi_u32 v21, v20, v8
+; TONGA-NEXT:    v_add_u32_e32 v9, vcc, v10, v9
+; TONGA-NEXT:    v_add_u32_e32 v18, vcc, v14, v9
+; TONGA-NEXT:    v_mad_u64_u32 v[9:10], s[8:9], v20, v18, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[14:15], s[8:9], v11, v8, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[18:19], s[8:9], v11, v18, 0
 ; TONGA-NEXT:    s_add_u32 s8, s2, s10
-; TONGA-NEXT:    v_add_u32_e32 v10, vcc, v18, v8
+; TONGA-NEXT:    v_add_u32_e32 v8, vcc, v21, v9
+; TONGA-NEXT:    v_addc_u32_e32 v9, vcc, 0, v10, vcc
+; TONGA-NEXT:    v_add_u32_e32 v8, vcc, v8, v14
+; TONGA-NEXT:    v_addc_u32_e32 v8, vcc, v9, v15, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v9, vcc, 0, v19, vcc
+; TONGA-NEXT:    v_add_u32_e32 v8, vcc, v8, v18
+; TONGA-NEXT:    v_addc_u32_e32 v9, vcc, 0, v9, vcc
+; TONGA-NEXT:    v_add_u32_e32 v10, vcc, v20, v8
 ; TONGA-NEXT:    s_mov_b32 s11, s10
 ; TONGA-NEXT:    s_addc_u32 s9, s3, s10
-; TONGA-NEXT:    v_addc_u32_e32 v11, vcc, v19, v9, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v11, vcc, v11, v9, vcc
 ; TONGA-NEXT:    s_xor_b64 s[12:13], s[8:9], s[10:11]
 ; TONGA-NEXT:    v_mad_u64_u32 v[8:9], s[8:9], s12, v11, 0
 ; TONGA-NEXT:    v_mul_hi_u32 v14, s12, v10
@@ -6209,9 +6209,9 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_mad_u64_u32 v[8:9], s[8:9], s6, v8, 0
 ; TONGA-NEXT:    s_addc_u32 s3, 0, s3
 ; TONGA-NEXT:    s_mul_i32 s3, s6, s3
+; TONGA-NEXT:    s_mul_i32 s1, s7, s1
 ; TONGA-NEXT:    v_readfirstlane_b32 s14, v9
 ; TONGA-NEXT:    s_add_i32 s3, s14, s3
-; TONGA-NEXT:    s_mul_i32 s1, s7, s1
 ; TONGA-NEXT:    s_add_i32 s3, s3, s1
 ; TONGA-NEXT:    s_sub_i32 s1, s13, s3
 ; TONGA-NEXT:    v_readfirstlane_b32 s14, v8
@@ -6275,7 +6275,7 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:  .LBB12_4:
 ; TONGA-NEXT:    v_mov_b32_e32 v9, s7
 ; TONGA-NEXT:    v_mov_b32_e32 v8, s6
-; TONGA-NEXT:  .LBB12_5:
+; TONGA-NEXT:  .LBB12_5: ; %.split
 ; TONGA-NEXT:    v_or_b32_e32 v10, v17, v13
 ; TONGA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
 ; TONGA-NEXT:    s_cbranch_vccz .LBB12_15
@@ -6301,30 +6301,30 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v22, v21, 0
 ; TONGA-NEXT:    v_mul_lo_u32 v18, v23, v21
 ; TONGA-NEXT:    v_add_u32_e32 v14, vcc, v14, v15
-; TONGA-NEXT:    v_add_u32_e32 v18, vcc, v14, v18
-; TONGA-NEXT:    v_mad_u64_u32 v[14:15], s[0:1], v21, v18, 0
-; TONGA-NEXT:    v_mul_hi_u32 v19, v21, v13
-; TONGA-NEXT:    v_add_u32_e32 v24, vcc, v19, v14
-; TONGA-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v20, v13, 0
-; TONGA-NEXT:    v_mad_u64_u32 v[18:19], s[0:1], v20, v18, 0
+; TONGA-NEXT:    v_add_u32_e32 v24, vcc, v14, v18
+; TONGA-NEXT:    v_mad_u64_u32 v[14:15], s[0:1], v21, v24, 0
+; TONGA-NEXT:    v_mul_hi_u32 v25, v21, v13
+; TONGA-NEXT:    v_mad_u64_u32 v[18:19], s[0:1], v20, v13, 0
+; TONGA-NEXT:    v_add_u32_e32 v25, vcc, v25, v14
+; TONGA-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v20, v24, 0
 ; TONGA-NEXT:    v_addc_u32_e32 v15, vcc, 0, v15, vcc
-; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v24, v13
-; TONGA-NEXT:    v_addc_u32_e32 v13, vcc, v15, v14, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v14, vcc, 0, v19, vcc
-; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v13, v18
+; TONGA-NEXT:    v_add_u32_e32 v18, vcc, v25, v18
+; TONGA-NEXT:    v_addc_u32_e32 v15, vcc, v15, v19, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v14, vcc, 0, v14, vcc
+; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v15, v13
 ; TONGA-NEXT:    v_addc_u32_e32 v14, vcc, 0, v14, vcc
 ; TONGA-NEXT:    v_add_u32_e32 v24, vcc, v21, v13
 ; TONGA-NEXT:    v_addc_u32_e32 v25, vcc, v20, v14, vcc
 ; TONGA-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v22, v24, 0
 ; TONGA-NEXT:    v_mul_lo_u32 v15, v22, v25
-; TONGA-NEXT:    v_mul_lo_u32 v20, v23, v24
-; TONGA-NEXT:    v_mad_u64_u32 v[18:19], s[0:1], v25, v13, 0
+; TONGA-NEXT:    v_mul_lo_u32 v18, v23, v24
+; TONGA-NEXT:    v_mul_hi_u32 v22, v24, v13
 ; TONGA-NEXT:    v_add_u32_e32 v14, vcc, v15, v14
-; TONGA-NEXT:    v_add_u32_e32 v20, vcc, v20, v14
+; TONGA-NEXT:    v_add_u32_e32 v20, vcc, v18, v14
 ; TONGA-NEXT:    v_mad_u64_u32 v[14:15], s[0:1], v24, v20, 0
-; TONGA-NEXT:    v_mul_hi_u32 v13, v24, v13
+; TONGA-NEXT:    v_mad_u64_u32 v[18:19], s[0:1], v25, v13, 0
 ; TONGA-NEXT:    v_mad_u64_u32 v[20:21], s[0:1], v25, v20, 0
-; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v13, v14
+; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v22, v14
 ; TONGA-NEXT:    v_addc_u32_e32 v14, vcc, 0, v15, vcc
 ; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v13, v18
 ; TONGA-NEXT:    v_addc_u32_e32 v13, vcc, v14, v19, vcc
@@ -6332,44 +6332,44 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v13, v20
 ; TONGA-NEXT:    v_addc_u32_e32 v14, vcc, 0, v14, vcc
 ; TONGA-NEXT:    v_add_u32_e32 v15, vcc, v24, v13
-; TONGA-NEXT:    v_addc_u32_e32 v18, vcc, v25, v14, vcc
-; TONGA-NEXT:    v_ashrrev_i32_e32 v19, 31, v17
-; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v16, v19
-; TONGA-NEXT:    v_xor_b32_e32 v20, v13, v19
-; TONGA-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v20, v18, 0
-; TONGA-NEXT:    v_mul_hi_u32 v21, v20, v15
-; TONGA-NEXT:    v_addc_u32_e32 v17, vcc, v17, v19, vcc
-; TONGA-NEXT:    v_xor_b32_e32 v22, v17, v19
-; TONGA-NEXT:    v_add_u32_e32 v21, vcc, v21, v13
-; TONGA-NEXT:    v_addc_u32_e32 v23, vcc, 0, v14, vcc
-; TONGA-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v22, v15, 0
-; TONGA-NEXT:    v_mad_u64_u32 v[17:18], s[0:1], v22, v18, 0
-; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v21, v13
-; TONGA-NEXT:    v_addc_u32_e32 v13, vcc, v23, v14, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v14, vcc, 0, v18, vcc
-; TONGA-NEXT:    v_add_u32_e32 v15, vcc, v13, v17
+; TONGA-NEXT:    v_addc_u32_e32 v19, vcc, v25, v14, vcc
+; TONGA-NEXT:    v_ashrrev_i32_e32 v20, 31, v17
+; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v16, v20
+; TONGA-NEXT:    v_xor_b32_e32 v21, v13, v20
+; TONGA-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v21, v19, 0
+; TONGA-NEXT:    v_mul_hi_u32 v22, v21, v15
+; TONGA-NEXT:    v_addc_u32_e32 v17, vcc, v17, v20, vcc
+; TONGA-NEXT:    v_xor_b32_e32 v23, v17, v20
+; TONGA-NEXT:    v_mad_u64_u32 v[17:18], s[0:1], v23, v15, 0
+; TONGA-NEXT:    v_add_u32_e32 v15, vcc, v22, v13
+; TONGA-NEXT:    v_addc_u32_e32 v22, vcc, 0, v14, vcc
+; TONGA-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v23, v19, 0
+; TONGA-NEXT:    v_add_u32_e32 v15, vcc, v15, v17
+; TONGA-NEXT:    v_addc_u32_e32 v15, vcc, v22, v18, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v14, vcc, 0, v14, vcc
+; TONGA-NEXT:    v_add_u32_e32 v15, vcc, v15, v13
 ; TONGA-NEXT:    v_addc_u32_e32 v13, vcc, 0, v14, vcc
 ; TONGA-NEXT:    v_mul_lo_u32 v17, v11, v13
 ; TONGA-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v11, v15, 0
 ; TONGA-NEXT:    v_mul_lo_u32 v15, v10, v15
 ; TONGA-NEXT:    v_add_u32_e32 v14, vcc, v17, v14
 ; TONGA-NEXT:    v_add_u32_e32 v14, vcc, v15, v14
-; TONGA-NEXT:    v_sub_u32_e32 v15, vcc, v22, v14
-; TONGA-NEXT:    v_sub_u32_e32 v13, vcc, v20, v13
+; TONGA-NEXT:    v_sub_u32_e32 v15, vcc, v23, v14
+; TONGA-NEXT:    v_sub_u32_e32 v13, vcc, v21, v13
 ; TONGA-NEXT:    v_subb_u32_e64 v15, s[0:1], v15, v10, vcc
 ; TONGA-NEXT:    v_sub_u32_e64 v17, s[0:1], v13, v11
 ; TONGA-NEXT:    v_subbrev_u32_e64 v18, s[2:3], 0, v15, s[0:1]
 ; TONGA-NEXT:    v_cmp_ge_u32_e64 s[2:3], v18, v10
-; TONGA-NEXT:    v_cndmask_b32_e64 v20, 0, -1, s[2:3]
+; TONGA-NEXT:    v_cndmask_b32_e64 v19, 0, -1, s[2:3]
 ; TONGA-NEXT:    v_cmp_ge_u32_e64 s[2:3], v17, v11
 ; TONGA-NEXT:    v_cndmask_b32_e64 v21, 0, -1, s[2:3]
 ; TONGA-NEXT:    v_cmp_eq_u32_e64 s[2:3], v18, v10
 ; TONGA-NEXT:    v_subb_u32_e64 v15, s[0:1], v15, v10, s[0:1]
-; TONGA-NEXT:    v_cndmask_b32_e64 v20, v20, v21, s[2:3]
+; TONGA-NEXT:    v_cndmask_b32_e64 v19, v19, v21, s[2:3]
 ; TONGA-NEXT:    v_sub_u32_e64 v21, s[0:1], v17, v11
 ; TONGA-NEXT:    v_subbrev_u32_e64 v15, s[0:1], 0, v15, s[0:1]
-; TONGA-NEXT:    v_subb_u32_e32 v14, vcc, v22, v14, vcc
-; TONGA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v20
+; TONGA-NEXT:    v_subb_u32_e32 v14, vcc, v23, v14, vcc
+; TONGA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v19
 ; TONGA-NEXT:    v_cmp_ge_u32_e32 vcc, v14, v10
 ; TONGA-NEXT:    v_cndmask_b32_e64 v15, v18, v15, s[0:1]
 ; TONGA-NEXT:    v_cndmask_b32_e64 v18, 0, -1, vcc
@@ -6381,10 +6381,10 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
 ; TONGA-NEXT:    v_cndmask_b32_e32 v11, v13, v17, vcc
 ; TONGA-NEXT:    v_cndmask_b32_e32 v10, v14, v15, vcc
-; TONGA-NEXT:    v_xor_b32_e32 v11, v11, v19
-; TONGA-NEXT:    v_xor_b32_e32 v13, v10, v19
-; TONGA-NEXT:    v_sub_u32_e32 v10, vcc, v11, v19
-; TONGA-NEXT:    v_subb_u32_e32 v11, vcc, v13, v19, vcc
+; TONGA-NEXT:    v_xor_b32_e32 v11, v11, v20
+; TONGA-NEXT:    v_xor_b32_e32 v13, v10, v20
+; TONGA-NEXT:    v_sub_u32_e32 v10, vcc, v11, v20
+; TONGA-NEXT:    v_subb_u32_e32 v11, vcc, v13, v20, vcc
 ; TONGA-NEXT:    s_cbranch_execnz .LBB12_8
 ; TONGA-NEXT:  .LBB12_7:
 ; TONGA-NEXT:    v_cvt_f32_u32_e32 v10, v12
@@ -6405,7 +6405,7 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_cmp_ge_u32_e32 vcc, v10, v12
 ; TONGA-NEXT:    v_cndmask_b32_e32 v10, v10, v11, vcc
 ; TONGA-NEXT:    v_mov_b32_e32 v11, 0
-; TONGA-NEXT:  .LBB12_8:
+; TONGA-NEXT:  .LBB12_8: ; %.split.split
 ; TONGA-NEXT:    s_waitcnt vmcnt(0)
 ; TONGA-NEXT:    v_or_b32_e32 v12, v5, v1
 ; TONGA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
@@ -6414,108 +6414,108 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_ashrrev_i32_e32 v12, 31, v1
 ; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v0, v12
 ; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, v1, v12, vcc
-; TONGA-NEXT:    v_xor_b32_e32 v18, v13, v12
+; TONGA-NEXT:    v_xor_b32_e32 v19, v13, v12
 ; TONGA-NEXT:    v_xor_b32_e32 v1, v1, v12
-; TONGA-NEXT:    v_cvt_f32_u32_e32 v12, v18
+; TONGA-NEXT:    v_cvt_f32_u32_e32 v12, v19
 ; TONGA-NEXT:    v_cvt_f32_u32_e32 v13, v1
-; TONGA-NEXT:    v_sub_u32_e32 v19, vcc, 0, v18
-; TONGA-NEXT:    v_subb_u32_e32 v20, vcc, 0, v1, vcc
+; TONGA-NEXT:    v_sub_u32_e32 v20, vcc, 0, v19
+; TONGA-NEXT:    v_subb_u32_e32 v21, vcc, 0, v1, vcc
 ; TONGA-NEXT:    v_madmk_f32 v12, v13, 0x4f800000, v12
 ; TONGA-NEXT:    v_rcp_f32_e32 v12, v12
 ; TONGA-NEXT:    v_mul_f32_e32 v12, 0x5f7ffffc, v12
 ; TONGA-NEXT:    v_mul_f32_e32 v13, 0x2f800000, v12
 ; TONGA-NEXT:    v_trunc_f32_e32 v13, v13
 ; TONGA-NEXT:    v_madmk_f32 v12, v13, 0xcf800000, v12
-; TONGA-NEXT:    v_cvt_u32_f32_e32 v16, v13
-; TONGA-NEXT:    v_cvt_u32_f32_e32 v17, v12
-; TONGA-NEXT:    v_mul_lo_u32 v14, v19, v16
-; TONGA-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v19, v17, 0
-; TONGA-NEXT:    v_mul_lo_u32 v15, v20, v17
+; TONGA-NEXT:    v_cvt_u32_f32_e32 v17, v13
+; TONGA-NEXT:    v_cvt_u32_f32_e32 v18, v12
+; TONGA-NEXT:    v_mul_lo_u32 v14, v20, v17
+; TONGA-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v20, v18, 0
+; TONGA-NEXT:    v_mul_lo_u32 v15, v21, v18
 ; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v13, v14
-; TONGA-NEXT:    v_add_u32_e32 v15, vcc, v13, v15
-; TONGA-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v17, v15, 0
-; TONGA-NEXT:    v_mul_hi_u32 v21, v17, v12
-; TONGA-NEXT:    v_add_u32_e32 v21, vcc, v21, v13
-; TONGA-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v16, v12, 0
-; TONGA-NEXT:    v_addc_u32_e32 v22, vcc, 0, v14, vcc
-; TONGA-NEXT:    v_mad_u64_u32 v[14:15], s[0:1], v16, v15, 0
-; TONGA-NEXT:    v_add_u32_e32 v12, vcc, v21, v12
-; TONGA-NEXT:    v_addc_u32_e32 v12, vcc, v22, v13, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v13, vcc, 0, v15, vcc
-; TONGA-NEXT:    v_add_u32_e32 v12, vcc, v12, v14
-; TONGA-NEXT:    v_addc_u32_e32 v13, vcc, 0, v13, vcc
-; TONGA-NEXT:    v_add_u32_e32 v21, vcc, v17, v12
-; TONGA-NEXT:    v_addc_u32_e32 v22, vcc, v16, v13, vcc
-; TONGA-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v19, v21, 0
-; TONGA-NEXT:    v_mul_lo_u32 v16, v19, v22
-; TONGA-NEXT:    v_mul_lo_u32 v17, v20, v21
-; TONGA-NEXT:    v_mul_hi_u32 v19, v21, v12
-; TONGA-NEXT:    v_mad_u64_u32 v[14:15], s[0:1], v22, v12, 0
-; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v16, v13
-; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v17, v13
-; TONGA-NEXT:    v_mad_u64_u32 v[16:17], s[0:1], v21, v13, 0
-; TONGA-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v22, v13, 0
-; TONGA-NEXT:    v_add_u32_e32 v16, vcc, v19, v16
-; TONGA-NEXT:    v_addc_u32_e32 v17, vcc, 0, v17, vcc
-; TONGA-NEXT:    v_add_u32_e32 v14, vcc, v16, v14
-; TONGA-NEXT:    v_addc_u32_e32 v14, vcc, v17, v15, vcc
+; TONGA-NEXT:    v_add_u32_e32 v22, vcc, v13, v15
+; TONGA-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v18, v22, 0
+; TONGA-NEXT:    v_mul_hi_u32 v23, v18, v12
+; TONGA-NEXT:    v_mad_u64_u32 v[15:16], s[0:1], v17, v12, 0
+; TONGA-NEXT:    v_add_u32_e32 v23, vcc, v23, v13
+; TONGA-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v17, v22, 0
+; TONGA-NEXT:    v_addc_u32_e32 v14, vcc, 0, v14, vcc
+; TONGA-NEXT:    v_add_u32_e32 v15, vcc, v23, v15
+; TONGA-NEXT:    v_addc_u32_e32 v14, vcc, v14, v16, vcc
 ; TONGA-NEXT:    v_addc_u32_e32 v13, vcc, 0, v13, vcc
 ; TONGA-NEXT:    v_add_u32_e32 v12, vcc, v14, v12
 ; TONGA-NEXT:    v_addc_u32_e32 v13, vcc, 0, v13, vcc
-; TONGA-NEXT:    v_add_u32_e32 v14, vcc, v21, v12
-; TONGA-NEXT:    v_addc_u32_e32 v15, vcc, v22, v13, vcc
-; TONGA-NEXT:    v_ashrrev_i32_e32 v16, 31, v5
-; TONGA-NEXT:    v_add_u32_e32 v12, vcc, v4, v16
-; TONGA-NEXT:    v_xor_b32_e32 v17, v12, v16
-; TONGA-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v17, v15, 0
-; TONGA-NEXT:    v_mul_hi_u32 v19, v17, v14
-; TONGA-NEXT:    v_addc_u32_e32 v5, vcc, v5, v16, vcc
-; TONGA-NEXT:    v_xor_b32_e32 v5, v5, v16
-; TONGA-NEXT:    v_add_u32_e32 v19, vcc, v19, v12
-; TONGA-NEXT:    v_addc_u32_e32 v20, vcc, 0, v13, vcc
-; TONGA-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v5, v14, 0
-; TONGA-NEXT:    v_mad_u64_u32 v[14:15], s[0:1], v5, v15, 0
-; TONGA-NEXT:    v_add_u32_e32 v12, vcc, v19, v12
-; TONGA-NEXT:    v_addc_u32_e32 v12, vcc, v20, v13, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v13, vcc, 0, v15, vcc
-; TONGA-NEXT:    v_add_u32_e32 v14, vcc, v12, v14
+; TONGA-NEXT:    v_add_u32_e32 v22, vcc, v18, v12
+; TONGA-NEXT:    v_addc_u32_e32 v23, vcc, v17, v13, vcc
+; TONGA-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v20, v22, 0
+; TONGA-NEXT:    v_mul_lo_u32 v14, v20, v23
+; TONGA-NEXT:    v_mul_lo_u32 v15, v21, v22
+; TONGA-NEXT:    v_mul_hi_u32 v20, v22, v12
+; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v14, v13
+; TONGA-NEXT:    v_add_u32_e32 v17, vcc, v15, v13
+; TONGA-NEXT:    v_mad_u64_u32 v[13:14], s[0:1], v22, v17, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[15:16], s[0:1], v23, v12, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[17:18], s[0:1], v23, v17, 0
+; TONGA-NEXT:    v_add_u32_e32 v12, vcc, v20, v13
+; TONGA-NEXT:    v_addc_u32_e32 v13, vcc, 0, v14, vcc
+; TONGA-NEXT:    v_add_u32_e32 v12, vcc, v12, v15
+; TONGA-NEXT:    v_addc_u32_e32 v12, vcc, v13, v16, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v13, vcc, 0, v18, vcc
+; TONGA-NEXT:    v_add_u32_e32 v12, vcc, v12, v17
+; TONGA-NEXT:    v_addc_u32_e32 v13, vcc, 0, v13, vcc
+; TONGA-NEXT:    v_add_u32_e32 v14, vcc, v22, v12
+; TONGA-NEXT:    v_addc_u32_e32 v16, vcc, v23, v13, vcc
+; TONGA-NEXT:    v_ashrrev_i32_e32 v17, 31, v5
+; TONGA-NEXT:    v_add_u32_e32 v12, vcc, v4, v17
+; TONGA-NEXT:    v_xor_b32_e32 v18, v12, v17
+; TONGA-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v18, v16, 0
+; TONGA-NEXT:    v_mul_hi_u32 v20, v18, v14
+; TONGA-NEXT:    v_addc_u32_e32 v5, vcc, v5, v17, vcc
+; TONGA-NEXT:    v_xor_b32_e32 v5, v5, v17
+; TONGA-NEXT:    v_mad_u64_u32 v[14:15], s[0:1], v5, v14, 0
+; TONGA-NEXT:    v_add_u32_e32 v20, vcc, v20, v12
+; TONGA-NEXT:    v_addc_u32_e32 v21, vcc, 0, v13, vcc
+; TONGA-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v5, v16, 0
+; TONGA-NEXT:    v_add_u32_e32 v14, vcc, v20, v14
+; TONGA-NEXT:    v_addc_u32_e32 v14, vcc, v21, v15, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v13, vcc, 0, v13, vcc
+; TONGA-NEXT:    v_add_u32_e32 v14, vcc, v14, v12
 ; TONGA-NEXT:    v_addc_u32_e32 v12, vcc, 0, v13, vcc
-; TONGA-NEXT:    v_mul_lo_u32 v15, v18, v12
-; TONGA-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v18, v14, 0
+; TONGA-NEXT:    v_mul_lo_u32 v15, v19, v12
+; TONGA-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v19, v14, 0
 ; TONGA-NEXT:    v_mul_lo_u32 v14, v1, v14
 ; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v15, v13
 ; TONGA-NEXT:    v_add_u32_e32 v13, vcc, v14, v13
 ; TONGA-NEXT:    v_sub_u32_e32 v14, vcc, v5, v13
-; TONGA-NEXT:    v_sub_u32_e32 v12, vcc, v17, v12
+; TONGA-NEXT:    v_sub_u32_e32 v12, vcc, v18, v12
 ; TONGA-NEXT:    v_subb_u32_e64 v14, s[0:1], v14, v1, vcc
-; TONGA-NEXT:    v_sub_u32_e64 v15, s[0:1], v12, v18
-; TONGA-NEXT:    v_subbrev_u32_e64 v17, s[2:3], 0, v14, s[0:1]
-; TONGA-NEXT:    v_cmp_ge_u32_e64 s[2:3], v17, v1
-; TONGA-NEXT:    v_cndmask_b32_e64 v19, 0, -1, s[2:3]
-; TONGA-NEXT:    v_cmp_ge_u32_e64 s[2:3], v15, v18
+; TONGA-NEXT:    v_sub_u32_e64 v15, s[0:1], v12, v19
+; TONGA-NEXT:    v_subbrev_u32_e64 v16, s[2:3], 0, v14, s[0:1]
+; TONGA-NEXT:    v_cmp_ge_u32_e64 s[2:3], v16, v1
+; TONGA-NEXT:    v_cndmask_b32_e64 v18, 0, -1, s[2:3]
+; TONGA-NEXT:    v_cmp_ge_u32_e64 s[2:3], v15, v19
 ; TONGA-NEXT:    v_cndmask_b32_e64 v20, 0, -1, s[2:3]
-; TONGA-NEXT:    v_cmp_eq_u32_e64 s[2:3], v17, v1
+; TONGA-NEXT:    v_cmp_eq_u32_e64 s[2:3], v16, v1
 ; TONGA-NEXT:    v_subb_u32_e64 v14, s[0:1], v14, v1, s[0:1]
-; TONGA-NEXT:    v_cndmask_b32_e64 v19, v19, v20, s[2:3]
-; TONGA-NEXT:    v_sub_u32_e64 v20, s[0:1], v15, v18
+; TONGA-NEXT:    v_cndmask_b32_e64 v18, v18, v20, s[2:3]
+; TONGA-NEXT:    v_sub_u32_e64 v20, s[0:1], v15, v19
 ; TONGA-NEXT:    v_subb_u32_e32 v5, vcc, v5, v13, vcc
 ; TONGA-NEXT:    v_subbrev_u32_e64 v14, s[0:1], 0, v14, s[0:1]
 ; TONGA-NEXT:    v_cmp_ge_u32_e32 vcc, v5, v1
-; TONGA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v19
+; TONGA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v18
 ; TONGA-NEXT:    v_cndmask_b32_e64 v13, 0, -1, vcc
-; TONGA-NEXT:    v_cmp_ge_u32_e32 vcc, v12, v18
-; TONGA-NEXT:    v_cndmask_b32_e64 v14, v17, v14, s[0:1]
-; TONGA-NEXT:    v_cndmask_b32_e64 v17, 0, -1, vcc
+; TONGA-NEXT:    v_cmp_ge_u32_e32 vcc, v12, v19
+; TONGA-NEXT:    v_cndmask_b32_e64 v14, v16, v14, s[0:1]
+; TONGA-NEXT:    v_cndmask_b32_e64 v16, 0, -1, vcc
 ; TONGA-NEXT:    v_cmp_eq_u32_e32 vcc, v5, v1
-; TONGA-NEXT:    v_cndmask_b32_e32 v1, v13, v17, vcc
+; TONGA-NEXT:    v_cndmask_b32_e32 v1, v13, v16, vcc
 ; TONGA-NEXT:    v_cndmask_b32_e64 v15, v15, v20, s[0:1]
 ; TONGA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
 ; TONGA-NEXT:    v_cndmask_b32_e32 v1, v5, v14, vcc
 ; TONGA-NEXT:    v_cndmask_b32_e32 v5, v12, v15, vcc
-; TONGA-NEXT:    v_xor_b32_e32 v5, v5, v16
-; TONGA-NEXT:    v_xor_b32_e32 v1, v1, v16
-; TONGA-NEXT:    v_sub_u32_e32 v12, vcc, v5, v16
-; TONGA-NEXT:    v_subb_u32_e32 v13, vcc, v1, v16, vcc
+; TONGA-NEXT:    v_xor_b32_e32 v5, v5, v17
+; TONGA-NEXT:    v_xor_b32_e32 v1, v1, v17
+; TONGA-NEXT:    v_sub_u32_e32 v12, vcc, v5, v17
+; TONGA-NEXT:    v_subb_u32_e32 v13, vcc, v1, v17, vcc
 ; TONGA-NEXT:    s_cbranch_execnz .LBB12_11
 ; TONGA-NEXT:  .LBB12_10:
 ; TONGA-NEXT:    v_cvt_f32_u32_e32 v1, v0
@@ -6536,7 +6536,7 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_subrev_u32_e32 v4, vcc, v0, v1
 ; TONGA-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v0
 ; TONGA-NEXT:    v_cndmask_b32_e32 v12, v1, v4, vcc
-; TONGA-NEXT:  .LBB12_11:
+; TONGA-NEXT:  .LBB12_11: ; %.split.split.split
 ; TONGA-NEXT:    v_or_b32_e32 v0, v7, v3
 ; TONGA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
 ; TONGA-NEXT:    s_cbranch_vccz .LBB12_17
@@ -6564,9 +6564,9 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v1, v3
 ; TONGA-NEXT:    v_add_u32_e32 v19, vcc, v1, v4
 ; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], v15, v19, 0
-; TONGA-NEXT:    v_mul_hi_u32 v1, v15, v0
-; TONGA-NEXT:    v_add_u32_e32 v20, vcc, v1, v3
+; TONGA-NEXT:    v_mul_hi_u32 v20, v15, v0
 ; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v14, v0, 0
+; TONGA-NEXT:    v_add_u32_e32 v20, vcc, v20, v3
 ; TONGA-NEXT:    v_addc_u32_e32 v21, vcc, 0, v4, vcc
 ; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], v14, v19, 0
 ; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v20, v0
@@ -6577,69 +6577,69 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_add_u32_e32 v19, vcc, v15, v0
 ; TONGA-NEXT:    v_addc_u32_e32 v20, vcc, v14, v1, vcc
 ; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v17, v19, 0
-; TONGA-NEXT:    v_mul_lo_u32 v14, v17, v20
-; TONGA-NEXT:    v_mul_lo_u32 v15, v18, v19
+; TONGA-NEXT:    v_mul_lo_u32 v3, v17, v20
+; TONGA-NEXT:    v_mul_lo_u32 v4, v18, v19
 ; TONGA-NEXT:    v_mul_hi_u32 v17, v19, v0
-; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], v20, v0, 0
-; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v14, v1
-; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v15, v1
-; TONGA-NEXT:    v_mad_u64_u32 v[14:15], s[0:1], v19, v1, 0
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v20, v1, 0
-; TONGA-NEXT:    v_add_u32_e32 v14, vcc, v17, v14
-; TONGA-NEXT:    v_addc_u32_e32 v15, vcc, 0, v15, vcc
-; TONGA-NEXT:    v_add_u32_e32 v3, vcc, v14, v3
-; TONGA-NEXT:    v_addc_u32_e32 v3, vcc, v15, v4, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
+; TONGA-NEXT:    v_add_u32_e32 v14, vcc, v4, v1
+; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], v19, v14, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v20, v0, 0
+; TONGA-NEXT:    v_mad_u64_u32 v[14:15], s[0:1], v20, v14, 0
+; TONGA-NEXT:    v_add_u32_e32 v3, vcc, v17, v3
+; TONGA-NEXT:    v_addc_u32_e32 v4, vcc, 0, v4, vcc
 ; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v3, v0
+; TONGA-NEXT:    v_addc_u32_e32 v0, vcc, v4, v1, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v15, vcc
+; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v0, v14
 ; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
 ; TONGA-NEXT:    v_add_u32_e32 v3, vcc, v19, v0
-; TONGA-NEXT:    v_addc_u32_e32 v4, vcc, v20, v1, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v14, vcc, v20, v1, vcc
 ; TONGA-NEXT:    v_ashrrev_i32_e32 v15, 31, v7
 ; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v6, v15
-; TONGA-NEXT:    v_xor_b32_e32 v14, v0, v15
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v14, v4, 0
-; TONGA-NEXT:    v_mul_hi_u32 v17, v14, v3
-; TONGA-NEXT:    v_addc_u32_e32 v7, vcc, v7, v15, vcc
-; TONGA-NEXT:    v_xor_b32_e32 v7, v7, v15
+; TONGA-NEXT:    v_addc_u32_e32 v4, vcc, v7, v15, vcc
+; TONGA-NEXT:    v_xor_b32_e32 v7, v0, v15
+; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v7, v14, 0
+; TONGA-NEXT:    v_mul_hi_u32 v17, v7, v3
+; TONGA-NEXT:    v_xor_b32_e32 v18, v4, v15
+; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], v18, v3, 0
 ; TONGA-NEXT:    v_add_u32_e32 v17, vcc, v17, v0
-; TONGA-NEXT:    v_addc_u32_e32 v18, vcc, 0, v1, vcc
-; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v7, v3, 0
-; TONGA-NEXT:    v_mad_u64_u32 v[3:4], s[0:1], v7, v4, 0
-; TONGA-NEXT:    v_add_u32_e32 v0, vcc, v17, v0
-; TONGA-NEXT:    v_addc_u32_e32 v0, vcc, v18, v1, vcc
-; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v4, vcc
-; TONGA-NEXT:    v_add_u32_e32 v3, vcc, v0, v3
+; TONGA-NEXT:    v_addc_u32_e32 v19, vcc, 0, v1, vcc
+; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v18, v14, 0
+; TONGA-NEXT:    v_add_u32_e32 v3, vcc, v17, v3
+; TONGA-NEXT:    v_addc_u32_e32 v3, vcc, v19, v4, vcc
+; TONGA-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; TONGA-NEXT:    v_add_u32_e32 v3, vcc, v3, v0
 ; TONGA-NEXT:    v_addc_u32_e32 v0, vcc, 0, v1, vcc
 ; TONGA-NEXT:    v_mul_lo_u32 v4, v5, v0
 ; TONGA-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v5, v3, 0
 ; TONGA-NEXT:    v_mul_lo_u32 v3, v16, v3
 ; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v4, v1
 ; TONGA-NEXT:    v_add_u32_e32 v1, vcc, v3, v1
-; TONGA-NEXT:    v_sub_u32_e32 v3, vcc, v7, v1
-; TONGA-NEXT:    v_sub_u32_e32 v0, vcc, v14, v0
+; TONGA-NEXT:    v_sub_u32_e32 v3, vcc, v18, v1
+; TONGA-NEXT:    v_sub_u32_e32 v0, vcc, v7, v0
 ; TONGA-NEXT:    v_subb_u32_e64 v3, s[0:1], v3, v16, vcc
 ; TONGA-NEXT:    v_sub_u32_e64 v4, s[0:1], v0, v5
-; TONGA-NEXT:    v_subbrev_u32_e64 v14, s[2:3], 0, v3, s[0:1]
-; TONGA-NEXT:    v_cmp_ge_u32_e64 s[2:3], v14, v16
-; TONGA-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s[2:3]
+; TONGA-NEXT:    v_subbrev_u32_e64 v7, s[2:3], 0, v3, s[0:1]
+; TONGA-NEXT:    v_cmp_ge_u32_e64 s[2:3], v7, v16
+; TONGA-NEXT:    v_cndmask_b32_e64 v14, 0, -1, s[2:3]
 ; TONGA-NEXT:    v_cmp_ge_u32_e64 s[2:3], v4, v5
-; TONGA-NEXT:    v_subb_u32_e32 v1, vcc, v7, v1, vcc
-; TONGA-NEXT:    v_cndmask_b32_e64 v18, 0, -1, s[2:3]
-; TONGA-NEXT:    v_cmp_eq_u32_e64 s[2:3], v14, v16
+; TONGA-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s[2:3]
+; TONGA-NEXT:    v_cmp_eq_u32_e64 s[2:3], v7, v16
 ; TONGA-NEXT:    v_subb_u32_e64 v3, s[0:1], v3, v16, s[0:1]
+; TONGA-NEXT:    v_cndmask_b32_e64 v14, v14, v17, s[2:3]
+; TONGA-NEXT:    v_sub_u32_e64 v17, s[0:1], v4, v5
+; TONGA-NEXT:    v_subbrev_u32_e64 v3, s[0:1], 0, v3, s[0:1]
+; TONGA-NEXT:    v_subb_u32_e32 v1, vcc, v18, v1, vcc
+; TONGA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v14
 ; TONGA-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v16
-; TONGA-NEXT:    v_cndmask_b32_e64 v17, v17, v18, s[2:3]
-; TONGA-NEXT:    v_sub_u32_e64 v18, s[0:1], v4, v5
+; TONGA-NEXT:    v_cndmask_b32_e64 v3, v7, v3, s[0:1]
 ; TONGA-NEXT:    v_cndmask_b32_e64 v7, 0, -1, vcc
 ; TONGA-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v5
-; TONGA-NEXT:    v_subbrev_u32_e64 v3, s[0:1], 0, v3, s[0:1]
 ; TONGA-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc
 ; TONGA-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v16
-; TONGA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v17
 ; TONGA-NEXT:    v_cndmask_b32_e32 v5, v7, v5, vcc
-; TONGA-NEXT:    v_cndmask_b32_e64 v4, v4, v18, s[0:1]
+; TONGA-NEXT:    v_cndmask_b32_e64 v4, v4, v17, s[0:1]
 ; TONGA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
-; TONGA-NEXT:    v_cndmask_b32_e64 v3, v14, v3, s[0:1]
 ; TONGA-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
 ; TONGA-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; TONGA-NEXT:    v_xor_b32_e32 v0, v0, v15
@@ -6666,7 +6666,7 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; TONGA-NEXT:    v_subrev_u32_e32 v1, vcc, v2, v0
 ; TONGA-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v2
 ; TONGA-NEXT:    v_cndmask_b32_e32 v14, v0, v1, vcc
-; TONGA-NEXT:  .LBB12_14:
+; TONGA-NEXT:  .LBB12_14: ; %.split.split.split.split
 ; TONGA-NEXT:    v_mov_b32_e32 v0, s4
 ; TONGA-NEXT:    v_mov_b32_e32 v1, s5
 ; TONGA-NEXT:    s_add_u32 s0, s4, 16

--- a/llvm/test/CodeGen/AMDGPU/vector-reduce-mul.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector-reduce-mul.ll
@@ -2771,10 +2771,10 @@ define i64 @test_vector_reduce_mul_v4i64(<4 x i64> %v) {
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v2, v1, v4
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v1, v3, v6
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v0, vcc, v10, v0
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v2, vcc, v5, v2
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v0, vcc, v0, v1
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v3, v8, v0
 ; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v9, 0
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v2, vcc, v5, v2
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v2, v2, v9
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v1, v3
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v1, v2
@@ -2806,10 +2806,10 @@ define i64 @test_vector_reduce_mul_v4i64(<4 x i64> %v) {
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v2, v1, v4
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v1, v3, v6
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v0, vcc, v10, v0
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v2, vcc, v5, v2
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v0, vcc, v0, v1
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v3, v8, v0
 ; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v9, 0
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v2, vcc, v5, v2
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v2, v2, v9
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v1, v3
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
@@ -2997,8 +2997,8 @@ define i64 @test_vector_reduce_mul_v8i64(<8 x i64> %v) {
 ; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v2, v10, 0
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v10, v3, v10
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v15, v6, v15
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v11, vcc, v17, v11
 ; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v6, v14, 0
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v11, vcc, v17, v11
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v10, vcc, v11, v10
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v11, v7, v14
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v3, vcc, v3, v15
@@ -3009,22 +3009,22 @@ define i64 @test_vector_reduce_mul_v8i64(<8 x i64> %v) {
 ; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v4, v12, 0
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v8, v1, v8
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v1, v5, v12
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v0, vcc, v4, v0
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v7, vcc, v7, v9
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v0, vcc, v4, v0
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v0, vcc, v0, v1
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v4, v6, v0
 ; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v3, 0
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v6, vcc, v7, v8
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v3, v6, v3
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v7, vcc, v1, v4
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v1, v16, v11
 ; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v16, v2, 0
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v2, v10, v2
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v3, v6, v3
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v3, vcc, v7, v3
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v5, v1
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v1, v2
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v2, v0, v1
 ; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, v4, 0
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v3, vcc, v7, v3
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v3, v3, v4
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v1, v2
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v1, v3
@@ -3049,8 +3049,8 @@ define i64 @test_vector_reduce_mul_v8i64(<8 x i64> %v) {
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[19:20], s[4:5], v5, v23, v[7:8]
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[23:24], s[4:5], v3, v10, v[13:14]
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v1, v8, v[17:18]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v23, v4, v[19:20]
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v12, v6, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v23, v4, v[19:20]
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v2, v16, v[21:22]
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v12, v7, v[1:2]
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v3, v6, v[4:5]
@@ -3063,8 +3063,8 @@ define i64 @test_vector_reduce_mul_v8i64(<8 x i64> %v) {
 ; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v2, v10, 0
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v10, v3, v10
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v15, v6, v15
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v11, vcc, v17, v11
 ; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v6, v14, 0
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v11, vcc, v17, v11
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v10, vcc, v11, v10
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v11, v7, v14
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v3, vcc, v3, v15
@@ -3075,22 +3075,22 @@ define i64 @test_vector_reduce_mul_v8i64(<8 x i64> %v) {
 ; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v4, v12, 0
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v8, v1, v8
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v1, v5, v12
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v0, vcc, v4, v0
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v7, vcc, v7, v9
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v0, vcc, v4, v0
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v0, vcc, v0, v1
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v4, v6, v0
 ; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v3, 0
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v6, vcc, v7, v8
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v3, v6, v3
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v7, vcc, v1, v4
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v1, v16, v11
 ; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v16, v2, 0
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v2, v10, v2
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v3, v6, v3
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v3, vcc, v7, v3
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v5, v1
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v2, v0, v1
 ; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, v4, 0
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v3, vcc, v7, v3
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v3, v3, v4
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v1, v3
@@ -3115,8 +3115,8 @@ define i64 @test_vector_reduce_mul_v8i64(<8 x i64> %v) {
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[19:20], s[4:5], v5, v23, v[7:8]
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[23:24], s[4:5], v3, v10, v[13:14]
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v1, v8, v[17:18]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v23, v4, v[19:20]
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v12, v6, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v23, v4, v[19:20]
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v2, v16, v[21:22]
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v12, v7, v[1:2]
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v3, v6, v[4:5]
@@ -3195,127 +3195,129 @@ define i64 @test_vector_reduce_mul_v8i64(<8 x i64> %v) {
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v13, v4, v13
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v17, v1, v8
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v9, v0, v9
-; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s4, v0, v8, 0
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v18, v7, v14
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v15, v6, v15
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v19, v3, v10
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v11, v2, v11
-; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s4, v2, v10, 0
+; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[1:2], s4, v2, v10, 0
 ; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[5:6], s4, v6, v14, 0
-; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[7:8], s4, v4, v12, 0
-; GFX10-SDAG-NEXT:    v_add3_u32 v1, v1, v9, v17
-; GFX10-SDAG-NEXT:    v_add3_u32 v3, v3, v11, v19
-; GFX10-SDAG-NEXT:    v_add3_u32 v4, v6, v15, v18
-; GFX10-SDAG-NEXT:    v_add3_u32 v6, v8, v13, v16
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v8, v3, v5
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v9, v1, v7
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v4, v2, v4
-; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s4, v2, v5, 0
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v6, v0, v6
-; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s4, v0, v7, 0
-; GFX10-SDAG-NEXT:    v_add3_u32 v3, v3, v4, v8
-; GFX10-SDAG-NEXT:    v_add3_u32 v1, v1, v6, v9
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v3, v0, v3
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v4, v1, v2
-; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s4, v0, v2, 0
-; GFX10-SDAG-NEXT:    v_add3_u32 v1, v1, v3, v4
+; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[7:8], s4, v0, v8, 0
+; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s4, v4, v12, 0
+; GFX10-SDAG-NEXT:    v_add3_u32 v0, v2, v11, v19
+; GFX10-SDAG-NEXT:    v_add3_u32 v2, v6, v15, v18
+; GFX10-SDAG-NEXT:    v_add3_u32 v6, v8, v9, v17
+; GFX10-SDAG-NEXT:    v_add3_u32 v4, v4, v13, v16
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v8, v0, v5
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v9, v1, v2
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v6, v6, v3
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v4, v7, v4
+; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s4, v7, v3, 0
+; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s4, v1, v5, 0
+; GFX10-SDAG-NEXT:    v_add3_u32 v3, v3, v4, v6
+; GFX10-SDAG-NEXT:    v_add3_u32 v1, v1, v9, v8
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v3, v3, v0
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v4, v2, v1
+; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s4, v2, v0, 0
+; GFX10-SDAG-NEXT:    v_add3_u32 v1, v1, v4, v3
 ; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-GISEL-LABEL: test_vector_reduce_mul_v8i64:
 ; GFX10-GISEL:       ; %bb.0: ; %entry
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s4, v6, v14, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s4, v0, v8, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[20:21], s4, v2, v10, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[22:23], s4, v4, v12, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[24:25], s4, v6, v15, v[17:18]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[25:26], s4, v0, v9, v[19:20]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[26:27], s4, v2, v11, v[21:22]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[27:28], s4, v4, v13, v[23:24]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[13:14], s4, v7, v14, v[24:25]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s4, v20, v16, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s4, v3, v10, v[26:27]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s4, v5, v12, v[27:28]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s4, v18, v22, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s4, v20, v13, v[7:8]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s4, v1, v8, v[25:26]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s4, v18, v4, v[3:4]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s4, v9, v16, v[10:11]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s4, v2, v6, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s4, v7, v22, v[3:4]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s4, v2, v4, v[1:2]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s4, v7, v6, v[1:2]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s4, v2, v10, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[20:21], s4, v4, v12, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[22:23], s4, v0, v8, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[26:27], s4, v6, v15, v[17:18]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[27:28], s4, v2, v11, v[19:20]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[24:25], s4, v18, v16, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[28:29], s4, v4, v13, v[21:22]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[13:14], s4, v7, v14, v[26:27]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[14:15], s4, v0, v9, v[23:24]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s4, v3, v10, v[27:28]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s4, v5, v12, v[28:29]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s4, v22, v20, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s4, v18, v13, v[25:26]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s4, v1, v8, v[14:15]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s4, v6, v24, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s4, v22, v3, v[7:8]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s4, v2, v16, v[4:5]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s4, v8, v20, v[9:10]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s4, v6, v2, v[1:2]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s4, v3, v24, v[1:2]
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-SDAG-LABEL: test_vector_reduce_mul_v8i64:
 ; GFX11-SDAG:       ; %bb.0: ; %entry
 ; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v18, v5, v12
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v17, v5, v12
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v13, v4, v13
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v19, v1, v8
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v18, v1, v8
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v9, v0, v9
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[16:17], null, v0, v8, 0
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v7, v7, v14
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v8, v6, v15
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v15, v3, v10
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v19, v7, v14
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v20, v6, v15
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v3, v3, v10
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v11, v2, v11
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[0:1], null, v2, v10, 0
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[2:3], null, v6, v14, 0
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[5:6], null, v4, v12, 0
-; GFX11-SDAG-NEXT:    v_add3_u32 v4, v17, v9, v19
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[15:16], null, v2, v10, 0
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[1:2], null, v6, v14, 0
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[5:6], null, v0, v8, 0
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[7:8], null, v4, v12, 0
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-SDAG-NEXT:    v_add3_u32 v1, v1, v11, v15
-; GFX11-SDAG-NEXT:    v_add3_u32 v3, v3, v8, v7
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-SDAG-NEXT:    v_add3_u32 v6, v6, v13, v18
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v1, v1, v2
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v8, v4, v5
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_3) | instid1(VALU_DEP_2)
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v7, v0, v3
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[3:4], null, v16, v5, 0
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v9, v16, v6
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[5:6], null, v0, v2, 0
-; GFX11-SDAG-NEXT:    v_add3_u32 v0, v4, v9, v8
+; GFX11-SDAG-NEXT:    v_add3_u32 v0, v16, v11, v3
+; GFX11-SDAG-NEXT:    v_add3_u32 v2, v2, v20, v19
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-SDAG-NEXT:    v_add3_u32 v3, v6, v9, v18
+; GFX11-SDAG-NEXT:    v_add3_u32 v4, v8, v13, v17
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v0, v0, v1
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v6, v15, v2
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v8, v3, v7
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v9, v5, v4
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[2:3], null, v5, v7, 0
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[4:5], null, v15, v1, 0
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-SDAG-NEXT:    v_add3_u32 v1, v6, v7, v1
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v2, v0, v5
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v4, v3, v1
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[0:1], null, v3, v5, 0
-; GFX11-SDAG-NEXT:    v_add3_u32 v1, v1, v4, v2
+; GFX11-SDAG-NEXT:    v_add3_u32 v1, v3, v9, v8
+; GFX11-SDAG-NEXT:    v_add3_u32 v0, v5, v6, v0
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v3, v1, v4
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v5, v2, v0
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[0:1], null, v2, v4, 0
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-SDAG-NEXT:    v_add3_u32 v1, v1, v5, v3
 ; GFX11-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-LABEL: test_vector_reduce_mul_v8i64:
 ; GFX11-GISEL:       ; %bb.0: ; %entry
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[16:17], null, v6, v14, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[18:19], null, v0, v8, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[20:21], null, v2, v10, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[22:23], null, v4, v12, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[18:19], null, v2, v10, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[20:21], null, v4, v12, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[22:23], null, v0, v8, 0
 ; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[24:25], null, v6, v15, v[17:18]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[25:26], null, v0, v9, v[19:20]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[26:27], null, v6, v15, v[17:18]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[27:28], null, v2, v11, v[19:20]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[24:25], null, v18, v16, 0
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[28:29], null, v4, v13, v[21:22]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[29:30], null, v7, v14, v[26:27]
 ; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[26:27], null, v2, v11, v[21:22]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[27:28], null, v4, v13, v[23:24]
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[28:29], null, v7, v14, v[24:25]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[6:7], null, v20, v16, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[13:14], null, v3, v10, v[26:27]
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v5, v12, v[27:28]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v18, v22, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[4:5], null, v20, v28, v[7:8]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[10:11], null, v1, v8, v[25:26]
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v2, v6, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[7:8], null, v18, v9, v[3:4]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[13:14], null, v0, v9, v[23:24]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[14:15], null, v3, v10, v[27:28]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[6:7], null, v22, v20, 0
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v5, v12, v[28:29]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[3:4], null, v18, v29, v[25:26]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[4:5], null, v1, v8, v[13:14]
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v6, v24, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v22, v2, v[7:8]
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v14, v16, v[3:4]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[10:11], null, v4, v20, v[8:9]
 ; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v13, v16, v[4:5]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[3:4], null, v10, v22, v[7:8]
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[4:5], null, v2, v8, v[1:2]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[1:2], null, v3, v6, v[4:5]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[3:4], null, v6, v9, v[1:2]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[1:2], null, v10, v24, v[3:4]
 ; GFX11-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-LABEL: test_vector_reduce_mul_v8i64:
@@ -3329,35 +3331,37 @@ define i64 @test_vector_reduce_mul_v8i64(<8 x i64> %v) {
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v13, v4, v13
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v17, v1, v8
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v9, v0, v9
-; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[0:1], null, v0, v8, 0
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v18, v7, v14
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v15, v6, v15
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v19, v3, v10
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v11, v2, v11
-; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[2:3], null, v2, v10, 0
+; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[1:2], null, v2, v10, 0
 ; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[5:6], null, v6, v14, 0
-; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[7:8], null, v4, v12, 0
-; GFX12-SDAG-NEXT:    v_add3_u32 v1, v1, v9, v17
+; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[7:8], null, v0, v8, 0
+; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[3:4], null, v4, v12, 0
 ; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX12-SDAG-NEXT:    v_add3_u32 v3, v3, v11, v19
-; GFX12-SDAG-NEXT:    v_add3_u32 v4, v6, v15, v18
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX12-SDAG-NEXT:    v_add3_u32 v6, v8, v13, v16
-; GFX12-SDAG-NEXT:    v_mul_lo_u32 v8, v3, v5
-; GFX12-SDAG-NEXT:    v_mul_lo_u32 v9, v1, v7
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_3) | instid1(VALU_DEP_3)
-; GFX12-SDAG-NEXT:    v_mul_lo_u32 v4, v2, v4
-; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[2:3], null, v2, v5, 0
-; GFX12-SDAG-NEXT:    v_mul_lo_u32 v6, v0, v6
-; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[0:1], null, v0, v7, 0
-; GFX12-SDAG-NEXT:    v_add3_u32 v3, v3, v4, v8
+; GFX12-SDAG-NEXT:    v_add3_u32 v0, v2, v11, v19
+; GFX12-SDAG-NEXT:    v_add3_u32 v2, v6, v15, v18
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX12-SDAG-NEXT:    v_add3_u32 v6, v8, v9, v17
+; GFX12-SDAG-NEXT:    v_add3_u32 v4, v4, v13, v16
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX12-SDAG-NEXT:    v_mul_lo_u32 v8, v0, v5
+; GFX12-SDAG-NEXT:    v_mul_lo_u32 v9, v1, v2
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX12-SDAG-NEXT:    v_mul_lo_u32 v6, v6, v3
+; GFX12-SDAG-NEXT:    v_mul_lo_u32 v4, v7, v4
+; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[2:3], null, v7, v3, 0
+; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[0:1], null, v1, v5, 0
 ; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX12-SDAG-NEXT:    v_add3_u32 v1, v1, v6, v9
-; GFX12-SDAG-NEXT:    v_mul_lo_u32 v3, v0, v3
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX12-SDAG-NEXT:    v_mul_lo_u32 v4, v1, v2
-; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[0:1], null, v0, v2, 0
-; GFX12-SDAG-NEXT:    v_add3_u32 v1, v1, v3, v4
+; GFX12-SDAG-NEXT:    v_add3_u32 v3, v3, v4, v6
+; GFX12-SDAG-NEXT:    v_add3_u32 v1, v1, v9, v8
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX12-SDAG-NEXT:    v_mul_lo_u32 v3, v3, v0
+; GFX12-SDAG-NEXT:    v_mul_lo_u32 v4, v2, v1
+; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[0:1], null, v2, v0, 0
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-SDAG-NEXT:    v_add3_u32 v1, v1, v4, v3
 ; GFX12-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GISEL-LABEL: test_vector_reduce_mul_v8i64:
@@ -3423,72 +3427,72 @@ define i64 @test_vector_reduce_mul_v16i64(<16 x i64> %v) {
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v33, v11, v26
 ; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v10, v26, 0
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v3, vcc, v3, v19
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v15, v15, v30
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v32, vcc, v3, v32
-; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v14, v30, 0
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v30, v4, v21
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v21, v4, v21
 ; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v4, v20, 0
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v5, v5, v20
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v29, v12, v29
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v34, v13, v28
-; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v12, v28, 0
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v11, vcc, v11, v27
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v11, vcc, v11, v33
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v4, vcc, v4, v30
-; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[20:21], s[4:5], v2, v10, 0
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v2, v2, v11
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v11, vcc, v13, v29
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v13, vcc, v4, v5
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v23, v6, v23
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v26, v7, v22
 ; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v6, v22, 0
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v17, v0, v17
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v10, v32, v10
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v5, v5, v20
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v20, v12, v29
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v29, v13, v28
+; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v12, v28, 0
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v11, vcc, v11, v27
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v11, vcc, v11, v33
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v4, vcc, v4, v21
+; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v14, v30, 0
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v7, vcc, v7, v23
-; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[22:23], s[4:5], v6, v18, 0
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v7, vcc, v7, v26
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v2, vcc, v21, v2
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v7, v7, v18
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v11, vcc, v11, v34
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v23, vcc, v4, v5
+; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v10, 0
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v2, v2, v11
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v11, vcc, v13, v20
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v22, v15, v30
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v17, v0, v17
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v28, v1, v16
+; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, v16, 0
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v25, v8, v25
+; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[15:16], s[4:5], v8, v24, 0
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v21, vcc, v7, v26
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v1, v17
+; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v6, v18, 0
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v10, v32, v10
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v2, vcc, v5, v2
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v11, vcc, v11, v29
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v5, vcc, v2, v10
 ; GFX7-SDAG-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v4, v14, v31
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v14, v1, v16
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v4, vcc, v19, v4
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v4, vcc, v4, v15
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v6, v6, v4
-; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, v16, 0
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v15, v8, v25
-; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v24, 0
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v8, v9, v24
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v5, vcc, v5, v17
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v1, v15
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v1, v8
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v8, vcc, v2, v10
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v9, v4, v1
-; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v4, v0, 0
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v6, vcc, v23, v6
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v5, vcc, v5, v14
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v4, vcc, v6, v7
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v6, vcc, v2, v9
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v7, v3, v11
-; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v3, v12, 0
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v5, v5, v0
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v0, v13, v12
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v3, vcc, v3, v7
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v0, vcc, v3, v0
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v3, v1, v0
-; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v1, v2, 0
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v2, v5, v2
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v5, v8, v22
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v6, vcc, v1, v3
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v1, v20, v4
-; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v20, v22, 0
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v2, vcc, v6, v2
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v4, v1
-; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v1, v5
-; GFX7-SDAG-NEXT:    v_mul_lo_u32 v4, v0, v1
-; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, v3, 0
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v13, v14, v31
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v14, v21, v18
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v13, vcc, v19, v13
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v13, vcc, v13, v22
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v6, v6, v13
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v13, vcc, v1, v28
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v1, v9, v24
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v9, vcc, v16, v25
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v2, vcc, v8, v6
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v9, v1
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v6, v0, v1
+; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, v15, 0
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v8, vcc, v2, v14
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v9, v3, v11
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v6, vcc, v1, v6
+; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v3, v12, 0
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v3, v23, v12
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v10, v13, v15
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v8, v4, v8
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v2, vcc, v2, v9
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v2, vcc, v2, v3
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v9, v0, v2
+; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v0, v1, 0
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v0, vcc, v6, v10
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v6, vcc, v3, v9
+; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v4, v7, 0
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v9, v0, v1
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v0, v5, v7
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v4, v8
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v0, vcc, v1, v0
+; GFX7-SDAG-NEXT:    v_mul_lo_u32 v4, v2, v0
+; GFX7-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v2, v3, 0
+; GFX7-SDAG-NEXT:    v_add_i32_e32 v2, vcc, v6, v9
 ; GFX7-SDAG-NEXT:    v_mul_lo_u32 v2, v2, v3
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v1, v4
 ; GFX7-SDAG-NEXT:    v_add_i32_e32 v1, vcc, v1, v2
@@ -3497,53 +3501,53 @@ define i64 @test_vector_reduce_mul_v16i64(<16 x i64> %v) {
 ; GFX7-GISEL-LABEL: test_vector_reduce_mul_v16i64:
 ; GFX7-GISEL:       ; %bb.0: ; %entry
 ; GFX7-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[31:32], s[4:5], v8, v24, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[33:34], s[4:5], v8, v25, v[32:33]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[35:36], s[4:5], v9, v24, v[33:34]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v0, v16, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[32:33], s[4:5], v0, v17, v[9:10]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[24:25], s[4:5], v8, v31, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[36:37], s[4:5], v8, v35, v[25:26]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v1, v16, v[32:33]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v10, v26, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v8, v31, v[36:37]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v10, v27, v[1:2]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[31:32], s[4:5], v11, v26, v[8:9]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v2, v18, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v2, v19, v[9:10]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v8, v0, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[25:26], s[4:5], v8, v31, v[2:3]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v3, v18, v[10:11]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[31:32], s[4:5], v10, v26, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[33:34], s[4:5], v10, v27, v[32:33]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[35:36], s[4:5], v11, v26, v[33:34]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v2, v18, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[32:33], s[4:5], v2, v19, v[11:12]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[26:27], s[4:5], v10, v31, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[36:37], s[4:5], v10, v35, v[27:28]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v3, v18, v[32:33]
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v12, v28, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[17:18], s[4:5], v8, v0, v[25:26]
-; GFX7-GISEL-NEXT:    buffer_load_dword v0, off, s[0:3], s32
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v10, v31, v[36:37]
 ; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v12, v29, v[3:4]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v4, v20, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v13, v28, v[10:11]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v8, v2, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[25:26], s[4:5], v4, v21, v[9:10]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v14, v30, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[27:28], s[4:5], v8, v18, v[11:12]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[31:32], s[4:5], v13, v28, v[10:11]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v4, v20, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v4, v21, v[11:12]
+; GFX7-GISEL-NEXT:    buffer_load_dword v21, off, s[0:3], s32
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v10, v2, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[27:28], s[4:5], v10, v31, v[4:5]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v5, v20, v[12:13]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v6, v22, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[19:20], s[4:5], v10, v2, v[27:28]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v14, v30, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v6, v23, v[5:6]
 ; GFX7-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v14, v0, v[4:5]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v15, v30, v[8:9]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v6, v22, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[14:15], s[4:5], v6, v23, v[9:10]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v8, v3, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v8, v13, v[12:13]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v5, v20, v[25:26]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v7, v22, v[14:15]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v8, v2, v[27:28]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v4, v3, v[18:19]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v1, v11, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v24, v10, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v1, v7, v[4:5]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v24, v12, v[6:7]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v17, v11, v[8:9]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v3, 0
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v16, v10, v[13:14]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v5, v6, v[1:2]
-; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v7, v3, v[8:9]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v14, v21, v[11:12]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[20:21], s[4:5], v7, v22, v[12:13]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v15, v30, v[5:6]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v10, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v4, v11, v[6:7]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v8, v24, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[14:15], s[4:5], v20, v10, v[12:13]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v0, v16, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v8, v25, v[7:8]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v10, v6, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[20:21], s[4:5], v0, v17, v[11:12]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[22:23], s[4:5], v9, v24, v[12:13]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v26, v5, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[23:24], s[4:5], v1, v16, v[20:21]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v10, v22, v[8:9]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v7, v3, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[15:16], s[4:5], v26, v14, v[12:13]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v23, v6, v[0:1]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v7, v19, v[9:10]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v18, v5, v[15:16]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v11, 0
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v12, v3, v[13:14]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v8, v6, v[1:2]
+; GFX7-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v4, v11, v[9:10]
 ; GFX7-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-SDAG-LABEL: test_vector_reduce_mul_v16i64:
@@ -3557,72 +3561,72 @@ define i64 @test_vector_reduce_mul_v16i64(<16 x i64> %v) {
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v33, v11, v26
 ; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v10, v26, 0
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v3, vcc, v3, v19
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v15, v15, v30
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v32, vcc, v3, v32
-; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v14, v30, 0
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v30, v4, v21
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v21, v4, v21
 ; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v4, v20, 0
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v5, v5, v20
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v29, v12, v29
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v34, v13, v28
-; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v12, v28, 0
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v11, vcc, v11, v27
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v11, vcc, v11, v33
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v4, vcc, v4, v30
-; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[20:21], s[4:5], v2, v10, 0
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v2, v2, v11
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v11, vcc, v13, v29
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v13, vcc, v4, v5
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v23, v6, v23
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v26, v7, v22
 ; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v6, v22, 0
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v17, v0, v17
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v10, v32, v10
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v5, v5, v20
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v20, v12, v29
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v29, v13, v28
+; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v12, v28, 0
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v11, vcc, v11, v27
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v11, vcc, v11, v33
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v4, vcc, v4, v21
+; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v14, v30, 0
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v7, vcc, v7, v23
-; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[22:23], s[4:5], v6, v18, 0
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v7, vcc, v7, v26
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v2, vcc, v21, v2
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v7, v7, v18
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v11, vcc, v11, v34
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v23, vcc, v4, v5
+; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v2, v10, 0
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v2, v2, v11
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v11, vcc, v13, v20
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v22, v15, v30
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v17, v0, v17
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v28, v1, v16
+; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, v16, 0
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v25, v8, v25
+; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[15:16], s[4:5], v8, v24, 0
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v21, vcc, v7, v26
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v1, v17
+; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v6, v18, 0
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v10, v32, v10
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v2, vcc, v5, v2
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v11, vcc, v11, v29
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v5, vcc, v2, v10
 ; GFX8-SDAG-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v4, v14, v31
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v14, v1, v16
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v4, vcc, v19, v4
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v4, vcc, v4, v15
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v6, v6, v4
-; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v0, v16, 0
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v15, v8, v25
-; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v24, 0
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v8, v9, v24
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v5, vcc, v5, v17
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v1, v15
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v1, v8
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v8, vcc, v2, v10
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v9, v4, v1
-; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v4, v0, 0
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v6, vcc, v23, v6
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v5, vcc, v5, v14
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v4, vcc, v6, v7
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v6, vcc, v2, v9
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v7, v3, v11
-; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v3, v12, 0
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v5, v5, v0
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v0, v13, v12
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v3, vcc, v3, v7
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v5, vcc, v6, v5
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v0, vcc, v3, v0
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v3, v1, v0
-; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v1, v2, 0
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v2, v5, v2
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v5, v8, v22
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v6, vcc, v1, v3
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v1, v20, v4
-; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v20, v22, 0
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v2, vcc, v6, v2
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v4, v1
-; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v1, v5
-; GFX8-SDAG-NEXT:    v_mul_lo_u32 v4, v0, v1
-; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, v3, 0
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v13, v14, v31
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v14, v21, v18
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v13, vcc, v19, v13
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v13, vcc, v13, v22
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v6, v6, v13
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v13, vcc, v1, v28
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v1, v9, v24
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v9, vcc, v16, v25
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v2, vcc, v8, v6
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v9, v1
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v6, v0, v1
+; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v0, v15, 0
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v8, vcc, v2, v14
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v9, v3, v11
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v6, vcc, v1, v6
+; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v3, v12, 0
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v3, v23, v12
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v10, v13, v15
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v8, v4, v8
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v2, vcc, v2, v9
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v2, vcc, v2, v3
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v9, v0, v2
+; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v0, v1, 0
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v0, vcc, v6, v10
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v6, vcc, v3, v9
+; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v4, v7, 0
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v9, v0, v1
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v0, v5, v7
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v4, v8
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v0, vcc, v1, v0
+; GFX8-SDAG-NEXT:    v_mul_lo_u32 v4, v2, v0
+; GFX8-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v2, v3, 0
+; GFX8-SDAG-NEXT:    v_add_u32_e32 v2, vcc, v6, v9
 ; GFX8-SDAG-NEXT:    v_mul_lo_u32 v2, v2, v3
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v1, v4
 ; GFX8-SDAG-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
@@ -3631,53 +3635,53 @@ define i64 @test_vector_reduce_mul_v16i64(<16 x i64> %v) {
 ; GFX8-GISEL-LABEL: test_vector_reduce_mul_v16i64:
 ; GFX8-GISEL:       ; %bb.0: ; %entry
 ; GFX8-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[31:32], s[4:5], v8, v24, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[33:34], s[4:5], v8, v25, v[32:33]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[35:36], s[4:5], v9, v24, v[33:34]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v0, v16, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[32:33], s[4:5], v0, v17, v[9:10]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[24:25], s[4:5], v8, v31, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[36:37], s[4:5], v8, v35, v[25:26]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v1, v16, v[32:33]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v10, v26, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s[4:5], v8, v31, v[36:37]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v10, v27, v[1:2]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[31:32], s[4:5], v11, v26, v[8:9]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v2, v18, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v2, v19, v[9:10]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v8, v0, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[25:26], s[4:5], v8, v31, v[2:3]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v3, v18, v[10:11]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[31:32], s[4:5], v10, v26, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[33:34], s[4:5], v10, v27, v[32:33]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[35:36], s[4:5], v11, v26, v[33:34]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v2, v18, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[32:33], s[4:5], v2, v19, v[11:12]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[26:27], s[4:5], v10, v31, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[36:37], s[4:5], v10, v35, v[27:28]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v3, v18, v[32:33]
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v12, v28, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[17:18], s[4:5], v8, v0, v[25:26]
-; GFX8-GISEL-NEXT:    buffer_load_dword v0, off, s[0:3], s32
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v10, v31, v[36:37]
 ; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v12, v29, v[3:4]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v4, v20, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v13, v28, v[10:11]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v8, v2, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[25:26], s[4:5], v4, v21, v[9:10]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v14, v30, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[27:28], s[4:5], v8, v18, v[11:12]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[31:32], s[4:5], v13, v28, v[10:11]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v4, v20, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v4, v21, v[11:12]
+; GFX8-GISEL-NEXT:    buffer_load_dword v21, off, s[0:3], s32
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v10, v2, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[27:28], s[4:5], v10, v31, v[4:5]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v5, v20, v[12:13]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v6, v22, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[19:20], s[4:5], v10, v2, v[27:28]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v14, v30, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v6, v23, v[5:6]
 ; GFX8-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v14, v0, v[4:5]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v15, v30, v[8:9]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v6, v22, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[14:15], s[4:5], v6, v23, v[9:10]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v8, v3, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v8, v13, v[12:13]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v5, v20, v[25:26]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v7, v22, v[14:15]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v8, v2, v[27:28]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v4, v3, v[18:19]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v1, v11, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v24, v10, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v1, v7, v[4:5]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v24, v12, v[6:7]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v17, v11, v[8:9]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v5, v3, 0
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v16, v10, v[13:14]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v5, v6, v[1:2]
-; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v7, v3, v[8:9]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v14, v21, v[11:12]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[20:21], s[4:5], v7, v22, v[12:13]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v15, v30, v[5:6]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v4, v10, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v4, v11, v[6:7]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v8, v24, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[14:15], s[4:5], v20, v10, v[12:13]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[4:5], v0, v16, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v8, v25, v[7:8]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v10, v6, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[20:21], s[4:5], v0, v17, v[11:12]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[22:23], s[4:5], v9, v24, v[12:13]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s[4:5], v26, v5, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[23:24], s[4:5], v1, v16, v[20:21]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v10, v22, v[8:9]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v7, v3, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[15:16], s[4:5], v26, v14, v[12:13]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[4:5], v23, v6, v[0:1]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[13:14], s[4:5], v7, v19, v[9:10]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v18, v5, v[15:16]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v8, v11, 0
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v12, v3, v[13:14]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v8, v6, v[1:2]
+; GFX8-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v4, v11, v[9:10]
 ; GFX8-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-SDAG-LABEL: test_vector_reduce_mul_v16i64:
@@ -3701,44 +3705,44 @@ define i64 @test_vector_reduce_mul_v16i64(<16 x i64> %v) {
 ; GFX9-SDAG-NEXT:    v_mul_lo_u32 v24, v1, v16
 ; GFX9-SDAG-NEXT:    v_mul_lo_u32 v17, v0, v17
 ; GFX9-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v0, v16, 0
+; GFX9-SDAG-NEXT:    v_add3_u32 v11, v11, v27, v32
+; GFX9-SDAG-NEXT:    v_add3_u32 v3, v3, v33, v26
+; GFX9-SDAG-NEXT:    v_add3_u32 v9, v9, v25, v22
+; GFX9-SDAG-NEXT:    v_add3_u32 v1, v1, v17, v24
+; GFX9-SDAG-NEXT:    v_mad_u64_u32 v[24:25], s[0:1], v2, v10, 0
+; GFX9-SDAG-NEXT:    v_mul_lo_u32 v3, v3, v10
+; GFX9-SDAG-NEXT:    v_mul_lo_u32 v2, v2, v11
+; GFX9-SDAG-NEXT:    v_add3_u32 v2, v25, v2, v3
 ; GFX9-SDAG-NEXT:    v_mul_lo_u32 v16, v13, v28
 ; GFX9-SDAG-NEXT:    v_mul_lo_u32 v29, v12, v29
 ; GFX9-SDAG-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v12, v28, 0
 ; GFX9-SDAG-NEXT:    v_mul_lo_u32 v28, v5, v20
 ; GFX9-SDAG-NEXT:    v_mul_lo_u32 v21, v4, v21
 ; GFX9-SDAG-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], v4, v20, 0
-; GFX9-SDAG-NEXT:    v_add3_u32 v9, v9, v25, v22
-; GFX9-SDAG-NEXT:    v_add3_u32 v1, v1, v17, v24
+; GFX9-SDAG-NEXT:    v_add3_u32 v7, v7, v23, v30
 ; GFX9-SDAG-NEXT:    v_add3_u32 v13, v13, v29, v16
 ; GFX9-SDAG-NEXT:    v_add3_u32 v5, v5, v21, v28
+; GFX9-SDAG-NEXT:    v_mad_u64_u32 v[22:23], s[0:1], v6, v18, 0
+; GFX9-SDAG-NEXT:    v_mul_lo_u32 v7, v7, v18
 ; GFX9-SDAG-NEXT:    v_mad_u64_u32 v[16:17], s[0:1], v4, v12, 0
 ; GFX9-SDAG-NEXT:    v_mad_u64_u32 v[20:21], s[0:1], v0, v8, 0
 ; GFX9-SDAG-NEXT:    v_mul_lo_u32 v5, v5, v12
 ; GFX9-SDAG-NEXT:    v_mul_lo_u32 v4, v4, v13
-; GFX9-SDAG-NEXT:    v_mul_lo_u32 v1, v1, v8
-; GFX9-SDAG-NEXT:    v_mul_lo_u32 v0, v0, v9
+; GFX9-SDAG-NEXT:    v_mul_lo_u32 v8, v1, v8
+; GFX9-SDAG-NEXT:    v_mul_lo_u32 v9, v0, v9
+; GFX9-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v24, v22, 0
 ; GFX9-SDAG-NEXT:    v_add3_u32 v4, v17, v4, v5
-; GFX9-SDAG-NEXT:    v_add3_u32 v5, v21, v0, v1
-; GFX9-SDAG-NEXT:    v_add3_u32 v7, v7, v23, v30
-; GFX9-SDAG-NEXT:    v_add3_u32 v11, v11, v27, v32
-; GFX9-SDAG-NEXT:    v_add3_u32 v3, v3, v33, v26
-; GFX9-SDAG-NEXT:    v_mul_lo_u32 v7, v7, v18
+; GFX9-SDAG-NEXT:    v_add3_u32 v5, v21, v9, v8
+; GFX9-SDAG-NEXT:    v_mul_lo_u32 v2, v2, v22
 ; GFX9-SDAG-NEXT:    v_mul_lo_u32 v5, v5, v16
 ; GFX9-SDAG-NEXT:    v_mul_lo_u32 v4, v20, v4
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-SDAG-NEXT:    v_mul_lo_u32 v0, v14, v31
-; GFX9-SDAG-NEXT:    v_add3_u32 v0, v19, v0, v15
-; GFX9-SDAG-NEXT:    v_mul_lo_u32 v8, v6, v0
-; GFX9-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v6, v18, 0
-; GFX9-SDAG-NEXT:    v_add3_u32 v1, v1, v8, v7
-; GFX9-SDAG-NEXT:    v_mul_lo_u32 v6, v3, v10
-; GFX9-SDAG-NEXT:    v_mul_lo_u32 v7, v2, v11
-; GFX9-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v2, v10, 0
-; GFX9-SDAG-NEXT:    v_add3_u32 v3, v3, v7, v6
-; GFX9-SDAG-NEXT:    v_mul_lo_u32 v3, v3, v0
-; GFX9-SDAG-NEXT:    v_mul_lo_u32 v6, v2, v1
-; GFX9-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v2, v0, 0
-; GFX9-SDAG-NEXT:    v_add3_u32 v1, v1, v6, v3
+; GFX9-SDAG-NEXT:    v_mul_lo_u32 v3, v14, v31
+; GFX9-SDAG-NEXT:    v_add3_u32 v3, v19, v3, v15
+; GFX9-SDAG-NEXT:    v_mul_lo_u32 v3, v6, v3
+; GFX9-SDAG-NEXT:    v_add3_u32 v3, v23, v3, v7
+; GFX9-SDAG-NEXT:    v_mul_lo_u32 v3, v24, v3
+; GFX9-SDAG-NEXT:    v_add3_u32 v1, v1, v3, v2
 ; GFX9-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v20, v16, 0
 ; GFX9-SDAG-NEXT:    v_add3_u32 v3, v3, v4, v5
 ; GFX9-SDAG-NEXT:    v_mul_lo_u32 v3, v3, v0
@@ -3751,67 +3755,99 @@ define i64 @test_vector_reduce_mul_v16i64(<16 x i64> %v) {
 ; GFX9-GISEL:       ; %bb.0: ; %entry
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-GISEL-NEXT:    scratch_load_dword v31, off, s32
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[34:35], s[0:1], v0, v17, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[32:33], s[0:1], v0, v16, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[36:37], s[0:1], v1, v16, v[34:35]
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s[0:1], v2, v19, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[34:35], s[0:1], v3, v18, v[16:17]
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s[0:1], v4, v21, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v2, v18, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v4, v20, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[0:1], v5, v20, v[16:17]
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s[0:1], v6, v23, 0
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v20, v3, v18
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], v6, v22, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[0:1], v7, v22, v[16:17]
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s[0:1], v8, v25, 0
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v21, v5, v18
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], v8, v24, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[0:1], v9, v24, v[16:17]
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s[0:1], v10, v27, 0
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v34, v1, v34
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v1, v7, v18
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v10, v26, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[0:1], v11, v26, v[16:17]
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s[0:1], v12, v29, 0
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v3, v9, v18
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[0:1], v12, v28, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[0:1], v13, v28, v[16:17]
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v33, v33, v36
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v5, v11, v18
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v14, v30, 0
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a2, v42 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a3, v43 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a6, v46 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a7, v47 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a10, v58 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a11, v59 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[36:37], s[0:1], v0, v17, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[48:49], s[0:1], v2, v19, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[52:53], s[0:1], v4, v21, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[54:55], s[0:1], v6, v23, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[42:43], s[0:1], v8, v25, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[46:47], s[0:1], v10, v27, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[58:59], s[0:1], v12, v29, 0
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a0, v40 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a1, v41 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a4, v44 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a5, v45 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a8, v56 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a9, v57 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a14, v62 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a15, v63 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[34:35], s[0:1], v0, v16, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[38:39], s[0:1], v2, v18, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[50:51], s[0:1], v4, v20, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[32:33], s[0:1], v6, v22, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[40:41], s[0:1], v8, v24, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[44:45], s[0:1], v10, v26, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[56:57], s[0:1], v12, v28, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[62:63], s[0:1], v1, v16, v[36:37]
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v3, v18, v[48:49]
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v5, v20, v[52:53]
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], v7, v22, v[54:55]
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], v9, v24, v[42:43]
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v11, v26, v[46:47]
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[0:1], v13, v28, v[58:59]
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v25, v39, v0
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v0, v41, v6
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v1, v45, v8
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v22, v57, v10
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v24, v35, v62
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v26, v51, v2
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], v34, v0, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v38, v1, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[0:1], v50, v22, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[0:1], v50, v56, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[22:23], s[0:1], v24, v40, v[6:7]
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], v25, v44, v[8:9]
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v26, v56, v[10:11]
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s[0:1], v34, v40, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s[0:1], v38, v44, 0
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v8, v19, v8
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v10, v13, v22
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v11, v17, v6
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], v12, v8, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v12, v18, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v10, v18, v[6:7]
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a12, v60 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_write_b32 a13, v61 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[60:61], s[0:1], v14, v30, 0
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v10, v3, v8
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v27, v33, v4
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[20:21], s[0:1], v32, v60, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], v16, v20, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v2, v4, 0
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v63, a15 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v62, a14 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v59, a11 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v58, a10 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v57, a9 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v56, a8 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v47, a7 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v46, a6 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v45, a5 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v44, a4 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v43, a3 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v42, a2 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v41, a1 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v40, a0 ; Reload Reuse
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s[0:1], v14, v31, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[0:1], v15, v30, v[16:17]
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s[0:1], v32, v1, 0
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v11, v13, v18
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s[0:1], v33, v6, v[16:17]
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s[0:1], v0, v3, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[14:15], s[0:1], v32, v6, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], v0, v8, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v34, v8, v[16:17]
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v2, v5, 0
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v13, v15, v18
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v15, v7, v0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v2, v10, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v20, v10, v[8:9]
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v4, v11, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], v14, v31, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v15, v30, v[6:7]
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v3, v61, v8
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], v32, v3, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v27, v60, v[6:7]
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v3, v21, v8
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], v16, v3, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v11, v20, v[6:7]
+; GFX9-GISEL-NEXT:    v_add_u32_e32 v3, v5, v8
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], v2, v3, 0
+; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v10, v4, v[6:7]
 ; GFX9-GISEL-NEXT:    v_add_u32_e32 v1, v1, v2
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v4, v12, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], v21, v12, v[8:9]
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v3, v3, v4
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v14, v1, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], v14, v0, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s[0:1], v13, v0, v[8:9]
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v6, v3, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s[0:1], v6, v2, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[0:1], v15, v2, v[0:1]
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v10, v5, v10
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v5, v9, v6
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[0:1], v4, v5, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[0:1], v4, v8, 0
-; GFX9-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[0:1], v10, v8, v[2:3]
-; GFX9-GISEL-NEXT:    v_add_u32_e32 v1, v1, v4
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v61, a13 ; Reload Reuse
+; GFX9-GISEL-NEXT:    v_accvgpr_read_b32 v60, a12 ; Reload Reuse
 ; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-SDAG-LABEL: test_vector_reduce_mul_v16i64:
@@ -3848,33 +3884,33 @@ define i64 @test_vector_reduce_mul_v16i64(<16 x i64> %v) {
 ; GFX10-SDAG-NEXT:    v_add3_u32 v9, v9, v25, v22
 ; GFX10-SDAG-NEXT:    v_add3_u32 v23, v13, v29, v34
 ; GFX10-SDAG-NEXT:    v_add3_u32 v5, v5, v21, v28
-; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[19:20], s4, v0, v8, 0
+; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[17:18], s4, v0, v8, 0
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v8, v1, v8
-; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[17:18], s4, v4, v12, 0
+; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[19:20], s4, v6, v15, 0
 ; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[21:22], s4, v2, v10, 0
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v5, v5, v12
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v4, v4, v23
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v9, v0, v9
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v3, v3, v10
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v2, v2, v11
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v9, v0, v9
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v7, v7, v15
-; GFX10-SDAG-NEXT:    v_add3_u32 v4, v18, v4, v5
-; GFX10-SDAG-NEXT:    v_add3_u32 v8, v20, v9, v8
-; GFX10-SDAG-NEXT:    v_add3_u32 v5, v22, v2, v3
-; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s4, v19, v17, 0
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v4, v19, v4
+; GFX10-SDAG-NEXT:    v_add3_u32 v10, v22, v2, v3
+; GFX10-SDAG-NEXT:    v_add3_u32 v8, v18, v9, v8
 ; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v24, v14, v31
-; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[13:14], s4, v6, v15, 0
+; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[13:14], s4, v4, v12, 0
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v4, v4, v23
 ; GFX10-SDAG-NEXT:    v_add3_u32 v1, v16, v24, v33
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v5, v5, v13
+; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[2:3], s4, v17, v13, 0
+; GFX10-SDAG-NEXT:    v_add3_u32 v4, v14, v4, v5
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v6, v6, v1
-; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s4, v21, v13, 0
-; GFX10-SDAG-NEXT:    v_add3_u32 v6, v14, v6, v7
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v7, v8, v17
-; GFX10-SDAG-NEXT:    v_mul_lo_u32 v6, v21, v6
+; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s4, v21, v19, 0
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v4, v17, v4
+; GFX10-SDAG-NEXT:    v_add3_u32 v5, v20, v6, v7
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v6, v10, v19
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v7, v8, v13
+; GFX10-SDAG-NEXT:    v_mul_lo_u32 v5, v21, v5
 ; GFX10-SDAG-NEXT:    v_add3_u32 v3, v3, v4, v7
-; GFX10-SDAG-NEXT:    v_add3_u32 v1, v1, v6, v5
+; GFX10-SDAG-NEXT:    v_add3_u32 v1, v1, v5, v6
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v3, v3, v0
 ; GFX10-SDAG-NEXT:    v_mul_lo_u32 v4, v2, v1
 ; GFX10-SDAG-NEXT:    v_mad_u64_u32 v[0:1], s4, v2, v0, 0
@@ -3891,46 +3927,46 @@ define i64 @test_vector_reduce_mul_v16i64(<16 x i64> %v) {
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[36:37], s4, v14, v35, v[32:33]
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[37:38], s4, v6, v23, v[34:35]
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[34:35], s4, v33, v31, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[38:39], s4, v15, v30, v[36:37]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[14:15], s4, v0, v16, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[14:15], s4, v15, v30, v[36:37]
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[36:37], s4, v7, v22, v[37:38]
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[6:7], s4, v2, v18, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[22:23], s4, v4, v20, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[32:33], s4, v33, v38, v[35:36]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[37:38], s4, v0, v17, v[15:16]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[38:39], s4, v2, v19, v[7:8]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[22:23], s4, v10, v26, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[32:33], s4, v33, v14, v[35:36]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[14:15], s4, v4, v20, 0
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[35:36], s4, v36, v31, v[32:33]
 ; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[30:31], s4, v8, v24, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[32:33], s4, v10, v26, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[15:16], s4, v1, v16, v[37:38]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[16:17], s4, v3, v18, v[38:39]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s4, v12, v28, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s4, v4, v21, v[23:24]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s4, v8, v25, v[31:32]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s4, v10, v27, v[33:34]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[17:18], s4, v12, v29, v[1:2]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s4, v5, v20, v[2:3]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[19:20], s4, v9, v24, v[3:4]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[9:10], s4, v11, v26, v[7:8]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s4, v6, v32, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s4, v13, v28, v[17:18]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s4, v22, v0, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s4, v14, v30, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s4, v6, v9, v[4:5]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s4, v22, v10, v[8:9]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s4, v3, v34, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[13:14], s4, v14, v19, v[2:3]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s4, v1, v7, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s4, v16, v32, v[11:12]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s4, v18, v0, v[12:13]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s4, v15, v30, v[13:14]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s4, v3, v35, v[9:10]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s4, v1, v11, v[5:6]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s4, v4, v8, 0
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s4, v10, v34, v[2:3]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s4, v12, v7, v[5:6]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s4, v4, v2, v[1:2]
-; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s4, v5, v8, v[1:2]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[32:33], s4, v12, v28, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[36:37], s4, v2, v19, v[7:8]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[37:38], s4, v4, v21, v[15:16]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[38:39], s4, v10, v27, v[23:24]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s4, v8, v25, v[31:32]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[48:49], s4, v12, v29, v[33:34]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[18:19], s4, v3, v18, v[36:37]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[19:20], s4, v5, v20, v[37:38]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s4, v0, v16, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s4, v11, v26, v[38:39]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s4, v6, v22, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[20:21], s4, v9, v24, v[7:8]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[11:12], s4, v13, v28, v[48:49]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[7:8], s4, v14, v32, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s4, v0, v17, v[3:4]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[23:24], s4, v6, v10, v[5:6]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[5:6], s4, v2, v30, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[13:14], s4, v14, v11, v[8:9]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[8:9], s4, v4, v34, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[10:11], s4, v5, v7, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s4, v1, v16, v[12:13]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[12:13], s4, v19, v32, v[13:14]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s4, v2, v20, v[6:7]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s4, v18, v22, v[23:24]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s4, v4, v35, v[9:10]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[4:5], s4, v5, v12, v[11:12]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[13:14], s4, v0, v30, v[1:2]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[0:1], s4, v10, v8, 0
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[2:3], s4, v2, v34, v[3:4]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[3:4], s4, v13, v7, v[4:5]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s4, v10, v2, v[1:2]
+; GFX10-GISEL-NEXT:    v_mad_u64_u32 v[1:2], s4, v3, v8, v[1:2]
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-SDAG-LABEL: test_vector_reduce_mul_v16i64:
@@ -3967,106 +4003,103 @@ define i64 @test_vector_reduce_mul_v16i64(<16 x i64> %v) {
 ; GFX11-SDAG-NEXT:    v_add3_u32 v9, v9, v17, v24
 ; GFX11-SDAG-NEXT:    v_add3_u32 v1, v1, v25, v16
 ; GFX11-SDAG-NEXT:    v_add3_u32 v21, v13, v21, v28
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[15:16], null, v12, v0, 0
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[17:18], null, v8, v6, 0
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[15:16], null, v8, v6, 0
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[17:18], null, v2, v4, 0
 ; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[19:20], null, v10, v31, 0
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v0, v21, v0
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v1, v12, v1
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v6, v9, v6
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v9, v11, v31
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v10, v10, v27
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v7, v8, v7
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v8, v11, v31
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v9, v10, v27
-; GFX11-SDAG-NEXT:    v_add3_u32 v0, v16, v1, v0
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-SDAG-NEXT:    v_add3_u32 v6, v18, v7, v6
-; GFX11-SDAG-NEXT:    v_add3_u32 v1, v20, v9, v8
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v0, v17, v0
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v6, v6, v15
-; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v22, v14, v33
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[13:14], null, v2, v4, 0
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v4, v3, v4
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-SDAG-NEXT:    v_add3_u32 v8, v20, v10, v9
+; GFX11-SDAG-NEXT:    v_add3_u32 v6, v16, v7, v6
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_4) | instid1(VALU_DEP_3)
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v7, v8, v17
+; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v22, v14, v33
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[13:14], null, v12, v0, 0
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v0, v21, v0
 ; GFX11-SDAG-NEXT:    v_add3_u32 v5, v5, v22, v35
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v1, v1, v13
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v6, v6, v13
+; GFX11-SDAG-NEXT:    v_add3_u32 v0, v14, v1, v0
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v5, v2, v5
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[2:3], null, v19, v13, 0
-; GFX11-SDAG-NEXT:    v_add3_u32 v7, v14, v5, v4
-; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[4:5], null, v17, v15, 0
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[2:3], null, v19, v17, 0
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v0, v15, v0
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-SDAG-NEXT:    v_add3_u32 v1, v18, v5, v4
+; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[4:5], null, v15, v13, 0
+; GFX11-SDAG-NEXT:    v_mul_lo_u32 v1, v19, v1
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-SDAG-NEXT:    v_mul_lo_u32 v7, v19, v7
 ; GFX11-SDAG-NEXT:    v_add3_u32 v0, v5, v0, v6
+; GFX11-SDAG-NEXT:    v_add3_u32 v1, v3, v1, v7
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-SDAG-NEXT:    v_add3_u32 v1, v3, v7, v1
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v3, v0, v2
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
 ; GFX11-SDAG-NEXT:    v_mul_lo_u32 v5, v4, v1
 ; GFX11-SDAG-NEXT:    v_mad_u64_u32 v[0:1], null, v4, v2, 0
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-SDAG-NEXT:    v_add3_u32 v1, v1, v5, v3
 ; GFX11-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-GISEL-LABEL: test_vector_reduce_mul_v16i64:
 ; GFX11-GISEL:       ; %bb.0: ; %entry
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-GISEL-NEXT:    scratch_load_b32 v55, off, s32
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[33:34], null, v2, v18, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[35:36], null, v4, v20, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[31:32], null, v0, v16, 0
+; GFX11-GISEL-NEXT:    scratch_load_b32 v39, off, s32
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[31:32], null, v14, v30, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[33:34], null, v0, v16, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[35:36], null, v2, v18, 0
 ; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[37:38], null, v6, v22, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[50:51], null, v10, v26, 0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[82:83], null, v2, v19, v[34:35]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[70:71], null, v0, v17, v[32:33]
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[83:84], null, v4, v21, v[36:37]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[52:53], null, v12, v28, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[64:65], null, v14, v30, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[66:67], null, v33, v50, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[48:49], null, v8, v24, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[84:85], null, v6, v23, v[38:39]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[96:97], null, v1, v16, v[70:71]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v3, v18, v[82:83]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[85:86], null, v10, v27, v[51:52]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[86:87], null, v12, v29, v[53:54]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[38:39], null, v8, v25, v[49:50]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[80:81], null, v37, v64, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[16:17], null, v5, v20, v[83:84]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[68:69], null, v35, v52, 0
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[17:18], null, v7, v22, v[84:85]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[6:7], null, v9, v24, v[38:39]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[7:8], null, v13, v28, v[86:87]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[53:54], null, v31, v48, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[50:51], null, v12, v28, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[52:53], null, v4, v20, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[48:49], null, v10, v26, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[64:65], null, v8, v24, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[68:69], null, v0, v17, v[34:35]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[69:70], null, v2, v19, v[36:37]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[66:67], null, v37, v31, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[80:81], null, v12, v29, v[51:52]
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[1:2], null, v14, v55, v[65:66]
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[4:5], null, v15, v30, v[1:2]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[1:2], null, v11, v26, v[85:86]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v53, v68, 0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v37, v4, v[81:82]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v33, v1, v[67:68]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[10:11], null, v35, v7, v[69:70]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[4:5], null, v66, v80, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[54:55], null, v14, v39, v[32:33]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[70:71], null, v6, v23, v[38:39]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[38:39], null, v10, v27, v[49:50]
 ; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[11:12], null, v17, v64, v[8:9]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[7:8], null, v31, v6, v[54:55]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[12:13], null, v0, v50, v[9:10]
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v66, v11, v[5:6]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v16, v52, v[10:11]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[5:6], null, v96, v48, v[7:8]
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[6:7], null, v53, v0, v[3:4]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v12, v80, v[8:9]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v2, v4, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[81:82], null, v15, v30, v[54:55]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[82:83], null, v8, v25, v[65:66]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[83:84], null, v7, v22, v[70:71]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[54:55], null, v4, v21, v[53:54]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[14:15], null, v35, v48, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[21:22], null, v11, v26, v[38:39]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[29:30], null, v52, v50, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[6:7], null, v33, v64, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[10:11], null, v13, v28, v[80:81]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[11:12], null, v37, v81, v[67:68]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[12:13], null, v3, v18, v[69:70]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[17:18], null, v9, v24, v[82:83]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[2:3], null, v5, v20, v[54:55]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[18:19], null, v35, v21, v[15:16]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[3:4], null, v14, v66, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[8:9], null, v6, v29, 0
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[19:20], null, v52, v10, v[30:31]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[20:21], null, v83, v31, v[11:12]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[10:11], null, v1, v16, v[68:69]
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v33, v17, v[7:8]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[15:16], null, v12, v48, v[18:19]
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[11:12], null, v2, v50, v[19:20]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[1:2], null, v14, v20, v[4:5]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[12:13], null, v6, v11, v[9:10]
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[4:5], null, v10, v64, v[0:1]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[5:6], null, v15, v66, v[1:2]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[0:1], null, v8, v3, 0
 ; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[7:8], null, v5, v68, v[6:7]
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[5:6], null, v2, v9, v[1:2]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[6:7], null, v4, v29, v[12:13]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[9:10], null, v8, v5, v[1:2]
 ; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[1:2], null, v7, v4, v[5:6]
+; GFX11-GISEL-NEXT:    v_mad_u64_u32 v[1:2], null, v6, v3, v[9:10]
 ; GFX11-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-LABEL: test_vector_reduce_mul_v16i64:
@@ -4107,38 +4140,39 @@ define i64 @test_vector_reduce_mul_v16i64(<16 x i64> %v) {
 ; GFX12-SDAG-NEXT:    v_add3_u32 v9, v9, v25, v22
 ; GFX12-SDAG-NEXT:    v_add3_u32 v23, v13, v29, v34
 ; GFX12-SDAG-NEXT:    v_add3_u32 v5, v5, v21, v28
-; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[19:20], null, v0, v8, 0
+; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[17:18], null, v0, v8, 0
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v8, v1, v8
-; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[17:18], null, v4, v12, 0
+; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[19:20], null, v6, v15, 0
 ; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[21:22], null, v2, v10, 0
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v5, v5, v12
-; GFX12-SDAG-NEXT:    v_mul_lo_u32 v4, v4, v23
-; GFX12-SDAG-NEXT:    v_mul_lo_u32 v9, v0, v9
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v3, v3, v10
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v2, v2, v11
+; GFX12-SDAG-NEXT:    v_mul_lo_u32 v9, v0, v9
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v7, v7, v15
-; GFX12-SDAG-NEXT:    v_add3_u32 v4, v18, v4, v5
-; GFX12-SDAG-NEXT:    v_add3_u32 v8, v20, v9, v8
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX12-SDAG-NEXT:    v_add3_u32 v5, v22, v2, v3
-; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[2:3], null, v19, v17, 0
-; GFX12-SDAG-NEXT:    v_mul_lo_u32 v4, v19, v4
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX12-SDAG-NEXT:    v_add3_u32 v10, v22, v2, v3
+; GFX12-SDAG-NEXT:    v_add3_u32 v8, v18, v9, v8
 ; GFX12-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v24, v14, v31
-; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[13:14], null, v6, v15, 0
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[13:14], null, v4, v12, 0
+; GFX12-SDAG-NEXT:    v_mul_lo_u32 v4, v4, v23
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX12-SDAG-NEXT:    v_add3_u32 v1, v16, v24, v33
-; GFX12-SDAG-NEXT:    v_mul_lo_u32 v5, v5, v13
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[2:3], null, v17, v13, 0
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX12-SDAG-NEXT:    v_add3_u32 v4, v14, v4, v5
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v6, v6, v1
-; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[0:1], null, v21, v13, 0
-; GFX12-SDAG-NEXT:    v_add3_u32 v6, v14, v6, v7
-; GFX12-SDAG-NEXT:    v_mul_lo_u32 v7, v8, v17
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX12-SDAG-NEXT:    v_mul_lo_u32 v6, v21, v6
+; GFX12-SDAG-NEXT:    v_mad_co_u64_u32 v[0:1], null, v21, v19, 0
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX12-SDAG-NEXT:    v_mul_lo_u32 v4, v17, v4
+; GFX12-SDAG-NEXT:    v_add3_u32 v5, v20, v6, v7
+; GFX12-SDAG-NEXT:    v_mul_lo_u32 v6, v10, v19
+; GFX12-SDAG-NEXT:    v_mul_lo_u32 v7, v8, v13
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX12-SDAG-NEXT:    v_mul_lo_u32 v5, v21, v5
 ; GFX12-SDAG-NEXT:    v_add3_u32 v3, v3, v4, v7
 ; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX12-SDAG-NEXT:    v_add3_u32 v1, v1, v6, v5
+; GFX12-SDAG-NEXT:    v_add3_u32 v1, v1, v5, v6
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v3, v3, v0
 ; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
 ; GFX12-SDAG-NEXT:    v_mul_lo_u32 v4, v2, v1


### PR DESCRIPTION
Updates the the new Write*Dummy HWWriteRes to maintain latency -- this is to ensure SchedModel->computeOperandLatency calls are unchanged.

This also uses the new HWWriteRes for v_mad_u64_u32 and v_mad_i64_i32. 

For an explanation of why we want to do this , see https://github.com/llvm/llvm-project/pull/190095 . In short, the scheduler will not try to cover the full latency of the instructions without this new modelling.

This causes a good amount of lit churn since these instructions are well covered.