### PR TITLE
Revert "RuntimeLibcalls: Add mustprogress to common function attributes (#167080)"

### DIFF
--- a/llvm/lib/IR/RuntimeLibcalls.cpp
+++ b/llvm/lib/IR/RuntimeLibcalls.cpp
@@ -163,10 +163,10 @@ RuntimeLibcallsInfo::getFunctionTy(LLVMContext &Ctx, const Triple &TT,
                                    RTLIB::LibcallImpl LibcallImpl) const {
   // TODO: NoCallback probably unsafe in general
   static constexpr Attribute::AttrKind CommonFnAttrs[] = {
-      Attribute::MustProgress, Attribute::NoCallback, Attribute::NoFree,
-      Attribute::NoSync,       Attribute::NoUnwind,   Attribute::WillReturn};
+      Attribute::NoCallback, Attribute::NoFree, Attribute::NoSync,
+      Attribute::NoUnwind, Attribute::WillReturn};
   static constexpr Attribute::AttrKind MemoryFnAttrs[] = {
-      Attribute::MustProgress, Attribute::NoUnwind, Attribute::WillReturn};
+      Attribute::NoUnwind, Attribute::WillReturn};
   static constexpr Attribute::AttrKind CommonPtrArgAttrs[] = {
       Attribute::NoAlias, Attribute::WriteOnly, Attribute::NonNull};
 

--- a/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/armpl.ll
+++ b/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/armpl.ll
@@ -46,5 +46,5 @@
 ; CHECK: declare aarch64_vector_pcs void @armpl_vsincosq_f64(<2 x double>, ptr noalias nonnull writeonly align 16, ptr noalias nonnull writeonly align 16) [[ATTRS_PTR_ARG]]
 
 
-; CHECK: attributes [[ATTRS]] = { mustprogress nocallback nofree nosync nounwind willreturn }
-; CHECK: attributes [[ATTRS_PTR_ARG]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: write) }
+; CHECK: attributes [[ATTRS]] = { nocallback nofree nosync nounwind willreturn }
+; CHECK: attributes [[ATTRS_PTR_ARG]] = { nocallback nofree nosync nounwind willreturn memory(argmem: write) }

--- a/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/basic.ll
+++ b/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/basic.ll
@@ -64,6 +64,6 @@ define float @sinf(float %x) {
 
 ; CHECK: declare void @truncl(...)
 
-; CHECK: attributes [[CALLOC_ATTRS]] = { mustprogress nofree nounwind willreturn allockind("alloc") allocsize(0,1) "alloc-family"="malloc" }
-; CHECK: attributes [[FREE_ATTRS]] = { mustprogress nounwind willreturn allockind("free") "alloc-family"="malloc" }
-; CHECK: attributes [[MALLOC_ATTRS]] = { mustprogress nofree nounwind willreturn allockind("alloc,uninitialized") allocsize(0) "alloc-family"="malloc" }
+; CHECK: attributes [[CALLOC_ATTRS]] = { nofree nounwind willreturn allockind("alloc") allocsize(0,1) "alloc-family"="malloc" }
+; CHECK: attributes [[FREE_ATTRS]] = { nounwind willreturn allockind("free") "alloc-family"="malloc" }
+; CHECK: attributes [[MALLOC_ATTRS]] = { nofree nounwind willreturn allockind("alloc,uninitialized") allocsize(0) "alloc-family"="malloc" }

--- a/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/merge_attributes.ll
+++ b/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/merge_attributes.ll
@@ -8,4 +8,4 @@ define noundef nofpclass(nan) float @sqrtf(float %x) "foo" {
 ; FIXME: Individual fields of nofpclass not merged
 ; CHECK: define noundef nofpclass(ninf nsub nnorm) float @sqrtf(float %x) [[SQRT_ATTR:#[0-9]+]] {
 
-; CHECK: attributes [[SQRT_ATTR]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(errnomem: write) "foo" }
+; CHECK: attributes [[SQRT_ATTR]] = { nocallback nofree nosync nounwind willreturn memory(errnomem: write) "foo" }

--- a/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/sincos_stret.ll
+++ b/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/sincos_stret.ll
@@ -16,8 +16,8 @@
 ; SRET: declare void @__sincos_stret(ptr sret({ double, double }) align 4, double) [[SINCOS_ATTRS:#[0-9]+]]
 ; SRET: declare void @__sincosf_stret(ptr sret({ float, float }) align 4, float) [[SINCOS_ATTRS:#[0-9]+]]
 
-; CHECK: attributes [[SINCOS_ATTRS]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(errnomem: write) }
-; SRET: attributes [[SINCOS_ATTRS]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: write, errnomem: write) }
+; CHECK: attributes [[SINCOS_ATTRS]] = { nocallback nofree nosync nounwind willreturn memory(errnomem: write) }
+; SRET: attributes [[SINCOS_ATTRS]] = { nocallback nofree nosync nounwind willreturn memory(argmem: write, errnomem: write) }
 
 ; NONE-NOT: __sincos_stret
 ; NONE-NOT: __sincosf_stret

--- a/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/sleef.ll
+++ b/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/sleef.ll
@@ -34,5 +34,5 @@
 
 ; CHECK: declare void @_ZGVsNxvl8l8_sincospi(<vscale x 2 x double>, ptr noalias nonnull writeonly align 16, ptr noalias nonnull writeonly align 16) [[ATTRS_PTR_ARG]]
 
-; CHECK: attributes [[ATTRS_PTR_ARG]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: write) }
-; CHECK: attributes [[ATTRS]] = { mustprogress nocallback nofree nosync nounwind willreturn }
+; CHECK: attributes [[ATTRS_PTR_ARG]] = { nocallback nofree nosync nounwind willreturn memory(argmem: write) }
+; CHECK: attributes [[ATTRS]] = { nocallback nofree nosync nounwind willreturn }


### PR DESCRIPTION
This reverts commit eb5297e0ade96fe8a6297763f28219be97dfac76.

This is redundant with willreturn.