### PR TITLE
[llvm-ar] Enable failed testacase on FreeBSD

### DIFF
--- a/llvm/test/tools/llvm-ar/error-opening-directory.test
+++ b/llvm/test/tools/llvm-ar/error-opening-directory.test
@@ -1,6 +1,5 @@
-## Unsupported on AIX and FreeBSD as AIX and FreeBSD 12 and earlier allow
-## reading directories by default.
-# UNSUPPORTED: system-freebsd, system-aix
+## Unsupported on AIX as AIX allow reading directories by default.
+# UNSUPPORTED: system-aix
 
 # RUN: rm -rf %t && mkdir -p %t
 


### PR DESCRIPTION
FreeBSD used to allow the read system call on directory file descriptors (dirfd). In those cases, it returned the internal file data structure instead of failing. This caused the llvm-ar test— which expects a failure when attempting to read a directory— to pass incorrectly.

This behavior existed for compatibility with older Unix implementations, but it was removed in commit dcef4f65ae3978c50eab745f67364db4660a9f43. The change applies to FreeBSD 13 and later. Since FreeBSD 12 has also reached end-of-life, the outdated behavior is no longer relevant.

As a result, the test now behaves as intended and can be safely re-enabled.