### PR TITLE
[clang][cmake] Add check-clang-extra to bootstrap targets for Fuchsia

### DIFF
--- a/clang/cmake/caches/Fuchsia-stage2-instrumented.cmake
+++ b/clang/cmake/caches/Fuchsia-stage2-instrumented.cmake
@@ -9,6 +9,7 @@ endif()
 set(CLANG_BOOTSTRAP_TARGETS
   check-all
   check-clang
+  check-clang-extra
   check-lld
   check-llvm
   check-polly

--- a/clang/cmake/caches/Fuchsia.cmake
+++ b/clang/cmake/caches/Fuchsia.cmake
@@ -190,6 +190,7 @@ if(FUCHSIA_ENABLE_PGO)
     stage2-install-toolchain-distribution-toolchain
     stage2-check-all
     stage2-check-clang
+    stage2-check-clang-extra
     stage2-check-lld
     stage2-check-llvm
     stage2-check-polly
@@ -207,6 +208,7 @@ else()
  set(_FUCHSIA_BOOTSTRAP_TARGETS
    check-all
    check-clang
+   check-clang-extra
    check-lld
    check-llvm
    check-polly


### PR DESCRIPTION
Not having these prevents us from testing the clang-tool-extra targets in
our CI, and multi stage builds.