### PR TITLE
[LFI][NFC] Mark lfi-enable-rewriter flag as hidden

### DIFF
--- a/llvm/lib/MC/MCLFI.cpp
+++ b/llvm/lib/MC/MCLFI.cpp
@@ -30,7 +30,7 @@ namespace llvm {
 
 cl::opt<bool> FlagEnableRewriting("lfi-enable-rewriter",
                                   cl::desc("Enable rewriting for LFI."),
-                                  cl::init(true));
+                                  cl::init(true), cl::Hidden);
 
 void initializeLFIMCStreamer(MCStreamer &Streamer, MCContext &Ctx,
                              const Triple &TheTriple) {


### PR DESCRIPTION
This flag is meant for debugging so it should be hidden.