### PR TITLE
[lldb] Fix casting from float in `ValueObject::CastToEnumType`

### DIFF
--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -3322,7 +3322,8 @@ lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
     byte_size = temp.value();
 
   if (is_float) {
-    llvm::APSInt integer(byte_size * CHAR_BIT, !type.IsSigned());
+    llvm::APSInt integer(byte_size * CHAR_BIT,
+                         !type.IsEnumerationIntegerTypeSigned());
     bool is_exact;
     auto value_or_err = GetValueAsAPFloat();
     if (value_or_err) {
@@ -3334,15 +3335,15 @@ lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
       if (status & llvm::APFloatBase::opInvalidOp)
         return ValueObjectConstResult::Create(
             exe_ctx.GetBestExecutionContextScope(),
-            Status::FromErrorStringWithFormat(
-                "invalid type cast detected: %s",
-                llvm::toString(value_or_err.takeError()).c_str()));
+            Status::FromErrorString("invalid cast from float to integer"));
       return ValueObject::CreateValueObjectFromAPInt(exe_ctx, integer, type,
                                                      "result");
     } else
       return ValueObjectConstResult::Create(
           exe_ctx.GetBestExecutionContextScope(),
-          Status::FromErrorString("cannot get value as APFloat"));
+          Status::FromErrorStringWithFormat(
+              "cannot get value as APFloat: %s",
+              llvm::toString(value_or_err.takeError()).c_str()));
   } else {
     // Get the value as APSInt and extend or truncate it to the requested size.
     auto value_or_err = GetValueAsAPSInt();

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -3341,9 +3341,9 @@ lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
     } else
       return ValueObjectConstResult::Create(
           exe_ctx.GetBestExecutionContextScope(),
-          Status::FromErrorStringWithFormat(
-              "cannot get value as APFloat: %s",
-              llvm::toString(value_or_err.takeError()).c_str()));
+          Status::FromErrorStringWithFormatv(
+              "cannot get value as APFloat: {0}",
+              llvm::toString(value_or_err.takeError())));
   } else {
     // Get the value as APSInt and extend or truncate it to the requested size.
     auto value_or_err = GetValueAsAPSInt();

--- a/lldb/test/API/commands/frame/var-dil/expr/Casts/TestFrameVarDILCast.py
+++ b/lldb/test/API/commands/frame/var-dil/expr/Casts/TestFrameVarDILCast.py
@@ -292,3 +292,18 @@ class TestFrameVarDILCast(TestBase):
         legacy = frame.GetValueForVariablePath("(char)a", lldb.eDILModeLegacy)
         self.assertFailure(simple.GetError())
         self.assertFailure(legacy.GetError())
+
+        # Check enum casting
+        self.expect_var_path("(UnscopedEnum) 0", value="kZero")
+        self.expect_var_path("(UnscopedEnum) ((char) 1)", value="kOne")
+        self.expect_var_path("(UnscopedEnum) 1.5", value="kOne")
+        self.expect_var_path("(UnscopedEnum) enum_one8", value="kOne")
+        self.expect_var_path("(UnscopedEnumInt8) 1ULL", value="kOne8")
+        self.expect_var_path("(UnscopedEnumInt8) -1.5", value="kMinusOne8")
+        self.expect_var_path("(UnscopedEnumInt8) 1.5", value="kOne8")
+        self.expect_var_path("(UnscopedEnumInt8) enum_one", value="kOne8")
+        self.expect(
+            "frame variable '(UnscopedEnum) ifoo'",
+            error=True,
+            substrs=["Cast from 'InnerFoo' to 'UnscopedEnum' is not allowed"],
+        )

--- a/lldb/test/API/commands/frame/var-dil/expr/Casts/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/expr/Casts/main.cpp
@@ -22,6 +22,9 @@ class Foo {};
 // Global variable
 bool myGlobalName = true;
 
+enum UnscopedEnum { kZero, kOne, kTwo };
+enum UnscopedEnumInt8 : int8_t { kMinusOne8 = -1, kZero8, kOne8 };
+
 int main(int argc, char **argv) {
   int a = 1;
   int *ap = &a;
@@ -80,6 +83,9 @@ int main(int argc, char **argv) {
   };
 
   struct myGlobalName secondStruct = {42, false};
+
+  auto enum_one = UnscopedEnum::kOne;
+  auto enum_one8 = UnscopedEnumInt8::kOne8;
 
   return 0; // Set a breakpoint here
 }


### PR DESCRIPTION
Fix how enum's underlying type sign is retrieved and adjust error messaging.