### PR TITLE
[clang][Driver][BareMetal] Add profile library to the command line when needed

### DIFF
--- a/clang/lib/Driver/ToolChains/BareMetal.cpp
+++ b/clang/lib/Driver/ToolChains/BareMetal.cpp
@@ -605,6 +605,7 @@ void baremetal::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                   D.getLTOMode() == LTOK_Thin);
 
   AddLinkerInputs(TC, Inputs, Args, CmdArgs, JA);
+  TC.addProfileRTLibs(Args, CmdArgs);
 
   if (TC.ShouldLinkCXXStdlib(Args)) {
     bool OnlyLibstdcxxStatic = Args.hasArg(options::OPT_static_libstdcxx) &&

--- a/clang/test/Driver/baremetal.cpp
+++ b/clang/test/Driver/baremetal.cpp
@@ -176,6 +176,18 @@
 // RUN:   | FileCheck %s --check-prefix=CHECK-RTLIB-GCC
 // CHECK-RTLIB-GCC: -lgcc
 
+// RUN: %clang -### --target=arm-none-eabi -rtlib=compiler-rt \
+// RUN:   -fprofile-instr-generate %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-PROFILE
+// CHECK-PROFILE: "{{[^"]*}}libclang_rt.profile.a"
+
+// RUN: %clang -### --target=arm-none-eabi -nostdlib -rtlib=compiler-rt \
+// RUN:   -fprofile-instr-generate %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-PROFILE-NOSTDLIB
+// CHECK-PROFILE-NOSTDLIB: "{{[^"]*}}libclang_rt.profile.a"
+// CHECK-PROFILE-NOSTDLIB-NOT: "-lc"
+// CHECK-PROFILE-NOSTDLIB-NOT: "{{[^"]*}}libclang_rt.builtins.a"
+
 // RUN: %clang -### --target=arm-none-eabi -nolibc -rtlib=compiler-rt %s 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=CHECK-NOLIBC
 // CHECK-NOLIBC-NOT: "-lc"


### PR DESCRIPTION
Now that libclang_rt.profile.a supports bare-metal targets, follow other drivers and add libclang_rt.profile.a in the BareMetal driver to the command line automatically when needed, e.g. when -fprofile-instr-generate is provided.