### PR TITLE
[lldb][Windows] Invalidate cached register values on thread stop

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
@@ -37,9 +37,6 @@ public:
   // Determine the architecture of the thread given by its ID.
   static llvm::Expected<ArchSpec> DetermineArchitecture(lldb::tid_t tid);
 
-  // Invalidates cached values in register context data structures
-  virtual void InvalidateAllRegisters(){}
-
   struct SyscallData {
     /// The syscall instruction. If the architecture uses software
     /// single-stepping, the instruction should also be followed by a trap to

--- a/lldb/source/Plugins/Process/Utility/NativeRegisterContextRegisterInfo.h
+++ b/lldb/source/Plugins/Process/Utility/NativeRegisterContextRegisterInfo.h
@@ -33,6 +33,9 @@ public:
 
   const RegisterInfoInterface &GetRegisterInfoInterface() const;
 
+  // Invalidate cached values in register context data structures.
+  virtual void InvalidateAllRegisters() {}
+
 protected:
   std::unique_ptr<RegisterInfoInterface> m_register_info_interface_up;
 };

--- a/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows.h
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows.h
@@ -28,9 +28,6 @@ public:
   // Explicitly defining it ensures the class remains constructible.
   NativeRegisterContextWindows() {}
 
-  // Invalidate cached values in register context data structures.
-  virtual void InvalidateAllRegisters() {}
-
 protected:
   lldb::thread_t GetThreadHandle() const;
 };

--- a/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows.h
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows.h
@@ -28,6 +28,9 @@ public:
   // Explicitly defining it ensures the class remains constructible.
   NativeRegisterContextWindows() {}
 
+  // Invalidate cached values in register context data structures.
+  virtual void InvalidateAllRegisters() {}
+
 protected:
   lldb::thread_t GetThreadHandle() const;
 };

--- a/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.cpp
@@ -38,6 +38,9 @@ Status NativeThreadWindows::DoStop() {
     if (previous_suspend_count == (DWORD)-1)
       return Status(::GetLastError(), eErrorTypeWin32);
 
+    // Invalidate cached register values on every stop.
+    GetRegisterContext().InvalidateAllRegisters();
+
     m_state = eStateStopped;
   }
   return Status();


### PR DESCRIPTION
Invalidate cached values in register context data structures on every thread stop.

_NativeRegisterContextRegisterInfo::InvalidateAllRegisters_ performs no operation by default. Subclasses may override it to clear cached values within their register context data structures whenever a thread stops.

This change intends to set up the necessary infrastructure to support caching of the thread context in _NativeRegisterContextWindows_arm64_, which will improve read performance. Currently, the thread context is retrieved for every read or write operation.