### PR TITLE
[libc++] Fix the mdspan ElementType complete object type mandate

### DIFF
--- a/libcxx/include/__mdspan/mdspan.h
+++ b/libcxx/include/__mdspan/mdspan.h
@@ -30,6 +30,7 @@
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_convertible.h>
 #include <__type_traits/is_nothrow_constructible.h>
+#include <__type_traits/is_object.h>
 #include <__type_traits/is_pointer.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/rank.h>
@@ -66,6 +67,9 @@ class mdspan {
 private:
   static_assert(__mdspan_detail::__is_extents_v<_Extents>,
                 "mdspan: Extents template parameter must be a specialization of extents.");
+  static_assert(
+      is_object_v<_ElementType> && requires { sizeof(_ElementType); },
+      "mdspan: ElementType template parameter must be a complete object type");
   static_assert(!is_array_v<_ElementType>, "mdspan: ElementType template parameter may not be an array type");
   static_assert(!is_abstract_v<_ElementType>, "mdspan: ElementType template parameter may not be an abstract class");
   static_assert(is_same_v<_ElementType, typename _AccessorPolicy::element_type>,

--- a/libcxx/test/std/containers/views/mdspan/mdspan/element_type.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/element_type.verify.cpp
@@ -31,7 +31,7 @@ struct BadAccessor {
   reference access(data_handle_type, std::size_t) const;
 };
 
-int incomplete_type() {
+void incomplete_type() {
   // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: ElementType template parameter must be a complete object type}}
   [[maybe_unused]] std::mdspan<void, std::dextents<std::size_t, 2>, std::layout_right, BadAccessor> m;
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/element_type.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/element_type.verify.cpp
@@ -23,6 +23,19 @@ public:
   virtual void method() = 0;
 };
 
+struct BadAccessor {
+  using offset_policy    = BadAccessor;
+  using element_type     = void;
+  using reference        = void;
+  using data_handle_type = element_type*;
+  reference access(data_handle_type, std::size_t) const;
+};
+
+int incomplete_type() {
+  // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: ElementType template parameter must be a complete object type}}
+  [[maybe_unused]] std::mdspan<void, std::dextents<std::size_t, 2>, std::layout_right, BadAccessor> m;
+}
+
 void not_abstract_class() {
   // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: ElementType template parameter may not be an abstract class}}
   [[maybe_unused]] std::mdspan<AbstractClass, std::extents<int>> m;

--- a/libcxx/test/std/containers/views/mdspan/mdspan/element_type.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/element_type.verify.cpp
@@ -18,13 +18,15 @@
 
 #include <mdspan>
 
+struct Incomplete;
+
 class AbstractClass {
 public:
   virtual void method() = 0;
 };
 
-struct BadAccessor {
-  using offset_policy    = BadAccessor;
+struct VoidAccessor {
+  using offset_policy    = VoidAccessor;
   using element_type     = void;
   using reference        = void;
   using data_handle_type = element_type*;
@@ -36,7 +38,6 @@ struct RefAccessor {
   using element_type     = int&;
   using reference        = int&;
   using data_handle_type = int*;
-
   reference access(data_handle_type p, std::size_t i) const { return p[i]; }
 };
 
@@ -48,9 +49,14 @@ struct FuncAccessor {
   reference access(data_handle_type, std::size_t) const;
 };
 
-void incomplete_type() {
+void incomplete_object_type() {
   // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: ElementType template parameter must be a complete object type}}
-  [[maybe_unused]] std::mdspan<void, std::dextents<std::size_t, 2>, std::layout_right, BadAccessor> m;
+  [[maybe_unused]] std::mdspan<Incomplete, std::dextents<std::size_t, 2>> m;
+}
+
+void void_type() {
+  // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: ElementType template parameter must be a complete object type}}
+  [[maybe_unused]] std::mdspan<void, std::dextents<std::size_t, 2>, std::layout_right, VoidAccessor> m;
 }
 
 void reference_type() {

--- a/libcxx/test/std/containers/views/mdspan/mdspan/element_type.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/element_type.verify.cpp
@@ -31,9 +31,36 @@ struct BadAccessor {
   reference access(data_handle_type, std::size_t) const;
 };
 
+struct RefAccessor {
+  using offset_policy    = RefAccessor;
+  using element_type     = int&;
+  using reference        = int&;
+  using data_handle_type = int*;
+
+  reference access(data_handle_type p, std::size_t i) const { return p[i]; }
+};
+
+struct FuncAccessor {
+  using offset_policy    = FuncAccessor;
+  using element_type     = int();
+  using reference        = int (&)();
+  using data_handle_type = int (*)();
+  reference access(data_handle_type, std::size_t) const;
+};
+
 void incomplete_type() {
   // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: ElementType template parameter must be a complete object type}}
   [[maybe_unused]] std::mdspan<void, std::dextents<std::size_t, 2>, std::layout_right, BadAccessor> m;
+}
+
+void reference_type() {
+  // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: ElementType template parameter must be a complete object type}}
+  [[maybe_unused]] std::mdspan<int&, std::dextents<std::size_t, 2>, std::layout_right, RefAccessor> m;
+}
+
+void function_type() {
+  // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: ElementType template parameter must be a complete object type}}
+  [[maybe_unused]] std::mdspan<int(), std::dextents<std::size_t, 2>, std::layout_right, FuncAccessor> m;
 }
 
 void not_abstract_class() {


### PR DESCRIPTION
Fixes: #191688
