### PR TITLE
Revert "[libclc][CMake] Use clang/llvm-ar on Windows (#186726)"

### DIFF
--- a/libclc/cmake/modules/CMakeCLCInformation.cmake
+++ b/libclc/cmake/modules/CMakeCLCInformation.cmake
@@ -11,32 +11,14 @@ if(NOT CMAKE_CLC_COMPILE_OBJECT)
     "<CMAKE_CLC_COMPILER> -x cl <DEFINES> <INCLUDES> <FLAGS> -c -o <OBJECT> <SOURCE>")
 endif()
 
-# Finds a required LLVM tool by searching the CLC compiler directory first.
-function(find_llvm_tool name out_var)
-  cmake_path(GET CMAKE_CLC_COMPILER PARENT_PATH llvm_bin_dir)
-  find_program(${out_var}
-    NAMES ${name}
-    HINTS "${llvm_bin_dir}"
-    DOC "libclc: path to the ${name} tool"
-  )
-  if(NOT ${out_var})
-    message(FATAL_ERROR "${name} not found for libclc build.")
-  endif()
-endfunction()
-
-find_llvm_tool(llvm-ar CLC_AR)
-find_llvm_tool(llvm-ranlib CLC_RANLIB)
-
 if(NOT DEFINED CMAKE_CLC_ARCHIVE_CREATE)
-  set(CMAKE_CLC_ARCHIVE_CREATE "${CLC_AR} qc <TARGET> <OBJECTS>")
+  set(CMAKE_CLC_ARCHIVE_CREATE "<CMAKE_AR> qc <TARGET> <LINK_FLAGS> <OBJECTS>")
 endif()
-
 if(NOT DEFINED CMAKE_CLC_ARCHIVE_APPEND)
-  set(CMAKE_CLC_ARCHIVE_APPEND "${CLC_AR} q <TARGET> <OBJECTS>")
+  set(CMAKE_CLC_ARCHIVE_APPEND "<CMAKE_AR> q <TARGET> <LINK_FLAGS> <OBJECTS>")
 endif()
-
 if(NOT DEFINED CMAKE_CLC_ARCHIVE_FINISH)
-  set(CMAKE_CLC_ARCHIVE_FINISH "${CLC_RANLIB} <TARGET>")
+  set(CMAKE_CLC_ARCHIVE_FINISH "<CMAKE_RANLIB> <TARGET>")
 endif()
 
 set(CMAKE_CLC_USE_LINKER_INFORMATION FALSE)

--- a/libclc/cmake/modules/CMakeDetermineCLCCompiler.cmake
+++ b/libclc/cmake/modules/CMakeDetermineCLCCompiler.cmake
@@ -4,22 +4,7 @@ if(NOT CMAKE_CLC_COMPILER)
       "The CLC language requires the C compiler (CMAKE_C_COMPILER) to be "
       "Clang, but CMAKE_C_COMPILER_ID is '${CMAKE_C_COMPILER_ID}'.")
   endif()
-
-  # Use the regular clang driver if the C compiler is clang-cl.
-  if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
-    cmake_path(GET CMAKE_C_COMPILER PARENT_PATH llvm_bin_dir)
-    find_program(clang_exe clang
-      HINTS "${llvm_bin_dir}"
-      NO_DEFAULT_PATH
-    )
-    if(NOT clang_exe)
-      message(FATAL_ERROR "clang-cl detected, but clang not found in ${llvm_bin_dir}")
-    endif()
-    set(clc_compiler "${clang_exe}")
-  else()
-    set(clc_compiler "${CMAKE_C_COMPILER}")
-  endif()
-  set(CMAKE_CLC_COMPILER "${clc_compiler}" CACHE FILEPATH "libclc: CLC compiler")
+  set(CMAKE_CLC_COMPILER "${CMAKE_C_COMPILER}" CACHE FILEPATH "CLC compiler")
 endif()
 
 mark_as_advanced(CMAKE_CLC_COMPILER)


### PR DESCRIPTION
This reverts commit 4abb927bacf37f18f6359a41639a6d1b3bffffb5.

The code is not needed since 121f5a96ff38 because the C compiler is now always just-built clang in in-tree build. In addition, CMAKE_AR is llvm-ar and CMAKE_RANLIB is llvm-ranlib.