### PR TITLE
[clang][Parser] Preserve LHS in RecoveryExpr for binary operations statement boundaries.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -694,7 +694,7 @@ Improvements
 
 - Clang now preserves the left-hand side of a binary expression (such as an
   assignment or comparison) in a ``RecoveryExpr`` when the right-hand side fails
-  to parse. This improves IDE features like go-to-definition in ``clangd``. (#GH2640)
+  to parse. This improves IDE features like go-to-definition in ``clangd``.
 
 Additional Information
 ======================

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -692,6 +692,10 @@ Improvements
 ^^^^^^^^^^^^
 - Improved substitution performance in concept checking. (#GH172266)
 
+- Clang now preserves the left-hand side of a binary expression (such as an
+  assignment or comparison) in a ``RecoveryExpr`` when the right-hand side fails
+  to parse. This improves IDE features like go-to-definition in ``clangd``. (#GH2640)
+
 Additional Information
 ======================
 

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -481,7 +481,9 @@ Parser::ParseRHSOfBinaryExpression(ExprResult LHS, prec::Level MinPrec) {
     else
       RHS = ParseCastExpression(CastParseKind::AnyCastExpr);
 
-    if (RHS.isInvalid()) {
+    // We preserve the LHS only if we hit a clear statement boundary (tok::semi)
+    // to avoid additional bogus diagnostics.
+    if (RHS.isInvalid() && Tok.isNot(tok::semi)) {
       LHS = ExprError();
     }
 
@@ -513,7 +515,7 @@ Parser::ParseRHSOfBinaryExpression(ExprResult LHS, prec::Level MinPrec) {
                             static_cast<prec::Level>(ThisPrec + !isRightAssoc));
       RHSIsInitList = false;
 
-      if (RHS.isInvalid()) {
+      if (RHS.isInvalid() && Tok.isNot(tok::semi)) {
         LHS = ExprError();
       }
 
@@ -540,7 +542,11 @@ Parser::ParseRHSOfBinaryExpression(ExprResult LHS, prec::Level MinPrec) {
 
     if (!LHS.isInvalid()) {
       // Combine the LHS and RHS into the LHS (e.g. build AST).
-      if (TernaryMiddle.isInvalid()) {
+      if (RHS.isInvalid()) {
+        LHS = Actions.CreateRecoveryExpr(LHS.get()->getBeginLoc(),
+                                         PrevTokLocation,
+                                         {LHS.get()});
+      } else if (TernaryMiddle.isInvalid()) {
         // If we're using '>>' as an operator within a template
         // argument list (in C++98), suggest the addition of
         // parentheses so that the code remains well-formed in C++0x.

--- a/clang/test/AST/ast-dump-recovery.cpp
+++ b/clang/test/AST/ast-dump-recovery.cpp
@@ -309,3 +309,16 @@ void foo() {
 void brokenDeducedVarDecl() {
    auto* x = some_func(nullptr);
 }
+
+// CHECK:     FunctionDecl {{.*}} test_stmt_recovery
+// CHECK-NEXT:|-ParmVarDecl {{.*}} a
+// CHECK-NEXT:`-CompoundStmt
+// CHECK-NEXT:  |-RecoveryExpr {{.*}} contains-errors
+// CHECK-NEXT:  | `-DeclRefExpr {{.*}} 'a'
+// CHECK-NEXT:  `-RecoveryExpr {{.*}} contains-errors
+// CHECK-NEXT:    `-DeclRefExpr {{.*}} 'a'
+// DISABLED-NOT: -RecoveryExpr {{.*}} contains-errors
+void test_stmt_recovery(int a) {
+  a = unresolved;
+  a < unresolved;
+}


### PR DESCRIPTION
Fixes https://github.com/clangd/clangd/issues/2640