### PR TITLE
[Flang] Add `INLINEALWAYS` Compiler Directive

### DIFF
--- a/flang/docs/Directives.md
+++ b/flang/docs/Directives.md
@@ -102,6 +102,16 @@ A list of non-standard directives supported by Flang
   assignment statement.
 * `!dir$ forceinline` works in the same way as the `inline` directive, but it forces
    inlining by the compiler on a function call statement.
+* `!dir$ inlinealways <name>`. An alternative spelling to `forceinline`, providing compatibility
+  with older Fortran compilers, such as classic-flang. Can be defined at the callsite, or
+  in the function you want to inline. `name` is optional and should only be used when
+  defining the directive within a function, example:
+  ```
+  function test
+    !DIR$ INLINEALWAYS test
+    ...
+  end function
+  ```
 * `!dir$ noinline` works in the same way as the `inline` directive, but prevents
   any attempt of inlining by the compiler on a function call statement.
 

--- a/flang/docs/Directives.md
+++ b/flang/docs/Directives.md
@@ -103,9 +103,9 @@ A list of non-standard directives supported by Flang
 * `!dir$ forceinline` works in the same way as the `inline` directive, but it forces
    inlining by the compiler on a function call statement.
 * `!dir$ inlinealways <name>`. An alternative spelling to `forceinline`, providing compatibility
-  with older Fortran compilers, such as classic-flang. It can be defined at the callsite, or
-  in the function you want to inline. `name` is optional and should only be used when
-  specifying the directive within a function, example:
+  with older Fortran compilers, such as classic-flang. It can be specified at the callsite, or
+  in the function or subroutine you want to inline. `name` is optional and should only be used
+  when specifying the directive within a function, example:
   ```
   function test
     !DIR$ INLINEALWAYS test

--- a/flang/docs/Directives.md
+++ b/flang/docs/Directives.md
@@ -103,9 +103,9 @@ A list of non-standard directives supported by Flang
 * `!dir$ forceinline` works in the same way as the `inline` directive, but it forces
    inlining by the compiler on a function call statement.
 * `!dir$ inlinealways <name>`. An alternative spelling to `forceinline`, providing compatibility
-  with older Fortran compilers, such as classic-flang. Can be defined at the callsite, or
+  with older Fortran compilers, such as classic-flang. It can be defined at the callsite, or
   in the function you want to inline. `name` is optional and should only be used when
-  defining the directive within a function, example:
+  specifying the directive within a function, example:
   ```
   function test
     !DIR$ INLINEALWAYS test

--- a/flang/include/flang/Parser/dump-parse-tree.h
+++ b/flang/include/flang/Parser/dump-parse-tree.h
@@ -239,6 +239,7 @@ public:
   NODE(CompilerDirective, NoUnroll)
   NODE(CompilerDirective, NoUnrollAndJam)
   NODE(CompilerDirective, Prefetch)
+  NODE(CompilerDirective, InlineAlways)
   NODE(CompilerDirective, Simd)
   NODE(parser, ComplexLiteralConstant)
   NODE(parser, ComplexPart)

--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -3344,6 +3344,7 @@ struct StmtFunctionStmt {
 // !DIR$ FORCEINLINE
 // !DIR$ INLINE
 // !DIR$ NOINLINE
+// !DIR$ INLINEALWAYS
 // !DIR$ IVDEP
 // !DIR$ SIMD
 // !DIR$ <anything else>
@@ -3381,6 +3382,10 @@ struct CompilerDirective {
     WRAPPER_CLASS_BOILERPLATE(
         Prefetch, std::list<common::Indirection<Designator>>);
   };
+  struct InlineAlways {
+    WRAPPER_CLASS_BOILERPLATE(
+      InlineAlways, std::optional<Name>);
+  };
   EMPTY_CLASS(NoVector);
   EMPTY_CLASS(NoUnroll);
   EMPTY_CLASS(NoUnrollAndJam);
@@ -3394,7 +3399,7 @@ struct CompilerDirective {
   std::variant<std::list<IgnoreTKR>, LoopCount, std::list<AssumeAligned>,
       VectorAlways, VectorLength, std::list<NameValue>, Unroll, UnrollAndJam,
       Unrecognized, NoVector, NoUnroll, NoUnrollAndJam, ForceInline, Inline,
-      NoInline, Prefetch, IVDep, Simd>
+      NoInline, InlineAlways, Prefetch, IVDep, Simd>
       u;
 };
 

--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -3383,8 +3383,7 @@ struct CompilerDirective {
         Prefetch, std::list<common::Indirection<Designator>>);
   };
   struct InlineAlways {
-    WRAPPER_CLASS_BOILERPLATE(
-      InlineAlways, std::optional<Name>);
+    WRAPPER_CLASS_BOILERPLATE(InlineAlways, std::optional<Name>);
   };
   EMPTY_CLASS(NoVector);
   EMPTY_CLASS(NoUnroll);

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2117,6 +2117,9 @@ private:
               [&](const Fortran::parser::CompilerDirective::ForceInline &) {
                 stmt.typedCall->setAlwaysInline(true);
               },
