### PR TITLE
[VPlan] Assert ComputeReductionResult isn't predicated in middle block. NFC

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -3288,6 +3288,17 @@ static void fixupVFUsersForEVL(VPlan &Plan, VPValue &EVL) {
   if (!HeaderMask)
     return;
 
+  // Ensure that any reduction that uses a select to mask off tail lanes does so
+  // in the vector loop, not the middle block, since EVL tail folding can have
+  // tail elements in the penultimate iteration.
+  assert(all_of(*Plan.getMiddleBlock(), [&Plan, HeaderMask](VPRecipeBase &R) {
+    if (match(&R, m_ComputeReductionResult(m_Select(m_Specific(HeaderMask),
+                                                    m_VPValue(), m_VPValue()))))
+      return R.getOperand(0)->getDefiningRecipe()->getRegion() ==
+             Plan.getVectorLoopRegion();
+    return true;
+  }));
+
   // Replace header masks with a mask equivalent to predicating by EVL:
   //
   // icmp ule widen-canonical-iv backedge-taken-count


### PR DESCRIPTION
Because EVL tail folding can have tail elements in not just the final iteration but in the penultimate iteration too, this adds an assert to make sure any reduction result computations haven't inadvertently sunk the select instruction into the middle block, see https://github.com/llvm/llvm-project/pull/191166 and https://github.com/llvm/llvm-project/pull/190938#discussion_r3056330550
