### PR TITLE
Avoid code pages issues with escape chars in printf command

### DIFF
--- a/clang/test/Lexer/Inputs/bom-directives.c
+++ b/clang/test/Lexer/Inputs/bom-directives.c
@@ -1,0 +1,3 @@
+﻿#ifdef TEST\n
+#include <string>
+#endif

--- a/clang/test/Lexer/minimize_source_to_dependency_directives_utf8bom.c
+++ b/clang/test/Lexer/minimize_source_to_dependency_directives_utf8bom.c
@@ -1,9 +1,6 @@
 // Test UTF8 BOM at start of file
-// RUN: printf '\357\273\277' > %t.c
-﻿// RUN: echo '#ifdef TEST\n' >> %t.c
-// RUN: echo '#include <string>' >> %t.c
-// RUN: echo '#endif' >> %t.c
-// RUN: %clang_cc1 -DTEST -print-dependency-directives-minimized-source %t.c 2>&1 | FileCheck %s
+// RUN: cat %S/Inputs/bom-directives.c | od -t x1 | grep -iq 'ef[[:space:]]*bb[[:space:]]*bf'
+// RUN: %clang_cc1 -DTEST -print-dependency-directives-minimized-source %S/Inputs/bom-directives.c 2>&1 | FileCheck %s
 
 ﻿// CHECK:      #ifdef TEST
 // CHECK-NEXT: #include <string>


### PR DESCRIPTION
On z/OS the printf command run via the `RUN:` commands in lit prints on EBCDIC.  The llvm-lit util ends up converting the string literal (without evaluating the escape sequences) into EBCDIC.  The system printf command then parses that string literal and prints out the EBCDIC string.  The octal and hex escape sequences create EBCDIC characters with those values.  The llvm-lit then converts the final EBCDIC string literal to ASCII.  For this test case that causes the char `\357` to end up with the \xd5 instead of \xef.

Other BOM tests store the source file with the BOM marker as a file in the Inputs dir.  Do the same with this test case.