### PR TITLE
[bazel] Fix nanobind header build

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -1097,6 +1097,8 @@ cc_library(
 cc_library(
     name = "MLIRBindingsPythonNanobindHeaders",
     hdrs = [":MLIRBindingsPythonHeaderFiles"],
+    copts = PYTHON_BINDINGS_COPTS,
+    features = PYTHON_BINDINGS_FEATURES,
     includes = ["include"],
     deps = [
         ":CAPIDebugHeaders",


### PR DESCRIPTION
The build was broken by 3b3ac5a1169722bff1ae0f5f8f27a48cc08c3d02 changing textual_hdrs to hdrs - the copts/features weren't copied over, meaning Nanobind was attempted to be built with exceptions disabled.