### PR TITLE
Amdgpu si call isel callinfo pr clean

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -6847,6 +6847,8 @@ SITargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
       MIB.add(MO);
 
     MIB.cloneMemRefs(MI);
+    if (MI.shouldUpdateAdditionalCallInfo())
+      MF->moveAdditionalCallInfo(&MI, MIB.getInstr());
     MI.eraseFromParent();
     return BB;
   }

--- a/llvm/test/CodeGen/AMDGPU/si-call-isel-callsite-info.ll
+++ b/llvm/test/CodeGen/AMDGPU/si-call-isel-callsite-info.ll
@@ -1,0 +1,15 @@
+; RUN: llc -emit-call-site-info -stop-after=dead-mi-elimination -mtriple=amdgcn-- -mcpu=gfx900 -o - %s | FileCheck %s
+
+; CHECK-LABEL: name:            basic_call
+; CHECK: $sgpr30_sgpr31 = SI_CALL {{.*}}, @foo, csr_amdgpu
+
+define i32 @basic_call(i32 %src) #0 {
+  %token = call token @llvm.experimental.convergence.entry()
+  %result = call i32 @foo(i32 %src) [ "convergencectrl"(token %token) ]
+  ret i32 %result
+}
+
+declare i32 @foo(i32) #0
+declare token @llvm.experimental.convergence.entry()
+
+attributes #0 = { convergent nounwind readnone }


### PR DESCRIPTION
[AMDGPU] Add SI_CALL_ISEL callsite info regression
    
    Cover the SI_CALL_ISEL lowering path with emit-call-site-info enabled so call metadata regressions are caught before FinalizeISel erases the pseudo.
