### PR TITLE
[libc][threads] adjust futex library and expose requeue API

### DIFF
--- a/libc/src/__support/threads/CMakeLists.txt
+++ b/libc/src/__support/threads/CMakeLists.txt
@@ -24,6 +24,14 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
 endif()
 
 if(TARGET libc.src.__support.threads.${LIBC_TARGET_OS}.futex_utils)
+  add_header_library(
+    futex_utils
+    HDRS
+      futex_utils.h
+    DEPENDS
+      .${LIBC_TARGET_OS}.futex_utils
+  )
+
   libc_set_definition(rwlock_default_spin_count "LIBC_COPT_RWLOCK_DEFAULT_SPIN_COUNT=${LIBC_CONF_RWLOCK_DEFAULT_SPIN_COUNT}")
 
   add_header_library(
@@ -33,7 +41,7 @@ if(TARGET libc.src.__support.threads.${LIBC_TARGET_OS}.futex_utils)
     COMPILE_OPTIONS
       ${monotonicity_flags}
     DEPENDS
-      .${LIBC_TARGET_OS}.futex_utils
+      .futex_utils
       libc.src.__support.threads.sleep
       libc.src.__support.time.abs_timeout
       libc.src.__support.time.monotonicity

--- a/libc/src/__support/threads/CndVar.h
+++ b/libc/src/__support/threads/CndVar.h
@@ -11,7 +11,7 @@
 
 #include "hdr/stdint_proxy.h" // uint32_t
 #include "src/__support/macros/config.h"
-#include "src/__support/threads/linux/futex_utils.h" // Futex
+#include "src/__support/threads/futex_utils.h" // Futex
 #include "src/__support/threads/mutex.h"             // Mutex
 #include "src/__support/threads/raw_mutex.h"         // RawMutex
 

--- a/libc/src/__support/threads/CndVar.h
+++ b/libc/src/__support/threads/CndVar.h
@@ -11,7 +11,7 @@
 
 #include "hdr/stdint_proxy.h" // uint32_t
 #include "src/__support/macros/config.h"
-#include "src/__support/threads/futex_utils.h" // Futex
+#include "src/__support/threads/futex_utils.h"       // Futex
 #include "src/__support/threads/mutex.h"             // Mutex
 #include "src/__support/threads/raw_mutex.h"         // RawMutex
 

--- a/libc/src/__support/threads/darwin/futex_utils.h
+++ b/libc/src/__support/threads/darwin/futex_utils.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_THREADS_DARWIN_FUTEX_UTILS_H
 #define LLVM_LIBC_SRC___SUPPORT_THREADS_DARWIN_FUTEX_UTILS_H
 
+#include "hdr/errno_macros.h"
 #include "src/__support/CPP/atomic.h"
 #include "src/__support/CPP/optional.h"
 #include "src/__support/error_or.h"
@@ -22,15 +23,24 @@ namespace LIBC_NAMESPACE_DECL {
 
 using FutexWordType = uint32_t;
 
+// errno from libSystem
+extern int *__error(void);
+
+class FutexErrnoProtect {
+  int backup;
+
+public:
+  LIBC_INLINE FutexErrnoProtect() : backup(*__error()) {}
+  LIBC_INLINE ~FutexErrnoProtect() { *__error() = backup; }
+};
+
 struct Futex : public cpp::Atomic<FutexWordType> {
   using cpp::Atomic<FutexWordType>::Atomic;
   using Timeout = internal::AbsTimeout;
 
   LIBC_INLINE long wait(FutexWordType val, cpp::optional<Timeout> timeout,
                         bool is_shared) {
-    // TODO(bojle): consider using OS_SYNC_WAIT_ON_ADDRESS_SHARED to sync
-    // betweeen processes. Catch: it is recommended to only be used by shared
-    // processes, not threads of a same process.
+    FutexErrnoProtect protect;
     os_sync_wait_on_address_flags_t flags = OS_SYNC_WAIT_ON_ADDRESS_NONE;
     if (is_shared)
       flags = OS_SYNC_WAIT_ON_ADDRESS_SHARED;
@@ -51,30 +61,37 @@ struct Futex : public cpp::Atomic<FutexWordType> {
                                       static_cast<uint64_t>(val),
                                       sizeof(FutexWordType), flags);
       }
-      if ((ret < 0) && (errno == ETIMEDOUT))
+      if ((ret < 0) && (*__error() == ETIMEDOUT))
         return -ETIMEDOUT;
       // case when os_sync returns early with an error. retry.
-      if ((ret < 0) && ((errno == EINTR) || (errno == EFAULT)))
+      if ((ret < 0) && ((*__error() == EINTR) || (*__error() == EFAULT)))
         continue;
       return ret;
     }
   }
 
   LIBC_INLINE long notify_one(bool is_shared) {
+    FutexErrnoProtect protect;
     os_sync_wake_by_address_flags_t flags = OS_SYNC_WAKE_BY_ADDRESS_NONE;
     if (is_shared)
       flags = OS_SYNC_WAKE_BY_ADDRESS_SHARED;
-
-    return os_sync_wake_by_address_any(reinterpret_cast<void *>(this),
-                                       sizeof(FutexWordType), flags);
+    int res = os_sync_wake_by_address_any(reinterpret_cast<void *>(this),
+                                          sizeof(FutexWordType), flags);
+    if (res < 0)
+      return -*__error();
+    return res;
   }
 
   LIBC_INLINE long notify_all(bool is_shared) {
+    FutexErrnoProtect protect;
     os_sync_wake_by_address_flags_t flags = OS_SYNC_WAKE_BY_ADDRESS_NONE;
     if (is_shared)
       flags = OS_SYNC_WAKE_BY_ADDRESS_SHARED;
-    return os_sync_wake_by_address_all(reinterpret_cast<void *>(this),
-                                       sizeof(FutexWordType), flags);
+    int res = os_sync_wake_by_address_all(reinterpret_cast<void *>(this),
+                                          sizeof(FutexWordType), flags);
+    if (res < 0)
+      return -*__error();
+    return res;
   }
 
   LIBC_INLINE ErrorOr<int> requeue_to(Futex & /*other*/,

--- a/libc/src/__support/threads/darwin/futex_utils.h
+++ b/libc/src/__support/threads/darwin/futex_utils.h
@@ -79,8 +79,7 @@ struct Futex : public cpp::Atomic<FutexWordType> {
 
   LIBC_INLINE ErrorOr<int> requeue_to(Futex & /*other*/,
                                       cpp::optional<FutexWordType> /*oldval*/,
-                                      int /*wake_limit*/,
-                                      int /*requeue_limit*/,
+                                      int /*wake_limit*/, int /*requeue_limit*/,
                                       bool /*is_shared*/ = false) {
     return cpp::unexpected(ENOSYS);
   }

--- a/libc/src/__support/threads/darwin/futex_utils.h
+++ b/libc/src/__support/threads/darwin/futex_utils.h
@@ -24,13 +24,13 @@ namespace LIBC_NAMESPACE_DECL {
 using FutexWordType = uint32_t;
 
 // errno from libSystem
-extern int *__error(void);
+extern "C" int *__error(void);
 
 class FutexErrnoProtect {
   int backup;
 
 public:
-  LIBC_INLINE FutexErrnoProtect() : backup(*__error()) {}
+  LIBC_INLINE FutexErrnoProtect() : backup(*__error()) { *__error() = 0; }
   LIBC_INLINE ~FutexErrnoProtect() { *__error() = backup; }
 };
 
@@ -38,8 +38,8 @@ struct Futex : public cpp::Atomic<FutexWordType> {
   using cpp::Atomic<FutexWordType>::Atomic;
   using Timeout = internal::AbsTimeout;
 
-  LIBC_INLINE long wait(FutexWordType val, cpp::optional<Timeout> timeout,
-                        bool is_shared) {
+  LIBC_INLINE ErrorOr<int>
+  wait(FutexWordType val, cpp::optional<Timeout> timeout, bool is_shared) {
     FutexErrnoProtect protect;
     os_sync_wait_on_address_flags_t flags = OS_SYNC_WAIT_ON_ADDRESS_NONE;
     if (is_shared)
@@ -47,7 +47,7 @@ struct Futex : public cpp::Atomic<FutexWordType> {
     for (;;) {
       if (this->load(cpp::MemoryOrder::RELAXED) != val)
         return 0;
-      long ret = 0;
+      int ret = 0;
       if (timeout) {
         // Assuming, OS_CLOCK_MACH_ABSOLUTE_TIME is equivalent to CLOCK_REALTIME
         using namespace time_units;
@@ -62,7 +62,7 @@ struct Futex : public cpp::Atomic<FutexWordType> {
                                       sizeof(FutexWordType), flags);
       }
       if ((ret < 0) && (*__error() == ETIMEDOUT))
-        return -ETIMEDOUT;
+        return cpp::unexpected(ETIMEDOUT);
       // case when os_sync returns early with an error. retry.
       if ((ret < 0) && ((*__error() == EINTR) || (*__error() == EFAULT)))
         continue;
@@ -70,7 +70,7 @@ struct Futex : public cpp::Atomic<FutexWordType> {
     }
   }
 
-  LIBC_INLINE long notify_one(bool is_shared) {
+  LIBC_INLINE ErrorOr<int> notify_one(bool is_shared) {
     FutexErrnoProtect protect;
     os_sync_wake_by_address_flags_t flags = OS_SYNC_WAKE_BY_ADDRESS_NONE;
     if (is_shared)
@@ -78,11 +78,11 @@ struct Futex : public cpp::Atomic<FutexWordType> {
     int res = os_sync_wake_by_address_any(reinterpret_cast<void *>(this),
                                           sizeof(FutexWordType), flags);
     if (res < 0)
-      return -*__error();
+      return cpp::unexpected(*__error());
     return res;
   }
 
-  LIBC_INLINE long notify_all(bool is_shared) {
+  LIBC_INLINE ErrorOr<int> notify_all(bool is_shared) {
     FutexErrnoProtect protect;
     os_sync_wake_by_address_flags_t flags = OS_SYNC_WAKE_BY_ADDRESS_NONE;
     if (is_shared)
@@ -90,7 +90,7 @@ struct Futex : public cpp::Atomic<FutexWordType> {
     int res = os_sync_wake_by_address_all(reinterpret_cast<void *>(this),
                                           sizeof(FutexWordType), flags);
     if (res < 0)
-      return -*__error();
+      return cpp::unexpected(*__error());
     return res;
   }
 

--- a/libc/src/__support/threads/darwin/futex_utils.h
+++ b/libc/src/__support/threads/darwin/futex_utils.h
@@ -11,6 +11,7 @@
 
 #include "src/__support/CPP/atomic.h"
 #include "src/__support/CPP/optional.h"
+#include "src/__support/error_or.h"
 #include "src/__support/time/abs_timeout.h"
 #include "src/__support/time/clock_conversion.h"
 #include "src/__support/time/units.h"
@@ -26,11 +27,13 @@ struct Futex : public cpp::Atomic<FutexWordType> {
   using Timeout = internal::AbsTimeout;
 
   LIBC_INLINE long wait(FutexWordType val, cpp::optional<Timeout> timeout,
-                        bool /* is_shared */) {
+                        bool is_shared) {
     // TODO(bojle): consider using OS_SYNC_WAIT_ON_ADDRESS_SHARED to sync
     // betweeen processes. Catch: it is recommended to only be used by shared
     // processes, not threads of a same process.
-
+    os_sync_wait_on_address_flags_t flags = OS_SYNC_WAIT_ON_ADDRESS_NONE;
+    if (is_shared)
+      flags = OS_SYNC_WAIT_ON_ADDRESS_SHARED;
     for (;;) {
       if (this->load(cpp::MemoryOrder::RELAXED) != val)
         return 0;
@@ -42,35 +45,44 @@ struct Futex : public cpp::Atomic<FutexWordType> {
                          timeout->get_timespec().tv_nsec;
         ret = os_sync_wait_on_address_with_timeout(
             reinterpret_cast<void *>(this), static_cast<uint64_t>(val),
-            sizeof(FutexWordType), OS_SYNC_WAIT_ON_ADDRESS_NONE,
-            OS_CLOCK_MACH_ABSOLUTE_TIME, tnsec);
+            sizeof(FutexWordType), flags, OS_CLOCK_MACH_ABSOLUTE_TIME, tnsec);
       } else {
-        ret = os_sync_wait_on_address(
-            reinterpret_cast<void *>(this), static_cast<uint64_t>(val),
-            sizeof(FutexWordType), OS_SYNC_WAIT_ON_ADDRESS_NONE);
+        ret = os_sync_wait_on_address(reinterpret_cast<void *>(this),
+                                      static_cast<uint64_t>(val),
+                                      sizeof(FutexWordType), flags);
       }
       if ((ret < 0) && (errno == ETIMEDOUT))
         return -ETIMEDOUT;
       // case when os_sync returns early with an error. retry.
-      if ((ret < 0) && ((errno == EINTR) || (errno == EFAULT))) {
+      if ((ret < 0) && ((errno == EINTR) || (errno == EFAULT)))
         continue;
-      }
       return ret;
     }
   }
 
-  LIBC_INLINE long notify_one(bool /* is_shared */) {
-    // TODO(bojle): deal with is_shared
+  LIBC_INLINE long notify_one(bool is_shared) {
+    os_sync_wake_by_address_flags_t flags = OS_SYNC_WAKE_BY_ADDRESS_NONE;
+    if (is_shared)
+      flags = OS_SYNC_WAKE_BY_ADDRESS_SHARED;
+
     return os_sync_wake_by_address_any(reinterpret_cast<void *>(this),
-                                       sizeof(FutexWordType),
-                                       OS_SYNC_WAKE_BY_ADDRESS_NONE);
+                                       sizeof(FutexWordType), flags);
   }
 
-  LIBC_INLINE long notify_all(bool /* is_shared */) {
-    // TODO(bojle): deal with is_shared
+  LIBC_INLINE long notify_all(bool is_shared) {
+    os_sync_wake_by_address_flags_t flags = OS_SYNC_WAKE_BY_ADDRESS_NONE;
+    if (is_shared)
+      flags = OS_SYNC_WAKE_BY_ADDRESS_SHARED;
     return os_sync_wake_by_address_all(reinterpret_cast<void *>(this),
-                                       sizeof(FutexWordType),
-                                       OS_SYNC_WAKE_BY_ADDRESS_NONE);
+                                       sizeof(FutexWordType), flags);
+  }
+
+  LIBC_INLINE ErrorOr<int> requeue_to(Futex & /*other*/,
+                                      cpp::optional<FutexWordType> /*oldval*/,
+                                      int /*wake_limit*/,
+                                      int /*requeue_limit*/,
+                                      bool /*is_shared*/ = false) {
+    return cpp::unexpected(ENOSYS);
   }
 };
 

--- a/libc/src/__support/threads/futex_utils.h
+++ b/libc/src/__support/threads/futex_utils.h
@@ -1,0 +1,20 @@
+//===--- Platform dispatch for futex utilities ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_THREADS_FUTEX_UTILS_H
+#define LLVM_LIBC_SRC___SUPPORT_THREADS_FUTEX_UTILS_H
+
+#if defined(__linux__)
+#include "src/__support/threads/linux/futex_utils.h"
+#elif defined(__APPLE__)
+#include "src/__support/threads/darwin/futex_utils.h"
+#else
+#error "futex_utils is not supported on this platform"
+#endif
+
+#endif // LLVM_LIBC_SRC___SUPPORT_THREADS_FUTEX_UTILS_H

--- a/libc/src/__support/threads/linux/futex_utils.h
+++ b/libc/src/__support/threads/linux/futex_utils.h
@@ -31,9 +31,9 @@ public:
     cpp::Atomic<FutexWordType>::store(value);
     return *this;
   }
-  LIBC_INLINE long wait(FutexWordType expected,
-                        cpp::optional<Timeout> timeout = cpp::nullopt,
-                        bool is_shared = false) {
+  LIBC_INLINE ErrorOr<int> wait(FutexWordType expected,
+                                cpp::optional<Timeout> timeout = cpp::nullopt,
+                                bool is_shared = false) {
     // use bitset variants to enforce abs_time
     uint32_t op = is_shared ? FUTEX_WAIT_BITSET : FUTEX_WAIT_BITSET_PRIVATE;
     if (timeout && timeout->is_realtime()) {
@@ -43,7 +43,7 @@ public:
       if (this->load(cpp::MemoryOrder::RELAXED) != expected)
         return 0;
 
-      long ret = syscall_impl<long>(
+      int ret = syscall_impl<int>(
           /* syscall number */ FUTEX_SYSCALL_ID,
           /* futex address */ this,
           /* futex operation  */ op,
@@ -53,15 +53,19 @@ public:
           /* bitset */ FUTEX_BITSET_MATCH_ANY);
 
       // continue waiting if interrupted; otherwise return the result
-      // which should normally be 0 or -ETIMEOUT
-      if (ret == -EINTR)
+      // which should normally be 0 or -ETIMEOUT. we also need to continue
+      // if the error is EAGAIN, where the futex value may be detected as
+      // changed spuriously, and we just poll again to ensure correctness.
+      if (ret == -EINTR || ret == -EAGAIN)
         continue;
 
+      if (ret < 0)
+        return cpp::unexpected(-ret);
       return ret;
     }
   }
-  LIBC_INLINE long notify_one(bool is_shared = false) {
-    return syscall_impl<long>(
+  LIBC_INLINE ErrorOr<int> notify_one(bool is_shared = false) {
+    int ret = syscall_impl<int>(
         /* syscall number */ FUTEX_SYSCALL_ID,
         /* futex address */ this,
         /* futex operation  */ is_shared ? FUTEX_WAKE : FUTEX_WAKE_PRIVATE,
@@ -69,9 +73,12 @@ public:
         /* ignored */ nullptr,
         /* ignored */ nullptr,
         /* ignored */ 0);
+    if (ret < 0)
+      return cpp::unexpected(-ret);
+    return ret;
   }
-  LIBC_INLINE long notify_all(bool is_shared = false) {
-    return syscall_impl<long>(
+  LIBC_INLINE ErrorOr<int> notify_all(bool is_shared = false) {
+    int ret = syscall_impl<int>(
         /* syscall number */ FUTEX_SYSCALL_ID,
         /* futex address */ this,
         /* futex operation  */ is_shared ? FUTEX_WAKE : FUTEX_WAKE_PRIVATE,
@@ -79,6 +86,9 @@ public:
         /* ignored */ nullptr,
         /* ignored */ nullptr,
         /* ignored */ 0);
+    if (ret < 0)
+      return cpp::unexpected(-ret);
+    return ret;
   }
   LIBC_INLINE ErrorOr<int> requeue_to(Futex &other,
                                       cpp::optional<FutexWordType> oldval,

--- a/libc/src/__support/threads/linux/futex_utils.h
+++ b/libc/src/__support/threads/linux/futex_utils.h
@@ -13,6 +13,7 @@
 #include "src/__support/CPP/limits.h"
 #include "src/__support/CPP/optional.h"
 #include "src/__support/OSUtil/syscall.h"
+#include "src/__support/error_or.h"
 #include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/threads/linux/futex_word.h"
@@ -78,6 +79,35 @@ public:
         /* ignored */ nullptr,
         /* ignored */ nullptr,
         /* ignored */ 0);
+  }
+  LIBC_INLINE ErrorOr<int> requeue_to(Futex &other,
+                                      cpp::optional<FutexWordType> oldval,
+                                      int wake_limit, int requeue_limit,
+                                      bool is_shared = false) {
+    int ret;
+    if (oldval)
+      ret = syscall_impl<int>(
+          /* syscall number */ FUTEX_SYSCALL_ID,
+          /* futex address */ this,
+          /* futex operation  */
+          is_shared ? FUTEX_CMP_REQUEUE : FUTEX_CMP_REQUEUE_PRIVATE,
+          /* wake up limit */ wake_limit,
+          /* requeue limit */ requeue_limit,
+          /* requeue address */ &other, *oldval);
+    else
+      ret = syscall_impl<int>(
+          /* syscall number */ FUTEX_SYSCALL_ID,
+          /* futex address */ this,
+          /* futex operation  */
+          is_shared ? FUTEX_REQUEUE : FUTEX_REQUEUE_PRIVATE,
+          /* wake up limit */ wake_limit,
+          /* requeue limit */
+          requeue_limit,
+          /* requeue address */
+          &other);
+    if (ret < 0)
+      return cpp::unexpected<int>(-ret);
+    return static_cast<int>(ret);
   }
 };
 

--- a/libc/src/__support/threads/linux/futex_utils.h
+++ b/libc/src/__support/threads/linux/futex_utils.h
@@ -44,19 +44,17 @@ public:
         return 0;
 
       int ret = syscall_impl<int>(
-          /* syscall number */ FUTEX_SYSCALL_ID,
-          /* futex address */ this,
-          /* futex operation  */ op,
-          /* expected value */ expected,
-          /* timeout */ timeout ? &timeout->get_timespec() : nullptr,
-          /* ignored */ nullptr,
-          /* bitset */ FUTEX_BITSET_MATCH_ANY);
+          /*syscall_number=*/FUTEX_SYSCALL_ID,
+          /*futex_addr=*/this,
+          /*op=*/op,
+          /*expected=*/expected,
+          /*timeout=*/timeout ? &timeout->get_timespec() : nullptr,
+          /*ignored=*/nullptr,
+          /*bitset=*/FUTEX_BITSET_MATCH_ANY);
 
       // continue waiting if interrupted; otherwise return the result
-      // which should normally be 0 or -ETIMEOUT. we also need to continue
-      // if the error is EAGAIN, where the futex value may be detected as
-      // changed spuriously, and we just poll again to ensure correctness.
-      if (ret == -EINTR || ret == -EAGAIN)
+      // which should normally be 0 or -ETIMEOUT.
+      if (ret == -EINTR)
         continue;
 
       if (ret < 0)
@@ -66,12 +64,12 @@ public:
   }
   LIBC_INLINE ErrorOr<int> notify_one(bool is_shared = false) {
     int ret = syscall_impl<int>(
-        /* syscall number */ FUTEX_SYSCALL_ID,
-        /* futex address */ this,
-        /* futex operation  */ is_shared ? FUTEX_WAKE : FUTEX_WAKE_PRIVATE,
-        /* wake up limit */ 1,
-        /* ignored */ nullptr,
-        /* ignored */ nullptr,
+        /*syscall_number=*/FUTEX_SYSCALL_ID,
+        /*futex_addr=*/this,
+        /*op=*/is_shared ? FUTEX_WAKE : FUTEX_WAKE_PRIVATE,
+        /*wake_limit=*/1,
+        /*ignored=*/nullptr,
+        /*ignored=*/nullptr,
         /* ignored */ 0);
     if (ret < 0)
       return cpp::unexpected(-ret);
@@ -79,13 +77,13 @@ public:
   }
   LIBC_INLINE ErrorOr<int> notify_all(bool is_shared = false) {
     int ret = syscall_impl<int>(
-        /* syscall number */ FUTEX_SYSCALL_ID,
-        /* futex address */ this,
-        /* futex operation  */ is_shared ? FUTEX_WAKE : FUTEX_WAKE_PRIVATE,
-        /* wake up limit */ cpp::numeric_limits<int>::max(),
-        /* ignored */ nullptr,
-        /* ignored */ nullptr,
-        /* ignored */ 0);
+        /*syscall_number=*/FUTEX_SYSCALL_ID,
+        /*futex_addr=*/this,
+        /*op=*/is_shared ? FUTEX_WAKE : FUTEX_WAKE_PRIVATE,
+        /*wake_limit=*/cpp::numeric_limits<int>::max(),
+        /*ignored=*/nullptr,
+        /*ignored=*/nullptr,
+        /*ignored=*/0);
     if (ret < 0)
       return cpp::unexpected(-ret);
     return ret;
@@ -97,24 +95,21 @@ public:
     int ret;
     if (oldval)
       ret = syscall_impl<int>(
-          /* syscall number */ FUTEX_SYSCALL_ID,
-          /* futex address */ this,
-          /* futex operation  */
+          /*syscall_number=*/FUTEX_SYSCALL_ID,
+          /*futex_addr=*/this,
+          /*op=*/
           is_shared ? FUTEX_CMP_REQUEUE : FUTEX_CMP_REQUEUE_PRIVATE,
-          /* wake up limit */ wake_limit,
-          /* requeue limit */ requeue_limit,
-          /* requeue address */ &other, *oldval);
+          /*wake_limit=*/wake_limit,
+          /*requeue_limit=*/requeue_limit,
+          /*requeue_addr=*/&other, *oldval);
     else
       ret = syscall_impl<int>(
-          /* syscall number */ FUTEX_SYSCALL_ID,
-          /* futex address */ this,
-          /* futex operation  */
-          is_shared ? FUTEX_REQUEUE : FUTEX_REQUEUE_PRIVATE,
-          /* wake up limit */ wake_limit,
-          /* requeue limit */
-          requeue_limit,
-          /* requeue address */
-          &other);
+          /*syscall_number=*/FUTEX_SYSCALL_ID,
+          /*futex_addr=*/this,
+          /*op=*/is_shared ? FUTEX_REQUEUE : FUTEX_REQUEUE_PRIVATE,
+          /*wake_limit=*/wake_limit,
+          /*requeue_limit=*/requeue_limit,
+          /*requeue_addr=*/&other);
     if (ret < 0)
       return cpp::unexpected<int>(-ret);
     return static_cast<int>(ret);

--- a/libc/src/__support/threads/raw_mutex.h
+++ b/libc/src/__support/threads/raw_mutex.h
@@ -86,8 +86,10 @@ private:
           futex.exchange(IN_CONTENTION, cpp::MemoryOrder::ACQUIRE) == UNLOCKED)
         return true;
       // Contention persists. Park the thread and wait for further notification.
-      if (ETIMEDOUT == -futex.wait(IN_CONTENTION, timeout, is_pshared))
+      if (!futex.wait(IN_CONTENTION, timeout, is_pshared).has_value() &&
+          timeout.has_value())
         return false;
+
       // Continue to spin after waking up.
       state = spin(spin_count);
     }

--- a/libc/src/__support/threads/raw_mutex.h
+++ b/libc/src/__support/threads/raw_mutex.h
@@ -15,16 +15,11 @@
 #include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h"
+#include "src/__support/threads/futex_utils.h"
 #include "src/__support/threads/sleep.h"
 #include "src/__support/time/abs_timeout.h"
 
 #include <stdio.h>
-
-#if defined(__linux__)
-#include "src/__support/threads/linux/futex_utils.h"
-#elif defined(__APPLE__)
-#include "src/__support/threads/darwin/futex_utils.h"
-#endif
 
 #ifndef LIBC_COPT_TIMEOUT_ENSURE_MONOTONICITY
 #define LIBC_COPT_TIMEOUT_ENSURE_MONOTONICITY 1

--- a/libc/src/__support/threads/raw_rwlock.h
+++ b/libc/src/__support/threads/raw_rwlock.h
@@ -99,16 +99,16 @@ public:
   }
 
   template <Role role>
-  LIBC_INLINE long wait(FutexWordType expected,
-                        cpp::optional<Futex::Timeout> timeout,
-                        bool is_pshared) {
+  LIBC_INLINE ErrorOr<int> wait(FutexWordType expected,
+                                cpp::optional<Futex::Timeout> timeout,
+                                bool is_pshared) {
     if constexpr (role == Role::Reader)
       return reader_serialization.wait(expected, timeout, is_pshared);
     else
       return writer_serialization.wait(expected, timeout, is_pshared);
   }
 
-  template <Role role> LIBC_INLINE long notify(bool is_pshared) {
+  template <Role role> LIBC_INLINE ErrorOr<int> notify(bool is_pshared) {
     if constexpr (role == Role::Reader)
       return reader_serialization.notify_all(is_pshared);
     else
@@ -403,9 +403,10 @@ private:
       // Phase 6: do futex wait until the lock is available or timeout is
       // reached.
       bool timeout_flag = false;
-      if (!old.can_acquire<role>(get_preference()))
-        timeout_flag = (queue.wait<role>(serial_number, timeout, is_pshared) ==
-                        -ETIMEDOUT);
+      if (!old.can_acquire<role>(get_preference())) {
+        auto result = queue.wait<role>(serial_number, timeout, is_pshared);
+        timeout_flag = (!result.has_value() && timeout.has_value());
+      }
 
       // Phase 7: unregister ourselves as a pending reader/writer.
       {

--- a/libc/src/semaphore/CMakeLists.txt
+++ b/libc/src/semaphore/CMakeLists.txt
@@ -4,5 +4,5 @@ add_header_library(
     posix_semaphore.h
   DEPENDS
     libc.src.__support.CPP.atomic
-    libc.src.__support.threads.linux.futex_utils
+    libc.src.__support.threads.futex_utils
 )

--- a/libc/src/semaphore/posix_semaphore.h
+++ b/libc/src/semaphore/posix_semaphore.h
@@ -11,7 +11,7 @@
 
 #include "src/__support/CPP/atomic.h"
 #include "src/__support/common.h"
-#include "src/__support/threads/linux/futex_utils.h"
+#include "src/__support/threads/futex_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/test/integration/src/__support/threads/CMakeLists.txt
+++ b/libc/test/integration/src/__support/threads/CMakeLists.txt
@@ -46,3 +46,16 @@ add_integration_test(
     libc.src.__support.threads.thread
     libc.src.stdlib.exit
 )
+
+add_integration_test(
+  futex_requeue_test
+  SUITE
+    libc-support-threads-integration-tests
+  SRCS
+    futex_requeue_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.include.pthread
+    libc.src.pthread.pthread_create
+    libc.src.pthread.pthread_join
+)

--- a/libc/test/integration/src/__support/threads/futex_requeue_test.cpp
+++ b/libc/test/integration/src/__support/threads/futex_requeue_test.cpp
@@ -1,0 +1,80 @@
+//===-- Integration test for futex requeue with real threads --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "src/__support/CPP/optional.h"
+#include "src/__support/threads/futex_utils.h"
+#include "src/__support/threads/sleep.h"
+#include "src/pthread/pthread_create.h"
+#include "src/pthread/pthread_join.h"
+#include "test/IntegrationTest/test.h"
+
+#include <pthread.h>
+
+namespace {
+
+constexpr int NUM_ITERATIONS = 1000;
+
+struct SharedState {
+  LIBC_NAMESPACE::Futex lock1{1};
+  LIBC_NAMESPACE::Futex lock2{1};
+  LIBC_NAMESPACE::cpp::Atomic<int> started{0};
+};
+
+void wait_until_zero(LIBC_NAMESPACE::Futex &futex) {
+  while (futex.load() != 0) {
+    auto wait_result = futex.wait(1, LIBC_NAMESPACE::cpp::nullopt, false);
+    ASSERT_TRUE(wait_result.has_value() || wait_result.error() == EAGAIN);
+  }
+}
+
+void *worker(void *arg) {
+  auto *state = reinterpret_cast<SharedState *>(arg);
+
+  // This mimics a dual mutex handover process.
+  state->started.store(1);
+  wait_until_zero(state->lock1);
+  wait_until_zero(state->lock2);
+
+  return nullptr;
+}
+
+void futex_requeue_test() {
+  for (int i = 0; i < NUM_ITERATIONS; ++i) {
+    SharedState state;
+    pthread_t thread;
+
+    ASSERT_EQ(LIBC_NAMESPACE::pthread_create(&thread, nullptr, worker, &state),
+              0);
+
+    while (state.started.load() == 0)
+      LIBC_NAMESPACE::sleep_briefly();
+
+    state.lock1.store(0);
+    auto requeue_result = state.lock1.requeue_to(
+        state.lock2, LIBC_NAMESPACE::FutexWordType(0), 0, 1, false);
+    if (!requeue_result.has_value()) {
+      ASSERT_EQ(requeue_result.error(), ENOSYS);
+      auto wake_first = state.lock1.notify_one(false);
+      ASSERT_TRUE(wake_first.has_value());
+    }
+
+    state.lock2.store(0);
+    auto wake_second = state.lock2.notify_one(false);
+    ASSERT_TRUE(wake_second.has_value());
+
+    ASSERT_EQ(LIBC_NAMESPACE::pthread_join(thread, nullptr), 0);
+  }
+}
+
+} // namespace
+
+TEST_MAIN() {
+  futex_requeue_test();
+  return 0;
+}

--- a/libc/test/src/__support/threads/CMakeLists.txt
+++ b/libc/test/src/__support/threads/CMakeLists.txt
@@ -1,4 +1,17 @@
 add_custom_target(libc-support-threads-tests)
+
+if(TARGET libc.src.__support.threads.${LIBC_TARGET_OS}.futex_utils)
+  add_libc_test(
+    futex_utils_test
+    SUITE
+      libc-support-threads-tests
+    SRCS
+      futex_utils_test.cpp
+    DEPENDS
+      libc.src.__support.threads.futex_utils
+  )
+endif()
+
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
   add_subdirectory(${LIBC_TARGET_OS})
 endif()

--- a/libc/test/src/__support/threads/futex_utils_test.cpp
+++ b/libc/test/src/__support/threads/futex_utils_test.cpp
@@ -10,7 +10,7 @@
 #include "src/__support/threads/futex_utils.h"
 #include "test/UnitTest/Test.h"
 
-#include <errno.h>
+#include "hdr/errno_macros.h"
 
 TEST(LlvmLibcSupportThreadsFutexUtilsTest, RequeueSmokeTest) {
   LIBC_NAMESPACE::Futex source(1);

--- a/libc/test/src/__support/threads/futex_utils_test.cpp
+++ b/libc/test/src/__support/threads/futex_utils_test.cpp
@@ -1,0 +1,37 @@
+//===-- Unittests for futex utilities ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/CPP/optional.h"
+#include "src/__support/threads/futex_utils.h"
+#include "test/UnitTest/Test.h"
+
+#include <errno.h>
+
+TEST(LlvmLibcSupportThreadsFutexUtilsTest, RequeueSmokeTest) {
+  LIBC_NAMESPACE::Futex source(1);
+  LIBC_NAMESPACE::Futex destination(2);
+
+  auto no_requeue = source.requeue_to(destination, 1, 1, 0);
+  if (no_requeue.has_value())
+    ASSERT_EQ(*no_requeue, 0);
+  else
+    ASSERT_EQ(no_requeue.error(), ENOSYS);
+
+  auto no_wake = source.requeue_to(destination, 1, 0, 1);
+  if (no_wake.has_value())
+    ASSERT_EQ(*no_wake, 0);
+  else
+    ASSERT_EQ(no_wake.error(), ENOSYS);
+
+  auto cmp_mismatch = source.requeue_to(destination, 0, 0, 1);
+  if (cmp_mismatch.has_value())
+    ASSERT_EQ(*cmp_mismatch, 0);
+  else
+    ASSERT_TRUE(cmp_mismatch.error() == ENOSYS ||
+                cmp_mismatch.error() == EAGAIN);
+}


### PR DESCRIPTION
Make futex a common abstraction layer across platforms. (linux/wasm/macOS/windows/fuchsia all have the support, which we can align their support later on).

This patch also expose a requeue API that returns ENOSYS on unsupported platforms. The requeue operation will be needed to reimplement a strict FIFO style condvar similar to musl.

Additional cleanup is done to change raw syscall return value to `ErrorOr<int>`.

Assisted-by: Codex with gpt-5.4 medium fast