### PR TITLE
[llvm-nm] Drop STT_FILE/STT_SECTION from --special-syms

### DIFF
--- a/llvm/test/tools/llvm-nm/special-syms-aarch64.test
+++ b/llvm/test/tools/llvm-nm/special-syms-aarch64.test
@@ -2,13 +2,12 @@
 # RUN: yaml2obj %s -o %t
 
 # RUN: llvm-nm %t | count 0
-# RUN: llvm-nm %t --special-syms | FileCheck %s
+# RUN: llvm-nm %t --special-syms | FileCheck %s \
+# RUN:   --implicit-check-not=file_sym --implicit-check-not=.text
 
 ## --special-syms should show mapping symbols but not STT_FILE or STT_SECTION.
 # CHECK:      2000 d $d.1
 # CHECK-NEXT: 1000 t $x.1
-# CHECK-NOT:  file_sym
-# CHECK-NOT:  .text
 
 !ELF
 FileHeader:

--- a/llvm/test/tools/llvm-nm/special-syms-aarch64.test
+++ b/llvm/test/tools/llvm-nm/special-syms-aarch64.test
@@ -4,6 +4,12 @@
 # RUN: llvm-nm %t | count 0
 # RUN: llvm-nm %t --special-syms | FileCheck %s
 
+## --special-syms should show mapping symbols but not STT_FILE or STT_SECTION.
+# CHECK:      2000 d $d.1
+# CHECK-NEXT: 1000 t $x.1
+# CHECK-NOT:  file_sym
+# CHECK-NOT:  .text
+
 !ELF
 FileHeader:
   Class:           ELFCLASS64
@@ -20,10 +26,13 @@ Sections:
     Flags:           [ SHF_ALLOC, SHF_WRITE ]
     Address:         0x2000
 Symbols:
+  - Name:     ""
+    Type:     STT_SECTION
+    Section:  .text
+  - Name:     file_sym
+    Type:     STT_FILE
+    Index:    SHN_ABS
   - Name:     $x.1
     Section:  .text
   - Name:     $d.1
     Section:  .data
-
-# CHECK:      2000 d $d.1
-# CHECK-NEXT: 1000 t $x.1

--- a/llvm/test/tools/llvm-nm/special-syms-arm.test
+++ b/llvm/test/tools/llvm-nm/special-syms-arm.test
@@ -5,6 +5,13 @@
 # RUN: llvm-nm %t | count 0
 # RUN: llvm-nm --special-syms %t | FileCheck %s
 
+## --special-syms should show mapping symbols but not STT_FILE or STT_SECTION.
+# CHECK:     00000000 t $a.1
+# CHECK:     00000000 t $d.0
+# CHECK:     00000000 t $t.1
+# CHECK-NOT: file_sym
+# CHECK-NOT: .text
+
 !ELF
 FileHeader:
   Class:           ELFCLASS32
@@ -18,13 +25,15 @@ Sections:
     Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
     AddressAlign:    0x4
 Symbols:
+  - Name:            ''
+    Type:            STT_SECTION
+    Section:         .text
+  - Name:            file_sym
+    Type:            STT_FILE
+    Index:           SHN_ABS
   - Name:            '$d.0'
     Section:         .text
   - Name:            '$a.1'
     Section:         .text
   - Name:            '$t.1'
     Section:         .text
-
-# CHECK: 00000000 t $a.1
-# CHECK: 00000000 t $d.0
-# CHECK: 00000000 t $t.1

--- a/llvm/test/tools/llvm-nm/special-syms-arm.test
+++ b/llvm/test/tools/llvm-nm/special-syms-arm.test
@@ -3,14 +3,13 @@
 #
 # RUN: yaml2obj %s -o %t
 # RUN: llvm-nm %t | count 0
-# RUN: llvm-nm --special-syms %t | FileCheck %s
+# RUN: llvm-nm --special-syms %t | FileCheck %s \
+# RUN:   --implicit-check-not=file_sym --implicit-check-not=.text
 
 ## --special-syms should show mapping symbols but not STT_FILE or STT_SECTION.
 # CHECK:     00000000 t $a.1
 # CHECK:     00000000 t $d.0
 # CHECK:     00000000 t $t.1
-# CHECK-NOT: file_sym
-# CHECK-NOT: .text
 
 !ELF
 FileHeader:

