### PR TITLE
[flang] Handle ub.poison in lowering

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/flang/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -48,5 +48,7 @@ add_flang_library(FIRCodeGen
   MLIRBuiltinToLLVMIRTranslation
   MLIRLLVMToLLVMIRTranslation
   MLIRTargetLLVMIRExport
+  MLIRUBDialect
+  MLIRUBToLLVM
   MLIRVectorToLLVM
 )

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -47,6 +47,7 @@
 #include "mlir/Conversion/MathToNVVM/MathToNVVM.h"
 #include "mlir/Conversion/MathToROCDL/MathToROCDL.h"
 #include "mlir/Conversion/OpenMPToLLVM/ConvertOpenMPToLLVM.h"
+#include "mlir/Conversion/UBToLLVM/UBToLLVM.h"
 #include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/DLTI/DLTI.h"
@@ -4677,6 +4678,7 @@ public:
     mlir::populateComplexToLLVMConversionPatterns(typeConverter, pattern);
     mlir::index::populateIndexToLLVMConversionPatterns(typeConverter, pattern);
     mlir::populateVectorToLLVMConversionPatterns(typeConverter, pattern);
+    mlir::ub::populateUBToLLVMConversionPatterns(typeConverter, pattern);
 
     // Flang specific overloads for OpenMP operations, to allow for special
     // handling of things like Box types.

--- a/flang/test/Lower/PowerPC/ppc-vec-convert.f90
+++ b/flang/test/Lower/PowerPC/ppc-vec-convert.f90
@@ -1,5 +1,5 @@
-! RUN: %flang_fc1 -flang-experimental-hlfir -triple powerpc64le-unknown-unknown -emit-llvm %s -o - | FileCheck --check-prefixes="LLVMIR","LLVMIR-LE" %s
-! RUN: %flang_fc1 -flang-experimental-hlfir -triple powerpc64-unknown-unknown -emit-llvm %s -o - | FileCheck --check-prefixes="LLVMIR","LLVMIR-BE" %s
+! RUN: %flang_fc1 -triple powerpc64le-unknown-unknown -emit-llvm %s -o - | FileCheck --check-prefixes="LLVMIR","LLVMIR-LE" %s
+! RUN: %flang_fc1 -triple powerpc64-unknown-unknown -emit-llvm %s -o - | FileCheck --check-prefixes="LLVMIR","LLVMIR-BE" %s
 ! REQUIRES: target=powerpc{{.*}}
 
 !---------
@@ -1318,7 +1318,7 @@ subroutine vec_cvf_test_r4r8(arg1)
 ! LLVMIR: %[[arg:.*]] = load <2 x double>, ptr %{{.*}}, align 16
 ! LLVMIR: %[[call:.*]] = call contract <4 x float> @llvm.ppc.vsx.xvcvdpsp(<2 x double> %[[arg]])
 ! LLVMIR-LE: %[[b:.*]] = bitcast <4 x float> %[[call]] to <16 x i8>
-! LLVMIR-LE: %[[sh:.*]] = shufflevector <16 x i8> %[[b]], <16 x i8> %[[b]], <16 x i32> <i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 12, i32 13, i32 14, i32 15, i32 8, i32 9, i32 10, i32 11>
+! LLVMIR-LE: %[[sh:.*]] = shufflevector <16 x i8> %[[b]], <16 x i8> poison, <16 x i32> <i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 12, i32 13, i32 14, i32 15, i32 8, i32 9, i32 10, i32 11>
 ! LLVMIR-LE: %[[r:.*]] = bitcast <16 x i8> %[[sh]] to <4 x float>
 ! LLVMIR-LE: store <4 x float> %[[r]], ptr %{{.*}}, align 16
 ! LLVMIR-BE: store <4 x float> %[[call]], ptr %{{.*}}, align 16
@@ -1332,7 +1332,7 @@ subroutine vec_cvf_test_r8r4(arg1)
 
 ! LLVMIR: %[[arg:.*]] = load <4 x float>, ptr %{{.*}}, align 16
 ! LLVMIR-LE: %[[bfi:.*]] = bitcast <4 x float> %[[arg]] to <16 x i8>
-! LLVMIR-LE: %[[sh:.*]] = shufflevector <16 x i8> %[[bfi]], <16 x i8> %[[bfi]], <16 x i32> <i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 12, i32 13, i32 14, i32 15, i32 8, i32 9, i32 10, i32 11>
+! LLVMIR-LE: %[[sh:.*]] = shufflevector <16 x i8> %[[bfi]], <16 x i8> poison, <16 x i32> <i32 4, i32 5, i32 6, i32 7, i32 0, i32 1, i32 2, i32 3, i32 12, i32 13, i32 14, i32 15, i32 8, i32 9, i32 10, i32 11>
 ! LLVMIR-LE: %[[bif:.*]] = bitcast <16 x i8> %[[sh]] to <4 x float>
 ! LLVMIR-LE: %[[r:.*]] = call contract <2 x double> @llvm.ppc.vsx.xvcvspdp(<4 x float> %[[bif]])
 ! LLVMIR-LE: store <2 x double> %[[r]], ptr %{{.*}}, align 16

