### PR TITLE
[llvm-mc][AsmMatcherEmitter] Fix the minimum ConversionTable entry size

### DIFF
--- a/llvm/test/TableGen/AsmMatcherFullCustomConversionMethod.td
+++ b/llvm/test/TableGen/AsmMatcherFullCustomConversionMethod.td
@@ -1,0 +1,30 @@
+// RUN: llvm-tblgen -gen-asm-matcher -I %p/../../include %s | FileCheck %s
+
+include "llvm/Target/Target.td"
+
+def ArchInstrInfo : InstrInfo { }
+
+def Arch : Target {
+  let InstructionSet = ArchInstrInfo;
+}
+
+def Reg : Register<"reg">;
+def RegClass : RegisterClass<"foo", [i32], 0, (add Reg)>;
+
+class ArchInstruction<string AsmStr, dag OutOperands, dag InOperands> : Instruction {
+    let OutOperandList = OutOperands;
+    let InOperandList = InOperands;
+    let AsmString = AsmStr;
+    let AsmMatchConverter = "ConvertInstr";
+}
+
+def Instr1 : ArchInstruction<"Instr1", (outs), (ins)>;
+def Instr2 : ArchInstruction<"Instr2", (outs), (ins)>;
+
+// Check that the size of ConversionTable is 3
+
+// CHECK:      static const uint8_t ConversionTable[CVT_NUM_SIGNATURES][3] = {
+// CHECK-NEXT:   // ConvertCustom_ConvertInstr
+// CHECK-NEXT:   { CVT_ConvertInstr, 0, CVT_Done },
+// CHECK-NEXT: };
+

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -2010,7 +2010,10 @@ emitConvertFuncs(CodeGenTarget &Target, StringRef ClassName,
   SmallSetVector<CachedHashString, 16> OperandConversionKinds;
   SmallSetVector<CachedHashString, 16> InstructionConversionKinds;
   std::vector<std::vector<uint8_t>> ConversionTable;
-  size_t MaxRowLength = 2; // minimum is custom converter plus terminator.
+
+  // minimum is custom converter plus a operand index in parsed OperandVector
+  // (0 for custom converter) and terminator (CVT_Done).
+  size_t MaxRowLength = 3;
 
   // TargetOperandClass - This is the target's operand class, like X86Operand.
   std::string TargetOperandClass = Target.getName().str() + "Operand";


### PR DESCRIPTION
[AsmParser] When working on a target with fully customized instruction conversion method, there's a build failure due to the case that in the target's generated asm matcher, the size of `ConversionTable` entry is 2 (i.e., the minimum size defined in `AsmMatcherEmitter` TableGen backend). 
However, for a target that has customized conversion method for all instructions, a `ConversionTable` entry should be looking like: `{ CVT_<the-custom-conversion-method>, <the-position-of-operand>, CVT_Done }`, where the position of operand for custom conversion is by-default 0. 

This commit includes a test case to illustrate this scenario, along with a little fix. 
