### PR TITLE
[clang] Clear ASTContext::TUDecl in 'cleanup' for easier debugging

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1268,6 +1268,8 @@ public:
   bool isInSameModule(const Module *M1, const Module *M2) const;
 
   TranslationUnitDecl *getTranslationUnitDecl() const {
+    assert(TUDecl && "TUDecl might have been reset by 'cleanup' likely because "
+                     "'CodeGenOpts.ClearASTBeforeBackend' was set.");
     assert(TUDecl->getMostRecentDecl() == TUDecl &&
            "The active TU is not current one!");
     return TUDecl->getMostRecentDecl();

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -943,6 +943,7 @@ void ASTContext::cleanup() {
     Value.second->~PerModuleInitializers();
   ModuleInitializers.clear();
 
+  TUDecl = nullptr;
   XRayFilter.reset();
   NoSanitizeL.reset();
 }


### PR DESCRIPTION
While the ASTContext has more things inside, I think we should at least clear the TUDecl so that when traversing the (dangling) AST would immediately step on the null-dereference instead of chasing dangling pointers and crash later.

I was bitten by this in #191058.

This commit should be NFC - assuming that people didn't traverse already dangling ASTs.