### PR TITLE
[mlir] Silence warnings on unit tests on Windows

### DIFF
--- a/mlir/unittests/CMakeLists.txt
+++ b/mlir/unittests/CMakeLists.txt
@@ -1,5 +1,8 @@
-# To silence warning caused by Wundef.
-add_definitions(-DGTEST_NO_LLVM_SUPPORT=0)
+# To silence warnings caused by -Wundef in gtest/gmock headers.
+add_definitions(
+  -DGTEST_NO_LLVM_SUPPORT=0
+  -DGTEST_LINKED_AS_SHARED_LIBRARY=0
+  -DGTEST_CREATE_SHARED_LIBRARY=0)
 
 function(add_mlir_unittest test_dirname)
   add_unittest(MLIRUnitTests ${test_dirname} ${ARGN})


### PR DESCRIPTION
MLIR unit tests use `-Wundef`; gtest headers reference macros that may be unset:
```
warning: 'GTEST_LINKED_AS_SHARED_LIBRARY' is not defined, evaluates to 0 [-Wundef]
```