### PR TITLE
[CFG] Fix cleanup ordering for CXXDefaultInitExpr


### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
@@ -36,6 +36,7 @@ public:
   void VisitDeclStmt(const DeclStmt *DS);
   void VisitDeclRefExpr(const DeclRefExpr *DRE);
   void VisitCXXConstructExpr(const CXXConstructExpr *CCE);
+  void VisitCXXDefaultInitExpr(const CXXDefaultInitExpr *DIE);
   void VisitCXXMemberCallExpr(const CXXMemberCallExpr *MCE);
   void VisitMemberExpr(const MemberExpr *ME);
   void VisitCallExpr(const CallExpr *CE);

--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -1824,17 +1824,18 @@ CFGBlock *CFGBuilder::addInitializer(CXXCtorInitializer *I) {
   if (!BuildOpts.AddInitializers)
     return Block;
 
+  bool HasTemporaries = false;
+
   // Destructors of temporaries in initialization expression should be called
   // after initialization finishes.
   Expr *Init = I->getInit();
   if (Init) {
     Expr *ActualInit = Init;
-    if (BuildOpts.AddCXXDefaultInitExprInCtors) {
+    if (BuildOpts.AddCXXDefaultInitExprInCtors)
       if (auto *DIE = dyn_cast<CXXDefaultInitExpr>(Init))
         ActualInit = DIE->getExpr();
-    }
 
-    bool HasTemporaries = isa<ExprWithCleanups>(ActualInit);
+    HasTemporaries = isa<ExprWithCleanups>(ActualInit);
 
     if (HasTemporaries &&
         (BuildOpts.AddTemporaryDtors || BuildOpts.AddLifetime)) {
@@ -1845,10 +1846,12 @@ CFGBlock *CFGBuilder::addInitializer(CXXCtorInitializer *I) {
 
       addFullExprCleanupMarker(Context);
     }
+  }
 
-    autoCreateBlock();
-    appendInitializer(Block, I);
+  autoCreateBlock();
+  appendInitializer(Block, I);
 
+  if (Init) {
     // If the initializer is an ArrayInitLoopExpr, we want to extract the
     // initializer, that's used for each element.
     auto *AILEInit = extractElementInitializerFromNestedAILE(

--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -1824,29 +1824,31 @@ CFGBlock *CFGBuilder::addInitializer(CXXCtorInitializer *I) {
   if (!BuildOpts.AddInitializers)
     return Block;
 
-  bool HasTemporaries = false;
-
   // Destructors of temporaries in initialization expression should be called
   // after initialization finishes.
   Expr *Init = I->getInit();
   if (Init) {
-    HasTemporaries = isa<ExprWithCleanups>(Init);
+    Expr *ActualInit = Init;
+    if (BuildOpts.AddCXXDefaultInitExprInCtors) {
+      if (auto *DIE = dyn_cast<CXXDefaultInitExpr>(Init))
+        ActualInit = DIE->getExpr();
+    }
+
+    bool HasTemporaries = isa<ExprWithCleanups>(ActualInit);
 
     if (HasTemporaries &&
         (BuildOpts.AddTemporaryDtors || BuildOpts.AddLifetime)) {
       // Generate destructors for temporaries in initialization expression.
       TempDtorContext Context;
-      VisitForTemporaries(cast<ExprWithCleanups>(Init)->getSubExpr(),
+      VisitForTemporaries(cast<ExprWithCleanups>(ActualInit)->getSubExpr(),
                           /*ExternallyDestructed=*/false, Context);
 
       addFullExprCleanupMarker(Context);
     }
-  }
 
-  autoCreateBlock();
-  appendInitializer(Block, I);
+    autoCreateBlock();
+    appendInitializer(Block, I);
 
-  if (Init) {
     // If the initializer is an ArrayInitLoopExpr, we want to extract the
     // initializer, that's used for each element.
     auto *AILEInit = extractElementInitializerFromNestedAILE(
@@ -1856,11 +1858,6 @@ CFGBlock *CFGBuilder::addInitializer(CXXCtorInitializer *I) {
         ConstructionContextLayer::create(cfg->getBumpVectorContext(), I),
         AILEInit ? AILEInit : Init);
 
-    if (HasTemporaries) {
-      // For expression with temporaries go directly to subexpression to omit
-      // generating destructors for the second time.
-      return Visit(cast<ExprWithCleanups>(Init)->getSubExpr());
-    }
     if (BuildOpts.AddCXXDefaultInitExprInCtors) {
       if (CXXDefaultInitExpr *Default = dyn_cast<CXXDefaultInitExpr>(Init)) {
         // In general, appending the expression wrapped by a CXXDefaultInitExpr
@@ -1868,11 +1865,20 @@ CFGBlock *CFGBuilder::addInitializer(CXXCtorInitializer *I) {
         // here is safe because there's only one initializer per field.
         autoCreateBlock();
         appendStmt(Block, Default);
-        if (Stmt *Child = Default->getExpr())
+        if (Stmt *Child = Default->getExpr()) {
+          if (HasTemporaries)
+            Child = cast<ExprWithCleanups>(Child)->getSubExpr();
           if (CFGBlock *R = Visit(Child))
             Block = R;
+        }
         return Block;
       }
+    }
+
+    if (HasTemporaries) {
+      // For expression with temporaries go directly to subexpression to omit
+      // generating destructors for the second time.
+      return Visit(cast<ExprWithCleanups>(Init)->getSubExpr());
     }
     return Visit(Init);
   }

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -207,6 +207,11 @@ void FactsGenerator::VisitCXXConstructExpr(const CXXConstructExpr *CCE) {
                      /*IsGslConstruction=*/false);
 }
 
+void FactsGenerator::VisitCXXDefaultInitExpr(const CXXDefaultInitExpr *DIE) {
+  if (const Expr *Init = DIE->getExpr())
+    killAndFlowOrigin(*DIE, *Init);
+}
+
 void FactsGenerator::handleCXXCtorInitializer(const CXXCtorInitializer *CII) {
   // Flows origins from the initializer expression to the field.
   // Example: `MyObj(std::string s) : view(s) {}`

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2537,9 +2537,4 @@ struct Holder {
   std::string_view view = std::string("temporary"); // expected-warning {{address of stack memory escapes to a field}} expected-note {{this field dangles}}
   Holder() {}
 };
-
-void test() {
-  Holder h;
-  (void)h;
-}
 } // namespace CXXDefaultInitExprTests

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2531,3 +2531,15 @@ int *noreturn_dead_nested(bool cond, bool cond2, int *num) {
 }
 
 } // namespace conditional_operator_control_flow
+
+namespace CXXDefaultInitExprTests {
+struct Holder {
+  std::string_view view = std::string("temporary"); // expected-warning {{address of stack memory escapes to a field}} expected-note {{this field dangles}}
+  Holder() {}
+};
+
+void test() {
+  Holder h;
+  (void)h;
+}
+} // namespace CXXDefaultInitExprTests


### PR DESCRIPTION
Fixes CFG construction for default member initializers when `AddCXXDefaultInitExprInCtors` is enabled by correcting the execution order of cleanups. 

E.g., in 

```cpp
struct H { 
  std::string_view v = std::string("x");
  H() {}
}; 
```

Previously, destructors for temporaries in default initializers for`std::string("x")` was sequenced _before_ the member initialization, causing false negatives in lifetime safety analysis because the temporary appeared to be destroyed prematurely before making to a origin.

Resolved this by modifying `CFGBuilder::addInitializer` to defer these cleanups to the end of the initialization full-expression.

_(AI-assisted with HITL)_