### PR TITLE
[clang][bytecode] Don't check anonymous union in memcpy op

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -2428,8 +2428,10 @@ inline bool Memcpy(InterpState &S, CodePtr OpPC) {
   const Pointer &Src = S.Stk.pop<Pointer>();
   Pointer &Dest = S.Stk.peek<Pointer>();
 
-  if (!CheckLoad(S, OpPC, Src))
-    return false;
+  if (!Src.getRecord() || !Src.getRecord()->isAnonymousUnion()) {
+    if (!CheckLoad(S, OpPC, Src))
+      return false;
+  }
 
   return DoMemcpy(S, OpPC, Src, Dest);
 }

--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -345,6 +345,16 @@ namespace ReadMutableInCopyCtor {
                        // both-note {{in call to 'G(g1)'}}
 }
 
+namespace ReadAnonUnionInCopyCtor {
+  struct G {
+    struct X {};
+    union U { X a; };
+    union {X a; };
+  };
+  constexpr G g1 = {};
+  constexpr G g2 = g1;
+}
+
 namespace GH150709 {
   struct C { };
   struct D : C {
@@ -353,7 +363,7 @@ namespace GH150709 {
   struct E : C { };
   struct F : D { };
   struct G : E { };
-  
+
   constexpr C c1, c2[2];
   constexpr D d1, d2[2];
   constexpr E e1, e2[2];


### PR DESCRIPTION
It's fine if they are uninitialized.