### PR TITLE
[flang][cuda][openacc] use the ultimate symbol to set the implicit device attribute

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1513,7 +1513,7 @@ void AccVisitor::CopySymbolWithDevice(const parser::Name *name) {
       name && name->symbol) {
     if (Symbol * copy{currScope().CopySymbol(*name->symbol)}) {
       name->symbol = copy;
-      if (auto *object{copy->detailsIf<ObjectEntityDetails>()}) {
+      if (auto *object{copy->GetUltimate().detailsIf<ObjectEntityDetails>()}) {
         object->set_cudaDataAttr(common::CUDADataAttr::Device);
       }
     }

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1511,7 +1511,7 @@ void AccVisitor::CopySymbolWithDevice(const parser::Name *name) {
   // attribute.
   if (context_.languageFeatures().IsEnabled(common::LanguageFeature::CUDA) &&
       name && name->symbol) {
-    if (Symbol * copy{currScope().CopySymbol(*name->symbol)}) {
+    if (Symbol * copy{currScope().CopySymbol(name->symbol->GetUltimate())}) {
       name->symbol = copy;
       if (auto *object{copy->GetUltimate().detailsIf<ObjectEntityDetails>()}) {
         object->set_cudaDataAttr(common::CUDADataAttr::Device);

--- a/flang/test/Lower/OpenACC/acc-host-data-cuda-device.f90
+++ b/flang/test/Lower/OpenACC/acc-host-data-cuda-device.f90
@@ -3,6 +3,8 @@
 
 module m
 
+real, allocatable, pinned :: pinned_real(:,:,:)
+
 interface doit
 subroutine __device_sub(a)
     real(4), device, intent(in) :: a(:,:,:)
@@ -78,3 +80,12 @@ end
 ! CHECK: fir.call @_QP__host_sub
 ! CHECK: fir.call @_QP__device_sub
 ! CHECK: fir.call @_QP__device_sub
+
+subroutine test_use_details()
+  use m
+  !$acc host_data use_device(pinned_real)
+  call doit(pinned_real)
+  !$acc end host_data
+end subroutine
+
+! CHECK: fir.address_of(@_QP__device_sub)

--- a/flang/test/Lower/OpenACC/acc-host-data-cuda-device.f90
+++ b/flang/test/Lower/OpenACC/acc-host-data-cuda-device.f90
@@ -83,9 +83,13 @@ end
 
 subroutine test_use_details()
   use m
+  call doit(pinned_real)
   !$acc host_data use_device(pinned_real)
   call doit(pinned_real)
   !$acc end host_data
+  call doit(pinned_real)
 end subroutine
 
+! CHECK: fir.address_of(@_QP__host_sub)
 ! CHECK: fir.address_of(@_QP__device_sub)
+! CHECK: fir.address_of(@_QP__host_sub)


### PR DESCRIPTION
The attribute was not applied when the symbol had a UseDetails. Use the ultimate symbol so we get the proper ObjectEntityDetails to apply the implicit attribute. 