### PR TITLE
[clang][rtsan] Disallow type and realtime sanitizer combo

### DIFF
--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -668,7 +668,8 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
       std::make_pair(SanitizerKind::KCFI, SanitizerKind::Function),
       std::make_pair(SanitizerKind::Realtime,
                      SanitizerKind::Address | SanitizerKind::Thread |
-                         SanitizerKind::Undefined | SanitizerKind::Memory),
+                         SanitizerKind::Undefined | SanitizerKind::Memory |
+                         SanitizerKind::Type),
       std::make_pair(SanitizerKind::AllocToken,
                      SanitizerKind::Address | SanitizerKind::HWAddress |
                          SanitizerKind::KernelAddress |

--- a/clang/test/Driver/fsanitize-realtime.c
+++ b/clang/test/Driver/fsanitize-realtime.c
@@ -43,3 +43,8 @@
 
 // RUN: not %clang --target=x86_64-linux-gnu -fsanitize=realtime,undefined  %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-REALTIME-UBSAN
 // CHECK-REALTIME-UBSAN: error: invalid argument '-fsanitize=realtime' not allowed with '-fsanitize=undefined'
+
+// RUN: not %clang --target=x86_64-linux-gnu -fsanitize=type,realtime  %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-REALTIME-TYSAN
+// RUN: not %clang --target=x86_64-linux-gnu -fsanitize=realtime,type  %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-REALTIME-TYSAN
+// CHECK-REALTIME-TYSAN: error: invalid argument '-fsanitize=realtime' not allowed with '-fsanitize=type'
+


### PR DESCRIPTION
Both of these sanitizer runtimes define similar interceptors, so they may not be used together