### PR TITLE
[RISCV] Prefer LUI over PLUI.H on RV32.

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMatInt.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMatInt.cpp
@@ -79,7 +79,9 @@ static void generateInstSeqImpl(int64_t Val, const MCSubtargetInfo &STI,
     }
   }
 
-  if (STI.hasFeature(RISCV::FeatureStdExtP) && !isInt<12>(Val)) {
+  // Try PLI/PLUI if available, but prefer LI/LUI.
+  if (STI.hasFeature(RISCV::FeatureStdExtP) && !isInt<12>(Val) &&
+      !isShiftedInt<20, 12>(Val)) {
     unsigned Width = 64;
 
     int32_t Bit31To0 = Val;

--- a/llvm/test/MC/RISCV/rv32p-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv32p-aliases-valid.s
@@ -279,6 +279,10 @@ li s10, 0x11111111
 # CHECK-S-OBJ: pli.h s11, 1
 li s11, 0x00010001
 
-# CHECK-S-OBJ-NOALIAS: plui.h t3, -512
-# CHECK-S-OBJ: plui.h t3, -512
-li t3, 0x80008000
+# CHECK-S-OBJ-NOALIAS: plui.h t3, -508
+# CHECK-S-OBJ: plui.h t3, -508
+li t3, 0x81008100
+
+# CHECK-S-OBJ-NOALIAS: lui t4, 524296
+# CHECK-S-OBJ: lui t4, 524296
+li t4, 0x80008000


### PR DESCRIPTION
I don't think any of the cases PLUI.H can handle would be eligible for C.LUI, but still figured it was best to use base ISA instructions when possible.