### PR TITLE
[OFFLOAD] Fix interop-print test commands

### DIFF
--- a/offload/test/offloading/interop-print.c
+++ b/offload/test/offloading/interop-print.c
@@ -1,9 +1,7 @@
-// RUN: %libomptarget-compile-amdgcn-amd-amdhsa
-// RUN:   %libomptarget-run-generic 2>&1 | \
+// RUN: %libomptarget-compile-and-run-amdgcn-amd-amdhsa 2>&1 | \
 // RUN:   %fcheck-amdgcn-amd-amdhsa -check-prefixes=AMD
 
-// RUN: %libomptarget-compile-nvptx64-nvidia-cuda
-// RUN:   %libomptarget-run-generic 2>&1 | \
+// RUN: %libomptarget-compile-and-run-nvptx64-nvidia-cuda 2>&1 | \
 // RUN:   %fcheck-nvptx64-nvidia-cuda -check-prefixes=NVIDIA
 
 // RUN: %libomptarget-compile-and-run-spirv64-intel 2>&1 | \


### PR DESCRIPTION
Using %libomptarget-run-generic will fail or run an incorrect binary if the previous %libomptarget-compile becames ignored because there's no such device. Switching to use %libomptarget-compile-and-run-* which doesn't have this issue.

Fixes post-merge issue of #191901