### PR TITLE
[CodeGen] Add early-exit to getFoldedSpillSize

### DIFF
--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -2613,6 +2613,9 @@ MachineInstr::getSpillSize(const TargetInstrInfo *TII) const {
 
 std::optional<LocationSize>
 MachineInstr::getFoldedSpillSize(const TargetInstrInfo *TII) const {
+  if (!mayStore())
+    return std::nullopt;
+
   MMOList Accesses;
   if (TII->hasStoreToStackSlot(*this, Accesses))
     return getSpillSlotSize(Accesses, getMF()->getFrameInfo());


### PR DESCRIPTION
TargetInstrInfo::hasStoreToStackSlot is showing up in compile-time profiles of sqlite via MachineInstr::getFoldedSpillSize. Adding an early-exit for non-store instructions is a small win on this and some other workloads on stage1-aarch64-O0-g.

https://llvm-compile-time-tracker.com/compare.php?from=215f35eb8f1c313ac135ad47db1cc0b99b3ae694&to=4d8ce0a2e30829976c03a9e90b2dc56ab9b60646&stat=instructions%3Au