### PR TITLE
[clang] Reland NO_LIBCXX test in serenity.cpp

### DIFF
--- a/clang/test/Driver/serenity.cpp
+++ b/clang/test/Driver/serenity.cpp
@@ -230,6 +230,13 @@
 // STATIC_LIBSTDCXX: "--pop-state"
 // STATIC_LIBSTDCXX: "-lc" "crtendS.o"
 
+// RUN: %clangxx -### %s --target=x86_64-unknown-serenity --sysroot="" -resource-dir= \
+// RUN:   -nostdlib++ 2>&1 | FileCheck %s --check-prefix=NO_LIBCXX
+// NO_LIBCXX: "-z" "pack-relative-relocs"
+// NO_LIBCXX: "crt0.o" "crtbeginS.o"
+// NO_LIBCXX-NOT: "-lc++"
+// NO_LIBCXX-SAME: "-lc" "crtendS.o"
+
 /// Check that unwind tables are enabled.
 // RUN: %clang --target=x86_64-unknown-serenity -### -S %s 2>&1 | \
 // RUN:   FileCheck -check-prefix=UNWIND-TABLES %s


### PR DESCRIPTION
The test was first introduced in 934f7950 and then removed in 9c94881f. The first iteration was depending on the default runtime being compiler-rt, which isn't true for all bots and thus caused failures: https://lab.llvm.org/buildbot/#/builders/10/builds/26512

The new version of the test doesn't depend on the compiler runtime.