### PR TITLE
[llvm][DebugInfo] Use formatv in DWARFDebugPubTable

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugPubTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugPubTable.cpp
@@ -117,8 +117,8 @@ void DWARFDebugPubTable::dump(raw_ostream &OS) const {
         StringRef EntryLinkage =
             GDBIndexEntryLinkageString(E.Descriptor.Linkage);
         StringRef EntryKind = dwarf::GDBIndexEntryKindString(E.Descriptor.Kind);
-        OS << formatv("{0, -8}", EntryLinkage.data()) << ' '
-           << formatv("{0, -8}", EntryKind.data()) << ' ';
+        OS << formatv("{0,-8}", EntryLinkage.data()) << ' '
+           << formatv("{0,-8}", EntryKind.data()) << ' ';
       }
       OS << '\"' << E.Name << "\"\n";
     }

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugPubTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugPubTable.cpp
@@ -7,12 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/DebugInfo/DWARF/DWARFDebugPubTable.h"
-#include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdint>
 
@@ -93,24 +95,30 @@ void DWARFDebugPubTable::extract(
 void DWARFDebugPubTable::dump(raw_ostream &OS) const {
   for (const Set &S : Sets) {
     int OffsetDumpWidth = 2 * dwarf::getDwarfOffsetByteSize(S.Format);
-    OS << "length = " << format("0x%0*" PRIx64, OffsetDumpWidth, S.Length);
+    OS << "length = "
+       << formatv("0x{0:x-}",
+                  fmt_align(S.Length, AlignStyle::Right, OffsetDumpWidth, '0'));
     OS << ", format = " << dwarf::FormatString(S.Format);
-    OS << ", version = " << format("0x%04x", S.Version);
+    OS << ", version = " << formatv("{0:x4}", S.Version);
     OS << ", unit_offset = "
-       << format("0x%0*" PRIx64, OffsetDumpWidth, S.Offset);
-    OS << ", unit_size = " << format("0x%0*" PRIx64, OffsetDumpWidth, S.Size)
+       << formatv("0x{0:x-}",
+                  fmt_align(S.Offset, AlignStyle::Right, OffsetDumpWidth, '0'));
+    OS << ", unit_size = "
+       << formatv("0x{0:x-}",
+                  fmt_align(S.Size, AlignStyle::Right, OffsetDumpWidth, '0'))
        << '\n';
     OS << (GnuStyle ? "Offset     Linkage  Kind     Name\n"
                     : "Offset     Name\n");
 
     for (const Entry &E : S.Entries) {
-      OS << format("0x%0*" PRIx64 " ", OffsetDumpWidth, E.SecOffset);
+      OS << formatv("0x{0:x-} ", fmt_align(E.SecOffset, AlignStyle::Right,
+                                           OffsetDumpWidth, '0'));
       if (GnuStyle) {
         StringRef EntryLinkage =
             GDBIndexEntryLinkageString(E.Descriptor.Linkage);
         StringRef EntryKind = dwarf::GDBIndexEntryKindString(E.Descriptor.Kind);
-        OS << format("%-8s", EntryLinkage.data()) << ' '
-           << format("%-8s", EntryKind.data()) << ' ';
+        OS << formatv("{0, -8}", EntryLinkage.data()) << ' '
+           << formatv("{0, -8}", EntryKind.data()) << ' ';
       }
       OS << '\"' << E.Name << "\"\n";
     }


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* -> llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980