### PR TITLE
[CIR][NFC] Add LLVM and OGCG checks to six codegen tests

### DIFF
--- a/clang/test/CIR/CodeGen/binop.c
+++ b/clang/test/CIR/CodeGen/binop.c
@@ -1,13 +1,27 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
 void conditionalResultIimplicitCast(int a, int b, float f) {
   // Should implicit cast back to int.
   int x = a && b;
-  // CHECK: %[[#INT:]] = cir.ternary
-  // CHECK: %{{.+}} = cir.cast bool_to_int %[[#INT]] : !cir.bool -> !s32i
+  // CIR: %[[#INT:]] = cir.ternary
+  // CIR: %{{.+}} = cir.cast bool_to_int %[[#INT]] : !cir.bool -> !s32i
   float y = f && f;
-  // CHECK: %[[#BOOL:]] = cir.ternary
-  // CHECK: %[[#INT:]] = cir.cast bool_to_int %[[#BOOL]] : !cir.bool -> !s32i
-  // CHECK: %{{.+}} = cir.cast int_to_float %[[#INT]] : !s32i -> !cir.float
+  // CIR: %[[#BOOL:]] = cir.ternary
+  // CIR: %[[#INT:]] = cir.cast bool_to_int %[[#BOOL]] : !cir.bool -> !s32i
+  // CIR: %{{.+}} = cir.cast int_to_float %[[#INT]] : !s32i -> !cir.float
 }
+
+// LLVM: define {{.*}}void @conditionalResultIimplicitCast(i32 {{.*}}, i32 {{.*}}, float {{.*}})
+// LLVM:   zext i1 %{{.*}} to i32
+// LLVM:   zext i1 %{{.*}} to i32
+// LLVM:   sitofp i32 %{{.*}} to float
+
+// OGCG: define {{.*}}void @conditionalResultIimplicitCast(i32 {{.*}}, i32 {{.*}}, float {{.*}})
+// OGCG:   zext i1 %{{.*}} to i32
+// OGCG:   zext i1 %{{.*}} to i32
+// OGCG:   sitofp i32 %{{.*}} to float

--- a/clang/test/CIR/CodeGen/c89-implicit-int.c
+++ b/clang/test/CIR/CodeGen/c89-implicit-int.c
@@ -1,5 +1,9 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c89 -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c89 -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c89 -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
 // Implicit int return type.
 test = 0;
