### PR TITLE
[mlir] Silence warnings on Windows

### DIFF
--- a/mlir/include/mlir/Dialect/Complex/IR/Complex.h
+++ b/mlir/include/mlir/Dialect/Complex/IR/Complex.h
@@ -15,6 +15,7 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "llvm/Support/Compiler.h"
 
 //===----------------------------------------------------------------------===//
 // Complex Dialect
@@ -35,7 +36,11 @@
 #define GET_OP_CLASSES
 #include "mlir/Dialect/Complex/IR/ComplexOps.h.inc"
 
+// std::complex<APFloat> is a non-standard instantiation that triggers
+// MSVC STL4037 deprecation warnings in the generated attribute code.
+LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/Complex/IR/ComplexAttributes.h.inc"
+LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
 
 #endif // MLIR_DIALECT_COMPLEX_IR_COMPLEX_H_

--- a/mlir/include/mlir/IR/BuiltinAttributes.h
+++ b/mlir/include/mlir/IR/BuiltinAttributes.h
@@ -12,6 +12,7 @@
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/Sequence.h"
+#include "llvm/Support/Compiler.h"
 #include <complex>
 #include <optional>
 
@@ -294,6 +295,10 @@ public:
     size_t bitWidth;
   };
 
+  // std::complex<APInt> and std::complex<APFloat> are non-standard
+  // instantiations that trigger MSVC STL4037 deprecation warnings.
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
+
   /// A utility iterator that allows walking over the internal raw complex APInt
   /// values.
   class ComplexIntElementIterator
@@ -357,6 +362,8 @@ public:
     /// The float semantics to use when constructing the APFloat.
     const llvm::fltSemantics *smt;
   };
+
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
 
   //===--------------------------------------------------------------------===//
   // Value Querying

--- a/mlir/lib/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/IR/BuiltinAttributes.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/Support/Compiler.h"
+LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
 #include "mlir/IR/BuiltinAttributes.h"
 #include "AttributeDetail.h"
 #include "mlir/IR/AffineMap.h"
@@ -1698,3 +1700,4 @@ AffineMap mlir::makeStridedLinearLayoutMap(ArrayRef<int64_t> strides,
 
   return AffineMap::get(strides.size(), nSymbols, expr);
 }
+LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP

--- a/mlir/unittests/IR/AttributeTest.cpp
+++ b/mlir/unittests/IR/AttributeTest.cpp
@@ -10,6 +10,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "llvm/Support/Compiler.h"
 #include "gtest/gtest.h"
 #include <optional>
 
@@ -198,21 +199,27 @@ TEST(DenseComplexTest, ComplexFloatSplat) {
 TEST(DenseComplexTest, ComplexIntSplat) {
   MLIRContext context;
   ComplexType complexType = ComplexType::get(IntegerType::get(&context, 64));
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
   std::complex<int64_t> value(10, 15);
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
   testSplat(complexType, value);
 }
 
 TEST(DenseComplexTest, ComplexAPFloatSplat) {
   MLIRContext context;
   ComplexType complexType = ComplexType::get(Float32Type::get(&context));
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
   std::complex<APFloat> value(APFloat(10.0f), APFloat(15.0f));
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
   testSplat(complexType, value);
 }
 
 TEST(DenseComplexTest, ComplexAPIntSplat) {
   MLIRContext context;
   ComplexType complexType = ComplexType::get(IntegerType::get(&context, 64));
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
   std::complex<APInt> value(APInt(64, 10), APInt(64, 15));
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
   testSplat(complexType, value);
 }
 


### PR DESCRIPTION
MSVC STL4037 deprecates `std::complex` with non-floating-point element types.

This fixes:
```
warning: 'complex' is deprecated: warning STL4037: ...
```