### PR TITLE
[openmp] Silence warnings when building on Windows

### DIFF
--- a/openmp/runtime/src/kmp_alloc.cpp
+++ b/openmp/runtime/src/kmp_alloc.cpp
@@ -1235,27 +1235,29 @@ void ___kmp_thread_free(kmp_info_t *th, void *ptr KMP_SRC_LOC_DECL) {
 }
 
 /* OMP 5.0 Memory Management support */
-static const char *kmp_mk_lib_name;
-static void *h_memkind;
 /* memkind experimental API: */
 // memkind_alloc
 static void *(*kmp_mk_alloc)(void *k, size_t sz);
 // memkind_free
 static void (*kmp_mk_free)(void *kind, void *ptr);
-// memkind_check_available
-static int (*kmp_mk_check)(void *kind);
 // kinds we are going to use
 static void **mk_default;
 static void **mk_interleave;
-static void **mk_hbw;
 static void **mk_hbw_interleave;
 static void **mk_hbw_preferred;
+static void **mk_dax_kmem;
+static void **mk_dax_kmem_all;
+#if KMP_OS_UNIX && KMP_DYNAMIC_LIB && !KMP_OS_DARWIN
+static const char *kmp_mk_lib_name;
+static void *h_memkind;
+// memkind_check_available
+static int (*kmp_mk_check)(void *kind);
+static void **mk_hbw;
 static void **mk_hugetlb;
 static void **mk_hbw_hugetlb;
 static void **mk_hbw_preferred_hugetlb;
-static void **mk_dax_kmem;
-static void **mk_dax_kmem_all;
 static void **mk_dax_kmem_preferred;
+#endif
 static void *(*kmp_target_alloc_host)(size_t size, int device);
 static void *(*kmp_target_alloc_shared)(size_t size, int device);
 static void *(*kmp_target_alloc_device)(size_t size, int device);
@@ -1500,24 +1502,23 @@ void __kmp_init_memkind() {
     }
     dlclose(h_memkind); // failure
   }
-#else // !(KMP_OS_UNIX && KMP_DYNAMIC_LIB)
-  kmp_mk_lib_name = "";
-#endif // !(KMP_OS_UNIX && KMP_DYNAMIC_LIB)
   h_memkind = NULL;
   kmp_mk_check = NULL;
+  mk_hbw = NULL;
+  mk_hugetlb = NULL;
+  mk_hbw_hugetlb = NULL;
+  mk_hbw_preferred_hugetlb = NULL;
+  mk_dax_kmem_preferred = NULL;
+  kmp_mk_lib_name = "";
+#endif // !(KMP_OS_UNIX && KMP_DYNAMIC_LIB)
   kmp_mk_alloc = NULL;
   kmp_mk_free = NULL;
   mk_default = NULL;
   mk_interleave = NULL;
-  mk_hbw = NULL;
   mk_hbw_interleave = NULL;
   mk_hbw_preferred = NULL;
-  mk_hugetlb = NULL;
-  mk_hbw_hugetlb = NULL;
-  mk_hbw_preferred_hugetlb = NULL;
   mk_dax_kmem = NULL;
   mk_dax_kmem_all = NULL;
-  mk_dax_kmem_preferred = NULL;
 }
 
 void __kmp_fini_memkind() {
@@ -1529,19 +1530,19 @@ void __kmp_fini_memkind() {
     h_memkind = NULL;
   }
   kmp_mk_check = NULL;
+  mk_hbw = NULL;
+  mk_hugetlb = NULL;
+  mk_hbw_hugetlb = NULL;
+  mk_hbw_preferred_hugetlb = NULL;
+  mk_dax_kmem_preferred = NULL;
   kmp_mk_alloc = NULL;
   kmp_mk_free = NULL;
   mk_default = NULL;
   mk_interleave = NULL;
-  mk_hbw = NULL;
   mk_hbw_interleave = NULL;
   mk_hbw_preferred = NULL;
-  mk_hugetlb = NULL;
-  mk_hbw_hugetlb = NULL;
-  mk_hbw_preferred_hugetlb = NULL;
   mk_dax_kmem = NULL;
   mk_dax_kmem_all = NULL;
-  mk_dax_kmem_preferred = NULL;
 #endif
 }
 


### PR DESCRIPTION
Fixes unused-but-set globals on non-Unix paths in kmp_alloc.cpp