### PR TITLE
[CIR] Implement array-to-incomplete-array cast

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1561,9 +1561,21 @@ LValue CIRGenFunction::emitCastLValue(const CastExpr *e) {
       Address v = lv.getAddress();
       if (v.isValid()) {
         mlir::Type ty = convertTypeForMem(e->getType());
-        if (v.getElementType() != ty)
-          cgm.errorNYI(e->getSourceRange(),
-                       "emitCastLValue: NoOp needs bitcast");
+        if (v.getElementType() != ty) {
+          // We have only inspected/reproduced this with complete to incomplete
+          // array types, so we do an NYI for other cases, so we can make sure
+          // we're doing a conversion we want to be making.
+          auto fromTy = dyn_cast<cir::ArrayType>(v.getElementType());
+          auto toTy = dyn_cast<cir::ArrayType>(ty);
+          if (!fromTy || !toTy ||
+              fromTy.getElementType() != toTy.getElementType() ||
+              toTy.getSize() != 0)
+            cgm.errorNYI(e->getSourceRange(),
+                         "emitCastLValue NoOp not array-shrink case");
+
+          lv = makeAddrLValue(v.withElementType(builder, ty), e->getType(),
+                              lv.getBaseInfo());
+        }
       }
     }
     return lv;

--- a/clang/test/CIR/CodeGen/cast-cxx20.cpp
+++ b/clang/test/CIR/CodeGen/cast-cxx20.cpp
@@ -1,0 +1,55 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+
+using Arr4Ty = int [4];
+using ArrNTy = int [];
+using CArrNTy = const int [];
+
+void cast1() {
+  Arr4Ty arr = {};
+  ArrNTy &toArr = arr;
+
+  // CIR-LABEL: cir.func {{.*}}@_Z5cast1v()
+  // CIR: %[[ARR_ALLOCA:.*]] = cir.alloca !cir.array<!s32i x 4>, !cir.ptr<!cir.array<!s32i x 4>>, ["arr", init]
+  // CIR: %[[TO_ARR_ALLOCA:.*]] = cir.alloca !cir.ptr<!cir.array<!s32i x 0>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 0>>>, ["toArr", init, const]
+  // CIR: %[[TO_INCOMPLETE:.*]] = cir.cast bitcast %[[ARR_ALLOCA]] : !cir.ptr<!cir.array<!s32i x 4>> -> !cir.ptr<!cir.array<!s32i x 0>>
+  // CIR: cir.store {{.*}}%[[TO_INCOMPLETE]], %[[TO_ARR_ALLOCA]] : !cir.ptr<!cir.array<!s32i x 0>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 0>>>
+
+  // LLVM-LABEL: define {{.*}}@_Z5cast1v()
+  // LLVM: %[[ARR_ALLOCA:.*]] = alloca [4 x i32]
+  // LLVM: %[[TO_ARR_ALLOCA:.*]] = alloca ptr
+  // LLVM: store ptr %[[ARR_ALLOCA]], ptr %[[TO_ARR_ALLOCA]]
+}
+
+void cast2() {
+  Arr4Ty arr = {};
+  CArrNTy &toArr = arr;
+  // CIR-LABEL: cir.func {{.*}}@_Z5cast2v()
+  // CIR: %[[ARR_ALLOCA:.*]] = cir.alloca !cir.array<!s32i x 4>, !cir.ptr<!cir.array<!s32i x 4>>, ["arr", init]
+  // CIR: %[[TO_ARR_ALLOCA:.*]] = cir.alloca !cir.ptr<!cir.array<!s32i x 0>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 0>>>, ["toArr", init, const]
+  // CIR: %[[TO_INCOMPLETE:.*]] = cir.cast bitcast %[[ARR_ALLOCA]] : !cir.ptr<!cir.array<!s32i x 4>> -> !cir.ptr<!cir.array<!s32i x 0>>
+  // CIR: cir.store {{.*}}%[[TO_INCOMPLETE]], %[[TO_ARR_ALLOCA]] : !cir.ptr<!cir.array<!s32i x 0>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 0>>>
+  //
+  // LLVM-LABEL: define {{.*}}@_Z5cast2v()
+  // LLVM: %[[ARR_ALLOCA:.*]] = alloca [4 x i32]
+  // LLVM: %[[TO_ARR_ALLOCA:.*]] = alloca ptr
+  // LLVM: store ptr %[[ARR_ALLOCA]], ptr %[[TO_ARR_ALLOCA]]
+}
+
+void cast3() {
+  int (&&toArr)[] = static_cast<int[]>(3);
+  // CIR-LABEL: cir.func {{.*}}@_Z5cast3v()
+  // CIR: %[[TMP_ALLOCA:.*]] = cir.alloca !cir.array<!s32i x 1>, !cir.ptr<!cir.array<!s32i x 1>>, ["ref.tmp0"] 
+  // CIR: %[[TO_ARR_ALLOCA:.*]] = cir.alloca !cir.ptr<!cir.array<!s32i x 0>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 0>>>, ["toArr", init, const]
+  // CIR: %[[TO_INCOMPLETE:.*]] = cir.cast bitcast %[[TMP_ALLOCA]] : !cir.ptr<!cir.array<!s32i x 1>> -> !cir.ptr<!cir.array<!s32i x 0>>
+  // CIR: cir.store {{.*}}%[[TO_INCOMPLETE]], %[[TO_ARR_ALLOCA]] : !cir.ptr<!cir.array<!s32i x 0>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 0>>>
+  //
+  // LLVM-LABEL: define {{.*}}@_Z5cast3v()
+  // LLVM: %[[ARR_ALLOCA:.*]] = alloca [1 x i32]
+  // LLVM: %[[TO_ARR_ALLOCA:.*]] = alloca ptr
+  // LLVM: store ptr %[[ARR_ALLOCA]], ptr %[[TO_ARR_ALLOCA]]
+}


### PR DESCRIPTION
This is a noop cast that is allowed in some situations in C++20, and is validated with one of the test suites.  This patch adds a very defensive NYI diagnostic to replace the other one, plus implements the array decay case.