### PR TITLE
[CIR] Fix CIR __builtin_(add|sub|mul)_overflow bugs

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2337,7 +2337,7 @@ class CIR_BinOpOverflow<string mnemonic, list<Trait> traits = []>
     CIR_IntType:$rhs
   );
 
-  let results = (outs CIR_IntType:$result, CIR_BoolType:$overflow);
+  let results = (outs CIR_AnyIntOrBoolType:$result, CIR_BoolType:$overflow);
 
   let assemblyFormat = [{
     $lhs `,` $rhs `:` qualified(type($lhs)) `->` qualified(type($result))
@@ -2345,7 +2345,7 @@ class CIR_BinOpOverflow<string mnemonic, list<Trait> traits = []>
   }];
 
   let builders = [
-    OpBuilder<(ins "cir::IntType":$resultTy,
+    OpBuilder<(ins "mlir::Type":$resultTy,
                    "mlir::Value":$lhs,
                    "mlir::Value":$rhs), [{
       auto overflowTy = cir::BoolType::get($_builder.getContext());
@@ -2366,6 +2366,7 @@ def CIR_AddOverflowOp : CIR_BinOpOverflow<"add.overflow", [Commutative]> {
     ```
     %result, %overflow = cir.add.overflow %a, %b : !u32i -> !u32i
     %result, %overflow = cir.add.overflow %a, %b : !cir.int<s, 33> -> !s32i
+    %result, %overflow = cir.add.overflow %a, %b : !s32i -> !cir.bool
     ```
   }];
 }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -284,7 +284,7 @@ getIntegerWidthAndSignedness(const clang::ASTContext &astContext,
 template <typename OpTy>
 static std::pair<mlir::Value, mlir::Value>
 emitOverflowOp(CIRGenBuilderTy &builder, mlir::Location loc,
-               cir::IntType resultTy, mlir::Value lhs, mlir::Value rhs) {
+               mlir::Type resultTy, mlir::Value lhs, mlir::Value rhs) {
   auto op = OpTy::create(builder, loc, resultTy, lhs, rhs);
   return {op.getResult(), op.getOverflow()};
 }
@@ -2212,7 +2212,7 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
 
     auto encompassingCIRTy = cir::IntType::get(
         &getMLIRContext(), encompassingInfo.width, encompassingInfo.isSigned);
-    auto resultCIRTy = mlir::cast<cir::IntType>(cgm.convertType(resultQTy));
+    mlir::Type resultCIRTy = cgm.convertType(resultQTy);
 
     mlir::Value x = emitScalarExpr(leftArg);
     mlir::Value y = emitScalarExpr(rightArg);
@@ -2258,7 +2258,8 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
     //     first computed as a value of the encompassing type, and then it is
     //     truncated to the actual result type with a second overflow checking.
     //   - In CIRGen, the checked arithmetic operation directly produce the
-    //     checked arithmetic result in its expected type.
+    //     checked arithmetic result in its expected type, which may be a
+    //     `cir.bool`.
     //
     // So we don't need a truncation and a second overflow checking here.
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -2012,7 +2012,11 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
 
     auto encompassingCIRTy = cir::IntType::get(
         &getMLIRContext(), encompassingInfo.width, encompassingInfo.isSigned);
-    auto resultCIRTy = mlir::cast<cir::IntType>(cgm.convertType(resultQTy));
+    auto resultCIRType = cgm.convertType(resultQTy);
+    bool resultIsBool = mlir::isa<cir::BoolType>(resultCIRType);
+    auto resultCIRTy = resultIsBool ? cir::IntType::get(&getMLIRContext(), 1,
+                                                        /*isSigned=*/false)
+                                    : mlir::cast<cir::IntType>(resultCIRType);
 
     mlir::Value x = emitScalarExpr(leftArg);
     mlir::Value y = emitScalarExpr(rightArg);
@@ -2064,7 +2068,11 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
     // Finally, store the result using the pointer.
     bool isVolatile =
         resultArg->getType()->getPointeeType().isVolatileQualified();
-    builder.createStore(loc, result, resultPtr, isVolatile);
+    mlir::Value storeVal = result;
+    if (resultIsBool)
+      storeVal = builder.createCast(loc, cir::CastKind::int_to_bool, storeVal,
+                                    cir::BoolType::get(&getMLIRContext()));
+    builder.createStore(loc, storeVal, resultPtr, isVolatile);
 
     return RValue::get(overflow);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -224,9 +224,9 @@ static WidthAndSignedness
 getIntegerWidthAndSignedness(const clang::ASTContext &astContext,
                              const clang::QualType type) {
   assert(type->isIntegerType() && "Given type is not an integer.");
-  unsigned width = type->isBooleanType()  ? 1
-                   : type->isBitIntType() ? astContext.getIntWidth(type)
-                                          : astContext.getTypeInfo(type).Width;
+  // Use ASTContext::getIntWidth for consistency with OGCG and to avoid
+  // future target-specific width divergences (e.g. padding bits).
+  unsigned width = astContext.getIntWidth(type);
   bool isSigned = type->isSignedIntegerType();
   return {width, isSigned};
 }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -2019,10 +2019,18 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
     Address resultPtr = emitPointerWithAlignment(resultArg);
 
     // Extend each operand to the encompassing type, if necessary.
-    if (x.getType() != encompassingCIRTy)
-      x = builder.createCast(cir::CastKind::integral, x, encompassingCIRTy);
-    if (y.getType() != encompassingCIRTy)
-      y = builder.createCast(cir::CastKind::integral, y, encompassingCIRTy);
+    if (x.getType() != encompassingCIRTy) {
+      auto kind = mlir::isa<cir::BoolType>(x.getType())
+                      ? cir::CastKind::bool_to_int
+                      : cir::CastKind::integral;
+      x = builder.createCast(kind, x, encompassingCIRTy);
+    }
+    if (y.getType() != encompassingCIRTy) {
+      auto kind = mlir::isa<cir::BoolType>(y.getType())
+                      ? cir::CastKind::bool_to_int
+                      : cir::CastKind::integral;
+      y = builder.createCast(kind, y, encompassingCIRTy);
+    }
 
     // Perform the operation on the extended values.
     mlir::Location loc = getLoc(e->getSourceRange());

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2976,12 +2976,17 @@ lowerBinOpOverflow(OpTy op, typename OpTy::Adaptor adaptor,
                    llvm::StringRef opStr) {
   mlir::Location loc = op.getLoc();
   cir::IntType operandTy = op.getLhs().getType();
-  cir::IntType resultTy = op.getResult().getType();
+  // The result type may be a `cir.bool`, which behaves as a 1-bit unsigned
+  // integer for the purposes of the checked arithmetic.
+  mlir::Type resultTy = op.getResult().getType();
+  auto resultIntTy = mlir::dyn_cast<cir::IntType>(resultTy);
+  unsigned resultWidth = resultIntTy ? resultIntTy.getWidth() : 1;
+  bool resultSigned = resultIntTy && resultIntTy.getIsSigned();
 
-  bool sign = operandTy.getIsSigned() || resultTy.getIsSigned();
+  bool sign = operandTy.getIsSigned() || resultSigned;
   unsigned width =
       std::max(operandTy.getWidth() + (sign && operandTy.isUnsigned()),
-               resultTy.getWidth() + (sign && resultTy.isUnsigned()));
+               resultWidth + (sign && !resultSigned));
 
   mlir::IntegerType encompassedLLVMTy = rewriter.getIntegerType(width);
 
@@ -3018,7 +3023,7 @@ lowerBinOpOverflow(OpTy op, typename OpTy::Adaptor adaptor,
                              rewriter, loc, intrinRet, ArrayRef<int64_t>{1})
                              .getResult();
 
-  if (resultTy.getWidth() < width) {
+  if (resultWidth < width) {
     mlir::Type resultLLVMTy = typeConverter->convertType(resultTy);
     auto truncResult =
         mlir::LLVM::TruncOp::create(rewriter, loc, resultLLVMTy, result);
@@ -3026,7 +3031,7 @@ lowerBinOpOverflow(OpTy op, typename OpTy::Adaptor adaptor,
     // Extend the truncated result back to the encompassing type to check for
     // any overflows during the truncation.
     mlir::Value truncResultExt;
-    if (resultTy.isSigned())
+    if (resultSigned)
       truncResultExt = mlir::LLVM::SExtOp::create(
           rewriter, loc, encompassedLLVMTy, truncResult);
     else

--- a/clang/test/CIR/CodeGenBuiltins/builtins-overflow.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtins-overflow.cpp
@@ -388,3 +388,19 @@ bool test_bool_math_overflow(bool x, bool y, int *res) {
 // LLVM: call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 %[[X_CAST]], i32 %[[Y_CAST]])
 }
 
+bool f(int x, int y, bool *r) {
+  return __builtin_add_overflow(x, y, r);
+}
+
+//      CIR: cir.func {{.*}} @_Z1fiiPb
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   %[[#R_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.bool>>, !cir.ptr<!cir.bool>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.add.overflow %[[#X]], %[[#Y]] : !s32i -> !cir.bool
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#R_PTR]] : !cir.bool, !cir.ptr<!cir.bool>
+//      CIR: }
+
+// LLVM-LABEL: @_Z1fiiPb(
+// LLVM: call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 %{{.+}}, i32 %{{.+}})
+// LLVM: trunc i32 %{{.+}} to i1
+// LLVM: store i8 %{{.+}}, ptr %{{.+}}

--- a/clang/test/CIR/CodeGenBuiltins/builtins-overflow.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtins-overflow.cpp
@@ -23,6 +23,121 @@ bool test_add_overflow_uint_uint_uint(unsigned x, unsigned y, unsigned *res) {
 // OGCG: define{{.*}} i1 @_Z32test_add_overflow_uint_uint_uintjjPj(i32{{.*}}, i32{{.*}}, ptr{{.*}})
 // OGCG:   call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %{{.+}}, i32 %{{.+}})
 
+bool test_add_overflow_bool_bool_uint(bool x, bool y, unsigned *res) {
+  return __builtin_add_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_add_overflow_bool_bool_uint{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!u32i>>, !cir.ptr<!u32i>
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast bool_to_int %[[#X]] : !cir.bool -> !u32i
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast bool_to_int %[[#Y]] : !cir.bool -> !u32i
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.add.overflow %[[#PROM_X]], %[[#PROM_Y]] : !u32i -> !u32i
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !u32i, !cir.ptr<!u32i>
+//      CIR: }
+bool test_uadd_overflow_bool_bool_uint(bool x, bool y, unsigned *res) {
+  return __builtin_uadd_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_uadd_overflow_bool_bool_uint{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast bool_to_int %[[#X]] : !cir.bool -> !u32i
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast bool_to_int %[[#Y]] : !cir.bool -> !u32i
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!u32i>>, !cir.ptr<!u32i>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.add.overflow %[[#PROM_X]], %[[#PROM_Y]] : !u32i -> !u32i
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !u32i, !cir.ptr<!u32i>
+//      CIR: }
+
+// LLVM: define{{.*}} i1 @{{.*}}test_uadd_overflow_bool_bool_uint{{.*}}
+// LLVM:   %[[#XZ:]] = zext i1 %{{.*}} to i32
+// LLVM:   %[[#YZ:]] = zext i1 %{{.*}} to i32
+// LLVM:   call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %[[#XZ]], i32 %[[#YZ]])
+
+// OGCG-LABEL: define{{.*}} i1 @{{.*}}test_uadd_overflow_bool_bool_uint{{.*}}
+// OGCG-DAG:   zext i1 %{{.*}} to i32
+// OGCG-DAG:   zext i1 %{{.*}} to i32
+// OGCG:       call { i32, i1 } @llvm.uadd.with.overflow.i32
+
+bool test_add_overflow_int_int_bool(int x, int y, bool *res) {
+  return __builtin_add_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_add_overflow_int_int_bool{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.bool>>, !cir.ptr<!cir.bool>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.add.overflow %[[#X]], %[[#Y]] : !s32i -> !cir.int<u, 1>
+// CIR-NEXT:   %[[BOOL_RES:.+]] = cir.cast int_to_bool %[[RES]] : !cir.int<u, 1> -> !cir.bool
+// CIR-NEXT:   cir.store{{.*}} %[[BOOL_RES]], %[[#RES_PTR]] : !cir.bool, !cir.ptr<!cir.bool>
+//      CIR: }
+
+bool test_add_overflow_bool_bool_bool(bool x, bool y, bool *res) {
+  return __builtin_add_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_add_overflow_bool_bool_bool{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.bool>>, !cir.ptr<!cir.bool>
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast bool_to_int %[[#X]] : !cir.bool -> !cir.int<u, 1>
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast bool_to_int %[[#Y]] : !cir.bool -> !cir.int<u, 1>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.add.overflow %[[#PROM_X]], %[[#PROM_Y]] : !cir.int<u, 1> -> !cir.int<u, 1>
+// CIR-NEXT:   %[[BOOL_RES:.+]] = cir.cast int_to_bool %[[RES]] : !cir.int<u, 1> -> !cir.bool
+// CIR-NEXT:   cir.store{{.*}} %[[BOOL_RES]], %[[#RES_PTR]] : !cir.bool, !cir.ptr<!cir.bool>
+//      CIR: }
+
+// LLVM: define{{.*}} i1 @{{.*}}test_add_overflow_bool_bool_bool
+// LLVM:   call { i1, i1 } @llvm.uadd.with.overflow.i1
+
+// OGCG: define{{.*}} i1 @{{.*}}test_add_overflow_bool_bool_bool
+// OGCG:   call { i1, i1 } @llvm.uadd.with.overflow.i1
+
+bool test_add_overflow_schar_uchar_ushort(signed char x, unsigned char y,
+                                          unsigned short *res) {
+  return __builtin_add_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_add_overflow_schar_uchar_ushort{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!s8i>, !s8i
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u8i>, !u8i
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!u16i>>, !cir.ptr<!u16i>
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast integral %[[#X]] : !s8i -> !cir.int<s, 17>
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast integral %[[#Y]] : !u8i -> !cir.int<s, 17>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.add.overflow %[[#PROM_X]], %[[#PROM_Y]] : !cir.int<s, 17> -> !u16i
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !u16i, !cir.ptr<!u16i>
+//      CIR: }
+
+// LLVM: define{{.*}} i1 @{{.*}}test_add_overflow_schar_uchar_ushort
+// LLVM:   call { i17, i1 } @llvm.sadd.with.overflow.i17
+
+// OGCG: define{{.*}} i1 @{{.*}}test_add_overflow_schar_uchar_ushort
+// OGCG:   call { i17, i1 } @llvm.sadd.with.overflow.i17
+
+enum UShortEnum : unsigned short { UShortEnum_A = 1 };
+enum SCharEnum : signed char { SCharEnum_A = -1 };
+
+bool test_add_overflow_enum_enum_enum(UShortEnum x, SCharEnum y,
+                                      UShortEnum *res) {
+  return __builtin_add_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_add_overflow_enum_enum_enum{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u16i>, !u16i
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!s8i>, !s8i
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!u16i>>, !cir.ptr<!u16i>
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast integral %[[#X]] : !u16i -> !cir.int<s, 17>
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast integral %[[#Y]] : !s8i -> !cir.int<s, 17>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.add.overflow %[[#PROM_X]], %[[#PROM_Y]] : !cir.int<s, 17> -> !u16i
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !u16i, !cir.ptr<!u16i>
+//      CIR: }
+
+// LLVM: define{{.*}} i1 @{{.*}}test_add_overflow_enum_enum_enum
+// LLVM:   call { i17, i1 } @llvm.sadd.with.overflow.i17
+
+// OGCG: define{{.*}} i1 @{{.*}}test_add_overflow_enum_enum_enum
+// OGCG:   call { i17, i1 } @llvm.sadd.with.overflow.i17
 bool test_add_overflow_int_int_int(int x, int y, int *res) {
   return __builtin_add_overflow(x, y, res);
 }
@@ -47,6 +162,59 @@ bool test_add_overflow_xint31_xint31_xint31(_BitInt(31) x, _BitInt(31) y, _BitIn
 // CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !cir.int<s, 31, bitint>, !cir.ptr<!cir.int<s, 31, bitint>>
 //      CIR: }
 
+bool test_add_overflow_xint127_xint127_xint127(_BitInt(127) x, _BitInt(127) y, _BitInt(127) *res) {
+  return __builtin_add_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @_Z41test_add_overflow_xint127_xint127_xint127DB127_S_PS_
+//      CIR:   %[[#LHS:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.int<s, 127, bitint>>, !cir.int<s, 127, bitint>
+// CIR-NEXT:   %[[#RHS:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.int<s, 127, bitint>>, !cir.int<s, 127, bitint>
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.int<s, 127, bitint>>>, !cir.ptr<!cir.int<s, 127, bitint>>
+// CIR-NEXT:   %[[#PROM_LHS:]] = cir.cast integral %[[#LHS]] : !cir.int<s, 127, bitint> -> !cir.int<s, 127>
+// CIR-NEXT:   %[[#PROM_RHS:]] = cir.cast integral %[[#RHS]] : !cir.int<s, 127, bitint> -> !cir.int<s, 127>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.add.overflow %[[#PROM_LHS]], %[[#PROM_RHS]] : !cir.int<s, 127> -> !cir.int<s, 127, bitint>
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !cir.int<s, 127, bitint>, !cir.ptr<!cir.int<s, 127, bitint>>
+//      CIR: }
+
+bool test_add_overflow_uxint128_uxint128_uxint128(unsigned _BitInt(128) x, unsigned _BitInt(128) y, unsigned _BitInt(128) *res) {
+  return __builtin_add_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @_Z44test_add_overflow_uxint128_uxint128_uxint128DU128_S_PS_
+//      CIR:   %[[#LHS:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u128i_bitint>, !u128i_bitint
+// CIR-NEXT:   %[[#RHS:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u128i_bitint>, !u128i_bitint
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!u128i_bitint>>, !cir.ptr<!u128i_bitint>
+// CIR-NEXT:   %[[#PROM_LHS:]] = cir.cast integral %[[#LHS]] : !u128i_bitint -> !u128i
+// CIR-NEXT:   %[[#PROM_RHS:]] = cir.cast integral %[[#RHS]] : !u128i_bitint -> !u128i
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.add.overflow %[[#PROM_LHS]], %[[#PROM_RHS]] : !u128i -> !u128i_bitint
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !u128i_bitint, !cir.ptr<!u128i_bitint>
+//      CIR: }
+
+#if __BITINT_MAXWIDTH__ > 128
+bool test_add_overflow_uxint129_uxint129_uxint129(unsigned _BitInt(129) x,
+                                                   unsigned _BitInt(129) y,
+                                                   unsigned _BitInt(129) *res) {
+  return __builtin_add_overflow(x, y, res);
+}
+
+// LLVM-LABEL: define{{.*}} i1 @{{.*}}test_add_overflow_uxint129_uxint129_uxint129{{.*}}
+// LLVM: call { i129, i1 } @llvm.uadd.with.overflow.i129
+#endif
+
+bool test_add_overflow_xint127_uxint127_uxint127(_BitInt(127) x, unsigned _BitInt(127) y, unsigned _BitInt(127) *res) {
+  return __builtin_add_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @_Z43test_add_overflow_xint127_uxint127_uxint127DB127_DU127_PS0_
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.int<s, 127, bitint>>, !cir.int<s, 127, bitint>
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.int<u, 127, bitint>>, !cir.int<u, 127, bitint>
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.int<u, 127, bitint>>>, !cir.ptr<!cir.int<u, 127, bitint>>
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast integral %[[#X]] : !cir.int<s, 127, bitint> -> !s128i
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast integral %[[#Y]] : !cir.int<u, 127, bitint> -> !s128i
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.add.overflow %[[#PROM_X]], %[[#PROM_Y]] : !s128i -> !cir.int<u, 127, bitint>
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !cir.int<u, 127, bitint>, !cir.ptr<!cir.int<u, 127, bitint>>
+//      CIR: }
+
 bool test_sub_overflow_uint_uint_uint(unsigned x, unsigned y, unsigned *res) {
   return __builtin_sub_overflow(x, y, res);
 }
@@ -57,6 +225,19 @@ bool test_sub_overflow_uint_uint_uint(unsigned x, unsigned y, unsigned *res) {
 // CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!u32i>>, !cir.ptr<!u32i>
 // CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.sub.overflow %[[#LHS]], %[[#RHS]] : !u32i -> !u32i
 // CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !u32i, !cir.ptr<!u32i>
+//      CIR: }
+
+bool test_sub_overflow_uint_uint_bool(unsigned x, unsigned y, bool *res) {
+  return __builtin_sub_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_sub_overflow_uint_uint_bool{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u32i>, !u32i
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u32i>, !u32i
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.bool>>, !cir.ptr<!cir.bool>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.sub.overflow %[[#X]], %[[#Y]] : !u32i -> !cir.int<u, 1>
+// CIR-NEXT:   %[[BOOL_RES:.+]] = cir.cast int_to_bool %[[RES]] : !cir.int<u, 1> -> !cir.bool
+// CIR-NEXT:   cir.store{{.*}} %[[BOOL_RES]], %[[#RES_PTR]] : !cir.bool, !cir.ptr<!cir.bool>
 //      CIR: }
 
 bool test_sub_overflow_int_int_int(int x, int y, int *res) {
@@ -83,6 +264,48 @@ bool test_sub_overflow_xint31_xint31_xint31(_BitInt(31) x, _BitInt(31) y, _BitIn
 // CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !cir.int<s, 31, bitint>, !cir.ptr<!cir.int<s, 31, bitint>>
 //      CIR: }
 
+bool test_sub_overflow_xint127_xint127_xint127(_BitInt(127) x, _BitInt(127) y, _BitInt(127) *res) {
+  return __builtin_sub_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @_Z41test_sub_overflow_xint127_xint127_xint127DB127_S_PS_
+//      CIR:   %[[#LHS:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.int<s, 127, bitint>>, !cir.int<s, 127, bitint>
+// CIR-NEXT:   %[[#RHS:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.int<s, 127, bitint>>, !cir.int<s, 127, bitint>
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.int<s, 127, bitint>>>, !cir.ptr<!cir.int<s, 127, bitint>>
+// CIR-NEXT:   %[[#PROM_LHS:]] = cir.cast integral %[[#LHS]] : !cir.int<s, 127, bitint> -> !cir.int<s, 127>
+// CIR-NEXT:   %[[#PROM_RHS:]] = cir.cast integral %[[#RHS]] : !cir.int<s, 127, bitint> -> !cir.int<s, 127>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.sub.overflow %[[#PROM_LHS]], %[[#PROM_RHS]] : !cir.int<s, 127> -> !cir.int<s, 127, bitint>
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !cir.int<s, 127, bitint>, !cir.ptr<!cir.int<s, 127, bitint>>
+//      CIR: }
+
+bool test_sub_overflow_uxint128_uxint128_uxint128(unsigned _BitInt(128) x, unsigned _BitInt(128) y, unsigned _BitInt(128) *res) {
+  return __builtin_sub_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @_Z44test_sub_overflow_uxint128_uxint128_uxint128DU128_S_PS_
+//      CIR:   %[[#LHS:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u128i_bitint>, !u128i_bitint
+// CIR-NEXT:   %[[#RHS:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u128i_bitint>, !u128i_bitint
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!u128i_bitint>>, !cir.ptr<!u128i_bitint>
+// CIR-NEXT:   %[[#PROM_LHS:]] = cir.cast integral %[[#LHS]] : !u128i_bitint -> !u128i
+// CIR-NEXT:   %[[#PROM_RHS:]] = cir.cast integral %[[#RHS]] : !u128i_bitint -> !u128i
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.sub.overflow %[[#PROM_LHS]], %[[#PROM_RHS]] : !u128i -> !u128i_bitint
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !u128i_bitint, !cir.ptr<!u128i_bitint>
+//      CIR: }
+
+bool test_sub_overflow_xint127_uxint127_uxint127(_BitInt(127) x, unsigned _BitInt(127) y, unsigned _BitInt(127) *res) {
+  return __builtin_sub_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @_Z43test_sub_overflow_xint127_uxint127_uxint127DB127_DU127_PS0_
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.int<s, 127, bitint>>, !cir.int<s, 127, bitint>
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.int<u, 127, bitint>>, !cir.int<u, 127, bitint>
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.int<u, 127, bitint>>>, !cir.ptr<!cir.int<u, 127, bitint>>
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast integral %[[#X]] : !cir.int<s, 127, bitint> -> !s128i
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast integral %[[#Y]] : !cir.int<u, 127, bitint> -> !s128i
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.sub.overflow %[[#PROM_X]], %[[#PROM_Y]] : !s128i -> !cir.int<u, 127, bitint>
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !cir.int<u, 127, bitint>, !cir.ptr<!cir.int<u, 127, bitint>>
+//      CIR: }
+
 bool test_mul_overflow_uint_uint_uint(unsigned x, unsigned y, unsigned *res) {
   return __builtin_mul_overflow(x, y, res);
 }
@@ -93,6 +316,65 @@ bool test_mul_overflow_uint_uint_uint(unsigned x, unsigned y, unsigned *res) {
 // CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!u32i>>, !cir.ptr<!u32i>
 // CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.mul.overflow %[[#LHS]], %[[#RHS]] : !u32i -> !u32i
 // CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !u32i, !cir.ptr<!u32i>
+//      CIR: }
+
+bool test_mul_overflow_uint_uint_int(unsigned x, unsigned y, int *res) {
+  return __builtin_mul_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_mul_overflow_uint_uint_int{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u32i>, !u32i
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u32i>, !u32i
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast integral %[[#X]] : !u32i -> !cir.int<s, 33>
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast integral %[[#Y]] : !u32i -> !cir.int<s, 33>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.mul.overflow %[[#PROM_X]], %[[#PROM_Y]] : !cir.int<s, 33> -> !s32i
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !s32i, !cir.ptr<!s32i>
+//      CIR: }
+
+// LLVM: define{{.*}} i1 @{{.*}}test_mul_overflow_uint_uint_int{{.*}}
+// LLVM:   %[[#X:]] = zext i32 %{{.*}} to i33
+// LLVM:   %[[#Y:]] = zext i32 %{{.*}} to i33
+// LLVM:   %[[#CALL:]] = call { i33, i1 } @llvm.smul.with.overflow.i33(i33 %[[#X]], i33 %[[#Y]])
+// LLVM:   %[[#RES:]] = extractvalue { i33, i1 } %[[#CALL]], 0
+// LLVM:   %[[#OV:]] = extractvalue { i33, i1 } %[[#CALL]], 1
+// LLVM:   %[[#TRUNC:]] = trunc i33 %[[#RES]] to i32
+// LLVM:   %[[#TRUNC_EXT:]] = sext i32 %[[#TRUNC]] to i33
+// LLVM:   %[[#TRUNC_OV:]] = icmp ne i33 %[[#TRUNC_EXT]], %[[#RES]]
+// LLVM:   or i1 %[[#OV]], %[[#TRUNC_OV]]
+
+// OGCG-LABEL: define{{.*}} i1 @{{.*}}test_mul_overflow_uint_uint_int{{.*}}
+// OGCG:       %[[#CALL:]] = call { i32, i1 } @llvm.umul.with.overflow.i32(i32 %{{.*}}, i32 %{{.*}})
+// OGCG:       %[[#OV:]] = extractvalue { i32, i1 } %[[#CALL]], 1
+// OGCG:       %[[#RES:]] = extractvalue { i32, i1 } %[[#CALL]], 0
+// OGCG:       %[[#OV2:]] = icmp ugt i32 %[[#RES]], 2147483647
+// OGCG:       or i1 %[[#OV]], %[[#OV2]]
+
+bool test_mul_overflow_int_uint_int(int x, unsigned y, int *res) {
+  return __builtin_mul_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_mul_overflow_int_uint_int{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u32i>, !u32i
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast integral %[[#X]] : !s32i -> !cir.int<s, 33>
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast integral %[[#Y]] : !u32i -> !cir.int<s, 33>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.mul.overflow %[[#PROM_X]], %[[#PROM_Y]] : !cir.int<s, 33> -> !s32i
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !s32i, !cir.ptr<!s32i>
+//      CIR: }
+
+bool test_mul_overflow_uint_uint_bool(unsigned x, unsigned y, bool *res) {
+  return __builtin_mul_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_mul_overflow_uint_uint_bool{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u32i>, !u32i
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u32i>, !u32i
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.bool>>, !cir.ptr<!cir.bool>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.mul.overflow %[[#X]], %[[#Y]] : !u32i -> !cir.int<u, 1>
+// CIR-NEXT:   %[[BOOL_RES:.+]] = cir.cast int_to_bool %[[RES]] : !cir.int<u, 1> -> !cir.bool
+// CIR-NEXT:   cir.store{{.*}} %[[BOOL_RES]], %[[#RES_PTR]] : !cir.bool, !cir.ptr<!cir.bool>
 //      CIR: }
 
 bool test_mul_overflow_int_int_int(int x, int y, int *res) {
@@ -119,6 +401,48 @@ bool test_mul_overflow_xint31_xint31_xint31(_BitInt(31) x, _BitInt(31) y, _BitIn
 // CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !cir.int<s, 31, bitint>, !cir.ptr<!cir.int<s, 31, bitint>>
 //      CIR: }
 
+bool test_mul_overflow_xint127_xint127_xint127(_BitInt(127) x, _BitInt(127) y, _BitInt(127) *res) {
+  return __builtin_mul_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @_Z41test_mul_overflow_xint127_xint127_xint127DB127_S_PS_
+//      CIR:   %[[#LHS:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.int<s, 127, bitint>>, !cir.int<s, 127, bitint>
+// CIR-NEXT:   %[[#RHS:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.int<s, 127, bitint>>, !cir.int<s, 127, bitint>
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.int<s, 127, bitint>>>, !cir.ptr<!cir.int<s, 127, bitint>>
+// CIR-NEXT:   %[[#PROM_LHS:]] = cir.cast integral %[[#LHS]] : !cir.int<s, 127, bitint> -> !cir.int<s, 127>
+// CIR-NEXT:   %[[#PROM_RHS:]] = cir.cast integral %[[#RHS]] : !cir.int<s, 127, bitint> -> !cir.int<s, 127>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.mul.overflow %[[#PROM_LHS]], %[[#PROM_RHS]] : !cir.int<s, 127> -> !cir.int<s, 127, bitint>
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !cir.int<s, 127, bitint>, !cir.ptr<!cir.int<s, 127, bitint>>
+//      CIR: }
+
+bool test_mul_overflow_uxint128_uxint128_uxint128(unsigned _BitInt(128) x, unsigned _BitInt(128) y, unsigned _BitInt(128) *res) {
+  return __builtin_mul_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @_Z44test_mul_overflow_uxint128_uxint128_uxint128DU128_S_PS_
+//      CIR:   %[[#LHS:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u128i_bitint>, !u128i_bitint
+// CIR-NEXT:   %[[#RHS:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u128i_bitint>, !u128i_bitint
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!u128i_bitint>>, !cir.ptr<!u128i_bitint>
+// CIR-NEXT:   %[[#PROM_LHS:]] = cir.cast integral %[[#LHS]] : !u128i_bitint -> !u128i
+// CIR-NEXT:   %[[#PROM_RHS:]] = cir.cast integral %[[#RHS]] : !u128i_bitint -> !u128i
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.mul.overflow %[[#PROM_LHS]], %[[#PROM_RHS]] : !u128i -> !u128i_bitint
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !u128i_bitint, !cir.ptr<!u128i_bitint>
+//      CIR: }
+
+bool test_mul_overflow_xint127_uxint127_uxint127(_BitInt(127) x, unsigned _BitInt(127) y, unsigned _BitInt(127) *res) {
+  return __builtin_mul_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @_Z43test_mul_overflow_xint127_uxint127_uxint127DB127_DU127_PS0_
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.int<s, 127, bitint>>, !cir.int<s, 127, bitint>
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.int<u, 127, bitint>>, !cir.int<u, 127, bitint>
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.int<u, 127, bitint>>>, !cir.ptr<!cir.int<u, 127, bitint>>
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast integral %[[#X]] : !cir.int<s, 127, bitint> -> !s128i
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast integral %[[#Y]] : !cir.int<u, 127, bitint> -> !s128i
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.mul.overflow %[[#PROM_X]], %[[#PROM_Y]] : !s128i -> !cir.int<u, 127, bitint>
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !cir.int<u, 127, bitint>, !cir.ptr<!cir.int<u, 127, bitint>>
+//      CIR: }
+
 bool test_mul_overflow_ulong_ulong_long(unsigned long x, unsigned long y, unsigned long *res) {
   return __builtin_mul_overflow(x, y, res);
 }
@@ -130,6 +454,38 @@ bool test_mul_overflow_ulong_ulong_long(unsigned long x, unsigned long y, unsign
 // CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.mul.overflow %[[#LHS]], %[[#RHS]] : !u64i -> !u64i
 // CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !u64i, !cir.ptr<!u64i>
 //      CIR: }
+
+bool test_mul_overflow_ulong_ulong_long_signed(unsigned long x, unsigned long y, long *res) {
+  return __builtin_mul_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_mul_overflow_ulong_ulong_long_signed{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u64i>, !u64i
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u64i>, !u64i
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!s64i>>, !cir.ptr<!s64i>
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast integral %[[#X]] : !u64i -> !cir.int<s, 65>
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast integral %[[#Y]] : !u64i -> !cir.int<s, 65>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.mul.overflow %[[#PROM_X]], %[[#PROM_Y]] : !cir.int<s, 65> -> !s64i
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !s64i, !cir.ptr<!s64i>
+//      CIR: }
+
+// LLVM: define{{.*}} i1 @{{.*}}test_mul_overflow_ulong_ulong_long_signed{{.*}}
+// LLVM:   %[[#X:]] = zext i64 %{{.*}} to i65
+// LLVM:   %[[#Y:]] = zext i64 %{{.*}} to i65
+// LLVM:   %[[#CALL:]] = call { i65, i1 } @llvm.smul.with.overflow.i65(i65 %[[#X]], i65 %[[#Y]])
+// LLVM:   %[[#RES:]] = extractvalue { i65, i1 } %[[#CALL]], 0
+// LLVM:   %[[#OV:]] = extractvalue { i65, i1 } %[[#CALL]], 1
+// LLVM:   %[[#TRUNC:]] = trunc i65 %[[#RES]] to i64
+// LLVM:   %[[#TRUNC_EXT:]] = sext i64 %[[#TRUNC]] to i65
+// LLVM:   %[[#TRUNC_OV:]] = icmp ne i65 %[[#TRUNC_EXT]], %[[#RES]]
+// LLVM:   or i1 %[[#OV]], %[[#TRUNC_OV]]
+
+// OGCG-LABEL: define{{.*}} i1 @{{.*}}test_mul_overflow_ulong_ulong_long_signed{{.*}}
+// OGCG:       %[[#CALL:]] = call { i64, i1 } @llvm.umul.with.overflow.i64(i64 %{{.*}}, i64 %{{.*}})
+// OGCG:       %[[#OV:]] = extractvalue { i64, i1 } %[[#CALL]], 1
+// OGCG:       %[[#RES:]] = extractvalue { i64, i1 } %[[#CALL]], 0
+// OGCG:       %[[#OV2:]] = icmp ugt i64 %[[#RES]], 9223372036854775807
+// OGCG:       or i1 %[[#OV]], %[[#OV2]]
 
 bool test_add_overflow_uint_int_int(unsigned x, int y, int *res) {
   return __builtin_add_overflow(x, y, res);
@@ -144,6 +500,116 @@ bool test_add_overflow_uint_int_int(unsigned x, int y, int *res) {
 // CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.add.overflow %[[#PROM_X]], %[[#PROM_Y]] : !cir.int<s, 33> -> !s32i
 // CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !s32i, !cir.ptr<!s32i>
 //      CIR: }
+
+bool test_add_overflow_int_uint_uint(int x, unsigned y, unsigned *res) {
+  return __builtin_add_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_add_overflow_int_uint_uint{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u32i>, !u32i
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!u32i>>, !cir.ptr<!u32i>
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast integral %[[#X]] : !s32i -> !cir.int<s, 33>
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast integral %[[#Y]] : !u32i -> !cir.int<s, 33>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.add.overflow %[[#PROM_X]], %[[#PROM_Y]] : !cir.int<s, 33> -> !u32i
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !u32i, !cir.ptr<!u32i>
+//      CIR: }
+
+// LLVM: define{{.*}} i1 @{{.*}}test_add_overflow_int_uint_uint{{.*}}
+// LLVM:   %[[#X:]] = sext i32 %{{.*}} to i33
+// LLVM:   %[[#Y:]] = zext i32 %{{.*}} to i33
+// LLVM:   %[[#CALL:]] = call { i33, i1 } @llvm.sadd.with.overflow.i33(i33 %[[#X]], i33 %[[#Y]])
+// LLVM:   %[[#RES:]] = extractvalue { i33, i1 } %[[#CALL]], 0
+// LLVM:   %[[#OV:]] = extractvalue { i33, i1 } %[[#CALL]], 1
+// LLVM:   %[[#TRUNC:]] = trunc i33 %[[#RES]] to i32
+// LLVM:   %[[#TRUNC_EXT:]] = zext i32 %[[#TRUNC]] to i33
+// LLVM:   %[[#TRUNC_OV:]] = icmp ne i33 %[[#TRUNC_EXT]], %[[#RES]]
+// LLVM:   or i1 %[[#OV]], %[[#TRUNC_OV]]
+
+// OGCG-LABEL: define{{.*}} i1 @{{.*}}test_add_overflow_int_uint_uint{{.*}}
+// OGCG:       %[[#X:]] = sext i32 %{{.*}} to i33
+// OGCG:       %[[#Y:]] = zext i32 %{{.*}} to i33
+// OGCG:       %[[#CALL:]] = call { i33, i1 } @llvm.sadd.with.overflow.i33(i33 %[[#X]], i33 %[[#Y]])
+// OGCG-DAG:   %[[#OV:]] = extractvalue { i33, i1 } %[[#CALL]], 1
+// OGCG-DAG:   %[[#RES:]] = extractvalue { i33, i1 } %[[#CALL]], 0
+// OGCG:       %[[#TRUNC:]] = trunc i33 %[[#RES]] to i32
+// OGCG:       %[[#TRUNC_EXT:]] = zext i32 %[[#TRUNC]] to i33
+// OGCG:       %[[#TRUNC_OV:]] = icmp ne i33 %[[#RES]], %[[#TRUNC_EXT]]
+// OGCG:       or i1 %[[#OV]], %[[#TRUNC_OV]]
+
+bool test_sub_overflow_int_uint_uint(int x, unsigned y, unsigned *res) {
+  return __builtin_sub_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_sub_overflow_int_uint_uint{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u32i>, !u32i
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!u32i>>, !cir.ptr<!u32i>
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast integral %[[#X]] : !s32i -> !cir.int<s, 33>
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast integral %[[#Y]] : !u32i -> !cir.int<s, 33>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.sub.overflow %[[#PROM_X]], %[[#PROM_Y]] : !cir.int<s, 33> -> !u32i
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !u32i, !cir.ptr<!u32i>
+//      CIR: }
+
+// LLVM: define{{.*}} i1 @{{.*}}test_sub_overflow_int_uint_uint{{.*}}
+// LLVM:   %[[#X:]] = sext i32 %{{.*}} to i33
+// LLVM:   %[[#Y:]] = zext i32 %{{.*}} to i33
+// LLVM:   %[[#CALL:]] = call { i33, i1 } @llvm.ssub.with.overflow.i33(i33 %[[#X]], i33 %[[#Y]])
+// LLVM:   %[[#RES:]] = extractvalue { i33, i1 } %[[#CALL]], 0
+// LLVM:   %[[#OV:]] = extractvalue { i33, i1 } %[[#CALL]], 1
+// LLVM:   %[[#TRUNC:]] = trunc i33 %[[#RES]] to i32
+// LLVM:   %[[#TRUNC_EXT:]] = zext i32 %[[#TRUNC]] to i33
+// LLVM:   %[[#TRUNC_OV:]] = icmp ne i33 %[[#TRUNC_EXT]], %[[#RES]]
+// LLVM:   or i1 %[[#OV]], %[[#TRUNC_OV]]
+
+// OGCG-LABEL: define{{.*}} i1 @{{.*}}test_sub_overflow_int_uint_uint{{.*}}
+// OGCG:       %[[#X:]] = sext i32 %{{.*}} to i33
+// OGCG:       %[[#Y:]] = zext i32 %{{.*}} to i33
+// OGCG:       %[[#CALL:]] = call { i33, i1 } @llvm.ssub.with.overflow.i33(i33 %[[#X]], i33 %[[#Y]])
+// OGCG-DAG:   %[[#OV:]] = extractvalue { i33, i1 } %[[#CALL]], 1
+// OGCG-DAG:   %[[#RES:]] = extractvalue { i33, i1 } %[[#CALL]], 0
+// OGCG:       %[[#TRUNC:]] = trunc i33 %[[#RES]] to i32
+// OGCG:       %[[#TRUNC_EXT:]] = zext i32 %[[#TRUNC]] to i33
+// OGCG:       %[[#TRUNC_OV:]] = icmp ne i33 %[[#RES]], %[[#TRUNC_EXT]]
+// OGCG:       or i1 %[[#OV]], %[[#TRUNC_OV]]
+
+bool test_mul_overflow_int_uint_uint(int x, unsigned y, unsigned *res) {
+  return __builtin_mul_overflow(x, y, res);
+}
+
+//      CIR: cir.func {{.*}} @{{.*}}test_mul_overflow_int_uint_uint{{.*}}
+//      CIR:   %[[#X:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   %[[#Y:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u32i>, !u32i
+// CIR-NEXT:   %[[#RES_PTR:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!u32i>>, !cir.ptr<!u32i>
+// CIR-NEXT:   %[[#PROM_X:]] = cir.cast integral %[[#X]] : !s32i -> !cir.int<s, 33>
+// CIR-NEXT:   %[[#PROM_Y:]] = cir.cast integral %[[#Y]] : !u32i -> !cir.int<s, 33>
+// CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.mul.overflow %[[#PROM_X]], %[[#PROM_Y]] : !cir.int<s, 33> -> !u32i
+// CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !u32i, !cir.ptr<!u32i>
+//      CIR: }
+
+// LLVM: define{{.*}} i1 @{{.*}}test_mul_overflow_int_uint_uint{{.*}}
+// LLVM:   %[[#X:]] = sext i32 %{{.*}} to i33
+// LLVM:   %[[#Y:]] = zext i32 %{{.*}} to i33
+// LLVM:   %[[#CALL:]] = call { i33, i1 } @llvm.smul.with.overflow.i33(i33 %[[#X]], i33 %[[#Y]])
+// LLVM:   %[[#RES:]] = extractvalue { i33, i1 } %[[#CALL]], 0
+// LLVM:   %[[#OV:]] = extractvalue { i33, i1 } %[[#CALL]], 1
+// LLVM:   %[[#TRUNC:]] = trunc i33 %[[#RES]] to i32
+// LLVM:   %[[#TRUNC_EXT:]] = zext i32 %[[#TRUNC]] to i33
+// LLVM:   %[[#TRUNC_OV:]] = icmp ne i33 %[[#TRUNC_EXT]], %[[#RES]]
+// LLVM:   or i1 %[[#OV]], %[[#TRUNC_OV]]
+
+// OGCG-LABEL: define{{.*}} i1 @{{.*}}test_mul_overflow_int_uint_uint{{.*}}
+// OGCG:       %[[#NEG:]] = icmp slt i32 %{{.*}}, 0
+// OGCG:       %[[#NEG_VAL:]] = sub i32 0, %{{.*}}
+// OGCG:       %[[#ABS:]] = select i1 %[[#NEG]], i32 %[[#NEG_VAL]], i32 %{{.*}}
+// OGCG:       %[[#CALL:]] = call { i32, i1 } @llvm.umul.with.overflow.i32(i32 %[[#ABS]], i32 %{{.*}})
+// OGCG:       %[[#OV:]] = extractvalue { i32, i1 } %[[#CALL]], 1
+// OGCG:       %[[#RES:]] = extractvalue { i32, i1 } %[[#CALL]], 0
+// OGCG:       %[[#NZ:]] = icmp ne i32 %[[#RES]], 0
+// OGCG:       %[[#UNDER:]] = and i1 %[[#NEG]], %[[#NZ]]
+// OGCG:       %[[#OV2:]] = or i1 %[[#OV]], %[[#UNDER]]
+// OGCG:       %[[#NEG_RES:]] = sub i32 0, %[[#RES]]
+// OGCG:       %[[#RES2:]] = select i1 %[[#NEG]], i32 %[[#NEG_RES]], i32 %[[#RES]]
 
 bool test_add_overflow_volatile(int x, int y, volatile int *res) {
   return __builtin_add_overflow(x, y, res);


### PR DESCRIPTION
Fixes

1. ~~bool arguments assertion https://godbolt.org/z/v4Mf7dbxW.~~ Fixed by https://github.com/llvm/llvm-project/pull/198958 which was opened and merged after this PR was opened :\
2. bool result assertion https://godbolt.org/z/K5rPbvefP.
3. ~~high _BitInt assertion https://godbolt.org/z/7xWsb8h8h.~~ No longer crashes, the added tests and simplification seemed like added noise that would delay this getting reviewed even longer.

clangir on Compiler Explorer is wildly out of date, so feel free to try the code locally.

related non-CIR PR #192568.