### PR TITLE
[InstCombine] Fold select of ordered fcmps of fabs over NaN-scrubber selects to a single select

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3403,13 +3403,11 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
   FastMathFlags CommonRewriteFMF =
       FastMathFlags::intersectRewrite(FAbsFMF, CmpFMF);
 
-  auto ValueFMF = [](FastMathFlags FMF) {
-    // unionValue with FastMathFlags() drops all rewriter based flags
-    return FastMathFlags::unionValue(FMF, FastMathFlags());
-  };
-
-  FastMathFlags NewFAbsFMF = CommonRewriteFMF | ValueFMF(FAbsFMF);
-  FastMathFlags NewCmpFMF = CommonRewriteFMF | ValueFMF(CmpFMF);
+  // unionValue with FastMathFlags() drops all rewriter based flags
+  FastMathFlags NewFAbsFMF =
+      CommonRewriteFMF | FastMathFlags::unionValue(FAbsFMF, FastMathFlags());
+  FastMathFlags NewCmpFMF =
+      CommonRewriteFMF | FastMathFlags::unionValue(CmpFMF, FastMathFlags());
 
   // When X is NaN, the old code evaluated fabs(Y), while the new code evaluates
   // fabs(X). Do not preserve nnan on either newly-created instruction.

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3373,7 +3373,9 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
 
   Value *Y = SI.getFalseValue();
   Value *InnerSel = SI.getTrueValue();
