### PR TITLE
[DWARFYAML] Add support for v5 debug_line file/dir entries

### DIFF
--- a/llvm/include/llvm/ObjectYAML/DWARFYAML.h
+++ b/llvm/include/llvm/ObjectYAML/DWARFYAML.h
@@ -189,8 +189,12 @@ struct LineTable {
   // For DWARF>=v5
   uint8_t DirectoryEntryFormatCount;
   std::vector<LnctForm> DirectoryEntryFormat;
+  uint64_t DirectoriesCount;
+  std::vector<std::vector<FormValue>> Directories;
   uint8_t FileNameEntryFormatCount;
   std::vector<LnctForm> FileNameEntryFormat;
+  uint64_t FileNamesCount;
+  std::vector<std::vector<FormValue>> FileNames;
 
   std::vector<LineTableOpcode> Opcodes;
 };
@@ -301,6 +305,7 @@ LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::DWARFYAML::Ranges)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::DWARFYAML::PubEntry)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::DWARFYAML::Unit)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::DWARFYAML::FormValue)
+LLVM_YAML_IS_SEQUENCE_VECTOR(std::vector<llvm::DWARFYAML::FormValue>)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::DWARFYAML::Entry)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::DWARFYAML::File)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::DWARFYAML::LnctForm)

--- a/llvm/lib/ObjectYAML/DWARFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/DWARFEmitter.cpp
@@ -258,39 +258,16 @@ Error DWARFYAML::emitDebugGNUPubtypes(raw_ostream &OS, const Data &DI) {
                         /*IsGNUStyle=*/true);
 }
 
