### PR TITLE
[llvm][DebugInfo] Use formatv in DWARFUnitIndex

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFUnitIndex.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnitIndex.cpp
@@ -228,7 +228,7 @@ void DWARFUnitIndex::dump(raw_ostream &OS) const {
          << left_justify(Name,
                          Kind == DWARFSectionKind::DW_SECT_INFO ? 40 : 24);
     else
-      OS << formatv(" Unknown: {0, -15}", RawSectionIds[i]);
+      OS << formatv(" Unknown: {0,-15}", RawSectionIds[i]);
   }
   OS << "\n----- ------------------";
   for (unsigned i = 0; i != Header.NumColumns; ++i) {

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnitIndex.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnitIndex.cpp
@@ -12,6 +12,7 @@
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cinttypes>
 #include <cstdint>
@@ -113,7 +114,8 @@ bool DWARFUnitIndex::Header::parse(DataExtractor IndexData,
 }
 
 void DWARFUnitIndex::Header::dump(raw_ostream &OS) const {
-  OS << format("version = %u, units = %u, slots = %u\n\n", Version, NumUnits, NumBuckets);
+  OS << formatv("version = {0}, units = {1}, slots = {2}\n\n", Version,
+                NumUnits, NumBuckets);
 }
 
 bool DWARFUnitIndex::parse(DataExtractor IndexData) {
@@ -226,7 +228,7 @@ void DWARFUnitIndex::dump(raw_ostream &OS) const {
          << left_justify(Name,
                          Kind == DWARFSectionKind::DW_SECT_INFO ? 40 : 24);
     else
-      OS << format(" Unknown: %-15" PRIu32, RawSectionIds[i]);
+      OS << formatv(" Unknown: {0, -15}", RawSectionIds[i]);
   }
   OS << "\n----- ------------------";
   for (unsigned i = 0; i != Header.NumColumns; ++i) {
@@ -241,19 +243,17 @@ void DWARFUnitIndex::dump(raw_ostream &OS) const {
   for (unsigned i = 0; i != Header.NumBuckets; ++i) {
     auto &Row = Rows[i];
     if (auto *Contribs = Row.Contributions.get()) {
-      OS << format("%5u 0x%016" PRIx64 " ", i + 1, Row.Signature);
+      OS << formatv("{0,5} {1:x16} ", i + 1, Row.Signature);
       for (unsigned i = 0; i != Header.NumColumns; ++i) {
         auto &Contrib = Contribs[i];
         DWARFSectionKind Kind = ColumnKinds[i];
         if (Kind == DWARFSectionKind::DW_SECT_INFO ||
             Kind == DWARFSectionKind::DW_SECT_EXT_TYPES)
-          OS << format("[0x%016" PRIx64 ", 0x%016" PRIx64 ") ",
-                       Contrib.getOffset(),
-                       Contrib.getOffset() + Contrib.getLength());
+          OS << formatv("[{0:x16}, {1:x16}) ", Contrib.getOffset(),
+                        Contrib.getOffset() + Contrib.getLength());
         else
-          OS << format("[0x%08" PRIx32 ", 0x%08" PRIx32 ") ",
-                       Contrib.getOffset32(),
-                       Contrib.getOffset32() + Contrib.getLength32());
+          OS << formatv("[{0:x8}, {1:x8}) ", Contrib.getOffset32(),
+                        Contrib.getOffset32() + Contrib.getLength32());
       }
       OS << '\n';
     }


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* -> llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980