### PR TITLE
[SPIR-V] Use ToolSubst for spirv-tools lit substitutions

### DIFF
--- a/llvm/test/CodeGen/SPIRV/lit.local.cfg
+++ b/llvm/test/CodeGen/SPIRV/lit.local.cfg
@@ -3,7 +3,7 @@ if not "SPIRV" in config.root.targets:
 
 if config.spirv_tools_tests:
     config.available_features.add("spirv-tools")
-    config.substitutions.append(("spirv-dis", os.path.join(config.llvm_tools_dir, "spirv-dis")))
-    config.substitutions.append(("spirv-val", os.path.join(config.llvm_tools_dir, "spirv-val")))
-    config.substitutions.append(("spirv-as", os.path.join(config.llvm_tools_dir, "spirv-as")))
-    config.substitutions.append(("spirv-link", os.path.join(config.llvm_tools_dir, "spirv-link")))
+    from lit.llvm import llvm_config
+    llvm_config.add_tool_substitutions(
+        ["spirv-dis", "spirv-val", "spirv-as", "spirv-link"]
+    )


### PR DESCRIPTION
Bare-string substitutions match as substrings and the replacement path contains the tool name, causing corrupted RUN lines

The issue is reproducible, for example, when path to llvm has tool name substring at any point