### PR TITLE
[compiler-rt] clang-cl: skip MSVC external-header probe; -std=c++ for unit-test compiles

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTCompile.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTCompile.cmake
@@ -101,6 +101,17 @@ function(clang_compile object_file source)
     set(compile_flags ${SOURCE_CFLAGS})
   endif()
 
+  # CMAKE_CXX_STANDARD is not propagated to these custom compile commands
+  # (add_custom_command). Add it explicitly for C++ files so that C++17
+  # features used in headers (e.g. if constexpr) don't trigger warnings.
+  if(is_cxx)
+    if(CMAKE_CXX_STANDARD)
+      list(APPEND compile_flags "-std=c++${CMAKE_CXX_STANDARD}")
+    else()
+      list(APPEND compile_flags "-std=c++17")
+    endif()
+  endif()
+
   string(REGEX MATCH "[.](m|mm)$" is_objc ${source_rpath})
   if (is_objc)
     list(APPEND compile_flags "-ObjC")

--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -153,7 +153,11 @@ check_cxx_compiler_flag(-Wno-pedantic COMPILER_RT_HAS_WNO_PEDANTIC)
 check_cxx_compiler_flag(-Wno-format COMPILER_RT_HAS_WNO_FORMAT)
 check_cxx_compiler_flag(-Wno-format-pedantic COMPILER_RT_HAS_WNO_FORMAT_PEDANTIC)
 
-check_cxx_compiler_flag("/experimental:external /external:W0" COMPILER_RT_HAS_EXTERNAL_FLAG)
+if(MSVC AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  check_cxx_compiler_flag("/experimental:external /external:W0" COMPILER_RT_HAS_EXTERNAL_FLAG)
+else()
+  set(COMPILER_RT_HAS_EXTERNAL_FLAG FALSE)
+endif()
 
 check_cxx_compiler_flag(/W4 COMPILER_RT_HAS_W4_FLAG)
 check_cxx_compiler_flag(/WX COMPILER_RT_HAS_WX_FLAG)

--- a/compiler-rt/lib/asan/CMakeLists.txt
+++ b/compiler-rt/lib/asan/CMakeLists.txt
@@ -120,9 +120,7 @@ set(ASAN_COMMON_DEFINITIONS "")
 append_rtti_flag(OFF ASAN_CFLAGS)
 
 # Silence warnings in system headers with MSVC.
-if(NOT CLANG_CL)
-  append_list_if(COMPILER_RT_HAS_EXTERNAL_FLAG "/experimental:external;/external:W0;/external:anglebrackets" ASAN_CFLAGS)
-endif()
+append_list_if(COMPILER_RT_HAS_EXTERNAL_FLAG "/experimental:external;/external:W0;/external:anglebrackets" ASAN_CFLAGS)
 
 # Too many existing bugs, needs cleanup.
 append_list_if(COMPILER_RT_HAS_WNO_FORMAT -Wno-format ASAN_CFLAGS)

--- a/compiler-rt/lib/interception/CMakeLists.txt
+++ b/compiler-rt/lib/interception/CMakeLists.txt
@@ -30,9 +30,7 @@ set(INTERCEPTION_CFLAGS ${SANITIZER_COMMON_CFLAGS})
 append_rtti_flag(OFF INTERCEPTION_CFLAGS)
 
 # Silence warnings in system headers with MSVC.
-if(NOT CLANG_CL)
-  append_list_if(COMPILER_RT_HAS_EXTERNAL_FLAG "/experimental:external;/external:W0;/external:anglebrackets" INTERCEPTION_CFLAGS)
-endif()
+append_list_if(COMPILER_RT_HAS_EXTERNAL_FLAG "/experimental:external;/external:W0;/external:anglebrackets" INTERCEPTION_CFLAGS)
 
 add_compiler_rt_object_libraries(RTInterception
     OS ${SANITIZER_COMMON_SUPPORTED_OS}

--- a/compiler-rt/lib/ubsan/CMakeLists.txt
+++ b/compiler-rt/lib/ubsan/CMakeLists.txt
@@ -59,9 +59,7 @@ set(UBSAN_CXXFLAGS ${SANITIZER_COMMON_CFLAGS})
 append_rtti_flag(ON UBSAN_CXXFLAGS)
 
 # Silence warnings in system headers with MSVC.
-if(NOT CLANG_CL)
-  append_list_if(COMPILER_RT_HAS_EXTERNAL_FLAG "/experimental:external;/external:W0;/external:anglebrackets" UBSAN_CXXFLAGS)
-endif()
+append_list_if(COMPILER_RT_HAS_EXTERNAL_FLAG "/experimental:external;/external:W0;/external:anglebrackets" UBSAN_CXXFLAGS)
 
 set(UBSAN_LINK_FLAGS ${SANITIZER_COMMON_LINK_FLAGS})
 


### PR DESCRIPTION
1. `check_cxx_compiler_flag` marked `COMPILER_RT_HAS_EXTERNAL_FLAG` true for clang-cl, so `/experimental:external` and `/external:anglebrackets` were passed and clang-cl warned they were unused. Now only probe with real MSVC (not Clang); set the flag false otherwise; rely on that in asan/interception/ubsan.

2. Custom compile lines for unit tests didn’t get C++17, so headers hit `-Wc++17-extensions` (e.g. `constexpr if` / message-less `static_assert` in FuzzedDataProvider / asan_fake_stack). Now append `-std=c++${CMAKE_CXX_STANDARD}` or `-std=c++17` for C++ sources in `clang_compile()` for both standalone and non-standalone builds.