### PR TITLE
[DWARF] Disable generation of cross-CU references for DWARF V2

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -185,6 +185,13 @@ bool DwarfUnit::isShareableAcrossCUs(const DINode *D) const {
   // level already) but may be implementable for some value in projects
   // building multiple independent libraries with LTO and then linking those
   // together.
+
+  // Prevent generation of cross-CU references for DWARF v2 due to conflicts
+  // resulting from the FAQ recommendation: "If you are producing DWARF V2,
+  // please use the DWARF V3 definition of DW_FORM_ref_addr."
+  // (https://dwarfstd.org/faq.html)
+  if (DD->getDwarfVersion() == 2)
+    return false;
   if (isDwoUnit() && !DD->shareAcrossDWOCUs())
     return false;
   return (isa<DIType>(D) ||

--- a/llvm/test/DebugInfo/Generic/cross-cu-no-ref-addr-dwarf-v2.ll
+++ b/llvm/test/DebugInfo/Generic/cross-cu-no-ref-addr-dwarf-v2.ll
@@ -1,0 +1,47 @@
+; RUN: %llc_dwarf -dwarf-version=3 -O0 -filetype=obj < %s | llvm-dwarfdump -v -debug-info - | FileCheck --check-prefix=CHECK-V3 %s
+; RUN: %llc_dwarf -dwarf-version=2 -O0 -filetype=obj < %s | llvm-dwarfdump -v -debug-info - | FileCheck --check-prefix=CHECK-V2 --implicit-check-not=DW_FORM_ref_addr %s
+
+; DWARF V3: Expect cross-CU type deduplication resulting in only one "int"
+; definition and a DW_FORM_ref_addr.
+
+; CHECK-V3: DW_TAG_compile_unit
+; CHECK-V3: DW_AT_name{{.*}}"a.cpp"
+; CHECK-V3: DW_TAG_base_type
+; CHECK-V3: DW_AT_name{{.*}}"int"
+; CHECK-V3: DW_TAG_compile_unit
+; CHECK-V3: DW_AT_name{{.*}}"b.cpp"
+; CHECK-V3: DW_AT_type [DW_FORM_ref_addr]
+
+; DWARF V2: cross-CU type deduplication disabled resulting in two "int"
+; definitions and no DW_FORM_ref_addr (cross-CU ref)
+
+; CHECK-V2: DW_TAG_compile_unit
+; CHECK-V2: DW_AT_name{{.*}}"a.cpp"
+; CHECK-V2: DW_TAG_base_type
+; CHECK-V2: DW_AT_name{{.*}}"int"
+; CHECK-V2: DW_TAG_compile_unit
+; CHECK-V2: DW_AT_name{{.*}}"b.cpp"
+; CHECK-V2: DW_TAG_base_type
+; CHECK-V2: DW_AT_name{{.*}}"int"
+
+@x = global i32 0, !dbg !0
+@y = global i32 0, !dbg !7
+
+!llvm.dbg.cu = !{!2, !9}
+!llvm.module.flags = !{!13, !14}
+!llvm.ident = !{!15}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "x", scope: !2, file: !3, line: 1, type: !5, isLocal: false, isDefinition: true)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !4)
+!3 = !DIFile(filename: "a.cpp", directory: "/tmp/dbginfo")
+!4 = !{!0}
+!5 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
+!8 = distinct !DIGlobalVariable(name: "y", scope: !9, file: !10, line: 1, type: !5, isLocal: false, isDefinition: true)
+!9 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !10, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !11)
+!10 = !DIFile(filename: "b.cpp", directory: "/tmp/dbginfo")
+!11 = !{!7}
+!13 = !{i32 2, !"Dwarf Version", i32 4}
+!14 = !{i32 2, !"Debug Info Version", i32 3}
+!15 = !{!"clang"}

