### PR TITLE
[lldb] Remove unused bool members of DILParser (NFC)

### DIFF
--- a/lldb/include/lldb/ValueObject/DILParser.h
+++ b/lldb/include/lldb/ValueObject/DILParser.h
@@ -71,24 +71,15 @@ public:
                                          DILLexer lexer,
                                          std::shared_ptr<StackFrame> frame_sp,
                                          lldb::DynamicValueType use_dynamic,
-                                         uint32_t options, lldb::DILMode mode);
+                                         lldb::DILMode mode);
 
   ~DILParser() = default;
-
-  bool UseSynthetic() { return m_use_synthetic; }
-
-  bool UseFragileIvar() { return m_fragile_ivar; }
-
-  bool CheckPtrVsMember() { return m_check_ptr_vs_member; }
-
-  lldb::DynamicValueType UseDynamic() { return m_use_dynamic; }
 
 private:
   explicit DILParser(llvm::StringRef dil_input_expr, DILLexer lexer,
                      std::shared_ptr<StackFrame> frame_sp,
-                     lldb::DynamicValueType use_dynamic, bool use_synthetic,
-                     bool fragile_ivar, bool check_ptr_vs_member,
-                     llvm::Error &error, lldb::DILMode mode);
+                     lldb::DynamicValueType use_dynamic, llvm::Error &error,
+                     lldb::DILMode mode);
 
   ASTNodeUP Run();
 
@@ -144,9 +135,6 @@ private:
   llvm::Error &m_error;
 
   lldb::DynamicValueType m_use_dynamic;
-  bool m_use_synthetic;
-  bool m_fragile_ivar;
-  bool m_check_ptr_vs_member;
 
   // DIL Mode requested by the caller.
   lldb::DILMode m_mode;

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -549,9 +549,8 @@ ValueObjectSP StackFrame::DILGetValueForVariableExpressionPath(
   }
 
   // Parse the expression.
-  auto tree_or_error =
-      dil::DILParser::Parse(var_expr, std::move(*lex_or_err),
-                            shared_from_this(), use_dynamic, options, mode);
+  auto tree_or_error = dil::DILParser::Parse(
+      var_expr, std::move(*lex_or_err), shared_from_this(), use_dynamic, mode);
   if (!tree_or_error) {
     error = Status::FromError(tree_or_error.takeError());
     return ValueObjectConstResult::Create(nullptr, error.Clone());

--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -69,8 +69,8 @@ GetTypeSystemFromCU(std::shared_ptr<StackFrame> ctx) {
   return symbol_context.module_sp->GetTypeSystemForLanguage(language);
 }
 
-CompilerType ResolveTypeByName(const std::string &name,
-                               ExecutionContextScope &ctx_scope) {
+static CompilerType ResolveTypeByName(const std::string &name,
+                                      ExecutionContextScope &ctx_scope) {
   // Internally types don't have global scope qualifier in their names and
   // LLDB doesn't support queries with it too.
   llvm::StringRef name_ref(name);
@@ -104,19 +104,9 @@ llvm::Expected<ASTNodeUP> DILParser::Parse(llvm::StringRef dil_input_expr,
                                            DILLexer lexer,
                                            std::shared_ptr<StackFrame> frame_sp,
                                            lldb::DynamicValueType use_dynamic,
-                                           uint32_t options,
                                            lldb::DILMode mode) {
-  const bool check_ptr_vs_member =
-      (options & StackFrame::eExpressionPathOptionCheckPtrVsMember) != 0;
-  const bool no_fragile_ivar =
-      (options & StackFrame::eExpressionPathOptionsNoFragileObjcIvar) != 0;
-  const bool no_synth_child =
-      (options & StackFrame::eExpressionPathOptionsNoSyntheticChildren) != 0;
-
   llvm::Error error = llvm::Error::success();
-  DILParser parser(dil_input_expr, lexer, frame_sp, use_dynamic,
-                   !no_synth_child, !no_fragile_ivar, check_ptr_vs_member,
-                   error, mode);
+  DILParser parser(dil_input_expr, lexer, frame_sp, use_dynamic, error, mode);
 
   ASTNodeUP node_up = parser.Run();
   assert(node_up && "ASTNodeUP must not contain a nullptr");
@@ -129,13 +119,11 @@ llvm::Expected<ASTNodeUP> DILParser::Parse(llvm::StringRef dil_input_expr,
 
 DILParser::DILParser(llvm::StringRef dil_input_expr, DILLexer lexer,
                      std::shared_ptr<StackFrame> frame_sp,
-                     lldb::DynamicValueType use_dynamic, bool use_synthetic,
-                     bool fragile_ivar, bool check_ptr_vs_member,
-                     llvm::Error &error, lldb::DILMode mode)
+                     lldb::DynamicValueType use_dynamic, llvm::Error &error,
+                     lldb::DILMode mode)
     : m_ctx_scope(frame_sp), m_input_expr(dil_input_expr),
       m_dil_lexer(std::move(lexer)), m_error(error), m_use_dynamic(use_dynamic),
-      m_use_synthetic(use_synthetic), m_fragile_ivar(fragile_ivar),
-      m_check_ptr_vs_member(check_ptr_vs_member), m_mode(mode) {}
+      m_mode(mode) {}
 
 ASTNodeUP DILParser::Run() {
   ASTNodeUP expr = ParseExpression();


### PR DESCRIPTION
These options are used by DIL's `Interpreter`, but are unused by the Parser.