### PR TITLE
[TableGen] Fix the non-determinism in DFAPacketizerEmitter.cpp

### DIFF
--- a/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
+++ b/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
@@ -103,7 +103,7 @@ int DFAPacketizerEmitter::collectAllFuncUnits(
 
   struct RecordNameLess {
     bool operator()(const Record *LHS, const Record *RHS) const {
-        return LHS->getName() < RHS->getName();
+      return LHS->getName() < RHS->getName();
     }
   };
 

--- a/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
+++ b/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
@@ -101,6 +101,8 @@ int DFAPacketizerEmitter::collectAllFuncUnits(
   LLVM_DEBUG(dbgs() << "collectAllFuncUnits");
   LLVM_DEBUG(dbgs() << " (" << ProcModels.size() << " itineraries)\n");
 
+  // Use the LessRecord comparator to make the traversal deterministic with the
+  // same input
   std::set<const Record *, LessRecord> ProcItinList;
   for (const CodeGenProcModel *Model : ProcModels)
     ProcItinList.insert(Model->ItinsDef);

--- a/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
+++ b/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
@@ -101,7 +101,13 @@ int DFAPacketizerEmitter::collectAllFuncUnits(
   LLVM_DEBUG(dbgs() << "collectAllFuncUnits");
   LLVM_DEBUG(dbgs() << " (" << ProcModels.size() << " itineraries)\n");
 
-  std::set<const Record *> ProcItinList;
+  struct RecordNameLess {
+    bool operator()(const Record *LHS, const Record *RHS) const {
+        return LHS->getName() < RHS->getName();
+    }
+  };
+
+  std::set<const Record *, RecordNameLess> ProcItinList;
   for (const CodeGenProcModel *Model : ProcModels)
     ProcItinList.insert(Model->ItinsDef);
 

--- a/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
+++ b/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
@@ -101,13 +101,7 @@ int DFAPacketizerEmitter::collectAllFuncUnits(
   LLVM_DEBUG(dbgs() << "collectAllFuncUnits");
   LLVM_DEBUG(dbgs() << " (" << ProcModels.size() << " itineraries)\n");
 
-  struct RecordNameLess {
-    bool operator()(const Record *LHS, const Record *RHS) const {
-      return LHS->getName() < RHS->getName();
-    }
-  };
-
-  std::set<const Record *, RecordNameLess> ProcItinList;
+  std::set<const Record *, LessRecord> ProcItinList;
   for (const CodeGenProcModel *Model : ProcModels)
     ProcItinList.insert(Model->ItinsDef);
 


### PR DESCRIPTION
Sort the std::set ProcItinList by Record name, not the pointer address.
