### PR TITLE
[clang][LoongArch] Check target features in CheckLoongArchBuiltinFunctionCall

### DIFF
--- a/clang/lib/Sema/SemaLoongArch.cpp
+++ b/clang/lib/Sema/SemaLoongArch.cpp
@@ -11,8 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Sema/SemaLoongArch.h"
+#include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Basic/TargetBuiltins.h"
+#include "clang/Basic/TargetInfo.h"
 #include "clang/Sema/Sema.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MathExtras.h"
 
 namespace clang {
@@ -22,6 +25,19 @@ SemaLoongArch::SemaLoongArch(Sema &S) : SemaBase(S) {}
 bool SemaLoongArch::CheckLoongArchBuiltinFunctionCall(const TargetInfo &TI,
                                                       unsigned BuiltinID,
                                                       CallExpr *TheCall) {
+  ASTContext &Context = getASTContext();
+  const FunctionDecl *FD = SemaRef.getCurFunctionDecl();
+  llvm::StringMap<bool> FeatureMap;
+  Context.getFunctionFeatureMap(FeatureMap, FD);
+
+  llvm::StringRef Features = Context.BuiltinInfo.getRequiredFeatures(BuiltinID);
+  // Only check it when the builtin is not used in a function.
+  if (!Features.empty() && !FD) {
+    if (!Builtin::evaluateRequiredTargetFeatures(Features, FeatureMap))
+      return Diag(TheCall->getBeginLoc(), diag::err_builtin_needs_feature)
+             << "builtin" << Features;
+  }
+
   switch (BuiltinID) {
   default:
     break;

--- a/clang/test/Sema/builtin-loongarch-check-target-feature.cpp
+++ b/clang/test/Sema/builtin-loongarch-check-target-feature.cpp
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -triple loongarch64 -fsyntax-only -verify %s
+typedef long long __m128i __attribute__ ((__vector_size__ (16), __may_alias__));
+
+__m128i foo = __builtin_lsx_vinsgr2vr_w({0, 0}, 0, 0); // expected-error {{builtin needs target feature lsx}}
+__m128i bar = __builtin_lsx_vfrsqrte_s({0, 0}); // expected-error {{builtin needs target feature lsx,frecipe}}


### PR DESCRIPTION
Add target features check in `CheckLoongArchBuiltinFunctionCall`, thus we could through an error
when pass the `-mno-lsx` to clang while using the builtin LSX intrinsics for global variables instead of
trigger an ICE.

Minimal Example:
```
// clang-20 --march=loongarch64 -mno-lsx -S -o - "x.cc"
__attribute__((__vector_size__(16))) long foo = __builtin_lsx_vinsgr2vr_w(foo, 0, 0);
```
and the compiler will output
```
x.cc:1:49: error: builtin needs target feature lsx
    1 | __attribute__((__vector_size__(16))) long foo = __builtin_lsx_vinsgr2vr_w(foo, 0, 0);
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Fix https://github.com/llvm/llvm-project/issues/131771