--- a/flang/test/Lower/PowerPC/ppc-vec-load-elem-order.f90
+++ b/flang/test/Lower/PowerPC/ppc-vec-load-elem-order.f90
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -flang-experimental-hlfir -emit-llvm %s -fno-ppc-native-vector-element-order -triple ppc64le-unknown-linux -o - | FileCheck --check-prefixes="LLVMIR" %s
+! RUN: %flang_fc1 -emit-llvm %s -fno-ppc-native-vector-element-order -triple ppc64le-unknown-linux -o - | FileCheck --check-prefixes="LLVMIR" %s
 ! REQUIRES: target=powerpc{{.*}}
 
 !-------------------
@@ -15,7 +15,7 @@ subroutine vec_ld_testi8(arg1, arg2, res)
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i8 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = call <4 x i32> @llvm.ppc.altivec.lvx(ptr %[[addr]])
 ! LLVMIR: %[[bc:.*]] = bitcast <4 x i32> %[[ld]] to <16 x i8>
-! LLVMIR: %[[shflv:.*]] = shufflevector <16 x i8> %[[bc]], <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <16 x i8> %[[bc]], <16 x i8> poison, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <16 x i8> %[[shflv]], ptr %2, align 16
 end subroutine vec_ld_testi8
 
@@ -29,7 +29,7 @@ subroutine vec_ld_testi16(arg1, arg2, res)
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i16 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = call <4 x i32> @llvm.ppc.altivec.lvx(ptr %[[addr]])
 ! LLVMIR: %[[bc:.*]] = bitcast <4 x i32> %[[ld]] to <8 x i16>
-! LLVMIR: %[[shflv:.*]] = shufflevector <8 x i16> %[[bc]], <8 x i16> undef, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <8 x i16> %[[bc]], <8 x i16> poison, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <8 x i16> %[[shflv]], ptr %2, align 16
 end subroutine vec_ld_testi16
 
