### PR TITLE
[LLVM] Provide a default 'multilibs.yaml' when configured

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -723,13 +723,33 @@ if(build_runtimes)
         # Generate the file into a temporary. We only copy this if the user has
         # not provided one either in the build tree or the install directory.
         if(_multilibs_for_target)
-          set(_yaml "MultilibVersion: 1.0\n\nVariants:\n- Dir: .\n  Flags: []\n")
+          set(_yaml [=[
+MultilibVersion: 1.0
+
+Variants:
+- Dir: .
+  Flags: []
+]=])
           set(_flag_values "")
           foreach(multilib ${_multilibs_for_target})
-            string(APPEND _yaml "- Dir: ${multilib}\n  Flags: [-fmultilib-flag=${multilib}]\n")
-            string(APPEND _flag_values "  - Name: ${multilib}\n")
+            string(APPEND _yaml "\
+- Dir: ${multilib}
+  Flags: [-fmultilib-flag=${multilib}]
+")
+            string(APPEND _flag_values "\
+  - Name: ${multilib}
+")
           endforeach()
-          string(APPEND _yaml "\nMappings: []\n\nFlags:\n- Name: multilib\n  Values:\n  - Name: none\n${_flag_values}  Default: none\n")
+          string(APPEND _yaml "
+Mappings: []
+
+Flags:
+- Name: multilib
+  Values:
+  - Name: none
+${_flag_values}\
+  Default: none
+")
 
           set(_staged_dir "${CMAKE_CURRENT_BINARY_DIR}/multilib-yaml/${name}")
           set(_staged "${_staged_dir}/multilib.yaml")

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -708,6 +708,56 @@ if(build_runtimes)
           EXTRA_ARGS TARGET_TRIPLE ${name} ${extra_args})
       endforeach()
     endforeach()
+
+    # Generate a default multilib.yaml for each runtime target that has one.
+    if(LLVM_RUNTIME_MULTILIBS)
+      set(_multilib_yaml_outputs)
+      foreach(name ${LLVM_RUNTIME_TARGETS})
+        set(_multilibs_for_target)
+        foreach(multilib ${LLVM_RUNTIME_MULTILIBS})
+          if("${name}" IN_LIST LLVM_RUNTIME_MULTILIB_${multilib}_TARGETS)
+            list(APPEND _multilibs_for_target "${multilib}")
+          endif()
+        endforeach()
+
+        # Generate the file into a temporary. We only copy this if the user has
+        # not provided one either in the build tree or the install directory.
+        if(_multilibs_for_target)
+          set(_yaml "MultilibVersion: 1.0\n\nVariants:\n- Dir: .\n  Flags: []\n")
+          set(_flag_values "")
+          foreach(multilib ${_multilibs_for_target})
+            string(APPEND _yaml "- Dir: ${multilib}\n  Flags: [-fmultilib-flag=${multilib}]\n")
+            string(APPEND _flag_values "  - Name: ${multilib}\n")
+          endforeach()
+          string(APPEND _yaml "\nMappings: []\n\nFlags:\n- Name: multilib\n  Values:\n  - Name: none\n${_flag_values}  Default: none\n")
+
+          set(_staged_dir "${CMAKE_CURRENT_BINARY_DIR}/multilib-yaml/${name}")
+          set(_staged "${_staged_dir}/multilib.yaml")
+          set(_dest "${LLVM_LIBRARY_DIR}/${name}/multilib.yaml")
+          file(GENERATE OUTPUT "${_staged}" CONTENT "${_yaml}")
+
+          # Omitting DEPENDS so the command only runs when OUTPUT is absent.
+          add_custom_command(
+            OUTPUT "${_dest}"
+            COMMAND "${CMAKE_COMMAND}" -E copy "${_staged}" "${_dest}"
+            COMMENT "Generating default multilib.yaml for ${name}")
+          list(APPEND _multilib_yaml_outputs "${_dest}")
+
+          install(CODE "
+            set(_inst \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib/${name}/multilib.yaml\")
+            if(NOT EXISTS \"\${_inst}\")
+              file(INSTALL \"${_staged}\"
+                   DESTINATION \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib/${name}\")
+            endif()
+          ")
+        endif()
+      endforeach()
+
+      if(_multilib_yaml_outputs)
+        add_custom_target(runtimes-multilib-yaml ALL DEPENDS ${_multilib_yaml_outputs})
+        set_target_properties(runtimes-multilib-yaml PROPERTIES FOLDER "Runtimes")
+      endif()
+    endif()
   endif()
 
   if(NOT LLVM_BUILD_INSTRUMENTED AND CLANG_ENABLE_BOOTSTRAP)


### PR DESCRIPTION
Summary:
Right now it's a little difficult to use the multilibs support because
the user must manually provide one. I believe that when the user
configures multilibs with the LLVM CMake arguments at a minimum we
should provide one that forward `-fmultilib-flag=<multilib>` to the
created runtime.

This RP makes CMake emit this by manually writing a flag. Because users
could provide their own, this adds some extre complexity to prevent this
from being overwritten.

The desire for this change is to more easily ship this support in CMake
configuration files without needing to write files manually (for the
typical case).
