### PR TITLE
[CIR] Simplify expr with cleanup scopes

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
@@ -1021,24 +1021,8 @@ void AggExprEmitter::VisitLambdaExpr(LambdaExpr *e) {
 }
 
 void AggExprEmitter::VisitExprWithCleanups(ExprWithCleanups *e) {
-  CIRGenBuilderTy &builder = cgf.getBuilder();
-  mlir::Location scopeLoc = cgf.getLoc(e->getSourceRange());
-  mlir::OpBuilder::InsertPoint scopeBegin;
-
-  cir::ScopeOp::create(builder, scopeLoc, /*scopeBuilder=*/
-                       [&](mlir::OpBuilder &b, mlir::Location loc) {
-                         scopeBegin = b.saveInsertionPoint();
-                       });
-
-  {
-    mlir::OpBuilder::InsertionGuard guard(builder);
-    builder.restoreInsertionPoint(scopeBegin);
-    CIRGenFunction::LexicalScope lexScope{cgf, scopeLoc,
-                                          builder.getInsertionBlock()};
-
-    CIRGenFunction::FullExprCleanupScope fullExprScope(cgf, e->getSubExpr());
-    Visit(e->getSubExpr());
-  }
+  CIRGenFunction::FullExprCleanupScope fullExprScope(cgf, e->getSubExpr());
+  Visit(e->getSubExpr());
 }
 
 void AggExprEmitter::VisitCallExpr(const CallExpr *e) {

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -654,24 +654,8 @@ mlir::LogicalResult CIRGenFunction::emitReturnStmt(const ReturnStmt &s) {
   if (!createNewScope) {
     handleReturnVal();
   } else {
-    mlir::Location scopeLoc =
-        getLoc(rv ? rv->getSourceRange() : s.getSourceRange());
-    // First create cir.scope and later emit it's body. Otherwise all CIRGen
-    // dispatched by `handleReturnVal()` might needs to manipulate blocks and
-    // look into parents, which are all unlinked.
-    mlir::OpBuilder::InsertPoint scopeBody;
-    cir::ScopeOp::create(builder, scopeLoc, /*scopeBuilder=*/
-                         [&](mlir::OpBuilder &b, mlir::Location loc) {
-                           scopeBody = b.saveInsertionPoint();
-                         });
-    {
-      mlir::OpBuilder::InsertionGuard guard(builder);
-      builder.restoreInsertionPoint(scopeBody);
-      CIRGenFunction::LexicalScope lexScope{*this, scopeLoc,
-                                            builder.getInsertionBlock()};
-      FullExprCleanupScope fullExprScope(*this, rv);
-      handleReturnVal();
-    }
+    FullExprCleanupScope fullExprScope(*this, rv);
+    handleReturnVal();
   }
 
   cleanupScope.forceCleanup();

--- a/clang/test/CIR/CodeGen/abstract-cond.c
+++ b/clang/test/CIR/CodeGen/abstract-cond.c
@@ -15,16 +15,15 @@ int test_agg_cond(int a0, struct s6 a1, struct s6 a2) {
 // CIR:  %[[A0:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a0"
 // CIR:  %[[A1:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a1"
 // CIR:  %[[A2:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a2"
-// CIR:  cir.scope {
-// CIR:    %[[TMP:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["ref.tmp0"]
-// CIR:    %[[LOAD_A0:.*]] = cir.load{{.*}} %[[A0]] : !cir.ptr<!s32i>, !s32i
-// CIR:    %[[COND:.*]] = cir.cast int_to_bool %[[LOAD_A0]] : !s32i -> !cir.bool
-// CIR:    cir.if %[[COND]] {
-// CIR:      cir.copy %[[A1]] to %[[TMP]] : !cir.ptr<!rec_s6>
-// CIR:    } else {
-// CIR:      cir.copy %[[A2]] to %[[TMP]] : !cir.ptr<!rec_s6>
-// CIR:    }
-// CIR:    cir.get_member %[[TMP]][0] {name = "f0"} : !cir.ptr<!rec_s6> -> !cir.ptr<!s32i>
+// CIR:  %[[TMP:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["ref.tmp0"]
+// CIR:  %[[LOAD_A0:.*]] = cir.load{{.*}} %[[A0]] : !cir.ptr<!s32i>, !s32i
+// CIR:  %[[COND:.*]] = cir.cast int_to_bool %[[LOAD_A0]] : !s32i -> !cir.bool
+// CIR:  cir.if %[[COND]] {
+// CIR:    cir.copy %[[A1]] to %[[TMP]] : !cir.ptr<!rec_s6>
+// CIR:  } else {
+// CIR:    cir.copy %[[A2]] to %[[TMP]] : !cir.ptr<!rec_s6>
+// CIR:  }
+// CIR:  cir.get_member %[[TMP]][0] {name = "f0"} : !cir.ptr<!rec_s6> -> !cir.ptr<!s32i>
 
 // LLVM: define {{.*}} i32 @test_agg_cond
 // LLVM:    %[[LOAD_A0:.*]] = load i32, ptr {{.*}}
@@ -64,22 +63,21 @@ int test_stmt_expr(int flag, struct s6 a1, struct s6 a2) {
 // CIR:  %[[FLAG:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["flag"
 // CIR:  %[[A1:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a1"
 // CIR:  %[[A2:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a2"
-// CIR:  cir.scope {
-// CIR:    %[[TMP:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["ref.tmp0"]
-// CIR:    %[[LOAD_FLAG:.*]] = cir.load{{.*}} %[[FLAG]] : !cir.ptr<!s32i>, !s32i
-// CIR:    %[[COND:.*]] = cir.cast int_to_bool %[[LOAD_FLAG]] : !s32i -> !cir.bool
-// CIR:    cir.if %[[COND]] {
-// CIR:      %[[STMT_TMP:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["tmp"]
-// CIR:      cir.scope {
-// CIR:        %[[T:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["t", init]
-// CIR:        cir.copy %[[A1]] to %[[T]] : !cir.ptr<!rec_s6>
-// CIR:        cir.call @foo() : () -> ()
-// CIR:        cir.copy %[[T]] to %[[TMP]] : !cir.ptr<!rec_s6>
-// CIR:      }
-// CIR:    } else {
-// CIR:      cir.copy %[[A2]] to %[[TMP]] : !cir.ptr<!rec_s6>
+// CIR:  %[[TMP:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["ref.tmp0"]
+// CIR:  %[[LOAD_FLAG:.*]] = cir.load{{.*}} %[[FLAG]] : !cir.ptr<!s32i>, !s32i
+// CIR:  %[[COND:.*]] = cir.cast int_to_bool %[[LOAD_FLAG]] : !s32i -> !cir.bool
+// CIR:  cir.if %[[COND]] {
+// CIR:    %[[STMT_TMP:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["tmp"]
+// CIR:    cir.scope {
+// CIR:      %[[T:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["t", init]
+// CIR:      cir.copy %[[A1]] to %[[T]] : !cir.ptr<!rec_s6>
+// CIR:      cir.call @foo() : () -> ()
+// CIR:      cir.copy %[[T]] to %[[TMP]] : !cir.ptr<!rec_s6>
 // CIR:    }
-// CIR:    cir.get_member %[[TMP]][0] {name = "f0"} : !cir.ptr<!rec_s6> -> !cir.ptr<!s32i>
+// CIR:  } else {
+// CIR:    cir.copy %[[A2]] to %[[TMP]] : !cir.ptr<!rec_s6>
+// CIR:  }
+// CIR:  cir.get_member %[[TMP]][0] {name = "f0"} : !cir.ptr<!rec_s6> -> !cir.ptr<!s32i>
 
 // LLVM: define {{.*}} i32 @test_stmt_expr
 // LLVM:    %[[LOAD_FLAG:.*]] = load i32, ptr {{.*}}

--- a/clang/test/CIR/CodeGen/cleanup-conditional-eh.cpp
+++ b/clang/test/CIR/CodeGen/cleanup-conditional-eh.cpp
@@ -281,39 +281,37 @@ int test_return_ternary(bool c) {
 // CIR:   %[[ACTA:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.cond"]
 // CIR:   %[[TMPB:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp1"]
 // CIR:   %[[ACTB:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.cond"]
-// CIR:   cir.scope {
-// CIR:     cir.cleanup.scope {
-// CIR:       %[[COND:.*]] = cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
-// CIR:       %[[FALSE_A:.*]] = cir.const #false
-// CIR:       cir.store %[[FALSE_A]], %[[ACTA]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:       %[[FALSE_B:.*]] = cir.const #false
-// CIR:       cir.store %[[FALSE_B]], %[[ACTB]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:       %{{.*}} = cir.ternary(%[[COND]], true {
-// CIR:         cir.call @_ZN1AC1Ev(%[[TMPA]])
-// CIR:         %[[TRUE_A:.*]] = cir.const #true
-// CIR:         cir.store %[[TRUE_A]], %[[ACTA]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:         %[[GET_A:.*]] = cir.call @_ZN1A3getEv(%[[TMPA]])
-// CIR:         cir.yield %[[GET_A]] : !s32i
-// CIR:       }, false {
-// CIR:         cir.call @_ZN1BC1Ev(%[[TMPB]])
-// CIR:         %[[TRUE_B:.*]] = cir.const #true
-// CIR:         cir.store %[[TRUE_B]], %[[ACTB]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:         %[[GET_B:.*]] = cir.call @_ZN1B3getEv(%[[TMPB]])
-// CIR:         cir.yield %[[GET_B]] : !s32i
-// CIR:       })
-// CIR:       cir.store %{{.*}}, %{{.*}} : !s32i, !cir.ptr<!s32i>
-// CIR:       cir.yield
-// CIR:     } cleanup all {
-// CIR:       %[[FLAG_B:.*]] = cir.load {{.*}} %[[ACTB]]
-// CIR:       cir.if %[[FLAG_B]] {
-// CIR:         cir.call @_ZN1BD1Ev(%[[TMPB]])
-// CIR:       }
-// CIR:       %[[FLAG_A:.*]] = cir.load {{.*}} %[[ACTA]]
-// CIR:       cir.if %[[FLAG_A]] {
-// CIR:         cir.call @_ZN1AD1Ev(%[[TMPA]])
-// CIR:       }
-// CIR:       cir.yield
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[COND:.*]] = cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:     %[[FALSE_A:.*]] = cir.const #false
+// CIR:     cir.store %[[FALSE_A]], %[[ACTA]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:     %[[FALSE_B:.*]] = cir.const #false
+// CIR:     cir.store %[[FALSE_B]], %[[ACTB]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:     %{{.*}} = cir.ternary(%[[COND]], true {
+// CIR:       cir.call @_ZN1AC1Ev(%[[TMPA]])
+// CIR:       %[[TRUE_A:.*]] = cir.const #true
+// CIR:       cir.store %[[TRUE_A]], %[[ACTA]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:       %[[GET_A:.*]] = cir.call @_ZN1A3getEv(%[[TMPA]])
+// CIR:       cir.yield %[[GET_A]] : !s32i
+// CIR:     }, false {
+// CIR:       cir.call @_ZN1BC1Ev(%[[TMPB]])
+// CIR:       %[[TRUE_B:.*]] = cir.const #true
+// CIR:       cir.store %[[TRUE_B]], %[[ACTB]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:       %[[GET_B:.*]] = cir.call @_ZN1B3getEv(%[[TMPB]])
+// CIR:       cir.yield %[[GET_B]] : !s32i
+// CIR:     })
+// CIR:     cir.store %{{.*}}, %{{.*}} : !s32i, !cir.ptr<!s32i>
+// CIR:     cir.yield
+// CIR:   } cleanup all {
+// CIR:     %[[FLAG_B:.*]] = cir.load {{.*}} %[[ACTB]]
+// CIR:     cir.if %[[FLAG_B]] {
+// CIR:       cir.call @_ZN1BD1Ev(%[[TMPB]])
 // CIR:     }
+// CIR:     %[[FLAG_A:.*]] = cir.load {{.*}} %[[ACTA]]
+// CIR:     cir.if %[[FLAG_A]] {
+// CIR:       cir.call @_ZN1AD1Ev(%[[TMPA]])
+// CIR:     }
+// CIR:     cir.yield
 // CIR:   }
 // CIR:   %[[RET:.*]] = cir.load %{{.*}} : !cir.ptr<!s32i>, !s32i
 // CIR:   cir.return %[[RET]] : !s32i
@@ -432,27 +430,25 @@ int test_false_positive_conditional(bool c) {
 }
 // CIR-LABEL: @_Z31test_false_positive_conditionalb
 // CIR-NOT:   cir.alloca {{.*}} ["cleanup.cond"]
-// CIR:   cir.scope {
-// CIR:     %[[TMP:.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["ref.tmp0"]
-// CIR:     cir.call @_ZN1SC1Ev(%[[TMP]])
-// CIR:     cir.cleanup.scope {
-// CIR:       %[[VAL:.*]] = cir.call @_ZN1S3getEv(%[[TMP]])
-// CIR:       %[[BOOL:.*]] = cir.cast int_to_bool %[[VAL]]
-// CIR:       %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
-// CIR:       %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
-// CIR:       %[[SEL:.*]] = cir.select if %[[BOOL]] then %[[ONE]] else %[[TWO]]
-// CIR:       cir.store %[[SEL]], %{{.*}} : !s32i, !cir.ptr<!s32i>
-// CIR:       cir.yield
-// CIR:     } cleanup all {
-// CIR:       cir.call @_ZN1SD1Ev(%[[TMP]])
-// CIR:       cir.yield
-// CIR:     }
+// CIR:   %[[TMP:.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["ref.tmp0"]
+// CIR:   cir.call @_ZN1SC1Ev(%[[TMP]])
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[VAL:.*]] = cir.call @_ZN1S3getEv(%[[TMP]])
+// CIR:     %[[BOOL:.*]] = cir.cast int_to_bool %[[VAL]]
+// CIR:     %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+// CIR:     %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
+// CIR:     %[[SEL:.*]] = cir.select if %[[BOOL]] then %[[ONE]] else %[[TWO]]
+// CIR:     cir.store %[[SEL]], %{{.*}} : !s32i, !cir.ptr<!s32i>
+// CIR:     cir.yield
+// CIR:   } cleanup all {
+// CIR:     cir.call @_ZN1SD1Ev(%[[TMP]])
+// CIR:     cir.yield
 // CIR:   }
 
 // LLVM-LABEL: define dso_local noundef i32 @_Z31test_false_positive_conditionalb(
 // LLVM-SAME: personality ptr @__gxx_personality_v0
-// LLVM:         %[[TMP:.*]] = alloca %struct.S
 // LLVM:         %[[RETVAL:.*]] = alloca i32
+// LLVM:         %[[TMP:.*]] = alloca %struct.S
 // The constructor is call — no active EH cleanup yet.
 // LLVM:         call void @_ZN1SC1Ev({{.*}} %[[TMP]])
 // get() becomes invoke because the destructor cleanup is active.
@@ -519,52 +515,48 @@ void test_nested_ewc(bool c1, bool c2) {
 
 // CIR-LABEL: @_Z15test_nested_ewcbb
 // CIR:   %[[RESULT:.*]] = cir.alloca !rec_T, !cir.ptr<!rec_T>, ["result", init]
-// CIR:   cir.scope {
-// CIR:     %[[REF_TMP:.*]] = cir.alloca !rec_T, !cir.ptr<!rec_T>, ["ref.tmp0"]
+// CIR:   %[[REF_TMP:.*]] = cir.alloca !rec_T, !cir.ptr<!rec_T>, ["ref.tmp0"]
 // Inner cir.scope for the statement expression.
-// CIR:     cir.scope {
-// CIR:       %[[S:.*]] = cir.alloca !rec_T, !cir.ptr<!rec_T>, ["s", init]
+// CIR:   cir.scope {
+// CIR:     %[[S:.*]] = cir.alloca !rec_T, !cir.ptr<!rec_T>, ["s", init]
 // Inner ternary: c1 ? T(1) : T(2) — no cleanup scope needed.
-// CIR:       cir.scope {
-// CIR:         %[[C1:.*]] = cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
-// CIR:         cir.if %[[C1]] {
-// CIR:           %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
-// CIR:           cir.call @_ZN1TC1Ei(%[[S]], %[[ONE]])
-// CIR:         } else {
-// CIR:           %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
-// CIR:           cir.call @_ZN1TC1Ei(%[[S]], %[[TWO]])
-// CIR:         }
-// CIR:       }
-// Copy s into ref.tmp; destroy s on all paths (normal + EH).
-// CIR:       cir.cleanup.scope {
-// CIR:         cir.call @_ZN1TC1ERKS_(%[[REF_TMP]], %[[S]])
-// CIR:         cir.yield
-// CIR:       } cleanup all {
-// CIR:         cir.call @_ZN1TD1Ev(%[[S]])
-// CIR:         cir.yield
-// CIR:       }
+// CIR:     %[[C1:.*]] = cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:     cir.if %[[C1]] {
+// CIR:       %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+// CIR:       cir.call @_ZN1TC1Ei(%[[S]], %[[ONE]])
+// CIR:     } else {
+// CIR:       %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
+// CIR:       cir.call @_ZN1TC1Ei(%[[S]], %[[TWO]])
 // CIR:     }
-// Outer cleanup scope: operator bool() + outer ternary + destroys ref.tmp.
+// Copy s into ref.tmp; destroy s on all paths (normal + EH).
 // CIR:     cir.cleanup.scope {
-// CIR:       %[[BOOL:.*]] = cir.call @_ZN1TcvbEv(%[[REF_TMP]])
-// CIR:       cir.if %[[BOOL]] {
-// CIR:         %[[C2:.*]] = cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
-// CIR:         cir.if %[[C2]] {
-// CIR:           %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
-// CIR:           cir.call @_ZN1TC1Ei(%[[RESULT]], %[[THREE]])
-// CIR:         } else {
-// CIR:           %[[FOUR:.*]] = cir.const #cir.int<4> : !s32i
-// CIR:           cir.call @_ZN1TC1Ei(%[[RESULT]], %[[FOUR]])
-// CIR:         }
-// CIR:       } else {
-// CIR:         %[[FIVE:.*]] = cir.const #cir.int<5> : !s32i
-// CIR:         cir.call @_ZN1TC1Ei(%[[RESULT]], %[[FIVE]])
-// CIR:       }
+// CIR:       cir.call @_ZN1TC1ERKS_(%[[REF_TMP]], %[[S]])
 // CIR:       cir.yield
 // CIR:     } cleanup all {
-// CIR:       cir.call @_ZN1TD1Ev(%[[REF_TMP]])
+// CIR:       cir.call @_ZN1TD1Ev(%[[S]])
 // CIR:       cir.yield
 // CIR:     }
+// CIR:   }
+// Outer cleanup scope: operator bool() + outer ternary + destroys ref.tmp.
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[BOOL:.*]] = cir.call @_ZN1TcvbEv(%[[REF_TMP]])
+// CIR:     cir.if %[[BOOL]] {
+// CIR:       %[[C2:.*]] = cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:       cir.if %[[C2]] {
+// CIR:         %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
+// CIR:         cir.call @_ZN1TC1Ei(%[[RESULT]], %[[THREE]])
+// CIR:       } else {
+// CIR:         %[[FOUR:.*]] = cir.const #cir.int<4> : !s32i
+// CIR:         cir.call @_ZN1TC1Ei(%[[RESULT]], %[[FOUR]])
+// CIR:       }
+// CIR:     } else {
+// CIR:       %[[FIVE:.*]] = cir.const #cir.int<5> : !s32i
+// CIR:       cir.call @_ZN1TC1Ei(%[[RESULT]], %[[FIVE]])
+// CIR:     }
+// CIR:     cir.yield
+// CIR:   } cleanup all {
+// CIR:     cir.call @_ZN1TD1Ev(%[[REF_TMP]])
+// CIR:     cir.yield
 // CIR:   }
 // result destructor.
 // CIR:   cir.cleanup.scope {

--- a/clang/test/CIR/CodeGen/cleanup-conditional.cpp
+++ b/clang/test/CIR/CodeGen/cleanup-conditional.cpp
@@ -238,42 +238,40 @@ int test_return_ternary(bool c) {
 // CIR:   %[[ACTA:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.cond"]
 // CIR:   %[[TMPB:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp1"]
 // CIR:   %[[ACTB:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.cond"]
-// CIR:   cir.scope {
-// CIR:     cir.cleanup.scope {
-// CIR:       %[[COND:.*]] = cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
-// CIR:       %[[FALSE_A:.*]] = cir.const #false
-// CIR:       cir.store %[[FALSE_A]], %[[ACTA]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:       %[[FALSE_B:.*]] = cir.const #false
-// CIR:       cir.store %[[FALSE_B]], %[[ACTB]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:       %{{.*}} = cir.ternary(%[[COND]], true {
-// CIR:         cir.call @_ZN1AC1Ev(%[[TMPA]])
-// CIR:         %[[TRUE_A:.*]] = cir.const #true
-// CIR:         cir.store %[[TRUE_A]], %[[ACTA]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:         %[[GET_A:.*]] = cir.call @_ZN1A3getEv(%[[TMPA]])
-// CIR:         cir.yield %[[GET_A]] : !s32i
-// CIR:       }, false {
-// CIR:         cir.call @_ZN1BC1Ev(%[[TMPB]])
-// CIR:         %[[TRUE_B:.*]] = cir.const #true
-// CIR:         cir.store %[[TRUE_B]], %[[ACTB]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:         %[[GET_B:.*]] = cir.call @_ZN1B3getEv(%[[TMPB]])
-// CIR:         cir.yield %[[GET_B]] : !s32i
-// CIR:       })
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[COND:.*]] = cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:     %[[FALSE_A:.*]] = cir.const #false
+// CIR:     cir.store %[[FALSE_A]], %[[ACTA]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:     %[[FALSE_B:.*]] = cir.const #false
+// CIR:     cir.store %[[FALSE_B]], %[[ACTB]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:     %{{.*}} = cir.ternary(%[[COND]], true {
+// CIR:       cir.call @_ZN1AC1Ev(%[[TMPA]])
+// CIR:       %[[TRUE_A:.*]] = cir.const #true
+// CIR:       cir.store %[[TRUE_A]], %[[ACTA]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:       %[[GET_A:.*]] = cir.call @_ZN1A3getEv(%[[TMPA]])
+// CIR:       cir.yield %[[GET_A]] : !s32i
+// CIR:     }, false {
+// CIR:       cir.call @_ZN1BC1Ev(%[[TMPB]])
+// CIR:       %[[TRUE_B:.*]] = cir.const #true
+// CIR:       cir.store %[[TRUE_B]], %[[ACTB]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:       %[[GET_B:.*]] = cir.call @_ZN1B3getEv(%[[TMPB]])
+// CIR:       cir.yield %[[GET_B]] : !s32i
+// CIR:     })
 // The result is stored to __retval inside the cleanup scope body.
-// CIR:       cir.store %{{.*}}, %{{.*}} : !s32i, !cir.ptr<!s32i>
-// CIR:       cir.yield
-// CIR:     } cleanup normal {
-// CIR:       %[[FLAG_B:.*]] = cir.load {{.*}} %[[ACTB]]
-// CIR:       cir.if %[[FLAG_B]] {
-// CIR:         cir.call @_ZN1BD1Ev(%[[TMPB]])
-// CIR:       }
-// CIR:       %[[FLAG_A:.*]] = cir.load {{.*}} %[[ACTA]]
-// CIR:       cir.if %[[FLAG_A]] {
-// CIR:         cir.call @_ZN1AD1Ev(%[[TMPA]])
-// CIR:       }
-// CIR:       cir.yield
+// CIR:     cir.store %{{.*}}, %{{.*}} : !s32i, !cir.ptr<!s32i>
+// CIR:     cir.yield
+// CIR:   } cleanup normal {
+// CIR:     %[[FLAG_B:.*]] = cir.load {{.*}} %[[ACTB]]
+// CIR:     cir.if %[[FLAG_B]] {
+// CIR:       cir.call @_ZN1BD1Ev(%[[TMPB]])
 // CIR:     }
+// CIR:     %[[FLAG_A:.*]] = cir.load {{.*}} %[[ACTA]]
+// CIR:     cir.if %[[FLAG_A]] {
+// CIR:       cir.call @_ZN1AD1Ev(%[[TMPA]])
+// CIR:     }
+// CIR:     cir.yield
 // CIR:   }
-// Value loaded from __retval after the scope and returned.
+// Value loaded from __retval and returned.
 // CIR:   %[[RET:.*]] = cir.load %{{.*}} : !cir.ptr<!s32i>, !s32i
 // CIR:   cir.return %[[RET]] : !s32i
 
@@ -284,8 +282,6 @@ int test_return_ternary(bool c) {
 // LLVM:         %[[ACTA:.*]] = alloca i8
 // LLVM:         %[[TMPB:.*]] = alloca %struct.B
 // LLVM:         %[[ACTB:.*]] = alloca i8
-// LLVM:         br label %[[SCOPE:.*]]
-// LLVM:       [[SCOPE]]:
 // LLVM:         br label %[[INIT:.*]]
 // LLVM:       [[INIT]]:
 // LLVM:         %[[COND_BYTE:.*]] = load i8, ptr %{{.*}}
@@ -370,31 +366,27 @@ int test_false_positive_conditional(bool c) {
 }
 // No cleanup.cond alloca — the destructor is unconditional.
 // CIR-NOT:   cir.alloca {{.*}} ["cleanup.cond"]
-// CIR:   cir.scope {
-// CIR:     %[[TMP:.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["ref.tmp0"]
-// CIR:     cir.call @_ZN1SC1Ev(%[[TMP]])
-// The LexicalScope's cleanup scope wraps the get() + select + store.
-// CIR:     cir.cleanup.scope {
-// CIR:       %[[VAL:.*]] = cir.call @_ZN1S3getEv(%[[TMP]])
-// CIR:       %[[BOOL:.*]] = cir.cast int_to_bool %[[VAL]]
+// CIR:   %[[TMP:.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["ref.tmp0"]
+// CIR:   cir.call @_ZN1SC1Ev(%[[TMP]])
+// The cleanup scope wraps the get() + select + store.
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[VAL:.*]] = cir.call @_ZN1S3getEv(%[[TMP]])
+// CIR:     %[[BOOL:.*]] = cir.cast int_to_bool %[[VAL]]
 // No cir.ternary — both arms are constants, so this lowers to cir.select.
-// CIR:       %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
-// CIR:       %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
-// CIR:       %[[SEL:.*]] = cir.select if %[[BOOL]] then %[[ONE]] else %[[TWO]]
-// CIR:       cir.store %[[SEL]], %{{.*}} : !s32i, !cir.ptr<!s32i>
-// CIR:       cir.yield
+// CIR:     %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+// CIR:     %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
+// CIR:     %[[SEL:.*]] = cir.select if %[[BOOL]] then %[[ONE]] else %[[TWO]]
+// CIR:     cir.store %[[SEL]], %{{.*}} : !s32i, !cir.ptr<!s32i>
+// CIR:     cir.yield
 // S destructor runs unconditionally — no active-flag guard.
-// CIR:     } cleanup normal {
-// CIR:       cir.call @_ZN1SD1Ev(%[[TMP]])
-// CIR:       cir.yield
-// CIR:     }
+// CIR:   } cleanup normal {
+// CIR:     cir.call @_ZN1SD1Ev(%[[TMP]])
+// CIR:     cir.yield
 // CIR:   }
 
 // LLVM-LABEL: define dso_local noundef i32 @_Z31test_false_positive_conditionalb(
-// LLVM:         %[[TMP:.*]] = alloca %struct.S
 // LLVM:         %[[RETVAL:.*]] = alloca i32
-// LLVM:         br label %[[SCOPE:.*]]
-// LLVM:       [[SCOPE]]:
+// LLVM:         %[[TMP:.*]] = alloca %struct.S
 // LLVM:         call void @_ZN1SC1Ev({{.*}} %[[TMP]])
 // LLVM:         br label %[[BODY:.*]]
 // LLVM:       [[BODY]]:
@@ -444,53 +436,48 @@ void test_nested_ewc(bool c1, bool c2) {
 
 // CIR-LABEL: @_Z15test_nested_ewcbb
 // CIR:   %[[RESULT:.*]] = cir.alloca !rec_T, !cir.ptr<!rec_T>, ["result", init]
-// Outer cir.scope wraps the entire expression including the statement expr.
+// CIR:   %[[REF_TMP:.*]] = cir.alloca !rec_T, !cir.ptr<!rec_T>, ["ref.tmp0"]
+// cir.scope for the statement expression.
 // CIR:   cir.scope {
-// CIR:     %[[REF_TMP:.*]] = cir.alloca !rec_T, !cir.ptr<!rec_T>, ["ref.tmp0"]
-// Inner cir.scope for the statement expression.
-// CIR:     cir.scope {
-// CIR:       %[[S:.*]] = cir.alloca !rec_T, !cir.ptr<!rec_T>, ["s", init]
+// CIR:     %[[S:.*]] = cir.alloca !rec_T, !cir.ptr<!rec_T>, ["s", init]
 // Inner ternary: c1 ? T(1) : T(2) — no cleanup scope needed (no deferred dtors).
-// CIR:       cir.scope {
-// CIR:         %[[C1:.*]] = cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
-// CIR:         cir.if %[[C1]] {
-// CIR:           %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
-// CIR:           cir.call @_ZN1TC1Ei(%[[S]], %[[ONE]])
-// CIR:         } else {
-// CIR:           %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
-// CIR:           cir.call @_ZN1TC1Ei(%[[S]], %[[TWO]])
-// CIR:         }
-// CIR:       }
-// Statement expression result: copy s into ref.tmp, then destroy s.
-// CIR:       cir.cleanup.scope {
-// CIR:         cir.call @_ZN1TC1ERKS_(%[[REF_TMP]], %[[S]])
-// CIR:         cir.yield
-// CIR:       } cleanup normal {
-// CIR:         cir.call @_ZN1TD1Ev(%[[S]])
-// CIR:         cir.yield
-// CIR:       }
+// CIR:     %[[C1:.*]] = cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:     cir.if %[[C1]] {
+// CIR:       %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+// CIR:       cir.call @_ZN1TC1Ei(%[[S]], %[[ONE]])
+// CIR:     } else {
+// CIR:       %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
+// CIR:       cir.call @_ZN1TC1Ei(%[[S]], %[[TWO]])
 // CIR:     }
-// Outer cleanup scope: wraps operator bool() + outer ternary + destroys ref.tmp.
+// Statement expression result: copy s into ref.tmp, then destroy s.
 // CIR:     cir.cleanup.scope {
-// CIR:       %[[BOOL:.*]] = cir.call @_ZN1TcvbEv(%[[REF_TMP]])
-// CIR:       cir.if %[[BOOL]] {
-// CIR:         %[[C2:.*]] = cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
-// CIR:         cir.if %[[C2]] {
-// CIR:           %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
-// CIR:           cir.call @_ZN1TC1Ei(%[[RESULT]], %[[THREE]])
-// CIR:         } else {
-// CIR:           %[[FOUR:.*]] = cir.const #cir.int<4> : !s32i
-// CIR:           cir.call @_ZN1TC1Ei(%[[RESULT]], %[[FOUR]])
-// CIR:         }
-// CIR:       } else {
-// CIR:         %[[FIVE:.*]] = cir.const #cir.int<5> : !s32i
-// CIR:         cir.call @_ZN1TC1Ei(%[[RESULT]], %[[FIVE]])
-// CIR:       }
+// CIR:       cir.call @_ZN1TC1ERKS_(%[[REF_TMP]], %[[S]])
 // CIR:       cir.yield
 // CIR:     } cleanup normal {
-// CIR:       cir.call @_ZN1TD1Ev(%[[REF_TMP]])
+// CIR:       cir.call @_ZN1TD1Ev(%[[S]])
 // CIR:       cir.yield
 // CIR:     }
+// CIR:   }
+// Cleanup scope: wraps operator bool() + outer ternary + destroys ref.tmp.
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[BOOL:.*]] = cir.call @_ZN1TcvbEv(%[[REF_TMP]])
+// CIR:     cir.if %[[BOOL]] {
+// CIR:       %[[C2:.*]] = cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:       cir.if %[[C2]] {
+// CIR:         %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
+// CIR:         cir.call @_ZN1TC1Ei(%[[RESULT]], %[[THREE]])
+// CIR:       } else {
+// CIR:         %[[FOUR:.*]] = cir.const #cir.int<4> : !s32i
+// CIR:         cir.call @_ZN1TC1Ei(%[[RESULT]], %[[FOUR]])
+// CIR:       }
+// CIR:     } else {
+// CIR:       %[[FIVE:.*]] = cir.const #cir.int<5> : !s32i
+// CIR:       cir.call @_ZN1TC1Ei(%[[RESULT]], %[[FIVE]])
+// CIR:     }
+// CIR:     cir.yield
+// CIR:   } cleanup normal {
+// CIR:     cir.call @_ZN1TD1Ev(%[[REF_TMP]])
+// CIR:     cir.yield
 // CIR:   }
 // result destructor runs unconditionally after the outer scope.
 // CIR:   cir.cleanup.scope {

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -483,20 +483,17 @@ folly::coro::Task<int> go1() {
 
 // CIR: cir.func coroutine {{.*}} @_Z3go1v() {{.*}} ![[IntTask]]
 // CIR: %[[IntTaskAddr:.*]] = cir.alloca ![[IntTask]], !cir.ptr<![[IntTask]]>, ["task", init]
+// CIR: %[[OneAddr:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["ref.tmp1", init] {alignment = 4 : i64}
 
 // CIR: cir.await(init, ready : {
 // CIR: }, suspend : {
 // CIR: }, resume : {
 // CIR: },)
 
-// The call to go(1) has its own scope due to full-expression rules.
-// CIR: cir.scope {
-// CIR:   %[[OneAddr:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["ref.tmp1", init] {alignment = 4 : i64}
-// CIR:   %[[One:.*]] = cir.const #cir.int<1> : !s32i
-// CIR:   cir.store{{.*}} %[[One]], %[[OneAddr]] : !s32i, !cir.ptr<!s32i>
-// CIR:   %[[IntTaskTmp:.*]] = cir.call @_Z2goRKi(%[[OneAddr]]) : (!cir.ptr<!s32i>{{.*}}) -> ![[IntTask]]
-// CIR:   cir.store{{.*}} %[[IntTaskTmp]], %[[IntTaskAddr]] : ![[IntTask]], !cir.ptr<![[IntTask]]>
-// CIR: }
+// CIR: %[[One:.*]] = cir.const #cir.int<1> : !s32i
+// CIR: cir.store{{.*}} %[[One]], %[[OneAddr]] : !s32i, !cir.ptr<!s32i>
+// CIR: %[[IntTaskTmp:.*]] = cir.call @_Z2goRKi(%[[OneAddr]]) : (!cir.ptr<!s32i>{{.*}}) -> ![[IntTask]]
+// CIR: cir.store{{.*}} %[[IntTaskTmp]], %[[IntTaskAddr]] : ![[IntTask]], !cir.ptr<![[IntTask]]>
 
 // CIR: cir.await(user, ready : {
 // CIR: }, suspend : {
@@ -569,16 +566,13 @@ folly::coro::Task<int> go4() {
 // Get the lambda invoker ptr via `lambda operator folly::coro::Task<int> (*)(int const&)()`
 // CIR: %[[INVOKER:.*]] = cir.call @_ZZ3go4vENK3$_0cvPFN5folly4coro4TaskIiEERKiEEv(%{{.*}}) nothrow : {{.*}} -> (!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>> {llvm.noundef})
 // CIR: cir.store{{.*}} %[[INVOKER]], %[[FN_ADDR:.*]] : !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>, !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>>
-// CIR: cir.scope {
-// CIR:   %[[ARG:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["ref.tmp2", init] {alignment = 4 : i64}
-// CIR:   %[[FN:.*]] = cir.load{{.*}} %[[FN_ADDR]] : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>>, !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>
-// CIR:   %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
-// CIR:   cir.store{{.*}} %[[THREE]], %[[ARG]] : !s32i, !cir.ptr<!s32i>
+// CIR: %[[FN:.*]] = cir.load{{.*}} %[[FN_ADDR]] : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>>, !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>
+// CIR: %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
+// CIR: cir.store{{.*}} %[[THREE]], %[[ARG:.*]] : !s32i, !cir.ptr<!s32i>
 
 // Call invoker, which calls operator() indirectly.
-// CIR:   %[[CALLRES:.*]] = cir.call %[[FN]](%[[ARG]]) : (!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>, !cir.ptr<!s32i> {{.*}}) -> ![[IntTask]]
-// CIR:   cir.store{{.*}} %[[CALLRES]], %[[TASK_ADDR:.*]] : ![[IntTask]], !cir.ptr<![[IntTask]]>
-// CIR: }
+// CIR: %[[CALLRES:.*]] = cir.call %[[FN]](%[[ARG]]) : (!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>, !cir.ptr<!s32i> {{.*}}) -> ![[IntTask]]
+// CIR: cir.store{{.*}} %[[CALLRES]], %[[TASK_ADDR:.*]] : ![[IntTask]], !cir.ptr<![[IntTask]]>
 
 // CIR: cir.await(user, ready : {
 // CIR:   = cir.call @_ZN5folly4coro4TaskIiE11await_readyEv(%[[TASK_ADDR]])

--- a/clang/test/CIR/CodeGen/dtors.cpp
+++ b/clang/test/CIR/CodeGen/dtors.cpp
@@ -36,48 +36,44 @@ bool test_temp_or() { return make_temp(1) || make_temp(2); }
 
 // CIR: cir.func{{.*}} @_Z12test_temp_orv()
 // CIR:   %[[RET_ADDR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["__retval"]
-// CIR:   cir.scope {
-// CIR:     %[[REF_TMP0:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp0"]
-// CIR:     %[[ONE:.*]] = cir.const #cir.int<1>
-// CIR:     cir.call @_ZN1BC2Ei(%[[REF_TMP0]], %[[ONE]])
-// CIR:     cir.cleanup.scope {
-// CIR:       %[[MAKE_TEMP0:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP0]])
-// CIR:       %[[TERNARY:.*]] = cir.ternary(%[[MAKE_TEMP0]], true {
-// CIR:         %[[TRUE:.*]] = cir.const #true
-// CIR:         cir.yield %[[TRUE]] : !cir.bool
-// CIR:       }, false {
-// CIR:         %[[REF_TMP1:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp1"]
-// CIR:         %[[CLEANUP_TMP:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["tmp.exprcleanup"]
-// CIR:         %[[TWO:.*]] = cir.const #cir.int<2>
-// CIR:         cir.call @_ZN1BC2Ei(%[[REF_TMP1]], %[[TWO]])
-// CIR:         cir.cleanup.scope {
-// CIR:           %[[MAKE_TEMP1:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP1]]) : (!cir.ptr<!rec_B>
-// CIR:           cir.store{{.*}} %[[MAKE_TEMP1]], %[[CLEANUP_TMP]]
-// CIR:           cir.yield
-// CIR:         } cleanup  normal {
-// CIR:           cir.call @_ZN1BD2Ev(%[[REF_TMP1]])
-// CIR:           cir.yield
-// CIR:         }
-// CIR:         %[[TERNARY_TMP:.*]] = cir.load{{.*}} %[[CLEANUP_TMP]]
-// CIR:         cir.yield %[[TERNARY_TMP]] : !cir.bool
-// CIR:       })
-// CIR:       cir.store{{.*}} %[[TERNARY]], %[[RET_ADDR]]
-// CIR:       cir.yield
-// CIR:     } cleanup  normal {
-// CIR:       cir.call @_ZN1BD2Ev(%[[REF_TMP0]])
-// CIR:       cir.yield
-// CIR:     }
+// CIR:   %[[REF_TMP0:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp0"]
+// CIR:   %[[ONE:.*]] = cir.const #cir.int<1>
+// CIR:   cir.call @_ZN1BC2Ei(%[[REF_TMP0]], %[[ONE]])
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[MAKE_TEMP0:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP0]])
+// CIR:     %[[TERNARY:.*]] = cir.ternary(%[[MAKE_TEMP0]], true {
+// CIR:       %[[TRUE:.*]] = cir.const #true
+// CIR:       cir.yield %[[TRUE]] : !cir.bool
+// CIR:     }, false {
+// CIR:       %[[REF_TMP1:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp1"]
+// CIR:       %[[CLEANUP_TMP:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["tmp.exprcleanup"]
+// CIR:       %[[TWO:.*]] = cir.const #cir.int<2>
+// CIR:       cir.call @_ZN1BC2Ei(%[[REF_TMP1]], %[[TWO]])
+// CIR:       cir.cleanup.scope {
+// CIR:         %[[MAKE_TEMP1:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP1]]) : (!cir.ptr<!rec_B>
+// CIR:         cir.store{{.*}} %[[MAKE_TEMP1]], %[[CLEANUP_TMP]]
+// CIR:         cir.yield
+// CIR:       } cleanup normal {
+// CIR:         cir.call @_ZN1BD2Ev(%[[REF_TMP1]])
+// CIR:         cir.yield
+// CIR:       }
+// CIR:       %[[TERNARY_TMP:.*]] = cir.load{{.*}} %[[CLEANUP_TMP]]
+// CIR:       cir.yield %[[TERNARY_TMP]] : !cir.bool
+// CIR:     })
+// CIR:     cir.store{{.*}} %[[TERNARY]], %[[RET_ADDR]]
+// CIR:     cir.yield
+// CIR:   } cleanup normal {
+// CIR:     cir.call @_ZN1BD2Ev(%[[REF_TMP0]])
+// CIR:     cir.yield
 // CIR:   }
 // CIR:   %[[RETVAL:.*]] = cir.load{{.*}} %[[RET_ADDR]]
 // CIR:   cir.return %[[RETVAL]]
 
 // LLVM: define{{.*}} i1 @_Z12test_temp_orv(){{.*}} {
-// LLVM:   %[[REF_TMP0:.*]] = alloca %struct.B
 // LLVM:   %[[REF_TMP1:.*]] = alloca %struct.B
 // LLVM:   %[[TMP_RESULT1:.*]] = alloca i8
 // LLVM:   %[[TMP_RESULT2:.*]] = alloca i8
-// LLVM:   br label %[[LOR_BEGIN:.*]]
-// LLVM: [[LOR_BEGIN]]:
+// LLVM:   %[[REF_TMP0:.*]] = alloca %struct.B
 // LLVM:   call void @_ZN1BC2Ei(ptr {{.*}} %[[REF_TMP0]], i32 {{.*}} 1)
 // LLVM:   br label %[[SCOPE_BEGIN:.*]]
 // LLVM: [[SCOPE_BEGIN]]:
@@ -142,48 +138,44 @@ bool test_temp_and() { return make_temp(1) && make_temp(2); }
 
 // CIR: cir.func{{.*}} @_Z13test_temp_andv()
 // CIR:   %[[RET_ADDR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["__retval"]
-// CIR:   cir.scope {
-// CIR:     %[[REF_TMP0:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp0"]
-// CIR:     %[[ONE:.*]] = cir.const #cir.int<1>
-// CIR:     cir.call @_ZN1BC2Ei(%[[REF_TMP0]], %[[ONE]])
-// CIR:     cir.cleanup.scope {
-// CIR:       %[[MAKE_TEMP0:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP0]])
-// CIR:       %[[TERNARY:.*]] = cir.ternary(%[[MAKE_TEMP0]], true {
-// CIR:         %[[REF_TMP1:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp1"]
-// CIR:         %[[CLEANUP_TMP:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["tmp.exprcleanup"]
-// CIR:         %[[TWO:.*]] = cir.const #cir.int<2>
-// CIR:         cir.call @_ZN1BC2Ei(%[[REF_TMP1]], %[[TWO]])
-// CIR:         cir.cleanup.scope {
-// CIR:           %[[MAKE_TEMP1:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP1]]) : (!cir.ptr<!rec_B>
-// CIR:           cir.store{{.*}} %[[MAKE_TEMP1]], %[[CLEANUP_TMP]]
-// CIR:           cir.yield
-// CIR:         } cleanup  normal {
-// CIR:           cir.call @_ZN1BD2Ev(%[[REF_TMP1]])
-// CIR:           cir.yield
-// CIR:         }
-// CIR:         %[[TERNARY_TMP:.*]] = cir.load{{.*}} %[[CLEANUP_TMP]]
-// CIR:         cir.yield %[[TERNARY_TMP]] : !cir.bool
-// CIR:       }, false {
-// CIR:         %[[FALSE:.*]] = cir.const #false
-// CIR:         cir.yield %[[FALSE]] : !cir.bool
-// CIR:       })
-// CIR:       cir.store{{.*}} %[[TERNARY]], %[[RET_ADDR]]
-// CIR:       cir.yield
-// CIR:     } cleanup  normal {
-// CIR:       cir.call @_ZN1BD2Ev(%[[REF_TMP0]])
-// CIR:       cir.yield
-// CIR:     }
+// CIR:   %[[REF_TMP0:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp0"]
+// CIR:   %[[ONE:.*]] = cir.const #cir.int<1>
+// CIR:   cir.call @_ZN1BC2Ei(%[[REF_TMP0]], %[[ONE]])
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[MAKE_TEMP0:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP0]])
+// CIR:     %[[TERNARY:.*]] = cir.ternary(%[[MAKE_TEMP0]], true {
+// CIR:       %[[REF_TMP1:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp1"]
+// CIR:       %[[CLEANUP_TMP:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["tmp.exprcleanup"]
+// CIR:       %[[TWO:.*]] = cir.const #cir.int<2>
+// CIR:       cir.call @_ZN1BC2Ei(%[[REF_TMP1]], %[[TWO]])
+// CIR:       cir.cleanup.scope {
+// CIR:         %[[MAKE_TEMP1:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP1]]) : (!cir.ptr<!rec_B>
+// CIR:         cir.store{{.*}} %[[MAKE_TEMP1]], %[[CLEANUP_TMP]]
+// CIR:         cir.yield
+// CIR:       } cleanup normal {
+// CIR:         cir.call @_ZN1BD2Ev(%[[REF_TMP1]])
+// CIR:         cir.yield
+// CIR:       }
+// CIR:       %[[TERNARY_TMP:.*]] = cir.load{{.*}} %[[CLEANUP_TMP]]
+// CIR:       cir.yield %[[TERNARY_TMP]] : !cir.bool
+// CIR:     }, false {
+// CIR:       %[[FALSE:.*]] = cir.const #false
+// CIR:       cir.yield %[[FALSE]] : !cir.bool
+// CIR:     })
+// CIR:     cir.store{{.*}} %[[TERNARY]], %[[RET_ADDR]]
+// CIR:     cir.yield
+// CIR:   } cleanup normal {
+// CIR:     cir.call @_ZN1BD2Ev(%[[REF_TMP0]])
+// CIR:     cir.yield
 // CIR:   }
 // CIR:   %[[RETVAL:.*]] = cir.load{{.*}} %[[RET_ADDR]]
 // CIR:   cir.return %[[RETVAL]]
 
 // LLVM: define{{.*}} i1 @_Z13test_temp_andv(){{.*}} {
-// LLVM:   %[[REF_TMP0:.*]] = alloca %struct.B{{.*}}
 // LLVM:   %[[REF_TMP1:.*]] = alloca %struct.B{{.*}}
 // LLVM:   %[[TMP_RESULT:.*]] = alloca i8{{.*}}
 // LLVM:   %[[TMP_RESULT2:.*]] = alloca i8{{.*}}
-// LLVM:   br label %[[LAND_BEGIN:.*]]
-// LLVM: [[LAND_BEGIN]]:
+// LLVM:   %[[REF_TMP0:.*]] = alloca %struct.B{{.*}}
 // LLVM:   call void @_ZN1BC2Ei(ptr {{.*}} %[[REF_TMP0]], i32 {{.*}} 1)
 // LLVM:   br label %[[SCOPE_BEGIN:.*]]
 // LLVM: [[SCOPE_BEGIN]]:
@@ -219,8 +211,6 @@ bool test_temp_and() { return make_temp(1) && make_temp(2); }
 // LLVM:   call void @_ZN1BD2Ev(ptr {{.*}} %[[REF_TMP0]])
 // LLVM:   br label %[[LAND_END2:.*]]
 // LLVM: [[LAND_END2]]:
-// LLVM:   br label %[[LAND_END3:.*]]
-// LLVM: [[LAND_END3]]:
 // LLVM:   br label %[[RETURN_BLOCK:.*]]
 // LLVM: [[RETURN_BLOCK]]:
 // LLVM:   %[[TMP2_LOAD:.*]] = load i8, ptr %[[TMP_RESULT2]], align 1
@@ -361,12 +351,12 @@ int test_temp_in_condition(G &obj) {
 // CIR:         %[[EQUAL:.*]] = cir.call @_ZNK1GeqERKS_(%[[REF_TMP0]], %[[REF_TMP1]]) : (!cir.ptr<!rec_G> {{.*}}, !cir.ptr<!rec_G> {{.*}}) -> (!cir.bool {{.*}})
 // CIR:         cir.store{{.*}} %[[EQUAL]], %[[CLEANUP_TMP]]
 // CIR:         cir.yield
-// CIR:       } cleanup  normal {
+// CIR:       } cleanup normal {
 // CIR:         cir.call @_ZN1GD1Ev(%[[REF_TMP1]]) nothrow : (!cir.ptr<!rec_G> {{.*}}) -> ()
 // CIR:         cir.yield
 // CIR:       }
 // CIR:       cir.yield
-// CIR:     } cleanup  normal {
+// CIR:     } cleanup normal {
 // CIR:       cir.call @_ZN1GD1Ev(%[[REF_TMP0]]) nothrow : (!cir.ptr<!rec_G> {{.*}}) -> ()
 // CIR:       cir.yield
 // CIR:     }

--- a/clang/test/CIR/CodeGen/initializer-list-two-pointers.cpp
+++ b/clang/test/CIR/CodeGen/initializer-list-two-pointers.cpp
@@ -18,46 +18,40 @@ void initalizer_list_with_two_pointers_layout() {
 
 // CIR: %[[ARR_ADDR:.*]] = cir.alloca !cir.array<!s32i x 3>, !cir.ptr<!cir.array<!s32i x 3>>, ["ref.tmp0"]
 // CIR: %[[A_ADDR:.*]] = cir.alloca !rec_std3A3Ainitializer_list3Cint3E, !cir.ptr<!rec_std3A3Ainitializer_list3Cint3E>, ["a", init]
-// CIR: cir.scope {
-// CIR:   %[[ARR_PTR:.*]] = cir.cast array_to_ptrdecay %[[ARR_ADDR]] : !cir.ptr<!cir.array<!s32i x 3>> -> !cir.ptr<!s32i>
-// CIR:   %[[CONST_S32_10:.*]] = cir.const #cir.int<10> : !s32i
-// CIR:   cir.store {{.*}} %[[CONST_S32_10]], %[[ARR_PTR]] : !s32i, !cir.ptr<!s32i>
-// CIR:   %[[CONST_S64_1:.*]] = cir.const #cir.int<1> : !s64i
-// CIR:   %[[ARR_ELEM_1_PTR:.*]] = cir.ptr_stride %[[ARR_PTR]], %[[CONST_S64_1]] : (!cir.ptr<!s32i>, !s64i) -> !cir.ptr<!s32i>
-// CIR:   %[[CONST_S32_20:.*]] = cir.const #cir.int<20> : !s32i
-// CIR:   cir.store {{.*}} %[[CONST_S32_20]], %[[ARR_ELEM_1_PTR]] : !s32i, !cir.ptr<!s32i>
-// CIR:   %[[CONST_S64_2:.*]] = cir.const #cir.int<2> : !s64i
-// CIR:   %[[ARR_ELEM_2_PTR:.*]] = cir.ptr_stride %[[ARR_PTR]], %[[CONST_S64_2]] : (!cir.ptr<!s32i>, !s64i) -> !cir.ptr<!s32i>
-// CIR:   %[[CONST_S32_30:.*]] = cir.const #cir.int<30> : !s32i
-// CIR:   cir.store {{.*}} %[[CONST_S32_30]], %[[ARR_ELEM_2_PTR]] : !s32i, !cir.ptr<!s32i>
-// CIR:   %[[BEGIN_PTR:.*]] = cir.get_member %[[A_ADDR]][0] {name = "__begin_"} : !cir.ptr<!rec_std3A3Ainitializer_list3Cint3E> -> !cir.ptr<!cir.ptr<!s32i>
-// CIR:   %[[ARR_BEGIN_PTR:.*]] = cir.cast bitcast %[[BEGIN_PTR]] : !cir.ptr<!cir.ptr<!s32i>> -> !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
-// CIR:   cir.store {{.*}} %[[ARR_ADDR]], %[[ARR_BEGIN_PTR]] : !cir.ptr<!cir.array<!s32i x 3>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
-// CIR:   %[[CONST_U64_3:.*]] = cir.const #cir.int<3> : !u64i
-// CIR:   %[[END_PTR:.*]] = cir.get_member %[[A_ADDR]][1] {name = "__end_"} : !cir.ptr<!rec_std3A3Ainitializer_list3Cint3E> -> !cir.ptr<!cir.ptr<!s32i>>
-// CIR:   %[[ARR_END:.*]] = cir.ptr_stride %[[ARR_ADDR]], %[[CONST_U64_3]] : (!cir.ptr<!cir.array<!s32i x 3>>, !u64i) -> !cir.ptr<!cir.array<!s32i x 3>>
-// CIR:   %[[ARR_END_PTR:.*]] = cir.cast bitcast %[[END_PTR]] : !cir.ptr<!cir.ptr<!s32i>> -> !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
-// CIR:   cir.store {{.*}} %[[ARR_END]], %[[ARR_END_PTR]] : !cir.ptr<!cir.array<!s32i x 3>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
-// CIR: }
+// CIR: %[[ARR_PTR:.*]] = cir.cast array_to_ptrdecay %[[ARR_ADDR]] : !cir.ptr<!cir.array<!s32i x 3>> -> !cir.ptr<!s32i>
+// CIR: %[[CONST_S32_10:.*]] = cir.const #cir.int<10> : !s32i
+// CIR: cir.store {{.*}} %[[CONST_S32_10]], %[[ARR_PTR]] : !s32i, !cir.ptr<!s32i>
+// CIR: %[[CONST_S64_1:.*]] = cir.const #cir.int<1> : !s64i
+// CIR: %[[ARR_ELEM_1_PTR:.*]] = cir.ptr_stride %[[ARR_PTR]], %[[CONST_S64_1]] : (!cir.ptr<!s32i>, !s64i) -> !cir.ptr<!s32i>
+// CIR: %[[CONST_S32_20:.*]] = cir.const #cir.int<20> : !s32i
+// CIR: cir.store {{.*}} %[[CONST_S32_20]], %[[ARR_ELEM_1_PTR]] : !s32i, !cir.ptr<!s32i>
+// CIR: %[[CONST_S64_2:.*]] = cir.const #cir.int<2> : !s64i
+// CIR: %[[ARR_ELEM_2_PTR:.*]] = cir.ptr_stride %[[ARR_PTR]], %[[CONST_S64_2]] : (!cir.ptr<!s32i>, !s64i) -> !cir.ptr<!s32i>
+// CIR: %[[CONST_S32_30:.*]] = cir.const #cir.int<30> : !s32i
+// CIR: cir.store {{.*}} %[[CONST_S32_30]], %[[ARR_ELEM_2_PTR]] : !s32i, !cir.ptr<!s32i>
+// CIR: %[[BEGIN_PTR:.*]] = cir.get_member %[[A_ADDR]][0] {name = "__begin_"} : !cir.ptr<!rec_std3A3Ainitializer_list3Cint3E> -> !cir.ptr<!cir.ptr<!s32i>
+// CIR: %[[ARR_BEGIN_PTR:.*]] = cir.cast bitcast %[[BEGIN_PTR]] : !cir.ptr<!cir.ptr<!s32i>> -> !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
+// CIR: cir.store {{.*}} %[[ARR_ADDR]], %[[ARR_BEGIN_PTR]] : !cir.ptr<!cir.array<!s32i x 3>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
+// CIR: %[[CONST_U64_3:.*]] = cir.const #cir.int<3> : !u64i
+// CIR: %[[END_PTR:.*]] = cir.get_member %[[A_ADDR]][1] {name = "__end_"} : !cir.ptr<!rec_std3A3Ainitializer_list3Cint3E> -> !cir.ptr<!cir.ptr<!s32i>>
+// CIR: %[[ARR_END:.*]] = cir.ptr_stride %[[ARR_ADDR]], %[[CONST_U64_3]] : (!cir.ptr<!cir.array<!s32i x 3>>, !u64i) -> !cir.ptr<!cir.array<!s32i x 3>>
+// CIR: %[[ARR_END_PTR:.*]] = cir.cast bitcast %[[END_PTR]] : !cir.ptr<!cir.ptr<!s32i>> -> !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
+// CIR: cir.store {{.*}} %[[ARR_END]], %[[ARR_END_PTR]] : !cir.ptr<!cir.array<!s32i x 3>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
 
-// LLVM:   %[[ARR_ADDR:.*]] = alloca [3 x i32], i64 1, align 4
-// LLVM:   %[[A_ADDR:.*]] = alloca %"class.std::initializer_list<int>", i64 1, align 8
-// LLVM:   br label %[[SCOPE_BEGIN:.*]]
-// LLVM: [[SCOPE_BEGIN]]:
-// LLVM:   %[[ARR_ELEM_0_PTR:.*]] = getelementptr i32, ptr %[[ARR_ADDR]], i32 0
-// LLVM:   store i32 10, ptr %[[ARR_ELEM_0_PTR]], align 4
-// LLVM:   %[[ARR_ELEM_1_PTR:.*]] = getelementptr i32, ptr %[[ARR_ELEM_0_PTR]], i64 1
-// LLVM:   store i32 20, ptr %[[ARR_ELEM_1_PTR]], align 4
-// LLVM:   %[[ARR_ELEM_2_PTR:.*]] = getelementptr i32, ptr %[[ARR_ELEM_0_PTR]], i64 2
-// LLVM:   store i32 30, ptr %[[ARR_ELEM_2_PTR]], align 4
-// LLVM:   %[[BEGIN_PTR:.*]] = getelementptr %"class.std::initializer_list<int>", ptr %[[A_ADDR]], i32 0, i32 0
-// LLVM:   store ptr %[[ARR_ADDR]], ptr %[[BEGIN_PTR]], align 8
-// LLVM:   %[[END_PTR:.*]] = getelementptr %"class.std::initializer_list<int>", ptr %[[A_ADDR]], i32 0, i32 1
-// LLVM:   %[[ARR_END:.*]] = getelementptr [3 x i32], ptr %[[ARR_ADDR]], i64 3
-// LLVM:   store ptr %[[ARR_END]], ptr %[[END_PTR]], align 8
-// LLVM:   br label %[[SCOPE_END:.*]]
-// LLVM: [[SCOPE_END]]:
-// LLVM:   ret void
+// LLVM: %[[ARR_ADDR:.*]] = alloca [3 x i32], i64 1, align 4
+// LLVM: %[[A_ADDR:.*]] = alloca %"class.std::initializer_list<int>", i64 1, align 8
+// LLVM: %[[ARR_ELEM_0_PTR:.*]] = getelementptr i32, ptr %[[ARR_ADDR]], i32 0
+// LLVM: store i32 10, ptr %[[ARR_ELEM_0_PTR]], align 4
+// LLVM: %[[ARR_ELEM_1_PTR:.*]] = getelementptr i32, ptr %[[ARR_ELEM_0_PTR]], i64 1
+// LLVM: store i32 20, ptr %[[ARR_ELEM_1_PTR]], align 4
+// LLVM: %[[ARR_ELEM_2_PTR:.*]] = getelementptr i32, ptr %[[ARR_ELEM_0_PTR]], i64 2
+// LLVM: store i32 30, ptr %[[ARR_ELEM_2_PTR]], align 4
+// LLVM: %[[BEGIN_PTR:.*]] = getelementptr %"class.std::initializer_list<int>", ptr %[[A_ADDR]], i32 0, i32 0
+// LLVM: store ptr %[[ARR_ADDR]], ptr %[[BEGIN_PTR]], align 8
+// LLVM: %[[END_PTR:.*]] = getelementptr %"class.std::initializer_list<int>", ptr %[[A_ADDR]], i32 0, i32 1
+// LLVM: %[[ARR_END:.*]] = getelementptr [3 x i32], ptr %[[ARR_ADDR]], i64 3
+// LLVM: store ptr %[[ARR_END]], ptr %[[END_PTR]], align 8
+// LLVM: ret void
 
 // OGCG: %[[A_ADDR:.*]] = alloca %"class.std::initializer_list", align 8
 // OGCG: %[[ARR_ADDR:.*]] = alloca [3 x i32], align 4

--- a/clang/test/CIR/CodeGen/instantiate-init.cpp
+++ b/clang/test/CIR/CodeGen/instantiate-init.cpp
@@ -25,29 +25,27 @@ void init_vec_using_initalizer_list() {
 }
 
 // CIR: %[[VEC_ADDR:.*]] = cir.alloca !rec_Vector, !cir.ptr<!rec_Vector>, ["vec", init]
-// CIR: cir.scope {
-// CIR:   %[[AGG_ADDR:.*]] = cir.alloca !rec_std3A3Ainitializer_list3Cint3E, !cir.ptr<!rec_std3A3Ainitializer_list3Cint3E>, ["agg.tmp0"]
-// CIR:   %[[INIT_LIST_ADDR:.*]] = cir.alloca !cir.array<!s32i x 3>, !cir.ptr<!cir.array<!s32i x 3>>, ["ref.tmp0"]
-// CIR:   %[[INIT_LIST_PTR:.*]] = cir.cast array_to_ptrdecay %[[INIT_LIST_ADDR]] : !cir.ptr<!cir.array<!s32i x 3>> -> !cir.ptr<!s32i>
-// CIR:   %[[CONST_S32_0:.*]] = cir.const #cir.int<0> : !s32i
-// CIR:   cir.store {{.*}} %[[CONST_S32_0]], %[[INIT_LIST_PTR]] : !s32i, !cir.ptr<!s32i>
-// CIR:   %[[CONST_S64_1:.*]] = cir.const #cir.int<1> : !s64i
-// CIR:   %[[ELEM_1_PTR:.*]] = cir.ptr_stride %[[INIT_LIST_PTR]], %[[CONST_S64_1]] : (!cir.ptr<!s32i>, !s64i) -> !cir.ptr<!s32i>
-// CIR:   %[[CONST_S32_1:.*]] = cir.const #cir.int<1> : !s32i
-// CIR:   cir.store {{.*}} %[[CONST_S32_1]], %[[ELEM_1_PTR]] : !s32i, !cir.ptr<!s32i>
-// CIR:   %[[CONST_S64_2:.*]] = cir.const #cir.int<2> : !s64i
-// CIR:   %[[ELEM_2_PTR:.*]] = cir.ptr_stride %[[INIT_LIST_PTR]], %[[CONST_S64_2]] : (!cir.ptr<!s32i>, !s64i) -> !cir.ptr<!s32i>
-// CIR:   %[[CONST_S32_2:.*]] = cir.const #cir.int<2> : !s32i
-// CIR:   cir.store {{.*}} %[[CONST_S32_2]], %[[ELEM_2_PTR]] : !s32i, !cir.ptr<!s32i>
-// CIR:   %[[DATA_PTR:.*]] = cir.get_member %[[AGG_ADDR]][0] {name = "data"} : !cir.ptr<!rec_std3A3Ainitializer_list3Cint3E> -> !cir.ptr<!cir.ptr<!s32i>>
-// CIR:   %[[DATA_ARR_PTR:.*]] = cir.cast bitcast %[[DATA_PTR]] : !cir.ptr<!cir.ptr<!s32i>> -> !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
-// CIR:   cir.store {{.*}} %[[INIT_LIST_ADDR]], %[[DATA_ARR_PTR]] : !cir.ptr<!cir.array<!s32i x 3>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
-// CIR:   %[[CONST_U64_3:.*]] = cir.const #cir.int<3> : !u64i
-// CIR:   %[[SIZE_PTR:.*]] = cir.get_member %[[AGG_ADDR]][1] {name = "size"} : !cir.ptr<!rec_std3A3Ainitializer_list3Cint3E> -> !cir.ptr<!u64i>
-// CIR:   cir.store {{.*}} %[[CONST_U64_3]], %[[SIZE_PTR]] : !u64i, !cir.ptr<!u64i>
-// CIR:   %[[TMP_AGG:.*]] = cir.load {{.*}} %[[AGG_ADDR]] : !cir.ptr<!rec_std3A3Ainitializer_list3Cint3E>, !rec_std3A3Ainitializer_list3Cint3E
-// CIR:   cir.call @_ZN6VectorC1ESt16initializer_listIiE(%[[VEC_ADDR]], %[[TMP_AGG]]) : (!cir.ptr<!rec_Vector> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !rec_std3A3Ainitializer_list3Cint3E) -> ()
-// CIR: }
+// CIR: %[[AGG_ADDR:.*]] = cir.alloca !rec_std3A3Ainitializer_list3Cint3E, !cir.ptr<!rec_std3A3Ainitializer_list3Cint3E>, ["agg.tmp0"]
+// CIR: %[[INIT_LIST_ADDR:.*]] = cir.alloca !cir.array<!s32i x 3>, !cir.ptr<!cir.array<!s32i x 3>>, ["ref.tmp0"]
+// CIR: %[[INIT_LIST_PTR:.*]] = cir.cast array_to_ptrdecay %[[INIT_LIST_ADDR]] : !cir.ptr<!cir.array<!s32i x 3>> -> !cir.ptr<!s32i>
+// CIR: %[[CONST_S32_0:.*]] = cir.const #cir.int<0> : !s32i
+// CIR: cir.store {{.*}} %[[CONST_S32_0]], %[[INIT_LIST_PTR]] : !s32i, !cir.ptr<!s32i>
+// CIR: %[[CONST_S64_1:.*]] = cir.const #cir.int<1> : !s64i
+// CIR: %[[ELEM_1_PTR:.*]] = cir.ptr_stride %[[INIT_LIST_PTR]], %[[CONST_S64_1]] : (!cir.ptr<!s32i>, !s64i) -> !cir.ptr<!s32i>
+// CIR: %[[CONST_S32_1:.*]] = cir.const #cir.int<1> : !s32i
+// CIR: cir.store {{.*}} %[[CONST_S32_1]], %[[ELEM_1_PTR]] : !s32i, !cir.ptr<!s32i>
+// CIR: %[[CONST_S64_2:.*]] = cir.const #cir.int<2> : !s64i
+// CIR: %[[ELEM_2_PTR:.*]] = cir.ptr_stride %[[INIT_LIST_PTR]], %[[CONST_S64_2]] : (!cir.ptr<!s32i>, !s64i) -> !cir.ptr<!s32i>
+// CIR: %[[CONST_S32_2:.*]] = cir.const #cir.int<2> : !s32i
+// CIR: cir.store {{.*}} %[[CONST_S32_2]], %[[ELEM_2_PTR]] : !s32i, !cir.ptr<!s32i>
+// CIR: %[[DATA_PTR:.*]] = cir.get_member %[[AGG_ADDR]][0] {name = "data"} : !cir.ptr<!rec_std3A3Ainitializer_list3Cint3E> -> !cir.ptr<!cir.ptr<!s32i>>
+// CIR: %[[DATA_ARR_PTR:.*]] = cir.cast bitcast %[[DATA_PTR]] : !cir.ptr<!cir.ptr<!s32i>> -> !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
+// CIR: cir.store {{.*}} %[[INIT_LIST_ADDR]], %[[DATA_ARR_PTR]] : !cir.ptr<!cir.array<!s32i x 3>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>
+// CIR: %[[CONST_U64_3:.*]] = cir.const #cir.int<3> : !u64i
+// CIR: %[[SIZE_PTR:.*]] = cir.get_member %[[AGG_ADDR]][1] {name = "size"} : !cir.ptr<!rec_std3A3Ainitializer_list3Cint3E> -> !cir.ptr<!u64i>
+// CIR: cir.store {{.*}} %[[CONST_U64_3]], %[[SIZE_PTR]] : !u64i, !cir.ptr<!u64i>
+// CIR: %[[TMP_AGG:.*]] = cir.load {{.*}} %[[AGG_ADDR]] : !cir.ptr<!rec_std3A3Ainitializer_list3Cint3E>, !rec_std3A3Ainitializer_list3Cint3E
+// CIR: cir.call @_ZN6VectorC1ESt16initializer_listIiE(%[[VEC_ADDR]], %[[TMP_AGG]]) : (!cir.ptr<!rec_Vector> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !rec_std3A3Ainitializer_list3Cint3E) -> ()
 // CIR: cir.cleanup.scope {
 // CIR:   cir.yield
 // CIR: } cleanup normal {
@@ -55,11 +53,9 @@ void init_vec_using_initalizer_list() {
 // CIR:   cir.yield
 // CIR: }
 
-// LLVM: %[[AGG_ADDR:.*]] = alloca %"class.std::initializer_list<int>", i64 1, align 8
-// LLVM: %[[INIT_LIST_ADDR:.*]] = alloca [3 x i32], i64 1, align 4
-// LLVM: %[[VEC_ADDR:.*]] = alloca %struct.Vector, i64 1, align 1
-// LLVM: br label %[[SCOPE_START:.*]]
-// LLVM: [[SCOPE_START]]:
+// LLVM:   %[[VEC_ADDR:.*]] = alloca %struct.Vector, i64 1, align 1
+// LLVM:   %[[AGG_ADDR:.*]] = alloca %"class.std::initializer_list<int>", i64 1, align 8
+// LLVM:   %[[INIT_LIST_ADDR:.*]] = alloca [3 x i32], i64 1, align 4
 // LLVM:   %[[INIT_LIST_PTR:.*]] = getelementptr i32, ptr %[[INIT_LIST_ADDR]], i32 0
 // LLVM:   store i32 0, ptr %[[INIT_LIST_PTR]], align 4
 // LLVM:   %[[ELEM_1_PTR:.*]] = getelementptr i32, ptr %[[INIT_LIST_PTR]], i64 1
@@ -76,8 +72,6 @@ void init_vec_using_initalizer_list() {
 // LLVM: [[SCOPE_CONT]]:
 // LLVM:   br label %[[CLEANUP_START:.*]]
 // LLVM: [[CLEANUP_START]]:
-// LLVM:   br label %[[CLEANUO_BODY:.*]]
-// LLVM: [[CLEANUO_BODY:]]:
 // LLVM:   call void @_ZN6VectorD1Ev(ptr noundef nonnull align 1 dereferenceable(1) %[[VEC_ADDR]])
 // LLVM:   br label %[[CLEANUP_CONT:.*]]
 // LLVM: [[CLEANUP_CONT]]:

--- a/clang/test/CIR/CodeGen/lambda-dtor-field.cpp
+++ b/clang/test/CIR/CodeGen/lambda-dtor-field.cpp
@@ -19,10 +19,8 @@ void capture_one(S s) {
 
 // CIR-LABEL: @_Z11capture_one1S
 // CIR:         %[[LAM:.*]] = cir.alloca !rec_anon{{.*}}, {{.*}} ["lam", init]
-// CIR:         cir.scope {
-// CIR:           %[[FIELD:.*]] = cir.get_member %[[LAM]][0] {name = "s"}
-// CIR:           cir.call @_ZN1SC1ERKS_(%[[FIELD]],
-// CIR:         }
+// CIR:         %[[FIELD:.*]] = cir.get_member %[[LAM]][0] {name = "s"}
+// CIR:         cir.call @_ZN1SC1ERKS_(%[[FIELD]],
 // CIR:         cir.cleanup.scope {
 // CIR:           cir.yield
 // CIR:         } cleanup all {
@@ -57,17 +55,15 @@ void capture_two(S a, S b) {
 
 // CIR-LABEL: @_Z11capture_two1SS_
 // CIR:         %[[LAM2:.*]] = cir.alloca !rec_anon{{.*}}, {{.*}} ["lam", init]
-// CIR:         cir.scope {
-// CIR:           %[[FA:.*]] = cir.get_member %[[LAM2]][0] {name = "a"}
-// CIR:           cir.call @_ZN1SC1ERKS_(%[[FA]],
-// CIR:           cir.cleanup.scope {
-// CIR:             %[[FB:.*]] = cir.get_member %[[LAM2]][1] {name = "b"}
-// CIR:             cir.call @_ZN1SC1ERKS_(%[[FB]],
-// CIR:             cir.yield
-// CIR:           } cleanup eh {
-// CIR:             cir.call @_ZN1SD1Ev(%[[FA]]){{.*}}
-// CIR:             cir.yield
-// CIR:           }
+// CIR:         %[[FA:.*]] = cir.get_member %[[LAM2]][0] {name = "a"}
+// CIR:         cir.call @_ZN1SC1ERKS_(%[[FA]],
+// CIR:         cir.cleanup.scope {
+// CIR:           %[[FB:.*]] = cir.get_member %[[LAM2]][1] {name = "b"}
+// CIR:           cir.call @_ZN1SC1ERKS_(%[[FB]],
+// CIR:           cir.yield
+// CIR:         } cleanup eh {
+// CIR:           cir.call @_ZN1SD1Ev(%[[FA]]){{.*}}
+// CIR:           cir.yield
 // CIR:         }
 // CIR:         cir.cleanup.scope {
 // CIR:           cir.yield
@@ -112,13 +108,11 @@ void capture_mixed(int n, S s) {
 
 // CIR-LABEL: @_Z13capture_mixedi1S
 // CIR:         %[[LAM3:.*]] = cir.alloca !rec_anon{{.*}}, {{.*}} ["lam", init]
-// CIR:         cir.scope {
-// CIR:           %[[FN:.*]] = cir.get_member %[[LAM3]][0] {name = "n"}
-// CIR:           cir.load
-// CIR:           cir.store
-// CIR:           %[[FS:.*]] = cir.get_member %[[LAM3]][1] {name = "s"}
-// CIR:           cir.call @_ZN1SC1ERKS_(%[[FS]],
-// CIR:         }
+// CIR:         %[[FN:.*]] = cir.get_member %[[LAM3]][0] {name = "n"}
+// CIR:         cir.load
+// CIR:         cir.store
+// CIR:         %[[FS:.*]] = cir.get_member %[[LAM3]][1] {name = "s"}
+// CIR:         cir.call @_ZN1SC1ERKS_(%[[FS]],
 // CIR:         cir.cleanup.scope {
 // CIR:           cir.yield
 // CIR:         } cleanup all {
@@ -164,10 +158,8 @@ void capture_local() {
 // CIR:         %[[LAM4:.*]] = cir.alloca !rec_anon{{.*}}, {{.*}} ["lam", init]
 // CIR:         cir.call @_ZN1SC1Ev(%[[S4]])
 // CIR:         cir.cleanup.scope {
-// CIR:           cir.scope {
-// CIR:             %[[FL:.*]] = cir.get_member %[[LAM4]][0] {name = "s"}
-// CIR:             cir.call @_ZN1SC1ERKS_(%[[FL]],
-// CIR:           }
+// CIR:           %[[FL:.*]] = cir.get_member %[[LAM4]][0] {name = "s"}
+// CIR:           cir.call @_ZN1SC1ERKS_(%[[FL]],
 // CIR:           cir.cleanup.scope {
 // CIR:             cir.yield
 // CIR:           } cleanup all {
@@ -223,27 +215,25 @@ void stmt_expr_return(bool cond) {
 
 // CIR-LABEL: @_Z16stmt_expr_returnb
 // CIR:         %[[LAM5:.*]] = cir.alloca !rec_anon{{.*}}, {{.*}} ["lam", init]
-// CIR:         cir.scope {
-// CIR:           %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
-// CIR:           %[[FA5:.*]] = cir.get_member %[[LAM5]][0] {name = "a"}
-// CIR:           cir.call @_ZN1SC1Ei(%[[FA5]],
-// CIR:           %[[TRUE:.*]] = cir.const #true
-// CIR:           cir.store %[[TRUE]], %[[ACTIVE]]
-// CIR:           cir.cleanup.scope {
-// CIR:             %[[FB5:.*]] = cir.get_member %[[LAM5]][1] {name = "b"}
-// CIR:             cir.if
-// CIR:               cir.return
-// CIR:             cir.call @_ZN1SC1Ei(%[[FB5]],
-// CIR:             %[[FALSE:.*]] = cir.const #false
-// CIR:             cir.store %[[FALSE]], %[[ACTIVE]]
-// CIR:             cir.yield
-// CIR:           } cleanup all {
-// CIR:             %[[FLAG:.*]] = cir.load{{.*}} %[[ACTIVE]]
-// CIR:             cir.if %[[FLAG]] {
-// CIR:               cir.call @_ZN1SD1Ev(%[[FA5]]){{.*}}
-// CIR:             }
-// CIR:             cir.yield
+// CIR:         %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
+// CIR:         %[[FA5:.*]] = cir.get_member %[[LAM5]][0] {name = "a"}
+// CIR:         cir.call @_ZN1SC1Ei(%[[FA5]],
+// CIR:         %[[TRUE:.*]] = cir.const #true
+// CIR:         cir.store %[[TRUE]], %[[ACTIVE]]
+// CIR:         cir.cleanup.scope {
+// CIR:           %[[FB5:.*]] = cir.get_member %[[LAM5]][1] {name = "b"}
+// CIR:           cir.if
+// CIR:             cir.return
+// CIR:           cir.call @_ZN1SC1Ei(%[[FB5]],
+// CIR:           %[[FALSE:.*]] = cir.const #false
+// CIR:           cir.store %[[FALSE]], %[[ACTIVE]]
+// CIR:           cir.yield
+// CIR:         } cleanup all {
+// CIR:           %[[FLAG:.*]] = cir.load{{.*}} %[[ACTIVE]]
+// CIR:           cir.if %[[FLAG]] {
+// CIR:             cir.call @_ZN1SD1Ev(%[[FA5]]){{.*}}
 // CIR:           }
+// CIR:           cir.yield
 // CIR:         }
 // CIR:         cir.cleanup.scope {
 // CIR:           cir.yield
@@ -261,8 +251,8 @@ void stmt_expr_return(bool cond) {
 // LLVM:   ret void
 
 // LLVM-LABEL: define dso_local void @_Z16stmt_expr_returnb({{.*}}) {{.*}} personality ptr @__gxx_personality_v0 {
-// LLVM:   %[[ACTIVE_ALLOCA:.*]] = alloca i8
 // LLVM:   %[[LAM5:.*]] = alloca %[[LAM_TY_5]]
+// LLVM:   %[[ACTIVE_ALLOCA:.*]] = alloca i8
 // LLVM:   %[[FA5:.*]] = getelementptr %[[LAM_TY_5]], ptr %[[LAM5]], i32 0, i32 0
 // LLVM:   call void @_ZN1SC1Ei(ptr {{.*}} %[[FA5]], i32 {{.*}} 0)
 // LLVM:   store i8 1, ptr %[[ACTIVE_ALLOCA]]

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -252,13 +252,11 @@ int f() {
 
 // CIR: cir.func {{.*}} @_Z1fv() -> (!s32i{{.*}})
 // CIR:   %[[RETVAL:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
-// CIR:   cir.scope {
-// CIR:     %[[TMP:.*]] = cir.alloca ![[REC_LAM_G2]], !cir.ptr<![[REC_LAM_G2]]>, ["ref.tmp0"]
-// CIR:     %[[G2:.*]] = cir.call @_Z2g2v() : () -> ![[REC_LAM_G2]]
-// CIR:     cir.store{{.*}} %[[G2]], %[[TMP]]
-// CIR:     %[[RESULT:.*]] = cir.call @_ZZ2g2vENK3$_0clEv(%[[TMP]])
-// CIR:     cir.store{{.*}} %[[RESULT]], %[[RETVAL]]
-// CIR:   }
+// CIR:   %[[TMP:.*]] = cir.alloca ![[REC_LAM_G2]], !cir.ptr<![[REC_LAM_G2]]>, ["ref.tmp0"]
+// CIR:   %[[G2:.*]] = cir.call @_Z2g2v() : () -> ![[REC_LAM_G2]]
+// CIR:   cir.store{{.*}} %[[G2]], %[[TMP]]
+// CIR:   %[[RESULT:.*]] = cir.call @_ZZ2g2vENK3$_0clEv(%[[TMP]])
+// CIR:   cir.store{{.*}} %[[RESULT]], %[[RETVAL]]
 // CIR:   %[[RET:.*]] = cir.load{{.*}} %[[RETVAL]]
 // CIR:   cir.return %[[RET]]
 
@@ -280,16 +278,12 @@ int f() {
 // LLVM:   ret i32 %[[RET]]
 
 // LLVM: define {{.*}} i32 @_Z1fv()
-// LLVM:   %[[TMP:.*]] = alloca %[[REC_LAM_G2]]
 // LLVM:   %[[RETVAL:.*]] = alloca i32
-// LLVM:   br label %[[SCOPE_BB:.*]]
-// LLVM: [[SCOPE_BB]]:
+// LLVM:   %[[TMP:.*]] = alloca %[[REC_LAM_G2]]
 // LLVM:   %[[G2:.*]] = call %[[REC_LAM_G2]] @_Z2g2v()
 // LLVM:   store %[[REC_LAM_G2]] %[[G2]], ptr %[[TMP]]
 // LLVM:   %[[RESULT:.*]] = call {{.*}}i32 @"_ZZ2g2vENK3$_0clEv"(ptr {{.*}} %[[TMP]])
 // LLVM:   store i32 %[[RESULT]], ptr %[[RETVAL]]
-// LLVM:   br label %[[RET_BB:.*]]
-// LLVM: [[RET_BB]]:
 // LLVM:   %[[RET:.*]] = load i32, ptr %[[RETVAL]]
 // LLVM:   ret i32 %[[RET]]
 
@@ -362,32 +356,26 @@ struct A {
 // CIR: cir.func {{.*}} @_ZN1A3fooEv(%[[THIS_ARG:.*]]: !cir.ptr<!rec_A> {{.*}}) -> (!s32i {llvm.noundef})
 // CIR:   %[[THIS_ADDR:.*]] = cir.alloca !cir.ptr<!rec_A>, !cir.ptr<!cir.ptr<!rec_A>>, ["this", init]
 // CIR:   %[[RETVAL:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
+// CIR:   %[[LAM_ADDR:.*]] = cir.alloca ![[REC_LAM_A]], !cir.ptr<![[REC_LAM_A]]>, ["ref.tmp0"]
 // CIR:   cir.store %[[THIS_ARG]], %[[THIS_ADDR]]
-// CIR:   %[[THIS]] = cir.load deref %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_A>>, !cir.ptr<!rec_A>
-// CIR:   cir.scope {
-// CIR:     %[[LAM_ADDR:.*]] = cir.alloca ![[REC_LAM_A]], !cir.ptr<![[REC_LAM_A]]>, ["ref.tmp0"]
-// CIR:     %[[STRUCT_A:.*]] = cir.get_member %[[LAM_ADDR]][0] {name = "this"} : !cir.ptr<![[REC_LAM_A]]> -> !cir.ptr<!rec_A>
-// CIR:     cir.copy %[[THIS]] to %[[STRUCT_A]] : !cir.ptr<!rec_A>
-// CIR:     %[[LAM_RET:.*]] = cir.call @_ZZN1A3fooEvENKUlvE_clEv(%[[LAM_ADDR]])
-// CIR:     cir.store{{.*}} %[[LAM_RET]], %[[RETVAL]]
-// CIR:   }
+// CIR:   %[[THIS:.*]] = cir.load deref %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_A>>, !cir.ptr<!rec_A>
+// CIR:   %[[STRUCT_A:.*]] = cir.get_member %[[LAM_ADDR]][0] {name = "this"} : !cir.ptr<![[REC_LAM_A]]> -> !cir.ptr<!rec_A>
+// CIR:   cir.copy %[[THIS]] to %[[STRUCT_A]] : !cir.ptr<!rec_A>
+// CIR:   %[[LAM_RET:.*]] = cir.call @_ZZN1A3fooEvENKUlvE_clEv(%[[LAM_ADDR]])
+// CIR:   cir.store{{.*}} %[[LAM_RET]], %[[RETVAL]]
 // CIR:   %[[RET:.*]] = cir.load{{.*}} %[[RETVAL]]
 // CIR:   cir.return %[[RET]]
 
 // LLVM: define linkonce_odr noundef i32 @_ZN1A3fooEv(ptr {{.*}} %[[THIS_ARG:.*]])
-// LLVM:   %[[LAM_ALLOCA:.*]] =  alloca %[[REC_LAM_A]]
 // LLVM:   %[[THIS_ALLOCA:.*]] = alloca ptr
 // LLVM:   %[[RETVAL:.*]] = alloca i32
+// LLVM:   %[[LAM_ALLOCA:.*]] = alloca %[[REC_LAM_A]]
 // LLVM:   store ptr %[[THIS_ARG]], ptr %[[THIS_ALLOCA]]
 // LLVM:   %[[THIS:.*]] = load ptr, ptr %[[THIS_ALLOCA]]
-// LLVM:   br label %[[SCOPE_BB:.*]]
-// LLVM: [[SCOPE_BB]]:
 // LLVM:   %[[STRUCT_A:.*]] = getelementptr %[[REC_LAM_A]], ptr %[[LAM_ALLOCA]], i32 0, i32 0
 // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr %[[STRUCT_A]], ptr %[[THIS]], i64 4, i1 false)
 // LLVM:   %[[LAM_RET:.*]] = call noundef i32 @_ZZN1A3fooEvENKUlvE_clEv(ptr {{.*}} %[[LAM_ALLOCA]])
 // LLVM:   store i32 %[[LAM_RET]], ptr %[[RETVAL]]
-// LLVM:   br label %[[RET_BB:.*]]
-// LLVM: [[RET_BB]]:
 // LLVM:   %[[RET:.*]] = load i32, ptr %[[RETVAL]]
 // LLVM:   ret i32 %[[RET]]
 
@@ -434,32 +422,26 @@ struct A {
 // CIR: cir.func {{.*}} @_ZN1A3barEv(%[[THIS_ARG:.*]]: !cir.ptr<!rec_A> {{.*}}) -> (!s32i {llvm.noundef})
 // CIR:   %[[THIS_ADDR:.*]] = cir.alloca !cir.ptr<!rec_A>, !cir.ptr<!cir.ptr<!rec_A>>, ["this", init]
 // CIR:   %[[RETVAL:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
+// CIR:   %[[LAM_ADDR:.*]] = cir.alloca ![[REC_LAM_PTR_A]], !cir.ptr<![[REC_LAM_PTR_A]]>, ["ref.tmp0"]
 // CIR:   cir.store %[[THIS_ARG]], %[[THIS_ADDR]]
-// CIR:   %[[THIS]] = cir.load %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_A>>, !cir.ptr<!rec_A>
-// CIR:   cir.scope {
-// CIR:     %[[LAM_ADDR:.*]] = cir.alloca ![[REC_LAM_PTR_A]], !cir.ptr<![[REC_LAM_PTR_A]]>, ["ref.tmp0"]
-// CIR:     %[[A_ADDR_ADDR:.*]] = cir.get_member %[[LAM_ADDR]][0] {name = "this"} : !cir.ptr<![[REC_LAM_PTR_A]]> -> !cir.ptr<!cir.ptr<!rec_A>>
-// CIR:     cir.store{{.*}} %[[THIS]], %[[A_ADDR_ADDR]]
-// CIR:     %[[LAM_RET:.*]] = cir.call @_ZZN1A3barEvENKUlvE_clEv(%[[LAM_ADDR]])
-// CIR:     cir.store{{.*}} %[[LAM_RET]], %[[RETVAL]]
-// CIR:   }
+// CIR:   %[[THIS:.*]] = cir.load %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_A>>, !cir.ptr<!rec_A>
+// CIR:   %[[A_ADDR_ADDR:.*]] = cir.get_member %[[LAM_ADDR]][0] {name = "this"} : !cir.ptr<![[REC_LAM_PTR_A]]> -> !cir.ptr<!cir.ptr<!rec_A>>
+// CIR:   cir.store{{.*}} %[[THIS]], %[[A_ADDR_ADDR]]
+// CIR:   %[[LAM_RET:.*]] = cir.call @_ZZN1A3barEvENKUlvE_clEv(%[[LAM_ADDR]])
+// CIR:   cir.store{{.*}} %[[LAM_RET]], %[[RETVAL]]
 // CIR:   %[[RET:.*]] = cir.load{{.*}} %[[RETVAL]]
 // CIR:   cir.return %[[RET]]
 
 // LLVM: define linkonce_odr noundef i32 @_ZN1A3barEv(ptr {{.*}} %[[THIS_ARG:.*]])
-// LLVM:   %[[LAM_ALLOCA:.*]] =  alloca %[[REC_LAM_PTR_A]]
 // LLVM:   %[[THIS_ALLOCA:.*]] = alloca ptr
 // LLVM:   %[[RETVAL:.*]] = alloca i32
+// LLVM:   %[[LAM_ALLOCA:.*]] = alloca %[[REC_LAM_PTR_A]]
 // LLVM:   store ptr %[[THIS_ARG]], ptr %[[THIS_ALLOCA]]
 // LLVM:   %[[THIS:.*]] = load ptr, ptr %[[THIS_ALLOCA]]
-// LLVM:   br label %[[SCOPE_BB:.*]]
-// LLVM: [[SCOPE_BB]]:
 // LLVM:   %[[A_ADDR_ADDR:.*]] = getelementptr %[[REC_LAM_PTR_A]], ptr %[[LAM_ALLOCA]], i32 0, i32 0
 // LLVM:   store ptr %[[THIS]], ptr %[[A_ADDR_ADDR]]
 // LLVM:   %[[LAM_RET:.*]] = call noundef i32 @_ZZN1A3barEvENKUlvE_clEv(ptr {{.*}} %[[LAM_ALLOCA]])
 // LLVM:   store i32 %[[LAM_RET]], ptr %[[RETVAL]]
-// LLVM:   br label %[[RET_BB:.*]]
-// LLVM: [[RET_BB]]:
 // LLVM:   %[[RET:.*]] = load i32, ptr %[[RETVAL]]
 // LLVM:   ret i32 %[[RET]]
 

--- a/clang/test/CIR/CodeGen/new-delete-deactivation.cpp
+++ b/clang/test/CIR/CodeGen/new-delete-deactivation.cpp
@@ -23,30 +23,29 @@ A *deact_simple() { return new A(makeB()); }
 
 // CIR-LABEL: cir.func {{.*}} @_Z12deact_simplev() -> !cir.ptr<!rec_A> {
 // CIR:   %[[RETVAL:.*]] = cir.alloca !cir.ptr<!rec_A>, !cir.ptr<!cir.ptr<!rec_A>>, ["__retval"]
-// CIR:   cir.scope {
-// CIR:     %[[NEW_RESULT:.*]] = cir.alloca !cir.ptr<!rec_A>, !cir.ptr<!cir.ptr<!rec_A>>, ["__new_result"]
-// CIR:     %[[TMP:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp0"]
-// CIR:     %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
-// CIR:     %[[PTR:.*]] = cir.call @_Znwm({{.*}}) {{{.*}}builtin}
+// CIR:   %[[NEW_RESULT:.*]] = cir.alloca !cir.ptr<!rec_A>, !cir.ptr<!cir.ptr<!rec_A>>, ["__new_result"]
+// CIR:   %[[TMP:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp0"]
+// CIR:   %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
+// CIR:   %[[PTR:.*]] = cir.call @_Znwm({{.*}}) {{{.*}}builtin}
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[TRUE:.*]] = cir.const #true
+// CIR:     cir.store %[[TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:     %[[MAKEB:.*]] = cir.call @_Z5makeBv() : () -> !rec_B
+// CIR:     cir.store{{.*}} %[[MAKEB]], %[[TMP]] : !rec_B, !cir.ptr<!rec_B>
 // CIR:     cir.cleanup.scope {
-// CIR:       %[[TRUE:.*]] = cir.const #true
-// CIR:       cir.store %[[TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:       %[[MAKEB:.*]] = cir.call @_Z5makeBv() : () -> !rec_B
-// CIR:       cir.store{{.*}} %[[MAKEB]], %[[TMP]] : !rec_B, !cir.ptr<!rec_B>
-// CIR:       cir.cleanup.scope {
-// CIR:         %[[CONV:.*]] = cir.call @_ZN1BcviEv(%[[TMP]])
-// CIR:         cir.call @_ZN1AC1Ei({{.*}})
-// CIR:         %[[FALSE:.*]] = cir.const #false
-// CIR:         cir.store %[[FALSE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:       } cleanup all {
-// CIR:         cir.call @_ZN1BD1Ev(%[[TMP]]) nothrow
-// CIR:       }
-// CIR:     } cleanup eh {
-// CIR:       %[[IS_ACTIVE:.*]] = cir.load{{.*}} %[[ACTIVE]] : !cir.ptr<!cir.bool>, !cir.bool
-// CIR:       cir.if %[[IS_ACTIVE]] {
-// CIR:         cir.call @_ZdlPv(%[[PTR]]) nothrow {builtin}
-// CIR:       }
+// CIR:       %[[CONV:.*]] = cir.call @_ZN1BcviEv(%[[TMP]])
+// CIR:       cir.call @_ZN1AC1Ei({{.*}})
+// CIR:       %[[FALSE:.*]] = cir.const #false
+// CIR:       cir.store %[[FALSE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:     } cleanup all {
+// CIR:       cir.call @_ZN1BD1Ev(%[[TMP]]) nothrow
 // CIR:     }
+// CIR:   } cleanup eh {
+// CIR:     %[[IS_ACTIVE:.*]] = cir.load{{.*}} %[[ACTIVE]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:     cir.if %[[IS_ACTIVE]] {
+// CIR:       cir.call @_ZdlPv(%[[PTR]]) nothrow {builtin}
+// CIR:     }
+// CIR:   }
 
 // LLVM-LABEL: define dso_local ptr @_Z12deact_simplev() {{.*}} personality ptr @__gxx_personality_v0 {
 // LLVM:   %[[TMP:.*]] = alloca %struct.B
@@ -107,20 +106,18 @@ A *deact_if(bool cond) {
 
 // CIR-LABEL: cir.func {{.*}} @_Z8deact_ifb
 // CIR:   cir.if {{.*}} {
-// CIR:     cir.scope {
-// CIR:       %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
-// CIR:       %[[PTR:.*]] = cir.call @_Znwm({{.*}}) {{{.*}}builtin}
-// CIR:       cir.cleanup.scope {
-// CIR:         %[[TRUE:.*]] = cir.const #true
-// CIR:         cir.store %[[TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:         cir.call @_ZN1AC1Ei({{.*}})
-// CIR:         %[[FALSE:.*]] = cir.const #false
-// CIR:         cir.store %[[FALSE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:       } cleanup eh {
-// CIR:         %[[IS_ACTIVE:.*]] = cir.load{{.*}} %[[ACTIVE]] : !cir.ptr<!cir.bool>, !cir.bool
-// CIR:         cir.if %[[IS_ACTIVE]] {
-// CIR:           cir.call @_ZdlPv(%[[PTR]]) nothrow {builtin}
-// CIR:         }
+// CIR:     %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
+// CIR:     %[[PTR:.*]] = cir.call @_Znwm({{.*}}) {{{.*}}builtin}
+// CIR:     cir.cleanup.scope {
+// CIR:       %[[TRUE:.*]] = cir.const #true
+// CIR:       cir.store %[[TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:       cir.call @_ZN1AC1Ei({{.*}})
+// CIR:       %[[FALSE:.*]] = cir.const #false
+// CIR:       cir.store %[[FALSE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:     } cleanup eh {
+// CIR:       %[[IS_ACTIVE:.*]] = cir.load{{.*}} %[[ACTIVE]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:       cir.if %[[IS_ACTIVE]] {
+// CIR:         cir.call @_ZdlPv(%[[PTR]]) nothrow {builtin}
 // CIR:       }
 // CIR:     }
 // CIR:   }
@@ -165,20 +162,18 @@ A *deact_if(bool cond) {
 A *deact_ternary(bool cond) { return (new A(makeB()), cond) ? nullptr : nullptr; }
 
 // CIR-LABEL: cir.func {{.*}} @_Z13deact_ternaryb
-// CIR:   cir.scope {
-// CIR:     %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
-// CIR:     %[[PTR:.*]] = cir.call @_Znwm({{.*}}) {{{.*}}builtin}
-// CIR:     cir.cleanup.scope {
-// CIR:       %[[TRUE:.*]] = cir.const #true
-// CIR:       cir.store %[[TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:       cir.call @_ZN1AC1Ei({{.*}})
-// CIR:       %[[FALSE:.*]] = cir.const #false
-// CIR:       cir.store %[[FALSE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:     } cleanup eh {
-// CIR:       %[[IS_ACTIVE:.*]] = cir.load{{.*}} %[[ACTIVE]] : !cir.ptr<!cir.bool>, !cir.bool
-// CIR:       cir.if %[[IS_ACTIVE]] {
-// CIR:         cir.call @_ZdlPv(%[[PTR]]) nothrow {builtin}
-// CIR:       }
+// CIR:   %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
+// CIR:   %[[PTR:.*]] = cir.call @_Znwm({{.*}}) {{{.*}}builtin}
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[TRUE:.*]] = cir.const #true
+// CIR:     cir.store %[[TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:     cir.call @_ZN1AC1Ei({{.*}})
+// CIR:     %[[FALSE:.*]] = cir.const #false
+// CIR:     cir.store %[[FALSE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:   } cleanup eh {
+// CIR:     %[[IS_ACTIVE:.*]] = cir.load{{.*}} %[[ACTIVE]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:     cir.if %[[IS_ACTIVE]] {
+// CIR:       cir.call @_ZdlPv(%[[PTR]]) nothrow {builtin}
 // CIR:     }
 // CIR:   }
 
@@ -302,22 +297,20 @@ A *deact_switch(int kind) {
 }
 
 // CIR-LABEL: cir.func {{.*}} @_Z12deact_switchi
+// CIR:   %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
 // CIR:   cir.switch({{.*}}) {
 // CIR:     cir.case(equal, [#cir.int<1> : !s32i]) {
-// CIR:       cir.scope {
-// CIR:         %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
-// CIR:         %[[PTR:.*]] = cir.call @_Znwm({{.*}}) {{{.*}}builtin}
-// CIR:         cir.cleanup.scope {
-// CIR:           %[[TRUE:.*]] = cir.const #true
-// CIR:           cir.store %[[TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:           cir.call @_ZN1AC1Ei({{.*}})
-// CIR:           %[[FALSE:.*]] = cir.const #false
-// CIR:           cir.store %[[FALSE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:         } cleanup eh {
-// CIR:           %[[IS_ACTIVE:.*]] = cir.load{{.*}} %[[ACTIVE]] : !cir.ptr<!cir.bool>, !cir.bool
-// CIR:           cir.if %[[IS_ACTIVE]] {
-// CIR:             cir.call @_ZdlPv(%[[PTR]]) nothrow {builtin}
-// CIR:           }
+// CIR:       %[[PTR:.*]] = cir.call @_Znwm({{.*}}) {{{.*}}builtin}
+// CIR:       cir.cleanup.scope {
+// CIR:         %[[TRUE:.*]] = cir.const #true
+// CIR:         cir.store %[[TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:         cir.call @_ZN1AC1Ei({{.*}})
+// CIR:         %[[FALSE:.*]] = cir.const #false
+// CIR:         cir.store %[[FALSE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:       } cleanup eh {
+// CIR:         %[[IS_ACTIVE:.*]] = cir.load{{.*}} %[[ACTIVE]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:         cir.if %[[IS_ACTIVE]] {
+// CIR:           cir.call @_ZdlPv(%[[PTR]]) nothrow {builtin}
 // CIR:         }
 // CIR:       }
 // CIR:     }

--- a/clang/test/CIR/CodeGen/paren-init-list-eh.cpp
+++ b/clang/test/CIR/CodeGen/paren-init-list-eh.cpp
@@ -23,28 +23,26 @@ void test_init_list_with_dtor() {
 
 // CIR: cir.func {{.*}} @_Z24test_init_list_with_dtorv
 // CIR:   %[[O:.*]] = cir.alloca !rec_Outer, !cir.ptr<!rec_Outer>, ["o", init]
-// CIR:   cir.scope {
-// CIR:     %[[S1:.*]] = cir.get_member %[[O]][0] {name = "s1"} : !cir.ptr<!rec_Outer> -> !cir.ptr<!rec_Struk>
-// CIR:     %[[ONE:.*]] = cir.const #cir.int<1>
-// CIR:     cir.call @_ZN5StrukC1Ei(%[[S1]], %[[ONE]])
+// CIR:   %[[S1:.*]] = cir.get_member %[[O]][0] {name = "s1"} : !cir.ptr<!rec_Outer> -> !cir.ptr<!rec_Struk>
+// CIR:   %[[ONE:.*]] = cir.const #cir.int<1>
+// CIR:   cir.call @_ZN5StrukC1Ei(%[[S1]], %[[ONE]])
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[S2:.*]] = cir.get_member %[[O]][1] {name = "s2"} : !cir.ptr<!rec_Outer> -> !cir.ptr<!rec_Struk>
+// CIR:     %[[TWO:.*]] = cir.const #cir.int<2>
+// CIR:     cir.call @_ZN5StrukC1Ei(%[[S2]], %[[TWO]])
 // CIR:     cir.cleanup.scope {
-// CIR:       %[[S2:.*]] = cir.get_member %[[O]][1] {name = "s2"} : !cir.ptr<!rec_Outer> -> !cir.ptr<!rec_Struk>
-// CIR:       %[[TWO:.*]] = cir.const #cir.int<2>
-// CIR:       cir.call @_ZN5StrukC1Ei(%[[S2]], %[[TWO]])
-// CIR:       cir.cleanup.scope {
-// CIR:         %[[X:.*]] = cir.get_member %[[O]][2] {name = "x"}
-// CIR:         %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
-// CIR:         cir.store align(4) %[[THREE]], %[[X]]
-// CIR:         cir.yield
-// CIR:       } cleanup eh {
-// CIR:         cir.call @_ZN5StrukD1Ev(%[[S2]])
-// CIR:         cir.yield
-// CIR:       }
+// CIR:       %[[X:.*]] = cir.get_member %[[O]][2] {name = "x"}
+// CIR:       %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
+// CIR:       cir.store align(4) %[[THREE]], %[[X]]
 // CIR:       cir.yield
 // CIR:     } cleanup eh {
-// CIR:       cir.call @_ZN5StrukD1Ev(%[[S1]])
+// CIR:       cir.call @_ZN5StrukD1Ev(%[[S2]])
 // CIR:       cir.yield
 // CIR:     }
+// CIR:     cir.yield
+// CIR:   } cleanup eh {
+// CIR:     cir.call @_ZN5StrukD1Ev(%[[S1]])
+// CIR:     cir.yield
 // CIR:   }
 // CIR:   cir.cleanup.scope {
 // CIR:     cir.yield

--- a/clang/test/CIR/CodeGen/paren-init-list.cpp
+++ b/clang/test/CIR/CodeGen/paren-init-list.cpp
@@ -41,15 +41,13 @@ void test_init_list_with_dtor() {
 
 // CIR: cir.func {{.*}} @_Z24test_init_list_with_dtorv
 // CIR:   %[[O:.*]] = cir.alloca !rec_Outer, !cir.ptr<!rec_Outer>, ["o", init]
-// CIR:   cir.scope {
-// CIR:     %[[H:.*]] = cir.get_member %[[O]][0] {name = "h"} : !cir.ptr<!rec_Outer> -> !cir.ptr<!rec_HasDtor>
-// CIR:     %[[VAL:.*]] = cir.get_member %[[H]][0] {name = "val"} : !cir.ptr<!rec_HasDtor> -> !cir.ptr<!s32i>
-// CIR:     %[[CONST:.*]] = cir.const #cir.int<1>
-// CIR:     cir.store{{.*}} %[[CONST]], %[[VAL]]
-// CIR:     %[[X:.*]] = cir.get_member %[[O]][1] {name = "x"} : !cir.ptr<!rec_Outer> -> !cir.ptr<!s32i>
-// CIR:     %[[CONST:.*]] = cir.const #cir.int<2>
-// CIR:     cir.store{{.*}} %[[CONST]], %[[X]]
-// CIR:   }
+// CIR:   %[[H:.*]] = cir.get_member %[[O]][0] {name = "h"} : !cir.ptr<!rec_Outer> -> !cir.ptr<!rec_HasDtor>
+// CIR:   %[[VAL:.*]] = cir.get_member %[[H]][0] {name = "val"} : !cir.ptr<!rec_HasDtor> -> !cir.ptr<!s32i>
+// CIR:   %[[CONST:.*]] = cir.const #cir.int<1>
+// CIR:   cir.store{{.*}} %[[CONST]], %[[VAL]]
+// CIR:   %[[X:.*]] = cir.get_member %[[O]][1] {name = "x"} : !cir.ptr<!rec_Outer> -> !cir.ptr<!s32i>
+// CIR:   %[[CONST:.*]] = cir.const #cir.int<2>
+// CIR:   cir.store{{.*}} %[[CONST]], %[[X]]
 // CIR:   cir.cleanup.scope {
 // CIR:     cir.yield
 // CIR:   } cleanup normal {

--- a/clang/test/CIR/CodeGen/statement-exprs.c
+++ b/clang/test/CIR/CodeGen/statement-exprs.c
@@ -230,41 +230,35 @@ struct S { int x; };
 int test3() { return ({ struct S s = {1}; s; }).x; }
 // CIR: cir.func {{.*}} @test3() -> !s32i
 // CIR:   %[[RETVAL:.+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
+// CIR:   %[[REF_TMP0:.+]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["ref.tmp0"]
+// CIR:   %[[TMP:.+]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["tmp"]
 // CIR:   cir.scope {
-// CIR:     %[[REF_TMP0:.+]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["ref.tmp0"]
-// CIR:     %[[TMP:.+]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["tmp"]
-// CIR:     cir.scope {
-// CIR:       %[[S:.+]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["s", init]
-// CIR:       %[[CONST:.*]] = cir.get_global @[[TEST3_S]] : !cir.ptr<!rec_S>
-// CIR:       cir.copy %[[CONST]] to %[[S]] : !cir.ptr<!rec_S>
-// CIR:       cir.copy %[[S]] to %[[REF_TMP0]] : !cir.ptr<!rec_S>
-// CIR:     }
-// CIR:     %[[GEP_X_TMP:.+]] = cir.get_member %[[REF_TMP0]][0] {name = "x"} : !cir.ptr<!rec_S> -> !cir.ptr<!s32i>
-// CIR:     %[[XVAL:.+]] = cir.load {{.*}} %[[GEP_X_TMP]] : !cir.ptr<!s32i>, !s32i
-// CIR:     cir.store{{.*}} %[[XVAL]], %[[RETVAL]] : !s32i, !cir.ptr<!s32i>
+// CIR:     %[[S:.+]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["s", init]
+// CIR:     %[[CONST:.*]] = cir.get_global @[[TEST3_S]] : !cir.ptr<!rec_S>
+// CIR:     cir.copy %[[CONST]] to %[[S]] : !cir.ptr<!rec_S>
+// CIR:     cir.copy %[[S]] to %[[REF_TMP0]] : !cir.ptr<!rec_S>
 // CIR:   }
+// CIR:   %[[GEP_X_TMP:.+]] = cir.get_member %[[REF_TMP0]][0] {name = "x"} : !cir.ptr<!rec_S> -> !cir.ptr<!s32i>
+// CIR:   %[[XVAL:.+]] = cir.load {{.*}} %[[GEP_X_TMP]] : !cir.ptr<!s32i>, !s32i
+// CIR:   cir.store{{.*}} %[[XVAL]], %[[RETVAL]] : !s32i, !cir.ptr<!s32i>
 // CIR:   %[[RES:.+]] = cir.load %[[RETVAL]] : !cir.ptr<!s32i>, !s32i
 // CIR:   cir.return %[[RES]] : !s32i
 
 // LLVM: define dso_local i32 @test3()
 // LLVM:   %[[VAR1:.+]] = alloca %struct.S, i64 1
-// LLVM:   %[[VAR2:.+]] = alloca %struct.S, i64 1
+// LLVM:   %[[VAR2:.+]] = alloca i32, i64 1
 // LLVM:   %[[VAR3:.+]] = alloca %struct.S, i64 1
-// LLVM:   %[[VAR4:.+]] = alloca i32, i64 1
+// LLVM:   %[[VAR4:.+]] = alloca %struct.S, i64 1
 // LLVM:   br label %[[LBL5:.+]]
 // LLVM: [[LBL5]]:
+// LLVM:     call void @llvm.memcpy{{.*}}(ptr %[[VAR1]], ptr @[[TEST3_S]], i64 4, i1 false)
+// LLVM:     call void @llvm.memcpy.p0.p0.i64(ptr %[[VAR3]], ptr %[[VAR1]], i64 4, i1 false)
 // LLVM:     br label %[[LBL6:.+]]
 // LLVM: [[LBL6]]:
-// LLVM:     call void @llvm.memcpy{{.*}}(ptr %[[VAR3]], ptr @[[TEST3_S]], i64 4, i1 false)
-// LLVM:     call void @llvm.memcpy.p0.p0.i64(ptr %[[VAR1]], ptr %[[VAR3]], i64 4, i1 false)
-// LLVM:     br label %[[LBL8:.+]]
-// LLVM: [[LBL8]]:
-// LLVM:     %[[GEP_VAR1:.+]] = getelementptr %struct.S, ptr %[[VAR1]], i32 0, i32 0
-// LLVM:     %[[LOAD_X:.+]] = load i32, ptr %[[GEP_VAR1]]
-// LLVM:     store i32 %[[LOAD_X]], ptr %[[VAR4]]
-// LLVM:     br label %[[LBL11:.+]]
-// LLVM: [[LBL11]]:
-// LLVM:     %[[RES:.+]] = load i32, ptr %[[VAR4]]
+// LLVM:     %[[GEP_VAR3:.+]] = getelementptr %struct.S, ptr %[[VAR3]], i32 0, i32 0
+// LLVM:     %[[LOAD_X:.+]] = load i32, ptr %[[GEP_VAR3]]
+// LLVM:     store i32 %[[LOAD_X]], ptr %[[VAR2]]
+// LLVM:     %[[RES:.+]] = load i32, ptr %[[VAR2]]
 // LLVM:     ret i32 %[[RES]]
 
 // OGCG: define dso_local i32 @test3()

--- a/clang/test/CIR/CodeGen/trivial-ctor-const-init.cpp
+++ b/clang/test/CIR/CodeGen/trivial-ctor-const-init.cpp
@@ -27,13 +27,11 @@ StructWithCtorArg withArg = 0.0;
 // OGCG: @withArg = global %struct.StructWithCtorArg zeroinitializer
 
 // CIR: cir.func {{.*}} @__cxx_global_var_init()
+// CIR:   %[[TMP0:.*]] = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["ref.tmp0"]
 // CIR:   %[[WITH_ARG:.*]] = cir.get_global @withArg : !cir.ptr<!rec_StructWithCtorArg>
-// CIR:   cir.scope {
-// CIR:     %[[TMP0:.*]] = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["ref.tmp0"]
-// CIR:     %[[ZERO:.*]] = cir.const #cir.fp<0.000000e+00> : !cir.double
-// CIR:     cir.store{{.*}} %[[ZERO]], %[[TMP0]] : !cir.double, !cir.ptr<!cir.double>
-// CIR:     cir.call @_ZN17StructWithCtorArgC1ERKd(%[[WITH_ARG]], %[[TMP0]]) : (!cir.ptr<!rec_StructWithCtorArg> {{.*}}, !cir.ptr<!cir.double> {{.*}}) -> ()
-// CIR:   }
+// CIR:   %[[ZERO:.*]] = cir.const #cir.fp<0.000000e+00> : !cir.double
+// CIR:   cir.store{{.*}} %[[ZERO]], %[[TMP0]] : !cir.double, !cir.ptr<!cir.double>
+// CIR:   cir.call @_ZN17StructWithCtorArgC1ERKd(%[[WITH_ARG]], %[[TMP0]]) : (!cir.ptr<!rec_StructWithCtorArg> {{.*}}, !cir.ptr<!cir.double> {{.*}}) -> ()
 
 // LLVM: define {{.*}} void @__cxx_global_var_init()
 // LLVM:   %[[TMP0:.*]] = alloca double

--- a/clang/test/CIR/CodeGenBuiltins/builtin-bit-cast.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-bit-cast.cpp
@@ -118,15 +118,13 @@ two_ints test_rvalue_aggregate() {
 }
 
 // CIR-LABEL: cir.func {{.*}} @_Z21test_rvalue_aggregatev()
-//       CIR:   cir.scope {
-//  CIR-NEXT:     %[[#TMP_SLOT:]] = cir.alloca !u64i, !cir.ptr<!u64i>
-//  CIR-NEXT:     %[[#A:]] = cir.const #cir.int<42> : !u64i
-//  CIR-NEXT:     cir.store{{.*}} %[[#A]], %[[#TMP_SLOT]] : !u64i, !cir.ptr<!u64i>
-//  CIR-NEXT:     %[[#SRC_VOID_PTR:]] = cir.cast bitcast %[[#TMP_SLOT]] : !cir.ptr<!u64i> -> !cir.ptr<!void>
-//  CIR-NEXT:     %[[#DST_VOID_PTR:]] = cir.cast bitcast %0 : !cir.ptr<!rec_two_ints> -> !cir.ptr<!void>
-//  CIR-NEXT:     %[[#SIZE:]] = cir.const #cir.int<8> : !u64i
-//  CIR-NEXT:     cir.libc.memcpy %[[#SIZE]] bytes from %[[#SRC_VOID_PTR]] to %[[#DST_VOID_PTR]] : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
-//  CIR-NEXT:   }
+//  CIR:        %[[#TMP_SLOT:]] = cir.alloca !u64i, !cir.ptr<!u64i>
+//  CIR-NEXT:   %[[#A:]] = cir.const #cir.int<42> : !u64i
+//  CIR-NEXT:   cir.store{{.*}} %[[#A]], %[[#TMP_SLOT]] : !u64i, !cir.ptr<!u64i>
+//  CIR-NEXT:   %[[#SRC_VOID_PTR:]] = cir.cast bitcast %[[#TMP_SLOT]] : !cir.ptr<!u64i> -> !cir.ptr<!void>
+//  CIR-NEXT:   %[[#DST_VOID_PTR:]] = cir.cast bitcast %0 : !cir.ptr<!rec_two_ints> -> !cir.ptr<!void>
+//  CIR-NEXT:   %[[#SIZE:]] = cir.const #cir.int<8> : !u64i
+//  CIR-NEXT:   cir.libc.memcpy %[[#SIZE]] bytes from %[[#SRC_VOID_PTR]] to %[[#DST_VOID_PTR]] : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
 
 /// FIXME: The function signature below should be identical for both lowering
 /// paths, but CIR is still missing calling convention lowering. Update this


### PR DESCRIPTION
This change simplifies the level of scopes we build around aggregate expressions with cleanups and return values involving expressions with cleanups. This removes unnecessary scopes and lexical scopes that were created around the expressions and brings the code back into alignment with the corresponding classic codegen implementation of these handlers.