### PR TITLE
[WIP] AMDGPU: VGPR bank conflict avoidance hints

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -19,6 +19,7 @@
 #include "SIMachineFunctionInfo.h"
 #include "SIRegisterInfo.h"
 #include "llvm/CodeGen/LiveIntervals.h"
+#include "llvm/CodeGen/LiveRegMatrix.h"
 #include "llvm/CodeGen/LiveRegUnits.h"
 #include "llvm/CodeGen/MachineDominators.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
@@ -34,6 +35,11 @@ static cl::opt<bool> EnableSpillSGPRToVGPR(
   cl::desc("Enable spilling SGPRs to VGPRs"),
   cl::ReallyHidden,
   cl::init(true));
+
+static cl::opt<bool> EnableVGPRBankConflictAvoidance(
+    "amdgpu-avoid-vgpr-bank-conflicts",
+    cl::desc("Enable VGPR bank conflict avoidance in register allocation"),
+    cl::init(false), cl::Hidden);
 
 std::array<std::vector<int16_t>, 32> SIRegisterInfo::RegSplitParts;
 std::array<std::array<uint16_t, 32>, 9> SIRegisterInfo::SubRegFromChannelTable;
@@ -3853,6 +3859,26 @@ const int *SIRegisterInfo::getRegUnitPressureSets(MCRegUnit RegUnit) const {
   return AMDGPUGenRegisterInfo::getRegUnitPressureSets(RegUnit);
 }
 
+bool SIRegisterInfo::is3OperandVALU(const MachineInstr &MI) const {
+  if (!SIInstrInfo::isVALU(MI))
+    return false;
+
+  const MCInstrDesc &Desc = MI.getDesc();
+  const SIInstrInfo *TII = ST.getInstrInfo();
+  const MachineFunction &MF = *MI.getMF();
+  unsigned NumVGPRSrcs = 0;
+
+  // Count explicit source operands whose register class can hold VGPRs.
+  // Skip defs (operands 0..NumDefs-1); only inspect use slots.
+  for (unsigned i = Desc.getNumDefs(), e = Desc.getNumOperands(); i < e; ++i) {
+    const TargetRegisterClass *OpRC = TII->getRegClass(Desc, i);
+    if (OpRC && hasVGPRs(OpRC))
+      ++NumVGPRSrcs;
+  }
+
+  return NumVGPRSrcs >= 3;
+}
+
 bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
                                            ArrayRef<MCPhysReg> Order,
                                            SmallVectorImpl<MCPhysReg> &Hints,
@@ -3865,6 +3891,7 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
 
   std::pair<unsigned, Register> Hint = MRI.getRegAllocationHint(VirtReg);
 
+  bool BaseImplRetVal = false;
   switch (Hint.first) {
   case AMDGPURI::Size32: {
     Register Paired = Hint.second;
@@ -3883,7 +3910,8 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
       // isLo(Paired) is implicitly true here from the API of
       // getMatchingSuperReg.
       Hints.push_back(PairedPhys);
-    return false;
+    BaseImplRetVal = false;
+    break;
   }
   case AMDGPURI::Size16: {
     Register Paired = Hint.second;
@@ -3912,12 +3940,84 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
           Hints.push_back(PhysReg);
       }
     }
-    return false;
+    BaseImplRetVal = false;
+    break;
   }
-  default:
-    return TargetRegisterInfo::getRegAllocationHints(VirtReg, Order, Hints, MF,
-                                                     VRM);
+  default: {
+
+        BaseImplRetVal = TargetRegisterInfo::getRegAllocationHints(VirtReg, Order,
+                                                                   Hints, MF, VRM);
+        break;
+    }
   }
+
+  // Bank conflict avoidance for VGPRs
+  if (EnableVGPRBankConflictAvoidance && VRM && isVGPR(MRI, VirtReg)) {
+    // Track which banks are already in use by allocated operands
+    SmallDenseMap<unsigned, unsigned, 4> BankUsage; // bank_id -> use_count
+    bool HasRelevant3OpVALU = false;
+
+    // Scan all uses of this virtual register
+    for (const MachineInstr &Use : MRI.use_nodbg_instructions(VirtReg)) {
+      if (!is3OperandVALU(Use))
+        continue;
+
+      HasRelevant3OpVALU = true;
+
+      // Check which banks are used by other operands
+      for (const MachineOperand &MO : Use.uses()) {
+        if (!MO.isReg() || MO.getReg() == VirtReg)
+          continue;
+
+        Register OpReg = MO.getReg();
+
+        // Only care about already-allocated physical registers
+        if (OpReg.isVirtual()) {
+          if (VRM->hasPhys(OpReg))
+            OpReg = VRM->getPhys(OpReg);
+          else
+            continue;
+        }
+
+        if (OpReg.isPhysical() && isVGPR(MRI, OpReg)) {
+          unsigned Bank = getHWRegIndex(OpReg) % 4;
+          BankUsage[Bank]++;
+        }
+      }
+    }
+
+    if (HasRelevant3OpVALU && !BankUsage.empty()) {
+      constexpr unsigned MaxBankHints = 32; // Arbitrary limit to avoid excessive hints
+      unsigned Added = 0;
+
+      // Pass 1: conflict-free candidates (no operands on this bank)
+      for (MCPhysReg Cand : Order) {
+        if (Added >= MaxBankHints)
+          break;
+        unsigned CandBank = getHWRegIndex(Cand) % 4;
+        if (!BankUsage.count(CandBank)) {
+          Hints.push_back(Cand);
+          ++Added;
+        }
+      }
+
+      // Pass 2: moderate-conflict candidates (1 existing; 2-way conflict)
+      for (MCPhysReg Cand : Order) {
+        if (Added >= MaxBankHints)
+          break;
+        unsigned CandBank = getHWRegIndex(Cand) % 4;
+        auto It = BankUsage.find(CandBank);
+        if (It != BankUsage.end() && It->second < 2) {
+          Hints.push_back(Cand);
+          ++Added;
+        }
+      }
+      // 3-way conflicts (usage >= 2) are not hinted; the allocator falls
+      // back to Order naturally via AllocationOrder iteration.
+    }
+  }
+
+  return BaseImplRetVal;
 }
 
 MCRegister SIRegisterInfo::getReturnAddressReg(const MachineFunction &MF) const {

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -19,7 +19,6 @@
 #include "SIMachineFunctionInfo.h"
 #include "SIRegisterInfo.h"
 #include "llvm/CodeGen/LiveIntervals.h"
-#include "llvm/CodeGen/LiveRegMatrix.h"
 #include "llvm/CodeGen/LiveRegUnits.h"
 #include "llvm/CodeGen/MachineDominators.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
@@ -3859,24 +3858,102 @@ const int *SIRegisterInfo::getRegUnitPressureSets(MCRegUnit RegUnit) const {
   return AMDGPUGenRegisterInfo::getRegUnitPressureSets(RegUnit);
 }
 
-bool SIRegisterInfo::is3OperandVALU(const MachineInstr &MI) const {
+unsigned SIRegisterInfo::getVGPRBankIndex(MCRegister Reg) const {
+  return getHWRegIndex(Reg) % 4;
+}
+
+bool SIRegisterInfo::canHave3VGPROperands(const MachineInstr &MI) const {
   if (!SIInstrInfo::isVALU(MI))
     return false;
 
   const MCInstrDesc &Desc = MI.getDesc();
   const SIInstrInfo *TII = ST.getInstrInfo();
-  const MachineFunction &MF = *MI.getMF();
   unsigned NumVGPRSrcs = 0;
 
   // Count explicit source operands whose register class can hold VGPRs.
   // Skip defs (operands 0..NumDefs-1); only inspect use slots.
   for (unsigned i = Desc.getNumDefs(), e = Desc.getNumOperands(); i < e; ++i) {
     const TargetRegisterClass *OpRC = TII->getRegClass(Desc, i);
-    if (OpRC && hasVGPRs(OpRC))
-      ++NumVGPRSrcs;
+    if (OpRC && hasVGPRs(OpRC)) {
+      if (++NumVGPRSrcs >= 3)
+        return true;
+    }
   }
 
-  return NumVGPRSrcs >= 3;
+  return false;
+}
+
+void SIRegisterInfo::addVGPRBankConflictHints(Register VirtReg,
+                                              ArrayRef<MCPhysReg> Order,
+                                              SmallVectorImpl<MCPhysReg> &Hints,
+                                              const MachineFunction &MF,
+                                              const VirtRegMap *VRM) const {
+  const MachineRegisterInfo &MRI = MF.getRegInfo();
+  if (EnableVGPRBankConflictAvoidance && VRM && isVGPR(MRI, VirtReg)) {
+    // Track which banks are already in use by allocated operands
+    SmallDenseMap<unsigned, unsigned, 4> BankUsage; // bank_id -> use_count
+    bool HasRelevant3OpVALU = false;
+
+    // Scan all uses of this virtual register
+    for (const MachineInstr &Use : MRI.use_nodbg_instructions(VirtReg)) {
+      if (!canHave3VGPROperands(Use))
+        continue;
+
+      HasRelevant3OpVALU = true;
+
+      // Check which banks are used by other operands
+      for (const MachineOperand &MO : Use.uses()) {
+        if (!MO.isReg() || MO.getReg() == VirtReg)
+          continue;
+
+        Register OpReg = MO.getReg();
+
+        // Only care about already-allocated physical registers
+        if (OpReg.isVirtual()) {
+          if (VRM->hasPhys(OpReg))
+            OpReg = VRM->getPhys(OpReg);
+          else
+            continue;
+        }
+
+        if (OpReg.isPhysical() && isVGPR(MRI, OpReg)) {
+          unsigned Bank = getHWRegIndex(OpReg) % 4;
+          BankUsage[Bank]++;
+        }
+      }
+    }
+
+    if (HasRelevant3OpVALU && !BankUsage.empty()) {
+      constexpr unsigned MaxBankHints =
+          32; // Arbitrary limit to avoid excessive hints
+      unsigned Added = 0;
+
+      // Pass 1: conflict-free candidates (no operands on this bank)
+      for (MCPhysReg Cand : Order) {
+        if (Added >= MaxBankHints)
+          break;
+        unsigned CandBank = getVGPRBankIndex(Cand);
+        if (!BankUsage.count(CandBank)) {
+          Hints.push_back(Cand);
+          ++Added;
+        }
+      }
+
+      // Pass 2: moderate-conflict candidates (1 existing; 2-way conflict)
+      for (MCPhysReg Cand : Order) {
+        if (Added >= MaxBankHints)
+          break;
+        unsigned CandBank = getVGPRBankIndex(Cand);
+        auto It = BankUsage.find(CandBank);
+        if (It != BankUsage.end() && It->second < 2) {
+          Hints.push_back(Cand);
+          ++Added;
+        }
+      }
+      // 3-way conflicts (usage >= 2) are not hinted; the allocator falls
+      // back to Order naturally via AllocationOrder iteration.
+    }
+  }
 }
 
 bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
@@ -3910,7 +3987,6 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
       // isLo(Paired) is implicitly true here from the API of
       // getMatchingSuperReg.
       Hints.push_back(PairedPhys);
-    BaseImplRetVal = false;
     break;
   }
   case AMDGPURI::Size16: {
@@ -3940,7 +4016,6 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
           Hints.push_back(PhysReg);
       }
     }
