### PR TITLE
[Hexagon] Handle FK_Data_8 fixups in ELF object writer

### DIFF
--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonELFObjectWriter.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonELFObjectWriter.cpp
@@ -58,8 +58,20 @@ unsigned HexagonELFObjectWriter::getRelocType(const MCFixup &Fixup,
   }
   switch (Fixup.getKind()) {
   default:
-    report_fatal_error("Unrecognized relocation type");
+    report_fatal_error("Unrecognized relocation type, fixup kind=" +
+                       Twine(Fixup.getKind()));
     break;
+  case FK_Data_8:
+    // Hexagon is a 32-bit target with no native 64-bit relocation.
+    // Handle 8-byte data fixups as 32-bit relocations -- on a
+    // little-endian 32-bit platform, addresses occupy the low 4 bytes
+    // and the high 4 bytes are zero.
+    switch (Variant) {
+    case HexagonMCExpr::VK_None:
+      return IsPCRel ? ELF::R_HEX_32_PCREL : ELF::R_HEX_32;
+    default:
+      report_fatal_error("Unrecognized variant type for FK_Data_8");
+    };
   case FK_Data_4:
     switch (Variant) {
     case HexagonMCExpr::VK_DTPREL:

--- a/llvm/test/MC/Hexagon/reloc-data-sizes.s
+++ b/llvm/test/MC/Hexagon/reloc-data-sizes.s
@@ -2,7 +2,7 @@
 # RUN:   | llvm-objdump -r - | FileCheck %s
 
 # Test coverage for HexagonELFObjectWriter: exercise FK_Data_1, FK_Data_2,
-# and FK_Data_4 relocation sizes with GOT and TPREL variants.
+# FK_Data_4, and FK_Data_8 relocation sizes with GOT and TPREL variants.
 
 .data
 # CHECK: R_HEX_32
@@ -19,3 +19,11 @@
 
 # CHECK: R_HEX_TPREL_32
 .word ext_tprel@TPREL
+
+## FK_Data_8: Hexagon is a 32-bit target -- 8-byte data fixups are
+## lowered to R_HEX_32 (the address occupies the low 4 bytes on LE).
+# CHECK: R_HEX_32
+.8byte ext_8byte
+
+# CHECK: R_HEX_32
+.quad ext_quad


### PR DESCRIPTION
Hexagon is a 32-bit little-endian target with no native 64-bit relocation.  Map FK_Data_8 fixups to R_HEX_32 (or R_HEX_32_PCREL) so that 8-byte data directives (.8byte, .quad) referencing external symbols produce valid relocations instead of a fatal error.

Also improve the diagnostic for unrecognized fixup kinds by including the fixup kind number in the error message.