### PR TITLE
[clang][analyzer] Add support for detecting uninitialized union fields

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
@@ -374,9 +374,9 @@ bool FindUninitializedFields::isNonUnionUninit(const TypedValueRegion *R,
 bool FindUninitializedFields::isUnionUninit(const TypedValueRegion *R) {
   assert(R->getValueType()->isUnionType() &&
          "This method only checks union objects!");
-    
+
   const RecordDecl *RD = R->getValueType()->getAsRecordDecl()->getDefinition();
-   
+
   if (!RD)
     return false;
 
@@ -387,7 +387,8 @@ bool FindUninitializedFields::isUnionUninit(const TypedValueRegion *R) {
     if (FD->isUnnamedBitField())
       continue;
 
-    const auto FieldVal = State->getLValue(FD, loc::MemRegionVal(R)).castAs<loc::MemRegionVal>();
+    const auto FieldVal =
+        State->getLValue(FD, loc::MemRegionVal(R)).castAs<loc::MemRegionVal>();
     SVal V = State->getSVal(FieldVal);
 
     // If any field has a defined value, the union is initialized.

--- a/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
@@ -374,8 +374,30 @@ bool FindUninitializedFields::isNonUnionUninit(const TypedValueRegion *R,
 bool FindUninitializedFields::isUnionUninit(const TypedValueRegion *R) {
   assert(R->getValueType()->isUnionType() &&
          "This method only checks union objects!");
-  // TODO: Implement support for union fields.
-  return false;
+    
+  const RecordDecl *RD = R->getValueType()->getAsRecordDecl()->getDefinition();
+   
+  if (!RD)
+    return false;
+
+  // A union is considered initialized if at least one of its fields has a
+  // non-undefined value. If every field is undefined (or the union has no
+  // fields), we treat it as uninitialized.
+  for (const FieldDecl *FD : RD->fields()) {
+    if (FD->isUnnamedBitField())
+      continue;
+
+    const auto FieldVal = State->getLValue(FD, loc::MemRegionVal(R)).castAs<loc::MemRegionVal>();
+    SVal V = State->getSVal(FieldVal);
+
+    // If any field has a defined value, the union is initialized.
+    if (!V.isUndef()) {
+      IsAnyFieldInitialized = true;
+      return false;
+    }
+  }
+
+  return true;
 }
 
 bool FindUninitializedFields::isPrimitiveUninit(SVal V) {

--- a/clang/test/Analysis/cxx-uninitialized-object-union-field.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object-union-field.cpp
@@ -1,0 +1,57 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,optin.cplusplus.UninitializedObject \
+// RUN:   -analyzer-config optin.cplusplus.UninitializedObject:Pedantic=true -DPEDANTIC \
+// RUN:   -std=c++11 -verify %s
+
+//===----------------------------------------------------------------------===//
+// Tests for union fields inside structs/classes.
+//===----------------------------------------------------------------------===//
+
+// A struct with an uninitialized union field -- should warn.
+struct WithUninitUnion {
+  union {
+    int i;
+    float f;
+  } u; // expected-note{{uninitialized field 'this->u'}}
+  int x;
+
+  WithUninitUnion(int val) : x(val) { // expected-warning{{1 uninitialized field at the end of the constructor call}}
+    // u is never initialized
+  }
+};
+
+void fWithUninitUnion() {
+  WithUninitUnion w(42);
+}
+
+// A struct where the union field IS initialized -- should not warn.
+struct WithInitUnion {
+  union {
+    int i;
+    float f;
+  } u;
+  int x;
+
+  WithInitUnion(int val) : x(val) {
+    u.i = val; // union is initialized via one of its members
+  }
+};
+
+void fWithInitUnion() {
+  WithInitUnion w(42); // no-warning
+}
+
+// A struct with only a union field, left uninitialized (pedantic mode).
+struct OnlyUninitUnion {
+  union {
+    int i;
+    char c;
+  } u; // expected-note{{uninitialized field 'this->u'}}
+
+  OnlyUninitUnion() { // expected-warning{{1 uninitialized field at the end of the constructor call}}
+    // u is never initialized
+  }
+};
+
+void fOnlyUninitUnion() {
+  OnlyUninitUnion o;
+}

--- a/clang/test/Analysis/cxx-uninitialized-object.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object.cpp
@@ -435,15 +435,17 @@ class ContainsSimpleUnionTest2 {
     float uf;
     int ui;
     char uc;
-  } u;
 #ifdef PEDANTIC
-  // expected-note@-1{{uninitialized field 'this->u'}}
+  } u; // expected-note{{uninitialized field 'this->u'}}
+#else
+  } u;
 #endif
 
 public:
-  ContainsSimpleUnionTest2() {}
 #ifdef PEDANTIC
-  // expected-warning@-1{{1 uninitialized field at the end of the constructor call}}
+  ContainsSimpleUnionTest2() {} // expected-warning{{1 uninitialized field at the end of the constructor call}}
+#else
+  ContainsSimpleUnionTest2() {}
 #endif
 };
 
@@ -483,15 +485,17 @@ public:
   };
 
 private:
-  SimpleUnion *uptr;
 #ifdef PEDANTIC
-  // expected-note@-1{{uninitialized pointee 'this->uptr'}}
+  SimpleUnion *uptr; // expected-note{{uninitialized pointee 'this->uptr'}}
+#else
+  SimpleUnion *uptr;
 #endif
 
 public:
-  UnionPointerTest2(SimpleUnion *uptr, char) : uptr(uptr) {}
 #ifdef PEDANTIC
-  // expected-warning@-1{{1 uninitialized field at the end of the constructor call}}
+  UnionPointerTest2(SimpleUnion *uptr, char) : uptr(uptr) {} // expected-warning{{1 uninitialized field at the end of the constructor call}}
+#else
+  UnionPointerTest2(SimpleUnion *uptr, char) : uptr(uptr) {}
 #endif
 };
 

