### PR TITLE
[CIR] Fix FlattenCFG pattern rewriter contract violations

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -536,7 +536,10 @@ public:
     mlir::Operation *trueTerminator = trueRegion.back().getTerminator();
     rewriter.setInsertionPointToEnd(&trueRegion.back());
 
-    // Handle both yield and unreachable terminators (throw expressions)
+    // Handle both yield and unreachable terminators (throw expressions).
+    // Note: IR has already been modified (splitBlock, createBlock above), so
+    // we must not return failure() from this point onward per the MLIR pattern
+    // rewriter contract.
     if (auto trueYieldOp = dyn_cast<cir::YieldOp>(trueTerminator)) {
       rewriter.replaceOpWithNewOp<cir::BrOp>(trueYieldOp, trueYieldOp.getArgs(),
                                              continueBlock);
@@ -546,7 +549,9 @@ public:
       trueTerminator->emitError("unexpected terminator in ternary true region, "
                                 "expected yield or unreachable, got: ")
           << trueTerminator->getName();
-      return mlir::failure();
+      // Return success because IR was already modified
+      // (splitBlock/createBlock).
+      return mlir::success();
     }
     rewriter.inlineRegionBefore(trueRegion, continueBlock);
 
@@ -567,7 +572,9 @@ public:
       falseTerminator->emitError("unexpected terminator in ternary false "
                                  "region, expected yield or unreachable, got: ")
           << falseTerminator->getName();
-      return mlir::failure();
+      // Return success because IR was already modified
+      // (splitBlock/createBlock).
+      return mlir::success();
     }
     rewriter.inlineRegionBefore(falseRegion, continueBlock);
 
@@ -913,7 +920,7 @@ public:
       if (shouldSinkReturnOperand(operand, returnOp)) {
         // Sink the defining op to the dispatch block.
         mlir::Operation *defOp = operand.getDefiningOp();
-        defOp->moveBefore(destBlock, destBlock->end());
+        rewriter.moveOpBefore(defOp, destBlock, destBlock->end());
         returnValues.push_back(operand);
       } else {
         // Create an alloca in the function entry block.
@@ -1384,7 +1391,13 @@ public:
     // Erase the original cleanup scope op.
     rewriter.eraseOp(cleanupOp);
 
-    return result;
+    // Always return success because the IR has been modified (blocks split,
+    // regions inlined, ops erased, etc.). The MLIR pattern rewriter contract
+    // requires that if a pattern modifies IR, it must return success(). Any
+    // errors from unsupported exit operations (e.g. goto) have already been
+    // reported via emitError and an unreachable terminator was placed as a
+    // placeholder.
+    return mlir::success();
   }
 
   mlir::LogicalResult


### PR DESCRIPTION
Fix patterns in CIRFlattenCFGPass that modify IR but return failure(), violating the MLIR greedy pattern rewriter contract. The contract requires that if a pattern modifies IR, it must return success().

- CIRCleanupScopeOpFlattening: always return success() since IR is modified (blocks split, regions inlined) before error paths
- Ternary op flattening: return success() instead of falling through after emitError, since splitBlock/createBlock already modified IR
- Use rewriter.moveOpBefore() instead of direct defOp->moveBefore() to properly notify the rewriter of IR mutations

Found by MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON.
Test: flatten-cleanup-scope-nyi.cir (a silly one since it's testing an error, but point still valid)