### PR TITLE
[flang][cuda] Fix ignore_tkr(m) to also cover CUDA unified attribute

### DIFF
--- a/flang/docs/Directives.md
+++ b/flang/docs/Directives.md
@@ -16,8 +16,8 @@ A list of non-standard directives supported by Flang
   disables some semantic checks at call sites for the actual arguments that
   correspond to some named dummy arguments (or all of them, by default). The
   directive allow actual arguments that would otherwise be diagnosed as
-  incompatible in type (T), kind (K), rank (R), CUDA device (D), or managed (M)
-  status. The letter (A) is a shorthand for (TKRDM), and is the default when no
+  incompatible in type (T), kind (K), rank (R), CUDA device (D), or
+  managed/unified (M) status. The letter (A) is a shorthand for (TKRDM), and is the default when no
   letters appear.   The letter (C) checks for contiguity, for example allowing
   an element of an assumed-shape array to be passed as a dummy argument. When
   the dummy argument is passed by descriptor, (C) specifies that the descriptor

--- a/flang/docs/Directives.md
+++ b/flang/docs/Directives.md
@@ -16,9 +16,10 @@ A list of non-standard directives supported by Flang
   disables some semantic checks at call sites for the actual arguments that
   correspond to some named dummy arguments (or all of them, by default). The
   directive allow actual arguments that would otherwise be diagnosed as
-  incompatible in type (T), kind (K), rank (R), CUDA device (D), or
-  managed/unified (M) status. The letter (A) is a shorthand for (TKRDM), and is the default when no
-  letters appear.   The letter (C) checks for contiguity, for example allowing
+  incompatible in type (T), kind (K), rank (R), CUDA device (D), or managed/
+  unified (M) status. The letter (A) is a shorthand for (TKRDM), and is the
+  default when no letters appear.  The letter (C) checks for contiguity, for
+  example allowing
   an element of an assumed-shape array to be passed as a dummy argument. When
   the dummy argument is passed by descriptor, (C) specifies that the descriptor
   should not be copied or reboxed, allowing the original descriptor to be passed

--- a/flang/include/flang/Support/Fortran.h
+++ b/flang/include/flang/Support/Fortran.h
@@ -88,7 +88,7 @@ ENUM_CLASS(IgnoreTKR,
     Kind, // K - don't check kind
     Rank, // R - don't check ranks
     Device, // D - don't check host/device residence
-    Managed, // M - don't check managed storage
+    Managed, // M - don't check managed/unified storage
     Contiguous, // C - don't check for storage sequence association with a
                 // potentially non-contiguous object
     Pointer) // P - ignore pointer and allocatable matching

--- a/flang/lib/Support/Fortran.cpp
+++ b/flang/lib/Support/Fortran.cpp
@@ -132,8 +132,8 @@ bool AreCompatibleCUDADataAttrs(std::optional<CUDADataAttr> x,
       y.value_or(CUDADataAttr::Device) == CUDADataAttr::Device) {
     return true;
   } else if (ignoreTKR.test(IgnoreTKR::Managed) &&
-      x.value_or(CUDADataAttr::Managed) == CUDADataAttr::Managed &&
-      y.value_or(CUDADataAttr::Managed) == CUDADataAttr::Managed) {
+      (!x || *x == CUDADataAttr::Managed || *x == CUDADataAttr::Unified) &&
+      (!y || *y == CUDADataAttr::Managed || *y == CUDADataAttr::Unified)) {
     return true;
   } else if (allowUnifiedMatchingRule) {
     if (!x) { // Dummy argument has no attribute -> host

--- a/flang/test/Semantics/cuf10.cuf
+++ b/flang/test/Semantics/cuf10.cuf
@@ -58,6 +58,17 @@ module m
     integer :: a(10)
     call hostdev(a) ! ok because hostdev is attributes(host,device)
   end subroutine
-    
+
+  subroutine sub_ignore_tkr_m(x, n)
+!dir$ ignore_tkr (m) x
+    integer, unified :: x(n)
+    integer, value :: n
+  end subroutine
+  subroutine test_ignore_tkr_m()
+    integer :: host_arr(10)
+    integer, managed :: managed_arr(10)
+    call sub_ignore_tkr_m(host_arr, 10)
+    call sub_ignore_tkr_m(managed_arr, 10)
+  end subroutine
 
 end


### PR DESCRIPTION
The ignore_tkr(m) directive suppresses CUDA managed attribute checking on dummy arguments, but it was not covering the unified attribute. This caused a spurious error when passing a plain host array to a unified dummy with ignore_tkr(m):
```
error: dummy argument 'x=' has ATTRIBUTES(UNIFIED) but its associated actual argument has no CUDA data attribute
```
Extend the IgnoreTKR::Managed check in AreCompatibleCUDADataAttrs to accept Unified in addition to Managed and no-attribute.