### PR TITLE
[ORC] Move MemoryAccess ownership out of ExecutorProcessControl.

### DIFF
--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter3/KaleidoscopeJIT.h
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter3/KaleidoscopeJIT.h
@@ -43,6 +43,7 @@ class KaleidoscopeJIT {
 private:
   std::unique_ptr<ExecutionSession> ES;
   std::unique_ptr<EPCIndirectionUtils> EPCIU;
+  std::unique_ptr<MemoryAccess> MemAccess;
 
   DataLayout DL;
   MangleAndInterner Mangle;
@@ -63,8 +64,10 @@ private:
 public:
   KaleidoscopeJIT(std::unique_ptr<ExecutionSession> ES,
                   std::unique_ptr<EPCIndirectionUtils> EPCIU,
+                  std::unique_ptr<MemoryAccess> MemAccess,
                   JITTargetMachineBuilder JTMB, DataLayout DL)
-      : ES(std::move(ES)), EPCIU(std::move(EPCIU)), DL(std::move(DL)),
+      : ES(std::move(ES)), EPCIU(std::move(EPCIU)),
+        MemAccess(std::move(MemAccess)), DL(std::move(DL)),
         Mangle(*this->ES, this->DL),
         ObjectLayer(*this->ES,
                     [](const MemoryBuffer &) {
@@ -96,7 +99,13 @@ public:
 
     auto ES = std::make_unique<ExecutionSession>(std::move(*EPC));
 
-    auto EPCIU = EPCIndirectionUtils::Create(*ES);
+    auto MemAccess =
+        ES->getExecutorProcessControl().createDefaultMemoryAccess();
+    if (!MemAccess)
+      return MemAccess.takeError();
+
+    auto EPCIU = EPCIndirectionUtils::Create(ES->getExecutorProcessControl(),
+                                             **MemAccess);
     if (!EPCIU)
       return EPCIU.takeError();
 
@@ -114,6 +123,7 @@ public:
       return DL.takeError();
 
     return std::make_unique<KaleidoscopeJIT>(std::move(ES), std::move(*EPCIU),
+                                             std::move(*MemAccess),
                                              std::move(JTMB), std::move(*DL));
   }
 

--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter4/KaleidoscopeJIT.h
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter4/KaleidoscopeJIT.h
@@ -129,6 +129,7 @@ class KaleidoscopeJIT {
 private:
   std::unique_ptr<ExecutionSession> ES;
   std::unique_ptr<EPCIndirectionUtils> EPCIU;
+  std::unique_ptr<MemoryAccess> MemAccess;
 
   DataLayout DL;
   MangleAndInterner Mangle;
@@ -148,8 +149,10 @@ private:
 public:
   KaleidoscopeJIT(std::unique_ptr<ExecutionSession> ES,
                   std::unique_ptr<EPCIndirectionUtils> EPCIU,
+                  std::unique_ptr<MemoryAccess> MemAccess,
                   JITTargetMachineBuilder JTMB, DataLayout DL)
-      : ES(std::move(ES)), EPCIU(std::move(EPCIU)), DL(std::move(DL)),
+      : ES(std::move(ES)), EPCIU(std::move(EPCIU)),
+        MemAccess(std::move(MemAccess)), DL(std::move(DL)),
         Mangle(*this->ES, this->DL),
         ObjectLayer(*this->ES,
                     [](const MemoryBuffer &) {
@@ -179,7 +182,13 @@ public:
 
     auto ES = std::make_unique<ExecutionSession>(std::move(*EPC));
 
-    auto EPCIU = EPCIndirectionUtils::Create(*ES);
+    auto MemAccess =
+        ES->getExecutorProcessControl().createDefaultMemoryAccess();
+    if (!MemAccess)
+      return MemAccess.takeError();
+
+    auto EPCIU = EPCIndirectionUtils::Create(ES->getExecutorProcessControl(),
+                                             **MemAccess);
     if (!EPCIU)
       return EPCIU.takeError();
 
@@ -197,6 +206,7 @@ public:
       return DL.takeError();
 
     return std::make_unique<KaleidoscopeJIT>(std::move(ES), std::move(*EPCIU),
+                                             std::move(*MemAccess),
                                              std::move(JTMB), std::move(*DL));
   }
 

--- a/llvm/examples/OrcV2Examples/LLJITWithExecutorProcessControl/LLJITWithExecutorProcessControl.cpp
+++ b/llvm/examples/OrcV2Examples/LLJITWithExecutorProcessControl/LLJITWithExecutorProcessControl.cpp
@@ -145,7 +145,11 @@ int main(int argc, char *argv[]) {
       });
 
   // (3) Create stubs and call-through managers:
-  auto EPCIU = ExitOnErr(EPCIndirectionUtils::Create(J->getExecutionSession()));
+  auto MemAccess = ExitOnErr(J->getExecutionSession()
+                                 .getExecutorProcessControl()
+                                 .createDefaultMemoryAccess());
+  auto EPCIU = ExitOnErr(EPCIndirectionUtils::Create(
+      J->getExecutionSession().getExecutorProcessControl(), *MemAccess));
   ExitOnErr(EPCIU->writeResolverBlock(ExecutorAddr::fromPtr(&reenter),
                                       ExecutorAddr::fromPtr(EPCIU.get())));
   EPCIU->createLazyCallThroughManager(

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCIndirectionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCIndirectionUtils.h
@@ -25,6 +25,7 @@ namespace llvm {
 namespace orc {
 
 class ExecutorProcessControl;
+class MemoryAccess;
 
 /// Provides ExecutorProcessControl based indirect stubs, trampoline pool and
 /// lazy call through manager.
@@ -79,20 +80,17 @@ public:
   /// Create using the given ABI class.
   template <typename ORCABI>
   static std::unique_ptr<EPCIndirectionUtils>
-  CreateWithABI(ExecutorProcessControl &EPC);
+  CreateWithABI(ExecutorProcessControl &EPC, MemoryAccess &MemAccess);
 
   /// Create based on the ExecutorProcessControl triple.
   LLVM_ABI static Expected<std::unique_ptr<EPCIndirectionUtils>>
-  Create(ExecutorProcessControl &EPC);
-
-  /// Create based on the ExecutorProcessControl triple.
-  static Expected<std::unique_ptr<EPCIndirectionUtils>>
-  Create(ExecutionSession &ES) {
-    return Create(ES.getExecutorProcessControl());
-  }
+  Create(ExecutorProcessControl &EPC, MemoryAccess &MemAccess);
 
   /// Return a reference to the ExecutorProcessControl object.
   ExecutorProcessControl &getExecutorProcessControl() const { return EPC; }
+
+  /// Return a reference to the MemoryAccess object for this instance.
+  MemoryAccess &getMemoryAccess() const { return MemAccess; }
 
   /// Return a reference to the ABISupport object for this instance.
   ABISupport &getABISupport() const { return *ABI; }
@@ -143,13 +141,14 @@ private:
   using IndirectStubInfoVector = std::vector<IndirectStubInfo>;
 
   /// Create an EPCIndirectionUtils instance.
-  EPCIndirectionUtils(ExecutorProcessControl &EPC,
+  EPCIndirectionUtils(ExecutorProcessControl &EPC, MemoryAccess &MemAccess,
                       std::unique_ptr<ABISupport> ABI);
 
   Expected<IndirectStubInfoVector> getIndirectStubs(unsigned NumStubs);
 
   std::mutex EPCUIMutex;
   ExecutorProcessControl &EPC;
+  MemoryAccess &MemAccess;
   std::unique_ptr<ABISupport> ABI;
   ExecutorAddr ResolverBlockAddr;
   FinalizedAlloc ResolverBlock;
@@ -214,9 +213,10 @@ public:
 
 template <typename ORCABI>
 std::unique_ptr<EPCIndirectionUtils>
-EPCIndirectionUtils::CreateWithABI(ExecutorProcessControl &EPC) {
+EPCIndirectionUtils::CreateWithABI(ExecutorProcessControl &EPC,
+                                   MemoryAccess &MemAccess) {
   return std::unique_ptr<EPCIndirectionUtils>(new EPCIndirectionUtils(
-      EPC, std::make_unique<detail::ABISupportImpl<ORCABI>>()));
+      EPC, MemAccess, std::make_unique<detail::ABISupportImpl<ORCABI>>()));
 }
 
 } // end namespace orc

--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
@@ -134,12 +134,6 @@ public:
   /// Get the JIT dispatch function and context address for the executor.
   const JITDispatchInfo &getJITDispatchInfo() const { return JDI; }
 
-  /// Return a MemoryAccess object for the target process.
-  MemoryAccess &getMemoryAccess() const {
-    assert(MemAccess && "No MemAccess object set.");
-    return *MemAccess;
-  }
-
   /// Return a JITLinkMemoryManager for the target process.
   jitlink::JITLinkMemoryManager &getMemMgr() const {
     assert(MemMgr && "No MemMgr object set");
@@ -148,6 +142,10 @@ public:
 
   /// Create a default DylibManager for the target process.
   virtual Expected<std::unique_ptr<DylibManager>> createDefaultDylibMgr() = 0;
+
+  /// Create a default MemoryAccess for the target process.
+  virtual Expected<std::unique_ptr<MemoryAccess>>
+  createDefaultMemoryAccess() = 0;
 
   /// Returns the bootstrap map.
   const StringMap<std::vector<char>> &getBootstrapMap() const {
@@ -312,7 +310,6 @@ protected:
   Triple TargetTriple;
   unsigned PageSize = 0;
   JITDispatchInfo JDI;
-  MemoryAccess *MemAccess = nullptr;
   jitlink::JITLinkMemoryManager *MemMgr = nullptr;
   StringMap<std::vector<char>> BootstrapMap;
   StringMap<ExecutorAddr> BootstrapSymbols;

--- a/llvm/include/llvm/ExecutionEngine/Orc/JITLinkRedirectableSymbolManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/JITLinkRedirectableSymbolManager.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_JITLINKREDIRECABLESYMBOLMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_JITLINKREDIRECABLESYMBOLMANAGER_H
 
+#include "llvm/ExecutionEngine/Orc/MemoryAccess.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/RedirectionManager.h"
 #include "llvm/Support/Compiler.h"
@@ -28,7 +29,7 @@ class LLVM_ABI JITLinkRedirectableSymbolManager
 public:
   /// Create redirection manager that uses JITLink based implementaion.
   static Expected<std::unique_ptr<RedirectableSymbolManager>>
-  Create(ObjectLinkingLayer &ObjLinkingLayer) {
+  Create(ObjectLinkingLayer &ObjLinkingLayer, MemoryAccess &MemAccess) {
     auto AnonymousPtrCreator(jitlink::getAnonymousPointerCreator(
         ObjLinkingLayer.getExecutionSession().getTargetTriple()));
     auto PtrJumpStubCreator(jitlink::getPointerJumpStubCreator(
@@ -37,15 +38,16 @@ public:
       return make_error<StringError>("Architecture not supported",
                                      inconvertibleErrorCode());
     return std::unique_ptr<RedirectableSymbolManager>(
-        new JITLinkRedirectableSymbolManager(
-            ObjLinkingLayer, AnonymousPtrCreator, PtrJumpStubCreator));
+        new JITLinkRedirectableSymbolManager(ObjLinkingLayer, MemAccess,
+                                             AnonymousPtrCreator,
+                                             PtrJumpStubCreator));
   }
 
   JITLinkRedirectableSymbolManager(
-      ObjectLinkingLayer &ObjLinkingLayer,
+      ObjectLinkingLayer &ObjLinkingLayer, MemoryAccess &MemAccess,
       jitlink::AnonymousPointerCreator &AnonymousPtrCreator,
       jitlink::PointerJumpStubCreator &PtrJumpStubCreator)
-      : ObjLinkingLayer(ObjLinkingLayer),
+      : ObjLinkingLayer(ObjLinkingLayer), MemAccess(MemAccess),
         AnonymousPtrCreator(std::move(AnonymousPtrCreator)),
         PtrJumpStubCreator(std::move(PtrJumpStubCreator)) {}
 
@@ -58,6 +60,7 @@ public:
 
 private:
   ObjectLinkingLayer &ObjLinkingLayer;
+  MemoryAccess &MemAccess;
   jitlink::AnonymousPointerCreator AnonymousPtrCreator;
   jitlink::PointerJumpStubCreator PtrJumpStubCreator;
   std::atomic_size_t StubGraphIdx{0};

--- a/llvm/include/llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h
@@ -15,7 +15,6 @@
 #define LLVM_EXECUTIONENGINE_ORC_SELFEXECUTORPROCESSCONTROL_H
 
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
-#include "llvm/ExecutionEngine/Orc/InProcessMemoryAccess.h"
 
 #include <memory>
 
@@ -52,6 +51,8 @@ public:
 
   Expected<std::unique_ptr<DylibManager>> createDefaultDylibMgr() override;
 
+  Expected<std::unique_ptr<MemoryAccess>> createDefaultMemoryAccess() override;
+
   Error disconnect() override;
 
 private:
@@ -75,7 +76,6 @@ private:
 #ifdef __APPLE__
   std::unique_ptr<UnwindInfoManager> UnwindInfoMgr;
 #endif // __APPLE__
-  InProcessMemoryAccess IPMA;
 };
 
 } // namespace llvm::orc

--- a/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
@@ -31,18 +31,14 @@ namespace orc {
 class LLVM_ABI SimpleRemoteEPC : public ExecutorProcessControl,
                                  public SimpleRemoteEPCTransportClient {
 public:
-  /// A setup object containing callbacks to construct a memory manager and
-  /// memory access object. Both are optional. If not specified,
-  /// EPCGenericJITLinkMemoryManager and EPCGenericMemoryAccess will be used.
+  /// A setup object containing a callback to construct a memory manager.
+  /// If not specified, EPCGenericJITLinkMemoryManager will be used.
   struct Setup {
     using CreateMemoryManagerFn =
         Expected<std::unique_ptr<jitlink::JITLinkMemoryManager>>(
             SimpleRemoteEPC &);
-    using CreateMemoryAccessFn =
-        Expected<std::unique_ptr<MemoryAccess>>(SimpleRemoteEPC &);
 
     unique_function<CreateMemoryManagerFn> CreateMemoryManager;
-    unique_function<CreateMemoryAccessFn> CreateMemoryAccess;
   };
 
   /// Create a SimpleRemoteEPC using the given transport type and args.
@@ -82,6 +78,8 @@ public:
 
   Expected<std::unique_ptr<DylibManager>> createDefaultDylibMgr() override;
 
+  Expected<std::unique_ptr<MemoryAccess>> createDefaultMemoryAccess() override;
+
   Error disconnect() override;
 
   Expected<HandleMessageAction>
@@ -97,8 +95,6 @@ private:
 
   static Expected<std::unique_ptr<jitlink::JITLinkMemoryManager>>
   createDefaultMemoryManager(SimpleRemoteEPC &SREPC);
-  static Expected<std::unique_ptr<MemoryAccess>>
-  createDefaultMemoryAccess(SimpleRemoteEPC &SREPC);
 
   Error sendMessage(SimpleRemoteEPCOpcode OpC, uint64_t SeqNo,
                     ExecutorAddr TagAddr, ArrayRef<char> ArgBytes);
@@ -126,7 +122,6 @@ private:
 
   std::unique_ptr<SimpleRemoteEPCTransport> T;
   std::unique_ptr<jitlink::JITLinkMemoryManager> OwnedMemMgr;
-  std::unique_ptr<MemoryAccess> OwnedMemAccess;
 
   ExecutorAddr RunAsMainAddr;
   ExecutorAddr RunAsVoidFunctionAddr;

--- a/llvm/lib/ExecutionEngine/Orc/EPCIndirectionUtils.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCIndirectionUtils.cpp
@@ -154,7 +154,7 @@ Error EPCIndirectStubsManager::createStubs(const StubInitsMap &StubInits) {
     }
   }
 
-  auto &MemAccess = EPCIU.getExecutorProcessControl().getMemoryAccess();
+  auto &MemAccess = EPCIU.getMemoryAccess();
   switch (EPCIU.getABISupport().getPointerSize()) {
   case 4: {
     unsigned ASIdx = 0;
@@ -208,7 +208,7 @@ Error EPCIndirectStubsManager::updatePointer(StringRef Name,
     PtrAddr = I->second.first.PointerAddress;
   }
 
-  auto &MemAccess = EPCIU.getExecutorProcessControl().getMemoryAccess();
+  auto &MemAccess = EPCIU.getMemoryAccess();
   switch (EPCIU.getABISupport().getPointerSize()) {
   case 4: {
     tpctypes::UInt32Write PUpdate(PtrAddr, NewAddr.getValue());
@@ -232,7 +232,8 @@ namespace orc {
 EPCIndirectionUtils::ABISupport::~ABISupport() = default;
 
 Expected<std::unique_ptr<EPCIndirectionUtils>>
-EPCIndirectionUtils::Create(ExecutorProcessControl &EPC) {
+EPCIndirectionUtils::Create(ExecutorProcessControl &EPC,
+                            MemoryAccess &MemAccess) {
   const auto &TT = EPC.getTargetTriple();
   switch (TT.getArch()) {
   default:
@@ -241,32 +242,32 @@ EPCIndirectionUtils::Create(ExecutorProcessControl &EPC) {
         inconvertibleErrorCode());
   case Triple::aarch64:
   case Triple::aarch64_32:
-    return CreateWithABI<OrcAArch64>(EPC);
+    return CreateWithABI<OrcAArch64>(EPC, MemAccess);
 
   case Triple::x86:
-    return CreateWithABI<OrcI386>(EPC);
+    return CreateWithABI<OrcI386>(EPC, MemAccess);
 
   case Triple::loongarch64:
-    return CreateWithABI<OrcLoongArch64>(EPC);
+    return CreateWithABI<OrcLoongArch64>(EPC, MemAccess);
 
   case Triple::mips:
-    return CreateWithABI<OrcMips32Be>(EPC);
+    return CreateWithABI<OrcMips32Be>(EPC, MemAccess);
 
   case Triple::mipsel:
-    return CreateWithABI<OrcMips32Le>(EPC);
+    return CreateWithABI<OrcMips32Le>(EPC, MemAccess);
 
   case Triple::mips64:
   case Triple::mips64el:
-    return CreateWithABI<OrcMips64>(EPC);
+    return CreateWithABI<OrcMips64>(EPC, MemAccess);
 
   case Triple::riscv64:
-    return CreateWithABI<OrcRiscv64>(EPC);
+    return CreateWithABI<OrcRiscv64>(EPC, MemAccess);
 
   case Triple::x86_64:
     if (TT.getOS() == Triple::OSType::Win32)
-      return CreateWithABI<OrcX86_64_Win32>(EPC);
+      return CreateWithABI<OrcX86_64_Win32>(EPC, MemAccess);
     else
-      return CreateWithABI<OrcX86_64_SysV>(EPC);
+      return CreateWithABI<OrcX86_64_SysV>(EPC, MemAccess);
   }
 }
 
@@ -337,8 +338,9 @@ LazyCallThroughManager &EPCIndirectionUtils::createLazyCallThroughManager(
 }
 
 EPCIndirectionUtils::EPCIndirectionUtils(ExecutorProcessControl &EPC,
+                                         MemoryAccess &MemAccess,
                                          std::unique_ptr<ABISupport> ABI)
-    : EPC(EPC), ABI(std::move(ABI)) {
+    : EPC(EPC), MemAccess(MemAccess), ABI(std::move(ABI)) {
   assert(this->ABI && "ABI can not be null");
 
   assert(EPC.getPageSize() > getABISupport().getStubSize() &&

--- a/llvm/lib/ExecutionEngine/Orc/JITLinkRedirectableSymbolManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/JITLinkRedirectableSymbolManager.cpp
@@ -86,8 +86,5 @@ Error JITLinkRedirectableSymbolManager::redirect(JITDylib &JD,
     PtrWrites.push_back({PtrSym.getAddress(), DestSym.getAddress()});
   }
 
-  return ObjLinkingLayer.getExecutionSession()
-      .getExecutorProcessControl()
-      .getMemoryAccess()
-      .writePointers(PtrWrites);
+  return MemAccess.writePointers(PtrWrites);
 }

--- a/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h"
 
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/InProcessMemoryAccess.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/DefaultHostBootstrapValues.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/TargetExecutionUtils.h"
 #include "llvm/Support/DynamicLibrary.h"
@@ -23,8 +24,7 @@ SelfExecutorProcessControl::SelfExecutorProcessControl(
     std::shared_ptr<SymbolStringPool> SSP, std::unique_ptr<TaskDispatcher> D,
     Triple TargetTriple, unsigned PageSize,
     std::unique_ptr<jitlink::JITLinkMemoryManager> MemMgr)
-    : ExecutorProcessControl(std::move(SSP), std::move(D)),
-      IPMA(TargetTriple.isArch64Bit()) {
+    : ExecutorProcessControl(std::move(SSP), std::move(D)) {
 
   OwnedMemMgr = std::move(MemMgr);
   if (!OwnedMemMgr)
@@ -34,7 +34,6 @@ SelfExecutorProcessControl::SelfExecutorProcessControl(
   this->TargetTriple = std::move(TargetTriple);
   this->PageSize = PageSize;
   this->MemMgr = OwnedMemMgr.get();
-  this->MemAccess = &IPMA;
   this->JDI = {ExecutorAddr::fromPtr(jitDispatchViaWrapperFunctionManager),
                ExecutorAddr::fromPtr(this)};
 
@@ -109,6 +108,11 @@ Expected<std::unique_ptr<DylibManager>>
 SelfExecutorProcessControl::createDefaultDylibMgr() {
   char Prefix = TargetTriple.isOSBinFormatMachO() ? '_' : '\0';
   return std::make_unique<InProcessDylibManager>(Prefix);
+}
+
+Expected<std::unique_ptr<MemoryAccess>>
+SelfExecutorProcessControl::createDefaultMemoryAccess() {
+  return std::make_unique<InProcessMemoryAccess>(TargetTriple.isArch64Bit());
 }
 
 shared::CWrapperFunctionBuffer

--- a/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
@@ -94,6 +94,27 @@ SimpleRemoteEPC::createDefaultDylibMgr() {
   return std::make_unique<EPCGenericDylibManager>(std::move(*DM));
 }
 
+Expected<std::unique_ptr<MemoryAccess>>
+SimpleRemoteEPC::createDefaultMemoryAccess() {
+  EPCGenericMemoryAccess::FuncAddrs FAs;
+  if (auto Err = getBootstrapSymbols(
+          {{FAs.WriteUInt8s, rt::MemoryWriteUInt8sWrapperName},
+           {FAs.WriteUInt16s, rt::MemoryWriteUInt16sWrapperName},
+           {FAs.WriteUInt32s, rt::MemoryWriteUInt32sWrapperName},
+           {FAs.WriteUInt64s, rt::MemoryWriteUInt64sWrapperName},
+           {FAs.WriteBuffers, rt::MemoryWriteBuffersWrapperName},
+           {FAs.WritePointers, rt::MemoryWritePointersWrapperName},
+           {FAs.ReadUInt8s, rt::MemoryReadUInt8sWrapperName},
+           {FAs.ReadUInt16s, rt::MemoryReadUInt16sWrapperName},
+           {FAs.ReadUInt32s, rt::MemoryReadUInt32sWrapperName},
+           {FAs.ReadUInt64s, rt::MemoryReadUInt64sWrapperName},
+           {FAs.ReadBuffers, rt::MemoryReadBuffersWrapperName},
+           {FAs.ReadStrings, rt::MemoryReadStringsWrapperName}}))
+    return std::move(Err);
+
+  return std::make_unique<EPCGenericMemoryAccess>(*this, FAs);
+}
+
 Error SimpleRemoteEPC::disconnect() {
   T->disconnect();
   D->shutdown();
@@ -194,27 +215,6 @@ SimpleRemoteEPC::createDefaultMemoryManager(SimpleRemoteEPC &SREPC) {
     return std::move(Err);
 
   return std::make_unique<EPCGenericJITLinkMemoryManager>(SREPC, SAs);
-}
-
-Expected<std::unique_ptr<MemoryAccess>>
-SimpleRemoteEPC::createDefaultMemoryAccess(SimpleRemoteEPC &SREPC) {
-  EPCGenericMemoryAccess::FuncAddrs FAs;
-  if (auto Err = SREPC.getBootstrapSymbols(
-          {{FAs.WriteUInt8s, rt::MemoryWriteUInt8sWrapperName},
-           {FAs.WriteUInt16s, rt::MemoryWriteUInt16sWrapperName},
-           {FAs.WriteUInt32s, rt::MemoryWriteUInt32sWrapperName},
-           {FAs.WriteUInt64s, rt::MemoryWriteUInt64sWrapperName},
-           {FAs.WriteBuffers, rt::MemoryWriteBuffersWrapperName},
-           {FAs.WritePointers, rt::MemoryWritePointersWrapperName},
-           {FAs.ReadUInt8s, rt::MemoryReadUInt8sWrapperName},
-           {FAs.ReadUInt16s, rt::MemoryReadUInt16sWrapperName},
-           {FAs.ReadUInt32s, rt::MemoryReadUInt32sWrapperName},
-           {FAs.ReadUInt64s, rt::MemoryReadUInt64sWrapperName},
-           {FAs.ReadBuffers, rt::MemoryReadBuffersWrapperName},
-           {FAs.ReadStrings, rt::MemoryReadStringsWrapperName}}))
-    return std::move(Err);
-
-  return std::make_unique<EPCGenericMemoryAccess>(SREPC, FAs);
 }
 
 Error SimpleRemoteEPC::sendMessage(SimpleRemoteEPCOpcode OpC, uint64_t SeqNo,
@@ -350,16 +350,6 @@ Error SimpleRemoteEPC::setup(Setup S) {
     this->MemMgr = OwnedMemMgr.get();
   } else
     return MemMgr.takeError();
-
-  // Set a default CreateMemoryAccess if none is specified.
-  if (!S.CreateMemoryAccess)
-    S.CreateMemoryAccess = createDefaultMemoryAccess;
-
-  if (auto MemAccess = S.CreateMemoryAccess(*this)) {
-    OwnedMemAccess = std::move(*MemAccess);
-    this->MemAccess = OwnedMemAccess.get();
-  } else
-    return MemAccess.takeError();
 
   return Error::success();
 }

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -1086,7 +1086,12 @@ public:
 
 Expected<std::unique_ptr<Session::LazyLinkingSupport>>
 createLazyLinkingSupport(Session &S) {
-  auto RSMgr = JITLinkRedirectableSymbolManager::Create(S.ObjLayer);
+  auto MemAccess = S.ES.getExecutorProcessControl().createDefaultMemoryAccess();
+  if (!MemAccess)
+    return MemAccess.takeError();
+
+  auto RSMgr =
+      JITLinkRedirectableSymbolManager::Create(S.ObjLayer, **MemAccess);
   if (!RSMgr)
     return RSMgr.takeError();
 
@@ -1113,7 +1118,8 @@ createLazyLinkingSupport(Session &S) {
     return LRMgr.takeError();
 
   return std::make_unique<Session::LazyLinkingSupport>(
-      std::move(*RSMgr), std::move(Speculator), std::move(*LRMgr), S.ObjLayer);
+      std::move(*MemAccess), std::move(*RSMgr), std::move(Speculator),
+      std::move(*LRMgr), S.ObjLayer);
 }
 
 static Error writeLazyExecOrder(Session &S) {

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.h
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.h
@@ -20,6 +20,7 @@
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/LazyObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/LazyReexports.h"
+#include "llvm/ExecutionEngine/Orc/MemoryAccess.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/RedirectionManager.h"
 #include "llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h"
@@ -60,14 +61,16 @@ struct Session {
 
   struct LazyLinkingSupport {
     LazyLinkingSupport(
+        std::unique_ptr<orc::MemoryAccess> MemAccess,
         std::unique_ptr<orc::RedirectableSymbolManager> RSMgr,
         std::shared_ptr<orc::SimpleLazyReexportsSpeculator> Speculator,
         std::unique_ptr<orc::LazyReexportsManager> LRMgr,
         orc::ObjectLinkingLayer &ObjLinkingLayer)
-        : RSMgr(std::move(RSMgr)), Speculator(std::move(Speculator)),
-          LRMgr(std::move(LRMgr)),
+        : MemAccess(std::move(MemAccess)), RSMgr(std::move(RSMgr)),
+          Speculator(std::move(Speculator)), LRMgr(std::move(LRMgr)),
           LazyObjLinkingLayer(ObjLinkingLayer, *this->LRMgr) {}
 
+    std::unique_ptr<orc::MemoryAccess> MemAccess;
     std::unique_ptr<orc::RedirectableSymbolManager> RSMgr;
     std::shared_ptr<orc::SimpleLazyReexportsSpeculator> Speculator;
     std::unique_ptr<orc::LazyReexportsManager> LRMgr;

--- a/llvm/unittests/ExecutionEngine/Orc/JITLinkRedirectionManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/JITLinkRedirectionManagerTest.cpp
@@ -1,6 +1,7 @@
 #include "OrcTestCommon.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
+#include "llvm/ExecutionEngine/Orc/InProcessMemoryAccess.h"
 #include "llvm/ExecutionEngine/Orc/JITLinkRedirectableSymbolManager.h"
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
@@ -60,16 +61,19 @@ protected:
     JD = &ES->createBareJITDylib("main");
     ObjLinkingLayer = std::make_unique<ObjectLinkingLayer>(
         *ES, std::make_unique<InProcessMemoryManager>(*PageSize));
+    MA = std::make_unique<InProcessMemoryAccess>(
+        JTMB->getTargetTriple().isArch64Bit());
     DL = std::make_unique<DataLayout>(std::move(*DLOrErr));
   }
   JITDylib *JD{nullptr};
   std::unique_ptr<ExecutionSession> ES;
   std::unique_ptr<ObjectLinkingLayer> ObjLinkingLayer;
+  std::unique_ptr<InProcessMemoryAccess> MA;
   std::unique_ptr<DataLayout> DL;
 };
 
 TEST_F(JITLinkRedirectionManagerTest, BasicRedirectionOperation) {
-  auto RM = JITLinkRedirectableSymbolManager::Create(*ObjLinkingLayer);
+  auto RM = JITLinkRedirectableSymbolManager::Create(*ObjLinkingLayer, *MA);
   // Bail out if we can not create
   if (!RM) {
     consumeError(RM.takeError());

--- a/llvm/unittests/ExecutionEngine/Orc/LazyCallThroughAndReexportsTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/LazyCallThroughAndReexportsTest.cpp
@@ -92,7 +92,16 @@ TEST(JITLinkLazyReexportsTest, Basics) {
 
   auto &OLL = cast<ObjectLinkingLayer>((*J)->getObjLinkingLayer());
 
-  auto RSMgr = JITLinkRedirectableSymbolManager::Create(OLL);
+  auto MA = (*J)->getExecutionSession()
+                .getExecutorProcessControl()
+                .createDefaultMemoryAccess();
+  if (!MA) {
+    dbgs() << "Boom for MA\n";
+    consumeError(MA.takeError());
+    GTEST_SKIP();
+  }
+
+  auto RSMgr = JITLinkRedirectableSymbolManager::Create(OLL, **MA);
   if (!RSMgr) {
     dbgs() << "Boom for RSMgr\n";
     consumeError(RSMgr.takeError());

--- a/llvm/unittests/ExecutionEngine/Orc/OrcTestCommon.h
+++ b/llvm/unittests/ExecutionEngine/Orc/OrcTestCommon.h
@@ -99,7 +99,6 @@ public:
         InProcessMemoryAccess(Triple(TT).isArch64Bit()) {
     this->TargetTriple = Triple(TT);
     this->PageSize = PageSize;
-    this->MemAccess = this;
   }
 
   Expected<int32_t> runAsMain(ExecutorAddr MainFnAddr,
@@ -122,6 +121,10 @@ public:
   }
 
   Expected<std::unique_ptr<DylibManager>> createDefaultDylibMgr() override {
+    llvm_unreachable("Unsupported");
+  }
+
+  Expected<std::unique_ptr<MemoryAccess>> createDefaultMemoryAccess() override {
     llvm_unreachable("Unsupported");
   }
 

--- a/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
@@ -140,7 +140,10 @@ static Function *createRetFunction(Module *M, StringRef Name,
 TEST_F(ReOptimizeLayerTest, BasicReOptimization) {
   MangleAndInterner Mangle(*ES, *DL);
 
-  auto RM = JITLinkRedirectableSymbolManager::Create(*ObjLinkingLayer);
+  auto MA = ES->getExecutorProcessControl().createDefaultMemoryAccess();
+  EXPECT_THAT_ERROR(MA.takeError(), Succeeded());
+
+  auto RM = JITLinkRedirectableSymbolManager::Create(*ObjLinkingLayer, **MA);
   EXPECT_THAT_ERROR(RM.takeError(), Succeeded());
 
   ROLayer = std::make_unique<ReOptimizeLayer>(*ES, *DL, *CompileLayer, **RM);


### PR DESCRIPTION
Similar to the DylibManager change in e55fb5de0f9, this removes an unnecessary coupling between ExecutorProcessControl and MemoryAccess, allowing clients to select MemoryAccess implementations independently.

To simplify the transition, the
ExecutorProcessControl::createDefaultMemoryAccess method will return an instance of whatever MemoryAccess the ExecutorProcessControl implementation had been using previously.