### PR TITLE
[flang] Implement lowering for BOZ literal arguments in BGE, BLE, BGT, BLT

### DIFF
--- a/flang/lib/Lower/ConvertExprToHLFIR.cpp
+++ b/flang/lib/Lower/ConvertExprToHLFIR.cpp
@@ -1620,7 +1620,19 @@ public:
 private:
   hlfir::EntityWithAttributes
   gen(const Fortran::evaluate::BOZLiteralConstant &expr) {
-    TODO(getLoc(), "BOZ");
+    // BOZ literals reach lowering only from BGE/BGT/BLE/BLT intrinsics when at
+    // least one operand is not constant (otherwise folds). For all other
+    // intrinsics, semantics converts BOZ to the expected type before lowering.
+    Fortran::evaluate::Constant<Fortran::evaluate::LargestInt> intConstant{
+        expr};
+    mlir::Location loc{getLoc()};
+    fir::ExtendedValue exv{Fortran::lower::convertConstant(
+        getConverter(), loc, intConstant,
+        /*outlineBigConstantInReadOnlyMemory=*/false)};
+    if (const auto *scalarBox{exv.getUnboxed()})
+      if (fir::isa_trivial(scalarBox->getType()))
+        return hlfir::EntityWithAttributes(*scalarBox);
+    fir::emitFatalError(loc, "BOZ literal was lowered to unexpected format");
   }
 
   hlfir::EntityWithAttributes gen(const Fortran::evaluate::NullPointer &expr) {

--- a/flang/lib/Lower/ConvertExprToHLFIR.cpp
+++ b/flang/lib/Lower/ConvertExprToHLFIR.cpp
@@ -1625,14 +1625,7 @@ private:
     // intrinsics, semantics converts BOZ to the expected type before lowering.
     Fortran::evaluate::Constant<Fortran::evaluate::LargestInt> intConstant{
         expr};
-    mlir::Location loc{getLoc()};
-    fir::ExtendedValue exv{Fortran::lower::convertConstant(
-        getConverter(), loc, intConstant,
-        /*outlineBigConstantInReadOnlyMemory=*/false)};
-    if (const auto *scalarBox{exv.getUnboxed()})
-      if (fir::isa_trivial(scalarBox->getType()))
-        return hlfir::EntityWithAttributes(*scalarBox);
-    fir::emitFatalError(loc, "BOZ literal was lowered to unexpected format");
+    return gen(intConstant);
   }
 
   hlfir::EntityWithAttributes gen(const Fortran::evaluate::NullPointer &expr) {

--- a/flang/test/Lower/Intrinsics/bge.f90
+++ b/flang/test/Lower/Intrinsics/bge.f90
@@ -197,3 +197,45 @@ subroutine bge_test11(c)
   ! CHECK: %[[V:.*]] = fir.convert %[[R]] : (i1) -> !fir.logical<4>
   ! CHECK: hlfir.assign %[[V]] to %[[C_DECL]]#0 : !fir.logical<4>, !fir.ref<!fir.logical<4>>
 end subroutine bge_test11
+
+! Test BOZ literal as second argument
+! CHECK-LABEL: func.func @_QPbge_boz_second(
+subroutine bge_boz_second(a, c)
+  integer :: a
+  logical :: c
+  c = bge(a, z'FF')
+  ! CHECK: %[[BOZ:.*]] = arith.constant 255 : i128
+  ! CHECK: %[[A:.*]] = fir.load %{{.*}} : !fir.ref<i32>
+  ! CHECK: %[[EXT:.*]] = arith.extui %[[A]] : i32 to i128
+  ! CHECK: %[[CMP:.*]] = arith.cmpi uge, %[[EXT]], %[[BOZ]] : i128
+  ! CHECK: %[[RES:.*]] = fir.convert %[[CMP]] : (i1) -> !fir.logical<4>
+  ! CHECK: hlfir.assign %[[RES]] to %{{.*}}
+end subroutine bge_boz_second
+
+! Test BOZ literal as first argument
+! CHECK-LABEL: func.func @_QPbge_boz_first(
+subroutine bge_boz_first(a, c)
+  integer :: a
+  logical :: c
+  c = bge(z'FF', a)
+  ! CHECK: %[[BOZ:.*]] = arith.constant 255 : i128
+  ! CHECK: %[[A:.*]] = fir.load %{{.*}} : !fir.ref<i32>
+  ! CHECK: %[[EXT:.*]] = arith.extui %[[A]] : i32 to i128
+  ! CHECK: %[[CMP:.*]] = arith.cmpi uge, %[[BOZ]], %[[EXT]] : i128
+  ! CHECK: %[[RES:.*]] = fir.convert %[[CMP]] : (i1) -> !fir.logical<4>
+  ! CHECK: hlfir.assign %[[RES]] to %{{.*}}
+end subroutine bge_boz_first
+
+! Test BOZ literal wider than companion integer type
+! CHECK-LABEL: func.func @_QPbge_boz_wide(
+subroutine bge_boz_wide(a, c)
+  integer :: a
+  logical :: c
+  c = bge(a, z'1FFFFFFFF')
+  ! CHECK: %[[BOZ:.*]] = arith.constant 8589934591 : i128
+  ! CHECK: %[[A:.*]] = fir.load %{{.*}} : !fir.ref<i32>
+  ! CHECK: %[[EXT:.*]] = arith.extui %[[A]] : i32 to i128
+  ! CHECK: %[[CMP:.*]] = arith.cmpi uge, %[[EXT]], %[[BOZ]] : i128
+  ! CHECK: %[[RES:.*]] = fir.convert %[[CMP]] : (i1) -> !fir.logical<4>
+  ! CHECK: hlfir.assign %[[RES]] to %{{.*}}
+end subroutine bge_boz_wide

--- a/flang/test/Lower/Intrinsics/bge.f90
+++ b/flang/test/Lower/Intrinsics/bge.f90
@@ -239,3 +239,13 @@ subroutine bge_boz_wide(a, c)
   ! CHECK: %[[RES:.*]] = fir.convert %[[CMP]] : (i1) -> !fir.logical<4>
   ! CHECK: hlfir.assign %[[RES]] to %{{.*}}
 end subroutine bge_boz_wide
+
+! Test BOZ literal for both arguments (folded at compile time)
+! CHECK-LABEL: func.func @_QPbge_boz_both(
+subroutine bge_boz_both(c)
+  logical :: c
+  c = bge(z'FF', z'FE')
+  ! CHECK: %[[R:.*]] = arith.constant true
+  ! CHECK: %[[V:.*]] = fir.convert %[[R]] : (i1) -> !fir.logical<4>
+  ! CHECK: hlfir.assign %[[V]] to %{{.*}}
+end subroutine bge_boz_both

--- a/flang/test/Lower/Intrinsics/bgt.f90
+++ b/flang/test/Lower/Intrinsics/bgt.f90
@@ -197,3 +197,31 @@ subroutine bgt_test11(c)
   ! CHECK: %[[V:.*]] = fir.convert %[[R]] : (i1) -> !fir.logical<4>
   ! CHECK: hlfir.assign %[[V]] to %[[C_DECL]]#0 : !fir.logical<4>, !fir.ref<!fir.logical<4>>
 end subroutine bgt_test11
+
+! Test BOZ literal as second argument
+! CHECK-LABEL: func.func @_QPbgt_boz_second(
+subroutine bgt_boz_second(a, c)
+  integer :: a
+  logical :: c
+  c = bgt(a, z'FF')
+  ! CHECK: %[[BOZ:.*]] = arith.constant 255 : i128
+  ! CHECK: %[[A:.*]] = fir.load %{{.*}} : !fir.ref<i32>
+  ! CHECK: %[[EXT:.*]] = arith.extui %[[A]] : i32 to i128
+  ! CHECK: %[[CMP:.*]] = arith.cmpi ugt, %[[EXT]], %[[BOZ]] : i128
+  ! CHECK: %[[RES:.*]] = fir.convert %[[CMP]] : (i1) -> !fir.logical<4>
+  ! CHECK: hlfir.assign %[[RES]] to %{{.*}}
+end subroutine bgt_boz_second
+
+! Test BOZ literal as first argument
+! CHECK-LABEL: func.func @_QPbgt_boz_first(
+subroutine bgt_boz_first(a, c)
+  integer :: a
+  logical :: c
+  c = bgt(z'FF', a)
+  ! CHECK: %[[BOZ:.*]] = arith.constant 255 : i128
+  ! CHECK: %[[A:.*]] = fir.load %{{.*}} : !fir.ref<i32>
+  ! CHECK: %[[EXT:.*]] = arith.extui %[[A]] : i32 to i128
+  ! CHECK: %[[CMP:.*]] = arith.cmpi ugt, %[[BOZ]], %[[EXT]] : i128
+  ! CHECK: %[[RES:.*]] = fir.convert %[[CMP]] : (i1) -> !fir.logical<4>
+  ! CHECK: hlfir.assign %[[RES]] to %{{.*}}
+end subroutine bgt_boz_first

--- a/flang/test/Lower/Intrinsics/bgt.f90
+++ b/flang/test/Lower/Intrinsics/bgt.f90
@@ -225,3 +225,13 @@ subroutine bgt_boz_first(a, c)
   ! CHECK: %[[RES:.*]] = fir.convert %[[CMP]] : (i1) -> !fir.logical<4>
   ! CHECK: hlfir.assign %[[RES]] to %{{.*}}
 end subroutine bgt_boz_first
+
+! Test BOZ literal for both arguments (folded at compile time)
+! CHECK-LABEL: func.func @_QPbgt_boz_both(
+subroutine bgt_boz_both(c)
+  logical :: c
+  c = bgt(z'FF', z'FE')
+  ! CHECK: %[[R:.*]] = arith.constant true
+  ! CHECK: %[[V:.*]] = fir.convert %[[R]] : (i1) -> !fir.logical<4>
+  ! CHECK: hlfir.assign %[[V]] to %{{.*}}
+end subroutine bgt_boz_both

--- a/flang/test/Lower/Intrinsics/ble.f90
+++ b/flang/test/Lower/Intrinsics/ble.f90
@@ -197,3 +197,31 @@ subroutine ble_test11(c)
   ! CHECK: %[[V:.*]] = fir.convert %[[R]] : (i1) -> !fir.logical<4>
   ! CHECK: hlfir.assign %[[V]] to %[[C_DECL]]#0 : !fir.logical<4>, !fir.ref<!fir.logical<4>>
 end subroutine ble_test11
+
+! Test BOZ literal as second argument
+! CHECK-LABEL: func.func @_QPble_boz_second(
+subroutine ble_boz_second(a, c)
+  integer :: a
+  logical :: c
+  c = ble(a, z'FF')
+  ! CHECK: %[[BOZ:.*]] = arith.constant 255 : i128
+  ! CHECK: %[[A:.*]] = fir.load %{{.*}} : !fir.ref<i32>
+  ! CHECK: %[[EXT:.*]] = arith.extui %[[A]] : i32 to i128
+  ! CHECK: %[[CMP:.*]] = arith.cmpi ule, %[[EXT]], %[[BOZ]] : i128
+  ! CHECK: %[[RES:.*]] = fir.convert %[[CMP]] : (i1) -> !fir.logical<4>
+  ! CHECK: hlfir.assign %[[RES]] to %{{.*}}
+end subroutine ble_boz_second
+
+! Test BOZ literal as first argument
+! CHECK-LABEL: func.func @_QPble_boz_first(
+subroutine ble_boz_first(a, c)
+  integer :: a
+  logical :: c
+  c = ble(z'FF', a)
+  ! CHECK: %[[BOZ:.*]] = arith.constant 255 : i128
+  ! CHECK: %[[A:.*]] = fir.load %{{.*}} : !fir.ref<i32>
+  ! CHECK: %[[EXT:.*]] = arith.extui %[[A]] : i32 to i128
+  ! CHECK: %[[CMP:.*]] = arith.cmpi ule, %[[BOZ]], %[[EXT]] : i128
+  ! CHECK: %[[RES:.*]] = fir.convert %[[CMP]] : (i1) -> !fir.logical<4>
+  ! CHECK: hlfir.assign %[[RES]] to %{{.*}}
+end subroutine ble_boz_first

--- a/flang/test/Lower/Intrinsics/ble.f90
+++ b/flang/test/Lower/Intrinsics/ble.f90
@@ -225,3 +225,13 @@ subroutine ble_boz_first(a, c)
   ! CHECK: %[[RES:.*]] = fir.convert %[[CMP]] : (i1) -> !fir.logical<4>
   ! CHECK: hlfir.assign %[[RES]] to %{{.*}}
 end subroutine ble_boz_first
+
+! Test BOZ literal for both arguments (folded at compile time)
+! CHECK-LABEL: func.func @_QPble_boz_both(
+subroutine ble_boz_both(c)
+  logical :: c
+  c = ble(z'FF', z'FE')
+  ! CHECK: %[[R:.*]] = arith.constant false
+  ! CHECK: %[[V:.*]] = fir.convert %[[R]] : (i1) -> !fir.logical<4>
+  ! CHECK: hlfir.assign %[[V]] to %{{.*}}
+end subroutine ble_boz_both

--- a/flang/test/Lower/Intrinsics/blt.f90
+++ b/flang/test/Lower/Intrinsics/blt.f90
@@ -197,3 +197,31 @@ subroutine blt_test11(c)
   ! CHECK: %[[V:.*]] = fir.convert %[[R]] : (i1) -> !fir.logical<4>
   ! CHECK: hlfir.assign %[[V]] to %[[C_DECL]]#0 : !fir.logical<4>, !fir.ref<!fir.logical<4>>
 end subroutine blt_test11
+
+! Test BOZ literal as second argument
+! CHECK-LABEL: func.func @_QPblt_boz_second(
+subroutine blt_boz_second(a, c)
+  integer :: a
+  logical :: c
+  c = blt(a, z'FF')
+  ! CHECK: %[[BOZ:.*]] = arith.constant 255 : i128
+  ! CHECK: %[[A:.*]] = fir.load %{{.*}} : !fir.ref<i32>
+  ! CHECK: %[[EXT:.*]] = arith.extui %[[A]] : i32 to i128
+  ! CHECK: %[[CMP:.*]] = arith.cmpi ult, %[[EXT]], %[[BOZ]] : i128
+  ! CHECK: %[[RES:.*]] = fir.convert %[[CMP]] : (i1) -> !fir.logical<4>
+  ! CHECK: hlfir.assign %[[RES]] to %{{.*}}
+end subroutine blt_boz_second
+
+! Test BOZ literal as first argument
+! CHECK-LABEL: func.func @_QPblt_boz_first(
+subroutine blt_boz_first(a, c)
+  integer :: a
+  logical :: c
+  c = blt(z'FF', a)
+  ! CHECK: %[[BOZ:.*]] = arith.constant 255 : i128
+  ! CHECK: %[[A:.*]] = fir.load %{{.*}} : !fir.ref<i32>
+  ! CHECK: %[[EXT:.*]] = arith.extui %[[A]] : i32 to i128
+  ! CHECK: %[[CMP:.*]] = arith.cmpi ult, %[[BOZ]], %[[EXT]] : i128
+  ! CHECK: %[[RES:.*]] = fir.convert %[[CMP]] : (i1) -> !fir.logical<4>
+  ! CHECK: hlfir.assign %[[RES]] to %{{.*}}
+end subroutine blt_boz_first

--- a/flang/test/Lower/Intrinsics/blt.f90
+++ b/flang/test/Lower/Intrinsics/blt.f90
@@ -225,3 +225,13 @@ subroutine blt_boz_first(a, c)
   ! CHECK: %[[RES:.*]] = fir.convert %[[CMP]] : (i1) -> !fir.logical<4>
   ! CHECK: hlfir.assign %[[RES]] to %{{.*}}
 end subroutine blt_boz_first
+
+! Test BOZ literal for both arguments (folded at compile time)
+! CHECK-LABEL: func.func @_QPblt_boz_both(
+subroutine blt_boz_both(c)
+  logical :: c
+  c = blt(z'FF', z'FE')
+  ! CHECK: %[[R:.*]] = arith.constant false
+  ! CHECK: %[[V:.*]] = fir.convert %[[R]] : (i1) -> !fir.logical<4>
+  ! CHECK: hlfir.assign %[[V]] to %{{.*}}
+end subroutine blt_boz_both


### PR DESCRIPTION
BGE/BGT/BLE/BLT allow one or both arguments to be a BOZ literal constant. Unlike other intrinsics that accept BOZ arguments, these do not convert the BOZ to a typed value during semantic analysis.

When both arguments are constants, the comparison is folded at compile time in `fold-logical.cpp`. However, when the non-BOZ argument is a variable, folding is skipped and the BOZ literal constant persists in the expression tree through to lowering.

The lowering implementation wraps the `BOZLiteralConstant]` in a `Constant<LargestInt>` and feeds it through the existing `convertConstant` infrastructure. Since BOZ is always a scalar, this always produces a trivial SSA value. This follows the same pattern as `gen(Constant<T>)` for the trivial scalar path. The `AddrOfOp` branch from that template is intentionally omitted because a scalar i128 constant never produces a global reference. The `outlineBigConstantInReadOnlyMemory` parameter is set to false to make this intent explicit.

Tests:
- Added BOZ lowering tests to bge.f90, bgt.f90, ble.f90, blt.f90 covering BOZ in first position, second position
- Wider-than-companion BOZ (z'1FFFFFFFF' with i32 companion) lowering test added to bge.f90

Issue #190818 
Enable test in llvm-test-suite: https://github.com/llvm/llvm-test-suite/pull/393https://github.com/llvm/llvm-test-suite/pull/393

