### PR TITLE
[DirectX] Emit unresolved ptr as i8*

### DIFF
--- a/llvm/lib/Target/DirectX/DirectXIRPasses/PointerTypeAnalysis.cpp
+++ b/llvm/lib/Target/DirectX/DirectXIRPasses/PointerTypeAnalysis.cpp
@@ -81,8 +81,12 @@ Type *classifyPointerType(const Value *V, PointerTypeMap &Map) {
     }
   }
   // If we were unable to determine the pointee type, set to i8
+  // If we were able to determine the pointee type as ptr, set to i8*
   if (!PointeeTy)
     PointeeTy = Type::getInt8Ty(V->getContext());
+  if (PointeeTy->isPointerTy())
+    PointeeTy = TypedPointerType::get(Type::getInt8Ty(V->getContext()),
+                                      PointeeTy->getPointerAddressSpace());
   auto *TypedPtrTy =
       TypedPointerType::get(PointeeTy, V->getType()->getPointerAddressSpace());
 

--- a/llvm/test/CodeGen/DirectX/global-variable.ll
+++ b/llvm/test/CodeGen/DirectX/global-variable.ll
@@ -1,0 +1,6 @@
+; RUN: llc -mtriple=dxil-pc-shadermodel6.3-library --filetype=obj -o %t.dxbc %s
+; RUN: llvm-objcopy  --dump-section=DXIL=%t.bc %t.dxbc
+; RUN: llvm-dis -o - %t.bc | FileCheck %s
+
+; CHECK: @foo = common global ptr null
+@foo = common global ptr null

--- a/llvm/test/tools/dxil-dis/opaque-pointers-var.ll
+++ b/llvm/test/tools/dxil-dis/opaque-pointers-var.ll
@@ -1,0 +1,5 @@
+; RUN: llc --filetype=obj %s -o - | dxil-dis -o - | FileCheck %s
+target triple = "dxil-unknown-shadermodel6.3-library"
+
+; CHECK: @foo = common global i8* null
+@foo = common global ptr null


### PR DESCRIPTION
We cannot use dxilOpaquePtrReservedName in this test as that is the wrong type for the null initializer.