### PR TITLE
[llvm-pdbutil] Include DBI section contribs in YAML

### DIFF
--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiStream.h
@@ -93,6 +93,8 @@ public:
   LLVM_ABI void
   visitSectionContributions(ISectionContribVisitor &Visitor) const;
 
+  LLVM_ABI PdbRaw_DbiSecContribVer getSectionContributionsVersion() const;
+
   LLVM_ABI Expected<StringRef> getECName(uint32_t NI) const;
 
 private:

--- a/llvm/lib/DebugInfo/PDB/Native/DbiStream.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/DbiStream.cpp
@@ -231,6 +231,10 @@ void DbiStream::visitSectionContributions(
   }
 }
 
+PdbRaw_DbiSecContribVer DbiStream::getSectionContributionsVersion() const {
+  return SectionContribVersion;
+}
+
 Expected<StringRef> DbiStream::getECName(uint32_t NI) const {
   return ECNames.getStringForID(NI);
 }

--- a/llvm/test/tools/llvm-pdbutil/dbi-section-contribs-v2-yaml.test
+++ b/llvm/test/tools/llvm-pdbutil/dbi-section-contribs-v2-yaml.test
@@ -1,0 +1,25 @@
+# RUN: not llvm-pdbutil yaml2pdb %s --pdb=%t.pdb 2>&1 | FileCheck --check-prefix=CHECK-YAML2PDB %s
+
+# CHECK-YAML2PDB: Only DBI section contrib Version Ver60 is supported
+
+---
+DbiStream:
+  VerHeader:       V70
+  Age:             3
+  BuildNumber:     36402
+  PdbDllVersion:   35728
+  PdbDllRbld:      0
+  Flags:           1
+  MachineType:     Amd64
+  SectionContribs:
+    Version:         V2
+    Items:
+      - ISect:           1
+        Offset:          0
+        Size:            15
+        Characteristics: 1610612768
+        Imod:            1
+        DataCrc:         0
+        RelocCrc:        0
+        ISectCoff:       0
+...

