### PR TITLE
[mlir][tosa] Add `draft` information to specification version

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TargetEnv.h
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TargetEnv.h
@@ -59,22 +59,39 @@ class TosaSpecificationVersion {
 public:
   TosaSpecificationVersion() = default;
 
-  TosaSpecificationVersion(uint32_t major, uint32_t minor)
-      : majorVersion(major), minorVersion(minor) {}
+  TosaSpecificationVersion(uint32_t major, uint32_t minor, bool draft = false)
+      : majorVersion(major), minorVersion(minor), draft(draft) {}
   TosaSpecificationVersion(SpecificationVersion version)
       : TosaSpecificationVersion(fromVersionEnum(version)) {}
 
   bool isBackwardsCompatibleWith(TosaSpecificationVersion baseVersion) const {
-    return this->majorVersion == baseVersion.majorVersion &&
-           this->minorVersion >= baseVersion.minorVersion;
+    if (this->majorVersion != baseVersion.majorVersion)
+      return false;
+    if (this->minorVersion < baseVersion.minorVersion)
+      return false;
+    // An unreleased version is not expected to be backwards compatible with
+    // a corresponding released version. However, an unreleased version is
+    // expected to be backwards compatible with all released versions prior to
+    // it.
+    //
+    // For example:
+    // - 1.1.draft is not expected to be backwards compatible with 1.1
+    // - 1.1.draft is expected to be backwards compatible with 1.0
+    // - 1.1.draft is not expected to be backwards compatible with 1.0.draft
+    if (this->draft && !baseVersion.draft &&
+        this->minorVersion == baseVersion.minorVersion)
+      return false;
+    return true;
   }
 
   uint32_t getMajor() const { return majorVersion; }
   uint32_t getMinor() const { return minorVersion; }
+  bool isDraft() const { return draft; }
 
 private:
   uint32_t majorVersion = 0;
   uint32_t minorVersion = 0;
+  bool draft = false;
 
   static TosaSpecificationVersion
   fromVersionEnum(SpecificationVersion version) {
@@ -82,7 +99,7 @@ private:
     case SpecificationVersion::V_1_0:
       return TosaSpecificationVersion(1, 0);
     case SpecificationVersion::V_1_1_DRAFT:
-      return TosaSpecificationVersion(1, 1);
+      return TosaSpecificationVersion(1, 1, true);
     }
     llvm_unreachable("Unknown TOSA version");
   }

