### PR TITLE
[mlir] Fix copy paste typo in convertFromAttribute

### DIFF
--- a/mlir/lib/IR/ODSSupport.cpp
+++ b/mlir/lib/IR/ODSSupport.cpp
@@ -102,8 +102,7 @@ mlir::convertFromAttribute(bool &storage, Attribute attr,
                            function_ref<InFlightDiagnostic()> emitError) {
   auto valueAttr = dyn_cast<BoolAttr>(attr);
   if (!valueAttr)
-    return emitError()
-           << "expected string property to come from string attribute";
+    return emitError() << "expected BoolAttr for key `value`";
   storage = valueAttr.getValue();
   return success();
 }

--- a/mlir/test/IR/invalid-properties.mlir
+++ b/mlir/test/IR/invalid-properties.mlir
@@ -1,0 +1,49 @@
+// RUN: mlir-opt -verify-diagnostics -split-input-file %s
+
+
+// -----
+
+func.func @wrong_string_prop_type() {
+  // expected-error@+1 {{expected string property to come from string attribute}}
+  "test.with_properties"() <{b = "foo", c = 32 : i64}> : () -> ()
+  return
+}
+
+// -----
+
+func.func @wrong_bool_prop_type() {
+  // expected-error@+1 {{expected BoolAttr for key `value`}}
+  "test.with_properties"() <{b = "foo", flag = "bar"}> : () -> ()
+  return
+}
+
+// -----
+
+func.func @wrong_integer_prop_type() {
+  // expected-error@+1 {{expected IntegerAttr for key `value`}}
+  "test.with_properties"() <{b = "foo", a = "bar"}> : () -> ()
+  return
+}
+
+// -----
+
+func.func @wrong_dense_i64_array_prop_type() {
+  // expected-error@+1 {{expected DenseI64ArrayAttr for key `value`}}
+  "test.with_properties"() <{b = "foo", array = array<i32: 1, 2, 3, 4>}> : () -> ()
+  return
+}
+
+// -----
+
+func.func @wrong_dense_i32_array_prop_type() {
+  // expected-error@+1 {{expected DenseI32ArrayAttr for key `value`}}
+  "test.with_properties"() <{b = "foo", array32 = array<i64: 5, 6>}> : () -> ()
+  return
+}
+
+// -----
+
+func.func @valid_all_properties() {
+  "test.with_properties"() <{a = 32 : i64, array = array<i64: 1, 2, 3, 4>, array32 = array<i32: 5, 6>, b = "foo", c = "bar", flag = true}> : () -> ()
+  return
+}


### PR DESCRIPTION
It seems that the bool overload for `convertFromAttribute` has a failure message incorrectly copied over from the string overload's implementation.