### PR TITLE
[clang] Exclude trailing colons from param command names

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -70,6 +70,8 @@ AST Dumping Potentially Breaking Changes
   ``introduced``, ``deprecated``, ``obsoleted``, ``unavailable``, ``message``,
   ``strict``, ``replacement``, ``priority``, and ``environment``. Previously, these
   fields were missing from the JSON output.
+- Colons that appear at the end of a ParamCommentCommand name are not serialized
+  as part of the name.
 
 Clang Frontend Potentially Breaking Changes
 -------------------------------------------

--- a/clang/lib/AST/CommentParser.cpp
+++ b/clang/lib/AST/CommentParser.cpp
@@ -299,6 +299,8 @@ public:
       } else
         break;
     }
+    if (WordText.ends_with(':'))
+      WordText.pop_back();
     const unsigned Length = WordText.size();
     if (Length == 0) {
       Pos = SavedPos;

--- a/clang/test/AST/ast-dump-comment.cpp
+++ b/clang/test/AST/ast-dump-comment.cpp
@@ -41,6 +41,7 @@ int Test_BlockCommandComment_WithArgs();
 
 /// \param Aaa xxx
 /// \param [in,out] Bbb yyy
+/// \param Ccc: zzz
 void Test_ParamCommandComment(int Aaa, int Bbb);
 // CHECK:      FunctionDecl{{.*}}Test_ParamCommandComment
 // CHECK:        ParamCommandComment{{.*}} [in] implicitly Param="Aaa" ParamIndex=0
@@ -49,6 +50,9 @@ void Test_ParamCommandComment(int Aaa, int Bbb);
 // CHECK:        ParamCommandComment{{.*}} [in,out] explicitly Param="Bbb" ParamIndex=1
 // CHECK-NEXT:     ParagraphComment
 // CHECK-NEXT:       TextComment{{.*}} Text=" yyy"
+// CHECK:        ParamCommandComment{{.*}} [in] implicitly Param="Ccc"
+// CHECK-NEXT:     ParagraphComment
+// CHECK-NEXT:       TextComment{{.*}} Text=" zzz"
 
 /// \tparam Aaa xxx
 template <typename Aaa> class Test_TParamCommandComment;


### PR DESCRIPTION
Doxygen accepts param names with trailing colons and they are omitted in
documentation. The comment parser includes the colon in the param name
thus including it in AST dumps. This patch removes a trailing colon and
adds a test for it.

Fixes #185378
