### PR TITLE
[KnownBits][APInt] Optimize isConstant (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -1273,8 +1273,8 @@ public:
     assert(BitWidth == RHS.BitWidth && "Bit widths must be the same");
     if (isSingleWord()) {
       WordType Mask = BitWidth == APINT_BITS_PER_WORD
-                    ? WORDTYPE_MAX
-                    : llvm::maskTrailingOnes<WordType>(BitWidth);
+                          ? WORDTYPE_MAX
+                          : llvm::maskTrailingOnes<WordType>(BitWidth);
       return ((U.VAL | RHS.U.VAL) & Mask) == Mask;
     }
     return isExhaustiveSlowCase(RHS);

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -1268,6 +1268,18 @@ public:
     return isSubsetOfSlowCase(RHS);
   }
 
+  /// This operation checks if valid bits exclusively set in this APInt or RHS.
+  bool isExhaustive(const APInt &RHS) const {
+    assert(BitWidth == RHS.BitWidth && "Bit widths must be the same");
+    if (isSingleWord()) {
+      WordType Mask = BitWidth == APINT_BITS_PER_WORD
+                    ? WORDTYPE_MAX
+                    : llvm::maskTrailingOnes<WordType>(BitWidth);
+      return ((U.VAL | RHS.U.VAL) & Mask) == Mask;
+    }
+    return isExhaustiveSlowCase(RHS);
+  }
+
   /// @}
   /// \name Resizing Operators
   /// @{
@@ -2093,6 +2105,9 @@ private:
 
   /// out-of-line slow case for isSubsetOf.
   LLVM_ABI bool isSubsetOfSlowCase(const APInt &RHS) const LLVM_READONLY;
+
+  /// out-of-line slow case for isExhaustive.
+  LLVM_ABI bool isExhaustiveSlowCase(const APInt &RHS) const LLVM_READONLY;
 
   /// out-of-line slow case for setBits.
   LLVM_ABI void setBitsSlowCase(unsigned loBit, unsigned hiBit);

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -1271,12 +1271,8 @@ public:
   /// This operation checks if valid bits exclusively set in this APInt or RHS.
   bool isExhaustive(const APInt &RHS) const {
     assert(BitWidth == RHS.BitWidth && "Bit widths must be the same");
-    if (isSingleWord()) {
-      WordType Mask = BitWidth == APINT_BITS_PER_WORD
-                          ? WORDTYPE_MAX
-                          : llvm::maskTrailingOnes<WordType>(BitWidth);
-      return ((U.VAL | RHS.U.VAL) & Mask) == Mask;
-    }
+    if (isSingleWord())
+      return (U.VAL | RHS.U.VAL) == llvm::maskTrailingOnes<WordType>(BitWidth);
     return isExhaustiveSlowCase(RHS);
   }
 

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -1269,11 +1269,11 @@ public:
   }
 
   /// This operation checks if all bits are set in either this or RHS.
-  bool isExhaustive(const APInt &RHS) const {
+  bool isInverseOf(const APInt &RHS) const {
     assert(BitWidth == RHS.BitWidth && "Bit widths must be the same");
     if (isSingleWord())
-      return (U.VAL | RHS.U.VAL) == llvm::maskTrailingOnes<WordType>(BitWidth);
-    return isExhaustiveSlowCase(RHS);
+      return (U.VAL ^ RHS.U.VAL) == llvm::maskTrailingOnes<WordType>(BitWidth);
+    return isInverseOfSlowCase(RHS);
   }
 
   /// @}
@@ -2102,8 +2102,8 @@ private:
   /// out-of-line slow case for isSubsetOf.
   LLVM_ABI bool isSubsetOfSlowCase(const APInt &RHS) const LLVM_READONLY;
 
-  /// out-of-line slow case for isExhaustive.
-  LLVM_ABI bool isExhaustiveSlowCase(const APInt &RHS) const LLVM_READONLY;
+  /// out-of-line slow case for isInverseOf.
+  LLVM_ABI bool isInverseOfSlowCase(const APInt &RHS) const LLVM_READONLY;
 
   /// out-of-line slow case for setBits.
   LLVM_ABI void setBitsSlowCase(unsigned loBit, unsigned hiBit);

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -1268,6 +1268,14 @@ public:
     return isSubsetOfSlowCase(RHS);
   }
 
