### PR TITLE
[llvm][DebugInfo] Add more format/formatv equivalence tests

### DIFF
--- a/llvm/unittests/Support/FormatVariadicTest.cpp
+++ b/llvm/unittests/Support/FormatVariadicTest.cpp
@@ -440,9 +440,12 @@ TEST(FormatAndFormatvTest, StringPadding) {
   // the format string and the padding needs to be one off.
   EXPECT_EQ("[abcd         ]",
             formatv("[{0}]", fmt_pad("abcd", 0, 10 - 1)).str());
-  // We can also use the fmt_align function instead of fmt_pad but it makes it a bit more complex
+  // We can also use the fmt_align function instead of fmt_pad but it makes it a
+  // bit more complex
   EXPECT_EQ("[abcd         ]",
-            formatv("[{0}]", fmt_align("abcd", AlignStyle::Left, 10 + strlen("abcd") - 1 )).str());
+            formatv("[{0}]", fmt_align("abcd", AlignStyle::Left,
+                                       10 + strlen("abcd") - 1))
+                .str());
 }
 
 TEST(FormatAndFormatvTest, Alignment) {

--- a/llvm/unittests/Support/FormatVariadicTest.cpp
+++ b/llvm/unittests/Support/FormatVariadicTest.cpp
@@ -442,6 +442,9 @@ TEST(FormatAndFormatvTest, StringPadding) {
   // the format string and the padding needs to be one off.
   EXPECT_EQ("[abcd         ]",
             formatv("[{0}]", fmt_pad("abcd", 0, 10 - 1)).str());
+  // We can also use the fmt_align function instead of fmt_pad but it makes it a bit more complex
+  EXPECT_EQ("[abcd         ]",
+            formatv("[{0}]", fmt_align("abcd", AlignStyle::Left, 10 + strlen("abcd") - 1 )).str());
 }
 
 TEST(FormatAndFormatvTest, Alignment) {

--- a/llvm/unittests/Support/FormatVariadicTest.cpp
+++ b/llvm/unittests/Support/FormatVariadicTest.cpp
@@ -412,8 +412,56 @@ TEST(FormatAndFormatvTest, EquivalentHexFormatting) {
             formatv("0x{0:x-}", fmt_align(N, AlignStyle::Right, HexDigits, '0'))
                 .str());
 
+  // More examples
+
+  EXPECT_EQ("0x0000000abc",
+            printToString(format("0x%0*" PRIx64, 10, 0xABCULL)));
+  EXPECT_EQ("0x0000000abc",
+            formatv("0x{0:x-}", fmt_align(0xABCULL, AlignStyle::Right, 10, '0'))
+                .str());
+
   EXPECT_EQ("0x000000fe", printToString(format("0x%8.8" PRIx64, 0xfeULL)));
   EXPECT_EQ("0x000000fe", formatv("{0:x+8}", 0xfeULL).str());
+  EXPECT_EQ("0x000000fe", formatv("{0:x8}", 0xfeULL).str());
+
+  EXPECT_EQ("000000fe", printToString(format("%08" PRIx64, 0xfeULL)));
+  EXPECT_EQ("000000fe", formatv("{0:x-8}", 0xfeULL).str());
+
+  EXPECT_EQ("0x000000fb", printToString(format("0x%08.08" PRIx64, 0xfbULL)));
+  EXPECT_EQ("0x000000fb", formatv("{0:x+8}", 0xfbULL).str());
+
+  EXPECT_EQ("123", printToString(format("%x", 0x123)));
+  EXPECT_EQ("123", formatv("{0:x-}", 0x123).str());
+}
+
+TEST(FormatAndFormatvTest, StringPadding) {
+  // The expected string has 9 spaces after "abcd" and a closing bracket.
+  EXPECT_EQ("[abcd         ]",
+            printToString(format("[%s%*c", "abcd", 10, ']')));
+  // With formatv we can use padding but the closing bracket can be included in
+  // the format string and the padding needs to be one off.
+  EXPECT_EQ("[abcd         ]",
+            formatv("[{0}]", fmt_pad("abcd", 0, 10 - 1)).str());
+}
+
+TEST(FormatAndFormatvTest, Alignment) {
+  EXPECT_EQ("250            ", printToString(format("%-15" PRIu32, 0xfa)));
+  EXPECT_EQ("250            ", formatv("{0, -15}", 0xfa).str());
+  EXPECT_EQ("250            ",
+            formatv("{0}", fmt_align(0xfa, AlignStyle::Left, 15)).str());
+
+  EXPECT_EQ("  123", printToString(format("%5u", 123)));
+  EXPECT_EQ("  123", formatv("{0,5:d}", 123).str());
+  EXPECT_EQ("  123",
+            formatv("{0}", fmt_align(123, AlignStyle::Right, 5)).str());
+
+  EXPECT_EQ("001", printToString(format("%03d", 1)));
+  EXPECT_EQ("001", formatv("{0,0+3}", 1).str());
+
+  EXPECT_EQ("foo1     ", printToString(format("%-9s", "foo1")));
+  EXPECT_EQ("foo2     ", formatv("{0,-9}", "foo2").str());
+  EXPECT_EQ("foo3     ", formatv("{0, -9}", "foo3").str());
+  EXPECT_EQ("foo4_____", formatv("{0,_-9}", "foo4").str());
 }
 
 TEST(FormatAndFormatvTest, NonNegativePlusInteger) {

--- a/llvm/unittests/Support/FormatVariadicTest.cpp
+++ b/llvm/unittests/Support/FormatVariadicTest.cpp
@@ -407,12 +407,10 @@ TEST(FormatAndFormatvTest, EquivalentHexFormatting) {
   EXPECT_EQ("0x00000000ff",
             printToString(format("0x%*.*" PRIx64, HexDigits, HexDigits, N)));
 
-  // Now, do the same with formatv()
+  // Now, do the same with formatv().
   EXPECT_EQ("0x00000000ff",
             formatv("0x{0:x-}", fmt_align(N, AlignStyle::Right, HexDigits, '0'))
                 .str());
-
-  // More examples
 
   EXPECT_EQ("0x0000000abc",
             printToString(format("0x%0*" PRIx64, 10, 0xABCULL)));

--- a/llvm/unittests/Support/FormatVariadicTest.cpp
+++ b/llvm/unittests/Support/FormatVariadicTest.cpp
@@ -446,7 +446,7 @@ TEST(FormatAndFormatvTest, StringPadding) {
 
 TEST(FormatAndFormatvTest, Alignment) {
   EXPECT_EQ("250            ", printToString(format("%-15" PRIu32, 0xfa)));
-  EXPECT_EQ("250            ", formatv("{0, -15}", 0xfa).str());
+  EXPECT_EQ("250            ", formatv("{0,-15}", 0xfa).str());
   EXPECT_EQ("250            ",
             formatv("{0}", fmt_align(0xfa, AlignStyle::Left, 15)).str());
 


### PR DESCRIPTION
This is one commit out of of series of commits that deal with the migration from `format()` to `formatv()` in DebugInfo.

The idea for this commit is to show how `formatv()` format strings need to be constructed in order to achieve the same output as with `format()`.

This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* -> llvm/llvm-project#191980