### PR TITLE
[BOLT] Fix DW_FORM_implicit_const values lost during DWARF5 rewriting

### DIFF
--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -398,7 +398,7 @@ DIE *DIEBuilder::constructDIEFast(DWARFDie &DDie, DWARFUnit &U,
 
   using AttrSpec = DWARFAbbreviationDeclaration::AttributeSpec;
   for (const AttrSpec &AttrSpec : Abbrev->attributes()) {
-    DWARFFormValue Val(AttrSpec.Form);
+    DWARFFormValue Val = AttrSpec.getFormValue();
     Val.extractValue(Data, &AttrOffset, U.getFormParams(), &U);
     cloneAttribute(*DieInfo.Die, DDie, U, Val, AttrSpec);
   }
@@ -961,7 +961,7 @@ void DIEBuilder::assignAbbrev(DIEAbbrev &Abbrev) {
     Abbreviations.push_back(
         std::make_unique<DIEAbbrev>(Abbrev.getTag(), Abbrev.hasChildren()));
     for (const auto &Attr : Abbrev.getData())
-      Abbreviations.back()->AddAttribute(Attr.getAttribute(), Attr.getForm());
+      Abbreviations.back()->AddAttribute(Attr);
     AbbreviationsSet.InsertNode(Abbreviations.back().get(), InsertToken);
     // Assign the unique abbreviation number.
     Abbrev.setNumber(Abbreviations.size());

--- a/bolt/test/X86/dwarf5-locexpr-addrx.s
+++ b/bolt/test/X86/dwarf5-locexpr-addrx.s
@@ -15,6 +15,7 @@
 # PRECHECK: DW_TAG_variable
 # PRECHECK: DW_AT_location [DW_FORM_exprloc]  (DW_OP_addrx 0x1)
 # PRECHECK-EMPTY:
+# PRECHECK: DW_AT_inline [DW_FORM_implicit_const] (DW_INL_inlined)
 
 # POSTCHECK: version = 0x0005
 # POSTCHECK: DW_TAG_variable
@@ -23,6 +24,7 @@
 # POSTCHECK: DW_TAG_variable
 # POSTCHECK: DW_AT_location [DW_FORM_exprloc]  (DW_OP_addrx 0x3)
 # POSTCHECK-EMPTY:
+# POSTCHECK: DW_AT_inline [DW_FORM_implicit_const] (DW_INL_inlined)
 
 # clang++ main.cpp -g -O2
 # void use(int * x, int * y) {


### PR DESCRIPTION
Summary:
Fix two bugs in DIEBuilder that caused DW_FORM_implicit_const values to be zeroed out when rewriting DWARF5 debug sections (--update-debug-sections).

1. In constructDIEFast(), DWARFFormValue was constructed with just the form code, leaving the value at 0. For DW_FORM_implicit_const, extractValue() is a no-op since the value is expected to be pre-set. Fix: use AttrSpec.getFormValue() which initializes the value from the abbreviation table.

2. In assignAbbrev(), AddAttribute(Attr.getAttribute(), Attr.getForm()) used the two-argument overload which discards the implicit_const value. Fix: use AddAttribute(Attr) to copy the full DIEAbbrevData.

Fixes https://github.com/llvm/llvm-project/issues/192084