### PR TITLE
[AMDGPU] Fix DynamicCallStack remark reporting unknown state as False

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -1765,11 +1765,12 @@ void AMDGPUAsmPrinter::emitResourceUsageRemarks(
   EmitResourceUsageRemark("ScratchSize", "ScratchSize [bytes/lane]",
                           getMCExprStr(CurrentProgramInfo.ScratchSize));
   int64_t DynStack;
-  bool DynStackEvaluatable =
-      CurrentProgramInfo.DynamicCallStack->evaluateAsAbsolute(DynStack);
-  StringRef DynamicStackStr =
-      DynStackEvaluatable && DynStack ? "True" : "False";
-  EmitResourceUsageRemark("DynamicStack", "Dynamic Stack", DynamicStackStr);
+  if (CurrentProgramInfo.DynamicCallStack->evaluateAsAbsolute(DynStack))
+    EmitResourceUsageRemark("DynamicStack", "Dynamic Stack",
+                            StringRef(DynStack ? "True" : "False"));
+  else
+    EmitResourceUsageRemark("DynamicStack", "Dynamic Stack",
+                            getMCExprStr(CurrentProgramInfo.DynamicCallStack));
   EmitResourceUsageRemark("Occupancy", "Occupancy [waves/SIMD]",
                           getMCExprStr(CurrentProgramInfo.Occupancy));
   EmitResourceUsageRemark("SGPRSpill", "SGPRs Spill",


### PR DESCRIPTION
When the DynamicCallStack MCExpr cannot be evaluated as an absolute value (e.g., for functions with unresolved callee dependencies), the kernel-resource-usage remark previously defaulted to reporting "Dynamic Stack: False". This is semantically incorrect and non-conservative, as it reports no dynamic stack when the status is actually unknown.

Fix by falling back to printing the symbolic MCExpr representation when the expression cannot be evaluated, consistent with how other unresolvable resource usage fields (TotalSGPRs, Occupancy) are reported.