@@ -9,3 +13,11 @@ func (void) {
 
 // CIR: cir.global external @test = #cir.int<0> : !s32i
 // CIR: cir.func {{.*}} @func() -> !s32i
+
+// LLVM: @test = global i32 0, align 4
+// LLVM: define dso_local i32 @func()
+// LLVM:   ret i32
+
+// OGCG: @test = global i32 0, align 4
+// OGCG: define dso_local i32 @func()
+// OGCG:   ret i32 0

--- a/clang/test/CIR/CodeGen/empty.cpp
+++ b/clang/test/CIR/CodeGen/empty.cpp
@@ -1,5 +1,9 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
 // These declarations shouldn't emit any code. Therefore the module is expected to be empty.
 
@@ -30,3 +34,9 @@ deduction_guide() -> deduction_guide<int>;
 
 // CIR: module {{.*}} {
 // CIR-NEXT: }
+
+// LLVM: target triple = "x86_64-unknown-linux-gnu"
+// LLVM-NOT: define
+
+// OGCG: target triple = "x86_64-unknown-linux-gnu"
+// OGCG-NOT: define

--- a/clang/test/CIR/CodeGen/expressions.cpp
+++ b/clang/test/CIR/CodeGen/expressions.cpp
@@ -1,5 +1,9 @@
 // RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
 void test(int a) {
   // Should generate LValue parenthesis expression.
@@ -9,3 +13,11 @@ void test(int a) {
 // CIR: cir.func {{.*}} @{{.+}}test
 // CIR: %[[CONST:.*]] = cir.const #cir.int<1> : !s32i
 // CIR: cir.store{{.*}} %[[CONST]], %{{.+}} : !s32i, !cir.ptr<!s32i>
+
+// LLVM: define dso_local void @_Z4testi(i32 noundef %0)
+// LLVM:   store i32 1, ptr %{{.+}}, align 4
+// LLVM:   ret void
+
+// OGCG: define dso_local void @_Z4testi(i32 noundef %a)
+// OGCG:   store i32 1, ptr %{{.+}}, align 4
+// OGCG:   ret void

--- a/clang/test/CIR/CodeGen/forward-enum.c
+++ b/clang/test/CIR/CodeGen/forward-enum.c
@@ -1,5 +1,9 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck %s --input-file=%t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
 extern enum X x;
 void f(void) {
@@ -11,6 +15,12 @@ enum X {
   Two
 };
 
-// CHECK: cir.global "private" external @x : !u32i
-// CHECK: cir.func{{.*}} @f
-// CHECK:   cir.get_global @x : !cir.ptr<!u32i>
+// CIR: cir.global "private" external @x : !u32i
+// CIR: cir.func{{.*}} @f
+// CIR:   cir.get_global @x : !cir.ptr<!u32i>
+
+// LLVM: @x = external global i32
+// LLVM: define {{.*}}void @f()
+
+// OGCG: @x = external global i32
+// OGCG: define {{.*}}void @f()

--- a/clang/test/CIR/CodeGen/static-vars.c
+++ b/clang/test/CIR/CodeGen/static-vars.c
@@ -1,37 +1,69 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
 void func1(void) {
   // Should lower default-initialized static vars.
   static int i;
-  // CHECK-DAG: cir.global "private" internal dso_local @func1.i = #cir.int<0> : !s32i
+  // CIR-DAG: cir.global "private" internal dso_local @func1.i = #cir.int<0> : !s32i
 
   // Should lower constant-initialized static vars.
   static int j = 1;
-  // CHECK-DAG: cir.global "private" internal dso_local @func1.j = #cir.int<1> : !s32i
+  // CIR-DAG: cir.global "private" internal dso_local @func1.j = #cir.int<1> : !s32i
 
   // Should properly shadow static vars in nested scopes.
   {
     static int j = 2;
-    // CHECK-DAG: cir.global "private" internal dso_local @func1.j.1 = #cir.int<2> : !s32i
+    // CIR-DAG: cir.global "private" internal dso_local @func1.j.1 = #cir.int<2> : !s32i
   }
   {
     static int j = 3;
-    // CHECK-DAG: cir.global "private" internal dso_local @func1.j.2 = #cir.int<3> : !s32i
+    // CIR-DAG: cir.global "private" internal dso_local @func1.j.2 = #cir.int<3> : !s32i
   }
 
   // Should lower basic static vars arithmetics.
   j++;
-  // CHECK-DAG: %[[#V2:]] = cir.get_global @func1.j : !cir.ptr<!s32i>
-  // CHECK-DAG: %[[#V3:]] = cir.load{{.*}} %[[#V2]] : !cir.ptr<!s32i>, !s32i
-  // CHECK-DAG: %[[#V4:]] = cir.inc nsw %[[#V3]] : !s32i
-  // CHECK-DAG: cir.store{{.*}} %[[#V4]], %[[#V2]] : !s32i, !cir.ptr<!s32i>
+  // CIR-DAG: %[[#V2:]] = cir.get_global @func1.j : !cir.ptr<!s32i>
+  // CIR-DAG: %[[#V3:]] = cir.load{{.*}} %[[#V2]] : !cir.ptr<!s32i>, !s32i
+  // CIR-DAG: %[[#V4:]] = cir.inc nsw %[[#V3]] : !s32i
+  // CIR-DAG: cir.store{{.*}} %[[#V4]], %[[#V2]] : !s32i, !cir.ptr<!s32i>
 }
 
 // Should shadow static vars on different functions.
 void func2(void) {
   static char i;
-  // CHECK-DAG: cir.global "private" internal dso_local @func2.i = #cir.int<0> : !s8i
+  // CIR-DAG: cir.global "private" internal dso_local @func2.i = #cir.int<0> : !s8i
   static float j;
-  // CHECK-DAG: cir.global "private" internal dso_local @func2.j = #cir.fp<0.000000e+00> : !cir.float
+  // CIR-DAG: cir.global "private" internal dso_local @func2.j = #cir.fp<0.000000e+00> : !cir.float
 }
+
+// LLVM-DAG: @func1.i = internal global i32 0
+// LLVM-DAG: @func1.j = internal global i32 1
+// LLVM-DAG: @func1.j.1 = internal global i32 2
+// LLVM-DAG: @func1.j.2 = internal global i32 3
+// LLVM-DAG: @func2.i = internal global i8 0
+// LLVM-DAG: @func2.j = internal global float 0.000000e+00
+
+// LLVM: define {{.*}}void @func1()
+// LLVM:   load i32, ptr @func1.j
+// LLVM:   add nsw i32 %{{.*}}, 1
+// LLVM:   store i32 %{{.*}}, ptr @func1.j
+
+// LLVM: define {{.*}}void @func2()
+
+// OGCG-DAG: @func1.i = internal global i32 0
+// OGCG-DAG: @func1.j = internal global i32 1
+// OGCG-DAG: @func1.j.1 = internal global i32 2
+// OGCG-DAG: @func1.j.2 = internal global i32 3
+// OGCG-DAG: @func2.i = internal global i8 0
+// OGCG-DAG: @func2.j = internal global float 0.000000e+00
+
+// OGCG: define {{.*}}void @func1()
+// OGCG:   load i32, ptr @func1.j
+// OGCG:   add nsw i32 %{{.*}}, 1
+// OGCG:   store i32 %{{.*}}, ptr @func1.j
+
+// OGCG: define {{.*}}void @func2()


### PR DESCRIPTION
Add CIR-to-LLVM and classic codegen RUN lines to empty.cpp, c89-implicit-int.c, expressions.cpp, binop.c, forward-enum.c, and static-vars.c so each test verifies LLVM IR output from both pipelines.

Made with [Cursor](https://cursor.com)