### PR TITLE
[libc][cmake] Remove dependencies for bare-metal hermetic testing

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -272,6 +272,8 @@ endif()
 if(LIBC_TARGET_OS_IS_GPU)
   include(prepare_libc_gpu_build)
   set(LIBC_ENABLE_UNITTESTS OFF)
+elseif(LIBC_TARGET_OS_IS_BAREMETAL)
+  set(LIBC_ENABLE_UNITTESTS OFF)
 endif()
 
 include(LLVMLibCCheckMPFR)

--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_custom_target(check-libc)
 add_custom_target(libc-unit-tests)
 add_custom_target(libc-hermetic-tests)
-add_dependencies(check-libc libc-unit-tests libc-hermetic-tests)
 
 if (TARGET check-hdrgen)
   add_dependencies(check-libc check-hdrgen)
@@ -35,8 +34,16 @@ configure_lit_site_cfg(
 add_lit_testsuite(check-libc-lit
   "Running libc tests via lit"
   ${LIBC_BUILD_DIR}/test
-  DEPENDS libc-unit-tests-build libc-hermetic-tests-build libc-integration-tests-build libc_include_tests-build
 )
+
+if(LIBC_ENABLE_UNITTESTS AND NOT LIBC_TEST_HERMETIC_TEST_ONLY)
+  add_dependencies(check-libc libc-unit-tests)
+  add_dependencies(check-libc-lit libc-unit-tests-build)
+endif()
+if(LIBC_ENABLE_HERMETIC_TESTS AND NOT LIBC_TEST_UNIT_TEST_ONLY)
+  add_dependencies(check-libc libc-hermetic-tests)
+  add_dependencies(check-libc-lit libc-hermetic-tests-build)
+endif()
 
 add_subdirectory(UnitTest)
 


### PR DESCRIPTION
Unit tests can be disabled on bare-metal as they will fail to build. To prevent the check-libc and check-libc-lit targets from always attempting to build them, the dependencies are now set conditionally according to the relevant CMake options.