+              [&](const Fortran::parser::CompilerDirective::InlineAlways &) {
+                stmt.typedCall->setAlwaysInline(true);
+              },
               [&](const Fortran::parser::CompilerDirective::Inline &) {
                 stmt.typedCall->setInlineHint(true);
               },
@@ -2466,6 +2469,9 @@ private:
                   callOp.setInlineAttr(fir::FortranInlineEnum::inline_hint);
                 },
                 [&](const Fortran::parser::CompilerDirective::ForceInline &) {
+                  callOp.setInlineAttr(fir::FortranInlineEnum::always_inline);
+                },
+                [&](const Fortran::parser::CompilerDirective::InlineAlways &) {
                   callOp.setInlineAttr(fir::FortranInlineEnum::always_inline);
                 },
                 [&](const auto &) {}},
@@ -3557,6 +3563,21 @@ private:
       e->dirs.push_back(&dir);
   }
 
+  void markCurrentFuncAsAlwaysInline(const Fortran::parser::CompilerDirective::InlineAlways &dir) {
+    mlir::func::FuncOp func = builder->getFunction();
+    if (currentFunctionUnit && !currentFunctionUnit->isMainProgram()) {
+      const std::string symName =
+          currentFunctionUnit->getSubprogramSymbol().name().ToString();
+      if (!llvm::StringRef(dir.v->ToString()).equals_insensitive(symName)) {
+        mlir::emitWarning(toLocation())
+            << "Directive Ignored: INLINEALWAYS directive function name '" << dir.v->ToString()
+            << "' does not match the function '" << symName << "' where this is declared.";
+        return;
+      }
+    }
+    func->setAttr("llvm.always_inline", builder->getUnitAttr());
+  }
+
   void
   attachInliningDirectiveToStmt(const Fortran::parser::CompilerDirective &dir,
                                 Fortran::lower::pft::Evaluation *e) {
@@ -3634,6 +3655,12 @@ private:
             },
             [&](const Fortran::parser::CompilerDirective::IVDep &) {
               attachDirectiveToLoop(dir, &eval);
+            },
+            [&](const Fortran::parser::CompilerDirective::InlineAlways &inlineAlways) {
+              if (inlineAlways.v.has_value())
+                markCurrentFuncAsAlwaysInline(inlineAlways);
+              else
+                attachInliningDirectiveToStmt(dir, &eval);
             },
             [&](const Fortran::parser::CompilerDirective::Simd &) {
               attachDirectiveToLoop(dir, &eval);

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -3569,15 +3569,10 @@ private:
     if (currentFunctionUnit && !currentFunctionUnit->isMainProgram()) {
       const std::string symName =
           currentFunctionUnit->getSubprogramSymbol().name().ToString();
-      if (!llvm::StringRef(dir.v->ToString()).equals_insensitive(symName)) {
-        mlir::emitWarning(toLocation())
-            << "Directive Ignored: INLINEALWAYS directive function name '"
-            << dir.v->ToString() << "' does not match the function '" << symName
-            << "' where this is declared.";
-        return;
+      if (dir.v->ToString() == symName) {
+        func->setAttr("llvm.always_inline", builder->getUnitAttr());
       }
     }
-    func->setAttr("llvm.always_inline", builder->getUnitAttr());
   }
 
   void

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -3563,15 +3563,17 @@ private:
       e->dirs.push_back(&dir);
   }
 
