### PR TITLE
[sanitizer] Add missing bitcast to sanitizer_bitvector_test.cpp

### DIFF
--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_bitvector_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_bitvector_test.cpp
@@ -61,7 +61,7 @@ void Print(const BV &bv) {
   t.copyFrom(bv);
   while (!t.empty()) {
     uptr idx = t.getAndClearFirstOne();
-    fprintf(stderr, "%lu ", idx);
+    fprintf(stderr, "%lu ", (unsigned long)idx);
   }
   fprintf(stderr, "\n");
 }


### PR DESCRIPTION
Fixes buildbot report
(https://lab.llvm.org/buildbot/#/builders/66/builds/29379):

/home/b/sanitizer-x86_64-linux/build/llvm-project/compiler-rt/lib/sanitizer_common/tests/sanitizer_bitvector_test.cpp:64:29: error: format specifies type 'unsigned long' but the argument has type 'uptr' (aka 'unsigned int') [-Werror,-Wformat]
   64 |     fprintf(stderr, "%lu ", idx);
      |                      ~~~    ^~~
      |                      %u