### PR TITLE
[clang][CIR][docs] Fix a Python 3.8 compatibility issue in PostProcessCIRDocs.py

### DIFF
--- a/clang/docs/CIR/_raw/PostProcessCIRDocs.py
+++ b/clang/docs/CIR/_raw/PostProcessCIRDocs.py
@@ -42,7 +42,7 @@ depth: 2
 if len(cir_docs_toctree) > 0:
     with open(INDEX_PATH, encoding="utf-8") as fp:
         index_content = fp.read()
-    index_content += f"""
+    index_content += """
 
 CIR Dialect Reference
 ==========================
@@ -51,7 +51,9 @@ CIR Dialect Reference
     :numbered:
     :maxdepth: 1
 
-    {"\n    ".join(cir_docs_toctree)}
-"""
+    {}
+""".format(
+        "\n    ".join(cir_docs_toctree)
+    )
     with open(INDEX_OUTPUT_PATH, "w", encoding="utf-8") as fp:
         fp.write(index_content)


### PR DESCRIPTION
This patch fixes a compatibility issue with Python 3.8 in the `PostProcessCIRDocs.py` script.