### PR TITLE
[llubi] Fix invalid printf format specifier for %c

### DIFF
--- a/llvm/tools/llubi/lib/Library.cpp
+++ b/llvm/tools/llubi/lib/Library.cpp
@@ -242,13 +242,18 @@ AnyValue Library::executePrintf(ArrayRef<AnyValue> Args) {
     case 'u':
     case 'o':
     case 'x':
-    case 'X':
-    case 'c': {
+    case 'X': {
       // FIXME: The format specifiers "b" and "B" are not implemented here
       // since currently MSVC doesn't support it.
       std::string HostFmt = CleanChunk + "ll" + Specifier;
       OS << format(HostFmt.c_str(), static_cast<unsigned long long>(
                                         Arg.asInteger().getZExtValue()));
+      break;
+    }
+    case 'c': {
+      std::string HostFmt = CleanChunk + Specifier;
+      OS << format(HostFmt.c_str(),
+                   static_cast<int>(Arg.asInteger().getZExtValue()));
       break;
     }
     case 'f':


### PR DESCRIPTION
Fix ASAN warning about unexpected format specifier %llc introduced
in commit f149ab665a4b. The 'c' format specifier should not have the
'll' length modifier. Separated the 'c' case to use the correct format
without the length modifier, casting to int as required by the standard.
