### PR TITLE
[mlir][CSE] Add cleanup PostDominanceInfo logic to cse

### DIFF
--- a/mlir/include/mlir/Transforms/CSE.h
+++ b/mlir/include/mlir/Transforms/CSE.h
@@ -18,6 +18,7 @@
 namespace mlir {
 
 class DominanceInfo;
+class PostDominanceInfo;
 class Operation;
 class Region;
 class RewriterBase;
@@ -32,7 +33,8 @@ void eliminateCommonSubExpressions(RewriterBase &rewriter,
                                    DominanceInfo &domInfo, Operation *op,
                                    bool *changed = nullptr,
                                    int64_t *numCSE = nullptr,
-                                   int64_t *numDCE = nullptr);
+                                   int64_t *numDCE = nullptr,
+                                   PostDominanceInfo *postDomInfo = nullptr);
 
 /// Eliminate common subexpressions within the given region.
 ///
@@ -41,7 +43,8 @@ void eliminateCommonSubExpressions(RewriterBase &rewriter,
 /// DCE counts are needed.
 void eliminateCommonSubExpressions(RewriterBase &rewriter,
                                    DominanceInfo &domInfo, Region &region,
-                                   bool *changed = nullptr);
+                                   bool *changed = nullptr,
+                                   PostDominanceInfo *postDomInfo = nullptr);
 
 } // namespace mlir
 

--- a/mlir/lib/Transforms/CSE.cpp
+++ b/mlir/lib/Transforms/CSE.cpp
@@ -35,13 +35,20 @@ struct CSE : public impl::CSEPassBase<CSE> {
 void CSE::runOnOperation() {
   IRRewriter rewriter(&getContext());
   auto &domInfo = getAnalysis<DominanceInfo>();
+  // The CSE implementation does not rely on PostDominanceInfo. However,
+  // since we mark it as preserved at the end, if a cached PostDominanceInfo
+  // exists, we need to update it within CSE.
+  PostDominanceInfo *postDomInfo = nullptr;
+  if (auto dominate = getCachedAnalysis<PostDominanceInfo>())
+    postDomInfo = &dominate.value().get();
+
   bool changed = false;
   // `numCSE` / `numDCE` are `llvm::Statistic` objects, not raw `int64_t`, so
   // the public API's out-parameters cannot point at them directly.
   int64_t cseCount = 0;
   int64_t dceCount = 0;
   eliminateCommonSubExpressions(rewriter, domInfo, getOperation(), &changed,
-                                &cseCount, &dceCount);
+                                &cseCount, &dceCount, postDomInfo);
 
   numCSE = cseCount;
   numDCE = dceCount;

--- a/mlir/lib/Transforms/Utils/CSE.cpp
+++ b/mlir/lib/Transforms/Utils/CSE.cpp
@@ -52,8 +52,9 @@ namespace {
 /// Simple common sub-expression elimination.
 class CSEDriver {
 public:
-  CSEDriver(RewriterBase &rewriter, DominanceInfo *domInfo)
-      : rewriter(rewriter), domInfo(domInfo) {}
+  CSEDriver(RewriterBase &rewriter, DominanceInfo *domInfo,
+            PostDominanceInfo *postDomInfo)
+      : rewriter(rewriter), domInfo(domInfo), postDomInfo(postDomInfo) {}
 
   /// Simplify all operations within the given op.
   void simplify(Operation *op, bool *changed = nullptr);
@@ -118,6 +119,7 @@ private:
   /// Operations marked as dead and to be erased.
   std::vector<Operation *> opsToErase;
   DominanceInfo *domInfo = nullptr;
+  PostDominanceInfo *postDomInfo = nullptr;
   MemEffectsCache memEffectsCache;
 
   // Various statistics.
@@ -389,8 +391,11 @@ void CSEDriver::eraseDeadOps(bool *changed) {
   // Erase any operations that were marked as dead during simplification, and
   // remove their associated dominator trees.
   for (auto *op : opsToErase) {
-    for (Region &region : op->getRegions())
+    for (Region &region : op->getRegions()) {
       domInfo->invalidate(&region);
+      if (postDomInfo != nullptr)
+        postDomInfo->invalidate(&region);
+    }
     rewriter.eraseOp(op);
   }
   if (changed)
@@ -418,8 +423,9 @@ void CSEDriver::simplify(Region &region, bool *changed) {
 void mlir::eliminateCommonSubExpressions(RewriterBase &rewriter,
                                          DominanceInfo &domInfo, Operation *op,
                                          bool *changed, int64_t *numCSE,
-                                         int64_t *numDCE) {
-  CSEDriver driver(rewriter, &domInfo);
+                                         int64_t *numDCE,
+                                         PostDominanceInfo *postDomInfo) {
+  CSEDriver driver(rewriter, &domInfo, postDomInfo);
   driver.simplify(op, changed);
   if (numCSE)
     *numCSE = driver.getNumCSE();
@@ -429,7 +435,8 @@ void mlir::eliminateCommonSubExpressions(RewriterBase &rewriter,
 
 void mlir::eliminateCommonSubExpressions(RewriterBase &rewriter,
                                          DominanceInfo &domInfo, Region &region,
-                                         bool *changed) {
-  CSEDriver driver(rewriter, &domInfo);
+                                         bool *changed,
+                                         PostDominanceInfo *postDomInfo) {
+  CSEDriver driver(rewriter, &domInfo, postDomInfo);
   driver.simplify(region, changed);
 }


### PR DESCRIPTION
This PR fixes an issue where the `CSE` pass deletes region operations and marks `PostDominanceInfo` as preserved, but the `CSE` pass does not perform any cleanup on `PostDominanceInfo` after deleting the ops.