### PR TITLE
[lldb] Convert TestPtrAuth.py from an inline to a regular test (NFC)

### DIFF
--- a/lldb/test/API/lang/c/ptrauth/TestPtrAuth.py
+++ b/lldb/test/API/lang/c/ptrauth/TestPtrAuth.py
@@ -1,4 +1,52 @@
-import lldbsuite.test.lldbinline as lldbinline
-from lldbsuite.test.decorators import *
+"""Test __ptrauth type qualifier."""
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipUnlessArm64eSupported])
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestPtrAuth(TestBase):
+    @skipUnlessArm64eSupported
+    def test(self):
+        self.build()
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "// break in main", lldb.SBFileSpec("main.c")
+        )
+
+        self.expect(
+            "target var valid0",
+            substrs=["(int *__ptrauth(2,0,0))", "valid0 =", "(actual=0x"],
+        )
+        self.expect(
+            "target var valid1",
+            substrs=["(int *__ptrauth(2,0,0) *)", "valid1 ="],
+        )
+        self.expect(
+            "target var valid2",
+            substrs=["(__ptrauth(2,0,0) intp)", "valid2 =", "(actual=0x"],
+        )
+        self.expect(
+            "target var valid3",
+            substrs=["(__ptrauth(2,0,0) intp *)", "valid3 ="],
+        )
+        self.expect(
+            "target var valid4",
+            substrs=["(__ptrauth(2,0,0) intp)", "valid4 =", "(actual=0x"],
+        )
+
+        bkpt = self.target().BreakpointCreateBySourceRegex(
+            "// break in test_code", lldb.SBFileSpec("main.c")
+        )
+        self.assertGreater(bkpt.GetNumLocations(), 0)
+        lldbutil.continue_to_breakpoint(process, bkpt)
+
+        self.expect(
+            "fr var pSpecial",
+            substrs=["(__ptrauth(2,0,0) intp)", "pSpecial =", "(actual=0x"],
+        )
+        self.expect("fr var *pSpecial", substrs=["5"])
+        self.expect(
+            "p pSpecial",
+            substrs=["(__ptrauth(2,0,0) intp)", "(actual=0x"],
+        )

--- a/lldb/test/API/lang/c/ptrauth/main.c
+++ b/lldb/test/API/lang/c/ptrauth/main.c
@@ -24,12 +24,7 @@ int *__ptrauth(VALID_DATA_KEY, 1, 65535) valid10;
 
 void test_code(intp p) {
   __ptrauth(VALID_DATA_KEY) intp pSpecial = p;
-  //% self.expect("fr var pSpecial",
-  //%     substrs=['(__ptrauth(2,0,0) intp)', 'pSpecial =', '(actual=0x'])
-  //% self.expect("fr var *pSpecial", substrs=['5'])
-  //% self.expect("p pSpecial",
-  //%     substrs=['(__ptrauth(2,0,0) intp)', '(actual=0x'])
-  pSpecial = p;
+  pSpecial = p; // break in test_code
   intp pNormal = pSpecial;
   pNormal = pSpecial;
 
@@ -51,17 +46,7 @@ int main(int argc, char **argv) {
   valid2 = &nonConstantGlobal;
   valid3 = &valid2;
   valid4 = &nonConstantGlobal;
-  //% self.expect("target var valid0",
-  //%     substrs=['(int *__ptrauth(2,0,0))', 'valid0 =', '(actual=0x'])
-  //% self.expect("target var valid1",
-  //%     substrs=['(int *__ptrauth(2,0,0) *)', 'valid1 ='])
-  //% self.expect("target var valid2",
-  //%     substrs=['(__ptrauth(2,0,0) intp)', 'valid2 =', '(actual=0x'])
-  //% self.expect("target var valid3",
-  //%     substrs=['(__ptrauth(2,0,0) intp *)', 'valid3 ='])
-  //% self.expect("target var valid4",
-  //%     substrs=['(__ptrauth(2,0,0) intp)', 'valid4 =', '(actual=0x'])
-  int (*f)(int, char **) = main;
+  int (*f)(int, char **) = main; // break in main
   test_code(valid4);
   test_code(valid4);
   test_array();


### PR DESCRIPTION
This PR changes TestPtrAuth.py from an inline to a "regular" API test. The motivation for this is #191416 and the need to specify parameters to the build.