### PR TITLE
Add C++20 diagnostic to macro-braces-recovery.cpp.

### DIFF
--- a/clang/test/Parser/macro-braces-recovery.cpp
+++ b/clang/test/Parser/macro-braces-recovery.cpp
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify=expected -std=c++17 %s
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,cxx20 -std=c++20 %s
 
 namespace GH21755 {
 #define M(x) f x // expected-note {{macro 'M' defined here}}
@@ -16,7 +17,8 @@ class Foo { // expected-note {{candidate constructor (the implicit copy construc
             // expected-note {{candidate constructor (the implicit move constructor) not viable}}
 public:
   Foo(int); // expected-note {{candidate constructor not viable: requires 1 argument, but 2 were provided}}
-  bool operator==(const int l); // expected-note {{candidate function not viable: no known conversion from 'Foo' to 'const int' for 1st argument}}
+  bool operator==(const int l); // expected-note {{candidate function not viable: no known conversion from 'Foo' to 'const int' for 1st argument}} \
+                                // cxx20-note {{candidate function (with reversed parameter order) not viable: no known conversion from 'Foo' to 'const int' for object argument}}
 };
 #define EQ(x,y) (void)(x == y) // expected-note {{macro 'EQ' defined here}}
 


### PR DESCRIPTION
macro-braces-recovery.cpp was added in the following commit:

https://github.com/llvm/llvm-project/commit/d8f63bbc8e20a68e764852a15d67a06fcd14c5bd

for c++17 (clang's default standard)  this test passes fine. For C++20 or above standards as default this test produces an additional diagnostic for reverse order candidate conversion functions.

To fix this I've added a --std=c++17 to the original run line, introduced a second run line for C++20 and a cxx20-note expectation for the new language spec diagnostic. 

Thanks for your time reviewing this patch :)