### PR TITLE
[llvm][DebugInfo] formatv in LVRange

### DIFF
--- a/llvm/lib/DebugInfo/LogicalView/Core/LVRange.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVRange.cpp
@@ -13,6 +13,7 @@
 #include "llvm/DebugInfo/LogicalView/Core/LVRange.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVLocation.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVOptions.h"
+#include "llvm/Support/FormatVariadic.h"
 
 using namespace llvm;
 using namespace llvm::logicalview;
@@ -81,7 +82,7 @@ void LVRange::addEntry(LVScope *Scope) {
 
 // Get the scope associated with the input address.
 LVScope *LVRange::getEntry(LVAddress Address) const {
-  LLVM_DEBUG({ dbgs() << format("Searching: 0x%08x\nFound: ", Address); });
+  LLVM_DEBUG({ dbgs() << formatv("Searching: {0:x8}\nFound: ", Address); });
 
   LVScope *Target = nullptr;
   LVLevel TargetLevel = 0;
@@ -90,8 +91,9 @@ LVScope *LVRange::getEntry(LVAddress Address) const {
   for (LVRangesTree::find_iterator Iter = RangesTree.find(Address),
                                    End = RangesTree.find_end();
        Iter != End; ++Iter) {
-    LLVM_DEBUG(
-        { dbgs() << format("[0x%08x,0x%08x] ", Iter->left(), Iter->right()); });
+    LLVM_DEBUG({
+      dbgs() << formatv("[{0:x8},{1:x8}] ", Iter->left(), Iter->right());
+    });
     Scope = Iter->value();
     Level = Scope->getLevel();
     if (Level > TargetLevel) {
@@ -150,7 +152,7 @@ void LVRange::print(raw_ostream &OS, bool Full) const {
     Indentation = options().indentationSize();
     if (Indentation)
       OS << " ";
-    OS << format("[0x%08x,0x%08x] ", RangeEntry.lower(), RangeEntry.upper())
+    OS << formatv("[{0:x8},{1:x8}] ", RangeEntry.lower(), RangeEntry.upper())
        << formattedKind(Scope->kind()) << " " << formattedName(Scope->getName())
        << "\n";
   }


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* -> llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980