### PR TITLE
[FunctionAttrs] Don't infer noundef when return has nofpclass

### DIFF
--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -1745,9 +1745,11 @@ static void addNoUndefAttrs(const SCCNodeSet &SCCNodes,
               return false;
 
             FPClassTest AttrFPClass = Attrs.getRetNoFPClass();
-            KnownFPClass ComputedFPClass = computeKnownFPClass(RetVal, DL);
-            if (!ComputedFPClass.isKnownNever(AttrFPClass))
-              return false;
+            if (AttrFPClass != fcNone) {
+              KnownFPClass ComputedFPClass = computeKnownFPClass(RetVal, DL);
+              if (!ComputedFPClass.isKnownNever(AttrFPClass))
+                return false;
+            }
           }
           return true;
         })) {

--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -57,6 +57,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/KnownFPClass.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/Utils/Local.h"
@@ -1743,8 +1744,9 @@ static void addNoUndefAttrs(const SCCNodeSet &SCCNodes,
                     computeConstantRange(RetVal, /*ForSigned=*/false)))
               return false;
 
-            Attribute NoFP = Attrs.getRetAttr(Attribute::NoFPClass);
-            if (NoFP.hasAttribute(Attribute::NoFPClass))
+            FPClassTest AttrFPClass = Attrs.getRetNoFPClass();
+            KnownFPClass ComputedFPClass = computeKnownFPClass(RetVal, DL);
+            if (!ComputedFPClass.isKnownNever(AttrFPClass))
               return false;
           }
           return true;

--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -1742,6 +1742,10 @@ static void addNoUndefAttrs(const SCCNodeSet &SCCNodes,
                 !Attr.getRange().contains(
                     computeConstantRange(RetVal, /*ForSigned=*/false)))
               return false;
+
+            Attribute NoFP = Attrs.getRetAttr(Attribute::NoFPClass);
+            if (NoFP.hasAttribute(Attribute::NoFPClass))
+              return false;
           }
           return true;
         })) {

--- a/llvm/test/Transforms/FunctionAttrs/noundef.ll
+++ b/llvm/test/Transforms/FunctionAttrs/noundef.ll
@@ -215,9 +215,27 @@ define range(i8 0, 10) i8 @definitely_in_range(i8 noundef range(i8 0, 10) %v) {
   ret i8 %v
 }
 
-define nofpclass(nan) float @test_ret_nofpclass(float noundef %x) {
-; CHECK-LABEL: define nofpclass(nan) float @test_ret_nofpclass(
+define nofpclass(nan) float @maybe_nofpclass(float noundef %x) {
+; CHECK-LABEL: define nofpclass(nan) float @maybe_nofpclass(
 ; CHECK-SAME: float noundef returned [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    ret float [[X]]
+;
+  ret float %x
+}
+
+define nofpclass(nan) float @compute_not_nofpclass(float noundef nofpclass(nan) %x) {
+; CHECK-LABEL: define nofpclass(nan) float @compute_not_nofpclass(
+; CHECK-SAME: float noundef nofpclass(nan) [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[Y:%.*]] = fmul float [[X]], 0x7FF8000000000000
+; CHECK-NEXT:    ret float [[Y]]
+;
+  %y = fmul float %x, 0x7FF8000000000000
+  ret float %y
+}
+
+define nofpclass(nan) float @definitely_nofpclass(float noundef nofpclass(nan) %x) {
+; CHECK-LABEL: define noundef nofpclass(nan) float @definitely_nofpclass(
+; CHECK-SAME: float noundef returned nofpclass(nan) [[X:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    ret float [[X]]
 ;
   ret float %x

--- a/llvm/test/Transforms/FunctionAttrs/noundef.ll
+++ b/llvm/test/Transforms/FunctionAttrs/noundef.ll
@@ -214,3 +214,11 @@ define range(i8 0, 10) i8 @definitely_in_range(i8 noundef range(i8 0, 10) %v) {
 ;
   ret i8 %v
 }
+
+define nofpclass(nan) float @test_ret_nofpclass(float noundef %x) {
+; CHECK-LABEL: define nofpclass(nan) float @test_ret_nofpclass(
+; CHECK-SAME: float noundef returned [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    ret float [[X]]
+;
+  ret float %x
+}


### PR DESCRIPTION
- Fixes: #191338

nofpclass violations on a return produce poison.
Poison returns marked noundef are UB.
This turns off noundef inference when nofpclass attributes are present.