### PR TITLE
[LLDB] On Windows, fix Python lib path

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
@@ -52,3 +52,8 @@ add_lldb_library(lldbPluginScriptInterpreterPython PLUGIN
 
 target_include_directories(lldbPluginScriptInterpreterPython
   PUBLIC ${Python3_INCLUDE_DIRS})
+
+if(Python3_LIBRARY_DIRS)
+  target_link_directories(lldbPluginScriptInterpreterPython
+    PUBLIC ${Python3_LIBRARY_DIRS})
+endif()


### PR DESCRIPTION
When `LLDB_ENABLE_PYTHON_LIMITED_API` is ON (which defaults to ON with SWIG >= 4.2 and `LLDB_EMBED_PYTHON_HOME=OFF`), LLDB defines `Py_LIMITED_API`. This causes Python's `pyconfig.h` to emit:
```
#pragma comment(lib, "python3.lib")
```
This is the Windows MSVC auto-link directive for the Python Stable ABI import library. CMake's `FindPython3` correctly found and linked the version-specific `python313.lib` (with full path), but the `#pragma comment(lib)` adds an *additional* implicit link dependency on `python3.lib` using just the bare filename. The linker can't find it because the Python `libs` directory isn't in the default library search path.

This PR adds `target_link_directories` for `Python3_LIBRARY_DIRS` in `lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt`. This ensures the linker can find `python3.lib` (and any other Python libraries) in the Python installation's `libs` directory. The `PUBLIC` visibility propagates this to `liblldb.dll` which is where the actual link failure occurs.