### PR TITLE
[AMDGPU] Preserve call info when lowering SI_CALL_ISEL

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -6847,6 +6847,8 @@ SITargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
       MIB.add(MO);
 
     MIB.cloneMemRefs(MI);
+    if (MI.shouldUpdateAdditionalCallInfo())
+      MF->moveAdditionalCallInfo(&MI, MIB.getInstr());
     MI.eraseFromParent();
     return BB;
   }


### PR DESCRIPTION
Keep additional call metadata attached when the custom inserter rewrites SI_CALL_ISEL into SI_CALL so later analyses still see the original direct-call information.