### PR TITLE
[clang][Sema] fix crash on invalid expression with trailing return type and template keyword

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -1514,7 +1514,8 @@ Sema::ActOnCXXTypeConstructExpr(ParsedType TypeRep,
                                           RParenOrBraceLoc, ListInitialization);
   if (Result.isInvalid())
     Result = CreateRecoveryExpr(TInfo->getTypeLoc().getBeginLoc(),
-                                RParenOrBraceLoc, exprs, Ty);
+                                RParenOrBraceLoc, exprs, Ty->isIncompleteType() ? QualType() : Ty);
+
   return Result;
 }
 

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -7047,6 +7047,8 @@ ExprResult Sema::ActOnStartCXXMemberReference(Scope *S, Expr *Base,
   // call.  We'll do more incomplete-type checks later in the lookup process,
   // so just skip this check for ObjC types.
   if (!BaseType->isRecordType()) {
+    if (Base->containsErrors() && BaseType->isIncompleteType())
+      return ExprError();
     ObjectType = ParsedType::make(BaseType);
     MayBePseudoDestructor = true;
     return Base;

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -1514,8 +1514,7 @@ Sema::ActOnCXXTypeConstructExpr(ParsedType TypeRep,
                                           RParenOrBraceLoc, ListInitialization);
   if (Result.isInvalid())
     Result = CreateRecoveryExpr(TInfo->getTypeLoc().getBeginLoc(),
-                                RParenOrBraceLoc, exprs, Ty->isIncompleteType() ? QualType() : Ty);
-
+                                RParenOrBraceLoc, exprs, Ty);
   return Result;
 }
 

--- a/clang/test/Modules/cxx20-10-2-ex5.cpp
+++ b/clang/test/Modules/cxx20-10-2-ex5.cpp
@@ -61,6 +61,5 @@ int main() {
   auto f = rootFinder(2); // OK
                           // error: A is incomplete
   return A{45}.value;     // expected-error {{invalid use of incomplete type 'A'}}
-                          // expected-error@-1 {{member access into incomplete type 'A'}}
-                          // expected-note@std-10-2-ex5-tu1.cpp:12 2{{forward declaration of 'A'}}
+                          // expected-note@std-10-2-ex5-tu1.cpp:12 {{forward declaration of 'A'}}
 }

--- a/clang/test/Modules/cxx20-10-2-ex5.cpp
+++ b/clang/test/Modules/cxx20-10-2-ex5.cpp
@@ -61,5 +61,6 @@ int main() {
   auto f = rootFinder(2); // OK
                           // error: A is incomplete
   return A{45}.value;     // expected-error {{invalid use of incomplete type 'A'}}
-                          // expected-note@std-10-2-ex5-tu1.cpp:12 {{forward declaration of 'A'}}
+                          // expected-error@-1 {{member access into incomplete type 'A'}}
+                          // expected-note@std-10-2-ex5-tu1.cpp:12 2{{forward declaration of 'A'}}
 }

--- a/clang/test/SemaCXX/recovery-expr-type.cpp
+++ b/clang/test/SemaCXX/recovery-expr-type.cpp
@@ -104,7 +104,8 @@ void test() {
 // verify the secondary diagnostic "cannot initialize" is emitted.
 namespace test8 {
 typedef int arr[];
-int v = arr(); // expected-error {{array types cannot be value-initialized}}
+int v = arr(); // expected-error {{array types cannot be value-initialized}} \
+                  expected-error {{cannot initialize a variable of type 'int' with an rvalue of type 'arr'}}
 }
 
 namespace test9 {
@@ -177,18 +178,10 @@ void f() {
 
 namespace test16 {
 // verify we do not crash on incomplete class type.
-template<typename T, typename U> struct A; // expected-note 3{{template is declared here}}
+template<typename T, typename U> struct A; // expected-note 5{{template is declared here}}
 A<int, int> foo() { // expected-error {{implicit instantiation of undefined template}}
   if (1 == 1)
-    return A<int, int>{1}; // expected-error {{implicit instantiation of undefined template}}
-  return A<int, int>(1); // expected-error {{implicit instantiation of undefined template}}
+    return A<int, int>{1}; // expected-error 2{{implicit instantiation of undefined template}}
+  return A<int, int>(1); // expected-error 2{{implicit instantiation of undefined template}}
 }
-}
-
-namespace test17 {
-// Verify we do not crash on trailing expression with template keyword.
-int a((enum b )b {       } // expected-error {{ISO C++ forbids forward references to 'enum' types}} \
-                          // expected-error {{invalid use of incomplete type}} \
-                          // expected-note {{forward declaration of}}
-         -> template c);  // expected-error {{a template argument list is expected after a name prefixed by the template keyword}}
 }

--- a/clang/test/SemaCXX/recovery-expr-type.cpp
+++ b/clang/test/SemaCXX/recovery-expr-type.cpp
@@ -104,8 +104,7 @@ void test() {
 // verify the secondary diagnostic "cannot initialize" is emitted.
 namespace test8 {
 typedef int arr[];
-int v = arr(); // expected-error {{array types cannot be value-initialized}} \
-                  expected-error {{cannot initialize a variable of type 'int' with an rvalue of type 'arr'}}
+int v = arr(); // expected-error {{array types cannot be value-initialized}}
 }
 
 namespace test9 {
@@ -178,10 +177,18 @@ void f() {
 
 namespace test16 {
 // verify we do not crash on incomplete class type.
-template<typename T, typename U> struct A; // expected-note 5{{template is declared here}}
+template<typename T, typename U> struct A; // expected-note 3{{template is declared here}}
 A<int, int> foo() { // expected-error {{implicit instantiation of undefined template}}
   if (1 == 1)
-    return A<int, int>{1}; // expected-error 2{{implicit instantiation of undefined template}}
-  return A<int, int>(1); // expected-error 2{{implicit instantiation of undefined template}}
+    return A<int, int>{1}; // expected-error {{implicit instantiation of undefined template}}
+  return A<int, int>(1); // expected-error {{implicit instantiation of undefined template}}
 }
+}
+
+namespace test17 {
+// Verify we do not crash on trailing expression with template keyword.
+int a((enum b )b {       } // expected-error {{ISO C++ forbids forward references to 'enum' types}} \
+                          // expected-error {{invalid use of incomplete type}} \
+                          // expected-note {{forward declaration of}}
+         -> template c);  // expected-error {{a template argument list is expected after a name prefixed by the template keyword}}
 }

--- a/clang/test/SemaCXX/recovery-expr-type.cpp
+++ b/clang/test/SemaCXX/recovery-expr-type.cpp
@@ -185,3 +185,11 @@ A<int, int> foo() { // expected-error {{implicit instantiation of undefined temp
   return A<int, int>(1); // expected-error 2{{implicit instantiation of undefined template}}
 }
 }
+
+namespace test17 {
+// Verify we do not crash on trailing expression with template keyword.
+int a((enum b )b {       } // expected-error {{ISO C++ forbids forward references to 'enum' types}} \
+                          // expected-error {{invalid use of incomplete type}} \
+                          // expected-note {{forward declaration of}}
+         -> template c);
+}


### PR DESCRIPTION
When the type in a CXXTypeConstructExpr is incomplete, create a RecoveryExpr with an empty QualType to avoid triggering assertion in LookupTemplateName.

Fixes https://github.com/llvm/llvm-project/issues/186579