### PR TITLE
[Clang][diagtool] Fix memory leak in ShowEnabledWarnings

### DIFF
--- a/clang/tools/diagtool/ShowEnabledWarnings.cpp
+++ b/clang/tools/diagtool/ShowEnabledWarnings.cpp
@@ -58,7 +58,8 @@ static IntrusiveRefCntPtr<DiagnosticsEngine>
 createDiagnostics(unsigned int argc, char **argv) {
   // Buffer diagnostics from argument parsing so that we can output them using a
   // well formed diagnostic object.
-  TextDiagnosticBuffer *DiagsBuffer = new TextDiagnosticBuffer;
+  std::unique_ptr<TextDiagnosticBuffer> DiagsBuffer =
+      std::make_unique<TextDiagnosticBuffer>();
 
   // Try to build the diagnostics parser
   SmallVector<const char *, 4> Args;


### PR DESCRIPTION
Fix 136-byte memory leak introduced in commit 6dc059ac3c7c. Before
that commit, the TextDiagnosticBuffer was passed to DiagnosticsEngine
constructor which took ownership and managed its lifetime. After the
refactoring, the buffer is no longer passed to DiagnosticsEngine, so
it becomes an orphaned allocation that is never freed. Changed to use
std::unique_ptr for automatic cleanup.
