### PR TITLE
[llvm][DebugInfo] Use formatv in DWARFExpressionPrinter

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFExpressionPrinter.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFExpressionPrinter.cpp
@@ -29,19 +29,19 @@ static void prettyPrintBaseTypeRef(DWARFUnit *U, raw_ostream &OS,
                                    unsigned Operand) {
   assert(Operand < Operands.size() && "operand out of bounds");
   if (!U) {
-    OS << format(" <base_type ref: 0x%" PRIx64 ">", Operands[Operand]);
+    OS << formatv(" <base_type ref: {0:x}>", Operands[Operand]);
     return;
   }
   auto Die = U->getDIEForOffset(U->getOffset() + Operands[Operand]);
   if (Die && Die.getTag() == dwarf::DW_TAG_base_type) {
     OS << " (";
     if (DumpOpts.Verbose)
-      OS << format("0x%08" PRIx64 " -> ", Operands[Operand]);
-    OS << format("0x%08" PRIx64 ")", U->getOffset() + Operands[Operand]);
+      OS << formatv("{0:x8} -> ", Operands[Operand]);
+    OS << formatv("{0:x8})", U->getOffset() + Operands[Operand]);
     if (auto Name = dwarf::toString(Die.find(dwarf::DW_AT_name)))
       OS << " \"" << *Name << "\"";
   } else {
-    OS << format(" <invalid base_type ref: 0x%" PRIx64 ">", Operands[Operand]);
+    OS << formatv(" <invalid base_type ref: {0:x}>", Operands[Operand]);
   }
 }
 
@@ -142,7 +142,7 @@ static bool printOp(const DWARFExpression::Operation *Op, raw_ostream &OS,
         case 2:
         case 3: // global as uint32
         case 4:
-          OS << format(" 0x%" PRIx64, Op->getRawOperand(Operand));
+          OS << formatv(" {0:x}", Op->getRawOperand(Operand));
           break;
         default:
           assert(false);
@@ -150,14 +150,14 @@ static bool printOp(const DWARFExpression::Operation *Op, raw_ostream &OS,
       } else if (Size == DWARFExpression::Operation::SizeBlock) {
         uint64_t Offset = Op->getRawOperand(Operand);
         for (unsigned i = 0; i < Op->getRawOperand(Operand - 1); ++i)
-          OS << format(" 0x%02x",
-                       static_cast<uint8_t>(Expr->getData()[Offset++]));
+          OS << formatv(" {0:x2}",
+                        static_cast<uint8_t>(Expr->getData()[Offset++]));
       } else {
         if (Signed)
           OS << formatv(" {0:+d}", (int64_t)Op->getRawOperand(Operand));
         else if (Op->getCode() != DW_OP_entry_value &&
                  Op->getCode() != DW_OP_GNU_entry_value)
-          OS << format(" 0x%" PRIx64, Op->getRawOperand(Operand));
+          OS << formatv(" {0:x}", Op->getRawOperand(Operand));
       }
     }
   }
@@ -176,7 +176,8 @@ void printDwarfExpression(const DWARFExpression *E, raw_ostream &OS,
     if (!printOp(&Op, OS, DumpOpts, E, U) && !DumpOpts.PrintRegisterOnly) {
       uint64_t FailOffset = Op.getEndOffset();
       while (FailOffset < E->getData().size())
-        OS << format(" %02x", static_cast<uint8_t>(E->getData()[FailOffset++]));
+        OS << formatv(" {0:x-2}",
+                      static_cast<uint8_t>(E->getData()[FailOffset++]));
       return;
     }
     if (!DumpOpts.PrintRegisterOnly) {

--- a/llvm/lib/DebugInfo/DWARF/DWARFExpressionPrinter.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFExpressionPrinter.cpp
@@ -150,8 +150,7 @@ static bool printOp(const DWARFExpression::Operation *Op, raw_ostream &OS,
       } else if (Size == DWARFExpression::Operation::SizeBlock) {
         uint64_t Offset = Op->getRawOperand(Operand);
         for (unsigned i = 0; i < Op->getRawOperand(Operand - 1); ++i)
-          OS << formatv(" {0:x2}",
-                        static_cast<uint8_t>(Expr->getData()[Offset++]));
+          OS << formatv(" {0:x2}", Expr->getData()[Offset++]);
       } else {
         if (Signed)
           OS << formatv(" {0:+d}", (int64_t)Op->getRawOperand(Operand));
@@ -176,8 +175,7 @@ void printDwarfExpression(const DWARFExpression *E, raw_ostream &OS,
     if (!printOp(&Op, OS, DumpOpts, E, U) && !DumpOpts.PrintRegisterOnly) {
       uint64_t FailOffset = Op.getEndOffset();
       while (FailOffset < E->getData().size())
-        OS << formatv(" {0:x-2}",
-                      static_cast<uint8_t>(E->getData()[FailOffset++]));
+        OS << formatv(" {0:x-2}", E->getData()[FailOffset++]);
       return;
     }
     if (!DumpOpts.PrintRegisterOnly) {

--- a/llvm/lib/DebugInfo/DWARF/DWARFExpressionPrinter.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFExpressionPrinter.cpp
@@ -150,7 +150,8 @@ static bool printOp(const DWARFExpression::Operation *Op, raw_ostream &OS,
       } else if (Size == DWARFExpression::Operation::SizeBlock) {
         uint64_t Offset = Op->getRawOperand(Operand);
         for (unsigned i = 0; i < Op->getRawOperand(Operand - 1); ++i)
-          OS << formatv(" {0:x2}", Expr->getData()[Offset++]);
+          OS << formatv(" {0:x2}",
+                        static_cast<uint8_t>(Expr->getData()[Offset++]));
       } else {
         if (Signed)
           OS << formatv(" {0:+d}", (int64_t)Op->getRawOperand(Operand));
@@ -175,7 +176,8 @@ void printDwarfExpression(const DWARFExpression *E, raw_ostream &OS,
     if (!printOp(&Op, OS, DumpOpts, E, U) && !DumpOpts.PrintRegisterOnly) {
       uint64_t FailOffset = Op.getEndOffset();
       while (FailOffset < E->getData().size())
-        OS << formatv(" {0:x-2}", E->getData()[FailOffset++]);
+        OS << formatv(" {0:x-2}",
+                      static_cast<uint8_t>(E->getData()[FailOffset++]));
       return;
     }
     if (!DumpOpts.PrintRegisterOnly) {


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* -> llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980