-    BaseImplRetVal = false;
     break;
   }
   default: {
@@ -3952,70 +4027,7 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
   }
 
   // Bank conflict avoidance for VGPRs
-  if (EnableVGPRBankConflictAvoidance && VRM && isVGPR(MRI, VirtReg)) {
-    // Track which banks are already in use by allocated operands
-    SmallDenseMap<unsigned, unsigned, 4> BankUsage; // bank_id -> use_count
-    bool HasRelevant3OpVALU = false;
-
-    // Scan all uses of this virtual register
-    for (const MachineInstr &Use : MRI.use_nodbg_instructions(VirtReg)) {
-      if (!is3OperandVALU(Use))
-        continue;
-
-      HasRelevant3OpVALU = true;
-
-      // Check which banks are used by other operands
-      for (const MachineOperand &MO : Use.uses()) {
-        if (!MO.isReg() || MO.getReg() == VirtReg)
-          continue;
-
-        Register OpReg = MO.getReg();
-
-        // Only care about already-allocated physical registers
-        if (OpReg.isVirtual()) {
-          if (VRM->hasPhys(OpReg))
-            OpReg = VRM->getPhys(OpReg);
-          else
-            continue;
-        }
-
-        if (OpReg.isPhysical() && isVGPR(MRI, OpReg)) {
-          unsigned Bank = getHWRegIndex(OpReg) % 4;
-          BankUsage[Bank]++;
-        }
-      }
-    }
-
-    if (HasRelevant3OpVALU && !BankUsage.empty()) {
-      constexpr unsigned MaxBankHints = 32; // Arbitrary limit to avoid excessive hints
-      unsigned Added = 0;
-
-      // Pass 1: conflict-free candidates (no operands on this bank)
-      for (MCPhysReg Cand : Order) {
-        if (Added >= MaxBankHints)
-          break;
-        unsigned CandBank = getHWRegIndex(Cand) % 4;
-        if (!BankUsage.count(CandBank)) {
-          Hints.push_back(Cand);
-          ++Added;
-        }
-      }
-
-      // Pass 2: moderate-conflict candidates (1 existing; 2-way conflict)
-      for (MCPhysReg Cand : Order) {
-        if (Added >= MaxBankHints)
-          break;
-        unsigned CandBank = getHWRegIndex(Cand) % 4;
-        auto It = BankUsage.find(CandBank);
-        if (It != BankUsage.end() && It->second < 2) {
-          Hints.push_back(Cand);
-          ++Added;
-        }
-      }
-      // 3-way conflicts (usage >= 2) are not hinted; the allocator falls
-      // back to Order naturally via AllocationOrder iteration.
-    }
-  }
+  addVGPRBankConflictHints(VirtReg, Order, Hints, MF, VRM);
 
   return BaseImplRetVal;
 }

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -3889,70 +3889,68 @@ void SIRegisterInfo::addVGPRBankConflictHints(Register VirtReg,
                                               const MachineFunction &MF,
                                               const VirtRegMap *VRM) const {
   const MachineRegisterInfo &MRI = MF.getRegInfo();
-  if (EnableVGPRBankConflictAvoidance && VRM && isVGPR(MRI, VirtReg)) {
-    // Track which banks are already in use by allocated operands
-    SmallDenseMap<unsigned, unsigned, 4> BankUsage; // bank_id -> use_count
-    bool HasRelevant3OpVALU = false;
+  if (!EnableVGPRBankConflictAvoidance || !VRM || !isVGPR(MRI, VirtReg))
+    return;
 
-    // Scan all uses of this virtual register
-    for (const MachineInstr &Use : MRI.use_nodbg_instructions(VirtReg)) {
-      if (!canHave3VGPROperands(Use))
+  // Track which banks are already in use by allocated operands
+  SmallDenseMap<unsigned, unsigned, 4> BankUsage; // bank_id -> use_count
+  bool HasRelevant3OpVALU = false;
+
+  // Scan all uses of this virtual register
+  for (const MachineInstr &Use : MRI.use_nodbg_instructions(VirtReg)) {
+    if (!canHave3VGPROperands(Use))
+      continue;
+
+    HasRelevant3OpVALU = true;
+
+    // Check which banks are used by other operands
+    for (const MachineOperand &MO : Use.uses()) {
+      if (!MO.isReg() || MO.getReg() == VirtReg)
         continue;
 
-      HasRelevant3OpVALU = true;
+      Register OpReg = MO.getReg();
 
-      // Check which banks are used by other operands
-      for (const MachineOperand &MO : Use.uses()) {
-        if (!MO.isReg() || MO.getReg() == VirtReg)
-          continue;
+      // Only care about already-allocated physical registers
+      if (!OpReg.isVirtual() || !VRM->hasPhys(OpReg))
+        continue;
+      OpReg = VRM->getPhys(OpReg);
 
-        Register OpReg = MO.getReg();
+      if (OpReg.isPhysical() && isVGPR(MRI, OpReg)) {
+        unsigned Bank = getHWRegIndex(OpReg) % 4;
+        BankUsage[Bank]++;
+      }
+    }
+  }
 
-        // Only care about already-allocated physical registers
-        if (OpReg.isVirtual()) {
-          if (VRM->hasPhys(OpReg))
-            OpReg = VRM->getPhys(OpReg);
-          else
-            continue;
-        }
+  if (HasRelevant3OpVALU && !BankUsage.empty()) {
+    constexpr unsigned MaxBankHints =
+        32; // Arbitrary limit to avoid excessive hints
+    unsigned Added = 0;
 
-        if (OpReg.isPhysical() && isVGPR(MRI, OpReg)) {
-          unsigned Bank = getHWRegIndex(OpReg) % 4;
-          BankUsage[Bank]++;
-        }
+    // Pass 1: conflict-free candidates (no operands on this bank)
+    for (MCPhysReg Cand : Order) {
+      if (Added >= MaxBankHints)
+        break;
+      unsigned CandBank = getVGPRBankIndex(Cand);
+      if (!BankUsage.count(CandBank)) {
+        Hints.push_back(Cand);
+        ++Added;
       }
     }
 
-    if (HasRelevant3OpVALU && !BankUsage.empty()) {
-      constexpr unsigned MaxBankHints =
-          32; // Arbitrary limit to avoid excessive hints
-      unsigned Added = 0;
-
-      // Pass 1: conflict-free candidates (no operands on this bank)
-      for (MCPhysReg Cand : Order) {
-        if (Added >= MaxBankHints)
-          break;
-        unsigned CandBank = getVGPRBankIndex(Cand);
-        if (!BankUsage.count(CandBank)) {
-          Hints.push_back(Cand);
-          ++Added;
-        }
+    // Pass 2: moderate-conflict candidates (1 existing; 2-way conflict)
+    for (MCPhysReg Cand : Order) {
+      if (Added >= MaxBankHints)
+        break;
+      unsigned CandBank = getVGPRBankIndex(Cand);
+      auto It = BankUsage.find(CandBank);
+      if (It != BankUsage.end() && It->second < 2) {
+        Hints.push_back(Cand);
+        ++Added;
       }
-
-      // Pass 2: moderate-conflict candidates (1 existing; 2-way conflict)
-      for (MCPhysReg Cand : Order) {
-        if (Added >= MaxBankHints)
-          break;
-        unsigned CandBank = getVGPRBankIndex(Cand);
-        auto It = BankUsage.find(CandBank);
-        if (It != BankUsage.end() && It->second < 2) {
-          Hints.push_back(Cand);
-          ++Added;
-        }
-      }
-      // 3-way conflicts (usage >= 2) are not hinted; the allocator falls
-      // back to Order naturally via AllocationOrder iteration.
     }
+    // 3-way conflicts (usage >= 2) are not hinted; the allocator falls
+    // back to Order naturally via AllocationOrder iteration.
   }
 }
 

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -19,7 +19,6 @@
 #include "SIMachineFunctionInfo.h"
 #include "SIRegisterInfo.h"
 #include "llvm/CodeGen/LiveIntervals.h"
-#include "llvm/CodeGen/LiveRegMatrix.h"
 #include "llvm/CodeGen/LiveRegUnits.h"
 #include "llvm/CodeGen/MachineDominators.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
@@ -4104,24 +4103,102 @@ const int *SIRegisterInfo::getRegUnitPressureSets(MCRegUnit RegUnit) const {
   return AMDGPUGenRegisterInfo::getRegUnitPressureSets(RegUnit);
 }
 
-bool SIRegisterInfo::is3OperandVALU(const MachineInstr &MI) const {
+unsigned SIRegisterInfo::getVGPRBankIndex(MCRegister Reg) const {
+  return getHWRegIndex(Reg) % 4;
+}
+
+bool SIRegisterInfo::canHave3VGPROperands(const MachineInstr &MI) const {
   if (!SIInstrInfo::isVALU(MI))
     return false;
 
   const MCInstrDesc &Desc = MI.getDesc();
   const SIInstrInfo *TII = ST.getInstrInfo();
-  const MachineFunction &MF = *MI.getMF();
   unsigned NumVGPRSrcs = 0;
 
   // Count explicit source operands whose register class can hold VGPRs.
   // Skip defs (operands 0..NumDefs-1); only inspect use slots.
   for (unsigned i = Desc.getNumDefs(), e = Desc.getNumOperands(); i < e; ++i) {
     const TargetRegisterClass *OpRC = TII->getRegClass(Desc, i);
-    if (OpRC && hasVGPRs(OpRC))
-      ++NumVGPRSrcs;
+    if (OpRC && hasVGPRs(OpRC)) {
+      if (++NumVGPRSrcs >= 3)
+        return true;
+    }
   }
 
-  return NumVGPRSrcs >= 3;
+  return false;
+}
+
+void SIRegisterInfo::addVGPRBankConflictHints(Register VirtReg,
+                                              ArrayRef<MCPhysReg> Order,
+                                              SmallVectorImpl<MCPhysReg> &Hints,
+                                              const MachineFunction &MF,
+                                              const VirtRegMap *VRM) const {
+  const MachineRegisterInfo &MRI = MF.getRegInfo();
+  if (EnableVGPRBankConflictAvoidance && VRM && isVGPR(MRI, VirtReg)) {
+    // Track which banks are already in use by allocated operands
+    SmallDenseMap<unsigned, unsigned, 4> BankUsage; // bank_id -> use_count
+    bool HasRelevant3OpVALU = false;
+
+    // Scan all uses of this virtual register
+    for (const MachineInstr &Use : MRI.use_nodbg_instructions(VirtReg)) {
+      if (!canHave3VGPROperands(Use))
+        continue;
+
+      HasRelevant3OpVALU = true;
+
+      // Check which banks are used by other operands
+      for (const MachineOperand &MO : Use.uses()) {
+        if (!MO.isReg() || MO.getReg() == VirtReg)
+          continue;
+
+        Register OpReg = MO.getReg();
+
+        // Only care about already-allocated physical registers
+        if (OpReg.isVirtual()) {
+          if (VRM->hasPhys(OpReg))
+            OpReg = VRM->getPhys(OpReg);
+          else
+            continue;
+        }
+
+        if (OpReg.isPhysical() && isVGPR(MRI, OpReg)) {
+          unsigned Bank = getHWRegIndex(OpReg) % 4;
+          BankUsage[Bank]++;
+        }
+      }
+    }
+
+    if (HasRelevant3OpVALU && !BankUsage.empty()) {
+      constexpr unsigned MaxBankHints =
+          32; // Arbitrary limit to avoid excessive hints
+      unsigned Added = 0;
+
+      // Pass 1: conflict-free candidates (no operands on this bank)
+      for (MCPhysReg Cand : Order) {
+        if (Added >= MaxBankHints)
+          break;
+        unsigned CandBank = getVGPRBankIndex(Cand);
+        if (!BankUsage.count(CandBank)) {
+          Hints.push_back(Cand);
+          ++Added;
+        }
+      }
+
+      // Pass 2: moderate-conflict candidates (1 existing; 2-way conflict)
+      for (MCPhysReg Cand : Order) {
+        if (Added >= MaxBankHints)
+          break;
+        unsigned CandBank = getVGPRBankIndex(Cand);
+        auto It = BankUsage.find(CandBank);
+        if (It != BankUsage.end() && It->second < 2) {
+          Hints.push_back(Cand);
+          ++Added;
+        }
+      }
+      // 3-way conflicts (usage >= 2) are not hinted; the allocator falls
+      // back to Order naturally via AllocationOrder iteration.
+    }
+  }
 }
 
 bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
@@ -4155,7 +4232,6 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
       // isLo(Paired) is implicitly true here from the API of
       // getMatchingSuperReg.
       Hints.push_back(PairedPhys);
-    BaseImplRetVal = false;
     break;
   }
   case AMDGPURI::Size16: {
@@ -4185,7 +4261,6 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
           Hints.push_back(PhysReg);
       }
     }
-    BaseImplRetVal = false;
     break;
   }
   default: {
@@ -4197,70 +4272,7 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
   }
 
   // Bank conflict avoidance for VGPRs
-  if (EnableVGPRBankConflictAvoidance && VRM && isVGPR(MRI, VirtReg)) {
-    // Track which banks are already in use by allocated operands
-    SmallDenseMap<unsigned, unsigned, 4> BankUsage; // bank_id -> use_count
-    bool HasRelevant3OpVALU = false;
-
-    // Scan all uses of this virtual register
-    for (const MachineInstr &Use : MRI.use_nodbg_instructions(VirtReg)) {
-      if (!is3OperandVALU(Use))
-        continue;
-
-      HasRelevant3OpVALU = true;
-
-      // Check which banks are used by other operands
-      for (const MachineOperand &MO : Use.uses()) {
-        if (!MO.isReg() || MO.getReg() == VirtReg)
-          continue;
-
-        Register OpReg = MO.getReg();
-
-        // Only care about already-allocated physical registers
-        if (OpReg.isVirtual()) {
-          if (VRM->hasPhys(OpReg))
-            OpReg = VRM->getPhys(OpReg);
-          else
-            continue;
-        }
-
-        if (OpReg.isPhysical() && isVGPR(MRI, OpReg)) {
-          unsigned Bank = getHWRegIndex(OpReg) % 4;
-          BankUsage[Bank]++;
-        }
-      }
-    }
-
-    if (HasRelevant3OpVALU && !BankUsage.empty()) {
-      constexpr unsigned MaxBankHints = 32; // Arbitrary limit to avoid excessive hints
-      unsigned Added = 0;
-
-      // Pass 1: conflict-free candidates (no operands on this bank)
-      for (MCPhysReg Cand : Order) {
-        if (Added >= MaxBankHints)
-          break;
-        unsigned CandBank = getHWRegIndex(Cand) % 4;
-        if (!BankUsage.count(CandBank)) {
-          Hints.push_back(Cand);
-          ++Added;
-        }
-      }
-
-      // Pass 2: moderate-conflict candidates (1 existing; 2-way conflict)
-      for (MCPhysReg Cand : Order) {
-        if (Added >= MaxBankHints)
-          break;
-        unsigned CandBank = getHWRegIndex(Cand) % 4;
-        auto It = BankUsage.find(CandBank);
-        if (It != BankUsage.end() && It->second < 2) {
-          Hints.push_back(Cand);
-          ++Added;
-        }
-      }
-      // 3-way conflicts (usage >= 2) are not hinted; the allocator falls
-      // back to Order naturally via AllocationOrder iteration.
-    }
-  }
+  addVGPRBankConflictHints(VirtReg, Order, Hints, MF, VRM);
 
   return BaseImplRetVal;
 }

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -4134,70 +4134,68 @@ void SIRegisterInfo::addVGPRBankConflictHints(Register VirtReg,
                                               const MachineFunction &MF,
                                               const VirtRegMap *VRM) const {
   const MachineRegisterInfo &MRI = MF.getRegInfo();
-  if (EnableVGPRBankConflictAvoidance && VRM && isVGPR(MRI, VirtReg)) {
-    // Track which banks are already in use by allocated operands
-    SmallDenseMap<unsigned, unsigned, 4> BankUsage; // bank_id -> use_count
-    bool HasRelevant3OpVALU = false;
+  if (!EnableVGPRBankConflictAvoidance || !VRM || !isVGPR(MRI, VirtReg))
+    return;
 
-    // Scan all uses of this virtual register
-    for (const MachineInstr &Use : MRI.use_nodbg_instructions(VirtReg)) {
-      if (!canHave3VGPROperands(Use))
+  // Track which banks are already in use by allocated operands
+  SmallDenseMap<unsigned, unsigned, 4> BankUsage; // bank_id -> use_count
+  bool HasRelevant3OpVALU = false;
+
+  // Scan all uses of this virtual register
+  for (const MachineInstr &Use : MRI.use_nodbg_instructions(VirtReg)) {
+    if (!canHave3VGPROperands(Use))
+      continue;
+
+    HasRelevant3OpVALU = true;
+
+    // Check which banks are used by other operands
+    for (const MachineOperand &MO : Use.uses()) {
+      if (!MO.isReg() || MO.getReg() == VirtReg)
         continue;
 
-      HasRelevant3OpVALU = true;
+      Register OpReg = MO.getReg();
 
-      // Check which banks are used by other operands
-      for (const MachineOperand &MO : Use.uses()) {
-        if (!MO.isReg() || MO.getReg() == VirtReg)
-          continue;
+      // Only care about already-allocated physical registers
+      if (!OpReg.isVirtual() || !VRM->hasPhys(OpReg))
+        continue;
+      OpReg = VRM->getPhys(OpReg);
 
-        Register OpReg = MO.getReg();
+      if (OpReg.isPhysical() && isVGPR(MRI, OpReg)) {
+        unsigned Bank = getHWRegIndex(OpReg) % 4;
+        BankUsage[Bank]++;
+      }
+    }
+  }
 
-        // Only care about already-allocated physical registers
-        if (OpReg.isVirtual()) {
-          if (VRM->hasPhys(OpReg))
-            OpReg = VRM->getPhys(OpReg);
-          else
-            continue;
-        }
+  if (HasRelevant3OpVALU && !BankUsage.empty()) {
+    constexpr unsigned MaxBankHints =
+        32; // Arbitrary limit to avoid excessive hints
+    unsigned Added = 0;
 
-        if (OpReg.isPhysical() && isVGPR(MRI, OpReg)) {
-          unsigned Bank = getHWRegIndex(OpReg) % 4;
-          BankUsage[Bank]++;
-        }
+    // Pass 1: conflict-free candidates (no operands on this bank)
+    for (MCPhysReg Cand : Order) {
+      if (Added >= MaxBankHints)
+        break;
+      unsigned CandBank = getVGPRBankIndex(Cand);
+      if (!BankUsage.count(CandBank)) {
+        Hints.push_back(Cand);
+        ++Added;
       }
     }
 
-    if (HasRelevant3OpVALU && !BankUsage.empty()) {
-      constexpr unsigned MaxBankHints =
-          32; // Arbitrary limit to avoid excessive hints
-      unsigned Added = 0;
-
-      // Pass 1: conflict-free candidates (no operands on this bank)
-      for (MCPhysReg Cand : Order) {
-        if (Added >= MaxBankHints)
-          break;
-        unsigned CandBank = getVGPRBankIndex(Cand);
-        if (!BankUsage.count(CandBank)) {
-          Hints.push_back(Cand);
-          ++Added;
-        }
+    // Pass 2: moderate-conflict candidates (1 existing; 2-way conflict)
+    for (MCPhysReg Cand : Order) {
+      if (Added >= MaxBankHints)
+        break;
+      unsigned CandBank = getVGPRBankIndex(Cand);
+      auto It = BankUsage.find(CandBank);
+      if (It != BankUsage.end() && It->second < 2) {
+        Hints.push_back(Cand);
+        ++Added;
       }
-
-      // Pass 2: moderate-conflict candidates (1 existing; 2-way conflict)
-      for (MCPhysReg Cand : Order) {
-        if (Added >= MaxBankHints)
-          break;
-        unsigned CandBank = getVGPRBankIndex(Cand);
-        auto It = BankUsage.find(CandBank);
-        if (It != BankUsage.end() && It->second < 2) {
-          Hints.push_back(Cand);
-          ++Added;
-        }
-      }
-      // 3-way conflicts (usage >= 2) are not hinted; the allocator falls
-      // back to Order naturally via AllocationOrder iteration.
     }
+    // 3-way conflicts (usage >= 2) are not hinted; the allocator falls
+    // back to Order naturally via AllocationOrder iteration.
   }
 }
 

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -19,6 +19,7 @@
 #include "SIMachineFunctionInfo.h"
 #include "SIRegisterInfo.h"
 #include "llvm/CodeGen/LiveIntervals.h"
+#include "llvm/CodeGen/LiveRegMatrix.h"
 #include "llvm/CodeGen/LiveRegUnits.h"
 #include "llvm/CodeGen/MachineDominators.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
@@ -51,6 +52,11 @@ static cl::opt<unsigned> StressAGPRLimit(
 static cl::opt<unsigned> StressSGPRLimit(
     "amdgpu-stress-sgpr", cl::Hidden, cl::init(0),
     cl::desc("Limit SGPRs to N registers by reserving the rest"));
+
+static cl::opt<bool> EnableVGPRBankConflictAvoidance(
+    "amdgpu-avoid-vgpr-bank-conflicts",
+    cl::desc("Enable VGPR bank conflict avoidance in register allocation"),
+    cl::init(false), cl::Hidden);
 
 std::array<std::vector<int16_t>, 32> SIRegisterInfo::RegSplitParts;
 std::array<std::array<uint16_t, 32>, 9> SIRegisterInfo::SubRegFromChannelTable;
@@ -4098,6 +4104,26 @@ const int *SIRegisterInfo::getRegUnitPressureSets(MCRegUnit RegUnit) const {
   return AMDGPUGenRegisterInfo::getRegUnitPressureSets(RegUnit);
 }
 
+bool SIRegisterInfo::is3OperandVALU(const MachineInstr &MI) const {
+  if (!SIInstrInfo::isVALU(MI))
+    return false;
+
+  const MCInstrDesc &Desc = MI.getDesc();
+  const SIInstrInfo *TII = ST.getInstrInfo();
+  const MachineFunction &MF = *MI.getMF();
+  unsigned NumVGPRSrcs = 0;
+
+  // Count explicit source operands whose register class can hold VGPRs.
+  // Skip defs (operands 0..NumDefs-1); only inspect use slots.
+  for (unsigned i = Desc.getNumDefs(), e = Desc.getNumOperands(); i < e; ++i) {
+    const TargetRegisterClass *OpRC = TII->getRegClass(Desc, i);
+    if (OpRC && hasVGPRs(OpRC))
+      ++NumVGPRSrcs;
+  }
+
+  return NumVGPRSrcs >= 3;
+}
+
 bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
                                            ArrayRef<MCPhysReg> Order,
                                            SmallVectorImpl<MCPhysReg> &Hints,
@@ -4110,6 +4136,7 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
 
   std::pair<unsigned, Register> Hint = MRI.getRegAllocationHint(VirtReg);
 
+  bool BaseImplRetVal = false;
   switch (Hint.first) {
   case AMDGPURI::Size32: {
     Register Paired = Hint.second;
@@ -4128,7 +4155,8 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
       // isLo(Paired) is implicitly true here from the API of
       // getMatchingSuperReg.
       Hints.push_back(PairedPhys);
-    return false;
+    BaseImplRetVal = false;
+    break;
   }
   case AMDGPURI::Size16: {
     Register Paired = Hint.second;
@@ -4157,12 +4185,84 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
           Hints.push_back(PhysReg);
       }
     }
-    return false;
+    BaseImplRetVal = false;
+    break;
   }
-  default:
-    return TargetRegisterInfo::getRegAllocationHints(VirtReg, Order, Hints, MF,
-                                                     VRM);
+  default: {
+
+        BaseImplRetVal = TargetRegisterInfo::getRegAllocationHints(VirtReg, Order,
+                                                                   Hints, MF, VRM);
+        break;
+    }
   }
+
+  // Bank conflict avoidance for VGPRs
+  if (EnableVGPRBankConflictAvoidance && VRM && isVGPR(MRI, VirtReg)) {
+    // Track which banks are already in use by allocated operands
+    SmallDenseMap<unsigned, unsigned, 4> BankUsage; // bank_id -> use_count
+    bool HasRelevant3OpVALU = false;
+
+    // Scan all uses of this virtual register
+    for (const MachineInstr &Use : MRI.use_nodbg_instructions(VirtReg)) {
+      if (!is3OperandVALU(Use))
+        continue;
+
+      HasRelevant3OpVALU = true;
+
+      // Check which banks are used by other operands
+      for (const MachineOperand &MO : Use.uses()) {
+        if (!MO.isReg() || MO.getReg() == VirtReg)
+          continue;
+
+        Register OpReg = MO.getReg();
+
+        // Only care about already-allocated physical registers
+        if (OpReg.isVirtual()) {
+          if (VRM->hasPhys(OpReg))
+            OpReg = VRM->getPhys(OpReg);
+          else
+            continue;
+        }
+
+        if (OpReg.isPhysical() && isVGPR(MRI, OpReg)) {
+          unsigned Bank = getHWRegIndex(OpReg) % 4;
+          BankUsage[Bank]++;
+        }
+      }
+    }
+
+    if (HasRelevant3OpVALU && !BankUsage.empty()) {
+      constexpr unsigned MaxBankHints = 32; // Arbitrary limit to avoid excessive hints
+      unsigned Added = 0;
+
+      // Pass 1: conflict-free candidates (no operands on this bank)
+      for (MCPhysReg Cand : Order) {
+        if (Added >= MaxBankHints)
+          break;
+        unsigned CandBank = getHWRegIndex(Cand) % 4;
+        if (!BankUsage.count(CandBank)) {
+          Hints.push_back(Cand);
+          ++Added;
+        }
+      }
+
+      // Pass 2: moderate-conflict candidates (1 existing; 2-way conflict)
+      for (MCPhysReg Cand : Order) {
+        if (Added >= MaxBankHints)
+          break;
+        unsigned CandBank = getHWRegIndex(Cand) % 4;
+        auto It = BankUsage.find(CandBank);
+        if (It != BankUsage.end() && It->second < 2) {
+          Hints.push_back(Cand);
+          ++Added;
+        }
+      }
+      // 3-way conflicts (usage >= 2) are not hinted; the allocator falls
+      // back to Order naturally via AllocationOrder iteration.
+    }
+  }
+
+  return BaseImplRetVal;
 }
 
 MCRegister SIRegisterInfo::getReturnAddressReg(const MachineFunction &MF) const {

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -4111,14 +4111,12 @@ unsigned SIRegisterInfo::getVGPRBankIndex(MCRegister Reg) const {
   return getHWRegIndex(Reg) % NumVGPRBanks;
 }
 
-void SIRegisterInfo::addVGPRBankConflictHints(Register VirtReg,
-                                              ArrayRef<MCPhysReg> Order,
-                                              SmallVectorImpl<MCPhysReg> &Hints,
-                                              const MachineFunction &MF,
-                                              const VirtRegMap *VRM) const {
+unsigned SIRegisterInfo::getCoOpndsFreeVGPRBankMask(Register VirtReg,
+                                                    const MachineFunction &MF,
+                                                    const VirtRegMap *VRM) const {
   const MachineRegisterInfo &MRI = MF.getRegInfo();
   if (!EnableVGPRBankConflictAvoidance || !VRM || !isVGPR(MRI, VirtReg))
-    return;
+    return 0;
 
   // Track banks use count by allocated operands of VirtReg uses.
   // Key is bank index, value is number of operands using that bank.
@@ -4144,19 +4142,156 @@ void SIRegisterInfo::addVGPRBankConflictHints(Register VirtReg,
   }
 
   if (BankUsage.empty())
-    return;
-  constexpr unsigned MaxBankHints =
-      64; // Arbitrary limit to avoid excessive hints
-  unsigned Added = 0;
+    return 0;
 
-  //Hint conflict-free candidates (no operands on this bank)
-  for (MCPhysReg Cand : Order) {
-    if (Added >= MaxBankHints)
-      break;
-    if (BankUsage.count(getVGPRBankIndex(Cand)))
+  unsigned BankUsageMask = 0;
+    for (const auto &Bank : BankUsage) {
+      if (Bank.second > 0)
+        BankUsageMask |= 1 << Bank.first;
+    }
+    return ~BankUsageMask & ((1 << NumVGPRBanks) - 1);
+}
+
+static bool isVopdPairable(const MachineInstr &Def,
+                                    const MachineInstr &Neighbor,
+                                    const MachineFunction &MF,
+                                    AMDGPU::CanBeVOPD DefCanBeVOPD) {
+  const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
+
+  // Both instructions must be VOPD-eligible opcodes.
+  auto NeighborCanBeVOPD = AMDGPU::getCanBeVOPD(
+      Neighbor.getOpcode(), AMDGPU::getVOPDEncodingFamily(ST), ST.hasVOPD3());
+  if (!(DefCanBeVOPD.X && NeighborCanBeVOPD.Y) &&
+        !(DefCanBeVOPD.Y && NeighborCanBeVOPD.X))
+    return false;
+
+  // No DPP modifiers allowed.
+  if (Def.getDesc().TSFlags & SIInstrFlags::DPP)
+    return false;
+  if (Neighbor.getDesc().TSFlags & SIInstrFlags::DPP)
+    return false;
+
+  // OPX must not write any register read by OPY.
+  if (DefCanBeVOPD.X && NeighborCanBeVOPD.Y) {
+    Register NeighborDest = Neighbor.getOperand(0).getReg();
+    for (const MachineOperand &MO : Def.uses()) {
+      if (MO.isReg() && MO.getReg() == NeighborDest)
+        return false;
+    }
+  } else if (DefCanBeVOPD.Y && NeighborCanBeVOPD.X) {
+    Register DefDest = Def.getOperand(0).getReg();
+    for (const MachineOperand &MO : Neighbor.uses()) {
+      if (MO.isReg() && MO.getReg() == DefDest)
+        return false;
+    }
+  }
+
+  return true;
+}
+
+unsigned SIRegisterInfo::getVGPRBankParityMask(Register VirtReg,
+                                                     const MachineFunction &MF,
+                                                     const VirtRegMap *VRM) const {
+  const MachineRegisterInfo &MRI = MF.getRegInfo();
+  // VOPD is wave32 only.
+  if (ST.isWave64())
+    return 0;
+  if (!EnableVGPRBankConflictAvoidance || !VRM || !isVGPR(MRI, VirtReg))
+    return 0;
+
+  unsigned EvenParityBias = 0;
+  unsigned OddParityBias = 0;
+
+  for (const MachineInstr &Def : MRI.def_instructions(VirtReg)) {
+    auto DefCanBeVOPD = AMDGPU::getCanBeVOPD(
+        Def.getOpcode(), AMDGPU::getVOPDEncodingFamily(ST), ST.hasVOPD3());
+    if (!DefCanBeVOPD.X && !DefCanBeVOPD.Y)
       continue;
-    Hints.push_back(Cand);
-    ++Added;
+
+    unsigned InstCount = 0;
+    for (auto I = Def.getIterator();
+         I != Def.getParent()->begin() && InstCount < 4; --I, ++InstCount) {
+      if (!SIInstrInfo::isVALU(*I, false))
+        continue;
+      // Skip instructions that cannot be paired with the Def instruction
+      // to form a VOPD.
+      if (!isVopdPairable(Def, *I, MF, DefCanBeVOPD))
+        continue;
+      const MachineOperand &Dst = I->getOperand(0);
+      if (!Dst.isReg())
+        continue;
+      Register Reg = Dst.getReg();
+      if (Reg.isVirtual()) {
+        if (!VRM->hasPhys(Reg))
+          continue;
+        Reg = VRM->getPhys(Reg);
+      }
+      if (!Reg.isPhysical() || !isVGPR(MRI, Reg))
+        continue;
+      // Encourage pairing vop3 instructions together
+      if (SIInstrInfo::isVOP3(Def) != SIInstrInfo::isVOP3(*I))
+        continue;
+      unsigned Bank = getVGPRBankIndex(Reg);
+      // Bias towards the inverse destination parity
+      if (Bank % 2 == 0)
+        OddParityBias++;
+      else
+        EvenParityBias++;
+      // Stop at the first pairable instruction
+      break;
+    }
+  }
+  if (EvenParityBias == 0 && OddParityBias == 0)
+    return 0;
+  return (EvenParityBias > OddParityBias)
+             ? 0x5555 & ((1 << NumVGPRBanks) - 1)
+             : 0xaaaa & ((1 << NumVGPRBanks) - 1);
+}
+
+void SIRegisterInfo::appendRAHintsForConflictAndOverlapAvoidance(
+    ArrayRef<MCPhysReg> Order,SmallVectorImpl<MCPhysReg> &Hints,
+    unsigned BankMinConflictMask,unsigned BankMinOverlapMask) const{
+  if (!BankMinConflictMask && !BankMinOverlapMask)
+    return;
+  // Append registers that has least bank conflict and parity overlap
+  // to the end of the hints list.
+  const unsigned MaxNumHints = 32;
+  unsigned Added = 0;
+  for (MCPhysReg Cand : Order) {
+    if (Added >= MaxNumHints)
+      break;
+
+    if ((BankMinConflictMask & (1 << getVGPRBankIndex(Cand))) &&
+        (BankMinOverlapMask & (1 << getVGPRBankIndex(Cand)))) {
+      Hints.push_back(Cand);
+      Added++;
+    }
+  }
+  // Next prefer registers that are least possible to overlap in
+  // a way that prevents vopd pairing. No duplicates.
+  for (MCPhysReg Cand : Order) {
+    if (!BankMinOverlapMask)
+      break;
+    if (Added >= MaxNumHints)
+      break;
+    if (!(BankMinConflictMask & (1 << getVGPRBankIndex(Cand))) &&
+        (BankMinOverlapMask & (1 << getVGPRBankIndex(Cand)))) {
+      Hints.push_back(Cand);
+      Added++;
+    }
+  }
+  // Finally prefer registers that are least possible to cause bank conflicts,
+  // No duplicates.
+  for (MCPhysReg Cand : Order) {
+    if (!BankMinConflictMask)
+      break;
+    if (Added >= MaxNumHints)
+      break;
+    if ((BankMinConflictMask & (1 << getVGPRBankIndex(Cand))) &&
+        !(BankMinOverlapMask & (1 << getVGPRBankIndex(Cand)))) {
+      Hints.push_back(Cand);
+      Added++;
+    }
   }
 }
 
@@ -4230,8 +4365,14 @@ bool SIRegisterInfo::getRegAllocationHints(Register VirtReg,
     }
   }
 
-  // Bank conflict avoidance for VGPRs
-  addVGPRBankConflictHints(VirtReg, Order, Hints, MF, VRM);
+  // Bank conflict-free for VGPR source operands in the same instruction.
+  unsigned BankMinConflictMask = getCoOpndsFreeVGPRBankMask(VirtReg, MF, VRM);
+
+  // Bank overlap reduction for vopd pairing
+  unsigned BankMinOverlapMask = getVGPRBankParityMask(VirtReg, MF, VRM);
+
+  // Append the least bank conflict/overlap register to the end of the hints list.
+  appendRAHintsForConflictAndOverlapAvoidance(Order, Hints, BankMinConflictMask, BankMinOverlapMask);
 
   return BaseImplRetVal;
 }

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -55,7 +55,11 @@ static cl::opt<unsigned> StressSGPRLimit(
 static cl::opt<bool> EnableVGPRBankConflictAvoidance(
     "amdgpu-avoid-vgpr-bank-conflicts",
     cl::desc("Enable VGPR bank conflict avoidance in register allocation"),
-    cl::init(false), cl::Hidden);
+    cl::init(true), cl::Hidden);
+
+// AMDGPU organizes VGPRs into banks selected by the low bits of the register
+// index.
+static constexpr unsigned NumVGPRBanks = 4;
 
 std::array<std::vector<int16_t>, 32> SIRegisterInfo::RegSplitParts;
 std::array<std::array<uint16_t, 32>, 9> SIRegisterInfo::SubRegFromChannelTable;
@@ -4104,28 +4108,7 @@ const int *SIRegisterInfo::getRegUnitPressureSets(MCRegUnit RegUnit) const {
 }
 
 unsigned SIRegisterInfo::getVGPRBankIndex(MCRegister Reg) const {
-  return getHWRegIndex(Reg) % 4;
-}
-
-bool SIRegisterInfo::canHave3VGPROperands(const MachineInstr &MI) const {
-  if (!SIInstrInfo::isVALU(MI))
-    return false;
-
-  const MCInstrDesc &Desc = MI.getDesc();
-  const SIInstrInfo *TII = ST.getInstrInfo();
-  unsigned NumVGPRSrcs = 0;
-
-  // Count explicit source operands whose register class can hold VGPRs.
-  // Skip defs (operands 0..NumDefs-1); only inspect use slots.
-  for (unsigned i = Desc.getNumDefs(), e = Desc.getNumOperands(); i < e; ++i) {
-    const TargetRegisterClass *OpRC = TII->getRegClass(Desc, i);
-    if (OpRC && hasVGPRs(OpRC)) {
-      if (++NumVGPRSrcs >= 3)
-        return true;
-    }
-  }
-
-  return false;
+  return getHWRegIndex(Reg) % NumVGPRBanks;
 }
 
 void SIRegisterInfo::addVGPRBankConflictHints(Register VirtReg,
@@ -4137,17 +4120,12 @@ void SIRegisterInfo::addVGPRBankConflictHints(Register VirtReg,
   if (!EnableVGPRBankConflictAvoidance || !VRM || !isVGPR(MRI, VirtReg))
     return;
 
-  // Track which banks are already in use by allocated operands
-  SmallDenseMap<unsigned, unsigned, 4> BankUsage; // bank_id -> use_count
-  bool HasRelevant3OpVALU = false;
+  // Track banks use count by allocated operands of VirtReg uses.
+  // Key is bank index, value is number of operands using that bank.
+  SmallDenseMap<unsigned, unsigned, NumVGPRBanks> BankUsage;
 
   // Scan all uses of this virtual register
   for (const MachineInstr &Use : MRI.use_nodbg_instructions(VirtReg)) {
-    if (!canHave3VGPROperands(Use))
-      continue;
-
-    HasRelevant3OpVALU = true;
-
     // Check which banks are used by other operands
     for (const MachineOperand &MO : Use.uses()) {
       if (!MO.isReg() || MO.getReg() == VirtReg)
@@ -4160,42 +4138,25 @@ void SIRegisterInfo::addVGPRBankConflictHints(Register VirtReg,
         continue;
       OpReg = VRM->getPhys(OpReg);
 
-      if (OpReg.isPhysical() && isVGPR(MRI, OpReg)) {
-        unsigned Bank = getHWRegIndex(OpReg) % 4;
-        BankUsage[Bank]++;
-      }
+      if (OpReg.isPhysical() && isVGPR(MRI, OpReg))
+        BankUsage[getVGPRBankIndex(OpReg)]++;
     }
   }
 
-  if (HasRelevant3OpVALU && !BankUsage.empty()) {
-    constexpr unsigned MaxBankHints =
-        32; // Arbitrary limit to avoid excessive hints
-    unsigned Added = 0;
+  if (BankUsage.empty())
+    return;
+  constexpr unsigned MaxBankHints =
+      64; // Arbitrary limit to avoid excessive hints
+  unsigned Added = 0;
 
-    // Pass 1: conflict-free candidates (no operands on this bank)
-    for (MCPhysReg Cand : Order) {
-      if (Added >= MaxBankHints)
-        break;
-      unsigned CandBank = getVGPRBankIndex(Cand);
-      if (!BankUsage.count(CandBank)) {
-        Hints.push_back(Cand);
-        ++Added;
-      }
-    }
-
-    // Pass 2: moderate-conflict candidates (1 existing; 2-way conflict)
-    for (MCPhysReg Cand : Order) {
-      if (Added >= MaxBankHints)
-        break;
-      unsigned CandBank = getVGPRBankIndex(Cand);
-      auto It = BankUsage.find(CandBank);
-      if (It != BankUsage.end() && It->second < 2) {
-        Hints.push_back(Cand);
-        ++Added;
-      }
-    }
-    // 3-way conflicts (usage >= 2) are not hinted; the allocator falls
-    // back to Order naturally via AllocationOrder iteration.
+  //Hint conflict-free candidates (no operands on this bank)
+  for (MCPhysReg Cand : Order) {
+    if (Added >= MaxBankHints)
+      break;
+    if (BankUsage.count(getVGPRBankIndex(Cand)))
+      continue;
+    Hints.push_back(Cand);
+    ++Added;
   }
 }
 

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
@@ -274,6 +274,10 @@ public:
     return RC->TSFlags & SIRCFlags::HasSGPR;
   }
 
+  /// Returns true if MI is a 3-operand VALU instruction that may cause
+  /// bank conflicts if operands are from the same bank.
+  bool is3OperandVALU(const MachineInstr &MI) const;
+
   /// \returns true if this class contains any vector registers.
   static bool hasVectorRegisters(const TargetRegisterClass *RC) {
     return hasVGPRs(RC) || hasAGPRs(RC);

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
@@ -274,9 +274,19 @@ public:
     return RC->TSFlags & SIRCFlags::HasSGPR;
   }
 
-  /// Returns true if MI is a 3-operand VALU instruction that may cause
-  /// bank conflicts if operands are from the same bank.
-  bool is3OperandVALU(const MachineInstr &MI) const;
+  /// \returns the VGPR register bank index (0-3)
+  unsigned getVGPRBankIndex(MCRegister Reg) const;
+
+  /// \returns true if MI is a VALU instruction that may have
+  /// at least 3 VGPR operands.
+  bool canHave3VGPROperands(const MachineInstr &MI) const;
+
+  /// Add register allocation hints to avoid VGPRs that would cause
+  /// bank conflicts
+  void addVGPRBankConflictHints(Register VirtReg, ArrayRef<MCPhysReg> Order,
+                            SmallVectorImpl<MCPhysReg> &Hints,
+                            const MachineFunction &MF,
+                            const VirtRegMap *VRM) const;
 
   /// \returns true if this class contains any vector registers.
   static bool hasVectorRegisters(const TargetRegisterClass *RC) {

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
@@ -278,7 +278,7 @@ public:
   unsigned getVGPRBankIndex(MCRegister Reg) const;
 
   /// \returns true if MI is a VALU instruction that may have
-  /// at least 3 VGPR operands.
+  /// 3 VGPR operands.
   bool canHave3VGPROperands(const MachineInstr &MI) const;
 
   /// Add register allocation hints to avoid VGPRs that would cause

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
@@ -283,9 +283,19 @@ public:
     return RC->TSFlags & SIRCFlags::HasSGPR;
   }
 
-  /// Returns true if MI is a 3-operand VALU instruction that may cause
-  /// bank conflicts if operands are from the same bank.
-  bool is3OperandVALU(const MachineInstr &MI) const;
+  /// \returns the VGPR register bank index (0-3)
+  unsigned getVGPRBankIndex(MCRegister Reg) const;
+
+  /// \returns true if MI is a VALU instruction that may have
+  /// at least 3 VGPR operands.
+  bool canHave3VGPROperands(const MachineInstr &MI) const;
+
+  /// Add register allocation hints to avoid VGPRs that would cause
+  /// bank conflicts
+  void addVGPRBankConflictHints(Register VirtReg, ArrayRef<MCPhysReg> Order,
+                            SmallVectorImpl<MCPhysReg> &Hints,
+                            const MachineFunction &MF,
+                            const VirtRegMap *VRM) const;
 
   /// \returns true if this class contains any vector registers.
   static bool hasVectorRegisters(const TargetRegisterClass *RC) {

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
@@ -286,16 +286,21 @@ public:
   /// \returns the VGPR register bank index (0-3)
   unsigned getVGPRBankIndex(MCRegister Reg) const;
 
-  /// \returns true if MI is a VALU instruction that may have
-  /// 3 VGPR operands.
-  bool canHave3VGPROperands(const MachineInstr &MI) const;
+  /// \returns a mask of VGPR Banks that wouldn't cause a conflict
+  /// with other vgpr source operands of the instruction.
+  unsigned getCoOpndsFreeVGPRBankMask(Register VirtReg,
+                                      const MachineFunction &MF,
+                                      const VirtRegMap *VRM) const;
 
-  /// Add register allocation hints to avoid VGPRs that would cause
-  /// bank conflicts
-  void addVGPRBankConflictHints(Register VirtReg, ArrayRef<MCPhysReg> Order,
-                            SmallVectorImpl<MCPhysReg> &Hints,
-                            const MachineFunction &MF,
-                            const VirtRegMap *VRM) const;
+  /// \returns a mask of VGPR Banks with the least known overlap
+  /// that can hold vopd pairing.
+  unsigned getVGPRBankParityMask(Register VirtReg,
+                                 const MachineFunction &MF,
+                                 const VirtRegMap *VRM) const;
+
+  void appendRAHintsForConflictAndOverlapAvoidance(
+      ArrayRef<MCPhysReg> Order, SmallVectorImpl<MCPhysReg> &Hints,
+      unsigned LeastBankConflictMask, unsigned LeastBankOverlapMask) const;
 
   /// \returns true if this class contains any vector registers.
   static bool hasVectorRegisters(const TargetRegisterClass *RC) {

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
@@ -287,7 +287,7 @@ public:
   unsigned getVGPRBankIndex(MCRegister Reg) const;
 
   /// \returns true if MI is a VALU instruction that may have
-  /// at least 3 VGPR operands.
+  /// 3 VGPR operands.
   bool canHave3VGPROperands(const MachineInstr &MI) const;
 
   /// Add register allocation hints to avoid VGPRs that would cause

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
@@ -283,6 +283,10 @@ public:
     return RC->TSFlags & SIRCFlags::HasSGPR;
   }
 
+  /// Returns true if MI is a 3-operand VALU instruction that may cause
+  /// bank conflicts if operands are from the same bank.
+  bool is3OperandVALU(const MachineInstr &MI) const;
+
   /// \returns true if this class contains any vector registers.
   static bool hasVectorRegisters(const TargetRegisterClass *RC) {
     return hasVGPRs(RC) || hasAGPRs(RC);


### PR DESCRIPTION
On GFX10+ RDNA architectures, the VGPR register file is organized into 4 banks (determined by HWRegIndex % 4). When a 3-operand VALU instruction has all source VGPRs mapped to the same bank, the hardware serializes the operand reads, adding latency.
This patch adds an opt-in mechanism (-amdgpu-avoid-vgpr-bank-conflicts, off by default for now) that uses getRegAllocationHints to steer the greedy register allocator toward bank-conflict-free assignments without introducing any new instructions or spills.

### Approach:

- is3OperandVALU: a helper that uses getRegClass to count how many explicit source operand slots in a VALU instruction can hold VGPRs. Non-register operands that return NullPtr are naturally skipped.
- In getRegAllocationHints, for each virtual VGPR being allocated, we scan its uses for 3-operand VALU instructions and collect the bank IDs of already-assigned co-operands via VirtRegMap.
- Hints are emitted in two priority passes:
1. Conflict-free: banks with no existing operands (no conflict).
2. Moderate conflict: banks with exactly 1 existing operand (2-way, tolerable).
3. 3-way conflicts receive no hints; the allocator falls back to AllocationOrder naturally.

### Design rationale:

- Hints are advisory they cannot override correctness; however, they can indirectly increase interference with other live ranges, potentially ending in spills.
- The feature is hidden and disabled by default to allow targeted evaluation before broader enablement.
- The bank conflict model uses a simple % 4 scheme matching RDNA VGPR banking.
- Arbitrary limit on the number of hints (=32) that might be tuned experimentally or removed if proven harmless.