### PR TITLE
[clang][OpenMP] Fix __llvm_omp_indirect_call_lookup signature for targets with non-default program AS

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -7082,14 +7082,15 @@ RValue CodeGenFunction::EmitCall(QualType CalleeType,
 
     const auto *VD = DRE ? dyn_cast<VarDecl>(DRE->getDecl()) : nullptr;
     if (VD && VD->hasAttr<OMPTargetIndirectCallAttr>()) {
-      auto *PtrTy = CGM.VoidPtrTy;
-      llvm::Type *RtlFnArgs[] = {PtrTy};
+      auto *FuncPtrTy = llvm::PointerType::get(
+          CGM.getLLVMContext(), CGM.getDataLayout().getProgramAddressSpace());
+      llvm::Type *RtlFnArgs[] = {FuncPtrTy};
       llvm::FunctionCallee DeviceRtlFn = CGM.CreateRuntimeFunction(
-          llvm::FunctionType::get(PtrTy, RtlFnArgs, false),
+          llvm::FunctionType::get(FuncPtrTy, RtlFnArgs, false),
           "__llvm_omp_indirect_call_lookup");
       llvm::Value *Func = Callee.getFunctionPointer();
       llvm::Type *BackupTy = Func->getType();
-      Func = Builder.CreatePointerBitCastOrAddrSpaceCast(Func, PtrTy);
+      Func = Builder.CreatePointerBitCastOrAddrSpaceCast(Func, FuncPtrTy);
       Func = EmitRuntimeCall(DeviceRtlFn, {Func});
       Func = Builder.CreatePointerBitCastOrAddrSpaceCast(Func, BackupTy);
       Callee.setFunctionPointer(Func);

--- a/clang/test/OpenMP/target_indirect_codegen.cpp
+++ b/clang/test/OpenMP/target_indirect_codegen.cpp
@@ -6,9 +6,9 @@
 
 // RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=51 -x c++ -triple powerpc64le-unknown-unknown -fopenmp-targets=spirv64-intel -emit-llvm %s -o - | FileCheck %s --check-prefix=HOST
 // RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=51 -x c++ -triple powerpc64le-unknown-unknown -fopenmp-targets=spirv64-intel -emit-llvm-bc %s -o %t-spirv-host.bc
-// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=51 -x c++ -triple spirv64-intel -emit-llvm %s -fopenmp-is-target-device -fvisibility=protected -fopenmp-host-ir-file-path %t-spirv-host.bc -o - | FileCheck %s --check-prefix=DEVICE
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=51 -x c++ -triple spirv64-intel -emit-llvm %s -fopenmp-is-target-device -fvisibility=protected -fopenmp-host-ir-file-path %t-spirv-host.bc -o - | FileCheck %s --check-prefix=DEVICE,SPIRV
 // RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=51 -x c++ -triple spirv64-intel %s -fopenmp-is-target-device -fvisibility=protected -fopenmp-host-ir-file-path %t-spirv-host.bc -emit-pch -o %t
-// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=51 -x c++ -triple spirv64-intel -emit-llvm %s -fopenmp-is-target-device -fvisibility=protected -fopenmp-host-ir-file-path %t-spirv-host.bc -include-pch %t -o - | FileCheck %s --check-prefix=DEVICE
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=51 -x c++ -triple spirv64-intel -emit-llvm %s -fopenmp-is-target-device -fvisibility=protected -fopenmp-host-ir-file-path %t-spirv-host.bc -include-pch %t -o - | FileCheck %s --check-prefix=DEVICE,SPIRV
 
 // expected-no-diagnostics
 #ifndef HEADER
@@ -86,6 +86,7 @@ int main() {
 #endif
 // DEVICE-LABEL: define {{.*}}void @__omp_offloading_{{.+}}_main_l{{[0-9]+}}(
 // DEVICE: call {{.*}}@__llvm_omp_indirect_call_lookup(
+// SPIRV-SAME:  ptr addrspace(9)
 // DEVICE: call {{.*}}void %{{.+}}()
 // DEVICE: call {{.*}}@__llvm_omp_indirect_call_lookup(
 // DEVICE: call {{.*}}void %{{.+}}()


### PR DESCRIPTION
The argument and return value for `__llvm_omp_indirect_call_lookup` are function pointers so make sure they are in the correct address space.