+  /// This operation checks if all bits are set in either this or RHS.
+  bool isExhaustive(const APInt &RHS) const {
+    assert(BitWidth == RHS.BitWidth && "Bit widths must be the same");
+    if (isSingleWord())
+      return (U.VAL | RHS.U.VAL) == llvm::maskTrailingOnes<WordType>(BitWidth);
+    return isExhaustiveSlowCase(RHS);
+  }
+
   /// @}
   /// \name Resizing Operators
   /// @{
@@ -2093,6 +2101,9 @@ private:
 
   /// out-of-line slow case for isSubsetOf.
   LLVM_ABI bool isSubsetOfSlowCase(const APInt &RHS) const LLVM_READONLY;
+
+  /// out-of-line slow case for isExhaustive.
+  LLVM_ABI bool isExhaustiveSlowCase(const APInt &RHS) const LLVM_READONLY;
 
   /// out-of-line slow case for setBits.
   LLVM_ABI void setBitsSlowCase(unsigned loBit, unsigned hiBit);

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -1268,14 +1268,6 @@ public:
     return isSubsetOfSlowCase(RHS);
   }
 
-  /// This operation checks if all bits are set in either this or RHS.
-  bool isExhaustive(const APInt &RHS) const {
-    assert(BitWidth == RHS.BitWidth && "Bit widths must be the same");
-    if (isSingleWord())
-      return (U.VAL | RHS.U.VAL) == llvm::maskTrailingOnes<WordType>(BitWidth);
-    return isExhaustiveSlowCase(RHS);
-  }
-
   /// @}
   /// \name Resizing Operators
   /// @{
@@ -2101,9 +2093,6 @@ private:
 
   /// out-of-line slow case for isSubsetOf.
   LLVM_ABI bool isSubsetOfSlowCase(const APInt &RHS) const LLVM_READONLY;
-
-  /// out-of-line slow case for isExhaustive.
-  LLVM_ABI bool isExhaustiveSlowCase(const APInt &RHS) const LLVM_READONLY;
 
   /// out-of-line slow case for setBits.
   LLVM_ABI void setBitsSlowCase(unsigned loBit, unsigned hiBit);

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -1268,7 +1268,7 @@ public:
     return isSubsetOfSlowCase(RHS);
   }
 
