### PR TITLE
[lldb] Remove unused argument of DataExtractor constructor (NFC)

### DIFF
--- a/lldb/include/lldb/Utility/DataExtractor.h
+++ b/lldb/include/lldb/Utility/DataExtractor.h
@@ -1034,15 +1034,8 @@ public:
     return {GetDataStart(), size_t(GetByteSize())};
   }
 
-  llvm::DWARFDataExtractor GetAsLLVMDWARF() const {
-    return llvm::DWARFDataExtractor(GetData(),
-                                    GetByteOrder() == lldb::eByteOrderLittle,
-                                    GetAddressByteSize());
-  }
-
   llvm::DataExtractor GetAsLLVM() const {
-    return {GetData(), GetByteOrder() == lldb::eByteOrderLittle,
-            uint8_t(GetAddressByteSize())};
+    return {GetData(), GetByteOrder() == lldb::eByteOrderLittle};
   }
 
 protected:

--- a/lldb/source/DataFormatters/FormatterBytecode.cpp
+++ b/lldb/source/DataFormatters/FormatterBytecode.cpp
@@ -187,7 +187,7 @@ llvm::Error Interpret(ControlStack &control, DataStack &data, Signatures sig) {
     return llvm::Error::success();
   // Since the only data types are single endian and ULEBs, the
   // endianness should not matter.
-  llvm::DataExtractor cur_block(control.back(), true, 64);
+  llvm::DataExtractor cur_block(control.back(), true);
   llvm::DataExtractor::Cursor pc(0);
 
   while (!control.empty()) {
@@ -196,7 +196,7 @@ llvm::Error Interpret(ControlStack &control, DataStack &data, Signatures sig) {
       // Save the return address.
       if (control.size() > 1)
         control[control.size() - 2] = cur_block.getData().drop_front(pc.tell());
-      cur_block = llvm::DataExtractor(control.back(), true, 64);
+      cur_block = llvm::DataExtractor(control.back(), true);
       if (pc)
         pc = llvm::DataExtractor::Cursor(0);
     };

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDataExtractor.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDataExtractor.cpp
@@ -16,9 +16,5 @@ llvm::DWARFDataExtractor DWARFDataExtractor::GetAsLLVMDWARF() const {
                                   GetByteOrder() == lldb::eByteOrderLittle,
                                   GetAddressByteSize());
 }
-llvm::DataExtractor DWARFDataExtractor::GetAsLLVM() const {
-  return llvm::DataExtractor(llvm::ArrayRef(GetDataStart(), GetByteSize()),
-                             GetByteOrder() == lldb::eByteOrderLittle,
-                             GetAddressByteSize());
-}
+
 } // namespace lldb_private

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDataExtractor.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDataExtractor.h
@@ -23,7 +23,6 @@ public:
       : DataExtractor(data, offset, length) {}
 
   llvm::DWARFDataExtractor GetAsLLVMDWARF() const;
-  llvm::DataExtractor GetAsLLVM() const;
 };
 } // namespace lldb_private
 

--- a/lldb/source/Symbol/UnwindPlan.cpp
+++ b/lldb/source/Symbol/UnwindPlan.cpp
@@ -86,8 +86,7 @@ GetByteOrderAndAddrSize(Thread *thread) {
 
 static void DumpDWARFExpr(Stream &s, llvm::ArrayRef<uint8_t> expr, Thread *thread) {
   if (auto order_and_width = GetByteOrderAndAddrSize(thread)) {
-    llvm::DataExtractor data(expr, order_and_width->first == eByteOrderLittle,
-                             order_and_width->second);
+    llvm::DataExtractor data(expr, order_and_width->first == eByteOrderLittle);
     llvm::DWARFExpression E(data, order_and_width->second,
                             llvm::dwarf::DWARF32);
     printDwarfExpression(&E, s.AsRawOstream(), llvm::DIDumpOptions(), nullptr);

--- a/lldb/unittests/Symbol/PostfixExpressionTest.cpp
+++ b/lldb/unittests/Symbol/PostfixExpressionTest.cpp
@@ -155,8 +155,7 @@ static std::string ParseAndGenerateDWARF(llvm::StringRef expr) {
   ToDWARF(*ast, dwarf);
 
   // print dwarf expression to comparable textual representation
-  llvm::DataExtractor extractor(dwarf.GetString(), /*IsLittleEndian=*/true,
-                                addr_size);
+  llvm::DataExtractor extractor(dwarf.GetString(), /*IsLittleEndian=*/true);
 
   std::string result;
   llvm::raw_string_ostream os(result);

--- a/lldb/unittests/SymbolFile/NativePDB/PdbFPOProgramToDWARFExpressionTests.cpp
+++ b/lldb/unittests/SymbolFile/NativePDB/PdbFPOProgramToDWARFExpressionTests.cpp
@@ -36,7 +36,7 @@ CheckValidProgramTranslation(llvm::StringRef fpo_program,
 
   // print dwarf expression to comparable textual representation
   llvm::DataExtractor extractor({stream.GetData(), stream.GetSize()},
-                                /*IsLittleEndian=*/true, /*AddressSize=*/4);
+                                /*IsLittleEndian=*/true);
 
   std::string result;
   llvm::raw_string_ostream os(result);


### PR DESCRIPTION
`AddressSize` parameter is not used by `DataExtractor` and will be removed in the future. See #190519 for more context.

This also removes two of the four related methods:
```
DataExtractor::GetAsLLVM()
DataExtractor::GetAsLLVMDWARF() - removed as unused
DWARFDataExtractor::GetAsLLVM() - removed as redundant, it hid the equivalent method of DataExtractor
DWARFDataExtractor::GetAsLLVMDWARF()
```

That is, now we have:
```
DataExtractor::GetAsLLVM()
DWARFDataExtractor::GetAsLLVMDWARF()
```
