### PR TITLE
Refactor LaneBitmask to be a wrapper of Bitset

### DIFF
--- a/llvm/include/llvm/ADT/Bitset.h
+++ b/llvm/include/llvm/ADT/Bitset.h
@@ -16,12 +16,17 @@
 #ifndef LLVM_ADT_BITSET_H
 #define LLVM_ADT_BITSET_H
 
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/bit.h"
 #include <array>
 #include <climits>
 #include <cstdint>
 
 namespace llvm {
+
+// Forward declare Bitset and hash_value for friend declarations.
+template <unsigned NumBits> class Bitset;
+template <unsigned NumBits> hash_code hash_value(const Bitset<NumBits> &);
 
 /// This is a constexpr reimplementation of a subset of std::bitset. It would be
 /// nice to use std::bitset directly, but it doesn't support constant
@@ -52,6 +57,8 @@ template <unsigned NumBits> class Bitset {
   constexpr void maskLastWord() { Bits[getLastWordIndex()] &= RemainderMask; }
 
 protected:
+  constexpr const StorageType &getData() const { return Bits; }
+
   constexpr Bitset(const std::array<uint64_t, (NumBits + 63) / 64> &B) {
     if constexpr (sizeof(BitWord) == sizeof(uint64_t)) {
       for (size_t I = 0; I != B.size(); ++I)
@@ -194,8 +201,86 @@ public:
     }
     return false;
   }
+
+  constexpr Bitset &operator<<=(unsigned N) {
+    if (N == 0)
+      return *this;
+    if (N >= NumBits) {
+      return *this = Bitset();
+    }
+    const unsigned WordShift = N / BitwordBits;
+    const unsigned BitShift = N % BitwordBits;
+    if (BitShift == 0) {
+      for (int I = NumWords - 1; I >= static_cast<int>(WordShift); --I)
+        Bits[I] = Bits[I - WordShift];
+    } else {
+      const unsigned CarryShift = BitwordBits - BitShift;
+      for (int I = NumWords - 1; I > static_cast<int>(WordShift); --I) {
+        Bits[I] = (Bits[I - WordShift] << BitShift) |
+                  (Bits[I - WordShift - 1] >> CarryShift);
+      }
+      Bits[WordShift] = Bits[0] << BitShift;
+    }
+    for (unsigned I = 0; I < WordShift; ++I)
+      Bits[I] = 0;
+    maskLastWord();
+    return *this;
+  }
+
+  constexpr Bitset operator<<(unsigned N) const {
+    Bitset Result(*this);
+    Result <<= N;
+    return Result;
+  }
+
+  constexpr Bitset &operator>>=(unsigned N) {
+    if (N == 0)
+      return *this;
+    if (N >= NumBits) {
+      return *this = Bitset();
+    }
+    const unsigned WordShift = N / BitwordBits;
+    const unsigned BitShift = N % BitwordBits;
+    if (BitShift == 0) {
+      for (unsigned I = 0; I < NumWords - WordShift; ++I)
+        Bits[I] = Bits[I + WordShift];
+    } else {
+      const unsigned CarryShift = BitwordBits - BitShift;
+      for (unsigned I = 0; I < NumWords - WordShift - 1; ++I) {
+        Bits[I] = (Bits[I + WordShift] >> BitShift) |
+                  (Bits[I + WordShift + 1] << CarryShift);
+      }
+      Bits[NumWords - WordShift - 1] = Bits[NumWords - 1] >> BitShift;
+    }
+    for (unsigned I = NumWords - WordShift; I < NumWords; ++I)
+      Bits[I] = 0;
+    maskLastWord();
+    return *this;
+  }
+
+  constexpr Bitset operator>>(unsigned N) const {
+    Bitset Result(*this);
+    Result >>= N;
+    return Result;
+  }
+
+  friend hash_code hash_value<NumBits>(const Bitset<NumBits> &);
+  friend struct std::hash<Bitset<NumBits>>;
 };
 
+template <unsigned NumBits>
+inline hash_code hash_value(const Bitset<NumBits> &B) {
+  return hash_combine_range(B.Bits.begin(), B.Bits.end());
+}
+
 } // end namespace llvm
+
+namespace std {
+template <unsigned NumBits> struct hash<llvm::Bitset<NumBits>> {
+  size_t operator()(const llvm::Bitset<NumBits> &B) const {
+    return llvm::hash_combine_range(B.Bits.begin(), B.Bits.end());
+  }
+};
+} // end namespace std
 
 #endif

--- a/llvm/include/llvm/ADT/Bitset.h
+++ b/llvm/include/llvm/ADT/Bitset.h
@@ -16,17 +16,12 @@
 #ifndef LLVM_ADT_BITSET_H
 #define LLVM_ADT_BITSET_H
 
