### PR TITLE
[mlir][CSE] Fix dominanceInfo analysis preservation

### DIFF
--- a/mlir/lib/Transforms/CSE.cpp
+++ b/mlir/lib/Transforms/CSE.cpp
@@ -394,9 +394,13 @@ void CSEDriver::simplify(Operation *op, bool *changed) {
   for (auto &region : op->getRegions())
     simplifyRegion(knownValues, region);
 
-  /// Erase any operations that were marked as dead during simplification.
-  for (auto *op : opsToErase)
+  /// Erase any operations that were marked as dead during simplification, and
+  /// remove their associated dominator trees.
+  for (auto *op : opsToErase) {
+    for (Region &region : op->getRegions())
+      domInfo->invalidate(&region);
     rewriter.eraseOp(op);
+  }
   if (changed)
     *changed = !opsToErase.empty();
 


### PR DESCRIPTION
The CSE pass calls `markAnalysesPreserved<DominanceInfo, PostDominanceInfo>()` at the end. While CSE erases operations, it does not remove their corresponding dominator trees, causing them to be unnecessarily preserved in memory. This PR addresses the issue by explicitly calling invalidate within CSE to clean up the dominator trees for those erased operations.