-  // Match a select that returns X when X is not NaN, and Y otherwise.
+
+  // Match a select that returns X when X is not NaN, and Y otherwise:
+  //   select (fcmp ord X, 0.0), X, Y
   Value *X;
   if (!match(InnerSel,
              m_Select(m_OneUse(m_SpecificFCmp(FCmpInst::FCMP_ORD, m_Value(X),
@@ -3381,24 +3383,42 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
                       m_Deferred(X), m_Specific(Y))))
     return nullptr;
 
-  if (!match(Cmp0, m_OneUse(m_FAbs(m_Specific(InnerSel))))) {
-    if (!match(Cmp1, m_OneUse(m_FAbs(m_Specific(InnerSel)))))
+  Instruction *FAbsI;
+  auto MatchFAbsOfInnerSel = [&](Value *V) {
+    return match(V,
+                 m_OneUse(m_Instruction(FAbsI, m_FAbs(m_Specific(InnerSel)))));
+  };
+
+  if (!MatchFAbsOfInnerSel(Cmp0)) {
+    if (!MatchFAbsOfInnerSel(Cmp1))
       return nullptr;
 
     std::swap(Cmp0, Cmp1);
     Pred = CmpInst::getSwappedPredicate(Pred);
   }
 
-  Value *NewAbs = IC.Builder.CreateFAbs(X);
+  FastMathFlags FAbsFMF = FAbsI->getFastMathFlags();
+  FastMathFlags CmpFMF = OuterCmp->getFastMathFlags();
 
-  // Do not preserve nnan on the new fcmp: when X is NaN, the old compare
-  // evaluated fabs(Y), while the new compare evaluates fabs(X).
-  FastMathFlags NewCmpFMF = OuterCmp->getFastMathFlags();
+  FastMathFlags CommonRewriteFMF =
+      FastMathFlags::intersectRewrite(FAbsFMF, CmpFMF);
+
+  auto ValueFMF = [](FastMathFlags FMF) {
+    // unionValue with FastMathFlags() drops all rewriter based flags
+    return FastMathFlags::unionValue(FMF, FastMathFlags());
+  };
+
+  FastMathFlags NewFAbsFMF = CommonRewriteFMF | ValueFMF(FAbsFMF);
+  FastMathFlags NewCmpFMF = CommonRewriteFMF | ValueFMF(CmpFMF);
+
+  // When X is NaN, the old code evaluated fabs(Y), while the new code evaluates
+  // fabs(X). Do not preserve nnan on either newly-created instruction.
+  NewFAbsFMF.setNoNaNs(false);
   NewCmpFMF.setNoNaNs(false);
 
+  Value *NewAbs = IC.Builder.CreateFAbs(X, FMFSource(NewFAbsFMF));
   Value *NewCmp =
       IC.Builder.CreateFCmpFMF(Pred, NewAbs, Cmp1, FMFSource(NewCmpFMF));
-
   Value *NewSel = IC.Builder.CreateSelectFMF(NewCmp, X, Y, &SI);
   return IC.replaceInstUsesWith(SI, NewSel);
 }

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3347,33 +3347,17 @@ static Instruction *foldSelectWithFCmpToFabs(SelectInst &SI,
   return ChangedFMF ? &SI : nullptr;
 }
 
-static bool matchIsNotNaNTest(Value *Cond, Value *X, InstCombinerImpl &IC) {
-  Instruction *CmpI;
-  Value *Other;
-
-  // Match:
-  //   fcmp ord X, Other
-  //   fcmp ord Other, X
-  // where Other is known non-NaN.
-  if (!match(Cond,
-             m_OneUse(m_Instruction(
-                 CmpI,
-                 m_CombineOr(m_SpecificFCmp(FCmpInst::FCMP_ORD, m_Specific(X),
-                                            m_Value(Other)),
-                             m_SpecificFCmp(FCmpInst::FCMP_ORD, m_Value(Other),
-                                            m_Specific(X)))))))
-    return false;
-
-  return isKnownNeverNaN(Other, IC.getSimplifyQuery().getWithInstruction(CmpI));
-}
-
 // Match a select that returns X when X is not NaN, and Y otherwise.
-static Value *matchNaNScrubbedValue(Value *V, Value *Y, InstCombinerImpl &IC) {
+static Value *matchNaNScrubbedValue(Value *V, Value *Y) {
   Value *Cond, *X;
   if (!match(V, m_Select(m_Value(Cond), m_Value(X), m_Specific(Y))))
     return nullptr;
 
-  return matchIsNotNaNTest(Cond, X, IC) ? X : nullptr;
+  if (!match(Cond, m_OneUse(m_SpecificFCmp(FCmpInst::FCMP_ORD, m_Specific(X),
+                                           m_AnyZeroFP()))))
+    return nullptr;
+
+  return X;
 }
 
 // Fold a select of an ordered fcmp using fabs of a NaN-scrubbed value:
@@ -3402,7 +3386,7 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
 
   Value *Y = SI.getFalseValue();
   Value *InnerSel = SI.getTrueValue();
-  Value *X = matchNaNScrubbedValue(InnerSel, Y, IC);
+  Value *X = matchNaNScrubbedValue(InnerSel, Y);
   if (!X)
     return nullptr;
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3347,6 +3347,74 @@ static Instruction *foldSelectWithFCmpToFabs(SelectInst &SI,
   return ChangedFMF ? &SI : nullptr;
 }
 
+// Fold a select of an ordered fcmp using fabs of a NaN-scrubbed value:
+//   %ord = fcmp ord T %x, 0.0
+//   %s   = select i1 %ord, T %x, T %y
+//   %a   = call T @llvm.fabs.T(T %s)
+//   %c   = fcmp <ordered-pred> T %a, %k
+//   %r   = select i1 %c, T %s, T %y
+//     =>
+//   %a2  = call T @llvm.fabs.T(T %x)
+//   %c2  = fcmp <ordered-pred> T %a2, %k
+//   %r2  = select i1 %c2, T %x, T %y
+static Instruction *
+foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
+                                             InstCombinerImpl &IC) {
+  auto *OuterCmp = dyn_cast<FCmpInst>(SI.getCondition());
+  if (!OuterCmp || !OuterCmp->hasOneUse() ||
+      !FCmpInst::isOrdered(OuterCmp->getPredicate()))
+    return nullptr;
+
+  // The NaN path now evaluates fabs(X) instead of fabs(Y), so preserving nnan
+  // on the fcmp could introduce poison when X is NaN.
+  if (OuterCmp->hasNoNaNs())
+    return nullptr;
+
+  Value *Y = SI.getFalseValue();
+  Value *X = nullptr;
+
+  auto *InnerSel = dyn_cast<SelectInst>(SI.getTrueValue());
+  if (!InnerSel)
+    return nullptr;
+
+  // Match: select (fcmp ord X, 0.0), X, Y
+  auto *InnerCmp = dyn_cast<FCmpInst>(InnerSel->getCondition());
+  if (!InnerCmp || !InnerCmp->hasOneUse() ||
+      InnerCmp->getPredicate() != FCmpInst::FCMP_ORD ||
+      InnerSel->getFalseValue() != Y)
+    return nullptr;
+
+  X = InnerSel->getTrueValue();
+  if (InnerCmp->getOperand(0) != X ||
+      !match(InnerCmp->getOperand(1), m_AnyZeroFP()))
+    return nullptr;
+
+  bool Swapped = false;
+  Value *OtherOp = nullptr;
+  auto *FAbs = dyn_cast<IntrinsicInst>(OuterCmp->getOperand(0));
+
+  if (FAbs && FAbs->hasOneUse() && FAbs->getIntrinsicID() == Intrinsic::fabs &&
+      FAbs->getArgOperand(0) == InnerSel) {
+    OtherOp = OuterCmp->getOperand(1);
+  } else if ((FAbs = dyn_cast<IntrinsicInst>(OuterCmp->getOperand(1))) &&
+             FAbs->hasOneUse() && FAbs->getIntrinsicID() == Intrinsic::fabs &&
+             FAbs->getArgOperand(0) == InnerSel) {
+    Swapped = true;
+    OtherOp = OuterCmp->getOperand(0);
+  } else {
+    return nullptr;
+  }
+
+  Value *NewAbs = IC.Builder.CreateUnaryIntrinsic(Intrinsic::fabs, X);
+  Value *NewCmp = Swapped
+                      ? IC.Builder.CreateFCmpFMF(OuterCmp->getPredicate(),
+                                                 OtherOp, NewAbs, OuterCmp)
+                      : IC.Builder.CreateFCmpFMF(OuterCmp->getPredicate(),
+                                                 NewAbs, OtherOp, OuterCmp);
+  Value *NewSel = IC.Builder.CreateSelectFMF(NewCmp, X, Y, &SI);
+  return IC.replaceInstUsesWith(SI, NewSel);
+}
+
 // Match the following IR pattern:
 //   %x.lowbits = and i8 %x, %lowbitmask
 //   %x.lowbits.are.zero = icmp eq i8 %x.lowbits, 0
@@ -4598,6 +4666,9 @@ Instruction *InstCombinerImpl::visitSelectInst(SelectInst &SI) {
   // Fold selecting to fabs.
   if (Instruction *Fabs = foldSelectWithFCmpToFabs(SI, *this))
     return Fabs;
+
+  if (Instruction *I = foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SI, *this))
+    return I;
 
   // See if we are selecting two values based on a comparison of the two values.
   if (CmpInst *CI = dyn_cast<CmpInst>(CondVal))

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3347,9 +3347,50 @@ static Instruction *foldSelectWithFCmpToFabs(SelectInst &SI,
   return ChangedFMF ? &SI : nullptr;
 }
 
+static bool matchIsNaNTest(FCmpInst *Cmp, Value *X, bool MatchIsNaN,
+                           InstCombinerImpl &IC) {
+  FCmpInst::Predicate ExpectedPred =
+      MatchIsNaN ? FCmpInst::FCMP_UNO : FCmpInst::FCMP_ORD;
+  if (Cmp->getPredicate() != ExpectedPred)
+    return false;
+
+  Value *Cmp0 = Cmp->getOperand(0), *Cmp1 = Cmp->getOperand(1);
+  if (Cmp0 == X && Cmp1 == X)
+    return true;
+
+  auto IsKnownNeverNaN = [&](Value *V) {
+    return match(V, m_NonNaN()) ||
+           isKnownNeverNaN(V, IC.getSimplifyQuery().getWithInstruction(Cmp));
+  };
+
+  return (Cmp0 == X && IsKnownNeverNaN(Cmp1)) ||
+         (Cmp1 == X && IsKnownNeverNaN(Cmp0));
+}
+
+// Match a select that returns X when X is not NaN, and Y otherwise.
+static Value *matchNaNScrubbedValue(SelectInst *SI, Value *Y,
+                                    InstCombinerImpl &IC) {
+  auto *Cmp = dyn_cast<FCmpInst>(SI->getCondition());
+  if (!Cmp || !Cmp->hasOneUse())
+    return nullptr;
+
+  Value *X;
+  bool MatchIsNaN;
+  if (SI->getFalseValue() == Y) {
+    X = SI->getTrueValue();
+    MatchIsNaN = false;
+  } else if (SI->getTrueValue() == Y) {
+    X = SI->getFalseValue();
+    MatchIsNaN = true;
+  } else {
+    return nullptr;
+  }
+
+  return matchIsNaNTest(Cmp, X, MatchIsNaN, IC) ? X : nullptr;
+}
+
 // Fold a select of an ordered fcmp using fabs of a NaN-scrubbed value:
-//   %ord = fcmp ord T %x, 0.0
-//   %s   = select i1 %ord, T %x, T %y
+//   %s   = select i1 (isnotnan T %x), T %x, T %y
 //   %a   = call T @llvm.fabs.T(T %s)
 //   %c   = fcmp <ordered-pred> T %a, %k
 //   %r   = select i1 %c, T %s, T %y
@@ -3377,16 +3418,8 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
   if (!InnerSel)
     return nullptr;
 
-  // Match: select (fcmp ord X, 0.0), X, Y
-  auto *InnerCmp = dyn_cast<FCmpInst>(InnerSel->getCondition());
-  if (!InnerCmp || !InnerCmp->hasOneUse() ||
-      InnerCmp->getPredicate() != FCmpInst::FCMP_ORD ||
-      InnerSel->getFalseValue() != Y)
-    return nullptr;
-
-  X = InnerSel->getTrueValue();
-  if (InnerCmp->getOperand(0) != X ||
-      !match(InnerCmp->getOperand(1), m_AnyZeroFP()))
+  X = matchNaNScrubbedValue(InnerSel, Y, IC);
+  if (!X)
     return nullptr;
 
   bool Swapped = false;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3439,11 +3439,10 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
   }
 
   Value *NewAbs = IC.Builder.CreateUnaryIntrinsic(Intrinsic::fabs, X);
-  Value *NewCmp = Swapped
-                      ? IC.Builder.CreateFCmpFMF(OuterCmp->getPredicate(),
-                                                 OtherOp, NewAbs, OuterCmp)
-                      : IC.Builder.CreateFCmpFMF(OuterCmp->getPredicate(),
-                                                 NewAbs, OtherOp, OuterCmp);
+  Value *NewCmp = Swapped ? IC.Builder.CreateFCmpFMF(OuterCmp->getPredicate(),
+                                                     OtherOp, NewAbs, OuterCmp)
+                          : IC.Builder.CreateFCmpFMF(OuterCmp->getPredicate(),
+                                                     NewAbs, OtherOp, OuterCmp);
   Value *NewSel = IC.Builder.CreateSelectFMF(NewCmp, X, Y, &SI);
   return IC.replaceInstUsesWith(SI, NewSel);
 }

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3347,19 +3347,6 @@ static Instruction *foldSelectWithFCmpToFabs(SelectInst &SI,
   return ChangedFMF ? &SI : nullptr;
 }
 