--- a/llvm/test/tools/llvm-pdbutil/dbi-section-contribs-ver60-yaml.test
+++ b/llvm/test/tools/llvm-pdbutil/dbi-section-contribs-ver60-yaml.test
@@ -1,0 +1,193 @@
+# RUN: llvm-pdbutil yaml2pdb %s --pdb=%t.pdb
+# RUN: llvm-pdbutil dump --section-contribs %t.pdb | FileCheck --check-prefix=CHECK-YAML2PDB %s
+
+# RUN: llvm-pdbutil pdb2yaml --section-contribs %t.pdb > %t.yaml
+# RUN: FileCheck --input-file=%t.yaml --check-prefix=CHECK-PDB2YAML %s
+
+# CHECK-YAML2PDB:      SC[.text]   | mod = 1, 0001:0000, size = 15, data crc = 0, reloc crc = 0
+# CHECK-YAML2PDB-NEXT:               IMAGE_SCN_CNT_CODE | IMAGE_SCN_MEM_EXECUTE | IMAGE_SCN_MEM_READ
+# CHECK-YAML2PDB-NEXT: SC[.text]   | mod = 0, 0001:0032, size = 44, data crc = 994759651, reloc crc = 0
+# CHECK-YAML2PDB-NEXT:               IMAGE_SCN_CNT_CODE | IMAGE_SCN_ALIGN_16BYTES | IMAGE_SCN_MEM_EXECUTE |
+# CHECK-YAML2PDB-NEXT:               IMAGE_SCN_MEM_READ
+# CHECK-YAML2PDB-NEXT: SC[.text]   | mod = 0, 0001:0096, size = 22, data crc = 3114067823, reloc crc = 0
+# CHECK-YAML2PDB-NEXT:               IMAGE_SCN_CNT_CODE | IMAGE_SCN_LNK_COMDAT | IMAGE_SCN_ALIGN_16BYTES |
+# CHECK-YAML2PDB-NEXT:               IMAGE_SCN_MEM_EXECUTE | IMAGE_SCN_MEM_READ
+# CHECK-YAML2PDB-NEXT: SC[.rdata]  | mod = 1, 0002:0000, size = 56, data crc = 0, reloc crc = 0
+# CHECK-YAML2PDB-NEXT:               IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_ALIGN_4BYTES | IMAGE_SCN_MEM_READ
+# CHECK-YAML2PDB-NEXT: SC[.rdata]  | mod = 1, 0002:0324, size = 58, data crc = 0, reloc crc = 0
+# CHECK-YAML2PDB-NEXT:               IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_ALIGN_4BYTES | IMAGE_SCN_MEM_READ
+# CHECK-YAML2PDB-NEXT: SC[.rdata]  | mod = 1, 0002:0384, size = 20, data crc = 0, reloc crc = 0
+# CHECK-YAML2PDB-NEXT:               IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_ALIGN_4BYTES | IMAGE_SCN_MEM_READ
+# CHECK-YAML2PDB-NEXT: SC[.rdata]  | mod = 0, 0002:0676, size = 8, data crc = 931692337, reloc crc = 0
+# CHECK-YAML2PDB-NEXT:               IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_ALIGN_4BYTES | IMAGE_SCN_MEM_READ
+
+# CHECK-PDB2YAML:      SectionContribs:
+# CHECK-PDB2YAML-NEXT:   Version:         Ver60
+# CHECK-PDB2YAML-NEXT:   Items:
+# CHECK-PDB2YAML-NEXT:     - ISect:           1
+# CHECK-PDB2YAML-NEXT:       Offset:          0
+# CHECK-PDB2YAML-NEXT:       Size:            15
+# CHECK-PDB2YAML-NEXT:       Characteristics: 1610612768
+# CHECK-PDB2YAML-NEXT:       Imod:            1
+# CHECK-PDB2YAML-NEXT:       DataCrc:         0
+# CHECK-PDB2YAML-NEXT:       RelocCrc:        0
+# CHECK-PDB2YAML-NEXT:       ISectCoff:       0
+# CHECK-PDB2YAML-NEXT:     - ISect:           1
+# CHECK-PDB2YAML-NEXT:       Offset:          32
+# CHECK-PDB2YAML-NEXT:       Size:            44
+# CHECK-PDB2YAML-NEXT:       Characteristics: 1615855648
+# CHECK-PDB2YAML-NEXT:       Imod:            0
+# CHECK-PDB2YAML-NEXT:       DataCrc:         994759651
+# CHECK-PDB2YAML-NEXT:       RelocCrc:        0
+# CHECK-PDB2YAML-NEXT:       ISectCoff:       0
+# CHECK-PDB2YAML-NEXT:     - ISect:           1
+# CHECK-PDB2YAML-NEXT:       Offset:          96
+# CHECK-PDB2YAML-NEXT:       Size:            22
+# CHECK-PDB2YAML-NEXT:       Characteristics: 1615859744
+# CHECK-PDB2YAML-NEXT:       Imod:            0
+# CHECK-PDB2YAML-NEXT:       DataCrc:         3114067823
+# CHECK-PDB2YAML-NEXT:       RelocCrc:        0
+# CHECK-PDB2YAML-NEXT:       ISectCoff:       0
+# CHECK-PDB2YAML-NEXT:     - ISect:           2
+# CHECK-PDB2YAML-NEXT:       Offset:          0
+# CHECK-PDB2YAML-NEXT:       Size:            56
+# CHECK-PDB2YAML-NEXT:       Characteristics: 1076887616
+# CHECK-PDB2YAML-NEXT:       Imod:            1
+# CHECK-PDB2YAML-NEXT:       DataCrc:         0
+# CHECK-PDB2YAML-NEXT:       RelocCrc:        0
+# CHECK-PDB2YAML-NEXT:       ISectCoff:       0
+# CHECK-PDB2YAML-NEXT:     - ISect:           2
+# CHECK-PDB2YAML-NEXT:       Offset:          324
+# CHECK-PDB2YAML-NEXT:       Size:            58
+# CHECK-PDB2YAML-NEXT:       Characteristics: 1076887616
+# CHECK-PDB2YAML-NEXT:       Imod:            1
+# CHECK-PDB2YAML-NEXT:       DataCrc:         0
+# CHECK-PDB2YAML-NEXT:       RelocCrc:        0
+# CHECK-PDB2YAML-NEXT:       ISectCoff:       0
+# CHECK-PDB2YAML-NEXT:     - ISect:           2
+# CHECK-PDB2YAML-NEXT:       Offset:          384
+# CHECK-PDB2YAML-NEXT:       Size:            20
+# CHECK-PDB2YAML-NEXT:       Characteristics: 1076887616
+# CHECK-PDB2YAML-NEXT:       Imod:            1
+# CHECK-PDB2YAML-NEXT:       DataCrc:         0
+# CHECK-PDB2YAML-NEXT:       RelocCrc:        0
+# CHECK-PDB2YAML-NEXT:       ISectCoff:       0
+# CHECK-PDB2YAML-NEXT:     - ISect:           2
+# CHECK-PDB2YAML-NEXT:       Offset:          676
+# CHECK-PDB2YAML-NEXT:       Size:            8
+# CHECK-PDB2YAML-NEXT:       Characteristics: 1076887616
+# CHECK-PDB2YAML-NEXT:       Imod:            0
+# CHECK-PDB2YAML-NEXT:       DataCrc:         931692337
+# CHECK-PDB2YAML-NEXT:       RelocCrc:        0
+# CHECK-PDB2YAML-NEXT:       ISectCoff:       0
+
+---
+DbiStream:
+  VerHeader:       V70
+  Age:             3
+  BuildNumber:     36402
+  PdbDllVersion:   35728
+  PdbDllRbld:      0
+  Flags:           1
+  MachineType:     Amd64
+  SectionHeaders:
+    - Name:            .text
+      VirtualSize:     4229
+      VirtualAddress:  4096
+      SizeOfRawData:   4608
+      PointerToRawData: 1024
+      PointerToRelocations: 0
+      PointerToLinenumbers: 0
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      Characteristics: 1610612768
+    - Name:            .rdata
+      VirtualSize:     1196
+      VirtualAddress:  12288
+      SizeOfRawData:   1536
+      PointerToRawData: 5632
+      PointerToRelocations: 0
+      PointerToLinenumbers: 0
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      Characteristics: 1073741888
+    - Name:            .pdata
+      VirtualSize:     312
+      VirtualAddress:  16384
+      SizeOfRawData:   512
+      PointerToRawData: 7168
+      PointerToRelocations: 0
+      PointerToLinenumbers: 0
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      Characteristics: 1073741888
+    - Name:            .reloc
+      VirtualSize:     8
+      VirtualAddress:  20480
+      SizeOfRawData:   512
+      PointerToRawData: 7680
+      PointerToRelocations: 0
+      PointerToLinenumbers: 0
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      Characteristics: 1107296320
+  SectionContribs:
+    Version:         Ver60
+    Items:
+      - ISect:           1
+        Offset:          0
+        Size:            15
+        Characteristics: 1610612768
+        Imod:            1
+        DataCrc:         0
+        RelocCrc:        0
+        ISectCoff:       0
+      - ISect:           1
+        Offset:          32
+        Size:            44
+        Characteristics: 1615855648
+        Imod:            0
+        DataCrc:         994759651
+        RelocCrc:        0
+        ISectCoff:       0
+      - ISect:           1
+        Offset:          96
+        Size:            22
+        Characteristics: 1615859744
+        Imod:            0
+        DataCrc:         3114067823
+        RelocCrc:        0
+        ISectCoff:       0
+      - ISect:           2
+        Offset:          0
+        Size:            56
+        Characteristics: 1076887616
+        Imod:            1
+        DataCrc:         0
+        RelocCrc:        0
+        ISectCoff:       0
+      - ISect:           2
+        Offset:          324
+        Size:            58
+        Characteristics: 1076887616
+        Imod:            1
+        DataCrc:         0
+        RelocCrc:        0
+        ISectCoff:       0
+      - ISect:           2
+        Offset:          384
+        Size:            20
+        Characteristics: 1076887616
+        Imod:            1
+        DataCrc:         0
+        RelocCrc:        0
+        ISectCoff:       0
+      - ISect:           2
+        Offset:          676
+        Size:            8
+        Characteristics: 1076887616
+        Imod:            0
+        DataCrc:         931692337
+        RelocCrc:        0
+        ISectCoff:       0
+...

