### PR TITLE
[llvm-profgen][NFC] Detect pre-aggregated format

### DIFF
--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -365,9 +365,11 @@ PerfReaderBase::create(ProfiledBinary *Binary, PerfInputFile &PerfInput,
 
   PerfInput.Content =
       PerfScriptReader::checkPerfScriptType(PerfInput.InputFile);
-  if (PerfInput.Content == PerfContent::LBRStack) {
-    PerfReader.reset(
-        new HybridPerfReader(Binary, PerfInput.InputFile, PIDFilter));
+  if (PerfInput.Content == PerfContent::LBRStack ||
+      PerfInput.Content == PerfContent::AggLBRStack) {
+    auto *Reader = new HybridPerfReader(Binary, PerfInput.InputFile, PIDFilter);
+    Reader->setIsPreAggregated(PerfInput.Content == PerfContent::AggLBRStack);
+    PerfReader.reset(Reader);
   } else if (PerfInput.Content == PerfContent::LBR) {
     PerfReader.reset(new LBRPerfReader(Binary, PerfInput.InputFile, PIDFilter));
   } else {
@@ -1191,8 +1193,9 @@ PerfContent PerfScriptReader::checkPerfScriptType(StringRef FileName) {
   TraceStream TraceIt(FileName);
   uint64_t FrameAddr = 0;
   while (!TraceIt.isAtEoF()) {
-    // Skip the aggregated count
-    if (!TraceIt.getCurrentLine().getAsInteger(10, FrameAddr))
+    // Skip the aggregated count and detect pre-aggregated input.
+    bool HasAggCount = !TraceIt.getCurrentLine().getAsInteger(10, FrameAddr);
+    if (HasAggCount)
       TraceIt.advance();
 
     // Detect sample with call stack
@@ -1205,7 +1208,7 @@ PerfContent PerfScriptReader::checkPerfScriptType(StringRef FileName) {
     if (!TraceIt.isAtEoF()) {
       if (isLBRSample(TraceIt.getCurrentLine())) {
         if (Count > 0)
-          return PerfContent::LBRStack;
+          return HasAggCount ? PerfContent::AggLBRStack : PerfContent::LBRStack;
         else
           return PerfContent::LBR;
       }

--- a/llvm/tools/llvm-profgen/PerfReader.h
+++ b/llvm/tools/llvm-profgen/PerfReader.h
@@ -69,8 +69,9 @@ enum PerfFormat {
 // The type of perfscript content.
 enum PerfContent {
   UnknownContent = 0,
-  LBR = 1,      // Only LBR sample.
-  LBRStack = 2, // Hybrid sample including call stack and LBR stack.
+  LBR = 1,         // Only LBR sample.
+  LBRStack = 2,    // Hybrid sample including call stack and LBR stack.
+  AggLBRStack = 3, // Pre-aggregated hybrid sample.
 };
 
 struct PerfInputFile {
@@ -631,6 +632,8 @@ public:
   // receiving signals.
   static SmallVector<CleanupInstaller, 2> TempFileCleanups;
 
+  void setIsPreAggregated(bool V) { IsPreAggregated = V; }
+
 protected:
   // Check whether a given line is LBR sample
   static bool isLBRSample(StringRef Line);
@@ -676,6 +679,8 @@ protected:
   std::set<uint64_t> InvalidReturnAddresses;
   // PID for the process of interest
   std::optional<int32_t> PIDFilter;
+  // Whether the input is pre-aggregated
+  bool IsPreAggregated = false;
 };
 
 /*


### PR DESCRIPTION
Distinguish the following profgen input formats:
1. perf script with brstack only,
2. perf script with call stack and brstack (hybrid),
3. pre-aggregated input with count, call stack and brstack.

Pre-aggregated input lacks mmap information, so to enable using single input file for optimizing the main binary and shared libraries, the addresses will be augmented with buildid information in a follow-up (#190863).