### PR TITLE
[llvm][DebugInfo] formatv in LVCodeViewVisitor

### DIFF
--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVCodeViewVisitor.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVCodeViewVisitor.cpp
@@ -410,7 +410,7 @@ void LVNamespaceDeduction::init() {
       };
       Header();
       for (const StringRef &Item : Container)
-        dbgs() << formatv("'{0}'\n", Item.str().c_str());
+        dbgs() << formatv("'{0}'\n", Item);
     };
 
     Print(DeducedScopes, "Deducted Scopes");
@@ -422,7 +422,7 @@ void LVNamespaceDeduction::init() {
 LVScope *LVNamespaceDeduction::get(LVStringRefs Components) {
   LLVM_DEBUG({
     for (const StringRef &Component : Components)
-      dbgs() << formatv("'{0}'\n", Component.str().c_str());
+      dbgs() << formatv("'{0}'\n", Component);
   });
 
   if (Components.empty())
@@ -458,7 +458,7 @@ LVScope *LVNamespaceDeduction::get(StringRef ScopedName, bool CheckScope) {
     });
 
   LLVM_DEBUG(
-      { dbgs() << formatv("ScopedName: '{0}'\n", ScopedName.str().c_str()); });
+      { dbgs() << formatv("ScopedName: '{0}'\n", ScopedName); });
 
   return get(Components);
 }
@@ -3456,7 +3456,7 @@ void LVLogicalVisitor::printRecords(raw_ostream &OS) const {
         OS << "\n";
       }
     };
-    OS << format("%20s", Name.str().c_str());
+    OS << formatv("{0,20}", Name);
     NewLine();
   };
 

--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVCodeViewVisitor.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVCodeViewVisitor.cpp
@@ -457,8 +457,7 @@ LVScope *LVNamespaceDeduction::get(StringRef ScopedName, bool CheckScope) {
       return Iter == IdentifiedNamespaces.end();
     });
 
-  LLVM_DEBUG(
-      { dbgs() << formatv("ScopedName: '{0}'\n", ScopedName); });
+  LLVM_DEBUG({ dbgs() << formatv("ScopedName: '{0}'\n", ScopedName); });
 
   return get(Components);
 }


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* llvm/llvm-project#192011
* -> llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980