### PR TITLE
[mlir] Add removeDomTree method to DominanceInfoBase

### DIFF
--- a/mlir/include/mlir/IR/Dominance.h
+++ b/mlir/include/mlir/IR/Dominance.h
@@ -104,6 +104,13 @@ public:
     return *getDominanceInfo(region, /*needsDomTree=*/true).getPointer();
   }
 
+  void removeDomTree(Region *region) {
+    if (dominanceInfos.contains(region)) {
+      delete dominanceInfos[region].getPointer();
+      dominanceInfos.erase(region);
+    }
+  };
+
 protected:
   using super = DominanceInfoBase<IsPostDom>;
 


### PR DESCRIPTION
When a pass runs and marks markAnalysesPreserved<DominanceInfo, PostDominanceInfo>(), any deleted RegionOps that have associated dominator trees will keep those trees in memory until DominanceInfo is destructed. This PR introduces a removeDomTree method in DominanceInfoBase, allowing us to explicitly remove dominator trees in a timely manner.