### PR TITLE
[mlir][LLVM] Add fastmath flags support to fpext/fptrunc ops.

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -588,6 +588,25 @@ class LLVM_CastOpWithOverflowFlag<string mnemonic, string instName, Type type,
   }];
 }
 
+class LLVM_CastOpWithFastMathFlag<string mnemonic, string instName, Type type,
+                  Type resultType, list<Trait> traits = []> :
+    LLVM_Op<mnemonic, !listconcat([Pure], [DeclareOpInterfaceMethods<FastmathFlagsInterface>], traits)>,
+    LLVM_Builder<"$res = builder.Create" # instName # "($arg, $_resultType);"> {
+  let arguments = (
+    ins type:$arg,
+    DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags);
+  let results = (outs resultType:$res);
+  let builders = [LLVM_OneResultOpBuilder];
+  let assemblyFormat = "$arg attr-dict `:` type($arg) `to` type($res)";
+  string llvmInstName = instName;
+  string mlirBuilder = [{
+    auto op = $_qualCppClassName::create($_builder,
+      $_location, $_resultType, $arg);
+    moduleImport.setFastmathFlagsAttr(inst, op);
+    $res = op;
+  }];
+}
+
 class LLVM_DereferenceableCastOp<string mnemonic, string instName, Type type,
                   Type resultType, list<Trait> traits = []> :
     LLVM_Op<mnemonic, !listconcat([Pure], [DeclareOpInterfaceMethods<DereferenceableOpInterface>], traits)> {
@@ -655,10 +674,10 @@ def LLVM_FPToSIOp : LLVM_CastOp<"fptosi", "FPToSI",
 def LLVM_FPToUIOp : LLVM_CastOp<"fptoui", "FPToUI",
                                 LLVM_ScalarOrVectorOf<LLVM_AnyFloat>,
                                 LLVM_ScalarOrVectorOf<AnySignlessInteger>>;
-def LLVM_FPExtOp : LLVM_CastOp<"fpext", "FPExt",
+def LLVM_FPExtOp : LLVM_CastOpWithFastMathFlag<"fpext", "FPExt",
                                 LLVM_ScalarOrVectorOf<LLVM_AnyFloat>,
                                 LLVM_ScalarOrVectorOf<LLVM_AnyFloat>>;
-def LLVM_FPTruncOp : LLVM_CastOp<"fptrunc", "FPTrunc",
+def LLVM_FPTruncOp : LLVM_CastOpWithFastMathFlag<"fptrunc", "FPTrunc",
                                  LLVM_ScalarOrVectorOf<LLVM_AnyFloat>,
                                  LLVM_ScalarOrVectorOf<LLVM_AnyFloat>>;
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -597,7 +597,8 @@ class LLVM_CastOpWithFastMathFlag<string mnemonic, string instName, Type type,
     DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags);
   let results = (outs resultType:$res);
   let builders = [LLVM_OneResultOpBuilder];
