### PR TITLE
[clang][bytecode] Fix placement new on multidimensional array elements

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1990,7 +1990,12 @@ bool CheckNewTypeMismatch(InterpState &S, CodePtr OpPC, const Expr *E,
                           std::optional<uint64_t> ArraySize) {
   const Pointer &Ptr = S.Stk.peek<Pointer>();
 
-  if (Ptr.inUnion() && Ptr.getBase().getRecord()->isUnion())
+  auto directBaseIsUnion = [](const Pointer &Ptr) -> bool {
+    const Record *R = Ptr.getBase().getRecord();
+    return R && R->isUnion();
+  };
+
+  if (Ptr.inUnion() && directBaseIsUnion(Ptr))
     Ptr.activate();
 
   if (Ptr.isZero()) {
@@ -2071,7 +2076,7 @@ bool CheckNewTypeMismatch(InterpState &S, CodePtr OpPC, const Expr *E,
   }
 
   // Can't activate fields in a union, unless the direct base is the union.
-  if (Ptr.inUnion() && !Ptr.isActive() && !Ptr.getBase().getRecord()->isUnion())
+  if (Ptr.inUnion() && !Ptr.isActive() && !directBaseIsUnion(Ptr))
     return CheckActive(S, OpPC, Ptr, AK_Construct);
 
   return true;

--- a/clang/test/AST/ByteCode/placement-new.cpp
+++ b/clang/test/AST/ByteCode/placement-new.cpp
@@ -524,3 +524,18 @@ static_assert(intDestArray() == 0); // both-error {{not an integral constant exp
 
 constexpr void invalidDest() { new (undefinedfunction()) int; } // both-error {{use of undeclared identifier 'undefinedfunction'}}
 static_assert((invalidDest(), true)); // both-error {{not an integral constant expression}}
+
+namespace DirectBaseHasNoRecord {
+  constexpr int test_multidim_single_start() {
+    struct S {
+      union {
+        int storage[2][3];
+      };
+    };
+    S s;
+    new (&s.storage[0][0]) int(1); // both-note {{construction of subobject of member 'storage' of union with no active member is not allowed in a constant expression}}
+    return 13;
+  }
+  static_assert(test_multidim_single_start() == 13); // both-error {{not an integral constant expression}} \
+                                                     // both-note {{in call to}}
+}


### PR DESCRIPTION
The direct base of those pointers is not a union, i.e. `getRecord()` returns `nullptr`.