### PR TITLE
[OpenMP] Fix convention of SPIRV outline functions

### DIFF
--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -608,6 +608,12 @@ static llvm::Function *emitOutlinedFunctionPrologue(
       llvm::Function::Create(FuncLLVMTy, llvm::GlobalValue::InternalLinkage,
                              FO.FunctionName, &CGM.getModule());
   CGM.SetInternalFunctionAttributes(CD, F, FuncInfo);
+
+  // Adjust the calling convention for SPIR-V targets to avoid mismatches
+  // between callee and caller.
+  if (CGM.getTriple().isSPIRV() && !FO.IsDeviceKernel)
+    F->setCallingConv(llvm::CallingConv::SPIR_FUNC);
+
   if (CD->isNothrow())
     F->setDoesNotThrow();
   F->setDoesNotRecurse();

--- a/clang/test/OpenMP/metadirective_device_arch_codegen.cpp
+++ b/clang/test/OpenMP/metadirective_device_arch_codegen.cpp
@@ -53,14 +53,13 @@ int metadirective1() {
 // CHECK: ret void
 
 
-// CHECK: define internal void @[[METADIRECTIVE]]_omp_outlined
+// CHECK: define internal {{(spir_func )?}}void @[[METADIRECTIVE]]_omp_outlined
 // CHECK: entry:
 // CHECK: call{{.*}} void @__kmpc_distribute_static_init
 // CHECK: omp.loop.exit:
 // CHECK: call{{.*}} void @__kmpc_distribute_static_fini
 
-
-// CHECK: define internal void @[[METADIRECTIVE]]_omp_outlined_omp_outlined
+// CHECK: define internal {{(spir_func )?}}void @[[METADIRECTIVE]]_omp_outlined_omp_outlined
 // CHECK: entry:
 // CHECK: call{{.*}} void @__kmpc_for_static_init_4
 // CHECK: omp.inner.for.body:

--- a/offload/test/offloading/ompx_coords.c
+++ b/offload/test/offloading/ompx_coords.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compileopt-run-and-check-generic
 //
 // REQUIRES: gpu
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <ompx.h>


### PR DESCRIPTION
When creating an outline function for device code we're not setting the right calling convention when the target is SPIRV. This results in the calls to the function to be removed by the InstCombine pass as it thinks is not callable.