### PR TITLE
[lldb][debugserver] Fix lldb testsuite routine parsing logs

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -1738,7 +1738,6 @@ def packetlog_get_dylib_info(log):
         fetched_all_binary_addresses = False
         expect_dylib_info_response = False
         for line in logfile:
-
             # We've seen a jGetLoadedDynamicLibrariesInfos
             # We may have a response with *only* addresses, or
             # it may include detailed information.  If it is

--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -331,6 +331,7 @@ def get_use_break_add():
     global g_use_break_add
     return g_use_break_add
 
+
 def run_break_set_by_script(
     test, class_name, extra_options=None, num_expected_locations=1
 ):
@@ -346,6 +347,7 @@ def run_break_set_by_script(
     break_results = run_break_set_command(test, command)
     check_breakpoint_result(test, break_results, num_locations=num_expected_locations)
     return get_bpno_from_match(break_results)
+
 
 def run_break_set_by_file_and_line(
     test,
@@ -1255,9 +1257,11 @@ def print_stacktrace(thread, string_buffer=False):
                     func="%s [inlined]" % funcs[i] if frame.IsInlined() else funcs[i],
                     file=files[i],
                     line=lines[i],
-                    args=get_args_as_string(frame, showFuncName=False)
-                    if not frame.IsInlined()
-                    else "()",
+                    args=(
+                        get_args_as_string(frame, showFuncName=False)
+                        if not frame.IsInlined()
+                        else "()"
+                    ),
                 ),
                 file=output,
             )
@@ -1731,20 +1735,51 @@ def packetlog_get_dylib_info(log):
     dylib_info = None
     with open(log, "r") as logfile:
         dylib_info = None
+        fetched_all_binary_addresses = False
         expect_dylib_info_response = False
         for line in logfile:
+
+            # We've seen a jGetLoadedDynamicLibrariesInfos
+            # We may have a response with *only* addresses, or
+            # it may include detailed information.  If it is
+            # addresses-only, set fetched_all_binary_addresses to
+            # True, and when we send another jGetLoadedDynamicLibrariesInfos
+            # getting the detailed information for these, we'll have
+            # what we want.
             if expect_dylib_info_response:
                 while line[0] != "$":
                     line = line[1:]
                 line = line[1:]
                 # Unescape '}'.
                 dylib_info = json.loads(line.replace("}]", "}")[:-4])
-                expect_dylib_info_response = False
+                # See if this is an addresses-only response.
+                if "images" in dylib_info:
+                    if len(dylib_info["images"]) > 0:
+                        if not ("mach_header" in dylib_info["images"][0]):
+                            fetched_all_binary_addresses = True
+                            expect_dylib_info_response = False
+                            dylib_info = None
+                            continue
+                break
+
             if (
-                'send packet: $jGetLoadedDynamicLibrariesInfos:{"fetch_all_solibs":true}'
+                'send packet: $jGetLoadedDynamicLibrariesInfos:{"fetch_all_solibs":true'
                 in line
             ):
                 expect_dylib_info_response = True
+                continue
+
+            # We had an addresses-only jGetLoadedDynamicLibrariesInfos
+            # and now we're getting the detailed information for a group
+            # of the binaries.
+            if (
+                fetched_all_binary_addresses
+                and 'send packet: $jGetLoadedDynamicLibrariesInfos:{"information-level":"full","solib_addresses"'
+                in line
+            ):
+                fetched_all_binary_addresses = False
+                expect_dylib_info_response = True
+                continue
 
     return dylib_info
 


### PR DESCRIPTION
I changed how lldb and debugserver fetch binaries when attaching to a process (only fetching the addresses of binaries, not the detailed information) but a utility function was parsing the log file and expected the detailed information in the initial response.  Updated it to expect detailed information in the initial response, or in the subsequent query when the first response is addresses-only.