### PR TITLE
[clang][Sema] support block pointers as non-type template parameters

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -122,6 +122,8 @@ What's New in Clang |release|?
 C++ Language Changes
 --------------------
 
+- Clang now supports block pointers as non-type template parameters. (#GH189247)
+
 - ``__is_trivially_equality_comparable`` no longer returns false for all enum types. (#GH132672)
 
 C++2c Feature Support

--- a/clang/include/clang/AST/TypeBase.h
+++ b/clang/include/clang/AST/TypeBase.h
@@ -2649,6 +2649,8 @@ public:
   bool isFunctionProtoType() const { return getAs<FunctionProtoType>(); }
   bool isPointerType() const;
   bool isPointerOrReferenceType() const;
+  bool isPointerOrBlockPointerType() const;
+  bool isPointerOrBlockPointerOrReferenceType() const;
   bool isSignableType(const ASTContext &Ctx) const;
   bool isSignablePointerType() const;
   bool isSignableIntegerType(const ASTContext &Ctx) const;
@@ -8671,6 +8673,14 @@ inline bool Type::isPointerType() const {
 
 inline bool Type::isPointerOrReferenceType() const {
   return isPointerType() || isReferenceType();
+}
+
+inline bool Type::isPointerOrBlockPointerType() const {
+  return isPointerType() || isBlockPointerType();
+}
+
+inline bool Type::isPointerOrBlockPointerOrReferenceType() const {
+  return isPointerOrBlockPointerType() || isReferenceType();
 }
 
 inline bool Type::isAnyPointerType() const {

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -5009,7 +5009,11 @@ recurse:
   }
 
   // FIXME: invent manglings for all these.
-  case Expr::BlockExprClass:
+  case Expr::BlockExprClass: {
+    NotPrimaryExpr();
+    mangleUnqualifiedBlock(cast<BlockExpr>(E)->getBlockDecl());
+    break;
+  }
   case Expr::ChooseExprClass:
   case Expr::CompoundLiteralExprClass:
   case Expr::ExtVectorElementExprClass:
@@ -6775,7 +6779,7 @@ void CXXNameMangler::mangleValueInTemplateArg(QualType T, const APValue &V,
 
   case APValue::LValue: {
     // Proposed in https://github.com/itanium-cxx-abi/cxx-abi/issues/47.
-    assert((T->isPointerOrReferenceType()) &&
+    assert((T->isPointerOrReferenceType() || T->isBlockPointerType()) &&
            "unexpected type for LValue template arg");
 
     if (V.isNullPointer()) {
@@ -6844,7 +6848,7 @@ void CXXNameMangler::mangleValueInTemplateArg(QualType T, const APValue &V,
           Out << "cv";
           mangleType(T);
         }
-        if (T->isPointerType())
+        if (T->isPointerType() || T->isBlockPointerType())
           Out << "ad";
         Out << "so";
         mangleType(T->isVoidPointerType()
@@ -6859,7 +6863,7 @@ void CXXNameMangler::mangleValueInTemplateArg(QualType T, const APValue &V,
           Out << "cv";
           mangleType(T);
         }
-        if (T->isPointerType()) {
+        if (T->isPointerType() || T->isBlockPointerType()) {
           NotPrimaryExpr();
           Out << "ad";
         }

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -5008,12 +5008,13 @@ recurse:
     break;
   }
 
-  // FIXME: invent manglings for all these.
   case Expr::BlockExprClass: {
     NotPrimaryExpr();
     mangleUnqualifiedBlock(cast<BlockExpr>(E)->getBlockDecl());
     break;
   }
+
+  // FIXME: invent manglings for all these.
   case Expr::ChooseExprClass:
   case Expr::CompoundLiteralExprClass:
   case Expr::ExtVectorElementExprClass:

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -6849,7 +6849,7 @@ void CXXNameMangler::mangleValueInTemplateArg(QualType T, const APValue &V,
           Out << "cv";
           mangleType(T);
         }
-        if (T->isPointerType() || T->isBlockPointerType())
+        if (T->isPointerOrBlockPointerType())
           Out << "ad";
         Out << "so";
         mangleType(T->isVoidPointerType()
@@ -6864,7 +6864,7 @@ void CXXNameMangler::mangleValueInTemplateArg(QualType T, const APValue &V,
           Out << "cv";
           mangleType(T);
         }
-        if (T->isPointerType() || T->isBlockPointerType()) {
+        if (T->isPointerOrBlockPointerType()) {
           NotPrimaryExpr();
           Out << "ad";
         }

--- a/clang/lib/AST/ODRHash.cpp
+++ b/clang/lib/AST/ODRHash.cpp
@@ -1270,8 +1270,13 @@ void ODRHash::AddStructuralValue(const APValue &Value) {
       break;
     }
 
-    assert(Base.is<const ValueDecl *>());
-    AddDecl(Base.get<const ValueDecl *>());
+    if (auto *VD = Base.dyn_cast<const ValueDecl *>()) {
+      AddDecl(VD);
+    } else if (auto *E = Base.dyn_cast<const Expr *>()) {
+      AddStmt(E);
+    } else {
+      llvm_unreachable("unexpected LValue base kind in structural value");
+    }
     ID.AddInteger(Value.getLValueOffset().getQuantity());
 
     bool OnePastTheEnd = Value.isLValueOnePastTheEnd();

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -1459,11 +1459,6 @@ QualType Sema::CheckNonTypeTemplateParameterType(QualType T,
     return QualType();
   }
 
-  if (T->isBlockPointerType()) {
-    Diag(Loc, diag::err_template_nontype_parm_bad_type) << T;
-    return QualType();
-  }
-
   // C++ [temp.param]p4:
   //
   // A non-type template-parameter shall have one of the following
@@ -1473,6 +1468,8 @@ QualType Sema::CheckNonTypeTemplateParameterType(QualType T,
   if (T->isIntegralOrEnumerationType() ||
       //   -- pointer to object or pointer to function,
       T->isPointerType() ||
+      //   -- block pointer type,
+      (getLangOpts().CPlusPlus20 && T->isBlockPointerType()) ||
       //   -- lvalue reference to object or lvalue reference to function,
       T->isLValueReferenceType() ||
       //   -- pointer to member,
@@ -6670,8 +6667,8 @@ CheckTemplateArgumentIsCompatibleWithParameter(Sema &S, NamedDecl *Param,
                                                QualType ParamType, Expr *ArgIn,
                                                Expr *Arg, QualType ArgType) {
   bool ObjCLifetimeConversion;
-  if (ParamType->isPointerType() &&
-      !ParamType->castAs<PointerType>()->getPointeeType()->isFunctionType() &&
+  if ((ParamType->isPointerType() || ParamType->isBlockPointerType()) &&
+      !ParamType->getPointeeType()->isFunctionType() &&
       S.IsQualificationConversion(ArgType, ParamType, false,
                                   ObjCLifetimeConversion)) {
     // For pointer-to-object types, qualification conversions are
@@ -6821,7 +6818,8 @@ static bool CheckTemplateArgumentAddressOfObjectOrFunction(
     Entity = CUE->getGuidDecl();
 
   // If our parameter has pointer type, check for a null template value.
-  if (ParamType->isPointerType() || ParamType->isNullPtrType()) {
+  if (ParamType->isPointerType() || ParamType->isBlockPointerType() ||
+      ParamType->isNullPtrType()) {
     switch (isNullPointerValueTemplateArgument(S, Param, ParamType, ArgIn,
                                                Entity)) {
     case NPV_NullPointer:
@@ -7355,17 +7353,19 @@ ExprResult Sema::CheckTemplateArgument(NamedDecl *Param, QualType ParamType,
     if (Value.isLValue()) {
       APValue::LValueBase Base = Value.getLValueBase();
       auto *VD = const_cast<ValueDecl *>(Base.dyn_cast<const ValueDecl *>());
+      auto *E = const_cast<Expr *>(Base.dyn_cast<const Expr *>());
       //   For a non-type template-parameter of pointer or reference type,
       //   the value of the constant expression shall not refer to
       assert(ParamType->isPointerOrReferenceType() ||
-             ParamType->isNullPtrType());
+             ParamType->isBlockPointerType() || ParamType->isNullPtrType());
       // -- a temporary object
       // -- a string literal
       // -- the result of a typeid expression, or
       // -- a predefined __func__ variable
       if (Base &&
           (!VD ||
-           isa<LifetimeExtendedTemporaryDecl, UnnamedGlobalConstantDecl>(VD))) {
+           isa<LifetimeExtendedTemporaryDecl, UnnamedGlobalConstantDecl>(VD)) &&
+          (!E || !isa<BlockExpr>(E))) {
         Diag(Arg->getBeginLoc(), diag::err_template_arg_not_decl_ref)
             << Arg->getSourceRange();
         return ExprError();
@@ -7663,13 +7663,16 @@ ExprResult Sema::CheckTemplateArgument(NamedDecl *Param, QualType ParamType,
     return Arg;
   }
 
-  if (ParamType->isPointerType()) {
+  if (ParamType->isPointerType() || ParamType->isBlockPointerType()) {
     //   -- for a non-type template-parameter of type pointer to
     //      object, qualification conversions (4.4) and the
     //      array-to-pointer conversion (4.2) are applied.
     // C++0x also allows a value of std::nullptr_t.
-    assert(ParamType->getPointeeType()->isIncompleteOrObjectType() &&
-           "Only object pointers allowed here");
+    if (ParamType->isPointerType())
+      assert(ParamType->getPointeeType()->isIncompleteOrObjectType() &&
+             "Only object pointers allowed here");
+    else
+      assert(ParamType->isBlockPointerType() && "Expected block pointer");
 
     if (CheckTemplateArgumentAddressOfObjectOrFunction(
             *this, Param, ParamType, Arg, SugaredConverted, CanonicalConverted))
@@ -7974,6 +7977,10 @@ ExprResult Sema::BuildExpressionFromDeclTemplateArgument(
       Context.hasSimilarType(ElemT, ParamType->getPointeeType())) {
     // Decay an array argument if we want a pointer to its first element.
     RefExpr = DefaultFunctionArrayConversion(RefExpr.get());
+    if (RefExpr.isInvalid())
+      return ExprError();
+  } else if (ParamType->isBlockPointerType()) {
+    RefExpr = DefaultLvalueConversion(RefExpr.get());
     if (RefExpr.isInvalid())
       return ExprError();
   } else if (ParamType->isPointerType() || ParamType->isMemberPointerType()) {

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -1469,7 +1469,7 @@ QualType Sema::CheckNonTypeTemplateParameterType(QualType T,
       //   -- pointer to object or pointer to function,
       T->isPointerType() ||
       //   -- block pointer type,
-      (getLangOpts().CPlusPlus20 && T->isBlockPointerType()) ||
+      T->isBlockPointerType() ||
       //   -- lvalue reference to object or lvalue reference to function,
       T->isLValueReferenceType() ||
       //   -- pointer to member,

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -1468,8 +1468,6 @@ QualType Sema::CheckNonTypeTemplateParameterType(QualType T,
   if (T->isIntegralOrEnumerationType() ||
       //   -- pointer to object or pointer to function,
       T->isPointerType() ||
-      //   -- block pointer type,
-      T->isBlockPointerType() ||
       //   -- lvalue reference to object or lvalue reference to function,
       T->isLValueReferenceType() ||
       //   -- pointer to member,
@@ -1482,6 +1480,10 @@ QualType Sema::CheckNonTypeTemplateParameterType(QualType T,
     // are ignored when determining its type.
     return T.getUnqualifiedType();
   }
+
+  // Allow block pointer types as an extension.
+  if (T->isBlockPointerType())
+    return T.getUnqualifiedType();
 
   // C++ [temp.param]p8:
   //

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -6820,8 +6820,7 @@ static bool CheckTemplateArgumentAddressOfObjectOrFunction(
     Entity = CUE->getGuidDecl();
 
   // If our parameter has pointer type, check for a null template value.
-  if (ParamType->isPointerOrBlockPointerType() ||
-      ParamType->isNullPtrType()) {
+  if (ParamType->isPointerOrBlockPointerType() || ParamType->isNullPtrType()) {
     switch (isNullPointerValueTemplateArgument(S, Param, ParamType, ArgIn,
                                                Entity)) {
     case NPV_NullPointer:

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -6669,7 +6669,7 @@ CheckTemplateArgumentIsCompatibleWithParameter(Sema &S, NamedDecl *Param,
                                                QualType ParamType, Expr *ArgIn,
                                                Expr *Arg, QualType ArgType) {
   bool ObjCLifetimeConversion;
-  if ((ParamType->isPointerType() || ParamType->isBlockPointerType()) &&
+  if (ParamType->isPointerOrBlockPointerType() &&
       !ParamType->getPointeeType()->isFunctionType() &&
       S.IsQualificationConversion(ArgType, ParamType, false,
                                   ObjCLifetimeConversion)) {
@@ -6820,7 +6820,7 @@ static bool CheckTemplateArgumentAddressOfObjectOrFunction(
     Entity = CUE->getGuidDecl();
 
   // If our parameter has pointer type, check for a null template value.
-  if (ParamType->isPointerType() || ParamType->isBlockPointerType() ||
+  if (ParamType->isPointerOrBlockPointerType() ||
       ParamType->isNullPtrType()) {
     switch (isNullPointerValueTemplateArgument(S, Param, ParamType, ArgIn,
                                                Entity)) {
@@ -7358,8 +7358,8 @@ ExprResult Sema::CheckTemplateArgument(NamedDecl *Param, QualType ParamType,
       auto *E = const_cast<Expr *>(Base.dyn_cast<const Expr *>());
       //   For a non-type template-parameter of pointer or reference type,
       //   the value of the constant expression shall not refer to
-      assert(ParamType->isPointerOrReferenceType() ||
-             ParamType->isBlockPointerType() || ParamType->isNullPtrType());
+      assert(ParamType->isPointerOrBlockPointerOrReferenceType() ||
+             ParamType->isNullPtrType());
       // -- a temporary object
       // -- a string literal
       // -- the result of a typeid expression, or
@@ -7665,7 +7665,7 @@ ExprResult Sema::CheckTemplateArgument(NamedDecl *Param, QualType ParamType,
     return Arg;
   }
 
-  if (ParamType->isPointerType() || ParamType->isBlockPointerType()) {
+  if (ParamType->isPointerOrBlockPointerType()) {
     //   -- for a non-type template-parameter of type pointer to
     //      object, qualification conversions (4.4) and the
     //      array-to-pointer conversion (4.2) are applied.

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -4986,6 +4986,7 @@ TemplateDeductionResult Sema::DeduceTemplateArguments(
   // both P and A are pointers or member pointers. In this case, we
   // just ignore cv-qualifiers completely).
   if ((P->isPointerType() && A->isPointerType()) ||
+      (P->isBlockPointerType() && A->isBlockPointerType()) ||
       (P->isMemberPointerType() && A->isMemberPointerType()))
     TDF |= TDF_IgnoreQualifiers;
 

--- a/clang/test/CodeGenCXX/nttp-blockpointer.cpp
+++ b/clang/test/CodeGenCXX/nttp-blockpointer.cpp
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 -std=c++20 -fblocks -triple x86_64-apple-darwin -emit-llvm -o - %s | FileCheck %s
+
+template<void (^B)()> void f() {}
+
+// CHECK: define{{.*}} void @_Z12test_literalv()
+void test_literal() {
+  // CHECK: call void @_Z1fIXcvU13block_pointerFvvEadUb_EEvv()
+  f<^{}>();
+}
+
+constexpr void (^global_block)() = ^{};
+// CHECK: define{{.*}} void @_Z11test_globalv()
+void test_global() {
+  // CHECK: call void @_Z1fIXcvU13block_pointerFvvEadUb0_EEvv()
+  f<global_block>();
+}
+
+template<int (^B)(int)> struct S {
+  static int call(int x) { return B(x); }
+};
+
+// CHECK: define{{.*}} i32 @_Z10test_parami(i32 noundef %x)
+int test_param(int x) {
+  // CHECK: call noundef i32 @_ZN1SIXadUb1_EE4callEi(i32 noundef %0)
+  return S<^(int x) { return x + 1; }>::call(x);
+}

--- a/clang/test/CodeGenCXX/nttp-blockpointer.cpp
+++ b/clang/test/CodeGenCXX/nttp-blockpointer.cpp
@@ -21,3 +21,50 @@ int test_param(int x) {
   // CHECK: call noundef i32 @_ZN1SIXadUb1_EE4callEi(i32 noundef %0)
   return S<^(int x) { return x + 1; }>::call(x);
 }
+
+void test_nullptr() {
+  // CHECK: call void @_Z1fILU13block_pointerFvvE0EEvv()
+  f<nullptr>();
+}
+
+namespace TestNamespace {
+  template<void (^B)()> struct S {
+    static void call() { B(); }
+  };
+  void test_namespace() {
+    // CHECK: call void @_ZN13TestNamespace1SIXadUb2_EE4callEv()
+    S<^{}>::call();
+  }
+}
+
+template<void (^B)() = ^{}>
+void f_default() { B(); }
+
+void test_default() {
+  // CHECK: call void @_Z9f_defaultIXcvU13block_pointerFvvEadUb_EEvv()
+  f_default();
+}
+
+struct Structural {
+  void (^b)();
+};
+
+template<Structural s>
+void f_struct() {
+  s.b();
+}
+
+void test_struct() {
+  // CHECK: call void @_Z8f_structIXtl10StructuraladUb3_EEEvv()
+  f_struct<Structural{^{}}>();
+}
+
+template<void (^...Blocks)()>
+void f_variadic() {
+  (Blocks(), ...);
+}
+
+void test_variadic() {
+  // CHECK: call void @_Z10f_variadicIJXcvU13block_pointerFvvEadUb4_EXcvS1_adUb5_EEEvv()
+  f_variadic<^{}, ^{}>();
+}

--- a/clang/test/CodeGenCXX/nttp-blockpointer.cpp
+++ b/clang/test/CodeGenCXX/nttp-blockpointer.cpp
@@ -2,14 +2,12 @@
 
 template<void (^B)()> void f() {}
 
-// CHECK: define{{.*}} void @_Z12test_literalv()
 void test_literal() {
   // CHECK: call void @_Z1fIXcvU13block_pointerFvvEadUb_EEvv()
   f<^{}>();
 }
 
 constexpr void (^global_block)() = ^{};
-// CHECK: define{{.*}} void @_Z11test_globalv()
 void test_global() {
   // CHECK: call void @_Z1fIXcvU13block_pointerFvvEadUb0_EEvv()
   f<global_block>();
@@ -19,7 +17,6 @@ template<int (^B)(int)> struct S {
   static int call(int x) { return B(x); }
 };
 
-// CHECK: define{{.*}} i32 @_Z10test_parami(i32 noundef %x)
 int test_param(int x) {
   // CHECK: call noundef i32 @_ZN1SIXadUb1_EE4callEi(i32 noundef %0)
   return S<^(int x) { return x + 1; }>::call(x);

--- a/clang/test/CodeGenCXX/nttp-blockpointer.cpp
+++ b/clang/test/CodeGenCXX/nttp-blockpointer.cpp
@@ -68,3 +68,5 @@ void test_variadic() {
   // CHECK: call void @_Z10f_variadicIJXcvU13block_pointerFvvEadUb4_EXcvS1_adUb5_EEEvv()
   f_variadic<^{}, ^{}>();
 }
+
+// CHECK: define internal void @_Z1fIXcvU13block_pointerFvvEadUb_EEvv()

--- a/clang/test/CodeGenCXX/nttp-blockpointer.cpp
+++ b/clang/test/CodeGenCXX/nttp-blockpointer.cpp
@@ -7,6 +7,8 @@ void test_literal() {
   f<^{}>();
 }
 
+// CHECK: define internal void @_Z1fIXcvU13block_pointerFvvEadUb_EEvv()
+
 constexpr void (^global_block)() = ^{};
 void test_global() {
   // CHECK: call void @_Z1fIXcvU13block_pointerFvvEadUb0_EEvv()
@@ -68,5 +70,3 @@ void test_variadic() {
   // CHECK: call void @_Z10f_variadicIJXcvU13block_pointerFvvEadUb4_EXcvS1_adUb5_EEEvv()
   f_variadic<^{}, ^{}>();
 }
-
-// CHECK: define internal void @_Z1fIXcvU13block_pointerFvvEadUb_EEvv()

--- a/clang/test/CodeGenCXX/nttp-blockpointer.cpp
+++ b/clang/test/CodeGenCXX/nttp-blockpointer.cpp
@@ -70,3 +70,13 @@ void test_variadic() {
   // CHECK: call void @_Z10f_variadicIJXcvU13block_pointerFvvEadUb4_EXcvS1_adUb5_EEEvv()
   f_variadic<^{}, ^{}>();
 }
+
+template<auto B>
+void f_auto() {
+  B();
+}
+
+void test_auto() {
+  // CHECK: call void @_Z6f_autoITnDaXcvU13block_pointerFvvEadUb6_EEvv()
+  f_auto<^{}>();
+}

--- a/clang/test/SemaCXX/blocks.cpp
+++ b/clang/test/SemaCXX/blocks.cpp
@@ -165,5 +165,5 @@ void static_data_member() {
 }
 
 namespace gh189247 {
-  template<void (^)()> struct A; // expected-error {{a non-type template parameter cannot have type 'void (^)()'}}
+  template<void (^)()> struct A; 
 }

--- a/clang/test/SemaCXX/nttp-blockpointer.cpp
+++ b/clang/test/SemaCXX/nttp-blockpointer.cpp
@@ -45,6 +45,7 @@ void test_params() {
   (void)b.call(1);
 }
 
+
 template<auto B>
 struct AutoBlock {};
 

--- a/clang/test/SemaCXX/nttp-blockpointer.cpp
+++ b/clang/test/SemaCXX/nttp-blockpointer.cpp
@@ -1,0 +1,53 @@
+// RUN: %clang_cc1 -std=c++20 -fblocks -triple x86_64-apple-darwin %s -verify
+
+template<void (^B)()>
+struct A {
+  void call() { B(); }
+};
+
+constexpr void (^global_block)() = ^{};
+void test_global() {
+  A<global_block> a;
+  a.call();
+}
+
+void test_literal() {
+  A<^{}> a;
+  a.call();
+}
+
+void test_null() {
+  A<nullptr> a;
+}
+
+void test_capturing(int x) {
+  A<^{ (void)x; }> a; // expected-error {{non-type template argument is not a constant expression}}
+}
+
+template<void (^B)()>
+void deduce(A<B> a) {}
+
+void test_deduce() {
+  A<global_block> a;
+  deduce(a);
+}
+
+constexpr void (^another_block)() = ^{};
+static_assert(!__is_same(A<global_block>, A<another_block>));
+
+template<int (^B)(int)>
+struct BFunc {
+  int call(int x) { return B(x); }
+};
+
+void test_params() {
+  BFunc<^(int x) { return x + 1; }> b;
+  (void)b.call(1);
+}
+
+template<auto B>
+struct AutoBlock {};
+
+void test_auto() {
+  AutoBlock<global_block> a;
+}

--- a/clang/test/SemaCXX/nttp-blockpointer.cpp
+++ b/clang/test/SemaCXX/nttp-blockpointer.cpp
@@ -49,6 +49,21 @@ void test_params() {
 template<auto B>
 struct AutoBlock {};
 
+template<auto B>
+void deduce_auto(AutoBlock<B> a) {}
+
 void test_auto() {
   AutoBlock<global_block> a;
+  deduce_auto(a);
+}
+
+template<typename T, T B>
+struct TypedBlock {};
+
+template<typename T, T B>
+void deduce_type(TypedBlock<T, B> a) {}
+
+void test_typed() {
+  TypedBlock<void(^)(), global_block> a;
+  deduce_type(a);
 }


### PR DESCRIPTION
allow block pointers to be used as template parameters in C++20.
Add mangling for block literals in template arguments.
Let ODR hashing see block expressions so they don't cause a crash.
Fix a crash by making sure block names decay to pointers.
Allow matching block pointer types even if they have different const qualifiers.