### PR TITLE
[NFC][SPIR-V] Fix logical-struct-access.ll to pass spirv-val validation

### DIFF
--- a/llvm/test/CodeGen/SPIRV/logical-struct-access.ll
+++ b/llvm/test/CodeGen/SPIRV/logical-struct-access.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-DAG: [[uint:%[0-9]+]] = OpTypeInt 32 0
 
@@ -23,69 +24,78 @@
 ; CHECK-DAG:    [[ptr_A:%[0-9]+]] = OpTypePointer Function [[A]]
 ; CHECK-DAG:    [[ptr_B:%[0-9]+]] = OpTypePointer Function [[B]]
 
-define internal ptr @gep_B_0(ptr %base) {
+define internal i32 @load_B_0(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
 ; CHECK: {{%[0-9]+}} = OpAccessChain [[ptr_A]] [[tmp]] [[uint_0]]
   %res = getelementptr %B, ptr %base, i32 0, i32 0
-  ret ptr %res
+  %val = load i32, ptr %res
+  ret i32 %val
 }
 
-define internal ptr @gep_inbounds_B_0(ptr %base) {
+define internal i32 @load_inbounds_B_0(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
 ; CHECK: {{%[0-9]+}} = OpInBoundsAccessChain [[ptr_A]] [[tmp]] [[uint_0]]
   %res = getelementptr inbounds %B, ptr %base, i32 0, i32 0
-  ret ptr %res
+  %val = load i32, ptr %res
+  ret i32 %val
 }
 
-define internal ptr @gep_B_1(ptr %base) {
+define internal i32 @load_B_1(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
 ; CHECK: {{%[0-9]+}} = OpAccessChain [[ptr_uint]] [[tmp]] [[uint_1]]
   %res = getelementptr %B, ptr %base, i32 0, i32 1
-  ret ptr %res
+  %val = load i32, ptr %res
+  ret i32 %val
 }
 
-define internal ptr @gep_inbounds_B_1(ptr %base) {
+define internal i32 @load_inbounds_B_1(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
 ; CHECK: {{%[0-9]+}} = OpInBoundsAccessChain [[ptr_uint]] [[tmp]] [[uint_1]]
   %res = getelementptr inbounds %B, ptr %base, i32 0, i32 1
-  ret ptr %res
+  %val = load i32, ptr %res
+  ret i32 %val
 }
 
-define internal ptr @gep_B_2(ptr %base) {
+define internal i32 @load_B_2(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
 ; CHECK: {{%[0-9]+}} = OpAccessChain [[ptr_A]] [[tmp]] [[uint_2]]
   %res = getelementptr %B, ptr %base, i32 0, i32 2
-  ret ptr %res
+  %val = load i32, ptr %res
+  ret i32 %val
 }
 
-define internal ptr @gep_inbounds_B_2(ptr %base) {
+define internal i32 @load_inbounds_B_2(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
 ; CHECK: {{%[0-9]+}} = OpInBoundsAccessChain [[ptr_A]] [[tmp]] [[uint_2]]
   %res = getelementptr inbounds %B, ptr %base, i32 0, i32 2
-  ret ptr %res
+  %val = load i32, ptr %res
+  ret i32 %val
 }
 
-define internal ptr @gep_B_2_1(ptr %base) {
+define internal i32 @load_B_2_1(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
 ; CHECK: {{%[0-9]+}} = OpAccessChain [[ptr_uint]] [[tmp]] [[uint_2]] [[uint_1]]
   %res = getelementptr %B, ptr %base, i32 0, i32 2, i32 1
-  ret ptr %res
+  %val = load i32, ptr %res
+  ret i32 %val
 }
 
-define internal ptr @gep_inbounds_B_2_1(ptr %base) {
+define internal i32 @load_inbounds_B_2_1(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
 ; CHECK: {{%[0-9]+}} = OpInBoundsAccessChain [[ptr_uint]] [[tmp]] [[uint_2]] [[uint_1]]
   %res = getelementptr inbounds %B, ptr %base, i32 0, i32 2, i32 1
-  ret ptr %res
+  %val = load i32, ptr %res
+  ret i32 %val
 }
 
-define internal ptr @gep_B_2_A_1(ptr %base) {
+define internal i32 @load_B_2_A_1(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
 ; CHECK: [[x:%[0-9]+]] = OpAccessChain [[ptr_A]] [[tmp]] [[uint_2]]
 ; CHECK:   {{%[0-9]+}} = OpAccessChain [[ptr_uint]] [[x]] [[uint_1]]
   %x = getelementptr %B, ptr %base, i32 0, i32 2
   %res = getelementptr %A, ptr %x, i32 0, i32 1
-  ret ptr %res
+  %val = load i32, ptr %res
+  ret i32 %val
 }
 
 define void @main() #1 {
@@ -93,15 +103,15 @@ entry:
   %0 = alloca %B, align 4
 ; CHECK: [[tmp:%[0-9]+]] = OpVariable [[ptr_B]] Function
 
-  %1 = call ptr @gep_B_0(ptr %0)
-  %2 = call ptr @gep_inbounds_B_0(ptr %0)
-  %3 = call ptr @gep_B_1(ptr %0)
-  %4 = call ptr @gep_inbounds_B_1(ptr %0)
-  %5 = call ptr @gep_B_2(ptr %0)
-  %6 = call ptr @gep_inbounds_B_2(ptr %0)
-  %7 = call ptr @gep_B_2_1(ptr %0)
-  %8 = call ptr @gep_inbounds_B_2_1(ptr %0)
-  %10 = call ptr @gep_B_2_A_1(ptr %0)
+  %1 = call i32 @load_B_0(ptr %0)
+  %2 = call i32 @load_inbounds_B_0(ptr %0)
+  %3 = call i32 @load_B_1(ptr %0)
+  %4 = call i32 @load_inbounds_B_1(ptr %0)
+  %5 = call i32 @load_B_2(ptr %0)
+  %6 = call i32 @load_inbounds_B_2(ptr %0)
+  %7 = call i32 @load_B_2_1(ptr %0)
+  %8 = call i32 @load_inbounds_B_2_1(ptr %0)
+  %10 = call i32 @load_B_2_A_1(ptr %0)
 
   ret void
 }


### PR DESCRIPTION
OpReturnValue with a pointer type is invalid in SPIR-V Logical addressing model (Vulkan). The functions in the test return OpAccessChain results, which are pointers

related to https://github.com/llvm/llvm-project/issues/190736