### PR TITLE
[llvm][DebugInfo] formatv in LVLocation

### DIFF
--- a/llvm/lib/DebugInfo/LogicalView/Core/LVLocation.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVLocation.cpp
@@ -52,8 +52,7 @@ std::string LVOperation::getOperandsDWARFInfo() {
     //-----------------------------------------------------------------------
     if (dwarf::DW_OP_reg0 <= Code && Code <= dwarf::DW_OP_reg31) {
       std::string RegisterName(getReader().getRegisterName(Code, Operands));
-      Stream << formatv("reg{0}{1}", Code - dwarf::DW_OP_reg0,
-                        RegisterName);
+      Stream << formatv("reg{0}{1}", Code - dwarf::DW_OP_reg0, RegisterName);
       return;
     }
 
@@ -106,8 +105,8 @@ std::string LVOperation::getOperandsDWARFInfo() {
   }
   case dwarf::DW_OP_regval_type: {
     std::string RegisterName(getReader().getRegisterName(Opcode, Operands));
-    Stream << formatv("regval_type {0}{1}+{2}", Operands[0],
-                      RegisterName, unsigned(Operands[1]));
+    Stream << formatv("regval_type {0}{1}+{2}", Operands[0], RegisterName,
+                      unsigned(Operands[1]));
     break;
   }
 

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVLocation.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVLocation.cpp
@@ -33,7 +33,7 @@ std::string LVOperation::getOperandsDWARFInfo() {
     // 2.5.1.1 Literal encodings.
     //-----------------------------------------------------------------------
     if (dwarf::DW_OP_lit0 <= Code && Code <= dwarf::DW_OP_lit31) {
-      Stream << format("lit%d", Code - dwarf::DW_OP_lit0);
+      Stream << formatv("lit{0}", Code - dwarf::DW_OP_lit0);
       return;
     }
 
@@ -42,8 +42,8 @@ std::string LVOperation::getOperandsDWARFInfo() {
     //-----------------------------------------------------------------------
     if (dwarf::DW_OP_breg0 <= Code && Code <= dwarf::DW_OP_breg31) {
       std::string RegisterName(getReader().getRegisterName(Code, Operands));
-      Stream << format("breg%d+%d%s", Code - dwarf::DW_OP_breg0, Operands[0],
-                       RegisterName.c_str());
+      Stream << formatv("breg{0}+{1}{2}", Code - dwarf::DW_OP_breg0,
+                        Operands[0], RegisterName);
       return;
     }
 
@@ -52,12 +52,12 @@ std::string LVOperation::getOperandsDWARFInfo() {
     //-----------------------------------------------------------------------
     if (dwarf::DW_OP_reg0 <= Code && Code <= dwarf::DW_OP_reg31) {
       std::string RegisterName(getReader().getRegisterName(Code, Operands));
-      Stream << format("reg%d%s", Code - dwarf::DW_OP_reg0,
-                       RegisterName.c_str());
+      Stream << formatv("reg{0}{1}", Code - dwarf::DW_OP_reg0,
+                        RegisterName);
       return;
     }
 
-    Stream << format("#0x%02x ", Code) << hexString(Operands[0]) << " "
+    Stream << formatv("#{0:x2} ", Code) << hexString(Operands[0]) << " "
            << hexString(Operands[1]) << "#";
   };
 
@@ -100,14 +100,14 @@ std::string LVOperation::getOperandsDWARFInfo() {
     break;
   case dwarf::DW_OP_bregx: {
     std::string RegisterName(getReader().getRegisterName(Opcode, Operands));
-    Stream << format("bregx %d%s+%d", Operands[0], RegisterName.c_str(),
-                     unsigned(Operands[1]));
+    Stream << formatv("bregx {0}{1}+{2}", Operands[0], RegisterName,
+                      unsigned(Operands[1]));
     break;
   }
   case dwarf::DW_OP_regval_type: {
     std::string RegisterName(getReader().getRegisterName(Opcode, Operands));
-    Stream << format("regval_type %d%s+%d", Operands[0], RegisterName.c_str(),
-                     unsigned(Operands[1]));
+    Stream << formatv("regval_type {0}{1}+{2}", Operands[0],
+                      RegisterName, unsigned(Operands[1]));
     break;
   }
 
@@ -390,7 +390,7 @@ std::string LVOperation::getOperandsCodeViewInfo() {
     break;
 
   default:
-    Stream << format("#0x%02x: ", Opcode) << hexString(Operands[0]) << " "
+    Stream << formatv("#{0:x2}: ", Opcode) << hexString(Operands[0]) << " "
            << hexString(Operands[1]) << "#";
     break;
   }
@@ -639,10 +639,10 @@ void LVLocation::print(LVLocations *Locations, raw_ostream &OS, bool Full) {
     // The coverage is dependent on the kind of location.
     std::string String;
     raw_string_ostream Stream(String);
-    Stream << format("%.2f%%", Percentage);
+    Stream << formatv("{0:f2}%", Percentage);
     if (!Location->getIsLocationSimple())
-      Stream << format(" (%d/%d)", Symbol->getCoverageFactor(),
-                       Symbol->getParentScope()->getCoverageFactor());
+      Stream << formatv(" ({0}/{1})", Symbol->getCoverageFactor(),
+                        Symbol->getParentScope()->getCoverageFactor());
     Symbol->printAttributes(OS, Full, "{Coverage} ", Symbol, StringRef(String),
                             /*UseQuotes=*/false,
                             /*PrintRef=*/false);


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* -> llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980