### PR TITLE
[MLIR] Fix a mismatch between the function return type and the returned value type (NFC)

### DIFF
--- a/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
+++ b/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
@@ -409,7 +409,7 @@ static SmallVector<NamedAttribute>
 convertArgumentAttributes(DictionaryAttr attrsDict,
                           ConversionPatternRewriter &rewriter,
                           const LLVMTypeConverter &converter) {
-  SmallVector<NamedAttribute, 4> convertedAttrs;
+  SmallVector<NamedAttribute> convertedAttrs;
   convertedAttrs.reserve(attrsDict.size());
   for (const NamedAttribute &attr : attrsDict) {
     const auto convert = [&](const NamedAttribute &attr) {


### PR DESCRIPTION
This fixes the build on some platform where the inferred count differs.