### PR TITLE
Initialize PreferredAlign in Function

### DIFF
--- a/llvm/include/llvm/IR/Function.h
+++ b/llvm/include/llvm/IR/Function.h
@@ -87,7 +87,7 @@ private:
 
   mutable Argument *Arguments = nullptr;  ///< The formal arguments
   uint32_t NumArgs;
-  MaybeAlign PreferredAlign;
+  MaybeAlign PreferredAlign{};
   std::unique_ptr<ValueSymbolTable>
       SymTab;                             ///< Symbol table of args/instructions
   AttributeList AttributeSets;            ///< Parameter attributes


### PR DESCRIPTION
Use value initialization of `MaybeAlign` in `Function` to avoid a valgrind "conditional jump or moved depends on uniitizlied value(s) error in (at least) Clang 17 and 18.  This fixes an issue introduced with this feature in #155527.

For background, `llvm/circt` runs nightly valgrind tests.  We started observing this failure after a recent LLVM bump in our CI using Clang 17. We then upgrade our CI infrastructure and this was still present in Clang
18.  I was then able to reproduce in Arch w/ Clang 18.  This was not observed with Clang 21 or Clang 22.

See `llvm/circt` issue: https://github.com/llvm/circt/issues/9914

Assisted-by: Claude:claude-opus-4-6