### PR TITLE
[DirectX] Disable DCE and DSE for -O0

### DIFF
--- a/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
+++ b/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
@@ -112,9 +112,13 @@ public:
 
   FunctionPass *createTargetRegisterAllocator(bool) override { return nullptr; }
   void addCodeGenPrepare() override {
+    CodeGenOptLevel OptLevel = getDirectXTargetMachine().getOptLevel();
+
     addPass(createStripConvergenceIntrinsicsPass());
     addPass(createDXILFinalizeLinkageLegacyPass());
-    addPass(createGlobalDCEPass());
+    if (OptLevel != CodeGenOptLevel::None) {
+      addPass(createGlobalDCEPass());
+    }
     addPass(createDXILMemIntrinsicsLegacyPass());
     addPass(createDXILCBufferAccessLegacyPass());
     addPass(createDXILResourceAccessLegacyPass());
@@ -125,7 +129,9 @@ public:
     addPass(createScalarizerPass(DxilScalarOptions));
     addPass(createDXILFlattenArraysLegacyPass());
     addPass(createDXILForwardHandleAccessesLegacyPass());
-    addPass(createDeadStoreEliminationPass());
+    if (OptLevel != CodeGenOptLevel::None) {
+      addPass(createDeadStoreEliminationPass());
+    }
     addPass(createDXILLegalizeLegacyPass());
     addPass(createDXILResourceImplicitBindingLegacyPass());
     addPass(createDXILTranslateMetadataLegacyPass());

--- a/llvm/test/CodeGen/DirectX/llc-pipeline.ll
+++ b/llvm/test/CodeGen/DirectX/llc-pipeline.ll
@@ -1,5 +1,7 @@
-; RUN: llc -filetype=asm -mtriple=dxil-pc-shadermodel6.3-library -debug-pass=Structure < %s -o /dev/null 2>&1 | grep -v "Verify generated machine code" | FileCheck %s --check-prefixes=CHECK,CHECK-ASM
-; RUN: llc -filetype=obj -mtriple=dxil-pc-shadermodel6.3-library -debug-pass=Structure < %s -o /dev/null 2>&1 | grep -v "Verify generated machine code" | FileCheck %s --check-prefixes=CHECK,CHECK-OBJ
+; RUN: llc -filetype=asm -mtriple=dxil-pc-shadermodel6.3-library -O0 -debug-pass=Structure < %s -o /dev/null 2>&1 | grep -v "Verify generated machine code" | FileCheck %s --check-prefixes=CHECK,CHECK-ASM
+; RUN: llc -filetype=asm -mtriple=dxil-pc-shadermodel6.3-library -O1 -debug-pass=Structure < %s -o /dev/null 2>&1 | grep -v "Verify generated machine code" | FileCheck %s --check-prefixes=CHECK,CHECK-O1,CHECK-ASM
+; RUN: llc -filetype=obj -mtriple=dxil-pc-shadermodel6.3-library -O0 -debug-pass=Structure < %s -o /dev/null 2>&1 | grep -v "Verify generated machine code" | FileCheck %s --check-prefixes=CHECK,CHECK-OBJ
+; RUN: llc -filetype=obj -mtriple=dxil-pc-shadermodel6.3-library -O1 -debug-pass=Structure < %s -o /dev/null 2>&1 | grep -v "Verify generated machine code" | FileCheck %s --check-prefixes=CHECK,CHECK-O1,CHECK-OBJ
 
 ; REQUIRES: asserts
 
@@ -8,7 +10,7 @@
 ; CHECK-NEXT: Runtime Library Function Analysis
 ; CHECK-NEXT: DXIL Resource Type Analysis
 ; CHECK-NEXT: Target Transform Information
-; CHECK-NEXT: Assumption Cache Tracker
+; CHECK-O1-NEXT: Assumption Cache Tracker
 ; CHECK-OBJ-NEXT: Machine Module Information
 ; CHECK-OBJ-NEXT: Machine Branch Probability Analysis
 ; CHECK-OBJ-NEXT: Create Garbage Collector Module Metadata
@@ -17,7 +19,7 @@
 ; CHECK-NEXT:   FunctionPass Manager
 ; CHECK-NEXT:     Strip convergence intrinsics and operand bundles
 ; CHECK-NEXT:   DXIL Finalize Linkage
-; CHECK-NEXT:   Dead Global Elimination
+; CHECK-O1-NEXT: Dead Global Elimination
 ; CHECK-NEXT:   DXIL Memory Intrinsic Elimination
 ; CHECK-NEXT:   DXIL CBuffer Access
 ; CHECK-NEXT:   FunctionPass Manager
@@ -31,13 +33,13 @@
 ; CHECK-NEXT:   FunctionPass Manager
 ; CHECK-NEXT:     Dominator Tree Construction
 ; CHECK-NEXT:     DXIL Forward Handle Accesses
-; CHECK-NEXT:     Dominator Tree Construction
-; CHECK-NEXT:     Basic Alias Analysis (stateless AA impl)
-; CHECK-NEXT:     Function Alias Analysis Results
-; CHECK-NEXT:     Post-Dominator Tree Construction
-; CHECK-NEXT:     Memory SSA
-; CHECK-NEXT:     Cycle Info Analysis
-; CHECK-NEXT:     Dead Store Elimination
+; CHECK-O1-NEXT:  Dominator Tree Construction
+; CHECK-O1-NEXT:  Basic Alias Analysis (stateless AA impl)
+; CHECK-O1-NEXT:  Function Alias Analysis Results
+; CHECK-O1-NEXT:  Post-Dominator Tree Construction
+; CHECK-O1-NEXT:  Memory SSA
+; CHECK-O1-NEXT:  Cycle Info Analysis
+; CHECK-O1-NEXT:  Dead Store Elimination
 ; CHECK-NEXT:     DXIL Legalizer
 ; CHECK-NEXT:   DXIL Resource Binding Analysis
 ; CHECK-NEXT:   DXIL Resource Implicit Binding


### PR DESCRIPTION
These are optimisation passes which are inappropriate to run when the user has requested no optimisations, and which make it more difficult to write tests.