### PR TITLE
[DO NOT MERGE][clang-tidy] Deprecate `hicpp` checks [1/4]

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/StdExceptionBaseclassCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/StdExceptionBaseclassCheck.cpp
@@ -7,12 +7,29 @@
 //===----------------------------------------------------------------------===//
 
 #include "StdExceptionBaseclassCheck.h"
+#include "../utils/CheckUtils.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 
 using namespace clang::ast_matchers;
 
 namespace clang::tidy::bugprone {
+
+namespace {
+
+constexpr llvm::StringLiteral DeprecatedCheckName = "hicpp-exception-baseclass";
+constexpr llvm::StringLiteral CanonicalCheckName =
+    "bugprone-std-exception-baseclass";
+
+} // namespace
+
+StdExceptionBaseclassCheck::StdExceptionBaseclassCheck(
+    StringRef Name, ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context) {
+  if (Name == DeprecatedCheckName)
+    utils::diagDeprecatedCheckAlias(*this, *Context, DeprecatedCheckName,
+                                    CanonicalCheckName);
+}
 
 void StdExceptionBaseclassCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(

--- a/clang-tools-extra/clang-tidy/bugprone/StdExceptionBaseclassCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/StdExceptionBaseclassCheck.h
@@ -20,8 +20,7 @@ namespace clang::tidy::bugprone {
 /// https://clang.llvm.org/extra/clang-tidy/checks/bugprone/std-exception-baseclass.html
 class StdExceptionBaseclassCheck : public ClangTidyCheck {
 public:
-  StdExceptionBaseclassCheck(StringRef Name, ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {}
+  StdExceptionBaseclassCheck(StringRef Name, ClangTidyContext *Context);
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus;
   }

--- a/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "UnusedReturnValueCheck.h"
+#include "../utils/CheckUtils.h"
 #include "../utils/Matchers.h"
 #include "../utils/OptionsUtils.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
@@ -19,6 +20,11 @@ using namespace clang::ast_matchers::internal;
 namespace clang::tidy::bugprone {
 
 namespace {
+
+constexpr llvm::StringLiteral DeprecatedCheckName =
+    "hicpp-ignored-remove-result";
+constexpr llvm::StringLiteral CanonicalCheckName =
+    "bugprone-unused-return-value";
 
 // Matches functions that are instantiated from a class template member function
 // matching InnerMatcher. Functions not instantiated from a class template
@@ -145,7 +151,11 @@ UnusedReturnValueCheck::UnusedReturnValueCheck(StringRef Name,
                                             "^::std::errc$;"
                                             "^::std::expected$;"
                                             "^::boost::system::error_code$"))),
-      AllowCastToVoid(Options.get("AllowCastToVoid", false)) {}
+      AllowCastToVoid(Options.get("AllowCastToVoid", false)) {
+  if (Name == DeprecatedCheckName)
+    utils::diagDeprecatedCheckAlias(*this, *Context, DeprecatedCheckName,
+                                    CanonicalCheckName);
+}
 
 UnusedReturnValueCheck::UnusedReturnValueCheck(
     StringRef Name, ClangTidyContext *Context,

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/AvoidGotoCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/AvoidGotoCheck.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AvoidGotoCheck.h"
+#include "../utils/CheckUtils.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 
 using namespace clang::ast_matchers;
@@ -14,6 +15,10 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::cppcoreguidelines {
 
 namespace {
+constexpr llvm::StringLiteral DeprecatedCheckName = "hicpp-avoid-goto";
+constexpr llvm::StringLiteral CanonicalCheckName =
+    "cppcoreguidelines-avoid-goto";
+
 AST_MATCHER(GotoStmt, isForwardJumping) {
   return Node.getBeginLoc() < Node.getLabel()->getBeginLoc();
 }
@@ -25,7 +30,11 @@ AST_MATCHER(GotoStmt, isInMacro) {
 
 AvoidGotoCheck::AvoidGotoCheck(StringRef Name, ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
-      IgnoreMacros(Options.get("IgnoreMacros", false)) {}
+      IgnoreMacros(Options.get("IgnoreMacros", false)) {
+  if (Name == DeprecatedCheckName)
+    utils::diagDeprecatedCheckAlias(*this, *Context, DeprecatedCheckName,
+                                    CanonicalCheckName);
+}
 
 void AvoidGotoCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "IgnoreMacros", IgnoreMacros);

--- a/clang-tools-extra/clang-tidy/google/ExplicitConstructorCheck.cpp
+++ b/clang-tools-extra/clang-tidy/google/ExplicitConstructorCheck.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ExplicitConstructorCheck.h"
+#include "../utils/CheckUtils.h"
 #include "../utils/LexerUtils.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
@@ -15,6 +16,23 @@
 using namespace clang::ast_matchers;
 
 namespace clang::tidy::google {
+
+namespace {
+
+constexpr llvm::StringLiteral DeprecatedCheckName =
+    "hicpp-explicit-conversions";
+constexpr llvm::StringLiteral CanonicalCheckName =
+    "google-explicit-constructor";
+
+} // namespace
+
+ExplicitConstructorCheck::ExplicitConstructorCheck(StringRef Name,
+                                                   ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context) {
+  if (Name == DeprecatedCheckName)
+    utils::diagDeprecatedCheckAlias(*this, *Context, DeprecatedCheckName,
+                                    CanonicalCheckName);
+}
 
 void ExplicitConstructorCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(

--- a/clang-tools-extra/clang-tidy/google/ExplicitConstructorCheck.h
+++ b/clang-tools-extra/clang-tidy/google/ExplicitConstructorCheck.h
@@ -21,8 +21,7 @@ namespace clang::tidy::google {
 /// https://clang.llvm.org/extra/clang-tidy/checks/google/explicit-constructor.html
 class ExplicitConstructorCheck : public ClangTidyCheck {
 public:
-  ExplicitConstructorCheck(StringRef Name, ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {}
+  ExplicitConstructorCheck(StringRef Name, ClangTidyContext *Context);
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus;
   }

--- a/clang-tools-extra/clang-tidy/modernize/AvoidCArraysCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/AvoidCArraysCheck.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AvoidCArraysCheck.h"
+#include "../utils/CheckUtils.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
@@ -24,6 +25,9 @@ static const TargetType *getAs(const NodeType *Node) {
 }
 
 namespace {
+
+constexpr llvm::StringLiteral DeprecatedCheckName = "hicpp-avoid-c-arrays";
+constexpr llvm::StringLiteral CanonicalCheckName = "modernize-avoid-c-arrays";
 
 AST_MATCHER(TypeLoc, hasValidBeginLoc) { return Node.getBeginLoc().isValid(); }
 
@@ -85,7 +89,11 @@ AST_MATCHER(TypeLoc, isWithinImplicitTemplateInstantiation) {
 
 AvoidCArraysCheck::AvoidCArraysCheck(StringRef Name, ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
-      AllowStringArrays(Options.get("AllowStringArrays", false)) {}
+      AllowStringArrays(Options.get("AllowStringArrays", false)) {
+  if (Name == DeprecatedCheckName)
+    utils::diagDeprecatedCheckAlias(*this, *Context, DeprecatedCheckName,
+                                    CanonicalCheckName);
+}
 
 void AvoidCArraysCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "AllowStringArrays", AllowStringArrays);

--- a/clang-tools-extra/clang-tidy/modernize/DeprecatedHeadersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/DeprecatedHeadersCheck.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "DeprecatedHeadersCheck.h"
+#include "../utils/CheckUtils.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/PPCallbacks.h"
@@ -20,6 +21,10 @@ using IncludeMarker =
     clang::tidy::modernize::DeprecatedHeadersCheck::IncludeMarker;
 namespace clang::tidy::modernize {
 namespace {
+
+constexpr llvm::StringLiteral DeprecatedCheckName = "hicpp-deprecated-headers";
+constexpr llvm::StringLiteral CanonicalCheckName =
+    "modernize-deprecated-headers";
 
 class IncludeModernizePPCallbacks : public PPCallbacks {
 public:
@@ -77,7 +82,11 @@ public:
 DeprecatedHeadersCheck::DeprecatedHeadersCheck(StringRef Name,
                                                ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
-      CheckHeaderFile(Options.get("CheckHeaderFile", false)) {}
+      CheckHeaderFile(Options.get("CheckHeaderFile", false)) {
+  if (Name == DeprecatedCheckName)
+    utils::diagDeprecatedCheckAlias(*this, *Context, DeprecatedCheckName,
+                                    CanonicalCheckName);
+}
 
 void DeprecatedHeadersCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "CheckHeaderFile", CheckHeaderFile);

--- a/clang-tools-extra/clang-tidy/readability/BracesAroundStatementsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/BracesAroundStatementsCheck.cpp
@@ -8,6 +8,7 @@
 
 #include "BracesAroundStatementsCheck.h"
 #include "../utils/BracesAroundStatement.h"
+#include "../utils/CheckUtils.h"
 #include "../utils/LexerUtils.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
@@ -16,6 +17,15 @@
 using namespace clang::ast_matchers;
 
 namespace clang::tidy::readability {
+
+namespace {
+
+constexpr llvm::StringLiteral DeprecatedCheckName =
+    "hicpp-braces-around-statements";
+constexpr llvm::StringLiteral CanonicalCheckName =
+    "readability-braces-around-statements";
+
+} // namespace
 
 static tok::TokenKind getTokenKind(SourceLocation Loc, const SourceManager &SM,
                                    const LangOptions &LangOpts) {
@@ -52,7 +62,11 @@ BracesAroundStatementsCheck::BracesAroundStatementsCheck(
     StringRef Name, ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       // Always add braces by default.
-      ShortStatementLines(Options.get("ShortStatementLines", 0U)) {}
+      ShortStatementLines(Options.get("ShortStatementLines", 0U)) {
+  if (Name == DeprecatedCheckName)
+    utils::diagDeprecatedCheckAlias(*this, *Context, DeprecatedCheckName,
+                                    CanonicalCheckName);
+}
 
 void BracesAroundStatementsCheck::storeOptions(
     ClangTidyOptions::OptionMap &Opts) {

--- a/clang-tools-extra/clang-tidy/readability/FunctionSizeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/FunctionSizeCheck.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "FunctionSizeCheck.h"
+#include "../utils/CheckUtils.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "llvm/ADT/BitVector.h"
@@ -15,6 +16,9 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy::readability {
 namespace {
+
+constexpr llvm::StringLiteral DeprecatedCheckName = "hicpp-function-size";
+constexpr llvm::StringLiteral CanonicalCheckName = "readability-function-size";
 
 class FunctionASTVisitor : public RecursiveASTVisitor<FunctionASTVisitor> {
   using Base = RecursiveASTVisitor<FunctionASTVisitor>;
@@ -146,7 +150,11 @@ FunctionSizeCheck::FunctionSizeCheck(StringRef Name, ClangTidyContext *Context)
       VariableThreshold(
           Options.get("VariableThreshold", DefaultVariableThreshold)),
       CountMemberInitAsStmt(
-          Options.get("CountMemberInitAsStmt", DefaultCountMemberInitAsStmt)) {}
+          Options.get("CountMemberInitAsStmt", DefaultCountMemberInitAsStmt)) {
+  if (Name == DeprecatedCheckName)
+    utils::diagDeprecatedCheckAlias(*this, *Context, DeprecatedCheckName,
+                                    CanonicalCheckName);
+}
 
 void FunctionSizeCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "LineThreshold", LineThreshold);

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/std-exception-baseclass-hicpp-alias.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/std-exception-baseclass-hicpp-alias.cpp
@@ -1,0 +1,11 @@
+// RUN: %check_clang_tidy %s hicpp-exception-baseclass %t -- -- -fcxx-exceptions
+
+namespace std {
+class exception {};
+} // namespace std
+
+void f() {
+  throw 1;
+  // CHECK-MESSAGES: warning: 'hicpp-exception-baseclass' check is deprecated and will be removed in a future release; consider using 'bugprone-std-exception-baseclass' instead [clang-tidy-config]
+  // CHECK-MESSAGES: [[@LINE-2]]:9: warning: throwing an exception whose type 'int' is not derived from 'std::exception' [hicpp-exception-baseclass]
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/avoid-goto-hicpp-alias.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/avoid-goto-hicpp-alias.cpp
@@ -1,0 +1,9 @@
+// RUN: %check_clang_tidy %s hicpp-avoid-goto %t
+
+void f() {
+  goto Exit;
+  // CHECK-MESSAGES: warning: 'hicpp-avoid-goto' check is deprecated and will be removed in a future release; consider using 'cppcoreguidelines-avoid-goto' instead [clang-tidy-config]
+  // CHECK-MESSAGES: [[@LINE-2]]:3: warning: avoid using 'goto' for flow control [hicpp-avoid-goto]
+Exit:;
+  // CHECK-MESSAGES: [[@LINE-1]]:1: note: label defined here
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/google/explicit-constructor-hicpp-alias.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/explicit-constructor-hicpp-alias.cpp
@@ -1,0 +1,8 @@
+// RUN: %check_clang_tidy %s hicpp-explicit-conversions %t
+
+struct A {
+  A(int);
+  // CHECK-MESSAGES: warning: 'hicpp-explicit-conversions' check is deprecated and will be removed in a future release; consider using 'google-explicit-constructor' instead [clang-tidy-config]
+  // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: single-argument constructors must be marked explicit to avoid unintentional implicit conversions [hicpp-explicit-conversions]
+  // CHECK-FIXES: explicit A(int);
+};

--- a/clang-tools-extra/test/clang-tidy/checkers/hicpp/ignored-remove-result.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/hicpp/ignored-remove-result.cpp
@@ -30,9 +30,11 @@ std::error_code errorFunc() {
 
 void warning() {
   std::remove(nullptr, nullptr, 1);
-  // CHECK-MESSAGES: [[@LINE-1]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
-  // CHECK-MESSAGES: [[@LINE-2]]:3: note: cast the expression to void to silence this warning
-  // CHECK-MESSAGES-NOCAST: [[@LINE-3]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
+  // CHECK-MESSAGES: warning: 'hicpp-ignored-remove-result' check is deprecated and will be removed in a future release; consider using 'bugprone-unused-return-value' instead [clang-tidy-config]
+  // CHECK-MESSAGES-NOCAST: warning: 'hicpp-ignored-remove-result' check is deprecated and will be removed in a future release; consider using 'bugprone-unused-return-value' instead [clang-tidy-config]
+  // CHECK-MESSAGES: [[@LINE-3]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
+  // CHECK-MESSAGES: [[@LINE-4]]:3: note: cast the expression to void to silence this warning
+  // CHECK-MESSAGES-NOCAST: [[@LINE-5]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
 
   std::remove_if(nullptr, nullptr, nullptr);
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/avoid-c-arrays-hicpp-alias.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/avoid-c-arrays-hicpp-alias.cpp
@@ -1,0 +1,5 @@
+// RUN: %check_clang_tidy -std=c++17-or-later %s hicpp-avoid-c-arrays %t
+
+int Values[4];
+// CHECK-MESSAGES: warning: 'hicpp-avoid-c-arrays' check is deprecated and will be removed in a future release; consider using 'modernize-avoid-c-arrays' instead [clang-tidy-config]
+// CHECK-MESSAGES: :[[@LINE-2]]:1: warning: do not declare C-style arrays, use 'std::array' instead [hicpp-avoid-c-arrays]

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/deprecated-headers-hicpp-alias.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/deprecated-headers-hicpp-alias.cpp
@@ -1,0 +1,6 @@
+// RUN: %check_clang_tidy -std=c++98 %s hicpp-deprecated-headers %t -- -extra-arg-before=-isystem%S/Inputs/deprecated-headers
+
+#include <assert.h>
+// CHECK-MESSAGES: warning: 'hicpp-deprecated-headers' check is deprecated and will be removed in a future release; consider using 'modernize-deprecated-headers' instead [clang-tidy-config]
+// CHECK-MESSAGES: :[[@LINE-2]]:10: warning: inclusion of deprecated C++ header 'assert.h'; consider using 'cassert' instead [hicpp-deprecated-headers]
+// CHECK-FIXES: #include <cassert>

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/braces-around-statements-hicpp-alias.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/braces-around-statements-hicpp-alias.cpp
@@ -1,0 +1,13 @@
+// RUN: %check_clang_tidy %s hicpp-braces-around-statements %t
+
+void f();
+bool b();
+
+void test() {
+if (b())
+  f();
+// CHECK-MESSAGES: warning: 'hicpp-braces-around-statements' check is deprecated and will be removed in a future release; consider using 'readability-braces-around-statements' instead [clang-tidy-config]
+// CHECK-MESSAGES: :[[@LINE-3]]:9: warning: statement should be inside braces [hicpp-braces-around-statements]
+// CHECK-FIXES: if (b()) {
+// CHECK-FIXES: }
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/function-size-hicpp-alias.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/function-size-hicpp-alias.cpp
@@ -1,0 +1,13 @@
+// RUN: %check_clang_tidy %s hicpp-function-size %t -- \
+// RUN:   -config='{CheckOptions: { \
+// RUN:     hicpp-function-size.StatementThreshold: 0, \
+// RUN:     hicpp-function-size.BranchThreshold: 100, \
+// RUN:     hicpp-function-size.ParameterThreshold: 100, \
+// RUN:     hicpp-function-size.NestingThreshold: 100, \
+// RUN:     hicpp-function-size.VariableThreshold: 100 \
+// RUN:   }}'
+
+void f() { ; }
+// CHECK-MESSAGES: warning: 'hicpp-function-size' check is deprecated and will be removed in a future release; consider using 'readability-function-size' instead [clang-tidy-config]
+// CHECK-MESSAGES: :[[@LINE-2]]:6: warning: function 'f' exceeds recommended size/complexity thresholds [hicpp-function-size]
+// CHECK-MESSAGES: :[[@LINE-3]]:6: note: 1 statements (threshold 0)


### PR DESCRIPTION
This is still an ongoing draft. We may not actually going this way (please see https://github.com/llvm/llvm-project/issues/183462#issuecomment-4254659231).