### PR TITLE
[LTO] Enable `PrepareForLTO` for loop unrolling in pre-link pipelines

### DIFF
--- a/clang/test/CodeGen/fat-lto-objects-cfi.cpp
+++ b/clang/test/CodeGen/fat-lto-objects-cfi.cpp
@@ -17,7 +17,7 @@
 // TYPE_TEST-NEXT:    %cmp14.not = icmp eq i64 %len, 0
 // TYPE_TEST-NEXT:    br i1 %cmp14.not, label %for.end7, label %for.cond1.preheader.preheader
 // TYPE_TEST-LABEL: for.cond1.preheader.preheader:                    ; preds = %entry
-// TYPE_TEST-NEXT:    %arrayidx.1 = getelementptr inbounds nuw i8, ptr %ptr, i64 4
+// TYPE_TEST-NEXT:    %arrayidx.c = getelementptr inbounds nuw i8, ptr %ptr, i64 4
 // TYPE_TEST-NEXT:    br label %for.cond1.preheader
 
 // The code below is a reduced case from https://github.com/llvm/llvm-project/issues/112053

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -538,7 +538,8 @@ PassBuilder::buildO1FunctionSimplificationPipeline(OptimizationLevel Level,
       PGOOpt->Action != PGOOptions::SampleUse)
     LPM2.addPass(LoopFullUnrollPass(Level.getSpeedupLevel(),
                                     /* OnlyWhenForced= */ !PTO.LoopUnrolling,
-                                    PTO.ForgetAllSCEVInLoopUnroll));
+                                    PTO.ForgetAllSCEVInLoopUnroll,
+                                    /* PrepareForLTO= */ isLTOPreLink(Phase)));
 
   invokeLoopOptimizerEndEPCallbacks(LPM2, Level);
 
@@ -722,7 +723,8 @@ PassBuilder::buildFunctionSimplificationPipeline(OptimizationLevel Level,
       PGOOpt->Action != PGOOptions::SampleUse)
     LPM2.addPass(LoopFullUnrollPass(Level.getSpeedupLevel(),
                                     /* OnlyWhenForced= */ !PTO.LoopUnrolling,
-                                    PTO.ForgetAllSCEVInLoopUnroll));
+                                    PTO.ForgetAllSCEVInLoopUnroll,
+                                    /* PrepareForLTO= */ isLTOPreLink(Phase)));
 
   invokeLoopOptimizerEndEPCallbacks(LPM2, Level);
 

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -567,7 +567,8 @@ PassBuilder::buildO1FunctionSimplificationPipeline(OptimizationLevel Level,
       PGOOpt->Action != PGOOptions::SampleUse)
     LPM2.addPass(LoopFullUnrollPass(static_cast<int>(Level),
                                     /* OnlyWhenForced= */ !PTO.LoopUnrolling,
-                                    PTO.ForgetAllSCEVInLoopUnroll));
+                                    PTO.ForgetAllSCEVInLoopUnroll,
+                                    /* PrepareForLTO= */ isLTOPreLink(Phase)));
 
   invokeLoopOptimizerEndEPCallbacks(LPM2, Level);
 
@@ -749,7 +750,8 @@ PassBuilder::buildFunctionSimplificationPipeline(OptimizationLevel Level,
       PGOOpt->Action != PGOOptions::SampleUse)
     LPM2.addPass(LoopFullUnrollPass(static_cast<int>(Level),
                                     /* OnlyWhenForced= */ !PTO.LoopUnrolling,
-                                    PTO.ForgetAllSCEVInLoopUnroll));
+                                    PTO.ForgetAllSCEVInLoopUnroll,
+                                    /* PrepareForLTO= */ isLTOPreLink(Phase)));
 
   invokeLoopOptimizerEndEPCallbacks(LPM2, Level);
 


### PR DESCRIPTION
Currently, the unroller will not unroll loops with inlineable calls. However, calls that may not appear to be inlineable during the pre-link phase may become inlineable during the post-link phase. The unroller's `PrepareForLTO` option addresses this gap by counting calls that may become inlineable after linking as inlineable when the option is set. Thus, this PR enables the `PrepareForLTO` option for loop unrolling in the pre-link phase. 