### PR TITLE
[CIR] Add sret, byval, and struct flattening to CIRABIRewriteContext

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -12,6 +12,7 @@
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
+#include <limits>
 
 using namespace cir;
 using namespace mlir;
@@ -85,12 +86,37 @@ static void insertReturnCoercion(FunctionOpInterface funcOp, Type origRetTy,
   }
 }
 
+/// Rewrite each cir.return to store the return value through the sret
+/// pointer (first block argument) and return void.
+static void insertSRetStores(FunctionOpInterface funcOp, Type origRetTy,
+                             OpBuilder &rewriter) {
+  Value sretPtr = funcOp.getArguments()[0];
+
+  SmallVector<cir::ReturnOp> returnOps;
+  funcOp->walk([&](cir::ReturnOp retOp) { returnOps.push_back(retOp); });
+
+  for (cir::ReturnOp retOp : returnOps) {
+    if (retOp.getInput().empty())
+      continue;
+
+    Value retVal = retOp.getInput()[0];
+    rewriter.setInsertionPoint(retOp);
+    cir::StoreOp::create(rewriter, retOp.getLoc(), retVal, sretPtr,
+                         /*isVolatile=*/mlir::UnitAttr(),
+                         /*alignment=*/mlir::IntegerAttr(),
+                         /*sync_scope=*/cir::SyncScopeKindAttr(),
+                         /*mem_order=*/cir::MemOrderAttr());
+    cir::ReturnOp::create(rewriter, retOp.getLoc());
+    retOp->erase();
+  }
+}
+
 /// For each argument that requires ABI coercion (Extend or Direct
 /// with a coerced type), insert a cast at the function entry and
 /// replace all uses of the block argument with the cast result.
 static void insertArgAdaptation(FunctionOpInterface funcOp,
                                 const FunctionClassification &fc,
-                                OpBuilder &rewriter) {
+                                unsigned sretOffset, OpBuilder &rewriter) {
   Region &body = funcOp->getRegion(0);
   if (body.empty())
     return;
@@ -105,7 +131,14 @@ static void insertArgAdaptation(FunctionOpInterface funcOp,
     if (argClass.kind != ArgKind::Extend && argClass.kind != ArgKind::Direct)
       continue;
 
-    BlockArgument blockArg = entryBlock.getArgument(idx);
+    // Skip flattened args -- handled separately.
+    if (argClass.canFlatten && argClass.coercedType)
+      if (auto cr = dyn_cast<cir::RecordType>(argClass.coercedType))
+        if (cr.getMembers().size() > 1)
+          continue;
+
+    unsigned blockIdx = idx + sretOffset;
+    BlockArgument blockArg = entryBlock.getArgument(blockIdx);
     Type oldArgTy = blockArg.getType();
     Type newArgTy = argClass.coercedType;
 
@@ -172,6 +205,8 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   ArrayRef<Type> oldResultTypes = funcOp.getResultTypes();
   bool isDecl = funcOp.isDeclaration();
 
+  bool hasSRet =
+      fc.returnInfo.kind == ArgKind::Indirect && !oldResultTypes.empty();
   bool returnCoerced = false;
   bool hasArgChanges = false;
   SmallVector<unsigned> ignoredArgIndices;
@@ -179,21 +214,39 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   // Compute new argument types.
   SmallVector<Type> newArgTypes;
 
+  if (hasSRet) {
+    auto ptrTy = cir::PointerType::get(oldResultTypes[0]);
+    newArgTypes.push_back(ptrTy);
+  }
+
   for (auto [idx, argClass] : llvm::enumerate(fc.argInfos)) {
     Type origTy = oldArgTypes[idx];
     switch (argClass.kind) {
     case ArgKind::Direct:
     case ArgKind::Extend:
+      if (argClass.canFlatten && argClass.coercedType) {
+        if (auto coercedRec = dyn_cast<cir::RecordType>(argClass.coercedType)) {
+          if (coercedRec.getMembers().size() > 1) {
+            for (mlir::Type fieldTy : coercedRec.getMembers())
+              newArgTypes.push_back(fieldTy);
+            hasArgChanges = true;
+            break;
+          }
+        }
+      }
       newArgTypes.push_back(argClass.coercedType ? argClass.coercedType
                                                  : origTy);
       if (argClass.coercedType && argClass.coercedType != origTy)
         hasArgChanges = true;
       break;
+    case ArgKind::Indirect:
+      newArgTypes.push_back(cir::PointerType::get(origTy));
+      hasArgChanges = true;
+      break;
     case ArgKind::Ignore:
       ignoredArgIndices.push_back(idx);
       hasArgChanges = true;
       break;
-    case ArgKind::Indirect:
     case ArgKind::Expand:
       newArgTypes.push_back(origTy);
       break;
@@ -206,8 +259,10 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   Type origRetTy = oldResultTypes.empty() ? voidTy : oldResultTypes[0];
   Type newRetTy = origRetTy;
 
-  if (fc.returnInfo.kind == ArgKind::Direct ||
-      fc.returnInfo.kind == ArgKind::Extend) {
+  if (hasSRet) {
+    newRetTy = voidTy;
+  } else if (fc.returnInfo.kind == ArgKind::Direct ||
+             fc.returnInfo.kind == ArgKind::Extend) {
     if (fc.returnInfo.coercedType && !oldResultTypes.empty() &&
         fc.returnInfo.coercedType != oldResultTypes[0]) {
       newRetTy = fc.returnInfo.coercedType;
@@ -225,14 +280,111 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   for (auto &argClass : fc.argInfos)
     if (argClass.kind == ArgKind::Extend)
       hasExtend = true;
-  if (!hasArgChanges && !hasExtend && !returnCoerced && newRetTy == origRetTy &&
-      newArgTypes == SmallVector<Type>(oldArgTypes))
+  if (!hasSRet && !hasArgChanges && !hasExtend && !returnCoerced &&
+      newRetTy == origRetTy && newArgTypes == SmallVector<Type>(oldArgTypes))
     return success();
 
   // Body modifications only apply to definitions.
   if (!isDecl) {
+    if (hasSRet) {
+      auto ptrTy = cir::PointerType::get(oldResultTypes[0]);
+      Region &body = funcOp->getRegion(0);
+      body.insertArgument(0u, ptrTy, funcOp.getLoc());
+      insertSRetStores(funcOp, oldResultTypes[0], rewriter);
+    }
+
+    unsigned sretOffset = hasSRet ? 1 : 0;
     if (hasArgChanges)
-      insertArgAdaptation(funcOp, fc, rewriter);
+      insertArgAdaptation(funcOp, fc, sretOffset, rewriter);
+
+    // For Indirect args, the block argument type was changed to a
+    // pointer.  Insert a load at function entry so existing uses see
+    // the original value type.
+    if (!funcOp->getRegion(0).empty()) {
+      Block &entry = funcOp->getRegion(0).front();
+      for (auto [idx, argClass] : llvm::enumerate(fc.argInfos)) {
+        if (argClass.kind != ArgKind::Indirect)
+          continue;
+        unsigned blockIdx = idx + sretOffset;
+        BlockArgument blockArg = entry.getArgument(blockIdx);
+        Type origArgTy = oldArgTypes[idx];
+        auto ptrTy = cir::PointerType::get(origArgTy);
+        blockArg.setType(ptrTy);
+
+        rewriter.setInsertionPointToStart(&entry);
+        auto load =
+            cir::LoadOp::create(rewriter, funcOp.getLoc(), origArgTy, blockArg,
+                                /*isDeref=*/mlir::UnitAttr(),
+                                /*isVolatile=*/mlir::UnitAttr(),
+                                /*alignment=*/mlir::IntegerAttr(),
+                                /*sync_scope=*/cir::SyncScopeKindAttr(),
+                                /*mem_order=*/cir::MemOrderAttr());
+        SmallPtrSet<Operation *, 1> loadOps;
+        loadOps.insert(load.getOperation());
+        blockArg.replaceAllUsesExcept(load, loadOps);
+      }
+    }
+
+    // For flattened Direct args (canFlatten + RecordType coercion),
+    // replace the single struct block arg with N scalar block args
+    // and reconstruct the struct at function entry.
+    if (!funcOp->getRegion(0).empty()) {
+      Block &entry = funcOp->getRegion(0).front();
+      for (int i = fc.argInfos.size() - 1; i >= 0; --i) {
+        auto &argClass = fc.argInfos[i];
+        if (argClass.kind != ArgKind::Direct || !argClass.canFlatten ||
+            !argClass.coercedType)
+          continue;
+        auto coercedRec = dyn_cast<cir::RecordType>(argClass.coercedType);
+        if (!coercedRec || coercedRec.getMembers().size() <= 1)
+          continue;
+
+        unsigned origBlockIdx = i + sretOffset;
+        Type origArgTy = oldArgTypes[i];
+        auto members = coercedRec.getMembers();
+        unsigned numFields = members.size();
+
+        BlockArgument origArg = entry.getArgument(origBlockIdx);
+
+        for (unsigned f = 0; f < numFields; ++f)
+          entry.insertArgument(origBlockIdx + 1 + f, members[f],
+                               funcOp.getLoc());
+
+        rewriter.setInsertionPointToStart(&entry);
+        Type coercedTy = argClass.coercedType;
+        auto coercedPtrTy = cir::PointerType::get(coercedTy);
+        auto alloca = cir::AllocaOp::create(
+            rewriter, funcOp.getLoc(), coercedPtrTy, coercedTy,
+            /*name=*/rewriter.getStringAttr("coerce"),
+            /*alignment=*/rewriter.getI64IntegerAttr(8));
+
+        for (unsigned f = 0; f < numFields; ++f) {
+          BlockArgument scalarArg = entry.getArgument(origBlockIdx + 1 + f);
+          auto memberPtr = cir::GetMemberOp::create(
+              rewriter, funcOp.getLoc(), cir::PointerType::get(members[f]),
+              alloca, /*name=*/"", f);
+          cir::StoreOp::create(rewriter, funcOp.getLoc(), scalarArg, memberPtr,
+                               /*isVolatile=*/mlir::UnitAttr(),
+                               /*alignment=*/mlir::IntegerAttr(),
+                               /*sync_scope=*/cir::SyncScopeKindAttr(),
+                               /*mem_order=*/cir::MemOrderAttr());
+        }
+
+        auto origPtrTy = cir::PointerType::get(origArgTy);
+        auto ptrCast = cir::CastOp::create(rewriter, funcOp.getLoc(), origPtrTy,
+                                           cir::CastKind::bitcast, alloca);
+        auto loaded =
+            cir::LoadOp::create(rewriter, funcOp.getLoc(), origArgTy, ptrCast,
+                                /*isDeref=*/mlir::UnitAttr(),
+                                /*isVolatile=*/mlir::UnitAttr(),
+                                /*alignment=*/mlir::IntegerAttr(),
+                                /*sync_scope=*/cir::SyncScopeKindAttr(),
+                                /*mem_order=*/cir::MemOrderAttr());
+
+        origArg.replaceAllUsesWith(loaded);
+        entry.eraseArgument(origBlockIdx);
+      }
+    }
 
     // Erase block arguments for Ignore'd args (in reverse to keep
     // indices valid).  Replace any remaining uses with undef first.
@@ -240,8 +392,9 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
       Region &body = funcOp->getRegion(0);
       if (!body.empty()) {
         Block &entry = body.front();
+        unsigned sretOff = hasSRet ? 1 : 0;
         for (int i = ignoredArgIndices.size() - 1; i >= 0; --i) {
-          unsigned blockIdx = ignoredArgIndices[i];
+          unsigned blockIdx = ignoredArgIndices[i] + sretOff;
           if (blockIdx < entry.getNumArguments()) {
             BlockArgument arg = entry.getArgument(blockIdx);
             if (!arg.use_empty()) {
@@ -286,46 +439,102 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   Type newFnTy = funcOp.cloneTypeWith(newArgTypes, newResultTypes);
   funcOp.setFunctionTypeAttr(TypeAttr::get(newFnTy));
 
-  // Attach signext/zeroext attributes for Extend args and returns.
+  // Attach sret / byval / signext / zeroext attributes.
   {
     MLIRContext *ctx = funcOp->getContext();
     unsigned numArgs = newArgTypes.size();
-    bool needsArgAttrs = false;
+    bool needsAttrs = hasSRet;
     bool hasIgnoredArgs = !ignoredArgIndices.empty();
-    for (auto &argClass : fc.argInfos)
+    for (auto &argClass : fc.argInfos) {
+      if (argClass.kind == ArgKind::Indirect)
+        needsAttrs = true;
       if (argClass.kind == ArgKind::Extend)
-        needsArgAttrs = true;
-    if (hasIgnoredArgs && funcOp->hasAttr("arg_attrs"))
-      needsArgAttrs = true;
+        needsAttrs = true;
+    }
+    if ((hasIgnoredArgs || hasArgChanges) && funcOp->hasAttr("arg_attrs"))
+      needsAttrs = true;
 
-    if (needsArgAttrs) {
+    if (needsAttrs) {
       SmallVector<Attribute> argAttrDicts(numArgs, DictionaryAttr::get(ctx));
 
-      // Preserve existing arg_attrs, skipping Ignore'd args.
+      // Preserve existing arg_attrs, shifting by sretOff and
+      // skipping Ignore'd args.
+      unsigned sretOff = hasSRet ? 1 : 0;
       if (auto existingAttrs = funcOp->getAttrOfType<ArrayAttr>("arg_attrs")) {
-        unsigned newIdx = 0;
+        unsigned newIdx = sretOff;
         for (unsigned oldIdx = 0; oldIdx < existingAttrs.size(); ++oldIdx) {
           if (oldIdx < fc.argInfos.size() &&
               fc.argInfos[oldIdx].kind == ArgKind::Ignore)
             continue;
           if (newIdx < numArgs)
             argAttrDicts[newIdx] = existingAttrs[oldIdx];
+          if (oldIdx < fc.argInfos.size()) {
+            auto &ac = fc.argInfos[oldIdx];
+            if (ac.canFlatten && ac.coercedType)
+              if (auto coercedRec = dyn_cast<cir::RecordType>(ac.coercedType))
+                if (coercedRec.getMembers().size() > 1) {
+                  newIdx += coercedRec.getMembers().size();
+                  continue;
+                }
+          }
           ++newIdx;
         }
       }
 
+      if (hasSRet) {
+        SmallVector<NamedAttribute> sretAttrs;
+        sretAttrs.push_back(rewriter.getNamedAttr(
+            "llvm.sret", TypeAttr::get(oldResultTypes[0])));
+        sretAttrs.push_back(rewriter.getNamedAttr(
+            "llvm.align",
+            rewriter.getI64IntegerAttr(fc.returnInfo.indirectAlign.value())));
+        if (!funcOp.isDeclaration())
+          sretAttrs.push_back(
+              rewriter.getNamedAttr("llvm.noalias", rewriter.getUnitAttr()));
+        sretAttrs.push_back(
+            rewriter.getNamedAttr("llvm.writable", rewriter.getUnitAttr()));
+        sretAttrs.push_back(rewriter.getNamedAttr("llvm.dead_on_unwind",
+                                                  rewriter.getUnitAttr()));
+        argAttrDicts[0] = DictionaryAttr::get(ctx, sretAttrs);
+      }
+
+      unsigned sretOff2 = hasSRet ? 1 : 0;
       for (auto [idx, argClass] : llvm::enumerate(fc.argInfos)) {
-        if (argClass.kind != ArgKind::Extend)
-          continue;
-        if (idx >= numArgs)
-          continue;
-        auto existing = mlir::cast<DictionaryAttr>(argAttrDicts[idx]);
-        SmallVector<NamedAttribute> attrs(existing.begin(), existing.end());
-        StringRef attrName =
-            argClass.signExtend ? "llvm.signext" : "llvm.zeroext";
-        attrs.push_back(
-            rewriter.getNamedAttr(attrName, rewriter.getUnitAttr()));
-        argAttrDicts[idx] = DictionaryAttr::get(ctx, attrs);
+        if (argClass.kind == ArgKind::Indirect) {
+          if (argClass.byVal) {
+            SmallVector<NamedAttribute> byvalAttrs;
+            byvalAttrs.push_back(rewriter.getNamedAttr(
+                "llvm.byval", TypeAttr::get(oldArgTypes[idx])));
+            byvalAttrs.push_back(rewriter.getNamedAttr(
+                "llvm.align",
+                rewriter.getI64IntegerAttr(argClass.indirectAlign.value())));
+            byvalAttrs.push_back(
+                rewriter.getNamedAttr("llvm.noundef", rewriter.getUnitAttr()));
+            if (passByValueIsNoAlias)
+              byvalAttrs.push_back(rewriter.getNamedAttr(
+                  "llvm.noalias", rewriter.getUnitAttr()));
+            argAttrDicts[idx + sretOff2] = DictionaryAttr::get(ctx, byvalAttrs);
+          } else {
+            SmallVector<NamedAttribute> indirectAttrs;
+            indirectAttrs.push_back(
+                rewriter.getNamedAttr("llvm.noundef", rewriter.getUnitAttr()));
+            argAttrDicts[idx + sretOff2] =
+                DictionaryAttr::get(ctx, indirectAttrs);
+          }
+        }
+
+        if (argClass.kind == ArgKind::Extend) {
+          if (idx + sretOff2 >= numArgs)
+            continue;
+          auto existing =
+              mlir::cast<DictionaryAttr>(argAttrDicts[idx + sretOff2]);
+          SmallVector<NamedAttribute> attrs(existing.begin(), existing.end());
+          StringRef attrName =
+              argClass.signExtend ? "llvm.signext" : "llvm.zeroext";
+          attrs.push_back(
+              rewriter.getNamedAttr(attrName, rewriter.getUnitAttr()));
+          argAttrDicts[idx + sretOff2] = DictionaryAttr::get(ctx, attrs);
+        }
       }
 
       funcOp->setAttr("arg_attrs", ArrayAttr::get(ctx, argAttrDicts));
@@ -354,6 +563,7 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
 LogicalResult CIRABIRewriteContext::rewriteCallSite(
     Operation *callOp, const FunctionClassification &fc, OpBuilder &rewriter) {
   auto call = cast<cir::CallOp>(callOp);
+  bool hasSRet = fc.returnInfo.kind == ArgKind::Indirect;
 
   SmallVector<Value> newArgs;
   bool argsChanged = false;
@@ -368,6 +578,66 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
     if (argClass.kind == ArgKind::Ignore) {
       argsChanged = true;
       continue;
+    }
+
+    if (argClass.kind == ArgKind::Indirect) {
+      rewriter.setInsertionPoint(call);
+      Type origTy = arg.getType();
+      auto ptrTy = cir::PointerType::get(origTy);
+      auto alloca = cir::AllocaOp::create(
+          rewriter, call.getLoc(), ptrTy, origTy,
+          /*name=*/
+          rewriter.getStringAttr(argClass.byVal ? "byval" : "indirect"),
+          /*alignment=*/
+          rewriter.getI64IntegerAttr(argClass.indirectAlign.value()));
+      cir::StoreOp::create(rewriter, call.getLoc(), arg, alloca,
+                           /*isVolatile=*/mlir::UnitAttr(),
+                           /*alignment=*/mlir::IntegerAttr(),
+                           /*sync_scope=*/cir::SyncScopeKindAttr(),
+                           /*mem_order=*/cir::MemOrderAttr());
+      newArgs.push_back(alloca);
+      argsChanged = true;
+      continue;
+    }
+
+    // Flatten multi-register struct args into individual scalars.
+    if (argClass.kind == ArgKind::Direct && argClass.canFlatten &&
+        argClass.coercedType) {
+      if (auto coercedRec = dyn_cast<cir::RecordType>(argClass.coercedType)) {
+        if (coercedRec.getMembers().size() > 1) {
+          rewriter.setInsertionPoint(call);
+          Type origTy = arg.getType();
+          auto origPtrTy = cir::PointerType::get(origTy);
+          auto alloca = cir::AllocaOp::create(
+              rewriter, call.getLoc(), origPtrTy, origTy,
+              /*name=*/rewriter.getStringAttr("coerce"),
+              /*alignment=*/rewriter.getI64IntegerAttr(8));
+          cir::StoreOp::create(rewriter, call.getLoc(), arg, alloca,
+                               /*isVolatile=*/mlir::UnitAttr(),
+                               /*alignment=*/mlir::IntegerAttr(),
+                               /*sync_scope=*/cir::SyncScopeKindAttr(),
+                               /*mem_order=*/cir::MemOrderAttr());
+          auto coercedPtrTy = cir::PointerType::get(argClass.coercedType);
+          auto ptrCast =
+              cir::CastOp::create(rewriter, call.getLoc(), coercedPtrTy,
+                                  cir::CastKind::bitcast, alloca);
+          for (auto [f, fieldTy] : llvm::enumerate(coercedRec.getMembers())) {
+            auto memberPtr = cir::GetMemberOp::create(
+                rewriter, call.getLoc(), cir::PointerType::get(fieldTy),
+                ptrCast, /*name=*/"", f);
+            auto fieldVal =
+                cir::LoadOp::create(rewriter, call.getLoc(), fieldTy, memberPtr,
+                                    /*isDeref=*/mlir::UnitAttr(),
+                                    /*isVolatile=*/mlir::UnitAttr(),
+                                    /*alignment=*/mlir::IntegerAttr(),
+                                    /*sync_scope=*/cir::SyncScopeKindAttr(),
+                                    /*mem_order=*/cir::MemOrderAttr());
+            newArgs.push_back(fieldVal);
+          }
+          argsChanged = true;
+          continue;
+        }
+      }
     }
 
     if ((argClass.kind == ArgKind::Extend ||
@@ -392,6 +662,41 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
   // Pass through any extra operands beyond classified args.
   for (unsigned i = fc.argInfos.size(); i < argOperands.size(); ++i)
     newArgs.push_back(argOperands[i]);
+
+  // Handle indirect return (sret) at call site.
+  if (hasSRet && call.getNumResults() > 0) {
+    Type origRetTy = call.getResult().getType();
+    auto ptrTy = cir::PointerType::get(origRetTy);
+
+    rewriter.setInsertionPoint(call);
+    auto alloca =
+        cir::AllocaOp::create(rewriter, call.getLoc(), ptrTy, origRetTy,
+                              /*name=*/rewriter.getStringAttr("sret"),
+                              /*alignment=*/rewriter.getI64IntegerAttr(8));
+
+    SmallVector<Value> sretArgs;
+    sretArgs.push_back(alloca);
+    sretArgs.append(newArgs.begin(), newArgs.end());
+
+    auto voidTy = cir::VoidType::get(call.getContext());
+    auto newCall = cir::CallOp::create(rewriter, call.getLoc(),
+                                       call.getCalleeAttr(), voidTy, sretArgs);
+    for (NamedAttribute attr : call->getAttrs())
+      if (!newCall->hasAttr(attr.getName()))
+        newCall->setAttr(attr.getName(), attr.getValue());
+
+    rewriter.setInsertionPointAfter(newCall);
+    auto load = cir::LoadOp::create(rewriter, call.getLoc(), origRetTy, alloca,
+                                    /*isDeref=*/mlir::UnitAttr(),
+                                    /*isVolatile=*/mlir::UnitAttr(),
+                                    /*alignment=*/mlir::IntegerAttr(),
+                                    /*sync_scope=*/cir::SyncScopeKindAttr(),
+                                    /*mem_order=*/cir::MemOrderAttr());
+
+    call.getResult().replaceAllUsesWith(load);
+    call->erase();
+    return success();
+  }
 
   // Handle direct return coercion.
   bool returnCoerced = false;

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -1,0 +1,469 @@
+//===- CIRABIRewriteContext.cpp - CIR-specific ABI rewriting --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CIRABIRewriteContext.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Types.h"
+#include "clang/CIR/Dialect/IR/CIRAttrs.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/IR/CIROpsEnums.h"
+
+using namespace cir;
+using namespace mlir;
+using namespace mlir::abi;
+
+/// Emit a value coercion between two types.  For scalar-to-scalar
+/// (e.g. integer sign extension), a direct cir.cast is sufficient.
+/// When one of the types is a record (struct), LLVM IR's bitcast
+/// cannot reinterpret between aggregate and scalar types, so we go
+/// through memory: alloca srcTy -> store src -> bitcast ptr -> load
+/// dstTy.
+static Value emitCoercion(OpBuilder &rewriter, Location loc, Type dstTy,
+                          Value src) {
+  Type srcTy = src.getType();
+  if (srcTy == dstTy)
+    return src;
+
+  bool needsMemory =
+      mlir::isa<cir::RecordType, cir::ComplexType>(srcTy) ||
+      mlir::isa<cir::RecordType, cir::ComplexType>(dstTy) ||
+      (mlir::isa<cir::VectorType>(srcTy) != mlir::isa<cir::VectorType>(dstTy));
+
+  if (!needsMemory)
+    return cir::CastOp::create(rewriter, loc, dstTy, cir::CastKind::bitcast,
+                               src);
+
+  auto srcPtrTy = cir::PointerType::get(srcTy);
+  auto dstPtrTy = cir::PointerType::get(dstTy);
+
+  auto alloca =
+      cir::AllocaOp::create(rewriter, loc, srcPtrTy, srcTy,
+                            /*name=*/rewriter.getStringAttr("coerce"),
+                            /*alignment=*/rewriter.getI64IntegerAttr(8));
+
+  cir::StoreOp::create(rewriter, loc, src, alloca,
+                       /*isVolatile=*/mlir::UnitAttr(),
+                       /*alignment=*/mlir::IntegerAttr(),
+                       /*sync_scope=*/cir::SyncScopeKindAttr(),
+                       /*mem_order=*/cir::MemOrderAttr());
+
+  auto ptrCast = cir::CastOp::create(rewriter, loc, dstPtrTy,
+                                     cir::CastKind::bitcast, alloca);
+
+  return cir::LoadOp::create(rewriter, loc, dstTy, ptrCast,
+                             /*isDeref=*/mlir::UnitAttr(),
+                             /*isVolatile=*/mlir::UnitAttr(),
+                             /*alignment=*/mlir::IntegerAttr(),
+                             /*sync_scope=*/cir::SyncScopeKindAttr(),
+                             /*mem_order=*/cir::MemOrderAttr());
+}
+
+/// Insert coercion before each cir.return to coerce the return value
+/// from the original type to the ABI type.
+static void insertReturnCoercion(FunctionOpInterface funcOp, Type origRetTy,
+                                 Type coercedRetTy, OpBuilder &rewriter) {
+  SmallVector<cir::ReturnOp> returnOps;
+  funcOp->walk([&](cir::ReturnOp retOp) { returnOps.push_back(retOp); });
+
+  for (cir::ReturnOp retOp : returnOps) {
+    if (retOp.getInput().empty())
+      continue;
+
+    Value origVal = retOp.getInput()[0];
+    if (origVal.getType() == coercedRetTy)
+      continue;
+
+    rewriter.setInsertionPoint(retOp);
+    Value coerced =
+        emitCoercion(rewriter, retOp.getLoc(), coercedRetTy, origVal);
+    retOp->setOperand(0, coerced);
+  }
+}
+
+/// For each argument that requires ABI coercion (Extend or Direct
+/// with a coerced type), insert a cast at the function entry and
+/// replace all uses of the block argument with the cast result.
+static void insertArgAdaptation(FunctionOpInterface funcOp,
+                                const FunctionClassification &fc,
+                                OpBuilder &rewriter) {
+  Region &body = funcOp->getRegion(0);
+  if (body.empty())
+    return;
+
+  Block &entryBlock = body.front();
+  Operation *lastInserted = nullptr;
+
+  for (auto [idx, argClass] : llvm::enumerate(fc.argInfos)) {
+    if (!argClass.coercedType)
+      continue;
+
+    if (argClass.kind != ArgKind::Extend && argClass.kind != ArgKind::Direct)
+      continue;
+
+    BlockArgument blockArg = entryBlock.getArgument(idx);
+    Type oldArgTy = blockArg.getType();
+    Type newArgTy = argClass.coercedType;
+
+    if (oldArgTy == newArgTy)
+      continue;
+
+    blockArg.setType(newArgTy);
+
+    if (lastInserted)
+      rewriter.setInsertionPointAfter(lastInserted);
+    else
+      rewriter.setInsertionPointToStart(&entryBlock);
+
+    Value adapted;
+    SmallPtrSet<Operation *, 4> coercionOps;
+
+    if (argClass.kind == ArgKind::Extend) {
+      auto cast = cir::CastOp::create(rewriter, funcOp.getLoc(), oldArgTy,
+                                      cir::CastKind::integral, blockArg);
+      adapted = cast;
+      coercionOps.insert(cast.getOperation());
+    } else {
+      auto srcPtrTy = cir::PointerType::get(newArgTy);
+      auto dstPtrTy = cir::PointerType::get(oldArgTy);
+      Location loc = funcOp.getLoc();
+
+      auto alloca =
+          cir::AllocaOp::create(rewriter, loc, srcPtrTy, newArgTy,
+                                /*name=*/rewriter.getStringAttr("coerce"),
+                                /*alignment=*/rewriter.getI64IntegerAttr(8));
+
+      auto store = cir::StoreOp::create(rewriter, loc, blockArg, alloca,
+                                        /*isVolatile=*/mlir::UnitAttr(),
+                                        /*alignment=*/mlir::IntegerAttr(),
+                                        /*sync_scope=*/cir::SyncScopeKindAttr(),
+                                        /*mem_order=*/cir::MemOrderAttr());
+
+      auto ptrCast = cir::CastOp::create(rewriter, loc, dstPtrTy,
+                                         cir::CastKind::bitcast, alloca);
+
+      auto load = cir::LoadOp::create(rewriter, loc, oldArgTy, ptrCast,
+                                      /*isDeref=*/mlir::UnitAttr(),
+                                      /*isVolatile=*/mlir::UnitAttr(),
+                                      /*alignment=*/mlir::IntegerAttr(),
+                                      /*sync_scope=*/cir::SyncScopeKindAttr(),
+                                      /*mem_order=*/cir::MemOrderAttr());
+
+      adapted = load;
+      coercionOps.insert(alloca.getOperation());
+      coercionOps.insert(store.getOperation());
+      coercionOps.insert(ptrCast.getOperation());
+      coercionOps.insert(load.getOperation());
+    }
+    lastInserted = adapted.getDefiningOp();
+
+    blockArg.replaceAllUsesExcept(adapted, coercionOps);
+  }
+}
+
+LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
+    FunctionOpInterface funcOp, const FunctionClassification &fc,
+    OpBuilder &rewriter) {
+  ArrayRef<Type> oldArgTypes = funcOp.getArgumentTypes();
+  ArrayRef<Type> oldResultTypes = funcOp.getResultTypes();
+  bool isDecl = funcOp.isDeclaration();
+
+  bool returnCoerced = false;
+  bool hasArgChanges = false;
+  SmallVector<unsigned> ignoredArgIndices;
+
+  // Compute new argument types.
+  SmallVector<Type> newArgTypes;
+
+  for (auto [idx, argClass] : llvm::enumerate(fc.argInfos)) {
+    Type origTy = oldArgTypes[idx];
+    switch (argClass.kind) {
+    case ArgKind::Direct:
+    case ArgKind::Extend:
+      newArgTypes.push_back(argClass.coercedType ? argClass.coercedType
+                                                 : origTy);
+      if (argClass.coercedType && argClass.coercedType != origTy)
+        hasArgChanges = true;
+      break;
+    case ArgKind::Ignore:
+      ignoredArgIndices.push_back(idx);
+      hasArgChanges = true;
+      break;
+    case ArgKind::Indirect:
+    case ArgKind::Expand:
+      newArgTypes.push_back(origTy);
+      break;
+    }
+  }
+
+  // Compute new result type.  CIR's FuncType::clone expects exactly
+  // one result type (VoidType for void-returning functions).
+  auto voidTy = cir::VoidType::get(funcOp->getContext());
+  Type origRetTy = oldResultTypes.empty() ? voidTy : oldResultTypes[0];
+  Type newRetTy = origRetTy;
+
+  if (fc.returnInfo.kind == ArgKind::Direct ||
+      fc.returnInfo.kind == ArgKind::Extend) {
+    if (fc.returnInfo.coercedType && !oldResultTypes.empty() &&
+        fc.returnInfo.coercedType != oldResultTypes[0]) {
+      newRetTy = fc.returnInfo.coercedType;
+      returnCoerced = true;
+    }
+  } else if (fc.returnInfo.kind == ArgKind::Ignore) {
+    newRetTy = voidTy;
+  }
+
+  SmallVector<Type> newResultTypes = {newRetTy};
+
+  // If nothing changed, skip the rewrite -- unless we have
+  // Extend args/returns that need signext/zeroext attrs.
+  bool hasExtend = fc.returnInfo.kind == ArgKind::Extend;
+  for (auto &argClass : fc.argInfos)
+    if (argClass.kind == ArgKind::Extend)
+      hasExtend = true;
+  if (!hasArgChanges && !hasExtend && !returnCoerced && newRetTy == origRetTy &&
+      newArgTypes == SmallVector<Type>(oldArgTypes))
+    return success();
+
+  // Body modifications only apply to definitions.
+  if (!isDecl) {
+    if (hasArgChanges)
+      insertArgAdaptation(funcOp, fc, rewriter);
+
+    // Erase block arguments for Ignore'd args (in reverse to keep
+    // indices valid).  Replace any remaining uses with undef first.
+    if (!ignoredArgIndices.empty()) {
+      Region &body = funcOp->getRegion(0);
+      if (!body.empty()) {
+        Block &entry = body.front();
+        for (int i = ignoredArgIndices.size() - 1; i >= 0; --i) {
+          unsigned blockIdx = ignoredArgIndices[i];
+          if (blockIdx < entry.getNumArguments()) {
+            BlockArgument arg = entry.getArgument(blockIdx);
+            if (!arg.use_empty()) {
+              rewriter.setInsertionPointToStart(&entry);
+              auto ptrTy = cir::PointerType::get(arg.getType());
+              auto alloca = cir::AllocaOp::create(
+                  rewriter, funcOp.getLoc(), ptrTy, arg.getType(),
+                  /*name=*/rewriter.getStringAttr("ignored"),
+                  /*alignment=*/rewriter.getI64IntegerAttr(1));
+              auto load = cir::LoadOp::create(
+                  rewriter, funcOp.getLoc(), arg.getType(), alloca,
+                  /*isDeref=*/mlir::UnitAttr(),
+                  /*isVolatile=*/mlir::UnitAttr(),
+                  /*alignment=*/mlir::IntegerAttr(),
+                  /*sync_scope=*/cir::SyncScopeKindAttr(),
+                  /*mem_order=*/cir::MemOrderAttr());
+              arg.replaceAllUsesWith(load);
+            }
+            entry.eraseArgument(blockIdx);
+          }
+        }
+      }
+    }
+
+    if (returnCoerced)
+      insertReturnCoercion(funcOp, origRetTy, fc.returnInfo.coercedType,
+                           rewriter);
+
+    // When the return type is Ignore (empty struct), rewrite all
+    // return ops to drop their operand so they return void.
+    if (fc.returnInfo.kind == ArgKind::Ignore && !oldResultTypes.empty()) {
+      funcOp.walk([&](cir::ReturnOp retOp) {
+        if (retOp.getNumOperands() > 0) {
+          rewriter.setInsertionPoint(retOp);
+          cir::ReturnOp::create(rewriter, retOp.getLoc());
+          retOp->erase();
+        }
+      });
+    }
+  }
+
+  Type newFnTy = funcOp.cloneTypeWith(newArgTypes, newResultTypes);
+  funcOp.setFunctionTypeAttr(TypeAttr::get(newFnTy));
+
+  // Attach signext/zeroext attributes for Extend args and returns.
+  {
+    MLIRContext *ctx = funcOp->getContext();
+    unsigned numArgs = newArgTypes.size();
+    bool needsArgAttrs = false;
+    bool hasIgnoredArgs = !ignoredArgIndices.empty();
+    for (auto &argClass : fc.argInfos)
+      if (argClass.kind == ArgKind::Extend)
+        needsArgAttrs = true;
+    if (hasIgnoredArgs && funcOp->hasAttr("arg_attrs"))
+      needsArgAttrs = true;
+
+    if (needsArgAttrs) {
+      SmallVector<Attribute> argAttrDicts(numArgs, DictionaryAttr::get(ctx));
+
+      // Preserve existing arg_attrs, skipping Ignore'd args.
+      if (auto existingAttrs = funcOp->getAttrOfType<ArrayAttr>("arg_attrs")) {
+        unsigned newIdx = 0;
+        for (unsigned oldIdx = 0; oldIdx < existingAttrs.size(); ++oldIdx) {
+          if (oldIdx < fc.argInfos.size() &&
+              fc.argInfos[oldIdx].kind == ArgKind::Ignore)
+            continue;
+          if (newIdx < numArgs)
+            argAttrDicts[newIdx] = existingAttrs[oldIdx];
+          ++newIdx;
+        }
+      }
+
+      for (auto [idx, argClass] : llvm::enumerate(fc.argInfos)) {
+        if (argClass.kind != ArgKind::Extend)
+          continue;
+        if (idx >= numArgs)
+          continue;
+        auto existing = mlir::cast<DictionaryAttr>(argAttrDicts[idx]);
+        SmallVector<NamedAttribute> attrs(existing.begin(), existing.end());
+        StringRef attrName =
+            argClass.signExtend ? "llvm.signext" : "llvm.zeroext";
+        attrs.push_back(
+            rewriter.getNamedAttr(attrName, rewriter.getUnitAttr()));
+        argAttrDicts[idx] = DictionaryAttr::get(ctx, attrs);
+      }
+
+      funcOp->setAttr("arg_attrs", ArrayAttr::get(ctx, argAttrDicts));
+    }
+
+    // Add signext/zeroext to return value for Extend returns.
+    if (fc.returnInfo.kind == ArgKind::Extend) {
+      SmallVector<NamedAttribute> retAttrs;
+      if (auto existing = funcOp->getAttrOfType<ArrayAttr>("res_attrs"))
+        if (existing.size() > 0)
+          for (auto attr : mlir::cast<DictionaryAttr>(existing[0]))
+            retAttrs.push_back(attr);
+      StringRef attrName =
+          fc.returnInfo.signExtend ? "llvm.signext" : "llvm.zeroext";
+      retAttrs.push_back(
+          rewriter.getNamedAttr(attrName, rewriter.getUnitAttr()));
+      SmallVector<Attribute> resAttrDicts;
+      resAttrDicts.push_back(DictionaryAttr::get(ctx, retAttrs));
+      funcOp->setAttr("res_attrs", ArrayAttr::get(ctx, resAttrDicts));
+    }
+  }
+
+  return success();
+}
+
+LogicalResult CIRABIRewriteContext::rewriteCallSite(
+    Operation *callOp, const FunctionClassification &fc, OpBuilder &rewriter) {
+  auto call = cast<cir::CallOp>(callOp);
+
+  SmallVector<Value> newArgs;
+  bool argsChanged = false;
+  auto argOperands = call.getArgOperands();
+
+  for (auto [idx, argClass] : llvm::enumerate(fc.argInfos)) {
+    if (idx >= argOperands.size())
+      break;
+
+    Value arg = argOperands[idx];
+
+    if (argClass.kind == ArgKind::Ignore) {
+      argsChanged = true;
+      continue;
+    }
+
+    if ((argClass.kind == ArgKind::Extend ||
+         argClass.kind == ArgKind::Direct) &&
+        argClass.coercedType && arg.getType() != argClass.coercedType) {
+      rewriter.setInsertionPoint(call);
+      Value coerced;
+      if (argClass.kind == ArgKind::Extend)
+        coerced =
+            cir::CastOp::create(rewriter, call.getLoc(), argClass.coercedType,
+                                cir::CastKind::integral, arg);
+      else
+        coerced =
+            emitCoercion(rewriter, call.getLoc(), argClass.coercedType, arg);
+      newArgs.push_back(coerced);
+      argsChanged = true;
+    } else {
+      newArgs.push_back(arg);
+    }
+  }
+
+  // Pass through any extra operands beyond classified args.
+  for (unsigned i = fc.argInfos.size(); i < argOperands.size(); ++i)
+    newArgs.push_back(argOperands[i]);
+
+  // Handle direct return coercion.
+  bool returnCoerced = false;
+  Type coercedRetTy;
+  if ((fc.returnInfo.kind == ArgKind::Direct ||
+       fc.returnInfo.kind == ArgKind::Extend) &&
+      fc.returnInfo.coercedType) {
+    returnCoerced = true;
+    coercedRetTy = fc.returnInfo.coercedType;
+  }
+
+  // Handle Ignore return: replace with void call.
+  if (fc.returnInfo.kind == ArgKind::Ignore && call.getNumResults() > 0) {
+    rewriter.setInsertionPoint(call);
+    auto voidTy = cir::VoidType::get(call.getContext());
+    auto newCall = cir::CallOp::create(rewriter, call.getLoc(),
+                                       call.getCalleeAttr(), voidTy, newArgs);
+    for (NamedAttribute attr : call->getAttrs())
+      if (!newCall->hasAttr(attr.getName()))
+        newCall->setAttr(attr.getName(), attr.getValue());
+
+    if (!call.getResult().use_empty()) {
+      rewriter.setInsertionPointAfter(newCall);
+      Type origRetTy = call.getResult().getType();
+      auto ptrTy = cir::PointerType::get(origRetTy);
+      auto alloca =
+          cir::AllocaOp::create(rewriter, call.getLoc(), ptrTy, origRetTy,
+                                /*name=*/rewriter.getStringAttr("ignored"),
+                                /*alignment=*/rewriter.getI64IntegerAttr(1));
+      auto load =
+          cir::LoadOp::create(rewriter, call.getLoc(), origRetTy, alloca,
+                              /*isDeref=*/mlir::UnitAttr(),
+                              /*isVolatile=*/mlir::UnitAttr(),
+                              /*alignment=*/mlir::IntegerAttr(),
+                              /*sync_scope=*/cir::SyncScopeKindAttr(),
+                              /*mem_order=*/cir::MemOrderAttr());
+      call.getResult().replaceAllUsesWith(load);
+    }
+    call->erase();
+    return success();
+  }
+
+  if (!returnCoerced && !argsChanged)
+    return success();
+
+  Type callRetTy;
+  Type origRetTy;
+  bool hasResult = call.getNumResults() > 0;
+
+  if (hasResult) {
+    origRetTy = call.getResult().getType();
+    callRetTy = returnCoerced ? coercedRetTy : origRetTy;
+  } else {
+    callRetTy = cir::VoidType::get(call.getContext());
+  }
+
+  rewriter.setInsertionPoint(call);
+  auto newCall = cir::CallOp::create(rewriter, call.getLoc(),
+                                     call.getCalleeAttr(), callRetTy, newArgs);
+  for (NamedAttribute attr : call->getAttrs())
+    if (!newCall->hasAttr(attr.getName()))
+      newCall->setAttr(attr.getName(), attr.getValue());
+
+  if (hasResult && returnCoerced && origRetTy != coercedRetTy) {
+    rewriter.setInsertionPointAfter(newCall);
+    Value castBack =
+        emitCoercion(rewriter, call.getLoc(), origRetTy, newCall.getResult());
+    call.getResult().replaceAllUsesWith(castBack);
+  } else if (hasResult) {
+    call.getResult().replaceAllUsesWith(newCall.getResult());
+  }
+
+  call->erase();
+  return success();
+}

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
@@ -28,9 +28,12 @@ namespace cir {
 /// load, store, cast, etc.).
 class CIRABIRewriteContext : public mlir::abi::ABIRewriteContext {
   mlir::ModuleOp module;
+  bool passByValueIsNoAlias = false;
 
 public:
-  explicit CIRABIRewriteContext(mlir::ModuleOp module) : module(module) {}
+  explicit CIRABIRewriteContext(mlir::ModuleOp module,
+                                bool passByValueIsNoAlias = false)
+      : module(module), passByValueIsNoAlias(passByValueIsNoAlias) {}
 
   mlir::LogicalResult
   rewriteFunctionDefinition(mlir::FunctionOpInterface funcOp,

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
@@ -1,0 +1,50 @@
+//===- CIRABIRewriteContext.h - CIR-specific ABI rewriting ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines CIRABIRewriteContext, the CIR dialect's implementation of
+// the shared ABIRewriteContext interface.  It rewrites CIR function definitions
+// and call sites to match ABI-lowered signatures.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CLANG_LIB_CIR_DIALECT_TRANSFORMS_TARGETLOWERING_CIRABIREWRITECONTEXT_H
+#define CLANG_LIB_CIR_DIALECT_TRANSFORMS_TARGETLOWERING_CIRABIREWRITECONTEXT_H
+
+#include "mlir/ABI/ABIRewriteContext.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+
+namespace cir {
+
+/// CIR-specific implementation of the ABIRewriteContext interface.
+///
+/// This class knows how to rewrite CIR FuncOps and CallOps to match
+/// ABI-lowered signatures, using CIR operations for coercion (alloca,
+/// load, store, cast, etc.).
+class CIRABIRewriteContext : public mlir::abi::ABIRewriteContext {
+  mlir::ModuleOp module;
+
+public:
+  explicit CIRABIRewriteContext(mlir::ModuleOp module) : module(module) {}
+
+  mlir::LogicalResult
+  rewriteFunctionDefinition(mlir::FunctionOpInterface funcOp,
+                            const mlir::abi::FunctionClassification &fc,
+                            mlir::OpBuilder &rewriter) override;
+
+  mlir::LogicalResult
+  rewriteCallSite(mlir::Operation *callOp,
+                  const mlir::abi::FunctionClassification &fc,
+                  mlir::OpBuilder &rewriter) override;
+
+  mlir::StringRef getDialectNamespace() const override { return "cir"; }
+};
+
+} // namespace cir
+
+#endif // CLANG_LIB_CIR_DIALECT_TRANSFORMS_TARGETLOWERING_CIRABIREWRITECONTEXT_H

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_clang_library(MLIRCIRTargetLowering
+  CIRABIRewriteContext.cpp
   CIRCXXABI.cpp
   LowerModule.cpp
   LowerItaniumCXXABI.cpp
@@ -15,6 +16,7 @@ add_clang_library(MLIRCIRTargetLowering
   LINK_LIBS PUBLIC
 
   clangBasic
+  MLIRABI
   MLIRIR
   MLIRPass
   MLIRDLTIDialect

--- a/clang/test/CIR/CodeGen/attr-noundef.cpp
+++ b/clang/test/CIR/CodeGen/attr-noundef.cpp
@@ -1,0 +1,235 @@
+// RUN: %clang_cc1 -triple x86_64-gnu-linux -x c++ -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-gnu-linux -x c++ -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-gnu-linux -x c++ -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+// All cases from CodeGen/attr-noundef.cpp (x86_64 only).
+// Tests noundef placement on structs, unions, this pointers, vectors,
+// function/array pointers, member pointers, nullptr_t, and _BitInt.
+
+//************ Passing structs by value
+
+namespace check_structs {
+struct Trivial {
+  int a;
+};
+Trivial ret_trivial() { return {}; }
+void pass_trivial(Trivial e) {}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN13check_structs11ret_trivialEv
+// CIR-LABEL: cir.func {{.*}} @_ZN13check_structs12pass_trivialENS_7TrivialE
+
+// LLVM-LABEL: define {{.*}} @_ZN13check_structs11ret_trivialEv(
+// LLVM-LABEL: define {{.*}} void @_ZN13check_structs12pass_trivialENS_7TrivialE(
+
+// OGCG: define{{.*}} i32 @_ZN13check_structs11ret_trivialEv
+// OGCG: define{{.*}} void @_ZN13check_structs12pass_trivialENS_7TrivialE{{.*}}(i32 %
+
+struct NoCopy {
+  int a;
+  NoCopy(NoCopy &) = delete;
+};
+NoCopy ret_nocopy() { return {}; }
+void pass_nocopy(NoCopy e) {}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN13check_structs10ret_nocopyEv
+// CIR-LABEL: cir.func {{.*}} @_ZN13check_structs11pass_nocopyENS_6NoCopyE
+
+// LLVM-LABEL: define {{.*}} @_ZN13check_structs10ret_nocopyEv(
+// LLVM-LABEL: define {{.*}} void @_ZN13check_structs11pass_nocopyENS_6NoCopyE(
+
+// OGCG: define{{.*}} void @_ZN13check_structs10ret_nocopyEv{{.*}}(ptr dead_on_unwind noalias writable sret({{[^)]+}}) align 4 %
+// OGCG: define{{.*}} void @_ZN13check_structs11pass_nocopyENS_6NoCopyE{{.*}}(ptr noundef dead_on_return %
+
+struct Huge {
+  int a[1024];
+};
+Huge ret_huge() { return {}; }
+void pass_huge(Huge h) {}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN13check_structs8ret_hugeEv
+// CIR-LABEL: cir.func {{.*}} @_ZN13check_structs9pass_hugeENS_4HugeE
+
+// LLVM-LABEL: define {{.*}} @_ZN13check_structs8ret_hugeEv(
+// LLVM-LABEL: define {{.*}} void @_ZN13check_structs9pass_hugeENS_4HugeE(
+
+// OGCG: define{{.*}} void @_ZN13check_structs8ret_hugeEv{{.*}}(ptr dead_on_unwind noalias writable sret({{[^)]+}}) align 4 %
+// OGCG: define{{.*}} void @_ZN13check_structs9pass_hugeENS_4HugeE{{.*}}(ptr noundef
+} // namespace check_structs
+
+//************ Passing unions by value
+
+namespace check_unions {
+union Trivial {
+  int a;
+};
+Trivial ret_trivial() { return {}; }
+void pass_trivial(Trivial e) {}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN12check_unions11ret_trivialEv
+// CIR-LABEL: cir.func {{.*}} @_ZN12check_unions12pass_trivialENS_7TrivialE
+
+// LLVM-LABEL: define {{.*}} @_ZN12check_unions11ret_trivialEv(
+// LLVM-LABEL: define {{.*}} void @_ZN12check_unions12pass_trivialENS_7TrivialE(
+
+// OGCG: define{{.*}} i32 @_ZN12check_unions11ret_trivialEv
+// OGCG: define{{.*}} void @_ZN12check_unions12pass_trivialENS_7TrivialE{{.*}}(i32 %
+
+union NoCopy {
+  int a;
+  NoCopy(NoCopy &) = delete;
+};
+NoCopy ret_nocopy() { return {}; }
+void pass_nocopy(NoCopy e) {}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN12check_unions10ret_nocopyEv
+// CIR-LABEL: cir.func {{.*}} @_ZN12check_unions11pass_nocopyENS_6NoCopyE
+
+// LLVM-LABEL: define {{.*}} @_ZN12check_unions10ret_nocopyEv(
+// LLVM-LABEL: define {{.*}} void @_ZN12check_unions11pass_nocopyENS_6NoCopyE(
+
+// OGCG: define{{.*}} void @_ZN12check_unions10ret_nocopyEv{{.*}}(ptr dead_on_unwind noalias writable sret({{[^)]+}}) align 4 %
+// OGCG: define{{.*}} void @_ZN12check_unions11pass_nocopyENS_6NoCopyE{{.*}}(ptr noundef dead_on_return %
+} // namespace check_unions
+
+//************ Passing `this` pointers
+
+namespace check_this {
+struct Object {
+  int data[];
+
+  Object() {
+    this->data[0] = 0;
+  }
+  int getData() {
+    return this->data[0];
+  }
+  Object *getThis() {
+    return this;
+  }
+};
+
+void use_object() {
+  Object obj;
+  obj.getData();
+  obj.getThis();
+}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN10check_this10use_objectEv
+// CIR:   cir.call @_ZN10check_this6ObjectC1Ev
+// CIR:   cir.call @_ZN10check_this6Object7getDataEv
+// CIR:   cir.call @_ZN10check_this6Object7getThisEv
+
+// this pointer: noundef nonnull dereferenceable align
+// LLVM: define linkonce_odr void @_ZN10check_this6Object{{.*}}(ptr noundef nonnull align 4 dereferenceable(1) %
+// LLVM: define linkonce_odr noundef i32 @_ZN10check_this6Object7getDataEv(ptr noundef nonnull align 4 dereferenceable(1) %
+// LLVM: define linkonce_odr noundef ptr @_ZN10check_this6Object7getThisEv(ptr noundef nonnull align 4 dereferenceable(1) %
+
+// OGCG: define linkonce_odr void @_ZN10check_this6ObjectC1Ev(ptr noundef nonnull align 4 dereferenceable(1) %
+// OGCG: define linkonce_odr noundef i32 @_ZN10check_this6Object7getDataEv(ptr noundef nonnull align 4 dereferenceable(1) %
+// OGCG: define linkonce_odr noundef ptr @_ZN10check_this6Object7getThisEv(ptr noundef nonnull align 4 dereferenceable(1) %
+} // namespace check_this
+
+//************ Passing vector types
+
+namespace check_vecs {
+typedef int __attribute__((vector_size(12))) i32x3;
+i32x3 ret_vec() {
+  return {};
+}
+void pass_vec(i32x3 v) {
+}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN10check_vecs7ret_vecEv
+// CIR-LABEL: cir.func {{.*}} @_ZN10check_vecs8pass_vecEDv3_i
+
+// LLVM: define {{.*}} noundef <3 x i32> @_ZN10check_vecs7ret_vecEv(
+// LLVM: define {{.*}} void @_ZN10check_vecs8pass_vecEDv3_i(<3 x i32> noundef %
+
+// OGCG: define {{.*}} noundef <3 x i32> @_ZN10check_vecs7ret_vecEv(
+// OGCG: define {{.*}} void @_ZN10check_vecs8pass_vecEDv3_i(<3 x i32> noundef %
+} // namespace check_vecs
+
+//************ Passing exotic types
+
+namespace check_exotic {
+struct Object {
+  int mfunc();
+  int mdata;
+};
+typedef int Object::*mdptr;
+typedef int (Object::*mfptr)();
+typedef decltype(nullptr) nullptr_t;
+typedef int (*arrptr)[32];
+typedef int (*fnptr)(int);
+
+arrptr ret_arrptr() {
+  return nullptr;
+}
+fnptr ret_fnptr() {
+  return nullptr;
+}
+mdptr ret_mdptr() {
+  return nullptr;
+}
+mfptr ret_mfptr() {
+  return nullptr;
+}
+nullptr_t ret_npt() {
+  return nullptr;
+}
+void pass_npt(nullptr_t t) {
+}
+_BitInt(3) ret_BitInt() {
+  return 0;
+}
+void pass_BitInt(_BitInt(3) e) {
+}
+void pass_large_BitInt(_BitInt(127) e) {
+}
+
+// Pointers to arrays/functions: always noundef
+// CIR-LABEL: cir.func {{.*}} @_ZN12check_exotic10ret_arrptrEv
+// CIR-LABEL: cir.func {{.*}} @_ZN12check_exotic9ret_fnptrEv
+
+// LLVM: define {{.*}} noundef ptr @_ZN12check_exotic10ret_arrptrEv(
+// LLVM: define {{.*}} noundef ptr @_ZN12check_exotic9ret_fnptrEv(
+
+// OGCG: define {{.*}} noundef ptr @_ZN12check_exotic10ret_arrptrEv(
+// OGCG: define {{.*}} noundef ptr @_ZN12check_exotic9ret_fnptrEv(
+
+// Member pointers: never noundef
+// CIR-LABEL: cir.func {{.*}} @_ZN12check_exotic9ret_mdptrEv
+// CIR-LABEL: cir.func {{.*}} @_ZN12check_exotic9ret_mfptrEv
+
+// LLVM: define {{.*}} i64 @_ZN12check_exotic9ret_mdptrEv(
+// LLVM: define {{.*}} { i64, i64 } @_ZN12check_exotic9ret_mfptrEv(
+
+// OGCG: define {{.*}} i64 @_ZN12check_exotic9ret_mdptrEv(
+// OGCG: define {{.*}} { i64, i64 } @_ZN12check_exotic9ret_mfptrEv(
+
+// nullptr_t: never noundef
+// CIR-LABEL: cir.func {{.*}} @_ZN12check_exotic7ret_nptEv
+// CIR-LABEL: cir.func {{.*}} @_ZN12check_exotic8pass_nptEDn
+
+// LLVM: define {{.*}} ptr @_ZN12check_exotic7ret_nptEv(
+// LLVM: define {{.*}} void @_ZN12check_exotic8pass_nptEDn(ptr %
+
+// OGCG: define {{.*}} ptr @_ZN12check_exotic7ret_nptEv(
+// OGCG: define {{.*}} void @_ZN12check_exotic8pass_nptEDn(ptr %
+
+// _BitInt types
+// CIR-LABEL: cir.func {{.*}} @_ZN12check_exotic10ret_BitIntEv
+// CIR-LABEL: cir.func {{.*}} @_ZN12check_exotic11pass_BitIntEDB3_
+// CIR-LABEL: cir.func {{.*}} @_ZN12check_exotic17pass_large_BitIntEDB127_
+
+// LLVM: define {{.*}} i3 @_ZN12check_exotic10ret_BitIntEv(
+// LLVM: define {{.*}} void @_ZN12check_exotic11pass_BitIntEDB3_(i3 %
+// LLVM: define {{.*}} void @_ZN12check_exotic17pass_large_BitIntEDB127_(i127 %
+
+// OGCG: define {{.*}} noundef signext i3 @_ZN12check_exotic10ret_BitIntEv(
+// OGCG: define {{.*}} void @_ZN12check_exotic11pass_BitIntEDB3_(i3 noundef signext %
+// OGCG: define {{.*}} void @_ZN12check_exotic17pass_large_BitIntEDB127_(i64 noundef %{{.*}}, i64 noundef %
+} // namespace check_exotic

--- a/clang/test/CIR/CodeGenCXX/uncopyable-args.cpp
+++ b/clang/test/CIR/CodeGenCXX/uncopyable-args.cpp
@@ -1,0 +1,464 @@
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-unknown -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-unknown -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-unknown -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+// All test cases from CodeGenCXX/uncopyable-args.cpp (Itanium x86_64 only).
+// Tests CIRGen handling of types with deleted/defaulted/implicit copy/move ctors.
+
+namespace trivial {
+struct A {
+  void *p;
+};
+void foo(A);
+void bar() {
+  foo({});
+}
+// CIR-LABEL: cir.func {{.*}} @_ZN7trivial3barEv
+// CIR:   cir.call @_ZN7trivial3fooENS_1AE
+
+// LLVM-LABEL: define {{.*}} void @_ZN7trivial3barEv(
+// LLVM:   call void @_ZN7trivial3fooENS_1AE(
+
+// OGCG-LABEL: define {{.*}} void @_ZN7trivial3barEv(
+// OGCG:   call void @_ZN7trivial3fooENS_1AE(ptr
+}
+
+namespace default_ctor {
+struct A {
+  A();
+  void *p;
+};
+void foo(A);
+void bar() {
+  foo({});
+}
+// CIR-LABEL: cir.func {{.*}} @_ZN12default_ctor3barEv
+// CIR:   cir.call @_ZN12default_ctor1AC1Ev
+// CIR:   cir.call @_ZN12default_ctor3fooENS_1AE
+
+// LLVM-LABEL: define {{.*}} void @_ZN12default_ctor3barEv(
+// LLVM:   call void @_ZN12default_ctor1AC1Ev(
+// LLVM:   call void @_ZN12default_ctor3fooENS_1AE(
+
+// OGCG-LABEL: define {{.*}} void @_ZN12default_ctor3barEv(
+// OGCG:   call {{.*}} @_ZN12default_ctor1AC1Ev(
+// OGCG:   call void @_ZN12default_ctor3fooENS_1AE(ptr
+}
+
+namespace move_ctor {
+struct A {
+  A();
+  A(A &&o);
+  void *p;
+};
+void foo(A);
+void bar() {
+  foo({});
+}
+// CIR-LABEL: cir.func {{.*}} @_ZN9move_ctor3barEv
+// CIR:   cir.call @_ZN9move_ctor1AC1Ev
+// CIR:   cir.call @_ZN9move_ctor3fooENS_1AE
+
+// LLVM-LABEL: define {{.*}} void @_ZN9move_ctor3barEv(
+// LLVM:   call void @_ZN9move_ctor1AC1Ev(
+// LLVM:   call void @_ZN9move_ctor3fooENS_1AE(
+
+// OGCG-LABEL: define {{.*}} void @_ZN9move_ctor3barEv(
+// OGCG:   call {{.*}} @_ZN9move_ctor1AC1Ev(
+// OGCG:   call void @_ZN9move_ctor3fooENS_1AE(ptr noundef dead_on_return
+}
+
+namespace all_deleted {
+struct A {
+  A();
+  A(const A &o) = delete;
+  A(A &&o) = delete;
+  void *p;
+};
+void foo(A);
+void bar() {
+  foo({});
+}
+// CIR-LABEL: cir.func {{.*}} @_ZN11all_deleted3barEv
+// CIR:   cir.call @_ZN11all_deleted1AC1Ev
+// CIR:   cir.call @_ZN11all_deleted3fooENS_1AE
+
+// LLVM-LABEL: define {{.*}} void @_ZN11all_deleted3barEv(
+// LLVM:   call void @_ZN11all_deleted1AC1Ev(
+// LLVM:   call void @_ZN11all_deleted3fooENS_1AE(
+
+// OGCG-LABEL: define {{.*}} void @_ZN11all_deleted3barEv(
+// OGCG:   call {{.*}} @_ZN11all_deleted1AC1Ev(
+// OGCG:   call void @_ZN11all_deleted3fooENS_1AE(ptr noundef dead_on_return
+}
+
+namespace implicitly_deleted {
+struct A {
+  A();
+  A &operator=(A &&o);
+  void *p;
+};
+void foo(A);
+void bar() {
+  foo({});
+}
+// CIR-LABEL: cir.func {{.*}} @_ZN18implicitly_deleted3barEv
+// CIR:   cir.call @_ZN18implicitly_deleted1AC1Ev
+// CIR:   cir.call @_ZN18implicitly_deleted3fooENS_1AE
+
+// LLVM-LABEL: define {{.*}} void @_ZN18implicitly_deleted3barEv(
+// LLVM:   call void @_ZN18implicitly_deleted1AC1Ev(
+// LLVM:   call void @_ZN18implicitly_deleted3fooENS_1AE(
+
+// OGCG-LABEL: define {{.*}} void @_ZN18implicitly_deleted3barEv(
+// OGCG:   call {{.*}} @_ZN18implicitly_deleted1AC1Ev(
+// OGCG:   call void @_ZN18implicitly_deleted3fooENS_1AE(ptr noundef dead_on_return
+}
+
+namespace one_deleted {
+struct A {
+  A();
+  A(A &&o) = delete;
+  void *p;
+};
+void foo(A);
+void bar() {
+  foo({});
+}
+// CIR-LABEL: cir.func {{.*}} @_ZN11one_deleted3barEv
+// CIR:   cir.call @_ZN11one_deleted1AC1Ev
+// CIR:   cir.call @_ZN11one_deleted3fooENS_1AE
+
+// LLVM-LABEL: define {{.*}} void @_ZN11one_deleted3barEv(
+// LLVM:   call void @_ZN11one_deleted1AC1Ev(
+// LLVM:   call void @_ZN11one_deleted3fooENS_1AE(
+
+// OGCG-LABEL: define {{.*}} void @_ZN11one_deleted3barEv(
+// OGCG:   call {{.*}} @_ZN11one_deleted1AC1Ev(
+// OGCG:   call void @_ZN11one_deleted3fooENS_1AE(ptr noundef dead_on_return
+}
+
+namespace copy_defaulted {
+struct A {
+  A();
+  A(const A &o) = default;
+  A(A &&o) = delete;
+  void *p;
+};
+void foo(A);
+void bar() {
+  foo({});
+}
+// CIR-LABEL: cir.func {{.*}} @_ZN14copy_defaulted3barEv
+// CIR:   cir.call @_ZN14copy_defaulted1AC1Ev
+// CIR:   cir.call @_ZN14copy_defaulted3fooENS_1AE
+
+// LLVM-LABEL: define {{.*}} void @_ZN14copy_defaulted3barEv(
+// LLVM:   call void @_ZN14copy_defaulted1AC1Ev(
+// LLVM:   call void @_ZN14copy_defaulted3fooENS_1AE(
+
+// OGCG-LABEL: define {{.*}} void @_ZN14copy_defaulted3barEv(
+// OGCG:   call {{.*}} @_ZN14copy_defaulted1AC1Ev(
+// OGCG:   call void @_ZN14copy_defaulted3fooENS_1AE(ptr
+}
+
+namespace move_defaulted {
+struct A {
+  A();
+  A(const A &o) = delete;
+  A(A &&o) = default;
+  void *p;
+};
+void foo(A);
+void bar() {
+  foo({});
+}
+// CIR-LABEL: cir.func {{.*}} @_ZN14move_defaulted3barEv
+// CIR:   cir.call @_ZN14move_defaulted1AC1Ev
+// CIR:   cir.call @_ZN14move_defaulted3fooENS_1AE
+
+// LLVM-LABEL: define {{.*}} void @_ZN14move_defaulted3barEv(
+// LLVM:   call void @_ZN14move_defaulted1AC1Ev(
+// LLVM:   call void @_ZN14move_defaulted3fooENS_1AE(
+
+// OGCG-LABEL: define {{.*}} void @_ZN14move_defaulted3barEv(
+// OGCG:   call {{.*}} @_ZN14move_defaulted1AC1Ev(
+// OGCG:   call void @_ZN14move_defaulted3fooENS_1AE(ptr
+}
+
+namespace trivial_defaulted {
+struct A {
+  A();
+  A(const A &o) = default;
+  void *p;
+};
+void foo(A);
+void bar() {
+  foo({});
+}
+// CIR-LABEL: cir.func {{.*}} @_ZN17trivial_defaulted3barEv
+// CIR:   cir.call @_ZN17trivial_defaulted1AC1Ev
+// CIR:   cir.call @_ZN17trivial_defaulted3fooENS_1AE
+
+// LLVM-LABEL: define {{.*}} void @_ZN17trivial_defaulted3barEv(
+// LLVM:   call void @_ZN17trivial_defaulted1AC1Ev(
+// LLVM:   call void @_ZN17trivial_defaulted3fooENS_1AE(
+
+// OGCG-LABEL: define {{.*}} void @_ZN17trivial_defaulted3barEv(
+// OGCG:   call {{.*}} @_ZN17trivial_defaulted1AC1Ev(
+// OGCG:   call void @_ZN17trivial_defaulted3fooENS_1AE(ptr
+}
+
+namespace two_copy_ctors {
+struct A {
+  A();
+  A(const A &) = default;
+  A(const A &, int = 0);
+  void *p;
+};
+struct B : A {};
+
+void foo(B);
+void bar() {
+  foo({});
+}
+// CIR-LABEL: cir.func {{.*}} @_ZN14two_copy_ctors3barEv
+// CIR:   cir.call @{{.*}}C1Ev
+// CIR:   cir.call @_ZN14two_copy_ctors3fooENS_1BE
+
+// LLVM-LABEL: define {{.*}} void @_ZN14two_copy_ctors3barEv(
+// LLVM:   call void @{{.*}}C1Ev(
+// LLVM:   call void @_ZN14two_copy_ctors3fooENS_1BE(
+
+// OGCG-LABEL: define {{.*}} void @_ZN14two_copy_ctors3barEv(
+// OGCG:   call {{.*}} @{{.*}}C1Ev(
+// OGCG:   call void @_ZN14two_copy_ctors3fooENS_1BE(ptr noundef dead_on_return
+}
+
+namespace definition_only {
+struct A {
+  A();
+  A(A &&o);
+  void *p;
+};
+void *foo(A a) { return a.p; }
+
+// CIR-LABEL: cir.func {{.*}} @_ZN15definition_only3fooENS_1AE
+// CIR:   cir.return
+
+// LLVM-LABEL: define {{.*}} @_ZN15definition_only3fooENS_1AE(
+// LLVM:   ret
+
+// OGCG-LABEL: define {{.*}} ptr @_ZN15definition_only3fooENS_1AE(ptr
+// OGCG:   ret ptr
+}
+
+namespace deleted_by_member {
+struct B {
+  B();
+  B(B &&o);
+  void *p;
+};
+struct A {
+  A();
+  B b;
+};
+void *foo(A a) { return a.b.p; }
+
+// CIR-LABEL: cir.func {{.*}} @_ZN17deleted_by_member3fooENS_1AE
+// CIR:   cir.return
+
+// LLVM-LABEL: define {{.*}} @_ZN17deleted_by_member3fooENS_1AE(
+// LLVM:   ret
+
+// OGCG-LABEL: define {{.*}} ptr @_ZN17deleted_by_member3fooENS_1AE(ptr
+// OGCG:   ret ptr
+}
+
+namespace deleted_by_base {
+struct B {
+  B();
+  B(B &&o);
+  void *p;
+};
+struct A : B {
+  A();
+};
+void *foo(A a) { return a.p; }
+
+// CIR-LABEL: cir.func {{.*}} @_ZN15deleted_by_base3fooENS_1AE
+// CIR:   cir.return
+
+// LLVM-LABEL: define {{.*}} @_ZN15deleted_by_base3fooENS_1AE(
+// LLVM:   ret
+
+// OGCG-LABEL: define {{.*}} ptr @_ZN15deleted_by_base3fooENS_1AE(ptr
+// OGCG:   ret ptr
+}
+
+namespace deleted_by_member_copy {
+struct B {
+  B();
+  B(const B &o) = delete;
+  void *p;
+};
+struct A {
+  A();
+  B b;
+};
+void *foo(A a) { return a.b.p; }
+
+// CIR-LABEL: cir.func {{.*}} @_ZN22deleted_by_member_copy3fooENS_1AE
+// CIR:   cir.return
+
+// LLVM-LABEL: define {{.*}} @_ZN22deleted_by_member_copy3fooENS_1AE(
+// LLVM:   ret
+
+// OGCG-LABEL: define {{.*}} ptr @_ZN22deleted_by_member_copy3fooENS_1AE(ptr
+// OGCG:   ret ptr
+}
+
+namespace deleted_by_base_copy {
+struct B {
+  B();
+  B(const B &o) = delete;
+  void *p;
+};
+struct A : B {
+  A();
+};
+void *foo(A a) { return a.p; }
+
+// CIR-LABEL: cir.func {{.*}} @_ZN20deleted_by_base_copy3fooENS_1AE
+// CIR:   cir.return
+
+// LLVM-LABEL: define {{.*}} @_ZN20deleted_by_base_copy3fooENS_1AE(
+// LLVM:   ret
+
+// OGCG-LABEL: define {{.*}} ptr @_ZN20deleted_by_base_copy3fooENS_1AE(ptr
+// OGCG:   ret ptr
+}
+
+namespace explicit_delete {
+struct A {
+  A();
+  A(const A &o) = delete;
+  void *p;
+};
+void *foo(A a) { return a.p; }
+
+// CIR-LABEL: cir.func {{.*}} @_ZN15explicit_delete3fooENS_1AE
+// CIR:   cir.return
+
+// LLVM-LABEL: define {{.*}} @_ZN15explicit_delete3fooENS_1AE(
+// LLVM:   ret
+
+// OGCG-LABEL: define {{.*}} ptr @_ZN15explicit_delete3fooENS_1AE(ptr
+// OGCG:   ret ptr
+}
+
+namespace implicitly_deleted_copy_ctor {
+struct A {
+  A &operator=(const A&);
+  int &&ref;
+};
+int &foo(A a) { return a.ref; }
+
+// CIR-LABEL: cir.func {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1AE
+// CIR:   cir.return
+
+// LLVM-LABEL: define {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1AE(
+// LLVM:   ret
+
+// OGCG-LABEL: define {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1AE(ptr
+// OGCG:   ret ptr
+
+struct B {
+  B &operator=(const B&);
+  int &ref;
+};
+int &foo(B b) { return b.ref; }
+
+// CIR-LABEL: cir.func {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1BE
+// CIR:   cir.return
+
+// LLVM-LABEL: define {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1BE(
+// LLVM:   ret
+
+// OGCG-LABEL: define {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1BE(ptr
+// OGCG:   ret ptr
+
+struct X { X(const X&); };
+struct Y { Y(const Y&) = default; };
+
+union C {
+  C &operator=(const C&);
+  X x;
+  int n;
+};
+int foo(C c) { return c.n; }
+
+// CIR-LABEL: cir.func {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1CE
+// CIR:   cir.return
+
+// LLVM-LABEL: define {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1CE(
+// LLVM:   ret
+
+// OGCG-LABEL: define {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1CE(ptr
+// OGCG:   ret i32
+
+struct D {
+  D &operator=(const D&);
+  union {
+    X x;
+    int n;
+  };
+};
+int foo(D d) { return d.n; }
+
+// CIR-LABEL: cir.func {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1DE
+// CIR:   cir.return
+
+// LLVM-LABEL: define {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1DE(
+// LLVM:   ret
+
+// OGCG-LABEL: define {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1DE(ptr
+// OGCG:   ret i32
+
+union E {
+  E &operator=(const E&);
+  Y y;
+  int n;
+};
+int foo(E e) { return e.n; }
+
+// CIR-LABEL: cir.func {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1EE
+// CIR:   cir.return
+
+// LLVM-LABEL: define {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1EE(
+// LLVM:   ret
+
+// OGCG-LABEL: define {{.*}} i32 @_ZN28implicitly_deleted_copy_ctor3fooENS_1EE(i32
+// OGCG:   ret i32
+
+struct F {
+  F &operator=(const F&);
+  union {
+    Y y;
+    int n;
+  };
+};
+int foo(F f) { return f.n; }
+
+// CIR-LABEL: cir.func {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1FE
+// CIR:   cir.return
+
+// LLVM-LABEL: define {{.*}} @_ZN28implicitly_deleted_copy_ctor3fooENS_1FE(
+// LLVM:   ret
+
+// OGCG-LABEL: define {{.*}} i32 @_ZN28implicitly_deleted_copy_ctor3fooENS_1FE(i32
+// OGCG:   ret i32
+}

--- a/clang/test/CIR/CodeGenCXX/x86_64-arguments.cpp
+++ b/clang/test/CIR/CodeGenCXX/x86_64-arguments.cpp
@@ -1,0 +1,252 @@
+// RUN: %clang_cc1 -no-enable-noundef-analysis -triple x86_64-unknown-unknown -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -no-enable-noundef-analysis -triple x86_64-unknown-unknown -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -no-enable-noundef-analysis -triple x86_64-unknown-unknown -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+// All cases from CodeGenCXX/x86_64-arguments.cpp (Itanium x86_64 only).
+// Tests C++ struct passing with inheritance, member pointers, empty bases,
+// packed structs, non-trivially-destructible types, and unions.
+
+// Basic base class test.
+struct f0_s0 { unsigned a; };
+struct f0_s1 : public f0_s0 { void *b; };
+void f0(f0_s1 a0) { }
+
+// CIR-LABEL: cir.func {{.*}} @_Z2f05f0_s1
+// LLVM-LABEL: define {{.*}} void @_Z2f05f0_s1(
+// OGCG-LABEL: define {{.*}} void @_Z2f05f0_s1(i32 %a0.coerce0, ptr %a0.coerce1)
+
+// Two eight-bytes in base class.
+struct f1_s0 { unsigned a; unsigned b; float c; };
+struct f1_s1 : public f1_s0 { float d;};
+void f1(f1_s1 a0) { }
+
+// CIR-LABEL: cir.func {{.*}} @_Z2f15f1_s1
+// LLVM-LABEL: define {{.*}} void @_Z2f15f1_s1(
+// OGCG-LABEL: define {{.*}} void @_Z2f15f1_s1(i64 %a0.coerce0, <2 x float> %a0.coerce1)
+
+// Two eight-bytes in base class and merge.
+struct f2_s0 { unsigned a; unsigned b; float c; };
+struct f2_s1 : public f2_s0 { char d;};
+void f2(f2_s1 a0) { }
+
+// CIR-LABEL: cir.func {{.*}} @_Z2f25f2_s1
+// LLVM-LABEL: define {{.*}} void @_Z2f25f2_s1(
+// OGCG-LABEL: define {{.*}} void @_Z2f25f2_s1(i64 %a0.coerce0, i64 %a0.coerce1)
+
+// PR5831
+struct s3_0 {};
+struct s3_1 { struct s3_0 a; long b; };
+void f3(struct s3_1 x) {}
+
+// CIR-LABEL: cir.func {{.*}} @_Z2f34s3_1
+// LLVM-LABEL: define {{.*}} void @_Z2f34s3_1(
+// OGCG-LABEL: define {{.*}} void @_Z2f34s3_1(i64 %x.coerce)
+
+// Member data pointer and member function pointer.
+struct s4 {};
+typedef int s4::* s4_mdp;
+typedef int (s4::*s4_mfp)();
+s4_mdp f4_0(s4_mdp a) { return a; }
+s4_mfp f4_1(s4_mfp a) { return a; }
+
+// CIR-LABEL: cir.func {{.*}} @_Z4f4_0M2s4i
+// CIR-LABEL: cir.func {{.*}} @_Z4f4_1M2s4FivE
+
+// LLVM-LABEL: define {{.*}} i64 @_Z4f4_0M2s4i(i64
+// LLVM-LABEL: define {{.*}} @_Z4f4_1M2s4FivE(
+
+// OGCG-LABEL: define {{.*}} i64 @_Z4f4_0M2s4i(i64 %a)
+// OGCG: define {{.*}} @_Z4f4_1M2s4FivE(i64 %a.coerce0, i64 %a.coerce1)
+
+// Struct with member data pointer (fits in registers).
+struct struct_with_mdp { char *a; s4_mdp b; };
+void f_struct_with_mdp(struct_with_mdp a) { (void)a; }
+
+// CIR-LABEL: cir.func {{.*}} @_Z17f_struct_with_mdp
+// LLVM-LABEL: define {{.*}} void @_Z17f_struct_with_mdp
+// OGCG-LABEL: define {{.*}} void @{{.*}}f_struct_with_mdp{{.*}}(ptr %a.coerce0, i64 %a.coerce1)
+
+// Struct with member function pointer (too big, goes to memory).
+struct struct_with_mfp_0 { char a; s4_mfp b; };
+void f_struct_with_mfp_0(struct_with_mfp_0 a) { (void)a; }
+
+// CIR-LABEL: cir.func {{.*}} @_Z19f_struct_with_mfp_0
+// LLVM-LABEL: define {{.*}} void @_Z19f_struct_with_mfp_0
+// OGCG-LABEL: define {{.*}} void @{{.*}}f_struct_with_mfp_0{{.*}}(ptr byval(%struct{{.*}}) align 8 %a)
+
+struct struct_with_mfp_1 { void *a; s4_mfp b; };
+void f_struct_with_mfp_1(struct_with_mfp_1 a) { (void)a; }
+
+// CIR-LABEL: cir.func {{.*}} @_Z19f_struct_with_mfp_1
+// LLVM-LABEL: define {{.*}} void @_Z19f_struct_with_mfp_1
+// OGCG-LABEL: define {{.*}} void @{{.*}}f_struct_with_mfp_1{{.*}}(ptr byval(%struct{{.*}}) align 8 %a)
+
+namespace PR7523 {
+struct StringRef { char *a; };
+void AddKeyword(StringRef, int x);
+void foo() {
+  AddKeyword(StringRef(), 4);
+}
+}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN6PR75233fooEv
+// CIR:   cir.call @_ZN6PR752310AddKeywordENS_9StringRefEi
+
+// LLVM-LABEL: define {{.*}} void @_ZN6PR75233fooEv(
+// LLVM:   call void @_ZN6PR752310AddKeywordENS_9StringRefEi(
+
+// OGCG-LABEL: define {{.*}} void @_ZN6PR75233fooEv(
+// OGCG:   call void @_ZN6PR752310AddKeywordENS_9StringRefEi(ptr {{.*}}, i32 4)
+
+namespace PR7742 {
+  struct s2 { float a[2]; };
+  struct c2 : public s2 {};
+  c2 foo(c2 *P) { return c2(); }
+}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN6PR77423fooEPNS_2c2E
+// LLVM-LABEL: define {{.*}} @_ZN6PR77423fooEPNS_2c2E(
+// OGCG-LABEL: define {{.*}} <2 x float> @_ZN6PR77423fooEPNS_2c2E(ptr %P)
+
+namespace PR5179 {
+  struct B {};
+  struct B1 : B { int* pa; };
+  struct B2 : B { B1 b1; };
+  const void *bar(B2 b2) { return b2.b1.pa; }
+}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN6PR51793barENS_2B2E
+// LLVM-LABEL: define {{.*}} @_ZN6PR51793barENS_2B2E(
+// OGCG-LABEL: define {{.*}} ptr @_ZN6PR51793barENS_2B2E(ptr %b2.coerce)
+
+namespace test5 {
+  struct Xbase { };
+  struct Empty { };
+  struct Y;
+  struct X : public Xbase { Empty empty; Y f(); };
+  struct Y : public X { Empty empty; };
+  X getX();
+  int takeY(const Y&, int y);
+  void g() { takeY(getX().f(), 42); }
+}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN5test51gEv
+// CIR:   cir.alloca !rec_{{.*}}Y
+// CIR:   cir.alloca !rec_{{.*}}X
+// CIR:   cir.call @_ZN5test54getXEv
+// CIR:   cir.call @_ZN5test51X1fEv
+// CIR:   cir.call @_ZN5test55takeYERKNS_1YEi
+
+// LLVM-LABEL: define {{.*}} void @_ZN5test51gEv(
+// LLVM:   alloca %"struct.test5::Y"
+// LLVM:   alloca %"struct.test5::X"
+
+// OGCG: void @_ZN5test51gEv()
+// OGCG:   alloca %"struct.test5::Y"
+// OGCG:   alloca %"struct.test5::X"
+// OGCG:   alloca %"struct.test5::Y"
+
+namespace test6 {
+  struct outer { int x; struct epsilon_matcher {} e; int f; };
+  int test(outer x) { return x.x + x.f; }
+}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN5test64testENS_5outerE
+// LLVM-LABEL: define {{.*}} i32 @_ZN5test64testENS_5outerE(
+// OGCG-LABEL: define {{.*}} i32 @_ZN5test64testENS_5outerE(i64 %x.coerce0, i32 %x.coerce1)
+
+namespace test7 {
+  struct StringRef {char* ptr; long len; };
+  class A { public: ~A(); };
+  A x(A, A, long, long, StringRef) { return A(); }
+  A y(A, long double, long, long, StringRef) { return A(); }
+  struct StringDouble {char * ptr; double d;};
+  A z(A, A, A, A, A, StringDouble) { return A(); }
+  A zz(A, A, A, A, StringDouble) { return A(); }
+}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN5test71xENS_1AES0_llNS_9StringRefE
+// CIR-LABEL: cir.func {{.*}} @_ZN5test71yENS_1AEellNS_9StringRefE
+// CIR-LABEL: cir.func {{.*}} @_ZN5test71zENS_1AES0_S0_S0_S0_NS_12StringDoubleE
+// CIR-LABEL: cir.func {{.*}} @_ZN5test72zzENS_1AES0_S0_S0_NS_12StringDoubleE
+
+// LLVM-LABEL: define {{.*}} @_ZN5test71xENS_1AES0_llNS_9StringRefE(
+// LLVM-LABEL: define {{.*}} @_ZN5test71yENS_1AEellNS_9StringRefE(
+// LLVM-LABEL: define {{.*}} @_ZN5test71zENS_1AES0_S0_S0_S0_NS_12StringDoubleE(
+// LLVM-LABEL: define {{.*}} @_ZN5test72zzENS_1AES0_S0_S0_NS_12StringDoubleE(
+
+// OGCG: define{{.*}} void @_ZN5test71xENS_1AES0_llNS_9StringRefE({{.*}} byval({{.*}}) align 8 {{%.*}})
+// OGCG: define{{.*}} void @_ZN5test71yENS_1AEellNS_9StringRefE({{.*}} ptr
+// OGCG: define{{.*}} void @_ZN5test71zENS_1AES0_S0_S0_S0_NS_12StringDoubleE({{.*}} byval({{.*}}) align 8 {{%.*}})
+// OGCG: define{{.*}} void @_ZN5test72zzENS_1AES0_S0_S0_NS_12StringDoubleE({{.*}} ptr
+
+namespace test8 {
+  class A { char big[17]; };
+  class B : public A {};
+  void foo(B b);
+  void bar() { B b; foo(b); }
+}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN5test83barEv
+// CIR:   cir.call @_ZN5test83fooENS_1BE
+
+// LLVM-LABEL: define {{.*}} void @_ZN5test83barEv(
+// LLVM:   call void @_ZN5test83fooENS_1BE(
+
+// OGCG-LABEL: define {{.*}} void @_ZN5test83barEv(
+// OGCG:   call void @_ZN5test83fooENS_1BE(ptr byval(%"class.test8::B") align 8
+
+namespace test9 {
+  struct S { void *data[3]; };
+  struct T { void *data[2]; };
+  void foo(S*, T*) {}
+  S a(int, int, int, int, T, void*) { return S(); }
+  S* b(S* sret, int, int, int, int, T, void*) { return sret; }
+  S c(int, int, int, T, void*) { return S(); }
+  S* d(S* sret, int, int, int, T, void*) { return sret; }
+}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN5test93fooEPNS_1SEPNS_1TE
+// CIR-LABEL: cir.func {{.*}} @_ZN5test91aEiiiiNS_1TEPv
+// CIR-LABEL: cir.func {{.*}} @_ZN5test91bEPNS_1SEiiiiNS_1TEPv
+// CIR-LABEL: cir.func {{.*}} @_ZN5test91cEiiiNS_1TEPv
+// CIR-LABEL: cir.func {{.*}} @_ZN5test91dEPNS_1SEiiiNS_1TEPv
+
+// LLVM-LABEL: define {{.*}} void @_ZN5test93fooEPNS_1SEPNS_1TE(ptr {{.*}}, ptr
+// LLVM-LABEL: define {{.*}} @_ZN5test91aEiiiiNS_1TEPv(
+// LLVM-LABEL: define {{.*}} ptr @_ZN5test91bEPNS_1SEiiiiNS_1TEPv(
+// LLVM-LABEL: define {{.*}} @_ZN5test91cEiiiNS_1TEPv(
+// LLVM-LABEL: define {{.*}} ptr @_ZN5test91dEPNS_1SEiiiNS_1TEPv(
+
+// OGCG: define{{.*}} void @_ZN5test93fooEPNS_1SEPNS_1TE(ptr %0, ptr %1)
+// OGCG: define{{.*}} void @_ZN5test91aEiiiiNS_1TEPv(ptr dead_on_unwind noalias writable sret({{.*}}) align 8 {{%.*}}, i32 %0, i32 %1, i32 %2, i32 %3, ptr byval({{.*}}) align 8 %4, ptr %5)
+// OGCG: define{{.*}} ptr @_ZN5test91bEPNS_1SEiiiiNS_1TEPv(ptr {{%.*}}, i32 %0, i32 %1, i32 %2, i32 %3, ptr byval({{.*}}) align 8 %4, ptr %5)
+// OGCG: define{{.*}} void @_ZN5test91cEiiiNS_1TEPv(ptr dead_on_unwind noalias writable sret({{.*}}) align 8 {{%.*}}, i32 %0, i32 %1, i32 %2, ptr {{%.*}}, ptr {{%.*}}, ptr %3)
+// OGCG: define{{.*}} ptr @_ZN5test91dEPNS_1SEiiiNS_1TEPv(ptr {{%.*}}, i32 %0, i32 %1, i32 %2, ptr {{%.*}}, ptr {{%.*}}, ptr %3)
+
+namespace test10 {
+#pragma pack(1)
+struct BasePacked { char one; short two; };
+#pragma pack()
+struct DerivedPacked : public BasePacked { int three; };
+int FuncForDerivedPacked(DerivedPacked d) { return d.three; }
+}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN6test1020FuncForDerivedPackedENS_13DerivedPackedE
+// LLVM-LABEL: define {{.*}} i32 @_ZN6test1020FuncForDerivedPackedENS_13DerivedPackedE(
+// OGCG-LABEL: define {{.*}} i32 @_ZN6test1020FuncForDerivedPackedENS_13DerivedPackedE(ptr byval({{.*}}) align 8
+
+namespace test11 {
+union U {
+  float f1;
+  char __attribute__((__vector_size__(1))) f2;
+};
+int f(union U u) { return u.f2[1]; }
+}
+
+// CIR-LABEL: cir.func {{.*}} @_ZN6test111fENS_1UE
+// LLVM-LABEL: define {{.*}} i32 @_ZN6test111fENS_1UE(
+// OGCG-LABEL: define {{.*}} i32 @_ZN6test111fENS_1UE(i32

--- a/clang/unittests/CIR/CIRABIRewriteContextTest.cpp
+++ b/clang/unittests/CIR/CIRABIRewriteContextTest.cpp
@@ -403,4 +403,178 @@ TEST_F(CIRABIRewriteTest, CallSiteIgnoreArg) {
   fixture.module->erase();
 }
 
+// ---- Indirect (sret / byval) tests ----
+
+TEST_F(CIRABIRewriteTest, IndirectReturnSRet) {
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto recTy = cir::RecordType::get(&context, builder.getStringAttr("Big"),
+                                    cir::RecordType::RecordKind::Struct);
+  recTy.complete({i32Ty, i32Ty, i32Ty, i32Ty}, false, false);
+
+  auto [module, funcOp] = createFunc("f", {i32Ty}, recTy);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getIndirect(llvm::Align(4));
+  fc.argInfos.push_back(ArgClassification::getDirect());
+
+  cir::CIRABIRewriteContext rewriteCtx(module);
+  OpBuilder rewriter(funcOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteFunctionDefinition(funcOp, fc, rewriter)));
+
+  auto fnTy = cast<cir::FuncType>(funcOp.getFunctionType());
+  auto voidTy = cir::VoidType::get(&context);
+  EXPECT_EQ(fnTy.getReturnType(), voidTy);
+  // sret ptr prepended + original i32 arg
+  EXPECT_EQ(fnTy.getInputs().size(), 2u);
+  auto firstArgTy = dyn_cast<cir::PointerType>(fnTy.getInputs()[0]);
+  ASSERT_TRUE(firstArgTy != nullptr);
+  EXPECT_EQ(firstArgTy.getPointee(), recTy);
+
+  // Verify sret attribute on first arg.
+  auto argAttrs = funcOp->getAttrOfType<ArrayAttr>("arg_attrs");
+  ASSERT_TRUE(argAttrs != nullptr);
+  auto sretDict = cast<DictionaryAttr>(argAttrs[0]);
+  EXPECT_TRUE(sretDict.get("llvm.sret") != nullptr);
+  EXPECT_TRUE(sretDict.get("llvm.writable") != nullptr);
+  EXPECT_TRUE(sretDict.get("llvm.dead_on_unwind") != nullptr);
+
+  module->erase();
+}
+
+TEST_F(CIRABIRewriteTest, IndirectArgByVal) {
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto recTy = cir::RecordType::get(&context, builder.getStringAttr("Big"),
+                                    cir::RecordType::RecordKind::Struct);
+  recTy.complete({i32Ty, i32Ty, i32Ty, i32Ty}, false, false);
+
+  auto voidTy = cir::VoidType::get(&context);
+  auto [module, funcOp] = createFunc("f", {recTy}, voidTy);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getDirect();
+  fc.argInfos.push_back(
+      ArgClassification::getIndirect(llvm::Align(8), /*byVal=*/true));
+
+  cir::CIRABIRewriteContext rewriteCtx(module);
+  OpBuilder rewriter(funcOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteFunctionDefinition(funcOp, fc, rewriter)));
+
+  auto fnTy = cast<cir::FuncType>(funcOp.getFunctionType());
+  EXPECT_EQ(fnTy.getInputs().size(), 1u);
+  auto argTy = dyn_cast<cir::PointerType>(fnTy.getInputs()[0]);
+  ASSERT_TRUE(argTy != nullptr);
+  EXPECT_EQ(argTy.getPointee(), recTy);
+
+  // Verify byval attribute.
+  auto argAttrs = funcOp->getAttrOfType<ArrayAttr>("arg_attrs");
+  ASSERT_TRUE(argAttrs != nullptr);
+  auto byvalDict = cast<DictionaryAttr>(argAttrs[0]);
+  EXPECT_TRUE(byvalDict.get("llvm.byval") != nullptr);
+  EXPECT_TRUE(byvalDict.get("llvm.align") != nullptr);
+  EXPECT_TRUE(byvalDict.get("llvm.noundef") != nullptr);
+
+  module->erase();
+}
+
+TEST_F(CIRABIRewriteTest, IndirectArgNoByVal) {
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto recTy = cir::RecordType::get(&context, builder.getStringAttr("NTC"),
+                                    cir::RecordType::RecordKind::Struct);
+  recTy.complete({i32Ty}, false, false);
+
+  auto voidTy = cir::VoidType::get(&context);
+  auto [module, funcOp] = createFunc("f", {recTy}, voidTy);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getDirect();
+  fc.argInfos.push_back(
+      ArgClassification::getIndirect(llvm::Align(8), /*byVal=*/false));
+
+  cir::CIRABIRewriteContext rewriteCtx(module);
+  OpBuilder rewriter(funcOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteFunctionDefinition(funcOp, fc, rewriter)));
+
+  auto fnTy = cast<cir::FuncType>(funcOp.getFunctionType());
+  auto argTy = dyn_cast<cir::PointerType>(fnTy.getInputs()[0]);
+  ASSERT_TRUE(argTy != nullptr);
+
+  // Verify noundef but no byval.
+  auto argAttrs = funcOp->getAttrOfType<ArrayAttr>("arg_attrs");
+  ASSERT_TRUE(argAttrs != nullptr);
+  auto dict = cast<DictionaryAttr>(argAttrs[0]);
+  EXPECT_TRUE(dict.get("llvm.noundef") != nullptr);
+  EXPECT_TRUE(dict.get("llvm.byval") == nullptr);
+
+  module->erase();
+}
+
+// ---- Call-site sret test ----
+
+TEST_F(CIRABIRewriteTest, CallSiteSRet) {
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto recTy = cir::RecordType::get(&context, builder.getStringAttr("Big"),
+                                    cir::RecordType::RecordKind::Struct);
+  recTy.complete({i32Ty, i32Ty, i32Ty, i32Ty}, false, false);
+
+  auto fixture = createCallPair("callee", {i32Ty}, recTy);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getIndirect(llvm::Align(4));
+  fc.argInfos.push_back(ArgClassification::getDirect());
+
+  cir::CIRABIRewriteContext rewriteCtx(fixture.module);
+  OpBuilder rewriter(fixture.callOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteCallSite(fixture.callOp, fc, rewriter)));
+
+  // The original call was replaced.  Find the new void call.
+  Block &callerEntry = fixture.caller->getRegion(0).front();
+  cir::CallOp newCall;
+  for (Operation &op : callerEntry)
+    if (auto c = dyn_cast<cir::CallOp>(op))
+      newCall = c;
+  ASSERT_TRUE(newCall != nullptr);
+  EXPECT_EQ(newCall.getNumResults(), 0u);
+  // First arg should be a pointer (the sret alloca).
+  EXPECT_TRUE(isa<cir::PointerType>(newCall.getArgOperands()[0].getType()));
+
+  fixture.module->erase();
+}
+
+// ---- Call-site indirect (byval) arg test ----
+
+TEST_F(CIRABIRewriteTest, CallSiteByValArg) {
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto recTy = cir::RecordType::get(&context, builder.getStringAttr("Big"),
+                                    cir::RecordType::RecordKind::Struct);
+  recTy.complete({i32Ty, i32Ty, i32Ty, i32Ty}, false, false);
+
+  auto voidTy = cir::VoidType::get(&context);
+  auto fixture = createCallPair("callee", {recTy}, voidTy);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getDirect();
+  fc.argInfos.push_back(
+      ArgClassification::getIndirect(llvm::Align(8), /*byVal=*/true));
+
+  cir::CIRABIRewriteContext rewriteCtx(fixture.module);
+  OpBuilder rewriter(fixture.callOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteCallSite(fixture.callOp, fc, rewriter)));
+
+  // Find the new call.  Its arg should be a pointer (the byval alloca).
+  Block &callerEntry = fixture.caller->getRegion(0).front();
+  cir::CallOp newCall;
+  for (Operation &op : callerEntry)
+    if (auto c = dyn_cast<cir::CallOp>(op))
+      newCall = c;
+  ASSERT_TRUE(newCall != nullptr);
+  EXPECT_TRUE(isa<cir::PointerType>(newCall.getArgOperands()[0].getType()));
+
+  fixture.module->erase();
+}
+
 } // namespace

--- a/clang/unittests/CIR/CIRABIRewriteContextTest.cpp
+++ b/clang/unittests/CIR/CIRABIRewriteContextTest.cpp
@@ -1,0 +1,406 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Unit tests for CIRABIRewriteContext, the CIR dialect's concrete
+// implementation of the shared ABIRewriteContext interface.  Each test
+// constructs a FunctionClassification manually (no ABI library needed)
+// and verifies the resulting IR after rewriting.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/ABI/ABIRewriteContext.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "clang/CIR/Dialect/IR/CIRAttrs.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include "gtest/gtest.h"
+
+// The header is private to the Transforms library, so we include it
+// via the path relative to the source tree.  The CMakeLists arranges
+// the include directories.
+#include "../../lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h"
+
+using namespace mlir;
+using namespace mlir::abi;
+
+namespace {
+
+class CIRABIRewriteTest : public ::testing::Test {
+protected:
+  CIRABIRewriteTest() : builder(&context), loc(UnknownLoc::get(&context)) {
+    context.loadDialect<cir::CIRDialect>();
+  }
+
+  MLIRContext context;
+  OpBuilder builder;
+  Location loc;
+
+  /// Create a ModuleOp containing a single CIR FuncOp with the given
+  /// argument types and return type.  If \p addBody is true, the
+  /// function gets an entry block with a cir.return (returning its
+  /// first result-typed block arg if non-void, or void otherwise).
+  std::pair<ModuleOp, cir::FuncOp> createFunc(StringRef name,
+                                              ArrayRef<Type> argTypes,
+                                              Type retType,
+                                              bool addBody = true) {
+    auto module = ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module.getBody());
+
+    auto funcTy = cir::FuncType::get(argTypes, retType);
+    auto funcOp = cir::FuncOp::create(builder, loc, name, funcTy);
+
+    if (addBody) {
+      Block *entry = funcOp.addEntryBlock();
+      builder.setInsertionPointToEnd(entry);
+      if (isa<cir::VoidType>(retType))
+        cir::ReturnOp::create(builder, loc);
+      else
+        cir::ReturnOp::create(builder, loc,
+                              mlir::ValueRange{entry->getArgument(0)});
+    }
+
+    return {module, funcOp};
+  }
+
+  /// Create a ModuleOp containing a caller function that calls a
+  /// callee.  The caller passes its own block arguments to the callee.
+  struct CallFixture {
+    ModuleOp module;
+    cir::FuncOp callee;
+    cir::FuncOp caller;
+    cir::CallOp callOp;
+  };
+
+  CallFixture createCallPair(StringRef calleeName, ArrayRef<Type> argTypes,
+                             Type retType) {
+    auto module = ModuleOp::create(loc);
+    builder.setInsertionPointToEnd(module.getBody());
+
+    auto funcTy = cir::FuncType::get(argTypes, retType);
+
+    // Callee (declaration only).
+    auto callee = cir::FuncOp::create(builder, loc, calleeName, funcTy);
+
+    // Caller with a body that calls the callee.
+    auto caller = cir::FuncOp::create(builder, loc, "caller", funcTy);
+    Block *entry = caller.addEntryBlock();
+    builder.setInsertionPointToEnd(entry);
+
+    SmallVector<Value> args;
+    for (unsigned i = 0; i < argTypes.size(); ++i)
+      args.push_back(entry->getArgument(i));
+
+    cir::CallOp call;
+    if (isa<cir::VoidType>(retType)) {
+      auto voidTy = cir::VoidType::get(&context);
+      call = cir::CallOp::create(
+          builder, loc, mlir::FlatSymbolRefAttr::get(&context, calleeName),
+          voidTy, args);
+      cir::ReturnOp::create(builder, loc);
+    } else {
+      call = cir::CallOp::create(
+          builder, loc, mlir::FlatSymbolRefAttr::get(&context, calleeName),
+          retType, args);
+      cir::ReturnOp::create(builder, loc, mlir::ValueRange{call.getResult()});
+    }
+
+    return {module, callee, caller, call};
+  }
+};
+
+// ---- rewriteFunctionDefinition tests ----
+
+TEST_F(CIRABIRewriteTest, DirectPassthrough) {
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto [module, funcOp] = createFunc("f", {i32Ty}, i32Ty);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getDirect();
+  fc.argInfos.push_back(ArgClassification::getDirect());
+
+  cir::CIRABIRewriteContext rewriteCtx(module);
+  OpBuilder rewriter(funcOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteFunctionDefinition(funcOp, fc, rewriter)));
+
+  auto fnTy = cast<cir::FuncType>(funcOp.getFunctionType());
+  EXPECT_EQ(fnTy.getInputs().size(), 1u);
+  EXPECT_EQ(fnTy.getInputs()[0], i32Ty);
+  EXPECT_EQ(fnTy.getReturnType(), i32Ty);
+
+  module->erase();
+}
+
+TEST_F(CIRABIRewriteTest, DirectReturnCoercion) {
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto i64Ty = cir::IntType::get(&context, 64, false);
+  auto [module, funcOp] = createFunc("f", {i32Ty}, i32Ty);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getDirect(i64Ty);
+  fc.argInfos.push_back(ArgClassification::getDirect());
+
+  cir::CIRABIRewriteContext rewriteCtx(module);
+  OpBuilder rewriter(funcOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteFunctionDefinition(funcOp, fc, rewriter)));
+
+  auto fnTy = cast<cir::FuncType>(funcOp.getFunctionType());
+  EXPECT_EQ(fnTy.getReturnType(), i64Ty);
+
+  module->erase();
+}
+
+TEST_F(CIRABIRewriteTest, ExtendArg) {
+  auto i8Ty = cir::IntType::get(&context, 8, true);
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto voidTy = cir::VoidType::get(&context);
+  auto [module, funcOp] = createFunc("f", {i8Ty}, voidTy);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getDirect();
+  fc.argInfos.push_back(ArgClassification::getExtend(i32Ty, true));
+
+  cir::CIRABIRewriteContext rewriteCtx(module);
+  OpBuilder rewriter(funcOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteFunctionDefinition(funcOp, fc, rewriter)));
+
+  auto fnTy = cast<cir::FuncType>(funcOp.getFunctionType());
+  EXPECT_EQ(fnTy.getInputs().size(), 1u);
+  EXPECT_EQ(fnTy.getInputs()[0], i32Ty);
+
+  // Verify signext attribute was attached.
+  auto argAttrs = funcOp->getAttrOfType<ArrayAttr>("arg_attrs");
+  ASSERT_TRUE(argAttrs != nullptr);
+  ASSERT_EQ(argAttrs.size(), 1u);
+  auto dict = cast<DictionaryAttr>(argAttrs[0]);
+  EXPECT_TRUE(dict.get("llvm.signext") != nullptr);
+
+  // Verify the entry block has a cir.cast (integral) to adapt i32
+  // back to i8 for body uses.
+  Block &entry = funcOp->getRegion(0).front();
+  bool foundCast = false;
+  for (Operation &op : entry) {
+    if (auto cast = dyn_cast<cir::CastOp>(op)) {
+      if (cast.getKind() == cir::CastKind::integral) {
+        EXPECT_EQ(cast.getResult().getType(), i8Ty);
+        foundCast = true;
+      }
+    }
+  }
+  EXPECT_TRUE(foundCast);
+
+  module->erase();
+}
+
+TEST_F(CIRABIRewriteTest, ExtendReturn) {
+  auto i8Ty = cir::IntType::get(&context, 8, true);
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto [module, funcOp] = createFunc("f", {i8Ty}, i8Ty);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getExtend(i32Ty, false);
+  fc.argInfos.push_back(ArgClassification::getDirect());
+
+  cir::CIRABIRewriteContext rewriteCtx(module);
+  OpBuilder rewriter(funcOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteFunctionDefinition(funcOp, fc, rewriter)));
+
+  auto fnTy = cast<cir::FuncType>(funcOp.getFunctionType());
+  EXPECT_EQ(fnTy.getReturnType(), i32Ty);
+
+  // Verify zeroext attribute on return.
+  auto resAttrs = funcOp->getAttrOfType<ArrayAttr>("res_attrs");
+  ASSERT_TRUE(resAttrs != nullptr);
+  ASSERT_EQ(resAttrs.size(), 1u);
+  auto dict = cast<DictionaryAttr>(resAttrs[0]);
+  EXPECT_TRUE(dict.get("llvm.zeroext") != nullptr);
+
+  module->erase();
+}
+
+TEST_F(CIRABIRewriteTest, IgnoreReturn) {
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto [module, funcOp] = createFunc("f", {i32Ty}, i32Ty);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getIgnore();
+  fc.argInfos.push_back(ArgClassification::getDirect());
+
+  cir::CIRABIRewriteContext rewriteCtx(module);
+  OpBuilder rewriter(funcOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteFunctionDefinition(funcOp, fc, rewriter)));
+
+  auto fnTy = cast<cir::FuncType>(funcOp.getFunctionType());
+  auto voidTy = cir::VoidType::get(&context);
+  EXPECT_EQ(fnTy.getReturnType(), voidTy);
+
+  module->erase();
+}
+
+TEST_F(CIRABIRewriteTest, IgnoreArg) {
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto voidTy = cir::VoidType::get(&context);
+  auto [module, funcOp] = createFunc("f", {i32Ty}, voidTy);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getDirect();
+  fc.argInfos.push_back(ArgClassification::getIgnore());
+
+  cir::CIRABIRewriteContext rewriteCtx(module);
+  OpBuilder rewriter(funcOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteFunctionDefinition(funcOp, fc, rewriter)));
+
+  auto fnTy = cast<cir::FuncType>(funcOp.getFunctionType());
+  EXPECT_EQ(fnTy.getInputs().size(), 0u);
+
+  Block &entry = funcOp->getRegion(0).front();
+  EXPECT_EQ(entry.getNumArguments(), 0u);
+
+  module->erase();
+}
+
+TEST_F(CIRABIRewriteTest, DeclarationRewrite) {
+  auto i8Ty = cir::IntType::get(&context, 8, true);
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto [module, funcOp] = createFunc("f", {i8Ty}, i8Ty, /*addBody=*/false);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getExtend(i32Ty, true);
+  fc.argInfos.push_back(ArgClassification::getExtend(i32Ty, true));
+
+  cir::CIRABIRewriteContext rewriteCtx(module);
+  OpBuilder rewriter(funcOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteFunctionDefinition(funcOp, fc, rewriter)));
+
+  auto fnTy = cast<cir::FuncType>(funcOp.getFunctionType());
+  EXPECT_EQ(fnTy.getInputs()[0], i32Ty);
+  EXPECT_EQ(fnTy.getReturnType(), i32Ty);
+
+  // Verify both signext attributes.
+  auto argAttrs = funcOp->getAttrOfType<ArrayAttr>("arg_attrs");
+  ASSERT_TRUE(argAttrs != nullptr);
+  auto dict = cast<DictionaryAttr>(argAttrs[0]);
+  EXPECT_TRUE(dict.get("llvm.signext") != nullptr);
+
+  auto resAttrs = funcOp->getAttrOfType<ArrayAttr>("res_attrs");
+  ASSERT_TRUE(resAttrs != nullptr);
+  auto rdict = cast<DictionaryAttr>(resAttrs[0]);
+  EXPECT_TRUE(rdict.get("llvm.signext") != nullptr);
+
+  module->erase();
+}
+
+// ---- rewriteCallSite tests ----
+
+TEST_F(CIRABIRewriteTest, CallSiteDirectPassthrough) {
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto fixture = createCallPair("callee", {i32Ty}, i32Ty);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getDirect();
+  fc.argInfos.push_back(ArgClassification::getDirect());
+
+  cir::CIRABIRewriteContext rewriteCtx(fixture.module);
+  OpBuilder rewriter(fixture.callOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteCallSite(fixture.callOp, fc, rewriter)));
+
+  // The original call should still be there (no changes needed).
+  EXPECT_EQ(fixture.callOp->getNumResults(), 1u);
+  EXPECT_EQ(fixture.callOp->getResult(0).getType(), i32Ty);
+
+  fixture.module->erase();
+}
+
+TEST_F(CIRABIRewriteTest, CallSiteExtendArg) {
+  auto i8Ty = cir::IntType::get(&context, 8, true);
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto voidTy = cir::VoidType::get(&context);
+  auto fixture = createCallPair("callee", {i8Ty}, voidTy);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getDirect();
+  fc.argInfos.push_back(ArgClassification::getExtend(i32Ty, true));
+
+  cir::CIRABIRewriteContext rewriteCtx(fixture.module);
+  OpBuilder rewriter(fixture.callOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteCallSite(fixture.callOp, fc, rewriter)));
+
+  // The old call was erased and replaced.  Look for a CallOp whose
+  // argument is i32 (the extended type).
+  Block &callerEntry = fixture.caller->getRegion(0).front();
+  cir::CallOp newCall;
+  for (Operation &op : callerEntry)
+    if (auto c = dyn_cast<cir::CallOp>(op))
+      newCall = c;
+  ASSERT_TRUE(newCall != nullptr);
+  EXPECT_EQ(newCall.getArgOperands()[0].getType(), i32Ty);
+
+  fixture.module->erase();
+}
+
+TEST_F(CIRABIRewriteTest, CallSiteIgnoreReturn) {
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto fixture = createCallPair("callee", {i32Ty}, i32Ty);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getIgnore();
+  fc.argInfos.push_back(ArgClassification::getDirect());
+
+  cir::CIRABIRewriteContext rewriteCtx(fixture.module);
+  OpBuilder rewriter(fixture.callOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteCallSite(fixture.callOp, fc, rewriter)));
+
+  // Find the replacement void call.
+  Block &callerEntry = fixture.caller->getRegion(0).front();
+  cir::CallOp newCall;
+  for (Operation &op : callerEntry)
+    if (auto c = dyn_cast<cir::CallOp>(op))
+      newCall = c;
+  ASSERT_TRUE(newCall != nullptr);
+  EXPECT_EQ(newCall.getNumResults(), 0u);
+
+  fixture.module->erase();
+}
+
+TEST_F(CIRABIRewriteTest, CallSiteIgnoreArg) {
+  auto i32Ty = cir::IntType::get(&context, 32, true);
+  auto voidTy = cir::VoidType::get(&context);
+  auto fixture = createCallPair("callee", {i32Ty}, voidTy);
+
+  FunctionClassification fc;
+  fc.returnInfo = ArgClassification::getDirect();
+  fc.argInfos.push_back(ArgClassification::getIgnore());
+
+  cir::CIRABIRewriteContext rewriteCtx(fixture.module);
+  OpBuilder rewriter(fixture.callOp);
+  ASSERT_TRUE(
+      succeeded(rewriteCtx.rewriteCallSite(fixture.callOp, fc, rewriter)));
+
+  // Find the replacement call -- it should have zero args.
+  Block &callerEntry = fixture.caller->getRegion(0).front();
+  cir::CallOp newCall;
+  for (Operation &op : callerEntry)
+    if (auto c = dyn_cast<cir::CallOp>(op))
+      newCall = c;
+  ASSERT_TRUE(newCall != nullptr);
+  EXPECT_EQ(newCall.getArgOperands().size(), 0u);
+
+  fixture.module->erase();
+}
+
+} // namespace

--- a/clang/unittests/CIR/CMakeLists.txt
+++ b/clang/unittests/CIR/CMakeLists.txt
@@ -1,15 +1,20 @@
 set(MLIR_INCLUDE_DIR ${LLVM_MAIN_SRC_DIR}/../mlir/include )
 set(MLIR_TABLEGEN_OUTPUT_DIR ${CMAKE_BINARY_DIR}/tools/mlir/include)
+set(CLANG_CIR_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/CIR)
 include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
 include_directories(${MLIR_TABLEGEN_OUTPUT_DIR})
+include_directories(${CLANG_CIR_SRC_DIR})
 
 add_distinct_clang_unittest(CIRUnitTests
+  CIRABIRewriteContextTest.cpp
   PointerLikeTest.cpp
   LLVM_COMPONENTS
   Core
 
   LINK_LIBS
+  MLIRABI
   MLIRCIR
+  MLIRCIRTargetLowering
   CIROpenACCSupport
   MLIRIR
   MLIROpenACCDialect

--- a/mlir/include/mlir/ABI/ABIRewriteContext.h
+++ b/mlir/include/mlir/ABI/ABIRewriteContext.h
@@ -55,51 +55,51 @@ enum class ArgKind : uint8_t {
 /// Describes how a single argument or return value is passed after ABI
 /// lowering.
 struct ArgClassification {
-  ArgKind Kind = ArgKind::Direct;
+  ArgKind kind = ArgKind::Direct;
 
   /// The ABI-coerced type, if different from the original.  Null means
   /// use the original type.
-  Type CoercedType = nullptr;
+  Type coercedType = nullptr;
 
   /// For Indirect: alignment of the pointed-to object.
-  llvm::Align IndirectAlign = llvm::Align(1);
+  llvm::Align indirectAlign = llvm::Align(1);
 
   /// For Extend: whether to sign-extend (true) or zero-extend (false).
-  bool SignExtend = false;
+  bool signExtend = false;
 
   /// For Direct: whether a struct coercion can be flattened into
   /// individual register-width arguments.
-  bool CanFlatten = true;
+  bool canFlatten = true;
 
   /// For Indirect: whether the callee gets ownership (byval).
-  bool ByVal = false;
+  bool byVal = false;
 
   static ArgClassification getDirect(Type coerced = nullptr) {
     ArgClassification c;
-    c.Kind = ArgKind::Direct;
-    c.CoercedType = coerced;
+    c.kind = ArgKind::Direct;
+    c.coercedType = coerced;
     return c;
   }
 
   static ArgClassification getIgnore() {
     ArgClassification c;
-    c.Kind = ArgKind::Ignore;
+    c.kind = ArgKind::Ignore;
     return c;
   }
 
   static ArgClassification getIndirect(llvm::Align align, bool byVal = true) {
     ArgClassification c;
-    c.Kind = ArgKind::Indirect;
-    c.IndirectAlign = align;
-    c.ByVal = byVal;
+    c.kind = ArgKind::Indirect;
+    c.indirectAlign = align;
+    c.byVal = byVal;
     return c;
   }
 
   static ArgClassification getExtend(Type coerced, bool signExt) {
     ArgClassification c;
-    c.Kind = ArgKind::Extend;
-    c.CoercedType = coerced;
-    c.SignExtend = signExt;
+    c.kind = ArgKind::Extend;
+    c.coercedType = coerced;
+    c.signExtend = signExt;
     return c;
   }
 };
@@ -107,8 +107,8 @@ struct ArgClassification {
 /// Holds the full ABI classification for a function: return type and
 /// all arguments.
 struct FunctionClassification {
-  ArgClassification ReturnInfo;
-  SmallVector<ArgClassification> ArgInfos;
+  ArgClassification returnInfo;
+  SmallVector<ArgClassification> argInfos;
 };
 
 /// ABIRewriteContext is the abstract interface that each dialect

--- a/mlir/include/mlir/ABI/ABIRewriteContext.h
+++ b/mlir/include/mlir/ABI/ABIRewriteContext.h
@@ -1,0 +1,159 @@
+//===- ABIRewriteContext.h - Dialect-specific ABI rewriting -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines ABIRewriteContext, the abstract interface for dialect-
+// specific ABI lowering rewrites.  Each MLIR dialect that wants ABI lowering
+// (CIR, FIR, etc.) provides a concrete subclass.
+//
+// ABIRewriteContext consumes ABI classification results and drives the
+// creation of lowered function signatures, argument coercions, and call
+// site rewrites using dialect-specific operations.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_ABI_ABIREWRITECONTEXT_H
+#define MLIR_ABI_ABIREWRITECONTEXT_H
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "llvm/Support/Alignment.h"
+
+namespace mlir {
+namespace abi {
+
+/// Classification of how a single argument or return value should be
+/// passed at the ABI level.
+///
+/// This is a dialect-agnostic representation.  It mirrors the kinds
+/// found in the LLVM ABI library and in CIR's ABIArgInfo, but does
+/// not depend on either.
+enum class ArgKind : uint8_t {
+  /// Pass directly in registers, possibly coerced to a different type.
+  Direct,
+
+  /// Like Direct, but with a sign/zero extension attribute.
+  Extend,
+
+  /// Pass indirectly via a pointer (sret for returns, byval for args).
+  Indirect,
+
+  /// Ignore (void return, empty struct).
+  Ignore,
+
+  /// Expand an aggregate into its constituent scalar fields.
+  Expand,
+};
+
+/// Describes how a single argument or return value is passed after ABI
+/// lowering.
+struct ArgClassification {
+  ArgKind Kind = ArgKind::Direct;
+
+  /// The ABI-coerced type, if different from the original.  Null means
+  /// use the original type.
+  Type CoercedType = nullptr;
+
+  /// For Indirect: alignment of the pointed-to object.
+  llvm::Align IndirectAlign = llvm::Align(1);
+
+  /// For Extend: whether to sign-extend (true) or zero-extend (false).
+  bool SignExtend = false;
+
+  /// For Direct: whether a struct coercion can be flattened into
+  /// individual register-width arguments.
+  bool CanFlatten = true;
+
+  /// For Indirect: whether the callee gets ownership (byval).
+  bool ByVal = false;
+
+  static ArgClassification getDirect(Type coerced = nullptr) {
+    ArgClassification c;
+    c.Kind = ArgKind::Direct;
+    c.CoercedType = coerced;
+    return c;
+  }
+
+  static ArgClassification getIgnore() {
+    ArgClassification c;
+    c.Kind = ArgKind::Ignore;
+    return c;
+  }
+
+  static ArgClassification getIndirect(llvm::Align align, bool byVal = true) {
+    ArgClassification c;
+    c.Kind = ArgKind::Indirect;
+    c.IndirectAlign = align;
+    c.ByVal = byVal;
+    return c;
+  }
+
+  static ArgClassification getExtend(Type coerced, bool signExt) {
+    ArgClassification c;
+    c.Kind = ArgKind::Extend;
+    c.CoercedType = coerced;
+    c.SignExtend = signExt;
+    return c;
+  }
+};
+
+/// Holds the full ABI classification for a function: return type and
+/// all arguments.
+struct FunctionClassification {
+  ArgClassification ReturnInfo;
+  SmallVector<ArgClassification> ArgInfos;
+};
+
+/// ABIRewriteContext is the abstract interface that each dialect
+/// implements to perform ABI-specific rewrites on its operations.
+///
+/// The pass orchestrator calls these methods after ABI classification
+/// to rewrite function definitions and call sites.
+class ABIRewriteContext {
+public:
+  virtual ~ABIRewriteContext() = default;
+
+  /// Rewrite a function definition to use ABI-lowered types.
+  ///
+  /// This creates a new function with the lowered signature, rewrites
+  /// the function body to adapt between the ABI types and the
+  /// original high-level types, and replaces the original function.
+  ///
+  /// \param funcOp  The function to rewrite (via FunctionOpInterface).
+  /// \param fc      The ABI classification for this function.
+  /// \param rewriter  The pattern rewriter to use for modifications.
+  /// \returns success() if the function was rewritten.
+  virtual LogicalResult
+  rewriteFunctionDefinition(FunctionOpInterface funcOp,
+                            const FunctionClassification &fc,
+                            OpBuilder &rewriter) = 0;
+
+  /// Rewrite a call operation to match the callee's ABI-lowered
+  /// signature.
+  ///
+  /// This coerces arguments, handles indirect returns (sret), and
+  /// adapts the call result back to the original high-level type.
+  ///
+  /// \param callOp  The call operation to rewrite.
+  /// \param fc      The ABI classification for the callee.
+  /// \param rewriter  The pattern rewriter to use for modifications.
+  /// \returns success() if the call was rewritten.
+  virtual LogicalResult rewriteCallSite(Operation *callOp,
+                                        const FunctionClassification &fc,
+                                        OpBuilder &rewriter) = 0;
+
+  /// Return the dialect namespace this context handles (e.g. "cir").
+  virtual StringRef getDialectNamespace() const = 0;
+};
+
+} // namespace abi
+} // namespace mlir
+
+#endif // MLIR_ABI_ABIREWRITECONTEXT_H

--- a/mlir/include/mlir/ABI/ABITypeMapper.h
+++ b/mlir/include/mlir/ABI/ABITypeMapper.h
@@ -45,7 +45,7 @@ public:
   const llvm::abi::Type *map(mlir::Type type);
 
   /// Access the underlying TypeBuilder for advanced use.
-  llvm::abi::TypeBuilder &getTypeBuilder() { return Builder; }
+  llvm::abi::TypeBuilder &getTypeBuilder() { return builder; }
 
 private:
   const llvm::abi::Type *mapIntegerType(mlir::IntegerType type);
@@ -55,9 +55,9 @@ private:
   const llvm::abi::Type *mapMemRefType(mlir::MemRefType type);
   const llvm::abi::Type *mapNoneType(mlir::NoneType type);
 
-  const DataLayout &DL;
-  llvm::BumpPtrAllocator Allocator;
-  llvm::abi::TypeBuilder Builder;
+  const DataLayout &dl;
+  llvm::BumpPtrAllocator allocator;
+  llvm::abi::TypeBuilder builder;
 };
 
 } // namespace abi

--- a/mlir/include/mlir/ABI/ABITypeMapper.h
+++ b/mlir/include/mlir/ABI/ABITypeMapper.h
@@ -1,0 +1,66 @@
+//===- ABITypeMapper.h - Map MLIR types to ABI types -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines ABITypeMapper, which translates mlir::Type instances into
+// the llvm::abi::Type hierarchy defined in llvm/ABI/Types.h.  Dialect-specific
+// types are handled via MLIR's DataLayoutTypeInterface.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_ABI_ABITYPEMAPPER_H
+#define MLIR_ABI_ABITYPEMAPPER_H
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
+#include "llvm/ABI/Types.h"
+#include "llvm/Support/Allocator.h"
+
+namespace mlir {
+namespace abi {
+
+/// ABITypeMapper translates mlir::Type values into the llvm::abi::Type
+/// hierarchy used by the LLVM ABI Lowering Library.
+///
+/// Standard MLIR types (IntegerType, FloatType, IndexType, VectorType,
+/// MemRefType) are mapped directly.  Dialect-specific types are mapped
+/// by querying the MLIR DataLayout for size and alignment.
+///
+/// Callers must supply a DataLayout (typically from the enclosing module)
+/// so the mapper can determine sizes and alignments.
+///
+/// The mapper owns a BumpPtrAllocator; all returned abi::Type pointers
+/// are valid for the lifetime of the mapper.
+class ABITypeMapper {
+public:
+  explicit ABITypeMapper(const DataLayout &dl);
+
+  /// Map an MLIR type to its ABI type representation.  Returns nullptr
+  /// if the type cannot be mapped.
+  const llvm::abi::Type *map(mlir::Type type);
+
+  /// Access the underlying TypeBuilder for advanced use.
+  llvm::abi::TypeBuilder &getTypeBuilder() { return Builder; }
+
+private:
+  const llvm::abi::Type *mapIntegerType(mlir::IntegerType type);
+  const llvm::abi::Type *mapFloatType(mlir::FloatType type);
+  const llvm::abi::Type *mapIndexType(mlir::IndexType type);
+  const llvm::abi::Type *mapVectorType(mlir::VectorType type);
+  const llvm::abi::Type *mapMemRefType(mlir::MemRefType type);
+  const llvm::abi::Type *mapNoneType(mlir::NoneType type);
+
+  const DataLayout &DL;
+  llvm::BumpPtrAllocator Allocator;
+  llvm::abi::TypeBuilder Builder;
+};
+
+} // namespace abi
+} // namespace mlir
+
+#endif // MLIR_ABI_ABITYPEMAPPER_H

--- a/mlir/lib/ABI/ABITypeMapper.cpp
+++ b/mlir/lib/ABI/ABITypeMapper.cpp
@@ -13,8 +13,8 @@
 using namespace mlir;
 using namespace mlir::abi;
 
-ABITypeMapper::ABITypeMapper(const DataLayout &dl)
-    : DL(dl), Builder(Allocator) {}
+ABITypeMapper::ABITypeMapper(const DataLayout &dataLayout)
+    : dl(dataLayout), builder(allocator) {}
 
 const llvm::abi::Type *ABITypeMapper::map(mlir::Type type) {
   if (auto intTy = dyn_cast<mlir::IntegerType>(type))
@@ -37,33 +37,30 @@ const llvm::abi::Type *ABITypeMapper::map(mlir::Type type) {
 
   // For dialect-specific types, fall back to DataLayout queries.
   // The type must implement DataLayoutTypeInterface for this to work.
-  llvm::TypeSize sizeInBits = DL.getTypeSizeInBits(type);
-  uint64_t abiAlign = DL.getTypeABIAlignment(type);
-  return Builder.getIntegerType(sizeInBits.getFixedValue(),
+  llvm::TypeSize sizeInBits = dl.getTypeSizeInBits(type);
+  uint64_t abiAlign = dl.getTypeABIAlignment(type);
+  return builder.getIntegerType(sizeInBits.getFixedValue(),
                                 llvm::Align(abiAlign),
                                 /*Signed=*/false);
 }
 
 const llvm::abi::Type *ABITypeMapper::mapIntegerType(mlir::IntegerType type) {
   uint64_t width = type.getWidth();
-  uint64_t abiAlign = DL.getTypeABIAlignment(type);
-  // MLIR signless integers are treated as signed for ABI purposes.
-  // Most C/C++ integer types are signless in MLIR but behave as
-  // signed for ABI classification (sign extension, etc.).
+  uint64_t abiAlign = dl.getTypeABIAlignment(type);
   bool isSigned = type.isSigned() || type.isSignless();
-  return Builder.getIntegerType(width, llvm::Align(abiAlign), isSigned);
+  return builder.getIntegerType(width, llvm::Align(abiAlign), isSigned);
 }
 
 const llvm::abi::Type *ABITypeMapper::mapFloatType(mlir::FloatType type) {
-  uint64_t abiAlign = DL.getTypeABIAlignment(type);
+  uint64_t abiAlign = dl.getTypeABIAlignment(type);
   const llvm::fltSemantics &semantics = type.getFloatSemantics();
-  return Builder.getFloatType(semantics, llvm::Align(abiAlign));
+  return builder.getFloatType(semantics, llvm::Align(abiAlign));
 }
 
 const llvm::abi::Type *ABITypeMapper::mapIndexType(mlir::IndexType type) {
-  llvm::TypeSize sizeInBits = DL.getTypeSizeInBits(type);
-  uint64_t abiAlign = DL.getTypeABIAlignment(type);
-  return Builder.getIntegerType(sizeInBits.getFixedValue(),
+  llvm::TypeSize sizeInBits = dl.getTypeSizeInBits(type);
+  uint64_t abiAlign = dl.getTypeABIAlignment(type);
+  return builder.getIntegerType(sizeInBits.getFixedValue(),
                                 llvm::Align(abiAlign),
                                 /*Signed=*/false);
 }
@@ -74,29 +71,26 @@ const llvm::abi::Type *ABITypeMapper::mapVectorType(mlir::VectorType type) {
     return nullptr;
 
   auto shape = type.getShape();
-  // MLIR VectorType is always fixed-length and can be multi-dimensional.
-  // Flatten to a single dimension for ABI purposes.
   uint64_t totalElements = 1;
   for (int64_t dim : shape)
     totalElements *= dim;
 
   llvm::ElementCount ec = llvm::ElementCount::getFixed(totalElements);
-  uint64_t abiAlign = DL.getTypeABIAlignment(type);
-  return Builder.getVectorType(elementTy, ec, llvm::Align(abiAlign));
+  uint64_t abiAlign = dl.getTypeABIAlignment(type);
+  return builder.getVectorType(elementTy, ec, llvm::Align(abiAlign));
 }
 
 const llvm::abi::Type *ABITypeMapper::mapMemRefType(mlir::MemRefType type) {
-  // MemRef is pointer-like for ABI purposes.
-  llvm::TypeSize sizeInBits = DL.getTypeSizeInBits(type);
-  uint64_t abiAlign = DL.getTypeABIAlignment(type);
+  llvm::TypeSize sizeInBits = dl.getTypeSizeInBits(type);
+  uint64_t abiAlign = dl.getTypeABIAlignment(type);
   unsigned addrSpace = 0;
   if (auto as = type.getMemorySpace())
     if (auto intAttr = dyn_cast<IntegerAttr>(as))
       addrSpace = intAttr.getInt();
-  return Builder.getPointerType(sizeInBits.getFixedValue(),
+  return builder.getPointerType(sizeInBits.getFixedValue(),
                                 llvm::Align(abiAlign), addrSpace);
 }
 
 const llvm::abi::Type *ABITypeMapper::mapNoneType(mlir::NoneType type) {
-  return Builder.getVoidType();
+  return builder.getVoidType();
 }

--- a/mlir/lib/ABI/ABITypeMapper.cpp
+++ b/mlir/lib/ABI/ABITypeMapper.cpp
@@ -1,0 +1,102 @@
+//===- ABITypeMapper.cpp - Map MLIR types to ABI types --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/ABI/ABITypeMapper.h"
+#include "llvm/ADT/APFloat.h"
+#include "llvm/Support/Alignment.h"
+
+using namespace mlir;
+using namespace mlir::abi;
+
+ABITypeMapper::ABITypeMapper(const DataLayout &dl)
+    : DL(dl), Builder(Allocator) {}
+
+const llvm::abi::Type *ABITypeMapper::map(mlir::Type type) {
+  if (auto intTy = dyn_cast<mlir::IntegerType>(type))
+    return mapIntegerType(intTy);
+
+  if (auto floatTy = dyn_cast<mlir::FloatType>(type))
+    return mapFloatType(floatTy);
+
+  if (auto indexTy = dyn_cast<mlir::IndexType>(type))
+    return mapIndexType(indexTy);
+
+  if (auto vecTy = dyn_cast<mlir::VectorType>(type))
+    return mapVectorType(vecTy);
+
+  if (auto memRefTy = dyn_cast<mlir::MemRefType>(type))
+    return mapMemRefType(memRefTy);
+
+  if (auto noneTy = dyn_cast<mlir::NoneType>(type))
+    return mapNoneType(noneTy);
+
+  // For dialect-specific types, fall back to DataLayout queries.
+  // The type must implement DataLayoutTypeInterface for this to work.
+  llvm::TypeSize sizeInBits = DL.getTypeSizeInBits(type);
+  uint64_t abiAlign = DL.getTypeABIAlignment(type);
+  return Builder.getIntegerType(sizeInBits.getFixedValue(),
+                                llvm::Align(abiAlign),
+                                /*Signed=*/false);
+}
+
+const llvm::abi::Type *ABITypeMapper::mapIntegerType(mlir::IntegerType type) {
+  uint64_t width = type.getWidth();
+  uint64_t abiAlign = DL.getTypeABIAlignment(type);
+  // MLIR signless integers are treated as signed for ABI purposes.
+  // Most C/C++ integer types are signless in MLIR but behave as
+  // signed for ABI classification (sign extension, etc.).
+  bool isSigned = type.isSigned() || type.isSignless();
+  return Builder.getIntegerType(width, llvm::Align(abiAlign), isSigned);
+}
+
+const llvm::abi::Type *ABITypeMapper::mapFloatType(mlir::FloatType type) {
+  uint64_t abiAlign = DL.getTypeABIAlignment(type);
+  const llvm::fltSemantics &semantics = type.getFloatSemantics();
+  return Builder.getFloatType(semantics, llvm::Align(abiAlign));
+}
+
+const llvm::abi::Type *ABITypeMapper::mapIndexType(mlir::IndexType type) {
+  llvm::TypeSize sizeInBits = DL.getTypeSizeInBits(type);
+  uint64_t abiAlign = DL.getTypeABIAlignment(type);
+  return Builder.getIntegerType(sizeInBits.getFixedValue(),
+                                llvm::Align(abiAlign),
+                                /*Signed=*/false);
+}
+
+const llvm::abi::Type *ABITypeMapper::mapVectorType(mlir::VectorType type) {
+  const llvm::abi::Type *elementTy = map(type.getElementType());
+  if (!elementTy)
+    return nullptr;
+
+  auto shape = type.getShape();
+  // MLIR VectorType is always fixed-length and can be multi-dimensional.
+  // Flatten to a single dimension for ABI purposes.
+  uint64_t totalElements = 1;
+  for (int64_t dim : shape)
+    totalElements *= dim;
+
+  llvm::ElementCount ec = llvm::ElementCount::getFixed(totalElements);
+  uint64_t abiAlign = DL.getTypeABIAlignment(type);
+  return Builder.getVectorType(elementTy, ec, llvm::Align(abiAlign));
+}
+
+const llvm::abi::Type *ABITypeMapper::mapMemRefType(mlir::MemRefType type) {
+  // MemRef is pointer-like for ABI purposes.
+  llvm::TypeSize sizeInBits = DL.getTypeSizeInBits(type);
+  uint64_t abiAlign = DL.getTypeABIAlignment(type);
+  unsigned addrSpace = 0;
+  if (auto as = type.getMemorySpace())
+    if (auto intAttr = dyn_cast<IntegerAttr>(as))
+      addrSpace = intAttr.getInt();
+  return Builder.getPointerType(sizeInBits.getFixedValue(),
+                                llvm::Align(abiAlign), addrSpace);
+}
+
+const llvm::abi::Type *ABITypeMapper::mapNoneType(mlir::NoneType type) {
+  return Builder.getVoidType();
+}

--- a/mlir/lib/ABI/CMakeLists.txt
+++ b/mlir/lib/ABI/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_mlir_library(MLIRABI
+  ABITypeMapper.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/ABI
+
+  LINK_COMPONENTS
+  ABI
+  Support
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRDataLayoutInterfaces
+  )

--- a/mlir/lib/CMakeLists.txt
+++ b/mlir/lib/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Enable errors for any global constructors.
 add_flag_if_supported("-Werror=global-constructors" WERROR_GLOBAL_CONSTRUCTOR)
 
+add_subdirectory(ABI)
 add_subdirectory(Analysis)
 add_subdirectory(AsmParser)
 add_subdirectory(Bytecode)

--- a/mlir/unittests/ABI/ABIRewriteContextTest.cpp
+++ b/mlir/unittests/ABI/ABIRewriteContextTest.cpp
@@ -37,36 +37,36 @@ TEST(ABIRewriteContextTest, MockCanBeConstructedAndDestroyed) {
 
 TEST(ABIRewriteContextTest, ArgClassificationDirect) {
   auto c = ArgClassification::getDirect();
-  EXPECT_EQ(c.Kind, ArgKind::Direct);
-  EXPECT_EQ(c.CoercedType, nullptr);
-  EXPECT_TRUE(c.CanFlatten);
+  EXPECT_EQ(c.kind, ArgKind::Direct);
+  EXPECT_EQ(c.coercedType, nullptr);
+  EXPECT_TRUE(c.canFlatten);
 }
 
 TEST(ABIRewriteContextTest, ArgClassificationDirectWithType) {
   MLIRContext mlirCtx;
   auto i32 = IntegerType::get(&mlirCtx, 32);
   auto c = ArgClassification::getDirect(i32);
-  EXPECT_EQ(c.Kind, ArgKind::Direct);
-  EXPECT_EQ(c.CoercedType, i32);
+  EXPECT_EQ(c.kind, ArgKind::Direct);
+  EXPECT_EQ(c.coercedType, i32);
 }
 
 TEST(ABIRewriteContextTest, ArgClassificationIgnore) {
   auto c = ArgClassification::getIgnore();
-  EXPECT_EQ(c.Kind, ArgKind::Ignore);
+  EXPECT_EQ(c.kind, ArgKind::Ignore);
 }
 
 TEST(ABIRewriteContextTest, ArgClassificationIndirect) {
   auto c = ArgClassification::getIndirect(llvm::Align(8), true);
-  EXPECT_EQ(c.Kind, ArgKind::Indirect);
-  EXPECT_EQ(c.IndirectAlign, llvm::Align(8));
-  EXPECT_TRUE(c.ByVal);
+  EXPECT_EQ(c.kind, ArgKind::Indirect);
+  EXPECT_EQ(c.indirectAlign, llvm::Align(8));
+  EXPECT_TRUE(c.byVal);
 }
 
 TEST(ABIRewriteContextTest, ArgClassificationIndirectNoByVal) {
   auto c = ArgClassification::getIndirect(llvm::Align(16), false);
-  EXPECT_EQ(c.Kind, ArgKind::Indirect);
-  EXPECT_EQ(c.IndirectAlign, llvm::Align(16));
-  EXPECT_FALSE(c.ByVal);
+  EXPECT_EQ(c.kind, ArgKind::Indirect);
+  EXPECT_EQ(c.indirectAlign, llvm::Align(16));
+  EXPECT_FALSE(c.byVal);
 }
 
 TEST(ABIRewriteContextTest, ArgClassificationExtend) {
@@ -74,26 +74,26 @@ TEST(ABIRewriteContextTest, ArgClassificationExtend) {
   auto i8 = IntegerType::get(&mlirCtx, 8);
 
   auto signExt = ArgClassification::getExtend(i8, true);
-  EXPECT_EQ(signExt.Kind, ArgKind::Extend);
-  EXPECT_TRUE(signExt.SignExtend);
+  EXPECT_EQ(signExt.kind, ArgKind::Extend);
+  EXPECT_TRUE(signExt.signExtend);
 
   auto zeroExt = ArgClassification::getExtend(i8, false);
-  EXPECT_EQ(zeroExt.Kind, ArgKind::Extend);
-  EXPECT_FALSE(zeroExt.SignExtend);
+  EXPECT_EQ(zeroExt.kind, ArgKind::Extend);
+  EXPECT_FALSE(zeroExt.signExtend);
 }
 
 TEST(ABIRewriteContextTest, FunctionClassificationHoldsReturnAndArgs) {
   FunctionClassification fc;
-  fc.ReturnInfo = ArgClassification::getDirect();
-  fc.ArgInfos.push_back(ArgClassification::getDirect());
-  fc.ArgInfos.push_back(ArgClassification::getIndirect(llvm::Align(8), true));
-  fc.ArgInfos.push_back(ArgClassification::getIgnore());
+  fc.returnInfo = ArgClassification::getDirect();
+  fc.argInfos.push_back(ArgClassification::getDirect());
+  fc.argInfos.push_back(ArgClassification::getIndirect(llvm::Align(8), true));
+  fc.argInfos.push_back(ArgClassification::getIgnore());
 
-  EXPECT_EQ(fc.ReturnInfo.Kind, ArgKind::Direct);
-  EXPECT_EQ(fc.ArgInfos.size(), 3u);
-  EXPECT_EQ(fc.ArgInfos[0].Kind, ArgKind::Direct);
-  EXPECT_EQ(fc.ArgInfos[1].Kind, ArgKind::Indirect);
-  EXPECT_EQ(fc.ArgInfos[2].Kind, ArgKind::Ignore);
+  EXPECT_EQ(fc.returnInfo.kind, ArgKind::Direct);
+  EXPECT_EQ(fc.argInfos.size(), 3u);
+  EXPECT_EQ(fc.argInfos[0].kind, ArgKind::Direct);
+  EXPECT_EQ(fc.argInfos[1].kind, ArgKind::Indirect);
+  EXPECT_EQ(fc.argInfos[2].kind, ArgKind::Ignore);
 }
 
 } // namespace

--- a/mlir/unittests/ABI/ABIRewriteContextTest.cpp
+++ b/mlir/unittests/ABI/ABIRewriteContextTest.cpp
@@ -1,0 +1,99 @@
+//===- ABIRewriteContextTest.cpp - Unit tests for ABIRewriteContext -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/ABI/ABIRewriteContext.h"
+#include <gtest/gtest.h>
+
+using namespace mlir;
+using namespace mlir::abi;
+
+namespace {
+
+class MockRewriteContext : public ABIRewriteContext {
+public:
+  LogicalResult rewriteFunctionDefinition(FunctionOpInterface,
+                                          const FunctionClassification &,
+                                          OpBuilder &) override {
+    return success();
+  }
+
+  LogicalResult rewriteCallSite(Operation *, const FunctionClassification &,
+                                OpBuilder &) override {
+    return success();
+  }
+
+  StringRef getDialectNamespace() const override { return "mock"; }
+};
+
+TEST(ABIRewriteContextTest, MockCanBeConstructedAndDestroyed) {
+  MockRewriteContext ctx;
+  EXPECT_EQ(ctx.getDialectNamespace(), "mock");
+}
+
+TEST(ABIRewriteContextTest, ArgClassificationDirect) {
+  auto c = ArgClassification::getDirect();
+  EXPECT_EQ(c.Kind, ArgKind::Direct);
+  EXPECT_EQ(c.CoercedType, nullptr);
+  EXPECT_TRUE(c.CanFlatten);
+}
+
+TEST(ABIRewriteContextTest, ArgClassificationDirectWithType) {
+  MLIRContext mlirCtx;
+  auto i32 = IntegerType::get(&mlirCtx, 32);
+  auto c = ArgClassification::getDirect(i32);
+  EXPECT_EQ(c.Kind, ArgKind::Direct);
+  EXPECT_EQ(c.CoercedType, i32);
+}
+
+TEST(ABIRewriteContextTest, ArgClassificationIgnore) {
+  auto c = ArgClassification::getIgnore();
+  EXPECT_EQ(c.Kind, ArgKind::Ignore);
+}
+
+TEST(ABIRewriteContextTest, ArgClassificationIndirect) {
+  auto c = ArgClassification::getIndirect(llvm::Align(8), true);
+  EXPECT_EQ(c.Kind, ArgKind::Indirect);
+  EXPECT_EQ(c.IndirectAlign, llvm::Align(8));
+  EXPECT_TRUE(c.ByVal);
+}
+
+TEST(ABIRewriteContextTest, ArgClassificationIndirectNoByVal) {
+  auto c = ArgClassification::getIndirect(llvm::Align(16), false);
+  EXPECT_EQ(c.Kind, ArgKind::Indirect);
+  EXPECT_EQ(c.IndirectAlign, llvm::Align(16));
+  EXPECT_FALSE(c.ByVal);
+}
+
+TEST(ABIRewriteContextTest, ArgClassificationExtend) {
+  MLIRContext mlirCtx;
+  auto i8 = IntegerType::get(&mlirCtx, 8);
+
+  auto signExt = ArgClassification::getExtend(i8, true);
+  EXPECT_EQ(signExt.Kind, ArgKind::Extend);
+  EXPECT_TRUE(signExt.SignExtend);
+
+  auto zeroExt = ArgClassification::getExtend(i8, false);
+  EXPECT_EQ(zeroExt.Kind, ArgKind::Extend);
+  EXPECT_FALSE(zeroExt.SignExtend);
+}
+
+TEST(ABIRewriteContextTest, FunctionClassificationHoldsReturnAndArgs) {
+  FunctionClassification fc;
+  fc.ReturnInfo = ArgClassification::getDirect();
+  fc.ArgInfos.push_back(ArgClassification::getDirect());
+  fc.ArgInfos.push_back(ArgClassification::getIndirect(llvm::Align(8), true));
+  fc.ArgInfos.push_back(ArgClassification::getIgnore());
+
+  EXPECT_EQ(fc.ReturnInfo.Kind, ArgKind::Direct);
+  EXPECT_EQ(fc.ArgInfos.size(), 3u);
+  EXPECT_EQ(fc.ArgInfos[0].Kind, ArgKind::Direct);
+  EXPECT_EQ(fc.ArgInfos[1].Kind, ArgKind::Indirect);
+  EXPECT_EQ(fc.ArgInfos[2].Kind, ArgKind::Ignore);
+}
+
+} // namespace

--- a/mlir/unittests/ABI/ABITypeMapperTest.cpp
+++ b/mlir/unittests/ABI/ABITypeMapperTest.cpp
@@ -1,0 +1,173 @@
+//===- ABITypeMapperTest.cpp - Unit tests for ABITypeMapper ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/ABI/ABITypeMapper.h"
+#include "mlir/Dialect/DLTI/DLTI.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
+#include "llvm/ABI/Types.h"
+
+#include <gtest/gtest.h>
+
+using namespace mlir;
+using namespace mlir::abi;
+
+namespace {
+
+class ABITypeMapperTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    ctx.loadDialect<DLTIDialect>();
+    module = ModuleOp::create(UnknownLoc::get(&ctx));
+  }
+
+  void TearDown() override { module->destroy(); }
+
+  MLIRContext ctx;
+  ModuleOp module;
+};
+
+TEST_F(ABITypeMapperTest, MapI32) {
+  DataLayout dl(module);
+  ABITypeMapper mapper(dl);
+
+  auto i32 = IntegerType::get(&ctx, 32);
+  const llvm::abi::Type *result = mapper.map(i32);
+
+  ASSERT_NE(result, nullptr);
+  EXPECT_TRUE(result->isInteger());
+
+  auto *intTy = llvm::cast<llvm::abi::IntegerType>(result);
+  EXPECT_EQ(intTy->getSizeInBits().getFixedValue(), 32u);
+}
+
+TEST_F(ABITypeMapperTest, MapI1) {
+  DataLayout dl(module);
+  ABITypeMapper mapper(dl);
+
+  auto i1 = IntegerType::get(&ctx, 1);
+  const llvm::abi::Type *result = mapper.map(i1);
+
+  ASSERT_NE(result, nullptr);
+  EXPECT_TRUE(result->isInteger());
+
+  auto *intTy = llvm::cast<llvm::abi::IntegerType>(result);
+  EXPECT_EQ(intTy->getSizeInBits().getFixedValue(), 1u);
+}
+
+TEST_F(ABITypeMapperTest, MapI64) {
+  DataLayout dl(module);
+  ABITypeMapper mapper(dl);
+
+  auto i64 = IntegerType::get(&ctx, 64);
+  const llvm::abi::Type *result = mapper.map(i64);
+
+  ASSERT_NE(result, nullptr);
+  EXPECT_TRUE(result->isInteger());
+
+  auto *intTy = llvm::cast<llvm::abi::IntegerType>(result);
+  EXPECT_EQ(intTy->getSizeInBits().getFixedValue(), 64u);
+}
+
+TEST_F(ABITypeMapperTest, MapF32) {
+  DataLayout dl(module);
+  ABITypeMapper mapper(dl);
+
+  auto f32 = Float32Type::get(&ctx);
+  const llvm::abi::Type *result = mapper.map(f32);
+
+  ASSERT_NE(result, nullptr);
+  EXPECT_TRUE(result->isFloat());
+
+  auto *floatTy = llvm::cast<llvm::abi::FloatType>(result);
+  EXPECT_EQ(floatTy->getSizeInBits().getFixedValue(), 32u);
+}
+
+TEST_F(ABITypeMapperTest, MapF64) {
+  DataLayout dl(module);
+  ABITypeMapper mapper(dl);
+
+  auto f64 = Float64Type::get(&ctx);
+  const llvm::abi::Type *result = mapper.map(f64);
+
+  ASSERT_NE(result, nullptr);
+  EXPECT_TRUE(result->isFloat());
+
+  auto *floatTy = llvm::cast<llvm::abi::FloatType>(result);
+  EXPECT_EQ(floatTy->getSizeInBits().getFixedValue(), 64u);
+}
+
+TEST_F(ABITypeMapperTest, MapF16) {
+  DataLayout dl(module);
+  ABITypeMapper mapper(dl);
+
+  auto f16 = Float16Type::get(&ctx);
+  const llvm::abi::Type *result = mapper.map(f16);
+
+  ASSERT_NE(result, nullptr);
+  EXPECT_TRUE(result->isFloat());
+
+  auto *floatTy = llvm::cast<llvm::abi::FloatType>(result);
+  EXPECT_EQ(floatTy->getSizeInBits().getFixedValue(), 16u);
+}
+
+TEST_F(ABITypeMapperTest, MapNoneType) {
+  DataLayout dl(module);
+  ABITypeMapper mapper(dl);
+
+  auto none = NoneType::get(&ctx);
+  const llvm::abi::Type *result = mapper.map(none);
+
+  ASSERT_NE(result, nullptr);
+  EXPECT_TRUE(result->isVoid());
+}
+
+TEST_F(ABITypeMapperTest, MapVectorOf4xF32) {
+  DataLayout dl(module);
+  ABITypeMapper mapper(dl);
+
+  auto f32 = Float32Type::get(&ctx);
+  auto vec = VectorType::get({4}, f32);
+  const llvm::abi::Type *result = mapper.map(vec);
+
+  ASSERT_NE(result, nullptr);
+  EXPECT_TRUE(result->isVector());
+
+  auto *vecTy = llvm::cast<llvm::abi::VectorType>(result);
+  EXPECT_EQ(vecTy->getNumElements().getFixedValue(), 4u);
+  EXPECT_TRUE(vecTy->getElementType()->isFloat());
+}
+
+TEST_F(ABITypeMapperTest, MapSignedI32) {
+  DataLayout dl(module);
+  ABITypeMapper mapper(dl);
+
+  auto si32 = IntegerType::get(&ctx, 32, IntegerType::Signed);
+  const llvm::abi::Type *result = mapper.map(si32);
+
+  ASSERT_NE(result, nullptr);
+  auto *intTy = llvm::cast<llvm::abi::IntegerType>(result);
+  EXPECT_TRUE(intTy->isSigned());
+}
+
+TEST_F(ABITypeMapperTest, MapUnsignedI32) {
+  DataLayout dl(module);
+  ABITypeMapper mapper(dl);
+
+  auto ui32 = IntegerType::get(&ctx, 32, IntegerType::Unsigned);
+  const llvm::abi::Type *result = mapper.map(ui32);
+
+  ASSERT_NE(result, nullptr);
+  auto *intTy = llvm::cast<llvm::abi::IntegerType>(result);
+  EXPECT_FALSE(intTy->isSigned());
+}
+
+} // namespace

--- a/mlir/unittests/ABI/CMakeLists.txt
+++ b/mlir/unittests/ABI/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_mlir_unittest(MLIRABITests
+  ABIRewriteContextTest.cpp
+  ABITypeMapperTest.cpp
+)
+
+mlir_target_link_libraries(MLIRABITests
+  PRIVATE
+  MLIRABI
+  MLIRDataLayoutInterfaces
+  MLIRDLTIDialect
+  MLIRIR
+)

--- a/mlir/unittests/CMakeLists.txt
+++ b/mlir/unittests/CMakeLists.txt
@@ -5,6 +5,7 @@ function(add_mlir_unittest test_dirname)
   add_unittest(MLIRUnitTests ${test_dirname} ${ARGN})
 endfunction()
 
+add_subdirectory(ABI)
 add_subdirectory(Analysis)
 add_subdirectory(Bytecode)
 add_subdirectory(Conversion)


### PR DESCRIPTION
Extends CIRABIRewriteContext (#192119) with Indirect argument/return handling.  Covers sret for large return types, byval for large arguments, non-byval indirect for non-trivially-copyable types, and multi-register struct flattening via GetMemberOp.  Call-site rewrites for all of the above.

5 new unit tests (29 total).  Depends on #192119.

Made with [Cursor](https://cursor.com)