### PR TITLE
[IR] treat nofpclass as a poison-generating return attribute

### DIFF
--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -538,7 +538,8 @@ bool Instruction::hasPoisonGeneratingReturnAttributes() const {
     AttributeSet RetAttrs = CB->getAttributes().getRetAttrs();
     return RetAttrs.hasAttribute(Attribute::Range) ||
            RetAttrs.hasAttribute(Attribute::Alignment) ||
-           RetAttrs.hasAttribute(Attribute::NonNull);
+           RetAttrs.hasAttribute(Attribute::NonNull) ||
+           RetAttrs.hasAttribute(Attribute::NoFPClass);
   }
   return false;
 }
@@ -549,6 +550,7 @@ void Instruction::dropPoisonGeneratingReturnAttributes() {
     AM.addAttribute(Attribute::Range);
     AM.addAttribute(Attribute::Alignment);
     AM.addAttribute(Attribute::NonNull);
+    AM.addAttribute(Attribute::NoFPClass);
     CB->removeRetAttrs(AM);
   }
   assert(!hasPoisonGeneratingReturnAttributes() && "must be kept in sync");

--- a/llvm/test/Transforms/InstCombine/freeze.ll
+++ b/llvm/test/Transforms/InstCombine/freeze.ll
@@ -1721,6 +1721,18 @@ bb.13:                                             ; preds = %bb.8, %bb.2
   br label %bb.2
 }
 
+define float @freeze_fabs_nofpclass(float %a) {
+; CHECK-LABEL: define float @freeze_fabs_nofpclass(
+; CHECK-SAME: float [[A:%.*]]) {
+; CHECK-NEXT:    [[A_FR:%.*]] = freeze float [[A]]
+; CHECK-NEXT:    [[X:%.*]] = call float @llvm.fabs.f32(float [[A_FR]])
+; CHECK-NEXT:    ret float [[X]]
+;
+  %x = call nofpclass(nan) float @llvm.fabs.f32(float %a)
+  %x.fr = freeze float %x
+  ret float %x.fr
+}
+
 !0 = !{}
 !1 = !{i64 4}
 !2 = !{i32 0, i32 100}


### PR DESCRIPTION
- For: #191338

Failing nofpclass attribute will generate poison.
This change adds nofpclass attributes to `hasPoisonGeneratingReturnAttributes`/`dropPoisonGeneratingReturnAttributes`.