### PR TITLE
Load AST files as binary on z/OS

### DIFF
--- a/clang/include/clang/Basic/FileManager.h
+++ b/clang/include/clang/Basic/FileManager.h
@@ -207,9 +207,10 @@ public:
   /// Get a FileEntryRef if it exists, without doing anything on error.
   OptionalFileEntryRef getOptionalFileRef(StringRef Filename,
                                           bool OpenFile = false,
-                                          bool CacheFailure = true) {
+                                          bool CacheFailure = true,
+                                          bool IsText = true) {
     return llvm::expectedToOptional(
-        getFileRef(Filename, OpenFile, CacheFailure));
+        getFileRef(Filename, OpenFile, CacheFailure, IsText));
   }
 
   /// Returns the current file system options

--- a/clang/lib/Basic/Module.cpp
+++ b/clang/lib/Basic/Module.cpp
@@ -45,7 +45,8 @@ ModuleFileName::makeKey(FileManager &FileMgr) const {
       return ModuleFileKey(*ModuleCache, ImplicitModuleSuffix);
   } else {
     if (auto ModuleFile = FileMgr.getOptionalFileRef(Path, /*OpenFile=*/true,
-                                                     /*CacheFailure=*/false))
+                                                     /*CacheFailure=*/false,
+                                                     /*IsText=*/false))
       return ModuleFileKey(*ModuleFile);
   }
 

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -2873,9 +2873,7 @@ InputFile ASTReader::getInputFile(ModuleFile &F, unsigned ID, bool Complain) {
     Overridden = false;
   }
 
-  auto File = FileMgr.getOptionalFileRef(*Filename, /*OpenFile=*/false,
-                                         /*CacheFailure=*/true,
-                                         /*IsText=*/false);
+  auto File = FileMgr.getOptionalFileRef(*Filename, /*OpenFile=*/false);
 
   // For an overridden file, create a virtual file with the stored
   // size/timestamp.
@@ -2935,11 +2933,7 @@ InputFile ASTReader::getInputFile(ModuleFile &F, unsigned ID, bool Complain) {
       return OriginalChange;
 
     auto MemBuffOrError =
-        FileMgr.getBufferForFile(*File,
-                                 /*IsVolatile=*/false,
-                                 /*RequiresNullTerminator=*/false,
-                                 /*MaybeLimit=*/std::nullopt,
-                                 /*IsText=*/false);
+        FileMgr.getBufferForFile(*File);
     if (!MemBuffOrError) {
       if (!Complain)
         return OriginalChange;

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -2932,8 +2932,7 @@ InputFile ASTReader::getInputFile(ModuleFile &F, unsigned ID, bool Complain) {
     if (StoredContentHash == 0)
       return OriginalChange;
 
-    auto MemBuffOrError =
-        FileMgr.getBufferForFile(*File);
+    auto MemBuffOrError = FileMgr.getBufferForFile(*File);
     if (!MemBuffOrError) {
       if (!Complain)
         return OriginalChange;

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -2873,7 +2873,9 @@ InputFile ASTReader::getInputFile(ModuleFile &F, unsigned ID, bool Complain) {
     Overridden = false;
   }
 
-  auto File = FileMgr.getOptionalFileRef(*Filename, /*OpenFile=*/false);
+  auto File = FileMgr.getOptionalFileRef(*Filename, /*OpenFile=*/false,
+                                         /*CacheFailure=*/true,
+                                         /*IsText=*/false);
 
   // For an overridden file, create a virtual file with the stored
   // size/timestamp.
@@ -2932,7 +2934,12 @@ InputFile ASTReader::getInputFile(ModuleFile &F, unsigned ID, bool Complain) {
     if (StoredContentHash == 0)
       return OriginalChange;
 
-    auto MemBuffOrError = FileMgr.getBufferForFile(*File);
+    auto MemBuffOrError =
+        FileMgr.getBufferForFile(*File,
+                                 /*IsVolatile=*/false,
+                                 /*RequiresNullTerminator=*/false,
+                                 /*MaybeLimit=*/std::nullopt,
+                                 /*IsText=*/false);
     if (!MemBuffOrError) {
       if (!Complain)
         return OriginalChange;
@@ -5948,13 +5955,21 @@ bool ASTReader::readASTFileControlBlock(
 
     // FIXME: This allows use of the VFS; we do not allow use of the
     // VFS when actually loading a module.
-    auto Entry =
-        Filename == "-" ? FileMgr.getSTDIN() : FileMgr.getFileRef(Filename);
+    auto Entry = Filename == "-" ? FileMgr.getSTDIN()
+                                 : FileMgr.getFileRef(Filename,
+                                                      /*OpenFile=*/false,
+                                                      /*CacheFailure=*/true,
+                                                      /*IsText=*/false);
     if (!Entry) {
       llvm::consumeError(Entry.takeError());
       return true;
     }
-    auto BufferOrErr = FileMgr.getBufferForFile(*Entry);
+    auto BufferOrErr =
+        FileMgr.getBufferForFile(*Entry,
+                                 /*IsVolatile=*/false,
+                                 /*RequiresNullTerminator=*/false,
+                                 /*MaybeLimit=*/std::nullopt,
+                                 /*IsText=*/false);
     if (!BufferOrErr)
       return true;
     OwnedBuffer = std::move(*BufferOrErr);

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -61,7 +61,8 @@ ModuleFile *ModuleManager::lookup(ModuleFileKey Key) const {
 std::unique_ptr<llvm::MemoryBuffer>
 ModuleManager::lookupBuffer(StringRef Name) {
   auto Entry = FileMgr.getOptionalFileRef(Name, /*OpenFile=*/false,
-                                          /*CacheFailure=*/false);
+                                          /*CacheFailure=*/false,
+                                          /*IsText=*/false);
   if (!Entry)
     return nullptr;
   return std::move(InMemoryBuffers[*Entry]);
@@ -175,7 +176,8 @@ ModuleManager::AddModuleResult ModuleManager::addModule(
       // should store this directly in the in-memory module cache.
       OptionalFileEntryRef Entry =
           FileMgr.getOptionalFileRef(FileName, /*OpenFile=*/true,
-                                     /*CacheFailure=*/false);
+                                     /*CacheFailure=*/false,
+                                     /*IsText=*/false);
       if (!Entry) {
         ErrorStr = "module file not found";
         return Missing;
@@ -200,7 +202,8 @@ ModuleManager::AddModuleResult ModuleManager::addModule(
           FileName == StringRef("-")
               ? FileMgr.getSTDIN()
               : FileMgr.getFileRef(FileName, /*OpenFile=*/true,
-                                   /*CacheFailure=*/false);
+                                   /*CacheFailure=*/false,
+                                   /*IsText=*/false);
       if (!Entry)
         return Entry.takeError();
 
@@ -211,7 +214,9 @@ ModuleManager::AddModuleResult ModuleManager::addModule(
       // this allows the file to still be mmapped.
       return llvm::errorOrToExpected(
           FileMgr.getBufferForFile(*Entry, /*IsVolatile=*/false,
-                                   /*RequiresNullTerminator=*/false));
+                                   /*RequiresNullTerminator=*/false,
+                                   /*MaybeLimit=*/std::nullopt,
+                                   /*IsText=*/false));
     }();
 
     if (!Buf) {


### PR DESCRIPTION
The ast files need to be loaded as binary on z/OS to avoid translation.  Add the `IsText=false` option to all of the relevant file open calls.