### PR TITLE
[OpenMP] Create check-openmp target for device targets

### DIFF
--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -173,7 +173,7 @@ else()
 
   # Build documentation
   add_subdirectory(docs)
-
-  # Now that we have seen all testsuites, create the check-openmp target.
-  construct_check_openmp_target()
 endif()
+
+# Now that we have seen all testsuites, create the check-openmp target.
+construct_check_openmp_target()


### PR DESCRIPTION
offload/cmake/caches/AMDGPUBot.cmake enables
RUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES="openmp". In that sub-build, check-openmp target doesn't exist and there is build error `unknown target 'check-openmp'` after 18f63d1375d0, which makes top-level check-openmp depend on check-openmp-amdgcn-amd-amdhsa.

In openmp, the device targets only call add_subdirectory(device), which doesn't calls construct_check_openmp_target() and check-openmp target doesn't exist. `ninja check-openmp-amdgcn-amd-amdhsa` also fails with the same error before 18f63d1375d0.

Fix by adding construct_check_openmp_target() for device targets as well.

Assisted-by: Claude Sonnet 4.6