### PR TITLE
[AArch64] Remove EnableOptimizeLogicalImm CLI option

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -119,12 +119,6 @@ cl::opt<bool> EnableAArch64ELFLocalDynamicTLSGeneration(
     cl::desc("Allow AArch64 Local Dynamic TLS code generation"),
     cl::init(false));
 
-static cl::opt<bool>
-EnableOptimizeLogicalImm("aarch64-enable-logical-imm", cl::Hidden,
-                         cl::desc("Enable AArch64 logical imm instruction "
-                                  "optimization"),
-                         cl::init(true));
-
 // Temporary option added for the purpose of testing functionality added
 // to DAGCombiner.cpp in D92230. It is expected that this can be removed
 // in future when both implementations will be based off MGATHER rather
@@ -2695,9 +2689,6 @@ bool AArch64TargetLowering::targetShrinkDemandedConstant(
     TargetLoweringOpt &TLO) const {
   // Delay this optimization to as late as possible.
   if (!TLO.LegalOps)
-    return false;
-
-  if (!EnableOptimizeLogicalImm)
     return false;
 
   EVT VT = Op.getValueType();


### PR DESCRIPTION
There is no reason to have this switch. We wouldn't have it for ARM, so why have it here?