### PR TITLE
[AMDGPU] Propagate debug info to constant materialization instr

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -1839,6 +1839,8 @@ SDValue SelectionDAG::getConstant(const ConstantInt &Val, const SDLoc &DL,
 
   if (!N) {
     N = newSDNode<ConstantSDNode>(isT, isO, Elt, VTs);
+    if (!isT)
+      N->setDebugLoc(DL.getDebugLoc());
     CSEMap.InsertNode(N, IP);
     InsertNode(N);
     NewSDValueDbgMsg(SDValue(N, 0), "Creating constant: ", this);

--- a/llvm/test/CodeGen/AMDGPU/ptr-arg-dbg-value.ll
+++ b/llvm/test/CodeGen/AMDGPU/ptr-arg-dbg-value.ll
@@ -17,9 +17,9 @@ define hidden void @ptr_arg_split_subregs(ptr %arg1) #0 !dbg !9 {
 ; CHECK-NEXT:    ;DEBUG_VALUE: ptr_arg_split_subregs:a <- [DW_OP_LLVM_fragment 32 32] [$vgpr1+0]
 ; CHECK-NEXT:    ;DEBUG_VALUE: ptr_arg_split_subregs:a <- [DW_OP_LLVM_fragment 0 32] [$vgpr0+0]
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; CHECK-NEXT:    v_mov_b32_e32 v2, 1
 ; CHECK-NEXT:  .Ltmp0:
 ; CHECK-NEXT:    .loc 1 7 13 prologue_end ; example.cpp:7:13
+; CHECK-NEXT:    v_mov_b32_e32 v2, 1
 ; CHECK-NEXT:    flat_store_dword v[0:1], v2 offset:396
 ; CHECK-NEXT:    .loc 1 8 5 ; example.cpp:8:5
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -46,9 +46,9 @@ define hidden void @ptr_arg_split_reg_mem(<30 x i32>, ptr %arg2) #0 !dbg !25 {
 ; CHECK-NEXT:    ;DEBUG_VALUE: ptr_arg_split_reg_mem:b <- [$vgpr30+0]
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    buffer_load_dword v31, off, s[0:3], s32
-; CHECK-NEXT:    v_mov_b32_e32 v0, 1
 ; CHECK-NEXT:  .Ltmp2:
 ; CHECK-NEXT:    .loc 1 12 13 prologue_end ; example.cpp:12:13
+; CHECK-NEXT:    v_mov_b32_e32 v0, 1
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
 ; CHECK-NEXT:    flat_store_dword v[30:31], v0 offset:396
 ; CHECK-NEXT:    .loc 1 13 5 ; example.cpp:13:5
@@ -72,9 +72,9 @@ define hidden void @ptr_arg_in_memory(<32 x i32>, ptr %arg3) #0 !dbg !31 {
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8
 ; CHECK-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4
-; CHECK-NEXT:    v_mov_b32_e32 v2, 1
 ; CHECK-NEXT:  .Ltmp4:
 ; CHECK-NEXT:    .loc 1 17 13 prologue_end ; example.cpp:17:13
+; CHECK-NEXT:    v_mov_b32_e32 v2, 1
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
 ; CHECK-NEXT:    flat_store_dword v[0:1], v2 offset:396
 ; CHECK-NEXT:    .loc 1 18 5 ; example.cpp:18:5

--- a/llvm/test/CodeGen/BPF/CORE/offset-reloc-basic.ll
+++ b/llvm/test/CodeGen/BPF/CORE/offset-reloc-basic.ll
@@ -108,8 +108,8 @@ define dso_local i32 @bpf_prog(ptr) local_unnamed_addr !dbg !15 {
 ; CHECK-NEXT:        .long   0
 ; CHECK-NEXT:        .long   20
 ; CHECK-NEXT:        .long   20
-; CHECK-NEXT:        .long   108
-; CHECK-NEXT:        .long   128
+; CHECK-NEXT:        .long   124
+; CHECK-NEXT:        .long   144
 ; CHECK-NEXT:        .long   28
 ; CHECK-NEXT:        .long   8                       # FuncInfo
 

--- a/llvm/test/DebugInfo/AMDGPU/debug-loc-copy.ll
+++ b/llvm/test/DebugInfo/AMDGPU/debug-loc-copy.ll
@@ -14,9 +14,9 @@ define void @_Z12lane_pc_testj() #0 !dbg !9 {
 ; GCN-NEXT:  ; %bb.0:
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-NEXT:  ; %bb.1: ; %lab
-; GCN-NEXT:    s_mov_b64 s[4:5], 0
 ; GCN-NEXT:  .Ltmp0:
 ; GCN-NEXT:    .loc 0 12 1 prologue_end ; t.cpp:12:1
+; GCN-NEXT:    s_mov_b64 s[4:5], 0
 ; GCN-NEXT:    s_mov_b64 s[6:7], src_private_base
 ; GCN-NEXT:    s_mov_b32 s6, -1
 ; GCN-NEXT:    s_lshr_b32 s8, s32, 5

--- a/llvm/test/DebugInfo/ARM/single-constant-use-preserves-dbgloc.ll
+++ b/llvm/test/DebugInfo/ARM/single-constant-use-preserves-dbgloc.ll
@@ -31,7 +31,7 @@ if.then:                                          ; preds = %entry
 
 if.end:                                           ; preds = %entry
 ; Materialize the constant.
-; CHECK:      .loc    1 0
+; CHECK:      .loc    1 6 7
 ; CHECK-NEXT: mvn     r0, #0
 
 ; The backend performs the store to %retval first, for some reason.

--- a/llvm/test/DebugInfo/COFF/jump-table-with-indirect-ptr-null.ll
+++ b/llvm/test/DebugInfo/COFF/jump-table-with-indirect-ptr-null.ll
@@ -4,9 +4,8 @@
 ; Repro for issue https://reviews.llvm.org/D149367#4619121
 ; Validates that `indirect ptr null` and a jump table can be used in the same function.
 
-; Verify branch labels match what's in the CodeView
-; CHECK:            .Ltmp2:
-; CHECK-NEXT:       jmpq    *%{{.*}}
+; Verify the jmpq exists in the code section
+; CHECK:            jmpq    *%{{.*}}
 
 ; Verify jump table have the same entry size, base offset and shift as what's in the CodeView
 ; CHECK:          {{\.?}}LJTI0_0:
@@ -17,9 +16,9 @@
 ; CHECK-NEXT:     .secrel32	.LJTI0_0    # Base offset
 ; CHECK-NEXT:     .secidx	.LJTI0_0      # Base section index
 ; CHECK-NEXT:     .short	4             # Switch type
-; CHECK-NEXT:     .secrel32	.Ltmp2      # Branch offset
+; CHECK-NEXT:     .secrel32	.Ltmp{{[0-9]+}}      # Branch offset
 ; CHECK-NEXT:     .secrel32	.LJTI0_0    # Table offset
-; CHECK-NEXT:     .secidx	.Ltmp2        # Branch section index
+; CHECK-NEXT:     .secidx	.Ltmp{{[0-9]+}}        # Branch section index
 ; CHECK-NEXT:     .secidx	.LJTI0_0      # Table section index
 ; CHECK-NEXT:     .long	4               # Entries count
 ; CHECK-NOT:      .short	4441          # Record kind: S_ARMSWITCHTABLE

--- a/llvm/test/DebugInfo/COFF/jump-table-with-indirect-ptr-null.ll
+++ b/llvm/test/DebugInfo/COFF/jump-table-with-indirect-ptr-null.ll
@@ -4,8 +4,10 @@
 ; Repro for issue https://reviews.llvm.org/D149367#4619121
 ; Validates that `indirect ptr null` and a jump table can be used in the same function.
 
-; Verify the jmpq exists in the code section
-; CHECK:            jmpq    *%{{.*}}
+; Verify branch label matches what's in the CodeView
+; CHECK:            addq    %rcx, %rax
+; CHECK-NEXT:       [[BRANCH:\.Ltmp[0-9]+]]:
+; CHECK-NEXT:       jmpq    *%{{.*}}
 
 ; Verify jump table have the same entry size, base offset and shift as what's in the CodeView
 ; CHECK:          {{\.?}}LJTI0_0:
@@ -16,9 +18,9 @@
 ; CHECK-NEXT:     .secrel32	.LJTI0_0    # Base offset
 ; CHECK-NEXT:     .secidx	.LJTI0_0      # Base section index
 ; CHECK-NEXT:     .short	4             # Switch type
-; CHECK-NEXT:     .secrel32	.Ltmp{{[0-9]+}}      # Branch offset
+; CHECK-NEXT:     .secrel32	[[BRANCH]]  # Branch offset
 ; CHECK-NEXT:     .secrel32	.LJTI0_0    # Table offset
-; CHECK-NEXT:     .secidx	.Ltmp{{[0-9]+}}        # Branch section index
+; CHECK-NEXT:     .secidx	[[BRANCH]]    # Branch section index
 ; CHECK-NEXT:     .secidx	.LJTI0_0      # Table section index
 ; CHECK-NEXT:     .long	4               # Entries count
 ; CHECK-NOT:      .short	4441          # Record kind: S_ARMSWITCHTABLE

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/source-lines.ll
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/source-lines.ll
@@ -8,10 +8,10 @@
 ; LINE-NEXT: ; source_lines_test():
 ; LINE-NEXT: ; {{.*}}source-lines.cl:1
 ; Kernel.
-; LINE: v_mov_b32_e32 v{{[0-9]+}}, 0x777
 ; LINE: ; {{.*}}source-lines.cl:2
-; LINE: v_mov_b32_e32 v{{[0-9]+}}, 0x888
+; LINE: v_mov_b32_e32 v{{[0-9]+}}, 0x777
 ; LINE: ; {{.*}}source-lines.cl:3
+; LINE: v_mov_b32_e32 v{{[0-9]+}}, 0x888
 ; LINE: ; {{.*}}source-lines.cl:4
 ; LINE: v_add_u32_e64
 ; LINE: ; {{.*}}source-lines.cl:5
@@ -24,10 +24,10 @@
 ; SOURCE:      source_lines_test{{>?}}:
 ; SOURCE-NEXT: ; kernel void source_lines_test(global int *Out) {
 ; Kernel.
-; SOURCE: v_mov_b32_e32 v{{[0-9]+}}, 0x777
 ; SOURCE: ; int var0 = 0x777;
-; SOURCE: v_mov_b32_e32 v{{[0-9]+}}, 0x888
+; SOURCE: v_mov_b32_e32 v{{[0-9]+}}, 0x777
 ; SOURCE: ; int var1 = 0x888;
+; SOURCE: v_mov_b32_e32 v{{[0-9]+}}, 0x888
 ; SOURCE: ; int var2 = var0 + var1;
 ; SOURCE: v_add_u32_e64
 ; SOURCE: ; *Out = var2;


### PR DESCRIPTION
Set the debug location on non-target constant nodes so that the resulting machine instructions inherit the correct source location.