### PR TITLE
[libc][NFC] Fix GCC build in __futex_word.h

### DIFF
--- a/libc/include/llvm-libc-types/__futex_word.h
+++ b/libc/include/llvm-libc-types/__futex_word.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_LIBC_TYPES___FUTEX_WORD_H
 #define LLVM_LIBC_TYPES___FUTEX_WORD_H
 
+#include "__llvm-libc-common.h"
+
 typedef struct {
   // Futex word should be aligned appropriately to allow target atomic
   // instructions. This declaration mimics the internal setup.


### PR DESCRIPTION
Included __llvm-libc-common.h in __futex_word.h to fix a build failure with GCC.

GCC in C++ mode does not recognize _Alignas without the mapping to alignas provided in __llvm-libc-common.h.

The failure was introduced in commit 91c0fdfe1392.