### PR TITLE
[mlir] Support full commutative operation equality

### DIFF
--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -791,11 +791,12 @@ struct ValueEquivalenceCache {
     if (lhsIt == lhsRange.end())
       return success();
 
-    // Handle another simple case where operands are just a permutation.
-    // Note: This is not sufficient, this handles simple cases relatively
-    // cheaply.
-    auto sortValues = [](ValueRange values) {
-      SmallVector<Value> sortedValues = llvm::to_vector(values);
+    // Replace values with their entry in equivalentValues if they're in there
+    // that way, a sorted pointer comparison is enough to determine
+    // commutativity.
+    auto sortValues = [this](ValueRange values) {
+      SmallVector<Value> sortedValues = llvm::map_to_vector(
+          values, [this](Value a) { return equivalentValues.lookup_or(a, a); });
       llvm::sort(sortedValues, [](Value a, Value b) {
         return a.getAsOpaquePointer() < b.getAsOpaquePointer();
       });
@@ -806,13 +807,7 @@ struct ValueEquivalenceCache {
     if (lhsSorted == rhsSorted) {
       return success();
     }
-    for (auto operandPair : llvm::zip(lhsSorted, rhsSorted)) {
-      Value lhs = std::get<0>(operandPair);
-      Value rhs = std::get<1>(operandPair);
-      if (failed(checkEquivalent(lhs, rhs)))
-        return failure();
-    }
-    return success();
+    return failure();
   }
   void markEquivalent(Value lhsResult, Value rhsResult) {
     auto insertion = equivalentValues.insert({lhsResult, rhsResult});

--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -803,7 +803,16 @@ struct ValueEquivalenceCache {
     };
     auto lhsSorted = sortValues({lhsIt, lhsRange.end()});
     auto rhsSorted = sortValues({rhsIt, rhsRange.end()});
-    return success(lhsSorted == rhsSorted);
+    if (lhsSorted == rhsSorted) {
+      return success();
+    }
+    for (auto operandPair : llvm::zip(lhsSorted, rhsSorted)) {
+      Value lhs = std::get<0>(operandPair);
+      Value rhs = std::get<1>(operandPair);
+      if (failed(checkEquivalent(lhs, rhs)))
+        return failure();
+    }
+    return success();
   }
   void markEquivalent(Value lhsResult, Value rhsResult) {
     auto insertion = equivalentValues.insert({lhsResult, rhsResult});

--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -804,10 +804,7 @@ struct ValueEquivalenceCache {
     };
     auto lhsSorted = sortValues({lhsIt, lhsRange.end()});
     auto rhsSorted = sortValues({rhsIt, rhsRange.end()});
-    if (lhsSorted == rhsSorted) {
-      return success();
-    }
-    return failure();
+    return success(lhsSorted == rhsSorted);
   }
   void markEquivalent(Value lhsResult, Value rhsResult) {
     auto insertion = equivalentValues.insert({lhsResult, rhsResult});

--- a/mlir/test/Dialect/Func/duplicate-function-elimination.mlir
+++ b/mlir/test/Dialect/Func/duplicate-function-elimination.mlir
@@ -58,11 +58,10 @@ func.func @user(%arg0: f32, %arg1: f32) -> f32 {
 
 // CHECK:     @add_lr
 // CHECK-NOT: @also_add_lr
-// CHECK:     @add_rl
+// CHECK-NOT:     @add_rl
 // CHECK-NOT: @also_add_rl
 // CHECK:     @user
-// CHECK-2:     call @add_lr
-// CHECK-2:     call @add_rl
+// CHECK-4:     call @add_lr
 
 // -----
 

--- a/mlir/test/IR/operation-equality.mlir
+++ b/mlir/test/IR/operation-equality.mlir
@@ -214,3 +214,31 @@ builtin.module attributes {test.includes_setup} {
     arith.addi %0#1, %0#0 : i32
   }) { ignore_commutativity } : () -> ()
 }
+
+// -----
+
+// CHECK-LABEL: test.commutatively_equal
+// CHECK-SAME: compares equals
+
+"test.commutatively_equal"() ({
+  ^bb0(%arg0 : i32, %arg1 : i32):
+    arith.addi %arg0, %arg1 : i32
+  }) : () -> ()
+"test.commutatively_equal"() ({
+  ^bb0(%arg0 : i32, %arg1 : i32):
+    arith.addi %arg1, %arg0 : i32
+  }) : () -> ()
+
+// -----
+
+// CHECK-LABEL: test.ignore_commutatively_equal
+// CHECK-SAME: compares NOT equals
+
+"test.ignore_commutatively_equal"() ({
+  ^bb0(%arg0 : i32, %arg1 : i32):
+    arith.addi %arg0, %arg1 : i32
+  }) { ignore_commutativity } : () -> ()
+"test.ignore_commutatively_equal"() ({
+  ^bb0(%arg0 : i32, %arg1 : i32):
+    arith.addi %arg1, %arg0 : i32
+  }) { ignore_commutativity } : () -> ()


### PR DESCRIPTION
Currently, commutative equality only works if the operand lists are permutations of one another.
By treating the `equivalentValues` map as a map onto a common set of values, I believe full commutative equality can be achieved relatively cheaply.
Does this seem like a good approach?