### PR TITLE
Make Passes Required - func-properties-stats and instcount

### DIFF
--- a/llvm/include/llvm/Analysis/FunctionPropertiesAnalysis.h
+++ b/llvm/include/llvm/Analysis/FunctionPropertiesAnalysis.h
@@ -194,6 +194,8 @@ public:
       : IsPreOptimization(IsPreOptimization) {}
 
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+
+  static bool isRequired() { return true; }
 };
 
 /// Correctly update FunctionPropertiesInfo post-inlining. A

--- a/llvm/include/llvm/Analysis/InstCount.h
+++ b/llvm/include/llvm/Analysis/InstCount.h
@@ -27,6 +27,8 @@ public:
       : IsPreOptimization(IsPreOptimization) {}
 
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+
+  static bool isRequired() { return true; }
 };
 
 } // end namespace llvm


### PR DESCRIPTION
These passes count different types of instructions and we want to see them even though optnone is enabled