### PR TITLE
[clang] Make serenity.cpp tests pass on clang-with-thin-lto-ubuntu

### DIFF
--- a/clang/test/Driver/serenity.cpp
+++ b/clang/test/Driver/serenity.cpp
@@ -259,7 +259,7 @@
 // RUN: %clang --target=x86_64-unknown-serenity -flto %s -### 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=LTO_FULL
 // LTO_FULL: "-plugin-opt=
-// LTO_FULL-NOT: thin
+// LTO_FULL-NOT: "-plugin-opt=thinlto"
 
 // RUN: %clang --target=x86_64-unknown-serenity -flto=thin %s -### 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=LTO_THIN


### PR DESCRIPTION
LTO_FULL-NOT was definitely too generic and prone to matching unrelated content. It would, as an example, match against the build path on clang-with-thin-lto-ubuntu builder [1].

Making the match more restrictive should avoid this kind of issues.

[1] https://lab.llvm.org/buildbot/#/builders/127/builds/6956