### PR TITLE
[llvm-readobj][ELF] Remove redundant error in reportWarning

### DIFF
--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -8245,8 +8245,7 @@ template <class ELFT> void LLVMELFDumper<ELFT>::printCallGraphInfo() {
     return;
   }
   if (MapOrErr->empty()) {
-    reportWarning(createError("no SHT_LLVM_CALL_GRAPH section found" +
-                              toString(MapOrErr.takeError())),
+    reportWarning(createError("no SHT_LLVM_CALL_GRAPH section found"),
                   this->FileName);
     return;
   }


### PR DESCRIPTION
If MapOrError contains no error, calling takeError() results in undefined behavior and may crash the program.