--- a/llvm/tools/llvm-pdbutil/PdbYaml.cpp
+++ b/llvm/tools/llvm-pdbutil/PdbYaml.cpp
@@ -25,6 +25,7 @@ using namespace llvm::yaml;
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::pdb::yaml::CoffSectionHeader)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::pdb::yaml::NamedStreamMapping)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::pdb::yaml::PdbDbiModuleInfo)
+LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::pdb::yaml::PdbDbiSectionContrib)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::pdb::yaml::StreamBlockList)
 LLVM_YAML_IS_FLOW_SEQUENCE_VECTOR(llvm::pdb::PdbRaw_FeatureSig)
 
@@ -97,6 +98,13 @@ template <> struct ScalarEnumerationTraits<llvm::pdb::PdbRaw_FeatureSig> {
     io.enumCase(Features, "NoTypeMerge", PdbRaw_FeatureSig::NoTypeMerge);
     io.enumCase(Features, "VC110", PdbRaw_FeatureSig::VC110);
     io.enumCase(Features, "VC140", PdbRaw_FeatureSig::VC140);
+  }
+};
+
+template <> struct ScalarEnumerationTraits<llvm::pdb::PdbRaw_DbiSecContribVer> {
+  static void enumeration(IO &IO, PdbRaw_DbiSecContribVer &Ver) {
+    IO.enumCase(Ver, "Ver60", PdbRaw_DbiSecContribVer::DbiSecContribVer60);
+    IO.enumCase(Ver, "V2", PdbRaw_DbiSecContribVer::DbiSecContribV2);
   }
 };
 }
