### PR TITLE
[NFC] Try to unbreak the module builds due to missing `StringRef.h` include in `UniqueBBID.h`

### DIFF
--- a/llvm/include/llvm/Support/UniqueBBID.h
+++ b/llvm/include/llvm/Support/UniqueBBID.h
@@ -15,6 +15,7 @@
 #define LLVM_SUPPORT_UNIQUEBBID_H
 
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace llvm {
 


### PR DESCRIPTION
The modules build of LLVM broke when this patch landed

```
commit 2f422a52fde267757ce48041af6e731421fed2a3
Author: Rahman Lavaee <rahmanl@google.com>
Date:   Fri Apr 10 15:58:16 2026 -0700

    [Codegen, X86] Add prefetch insertion based on Propeller profile (#166324)
```

with an error like:

```
[2026-04-11T10:33:41.699Z] While building module 'LLVM_Utils' imported from /Users/ec2-user/jenkins/workspace/m.org_clang-stage2-Rthinlto_main/llvm-project/llvm/lib/Demangle/Demangle.cpp:13:
[2026-04-11T10:33:41.699Z] In file included from <module-includes>:321:
[2026-04-11T10:33:41.699Z] /Users/ec2-user/jenkins/workspace/m.org_clang-stage2-Rthinlto_main/llvm-project/llvm/include/llvm/Support/UniqueBBID.h:40:3: error: missing '#include "llvm/ADT/StringRef.h"'; 'StringRef' must be declared before it is used
[2026-04-11T10:33:41.699Z]    40 |   StringRef TargetFunction;
[2026-04-11T10:33:41.699Z]       |   ^
[2026-04-11T10:33:41.699Z] /Users/ec2-user/jenkins/workspace/m.org_clang-stage2-Rthinlto_main/llvm-project/llvm/include/llvm/ADT/StringRef.h:55:24: note: declaration here is not visible
[2026-04-11T10:33:41.699Z]    55 | class LLVM_GSL_POINTER StringRef {
[2026-04-11T10:33:41.699Z]       |                        ^
[2026-04-11T10:33:41.699Z] /Users/ec2-user/jenkins/workspace/m.org_clang-stage2-Rthinlto_main/llvm-project/llvm/lib/Demangle/Demangle.cpp:13:10: fatal error: could not build module 'LLVM_Utils'
[2026-04-11T10:33:41.699Z]    13 | #include "llvm/Demangle/Demangle.h"
[2026-04-11T10:33:41.699Z]       |  ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
```

https://ci.swift.org/job/llvm.org/job/clang-stage2-Rthinlto/job/main/150/

This patch tries to fix that by adding the missing include.

rdar://174555346