--- a/llvm/test/DebugInfo/Generic/cross-cu-no-ref-addr-dwarf-v2.ll
+++ b/llvm/test/DebugInfo/Generic/cross-cu-no-ref-addr-dwarf-v2.ll
@@ -1,28 +1,40 @@
 ; RUN: %llc_dwarf -dwarf-version=3 -O0 -filetype=obj < %s | llvm-dwarfdump -v -debug-info - | FileCheck --check-prefix=CHECK-V3 %s
 ; RUN: %llc_dwarf -dwarf-version=2 -O0 -filetype=obj < %s | llvm-dwarfdump -v -debug-info - | FileCheck --check-prefix=CHECK-V2 --implicit-check-not=DW_FORM_ref_addr %s
 
+; DWARF v2 is incompatible with 64-bit XCOFF/AIX (requires DWARF64 format which needs DWARF v3+).
+; UNSUPPORTED: target=powerpc64{{.*}}-aix{{.*}}
+
 ; DWARF V3: Expect cross-CU type deduplication resulting in only one "int"
 ; definition and a DW_FORM_ref_addr.
 
+; CHECK-V3: Compile Unit{{.*}} version = 0x0003
+
 ; CHECK-V3: DW_TAG_compile_unit
-; CHECK-V3: DW_AT_name{{.*}}"a.cpp"
-; CHECK-V3: DW_TAG_base_type
-; CHECK-V3: DW_AT_name{{.*}}"int"
+; CHECK-V3: DW_AT_name{{.*}}"x"
+; CHECK-V3-NEXT: DW_AT_type [DW_FORM_ref4]{{.*}}(cu + {{.*}} => {0x[[INT_ADDR:[0-9a-f]+]]} "int")
+; CHECK-V3: [[INT_ADDR]]:{{.*}}DW_TAG_base_type
+; CHECK-V3-NEXT: DW_AT_name{{.*}}"int"
+
 ; CHECK-V3: DW_TAG_compile_unit
-; CHECK-V3: DW_AT_name{{.*}}"b.cpp"
-; CHECK-V3: DW_AT_type [DW_FORM_ref_addr]
+; CHECK-V3: DW_AT_name{{.*}}"y"
+; CHECK-V3-NEXT: DW_AT_type [DW_FORM_ref_addr]{{.*}}(0x{{0*}}[[INT_ADDR]] "int")
 
 ; DWARF V2: cross-CU type deduplication disabled resulting in two "int"
 ; definitions and no DW_FORM_ref_addr (cross-CU ref)
 
+; CHECK-V2: Compile Unit{{.*}} version = 0x0002
+
 ; CHECK-V2: DW_TAG_compile_unit
-; CHECK-V2: DW_AT_name{{.*}}"a.cpp"
-; CHECK-V2: DW_TAG_base_type
-; CHECK-V2: DW_AT_name{{.*}}"int"
+; CHECK-V2: DW_AT_name{{.*}}"x"
+; CHECK-V2-NEXT: DW_AT_type [DW_FORM_ref4]{{.*}}(cu + {{.*}} => {0x[[X_INT_ADDR:[0-9a-f]+]]} "int")
+; CHECK-V2: [[X_INT_ADDR]]:{{.*}}DW_TAG_base_type
+; CHECK-V2-NEXT: DW_AT_name{{.*}}"int"
+
 ; CHECK-V2: DW_TAG_compile_unit
-; CHECK-V2: DW_AT_name{{.*}}"b.cpp"
-; CHECK-V2: DW_TAG_base_type
-; CHECK-V2: DW_AT_name{{.*}}"int"
+; CHECK-V2: DW_AT_name{{.*}}"y"
+; CHECK-V2-NEXT: DW_AT_type [DW_FORM_ref4]{{.*}}(cu + {{.*}} => {0x[[Y_INT_ADDR:[0-9a-f]+]]} "int")
+; CHECK-V2: [[Y_INT_ADDR]]:{{.*}}DW_TAG_base_type
+; CHECK-V2-NEXT: DW_AT_name{{.*}}"int"
 
 @x = global i32 0, !dbg !0
 @y = global i32 0, !dbg !7
@@ -42,6 +54,6 @@
 !9 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !10, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !11)
 !10 = !DIFile(filename: "b.cpp", directory: "/tmp/dbginfo")
 !11 = !{!7}
