### PR TITLE
[NFC][mlir][SPIR-V] Rename getUnaryOpResultType to getMatchingBoolType

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVLogicalOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVLogicalOps.td
@@ -27,7 +27,7 @@ class SPIRV_LogicalBinaryOp<string mnemonic, Type operandsType,
                      TypesMatchWith<"type of result to correspond to the `i1` "
                                     "equivalent of the operand",
                                     "operand1", "result",
-                                    "getUnaryOpResultType($_self)"
+                                    "getMatchingBoolType($_self)"
                      >])> {
   let assemblyFormat = "$operand1 `,` $operand2 `:` type($operand1) attr-dict";
 }
@@ -41,7 +41,7 @@ class SPIRV_LogicalUnaryOp<string mnemonic, Type operandType,
                      TypesMatchWith<"type of result to correspond to the `i1` "
                                     "equivalent of the operand",
                                     "operand", "result",
-                                    "getUnaryOpResultType($_self)"
+                                    "getMatchingBoolType($_self)"
                      >])> {
   let assemblyFormat = "$operand `:` type($operand) attr-dict";
 }

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVOpDefinition.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVOpDefinition.cpp
@@ -49,8 +49,9 @@ static bool isDirectInModuleLikeOp(Operation *op) {
   return op && op->hasTrait<OpTrait::SymbolTable>();
 }
 
-/// Result of a logical op must be a scalar or vector of boolean type.
-static Type getUnaryOpResultType(Type operandType) {
+/// Returns a boolean scalar or vector type matching the shape of the given
+/// type. Scalar inputs yield i1, vector inputs yield vector<Nxi1>.
+static Type getMatchingBoolType(Type operandType) {
   Builder builder(operandType.getContext());
   Type resultType = builder.getIntegerType(1);
   if (auto vecType = dyn_cast<VectorType>(operandType))


### PR DESCRIPTION
The old name was misleading because this function is not specific to unary ops

suggested in https://github.com/llvm/llvm-project/pull/189099#discussion_r3051945317 