@@ -192,6 +200,25 @@ void MappingTraits<PdbInfoStream>::mapping(IO &IO, PdbInfoStream &Obj) {
   IO.mapOptional("Version", Obj.Version, PdbImplVC70);
 }
 
+void MappingTraits<PdbDbiSectionContribs>::mapping(IO &IO,
+                                                   PdbDbiSectionContribs &Obj) {
+  IO.mapOptional("Version", Obj.Version,
+                 PdbRaw_DbiSecContribVer::DbiSecContribVer60);
+  IO.mapOptional("Items", Obj.Items);
+}
+
+void MappingTraits<PdbDbiSectionContrib>::mapping(IO &IO,
+                                                  PdbDbiSectionContrib &Obj) {
+  IO.mapOptional("ISect", Obj.ISect);
+  IO.mapOptional("Offset", Obj.Off);
+  IO.mapOptional("Size", Obj.Size);
+  IO.mapOptional("Characteristics", Obj.Characteristics);
+  IO.mapOptional("Imod", Obj.Imod);
+  IO.mapOptional("DataCrc", Obj.DataCrc);
+  IO.mapOptional("RelocCrc", Obj.RelocCrc);
+  IO.mapOptional("ISectCoff", Obj.ISectCoff);
+}
+
 void MappingTraits<PdbDbiStream>::mapping(IO &IO, PdbDbiStream &Obj) {
   IO.mapOptional("VerHeader", Obj.VerHeader, PdbDbiV70);
   IO.mapOptional("Age", Obj.Age, 1U);
@@ -209,6 +236,7 @@ void MappingTraits<PdbDbiStream>::mapping(IO &IO, PdbDbiStream &Obj) {
   }
   IO.mapOptional("Modules", Obj.ModInfos);
   IO.mapOptional("SectionHeaders", Obj.SectionHeaders);
+  IO.mapOptional("SectionContribs", Obj.SectionContribs);
 }
 
 void MappingTraits<PdbTpiStream>::mapping(IO &IO,

--- a/llvm/tools/llvm-pdbutil/PdbYaml.cpp
+++ b/llvm/tools/llvm-pdbutil/PdbYaml.cpp
@@ -25,6 +25,7 @@ using namespace llvm::yaml;
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::pdb::yaml::CoffSectionHeader)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::pdb::yaml::NamedStreamMapping)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::pdb::yaml::PdbDbiModuleInfo)
+LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::pdb::yaml::PdbDbiSectionContrib)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::pdb::yaml::StreamBlockList)
 LLVM_YAML_IS_FLOW_SEQUENCE_VECTOR(llvm::pdb::PdbRaw_FeatureSig)
 
@@ -97,6 +98,13 @@ template <> struct ScalarEnumerationTraits<llvm::pdb::PdbRaw_FeatureSig> {
     io.enumCase(Features, "NoTypeMerge", PdbRaw_FeatureSig::NoTypeMerge);
     io.enumCase(Features, "VC110", PdbRaw_FeatureSig::VC110);
     io.enumCase(Features, "VC140", PdbRaw_FeatureSig::VC140);
+  }
+};
+
+template <> struct ScalarEnumerationTraits<llvm::pdb::PdbRaw_DbiSecContribVer> {
+  static void enumeration(IO &IO, PdbRaw_DbiSecContribVer &Ver) {
+    IO.enumCase(Ver, "Ver60", PdbRaw_DbiSecContribVer::DbiSecContribVer60);
+    IO.enumCase(Ver, "V2", PdbRaw_DbiSecContribVer::DbiSecContribV2);
   }
 };
 }
@@ -191,6 +199,25 @@ void MappingTraits<PdbInfoStream>::mapping(IO &IO, PdbInfoStream &Obj) {
   IO.mapOptional("Version", Obj.Version, PdbImplVC70);
 }
 
