### PR TITLE
[Hexagon] Add SafeStack runtime libcall to HexagonSystemLibrary

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -2800,7 +2800,8 @@ def HexagonSystemLibrary
     __umoddi3, __divdf3, __muldf3, __divsi3, __subdf3, sqrtf,
     __divdi3, __umodsi3, __moddi3, __modsi3), HexagonLibcalls,
     LibmHasSinCosF32, LibmHasSinCosF64, LibmHasSinCosF128,
-    exp10f, exp10, exp10l_f128, __stack_chk_fail, __stack_chk_guard)>;
+    exp10f, exp10, exp10l_f128, __stack_chk_fail, __stack_chk_guard,
+    DefaultSafeStackGlobals)>;
 
 //===----------------------------------------------------------------------===//
 // Lanai Runtime Libcalls

--- a/llvm/test/CodeGen/Hexagon/safestack.ll
+++ b/llvm/test/CodeGen/Hexagon/safestack.ll
@@ -1,0 +1,16 @@
+; RUN: llc -mtriple=hexagon < %s | FileCheck %s
+
+;; Verify that the SafeStack pass can locate __safestack_unsafe_stack_ptr
+;; for Hexagon (added via DefaultSafeStackGlobals in HexagonSystemLibrary).
+
+define void @test_safestack() safestack {
+entry:
+  %x = alloca i32, align 4
+  call void @capture(ptr nonnull %x)
+  ret void
+}
+
+declare void @capture(ptr)
+
+; CHECK-LABEL: test_safestack:
+; CHECK: __safestack_unsafe_stack_ptr


### PR DESCRIPTION
Register DefaultSafeStackGlobals for the Hexagon target so that the SafeStack pass can locate the thread-local unsafe stack pointer during codegen.

Without this, compiling with `-fsanitize=safe-stack` for Hexagon errors with "no location available for safestack pointer address".