### PR TITLE
[libclc] Fix atomic_fetch_add/sub overloads for uintptr_t

### DIFF
--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
@@ -52,22 +52,21 @@ _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
 
 #ifdef __opencl_c_atomic_scope_device
 
-_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add_explicit(
     volatile __local atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
   return __scoped_atomic_fetch_add((volatile __local uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
-_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add_explicit(
     volatile __global atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
   return __scoped_atomic_fetch_add((volatile __global uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
-_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
-                                                  ptrdiff_t v,
-                                                  memory_order order) {
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add_explicit(
+    volatile atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
   return __scoped_atomic_fetch_add((volatile uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
@@ -75,25 +74,24 @@ _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
 #endif // __opencl_c_atomic_scope_device
 
 _CLC_DEF _CLC_OVERLOAD uintptr_t
-atomic_fetch_add(volatile __local atomic_uintptr_t *p, ptrdiff_t v,
-                 memory_order order, memory_scope scope) {
+atomic_fetch_add_explicit(volatile __local atomic_uintptr_t *p, ptrdiff_t v,
+                          memory_order order, memory_scope scope) {
   return __scoped_atomic_fetch_add((volatile __local uintptr_t *)p, v, order,
                                    __opencl_get_clang_memory_scope(scope));
 }
 
 _CLC_DEF _CLC_OVERLOAD uintptr_t
-atomic_fetch_add(volatile __global atomic_uintptr_t *p, ptrdiff_t v,
-                 memory_order order, memory_scope scope) {
+atomic_fetch_add_explicit(volatile __global atomic_uintptr_t *p, ptrdiff_t v,
+                          memory_order order, memory_scope scope) {
   return __scoped_atomic_fetch_add((volatile __global uintptr_t *)p, v, order,
                                    __opencl_get_clang_memory_scope(scope));
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
 
-_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
-                                                  ptrdiff_t v,
-                                                  memory_order order,
-                                                  memory_scope scope) {
+_CLC_DEF _CLC_OVERLOAD uintptr_t
+atomic_fetch_add_explicit(volatile atomic_uintptr_t *p, ptrdiff_t v,
+                          memory_order order, memory_scope scope) {
   return __scoped_atomic_fetch_add((volatile uintptr_t *)p, v, order,
                                    __opencl_get_clang_memory_scope(scope));
 }

--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
@@ -52,22 +52,21 @@ _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
 
 #ifdef __opencl_c_atomic_scope_device
 
-_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub_explicit(
     volatile __local atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
   return __scoped_atomic_fetch_sub((volatile __local uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
-_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub_explicit(
     volatile __global atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
   return __scoped_atomic_fetch_sub((volatile __global uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
-_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
-                                                  ptrdiff_t v,
-                                                  memory_order order) {
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub_explicit(
+    volatile atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
   return __scoped_atomic_fetch_sub((volatile uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
@@ -75,25 +74,24 @@ _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
 #endif // __opencl_c_atomic_scope_device
 
 _CLC_DEF _CLC_OVERLOAD uintptr_t
-atomic_fetch_sub(volatile __local atomic_uintptr_t *p, ptrdiff_t v,
-                 memory_order order, memory_scope scope) {
+atomic_fetch_sub_explicit(volatile __local atomic_uintptr_t *p, ptrdiff_t v,
+                          memory_order order, memory_scope scope) {
   return __scoped_atomic_fetch_sub((volatile __local uintptr_t *)p, v, order,
                                    __opencl_get_clang_memory_scope(scope));
 }
 
 _CLC_DEF _CLC_OVERLOAD uintptr_t
-atomic_fetch_sub(volatile __global atomic_uintptr_t *p, ptrdiff_t v,
-                 memory_order order, memory_scope scope) {
+atomic_fetch_sub_explicit(volatile __global atomic_uintptr_t *p, ptrdiff_t v,
+                          memory_order order, memory_scope scope) {
   return __scoped_atomic_fetch_sub((volatile __global uintptr_t *)p, v, order,
                                    __opencl_get_clang_memory_scope(scope));
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
 
-_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
-                                                  ptrdiff_t v,
-                                                  memory_order order,
-                                                  memory_scope scope) {
+_CLC_DEF _CLC_OVERLOAD uintptr_t
+atomic_fetch_sub_explicit(volatile atomic_uintptr_t *p, ptrdiff_t v,
+                          memory_order order, memory_scope scope) {
   return __scoped_atomic_fetch_sub((volatile uintptr_t *)p, v, order,
                                    __opencl_get_clang_memory_scope(scope));
 }


### PR DESCRIPTION
The overloads taking the memory order and/or scope parameters should
have the `_explicit` suffix, according to the OpenCL C specification.