### PR TITLE
[ORC] Add MachOPlatform::HeaderOptions customization callback.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/MachOPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MachOPlatform.h
@@ -92,6 +92,9 @@ public:
     HeaderOptions(Dylib D) : IDDylib(std::move(D)) {}
   };
 
+  /// Callback for generating HeaderOptions structs for new JITDylibs.
+  using HeaderOptionsBuilder = unique_function<HeaderOptions(JITDylib &JD)>;
+
   /// Used by setupJITDylib to create MachO header MaterializationUnits for
   /// JITDylibs.
   using MachOHeaderMUBuilder =
@@ -143,6 +146,7 @@ public:
   static Expected<std::unique_ptr<MachOPlatform>>
   Create(ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
          std::unique_ptr<DefinitionGenerator> OrcRuntime,
+         HeaderOptionsBuilder BuildHeaderOpts = defaultHeaderOpts,
          HeaderOptions PlatformJDOpts = {},
          MachOHeaderMUBuilder BuildMachOHeaderMU = buildSimpleMachOHeaderMU,
          std::optional<SymbolAliasMap> RuntimeAliases = std::nullopt);
@@ -150,7 +154,9 @@ public:
   /// Construct using a path to the ORC runtime.
   static Expected<std::unique_ptr<MachOPlatform>>
   Create(ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
-         const char *OrcRuntimePath, HeaderOptions PlatformJDOpts = {},
+         const char *OrcRuntimePath,
+         HeaderOptionsBuilder BuildHeaderOpts = defaultHeaderOpts,
+         HeaderOptions PlatformJDOpts = {},
          MachOHeaderMUBuilder BuildMachOHeaderMU = buildSimpleMachOHeaderMU,
          std::optional<SymbolAliasMap> RuntimeAliases = std::nullopt);
 
@@ -188,6 +194,8 @@ public:
   /// ORC runtime.
   static ArrayRef<std::pair<const char *, const char *>>
   standardLazyCompilationAliases();
+
+  static HeaderOptions defaultHeaderOpts(JITDylib &JD);
 
 private:
   using SymbolTableVector = SmallVector<
@@ -305,6 +313,7 @@ private:
 
   MachOPlatform(ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
                 std::unique_ptr<DefinitionGenerator> OrcRuntimeGenerator,
+                HeaderOptionsBuilder BuildHeaderOpts,
                 HeaderOptions PlatformJDOpts,
                 MachOHeaderMUBuilder BuildMachOHeaderMU, Error &Err);
 
@@ -334,6 +343,7 @@ private:
   ExecutionSession &ES;
   JITDylib &PlatformJD;
   ObjectLinkingLayer &ObjLinkingLayer;
+  HeaderOptionsBuilder BuildHeaderOpts;
   MachOHeaderMUBuilder BuildMachOHeaderMU;
 
   SymbolStringPtr MachOHeaderStartSymbol = ES.intern("___dso_handle");