+void MappingTraits<PdbDbiSectionContribs>::mapping(IO &IO,
+                                                   PdbDbiSectionContribs &Obj) {
+  IO.mapOptional("Version", Obj.Version,
+                 PdbRaw_DbiSecContribVer::DbiSecContribVer60);
+  IO.mapOptional("Items", Obj.Items);
+}
+
+void MappingTraits<PdbDbiSectionContrib>::mapping(IO &IO,
+                                                  PdbDbiSectionContrib &Obj) {
+  IO.mapOptional("ISect", Obj.ISect);
+  IO.mapOptional("Offset", Obj.Off);
+  IO.mapOptional("Size", Obj.Size);
+  IO.mapOptional("Characteristics", Obj.Characteristics);
+  IO.mapOptional("Imod", Obj.Imod);
+  IO.mapOptional("DataCrc", Obj.DataCrc);
+  IO.mapOptional("RelocCrc", Obj.RelocCrc);
+  IO.mapOptional("ISectCoff", Obj.ISectCoff);
+}
+
 void MappingTraits<PdbDbiStream>::mapping(IO &IO, PdbDbiStream &Obj) {
   IO.mapOptional("VerHeader", Obj.VerHeader, PdbDbiV70);
   IO.mapOptional("Age", Obj.Age, 1U);
@@ -208,6 +235,7 @@ void MappingTraits<PdbDbiStream>::mapping(IO &IO, PdbDbiStream &Obj) {
   }
   IO.mapOptional("Modules", Obj.ModInfos);
   IO.mapOptional("SectionHeaders", Obj.SectionHeaders);
+  IO.mapOptional("SectionContribs", Obj.SectionContribs);
 }
 
 void MappingTraits<PdbTpiStream>::mapping(IO &IO,

--- a/llvm/tools/llvm-pdbutil/PdbYaml.h
+++ b/llvm/tools/llvm-pdbutil/PdbYaml.h
@@ -91,6 +91,23 @@ struct PdbDbiModuleInfo {
   std::optional<PdbModiStream> Modi;
 };
 
+struct PdbDbiSectionContrib {
+  uint16_t ISect = 0;
+  int32_t Off = 0;
+  int32_t Size = 0;
+  uint32_t Characteristics = 0;
+  uint16_t Imod = 0;
+  uint32_t DataCrc = 0;
+  uint32_t RelocCrc = 0;
+  /// Only in `SectionContrib2`.
+  uint32_t ISectCoff = 0;
+};
+
+struct PdbDbiSectionContribs {
+  PdbRaw_DbiSecContribVer Version = PdbRaw_DbiSecContribVer::DbiSecContribVer60;
+  std::vector<PdbDbiSectionContrib> Items;
+};
+
 struct PdbDbiStream {
   PdbRaw_DbiVer VerHeader = PdbDbiV70;
   uint32_t Age = 1;
@@ -103,6 +120,7 @@ struct PdbDbiStream {
   std::vector<PdbDbiModuleInfo> ModInfos;
   COFF::header FakeHeader;
   std::vector<CoffSectionHeader> SectionHeaders;
+  std::optional<PdbDbiSectionContribs> SectionContribs;
 };
 
 struct PdbTpiStream {
@@ -145,6 +163,8 @@ LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::MSFHeaders)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(msf::SuperBlock)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::StreamBlockList)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbInfoStream)
+LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbDbiSectionContrib)
+LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbDbiSectionContribs)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbDbiStream)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbTpiStream)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbPublicsStream)

--- a/llvm/tools/llvm-pdbutil/PdbYaml.h
+++ b/llvm/tools/llvm-pdbutil/PdbYaml.h
@@ -90,6 +90,23 @@ struct PdbDbiModuleInfo {
   std::optional<PdbModiStream> Modi;
 };
 
+struct PdbDbiSectionContrib {
+  uint16_t ISect = 0;
+  int32_t Off = 0;
+  int32_t Size = 0;
+  uint32_t Characteristics = 0;
+  uint16_t Imod = 0;
+  uint32_t DataCrc = 0;
+  uint32_t RelocCrc = 0;
+  /// Only in `SectionContrib2`.
+  uint32_t ISectCoff = 0;
+};
+
+struct PdbDbiSectionContribs {
+  PdbRaw_DbiSecContribVer Version = PdbRaw_DbiSecContribVer::DbiSecContribVer60;
+  std::vector<PdbDbiSectionContrib> Items;
+};
+
 struct PdbDbiStream {
   PdbRaw_DbiVer VerHeader = PdbDbiV70;
   uint32_t Age = 1;
@@ -102,6 +119,7 @@ struct PdbDbiStream {
   std::vector<PdbDbiModuleInfo> ModInfos;
   COFF::header FakeHeader;
   std::vector<CoffSectionHeader> SectionHeaders;
+  std::optional<PdbDbiSectionContribs> SectionContribs;
 };
 
 struct PdbTpiStream {
@@ -139,6 +157,8 @@ LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::MSFHeaders)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(msf::SuperBlock)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::StreamBlockList)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbInfoStream)
+LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbDbiSectionContrib)
+LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbDbiSectionContribs)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbDbiStream)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbTpiStream)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbPublicsStream)

