### PR TITLE
[libc][nfc] Fix ucontext buildbot failure with noexcept (#192343)

### DIFF
--- a/libc/src/ucontext/getcontext.h
+++ b/libc/src/ucontext/getcontext.h
@@ -14,7 +14,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-int getcontext(ucontext_t *ucp);
+int getcontext(ucontext_t *ucp) noexcept;
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/ucontext/setcontext.h
+++ b/libc/src/ucontext/setcontext.h
@@ -14,7 +14,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-int setcontext(const ucontext_t *ucp);
+int setcontext(const ucontext_t *ucp) noexcept;
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/ucontext/x86_64/getcontext.cpp
+++ b/libc/src/ucontext/x86_64/getcontext.cpp
@@ -19,7 +19,8 @@ namespace LIBC_NAMESPACE_DECL {
 
 // We use naked because we need to capture the exact register state
 // at the moment of the function call, avoiding any compiler prologue/epilogue.
-__attribute__((naked)) LLVM_LIBC_FUNCTION(int, getcontext, (ucontext_t * ucp)) {
+__attribute__((naked)) LLVM_LIBC_FUNCTION(int, getcontext,
+                                          (ucontext_t * ucp)) noexcept {
   asm(R"(
       # ucp is in rdi
       

--- a/libc/src/ucontext/x86_64/setcontext.cpp
+++ b/libc/src/ucontext/x86_64/setcontext.cpp
@@ -18,7 +18,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 __attribute__((naked)) LLVM_LIBC_FUNCTION(int, setcontext,
-                                          (const ucontext_t *ucp)) {
+                                          (const ucontext_t *ucp)) noexcept {
   asm(R"(
       # ucp is in rdi
       


### PR DESCRIPTION
Added noexcept to getcontext and setcontext declarations and definitions to resolve missing attribute warning on aliases.

This fixes failures on builders using GCC like libc-x86_64-debian-gcc-fullbuild-dbg.