### PR TITLE
[NFC] Use stable_sort to fix the basic-block-sections-code-prefetch.l test.

### DIFF
--- a/llvm/lib/CodeGen/InsertCodePrefetch.cpp
+++ b/llvm/lib/CodeGen/InsertCodePrefetch.cpp
@@ -112,7 +112,7 @@ insertPrefetchHints(MachineFunction &MF,
   // Sort prefetch hints by their callsite index so we can insert them by one
   // pass over the block's instructions.
   for (auto &[SiteBBID, Hints] : PrefetchHintsBySiteBBID) {
-    llvm::sort(Hints, [](const PrefetchHint &H1, const PrefetchHint &H2) {
+    llvm::stable_sort(Hints, [](const PrefetchHint &H1, const PrefetchHint &H2) {
       return H1.SiteID.CallsiteIndex < H2.SiteID.CallsiteIndex;
     });
   }


### PR DESCRIPTION
This fixes https://lab.llvm.org/buildbot/#/builders/187/builds/18954.