### PR TITLE
[llvm][DebugInfo] Use formatv in LVCompare

### DIFF
--- a/llvm/lib/DebugInfo/LogicalView/Core/LVCompare.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVCompare.cpp
@@ -405,7 +405,7 @@ void LVCompare::printSummary() const {
   auto PrintSeparator = [&]() { OS << Separator << "\n"; };
   auto PrintHeadingRow = [&](const char *T, const char *U, const char *V,
                              const char *W) {
-    OS << formatv("{0, -9}{1,9}  {2,9}  {3,9}\n", T, U, V, W);
+    OS << formatv("{0,-9}{1,9}  {2,9}  {3,9}\n", T, U, V, W);
   };
   auto PrintDataRow = [&](const char *T, unsigned U, unsigned V, unsigned W) {
     OS << formatv("{0,-9}{1,9}  {2,9}  {3,9}\n", T, U, V, W);

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVCompare.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVCompare.cpp
@@ -408,7 +408,7 @@ void LVCompare::printSummary() const {
     OS << formatv("{0, -9}{1,9}  {2,9}  {3,9}\n", T, U, V, W);
   };
   auto PrintDataRow = [&](const char *T, unsigned U, unsigned V, unsigned W) {
-    OS << formatv("{0, -9}{1,9}  {2,9}  {3,9}\n", T, U, V, W);
+    OS << formatv("{0,-9}{1,9}  {2,9}  {3,9}\n", T, U, V, W);
   };
 
   OS << "\n";

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVCompare.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVCompare.cpp
@@ -405,10 +405,10 @@ void LVCompare::printSummary() const {
   auto PrintSeparator = [&]() { OS << Separator << "\n"; };
   auto PrintHeadingRow = [&](const char *T, const char *U, const char *V,
                              const char *W) {
-    OS << format("%-9s%9s  %9s  %9s\n", T, U, V, W);
+    OS << formatv("{0, -9}{1,9}  {2,9}  {3,9}\n", T, U, V, W);
   };
   auto PrintDataRow = [&](const char *T, unsigned U, unsigned V, unsigned W) {
-    OS << format("%-9s%9d  %9d  %9d\n", T, U, V, W);
+    OS << formatv("{0, -9}{1,9}  {2,9}  {3,9}\n", T, U, V, W);
   };
 
   OS << "\n";


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* -> llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980