-  let assemblyFormat = "$arg attr-dict `:` type($arg) `to` type($res)";
+  let assemblyFormat = "$arg (`fastmath` `` $fastmathFlags^)? "
+                       "attr-dict `:` type($arg) `to` type($res)";
   string llvmInstName = instName;
   string mlirBuilder = [{
     auto op = $_qualCppClassName::create($_builder,

--- a/mlir/test/Target/LLVMIR/Import/fastmath.ll
+++ b/mlir/test/Target/LLVMIR/Import/fastmath.ll
@@ -21,9 +21,9 @@ define void @fastmath_inst(float %arg1, float %arg2, i1 %arg3) {
 
 ; CHECK-LABEL: @fastmath_cast
 define void @fastmath_cast(float %arg1) {
-  ; CHECK: llvm.fpext %{{.*}} : f32 to f64
+  ; CHECK: llvm.fpext %{{.*}} {fastmathFlags = #llvm.fastmath<nnan>} : f32 to f64
   %1 = fpext nnan float %arg1 to double
-  ; CHECK: llvm.fptrunc %{{.*}} : f32 to f16
+  ; CHECK: llvm.fptrunc %{{.*}} {fastmathFlags = #llvm.fastmath<fast>} : f32 to f16
   %2 = fptrunc fast float %arg1 to half
   ret void
 }

--- a/mlir/test/Target/LLVMIR/Import/fastmath.ll
+++ b/mlir/test/Target/LLVMIR/Import/fastmath.ll
@@ -19,6 +19,17 @@ define void @fastmath_inst(float %arg1, float %arg2, i1 %arg3) {
 
 ; // -----
 
+; CHECK-LABEL: @fastmath_cast
+define void @fastmath_cast(float %arg1) {
+  ; CHECK: llvm.fpext %{{.*}} : f32 to f64
+  %1 = fpext nnan float %arg1 to double
+  ; CHECK: llvm.fptrunc %{{.*}} : f32 to f16
+  %2 = fptrunc fast float %arg1 to half
+  ret void
+}
+
+; // -----
+
 ; CHECK-LABEL: @fastmath_fcmp
 define void @fastmath_fcmp(float %arg1, float %arg2) {
   ; CHECK:  llvm.fcmp "oge" %{{.*}}, %{{.*}} {fastmathFlags = #llvm.fastmath<nsz>} : f32

--- a/mlir/test/Target/LLVMIR/Import/fastmath.ll
+++ b/mlir/test/Target/LLVMIR/Import/fastmath.ll
@@ -21,9 +21,9 @@ define void @fastmath_inst(float %arg1, float %arg2, i1 %arg3) {
 
 ; CHECK-LABEL: @fastmath_cast
 define void @fastmath_cast(float %arg1) {
-  ; CHECK: llvm.fpext %{{.*}} {fastmathFlags = #llvm.fastmath<nnan>} : f32 to f64
+  ; CHECK: llvm.fpext %{{.*}} fastmath<nnan> : f32 to f64
   %1 = fpext nnan float %arg1 to double
-  ; CHECK: llvm.fptrunc %{{.*}} {fastmathFlags = #llvm.fastmath<fast>} : f32 to f16
+  ; CHECK: llvm.fptrunc %{{.*}} fastmath<fast> : f32 to f16
   %2 = fptrunc fast float %arg1 to half
   ret void
 }

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2156,8 +2156,8 @@ llvm.func @fastmathFlags(%arg0: f32, %arg1 : vector<2xf32>) {
 // CHECK: select contract i1
   %26 = llvm.select %25, %arg0, %20 {fastmathFlags = #llvm.fastmath<contract>} : i1, f32
 
-// CHECK: {{.*}} = fpext float {{.*}} to double
-// CHECK: {{.*}} = fptrunc float {{.*}} to half
+// CHECK: {{.*}} = fpext nnan float {{.*}} to double
+// CHECK: {{.*}} = fptrunc fast float {{.*}} to half
   %27 = llvm.fpext %arg0 {fastmathFlags = #llvm.fastmath<nnan>} : f32 to f64
   %28 = llvm.fptrunc %arg0 {fastmathFlags = #llvm.fastmath<fast>} : f32 to f16
   llvm.return

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2158,8 +2158,8 @@ llvm.func @fastmathFlags(%arg0: f32, %arg1 : vector<2xf32>) {
 
 // CHECK: {{.*}} = fpext nnan float {{.*}} to double
 // CHECK: {{.*}} = fptrunc fast float {{.*}} to half
-  %27 = llvm.fpext %arg0 {fastmathFlags = #llvm.fastmath<nnan>} : f32 to f64
-  %28 = llvm.fptrunc %arg0 {fastmathFlags = #llvm.fastmath<fast>} : f32 to f16
+  %27 = llvm.fpext %arg0 fastmath<nnan> : f32 to f64
+  %28 = llvm.fptrunc %arg0 fastmath<fast> : f32 to f16
   llvm.return
 }
 

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2155,6 +2155,11 @@ llvm.func @fastmathFlags(%arg0: f32, %arg1 : vector<2xf32>) {
   %25 = llvm.mlir.constant(true) : i1
 // CHECK: select contract i1
   %26 = llvm.select %25, %arg0, %20 {fastmathFlags = #llvm.fastmath<contract>} : i1, f32
+
+// CHECK: {{.*}} = fpext float {{.*}} to double
+// CHECK: {{.*}} = fptrunc float {{.*}} to half
+  %27 = llvm.fpext %arg0 {fastmathFlags = #llvm.fastmath<nnan>} : f32 to f64
+  %28 = llvm.fptrunc %arg0 {fastmathFlags = #llvm.fastmath<fast>} : f32 to f16
   llvm.return
 }
 


### PR DESCRIPTION
Add fastmath attributes to llvm fpext/fptrunc ops, FastmathFlagsInterface op interface support.