### PR TITLE
[lit] Fix tests when run via symlinks

### DIFF
--- a/llvm/utils/lit/tests/filter-failed-delete.py
+++ b/llvm/utils/lit/tests/filter-failed-delete.py
@@ -2,7 +2,7 @@
 # before running with --filter-failed.
 
 # RUN: rm -rf %t
-# RUN: cp -r %{inputs}%{fs-sep}filter-failed %t
+# RUN: cp -rL %{inputs}%{fs-sep}filter-failed %t
 #
 # RUN: not %{lit} %t | FileCheck %s --check-prefix=CHECK-FIRST
 #

--- a/llvm/utils/lit/tests/filter-failed-rerun.py
+++ b/llvm/utils/lit/tests/filter-failed-rerun.py
@@ -2,7 +2,7 @@
 # since the last time --filter-failed was run.
 
 # RUN: rm -rf %t
-# RUN: cp -r %{inputs}%{fs-sep}filter-failed %t
+# RUN: cp -rL %{inputs}%{fs-sep}filter-failed %t
 #
 # RUN: not %{lit} %t | FileCheck %s --check-prefix=CHECK-FIRST
 #

--- a/llvm/utils/lit/tests/filter-failed.py
+++ b/llvm/utils/lit/tests/filter-failed.py
@@ -1,7 +1,7 @@
 # Checks that --filter-failed only runs tests that previously failed.
 
 # RUN: rm -rf %t
-# RUN: cp -r %{inputs}%{fs-sep}filter-failed %t
+# RUN: cp -rL %{inputs}%{fs-sep}filter-failed %t
 #
 # RUN: not %{lit} %t
 #


### PR DESCRIPTION
If the path to Inputs/filter-failed was a symlink, it would copy the
symlinks, and then edit the same files, leading to flaky failures if the
tests ran in parallel.
