### PR TITLE
[bolt] Remove unused argument of DataExtractor constructor (NFC)

### DIFF
--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2128,8 +2128,7 @@ ArrayRef<uint8_t> BinaryContext::extractData(uint64_t Address,
 
 void BinaryContext::printData(raw_ostream &OS, ArrayRef<uint8_t> Data,
                               uint64_t Offset) const {
-  DataExtractor DE(Data, AsmInfo->isLittleEndian(),
-                   AsmInfo->getCodePointerSize());
+  DataExtractor DE(Data, AsmInfo->isLittleEndian());
   uint64_t DataOffset = 0;
   while (DataOffset + 4 <= Data.size()) {
     OS << format("    %08" PRIx64 ": \t.word\t0x", Offset + DataOffset);
@@ -2425,8 +2424,7 @@ ErrorOr<uint64_t> BinaryContext::getUnsignedValueAtAddress(uint64_t Address,
   if (Section->isVirtual())
     return 0;
 
-  DataExtractor DE(Section->getContents(), AsmInfo->isLittleEndian(),
-                   AsmInfo->getCodePointerSize());
+  DataExtractor DE(Section->getContents(), AsmInfo->isLittleEndian());
   auto ValueOffset = static_cast<uint64_t>(Address - Section->getAddress());
   return DE.getUnsigned(&ValueOffset, Size);
 }
@@ -2440,8 +2438,7 @@ ErrorOr<int64_t> BinaryContext::getSignedValueAtAddress(uint64_t Address,
   if (Section->isVirtual())
     return 0;
 
-  DataExtractor DE(Section->getContents(), AsmInfo->isLittleEndian(),
-                   AsmInfo->getCodePointerSize());
+  DataExtractor DE(Section->getContents(), AsmInfo->isLittleEndian());
   auto ValueOffset = static_cast<uint64_t>(Address - Section->getAddress());
   return DE.getSigned(&ValueOffset, Size);
 }

--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -140,10 +140,7 @@ void DIEBuilder::updateReferences() {
   // Handling references in location expressions.
   for (LocWithReference &LocExpr : getState().LocWithReferencesToProcess) {
     SmallVector<uint8_t, 32> Buffer;
-    DataExtractor Data(StringRef((const char *)LocExpr.BlockData.data(),
-                                 LocExpr.BlockData.size()),
-                       LocExpr.U.isLittleEndian(),
-                       LocExpr.U.getAddressByteSize());
+    DataExtractor Data(LocExpr.BlockData, LocExpr.U.isLittleEndian());
     DWARFExpression Expr(Data, LocExpr.U.getAddressByteSize(),
                          LocExpr.U.getFormParams().Format);
     cloneExpression(Data, Expr, LocExpr.U, Buffer, CloneExpressionStage::PATCH);
@@ -794,8 +791,7 @@ void DIEBuilder::cloneBlockAttribute(
   if (DWARFAttribute::mayHaveLocationExpr(AttrSpec.Attr) &&
       (Val.isFormClass(DWARFFormValue::FC_Block) ||
        Val.isFormClass(DWARFFormValue::FC_Exprloc))) {
-    DataExtractor Data(StringRef((const char *)Bytes.data(), Bytes.size()),
-                       U.isLittleEndian(), U.getAddressByteSize());
+    DataExtractor Data(Bytes, U.isLittleEndian());
     DWARFExpression Expr(Data, U.getAddressByteSize(),
                          U.getFormParams().Format);
     if (cloneExpression(Data, Expr, U, Buffer, CloneExpressionStage::INIT))

--- a/bolt/lib/Core/DebugData.cpp
+++ b/bolt/lib/Core/DebugData.cpp
@@ -1174,7 +1174,7 @@ static void parseAndPopulateDebugLineStr(BinarySection &LineStrSection,
                                          MCDwarfLineStr &LineStr,
                                          BinaryContext &BC) {
   DataExtractor StrData(LineStrSection.getContents(),
-                        BC.DwCtx->isLittleEndian(), 0);
+                        BC.DwCtx->isLittleEndian());
   uint64_t Offset = 0;
   while (StrData.isValidOffset(Offset)) {
     const uint64_t StrOffset = Offset;

--- a/bolt/lib/Core/DebugNames.cpp
+++ b/bolt/lib/Core/DebugNames.cpp
@@ -38,7 +38,7 @@ DWARF5AcceleratorTable::DWARF5AcceleratorTable(
   // for the .debug_names contributions they are in .debug_str section.
   if (BC.getNumDWOCUs()) {
     DataExtractor StrData(BC.DwCtx->getDWARFObj().getStrSection(),
-                          BC.DwCtx->isLittleEndian(), 0);
+                          BC.DwCtx->isLittleEndian());
     uint64_t Offset = 0;
     uint64_t StrOffset = 0;
     while (StrData.isValidOffset(Offset)) {
@@ -136,9 +136,7 @@ static bool shouldIncludeVariable(const DWARFUnit &Unit, const DIE &Die) {
     constructVect(LocAttrInfo.getDIELoc().values());
   else
     constructVect(LocAttrInfo.getDIEBlock().values());
-  ArrayRef<uint8_t> Expr = ArrayRef<uint8_t>(Sblock);
-  DataExtractor Data(StringRef((const char *)Expr.data(), Expr.size()),
-                     Unit.getContext().isLittleEndian(), 0);
+  DataExtractor Data(Sblock, Unit.getContext().isLittleEndian());
   DWARFExpression LocExpr(Data, Unit.getAddressByteSize(),
                           Unit.getFormParams().Format);
   for (const DWARFExpression::Operation &Expr : LocExpr)

--- a/bolt/lib/Profile/BoltAddressTranslation.cpp
+++ b/bolt/lib/Profile/BoltAddressTranslation.cpp
@@ -292,7 +292,7 @@ void BoltAddressTranslation::writeMaps(uint64_t &PrevAddress, raw_ostream &OS) {
 }
 
 std::error_code BoltAddressTranslation::parse(raw_ostream &OS, StringRef Buf) {
-  DataExtractor DE = DataExtractor(Buf, true, 8);
+  DataExtractor DE = DataExtractor(Buf, true);
   uint64_t Offset = 0;
   if (Buf.size() < 12)
     return make_error_code(llvm::errc::io_error);

--- a/bolt/lib/Rewrite/BuildIDRewriter.cpp
+++ b/bolt/lib/Rewrite/BuildIDRewriter.cpp
@@ -56,8 +56,7 @@ Error BuildIDRewriter::sectionInitializer() {
       continue;
 
     StringRef Buf = NoteSection.getContents();
-    DataExtractor DE = DataExtractor(Buf, BC.AsmInfo->isLittleEndian(),
-                                     BC.AsmInfo->getCodePointerSize());
+    DataExtractor DE = DataExtractor(Buf, BC.AsmInfo->isLittleEndian());
     DataExtractor::Cursor Cursor(0);
     while (Cursor && !DE.eof(Cursor)) {
       const uint32_t NameSz = DE.getU32(Cursor);

--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -1139,10 +1139,7 @@ void DWARFRewriter::updateUnitDebugInfo(
                   const_cast<DIEBlock *>(&LocAttrInfo.getDIEBlock());
               AttrLocValList = static_cast<DIEValueList *>(BlockAttr);
             }
-            ArrayRef<uint8_t> Expr = ArrayRef<uint8_t>(Sblock);
-            DataExtractor Data(
-                StringRef((const char *)Expr.data(), Expr.size()),
-                Unit.getContext().isLittleEndian(), 0);
+            DataExtractor Data(Sblock, Unit.getContext().isLittleEndian());
             DWARFExpression LocExpr(Data, Unit.getAddressByteSize(),
                                     Unit.getFormParams().Format);
             uint32_t PrevOffset = 0;
@@ -1745,7 +1742,7 @@ static void UpdateStrAndStrOffsets(StringRef StrDWOContent,
   const uint64_t NumOffsets =
       (StrOffsetsContent.size() - HeaderOffset) / SizeOfOffset;
 
-  DataExtractor Extractor(StrOffsetsContent, IsLittleEndian, 0);
+  DataExtractor Extractor(StrOffsetsContent, IsLittleEndian);
   uint64_t ExtractionOffset = HeaderOffset;
 
   using StringFragment = DWARFUnitIndex::Entry::SectionContribution;

--- a/bolt/lib/Rewrite/GNUPropertyRewriter.cpp
+++ b/bolt/lib/Rewrite/GNUPropertyRewriter.cpp
@@ -41,8 +41,7 @@ Error GNUPropertyRewriter::sectionInitializer() {
   uint32_t FeaturesAcc = 0;
 
   StringRef Buf = Sec->getContents();
-  DataExtractor DE(Buf, BC.AsmInfo->isLittleEndian(),
-                   BC.AsmInfo->getCodePointerSize());
+  DataExtractor DE(Buf, BC.AsmInfo->isLittleEndian());
   DataExtractor::Cursor Cursor(0);
   while (Cursor && !DE.eof(Cursor)) {
     const uint32_t NameSz = DE.getU32(Cursor);

--- a/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
+++ b/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
@@ -159,10 +159,8 @@ class AddressExtractor : public DataExtractor {
   uint64_t DataAddress;
 
 public:
-  AddressExtractor(StringRef Data, uint64_t DataAddress, bool IsLittleEndian,
-                   uint8_t AddressSize)
-      : DataExtractor(Data, IsLittleEndian, AddressSize),
-        DataAddress(DataAddress) {}
+  AddressExtractor(StringRef Data, uint64_t DataAddress, bool IsLittleEndian)
+      : DataExtractor(Data, IsLittleEndian), DataAddress(DataAddress) {}
 
   /// Extract 32-bit PC-relative address/pointer.
   uint64_t getPCRelAddress32(Cursor &C) {
@@ -515,8 +513,7 @@ Error LinuxKernelRewriter::processSMPLocks() {
                              "bad size of .smp_locks section");
 
   AddressExtractor AE(SMPLocksSection->getContents(), SectionAddress,
-                      BC.AsmInfo->isLittleEndian(),
-                      BC.AsmInfo->getCodePointerSize());
+                      BC.AsmInfo->isLittleEndian());
   AddressExtractor::Cursor Cursor(0);
   while (Cursor && Cursor.tell() < SectionSize) {
     const uint64_t Offset = Cursor.tell();
@@ -591,11 +588,10 @@ Error LinuxKernelRewriter::readORCTables() {
                              "ORC entries number mismatch detected");
 
   DataExtractor OrcDE(ORCUnwindSection->getContents(),
-                      BC.AsmInfo->isLittleEndian(),
-                      BC.AsmInfo->getCodePointerSize());
-  AddressExtractor IPAE(
-      ORCUnwindIPSection->getContents(), ORCUnwindIPSection->getAddress(),
-      BC.AsmInfo->isLittleEndian(), BC.AsmInfo->getCodePointerSize());
+                      BC.AsmInfo->isLittleEndian());
+  AddressExtractor IPAE(ORCUnwindIPSection->getContents(),
+                        ORCUnwindIPSection->getAddress(),
+                        BC.AsmInfo->isLittleEndian());
   DataExtractor::Cursor ORCCursor(0);
   DataExtractor::Cursor IPCursor(0);
   uint64_t PrevIP = 0;
@@ -944,9 +940,9 @@ Error LinuxKernelRewriter::validateORCTables() {
   if (!ORCUnwindIPSection)
     return Error::success();
 
-  AddressExtractor IPAE(
-      ORCUnwindIPSection->getOutputContents(), ORCUnwindIPSection->getAddress(),
-      BC.AsmInfo->isLittleEndian(), BC.AsmInfo->getCodePointerSize());
+  AddressExtractor IPAE(ORCUnwindIPSection->getOutputContents(),
+                        ORCUnwindIPSection->getAddress(),
+                        BC.AsmInfo->isLittleEndian());
   AddressExtractor::Cursor IPCursor(0);
   uint64_t PrevIP = 0;
   for (uint32_t Index = 0; Index < NumORCEntries; ++Index) {
@@ -1003,8 +999,7 @@ Error LinuxKernelRewriter::readStaticCalls() {
 
   const uint64_t SectionAddress = StaticCallSection->getAddress();
   AddressExtractor AE(StaticCallSection->getContents(), SectionAddress,
-                      BC.AsmInfo->isLittleEndian(),
-                      BC.AsmInfo->getCodePointerSize());
+                      BC.AsmInfo->isLittleEndian());
   AddressExtractor::Cursor Cursor(StaticCallTableAddress - SectionAddress);
   uint32_t EntryID = 0;
   while (Cursor && Cursor.tell() < Stop->getAddress() - SectionAddress) {
@@ -1111,9 +1106,9 @@ Error LinuxKernelRewriter::readExceptionTable() {
     return createStringError(errc::executable_format_error,
                              "exception table size error");
 
-  AddressExtractor AE(
-      ExceptionsSection->getContents(), ExceptionsSection->getAddress(),
-      BC.AsmInfo->isLittleEndian(), BC.AsmInfo->getCodePointerSize());
+  AddressExtractor AE(ExceptionsSection->getContents(),
+                      ExceptionsSection->getAddress(),
+                      BC.AsmInfo->isLittleEndian());
   AddressExtractor::Cursor Cursor(0);
   uint32_t EntryID = 0;
   while (Cursor && Cursor.tell() < ExceptionsSection->getSize()) {
@@ -1216,8 +1211,7 @@ Error LinuxKernelRewriter::readParaInstructions() {
     return Error::success();
 
   DataExtractor DE(ParavirtualPatchSection->getContents(),
-                   BC.AsmInfo->isLittleEndian(),
-                   BC.AsmInfo->getCodePointerSize());
+                   BC.AsmInfo->isLittleEndian());
   uint32_t EntryID = 0;
   DataExtractor::Cursor Cursor(0);
   while (Cursor && !DE.eof(Cursor)) {
@@ -1316,9 +1310,9 @@ Error LinuxKernelRewriter::readBugTable() {
     return createStringError(errc::executable_format_error,
                              "bug table size error");
 
-  AddressExtractor AE(
-      BugTableSection->getContents(), BugTableSection->getAddress(),
-      BC.AsmInfo->isLittleEndian(), BC.AsmInfo->getCodePointerSize());
+  AddressExtractor AE(BugTableSection->getContents(),
+                      BugTableSection->getAddress(),
+                      BC.AsmInfo->isLittleEndian());
   AddressExtractor::Cursor Cursor(0);
   uint32_t EntryID = 0;
   while (Cursor && Cursor.tell() < BugTableSection->getSize()) {
@@ -1482,9 +1476,9 @@ Error LinuxKernelRewriter::readAltInstructions() {
 Error LinuxKernelRewriter::tryReadAltInstructions(uint32_t AltInstFeatureSize,
                                                   bool AltInstHasPadLen,
                                                   bool ParseOnly) {
-  AddressExtractor AE(
-      AltInstrSection->getContents(), AltInstrSection->getAddress(),
-      BC.AsmInfo->isLittleEndian(), BC.AsmInfo->getCodePointerSize());
+  AddressExtractor AE(AltInstrSection->getContents(),
+                      AltInstrSection->getAddress(),
+                      BC.AsmInfo->isLittleEndian());
   AddressExtractor::Cursor Cursor(0);
   uint64_t EntryID = 0;
   while (Cursor && !AE.eof(Cursor)) {
@@ -1614,9 +1608,9 @@ Error LinuxKernelRewriter::readPCIFixupTable() {
     return createStringError(errc::executable_format_error,
                              "PCI fixup table size error");
 
-  AddressExtractor AE(
-      PCIFixupSection->getContents(), PCIFixupSection->getAddress(),
-      BC.AsmInfo->isLittleEndian(), BC.AsmInfo->getCodePointerSize());
+  AddressExtractor AE(PCIFixupSection->getContents(),
+                      PCIFixupSection->getAddress(),
+                      BC.AsmInfo->isLittleEndian());
   AddressExtractor::Cursor Cursor(0);
   uint64_t EntryID = 0;
   while (Cursor && !AE.eof(Cursor)) {
@@ -1730,8 +1724,7 @@ Error LinuxKernelRewriter::readStaticKeysJumpTable() {
 
   const uint64_t SectionAddress = StaticKeysJumpSection->getAddress();
   AddressExtractor AE(StaticKeysJumpSection->getContents(), SectionAddress,
-                      BC.AsmInfo->isLittleEndian(),
-                      BC.AsmInfo->getCodePointerSize());
+                      BC.AsmInfo->isLittleEndian());
   AddressExtractor::Cursor Cursor(StaticKeysJumpTableAddress - SectionAddress);
   uint32_t EntryID = 0;
   while (Cursor && Cursor.tell() < Stop->getAddress() - SectionAddress) {
@@ -1932,8 +1925,7 @@ Error LinuxKernelRewriter::updateStaticKeysJumpTablePostEmit() {
 
   const uint64_t SectionAddress = StaticKeysJumpSection->getAddress();
   AddressExtractor AE(StaticKeysJumpSection->getOutputContents(),
-                      SectionAddress, BC.AsmInfo->isLittleEndian(),
-                      BC.AsmInfo->getCodePointerSize());
+                      SectionAddress, BC.AsmInfo->isLittleEndian());
   AddressExtractor::Cursor Cursor(StaticKeysJumpTableAddress - SectionAddress);
   const BinaryData *Stop = BC.getBinaryDataByName("__stop___jump_table");
   uint32_t EntryID = 0;

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2800,8 +2800,7 @@ void RewriteInstance::readDynamicRelrRelocations(BinarySection &Section) {
   auto ExtractAddendValue = [&](uint64_t Address) -> uint64_t {
     ErrorOr<BinarySection &> Section = BC->getSectionForAddress(Address);
     assert(Section && "cannot get section for data address from RELR");
-    DataExtractor DE = DataExtractor(Section->getContents(),
-                                     BC->AsmInfo->isLittleEndian(), PSize);
+    DataExtractor DE(Section->getContents(), BC->AsmInfo->isLittleEndian());
     uint64_t Offset = Address - Section->getAddress();
     return DE.getUnsigned(&Offset, PSize);
   };
@@ -2814,8 +2813,7 @@ void RewriteInstance::readDynamicRelrRelocations(BinarySection &Section) {
     BC->addDynamicRelocation(Address, nullptr, RType, Addend);
   };
 
-  DataExtractor DE = DataExtractor(Section.getContents(),
-                                   BC->AsmInfo->isLittleEndian(), PSize);
+  DataExtractor DE(Section.getContents(), BC->AsmInfo->isLittleEndian());
   uint64_t Offset = 0, Address = 0;
   uint64_t RelrCount = DynamicRelrSize / DynamicRelrEntrySize;
   while (RelrCount--) {

--- a/bolt/lib/Rewrite/SDTRewriter.cpp
+++ b/bolt/lib/Rewrite/SDTRewriter.cpp
@@ -68,8 +68,7 @@ void SDTRewriter::readSection() {
     return;
 
   StringRef Buf = SDTSection->getContents();
-  DataExtractor DE = DataExtractor(Buf, BC.AsmInfo->isLittleEndian(),
-                                   BC.AsmInfo->getCodePointerSize());
+  DataExtractor DE = DataExtractor(Buf, BC.AsmInfo->isLittleEndian());
   uint64_t Offset = 0;
 
   while (DE.isValidOffset(Offset)) {

--- a/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
+++ b/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
@@ -1444,7 +1444,7 @@ public:
     assert(Offset + I.DataSize <= ConstantData.size() &&
            "invalid offset for given constant data");
     int64_t ImmVal =
-        DataExtractor(ConstantData, true, 8).getSigned(&Offset, I.DataSize);
+        DataExtractor(ConstantData, true).getSigned(&Offset, I.DataSize);
 
     // Compute the new opcode.
     unsigned NewOpcode = 0;


### PR DESCRIPTION
`AddressSize` parameter is not used by `DataExtractor` and will be removed in the future. See #190519 for more context.

I took the liberty of switching from using the `StringRef` constructor overload to `ArrayRef` where appropriate.
