### PR TITLE
[MISched] Extract `isClustered()` method on SUnit (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/ScheduleDAG.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAG.h
@@ -481,6 +481,8 @@ class TargetRegisterInfo;
     /// edge occurs first.
     LLVM_ABI void biasCriticalPath();
 
+    bool isClustered() const { return ParentClusterIdx != InvalidClusterId; }
+
     LLVM_ABI void dumpAttributes() const;
 
   private:

--- a/llvm/include/llvm/CodeGen/ScheduleDAG.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAG.h
@@ -481,7 +481,9 @@ class TargetRegisterInfo;
     /// edge occurs first.
     LLVM_ABI void biasCriticalPath();
 
-    bool isClustered() const { return ParentClusterIdx != InvalidClusterId; }
+    LLVM_ABI bool isClustered() const {
+      return ParentClusterIdx != InvalidClusterId;
+    }
 
     LLVM_ABI void dumpAttributes() const;
 

--- a/llvm/lib/CodeGen/ScheduleDAG.cpp
+++ b/llvm/lib/CodeGen/ScheduleDAG.cpp
@@ -365,7 +365,7 @@ LLVM_DUMP_METHOD void ScheduleDAG::dumpNodeName(const SUnit &SU) const {
 LLVM_DUMP_METHOD void ScheduleDAG::dumpNodeAll(const SUnit &SU) const {
   dumpNode(SU);
   SU.dumpAttributes();
-  if (SU.ParentClusterIdx != InvalidClusterId)
+  if (SU.isClustered())
     dbgs() << "  Parent Cluster Index: " << SU.ParentClusterIdx << '\n';
 
   if (SU.Preds.size() > 0) {


### PR DESCRIPTION
This patch encapsulates the check for wether a `SUnit` is clustered, rather than letting it scatter across call sites. Currently there is only a single user, but more users can show up, and I think it provides a cleaner API even for that single user.