@@ -42,7 +42,7 @@ subroutine vec_ld_testi32(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i32, ptr %0, align 4
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i32 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = call <4 x i32> @llvm.ppc.altivec.lvx(ptr %[[addr]])
-! LLVMIR: %[[shflv:.*]] = shufflevector <4 x i32> %[[ld]], <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <4 x i32> %[[ld]], <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x i32> %[[shflv]], ptr %2, align 16
 end subroutine vec_ld_testi32
 
@@ -57,7 +57,7 @@ subroutine vec_ld_testf32(arg1, arg2, res)
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i32 %[[i4]]
 ! LLVMIR: %[[ld:.*]] = call <4 x i32> @llvm.ppc.altivec.lvx(ptr %[[addr]])
 ! LLVMIR: %[[bc:.*]] = bitcast <4 x i32> %[[ld]] to <4 x float>
-! LLVMIR: %[[shflv:.*]] = shufflevector <4 x float> %[[bc]], <4 x float> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <4 x float> %[[bc]], <4 x float> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x float> %[[shflv]], ptr %2, align 16
 end subroutine vec_ld_testf32
 
@@ -70,7 +70,7 @@ subroutine vec_ld_testu32(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i8, ptr %0, align 1
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i8 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = call <4 x i32> @llvm.ppc.altivec.lvx(ptr %[[addr]])
-! LLVMIR: %[[shflv:.*]] = shufflevector <4 x i32> %[[ld]], <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <4 x i32> %[[ld]], <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x i32> %[[shflv]], ptr %2, align 16
 end subroutine vec_ld_testu32
 
@@ -84,7 +84,7 @@ subroutine vec_ld_testi32a(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i32, ptr %0, align 4
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i32 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = call <4 x i32> @llvm.ppc.altivec.lvx(ptr %[[addr]])
-! LLVMIR: %[[shflv:.*]] = shufflevector <4 x i32> %[[ld]], <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <4 x i32> %[[ld]], <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x i32> %[[shflv]], ptr %2, align 16
 end subroutine vec_ld_testi32a
 
@@ -100,7 +100,7 @@ subroutine vec_ld_testf32av(arg1, arg2, res)
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i32 %[[i4]]
 ! LLVMIR: %[[ld:.*]] = call <4 x i32> @llvm.ppc.altivec.lvx(ptr %[[addr]])
 ! LLVMIR: %[[bc:.*]] = bitcast <4 x i32> %[[ld]] to <4 x float>
-! LLVMIR: %[[shflv:.*]] = shufflevector <4 x float> %[[bc]], <4 x float> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <4 x float> %[[bc]], <4 x float> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x float> %[[shflv]], ptr %2, align 16
 end subroutine vec_ld_testf32av
 
@@ -115,7 +115,7 @@ subroutine vec_ld_testi32s(arg1, arg2, res)
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i32 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = call <4 x i32> @llvm.ppc.altivec.lvx(ptr %[[addr]])
 ! LLVMIR: %[[bc:.*]] = bitcast <4 x i32> %[[ld]] to <4 x float>
-! LLVMIR: %[[shflv:.*]] = shufflevector <4 x float> %[[bc]], <4 x float> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <4 x float> %[[bc]], <4 x float> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x float> %[[shflv]], ptr %2, align 16
 end subroutine vec_ld_testi32s
 
@@ -133,7 +133,7 @@ subroutine vec_lde_testi8s(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i8, ptr %0, align 1
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i8 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = call <16 x i8> @llvm.ppc.altivec.lvebx(ptr %[[addr]])
-! LLVMIR: %[[shflv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> poison, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <16 x i8> %[[shflv]], ptr %2, align 16
 end subroutine vec_lde_testi8s
 
@@ -147,7 +147,7 @@ subroutine vec_lde_testi16a(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i16, ptr %0, align 2
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i16 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = call <8 x i16> @llvm.ppc.altivec.lvehx(ptr %[[addr]])
-! LLVMIR: %[[shflv:.*]] = shufflevector <8 x i16> %[[ld]], <8 x i16> undef, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <8 x i16> %[[ld]], <8 x i16> poison, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <8 x i16> %[[shflv]], ptr %2, align 16
 end subroutine vec_lde_testi16a
 
@@ -161,7 +161,7 @@ subroutine vec_lde_testi32a(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i32, ptr %0, align 4
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i32 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = call <4 x i32> @llvm.ppc.altivec.lvewx(ptr %[[addr]])
-! LLVMIR: %[[shflv:.*]] = shufflevector <4 x i32> %[[ld]], <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <4 x i32> %[[ld]], <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x i32> %[[shflv]], ptr %2, align 16
 end subroutine vec_lde_testi32a
 
@@ -176,7 +176,7 @@ subroutine vec_lde_testf32a(arg1, arg2, res)
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i64 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = call <4 x i32> @llvm.ppc.altivec.lvewx(ptr %[[addr]])
 ! LLVMIR: %[[bc:.*]] = bitcast <4 x i32> %[[ld]] to <4 x float>
-! LLVMIR: %[[shflv:.*]] = shufflevector <4 x float> %[[bc]], <4 x float> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <4 x float> %[[bc]], <4 x float> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x float> %[[shflv]], ptr %2, align 16
 end subroutine vec_lde_testf32a
 
@@ -398,7 +398,7 @@ subroutine vec_xl_testi8a(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i8, ptr %0, align 1
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i8 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = load <16 x i8>, ptr %[[addr]], align 1
-! LLVMIR: %[[shflv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> poison, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <16 x i8> %[[shflv]], ptr %2, align 16
 end subroutine vec_xl_testi8a
 
@@ -412,7 +412,7 @@ subroutine vec_xl_testi16a(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i16, ptr %0, align 2
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i16 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = load <8 x i16>, ptr %[[addr]], align 1
-! LLVMIR: %[[shflv:.*]] = shufflevector <8 x i16> %[[ld]], <8 x i16> undef, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shflv:.*]] = shufflevector <8 x i16> %[[ld]], <8 x i16> poison, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <8 x i16> %[[shflv]], ptr %2, align 16
 end subroutine vec_xl_testi16a
 
@@ -485,7 +485,7 @@ subroutine vec_xl_be_testi8a(arg1, arg2, res)
 ! LLVMIR: %4 = load i8, ptr %0, align 1
 ! LLVMIR: %5 = getelementptr i8, ptr %1, i8 %4
 ! LLVMIR: %6 = load <16 x i8>, ptr %5, align 1
-! LLVMIR: %7 = shufflevector <16 x i8> %6, <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %7 = shufflevector <16 x i8> %6, <16 x i8> poison, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <16 x i8> %7, ptr %2, align 16
 end subroutine vec_xl_be_testi8a
 
@@ -499,7 +499,7 @@ subroutine vec_xl_be_testi16a(arg1, arg2, res)
 ! LLVMIR: %4 = load i16, ptr %0, align 2
 ! LLVMIR: %5 = getelementptr i8, ptr %1, i16 %4
 ! LLVMIR: %6 = load <8 x i16>, ptr %5, align 1
-! LLVMIR: %7 = shufflevector <8 x i16> %6, <8 x i16> undef, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %7 = shufflevector <8 x i16> %6, <8 x i16> poison, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <8 x i16> %7, ptr %2, align 16
 end subroutine vec_xl_be_testi16a
 
@@ -513,7 +513,7 @@ subroutine vec_xl_be_testi32a(arg1, arg2, res)
 ! LLVMIR: %4 = load i32, ptr %0, align 4
 ! LLVMIR: %5 = getelementptr i8, ptr %1, i32 %4
 ! LLVMIR: %6 = load <4 x i32>, ptr %5, align 1
-! LLVMIR: %7 = shufflevector <4 x i32> %6, <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %7 = shufflevector <4 x i32> %6, <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x i32> %7, ptr %2, align 16
 end subroutine vec_xl_be_testi32a
 
@@ -527,7 +527,7 @@ subroutine vec_xl_be_testi64a(arg1, arg2, res)
 ! LLVMIR: %4 = load i64, ptr %0, align 8
 ! LLVMIR: %5 = getelementptr i8, ptr %1, i64 %4
 ! LLVMIR: %6 = load <2 x i64>, ptr %5, align 1
-! LLVMIR: %7 = shufflevector <2 x i64> %6, <2 x i64> undef, <2 x i32> <i32 1, i32 0>
+! LLVMIR: %7 = shufflevector <2 x i64> %6, <2 x i64> poison, <2 x i32> <i32 1, i32 0>
 ! LLVMIR: store <2 x i64> %7, ptr %2, align 16
 end subroutine vec_xl_be_testi64a
 
@@ -541,7 +541,7 @@ subroutine vec_xl_be_testf32a(arg1, arg2, res)
 ! LLVMIR: %4 = load i16, ptr %0, align 2
 ! LLVMIR: %5 = getelementptr i8, ptr %1, i16 %4
 ! LLVMIR: %6 = load <4 x float>, ptr %5, align 1
-! LLVMIR: %7 = shufflevector <4 x float> %6, <4 x float> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %7 = shufflevector <4 x float> %6, <4 x float> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x float> %7, ptr %2, align 16
 end subroutine vec_xl_be_testf32a
 
@@ -555,7 +555,7 @@ subroutine vec_xl_be_testf64a(arg1, arg2, res)
 ! LLVMIR: %4 = load i64, ptr %0, align 8
 ! LLVMIR: %5 = getelementptr i8, ptr %1, i64 %4
 ! LLVMIR: %6 = load <2 x double>, ptr %5, align 1
-! LLVMIR: %7 = shufflevector <2 x double> %6, <2 x double> undef, <2 x i32> <i32 1, i32 0>
+! LLVMIR: %7 = shufflevector <2 x double> %6, <2 x double> poison, <2 x i32> <i32 1, i32 0>
 ! LLVMIR: store <2 x double> %7, ptr %2, align 16
 end subroutine vec_xl_be_testf64a
 

--- a/flang/test/Lower/PowerPC/ppc-vec-load.f90
+++ b/flang/test/Lower/PowerPC/ppc-vec-load.f90
@@ -1,6 +1,6 @@
-! RUN: %flang_fc1 -flang-experimental-hlfir -triple powerpc64le-unknown-unknown -emit-llvm %s -o - | FileCheck --check-prefixes="LLVMIR","LLVMIR-LE","LLVM" %s
+! RUN: %flang_fc1 -triple powerpc64le-unknown-unknown -emit-llvm %s -o - | FileCheck --check-prefixes="LLVMIR","LLVMIR-LE","LLVM" %s
 ! RUN: %flang_fc1 -triple powerpc64le-unknown-unknown -target-cpu pwr9 -emit-llvm %s -o - | FileCheck --check-prefixes="LLVMIR","LLVMIR_P9","LLVM" %s
-! RUN: %flang_fc1 -flang-experimental-hlfir -triple powerpc64-unknown-unknown -emit-llvm %s -o - | FileCheck --check-prefixes="LLVMIR","LLVMIR-BE","LLVM" %s
+! RUN: %flang_fc1 -triple powerpc64-unknown-unknown -emit-llvm %s -o - | FileCheck --check-prefixes="LLVMIR","LLVMIR-BE","LLVM" %s
 ! REQUIRES: target=powerpc{{.*}}
 
 !----------------------
@@ -296,7 +296,7 @@ subroutine vec_lvsl_testi8s(arg1, arg2, res)
 ! LLVMIR: %[[rshft:.*]] = ashr i64 %[[lshft]], 56
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i64 %[[rshft]]
 ! LLVMIR: %[[ld:.*]] = call <16 x i8> @llvm.ppc.altivec.lvsl(ptr %[[addr]])
-! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> poison, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR-LE: store <16 x i8> %[[sv]], ptr %2, align 16
 ! LLVMIR-BE: store <16 x i8> %[[ld]], ptr %2, align 16
 end subroutine vec_lvsl_testi8s
@@ -314,7 +314,7 @@ subroutine vec_lvsl_testi16a(arg1, arg2, res)
 ! LLVMIR: %[[rshft:.*]] = ashr i64 %[[lshft]], 56
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i64 %[[rshft]]
 ! LLVMIR: %[[ld:.*]] = call <16 x i8> @llvm.ppc.altivec.lvsl(ptr %[[addr]])
-! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> poison, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR-LE:  store <16 x i8> %[[sv]], ptr %2, align 16
 ! LLVMIR-BE:  store <16 x i8> %[[ld]], ptr %2, align 16
 end subroutine vec_lvsl_testi16a
@@ -332,7 +332,7 @@ subroutine vec_lvsl_testi32a(arg1, arg2, res)
 ! LLVMIR: %[[rshft:.*]] = ashr i64 %[[lshft]], 56
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i64 %[[rshft]]
 ! LLVMIR: %[[ld:.*]] = call <16 x i8> @llvm.ppc.altivec.lvsl(ptr %[[addr]])
-! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> poison, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR-LE:  store <16 x i8> %[[sv]], ptr %2, align 16
 ! LLVMIR-BE:  store <16 x i8> %[[ld]], ptr %2, align 16
 end subroutine vec_lvsl_testi32a
@@ -349,7 +349,7 @@ subroutine vec_lvsl_testf32a(arg1, arg2, res)
 ! LLVMIR: %[[rshft:.*]] = ashr i64 %[[lshft]], 56
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i64 %[[rshft]]
 ! LLVMIR: %[[ld:.*]] = call <16 x i8> @llvm.ppc.altivec.lvsl(ptr %[[addr]])
-! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> poison, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR-LE:  store <16 x i8> %[[sv]], ptr %2, align 16
 ! LLVMIR-BE:  store <16 x i8> %[[ld]], ptr %2, align 16
 end subroutine vec_lvsl_testf32a
@@ -371,7 +371,7 @@ subroutine vec_lvsr_testi8s(arg1, arg2, res)
 ! LLVMIR: %[[rshft:.*]] = ashr i64 %[[lshft]], 56
 ! LLVMIR: %[[ld:.*]] = getelementptr i8, ptr %1, i64 %[[rshft]]
 ! LLVMIR: %[[addr:.*]] = call <16 x i8> @llvm.ppc.altivec.lvsr(ptr %[[ld]])
-! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[addr]], <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[addr]], <16 x i8> poison, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR-LE: store <16 x i8> %[[sv]], ptr %2, align 16
 ! LLVMIR-BE: store <16 x i8> %[[addr]], ptr %2, align 16
 end subroutine vec_lvsr_testi8s
@@ -389,7 +389,7 @@ subroutine vec_lvsr_testi16a(arg1, arg2, res)
 ! LLVMIR: %[[rshft:.*]] = ashr i64 %[[lshft]], 56
 ! LLVMIR: %[[ld:.*]] = getelementptr i8, ptr %1, i64 %[[rshft]]
 ! LLVMIR: %[[addr:.*]] = call <16 x i8> @llvm.ppc.altivec.lvsr(ptr %[[ld]])
-! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[addr]], <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[addr]], <16 x i8> poison, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR-LE: store <16 x i8> %[[sv]], ptr %2, align 16
 ! LLVMIR-BE: store <16 x i8> %[[addr]], ptr %2, align 16
 end subroutine vec_lvsr_testi16a
@@ -407,7 +407,7 @@ subroutine vec_lvsr_testi32a(arg1, arg2, res)
 ! LLVMIR: %[[rshft:.*]] = ashr i64 %[[lshft]], 56
 ! LLVMIR: %[[ld:.*]] = getelementptr i8, ptr %1, i64 %[[rshft]]
 ! LLVMIR: %[[addr:.*]] = call <16 x i8> @llvm.ppc.altivec.lvsr(ptr %[[ld]])
-! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[addr]], <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[addr]], <16 x i8> poison, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR-LE: store <16 x i8> %[[sv]], ptr %2, align 16
 ! LLVMIR-BE: store <16 x i8> %[[addr]], ptr %2, align 16
 end subroutine vec_lvsr_testi32a
@@ -424,7 +424,7 @@ subroutine vec_lvsr_testf32a(arg1, arg2, res)
 ! LLVMIR: %[[rshft:.*]] = ashr i64 %[[lshft]], 56
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i64 %[[rshft]]
 ! LLVMIR: %[[ld:.*]] = call <16 x i8> @llvm.ppc.altivec.lvsr(ptr %[[addr]])
-! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR-LE: %[[sv:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> poison, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR-LE: store <16 x i8> %[[sv]], ptr %2, align 16
 ! LLVMIR-BE: store <16 x i8> %[[ld]], ptr %2, align 16
 end subroutine vec_lvsr_testf32a
@@ -718,7 +718,7 @@ subroutine vec_xl_be_testi8a(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i8, ptr %0, align 1
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i8 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = load <16 x i8>, ptr %[[addr]], align 1
-! LLVMIR-LE: %[[shff:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR-LE: %[[shff:.*]] = shufflevector <16 x i8> %[[ld]], <16 x i8> poison, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR-LE: store <16 x i8> %[[shff]], ptr %2, align 16
 ! LLVMIR-BE: store <16 x i8> %[[ld]], ptr %2, align 16
 end subroutine vec_xl_be_testi8a
@@ -733,7 +733,7 @@ subroutine vec_xl_be_testi16a(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i16, ptr %0, align 2
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i16 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = load <8 x i16>, ptr %[[addr]], align 1
-! LLVMIR-LE: %[[shff:.*]] = shufflevector <8 x i16> %[[ld]], <8 x i16> undef, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR-LE: %[[shff:.*]] = shufflevector <8 x i16> %[[ld]], <8 x i16> poison, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR-LE: store <8 x i16> %[[shff]], ptr %2, align 16
 ! LLVMIR-BE: store <8 x i16> %[[ld]], ptr %2, align 16
 end subroutine vec_xl_be_testi16a
@@ -748,7 +748,7 @@ subroutine vec_xl_be_testi32a(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i32, ptr %0, align 4
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i32 %[[arg1]]
 ! LLVMIR:  %[[ld:.*]] = load <4 x i32>, ptr %[[addr]], align 1
-! LLVMIR-LE:  %[[shff:.*]] = shufflevector <4 x i32> %[[ld]], <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR-LE:  %[[shff:.*]] = shufflevector <4 x i32> %[[ld]], <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR-LE:  store <4 x i32> %[[shff]], ptr %2, align 16
 ! LLVMIR-BE:  store <4 x i32> %[[ld]], ptr %2, align 16
 end subroutine vec_xl_be_testi32a
@@ -763,7 +763,7 @@ subroutine vec_xl_be_testi64a(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i64, ptr %0, align 8
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i64 %[[arg1]]
 ! LLVMIR:  %[[ld:.*]] = load <2 x i64>, ptr %[[addr]], align 1
-! LLVMIR-LE:  %[[shff:.*]] = shufflevector <2 x i64> %[[ld]], <2 x i64> undef, <2 x i32> <i32 1, i32 0>
+! LLVMIR-LE:  %[[shff:.*]] = shufflevector <2 x i64> %[[ld]], <2 x i64> poison, <2 x i32> <i32 1, i32 0>
 ! LLVMIR-LE:  store <2 x i64> %[[shff]], ptr %2, align 16
 ! LLVMIR-BE:  store <2 x i64> %[[ld]], ptr %2, align 16
 end subroutine vec_xl_be_testi64a
@@ -778,7 +778,7 @@ subroutine vec_xl_be_testf32a(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i16, ptr %0, align 2
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i16 %[[arg1]]
 ! LLVMIR:  %[[ld:.*]] = load <4 x float>, ptr %[[addr]], align 1
-! LLVMIR-LE:  %[[shff:.*]] = shufflevector <4 x float> %[[ld]], <4 x float> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR-LE:  %[[shff:.*]] = shufflevector <4 x float> %[[ld]], <4 x float> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR-LE:  store <4 x float> %[[shff]], ptr %2, align 16
 ! LLVMIR-BE:  store <4 x float> %[[ld]], ptr %2, align 16
 end subroutine vec_xl_be_testf32a
@@ -793,7 +793,7 @@ subroutine vec_xl_be_testf64a(arg1, arg2, res)
 ! LLVMIR: %[[arg1:.*]] = load i64, ptr %0, align 8
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i64 %[[arg1]]
 ! LLVMIR:  %[[ld:.*]] = load <2 x double>, ptr %[[addr]], align 1
-! LLVMIR-LE:  %[[shff:.*]] = shufflevector <2 x double> %[[ld]], <2 x double> undef, <2 x i32> <i32 1, i32 0>
+! LLVMIR-LE:  %[[shff:.*]] = shufflevector <2 x double> %[[ld]], <2 x double> poison, <2 x i32> <i32 1, i32 0>
 ! LLVMIR-LE:  store <2 x double> %[[shff]], ptr %2, align 16
 ! LLVMIR-BE:  store <2 x double> %[[ld]], ptr %2, align 16
 end subroutine vec_xl_be_testf64a

--- a/flang/test/Lower/PowerPC/ppc-vec-store-elem-order.f90
+++ b/flang/test/Lower/PowerPC/ppc-vec-store-elem-order.f90
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -flang-experimental-hlfir -emit-llvm %s -fno-ppc-native-vector-element-order -triple ppc64le-unknown-linux -o - | FileCheck --check-prefixes="LLVMIR" %s
+! RUN: %flang_fc1 -emit-llvm %s -fno-ppc-native-vector-element-order -triple ppc64le-unknown-linux -o - | FileCheck --check-prefixes="LLVMIR" %s
 ! REQUIRES: target=powerpc{{.*}}
 
 !----------------------
@@ -15,7 +15,7 @@ subroutine vec_st_test(arg1, arg2, arg3)
 ! LLVMIR: %[[arg2:.*]] = load i32, ptr %1, align 4
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %2, i32 %[[arg2]]
 ! LLVMIR: %[[bc:.*]] = bitcast <8 x i16> %[[arg1]] to <4 x i32>
-! LLVMIR: %[[shf:.*]] = shufflevector <4 x i32> %[[bc]], <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shf:.*]] = shufflevector <4 x i32> %[[bc]], <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR:  call void @llvm.ppc.altivec.stvx(<4 x i32> %[[shf]], ptr %[[addr]])
 end subroutine vec_st_test
 
@@ -33,7 +33,7 @@ subroutine vec_ste_test(arg1, arg2, arg3)
 ! LLVMIR: %[[arg2:.*]] = load i32, ptr %1, align 4
 ! LLVMIR: %[[addr]] = getelementptr i8, ptr %2, i32 %[[arg2]]
 ! LLVMIR: %[[bc:.*]] = bitcast <4 x float> %[[arg1]] to <4 x i32>
-! LLVMIR: %[[shf:.*]] = shufflevector <4 x i32> %[[bc]], <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shf:.*]] = shufflevector <4 x i32> %[[bc]], <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: call void @llvm.ppc.altivec.stvewx(<4 x i32> %[[shf]], ptr %[[addr]])
 end subroutine vec_ste_test
 
@@ -50,7 +50,7 @@ subroutine vec_xst_test(arg1, arg2, arg3)
 ! LLVMIR: %[[arg1:.*]] = load <4 x i32>, ptr %0, align 16
 ! LLVMIR: %[[arg2:.*]] = load i32, ptr %1, align 4
 ! LLVMIR: %[[trg:.*]] = getelementptr i8, ptr %2, i32 %[[arg2]]
-! LLVMIR: %[[src:.*]] = shufflevector <4 x i32> %[[arg1]], <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[src:.*]] = shufflevector <4 x i32> %[[arg1]], <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR:  store <4 x i32> %[[src]], ptr %[[trg]], align 16
 end subroutine vec_xst_test
 
@@ -76,7 +76,7 @@ subroutine vec_xstd2_test(arg1, arg2, arg3, i)
 ! LLVMIR: %[[arg2:.*]] = load i16, ptr %1, align 2
 ! LLVMIR: %[[gep2:.*]] = getelementptr i8, ptr %[[gep1]], i16 %[[arg2]]
 ! LLVMIR: %[[src:.*]] = bitcast <4 x float> %[[arg1]] to <2 x i64>
-! LLVMIR: %[[shf:.*]] = shufflevector <2 x i64> %[[src]], <2 x i64> undef, <2 x i32> <i32 1, i32 0>
+! LLVMIR: %[[shf:.*]] = shufflevector <2 x i64> %[[src]], <2 x i64> poison, <2 x i32> <i32 1, i32 0>
 ! LLVMIR: store <2 x i64> %[[shf]], ptr %[[gep2]], align 16
 end subroutine vec_xstd2_test
 
@@ -101,6 +101,6 @@ subroutine vec_xstw4_test(arg1, arg2, arg3, i)
 ! LLVMIR: %[[arg1:.*]] = load <4 x float>, ptr %0, align 16
 ! LLVMIR: %[[arg2:.*]] = load i16, ptr %1, align 2
 ! LLVMIR: %[[gep2:.*]] = getelementptr i8, ptr %[[gep1]], i16 %[[arg2]]
-! LLVMIR: %[[src:.*]] = shufflevector <4 x float> %[[arg1]], <4 x float> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[src:.*]] = shufflevector <4 x float> %[[arg1]], <4 x float> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x float> %[[src]], ptr %[[gep2]], align 16
 end subroutine vec_xstw4_test

--- a/flang/test/Lower/PowerPC/ppc-vec-store.f90
+++ b/flang/test/Lower/PowerPC/ppc-vec-store.f90
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -flang-experimental-hlfir -emit-llvm %s -o - | FileCheck --check-prefixes="LLVMIR" %s
+! RUN: %flang_fc1 -emit-llvm %s -o - | FileCheck --check-prefixes="LLVMIR" %s
 ! REQUIRES: target=powerpc{{.*}}
 
 !----------------------
@@ -376,7 +376,7 @@ subroutine vec_xst_be_test_vr4i2r4(arg1, arg2, arg3)
 ! LLVMIR: %[[arg1:.*]] = load <4 x float>, ptr %{{.*}}, align 16
 ! LLVMIR: %[[arg2:.*]] = load i16, ptr %{{.*}}, align 2
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %{{.*}}, i16 %[[arg2]]
-! LLVMIR: %[[shf:.*]] = shufflevector <4 x float> %[[arg1]], <4 x float> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[shf:.*]] = shufflevector <4 x float> %[[arg1]], <4 x float> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x float> %[[shf]], ptr %[[addr]], align 16
 end subroutine vec_xst_be_test_vr4i2r4
 
@@ -398,7 +398,7 @@ subroutine vec_xst_be_test_vi4i8ia4(arg1, arg2, arg3, i)
 ! LLVMIR: %[[arg1:.*]] = load <4 x i32>, ptr %0, align 16
 ! LLVMIR: %[[arg2:.*]] = load i64, ptr %1, align 8
 ! LLVMIR: %[[gep2:.*]] = getelementptr i8, ptr %[[gep1]], i64 %[[arg2]]
-! LLVMIR: %[[src:.*]] = shufflevector <4 x i32> %[[arg1]], <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[src:.*]] = shufflevector <4 x i32> %[[arg1]], <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x i32> %[[src]], ptr %[[gep2]], align 16
 end subroutine vec_xst_be_test_vi4i8ia4
 
@@ -412,7 +412,7 @@ subroutine vec_xst_be_test_vi2i4vi2(arg1, arg2, arg3)
 ! LLVMIR: %[[arg1:.*]] = load <8 x i16>, ptr %0, align 16
 ! LLVMIR: %[[arg2:.*]] = load i32, ptr %1, align 4
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %2, i32 %[[arg2]]
-! LLVMIR: %[[src:.*]] = shufflevector <8 x i16> %[[arg1]], <8 x i16> undef, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[src:.*]] = shufflevector <8 x i16> %[[arg1]], <8 x i16> poison, <8 x i32> <i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <8 x i16> %[[src]], ptr %[[addr]], align 16
 end subroutine vec_xst_be_test_vi2i4vi2
 
@@ -434,7 +434,7 @@ subroutine vec_xst_be_test_vi4i4vai4(arg1, arg2, arg3, i)
 ! LLVMIR: %[[arg1:.*]] = load <4 x i32>, ptr %0, align 16
 ! LLVMIR: %[[arg2:.*]] = load i32, ptr %1, align 4
 ! LLVMIR: %[[gep2:.*]] = getelementptr i8, ptr %[[gep1]], i32 %[[arg2]]
-! LLVMIR: %[[src:.*]] = shufflevector <4 x i32> %[[arg1]], <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+! LLVMIR: %[[src:.*]] = shufflevector <4 x i32> %[[arg1]], <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x i32> %[[src]], ptr %[[gep2]], align 16
 end subroutine vec_xst_be_test_vi4i4vai4
 


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/commit/1c0b2d3abb04ca92dbbf637b30e25829ef90d859, the code `vector.shuffle %7, %7 [4, 5, 6, 7, 0, 1, 2, 3, 12, 13, 14, 15, 8, 9, 10, 11] : vector<16xi8>, vector<16xi8>` causes the following error:

```bash
loc("llvm-project/flang/test/Lower/PowerPC/ppc-vec-convert.f90":1316:3): error: failed to legalize operation 'ub.poison': %0 = "ub.poison"() <{value = #ub.poison}> : () -> vector<16xi8>
error: Lowering to LLVM IR failed
loc("llvm-project/flang/test/Lower/PowerPC/ppc-vec-convert.f90":9:1): error: cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface` registration for dialect for op: func.func
error: failed to create the LLVM module
```

This patch is to add the UB dialect registration and UBToLLVM conversion interface in lowering.