### PR TITLE
[libc] Add wcsxfrm

### DIFF
--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -399,6 +399,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wchar.wmemset
     libc.src.wchar.wcschr
     libc.src.wchar.wcsncmp
+    libc.src.wchar.wcsxfrm
     libc.src.wchar.wcscmp
     libc.src.wchar.wcspbrk
     libc.src.wchar.wcsrchr

--- a/libc/include/wchar.yaml
+++ b/libc/include/wchar.yaml
@@ -354,3 +354,11 @@ functions:
     arguments:
       - type: const wchar_t *__restrict
       - type: wchar_t **__restrict
+  - name: wcsxfrm
+    standards:
+      - stdc
+    return_type: size_t
+    arguments:
+      - type: wchar_t *__restrict
+      - type: const wchar_t *__restrict
+      - type: size_t

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -550,4 +550,8 @@ add_entrypoint_object(
     wcsxfrm.cpp
   HDRS
     wcsxfrm.h
+  DEPENDS
+    libc.hdr.types.size_t
+    libc.hdr.types.wchar_t
+    libc.src.__support.macros.config
 )

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -554,4 +554,5 @@ add_entrypoint_object(
     libc.hdr.types.size_t
     libc.hdr.types.wchar_t
     libc.src.__support.macros.config
+    libc.src.__support.common
 )

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -543,3 +543,11 @@ add_entrypoint_object(
     libc.hdr.types.size_t
     libc.hdr.wchar_macros
 )
+
+add_entrypoint_object(
+  wcsxfrm
+  SRCS
+    wcsxfrm.cpp
+  HDRS
+    wcsxfrm.h
+)

--- a/libc/src/wchar/wcsxfrm.cpp
+++ b/libc/src/wchar/wcsxfrm.cpp
@@ -8,6 +8,9 @@
 
 #include "src/wchar/wcsxfrm.h"
 
+#include "hdr/types/size_t.h"
+#include "hdr/types/wchar_t.h"
+#include "src/__support/macros/config.h"
 #include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/wchar/wcsxfrm.cpp
+++ b/libc/src/wchar/wcsxfrm.cpp
@@ -1,0 +1,51 @@
+//===-- Implementation of wcsxfrm ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/wcsxfrm.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO: Add support for locale-aware collation keys.
+// For now, this implements C/POSIX-like behavior: the transformed form is the
+// original wide string itself, so comparing transformed strings with wcscmp
+// matches code-point order.
+LLVM_LIBC_FUNCTION(size_t, wcsxfrm,
+                   (wchar_t *__restrict dest, const wchar_t *__restrict src,
+                    size_t n)) {
+  // Number of source characters that may be written before the trailing NUL.
+  const size_t write_limit = n > 0 ? n - 1 : 0;
+
+  size_t i = 0;
+
+  // Single pass over the prefix we might need to copy.
+  // This avoids a full wcslen(src) pass for the common case where the source
+  // fits in the destination buffer.
+  for (; i < write_limit; ++i) {
+    const wchar_t ch = src[i];
+    if (ch == L'\0') {
+      dest[i] = L'\0';
+      return i;
+    }
+    dest[i] = ch;
+  }
+
+  // If n > 0, always NUL-terminate. This is correct both when truncating and
+  // when write_limit == 0 (i.e. n == 1).
+  if (n > 0)
+    dest[write_limit] = L'\0';
+
+  // Finish counting the remaining source length if we truncated or if n == 0.
+  while (src[i] != L'\0')
+    ++i;
+
+  return i;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/wcsxfrm.cpp
+++ b/libc/src/wchar/wcsxfrm.cpp
@@ -10,8 +10,8 @@
 
 #include "hdr/types/size_t.h"
 #include "hdr/types/wchar_t.h"
-#include "src/__support/macros/config.h"
 #include "src/__support/common.h"
+#include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/wchar/wcsxfrm.h
+++ b/libc/src/wchar/wcsxfrm.h
@@ -1,0 +1,16 @@
+#ifndef LLVM_LIBC_SRC_WCHAR_WCSXFRM_H
+#define LLVM_LIBC_SRC_WCHAR_WCSXFRM_H
+
+#include "src/__support/macros/config.h"
+
+#include <stddef.h>
+#include <wchar.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t wcsxfrm(wchar_t *__restrict dest, const wchar_t *__restrict src,
+               size_t n);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_WCSXFRM_H

