### PR TITLE
[flang] Fix FIR AliasAnalysis for zero-offset view chains

### DIFF
--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -367,8 +367,8 @@ static bool pathsDivergeAtComponent(const fir::AliasAnalysis::Source &lhsSrc,
 
 /// Walk backward from \p val through FortranObjectViewOpInterface ops
 /// that have zero offset (i.e. they access the same base address).
-/// Return true if \p other is found on this chain.
-static bool isOnZeroOffsetViewChain(mlir::Value val, mlir::Value other) {
+/// Return the root value at the end of the chain.
+static mlir::Value getZeroOffsetViewRoot(mlir::Value val) {
   while (auto *defOp = val.getDefiningOp()) {
     auto viewOp = mlir::dyn_cast<fir::FortranObjectViewOpInterface>(defOp);
     if (!viewOp)
@@ -377,10 +377,8 @@ static bool isOnZeroOffsetViewChain(mlir::Value val, mlir::Value other) {
     if (!offset || *offset != 0)
       break;
     val = viewOp.getViewSource(mlir::cast<mlir::OpResult>(val));
-    if (val == other)
-      return true;
   }
-  return false;
+  return val;
 }
 
 AliasResult AliasAnalysis::alias(mlir::Value lhs, mlir::Value rhs) {
@@ -398,13 +396,12 @@ AliasResult AliasAnalysis::alias(Source lhsSrc, Source rhsSrc, mlir::Value lhs,
   // After MLIR inlining, the current implementation may
   // not recognize non-aliasing entities.
 
-  // If one value is directly derived from the other through a chain of
-  // zero-offset view operations (e.g. embox, declare, convert), they
-  // access the same underlying memory. This check avoids the case where
+  // If both values trace back to the same root through zero-offset view
+  // operations (e.g. embox without slice, declare, convert), they access
+  // the same underlying memory. This check avoids the case where
   // getSource() traces through upstream operations (e.g. a sliced embox)
   // that set approximateSource, conservatively preventing MustAlias.
-  if (lhs == rhs || isOnZeroOffsetViewChain(lhs, rhs) ||
-      isOnZeroOffsetViewChain(rhs, lhs))
+  if (lhs == rhs || getZeroOffsetViewRoot(lhs) == getZeroOffsetViewRoot(rhs))
     return AliasResult::MustAlias;
 
   bool approximateSource = lhsSrc.approximateSource || rhsSrc.approximateSource;

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -365,6 +365,24 @@ static bool pathsDivergeAtComponent(const fir::AliasAnalysis::Source &lhsSrc,
   return false;
 }
 
+/// Walk backward from \p val through FortranObjectViewOpInterface ops
+/// that have zero offset (i.e. they access the same base address).
+/// Return true if \p other is found on this chain.
+static bool isOnZeroOffsetViewChain(mlir::Value val, mlir::Value other) {
+  while (auto *defOp = val.getDefiningOp()) {
+    auto viewOp = mlir::dyn_cast<fir::FortranObjectViewOpInterface>(defOp);
+    if (!viewOp)
+      break;
+    auto offset = viewOp.getViewOffset(mlir::cast<mlir::OpResult>(val));
+    if (!offset || *offset != 0)
+      break;
+    val = viewOp.getViewSource(mlir::cast<mlir::OpResult>(val));
+    if (val == other)
+      return true;
+  }
+  return false;
+}
+
 AliasResult AliasAnalysis::alias(mlir::Value lhs, mlir::Value rhs) {
   // A wrapper around alias(Source lhsSrc, Source rhsSrc, mlir::Value lhs,
   // mlir::Value rhs) This allows a user to provide Source that may be obtained
@@ -379,6 +397,16 @@ AliasResult AliasAnalysis::alias(Source lhsSrc, Source rhsSrc, mlir::Value lhs,
   // TODO: alias() has to be aware of the function scopes.
   // After MLIR inlining, the current implementation may
   // not recognize non-aliasing entities.
+
+  // If one value is directly derived from the other through a chain of
+  // zero-offset view operations (e.g. embox, declare, convert), they
+  // access the same underlying memory. This check avoids the case where
+  // getSource() traces through upstream operations (e.g. a sliced embox)
+  // that set approximateSource, conservatively preventing MustAlias.
+  if (lhs == rhs || isOnZeroOffsetViewChain(lhs, rhs) ||
+      isOnZeroOffsetViewChain(rhs, lhs))
+    return AliasResult::MustAlias;
+
   bool approximateSource = lhsSrc.approximateSource || rhsSrc.approximateSource;
   LLVM_DEBUG(llvm::dbgs() << "\nAliasAnalysis::alias\n";
              llvm::dbgs() << "  lhs: " << lhs << "\n";

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-pack-array.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-pack-array.fir
@@ -16,10 +16,8 @@
 // CHECK-DAG: test1_x_repack(1)#0 <-> test1_x_orig(1)#0: MayAlias
 // CHECK-DAG: test1_y_repack(1)#0 <-> test1_y_orig(1)#0: MayAlias
 
-// Ideally, these should report MustAlias, but MayAlias
-// may work as well:
-// CHECK-DAG: test1_y_repack(1)#0 <-> test1_y_repack2(1)#0: MayAlias
-// CHECK-DAG: test1_x_repack(1)#0 <-> test1_x_repack2(1)#0: MayAlias
+// CHECK-DAG: test1_y_repack(1)#0 <-> test1_y_repack2(1)#0: MustAlias
+// CHECK-DAG: test1_x_repack(1)#0 <-> test1_x_repack2(1)#0: MustAlias
 
 
 func.func @_QFtest1(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}, %arg1: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "y"}) {

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-zero-offset-view-chain.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-zero-offset-view-chain.fir
@@ -45,6 +45,19 @@ func.func @_QPtest_embox_declare_ref() {
 
 // -----
 
+// Test: two box_addr from the same source => MustAlias (sibling case)
+// CHECK-LABEL: Testing : "_QPtest_sibling_box_addr"
+// CHECK-DAG: addr1#0 <-> addr2#0: MustAlias
+func.func @_QPtest_sibling_box_addr(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}) {
+  %0 = fir.dummy_scope : !fir.dscope
+  %1:2 = hlfir.declare %arg0 dummy_scope %0 {uniq_name = "_QPtestEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
+  %addr1 = fir.box_addr %1#0 {test.ptr = "addr1"} : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<f32>
+  %addr2 = fir.box_addr %1#0 {test.ptr = "addr2"} : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<f32>
+  return
+}
+
+// -----
+
 // Test: embox with slice does NOT chain-walk to the ref (non-zero offset)
 // CHECK-LABEL: Testing : "_QPtest_embox_slice_ref"
 // CHECK-DAG: ref#0 <-> sliced_box#0: MayAlias

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-zero-offset-view-chain.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-zero-offset-view-chain.fir
@@ -1,0 +1,60 @@
+// Test that values connected through zero-offset FortranObjectViewOpInterface
+// operations (embox, declare, convert) are recognized as MustAlias, even when
+// getSource() would set approximateSource due to upstream sliced operations.
+// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+
+// Test: embox(ref) vs ref => MustAlias
+// This is the pattern that arises when a subroutine with acc.deviceptr
+// on embox(b) is inlined into a caller that uses b directly.
+// CHECK-LABEL: Testing : "_QPtest_embox_ref"
+// CHECK-DAG: ref#0 <-> box#0: MustAlias
+func.func @_QPtest_embox_ref(%arg0: !fir.ref<!fir.array<10xf32>> {fir.bindc_name = "b"}) {
+  %c10 = arith.constant 10 : index
+  %shape = fir.shape %c10 : (index) -> !fir.shape<1>
+  %ref = fir.declare %arg0(%shape) {test.ptr = "ref", uniq_name = "b"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.ref<!fir.array<10xf32>>
+  %box = fir.embox %ref(%shape) {test.ptr = "box"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf32>>
+  return
+}
+
+// -----
+
+// Test: declare(ref) vs ref => MustAlias
+// CHECK-LABEL: Testing : "_QPtest_declare_ref"
+// CHECK-DAG: ref#0 <-> decl#0: MustAlias
+func.func @_QPtest_declare_ref() {
+  %ref = fir.alloca !fir.array<10xf32> {test.ptr = "ref"}
+  %c10 = arith.constant 10 : index
+  %shape = fir.shape %c10 : (index) -> !fir.shape<1>
+  %decl = fir.declare %ref(%shape) {test.ptr = "decl", uniq_name = "arr"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.ref<!fir.array<10xf32>>
+  return
+}
+
+// -----
+
+// Test: embox(declare(ref)) vs ref => MustAlias (two-hop chain)
+// CHECK-LABEL: Testing : "_QPtest_embox_declare_ref"
+// CHECK-DAG: ref#0 <-> box#0: MustAlias
+func.func @_QPtest_embox_declare_ref() {
+  %ref = fir.alloca !fir.array<10xf32> {test.ptr = "ref"}
+  %c10 = arith.constant 10 : index
+  %shape = fir.shape %c10 : (index) -> !fir.shape<1>
+  %decl = fir.declare %ref(%shape) {uniq_name = "arr"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.ref<!fir.array<10xf32>>
+  %box = fir.embox %decl(%shape) {test.ptr = "box"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf32>>
+  return
+}
+
+// -----
+
+// Test: embox with slice does NOT chain-walk to the ref (non-zero offset)
+// CHECK-LABEL: Testing : "_QPtest_embox_slice_ref"
+// CHECK-DAG: ref#0 <-> sliced_box#0: MayAlias
+func.func @_QPtest_embox_slice_ref() {
+  %ref = fir.alloca !fir.array<10xf32> {test.ptr = "ref"}
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  %c5 = arith.constant 5 : index
+  %shape = fir.shape %c10 : (index) -> !fir.shape<1>
+  %slice = fir.slice %c1, %c5, %c1 : (index, index, index) -> !fir.slice<1>
+  %sliced_box = fir.embox %ref(%shape) [%slice] {test.ptr = "sliced_box"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  return
+}

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-zero-offset-view-chain.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-zero-offset-view-chain.fir
@@ -4,8 +4,6 @@
 // RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // Test: embox(ref) vs ref => MustAlias
-// This is the pattern that arises when a subroutine with acc.deviceptr
-// on embox(b) is inlined into a caller that uses b directly.
 // CHECK-LABEL: Testing : "_QPtest_embox_ref"
 // CHECK-DAG: ref#0 <-> box#0: MustAlias
 func.func @_QPtest_embox_ref(%arg0: !fir.ref<!fir.array<10xf32>> {fir.bindc_name = "b"}) {

--- a/flang/test/Transforms/OpenACC/acc-implicit-data.fir
+++ b/flang/test/Transforms/OpenACC/acc-implicit-data.fir
@@ -394,3 +394,46 @@ func.func private @_FortranAAllocatableSetBounds(!fir.ref<!fir.box<none>>, i32, 
 // CHECK-NOT: acc.copyin
 // CHECK: acc.deviceptr
 // CHECK-NOT: acc.copyout
+
+// -----
+
+// Test that acc.serial inside acc.data deviceptr generates implicit deviceptr
+// (not copyin) when the deviceptr clause variable is derived from the ref used
+// by the serial construct (here, via fir.embox wrapping the declared ref).
+// This pattern arises when a subroutine containing:
+//   !$acc data deviceptr(b)    ← deviceptr operates on embox(b) (a box type)
+//     !$acc serial
+//       ... uses b ...         ← serial uses b directly (a ref type)
+//     !$acc end serial
+//   !$acc end data
+// is inlined into the caller. After inlining, the deviceptr's box and the
+// serial's ref are different SSA values with different types, so alias
+// analysis returns NoAlias. The pass must recognize that the deviceptr's
+// variable is derived from the ref and generate an implicit deviceptr clause
+// instead of falling back to copyin/copyout.
+func.func @test_serial_inside_data_deviceptr_embox() {
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  %arr = fir.alloca !fir.array<10xf32> {bindc_name = "b"}
+  %shape = fir.shape %c10 : (index) -> !fir.shape<1>
+  %arr_decl = fir.declare %arr(%shape) {uniq_name = "b"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.ref<!fir.array<10xf32>>
+  %box = fir.embox %arr_decl(%shape) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf32>>
+  %devptr = acc.deviceptr var(%box : !fir.box<!fir.array<10xf32>>) -> !fir.box<!fir.array<10xf32>> {name = "b(1:10)"}
+  acc.data dataOperands(%devptr : !fir.box<!fir.array<10xf32>>) {
+    acc.serial {
+      %elem = fir.array_coor %arr_decl(%shape) %c1 : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+      %val = fir.load %elem : !fir.ref<f32>
+      acc.yield
+    }
+    acc.terminator
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @test_serial_inside_data_deviceptr_embox
+// CHECK: acc.deviceptr var({{.*}} : !fir.box<!fir.array<10xf32>>) -> !fir.box<!fir.array<10xf32>> {name = "b(1:10)"}
+// CHECK: acc.data
+// CHECK: acc.deviceptr varPtr({{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {implicit = true, name = "b"}
+// CHECK: acc.serial dataOperands({{.*}} : !fir.ref<!fir.array<10xf32>>)
+// CHECK-NOT: acc.copyin
+// CHECK-NOT: acc.copyout


### PR DESCRIPTION
When subroutine `f` below is inlined, the `ACCImplicitData` pass fails to recognize that `b` is already covered by the enclosing `!$acc data deviceptr`. The deviceptr clause operates on a box (`fir.embox` result) while the inner `acc.serial` uses the underlying ref. `fir::AliasAnalysis` traces both back through the full def-chain, where an upstream sliced `fir.embox` (from `a(:,5)`) sets `approximateSource=true`, causing `MayAlias` instead of `MustAlias`. The pass falls back to implicit `copyin`/`copyout`, causing a segfault.

```fortran
module test_mod
  real, allocatable :: a(:,:)
contains
  subroutine f(b)
    real, dimension(*) :: b
    !$acc data deviceptr(b(1:100))
    !$acc serial
    print *, b(10)
    !$acc end serial
    !$acc end data
  end subroutine f
end module test_mod

program test
  use test_mod
  call alloc_a
  !$acc data present(a)
  !$acc host_data use_device(a)
  call f( a(:,5) )
  !$acc end host_data
  !$acc end data
end program
```

Fix: add `getZeroOffsetViewRoot()` as a short-circuit in `alias(Source, Source, Value, Value)`. Before consulting `approximateSource`, it walks each value backward through `FortranObjectViewOpInterface` ops with zero offset (embox without slice, declare, box_addr) to find its root. If both values share the same root, `MustAlias` is returned immediately, avoiding the conservative `MayAlias` caused by distant `approximateSource` flags.