### PR TITLE
[compiler-rt][Fuchsia] Use dynamic shadow global in hwasan runtime

### DIFF
--- a/compiler-rt/lib/hwasan/hwasan_mapping.h
+++ b/compiler-rt/lib/hwasan/hwasan_mapping.h
@@ -49,7 +49,7 @@ extern uptr kHighMemStart;
 extern uptr kHighMemEnd;
 
 inline uptr GetShadowOffset() {
-  return SANITIZER_FUCHSIA ? 0 : __hwasan_shadow_memory_dynamic_address;
+  return __hwasan_shadow_memory_dynamic_address;
 }
 inline uptr MemToShadow(uptr untagged_addr) {
   return (untagged_addr >> kShadowScale) + GetShadowOffset();


### PR DESCRIPTION
For now, the global is still default initialized to zero.

This will be needed if shadow on fuchsia would ever start at an address other than zero.