### PR TITLE
[BPF] Add exception handling support with .bpf_cleanup section

### DIFF
--- a/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
+++ b/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
@@ -25,10 +25,12 @@
 #include "llvm/CodeGen/MachineJumpTableInfo.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/TargetLowering.h"
+#include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/Module.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCSectionELF.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/MC/MCSymbolELF.h"
@@ -190,6 +192,61 @@ void BPFAsmPrinter::emitInstruction(const MachineInstr *MI) {
     MCInstLowering.Lower(MI, TmpInst);
   }
   EmitToStreamer(*OutStreamer, TmpInst);
+}
+
+void BPFAsmPrinter::emitFunctionBodyEnd() {
+  // Emit .bpf_cleanup section with a flat table of
+  // (call_site, landing_pad) pairs.
+  const std::vector<LandingPadInfo> &LandingPads = MF->getLandingPads();
+  if (LandingPads.empty())
+    return;
+
+  MCContext &Ctx = OutContext;
+  auto *CleanupSec =
+      Ctx.getELFSection(".bpf_cleanup", ELF::SHT_PROGBITS, ELF::SHF_ALLOC);
+  OutStreamer->switchSection(CleanupSec);
+
+  const auto &TypeInfos = MF->getTypeInfos();
+  const Function &F = MF->getFunction();
+  LLVMContext &LLVMCtx = F.getContext();
+
+  // Each landing pad has BeginLabels/EndLabels marking the invoke
+  // call sites that unwind to it.
+  for (const LandingPadInfo &LP : LandingPads) {
+    // BPF treats all landing pads as catch-all: the kernel redirects to
+    // the landing pad regardless of exception type. Reject type-specific
+    // catches and filters which would silently misbehave.
+    for (int TId : LP.TypeIds) {
+      if (TId > 0 && TypeInfos[TId - 1] != nullptr) {
+        LLVMCtx.diagnose(DiagnosticInfoUnsupported(
+            F, "BPF does not support type-specific exception catches yet"));
+        return;
+      }
+      if (TId < 0) {
+        LLVMCtx.diagnose(DiagnosticInfoUnsupported(
+            F, "BPF does not support exception filters yet"));
+        return;
+      }
+    }
+
+    MCSymbol *LPLabel = LP.LandingPadLabel;
+    if (!LPLabel)
+      continue;
+    for (unsigned i = 0, e = LP.BeginLabels.size(); i != e; ++i) {
+      MCSymbol *Begin = LP.BeginLabels[i];
+      MCSymbol *End = LP.EndLabels[i];
+
+      // Each entry is 3 x 4 bytes: begin, end, landing_pad.
+      // The invoke region [begin, end) may include argument setup
+      // before the call. The runtime checks begin <= PC < end.
+      OutStreamer->emitSymbolValue(Begin, 4);
+      OutStreamer->emitSymbolValue(End, 4);
+      OutStreamer->emitSymbolValue(LPLabel, 4);
+    }
+  }
+
+  // Switch back to the function's section.
+  OutStreamer->switchSection(MF->getSection());
 }
 
 MCSymbol *BPFAsmPrinter::getJTPublicSymbol(unsigned JTI) {

--- a/llvm/lib/Target/BPF/BPFAsmPrinter.h
+++ b/llvm/lib/Target/BPF/BPFAsmPrinter.h
@@ -31,6 +31,7 @@ public:
                              const char *ExtraCode, raw_ostream &O) override;
 
   void emitInstruction(const MachineInstr *MI) override;
+  void emitFunctionBodyEnd() override;
   MCSymbol *getJTPublicSymbol(unsigned JTI);
   void emitJumpTableInfo() override;
 

--- a/llvm/lib/Target/BPF/BPFISelLowering.h
+++ b/llvm/lib/Target/BPF/BPFISelLowering.h
@@ -54,6 +54,14 @@ public:
   EVT getSetCCResultType(const DataLayout &DL, LLVMContext &Context,
                          EVT VT) const override;
 
+  // Exception handling support.
+  Register getExceptionPointerRegister(const Constant *) const override {
+    return BPF::R0;
+  }
+  Register getExceptionSelectorRegister(const Constant *) const override {
+    return BPF::R0;
+  }
+
   MVT getScalarShiftAmountTy(const DataLayout &, EVT) const override;
 
   unsigned getJumpTableEncoding() const override;

