### PR TITLE
[lldb] Mark enum types as scalar in clang typesystem

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3909,7 +3909,7 @@ TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
                                 ->getDefinitionOrSelf()
                                 ->getIntegerType()
                                 .getAsOpaquePtr());
-    return eTypeIsEnumeration | eTypeHasValue;
+    return eTypeIsEnumeration | eTypeHasValue | eTypeIsScalar;
 
   case clang::Type::FunctionProto:
     return eTypeIsFuncPrototype | eTypeHasValue;

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3919,7 +3919,7 @@ TypeSystemClang::GetTypeInfo(lldb::opaque_compiler_type_t type,
                                 ->getDefinitionOrSelf()
                                 ->getIntegerType()
                                 .getAsOpaquePtr());
-    return eTypeIsEnumeration | eTypeHasValue;
+    return eTypeIsEnumeration | eTypeHasValue | eTypeIsScalar;
 
   case clang::Type::FunctionProto:
     return eTypeIsFuncPrototype | eTypeHasValue;

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -1573,9 +1573,7 @@ Interpreter::VerifyCastType(lldb::ValueObjectSP operand,
                             CompilerType source_type, CompilerType target_type,
                             int location) {
 
-  if (target_type.IsScalarType())
-    return VerifyArithmeticCast(source_type, target_type, location);
-
+  // Enumerations can also be a scalar value, try enum cast first.
   if (target_type.IsEnumerationType()) {
     // Cast to enum type.
     if (!source_type.IsScalarType() && !source_type.IsEnumerationType()) {
@@ -1589,6 +1587,9 @@ Interpreter::VerifyCastType(lldb::ValueObjectSP operand,
     }
     return CastKind::eEnumeration;
   }
+
+  if (target_type.IsScalarType())
+    return VerifyArithmeticCast(source_type, target_type, location);
 
   if (target_type.IsPointerType()) {
     if (!source_type.IsInteger() && !source_type.IsEnumerationType() &&

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -3202,7 +3202,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
   }
 
   if (type.IsInteger()) {
-    if (!is_scalar || is_integer) {
+    if ((is_enum && is_scalar) || !is_scalar || is_integer) {
       auto int_value_or_err = GetValueAsAPSInt();
       if (int_value_or_err) {
         // Get the value as APSInt and extend or truncate it to the requested

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -3236,7 +3236,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
   }
 
   if (type.IsInteger()) {
-    if (!is_scalar || is_integer) {
+    if (is_integer || (is_enum && is_scalar) || !is_scalar) {
       auto int_value_or_err = GetValueAsAPSInt();
       if (int_value_or_err) {
         // Get the value as APSInt and extend or truncate it to the requested

--- a/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
+++ b/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
@@ -151,6 +151,9 @@ class EnumTypesTestCase(TestBase):
             self.assertEqual(
                 member.signed, value_matches[idx], "Value matches for %d" % (idx)
             )
+            member_type_flags = member.GetType().GetTypeFlags()
+            is_scalar = (member_type_flags & lldb.eTypeIsScalar) == lldb.eTypeIsScalar
+            self.assertTrue(is_scalar, f"expects enum: {member.name} is a scalar value")
 
     def test_api(self):
         """Test that the SBTypeEnumMember API's work correctly for enum_test_days"""

--- a/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
+++ b/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
@@ -152,6 +152,9 @@ class EnumTypesTestCase(TestBase):
             self.assertEqual(
                 member.signed, value_matches[idx], "Value matches for %d" % (idx)
             )
+            member_type_flags = member.GetType().GetTypeFlags()
+            is_scalar = (member_type_flags & lldb.eTypeIsScalar) == lldb.eTypeIsScalar
+            self.assertTrue(is_scalar, f"expects enum: {member.name} is a scalar value")
 
     def test_api(self):
         """Test that the SBTypeEnumMember API's work correctly for enum_test_days"""

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -463,6 +463,7 @@ TEST_F(TestTypeSystemClang, TestIsEnumerationType) {
     EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
     EXPECT_TRUE(is_signed);
     EXPECT_FALSE(enum_type.IsIntegerType(is_signed));
+    EXPECT_TRUE(enum_type.IsScalarType());
   }
 
   // Scoped unsigned enum
@@ -477,6 +478,7 @@ TEST_F(TestTypeSystemClang, TestIsEnumerationType) {
     EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
     EXPECT_FALSE(is_signed);
     EXPECT_FALSE(enum_type.IsIntegerType(is_signed));
+    EXPECT_TRUE(enum_type.IsScalarType());
   }
 
   // Unscoped signed enum
@@ -491,6 +493,7 @@ TEST_F(TestTypeSystemClang, TestIsEnumerationType) {
     EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
     EXPECT_TRUE(is_signed);
     EXPECT_FALSE(enum_type.IsIntegerType(is_signed));
+    EXPECT_TRUE(enum_type.IsScalarType());
   }
 
   // Unscoped unsigned enum
@@ -505,6 +508,7 @@ TEST_F(TestTypeSystemClang, TestIsEnumerationType) {
     EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
     EXPECT_FALSE(is_signed);
     EXPECT_FALSE(enum_type.IsIntegerType(is_signed));
+    EXPECT_TRUE(enum_type.IsScalarType());
   }
 }
 

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -470,6 +470,7 @@ TEST_F(TestTypeSystemClang, TestIsEnumerationType) {
     EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
     EXPECT_TRUE(is_signed);
     EXPECT_FALSE(enum_type.IsIntegerType(is_signed));
+    EXPECT_TRUE(enum_type.IsScalarType());
   }
 
   // Scoped unsigned enum
@@ -484,6 +485,7 @@ TEST_F(TestTypeSystemClang, TestIsEnumerationType) {
     EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
     EXPECT_FALSE(is_signed);
     EXPECT_FALSE(enum_type.IsIntegerType(is_signed));
+    EXPECT_TRUE(enum_type.IsScalarType());
   }
 
   // Unscoped signed enum
@@ -498,6 +500,7 @@ TEST_F(TestTypeSystemClang, TestIsEnumerationType) {
     EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
     EXPECT_TRUE(is_signed);
     EXPECT_FALSE(enum_type.IsIntegerType(is_signed));
+    EXPECT_TRUE(enum_type.IsScalarType());
   }
 
   // Unscoped unsigned enum
@@ -512,6 +515,7 @@ TEST_F(TestTypeSystemClang, TestIsEnumerationType) {
     EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
     EXPECT_FALSE(is_signed);
     EXPECT_FALSE(enum_type.IsIntegerType(is_signed));
+    EXPECT_TRUE(enum_type.IsScalarType());
   }
 }
 


### PR DESCRIPTION
This is to differentiate enums in other languages that has non scalar enums.

C/C++ enums are backed by an integer type and are always scalars. However.
in languages such as swift and rust, Enums can have associated values. such as 
```swift
enum Barcode {
    case upc(Int, Int, Int, Int)
    case qrCode(String)
    case Empty
}
```
```rust
enum IpAddr {
    V4(String),
    V6(String),
}
```

in lldb-dap we would like to support changing enum values. but lldb currently only support changing values is that has an valid encoding and is 16 bytes (mostly likely the size of a general register).

In the case of enums with associated values. the user should be able to set scalar enums directly
```swift
enum Color {
    case Red
    case Blue
    case Green
}
var m_color = Color.Red
```
we should be able to set m_color to 2. to get the color green. and we only want do that if it is safe to do so. 
i.e it is an enum and is_scalar (doesn't have associated values). This fails currently because, type system clang does not mark enums as scalars. 

