### PR TITLE
[ScheduleDAG] Avoid duplicate worklist entries in ComputeDepth/ComputeHeight. NFC

### DIFF
--- a/llvm/lib/CodeGen/ScheduleDAG.cpp
+++ b/llvm/lib/CodeGen/ScheduleDAG.cpp
@@ -260,65 +260,61 @@ void SUnit::setHeightToAtLeast(unsigned NewHeight) {
   isHeightCurrent = true;
 }
 
-/// Calculates the maximal path from the node to the exit.
+/// Calculates the maximal path from the node to the entry.
 void SUnit::ComputeDepth() {
-  SmallVector<SUnit*, 8> WorkList;
+  // Iterative post-order DFS along Preds. Pushing one pred at a time and
+  // finalizing on pop. A node on the stack cannot reappear as a pred of any
+  // descendant.
+  SmallVector<SUnit *, 8> WorkList;
   WorkList.push_back(this);
   do {
     SUnit *Cur = WorkList.back();
-
-    bool Done = true;
-    unsigned MaxPredDepth = 0;
+    bool Descended = false;
     for (const SDep &PredDep : Cur->Preds) {
       SUnit *PredSU = PredDep.getSUnit();
-      if (PredSU->isDepthCurrent)
-        MaxPredDepth = std::max(MaxPredDepth,
-                                PredSU->Depth + PredDep.getLatency());
-      else {
-        Done = false;
+      if (!PredSU->isDepthCurrent) {
         WorkList.push_back(PredSU);
+        Descended = true;
+        break;
       }
     }
-
-    if (Done) {
-      WorkList.pop_back();
-      if (MaxPredDepth != Cur->Depth) {
-        Cur->setDepthDirty();
-        Cur->Depth = MaxPredDepth;
-      }
-      Cur->isDepthCurrent = true;
-    }
+    if (Descended)
+      continue;
+    WorkList.pop_back();
+    unsigned MaxPredDepth = 0;
+    for (const SDep &PredDep : Cur->Preds)
+      MaxPredDepth = std::max(MaxPredDepth,
+                              PredDep.getSUnit()->Depth + PredDep.getLatency());
+    Cur->Depth = MaxPredDepth;
+    Cur->isDepthCurrent = true;
   } while (!WorkList.empty());
 }
 
-/// Calculates the maximal path from the node to the entry.
+/// Calculates the maximal path from the node to the exit.
 void SUnit::ComputeHeight() {
-  SmallVector<SUnit*, 8> WorkList;
+  // See ComputeDepth; this is the mirror image walking Succs.
+  SmallVector<SUnit *, 8> WorkList;
   WorkList.push_back(this);
   do {
     SUnit *Cur = WorkList.back();
-
-    bool Done = true;
-    unsigned MaxSuccHeight = 0;
+    bool Descended = false;
     for (const SDep &SuccDep : Cur->Succs) {
       SUnit *SuccSU = SuccDep.getSUnit();
-      if (SuccSU->isHeightCurrent)
-        MaxSuccHeight = std::max(MaxSuccHeight,
-                                 SuccSU->Height + SuccDep.getLatency());
-      else {
-        Done = false;
+      if (!SuccSU->isHeightCurrent) {
         WorkList.push_back(SuccSU);
+        Descended = true;
+        break;
       }
     }
-
-    if (Done) {
-      WorkList.pop_back();
-      if (MaxSuccHeight != Cur->Height) {
-        Cur->setHeightDirty();
-        Cur->Height = MaxSuccHeight;
-      }
-      Cur->isHeightCurrent = true;
-    }
+    if (Descended)
+      continue;
+    WorkList.pop_back();
+    unsigned MaxSuccHeight = 0;
+    for (const SDep &SuccDep : Cur->Succs)
+      MaxSuccHeight = std::max(MaxSuccHeight, SuccDep.getSUnit()->Height +
+                                                  SuccDep.getLatency());
+    Cur->Height = MaxSuccHeight;
+    Cur->isHeightCurrent = true;
   } while (!WorkList.empty());
 }
 


### PR DESCRIPTION
The old loop pushed every not-current predecessor in one sweep, so on
diamond-shaped DAGs a predecessor could be pushed while still on the
stack. Measured on clang -O2 -c sqlite3.i with the old algorithm
instrumented: ComputeDepth had 10.8% duplicate pushes (21.4% of calls
hit the issue).

Rewrite as an iterative post-order DFS that pushes one predecessor at a
time and breaks.