--- a/libc/src/wchar/wcsxfrm.h
+++ b/libc/src/wchar/wcsxfrm.h
@@ -1,3 +1,11 @@
+//===-- Implementation header for wcsxfrm -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #ifndef LLVM_LIBC_SRC_WCHAR_WCSXFRM_H
 #define LLVM_LIBC_SRC_WCHAR_WCSXFRM_H
 

--- a/libc/src/wchar/wcsxfrm.h
+++ b/libc/src/wchar/wcsxfrm.h
@@ -3,8 +3,8 @@
 
 #include "src/__support/macros/config.h"
 
-#include <stddef.h>
-#include <wchar.h>
+#include "hdr/types/size_t.h"
+#include "hdr/types/wchar_t.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/test/src/wchar/CMakeLists.txt
+++ b/libc/test/src/wchar/CMakeLists.txt
@@ -517,3 +517,13 @@ add_libc_test(
     libc.src.wchar.wcstold
     libc.test.UnitTest.ErrnoCheckingTest
 )
+
+add_libc_unittest(
+  wcsxfrm_test
+  SUITE
+    libc_wchar_unittests
+  SRCS
+    wcsxfrm_test.cpp
+  DEPENDS
+    libc.src.wchar.wcsxfrm
+)

--- a/libc/test/src/wchar/wcsxfrm_test.cpp
+++ b/libc/test/src/wchar/wcsxfrm_test.cpp
@@ -9,6 +9,8 @@
 #include "src/wchar/wcsxfrm.h"
 #include "test/UnitTest/Test.h"
 
+// TODO: Remove this once the test framework supports direct wchar_t
+// comparisons in EXPECT_EQ.
 #define EXPECT_WCHAR_EQ(ACTUAL, EXPECTED)                                      \
   EXPECT_EQ(static_cast<int>(ACTUAL), static_cast<int>(EXPECTED))
 

