### PR TITLE
[lldb][AArch64] Fix typeo in AArch64 DoFixAddr highmem

### DIFF
--- a/lldb/source/Plugins/ABI/AArch64/ABIMacOSX_arm64.cpp
+++ b/lldb/source/Plugins/ABI/AArch64/ABIMacOSX_arm64.cpp
@@ -773,7 +773,7 @@ static addr_t DoFixAddr(addr_t addr, bool is_code, ProcessSP process_sp) {
 
   if (addr & pac_sign_extension) {
     addr_t highmem_mask = is_code ? process_sp->GetHighmemCodeAddressMask()
-                                  : process_sp->GetHighmemCodeAddressMask();
+                                  : process_sp->GetHighmemDataAddressMask();
     if (highmem_mask != LLDB_INVALID_ADDRESS_MASK)
       return addr | highmem_mask;
     return addr | mask;


### PR DESCRIPTION
Code and Data masks are the same on AArch64, but someone could adopt a Code mask that cleared the low 2 bits, so it's good to correct the mistake.

rdar://174463000