-#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/bit.h"
 #include <array>
 #include <climits>
 #include <cstdint>
 
 namespace llvm {
-
-// Forward declare Bitset and hash_value for friend declarations.
-template <unsigned NumBits> class Bitset;
-template <unsigned NumBits> hash_code hash_value(const Bitset<NumBits> &);
 
 /// This is a constexpr reimplementation of a subset of std::bitset. It would be
 /// nice to use std::bitset directly, but it doesn't support constant
@@ -59,7 +54,13 @@ template <unsigned NumBits> class Bitset {
 protected:
   constexpr const StorageType &getData() const { return Bits; }
 
-  constexpr Bitset(const std::array<uint64_t, (NumBits + 63) / 64> &B) {
+public:
+  constexpr Bitset() = default;
+
+  /// Construct from an array of 64-bit words. On 32-bit platforms, each 64-bit
+  /// element is split into two 32-bit storage words.
+  explicit constexpr Bitset(
+      const std::array<uint64_t, (NumBits + 63) / 64> &B) {
     if constexpr (sizeof(BitWord) == sizeof(uint64_t)) {
       for (size_t I = 0; I != B.size(); ++I)
         Bits[I] = B[I];
@@ -77,9 +78,6 @@ protected:
     }
     maskLastWord();
   }
-
-public:
-  constexpr Bitset() = default;
   constexpr Bitset(std::initializer_list<unsigned> Init) {
     for (auto I : Init)
       set(I);
@@ -264,23 +262,37 @@ public:
     return Result;
   }
 
-  friend hash_code hash_value<NumBits>(const Bitset<NumBits> &);
-  friend struct std::hash<Bitset<NumBits>>;
-};
+  /// Return the number of 64-bit words needed to hold all bits.
+  static constexpr unsigned getNumWords64() { return (NumBits + 63) / 64; }
 
-template <unsigned NumBits>
-inline hash_code hash_value(const Bitset<NumBits> &B) {
-  return hash_combine_range(B.Bits.begin(), B.Bits.end());
-}
+  /// Return the I-th 64-bit word of the bitset, where word 0 contains bits
+  /// [0..63], word 1 contains bits [64..127], etc. On 32-bit platforms this
+  /// assembles two underlying storage words into one 64-bit value.
+  constexpr uint64_t getWord(unsigned I) const {
+    if constexpr (BitwordBits == 64) {
+      return Bits[I];
+    } else {
+      static_assert(BitwordBits == 32, "Unsupported word size");
+      uint64_t Lo = (2 * I < NumWords) ? Bits[2 * I] : 0;
+      uint64_t Hi = (2 * I + 1 < NumWords) ? Bits[2 * I + 1] : 0;
+      return Lo | (Hi << 32);
+    }
+  }
 
-} // end namespace llvm
-
-namespace std {
-template <unsigned NumBits> struct hash<llvm::Bitset<NumBits>> {
-  size_t operator()(const llvm::Bitset<NumBits> &B) const {
-    return llvm::hash_combine_range(B.Bits.begin(), B.Bits.end());
+  /// Return the index of the highest set bit, or -1 if no bits are set.
+  /// The return type is signed to allow the -1 sentinel.
+  constexpr int findLastSet() const {
+    for (int I = NumWords - 1; I >= 0; --I) {
+      if (Bits[I] != 0) {
+        unsigned LeadingZeros =
+            countl_zero_constexpr(static_cast<BitWord>(Bits[I]));
+        return I * BitwordBits + (BitwordBits - 1 - LeadingZeros);
+      }
+    }
+    return -1;
   }
 };
-} // end namespace std
+
+} // end namespace llvm
 
 #endif

--- a/llvm/include/llvm/CodeGen/RDFLiveness.h
+++ b/llvm/include/llvm/CodeGen/RDFLiveness.h
@@ -44,7 +44,7 @@ namespace std {
 template <> struct hash<llvm::rdf::detail::NodeRef> {
   std::size_t operator()(llvm::rdf::detail::NodeRef R) const {
     return std::hash<llvm::rdf::NodeId>{}(R.first) ^
-           std::hash<llvm::LaneBitmask::Type>{}(R.second.getAsInteger());
+           std::hash<llvm::LaneBitmask>{}(R.second);
   }
 };
 

--- a/llvm/include/llvm/CodeGen/RDFRegisters.h
+++ b/llvm/include/llvm/CodeGen/RDFRegisters.h
@@ -125,8 +125,7 @@ public:
   }
 
   size_t hash() const {
-    return std::hash<RegisterId>{}(Id) ^
-           std::hash<LaneBitmask::Type>{}(Mask.getAsInteger());
+    return std::hash<RegisterId>{}(Id) ^ std::hash<LaneBitmask>{}(Mask);
   }
 
   static constexpr bool isRegId(RegisterId Id) {

--- a/llvm/include/llvm/MC/LaneBitmask.h
+++ b/llvm/include/llvm/MC/LaneBitmask.h
@@ -29,72 +29,193 @@
 #ifndef LLVM_MC_LANEBITMASK_H
 #define LLVM_MC_LANEBITMASK_H
 
-#include "llvm/Support/Compiler.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/Bitset.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/Printable.h"
 #include "llvm/Support/raw_ostream.h"
+#include <array>
+#include <cassert>
 
-namespace llvm {
+namespace llvm::detail {
+template <unsigned NumBits> struct LaneBitmaskImpl : public Bitset<NumBits> {
+  static constexpr unsigned BitWidth = NumBits;
 
-  struct LaneBitmask {
-    // When changing the underlying type, change the format string as well.
-    using Type = uint64_t;
-    enum : unsigned { BitWidth = 8*sizeof(Type) };
-    constexpr static const char *const FormatStr = "%016llX";
+  constexpr LaneBitmaskImpl() = default;
+  constexpr LaneBitmaskImpl(const LaneBitmaskImpl &) = default;
+  explicit constexpr LaneBitmaskImpl(uint64_t V)
+      : Bitset<NumBits>(std::array<uint64_t, (NumBits + 63) / 64>{V}) {}
+  explicit constexpr LaneBitmaskImpl(
+      const std::array<uint64_t, (NumBits + 63) / 64> &B)
+      : Bitset<NumBits>(B) {}
+  explicit LaneBitmaskImpl(const APInt &N)
+      : Bitset<NumBits>(convertAPIntToArray(N)) {}
+  // Delete the initializer_list constructor to avoid ambiguity with the
+  // std::array constructor.
+  LaneBitmaskImpl(std::initializer_list<unsigned>) = delete;
+  constexpr LaneBitmaskImpl &operator=(const LaneBitmaskImpl &) = default;
 
-    constexpr LaneBitmask() = default;
-    explicit constexpr LaneBitmask(Type V) : Mask(V) {}
-
-    constexpr bool operator== (LaneBitmask M) const { return Mask == M.Mask; }
-    constexpr bool operator!= (LaneBitmask M) const { return Mask != M.Mask; }
-    constexpr bool operator< (LaneBitmask M)  const { return Mask < M.Mask; }
-    constexpr bool none() const { return Mask == 0; }
-    constexpr bool any()  const { return Mask != 0; }
-    constexpr bool all()  const { return ~Mask == 0; }
-
-    constexpr LaneBitmask operator~() const {
-      return LaneBitmask(~Mask);
+  /// Compare as unsigned integers (most-significant word first). This differs
+  /// from Bitset::operator< which compares bit-by-bit from LSB.
+  constexpr bool operator<(const LaneBitmaskImpl &Other) const {
+    const auto &ThisBits = this->getData();
+    const auto &OtherBits = Other.getData();
+    for (int I = ThisBits.size() - 1; I >= 0; --I) {
+      if (ThisBits[I] != OtherBits[I])
+        return ThisBits[I] < OtherBits[I];
     }
-    constexpr LaneBitmask operator|(LaneBitmask M) const {
-      return LaneBitmask(Mask | M.Mask);
-    }
-    constexpr LaneBitmask operator&(LaneBitmask M) const {
-      return LaneBitmask(Mask & M.Mask);
-    }
-    LaneBitmask &operator|=(LaneBitmask M) {
-      Mask |= M.Mask;
-      return *this;
-    }
-    LaneBitmask &operator&=(LaneBitmask M) {
-      Mask &= M.Mask;
-      return *this;
-    }
-
-    constexpr Type getAsInteger() const { return Mask; }
-
-    unsigned getNumLanes() const { return llvm::popcount(Mask); }
-    unsigned getHighestLane() const {
-      return Log2_64(Mask);
-    }
-
-    static constexpr LaneBitmask getNone() { return LaneBitmask(0); }
-    static constexpr LaneBitmask getAll() { return ~LaneBitmask(0); }
-    static constexpr LaneBitmask getLane(unsigned Lane) {
-      return LaneBitmask(Type(1) << Lane);
-    }
-
-  private:
-    Type Mask = 0;
-  };
-
-  /// Create Printable object to print LaneBitmasks on a \ref raw_ostream.
-  inline Printable PrintLaneMask(LaneBitmask LaneMask) {
-    return Printable([LaneMask](raw_ostream &OS) {
-      OS << format(LaneBitmask::FormatStr, LaneMask.getAsInteger());
-    });
+    return false;
   }
 
+  constexpr LaneBitmaskImpl operator~() const {
+    return Bitset<NumBits>::operator~();
+  }
+  constexpr LaneBitmaskImpl operator|(LaneBitmaskImpl M) const {
+    return Bitset<NumBits>::operator|(M);
+  }
+  constexpr LaneBitmaskImpl operator&(LaneBitmaskImpl M) const {
+    return Bitset<NumBits>::operator&(M);
+  }
+  constexpr LaneBitmaskImpl &operator|=(LaneBitmaskImpl M) {
+    Bitset<NumBits>::operator|=(M);
+    return *this;
+  }
+  constexpr LaneBitmaskImpl &operator&=(LaneBitmaskImpl M) {
+    Bitset<NumBits>::operator&=(M);
+    return *this;
+  }
+  constexpr LaneBitmaskImpl operator^(LaneBitmaskImpl M) const {
+    return Bitset<NumBits>::operator^(M);
+  }
+  constexpr LaneBitmaskImpl &operator^=(LaneBitmaskImpl M) {
+    Bitset<NumBits>::operator^=(M);
+    return *this;
+  }
+
+  constexpr size_t getNumLanes() const { return this->count(); }
+
+  unsigned getHighestLane() const {
+    assert(this->any() && "getHighestLane called on empty mask");
+    const auto &Bits = this->getData();
+    constexpr size_t WordBits = sizeof(decltype(Bits[0])) * 8;
+    for (int I = Bits.size() - 1; I >= 0; --I)
+      if (Bits[I] != 0)
+        return I * WordBits + Log2_64(Bits[I]);
+    llvm_unreachable("should have found a set bit");
+  }
+
+  /// Shift bits left by \p S positions. Zeroes are shifted in from the right.
+  constexpr LaneBitmaskImpl operator<<(unsigned S) const {
+    return Bitset<NumBits>::operator<<(S);
+  }
+
+  /// Shift bits right by \p S positions. Zeroes are shifted in from the left.
+  constexpr LaneBitmaskImpl operator>>(unsigned S) const {
+    return Bitset<NumBits>::operator>>(S);
+  }
+
+  /// Rotate bits left by \p S positions.
+  constexpr LaneBitmaskImpl rotateLeft(unsigned S) const {
+    S = S % NumBits;
+    if (S == 0)
+      return *this;
+    return (*this << S) | (*this >> (NumBits - S));
+  }
+
+  /// Rotate bits right by \p S positions.
+  constexpr LaneBitmaskImpl rotateRight(unsigned S) const {
+    S = S % NumBits;
+    if (S == 0)
+      return *this;
+    return (*this >> S) | (*this << (NumBits - S));
+  }
+
+  static constexpr LaneBitmaskImpl getNone() { return LaneBitmaskImpl(); }
+
+  static constexpr LaneBitmaskImpl getAll() {
+    LaneBitmaskImpl Result;
+    Result.set();
+    return Result;
+  }
+
+  static constexpr LaneBitmaskImpl getLane(unsigned Lane) {
+    LaneBitmaskImpl Result;
+    Result.set(Lane);
+    return Result;
+  }
+
+private:
+  constexpr LaneBitmaskImpl(const Bitset<NumBits> &B) : Bitset<NumBits>(B) {}
+
+  /// Helper to convert APInt to array format for Bitset constructor.
+  static std::array<uint64_t, (NumBits + 63) / 64>
+  convertAPIntToArray(const APInt &N) {
+    static_assert(std::is_same_v<APInt::WordType, uint64_t>,
+                  "APInt::WordType needs to be uint64_t for word-level copy.");
+    assert(N.getBitWidth() <= NumBits &&
+           "Cannot convert to LaneBitmask. The input APInt has "
+           "more bits than LaneBitmask can hold.");
+    std::array<uint64_t, (NumBits + 63) / 64> Result{};
+    const uint64_t *RawData = N.getRawData();
+    const size_t NumWords = N.getNumWords();
+    for (size_t I = 0; I < NumWords && I < Result.size(); ++I)
+      Result[I] = RawData[I];
+    return Result;
+  }
+
+  template <typename, typename> friend struct llvm::format_provider;
+};
+
+} // end namespace llvm::detail
+
+namespace llvm {
+using LaneBitmask = detail::LaneBitmaskImpl<64>;
+
+template <unsigned NumBits>
+struct format_provider<detail::LaneBitmaskImpl<NumBits>> {
+  using T = detail::LaneBitmaskImpl<NumBits>;
+  static void format(const T &V, raw_ostream &Stream, StringRef Style) {
+    // Print as hex using platform words from most significant to least.
+    // Only print the first 64 bits if all upper words are zero.
+    const auto &Data = V.getData();
+    constexpr unsigned SizeOfBitword = sizeof(Data[0]);
+    constexpr unsigned HexWidth = SizeOfBitword * 2;
+    constexpr unsigned NumWordsIn64Bits = 8 / SizeOfBitword;
+    T UpperWords = ~T(~0ULL) & V;
+    if (UpperWords.none())
+      for (int I = NumWordsIn64Bits - 1; I >= 0; --I)
+        Stream << format_hex_no_prefix(Data[I], HexWidth, true);
+    else
+      for (int I = Data.size() - 1; I >= 0; --I)
+        Stream << format_hex_no_prefix(Data[I], HexWidth, true);
+  }
+};
+
+/// Create Printable object to print LaneBitmasks on a \ref raw_ostream.
+template <unsigned NumBits>
+inline Printable PrintLaneMask(detail::LaneBitmaskImpl<NumBits> LaneMask) {
+  return Printable(
+      [LaneMask](raw_ostream &OS) { OS << formatv("{0}", LaneMask); });
+}
+
+template <unsigned NumBits>
+inline hash_code hash_value(const detail::LaneBitmaskImpl<NumBits> &LM) {
+  return hash_value(static_cast<const Bitset<NumBits> &>(LM));
+}
+
 } // end namespace llvm
+
+namespace std {
+
+template <unsigned NumBits>
+struct hash<llvm::detail::LaneBitmaskImpl<NumBits>> {
+  size_t operator()(const llvm::detail::LaneBitmaskImpl<NumBits> &LM) const {
+    return hash<llvm::Bitset<NumBits>>{}(LM);
+  }
+};
+
+} // end namespace std
 
 #endif // LLVM_MC_LANEBITMASK_H

--- a/llvm/include/llvm/MC/LaneBitmask.h
+++ b/llvm/include/llvm/MC/LaneBitmask.h
@@ -33,87 +33,93 @@
 #include "llvm/ADT/Bitset.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/FormatVariadic.h"
-#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/Printable.h"
 #include "llvm/Support/raw_ostream.h"
 #include <array>
 #include <cassert>
 
 namespace llvm::detail {
-template <unsigned NumBits> struct LaneBitmaskImpl : public Bitset<NumBits> {
+template <unsigned NumBits> struct LaneBitmaskImpl {
   static constexpr unsigned BitWidth = NumBits;
 
   constexpr LaneBitmaskImpl() = default;
   constexpr LaneBitmaskImpl(const LaneBitmaskImpl &) = default;
   explicit constexpr LaneBitmaskImpl(uint64_t V)
-      : Bitset<NumBits>(std::array<uint64_t, (NumBits + 63) / 64>{V}) {}
+      : Storage(std::array<uint64_t, (NumBits + 63) / 64>{V}) {}
   explicit constexpr LaneBitmaskImpl(
       const std::array<uint64_t, (NumBits + 63) / 64> &B)
-      : Bitset<NumBits>(B) {}
-  explicit LaneBitmaskImpl(const APInt &N)
-      : Bitset<NumBits>(convertAPIntToArray(N)) {}
+      : Storage(B) {}
+  explicit LaneBitmaskImpl(const APInt &N) : Storage(convertAPIntToArray(N)) {}
   // Delete the initializer_list constructor to avoid ambiguity with the
   // std::array constructor.
   LaneBitmaskImpl(std::initializer_list<unsigned>) = delete;
   constexpr LaneBitmaskImpl &operator=(const LaneBitmaskImpl &) = default;
 
+  constexpr bool operator==(const LaneBitmaskImpl &Other) const {
+    return Storage == Other.Storage;
+  }
+  constexpr bool operator!=(const LaneBitmaskImpl &Other) const {
+    return Storage != Other.Storage;
+  }
   /// Compare as unsigned integers (most-significant word first). This differs
   /// from Bitset::operator< which compares bit-by-bit from LSB.
   constexpr bool operator<(const LaneBitmaskImpl &Other) const {
-    const auto &ThisBits = this->getData();
-    const auto &OtherBits = Other.getData();
-    for (int I = ThisBits.size() - 1; I >= 0; --I) {
-      if (ThisBits[I] != OtherBits[I])
-        return ThisBits[I] < OtherBits[I];
+    for (int I = Storage.getNumWords64() - 1; I >= 0; --I) {
+      if (Storage.getWord(I) != Other.Storage.getWord(I))
+        return Storage.getWord(I) < Other.Storage.getWord(I);
     }
     return false;
   }
 
+  constexpr bool none() const { return Storage.none(); }
+  constexpr bool any() const { return Storage.any(); }
+  constexpr bool all() const { return Storage.all(); }
+
   constexpr LaneBitmaskImpl operator~() const {
-    return Bitset<NumBits>::operator~();
+    LaneBitmaskImpl Result;
+    Result.Storage = ~Storage;
+    return Result;
   }
-  constexpr LaneBitmaskImpl operator|(LaneBitmaskImpl M) const {
-    return Bitset<NumBits>::operator|(M);
+  constexpr LaneBitmaskImpl operator|(const LaneBitmaskImpl &M) const {
+    LaneBitmaskImpl Result;
+    Result.Storage = Storage | M.Storage;
+    return Result;
   }
-  constexpr LaneBitmaskImpl operator&(LaneBitmaskImpl M) const {
-    return Bitset<NumBits>::operator&(M);
+  constexpr LaneBitmaskImpl operator&(const LaneBitmaskImpl &M) const {
+    LaneBitmaskImpl Result;
+    Result.Storage = Storage & M.Storage;
+    return Result;
   }
-  constexpr LaneBitmaskImpl &operator|=(LaneBitmaskImpl M) {
-    Bitset<NumBits>::operator|=(M);
+  constexpr LaneBitmaskImpl &operator|=(const LaneBitmaskImpl &M) {
+    Storage |= M.Storage;
     return *this;
   }
-  constexpr LaneBitmaskImpl &operator&=(LaneBitmaskImpl M) {
-    Bitset<NumBits>::operator&=(M);
-    return *this;
-  }
-  constexpr LaneBitmaskImpl operator^(LaneBitmaskImpl M) const {
-    return Bitset<NumBits>::operator^(M);
-  }
-  constexpr LaneBitmaskImpl &operator^=(LaneBitmaskImpl M) {
-    Bitset<NumBits>::operator^=(M);
+  constexpr LaneBitmaskImpl &operator&=(const LaneBitmaskImpl &M) {
+    Storage &= M.Storage;
     return *this;
   }
 
-  constexpr size_t getNumLanes() const { return this->count(); }
+  /// Return the I-th 64-bit word of the bitmask from least significant to most
+  /// significant.
+  constexpr uint64_t getWord(unsigned I) const { return Storage.getWord(I); }
+
+  constexpr size_t getNumLanes() const { return Storage.count(); }
 
   unsigned getHighestLane() const {
-    assert(this->any() && "getHighestLane called on empty mask");
-    const auto &Bits = this->getData();
-    constexpr size_t WordBits = sizeof(decltype(Bits[0])) * 8;
-    for (int I = Bits.size() - 1; I >= 0; --I)
-      if (Bits[I] != 0)
-        return I * WordBits + Log2_64(Bits[I]);
-    llvm_unreachable("should have found a set bit");
+    int Result = Storage.findLastSet();
+    assert(Result >= 0 && "getHighestLane called on empty mask");
+    return static_cast<unsigned>(Result);
   }
 
-  /// Shift bits left by \p S positions. Zeroes are shifted in from the right.
   constexpr LaneBitmaskImpl operator<<(unsigned S) const {
-    return Bitset<NumBits>::operator<<(S);
+    LaneBitmaskImpl Result;
+    Result.Storage = Storage << S;
+    return Result;
   }
-
-  /// Shift bits right by \p S positions. Zeroes are shifted in from the left.
   constexpr LaneBitmaskImpl operator>>(unsigned S) const {
-    return Bitset<NumBits>::operator>>(S);
+    LaneBitmaskImpl Result;
+    Result.Storage = Storage >> S;
+    return Result;
   }
 
   /// Rotate bits left by \p S positions.
@@ -136,18 +142,18 @@ template <unsigned NumBits> struct LaneBitmaskImpl : public Bitset<NumBits> {
 
   static constexpr LaneBitmaskImpl getAll() {
     LaneBitmaskImpl Result;
-    Result.set();
+    Result.Storage.set();
     return Result;
   }
 
   static constexpr LaneBitmaskImpl getLane(unsigned Lane) {
     LaneBitmaskImpl Result;
-    Result.set(Lane);
+    Result.Storage.set(Lane);
     return Result;
   }
 
 private:
-  constexpr LaneBitmaskImpl(const Bitset<NumBits> &B) : Bitset<NumBits>(B) {}
+  Bitset<NumBits> Storage;
 
   /// Helper to convert APInt to array format for Bitset constructor.
   static std::array<uint64_t, (NumBits + 63) / 64>
@@ -164,8 +170,6 @@ private:
       Result[I] = RawData[I];
     return Result;
   }
-
-  template <typename, typename> friend struct llvm::format_provider;
 };
 
 } // end namespace llvm::detail
@@ -177,19 +181,16 @@ template <unsigned NumBits>
 struct format_provider<detail::LaneBitmaskImpl<NumBits>> {
   using T = detail::LaneBitmaskImpl<NumBits>;
   static void format(const T &V, raw_ostream &Stream, StringRef Style) {
-    // Print as hex using platform words from most significant to least.
+    // Print as hex using 64-bit words from most significant to least.
     // Only print the first 64 bits if all upper words are zero.
-    const auto &Data = V.getData();
-    constexpr unsigned SizeOfBitword = sizeof(Data[0]);
-    constexpr unsigned HexWidth = SizeOfBitword * 2;
-    constexpr unsigned NumWordsIn64Bits = 8 / SizeOfBitword;
+    constexpr unsigned HexWidth = 16; // 16 hex digits per 64-bit word.
+    constexpr unsigned NumWords = Bitset<NumBits>::getNumWords64();
     T UpperWords = ~T(~0ULL) & V;
     if (UpperWords.none())
-      for (int I = NumWordsIn64Bits - 1; I >= 0; --I)
-        Stream << format_hex_no_prefix(Data[I], HexWidth, true);
+      Stream << format_hex_no_prefix(V.getWord(0), HexWidth, true);
     else
-      for (int I = Data.size() - 1; I >= 0; --I)
-        Stream << format_hex_no_prefix(Data[I], HexWidth, true);
+      for (int I = NumWords - 1; I >= 0; --I)
+        Stream << format_hex_no_prefix(V.getWord(I), HexWidth, true);
   }
 };
 
@@ -202,7 +203,17 @@ inline Printable PrintLaneMask(detail::LaneBitmaskImpl<NumBits> LaneMask) {
 
 template <unsigned NumBits>
 inline hash_code hash_value(const detail::LaneBitmaskImpl<NumBits> &LM) {
-  return hash_value(static_cast<const Bitset<NumBits> &>(LM));
+  constexpr unsigned NumWords = Bitset<NumBits>::getNumWords64();
+  if constexpr (NumWords == 1)
+    return hash_value(LM.getWord(0));
+  else if constexpr (NumWords == 2)
+    return hash_combine(LM.getWord(0), LM.getWord(1));
+  else {
+    hash_code H = hash_value(LM.getWord(0));
+    for (unsigned I = 1; I < NumWords; ++I)
+      H = hash_combine(H, LM.getWord(I));
+    return H;
+  }
 }
 
 } // end namespace llvm
@@ -212,7 +223,7 @@ namespace std {
 template <unsigned NumBits>
 struct hash<llvm::detail::LaneBitmaskImpl<NumBits>> {
   size_t operator()(const llvm::detail::LaneBitmaskImpl<NumBits> &LM) const {
-    return hash<llvm::Bitset<NumBits>>{}(LM);
+    return llvm::hash_value(LM);
   }
 };
 

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -912,12 +912,20 @@ bool MIParser::parseBasicBlockLiveins(MachineBasicBlock &MBB) {
       if (Token.isNot(MIToken::IntegerLiteral) &&
           Token.isNot(MIToken::HexLiteral))
         return error("expected a lane mask");
-      static_assert(sizeof(LaneBitmask::Type) == sizeof(uint64_t),
-                    "Use correct get-function for lane mask");
-      LaneBitmask::Type V;
-      if (getUint64(V))
-        return error("invalid lane mask value");
-      Mask = LaneBitmask(V);
+
+      if (Token.is(MIToken::IntegerLiteral)) {
+        // Parse as integer literal (fits in 64 bits).
+        uint64_t V;
+        if (getUint64(V))
+          return error("invalid lane mask value");
+        Mask = LaneBitmask(V);
+      } else {
+        // Parse as hex literal (may be > 64 bits).
+        APInt A;
+        if (getHexUint(A))
+          return error("invalid lane mask value");
+        Mask = LaneBitmask(A);
+      }
       lex();
     }
     MBB.addLiveIn(Reg, Mask);
@@ -3117,12 +3125,21 @@ bool MIParser::parseLaneMaskOperand(MachineOperand &Dest) {
   // Parse lanemask.
   if (Token.isNot(MIToken::IntegerLiteral) && Token.isNot(MIToken::HexLiteral))
     return error("expected a valid lane mask value");
-  static_assert(sizeof(LaneBitmask::Type) == sizeof(uint64_t),
-                "Use correct get-function for lane mask.");
-  LaneBitmask::Type V;
-  if (getUint64(V))
-    return true;
-  LaneBitmask LaneMask(V);
+
+  LaneBitmask LaneMask;
+  if (Token.is(MIToken::IntegerLiteral)) {
+    // Parse as integer literal (fits in 64 bits).
+    uint64_t V;
+    if (getUint64(V))
+      return error("invalid lane mask value");
+    LaneMask = LaneBitmask(V);
+  } else {
+    // Parse as hex literal (may be > 64 bits).
+    APInt A;
+    if (getHexUint(A))
+      return error("invalid lane mask value");
+    LaneMask = LaneBitmask(A);
+  }
   lex();
 
   if (expectAndConsume(MIToken::rparen))

--- a/llvm/lib/CodeGen/MachineOperand.cpp
+++ b/llvm/lib/CodeGen/MachineOperand.cpp
@@ -464,7 +464,7 @@ hash_code llvm::hash_value(const MachineOperand &MO) {
     return hash_combine(MO.getType(), MO.getTargetFlags(), MO.getShuffleMask());
   case MachineOperand::MO_LaneMask:
     return hash_combine(MO.getType(), MO.getTargetFlags(),
-                        MO.getLaneMask().getAsInteger());
+                        hash_value(MO.getLaneMask()));
   }
   llvm_unreachable("Invalid machine operand type");
 }

--- a/llvm/lib/CodeGen/MachineStableHash.cpp
+++ b/llvm/lib/CodeGen/MachineStableHash.cpp
@@ -166,8 +166,12 @@ stable_hash llvm::stableHashValue(const MachineOperand &MO) {
                                stable_hash_name(SymbolName));
   }
   case MachineOperand::MO_LaneMask: {
+    // Use the deterministic printed representation for stable hashing.
+    std::string Str;
+    raw_string_ostream OS(Str);
+    OS << PrintLaneMask(MO.getLaneMask());
     return stable_hash_combine(MO.getType(), MO.getTargetFlags(),
-                               MO.getLaneMask().getAsInteger());
+                               stable_hash_name(OS.str()));
   }
   case MachineOperand::MO_CFIIndex:
     return stable_hash_combine(MO.getType(), MO.getTargetFlags(),

--- a/llvm/lib/CodeGen/RDFRegisters.cpp
+++ b/llvm/lib/CodeGen/RDFRegisters.cpp
@@ -407,11 +407,6 @@ raw_ostream &operator<<(raw_ostream &OS, const PrintLaneMaskShort &P) {
   if (P.Mask.none())
     return OS << ":*none*";
 
-  LaneBitmask::Type Val = P.Mask.getAsInteger();
-  if ((Val & 0xffff) == Val)
-    return OS << ':' << format("%04llX", Val);
-  if ((Val & 0xffffffff) == Val)
-    return OS << ':' << format("%08llX", Val);
   return OS << ':' << PrintLaneMask(P.Mask);
 }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUNextUseAnalysis.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUNextUseAnalysis.cpp
@@ -1828,7 +1828,7 @@ private:
           if (Indexes.size() == 1)
             KOS << printReg(Reg, TRI, Indexes.front(), MRI);
           else
-            KOS << printReg(Reg) << " mask=" << Mask.getAsInteger();
+            KOS << printReg(Reg) << " mask=" << PrintLaneMask(Mask);
         }
         OS << "  " << left_justify(RegName, RegNameWidth) << " : ";
         Elem.print(OS);

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -332,11 +332,11 @@ SIRegisterInfo::SIRegisterInfo(const GCNSubtarget &ST)
                             ST.getHwMode(MCSubtargetInfo::HwMode_RegInfo)),
       ST(ST), SpillSGPRToVGPR(EnableSpillSGPRToVGPR), isWave32(ST.isWave32()) {
 
-  assert(getSubRegIndexLaneMask(AMDGPU::sub0).getAsInteger() == 3 &&
-         getSubRegIndexLaneMask(AMDGPU::sub31).getAsInteger() == (3ULL << 62) &&
+  assert(getSubRegIndexLaneMask(AMDGPU::sub0) == LaneBitmask(3) &&
+         getSubRegIndexLaneMask(AMDGPU::sub31) == LaneBitmask(3ULL << 62) &&
          (getSubRegIndexLaneMask(AMDGPU::lo16) |
-          getSubRegIndexLaneMask(AMDGPU::hi16)).getAsInteger() ==
-           getSubRegIndexLaneMask(AMDGPU::sub0).getAsInteger() &&
+          getSubRegIndexLaneMask(AMDGPU::hi16)) ==
+             getSubRegIndexLaneMask(AMDGPU::sub0) &&
          "getNumCoveredRegs() will not work with generated subreg masks!");
 
   RegPressureIgnoredUnits.resize(getNumRegUnits());

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
@@ -404,11 +404,10 @@ public:
   static unsigned getNumCoveredRegs(LaneBitmask LM) {
     // The assumption is that every lo16 subreg is an even bit and every hi16
     // is an adjacent odd bit or vice versa.
-    uint64_t Mask = LM.getAsInteger();
-    uint64_t Even = Mask & 0xAAAAAAAAAAAAAAAAULL;
-    Mask = (Even >> 1) | Mask;
-    uint64_t Odd = Mask & 0x5555555555555555ULL;
-    return llvm::popcount(Odd);
+    LaneBitmask Even = LM & LaneBitmask(0xAAAAAAAAAAAAAAAAULL);
+    LaneBitmask Mask = (Even >> 1) | LM;
+    LaneBitmask Odd = Mask & LaneBitmask(0x5555555555555555ULL);
+    return Odd.count();
   }
 
   // \returns a DWORD offset of a \p SubReg

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
@@ -407,7 +407,7 @@ public:
     LaneBitmask Even = LM & LaneBitmask(0xAAAAAAAAAAAAAAAAULL);
     LaneBitmask Mask = (Even >> 1) | LM;
     LaneBitmask Odd = Mask & LaneBitmask(0x5555555555555555ULL);
-    return Odd.count();
+    return Odd.getNumLanes();
   }
 
   // \returns a DWORD offset of a \p SubReg

--- a/llvm/unittests/ADT/BitsetTest.cpp
+++ b/llvm/unittests/ADT/BitsetTest.cpp
@@ -294,4 +294,93 @@ TEST(BitsetTest, BitwiseOperators) {
                 TestXor128.test(127));
 }
 
+TEST(BitsetTest, ShiftOperators) {
+  // Test left shift.
+  static_assert((Bitset<64>({0}) << 10).test(10));
+  static_assert(!(Bitset<64>({0}) << 10).test(0));
+  static_assert((Bitset<64>({63}) << 1).none());
+  static_assert((Bitset<128>({0}) << 64).test(64));
+  static_assert((Bitset<128>({63}) << 1).test(64));
+  static_assert((Bitset<128>({127}) << 1).none());
+
+  // Test right shift.
+  static_assert((Bitset<64>({10}) >> 10).test(0));
+  static_assert(!(Bitset<64>({10}) >> 10).test(10));
+  static_assert((Bitset<64>({0}) >> 1).none());
+  static_assert((Bitset<128>({64}) >> 64).test(0));
+  static_assert((Bitset<128>({64}) >> 1).test(63));
+  static_assert((Bitset<128>({0}) >> 1).none());
+
+  // Test shift by 0.
+  static_assert((Bitset<64>({10, 20}) << 0) == Bitset<64>({10, 20}));
+  static_assert((Bitset<64>({10, 20}) >> 0) == Bitset<64>({10, 20}));
+
+  // Test shift by NumBits (clears all).
+  static_assert((Bitset<64>({0, 63}) << 64).none());
+  static_assert((Bitset<64>({0, 63}) >> 64).none());
+  static_assert((Bitset<128>({0, 127}) << 128).none());
+  static_assert((Bitset<128>({0, 127}) >> 128).none());
+}
+
+TEST(BitsetTest, GetNumWords64) {
+  static_assert(Bitset<1>::getNumWords64() == 1);
+  static_assert(Bitset<32>::getNumWords64() == 1);
+  static_assert(Bitset<64>::getNumWords64() == 1);
+  static_assert(Bitset<65>::getNumWords64() == 2);
+  static_assert(Bitset<96>::getNumWords64() == 2);
+  static_assert(Bitset<128>::getNumWords64() == 2);
+  static_assert(Bitset<129>::getNumWords64() == 3);
+}
+
+TEST(BitsetTest, GetWord) {
+  // Single-word bitset.
+  constexpr auto B64 = Bitset<64>(std::array<uint64_t, 1>{0xdeadbeefcafe1234});
+  static_assert(B64.getWord(0) == 0xdeadbeefcafe1234);
+
+  // Multi-word bitset.
+  constexpr auto B128 = Bitset<128>(
+      std::array<uint64_t, 2>{0x1111222233334444, 0xaaaabbbbccccdddd});
+  static_assert(B128.getWord(0) == 0x1111222233334444);
+  static_assert(B128.getWord(1) == 0xaaaabbbbccccdddd);
+
+  // Partial last word — high bits should be masked off.
+  constexpr auto B96 = Bitset<96>(
+      std::array<uint64_t, 2>{0xffffffffffffffff, 0xffffffffffffffff});
+  static_assert(B96.getWord(0) == 0xffffffffffffffff);
+  static_assert(B96.getWord(1) == 0x00000000ffffffff); // Only lower 32 bits.
+
+  // Empty bitset.
+  static_assert(Bitset<64>().getWord(0) == 0);
+  static_assert(Bitset<128>().getWord(0) == 0);
+  static_assert(Bitset<128>().getWord(1) == 0);
+}
+
+TEST(BitsetTest, FindLastSet) {
+  // Empty bitset returns -1.
+  static_assert(Bitset<64>().findLastSet() == -1);
+  static_assert(Bitset<128>().findLastSet() == -1);
+
+  // Single bit set.
+  static_assert(Bitset<64>({0}).findLastSet() == 0);
+  static_assert(Bitset<64>({63}).findLastSet() == 63);
+  static_assert(Bitset<64>({31}).findLastSet() == 31);
+  static_assert(Bitset<128>({0}).findLastSet() == 0);
+  static_assert(Bitset<128>({64}).findLastSet() == 64);
+  static_assert(Bitset<128>({127}).findLastSet() == 127);
+
+  // Multiple bits — returns highest.
+  static_assert(Bitset<64>({0, 10, 50}).findLastSet() == 50);
+  static_assert(Bitset<128>({0, 63, 64, 100}).findLastSet() == 100);
+
+  // All bits set.
+  static_assert(Bitset<64>().set().findLastSet() == 63);
+  static_assert(Bitset<128>().set().findLastSet() == 127);
+  static_assert(Bitset<96>().set().findLastSet() == 95);
+
+  // Non-power-of-2 sizes.
+  static_assert(Bitset<33>({32}).findLastSet() == 32);
+  static_assert(Bitset<33>({0, 32}).findLastSet() == 32);
+  static_assert(Bitset<65>({64}).findLastSet() == 64);
+}
+
 } // namespace

--- a/llvm/unittests/CodeGen/CMakeLists.txt
+++ b/llvm/unittests/CodeGen/CMakeLists.txt
@@ -30,8 +30,9 @@ add_llvm_unittest(CodeGenTests
   DwarfStringPoolEntryRefTest.cpp
   GCMetadata.cpp
   InstrRefLDVTest.cpp
-  LowLevelTypeTest.cpp
+  LaneBitmaskTest.cpp
   LexicalScopesTest.cpp
+  LowLevelTypeTest.cpp
   MachineBasicBlockTest.cpp
   MachineDomTreeUpdaterTest.cpp
   MachineInstrBundleIteratorTest.cpp

--- a/llvm/unittests/CodeGen/LaneBitmaskTest.cpp
+++ b/llvm/unittests/CodeGen/LaneBitmaskTest.cpp
@@ -1,0 +1,933 @@
+//===- llvm/unittest/CodeGen/LaneBitmaskTest.cpp --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/MC/LaneBitmask.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+// Type aliases for clarity.
+using LaneMask64 = detail::LaneBitmaskImpl<64>;
+using LaneMask128 = detail::LaneBitmaskImpl<128>;
+
+TEST(LaneBitmaskTest, ConstructorAndAssignment) {
+  // Test 64-bit version.
+  {
+    LaneMask64 Default;
+    EXPECT_TRUE(Default.none());
+    EXPECT_FALSE(Default.any());
+
+    LaneMask64 FromInt(0x123456789abcdef0);
+    EXPECT_TRUE(FromInt.any());
+    EXPECT_FALSE(FromInt.none());
+
+    std::array<uint64_t, 1> Arr64 = {0x123456789abcdef0};
+    LaneMask64 FromArray(Arr64);
+    EXPECT_TRUE(FromArray.test(4));
+    EXPECT_EQ(FromArray.count(), 32u);
+
+    LaneMask64 None = LaneMask64::getNone();
+    EXPECT_TRUE(None.none());
+
+    LaneMask64 All = LaneMask64::getAll();
+    EXPECT_TRUE(All.all());
+    EXPECT_EQ(All.count(), LaneMask64::BitWidth);
+
+    LaneMask64 Lane5 = LaneMask64::getLane(5);
+    EXPECT_TRUE(Lane5.test(5));
+    EXPECT_EQ(Lane5.getNumLanes(), 1u);
+
+    LaneMask64 Bit0 = LaneMask64::getLane(0);
+    EXPECT_TRUE(Bit0.test(0));
+    EXPECT_FALSE(Bit0.test(1));
+    EXPECT_EQ(Bit0.getHighestLane(), 0u);
+    EXPECT_TRUE((Bit0 >> 1).none());
+    EXPECT_TRUE(Bit0.rotateLeft(1).test(1));
+
+    LaneMask64 BitMax = LaneMask64::getLane(LaneMask64::BitWidth - 1);
+    EXPECT_TRUE(BitMax.test(LaneMask64::BitWidth - 1));
+    EXPECT_FALSE(BitMax.test(LaneMask64::BitWidth - 2));
+    EXPECT_EQ(BitMax.getHighestLane(), LaneMask64::BitWidth - 1);
+    EXPECT_TRUE(BitMax.rotateLeft(1).test(0));
+    EXPECT_TRUE((BitMax << 1).none());
+
+    LaneMask64 Original(0xabcd);
+    LaneMask64 Copied(Original);
+    EXPECT_EQ(Copied, Original);
+
+    LaneMask64 Assigned;
+    Assigned = Original;
+    EXPECT_EQ(Assigned, Original);
+  }
+
+  // Test 128-bit version.
+  {
+    LaneMask128 Default;
+    EXPECT_TRUE(Default.none());
+    EXPECT_FALSE(Default.any());
+
+    LaneMask128 FromInt(0x123456789abcdef0);
+    EXPECT_TRUE(FromInt.any());
+    EXPECT_FALSE(FromInt.none());
+
+    std::array<uint64_t, 2> Arr128 = {0xff, 0xff00};
+    LaneMask128 FromArray(Arr128);
+    EXPECT_TRUE(FromArray.test(0));
+    EXPECT_TRUE(FromArray.test(7));
+    EXPECT_TRUE(FromArray.test(64 + 8));
+    EXPECT_EQ(FromArray.count(), 16u);
+
+    LaneMask128 None = LaneMask128::getNone();
+    EXPECT_TRUE(None.none());
+
+    LaneMask128 All = LaneMask128::getAll();
+    EXPECT_TRUE(All.all());
+    EXPECT_EQ(All.count(), LaneMask128::BitWidth);
+
+    LaneMask128 Lane5 = LaneMask128::getLane(5);
+    EXPECT_TRUE(Lane5.test(5));
+    EXPECT_EQ(Lane5.getNumLanes(), 1u);
+
+    LaneMask128 Lane100 = LaneMask128::getLane(100);
+    EXPECT_TRUE(Lane100.test(100));
+    EXPECT_FALSE(Lane100.test(99));
+    EXPECT_EQ(Lane100.getNumLanes(), 1u);
+
+    LaneMask128 Bit127 = LaneMask128::getLane(127);
+    EXPECT_TRUE(Bit127.test(127));
+    EXPECT_FALSE(Bit127.test(126));
+    EXPECT_EQ(Bit127.getHighestLane(), 127u);
+    EXPECT_TRUE(Bit127.rotateLeft(1).test(0));
+    EXPECT_TRUE((Bit127 << 1).none());
+
+    LaneMask128 Bit63 = LaneMask128::getLane(63);
+    EXPECT_TRUE(Bit63.test(63));
+    EXPECT_FALSE(Bit63.test(62));
+    EXPECT_FALSE(Bit63.test(64));
+    EXPECT_EQ(Bit63.getHighestLane(), 63u);
+
+    LaneMask128 Original = LaneMask128::getLane(100);
+    LaneMask128 Copied(Original);
+    EXPECT_EQ(Copied, Original);
+
+    LaneMask128 Assigned;
+    Assigned = Original;
+    EXPECT_EQ(Assigned, Original);
+  }
+
+  // Constexpr tests for 64-bit.
+  static_assert(LaneMask64::getNone().none(), "getNone() should be empty");
+  static_assert(LaneMask64::getAll().all(), "getAll() should be full");
+  static_assert(LaneMask64::getAll().count() == LaneMask64::BitWidth,
+                "getAll() should have all bits set");
+  static_assert(LaneMask64::getLane(5).test(5), "getLane() should set bit");
+  static_assert(LaneMask64::getLane(0).count() == 1, "getLane() sets one bit");
+  static_assert(LaneMask64::getLane(0).test(0), "Bit 0 is set");
+  static_assert((LaneMask64::getLane(0) >> 1).none(), "Shift clears bit 0");
+  static_assert(
+      LaneMask64::getLane(LaneMask64::BitWidth - 1).rotateLeft(1).test(0),
+      "Rotate highest bit wraps to 0");
+  static_assert((LaneMask64::getLane(LaneMask64::BitWidth - 1) << 1).none(),
+                "Shift clears highest bit");
+
+  // Constexpr tests for 128-bit.
+  static_assert(LaneMask128::getNone().none(), "getNone() should be empty");
+  static_assert(LaneMask128::getAll().all(), "getAll() should be full");
+  static_assert(LaneMask128::getAll().count() == LaneMask128::BitWidth,
+                "getAll() should have all bits set");
+  static_assert(LaneMask128::getLane(100).test(100),
+                "getLane(100) should set bit 100");
+  static_assert(LaneMask128::getLane(127).count() == 1,
+                "getLane() sets one bit");
+  static_assert(LaneMask128::getLane(127).test(127), "Bit 127 is set");
+  static_assert(!LaneMask128::getLane(63).test(64), "Bit 64 not set");
+  static_assert((LaneMask128::getLane(0) >> 1).none(), "Shift clears bit 0");
+  static_assert(
+      LaneMask128::getLane(LaneMask128::BitWidth - 1).rotateLeft(1).test(0),
+      "Rotate highest bit wraps to 0");
+  static_assert((LaneMask128::getLane(LaneMask128::BitWidth - 1) << 1).none(),
+                "Shift clears highest bit");
+  static_assert(
+      []() constexpr {
+        std::array<uint64_t, 1> Arr = {0xff};
+        LaneMask64 M(Arr);
+        return M.count() == 8;
+      }(),
+      "Constexpr array constructor");
+  static_assert(
+      []() constexpr {
+        std::array<uint64_t, 2> Arr = {0xff, 0xff00};
+        LaneMask128 M(Arr);
+        return M.count() == 16;
+      }(),
+      "Constexpr array constructor 128-bit");
+  static_assert(
+      []() constexpr {
+        LaneMask64 Original(0xff);
+        LaneMask64 Copied(Original);
+        return Copied == Original;
+      }(),
+      "Constexpr copy constructor");
+  static_assert(
+      []() constexpr {
+        LaneMask64 Original(0xff);
+        LaneMask64 Assigned;
+        Assigned = Original;
+        return Assigned == Original;
+      }(),
+      "Constexpr copy assignment");
+  static_assert(
+      []() constexpr {
+        LaneMask128 Original = LaneMask128::getLane(100);
+        LaneMask128 Copied(Original);
+        return Copied == Original;
+      }(),
+      "Constexpr copy constructor 128-bit");
+  static_assert(
+      []() constexpr {
+        LaneMask128 Original = LaneMask128::getLane(100);
+        LaneMask128 Assigned;
+        Assigned = Original;
+        return Assigned == Original;
+      }(),
+      "Constexpr copy assignment 128-bit");
+}
+
+TEST(LaneBitmaskTest, ComparisonOperators) {
+  // Test 64-bit version.
+  {
+    LaneMask64 A(0x1234);
+    LaneMask64 B(0x1234);
+    LaneMask64 C(0x5678);
+
+    EXPECT_TRUE(A == B);
+    EXPECT_FALSE(A == C);
+    EXPECT_FALSE(A != B);
+    EXPECT_TRUE(A != C);
+    EXPECT_TRUE(A < C);
+    EXPECT_FALSE(C < A);
+    EXPECT_FALSE(A < B);
+  }
+
+  // Test 128-bit version.
+  {
+    LaneMask128 A(0x1234);
+    LaneMask128 B(0x1234);
+    LaneMask128 C(0x5678);
+
+    EXPECT_TRUE(A == B);
+    EXPECT_FALSE(A == C);
+    EXPECT_FALSE(A != B);
+    EXPECT_TRUE(A != C);
+    EXPECT_TRUE(A < C);
+    EXPECT_FALSE(C < A);
+    EXPECT_FALSE(A < B);
+
+    // Test comparison across word boundaries.
+    LaneMask128 Low(0x1234);
+    LaneMask128 High = LaneMask128::getLane(100);
+    EXPECT_TRUE(Low < High);
+    EXPECT_FALSE(High < Low);
+  }
+
+  // Constexpr comparison operators for 64-bit.
+  static_assert(LaneMask64(0x1234) == LaneMask64(0x1234), "Equality");
+  static_assert(LaneMask64(0x1234) != LaneMask64(0x5678), "Inequality");
+  static_assert(LaneMask64(0x1000) < LaneMask64(0x2000), "Less than");
+
+  // Constexpr comparison operators for 128-bit.
+  static_assert(LaneMask128(0x1234) == LaneMask128(0x1234), "Equality");
+  static_assert(LaneMask128(0x1234) != LaneMask128(0x5678), "Inequality");
+  static_assert(LaneMask128::getLane(64) < LaneMask128::getLane(100),
+                "Cross-word less than");
+}
+
+TEST(LaneBitmaskTest, BitwiseOperators) {
+  // Test 64-bit version.
+  {
+    LaneMask64 A(0xff00);
+    LaneMask64 B(0x0ff0);
+
+    // Test OR.
+    EXPECT_EQ(A | B, LaneMask64(0xfff0));
+
+    // Test AND.
+    EXPECT_EQ(A & B, LaneMask64(0x0f00));
+
+    // Test XOR.
+    EXPECT_EQ(A ^ B, LaneMask64(0xf0f0));
+    EXPECT_EQ((LaneMask64(0xff) ^ LaneMask64(0xff)), LaneMask64::getNone());
+
+    // Test NOT.
+    LaneMask64 NotA = ~A;
+    EXPECT_EQ(NotA.count(), LaneMask64::BitWidth - A.count());
+
+    // Test OR assign.
+    LaneMask64 A2(0xff00);
+    A2 |= B;
+    EXPECT_EQ(A2, LaneMask64(0xfff0));
+
+    // Test AND assign.
+    LaneMask64 A3(0xff00);
+    A3 &= B;
+    EXPECT_EQ(A3, LaneMask64(0x0f00));
+
+    // Test XOR assign.
+    LaneMask64 A4(0xff00);
+    A4 ^= B;
+    EXPECT_EQ(A4, LaneMask64(0xf0f0));
+  }
+
+  // Test 128-bit version.
+  {
+    LaneMask128 A(0xff00);
+    LaneMask128 B(0x0ff0);
+
+    // Test OR.
+    EXPECT_EQ(A | B, LaneMask128(0xfff0));
+
+    // Test AND.
+    EXPECT_EQ(A & B, LaneMask128(0x0f00));
+
+    // Test XOR.
+    EXPECT_EQ(A ^ B, LaneMask128(0xf0f0));
+    EXPECT_EQ((LaneMask128(0xff) ^ LaneMask128(0xff)), LaneMask128::getNone());
+
+    // Test NOT.
+    LaneMask128 NotA = ~A;
+    EXPECT_EQ(NotA.count(), LaneMask128::BitWidth - A.count());
+
+    // Test operations across word boundaries.
+    LaneMask128 Low(0xff);
+    LaneMask128 High = LaneMask128::getLane(100);
+    LaneMask128 Combined = Low | High;
+    EXPECT_TRUE(Combined.test(0));
+    EXPECT_TRUE(Combined.test(100));
+    EXPECT_EQ(Combined.count(), 9u);
+
+    LaneMask128 AndResult = Combined & High;
+    EXPECT_FALSE(AndResult.test(0));
+    EXPECT_TRUE(AndResult.test(100));
+    EXPECT_EQ(AndResult.count(), 1u);
+
+    // Test XOR across word boundaries.
+    EXPECT_TRUE((Combined ^ High).test(0));
+    EXPECT_FALSE((Combined ^ High).test(100));
+    EXPECT_EQ((Combined ^ High).count(), 8u);
+
+    // Test XOR assign.
+    LaneMask128 A4(0xff00);
+    A4 ^= B;
+    EXPECT_EQ(A4, LaneMask128(0xf0f0));
+  }
+
+  // Constexpr bitwise operations for 64-bit.
+  static_assert((LaneMask64(0xff00) | LaneMask64(0x0ff0)) == LaneMask64(0xfff0),
+                "Constexpr OR");
+  static_assert((LaneMask64(0xff00) & LaneMask64(0x0ff0)) == LaneMask64(0x0f00),
+                "Constexpr AND");
+  static_assert((LaneMask64(0xff00) ^ LaneMask64(0x0ff0)) == LaneMask64(0xf0f0),
+                "Constexpr XOR");
+  static_assert((~LaneMask64(0xff)).any(), "Constexpr NOT");
+  static_assert((~LaneMask64::getAll()).none(), "Constexpr NOT of all");
+  static_assert(
+      []() constexpr {
+        LaneMask64 L(0xff00);
+        L |= LaneMask64(0x0ff0);
+        return L == LaneMask64(0xfff0);
+      }(),
+      "Constexpr OR assign");
+  static_assert(
+      []() constexpr {
+        LaneMask64 L(0xff00);
+        L &= LaneMask64(0x0ff0);
+        return L == LaneMask64(0x0f00);
+      }(),
+      "Constexpr AND assign");
+  static_assert(
+      []() constexpr {
+        LaneMask64 L(0xff00);
+        L ^= LaneMask64(0x0ff0);
+        return L == LaneMask64(0xf0f0);
+      }(),
+      "Constexpr XOR assign");
+
+  // Constexpr bitwise operations for 128-bit.
+  static_assert((LaneMask128(0xff00) | LaneMask128(0x0ff0)) ==
+                    LaneMask128(0xfff0),
+                "Constexpr OR");
+  static_assert((LaneMask128(0xff00) ^ LaneMask128(0x0ff0)) ==
+                    LaneMask128(0xf0f0),
+                "Constexpr XOR");
+  static_assert(
+      (LaneMask128::getLane(64) | LaneMask128::getLane(100)).count() == 2,
+      "Constexpr OR across words");
+  static_assert((LaneMask128::getLane(64) ^ LaneMask128::getLane(64)).none(),
+                "Constexpr XOR with self is empty");
+  static_assert(
+      []() constexpr {
+        LaneMask128 L(0xff00);
+        L |= LaneMask128::getLane(100);
+        return L.count() == 9;
+      }(),
+      "Constexpr OR assign 128-bit");
+  static_assert(
+      []() constexpr {
+        LaneMask128 L(0xff00);
+        L &= LaneMask128(0x0ff0);
+        return L == LaneMask128(0x0f00);
+      }(),
+      "Constexpr AND assign 128-bit");
+  static_assert(
+      []() constexpr {
+        LaneMask128 L(0xff00);
+        L ^= LaneMask128(0x0ff0);
+        return L == LaneMask128(0xf0f0);
+      }(),
+      "Constexpr XOR assign 128-bit");
+}
+
+TEST(LaneBitmaskTest, QueryMethods) {
+  // Test 64-bit version.
+  {
+    LaneMask64 Empty;
+    EXPECT_TRUE(Empty.none());
+    EXPECT_FALSE(Empty.any());
+    EXPECT_FALSE(Empty.all());
+    EXPECT_EQ(Empty.count(), 0u);
+    EXPECT_EQ(Empty.getNumLanes(), 0u);
+
+    LaneMask64 Partial(0x00ff);
+    EXPECT_FALSE(Partial.none());
+    EXPECT_TRUE(Partial.any());
+    EXPECT_FALSE(Partial.all());
+    EXPECT_EQ(Partial.count(), 8u);
+    EXPECT_EQ(Partial.getNumLanes(), 8u);
+
+    LaneMask64 Full = LaneMask64::getAll();
+    EXPECT_FALSE(Full.none());
+    EXPECT_TRUE(Full.any());
+    EXPECT_TRUE(Full.all());
+    EXPECT_EQ(Full.count(), LaneMask64::BitWidth);
+    EXPECT_EQ(Full.getNumLanes(), LaneMask64::BitWidth);
+    EXPECT_EQ(Full.size(), LaneMask64::BitWidth);
+  }
+
+  // Test 128-bit version.
+  {
+    LaneMask128 Empty;
+    EXPECT_TRUE(Empty.none());
+    EXPECT_FALSE(Empty.any());
+    EXPECT_FALSE(Empty.all());
+    EXPECT_EQ(Empty.count(), 0u);
+    EXPECT_EQ(Empty.getNumLanes(), 0u);
+
+    LaneMask128 Partial(0x00ff);
+    EXPECT_FALSE(Partial.none());
+    EXPECT_TRUE(Partial.any());
+    EXPECT_FALSE(Partial.all());
+    EXPECT_EQ(Partial.count(), 8u);
+    EXPECT_EQ(Partial.getNumLanes(), 8u);
+
+    LaneMask128 Full = LaneMask128::getAll();
+    EXPECT_FALSE(Full.none());
+    EXPECT_TRUE(Full.any());
+    EXPECT_TRUE(Full.all());
+    EXPECT_EQ(Full.count(), LaneMask128::BitWidth);
+    EXPECT_EQ(Full.getNumLanes(), LaneMask128::BitWidth);
+
+    LaneMask128 UpperBit = LaneMask128::getLane(127);
+    EXPECT_FALSE(UpperBit.none());
+    EXPECT_TRUE(UpperBit.any());
+    EXPECT_FALSE(UpperBit.all());
+  }
+
+  // Constexpr query methods for 64-bit.
+  static_assert(LaneMask64().none(), "Empty mask");
+  static_assert(!LaneMask64(0x1).none(), "Non-empty mask");
+  static_assert(LaneMask64(0x1).any(), "Any bit set");
+  static_assert(!LaneMask64().any(), "No bits set");
+  static_assert(LaneMask64::getAll().all(), "All bits set");
+  static_assert(!LaneMask64(0xff).all(), "Not all bits set");
+  static_assert(LaneMask64().count() == 0, "Count zero");
+  static_assert(LaneMask64(0x7).count() == 3, "Count three");
+  static_assert(LaneMask64(0x7).getNumLanes() == 3, "Num lanes three");
+  static_assert(LaneMask64().size() == LaneMask64::BitWidth, "Size");
+  static_assert(LaneMask64::getAll().getNumLanes() == LaneMask64::BitWidth,
+                "Full mask num lanes");
+
+  // Constexpr query methods for 128-bit.
+  static_assert(LaneMask128().none(), "Empty mask");
+  static_assert(LaneMask128::getLane(127).any(), "High bit set");
+  static_assert(LaneMask128::getAll().all(), "All bits set");
+  static_assert(LaneMask128().size() == LaneMask128::BitWidth, "Size");
+  static_assert(LaneMask128::getAll().getNumLanes() == 128, "128 lanes");
+}
+
+TEST(LaneBitmaskTest, GetHighestLane) {
+  // Test 64-bit version.
+  EXPECT_EQ(LaneMask64(1).getHighestLane(), 0u);
+  EXPECT_EQ(LaneMask64(1ull << 5).getHighestLane(), 5u);
+  EXPECT_EQ(LaneMask64(1ull << 63).getHighestLane(), 63u);
+  EXPECT_EQ(LaneMask64((1ull << 10) | (1ull << 30)).getHighestLane(), 30u);
+
+  // Test 128-bit version.
+  EXPECT_EQ(LaneMask128(1).getHighestLane(), 0u);
+  EXPECT_EQ(LaneMask128(1ull << 5).getHighestLane(), 5u);
+  EXPECT_EQ(LaneMask128::getLane(100).getHighestLane(), 100u);
+  EXPECT_EQ(LaneMask128::getLane(127).getHighestLane(), 127u);
+  EXPECT_EQ(
+      (LaneMask128::getLane(10) | LaneMask128::getLane(100)).getHighestLane(),
+      100u);
+}
+
+TEST(LaneBitmaskTest, ShiftAssignOperators) {
+  // Test 64-bit version.
+  {
+    LaneMask64 A1(0xff);
+    A1 <<= 8;
+    EXPECT_EQ(A1, LaneMask64(0xff00));
+
+    LaneMask64 A2(0xff00);
+    A2 >>= 8;
+    EXPECT_EQ(A2, LaneMask64(0xff));
+
+    LaneMask64 A3(0x1);
+    A3 <<= 4;
+    A3 <<= 4;
+    EXPECT_EQ(A3, LaneMask64(0x100));
+  }
+
+  // Test 128-bit version with cross-word shifts.
+  {
+    LaneMask128 A1(0xff);
+    A1 <<= 8;
+    EXPECT_EQ(A1, LaneMask128(0xff00));
+
+    LaneMask128 A2(0xff);
+    A2 <<= 64;
+    EXPECT_FALSE(A2.test(0));
+    EXPECT_TRUE(A2.test(64));
+
+    LaneMask128 A3 = LaneMask128::getLane(100);
+    A3 >>= 50;
+    EXPECT_TRUE(A3.test(50));
+    EXPECT_FALSE(A3.test(100));
+  }
+
+  static_assert(
+      []() constexpr {
+        LaneMask64 L(0xff);
+        L <<= 8;
+        return L == LaneMask64(0xff00);
+      }(),
+      "Constexpr shift left assign");
+
+  static_assert(
+      []() constexpr {
+        LaneMask64 L(0xff00);
+        L >>= 8;
+        return L == LaneMask64(0xff);
+      }(),
+      "Constexpr shift right assign");
+
+  static_assert(
+      []() constexpr {
+        LaneMask128 L(0xff);
+        L <<= 64;
+        return !L.test(0) && L.test(64);
+      }(),
+      "Constexpr shift left assign 128-bit");
+
+  static_assert(
+      []() constexpr {
+        LaneMask128 L = LaneMask128::getLane(100);
+        L >>= 50;
+        return L.test(50) && !L.test(100);
+      }(),
+      "Constexpr shift right assign 128-bit");
+}
+
+TEST(LaneBitmaskTest, ShiftOperators) {
+  // Test 64-bit version.
+  {
+    LaneMask64 A(0xff);
+
+    EXPECT_EQ(A << 0, A);
+    EXPECT_EQ(A << 8, LaneMask64(0xff00));
+    EXPECT_TRUE((A << LaneMask64::BitWidth).none());
+    EXPECT_TRUE((A << (LaneMask64::BitWidth + 10)).none());
+
+    LaneMask64 B(0xff00);
+    EXPECT_EQ(B >> 0, B);
+    EXPECT_EQ(B >> 8, LaneMask64(0xff));
+    EXPECT_TRUE((B >> LaneMask64::BitWidth).none());
+
+    LaneMask64 Bit0 = LaneMask64::getLane(0);
+    LaneMask64 ShiftedLeft = Bit0 << (LaneMask64::BitWidth - 1);
+    EXPECT_FALSE(ShiftedLeft.none());
+    EXPECT_TRUE(ShiftedLeft.test(LaneMask64::BitWidth - 1));
+    EXPECT_TRUE((ShiftedLeft << 1).none());
+  }
+
+  // Test 128-bit version with cross-word shifts.
+  {
+    LaneMask128 A(0xff);
+
+    // Shift left within word.
+    EXPECT_EQ(A << 8, LaneMask128(0xff00));
+
+    // Shift left across word boundary.
+    LaneMask128 B = A << 60;
+    EXPECT_TRUE(B.test(60));
+    EXPECT_TRUE(B.test(67));
+
+    // Shift left completely into upper word.
+    LaneMask128 C = A << 64;
+    EXPECT_FALSE(C.test(0));
+    EXPECT_TRUE(C.test(64));
+    EXPECT_TRUE(C.test(71));
+
+    // Shift right across word boundary.
+    LaneMask128 D = LaneMask128::getLane(100);
+    LaneMask128 E = D >> 50;
+    EXPECT_TRUE(E.test(50));
+    EXPECT_FALSE(E.test(100));
+
+    // Shift by full width.
+    EXPECT_TRUE((A << LaneMask128::BitWidth).none());
+    EXPECT_TRUE((A >> LaneMask128::BitWidth).none());
+  }
+
+  // Constexpr shift operations for 64-bit.
+  static_assert((LaneMask64(0xff) << 8) == LaneMask64(0xff00),
+                "Constexpr shift left");
+  static_assert((LaneMask64(0xff00) >> 8) == LaneMask64(0xff),
+                "Constexpr shift right");
+  static_assert((LaneMask64(0xff) << LaneMask64::BitWidth).none(),
+                "Shift left by BitWidth");
+  static_assert((LaneMask64(0xff) << (LaneMask64::BitWidth + 10)).none(),
+                "Shift left beyond BitWidth");
+  static_assert(
+      []() constexpr {
+        LaneMask64 Bit0 = LaneMask64::getLane(0);
+        LaneMask64 Shifted = Bit0 << (LaneMask64::BitWidth - 1);
+        return !Shifted.none() && Shifted.test(LaneMask64::BitWidth - 1) &&
+               (Shifted << 1).none();
+      }(),
+      "Shift by BitWidth-1 then by 1");
+
+  // Constexpr shift operations for 128-bit.
+  static_assert((LaneMask128(0xff) << 8) == LaneMask128(0xff00),
+                "Constexpr shift left");
+  static_assert((LaneMask128::getLane(64) >> 64).test(0),
+                "Shift across word boundary");
+}
+
+TEST(LaneBitmaskTest, RotateOperators) {
+  // Test 64-bit version.
+  {
+    LaneMask64 A(0xff);
+
+    EXPECT_EQ(A.rotateLeft(0), A);
+    EXPECT_EQ(A.rotateLeft(8), LaneMask64(0xff00));
+    EXPECT_EQ(A.rotateLeft(LaneMask64::BitWidth), A);
+    EXPECT_EQ(A.rotateLeft(LaneMask64::BitWidth * 2), A);
+    EXPECT_EQ(A.rotateLeft(LaneMask64::BitWidth + 8), A.rotateLeft(8));
+
+    LaneMask64 B(0xff00);
+    EXPECT_EQ(B.rotateRight(0), B);
+    EXPECT_EQ(B.rotateRight(8), LaneMask64(0xff));
+    EXPECT_EQ(B.rotateRight(LaneMask64::BitWidth), B);
+    EXPECT_EQ(B.rotateRight(LaneMask64::BitWidth * 3), B);
+    EXPECT_EQ(B.rotateRight(LaneMask64::BitWidth + 8), B.rotateRight(8));
+
+    LaneMask64 C(0x123456789abcdef0);
+    EXPECT_EQ(C.rotateLeft(37).rotateRight(37), C);
+
+    LaneMask64 HighBit = LaneMask64::getLane(LaneMask64::BitWidth - 1);
+    EXPECT_TRUE((HighBit << 1).none());
+    EXPECT_TRUE(HighBit.rotateLeft(1).test(0));
+  }
+
+  // Test 128-bit version with cross-word rotations.
+  {
+    LaneMask128 A(0xff);
+
+    // Rotate left within and across words.
+    EXPECT_EQ(A.rotateLeft(0), A);
+    EXPECT_EQ(A.rotateLeft(8), LaneMask128(0xff00));
+    EXPECT_EQ(A.rotateLeft(LaneMask128::BitWidth), A);
+
+    // Rotate across word boundary.
+    LaneMask128 B = A.rotateLeft(60);
+    EXPECT_TRUE(B.test(60));
+    EXPECT_TRUE(B.test(67));
+
+    // Rotate highest bit wraps to bit 0.
+    LaneMask128 HighBit = LaneMask128::getLane(127);
+    EXPECT_TRUE(HighBit.rotateLeft(1).test(0));
+    EXPECT_FALSE(HighBit.rotateLeft(1).test(127));
+
+    // Rotate from upper word to lower word.
+    LaneMask128 UpperBit = LaneMask128::getLane(100);
+    LaneMask128 Rotated = UpperBit.rotateRight(50);
+    EXPECT_TRUE(Rotated.test(50));
+    EXPECT_FALSE(Rotated.test(100));
+
+    // Verify rotate vs shift difference for 128-bit.
+    EXPECT_TRUE((HighBit << 1).none());
+    EXPECT_TRUE(HighBit.rotateLeft(1).test(0));
+  }
+
+  // Constexpr rotate operations for 64-bit.
+  static_assert(LaneMask64(0xff).rotateLeft(8) == LaneMask64(0xff00),
+                "Constexpr rotate left");
+  static_assert(LaneMask64(0xff00).rotateRight(8) == LaneMask64(0xff),
+                "Constexpr rotate right");
+  static_assert(LaneMask64(0xff).rotateLeft(LaneMask64::BitWidth) ==
+                    LaneMask64(0xff),
+                "Rotate by BitWidth is identity");
+  static_assert(LaneMask64(0xff).rotateLeft(LaneMask64::BitWidth * 2) ==
+                    LaneMask64(0xff),
+                "Rotate by multiple of BitWidth");
+  static_assert(LaneMask64(0xff).rotateLeft(LaneMask64::BitWidth + 8) ==
+                    LaneMask64(0xff).rotateLeft(8),
+                "Rotate by BitWidth + N");
+  static_assert(LaneMask64(0x1234).rotateLeft(37).rotateRight(37) ==
+                    LaneMask64(0x1234),
+                "Rotate roundtrip");
+  static_assert(
+      LaneMask64::getLane(LaneMask64::BitWidth - 1).rotateLeft(1).test(0),
+      "Rotate wraps around");
+
+  // Constexpr rotate operations for 128-bit.
+  static_assert(LaneMask128(0xff).rotateLeft(8) == LaneMask128(0xff00),
+                "Constexpr rotate left");
+  static_assert(LaneMask128::getLane(127).rotateLeft(1).test(0),
+                "Rotate highest bit wraps to 0");
+  static_assert(LaneMask128(0xff).rotateLeft(LaneMask128::BitWidth) ==
+                    LaneMask128(0xff),
+                "Rotate by 128 is identity");
+}
+
+TEST(LaneBitmaskTest, InheritedBitsetOperations) {
+  // Test 64-bit version.
+  {
+    LaneMask64 M;
+
+    M.set(5);
+    EXPECT_TRUE(M.test(5));
+    EXPECT_TRUE(M[5]);
+    EXPECT_EQ(M.count(), 1u);
+
+    M.set(10);
+    EXPECT_EQ(M.count(), 2u);
+
+    M.reset(5);
+    EXPECT_FALSE(M.test(5));
+    EXPECT_FALSE(M[5]);
+    EXPECT_EQ(M.count(), 1u);
+
+    M.flip(5);
+    EXPECT_TRUE(M.test(5));
+    EXPECT_TRUE(M[5]);
+
+    M.set();
+    EXPECT_TRUE(M.all());
+    EXPECT_EQ(M.getNumLanes(), LaneMask64::BitWidth);
+  }
+
+  // Test 128-bit version.
+  {
+    LaneMask128 M;
+
+    M.set(100);
+    EXPECT_TRUE(M.test(100));
+    EXPECT_TRUE(M[100]);
+    EXPECT_EQ(M.count(), 1u);
+
+    M.set(10);
+    EXPECT_EQ(M.count(), 2u);
+
+    M.reset(100);
+    EXPECT_FALSE(M.test(100));
+    EXPECT_FALSE(M[100]);
+
+    M.flip(127);
+    EXPECT_TRUE(M.test(127));
+    EXPECT_TRUE(M[127]);
+
+    M.set();
+    EXPECT_TRUE(M.all());
+    EXPECT_EQ(M.getNumLanes(), LaneMask128::BitWidth);
+  }
+
+  // Constexpr set/reset/flip/test/operator[] operations for 64-bit.
+  constexpr auto TestSet64 = []() constexpr {
+    LaneMask64 L;
+    L.set(5);
+    return L.test(5) && L[5] && L.count() == 1;
+  };
+  static_assert(TestSet64(), "Constexpr set and test");
+
+  constexpr auto TestReset64 = []() constexpr {
+    LaneMask64 L;
+    L.set(5);
+    L.reset(5);
+    return !L.test(5) && !L[5] && L.none();
+  };
+  static_assert(TestReset64(), "Constexpr reset");
+
+  constexpr auto TestFlip64 = []() constexpr {
+    LaneMask64 L;
+    L.flip(5);
+    return L.test(5) && L[5] && L.count() == 1;
+  };
+  static_assert(TestFlip64(), "Constexpr flip");
+
+  constexpr auto TestSetAll64 = []() constexpr {
+    LaneMask64 L;
+    L.set();
+    return L.all() && L.count() == LaneMask64::BitWidth;
+  };
+  static_assert(TestSetAll64(), "Constexpr set all");
+
+  // Constexpr operations for 128-bit.
+  constexpr auto TestSet128 = []() constexpr {
+    LaneMask128 L;
+    L.set(100);
+    return L.test(100) && L[100] && L.count() == 1;
+  };
+  static_assert(TestSet128(), "Constexpr set bit 100");
+
+  constexpr auto TestReset128 = []() constexpr {
+    LaneMask128 L;
+    L.set(100);
+    L.reset(100);
+    return !L.test(100) && L.none();
+  };
+  static_assert(TestReset128(), "Constexpr reset bit 100");
+
+  constexpr auto TestFlip128 = []() constexpr {
+    LaneMask128 L;
+    L.flip(100);
+    return L.test(100) && L.count() == 1;
+  };
+  static_assert(TestFlip128(), "Constexpr flip bit 100");
+
+  constexpr auto TestSetAll128 = []() constexpr {
+    LaneMask128 L;
+    L.set();
+    return L.all() && L.count() == LaneMask128::BitWidth;
+  };
+  static_assert(TestSetAll128(), "Constexpr set all 128-bit");
+}
+
+TEST(LaneBitmaskTest, APIntConstructor) {
+  APInt Empty(64, 0);
+  LaneMask64 MEmpty(Empty);
+  EXPECT_TRUE(MEmpty.none());
+
+  APInt Full(64, ~0ull);
+  LaneMask64 MFull(Full);
+  EXPECT_EQ(MFull.getNumLanes(), 64u);
+  EXPECT_TRUE(MFull.all());
+
+  APInt A64(64, 0x123456789abcdef0, false);
+  LaneMask64 M64(A64);
+  EXPECT_TRUE(M64.test(4));
+  EXPECT_EQ(M64.getHighestLane(), 60u);
+
+  APInt Small(16, 0xff);
+  LaneMask64 MSmall(Small);
+  EXPECT_EQ(MSmall.getNumLanes(), 8u);
+  EXPECT_TRUE(MSmall.test(0));
+  EXPECT_TRUE(MSmall.test(7));
+  EXPECT_FALSE(MSmall.test(8));
+
+  APInt A128(128, {0xff, 0xff00});
+  LaneMask128 M128(A128);
+  EXPECT_TRUE(M128.test(0));
+  EXPECT_TRUE(M128.test(7));
+  EXPECT_TRUE(M128.test(64 + 8));
+  EXPECT_FALSE(M128.test(64 + 16));
+}
+
+TEST(LaneBitmaskTest, Printing) {
+  std::string Str;
+  raw_string_ostream OS(Str);
+
+  LaneBitmask M(0xABCD);
+  OS << PrintLaneMask(M);
+  OS.flush();
+
+  EXPECT_TRUE(Str.find("ABCD") != std::string::npos);
+}
+
+TEST(LaneBitmaskTest, Hashing) {
+  // Test 64-bit version.
+  {
+    LaneMask64 A(0x1234);
+    LaneMask64 B(0x1234);
+    LaneMask64 C(0x5678);
+
+    EXPECT_EQ(std::hash<LaneMask64>{}(A), std::hash<LaneMask64>{}(B));
+    EXPECT_NE(std::hash<LaneMask64>{}(A), std::hash<LaneMask64>{}(C));
+  }
+
+  // Test 128-bit version.
+  {
+    LaneMask128 A = LaneMask128::getLane(100);
+    LaneMask128 B = LaneMask128::getLane(100);
+    LaneMask128 C = LaneMask128::getLane(50);
+
+    EXPECT_EQ(std::hash<LaneMask128>{}(A), std::hash<LaneMask128>{}(B));
+    EXPECT_NE(std::hash<LaneMask128>{}(A), std::hash<LaneMask128>{}(C));
+  }
+}
+
+TEST(LaneBitmaskTest, MultiWordOperations) {
+  // Test comprehensive operations on 128-bit LaneMask64 across word boundaries.
+  LaneMask128 M;
+  M.set(0);
+  M.set(64);
+  M.set(127);
+
+  EXPECT_EQ(M.getNumLanes(), 3u);
+  EXPECT_EQ(M.getHighestLane(), 127u);
+  EXPECT_TRUE(M.test(0));
+  EXPECT_TRUE(M.test(64));
+  EXPECT_TRUE(M.test(127));
+  EXPECT_FALSE(M.test(63));
+
+  // Test bitwise operations across word boundaries.
+  LaneMask128 N;
+  N.set(64);
+  N.set(100);
+
+  LaneMask128 Or = M | N;
+  EXPECT_EQ(Or.getNumLanes(), 4u);
+
+  LaneMask128 And = M & N;
+  EXPECT_EQ(And.getNumLanes(), 1u);
+  EXPECT_TRUE(And.test(64));
+
+  // Test NOT across multiple words.
+  LaneMask128 NotM = ~M;
+  EXPECT_FALSE(NotM.test(0));
+  EXPECT_FALSE(NotM.test(64));
+  EXPECT_FALSE(NotM.test(127));
+  EXPECT_TRUE(NotM.test(63));
+  EXPECT_TRUE(NotM.test(65));
+  EXPECT_EQ(NotM.getNumLanes(), LaneMask128::BitWidth - 3);
+}
+
+} // namespace

--- a/llvm/unittests/CodeGen/LaneBitmaskTest.cpp
+++ b/llvm/unittests/CodeGen/LaneBitmaskTest.cpp
@@ -30,33 +30,17 @@ TEST(LaneBitmaskTest, ConstructorAndAssignment) {
 
     std::array<uint64_t, 1> Arr64 = {0x123456789abcdef0};
     LaneMask64 FromArray(Arr64);
-    EXPECT_TRUE(FromArray.test(4));
-    EXPECT_EQ(FromArray.count(), 32u);
+    EXPECT_EQ(FromArray.getNumLanes(), 32u);
 
     LaneMask64 None = LaneMask64::getNone();
     EXPECT_TRUE(None.none());
 
     LaneMask64 All = LaneMask64::getAll();
     EXPECT_TRUE(All.all());
-    EXPECT_EQ(All.count(), LaneMask64::BitWidth);
+    EXPECT_EQ(All.getNumLanes(), LaneMask64::BitWidth);
 
     LaneMask64 Lane5 = LaneMask64::getLane(5);
-    EXPECT_TRUE(Lane5.test(5));
     EXPECT_EQ(Lane5.getNumLanes(), 1u);
-
-    LaneMask64 Bit0 = LaneMask64::getLane(0);
-    EXPECT_TRUE(Bit0.test(0));
-    EXPECT_FALSE(Bit0.test(1));
-    EXPECT_EQ(Bit0.getHighestLane(), 0u);
-    EXPECT_TRUE((Bit0 >> 1).none());
-    EXPECT_TRUE(Bit0.rotateLeft(1).test(1));
-
-    LaneMask64 BitMax = LaneMask64::getLane(LaneMask64::BitWidth - 1);
-    EXPECT_TRUE(BitMax.test(LaneMask64::BitWidth - 1));
-    EXPECT_FALSE(BitMax.test(LaneMask64::BitWidth - 2));
-    EXPECT_EQ(BitMax.getHighestLane(), LaneMask64::BitWidth - 1);
-    EXPECT_TRUE(BitMax.rotateLeft(1).test(0));
-    EXPECT_TRUE((BitMax << 1).none());
 
     LaneMask64 Original(0xabcd);
     LaneMask64 Copied(Original);
@@ -79,39 +63,18 @@ TEST(LaneBitmaskTest, ConstructorAndAssignment) {
 
     std::array<uint64_t, 2> Arr128 = {0xff, 0xff00};
     LaneMask128 FromArray(Arr128);
-    EXPECT_TRUE(FromArray.test(0));
-    EXPECT_TRUE(FromArray.test(7));
-    EXPECT_TRUE(FromArray.test(64 + 8));
-    EXPECT_EQ(FromArray.count(), 16u);
+    EXPECT_EQ(FromArray.getNumLanes(), 16u);
 
     LaneMask128 None = LaneMask128::getNone();
     EXPECT_TRUE(None.none());
 
     LaneMask128 All = LaneMask128::getAll();
     EXPECT_TRUE(All.all());
-    EXPECT_EQ(All.count(), LaneMask128::BitWidth);
-
-    LaneMask128 Lane5 = LaneMask128::getLane(5);
-    EXPECT_TRUE(Lane5.test(5));
-    EXPECT_EQ(Lane5.getNumLanes(), 1u);
+    EXPECT_EQ(All.getNumLanes(), LaneMask128::BitWidth);
 
     LaneMask128 Lane100 = LaneMask128::getLane(100);
-    EXPECT_TRUE(Lane100.test(100));
-    EXPECT_FALSE(Lane100.test(99));
     EXPECT_EQ(Lane100.getNumLanes(), 1u);
-
-    LaneMask128 Bit127 = LaneMask128::getLane(127);
-    EXPECT_TRUE(Bit127.test(127));
-    EXPECT_FALSE(Bit127.test(126));
-    EXPECT_EQ(Bit127.getHighestLane(), 127u);
-    EXPECT_TRUE(Bit127.rotateLeft(1).test(0));
-    EXPECT_TRUE((Bit127 << 1).none());
-
-    LaneMask128 Bit63 = LaneMask128::getLane(63);
-    EXPECT_TRUE(Bit63.test(63));
-    EXPECT_FALSE(Bit63.test(62));
-    EXPECT_FALSE(Bit63.test(64));
-    EXPECT_EQ(Bit63.getHighestLane(), 63u);
+    EXPECT_EQ(Lane100.getHighestLane(), 100u);
 
     LaneMask128 Original = LaneMask128::getLane(100);
     LaneMask128 Copied(Original);
@@ -122,52 +85,20 @@ TEST(LaneBitmaskTest, ConstructorAndAssignment) {
     EXPECT_EQ(Assigned, Original);
   }
 
-  // Constexpr tests for 64-bit.
-  static_assert(LaneMask64::getNone().none(), "getNone() should be empty");
-  static_assert(LaneMask64::getAll().all(), "getAll() should be full");
-  static_assert(LaneMask64::getAll().count() == LaneMask64::BitWidth,
-                "getAll() should have all bits set");
-  static_assert(LaneMask64::getLane(5).test(5), "getLane() should set bit");
-  static_assert(LaneMask64::getLane(0).count() == 1, "getLane() sets one bit");
-  static_assert(LaneMask64::getLane(0).test(0), "Bit 0 is set");
-  static_assert((LaneMask64::getLane(0) >> 1).none(), "Shift clears bit 0");
-  static_assert(
-      LaneMask64::getLane(LaneMask64::BitWidth - 1).rotateLeft(1).test(0),
-      "Rotate highest bit wraps to 0");
-  static_assert((LaneMask64::getLane(LaneMask64::BitWidth - 1) << 1).none(),
-                "Shift clears highest bit");
-
-  // Constexpr tests for 128-bit.
-  static_assert(LaneMask128::getNone().none(), "getNone() should be empty");
-  static_assert(LaneMask128::getAll().all(), "getAll() should be full");
-  static_assert(LaneMask128::getAll().count() == LaneMask128::BitWidth,
-                "getAll() should have all bits set");
-  static_assert(LaneMask128::getLane(100).test(100),
-                "getLane(100) should set bit 100");
-  static_assert(LaneMask128::getLane(127).count() == 1,
-                "getLane() sets one bit");
-  static_assert(LaneMask128::getLane(127).test(127), "Bit 127 is set");
-  static_assert(!LaneMask128::getLane(63).test(64), "Bit 64 not set");
-  static_assert((LaneMask128::getLane(0) >> 1).none(), "Shift clears bit 0");
-  static_assert(
-      LaneMask128::getLane(LaneMask128::BitWidth - 1).rotateLeft(1).test(0),
-      "Rotate highest bit wraps to 0");
-  static_assert((LaneMask128::getLane(LaneMask128::BitWidth - 1) << 1).none(),
-                "Shift clears highest bit");
+  // Constexpr tests.
+  static_assert(LaneMask64::getNone().none());
+  static_assert(LaneMask64::getAll().all());
+  static_assert(LaneMask64::getAll().getNumLanes() == LaneMask64::BitWidth);
+  static_assert(LaneMask128::getNone().none());
+  static_assert(LaneMask128::getAll().all());
+  static_assert(LaneMask128::getAll().getNumLanes() == LaneMask128::BitWidth);
   static_assert(
       []() constexpr {
         std::array<uint64_t, 1> Arr = {0xff};
         LaneMask64 M(Arr);
-        return M.count() == 8;
+        return M.getNumLanes() == 8;
       }(),
       "Constexpr array constructor");
-  static_assert(
-      []() constexpr {
-        std::array<uint64_t, 2> Arr = {0xff, 0xff00};
-        LaneMask128 M(Arr);
-        return M.count() == 16;
-      }(),
-      "Constexpr array constructor 128-bit");
   static_assert(
       []() constexpr {
         LaneMask64 Original(0xff);
@@ -183,21 +114,6 @@ TEST(LaneBitmaskTest, ConstructorAndAssignment) {
         return Assigned == Original;
       }(),
       "Constexpr copy assignment");
-  static_assert(
-      []() constexpr {
-        LaneMask128 Original = LaneMask128::getLane(100);
-        LaneMask128 Copied(Original);
-        return Copied == Original;
-      }(),
-      "Constexpr copy constructor 128-bit");
-  static_assert(
-      []() constexpr {
-        LaneMask128 Original = LaneMask128::getLane(100);
-        LaneMask128 Assigned;
-        Assigned = Original;
-        return Assigned == Original;
-      }(),
-      "Constexpr copy assignment 128-bit");
 }
 
 TEST(LaneBitmaskTest, ComparisonOperators) {
@@ -218,35 +134,16 @@ TEST(LaneBitmaskTest, ComparisonOperators) {
 
   // Test 128-bit version.
   {
-    LaneMask128 A(0x1234);
-    LaneMask128 B(0x1234);
-    LaneMask128 C(0x5678);
-
-    EXPECT_TRUE(A == B);
-    EXPECT_FALSE(A == C);
-    EXPECT_FALSE(A != B);
-    EXPECT_TRUE(A != C);
-    EXPECT_TRUE(A < C);
-    EXPECT_FALSE(C < A);
-    EXPECT_FALSE(A < B);
-
-    // Test comparison across word boundaries.
     LaneMask128 Low(0x1234);
     LaneMask128 High = LaneMask128::getLane(100);
     EXPECT_TRUE(Low < High);
     EXPECT_FALSE(High < Low);
   }
 
-  // Constexpr comparison operators for 64-bit.
-  static_assert(LaneMask64(0x1234) == LaneMask64(0x1234), "Equality");
-  static_assert(LaneMask64(0x1234) != LaneMask64(0x5678), "Inequality");
-  static_assert(LaneMask64(0x1000) < LaneMask64(0x2000), "Less than");
-
-  // Constexpr comparison operators for 128-bit.
-  static_assert(LaneMask128(0x1234) == LaneMask128(0x1234), "Equality");
-  static_assert(LaneMask128(0x1234) != LaneMask128(0x5678), "Inequality");
-  static_assert(LaneMask128::getLane(64) < LaneMask128::getLane(100),
-                "Cross-word less than");
+  static_assert(LaneMask64(0x1234) == LaneMask64(0x1234));
+  static_assert(LaneMask64(0x1234) != LaneMask64(0x5678));
+  static_assert(LaneMask64(0x1000) < LaneMask64(0x2000));
+  static_assert(LaneMask128::getLane(64) < LaneMask128::getLane(100));
 }
 
 TEST(LaneBitmaskTest, BitwiseOperators) {
@@ -255,88 +152,39 @@ TEST(LaneBitmaskTest, BitwiseOperators) {
     LaneMask64 A(0xff00);
     LaneMask64 B(0x0ff0);
 
-    // Test OR.
     EXPECT_EQ(A | B, LaneMask64(0xfff0));
-
-    // Test AND.
     EXPECT_EQ(A & B, LaneMask64(0x0f00));
 
-    // Test XOR.
-    EXPECT_EQ(A ^ B, LaneMask64(0xf0f0));
-    EXPECT_EQ((LaneMask64(0xff) ^ LaneMask64(0xff)), LaneMask64::getNone());
-
-    // Test NOT.
     LaneMask64 NotA = ~A;
-    EXPECT_EQ(NotA.count(), LaneMask64::BitWidth - A.count());
+    EXPECT_EQ(NotA.getNumLanes(), LaneMask64::BitWidth - A.getNumLanes());
 
-    // Test OR assign.
     LaneMask64 A2(0xff00);
     A2 |= B;
     EXPECT_EQ(A2, LaneMask64(0xfff0));
 
-    // Test AND assign.
     LaneMask64 A3(0xff00);
     A3 &= B;
     EXPECT_EQ(A3, LaneMask64(0x0f00));
-
-    // Test XOR assign.
-    LaneMask64 A4(0xff00);
-    A4 ^= B;
-    EXPECT_EQ(A4, LaneMask64(0xf0f0));
   }
 
-  // Test 128-bit version.
+  // Test 128-bit version across word boundaries.
   {
-    LaneMask128 A(0xff00);
-    LaneMask128 B(0x0ff0);
-
-    // Test OR.
-    EXPECT_EQ(A | B, LaneMask128(0xfff0));
-
-    // Test AND.
-    EXPECT_EQ(A & B, LaneMask128(0x0f00));
-
-    // Test XOR.
-    EXPECT_EQ(A ^ B, LaneMask128(0xf0f0));
-    EXPECT_EQ((LaneMask128(0xff) ^ LaneMask128(0xff)), LaneMask128::getNone());
-
-    // Test NOT.
-    LaneMask128 NotA = ~A;
-    EXPECT_EQ(NotA.count(), LaneMask128::BitWidth - A.count());
-
-    // Test operations across word boundaries.
     LaneMask128 Low(0xff);
     LaneMask128 High = LaneMask128::getLane(100);
     LaneMask128 Combined = Low | High;
-    EXPECT_TRUE(Combined.test(0));
-    EXPECT_TRUE(Combined.test(100));
-    EXPECT_EQ(Combined.count(), 9u);
+    EXPECT_TRUE(Combined.any());
+    EXPECT_EQ(Combined.getNumLanes(), 9u);
 
     LaneMask128 AndResult = Combined & High;
-    EXPECT_FALSE(AndResult.test(0));
-    EXPECT_TRUE(AndResult.test(100));
-    EXPECT_EQ(AndResult.count(), 1u);
-
-    // Test XOR across word boundaries.
-    EXPECT_TRUE((Combined ^ High).test(0));
-    EXPECT_FALSE((Combined ^ High).test(100));
-    EXPECT_EQ((Combined ^ High).count(), 8u);
-
-    // Test XOR assign.
-    LaneMask128 A4(0xff00);
-    A4 ^= B;
-    EXPECT_EQ(A4, LaneMask128(0xf0f0));
+    EXPECT_EQ(AndResult.getNumLanes(), 1u);
+    EXPECT_EQ(AndResult.getHighestLane(), 100u);
   }
 
-  // Constexpr bitwise operations for 64-bit.
-  static_assert((LaneMask64(0xff00) | LaneMask64(0x0ff0)) == LaneMask64(0xfff0),
-                "Constexpr OR");
-  static_assert((LaneMask64(0xff00) & LaneMask64(0x0ff0)) == LaneMask64(0x0f00),
-                "Constexpr AND");
-  static_assert((LaneMask64(0xff00) ^ LaneMask64(0x0ff0)) == LaneMask64(0xf0f0),
-                "Constexpr XOR");
-  static_assert((~LaneMask64(0xff)).any(), "Constexpr NOT");
-  static_assert((~LaneMask64::getAll()).none(), "Constexpr NOT of all");
+  static_assert((LaneMask64(0xff00) | LaneMask64(0x0ff0)) ==
+                LaneMask64(0xfff0));
+  static_assert((LaneMask64(0xff00) & LaneMask64(0x0ff0)) ==
+                LaneMask64(0x0f00));
+  static_assert((~LaneMask64::getAll()).none());
   static_assert(
       []() constexpr {
         LaneMask64 L(0xff00);
@@ -351,47 +199,6 @@ TEST(LaneBitmaskTest, BitwiseOperators) {
         return L == LaneMask64(0x0f00);
       }(),
       "Constexpr AND assign");
-  static_assert(
-      []() constexpr {
-        LaneMask64 L(0xff00);
-        L ^= LaneMask64(0x0ff0);
-        return L == LaneMask64(0xf0f0);
-      }(),
-      "Constexpr XOR assign");
-
-  // Constexpr bitwise operations for 128-bit.
-  static_assert((LaneMask128(0xff00) | LaneMask128(0x0ff0)) ==
-                    LaneMask128(0xfff0),
-                "Constexpr OR");
-  static_assert((LaneMask128(0xff00) ^ LaneMask128(0x0ff0)) ==
-                    LaneMask128(0xf0f0),
-                "Constexpr XOR");
-  static_assert(
-      (LaneMask128::getLane(64) | LaneMask128::getLane(100)).count() == 2,
-      "Constexpr OR across words");
-  static_assert((LaneMask128::getLane(64) ^ LaneMask128::getLane(64)).none(),
-                "Constexpr XOR with self is empty");
-  static_assert(
-      []() constexpr {
-        LaneMask128 L(0xff00);
-        L |= LaneMask128::getLane(100);
-        return L.count() == 9;
-      }(),
-      "Constexpr OR assign 128-bit");
-  static_assert(
-      []() constexpr {
-        LaneMask128 L(0xff00);
-        L &= LaneMask128(0x0ff0);
-        return L == LaneMask128(0x0f00);
-      }(),
-      "Constexpr AND assign 128-bit");
-  static_assert(
-      []() constexpr {
-        LaneMask128 L(0xff00);
-        L ^= LaneMask128(0x0ff0);
-        return L == LaneMask128(0xf0f0);
-      }(),
-      "Constexpr XOR assign 128-bit");
 }
 
 TEST(LaneBitmaskTest, QueryMethods) {
@@ -401,23 +208,19 @@ TEST(LaneBitmaskTest, QueryMethods) {
     EXPECT_TRUE(Empty.none());
     EXPECT_FALSE(Empty.any());
     EXPECT_FALSE(Empty.all());
-    EXPECT_EQ(Empty.count(), 0u);
     EXPECT_EQ(Empty.getNumLanes(), 0u);
 
     LaneMask64 Partial(0x00ff);
     EXPECT_FALSE(Partial.none());
     EXPECT_TRUE(Partial.any());
     EXPECT_FALSE(Partial.all());
-    EXPECT_EQ(Partial.count(), 8u);
     EXPECT_EQ(Partial.getNumLanes(), 8u);
 
     LaneMask64 Full = LaneMask64::getAll();
     EXPECT_FALSE(Full.none());
     EXPECT_TRUE(Full.any());
     EXPECT_TRUE(Full.all());
-    EXPECT_EQ(Full.count(), LaneMask64::BitWidth);
     EXPECT_EQ(Full.getNumLanes(), LaneMask64::BitWidth);
-    EXPECT_EQ(Full.size(), LaneMask64::BitWidth);
   }
 
   // Test 128-bit version.
@@ -426,61 +229,34 @@ TEST(LaneBitmaskTest, QueryMethods) {
     EXPECT_TRUE(Empty.none());
     EXPECT_FALSE(Empty.any());
     EXPECT_FALSE(Empty.all());
-    EXPECT_EQ(Empty.count(), 0u);
     EXPECT_EQ(Empty.getNumLanes(), 0u);
 
-    LaneMask128 Partial(0x00ff);
-    EXPECT_FALSE(Partial.none());
-    EXPECT_TRUE(Partial.any());
-    EXPECT_FALSE(Partial.all());
-    EXPECT_EQ(Partial.count(), 8u);
-    EXPECT_EQ(Partial.getNumLanes(), 8u);
-
     LaneMask128 Full = LaneMask128::getAll();
-    EXPECT_FALSE(Full.none());
-    EXPECT_TRUE(Full.any());
     EXPECT_TRUE(Full.all());
-    EXPECT_EQ(Full.count(), LaneMask128::BitWidth);
     EXPECT_EQ(Full.getNumLanes(), LaneMask128::BitWidth);
 
     LaneMask128 UpperBit = LaneMask128::getLane(127);
-    EXPECT_FALSE(UpperBit.none());
     EXPECT_TRUE(UpperBit.any());
     EXPECT_FALSE(UpperBit.all());
   }
 
-  // Constexpr query methods for 64-bit.
-  static_assert(LaneMask64().none(), "Empty mask");
-  static_assert(!LaneMask64(0x1).none(), "Non-empty mask");
-  static_assert(LaneMask64(0x1).any(), "Any bit set");
-  static_assert(!LaneMask64().any(), "No bits set");
-  static_assert(LaneMask64::getAll().all(), "All bits set");
-  static_assert(!LaneMask64(0xff).all(), "Not all bits set");
-  static_assert(LaneMask64().count() == 0, "Count zero");
-  static_assert(LaneMask64(0x7).count() == 3, "Count three");
-  static_assert(LaneMask64(0x7).getNumLanes() == 3, "Num lanes three");
-  static_assert(LaneMask64().size() == LaneMask64::BitWidth, "Size");
-  static_assert(LaneMask64::getAll().getNumLanes() == LaneMask64::BitWidth,
-                "Full mask num lanes");
-
-  // Constexpr query methods for 128-bit.
-  static_assert(LaneMask128().none(), "Empty mask");
-  static_assert(LaneMask128::getLane(127).any(), "High bit set");
-  static_assert(LaneMask128::getAll().all(), "All bits set");
-  static_assert(LaneMask128().size() == LaneMask128::BitWidth, "Size");
-  static_assert(LaneMask128::getAll().getNumLanes() == 128, "128 lanes");
+  static_assert(LaneMask64().none());
+  static_assert(!LaneMask64(0x1).none());
+  static_assert(LaneMask64(0x1).any());
+  static_assert(LaneMask64::getAll().all());
+  static_assert(!LaneMask64(0xff).all());
+  static_assert(LaneMask64(0x7).getNumLanes() == 3);
+  static_assert(LaneMask128::getLane(127).any());
+  static_assert(LaneMask128::getAll().all());
 }
 
 TEST(LaneBitmaskTest, GetHighestLane) {
-  // Test 64-bit version.
   EXPECT_EQ(LaneMask64(1).getHighestLane(), 0u);
   EXPECT_EQ(LaneMask64(1ull << 5).getHighestLane(), 5u);
   EXPECT_EQ(LaneMask64(1ull << 63).getHighestLane(), 63u);
   EXPECT_EQ(LaneMask64((1ull << 10) | (1ull << 30)).getHighestLane(), 30u);
 
-  // Test 128-bit version.
   EXPECT_EQ(LaneMask128(1).getHighestLane(), 0u);
-  EXPECT_EQ(LaneMask128(1ull << 5).getHighestLane(), 5u);
   EXPECT_EQ(LaneMask128::getLane(100).getHighestLane(), 100u);
   EXPECT_EQ(LaneMask128::getLane(127).getHighestLane(), 127u);
   EXPECT_EQ(
@@ -488,347 +264,77 @@ TEST(LaneBitmaskTest, GetHighestLane) {
       100u);
 }
 
-TEST(LaneBitmaskTest, ShiftAssignOperators) {
-  // Test 64-bit version.
-  {
-    LaneMask64 A1(0xff);
-    A1 <<= 8;
-    EXPECT_EQ(A1, LaneMask64(0xff00));
-
-    LaneMask64 A2(0xff00);
-    A2 >>= 8;
-    EXPECT_EQ(A2, LaneMask64(0xff));
-
-    LaneMask64 A3(0x1);
-    A3 <<= 4;
-    A3 <<= 4;
-    EXPECT_EQ(A3, LaneMask64(0x100));
-  }
-
-  // Test 128-bit version with cross-word shifts.
-  {
-    LaneMask128 A1(0xff);
-    A1 <<= 8;
-    EXPECT_EQ(A1, LaneMask128(0xff00));
-
-    LaneMask128 A2(0xff);
-    A2 <<= 64;
-    EXPECT_FALSE(A2.test(0));
-    EXPECT_TRUE(A2.test(64));
-
-    LaneMask128 A3 = LaneMask128::getLane(100);
-    A3 >>= 50;
-    EXPECT_TRUE(A3.test(50));
-    EXPECT_FALSE(A3.test(100));
-  }
-
-  static_assert(
-      []() constexpr {
-        LaneMask64 L(0xff);
-        L <<= 8;
-        return L == LaneMask64(0xff00);
-      }(),
-      "Constexpr shift left assign");
-
-  static_assert(
-      []() constexpr {
-        LaneMask64 L(0xff00);
-        L >>= 8;
-        return L == LaneMask64(0xff);
-      }(),
-      "Constexpr shift right assign");
-
-  static_assert(
-      []() constexpr {
-        LaneMask128 L(0xff);
-        L <<= 64;
-        return !L.test(0) && L.test(64);
-      }(),
-      "Constexpr shift left assign 128-bit");
-
-  static_assert(
-      []() constexpr {
-        LaneMask128 L = LaneMask128::getLane(100);
-        L >>= 50;
-        return L.test(50) && !L.test(100);
-      }(),
-      "Constexpr shift right assign 128-bit");
-}
-
-TEST(LaneBitmaskTest, ShiftOperators) {
-  // Test 64-bit version.
-  {
-    LaneMask64 A(0xff);
-
-    EXPECT_EQ(A << 0, A);
-    EXPECT_EQ(A << 8, LaneMask64(0xff00));
-    EXPECT_TRUE((A << LaneMask64::BitWidth).none());
-    EXPECT_TRUE((A << (LaneMask64::BitWidth + 10)).none());
-
-    LaneMask64 B(0xff00);
-    EXPECT_EQ(B >> 0, B);
-    EXPECT_EQ(B >> 8, LaneMask64(0xff));
-    EXPECT_TRUE((B >> LaneMask64::BitWidth).none());
-
-    LaneMask64 Bit0 = LaneMask64::getLane(0);
-    LaneMask64 ShiftedLeft = Bit0 << (LaneMask64::BitWidth - 1);
-    EXPECT_FALSE(ShiftedLeft.none());
-    EXPECT_TRUE(ShiftedLeft.test(LaneMask64::BitWidth - 1));
-    EXPECT_TRUE((ShiftedLeft << 1).none());
-  }
-
-  // Test 128-bit version with cross-word shifts.
-  {
-    LaneMask128 A(0xff);
-
-    // Shift left within word.
-    EXPECT_EQ(A << 8, LaneMask128(0xff00));
-
-    // Shift left across word boundary.
-    LaneMask128 B = A << 60;
-    EXPECT_TRUE(B.test(60));
-    EXPECT_TRUE(B.test(67));
-
-    // Shift left completely into upper word.
-    LaneMask128 C = A << 64;
-    EXPECT_FALSE(C.test(0));
-    EXPECT_TRUE(C.test(64));
-    EXPECT_TRUE(C.test(71));
-
-    // Shift right across word boundary.
-    LaneMask128 D = LaneMask128::getLane(100);
-    LaneMask128 E = D >> 50;
-    EXPECT_TRUE(E.test(50));
-    EXPECT_FALSE(E.test(100));
-
-    // Shift by full width.
-    EXPECT_TRUE((A << LaneMask128::BitWidth).none());
-    EXPECT_TRUE((A >> LaneMask128::BitWidth).none());
-  }
-
-  // Constexpr shift operations for 64-bit.
-  static_assert((LaneMask64(0xff) << 8) == LaneMask64(0xff00),
-                "Constexpr shift left");
-  static_assert((LaneMask64(0xff00) >> 8) == LaneMask64(0xff),
-                "Constexpr shift right");
-  static_assert((LaneMask64(0xff) << LaneMask64::BitWidth).none(),
-                "Shift left by BitWidth");
-  static_assert((LaneMask64(0xff) << (LaneMask64::BitWidth + 10)).none(),
-                "Shift left beyond BitWidth");
-  static_assert(
-      []() constexpr {
-        LaneMask64 Bit0 = LaneMask64::getLane(0);
-        LaneMask64 Shifted = Bit0 << (LaneMask64::BitWidth - 1);
-        return !Shifted.none() && Shifted.test(LaneMask64::BitWidth - 1) &&
-               (Shifted << 1).none();
-      }(),
-      "Shift by BitWidth-1 then by 1");
-
-  // Constexpr shift operations for 128-bit.
-  static_assert((LaneMask128(0xff) << 8) == LaneMask128(0xff00),
-                "Constexpr shift left");
-  static_assert((LaneMask128::getLane(64) >> 64).test(0),
-                "Shift across word boundary");
-}
-
 TEST(LaneBitmaskTest, RotateOperators) {
   // Test 64-bit version.
   {
     LaneMask64 A(0xff);
-
     EXPECT_EQ(A.rotateLeft(0), A);
     EXPECT_EQ(A.rotateLeft(8), LaneMask64(0xff00));
     EXPECT_EQ(A.rotateLeft(LaneMask64::BitWidth), A);
-    EXPECT_EQ(A.rotateLeft(LaneMask64::BitWidth * 2), A);
-    EXPECT_EQ(A.rotateLeft(LaneMask64::BitWidth + 8), A.rotateLeft(8));
 
     LaneMask64 B(0xff00);
     EXPECT_EQ(B.rotateRight(0), B);
     EXPECT_EQ(B.rotateRight(8), LaneMask64(0xff));
     EXPECT_EQ(B.rotateRight(LaneMask64::BitWidth), B);
-    EXPECT_EQ(B.rotateRight(LaneMask64::BitWidth * 3), B);
-    EXPECT_EQ(B.rotateRight(LaneMask64::BitWidth + 8), B.rotateRight(8));
 
     LaneMask64 C(0x123456789abcdef0);
     EXPECT_EQ(C.rotateLeft(37).rotateRight(37), C);
 
     LaneMask64 HighBit = LaneMask64::getLane(LaneMask64::BitWidth - 1);
-    EXPECT_TRUE((HighBit << 1).none());
-    EXPECT_TRUE(HighBit.rotateLeft(1).test(0));
-  }
-
-  // Test 128-bit version with cross-word rotations.
-  {
-    LaneMask128 A(0xff);
-
-    // Rotate left within and across words.
-    EXPECT_EQ(A.rotateLeft(0), A);
-    EXPECT_EQ(A.rotateLeft(8), LaneMask128(0xff00));
-    EXPECT_EQ(A.rotateLeft(LaneMask128::BitWidth), A);
-
-    // Rotate across word boundary.
-    LaneMask128 B = A.rotateLeft(60);
-    EXPECT_TRUE(B.test(60));
-    EXPECT_TRUE(B.test(67));
-
-    // Rotate highest bit wraps to bit 0.
-    LaneMask128 HighBit = LaneMask128::getLane(127);
-    EXPECT_TRUE(HighBit.rotateLeft(1).test(0));
-    EXPECT_FALSE(HighBit.rotateLeft(1).test(127));
-
-    // Rotate from upper word to lower word.
-    LaneMask128 UpperBit = LaneMask128::getLane(100);
-    LaneMask128 Rotated = UpperBit.rotateRight(50);
-    EXPECT_TRUE(Rotated.test(50));
-    EXPECT_FALSE(Rotated.test(100));
-
-    // Verify rotate vs shift difference for 128-bit.
-    EXPECT_TRUE((HighBit << 1).none());
-    EXPECT_TRUE(HighBit.rotateLeft(1).test(0));
-  }
-
-  // Constexpr rotate operations for 64-bit.
-  static_assert(LaneMask64(0xff).rotateLeft(8) == LaneMask64(0xff00),
-                "Constexpr rotate left");
-  static_assert(LaneMask64(0xff00).rotateRight(8) == LaneMask64(0xff),
-                "Constexpr rotate right");
-  static_assert(LaneMask64(0xff).rotateLeft(LaneMask64::BitWidth) ==
-                    LaneMask64(0xff),
-                "Rotate by BitWidth is identity");
-  static_assert(LaneMask64(0xff).rotateLeft(LaneMask64::BitWidth * 2) ==
-                    LaneMask64(0xff),
-                "Rotate by multiple of BitWidth");
-  static_assert(LaneMask64(0xff).rotateLeft(LaneMask64::BitWidth + 8) ==
-                    LaneMask64(0xff).rotateLeft(8),
-                "Rotate by BitWidth + N");
-  static_assert(LaneMask64(0x1234).rotateLeft(37).rotateRight(37) ==
-                    LaneMask64(0x1234),
-                "Rotate roundtrip");
-  static_assert(
-      LaneMask64::getLane(LaneMask64::BitWidth - 1).rotateLeft(1).test(0),
-      "Rotate wraps around");
-
-  // Constexpr rotate operations for 128-bit.
-  static_assert(LaneMask128(0xff).rotateLeft(8) == LaneMask128(0xff00),
-                "Constexpr rotate left");
-  static_assert(LaneMask128::getLane(127).rotateLeft(1).test(0),
-                "Rotate highest bit wraps to 0");
-  static_assert(LaneMask128(0xff).rotateLeft(LaneMask128::BitWidth) ==
-                    LaneMask128(0xff),
-                "Rotate by 128 is identity");
-}
-
-TEST(LaneBitmaskTest, InheritedBitsetOperations) {
-  // Test 64-bit version.
-  {
-    LaneMask64 M;
-
-    M.set(5);
-    EXPECT_TRUE(M.test(5));
-    EXPECT_TRUE(M[5]);
-    EXPECT_EQ(M.count(), 1u);
-
-    M.set(10);
-    EXPECT_EQ(M.count(), 2u);
-
-    M.reset(5);
-    EXPECT_FALSE(M.test(5));
-    EXPECT_FALSE(M[5]);
-    EXPECT_EQ(M.count(), 1u);
-
-    M.flip(5);
-    EXPECT_TRUE(M.test(5));
-    EXPECT_TRUE(M[5]);
-
-    M.set();
-    EXPECT_TRUE(M.all());
-    EXPECT_EQ(M.getNumLanes(), LaneMask64::BitWidth);
+    EXPECT_TRUE(HighBit.rotateLeft(1).any());
   }
 
   // Test 128-bit version.
   {
-    LaneMask128 M;
+    LaneMask128 A(0xff);
+    EXPECT_EQ(A.rotateLeft(0), A);
+    EXPECT_EQ(A.rotateLeft(8), LaneMask128(0xff00));
+    EXPECT_EQ(A.rotateLeft(LaneMask128::BitWidth), A);
 
-    M.set(100);
-    EXPECT_TRUE(M.test(100));
-    EXPECT_TRUE(M[100]);
-    EXPECT_EQ(M.count(), 1u);
+    LaneMask128 HighBit = LaneMask128::getLane(127);
+    LaneMask128 Rotated = HighBit.rotateLeft(1);
+    EXPECT_EQ(Rotated.getNumLanes(), 1u);
+    EXPECT_EQ(Rotated.getHighestLane(), 0u);
 
-    M.set(10);
-    EXPECT_EQ(M.count(), 2u);
-
-    M.reset(100);
-    EXPECT_FALSE(M.test(100));
-    EXPECT_FALSE(M[100]);
-
-    M.flip(127);
-    EXPECT_TRUE(M.test(127));
-    EXPECT_TRUE(M[127]);
-
-    M.set();
-    EXPECT_TRUE(M.all());
-    EXPECT_EQ(M.getNumLanes(), LaneMask128::BitWidth);
+    LaneMask128 UpperBit = LaneMask128::getLane(100);
+    LaneMask128 RotatedDown = UpperBit.rotateRight(50);
+    EXPECT_EQ(RotatedDown.getHighestLane(), 50u);
   }
 
-  // Constexpr set/reset/flip/test/operator[] operations for 64-bit.
-  constexpr auto TestSet64 = []() constexpr {
-    LaneMask64 L;
-    L.set(5);
-    return L.test(5) && L[5] && L.count() == 1;
-  };
-  static_assert(TestSet64(), "Constexpr set and test");
+  static_assert(LaneMask64(0xff).rotateLeft(8) == LaneMask64(0xff00));
+  static_assert(LaneMask64(0xff00).rotateRight(8) == LaneMask64(0xff));
+  static_assert(LaneMask64(0xff).rotateLeft(LaneMask64::BitWidth) ==
+                LaneMask64(0xff));
+  static_assert(LaneMask64(0x1234).rotateLeft(37).rotateRight(37) ==
+                LaneMask64(0x1234));
+  static_assert(LaneMask128(0xff).rotateLeft(8) == LaneMask128(0xff00));
+  static_assert(LaneMask128(0xff).rotateLeft(LaneMask128::BitWidth) ==
+                LaneMask128(0xff));
+}
 
-  constexpr auto TestReset64 = []() constexpr {
-    LaneMask64 L;
-    L.set(5);
-    L.reset(5);
-    return !L.test(5) && !L[5] && L.none();
-  };
-  static_assert(TestReset64(), "Constexpr reset");
+TEST(LaneBitmaskTest, GetWord) {
+  // Test 64-bit version.
+  {
+    LaneMask64 M(0xdeadbeefcafe1234);
+    EXPECT_EQ(M.getWord(0), 0xdeadbeefcafe1234ULL);
+  }
 
-  constexpr auto TestFlip64 = []() constexpr {
-    LaneMask64 L;
-    L.flip(5);
-    return L.test(5) && L[5] && L.count() == 1;
-  };
-  static_assert(TestFlip64(), "Constexpr flip");
+  // Test 128-bit version.
+  {
+    std::array<uint64_t, 2> Arr = {0x1111222233334444, 0xaaaabbbbccccdddd};
+    LaneMask128 M(Arr);
+    EXPECT_EQ(M.getWord(0), 0x1111222233334444ULL);
+    EXPECT_EQ(M.getWord(1), 0xaaaabbbbccccddddULL);
+  }
 
-  constexpr auto TestSetAll64 = []() constexpr {
-    LaneMask64 L;
-    L.set();
-    return L.all() && L.count() == LaneMask64::BitWidth;
-  };
-  static_assert(TestSetAll64(), "Constexpr set all");
+  // Empty mask.
+  EXPECT_EQ(LaneMask64().getWord(0), 0ULL);
+  EXPECT_EQ(LaneMask128().getWord(0), 0ULL);
+  EXPECT_EQ(LaneMask128().getWord(1), 0ULL);
 
-  // Constexpr operations for 128-bit.
-  constexpr auto TestSet128 = []() constexpr {
-    LaneMask128 L;
-    L.set(100);
-    return L.test(100) && L[100] && L.count() == 1;
-  };
-  static_assert(TestSet128(), "Constexpr set bit 100");
-
-  constexpr auto TestReset128 = []() constexpr {
-    LaneMask128 L;
-    L.set(100);
-    L.reset(100);
-    return !L.test(100) && L.none();
-  };
-  static_assert(TestReset128(), "Constexpr reset bit 100");
-
-  constexpr auto TestFlip128 = []() constexpr {
-    LaneMask128 L;
-    L.flip(100);
-    return L.test(100) && L.count() == 1;
-  };
-  static_assert(TestFlip128(), "Constexpr flip bit 100");
-
-  constexpr auto TestSetAll128 = []() constexpr {
-    LaneMask128 L;
-    L.set();
-    return L.all() && L.count() == LaneMask128::BitWidth;
-  };
-  static_assert(TestSetAll128(), "Constexpr set all 128-bit");
+  static_assert(LaneMask64(0xff).getWord(0) == 0xff);
+  static_assert(LaneMask128::getAll().getWord(0) == ~0ULL);
+  static_assert(LaneMask128::getAll().getWord(1) == ~0ULL);
 }
 
 TEST(LaneBitmaskTest, APIntConstructor) {
@@ -843,22 +349,15 @@ TEST(LaneBitmaskTest, APIntConstructor) {
 
   APInt A64(64, 0x123456789abcdef0, false);
   LaneMask64 M64(A64);
-  EXPECT_TRUE(M64.test(4));
   EXPECT_EQ(M64.getHighestLane(), 60u);
 
   APInt Small(16, 0xff);
   LaneMask64 MSmall(Small);
   EXPECT_EQ(MSmall.getNumLanes(), 8u);
-  EXPECT_TRUE(MSmall.test(0));
-  EXPECT_TRUE(MSmall.test(7));
-  EXPECT_FALSE(MSmall.test(8));
 
   APInt A128(128, {0xff, 0xff00});
   LaneMask128 M128(A128);
-  EXPECT_TRUE(M128.test(0));
-  EXPECT_TRUE(M128.test(7));
-  EXPECT_TRUE(M128.test(64 + 8));
-  EXPECT_FALSE(M128.test(64 + 16));
+  EXPECT_EQ(M128.getNumLanes(), 16u);
 }
 
 TEST(LaneBitmaskTest, Printing) {
@@ -895,39 +394,24 @@ TEST(LaneBitmaskTest, Hashing) {
 }
 
 TEST(LaneBitmaskTest, MultiWordOperations) {
-  // Test comprehensive operations on 128-bit LaneMask64 across word boundaries.
-  LaneMask128 M;
-  M.set(0);
-  M.set(64);
-  M.set(127);
+  LaneMask128 A = LaneMask128::getLane(0) | LaneMask128::getLane(64) |
+                  LaneMask128::getLane(127);
 
-  EXPECT_EQ(M.getNumLanes(), 3u);
-  EXPECT_EQ(M.getHighestLane(), 127u);
-  EXPECT_TRUE(M.test(0));
-  EXPECT_TRUE(M.test(64));
-  EXPECT_TRUE(M.test(127));
-  EXPECT_FALSE(M.test(63));
+  EXPECT_EQ(A.getNumLanes(), 3u);
+  EXPECT_EQ(A.getHighestLane(), 127u);
 
-  // Test bitwise operations across word boundaries.
-  LaneMask128 N;
-  N.set(64);
-  N.set(100);
+  LaneMask128 B = LaneMask128::getLane(64) | LaneMask128::getLane(100);
 
-  LaneMask128 Or = M | N;
+  LaneMask128 Or = A | B;
   EXPECT_EQ(Or.getNumLanes(), 4u);
 
-  LaneMask128 And = M & N;
+  LaneMask128 And = A & B;
   EXPECT_EQ(And.getNumLanes(), 1u);
-  EXPECT_TRUE(And.test(64));
+  EXPECT_EQ(And.getHighestLane(), 64u);
 
-  // Test NOT across multiple words.
-  LaneMask128 NotM = ~M;
-  EXPECT_FALSE(NotM.test(0));
-  EXPECT_FALSE(NotM.test(64));
-  EXPECT_FALSE(NotM.test(127));
-  EXPECT_TRUE(NotM.test(63));
-  EXPECT_TRUE(NotM.test(65));
-  EXPECT_EQ(NotM.getNumLanes(), LaneMask128::BitWidth - 3);
+  LaneMask128 NotA = ~A;
+  EXPECT_FALSE(NotA.any() && NotA.none()); // sanity
+  EXPECT_EQ(NotA.getNumLanes(), LaneMask128::BitWidth - 3);
 }
 
 } // namespace

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -671,7 +671,23 @@ static DiffVec &diffEncode(DiffVec &V, unsigned InitVal, Iter Begin, Iter End) {
 static void printDiff16(raw_ostream &OS, int16_t Val) { OS << Val; }
 
 static void printMask(raw_ostream &OS, LaneBitmask Val) {
-  OS << "LaneBitmask(0x" << PrintLaneMask(Val) << ')';
+  constexpr unsigned NumWords = (LaneBitmask::BitWidth + 63) / 64;
+  // Check if all upper words beyond the first 64 bits are zero.
+  LaneBitmask UpperWords = ~LaneBitmask(~0ULL) & Val;
+  if (UpperWords.none()) {
+    OS << "LaneBitmask(0x" << PrintLaneMask(Val) << ')';
+  } else {
+    // Emit the explicit std::array constructor for multi-word values.
+    // Extract each 64-bit word by shifting and masking.
+    OS << "LaneBitmask(std::array<uint64_t, " << NumWords << ">{";
+    for (unsigned I = 0; I < NumWords; ++I) {
+      if (I > 0)
+        OS << ", ";
+      LaneBitmask Word = (Val >> (I * 64)) & LaneBitmask(~0ULL);
+      OS << "0x" << PrintLaneMask(Word);
+    }
+    OS << "})";
+  }
 }
 
 // Try to combine Idx's compose map into Vec if it is compatible.
@@ -881,13 +897,11 @@ void RegisterInfoEmitter::emitComposeSubRegIndexLaneMask(raw_ostream &OS,
         "  for (const MaskRolOp *Ops =\n"
         "       &LaneMaskComposeSequences[CompositeSequences[IdxA]];\n"
         "       Ops->Mask.any(); ++Ops) {\n"
-        "    LaneBitmask::Type M = LaneMask.getAsInteger() & "
-        "Ops->Mask.getAsInteger();\n"
+        "    LaneBitmask M = LaneMask & Ops->Mask;\n"
         "    if (unsigned S = Ops->RotateLeft)\n"
-        "      Result |= LaneBitmask((M << S) | (M >> (LaneBitmask::BitWidth - "
-        "S)));\n"
+        "      Result |= M.rotateLeft(S);\n"
         "    else\n"
-        "      Result |= LaneBitmask(M);\n"
+        "      Result |= M;\n"
         "  }\n"
         "  return Result;\n"
         "}\n\n";
@@ -903,12 +917,10 @@ void RegisterInfoEmitter::emitComposeSubRegIndexLaneMask(raw_ostream &OS,
         "  for (const MaskRolOp *Ops =\n"
         "       &LaneMaskComposeSequences[CompositeSequences[IdxA]];\n"
         "       Ops->Mask.any(); ++Ops) {\n"
-        "    LaneBitmask::Type M = LaneMask.getAsInteger();\n"
         "    if (unsigned S = Ops->RotateLeft)\n"
-        "      Result |= LaneBitmask((M >> S) | (M << (LaneBitmask::BitWidth - "
-        "S)));\n"
+        "      Result |= LaneMask.rotateRight(S);\n"
         "    else\n"
-        "      Result |= LaneBitmask(M);\n"
+        "      Result |= LaneMask;\n"
         "  }\n"
         "  return Result;\n"
         "}\n\n";

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -671,7 +671,7 @@ static DiffVec &diffEncode(DiffVec &V, unsigned InitVal, Iter Begin, Iter End) {
 static void printDiff16(raw_ostream &OS, int16_t Val) { OS << Val; }
 
 static void printMask(raw_ostream &OS, LaneBitmask Val) {
-  constexpr unsigned NumWords = (LaneBitmask::BitWidth + 63) / 64;
+  constexpr unsigned NumWords = Bitset<LaneBitmask::BitWidth>::getNumWords64();
   // Check if all upper words beyond the first 64 bits are zero.
   LaneBitmask UpperWords = ~LaneBitmask(~0ULL) & Val;
   if (UpperWords.none()) {


### PR DESCRIPTION
This PR refactors `LaneBitmask` to be a wrapper around `llvm::Bitset`. It serves as the groundwork for targets to have a more extensible `LaneBitmask`.
## Context

**Discourse discussion:** https://discourse.llvm.org/t/rfc-out-of-lanebitmask-bits-again/88613
**Other PR along the effort**:  `Bitset` refactor - https://github.com/llvm/llvm-project/pull/189497

## Overview

This patch replaces `LaneBitmask`'s `uint64_t` implementation with a template class `detail::LaneBitmaskImpl<NumBits>` that holds `Bitset<NumBits>` as a member. For the current stage of the refactor, it remains 64-bit:

```cpp
using LaneBitmask = detail::LaneBitmaskImpl<64>;
```

The goal for this refactor is that a downstream target needing a wider lane bitmask (e.g. 128-bit) can simply change this alias — all LaneBitmask operations, printing, parsing, hashing, and TableGen emission are already templated and will work at any width.

To maintain backward compatibility, the refactored class will preserve the existing public APIs and all existing constructors except for `getAsInteger()`, which is an escape hatch of the abstraction anyway and is **intentionally removed** — all consumer code is adjusted to work through the type-safe LaneBitmask API instead of extracting raw integers.

## Next Steps

The next step after this PR is to add a mechanism — likely in TableGen/CMake — for targets to opt in to a wider `LaneBitmask`. With this patch landed, that becomes a matter of changing the `using` alias and the configuration plumbing — all the C++ infrastructure is already in place.

---
Claude Code was used to assist with implementation and testing of this change. All code has been reviewed and understood by the author.