### PR TITLE
[HLSL][Matrix] Add Matrix Layout Keywords

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -5288,7 +5288,7 @@ def HLSLVkLocation : HLSLAnnotationAttr {
 
 def HLSLMatrixLayout : InheritableAttr {
   let Spellings = [CustomKeyword<"row_major">, CustomKeyword<"column_major">];
-  let Subjects = SubjectList<[Var, TypedefName, Field]>;
+  let Subjects = SubjectList<[Var, TypedefName, Field, Function]>;
   let LangOpts = [HLSL];
   let Documentation = [HLSLMatrixLayoutDocs];
 }

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -5286,6 +5286,13 @@ def HLSLVkLocation : HLSLAnnotationAttr {
   let Documentation = [HLSLVkLocationDocs];
 }
 
+def HLSLMatrixLayout : InheritableAttr {
+  let Spellings = [CustomKeyword<"row_major">, CustomKeyword<"column_major">];
+  let Subjects = SubjectList<[Var, TypedefName, Field]>;
+  let LangOpts = [HLSL];
+  let Documentation = [HLSLMatrixLayoutDocs];
+}
+
 def RandomizeLayout : InheritableAttr {
   let Spellings = [GCC<"randomize_layout">];
   let Subjects = SubjectList<[Record]>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -9257,6 +9257,7 @@ This attribute maps to the 'Location' SPIR-V decoration.
 
 def HLSLMatrixLayoutDocs : Documentation {
   let Category = DocCatVariable;
+  let Heading = "row_major, column_major";
   let Content = [{
 The ``row_major`` and ``column_major`` keywords specify the memory layout 
 of an HLSL matrix type. 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -9255,6 +9255,22 @@ This attribute maps to the 'Location' SPIR-V decoration.
   }];
 }
 
+def HLSLMatrixLayoutDocs : Documentation {
+  let Category = DocCatVariable;
+  let Content = [{
+The ``row_major`` and ``column_major`` keywords specify the memory layout 
+of an HLSL matrix type. 
+
+* ``row_major``: Matrices are stored in memory row-by-row.
+* ``column_major``: Matrices are stored in memory column-by-column (default).
+
+Example:
+.. code-block:: hlsl
+
+  row_major float2x2 myMatrix;
+  }];
+}
+
 def WebAssemblyFuncrefDocs : Documentation {
   let Category = DocCatType;
   let Content = [{

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13574,6 +13574,10 @@ def err_hlsl_attr_invalid_ast_node : Error<
    "attribute %0 only applies to %1">;
 def err_hlsl_attr_incompatible
     : Error<"%0 attribute is not compatible with %1 attribute">;
+def err_hlsl_matrix_layout_non_matrix
+    : Error<"%0 attribute can only be applied to a matrix type">;
+def err_hlsl_matrix_layout_conflict
+    : Error<"%0 and %1 attributes are not compatible">;
 
 def err_hlsl_entry_shader_attr_mismatch : Error<
    "%0 attribute on entry function does not match the target profile">;

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -681,6 +681,8 @@ KEYWORD(groupshared                 , KEYHLSL)
 KEYWORD(in                          , KEYHLSL)
 KEYWORD(inout                       , KEYHLSL)
 KEYWORD(out                         , KEYHLSL)
+KEYWORD(row_major                   , KEYHLSL)
+KEYWORD(column_major                , KEYHLSL)
 // HLSL Intangible Types
 #define HLSL_INTANGIBLE_TYPE(Name, Id, SingletonId) KEYWORD(Name, KEYHLSL)
 #include "clang/Basic/HLSLIntangibleTypes.def"

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -177,6 +177,8 @@ public:
   void handleResourceBindingAttr(Decl *D, const ParsedAttr &AL);
   void handleParamModifierAttr(Decl *D, const ParsedAttr &AL);
   void handleMatrixLayoutAttr(Decl *D, const ParsedAttr &AL);
+  void diagnoseInstantiatedMatrixLayoutAttr(Decl *D,
+                                            const HLSLMatrixLayoutAttr *Attr);
   bool handleResourceTypeAttr(QualType T, const ParsedAttr &AL);
 
   template <typename T>

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -177,7 +177,7 @@ public:
   void handleResourceBindingAttr(Decl *D, const ParsedAttr &AL);
   void handleParamModifierAttr(Decl *D, const ParsedAttr &AL);
   void handleMatrixLayoutAttr(Decl *D, const ParsedAttr &AL);
-  void diagnoseInstantiatedMatrixLayoutAttr(Decl *D,
+  bool diagnoseInstantiatedMatrixLayoutAttr(Decl *D,
                                             const HLSLMatrixLayoutAttr *Attr);
   bool handleResourceTypeAttr(QualType T, const ParsedAttr &AL);
 

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -176,6 +176,7 @@ public:
   void handleShaderAttr(Decl *D, const ParsedAttr &AL);
   void handleResourceBindingAttr(Decl *D, const ParsedAttr &AL);
   void handleParamModifierAttr(Decl *D, const ParsedAttr &AL);
+  void handleMatrixLayoutAttr(Decl *D, const ParsedAttr &AL);
   bool handleResourceTypeAttr(QualType T, const ParsedAttr &AL);
 
   template <typename T>

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4641,6 +4641,7 @@ void Parser::ParseDeclarationSpecifiers(
       // NOTE: ParseHLSLQualifiers will consume the qualifier token.
       ParseHLSLQualifiers(DS.getAttributes());
       continue;
+
 #define HLSL_INTANGIBLE_TYPE(Name, Id, SingletonId)                            \
   case tok::kw_##Name:                                                         \
     isInvalid = DS.SetTypeSpecType(DeclSpec::TST_##Name, Loc, PrevSpec,        \

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -1067,7 +1067,8 @@ void Parser::ParseOpenCLQualifiers(ParsedAttributes &Attrs) {
 }
 
 bool Parser::isHLSLQualifier(const Token &Tok) const {
-  return Tok.is(tok::kw_groupshared);
+  return Tok.is(tok::kw_groupshared) || Tok.is(tok::kw_row_major) ||
+         Tok.is(tok::kw_column_major);
 }
 
 void Parser::ParseHLSLQualifiers(ParsedAttributes &Attrs) {
@@ -4631,7 +4632,8 @@ void Parser::ParseDeclarationSpecifiers(
     case tok::kw___read_write:
       ParseOpenCLQualifiers(DS.getAttributes());
       break;
-
+    case tok::kw_row_major:
+    case tok::kw_column_major:
     case tok::kw_groupshared:
     case tok::kw_in:
     case tok::kw_inout:
@@ -4639,7 +4641,6 @@ void Parser::ParseDeclarationSpecifiers(
       // NOTE: ParseHLSLQualifiers will consume the qualifier token.
       ParseHLSLQualifiers(DS.getAttributes());
       continue;
-
 #define HLSL_INTANGIBLE_TYPE(Name, Id, SingletonId)                            \
   case tok::kw_##Name:                                                         \
     isInvalid = DS.SetTypeSpecType(DeclSpec::TST_##Name, Loc, PrevSpec,        \
@@ -5752,6 +5753,8 @@ bool Parser::isTypeSpecifierQualifier(const Token &Tok) {
   case tok::kw_in:
   case tok::kw_inout:
   case tok::kw_out:
+  case tok::kw_row_major:
+  case tok::kw_column_major:
     return getLangOpts().HLSL;
   }
 }

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -6034,6 +6034,10 @@ bool Parser::isDeclarationSpecifier(
   case tok::kw_groupshared:
     return true;
 
+  case tok::kw_row_major:
+  case tok::kw_column_major:
+    return getLangOpts().HLSL;
+
   case tok::kw_private:
     return getLangOpts().OpenCL;
   }

--- a/clang/lib/Parse/ParseTentative.cpp
+++ b/clang/lib/Parse/ParseTentative.cpp
@@ -1243,6 +1243,9 @@ Parser::isCXXDeclarationSpecifier(ImplicitTypenameContext AllowImplicitTypename,
   case tok::kw_in:
   case tok::kw_inout:
   case tok::kw_out:
+    // HLSL layout qualifiers
+  case tok::kw_row_major:
+  case tok::kw_column_major:
 
     // GNU
   case tok::kw_restrict:

--- a/clang/lib/Parse/ParseTentative.cpp
+++ b/clang/lib/Parse/ParseTentative.cpp
@@ -1243,7 +1243,7 @@ Parser::isCXXDeclarationSpecifier(ImplicitTypenameContext AllowImplicitTypename,
   case tok::kw_in:
   case tok::kw_inout:
   case tok::kw_out:
-    // HLSL layout qualifiers
+    // HLSL matrix layout qualifiers
   case tok::kw_row_major:
   case tok::kw_column_major:
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8091,6 +8091,9 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
   case ParsedAttr::AT_HLSLParamModifier:
     S.HLSL().handleParamModifierAttr(D, AL);
     break;
+  case ParsedAttr::AT_HLSLMatrixLayout:
+    S.HLSL().handleMatrixLayoutAttr(D, AL);
+    break;
   case ParsedAttr::AT_HLSLUnparsedSemantic:
     S.HLSL().handleSemanticAttr(D, AL);
     break;

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2684,9 +2684,10 @@ void SemaHLSL::handleParamModifierAttr(Decl *D, const ParsedAttr &AL) {
     D->addAttr(NewAttr);
 }
 
-static bool isMatrixOrArrayOfMatrix(const ASTContext &Ctx, QualType Ty) {
-  if (const auto *AT = Ctx.getAsArrayType(Ty))
-    Ty = AT->getElementType();
+static bool isMatrixOrArrayOfMatrix(const ASTContext &Ctx, QualType QT) {
+  const Type *Ty = QT->getUnqualifiedDesugaredType();
+  while (isa<ArrayType>(Ty))
+    Ty = Ty->getArrayElementTypeNoTypeQual();
   return Ty->isDependentType() || Ty->isConstantMatrixType();
 }
 

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2684,19 +2684,34 @@ void SemaHLSL::handleParamModifierAttr(Decl *D, const ParsedAttr &AL) {
     D->addAttr(NewAttr);
 }
 
-void SemaHLSL::handleMatrixLayoutAttr(Decl *D, const ParsedAttr &AL) {
-  // row_major and column_major are only valid on matrix types.
+static bool diagnoseMatrixLayoutOnNonMatrix(Sema &SemaRef, Decl *D,
+                                            SourceLocation Loc,
+                                            const IdentifierInfo *AttrName) {
   QualType Ty;
   if (auto *VD = dyn_cast<ValueDecl>(D))
     Ty = VD->getType();
   else if (auto *TD = dyn_cast<TypedefNameDecl>(D))
     Ty = TD->getUnderlyingType();
 
-  if (!Ty.isNull() && !Ty->isDependentType() && !Ty->isConstantMatrixType()) {
-    Diag(AL.getLoc(), diag::err_hlsl_matrix_layout_non_matrix)
-        << AL.getAttrName();
+  if (Ty.isNull() || Ty->isDependentType())
+    return false;
+
+  QualType ElemTy = Ty;
+  if (const auto *AT = SemaRef.getASTContext().getAsArrayType(Ty))
+    ElemTy = AT->getElementType();
+
+  if (ElemTy->isDependentType() || ElemTy->isConstantMatrixType())
+    return false;
+
+  SemaRef.Diag(Loc, diag::err_hlsl_matrix_layout_non_matrix) << AttrName;
+  return true;
+}
+
+void SemaHLSL::handleMatrixLayoutAttr(Decl *D, const ParsedAttr &AL) {
+  // row_major and column_major are only valid on matrix types.
+  if (diagnoseMatrixLayoutOnNonMatrix(SemaRef, D, AL.getLoc(),
+                                      AL.getAttrName()))
     return;
-  }
 
   // Check for conflicting or duplicate matrix layout attributes.
   if (const auto *Existing = D->getAttr<HLSLMatrixLayoutAttr>()) {
@@ -2705,13 +2720,20 @@ void SemaHLSL::handleMatrixLayoutAttr(Decl *D, const ParsedAttr &AL) {
           << AL.getAttrName() << Existing->getAttrName();
       Diag(Existing->getLoc(), diag::note_conflicting_attribute);
     } else {
-      Diag(AL.getLoc(), diag::warn_duplicate_attribute) << AL.getAttrName();
+      Diag(AL.getLoc(), diag::warn_duplicate_attribute_exact)
+          << AL.getAttrName();
       Diag(Existing->getLoc(), diag::note_previous_attribute);
     }
     return;
   }
 
   D->addAttr(::new (getASTContext()) HLSLMatrixLayoutAttr(getASTContext(), AL));
+}
+
+void SemaHLSL::diagnoseInstantiatedMatrixLayoutAttr(
+    Decl *D, const HLSLMatrixLayoutAttr *Attr) {
+  diagnoseMatrixLayoutOnNonMatrix(SemaRef, D, Attr->getLoc(),
+                                  Attr->getAttrName());
 }
 
 namespace {

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2684,6 +2684,12 @@ void SemaHLSL::handleParamModifierAttr(Decl *D, const ParsedAttr &AL) {
     D->addAttr(NewAttr);
 }
 
+static bool isMatrixOrArrayOfMatrix(const ASTContext &Ctx, QualType Ty) {
+  if (const auto *AT = Ctx.getAsArrayType(Ty))
+    Ty = AT->getElementType();
+  return Ty->isDependentType() || Ty->isConstantMatrixType();
+}
+
 static bool diagnoseMatrixLayoutOnNonMatrix(Sema &SemaRef, Decl *D,
                                             SourceLocation Loc,
                                             const IdentifierInfo *AttrName) {
@@ -2696,11 +2702,18 @@ static bool diagnoseMatrixLayoutOnNonMatrix(Sema &SemaRef, Decl *D,
   if (Ty.isNull() || Ty->isDependentType())
     return false;
 
-  QualType ElemTy = Ty;
-  if (const auto *AT = SemaRef.getASTContext().getAsArrayType(Ty))
-    ElemTy = AT->getElementType();
+  // For functions, the qualifier can apply to the return type or any parameter.
+  if (const auto *FPT = Ty->getAs<FunctionProtoType>()) {
+    if (isMatrixOrArrayOfMatrix(SemaRef.getASTContext(), FPT->getReturnType()))
+      return false;
+    for (QualType ParamTy : FPT->param_types())
+      if (isMatrixOrArrayOfMatrix(SemaRef.getASTContext(), ParamTy))
+        return false;
+    SemaRef.Diag(Loc, diag::err_hlsl_matrix_layout_non_matrix) << AttrName;
+    return true;
+  }
 
-  if (ElemTy->isDependentType() || ElemTy->isConstantMatrixType())
+  if (isMatrixOrArrayOfMatrix(SemaRef.getASTContext(), Ty))
     return false;
 
   SemaRef.Diag(Loc, diag::err_hlsl_matrix_layout_non_matrix) << AttrName;

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2744,10 +2744,10 @@ void SemaHLSL::handleMatrixLayoutAttr(Decl *D, const ParsedAttr &AL) {
   D->addAttr(::new (getASTContext()) HLSLMatrixLayoutAttr(getASTContext(), AL));
 }
 
-void SemaHLSL::diagnoseInstantiatedMatrixLayoutAttr(
+bool SemaHLSL::diagnoseInstantiatedMatrixLayoutAttr(
     Decl *D, const HLSLMatrixLayoutAttr *Attr) {
-  diagnoseMatrixLayoutOnNonMatrix(SemaRef, D, Attr->getLoc(),
-                                  Attr->getAttrName());
+  return diagnoseMatrixLayoutOnNonMatrix(SemaRef, D, Attr->getLoc(),
+                                         Attr->getAttrName());
 }
 
 namespace {

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2707,9 +2707,6 @@ static bool diagnoseMatrixLayoutOnNonMatrix(Sema &SemaRef, Decl *D,
   if (const auto *FPT = Ty->getAs<FunctionProtoType>()) {
     if (isMatrixOrArrayOfMatrix(SemaRef.getASTContext(), FPT->getReturnType()))
       return false;
-    for (QualType ParamTy : FPT->param_types())
-      if (isMatrixOrArrayOfMatrix(SemaRef.getASTContext(), ParamTy))
-        return false;
     SemaRef.Diag(Loc, diag::err_hlsl_matrix_layout_non_matrix) << AttrName;
     return true;
   }

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2684,6 +2684,36 @@ void SemaHLSL::handleParamModifierAttr(Decl *D, const ParsedAttr &AL) {
     D->addAttr(NewAttr);
 }
 
+void SemaHLSL::handleMatrixLayoutAttr(Decl *D, const ParsedAttr &AL) {
+  // row_major and column_major are only valid on matrix types.
+  QualType Ty;
+  if (auto *VD = dyn_cast<ValueDecl>(D))
+    Ty = VD->getType();
+  else if (auto *TD = dyn_cast<TypedefNameDecl>(D))
+    Ty = TD->getUnderlyingType();
+
+  if (!Ty.isNull() && !Ty->isDependentType() && !Ty->isConstantMatrixType()) {
+    Diag(AL.getLoc(), diag::err_hlsl_matrix_layout_non_matrix)
+        << AL.getAttrName();
+    return;
+  }
+
+  // Check for conflicting or duplicate matrix layout attributes.
+  if (const auto *Existing = D->getAttr<HLSLMatrixLayoutAttr>()) {
+    if (Existing->getSemanticSpelling() != AL.getSemanticSpelling()) {
+      Diag(AL.getLoc(), diag::err_hlsl_matrix_layout_conflict)
+          << AL.getAttrName() << Existing->getAttrName();
+      Diag(Existing->getLoc(), diag::note_conflicting_attribute);
+    } else {
+      Diag(AL.getLoc(), diag::warn_duplicate_attribute) << AL.getAttrName();
+      Diag(Existing->getLoc(), diag::note_previous_attribute);
+    }
+    return;
+  }
+
+  D->addAttr(::new (getASTContext()) HLSLMatrixLayoutAttr(getASTContext(), AL));
+}
+
 namespace {
 
 /// This class implements HLSL availability diagnostics for default

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -1043,6 +1043,13 @@ void Sema::InstantiateAttrs(const MultiLevelTemplateArgumentList &TemplateArgs,
       continue;
     }
 
+    if (auto *A = dyn_cast<HLSLMatrixLayoutAttr>(TmplAttr)) {
+      if (!New->hasAttr<HLSLMatrixLayoutAttr>())
+        New->addAttr(A->clone(Context));
+      HLSL().diagnoseInstantiatedMatrixLayoutAttr(New, A);
+      continue;
+    }
+
     assert(!TmplAttr->isPackExpansion());
     if (TmplAttr->isLateParsed() && LateAttrs) {
       // Late parsed attributes must be instantiated and attached after the

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -1044,9 +1044,9 @@ void Sema::InstantiateAttrs(const MultiLevelTemplateArgumentList &TemplateArgs,
     }
 
     if (auto *A = dyn_cast<HLSLMatrixLayoutAttr>(TmplAttr)) {
-      if (!New->hasAttr<HLSLMatrixLayoutAttr>())
+      if (!HLSL().diagnoseInstantiatedMatrixLayoutAttr(New, A) &&
+          !New->hasAttr<HLSLMatrixLayoutAttr>())
         New->addAttr(A->clone(Context));
-      HLSL().diagnoseInstantiatedMatrixLayoutAttr(New, A);
       continue;
     }
 

--- a/clang/test/AST/HLSL/matrix_layout_attr.hlsl
+++ b/clang/test/AST/HLSL/matrix_layout_attr.hlsl
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.6-library -finclude-default-header \
+// RUN:   -std=hlsl202x -ast-dump -x hlsl %s | FileCheck %s
+
+// CHECK: VarDecl {{.*}} rm_mat 'hlsl_constant float3x3'
+// CHECK-NEXT: HLSLMatrixLayoutAttr {{.*}} row_major
+row_major float3x3 rm_mat;
+
+// CHECK: VarDecl {{.*}} cm_mat 'hlsl_constant float4x4'
+// CHECK-NEXT: HLSLMatrixLayoutAttr {{.*}} column_major
+column_major float4x4 cm_mat;
+
+// CHECK: CXXRecordDecl {{.*}} struct S definition
+struct S {
+  // CHECK: FieldDecl {{.*}} m1 'float2x2'
+  // CHECK-NEXT: HLSLMatrixLayoutAttr {{.*}} row_major
+  row_major float2x2 m1;
+  // CHECK: FieldDecl {{.*}} m2 'float3x3'
+  // CHECK-NEXT: HLSLMatrixLayoutAttr {{.*}} column_major
+  column_major float3x3 m2;
+};
+
+// CHECK: TypedefDecl {{.*}} RM44 'float4x4'
+// CHECK: HLSLMatrixLayoutAttr {{.*}} row_major
+typedef row_major float4x4 RM44;

--- a/clang/test/Sema/hlsl_matrix_layout_non_hlsl.cpp
+++ b/clang/test/Sema/hlsl_matrix_layout_non_hlsl.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -triple x86_64-pc-linux -std=c++17 -fsyntax-only -verify -x c++ %s
+// expected-no-diagnostics
+
+// row_major and column_major are HLSL-only keywords.
+// In non-HLSL modes, they should not be treated as keywords
+// and can be used as regular identifiers.
+int row_major = 1;
+int column_major = 2;
+
+void foo() {
+  int row_major = 10;
+  int column_major = 20;
+}

--- a/clang/test/SemaHLSL/matrix_layout_attr.hlsl
+++ b/clang/test/SemaHLSL/matrix_layout_attr.hlsl
@@ -42,6 +42,14 @@ column_major float4x4 Col2Row(row_major float4x4 M) {
     return M;
 }
 
+void bar(row_major float4x4 M, column_major float4x4 M2) {}
+
+//Invalid: 
+// expected-error@+1 {{'row_major' attribute can only be applied to a matrix type}}
+void foo(column_major float4x4 mat, row_major int i) {}
+// expected-error@+1 {{'row_major' attribute can only be applied to a matrix type}}
+void foo2(float4x4 mat, row_major int i) {}
+
 
 template <typename T>
 struct Wrapper {

--- a/clang/test/SemaHLSL/matrix_layout_attr.hlsl
+++ b/clang/test/SemaHLSL/matrix_layout_attr.hlsl
@@ -1,0 +1,65 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.6-library -finclude-default-header -std=hlsl202x -verify %s
+
+// Valid uses: row_major and column_major on matrix types.
+row_major float3x3 rm_mat;
+column_major float4x4 cm_mat;
+
+row_major int2x3 rm_int_mat;
+column_major bool2x2 cm_bool_mat;
+
+// Valid: on struct fields with matrix type.
+struct S {
+  row_major float2x2 mat1;
+  column_major float3x3 mat2;
+};
+
+// Valid: typedef of a matrix type.
+typedef row_major float4x4 RowMajorFloat4x4;
+typedef column_major float4x4 ColMajorFloat4x4;
+
+// Invalid: scalar types.
+// expected-error@+1 {{'row_major' attribute can only be applied to a matrix type}}
+row_major float f;
+// expected-error@+1 {{'column_major' attribute can only be applied to a matrix type}}
+column_major int i;
+
+// Invalid: vector types.
+// expected-error@+1 {{'row_major' attribute can only be applied to a matrix type}}
+row_major float3 v;
+// expected-error@+1 {{'column_major' attribute can only be applied to a matrix type}}
+column_major int4 iv;
+
+// Invalid: array types.
+// expected-error@+1 {{'row_major' attribute can only be applied to a matrix type}}
+row_major float arr[10];
+
+// Invalid: struct types.
+// expected-error@+1 {{'column_major' attribute can only be applied to a matrix type}}
+column_major S s;
+
+// Invalid: struct field with non-matrix type.
+struct S2 {
+  // expected-error@+1 {{'row_major' attribute can only be applied to a matrix type}}
+  row_major float x;
+  // expected-error@+1 {{'column_major' attribute can only be applied to a matrix type}}
+  column_major int y;
+};
+
+// Invalid: typedef of non-matrix type.
+// expected-error@+1 {{'row_major' attribute can only be applied to a matrix type}}
+typedef row_major float ScalarRM;
+
+// Invalid: conflicting row_major and column_major on same decl.
+// expected-note@+2 {{conflicting attribute is here}}
+// expected-error@+1 {{'column_major' and 'row_major' attributes are not compatible}}
+row_major column_major float3x3 conflict_mat;
+
+// Invalid: duplicate row_major.
+// expected-note@+2 {{previous attribute is here}}
+// expected-warning@+1 {{attribute 'row_major' is already applied}}
+row_major row_major float3x3 dup_rm_mat;
+
+// Invalid: duplicate column_major.
+// expected-note@+2 {{previous attribute is here}}
+// expected-warning@+1 {{attribute 'column_major' is already applied}}
+column_major column_major float4x4 dup_cm_mat;

--- a/clang/test/SemaHLSL/matrix_layout_attr.hlsl
+++ b/clang/test/SemaHLSL/matrix_layout_attr.hlsl
@@ -1,11 +1,15 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.6-library -finclude-default-header -std=hlsl202x -verify %s
 
-// Valid uses: row_major and column_major on matrix types.
+// Valid: row_major and column_major on matrix types.
 row_major float3x3 rm_mat;
 column_major float4x4 cm_mat;
 
 row_major int2x3 rm_int_mat;
 column_major bool2x2 cm_bool_mat;
+
+// Valid: row_major and column_major on matrix arrays
+row_major float3x3 rm_mat_arr[2];
+column_major float4x4 cm_mat_arr[3];
 
 // Valid: on struct fields with matrix type.
 struct S {
@@ -16,6 +20,21 @@ struct S {
 // Valid: typedef of a matrix type.
 typedef row_major float4x4 RowMajorFloat4x4;
 typedef column_major float4x4 ColMajorFloat4x4;
+
+template <typename T>
+struct Wrapper {
+  row_major T mat; // expected-error 2 {{'row_major' attribute can only be applied to a matrix type}}
+};
+
+Wrapper<float4x4> valid;
+
+// expected-note@+1 {{in instantiation of template class 'Wrapper<float>' requested here}}
+Wrapper<float> invalid;
+
+// expected-note@+1 {{in instantiation of template class 'Wrapper<vector<float, 2>>' requested here}}
+Wrapper<float2> invalid2;
+
+
 
 // Invalid: scalar types.
 // expected-error@+1 {{'row_major' attribute can only be applied to a matrix type}}

--- a/clang/test/SemaHLSL/matrix_layout_attr.hlsl
+++ b/clang/test/SemaHLSL/matrix_layout_attr.hlsl
@@ -21,6 +21,24 @@ struct S {
 typedef row_major float4x4 RowMajorFloat4x4;
 typedef column_major float4x4 ColMajorFloat4x4;
 
+// Valid: layout order conversion
+row_major float4x4 Row2Col1(float4x4 M) {
+    return M;
+}
+
+float4x4 Row2Col2(column_major float4x4 M) {
+    return M;
+}
+
+row_major float4x4 Row2Col(column_major float4x4 M) {
+    return M;
+}
+
+column_major float4x4 Col2Row(row_major float4x4 M) {
+    return M;
+}
+
+
 template <typename T>
 struct Wrapper {
   row_major T mat; // expected-error 2 {{'row_major' attribute can only be applied to a matrix type}}

--- a/clang/test/SemaHLSL/matrix_layout_attr.hlsl
+++ b/clang/test/SemaHLSL/matrix_layout_attr.hlsl
@@ -11,6 +11,10 @@ column_major bool2x2 cm_bool_mat;
 row_major float3x3 rm_mat_arr[2];
 column_major float4x4 cm_mat_arr[3];
 
+// Valid: row_major and column_major on matrix 2d arrays
+row_major float3x3 rm_mat_arr_2d[2][3];
+column_major float4x4 cm_mat_arr_2d[3][2];
+
 // Valid: on struct fields with matrix type.
 struct S {
   row_major float2x2 mat1;

--- a/clang/test/SemaHLSL/matrix_layout_attr.hlsl
+++ b/clang/test/SemaHLSL/matrix_layout_attr.hlsl
@@ -50,6 +50,9 @@ void foo(column_major float4x4 mat, row_major int i) {}
 // expected-error@+1 {{'row_major' attribute can only be applied to a matrix type}}
 void foo2(float4x4 mat, row_major int i) {}
 
+// expected-error@+1 {{'row_major' attribute can only be applied to a matrix type}}
+row_major int foo(float4x4 mat) {}
+
 
 template <typename T>
 struct Wrapper {


### PR DESCRIPTION
fixes #192263

HLSL allows per-declaration matrix layout overrides via the row_major and column_major keywords. Prior to this commit, matrix layout was only controlled globally via the -fmatrix-memory-layout command-line flag (LangOptions::DefaultMatrixMemoryLayout). This commit adds the parsing and semantic analysis infrastructure needed to support per-declaration layout, matching DXC behavior.


Assisted-by: Claude Opus 4.6