### PR TITLE
[llvm-profgen][NFC] Factor out parseAddress

### DIFF
--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -659,7 +659,7 @@ void HybridPerfReader::unwindSamples() {
 /// Parse a hex address from \p Str.
 static bool parseAddress(StringRef Str, uint64_t &Addr, bool HasPrefix) {
   if (Str.consume_front("0x") != HasPrefix)
-    return false;
+    return true;
   return Str.getAsInteger(16, Addr);
 }
 

--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -365,9 +365,11 @@ PerfReaderBase::create(ProfiledBinary *Binary, PerfInputFile &PerfInput,
 
   PerfInput.Content =
       PerfScriptReader::checkPerfScriptType(PerfInput.InputFile);
-  if (PerfInput.Content == PerfContent::LBRStack) {
-    PerfReader.reset(
-        new HybridPerfReader(Binary, PerfInput.InputFile, PIDFilter));
+  if (PerfInput.Content == PerfContent::LBRStack ||
+      PerfInput.Content == PerfContent::AggLBRStack) {
+    auto *Reader = new HybridPerfReader(Binary, PerfInput.InputFile, PIDFilter);
+    Reader->setIsPreAggregated(PerfInput.Content == PerfContent::AggLBRStack);
+    PerfReader.reset(Reader);
   } else if (PerfInput.Content == PerfContent::LBR) {
     PerfReader.reset(new LBRPerfReader(Binary, PerfInput.InputFile, PIDFilter));
   } else {
@@ -1191,8 +1193,9 @@ PerfContent PerfScriptReader::checkPerfScriptType(StringRef FileName) {
   TraceStream TraceIt(FileName);
   uint64_t FrameAddr = 0;
   while (!TraceIt.isAtEoF()) {
-    // Skip the aggregated count
-    if (!TraceIt.getCurrentLine().getAsInteger(10, FrameAddr))
+    // Skip the aggregated count and detect pre-aggregated input.
+    bool HasAggCount = !TraceIt.getCurrentLine().getAsInteger(10, FrameAddr);
+    if (HasAggCount)
       TraceIt.advance();
 
     // Detect sample with call stack
@@ -1205,7 +1208,7 @@ PerfContent PerfScriptReader::checkPerfScriptType(StringRef FileName) {
     if (!TraceIt.isAtEoF()) {
       if (isLBRSample(TraceIt.getCurrentLine())) {
         if (Count > 0)
-          return PerfContent::LBRStack;
+          return HasAggCount ? PerfContent::AggLBRStack : PerfContent::LBRStack;
         else
           return PerfContent::LBR;
       }

--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -657,7 +657,7 @@ void HybridPerfReader::unwindSamples() {
 }
 
 /// Parse a hex address from \p Str.
-static bool parseAddress(StringRef Str, uint64_t &Addr, bool HasPrefix = false) {
+static bool parseAddress(StringRef Str, uint64_t &Addr, bool HasPrefix) {
   if (Str.consume_front("0x") != HasPrefix)
     return false;
   return Str.getAsInteger(16, Addr);
@@ -681,7 +681,7 @@ bool PerfScriptReader::extractLBRStack(TraceStream &TraceIt,
   size_t Index = 0;
   uint64_t LeadingAddr;
   if (!Records.empty() && !Records[0].contains('/')) {
-    if (parseAddress(Records[0], LeadingAddr)) {
+    if (parseAddress(Records[0], LeadingAddr, false)) {
       WarnInvalidLBR(TraceIt);
       TraceIt.advance();
       return false;
@@ -740,7 +740,7 @@ bool PerfScriptReader::extractCallstack(TraceStream &TraceIt,
   while (!TraceIt.isAtEoF() && !TraceIt.getCurrentLine().starts_with(" 0x")) {
     StringRef FrameStr = TraceIt.getCurrentLine().ltrim();
     uint64_t FrameAddr = 0;
-    if (parseAddress(FrameStr, FrameAddr)) {
+    if (parseAddress(FrameStr, FrameAddr, false)) {
       // We might parse a non-perf sample line like empty line and comments,
       // skip it
       TraceIt.advance();
@@ -1208,7 +1208,7 @@ PerfContent PerfScriptReader::checkPerfScriptType(StringRef FileName) {
     // Detect sample with call stack
     int32_t Count = 0;
     while (!TraceIt.isAtEoF() &&
-           !parseAddress(TraceIt.getCurrentLine().ltrim(), FrameAddr)) {
+           !parseAddress(TraceIt.getCurrentLine().ltrim(), FrameAddr, false)) {
       Count++;
       TraceIt.advance();
     }

--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -365,11 +365,9 @@ PerfReaderBase::create(ProfiledBinary *Binary, PerfInputFile &PerfInput,
 
   PerfInput.Content =
       PerfScriptReader::checkPerfScriptType(PerfInput.InputFile);
-  if (PerfInput.Content == PerfContent::LBRStack ||
-      PerfInput.Content == PerfContent::AggLBRStack) {
-    auto *Reader = new HybridPerfReader(Binary, PerfInput.InputFile, PIDFilter);
-    Reader->setIsPreAggregated(PerfInput.Content == PerfContent::AggLBRStack);
-    PerfReader.reset(Reader);
+  if (PerfInput.Content == PerfContent::LBRStack) {
+    PerfReader.reset(
+        new HybridPerfReader(Binary, PerfInput.InputFile, PIDFilter));
   } else if (PerfInput.Content == PerfContent::LBR) {
     PerfReader.reset(new LBRPerfReader(Binary, PerfInput.InputFile, PIDFilter));
   } else {
@@ -1193,9 +1191,8 @@ PerfContent PerfScriptReader::checkPerfScriptType(StringRef FileName) {
   TraceStream TraceIt(FileName);
   uint64_t FrameAddr = 0;
   while (!TraceIt.isAtEoF()) {
-    // Skip the aggregated count and detect pre-aggregated input.
-    bool HasAggCount = !TraceIt.getCurrentLine().getAsInteger(10, FrameAddr);
-    if (HasAggCount)
+    // Skip the aggregated count
+    if (!TraceIt.getCurrentLine().getAsInteger(10, FrameAddr))
       TraceIt.advance();
 
     // Detect sample with call stack
@@ -1208,7 +1205,7 @@ PerfContent PerfScriptReader::checkPerfScriptType(StringRef FileName) {
     if (!TraceIt.isAtEoF()) {
       if (isLBRSample(TraceIt.getCurrentLine())) {
         if (Count > 0)
-          return HasAggCount ? PerfContent::AggLBRStack : PerfContent::LBRStack;
+          return PerfContent::LBRStack;
         else
           return PerfContent::LBR;
       }

--- a/llvm/tools/llvm-profgen/PerfReader.h
+++ b/llvm/tools/llvm-profgen/PerfReader.h
@@ -69,8 +69,9 @@ enum PerfFormat {
 // The type of perfscript content.
 enum PerfContent {
   UnknownContent = 0,
-  LBR = 1,      // Only LBR sample.
-  LBRStack = 2, // Hybrid sample including call stack and LBR stack.
+  LBR = 1,         // Only LBR sample.
+  LBRStack = 2,    // Hybrid sample including call stack and LBR stack.
+  AggLBRStack = 3, // Pre-aggregated hybrid sample.
 };
 
 struct PerfInputFile {
@@ -631,6 +632,8 @@ public:
   // receiving signals.
   static SmallVector<CleanupInstaller, 2> TempFileCleanups;
 
+  void setIsPreAggregated(bool V) { IsPreAggregated = V; }
+
 protected:
   // Check whether a given line is LBR sample
   static bool isLBRSample(StringRef Line);
@@ -676,6 +679,8 @@ protected:
   std::set<uint64_t> InvalidReturnAddresses;
   // PID for the process of interest
   std::optional<int32_t> PIDFilter;
+  // Whether the input is pre-aggregated
+  bool IsPreAggregated = false;
 };
 
 /*

--- a/llvm/tools/llvm-profgen/PerfReader.h
+++ b/llvm/tools/llvm-profgen/PerfReader.h
@@ -69,9 +69,8 @@ enum PerfFormat {
 // The type of perfscript content.
 enum PerfContent {
   UnknownContent = 0,
-  LBR = 1,         // Only LBR sample.
-  LBRStack = 2,    // Hybrid sample including call stack and LBR stack.
-  AggLBRStack = 3, // Pre-aggregated hybrid sample.
+  LBR = 1,      // Only LBR sample.
+  LBRStack = 2, // Hybrid sample including call stack and LBR stack.
 };
 
 struct PerfInputFile {
@@ -632,8 +631,6 @@ public:
   // receiving signals.
   static SmallVector<CleanupInstaller, 2> TempFileCleanups;
 
-  void setIsPreAggregated(bool V) { IsPreAggregated = V; }
-
 protected:
   // Check whether a given line is LBR sample
   static bool isLBRSample(StringRef Line);
@@ -679,8 +676,6 @@ protected:
   std::set<uint64_t> InvalidReturnAddresses;
   // PID for the process of interest
   std::optional<int32_t> PIDFilter;
-  // Whether the input is pre-aggregated
-  bool IsPreAggregated = false;
 };
 
 /*


### PR DESCRIPTION
Replace `StringRef::getAsInteger(16)` calls with explicit `parseAddress` to
make it easier to support buildid-prefixed addresses in a follow-up (#190863).