### PR TITLE
[AArch64] Check Subtarget via STI in getInstSizeInBytes

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -151,7 +151,8 @@ unsigned AArch64InstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   const MCInstrDesc &Desc = MI.getDesc();
 
   // LFI rewriter expansions that supersede normal sizing.
-  if (Subtarget.isLFI())
+  const auto &STI = MF->getSubtarget<AArch64Subtarget>();
+  if (STI.isLFI())
     if (auto Size = getLFIInstSizeInBytes(MI))
       return *Size;
 
@@ -162,7 +163,6 @@ unsigned AArch64InstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
     if (!MFI->shouldSignReturnAddress(*MF))
       return NumBytes;
 
-    const auto &STI = MF->getSubtarget<AArch64Subtarget>();
     auto Method = STI.getAuthenticatedLRCheckMethod(*MF);
     NumBytes += AArch64PAuth::getCheckerSizeInBytes(Method);
     return NumBytes;


### PR DESCRIPTION
The InstSizes test (`llvm/unittests/Target/AArch64/InstSizes.cpp`) destroys the Subtarget field early (`ST` created on the stack in [`createInstrInfo`](https://github.com/llvm/llvm-project/blob/40a585e742ed6b28306d7511380079325ba1a003/llvm/unittests/Target/AArch64/InstSizes.cpp#L32)), causing a use-after-free if it is used in `getInstSizeInBytes`. This causes a failure when running the test with hwasan (reported by build bot). To fix this, this PR switches to using `STI` instead of `Subtarget` in `getInstSizeInBytes` for checking `isLFI`, which survives for the lifetime of the test.

I think fixing the test itself (the root of the issue, as far as I can tell) would be more involved. Perhaps I should open an issue for it though?

I have tested the fix on an AArch64 machine with hwasan to confirm that it resolves the issue.