### PR TITLE
[llvm][DebugInfo] formatv in DWARFTypeUnit

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFTypeUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFTypeUnit.cpp
@@ -10,6 +10,8 @@
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFDie.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cinttypes>
 
@@ -22,27 +24,30 @@ void DWARFTypeUnit::dump(raw_ostream &OS, DIDumpOptions DumpOpts) {
 
   if (DumpOpts.SummarizeTypes) {
     OS << "name = '" << Name << "'"
-       << ", type_signature = " << format("0x%016" PRIx64, getTypeHash())
-       << ", length = " << format("0x%0*" PRIx64, OffsetDumpWidth, getLength())
+       << ", type_signature = " << formatv("{0:x16}", getTypeHash())
+       << ", length = "
+       << formatv("0x{0:x-}", fmt_align(getLength(), AlignStyle::Right,
+                                        OffsetDumpWidth, '0'))
        << '\n';
     return;
   }
 
-  OS << format("0x%08" PRIx64, getOffset()) << ": Type Unit:"
-     << " length = " << format("0x%0*" PRIx64, OffsetDumpWidth, getLength())
+  OS << formatv("{0:x8}", getOffset()) << ": Type Unit:"
+     << " length = "
+     << formatv("0x{0:x-}",
+                fmt_align(getLength(), AlignStyle::Right, OffsetDumpWidth, '0'))
      << ", format = " << dwarf::FormatString(getFormat())
-     << ", version = " << format("0x%04x", getVersion());
+     << ", version = " << formatv("{0:x4}", getVersion());
   if (getVersion() >= 5)
     OS << ", unit_type = " << dwarf::UnitTypeString(getUnitType());
-  OS << ", abbr_offset = " << format("0x%04" PRIx64, getAbbrOffset());
+  OS << ", abbr_offset = " << formatv("{0:x4}", getAbbrOffset());
   if (!getAbbreviations())
     OS << " (invalid)";
-  OS << ", addr_size = " << format("0x%02x", getAddressByteSize())
+  OS << ", addr_size = " << formatv("{0:x2}", getAddressByteSize())
      << ", name = '" << Name << "'"
-     << ", type_signature = " << format("0x%016" PRIx64, getTypeHash())
-     << ", type_offset = " << format("0x%04" PRIx64, getTypeOffset())
-     << " (next unit at " << format("0x%08" PRIx64, getNextUnitOffset())
-     << ")\n";
+     << ", type_signature = " << formatv("{0:x16}", getTypeHash())
+     << ", type_offset = " << formatv("{0:x4}", getTypeOffset())
+     << " (next unit at " << formatv("{0:x8}", getNextUnitOffset()) << ")\n";
 
   if (DWARFDie TU = getUnitDIE(false))
     TU.dump(OS, 0, DumpOpts);


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* -> llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980