### PR TITLE
[MLIR] Fix -Wunused-variable

### DIFF
--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -3453,9 +3453,8 @@ static OpFoldResult foldShuffleConstantInputs(ShuffleOp op, Attribute v1Attr,
 
 OpFoldResult vector::ShuffleOp::fold(FoldAdaptor adaptor) {
   auto v1Type = getV1VectorType();
-  auto v2Type = getV2VectorType();
 
-  assert(!v1Type.isScalable() && !v2Type.isScalable() &&
+  assert(!v1Type.isScalable() && !getV2VectorType.isScalable() &&
          "Vector shuffle does not support scalable vectors");
 
   // For consistency: 0-D shuffle return type is 1-D, this cannot be a folding


### PR DESCRIPTION
Inline the variable given the call does not have side effects and the
variable name does not add any clarity.