### PR TITLE
[mlir][test] Notify rewriter on in-place attrs in clone test patterns

### DIFF
--- a/mlir/test/lib/Dialect/Test/TestPatterns.cpp
+++ b/mlir/test/lib/Dialect/Test/TestPatterns.cpp
@@ -365,7 +365,9 @@ struct CloneOp : public RewritePattern {
     if (op->hasAttr("was_cloned"))
       return failure();
     Operation *cloned = rewriter.clone(*op);
-    cloned->setAttr("was_cloned", rewriter.getUnitAttr());
+    rewriter.modifyOpInPlace(cloned, [&]() {
+      cloned->setAttr("was_cloned", rewriter.getUnitAttr());
+    });
     return success();
   }
 };
@@ -383,7 +385,8 @@ struct CloneRegionBeforeOp : public RewritePattern {
       return failure();
     for (Region &r : op->getRegions())
       rewriter.cloneRegionBefore(r, op->getBlock());
-    op->setAttr("was_cloned", rewriter.getUnitAttr());
+    rewriter.modifyOpInPlace(
+        op, [&]() { op->setAttr("was_cloned", rewriter.getUnitAttr()); });
     return success();
   }
 };


### PR DESCRIPTION
Test patterns `CloneOp` and `CloneRegionBeforeOp` set the `was_cloned` unit attribute with a direct `setAttr` on the operation. That mutates the IR without going through `RewriterBase::finalizeOpModification`, so `notifyOperationModified` is never sent to listeners.

When `MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS` is enabled, the greedy pattern driver’s fingerprint bookkeeping still holds stale entries for those ops and aborts with `LLVM ERROR: operation finger print changed` after a successful rewrite. This does not change IR semantics of the patterns; it aligns them with the rewriter notification contract expected by expensive checks and other listeners.

**Testing**

`mlir-opt` on IR using `test.clone_region_before` with `-test-strict-pattern-driver=strictness=AnyOp` (no fingerprint fatal error with expensive checks on).

Assisted-by: Cursor (Composer 2)