--- a/clang/test/Analysis/cxx-uninitialized-object.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object.cpp
@@ -435,10 +435,16 @@ class ContainsSimpleUnionTest2 {
     float uf;
     int ui;
     char uc;
-  } u; // expected-note{{uninitialized field 'this->u'}}
+  } u;
+#ifdef PEDANTIC
+  // expected-note@-1{{uninitialized field 'this->u'}}
+#endif
 
 public:
-  ContainsSimpleUnionTest2() {} // expected-warning{{1 uninitialized field at the end of the constructor call}}
+  ContainsSimpleUnionTest2() {}
+#ifdef PEDANTIC
+  // expected-warning@-1{{1 uninitialized field at the end of the constructor call}}
+#endif
 };
 
 void fContainsSimpleUnionTest2() {
@@ -477,10 +483,16 @@ public:
   };
 
 private:
-  SimpleUnion *uptr; // expected-note{{uninitialized pointee 'this->uptr'}}
+  SimpleUnion *uptr;
+#ifdef PEDANTIC
+  // expected-note@-1{{uninitialized pointee 'this->uptr'}}
+#endif
 
 public:
-  UnionPointerTest2(SimpleUnion *uptr, char) : uptr(uptr) {} // expected-warning{{1 uninitialized field at the end of the constructor call}}
+  UnionPointerTest2(SimpleUnion *uptr, char) : uptr(uptr) {}
+#ifdef PEDANTIC
+  // expected-warning@-1{{1 uninitialized field at the end of the constructor call}}
+#endif
 };
 
 void fUnionPointerTest2() {

--- a/clang/test/Analysis/cxx-uninitialized-object.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object.cpp
@@ -435,16 +435,14 @@ class ContainsSimpleUnionTest2 {
     float uf;
     int ui;
     char uc;
-    // TODO: we'd expect the note: {{uninitialized field 'this->u'}}
-  } u; // no-note
+  } u; // expected-note{{uninitialized field 'this->u'}}
 
 public:
-  ContainsSimpleUnionTest2() {}
+  ContainsSimpleUnionTest2() {} // expected-warning{{1 uninitialized field at the end of the constructor call}}
 };
 
 void fContainsSimpleUnionTest2() {
-  // TODO: we'd expect the warning: {{1 uninitialized field}}
-  ContainsSimpleUnionTest2(); // no-warning
+  ContainsSimpleUnionTest2();
 }
 
 class UnionPointerTest1 {
@@ -479,17 +477,15 @@ public:
   };
 
 private:
-  // TODO: we'd expect the note: {{uninitialized field 'this->uptr'}}
-  SimpleUnion *uptr; // no-note
+  SimpleUnion *uptr; // expected-note{{uninitialized pointee 'this->uptr'}}
 
 public:
-  UnionPointerTest2(SimpleUnion *uptr, char) : uptr(uptr) {}
+  UnionPointerTest2(SimpleUnion *uptr, char) : uptr(uptr) {} // expected-warning{{1 uninitialized field at the end of the constructor call}}
 };
 
 void fUnionPointerTest2() {
   UnionPointerTest2::SimpleUnion u;
-  // TODO: we'd expect the warning: {{1 uninitialized field}}
-  UnionPointerTest2(&u, int()); // no-warning
+  UnionPointerTest2(&u, int());
 }
 
 class ContainsUnionWithRecordTest1 {


### PR DESCRIPTION
Implement `isUnionUninit()` in `UninitializedObjectChecker` to detect
uninitialized union fields.  Also adds a new test file to verify the behavior with union fields
inside structs and classes.