### PR TITLE
[llvm][DebugInfo] formatv in LVObject

### DIFF
--- a/llvm/lib/DebugInfo/LogicalView/Core/LVObject.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVObject.cpp
@@ -123,7 +123,7 @@ void LVObject::printAttributes(raw_ostream &OS, bool Full, StringRef Name,
   // Print the line.
   std::string TheLineNumber(Object.lineNumberAsString());
   std::string TheIndentation(Object.indentAsString());
-  OS << format(" %5s %s ", TheLineNumber.c_str(), TheIndentation.c_str());
+  OS << formatv(" {0,5} {1} ", TheLineNumber, TheIndentation);
 
   OS << Name;
   if (PrintRef && options().getAttributeOffset())


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* -> llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980