### PR TITLE
[BOLT][runtime] fix readlink bound check in getBinaryPath.

### DIFF
--- a/bolt/runtime/instr.cpp
+++ b/bolt/runtime/instr.cpp
@@ -724,8 +724,9 @@ static char *getBinaryPath() {
       char *C = strCopy(FindBuf, DirPath, NameMax);
       C = strCopy(C, d->d_name, NameMax - (C - FindBuf));
       *C = '\0';
-      uint32_t Ret = __readlink(FindBuf, TargetPath, sizeof(TargetPath));
-      assert(Ret != -1 && Ret != BufSize, "readlink error");
+      uint64_t Ret = __readlink(FindBuf, TargetPath, sizeof(TargetPath));
+      assert(static_cast<int64_t>(Ret) >= 0 && Ret < sizeof(TargetPath),
+             "readlink error");
       TargetPath[Ret] = '\0';
       __close(FDdir);
       return TargetPath;


### PR DESCRIPTION
Ret was uint32_t truncating the uint64_t __readlink return, and was compared against the unrelated getdents64 BufSize (1024) instead of sizeof(TargetPath) (NameMax, 4096). A truncated readlink of exactly NameMax bytes also wrote one byte past TargetPath.