### PR TITLE
[mlir] MlirOptMain: avoid double verification

### DIFF
--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -621,8 +621,13 @@ performActions(raw_ostream &os,
   if (config.bytecodeVersionToEmit().has_value())
     return emitError(UnknownLoc::get(pm.getContext()))
            << "bytecode version while not emitting bytecode";
-  AsmState asmState(op.get(), OpPrintingFlags(), /*locationMap=*/nullptr,
-                    &fallbackResourceMap);
+
+  // Don't re-run the verifier if we already ran the verifier at the end of the
+  // pass pipeline.
+  AsmState asmState(op.get(),
+                    OpPrintingFlags().assumeVerified(
+                        config.shouldVerifyPasses() && !pm.empty()),
+                    /*locationMap=*/nullptr, &fallbackResourceMap);
   os << OpWithState(op.get(), asmState) << '\n';
 
   // This is required if the remark policy is final. Otherwise, the remarks are

--- a/mlir/test/Dialect/Transform/normal-forms.mlir
+++ b/mlir/test/Dialect/Transform/normal-forms.mlir
@@ -141,14 +141,12 @@ transform.payload attributes {
 //  1. after the initial parsing (reasonable)
 //  2. also in transform::detail::mergeSymbolsInto (has a TODO to be removed)
 //  3. after the transform interpreter pass (reasonable)
-//  4. before printing (generally reasonable, but would be nice to avoid if
-//     the IR is known-verified after by the pass manager).
 // Notably this doesn't include an extra run from checkPayload, which is
 // what we intend to test here.
 
 // CHECK-LABEL: @verification_count
 // CHECK: transform.payload
-// CHECK-SAME: test.counting_normal_form_count = 4
+// CHECK-SAME: test.counting_normal_form_count = 3
 
 module @verification_count attributes {transform.with_named_sequence} {
   transform.payload attributes {


### PR DESCRIPTION
MlirOptMain would run verification twice at the end of the processing:
  1. after the last pass in the pipeline;
  2. prior to printing. Since there is no logic that could mutate, and thus potentially invalidate, the IR between the two, the second verification is redundant. Skip it when possible.