--- a/llvm/tools/llvm-pdbutil/YAMLOutputStyle.cpp
+++ b/llvm/tools/llvm-pdbutil/YAMLOutputStyle.cpp
@@ -19,6 +19,7 @@
 #include "llvm/DebugInfo/MSF/MappedBlockStream.h"
 #include "llvm/DebugInfo/PDB/Native/DbiStream.h"
 #include "llvm/DebugInfo/PDB/Native/GlobalsStream.h"
+#include "llvm/DebugInfo/PDB/Native/ISectionContribVisitor.h"
 #include "llvm/DebugInfo/PDB/Native/InfoStream.h"
 #include "llvm/DebugInfo/PDB/Native/ModuleDebugStream.h"
 #include "llvm/DebugInfo/PDB/Native/PDBFile.h"
@@ -307,6 +308,41 @@ Error YAMLOutputStyle::dumpDbiStream() {
       Hdr.Characteristics = Section.Characteristics;
       Obj.DbiStream->SectionHeaders.emplace_back(Hdr);
     }
+  }
+
+  if (opts::pdb2yaml::DumpSectionContribs) {
+    struct Visitor : public ISectionContribVisitor {
+      Visitor(std::vector<yaml::PdbDbiSectionContrib> &Out) : Out(Out) {}
+
+      static yaml::PdbDbiSectionContrib createFromSC(const SectionContrib &C) {
+        yaml::PdbDbiSectionContrib SC;
+        SC.ISect = C.ISect;
+        SC.Off = C.Off;
+        SC.Size = C.Size;
+        SC.Characteristics = C.Characteristics;
+        SC.Imod = C.Imod;
+        SC.DataCrc = C.DataCrc;
+        SC.RelocCrc = C.RelocCrc;
+        return SC;
+      }
+
+      void visit(const SectionContrib &C) override {
+        Out.emplace_back(createFromSC(C));
+      }
+      void visit(const SectionContrib2 &C) override {
+        yaml::PdbDbiSectionContrib SC = createFromSC(C.Base);
+        SC.ISectCoff = C.ISectCoff;
+        Out.emplace_back(SC);
+      }
+
+      std::vector<yaml::PdbDbiSectionContrib> &Out;
+    };
+    Obj.DbiStream->SectionContribs.emplace(yaml::PdbDbiSectionContribs{
+        /*Version=*/DS.getSectionContributionsVersion(),
+        /*Items=*/{},
+    });
+    Visitor Vis(Obj.DbiStream->SectionContribs->Items);
+    DS.visitSectionContributions(Vis);
   }
 
   return Error::success();

--- a/llvm/tools/llvm-pdbutil/YAMLOutputStyle.cpp
+++ b/llvm/tools/llvm-pdbutil/YAMLOutputStyle.cpp
@@ -19,6 +19,7 @@
 #include "llvm/DebugInfo/MSF/MappedBlockStream.h"
 #include "llvm/DebugInfo/PDB/Native/DbiStream.h"
 #include "llvm/DebugInfo/PDB/Native/GlobalsStream.h"
+#include "llvm/DebugInfo/PDB/Native/ISectionContribVisitor.h"
 #include "llvm/DebugInfo/PDB/Native/InfoStream.h"
 #include "llvm/DebugInfo/PDB/Native/ModuleDebugStream.h"
 #include "llvm/DebugInfo/PDB/Native/PDBFile.h"
@@ -301,6 +302,41 @@ Error YAMLOutputStyle::dumpDbiStream() {
       Hdr.Characteristics = Section.Characteristics;
       Obj.DbiStream->SectionHeaders.emplace_back(Hdr);
     }
+  }
+
+  if (opts::pdb2yaml::DumpSectionContribs) {
+    struct Visitor : public ISectionContribVisitor {
+      Visitor(std::vector<yaml::PdbDbiSectionContrib> &Out) : Out(Out) {}
+
+      static yaml::PdbDbiSectionContrib createFromSC(const SectionContrib &C) {
+        yaml::PdbDbiSectionContrib SC;
+        SC.ISect = C.ISect;
+        SC.Off = C.Off;
+        SC.Size = C.Size;
+        SC.Characteristics = C.Characteristics;
+        SC.Imod = C.Imod;
+        SC.DataCrc = C.DataCrc;
+        SC.RelocCrc = C.RelocCrc;
+        return SC;
+      }
+
+      void visit(const SectionContrib &C) override {
+        Out.emplace_back(createFromSC(C));
+      }
+      void visit(const SectionContrib2 &C) override {
+        yaml::PdbDbiSectionContrib SC = createFromSC(C.Base);
+        SC.ISectCoff = C.ISectCoff;
+        Out.emplace_back(SC);
+      }
+
+      std::vector<yaml::PdbDbiSectionContrib> &Out;
+    };
+    Obj.DbiStream->SectionContribs.emplace(yaml::PdbDbiSectionContribs{
+        /*Version=*/DS.getSectionContributionsVersion(),
+        /*Items=*/{},
+    });
+    Visitor Vis(Obj.DbiStream->SectionContribs->Items);
+    DS.visitSectionContributions(Vis);
   }
 
   return Error::success();

