### PR TITLE
Support Vendor openruyi

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -320,6 +320,8 @@ std::string riscv::getRISCVArch(const llvm::opt::ArgList &Args,
         return "rv64imafdcv_zba_zbb_zbs";
       if (Triple.isOSFuchsia())
         return "rva22u64_v";
+      if (Triple.getVendor() == llvm::Triple::openRuyi)
+        return "rva23u64";
       return "rv64imafdc";
     }
   }
@@ -341,6 +343,8 @@ std::string riscv::getRISCVArch(const llvm::opt::ArgList &Args,
     return "rv64imafdcv_zba_zbb_zbs";
   if (Triple.isOSFuchsia())
     return "rva22u64_v";
+  if (Triple.getVendor() == llvm::Triple::openRuyi)
+    return "rva23u64";
   return "rv64imafdc";
 }
 

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -203,7 +203,8 @@ public:
     OpenEmbedded,
     Intel,
     Meta,
-    LastVendorType = Meta
+    openRuyi,
+    LastVendorType = openRuyi
   };
   enum OSType {
     UnknownOS,

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -387,6 +387,8 @@ StringRef Triple::getVendorTypeName(VendorType Kind) {
     return "suse";
   case Meta:
     return "meta";
+  case openRuyi:
+    return "openruyi";
   }
 
   llvm_unreachable("Invalid VendorType!");
@@ -906,6 +908,7 @@ static Triple::VendorType parseVendor(StringRef VendorName) {
       .Case("oe", Triple::OpenEmbedded)
       .Case("intel", Triple::Intel)
       .Case("meta", Triple::Meta)
+      .Case("openruyi", Triple::openRuyi)
       .Default(Triple::UnknownVendor);
 }
 

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -854,6 +854,12 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::Hurd, T.getOS());
   EXPECT_EQ(Triple::GNU, T.getEnvironment());
 
+  T = Triple("riscv64-openruyi-linux");
+  EXPECT_EQ(Triple::riscv64, T.getArch());
+  EXPECT_EQ(Triple::openRuyi, T.getVendor());
+  EXPECT_EQ(Triple::Linux, T.getOS());
+  EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
+
   T = Triple("armv7hl-suse-linux-gnueabi");
   EXPECT_EQ(Triple::arm, T.getArch());
   EXPECT_EQ(Triple::SUSE, T.getVendor());


### PR DESCRIPTION
openRuyi is a rolling release focusing on RISC-V support, which is launched by Institute of Software, CAS.

The default ISA level for RISC-V is set to RVA23U64.

See: https://openruyi.cn/