### PR TITLE
[llvm] Fix: DebuginfodTests must link libHTTP after 789f30c73ef4

### DIFF
--- a/llvm/unittests/Debuginfod/CMakeLists.txt
+++ b/llvm/unittests/Debuginfod/CMakeLists.txt
@@ -4,5 +4,6 @@ add_llvm_unittest(DebuginfodTests
 
 target_link_libraries(DebuginfodTests PRIVATE
   LLVMDebuginfod
+  LLVMHTTP
   LLVMTestingSupport
   )


### PR DESCRIPTION
This should fix various share libraries bots that are failing right now with:
```
5.829 [1/1/795] Linking CXX executable unittests/Debuginfod/DebuginfodTests
FAILED: unittests/Debuginfod/DebuginfodTests 
(.text._ZN31DebuginfodClient_CacheMiss_Test8TestBodyEv+0x1b9): error: undefined reference to 'llvm::HTTPClient::initialize()'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```