### PR TITLE
[llvm][DebugInfo] Use formatv in DWARFGdbIndex

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFGdbIndex.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFGdbIndex.cpp
@@ -25,7 +25,7 @@ using namespace llvm;
 
 void DWARFGdbIndex::dumpCUList(raw_ostream &OS) const {
   OS << formatv("\n  CU list offset = {0:x}, has {1} entries:", CuListOffset,
-                (uint64_t)CuList.size())
+                CuList.size())
      << '\n';
   uint32_t I = 0;
   for (const CompUnitEntry &CU : CuList)

--- a/llvm/lib/DebugInfo/DWARF/DWARFGdbIndex.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFGdbIndex.cpp
@@ -24,13 +24,13 @@ using namespace llvm;
 // https://sourceware.org/gdb/onlinedocs/gdb/Index-Section-Format.html
 
 void DWARFGdbIndex::dumpCUList(raw_ostream &OS) const {
-  OS << format("\n  CU list offset = 0x%x, has %" PRId64 " entries:",
-               CuListOffset, (uint64_t)CuList.size())
+  OS << formatv("\n  CU list offset = {0:x}, has {1} entries:", CuListOffset,
+                (uint64_t)CuList.size())
      << '\n';
   uint32_t I = 0;
   for (const CompUnitEntry &CU : CuList)
-    OS << format("    %d: Offset = 0x%llx, Length = 0x%llx\n", I++, CU.Offset,
-                 CU.Length);
+    OS << formatv("    {0}: Offset = {1:x}, Length = {2:x}\n", I++, CU.Offset,
+                  CU.Length);
 }
 
 void DWARFGdbIndex::dumpTUList(raw_ostream &OS) const {
@@ -44,20 +44,19 @@ void DWARFGdbIndex::dumpTUList(raw_ostream &OS) const {
 }
 
 void DWARFGdbIndex::dumpAddressArea(raw_ostream &OS) const {
-  OS << format("\n  Address area offset = 0x%x, has %" PRId64 " entries:",
-               AddressAreaOffset, (uint64_t)AddressArea.size())
+  OS << formatv("\n  Address area offset = {0:x}, has {1} entries:",
+                AddressAreaOffset, (uint64_t)AddressArea.size())
      << '\n';
   for (const AddressEntry &Addr : AddressArea)
-    OS << format(
-        "    Low/High address = [0x%llx, 0x%llx) (Size: 0x%llx), CU id = %d\n",
-        Addr.LowAddress, Addr.HighAddress, Addr.HighAddress - Addr.LowAddress,
-        Addr.CuIndex);
+    OS << formatv("    Low/High address = [{0:x}, {1:x}) (Size: {2:x}), CU "
+                  "id = {3}\n",
+                  Addr.LowAddress, Addr.HighAddress,
+                  Addr.HighAddress - Addr.LowAddress, Addr.CuIndex);
 }
 
 void DWARFGdbIndex::dumpSymbolTable(raw_ostream &OS) const {
-  OS << format("\n  Symbol table offset = 0x%x, size = %" PRId64
-               ", filled slots:",
-               SymbolTableOffset, (uint64_t)SymbolTable.size())
+  OS << formatv("\n  Symbol table offset = {0:x}, size = {1}, filled slots:",
+                SymbolTableOffset, (uint64_t)SymbolTable.size())
      << '\n';
 
   const auto FindCuVectorId = [&](uint32_t VecOffset) {
@@ -79,26 +78,26 @@ void DWARFGdbIndex::dumpSymbolTable(raw_ostream &OS) const {
     if (!E.NameOffset && !E.VecOffset)
       continue;
 
-    OS << format("    %d: Name offset = 0x%x, CU vector offset = 0x%x\n", I,
-                 E.NameOffset, E.VecOffset);
+    OS << formatv("    {0}: Name offset = {1:x}, CU vector offset = {2:x}\n", I,
+                  E.NameOffset, E.VecOffset);
 
     StringRef Name = ConstantPoolStrings.substr(
         ConstantPoolOffset - StringPoolOffset + E.NameOffset);
 
     const uint32_t CuVectorId = FindCuVectorId(E.VecOffset);
-    OS << format("      String name: %s, CU vector index: %d\n", Name.data(),
-                 CuVectorId);
+    OS << formatv("      String name: {0}, CU vector index: {1}\n", Name.data(),
+                  CuVectorId);
   }
 }
 
 void DWARFGdbIndex::dumpConstantPool(raw_ostream &OS) const {
-  OS << format("\n  Constant pool offset = 0x%x, has %" PRId64 " CU vectors:",
-               ConstantPoolOffset, (uint64_t)ConstantPoolVectors.size());
+  OS << formatv("\n  Constant pool offset = {0:x}, has {1} CU vectors:",
+                ConstantPoolOffset, (uint64_t)ConstantPoolVectors.size());
   uint32_t I = 0;
   for (const auto &V : ConstantPoolVectors) {
-    OS << format("\n    %d(0x%x): ", I++, V.first);
+    OS << formatv("\n    {0}({1:x}): ", I++, V.first);
     for (uint32_t Val : V.second)
-      OS << format("0x%x ", Val);
+      OS << formatv("{0:x} ", Val);
   }
   OS << '\n';
 }

--- a/llvm/lib/DebugInfo/DWARF/DWARFGdbIndex.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFGdbIndex.cpp
@@ -45,7 +45,7 @@ void DWARFGdbIndex::dumpTUList(raw_ostream &OS) const {
 
 void DWARFGdbIndex::dumpAddressArea(raw_ostream &OS) const {
   OS << formatv("\n  Address area offset = {0:x}, has {1} entries:",
-                AddressAreaOffset, (uint64_t)AddressArea.size())
+                AddressAreaOffset, AddressArea.size())
      << '\n';
   for (const AddressEntry &Addr : AddressArea)
     OS << formatv("    Low/High address = [{0:x}, {1:x}) (Size: {2:x}), CU "
@@ -56,7 +56,7 @@ void DWARFGdbIndex::dumpAddressArea(raw_ostream &OS) const {
 
 void DWARFGdbIndex::dumpSymbolTable(raw_ostream &OS) const {
   OS << formatv("\n  Symbol table offset = {0:x}, size = {1}, filled slots:",
-                SymbolTableOffset, (uint64_t)SymbolTable.size())
+                SymbolTableOffset, SymbolTable.size())
      << '\n';
 
   const auto FindCuVectorId = [&](uint32_t VecOffset) {
@@ -92,7 +92,7 @@ void DWARFGdbIndex::dumpSymbolTable(raw_ostream &OS) const {
 
 void DWARFGdbIndex::dumpConstantPool(raw_ostream &OS) const {
   OS << formatv("\n  Constant pool offset = {0:x}, has {1} CU vectors:",
-                ConstantPoolOffset, (uint64_t)ConstantPoolVectors.size());
+                ConstantPoolOffset, ConstantPoolVectors.size());
   uint32_t I = 0;
   for (const auto &V : ConstantPoolVectors) {
     OS << formatv("\n    {0}({1:x}): ", I++, V.first);


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* -> llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980