### PR TITLE
[LifetimeSafety] Handle xvalue operand of LValueToRValue cast

### DIFF
--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -288,8 +288,7 @@ void FactsGenerator::VisitCastExpr(const CastExpr *CE) {
 
   switch (CE->getCastKind()) {
   case CK_LValueToRValue:
-    // TODO: Decide what to do for x-values here.
-    if (!SubExpr->isLValue())
+    if (!SubExpr->isGLValue())
       return;
 
     assert(Src && "LValue being cast to RValue has no origin list");

--- a/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: %clang_cc1 -fsyntax-only -flifetime-safety-inference -fexperimental-lifetime-safety-tu-analysis -Wlifetime-safety-suggestions -Wlifetime-safety -Wno-dangling -I%t -I%S -verify %t/test_source.cpp
+// RUN: %clang_cc1 -fsyntax-only -std=c++23 -flifetime-safety-inference -fexperimental-lifetime-safety-tu-analysis -Wlifetime-safety-suggestions -Wlifetime-safety -Wno-dangling -I%t -I%S -verify %t/test_source.cpp
 // RUN: %clang_cc1 -flifetime-safety-inference -fexperimental-lifetime-safety-tu-analysis -Wlifetime-safety-suggestions -Wlifetime-safety -Wno-dangling -I%t -I%S -fixit %t/test_source.cpp
 // RUN: %clang_cc1 -fsyntax-only -flifetime-safety-inference -fexperimental-lifetime-safety-tu-analysis -Wlifetime-safety-suggestions -Wno-dangling -I%t -I%S -Werror=lifetime-safety-suggestions %t/test_source.cpp
 


### PR DESCRIPTION
Under C++23, P2266 wraps the operand of `return p;` in an xvalue NoOp cast for by-value parameters. The `CK_LValueToRValue` branch in FactsGenerator guarded on `!SubExpr->isLValue()`, breaking origin flow and silencing the suggestion for `int* id(int* p) { return p; }`.

Use `isGLValue()`, matching how origins are built and stripped elsewhere in the analysis.

Only add a RUN in suggestion test file, since some tests in `warn-lifetime-safety.cpp` cause a hard error under C++23. For example: `MyObj& f() { MyObj s; return s; }`. `error: non-const lvalue reference to type 'MyObj' cannot bind to a temporary of type 'MyObj'`.

Fixes: #176292