### PR TITLE
[mlir][func] Avoid to create duplicate symbol during conversion

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/FunctionCallUtils.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/FunctionCallUtils.cpp
@@ -87,6 +87,17 @@ mlir::LLVM::lookupOrCreateFn(OpBuilder &b, Operation *moduleOp, StringRef name,
     return func;
   }
 
+  // A symbol with this name may already exist as a non-LLVM function (e.g.,
+  // func::FuncOp from user code that hasn't been converted to LLVM dialect
+  // yet). Creating a new LLVMFuncOp with the same name would cause a symbol
+  // redefinition error. Return failure so the calling pattern can retry after
+  // the existing symbol is converted.
+  if (symbolTables
+          ? symbolTables->lookupSymbolIn(
+                moduleOp, StringAttr::get(moduleOp->getContext(), name))
+          : SymbolTable::lookupSymbolIn(moduleOp, name))
+    return failure();
+
   OpBuilder::InsertionGuard g(b);
   assert(!moduleOp->getRegion(0).empty() && "expected non-empty region");
   b.setInsertionPointToStart(&moduleOp->getRegion(0).front());

--- a/mlir/test/Conversion/FuncToLLVM/func-duplicate-symbol.mlir
+++ b/mlir/test/Conversion/FuncToLLVM/func-duplicate-symbol.mlir
@@ -1,0 +1,23 @@
+// RUN: mlir-opt -finalize-memref-to-llvm -convert-func-to-llvm -finalize-memref-to-llvm %s | FileCheck %s
+
+// Verify that memref.dealloc lowering does not create a duplicate @free
+// declaration when a func.func @free already exists in the module (e.g. from
+// a user-defined declaration). Both func-to-llvm and memref-to-llvm patterns
+// run in the same conversion in convert-to-llvm, and the func.func @free may
+// not yet be converted to llvm.func when the dealloc pattern runs.
+// The pipeline used in the test is to simulate MemrefToLLVM and FuncToLLVM
+// patterns used in a same pass.
+
+// CHECK-LABEL: llvm.func @dealloc_with_user_free
+// CHECK:         llvm.call @free(%{{.*}}) : (!llvm.ptr) -> ()
+// CHECK:         llvm.return
+
+// CHECK: llvm.func @free(!llvm.ptr)
+// CHECK-NOT: llvm.func @free
+
+func.func @dealloc_with_user_free(%arg0: memref<?xf32>) {
+  memref.dealloc %arg0 : memref<?xf32>
+  return
+}
+
+func.func private @free(!llvm.ptr)


### PR DESCRIPTION
`LLVM::lookupOrCreateFn` only checks for an existing `LLVM::LLVMFuncOp` before creating a new function declaration. When a symbol with the same name exists as a different op type (e.g., `func.func` that hasn't been converted to LLVM dialect yet), the function blindly creates a duplicate `LLVMFuncOp`, which either causes a "redefinition of symbol" error or silently introduces a renamed symbol (`@free_0`) that won't resolve at link time.

This happens in practice when user code declares function that is also used internally by MLIR lowerings. For example, a Fortran `bind(c, name="free")` declaration produces a `func.func @free` in the IR. When `memref.dealloc` is lowered (via DeallocOpLowering), it calls lookupOrCreateFreeFn which calls lookupOrCreateFn — and since the existing `func.func @free` is not an LLVMFuncOp, a conflicting duplicate is created.

The fix adds a check in lookupOrCreateFn: before creating a new LLVMFuncOp, it verifies that no symbol with the requested name already exists in the module (regardless of op type). If one does, it returns failure() so the calling conversion pattern can be retried after the existing symbol is converted by another pattern (e.g., func-to-llvm).