### PR TITLE
[LoopBoundSplit] Fix edge connections during transformation

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
@@ -356,6 +356,11 @@ static bool splitLoopBound(Loop &L, DominatorTree &DT, LoopInfo &LI,
   BasicBlock *PostLoopPreHeader = PostLoop->getLoopPreheader();
   IRBuilder<> Builder(&PostLoopPreHeader->front());
 
+  // Replace exit branch target of pre-loop by post-loop's preheader.
+  if (L.getExitBlock() == ExitingCond.BI->getSuccessor(0))
+    ExitingCond.BI->setSuccessor(0, PostLoopPreHeader);
+  else
+    ExitingCond.BI->setSuccessor(1, PostLoopPreHeader);
   // Update phi nodes in header of post-loop.
   bool isExitingLatch = L.getExitingBlock() == L.getLoopLatch();
   Value *ExitingCondLCSSAPhi = nullptr;
@@ -419,11 +424,6 @@ static bool splitLoopBound(Loop &L, DominatorTree &DT, LoopInfo &LI,
       cast<CondBrInst>(VMap[SplitCandidateCond.BI]);
   ClonedSplitCandidateBI->setCondition(ConstantInt::getFalse(Context));
 
-  // Replace exit branch target of pre-loop by post-loop's preheader.
-  if (L.getExitBlock() == ExitingCond.BI->getSuccessor(0))
-    ExitingCond.BI->setSuccessor(0, PostLoopPreHeader);
-  else
-    ExitingCond.BI->setSuccessor(1, PostLoopPreHeader);
 
   // Update phi node in exit block of post-loop.
   Builder.SetInsertPoint(PostLoopPreHeader, PostLoopPreHeader->begin());

--- a/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
@@ -424,7 +424,6 @@ static bool splitLoopBound(Loop &L, DominatorTree &DT, LoopInfo &LI,
       cast<CondBrInst>(VMap[SplitCandidateCond.BI]);
   ClonedSplitCandidateBI->setCondition(ConstantInt::getFalse(Context));
 
-
   // Update phi node in exit block of post-loop.
   Builder.SetInsertPoint(PostLoopPreHeader, PostLoopPreHeader->begin());
   for (PHINode &PN : PostLoop->getExitBlock()->phis()) {

--- a/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
@@ -357,10 +357,20 @@ static bool splitLoopBound(Loop &L, DominatorTree &DT, LoopInfo &LI,
   IRBuilder<> Builder(&PostLoopPreHeader->front());
 
   // Replace exit branch target of pre-loop by post-loop's preheader.
+  // Note: update the branch here after calling cloneLoopWithPreheader()
+  // to keep the IR valid. Otherwise LI.verify(DT) would fail below
+  // because with invalide IR it would not be able to correctly compute
+  // another fresh LoopInfo for verification.
   if (L.getExitBlock() == ExitingCond.BI->getSuccessor(0))
     ExitingCond.BI->setSuccessor(0, PostLoopPreHeader);
   else
     ExitingCond.BI->setSuccessor(1, PostLoopPreHeader);
+
+  // Update dominator tree.
+  DT.changeImmediateDominator(PostLoopPreHeader, L.getExitingBlock());
+#ifndef NDEBUG
+  LI.verify(DT);
+#endif
   // Update phi nodes in header of post-loop.
   bool isExitingLatch = L.getExitingBlock() == L.getLoopLatch();
   Value *ExitingCondLCSSAPhi = nullptr;
@@ -382,6 +392,8 @@ static bool splitLoopBound(Loop &L, DominatorTree &DT, LoopInfo &LI,
     // Find PHI with exiting condition from pre-loop. The PHI should be
     // SCEVAddRecExpr and have same incoming value from backedge with
     // ExitingCond.
+    //
+    // TODO: Separate SCEV queries from PHI node updates.
     if (!SE.isSCEVable(PN.getType()))
       continue;
 
@@ -391,13 +403,22 @@ static bool splitLoopBound(Loop &L, DominatorTree &DT, LoopInfo &LI,
       ExitingCondLCSSAPhi = LCSSAPhi;
   }
 
-  // Add conditional branch to check we can skip post-loop in its preheader.
+  // Add conditional branch to check we can skip post-loop in its preheader,
+  // and update DT.
   Instruction *OrigBI = PostLoopPreHeader->getTerminator();
   ICmpInst::Predicate Pred = ICmpInst::ICMP_NE;
   Value *Cond =
       Builder.CreateICmp(Pred, ExitingCondLCSSAPhi, ExitingCond.BoundValue);
   Builder.CreateCondBr(Cond, PostLoop->getHeader(), PostLoop->getExitBlock());
   OrigBI->eraseFromParent();
+  DT.changeImmediateDominator(PostLoop->getExitBlock(), PostLoopPreHeader);
+#ifdef EXPENSIVE_CHECKS
+  assert(DT.verify(DominatorTree::VerificationLevel::Full) &&
+         "DT broken during transformation!");
+#else
+  assert(DT.verify(DominatorTree::VerificationLevel::Fast) &&
+         "DT broken during transformation!");
+#endif
 
   // Create new loop bound and add it into preheader of pre-loop.
   const SCEV *NewBoundSCEV = ExitingCond.BoundSCEV;
@@ -447,10 +468,6 @@ static bool splitLoopBound(Loop &L, DominatorTree &DT, LoopInfo &LI,
       }
     }
   }
-
-  // Update dominator tree.
-  DT.changeImmediateDominator(PostLoopPreHeader, L.getExitingBlock());
-  DT.changeImmediateDominator(PostLoop->getExitBlock(), PostLoopPreHeader);
 
   // Invalidate cached SE information.
   SE.forgetLoop(&L);

--- a/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
@@ -358,9 +358,7 @@ static bool splitLoopBound(Loop &L, DominatorTree &DT, LoopInfo &LI,
 
   // Replace exit branch target of pre-loop by post-loop's preheader.
   // Note: update the branch here after calling cloneLoopWithPreheader()
-  // to keep the IR valid. Otherwise LI.verify(DT) would fail below
-  // because with invalide IR it would not be able to correctly compute
-  // another fresh LoopInfo for verification.
+  // to keep the IR valid.
   if (L.getExitBlock() == ExitingCond.BI->getSuccessor(0))
     ExitingCond.BI->setSuccessor(0, PostLoopPreHeader);
   else


### PR DESCRIPTION
This is the fix to #190672. 

The issue is caused by invalid intermediate IR when `getSCEV()` is called during transformation: the exiting block of `pre-loop` did not re-connect to preheader of the `post-loop` but still connected to original pre-loop exit block which is broken, causing `LI.verify()` unable to correctly recompute another LoopInfo for verification. To fix, reconnect the edge earlier before calling `getSCEV()`.