### PR TITLE
[Lexer] Prevent hitting the file system for ASTReader tokens

### DIFF
--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -874,6 +874,13 @@ SourceLocation Lexer::getLocForEndOfToken(SourceLocation Loc, unsigned Offset,
       return Loc;
   }
 
+  // Don't hit the file system for ASTReader tokens.
+  if (SM.isLoadedSourceLocation(Loc)) {
+    FileID FID = SM.getFileID(Loc);
+    if (!SM.getFileEntryRefForID(FID))
+      return Loc;
+  }
+
   unsigned Len = Lexer::MeasureTokenLength(Loc, SM, LangOpts);
   if (Len > Offset)
     Len = Len - Offset;

--- a/clang/test/Lexer/pch-deleted-header.cpp
+++ b/clang/test/Lexer/pch-deleted-header.cpp
@@ -1,0 +1,15 @@
+// RUN: rm -f %t.h %t.pch
+// RUN: echo "int variable_del_cern = 42;" > %t.h
+// RUN: %clang_cc1 -x c++-header -emit-pch -o %t.pch %t.h
+// RUN: rm %t.h
+// RUN: %clang_cc1 -fno-validate-pch -ast-dump -include-pch %t.pch %s
+
+// This test ensures that Clang does not access the filesystem when
+// handling SourceLocations originating from a PCH.
+//
+// After generating the PCH, the original header is removed. If Clang
+// attempts to access it (e.g. via MeasureTokenLength), the test will fail.
+
+int function() { 
+    return variable_del_cern; 
+}


### PR DESCRIPTION
This patch resolves an issue where the Lexer would attempt to measure token lengths from the physical file system (via MeasureTokenLength) even when the SourceLocation was already loaded from a precompiled AST or module.

In environments like interactive C++ (ROOT/Cling) where the original headers might be temporary or removed after the PCH generation, this caused fatal 'file not found' errors.

This upstreaming effort matches ROOT-7111. It includes a robust, cross-platform regression test that deletes the underlying header and uses -ast-dump to force source location resolution without triggering the diagnostics engine's file system checks.

**Note:** This work is submitted as part of my evaluation process for the ROOT/Compiler Fellowship program.
CC: @vgvassilev