### PR TITLE
[clang-tidy] Fix false positive in readability-convert-member-functions-to-static for const overloads

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
@@ -95,12 +95,10 @@ AST_MATCHER(CXXMethodDecl, hasNonConstOverload) {
     return false;
 
   for (const Decl *D : LookupResult) {
-    if (const auto *Overload = dyn_cast<CXXMethodDecl>(D)) {
-      if (Overload != Method && !Overload->isConst() &&
-          hasSameParameterTypes(*Method, *Overload)) {
-        return true;
-      }
-    }
+    const auto *Overload = dyn_cast<CXXMethodDecl>(D);
+    if (Overload && Overload != Method && !Overload->isConst() &&
+        hasSameParameterTypes(*Method, *Overload))
+      return true;
   }
   return false;
 }

--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
@@ -94,12 +94,11 @@ static bool hasNonConstOverload(const CXXMethodDecl &Node) {
   if (LookupResult.isSingleResult())
     return false;
 
-  return llvm::any_of(
-      LookupResult, [Method](const Decl *D) {
-        const auto *Overload = dyn_cast<CXXMethodDecl>(D);
-        return Overload && Overload != Method && !Overload->isConst() &&
-               hasSameParameterTypes(*Method, *Overload);
-      });
+  return llvm::any_of(LookupResult, [Method](const Decl *D) {
+    const auto *Overload = dyn_cast<CXXMethodDecl>(D);
+    return Overload && Overload != Method && !Overload->isConst() &&
+           hasSameParameterTypes(*Method, *Overload);
+  });
 }
 
 void ConvertMemberFunctionsToStaticCheck::registerMatchers(

--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
@@ -75,8 +75,9 @@ AST_MATCHER(CXXMethodDecl, usesThis) {
 
   return UsageOfThis.Used;
 }
+} // namespace
 
