### PR TITLE
[Docs] Warn against extremely wide integer types in PerformanceTips

### DIFF
--- a/llvm/docs/Frontend/PerformanceTips.rst
+++ b/llvm/docs/Frontend/PerformanceTips.rst
@@ -157,6 +157,10 @@ As a result, alignment is mandatory for atomic loads and stores.
 Other Things to Consider
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
+#. Avoid emitting extremely wide integer types. The optimizer is not designed
+   for types exceeding a few thousand bits; several passes have super-linear
+   complexity, and the generated code is often sub-par as well.
+
 #. Use ptrtoint/inttoptr sparingly (they interfere with pointer aliasing
    analysis), prefer GEPs
 


### PR DESCRIPTION
Following the discussion, this patch adds a warning to the PerformanceTips documentation regarding the use of extremely wide integer types. 

The LLVM optimizer and certain analysis passes (like ConstantRange) are not designed to handle integer types exceeding a few thousand bits, which can lead to super-linear complexity and significant compile-time hangs. Frontend authors are advised to decompose such large integers into machine-word-sized pieces instead.

Fixes #192277