-// Match a select that returns X when X is not NaN, and Y otherwise.
-static Value *matchNaNScrubbedValue(Value *V, Value *Y) {
-  Value *Cond, *X;
-  if (!match(V, m_Select(m_Value(Cond), m_Value(X), m_Specific(Y))))
-    return nullptr;
-
-  if (!match(Cond, m_OneUse(m_SpecificFCmp(FCmpInst::FCMP_ORD, m_Specific(X),
-                                           m_AnyZeroFP()))))
-    return nullptr;
-
-  return X;
-}
-
 // Fold a select of an ordered fcmp using fabs of a NaN-scrubbed value:
 //   %s   = select i1 (isnotnan T %x), T %x, T %y
 //   %a   = call T @llvm.fabs.T(T %s)
@@ -3386,8 +3373,12 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
 
   Value *Y = SI.getFalseValue();
   Value *InnerSel = SI.getTrueValue();
-  Value *X = matchNaNScrubbedValue(InnerSel, Y);
-  if (!X)
+  // Match a select that returns X when X is not NaN, and Y otherwise.
+  Value *X;
+  if (!match(InnerSel,
+             m_Select(m_OneUse(m_SpecificFCmp(FCmpInst::FCMP_ORD, m_Value(X),
+                                              m_AnyZeroFP())),
+                      m_Deferred(X), m_Specific(Y))))
     return nullptr;
 
   if (!match(Cmp0, m_OneUse(m_FAbs(m_Specific(InnerSel))))) {
@@ -3398,7 +3389,7 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
     Pred = CmpInst::getSwappedPredicate(Pred);
   }
 
-  Value *NewAbs = IC.Builder.CreateUnaryIntrinsic(Intrinsic::fabs, X);
+  Value *NewAbs = IC.Builder.CreateFAbs(X);
 
   // Do not preserve nnan on the new fcmp: when X is NaN, the old compare
   // evaluated fabs(Y), while the new compare evaluates fabs(X).

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3347,20 +3347,20 @@ static Instruction *foldSelectWithFCmpToFabs(SelectInst &SI,
   return ChangedFMF ? &SI : nullptr;
 }
 