--- a/llvm/test/tools/llvm-nm/special-syms-csky.test
+++ b/llvm/test/tools/llvm-nm/special-syms-csky.test
@@ -2,6 +2,12 @@
 # RUN: llvm-nm %t | count 0
 # RUN: llvm-nm --special-syms %t | FileCheck %s
 
+## --special-syms should show mapping symbols but not STT_FILE or STT_SECTION.
+# CHECK:     00000000 t $d.1
+# CHECK:     00000000 t $t.1
+# CHECK-NOT: file_sym
+# CHECK-NOT: .text
+
 !ELF
 FileHeader:
   Class:           ELFCLASS32
@@ -14,10 +20,13 @@ Sections:
     Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
     AddressAlign:    0x4
 Symbols:
+  - Name:     ""
+    Type:     STT_SECTION
+    Section:  .text
+  - Name:     file_sym
+    Type:     STT_FILE
+    Index:    SHN_ABS
   - Name:     $d.1
     Section:  .text
   - Name:     $t.1
     Section:  .text
-
-# CHECK: 00000000 t $d.1
-# CHECK: 00000000 t $t.1

--- a/llvm/test/tools/llvm-nm/special-syms-csky.test
+++ b/llvm/test/tools/llvm-nm/special-syms-csky.test
@@ -1,12 +1,11 @@
 # RUN: yaml2obj %s -o %t
 # RUN: llvm-nm %t | count 0
-# RUN: llvm-nm --special-syms %t | FileCheck %s
+# RUN: llvm-nm --special-syms %t | FileCheck %s \
+# RUN:   --implicit-check-not=file_sym --implicit-check-not=.text
 
 ## --special-syms should show mapping symbols but not STT_FILE or STT_SECTION.
 # CHECK:     00000000 t $d.1
 # CHECK:     00000000 t $t.1
-# CHECK-NOT: file_sym
-# CHECK-NOT: .text
 
 !ELF
 FileHeader:

--- a/llvm/test/tools/llvm-nm/special-syms-riscv.test
+++ b/llvm/test/tools/llvm-nm/special-syms-riscv.test
@@ -2,13 +2,12 @@
 # RUN: yaml2obj %s -o %t
 
 # RUN: llvm-nm %t | count 0
-# RUN: llvm-nm %t --special-syms | FileCheck %s
+# RUN: llvm-nm %t --special-syms | FileCheck %s \
+# RUN:   --implicit-check-not=file_sym --implicit-check-not=.text
 
 ## --special-syms should show mapping symbols but not STT_FILE or STT_SECTION.
 # CHECK:      2000 d $d.1
 # CHECK-NEXT: 1000 t $x.1
-# CHECK-NOT:  file_sym
-# CHECK-NOT:  .text
 
 !ELF
 FileHeader:

--- a/llvm/test/tools/llvm-nm/special-syms-riscv.test
+++ b/llvm/test/tools/llvm-nm/special-syms-riscv.test
@@ -4,6 +4,12 @@
 # RUN: llvm-nm %t | count 0
 # RUN: llvm-nm %t --special-syms | FileCheck %s
 
+## --special-syms should show mapping symbols but not STT_FILE or STT_SECTION.
+# CHECK:      2000 d $d.1
+# CHECK-NEXT: 1000 t $x.1
+# CHECK-NOT:  file_sym
+# CHECK-NOT:  .text
+
 !ELF
 FileHeader:
   Class:           ELFCLASS64
@@ -20,10 +26,13 @@ Sections:
     Flags:           [ SHF_ALLOC, SHF_WRITE ]
     Address:         0x2000
 Symbols:
+  - Name:     ""
+    Type:     STT_SECTION
+    Section:  .text
+  - Name:     file_sym
+    Type:     STT_FILE
+    Index:    SHN_ABS
   - Name:     $x.1
     Section:  .text
   - Name:     $d.1
     Section:  .data
