### PR TITLE
[NVPTX] Introduce custom AsmStreamer for NVPTX backend

### DIFF
--- a/llvm/lib/Target/NVPTX/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_llvm_component_library(LLVMNVPTXDesc
+  NVPTXAsmStreamer.cpp
   NVPTXInstPrinter.cpp
   NVPTXMCAsmInfo.cpp
   NVPTXMCTargetDesc.cpp

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.cpp
@@ -186,6 +186,8 @@ bool NVPTXAsmStreamer::emitSymbolAttribute(MCSymbol *Symbol,
   case MCSA_Weak:
     OS << MAI->getWeakDirective();
     break;
+  case MCSA_Cold:
+    return false;
   default:
     llvm_unreachable("Unsupported symbol attribute in NVPTXAsmStreamer.");
   }
@@ -205,6 +207,18 @@ void NVPTXAsmStreamer::emitInstruction(const MCInst &Inst,
   }
 
   InstPrinter->printInst(&Inst, 0, "", STI, OS);
+  EmitEOL();
+}
+
+void NVPTXAsmStreamer::emitRelocDirective(const MCExpr &Offset, StringRef Name,
+                                          const MCExpr *Expr, SMLoc) {
+  OS << "\t.reloc ";
+  MAI->printExpr(OS, Offset);
+  OS << ", " << Name;
+  if (Expr) {
+    OS << ", ";
+    MAI->printExpr(OS, *Expr);
+  }
   EmitEOL();
 }
 

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.cpp
@@ -1,4 +1,4 @@
-//===-- NVPTXMCAsmStreamer.cpp - NVPTX assembly text output ----*- C++ -*--===//
+//===-- NVPTXAsmStreamer.cpp - NVPTX assembly text output ------*- C++ -*--===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,6 +9,41 @@
 #include "NVPTXAsmStreamer.h"
 
 using namespace llvm;
