### PR TITLE
[llvm-jitlink] Hold Session::ObjLayer by unique_ptr.

### DIFF
--- a/llvm/tools/llvm-jitlink/llvm-jitlink-statistics.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink-statistics.cpp
@@ -49,7 +49,7 @@ public:
       GetStats().PostFixupTotalBlockSize = 0;
 
     if (Instance)
-      S.ObjLayer.addPlugin(std::move(Instance));
+      S.ObjLayer->addPlugin(std::move(Instance));
   }
 
   ~StatsPlugin() override { publish(dbgs()); }

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -1091,7 +1091,7 @@ createLazyLinkingSupport(Session &S) {
     return MemAccess.takeError();
 
   auto RSMgr =
-      JITLinkRedirectableSymbolManager::Create(S.ObjLayer, **MemAccess);
+      JITLinkRedirectableSymbolManager::Create(*S.ObjLayer, **MemAccess);
   if (!RSMgr)
     return RSMgr.takeError();
 
@@ -1113,13 +1113,13 @@ createLazyLinkingSupport(Session &S) {
   }
 
   auto LRMgr = createJITLinkLazyReexportsManager(
-      S.ObjLayer, **RSMgr, *S.PlatformJD, Speculator.get());
+      *S.ObjLayer, **RSMgr, *S.PlatformJD, Speculator.get());
   if (!LRMgr)
     return LRMgr.takeError();
 
   return std::make_unique<Session::LazyLinkingSupport>(
       std::move(*MemAccess), std::move(*RSMgr), std::move(Speculator),
-      std::move(*LRMgr), S.ObjLayer);
+      std::move(*LRMgr), *S.ObjLayer);
 }
 
 static Error writeLazyExecOrder(Session &S) {
@@ -1200,8 +1200,7 @@ Session::~Session() {
 }
 
 Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
-    : ES(std::move(EPC)),
-      ObjLayer(ES, ES.getExecutorProcessControl().getMemMgr()) {
+    : ES(std::move(EPC)) {
 
   /// Local ObjectLinkingLayer::Plugin class to forward modifyPassConfig to the
   /// Session.
@@ -1226,6 +1225,8 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
     Session &S;
   };
 
+  ObjLayer = std::make_unique<ObjectLinkingLayer>(
+      ES, ES.getExecutorProcessControl().getMemMgr());
   ErrorAsOutParameter _(&Err);
 
   if (auto DM = ES.getExecutorProcessControl().createDefaultDylibMgr())
@@ -1258,7 +1259,7 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
 
   if (!WriteSymbolTableTo.empty()) {
     if (auto STDump = SymbolTableDumpPlugin::Create(WriteSymbolTableTo))
-      ObjLayer.addPlugin(std::move(*STDump));
+      ObjLayer->addPlugin(std::move(*STDump));
     else {
       Err = STDump.takeError();
       return;
@@ -1271,7 +1272,7 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
                                     inconvertibleErrorCode());
       return;
     }
-    ObjLayer.addPlugin(ExitOnErr(GDBJITDebugInfoRegistrationPlugin::Create(
+    ObjLayer->addPlugin(ExitOnErr(GDBJITDebugInfoRegistrationPlugin::Create(
         this->ES, *ProcessSymsJD, TT)));
   }
 
@@ -1281,14 +1282,14 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
                                     inconvertibleErrorCode());
       return;
     }
-    ObjLayer.addPlugin(ExitOnErr(DebugInfoPreservationPlugin::Create()));
-    ObjLayer.addPlugin(ExitOnErr(PerfSupportPlugin::Create(
+    ObjLayer->addPlugin(ExitOnErr(DebugInfoPreservationPlugin::Create()));
+    ObjLayer->addPlugin(ExitOnErr(PerfSupportPlugin::Create(
         this->ES.getExecutorProcessControl(), *ProcessSymsJD, true, true)));
   }
 
   if (VTuneSupport && TT.isOSBinFormatELF()) {
-    ObjLayer.addPlugin(ExitOnErr(DebugInfoPreservationPlugin::Create()));
-    ObjLayer.addPlugin(ExitOnErr(
+    ObjLayer->addPlugin(ExitOnErr(DebugInfoPreservationPlugin::Create()));
+    ObjLayer->addPlugin(ExitOnErr(
         VTuneSupportPlugin::Create(this->ES.getExecutorProcessControl(),
                                    *ProcessSymsJD, /*EmitDebugInfo=*/true,
                                    /*TestMode=*/true)));
@@ -1302,15 +1303,15 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
 
     if (TT.isOSBinFormatMachO()) {
       if (auto P =
-              MachOPlatform::Create(ObjLayer, *PlatformJD, OrcRuntime.c_str()))
+              MachOPlatform::Create(*ObjLayer, *PlatformJD, OrcRuntime.c_str()))
         ES.setPlatform(std::move(*P));
       else {
         Err = P.takeError();
         return;
       }
     } else if (TT.isOSBinFormatELF()) {
-      if (auto P =
-              ELFNixPlatform::Create(ObjLayer, *PlatformJD, OrcRuntime.c_str()))
+      if (auto P = ELFNixPlatform::Create(*ObjLayer, *PlatformJD,
+                                          OrcRuntime.c_str()))
         ES.setPlatform(std::move(*P));
       else {
         Err = P.takeError();
@@ -1326,7 +1327,7 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
       };
 
       if (auto P =
-              COFFPlatform::Create(ObjLayer, *PlatformJD, OrcRuntime.c_str(),
+              COFFPlatform::Create(*ObjLayer, *PlatformJD, OrcRuntime.c_str(),
                                    std::move(LoadDynLibrary)))
         ES.setPlatform(std::move(*P));
       else {
@@ -1349,19 +1350,20 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
         return;
       bool UseEHFrames = ForceEHFrames.value_or(false);
       if (!UseEHFrames)
-        ObjLayer.addPlugin(ExitOnErr(UnwindInfoRegistrationPlugin::Create(ES)));
+        ObjLayer->addPlugin(
+            ExitOnErr(UnwindInfoRegistrationPlugin::Create(ES)));
       else
-        ObjLayer.addPlugin(ExitOnErr(EHFrameRegistrationPlugin::Create(ES)));
+        ObjLayer->addPlugin(ExitOnErr(EHFrameRegistrationPlugin::Create(ES)));
     }
   } else if (TT.isOSBinFormatELF()) {
     if (!NoExec)
-      ObjLayer.addPlugin(ExitOnErr(EHFrameRegistrationPlugin::Create(ES)));
+      ObjLayer->addPlugin(ExitOnErr(EHFrameRegistrationPlugin::Create(ES)));
     if (DebuggerSupport) {
       Error TargetSymErr = Error::success();
       auto Plugin =
           std::make_unique<ELFDebugObjectPlugin>(ES, true, true, TargetSymErr);
       if (!TargetSymErr)
-        ObjLayer.addPlugin(std::move(Plugin));
+        ObjLayer->addPlugin(std::move(Plugin));
       else
         logAllUnhandledErrors(std::move(TargetSymErr), errs(),
                               "Debugger support not available: ");
@@ -1386,7 +1388,7 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
     MainJD->addToLinkOrder(TestResultJD);
   }
 
-  ObjLayer.addPlugin(std::make_unique<JITLinkSessionPlugin>(*this));
+  ObjLayer->addPlugin(std::make_unique<JITLinkSessionPlugin>(*this));
 
   // Process any harness files.
   for (auto &HarnessFile : TestHarnesses) {
@@ -2163,7 +2165,7 @@ static Error addSectCreates(Session &S,
     }
 
     if (auto Err = JD.define(std::make_unique<SectCreateMaterializationUnit>(
-            S.ObjLayer, SectName.str(), MemProt::Read, 16, std::move(*Content),
+            *S.ObjLayer, SectName.str(), MemProt::Read, 16, std::move(*Content),
             std::move(ExtraSymbols))))
       return Err;
   }
@@ -2179,7 +2181,7 @@ static Error addTestHarnesses(Session &S) {
                                      LoadArchives::Never);
     if (!Linkable)
       return Linkable.takeError();
-    if (auto Err = S.ObjLayer.add(*S.MainJD, std::move(Linkable->first)))
+    if (auto Err = S.ObjLayer->add(*S.MainJD, std::move(Linkable->first)))
       return Err;
   }
   return Error::success();
@@ -2221,8 +2223,8 @@ static Error addObjects(Session &S,
       if (!ObjInterface)
         return ObjInterface.takeError();
 
-      if (auto Err = S.ObjLayer.add(JD, std::move(ObjBuffer->first),
-                                    std::move(*ObjInterface)))
+      if (auto Err = S.ObjLayer->add(JD, std::move(ObjBuffer->first),
+                                     std::move(*ObjInterface)))
         return Err;
     }
   }

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.h
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.h
@@ -82,7 +82,7 @@ struct Session {
   orc::JITDylib *MainJD = nullptr;
   orc::JITDylib *ProcessSymsJD = nullptr;
   orc::JITDylib *PlatformJD = nullptr;
-  orc::ObjectLinkingLayer ObjLayer;
+  std::unique_ptr<orc::ObjectLinkingLayer> ObjLayer;
   std::unique_ptr<LazyLinkingSupport> LazyLinking;
   orc::JITDylibSearchOrder JDSearchOrder;
   SubtargetFeatures Features;
@@ -137,7 +137,7 @@ struct Session {
            "Lazy linking requested but not available");
     return Lazy ? static_cast<orc::ObjectLayer &>(
                       LazyLinking->LazyObjLinkingLayer)
-                : static_cast<orc::ObjectLayer &>(ObjLayer);
+                : static_cast<orc::ObjectLayer &>(*ObjLayer);
   }
 
   Expected<FileInfo &> findFileInfo(StringRef FileName);


### PR DESCRIPTION
This will simplify the Session construction process when we remove jitlink::JITLinkMemoryManager ownership from ExecutorProcessControl in an upcoming patch.

(Reason: ObjectLinkingLayer's constructor will require a JITLinkMemoryManager, which we'll want to cerate after the ExecutionSession has been initialized. Creating a JITLinkMemoryManager is generally a fallible operation, so we want to be able to bail on construction of the ObjectLinkingLayer entirely if we can't create a memory manager for it).