-!13 = !{i32 2, !"Dwarf Version", i32 4}
+!13 = !{i32 2, !"Dwarf Version", i32 2}
 !14 = !{i32 2, !"Debug Info Version", i32 3}
 !15 = !{!"clang"}

--- a/llvm/test/DebugInfo/Generic/cross-cu-no-ref-addr-dwarf-v2.ll
+++ b/llvm/test/DebugInfo/Generic/cross-cu-no-ref-addr-dwarf-v2.ll
@@ -11,13 +11,13 @@
 
 ; CHECK-V3: DW_TAG_compile_unit
 ; CHECK-V3: DW_AT_name{{.*}}"x"
-; CHECK-V3-NEXT: DW_AT_type [DW_FORM_ref4]{{.*}}(cu + {{.*}} => {0x[[INT_ADDR:[0-9a-f]+]]} "int")
+; CHECK-V3-NEXT: DW_AT_type [DW_FORM_ref4]{{.*}}{0x[[INT_ADDR:[0-9a-f]+]]}
 ; CHECK-V3: [[INT_ADDR]]:{{.*}}DW_TAG_base_type
 ; CHECK-V3-NEXT: DW_AT_name{{.*}}"int"
 
 ; CHECK-V3: DW_TAG_compile_unit
 ; CHECK-V3: DW_AT_name{{.*}}"y"
-; CHECK-V3-NEXT: DW_AT_type [DW_FORM_ref_addr]{{.*}}(0x{{0*}}[[INT_ADDR]] "int")
+; CHECK-V3-NEXT: DW_AT_type [DW_FORM_ref_addr]{{.*}}0x{{0*}}[[INT_ADDR]]
 
 ; DWARF V2: cross-CU type deduplication disabled resulting in two "int"
 ; definitions and no DW_FORM_ref_addr (cross-CU ref)
@@ -26,13 +26,13 @@
 
 ; CHECK-V2: DW_TAG_compile_unit
 ; CHECK-V2: DW_AT_name{{.*}}"x"
-; CHECK-V2-NEXT: DW_AT_type [DW_FORM_ref4]{{.*}}(cu + {{.*}} => {0x[[X_INT_ADDR:[0-9a-f]+]]} "int")
+; CHECK-V2-NEXT: DW_AT_type [DW_FORM_ref4]{{.*}}{0x[[X_INT_ADDR:[0-9a-f]+]]}
 ; CHECK-V2: [[X_INT_ADDR]]:{{.*}}DW_TAG_base_type
 ; CHECK-V2-NEXT: DW_AT_name{{.*}}"int"
 
 ; CHECK-V2: DW_TAG_compile_unit
 ; CHECK-V2: DW_AT_name{{.*}}"y"
-; CHECK-V2-NEXT: DW_AT_type [DW_FORM_ref4]{{.*}}(cu + {{.*}} => {0x[[Y_INT_ADDR:[0-9a-f]+]]} "int")
+; CHECK-V2-NEXT: DW_AT_type [DW_FORM_ref4]{{.*}}{0x[[Y_INT_ADDR:[0-9a-f]+]]}
 ; CHECK-V2: [[Y_INT_ADDR]]:{{.*}}DW_TAG_base_type
 ; CHECK-V2-NEXT: DW_AT_name{{.*}}"int"
 

--- a/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll
+++ b/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll
@@ -221,10 +221,21 @@ attributes #2 = { "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp
 ; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
 ; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
 ; CHECK-NEXT: .b8 73                                  // DW_AT_type
-; CHECK-NEXT: .b8 16                                  // DW_FORM_ref_addr
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
 ; CHECK-NEXT: .b8 0                                   // EOM(1)
 ; CHECK-NEXT: .b8 0                                   // EOM(2)
 ; CHECK-NEXT: .b8 6                                   // Abbreviation Code
+; CHECK-NEXT: .b8 36                                  // DW_TAG_base_type
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 62                                  // DW_AT_encoding
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 11                                  // DW_AT_byte_size
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 7                                   // Abbreviation Code
 ; CHECK-NEXT: .b8 46                                  // DW_TAG_subprogram
 ; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
 ; CHECK-NEXT: .b8 17                                  // DW_AT_low_pc