+
+NVPTXAsmStreamer::NVPTXAsmStreamer(MCContext &Context,
+                                   std::unique_ptr<formatted_raw_ostream> os,
+                                   std::unique_ptr<MCInstPrinter> printer,
+                                   std::unique_ptr<MCCodeEmitter> emitter,
+                                   std::unique_ptr<MCAsmBackend> asmbackend)
+    : MCAsmBaseStreamer(Context), OSOwner(std::move(os)), OS(*OSOwner),
+      MAI(Context.getAsmInfo()), InstPrinter(std::move(printer)),
+      Assembler(std::make_unique<MCAssembler>(
+          Context, std::move(asmbackend), std::move(emitter),
+          (asmbackend) ? asmbackend->createObjectWriter(NullStream) : nullptr)),
+      CommentStream(CommentToEmit) {
+  assert(InstPrinter);
+  if (Assembler->getBackendPtr())
+    setAllowAutoPadding(Assembler->getBackend().allowAutoPadding());
+
+  Context.setUseNamesOnTempLabels(true);
+
+  auto *TO = Context.getTargetOptions();
+  IsVerboseAsm = TO->AsmVerbose;
+  if (IsVerboseAsm)
+    InstPrinter->setCommentStream(CommentStream);
+  ShowInst = TO->ShowMCInst;
+  switch (TO->MCUseDwarfDirectory) {
+  case MCTargetOptions::DisableDwarfDirectory:
+    UseDwarfDirectory = false;
+    break;
+  case MCTargetOptions::EnableDwarfDirectory:
+    UseDwarfDirectory = true;
+    break;
+  case MCTargetOptions::DefaultDwarfDirectory:
+    UseDwarfDirectory = Context.getAsmInfo()->enableDwarfFileDirectoryDefault();
+    break;
+  }
+}
 
 void NVPTXAsmStreamer::EmitCommentsAndEOL() {
   if (CommentToEmit.empty() && CommentStream.GetNumBytesInBuffer() == 0) {

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.cpp
@@ -1,0 +1,46 @@
+//===-- NVPTXMCAsmStreamer.cpp - NVPTX assembly text output ----*- C++ -*--===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "NVPTXAsmStreamer.h"
+
+using namespace llvm;
+
+void NVPTXAsmStreamer::EmitCommentsAndEOL() {
+  if (CommentToEmit.empty() && CommentStream.GetNumBytesInBuffer() == 0) {
+    OS << '\n';
+    return;
+  }
+
+  StringRef Comments = CommentToEmit;
+
+  assert(Comments.back() == '\n' && "Comment array not newline terminated");
+  do {
+    // Emit a line of comments.
+    OS.PadToColumn(MAI->getCommentColumn());
+    size_t Position = Comments.find('\n');
+    OS << MAI->getCommentString() << ' ' << Comments.substr(0, Position)
+       << '\n';
+
+    Comments = Comments.substr(Position + 1);
+  } while (!Comments.empty());
+
+  CommentToEmit.clear();
+}
+
+void NVPTXAsmStreamer::emitExplicitComments() {
+  StringRef Comments = ExplicitCommentToEmit;
+  if (!Comments.empty())
+    OS << Comments;
+  ExplicitCommentToEmit.clear();
+}
+
+void NVPTXAsmStreamer::emitRawTextImpl(StringRef String) {
+  String.consume_back("\n");
+  OS << String;
+  EmitEOL();
+}

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.cpp
@@ -7,8 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "NVPTXAsmStreamer.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/Path.h"
 
 using namespace llvm;
+
+static inline char toOctal(int X) { return (X & 7) + '0'; }
 
 NVPTXAsmStreamer::NVPTXAsmStreamer(MCContext &Context,
                                    std::unique_ptr<formatted_raw_ostream> os,
@@ -45,6 +49,16 @@ NVPTXAsmStreamer::NVPTXAsmStreamer(MCContext &Context,
   }
 }
 
+void NVPTXAsmStreamer::AddComment(const Twine &T, bool EOL) {
+  if (!IsVerboseAsm)
+    return;
+
+  T.toVector(CommentToEmit);
+
+  if (EOL)
+    CommentToEmit.push_back('\n'); // Place comment in a new line.
+}
+
 void NVPTXAsmStreamer::EmitCommentsAndEOL() {
   if (CommentToEmit.empty() && CommentStream.GetNumBytesInBuffer() == 0) {
     OS << '\n';
@@ -67,6 +81,13 @@ void NVPTXAsmStreamer::EmitCommentsAndEOL() {
   CommentToEmit.clear();
 }
 
+void NVPTXAsmStreamer::emitRawComment(const Twine &T, bool TabPrefix) {
+  if (TabPrefix)
+    OS << '\t';
+  OS << MAI->getCommentString() << T;
+  EmitEOL();
+}
+
 void NVPTXAsmStreamer::emitExplicitComments() {
   StringRef Comments = ExplicitCommentToEmit;
   if (!Comments.empty())
@@ -74,8 +95,272 @@ void NVPTXAsmStreamer::emitExplicitComments() {
   ExplicitCommentToEmit.clear();
 }
 
+void NVPTXAsmStreamer::switchSection(MCSection *Section, uint32_t Subsection) {
+  MCSectionSubPair Cur = getCurrentSection();
+  if (!EmittedSectionDirective ||
+      MCSectionSubPair(Section, Subsection) != Cur) {
+    EmittedSectionDirective = true;
+    MCTargetStreamer *TS = getTargetStreamer();
+    TS->changeSection(Cur.first, Section, Subsection, OS);
+  }
+  MCStreamer::switchSection(Section, Subsection);
+}
+
+void NVPTXAsmStreamer::emitBytes(StringRef Data) {
+  MCTargetStreamer *TS = getTargetStreamer();
+  TS->emitRawBytes(Data);
+}
+
+void NVPTXAsmStreamer::emitLabel(MCSymbol *Symbol, SMLoc Loc) {
+  MCStreamer::emitLabel(Symbol, Loc);
+  Symbol->setOffset(0);
+  Symbol->print(OS, MAI);
+  OS << MAI->getLabelSuffix();
+
+  EmitEOL();
+}
+
+bool NVPTXAsmStreamer::emitSymbolAttribute(MCSymbol *Symbol,
+                                           MCSymbolAttr Attribute) {
+  switch (Attribute) {
+  case MCSA_Global: // .globl/.global
+    OS << MAI->getGlobalDirective();
+    break;
+  case MCSA_Weak:
+    OS << MAI->getWeakDirective();
+    break;
+  default:
+    llvm_unreachable("Unsupported symbol attribute in NVPTXAsmStreamer.");
+  }
+
+  Symbol->print(OS, MAI);
+  EmitEOL();
+
+  return true;
+}
+
+void NVPTXAsmStreamer::emitInstruction(const MCInst &Inst,
+                                       const MCSubtargetInfo &STI) {
+  // Show the MCInst if enabled.
+  if (ShowInst) {
+    Inst.dump_pretty(getCommentOS(), InstPrinter.get(), "\n ", &getContext());
+    getCommentOS() << "\n";
+  }
+
+  InstPrinter->printInst(&Inst, 0, "", STI, OS);
+  EmitEOL();
+}
+
 void NVPTXAsmStreamer::emitRawTextImpl(StringRef String) {
   String.consume_back("\n");
   OS << String;
   EmitEOL();
+}
+
+void NVPTXAsmStreamer::PrintQuotedString(StringRef Data,
+                                         raw_ostream &OS) const {
+  OS << '"';
+
+  for (unsigned char C : Data) {
+    if (C == '"' || C == '\\') {
+      OS << '\\' << (char)C;
+      continue;
+    }
+
+    if (isPrint(C)) {
+      OS << (char)C;
+      continue;
+    }
+
+    switch (C) {
+    case '\b':
+      OS << "\\b";
+      break;
+    case '\f':
+      OS << "\\f";
+      break;
+    case '\n':
+      OS << "\\n";
+      break;
+    case '\r':
+      OS << "\\r";
+      break;
+    case '\t':
+      OS << "\\t";
+      break;
+    default:
+      OS << '\\';
+      OS << toOctal(C >> 6);
+      OS << toOctal(C >> 3);
+      OS << toOctal(C >> 0);
+      break;
+    }
+  }
+
+  OS << '"';
+}
+
+void NVPTXAsmStreamer::printDwarfFileDirective(
+    unsigned FileNo, StringRef Directory, StringRef Filename,
+    std::optional<MD5::MD5Result> Checksum, std::optional<StringRef> Source,
+    bool UseDwarfDirectory, raw_svector_ostream &OS) const {
+  SmallString<128> FullPathName;
+
+  if (!UseDwarfDirectory && !Directory.empty()) {
+    if (sys::path::is_absolute(Filename))
+      Directory = "";
+    else {
+      FullPathName = Directory;
+      sys::path::append(FullPathName, Filename);
+      Directory = "";
+      Filename = FullPathName;
+    }
+  }
+
+  OS << "\t.file\t" << FileNo << ' ';
+  if (!Directory.empty()) {
+    PrintQuotedString(Directory, OS);
+    OS << ' ';
+  }
+  PrintQuotedString(Filename, OS);
+  if (Checksum)
+    OS << " md5 0x" << Checksum->digest();
+  if (Source) {
+    OS << " source ";
+    PrintQuotedString(*Source, OS);
+  }
+}
+
+Expected<unsigned> NVPTXAsmStreamer::tryEmitDwarfFileDirective(
+    unsigned FileNo, StringRef Directory, StringRef Filename,
+    std::optional<MD5::MD5Result> Checksum, std::optional<StringRef> Source,
+    unsigned CUID) {
+  assert(CUID == 0 && "multiple CUs not supported by MCAsmStreamer");
+
+  MCDwarfLineTable &Table = getContext().getMCDwarfLineTable(CUID);
+  unsigned NumFiles = Table.getMCDwarfFiles().size();
+  Expected<unsigned> FileNoOrErr =
+      Table.tryGetFile(Directory, Filename, Checksum, Source,
+                       getContext().getDwarfVersion(), FileNo);
+  if (!FileNoOrErr)
+    return FileNoOrErr.takeError();
+  FileNo = FileNoOrErr.get();
+
+  // Return early if this file is already emitted before or if target doesn't
+  // support .file directive.
+  if (NumFiles == Table.getMCDwarfFiles().size() || MAI->isAIX())
+    return FileNo;
+
+  SmallString<128> Str;
+  raw_svector_ostream OS1(Str);
+  printDwarfFileDirective(FileNo, Directory, Filename, Checksum, Source,
+                          UseDwarfDirectory, OS1);
+
+  MCTargetStreamer *TS = getTargetStreamer();
+  assert(TS && "Expected target streamer for NVPTX backend.");
+  TS->emitDwarfFileDirective(OS1.str());
+
+  return FileNo;
+}
+
+void NVPTXAsmStreamer::emitDwarfFile0Directive(
+    StringRef Directory, StringRef Filename,
+    std::optional<MD5::MD5Result> Checksum, std::optional<StringRef> Source,
+    unsigned CUID) {
+  assert(CUID == 0);
+  // .file 0 is new for DWARF v5.
+  if (getContext().getDwarfVersion() < 5)
+    return;
+  // Inform MCDwarf about the root file.
+  getContext().setMCLineTableRootFile(CUID, Directory, Filename, Checksum,
+                                      Source);
+
+  assert(!MAI->isAIX() && "Unexpected AIX in NVPTX asm streamer.");
+
+  SmallString<128> Str;
+  raw_svector_ostream OS1(Str);
+  printDwarfFileDirective(0, Directory, Filename, Checksum, Source,
+                          UseDwarfDirectory, OS1);
+
+  MCTargetStreamer *TS = getTargetStreamer();
+  assert(TS && "Expected target streamer for NVPTX backend.");
+  TS->emitDwarfFileDirective(OS1.str());
+}
+
+/// Helper to emit common .loc directive flags, isa, and discriminator.
+void NVPTXAsmStreamer::emitDwarfLocDirectiveFlags(unsigned Flags, unsigned Isa,
+                                                  unsigned Discriminator) {
+  if (!MAI->supportsExtendedDwarfLocDirective())
+    return;
+
+  if (Flags & DWARF2_FLAG_BASIC_BLOCK)
+    OS << " basic_block";
+  if (Flags & DWARF2_FLAG_PROLOGUE_END)
+    OS << " prologue_end";
+  if (Flags & DWARF2_FLAG_EPILOGUE_BEGIN)
+    OS << " epilogue_begin";
+
+  const unsigned OldFlags = getContext().getCurrentDwarfLoc().getFlags();
+  if ((Flags & DWARF2_FLAG_IS_STMT) != (OldFlags & DWARF2_FLAG_IS_STMT)) {
+    OS << " is_stmt ";
+    OS << ((Flags & DWARF2_FLAG_IS_STMT) ? "1" : "0");
+  }
+
+  if (Isa)
+    OS << " isa " << Isa;
+  if (Discriminator)
+    OS << " discriminator " << Discriminator;
+}
+
+/// Helper to emit the common suffix of .loc directives.
+void NVPTXAsmStreamer::emitDwarfLocDirectiveSuffix(
+    unsigned FileNo, unsigned Line, unsigned Column, unsigned Flags,
+    unsigned Isa, unsigned Discriminator, StringRef FileName,
+    StringRef Comment) {
+  // Emit flags, isa, and discriminator.
+  emitDwarfLocDirectiveFlags(Flags, Isa, Discriminator);
+
+  // Emit verbose comment if enabled.
+  if (IsVerboseAsm) {
+    OS.PadToColumn(MAI->getCommentColumn());
+    OS << MAI->getCommentString() << ' ';
+    if (Comment.empty())
+      OS << FileName << ':' << Line << ':' << Column;
+    else
+      OS << Comment;
+  }
+
+  // Emit end of line and update the baseclass state.
+  EmitEOL();
+  MCStreamer::emitDwarfLocDirective(FileNo, Line, Column, Flags, Isa,
+                                    Discriminator, FileName, Comment);
+}
+
+void NVPTXAsmStreamer::emitDwarfLocDirective(unsigned FileNo, unsigned Line,
+                                             unsigned Column, unsigned Flags,
+                                             unsigned Isa,
+                                             unsigned Discriminator,
+                                             StringRef FileName,
+                                             StringRef Comment) {
+  // Emit the basic .loc directive.
+  OS << "\t.loc\t" << FileNo << " " << Line << " " << Column;
+
+  // Emit common suffix (flags, comment, EOL, parent call).
+  emitDwarfLocDirectiveSuffix(FileNo, Line, Column, Flags, Isa, Discriminator,
+                              FileName, Comment);
+}
+
+void NVPTXAsmStreamer::emitDwarfLocDirectiveWithInlinedAt(
+    unsigned FileNo, unsigned Line, unsigned Column, unsigned FileIA,
+    unsigned LineIA, unsigned ColIA, const MCSymbol *Sym, unsigned Flags,
+    unsigned Isa, unsigned Discriminator, StringRef FileName,
+    StringRef Comment) {
+  // Emit the basic .loc directive with NVPTX-specific extensions.
+  OS << "\t.loc\t" << FileNo << " " << Line << " " << Column;
+  OS << ", function_name " << *Sym;
+  OS << ", inlined_at " << FileIA << " " << LineIA << " " << ColIA;
+
+  // Emit common suffix (flags, comment, EOL, parent call).
+  emitDwarfLocDirectiveSuffix(FileNo, Line, Column, Flags, Isa, Discriminator,
+                              FileName, Comment);
 }

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.cpp
@@ -110,6 +110,7 @@ void NVPTXAsmStreamer::emitIntValue(uint64_t Value, unsigned Size) {
   emitValue(MCConstantExpr::create(Value, getContext()), Size);
 }
 
+// Helper to check if given section corresponds to a DebugInfo section.
 static bool isDebugSection(const MCSection *Sec) {
   StringRef Name = Sec->getName();
   return Name.starts_with(".debug_") || Name.starts_with(".zdebug_") ||
@@ -122,6 +123,8 @@ void NVPTXAsmStreamer::emitValueImpl(const MCExpr *Value, unsigned Size,
   MCSection *CurrSec = getCurrentSectionOnly();
   assert(CurrSec && "Cannot emit contents before setting section!");
 
+  // We don't need a directive to emit values in PTX. This is retained only for
+  // debug_info sections.
   if (isDebugSection(CurrSec)) {
     const char *Directive = nullptr;
     switch (Size) {
@@ -179,6 +182,7 @@ void NVPTXAsmStreamer::emitLabel(MCSymbol *Symbol, SMLoc Loc) {
 
 bool NVPTXAsmStreamer::emitSymbolAttribute(MCSymbol *Symbol,
                                            MCSymbolAttr Attribute) {
+  // Support only required symbols for PTX.
   switch (Attribute) {
   case MCSA_Global: // .globl/.global
     OS << MAI->getGlobalDirective();
@@ -227,6 +231,9 @@ void NVPTXAsmStreamer::emitRawTextImpl(StringRef String) {
   OS << String;
   EmitEOL();
 }
+
+// Implementation of support for .loc and .file directives is duplicated from
+// MCAsmStreamer.
 
 void NVPTXAsmStreamer::PrintQuotedString(StringRef Data,
                                          raw_ostream &OS) const {

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.cpp
@@ -106,6 +106,63 @@ void NVPTXAsmStreamer::switchSection(MCSection *Section, uint32_t Subsection) {
   MCStreamer::switchSection(Section, Subsection);
 }
 
+void NVPTXAsmStreamer::emitIntValue(uint64_t Value, unsigned Size) {
+  emitValue(MCConstantExpr::create(Value, getContext()), Size);
+}
+
+static bool isDebugSection(const MCSection *Sec) {
+  StringRef Name = Sec->getName();
+  return Name.starts_with(".debug_") || Name.starts_with(".zdebug_") ||
+         Name.contains("debug");
+}
+
+void NVPTXAsmStreamer::emitValueImpl(const MCExpr *Value, unsigned Size,
+                                     SMLoc Loc) {
+  assert(Size <= 8 && "Invalid size");
+  MCSection *CurrSec = getCurrentSectionOnly();
+  assert(CurrSec && "Cannot emit contents before setting section!");
+
+  if (isDebugSection(CurrSec)) {
+    const char *Directive = nullptr;
+    switch (Size) {
+    default:
+      break;
+    case 1:
+      Directive = MAI->getData8bitsDirective();
+      break;
+    case 4:
+      Directive = MAI->getData32bitsDirective();
+      break;
+    case 8:
+      Directive = MAI->getData64bitsDirective();
+      break;
+    }
+
+    if (!Directive) {
+      assert(Size == 2 && "Expected 16-bit values here.");
+
+      int64_t IntValue;
+      if (!Value->evaluateAsAbsolute(IntValue))
+        report_fatal_error("Don't know how to emit this value.");
+
+      // Break down Int16 value into two Int8 values and emit them. TODO:
+      // Current use-case is only for debug_info sections, investigate if this
+      // needs to be uplifted outside isDebugSection check.
+      for (unsigned I = 0; I < 2; I++) {
+        uint64_t Int8ValueToEmit = IntValue >> (I * 8);
+        Int8ValueToEmit &= ~0ULL >> 56;
+        emitInt8(Int8ValueToEmit);
+      }
+      return;
+    }
+
+    OS << Directive;
+  }
+
+  MCTargetStreamer *TS = getTargetStreamer();
+  TS->emitValue(Value);
+}
+
 void NVPTXAsmStreamer::emitBytes(StringRef Data) {
   MCTargetStreamer *TS = getTargetStreamer();
   TS->emitRawBytes(Data);

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.h
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.h
@@ -122,6 +122,9 @@ public:
   void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,
                         Align ByteAlignment) override {}
 
+  void emitRelocDirective(const MCExpr &Offset, StringRef Name,
+                          const MCExpr *Expr, SMLoc Loc) override;
+
   void emitRawTextImpl(StringRef String) override;
 
   Expected<unsigned> tryEmitDwarfFileDirective(

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.h
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.h
@@ -1,4 +1,4 @@
-//===-- NVPTXMCAsmStreamer.h - NVPTX asm streamer --------------*- C++ -*--===//
+//===-- NVPTXAsmStreamer.h - NVPTX asm streamer ----------------*- C++ -*--===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -49,39 +49,7 @@ public:
                    std::unique_ptr<formatted_raw_ostream> os,
                    std::unique_ptr<MCInstPrinter> printer,
                    std::unique_ptr<MCCodeEmitter> emitter,
-                   std::unique_ptr<MCAsmBackend> asmbackend)
-      : MCAsmBaseStreamer(Context), OSOwner(std::move(os)), OS(*OSOwner),
-        MAI(Context.getAsmInfo()), InstPrinter(std::move(printer)),
-        Assembler(std::make_unique<MCAssembler>(
-            Context, std::move(asmbackend), std::move(emitter),
-            (asmbackend) ? asmbackend->createObjectWriter(NullStream)
-                         : nullptr)),
-        CommentStream(CommentToEmit) {
-    // assert(false && "Implement NVPTXAsmStreamer.");
-    assert(InstPrinter);
-    if (Assembler->getBackendPtr())
-      setAllowAutoPadding(Assembler->getBackend().allowAutoPadding());
-
-    Context.setUseNamesOnTempLabels(true);
-
-    auto *TO = Context.getTargetOptions();
-    IsVerboseAsm = TO->AsmVerbose;
-    if (IsVerboseAsm)
-      InstPrinter->setCommentStream(CommentStream);
-    ShowInst = TO->ShowMCInst;
-    switch (TO->MCUseDwarfDirectory) {
-    case MCTargetOptions::DisableDwarfDirectory:
-      UseDwarfDirectory = false;
-      break;
-    case MCTargetOptions::EnableDwarfDirectory:
-      UseDwarfDirectory = true;
-      break;
-    case MCTargetOptions::DefaultDwarfDirectory:
-      UseDwarfDirectory =
-          Context.getAsmInfo()->enableDwarfFileDirectoryDefault();
-      break;
-    }
-  }
+                   std::unique_ptr<MCAsmBackend> asmbackend);
 
   inline void EmitEOL() {
     // Dump Explicit Comments here.

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.h
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.h
@@ -1,0 +1,112 @@
+//===-- NVPTXMCAsmStreamer.h - NVPTX asm streamer --------------*- C++ -*--===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the NVPTXAsmStreamer class
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_NVPTX_MCTARGETDESC_NVPTXASMSTREAMER_H
+#define LLVM_LIB_TARGET_NVPTX_MCTARGETDESC_NVPTXASMSTREAMER_H
+
+#include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCAsmStreamer.h"
+#include "llvm/MC/MCAssembler.h"
+#include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCObjectWriter.h"
+#include "llvm/MC/MCTargetOptions.h"
+#include "llvm/Support/FormattedStream.h"
+
+namespace llvm {
+
+class NVPTXAsmStreamer final : public MCAsmBaseStreamer {
+  std::unique_ptr<formatted_raw_ostream> OSOwner;
+  formatted_raw_ostream &OS;
+  const MCAsmInfo *MAI;
+  std::unique_ptr<MCInstPrinter> InstPrinter;
+  std::unique_ptr<MCAssembler> Assembler;
+
+  SmallString<128> ExplicitCommentToEmit;
+  SmallString<128> CommentToEmit;
+  raw_svector_ostream CommentStream;
+  raw_null_ostream NullStream;
+
+  bool EmittedSectionDirective = false;
+
+  bool IsVerboseAsm = false;
+  bool ShowInst = false;
+  bool UseDwarfDirectory = false;
+
+public:
+  NVPTXAsmStreamer(MCContext &Context,
+                   std::unique_ptr<formatted_raw_ostream> os,
+                   std::unique_ptr<MCInstPrinter> printer,
+                   std::unique_ptr<MCCodeEmitter> emitter,
+                   std::unique_ptr<MCAsmBackend> asmbackend)
+      : MCAsmBaseStreamer(Context), OSOwner(std::move(os)), OS(*OSOwner),
+        MAI(Context.getAsmInfo()), InstPrinter(std::move(printer)),
+        Assembler(std::make_unique<MCAssembler>(
+            Context, std::move(asmbackend), std::move(emitter),
+            (asmbackend) ? asmbackend->createObjectWriter(NullStream)
+                         : nullptr)),
+        CommentStream(CommentToEmit) {
+    // assert(false && "Implement NVPTXAsmStreamer.");
+    assert(InstPrinter);
+    if (Assembler->getBackendPtr())
+      setAllowAutoPadding(Assembler->getBackend().allowAutoPadding());
+
+    Context.setUseNamesOnTempLabels(true);
+
+    auto *TO = Context.getTargetOptions();
+    IsVerboseAsm = TO->AsmVerbose;
+    if (IsVerboseAsm)
+      InstPrinter->setCommentStream(CommentStream);
+    ShowInst = TO->ShowMCInst;
+    switch (TO->MCUseDwarfDirectory) {
+    case MCTargetOptions::DisableDwarfDirectory:
+      UseDwarfDirectory = false;
+      break;
+    case MCTargetOptions::EnableDwarfDirectory:
+      UseDwarfDirectory = true;
+      break;
+    case MCTargetOptions::DefaultDwarfDirectory:
+      UseDwarfDirectory =
+          Context.getAsmInfo()->enableDwarfFileDirectoryDefault();
+      break;
+    }
+  }
+
+  inline void EmitEOL() {
+    // Dump Explicit Comments here.
+    emitExplicitComments();
+    // If we don't have any comments, just emit a \n.
+    if (!IsVerboseAsm) {
+      OS << '\n';
+      return;
+    }
+    EmitCommentsAndEOL();
+  }
+
+  void EmitCommentsAndEOL();
+
+  void emitExplicitComments() override;
+
+  bool emitSymbolAttribute(MCSymbol *Symbol, MCSymbolAttr Attribute) override {
+    return false;
+  }
+
+  void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,
+                        Align ByteAlignment) override {}
+
+  void emitRawTextImpl(StringRef String) override;
+};
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_NVPTX_MCTARGETDESC_NVPTXASMSTREAMER_H

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.h
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.h
@@ -38,11 +38,29 @@ class NVPTXAsmStreamer final : public MCAsmBaseStreamer {
   raw_svector_ostream CommentStream;
   raw_null_ostream NullStream;
 
-  bool EmittedSectionDirective = false;
-
   bool IsVerboseAsm = false;
   bool ShowInst = false;
   bool UseDwarfDirectory = false;
+  bool EmittedSectionDirective = false;
+
+  void PrintQuotedString(StringRef Data, raw_ostream &OS) const;
+  void printDwarfFileDirective(unsigned FileNo, StringRef Directory,
+                               StringRef Filename,
+                               std::optional<MD5::MD5Result> Checksum,
+                               std::optional<StringRef> Source,
+                               bool UseDwarfDirectory,
+                               raw_svector_ostream &OS) const;
+
+  /// Helper to emit common .loc directive flags, isa, and discriminator.
+  void emitDwarfLocDirectiveFlags(unsigned Flags, unsigned Isa,
+                                  unsigned Discriminator);
+
+  /// Helper to emit the common suffix of .loc directives (flags, comment, EOL,
+  /// parent call).
+  void emitDwarfLocDirectiveSuffix(unsigned FileNo, unsigned Line,
+                                   unsigned Column, unsigned Flags,
+                                   unsigned Isa, unsigned Discriminator,
+                                   StringRef FileName, StringRef Comment);
 
 public:
   NVPTXAsmStreamer(MCContext &Context,
@@ -64,16 +82,68 @@ public:
 
   void EmitCommentsAndEOL();
 
+  /// Return true if this streamer supports verbose assembly at all.
+  bool isVerboseAsm() const override { return IsVerboseAsm; }
+
+  bool hasRawTextSupport() const override { return true; }
+
+  void AddComment(const Twine &T, bool EOL = true) override;
+
+  /// Return a raw_ostream that comments can be written to.
+  /// Unlike AddComment, you are required to terminate comments with \n if you
+  /// use this method.
+  raw_ostream &getCommentOS() override {
+    if (!IsVerboseAsm)
+      return nulls(); // Discard comments unless in verbose asm mode.
+    return CommentStream;
+  }
+
+  void emitRawComment(const Twine &T, bool TabPrefix = true) override;
+
   void emitExplicitComments() override;
 
-  bool emitSymbolAttribute(MCSymbol *Symbol, MCSymbolAttr Attribute) override {
-    return false;
-  }
+  void addBlankLine() override { EmitEOL(); }
+
+  void switchSection(MCSection *Section, uint32_t Subsection) override;
+
+  void emitBytes(StringRef Data) override;
+
+  void emitLabel(MCSymbol *Symbol, SMLoc Loc = SMLoc()) override;
+
+  bool emitSymbolAttribute(MCSymbol *Symbol, MCSymbolAttr Attribute) override;
+
+  void emitInstruction(const MCInst &Inst, const MCSubtargetInfo &STI) override;
 
   void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,
                         Align ByteAlignment) override {}
 
   void emitRawTextImpl(StringRef String) override;
+
+  Expected<unsigned> tryEmitDwarfFileDirective(
+      unsigned FileNo, StringRef Directory, StringRef Filename,
+      std::optional<MD5::MD5Result> Checksum = std::nullopt,
+      std::optional<StringRef> Source = std::nullopt,
+      unsigned CUID = 0) override;
+
+  void emitDwarfFile0Directive(StringRef Directory, StringRef Filename,
+                               std::optional<MD5::MD5Result> Checksum,
+                               std::optional<StringRef> Source,
+                               unsigned CUID = 0) override;
+
+  void emitDwarfLocDirective(unsigned FileNo, unsigned Line, unsigned Column,
+                             unsigned Flags, unsigned Isa,
+                             unsigned Discriminator, StringRef FileName,
+                             StringRef Location = {}) override;
+
+  /// This is same as emitDwarfLocDirective, except also emits inlined function
+  /// and inlined callsite information.
+  void emitDwarfLocDirectiveWithInlinedAt(unsigned FileNo, unsigned Line,
+                                          unsigned Column, unsigned FileIA,
+                                          unsigned LineIA, unsigned ColIA,
+                                          const MCSymbol *Sym, unsigned Flags,
+                                          unsigned Isa, unsigned Discriminator,
+                                          StringRef FileName,
+                                          StringRef Comment = {}) override;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.h
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.h
@@ -80,6 +80,7 @@ public:
     EmitCommentsAndEOL();
   }
 
+  /// Emit explicit comments and add EOL.
   void EmitCommentsAndEOL();
 
   /// Return true if this streamer supports verbose assembly at all.
@@ -98,16 +99,22 @@ public:
     return CommentStream;
   }
 
+  /// Print T and prefix it with the comment string and
+  /// optionally a tab. This prints the comment immediately, not at the end of
+  /// the current line.
   void emitRawComment(const Twine &T, bool TabPrefix = true) override;
 
+  /// Emit added explicit comments.
   void emitExplicitComments() override;
 
   void addBlankLine() override { EmitEOL(); }
 
+  /// Set the current section where code is being emitted to \p Section.
   void switchSection(MCSection *Section, uint32_t Subsection) override;
 
   void emitBytes(StringRef Data) override;
 
+  /// Customized version to emit values in PTX without needing a directive.
   void emitValueImpl(const MCExpr *Value, unsigned Size,
                      SMLoc Loc = SMLoc()) override;
 

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.h
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXAsmStreamer.h
@@ -108,6 +108,11 @@ public:
 
   void emitBytes(StringRef Data) override;
 
+  void emitValueImpl(const MCExpr *Value, unsigned Size,
+                     SMLoc Loc = SMLoc()) override;
+
+  void emitIntValue(uint64_t Value, unsigned Size) override;
+
   void emitLabel(MCSymbol *Symbol, SMLoc Loc = SMLoc()) override;
 
   bool emitSymbolAttribute(MCSymbol *Symbol, MCSymbolAttr Attribute) override;

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCTargetDesc.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCTargetDesc.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "NVPTXMCTargetDesc.h"
+#include "NVPTXAsmStreamer.h"
 #include "NVPTXInstPrinter.h"
 #include "NVPTXMCAsmInfo.h"
 #include "NVPTXTargetStreamer.h"
@@ -19,6 +20,7 @@
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
 
 using namespace llvm;
@@ -32,6 +34,11 @@ using namespace llvm;
 
 #define GET_REGINFO_MC_DESC
 #include "NVPTXGenRegisterInfo.inc"
+
+// Temporary option to assist with the migration to new NVPTXAsmStreamer.
+static cl::opt<bool> UsePTXAsmStreamer(
+    "use-ptx-asm-streamer", cl::init(false), cl::Hidden,
+    cl::desc("Use NVPTXAsmStreamer in printer instead of MCAsmStreamer."));
 
 static MCInstrInfo *createNVPTXMCInstrInfo() {
   MCInstrInfo *X = new MCInstrInfo();
@@ -67,6 +74,19 @@ static MCTargetStreamer *createTargetAsmStreamer(MCStreamer &S,
   return new NVPTXAsmTargetStreamer(S, OS);
 }
 
+static MCStreamer *createNVPTXAsmStreamer(
+    MCContext &Ctx, std::unique_ptr<formatted_raw_ostream> OS,
+    std::unique_ptr<MCInstPrinter> IP, std::unique_ptr<MCCodeEmitter> CE,
+    std::unique_ptr<MCAsmBackend> TAB) {
+
+  if (UsePTXAsmStreamer)
+    return new NVPTXAsmStreamer(Ctx, std::move(OS), std::move(IP),
+                                std::move(CE), std::move(TAB));
+
+  return llvm::createAsmStreamer(Ctx, std::move(OS), std::move(IP),
+                                 std::move(CE), std::move(TAB));
+}
+
 static MCTargetStreamer *createNullTargetStreamer(MCStreamer &S) {
   return new NVPTXTargetStreamer(S);
 }
@@ -89,6 +109,9 @@ LLVMInitializeNVPTXTargetMC() {
 
     // Register the MCInstPrinter.
     TargetRegistry::RegisterMCInstPrinter(*T, createNVPTXMCInstPrinter);
+
+    // Register the asm streamer.
+    TargetRegistry::RegisterAsmStreamer(*T, createNVPTXAsmStreamer);
 
     // Register the MCTargetStreamer.
     TargetRegistry::RegisterAsmTargetStreamer(*T, createTargetAsmStreamer);

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCTargetDesc.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCTargetDesc.cpp
@@ -37,7 +37,7 @@ using namespace llvm;
 
 // Temporary option to assist with the migration to new NVPTXAsmStreamer.
 static cl::opt<bool> UsePTXAsmStreamer(
-    "use-ptx-asm-streamer", cl::init(false), cl::Hidden,
+    "use-ptx-asm-streamer", cl::init(true), cl::Hidden,
     cl::desc("Use NVPTXAsmStreamer in printer instead of MCAsmStreamer."));
 
 static MCInstrInfo *createNVPTXMCInstrInfo() {

--- a/llvm/test/CodeGen/NVPTX/asm-printer-ptx-module-directives.ll
+++ b/llvm/test/CodeGen/NVPTX/asm-printer-ptx-module-directives.ll
@@ -1,6 +1,7 @@
 ; Test to verify functionality of NVPTXAsmPrinter for PTX module directives and header.
 
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_100 -mattr=+ptx87 | FileCheck %s
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_100 -mattr=+ptx87 -use-ptx-asm-streamer | FileCheck %s
 ; RUN: %if ptxas-sm_100 && ptxas-isa-8.7 %{ llc < %s -mtriple=nvptx64 -mcpu=sm_100 -mattr=+ptx87 | %ptxas-verify -arch=sm_100 %}
 
 ; CHECK:      //

--- a/llvm/test/CodeGen/NVPTX/asm-printer-ptx-module-directives.ll
+++ b/llvm/test/CodeGen/NVPTX/asm-printer-ptx-module-directives.ll
@@ -1,7 +1,6 @@
 ; Test to verify functionality of NVPTXAsmPrinter for PTX module directives and header.
 
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_100 -mattr=+ptx87 | FileCheck %s
-; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_100 -mattr=+ptx87 -use-ptx-asm-streamer | FileCheck %s
 ; RUN: %if ptxas-sm_100 && ptxas-isa-8.7 %{ llc < %s -mtriple=nvptx64 -mcpu=sm_100 -mattr=+ptx87 | %ptxas-verify -arch=sm_100 %}
 
 ; CHECK:      //


### PR DESCRIPTION
NVPTX backend currently uses MCAsmStreamer to stream PTX. This prohibits
NVPTXAsmPrinter from using the streamer for a more general purpose as the
streamer follows GNU assembly syntax by default. This PR adds a new
NVPTXAsmStreamer to replace usage of MCAsmStreamer in NVPTX backend. This
allows us to customize handling of various MC layer elements and thereby
reuse functionalities from llvm::AsmPrinter in NVPTXAsmPrinter. The
new streamer can be enabled using "-use-ptx-asm-streamer" option.

Related RFC: https://discourse.llvm.org/t/rfc-llvm-add-support-for-target-specific-asm-streamer/85095