### PR TITLE
[clang-tidy] fix verify config for custom checks

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -703,11 +703,14 @@ void exportReplacements(const StringRef MainFilePath,
   YAML << TUD;
 }
 
-ChecksAndOptions getAllChecksAndOptions(bool AllowEnablingAnalyzerAlphaCheckers,
-                                        bool ExperimentalCustomChecks) {
+ChecksAndOptions getAllChecksAndOptions(
+    bool AllowEnablingAnalyzerAlphaCheckers, bool ExperimentalCustomChecks,
+    std::optional<ClangTidyOptions::CustomCheckValueList> &&AllCustomChecks) {
   ChecksAndOptions Result;
   ClangTidyOptions Opts;
   Opts.Checks = "*";
+  Opts.CustomChecks = std::move(AllCustomChecks);
+
   ClangTidyContext Context(
       std::make_unique<DefaultOptionsProvider>(ClangTidyGlobalOptions(), Opts),
       AllowEnablingAnalyzerAlphaCheckers, false, ExperimentalCustomChecks);

--- a/clang-tools-extra/clang-tidy/ClangTidy.h
+++ b/clang-tools-extra/clang-tidy/ClangTidy.h
@@ -64,8 +64,9 @@ struct ChecksAndOptions {
   llvm::StringSet<> Options;
 };
 
-ChecksAndOptions getAllChecksAndOptions(bool AllowEnablingAnalyzerAlphaCheckers,
-                                        bool ExperimentalCustomChecks);
+ChecksAndOptions getAllChecksAndOptions(
+    bool AllowEnablingAnalyzerAlphaCheckers, bool ExperimentalCustomChecks,
+    std::optional<ClangTidyOptions::CustomCheckValueList> &&AllCustomChecks);
 
 /// Returns the effective check-specific options.
 ///

--- a/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
+++ b/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
@@ -700,8 +700,11 @@ int clangTidyMain(int argc, const char **argv) {
   if (VerifyConfig) {
     const std::vector<ClangTidyOptionsProvider::OptionsSource> RawOptions =
         OptionsProvider->getRawOptions(FileName);
+
+    std::optional<ClangTidyOptions::CustomCheckValueList> AllCustomChecks = OptionsProvider->getOptions(FileName).CustomChecks;
+
     const ChecksAndOptions Valid = getAllChecksAndOptions(
-        AllowEnablingAnalyzerAlphaCheckers, ExperimentalCustomChecks);
+        AllowEnablingAnalyzerAlphaCheckers, ExperimentalCustomChecks, std::move(AllCustomChecks));
     bool AnyInvalid = false;
     for (const auto &[Opts, Source] : RawOptions) {
       if (Opts.Checks)

--- a/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
+++ b/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
@@ -701,10 +701,22 @@ int clangTidyMain(int argc, const char **argv) {
     const std::vector<ClangTidyOptionsProvider::OptionsSource> RawOptions =
         OptionsProvider->getRawOptions(FileName);
 
-    std::optional<ClangTidyOptions::CustomCheckValueList> AllCustomChecks = OptionsProvider->getOptions(FileName).CustomChecks;
+    ClangTidyOptions AllCustomChecksOptions;
+    {
+      unsigned Priority = 0;
+      for (const auto &Source : RawOptions) {
+        ClangTidyOptions PartialOptions;
+        PartialOptions.CustomChecks = Source.first.CustomChecks;
+        AllCustomChecksOptions.mergeWith(PartialOptions, ++Priority);
+      }
+    }
+
+    std::optional<ClangTidyOptions::CustomCheckValueList> AllCustomChecks =
+        AllCustomChecksOptions.CustomChecks;
 
     const ChecksAndOptions Valid = getAllChecksAndOptions(
-        AllowEnablingAnalyzerAlphaCheckers, ExperimentalCustomChecks, std::move(AllCustomChecks));
+        AllowEnablingAnalyzerAlphaCheckers, ExperimentalCustomChecks,
+        std::move(AllCustomChecks));
     bool AnyInvalid = false;
     for (const auto &[Opts, Source] : RawOptions) {
       if (Opts.Checks)

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -111,6 +111,9 @@ Improvements to clang-tidy
 - Improved :program:`clang-tidy` ``-store-check-profile`` by generating valid
   JSON when the source file path contains characters that require JSON escaping.
 
+- Improved :program:`clang-tidy` ``--verify-config`` by correctly handling
+  custom checks.
+
 New checks
 ^^^^^^^^^^
 

--- a/clang-tools-extra/test/clang-tidy/infrastructure/verify-config.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/verify-config.cpp
@@ -36,3 +36,11 @@
 // RUN: echo -e 'Checks: "-*,clang-analyzer-optin.cplusplus.UninitializedObject"\nCheckOptions:\n clang-analyzer-optin.cplusplus.UninitializedObject.Pedantic: true' > %t.MyClangTidyConfigCSABad
 // RUN: not clang-tidy --verify-config --config-file=%t.MyClangTidyConfigCSABad 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-CSA-BAD -implicit-check-not='{{warnings|error}}'
 // CHECK-VERIFY-CSA-BAD: command-line option '-config': warning: unknown check option 'clang-analyzer-optin.cplusplus.UninitializedObject.Pedantic'; did you mean 'clang-analyzer-optin.cplusplus.UninitializedObject:Pedantic' [-verify-config]
+
+// RUN: echo -e 'Checks: "-*,custom-no-auto-usage-c"\nCustomChecks:\n - Name: no-auto-usage-c\n   Query: match varDecl(hasType(autoType())).bind("decl")\n   Diagnostic:\n      - BindName: decl\n        Message: Don''t use auto in C\n        Level: Warning' > %t.MyClangTidyConfigCustomChecksBad
+// RUN: not clang-tidy --verify-config --config-file=%t.MyClangTidyConfigCustomChecksBad 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-CUSTOM-CHECK-BAD -implicit-check-not='{{warnings|error}}'
+// CHECK-VERIFY-CUSTOM-CHECK-BAD: command-line option '-config': warning: unknown check 'custom-no-auto-usage-c' [-verify-config]
+
+// RUN: echo -e 'Checks: "-*,custom-no-auto-usage-c"\nCustomChecks:\n - Name: no-auto-usage-c\n   Query: match varDecl(hasType(autoType())).bind("decl")\n   Diagnostic:\n      - BindName: decl\n        Message: Don''t use auto in C\n        Level: Warning' > %t.MyClangTidyConfigCustomChecksOk
+// RUN: clang-tidy --experimental-custom-checks --verify-config --config-file=%t.MyClangTidyConfigCustomChecksOk 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-CUSTOM-CHECK-OK -implicit-check-not='{{warnings|error}}'
+// CHECK-VERIFY-CUSTOM-CHECK-OK: No config errors detected.


### PR DESCRIPTION
I noticed, that if I ran `clang-tidy --experimental-custom-checks --verify-config` it still couldn't find `custom-*` checks

Without `--experimental-custom-checks` it is expected, that custom checks are not found, but with it, it was strange.

So I debugged this issue in the source code and found the issue in `clang::tidy::getAllChecksAndOptions`

It sets the `ClangTidyOptions` it uses up, by setting `Checks = "*";`, but it never sets the actual custom checks from the config, so the resolved checks don't include custom checks.
By passing in the merged `CustomChecks` from the `FileName` in `ClangTidyMain.cpp` it works as expected.

I added 2 unit tests for the expected behavior (not passing `--experimental-custom-checks` ignores them, passing it recognizes them).

I split the path into 3 commits, for an easier review, but the goal would be to squash them all together.