### PR TITLE
[NVPTX] change fp128 operation crashes to diagnostics.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
@@ -22,6 +22,8 @@
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/TargetParser/Triple.h"
 using namespace llvm;
 
 #define DEBUG_TYPE "legalize-types"
@@ -200,6 +202,17 @@ SDValue DAGTypeLegalizer::SoftenFloatRes_Unary(SDNode *N, RTLIB::Libcall LC) {
   TargetLowering::MakeLibCallOptions CallOptions;
   EVT OpVT = N->getOperand(0 + Offset).getValueType();
   CallOptions.setTypeListBeforeSoften(OpVT, N->getValueType(0));
+  if (DAG.getLibcalls().getLibcallImpl(LC) == RTLIB::Unsupported) {
+    // Preserve existing behavior for most targets (which aborts in
+    // TargetLowering::makeLibCall), but provide a clean diagnostic for NVPTX.
+    if (DAG.getMachineFunction().getTarget().getTargetTriple().isNVPTX()) {
+      DAG.getContext()->emitError(Twine("no libcall available for ") +
+                                  N->getOperationName(&DAG));
+      if (IsStrict)
+        ReplaceValueWith(SDValue(N, 1), Chain);
+      return DAG.getUNDEF(NVT);
+    }
+  }
   std::pair<SDValue, SDValue> Tmp = TLI.makeLibCall(DAG, LC, NVT, Op,
                                                     CallOptions, SDLoc(N),
                                                     Chain);
@@ -221,6 +234,17 @@ SDValue DAGTypeLegalizer::SoftenFloatRes_Binary(SDNode *N, RTLIB::Libcall LC) {
   EVT OpsVT[2] = { N->getOperand(0 + Offset).getValueType(),
                    N->getOperand(1 + Offset).getValueType() };
   CallOptions.setTypeListBeforeSoften(OpsVT, N->getValueType(0));
+  if (DAG.getLibcalls().getLibcallImpl(LC) == RTLIB::Unsupported) {
+    // Preserve existing behavior for most targets (which aborts in
+    // TargetLowering::makeLibCall), but provide a clean diagnostic for NVPTX.
+    if (DAG.getMachineFunction().getTarget().getTargetTriple().isNVPTX()) {
+      DAG.getContext()->emitError(Twine("no libcall available for ") +
+                                  N->getOperationName(&DAG));
+      if (IsStrict)
+        ReplaceValueWith(SDValue(N, 1), Chain);
+      return DAG.getUNDEF(NVT);
+    }
+  }
   std::pair<SDValue, SDValue> Tmp = TLI.makeLibCall(DAG, LC, NVT, Ops,
                                                     CallOptions, SDLoc(N),
                                                     Chain);

--- a/llvm/test/CodeGen/NVPTX/fp128-libcall-error.ll
+++ b/llvm/test/CodeGen/NVPTX/fp128-libcall-error.ll
@@ -1,0 +1,20 @@
+; RUN: split-file %s %t
+; RUN: not llc < %t/mul.ll -mtriple=nvptx64 -filetype=null 2>&1 | FileCheck %s --check-prefix=FMUL
+; RUN: not llc < %t/sqrt.ll -mtriple=nvptx64 -filetype=null 2>&1 | FileCheck %s --check-prefix=FSQRT
+
+; FMUL: error: no libcall available for fmul
+; FSQRT: error: no libcall available for fsqrt
+
+;--- mul.ll
+define fp128 @mul128(fp128 %a) {
+  %r = fmul fp128 %a, 0xL00000000000000004000400000000000
+  ret fp128 %r
+}
+
+;--- sqrt.ll
+define fp128 @sqrt128(fp128 %a) {
+  %r = call fp128 @llvm.sqrt.f128(fp128 %a)
+  ret fp128 %r
+}
+
+declare fp128 @llvm.sqrt.f128(fp128)


### PR DESCRIPTION
NVPTX currently aborts when SelectionDAG tries to soften unsupported fp128 libcalls. This change turns those cases into normal backend diagnostics and adds regression coverage for fmul and sqrt on fp128.

```
ninja -C build-local-ci llc FileCheck
build-local-ci/bin/llvm-lit -sv llvm/test/CodeGen/NVPTX/fp128-libcall-error.ll
```
