### PR TITLE
[clang][OpenMP][test] Use -fopenmp=libomp explicitly in driver smoke test

### DIFF
--- a/clang/test/OpenMP/split_driver_smoke.c
+++ b/clang/test/OpenMP/split_driver_smoke.c
@@ -1,7 +1,7 @@
 // Driver forwards `-fopenmp-version=60` with split source (`###` only — no link).
 // REQUIRES: x86-registered-target
 //
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp -fopenmp-version=60 -c %s -o %t.o 2>&1 | FileCheck %s --check-prefix=INVOC
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp -fopenmp-version=60 -c %s -o %t.o 2>&1 | FileCheck %s --check-prefix=INVOC
 
 void f(int n) {
 #pragma omp split counts(2, omp_fill)


### PR DESCRIPTION
Using -fopenmp uses the default openmp lib, which defaults to libomp but may be something else. This test only passes with libomp, so it passes when using default, but fails downstream if configured for something else, like libgomp.