### PR TITLE
[sanitizer] Make internal_close_range available on all POSIX platforms

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_haiku.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_haiku.cpp
@@ -128,6 +128,10 @@ uptr internal_close(fd_t fd) {
   RETURN_AND_SET_ERRNO(_kern_close(fd));
 }
 
+uptr internal_close_range(fd_t lowfd, fd_t highfd, int flags) {
+  return -1;  // Not supported.
+}
+
 uptr internal_open(const char *filename, int flags) {
   CHECK(&_kern_open);
   RETURN_AND_SET_ERRNO(_kern_open(-1, filename, flags, 0));

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -306,11 +306,13 @@ int internal_madvise(uptr addr, uptr length, int advice) {
   return internal_syscall(SYSCALL(madvise), addr, length, advice);
 }
 
-#    if SANITIZER_FREEBSD
 uptr internal_close_range(fd_t lowfd, fd_t highfd, int flags) {
+#    if SANITIZER_FREEBSD
   return internal_syscall(SYSCALL(close_range), lowfd, highfd, flags);
-}
 #    endif
+  // TODO: Add Linux support using __NR_close_range (available since 5.9).
+  return -1;  // Not supported.
+}
 uptr internal_close(fd_t fd) { return internal_syscall(SYSCALL(close), fd); }
 
 uptr internal_open(const char *filename, int flags) {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -170,6 +170,10 @@ uptr internal_close(fd_t fd) {
   return close(fd);
 }
 
+uptr internal_close_range(fd_t lowfd, fd_t highfd, int flags) {
+  return -1;  // Not supported.
+}
+
 uptr internal_open(const char *filename, int flags) {
   return open(filename, flags);
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_netbsd.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_netbsd.cpp
@@ -126,6 +126,10 @@ uptr internal_close(fd_t fd) {
   return _sys_close(fd);
 }
 
+uptr internal_close_range(fd_t lowfd, fd_t highfd, int flags) {
+  return -1;  // Not supported.
+}
+
 uptr internal_open(const char *filename, int flags) {
   CHECK(&_sys_open);
   return _sys_open(filename, flags);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_posix.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_posix.h
@@ -28,9 +28,9 @@ namespace __sanitizer {
 // Don't use directly, use __sanitizer::OpenFile() instead.
 uptr internal_open(const char *filename, int flags);
 uptr internal_open(const char *filename, int flags, u32 mode);
-#  if SANITIZER_FREEBSD
+// Closes all file descriptors from lowfd to highfd (inclusive).
+// Returns 0 on success or non-zero if not supported on this platform.
 uptr internal_close_range(fd_t lowfd, fd_t highfd, int flags);
-#  endif
 uptr internal_close(fd_t fd);
 
 uptr internal_read(fd_t fd, void *buf, uptr count);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_solaris.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_solaris.cpp
@@ -102,6 +102,10 @@ uptr internal_open(const char *filename, int flags, u32 mode) {
   return _REAL64(open)(filename, flags, mode);
 }
 
+uptr internal_close_range(fd_t lowfd, fd_t highfd, int flags) {
+  return -1;  // Not supported.
+}
+
 DECLARE__REAL_AND_INTERNAL(uptr, read, fd_t fd, void *buf, uptr count) {
   return _REAL(read)(fd, buf, count);
 }


### PR DESCRIPTION
Make internal_close_range available on all POSIX platforms so callers can use it without platform-specific #if guards. Platforms without close_range return -1, letting callers fall back gracefully.

Currently only FreeBSD has a real implementation. A TODO is left for adding Linux support (__NR_close_range, kernel 5.9+).

The Linux support will be added in https://github.com/llvm/llvm-project/pull/191450.


