### PR TITLE
[llvm][DebugInfo] formatv in DWARFDebugRnglists

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugRnglists.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugRnglists.cpp
@@ -13,6 +13,8 @@
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
@@ -189,12 +191,13 @@ void RangeListEntry::dump(
 
   if (DumpOpts.Verbose) {
     // Print the section offset in verbose mode.
-    OS << format("0x%8.8" PRIx64 ":", Offset);
+    OS << formatv("{0:x8}:", Offset);
     auto EncodingString = dwarf::RangeListEncodingString(EntryKind);
     // Unsupported encodings should have been reported during parsing.
     assert(!EncodingString.empty() && "Unknown range entry encoding");
-    OS << format(" [%s%*c", EncodingString.data(),
-                 MaxEncodingStringLength - EncodingString.size() + 1, ']');
+    OS << formatv(" [{0}]",
+                  fmt_pad(EncodingString.data(), 0,
+                          MaxEncodingStringLength - EncodingString.size()));
     if (EntryKind != dwarf::DW_RLE_end_of_list)
       OS << ": ";
   }


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* -> llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980