### PR TITLE
[llvm][DebugInfo] formatv in DWARFListTable

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFListTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFListTable.cpp
@@ -12,6 +12,8 @@
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
@@ -78,25 +80,26 @@ Error DWARFListTableHeader::extract(DWARFDataExtractor Data,
 void DWARFListTableHeader::dump(DataExtractor Data, raw_ostream &OS,
                                 DIDumpOptions DumpOpts) const {
   if (DumpOpts.Verbose)
-    OS << format("0x%8.8" PRIx64 ": ", HeaderOffset);
+    OS << formatv("{0:x8}: ", HeaderOffset);
   int OffsetDumpWidth = 2 * dwarf::getDwarfOffsetByteSize(Format);
-  OS << format("%s list header: length = 0x%0*" PRIx64, ListTypeString.data(),
-               OffsetDumpWidth, HeaderData.Length)
+  OS << formatv("{0} list header: length = 0x{1:x-}", ListTypeString.data(),
+                fmt_align(HeaderData.Length, AlignStyle::Right, OffsetDumpWidth,
+                          '0'))
      << ", format = " << dwarf::FormatString(Format)
-     << format(", version = 0x%4.4" PRIx16 ", addr_size = 0x%2.2" PRIx8
-               ", seg_size = 0x%2.2" PRIx8
-               ", offset_entry_count = 0x%8.8" PRIx32 "\n",
-               HeaderData.Version, HeaderData.AddrSize, HeaderData.SegSize,
-               HeaderData.OffsetEntryCount);
+     << formatv(", version = {0:x4}, addr_size = {1:x2}"
+                ", seg_size = {2:x2}"
+                ", offset_entry_count = {3:x8}\n",
+                HeaderData.Version, HeaderData.AddrSize, HeaderData.SegSize,
+                HeaderData.OffsetEntryCount);
 
   if (HeaderData.OffsetEntryCount > 0) {
     OS << "offsets: [";
     for (uint32_t I = 0; I < HeaderData.OffsetEntryCount; ++I) {
       auto Off = *getOffsetEntry(Data, I);
-      OS << format("\n0x%0*" PRIx64, OffsetDumpWidth, Off);
+      OS << formatv("\n0x{0:x-}",
+                    fmt_align(Off, AlignStyle::Right, OffsetDumpWidth, '0'));
       if (DumpOpts.Verbose)
-        OS << format(" => 0x%08" PRIx64,
-                     Off + HeaderOffset + getHeaderSize(Format));
+        OS << formatv(" => {0:x8}", Off + HeaderOffset + getHeaderSize(Format));
     }
     OS << "\n]\n";
   }


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* -> llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980