### PR TITLE
[llvm][DebugInfo] formatv in LVBinaryReader

### DIFF
--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVBinaryReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVBinaryReader.cpp
@@ -496,8 +496,8 @@ Error LVBinaryReader::createInstructions(LVScope *Scope,
     dbgs() << "\nSectionIndex: " << format_decimal(SectionIndex, 3)
            << " Scope DIE: " << hexValue(Scope->getOffset()) << "\n"
            << "Address: " << hexValue(FirstAddress)
-           << format(" - Collected instructions lines: %d\n",
-                     Instructions.size());
+           << formatv(" - Collected instructions lines: {0}\n",
+                      Instructions.size());
     for (const LVLine *Line : Instructions)
       dbgs() << format_decimal(++Index, 5) << ": "
              << hexValue(Line->getOffset()) << ", (" << Line->getName()
@@ -584,7 +584,7 @@ void LVBinaryReader::processLines(LVLines *DebugLines,
   LLVM_DEBUG({
     size_t Index = 1;
     size_t PerLine = 4;
-    dbgs() << format("\nProcess debug lines: %d\n", DebugLines->size());
+    dbgs() << formatv("\nProcess debug lines: {0}\n", DebugLines->size());
     for (const LVLine *Line : *DebugLines) {
       dbgs() << format_decimal(Index, 5) << ": " << hexValue(Line->getOffset())
              << ", (" << Line->getLineNumber() << ")"
@@ -621,8 +621,8 @@ void LVBinaryReader::processLines(LVLines *DebugLines,
       size_t Index = 0;
       dbgs() << "\nSectionIndex: " << format_decimal(SectionIndex, 3)
              << " Scope DIE: " << hexValue(Scope->getOffset()) << "\n"
-             << format("Process instruction lines: %d\n",
-                       InstructionLines.size());
+             << formatv("Process instruction lines: {0}\n",
+                        InstructionLines.size());
       for (const LVLine *Line : InstructionLines)
         dbgs() << format_decimal(++Index, 5) << ": "
                << hexValue(Line->getOffset()) << ", (" << Line->getName()
@@ -649,7 +649,7 @@ void LVBinaryReader::processLines(LVLines *DebugLines,
             dbgs() << "Line " << (IsDebug ? "dbg:" : "ins:") << " ["
                    << hexValue(DebugAddress) << "]";
             if (IsDebug)
-              dbgs() << format(" %d", (*Iter)->getLineNumber());
+              dbgs() << formatv(" {0}", (*Iter)->getLineNumber());
             dbgs() << "\n";
           });
           // Instruction address before debug line.
@@ -657,7 +657,7 @@ void LVBinaryReader::processLines(LVLines *DebugLines,
             LLVM_DEBUG({
               dbgs() << "Inserted instruction address: "
                      << hexValue(InstructionAddress) << " before line: "
-                     << format("%d", (*Iter)->getLineNumber()) << " ["
+                     << formatv("{0}", (*Iter)->getLineNumber()) << " ["
                      << hexValue(DebugAddress) << "]\n";
             });
             Iter = DebugLines->insert(Iter, InstructionLine);
@@ -681,7 +681,7 @@ void LVBinaryReader::processLines(LVLines *DebugLines,
   }
 
   LLVM_DEBUG({
-    dbgs() << format("Lines after merge: %d\n", DebugLines->size());
+    dbgs() << formatv("Lines after merge: {0}\n", DebugLines->size());
     size_t Index = 0;
     for (const LVLine *Line : *DebugLines) {
       dbgs() << format_decimal(++Index, 5) << ": "
@@ -706,7 +706,7 @@ void LVBinaryReader::processLines(LVLines *DebugLines,
             size_t Index = 0;
             dbgs() << "\nSectionIndex: " << format_decimal(SectionIndex, 3)
                    << " Scope DIE: " << hexValue(Scope->getOffset()) << "\n"
-                   << format("Instruction lines: %d\n", Lines->size());
+                   << formatv("Instruction lines: {0}\n", Lines->size());
             for (const LVLine *Line : *Lines)
               dbgs() << format_decimal(++Index, 5) << ": "
                      << hexValue(Line->getOffset()) << ", (" << Line->getName()
@@ -901,7 +901,7 @@ void LVBinaryReader::includeInlineeLines(LVSectionIndex SectionIndex,
       for (const LVLine *Line : *InlineeLines)
         dbgs() << "[" << hexValue(Line->getAddress()) << "] "
                << Line->getLineNumber() << "\n";
-      dbgs() << format("Debug lines: %d\n", CULines.size());
+      dbgs() << formatv("Debug lines: {0}\n", CULines.size());
       for (const LVLine *Line : CULines)
         dbgs() << "Line address: " << hexValue(Line->getOffset()) << ", ("
                << Line->getLineNumber() << ")\n";
@@ -938,7 +938,7 @@ void LVBinaryReader::includeInlineeLines(LVSectionIndex SectionIndex,
   }
   LLVM_DEBUG({
     dbgs() << "Merged Inlined lines for: " << Function->getName() << "\n";
-    dbgs() << format("Debug lines: %d\n", CULines.size());
+    dbgs() << formatv("Debug lines: {0}\n", CULines.size());
     for (const LVLine *Line : CULines)
       dbgs() << "Line address: " << hexValue(Line->getOffset()) << ", ("
              << Line->getLineNumber() << ")\n";


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* llvm/llvm-project#192010
* -> llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980