### PR TITLE
[clang][cmake] Move perf-training out of CLANG_INCLUDE_TESTS

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -585,8 +585,9 @@ if( CLANG_INCLUDE_TESTS )
   if(CLANG_BUILT_STANDALONE)
     umbrella_lit_testsuite_end(check-all)
   endif()
-  add_subdirectory(utils/perf-training)
 endif()
+
+add_subdirectory(utils/perf-training)
 
 option(CLANG_INCLUDE_DOCS "Generate build targets for the Clang docs."
   ${LLVM_INCLUDE_DOCS})

--- a/clang/utils/perf-training/lit.site.cfg.in
+++ b/clang/utils/perf-training/lit.site.cfg.in
@@ -9,7 +9,7 @@ config.test_source_root = "@CLANG_PGO_TRAINING_DATA@"
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.python_exe = "@Python3_EXECUTABLE@"
 config.cmake_exe = "@CMAKE_COMMAND@"
-config.llvm_src_dir ="@CMAKE_SOURCE_DIR@"
+config.llvm_src_dir = "@LLVM_MAIN_SRC_DIR@"
 config.cmake_generator ="@CMAKE_GENERATOR@"
 config.use_llvm_build = @CLANG_PGO_TRAINING_USE_LLVM_BUILD@
 


### PR DESCRIPTION
perf-training defines the generate-profdata target used by the PGO bootstrap build.
However, it is currently enabled only when CLANG_INCLUDE_TESTS=ON.
For distribution builds such as Yocto/OE, tests are usually disabled by setting this to OFF.

But perf-training is a PGO utility, not a test target, and it is currently gated by that block.
As a result, generate-profdata is unavailable to the PGO bootstrap build when
CLANG_INCLUDE_TESTS=OFF.

Move perf-training out of the CLANG_INCLUDE_TESTS block.

This is safe because utils/perf-training/CMakeLists.txt adds targets only when
LLVM_BUILD_INSTRUMENTED or CLANG_BOLT is enabled, so moving it out does not add
any targets unless PGO or BOLT is actually in use.

Also fix the path in lit.site.cfg.in for standalone builds.
When llvm_src_dir is set from CMAKE_SOURCE_DIR, standalone clang builds end up
using the clang source directory instead of the LLVM source directory.
Set it to the proper LLVM source location instead.

Assisted-by: claude