### PR TITLE
[libc] Various limits adds and fixes

### DIFF
--- a/libc/include/limits.yaml
+++ b/libc/include/limits.yaml
@@ -74,6 +74,16 @@ macros:
     macro_header: limits-macros.h
   - macro_name: ULLONG_MIN
     macro_header: limits-macros.h
+  - macro_name: _POSIX_NAME_MAX
+    macro_header: limits-macros.h
+  - macro_name: _POSIX_PATH_MAX
+    macro_header: limits-macros.h
+  - macro_name: PATH_MAX
+    macro_header: limits-macros.h
+  - macro_name: _POSIX_THREAD_DESTRUCTOR_ITERATIONS
+    macro_header: limits-macros.h
+  - macro_name: PTHREAD_DESTRUCTOR_ITERATIONS
+    macro_header: limits-macros.h
 types: []
 enums: []
 objects: []

--- a/libc/include/llvm-libc-macros/limits-macros.h
+++ b/libc/include/llvm-libc-macros/limits-macros.h
@@ -232,7 +232,25 @@
 #endif
 
 #ifndef _POSIX_NAME_MAX
+#define _POSIX_NAME_MAX 14
+#endif
+
+#ifndef _POSIX_PATH_MAX
 #define _POSIX_PATH_MAX 256
+#endif
+
+#ifndef _POSIX_THREAD_DESTRUCTOR_ITERATIONS
+#define _POSIX_THREAD_DESTRUCTOR_ITERATIONS 4
+#endif
+
+#ifndef PTHREAD_DESTRUCTOR_ITERATIONS
+#define PTHREAD_DESTRUCTOR_ITERATIONS _POSIX_THREAD_DESTRUCTOR_ITERATIONS
+#endif
+
+#ifdef __linux__
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
 #endif
 
 #ifndef _POSIX_ARG_MAX


### PR DESCRIPTION
Implemented and corrected POSIX limits:

* Corrected _POSIX_NAME_MAX and _POSIX_PATH_MAX definitions.
* Added PATH_MAX for Linux.
* Added _POSIX_THREAD_DESTRUCTOR_ITERATIONS and PTHREAD_DESTRUCTOR_ITERATIONS.
* Updated limits.yaml to include these macros.