### PR TITLE
[scudo] Do not define some entrypoints on Fuchsia

### DIFF
--- a/compiler-rt/lib/scudo/standalone/wrappers_c.cpp
+++ b/compiler-rt/lib/scudo/standalone/wrappers_c.cpp
@@ -425,6 +425,7 @@ SCUDO_PREFIX(malloc_set_add_large_allocation_slack)(int add_slack) {
 // Extra Internal functions.
 INTERFACE void __scudo_print_stats(void) { Allocator.printStats(); }
 
+#if !SCUDO_FUCHSIA
 INTERFACE void __scudo_get_error_info(
     struct scudo_error_info *error_info, uintptr_t fault_addr,
     const char *stack_depot, size_t stack_depot_size, const char *region_info,
@@ -458,5 +459,6 @@ INTERFACE const char *__scudo_get_ring_buffer_addr() {
 INTERFACE size_t __scudo_get_ring_buffer_size() {
   return Allocator.getRingBufferSize();
 }
+#endif
 
 } // extern "C"


### PR DESCRIPTION
These entrypoints were defined separately in wrappers_c_bionic.cpp (which Fuchsia did not include in the build) before #190857 and, therefore, were not exposed to Fuchsia's Scudo clients.

With #190857, they have been merged into the main wrappers_c.cpp file, removing this separation.

This commit makes them conditionally-defined to not be building for Fuchsia, to restore the pre-#190857 ABI.