### PR TITLE
[libc] Implement getsockopt and setsockopt on linux

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1214,7 +1214,9 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.sys.socket.accept
     libc.src.sys.socket.bind
     libc.src.sys.socket.connect
+    libc.src.sys.socket.getsockopt
     libc.src.sys.socket.listen
+    libc.src.sys.socket.setsockopt
     libc.src.sys.socket.socket
   )
 endif()

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1348,7 +1348,9 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.sys.socket.accept
     libc.src.sys.socket.bind
     libc.src.sys.socket.connect
+    libc.src.sys.socket.getsockopt
     libc.src.sys.socket.listen
+    libc.src.sys.socket.setsockopt
     libc.src.sys.socket.socket
     libc.src.sys.socket.socketpair
     libc.src.sys.socket.send

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1419,8 +1419,10 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.sys.socket.socket
     libc.src.sys.socket.bind
     libc.src.sys.socket.connect
+    libc.src.sys.socket.getsockopt
     libc.src.sys.socket.listen
     libc.src.sys.socket.socketpair
+    libc.src.sys.socket.setsockopt
     libc.src.sys.socket.send
     libc.src.sys.socket.sendto
     libc.src.sys.socket.sendmsg

--- a/libc/include/llvm-libc-macros/linux/sys-socket-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sys-socket-macros.h
@@ -25,4 +25,22 @@
 #define SOCK_SEQPACKET 5
 #define SOCK_PACKET 10
 
+#define SOL_SOCKET 1
+
+#define SO_DEBUG 1
+#define SO_REUSEADDR 2
+#define SO_TYPE 3
+#define SO_ERROR 4
+#define SO_DONTROUTE 5
+#define SO_BROADCAST 6
+#define SO_SNDBUF 7
+#define SO_RCVBUF 8
+#define SO_KEEPALIVE 9
+#define SO_OOBINLINE 10
+#define SO_NO_CHECK 11
+#define SO_PRIORITY 12
+#define SO_LINGER 13
+#define SO_BSDCOMPAT 14
+#define SO_REUSEPORT 15
+
 #endif // LLVM_LIBC_MACROS_LINUX_SYS_SOCKET_MACROS_H

--- a/libc/include/sys/socket.yaml
+++ b/libc/include/sys/socket.yaml
@@ -39,6 +39,16 @@ functions:
       - type: int
       - type: const struct sockaddr *
       - type: socklen_t
+  - name: getsockopt
+    standards:
+      - POSIX
+    return_type: int
+    arguments:
+      - type: int
+      - type: int
+      - type: int
+      - type: void *__restrict
+      - type: socklen_t *__restrict
   - name: listen
     standards:
       - POSIX
@@ -101,6 +111,16 @@ functions:
       - type: size_t
       - type: int
       - type: const struct sockaddr *
