### PR TITLE
Search for @_thisIsNotAPipe vs _thisIsNotAPipe

### DIFF
--- a/clang/test/CodeGen/2008-07-31-asm-labels.c
+++ b/clang/test/CodeGen/2008-07-31-asm-labels.c
@@ -1,11 +1,11 @@
 // RUN: %clang_cc1 -emit-llvm -o %t %s
 // RUN: not grep "@pipe()" %t
-// RUN: grep '_thisIsNotAPipe' %t | count 3
+// RUN: grep '@_thisIsNotAPipe' %t | count 3
 // RUN: not grep '@g0' %t
-// RUN: grep '_renamed' %t | count 2
+// RUN: grep '@_renamed' %t | count 2
 // RUN: %clang_cc1 -DUSE_DEF -emit-llvm -o %t %s
 // RUN: not grep "@pipe()" %t
-// RUN: grep '_thisIsNotAPipe' %t | count 3
+// RUN: grep '@_thisIsNotAPipe' %t | count 3
 // <rdr://6116729>
 
 void pipe() asm("_thisIsNotAPipe");


### PR DESCRIPTION
z/OS has a table of mapped names in the IR.  Counting the hits for just the name leads to one more hit than expected.  Search for the name with the @ char to make sure the right occurrences are being counted.