### PR TITLE
[AsmPrinter] Fix AsmPrinterAnalysis::Result::invalidate to take PreservedAnalyses by const reference

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinterAnalysis.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinterAnalysis.h
@@ -33,7 +33,7 @@ public:
   public:
     AsmPrinter &getPrinter() { return Printer; }
 
-    bool invalidate(Module &, const PreservedAnalyses,
+    bool invalidate(Module &, const PreservedAnalyses &,
                     ModuleAnalysisManager::Invalidator &) {
       return false;
     }


### PR DESCRIPTION
The invalidate method was taking PreservedAnalyses by value instead of by const reference, causing an unnecessary copy on every invalidation query. All other analysis invalidate methods in LLVM use const reference.