### PR TITLE
[mlir][Transforms] Fix CSE memEffectsCache handling for existing entries (NFC)

### DIFF
--- a/mlir/lib/Transforms/CSE.cpp
+++ b/mlir/lib/Transforms/CSE.cpp
@@ -196,7 +196,7 @@ bool CSEDriver::hasOtherSideEffectingOpInBetween(Operation *fromOp,
   Operation *nextOp = fromOp->getNextNode();
   auto result =
       memEffectsCache.try_emplace(fromOp, std::make_pair(fromOp, nullptr));
-  if (result.second) {
+  if (!result.second) {
     auto memEffectsCachePair = result.first->second;
     if (memEffectsCachePair.second == nullptr) {
       // No MemoryEffects::Write has been detected until the cached operation.


### PR DESCRIPTION
The condition on detecting cache insertion was reversed. The consequence was that we would always go through the path of "cache hit" first, but find that the entry was the just-inserted one and then proceed with updating it. Subsequent attempt could go through the "cache miss" part and the cache would never be used.