@@ -248,7 +259,7 @@ attributes #2 = { "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp
 ; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
 ; CHECK-NEXT: .b8 0                                   // EOM(1)
 ; CHECK-NEXT: .b8 0                                   // EOM(2)
-; CHECK-NEXT: .b8 7                                   // Abbreviation Code
+; CHECK-NEXT: .b8 8                                   // Abbreviation Code
 ; CHECK-NEXT: .b8 5                                   // DW_TAG_formal_parameter
 ; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
 ; CHECK-NEXT: .b8 2                                   // DW_AT_location
@@ -263,27 +274,16 @@ attributes #2 = { "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp
 ; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
 ; CHECK-NEXT: .b8 0                                   // EOM(1)
 ; CHECK-NEXT: .b8 0                                   // EOM(2)
-; CHECK-NEXT: .b8 8                                   // Abbreviation Code
-; CHECK-NEXT: .b8 36                                  // DW_TAG_base_type
-; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT: .b8 3                                   // DW_AT_name
-; CHECK-NEXT: .b8 8                                   // DW_FORM_string
-; CHECK-NEXT: .b8 62                                  // DW_AT_encoding
-; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
-; CHECK-NEXT: .b8 11                                  // DW_AT_byte_size
-; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
-; CHECK-NEXT: .b8 0                                   // EOM(1)
-; CHECK-NEXT: .b8 0                                   // EOM(2)
 ; CHECK-NEXT: .b8 0                                   // EOM(3)
 ; CHECK-NEXT: 	}
 ; CHECK-NEXT: 	.section	.debug_info
 ; CHECK-NEXT: 	{
-; CHECK-NEXT: .b32 143                                // Length of Unit
+; CHECK-NEXT: .b32 146                                // Length of Unit
 ; CHECK-NEXT: .b8 2                                   // DWARF version number
 ; CHECK-NEXT: .b8 0
 ; CHECK-NEXT: .b32 .debug_abbrev                      // Offset Into Abbrev. Section
 ; CHECK-NEXT: .b8 8                                   // Address Size (in bytes)
-; CHECK-NEXT: .b8 1                                   // Abbrev [1] 0xb:0x88 DW_TAG_compile_unit
+; CHECK-NEXT: .b8 1                                   // Abbrev [1] 0xb:0x8b DW_TAG_compile_unit
 ; CHECK-NEXT: .b8 99                                  // DW_AT_producer
 ; CHECK-NEXT: .b8 108
 ; CHECK-NEXT: .b8 97
@@ -357,7 +357,7 @@ attributes #2 = { "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp
 ; CHECK-NEXT: .b8 65                                  // DW_AT_name
 ; CHECK-NEXT: .b8 0
 ; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
-; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0x58:0x3a DW_TAG_subprogram
+; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0x58:0x36 DW_TAG_subprogram
 ; CHECK-NEXT: .b64 $L__func_begin1                    // DW_AT_low_pc
 ; CHECK-NEXT: .b64 $L__func_end1                      // DW_AT_high_pc
 ; CHECK-NEXT: .b8 1                                   // DW_AT_frame_base
@@ -384,13 +384,20 @@ attributes #2 = { "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp
 ; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
 ; CHECK-NEXT: .b8 6                                   // DW_AT_decl_line
 ; CHECK-NEXT: .b32 84                                 // DW_AT_type
-; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x84:0xd DW_TAG_variable
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x84:0x9 DW_TAG_variable
 ; CHECK-NEXT: .b8 122                                 // DW_AT_name
 ; CHECK-NEXT: .b8 0
 ; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
 ; CHECK-NEXT: .b8 7                                   // DW_AT_decl_line
-; CHECK-NEXT: .b64 .debug_info+283                    // DW_AT_type
+; CHECK-NEXT: .b32 142                                // DW_AT_type
 ; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 6                                   // Abbrev [6] 0x8e:0x7 DW_TAG_base_type
+; CHECK-NEXT: .b8 105                                 // DW_AT_name
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 5                                   // DW_AT_encoding
+; CHECK-NEXT: .b8 4                                   // DW_AT_byte_size
 ; CHECK-NEXT: .b8 0                                   // End Of Children Mark
 ; CHECK-NEXT: .b32 140                                // Length of Unit
 ; CHECK-NEXT: .b8 2                                   // DWARF version number
@@ -467,7 +474,7 @@ attributes #2 = { "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp
 ; CHECK-NEXT: .b8 99
 ; CHECK-NEXT: .b8 99
 ; CHECK-NEXT: .b8 0
-; CHECK-NEXT: .b8 6                                   // Abbrev [6] 0x54:0x34 DW_TAG_subprogram
+; CHECK-NEXT: .b8 7                                   // Abbrev [7] 0x54:0x34 DW_TAG_subprogram
 ; CHECK-NEXT: .b64 $L__func_begin0                    // DW_AT_low_pc
 ; CHECK-NEXT: .b64 $L__func_end0                      // DW_AT_high_pc
 ; CHECK-NEXT: .b8 1                                   // DW_AT_frame_base
@@ -488,7 +495,7 @@ attributes #2 = { "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp
 ; CHECK-NEXT: .b8 1                                   // DW_AT_decl_line
 ; CHECK-NEXT: .b32 136                                // DW_AT_type
 ; CHECK-NEXT: .b8 1                                   // DW_AT_external
-; CHECK-NEXT: .b8 7                                   // Abbrev [7] 0x7a:0xd DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 8                                   // Abbrev [8] 0x7a:0xd DW_TAG_formal_parameter
 ; CHECK-NEXT: .b32 $L__debug_loc0                     // DW_AT_location
 ; CHECK-NEXT: .b8 98                                  // DW_AT_name
 ; CHECK-NEXT: .b8 0
@@ -496,7 +503,7 @@ attributes #2 = { "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp
 ; CHECK-NEXT: .b8 1                                   // DW_AT_decl_line
 ; CHECK-NEXT: .b32 136                                // DW_AT_type
 ; CHECK-NEXT: .b8 0                                   // End Of Children Mark
-; CHECK-NEXT: .b8 8                                   // Abbrev [8] 0x88:0x7 DW_TAG_base_type
+; CHECK-NEXT: .b8 6                                   // Abbrev [6] 0x88:0x7 DW_TAG_base_type
 ; CHECK-NEXT: .b8 105                                 // DW_AT_name
 ; CHECK-NEXT: .b8 110
 ; CHECK-NEXT: .b8 116

--- a/llvm/test/DebugInfo/X86/ref_addr_relocation.ll
+++ b/llvm/test/DebugInfo/X86/ref_addr_relocation.ll
@@ -1,20 +1,12 @@
-; RUN: llc -filetype=asm -O0 -mtriple=x86_64-linux-gnu < %s -dwarf-version 2 | FileCheck -check-prefixes=CHECK,ELF-ASM %s
-; RUN: llc -filetype=obj -O0 %s -mtriple=x86_64-linux-gnu -o %t-2 -dwarf-version 2
-; RUN: llvm-dwarfdump -v %t-2 | FileCheck %s -check-prefix=CHECK-DWARF
-; RUN: llc -filetype=obj -O0 %s -mtriple=x86_64-linux-gnu -o %t-4 -dwarf-version 2
+; RUN: llc -filetype=asm -O0 -mtriple=x86_64-linux-gnu < %s -dwarf-version 4 | FileCheck -check-prefixes=CHECK,ELF-ASM %s
+; RUN: llc -filetype=obj -O0 %s -mtriple=x86_64-linux-gnu -o %t-4 -dwarf-version 4
 ; RUN: llvm-dwarfdump -v %t-4 | FileCheck %s -check-prefix=CHECK-DWARF
 
-; RUN: llc -filetype=asm -O0 -mtriple=x86_64-apple-darwin < %s -dwarf-version 2 | FileCheck -check-prefixes=CHECK,DARWIN-ASM2 %s
-; RUN: llc -filetype=asm -O0 -mtriple=x86_64-apple-darwin < %s -dwarf-version 4 | FileCheck -check-prefixes=CHECK,DARWIN-ASM4 %s
-; RUN: llc -filetype=obj %s -mtriple=x86_64-apple-darwin -o %t2-2 -dwarf-version 2
-; RUN: llvm-dwarfdump -v %t2-2 | FileCheck %s -check-prefix=CHECK-DWARF
+; RUN: llc -filetype=asm -O0 -mtriple=x86_64-apple-darwin < %s -dwarf-version 4 | FileCheck -check-prefixes=CHECK,DARWIN-ASM %s
 ; RUN: llc -filetype=obj %s -mtriple=x86_64-apple-darwin -o %t2-4 -dwarf-version 4
 ; RUN: llvm-dwarfdump -v %t2-4 | FileCheck %s -check-prefix=CHECK-DWARF
 
-; RUN: llc -filetype=asm -O0 -mtriple=x86_64-pc-win32 < %s -dwarf-version 2 | FileCheck -check-prefixes=CHECK,COFF-ASM %s
 ; RUN: llc -filetype=asm -O0 -mtriple=x86_64-pc-win32 < %s -dwarf-version 4 | FileCheck -check-prefixes=CHECK,COFF-ASM %s
-; RUN: llc -filetype=obj -O0 %s -mtriple=x86_64-pc-win32 -o %t3-2 -dwarf-version 2
-; RUN: llvm-dwarfdump -v %t3-2 | FileCheck %s -check-prefix=CHECK-DWARF2
 ; RUN: llc -filetype=obj -O0 %s -mtriple=x86_64-pc-win32 -o %t3-4 -dwarf-version 4
 ; RUN: llvm-dwarfdump -v %t3-4 | FileCheck %s -check-prefix=CHECK-DWARF
 
@@ -36,8 +28,7 @@
 ; CHECK: DW_TAG_structure_type
 ; CHECK: DW_TAG_variable
 ; ELF-ASM: .long [[TYPE:.*]] # DW_AT_type
-; DARWIN-ASM2: .long [[TYPE:.*]] ## DW_AT_type
-; DARWIN-ASM4: .long [[TYPE:.*]] ## DW_AT_type
+; DARWIN-ASM: .long [[TYPE:.*]] ## DW_AT_type
 ; COFF-ASM: .long [[TYPE:.*]] # DW_AT_type
 ; CHECK: cu_begin1
 ; CHECK: DW_TAG_compile_unit
@@ -46,10 +37,9 @@
 ; CHECK: DW_TAG_variable
 ; Make sure this is relocatable.
 ; and test that we don't create the labels to emit a correct COFF relocation
-; ELF-ASM: .quad .debug_info+[[TYPE]] # DW_AT_type
+; ELF-ASM: .long .debug_info+[[TYPE]] # DW_AT_type
 ; COFF-ASM: .secrel32 .debug_info+[[TYPE]] # DW_AT_type
-; DARWIN-ASM2: .quad [[TYPE]] ## DW_AT_type
-; DARWIN-ASM4: .long [[TYPE]] ## DW_AT_type
+; DARWIN-ASM: .long [[TYPE]] ## DW_AT_type
 ; CHECK-NOT: DW_TAG_structure_type
 ; CHECK: .section
 
@@ -58,11 +48,6 @@
 ; CHECK-DWARF: DW_TAG_compile_unit
 ; CHECK-DWARF: DW_TAG_variable
 ; CHECK-DWARF: DW_AT_type [DW_FORM_ref_addr] {{.*}}[[ADDR]]
-
-; CHECK-DWARF2: DW_TAG_compile_unit
-; CHECK-DWARF2: [[ADDR:.*]]: DW_TAG_structure_type
-; CHECK-DWARF2: DW_TAG_variable
-; CHECK-DWARF2: DW_AT_type [DW_FORM_ref4] {{.*}} => {[[ADDR]]}
 
 source_filename = "test/DebugInfo/X86/ref_addr_relocation.ll"
 
@@ -88,6 +73,6 @@ source_filename = "test/DebugInfo/X86/ref_addr_relocation.ll"
 !11 = !{!0}
 !12 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !8, producer: "clang version 3.4 (trunk 191799)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5, retainedTypes: !10, globals: !13, imports: !5)
 !13 = !{!6}
-!14 = !{i32 2, !"Dwarf Version", i32 2}
+!14 = !{i32 2, !"Dwarf Version", i32 4}
 !15 = !{i32 1, !"Debug Info Version", i32 3}
 

--- a/llvm/test/DebugInfo/X86/sections_as_references.ll
+++ b/llvm/test/DebugInfo/X86/sections_as_references.ll
@@ -1,4 +1,4 @@
-; RUN: llc -filetype=asm -O0 -mtriple=x86_64-linux-gnu < %s -dwarf-sections-as-references=Enable -dwarf-inlined-strings=Enable -no-dwarf-ranges-section -dwarf-version 2 -debugger-tune=gdb | FileCheck %s
+; RUN: llc -filetype=asm -O0 -mtriple=x86_64-linux-gnu < %s -dwarf-sections-as-references=Enable -dwarf-inlined-strings=Enable -no-dwarf-ranges-section -dwarf-version 3 -debugger-tune=gdb | FileCheck %s
 
 ; CHECK:      .file
 
@@ -10,7 +10,7 @@
 
 ; CHECK:      .section .debug_info
 ; CHECK-NOT:  .L
-; CHECK:      .short 2             # DWARF version number
+; CHECK:      .short 3             # DWARF version number
 ; CHECK-NOT:  .L
 ; CHECK:      .long .debug_abbrev  # Offset Into Abbrev. Section
 ; CHECK-NOT:  .L
@@ -20,7 +20,7 @@
 ; CHECK-NOT:  .L
 ; CHECK:      .long .debug_line    # DW_AT_stmt_list
 ; CHECK-NOT:  .L
-; CHECK:      .quad .debug_info+{{[0-9]+}} # DW_AT_type
+; CHECK:      .long .debug_info+{{[0-9]+}} # DW_AT_type
 ; CHECK-NOT:  .L
 ; CHECK:      .byte 0              # End Of Children Mark
 ; CHECK-NOT:  .L
@@ -49,6 +49,6 @@ source_filename = "test/DebugInfo/X86/sections_as_references.ll"
 !11 = !{!0}
 !12 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !8, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5, retainedTypes: !10, globals: !13, imports: !5, nameTableKind: None)
 !13 = !{!6}
