### PR TITLE
[lldb] Support list-ing Source Embedded in DWARF

### DIFF
--- a/lldb/source/Core/SourceManager.cpp
+++ b/lldb/source/Core/SourceManager.cpp
@@ -582,7 +582,12 @@ void SourceManager::File::CommonInitializerImpl(SupportFileNSP support_file_nsp,
 }
 
 void SourceManager::File::SetSupportFile(SupportFileNSP support_file_nsp) {
-  FileSpec file_spec = support_file_nsp->GetSpecOnly();
+  // Use Materialize here to allow for the possibility of support files
+  // that may have special semantics for "generating" a file spec from
+  // a support file (e.g., DWARF with embedded source through
+  // DW_LNCT_LLVM_source).
+  FileSpec file_spec = support_file_nsp->Materialize();
+
   resolve_tilde(file_spec);
   m_support_file_nsp =
       std::make_shared<SupportFile>(file_spec, support_file_nsp->GetChecksum());

--- a/lldb/test/Shell/Commands/command-source-embedded.test
+++ b/lldb/test/Shell/Commands/command-source-embedded.test
@@ -1,0 +1,29 @@
+# Test automatically listing source on break for binary with embedded source.
+
+# When a program with embedded source being debugged reaches a breakpoint, its
+# source code should be listed. This test prevents a regression identified in #191801.
+
+# RUN: split-file %s %t
+# RUN: %clang_host -g -gdwarf -gembed-source %t/main.c -o %t.out
+# RUN: %lldb -x -b -s %t/commands %t.out -o exit 2>&1 \
+# RUN:       | FileCheck %s
+
+#--- main.c
+int main() {
+  return 0;
+}
+
+#--- commands
+break set -n main
+# CHECK-LABEL: break set -n main
+# CHECK-NEXT: Breakpoint 1: where = {{.*}}`main
+
+run
+# CHECK-LABEL: run
+# CHECK-NEXT:  Process [[PID:.*]] launched
+# CHECK-NEXT:  Process [[PID]] stopped
+# CHECK-NEXT:  name = {{.*}}, stop reason = breakpoint 1.1
+# CHECK-NEXT:  frame #0: {{.*}}`main at main.c:2:3
+# CHECK-NEXT:  1   	int main() {
+# CHECK-NEXT:  -> 2   					return 0;
+# CHECK-NEXT   3   	}


### PR DESCRIPTION
Compiled programs that embed their source code into their debugging information (using, e.g., DW_LNCT_LLVM_source) should display that code during debugging sessions.

Fixes #191801