### PR TITLE
[lldb] Fix tests on Linux on Arm (32-bit) after #181071

### DIFF
--- a/lldb/test/API/functionalities/scripted_frame_provider/pass_through_prefix/TestFrameProviderPassThroughPrefix.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/pass_through_prefix/TestFrameProviderPassThroughPrefix.py
@@ -24,6 +24,7 @@ class FrameProviderPassThroughPrefixTestCase(TestBase):
         TestBase.setUp(self)
         self.source = "main.c"
 
+    @expectedFailureAll(oslist=["linux"], archs=["arm$"], bugnumber="github.com/llvm/llvm-project/issues/191859")
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
     def test_pass_through_with_prefix(self):
         """

--- a/lldb/test/API/functionalities/scripted_frame_provider/pass_through_prefix/TestFrameProviderPassThroughPrefix.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/pass_through_prefix/TestFrameProviderPassThroughPrefix.py
@@ -24,7 +24,11 @@ class FrameProviderPassThroughPrefixTestCase(TestBase):
         TestBase.setUp(self)
         self.source = "main.c"
 
-    @expectedFailureAll(oslist=["linux"], archs=["arm$"], bugnumber="github.com/llvm/llvm-project/issues/191859")
+    @expectedFailureAll(
+        oslist=["linux"],
+        archs=["arm$"],
+        bugnumber="github.com/llvm/llvm-project/issues/191859",
+    )
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
     def test_pass_through_with_prefix(self):
         """

--- a/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/TestFrameProviderThreadFilter.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/TestFrameProviderThreadFilter.py
@@ -59,6 +59,7 @@ class FrameProviderThreadFilterTestCase(TestBase):
             )
             self.assertTrue(error.Success(), f"Should register {cls}: {error}")
 
+    @skipIf(oslist=["linux"], archs=["arm$"], bugnumber="github.com/llvm/llvm-project/issues/191855")
     @skipIf(oslist=["windows"], bugnumber="github.com/llvm/llvm-project/issues/191222")
     def test_bt_provider_star_with_thread_filter(self):
         """

--- a/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/TestFrameProviderThreadFilter.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/TestFrameProviderThreadFilter.py
@@ -59,7 +59,11 @@ class FrameProviderThreadFilterTestCase(TestBase):
             )
             self.assertTrue(error.Success(), f"Should register {cls}: {error}")
 
-    @skipIf(oslist=["linux"], archs=["arm$"], bugnumber="github.com/llvm/llvm-project/issues/191855")
+    @skipIf(
+        oslist=["linux"],
+        archs=["arm$"],
+        bugnumber="github.com/llvm/llvm-project/issues/191855",
+    )
     @skipIf(oslist=["windows"], bugnumber="github.com/llvm/llvm-project/issues/191222")
     def test_bt_provider_star_with_thread_filter(self):
         """


### PR DESCRIPTION
PR #181071 caused regressions on Linux on Arm. These are being tracked
in:
- #191855
- #191859

This PR disables the failing tests for now, to fix the broken buildbot.