-  void markCurrentFuncAsAlwaysInline(const Fortran::parser::CompilerDirective::InlineAlways &dir) {
+  void markCurrentFuncAsAlwaysInline(
+      const Fortran::parser::CompilerDirective::InlineAlways &dir) {
     mlir::func::FuncOp func = builder->getFunction();
     if (currentFunctionUnit && !currentFunctionUnit->isMainProgram()) {
       const std::string symName =
           currentFunctionUnit->getSubprogramSymbol().name().ToString();
       if (!llvm::StringRef(dir.v->ToString()).equals_insensitive(symName)) {
         mlir::emitWarning(toLocation())
-            << "Directive Ignored: INLINEALWAYS directive function name '" << dir.v->ToString()
-            << "' does not match the function '" << symName << "' where this is declared.";
+            << "Directive Ignored: INLINEALWAYS directive function name '"
+            << dir.v->ToString() << "' does not match the function '" << symName
+            << "' where this is declared.";
         return;
       }
     }
@@ -3656,7 +3658,8 @@ private:
             [&](const Fortran::parser::CompilerDirective::IVDep &) {
               attachDirectiveToLoop(dir, &eval);
             },
-            [&](const Fortran::parser::CompilerDirective::InlineAlways &inlineAlways) {
+            [&](const Fortran::parser::CompilerDirective::InlineAlways
+                    &inlineAlways) {
               if (inlineAlways.v.has_value())
                 markCurrentFuncAsAlwaysInline(inlineAlways);
               else

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -1339,6 +1339,8 @@ constexpr auto forceinlineDir{
     "FORCEINLINE" >> construct<CompilerDirective::ForceInline>()};
 constexpr auto noinlineDir{
     "NOINLINE" >> construct<CompilerDirective::NoInline>()};
+constexpr auto inlinealwaysDir{
+    "INLINEALWAYS" >> construct<CompilerDirective::InlineAlways>(maybe(name))};
 constexpr auto inlineDir{"INLINE" >> construct<CompilerDirective::Inline>()};
 constexpr auto ivdep{"IVDEP" >> construct<CompilerDirective::IVDep>()};
 constexpr auto simd{"SIMD" >> construct<CompilerDirective::Simd>()};
@@ -1356,6 +1358,7 @@ TYPE_PARSER(beginDirective >> some(letter) >> "$ "_tok >>
                 construct<CompilerDirective>(nounroll) ||
                 construct<CompilerDirective>(noinlineDir) ||
                 construct<CompilerDirective>(forceinlineDir) ||
+                construct<CompilerDirective>(inlinealwaysDir) ||
                 construct<CompilerDirective>(inlineDir) ||
                 construct<CompilerDirective>(simd) ||
                 construct<CompilerDirective>(ivdep) ||

--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -1886,6 +1886,13 @@ public:
               Word("!DIR$ NOINLINE");
             },
             [&](const CompilerDirective::IVDep &) { Word("!DIR$ IVDEP"); },
+            [&](const CompilerDirective::InlineAlways &InlineAlways) {
+              Word("!DIR$ INLINEALWAYS");
+              if (InlineAlways.v.has_value()){
+                Word(" ");
+                Word (InlineAlways.v->ToString());
+              }
+            },
             [&](const CompilerDirective::Simd &) { Word("!DIR$ SIMD"); },
             [&](const CompilerDirective::Unrecognized &) {
               Word("!DIR$ ");

--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -1888,9 +1888,9 @@ public:
             [&](const CompilerDirective::IVDep &) { Word("!DIR$ IVDEP"); },
             [&](const CompilerDirective::InlineAlways &InlineAlways) {
               Word("!DIR$ INLINEALWAYS");
-              if (InlineAlways.v.has_value()){
+              if (InlineAlways.v.has_value()) {
                 Word(" ");
-                Word (InlineAlways.v->ToString());
+                Word(InlineAlways.v->ToString());
               }
             },
             [&](const CompilerDirective::Simd &) { Word("!DIR$ SIMD"); },

--- a/flang/lib/Semantics/canonicalize-directives.cpp
+++ b/flang/lib/Semantics/canonicalize-directives.cpp
@@ -67,6 +67,7 @@ static bool IsExecutionDirective(const parser::CompilerDirective &dir) {
       std::holds_alternative<parser::CompilerDirective::Inline>(dir.u) ||
       std::holds_alternative<parser::CompilerDirective::NoInline>(dir.u) ||
       std::holds_alternative<parser::CompilerDirective::IVDep>(dir.u) ||
+      std::holds_alternative<parser::CompilerDirective::InlineAlways>(dir.u) ||
       std::holds_alternative<parser::CompilerDirective::Simd>(dir.u);
 }
 

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -10403,7 +10403,6 @@ void ResolveNamesVisitor::Post(const parser::CompilerDirective &x) {
       std::holds_alternative<parser::CompilerDirective::Prefetch>(x.u) ||
       std::holds_alternative<parser::CompilerDirective::NoInline>(x.u) ||
       std::holds_alternative<parser::CompilerDirective::IVDep>(x.u) ||
-      std::holds_alternative<parser::CompilerDirective::InlineAlways>(x.u) ||
       std::holds_alternative<parser::CompilerDirective::Simd>(x.u)) {
     return;
   }
@@ -10495,6 +10494,21 @@ void ResolveNamesVisitor::Post(const parser::CompilerDirective &x) {
           }
         }
       }
+    }
+  } else if (const auto *inlineAlways{
+                 std::get_if<parser::CompilerDirective::InlineAlways>(&x.u)}) {
+    if (!inlineAlways->v.has_value()) {
+      return;
+    }
+
+    Symbol *sym{currScope().symbol()};
+    if (!sym || !sym->has<SubprogramDetails>()) {
+      Say(x.source,
+          "!DIR$ INLINEALWAYS directive with name must appear in a subroutine or function"_err_en_US);
+    }
+    if (inlineAlways->v->ToString() != sym->name().ToString()) {
+      context().Warn(common::UsageWarning::IgnoredDirective, x.source,
+          "IGNOREALWAYS function name does not match the function"_warn_en_US);
     }
   } else if (context().ShouldWarn(common::UsageWarning::IgnoredDirective)) {
     Say(x.source, "Unrecognized compiler directive was ignored"_warn_en_US)

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -10403,6 +10403,7 @@ void ResolveNamesVisitor::Post(const parser::CompilerDirective &x) {
       std::holds_alternative<parser::CompilerDirective::Prefetch>(x.u) ||
       std::holds_alternative<parser::CompilerDirective::NoInline>(x.u) ||
       std::holds_alternative<parser::CompilerDirective::IVDep>(x.u) ||
+      std::holds_alternative<parser::CompilerDirective::InlineAlways>(x.u) ||
       std::holds_alternative<parser::CompilerDirective::Simd>(x.u)) {
     return;
   }

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -10508,7 +10508,7 @@ void ResolveNamesVisitor::Post(const parser::CompilerDirective &x) {
     }
     if (inlineAlways->v->ToString() != sym->name().ToString()) {
       context().Warn(common::UsageWarning::IgnoredDirective, x.source,
-          "IGNOREALWAYS function name does not match the function"_warn_en_US);
+          "INLINEALWAYS name does not match the subroutine or function name"_warn_en_US);
     }
   } else if (context().ShouldWarn(common::UsageWarning::IgnoredDirective)) {
     Say(x.source, "Unrecognized compiler directive was ignored"_warn_en_US)

--- a/flang/test/Lower/inlinealways-directive.f90
+++ b/flang/test/Lower/inlinealways-directive.f90
@@ -1,11 +1,11 @@
-! Check the appropriate flags are added to inline functions when inlinealways is used
+! Check the appropriate flags are added to inline functions when inlinealways is used, or ignored when the name is incorrect.
 
 ! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
-! RUN: %flang_fc1 -emit-hlfir %s 2>&1 | FileCheck %s --check-prefix=CHECK-WARN
 
 subroutine test_function()
   !DIR$ INLINEALWAYS test_function
 end subroutine
+! CHECK: func.func @_QPtest_function() attributes {llvm.always_inline} {
 
 subroutine test_function2()
 end subroutine
@@ -13,14 +13,10 @@ end subroutine
 subroutine test_function3()
   !DIR$ INLINEALWAYS wrong_func
 end subroutine
+! CHECK: func.func @_QPtest_function2() {
 
 subroutine test()
   !DIR$ INLINEALWAYS
   call test_function2()
 end subroutine
-
-! CHECK: func.func @_QPtest_function() attributes {llvm.always_inline} {
 ! CHECK: fir.call @_QPtest_function2() fastmath<contract> {inline_attr = #fir.inline_attrs<always_inline>} : () -> ()
-
-! CHECK-WARN:      warning: loc({{.*}}inlinealways-directive.f90{{.*}}): Directive Ignored:
-! CHECK-WARN-SAME: INLINEALWAYS directive function name 'wrong_func' does not match the function 'test_function3' where this is declared.

--- a/flang/test/Lower/inlinealways-directive.f90
+++ b/flang/test/Lower/inlinealways-directive.f90
@@ -2,21 +2,43 @@
 
 ! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
-subroutine test_function()
-  !DIR$ INLINEALWAYS test_function
+subroutine test_subroutine()
+  !DIR$ INLINEALWAYS test_subroutine
 end subroutine
-! CHECK: func.func @_QPtest_function() attributes {llvm.always_inline} {
+! CHECK: func.func @_QPtest_subroutine() attributes {llvm.always_inline} {
 
-subroutine test_function2()
+subroutine test_subroutine2()
+  !DIR$ INLINEALWAYS wrong_subroutine
+end subroutine
+! CHECK: func.func @_QPtest_subroutine2() {
+
+subroutine test_subroutine3()
 end subroutine
 
-subroutine test_function3()
-  !DIR$ INLINEALWAYS wrong_func
-end subroutine
-! CHECK: func.func @_QPtest_function2() {
+function test_func1()
+!DIR$ INLINEALWAYS test_func1
+end function
+! CHECK: func.func @_QPtest_func1() -> f32 attributes {llvm.always_inline} {
+
+function test_func2()
+!DIR$ INLINEALWAYS wrong_func
+end function
+! CHCEK: func.func @_QPtest_func2() -> f32 {
+
+integer function test_func3() result(res)
+  res = 10
+end function
 
 subroutine test()
+  implicit none
+  integer:: result, test_func3
+
   !DIR$ INLINEALWAYS
-  call test_function2()
+  call test_subroutine3
+! CHECK: fir.call @_QPtest_subroutine3() fastmath<contract> {inline_attr = #fir.inline_attrs<always_inline>} : () -> ()
+
+  result = 0
+  !DIR$ INLINEALWAYS
+  result = test_func3()
+! CHCEK: %[[.*]] = fir.call @_QPtest_func3() fastmath<contract> {inline_attr = #fir.inline_attrs<always_inline>} : () -> i32
 end subroutine
-! CHECK: fir.call @_QPtest_function2() fastmath<contract> {inline_attr = #fir.inline_attrs<always_inline>} : () -> ()

--- a/flang/test/Lower/inlinealways-directive.f90
+++ b/flang/test/Lower/inlinealways-directive.f90
@@ -1,0 +1,26 @@
+! Check the appropriate flags are added to inline functions when inlinealways is used
+
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s 2>&1 | FileCheck %s --check-prefix=CHECK-WARN
+
+subroutine test_function()
+  !DIR$ INLINEALWAYS test_function
+end subroutine
+
+subroutine test_function2()
+end subroutine
+
+subroutine test_function3()
+  !DIR$ INLINEALWAYS wrong_func
+end subroutine
+
+subroutine test()
+  !DIR$ INLINEALWAYS
+  call test_function2()
+end subroutine
+
+! CHECK: func.func @_QPtest_function() attributes {llvm.always_inline} {
+! CHECK: fir.call @_QPtest_function2() fastmath<contract> {inline_attr = #fir.inline_attrs<always_inline>} : () -> ()
+
+! CHECK-WARN:      warning: loc({{.*}}inlinealways-directive.f90{{.*}}): Directive Ignored:
+! CHECK-WARN-SAME: INLINEALWAYS directive function name 'wrong_func' does not match the function 'test_function3' where this is declared.

--- a/flang/test/Parser/inlinealways-directive.f90
+++ b/flang/test/Parser/inlinealways-directive.f90
@@ -1,0 +1,58 @@
+! Test that the INLINEALWAYS directive can be parsed, both at callsite and within the function
+
+! RUN: %flang_fc1 -fdebug-dump-parse-tree %s 2>&1 | FileCheck %s --check-prefix=PARSE-TREE
+! RUN: %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s --check-prefix=UNPARSE
+
+subroutine test_function()
+  !DIR$ INLINEALWAYS test_function
+end subroutine
+
+subroutine test_function2()
+end subroutine
+
+subroutine test()
+  call test_function()
+  !DIR$ INLINEALWAYS
+  call test_function2()
+end subroutine
+
+! UNPARSE: SUBROUTINE test_function
+! UNPARSE:  !DIR$ INLINEALWAYS TEST_FUNCTION
+! UNPARSE: END SUBROUTINE
+! UNPARSE: SUBROUTINE test_function2
+! UNPARSE: END SUBROUTINE
+! UNPARSE: SUBROUTINE test
+! UNPARSE:   CALL test_function()
+! UNPARSE:  !DIR$ INLINEALWAYS
+! UNPARSE:   CALL test_function2()
+! UNPARSE: END SUBROUTINE
+
+! PARSE-TREE: Program -> ProgramUnit -> SubroutineSubprogram
+! PARSE-TREE: | SubroutineStmt
+! PARSE-TREE: | | Name = 'test_function'
+! PARSE-TREE: | SpecificationPart
+! PARSE-TREE: | | ImplicitPart -> 
+! PARSE-TREE: | ExecutionPart -> Block
+! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> CompilerDirective -> InlineAlways -> Name = 'test_function'
+! PARSE-TREE: | EndSubroutineStmt -> 
+! PARSE-TREE: ProgramUnit -> SubroutineSubprogram
+! PARSE-TREE: | SubroutineStmt
+! PARSE-TREE: | | Name = 'test_function2'
+! PARSE-TREE: | SpecificationPart
+! PARSE-TREE: | | ImplicitPart -> 
+! PARSE-TREE: | ExecutionPart -> Block
+! PARSE-TREE: | EndSubroutineStmt -> 
+! PARSE-TREE: ProgramUnit -> SubroutineSubprogram
+! PARSE-TREE: | SubroutineStmt
+! PARSE-TREE: | | Name = 'test'
+! PARSE-TREE: | SpecificationPart
+! PARSE-TREE: | | ImplicitPart -> 
+! PARSE-TREE: | ExecutionPart -> Block
+! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL test_function()'
+! PARSE-TREE: | | | Call
+! PARSE-TREE: | | | | ProcedureDesignator -> Name = 'test_function'
+! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> CompilerDirective -> InlineAlways -> 
+! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL test_function2()'
+! PARSE-TREE: | | | Call
+! PARSE-TREE: | | | | ProcedureDesignator -> Name = 'test_function2'
+! PARSE-TREE: | EndSubroutineStmt -> 

--- a/flang/test/Parser/inlinealways-directive.f90
+++ b/flang/test/Parser/inlinealways-directive.f90
@@ -3,56 +3,137 @@
 ! RUN: %flang_fc1 -fdebug-dump-parse-tree %s 2>&1 | FileCheck %s --check-prefix=PARSE-TREE
 ! RUN: %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s --check-prefix=UNPARSE
 
-subroutine test_function()
-  !DIR$ INLINEALWAYS test_function
+subroutine test_subroutine()
+  !DIR$ INLINEALWAYS test_subroutine
 end subroutine
 
-subroutine test_function2()
+subroutine test_subroutine2()
 end subroutine
+
+integer function test_func() result(res)
+  !DIR$ INLINEALWAYS test_func
+  res = 10
+end function
+
+integer function test_func2() result(res)
+  res = 10
+end function
 
 subroutine test()
-  call test_function()
+  implicit none
+  integer :: i, test_func1, test_func2
+
+  call test_subroutine()
   !DIR$ INLINEALWAYS
-  call test_function2()
+  call test_subroutine2()
+
+  i = test_func1()
+  !DIR$ INLINEALWAYS
+  i = test_func2()
 end subroutine
 
-! UNPARSE: SUBROUTINE test_function
-! UNPARSE:  !DIR$ INLINEALWAYS TEST_FUNCTION
+! UNPARSE: SUBROUTINE test_subroutine
+! UNPARSE:  !DIR$ INLINEALWAYS TEST_SUBROUTINE
 ! UNPARSE: END SUBROUTINE
-! UNPARSE: SUBROUTINE test_function2
+! UNPARSE: SUBROUTINE test_subroutine2
 ! UNPARSE: END SUBROUTINE
+! UNPARSE: INTEGER FUNCTION test_func() RESULT(res)
+! UNPARSE:  !DIR$ INLINEALWAYS TEST_FUNC
+! UNPARSE:   res=10_4
+! UNPARSE: END FUNCTION
+! UNPARSE: INTEGER FUNCTION test_func2() RESULT(res)
+! UNPARSE:   res=10_4
+! UNPARSE: END FUNCTION
 ! UNPARSE: SUBROUTINE test
-! UNPARSE:   CALL test_function()
+! UNPARSE:  IMPLICIT NONE
+! UNPARSE:  INTEGER i, test_func1, test_func2
+! UNPARSE:   CALL test_subroutine()
 ! UNPARSE:  !DIR$ INLINEALWAYS
-! UNPARSE:   CALL test_function2()
+! UNPARSE:   CALL test_subroutine2()
+! UNPARSE:   i=test_func1()
+! UNPARSE:  !DIR$ INLINEALWAYS
+! UNPARSE:   i=test_func2()
 ! UNPARSE: END SUBROUTINE
 
+! PARSE-TREE: ======================== Flang: parse tree dump ========================
 ! PARSE-TREE: Program -> ProgramUnit -> SubroutineSubprogram
 ! PARSE-TREE: | SubroutineStmt
-! PARSE-TREE: | | Name = 'test_function'
+! PARSE-TREE: | | Name = 'test_subroutine'
 ! PARSE-TREE: | SpecificationPart
 ! PARSE-TREE: | | ImplicitPart -> 
 ! PARSE-TREE: | ExecutionPart -> Block
-! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> CompilerDirective -> InlineAlways -> Name = 'test_function'
+! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> CompilerDirective -> InlineAlways -> Name = 'test_subroutine'
 ! PARSE-TREE: | EndSubroutineStmt -> 
 ! PARSE-TREE: ProgramUnit -> SubroutineSubprogram
 ! PARSE-TREE: | SubroutineStmt
-! PARSE-TREE: | | Name = 'test_function2'
+! PARSE-TREE: | | Name = 'test_subroutine2'
 ! PARSE-TREE: | SpecificationPart
 ! PARSE-TREE: | | ImplicitPart -> 
 ! PARSE-TREE: | ExecutionPart -> Block
 ! PARSE-TREE: | EndSubroutineStmt -> 
+! PARSE-TREE: ProgramUnit -> FunctionSubprogram
+! PARSE-TREE: | FunctionStmt
+! PARSE-TREE: | | PrefixSpec -> DeclarationTypeSpec -> IntrinsicTypeSpec -> IntegerTypeSpec -> 
+! PARSE-TREE: | | Name = 'test_func'
+! PARSE-TREE: | | Suffix
+! PARSE-TREE: | | | Name = 'res'
+! PARSE-TREE: | SpecificationPart
+! PARSE-TREE: | | ImplicitPart -> 
+! PARSE-TREE: | ExecutionPart -> Block
+! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> CompilerDirective -> InlineAlways -> Name = 'test_func'
+! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'res=10_4'
+! PARSE-TREE: | | | Variable = 'res'
+! PARSE-TREE: | | | | Designator -> DataRef -> Name = 'res'
+! PARSE-TREE: | | | Expr = '10_4'
+! PARSE-TREE: | | | | LiteralConstant -> IntLiteralConstant = '10'
+! PARSE-TREE: | EndFunctionStmt -> 
+! PARSE-TREE: ProgramUnit -> FunctionSubprogram
+! PARSE-TREE: | FunctionStmt
+! PARSE-TREE: | | PrefixSpec -> DeclarationTypeSpec -> IntrinsicTypeSpec -> IntegerTypeSpec -> 
+! PARSE-TREE: | | Name = 'test_func2'
+! PARSE-TREE: | | Suffix
+! PARSE-TREE: | | | Name = 'res'
+! PARSE-TREE: | SpecificationPart
+! PARSE-TREE: | | ImplicitPart -> 
+! PARSE-TREE: | ExecutionPart -> Block
+! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'res=10_4'
+! PARSE-TREE: | | | Variable = 'res'
+! PARSE-TREE: | | | | Designator -> DataRef -> Name = 'res'
+! PARSE-TREE: | | | Expr = '10_4'
+! PARSE-TREE: | | | | LiteralConstant -> IntLiteralConstant = '10'
+! PARSE-TREE: | EndFunctionStmt -> 
 ! PARSE-TREE: ProgramUnit -> SubroutineSubprogram
 ! PARSE-TREE: | SubroutineStmt
 ! PARSE-TREE: | | Name = 'test'
 ! PARSE-TREE: | SpecificationPart
-! PARSE-TREE: | | ImplicitPart -> 
+! PARSE-TREE: | | ImplicitPart -> ImplicitPartStmt -> ImplicitStmt -> 
+! PARSE-TREE: | | DeclarationConstruct -> SpecificationConstruct -> TypeDeclarationStmt
+! PARSE-TREE: | | | DeclarationTypeSpec -> IntrinsicTypeSpec -> IntegerTypeSpec -> 
+! PARSE-TREE: | | | EntityDecl
+! PARSE-TREE: | | | | Name = 'i'
+! PARSE-TREE: | | | EntityDecl
+! PARSE-TREE: | | | | Name = 'test_func1'
+! PARSE-TREE: | | | EntityDecl
+! PARSE-TREE: | | | | Name = 'test_func2'
 ! PARSE-TREE: | ExecutionPart -> Block
-! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL test_function()'
+! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL test_subroutine()'
 ! PARSE-TREE: | | | Call
-! PARSE-TREE: | | | | ProcedureDesignator -> Name = 'test_function'
+! PARSE-TREE: | | | | ProcedureDesignator -> Name = 'test_subroutine'
 ! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> CompilerDirective -> InlineAlways -> 
-! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL test_function2()'
+! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL test_subroutine2()'
 ! PARSE-TREE: | | | Call
-! PARSE-TREE: | | | | ProcedureDesignator -> Name = 'test_function2'
+! PARSE-TREE: | | | | ProcedureDesignator -> Name = 'test_subroutine2'
+! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'i=test_func1()'
+! PARSE-TREE: | | | Variable = 'i'
+! PARSE-TREE: | | | | Designator -> DataRef -> Name = 'i'
+! PARSE-TREE: | | | Expr = 'test_func1()'
+! PARSE-TREE: | | | | FunctionReference -> Call
+! PARSE-TREE: | | | | | ProcedureDesignator -> Name = 'test_func1'
+! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> CompilerDirective -> InlineAlways -> 
+! PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'i=test_func2()'
+! PARSE-TREE: | | | Variable = 'i'
+! PARSE-TREE: | | | | Designator -> DataRef -> Name = 'i'
+! PARSE-TREE: | | | Expr = 'test_func2()'
+! PARSE-TREE: | | | | FunctionReference -> Call
+! PARSE-TREE: | | | | | ProcedureDesignator -> Name = 'test_func2'
 ! PARSE-TREE: | EndSubroutineStmt -> 

--- a/flang/test/Semantics/inlinealways-directive01.f90
+++ b/flang/test/Semantics/inlinealways-directive01.f90
@@ -6,7 +6,12 @@ module m
   !DIR$ INLINEALWAYS m
 end module
 
-subroutine test_function3()
+subroutine test_subroutine()
+! WARNING: INLINEALWAYS name does not match the subroutine or function name [-Wignored-directive]
+  !DIR$ INLINEALWAYS wrong_subroutine
+end subroutine
+
+function test_func()
 ! WARNING: INLINEALWAYS name does not match the subroutine or function name [-Wignored-directive]
   !DIR$ INLINEALWAYS wrong_func
-end subroutine
+end function

--- a/flang/test/Semantics/inlinealways-directive01.f90
+++ b/flang/test/Semantics/inlinealways-directive01.f90
@@ -1,0 +1,12 @@
+! Check that the appropriate warnings are emitted when using INLINEALWAYS incorrectly
+! RUN: %python %S/test_errors.py %s %flang_fc1
+
+module m
+! ERROR: !DIR$ INLINEALWAYS directive with name must appear in a subroutine or function
+  !DIR$ INLINEALWAYS m
+end module
+
+subroutine test_function3()
+! WARNING: IGNOREALWAYS function name does not match the function [-Wignored-directive]
+  !DIR$ INLINEALWAYS wrong_func
+end subroutine

--- a/flang/test/Semantics/inlinealways-directive01.f90
+++ b/flang/test/Semantics/inlinealways-directive01.f90
@@ -7,6 +7,6 @@ module m
 end module
 
 subroutine test_function3()
-! WARNING: IGNOREALWAYS function name does not match the function [-Wignored-directive]
+! WARNING: INLINEALWAYS function name does not match the function [-Wignored-directive]
   !DIR$ INLINEALWAYS wrong_func
 end subroutine

--- a/flang/test/Semantics/inlinealways-directive01.f90
+++ b/flang/test/Semantics/inlinealways-directive01.f90
@@ -7,6 +7,6 @@ module m
 end module
 
 subroutine test_function3()
-! WARNING: INLINEALWAYS function name does not match the function [-Wignored-directive]
+! WARNING: INLINEALWAYS name does not match the subroutine or function name [-Wignored-directive]
   !DIR$ INLINEALWAYS wrong_func
 end subroutine


### PR DESCRIPTION
Adds support for the INLINEALWAYS Compiler Directive to Flang. This was previously supported in Classic-Flang, and works in the same way as FORCEINLINE.

It can either be defined at the call site, or within the function the user wishes to inline.

The missing support was highlighted while building an opensource benchmark, as build warnings were indicating that this compiler directive was being ignored.