--- a/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
@@ -279,6 +279,7 @@ MachOPlatform::HeaderOptions::BuildVersionOpts::fromTriple(const Triple &TT,
 Expected<std::unique_ptr<MachOPlatform>>
 MachOPlatform::Create(ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
                       std::unique_ptr<DefinitionGenerator> OrcRuntime,
+                      HeaderOptionsBuilder BuildHeaderOpts,
                       HeaderOptions PlatformJDOpts,
                       MachOHeaderMUBuilder BuildMachOHeaderMU,
                       std::optional<SymbolAliasMap> RuntimeAliases) {
@@ -313,19 +314,20 @@ MachOPlatform::Create(ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
 
   // Create the instance.
   Error Err = Error::success();
-  auto P = std::unique_ptr<MachOPlatform>(new MachOPlatform(
-      ObjLinkingLayer, PlatformJD, std::move(OrcRuntime),
-      std::move(PlatformJDOpts), std::move(BuildMachOHeaderMU), Err));
+  auto P = std::unique_ptr<MachOPlatform>(
+      new MachOPlatform(ObjLinkingLayer, PlatformJD, std::move(OrcRuntime),
+                        std::move(BuildHeaderOpts), std::move(PlatformJDOpts),
+                        std::move(BuildMachOHeaderMU), Err));
   if (Err)
     return std::move(Err);
   return std::move(P);
 }
 
-Expected<std::unique_ptr<MachOPlatform>>
-MachOPlatform::Create(ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
-                      const char *OrcRuntimePath, HeaderOptions PlatformJDOpts,
-                      MachOHeaderMUBuilder BuildMachOHeaderMU,
-                      std::optional<SymbolAliasMap> RuntimeAliases) {
+Expected<std::unique_ptr<MachOPlatform>> MachOPlatform::Create(
+    ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
+    const char *OrcRuntimePath, HeaderOptionsBuilder BuildHeaderOpts,
+    HeaderOptions PlatformJDOpts, MachOHeaderMUBuilder BuildMachOHeaderMU,
+    std::optional<SymbolAliasMap> RuntimeAliases) {
 
   // Create a generator for the ORC runtime archive.
   auto OrcRuntimeArchiveGenerator =
@@ -335,12 +337,12 @@ MachOPlatform::Create(ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
 
   return Create(ObjLinkingLayer, PlatformJD,
                 std::move(*OrcRuntimeArchiveGenerator),
-                std::move(PlatformJDOpts), std::move(BuildMachOHeaderMU),
-                std::move(RuntimeAliases));
+                std::move(BuildHeaderOpts), std::move(PlatformJDOpts),
+                std::move(BuildMachOHeaderMU), std::move(RuntimeAliases));
 }
 
 Error MachOPlatform::setupJITDylib(JITDylib &JD) {
-  return setupJITDylib(JD, /*Opts=*/{});
+  return setupJITDylib(JD, BuildHeaderOpts(JD));
 }
 
 Error MachOPlatform::setupJITDylib(JITDylib &JD, HeaderOptions Opts) {
@@ -436,6 +438,10 @@ MachOPlatform::standardLazyCompilationAliases() {
       StandardLazyCompilationAliases);
 }
 
+MachOPlatform::HeaderOptions MachOPlatform::defaultHeaderOpts(JITDylib &JD) {
+  return {};
+}
+
 bool MachOPlatform::supportedTarget(const Triple &TT) {
   switch (TT.getArch()) {
   case Triple::aarch64:
@@ -472,10 +478,11 @@ MachOPlatform::flagsForSymbol(jitlink::Symbol &Sym) {
 MachOPlatform::MachOPlatform(
     ObjectLinkingLayer &ObjLinkingLayer, JITDylib &PlatformJD,
     std::unique_ptr<DefinitionGenerator> OrcRuntimeGenerator,
-    HeaderOptions PlatformJDOpts, MachOHeaderMUBuilder BuildMachOHeaderMU,
-    Error &Err)
+    HeaderOptionsBuilder BuildHeaderOpts, HeaderOptions PlatformJDOpts,
+    MachOHeaderMUBuilder BuildMachOHeaderMU, Error &Err)
     : ES(ObjLinkingLayer.getExecutionSession()), PlatformJD(PlatformJD),
       ObjLinkingLayer(ObjLinkingLayer),
+      BuildHeaderOpts(std::move(BuildHeaderOpts)),
       BuildMachOHeaderMU(std::move(BuildMachOHeaderMU)) {
   ErrorAsOutParameter _(Err);
   ObjLinkingLayer.addPlugin(std::make_unique<MachOPlatformPlugin>(*this));


### PR DESCRIPTION
This change aims to make it easier for MachOPlatform clients to customize JITDylib MachO headers.

At MachOPlatform construction time clients can now supply a MachOPlatform::HeaderOptionsBuilder. The supplied callback will be called by setupJITDylib to create the HeaderOptions for the JITDylib being set up.

No testcase: Constructing a MachOPlatform instance requires the ORC runtime, which we can't require for LLVM unit or regression suite tests. We should look at testing this functionality in the new ORC runtime once it's ready.