### PR TITLE
[clang] Fix assertion crash in CTAD for alias templates with non-dependent type

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -498,6 +498,7 @@ Miscellaneous Clang Crashes Fixed
 - Fixed a crash when explicitly casting a scalar to an atomic complex. (#GH114885)
 - Fixed an assertion failure when parsing an invalid out-of-line enum definition with template parameters. (#GH187909)
 - Fixed an assertion failure on invalid template template parameter during typo correction. (#GH183983)
+- Fixed an assertion failure when using CTAD for alias templates where the RHS resolves to a non-dependent class template specialization. (#GH190517)
 
 OpenACC Specific Changes
 ------------------------

--- a/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
+++ b/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
@@ -1124,7 +1124,18 @@ BuildDeductionGuideForTypeAlias(Sema &SemaRef,
     FReturnType = cast<TemplateSpecializationType>(
         ICNT->getDecl()->getCanonicalTemplateSpecializationType(
             SemaRef.Context));
-  assert(FReturnType && "expected to see a return type");
+
+  ArrayRef<TemplateArgument> FReturnTemplateArgs;
+  if (FReturnType) {
+    FReturnTemplateArgs = FReturnType->template_arguments();
+  } else if (const auto *RT = RType->getAs<RecordType>()) {
+    // If the return type is a non-dependent class template specialization,
+    // it might be resolved to a RecordType.
+    if (const auto *CTSD = dyn_cast<ClassTemplateSpecializationDecl>(RT->getDecl()))
+      FReturnTemplateArgs = CTSD->getTemplateArgs().asArray();
+  }
+  assert(!FReturnTemplateArgs.empty() && "expected to see template arguments");
+
   // Deduce template arguments of the deduction guide f from the RHS of
   // the alias.
   //
@@ -1156,7 +1167,7 @@ BuildDeductionGuideForTypeAlias(Sema &SemaRef,
   // performing deduction for rest of arguments to align with the C++
   // standard.
   SemaRef.DeduceTemplateArguments(
-      F->getTemplateParameters(), FReturnType->template_arguments(),
+      F->getTemplateParameters(), FReturnTemplateArgs,
       AliasRhsTemplateArgs, TDeduceInfo, DeduceResults,
       /*NumberOfArgumentsMustMatch=*/false);
 

--- a/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
+++ b/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
@@ -618,3 +618,13 @@ Alias  b(42);
 // expected-error@-1 {{alias template 'Alias' requires template arguments; argument deduction only allowed for class templates or alias template}}
 // expected-note@#gh130604-alias {{template is declared here}}
 }
+
+namespace GH190517 {
+template <typename T> struct S1 {};
+template <typename T> using S2 = S1<char>;
+template <typename T> using S3 = S2<T>; // expected-note {{candidate function template not viable}} \
+                                        // expected-note {{implicit deduction guide declared}} \
+                                        // expected-note {{candidate function template not viable}} \
+                                        // expected-note {{implicit deduction guide declared}}
+S3 foo(42); // expected-error {{no viable constructor or deduction guide for deduction of template arguments of 'S3'}}
+}


### PR DESCRIPTION
When building deduction guides, clang assumes that the return type of the deduction guide would always be a dependent type (`TemplateSpecializationType`), but this is not true for invalid case, where the alias RHS is a non-dependent class template specialization, it is represented as a `RecordType` instead.

Fixes #190517.