### PR TITLE
[lld][AMDGPU] Support R_AMDGPU_ABS32_(LO|HI) relocations

### DIFF
--- a/lld/ELF/Arch/AMDGPU.cpp
+++ b/lld/ELF/Arch/AMDGPU.cpp
@@ -151,6 +151,7 @@ uint32_t AMDGPU::calcEFlags() const {
 void AMDGPU::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
   switch (rel.type) {
   case R_AMDGPU_ABS32:
+  case R_AMDGPU_ABS32_LO:
   case R_AMDGPU_GOTPCREL:
   case R_AMDGPU_GOTPCREL32_LO:
   case R_AMDGPU_REL32:
@@ -161,6 +162,7 @@ void AMDGPU::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
   case R_AMDGPU_REL64:
     write64le(loc, val);
     break;
+  case R_AMDGPU_ABS32_HI:
   case R_AMDGPU_GOTPCREL32_HI:
   case R_AMDGPU_REL32_HI:
     write32le(loc, val >> 32);
@@ -180,6 +182,8 @@ RelExpr AMDGPU::getRelExpr(RelType type, const Symbol &s,
                            const uint8_t *loc) const {
   switch (type) {
   case R_AMDGPU_ABS32:
+  case R_AMDGPU_ABS32_LO:
+  case R_AMDGPU_ABS32_HI:
   case R_AMDGPU_ABS64:
     return R_ABS;
   case R_AMDGPU_REL32:
@@ -209,6 +213,16 @@ int64_t AMDGPU::getImplicitAddend(const uint8_t *buf, RelType type) const {
   switch (type) {
   case R_AMDGPU_NONE:
     return 0;
+  case R_AMDGPU_ABS32:
+  case R_AMDGPU_ABS32_LO:
+  case R_AMDGPU_ABS32_HI:
+  case R_AMDGPU_REL32:
+  case R_AMDGPU_REL32_LO:
+  case R_AMDGPU_REL32_HI:
+  case R_AMDGPU_GOTPCREL:
+  case R_AMDGPU_GOTPCREL32_LO:
+  case R_AMDGPU_GOTPCREL32_HI:
+    return SignExtend64<32>(read32(ctx, buf));
   case R_AMDGPU_ABS64:
   case R_AMDGPU_RELATIVE64:
     return read64(ctx, buf);

--- a/lld/test/ELF/amdgpu-abs32-reloc.s
+++ b/lld/test/ELF/amdgpu-abs32-reloc.s
@@ -1,0 +1,22 @@
+# REQUIRES: amdgpu
+
+# RUN: llvm-mc -filetype=obj -triple=amdgcn-- -mcpu=fiji %s -o %t.o
+# RUN: ld.lld %t.o -o %t
+# RUN: llvm-objdump -d %t | FileCheck %s
+# RUN: llvm-readelf -s -d %t | FileCheck %s --check-prefix=SYMBOL
+
+# CHECK:      <_start>:
+# CHECK-NEXT: s_mov_b32 s0, 0xfeedface
+# CHECK-NEXT: s_mov_b32 s1, 0xdeadbeef
+# CHECK-NEXT: s_endpgm
+
+# SYMBOL: deadbeeffeedface     0 NOTYPE  GLOBAL DEFAULT   ABS sym
+
+.globl sym
+sym = 0xdeadbeeffeedface
+
+.globl _start
+_start:
+  s_mov_b32 s0, sym@abs32@lo
+  s_mov_b32 s1, sym@abs32@hi
+  s_endpgm


### PR DESCRIPTION
Summary:
These relocations are extremely rare, but they are listed as an expected
relocation in https://llvm.org/docs/AMDGPUUsage.html#relocation-records
and you can theoretically make them happen so we should probably support
it in the linker.
