### PR TITLE
[llvm][DebugInfo] formatv in DWARFDebugRangeList

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugRangeList.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugRangeList.cpp
@@ -10,6 +10,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cinttypes>
 #include <cstdint>
@@ -68,20 +69,20 @@ void DWARFDebugRangeList::dump(raw_ostream &OS) const {
   const char *AddrFmt;
   switch (AddressSize) {
   case 2:
-    AddrFmt = "%08" PRIx64 " %04" PRIx64 " %04" PRIx64 "\n";
+    AddrFmt = "{0:x-8} {1:x-4} {2:x-4}\n";
     break;
   case 4:
-    AddrFmt = "%08" PRIx64 " %08" PRIx64 " %08" PRIx64 "\n";
+    AddrFmt = "{0:x-8} {1:x-8} {2:x-8}\n";
     break;
   case 8:
-    AddrFmt = "%08" PRIx64 " %016" PRIx64 " %016" PRIx64 "\n";
+    AddrFmt = "{0:x-8} {1:x-16} {2:x-16}\n";
     break;
   default:
     llvm_unreachable("unsupported address size");
   }
   for (const RangeListEntry &RLE : Entries)
-    OS << format(AddrFmt, Offset, RLE.StartAddress, RLE.EndAddress);
-  OS << format("%08" PRIx64 " <End of list>\n", Offset);
+    OS << formatv(AddrFmt, Offset, RLE.StartAddress, RLE.EndAddress);
+  OS << formatv("{0:x-8} <End of list>\n", Offset);
 }
 
 DWARFAddressRangesVector DWARFDebugRangeList::getAbsoluteRanges(


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* -> llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980