### PR TITLE
[GitHub][RISCV] Restrict backend:RISC-V labelling to Clang and LLVM

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -1084,10 +1084,14 @@ backend:MIPS:
 backend:RISC-V:
   - changed-files:
     - any-glob-to-any-file:
-      - '**/*riscv*'
-      - '**/*RISCV*'
-      - '**/*riscv*/**'
-      - '**/*RISCV*/**'
+      - 'llvm/**/*riscv*'
+      - 'llvm/**/*RISCV*'
+      - 'llvm/**/*riscv*/**'
+      - 'llvm/**/*RISCV*/**'
+      - 'clang/**/*riscv*'
+      - 'clang/**/*RISCV*'
+      - 'clang/**/*riscv*/**'
+      - 'clang/**/*RISCV*/**'
 
 backend:Xtensa:
   - changed-files:


### PR DESCRIPTION
The auto-labeller currently assigns the `backend:RISC-V` label to any PR that touches any file with "RISCV" in its path. This means that if you're subscribed to that label you get a lot of notifications about other projects like LLDB, libc etc. which often add test cases for RISC-V. Whilst they have something to do with RISC-V they aren't specific to the RISC-V backend per se, and I'm not sure if RISC-V backend developers particularly need visibility on them.

Other backends like AArch64 and X86 only label PRs that touch LLVM or Clang. This PR proposes to change RISC-V to follow suit, and help reduce the number of non-backend relevant notifications.