--- a/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
+++ b/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
@@ -726,6 +726,10 @@ cl::opt<bool> DumpSectionHeaders("section-headers",
                                  cl::desc("Dump section headers."),
                                  cl::cat(FileOptions),
                                  cl::sub(PdbToYamlSubcommand));
+cl::opt<bool> DumpSectionContribs("section-contribs",
+                                  cl::desc("dump section contributions"),
+                                  cl::cat(FileOptions),
+                                  cl::sub(PdbToYamlSubcommand));
 
 cl::list<std::string> InputFilename(cl::Positional,
                                     cl::desc("<input PDB file>"), cl::Required,
@@ -896,6 +900,31 @@ static void yamlToPdb(StringRef Path) {
         Allocator, MI.Subsections, Strings));
     for (auto &SS : CodeViewSubsections) {
       ModiBuilder.addDebugSubsection(SS);
+    }
+  }
+
+  if (Dbi.SectionContribs) {
+    if (Dbi.SectionContribs->Version !=
+        PdbRaw_DbiSecContribVer::DbiSecContribVer60) {
+      errs() << "Only DBI section contrib Version Ver60 is supported\n";
+      errs().flush();
+      exit(1);
+    }
+
+    for (const auto &Contrib : Dbi.SectionContribs->Items) {
+      SectionContrib SC;
+      SC.ISect = Contrib.ISect;
+      SC.Padding[0] = 0;
+      SC.Padding[1] = 0;
+      SC.Off = Contrib.Off;
+      SC.Size = Contrib.Size;
+      SC.Characteristics = Contrib.Characteristics;
+      SC.Imod = Contrib.Imod;
+      SC.Padding2[0] = 0;
+      SC.Padding2[1] = 0;
+      SC.DataCrc = Contrib.DataCrc;
+      SC.RelocCrc = Contrib.RelocCrc;
+      DbiBuilder.addSectionContrib(SC);
     }
   }
 
@@ -1595,6 +1624,7 @@ int main(int Argc, const char **Argv) {
       opts::pdb2yaml::DumpModuleFiles = true;
       opts::pdb2yaml::DumpModuleSyms = true;
       opts::pdb2yaml::DumpSectionHeaders = true;
+      opts::pdb2yaml::DumpSectionContribs = true;
       opts::pdb2yaml::DumpModuleSubsections.push_back(
           opts::ModuleSubsection::All);
     }
@@ -1607,6 +1637,9 @@ int main(int Argc, const char **Argv) {
       opts::pdb2yaml::DbiStream = true;
 
     if (opts::pdb2yaml::DumpSectionHeaders)
+      opts::pdb2yaml::DbiStream = true;
+
+    if (opts::pdb2yaml::DumpSectionContribs)
       opts::pdb2yaml::DbiStream = true;
   }
 

