### PR TITLE
[clang] Attempt to unbreak clang/test/Driver/serenity.cpp on bots more

### DIFF
--- a/clang/test/Driver/serenity.cpp
+++ b/clang/test/Driver/serenity.cpp
@@ -230,15 +230,6 @@
 // STATIC_LIBSTDCXX: "--pop-state"
 // STATIC_LIBSTDCXX: "-lc" "crtendS.o"
 
-// RUN: %clangxx -### %s --target=x86_64-unknown-serenity --sysroot="" -resource-dir= \
-// RUN:   -nostdlib++ 2>&1 | FileCheck %s --check-prefix=NO_LIBCXX
-// NO_LIBCXX: "-z" "pack-relative-relocs"
-// NO_LIBCXX: "crt0.o" "crtbeginS.o"
-// NO_LIBCXX-SAME: "--as-needed"
-// NO_LIBCXX-SAME: "-lunwind"
-// NO_LIBCXX-NOT: "-lc++"
-// NO_LIBCXX-SAME: "-lc" "crtendS.o"
-
 /// Check that unwind tables are enabled.
 // RUN: %clang --target=x86_64-unknown-serenity -### -S %s 2>&1 | \
 // RUN:   FileCheck -check-prefix=UNWIND-TABLES %s


### PR DESCRIPTION
This snippet fails on (at least) this bot:
https://lab.llvm.org/buildbot/#/builders/10/builds/26512