### PR TITLE
[MLIR][GPU] Support synchronous gpu.alloc and gpu.dealloc in gpu-to-llvm

### DIFF
--- a/mlir/lib/Conversion/GPUCommon/GPUToLLVMConversion.cpp
+++ b/mlir/lib/Conversion/GPUCommon/GPUToLLVMConversion.cpp
@@ -771,8 +771,9 @@ LogicalResult ConvertAllocOpToGpuRuntimeCallPattern::matchAndRewrite(
   if (isShared && allocOp.getAsyncToken())
     return rewriter.notifyMatchFailure(
         allocOp, "Host Shared allocation cannot be done async");
-  if (!isShared && failed(isAsyncWithOneDependency(rewriter, allocOp)))
-    return failure();
+  if (adaptor.getAsyncDependencies().size() > 1)
+    return rewriter.notifyMatchFailure(
+        allocOp, "Can convert with at most one async dependency.");
 
   // Get shape of the memref as values: static sizes are constant
   // values and dynamic sizes are passed to 'alloc' as operands.
@@ -796,6 +797,18 @@ LogicalResult ConvertAllocOpToGpuRuntimeCallPattern::matchAndRewrite(
       allocCallBuilder.create(loc, rewriter, {sizeBytes, stream, isHostShared})
           .getResult();
 
+  // Cast the runtime-returned pointer to the memref's address space if it
+  // isn't there already, so it fits the descriptor's pointer slots.
+  unsigned dstAddrSpace = memRefType.getMemorySpaceAsInt();
+  unsigned srcAddrSpace =
+      cast<LLVM::LLVMPointerType>(allocatedPtr.getType()).getAddressSpace();
+  if (dstAddrSpace != srcAddrSpace) {
+    auto targetPtrTy =
+        LLVM::LLVMPointerType::get(rewriter.getContext(), dstAddrSpace);
+    allocatedPtr =
+        LLVM::AddrSpaceCastOp::create(rewriter, loc, targetPtrTy, allocatedPtr);
+  }
+
   // No alignment.
   Value alignedPtr = allocatedPtr;
 
@@ -816,18 +829,29 @@ LogicalResult ConvertAllocOpToGpuRuntimeCallPattern::matchAndRewrite(
 LogicalResult ConvertDeallocOpToGpuRuntimeCallPattern::matchAndRewrite(
     gpu::DeallocOp deallocOp, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  if (failed(areAllLLVMTypes(deallocOp, adaptor.getOperands(), rewriter)) ||
-      failed(isAsyncWithOneDependency(rewriter, deallocOp)))
+  if (failed(areAllLLVMTypes(deallocOp, adaptor.getOperands(), rewriter)))
     return failure();
+  if (adaptor.getAsyncDependencies().size() > 1)
+    return rewriter.notifyMatchFailure(
+        deallocOp, "Can convert with at most one async dependency.");
 
   Location loc = deallocOp.getLoc();
 
   Value pointer =
       MemRefDescriptor(adaptor.getMemref()).allocatedPtr(rewriter, loc);
-  Value stream = adaptor.getAsyncDependencies().front();
+  auto nullPtr = mlir::LLVM::ZeroOp::create(rewriter, loc, llvmPointerType);
+  Value stream = adaptor.getAsyncDependencies().empty()
+                     ? nullPtr
+                     : adaptor.getAsyncDependencies().front();
   deallocCallBuilder.create(loc, rewriter, {pointer, stream});
 
-  rewriter.replaceOp(deallocOp, {stream});
+  if (deallocOp.getAsyncToken()) {
+    // Async dealloc: propagate the stream as the async token replacement.
+    rewriter.replaceOp(deallocOp, {stream});
+  } else {
+    // Sync dealloc: no results to replace, just remove the op.
+    rewriter.eraseOp(deallocOp);
+  }
   return success();
 }
 

--- a/mlir/test/Conversion/GPUCommon/lower-alloc-to-gpu-runtime-calls.mlir
+++ b/mlir/test/Conversion/GPUCommon/lower-alloc-to-gpu-runtime-calls.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --gpu-to-llvm | FileCheck %s
+// RUN: mlir-opt %s --gpu-to-llvm -split-input-file | FileCheck %s
 
 module attributes {gpu.container_module} {
   // CHECK-LABEL: llvm.func @main
@@ -20,6 +20,22 @@ module attributes {gpu.container_module} {
     return
   }
 
+  // CHECK-LABEL: llvm.func @alloc_dealloc_sync
+  // CHECK-SAME: %[[size:.*]]: i64
+  func.func @alloc_dealloc_sync(%size : index) {
+    // CHECK: %[[gep:.*]] = llvm.getelementptr {{.*}}[%[[size]]]
+    // CHECK: %[[size_bytes:.*]] = llvm.ptrtoint %[[gep]]
+    // CHECK: %[[nullptr:.*]] = llvm.mlir.zero
+    // CHECK: %[[isHostShared:.*]] = llvm.mlir.constant
+    // CHECK: llvm.call @mgpuMemAlloc(%[[size_bytes]], %[[nullptr]], %[[isHostShared]])
+    %0 = gpu.alloc (%size) : memref<?xf32>
+    // CHECK: %[[float_ptr:.*]] = llvm.extractvalue {{.*}}[0]
+    // CHECK: %[[nullptr2:.*]] = llvm.mlir.zero
+    // CHECK: llvm.call @mgpuMemFree(%[[float_ptr]], %[[nullptr2]])
+    gpu.dealloc %0 : memref<?xf32>
+    return
+  }
+
   // CHECK-LABEL: llvm.func @alloc_sync
   // CHECK-SAME: %[[size:.*]]: i64
   func.func @alloc_sync(%size : index) {
@@ -35,6 +51,26 @@ module attributes {gpu.container_module} {
     // CHECK: llvm.call @mgpuStreamSynchronize(%[[stream]])
     // CHECK: llvm.call @mgpuStreamDestroy(%[[stream]])
     gpu.wait [%2]
+    return
+  }
+}
+
+// -----
+
+// More than one async dependency is not supported; the alloc and dealloc
+// should be left unconverted.
+module attributes {gpu.container_module} {
+  // CHECK-LABEL: func @multi_dep_unsupported
+  func.func @multi_dep_unsupported(%size : index) {
+    %t1 = gpu.wait async
+    %t2 = gpu.wait async
+    // CHECK: gpu.alloc async [{{.*}}, {{.*}}]
+    // CHECK-NOT: mgpuMemAlloc
+    %buf, %t3 = gpu.alloc async [%t1, %t2] (%size) : memref<?xf32>
+    // CHECK: gpu.dealloc async [{{.*}}, {{.*}}]
+    // CHECK-NOT: mgpuMemFree
+    %t4 = gpu.dealloc async [%t3, %t1] %buf : memref<?xf32>
+    gpu.wait [%t4]
     return
   }
 }

--- a/mlir/test/Conversion/GPUCommon/lower-launch-func-bare-ptr.mlir
+++ b/mlir/test/Conversion/GPUCommon/lower-launch-func-bare-ptr.mlir
@@ -16,9 +16,10 @@ module attributes {gpu.container_module} {
     }
   }
   func.func @foo() {
-    // CHECK: [[MEMREF:%.*]] = gpu.alloc () : memref<10xf32, 1>
-    // CHECK: [[DESCRIPTOR:%.*]] = builtin.unrealized_conversion_cast [[MEMREF]] : memref<10xf32, 1> to !llvm.struct<(ptr<1>, ptr<1>, i64, array<1 x i64>, array<1 x i64>)>
-    // CHECK: [[PTR:%.*]] = llvm.extractvalue [[DESCRIPTOR]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<1 x i64>, array<1 x i64>)>
+    // CHECK: [[ALLOCATED:%.*]] = llvm.call @mgpuMemAlloc({{.*}}) : (i64, !llvm.ptr, i8) -> !llvm.ptr
+    // CHECK: [[CAST:%.*]] = llvm.addrspacecast [[ALLOCATED]] : !llvm.ptr to !llvm.ptr<1>
+    // CHECK: [[DESCRIPTOR:%.*]] = llvm.insertvalue [[CAST]], {{.*}}[0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<1 x i64>, array<1 x i64>)>
+    // CHECK: [[PTR:%.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<1 x i64>, array<1 x i64>)>
     // CHECK: gpu.launch_func  @kernels::@kernel_1 blocks in ({{.*}}) threads in ({{.*}}) : i64
     // CHECK: args(%{{.*}} : f32, [[PTR]] : !llvm.ptr<1>)
     %0 = arith.constant 0. : f32


### PR DESCRIPTION
The gpu-to-llvm conversion patterns for gpu.alloc and gpu.dealloc previously required async tokens for non-host shared operations. This prevented lowering synchronous device memory allocation and deallocation to runtime calls.

Changes:
- gpu.alloc: drop the isAsyncWithOneDependency guard for non-shared allocs. Cap the number of async dependencies at one to preserve the prior single-dependency invariant. Cast the runtime-returned pointer to the memref's address space when they differ, so the descriptor's pointer slots type-check for memref<..., N>.
- gpu.dealloc: drop the async requirement entirely. Use a null stream when no async dependencies are present. Use eraseOp instead of replaceOp for sync deallocs (which have no results). Cap the number of async dependencies at one.
- Add a unit test for the synchronous alloc/dealloc lowering and a test that more than one async dependency leaves the op unconverted.
- Update lower-launch-func-bare-ptr.mlir, which previously asserted gpu.alloc survived the conversion (because the pattern bailed for sync non-shared allocs); it now asserts the full lowering through mgpuMemAlloc + addrspacecast.

Assisted-by: Claude