### PR TITLE
[lldb][Target] Move Debugger::GetSafeAutoLoadPaths into Target

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -69,7 +69,6 @@ class Process;
 class Stream;
 class SymbolContext;
 class Target;
-class Debugger;
 
 #ifndef NDEBUG
 /// Global properties used in the LLDB testsuite.
@@ -85,7 +84,7 @@ struct TestingProperties : public Properties {
   void AppendSafeAutoLoadPaths(FileSpec path);
 
 private:
-  friend Debugger;
+  friend Target;
 
   /// Callers should use Debugger::GetSafeAutoLoadPaths since it
   /// accounts for default paths configured via CMake.
@@ -144,12 +143,6 @@ public:
 
   static void AssertCallback(llvm::StringRef message, llvm::StringRef backtrace,
                              llvm::StringRef prompt);
-
-  /// Get the list of paths that LLDB will consider automatically loading
-  /// scripting resources from. Currently whether to load scripts
-  /// unconditionally is controlled via the
-  /// `target.load-script-from-symbol-file` setting.
-  static FileSpecList GetSafeAutoLoadPaths();
 
   void Clear();
 
@@ -654,6 +647,8 @@ public:
     std::string message;
   };
   std::optional<ProgressReport> GetCurrentProgressReport() const;
+
+  static const FileSpecList &GetDefaultSafeAutoLoadPaths();
 
 protected:
   friend class CommandInterpreter;

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1721,6 +1721,12 @@ public:
 
   void SaveScriptedLaunchInfo(lldb_private::ProcessInfo &process_info);
 
+  /// Get the list of paths that LLDB will consider automatically loading
+  /// scripting resources from. Currently whether to load scripts
+  /// unconditionally is controlled via the
+  /// `target.load-script-from-symbol-file` setting.
+  FileSpecList GetSafeAutoLoadPaths() const;
+
   /// Add a signal for the target.  This will get copied over to the process
   /// if the signal exists on that target.  Only the values with Yes and No are
   /// set, Calculate values will be ignored.

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -213,7 +213,7 @@ enum {
 };
 #endif
 
-static const FileSpecList &GetDefaultSafeAutoLoadPaths() {
+const FileSpecList &Debugger::GetDefaultSafeAutoLoadPaths() {
   static const FileSpecList sSafePaths = [] {
     // FIXME: in c++20 this could be a std::array (with CTAD deduced size)
     // and we could statically assert that all members are non-empty.
@@ -2600,16 +2600,4 @@ StructuredData::DictionarySP Debugger::GetBuildConfiguration() {
       "A boolean value that indicates if lua support is enabled in LLDB");
   AddLLVMTargets(*config_up);
   return config_up;
-}
-
-FileSpecList Debugger::GetSafeAutoLoadPaths() {
-  FileSpecList fspecs = GetDefaultSafeAutoLoadPaths();
-
-#ifndef NDEBUG
-  for (const auto &fspec :
-       TestingProperties::GetGlobalTestingProperties().GetSafeAutoLoadPaths())
-    fspecs.Append(fspec);
-#endif
-
-  return fspecs;
 }

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -190,7 +190,7 @@ Platform::LocateExecutableScriptingResourcesFromSafePaths(
           ->GetSanitizedScriptingModuleName(
               module_spec.GetFileNameStrippingExtension().GetStringRef());
 
-  FileSpecList paths = Debugger::GetSafeAutoLoadPaths();
+  FileSpecList paths = target.GetSafeAutoLoadPaths();
 
   // Iterate in reverse so we consider the latest appended path first.
   for (FileSpec path : llvm::reverse(paths)) {

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -5431,6 +5431,18 @@ void Target::NotifyBreakpointChanged(
     BroadcastEvent(Target::eBroadcastBitBreakpointChanged, breakpoint_data_sp);
 }
 
+FileSpecList Target::GetSafeAutoLoadPaths() const {
+  FileSpecList fspecs = Debugger::GetDefaultSafeAutoLoadPaths();
+
+#ifndef NDEBUG
+  for (const auto &fspec :
+       TestingProperties::GetGlobalTestingProperties().GetSafeAutoLoadPaths())
+    fspecs.Append(fspec);
+#endif
+
+  return fspecs;
+}
+
 // FIXME: the language plugin should expression options dynamically and
 // we should validate here (by asking the language plugin) that the options
 // being set/retrieved are actually valid options.


### PR DESCRIPTION
Required for https://github.com/llvm/llvm-project/pull/191454

We want to make the `Target`/`Platform` define commonly used default paths (without configuring them in CMake). This is easiest if this logic lived in `Target` (since then we have access to the associated `Platform`).