### PR TITLE
[OpenACC] Require a complete type for vars-with-restrictions

### DIFF
--- a/clang/lib/Sema/SemaOpenACC.cpp
+++ b/clang/lib/Sema/SemaOpenACC.cpp
@@ -659,6 +659,11 @@ ExprResult CheckVarType(SemaOpenACC &S, OpenACCClauseKind CK, Expr *VarExpr,
     return CheckVarType(S, CK, VarExpr, InnerLoc, ArrTy->getElementType());
   }
 
+  if (S.SemaRef.RequireCompleteType(InnerLoc, InnerTy,
+                                    Sema::CompleteTypeKind::Normal,
+                                    diag::err_incomplete_type))
+    return ExprError();
+
   auto *RD = InnerTy->getAsCXXRecordDecl();
 
   // if this isn't a C++ record decl, we can create/copy/destroy this thing at

--- a/clang/test/SemaOpenACC/compute-construct-firstprivate-clause.cpp
+++ b/clang/test/SemaOpenACC/compute-construct-firstprivate-clause.cpp
@@ -110,3 +110,12 @@ void Inst() {
   TemplUses(i, Arr, C); // #TEMPL_USES_INST
   NTTP<5, NTTP_REFed>(); // #NTTP_INST
 }
+
+struct Incomplete;
+
+void incomplete_use(Incomplete &i) {
+  // expected-error@+2{{incomplete type 'Incomplete' where a complete type is required}}
+  // expected-note@-4{{forward declaration}}
+#pragma acc parallel firstprivate(i)
+  while (1);
+}

--- a/clang/test/SemaOpenACC/compute-construct-private-clause.cpp
+++ b/clang/test/SemaOpenACC/compute-construct-private-clause.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 %s -fopenacc -verify
 
-struct Incomplete;
+struct Incomplete; // #INCOMPLETE
 enum SomeE{};
 typedef struct IsComplete {
   struct S { int A; } CompositeMember;
@@ -172,3 +172,9 @@ void inst_crash() {
   ThisCrashed<int>(1, 2);
 }
 
+void incomplete_use(Incomplete &i) {
+  // expected-error@+2{{incomplete type 'Incomplete' where a complete type is required}}
+  // expected-note@#INCOMPLETE{{forward declaration}}
+#pragma acc parallel private(i)
+  while (1);
+}

--- a/clang/test/SemaOpenACC/compute-construct-reduction-clause.cpp
+++ b/clang/test/SemaOpenACC/compute-construct-reduction-clause.cpp
@@ -311,3 +311,12 @@ void inst() {
   // expected-note@+1{{in instantiation of function template specialization}}
   TemplUses(5, CoS, ChC);
 }
+
+struct Incomplete;
+
+void incomplete_use(Incomplete &i) {
+  // expected-error@+2{{incomplete type 'Incomplete' where a complete type is required}}
+  // expected-note@-4{{forward declaration}}
+#pragma acc parallel reduction(+:i)
+  while (1);
+}


### PR DESCRIPTION
The bug report shows a case where an incomplete type was passed to a var-list in a clause that has a restriction.  Only the 'private',
  'firstprivate', and 'reduction' clauses have such restrictions on what
  they can reference, so only those will cause problems.

This patch adds a 'completeness' requirement for all 3 of those to make sure we can properly enforce our restrictions.

Fixes: #192664