### PR TITLE
[lldb] Update dwim-print for DIL simple mode (NFC)

### DIFF
--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -155,17 +155,15 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
     result.SetStatus(eReturnStatusSuccessFinishResult);
   };
 
-  // First, try `expr` as a _limited_ frame variable expression path: only the
-  // dot operator (`.`) is permitted for this case.
+  // First, try `expr` as a _limited_ frame variable expression path with
+  // eDILModeSimple. This permits only the dot operator (`.`).
   //
-  // This is limited to support only unambiguous expression paths. Of note,
-  // expression paths are not attempted if the expression contain either the
-  // arrow operator (`->`) or the subscript operator (`[]`). This is because
-  // both operators can be overloaded in C++, and could result in ambiguity in
-  // how the expression is handled. Additionally, `*` and `&` are not supported.
-  const bool try_variable_path =
-      expr.find_first_of("*&->[]") == StringRef::npos;
-  if (frame && try_variable_path) {
+  // Simple mode avoids unambiguous expressions. Expressions containing either
+  // the arrow operator (`->`) or the subscript operator (`[]`) are not allowed,
+  // because both operators can be overloaded in C++. The behavior of overloaded
+  // operators is unknown, and unsupported by DIL. Additionally, `*` and `&`
+  // operators are not supported.
+  if (frame) {
     VariableSP var_sp;
     Status status;
     auto valobj_sp = frame->GetValueForVariableExpressionPath(


### PR DESCRIPTION
With the adoption of `eDILModeSimple`, dwim-print shouldn't need to do string checks on the expression. Follow up to https://github.com/llvm/llvm-project/pull/178747