--- a/mlir/lib/Dialect/Tosa/IR/TargetEnv.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TargetEnv.cpp
@@ -13,7 +13,8 @@ namespace mlir {
 namespace tosa {
 
 llvm::SmallString<4> stringifyVersion(TosaSpecificationVersion version) {
-  return llvm::formatv("{0}.{1}", version.getMajor(), version.getMinor());
+  return llvm::formatv("{0}.{1}{2}", version.getMajor(), version.getMinor(),
+                       version.isDraft() ? ".draft" : "");
 }
 
 TosaSpecificationVersion getMinVersion(const Profile &profile) {
@@ -45,7 +46,7 @@ TosaSpecificationVersion getMinVersion(const Extension &extension) {
   case Extension::int64:
   case Extension::mxfp_conv:
   case Extension::shape:
-    return TosaSpecificationVersion(1, 1);
+    return TosaSpecificationVersion(1, 1, true);
   case Extension::none:
     return TosaSpecificationVersion(0, 0);
   }

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaValidation.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaValidation.cpp
@@ -867,7 +867,7 @@ LogicalResult TosaValidation::levelCheckSize(Operation *op,
     for (auto dim : shape) {
       const bool dimIsDynamic = mlir::ShapedType::isDynamic(dim);
       const TosaSpecificationVersion targetVersion = targetEnv.getSpecVersion();
-      const TosaSpecificationVersion minRequiredVersion(1, 1);
+      const TosaSpecificationVersion minRequiredVersion(1, 1, true);
       if (targetVersion.isBackwardsCompatibleWith(minRequiredVersion) &&
           dimIsDynamic)
         // TOSA 1.1 and above supports dynamic dimensions, however, they must be

--- a/mlir/test/Dialect/Tosa/tosa-validation-version-1p0-invalid.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-validation-version-1p0-invalid.mlir
@@ -5,7 +5,7 @@
 func.func @test_matmul_fp8_mixed_precision_operands(%arg0: tensor<1x14x19xf8E4M3FN>, %arg1: tensor<1x19x28xf8E5M2>) -> tensor<1x14x28xf16> {
   %azp0 = "tosa.const"() <{values = dense<0.0> : tensor<1xf8E4M3FN>}> : () -> tensor<1xf8E4M3FN>
   %bzp0 = "tosa.const"() <{values = dense<0.0> : tensor<1xf8E5M2>}> : () -> tensor<1xf8E5M2>
-  // expected-error@+1 {{'tosa.matmul' op illegal: requires specification version compatible with 1.1 (got 1.0) to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.matmul' op illegal: requires specification version compatible with 1.1.draft (got 1.0) to be specified in the target environment}}
   %0 = tosa.matmul %arg0, %arg1, %azp0, %bzp0 : (tensor<1x14x19xf8E4M3FN>, tensor<1x19x28xf8E5M2>, tensor<1xf8E4M3FN>, tensor<1xf8E5M2>)  -> tensor<1x14x28xf16>
   return %0 : tensor<1x14x28xf16>
 }
@@ -15,7 +15,7 @@ func.func @test_matmul_fp8_mixed_precision_operands(%arg0: tensor<1x14x19xf8E4M3
 func.func @test_matmul_fp8_input_fp32_acc_type(%arg0: tensor<1x14x19xf8E4M3FN>, %arg1: tensor<1x19x28xf8E4M3FN>) -> tensor<1x14x28xf32> {
   %azp0 = "tosa.const"() <{values = dense<0.0> : tensor<1xf8E4M3FN>}> : () -> tensor<1xf8E4M3FN>
   %bzp0 = "tosa.const"() <{values = dense<0.0> : tensor<1xf8E4M3FN>}> : () -> tensor<1xf8E4M3FN>
-  // expected-error@+1 {{'tosa.matmul' op illegal: requires specification version compatible with 1.1 (got 1.0) to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.matmul' op illegal: requires specification version compatible with 1.1.draft (got 1.0) to be specified in the target environment}}
   %0 = tosa.matmul %arg0, %arg1, %azp0, %bzp0 : (tensor<1x14x19xf8E4M3FN>, tensor<1x19x28xf8E4M3FN>, tensor<1xf8E4M3FN>, tensor<1xf8E4M3FN>)  -> tensor<1x14x28xf32>
   return %0 : tensor<1x14x28xf32>
 }
@@ -25,7 +25,7 @@ func.func @test_matmul_fp8_input_fp32_acc_type(%arg0: tensor<1x14x19xf8E4M3FN>, 
 func.func @test_conv2d_fp8_acc32(%arg0: tensor<1x4x4x4xf8E5M2>, %arg1: tensor<8x1x1x4xf8E5M2>, %arg2: tensor<8xf32>) -> tensor<1x4x4x8xf32> {
   %input_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf8E5M2>}> : () -> tensor<1xf8E5M2>
   %weight_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf8E5M2>}> : () -> tensor<1xf8E5M2>
-  // expected-error@+1 {{'tosa.conv2d' op illegal: requires specification version compatible with 1.1 (got 1.0) to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.conv2d' op illegal: requires specification version compatible with 1.1.draft (got 1.0) to be specified in the target environment}}
   %0 = tosa.conv2d %arg0, %arg1, %arg2, %input_zp, %weight_zp {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x4x4x4xf8E5M2>, tensor<8x1x1x4xf8E5M2>, tensor<8xf32>, tensor<1xf8E5M2>, tensor<1xf8E5M2>) -> tensor<1x4x4x8xf32>
   return %0 : tensor<1x4x4x8xf32>
 }
@@ -35,7 +35,7 @@ func.func @test_conv2d_fp8_acc32(%arg0: tensor<1x4x4x4xf8E5M2>, %arg1: tensor<8x
 func.func @test_conv3d_fp8_acc32(%arg0: tensor<1x4x8x21x17xf8E5M2>, %arg1: tensor<34x1x1x1x17xf8E5M2>, %arg2: tensor<34xf32>) -> tensor<1x4x8x21x34xf32> {
   %input_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf8E5M2>}> : () -> tensor<1xf8E5M2>
   %weight_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf8E5M2>}> : () -> tensor<1xf8E5M2>
-  // expected-error@+1 {{'tosa.conv3d' op illegal: requires specification version compatible with 1.1 (got 1.0) to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.conv3d' op illegal: requires specification version compatible with 1.1.draft (got 1.0) to be specified in the target environment}}
   %0 = tosa.conv3d %arg0, %arg1, %arg2, %input_zp, %weight_zp {acc_type = f32, dilation = array<i64: 1, 1, 1>, pad = array<i64: 0, 0, 0, 0, 0, 0>, stride = array<i64: 1, 1, 1>} : (tensor<1x4x8x21x17xf8E5M2>, tensor<34x1x1x1x17xf8E5M2>, tensor<34xf32>, tensor<1xf8E5M2>, tensor<1xf8E5M2>) -> tensor<1x4x8x21x34xf32>
   return %0 : tensor<1x4x8x21x34xf32>
 }
@@ -45,7 +45,7 @@ func.func @test_conv3d_fp8_acc32(%arg0: tensor<1x4x8x21x17xf8E5M2>, %arg1: tenso
 func.func @test_depthwise_conv2d_fp8_acc32(%arg0: tensor<1x4x4x4xf8E5M2>, %arg1: tensor<1x1x4x2xf8E5M2>, %arg2: tensor<8xf32>) -> tensor<1x4x4x8xf32> {
   %input_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf8E5M2>}> : () -> tensor<1xf8E5M2>
   %weight_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf8E5M2>}> : () -> tensor<1xf8E5M2>
-  // expected-error@+1 {{'tosa.depthwise_conv2d' op illegal: requires specification version compatible with 1.1 (got 1.0) to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.depthwise_conv2d' op illegal: requires specification version compatible with 1.1.draft (got 1.0) to be specified in the target environment}}
   %0 = tosa.depthwise_conv2d %arg0, %arg1, %arg2, %input_zp, %weight_zp {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x4x4x4xf8E5M2>, tensor<1x1x4x2xf8E5M2>, tensor<8xf32>, tensor<1xf8E5M2>, tensor<1xf8E5M2>) -> tensor<1x4x4x8xf32>
   return %0 : tensor<1x4x4x8xf32>
 }
@@ -55,7 +55,7 @@ func.func @test_depthwise_conv2d_fp8_acc32(%arg0: tensor<1x4x4x4xf8E5M2>, %arg1:
 func.func @test_transpose_conv2d_fp8_acc32(%arg0: tensor<1x32x32x8xf8E5M2>, %arg1: tensor<16x1x1x8xf8E5M2>, %arg2: tensor<16xf32>) -> tensor<1x32x32x16xf32> {
   %input_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf8E5M2>}> : () -> tensor<1xf8E5M2>
   %weight_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf8E5M2>}> : () -> tensor<1xf8E5M2>
-  // expected-error@+1 {{'tosa.transpose_conv2d' op illegal: requires specification version compatible with 1.1 (got 1.0) to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.transpose_conv2d' op illegal: requires specification version compatible with 1.1.draft (got 1.0) to be specified in the target environment}}
   %0 = tosa.transpose_conv2d %arg0, %arg1, %arg2, %input_zp, %weight_zp {acc_type = f32, out_pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x32x32x8xf8E5M2>, tensor<16x1x1x8xf8E5M2>, tensor<16xf32>, tensor<1xf8E5M2>, tensor<1xf8E5M2>) -> tensor<1x32x32x16xf32>
   return %0 : tensor<1x32x32x16xf32>
 }
@@ -63,7 +63,7 @@ func.func @test_transpose_conv2d_fp8_acc32(%arg0: tensor<1x32x32x8xf8E5M2>, %arg
 // -----
 
 func.func @test_gather_bool_i64(%arg0: tensor<13x21x3xi1>, %arg1: tensor<13x26xi64>) -> tensor<13x26x3xi1> {
-  // expected-error@+1 {{'tosa.gather' op illegal: requires specification version compatible with 1.1 (got 1.0) and requires any of [int64] profiles/extensions to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.gather' op illegal: requires specification version compatible with 1.1.draft (got 1.0) and requires any of [int64] profiles/extensions to be specified in the target environment}}
   %0 = tosa.gather %arg0, %arg1 : (tensor<13x21x3xi1>, tensor<13x26xi64>) -> tensor<13x26x3xi1>
   return %0 : tensor<13x26x3xi1>
 }
@@ -71,7 +71,7 @@ func.func @test_gather_bool_i64(%arg0: tensor<13x21x3xi1>, %arg1: tensor<13x26xi
 // -----
 
 func.func @test_gather_bool_i32(%arg0: tensor<13x21x3xi1>, %arg1: tensor<13x26xi32>) -> tensor<13x26x3xi1> {
-  // expected-error@+1 {{'tosa.gather' op illegal: requires specification version compatible with 1.1 (got 1.0) to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.gather' op illegal: requires specification version compatible with 1.1.draft (got 1.0) to be specified in the target environment}}
   %0 = tosa.gather %arg0, %arg1 : (tensor<13x21x3xi1>, tensor<13x26xi32>) -> tensor<13x26x3xi1>
   return %0 : tensor<13x26x3xi1>
 }
@@ -79,7 +79,7 @@ func.func @test_gather_bool_i32(%arg0: tensor<13x21x3xi1>, %arg1: tensor<13x26xi
 // -----
 
 func.func @test_scatter_bool_i64(%arg0: tensor<13x52x3xi1>, %arg1: tensor<13x26xi64>, %arg2: tensor<13x26x3xi1>) -> tensor<13x52x3xi1> {
-  // expected-error@+1 {{'tosa.scatter' op illegal: requires specification version compatible with 1.1 (got 1.0) and requires any of [int64] profiles/extensions to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.scatter' op illegal: requires specification version compatible with 1.1.draft (got 1.0) and requires any of [int64] profiles/extensions to be specified in the target environment}}
   %0 = tosa.scatter %arg0, %arg1, %arg2 : (tensor<13x52x3xi1>, tensor<13x26xi64>, tensor<13x26x3xi1>) -> tensor<13x52x3xi1>
   return %0 : tensor<13x52x3xi1>
 }
@@ -87,7 +87,7 @@ func.func @test_scatter_bool_i64(%arg0: tensor<13x52x3xi1>, %arg1: tensor<13x26x
 // -----
 
 func.func @test_scatter_bool_i32(%arg0: tensor<13x52x3xi1>, %arg1: tensor<13x26xi32>, %arg2: tensor<13x26x3xi1>) -> tensor<13x52x3xi1> {
-  // expected-error@+1 {{'tosa.scatter' op illegal: requires specification version compatible with 1.1 (got 1.0) to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.scatter' op illegal: requires specification version compatible with 1.1.draft (got 1.0) to be specified in the target environment}}
   %0 = tosa.scatter %arg0, %arg1, %arg2 : (tensor<13x52x3xi1>, tensor<13x26xi32>, tensor<13x26x3xi1>) -> tensor<13x52x3xi1>
   return %0 : tensor<13x52x3xi1>
 }
@@ -95,7 +95,7 @@ func.func @test_scatter_bool_i32(%arg0: tensor<13x52x3xi1>, %arg1: tensor<13x26x
 // -----
 
 func.func @test_cast_bool_fp32(%arg0: tensor<13x21x3xi1>) -> tensor<13x21x3xf32> {
-  // expected-error@+1 {{'tosa.cast' op illegal: requires specification version compatible with 1.1 (got 1.0) to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.cast' op illegal: requires specification version compatible with 1.1.draft (got 1.0) to be specified in the target environment}}
   %0 = tosa.cast %arg0 : (tensor<13x21x3xi1>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
@@ -103,7 +103,7 @@ func.func @test_cast_bool_fp32(%arg0: tensor<13x21x3xi1>) -> tensor<13x21x3xf32>
 // -----
 
 func.func @test_cast_bool_i64(%arg0: tensor<13x21x3xi1>) -> tensor<13x21x3xi64> {
-  // expected-error@+1 {{'tosa.cast' op illegal: requires specification version compatible with 1.1 (got 1.0) and requires any of [int64] profiles/extensions to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.cast' op illegal: requires specification version compatible with 1.1.draft (got 1.0) and requires any of [int64] profiles/extensions to be specified in the target environment}}
   %0 = tosa.cast %arg0 : (tensor<13x21x3xi1>) -> tensor<13x21x3xi64>
   return %0 : tensor<13x21x3xi64>
 }
@@ -111,7 +111,7 @@ func.func @test_cast_bool_i64(%arg0: tensor<13x21x3xi1>) -> tensor<13x21x3xi64> 
 // -----
 
 func.func @test_cast_fp32_bool(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xi1> {
-  // expected-error@+1 {{'tosa.cast' op illegal: requires specification version compatible with 1.1 (got 1.0) to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.cast' op illegal: requires specification version compatible with 1.1.draft (got 1.0) to be specified in the target environment}}
   %0 = tosa.cast %arg0 : (tensor<13x21x3xf32>) -> tensor<13x21x3xi1>
   return %0 : tensor<13x21x3xi1>
 }
@@ -119,7 +119,7 @@ func.func @test_cast_fp32_bool(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xi1>
 // -----
 
 func.func @test_cast_i64_bool(%arg0: tensor<13x21x3xi64>) -> tensor<13x21x3xi1> {
-  // expected-error@+1 {{'tosa.cast' op illegal: requires specification version compatible with 1.1 (got 1.0) and requires any of [int64] profiles/extensions to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.cast' op illegal: requires specification version compatible with 1.1.draft (got 1.0) and requires any of [int64] profiles/extensions to be specified in the target environment}}
   %0 = tosa.cast %arg0 : (tensor<13x21x3xi64>) -> tensor<13x21x3xi1>
   return %0 : tensor<13x21x3xi1>
 }
@@ -135,7 +135,7 @@ func.func @test_dyanmic_dims(%arg0: tensor<?x8x16xi8>) -> tensor<?x16xi32> {
 // -----
 
 func.func @test_matmul_t_block_scaled(%arg0: tensor<4x8x32xf8E4M3FN>, %arg1: tensor<4x8x1xf8E8M0FNU>, %arg2: tensor<4x16x32xf8E4M3FN>, %arg3: tensor<4x16x1xf8E8M0FNU>) -> tensor<4x8x16xf32> {
-  // expected-error@+1 {{'tosa.matmul_t_block_scaled' op illegal: requires specification version compatible with 1.1 (got 1.0) and requires any of [mxfp] profiles/extensions to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.matmul_t_block_scaled' op illegal: requires specification version compatible with 1.1.draft (got 1.0) and requires any of [mxfp] profiles/extensions to be specified in the target environment}}
   %0 = tosa.matmul_t_block_scaled %arg0, %arg1, %arg2, %arg3 {block_size = #tosa.block_size<BLOCK_SIZE_32>} : (tensor<4x8x32xf8E4M3FN>, tensor<4x8x1xf8E8M0FNU>, tensor<4x16x32xf8E4M3FN>, tensor<4x16x1xf8E8M0FNU>) -> tensor<4x8x16xf32>
   return %0 : tensor<4x8x16xf32>
 }
@@ -143,14 +143,14 @@ func.func @test_matmul_t_block_scaled(%arg0: tensor<4x8x32xf8E4M3FN>, %arg1: ten
 // -----
 
 func.func @test_argmax_int64(%arg0: tensor<1x13x13x5xf32>) -> tensor<1x13x13xi64> {
-  // expected-error@+1 {{'tosa.argmax' op illegal: requires specification version compatible with 1.1 (got 1.0) and requires any of [int64] profiles/extensions to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.argmax' op illegal: requires specification version compatible with 1.1.draft (got 1.0) and requires any of [int64] profiles/extensions to be specified in the target environment}}
   %0 = tosa.argmax %arg0 {axis = 3 : i32} : (tensor<1x13x13x5xf32>) -> tensor<1x13x13xi64>
   return %0 : tensor<1x13x13xi64>
 }
 
 // -----
 func.func @test_const_fp6e3m2(%arg0 : index) -> tensor<4xf6E3M2FN> {
-  // expected-error@+1 {{'tosa.const' op illegal: requires specification version compatible with 1.1 (got 1.0) and requires any of [mxfp] profiles/extensions to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.const' op illegal: requires specification version compatible with 1.1.draft (got 1.0) and requires any of [mxfp] profiles/extensions to be specified in the target environment}}
     %0 = "tosa.const"() {values = dense<[0.0, 0.0, 0.0, 0.0]> : tensor<4xf6E3M2FN>} : () -> tensor<4xf6E3M2FN>
     return %0 : tensor<4xf6E3M2FN>
 }
@@ -158,7 +158,7 @@ func.func @test_const_fp6e3m2(%arg0 : index) -> tensor<4xf6E3M2FN> {
 // -----
 
 func.func @test_cast_from_block_scaled(%arg0: tensor<4x32xf8E5M2>, %arg1: tensor<4x1xf8E8M0FNU>) -> tensor<4x32xf32> {
-  // expected-error@+1 {{'tosa.cast_from_block_scaled' op illegal: requires specification version compatible with 1.1 (got 1.0) and requires any of [mxfp] profiles/extensions to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.cast_from_block_scaled' op illegal: requires specification version compatible with 1.1.draft (got 1.0) and requires any of [mxfp] profiles/extensions to be specified in the target environment}}
   %0 = tosa.cast_from_block_scaled %arg0, %arg1 {block_size = #tosa.block_size<BLOCK_SIZE_32> : i32} : (tensor<4x32xf8E5M2>, tensor<4x1xf8E8M0FNU>) -> tensor<4x32xf32>
   return %0 : tensor<4x32xf32>
 }
@@ -166,7 +166,7 @@ func.func @test_cast_from_block_scaled(%arg0: tensor<4x32xf8E5M2>, %arg1: tensor
 // -----
 
 func.func @test_cast_to_block_scaled(%arg0: tensor<4x32xf32>) -> (tensor<4x32xf6E3M2FN>, tensor<4x1xf8E8M0FNU>) {
-  // expected-error@+1 {{'tosa.cast_to_block_scaled' op illegal: requires specification version compatible with 1.1 (got 1.0) and requires any of [mxfp] profiles/extensions to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.cast_to_block_scaled' op illegal: requires specification version compatible with 1.1.draft (got 1.0) and requires any of [mxfp] profiles/extensions to be specified in the target environment}}
   %0:2 = tosa.cast_to_block_scaled %arg0 {block_size = #tosa.block_size<BLOCK_SIZE_32>} : (tensor<4x32xf32>) -> (tensor<4x32xf6E3M2FN>, tensor<4x1xf8E8M0FNU>)
   return %0#0, %0#1 : tensor<4x32xf6E3M2FN>, tensor<4x1xf8E8M0FNU>
 }
@@ -177,17 +177,17 @@ func.func @test_conv2d_block_scaled(%arg0: tensor<*xf4E2M1FN>, %arg1: tensor<*xf
   %0 = tosa.const_shape {values = dense<[0, 0, 0, 0]> : tensor<4xindex>} : () -> !tosa.shape<4>
   %1 = tosa.const_shape {values = dense<[1, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
   %2 = tosa.const_shape {values = dense<[1, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
-  // expected-error@+1 {{'tosa.conv2d_block_scaled' op illegal: requires specification version compatible with 1.1 (got 1.0) and requires any of [mxfp_conv] profiles/extensions to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.conv2d_block_scaled' op illegal: requires specification version compatible with 1.1.draft (got 1.0) and requires any of [mxfp_conv] profiles/extensions to be specified in the target environment}}
   %3 = tosa.conv2d_block_scaled %arg0, %arg1, %arg2, %arg3, %arg4, %0, %1, %2 {block_size = BLOCK_SIZE_32} : (tensor<*xf4E2M1FN>, tensor<*xf8E8M0FNU>, tensor<*xf4E2M1FN>, tensor<*xf8E8M0FNU>, tensor<*xf32>, !tosa.shape<4>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<*xf32>
   return %3 : tensor<*xf32>
 }
 
 // -----
-func.func @test_maxpool2d_adaptive(%arg0: tensor<1x32x32x8xf32>) -> tensor<1x32x32x8xf32> { 
+func.func @test_maxpool2d_adaptive(%arg0: tensor<1x32x32x8xf32>) -> tensor<1x32x32x8xf32> {
   %kernel = tosa.const_shape {values = dense<[1, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
   %stride = tosa.const_shape {values = dense<[1, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
   %pad = tosa.const_shape {values = dense<[0, 0, 0, 0]> : tensor<4xindex>} : () -> !tosa.shape<4>
-  // expected-error@+1 {{'tosa.max_pool2d_adaptive' op illegal: requires specification version compatible with 1.1 (got 1.0) to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.max_pool2d_adaptive' op illegal: requires specification version compatible with 1.1.draft (got 1.0) to be specified in the target environment}}
   %0 = tosa.max_pool2d_adaptive %arg0, %kernel, %stride, %pad :
          (tensor<1x32x32x8xf32>, !tosa.shape<2>, !tosa.shape<2>, !tosa.shape<4>) -> tensor<1x32x32x8xf32>
   return %0 : tensor<1x32x32x8xf32>

--- a/mlir/test/Dialect/Tosa/tosa-validation-version-1p0-pro-fp-invalid.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-validation-version-1p0-pro-fp-invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-opt %s -verify-diagnostics -tosa-attach-target="specification_version=1.0 profiles=pro_fp" -tosa-validate="strict-op-spec-alignment"
 
 func.func @test_gather_i8_i32(%input: tensor<13x27x3xi8>, %indices: tensor<13x26xi32>) -> tensor<13x26x3xi8> {
-  // expected-error@+1 {{'tosa.gather' op illegal: requires any of [pro_int] profiles/extensions OR requires specification version compatible with 1.1 (got 1.0) to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.gather' op illegal: requires any of [pro_int] profiles/extensions OR requires specification version compatible with 1.1.draft (got 1.0) to be specified in the target environment}}
   %gather = tosa.gather %input, %indices : (tensor<13x27x3xi8>, tensor<13x26xi32>) -> tensor<13x26x3xi8>
   return %gather : tensor<13x26x3xi8>
 }
@@ -9,7 +9,7 @@ func.func @test_gather_i8_i32(%input: tensor<13x27x3xi8>, %indices: tensor<13x26
 // -----
 
 func.func @test_scatter_i8_i32(%input: tensor<13x27x3xi8>, %indices: tensor<13x26xi32>, %updates: tensor<13x26x3xi8>) -> tensor<13x27x3xi8> {
-  // expected-error@+1 {{'tosa.scatter' op illegal: requires any of [pro_int] profiles/extensions OR requires specification version compatible with 1.1 (got 1.0) to be specified in the target environment}}
+  // expected-error@+1 {{'tosa.scatter' op illegal: requires any of [pro_int] profiles/extensions OR requires specification version compatible with 1.1.draft (got 1.0) to be specified in the target environment}}
   %scatter = tosa.scatter %input, %indices, %updates : (tensor<13x27x3xi8>, tensor<13x26xi32>, tensor<13x26x3xi8>) -> tensor<13x27x3xi8>
   return %scatter : tensor<13x27x3xi8>
 }


### PR DESCRIPTION
The draft flag can be used by useful to indicate that a specification version is not yet finalized, and may be subject to change. This is particularly important for serialized formats that offer guarantees around backwards compatibility. By exposing `draft` information in the specification version in the target environment, we can allow consumers to query this information.