-  /// This operation checks if valid bits exclusively set in this APInt or RHS.
+  /// This operation checks if all bits are set in either this or RHS.
   bool isExhaustive(const APInt &RHS) const {
     assert(BitWidth == RHS.BitWidth && "Bit widths must be the same");
     if (isSingleWord())

--- a/llvm/include/llvm/Support/KnownBits.h
+++ b/llvm/include/llvm/Support/KnownBits.h
@@ -52,7 +52,10 @@ public:
 
   /// Returns true if we know the value of all bits.
   bool isConstant() const {
-    return Zero.popcount() + One.popcount() == getBitWidth();
+    if (Zero.isSingleWord())
+      return (Zero.getZExtValue() | One.getZExtValue()) ==
+             llvm::maskTrailingOnes<uint64_t>(getBitWidth());
+    return isConstantSlowCase();
   }
 
   /// Returns the value when all bits have a known value. This just returns One
@@ -576,6 +579,9 @@ private:
   // Internal helper for getting the initial KnownBits for an `srem` or `urem`
   // operation with the low-bits set.
   static KnownBits remGetLowBits(const KnownBits &LHS, const KnownBits &RHS);
+
+  /// Multi-word case helper for isConstant().
+  bool isConstantSlowCase() const;
 };
 
 inline KnownBits operator&(KnownBits LHS, const KnownBits &RHS) {

--- a/llvm/include/llvm/Support/KnownBits.h
+++ b/llvm/include/llvm/Support/KnownBits.h
@@ -51,9 +51,7 @@ public:
   bool hasConflict() const { return Zero.intersects(One); }
 
   /// Returns true if we know the value of all bits.
-  bool isConstant() const {
-    return Zero.isExhaustive(One);
-  }
+  bool isConstant() const { return Zero.isExhaustive(One); }
 
   /// Returns the value when all bits have a known value. This just returns One
   /// with a protective assertion.

--- a/llvm/include/llvm/Support/KnownBits.h
+++ b/llvm/include/llvm/Support/KnownBits.h
@@ -52,7 +52,7 @@ public:
 
   /// Returns true if we know the value of all bits.
   bool isConstant() const {
-    if (Zero.isSingleWord())
+    if (LLVM_LIKELY(Zero.isSingleWord()))
       return (Zero.getZExtValue() | One.getZExtValue()) ==
              llvm::maskTrailingOnes<uint64_t>(getBitWidth());
     return isConstantSlowCase();

--- a/llvm/include/llvm/Support/KnownBits.h
+++ b/llvm/include/llvm/Support/KnownBits.h
@@ -52,10 +52,7 @@ public:
 
   /// Returns true if we know the value of all bits.
   bool isConstant() const {
-    if (LLVM_LIKELY(Zero.isSingleWord()))
-      return (Zero.getZExtValue() | One.getZExtValue()) ==
-             llvm::maskTrailingOnes<uint64_t>(getBitWidth());
-    return isConstantSlowCase();
+    return Zero.isExhaustive(One);
   }
 
   /// Returns the value when all bits have a known value. This just returns One
@@ -579,9 +576,6 @@ private:
   // Internal helper for getting the initial KnownBits for an `srem` or `urem`
   // operation with the low-bits set.
   static KnownBits remGetLowBits(const KnownBits &LHS, const KnownBits &RHS);
-
-  /// Multi-word case helper for isConstant().
-  bool isConstantSlowCase() const;
 };
 
 inline KnownBits operator&(KnownBits LHS, const KnownBits &RHS) {

--- a/llvm/include/llvm/Support/KnownBits.h
+++ b/llvm/include/llvm/Support/KnownBits.h
@@ -51,7 +51,7 @@ public:
   bool hasConflict() const { return Zero.intersects(One); }
 
   /// Returns true if we know the value of all bits.
-  bool isConstant() const { return Zero.isExhaustive(One); }
+  bool isConstant() const { return Zero.isInverseOf(One); }
 
   /// Returns the value when all bits have a known value. This just returns One
   /// with a protective assertion.

--- a/llvm/include/llvm/Support/KnownBits.h
+++ b/llvm/include/llvm/Support/KnownBits.h
@@ -51,7 +51,7 @@ public:
   bool hasConflict() const { return Zero.intersects(One); }
 
   /// Returns true if we know the value of all bits.
-  bool isConstant() const { return Zero.isExhaustive(One); }
+  bool isConstant() const { return Zero == ~One; }
 
   /// Returns the value when all bits have a known value. This just returns One
   /// with a protective assertion.

--- a/llvm/include/llvm/Support/KnownBits.h
+++ b/llvm/include/llvm/Support/KnownBits.h
@@ -51,7 +51,7 @@ public:
   bool hasConflict() const { return Zero.intersects(One); }
 
   /// Returns true if we know the value of all bits.
-  bool isConstant() const { return Zero == ~One; }
+  bool isConstant() const { return Zero.isExhaustive(One); }
 
   /// Returns the value when all bits have a known value. This just returns One
   /// with a protective assertion.

--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -755,16 +755,13 @@ bool APInt::isSubsetOfSlowCase(const APInt &RHS) const {
 
 bool APInt::isExhaustiveSlowCase(const APInt &RHS) const {
   const unsigned Last = getNumWords() - 1;
-  const WordType *LHSWords = getRawData();
-  const WordType *RHSWords = RHS.getRawData();
-
   for (unsigned I = 0; I != Last; ++I)
-    if ((LHSWords[I] | RHSWords[I]) != WORDTYPE_MAX)
+    if ((U.pVal[I] | RHS.U.pVal[I]) != WORDTYPE_MAX)
       return false;
 
   unsigned TailBits = BitWidth - Last * APINT_BITS_PER_WORD;
   WordType TailMask = llvm::maskTrailingOnes<WordType>(TailBits);
-  return ((LHSWords[Last] | RHSWords[Last]) & TailMask) == TailMask;
+  return ((U.pVal[Last] | RHS.U.pVal[Last]) & TailMask) == TailMask;
 }
 
 APInt APInt::byteSwap() const {

--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -761,7 +761,7 @@ bool APInt::isExhaustiveSlowCase(const APInt &RHS) const {
 
   unsigned TailBits = BitWidth - Last * APINT_BITS_PER_WORD;
   WordType TailMask = llvm::maskTrailingOnes<WordType>(TailBits);
-  return ((U.pVal[Last] | RHS.U.pVal[Last]) & TailMask) == TailMask;
+  return (U.pVal[Last] | RHS.U.pVal[Last]) == TailMask;
 }
 
 APInt APInt::byteSwap() const {

--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -753,6 +753,20 @@ bool APInt::isSubsetOfSlowCase(const APInt &RHS) const {
   return true;
 }
 
+bool APInt::isExhaustiveSlowCase(const APInt &RHS) const {
+  const unsigned Last = getNumWords() - 1;
+  const WordType *LHSWords = getRawData();
+  const WordType *RHSWords = RHS.getRawData();
+
+  for (unsigned I = 0; I != Last; ++I)
+    if ((LHSWords[I] | RHSWords[I]) != WORDTYPE_MAX)
+      return false;
+
+  unsigned TailBits = BitWidth - Last * APINT_BITS_PER_WORD;
+  WordType TailMask = llvm::maskTrailingOnes<WordType>(TailBits);
+  return ((LHSWords[Last] | RHSWords[Last]) & TailMask) == TailMask;
+}
+
 APInt APInt::byteSwap() const {
   assert(BitWidth >= 16 && BitWidth % 8 == 0 && "Cannot byteswap!");
   if (BitWidth == 16)

--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -753,6 +753,17 @@ bool APInt::isSubsetOfSlowCase(const APInt &RHS) const {
   return true;
 }
 
+bool APInt::isExhaustiveSlowCase(const APInt &RHS) const {
+  const unsigned Last = getNumWords() - 1;
+  for (unsigned I = 0; I != Last; ++I)
+    if ((U.pVal[I] | RHS.U.pVal[I]) != WORDTYPE_MAX)
+      return false;
+
+  unsigned TailBits = BitWidth - Last * APINT_BITS_PER_WORD;
+  WordType TailMask = llvm::maskTrailingOnes<WordType>(TailBits);
+  return (U.pVal[Last] | RHS.U.pVal[Last]) == TailMask;
+}
+
 APInt APInt::byteSwap() const {
   assert(BitWidth >= 16 && BitWidth % 8 == 0 && "Cannot byteswap!");
   if (BitWidth == 16)

--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -753,17 +753,6 @@ bool APInt::isSubsetOfSlowCase(const APInt &RHS) const {
   return true;
 }
 
-bool APInt::isExhaustiveSlowCase(const APInt &RHS) const {
-  const unsigned Last = getNumWords() - 1;
-  for (unsigned I = 0; I != Last; ++I)
-    if ((U.pVal[I] | RHS.U.pVal[I]) != WORDTYPE_MAX)
-      return false;
-
-  unsigned TailBits = BitWidth - Last * APINT_BITS_PER_WORD;
-  WordType TailMask = llvm::maskTrailingOnes<WordType>(TailBits);
-  return (U.pVal[Last] | RHS.U.pVal[Last]) == TailMask;
-}
-
 APInt APInt::byteSwap() const {
   assert(BitWidth >= 16 && BitWidth % 8 == 0 && "Cannot byteswap!");
   if (BitWidth == 16)

--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -753,15 +753,15 @@ bool APInt::isSubsetOfSlowCase(const APInt &RHS) const {
   return true;
 }
 
-bool APInt::isExhaustiveSlowCase(const APInt &RHS) const {
+bool APInt::isInverseOfSlowCase(const APInt &RHS) const {
   const unsigned Last = getNumWords() - 1;
   for (unsigned I = 0; I != Last; ++I)
-    if ((U.pVal[I] | RHS.U.pVal[I]) != WORDTYPE_MAX)
+    if ((U.pVal[I] ^ RHS.U.pVal[I]) != WORDTYPE_MAX)
       return false;
 
   unsigned TailBits = BitWidth - Last * APINT_BITS_PER_WORD;
   WordType TailMask = llvm::maskTrailingOnes<WordType>(TailBits);
-  return (U.pVal[Last] | RHS.U.pVal[Last]) == TailMask;
+  return (U.pVal[Last] ^ RHS.U.pVal[Last]) == TailMask;
 }
 
 APInt APInt::byteSwap() const {

--- a/llvm/lib/Support/KnownBits.cpp
+++ b/llvm/lib/Support/KnownBits.cpp
@@ -19,20 +19,6 @@
 
 using namespace llvm;
 
-bool KnownBits::isConstantSlowCase() const {
-  const unsigned Last = Zero.getNumWords() - 1;
-  const uint64_t *Zeros = Zero.getRawData();
-  const uint64_t *Ones = One.getRawData();
-
-  for (unsigned I = 0; I != Last; ++I)
-    if ((Zeros[I] | Ones[I]) != UINT64_MAX)
-      return false;
-
-  unsigned TailBits = getBitWidth() - Last * APInt::APINT_BITS_PER_WORD;
-  uint64_t TailMask = llvm::maskTrailingOnes<uint64_t>(TailBits);
-  return ((Zeros[Last] | Ones[Last]) & TailMask) == TailMask;
-}
-
 KnownBits KnownBits::flipSignBit(const KnownBits &Val) {
   unsigned SignBitPosition = Val.getBitWidth() - 1;
   APInt Zero = Val.Zero;

--- a/llvm/lib/Support/KnownBits.cpp
+++ b/llvm/lib/Support/KnownBits.cpp
@@ -20,17 +20,17 @@
 using namespace llvm;
 
 bool KnownBits::isConstantSlowCase() const {
-  const unsigned LastWord = Zero.getNumWords() - 1;
+  const unsigned Last = Zero.getNumWords() - 1;
   const uint64_t *Zeros = Zero.getRawData();
   const uint64_t *Ones = One.getRawData();
 
-  for (unsigned I = 0; I != LastWord; ++I)
+  for (unsigned I = 0; I != Last; ++I)
     if ((Zeros[I] | Ones[I]) != UINT64_MAX)
       return false;
 
-  unsigned TailBits = getBitWidth() - LastWord * APInt::APINT_BITS_PER_WORD;
+  unsigned TailBits = getBitWidth() - Last * APInt::APINT_BITS_PER_WORD;
   uint64_t TailMask = llvm::maskTrailingOnes<uint64_t>(TailBits);
-  return ((Zeros[LastWord] | Ones[LastWord]) & TailMask) == TailMask;
+  return ((Zeros[Last] | Ones[Last]) & TailMask) == TailMask;
 }
 
 KnownBits KnownBits::flipSignBit(const KnownBits &Val) {

--- a/llvm/lib/Support/KnownBits.cpp
+++ b/llvm/lib/Support/KnownBits.cpp
@@ -19,6 +19,20 @@
 
 using namespace llvm;
 
+bool KnownBits::isConstantSlowCase() const {
+  const unsigned LastWord = Zero.getNumWords() - 1;
+  const uint64_t *Zeros = Zero.getRawData();
+  const uint64_t *Ones = One.getRawData();
+
+  for (unsigned I = 0; I != LastWord; ++I)
+    if ((Zeros[I] | Ones[I]) != UINT64_MAX)
+      return false;
+
+  unsigned TailBits = getBitWidth() - LastWord * APInt::APINT_BITS_PER_WORD;
+  uint64_t TailMask = llvm::maskTrailingOnes<uint64_t>(TailBits);
+  return ((Zeros[LastWord] | Ones[LastWord]) & TailMask) == TailMask;
+}
+
 KnownBits KnownBits::flipSignBit(const KnownBits &Val) {
   unsigned SignBitPosition = Val.getBitWidth() - 1;
   APInt Zero = Val.Zero;

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -3057,32 +3057,6 @@ TEST(APIntTest, isSubsetOf) {
   EXPECT_TRUE(i128_3.isSubsetOf(i128_3));
 }
 
-TEST(APIntTest, isExhaustive) {
-  APInt i4_0(4, 0);
-  APInt i4_1(4, 1);
-  APInt i4_12(4, 12);
-  APInt i4_14(4, 14);
-  APInt i4_15(4, 15);
-  EXPECT_TRUE(i4_1.isExhaustive(i4_14));
-  EXPECT_TRUE(i4_14.isExhaustive(i4_1));
-  EXPECT_FALSE(i4_1.isExhaustive(i4_12));
-  EXPECT_FALSE(i4_0.isExhaustive(i4_0));
-  EXPECT_TRUE(i4_15.isExhaustive(i4_0));
-
-  APInt i128Lo64 = APInt::getLowBitsSet(128, 64);
-  APInt i128Hi64 = APInt::getHighBitsSet(128, 64);
-  APInt i128Hi63 = APInt::getHighBitsSet(128, 63);
-  EXPECT_TRUE(i128Lo64.isExhaustive(i128Hi64));
-  EXPECT_TRUE(i128Hi64.isExhaustive(i128Lo64));
-  EXPECT_FALSE(i128Lo64.isExhaustive(i128Hi63));
-
-  APInt i65Lo64 = APInt::getLowBitsSet(65, 64);
-  APInt i65Hi1 = APInt::getHighBitsSet(65, 1);
-  EXPECT_TRUE(i65Lo64.isExhaustive(i65Hi1));
-  EXPECT_TRUE(i65Hi1.isExhaustive(i65Lo64));
-  EXPECT_FALSE(i65Lo64.isExhaustive(APInt(65, 0)));
-}
-
 TEST(APIntTest, sext) {
   EXPECT_EQ(0, APInt(1, 0).sext(64));
   EXPECT_EQ(~uint64_t(0), APInt(1, 1).sext(64));

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -3057,30 +3057,33 @@ TEST(APIntTest, isSubsetOf) {
   EXPECT_TRUE(i128_3.isSubsetOf(i128_3));
 }
 
-TEST(APIntTest, isExhaustive) {
+TEST(APIntTest, isInverseOf) {
   APInt i4_0(4, 0);
   APInt i4_1(4, 1);
+  APInt i4_3(4, 3);
   APInt i4_12(4, 12);
+  APInt i4_13(4, 13);
   APInt i4_14(4, 14);
   APInt i4_15(4, 15);
-  EXPECT_TRUE(i4_1.isExhaustive(i4_14));
-  EXPECT_TRUE(i4_14.isExhaustive(i4_1));
-  EXPECT_FALSE(i4_1.isExhaustive(i4_12));
-  EXPECT_FALSE(i4_0.isExhaustive(i4_0));
-  EXPECT_TRUE(i4_15.isExhaustive(i4_0));
+  EXPECT_TRUE(i4_1.isInverseOf(i4_14));
+  EXPECT_TRUE(i4_14.isInverseOf(i4_1));
+  EXPECT_FALSE(i4_1.isInverseOf(i4_12));
+  EXPECT_FALSE(i4_3.isInverseOf(i4_13));
+  EXPECT_FALSE(i4_0.isInverseOf(i4_0));
+  EXPECT_TRUE(i4_15.isInverseOf(i4_0));
 
   APInt i128Lo64 = APInt::getLowBitsSet(128, 64);
   APInt i128Hi64 = APInt::getHighBitsSet(128, 64);
   APInt i128Hi63 = APInt::getHighBitsSet(128, 63);
-  EXPECT_TRUE(i128Lo64.isExhaustive(i128Hi64));
-  EXPECT_TRUE(i128Hi64.isExhaustive(i128Lo64));
-  EXPECT_FALSE(i128Lo64.isExhaustive(i128Hi63));
+  EXPECT_TRUE(i128Lo64.isInverseOf(i128Hi64));
+  EXPECT_TRUE(i128Hi64.isInverseOf(i128Lo64));
+  EXPECT_FALSE(i128Lo64.isInverseOf(i128Hi63));
 
   APInt i65Lo64 = APInt::getLowBitsSet(65, 64);
   APInt i65Hi1 = APInt::getHighBitsSet(65, 1);
-  EXPECT_TRUE(i65Lo64.isExhaustive(i65Hi1));
-  EXPECT_TRUE(i65Hi1.isExhaustive(i65Lo64));
-  EXPECT_FALSE(i65Lo64.isExhaustive(APInt(65, 0)));
+  EXPECT_TRUE(i65Lo64.isInverseOf(i65Hi1));
+  EXPECT_TRUE(i65Hi1.isInverseOf(i65Lo64));
+  EXPECT_FALSE(i65Lo64.isInverseOf(APInt(65, 0)));
 }
 
 TEST(APIntTest, sext) {

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -3057,6 +3057,32 @@ TEST(APIntTest, isSubsetOf) {
   EXPECT_TRUE(i128_3.isSubsetOf(i128_3));
 }
 
+TEST(APIntTest, isExhaustive) {
+  APInt i4_0(4, 0);
+  APInt i4_1(4, 1);
+  APInt i4_12(4, 12);
+  APInt i4_14(4, 14);
+  APInt i4_15(4, 15);
+  EXPECT_TRUE(i4_1.isExhaustive(i4_14));
+  EXPECT_TRUE(i4_14.isExhaustive(i4_1));
+  EXPECT_FALSE(i4_1.isExhaustive(i4_12));
+  EXPECT_FALSE(i4_0.isExhaustive(i4_0));
+  EXPECT_TRUE(i4_15.isExhaustive(i4_0));
+
+  APInt i128Lo64 = APInt::getLowBitsSet(128, 64);
+  APInt i128Hi64 = APInt::getHighBitsSet(128, 64);
+  APInt i128Hi63 = APInt::getHighBitsSet(128, 63);
+  EXPECT_TRUE(i128Lo64.isExhaustive(i128Hi64));
+  EXPECT_TRUE(i128Hi64.isExhaustive(i128Lo64));
+  EXPECT_FALSE(i128Lo64.isExhaustive(i128Hi63));
+
+  APInt i65Lo64 = APInt::getLowBitsSet(65, 64);
+  APInt i65Hi1 = APInt::getHighBitsSet(65, 1);
+  EXPECT_TRUE(i65Lo64.isExhaustive(i65Hi1));
+  EXPECT_TRUE(i65Hi1.isExhaustive(i65Lo64));
+  EXPECT_FALSE(i65Lo64.isExhaustive(APInt(65, 0)));
+}
+
 TEST(APIntTest, sext) {
   EXPECT_EQ(0, APInt(1, 0).sext(64));
   EXPECT_EQ(~uint64_t(0), APInt(1, 1).sext(64));


### PR DESCRIPTION
`isConstant` used is quite often and should be as lightweight as possible. Add `APInt::isInverseOf` and utilize it for `isConstant`. It is equivalent to `LHS == ~RHS`, but avoids intermediate allocations.