--- a/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
+++ b/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
@@ -904,12 +904,11 @@ static void yamlToPdb(StringRef Path) {
   }
 
   if (Dbi.SectionContribs) {
+    // DbiStreamBuilder only supports writing Ver60 section contribs.
     if (Dbi.SectionContribs->Version !=
-        PdbRaw_DbiSecContribVer::DbiSecContribVer60) {
-      errs() << "Only DBI section contrib Version Ver60 is supported\n";
-      errs().flush();
-      exit(1);
-    }
+        PdbRaw_DbiSecContribVer::DbiSecContribVer60)
+      ExitOnErr(createStringError(
+          "Only DBI section contrib Version Ver60 is supported"));
 
     for (const auto &Contrib : Dbi.SectionContribs->Items) {
       SectionContrib SC;
@@ -1633,13 +1632,8 @@ int main(int Argc, const char **Argv) {
     if (opts::pdb2yaml::DumpModuleSyms || opts::pdb2yaml::DumpModuleFiles)
       opts::pdb2yaml::DumpModules = true;
 
-    if (opts::pdb2yaml::DumpModules)
-      opts::pdb2yaml::DbiStream = true;
-
-    if (opts::pdb2yaml::DumpSectionHeaders)
-      opts::pdb2yaml::DbiStream = true;
-
-    if (opts::pdb2yaml::DumpSectionContribs)
+    if (opts::pdb2yaml::DumpModules || opts::pdb2yaml::DumpSectionHeaders ||
+        opts::pdb2yaml::DumpSectionContribs)
       opts::pdb2yaml::DbiStream = true;
   }
 

--- a/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
+++ b/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
@@ -721,6 +721,10 @@ cl::opt<bool> DumpSectionHeaders("section-headers",
                                  cl::desc("Dump section headers."),
                                  cl::cat(FileOptions),
                                  cl::sub(PdbToYamlSubcommand));
+cl::opt<bool> DumpSectionContribs("section-contribs",
+                                  cl::desc("dump section contributions"),
+                                  cl::cat(FileOptions),
+                                  cl::sub(PdbToYamlSubcommand));
 
 cl::list<std::string> InputFilename(cl::Positional,
                                     cl::desc("<input PDB file>"), cl::Required,
@@ -867,6 +871,31 @@ static void yamlToPdb(StringRef Path) {
         Allocator, MI.Subsections, Strings));
     for (auto &SS : CodeViewSubsections) {
       ModiBuilder.addDebugSubsection(SS);
+    }
+  }
+
+  if (Dbi.SectionContribs) {
+    if (Dbi.SectionContribs->Version !=
+        PdbRaw_DbiSecContribVer::DbiSecContribVer60) {
+      errs() << "Only DBI section contrib Version Ver60 is supported\n";
+      errs().flush();
+      exit(1);
+    }
+
+    for (const auto &Contrib : Dbi.SectionContribs->Items) {
+      SectionContrib SC;
+      SC.ISect = Contrib.ISect;
+      SC.Padding[0] = 0;
+      SC.Padding[1] = 0;
+      SC.Off = Contrib.Off;
+      SC.Size = Contrib.Size;
+      SC.Characteristics = Contrib.Characteristics;
+      SC.Imod = Contrib.Imod;
+      SC.Padding2[0] = 0;
+      SC.Padding2[1] = 0;
+      SC.DataCrc = Contrib.DataCrc;
+      SC.RelocCrc = Contrib.RelocCrc;
+      DbiBuilder.addSectionContrib(SC);
     }
   }
 
@@ -1565,6 +1594,7 @@ int main(int Argc, const char **Argv) {
       opts::pdb2yaml::DumpModuleFiles = true;
       opts::pdb2yaml::DumpModuleSyms = true;
       opts::pdb2yaml::DumpSectionHeaders = true;
+      opts::pdb2yaml::DumpSectionContribs = true;
       opts::pdb2yaml::DumpModuleSubsections.push_back(
           opts::ModuleSubsection::All);
     }
@@ -1577,6 +1607,9 @@ int main(int Argc, const char **Argv) {
       opts::pdb2yaml::DbiStream = true;
 
     if (opts::pdb2yaml::DumpSectionHeaders)
+      opts::pdb2yaml::DbiStream = true;
+
+    if (opts::pdb2yaml::DumpSectionContribs)
       opts::pdb2yaml::DbiStream = true;
   }
 

--- a/llvm/tools/llvm-pdbutil/llvm-pdbutil.h
+++ b/llvm/tools/llvm-pdbutil/llvm-pdbutil.h
@@ -202,6 +202,7 @@ extern llvm::cl::opt<bool> DumpModuleFiles;
 extern llvm::cl::list<ModuleSubsection> DumpModuleSubsections;
 extern llvm::cl::opt<bool> DumpModuleSyms;
 extern llvm::cl::opt<bool> DumpSectionHeaders;
+extern llvm::cl::opt<bool> DumpSectionContribs;
 extern llvm::cl::opt<bool> DXContainerStream;
 } // namespace pdb2yaml
 

--- a/llvm/tools/llvm-pdbutil/llvm-pdbutil.h
+++ b/llvm/tools/llvm-pdbutil/llvm-pdbutil.h
@@ -202,6 +202,7 @@ extern llvm::cl::opt<bool> DumpModuleFiles;
 extern llvm::cl::list<ModuleSubsection> DumpModuleSubsections;
 extern llvm::cl::opt<bool> DumpModuleSyms;
 extern llvm::cl::opt<bool> DumpSectionHeaders;
+extern llvm::cl::opt<bool> DumpSectionContribs;
 } // namespace pdb2yaml
 
 namespace explain {


### PR DESCRIPTION
The DBI section contribs stream is required for line information in WinDBG and VS - otherwise, you can't set line breakpoints. With this PR, we generate and parse it in yaml2pdb/pdb2yaml.

LLVM can't generate the `SectionContrib2` (`SC2`) record, so we don't support this in yaml2pdb. At least in my small test, MSVC didn't generate that record either.