### PR TITLE
[BPF] Handle aliases in CodeGenModule::EmitExternalDeclaration. Fixes #192365

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5989,19 +5989,19 @@ void CodeGenModule::EmitExternalDeclaration(const DeclaratorDecl *D) {
     return;
 
   llvm::Constant *Addr = GetAddrOfGlobal(GD)->stripPointerCasts();
+  if (auto *GA = dyn_cast<llvm::GlobalAlias>(Addr)) {
+      DI->EmitGlobalAlias(GA, GD);
+      return;
+  }
   if (const auto *VD = dyn_cast<VarDecl>(D)) {
     if (auto *GV = dyn_cast<llvm::GlobalVariable>(Addr))
       DI->EmitExternalVariable(GV, VD);
-    else if (auto *GA = dyn_cast<llvm::GlobalAlias>(Addr))
-      DI->EmitGlobalAlias(GA, GD);
     else
       llvm_unreachable("Unexpected address for external variable");
   } else if (const auto *FD = dyn_cast<FunctionDecl>(D)) {
     if (auto *Fn = dyn_cast<llvm::Function>(Addr)) {
       if (!Fn->getSubprogram())
         DI->EmitFunctionDecl(GD, FD->getLocation(), FD->getType(), Fn);
-    } else if (auto *GA = dyn_cast<llvm::GlobalAlias>(Addr)) {
-      DI->EmitGlobalAlias(GA, GD);
     } else {
       llvm_unreachable("Unexpected address for external function");
     }

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5990,12 +5990,21 @@ void CodeGenModule::EmitExternalDeclaration(const DeclaratorDecl *D) {
 
   llvm::Constant *Addr = GetAddrOfGlobal(GD)->stripPointerCasts();
   if (const auto *VD = dyn_cast<VarDecl>(D)) {
-    DI->EmitExternalVariable(
-        cast<llvm::GlobalVariable>(Addr->stripPointerCasts()), VD);
+    if (auto *GV = dyn_cast<llvm::GlobalVariable>(Addr))
+      DI->EmitExternalVariable(GV, VD);
+    else if (auto *GA = dyn_cast<llvm::GlobalAlias>(Addr))
+      DI->EmitGlobalAlias(GA, GD);
+    else
+      llvm_unreachable("Unexpected address for external variable");
   } else if (const auto *FD = dyn_cast<FunctionDecl>(D)) {
-    llvm::Function *Fn = cast<llvm::Function>(Addr);
-    if (!Fn->getSubprogram())
-      DI->EmitFunctionDecl(GD, FD->getLocation(), FD->getType(), Fn);
+    if (auto *Fn = dyn_cast<llvm::Function>(Addr)) {
+      if (!Fn->getSubprogram())
+        DI->EmitFunctionDecl(GD, FD->getLocation(), FD->getType(), Fn);
+    } else if (auto *GA = dyn_cast<llvm::GlobalAlias>(Addr)) {
+      DI->EmitGlobalAlias(GA, GD);
+    } else {
+      llvm_unreachable("Unexpected address for external function");
+    }
   }
 }
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5994,17 +5994,12 @@ void CodeGenModule::EmitExternalDeclaration(const DeclaratorDecl *D) {
       return;
   }
   if (const auto *VD = dyn_cast<VarDecl>(D)) {
-    if (auto *GV = dyn_cast<llvm::GlobalVariable>(Addr))
-      DI->EmitExternalVariable(GV, VD);
-    else
-      llvm_unreachable("Unexpected address for external variable");
+    DI->EmitExternalVariable(
+        cast<llvm::GlobalVariable>(Addr->stripPointerCasts()), VD);
   } else if (const auto *FD = dyn_cast<FunctionDecl>(D)) {
-    if (auto *Fn = dyn_cast<llvm::Function>(Addr)) {
-      if (!Fn->getSubprogram())
-        DI->EmitFunctionDecl(GD, FD->getLocation(), FD->getType(), Fn);
-    } else {
-      llvm_unreachable("Unexpected address for external function");
-    }
+    llvm::Function *Fn = cast<llvm::Function>(Addr);
+    if (!Fn->getSubprogram())
+      DI->EmitFunctionDecl(GD, FD->getLocation(), FD->getType(), Fn);
   }
 }
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5990,8 +5990,8 @@ void CodeGenModule::EmitExternalDeclaration(const DeclaratorDecl *D) {
 
   llvm::Constant *Addr = GetAddrOfGlobal(GD)->stripPointerCasts();
   if (auto *GA = dyn_cast<llvm::GlobalAlias>(Addr)) {
-      DI->EmitGlobalAlias(GA, GD);
-      return;
+    DI->EmitGlobalAlias(GA, GD);
+    return;
   }
   if (const auto *VD = dyn_cast<VarDecl>(D)) {
     DI->EmitExternalVariable(

--- a/clang/test/CodeGenCXX/bpf-debug-info-alias.cpp
+++ b/clang/test/CodeGenCXX/bpf-debug-info-alias.cpp
@@ -1,9 +1,16 @@
 // RUN: %clang_cc1 -triple bpfel -emit-llvm -debug-info-kind=constructor %s -o - | FileCheck %s
 
 // CHECK: @_Z9__cat_op0v = alias void (), ptr @e
-// CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "__cat_op0", {{.*}} entity: ![[ENTITY:[0-9]+]]
-// CHECK: ![[ENTITY]] = !DISubprogram(name: "__cat_op0", linkageName: "_Z9__cat_op0v"
+// CHECK: @alias_var = alias i32, ptr @global_var
+// CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "__cat_op0", {{.*}} entity: ![[ENTITY:[0-9]+]]
+// CHECK-DAG: ![[ENTITY]] = {{.*}}!DISubprogram(name: "__cat_op0", linkageName: "_Z9__cat_op0v"
+// CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "alias_var", {{.*}} entity: ![[ENTITY2:[0-9]+]]
+// CHECK-DAG: ![[ENTITY2]] = {{.*}}!DIGlobalVariable(name: "global_var", {{.*}}
 
 extern "C" void e() {}
 void __attribute__((alias("e"))) __cat_op0();
 void r() { __cat_op0(); }
+
+int global_var;
+extern "C" int alias_var __attribute__((alias("global_var")));
+int use_alias() { return alias_var; }

--- a/clang/test/CodeGenCXX/bpf-debug-info-alias.cpp
+++ b/clang/test/CodeGenCXX/bpf-debug-info-alias.cpp
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -triple bpfel -emit-llvm -debug-info-kind=constructor %s -o - | FileCheck %s
+
+// CHECK: @_Z9__cat_op0v = alias void (), ptr @e
+// CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "__cat_op0", {{.*}} entity: ![[ENTITY:[0-9]+]]
+// CHECK: ![[ENTITY]] = !DISubprogram(name: "__cat_op0", linkageName: "_Z9__cat_op0v"
+
+extern "C" void e() {}
+void __attribute__((alias("e"))) __cat_op0();
+void r() { __cat_op0(); }


### PR DESCRIPTION
Adds handling of global aliases in CodeGenModule::EmitExternalDeclaration. This fixes a clang crash on some real code, see llvm#192365.