### PR TITLE
[LIT] Add -nostdinc so system headers aren't searched with implicit module maps

### DIFF
--- a/clang/test/ClangScanDeps/modules-full-by-mult-mod-names-diagnostics.c
+++ b/clang/test/ClangScanDeps/modules-full-by-mult-mod-names-diagnostics.c
@@ -16,7 +16,7 @@ module root2 { header "root2.h" }
 [{
   "file": "",
   "directory": "DIR",
-  "command": "clang -fmodules -fmodules-cache-path=DIR/cache -I DIR -x c"
+  "command": "clang -nostdinc -fmodules -fmodules-cache-path=DIR/cache -I DIR -x c"
 }]
 
 // RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json

--- a/clang/test/ClangScanDeps/modules-pch-common-stale.c
+++ b/clang/test/ClangScanDeps/modules-pch-common-stale.c
@@ -27,7 +27,7 @@ module mod_tu_extra { header "mod_tu_extra.h" }
 
 // Clean: scan the PCH.
 // RUN: clang-scan-deps -format experimental-full -o %t/deps_pch_clean.json -- \
-// RUN:     %clang -x c-header %t/prefix.h -o %t/prefix.h.pch \
+// RUN:     %clang -nostdinc -x c-header %t/prefix.h -o %t/prefix.h.pch \
 // RUN:     -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache
 
 // Clean: build the PCH.
@@ -38,7 +38,7 @@ module mod_tu_extra { header "mod_tu_extra.h" }
 
 // Clean: scan the TU.
 // RUN: clang-scan-deps -format experimental-full -o %t/deps_tu_clean.json -- \
-// RUN:     %clang -c %t/tu.c -o %t/tu.o -include %t/prefix.h \
+// RUN:     %clang -nostdinc -c %t/tu.c -o %t/tu.o -include %t/prefix.h \
 // RUN:     -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache
 // RUN: cat %t/deps_tu_clean.json | sed 's:\\\\\?:/:g' | FileCheck %s --check-prefix=CHECK-TU-CLEAN -DPREFIX=%/t
 // CHECK-TU-CLEAN:      {
@@ -94,7 +94,7 @@ module mod_tu_extra { header "mod_tu_extra.h" }
 
 // Incremental: scan the PCH.
 // RUN: clang-scan-deps -format experimental-full -o %t/deps_pch_incremental.json -- \
-// RUN:     %clang -x c-header %t/prefix.h -o %t/prefix.h.pch \
+// RUN:     %clang -nostdinc -x c-header %t/prefix.h -o %t/prefix.h.pch \
 // RUN:     -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache
 
 // Incremental: build the PCH.
@@ -107,7 +107,7 @@ module mod_tu_extra { header "mod_tu_extra.h" }
 //              TU that depend on modules imported from the PCH and discover the
 //              new dependency on 'mod_tu_extra'.
 // RUN: clang-scan-deps -format experimental-full -o %t/deps_tu_incremental.json -- \
-// RUN:     %clang -c %t/tu.c -o %t/tu.o -include %t/prefix.h \
+// RUN:     %clang -nostdinc -c %t/tu.c -o %t/tu.o -include %t/prefix.h \
 // RUN:     -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache
 // RUN: cat %t/deps_tu_incremental.json | sed 's:\\\\\?:/:g' | FileCheck %s --check-prefix=CHECK-TU-INCREMENTAL -DPREFIX=%/t
 // CHECK-TU-INCREMENTAL:      {

--- a/clang/test/ClangScanDeps/modules-pch-imports.c
+++ b/clang/test/ClangScanDeps/modules-pch-imports.c
@@ -51,14 +51,14 @@
 [{
   "file": "DIR/prefix.h",
   "directory": "DIR",
-  "command": "clang -x c-header DIR/prefix.h -o DIR/prefix.h.pch -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+  "command": "clang -nostdinc -x c-header DIR/prefix.h -o DIR/prefix.h.pch -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
 }]
 
 //--- cdb.json.template
 [{
   "file": "DIR/tu.c",
   "directory": "DIR",
-  "command": "clang -fsyntax-only DIR/tu.c -include DIR/prefix.h -fmodule-name=C -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+  "command": "clang -nostdinc -fsyntax-only DIR/tu.c -include DIR/prefix.h -fmodule-name=C -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
 }]
 
 //--- module.modulemap

--- a/clang/test/ClangScanDeps/optimize-vfs-pch.m
+++ b/clang/test/ClangScanDeps/optimize-vfs-pch.m
@@ -90,7 +90,7 @@
 [
 {
   "directory": "DIR",
-  "command": "clang -x objective-c-header DIR/pch.h -I DIR/modules/A -I DIR/modules/B -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache -o DIR/pch.h.pch -ivfsoverlay DIR/build/pch-overlay.yaml",
+  "command": "clang -nostdinc -x objective-c-header DIR/pch.h -I DIR/modules/A -I DIR/modules/B -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache -o DIR/pch.h.pch -ivfsoverlay DIR/build/pch-overlay.yaml",
   "file": "DIR/pch.h"
 }
 ]
@@ -100,7 +100,7 @@
 [
 {
   "directory": "DIR",
-  "command": "clang -fsyntax-only DIR/tu.m -I DIR/modules/A -I DIR/modules/B -I DIR/modules/C -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache -include DIR/pch.h -o DIR/tu.o -ivfsoverlay DIR/build/pch-overlay.yaml",
+  "command": "clang -nostdinc -fsyntax-only DIR/tu.m -I DIR/modules/A -I DIR/modules/B -I DIR/modules/C -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache -include DIR/pch.h -o DIR/tu.o -ivfsoverlay DIR/build/pch-overlay.yaml",
   "file": "DIR/tu.m"
 }
 ]
@@ -110,7 +110,7 @@
 [
 {
   "directory": "DIR",
-  "command": "clang -Wpch-vfs-diff -Werror=pch-vfs-diff -fsyntax-only DIR/tu.m -I DIR/modules/A -I DIR/modules/B -I DIR/modules/C -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache -include DIR/pch.h -o DIR/tu.o",
+  "command": "clang -nostdinc -Wpch-vfs-diff -Werror=pch-vfs-diff -fsyntax-only DIR/tu.m -I DIR/modules/A -I DIR/modules/B -I DIR/modules/C -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache -include DIR/pch.h -o DIR/tu.o",
   "file": "DIR/tu.m"
 }
 ]
@@ -120,7 +120,7 @@
 [
 {
   "directory": "DIR",
-  "command": "clang -fsyntax-only DIR/tu1.m -I DIR/modules/B -I DIR/modules/D -I DIR/modules/E -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache -include DIR/pch.h -o DIR/tu1.o -ivfsoverlay DIR/build/pch-overlay.yaml",
+  "command": "clang -nostdinc -fsyntax-only DIR/tu1.m -I DIR/modules/B -I DIR/modules/D -I DIR/modules/E -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache -include DIR/pch.h -o DIR/tu1.o -ivfsoverlay DIR/build/pch-overlay.yaml",
   "file": "DIR/tu1.m"
 }
 ]


### PR DESCRIPTION
These lit tests are implicitly loading the module maps found in the directories found in the search path.  On z/OS this ends up trying to load an invalid module map that is never used with the actual clang compilation.  Add `-nostdinc` to avoid searching dirs outside of the ones being tested.