### PR TITLE
[llvm][DebugInfo] Use formatv in DWARFCFIPrinter

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFCFIPrinter.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFCFIPrinter.cpp
@@ -69,9 +69,9 @@ static void printOperand(raw_ostream &OS, const DIDumpOptions &DumpOpts,
     break;
   case CFIProgram::OT_FactoredCodeOffset: // Always Unsigned
     if (P.codeAlign())
-      OS << formatv(" {0}", Operand * P.codeAlign());
+      OS << formatv(" {0}", int64_t(Operand * P.codeAlign()));
     else
-      OS << formatv(" {0}*code_alignment_factor", Operand);
+      OS << formatv(" {0}*code_alignment_factor", int64_t(Operand));
     if (Address && P.codeAlign()) {
       *Address += Operand * P.codeAlign();
       OS << formatv(" to {0:x+}", *Address);
@@ -87,7 +87,7 @@ static void printOperand(raw_ostream &OS, const DIDumpOptions &DumpOpts,
     if (P.dataAlign())
       OS << formatv(" {0}", int64_t(Operand * P.dataAlign()));
     else
-      OS << formatv(" {0}*data_alignment_factor", Operand);
+      OS << formatv(" {0}*data_alignment_factor", int64_t(Operand));
     break;
   case CFIProgram::OT_Register:
     OS << ' ';

--- a/llvm/lib/DebugInfo/DWARF/DWARFCFIPrinter.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFCFIPrinter.cpp
@@ -52,13 +52,13 @@ static void printOperand(raw_ostream &OS, const DIDumpOptions &DumpOpts,
     if (!OpcodeName.empty())
       OS << " " << OpcodeName;
     else
-      OS << format(" Opcode %x", Opcode);
+      OS << formatv(" Opcode {0:x-}", Opcode);
     break;
   }
   case CFIProgram::OT_None:
     break;
   case CFIProgram::OT_Address:
-    OS << format(" %" PRIx64, Operand);
+    OS << formatv(" {0:x-}", Operand);
     Address = Operand;
     break;
   case CFIProgram::OT_Offset:
@@ -69,32 +69,32 @@ static void printOperand(raw_ostream &OS, const DIDumpOptions &DumpOpts,
     break;
   case CFIProgram::OT_FactoredCodeOffset: // Always Unsigned
     if (P.codeAlign())
-      OS << format(" %" PRId64, Operand * P.codeAlign());
+      OS << formatv(" {0}", Operand * P.codeAlign());
     else
-      OS << format(" %" PRId64 "*code_alignment_factor", Operand);
+      OS << formatv(" {0}*code_alignment_factor", Operand);
     if (Address && P.codeAlign()) {
       *Address += Operand * P.codeAlign();
-      OS << format(" to 0x%" PRIx64, *Address);
+      OS << formatv(" to {0:x+}", *Address);
     }
     break;
   case CFIProgram::OT_SignedFactDataOffset:
     if (P.dataAlign())
-      OS << format(" %" PRId64, int64_t(Operand) * P.dataAlign());
+      OS << formatv(" {0}", int64_t(Operand) * P.dataAlign());
     else
-      OS << format(" %" PRId64 "*data_alignment_factor", int64_t(Operand));
+      OS << formatv(" {0}*data_alignment_factor", int64_t(Operand));
     break;
   case CFIProgram::OT_UnsignedFactDataOffset:
     if (P.dataAlign())
-      OS << format(" %" PRId64, Operand * P.dataAlign());
+      OS << formatv(" {0}", int64_t(Operand * P.dataAlign()));
     else
-      OS << format(" %" PRId64 "*data_alignment_factor", Operand);
+      OS << formatv(" {0}*data_alignment_factor", Operand);
     break;
   case CFIProgram::OT_Register:
     OS << ' ';
     printRegister(OS, DumpOpts, Operand);
     break;
   case CFIProgram::OT_AddressSpace:
-    OS << format(" in addrspace%" PRId64, Operand);
+    OS << formatv(" in addrspace{0}", Operand);
     break;
   case CFIProgram::OT_Expression:
     assert(Instr.Expression && "missing DWARFExpression object");


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* -> llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980