### PR TITLE
[OpenMP][Device] Fix __llvm_omp_indirect_call_lookup function pointer types

### DIFF
--- a/offload/test/api/omp_indirect_call_table_manual.c
+++ b/offload/test/api/omp_indirect_call_table_manual.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 // REQUIRES: gpu
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/api/omp_indirect_func_array.c
+++ b/offload/test/api/omp_indirect_func_array.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>

--- a/offload/test/api/omp_indirect_func_struct.c
+++ b/offload/test/api/omp_indirect_func_struct.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>

--- a/openmp/device/src/Misc.cpp
+++ b/openmp/device/src/Misc.cpp
@@ -23,13 +23,13 @@ namespace impl {
 /// Lookup a device-side function using a host pointer /p HstPtr using the table
 /// provided by the device plugin. The table is an ordered pair of host and
 /// device pointers sorted on the value of the host pointer.
-static void *indirectCallLookup(void *HstPtr) {
+static FnPtrTy indirectCallLookup(FnPtrTy HstPtr) {
   if (!HstPtr)
     return nullptr;
 
   struct IndirectCallTable {
-    void *HstPtr;
-    void *DevPtr;
+    FnPtrTy HstPtr;
+    FnPtrTy DevPtr;
   };
   IndirectCallTable *Table =
       reinterpret_cast<IndirectCallTable *>(config::getIndirectCallTablePtr());
@@ -89,7 +89,7 @@ double omp_get_wtime(void) {
   return static_cast<double>(__builtin_readsteadycounter()) * omp_get_wtick();
 }
 
-void *__llvm_omp_indirect_call_lookup(void *HstPtr) {
+FnPtrTy __llvm_omp_indirect_call_lookup(FnPtrTy HstPtr) {
   return ompx::impl::indirectCallLookup(HstPtr);
 }
 


### PR DESCRIPTION
`__llvm_omp_indirect_call_lookup` takes in and returns a function pointer, so make sure the types are correct, which includes the correct address space.

The FE was recently changed to generate the correct code [here](https://github.com/llvm/llvm-project/pull/192470).

With this change, three function pointer tests start passing.