### PR TITLE
[llvm][DebugInfo] formatv in DWARFDebugFrame

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugFrame.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugFrame.cpp
@@ -24,6 +24,8 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <cinttypes>
@@ -101,30 +103,34 @@ constexpr uint64_t getCIEId(bool IsDWARF64, bool IsEH) {
 void CIE::dump(raw_ostream &OS, DIDumpOptions DumpOpts) const {
   // A CIE with a zero length is a terminator entry in the .eh_frame section.
   if (DumpOpts.IsEH && Length == 0) {
-    OS << format("%08" PRIx64, Offset) << " ZERO terminator\n";
+    OS << formatv("{0:x-8}", Offset) << " ZERO terminator\n";
     return;
   }
 
-  OS << format("%08" PRIx64, Offset)
-     << format(" %0*" PRIx64, IsDWARF64 ? 16 : 8, Length)
-     << format(" %0*" PRIx64, IsDWARF64 && !DumpOpts.IsEH ? 16 : 8,
-               getCIEId(IsDWARF64, DumpOpts.IsEH))
+  OS << formatv("{0:x-8}", Offset)
+     << formatv(" {0:x-}",
+                fmt_align(Length, AlignStyle::Right, IsDWARF64 ? 16 : 8, '0'))
+     << formatv(" {0:x-}",
+                fmt_align(getCIEId(IsDWARF64, DumpOpts.IsEH), AlignStyle::Right,
+                          IsDWARF64 && !DumpOpts.IsEH ? 16 : 8, '0'))
      << " CIE\n"
      << "  Format:                " << FormatString(IsDWARF64) << "\n";
   if (DumpOpts.IsEH && Version != 1)
     OS << "WARNING: unsupported CIE version\n";
-  OS << format("  Version:               %d\n", Version)
+  OS << formatv("  Version:               {0}\n", Version)
      << "  Augmentation:          \"" << Augmentation << "\"\n";
   if (Version >= 4) {
-    OS << format("  Address size:          %u\n", (uint32_t)AddressSize);
-    OS << format("  Segment desc size:     %u\n",
-                 (uint32_t)SegmentDescriptorSize);
+    OS << formatv("  Address size:          {0}\n", (uint32_t)AddressSize);
+    OS << formatv("  Segment desc size:     {0}\n",
+                  (uint32_t)SegmentDescriptorSize);
   }
-  OS << format("  Code alignment factor: %u\n", (uint32_t)CodeAlignmentFactor);
-  OS << format("  Data alignment factor: %d\n", (int32_t)DataAlignmentFactor);
-  OS << format("  Return address column: %d\n", (int32_t)ReturnAddressRegister);
+  OS << formatv("  Code alignment factor: {0}\n",
+                (uint32_t)CodeAlignmentFactor);
+  OS << formatv("  Data alignment factor: {0}\n", (int32_t)DataAlignmentFactor);
+  OS << formatv("  Return address column: {0}\n",
+                (int32_t)ReturnAddressRegister);
   if (Personality)
-    OS << format("  Personality Address: %016" PRIx64 "\n", *Personality);
+    OS << formatv("  Personality Address: {0:x-16}\n", *Personality);
   if (!AugmentationData.empty()) {
     OS << "  Augmentation data:    ";
     for (uint8_t Byte : AugmentationData)
@@ -148,19 +154,21 @@ void CIE::dump(raw_ostream &OS, DIDumpOptions DumpOpts) const {
 }
 
 void FDE::dump(raw_ostream &OS, DIDumpOptions DumpOpts) const {
-  OS << format("%08" PRIx64, Offset)
-     << format(" %0*" PRIx64, IsDWARF64 ? 16 : 8, Length)
-     << format(" %0*" PRIx64, IsDWARF64 && !DumpOpts.IsEH ? 16 : 8, CIEPointer)
+  OS << formatv("{0:x-8}", Offset)
+     << formatv(" {0:x-}",
+                fmt_align(Length, AlignStyle::Right, IsDWARF64 ? 16 : 8, '0'))
+     << formatv(" {0:x-}", fmt_align(CIEPointer, AlignStyle::Right,
+                                     IsDWARF64 && !DumpOpts.IsEH ? 16 : 8, '0'))
      << " FDE cie=";
   if (LinkedCIE)
-    OS << format("%08" PRIx64, LinkedCIE->getOffset());
+    OS << formatv("{0:x-8}", LinkedCIE->getOffset());
   else
     OS << "<invalid offset>";
-  OS << format(" pc=%08" PRIx64 "...%08" PRIx64 "\n", InitialLocation,
-               InitialLocation + AddressRange);
+  OS << formatv(" pc={0:x-8}...{1:x-8}\n", InitialLocation,
+                InitialLocation + AddressRange);
   OS << "  Format:       " << FormatString(IsDWARF64) << "\n";
   if (LSDAAddress)
-    OS << format("  LSDA Address: %016" PRIx64 "\n", *LSDAAddress);
+    OS << formatv("  LSDA Address: {0:x-16}\n", *LSDAAddress);
   printCFIProgram(CFIs, OS, DumpOpts, /*IndentLevel=*/1, InitialLocation);
   OS << "\n";
 


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* -> llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980