### PR TITLE
[ConstantMerge] don't merge constants with COMDAT

### DIFF
--- a/llvm/lib/Transforms/IPO/ConstantMerge.cpp
+++ b/llvm/lib/Transforms/IPO/ConstantMerge.cpp
@@ -63,7 +63,10 @@ static bool IsBetterCanonical(const GlobalVariable &A,
   if (A.hasLocalLinkage() && !B.hasLocalLinkage())
     return false;
 
-  return A.hasGlobalUnnamedAddr();
+  if (A.hasGlobalUnnamedAddr() != B.hasGlobalUnnamedAddr())
+    return A.hasGlobalUnnamedAddr();
+
+  return !A.hasComdat();
 }
 
 static void copyDebugLocMetadata(const GlobalVariable *From,
@@ -98,6 +101,16 @@ static CanMerge makeMergeable(GlobalVariable *Old, GlobalVariable *New) {
   if (Old->hasMetadataOtherThanDebugLoc())
     return CanMerge::No;
   assert(!New->hasMetadataOtherThanDebugLoc());
+
+  // Merging constants with different comdats means one group cannot in general
+  // be dropped independently without the other group now having an invalid
+  // reference to the dropped constant.
+  // If we merge into a constant that does not have comdat, we can merge even
+  // when the old constant has a comdat group because it has local linkage and
+  // is therefore not the comdat key.
+  if (Old->getComdat() != New->getComdat() && New->hasComdat())
+    return CanMerge::No;
+
   if (!Old->hasGlobalUnnamedAddr())
     New->setUnnamedAddr(GlobalValue::UnnamedAddr::None);
   return CanMerge::Yes;

--- a/llvm/test/Transforms/ConstantMerge/dont-merge.ll
+++ b/llvm/test/Transforms/ConstantMerge/dont-merge.ll
@@ -92,3 +92,25 @@ define void @test5(ptr %P1, ptr %P2) {
         store ptr @T5ua, ptr %P2
         ret void
 }
+
+$test6a = comdat any
+$test6b = comdat any
+
+; If @T6a were to get merged into @T6b and the $test6b comdat group gets dropped,
+; @test6a would have a (now invalid) reference to the dropped @T6b constant
+
+@T6a = private unnamed_addr constant i32 666, comdat($test6a)
+@T6b = private unnamed_addr constant i32 666, comdat($test6b)
+
+; CHECK: @T6a
+; CHECK: @T6b
+
+define void @test6a(ptr %P) comdat {
+        store ptr @T6a, ptr %P
+        ret void
+}
+
+define void @test6b(ptr %P) comdat {
+        store ptr @T6b, ptr %P
+        ret void
+}

--- a/llvm/test/Transforms/ConstantMerge/merge-comdat.ll
+++ b/llvm/test/Transforms/ConstantMerge/merge-comdat.ll
@@ -1,0 +1,27 @@
+; RUN: opt -passes=constmerge -S < %s | FileCheck %s
+
+; @ComdatGlobal1 can be merged into @RegularGlobal which does not have
+; a comdat group and should not get dropped by the linker.
+; Same for @ComdatGlobal2 into @PrivateGlobal.
+
+$test = comdat any
+
+@ComdatGlobal1 = private unnamed_addr constant i32 111, comdat($test)
+@RegularGlobal = constant i32 111
+
+; CHECK NOT: @ComdatGlobal1
+; CHECK: @RegularGlobal
+
+@ComdatGlobal2 = private unnamed_addr constant i32 222, comdat($test)
+@PrivateGlobal = private unnamed_addr constant i32 222
+
+; CHECK NOT: @ComdatGlobal2
+; CHECK: @PrivateGlobal
+
+define void @test(ptr %P) comdat {
+        store ptr @ComdatGlobal1, ptr %P
+        store ptr @RegularGlobal, ptr %P
+        store ptr @ComdatGlobal2, ptr %P
+        store ptr @PrivateGlobal, ptr %P
+        ret void
+}


### PR DESCRIPTION
After merging #190995 (now reverted) the CI failed because ConstantMerge currently merges constants with differing COMDATs. This can result in a function referencing globals with a different COMDAT than before the merge, producing a linking error when that global gets discarded.

It is still possible to merge same comdats, or to merge a non-key comdat constant into a non-comdat constant.