### PR TITLE
[clang-tidy] fix false positive of parentheses removal for overloaded operator

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
@@ -55,12 +55,10 @@ void RedundantParenthesesCheck::registerMatchers(MatchFinder *Finder) {
                     parenExpr(), ConstantExpr,
                     declRefExpr(to(namedDecl(unless(
                         matchers::matchesAnyListedRegexName(AllowedDecls))))),
-                    memberExpr(), callExpr())),
+                    memberExpr(), callExpr(unless(cxxOperatorCallExpr())))),
                 unless(anyOf(isInMacro(),
                              // sizeof(...) is common used.
-                             hasParent(unaryExprOrTypeTraitExpr()),
-                             allOf(has(cxxOperatorCallExpr()),
-                                   hasParent(binaryOperator())))))
+                             hasParent(unaryExprOrTypeTraitExpr()))))
           .bind("dup"),
       this);
 }

--- a/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
@@ -59,7 +59,7 @@ void RedundantParenthesesCheck::registerMatchers(MatchFinder *Finder) {
                 unless(anyOf(isInMacro(),
                              // sizeof(...) is common used.
                              hasParent(unaryExprOrTypeTraitExpr()),
-                             allOf(hasDescendant(cxxOperatorCallExpr()),
+                             allOf(has(cxxOperatorCallExpr()),
                                    hasParent(binaryOperator())))))
           .bind("dup"),
       this);

--- a/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
@@ -58,7 +58,9 @@ void RedundantParenthesesCheck::registerMatchers(MatchFinder *Finder) {
                     memberExpr(), callExpr())),
                 unless(anyOf(isInMacro(),
                              // sizeof(...) is common used.
-                             hasParent(unaryExprOrTypeTraitExpr()))))
+                             hasParent(unaryExprOrTypeTraitExpr()),
+                             allOf(hasDescendant(cxxOperatorCallExpr()),
+                                   hasParent(binaryOperator())))))
           .bind("dup"),
       this);
 }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -577,6 +577,11 @@ Changes in existing checks
   `IgnoreMacros` option to suppress warnings when the initializer involves
   macros that may expand differently in other configurations.
 
