### PR TITLE
Revert "[TySan][Sanitizer Common] Make TySan compatible with sanitizer common…"

### DIFF
--- a/compiler-rt/lib/tysan/tysan.cpp
+++ b/compiler-rt/lib/tysan/tysan.cpp
@@ -15,7 +15,6 @@
 #include "sanitizer_common/sanitizer_common.h"
 #include "sanitizer_common/sanitizer_flag_parser.h"
 #include "sanitizer_common/sanitizer_flags.h"
-#include "sanitizer_common/sanitizer_interface_internal.h"
 #include "sanitizer_common/sanitizer_libc.h"
 #include "sanitizer_common/sanitizer_report_decorator.h"
 #include "sanitizer_common/sanitizer_stacktrace.h"
@@ -39,30 +38,6 @@ extern "C" SANITIZER_INTERFACE_ATTRIBUTE void
 tysan_copy_types(const void *daddr, const void *saddr, uptr size) {
   if (tysan_inited)
     internal_memmove(shadow_for(daddr), shadow_for(saddr), size * sizeof(uptr));
-}
-
-static void getStackTrace(bool fullStacktrace, uptr pc, uptr bp,
-                          BufferedStackTrace *ST) {
-  uptr top = 0;
-  uptr bottom = 0;
-  if (fullStacktrace)
-    GetThreadStackTopAndBottom(false, &top, &bottom);
-  bool request_fast = StackTrace::WillUseFastUnwind(true);
-  ST->Unwind(kStackTraceMax, pc, bp, 0, top, bottom, request_fast);
-}
-
-namespace __tysan {
-void OnStackUnwind(const SignalContext &sig, const void *,
-                   BufferedStackTrace *stack) {
-  getStackTrace(true, StackTrace::GetNextInstructionPc(sig.pc), sig.bp, stack);
-}
-} // namespace __tysan
-
-extern "C" SANITIZER_INTERFACE_ATTRIBUTE void __sanitizer_print_stack_trace() {
-  GET_CURRENT_PC_BP;
-  UNINITIALIZED BufferedStackTrace stack;
-  getStackTrace(true, pc, bp, &stack);
-  stack.Print();
 }
 
 static const char *getDisplayName(const char *Name) {
@@ -266,8 +241,14 @@ static void reportError(void *Addr, int Size, tysan_type_descriptor *TD,
     Printf("\n");
 
   if (pc) {
+    uptr top = 0;
+    uptr bottom = 0;
+    if (flags().print_stacktrace)
+      GetThreadStackTopAndBottom(false, &top, &bottom);
+
+    bool request_fast = StackTrace::WillUseFastUnwind(true);
     BufferedStackTrace ST;
-    getStackTrace(flags().print_stacktrace, pc, bp, &ST);
+    ST.Unwind(kStackTraceMax, pc, bp, 0, top, bottom, request_fast);
     ST.Print();
   } else {
     Printf("\n");
@@ -484,8 +465,6 @@ static void InitializeFlags() {
     ReportUnrecognizedFlags();
   if (common_flags()->help)
     parser.PrintFlagDescriptions();
-
-  __sanitizer_set_report_path(common_flags()->log_path);
 }
 
 static void TySanInitializePlatformEarly() {
@@ -510,13 +489,9 @@ static void TySanInitializePlatformEarly() {
 namespace __tysan {
 bool tysan_inited = false;
 bool tysan_init_is_running;
-void InitializeDeadlySignals();
 } // namespace __tysan
 
 extern "C" SANITIZER_INTERFACE_ATTRIBUTE void __tysan_init() {
-  SanitizerToolName = "TypeSanitizer";
-  CacheBinaryName();
-
   CHECK(!tysan_init_is_running);
   if (tysan_inited)
     return;
@@ -526,7 +501,6 @@ extern "C" SANITIZER_INTERFACE_ATTRIBUTE void __tysan_init() {
   TySanInitializePlatformEarly();
 
   InitializeInterceptors();
-  InitializeDeadlySignals();
 
   if (!MmapFixedNoReserve(ShadowAddr(), AppAddr() - ShadowAddr()))
     Die();

--- a/compiler-rt/lib/tysan/tysan_interceptors.cpp
+++ b/compiler-rt/lib/tysan/tysan_interceptors.cpp
@@ -22,44 +22,12 @@
 #define TYSAN_INTERCEPT___STRDUP 0
 #endif
 
-#define TYSAN_INTERCEPT_FUNC(name)                                             \
-  do {                                                                         \
-    if (!INTERCEPT_FUNCTION(name))                                             \
-      VReport(1, "TypeSanitizer: failed to intercept '%s'\n", #name);          \
-  } while (0)
-
 #if SANITIZER_LINUX
 extern "C" int mallopt(int param, int value);
 #endif
 
 using namespace __sanitizer;
 using namespace __tysan;
-namespace __tysan {
-// Defined in tysan.cpp
-void OnStackUnwind(const SignalContext &sig, const void *,
-                   BufferedStackTrace *stack);
-
-static void TysanOnDeadlySignal(int signo, void *siginfo, void *context) {
-  HandleDeadlySignal(siginfo, context, GetTid(), &OnStackUnwind, nullptr);
-}
-
-static bool tysanSignalsInitialized = false;
-void InitializeDeadlySignals();
-} // namespace __tysan
-
-#define SIGNAL_INTERCEPTOR_ENTER() __tysan::InitializeDeadlySignals()
-#define COMMON_INTERCEPT_FUNCTION(name) TYSAN_INTERCEPT_FUNC(name)
-#include "sanitizer_common/sanitizer_signal_interceptors.inc"
-
-namespace __tysan {
-void InitializeDeadlySignals() {
-  if (tysanSignalsInitialized)
-    return;
-  InitializeSignalInterceptors();
-  InstallDeadlySignalHandlers(&TysanOnDeadlySignal);
-  tysanSignalsInitialized = true;
-}
-} // namespace __tysan
 
 namespace {
 struct DlsymAlloc : public DlSymAllocator<DlsymAlloc> {
@@ -265,7 +233,7 @@ void InitializeInterceptors() {
   TYSAN_MAYBE_INTERCEPT_MEMALIGN;
   TYSAN_MAYBE_INTERCEPT___LIBC_MEMALIGN;
   TYSAN_MAYBE_INTERCEPT_PVALLOC;
-  TYSAN_MAYBE_INTERCEPT_ALIGNED_ALLOC;
+  TYSAN_MAYBE_INTERCEPT_ALIGNED_ALLOC
   INTERCEPT_FUNCTION(posix_memalign);
 
   INTERCEPT_FUNCTION(memset);


### PR DESCRIPTION
Reverts llvm/llvm-project#183310 due to macOS build breakages.

https://ci.swift.org/job/llvm.org/job/clang-stage1-RA-cmake-incremental/job/main/638/consoleFull#-1919712802f80d942a-f672-4696-b0d9-c66cae8aa9dd

The error looked something like:

```
[2026-04-13T18:56:31.979Z] /Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/llvm-project/compiler-rt/lib/tysan/../sanitizer_common/sanitizer_signal_interceptors.inc:136:3: error: expected expression
[2026-04-13T18:56:31.979Z]   136 |   INIT_SIGNAL;
[2026-04-13T18:56:31.979Z]       |   ^
[2026-04-13T18:56:31.979Z] /Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/llvm-project/compiler-rt/lib/tysan/../sanitizer_common/sanitizer_signal_interceptors.inc:77:21: note: expanded from macro 'INIT_SIGNAL'
[2026-04-13T18:56:31.979Z]    77 | #define INIT_SIGNAL COMMON_INTERCEPT_FUNCTION(signal)
[2026-04-13T18:56:31.979Z]       |                     ^
[2026-04-13T18:56:31.979Z] /Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/llvm-project/compiler-rt/lib/tysan/tysan_interceptors.cpp:51:41: note: expanded from macro 'COMMON_INTERCEPT_FUNCTION'
[2026-04-13T18:56:31.979Z]    51 | #define COMMON_INTERCEPT_FUNCTION(name) TYSAN_INTERCEPT_FUNC(name)
[2026-04-13T18:56:31.979Z]       |                                         ^
[2026-04-13T18:56:31.979Z] /Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/llvm-project/compiler-rt/lib/tysan/tysan_interceptors.cpp:27:34: note: expanded from macro 'TYSAN_INTERCEPT_FUNC'
[2026-04-13T18:56:31.979Z]    27 |     if (!INTERCEPT_FUNCTION(name))                               
```

Some initial diagnosis can be found at https://github.com/llvm/llvm-project/pull/183310#issuecomment-4239575059

rdar://174648152