### PR TITLE
[llvm][DebugInfo] formatv in DWARFUnwindTablePrinter

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFUnwindTablePrinter.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnwindTablePrinter.cpp
@@ -12,6 +12,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFExpressionPrinter.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <cinttypes>
@@ -153,7 +154,7 @@ static void printUnwindRow(const UnwindRow &Row, raw_ostream &OS,
                            DIDumpOptions DumpOpts, unsigned IndentLevel) {
   OS.indent(2 * IndentLevel);
   if (Row.hasAddress())
-    OS << format("0x%" PRIx64 ": ", Row.getAddress());
+    OS << formatv("{0:x}: ", Row.getAddress());
   OS << "CFA=";
   printUnwindLocation(Row.getCFAValue(), OS, DumpOpts);
   if (Row.getRegisterLocations().hasLocations()) {


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* -> llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980