### PR TITLE
[CMake] Pass ZLIB_LIBRARY_* to runtimes bootstrap

### DIFF
--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -179,6 +179,8 @@ function(llvm_ExternalProject_Add name source_dir)
     LibEdit_LIBRARIES
     ZLIB_INCLUDE_DIR
     ZLIB_LIBRARY
+    ZLIB_LIBRARY_RELEASE
+    ZLIB_LIBRARY_DEBUG
     zstd_INCLUDE_DIR
     zstd_LIBRARY
     LIBXML2_LIBRARY

--- a/llvm/utils/release/build_llvm_release.bat
+++ b/llvm/utils/release/build_llvm_release.bat
@@ -246,6 +246,7 @@ set cmake_flags=^
   -DLIBXML2_LIBRARIES=%libxmldir%/lib/libxml2s.lib ^
   -DZLIB_INCLUDE_DIR=%zlibdir%/include ^
   -DZLIB_LIBRARY=%zlibdir%/lib/zs.lib ^
+  -DZLIB_LIBRARY_RELEASE=%zlibdir%/lib/zs.lib ^
   -Dzstd_INCLUDE_DIR=%zstddir%/include ^
   -Dzstd_LIBRARY=%zstddir%/lib/zstd_static.lib
 
@@ -312,6 +313,7 @@ set cmake_flags=^
   -DLIBXML2_LIBRARIES=%libxmldir%/lib/libxml2s.lib ^
   -DZLIB_INCLUDE_DIR=%zlibdir%/include ^
   -DZLIB_LIBRARY=%zlibdir%/lib/zs.lib ^
+  -DZLIB_LIBRARY_RELEASE=%zlibdir%/lib/zs.lib ^
   -Dzstd_INCLUDE_DIR=%zstddir%/include ^
   -Dzstd_LIBRARY=%zstddir%/lib/zstd_static.lib ^
   -DCLANG_DEFAULT_LINKER=lld


### PR DESCRIPTION
Runtimes external project (compiler-rt / combined runtimes) reconfigures with an initial cache that did not propagate `ZLIB_LIBRARY_RELEASE`. CMake 4.x `FindZLIB` may leave `ZLIB_LIBRARY` unset while finding headers, leading to:
```
   -- Could NOT find ZLIB (missing: ZLIB_LIBRARY) (found version "...")
```
and later when loading LLVM exports from the main build:
```
   The link interface of target "LLVMSupport" contains: ZLIB::ZLIB
   but the target was not found.
```
This was found by building the Windows installer with:
```
llvm\utils\release\build_llvm_release.bat --x64 --version 23.0.0 --skip-checkout --local-python
```