### PR TITLE
[libc++] Update `__mbstate_t.h` to include path to Android's `mbstate_t.h`

### DIFF
--- a/libcxx/include/__mbstate_t.h
+++ b/libcxx/include/__mbstate_t.h
@@ -43,6 +43,8 @@
 #  include <bits/types/mbstate_t.h> // works on most Unixes
 #elif __has_include(<sys/_types/_mbstate_t.h>)
 #  include <sys/_types/_mbstate_t.h> // works on Darwin
+#elif __has_include(<bits/mbstate_t.h>)
+#  include <bits/mbstate_t.h> // works for Android
 #elif __has_include_next(<wchar.h>)
 #  include_next <wchar.h> // use the C standard provider of mbstate_t if present
 #elif __has_include_next(<uchar.h>)


### PR DESCRIPTION
Ever since ce4ac9945 started including `__mbstate_t.h` in this C++ `wchar.h`, the Android NDK sees some redefinition errors with `-fmodules`, likely because this Android `mbstate_t.h` was not included. Elliot, enh-google from the Android team, suggested this inclusion to fix it, and it worked for me in my local testing: see swiftlang/swift#85365 for the errors and more info. This fixes android/ndk#2230, once it gets into the NDK sysroot.