### PR TITLE
[BOLT] Support non-null MCInst operands in annotation handling

### DIFF
--- a/bolt/include/bolt/Core/MCPlus.h
+++ b/bolt/include/bolt/Core/MCPlus.h
@@ -113,13 +113,20 @@ private:
   ValueType Value;
 };
 
+/// Return true if \p Op is the annotation sentinel: a null MCInst operand
+/// that marks the start of BOLT annotations. Non-null MCInst operands
+/// (e.g. Hexagon duplex sub-instructions) are legitimate prime operands.
+inline bool isAnnotationSentinel(const MCOperand &Op) {
+  return Op.isInst() && Op.getInst() == nullptr;
+}
+
 /// Return a number of operands in \Inst excluding operands representing
 /// annotations.
 inline unsigned getNumPrimeOperands(const MCInst &Inst) {
   for (signed I = Inst.getNumOperands() - 1; I >= 0; --I) {
-    if (Inst.getOperand(I).isInst())
+    if (isAnnotationSentinel(Inst.getOperand(I)))
       return I;
-    if (!Inst.getOperand(I).isImm())
+    if (!Inst.getOperand(I).isInst() && !Inst.getOperand(I).isImm())
       return Inst.getNumOperands();
   }
   return Inst.getNumOperands();

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -138,10 +138,8 @@ private:
 
   MCInst::iterator getAnnotationInstOp(MCInst &Inst) const {
     for (MCInst::iterator Iter = Inst.begin(); Iter != Inst.end(); ++Iter) {
-      if (Iter->isInst()) {
-        assert(Iter->getInst() == nullptr && "Empty instruction expected.");
+      if (MCPlus::isAnnotationSentinel(*Iter))
         return Iter;
-      }
     }
     return Inst.end();
   }


### PR DESCRIPTION
The annotation sentinel in BOLT is a null MCInst operand appended after all prime operands. However, some architectures (e.g. Hexagon) use non-null MCInst operands as legitimate prime operands for duplex sub-instructions. The existing code treated any MCInst operand as the annotation sentinel, causing duplex sub-instructions to be misidentified.
    
In getNumPrimeOperands(), only treat a null MCInst operand as the sentinel. In getAnnotationInstOp(), skip non-null MCInst operands when searching for the annotation sentinel.
