### PR TITLE
[mlir][SPIR-V] Reject initializer on Import-linkage GlobalVariable

### DIFF
--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
@@ -1339,6 +1339,16 @@ LogicalResult spirv::GlobalVariableOp::verify() {
            << stringifyStorageClass(storageClass) << "'";
   }
 
+  // SPIR-V spec: "If Linkage Type is Import, no further operands are
+  // permitted." — i.e. an Import-linkage variable must not have an initializer.
+  if (auto linkage = getLinkageAttributes()) {
+    if (linkage->getLinkageType().getValue() == spirv::LinkageType::Import &&
+        getInitializer()) {
+      return emitOpError(
+          "with Import linkage type must not have an initializer");
+    }
+  }
+
   if (auto init = (*this)->getAttrOfType<FlatSymbolRefAttr>(
           this->getInitializerAttrName())) {
     Operation *initOp = SymbolTable::lookupNearestSymbolFrom(

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
@@ -1339,9 +1339,10 @@ LogicalResult spirv::GlobalVariableOp::verify() {
            << stringifyStorageClass(storageClass) << "'";
   }
 
-  // SPIR-V spec: "If Linkage Type is Import, no further operands are
-  // permitted." — i.e. an Import-linkage variable must not have an initializer.
-  if (auto linkage = getLinkageAttributes()) {
+  // SPIR-V spec: "A module-scope OpVariable with an Initializer operand must
+  // not be decorated with the Import Linkage Type."
+  if (std::optional<spirv::LinkageAttributesAttr> linkage =
+          getLinkageAttributes()) {
     if (linkage->getLinkageType().getValue() == spirv::LinkageType::Import &&
         getInitializer()) {
       return emitOpError(

--- a/mlir/test/Dialect/SPIRV/IR/structure-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/structure-ops.mlir
@@ -589,6 +589,19 @@ spirv.module Logical GLSL450 {
 
 // -----
 
+spirv.module Logical GLSL450 requires #spirv.vce<v1.0, [Shader, Linkage], []> {
+  spirv.SpecConstant @sc = 1.0 : f32
+  // expected-error @+1 {{op with Import linkage type must not have an initializer}}
+  spirv.GlobalVariable @var0 initializer(@sc) {
+    linkage_attributes = #spirv.linkage_attributes<
+      linkage_name = "importedVar",
+      linkage_type = <Import>
+    >
+  } : !spirv.ptr<f32, Private>
+}
+
+// -----
+
 spirv.module Logical GLSL450 {
   spirv.func @foo() "None" {
     // expected-error @+1 {{op must appear in a module-like op's block}}


### PR DESCRIPTION
Per the SPIR-V spec, a module-scope OpVariable with Import linkage must not have an initializer