### PR TITLE
[Analysis] keep track of constant scalable offsets for scalable vectors

### DIFF
--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -558,12 +558,14 @@ struct VariableGEPIndex {
 }
 
 // Represents the internal structure of a GEP, decomposed into a base pointer,
-// constant offsets, and variable scaled indices.
+// constant offsets, scalable offsets, and variable scaled indices.
 struct BasicAAResult::DecomposedGEP {
   // Base pointer of the GEP
   const Value *Base;
   // Total constant offset from base.
   APInt Offset;
+  // Total scalable offset from base, in units of vscale.
+  APInt ScalableOffset;
   // Scaled variable (non-constant) indices.
   SmallVector<VariableGEPIndex, 4> VarIndices;
   // Nowrap flags common to all GEP operations involved in expression.
@@ -577,7 +579,7 @@ struct BasicAAResult::DecomposedGEP {
     OS << ", inbounds=" << (NWFlags.isInBounds() ? "1" : "0")
        << ", nuw=" << (NWFlags.hasNoUnsignedWrap() ? "1" : "0")
        << "(DecomposedGEP Base=" << Base->getName() << ", Offset=" << Offset
-       << ", VarIndices=[";
+       << ", ScalableOffset=" << ScalableOffset << ", VarIndices=[";
     for (size_t i = 0; i < VarIndices.size(); i++) {
       if (i != 0)
         OS << ", ";
@@ -606,6 +608,7 @@ BasicAAResult::DecomposeGEPExpression(const Value *V, const DataLayout &DL,
   unsigned IndexSize = DL.getIndexTypeSizeInBits(V->getType());
   DecomposedGEP Decomposed;
   Decomposed.Offset = APInt(IndexSize, 0);
+  Decomposed.ScalableOffset = APInt(IndexSize, 0);
   do {
     // See if this is a bitcast or GEP.
     const Operator *Op = dyn_cast<Operator>(V);
@@ -690,11 +693,13 @@ BasicAAResult::DecomposeGEPExpression(const Value *V, const DataLayout &DL,
         if (CIdx->isZero())
           continue;
 
-        // Don't attempt to analyze GEPs if the scalable index is not zero.
+        // Track the implicit vscale factor separately for scalable strides.
         TypeSize AllocTypeSize = GTI.getSequentialElementStride(DL);
         if (AllocTypeSize.isScalable()) {
-          Decomposed.Base = V;
-          return Decomposed;
+          Decomposed.ScalableOffset +=
+              APInt(IndexSize, AllocTypeSize.getKnownMinValue()) *
+              CIdx->getValue().sextOrTrunc(IndexSize);
+          continue;
         }
 
         Decomposed.Offset += AllocTypeSize.getFixedValue() *
@@ -1147,21 +1152,22 @@ AliasResult BasicAAResult::aliasGEP(
   // size
 
   if (DecompGEP1.NWFlags.isInBounds() && DecompGEP1.VarIndices.empty() &&
-      V2Size.hasValue() && !V2Size.isScalable() &&
-      DecompGEP1.Offset.sge(V2Size.getValue()) &&
+      DecompGEP1.ScalableOffset == 0 && V2Size.hasValue() &&
+      !V2Size.isScalable() && DecompGEP1.Offset.sge(V2Size.getValue()) &&
       isBaseOfObject(DecompGEP2.Base))
     return AliasResult::NoAlias;
 
   // Symmetric case to above.
   if (DecompGEP2.NWFlags.isInBounds() && DecompGEP1.VarIndices.empty() &&
-      V1Size.hasValue() && !V1Size.isScalable() &&
-      DecompGEP1.Offset.sle(-V1Size.getValue()) &&
+      DecompGEP1.ScalableOffset == 0 && V1Size.hasValue() &&
+      !V1Size.isScalable() && DecompGEP1.Offset.sle(-V1Size.getValue()) &&
       isBaseOfObject(DecompGEP1.Base))
     return AliasResult::NoAlias;
 
   // For GEPs with identical offsets, we can preserve the size and AAInfo
   // when performing the alias check on the underlying objects.
-  if (DecompGEP1.Offset == 0 && DecompGEP1.VarIndices.empty())
+  if (DecompGEP1.Offset == 0 && DecompGEP1.ScalableOffset == 0 &&
+      DecompGEP1.VarIndices.empty())
     return AAQI.AAR.alias(MemoryLocation(DecompGEP1.Base, V1Size),
                           MemoryLocation(DecompGEP2.Base, V2Size), AAQI);
 
@@ -1177,6 +1183,12 @@ AliasResult BasicAAResult::aliasGEP(
            BaseAlias == AliasResult::MayAlias);
     return BaseAlias;
   }
+
+  // The remaining checks reason about fixed constant offsets or explicit
+  // variable indices. Do not apply them if an implicit scalable GEP offset
+  // remains after subtracting the two decomposed GEPs.
+  if (DecompGEP1.ScalableOffset != 0)
+    return AliasResult::MayAlias;
 
   // If there is a constant difference between the pointers, but the difference
   // is less than the size of the associated memory object, then we know
@@ -1929,6 +1941,7 @@ void BasicAAResult::subtractDecomposedGEPs(DecomposedGEP &DestGEP,
     DestGEP.NWFlags = DestGEP.NWFlags.withoutNoUnsignedWrap();
 
   DestGEP.Offset -= SrcGEP.Offset;
+  DestGEP.ScalableOffset -= SrcGEP.ScalableOffset;
   for (const VariableGEPIndex &Src : SrcGEP.VarIndices) {
     // Find V in Dest.  This is N^2, but pointer indices almost never have more
     // than a few variable indexes.

--- a/llvm/test/Analysis/BasicAA/vscale.ll
+++ b/llvm/test/Analysis/BasicAA/vscale.ll
@@ -668,3 +668,33 @@ define void @gep_2048_vscalerange(ptr %p) vscale_range(1,16) {
   load <vscale x 4 x i32>, ptr %noff256
   ret void
 }
+
+; Two GEPs with different scalable vector types but the same known-minimum
+; stride (both 16 bytes/vscale). ScalableOffset cancels after subtraction,
+; so they resolve to MustAlias.
+; <vscale x 4 x i32>: known-min stride = 4 * 4 = 16 bytes
+; <vscale x 2 x i64>: known-min stride = 2 * 8 = 16 bytes
+; CHECK-LABEL: gep_mismatched_scalable_strides_same_size
+; CHECK-DAG:   MustAlias:    <vscale x 4 x i32>* %gep1, <vscale x 2 x i64>* %gep2
+define void @gep_mismatched_scalable_strides_same_size(ptr %p) {
+  %gep1 = getelementptr <vscale x 4 x i32>, ptr %p, i64 1
+  %gep2 = getelementptr <vscale x 2 x i64>, ptr %p, i64 1
+  load <vscale x 4 x i32>, ptr %gep1
+  load <vscale x 2 x i64>, ptr %gep2
+  ret void
+}
+
+; Two GEPs with different scalable vector types and different known-minimum
+; strides. ScalableOffset does not cancel after subtraction, so the result
+; is conservatively MayAlias.
+; <vscale x 4 x i32>: known-min stride = 4 * 4 = 16 bytes
+; <vscale x 4 x i64>: known-min stride = 4 * 8 = 32 bytes
+; CHECK-LABEL: gep_mismatched_scalable_strides_diff_size
+; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %gep1, <vscale x 4 x i64>* %gep2
+define void @gep_mismatched_scalable_strides_diff_size(ptr %p) {
+  %gep1 = getelementptr <vscale x 4 x i32>, ptr %p, i64 1
+  %gep2 = getelementptr <vscale x 4 x i64>, ptr %p, i64 1
+  load <vscale x 4 x i32>, ptr %gep1
+  load <vscale x 4 x i64>, ptr %gep2
+  ret void
+}

--- a/llvm/test/Analysis/BasicAA/vscale.ll
+++ b/llvm/test/Analysis/BasicAA/vscale.ll
@@ -19,8 +19,7 @@ define void @gep_alloca_const_offset_1() {
 ; CHECK-LABEL: gep_alloca_const_offset_2
 ; CHECK-DAG:  MayAlias:     <vscale x 4 x i32>* %alloc, <vscale x 4 x i32>* %gep1
 ; CHECK-DAG:  MayAlias:     <vscale x 4 x i32>* %alloc, <vscale x 4 x i32>* %gep2
-; TODO: AliasResult for gep1,gep2 can be improved as MustAlias
-; CHECK-DAG:  MayAlias:     <vscale x 4 x i32>* %gep1, <vscale x 4 x i32>* %gep2
+; CHECK-DAG:  MustAlias:    <vscale x 4 x i32>* %gep1, <vscale x 4 x i32>* %gep2
 define void @gep_alloca_const_offset_2() {
   %alloc = alloca <vscale x 4 x i32>
   %gep1 = getelementptr <vscale x 4 x i32>, ptr %alloc, i64 1
@@ -76,8 +75,7 @@ define void @gep_alloca_symbolic_offset(i64 %idx1, i64 %idx2) {
 ; CHECK-LABEL: gep_same_base_const_offset
 ; CHECK-DAG:  MayAlias:     i32* %gep1, <vscale x 4 x i32>* %p
 ; CHECK-DAG:  MayAlias:     i32* %gep2, <vscale x 4 x i32>* %p
-; TODO: AliasResult for gep1,gep2 can be improved as NoAlias
-; CHECK-DAG:  MayAlias:     i32* %gep1, i32* %gep2
+; CHECK-DAG:  NoAlias:      i32* %gep1, i32* %gep2
 define void @gep_same_base_const_offset(ptr %p) {
   %gep1 = getelementptr <vscale x 4 x i32>, ptr %p, i64 1, i64 0
   %gep2 = getelementptr <vscale x 4 x i32>, ptr %p, i64 1, i64 1
@@ -171,7 +169,7 @@ define void @gep_bitcast_1(ptr %p) {
 ; CHECK-DAG:  MayAlias:     i32* %gep1, <vscale x 4 x i32>* %p
 ; CHECK-DAG:  MayAlias:     i32* %gep1, <vscale x 4 x float>* %p
 ; CHECK-DAG:  MayAlias:     float* %gep2, <vscale x 4 x i32>* %p
-; CHECK-DAG:  MayAlias:     i32* %gep1, float* %gep2
+; CHECK-DAG:  MustAlias:    i32* %gep1, float* %gep2
 ; CHECK-DAG:  MayAlias:     float* %gep2, <vscale x 4 x float>* %p
 define void @gep_bitcast_2(ptr %p) {
   %gep1 = getelementptr <vscale x 4 x i32>, ptr %p, i64 1, i64 0
@@ -216,7 +214,7 @@ define void @gep_neg_notscalable(ptr %p) vscale_range(1,16) {
 ; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %p, <vscale x 4 x i32>* %vm16m16
 ; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %vm16, <vscale x 4 x i32>* %vm16m16
 ; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %m16, <vscale x 4 x i32>* %vm16m16
-; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %m16pv16, <vscale x 4 x i32>* %p
+; CHECK-DAG:   MustAlias:    <vscale x 4 x i32>* %m16pv16, <vscale x 4 x i32>* %p
 ; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %m16pv16, <vscale x 4 x i32>* %vm16
 ; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %m16, <vscale x 4 x i32>* %m16pv16
 ; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %m16pv16, <vscale x 4 x i32>* %vm16m16
@@ -240,9 +238,9 @@ define void @gep_neg_scalable(ptr %p) vscale_range(1,16) {
 ; CHECK-DAG:   MayAlias:     <4 x i32>* %p, <4 x i32>* %vm16m16
 ; CHECK-DAG:   NoAlias:      <4 x i32>* %vm16, <4 x i32>* %vm16m16
 ; CHECK-DAG:   MayAlias:     <4 x i32>* %m16, <4 x i32>* %vm16m16
-; CHECK-DAG:   MayAlias:     <4 x i32>* %m16pv16, <4 x i32>* %p
+; CHECK-DAG:   MustAlias:    <4 x i32>* %m16pv16, <4 x i32>* %p
 ; CHECK-DAG:   MayAlias:     <4 x i32>* %m16pv16, <4 x i32>* %vm16
-; CHECK-DAG:   MayAlias:     <4 x i32>* %m16, <4 x i32>* %m16pv16
+; CHECK-DAG:   NoAlias:      <4 x i32>* %m16, <4 x i32>* %m16pv16
 ; CHECK-DAG:   MayAlias:     <4 x i32>* %m16pv16, <4 x i32>* %vm16m16
 define void @gep_pos_notscalable(ptr %p) vscale_range(1,16) {
   %vm16 = getelementptr <vscale x 4 x i32>, ptr %p, i64 1
@@ -264,7 +262,7 @@ define void @gep_pos_notscalable(ptr %p) vscale_range(1,16) {
 ; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %p, <vscale x 4 x i32>* %vm16m16
 ; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %vm16, <vscale x 4 x i32>* %vm16m16
 ; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %m16, <vscale x 4 x i32>* %vm16m16
-; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %m16pv16, <vscale x 4 x i32>* %p
+; CHECK-DAG:   MustAlias:    <vscale x 4 x i32>* %m16pv16, <vscale x 4 x i32>* %p
 ; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %m16pv16, <vscale x 4 x i32>* %vm16
 ; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %m16, <vscale x 4 x i32>* %m16pv16
 ; CHECK-DAG:   MayAlias:     <vscale x 4 x i32>* %m16pv16, <vscale x 4 x i32>* %vm16m16

--- a/llvm/test/Transforms/GVN/vscale.ll
+++ b/llvm/test/Transforms/GVN/vscale.ll
@@ -101,16 +101,22 @@ define i32 @load_clobber_load_gep2(ptr %p) {
   ret i32 %add
 }
 
-; TODO: BasicAA return MayAlias for %gep1,%gep2, could improve as MustAlias.
+; MemoryDependence-backed GVN can use BasicAA's MustAlias result here.
 define i32 @load_clobber_load_gep3(ptr %p) {
-; CHECK-LABEL: @load_clobber_load_gep3(
-; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr <vscale x 4 x i32>, ptr [[P:%.*]], i64 1, i64 0
-; CHECK-NEXT:    [[LOAD1:%.*]] = load i32, ptr [[GEP1]], align 4
-; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr <vscale x 4 x float>, ptr [[P]], i64 1, i64 0
-; CHECK-NEXT:    [[LOAD2:%.*]] = load float, ptr [[GEP2]], align 4
-; CHECK-NEXT:    [[CAST:%.*]] = bitcast float [[LOAD2]] to i32
-; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[LOAD1]], [[CAST]]
-; CHECK-NEXT:    ret i32 [[ADD]]
+; MDEP-LABEL: @load_clobber_load_gep3(
+; MDEP-NEXT:    [[GEP1:%.*]] = getelementptr <vscale x 4 x i32>, ptr [[P:%.*]], i64 1, i64 0
+; MDEP-NEXT:    [[LOAD1:%.*]] = load i32, ptr [[GEP1]], align 4
+; MDEP-NEXT:    [[ADD:%.*]] = add i32 [[LOAD1]], [[LOAD1]]
+; MDEP-NEXT:    ret i32 [[ADD]]
+;
+; MSSA-LABEL: @load_clobber_load_gep3(
+; MSSA-NEXT:    [[GEP1:%.*]] = getelementptr <vscale x 4 x i32>, ptr [[P:%.*]], i64 1, i64 0
+; MSSA-NEXT:    [[LOAD1:%.*]] = load i32, ptr [[GEP1]], align 4
+; MSSA-NEXT:    [[GEP2:%.*]] = getelementptr <vscale x 4 x float>, ptr [[P]], i64 1, i64 0
+; MSSA-NEXT:    [[LOAD2:%.*]] = load float, ptr [[GEP2]], align 4
+; MSSA-NEXT:    [[CAST:%.*]] = bitcast float [[LOAD2]] to i32
+; MSSA-NEXT:    [[ADD:%.*]] = add i32 [[LOAD1]], [[CAST]]
+; MSSA-NEXT:    ret i32 [[ADD]]
 ;
   %gep1 = getelementptr <vscale x 4 x i32>, ptr %p, i64 1, i64 0
   %load1 = load i32, ptr %gep1
@@ -326,21 +332,34 @@ if.end:
   ret i32 %result
 }
 
-; TODO: BasicAA return MayAlias for %gep1,%gep2, could improve as NoAlias.
+; MemoryDependence-backed GVN can use BasicAA's NoAlias result here.
 define void @redundant_load_elimination_2(i1 %c, ptr %p, ptr %q) {
-; CHECK-LABEL: @redundant_load_elimination_2(
-; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr <vscale x 4 x i32>, ptr [[P:%.*]], i64 1, i64 1
-; CHECK-NEXT:    store i32 0, ptr [[GEP1]], align 4
-; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr <vscale x 4 x i32>, ptr [[P]], i64 1, i64 0
-; CHECK-NEXT:    store i32 1, ptr [[GEP2]], align 4
-; CHECK-NEXT:    br i1 [[C:%.*]], label [[IF_ELSE:%.*]], label [[IF_THEN:%.*]]
-; CHECK:       if.then:
-; CHECK-NEXT:    [[T:%.*]] = load i32, ptr [[GEP1]], align 4
-; CHECK-NEXT:    store i32 [[T]], ptr [[Q:%.*]], align 4
-; CHECK-NEXT:    ret void
-; CHECK:       if.else:
-; CHECK-NEXT:    ret void
+; MDEP-LABEL: @redundant_load_elimination_2(
+; MDEP-NEXT:  entry:
+; MDEP-NEXT:    [[GEP1:%.*]] = getelementptr <vscale x 4 x i32>, ptr [[P:%.*]], i64 1, i64 1
+; MDEP-NEXT:    store i32 0, ptr [[GEP1]], align 4
+; MDEP-NEXT:    [[GEP2:%.*]] = getelementptr <vscale x 4 x i32>, ptr [[P]], i64 1, i64 0
+; MDEP-NEXT:    store i32 1, ptr [[GEP2]], align 4
+; MDEP-NEXT:    br i1 [[C:%.*]], label [[IF_ELSE:%.*]], label [[IF_THEN:%.*]]
+; MDEP:       if.then:
+; MDEP-NEXT:    store i32 0, ptr [[Q:%.*]], align 4
+; MDEP-NEXT:    ret void
+; MDEP:       if.else:
+; MDEP-NEXT:    ret void
+;
+; MSSA-LABEL: @redundant_load_elimination_2(
+; MSSA-NEXT:  entry:
+; MSSA-NEXT:    [[GEP1:%.*]] = getelementptr <vscale x 4 x i32>, ptr [[P:%.*]], i64 1, i64 1
+; MSSA-NEXT:    store i32 0, ptr [[GEP1]], align 4
+; MSSA-NEXT:    [[GEP2:%.*]] = getelementptr <vscale x 4 x i32>, ptr [[P]], i64 1, i64 0
+; MSSA-NEXT:    store i32 1, ptr [[GEP2]], align 4
+; MSSA-NEXT:    br i1 [[C:%.*]], label [[IF_ELSE:%.*]], label [[IF_THEN:%.*]]
+; MSSA:       if.then:
+; MSSA-NEXT:    [[T:%.*]] = load i32, ptr [[GEP1]], align 4
+; MSSA-NEXT:    store i32 [[T]], ptr [[Q:%.*]], align 4
+; MSSA-NEXT:    ret void
+; MSSA:       if.else:
+; MSSA-NEXT:    ret void
 ;
 entry:
   %gep1 = getelementptr <vscale x 4 x i32>, ptr %p, i64 1, i64 1

--- a/llvm/test/Transforms/GVN/vscale.ll
+++ b/llvm/test/Transforms/GVN/vscale.ll
@@ -101,7 +101,9 @@ define i32 @load_clobber_load_gep2(ptr %p) {
   ret i32 %add
 }
 
-; MemoryDependence-backed GVN can use BasicAA's MustAlias result here.
+; MemoryDependence-backed GVN can use BasicAA's MustAlias result for %gep1 and
+; %gep2 to eliminate the redundant load. MSSA-backed GVN uses a coarser clobber
+; check and does not propagate the MustAlias result for this pattern.
 define i32 @load_clobber_load_gep3(ptr %p) {
 ; MDEP-LABEL: @load_clobber_load_gep3(
 ; MDEP-NEXT:    [[GEP1:%.*]] = getelementptr <vscale x 4 x i32>, ptr [[P:%.*]], i64 1, i64 0

--- a/llvm/test/Transforms/NewGVN/vscale.ll
+++ b/llvm/test/Transforms/NewGVN/vscale.ll
@@ -272,7 +272,7 @@ if.end:
   ret i32 %result
 }
 
-; TODO: BasicAA return MayAlias for %gep1,%gep2, could improve as NoAlias.
+; NewGVN can use BasicAA's NoAlias result here.
 define void @redundant_load_elimination_2(i1 %c, ptr %p, ptr %q) {
 ; CHECK-LABEL: @redundant_load_elimination_2(
 ; CHECK-NEXT:  entry:
@@ -282,8 +282,7 @@ define void @redundant_load_elimination_2(i1 %c, ptr %p, ptr %q) {
 ; CHECK-NEXT:    store i32 1, ptr [[GEP2]], align 4
 ; CHECK-NEXT:    br i1 [[C:%.*]], label [[IF_ELSE:%.*]], label [[IF_THEN:%.*]]
 ; CHECK:       if.then:
-; CHECK-NEXT:    [[T:%.*]] = load i32, ptr [[GEP1]], align 4
-; CHECK-NEXT:    store i32 [[T]], ptr [[Q:%.*]], align 4
+; CHECK-NEXT:    store i32 0, ptr [[Q:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ; CHECK:       if.else:
 ; CHECK-NEXT:    ret void


### PR DESCRIPTION
Currently BasicAA does not decompose a constant-index gep with a scalable element stride. This leaves a few cases in vscale.ll as MayAlias, even though they can be proven to be MustAlias or NoAlias.

This PR adds a ScalableOffset member to DecomposedGEP to track the vscaled part of a gep offset separately from the fixed byte offset. BasicAA can then cancel matching scalable offsets during gep comparison, while remaining conservative when a nonzero scalable offset remains.

This improves alias results for scalable-vector geps such as identical scalable offsets, or common scalable offsets followed by different fixed element offsets.
