### PR TITLE
[llvm][DebugInfo] Use formatv in LVReader

### DIFF
--- a/llvm/lib/DebugInfo/LogicalView/Core/LVReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVReader.cpp
@@ -81,8 +81,8 @@ bool checkIntegrityScopesTree(LVScope *Root) {
 
     std::string RootName(Root->getName());
     dbgs() << formatv("{0}\n", fmt_repeat('=', 72));
-    dbgs() << formatv("Root: '{0}'\nDuplicated elements: {1}\n",
-                      RootName, Duplicate.size());
+    dbgs() << formatv("Root: '{0}'\nDuplicated elements: {1}\n", RootName,
+                      Duplicate.size());
     dbgs() << formatv("{0}\n", fmt_repeat('=', 72));
 
     unsigned Index = 0;

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVReader.cpp
@@ -70,7 +70,10 @@ bool checkIntegrityScopesTree(LVScope *Root) {
     });
 
     auto PrintIndex = [](unsigned Index) {
-      dbgs() << formatv("{0,8}: ", Index ? Index : ' ');
+      if (Index)
+        dbgs() << formatv("{0,8}: ", Index);
+      else
+        dbgs() << formatv("{0,8:s}: ", ' ');
     };
     auto PrintElement = [&](LVElement *Element, unsigned Index = 0) {
       PrintIndex(Index);

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVReader.cpp
@@ -70,22 +70,19 @@ bool checkIntegrityScopesTree(LVScope *Root) {
     });
 
     auto PrintIndex = [](unsigned Index) {
-      if (Index)
-        dbgs() << format("%8d: ", Index);
-      else
-        dbgs() << format("%8c: ", ' ');
+      dbgs() << formatv("{0,8}: ", Index ? Index : ' ');
     };
     auto PrintElement = [&](LVElement *Element, unsigned Index = 0) {
       PrintIndex(Index);
       std::string ElementName(Element->getName());
-      dbgs() << format("%15s ID=0x%08x '%s'\n", Element->kind(),
-                       Element->getID(), ElementName.c_str());
+      dbgs() << formatv("{0,15} ID={1:x8} '{2}'\n", Element->kind(),
+                        Element->getID(), ElementName);
     };
 
     std::string RootName(Root->getName());
     dbgs() << formatv("{0}\n", fmt_repeat('=', 72));
-    dbgs() << format("Root: '%s'\nDuplicated elements: %d\n", RootName.c_str(),
-                     Duplicate.size());
+    dbgs() << formatv("Root: '{0}'\nDuplicated elements: {1}\n",
+                      RootName, Duplicate.size());
     dbgs() << formatv("{0}\n", fmt_repeat('=', 72));
 
     unsigned Index = 0;

--- a/llvm/lib/DebugInfo/LogicalView/Core/LVReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVReader.cpp
@@ -73,7 +73,7 @@ bool checkIntegrityScopesTree(LVScope *Root) {
       if (Index)
         dbgs() << formatv("{0,8}: ", Index);
       else
-        dbgs() << formatv("{0,8:s}: ", ' ');
+        dbgs() << formatv("{0,8}: ", ' ');
     };
     auto PrintElement = [&](LVElement *Element, unsigned Index = 0) {
       PrintIndex(Index);


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* -> llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980