-!14 = !{i32 2, !"Dwarf Version", i32 2}
+!14 = !{i32 2, !"Dwarf Version", i32 3}
 !15 = !{i32 1, !"Debug Info Version", i32 3}
 


### PR DESCRIPTION
Though LLVM's treatment of DW_FORM_ref_addr for DWARF V2 follows the spec, it does not follow the recommendation of the FAQ. This works for consumers which expect the V2 spec definition, but breaks those which expect producers to follow the FAQ.

The DWARF V2 spec defines DW_FORM_ref_addr as:

"... the address of any debugging information entry within the same executable or shared object... This type of reference (DW_FORM_ref_addr) is the size of an address on the target architecture..."

And the DWARF FAQ says:

"The DWARF V2 definition never made any sense and was a mistake in the DWARF V2 specification: the field DW_FORM_ref_addr defines is an offset, not an address. If you are producing DWARF V2, please use the DWARF V3 definition of DW_FORM_ref_addr."

Currently for DWARF V2, LLVM continues using address-sizing rather than fully adopting the V3 definition (4 bytes for DWARF32, 8 bytes for DWARF64) as directed by the FAQ.

Given that DWARF V2 is rather old and that the worst case size increase would match that of a non-LTO compilation flow, this PR disables de-duplication of DIEs across CUs to prevent the generation of cross-CU references using DW_FORM_ref_addr for DWARF V2. The alternative solution of updating LLVM to follow the FAQ and generate the DWARF V3 format would break tools currently expecting the V2 format.

Assisted-by: Claude Code (test)