### PR TITLE
[clang][test] Fix 32-bit bot failures after cc419f185e13

### DIFF
--- a/clang/test/CodeGen/2004-02-13-Memset.c
+++ b/clang/test/CodeGen/2004-02-13-Memset.c
@@ -5,8 +5,8 @@ void *memset(void*, int, size_t);
 void bzero(void*, size_t);
 
 void test(int* X, char *Y) {
-  // CHECK: call void @llvm.memset{{.*}}i8 4, i64 1000
+  // CHECK: call void @llvm.memset{{.*}}i8 4, {{.*}} 1000
   memset(X, 4, 1000);
-  // CHECK: call void @llvm.memset{{.*}}i8 0, i64 100
+  // CHECK: call void @llvm.memset{{.*}}i8 0, {{.*}} 100
   bzero(Y, 100);
 }


### PR DESCRIPTION
Use `{{.*}}` instead of `i64` for `memset` size type, as 32-bit platforms use `i32`.