### PR TITLE
[llvm][DebugInfo] Use formatv in GsymReaderV1 and GsymReaderV2

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/GsymReaderV1.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymReaderV1.cpp
@@ -13,6 +13,7 @@
 
 #include "llvm/DebugInfo/GSYM/GsymDataExtractor.h"
 #include "llvm/DebugInfo/GSYM/Header.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MemoryBuffer.h"
 
 using namespace llvm;
@@ -94,7 +95,7 @@ void GsymReaderV1::dump(raw_ostream &OS) {
   OS << " (ADDRESS)\n";
   OS << "====== =============================== \n";
   for (uint32_t I = 0; I < getNumAddresses(); ++I) {
-    OS << format("[%4u] ", I);
+    OS << formatv("[{0,4}] ", I);
     switch (getAddressOffsetSize()) {
     case 1:
       OS << HEX8(getAddrOffsets<uint8_t>()[I]);
@@ -117,7 +118,7 @@ void GsymReaderV1::dump(raw_ostream &OS) {
   OS << "INDEX  Offset\n";
   OS << "====== ==========\n";
   for (uint32_t I = 0; I < getNumAddresses(); ++I)
-    OS << format("[%4u] ", I) << HEX32(*getAddressInfoOffset(I)) << "\n";
+    OS << formatv("[{0,4}] ", I) << HEX32(*getAddressInfoOffset(I)) << "\n";
   OS << "\nFiles:\n";
   OS << "INDEX  DIRECTORY  BASENAME   PATH\n";
   OS << "====== ========== ========== ==============================\n";
@@ -125,7 +126,7 @@ void GsymReaderV1::dump(raw_ostream &OS) {
     auto FE = getFile(I);
     if (!FE)
       break;
-    OS << format("[%4u] ", I) << HEX32(FE->Dir) << ' ' << HEX32(FE->Base)
+    OS << formatv("[{0,4}] ", I) << HEX32(FE->Dir) << ' ' << HEX32(FE->Base)
        << ' ';
     dump(OS, FE);
     OS << "\n";

--- a/llvm/lib/DebugInfo/GSYM/GsymReaderV2.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymReaderV2.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/DebugInfo/GSYM/GlobalData.h"
 #include "llvm/DebugInfo/GSYM/GsymDataExtractor.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MemoryBuffer.h"
 
 using namespace llvm;
@@ -48,7 +49,7 @@ void GsymReaderV2::dump(raw_ostream &OS) {
     assert(GDOrErr && "GlobalData::decode() should not fail");
     const GlobalData &GD = *GDOrErr;
 
-    OS << format("%-15s ", getNameForGlobalInfoType(GD.Type).data())
+    OS << formatv("{0,-15} ", getNameForGlobalInfoType(GD.Type).data())
        << HEX64(GD.FileOffset) << "  " << HEX64(GD.FileSize) << "\n";
 
     // Stop printing after the end of list entry.
@@ -87,7 +88,7 @@ void GsymReaderV2::dump(raw_ostream &OS) {
   OS << " (ADDRESS 64)\n";
   OS << "====== ========================================\n";
   for (uint32_t I = 0; I < getNumAddresses(); ++I) {
-    OS << format("[%4u] ", I);
+    OS << formatv("[{0,4}] ", I);
     switch (getAddressOffsetSize()) {
     case 1:
       OS << HEX8(getAddrOffsets<uint8_t>()[I]);
@@ -113,7 +114,7 @@ void GsymReaderV2::dump(raw_ostream &OS) {
     uint64_t RelOffset = I * getAddressInfoOffsetSize();
     uint64_t RelValue =
         AddrInfoOffsetsData.getUnsigned(&RelOffset, getAddressInfoOffsetSize());
-    OS << format("[%4u] ", I) << HEX64(RelValue) << " ("
+    OS << formatv("[{0,4}] ", I) << HEX64(RelValue) << " ("
        << HEX64(*getAddressInfoOffset(I)) << ")\n";
   }
   OS << "\nFiles:\n";
@@ -126,7 +127,7 @@ void GsymReaderV2::dump(raw_ostream &OS) {
     auto FE = getFile(I);
     if (!FE)
       break;
-    OS << format("[%4u] ", I) << HEX32(FE->Dir) << ' ' << HEX32(FE->Base)
+    OS << formatv("[{0,4}] ", I) << HEX32(FE->Dir) << ' ' << HEX32(FE->Base)
        << ' ';
     dump(OS, FE);
     OS << "\n";


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* -> llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980