### PR TITLE
[llvm][DebugInfo][LogicalView] Use formatv() instead of format()

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/GsymReader.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymReader.cpp
@@ -17,6 +17,7 @@
 #include "llvm/DebugInfo/GSYM/LineTable.h"
 #include "llvm/Support/BinaryStreamReader.h"
 #include "llvm/Support/DataExtractor.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MemoryBuffer.h"
 
 using namespace llvm;
@@ -398,7 +399,7 @@ void GsymReader::dump(raw_ostream &OS) {
   OS << " (ADDRESS)\n";
   OS << "====== =============================== \n";
   for (uint32_t I = 0; I < Header.NumAddresses; ++I) {
-    OS << format("[%4u] ", I);
+    OS << formatv("[{0,4}] ", I);
     switch (Hdr->AddrOffSize) {
     case 1: OS << HEX8(getAddrOffsets<uint8_t>()[I]); break;
     case 2: OS << HEX16(getAddrOffsets<uint16_t>()[I]); break;
@@ -413,13 +414,13 @@ void GsymReader::dump(raw_ostream &OS) {
   OS << "INDEX  Offset\n";
   OS << "====== ==========\n";
   for (uint32_t I = 0; I < Header.NumAddresses; ++I)
-    OS << format("[%4u] ", I) << HEX32(AddrInfoOffsets[I]) << "\n";
+    OS << formatv("[{0,4}] ", I) << HEX32(AddrInfoOffsets[I]) << "\n";
   // Dump the file table.
   OS << "\nFiles:\n";
   OS << "INDEX  DIRECTORY  BASENAME   PATH\n";
   OS << "====== ========== ========== ==============================\n";
   for (uint32_t I = 0; I < Files.size(); ++I) {
-    OS << format("[%4u] ", I) << HEX32(Files[I].Dir) << ' '
+    OS << formatv("[{0,4}] ", I) << HEX32(Files[I].Dir) << ' '
        << HEX32(Files[I].Base) << ' ';
     dump(OS, getFile(I));
     OS << "\n";

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVCompare.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVCompare.cpp
@@ -405,10 +405,10 @@ void LVCompare::printSummary() const {
   auto PrintSeparator = [&]() { OS << Separator << "\n"; };
   auto PrintHeadingRow = [&](const char *T, const char *U, const char *V,
                              const char *W) {
-    OS << format("%-9s%9s  %9s  %9s\n", T, U, V, W);
+    OS << formatv("{0, -9}{1,9}  {2,9}  {3,9}\n", T, U, V, W);
   };
   auto PrintDataRow = [&](const char *T, unsigned U, unsigned V, unsigned W) {
-    OS << format("%-9s%9d  %9d  %9d\n", T, U, V, W);
+    OS << formatv("{0, -9}{1,9}  {2,9}  {3,9}\n", T, U, V, W);
   };
 
   OS << "\n";

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVElement.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVElement.cpp
@@ -529,7 +529,7 @@ void LVElement::printFileIndex(raw_ostream &OS, bool Full) const {
 
       OS << "  {Source} ";
       if (getInvalidFilename())
-        OS << format("[0x%08x]\n", Index);
+        OS << formatv("[{0:x8}]\n", Index);
       else
         OS << formattedName(getPathname()) << "\n";
     }

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVLocation.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVLocation.cpp
@@ -33,7 +33,7 @@ std::string LVOperation::getOperandsDWARFInfo() {
     // 2.5.1.1 Literal encodings.
     //-----------------------------------------------------------------------
     if (dwarf::DW_OP_lit0 <= Code && Code <= dwarf::DW_OP_lit31) {
-      Stream << format("lit%d", Code - dwarf::DW_OP_lit0);
+      Stream << formatv("lit{0}", Code - dwarf::DW_OP_lit0);
       return;
     }
 
@@ -42,8 +42,8 @@ std::string LVOperation::getOperandsDWARFInfo() {
     //-----------------------------------------------------------------------
     if (dwarf::DW_OP_breg0 <= Code && Code <= dwarf::DW_OP_breg31) {
       std::string RegisterName(getReader().getRegisterName(Code, Operands));
-      Stream << format("breg%d+%d%s", Code - dwarf::DW_OP_breg0, Operands[0],
-                       RegisterName.c_str());
+      Stream << formatv("breg{0}+{1}{2}", Code - dwarf::DW_OP_breg0,
+                        Operands[0], RegisterName.c_str());
       return;
     }
 
@@ -52,12 +52,12 @@ std::string LVOperation::getOperandsDWARFInfo() {
     //-----------------------------------------------------------------------
     if (dwarf::DW_OP_reg0 <= Code && Code <= dwarf::DW_OP_reg31) {
       std::string RegisterName(getReader().getRegisterName(Code, Operands));
-      Stream << format("reg%d%s", Code - dwarf::DW_OP_reg0,
-                       RegisterName.c_str());
+      Stream << formatv("reg{0}{1}", Code - dwarf::DW_OP_reg0,
+                        RegisterName.c_str());
       return;
     }
 
-    Stream << format("#0x%02x ", Code) << hexString(Operands[0]) << " "
+    Stream << formatv("#{0:x2} ", Code) << hexString(Operands[0]) << " "
            << hexString(Operands[1]) << "#";
   };
 
@@ -100,14 +100,14 @@ std::string LVOperation::getOperandsDWARFInfo() {
     break;
   case dwarf::DW_OP_bregx: {
     std::string RegisterName(getReader().getRegisterName(Opcode, Operands));
-    Stream << format("bregx %d%s+%d", Operands[0], RegisterName.c_str(),
-                     unsigned(Operands[1]));
+    Stream << formatv("bregx {0}{1}+{2}", Operands[0], RegisterName.c_str(),
+                      unsigned(Operands[1]));
     break;
   }
   case dwarf::DW_OP_regval_type: {
     std::string RegisterName(getReader().getRegisterName(Opcode, Operands));
-    Stream << format("regval_type %d%s+%d", Operands[0], RegisterName.c_str(),
-                     unsigned(Operands[1]));
+    Stream << formatv("regval_type {0}{1}+{2}", Operands[0],
+                      RegisterName.c_str(), unsigned(Operands[1]));
     break;
   }
 
@@ -390,7 +390,7 @@ std::string LVOperation::getOperandsCodeViewInfo() {
     break;
 
   default:
-    Stream << format("#0x%02x: ", Opcode) << hexString(Operands[0]) << " "
+    Stream << formatv("#{0:x2}: ", Opcode) << hexString(Operands[0]) << " "
            << hexString(Operands[1]) << "#";
     break;
   }
@@ -639,10 +639,10 @@ void LVLocation::print(LVLocations *Locations, raw_ostream &OS, bool Full) {
     // The coverage is dependent on the kind of location.
     std::string String;
     raw_string_ostream Stream(String);
-    Stream << format("%.2f%%", Percentage);
+    Stream << formatv("{0:F2}%", Percentage);
     if (!Location->getIsLocationSimple())
-      Stream << format(" (%d/%d)", Symbol->getCoverageFactor(),
-                       Symbol->getParentScope()->getCoverageFactor());
+      Stream << formatv(" ({0}/{1})", Symbol->getCoverageFactor(),
+                        Symbol->getParentScope()->getCoverageFactor());
     Symbol->printAttributes(OS, Full, "{Coverage} ", Symbol, StringRef(String),
                             /*UseQuotes=*/false,
                             /*PrintRef=*/false);

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVObject.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVObject.cpp
@@ -123,7 +123,7 @@ void LVObject::printAttributes(raw_ostream &OS, bool Full, StringRef Name,
   // Print the line.
   std::string TheLineNumber(Object.lineNumberAsString());
   std::string TheIndentation(Object.indentAsString());
-  OS << format(" %5s %s ", TheLineNumber.c_str(), TheIndentation.c_str());
+  OS << formatv(" {0,5} {1} ", TheLineNumber.c_str(), TheIndentation.c_str());
 
   OS << Name;
   if (PrintRef && options().getAttributeOffset())

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVRange.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVRange.cpp
@@ -13,6 +13,7 @@
 #include "llvm/DebugInfo/LogicalView/Core/LVRange.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVLocation.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVOptions.h"
+#include "llvm/Support/FormatVariadic.h"
 
 using namespace llvm;
 using namespace llvm::logicalview;
@@ -81,7 +82,7 @@ void LVRange::addEntry(LVScope *Scope) {
 
 // Get the scope associated with the input address.
 LVScope *LVRange::getEntry(LVAddress Address) const {
-  LLVM_DEBUG({ dbgs() << format("Searching: 0x%08x\nFound: ", Address); });
+  LLVM_DEBUG({ dbgs() << formatv("Searching: {0:x8}\nFound: ", Address); });
 
   LVScope *Target = nullptr;
   LVLevel TargetLevel = 0;
@@ -90,8 +91,9 @@ LVScope *LVRange::getEntry(LVAddress Address) const {
   for (LVRangesTree::find_iterator Iter = RangesTree.find(Address),
                                    End = RangesTree.find_end();
        Iter != End; ++Iter) {
-    LLVM_DEBUG(
-        { dbgs() << format("[0x%08x,0x%08x] ", Iter->left(), Iter->right()); });
+    LLVM_DEBUG({
+      dbgs() << formatv("[{0:x8},{1:x8}] ", Iter->left(), Iter->right());
+    });
     Scope = Iter->value();
     Level = Scope->getLevel();
     if (Level > TargetLevel) {
@@ -150,7 +152,7 @@ void LVRange::print(raw_ostream &OS, bool Full) const {
     Indentation = options().indentationSize();
     if (Indentation)
       OS << " ";
-    OS << format("[0x%08x,0x%08x] ", RangeEntry.lower(), RangeEntry.upper())
+    OS << formatv("[{0:x8},{1:x8}] ", RangeEntry.lower(), RangeEntry.upper())
        << formattedKind(Scope->kind()) << " " << formattedName(Scope->getName())
        << "\n";
   }

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVReader.cpp
@@ -70,22 +70,19 @@ bool checkIntegrityScopesTree(LVScope *Root) {
     });
 
     auto PrintIndex = [](unsigned Index) {
-      if (Index)
-        dbgs() << format("%8d: ", Index);
-      else
-        dbgs() << format("%8c: ", ' ');
+      dbgs() << formatv("{0,8}: ", Index ? Index : ' ');
     };
     auto PrintElement = [&](LVElement *Element, unsigned Index = 0) {
       PrintIndex(Index);
       std::string ElementName(Element->getName());
-      dbgs() << format("%15s ID=0x%08x '%s'\n", Element->kind(),
-                       Element->getID(), ElementName.c_str());
+      dbgs() << formatv("{0,15} ID={1:x8} '{2}'\n", Element->kind(),
+                        Element->getID(), ElementName.c_str());
     };
 
     std::string RootName(Root->getName());
     dbgs() << formatv("{0}\n", fmt_repeat('=', 72));
-    dbgs() << format("Root: '%s'\nDuplicated elements: %d\n", RootName.c_str(),
-                     Duplicate.size());
+    dbgs() << formatv("Root: '{0}'\nDuplicated elements: {1}\n",
+                      RootName.c_str(), Duplicate.size());
     dbgs() << formatv("{0}\n", fmt_repeat('=', 72));
 
     unsigned Index = 0;

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVScope.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVScope.cpp
@@ -1184,10 +1184,10 @@ void LVScopeArray::printExtra(raw_ostream &OS, bool Full) const {
 void LVScopeCompileUnit::addSize(LVScope *Scope, LVOffset Lower,
                                  LVOffset Upper) {
   LLVM_DEBUG({
-    dbgs() << format(
-        "CU [0x%08" PRIx64 "], Scope [0x%08" PRIx64 "], Range [0x%08" PRIx64
-        ":0x%08" PRIx64 "], Size = %" PRId64 "\n",
-        getOffset(), Scope->getOffset(), Lower, Upper, Upper - Lower);
+    dbgs() << formatv("CU [{0:x8}], Scope [{1:x8}], Range [{2:x8}"
+                      ":{3:x8}], Size = {4}\n",
+                      getOffset(), Scope->getOffset(), Lower, Upper,
+                      Upper - Lower);
   });
 
   // There is no need to check for a previous entry, as we are traversing the
@@ -1482,7 +1482,7 @@ void LVScopeCompileUnit::printWarnings(raw_ostream &OS, bool Full) const {
   if (options().getInternalTag() && getReader().isBinaryTypeELF()) {
     PrintHeader("Unsupported DWARF Tags");
     for (LVTagOffsetsMap::const_reference Entry : DebugTags) {
-      OS << format("\n0x%02x", (unsigned)Entry.first) << ", "
+      OS << formatv("\n{0:x2}", (unsigned)Entry.first) << ", "
          << dwarf::TagString(Entry.first) << "\n";
       unsigned Count = 0;
       for (const LVOffset &Offset : Entry.second)
@@ -1498,7 +1498,7 @@ void LVScopeCompileUnit::printWarnings(raw_ostream &OS, bool Full) const {
       // Symbol basic information.
       LVSymbol *Symbol = Entry.second;
       OS << hexSquareString(Entry.first) << " {Coverage} "
-         << format("%.2f%%", Symbol->getCoveragePercentage()) << " "
+         << formatv("{0:f2}%", Symbol->getCoveragePercentage()) << " "
          << formattedKind(Symbol->kind()) << " "
          << formattedName(Symbol->getName()) << "\n";
     }
@@ -1527,8 +1527,8 @@ void LVScopeCompileUnit::printWarnings(raw_ostream &OS, bool Full) const {
 void LVScopeCompileUnit::printTotals(raw_ostream &OS) const {
   OS << "\nTotals by lexical level:\n";
   for (size_t Index = 1; Index <= MaxSeenLevel; ++Index)
-    OS << format("[%03d]: %10d (%6.2f%%)\n", Index, Totals[Index].first,
-                 Totals[Index].second);
+    OS << formatv("[{0,0+3}]: {1,10} ({2,6:f2}%)\n", Index, Totals[Index].first,
+                  Totals[Index].second);
 }
 
 void LVScopeCompileUnit::printScopeSize(const LVScope *Scope, raw_ostream &OS) {
@@ -1540,7 +1540,7 @@ void LVScopeCompileUnit::printScopeSize(const LVScope *Scope, raw_ostream &OS) {
     // implementation-defined rounding inside printing functions.
     float Percentage =
         rint((float(Size) / CUContributionSize) * 100.0 * 100.0) / 100.0;
-    OS << format("%10" PRId64 " (%6.2f%%) : ", Size, Percentage);
+    OS << formatv("{0,10} ({1,6:f2}%) : ", Size, Percentage);
     Scope->print(OS);
 
     // Keep record of the total sizes at each lexical level.
@@ -1607,11 +1607,12 @@ void LVScopeCompileUnit::printSummary(raw_ostream &OS, const LVCounter &Counter,
                                       const char *Header) const {
   std::string Separator = std::string(29, '-');
   auto PrintSeparator = [&]() { OS << Separator << "\n"; };
+  const char *Fmt = "{0,-9}{1,9}  {2,9}\n";
   auto PrintHeadingRow = [&](const char *T, const char *U, const char *V) {
-    OS << format("%-9s%9s  %9s\n", T, U, V);
+    OS << formatv(Fmt, T, U, V);
   };
   auto PrintDataRow = [&](const char *T, unsigned U, unsigned V) {
-    OS << format("%-9s%9d  %9d\n", T, U, V);
+    OS << formatv(Fmt, T, U, V);
   };
 
   OS << "\n";

--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVBinaryReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVBinaryReader.cpp
@@ -496,8 +496,8 @@ Error LVBinaryReader::createInstructions(LVScope *Scope,
     dbgs() << "\nSectionIndex: " << format_decimal(SectionIndex, 3)
            << " Scope DIE: " << hexValue(Scope->getOffset()) << "\n"
            << "Address: " << hexValue(FirstAddress)
-           << format(" - Collected instructions lines: %d\n",
-                     Instructions.size());
+           << formatv(" - Collected instructions lines: {0}\n",
+                      Instructions.size());
     for (const LVLine *Line : Instructions)
       dbgs() << format_decimal(++Index, 5) << ": "
              << hexValue(Line->getOffset()) << ", (" << Line->getName()
@@ -584,7 +584,7 @@ void LVBinaryReader::processLines(LVLines *DebugLines,
   LLVM_DEBUG({
     size_t Index = 1;
     size_t PerLine = 4;
-    dbgs() << format("\nProcess debug lines: %d\n", DebugLines->size());
+    dbgs() << formatv("\nProcess debug lines: {0}\n", DebugLines->size());
     for (const LVLine *Line : *DebugLines) {
       dbgs() << format_decimal(Index, 5) << ": " << hexValue(Line->getOffset())
              << ", (" << Line->getLineNumber() << ")"
@@ -621,8 +621,8 @@ void LVBinaryReader::processLines(LVLines *DebugLines,
       size_t Index = 0;
       dbgs() << "\nSectionIndex: " << format_decimal(SectionIndex, 3)
              << " Scope DIE: " << hexValue(Scope->getOffset()) << "\n"
-             << format("Process instruction lines: %d\n",
-                       InstructionLines.size());
+             << formatv("Process instruction lines: {0}\n",
+                        InstructionLines.size());
       for (const LVLine *Line : InstructionLines)
         dbgs() << format_decimal(++Index, 5) << ": "
                << hexValue(Line->getOffset()) << ", (" << Line->getName()
@@ -649,7 +649,7 @@ void LVBinaryReader::processLines(LVLines *DebugLines,
             dbgs() << "Line " << (IsDebug ? "dbg:" : "ins:") << " ["
                    << hexValue(DebugAddress) << "]";
             if (IsDebug)
-              dbgs() << format(" %d", (*Iter)->getLineNumber());
+              dbgs() << formatv(" {0}", (*Iter)->getLineNumber());
             dbgs() << "\n";
           });
           // Instruction address before debug line.
@@ -657,7 +657,7 @@ void LVBinaryReader::processLines(LVLines *DebugLines,
             LLVM_DEBUG({
               dbgs() << "Inserted instruction address: "
                      << hexValue(InstructionAddress) << " before line: "
-                     << format("%d", (*Iter)->getLineNumber()) << " ["
+                     << formatv("{0}", (*Iter)->getLineNumber()) << " ["
                      << hexValue(DebugAddress) << "]\n";
             });
             Iter = DebugLines->insert(Iter, InstructionLine);
@@ -681,7 +681,7 @@ void LVBinaryReader::processLines(LVLines *DebugLines,
   }
 
   LLVM_DEBUG({
-    dbgs() << format("Lines after merge: %d\n", DebugLines->size());
+    dbgs() << formatv("Lines after merge: {0}\n", DebugLines->size());
     size_t Index = 0;
     for (const LVLine *Line : *DebugLines) {
       dbgs() << format_decimal(++Index, 5) << ": "
@@ -706,7 +706,7 @@ void LVBinaryReader::processLines(LVLines *DebugLines,
             size_t Index = 0;
             dbgs() << "\nSectionIndex: " << format_decimal(SectionIndex, 3)
                    << " Scope DIE: " << hexValue(Scope->getOffset()) << "\n"
-                   << format("Instruction lines: %d\n", Lines->size());
+                   << formatv("Instruction lines: {0}\n", Lines->size());
             for (const LVLine *Line : *Lines)
               dbgs() << format_decimal(++Index, 5) << ": "
                      << hexValue(Line->getOffset()) << ", (" << Line->getName()
@@ -901,7 +901,7 @@ void LVBinaryReader::includeInlineeLines(LVSectionIndex SectionIndex,
       for (const LVLine *Line : *InlineeLines)
         dbgs() << "[" << hexValue(Line->getAddress()) << "] "
                << Line->getLineNumber() << "\n";
-      dbgs() << format("Debug lines: %d\n", CULines.size());
+      dbgs() << formatv("Debug lines: {0}\n", CULines.size());
       for (const LVLine *Line : CULines)
         dbgs() << "Line address: " << hexValue(Line->getOffset()) << ", ("
                << Line->getLineNumber() << ")\n";
@@ -938,7 +938,7 @@ void LVBinaryReader::includeInlineeLines(LVSectionIndex SectionIndex,
   }
   LLVM_DEBUG({
     dbgs() << "Merged Inlined lines for: " << Function->getName() << "\n";
-    dbgs() << format("Debug lines: %d\n", CULines.size());
+    dbgs() << formatv("Debug lines: {0}\n", CULines.size());
     for (const LVLine *Line : CULines)
       dbgs() << "Line address: " << hexValue(Line->getOffset()) << ", ("
              << Line->getLineNumber() << ")\n";

--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVCodeViewVisitor.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVCodeViewVisitor.cpp
@@ -3456,7 +3456,7 @@ void LVLogicalVisitor::printRecords(raw_ostream &OS) const {
         OS << "\n";
       }
     };
-    OS << format("%20s", Name.str().c_str());
+    OS << formatv("{0,20}", Name.str().c_str());
     NewLine();
   };
 

--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
@@ -210,7 +210,7 @@ void LVDWARFReader::processOneAttribute(const DWARFDie &Die,
           FoundLowPC = false;
           // We are dealing with an index into the .debug_addr section.
           LLVM_DEBUG({
-            dbgs() << format("indexed (%8.8x) address = ", (uint32_t)UValue);
+            dbgs() << formatv("indexed ({0:x-8}) address = ", (uint32_t)UValue);
           });
         }
       }
@@ -263,8 +263,8 @@ void LVDWARFReader::processOneAttribute(const DWARFDie &Die,
       if (!RangesOrError) {
         LLVM_DEBUG({
           std::string TheError(toString(RangesOrError.takeError()));
-          dbgs() << format("error decoding address ranges = ",
-                           TheError.c_str());
+          dbgs() << formatv("error decoding address ranges = {0}",
+                            TheError.c_str());
         });
         consumeError(RangesOrError.takeError());
         break;


### PR DESCRIPTION
This addresses all use-cases in `llvm/lib/DebugInfo/LogicalView/` and `llvm/lib/DebugInfo/GSYM`.

See also https://github.com/llvm/llvm-project/pull/191308 for a similar change with test examples that prove some of the formatting I've done here actually works.

This relates to #35980.