+      - type: socklen_t
+  - name: setsockopt
+    standards:
+      - POSIX
+    return_type: int
+    arguments:
+      - type: int
+      - type: int
+      - type: int
+      - type: const void *
       - type: socklen_t
   - name: socket
     standards:

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
@@ -54,6 +54,19 @@ add_header_library(
 )
 
 add_header_library(
+  getsockopt
+  HDRS
+    getsockopt.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.libc_errno
+    libc.src.__support.macros.config
+    libc.hdr.types.socklen_t
+    libc.include.sys_syscall
+)
+
+add_header_library(
   listen
   HDRS
     listen.h
@@ -75,6 +88,19 @@ add_header_library(
     libc.src.__support.error_or
     libc.src.__support.macros.config
     libc.hdr.types.ssize_t
+    libc.include.sys_syscall
+)
+
+add_header_library(
+  setsockopt
+  HDRS
+    setsockopt.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.libc_errno
+    libc.src.__support.macros.config
+    libc.hdr.types.socklen_t
     libc.include.sys_syscall
 )
 

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/getsockopt.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/getsockopt.h
@@ -24,7 +24,7 @@ namespace linux_syscalls {
 LIBC_INLINE ErrorOr<int> getsockopt(int sockfd, int level, int optname,
                                     void *optval, socklen_t *optlen) {
 #ifdef SYS_getsockopt
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_getsockopt, sockfd, level,
+  int ret = syscall_impl<int>(SYS_getsockopt, sockfd, level,
                                               optname, optval, optlen);
 #elif defined(SYS_socketcall)
   unsigned long sockcall_args[5] = {static_cast<unsigned long>(sockfd),
@@ -32,7 +32,7 @@ LIBC_INLINE ErrorOr<int> getsockopt(int sockfd, int level, int optname,
                                     static_cast<unsigned long>(optname),
                                     reinterpret_cast<unsigned long>(optval),
                                     reinterpret_cast<unsigned long>(optlen)};
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_socketcall, SYS_GETSOCKOPT,
+  int ret = syscall_impl<int>(SYS_socketcall, SYS_GETSOCKOPT,
                                               sockcall_args);
 #else
 #error "getsockopt and socketcall syscalls unavailable for this platform."

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/getsockopt.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/getsockopt.h
@@ -1,0 +1,49 @@
+//===-- Implementation header for getsockopt --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_GETSOCKOPT_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_GETSOCKOPT_H
+
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+
+#include "hdr/types/socklen_t.h"
+#include <linux/net.h>   // For SYS_GETSOCKOPT socketcall number.
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> getsockopt(int sockfd, int level, int optname,
+                                    void *optval, socklen_t *optlen) {
+#ifdef SYS_getsockopt
+  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_getsockopt, sockfd, level,
+                                              optname, optval, optlen);
+#elif defined(SYS_socketcall)
+  unsigned long sockcall_args[5] = {static_cast<unsigned long>(sockfd),
+                                    static_cast<unsigned long>(level),
+                                    static_cast<unsigned long>(optname),
+                                    reinterpret_cast<unsigned long>(optval),
+                                    reinterpret_cast<unsigned long>(optlen)};
+  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_socketcall, SYS_GETSOCKOPT,
+                                              sockcall_args);
+#else
+#error "getsockopt and socketcall syscalls unavailable for this platform."
+#endif
+
+  if (ret < 0)
+    return Error(-static_cast<int>(ret));
+  return ret;
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_GETSOCKOPT_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/getsockopt.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/getsockopt.h
@@ -24,16 +24,15 @@ namespace linux_syscalls {
 LIBC_INLINE ErrorOr<int> getsockopt(int sockfd, int level, int optname,
                                     void *optval, socklen_t *optlen) {
 #ifdef SYS_getsockopt
-  int ret = syscall_impl<int>(SYS_getsockopt, sockfd, level,
-                                              optname, optval, optlen);
+  int ret =
+      syscall_impl<int>(SYS_getsockopt, sockfd, level, optname, optval, optlen);
 #elif defined(SYS_socketcall)
   unsigned long sockcall_args[5] = {static_cast<unsigned long>(sockfd),
                                     static_cast<unsigned long>(level),
                                     static_cast<unsigned long>(optname),
                                     reinterpret_cast<unsigned long>(optval),
                                     reinterpret_cast<unsigned long>(optlen)};
-  int ret = syscall_impl<int>(SYS_socketcall, SYS_GETSOCKOPT,
-                                              sockcall_args);
+  int ret = syscall_impl<int>(SYS_socketcall, SYS_GETSOCKOPT, sockcall_args);
 #else
 #error "getsockopt and socketcall syscalls unavailable for this platform."
 #endif

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/setsockopt.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/setsockopt.h
@@ -1,0 +1,49 @@
+//===-- Implementation header for setsockopt --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETSOCKOPT_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETSOCKOPT_H
+
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+
+#include "hdr/types/socklen_t.h"
+#include <linux/net.h>   // For SYS_SETSOCKOPT socketcall number.
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> setsockopt(int sockfd, int level, int optname,
+                                    const void *optval, socklen_t optlen) {
+#ifdef SYS_setsockopt
+  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_setsockopt, sockfd, level,
+                                              optname, optval, optlen);
+#elif defined(SYS_socketcall)
+  unsigned long sockcall_args[5] = {static_cast<unsigned long>(sockfd),
+                                    static_cast<unsigned long>(level),
+                                    static_cast<unsigned long>(optname),
+                                    reinterpret_cast<unsigned long>(optval),
+                                    static_cast<unsigned long>(optlen)};
+  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_socketcall, SYS_SETSOCKOPT,
+                                              sockcall_args);
+#else
+#error "setsockopt and socketcall syscalls unavailable for this platform."
+#endif
+
+  if (ret < 0)
+    return Error(-static_cast<int>(ret));
+  return ret;
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SETSOCKOPT_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/setsockopt.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/setsockopt.h
@@ -24,7 +24,7 @@ namespace linux_syscalls {
 LIBC_INLINE ErrorOr<int> setsockopt(int sockfd, int level, int optname,
                                     const void *optval, socklen_t optlen) {
 #ifdef SYS_setsockopt
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_setsockopt, sockfd, level,
+  int ret = syscall_impl<int>(SYS_setsockopt, sockfd, level,
                                               optname, optval, optlen);
 #elif defined(SYS_socketcall)
   unsigned long sockcall_args[5] = {static_cast<unsigned long>(sockfd),
@@ -32,7 +32,7 @@ LIBC_INLINE ErrorOr<int> setsockopt(int sockfd, int level, int optname,
                                     static_cast<unsigned long>(optname),
                                     reinterpret_cast<unsigned long>(optval),
                                     static_cast<unsigned long>(optlen)};
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_socketcall, SYS_SETSOCKOPT,
+  int ret = syscall_impl<int>(SYS_socketcall, SYS_SETSOCKOPT,
                                               sockcall_args);
 #else
 #error "setsockopt and socketcall syscalls unavailable for this platform."

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/setsockopt.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/setsockopt.h
@@ -24,16 +24,15 @@ namespace linux_syscalls {
 LIBC_INLINE ErrorOr<int> setsockopt(int sockfd, int level, int optname,
                                     const void *optval, socklen_t optlen) {
 #ifdef SYS_setsockopt
-  int ret = syscall_impl<int>(SYS_setsockopt, sockfd, level,
-                                              optname, optval, optlen);
+  int ret =
+      syscall_impl<int>(SYS_setsockopt, sockfd, level, optname, optval, optlen);
 #elif defined(SYS_socketcall)
   unsigned long sockcall_args[5] = {static_cast<unsigned long>(sockfd),
                                     static_cast<unsigned long>(level),
                                     static_cast<unsigned long>(optname),
                                     reinterpret_cast<unsigned long>(optval),
                                     static_cast<unsigned long>(optlen)};
-  int ret = syscall_impl<int>(SYS_socketcall, SYS_SETSOCKOPT,
-                                              sockcall_args);
+  int ret = syscall_impl<int>(SYS_socketcall, SYS_SETSOCKOPT, sockcall_args);
 #else
 #error "setsockopt and socketcall syscalls unavailable for this platform."
 #endif

--- a/libc/src/sys/socket/CMakeLists.txt
+++ b/libc/src/sys/socket/CMakeLists.txt
@@ -31,6 +31,13 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  getsockopt
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.getsockopt
+)
+
+add_entrypoint_object(
   listen
   ALIAS
   DEPENDS
@@ -56,6 +63,13 @@ add_entrypoint_object(
   ALIAS
   DEPENDS
     .${LIBC_TARGET_OS}.sendto
+)
+
+add_entrypoint_object(
+  setsockopt
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.setsockopt
 )
 
 add_entrypoint_object(

--- a/libc/src/sys/socket/getsockopt.h
+++ b/libc/src/sys/socket/getsockopt.h
@@ -1,0 +1,23 @@
+//===-- Implementation header for getsockopt --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SYS_SOCKET_GETSOCKOPT_H
+#define LLVM_LIBC_SRC_SYS_SOCKET_GETSOCKOPT_H
+
+#include "src/__support/macros/config.h"
+
+#include "hdr/types/socklen_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int getsockopt(int sockfd, int level, int optname, void *__restrict optval,
+               socklen_t *__restrict optlen);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SYS_SOCKET_GETSOCKOPT_H

--- a/libc/src/sys/socket/linux/CMakeLists.txt
+++ b/libc/src/sys/socket/linux/CMakeLists.txt
@@ -53,6 +53,19 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  getsockopt
+  SRCS
+    getsockopt.cpp
+  HDRS
+    ../getsockopt.h
+  DEPENDS
+    libc.include.sys_socket
+    libc.src.__support.OSUtil.osutil
+    libc.hdr.types.socklen_t
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
   listen
   SRCS
     listen.cpp
@@ -103,6 +116,19 @@ add_entrypoint_object(
     libc.hdr.types.struct_sockaddr
     libc.hdr.types.socklen_t
     libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
+  setsockopt
+  SRCS
+    setsockopt.cpp
+  HDRS
+    ../setsockopt.h
+  DEPENDS
+    libc.include.sys_socket
+    libc.src.__support.OSUtil.osutil
+    libc.hdr.types.socklen_t
     libc.src.errno.errno
 )
 

--- a/libc/src/sys/socket/linux/CMakeLists.txt
+++ b/libc/src/sys/socket/linux/CMakeLists.txt
@@ -62,6 +62,7 @@ add_entrypoint_object(
     libc.include.sys_socket
     libc.src.__support.OSUtil.osutil
     libc.hdr.types.socklen_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.getsockopt
     libc.src.errno.errno
 )
 
@@ -129,6 +130,7 @@ add_entrypoint_object(
     libc.include.sys_socket
     libc.src.__support.OSUtil.osutil
     libc.hdr.types.socklen_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.setsockopt
     libc.src.errno.errno
 )
 

--- a/libc/src/sys/socket/linux/getsockopt.cpp
+++ b/libc/src/sys/socket/linux/getsockopt.cpp
@@ -1,0 +1,31 @@
+//===-- Linux implementation of getsockopt --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/sys/socket/getsockopt.h"
+
+#include "hdr/types/socklen_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/getsockopt.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, getsockopt,
+                   (int sockfd, int level, int optname, void *__restrict optval,
+                    socklen_t *__restrict optlen)) {
+  auto result =
+      linux_syscalls::getsockopt(sockfd, level, optname, optval, optlen);
+  if (!result.has_value()) {
+    libc_errno = result.error();
+    return -1;
+  }
+
+  return result.value();
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sys/socket/linux/setsockopt.cpp
+++ b/libc/src/sys/socket/linux/setsockopt.cpp
@@ -1,0 +1,31 @@
+//===-- Linux implementation of setsockopt --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/sys/socket/setsockopt.h"
+
+#include "hdr/types/socklen_t.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/setsockopt.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, setsockopt,
+                   (int sockfd, int level, int optname, const void *optval,
+                    socklen_t optlen)) {
+  auto result =
+      linux_syscalls::setsockopt(sockfd, level, optname, optval, optlen);
+  if (!result.has_value()) {
+    libc_errno = result.error();
+    return -1;
+  }
+
+  return result.value();
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sys/socket/setsockopt.h
+++ b/libc/src/sys/socket/setsockopt.h
@@ -1,0 +1,23 @@
+//===-- Implementation header for setsockopt --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SYS_SOCKET_SETSOCKOPT_H
+#define LLVM_LIBC_SRC_SYS_SOCKET_SETSOCKOPT_H
+
+#include "src/__support/macros/config.h"
+
+#include "hdr/types/socklen_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int setsockopt(int sockfd, int level, int optname, const void *optval,
+               socklen_t optlen);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SYS_SOCKET_SETSOCKOPT_H

--- a/libc/test/src/sys/socket/linux/CMakeLists.txt
+++ b/libc/test/src/sys/socket/linux/CMakeLists.txt
@@ -80,6 +80,25 @@ add_libc_unittest(
 )
 
 add_libc_unittest(
+  socketopt_test
+  SUITE
+    libc_sys_socket_unittests
+  SRCS
+    socketopt_test.cpp
+  DEPENDS
+    libc.include.sys_socket
+    libc.hdr.sys_socket_macros
+    libc.hdr.types.socklen_t
+    libc.src.errno.errno
+    libc.src.sys.socket.getsockopt
+    libc.src.sys.socket.setsockopt
+    libc.src.sys.socket.socket
+    libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
+
+add_libc_unittest(
   socketpair_test
   SUITE
     libc_sys_socket_unittests

--- a/libc/test/src/sys/socket/linux/CMakeLists.txt
+++ b/libc/test/src/sys/socket/linux/CMakeLists.txt
@@ -94,6 +94,7 @@ add_libc_unittest(
     libc.src.sys.socket.setsockopt
     libc.src.sys.socket.socket
     libc.src.unistd.close
+    libc.src.unistd.pipe
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/socket/linux/socketopt_test.cpp
+++ b/libc/test/src/sys/socket/linux/socketopt_test.cpp
@@ -65,12 +65,12 @@ TEST_F(LlvmLibcSocketOptTest, NotASocket) {
 
   int optval = 1;
   socklen_t optlen = sizeof(optval);
-  ASSERT_THAT(
-      LIBC_NAMESPACE::setsockopt(fds[0], SOL_SOCKET, SO_KEEPALIVE, &optval, optlen),
-      Fails(ENOTSOCK));
+  ASSERT_THAT(LIBC_NAMESPACE::setsockopt(fds[0], SOL_SOCKET, SO_KEEPALIVE,
+                                         &optval, optlen),
+              Fails(ENOTSOCK));
 
-  ASSERT_THAT(LIBC_NAMESPACE::getsockopt(fds[0], SOL_SOCKET, SO_KEEPALIVE, &optval,
-                                         &optlen),
+  ASSERT_THAT(LIBC_NAMESPACE::getsockopt(fds[0], SOL_SOCKET, SO_KEEPALIVE,
+                                         &optval, &optlen),
               Fails(ENOTSOCK));
   ASSERT_THAT(LIBC_NAMESPACE::close(fds[0]), Succeeds(0));
 }

--- a/libc/test/src/sys/socket/linux/socketopt_test.cpp
+++ b/libc/test/src/sys/socket/linux/socketopt_test.cpp
@@ -12,6 +12,7 @@
 #include "src/sys/socket/socket.h"
 
 #include "src/unistd/close.h"
+#include "src/unistd/pipe.h"
 
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
@@ -55,6 +56,23 @@ TEST_F(LlvmLibcSocketOptTest, BasicSocketOpt) {
       Fails(ENOPROTOOPT));
 
   ASSERT_THAT(LIBC_NAMESPACE::close(sock), Succeeds(0));
+}
+
+TEST_F(LlvmLibcSocketOptTest, NotASocket) {
+  int fds[2];
+  ASSERT_THAT(LIBC_NAMESPACE::pipe(fds), Succeeds(0));
+  ASSERT_THAT(LIBC_NAMESPACE::close(fds[1]), Succeeds(0));
+
+  int optval = 1;
+  socklen_t optlen = sizeof(optval);
+  ASSERT_THAT(
+      LIBC_NAMESPACE::setsockopt(fds[0], SOL_SOCKET, SO_KEEPALIVE, &optval, optlen),
+      Fails(ENOTSOCK));
+
+  ASSERT_THAT(LIBC_NAMESPACE::getsockopt(fds[0], SOL_SOCKET, SO_KEEPALIVE, &optval,
+                                         &optlen),
+              Fails(ENOTSOCK));
+  ASSERT_THAT(LIBC_NAMESPACE::close(fds[0]), Succeeds(0));
 }
 
 TEST_F(LlvmLibcSocketOptTest, InvalidSocket) {

--- a/libc/test/src/sys/socket/linux/socketopt_test.cpp
+++ b/libc/test/src/sys/socket/linux/socketopt_test.cpp
@@ -1,0 +1,70 @@
+//===-- Unittests for getsockopt and setsockopt ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/sys_socket_macros.h"
+#include "src/sys/socket/getsockopt.h"
+#include "src/sys/socket/setsockopt.h"
+#include "src/sys/socket/socket.h"
+
+#include "src/unistd/close.h"
+
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/Test.h"
+#include <sys/socket.h>
+
+using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcSocketOptTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSocketOptTest, BasicSocketOpt) {
+  int sock = LIBC_NAMESPACE::socket(AF_UNIX, SOCK_STREAM, 0);
+  ASSERT_GE(sock, 0);
+
+  int optval = 0;
+  socklen_t optlen = sizeof(optval);
+
+  // Test a boolean-like option
+  optval = 1;
+  ASSERT_THAT(LIBC_NAMESPACE::setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE,
+                                         &optval, optlen),
+              Succeeds(0));
+
+  optval = 0;
+  ASSERT_THAT(LIBC_NAMESPACE::getsockopt(sock, SOL_SOCKET, SO_KEEPALIVE,
+                                         &optval, &optlen),
+              Succeeds(0));
+  ASSERT_EQ(optval, 1);
+  ASSERT_EQ(optlen, sizeof(optval));
+
+  // Test SO_TYPE (read-only)
+  ASSERT_THAT(
+      LIBC_NAMESPACE::getsockopt(sock, SOL_SOCKET, SO_TYPE, &optval, &optlen),
+      Succeeds(0));
+  ASSERT_EQ(optval, SOCK_STREAM);
+  ASSERT_EQ(optlen, sizeof(optval));
+
+  optval = SOCK_DGRAM;
+  ASSERT_THAT(
+      LIBC_NAMESPACE::setsockopt(sock, SOL_SOCKET, SO_TYPE, &optval, optlen),
+      Fails(ENOPROTOOPT));
+
+  ASSERT_THAT(LIBC_NAMESPACE::close(sock), Succeeds(0));
+}
+
+TEST_F(LlvmLibcSocketOptTest, InvalidSocket) {
+  int optval = 1;
+  socklen_t optlen = sizeof(optval);
+  ASSERT_THAT(
+      LIBC_NAMESPACE::setsockopt(-1, SOL_SOCKET, SO_KEEPALIVE, &optval, optlen),
+      Fails(EBADF));
+
+  ASSERT_THAT(LIBC_NAMESPACE::getsockopt(-1, SOL_SOCKET, SO_KEEPALIVE, &optval,
+                                         &optlen),
+              Fails(EBADF));
+}


### PR DESCRIPTION
This patch implements getsockopt and setsockopt socket functions on Linux. It follows the established pattern of wrapping socketcall or using direct syscalls.

I added a basic test setting a couple of options.

I only added the first couple of simple constants (e.g. whose value does not depend on the architecture). I've left the others for a separate patch.