### PR TITLE
[llvm][DebugInfo] Use formatv in LVDWARFReader

### DIFF
--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
@@ -21,6 +21,7 @@
 #include "llvm/DebugInfo/LogicalView/Core/LVSymbol.h"
 #include "llvm/DebugInfo/LogicalView/Core/LVType.h"
 #include "llvm/Object/MachO.h"
+#include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/FormatVariadic.h"
 
 using namespace llvm;

--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
@@ -262,9 +262,8 @@ void LVDWARFReader::processOneAttribute(const DWARFDie &Die,
           GetRanges(FormValue, U);
       if (!RangesOrError) {
         LLVM_DEBUG({
-          std::string TheError(toString(RangesOrError.takeError()));
           dbgs() << formatv("error decoding address ranges = {0}",
-                            TheError.c_str());
+                            fmt_consume(RangesOrError.takeError()));
         });
         consumeError(RangesOrError.takeError());
         break;

--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
@@ -210,7 +210,7 @@ void LVDWARFReader::processOneAttribute(const DWARFDie &Die,
           FoundLowPC = false;
           // We are dealing with an index into the .debug_addr section.
           LLVM_DEBUG({
-            dbgs() << format("indexed (%8.8x) address = ", (uint32_t)UValue);
+            dbgs() << formatv("indexed ({0:x-8}) address = ", (uint32_t)UValue);
           });
         }
       }
@@ -263,8 +263,8 @@ void LVDWARFReader::processOneAttribute(const DWARFDie &Die,
       if (!RangesOrError) {
         LLVM_DEBUG({
           std::string TheError(toString(RangesOrError.takeError()));
-          dbgs() << format("error decoding address ranges = ",
-                           TheError.c_str());
+          dbgs() << formatv("error decoding address ranges = {0}",
+                            TheError.c_str());
         });
         consumeError(RangesOrError.takeError());
         break;


### PR DESCRIPTION
This relates to #35980.

Here are all independent PRs that deal with replacing `format` with `formatv` in `llvm/lib/DebugInfo`:

* -> llvm/llvm-project#192011
* llvm/llvm-project#192010
* llvm/llvm-project#192009
* llvm/llvm-project#192008
* llvm/llvm-project#192007
* llvm/llvm-project#192006
* llvm/llvm-project#192004
* llvm/llvm-project#192003
* llvm/llvm-project#192002
* llvm/llvm-project#192001
* llvm/llvm-project#192000
* llvm/llvm-project#191999
* llvm/llvm-project#191998
* llvm/llvm-project#191997
* llvm/llvm-project#191996
* llvm/llvm-project#191994
* llvm/llvm-project#191993
* llvm/llvm-project#191992
* llvm/llvm-project#191991
* llvm/llvm-project#191989
* llvm/llvm-project#191988
* llvm/llvm-project#191987
* llvm/llvm-project#191986
* llvm/llvm-project#191984
* llvm/llvm-project#191983
* llvm/llvm-project#191982
* llvm/llvm-project#191981
* llvm/llvm-project#191980