### PR TITLE
[AsmPrinter] Use AsmPrinterAnalysis to hold AsmPrinter

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinterAnalysis.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinterAnalysis.h
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Holds an AsmPrinter instance so that state can be shared appropriately
+// between the Module and MachineFunction portions of AsmPrinter.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CODEGEN_ASMPRINTERANALYSIS_H
+#define LLVM_CODEGEN_ASMPRINTERANALYSIS_H
+
+#include "llvm/CodeGen/AsmPrinter.h"
+#include "llvm/IR/Analysis.h"
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+
+class AsmPrinterAnalysis : public AnalysisInfoMixin<AsmPrinterAnalysis> {
+public:
+  static AnalysisKey Key;
+  std::unique_ptr<AsmPrinter> HeldPrinter;
+
+  class Result {
+    AsmPrinter &Printer;
+    Result(AsmPrinter &Printer) : Printer(Printer) {}
+    friend class AsmPrinterAnalysis;
+
+  public:
+    AsmPrinter &getPrinter() { return Printer; }
+
+    bool invalidate(Module &, const PreservedAnalyses,
+                    ModuleAnalysisManager::Invalidator &) {
+      return false;
+    }
+  };
+
+  Result run(Module &M, ModuleAnalysisManager &) {
+    return Result(*HeldPrinter);
+  }
+
+public:
+  AsmPrinterAnalysis(std::unique_ptr<AsmPrinter> Printer)
+      : HeldPrinter(std::move(Printer)) {}
+};
+
+} // namespace llvm
+
+#endif //  LLVM_CODEGEN_ASMPRINTERANALYSIS_H

--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -603,7 +603,7 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::buildPipeline(
     std::unique_ptr<AsmPrinter> Printer(
         TM.getTarget().createAsmPrinter(TM, std::move(*MCStreamerOrErr)));
     if (!Printer)
-      return createStringError("Failed to create AsmPrinter");
+      return createStringError("failed to create AsmPrinter");
     MAM.registerPass([&] { return AsmPrinterAnalysis(std::move(Printer)); });
     derived().addAsmPrinterBegin(PMW);
   }

--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -23,6 +23,8 @@
 #include "llvm/Analysis/ScopedNoAliasAA.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Analysis/TypeBasedAliasAnalysis.h"
+#include "llvm/CodeGen/AsmPrinter.h"
+#include "llvm/CodeGen/AsmPrinterAnalysis.h"
 #include "llvm/CodeGen/BranchFoldingPass.h"
 #include "llvm/CodeGen/CodeGenPrepare.h"
 #include "llvm/CodeGen/DeadMachineInstructionElim.h"
@@ -102,6 +104,7 @@
 #include "llvm/IRPrinter/IRPrintingPasses.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCTargetOptions.h"
+#include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
@@ -163,9 +166,6 @@ private:
   friend class CodeGenPassBuilder;
 };
 
-using CreateMCStreamer =
-    std::function<Expected<std::unique_ptr<MCStreamer>>(TargetMachine &)>;
-
 /// This class provides access to building LLVM's passes.
 ///
 /// Its members provide the baseline state available to passes during their
@@ -197,9 +197,9 @@ public:
       Opt.OptimizeRegAlloc = getOptLevel() != CodeGenOptLevel::None;
   }
 