-static bool matchIsNaNTest(FCmpInst *Cmp, Value *X, bool MatchIsNaN,
-                           InstCombinerImpl &IC) {
-  FCmpInst::Predicate ExpectedPred =
-      MatchIsNaN ? FCmpInst::FCMP_UNO : FCmpInst::FCMP_ORD;
-  if (Cmp->getPredicate() != ExpectedPred)
+static bool matchIsNotNaNTest(Value *Cond, Value *X, InstCombinerImpl &IC) {
+  Instruction *CmpI;
+  Value *Cmp0, *Cmp1;
+  if (!match(Cond, m_OneUse(m_Instruction(
+                       CmpI, m_SpecificFCmp(FCmpInst::FCMP_ORD, m_Value(Cmp0),
+                                            m_Value(Cmp1))))))
     return false;
 
-  Value *Cmp0 = Cmp->getOperand(0), *Cmp1 = Cmp->getOperand(1);
   if (Cmp0 == X && Cmp1 == X)
     return true;
 
   auto IsKnownNeverNaN = [&](Value *V) {
     return match(V, m_NonNaN()) ||
-           isKnownNeverNaN(V, IC.getSimplifyQuery().getWithInstruction(Cmp));
+           isKnownNeverNaN(V, IC.getSimplifyQuery().getWithInstruction(CmpI));
   };
 
   return (Cmp0 == X && IsKnownNeverNaN(Cmp1)) ||
@@ -3368,25 +3368,12 @@ static bool matchIsNaNTest(FCmpInst *Cmp, Value *X, bool MatchIsNaN,
 }
 
 // Match a select that returns X when X is not NaN, and Y otherwise.
-static Value *matchNaNScrubbedValue(SelectInst *SI, Value *Y,
-                                    InstCombinerImpl &IC) {
-  auto *Cmp = dyn_cast<FCmpInst>(SI->getCondition());
-  if (!Cmp || !Cmp->hasOneUse())
+static Value *matchNaNScrubbedValue(Value *V, Value *Y, InstCombinerImpl &IC) {
+  Value *Cond, *X;
+  if (!match(V, m_Select(m_Value(Cond), m_Value(X), m_Specific(Y))))
     return nullptr;
 
-  Value *X;
-  bool MatchIsNaN;
-  if (SI->getFalseValue() == Y) {
-    X = SI->getTrueValue();
-    MatchIsNaN = false;
-  } else if (SI->getTrueValue() == Y) {
-    X = SI->getFalseValue();
-    MatchIsNaN = true;
-  } else {
-    return nullptr;
-  }
-
-  return matchIsNaNTest(Cmp, X, MatchIsNaN, IC) ? X : nullptr;
+  return matchIsNotNaNTest(Cond, X, IC) ? X : nullptr;
 }
 
 // Fold a select of an ordered fcmp using fabs of a NaN-scrubbed value:
@@ -3401,9 +3388,15 @@ static Value *matchNaNScrubbedValue(SelectInst *SI, Value *Y,
 static Instruction *
 foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
                                              InstCombinerImpl &IC) {
-  auto *OuterCmp = dyn_cast<FCmpInst>(SI.getCondition());
-  if (!OuterCmp || !OuterCmp->hasOneUse() ||
-      !FCmpInst::isOrdered(OuterCmp->getPredicate()))
+  Instruction *OuterCmpI;
+  Value *Cmp0, *Cmp1;
+  if (!match(SI.getCondition(),
+             m_OneUse(m_Instruction(OuterCmpI,
+                                    m_FCmp(m_Value(Cmp0), m_Value(Cmp1))))))
+    return nullptr;
+
+  auto *OuterCmp = cast<FCmpInst>(OuterCmpI);
+  if (!FCmpInst::isOrdered(OuterCmp->getPredicate()))
     return nullptr;
 
   // The NaN path now evaluates fabs(X) instead of fabs(Y), so preserving nnan
@@ -3412,28 +3405,18 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
     return nullptr;
 
   Value *Y = SI.getFalseValue();
-  Value *X = nullptr;
-
-  auto *InnerSel = dyn_cast<SelectInst>(SI.getTrueValue());
-  if (!InnerSel)
-    return nullptr;
-
-  X = matchNaNScrubbedValue(InnerSel, Y, IC);
+  Value *InnerSel = SI.getTrueValue();
+  Value *X = matchNaNScrubbedValue(InnerSel, Y, IC);
   if (!X)
     return nullptr;
 
   bool Swapped = false;
   Value *OtherOp = nullptr;
-  auto *FAbs = dyn_cast<IntrinsicInst>(OuterCmp->getOperand(0));
-
-  if (FAbs && FAbs->hasOneUse() && FAbs->getIntrinsicID() == Intrinsic::fabs &&
-      FAbs->getArgOperand(0) == InnerSel) {
-    OtherOp = OuterCmp->getOperand(1);
-  } else if ((FAbs = dyn_cast<IntrinsicInst>(OuterCmp->getOperand(1))) &&
-             FAbs->hasOneUse() && FAbs->getIntrinsicID() == Intrinsic::fabs &&
-             FAbs->getArgOperand(0) == InnerSel) {
+  if (match(Cmp0, m_OneUse(m_FAbs(m_Specific(InnerSel))))) {
+    OtherOp = Cmp1;
+  } else if (match(Cmp1, m_OneUse(m_FAbs(m_Specific(InnerSel))))) {
     Swapped = true;
-    OtherOp = OuterCmp->getOperand(0);
+    OtherOp = Cmp0;
   } else {
     return nullptr;
   }

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3348,23 +3348,28 @@ static Instruction *foldSelectWithFCmpToFabs(SelectInst &SI,
 }
 
 static bool matchIsNotNaNTest(Value *Cond, Value *X, InstCombinerImpl &IC) {
-  Instruction *CmpI;
-  Value *Cmp0, *Cmp1;
-  if (!match(Cond, m_OneUse(m_Instruction(
-                       CmpI, m_SpecificFCmp(FCmpInst::FCMP_ORD, m_Value(Cmp0),
-                                            m_Value(Cmp1))))))
-    return false;
-
-  if (Cmp0 == X && Cmp1 == X)
+  // Match: fcmp ord X, X
+  if (match(Cond, m_OneUse(m_SpecificFCmp(FCmpInst::FCMP_ORD, m_Specific(X),
+                                          m_Specific(X)))))
     return true;
 
-  auto IsKnownNeverNaN = [&](Value *V) {
-    return match(V, m_NonNaN()) ||
-           isKnownNeverNaN(V, IC.getSimplifyQuery().getWithInstruction(CmpI));
-  };
+  Instruction *CmpI;
+  Value *Other;
 
-  return (Cmp0 == X && IsKnownNeverNaN(Cmp1)) ||
-         (Cmp1 == X && IsKnownNeverNaN(Cmp0));
+  // Match:
+  //   fcmp ord X, Other
+  //   fcmp ord Other, X
+  // where Other is known non-NaN.
+  if (!match(Cond,
+             m_OneUse(m_Instruction(
+                 CmpI,
+                 m_CombineOr(m_SpecificFCmp(FCmpInst::FCMP_ORD, m_Specific(X),
+                                            m_Value(Other)),
+                             m_SpecificFCmp(FCmpInst::FCMP_ORD, m_Value(Other),
+                                            m_Specific(X)))))))
+    return false;
+
+  return isKnownNeverNaN(Other, IC.getSimplifyQuery().getWithInstruction(CmpI));
 }
 
 // Match a select that returns X when X is not NaN, and Y otherwise.
@@ -3399,11 +3404,6 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
   if (!FCmpInst::isOrdered(OuterCmp->getPredicate()))
     return nullptr;
 
-  // The NaN path now evaluates fabs(X) instead of fabs(Y), so preserving nnan
-  // on the fcmp could introduce poison when X is NaN.
-  if (OuterCmp->hasNoNaNs())
-    return nullptr;
-
   Value *Y = SI.getFalseValue();
   Value *InnerSel = SI.getTrueValue();
   Value *X = matchNaNScrubbedValue(InnerSel, Y, IC);
@@ -3422,10 +3422,18 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
   }
 
   Value *NewAbs = IC.Builder.CreateUnaryIntrinsic(Intrinsic::fabs, X);
-  Value *NewCmp = Swapped ? IC.Builder.CreateFCmpFMF(OuterCmp->getPredicate(),
-                                                     OtherOp, NewAbs, OuterCmp)
-                          : IC.Builder.CreateFCmpFMF(OuterCmp->getPredicate(),
-                                                     NewAbs, OtherOp, OuterCmp);
+
+  // Do not preserve nnan on the new fcmp: when X is NaN, the old compare
+  // evaluated fabs(Y), while the new compare evaluates fabs(X).
+  FastMathFlags NewCmpFMF = OuterCmp->getFastMathFlags();
+  NewCmpFMF.setNoNaNs(false);
+
+  Value *NewCmp =
+      Swapped ? IC.Builder.CreateFCmpFMF(OuterCmp->getPredicate(), OtherOp,
+                                         NewAbs, FMFSource(NewCmpFMF))
+              : IC.Builder.CreateFCmpFMF(OuterCmp->getPredicate(), NewAbs,
+                                         OtherOp, FMFSource(NewCmpFMF));
+
   Value *NewSel = IC.Builder.CreateSelectFMF(NewCmp, X, Y, &SI);
   return IC.replaceInstUsesWith(SI, NewSel);
 }

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3348,11 +3348,6 @@ static Instruction *foldSelectWithFCmpToFabs(SelectInst &SI,
 }
 
 static bool matchIsNotNaNTest(Value *Cond, Value *X, InstCombinerImpl &IC) {
-  // Match: fcmp ord X, X
-  if (match(Cond, m_OneUse(m_SpecificFCmp(FCmpInst::FCMP_ORD, m_Specific(X),
-                                          m_Specific(X)))))
-    return true;
-
   Instruction *CmpI;
   Value *Other;
 
@@ -3401,7 +3396,8 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
     return nullptr;
 
   auto *OuterCmp = cast<FCmpInst>(OuterCmpI);
-  if (!FCmpInst::isOrdered(OuterCmp->getPredicate()))
+  CmpInst::Predicate Pred = OuterCmp->getPredicate();
+  if (!FCmpInst::isOrdered(Pred))
     return nullptr;
 
   Value *Y = SI.getFalseValue();
@@ -3410,15 +3406,12 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
   if (!X)
     return nullptr;
 
-  bool Swapped = false;
-  Value *OtherOp = nullptr;
-  if (match(Cmp0, m_OneUse(m_FAbs(m_Specific(InnerSel))))) {
-    OtherOp = Cmp1;
-  } else if (match(Cmp1, m_OneUse(m_FAbs(m_Specific(InnerSel))))) {
-    Swapped = true;
-    OtherOp = Cmp0;
-  } else {
-    return nullptr;
+  if (!match(Cmp0, m_OneUse(m_FAbs(m_Specific(InnerSel))))) {
+    if (!match(Cmp1, m_OneUse(m_FAbs(m_Specific(InnerSel)))))
+      return nullptr;
+
+    std::swap(Cmp0, Cmp1);
+    Pred = CmpInst::getSwappedPredicate(Pred);
   }
 
   Value *NewAbs = IC.Builder.CreateUnaryIntrinsic(Intrinsic::fabs, X);
@@ -3429,10 +3422,7 @@ foldSelectOfOrderedFAbsCmpOfNaNScrubbedValue(SelectInst &SI,
   NewCmpFMF.setNoNaNs(false);
 
   Value *NewCmp =
-      Swapped ? IC.Builder.CreateFCmpFMF(OuterCmp->getPredicate(), OtherOp,
-                                         NewAbs, FMFSource(NewCmpFMF))
-              : IC.Builder.CreateFCmpFMF(OuterCmp->getPredicate(), NewAbs,
-                                         OtherOp, FMFSource(NewCmpFMF));
+      IC.Builder.CreateFCmpFMF(Pred, NewAbs, Cmp1, FMFSource(NewCmpFMF));
 
   Value *NewSel = IC.Builder.CreateSelectFMF(NewCmp, X, Y, &SI);
   return IC.replaceInstUsesWith(SI, NewSel);

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -311,21 +311,6 @@ define double @test_fcmp_ord_commuted_select_fabs_fcmp_one_select_var_const(doub
   ret double %sel2
 }
 
-define double @test_fcmp_uno_select_fabs_fcmp_one_select_var_var(double %x, double %y) {
-; CHECK-LABEL: @test_fcmp_uno_select_fabs_fcmp_one_select_var_var(
-; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
-; CHECK-NEXT:    [[CMP:%.*]] = fcmp one double [[ABS]], 0x7FF0000000000000
-; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
-; CHECK-NEXT:    ret double [[SEL]]
-;
-  %cmp1 = fcmp uno double %x, 0.000000e+00
-  %sel1 = select i1 %cmp1, double %y, double %x
-  %abs = call double @llvm.fabs.f64(double %sel1)
-  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
-  %sel2 = select i1 %cmp2, double %sel1, double %y
-  ret double %sel2
-}
-
 define double @test_fcmp_ord_select_fabs_fcmp_one_select_nonnan_const(double %x, double %y) {
 ; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_one_select_nonnan_const(
 ; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
@@ -382,22 +367,6 @@ define double @test_fcmp_ord_commuted_select_fabs_fcmp_one_select_sitofp_nonnan(
   %nonnan = sitofp i32 %i to double
   %cmp1 = fcmp ord double %nonnan, %x
   %sel1 = select i1 %cmp1, double %x, double %y
-  %abs = call double @llvm.fabs.f64(double %sel1)
-  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
-  %sel2 = select i1 %cmp2, double %sel1, double %y
-  ret double %sel2
-}
-
-define double @test_fcmp_uno_select_fabs_fcmp_one_select_uitofp_nonnan(double %x, double %y, i32 %i) {
-; CHECK-LABEL: @test_fcmp_uno_select_fabs_fcmp_one_select_uitofp_nonnan(
-; CHECK:         [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
-; CHECK-NEXT:    [[CMP:%.*]] = fcmp one double [[ABS]], 0x7FF0000000000000
-; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
-; CHECK-NEXT:    ret double [[SEL]]
-;
-  %nonnan = uitofp i32 %i to double
-  %cmp1 = fcmp uno double %x, %nonnan
-  %sel1 = select i1 %cmp1, double %y, double %x
   %abs = call double @llvm.fabs.f64(double %sel1)
   %cmp2 = fcmp one double %abs, 0x7FF0000000000000
   %sel2 = select i1 %cmp2, double %sel1, double %y

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -3,6 +3,7 @@
 
 declare void @use(i1)
 declare void @usef64(double)
+declare double @llvm.fabs.f64(double)
 
 ; X == 42.0 ? X : 42.0 --> 42.0
 
@@ -278,6 +279,70 @@ define i1 @test_fcmp_ord_select_fcmp_oeq_var_const(double %x) {
   %sel = select i1 %cmp1, double %x, double 0.000000e+00
   %cmp2 = fcmp oeq double %sel, 1.000000e+00
   ret i1 %cmp2
+}
+
+define double @test_fcmp_ord_select_fabs_fcmp_one_select_var_const(double %x) {
+; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_one_select_var_const(
+; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp one double [[ABS]], 0x7FF0000000000000
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double 0.000000e+00
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %cmp1 = fcmp ord double %x, 0.000000e+00
+  %sel1 = select i1 %cmp1, double %x, double 0.000000e+00
+  %abs = call double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %sel2 = select i1 %cmp2, double %sel1, double 0.000000e+00
+  ret double %sel2
+}
+
+define double @test_fcmp_ord_select_fabs_fcmp_une_select_var_const(double %x) {
+; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_une_select_var_const(
+; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ord double [[X:%.*]], 0.000000e+00
+; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[CMP1]], double [[X]], double 0.000000e+00
+; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[SEL1]])
+; CHECK-NEXT:    [[CMP2:%.*]] = fcmp une double [[ABS]], 0x7FF0000000000000
+; CHECK-NEXT:    [[SEL2:%.*]] = select i1 [[CMP2]], double [[SEL1]], double 0.000000e+00
+; CHECK-NEXT:    ret double [[SEL2]]
+;
+  %cmp1 = fcmp ord double %x, 0.000000e+00
+  %sel1 = select i1 %cmp1, double %x, double 0.000000e+00
+  %abs = call double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp une double %abs, 0x7FF0000000000000
+  %sel2 = select i1 %cmp2, double %sel1, double 0.000000e+00
+  ret double %sel2
+}
+
+define double @test_fcmp_ord_select_fabs_fcmp_nnan_one_select_var_var(double %x, double %y) {
+; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_nnan_one_select_var_var(
+; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ord double [[X:%.*]], 0.000000e+00
+; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[CMP1]], double [[X]], double [[Y:%.*]]
+; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[SEL1]])
+; CHECK-NEXT:    [[CMP2:%.*]] = fcmp nnan one double [[ABS]], 0x7FF0000000000000
+; CHECK-NEXT:    [[SEL2:%.*]] = select i1 [[CMP2]], double [[SEL1]], double [[Y]]
+; CHECK-NEXT:    ret double [[SEL2]]
+;
+  %cmp1 = fcmp ord double %x, 0.000000e+00
+  %sel1 = select i1 %cmp1, double %x, double %y
+  %abs = call double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp nnan one double %abs, 0x7FF0000000000000
+  %sel2 = select i1 %cmp2, double %sel1, double %y
+  ret double %sel2
+}
+
+define double @test_fcmp_ord_select_fabs_rhs_fcmp_ogt_select_var_var(double %x, double %y, double %k) {
+; CHECK-LABEL: @test_fcmp_ord_select_fabs_rhs_fcmp_ogt_select_var_var(
+; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp ninf ogt double [[K:%.*]], [[ABS]]
+; CHECK-NEXT:    [[SEL:%.*]] = select nnan i1 [[CMP]], double [[X]], double [[Y:%.*]]
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %cmp1 = fcmp ord double %x, 0.000000e+00
+  %sel1 = select i1 %cmp1, double %x, double %y
+  %abs = call ninf double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp ninf ogt double %k, %abs
+  %sel2 = select nnan i1 %cmp2, double %sel1, double %y
+  ret double %sel2
 }
 
 ; Make sure that we recognize the SPF correctly.

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -4,6 +4,7 @@
 declare void @use(i1)
 declare void @usef64(double)
 declare double @llvm.fabs.f64(double)
+declare <2 x double> @llvm.fabs.v2f64(<2 x double>)
 
 ; X == 42.0 ? X : 42.0 --> 42.0
 
@@ -408,12 +409,10 @@ define double @test_fcmp_ord_select_fabs_fcmp_une_select_var_const(double %x) {
 
 define double @test_fcmp_ord_select_fabs_fcmp_nnan_one_select_var_var(double %x, double %y) {
 ; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_nnan_one_select_var_var(
-; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ord double [[X:%.*]], 0.000000e+00
-; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[CMP1]], double [[X]], double [[Y:%.*]]
-; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[SEL1]])
-; CHECK-NEXT:    [[CMP2:%.*]] = fcmp nnan one double [[ABS]], 0x7FF0000000000000
-; CHECK-NEXT:    [[SEL2:%.*]] = select i1 [[CMP2]], double [[SEL1]], double [[Y]]
-; CHECK-NEXT:    ret double [[SEL2]]
+; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp one double [[ABS]], 0x7FF0000000000000
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
+; CHECK-NEXT:    ret double [[SEL]]
 ;
   %cmp1 = fcmp ord double %x, 0.000000e+00
   %sel1 = select i1 %cmp1, double %x, double %y
@@ -436,6 +435,52 @@ define double @test_fcmp_ord_select_fabs_rhs_fcmp_ogt_select_var_var(double %x, 
   %cmp2 = fcmp ninf ogt double %k, %abs
   %sel2 = select nnan i1 %cmp2, double %sel1, double %y
   ret double %sel2
+}
+
+define <2 x double> @test_fcmp_ord_select_fabs_fcmp_one_select_v2f64(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_one_select_v2f64(
+; CHECK-NEXT:    [[ABS:%.*]] = call <2 x double> @llvm.fabs.v2f64(<2 x double> [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp one <2 x double> [[ABS]], splat (double 0x7FF0000000000000)
+; CHECK-NEXT:    [[SEL:%.*]] = select <2 x i1> [[CMP]], <2 x double> [[X]], <2 x double> [[Y:%.*]]
+; CHECK-NEXT:    ret <2 x double> [[SEL]]
+;
+  %cmp1 = fcmp ord <2 x double> %x, zeroinitializer
+  %sel1 = select <2 x i1> %cmp1, <2 x double> %x, <2 x double> %y
+  %abs = call <2 x double> @llvm.fabs.v2f64(<2 x double> %sel1)
+  %cmp2 = fcmp one <2 x double> %abs, <double 0x7FF0000000000000, double 0x7FF0000000000000>
+  %sel2 = select <2 x i1> %cmp2, <2 x double> %sel1, <2 x double> %y
+  ret <2 x double> %sel2
+}
+
+define <2 x double> @test_fcmp_ord_select_fabs_fcmp_one_select_uitofp_v2f64(<2 x double> %x, <2 x double> %y, <2 x i32> %i) {
+; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_one_select_uitofp_v2f64(
+; CHECK:         [[ABS:%.*]] = call <2 x double> @llvm.fabs.v2f64(<2 x double> [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp one <2 x double> [[ABS]], splat (double 0x7FF0000000000000)
+; CHECK-NEXT:    [[SEL:%.*]] = select <2 x i1> [[CMP]], <2 x double> [[X]], <2 x double> [[Y:%.*]]
+; CHECK-NEXT:    ret <2 x double> [[SEL]]
+;
+  %nonnan = uitofp <2 x i32> %i to <2 x double>
+  %cmp1 = fcmp ord <2 x double> %x, %nonnan
+  %sel1 = select <2 x i1> %cmp1, <2 x double> %x, <2 x double> %y
+  %abs = call <2 x double> @llvm.fabs.v2f64(<2 x double> %sel1)
+  %cmp2 = fcmp one <2 x double> %abs, <double 0x7FF0000000000000, double 0x7FF0000000000000>
+  %sel2 = select <2 x i1> %cmp2, <2 x double> %sel1, <2 x double> %y
+  ret <2 x double> %sel2
+}
+
+define <2 x double> @test_fcmp_ord_select_fabs_fcmp_nnan_one_select_v2f64(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_nnan_one_select_v2f64(
+; CHECK-NEXT:    [[ABS:%.*]] = call <2 x double> @llvm.fabs.v2f64(<2 x double> [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp one <2 x double> [[ABS]], splat (double 0x7FF0000000000000)
+; CHECK-NEXT:    [[SEL:%.*]] = select <2 x i1> [[CMP]], <2 x double> [[X]], <2 x double> [[Y:%.*]]
+; CHECK-NEXT:    ret <2 x double> [[SEL]]
+;
+  %cmp1 = fcmp ord <2 x double> %x, zeroinitializer
+  %sel1 = select <2 x i1> %cmp1, <2 x double> %x, <2 x double> %y
+  %abs = call <2 x double> @llvm.fabs.v2f64(<2 x double> %sel1)
+  %cmp2 = fcmp nnan one <2 x double> %abs, <double 0x7FF0000000000000, double 0x7FF0000000000000>
+  %sel2 = select <2 x i1> %cmp2, <2 x double> %sel1, <2 x double> %y
+  ret <2 x double> %sel2
 }
 
 ; Make sure that we recognize the SPF correctly.

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -296,6 +296,130 @@ define double @test_fcmp_ord_select_fabs_fcmp_one_select_var_const(double %x) {
   ret double %sel2
 }
 
+define double @test_fcmp_ord_commuted_select_fabs_fcmp_one_select_var_const(double %x) {
+; CHECK-LABEL: @test_fcmp_ord_commuted_select_fabs_fcmp_one_select_var_const(
+; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp one double [[ABS]], 0x7FF0000000000000
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double 0.000000e+00
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %cmp1 = fcmp ord double 0.000000e+00, %x
+  %sel1 = select i1 %cmp1, double %x, double 0.000000e+00
+  %abs = call double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %sel2 = select i1 %cmp2, double %sel1, double 0.000000e+00
+  ret double %sel2
+}
+
+define double @test_fcmp_uno_select_fabs_fcmp_one_select_var_var(double %x, double %y) {
+; CHECK-LABEL: @test_fcmp_uno_select_fabs_fcmp_one_select_var_var(
+; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp one double [[ABS]], 0x7FF0000000000000
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %cmp1 = fcmp uno double %x, 0.000000e+00
+  %sel1 = select i1 %cmp1, double %y, double %x
+  %abs = call double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %sel2 = select i1 %cmp2, double %sel1, double %y
+  ret double %sel2
+}
+
+define double @test_fcmp_ord_select_fabs_fcmp_one_select_nonnan_const(double %x, double %y) {
+; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_one_select_nonnan_const(
+; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp one double [[ABS]], 0x7FF0000000000000
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %cmp1 = fcmp ord double %x, 1.000000e+00
+  %sel1 = select i1 %cmp1, double %x, double %y
+  %abs = call double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %sel2 = select i1 %cmp2, double %sel1, double %y
+  ret double %sel2
+}
+
+define double @test_fcmp_ord_self_select_fabs_fcmp_one_select_var_var(double %x, double %y) {
+; CHECK-LABEL: @test_fcmp_ord_self_select_fabs_fcmp_one_select_var_var(
+; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp one double [[ABS]], 0x7FF0000000000000
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %cmp1 = fcmp ord double %x, %x
+  %sel1 = select i1 %cmp1, double %x, double %y
+  %abs = call double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %sel2 = select i1 %cmp2, double %sel1, double %y
+  ret double %sel2
+}
+
+define double @test_fcmp_ord_select_fabs_fcmp_one_select_uitofp_nonnan(double %x, double %y, i32 %i) {
+; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_one_select_uitofp_nonnan(
+; CHECK:         [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp one double [[ABS]], 0x7FF0000000000000
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %nonnan = uitofp i32 %i to double
+  %cmp1 = fcmp ord double %x, %nonnan
+  %sel1 = select i1 %cmp1, double %x, double %y
+  %abs = call double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %sel2 = select i1 %cmp2, double %sel1, double %y
+  ret double %sel2
+}
+
+define double @test_fcmp_ord_commuted_select_fabs_fcmp_one_select_sitofp_nonnan(double %x, double %y, i32 %i) {
+; CHECK-LABEL: @test_fcmp_ord_commuted_select_fabs_fcmp_one_select_sitofp_nonnan(
+; CHECK:         [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp one double [[ABS]], 0x7FF0000000000000
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %nonnan = sitofp i32 %i to double
+  %cmp1 = fcmp ord double %nonnan, %x
+  %sel1 = select i1 %cmp1, double %x, double %y
+  %abs = call double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %sel2 = select i1 %cmp2, double %sel1, double %y
+  ret double %sel2
+}
+
+define double @test_fcmp_uno_select_fabs_fcmp_one_select_uitofp_nonnan(double %x, double %y, i32 %i) {
+; CHECK-LABEL: @test_fcmp_uno_select_fabs_fcmp_one_select_uitofp_nonnan(
+; CHECK:         [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp one double [[ABS]], 0x7FF0000000000000
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %nonnan = uitofp i32 %i to double
+  %cmp1 = fcmp uno double %x, %nonnan
+  %sel1 = select i1 %cmp1, double %y, double %x
+  %abs = call double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp one double %abs, 0x7FF0000000000000
+  %sel2 = select i1 %cmp2, double %sel1, double %y
+  ret double %sel2
+}
+
+define double @test_fcmp_ord_select_fabs_rhs_fcmp_ogt_select_uitofp_nonnan(double %x, double %y, double %k, i32 %i) {
+; CHECK-LABEL: @test_fcmp_ord_select_fabs_rhs_fcmp_ogt_select_uitofp_nonnan(
+; CHECK:         [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp ogt double [[K:%.*]], [[ABS]]
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %nonnan = uitofp i32 %i to double
+  %cmp1 = fcmp ord double %x, %nonnan
+  %sel1 = select i1 %cmp1, double %x, double %y
+  %abs = call double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp ogt double %k, %abs
+  %sel2 = select i1 %cmp2, double %sel1, double %y
+  ret double %sel2
+}
+
 define double @test_fcmp_ord_select_fabs_fcmp_une_select_var_const(double %x) {
 ; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_une_select_var_const(
 ; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ord double [[X:%.*]], 0.000000e+00

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -377,7 +377,7 @@ define double @test_fcmp_ord_commuted_select_fabs_fcmp_one_select_sitofp_nonnan(
 define double @test_fcmp_ord_select_fabs_rhs_fcmp_ogt_select_uitofp_nonnan(double %x, double %y, double %k, i32 %i) {
 ; CHECK-LABEL: @test_fcmp_ord_select_fabs_rhs_fcmp_ogt_select_uitofp_nonnan(
 ; CHECK:         [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
-; CHECK-NEXT:    [[CMP:%.*]] = fcmp ogt double [[K:%.*]], [[ABS]]
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp olt double [[ABS]], [[K:%.*]]
 ; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
 ; CHECK-NEXT:    ret double [[SEL]]
 ;
@@ -425,7 +425,7 @@ define double @test_fcmp_ord_select_fabs_fcmp_nnan_one_select_var_var(double %x,
 define double @test_fcmp_ord_select_fabs_rhs_fcmp_ogt_select_var_var(double %x, double %y, double %k) {
 ; CHECK-LABEL: @test_fcmp_ord_select_fabs_rhs_fcmp_ogt_select_var_var(
 ; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
-; CHECK-NEXT:    [[CMP:%.*]] = fcmp ninf ogt double [[K:%.*]], [[ABS]]
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp ninf olt double [[ABS]], [[K:%.*]]
 ; CHECK-NEXT:    [[SEL:%.*]] = select nnan i1 [[CMP]], double [[X]], double [[Y:%.*]]
 ; CHECK-NEXT:    ret double [[SEL]]
 ;

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -424,7 +424,7 @@ define double @test_fcmp_ord_select_fabs_fcmp_nnan_one_select_var_var(double %x,
 
 define double @test_fcmp_ord_select_fabs_rhs_fcmp_ogt_select_var_var(double %x, double %y, double %k) {
 ; CHECK-LABEL: @test_fcmp_ord_select_fabs_rhs_fcmp_ogt_select_var_var(
-; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[ABS:%.*]] = call ninf double @llvm.fabs.f64(double [[X:%.*]])
 ; CHECK-NEXT:    [[CMP:%.*]] = fcmp ninf olt double [[ABS]], [[K:%.*]]
 ; CHECK-NEXT:    [[SEL:%.*]] = select nnan i1 [[CMP]], double [[X]], double [[Y:%.*]]
 ; CHECK-NEXT:    ret double [[SEL]]
@@ -481,6 +481,51 @@ define <2 x double> @test_fcmp_ord_select_fabs_fcmp_nnan_one_select_v2f64(<2 x d
   %cmp2 = fcmp nnan one <2 x double> %abs, <double 0x7FF0000000000000, double 0x7FF0000000000000>
   %sel2 = select <2 x i1> %cmp2, <2 x double> %sel1, <2 x double> %y
   ret <2 x double> %sel2
+}
+
+define double @test_fcmp_ord_select_fabs_fcmp_fabs_only_ninf(double %x, double %y, double %k) {
+; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_fabs_only_ninf(
+; CHECK-NEXT:    [[ABS:%.*]] = call ninf double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp one double [[ABS]], [[K:%.*]]
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %cmp1 = fcmp ord double %x, 0.000000e+00
+  %sel1 = select i1 %cmp1, double %x, double %y
+  %abs = call ninf double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp one double %abs, %k
+  %sel2 = select i1 %cmp2, double %sel1, double %y
+  ret double %sel2
+}
+
+define double @test_fcmp_ord_select_fabs_fcmp_cmp_only_ninf(double %x, double %y, double %k) {
+; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_cmp_only_ninf(
+; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp ninf one double [[ABS]], [[K:%.*]]
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %cmp1 = fcmp ord double %x, 0.000000e+00
+  %sel1 = select i1 %cmp1, double %x, double %y
+  %abs = call double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp ninf one double %abs, %k
+  %sel2 = select i1 %cmp2, double %sel1, double %y
+  ret double %sel2
+}
+
+define double @test_fcmp_ord_select_fabs_fcmp_intersect_drop_nnan(double %x, double %y, double %k) {
+; CHECK-LABEL: @test_fcmp_ord_select_fabs_fcmp_intersect_drop_nnan(
+; CHECK-NEXT:    [[ABS:%.*]] = call ninf double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp ninf one double [[ABS]], [[K:%.*]]
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[X]], double [[Y:%.*]]
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %cmp1 = fcmp ord double %x, 0.000000e+00
+  %sel1 = select i1 %cmp1, double %x, double %y
+  %abs = call nnan ninf double @llvm.fabs.f64(double %sel1)
+  %cmp2 = fcmp nnan ninf one double %abs, %k
+  %sel2 = select i1 %cmp2, double %sel1, double %y
+  ret double %sel2
 }
 
 ; Make sure that we recognize the SPF correctly.


### PR DESCRIPTION
Fold `select (fcmp <ordered> (fabs (select isKnownNeverNaN X, X, Y)), K), ...` into a single compare/select directly on `X`. The outer fcmp is limited to ordered predicates, since only they preserve the original non-NaN behavior.


fixes #143649 
alive2: https://alive2.llvm.org/ce/z/G8UmjY


Generalized proof (needs local alive2 build):
```alive2
declare double @llvm.fabs.f64(double)

define double @src(double %x, double %y, double %k) {
entry:
  %ord = fcmp ord double %x, 0.000000e+00
  %s = select i1 %ord, double %x, double %y
  %a = call double @llvm.fabs.f64(double %s)
  %c = fcmp one double %a, %k
  %r = select i1 %c, double %s, double %y
  ret double %r
}

define double @tgt(double %x, double %y, double %k) {
entry:
  %a2 = call double @llvm.fabs.f64(double %x)
  %c2 = fcmp one double %a2, %k
  %r2 = select i1 %c2, double %x, double %y
  ret double %r2
}
```