### PR TITLE
[GlobalISel] use constexpr LLT types when creating ISel data

### DIFF
--- a/llvm/test/TableGen/GlobalISelEmitter/GlobalISelEmitter.td
+++ b/llvm/test/TableGen/GlobalISelEmitter/GlobalISelEmitter.td
@@ -117,8 +117,8 @@ def HasC : Predicate<"Subtarget->hasC()"> { let RecomputePerFunction = 1; }
 // EXTENDED-NEXT:  };
 // EXTENDED-NEXT:  const static size_t NumTypeObjects = 3;
 // EXTENDED-NEXT:  const static LLT TypeObjects[] = {
-// EXTENDED-NEXT:    LLT::integer(32),
-// EXTENDED-NEXT:    LLT::floatIEEE(32),
+// EXTENDED-NEXT:    LLT(LLT::Kind::INTEGER, ElementCount::getFixed(0), 32),
+// EXTENDED-NEXT:    LLT(LLT::Kind::FLOAT, ElementCount::getFixed(0), 32, LLT::FpSemantics::S_IEEEsingle),
 // EXTENDED-NEXT:    LLT::pointer(0, 32),
 // EXTENDED-NEXT:  };
 

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -409,19 +409,37 @@ void LLTCodeGen::emitCxxEnumValue(raw_ostream &OS) const {
 }
 
 void LLTCodeGen::emitCxxConstructorCall(raw_ostream &OS) const {
-  if (Ty.isScalar()) {
-    if (Ty.isInteger())
-      OS << "LLT::integer(" << Ty.getScalarSizeInBits() << ")";
-    else if (Ty.isBFloat16())
-      OS << "LLT::bfloat16()";
-    else if (Ty.isPPCF128())
-      OS << "LLT::ppcf128()";
-    else if (Ty.isX86FP80())
-      OS << "LLT::x86fp80()";
-    else if (Ty.isFloat())
-      OS << "LLT::floatIEEE(" << Ty.getScalarSizeInBits() << ")";
+  auto EmitScalarType = [&OS](LLT T) {
+    if (T.isInteger())
+      OS << "LLT(LLT::Kind::INTEGER, ElementCount::getFixed(0), "
+         << T.getScalarSizeInBits() << ")";
+    else if (T.isBFloat16())
+      OS << "LLT(LLT::Kind::FLOAT, ElementCount::getFixed(0), 16, "
+            "LLT::FpSemantics::S_BFloat)";
+    else if (T.isPPCF128())
+      OS << "LLT(LLT::Kind::FLOAT, ElementCount::getFixed(0), 128, "
+            "LLT::FpSemantics::S_PPCDoubleDouble)";
+    else if (T.isX86FP80())
+      OS << "LLT(LLT::Kind::FLOAT, ElementCount::getFixed(0), 80, "
+            "LLT::FpSemantics::S_x87DoubleExtended)";
+    else if (T.isFloat(16))
+      OS << "LLT(LLT::Kind::FLOAT, ElementCount::getFixed(0), 16, "
+            "LLT::FpSemantics::S_IEEEhalf)";
+    else if (T.isFloat(32))
+      OS << "LLT(LLT::Kind::FLOAT, ElementCount::getFixed(0), 32, "
+            "LLT::FpSemantics::S_IEEEsingle)";
+    else if (T.isFloat(64))
+      OS << "LLT(LLT::Kind::FLOAT, ElementCount::getFixed(0), 64, "
+            "LLT::FpSemantics::S_IEEEdouble)";
+    else if (T.isFloat(128))
+      OS << "LLT(LLT::Kind::FLOAT, ElementCount::getFixed(0), 128, "
+            "LLT::FpSemantics::S_IEEEquad)";
     else
-      OS << "LLT::scalar(" << Ty.getScalarSizeInBits() << ")";
+      OS << "LLT::scalar(" << T.getScalarSizeInBits() << ")";
+  };
+
+  if (Ty.isScalar()) {
+    EmitScalarType(Ty);
     return;
   }
 
@@ -430,20 +448,7 @@ void LLTCodeGen::emitCxxConstructorCall(raw_ostream &OS) const {
        << (Ty.isScalable() ? "ElementCount::getScalable("
                            : "ElementCount::getFixed(")
        << Ty.getElementCount().getKnownMinValue() << "), ";
-
-    LLT ElemTy = Ty.getElementType();
-    if (ElemTy.isInteger())
-      OS << "LLT::integer(" << ElemTy.getScalarSizeInBits() << ")";
-    else if (ElemTy.isBFloat16())
-      OS << "LLT::bfloat16()";
-    else if (ElemTy.isPPCF128())
-      OS << "LLT::ppcf128()";
-    else if (ElemTy.isX86FP80())
-      OS << "LLT::x86fp80()";
-    else if (ElemTy.isFloat())
-      OS << "LLT::floatIEEE(" << ElemTy.getScalarSizeInBits() << ")";
-    else
-      OS << "LLT::scalar(" << Ty.getScalarSizeInBits() << ")";
+    EmitScalarType(Ty.getElementType());
     OS << ")";
     return;
   }


### PR DESCRIPTION
The GlobalISel uses a lookup table to map LLTs which is constructed
prior to initialization of extended LLT functionality, resulting in
ANY_SCALAR entries. During instruction selection, a hash-based
lookup is done on actual INTEGER/FLOAT LLTs. But hash values of
ANY_SCALAR do not match those of INTEGER/FLOAT, causing a failure.

Workaround is the use constexpr LLT, which encodes INTEGER/FLOAT LLT.

Assisted-by: Claude Opus 4.6