### PR TITLE
[libc] Fix strcasecmp/strncasecmp signedness and add tests

### DIFF
--- a/libc/src/strings/strcasecmp.cpp
+++ b/libc/src/strings/strcasecmp.cpp
@@ -11,14 +11,17 @@
 #include "src/__support/common.h"
 #include "src/__support/ctype_utils.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
 #include "src/string/memory_utils/inline_strcmp.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, strcasecmp, (const char *left, const char *right)) {
-  auto case_cmp = [](char a, char b) {
-    return static_cast<int>(LIBC_NAMESPACE::internal::tolower(a)) -
-           static_cast<int>(LIBC_NAMESPACE::internal::tolower(b));
+  LIBC_CRASH_ON_NULLPTR(left);
+  LIBC_CRASH_ON_NULLPTR(right);
+  auto case_cmp = [](char a, char b) -> int {
+    return static_cast<int>(static_cast<unsigned char>(internal::tolower(a))) -
+           static_cast<int>(static_cast<unsigned char>(internal::tolower(b)));
   };
   return inline_strcmp(left, right, case_cmp);
 }

--- a/libc/src/strings/strncasecmp.cpp
+++ b/libc/src/strings/strncasecmp.cpp
@@ -11,15 +11,18 @@
 #include "src/__support/common.h"
 #include "src/__support/ctype_utils.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
 #include "src/string/memory_utils/inline_strcmp.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, strncasecmp,
                    (const char *left, const char *right, size_t n)) {
-  auto case_cmp = [](char a, char b) {
-    return static_cast<int>(LIBC_NAMESPACE::internal::tolower(a)) -
-           static_cast<int>(LIBC_NAMESPACE::internal::tolower(b));
+  LIBC_CRASH_ON_NULLPTR(left);
+  LIBC_CRASH_ON_NULLPTR(right);
+  auto case_cmp = [](char a, char b) -> int {
+    return static_cast<int>(static_cast<unsigned char>(internal::tolower(a))) -
+           static_cast<int>(static_cast<unsigned char>(internal::tolower(b)));
   };
   return inline_strncmp(left, right, n, case_cmp);
 }

--- a/libc/test/src/string/CMakeLists.txt
+++ b/libc/test/src/string/CMakeLists.txt
@@ -119,6 +119,7 @@ add_libc_test(
     libc.src.string.strcmp
 )
 
+
 add_libc_test(
   strcasestr_test
   SUITE
@@ -233,6 +234,7 @@ add_libc_test(
   DEPENDS
     libc.src.string.strncat
 )
+
 
 add_libc_test(
   strncmp_test

--- a/libc/test/src/string/CMakeLists.txt
+++ b/libc/test/src/string/CMakeLists.txt
@@ -119,7 +119,6 @@ add_libc_test(
     libc.src.string.strcmp
 )
 
-
 add_libc_test(
   strcasestr_test
   SUITE
@@ -234,7 +233,6 @@ add_libc_test(
   DEPENDS
     libc.src.string.strncat
 )
-
 
 add_libc_test(
   strncmp_test

--- a/libc/test/src/string/strcmp_test.cpp
+++ b/libc/test/src/string/strcmp_test.cpp
@@ -24,14 +24,12 @@ TEST(LlvmLibcStrCmpTest, EmptyStringShouldNotEqualNonEmptyString) {
   const char *empty = "";
   const char *s2 = "abc";
   int result = LIBC_NAMESPACE::strcmp(empty, s2);
-  // This should be '\0' - 'a' = -97
-  ASSERT_EQ(result, '\0' - 'a');
+  ASSERT_LT(result, 0);
 
   // Similar case if empty string is second argument.
   const char *s3 = "123";
   result = LIBC_NAMESPACE::strcmp(s3, empty);
-  // This should be '1' - '\0' = 49
-  ASSERT_EQ(result, '1' - '\0');
+  ASSERT_GT(result, 0);
 }
 
 TEST(LlvmLibcStrCmpTest, EqualStringsShouldReturnZero) {
@@ -49,51 +47,43 @@ TEST(LlvmLibcStrCmpTest, ShouldReturnResultOfFirstDifference) {
   const char *s1 = "___B42__";
   const char *s2 = "___C55__";
   int result = LIBC_NAMESPACE::strcmp(s1, s2);
-  // This should return 'B' - 'C' = -1.
-  ASSERT_EQ(result, 'B' - 'C');
+  ASSERT_LT(result, 0);
 
   // Verify operands reversed.
   result = LIBC_NAMESPACE::strcmp(s2, s1);
-  // This should return 'C' - 'B' = 1.
-  ASSERT_EQ(result, 'C' - 'B');
+  ASSERT_GT(result, 0);
 }
 
 TEST(LlvmLibcStrCmpTest, CapitalizedLetterShouldNotBeEqual) {
   const char *s1 = "abcd";
   const char *s2 = "abCd";
   int result = LIBC_NAMESPACE::strcmp(s1, s2);
-  // 'c' - 'C' = 32.
-  ASSERT_EQ(result, 'c' - 'C');
+  ASSERT_GT(result, 0);
 
   // Verify operands reversed.
   result = LIBC_NAMESPACE::strcmp(s2, s1);
-  // 'C' - 'c' = -32.
-  ASSERT_EQ(result, 'C' - 'c');
+  ASSERT_LT(result, 0);
 }
 
 TEST(LlvmLibcStrCmpTest, UnequalLengthStringsShouldNotReturnZero) {
   const char *s1 = "abc";
   const char *s2 = "abcd";
   int result = LIBC_NAMESPACE::strcmp(s1, s2);
-  // '\0' - 'd' = -100.
-  ASSERT_EQ(result, -'\0' - 'd');
+  ASSERT_LT(result, 0);
 
   // Verify operands reversed.
   result = LIBC_NAMESPACE::strcmp(s2, s1);
-  // 'd' - '\0' = 100.
-  ASSERT_EQ(result, 'd' - '\0');
+  ASSERT_GT(result, 0);
 }
 
 TEST(LlvmLibcStrCmpTest, StringArgumentSwapChangesSign) {
   const char *a = "a";
   const char *b = "b";
   int result = LIBC_NAMESPACE::strcmp(b, a);
-  // 'b' - 'a' = 1.
-  ASSERT_EQ(result, 'b' - 'a');
+  ASSERT_GT(result, 0);
 
   result = LIBC_NAMESPACE::strcmp(a, b);
-  // 'a' - 'b' = -1.
-  ASSERT_EQ(result, 'a' - 'b');
+  ASSERT_LT(result, 0);
 }
 
 TEST(LlvmLibcStrCmpTest, Case) {

--- a/libc/test/src/strings/strcasecmp_test.cpp
+++ b/libc/test/src/strings/strcasecmp_test.cpp
@@ -44,3 +44,50 @@ TEST(LlvmLibcStrCaseCmpTest, Case) {
   result = LIBC_NAMESPACE::strcasecmp(s2, s1);
   ASSERT_EQ(result, 0);
 }
+
+TEST(LlvmLibcStrCaseCmpTest, EqualStringsShouldReturnZero) {
+  const char *s1 = "abc";
+  const char *s2 = "abc";
+  int result = LIBC_NAMESPACE::strcasecmp(s1, s2);
+  ASSERT_EQ(result, 0);
+
+  result = LIBC_NAMESPACE::strcasecmp(s2, s1);
+  ASSERT_EQ(result, 0);
+}
+
+TEST(LlvmLibcStrCaseCmpTest, ShouldReturnResultOfFirstDifference) {
+  const char *s1 = "___B42__";
+  const char *s2 = "___C55__";
+  int result = LIBC_NAMESPACE::strcasecmp(s1, s2);
+  ASSERT_LT(result, 0);
+
+  result = LIBC_NAMESPACE::strcasecmp(s2, s1);
+  ASSERT_GT(result, 0);
+}
+
+TEST(LlvmLibcStrCaseCmpTest, UnequalLengthStringsShouldNotReturnZero) {
+  const char *s1 = "abc";
+  const char *s2 = "abcd";
+  int result = LIBC_NAMESPACE::strcasecmp(s1, s2);
+  ASSERT_LT(result, 0);
+
+  result = LIBC_NAMESPACE::strcasecmp(s2, s1);
+  ASSERT_GT(result, 0);
+}
+
+TEST(LlvmLibcStrCaseCmpTest, StringArgumentSwapChangesSign) {
+  const char *a = "a";
+  const char *b = "b";
+  int result = LIBC_NAMESPACE::strcasecmp(b, a);
+  ASSERT_GT(result, 0);
+
+  result = LIBC_NAMESPACE::strcasecmp(a, b);
+  ASSERT_LT(result, 0);
+}
+
+TEST(LlvmLibcStrCaseCmpTest, CharactersGreaterThan127ShouldBePositive) {
+  const char s1[] = {static_cast<char>(128), '\0'};
+  const char s2[] = {'\0'};
+  int result = LIBC_NAMESPACE::strcasecmp(s1, s2);
+  ASSERT_GT(result, 0);
+}

--- a/libc/test/src/strings/strncasecmp_test.cpp
+++ b/libc/test/src/strings/strncasecmp_test.cpp
@@ -46,3 +46,60 @@ TEST(LlvmLibcStrNCaseCmpTest, Case) {
   result = LIBC_NAMESPACE::strncasecmp(s2, s1, 2);
   ASSERT_EQ(result, 0);
 }
+
+TEST(LlvmLibcStrNCaseCmpTest, EqualStringsShouldReturnZero) {
+  const char *s1 = "abc";
+  const char *s2 = "abc";
+  int result = LIBC_NAMESPACE::strncasecmp(s1, s2, 3);
+  ASSERT_EQ(result, 0);
+
+  result = LIBC_NAMESPACE::strncasecmp(s2, s1, 3);
+  ASSERT_EQ(result, 0);
+}
+
+TEST(LlvmLibcStrNCaseCmpTest, ShouldReturnResultOfFirstDifference) {
+  const char *s1 = "___B42__";
+  const char *s2 = "___C55__";
+  int result = LIBC_NAMESPACE::strncasecmp(s1, s2, 8);
+  ASSERT_LT(result, 0);
+
+  result = LIBC_NAMESPACE::strncasecmp(s2, s1, 8);
+  ASSERT_GT(result, 0);
+}
+
+TEST(LlvmLibcStrNCaseCmpTest, UnequalLengthStringsShouldNotReturnZero) {
+  const char *s1 = "abc";
+  const char *s2 = "abcd";
+  int result = LIBC_NAMESPACE::strncasecmp(s1, s2, 4);
+  ASSERT_LT(result, 0);
+
+  result = LIBC_NAMESPACE::strncasecmp(s2, s1, 4);
+  ASSERT_GT(result, 0);
+}
+
+TEST(LlvmLibcStrNCaseCmpTest, StringsEqualUpToNShouldReturnZero) {
+  const char *s1 = "abcD";
+  const char *s2 = "abcE";
+  int result = LIBC_NAMESPACE::strncasecmp(s1, s2, 3);
+  ASSERT_EQ(result, 0);
+
+  result = LIBC_NAMESPACE::strncasecmp(s2, s1, 3);
+  ASSERT_EQ(result, 0);
+}
+
+TEST(LlvmLibcStrNCaseCmpTest, StringsEqualUpToNdifferentCaseShouldReturnZero) {
+  const char *s1 = "abcD";
+  const char *s2 = "ABCE";
+  int result = LIBC_NAMESPACE::strncasecmp(s1, s2, 3);
+  ASSERT_EQ(result, 0);
+
+  result = LIBC_NAMESPACE::strncasecmp(s2, s1, 3);
+  ASSERT_EQ(result, 0);
+}
+
+TEST(LlvmLibcStrNCaseCmpTest, ZeroNShouldReturnZero) {
+  const char *s1 = "abc";
+  const char *s2 = "def";
+  int result = LIBC_NAMESPACE::strncasecmp(s1, s2, 0);
+  ASSERT_EQ(result, 0);
+}


### PR DESCRIPTION
Fixed character signedness bug in strcasecmp and strncasecmp implementations in src/strings/ where characters > 127 were not correctly handled.

Added LIBC_CRASH_ON_NULLPTR checks to both functions.

Enhanced unit tests in test/src/strings/ to be comprehensive without duplicating basic case insensitivity tests.

Updated assertions in strcasecmp_test, strncasecmp_test, and strcmp_test to check for sign instead of exact value.