-bool hasSameParameterTypes(const CXXMethodDecl &MD1, const CXXMethodDecl &MD2) {
+static bool hasSameParameterTypes(const CXXMethodDecl &MD1, const CXXMethodDecl &MD2) {
   if (MD1.getNumParams() != MD2.getNumParams())
     return false;
   for (unsigned I = 0, E = MD1.getNumParams(); I < E; ++I)
@@ -86,7 +87,7 @@ bool hasSameParameterTypes(const CXXMethodDecl &MD1, const CXXMethodDecl &MD2) {
   return true;
 }
 
-AST_MATCHER(CXXMethodDecl, hasNonConstOverload) {
+static bool hasNonConstOverload(const CXXMethodDecl &Node) {
   const auto *Method = &Node;
   const DeclContext::lookup_result LookupResult =
       Method->getParent()->lookup(Method->getNameInfo().getName());
@@ -101,8 +102,6 @@ AST_MATCHER(CXXMethodDecl, hasNonConstOverload) {
       });
 }
 
-} // namespace
-
 void ConvertMemberFunctionsToStaticCheck::registerMatchers(
     MatchFinder *Finder) {
   Finder->addMatcher(
@@ -112,7 +111,7 @@ void ConvertMemberFunctionsToStaticCheck::registerMatchers(
               isVirtual(), isStatic(), hasTrivialBody(), isOverloadedOperator(),
               cxxConstructorDecl(), cxxDestructorDecl(), cxxConversionDecl(),
               isExplicitObjectMemberFunction(), isTemplate(),
-              isDependentContext(), allOf(isConst(), hasNonConstOverload()),
+              isDependentContext(),
               ofClass(anyOf(
                   isLambda(),
                   hasAnyDependentBases()) // Method might become virtual
@@ -159,6 +158,9 @@ static SourceRange getLocationOfConst(const TypeSourceInfo *TSI,
 void ConvertMemberFunctionsToStaticCheck::check(
     const MatchFinder::MatchResult &Result) {
   const auto *Definition = Result.Nodes.getNodeAs<CXXMethodDecl>("x");
+
+  if (Definition->isConst() && hasNonConstOverload(*Definition))
+    return;
 
   // TODO: For out-of-line declarations, don't modify the source if the header
   // is excluded by the -header-filter option.

--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
@@ -76,7 +76,7 @@ AST_MATCHER(CXXMethodDecl, usesThis) {
   return UsageOfThis.Used;
 }
 
-static bool hasSameParameterTypes(const CXXMethodDecl &MD1,
+bool hasSameParameterTypes(const CXXMethodDecl &MD1,
                                   const CXXMethodDecl &MD2) {
   if (MD1.getNumParams() != MD2.getNumParams())
     return false;

--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
@@ -76,6 +76,35 @@ AST_MATCHER(CXXMethodDecl, usesThis) {
   return UsageOfThis.Used;
 }
 
+static bool hasSameParameterTypes(const CXXMethodDecl &MD1,
+                                  const CXXMethodDecl &MD2) {
+  if (MD1.getNumParams() != MD2.getNumParams())
+    return false;
+  for (unsigned I = 0, E = MD1.getNumParams(); I < E; ++I)
+    if (MD1.getParamDecl(I)->getType().getCanonicalType() !=
+        MD2.getParamDecl(I)->getType().getCanonicalType())
+      return false;
+  return true;
+}
+
+AST_MATCHER(CXXMethodDecl, hasNonConstOverload) {
+  const auto *Method = &Node;
+  const DeclContext::lookup_result LookupResult =
+      Method->getParent()->lookup(Method->getNameInfo().getName());
+  if (LookupResult.isSingleResult())
+    return false;
+
+  for (const Decl *D : LookupResult) {
+    if (const auto *Overload = dyn_cast<CXXMethodDecl>(D)) {
+      if (Overload != Method && !Overload->isConst() &&
+          hasSameParameterTypes(*Method, *Overload)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 } // namespace
 
 void ConvertMemberFunctionsToStaticCheck::registerMatchers(
@@ -87,7 +116,7 @@ void ConvertMemberFunctionsToStaticCheck::registerMatchers(
               isVirtual(), isStatic(), hasTrivialBody(), isOverloadedOperator(),
               cxxConstructorDecl(), cxxDestructorDecl(), cxxConversionDecl(),
               isExplicitObjectMemberFunction(), isTemplate(),
-              isDependentContext(),
+              isDependentContext(), allOf(isConst(), hasNonConstOverload()),
               ofClass(anyOf(
                   isLambda(),
                   hasAnyDependentBases()) // Method might become virtual

--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
@@ -94,8 +94,8 @@ static bool hasNonConstOverload(const CXXMethodDecl &Node) {
   if (LookupResult.isSingleResult())
     return false;
 
-  return std::any_of(
-      LookupResult.begin(), LookupResult.end(), [Method](const Decl *D) {
+  return llvm::any_of(
+      LookupResult, [Method](const Decl *D) {
         const auto *Overload = dyn_cast<CXXMethodDecl>(D);
         return Overload && Overload != Method && !Overload->isConst() &&
                hasSameParameterTypes(*Method, *Overload);

--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
@@ -76,8 +76,7 @@ AST_MATCHER(CXXMethodDecl, usesThis) {
   return UsageOfThis.Used;
 }
 
-bool hasSameParameterTypes(const CXXMethodDecl &MD1,
-                                  const CXXMethodDecl &MD2) {
+bool hasSameParameterTypes(const CXXMethodDecl &MD1, const CXXMethodDecl &MD2) {
   if (MD1.getNumParams() != MD2.getNumParams())
     return false;
   for (unsigned I = 0, E = MD1.getNumParams(); I < E; ++I)
@@ -94,13 +93,12 @@ AST_MATCHER(CXXMethodDecl, hasNonConstOverload) {
   if (LookupResult.isSingleResult())
     return false;
 
-  for (const Decl *D : LookupResult) {
-    const auto *Overload = dyn_cast<CXXMethodDecl>(D);
-    if (Overload && Overload != Method && !Overload->isConst() &&
-        hasSameParameterTypes(*Method, *Overload))
-      return true;
-  }
-  return false;
+  return std::any_of(
+      LookupResult.begin(), LookupResult.end(), [Method](const Decl *D) {
+        const auto *Overload = dyn_cast<CXXMethodDecl>(D);
+        return Overload && Overload != Method && !Overload->isConst() &&
+               hasSameParameterTypes(*Method, *Overload);
+      });
 }
 
 } // namespace

--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
@@ -77,7 +77,8 @@ AST_MATCHER(CXXMethodDecl, usesThis) {
 }
 } // namespace
 
-static bool hasSameParameterTypes(const CXXMethodDecl &MD1, const CXXMethodDecl &MD2) {
+static bool hasSameParameterTypes(const CXXMethodDecl &MD1,
+                                  const CXXMethodDecl &MD2) {
   if (MD1.getNumParams() != MD2.getNumParams())
     return false;
   for (unsigned I = 0, E = MD1.getNumParams(); I < E; ++I)

--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
@@ -75,32 +75,33 @@ AST_MATCHER(CXXMethodDecl, usesThis) {
 
   return UsageOfThis.Used;
 }
-} // namespace
 
-static bool hasSameParameterTypes(const CXXMethodDecl &MD1,
-                                  const CXXMethodDecl &MD2) {
-  if (MD1.getNumParams() != MD2.getNumParams())
-    return false;
-  for (unsigned I = 0, E = MD1.getNumParams(); I < E; ++I)
-    if (MD1.getParamDecl(I)->getType().getCanonicalType() !=
-        MD2.getParamDecl(I)->getType().getCanonicalType())
-      return false;
-  return true;
-}
-
-static bool hasNonConstOverload(const CXXMethodDecl &Node) {
+AST_MATCHER(CXXMethodDecl, hasNonConstOverload) {
   const auto *Method = &Node;
   const DeclContext::lookup_result LookupResult =
       Method->getParent()->lookup(Method->getNameInfo().getName());
   if (LookupResult.isSingleResult())
     return false;
 
-  return llvm::any_of(LookupResult, [Method](const Decl *D) {
-    const auto *Overload = dyn_cast<CXXMethodDecl>(D);
-    return Overload && Overload != Method && !Overload->isConst() &&
-           hasSameParameterTypes(*Method, *Overload);
-  });
+  auto HasSameParameterTypes = [](const CXXMethodDecl &MD1,
+                                  const CXXMethodDecl &MD2) {
+    if (MD1.getNumParams() != MD2.getNumParams())
+      return false;
+    for (unsigned I = 0, E = MD1.getNumParams(); I < E; ++I)
+      if (MD1.getParamDecl(I)->getType().getCanonicalType() !=
+          MD2.getParamDecl(I)->getType().getCanonicalType())
+        return false;
+    return true;
+  };
+
+  return llvm::any_of(
+      LookupResult, [Method, HasSameParameterTypes](const Decl *D) {
+        const auto *Overload = dyn_cast<CXXMethodDecl>(D);
+        return Overload && Overload != Method && !Overload->isConst() &&
+               HasSameParameterTypes(*Method, *Overload);
+      });
 }
+} // namespace
 
 void ConvertMemberFunctionsToStaticCheck::registerMatchers(
     MatchFinder *Finder) {
@@ -111,7 +112,7 @@ void ConvertMemberFunctionsToStaticCheck::registerMatchers(
               isVirtual(), isStatic(), hasTrivialBody(), isOverloadedOperator(),
               cxxConstructorDecl(), cxxDestructorDecl(), cxxConversionDecl(),
               isExplicitObjectMemberFunction(), isTemplate(),
-              isDependentContext(),
+              isDependentContext(), allOf(isConst(), hasNonConstOverload()),
               ofClass(anyOf(
                   isLambda(),
                   hasAnyDependentBases()) // Method might become virtual
@@ -158,9 +159,6 @@ static SourceRange getLocationOfConst(const TypeSourceInfo *TSI,
 void ConvertMemberFunctionsToStaticCheck::check(
     const MatchFinder::MatchResult &Result) {
   const auto *Definition = Result.Nodes.getNodeAs<CXXMethodDecl>("x");
-
-  if (Definition->isConst() && hasNonConstOverload(*Definition))
-    return;
 
   // TODO: For out-of-line declarations, don't modify the source if the header
   // is excluded by the -header-filter option.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -412,6 +412,11 @@ Changes in existing checks
   - Reduce verbosity by removing the note indicating source location of the
     ``empty`` function.
 
+- Improved :doc:`readability-convert-member-functions-to-static
+  <clang-tidy/checks/readability/convert-member-functions-to-static>` check by
+  avoiding false positive on ``const`` member functions to static when they are
+  a part of const/non-const overload pair with same signature.
+
 - Improved :doc:`readability-else-after-return
   <clang-tidy/checks/readability/else-after-return>` check:
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -415,7 +415,7 @@ Changes in existing checks
 - Improved :doc:`readability-convert-member-functions-to-static
   <clang-tidy/checks/readability/convert-member-functions-to-static>` check by
   avoiding false positive on ``const`` member functions to static when they are
-  a part of const/non-const overload pair with same signature.
+  a part of const/non-const overload pair.
 
 - Improved :doc:`readability-else-after-return
   <clang-tidy/checks/readability/else-after-return>` check:

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static.cpp
@@ -235,3 +235,31 @@ struct NoFixitInMacro {
     return;
   }
 };
+
+
+struct OverloadedMethods {
+  void f() {
+    this->i++;
+  }
+  void f() const {
+    ;
+  };
+
+  void g(int) {
+    this->i++;
+  }
+  void g(int) const {
+    ;
+  };
+
+  void h(int) {
+    this->i++;
+  };
+  void h(float) const {
+    // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: method 'h' can be made static
+    // CHECK-FIXES: static void h(float) {
+    ;
+  };
+
+  int i = 0;
+};

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static.cpp
@@ -238,35 +238,21 @@ struct NoFixitInMacro {
 
 
 struct OverloadedMethods {
-  void f() {
-    this->i++;
-  }
-  void f() const {
-    ;
-  };
+  void f() { this->i++; }
+  void f() const { ; };   // `;` is necessary to ensure non trivial body
 
-  void g(int) {
-    this->i++;
-  }
-  void g(int) const {
-    ;
-  };
+  void g(int) { this->i++; }
+  void g(int) const { ; };
 
-  void h(int) {
-    this->i++;
-  };
+  void h(int) { this->i++; };
   void h(float) const {
     // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: method 'h' can be made static
     // CHECK-FIXES: static void h(float) {
     ;
   };
 
-  void j() {
-    this->i++;
-  }
-  int j() const {
-    ;
-  }
+  void j() { this->i++; }
+  int j() const { return 1; }
 
   int i = 0;
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static.cpp
@@ -261,5 +261,12 @@ struct OverloadedMethods {
     ;
   };
 
+  void j() {
+    this->i++;
+  }
+  int j() const {
+    ;
+  }
+
   int i = 0;
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/convert-member-functions-to-static.cpp
@@ -254,5 +254,40 @@ struct OverloadedMethods {
   void j() { this->i++; }
   int j() const { return 1; }
 
+  void l() { this->i++; }
+  void l() const volatile { ; }
+
+  void f_out_of_class();
+  void f_out_of_class() const;
+
+  void g_out_of_class(int);
+  void g_out_of_class(int) const;
+
+  void h_out_of_class(int);
+  void h_out_of_class(float) const;
+
+  void j_out_of_class();
+  int j_out_of_class() const;
+
+  void l_out_of_class();
+  void l_out_of_class() const volatile;
+
   int i = 0;
 };
+
+void OverloadedMethods::f_out_of_class() { this->i++; }
+void OverloadedMethods::f_out_of_class() const { ; }
+
+void OverloadedMethods::g_out_of_class(int) { this->i++; }
+void OverloadedMethods::g_out_of_class(int) const { ; }
+
+void OverloadedMethods::h_out_of_class(int) { this->i++; }
+void OverloadedMethods::h_out_of_class(float) const { ; }
+// CHECK-MESSAGES: :[[@LINE-1]]:25: warning: method 'h_out_of_class' can be made static
+// CHECK-FIXES: static void h_out_of_class(float) ;
+
+void OverloadedMethods::j_out_of_class() { this->i++; }
+int OverloadedMethods::j_out_of_class() const { return 1; }
+
+void OverloadedMethods::l_out_of_class() { this->i++; }
+void OverloadedMethods::l_out_of_class() const volatile { return; }


### PR DESCRIPTION
Don't suggest conversion of overloaded + same signature methods
differing in `const`ness to replace the `const` method with `static`.
    
E.g.;
```
void S::f();         // method1
void S::f() const;   // method2
```
    
method2 can't have it's `const` replaced with `static`.
    
Fixes #149152