### PR TITLE
[Clangd] Don't traverse ConceptDecl in typeForNode

### DIFF
--- a/clang-tools-extra/clangd/XRefs.cpp
+++ b/clang-tools-extra/clangd/XRefs.cpp
@@ -2058,7 +2058,10 @@ static QualType typeForNode(const ASTContext &Ctx, const HeuristicResolver *H,
       }
       // Look inside templates.
       QualType VisitTemplateDecl(const TemplateDecl *D) {
-        return Visit(D->getTemplatedDecl());
+        if (const auto *TD = D->getTemplatedDecl())
+          return Visit(TD);
+        // ConceptDecl doesn't have any associated templates nor types.
+        return QualType();
       }
     } V(Ctx);
     return V.Visit(D);

--- a/clang-tools-extra/clangd/unittests/XRefsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/XRefsTests.cpp
@@ -2094,14 +2094,19 @@ TEST(FindType, All) {
 TEST(FindType, Definition) {
   Annotations A(R"cpp(
     class $decl[[X]];
-    X *^x;
+    X *$x^x;
     class $def[[X]] {};
+
+    template <class T>
+    concept $Concept^True = true;
   )cpp");
   auto TU = TestTU::withCode(A.code().str());
+  TU.ExtraArgs.push_back("-std=c++20");
   ParsedAST AST = TU.build();
 
-  EXPECT_THAT(findType(AST, A.point(), nullptr),
+  EXPECT_THAT(findType(AST, A.point("x"), nullptr),
               ElementsAre(sym("X", A.range("decl"), A.range("def"))));
+  EXPECT_THAT(findType(AST, A.point("Concept"), nullptr), IsEmpty());
 }
 
 TEST(FindType, Index) {


### PR DESCRIPTION
ConceptDecl doesn't have an associated template declaration, and it doesn't introduce a type either.

Fixes https://github.com/llvm/llvm-project/issues/188914
