### PR TITLE
[libc][NFC] remove staled header libraries

### DIFF
--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -106,15 +106,6 @@ add_header_library(
 )
 
 add_header_library(
-  bit
-  HDRS
-    bit.h
-  DEPENDS
-    libc.src.__support.macros.attributes
-    libc.src.__support.CPP.type_traits
-)
-
-add_header_library(
   math_extras
   HDRS
     math_extras.h

--- a/libc/src/__support/OSUtil/linux/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/CMakeLists.txt
@@ -39,19 +39,6 @@ add_header_library(
 )
 
 add_header_library(
-  getrandom
-  HDRS
-    getrandom.h
-  DEPENDS
-    libc.src.__support.OSUtil.osutil
-    libc.src.__support.common
-    libc.src.__support.error_or
-    libc.src.__support.macros.config
-    libc.hdr.types.ssize_t
-    libc.include.sys_syscall
-)
-
-add_header_library(
   vdso_sym
   HDRS
     vdso_sym.h


### PR DESCRIPTION
Remove staled header library declaration in cmake:

```
[cmake] CMake Error in /home/schrodingerzy/Documents/llvm-project/libc/src/__support/OSUtil/linux/CMakeLists.txt:
[cmake]   Cannot find source file:
[cmake] 
[cmake]     /home/schrodingerzy/Documents/llvm-project/libc/src/__support/OSUtil/linux/getrandom.h
[cmake] 
[cmake] 
[cmake] CMake Error in /home/schrodingerzy/Documents/llvm-project/libc/src/__support/CMakeLists.txt:
[cmake]   Cannot find source file:
[cmake] 
[cmake]     /home/schrodingerzy/Documents/llvm-project/libc/src/__support/bit.h
[cmake] 
[cmake] 
[cmake] -- Build files have been written to: /home/schrodingerzy/Documents/llvm-project/build
```
