### PR TITLE
[lit] Prevent "lld" from being substituted by LIT in passthrough-lld.test

### DIFF
--- a/llvm/test/tools/llvm-driver/passthrough-lld.test
+++ b/llvm/test/tools/llvm-driver/passthrough-lld.test
@@ -2,7 +2,7 @@
 
 # RUN: %llvm ld.lld --help | FileCheck %s
 # RUN: %llvm ld --help | FileCheck %s
-# RUN: %llvm lld -flavor ld.lld --help | FileCheck %s
-# RUN: %llvm ld -flavor ld.lld --help | FileCheck %s
+# RUN: %llvm lld -flavor ld"."lld --help | FileCheck %s
+# RUN: %llvm ld -flavor ld"."lld --help | FileCheck %s
 
 # CHECK: supported targets: elf


### PR DESCRIPTION
We are seeing test failures in "passthrough-lld.test" as LIT substitute the "ld.lld" string in the test file to the full path to the lld. However, the "-flavor" flag does not expect a full path. It just need a name of the linker so it fails. This patch mitigate this issue by adding a no-op quote in the "ld.lld" to prevent it from matched by the regex in the LIT runner.