-  Error buildPipeline(ModulePassManager &MPM, raw_pwrite_stream &Out,
-                      raw_pwrite_stream *DwoOut, CodeGenFileType FileType,
-                      MCContext &Ctx) const;
+  Error buildPipeline(ModulePassManager &MPM, ModuleAnalysisManager &MAM,
+                      raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
+                      CodeGenFileType FileType, MCContext &Ctx) const;
 
   PassInstrumentationCallbacks *getPassInstrumentationCallbacks() const {
     return PIC;
@@ -489,18 +489,15 @@ protected:
 
   void addPostBBSections(PassManagerWrapper &PMW) const {}
 
-  void addAsmPrinterBegin(PassManagerWrapper &PMW,
-                          CreateMCStreamer CreateStreamer) const {
+  void addAsmPrinterBegin(PassManagerWrapper &PMW) const {
     llvm_unreachable("addAsmPrinterBegin is not overriden");
   }
 
-  void addAsmPrinter(PassManagerWrapper &PMW,
-                     CreateMCStreamer CreateStreamer) const {
+  void addAsmPrinter(PassManagerWrapper &PMW) const {
     llvm_unreachable("addAsmPrinter is not overridden");
   }
 
-  void addAsmPrinterEnd(PassManagerWrapper &PMW,
-                        CreateMCStreamer CreateStreamer) const {
+  void addAsmPrinterEnd(PassManagerWrapper &PMW) const {
     llvm_unreachable("addAsmPrinterEnd is not overriden");
   }
 
@@ -572,8 +569,8 @@ private:
 
 template <typename Derived, typename TargetMachineT>
 Error CodeGenPassBuilder<Derived, TargetMachineT>::buildPipeline(
-    ModulePassManager &MPM, raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
-    CodeGenFileType FileType, MCContext &Ctx) const {
+    ModulePassManager &MPM, ModuleAnalysisManager &MAM, raw_pwrite_stream &Out,
+    raw_pwrite_stream *DwoOut, CodeGenFileType FileType, MCContext &Ctx) const {
   auto StartStopInfo = TargetPassConfig::getStartStopInfo(*PIC);
   if (!StartStopInfo)
     return StartStopInfo.takeError();
@@ -598,12 +595,18 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::buildPipeline(
   addISelPasses(PMW);
   flushFPMsToMPM(PMW);
 
-  CreateMCStreamer CreateStreamer = [&Out, DwoOut, FileType,
-                                     &Ctx](TargetMachine &TM) {
-    return TM.createMCStreamer(Out, DwoOut, FileType, Ctx);
-  };
-  if (PrintAsm)
-    derived().addAsmPrinterBegin(PMW, CreateStreamer);
+  if (PrintAsm) {
+    Expected<std::unique_ptr<MCStreamer>> MCStreamerOrErr =
+        TM.createMCStreamer(Out, DwoOut, FileType, Ctx);
+    if (!MCStreamerOrErr)
+      return MCStreamerOrErr.takeError();
+    std::unique_ptr<AsmPrinter> Printer(
+        TM.getTarget().createAsmPrinter(TM, std::move(*MCStreamerOrErr)));
+    if (!Printer)
+      return createStringError("Failed to create AsmPrinter");
+    MAM.registerPass([&] { return AsmPrinterAnalysis(std::move(Printer)); });
+    derived().addAsmPrinterBegin(PMW);
+  }
 
   if (PrintMIR)
     addModulePass(PrintMIRPreparePass(Out), PMW, /*Force=*/true);
@@ -618,9 +621,9 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::buildPipeline(
     addMachineFunctionPass(MachineVerifierPass(), PMW);
 
   if (PrintAsm) {
-    derived().addAsmPrinter(PMW, CreateStreamer);
+    derived().addAsmPrinter(PMW);
     flushFPMsToMPM(PMW, /*FreeMachineFunctions=*/true);
-    derived().addAsmPrinterEnd(PMW, CreateStreamer);
+    derived().addAsmPrinterEnd(PMW);
   } else {
     if (PrintMIR)
       addMachineFunctionPass(PrintMIRPass(Out), PMW, /*Force=*/true);

--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -486,10 +486,10 @@ public:
   }
 
   virtual Error
-  buildCodeGenPipeline(ModulePassManager &MPM, raw_pwrite_stream &Out,
-                       raw_pwrite_stream *DwoOut, CodeGenFileType FileType,
-                       const CGPassBuilderOption &Opt, MCContext &Ctx,
-                       PassInstrumentationCallbacks *PIC) {
+  buildCodeGenPipeline(ModulePassManager &MPM, ModuleAnalysisManager &MAM,
+                       raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
+                       CodeGenFileType FileType, const CGPassBuilderOption &Opt,
+                       MCContext &Ctx, PassInstrumentationCallbacks *PIC) {
     return make_error<StringError>("buildCodeGenPipeline is not overridden",
                                    inconvertibleErrorCode());
   }

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -36,6 +36,7 @@
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/BinaryFormat/ELF.h"
+#include "llvm/CodeGen/AsmPrinterAnalysis.h"
 #include "llvm/CodeGen/BasicBlockSectionsProfileReader.h"
 #include "llvm/CodeGen/GCMetadata.h"
 #include "llvm/CodeGen/GCMetadataPrinter.h"
@@ -5342,5 +5343,7 @@ void setupMachineFunctionAsmPrinter(MachineFunctionAnalysisManager &MFAM,
   AsmPrinter.EmitStackMaps = [](Module &M) {};
   AsmPrinter.AssertDebugEHFinalized = []() {};
 }
+
+AnalysisKey AsmPrinterAnalysis::Key;
 
 } // namespace llvm

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -149,9 +149,9 @@ public:
   void addCodeGenPrepare(PassManagerWrapper &PMW) const;
   void addPreISel(PassManagerWrapper &PMW) const;
   void addILPOpts(PassManagerWrapper &PMWM) const;
-  void addAsmPrinterBegin(PassManagerWrapper &PMW, CreateMCStreamer) const;
-  void addAsmPrinter(PassManagerWrapper &PMW, CreateMCStreamer) const;
-  void addAsmPrinterEnd(PassManagerWrapper &PMW, CreateMCStreamer) const;
+  void addAsmPrinterBegin(PassManagerWrapper &PMW) const;
+  void addAsmPrinter(PassManagerWrapper &PMW) const;
+  void addAsmPrinterEnd(PassManagerWrapper &PMW) const;
   Error addInstSelector(PassManagerWrapper &PMW) const;
   void addPreRewrite(PassManagerWrapper &PMW) const;
   void addMachineSSAOptimization(PassManagerWrapper &PMW) const;
@@ -1265,11 +1265,12 @@ GCNTargetMachine::getTargetTransformInfo(const Function &F) const {
 }
 
 Error GCNTargetMachine::buildCodeGenPipeline(
-    ModulePassManager &MPM, raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
-    CodeGenFileType FileType, const CGPassBuilderOption &Opts, MCContext &Ctx,
+    ModulePassManager &MPM, ModuleAnalysisManager &MAM, raw_pwrite_stream &Out,
+    raw_pwrite_stream *DwoOut, CodeGenFileType FileType,
+    const CGPassBuilderOption &Opts, MCContext &Ctx,
     PassInstrumentationCallbacks *PIC) {
   AMDGPUCodeGenPassBuilder CGPB(*this, Opts, PIC);
-  return CGPB.buildPipeline(MPM, Out, DwoOut, FileType, Ctx);
+  return CGPB.buildPipeline(MPM, MAM, Out, DwoOut, FileType, Ctx);
 }
 
 ScheduleDAGInstrs *
@@ -2382,17 +2383,15 @@ void AMDGPUCodeGenPassBuilder::addILPOpts(PassManagerWrapper &PMW) const {
 }
 
 void AMDGPUCodeGenPassBuilder::addAsmPrinterBegin(
-    PassManagerWrapper &PMW, CreateMCStreamer CreateStreamer) const {
+    PassManagerWrapper &PMW) const {
   // TODO: Add AsmPrinterBegin
 }
 
-void AMDGPUCodeGenPassBuilder::addAsmPrinter(
-    PassManagerWrapper &PMW, CreateMCStreamer CreateStreamer) const {
+void AMDGPUCodeGenPassBuilder::addAsmPrinter(PassManagerWrapper &PMW) const {
   // TODO: Add AsmPrinter.
 }
 
-void AMDGPUCodeGenPassBuilder::addAsmPrinterEnd(
-    PassManagerWrapper &PMW, CreateMCStreamer CreateStreamer) const {
+void AMDGPUCodeGenPassBuilder::addAsmPrinterEnd(PassManagerWrapper &PMW) const {
   // TODO: Add AsmPrinterEnd
 }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.h
@@ -98,8 +98,8 @@ public:
 
   bool useIPRA() const override { return true; }
 
-  Error buildCodeGenPipeline(ModulePassManager &MPM, raw_pwrite_stream &Out,
-                             raw_pwrite_stream *DwoOut,
+  Error buildCodeGenPipeline(ModulePassManager &MPM, ModuleAnalysisManager &MAM,
+                             raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
                              CodeGenFileType FileType,
                              const CGPassBuilderOption &Opts, MCContext &Ctx,
                              PassInstrumentationCallbacks *PIC) override;

--- a/llvm/lib/Target/AMDGPU/R600TargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/R600TargetMachine.cpp
@@ -58,12 +58,9 @@ public:
                          PassInstrumentationCallbacks *PIC);
 
   void addPreISel(PassManagerWrapper &PMW) const;
-  void addAsmPrinterBegin(PassManagerWrapper &PMW,
-                          CreateMCStreamer CreateStreamer) const;
-  void addAsmPrinter(PassManagerWrapper &PMW,
-                     CreateMCStreamer CreateStreamer) const;
-  void addAsmPrinterEnd(PassManagerWrapper &PMW,
-                        CreateMCStreamer CreateStreamer) const;
+  void addAsmPrinterBegin(PassManagerWrapper &PMW) const;
+  void addAsmPrinter(PassManagerWrapper &PMW) const;
+  void addAsmPrinterEnd(PassManagerWrapper &PMW) const;
   Error addInstSelector(PassManagerWrapper &PMW) const;
 };
 
@@ -168,11 +165,12 @@ TargetPassConfig *R600TargetMachine::createPassConfig(PassManagerBase &PM) {
 }
 
 Error R600TargetMachine::buildCodeGenPipeline(
-    ModulePassManager &MPM, raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
-    CodeGenFileType FileType, const CGPassBuilderOption &Opts, MCContext &Ctx,
+    ModulePassManager &MPM, ModuleAnalysisManager &MAM, raw_pwrite_stream &Out,
+    raw_pwrite_stream *DwoOut, CodeGenFileType FileType,
+    const CGPassBuilderOption &Opts, MCContext &Ctx,
     PassInstrumentationCallbacks *PIC) {
   R600CodeGenPassBuilder CGPB(*this, Opts, PIC);
-  return CGPB.buildPipeline(MPM, Out, DwoOut, FileType, Ctx);
+  return CGPB.buildPipeline(MPM, MAM, Out, DwoOut, FileType, Ctx);
 }
 
 MachineFunctionInfo *R600TargetMachine::createMachineFunctionInfo(
@@ -197,18 +195,15 @@ void R600CodeGenPassBuilder::addPreISel(PassManagerWrapper &PMW) const {
   // TODO: Add passes pre instruction selection.
 }
 
-void R600CodeGenPassBuilder::addAsmPrinterBegin(
-    PassManagerWrapper &PMW, CreateMCStreamer CreateStreamer) const {
+void R600CodeGenPassBuilder::addAsmPrinterBegin(PassManagerWrapper &PMW) const {
   // TODO: Add AsmPrinterBegin
 }
 
-void R600CodeGenPassBuilder::addAsmPrinter(
-    PassManagerWrapper &PMW, CreateMCStreamer CreateStreamer) const {
+void R600CodeGenPassBuilder::addAsmPrinter(PassManagerWrapper &PMW) const {
   // TODO: Add AsmPrinter.
 }
 
-void R600CodeGenPassBuilder::addAsmPrinterEnd(
-    PassManagerWrapper &PMW, CreateMCStreamer CreateStreamer) const {
+void R600CodeGenPassBuilder::addAsmPrinterEnd(PassManagerWrapper &PMW) const {
   // TODO: Add AsmPrinterEnd
 }
 

--- a/llvm/lib/Target/AMDGPU/R600TargetMachine.h
+++ b/llvm/lib/Target/AMDGPU/R600TargetMachine.h
@@ -38,8 +38,8 @@ public:
 
   TargetPassConfig *createPassConfig(PassManagerBase &PM) override;
 
-  Error buildCodeGenPipeline(ModulePassManager &MPM, raw_pwrite_stream &Out,
-                             raw_pwrite_stream *DwoOut,
+  Error buildCodeGenPipeline(ModulePassManager &MPM, ModuleAnalysisManager &MAM,
+                             raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
                              CodeGenFileType FileType,
                              const CGPassBuilderOption &Opt, MCContext &Ctx,
                              PassInstrumentationCallbacks *PIC) override;

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -1157,10 +1157,8 @@ extern "C" LLVM_C_ABI void LLVMInitializeX86AsmPrinter() {
 
 PreservedAnalyses X86AsmPrinterBeginPass::run(Module &M,
                                               ModuleAnalysisManager &MAM) {
-  Expected<std::unique_ptr<MCStreamer>> Streamer = CreateStreamer(TM);
-  if (!Streamer)
-    reportFatalInternalError("Failed to create MCStreamer");
-  X86AsmPrinter AsmPrinter(TM, std::move(*Streamer));
+  X86AsmPrinter &AsmPrinter = static_cast<X86AsmPrinter &>(
+      MAM.getResult<AsmPrinterAnalysis>(M).getPrinter());
   AsmPrinter.GetPSI = [&MAM](Module &M) {
     return &MAM.getResult<ProfileSummaryAnalysis>(M);
   };
@@ -1172,10 +1170,10 @@ PreservedAnalyses X86AsmPrinterBeginPass::run(Module &M,
 
 PreservedAnalyses X86AsmPrinterPass::run(MachineFunction &MF,
                                          MachineFunctionAnalysisManager &MFAM) {
-  Expected<std::unique_ptr<MCStreamer>> Streamer = CreateStreamer(TM);
-  if (!Streamer)
-    reportFatalInternalError("Failed to create MCStreamer");
-  X86AsmPrinter AsmPrinter(TM, std::move(*Streamer));
+  X86AsmPrinter &AsmPrinter = static_cast<X86AsmPrinter &>(
+      MFAM.getResult<ModuleAnalysisManagerMachineFunctionProxy>(MF)
+          .getCachedResult<AsmPrinterAnalysis>(*MF.getFunction().getParent())
+          ->getPrinter());
   AsmPrinter.GetPSI = [&MFAM, &MF](Module &M) {
     return MFAM.getResult<ModuleAnalysisManagerMachineFunctionProxy>(MF)
         .getCachedResult<ProfileSummaryAnalysis>(M);
@@ -1188,10 +1186,8 @@ PreservedAnalyses X86AsmPrinterPass::run(MachineFunction &MF,
 
 PreservedAnalyses X86AsmPrinterEndPass::run(Module &M,
                                             ModuleAnalysisManager &MAM) {
-  Expected<std::unique_ptr<MCStreamer>> Streamer = CreateStreamer(TM);
-  if (!Streamer)
-    reportFatalInternalError("Failed to create MCStreamer");
-  X86AsmPrinter AsmPrinter(TM, std::move(*Streamer));
+  X86AsmPrinter &AsmPrinter = static_cast<X86AsmPrinter &>(
+      MAM.getCachedResult<AsmPrinterAnalysis>(M)->getPrinter());
   AsmPrinter.GetPSI = [&MAM](Module &M) {
     return &MAM.getResult<ProfileSummaryAnalysis>(M);
   };

--- a/llvm/lib/Target/X86/X86AsmPrinter.h
+++ b/llvm/lib/Target/X86/X86AsmPrinter.h
@@ -207,41 +207,20 @@ public:
 
 class X86AsmPrinterBeginPass : public PassInfoMixin<X86AsmPrinterBeginPass> {
 public:
-  X86AsmPrinterBeginPass(TargetMachine &TM, CreateMCStreamer CreateStreamer)
-      : TM(TM), CreateStreamer(CreateStreamer) {}
-
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
-
-private:
-  TargetMachine &TM;
-  CreateMCStreamer CreateStreamer;
 };
 
 class X86AsmPrinterPass : public PassInfoMixin<X86AsmPrinterPass> {
 public:
-  X86AsmPrinterPass(TargetMachine &TM, CreateMCStreamer CreateStreamer)
-      : TM(TM), CreateStreamer(CreateStreamer) {}
-
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
   // AsmPrinter needs to run regardless of optimization level.
   static bool isRequired() { return true; }
-
-private:
-  TargetMachine &TM;
-  CreateMCStreamer CreateStreamer;
 };
 
 class X86AsmPrinterEndPass : public PassInfoMixin<X86AsmPrinterEndPass> {
 public:
-  X86AsmPrinterEndPass(TargetMachine &TM, CreateMCStreamer CreateStreamer)
-      : TM(TM), CreateStreamer(CreateStreamer) {}
-
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
-
-private:
-  TargetMachine &TM;
-  CreateMCStreamer CreateStreamer;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
@@ -57,12 +57,9 @@ public:
   void addPreEmitPass2(PassManagerWrapper &PMW) const;
   // TODO(boomanaiden154): We need to add addRegAssignAndRewriteOptimized here
   // once it is available to support AMX.
-  void addAsmPrinterBegin(PassManagerWrapper &PMW,
-                          CreateMCStreamer CreateStreamer) const;
-  void addAsmPrinter(PassManagerWrapper &PMW,
-                     CreateMCStreamer CreateStreamer) const;
-  void addAsmPrinterEnd(PassManagerWrapper &PMW,
-                        CreateMCStreamer CreateStreamer) const;
+  void addAsmPrinterBegin(PassManagerWrapper &PMW) const;
+  void addAsmPrinter(PassManagerWrapper &PMW) const;
+  void addAsmPrinterEnd(PassManagerWrapper &PMW) const;
 };
 
 void X86CodeGenPassBuilder::addIRPasses(PassManagerWrapper &PMW) const {
@@ -260,20 +257,17 @@ void X86CodeGenPassBuilder::addPreEmitPass2(PassManagerWrapper &PMW) const {
   }
 }
 
-void X86CodeGenPassBuilder::addAsmPrinterBegin(
-    PassManagerWrapper &PMW, CreateMCStreamer CreateStreamer) const {
-  addModulePass(X86AsmPrinterBeginPass(TM, CreateStreamer), PMW,
+void X86CodeGenPassBuilder::addAsmPrinterBegin(PassManagerWrapper &PMW) const {
+  addModulePass(X86AsmPrinterBeginPass(), PMW,
                 /*Force=*/true);
 }
 
-void X86CodeGenPassBuilder::addAsmPrinter(
-    PassManagerWrapper &PMW, CreateMCStreamer CreateStreamer) const {
-  addMachineFunctionPass(X86AsmPrinterPass(TM, CreateStreamer), PMW);
+void X86CodeGenPassBuilder::addAsmPrinter(PassManagerWrapper &PMW) const {
+  addMachineFunctionPass(X86AsmPrinterPass(), PMW);
 }
 
-void X86CodeGenPassBuilder::addAsmPrinterEnd(
-    PassManagerWrapper &PMW, CreateMCStreamer CreateStreamer) const {
-  addModulePass(X86AsmPrinterEndPass(TM, CreateStreamer), PMW, /*Force=*/true);
+void X86CodeGenPassBuilder::addAsmPrinterEnd(PassManagerWrapper &PMW) const {
+  addModulePass(X86AsmPrinterEndPass(), PMW, /*Force=*/true);
 }
 
 } // namespace
@@ -293,9 +287,10 @@ void X86TargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
 }
 
 Error X86TargetMachine::buildCodeGenPipeline(
-    ModulePassManager &MPM, raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
-    CodeGenFileType FileType, const CGPassBuilderOption &Opt, MCContext &Ctx,
+    ModulePassManager &MPM, ModuleAnalysisManager &MAM, raw_pwrite_stream &Out,
+    raw_pwrite_stream *DwoOut, CodeGenFileType FileType,
+    const CGPassBuilderOption &Opt, MCContext &Ctx,
     PassInstrumentationCallbacks *PIC) {
   auto CGPB = X86CodeGenPassBuilder(*this, Opt, PIC);
-  return CGPB.buildPipeline(MPM, Out, DwoOut, FileType, Ctx);
+  return CGPB.buildPipeline(MPM, MAM, Out, DwoOut, FileType, Ctx);
 }

--- a/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
@@ -258,8 +258,7 @@ void X86CodeGenPassBuilder::addPreEmitPass2(PassManagerWrapper &PMW) const {
 }
 
 void X86CodeGenPassBuilder::addAsmPrinterBegin(PassManagerWrapper &PMW) const {
-  addModulePass(X86AsmPrinterBeginPass(), PMW,
-                /*Force=*/true);
+  addModulePass(X86AsmPrinterBeginPass(), PMW, /*Force=*/true);
 }
 
 void X86CodeGenPassBuilder::addAsmPrinter(PassManagerWrapper &PMW) const {

--- a/llvm/lib/Target/X86/X86TargetMachine.h
+++ b/llvm/lib/Target/X86/X86TargetMachine.h
@@ -71,8 +71,8 @@ public:
 
   void registerPassBuilderCallbacks(PassBuilder &PB) override;
 
-  Error buildCodeGenPipeline(ModulePassManager &MPM, raw_pwrite_stream &Out,
-                             raw_pwrite_stream *DwoOut,
+  Error buildCodeGenPipeline(ModulePassManager &MPM, ModuleAnalysisManager &MAM,
+                             raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
                              CodeGenFileType FileType,
                              const CGPassBuilderOption &Opt, MCContext &Ctx,
                              PassInstrumentationCallbacks *PIC) override;

--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -173,9 +173,9 @@ int llvm::compileModuleWithNewPM(
     MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));
 
   } else {
-    ExitOnErr(
-        Target->buildCodeGenPipeline(MPM, *OS, DwoOut ? &DwoOut->os() : nullptr,
-                                     FileType, Opt, MMI.getContext(), &PIC));
+    ExitOnErr(Target->buildCodeGenPipeline(
+        MPM, MAM, *OS, DwoOut ? &DwoOut->os() : nullptr, FileType, Opt,
+        MMI.getContext(), &PIC));
   }
 
   // If user only wants to print the pipeline, print it before parsing the MIR.


### PR DESCRIPTION
AsmPrinter needs to hold state between doInitialization,
runOnMachineFunction, and doFinalization, which are all separate passes
in the NewPM. Storing this state externally somewhere like
MachineModuleInfo or a new analysis is possible, but a bit messy given
some state, particularly EHHandler objects, has backreferences into the
AsmPrinter and assumes there is a single AsmPrinter throughout the
entire compilation. So instead, store AsmPrinter in an analysis that
stays constant throughout compilation which solves all these problems.
This also means we can also just let AsmPrinter continue to own the
MCStreamer, which means object file emission should work after this as
well.

This does require passing the ModuleAnalysisManager into
buildCodeGenPipeline to register the AsmPrinterAnalysis, but that seems
pretty reasonable to do.
