### PR TITLE
Mark tests as unsupported on z/OS

### DIFF
--- a/clang/test/CodeGen/2006-01-23-FileScopeAsm.c
+++ b/clang/test/CodeGen/2006-01-23-FileScopeAsm.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 %s -emit-llvm -o - | FileCheck %s
 // UNSUPPORTED: target={{.*}}-zos{{.*}}
+// RUN: %clang_cc1 %s -emit-llvm -o - | FileCheck %s
 
 // CHECK: module asm "foo1"
 __asm__ ("foo1");

--- a/clang/test/CodeGen/2006-01-23-FileScopeAsm.c
+++ b/clang/test/CodeGen/2006-01-23-FileScopeAsm.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 %s -emit-llvm -o - | FileCheck %s
+// UNSUPPORTED: target={{.*}}-zos{{.*}}
 
 // CHECK: module asm "foo1"
 __asm__ ("foo1");

--- a/clang/test/CodeGen/asm_incbin.c
+++ b/clang/test/CodeGen/asm_incbin.c
@@ -1,3 +1,4 @@
+// UNSUPPORTED: target={{.*}}-zos{{.*}}
 // RUN: split-file %s %t
 //--- foo.h
 //--- tu.c

--- a/clang/test/Sema/warn-lifetime-safety-noescape.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-noescape.cpp
@@ -133,7 +133,6 @@ void escape_through_static_local(int *data [[clang::noescape]]) { // expected-wa
   static_local = data;
 }
 
-#if __has_feature(cxx_thread_local)
 thread_local int *thread_local_storage; // expected-note {{escapes to this global storage}}
 
 void escape_through_thread_local(int *data [[clang::noescape]]) { // expected-warning {{parameter is marked [[clang::noescape]] but escapes}}
@@ -142,7 +141,6 @@ void escape_through_thread_local(int *data [[clang::noescape]]) { // expected-wa
   // undesired behavior in most cases.
   thread_local_storage = data;
 }
-#endif
 
 struct ObjConsumer {
   void escape_through_member(const MyObj& in [[clang::noescape]]) { // expected-warning {{parameter is marked [[clang::noescape]] but escapes}}

--- a/clang/test/Sema/warn-lifetime-safety-noescape.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-noescape.cpp
@@ -133,6 +133,7 @@ void escape_through_static_local(int *data [[clang::noescape]]) { // expected-wa
   static_local = data;
 }
 
+#if __has_feature(cxx_thread_local)
 thread_local int *thread_local_storage; // expected-note {{escapes to this global storage}}
 
 void escape_through_thread_local(int *data [[clang::noescape]]) { // expected-warning {{parameter is marked [[clang::noescape]] but escapes}}
@@ -141,6 +142,7 @@ void escape_through_thread_local(int *data [[clang::noescape]]) { // expected-wa
   // undesired behavior in most cases.
   thread_local_storage = data;
 }
+#endif
 
 struct ObjConsumer {
   void escape_through_member(const MyObj& in [[clang::noescape]]) { // expected-warning {{parameter is marked [[clang::noescape]] but escapes}}


### PR DESCRIPTION
z/OS has a platform specific requirement to not allow asm statements at file scope.  These tests generate that message rather than the expected IR.  Mark the tests as unsupported on z/OS.