### PR TITLE
[mlir][LLVMIR] Extend FP array-splat constant lowering

### DIFF
--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -658,7 +658,6 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
         return llvm::ConstantAggregateZero::get(arrayType);
       }
       if (llvm::ConstantDataSequential::isElementTypeCompatible(elementType)) {
-        // TODO: Handle all compatible types. This code only handles integer.
         if (isa<llvm::IntegerType>(elementType)) {
           if (llvm::ConstantInt *ci = dyn_cast<llvm::ConstantInt>(child)) {
             if (ci->getBitWidth() == 8) {
@@ -680,6 +679,26 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
               SmallVector<int64_t> constants(numElements, ci->getZExtValue());
               return llvm::ConstantDataArray::get(elementType->getContext(),
                                                   constants);
+            }
+          }
+        }
+        if (elementType->isFloatingPointTy()) {
+          if (llvm::ConstantFP *cfp = dyn_cast<llvm::ConstantFP>(child)) {
+            APInt bitPattern = cfp->getValueAPF().bitcastToAPInt();
+            uint64_t value = bitPattern.getZExtValue();
+            // TODO: This code only handles 16, 32, and 64 bit floats. Handle
+            // all compatible types, fp8, fp4, etc.
+            if (bitPattern.getBitWidth() == 16) {
+              SmallVector<uint16_t> constants(numElements, value);
+              return llvm::ConstantDataArray::getFP(elementType, constants);
+            }
+            if (bitPattern.getBitWidth() == 32) {
+              SmallVector<uint32_t> constants(numElements, value);
+              return llvm::ConstantDataArray::getFP(elementType, constants);
+            }
+            if (bitPattern.getBitWidth() == 64) {
+              SmallVector<uint64_t> constants(numElements, value);
+              return llvm::ConstantDataArray::getFP(elementType, constants);
             }
           }
         }

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -33,6 +33,30 @@ llvm.mlir.global internal @float_global(0.0: f32) : f32
 // CHECK: @float_global_array = internal global [1 x float] [float -5.000000e+00]
 llvm.mlir.global internal @float_global_array(dense<[-5.0]> : vector<1xf32>) : !llvm.array<1 x f32>
 
+// CHECK: @splat_float_global_array = internal global [4 x float] [float 4.200000e+01, float 4.200000e+01, float 4.200000e+01, float 4.200000e+01]
+llvm.mlir.global internal @splat_float_global_array(dense<42.0> : tensor<4xf32>) : !llvm.array<4 x f32>
+
+// CHECK: @splat_double_global_array = internal global [3 x double] [double 4.200000e+01, double 4.200000e+01, double 4.200000e+01]
+llvm.mlir.global internal @splat_double_global_array(dense<42.0> : tensor<3xf64>) : !llvm.array<3 x f64>
+
+// CHECK: @splat_neg_float_global_array = internal global [4 x float] [float -1.350000e+01, float -1.350000e+01, float -1.350000e+01, float -1.350000e+01]
+llvm.mlir.global internal @splat_neg_float_global_array(dense<-13.5> : tensor<4xf32>) : !llvm.array<4 x f32>
+
+// CHECK: @splat_neg_double_global_array = internal global [3 x double] [double -1.350000e+01, double -1.350000e+01, double -1.350000e+01]
+llvm.mlir.global internal @splat_neg_double_global_array(dense<-13.5> : tensor<3xf64>) : !llvm.array<3 x f64>
+
+// CHECK: @splat_half_global_array = internal global [4 x half] [half 0xH5140, half 0xH5140, half 0xH5140, half 0xH5140]
+llvm.mlir.global internal @splat_half_global_array(dense<42.0> : tensor<4xf16>) : !llvm.array<4 x f16>
+
+// CHECK: @splat_bfloat_global_array = internal global [3 x bfloat] [bfloat 0xR4228, bfloat 0xR4228, bfloat 0xR4228]
+llvm.mlir.global internal @splat_bfloat_global_array(dense<42.0> : tensor<3xbf16>) : !llvm.array<3 x bf16>
+
+// CHECK: @splat_neg_half_global_array = internal global [4 x half] [half 0xHCAC0, half 0xHCAC0, half 0xHCAC0, half 0xHCAC0]
+llvm.mlir.global internal @splat_neg_half_global_array(dense<-13.5> : tensor<4xf16>) : !llvm.array<4 x f16>
+
+// CHECK: @splat_neg_bfloat_global_array = internal global [3 x bfloat] [bfloat 0xRC158, bfloat 0xRC158, bfloat 0xRC158]
+llvm.mlir.global internal @splat_neg_bfloat_global_array(dense<-13.5> : tensor<3xbf16>) : !llvm.array<3 x bf16>
+
 // CHECK: @string_const = internal constant [6 x i8] c"foobar"
 llvm.mlir.global internal constant @string_const("foobar") : !llvm.array<6 x i8>
 


### PR DESCRIPTION
Handle floating-point compatible array splats in the ConstantDataArray path using bit-pattern based ConstantDataArray::getFP construction, instead of only specializing integer element types.