### PR TITLE
[NFC][OpenMP] Make map ordering tests for no host->tgt transfer more robust

### DIFF
--- a/offload/test/mapping/map_ordering_tgt_exit_data_always_always.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_always_always.c
@@ -13,9 +13,10 @@ int main() {
 #pragma omp target data map(alloc : x)
   {
 #pragma omp target enter data map(alloc : x) map(to : x)
+// DEBUG-NOT: omptarget --> Moving {{.*}} bytes (hst:0x{{.*}}) -> (tgt:0x{{.*}})
 #pragma omp target map(present, alloc : x)
     {
-      printf("In tgt: %d\n", x); // CHECK-NOT: In tgt: 111
+      printf("In tgt: %d\n", x);
       x = 222;
     }
 #pragma omp target exit data map(always, from : x) map(always, from : x)

--- a/offload/test/mapping/map_ordering_tgt_exit_data_delete_from.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_delete_from.c
@@ -9,8 +9,7 @@ int main() {
 #pragma omp target enter data map(alloc : x) map(to : x)
 #pragma omp target map(present, alloc : x)
     {
-      // NOTE: It's ok for this to be 111 under "unified_shared_memory"
-      printf("In tgt: %d\n", x); // CHECK-NOT: In tgt: 111
+      printf("In tgt: %d\n", x);
       x = 222;
     }
 #pragma omp target exit data map(delete : x) map(from : x) map(delete : x)

--- a/offload/test/mapping/map_ordering_tgt_exit_data_delete_from_assumedsize.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_delete_from_assumedsize.c
@@ -25,8 +25,7 @@ int main() {
 // DEBUG-NOT: omptarget --> Moving {{.*}} bytes (hst:0x{{.*}}) -> (tgt:0x{{.*}})
 #pragma omp target map(present, alloc : x)
     {
-      // NOTE: It's ok for this to be 111 under "unified_shared_memory"
-      printf("In tgt: %d\n", x[1]); // CHECK-NOT: In tgt: 111
+      printf("In tgt: %d\n", x[1]);
       x[1] = 222;
     }
 

--- a/offload/test/mapping/map_ordering_tgt_exit_data_from_delete_assumedsize.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_from_delete_assumedsize.c
@@ -25,8 +25,7 @@ int main() {
 // DEBUG-NOT: omptarget --> Moving {{.*}} bytes (hst:0x{{.*}}) -> (tgt:0x{{.*}})
 #pragma omp target map(present, alloc : x)
     {
-      // NOTE: It's ok for this to be 111 under "unified_shared_memory"
-      printf("In tgt: %d\n", x[1]); // CHECK-NOT: In tgt: 111
+      printf("In tgt: %d\n", x[1]);
       x[1] = 222;
     }
 


### PR DESCRIPTION
They were relying on the host value not being seen on the device, but the value being matched was small enough for the probability of a successful match against garbage data relatively high.

Now we just rely on the LIBOMPTARGET_DEBUG logs to ensure there wasn't any transfer.