--- a/llvm/test/CodeGen/BPF/cleanup-reject-typed-catch.ll
+++ b/llvm/test/CodeGen/BPF/cleanup-reject-typed-catch.ll
@@ -1,0 +1,25 @@
+; RUN: not llc -mtriple=bpfel -mcpu=v4 -filetype=asm -o - %s 2>&1 | FileCheck %s
+
+; BPF does not support type-specific exception catches.
+; Verify that a catch clause with a non-null type info is rejected.
+
+@_ZTIi = external constant ptr
+
+declare void @may_throw()
+declare i32 @rust_personality(i32, i64, ptr, ptr)
+
+define void @typed_catch() personality ptr @rust_personality {
+entry:
+  invoke void @may_throw()
+          to label %ok unwind label %lpad
+
+ok:
+  ret void
+
+lpad:
+  %lp = landingpad { ptr, i32 }
+    catch ptr @_ZTIi
+  ret void
+}
+
+; CHECK: error: {{.*}} BPF does not support type-specific exception catches

--- a/llvm/test/CodeGen/BPF/cleanup-section.ll
+++ b/llvm/test/CodeGen/BPF/cleanup-section.ll
@@ -1,0 +1,160 @@
+; RUN: llc -mtriple=bpfel -mcpu=v4 -filetype=asm -o - %s | FileCheck --check-prefix=ASM %s
+; RUN: llc -mtriple=bpfel -mcpu=v4 -filetype=obj -o %t %s
+; RUN: llvm-readelf -S %t | FileCheck --check-prefix=SECTIONS %s
+; RUN: llvm-readelf -r %t | FileCheck --check-prefix=RELOCS %s
+
+; Verify that invoke/landingpad with cleanup produces a .bpf_cleanup section
+; containing (call_site, landing_pad) pairs with R_BPF_64_NODYLD32 relocations.
+; Models a Rust BTreeMap insertion that may fail, with Drop cleanup
+; calling bpf_free to release allocated nodes.
+
+declare ptr @bpf_alloc(i64, i64)
+declare void @bpf_free(ptr)
+declare void @btree_insert(ptr, ptr, i64)
+declare i32 @rust_personality(i32, i64, ptr, ptr)
+
+; SECTIONS: .bpf_cleanup
+
+define void @stat_inc(ptr %map, ptr %key, i64 %val) personality ptr @rust_personality {
+entry:
+  %node = call ptr @bpf_alloc(i64 256, i64 0)
+  %null = icmp eq ptr %node, null
+  br i1 %null, label %oom, label %insert
+
+insert:
+  invoke void @btree_insert(ptr %map, ptr %node, i64 %val)
+          to label %done unwind label %cleanup
+
+done:
+  ret void
+
+cleanup:
+  %lp = landingpad { ptr, i32 } cleanup
+  call void @bpf_free(ptr %node)
+  resume { ptr, i32 } %lp
+
+oom:
+  ret void
+}
+
+; ASM-LABEL: stat_inc:
+; ASM:         r1 = 256
+; ASM:         call bpf_alloc
+; ASM:         if r0 == 0 goto
+;   Normal path: call btree_insert then exit
+; ASM:       .Ltmp0:
+; ASM:         call btree_insert
+; ASM:       .Ltmp1:
+; ASM:         exit
+;   Cleanup landing pad: free the node, then resume unwinding
+; ASM:       .Ltmp2:
+; ASM:         r1 = r7
+; ASM:         call bpf_free
+; ASM:         call _Unwind_Resume
+;   .bpf_cleanup entry: [.Ltmp0, .Ltmp1) -> .Ltmp2
+; ASM:         .section .bpf_cleanup,"a",@progbits
+; ASM-NEXT:    .long .Ltmp0
+; ASM-NEXT:    .long .Ltmp1
+; ASM-NEXT:    .long .Ltmp2
+
+define void @two_allocs(ptr %map) personality ptr @rust_personality {
+entry:
+  %n1 = call ptr @bpf_alloc(i64 256, i64 0)
+  invoke void @btree_insert(ptr %map, ptr %n1, i64 1)
+          to label %second unwind label %clean1
+
+second:
+  %n2 = call ptr @bpf_alloc(i64 512, i64 0)
+  invoke void @btree_insert(ptr %map, ptr %n2, i64 2)
+          to label %done unwind label %clean2
+
+done:
+  ret void
+
+clean2:
+  ; Must free both n2 and n1
+  %lp2 = landingpad { ptr, i32 } cleanup
+  call void @bpf_free(ptr %n2)
+  call void @bpf_free(ptr %n1)
+  resume { ptr, i32 } %lp2
+
+clean1:
+  ; Only n1 allocated at this point
+  %lp1 = landingpad { ptr, i32 } cleanup
+  call void @bpf_free(ptr %n1)
+  resume { ptr, i32 } %lp1
+}
+
+; ASM-LABEL: two_allocs:
+;   First alloc + invoke
+; ASM:         r1 = 256
+; ASM:         call bpf_alloc
+; ASM:       .Ltmp3:
+; ASM:         call btree_insert
+; ASM:       .Ltmp4:
+;   Second alloc + invoke
+; ASM:         r1 = 512
+; ASM:         call bpf_alloc
+; ASM:       .Ltmp6:
+; ASM:         call btree_insert
+; ASM:       .Ltmp7:
+; ASM:         exit
+;   clean2: free n2, then fall through to free n1
+; ASM:       .Ltmp8:
+; ASM:         call bpf_free
+;   clean1 entry point, shared tail: free n1 then resume
+; ASM:       .Ltmp5:
+; ASM:         call bpf_free
+; ASM:         call _Unwind_Resume
+;   .bpf_cleanup entries: two triples
+; ASM:         .section .bpf_cleanup,"a",@progbits
+; ASM-NEXT:    .long .Ltmp3
+; ASM-NEXT:    .long .Ltmp4
+; ASM-NEXT:    .long .Ltmp5
+; ASM-NEXT:    .long .Ltmp6
+; ASM-NEXT:    .long .Ltmp7
+; ASM-NEXT:    .long .Ltmp8
+
+; Models std::panic::catch_unwind: catch the exception, free resources,
+; and return normally. The landing pad uses "catch ptr null" (catch-all)
+; instead of "cleanup", and does NOT call _Unwind_Resume — unwinding stops here.
+
+define i64 @with_catch_unwind(ptr %map, i64 %val) personality ptr @rust_personality {
+entry:
+  %node = call ptr @bpf_alloc(i64 128, i64 0)
+  invoke void @btree_insert(ptr %map, ptr %node, i64 %val)
+          to label %ok unwind label %caught
+
+ok:
+  ret i64 0
+
+caught:
+  %lp = landingpad { ptr, i32 }
+    catch ptr null
+  call void @bpf_free(ptr %node)
+  ret i64 1
+}
+
+; ASM-LABEL: with_catch_unwind:
+; ASM:         r1 = 128
+; ASM:         call bpf_alloc
+; ASM:       .Ltmp9:
+; ASM:         call btree_insert
+; ASM:       .Ltmp10:
+; ASM:         r0 = 0
+; ASM:         exit
+;   Catch block: free the node, return 1 (no _Unwind_Resume)
+; ASM:       .Ltmp11:
+; ASM:         call bpf_free
+; ASM:         r0 = 1
+; ASM:         exit
+;   .bpf_cleanup entry for the catch
+; ASM:         .section .bpf_cleanup,"a",@progbits
+; ASM-NEXT:    .long .Ltmp9
+; ASM-NEXT:    .long .Ltmp10
+; ASM-NEXT:    .long .Ltmp11
+
+; .bpf_cleanup should have R_BPF_64_NODYLD32 relocations
+; 4 entries x 3 fields = 12 relocs
+; RELOCS: .rel.bpf_cleanup
+; RELOCS-COUNT-12: R_BPF_64_NODYLD32 {{.*}} .text


