### PR TITLE
[clang] Fix crash in isAtEndOfMacroExpansion at FileID boundary.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -500,7 +500,7 @@ Miscellaneous Clang Crashes Fixed
 - Fixed a crash when explicitly casting a scalar to an atomic complex. (#GH114885)
 - Fixed an assertion failure when parsing an invalid out-of-line enum definition with template parameters. (#GH187909)
 - Fixed an assertion failure on invalid template template parameter during typo correction. (#GH183983)
-- Fixed an assertion failure when using CTAD for alias templates where the RHS resolves to a non-dependent class template specialization. (#GH190517)
+- Fixed an assertion failure in ``isAtEndOfMacroExpansion`` on macro expansions crossing the boundary of two fileIDs. (#GH115007), (#GH21755)
 
 OpenACC Specific Changes
 ------------------------

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -930,7 +930,8 @@ bool Lexer::isAtEndOfMacroExpansion(SourceLocation loc,
     // During error recovery, a zero-length synthetic token might be inserted
     // past the end of the FileID, e.g. inserting ")" when a macro-arg
     // containing a comma should be guarded by parentheses. In this case,
-    // afterLoc reaches the `NextLocalOffset` boundary, any operations on afterLoc will be invalid!
+    // afterLoc reaches the `NextLocalOffset` boundary, any operations on
+    // afterLoc will be invalid!
     const SrcMgr::SLocEntry &Entry = SM.getSLocEntry(FID);
     assert(Entry.isExpansion() && "Should be in an expansion");
     expansionLoc = Entry.getExpansion().getExpansionLocEnd();

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -921,8 +921,20 @@ bool Lexer::isAtEndOfMacroExpansion(SourceLocation loc,
 
   SourceLocation afterLoc = loc.getLocWithOffset(tokLen);
   SourceLocation expansionLoc;
-  if (!SM.isAtEndOfImmediateMacroExpansion(afterLoc, &expansionLoc))
-    return false;
+  FileID FID = SM.getFileID(loc);
+
+  if (SM.isInFileID(afterLoc, FID)) {
+    if (!SM.isAtEndOfImmediateMacroExpansion(afterLoc, &expansionLoc))
+      return false;
+  } else {
+    // During error recovery, a zero-length synthetic token might be inserted
+    // past the end of the FileID, e.g. inserting ")" when a macro-arg
+    // containing a comma should be guarded by parentheses. In this case,
+    // afterLoc reaches the `NextLocalOffset` boundary, any operations on afterLoc will be invalid!
+    const SrcMgr::SLocEntry &Entry = SM.getSLocEntry(FID);
+    assert(Entry.isExpansion() && "Should be in an expansion");
+    expansionLoc = Entry.getExpansion().getExpansionLocEnd();
+  }
 
   if (expansionLoc.isFileID()) {
     // No other macro expansions.

--- a/clang/test/Parser/macro-braces-recovery.cpp
+++ b/clang/test/Parser/macro-braces-recovery.cpp
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+namespace GH21755 {
+#define M(x) f x // expected-note {{macro 'M' defined here}}
+
+// expected-error@+5 {{too many arguments provided to function-like macro invocation}}
+// expected-note@+4 {{parentheses are required around macro argument containing braced initializer list}}
+// expected-error@+3 {{a type specifier is required for all declarations}}
+// expected-error@+2 {{expected ')'}}
+// expected-note@+1 {{to match this '('}}
+M(0 {,}) // expected-error {{expected ';' after top level declarator}}
+}
+
+namespace GH115007 {
+class Foo { // expected-note {{candidate constructor (the implicit copy constructor) not viable}} \
+            // expected-note {{candidate constructor (the implicit move constructor) not viable}}
+public:
+  Foo(int); // expected-note {{candidate constructor not viable: requires 1 argument, but 2 were provided}}
+  bool operator==(const int l); // expected-note {{candidate function not viable: no known conversion from 'Foo' to 'const int' for 1st argument}}
+};
+#define EQ(x,y) (void)(x == y) // expected-note {{macro 'EQ' defined here}}
+
+void test_EQ() {
+  Foo F = Foo{1};
+  // expected-error@+4 {{too many arguments provided to function-like macro invocation}}
+  // expected-note@+3 {{parentheses are required around macro argument containing braced initializer list}}
+  // expected-error@+2 {{no matching constructor for initialization of 'Foo'}}
+  // expected-error@+1 {{invalid operands to binary expression ('Foo' and 'Foo')}}
+  EQ(F,Foo{1,2});
+}
+}


### PR DESCRIPTION
During error recovery, a synthetic token (whose length is 0) can be inserted past the end of a FileID, e.g.  inserting ")" when a macro-arg containing a comma should be guarded by parentheses.

When calculating the location after this token, the calculated `AfterLoc` can point exactly to the start of the next FileID (`NextLocalOffset`), any source manager operations on the `AfterLoc` are invalid.
  
This patch adds a safe guard in `Lexer::isAtEndOfMacroExpansion` to prevent passing this invalid location to `SourceManager`.

 Fixes #115007
 Fixes #21755