### PR TITLE
[MemProf] Disable promotion to function declarations by default

### DIFF
--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -221,6 +221,9 @@ cl::opt<bool> SupportsHotColdNew(
     "supports-hot-cold-new", cl::init(false), cl::Hidden,
     cl::desc("Linking with hot/cold operator new interfaces"));
 
+// This is true because we cannot guarantee that function declarations of dead
+// functions have been stripped, even after running `dropDeadSymbols` before
+// ThinLTO optimization pipeline.
 static cl::opt<bool> MemProfRequireDefinitionForPromotion(
     "memprof-require-definition-for-promotion", cl::init(true), cl::Hidden,
     cl::desc(

--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -222,7 +222,7 @@ cl::opt<bool> SupportsHotColdNew(
     cl::desc("Linking with hot/cold operator new interfaces"));
 
 static cl::opt<bool> MemProfRequireDefinitionForPromotion(
-    "memprof-require-definition-for-promotion", cl::init(false), cl::Hidden,
+    "memprof-require-definition-for-promotion", cl::init(true), cl::Hidden,
     cl::desc(
         "Require target function definition when promoting indirect calls"));
 

--- a/llvm/test/ThinLTO/X86/memprof-icp.ll
+++ b/llvm/test/ThinLTO/X86/memprof-icp.ll
@@ -202,10 +202,12 @@
 
 ;; Run in-process ThinLTO again, but with importing disabled by setting the
 ;; instruction limit to 0. Ensure that the existing declarations of B::bar
-;; and B0::bar are sufficient to allow for the promotion and cloning.
+;; and B0::bar are sufficient to allow for the promotion and cloning with
+;; -memprof-require-definition-for-promotion=false.
 ; RUN: llvm-lto2 run %t/main.o %t/foo.o -enable-memprof-context-disambiguation \
 ; RUN:	-import-instr-limit=0 \
 ; RUN:	-enable-memprof-indirect-call-support=true \
+; RUN:  -memprof-require-definition-for-promotion=false \
 ; RUN:  -supports-hot-cold-new \
 ; RUN:  -r=%t/foo.o,_Z3fooR2B0j,plx \
 ; RUN:  -r=%t/foo.o,_ZN2B03barEj.abc,plx \
@@ -237,10 +239,10 @@
 ; RUN: llvm-dis %t.out.2.4.opt.bc -o - | FileCheck %s --check-prefix=IR --check-prefix=IR-NOIMPORT
 
 ;; Run it gain but with -memprof-require-definition-for-promotion, and confirm
-;; that no promotions occur.
+;; that no promotions occur with the default
+;; -memprof-require-definition-for-promotion=true.
 ; RUN: llvm-lto2 run %t/main.o %t/foo.o -enable-memprof-context-disambiguation \
 ; RUN:	-import-instr-limit=0 \
-; RUN:	-memprof-require-definition-for-promotion \
 ; RUN:	-icp-allow-decls=false \
 ; RUN:	-enable-memprof-indirect-call-support=true \
 ; RUN:  -supports-hot-cold-new \


### PR DESCRIPTION
This was added in #115555. However, we cannot guarantee that all dead declarations have been stripped via `dropDeadSymbols` because it doesn't delete the declaration if there are references to it.

https://github.com/llvm/llvm-project/blob/a3af640a1b5c61e7f31c7212338cd348d9b4a132/llvm/lib/LTO/LTOBackend.cpp#L637

In #190876 we now have functions in ValueAsMetadata (!inline_history metadata) which can prevent function declarations from being erased. This causes memprof's ICP to create a call to a declaration that in fact has been internalized in another module, causing undefined reference linker errors. This isn't necessarily specific to !inline_history, although !inline_history seems to be the first to take advantage of this. So disable ICP for function declarations for now.