### PR TITLE
[LFI][AArch64] Add rewrites for control flow

### DIFF
--- a/llvm/docs/LFI.rst
+++ b/llvm/docs/LFI.rst
@@ -173,8 +173,6 @@ In the following assembly rewrites, some shorthand is used.
 Control flow
 ~~~~~~~~~~~~
 
-**Note**: not yet implemented.
-
 Indirect branches get rewritten to branch through register ``x28``, which must
 always contain an address within the sandbox. An ``add`` is used to safely
 update ``x28`` with the destination address. Since ``ret`` uses ``x30`` by
@@ -303,8 +301,6 @@ before moving it back into ``sp`` with a safe ``add``.
 
 Link register modification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-**Note**: not yet implemented.
 
 When the link register is modified, we write the modified value to a
 temporary, before loading it back into ``x30`` with a safe ``add``.

--- a/llvm/include/llvm/MC/MCInstrDesc.h
+++ b/llvm/include/llvm/MC/MCInstrDesc.h
@@ -618,6 +618,11 @@ public:
     return -1;
   }
 
+  /// Return true if this instruction explicitly defines the specified physical
+  /// register.
+  LLVM_ABI bool hasExplicitDefOfPhysReg(const MCInst &MI, MCRegister Reg,
+                                        const MCRegisterInfo &RI) const;
+
   /// Return true if this instruction defines the specified physical
   /// register, either explicitly or implicitly.
   LLVM_ABI bool hasDefOfPhysReg(const MCInst &MI, MCRegister Reg,

--- a/llvm/include/llvm/MC/MCLFIRewriter.h
+++ b/llvm/include/llvm/MC/MCLFIRewriter.h
@@ -54,6 +54,8 @@ public:
   LLVM_ABI bool mayStore(const MCInst &Inst) const;
 
   LLVM_ABI bool mayModifyRegister(const MCInst &Inst, MCRegister Reg) const;
+  LLVM_ABI bool explicitlyModifiesRegister(const MCInst &Inst,
+                                           MCRegister Reg) const;
 
   virtual ~MCLFIRewriter() = default;
   virtual bool rewriteInst(const MCInst &Inst, MCStreamer &Out,

--- a/llvm/lib/MC/MCInstrDesc.cpp
+++ b/llvm/lib/MC/MCInstrDesc.cpp
@@ -37,8 +37,8 @@ bool MCInstrDesc::hasImplicitDefOfPhysReg(MCRegister Reg,
   return false;
 }
 
-bool MCInstrDesc::hasDefOfPhysReg(const MCInst &MI, MCRegister Reg,
-                                  const MCRegisterInfo &RI) const {
+bool MCInstrDesc::hasExplicitDefOfPhysReg(const MCInst &MI, MCRegister Reg,
+                                          const MCRegisterInfo &RI) const {
   for (int i = 0, e = NumDefs; i != e; ++i)
     if (MI.getOperand(i).isReg() && MI.getOperand(i).getReg() &&
         RI.isSubRegisterEq(Reg, MI.getOperand(i).getReg()))
@@ -48,5 +48,11 @@ bool MCInstrDesc::hasDefOfPhysReg(const MCInst &MI, MCRegister Reg,
       if (MI.getOperand(i).isReg() &&
           RI.isSubRegisterEq(Reg, MI.getOperand(i).getReg()))
         return true;
-  return hasImplicitDefOfPhysReg(Reg, &RI);
+  return false;
+}
+
+bool MCInstrDesc::hasDefOfPhysReg(const MCInst &MI, MCRegister Reg,
+                                  const MCRegisterInfo &RI) const {
+  return hasExplicitDefOfPhysReg(MI, Reg, RI) ||
+         hasImplicitDefOfPhysReg(Reg, &RI);
 }

--- a/llvm/lib/MC/MCLFIRewriter.cpp
+++ b/llvm/lib/MC/MCLFIRewriter.cpp
@@ -51,3 +51,14 @@ bool MCLFIRewriter::mayModifyRegister(const MCInst &Inst,
                                       MCRegister Reg) const {
   return InstInfo->get(Inst.getOpcode()).hasDefOfPhysReg(Inst, Reg, *RegInfo);
 }
+
+bool MCLFIRewriter::explicitlyModifiesRegister(const MCInst &Inst,
+                                               MCRegister Reg) const {
+  const MCInstrDesc &Desc = InstInfo->get(Inst.getOpcode());
+  for (unsigned I = 0, E = Desc.getNumDefs(); I != E; ++I) {
+    if (Desc.operands()[I].OperandType == MCOI::OPERAND_REGISTER &&
+        RegInfo->isSubRegisterEq(Reg, Inst.getOperand(I).getReg()))
+      return true;
+  }
+  return false;
+}

--- a/llvm/lib/MC/MCLFIRewriter.cpp
+++ b/llvm/lib/MC/MCLFIRewriter.cpp
@@ -54,11 +54,6 @@ bool MCLFIRewriter::mayModifyRegister(const MCInst &Inst,
 
 bool MCLFIRewriter::explicitlyModifiesRegister(const MCInst &Inst,
                                                MCRegister Reg) const {
-  const MCInstrDesc &Desc = InstInfo->get(Inst.getOpcode());
-  for (unsigned I = 0, E = Desc.getNumDefs(); I != E; ++I) {
-    if (Desc.operands()[I].OperandType == MCOI::OPERAND_REGISTER &&
-        RegInfo->isSubRegisterEq(Reg, Inst.getOperand(I).getReg()))
-      return true;
-  }
-  return false;
+  return InstInfo->get(Inst.getOpcode())
+      .hasExplicitDefOfPhysReg(Inst, Reg, *RegInfo);
 }

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -119,12 +119,29 @@ static std::optional<unsigned> getLFIInstSizeInBytes(const MachineInstr &MI) {
   case AArch64::SVC:
     // SVC expands to 4 instructions.
     return 16;
+  case AArch64::BR:
+  case AArch64::BLR:
+    // Indirect branches/calls expand to 2 instructions (guard + br/blr).
+    return 8;
+  case AArch64::RET:
+    // RET through LR is not rewritten, but RET through another register
+    // expands to 2 instructions (guard + ret).
+    if (MI.getOperand(0).getReg() != AArch64::LR)
+      return 8;
+    return 4;
   default:
-    // Default case: instructions that don't cause expansion.
-    // - TP accesses in LFI are a single load/store, so no expansion.
-    // - All remaining instructions are not rewritten.
-    return std::nullopt;
+    break;
   }
+
+  // Instructions that explicitly modify LR expand to 2 instructions.
+  for (const MachineOperand &MO : MI.explicit_operands())
+    if (MO.isReg() && MO.isDef() && MO.getReg() == AArch64::LR)
+      return 8;
+
+  // Default case: instructions that don't cause expansion.
+  // - TP accesses in LFI are a single load/store, so no expansion.
+  // - All remaining instructions are not rewritten.
+  return std::nullopt;
 }
 
 /// GetInstSize - Return the number of bytes of code the specified

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -118,21 +118,13 @@ void AArch64MCLFIRewriter::emitMov(MCRegister Dest, MCRegister Src,
 void AArch64MCLFIRewriter::rewriteIndirectBranch(const MCInst &Inst,
                                                  MCStreamer &Out,
                                                  const MCSubtargetInfo &STI) {
-  if (!Inst.getOperand(0).isReg())
-    return error(Inst, "unsupported instruction: expected target register");
+  assert(Inst.getNumOperands() >= 1 && Inst.getOperand(0).isReg() &&
+         "expected register operand");
   MCRegister BranchReg = Inst.getOperand(0).getReg();
 
   // Guard the branch target through X28.
   emitAddMask(LFIAddrReg, BranchReg, Out, STI);
   emitBranch(Inst.getOpcode(), LFIAddrReg, Out, STI);
-}
-
-void AArch64MCLFIRewriter::rewriteCall(const MCInst &Inst, MCStreamer &Out,
-                                       const MCSubtargetInfo &STI) {
-  if (Inst.getOperand(0).isReg())
-    rewriteIndirectBranch(Inst, Out, STI);
-  else
-    emitInst(Inst, Out, STI);
 }
 
 // ret xN (where xN != x30)
@@ -143,8 +135,8 @@ void AArch64MCLFIRewriter::rewriteCall(const MCInst &Inst, MCStreamer &Out,
 // ret (x30) is safe since x30 is always within the sandbox.
 void AArch64MCLFIRewriter::rewriteReturn(const MCInst &Inst, MCStreamer &Out,
                                          const MCSubtargetInfo &STI) {
-  if (Inst.getNumOperands() == 0 || !Inst.getOperand(0).isReg())
-    return error(Inst, "unsupported instruction: expected target register");
+  assert(Inst.getNumOperands() >= 1 && Inst.getOperand(0).isReg() &&
+         "expected register operand");
   // RET through LR is safe since LR is always within sandbox.
   if (Inst.getOperand(0).getReg() != AArch64::LR)
     rewriteIndirectBranch(Inst, Out, STI);
@@ -245,20 +237,16 @@ void AArch64MCLFIRewriter::doRewriteInst(const MCInst &Inst, MCStreamer &Out,
   }
 
   // Control flow.
-  if (isReturn(Inst))
+  switch (Inst.getOpcode()) {
+  case AArch64::RET:
     return rewriteReturn(Inst, Out, STI);
-
-  if (isIndirectBranch(Inst))
+  case AArch64::BR:
+  case AArch64::BLR:
     return rewriteIndirectBranch(Inst, Out, STI);
-
-  if (isCall(Inst))
-    return rewriteCall(Inst, Out, STI);
-
-  if (isBranch(Inst))
-    return emitInst(Inst, Out, STI);
+  }
 
   // Link register modification.
-  if (mayModifyRegister(Inst, AArch64::LR))
+  if (explicitlyModifiesRegister(Inst, AArch64::LR))
     return rewriteLRModification(Inst, Out, STI);
 
   emitInst(Inst, Out, STI);

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -111,6 +111,58 @@ void AArch64MCLFIRewriter::emitMov(MCRegister Dest, MCRegister Src,
   emitInst(Inst, Out, STI);
 }
 
+// {br,blr} xN
+// ->
+// add x28, x27, wN, uxtw
+// {br,blr} x28
+void AArch64MCLFIRewriter::rewriteIndirectBranch(const MCInst &Inst,
+                                                 MCStreamer &Out,
+                                                 const MCSubtargetInfo &STI) {
+  if (!Inst.getOperand(0).isReg())
+    return error(Inst, "unsupported instruction: expected target register");
+  MCRegister BranchReg = Inst.getOperand(0).getReg();
+
+  // Guard the branch target through X28.
+  emitAddMask(LFIAddrReg, BranchReg, Out, STI);
+  emitBranch(Inst.getOpcode(), LFIAddrReg, Out, STI);
+}
+
+void AArch64MCLFIRewriter::rewriteCall(const MCInst &Inst, MCStreamer &Out,
+                                       const MCSubtargetInfo &STI) {
+  if (Inst.getOperand(0).isReg())
+    rewriteIndirectBranch(Inst, Out, STI);
+  else
+    emitInst(Inst, Out, STI);
+}
+
+// ret xN (where xN != x30)
+// ->
+// add x28, x27, wN, uxtw
+// ret x28
+//
+// ret (x30) is safe since x30 is always within the sandbox.
+void AArch64MCLFIRewriter::rewriteReturn(const MCInst &Inst, MCStreamer &Out,
+                                         const MCSubtargetInfo &STI) {
+  if (Inst.getNumOperands() == 0 || !Inst.getOperand(0).isReg())
+    return error(Inst, "unsupported instruction: expected target register");
+  // RET through LR is safe since LR is always within sandbox.
+  if (Inst.getOperand(0).getReg() != AArch64::LR)
+    rewriteIndirectBranch(Inst, Out, STI);
+  else
+    emitInst(Inst, Out, STI);
+}
+
+// modify x30
+// ->
+// modify x30
+// add x30, x27, w30, uxtw
+void AArch64MCLFIRewriter::rewriteLRModification(const MCInst &Inst,
+                                                 MCStreamer &Out,
+                                                 const MCSubtargetInfo &STI) {
+  emitInst(Inst, Out, STI);
+  emitAddMask(AArch64::LR, AArch64::LR, Out, STI);
+}
+
 // svc #0
 // ->
 // mov x26, x30
@@ -191,6 +243,23 @@ void AArch64MCLFIRewriter::doRewriteInst(const MCInst &Inst, MCStreamer &Out,
     error(Inst, "illegal access to privileged thread pointer register");
     return;
   }
+
+  // Control flow.
+  if (isReturn(Inst))
+    return rewriteReturn(Inst, Out, STI);
+
+  if (isIndirectBranch(Inst))
+    return rewriteIndirectBranch(Inst, Out, STI);
+
+  if (isCall(Inst))
+    return rewriteCall(Inst, Out, STI);
+
+  if (isBranch(Inst))
+    return emitInst(Inst, Out, STI);
+
+  // Link register modification.
+  if (mayModifyRegister(Inst, AArch64::LR))
+    return rewriteLRModification(Inst, Out, STI);
 
   emitInst(Inst, Out, STI);
 }

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.h
@@ -67,6 +67,18 @@ private:
   void doRewriteInst(const MCInst &Inst, MCStreamer &Out,
                      const MCSubtargetInfo &STI);
 
+  // Control flow.
+  void rewriteIndirectBranch(const MCInst &Inst, MCStreamer &Out,
+                             const MCSubtargetInfo &STI);
+  void rewriteCall(const MCInst &Inst, MCStreamer &Out,
+                   const MCSubtargetInfo &STI);
+  void rewriteReturn(const MCInst &Inst, MCStreamer &Out,
+                     const MCSubtargetInfo &STI);
+
+  // Link register modification.
+  void rewriteLRModification(const MCInst &Inst, MCStreamer &Out,
+                             const MCSubtargetInfo &STI);
+
   // System instructions.
   void rewriteSyscall(const MCInst &Inst, MCStreamer &Out,
                       const MCSubtargetInfo &STI);

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.h
@@ -70,8 +70,6 @@ private:
   // Control flow.
   void rewriteIndirectBranch(const MCInst &Inst, MCStreamer &Out,
                              const MCSubtargetInfo &STI);
-  void rewriteCall(const MCInst &Inst, MCStreamer &Out,
-                   const MCSubtargetInfo &STI);
   void rewriteReturn(const MCInst &Inst, MCStreamer &Out,
                      const MCSubtargetInfo &STI);
 

--- a/llvm/test/MC/AArch64/LFI/branch.s
+++ b/llvm/test/MC/AArch64/LFI/branch.s
@@ -1,0 +1,21 @@
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+
+foo:
+
+b foo
+// CHECK: b foo
+
+br x0
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: br x28
+
+blr x0
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: blr x28
+
+ret
+// CHECK: ret
+
+ret x0
+// CHECK:      add x28, x27, w0, uxtw
+// CHECK-NEXT: ret x28

--- a/llvm/test/MC/AArch64/LFI/return.s
+++ b/llvm/test/MC/AArch64/LFI/return.s
@@ -1,0 +1,25 @@
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+
+mov x30, x0
+ret
+// CHECK:      mov x30, x0
+// CHECK-NEXT: add x30, x27, w30, uxtw
+// CHECK-NEXT: ret
+
+ldr x30, [sp]
+ret
+// CHECK:      ldr x30, [sp]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+// CHECK-NEXT: ret
+
+ldp x29, x30, [sp]
+ret
+// CHECK:      ldp x29, x30, [sp]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+// CHECK-NEXT: ret
+
+ldp x30, x29, [sp]
+ret
+// CHECK:      ldp x30, x29, [sp]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+// CHECK-NEXT: ret


### PR DESCRIPTION
Adds LFI rewrites for control flow instructions (indirect branches and returns). Indirect branches must go through `x28`, which is always guaranteed to hold a sandbox address. Modifications to `x30` must guard `x30` afterwards, to uphold the invariant that `x30` always holds a sandbox address. As a result, bare return instructions can be used without any additional rewrites.