### PR DESCRIPTION
Add support for invoke/landingpad/resume instructions in the BPF backend so that Rust programs compiled with panic=unwind can run cleanup code (Drop implementations) when bpf_throw fires.

Changes:

1. BPFISelLowering: Define exception pointer and selector registers (both R0) so SelectionDAG can lower landingpad instructions.

2. BPFAsmPrinter::emitFunctionBodyEnd: Emit a .bpf_cleanup section with a flat table of (begin, end, landing_pad) triples using R_BPF_64_NODYLD32 relocations.

The .bpf_cleanup section layout (12 bytes per entry):

  u32 begin         // start of the invoke region
  u32 end           // end of the invoke region
  u32 landing_pad   // address of the cleanup block

The invoke region [begin, end) includes argument setup instructions before the call. The runtime checks begin <= PC < end to find the matching landing pad.

Landing pad blocks survive optimization because invoke maintains CFG edges to them throughout codegen, same as every other backend. The standard .gcc_except_table and .eh_frame are also emitted by the existing DwarfCFIException handler; libbpf will ignore them.

In runtime:
- bpf_throw() is called (from panic handler)
- Kernel walks the BPF call stack with arch_bpf_stack_walk()
- For each frame, look up current PC in .bpf_cleanup table
- If match found: redirect execution to the cleanup function . cleanup function runs Drop impls (bpf_free, rcu_read_unlock, etc.) . calls _Unwind_Resume() which is patched to just 'ret' by the verifier . bpf_throw() pops frame goes to next
- If no match: go to next frame