### PR TITLE
[clang][bytecode] Don't implicitly begin union member lifetime...

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -5601,12 +5601,16 @@ bool Compiler<Emitter>::VisitCallExpr(const CallExpr *E) {
   SmallVector<const Expr *, 8> Args(ArrayRef(E->getArgs(), E->getNumArgs()));
 
   bool IsAssignmentOperatorCall = false;
+  bool ActivateLHS = false;
   if (const auto *OCE = dyn_cast<CXXOperatorCallExpr>(E);
       OCE && OCE->isAssignmentOp()) {
     // Just like with regular assignments, we need to special-case assignment
     // operators here and evaluate the RHS (the second arg) before the LHS (the
     // first arg). We fix this by using a Flip op later.
     assert(Args.size() == 2);
+    const CXXRecordDecl *LHSRecord = Args[0]->getType()->getAsCXXRecordDecl();
+    assert(LHSRecord);
+    ActivateLHS = LHSRecord->hasTrivialDefaultConstructor();
     IsAssignmentOperatorCall = true;
     std::reverse(Args.begin(), Args.end());
   }
@@ -5684,7 +5688,7 @@ bool Compiler<Emitter>::VisitCallExpr(const CallExpr *E) {
       return false;
   }
 
-  if (!this->visitCallArgs(Args, FuncDecl, IsAssignmentOperatorCall,
+  if (!this->visitCallArgs(Args, FuncDecl, ActivateLHS,
                            isa<CXXOperatorCallExpr>(E)))
     return false;
 

--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -5609,8 +5609,7 @@ bool Compiler<Emitter>::VisitCallExpr(const CallExpr *E) {
     // first arg). We fix this by using a Flip op later.
     assert(Args.size() == 2);
     const CXXRecordDecl *LHSRecord = Args[0]->getType()->getAsCXXRecordDecl();
-    assert(LHSRecord);
-    ActivateLHS = LHSRecord->hasTrivialDefaultConstructor();
+    ActivateLHS = LHSRecord && LHSRecord->hasTrivialDefaultConstructor();
     IsAssignmentOperatorCall = true;
     std::reverse(Args.begin(), Args.end());
   }

--- a/clang/test/AST/ByteCode/unions.cpp
+++ b/clang/test/AST/ByteCode/unions.cpp
@@ -1007,4 +1007,27 @@ namespace NonTrivialUnionCtor {
   static_assert(j()); // both-error {{not an integral constant expression}} \
                       // both-note {{in call to}}
 }
+
+/// u.a should not implicitly get activated when assigning to it, since A
+/// does not have a non-deleted trivial default constructor.
+namespace NoTrivialCtor {
+  struct A {
+   int i;
+   constexpr A() : i(0) {}
+   constexpr A(int i) : i(i) {}
+  };
+
+  constexpr auto test() {
+   union U {
+    int i;
+    A a;
+   } u{.i = 0};
+
+   u.a = {123}; // both-note {{member call on member 'a' of union with active member 'i'}}
+   return u.a.i;
+  }
+
+  constexpr auto r = test(); // both-error {{must be initialized by a constant expression}} \
+                             // both-note {{in call to}}
+}
 #endif

--- a/clang/test/AST/ByteCode/unions.cpp
+++ b/clang/test/AST/ByteCode/unions.cpp
@@ -1029,5 +1029,17 @@ namespace NoTrivialCtor {
 
   constexpr auto r = test(); // both-error {{must be initialized by a constant expression}} \
                              // both-note {{in call to}}
+
+  /// Should still work if the LHS is not a record type.
+  enum byte {};
+  constexpr byte operator|=(byte a, byte b) {
+    return byte{};
+  }
+  constexpr int foo() {
+    byte b{};
+    b |= byte{};
+    return 10;
+  }
+  static_assert(foo() == 10);
 }
 #endif


### PR DESCRIPTION
... on assignment operator calls if the LHS type does not have a non-deleted trivial default constructor.