### PR TITLE
[Object][ELF] Pass Error to WarningHandler

### DIFF
--- a/llvm/include/llvm/Object/ELF.h
+++ b/llvm/include/llvm/Object/ELF.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/Object/ELFTypes.h"
 #include "llvm/Object/Error.h"
@@ -76,6 +77,10 @@ LLVM_ABI StringRef getRISCVVendorRelocationTypeName(uint32_t Type,
                                                     StringRef Vendor);
 LLVM_ABI uint32_t getELFRelativeRelocationType(uint32_t Machine);
 LLVM_ABI StringRef getELFSectionTypeName(uint32_t Machine, uint32_t Type);
+
+static inline Error createError(Error E, const Twine &Context) {
+  return createContextualizedError(std::move(E), Context);
+}
 
 // Subclasses of ELFFile may need this for template instantiation
 inline std::pair<unsigned char, unsigned char>
@@ -164,9 +169,7 @@ static std::string getPhdrIndexForError(const ELFFile<ELFT> &Obj,
   return "[unknown index]";
 }
 
-static inline Error defaultWarningHandler(const Twine &Msg) {
-  return createError(Msg);
-}
+static inline Error defaultWarningHandler(Error Err) { return Err; }
 
 template <class ELFT>
 static bool checkSectionOffsets(const typename ELFT::Phdr &Phdr,
@@ -268,9 +271,9 @@ public:
   // This is a callback that can be passed to a number of functions.
   // It can be used to ignore non-critical errors (warnings), which is
   // useful for dumpers, like llvm-readobj.
-  // It accepts a warning message string and returns a success
+  // It accepts an error and returns a success
   // when the warning should be ignored or an error otherwise.
-  using WarningHandler = llvm::function_ref<Error(const Twine &Msg)>;
+  using WarningHandler = llvm::function_ref<Error(Error)>;
 
   const uint8_t *base() const { return Buf.bytes_begin(); }
   const uint8_t *end() const { return base() + getBufSize(); }
@@ -623,9 +626,9 @@ getExtendedSymbolTableIndex(const typename ELFT::Sym &Sym, unsigned SymIndex,
 
   Expected<typename ELFT::Word> TableOrErr = ShndxTable[SymIndex];
   if (!TableOrErr)
-    return createError("unable to read an extended symbol table at index " +
-                       Twine(SymIndex) + ": " +
-                       toString(TableOrErr.takeError()));
+    return createError(TableOrErr.takeError(),
+                       "unable to read an extended symbol table at index " +
+                           Twine(SymIndex));
   return *TableOrErr;
 }
 
@@ -842,8 +845,8 @@ ELFFile<ELFT>::getSectionStringTable(Elf_Shdr_Range Sections,
   Expected<uint32_t> ShStrNdxOrErr = getShStrNdx();
   if (!ShStrNdxOrErr)
     return createError(
-        "e_shstrndx == SHN_XINDEX, but cannot read section header 0: " +
-        toString(ShStrNdxOrErr.takeError()));
+        ShStrNdxOrErr.takeError(),
+        "e_shstrndx == SHN_XINDEX, but cannot read section header 0");
 
   uint32_t Index = *ShStrNdxOrErr;
   // There is no section name string table. Return FakeSectionStrings which
@@ -1153,8 +1156,8 @@ ELFFile<ELFT>::getVersionDefinitions(const Elf_Shdr &Sec) const {
 
   Expected<ArrayRef<uint8_t>> ContentsOrErr = getSectionContents(Sec);
   if (!ContentsOrErr)
-    return createError("cannot read content of " + describe(*this, Sec) + ": " +
-                       toString(ContentsOrErr.takeError()));
+    return createError(ContentsOrErr.takeError(),
+                       "cannot read content of " + describe(*this, Sec));
 
   const uint8_t *Start = ContentsOrErr->data();
   const uint8_t *End = Start + ContentsOrErr->size();
@@ -1238,7 +1241,7 @@ ELFFile<ELFT>::getVersionDependencies(const Elf_Shdr &Sec,
   StringRef StrTab;
   Expected<StringRef> StrTabOrErr = getLinkAsStrtab(Sec);
   if (!StrTabOrErr) {
-    if (Error E = WarnHandler(toString(StrTabOrErr.takeError())))
+    if (Error E = WarnHandler(StrTabOrErr.takeError()))
       return std::move(E);
   } else {
     StrTab = *StrTabOrErr;
@@ -1246,8 +1249,8 @@ ELFFile<ELFT>::getVersionDependencies(const Elf_Shdr &Sec,
 
   Expected<ArrayRef<uint8_t>> ContentsOrErr = getSectionContents(Sec);
   if (!ContentsOrErr)
-    return createError("cannot read content of " + describe(*this, Sec) + ": " +
-                       toString(ContentsOrErr.takeError()));
+    return createError(ContentsOrErr.takeError(),
+                       "cannot read content of " + describe(*this, Sec));
 
   const uint8_t *Start = ContentsOrErr->data();
   const uint8_t *End = Start + ContentsOrErr->size();
@@ -1333,11 +1336,12 @@ Expected<StringRef>
 ELFFile<ELFT>::getStringTable(const Elf_Shdr &Section,
                               WarningHandler WarnHandler) const {
   if (Section.sh_type != ELF::SHT_STRTAB)
-    if (Error E = WarnHandler("invalid sh_type for string table section " +
-                              getSecIndexForError(*this, Section) +
-                              ": expected SHT_STRTAB, but got " +
-                              object::getELFSectionTypeName(
-                                  getHeader().e_machine, Section.sh_type)))
+    if (Error E = WarnHandler(
+            createError("invalid sh_type for string table section " +
+                        getSecIndexForError(*this, Section) +
+                        ": expected SHT_STRTAB, but got " +
+                        object::getELFSectionTypeName(getHeader().e_machine,
+                                                      Section.sh_type))))
       return std::move(E);
 
   auto V = getSectionContentsAsArray<char>(Section);
@@ -1422,14 +1426,14 @@ ELFFile<ELFT>::getLinkAsStrtab(const typename ELFT::Shdr &Sec) const {
   Expected<const typename ELFT::Shdr *> StrTabSecOrErr =
       getSection(Sec.sh_link);
   if (!StrTabSecOrErr)
-    return createError("invalid section linked to " + describe(*this, Sec) +
-                       ": " + toString(StrTabSecOrErr.takeError()));
+    return createError(StrTabSecOrErr.takeError(),
+                       "invalid section linked to " + describe(*this, Sec));
 
   Expected<StringRef> StrTabOrErr = getStringTable(**StrTabSecOrErr);
   if (!StrTabOrErr)
-    return createError("invalid string table linked to " +
-                       describe(*this, Sec) + ": " +
-                       toString(StrTabOrErr.takeError()));
+    return createError(StrTabOrErr.takeError(),
+                       "invalid string table linked to " +
+                           describe(*this, Sec));
   return *StrTabOrErr;
 }
 

--- a/llvm/lib/Object/ELF.cpp
+++ b/llvm/lib/Object/ELF.cpp
@@ -690,8 +690,8 @@ ELFFile<ELFT>::toMappedAddr(uint64_t VAddr, WarningHandler WarnHandler) const {
     return A->p_vaddr < B->p_vaddr;
   };
   if (!llvm::is_sorted(LoadSegments, SortPred)) {
-    if (Error E =
-            WarnHandler("loadable segments are unsorted by virtual address"))
+    if (Error E = WarnHandler(
+            createError("loadable segments are unsorted by virtual address")))
       return std::move(E);
     llvm::stable_sort(LoadSegments, SortPred);
   }

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -355,19 +355,20 @@ static StringRef ToolName;
 std::unique_ptr<BuildIDFetcher> BIDFetcher;
 
 Dumper::Dumper(const object::ObjectFile &O) : O(O), OS(outs()) {
-  WarningHandler = [this](const Twine &Msg) {
-    if (Warnings.insert(Msg.str()).second)
+  WarningHandler = [this](Error Err) {
+    std::string Msg = toString(std::move(Err));
+    if (Warnings.insert(Msg).second)
       reportWarning(Msg, this->O.getFileName());
     return Error::success();
   };
 }
 
 void Dumper::reportUniqueWarning(Error Err) {
-  reportUniqueWarning(toString(std::move(Err)));
+  cantFail(WarningHandler(std::move(Err)));
 }
 
 void Dumper::reportUniqueWarning(const Twine &Msg) {
-  cantFail(WarningHandler(Msg));
+  cantFail(WarningHandler(createError(Msg)));
 }
 
 static Expected<std::unique_ptr<Dumper>> createDumper(const ObjectFile &Obj) {

--- a/llvm/tools/llvm-objdump/llvm-objdump.h
+++ b/llvm/tools/llvm-objdump/llvm-objdump.h
@@ -88,7 +88,7 @@ class Dumper {
 
 protected:
   llvm::raw_ostream &OS;
-  std::function<Error(const Twine &Msg)> WarningHandler;
+  std::function<Error(Error E)> WarningHandler;
 
 public:
   Dumper(const object::ObjectFile &O);

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -2028,8 +2028,8 @@ ELFDumper<ELFT>::ELFDumper(const object::ELFObjectFile<ELFT> &O,
 
 template <typename ELFT> void ELFDumper<ELFT>::parseDynamicTable() {
   auto toMappedAddr = [&](uint64_t Tag, uint64_t VAddr) -> const uint8_t * {
-    auto MappedAddrOrError = Obj.toMappedAddr(VAddr, [&](const Twine &Msg) {
-      this->reportUniqueWarning(Msg);
+    auto MappedAddrOrError = Obj.toMappedAddr(VAddr, [&](Error E) {
+      this->reportUniqueWarning(std::move(E));
       return Error::success();
     });
     if (!MappedAddrOrError) {

--- a/llvm/tools/llvm-readobj/ObjDumper.cpp
+++ b/llvm/tools/llvm-readobj/ObjDumper.cpp
@@ -33,8 +33,9 @@ static inline Error createError(const Twine &Msg) {
 ObjDumper::ObjDumper(ScopedPrinter &Writer, StringRef ObjName) : W(Writer) {
   // Dumper reports all non-critical errors as warnings.
   // It does not print the same warning more than once.
-  WarningHandler = [=](const Twine &Msg) {
-    if (Warnings.insert(Msg.str()).second)
+  WarningHandler = [=](Error E) {
+    std::string Msg = toString(std::move(E));
+    if (Warnings.insert(Msg).second)
       reportWarning(createError(Msg), ObjName);
     return Error::success();
   };
@@ -47,7 +48,7 @@ void ObjDumper::reportUniqueWarning(Error Err) const {
 }
 
 void ObjDumper::reportUniqueWarning(const Twine &Msg) const {
-  cantFail(WarningHandler(Msg),
+  cantFail(WarningHandler(createError(Msg)),
            "WarningHandler should always return ErrorSuccess");
 }
 

--- a/llvm/tools/llvm-readobj/ObjDumper.h
+++ b/llvm/tools/llvm-readobj/ObjDumper.h
@@ -187,7 +187,7 @@ public:
   void printSectionsAsHex(const object::ObjectFile &Obj,
                           ArrayRef<std::string> Sections, bool Decompress);
 
-  std::function<Error(const Twine &Msg)> WarningHandler;
+  std::function<Error(Error)> WarningHandler;
   void reportUniqueWarning(Error Err) const;
   void reportUniqueWarning(const Twine &Msg) const;
   void printOffloading(const object::ObjectFile &Obj);

--- a/llvm/unittests/Object/ELFObjectFileTest.cpp
+++ b/llvm/unittests/Object/ELFObjectFileTest.cpp
@@ -389,9 +389,9 @@ ProgramHeaders:
   std::string WarnString;
   auto ToMappedAddr = [&](uint64_t Addr) -> const uint8_t * {
     Expected<const uint8_t *> DataOrErr =
-        ExpectedFile->getELFFile().toMappedAddr(Addr, [&](const Twine &Msg) {
+        ExpectedFile->getELFFile().toMappedAddr(Addr, [&](Error E) {
           EXPECT_TRUE(WarnString.empty());
-          WarnString = Msg.str();
+          WarnString = toString(std::move(E));
           return Error::success();
         });
 


### PR DESCRIPTION
Warning consumers may need to handle errors based on their type. Pass the Error object instead of a string representation to enable this. This also brings WarningHandler in line with Support/WithColor.h.