### PR TITLE
[clang-tidy] Emit deprecation warning for preformance-faster-string-find

### DIFF
--- a/clang-tools-extra/clang-tidy/performance/PreferSingleCharOverloadsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/PreferSingleCharOverloadsCheck.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PreferSingleCharOverloadsCheck.h"
+#include "../utils/CheckUtils.h"
 #include "../utils/OptionsUtils.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "llvm/Support/raw_ostream.h"
@@ -15,6 +16,15 @@
 using namespace clang::ast_matchers;
 
 namespace clang::tidy::performance {
+
+namespace {
+
+constexpr llvm::StringLiteral DeprecatedCheckName =
+    "performance-faster-string-find";
+constexpr llvm::StringLiteral CanonicalCheckName =
+    "performance-prefer-single-char-overloads";
+
+} // namespace
 
 static std::optional<std::string>
 makeCharacterLiteral(const StringLiteral *Literal) {
@@ -46,7 +56,11 @@ PreferSingleCharOverloadsCheck::PreferSingleCharOverloadsCheck(
     : ClangTidyCheck(Name, Context),
       StringLikeClasses(utils::options::parseStringList(
           Options.get("StringLikeClasses",
-                      "::std::basic_string;::std::basic_string_view"))) {}
+                      "::std::basic_string;::std::basic_string_view"))) {
+  if (Name == DeprecatedCheckName)
+    utils::diagDeprecatedCheckAlias(*this, *Context, DeprecatedCheckName,
+                                    CanonicalCheckName);
+}
 
 void PreferSingleCharOverloadsCheck::storeOptions(
     ClangTidyOptions::OptionMap &Opts) {

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/prefer-single-char-overloads-alias.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/prefer-single-char-overloads-alias.cpp
@@ -1,18 +1,6 @@
 // RUN: %check_clang_tidy %s performance-faster-string-find %t
-// RUN: %check_clang_tidy -check-suffix=CUSTOM %s performance-faster-string-find %t -- \
-// RUN:   -config="{CheckOptions: \
-// RUN:             {performance-faster-string-find.StringLikeClasses: \
-// RUN:                '::llvm::StringRef;'}}"
-// RUN: %check_clang_tidy -check-suffix=BOTH %s \
-// RUN:   performance-faster-string-find,performance-prefer-single-char-overloads %t
 
 #include <string>
-
-namespace llvm {
-struct StringRef {
-  int find(const char *) const;
-};
-} // namespace llvm
 
 void stringFind() {
   std::string Str;
@@ -20,13 +8,4 @@ void stringFind() {
   // CHECK-MESSAGES: warning: 'performance-faster-string-find' check is deprecated and will be removed in a future release; consider using 'performance-prefer-single-char-overloads' instead [clang-tidy-config]
   // CHECK-MESSAGES: [[@LINE-2]]:12: warning: 'find' called with a string literal consisting of a single character; consider using the more efficient overload accepting a character [performance-faster-string-find]
   // CHECK-FIXES: Str.find('a');
-  // CHECK-MESSAGES-BOTH: [[@LINE-4]]:12: warning: 'find' called with a string literal consisting of a single character; consider using the more efficient overload accepting a character
-}
-
-void customStringLikeClass() {
-  llvm::StringRef Sr;
-  Sr.find("x");
-  // CHECK-MESSAGES-CUSTOM: warning: 'performance-faster-string-find' check is deprecated and will be removed in a future release; consider using 'performance-prefer-single-char-overloads' instead [clang-tidy-config]
-  // CHECK-MESSAGES-CUSTOM: [[@LINE-2]]:11: warning: 'find' called with a string literal consisting of a single character; consider using the more efficient overload accepting a character [performance-faster-string-find]
-  // CHECK-FIXES-CUSTOM: Sr.find('x');
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/prefer-single-char-overloads-alias.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/prefer-single-char-overloads-alias.cpp
@@ -1,0 +1,32 @@
+// RUN: %check_clang_tidy %s performance-faster-string-find %t
+// RUN: %check_clang_tidy -check-suffix=CUSTOM %s performance-faster-string-find %t -- \
+// RUN:   -config="{CheckOptions: \
+// RUN:             {performance-faster-string-find.StringLikeClasses: \
+// RUN:                '::llvm::StringRef;'}}"
+// RUN: %check_clang_tidy -check-suffix=BOTH %s \
+// RUN:   performance-faster-string-find,performance-prefer-single-char-overloads %t
+
+#include <string>
+
+namespace llvm {
+struct StringRef {
+  int find(const char *) const;
+};
+} // namespace llvm
+
+void stringFind() {
+  std::string Str;
+  Str.find("a");
+  // CHECK-MESSAGES: warning: 'performance-faster-string-find' check is deprecated and will be removed in a future release; consider using 'performance-prefer-single-char-overloads' instead [clang-tidy-config]
+  // CHECK-MESSAGES: [[@LINE-2]]:12: warning: 'find' called with a string literal consisting of a single character; consider using the more efficient overload accepting a character [performance-faster-string-find]
+  // CHECK-FIXES: Str.find('a');
+  // CHECK-MESSAGES-BOTH: [[@LINE-4]]:12: warning: 'find' called with a string literal consisting of a single character; consider using the more efficient overload accepting a character
+}
+
+void customStringLikeClass() {
+  llvm::StringRef Sr;
+  Sr.find("x");
+  // CHECK-MESSAGES-CUSTOM: warning: 'performance-faster-string-find' check is deprecated and will be removed in a future release; consider using 'performance-prefer-single-char-overloads' instead [clang-tidy-config]
+  // CHECK-MESSAGES-CUSTOM: [[@LINE-2]]:11: warning: 'find' called with a string literal consisting of a single character; consider using the more efficient overload accepting a character [performance-faster-string-find]
+  // CHECK-FIXES-CUSTOM: Sr.find('x');
+}


### PR DESCRIPTION
Related discussion in: https://github.com/llvm/llvm-project/pull/186946#discussion_r2983649044