### PR TITLE
[AMDGPU] Remove duplicate SGPR limit diagnostics from getSIProgramInfo

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -1048,18 +1048,15 @@ void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
       ProgInfo.VCCUsed, ProgInfo.FlatUsed,
       getTargetStreamer()->getTargetID()->isXnackOnOrAny(), Ctx);
 
-  // Check the addressable register limit before we add ExtraSGPRs.
+  // Clamp the addressable register count before we add ExtraSGPRs.
+  // The diagnostic is emitted by validateMCResourceInfo() during
+  // doFinalization to avoid duplicate error messages.
   if (STM.getGeneration() >= AMDGPUSubtarget::VOLCANIC_ISLANDS &&
       !STM.hasSGPRInitBug()) {
     unsigned MaxAddressableNumSGPRs = STM.getAddressableNumSGPRs();
     uint64_t NumSgpr;
     if (TryGetMCExprValue(ProgInfo.NumSGPR, NumSgpr) &&
         NumSgpr > MaxAddressableNumSGPRs) {
-      // This can happen due to a compiler bug or when using inline asm.
-      LLVMContext &Ctx = MF.getFunction().getContext();
-      Ctx.diagnose(DiagnosticInfoResourceLimit(
-          MF.getFunction(), "addressable scalar registers", NumSgpr,
-          MaxAddressableNumSGPRs, DS_Error, DK_ResourceLimit));
       ProgInfo.NumSGPR = CreateExpr(MaxAddressableNumSGPRs - 1);
     }
   }
@@ -1103,18 +1100,15 @@ void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
                                    MaxWaves, MFI->getDynamicVGPRBlockSize()))},
                               Ctx);
 
+  // Clamp total SGPRs (including ExtraSGPRs) for correct register block
+  // encoding. The diagnostic is emitted by validateMCResourceInfo() during
+  // doFinalization to avoid duplicate error messages.
   if (STM.getGeneration() <= AMDGPUSubtarget::SEA_ISLANDS ||
       STM.hasSGPRInitBug()) {
     unsigned MaxAddressableNumSGPRs = STM.getAddressableNumSGPRs();
     uint64_t NumSgpr;
     if (TryGetMCExprValue(ProgInfo.NumSGPR, NumSgpr) &&
         NumSgpr > MaxAddressableNumSGPRs) {
-      // This can happen due to a compiler bug or when using inline asm to use
-      // the registers which are usually reserved for vcc etc.
-      LLVMContext &Ctx = MF.getFunction().getContext();
-      Ctx.diagnose(DiagnosticInfoResourceLimit(
-          MF.getFunction(), "scalar registers", NumSgpr, MaxAddressableNumSGPRs,
-          DS_Error, DK_ResourceLimit));
       ProgInfo.NumSGPR = CreateExpr(MaxAddressableNumSGPRs);
       ProgInfo.NumSGPRsForWavesPerEU = CreateExpr(MaxAddressableNumSGPRs);
     }

--- a/llvm/test/CodeGen/AMDGPU/exceed-max-sgprs.ll
+++ b/llvm/test/CodeGen/AMDGPU/exceed-max-sgprs.ll
@@ -1,4 +1,4 @@
-; RUN: not llc -mtriple=amdgcn < %s 2>&1 | FileCheck -check-prefix=ERROR %s
+; RUN: not llc -mtriple=amdgcn < %s 2>&1 | FileCheck -check-prefix=ERROR --implicit-check-not="exceeds limit" %s
 
 ; ERROR: error: <unknown>:0:0: scalar registers (106) exceeds limit (104) in function 'use_too_many_sgprs_tahiti'
 define amdgpu_kernel void @use_too_many_sgprs_tahiti() #0 {


### PR DESCRIPTION
Both getSIProgramInfo() and validateMCResourceInfo() checked SGPR register counts against hardware limits and emitted identical DiagnosticInfoResourceLimit errors. When the MCExpr values were resolvable (common for kernels without unresolved callee dependencies), both checks fired, producing duplicate error messages.

Remove the diagnostic emission from getSIProgramInfo() while retaining the clamping logic needed for correct register block encoding. The single authoritative diagnostic is now emitted by validateMCResourceInfo() during doFinalization.

Update exceed-max-sgprs.ll to enforce exactly one diagnostic per violation via --implicit-check-not.