### PR TITLE
[Flang] bug: preprocessor increases backslash to double backslash

### DIFF
--- a/flang/lib/Parser/prescan.cpp
+++ b/flang/lib/Parser/prescan.cpp
@@ -1014,9 +1014,9 @@ void Prescanner::QuotedCharacterLiteral(
     if (*at_ == '\\') {
       if (escapesEnabled) {
         isEscaped = !isEscaped;
-      } else {
-        // The parser always processes escape sequences, so don't confuse it
-        // when escapes are disabled.
+      } else if (!preprocessingOnly_) {
+        // Except when -E is used, the parser always processes escape sequences,
+        // so don't confuse it when escapes are disabled.
         insert('\\');
       }
     } else {

--- a/flang/test/Driver/escaped-backslash.f90
+++ b/flang/test/Driver/escaped-backslash.f90
@@ -15,8 +15,8 @@
 ! RUN: %flang_fc1 -E -fbackslash %s  2>&1 | FileCheck %s --check-prefix=UNESCAPED
 
 ! ESCAPED:program Backslash
-! ESCAPED-NEXT:New\\nline
-! ESCAPED-NOT:New\nline
+! ESCAPED-NEXT:New\nline
+! ESCAPED-NOT:New\\nline
 
 ! UNESCAPED:program Backslash
 ! UNESCAPED-NEXT:New\nline


### PR DESCRIPTION
Correcting the preprocessing (-E) output when` '\'` is used in a string.
Prior to this fix it was being replaced with `"\\"`.

Fixes[191463](https://github.com/llvm/llvm-project/issues/191463)