### PR TITLE
[ORC] Add MemMgr arg to LLJITBuilder::ObjectLinkingLayerCreator.

### DIFF
--- a/llvm/examples/OrcV2Examples/LLJITWithCustomObjectLinkingLayer/LLJITWithCustomObjectLinkingLayer.cpp
+++ b/llvm/examples/OrcV2Examples/LLJITWithCustomObjectLinkingLayer/LLJITWithCustomObjectLinkingLayer.cpp
@@ -45,9 +45,8 @@ int main(int argc, char *argv[]) {
       LLJITBuilder()
           .setJITTargetMachineBuilder(std::move(JTMB))
           .setObjectLinkingLayerCreator(
-              [&](ExecutionSession &ES) {
-                return std::make_unique<ObjectLinkingLayer>(
-                    ES, ExitOnErr(jitlink::InProcessMemoryManager::Create()));
+              [&](ExecutionSession &ES, jitlink::JITLinkMemoryManager &MemMgr) {
+                return std::make_unique<ObjectLinkingLayer>(ES, MemMgr);
               })
           .create());
 

--- a/llvm/examples/OrcV2Examples/LLJITWithGDBRegistrationListener/LLJITWithGDBRegistrationListener.cpp
+++ b/llvm/examples/OrcV2Examples/LLJITWithGDBRegistrationListener/LLJITWithGDBRegistrationListener.cpp
@@ -59,27 +59,29 @@ int main(int argc, char *argv[]) {
 
   // Create an LLJIT instance and use a custom object linking layer creator to
   // register the GDBRegistrationListener with our RTDyldObjectLinkingLayer.
-  auto J =
-      ExitOnErr(LLJITBuilder()
-                    .setJITTargetMachineBuilder(std::move(JTMB))
-                    .setObjectLinkingLayerCreator([&](ExecutionSession &ES) {
-                      auto GetMemMgr = [](const MemoryBuffer &) {
-                        return std::make_unique<SectionMemoryManager>();
-                      };
-                      auto ObjLinkingLayer =
-                          std::make_unique<RTDyldObjectLinkingLayer>(
-                              ES, std::move(GetMemMgr));
+  auto J = ExitOnErr(
+      LLJITBuilder()
+          .setJITTargetMachineBuilder(std::move(JTMB))
+          .setObjectLinkingLayerCreator(
+              [&](ExecutionSession &ES,
+                  jitlink::JITLinkMemoryManager &IgnoredMemMgr) {
+                auto GetMemMgr = [](const MemoryBuffer &) {
+                  return std::make_unique<SectionMemoryManager>();
+                };
+                auto ObjLinkingLayer =
+                    std::make_unique<RTDyldObjectLinkingLayer>(
+                        ES, std::move(GetMemMgr));
 
-                      // Register the event listener.
-                      ObjLinkingLayer->registerJITEventListener(
-                          *JITEventListener::createGDBRegistrationListener());
+                // Register the event listener.
+                ObjLinkingLayer->registerJITEventListener(
+                    *JITEventListener::createGDBRegistrationListener());
 
-                      // Make sure the debug info sections aren't stripped.
-                      ObjLinkingLayer->setProcessAllSections(true);
+                // Make sure the debug info sections aren't stripped.
+                ObjLinkingLayer->setProcessAllSections(true);
 
-                      return ObjLinkingLayer;
-                    })
-                    .create());
+                return ObjLinkingLayer;
+              })
+          .create());
 
   // Load the input modules.
   for (auto &InputFile : InputFiles) {

--- a/llvm/examples/OrcV2Examples/LLJITWithObjectLinkingLayerPlugin/LLJITWithObjectLinkingLayerPlugin.cpp
+++ b/llvm/examples/OrcV2Examples/LLJITWithObjectLinkingLayerPlugin/LLJITWithObjectLinkingLayerPlugin.cpp
@@ -203,10 +203,10 @@ int main(int argc, char *argv[]) {
       LLJITBuilder()
           .setJITTargetMachineBuilder(std::move(JTMB))
           .setObjectLinkingLayerCreator(
-              [&](ExecutionSession &ES) {
+              [&](ExecutionSession &ES, jitlink::JITLinkMemoryManager &MemMgr) {
                 // Create ObjectLinkingLayer.
-                auto ObjLinkingLayer = std::make_unique<ObjectLinkingLayer>(
-                    ES, ExitOnErr(jitlink::InProcessMemoryManager::Create()));
+                auto ObjLinkingLayer =
+                    std::make_unique<ObjectLinkingLayer>(ES, MemMgr);
                 // Add an instance of our plugin.
                 ObjLinkingLayer->addPlugin(std::make_unique<MyPlugin>());
                 return ObjLinkingLayer;

--- a/llvm/include/llvm-c/LLJIT.h
+++ b/llvm/include/llvm-c/LLJIT.h
@@ -51,6 +51,10 @@ LLVM_C_EXTERN_C_BEGIN
  * Object linking layers returned by this function will become owned by the
  * LLJIT instance. The client is not responsible for managing their lifetimes
  * after the function returns.
+ *
+ * FIXME: This method needs to be updated to take a JITLinkMemoryManager
+ *        argument.
+ *
  */
 typedef LLVMOrcObjectLayerRef (
     *LLVMOrcLLJITBuilderObjectLinkingLayerCreatorFunction)(

--- a/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
@@ -242,7 +242,8 @@ public:
 
 protected:
   static Expected<std::unique_ptr<ObjectLayer>>
-  createObjectLinkingLayer(LLJITBuilderState &S, ExecutionSession &ES);
+  createObjectLinkingLayer(LLJITBuilderState &S, ExecutionSession &ES,
+                           jitlink::JITLinkMemoryManager &MemMgr);
 
   static Expected<std::unique_ptr<IRCompileLayer::IRCompiler>>
   createCompileFunction(LLJITBuilderState &S, JITTargetMachineBuilder JTMB);
@@ -308,7 +309,8 @@ private:
 class LLJITBuilderState {
 public:
   using ObjectLinkingLayerCreator =
-      std::function<Expected<std::unique_ptr<ObjectLayer>>(ExecutionSession &)>;
+      std::function<Expected<std::unique_ptr<ObjectLayer>>(
+          ExecutionSession &, jitlink::JITLinkMemoryManager &)>;
 
   using CompileFunctionCreator =
       std::function<Expected<std::unique_ptr<IRCompileLayer::IRCompiler>>(

--- a/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
@@ -828,9 +828,10 @@ Error LLJITBuilderState::prepareForConstruction() {
       if (!JTMB->getCodeModel())
         JTMB->setCodeModel(CodeModel::Small);
       JTMB->setRelocationModel(Reloc::PIC_);
-      CreateObjectLinkingLayer =
-          [](ExecutionSession &ES) -> Expected<std::unique_ptr<ObjectLayer>> {
-        return std::make_unique<ObjectLinkingLayer>(ES);
+      CreateObjectLinkingLayer = [](ExecutionSession &ES,
+                                    jitlink::JITLinkMemoryManager &MemMgr)
+          -> Expected<std::unique_ptr<ObjectLayer>> {
+        return std::make_unique<ObjectLinkingLayer>(ES, MemMgr);
       };
     }
   }
@@ -943,11 +944,12 @@ Expected<ExecutorAddr> LLJIT::lookupLinkerMangled(JITDylib &JD,
 }
 
 Expected<std::unique_ptr<ObjectLayer>>
-LLJIT::createObjectLinkingLayer(LLJITBuilderState &S, ExecutionSession &ES) {
+LLJIT::createObjectLinkingLayer(LLJITBuilderState &S, ExecutionSession &ES,
+                                jitlink::JITLinkMemoryManager &MemMgr) {
 
   // If the config state provided an ObjectLinkingLayer factory then use it.
   if (S.CreateObjectLinkingLayer)
-    return S.CreateObjectLinkingLayer(ES);
+    return S.CreateObjectLinkingLayer(ES, MemMgr);
 
   // Otherwise default to creating an RTDyldObjectLinkingLayer that constructs
   // a new SectionMemoryManager for each object.
@@ -1019,7 +1021,8 @@ LLJIT::LLJIT(LLJITBuilderState &S, Error &Err)
     return;
   }
 
-  auto ObjLayer = createObjectLinkingLayer(S, *ES);
+  auto ObjLayer = createObjectLinkingLayer(
+      S, *ES, ES->getExecutorProcessControl().getMemMgr());
   if (!ObjLayer) {
     Err = ObjLayer.takeError();
     return;

--- a/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
@@ -913,11 +913,13 @@ void LLVMOrcLLJITBuilderSetJITTargetMachineBuilder(
 void LLVMOrcLLJITBuilderSetObjectLinkingLayerCreator(
     LLVMOrcLLJITBuilderRef Builder,
     LLVMOrcLLJITBuilderObjectLinkingLayerCreatorFunction F, void *Ctx) {
-  unwrap(Builder)->setObjectLinkingLayerCreator([=](ExecutionSession &ES) {
-    auto TTStr = ES.getTargetTriple().str();
-    return std::unique_ptr<ObjectLayer>(
-        unwrap(F(Ctx, wrap(&ES), TTStr.c_str())));
-  });
+  unwrap(Builder)->setObjectLinkingLayerCreator(
+      [=](ExecutionSession &ES,
+          jitlink::JITLinkMemoryManager &MemMgr /* <- Currently ignored */) {
+        auto TTStr = ES.getTargetTriple().str();
+        return std::unique_ptr<ObjectLayer>(
+            unwrap(F(Ctx, wrap(&ES), TTStr.c_str())));
+      });
 }
 
 LLVMErrorRef LLVMOrcCreateLLJIT(LLVMOrcLLJITRef *Result,

--- a/llvm/tools/lli/lli.cpp
+++ b/llvm/tools/lli/lli.cpp
@@ -1023,17 +1023,19 @@ static int runOrcJIT(const char *ProgName) {
     Builder.getJITTargetMachineBuilder()
         ->setRelocationModel(Reloc::PIC_)
         .setCodeModel(CodeModel::Small);
-    Builder.setObjectLinkingLayerCreator([&](orc::ExecutionSession &ES) {
-      return std::make_unique<orc::ObjectLinkingLayer>(ES);
-    });
+    Builder.setObjectLinkingLayerCreator(
+        [&](orc::ExecutionSession &ES, jitlink::JITLinkMemoryManager &MemMgr) {
+          return std::make_unique<orc::ObjectLinkingLayer>(ES, MemMgr);
+        });
     break;
   case JITLinkerKind::RuntimeDyld:
-    Builder.setObjectLinkingLayerCreator([&](orc::ExecutionSession &ES) {
-      return std::make_unique<orc::RTDyldObjectLinkingLayer>(
-          ES, [](const MemoryBuffer &) {
-            return std::make_unique<SectionMemoryManager>();
-          });
-    });
+    Builder.setObjectLinkingLayerCreator(
+        [&](orc::ExecutionSession &ES, jitlink::JITLinkMemoryManager &MemMgr) {
+          return std::make_unique<orc::RTDyldObjectLinkingLayer>(
+              ES, [](const MemoryBuffer &) {
+                return std::make_unique<SectionMemoryManager>();
+              });
+        });
     break;
   case JITLinkerKind::Default:
     // Let LLJITBuilder decide

--- a/mlir/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/mlir/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -311,7 +311,9 @@ ExecutionEngine::create(Operation *m, const ExecutionEngineOptions &options,
 
   // Callback to create the object layer with symbol resolution to current
   // process and dynamically linked libraries.
-  auto objectLinkingLayerCreator = [&](ExecutionSession &session) {
+  auto objectLinkingLayerCreator = [&](ExecutionSession &session,
+                                       llvm::jitlink::JITLinkMemoryManager
+                                           &IgnoredMemMgr) {
     // Needed to respect AArch64 ABI requirements on the distance between
     // TEXT and GOT sections.
     bool reserveAlloc = llvmModule->getTargetTriple().isAArch64();


### PR DESCRIPTION
LinkGraphLinkingLayer and ObjectLinkingLayer will start requiring a jitlink::JITLinkMemoryManager argument in an upcoming commit. In preparation for that, this patch threads a MemMgr argument through the LLJITBuilder::ObjectLinkingLayerCreator factory type.

Note: This patch does not thread the argument through the C API (LLVMOrcLLJITBuilderObjectLinkingLayerCreatorFunction) yet so as to not break compatibility. All current users of the C API construct RuntimeDyld instances, which would have to ignore this argument anyway. If we don't update the LLVMOrcLLJITBuilderObjectLinkingLayerCreatorFunction type before RuntimeDyld is removed then that will be a good time to update it, since all existing users were going to have to remove their code anyway.