### PR TITLE
[mlir] Add erase sub-region dominate tree logic in DominanceInfoBase::invalidate method

### DIFF
--- a/mlir/include/mlir/IR/Dominance.h
+++ b/mlir/include/mlir/IR/Dominance.h
@@ -47,7 +47,10 @@ public:
   /// Invalidate dominance info. This can be used by clients that make major
   /// changes to the CFG and don't have a good way to update it.
   void invalidate();
-  void invalidate(Region *region);
+
+  /// Invalidate dominance info of the \p region, if \p recursive is true, it
+  /// invalidates the dominance information of child regions.
+  void invalidate(Region *region, bool recursive = true);
 
   /// Finds the nearest common dominator block for the two given blocks a
   /// and b. If no common dominator can be found, this function will return

--- a/mlir/lib/IR/Dominance.cpp
+++ b/mlir/lib/IR/Dominance.cpp
@@ -42,10 +42,17 @@ void DominanceInfoBase<IsPostDom>::invalidate() {
 
 template <bool IsPostDom>
 void DominanceInfoBase<IsPostDom>::invalidate(Region *region) {
-  auto it = dominanceInfos.find(region);
-  if (it != dominanceInfos.end()) {
-    delete it->second.getPointer();
-    dominanceInfos.erase(it);
+  SmallVector<Region*> regions = {region};
+  region->walk([&](Operation *op) {
+    for (Region &r : op->getRegions()) 
+      regions.push_back(&r);
+  });
+  for (Region* region : regions) {
+    auto it = dominanceInfos.find(region);
+    if (it != dominanceInfos.end()) {
+      delete it->second.getPointer();
+      dominanceInfos.erase(it);
+    }
   }
 }
 

--- a/mlir/lib/IR/Dominance.cpp
+++ b/mlir/lib/IR/Dominance.cpp
@@ -42,12 +42,12 @@ void DominanceInfoBase<IsPostDom>::invalidate() {
 
 template <bool IsPostDom>
 void DominanceInfoBase<IsPostDom>::invalidate(Region *region) {
-  SmallVector<Region*> regions = {region};
+  SmallVector<Region *> regions = {region};
   region->walk([&](Operation *op) {
-    for (Region &r : op->getRegions()) 
+    for (Region &r : op->getRegions())
       regions.push_back(&r);
   });
-  for (Region* region : regions) {
+  for (Region *region : regions) {
     auto it = dominanceInfos.find(region);
     if (it != dominanceInfos.end()) {
       delete it->second.getPointer();

--- a/mlir/lib/IR/Dominance.cpp
+++ b/mlir/lib/IR/Dominance.cpp
@@ -42,17 +42,23 @@ void DominanceInfoBase<IsPostDom>::invalidate() {
 
 template <bool IsPostDom>
 void DominanceInfoBase<IsPostDom>::invalidate(Region *region) {
-  SmallVector<Region *> regions = {region};
-  region->walk([&](Operation *op) {
-    for (Region &r : op->getRegions())
-      regions.push_back(&r);
-  });
-  for (Region *region : regions) {
-    auto it = dominanceInfos.find(region);
-    if (it != dominanceInfos.end()) {
-      delete it->second.getPointer();
-      dominanceInfos.erase(it);
-    }
+  auto it = dominanceInfos.find(region);
+  if (it != dominanceInfos.end()) {
+    delete it->second.getPointer();
+    dominanceInfos.erase(it);
+  }
+
+  // Invalidate dominator trees of nested sub-regions.
+  if (region) {
+    region->walk([&](Operation *op) {
+      for (Region &region : op->getRegions()) {
+        auto it = dominanceInfos.find(&region);
+        if (it != dominanceInfos.end()) {
+          delete it->second.getPointer();
+          dominanceInfos.erase(it);
+        }
+      }
+    });
   }
 }
 

--- a/mlir/lib/IR/Dominance.cpp
+++ b/mlir/lib/IR/Dominance.cpp
@@ -47,19 +47,13 @@ void DominanceInfoBase<IsPostDom>::invalidate(Region *region) {
     delete it->second.getPointer();
     dominanceInfos.erase(it);
   }
-
-  // Invalidate dominator trees of nested sub-regions.
-  if (region) {
-    region->walk([&](Operation *op) {
-      for (Region &region : op->getRegions()) {
-        auto it = dominanceInfos.find(&region);
-        if (it != dominanceInfos.end()) {
-          delete it->second.getPointer();
-          dominanceInfos.erase(it);
-        }
-      }
-    });
-  }
+  region->walk([&](Region *op) {
+    auto it = dominanceInfos.find(region);
+    if (it != dominanceInfos.end()) {
+      delete it->second.getPointer();
+      dominanceInfos.erase(it);
+    }
+  });
 }
 
 /// Return the dom tree and "hasSSADominance" bit for the given region.  The

--- a/mlir/lib/IR/Dominance.cpp
+++ b/mlir/lib/IR/Dominance.cpp
@@ -42,13 +42,8 @@ void DominanceInfoBase<IsPostDom>::invalidate() {
 
 template <bool IsPostDom>
 void DominanceInfoBase<IsPostDom>::invalidate(Region *region) {
-  auto it = dominanceInfos.find(region);
-  if (it != dominanceInfos.end()) {
-    delete it->second.getPointer();
-    dominanceInfos.erase(it);
-  }
-  region->walk([&](Region *op) {
-    auto it = dominanceInfos.find(region);
+  region->walk([&](Region *r) {
+    auto it = dominanceInfos.find(r);
     if (it != dominanceInfos.end()) {
       delete it->second.getPointer();
       dominanceInfos.erase(it);

--- a/mlir/lib/IR/Dominance.cpp
+++ b/mlir/lib/IR/Dominance.cpp
@@ -41,14 +41,18 @@ void DominanceInfoBase<IsPostDom>::invalidate() {
 }
 
 template <bool IsPostDom>
-void DominanceInfoBase<IsPostDom>::invalidate(Region *region) {
-  region->walk([&](Region *r) {
+void DominanceInfoBase<IsPostDom>::invalidate(Region *region, bool recursive) {
+  auto invalidate = [&](Region *r) {
     auto it = dominanceInfos.find(r);
     if (it != dominanceInfos.end()) {
       delete it->second.getPointer();
       dominanceInfos.erase(it);
     }
-  });
+  };
+  if (recursive)
+    region->walk([&](Region *r) { invalidate(r); });
+  else
+    invalidate(region);
 }
 
 /// Return the dom tree and "hasSSADominance" bit for the given region.  The


### PR DESCRIPTION
Fix the issue: a region may contain nested sub-regions. When we remove the dominate tree of a parent region and delete the region, the dominate trees of its sub-regions should also be removed.