### PR TITLE
[llvm][DebugInfo] formatv in LVScope

### DIFF
--- a/llvm/lib/DebugInfo/LogicalView/Core/LVScope.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Core/LVScope.cpp
@@ -1184,10 +1184,10 @@ void LVScopeArray::printExtra(raw_ostream &OS, bool Full) const {
 void LVScopeCompileUnit::addSize(LVScope *Scope, LVOffset Lower,
                                  LVOffset Upper) {
   LLVM_DEBUG({
-    dbgs() << format(
-        "CU [0x%08" PRIx64 "], Scope [0x%08" PRIx64 "], Range [0x%08" PRIx64
-        ":0x%08" PRIx64 "], Size = %" PRId64 "\n",
-        getOffset(), Scope->getOffset(), Lower, Upper, Upper - Lower);
+    dbgs() << formatv("CU [{0:x8}], Scope [{1:x8}], Range [{2:x8}"
+                      ":{3:x8}], Size = {4}\n",
+                      getOffset(), Scope->getOffset(), Lower, Upper,
+                      Upper - Lower);
   });
 
   // There is no need to check for a previous entry, as we are traversing the
@@ -1482,7 +1482,7 @@ void LVScopeCompileUnit::printWarnings(raw_ostream &OS, bool Full) const {
   if (options().getInternalTag() && getReader().isBinaryTypeELF()) {
     PrintHeader("Unsupported DWARF Tags");
     for (LVTagOffsetsMap::const_reference Entry : DebugTags) {
-      OS << format("\n0x%02x", (unsigned)Entry.first) << ", "
+      OS << formatv("\n{0:x2}", (unsigned)Entry.first) << ", "
          << dwarf::TagString(Entry.first) << "\n";
       unsigned Count = 0;
       for (const LVOffset &Offset : Entry.second)
@@ -1498,7 +1498,7 @@ void LVScopeCompileUnit::printWarnings(raw_ostream &OS, bool Full) const {
       // Symbol basic information.
       LVSymbol *Symbol = Entry.second;
       OS << hexSquareString(Entry.first) << " {Coverage} "
-         << format("%.2f%%", Symbol->getCoveragePercentage()) << " "
+         << formatv("{0:f2}%", Symbol->getCoveragePercentage()) << " "
          << formattedKind(Symbol->kind()) << " "
          << formattedName(Symbol->getName()) << "\n";
     }
@@ -1527,8 +1527,8 @@ void LVScopeCompileUnit::printWarnings(raw_ostream &OS, bool Full) const {
 void LVScopeCompileUnit::printTotals(raw_ostream &OS) const {
   OS << "\nTotals by lexical level:\n";
   for (size_t Index = 1; Index <= MaxSeenLevel; ++Index)
-    OS << format("[%03d]: %10d (%6.2f%%)\n", Index, Totals[Index].first,
-                 Totals[Index].second);
+    OS << formatv("[{0,0+3}]: {1,10} ({2,6:f2}%)\n", Index, Totals[Index].first,
+                  Totals[Index].second);
 }
 
 void LVScopeCompileUnit::printScopeSize(const LVScope *Scope, raw_ostream &OS) {
@@ -1540,7 +1540,7 @@ void LVScopeCompileUnit::printScopeSize(const LVScope *Scope, raw_ostream &OS) {
     // implementation-defined rounding inside printing functions.
     float Percentage =
         rint((float(Size) / CUContributionSize) * 100.0 * 100.0) / 100.0;
-    OS << format("%10" PRId64 " (%6.2f%%) : ", Size, Percentage);
+    OS << formatv("{0,10} ({1,6:f2}%) : ", Size, Percentage);
     Scope->print(OS);
 
     // Keep record of the total sizes at each lexical level.
@@ -1607,11 +1607,12 @@ void LVScopeCompileUnit::printSummary(raw_ostream &OS, const LVCounter &Counter,
                                       const char *Header) const {
   std::string Separator = std::string(29, '-');
   auto PrintSeparator = [&]() { OS << Separator << "\n"; };
+  const char *Fmt = "{0,-9}{1,9}  {2,9}\n";
   auto PrintHeadingRow = [&](const char *T, const char *U, const char *V) {
-    OS << format("%-9s%9s  %9s\n", T, U, V);
+    OS << formatv(Fmt, T, U, V);
   };
   auto PrintDataRow = [&](const char *T, unsigned U, unsigned V) {
-    OS << format("%-9s%9d  %9d\n", T, U, V);
+    OS << formatv(Fmt, T, U, V);
   };
 
   OS << "\n";


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* -> llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980