### PR TITLE
[AMDGPU] Mark s_get_*_barrier_state intrinsics always uniform

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUSearchableTables.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSearchableTables.td
@@ -413,6 +413,8 @@ def : AlwaysUniform<int_amdgcn_workgroup_id_x>;
 def : AlwaysUniform<int_amdgcn_workgroup_id_y>;
 def : AlwaysUniform<int_amdgcn_workgroup_id_z>;
 def : AlwaysUniform<int_amdgcn_s_alloc_vgpr>;
+def : AlwaysUniform<int_amdgcn_s_get_barrier_state>;
+def : AlwaysUniform<int_amdgcn_s_get_named_barrier_state>;
 def : AlwaysUniform<int_amdgcn_s_getpc>;
 def : AlwaysUniform<int_amdgcn_s_getreg>;
 def : AlwaysUniform<int_amdgcn_s_memrealtime>;

--- a/llvm/test/Analysis/UniformityAnalysis/AMDGPU/always_uniform.ll
+++ b/llvm/test/Analysis/UniformityAnalysis/AMDGPU/always_uniform.ll
@@ -119,6 +119,22 @@ define void @s_getreg(ptr addrspace(1) inreg %out) {
   ret void
 }
 
+; CHECK-LABEL: for function 's_get_barrier_state':
+; CHECK: DIVERGENT: i32 %bar
+; CHECK-NOT: DIVERGENT
+define i32 @s_get_barrier_state(i32 %bar) {
+  %result = call i32 @llvm.amdgcn.s.get.barrier.state(i32 %bar)
+  ret i32 %result
+}
+
+; CHECK-LABEL: for function 's_get_named_barrier_state':
+; CHECK: DIVERGENT: ptr addrspace(3) %bar
+; CHECK-NOT: DIVERGENT
+define i32 @s_get_named_barrier_state(ptr addrspace(3) %bar) {
+  %result = call i32 @llvm.amdgcn.s.get.named.barrier.state(ptr addrspace(3) %bar)
+  ret i32 %result
+}
+
 ; CHECK-LABEL: for function 'cluster_workgroup_id_x':
 ; CHECK: ALL VALUES UNIFORM
 define void @cluster_workgroup_id_x(ptr addrspace(1) inreg %out) {


### PR DESCRIPTION
Both intrinsics return a 32-bit SGPR value containing the barrier's member count and signal count.