### PR TITLE
[LLDB] Silence warnings when building on Windows

### DIFF
--- a/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
+++ b/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
@@ -19,6 +19,8 @@
 
 using namespace llvm;
 
+#if defined(LLDB_PYTHON_DLL_RELATIVE_PATH) ||                                  \
+    defined(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME)
 static std::string GetModulePath(HMODULE module) {
   std::vector<WCHAR> buffer(MAX_PATH);
   while (buffer.size() <= PATHCCH_MAX_CCH) {
@@ -36,11 +38,12 @@ static std::string GetModulePath(HMODULE module) {
   }
   return "";
 }
+#endif
 
+#ifdef LLDB_PYTHON_DLL_RELATIVE_PATH
 /// Returns the full path to the lldb.exe executable.
 static std::string GetPathToExecutable() { return GetModulePath(NULL); }
 
-#ifdef LLDB_PYTHON_DLL_RELATIVE_PATH
 bool AddPythonDLLToSearchPath() {
   std::string path_str = GetPathToExecutable();
   if (path_str.empty())

--- a/lldb/tools/lldb-dap/RunInTerminal.cpp
+++ b/lldb/tools/lldb-dap/RunInTerminal.cpp
@@ -171,7 +171,7 @@ Expected<std::shared_ptr<FifoFile>> CreateRunInTerminalCommFile() {
   SmallString<256> comm_file;
 #if _WIN32
   char pipe_name[MAX_PATH];
-  sprintf(pipe_name, "\\\\.\\pipe\\lldb-dap-run-in-terminal-comm-%d",
+  sprintf(pipe_name, "\\\\.\\pipe\\lldb-dap-run-in-terminal-comm-%lu",
           GetCurrentProcessId());
   return CreateFifoFile(pipe_name);
 #else

--- a/lldb/unittests/Platform/TestUtils.cpp
+++ b/lldb/unittests/Platform/TestUtils.cpp
@@ -36,6 +36,7 @@ std::string lldb_private::CreateFile(llvm::StringRef filename,
   int fd;
   std::error_code ret = llvm::sys::fs::openFileForWrite(path, fd);
   assert(!ret && "Failed to create test file.");
+  (void)ret;
   ::close(fd);
 
   return path.c_str();

--- a/lldb/unittests/Platform/TestUtils.cpp
+++ b/lldb/unittests/Platform/TestUtils.cpp
@@ -36,7 +36,7 @@ std::string lldb_private::CreateFile(llvm::StringRef filename,
   int fd;
   std::error_code ret = llvm::sys::fs::openFileForWrite(path, fd);
   assert(!ret && "Failed to create test file.");
-  (void)ret;
+  [[maybe_unused]] ret;
   ::close(fd);
 
   return path.c_str();

--- a/lldb/unittests/Platform/TestUtils.cpp
+++ b/lldb/unittests/Platform/TestUtils.cpp
@@ -36,7 +36,7 @@ std::string lldb_private::CreateFile(llvm::StringRef filename,
   int fd;
   std::error_code ret = llvm::sys::fs::openFileForWrite(path, fd);
   assert(!ret && "Failed to create test file.");
-  [[maybe_unused]] ret;
+  (void)ret;
   ::close(fd);
 
   return path.c_str();


### PR DESCRIPTION
Fixes a few warnings found while building the LLVM installer with `llvm/utils/release/build_llvm_release.bat --x64 --version 23.0.0 --skip-checkout --local-python`.