--- a/libc/test/src/wchar/wcsxfrm_test.cpp
+++ b/libc/test/src/wchar/wcsxfrm_test.cpp
@@ -1,0 +1,98 @@
+//===-- Unittests for wcsxfrm --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/wcsxfrm.h"
+#include "test/UnitTest/Test.h"
+
+#define EXPECT_WCHAR_EQ(ACTUAL, EXPECTED)                                      \
+  EXPECT_EQ(static_cast<int>(ACTUAL), static_cast<int>(EXPECTED))
+
+TEST(LlvmLibcWCSXfrmTest, EmptyString) {
+  wchar_t dest[8];
+  size_t result = LIBC_NAMESPACE::wcsxfrm(dest, L"", 8);
+
+  EXPECT_EQ(result, size_t(0));
+  EXPECT_WCHAR_EQ(dest[0], L'\0');
+}
+
+TEST(LlvmLibcWCSXfrmTest, NullDestinationWhenCountIsZero) {
+  size_t result = LIBC_NAMESPACE::wcsxfrm(nullptr, L"abc", 0);
+  EXPECT_EQ(result, size_t(3));
+}
+
+TEST(LlvmLibcWCSXfrmTest, CopiesWholeStringWhenBufferIsLargeEnough) {
+  wchar_t dest[16];
+  size_t result = LIBC_NAMESPACE::wcsxfrm(dest, L"hello", 16);
+
+  EXPECT_EQ(result, size_t(5));
+  EXPECT_WCHAR_EQ(dest[0], L'h');
+  EXPECT_WCHAR_EQ(dest[1], L'e');
+  EXPECT_WCHAR_EQ(dest[2], L'l');
+  EXPECT_WCHAR_EQ(dest[3], L'l');
+  EXPECT_WCHAR_EQ(dest[4], L'o');
+  EXPECT_WCHAR_EQ(dest[5], L'\0');
+}
+
+TEST(LlvmLibcWCSXfrmTest, ExactFitIncludingNullTerminator) {
+  wchar_t dest[6];
+  size_t result = LIBC_NAMESPACE::wcsxfrm(dest, L"hello", 6);
+
+  EXPECT_EQ(result, size_t(5));
+  EXPECT_WCHAR_EQ(dest[0], L'h');
+  EXPECT_WCHAR_EQ(dest[1], L'e');
+  EXPECT_WCHAR_EQ(dest[2], L'l');
+  EXPECT_WCHAR_EQ(dest[3], L'l');
+  EXPECT_WCHAR_EQ(dest[4], L'o');
+  EXPECT_WCHAR_EQ(dest[5], L'\0');
+}
+
+TEST(LlvmLibcWCSXfrmTest, TruncatesAndNullTerminates) {
+  wchar_t dest[4];
+  size_t result = LIBC_NAMESPACE::wcsxfrm(dest, L"hello", 4);
+
+  EXPECT_EQ(result, size_t(5));
+  EXPECT_WCHAR_EQ(dest[0], L'h');
+  EXPECT_WCHAR_EQ(dest[1], L'e');
+  EXPECT_WCHAR_EQ(dest[2], L'l');
+  EXPECT_WCHAR_EQ(dest[3], L'\0');
+}
+
+TEST(LlvmLibcWCSXfrmTest, BufferSizeOneWritesOnlyNullTerminator) {
+  wchar_t dest[1];
+  dest[0] = L'x';
+
+  size_t result = LIBC_NAMESPACE::wcsxfrm(dest, L"hello", 1);
+
+  EXPECT_EQ(result, size_t(5));
+  EXPECT_WCHAR_EQ(dest[0], L'\0');
+}
+
+TEST(LlvmLibcWCSXfrmTest, DoesNotWriteWhenCountIsZero) {
+  wchar_t dest[4] = {L'x', L'y', L'z', L'\0'};
+
+  size_t result = LIBC_NAMESPACE::wcsxfrm(dest, L"hello", 0);
+
+  EXPECT_EQ(result, size_t(5));
+  EXPECT_WCHAR_EQ(dest[0], L'x');
+  EXPECT_WCHAR_EQ(dest[1], L'y');
+  EXPECT_WCHAR_EQ(dest[2], L'z');
+  EXPECT_WCHAR_EQ(dest[3], L'\0');
+}
+
+TEST(LlvmLibcWCSXfrmTest, WideCharactersAreHandledCorrectly) {
+  wchar_t dest[8];
+  const wchar_t src[] = {L'A', L'\u03A9', L'\u2603', L'\0'};
+
+  size_t result = LIBC_NAMESPACE::wcsxfrm(dest, src, 8);
+
+  EXPECT_EQ(result, size_t(3));
+  EXPECT_WCHAR_EQ(dest[0], L'A');
+  EXPECT_WCHAR_EQ(dest[1], L'\u03A9');
+  EXPECT_WCHAR_EQ(dest[2], L'\u2603');
+  EXPECT_WCHAR_EQ(dest[3], L'\0');
+}


### PR DESCRIPTION
This patch adds wcsxfrm to LLVM libc.

It includes:
- wchar.yaml declaration
- implementation and header
- CMake wiring
- entrypoint registration
- unit tests

The current implementation provides C/POSIX-style behavior and does not yet add locale-aware collation support.

Tested with:
- ninja libc.test.src.wchar.wcsxfrm_test

Notes:
- local full check-libc was blocked by unrelated pre-existing timeout failures in other tests.

Fixes #191074