### PR TITLE
[Clang] Fix constexpr __builtin_(add|sub|mul)_overflow bugs

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -850,7 +850,7 @@ static bool interp__builtin_overflowop(InterpState &S, CodePtr OpPC,
                      ResultType->isSignedIntegerOrEnumerationType();
     uint64_t LHSSize = LHS.getBitWidth();
     uint64_t RHSSize = RHS.getBitWidth();
-    uint64_t ResultSize = S.getASTContext().getTypeSize(ResultType);
+    uint64_t ResultSize = S.getASTContext().getIntWidth(ResultType);
     uint64_t MaxBits = std::max(std::max(LHSSize, RHSSize), ResultSize);
 
     // Add an additional bit if the signedness isn't uniformly agreed to. We
@@ -909,8 +909,8 @@ static bool interp__builtin_overflowop(InterpState &S, CodePtr OpPC,
     // APSInt doesn't have a TruncOrSelf, so we use extOrTrunc instead,
     // since it will give us the behavior of a TruncOrSelf in the case where
     // its parameter <= its size.  We previously set Result to be at least the
-    // type-size of the result, so getTypeSize(ResultType) <= Resu
-    APSInt Temp = Result.extOrTrunc(S.getASTContext().getTypeSize(ResultType));
+    // integer width of the result, so getIntWidth(ResultType) <= Result.BitWidth
+    APSInt Temp = Result.extOrTrunc(S.getASTContext().getIntWidth(ResultType));
     Temp.setIsSigned(ResultType->isSignedIntegerOrEnumerationType());
 
     if (!APSInt::isSameValue(Temp, Result))

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -136,6 +136,8 @@ static void assignInteger(InterpState &S, const Pointer &Dest, PrimType ValueT,
     Dest.deref<IntegralAP<false>>() =
         S.allocAP<IntegralAP<false>>(Value.getBitWidth());
     Dest.deref<IntegralAP<false>>().copy(Value);
+  } else if (ValueT == PT_Bool) {
+    Dest.deref<Boolean>() = Boolean::from(!Value.isZero());
   } else {
     INT_TYPE_SWITCH_NO_BOOL(
         ValueT, { Dest.deref<T>() = T::from(static_cast<T>(Value)); });

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -125,7 +125,7 @@ static void pushInteger(InterpState &S, T Val, QualType QT) {
                 QT);
 }
 
-static void assignInteger(InterpState &S, const Pointer &Dest, PrimType ValueT,
+static void assignIntegral(InterpState &S, const Pointer &Dest, PrimType ValueT,
                           const APSInt &Value) {
 
   if (ValueT == PT_IntAPS) {
@@ -921,7 +921,7 @@ static bool interp__builtin_overflowop(InterpState &S, CodePtr OpPC,
   }
 
   // Write Result to ResultPtr and put Overflow on the stack.
-  assignInteger(S, ResultPtr, ResultT, Result);
+  assignIntegral(S, ResultPtr, ResultT, Result);
   if (ResultPtr.canBeInitialized())
     ResultPtr.initialize();
 
@@ -979,7 +979,7 @@ static bool interp__builtin_carryop(InterpState &S, CodePtr OpPC,
 
   QualType CarryOutType = Call->getArg(3)->getType()->getPointeeType();
   PrimType CarryOutT = *S.getContext().classify(CarryOutType);
-  assignInteger(S, CarryOutPtr, CarryOutT, CarryOut);
+  assignIntegral(S, CarryOutPtr, CarryOutT, CarryOut);
   CarryOutPtr.initialize();
 
   assert(Call->getType() == Call->getArg(0)->getType());
@@ -1373,7 +1373,7 @@ static bool interp__builtin_ia32_addcarry_subborrow(InterpState &S,
 
   QualType CarryOutType = Call->getArg(3)->getType()->getPointeeType();
   PrimType CarryOutT = *S.getContext().classify(CarryOutType);
-  assignInteger(S, CarryOutPtr, CarryOutT, APSInt(std::move(Result), true));
+  assignIntegral(S, CarryOutPtr, CarryOutT, APSInt(std::move(Result), true));
 
   pushInteger(S, CarryOut, Call->getType());
 
@@ -2696,9 +2696,9 @@ interp__builtin_x86_pack(InterpState &S, CodePtr, const CallExpr *E,
         APSInt A = LHS.elem<T>(BaseSrc + I).toAPSInt();
         APSInt B = RHS.elem<T>(BaseSrc + I).toAPSInt();
 
-        assignInteger(S, Dst.atIndex(BaseDst + I), DstT,
+        assignIntegral(S, Dst.atIndex(BaseDst + I), DstT,
                       APSInt(PackFn(A), IsUnsigend));
-        assignInteger(S, Dst.atIndex(BaseDst + SrcPerLane + I), DstT,
+        assignIntegral(S, Dst.atIndex(BaseDst + SrcPerLane + I), DstT,
                       APSInt(PackFn(B), IsUnsigend));
       });
     }

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -126,7 +126,7 @@ static void pushInteger(InterpState &S, T Val, QualType QT) {
 }
 
 static void assignIntegral(InterpState &S, const Pointer &Dest, PrimType ValueT,
-                          const APSInt &Value) {
+                           const APSInt &Value) {
 
   if (ValueT == PT_IntAPS) {
     Dest.deref<IntegralAP<true>>() =
@@ -911,7 +911,8 @@ static bool interp__builtin_overflowop(InterpState &S, CodePtr OpPC,
     // APSInt doesn't have a TruncOrSelf, so we use extOrTrunc instead,
     // since it will give us the behavior of a TruncOrSelf in the case where
     // its parameter <= its size.  We previously set Result to be at least the
-    // integer width of the result, so getIntWidth(ResultType) <= Result.BitWidth
+    // integer width of the result, so getIntWidth(ResultType) <=
+    // Result.BitWidth
     APSInt Temp = Result.extOrTrunc(S.getASTContext().getIntWidth(ResultType));
     Temp.setIsSigned(ResultType->isSignedIntegerOrEnumerationType());
 
@@ -2697,9 +2698,9 @@ interp__builtin_x86_pack(InterpState &S, CodePtr, const CallExpr *E,
         APSInt B = RHS.elem<T>(BaseSrc + I).toAPSInt();
 
         assignIntegral(S, Dst.atIndex(BaseDst + I), DstT,
-                      APSInt(PackFn(A), IsUnsigend));
+                       APSInt(PackFn(A), IsUnsigend));
         assignIntegral(S, Dst.atIndex(BaseDst + SrcPerLane + I), DstT,
-                      APSInt(PackFn(B), IsUnsigend));
+                       APSInt(PackFn(B), IsUnsigend));
       });
     }
   }

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -17175,7 +17175,7 @@ bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
                       ResultType->isSignedIntegerOrEnumerationType();
       uint64_t LHSSize = LHS.getBitWidth();
       uint64_t RHSSize = RHS.getBitWidth();
-      uint64_t ResultSize = Info.Ctx.getTypeSize(ResultType);
+      uint64_t ResultSize = Info.Ctx.getIntWidth(ResultType);
       uint64_t MaxBits = std::max(std::max(LHSSize, RHSSize), ResultSize);
 
       // Add an additional bit if the signedness isn't uniformly agreed to. We
@@ -17234,9 +17234,9 @@ bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
       // APSInt doesn't have a TruncOrSelf, so we use extOrTrunc instead,
       // since it will give us the behavior of a TruncOrSelf in the case where
       // its parameter <= its size.  We previously set Result to be at least the
-      // type-size of the result, so getTypeSize(ResultType) <= Result.BitWidth
+      // integer width of the result, so getIntWidth(ResultType) <= Result.BitWidth
       // will work exactly like TruncOrSelf.
-      APSInt Temp = Result.extOrTrunc(Info.Ctx.getTypeSize(ResultType));
+      APSInt Temp = Result.extOrTrunc(Info.Ctx.getIntWidth(ResultType));
       Temp.setIsSigned(ResultType->isSignedIntegerOrEnumerationType());
 
       if (!APSInt::isSameValue(Temp, Result))

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -17226,23 +17226,23 @@ bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
       break;
     }
 
+    // APSInt doesn't have a TruncOrSelf, so we use extOrTrunc instead,
+    // since it will give us the behavior of a TruncOrSelf in the case where
+    // its parameter <= its size.  We previously set Result to be at least the
+    // integer width of the result, so getIntWidth(ResultType) <= Result.BitWidth
+    // will work exactly like TruncOrSelf.
+    APSInt Temp = Result.extOrTrunc(Info.Ctx.getIntWidth(ResultType));
+    Temp.setIsSigned(ResultType->isSignedIntegerOrEnumerationType());
+
     // In the case where multiple sizes are allowed, truncate and see if
     // the values are the same.
     if (BuiltinOp == Builtin::BI__builtin_add_overflow ||
         BuiltinOp == Builtin::BI__builtin_sub_overflow ||
         BuiltinOp == Builtin::BI__builtin_mul_overflow) {
-      // APSInt doesn't have a TruncOrSelf, so we use extOrTrunc instead,
-      // since it will give us the behavior of a TruncOrSelf in the case where
-      // its parameter <= its size.  We previously set Result to be at least the
-      // integer width of the result, so getIntWidth(ResultType) <= Result.BitWidth
-      // will work exactly like TruncOrSelf.
-      APSInt Temp = Result.extOrTrunc(Info.Ctx.getIntWidth(ResultType));
-      Temp.setIsSigned(ResultType->isSignedIntegerOrEnumerationType());
-
       if (!APSInt::isSameValue(Temp, Result))
         DidOverflow = true;
-      Result = Temp;
     }
+    Result = Temp;
 
     APValue APV{Result};
     if (!handleAssignment(Info, E, ResultLValue, ResultType, APV))

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -17229,8 +17229,8 @@ bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
     // APSInt doesn't have a TruncOrSelf, so we use extOrTrunc instead,
     // since it will give us the behavior of a TruncOrSelf in the case where
     // its parameter <= its size.  We previously set Result to be at least the
-    // integer width of the result, so getIntWidth(ResultType) <= Result.BitWidth
-    // will work exactly like TruncOrSelf.
+    // integer width of the result, so getIntWidth(ResultType) <=
+    // Result.BitWidth will work exactly like TruncOrSelf.
     APSInt Temp = Result.extOrTrunc(Info.Ctx.getIntWidth(ResultType));
     Temp.setIsSigned(ResultType->isSignedIntegerOrEnumerationType());
 

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -1964,6 +1964,29 @@ namespace I128Mul {
 }
 #endif
 
+namespace OverflowOps {
+  constexpr bool add_bool() {
+    bool r = false;
+    return __builtin_add_overflow(1u, 1u, &r) && r == false;
+  }
+  static_assert(add_bool());
+
+  constexpr bool sub_bool() {
+    bool r = false;
+    return __builtin_sub_overflow(0u, 1u, &r) && r == true;
+  }
+  static_assert(sub_bool());
+
+  constexpr int add_sub() {
+    int r = 0;
+    int s = 0;
+    __builtin_add_overflow(10, 20, &r);
+    __builtin_sub_overflow(10, 3, &s);
+    return r + s;
+  }
+  static_assert(add_sub() == 37);
+}
+
 namespace InitParam {
   constexpr int foo(int a) {
       __builtin_mul_overflow(20, 10, &a);

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -1971,11 +1971,35 @@ namespace OverflowOps {
   }
   static_assert(add_bool());
 
+  constexpr bool add_bool_non_overflow_true() {
+    bool r = false;
+    return !__builtin_add_overflow(1u, 0u, &r) && r == true;
+  }
+  static_assert(add_bool_non_overflow_true());
+
+  constexpr bool add_bool_non_overflow_false() {
+    bool r = true;
+    return !__builtin_add_overflow(0u, 0u, &r) && r == false;
+  }
+  static_assert(add_bool_non_overflow_false());
+
   constexpr bool sub_bool() {
     bool r = false;
     return __builtin_sub_overflow(0u, 1u, &r) && r == true;
   }
   static_assert(sub_bool());
+
+  constexpr bool sub_bool_non_overflow_true() {
+    bool r = false;
+    return !__builtin_sub_overflow(1u, 0u, &r) && r == true;
+  }
+  static_assert(sub_bool_non_overflow_true());
+
+  constexpr bool sub_bool_non_overflow_false() {
+    bool r = true;
+    return !__builtin_sub_overflow(1u, 1u, &r) && r == false;
+  }
+  static_assert(sub_bool_non_overflow_false());
 
   constexpr int add_sub() {
     int r = 0;

--- a/clang/test/SemaCXX/builtins-overflow.cpp
+++ b/clang/test/SemaCXX/builtins-overflow.cpp
@@ -42,6 +42,31 @@ static_assert(add<int>(static_cast<unsigned int>(INT_MAX), 1u) == Result<int>{tr
 static_assert(add<int>(17, 22) == Result<int>{false, 39});
 static_assert(add<int>(INT_MAX - 22, 24) == Result<int>{true, INT_MIN + 1});
 static_assert(add<int>(INT_MIN + 22, -23) == Result<int>{true, INT_MAX});
+static_assert(add<_BitInt(31)>((_BitInt(31))1073741823, (_BitInt(31))1) ==
+              Result<_BitInt(31)>{true, (_BitInt(31))(-1073741824)});
+static_assert(add<bool>(1u, 1u) == Result<bool>{true, false});
+static_assert(add<bool>(1u, 0u) == Result<bool>{false, true});
+static_assert(add<bool>(255u, 1u) == Result<bool>{true, false});
+
+constexpr Result<unsigned> uadd(unsigned lhs, unsigned rhs) {
+  unsigned sum{};
+  return {__builtin_uadd_overflow(lhs, rhs, &sum), sum};
+}
+
+constexpr Result<unsigned> usub(unsigned lhs, unsigned rhs) {
+  unsigned sum{};
+  return {__builtin_usub_overflow(lhs, rhs, &sum), sum};
+}
+
+constexpr Result<unsigned> umul(unsigned lhs, unsigned rhs) {
+  unsigned sum{};
+  return {__builtin_umul_overflow(lhs, rhs, &sum), sum};
+}
+
+static_assert(uadd(1u, 2u) == Result<unsigned>{false, 3u});
+static_assert(uadd(UINT_MAX, 1u) == Result<unsigned>{true, 0u});
+static_assert(usub(0u, 1u) == Result<unsigned>{true, UINT_MAX});
+static_assert(umul(UINT_MAX, 2u) == Result<unsigned>{true, UINT_MAX - 1u});
 
 template <typename RET, typename LHS, typename RHS>
 constexpr Result<RET> sub(LHS &&lhs, RHS &&rhs) {
@@ -57,6 +82,9 @@ static_assert(sub<uint8_t>(static_cast<uint8_t>(255),static_cast<int>(100)) == R
 static_assert(sub<int>(17,22) == Result<int>{false, -5});
 static_assert(sub<int>(INT_MAX - 22, -23) == Result<int>{true, INT_MIN});
 static_assert(sub<int>(INT_MIN + 22, 23) == Result<int>{true, INT_MAX});
+static_assert(sub<_BitInt(31)>((_BitInt(31))(-1073741824), (_BitInt(31))1) ==
+              Result<_BitInt(31)>{true, (_BitInt(31))1073741823});
+static_assert(sub<bool>(0u, 1u) == Result<bool>{true, true});
 
 template <typename RET, typename LHS, typename RHS>
 constexpr Result<RET> mul(LHS &&lhs, RHS &&rhs) {
@@ -67,6 +95,10 @@ constexpr Result<RET> mul(LHS &&lhs, RHS &&rhs) {
 static_assert(mul<int>(17,22) == Result<int>{false, 374});
 static_assert(mul<int>(INT_MAX / 22, 23) == Result<int>{true, -2049870757});
 static_assert(mul<int>(INT_MIN / 22, -23) == Result<int>{true, -2049870757});
+static_assert(mul<_BitInt(31)>((_BitInt(31))1073741823, (_BitInt(31))2) ==
+              Result<_BitInt(31)>{true, (_BitInt(31))(-2)});
+static_assert(mul<bool>(1u, 1u) == Result<bool>{false, true});
+static_assert(mul<bool>(1u, 2u) == Result<bool>{true, false});
 
 constexpr Result<int> sadd(int lhs, int rhs) {
   int sum{};


### PR DESCRIPTION
Fixes

1. constexpr/non-constexpr add overflowed disagree for 1 + 1 with a bool result https://godbolt.org/z/4Goaa63sc. I found this issue for a similar bug https://github.com/llvm/llvm-project/issues/40897.
2. constexpr unsigned assertion https://godbolt.org/z/MEahfsW9E.
3. constexpr bool result assertion https://godbolt.org/z/G3YsxozbE.

Fixes #204085.

Related CIR PR #192569.