### PR TITLE
[lld][MachO] Skip non-canonical ICF'd local symbols from regular nlist

### DIFF
--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -1376,6 +1376,19 @@ void SymtabSection::finalizeContents() {
   }
 
   emitStabs();
+
+  // When --keep-icf-stabs is enabled, STAB entries for ICF-folded symbols
+  // have been emitted above. Now remove non-canonical ICF'd local symbols
+  // from the regular nlist. Keeping them would produce duplicate entries at
+  // the same address, causing Apple's atos (and Crashlytics) to return
+  // "<deduplicated_symbol>" instead of a real function name.
+  if (config->keepICFStabs) {
+    llvm::erase_if(localSymbols, [](const SymtabEntry &e) {
+      auto *defined = dyn_cast<Defined>(e.sym);
+      return defined && !defined->isExternal() &&
+             defined->identicalCodeFoldingKind != Symbol::ICFFoldKind::None;
+    });
+  }
   uint32_t symtabIndex = stabs.size();
   for (const SymtabEntry &entry :
        concat<SymtabEntry>(localSymbols, externalSymbols, undefinedSymbols)) {

--- a/lld/test/MachO/Inputs/stabs-icf-local.s
+++ b/lld/test/MachO/Inputs/stabs-icf-local.s
@@ -1,0 +1,62 @@
+## Test input for stabs-icf.s: local (non-global) symbols that will be ICF'd.
+## _local_baz and _local_baz2 have identical bodies to _local_bar and will be
+## folded. Since they are local symbols, duplicate nlist entries at the same
+## address cause atos to return "<deduplicated_symbol>".
+
+.text
+.globl _main
+
+.subsections_via_symbols
+
+_local_bar:
+  ret
+
+_local_baz:
+  ret
+
+_local_baz2:
+  ret
+
+_main:
+Lfunc_begin0:
+  call _local_bar
+  call _local_baz
+  call _local_baz2
+  ret
+Lfunc_end0:
+
+.section  __DWARF,__debug_str,regular,debug
+  .asciz  "test.cpp"
+  .asciz  "/tmp"
+.section  __DWARF,__debug_abbrev,regular,debug
+Lsection_abbrev:
+  .byte  1
+  .byte  17
+  .byte  1
+  .byte  3
+  .byte  14
+  .byte  27
+  .byte  14
+  .byte  17
+  .byte  1
+  .byte  18
+  .byte  6
+  .byte  0
+  .byte  0
+  .byte  0
+.section  __DWARF,__debug_info,regular,debug
+.set Lset0, Ldebug_info_end0-Ldebug_info_start0
+  .long  Lset0
+Ldebug_info_start0:
+  .short  4
+.set Lset1, Lsection_abbrev-Lsection_abbrev
+  .long  Lset1
+  .byte  8
+  .byte  1
+  .long  0
+  .long  9
+  .quad  Lfunc_begin0
+.set Lset3, Lfunc_end0-Lfunc_begin0
+  .long  Lset3
+  .byte  0
+Ldebug_info_end0:

--- a/lld/test/MachO/stabs-icf.s
+++ b/lld/test/MachO/stabs-icf.s
@@ -7,6 +7,13 @@
 # RUN: %lld -lSystem --icf=all %t.o -o %t_icf_stabs --keep-icf-stabs
 # RUN: dsymutil -s %t_icf_stabs | FileCheck %s -DDIR=%t_icf_stabs -DSRC_PATH=%t.o --check-prefixes=ICF_STABS
 
+## Verify that --keep-icf-stabs with local (non-global) symbols emits STAB
+## entries for all ICF'd functions but only one regular nlist entry per address.
+## This prevents atos from returning "<deduplicated_symbol>".
+# RUN: llvm-mc -filetype=obj -triple=x86_64-apple-darwin %S/Inputs/stabs-icf-local.s -o %t_local.o
+# RUN: %lld -lSystem --icf=all %t_local.o -o %t_local --keep-icf-stabs
+# RUN: dsymutil -s %t_local | FileCheck %s -DDIR=%t_local -DSRC_PATH=%t_local.o --check-prefixes=ICF_LOCAL
+
 ## This should include no N_FUN entry for _baz (which is ICF'd into _bar),
 ## but it does include a SECT EXT entry.
 ## NOTE: We do not omit the N_FUN entry for _bar even though it is of size zero.
@@ -52,6 +59,28 @@
 # ICF_STABS-DAG:  (       {{.*}}) {{[0-9]+}}                 0010   {{[0-9a-f]+}}      '__mh_execute_header'
 # ICF_STABS-DAG:  (       {{.*}}) {{[0-9]+}}                 0100   0000000000000000   'dyld_stub_binder'
 # ICF_STABS-EMPTY:
+
+## --keep-icf-stabs with local symbols: STAB entries for all functions should
+## be present, but only the canonical local symbol gets a regular nlist entry.
+## _local_baz and _local_baz2 are ICF'd into _local_bar; they should have
+## N_FUN STABs but no SECT nlist entries.
+# ICF_LOCAL:      (N_SO         ) 00      0000   0000000000000000  '/tmp{{[/\\]}}test.cpp'
+# ICF_LOCAL-NEXT: (N_OSO        ) 03      0001   {{.*}} '[[SRC_PATH]]'
+# ICF_LOCAL-NEXT: (N_FUN        ) 01      0000   [[#%.16x,LMAIN:]]  '_main'
+# ICF_LOCAL-NEXT: (N_FUN        ) 00      0000   {{.*}}
+# ICF_LOCAL-NEXT: (N_FUN        ) 01      0000   [[#%.16x,LBAR:]]   '_local_bar'
+# ICF_LOCAL-NEXT: (N_FUN        ) 00      0000   {{.*}}
+# ICF_LOCAL-NEXT: (N_FUN        ) 01      0000   [[#LBAR]]          '_local_baz'
+# ICF_LOCAL-NEXT: (N_FUN        ) 00      0000   {{.*}}
+# ICF_LOCAL-NEXT: (N_FUN        ) 01      0000   [[#LBAR]]          '_local_baz2'
+# ICF_LOCAL-NEXT: (N_FUN        ) 00      0000   {{.*}}
+# ICF_LOCAL-NEXT: (N_SO         ) 01      0000   0000000000000000{{$}}
+## Only the canonical local symbol should appear in the regular nlist.
+# ICF_LOCAL-DAG:  (     SECT EXT) 01      0000   [[#LMAIN]]         '_main'
+# ICF_LOCAL-DAG:  (     SECT    ) 01      0000   [[#LBAR]]          '_local_bar'
+## ICF'd local symbols must NOT have regular nlist entries.
+# ICF_LOCAL-NOT:  (     SECT    ) {{.*}} '_local_baz'
+# ICF_LOCAL-NOT:  (     SECT    ) {{.*}} '_local_baz2'
 
 
 .text


### PR DESCRIPTION
## Summary

When `--keep-icf-stabs` is used with `--icf=all`, lld emits both STAB entries (N_FUN) and regular nlist entries for every ICF-folded symbol. The STAB entries are required so `dsymutil` can locate DWARF debug info for all folded functions.

However, the duplicate regular nlist entries at the same address cause Apple's `atos` (and Crashlytics server-side symbolication) to return `<deduplicated_symbol>` instead of a real function name. This only affects **local** (non-external) symbols; `atos` handles external symbols at the same address correctly.

After emitting STABs, this patch removes non-canonical ICF-folded local symbols from the regular nlist using `llvm::erase_if`. The result:

- `dsymutil` still finds all DWARF via STAB entries
- The dSYM contains one nlist entry per ICF'd address
- `atos` returns a real function name
- All DWARF subprogram DIEs are preserved in the dSYM

## Background

In a real-world iOS app with `--icf=all --keep-icf-stabs`, we observed 70+ local symbols folded to the same address. `atos` (and Crashlytics) returned `<deduplicated_symbol>` for every crash frame at those addresses, making crash reports unreadable. This fix eliminates the issue at link time.

The key insight is that `emitStabs()` and the regular nlist are independent:
- STAB entries go into the `stabs` vector (emitted by `emitStabs()`)
- Regular nlist entries come from `localSymbols` / `externalSymbols`

After `emitStabs()` runs, we can safely remove ICF'd locals from `localSymbols` without affecting STAB emission.

## Test

Extended `lld/test/MachO/stabs-icf.s` with a local-symbol test case that verifies:
- N_FUN STAB entries exist for all ICF'd local functions
- Only the canonical local symbol has a regular nlist entry
- ICF'd local symbols do NOT appear in the regular nlist

Made with [Cursor](https://cursor.com)