### PR TITLE
[cross-project-tests][lit] Print LLDB version when configuring tests

### DIFF
--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -311,7 +311,16 @@ def get_lldb_version_string():
 
 def set_lldb_formatters_compatibility_feature():
     current_lldb_version = get_lldb_version_string()
-    if not current_lldb_version:
+    if current_lldb_version:
+        print(
+            f"Found LLDB version '{current_lldb_version}'",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "No LLDB found on host. Skipping tests that require LLDB.",
+            file=sys.stderr,
+        )
         return
 
     if platform.system() == "Darwin":


### PR DESCRIPTION
Useful when debugging issues with the LLDB tests.