### PR TITLE
[X86] Use unsigned comparison for stack clash probing loop

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -37069,7 +37069,7 @@ X86TargetLowering::EmitLoweredProbedAlloca(MachineInstr &MI,
 
   BuildMI(testMBB, MIMD, TII->get(X86::JCC_1))
       .addMBB(tailMBB)
-      .addImm(X86::COND_GE);
+      .addImm(X86::COND_AE);
   testMBB->addSuccessor(blockMBB);
   testMBB->addSuccessor(tailMBB);
 

--- a/llvm/test/CodeGen/X86/stack-clash-dynamic-alloca.ll
+++ b/llvm/test/CodeGen/X86/stack-clash-dynamic-alloca.ll
@@ -16,12 +16,12 @@ define i32 @foo(i32 %n) local_unnamed_addr #0 {
 ; CHECK-X86-64-NEXT:    andq $-16, %rcx
 ; CHECK-X86-64-NEXT:    subq %rcx, %rax
 ; CHECK-X86-64-NEXT:    cmpq %rsp, %rax
-; CHECK-X86-64-NEXT:    jge .LBB0_3
+; CHECK-X86-64-NEXT:    jae .LBB0_3
 ; CHECK-X86-64-NEXT:  .LBB0_2: # =>This Inner Loop Header: Depth=1
 ; CHECK-X86-64-NEXT:    xorq $0, (%rsp)
 ; CHECK-X86-64-NEXT:    subq $4096, %rsp # imm = 0x1000
 ; CHECK-X86-64-NEXT:    cmpq %rsp, %rax
-; CHECK-X86-64-NEXT:    jl .LBB0_2
+; CHECK-X86-64-NEXT:    jb .LBB0_2
 ; CHECK-X86-64-NEXT:  .LBB0_3:
 ; CHECK-X86-64-NEXT:    movq %rax, %rsp
 ; CHECK-X86-64-NEXT:    movl $1, 4792(%rax)
@@ -45,12 +45,12 @@ define i32 @foo(i32 %n) local_unnamed_addr #0 {
 ; CHECK-X86-32-NEXT:    andl $-16, %ecx
 ; CHECK-X86-32-NEXT:    subl %ecx, %eax
 ; CHECK-X86-32-NEXT:    cmpl %esp, %eax
-; CHECK-X86-32-NEXT:    jge .LBB0_3
+; CHECK-X86-32-NEXT:    jae .LBB0_3
 ; CHECK-X86-32-NEXT:  .LBB0_2: # =>This Inner Loop Header: Depth=1
 ; CHECK-X86-32-NEXT:    xorl $0, (%esp)
 ; CHECK-X86-32-NEXT:    subl $4096, %esp # imm = 0x1000
 ; CHECK-X86-32-NEXT:    cmpl %esp, %eax
-; CHECK-X86-32-NEXT:    jl .LBB0_2
+; CHECK-X86-32-NEXT:    jb .LBB0_2
 ; CHECK-X86-32-NEXT:  .LBB0_3:
 ; CHECK-X86-32-NEXT:    movl %eax, %esp
 ; CHECK-X86-32-NEXT:    movl $1, 4792(%eax)

--- a/llvm/test/CodeGen/X86/stack-clash-small-alloc-medium-align.ll
+++ b/llvm/test/CodeGen/X86/stack-clash-small-alloc-medium-align.ll
@@ -103,12 +103,12 @@ define i32 @foo4(i64 %i) local_unnamed_addr #0 {
 ; CHECK-NEXT:    andq $-16, %rcx
 ; CHECK-NEXT:    subq %rcx, %rax
 ; CHECK-NEXT:    cmpq %rsp, %rax
-; CHECK-NEXT:    jge .LBB3_3
+; CHECK-NEXT:    jae .LBB3_3
 ; CHECK-NEXT:  .LBB3_2: # =>This Inner Loop Header: Depth=1
 ; CHECK-NEXT:    xorq $0, (%rsp)
 ; CHECK-NEXT:    subq $4096, %rsp # imm = 0x1000
 ; CHECK-NEXT:    cmpq %rsp, %rax
-; CHECK-NEXT:    jl .LBB3_2
+; CHECK-NEXT:    jb .LBB3_2
 ; CHECK-NEXT:  .LBB3_3:
 ; CHECK-NEXT:    andq $-64, %rax
 ; CHECK-NEXT:    movq %rax, %rsp


### PR DESCRIPTION
The stack clash probing loop generated in `EmitLoweredProbedAlloca` used
a signed comparison (`X86::COND_GE`) to determine when the allocation
target had been reached.

In 32-bit mode, memory addresses above `0x80000000` have the sign bit
set. If the stack pointer lands in this region, treating the addresses
as signed integers causes the comparison logic to fail. This leads to
incorrect loop execution, resulting in an infinite loop and a crash
(segmentation fault) when setting up custom stacks for pthreads mapped
above `0x80000000` in a 32b process.

This patch changes the condition code to `X86::COND_AE` (Above or
Equal), which generates an unsigned comparison. This ensures that
addresses are treated correctly as unsigned quantities on all targets.

On 64-bit systems, this change has no practical effect on valid
user-space addresses because they do not use the sign bit (being
restricted to the lower half of the address space). However, using
unsigned comparison is the correct behavior for pointer arithmetic and
bounds checks.

Reported-by: Wonsik Kim <wonsik@google.com>
