### PR TITLE
[libc] Fix ucontext_t and mcontext_t for C compliance

### DIFF
--- a/libc/include/llvm-libc-types/x86_64/mcontext_t.h
+++ b/libc/include/llvm-libc-types/x86_64/mcontext_t.h
@@ -8,8 +8,8 @@
 
 // Note: Definitions in this file are based on the Linux kernel ABI.
 
-#ifndef LLVM_LIBC_TYPES_MCONTEXT_T_H
-#define LLVM_LIBC_TYPES_MCONTEXT_T_H
+#ifndef LLVM_LIBC_TYPES_X86_64_MCONTEXT_T_H
+#define LLVM_LIBC_TYPES_X86_64_MCONTEXT_T_H
 
 // The following definitions correspond to the general purpose registers.
 // The layout of gregset_t and the enum indices must match the layout of
@@ -118,4 +118,4 @@ typedef struct {
   unsigned long long __reserved1[8];
 } mcontext_t;
 
-#endif // LLVM_LIBC_TYPES_MCONTEXT_T_H
+#endif // LLVM_LIBC_TYPES_X86_64_MCONTEXT_T_H

--- a/libc/include/llvm-libc-types/x86_64/ucontext_t.h
+++ b/libc/include/llvm-libc-types/x86_64/ucontext_t.h
@@ -15,7 +15,7 @@
 #include "../stack_t.h"
 #include "mcontext_t.h"
 
-typedef struct alignas(16) ucontext_t {
+typedef struct ucontext_t {
   // The following fields must match the Linux kernel's struct ucontext
   // on x86_64 to ensure ABI compatibility for signal handling.
   unsigned long uc_flags;
@@ -34,7 +34,7 @@ typedef struct alignas(16) ucontext_t {
   // provide space here for the FP state, and the pointer in uc_mcontext
   // can be set to point here. 64 long ints provide 512 bytes, which is
   // the size required for FXSAVE.
-  alignas(16) long int __fpregs_mem[64];
+  _Alignas(16) long int __fpregs_mem[64];
 
   // Support for Shadow Stack Pointer (Intel CET).
   unsigned long long __ssp[4];


### PR DESCRIPTION
* x86_64/ucontext_t.h: Removed alignas to fix C compilation error.

* x86_64/mcontext_t.h: Updated include guard to prevent collision.