### PR TITLE
[CAS] Fix assertion failure when opening CAS with smaller mapping size

### DIFF
--- a/llvm/lib/CAS/MappedFileRegionArena.cpp
+++ b/llvm/lib/CAS/MappedFileRegionArena.cpp
@@ -240,9 +240,9 @@ Expected<MappedFileRegionArena> MappedFileRegionArena::create(
 
   // If the size is smaller than capacity, we need to resize the file.
   if (FileSize->Size < Capacity) {
-    // Ensure the exclusive lock before resize the file. In the rare case when
-    // opening a large CAS using a small requested size, a shared lock needs to
-    // switch to an exclusive lock here.
+    // Acquire the exclusive lock before resizing the file. In the rare case
+    // when opening a large CAS using a small requested size, a shared lock
+    // needs to switch to an exclusive lock here.
     if (MainFile->Locked != sys::fs::LockKind::Exclusive) {
       if (Error E = MainFile->switchLock(sys::fs::LockKind::Exclusive))
         return std::move(E);

--- a/llvm/lib/CAS/MappedFileRegionArena.cpp
+++ b/llvm/lib/CAS/MappedFileRegionArena.cpp
@@ -240,7 +240,13 @@ Expected<MappedFileRegionArena> MappedFileRegionArena::create(
 
   // If the size is smaller than capacity, we need to resize the file.
   if (FileSize->Size < Capacity) {
-    assert(MainFile->Locked == sys::fs::LockKind::Exclusive);
+    // Ensure the exclusive lock before resize the file. In the rare case when
+    // opening a large CAS using a small requested size, a shared lock needs to
+    // switch to an exclusive lock here.
+    if (MainFile->Locked != sys::fs::LockKind::Exclusive) {
+      if (Error E = MainFile->switchLock(sys::fs::LockKind::Exclusive))
+        return std::move(E);
+    }
     if (std::error_code EC =
             sys::fs::resize_file_sparse(MainFile->FD, Capacity))
       return createFileError(Result.Path, EC);

--- a/llvm/test/tools/llvm-cas/mapping-size-too-small.test
+++ b/llvm/test/tools/llvm-cas/mapping-size-too-small.test
@@ -1,0 +1,22 @@
+RUN: rm -rf %t && mkdir -p %t
+RUN: split-file %s %t
+
+# Check that if we start with a larger CAS it does not blow up when read with a smaller size.
+RUN: env LLVM_CAS_MAX_MAPPING_SIZE=10240 llvm-cas -cas %t/cas -make-blob -data %t/input > %t/casid
+RUN: env LLVM_CAS_MAX_MAPPING_SIZE=1024 llvm-cas -cas %t/cas -cat-node-data @%t/casid | FileCheck %s
+# CHECK: 01234567890
+
+RUN: rm -rf %t/cas
+RUN: env LLVM_CAS_MAX_MAPPING_SIZE=1024 not llvm-cas -cas %t/cas -make-blob -data %t/input 2>&1 | FileCheck %s -check-prefix=TOO_SMALL
+# TOO_SMALL: memory mapped file allocator is out of space
+
+
+//--- input
+01234567890
+01234567890
+01234567890
+01234567890
+01234567890
+01234567890
+01234567890
+01234567890


### PR DESCRIPTION
When opening an existing large CAS using a smaller requested mapping
size, the file size can be smaller than capacity while holding only a
shared lock. Replace the assertion with a graceful lock upgrade to
exclusive before resizing the file.