-static Expected<uint64_t> writeDIE(const DWARFYAML::Data &DI, uint64_t CUIndex,
-                                   uint64_t AbbrevTableID,
-                                   const dwarf::FormParams &Params,
-                                   const DWARFYAML::Entry &Entry,
-                                   raw_ostream &OS, bool IsLittleEndian) {
-  uint64_t EntryBegin = OS.tell();
-  encodeULEB128(Entry.AbbrCode, OS);
-  uint32_t AbbrCode = Entry.AbbrCode;
-  if (AbbrCode == 0 || Entry.Values.empty())
-    return OS.tell() - EntryBegin;
-
-  Expected<DWARFYAML::Data::AbbrevTableInfo> AbbrevTableInfoOrErr =
-      DI.getAbbrevTableInfoByID(AbbrevTableID);
-  if (!AbbrevTableInfoOrErr)
-    return createStringError(errc::invalid_argument,
-                             toString(AbbrevTableInfoOrErr.takeError()) +
-                                 " for compilation unit with index " +
-                                 utostr(CUIndex));
-
-  ArrayRef<DWARFYAML::Abbrev> AbbrevDecls(
-      DI.DebugAbbrev[AbbrevTableInfoOrErr->Index].Table);
-
-  if (AbbrCode > AbbrevDecls.size())
-    return createStringError(
-        errc::invalid_argument,
-        "abbrev code must be less than or equal to the number of "
-        "entries in abbreviation table");
-  const DWARFYAML::Abbrev &Abbrev = AbbrevDecls[AbbrCode - 1];
-  auto FormVal = Entry.Values.begin();
-  auto AbbrForm = Abbrev.Attributes.begin();
-  for (; FormVal != Entry.Values.end() && AbbrForm != Abbrev.Attributes.end();
-       ++FormVal, ++AbbrForm) {
-    dwarf::Form Form = AbbrForm->Form;
+template <typename FormTy>
+static Error writeFormValues(raw_ostream &OS, const FormTy &Forms,
+                             ArrayRef<DWARFYAML::FormValue> Values,
+                             const dwarf::FormParams &Params,
+                             bool IsLittleEndian) {
+  auto FormIt = Forms.begin();
+  const DWARFYAML::FormValue *FormVal = Values.begin();
+  for (; FormIt != Forms.end() && FormVal != Values.end();
+       ++FormIt, ++FormVal) {
+    dwarf::Form Form = *FormIt;
     bool Indirect;
     do {
       Indirect = false;
@@ -396,6 +373,45 @@ static Expected<uint64_t> writeDIE(const DWARFYAML::Data &DI, uint64_t CUIndex,
       }
     } while (Indirect);
   }
+  return Error::success();
+}
+
+static Expected<uint64_t> writeDIE(const DWARFYAML::Data &DI, uint64_t CUIndex,
+                                   uint64_t AbbrevTableID,
+                                   const dwarf::FormParams &Params,
+                                   const DWARFYAML::Entry &Entry,
+                                   raw_ostream &OS, bool IsLittleEndian) {
+  uint64_t EntryBegin = OS.tell();
+  encodeULEB128(Entry.AbbrCode, OS);
+  uint32_t AbbrCode = Entry.AbbrCode;
+  if (AbbrCode == 0 || Entry.Values.empty())
+    return OS.tell() - EntryBegin;
+
+  Expected<DWARFYAML::Data::AbbrevTableInfo> AbbrevTableInfoOrErr =
+      DI.getAbbrevTableInfoByID(AbbrevTableID);
+  if (!AbbrevTableInfoOrErr)
+    return createStringError(errc::invalid_argument,
+                             toString(AbbrevTableInfoOrErr.takeError()) +
+                                 " for compilation unit with index " +
+                                 utostr(CUIndex));
+
+  ArrayRef<DWARFYAML::Abbrev> AbbrevDecls(
+      DI.DebugAbbrev[AbbrevTableInfoOrErr->Index].Table);
+
+  if (AbbrCode > AbbrevDecls.size())
+    return createStringError(
+        errc::invalid_argument,
+        "abbrev code must be less than or equal to the number of "
+        "entries in abbreviation table");
+  const DWARFYAML::Abbrev &Abbrev = AbbrevDecls[AbbrCode - 1];
+  if (Error Err =
+          writeFormValues(OS,
+                          map_range(Abbrev.Attributes,
+                                    [](const DWARFYAML::AttributeAbbrev &Abbr) {
+                                      return Abbr.Form;
+                                    }),
+                          Entry.Values, Params, IsLittleEndian))
+    return Err;
 
   return OS.tell() - EntryBegin;
 }
@@ -603,6 +619,23 @@ static void writeV5EntryFormat(raw_ostream &OS, uint8_t Count,
   }
 }
 
+static Error writeV5Entry(raw_ostream &OS, uint64_t Count,
+                          ArrayRef<DWARFYAML::LnctForm> Format,
+                          ArrayRef<std::vector<DWARFYAML::FormValue>> EntryList,
+                          const dwarf::FormParams &Params,
+                          bool IsLittleEndian) {
+  encodeULEB128(Count, OS);
+  for (ArrayRef<DWARFYAML::FormValue> Entry : EntryList) {
+    if (Error Err = writeFormValues(
+            OS,
+            map_range(Format,
+                      [](const DWARFYAML::LnctForm &F) { return F.Form; }),
+            Entry, Params, IsLittleEndian))
+      return Err;
+  }
+  return Error::success();
+}
+
 Error DWARFYAML::emitDebugLine(raw_ostream &OS, const DWARFYAML::Data &DI) {
   for (const DWARFYAML::LineTable &LineTable : DI.DebugLines) {
     // Buffer holds the bytes following the header_length (or prologue_length in
@@ -628,15 +661,23 @@ Error DWARFYAML::emitDebugLine(raw_ostream &OS, const DWARFYAML::Data &DI) {
       writeInteger(OpcodeLength, BufferOS, DI.IsLittleEndian);
 
     if (LineTable.Version >= 5) {
+      dwarf::FormParams Params{LineTable.Version, LineTable.AddressSize,
+                               LineTable.Format};
+
       writeV5EntryFormat(BufferOS, LineTable.DirectoryEntryFormatCount,
                          LineTable.DirectoryEntryFormat);
-      // TODO: Support directories in DWARFv5
-      encodeULEB128(/*directories_count=*/0, BufferOS);
+      if (Error Err =
+              writeV5Entry(BufferOS, LineTable.DirectoriesCount,
+                           LineTable.DirectoryEntryFormat,
+                           LineTable.Directories, Params, DI.IsLittleEndian))
+        return Err;
 
       writeV5EntryFormat(BufferOS, LineTable.FileNameEntryFormatCount,
                          LineTable.FileNameEntryFormat);
-      // TODO: Support file names in DWARFv5
-      encodeULEB128(/*file_names_count=*/0, BufferOS);
+      if (Error Err = writeV5Entry(
+              BufferOS, LineTable.FileNamesCount, LineTable.FileNameEntryFormat,
+              LineTable.FileNames, Params, DI.IsLittleEndian))
+        return Err;
     } else {
       for (StringRef IncludeDir : LineTable.IncludeDirs) {
         BufferOS.write(IncludeDir.data(), IncludeDir.size());

--- a/llvm/lib/ObjectYAML/DWARFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/DWARFEmitter.cpp
@@ -276,14 +276,14 @@ static Error writeFormValues(raw_ostream &OS, const FormTy &Forms,
         // TODO: Test this error.
         if (Error Err = writeVariableSizedInteger(
                 FormVal->Value, Params.AddrSize, OS, IsLittleEndian))
-          return std::move(Err);
+          return Err;
         break;
       case dwarf::DW_FORM_ref_addr:
         // TODO: Test this error.
         if (Error Err = writeVariableSizedInteger(FormVal->Value,
                                                   Params.getRefAddrByteSize(),
                                                   OS, IsLittleEndian))
-          return std::move(Err);
+          return Err;
         break;
       case dwarf::DW_FORM_exprloc:
       case dwarf::DW_FORM_block:

--- a/llvm/lib/ObjectYAML/DWARFYAML.cpp
+++ b/llvm/lib/ObjectYAML/DWARFYAML.cpp
@@ -304,13 +304,17 @@ void MappingTraits<DWARFYAML::LineTable>::mapping(
     IO.mapOptional("DirectoryEntryFormatCount",
                    LineTable.DirectoryEntryFormatCount,
                    LineTable.DirectoryEntryFormat.size());
+    IO.mapRequired("Directories", LineTable.Directories);
+    IO.mapOptional("DirectoriesCount", LineTable.DirectoriesCount,
+                   LineTable.Directories.size());
 
     IO.mapRequired("FileNameEntryFormat", LineTable.FileNameEntryFormat);
     IO.mapOptional("FileNameEntryFormatCount",
                    LineTable.FileNameEntryFormatCount,
                    LineTable.FileNameEntryFormat.size());
-
-    // TODO: Add support for directory and file entries.
+    IO.mapRequired("FileNames", LineTable.FileNames);
+    IO.mapOptional("FileNamesCount", LineTable.FileNamesCount,
+                   LineTable.FileNames.size());
   } else {
     IO.mapOptional("IncludeDirs", LineTable.IncludeDirs);
     IO.mapOptional("Files", LineTable.Files);

--- a/llvm/lib/ObjectYAML/DWARFYAML.cpp
+++ b/llvm/lib/ObjectYAML/DWARFYAML.cpp
@@ -300,19 +300,19 @@ void MappingTraits<DWARFYAML::LineTable>::mapping(
   IO.mapOptional("OpcodeBase", LineTable.OpcodeBase);
   IO.mapOptional("StandardOpcodeLengths", LineTable.StandardOpcodeLengths);
   if (LineTable.Version >= 5) {
-    IO.mapRequired("DirectoryEntryFormat", LineTable.DirectoryEntryFormat);
+    IO.mapOptional("DirectoryEntryFormat", LineTable.DirectoryEntryFormat);
     IO.mapOptional("DirectoryEntryFormatCount",
                    LineTable.DirectoryEntryFormatCount,
                    LineTable.DirectoryEntryFormat.size());
-    IO.mapRequired("Directories", LineTable.Directories);
+    IO.mapOptional("Directories", LineTable.Directories);
     IO.mapOptional("DirectoriesCount", LineTable.DirectoriesCount,
                    LineTable.Directories.size());
 
-    IO.mapRequired("FileNameEntryFormat", LineTable.FileNameEntryFormat);
+    IO.mapOptional("FileNameEntryFormat", LineTable.FileNameEntryFormat);
     IO.mapOptional("FileNameEntryFormatCount",
                    LineTable.FileNameEntryFormatCount,
                    LineTable.FileNameEntryFormat.size());
-    IO.mapRequired("FileNames", LineTable.FileNames);
+    IO.mapOptional("FileNames", LineTable.FileNames);
     IO.mapOptional("FileNamesCount", LineTable.FileNamesCount,
                    LineTable.FileNames.size());
   } else {

--- a/llvm/test/tools/yaml2obj/ELF/DWARF/debug-line-v5.yaml
+++ b/llvm/test/tools/yaml2obj/ELF/DWARF/debug-line-v5.yaml
@@ -20,10 +20,6 @@ DWARF:
       LineBase:            1
       LineRange:           14
       OpcodeBase:          13
-      DirectoryEntryFormat:
-      Directories:
-      FileNameEntryFormat:
-      FileNames:
 
 # RUN: yaml2obj --docnum=1 -DENDIAN=ELFDATA2LSB -DFORMAT=DWARF32 %s | \
 # RUN:   llvm-readelf --hex-dump=.debug_line - | \
@@ -155,12 +151,10 @@ DWARF:
       DirectoryEntryFormat:
         - ContentType:     DW_LNCT_path
           Form:            DW_FORM_string
-      Directories:
       FileNameEntryFormatCount: 1  # Explicit
       FileNameEntryFormat:
         - ContentType:     DW_LNCT_path
           Form:            DW_FORM_string
-      FileNames:
 
 # RUN: yaml2obj --docnum=2 %s | llvm-readelf --hex-dump=.debug_line - | \
 # RUN:   FileCheck %s --check-prefix=FORMATCNT1
@@ -212,12 +206,10 @@ DWARF:
       DirectoryEntryFormat:
         - ContentType:     DW_LNCT_path
           Form:            DW_FORM_string
-      Directories:
       FileNameEntryFormatCount: 2  # Larger than the array length
       FileNameEntryFormat:
         - ContentType:     DW_LNCT_path
           Form:            DW_FORM_string
-      FileNames:
 
 # RUN: yaml2obj --docnum=3 %s | llvm-readelf --hex-dump=.debug_line - | \
 # RUN:   FileCheck %s --check-prefix=FORMATCNT2

--- a/llvm/test/tools/yaml2obj/ELF/DWARF/debug-line-v5.yaml
+++ b/llvm/test/tools/yaml2obj/ELF/DWARF/debug-line-v5.yaml
@@ -21,7 +21,9 @@ DWARF:
       LineRange:           14
       OpcodeBase:          13
       DirectoryEntryFormat:
+      Directories:
       FileNameEntryFormat:
+      FileNames:
 
 # RUN: yaml2obj --docnum=1 -DENDIAN=ELFDATA2LSB -DFORMAT=DWARF32 %s | \
 # RUN:   llvm-readelf --hex-dump=.debug_line - | \
@@ -153,10 +155,12 @@ DWARF:
       DirectoryEntryFormat:
         - ContentType:     DW_LNCT_path
           Form:            DW_FORM_string
+      Directories:
       FileNameEntryFormatCount: 1  # Explicit
       FileNameEntryFormat:
         - ContentType:     DW_LNCT_path
           Form:            DW_FORM_string
+      FileNames:
 
 # RUN: yaml2obj --docnum=2 %s | llvm-readelf --hex-dump=.debug_line - | \
 # RUN:   FileCheck %s --check-prefix=FORMATCNT1
@@ -208,10 +212,12 @@ DWARF:
       DirectoryEntryFormat:
         - ContentType:     DW_LNCT_path
           Form:            DW_FORM_string
+      Directories:
       FileNameEntryFormatCount: 2  # Larger than the array length
       FileNameEntryFormat:
         - ContentType:     DW_LNCT_path
           Form:            DW_FORM_string
+      FileNames:
 
 # RUN: yaml2obj --docnum=3 %s | llvm-readelf --hex-dump=.debug_line - | \
 # RUN:   FileCheck %s --check-prefix=FORMATCNT2
@@ -241,3 +247,146 @@ DWARF:
 ##                                     ^-                         file_name_entry_format[0].form (ULEB128)
 ##                                       ^-                       file_names_count (ULEB128)
 ##                                         ^----                  EOF
+
+
+## Check file name and directory handling, including the cases where the
+## specified length of a list does not match its contents.
+
+--- !ELF
+FileHeader:
+  Class: ELFCLASS64
+  Data:  [[FORMAT]]
+  Type:  ET_EXEC
+Sections:
+  - Name:    .debug_line_str
+    Type:    SHT_PROGBITS
+    Content: 666f6f2e63707000  # foo.cpp
+DWARF:
+  debug_line:
+    - Format:              DWARF32
+      Version:             5
+      AddressSize:         8
+      MinInstLength:       1
+      MaxOpsPerInst:       1
+      DefaultIsStmt:       1
+      LineBase:            1
+      LineRange:           14
+      OpcodeBase:          13
+      DirectoryEntryFormat:
+        - ContentType:     DW_LNCT_path
+          Form:            DW_FORM_string
+      # DirectoriesCount:    2  # Implicit
+      Directories:
+        - - CStr: "bar"
+        - - CStr: "baz"
+      FileNameEntryFormat:
+        - ContentType:     DW_LNCT_path
+          Form:            DW_FORM_line_strp
+        - ContentType:     DW_LNCT_directory_index
+          Form:            DW_FORM_udata
+        - ContentType:     DW_LNCT_timestamp
+          Form:            DW_FORM_block
+        - ContentType:     DW_LNCT_size
+          Form:            DW_FORM_data4
+      FileNamesCount:      1  # Explicit
+      FileNames:
+        - - Value: 0
+          - Value: 1
+          - BlockData: [ 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47 ]
+          - Value: 0xdead
+
+# RUN: yaml2obj --docnum=4 -DFORMAT=ELFDATA2LSB %s | llvm-readelf --hex-dump=.debug_line - | \
+# RUN:   FileCheck %s --check-prefixes=FILEDIR1,FILEDIR1LE
+# RUN: yaml2obj --docnum=4 -DFORMAT=ELFDATA2MSB %s | llvm-readelf --hex-dump=.debug_line - | \
+# RUN:   FileCheck %s --check-prefixes=FILEDIR1,FILEDIR1BE
+# FILEDIR1:        Hex dump of section '.debug_line':
+## Start of header tested above.
+# FILEDIR1:        0x00000010 0e0d0001 01010100 00000100 00010101
+##                            ^-                                  line_range (1-byte)
+##                              ^-                                opcode_base (1-byte)
+##                                ^--- -------- -------- ----     standard_opcode_lengths
+##                                                           ^-   directory_entry_format_count (1-byte)
+##                                                             ^- directories_entry_format[0].content_type (ULEB128)
+# FILEDIR1-NEXT:   0x00000020 08026261 72006261 7a000401 1f020f03
+##                            ^-                                  directories_entry_format[0].form (ULEB128)
+##                              ^-                                directories_count (ULEB128)
+##                                ^--- ----                       directories[0][path] ("bar")
+##                                         ^--- ----              directories[1][path] ("baz")
+##                                                  ^-            file_name_entry_format_count (1-byte)
+##                                                    ^-          file_name_entry_format[0].content_type (ULEB128)
+##                                                       ^-       file_name_entry_format[0].form (ULEB128)
+##                                                         ^-     file_name_entry_format[1].content_type (ULEB128)
+##                                                           ^-   file_name_entry_format[1].form (ULEB128)
+##                                                             ^- file_name_entry_format[2].content_type (ULEB128)
+# FILEDIR1-NEXT:   0x00000030 09040601 00000000 01084041 42434445
+##                            ^-                                  file_name_entry_format[2].form (ULEB128)
+##                              ^-                                file_name_entry_format[3].content_type (ULEB128)
+##                                ^-                              file_name_entry_format[3].form (ULEB128)
+##                                  ^-                            file_names_count (ULEB128)
+##                                     ^-------                   file_names[0].path (4-byte)
+##                                              ^-                file_names[0].directory_index (ULEB128)
+##                                                ^----- -------- file_names[0].timestamp (block)
+# FILEDIR1LE-NEXT: 0x00000040 4647adde 0000{{ }}
+# FILEDIR1BE-NEXT: 0x00000040 46470000 dead{{ }}
+##                            ----
+##                                ^--- ----                       file_names[0].path (4-byte)
+##                                         ^----                  EOF
+
+--- !ELF
+FileHeader:
+  Class: ELFCLASS64
+  Data:  ELFDATA2LSB
+  Type:  ET_EXEC
+DWARF:
+  debug_line:
+    - Format:              DWARF32
+      Version:             5
+      AddressSize:         8
+      MinInstLength:       1
+      MaxOpsPerInst:       1
+      DefaultIsStmt:       1
+      LineBase:            1
+      LineRange:           14
+      OpcodeBase:          13
+      DirectoryEntryFormat:
+        - ContentType:     DW_LNCT_path
+          Form:            DW_FORM_string
+      DirectoriesCount:    1  # Larger than the actual length
+      Directories:
+      FileNameEntryFormat:
+        - ContentType:     DW_LNCT_path
+          Form:            DW_FORM_string
+        - ContentType:     DW_LNCT_directory_index
+          Form:            DW_FORM_indirect
+      FileNamesCount:      0  # Smaller than the actual length
+      FileNames:
+        - - CStr: foo.cpp
+          - Value: 0x0b  # DW_FORM_data1
+          - Value: 1
+        - - CStr: foo.c  # Shorter list ends the entry early
+        - - CStr: bar.cpp
+          - Value: 0x0b  # DW_FORM_data1
+          - Value: 2
+          - Value: 0xdead  # Extra values ignored
+
+# RUN: yaml2obj --docnum=5 %s | llvm-readelf --hex-dump=.debug_line - | \
+# RUN:   FileCheck %s --check-prefixes=FILEDIR2
+# FILEDIR2:      Hex dump of section '.debug_line':
+## Start of header tested above.
+# FILEDIR2:      0x00000020 08010201 08021600 666f6f2e 63707000
+##                          ^-                                  directories_entry_format[0].form (ULEB128)
+##                            ^-                                directories_count (ULEB128)
+##                              ^-                              file_name_entry_format_count (1-byte)
+##                                ^-                            file_name_entry_format[0].content_type (ULEB128)
+##                                   ^-                         file_name_entry_format[0].form (ULEB128)
+##                                     ^-                       file_name_entry_format[1].content_type (ULEB128)
+##                                       ^-                     file_name_entry_format[1].form (ULEB128)
+##                                         ^-                   file_names_count (ULEB128)
+##                                            ^------- -------- file_names[0].path (foo.cpp)
+# FILEDIR2-NEXT: 0x00000030 0b01666f 6f2e6300 6261722e 63707000
+##                          ^---                                file_names[0].directory_index (ULEB128 + 1-byte)
+##                              ^--- --------                   file_names[1].path (foo.c)
+##                                            ^------- -------- file_names[2].path (bar.c)
+# FILEDIR2-NEXT: 0b02{{ }}
+##               ^---                                           file_names[0].directory_index (ULEB128 + 1-byte)
+##                   ^----                                      EOF


### PR DESCRIPTION
This lets us specify all fields in the v5 header. Since v5 entries are form-based, I've extracted the relevant parts of the debug_info DIE writing code so it could be reused here as well.

The v5 file and directory entries are more expressive than <=v4 ones, so one could in theory store everything in the v5 format, while still reading (YAML) and writing (raw DWARF) in the old format.  However, that would create more corner cases (what if the data cannot be represented in the older format), and it didn't seem like it was particularly worthwhile to handle those.