### PR TITLE
[clang-tidy] Fix a false positive when converting a bool to a signed integer type

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.cpp
@@ -593,9 +593,17 @@ void NarrowingConversionsCheck::handleImplicitCast(
   case CK_IntegralToFloating:
     handleIntegralToFloating(Context, SourceLoc, Lhs, Rhs);
     return;
-  case CK_IntegralCast:
+  case CK_IntegralCast: {
+    const BuiltinType *ToType = getBuiltinType(Lhs);
+    const BuiltinType *FromType = getBuiltinType(Rhs);
+    if (ToType && FromType && FromType->getKind() == BuiltinType::Bool &&
+        ToType->isSignedInteger()) {
+      handleBooleanToSignedIntegral(Context, SourceLoc, Lhs, Rhs);
+      return;
+    }
     handleIntegralCast(Context, SourceLoc, Lhs, Rhs);
     return;
+  }
   case CK_FloatingToBoolean:
     handleFloatingToBoolean(Context, SourceLoc, Lhs, Rhs);
     return;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -262,6 +262,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/macro-parentheses>` check by printing the macro
   definition in the warning message if the macro is defined on command line.
 
+- Improved :doc:`bugprone-narrowing-conversions
+  <clang-tidy/checks/bugprone/narrowing-conversions>` check by fixing a false
+  positive when converting a ``bool`` to a signed integer type.
+
 - Improved :doc:`bugprone-pointer-arithmetic-on-polymorphic-object
   <clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object>` check
   by fixing a false positive when ``operator[]`` is used in a dependent context.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/narrowing-conversions.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/narrowing-conversions.cpp
@@ -355,4 +355,14 @@ void typedef_context() {
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: narrowing conversion from 'myint64_t' (aka 'long long') to signed type 'int' is implementation-defined [bugprone-narrowing-conversions]
 }
 
+void testBoolToSignedType() {
+  bool b = true;
+  auto c = char{b};
+  auto sc = (signed char){b};
+  auto s = short{b};
+  auto i = int{b};
+  auto c1 = static_cast<char>(b);
+  auto c2 = (char)b;
+}
+
 } // namespace floats


### PR DESCRIPTION
Fix #191337