### PR TITLE
[ORC] Add UUID support to MachOPlatform::HeaderOptions.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/MachOBuilder.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MachOBuilder.h
@@ -88,6 +88,11 @@ struct MachOBuilderLoadCommand<MachO::LC_UUID>
       : MachOBuilderLoadCommandImplBase<MachO::LC_UUID>() {
     memcpy(uuid, UUID, sizeof(uuid));
   }
+
+  MachOBuilderLoadCommand(const std::array<uint8_t, 16> &UUID)
+      : MachOBuilderLoadCommandImplBase<MachO::LC_UUID>() {
+    memcpy(uuid, UUID.data(), sizeof(uuid));
+  }
 };
 
 template <MachO::LoadCommandType LCType>

--- a/llvm/include/llvm/ExecutionEngine/Orc/MachOPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MachOPlatform.h
@@ -20,7 +20,9 @@
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/Support/Compiler.h"
 
+#include <array>
 #include <future>
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -87,6 +89,9 @@ public:
     std::vector<std::string> RPaths;
     /// List of LC_BUILD_VERSIONs.
     std::vector<BuildVersionOpts> BuildVersions;
+
+    /// Optional UUID. If set, this will be used to add an LC_UUID command.
+    std::optional<std::array<uint8_t, 16>> UUID;
 
     HeaderOptions() = default;
     HeaderOptions(Dylib D) : IDDylib(std::move(D)) {}

--- a/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
@@ -1765,6 +1765,9 @@ jitlink::Block &createHeaderBlock(MachOPlatform &MOP,
   else
     B.template addLoadCommand<MachO::LC_ID_DYLIB>(JD.getName(), 0, 0, 0);
 
+  if (Opts.UUID)
+    B.template addLoadCommand<MachO::LC_UUID>(*Opts.UUID);
+
   for (auto &BV : Opts.BuildVersions)
     B.template addLoadCommand<MachO::LC_BUILD_VERSION>(
         BV.Platform, BV.MinOS, BV.SDK, static_cast<uint32_t>(0));


### PR DESCRIPTION
MachOPlatform::HeaderOptions now includes an optional UUID field. If set, this will be used to build an LC_UUID load command for the JITDylib's MachO header.

No testcase: MachOPlatform construction requires the ORC runtime, which we can't require in LLVM regression or unit tests. In the future we should test this through the ORC runtime.