### PR TITLE
[clang][modules-driver] Add missing PrependArg for Clang module precompile jobs

### DIFF
--- a/clang/lib/Driver/ModulesDriver.cpp
+++ b/clang/lib/Driver/ModulesDriver.cpp
@@ -1243,11 +1243,12 @@ createClangModulePrecompileJob(Compilation &C, const Command &ImportingJob,
   for (const auto &Arg : BuildArgs)
     JobArgs.push_back(TCArgs.MakeArgString(Arg));
 
-  return std::make_unique<Command>(*PA, ImportingJob.getCreator(),
-                                   ResponseFileSupport::AtFileUTF8(),
-                                   C.getDriver().getClangProgramPath(), JobArgs,
-                                   /*Inputs=*/ArrayRef<InputInfo>{},
-                                   /*Outputs=*/ArrayRef<InputInfo>{});
+  const auto &D = C.getDriver();
+  return std::make_unique<Command>(
+      *PA, ImportingJob.getCreator(), ResponseFileSupport::AtFileUTF8(),
+      D.getClangProgramPath(), JobArgs,
+      /*Inputs=*/ArrayRef<InputInfo>{},
+      /*Outputs=*/ArrayRef<InputInfo>{}, D.getPrependArg());
 }
 
 /// Creates a \c ClangModuleJobNode with associated job for each unique Clang


### PR DESCRIPTION
In `createClangModulePrecompileJob`, the `PrependArg` parameter was not being passed for the newly created Clang module precompile job. 
This causes failures for setups where the clang executable is a wrapper (e.g., the llvm-driver wrapper).

See https://github.com/llvm/llvm-project/pull/191258#issuecomment-4227294864