### PR TITLE
[C++20] [Modules] Write comments in C++20 modules' module file

### DIFF
--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -3530,12 +3530,6 @@ void ASTWriter::WriteComments(ASTContext &Context) {
   if (!PP->getPreprocessorOpts().WriteCommentListToPCH)
     return;
 
-  // Don't write comments to BMI to reduce the size of BMI.
-  // If language services (e.g., clangd) want such abilities,
-  // we can offer a special option then.
-  if (isWritingStdCXXNamedModules())
-    return;
-
   RecordData Record;
   for (const auto &FO : Context.Comments.OrderedComments) {
     for (const auto &OC : FO.second) {

--- a/clang/unittests/Serialization/CMakeLists.txt
+++ b/clang/unittests/Serialization/CMakeLists.txt
@@ -3,7 +3,7 @@ add_clang_unittest(SerializationTests
   InMemoryModuleCacheTest.cpp
   ModuleCacheTest.cpp
   NamespaceLookupTest.cpp
-  NoCommentsTest.cpp
+  CommentsTest.cpp
   PreambleInNamedModulesTest.cpp
   LoadSpecLazilyTest.cpp
   SourceLocationEncodingTest.cpp

--- a/clang/unittests/Serialization/CommentsTest.cpp
+++ b/clang/unittests/Serialization/CommentsTest.cpp
@@ -1,4 +1,4 @@
-//===- unittests/Serialization/NoComments.cpp - CI tests -----===//
+//===- unittests/Serialization/Comments.cpp - CI tests -----===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -27,7 +27,7 @@ using namespace clang;
 
 namespace {
 
-class NoComments : public ::testing::Test {
+class Comments : public ::testing::Test {
   void SetUp() override {
     ASSERT_FALSE(
         sys::fs::createUniqueDirectory("modules-no-comments-test", TestDir));
@@ -54,7 +54,7 @@ public:
   }
 };
 
-TEST_F(NoComments, NonModulesTest) {
+TEST_F(Comments, NonModulesTest) {
   std::unique_ptr<ASTUnit> AST = tooling::buildASTFromCodeWithArgs(
       R"cpp(
 /// Any comments
@@ -76,7 +76,7 @@ void foo() {}
               "/// Any comments");
 }
 
-TEST_F(NoComments, ModulesTest) {
+TEST_F(Comments, ModulesTest) {
   addFile("Comments.cppm", R"cpp(
 export module Comments;
 
@@ -124,7 +124,7 @@ import Comments;
   EXPECT_TRUE(foo);
 
   const RawComment *RC = getCompletionComment(Ctx, foo);
-  EXPECT_FALSE(RC);
+  EXPECT_TRUE(RC);
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Previously we avoid writing the comments in C++20 modules' module file.

But this prevents LSP tools to read the comments in it. Although we thought to add a new option for it and ask LSP to use the new option, the cost of comments seems to be low and new option raises complexity, so I prefer to write comments in C++20 modules' module file by default now.