### PR TITLE
[Clang-tidy] Add dummy compile_commands.json for broken test

### DIFF
--- a/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check.cpp
@@ -1,3 +1,5 @@
+// Broken due to https://github.com/llvm/llvm-project/issues/182526.
+// UNSUPPORTED: *
 // sed command does not work as-is on Windows.
 // UNSUPPORTED: system-windows
 // REQUIRES: custom-check

--- a/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check.cpp
@@ -1,5 +1,3 @@
-// Broken due to https://github.com/llvm/llvm-project/issues/182526.
-// UNSUPPORTED: {{.*}}
 // sed command does not work as-is on Windows.
 // UNSUPPORTED: system-windows
 // REQUIRES: custom-check
@@ -7,6 +5,8 @@
 // Using cqc-main.cpp in the hope that we don't have a file with that name in
 // our source tree. See: https://github.com/llvm/llvm-project/issues/182526
 // RUN: sed -e "s:INPUT_DIR:%S/Inputs/custom-query-check:g" -e "s:OUT_DIR:%t:g" -e "s:MAIN_FILE:%s:g" %S/Inputs/custom-query-check/vfsoverlay.yaml > %t.yaml
+// RUN: mkdir -p %t
+// RUN: echo '[{"file": "cqc-main.cpp", "directory": "%t", "command": "clang++ -c cqc-main.cpp"}]' > %t/compile_commands.json
 // RUN: clang-tidy --experimental-custom-checks %t/cqc-main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml | FileCheck %s --check-prefix=CHECK-SAME-DIR
 // RUN: clang-tidy --experimental-custom-checks %t/subdir/cqc-main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml | FileCheck %s --check-prefix=CHECK-SUB-DIR-BASE
 // RUN: clang-tidy --experimental-custom-checks %t/subdir-override/cqc-main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml | FileCheck %s --check-prefix=CHECK-SUB-DIR-OVERRIDE

--- a/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check.cpp
@@ -1,5 +1,5 @@
 // Broken due to https://github.com/llvm/llvm-project/issues/182526.
-// UNSUPPORTED: *
+// UNSUPPORTED: {{.*}}
 // sed command does not work as-is on Windows.
 // UNSUPPORTED: system-windows
 // REQUIRES: custom-check


### PR DESCRIPTION
Consequence of https://github.com/llvm/llvm-project/issues/182526.

With PCH used for unit tests (#191402), this breaks now due to matching:

llvm-build/tools/clang/tools/extra/test/clang-tidy/infrastructure/Output/custom-query-check.cpp.tmp/cqc-main.cpp

with:

llvm-build/tools/clang/tools/extra/clangd/unittests/DecisionForestRuntimeTest.cpp
