### PR TITLE
[MachineOutliner] Do not allow debug instructions to affect liveness computations.

### DIFF
--- a/llvm/lib/CodeGen/MachineOutliner.cpp
+++ b/llvm/lib/CodeGen/MachineOutliner.cpp
@@ -1158,6 +1158,8 @@ bool MachineOutliner::outline(
                  Last = std::next(CallInst.getReverse());
              Iter != Last; Iter++) {
           MachineInstr *MI = &*Iter;
+          if (MI->isDebugInstr())
+            continue;
           SmallSet<Register, 2> InstrUseRegs;
           for (MachineOperand &MOP : MI->operands()) {
             // Skip over anything that isn't a register.


### PR DESCRIPTION
Because DBG_VALUE precedes the actual definition of a physical register, considering
these during the liveness updating phase of MachineOutliner was causing every register
definition to also be marked as a use, which would eventually lead to a verifier error
when a use without a def was detected.

A MIR testcase for this is present at https://github.com/CHERIoT-Platform/llvm-project/commit/b71f6d67e338e70a1dc23e15a77805da3e3cd015 but it depends on CHERIoT instructions that are not in LLVM upstream at present. It's also very senstive to small changes to the input, so I have not been able to reproduce it on an in-tree target. That said, I believe this change is small enough that its correctness is verifiable by inspection.
