### PR TITLE
[libc] add posix_mutex_trylock support

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1010,6 +1010,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_mutex_destroy
     libc.src.pthread.pthread_mutex_init
     libc.src.pthread.pthread_mutex_lock
+    libc.src.pthread.pthread_mutex_trylock
     libc.src.pthread.pthread_mutex_unlock
     libc.src.pthread.pthread_mutexattr_destroy
     libc.src.pthread.pthread_mutexattr_getpshared

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1143,6 +1143,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_mutex_destroy
     libc.src.pthread.pthread_mutex_init
     libc.src.pthread.pthread_mutex_lock
+    libc.src.pthread.pthread_mutex_trylock
     libc.src.pthread.pthread_mutex_unlock
     libc.src.pthread.pthread_mutexattr_destroy
     libc.src.pthread.pthread_mutexattr_getpshared

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1201,6 +1201,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_mutex_destroy
     libc.src.pthread.pthread_mutex_init
     libc.src.pthread.pthread_mutex_lock
+    libc.src.pthread.pthread_mutex_trylock
     libc.src.pthread.pthread_mutex_unlock
     libc.src.pthread.pthread_mutexattr_destroy
     libc.src.pthread.pthread_mutexattr_getpshared

--- a/libc/include/pthread.yaml
+++ b/libc/include/pthread.yaml
@@ -221,6 +221,10 @@ functions:
     return_type: int
     arguments:
       - type: pthread_mutex_t *
+  - name: pthread_mutex_trylock
+    return_type: int
+    arguments:
+      - type: pthread_mutex_t *
   - name: pthread_mutex_unlock
     return_type: int
     arguments:

--- a/libc/src/__support/threads/mutex.h
+++ b/libc/src/__support/threads/mutex.h
@@ -22,7 +22,7 @@
 //
 // MutexError lock();
 // MutexError trylock();
-// MutexError timedlock(...);
+// MutexError timed_lock(...);
 // MutexError unlock();
 // MutexError reset(); // Used to reset inconsistent robust mutexes.
 //
@@ -54,12 +54,14 @@ namespace LIBC_NAMESPACE_DECL {
 /// complete Mutex locks in general cannot be implemented on the GPU, or on some
 /// baremetal platforms. We simply define the Mutex interface and require that
 /// only a single thread executes code requiring a mutex lock.
+// TODO: declare abstract interface for timed_lock
 struct Mutex {
   LIBC_INLINE constexpr Mutex(bool, bool, bool, bool) {}
 
   LIBC_INLINE MutexError lock() { return MutexError::NONE; }
   LIBC_INLINE MutexError unlock() { return MutexError::NONE; }
   LIBC_INLINE MutexError reset() { return MutexError::NONE; }
+  LIBC_INLINE MutexError trylock() { return MutexError::NONE; }
 };
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/pthread/CMakeLists.txt
+++ b/libc/src/pthread/CMakeLists.txt
@@ -362,6 +362,17 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  pthread_mutex_trylock
+  SRCS
+    pthread_mutex_trylock.cpp
+  HDRS
+    pthread_mutex_trylock.h
+  DEPENDS
+    libc.include.pthread
+    libc.src.__support.threads.mutex
+)
+
+add_entrypoint_object(
   pthread_mutex_unlock
   SRCS
     pthread_mutex_unlock.cpp

--- a/libc/src/pthread/pthread_mutex_trylock.cpp
+++ b/libc/src/pthread/pthread_mutex_trylock.cpp
@@ -1,0 +1,26 @@
+//===-- Linux implementation of the pthread_mutex_trylock function --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "pthread_mutex_trylock.h"
+
+#include "hdr/errno_macros.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/threads/mutex.h"
+#include "src/__support/threads/mutex_common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// The implementation currently handles only plain mutexes.
+LLVM_LIBC_FUNCTION(int, pthread_mutex_trylock, (pthread_mutex_t * mutex)) {
+  if (reinterpret_cast<Mutex *>(mutex)->try_lock() == MutexError::BUSY)
+    return EBUSY;
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/pthread/pthread_mutex_trylock.h
+++ b/libc/src/pthread/pthread_mutex_trylock.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for pthread_mutex_trylock function ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_PTHREAD_PTHREAD_MUTEX_TRYLOCK_H
+#define LLVM_LIBC_SRC_PTHREAD_PTHREAD_MUTEX_TRYLOCK_H
+
+#include "include/llvm-libc-types/pthread_mutex_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int pthread_mutex_trylock(pthread_mutex_t *mutex);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_PTHREAD_PTHREAD_MUTEX_TRYLOCK_H

--- a/libc/test/integration/src/pthread/CMakeLists.txt
+++ b/libc/test/integration/src/pthread/CMakeLists.txt
@@ -13,6 +13,7 @@ add_integration_test(
     libc.src.pthread.pthread_mutex_destroy
     libc.src.pthread.pthread_mutex_init
     libc.src.pthread.pthread_mutex_lock
+    libc.src.pthread.pthread_mutex_trylock
     libc.src.pthread.pthread_mutex_unlock
     libc.src.pthread.pthread_create
     libc.src.pthread.pthread_join

--- a/libc/test/integration/src/pthread/pthread_mutex_test.cpp
+++ b/libc/test/integration/src/pthread/pthread_mutex_test.cpp
@@ -6,12 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "hdr/stdint_proxy.h" // uintptr_t
 #include "src/pthread/pthread_create.h"
 #include "src/pthread/pthread_join.h"
 #include "src/pthread/pthread_mutex_destroy.h"
 #include "src/pthread/pthread_mutex_init.h"
 #include "src/pthread/pthread_mutex_lock.h"
+#include "src/pthread/pthread_mutex_trylock.h"
 #include "src/pthread/pthread_mutex_unlock.h"
 #include "test/IntegrationTest/test.h"
 
@@ -128,6 +130,19 @@ void wait_and_step() {
   LIBC_NAMESPACE::pthread_mutex_destroy(&step_lock);
 }
 
+void trylock_test() {
+  pthread_mutex_t trylock_mutex;
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_init(&trylock_mutex, nullptr), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_trylock(&trylock_mutex), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_trylock(&trylock_mutex), EBUSY);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_unlock(&trylock_mutex), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_trylock(&trylock_mutex), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_unlock(&trylock_mutex), 0);
+
+  LIBC_NAMESPACE::pthread_mutex_destroy(&trylock_mutex);
+}
+
 static constexpr int THREAD_COUNT = 10;
 static pthread_mutex_t multiple_waiter_lock;
 static pthread_mutex_t counter_lock;
@@ -191,6 +206,7 @@ static pthread_mutex_t test_initializer = PTHREAD_MUTEX_INITIALIZER;
 TEST_MAIN() {
   relay_counter();
   wait_and_step();
+  trylock_test();
   multiple_waiters();
   return 0;
 }


### PR DESCRIPTION
Expose existing trylock internal operation to posix interface. POSIX.1-2024 only specifies the `EBUSY` error case.

Assisted-by: gpt-5.4 default fast