### PR TITLE
[lldb] Fix FreeBSD/NetBSD plugin build after AsCString API change

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
@@ -749,9 +749,9 @@ Status NativeProcessFreeBSD::GetLoadedModuleFileSpec(const char *module_path,
       return Status();
     }
   }
-  return Status::FromErrorStringWithFormat(
-      "Module file (%s) not found in process' memory map!",
-      module_file_spec.GetFilename().AsCString());
+  return Status::FromErrorStringWithFormatv(
+      "Module file ({0}) not found in process' memory map!",
+      module_file_spec.GetFilename());
 }
 
 Status

--- a/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
+++ b/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
@@ -770,9 +770,9 @@ Status NativeProcessNetBSD::GetLoadedModuleFileSpec(const char *module_path,
       return Status();
     }
   }
-  return Status::FromErrorStringWithFormat(
-      "Module file (%s) not found in process' memory map!",
-      module_file_spec.GetFilename().AsCString());
+  return Status::FromErrorStringWithFormatv(
+      "Module file ({0}) not found in process' memory map!",
+      module_file_spec.GetFilename());
 }
 
 Status NativeProcessNetBSD::GetFileLoadAddress(const llvm::StringRef &file_name,


### PR DESCRIPTION
The argument to `AsCString` was made explicit in 116b045b1e2bff462afff0dc0b06218e6074f427.

```
/home/ewilde/llvm-project/freebsd-lldb-build/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp:754:48: error: too few arguments to function call, single argument 'value_if_empty' was not specified
  754 |       module_file_spec.GetFilename().AsCString());
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/home/ewilde/llvm-project/freebsd-lldb-build/lldb/include/lldb/Utility/ConstString.h:183:15: note: 'AsCString' declared here
  183 |   const char *AsCString(const char *value_if_empty) const {
      |               ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Not all use-sites were updated to pass an argument resulting in build failures. I'm updating the errors in the FreeBSD and NetBSD plugins to use formatv instead of expanding the C String, like what is done on Linux, avoiding the issue entirely.

rdar://174675042