### PR TITLE
[BOLT] Account for stubs with symbols in plt

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -1041,8 +1041,11 @@ void RewriteInstance::discoverFileObjects() {
 
     FileSymRefs.emplace(SymbolAddress, Symbol);
 
-    // Skip section symbols that will be registered by disassemblePLT().
-    if (SymbolType == SymbolRef::ST_Debug) {
+    // Skip symbols in PLT sections that will be registered by disassemblePLT().
+    // ST_Debug covers section markers (lld/GNU ld), ST_Function covers
+    // explicit stub symbols emitted by mold (e.g., malloc$plt).
+    if (SymbolType == SymbolRef::ST_Debug ||
+        SymbolType == SymbolRef::ST_Function) {
       ErrorOr<BinarySection &> BSection =
           BC->getSectionForAddress(SymbolAddress);
       if (BSection && getPLTSectionInfo(BSection->getName()))

--- a/bolt/test/AArch64/plt-mold-func-symbols.s
+++ b/bolt/test/AArch64/plt-mold-func-symbols.s
@@ -1,0 +1,36 @@
+## Test that BOLT correctly handles mold-style STT_FUNC symbols in PLT
+## sections.
+
+# REQUIRES: system-linux
+
+## Build a shared library from the common stubs.
+# RUN: %clang %cflags %p/../Inputs/stub.c -fPIC -shared -o %t.so
+
+## Build and link the main binary. The linker creates a real PLT entry.
+# RUN: llvm-mc -filetype=obj -triple aarch64-linux %s -o %t.o
+# RUN: ld.lld -pie %t.o %t.so -o %t.exe --emit-relocs
+
+## Inject a mold-style STT_FUNC symbol at the PLT entry for printf.
+## Mold places "printf$plt" directly on the PLT stub; we simulate this
+## with llvm-objcopy. The PLT header is 32 bytes on AArch64, and each
+## entry is 16 bytes. printf is the only entry after the header.
+# RUN: llvm-objcopy --add-symbol "printf\$plt=.plt:32,function,local" \
+# RUN:   %t.exe %t
+
+## Verify BOLT resolves the call as printf@PLT, not printf$plt.
+# RUN: llvm-bolt %t -o %t.bolt --print-cfg --print-only=_start 2>&1 \
+# RUN:   | FileCheck %s
+# RUN: llvm-readobj --syms %t.bolt | grep -A7 printf$plt | FileCheck \
+# RUN:   %s --check-prefix=CHECK-SYM
+
+# CHECK:     bl printf@PLT
+# CHECK-NOT: printf$plt
+# CHECK-SYM: Section: .plt
+
+  .text
+  .globl _start
+  .type _start, %function
+_start:
+  bl printf
+  ret
+  .size _start, .-_start

--- a/bolt/test/X86/plt-mold.test
+++ b/bolt/test/X86/plt-mold.test
@@ -3,4 +3,4 @@
 
 ## Check that llvm-bolt correctly parses PLT created by mold linker.
 ## The only call instruction in main() should be a call to printf() in PLT.
-CHECK:  callq "printf$plt
+CHECK:  callq printf@PLT


### PR DESCRIPTION
LLD and bfd do not generate functions symbols for stubs in PLT. However, mold does and trips the object discovery to create two functions (BF then PLTFunc). This can cause symbol to be resoved with BF with incorrect ADRP immediate field in AArch64.

The issue is described in more detail here: https://github.com/llvm/llvm-project/issues/192552