### PR TITLE
[clang-format] Recognize more braced initializers

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -2084,10 +2084,10 @@ void UnwrappedLineParser::parseStructuralElement(
       SeenEqual = true;
       nextToken();
       if (FormatTok->is(tok::l_brace)) {
-        // Block kind should probably be set to BK_BracedInit for any language.
         // C# needs this change to ensure that array initialisers and object
-        // initialisers are indented the same way.
-        if (Style.isCSharp())
+        // initialisers are indented the same way. In TypeScript, the brace
+        // can also be an object type definition.
+        if (!Style.isJavaScript())
           FormatTok->setBlockKind(BK_BracedInit);
         // TableGen's defset statement has syntax of the form,
         // `defset <type> <name> = { <statement>... }`

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12041,6 +12041,7 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
   verifyFormat("int *f(int *a) {}");
   verifyFormat("int main(int argc, char **argv) {}");
   verifyFormat("Test::Test(int b) : a(b * b) {}");
+  verifyIndependentOfContext("a = {x * x, x * x};");
   verifyIndependentOfContext("f(a, *a);");
   verifyFormat("void g() { f(*a); }");
   verifyIndependentOfContext("int a = b * 10;");
@@ -14631,10 +14632,13 @@ TEST_F(FormatTest, FormatsBracedListsInColumnLayout) {
                getLLVMStyleWithColumns(39));
 
   // Trailing comment in the first line.
+  auto Style = getLLVMStyle();
+  Style.Cpp11BracedListStyle = FormatStyle::BLS_FunctionCall;
   verifyFormat("vector<int> iiiiiiiiiiiiiii = {                      //\n"
                "    1111111111, 2222222222, 33333333333, 4444444444, //\n"
                "    111111111,  222222222,  3333333333,  444444444,  //\n"
-               "    11111111,   22222222,   333333333,   44444444};");
+               "    11111111,   22222222,   333333333,   44444444};",
+               Style);
   // Trailing comment in the last line.
   verifyFormat("int aaaaa[] = {\n"
                "    1, 2, 3, // comment\n"

--- a/clang/unittests/Format/FormatTestComments.cpp
+++ b/clang/unittests/Format/FormatTestComments.cpp
@@ -187,11 +187,10 @@ TEST_F(FormatTestComments, UnderstandsSingleLineComments) {
 
   verifyGoogleFormat("#endif  // HEADER_GUARD");
 
-  verifyFormat("const char *test[] = {\n"
-               "    // A\n"
-               "    \"aaaa\",\n"
-               "    // B\n"
-               "    \"aaaaa\"};");
+  verifyFormat("const char *test[] = {// A\n"
+               "                      \"aaaa\",\n"
+               "                      // B\n"
+               "                      \"aaaaa\"};");
   verifyGoogleFormat(
       "aaaaaaaaaaaaaaaaaaaaaaaaaa(\n"
       "    aaaaaaaaaaaaaaaaaaaaaa);  // 81_cols_with_this_comment");
@@ -1421,12 +1420,11 @@ TEST_F(FormatTestComments, CommentsInStaticInitializers) {
                "       {// Group #3\n"
                "        g, h, i}};");
 
-  verifyFormat("S s = {\n"
-               "    // Some comment\n"
-               "    a,\n"
+  verifyFormat("S s = {// Some comment\n"
+               "       a,\n"
                "\n"
-               "    // Comment after empty line\n"
-               "    b}",
+               "       // Comment after empty line\n"
+               "       b}",
                "S s =    {\n"
                "      // Some comment\n"
                "  a,\n"
@@ -1434,12 +1432,11 @@ TEST_F(FormatTestComments, CommentsInStaticInitializers) {
                "     // Comment after empty line\n"
                "      b\n"
                "}");
-  verifyFormat("S s = {\n"
-               "    /* Some comment */\n"
-               "    a,\n"
+  verifyFormat("S s = {/* Some comment */\n"
+               "       a,\n"
                "\n"
-               "    /* Comment after empty line */\n"
-               "    b}",
+               "       /* Comment after empty line */\n"
+               "       b}",
                "S s =    {\n"
                "      /* Some comment */\n"
                "  a,\n"

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -3980,6 +3980,12 @@ TEST_F(TokenAnnotatorTest, BraceKind) {
   Tokens = annotate("&(type){v}");
   ASSERT_EQ(Tokens.size(), 8u) << Tokens;
   EXPECT_BRACE_KIND(Tokens[4], BK_BracedInit);
+
+  Tokens = annotate("a = {x * x, x * x};");
+  ASSERT_EQ(Tokens.size(), 13u) << Tokens;
+  EXPECT_BRACE_KIND(Tokens[2], BK_BracedInit);
+  EXPECT_TOKEN(Tokens[4], tok::star, TT_BinaryOperator);
+  EXPECT_TOKEN(Tokens[8], tok::star, TT_BinaryOperator);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsElaboratedTypeSpecifier) {


### PR DESCRIPTION
new

```C++
a = {x * x, x * x};
```

old

```C++
a = {x * x, x *x};
```

Fixes #57442.

The patch makes the program treat a brace following an equal sign a braced initializer.

The patch changes these tests.

- In UnderstandsSingleLineComments and CommentsInStaticInitializers, the comment in the formatted code used to be on a separate line, now it is on the same line as the brace.  The new behavior is consistent with comment in braced lists that are correctly identified.  Here is the code for it from the test LayoutCxx11BraceInitializers and the function mustBreakBefore.

  ```C++
  // In braced lists, the first comment is always assumed to belong to the
  // first element. Thus, it can be moved to the next or previous line as
  // appropriate.
  verifyFormat("function({// First element:\n"
               "          1,\n"
               "          // Second element:\n"
               "          2});",
               "function({\n"
               "    // First element:\n"
               "    1,\n"
               "    // Second element:\n"
               "    2});");

  if (Right.is(tok::comment)) {
    return Left.isNoneOf(BK_BracedInit, TT_CtorInitializerColon) &&
           Right.NewlinesBefore > 0 && Right.HasUnescapedNewline;
  }
  ```

- In FormatsBracedListsInColumnLayout, the style is configured to one which allows a trailing comment in the first line.