### PR TITLE
[WebAssembly] Explicitly set `getCmpLibcallReturnType` to i32

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.h
@@ -29,6 +29,11 @@ public:
   MVT getPointerTy(const DataLayout &DL, uint32_t AS = 0) const override;
   MVT getPointerMemTy(const DataLayout &DL, uint32_t AS = 0) const override;
 
+  MVT::SimpleValueType getCmpLibcallReturnType() const override {
+    // i32 may be more efficient than the default word size for wasm64 targets
+    return MVT::i32;
+  }
+
 private:
   /// Keep a pointer to the WebAssemblySubtarget around so that we can make the
   /// right decision when generating code for different targets.


### PR DESCRIPTION
LLVM's default for `getCmpLibcallReturnType` is currently set to `i32`,
but this is not exactly accurate: the default in GCC is an integer of
word size. This means that on wasm64 targets, runtime libraries that are
assuming word size are incorrect and instead need to be using a 32-bit
integer.

The unintentional i32 default is actually a reasonable choice for Wasm
because it may be slightly cheaper to operate on when running 64-bit
wasm on 32-bit hosts, and there is no advantage to using a larger
integer (the result of comparisons need only be able to represent three
possible values). Thus, make the `i32` explicit.

GCC does not support wasm64 so there is no compatibility concern at the
current time. If added, it would be reasonable for `i32` to be used
there as well.