### PR TITLE
[Clang] Fix crash when type-name is combined with class specifier in template argument

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -500,6 +500,7 @@ Bug Fixes to AST Handling
 - Fixed a bug where explicit nullability property attributes were not stored in AST nodes in Objective-C. (#GH179703)
 - Fixed a crash when parsing Doxygen ``@param`` commands attached to invalid declarations or non-function entities. (#GH182737)
 - Fixed the SourceLocation and SourceRange of reversed rewritten CXXOperatorCallExpr. (#GH192467)
+- Fixed a crash when a type-name is incorrectly combined with a class specifier within a template default argument. (#GH187664)
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -5984,11 +5984,15 @@ namespace {
           return;
         }
       }
+
+      NestedNameSpecifierLoc QualifierLoc;
+      if (TL.getTypePtr()->getQualifier())
+        QualifierLoc = DS.getTypeSpecScope().getWithLocInContext(Context);
+
       TL.set(TL.getTypePtr()->getKeyword() != ElaboratedTypeKeyword::None
                  ? DS.getTypeSpecTypeLoc()
                  : SourceLocation(),
-             DS.getTypeSpecScope().getWithLocInContext(Context),
-             DS.getTypeSpecTypeNameLoc());
+             QualifierLoc, DS.getTypeSpecTypeNameLoc());
     }
     void VisitUnresolvedUsingTypeLoc(UnresolvedUsingTypeLoc TL) {
       if (DS.getTypeSpecType() == TST_typename) {
@@ -6171,7 +6175,11 @@ namespace {
                                          ElaboratedTypeKeyword::None
                                      ? DS.getTypeSpecTypeLoc()
                                      : SourceLocation());
-      TL.setQualifierLoc(DS.getTypeSpecScope().getWithLocInContext(Context));
+
+      if (TL.getTypePtr()->getQualifier() &&
+          DS.getTypeSpecScope().getRange().isValid())
+        TL.setQualifierLoc(DS.getTypeSpecScope().getWithLocInContext(Context));
+
       TL.setNameLoc(DS.getTypeSpecTypeNameLoc());
     }
     void VisitAtomicTypeLoc(AtomicTypeLoc TL) {

--- a/clang/test/SemaTemplate/gh187664.cpp
+++ b/clang/test/SemaTemplate/gh187664.cpp
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+struct A {
+  struct B{};
+};
+
+A struct A::B i; // expected-error {{cannot combine with previous 'type-name' declaration specifier}}
+// expected-note@-1 + {{previous definition is here}}
+
+struct S{};
+S struct A::B i;
+// expected-error@-1 {{cannot combine with previous 'type-name' declaration specifier}}
+// expected-error@-2 {{redefinition of 'i' with a different type: 'S' vs 'A'}}
+
+using T = int;
+T struct A::B i;
+// expected-error@-1 {{cannot combine with previous 'type-name' declaration specifier}}
+// expected-error@-2 {{redefinition of 'i' with a different type: 'T' (aka 'int') vs 'A'}}
+
+namespace NS {
+  struct Scoped{};
+};
+
+S struct NS::Scoped i;
+// expected-error@-1 {{cannot combine with previous 'type-name' declaration specifier}}
+// expected-error@-2 {{redefinition of 'i' with a different type: 'S' vs 'A'}}
+
+S struct ::S i;
+// expected-error@-1 {{cannot combine with previous 'type-name' declaration specifier}}
+// expected-error@-2 {{redefinition of 'i' with a different type: 'S' vs 'A'}}


### PR DESCRIPTION
In addition to the existing conflict detection in `DeclSpec`, the state of `TypeScope` has been cleared to prevent erroneous data from leaking downstream.
close #187664 