### PR TITLE
[MC] Fix .prefalign oscillation when body contains a .p2align

### DIFF
--- a/llvm/lib/MC/MCAssembler.cpp
+++ b/llvm/lib/MC/MCAssembler.cpp
@@ -811,16 +811,15 @@ void MCAssembler::relaxPrefAlign(MCFragment &F) {
   const MCFragment *EndFrag = End.getFragment();
   if (EndFrag->getLayoutOrder() <= F.getLayoutOrder())
     return;
-  uint64_t BodySize = 0;
-  for (const MCFragment *Cur = F.getNext();; Cur = Cur->getNext()) {
-    if (Cur == EndFrag) {
-      BodySize += End.getOffset();
-      break;
-    }
+  uint64_t BodySize = End.getOffset();
+  for (auto *Cur = F.getNext(); Cur != EndFrag; Cur = Cur->getNext())
     BodySize += computeFragmentSize(*Cur);
-  }
+  // Intervening FT_Align's padding depends on where this prefalign lands, so
+  // `BodySize` depends on this prefalign's own padding and may not reach a
+  // fixed point. Break the cycle with a monotone value.
   Align NewAlign =
       std::min(Align(llvm::bit_ceil(BodySize)), F.getPrefAlignPreferred());
+  NewAlign = std::max(NewAlign, F.getPrefAlignComputed());
   F.setPrefAlignComputed(NewAlign);
   uint64_t NewPadSize = offsetToAlignment(RawStart, NewAlign);
   F.VarContentStart = F.getFixedSize();

--- a/llvm/test/MC/ELF/prefalign-internal-align.s
+++ b/llvm/test/MC/ELF/prefalign-internal-align.s
@@ -1,0 +1,48 @@
+# REQUIRES: asserts
+## Test that an internal alignment inside a .prefalign body does not cause oscillation.
+
+# RUN: llvm-mc -filetype=obj -triple x86_64 --stats %s -o %t 2>&1 | FileCheck %s --check-prefix=STATS
+# RUN: llvm-readelf -s %t | FileCheck %s
+
+## Converges in a small fixed number of layout passes.
+# STATS: 3 assembler - Number of assembler layout and relaxation steps
+
+# CHECK: {{0*}}20 0 NOTYPE LOCAL DEFAULT 2 c
+# CHECK: {{0*}}40 0 NOTYPE LOCAL DEFAULT 2 e
+# CHECK:  {{0*}}8 0 NOTYPE LOCAL DEFAULT 3 c2
+# CHECK:  {{0*}}c 0 NOTYPE LOCAL DEFAULT 3 e2
+
+.file 0 "." "t.c"
+.text
+.byte 0
+.loc 0 1 0
+.prefalign 5, .Lend0, nop
+c:
+.loc 0 2 0
+.p2align 5
+jmp c
+.Lend0:
+
+.prefalign 5, .Lend1, nop
+e:
+.loc 0 3 0
+.p2align 5
+jmp e
+.Lend1:
+
+.section .text.smaller,"ax",@progbits
+.byte 0
+.loc 0 4 0
+.prefalign 5, .Lend2, nop
+c2:
+.loc 0 5 0
+.p2align 2
+jmp c2
+.Lend2:
+
+.prefalign 5, .Lend3, nop
+e2:
+.loc 0 6 0
+.p2align 2
+jmp e2
+.Lend3:


### PR DESCRIPTION
The intervening FT_Align's padding depends on where this prefalign
lands, so body_size can oscillate across relaxOnce iterations.  When a
downstream section reacts (e.g. .debug_line DWARF deltas crossing a
special-opcode boundary), the outer loop never terminates -- originally
reported as a hang with -O1 -g on
https://github.com/llvm/llvm-project/pull/184032#issuecomment-4235991852

```
static int a;
void b() {}
int c() { for (;;) { int d; for (; a;) return 0; } }
void e() { for (;;) ; }
```

X86 sets both the preferred function alignment
and the loop-header alignment to 16 (X86ISelLowering setPrefLoopAlignment),
so any function containing a small loop whose first BB gets .p2align 4
lands a same-alignment .p2align inside the prefalign body.

Fix: never decrease ComputedAlign across iterations.