+- Improved :doc:`readability-redundant-parentheses
+  <clang-tidy/checks/readability/redundant-parentheses>` check by fixing a
+  false positive for parentheses present around an overloaded operator in the
+  context of a binary operation.
+
 - Improved :doc:`readability-redundant-preprocessor
   <clang-tidy/checks/readability/redundant-preprocessor>` check by fixing a
   false positive for nested ``#if`` directives using different builtin

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-parentheses.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-parentheses.cpp
@@ -169,12 +169,27 @@ constexpr bool UseOperatorAmpersand5(FoldLevel level) {
   FoldLevel hf = FoldLevel::HeaderFlag;
   // currently this check doesn't take into account order of operations, so the
   // parentheses around `left & rhs` is needed
-  return (((level & hf) * hf) != FoldLevel::None);
+  return ((level & hf) * hf) != FoldLevel::None;
 }
 
 constexpr bool UseOperatorAmpersand6(FoldLevel level) {
   FoldLevel hf = FoldLevel::HeaderFlag;
-  return ((!(level & hf) * hf) != FoldLevel::None);
+  return (!(level & hf) * hf) != FoldLevel::None;
+}
+
+constexpr FoldLevel UseOperatorAmpersand7(FoldLevel level) {
+  FoldLevel hf = FoldLevel::HeaderFlag;
+  return !(level & hf) * hf;
+}
+
+constexpr FoldLevel UseOperatorAmpersand8(FoldLevel level) {
+  FoldLevel hf = FoldLevel::HeaderFlag;
+  return hf * !(level & hf);
+}
+
+constexpr FoldLevel UseOperatorAmpersand9(FoldLevel level) {
+  FoldLevel hf = FoldLevel::HeaderFlag;
+  return !(level & hf);
 }
 
 constexpr bool UseOperatorPlus1(FoldLevel level) {
@@ -182,6 +197,13 @@ constexpr bool UseOperatorPlus1(FoldLevel level) {
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: redundant parentheses around expression [readability-redundant-parentheses]
   // CHECK-FIXES:    return FoldLevelToInt(level + FoldLevel::None) != 1;
 }
+
+constexpr bool UseOperatorPlus2(FoldLevel level) {
+  return (FoldLevelToInt(!(level + FoldLevel::None))) != 1;
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: redundant parentheses around expression [readability-redundant-parentheses]
+  // CHECK-FIXES:    return FoldLevelToInt(!(level + FoldLevel::None)) != 1;
+}
+
 
 const int bracket_int_plus_num = (4) + 5;
 // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: redundant parentheses around expression [readability-redundant-parentheses]

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-parentheses.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-parentheses.cpp
@@ -139,6 +139,10 @@ constexpr FoldLevel operator*(FoldLevel lhs, FoldLevel rhs) {
   return static_cast<FoldLevel>(static_cast<int>(lhs) * static_cast<int>(rhs));
 }
 
+constexpr FoldLevel operator!(FoldLevel operand) {
+  return static_cast<FoldLevel>(!static_cast<int>(operand));
+}
+
 
 constexpr FoldLevel operator+(FoldLevel lhs, FoldLevel rhs) {
   return lhs;
@@ -149,30 +153,28 @@ constexpr bool UseOperatorAmpersand1(FoldLevel level) {
 }
 
 constexpr bool UseOperatorAmpersand2(FoldLevel level) {
-  const FoldLevel l = (level & FoldLevel::HeaderFlag);
-  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: redundant parentheses around expression [readability-redundant-parentheses]
-  // CHECK-FIXES:    const FoldLevel l = level & FoldLevel::HeaderFlag;
-  return l != FoldLevel::None;
-}
-
-constexpr bool UseOperatorAmpersand3(FoldLevel level) {
   const FoldLevel l = level & FoldLevel::HeaderFlag;
   return (l != FoldLevel::None);
 }
 
-constexpr bool UseOperatorAmpersand4(FoldLevel level) {
+constexpr bool UseOperatorAmpersand3(FoldLevel level) {
   return ((level & FoldLevel::HeaderFlag) != FoldLevel::None);
 }
 
-constexpr bool UseOperatorAmpersand5(FoldLevel level) {
+constexpr bool UseOperatorAmpersand4(FoldLevel level) {
   return FoldLevel::None != (level & FoldLevel::HeaderFlag);
+}
+
+constexpr bool UseOperatorAmpersand5(FoldLevel level) {
+  FoldLevel hf = FoldLevel::HeaderFlag;
+  // currently this check doesn't take into account order of operations, so the
+  // parentheses around `left & rhs` is needed
+  return (((level & hf) * hf) != FoldLevel::None);
 }
 
 constexpr bool UseOperatorAmpersand6(FoldLevel level) {
   FoldLevel hf = FoldLevel::HeaderFlag;
-  return (((level & hf) * hf) != FoldLevel::None);
-  // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant parentheses around expression [readability-redundant-parentheses]
-  // CHECK-FIXES:    return ((level & hf * hf) != FoldLevel::None);
+  return ((!(level & hf) * hf) != FoldLevel::None);
 }
 
 constexpr bool UseOperatorPlus1(FoldLevel level) {

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-parentheses.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-parentheses.cpp
@@ -127,8 +127,21 @@ enum class FoldLevel {
   HeaderFlag = 0x2000,
 };
 
+int FoldLevelToInt(FoldLevel l) {
+  return static_cast<int>(l);
+}
+
 constexpr FoldLevel operator&(FoldLevel lhs, FoldLevel rhs) {
   return static_cast<FoldLevel>(static_cast<int>(lhs) & static_cast<int>(rhs));
+}
+
+constexpr FoldLevel operator*(FoldLevel lhs, FoldLevel rhs) {
+  return static_cast<FoldLevel>(static_cast<int>(lhs) * static_cast<int>(rhs));
+}
+
+
+constexpr FoldLevel operator+(FoldLevel lhs, FoldLevel rhs) {
+  return lhs;
 }
 
 constexpr bool UseOperatorAmpersand1(FoldLevel level) {
@@ -149,6 +162,23 @@ constexpr bool UseOperatorAmpersand3(FoldLevel level) {
 
 constexpr bool UseOperatorAmpersand4(FoldLevel level) {
   return ((level & FoldLevel::HeaderFlag) != FoldLevel::None);
+}
+
+constexpr bool UseOperatorAmpersand5(FoldLevel level) {
+  return FoldLevel::None != (level & FoldLevel::HeaderFlag);
+}
+
+constexpr bool UseOperatorAmpersand6(FoldLevel level) {
+  FoldLevel hf = FoldLevel::HeaderFlag;
+  return (((level & hf) * hf) != FoldLevel::None);
+  // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant parentheses around expression [readability-redundant-parentheses]
+  // CHECK-FIXES:    return ((level & hf * hf) != FoldLevel::None);
+}
+
+constexpr bool UseOperatorPlus1(FoldLevel level) {
+  return (FoldLevelToInt(level + FoldLevel::None)) != 1;
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: redundant parentheses around expression [readability-redundant-parentheses]
+  // CHECK-FIXES:    return FoldLevelToInt(level + FoldLevel::None) != 1;
 }
 
 const int bracket_int_plus_num = (4) + 5;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-parentheses.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-parentheses.cpp
@@ -121,3 +121,36 @@ void memberExpr() {
    // CHECK-FIXES:    if (foo.fooBar().z) {
   }
 }
+
+enum class FoldLevel {
+  None = 0x0,
+  HeaderFlag = 0x2000,
+};
+
+constexpr FoldLevel operator&(FoldLevel lhs, FoldLevel rhs) {
+  return static_cast<FoldLevel>(static_cast<int>(lhs) & static_cast<int>(rhs));
+}
+
+constexpr bool UseOperatorAmpersand1(FoldLevel level) {
+  return (level & FoldLevel::HeaderFlag) != FoldLevel::None;
+}
+
+constexpr bool UseOperatorAmpersand2(FoldLevel level) {
+  const FoldLevel l = (level & FoldLevel::HeaderFlag);
+  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: redundant parentheses around expression [readability-redundant-parentheses]
+  // CHECK-FIXES:    const FoldLevel l = level & FoldLevel::HeaderFlag;
+  return l != FoldLevel::None;
+}
+
+constexpr bool UseOperatorAmpersand3(FoldLevel level) {
+  const FoldLevel l = level & FoldLevel::HeaderFlag;
+  return (l != FoldLevel::None);
+}
+
+constexpr bool UseOperatorAmpersand4(FoldLevel level) {
+  return ((level & FoldLevel::HeaderFlag) != FoldLevel::None);
+}
+
+const int bracket_int_plus_num = (4) + 5;
+// CHECK-MESSAGES: :[[@LINE-1]]:34: warning: redundant parentheses around expression [readability-redundant-parentheses]
+// CHECK-FIXES:    const int bracket_int_plus_num = 4 + 5;


### PR DESCRIPTION
Fixes #189217
    
don't remove necessary parentheses for an overloaded operator, when
the parenthese occurs in the context of a binary operation
    
E.g. (E1 & E2) != E3       // the brackets aren't redundant here
E.g. (E1 & E2)             // brackets are redundant here