### PR TITLE
[clang][bytecode] Fix activating primitive array elements

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1991,6 +1991,8 @@ bool CheckNewTypeMismatch(InterpState &S, CodePtr OpPC, const Expr *E,
   const Pointer &Ptr = S.Stk.peek<Pointer>();
 
   auto directBaseIsUnion = [](const Pointer &Ptr) -> bool {
+    if (Ptr.isArrayElement())
+      return false;
     const Record *R = Ptr.getBase().getRecord();
     return R && R->isUnion();
   };

--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -669,6 +669,11 @@ void Pointer::activate() const {
   };
 
   Pointer B = *this;
+  // Primitive array elements can't be activated individually, so
+  // look at the array root instead.
+  if (B.getFieldDesc()->isPrimitiveArray() && B.isArrayElement())
+    B = B.getArray();
+
   while (!B.isRoot() && B.inUnion()) {
     activate(B);
 

--- a/clang/test/AST/ByteCode/placement-new.cpp
+++ b/clang/test/AST/ByteCode/placement-new.cpp
@@ -539,3 +539,29 @@ namespace DirectBaseHasNoRecord {
   static_assert(test_multidim_single_start() == 13); // both-error {{not an integral constant expression}} \
                                                      // both-note {{in call to}}
 }
+
+namespace PrimArray {
+  constexpr int test_start_lifetime_array() {
+    struct S {
+      union { int storage[4]; };
+    };
+    S s;
+    s.storage[0] = 10;
+    ::new (&s.storage[0]) int(10);
+    ::new (&s.storage[1]) int(20);
+    return s.storage[0] + s.storage[1];
+  }
+  static_assert(test_start_lifetime_array() == 30);
+
+
+  constexpr int primElem() {
+    union {int a[2]; };
+
+    new (&a[1]) int(30); // both-note {{construction of subobject of member 'a' of union with no active member is not allowed in a constant expression}}
+    return a[1];
+  }
+  static_assert(primElem() == 30); // both-error {{not an integral constant expression}} \
+                                   // both-note {{in call to}}
+
+
+}


### PR DESCRIPTION
For primitive array elements, we would accidentally activate the element and then immediate de-activate the array root, which is wrong.  Ignore the element from the beginning to the later check never even compares with the element.