### PR TITLE
[CIR] Implement __builtin_verbose_trap

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1336,6 +1336,9 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
     emitTrap(loc, /*createNewBlock=*/true);
     return RValue::getIgnored();
   case Builtin::BI__builtin_verbose_trap:
+    assert(!cir::MissingFeatures::generateDebugInfo());
+    emitTrap(loc, /*createNewBlock=*/true);
+    return RValue::getIgnored();
   case Builtin::BI__debugbreak:
     return errorBuiltinNYI(*this, e, builtinID);
   case Builtin::BI__builtin_unreachable:

--- a/clang/test/CIR/CodeGen/builtin-verbose-trap.cpp
+++ b/clang/test/CIR/CodeGen/builtin-verbose-trap.cpp
@@ -1,0 +1,35 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+void test_basic() {
+  __builtin_verbose_trap("Category", "Reason");
+}
+
+// CIR: cir.func {{.*}}@_Z10test_basicv()
+// CIR:   cir.trap
+// LLVM: define{{.*}} void @_Z10test_basicv()
+// LLVM:   call void @llvm.trap()
+// OGCG: define{{.*}} void @_Z10test_basicv()
+// OGCG:   call void @llvm.trap()
+
+void test_multiple(bool cond) {
+  if (cond) {
+    __builtin_verbose_trap("Cat1", "Reason1");
+  } else {
+    __builtin_verbose_trap("Cat2", "Reason2");
+  }
+}
+
+// CIR: cir.func {{.*}}@_Z13test_multipleb
+// CIR:   cir.trap
+// CIR:   cir.trap
+// LLVM: define{{.*}} void @_Z13test_multipleb
+// LLVM:   call void @llvm.trap()
+// LLVM:   call void @llvm.trap()
+// OGCG: define{{.*}} void @_Z13test_multipleb
+// OGCG:   call void @llvm.trap()
+// OGCG:   call void @llvm.trap()


### PR DESCRIPTION
Route BI__builtin_verbose_trap to the existing emitTrap() path so that it no longer hits the NYI fallback. Debug info message attachment from the string arguments is not yet implemented (tracked by MissingFeatures::generateDebugInfo).

This is the single largest NYI category in libcxx testing, unblocking ~1,008 test failures.