### PR TITLE
[mlir] Fix definition of type traits struct member for some ops

### DIFF
--- a/mlir/include/mlir/Dialect/Async/IR/Async.h
+++ b/mlir/include/mlir/Dialect/Async/IR/Async.h
@@ -67,7 +67,7 @@ struct PointerLikeTypeTraits<mlir::async::FuncOp> {
   static inline mlir::async::FuncOp getFromVoidPointer(void *p) {
     return mlir::async::FuncOp::getFromOpaquePointer(p);
   }
-  static constexpr int numLowBitsAvailable = 3;
+  static constexpr int NumLowBitsAvailable = 3;
 };
 } // namespace llvm
 

--- a/mlir/include/mlir/Dialect/Func/IR/FuncOps.h
+++ b/mlir/include/mlir/Dialect/Func/IR/FuncOps.h
@@ -41,7 +41,7 @@ struct PointerLikeTypeTraits<mlir::func::FuncOp> {
   static inline mlir::func::FuncOp getFromVoidPointer(void *p) {
     return mlir::func::FuncOp::getFromOpaquePointer(p);
   }
-  static constexpr int numLowBitsAvailable = 3;
+  static constexpr int NumLowBitsAvailable = 3;
 };
 } // namespace llvm
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVOps.h
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVOps.h
@@ -57,7 +57,7 @@ public:
   static inline mlir::spirv::FuncOp getFromVoidPointer(void *p) {
     return mlir::spirv::FuncOp::getFromOpaquePointer(p);
   }
-  static constexpr int numLowBitsAvailable = 3;
+  static constexpr int NumLowBitsAvailable = 3;
 };
 
 } // namespace llvm

--- a/mlir/include/mlir/IR/BuiltinOps.h
+++ b/mlir/include/mlir/IR/BuiltinOps.h
@@ -40,7 +40,7 @@ public:
   static inline mlir::ModuleOp getFromVoidPointer(void *p) {
     return mlir::ModuleOp::getFromOpaquePointer(p);
   }
-  static constexpr int numLowBitsAvailable = 3;
+  static constexpr int NumLowBitsAvailable = 3;
 };
 } // namespace llvm
 


### PR DESCRIPTION
This commit fixes all appearences of `numLowBitsAvailable` to the correct `NumLowBitsAvailable`. Prior to this change, instantiation of templates like `llvm::PointerIntPair<mlir::ModuleOp, 3>` would not compile.

See usage of `NumLowBitsAvailable`: https://github.com/llvm/llvm-project/blob/224c429e858f8171852990a6f7b2b3590eeaffb7/llvm/include/llvm/ADT/PointerIntPair.h#L169