-
-# CHECK:      2000 d $d.1
-# CHECK-NEXT: 1000 t $x.1

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -1833,9 +1833,9 @@ static bool getSymbolNamesFromObject(SymbolicFile &Obj,
         auto *ELFObj = dyn_cast<ELFObjectFileBase>(&Obj);
         bool IsMappingSymbol =
             ELFObj &&
-            llvm::is_contained({ELF::EM_ARM, ELF::EM_AARCH64, ELF::EM_CSKY,
-                                ELF::EM_RISCV},
-                               ELFObj->getEMachine()) &&
+            llvm::is_contained(
+                {ELF::EM_ARM, ELF::EM_AARCH64, ELF::EM_CSKY, ELF::EM_RISCV},
+                ELFObj->getEMachine()) &&
             ELFSymbolRef(Sym).getELFType() == ELF::STT_NOTYPE;
         if (!IsMappingSymbol)
           continue;

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -1825,10 +1825,9 @@ static bool getSymbolNamesFromObject(SymbolicFile &Obj,
         return false;
       }
 
-      // Don't drop format specific symbols for ARM and AArch64 ELF targets
-      // if they are mapping symbols (STT_NOTYPE), needed to honor the
-      // --special-syms option. Other format-specific symbols (STT_FILE,
-      // STT_SECTION, etc.) are dropped.
+      // Drop format-specific symbols (STT_FILE, STT_SECTION, etc.) but
+      // retain mapping symbols (STT_NOTYPE such as $d, $x) on ARM, AArch64,
+      // CSKY, and RISC-V targets to honor option --special-syms.
       if (!DebugSyms && (*SymFlagsOrErr & SymbolRef::SF_FormatSpecific)) {
         auto *ELFObj = dyn_cast<ELFObjectFileBase>(&Obj);
         bool IsMappingSymbol =

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -1825,17 +1825,21 @@ static bool getSymbolNamesFromObject(SymbolicFile &Obj,
         return false;
       }
 
-      // Don't drop format specifc symbols for ARM and AArch64 ELF targets, they
-      // are used to repesent mapping symbols and needed to honor the
-      // --special-syms option.
-      auto *ELFObj = dyn_cast<ELFObjectFileBase>(&Obj);
-      bool HasMappingSymbol =
-          ELFObj && llvm::is_contained({ELF::EM_ARM, ELF::EM_AARCH64,
-                                        ELF::EM_CSKY, ELF::EM_RISCV},
-                                       ELFObj->getEMachine());
-      if (!HasMappingSymbol && !DebugSyms &&
-          (*SymFlagsOrErr & SymbolRef::SF_FormatSpecific))
-        continue;
+      // Don't drop format specific symbols for ARM and AArch64 ELF targets
+      // if they are mapping symbols (STT_NOTYPE), needed to honor the
+      // --special-syms option. Other format-specific symbols (STT_FILE,
+      // STT_SECTION, etc.) are dropped.
+      if (!DebugSyms && (*SymFlagsOrErr & SymbolRef::SF_FormatSpecific)) {
+        auto *ELFObj = dyn_cast<ELFObjectFileBase>(&Obj);
+        bool IsMappingSymbol =
+            ELFObj &&
+            llvm::is_contained({ELF::EM_ARM, ELF::EM_AARCH64, ELF::EM_CSKY,
+                                ELF::EM_RISCV},
+                               ELFObj->getEMachine()) &&
+            ELFSymbolRef(Sym).getELFType() == ELF::STT_NOTYPE;
+        if (!IsMappingSymbol)
+          continue;
+      }
       if (WithoutAliases && (*SymFlagsOrErr & SymbolRef::SF_Indirect))
         continue;
       // If a "-s segname sectname" option was specified and this is a Mach-O

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -1827,7 +1827,7 @@ static bool getSymbolNamesFromObject(SymbolicFile &Obj,
 
       // Drop format-specific symbols (STT_FILE, STT_SECTION, etc.) but
       // retain mapping symbols (STT_NOTYPE such as $d, $x) on ARM, AArch64,
-      // CSKY, and RISC-V targets to honor option --special-syms.
+      // CSKY, and RISC-V targets to honor the --special-syms option.
       if (!DebugSyms && (*SymFlagsOrErr & SymbolRef::SF_FormatSpecific)) {
         auto *ELFObj = dyn_cast<ELFObjectFileBase>(&Obj);
         bool IsMappingSymbol =


### PR DESCRIPTION
The filter for SF_FormatSpecific symbols exempted all such symbols for architectures having mapping symbols. This caused STT_FILE and STT_SECTION symbols to appear with --special-syms on these targets but not on x86_64. Narrow the exemption to only STT_NOTYPE symbols, which are the actual mapping symbols ($d, $x, etc.).