### PR TITLE
[clang-offload-bundler] Convert `std::vector` to `llvm::SmallVector` in `OffloadBundlerConfig`

### DIFF
--- a/clang/include/clang/Driver/OffloadBundler.h
+++ b/clang/include/clang/Driver/OffloadBundler.h
@@ -17,12 +17,12 @@
 #ifndef LLVM_CLANG_DRIVER_OFFLOADBUNDLER_H
 #define LLVM_CLANG_DRIVER_OFFLOADBUNDLER_H
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Compression.h"
 #include "llvm/Support/Error.h"
 #include "llvm/TargetParser/Triple.h"
 #include <llvm/Support/MemoryBuffer.h>
 #include <string>
-#include <vector>
 
 namespace clang {
 
@@ -47,10 +47,9 @@ public:
   std::string FilesType;
   std::string ObjcopyPath;
 
-  // TODO: Convert these to llvm::SmallVector
-  std::vector<std::string> TargetNames;
-  std::vector<std::string> InputFileNames;
-  std::vector<std::string> OutputFileNames;
+  llvm::SmallVector<std::string, 4> TargetNames;
+  llvm::SmallVector<std::string, 4> InputFileNames;
+  llvm::SmallVector<std::string, 4> OutputFileNames;
 };
 
 class OffloadBundler {

--- a/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
+++ b/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
@@ -185,8 +185,10 @@ int main(int argc, const char **argv) {
     BundlerConfig.CompressionLevel = CompressionLevel;
 
   BundlerConfig.TargetNames.assign(TargetNames.begin(), TargetNames.end());
-  BundlerConfig.InputFileNames.assign(InputFileNames.begin(), InputFileNames.end());
-  BundlerConfig.OutputFileNames.assign(OutputFileNames.begin(), OutputFileNames.end());
+  BundlerConfig.InputFileNames.assign(InputFileNames.begin(),
+                                      InputFileNames.end());
+  BundlerConfig.OutputFileNames.assign(OutputFileNames.begin(),
+                                       OutputFileNames.end());
 
   /// The index of the host input in the list of inputs.
   BundlerConfig.HostInputIndex = ~0u;
@@ -243,7 +245,8 @@ int main(int argc, const char **argv) {
     s.insert(s.end(), InputFileNamesDeprecatedOpt.begin(),
              InputFileNamesDeprecatedOpt.end());
   }
-  BundlerConfig.InputFileNames.assign(InputFileNames.begin(), InputFileNames.end());
+  BundlerConfig.InputFileNames.assign(InputFileNames.begin(),
+                                      InputFileNames.end());
 
   if (OutputFileNames.getNumOccurrences() != 0 &&
       OutputFileNamesDeprecatedOpt.getNumOccurrences() != 0) {
@@ -259,7 +262,8 @@ int main(int argc, const char **argv) {
     s.insert(s.end(), OutputFileNamesDeprecatedOpt.begin(),
              OutputFileNamesDeprecatedOpt.end());
   }
-  BundlerConfig.OutputFileNames.assign(OutputFileNames.begin(), OutputFileNames.end());
+  BundlerConfig.OutputFileNames.assign(OutputFileNames.begin(),
+                                       OutputFileNames.end());
 
   if (ListBundleIDs) {
     if (Unbundle) {
@@ -395,7 +399,8 @@ int main(int argc, const char **argv) {
     ++Index;
   }
 
-  BundlerConfig.TargetNames.assign(StandardizedTargetNames.begin(), StandardizedTargetNames.end());
+  BundlerConfig.TargetNames.assign(StandardizedTargetNames.begin(),
+                                   StandardizedTargetNames.end());
 
   for (const auto &TargetID : TargetIDs) {
     if (auto ConflictingTID =

--- a/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
+++ b/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
@@ -184,9 +184,9 @@ int main(int argc, const char **argv) {
   if (CompressionLevel.getNumOccurrences() > 0)
     BundlerConfig.CompressionLevel = CompressionLevel;
 
-  BundlerConfig.TargetNames = TargetNames;
-  BundlerConfig.InputFileNames = InputFileNames;
-  BundlerConfig.OutputFileNames = OutputFileNames;
+  BundlerConfig.TargetNames.assign(TargetNames.begin(), TargetNames.end());
+  BundlerConfig.InputFileNames.assign(InputFileNames.begin(), InputFileNames.end());
+  BundlerConfig.OutputFileNames.assign(OutputFileNames.begin(), OutputFileNames.end());
 
   /// The index of the host input in the list of inputs.
   BundlerConfig.HostInputIndex = ~0u;
@@ -243,7 +243,7 @@ int main(int argc, const char **argv) {
     s.insert(s.end(), InputFileNamesDeprecatedOpt.begin(),
              InputFileNamesDeprecatedOpt.end());
   }
-  BundlerConfig.InputFileNames = InputFileNames;
+  BundlerConfig.InputFileNames.assign(InputFileNames.begin(), InputFileNames.end());
 
   if (OutputFileNames.getNumOccurrences() != 0 &&
       OutputFileNamesDeprecatedOpt.getNumOccurrences() != 0) {
@@ -259,7 +259,7 @@ int main(int argc, const char **argv) {
     s.insert(s.end(), OutputFileNamesDeprecatedOpt.begin(),
              OutputFileNamesDeprecatedOpt.end());
   }
-  BundlerConfig.OutputFileNames = OutputFileNames;
+  BundlerConfig.OutputFileNames.assign(OutputFileNames.begin(), OutputFileNames.end());
 
   if (ListBundleIDs) {
     if (Unbundle) {
@@ -395,7 +395,7 @@ int main(int argc, const char **argv) {
     ++Index;
   }
 
-  BundlerConfig.TargetNames = StandardizedTargetNames;
+  BundlerConfig.TargetNames.assign(StandardizedTargetNames.begin(), StandardizedTargetNames.end());
 
   for (const auto &TargetID : TargetIDs) {
     if (auto ConflictingTID =


### PR DESCRIPTION
Replace `std::vector<std::string>` with `llvm::SmallVector<std::string, 4>`
for TargetNames, InputFileNames, and OutputFileNames to avoid heap
allocation for small number of elements.