### PR TITLE
[clang-doc] Initialize member variable

### DIFF
--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -747,7 +747,7 @@ struct ConceptInfo : public SymbolInfo, public llvm::ilist_node<ConceptInfo> {
 
   void merge(ConceptInfo &&I);
 
-  bool IsType;
+  bool IsType = false;
   TemplateInfo Template;
   StringRef ConstraintExpression;
 };


### PR DESCRIPTION
We don't always initialize the IsType field in the current
implementation. We can ensure this field is always initialized to
`false`, and avoid any UB due to garbage data.