### PR TITLE
[Runtimes] Fix /clang: prefix warning for GNU-like clang on Windows

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -389,7 +389,7 @@ macro(construct_compiler_rt_default_triple)
 
   if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(option_prefix "")
-    if (CMAKE_C_SIMULATE_ID MATCHES "MSVC")
+    if (CMAKE_C_COMPILER_FRONTEND_VARIANT MATCHES "MSVC")
       set(option_prefix "/clang:")
     endif()
     set(print_target_triple ${CMAKE_C_COMPILER} ${option_prefix}--target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} ${option_prefix}-print-target-triple)

--- a/runtimes/CMakeLists.txt
+++ b/runtimes/CMakeLists.txt
@@ -223,7 +223,7 @@ set(LLVM_TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE}")
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
   set(option_prefix "")
-  if (CMAKE_C_SIMULATE_ID MATCHES "MSVC")
+  if (CMAKE_C_COMPILER_FRONTEND_VARIANT MATCHES "MSVC")
     set(option_prefix "/clang:")
   endif()
   set(print_target_triple ${CMAKE_C_COMPILER} ${option_prefix}--target=${LLVM_DEFAULT_TARGET_TRIPLE} ${option_prefix}-print-target-triple)


### PR DESCRIPTION
libclc has configure warning on Windows:
clang: error: no such file or directory: '/clang:--target=amdgcn-amd-amdhsa-llvm' clang: error: no such file or directory: '/clang:-print-target-triple'
  CMake Warning at CMakeLists.txt:239 (message):
    Failed to execute `llvm-project/build/bin/clang.exe
    /clang:--target=amdgcn-amd-amdhsa-llvm /clang:-print-target-triple` to
    normalize target triple.

Switch to check CMAKE_C_COMPILER_FRONTEND_VARIANT because
CMAKE_C_SIMULATE_ID=MSVC: true for both clang and clang-cl.
CMAKE_C_COMPILER_FRONTEND_VARIANT=MSVC: true for clang-cl; false for clang.