### PR TITLE
[clang] Add typed variants for C23 stdbit.h builtins

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -189,6 +189,23 @@ Non-comprehensive list of changes in this release
   ``__builtin_stdc_has_single_bit``, ``__builtin_stdc_bit_width``,
   ``__builtin_stdc_bit_floor``, and ``__builtin_stdc_bit_ceil``.
 
+- Implemented the type-specific C23 ``<stdbit.h>`` functions with constexpr
+  evaluation support:
+  ``stdc_leading_zeros_{uc,us,ui,ul,ull}``,
+  ``stdc_leading_ones_{uc,us,ui,ul,ull}``,
+  ``stdc_trailing_zeros_{uc,us,ui,ul,ull}``,
+  ``stdc_trailing_ones_{uc,us,ui,ul,ull}``,
+  ``stdc_first_leading_zero_{uc,us,ui,ul,ull}``,
+  ``stdc_first_leading_one_{uc,us,ui,ul,ull}``,
+  ``stdc_first_trailing_zero_{uc,us,ui,ul,ull}``,
+  ``stdc_first_trailing_one_{uc,us,ui,ul,ull}``,
+  ``stdc_count_zeros_{uc,us,ui,ul,ull}``,
+  ``stdc_count_ones_{uc,us,ui,ul,ull}``,
+  ``stdc_has_single_bit_{uc,us,ui,ul,ull}``,
+  ``stdc_bit_width_{uc,us,ui,ul,ull}``,
+  ``stdc_bit_floor_{uc,us,ui,ul,ull}``, and
+  ``stdc_bit_ceil_{uc,us,ui,ul,ull}``.
+
 - A new generic bit-reverse builtin function ``__builtin_bitreverseg`` that
   extends bit-reversal support to all standard integers type, including
   ``_BitInt``

--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -29,6 +29,11 @@ class F16F128MathTemplate : Template<["__fp16", "__float128"],
 class IntMathTemplate : Template<["int", "long int", "long long int"],
                                  ["",     "l",       "ll"], /*AsPrefix=*/1>;
 
+class IntBitUtilTemplate : Template<
+    ["unsigned char", "unsigned short", "unsigned int",
+     "unsigned long int", "unsigned long long int"],
+    ["_uc", "_us", "_ui", "_ul", "_ull"]>;
+
 class MSInt8_16_32Template : Template<["char", "short", "msint32_t"],
                                       ["8",    "16",    ""]>;
 
@@ -964,6 +969,95 @@ def StdcBitCeilLib: LibBuiltin<"stdbit.h", "C23_LANG"> {
   let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
+
+// Typed variants of the C23 stdbit.h builtins (e.g. stdc_leading_zeros_uc).
+// IntBitUtilTemplate generates the _uc/_us/_ui/_ul/_ull spellings with
+// concrete prototypes so the compiler can match the <stdbit.h> declarations.
+
+def StdcLeadingZerosTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_leading_zeros"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "unsigned int(T)";
+}
+
+def StdcLeadingOnesTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_leading_ones"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "unsigned int(T)";
+}
+
+def StdcTrailingZerosTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_trailing_zeros"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "unsigned int(T)";
+}
+
+def StdcTrailingOnesTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_trailing_ones"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "unsigned int(T)";
+}
+
+def StdcFirstLeadingZeroTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_first_leading_zero"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "unsigned int(T)";
+}
+
+def StdcFirstLeadingOneTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_first_leading_one"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "unsigned int(T)";
+}
+
+def StdcFirstTrailingZeroTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_first_trailing_zero"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "unsigned int(T)";
+}
+
+def StdcFirstTrailingOneTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_first_trailing_one"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "unsigned int(T)";
+}
+
+def StdcCountZerosTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_count_zeros"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "unsigned int(T)";
+}
+
+def StdcCountOnesTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_count_ones"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "unsigned int(T)";
+}
+
+def StdcBitWidthTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_bit_width"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "unsigned int(T)";
+}
+
+def StdcHasSingleBitTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_has_single_bit"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "bool(T)";
+}
+
+def StdcBitFloorTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_bit_floor"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "T(T)";
+}
+
+def StdcBitCeilTyped : LibBuiltin<"stdbit.h", "C23_LANG">, IntBitUtilTemplate {
+  let Spellings = ["stdc_bit_ceil"];
+  let Attributes = [NoThrow, Const, Constexpr];
+  let Prototype = "T(T)";
+}
+
 
 
 // Random GCC builtins

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -4413,6 +4413,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
         });
   }
 
+  case Builtin::BIstdc_leading_zeros_uc:
+  case Builtin::BIstdc_leading_zeros_us:
+  case Builtin::BIstdc_leading_zeros_ui:
+  case Builtin::BIstdc_leading_zeros_ul:
+  case Builtin::BIstdc_leading_zeros_ull:
   case Builtin::BIstdc_leading_zeros:
   case Builtin::BI__builtin_stdc_leading_zeros: {
     unsigned ResWidth = S.getASTContext().getIntWidth(Call->getType());
@@ -4422,6 +4427,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
         });
   }
 
+  case Builtin::BIstdc_leading_ones_uc:
+  case Builtin::BIstdc_leading_ones_us:
+  case Builtin::BIstdc_leading_ones_ui:
+  case Builtin::BIstdc_leading_ones_ul:
+  case Builtin::BIstdc_leading_ones_ull:
   case Builtin::BIstdc_leading_ones:
   case Builtin::BI__builtin_stdc_leading_ones: {
     unsigned ResWidth = S.getASTContext().getIntWidth(Call->getType());
@@ -4431,6 +4441,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
         });
   }
 
+  case Builtin::BIstdc_trailing_zeros_uc:
+  case Builtin::BIstdc_trailing_zeros_us:
+  case Builtin::BIstdc_trailing_zeros_ui:
+  case Builtin::BIstdc_trailing_zeros_ul:
+  case Builtin::BIstdc_trailing_zeros_ull:
   case Builtin::BIstdc_trailing_zeros:
   case Builtin::BI__builtin_stdc_trailing_zeros: {
     unsigned ResWidth = S.getASTContext().getIntWidth(Call->getType());
@@ -4440,6 +4455,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
         });
   }
 
+  case Builtin::BIstdc_trailing_ones_uc:
+  case Builtin::BIstdc_trailing_ones_us:
+  case Builtin::BIstdc_trailing_ones_ui:
+  case Builtin::BIstdc_trailing_ones_ul:
+  case Builtin::BIstdc_trailing_ones_ull:
   case Builtin::BIstdc_trailing_ones:
   case Builtin::BI__builtin_stdc_trailing_ones: {
     unsigned ResWidth = S.getASTContext().getIntWidth(Call->getType());
@@ -4449,6 +4469,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
         });
   }
 
+  case Builtin::BIstdc_first_leading_zero_uc:
+  case Builtin::BIstdc_first_leading_zero_us:
+  case Builtin::BIstdc_first_leading_zero_ui:
+  case Builtin::BIstdc_first_leading_zero_ul:
+  case Builtin::BIstdc_first_leading_zero_ull:
   case Builtin::BIstdc_first_leading_zero:
   case Builtin::BI__builtin_stdc_first_leading_zero: {
     unsigned ResWidth = S.getASTContext().getIntWidth(Call->getType());
@@ -4458,6 +4483,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
         });
   }
 
+  case Builtin::BIstdc_first_leading_one_uc:
+  case Builtin::BIstdc_first_leading_one_us:
+  case Builtin::BIstdc_first_leading_one_ui:
+  case Builtin::BIstdc_first_leading_one_ul:
+  case Builtin::BIstdc_first_leading_one_ull:
   case Builtin::BIstdc_first_leading_one:
   case Builtin::BI__builtin_stdc_first_leading_one: {
     unsigned ResWidth = S.getASTContext().getIntWidth(Call->getType());
@@ -4467,6 +4497,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
         });
   }
 
+  case Builtin::BIstdc_first_trailing_zero_uc:
+  case Builtin::BIstdc_first_trailing_zero_us:
+  case Builtin::BIstdc_first_trailing_zero_ui:
+  case Builtin::BIstdc_first_trailing_zero_ul:
+  case Builtin::BIstdc_first_trailing_zero_ull:
   case Builtin::BIstdc_first_trailing_zero:
   case Builtin::BI__builtin_stdc_first_trailing_zero: {
     unsigned ResWidth = S.getASTContext().getIntWidth(Call->getType());
@@ -4476,6 +4511,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
         });
   }
 
+  case Builtin::BIstdc_first_trailing_one_uc:
+  case Builtin::BIstdc_first_trailing_one_us:
+  case Builtin::BIstdc_first_trailing_one_ui:
+  case Builtin::BIstdc_first_trailing_one_ul:
+  case Builtin::BIstdc_first_trailing_one_ull:
   case Builtin::BIstdc_first_trailing_one:
   case Builtin::BI__builtin_stdc_first_trailing_one: {
     unsigned ResWidth = S.getASTContext().getIntWidth(Call->getType());
@@ -4485,6 +4525,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
         });
   }
 
+  case Builtin::BIstdc_count_zeros_uc:
+  case Builtin::BIstdc_count_zeros_us:
+  case Builtin::BIstdc_count_zeros_ui:
+  case Builtin::BIstdc_count_zeros_ul:
+  case Builtin::BIstdc_count_zeros_ull:
   case Builtin::BIstdc_count_zeros:
   case Builtin::BI__builtin_stdc_count_zeros: {
     unsigned ResWidth = S.getASTContext().getIntWidth(Call->getType());
@@ -4495,6 +4540,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
         });
   }
 
+  case Builtin::BIstdc_count_ones_uc:
+  case Builtin::BIstdc_count_ones_us:
+  case Builtin::BIstdc_count_ones_ui:
+  case Builtin::BIstdc_count_ones_ul:
+  case Builtin::BIstdc_count_ones_ull:
   case Builtin::BIstdc_count_ones:
   case Builtin::BI__builtin_stdc_count_ones: {
     unsigned ResWidth = S.getASTContext().getIntWidth(Call->getType());
@@ -4504,6 +4554,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
         });
   }
 
+  case Builtin::BIstdc_has_single_bit_uc:
+  case Builtin::BIstdc_has_single_bit_us:
+  case Builtin::BIstdc_has_single_bit_ui:
+  case Builtin::BIstdc_has_single_bit_ul:
+  case Builtin::BIstdc_has_single_bit_ull:
   case Builtin::BIstdc_has_single_bit:
   case Builtin::BI__builtin_stdc_has_single_bit: {
     unsigned ResWidth = S.getASTContext().getIntWidth(Call->getType());
@@ -4513,6 +4568,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
         });
   }
 
+  case Builtin::BIstdc_bit_width_uc:
+  case Builtin::BIstdc_bit_width_us:
+  case Builtin::BIstdc_bit_width_ui:
+  case Builtin::BIstdc_bit_width_ul:
+  case Builtin::BIstdc_bit_width_ull:
   case Builtin::BIstdc_bit_width:
   case Builtin::BI__builtin_stdc_bit_width: {
     unsigned ResWidth = S.getASTContext().getIntWidth(Call->getType());
@@ -4523,6 +4583,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
         });
   }
 
+  case Builtin::BIstdc_bit_floor_uc:
+  case Builtin::BIstdc_bit_floor_us:
+  case Builtin::BIstdc_bit_floor_ui:
+  case Builtin::BIstdc_bit_floor_ul:
+  case Builtin::BIstdc_bit_floor_ull:
   case Builtin::BIstdc_bit_floor:
   case Builtin::BI__builtin_stdc_bit_floor:
     return interp__builtin_elementwise_int_unaryop(
@@ -4534,6 +4599,11 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
                                      BitWidth - Val.countl_zero() - 1);
         });
 
+  case Builtin::BIstdc_bit_ceil_uc:
+  case Builtin::BIstdc_bit_ceil_us:
+  case Builtin::BIstdc_bit_ceil_ui:
+  case Builtin::BIstdc_bit_ceil_ul:
+  case Builtin::BIstdc_bit_ceil_ull:
   case Builtin::BIstdc_bit_ceil:
   case Builtin::BI__builtin_stdc_bit_ceil:
     return interp__builtin_elementwise_int_unaryop(

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -16829,6 +16829,76 @@ bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
     }
   }
 
+  case Builtin::BIstdc_leading_zeros_uc:
+  case Builtin::BIstdc_leading_zeros_us:
+  case Builtin::BIstdc_leading_zeros_ui:
+  case Builtin::BIstdc_leading_zeros_ul:
+  case Builtin::BIstdc_leading_zeros_ull:
+  case Builtin::BIstdc_leading_ones_uc:
+  case Builtin::BIstdc_leading_ones_us:
+  case Builtin::BIstdc_leading_ones_ui:
+  case Builtin::BIstdc_leading_ones_ul:
+  case Builtin::BIstdc_leading_ones_ull:
+  case Builtin::BIstdc_trailing_zeros_uc:
+  case Builtin::BIstdc_trailing_zeros_us:
+  case Builtin::BIstdc_trailing_zeros_ui:
+  case Builtin::BIstdc_trailing_zeros_ul:
+  case Builtin::BIstdc_trailing_zeros_ull:
+  case Builtin::BIstdc_trailing_ones_uc:
+  case Builtin::BIstdc_trailing_ones_us:
+  case Builtin::BIstdc_trailing_ones_ui:
+  case Builtin::BIstdc_trailing_ones_ul:
+  case Builtin::BIstdc_trailing_ones_ull:
+  case Builtin::BIstdc_first_leading_zero_uc:
+  case Builtin::BIstdc_first_leading_zero_us:
+  case Builtin::BIstdc_first_leading_zero_ui:
+  case Builtin::BIstdc_first_leading_zero_ul:
+  case Builtin::BIstdc_first_leading_zero_ull:
+  case Builtin::BIstdc_first_leading_one_uc:
+  case Builtin::BIstdc_first_leading_one_us:
+  case Builtin::BIstdc_first_leading_one_ui:
+  case Builtin::BIstdc_first_leading_one_ul:
+  case Builtin::BIstdc_first_leading_one_ull:
+  case Builtin::BIstdc_first_trailing_zero_uc:
+  case Builtin::BIstdc_first_trailing_zero_us:
+  case Builtin::BIstdc_first_trailing_zero_ui:
+  case Builtin::BIstdc_first_trailing_zero_ul:
+  case Builtin::BIstdc_first_trailing_zero_ull:
+  case Builtin::BIstdc_first_trailing_one_uc:
+  case Builtin::BIstdc_first_trailing_one_us:
+  case Builtin::BIstdc_first_trailing_one_ui:
+  case Builtin::BIstdc_first_trailing_one_ul:
+  case Builtin::BIstdc_first_trailing_one_ull:
+  case Builtin::BIstdc_count_zeros_uc:
+  case Builtin::BIstdc_count_zeros_us:
+  case Builtin::BIstdc_count_zeros_ui:
+  case Builtin::BIstdc_count_zeros_ul:
+  case Builtin::BIstdc_count_zeros_ull:
+  case Builtin::BIstdc_count_ones_uc:
+  case Builtin::BIstdc_count_ones_us:
+  case Builtin::BIstdc_count_ones_ui:
+  case Builtin::BIstdc_count_ones_ul:
+  case Builtin::BIstdc_count_ones_ull:
+  case Builtin::BIstdc_has_single_bit_uc:
+  case Builtin::BIstdc_has_single_bit_us:
+  case Builtin::BIstdc_has_single_bit_ui:
+  case Builtin::BIstdc_has_single_bit_ul:
+  case Builtin::BIstdc_has_single_bit_ull:
+  case Builtin::BIstdc_bit_width_uc:
+  case Builtin::BIstdc_bit_width_us:
+  case Builtin::BIstdc_bit_width_ui:
+  case Builtin::BIstdc_bit_width_ul:
+  case Builtin::BIstdc_bit_width_ull:
+  case Builtin::BIstdc_bit_floor_uc:
+  case Builtin::BIstdc_bit_floor_us:
+  case Builtin::BIstdc_bit_floor_ui:
+  case Builtin::BIstdc_bit_floor_ul:
+  case Builtin::BIstdc_bit_floor_ull:
+  case Builtin::BIstdc_bit_ceil_uc:
+  case Builtin::BIstdc_bit_ceil_us:
+  case Builtin::BIstdc_bit_ceil_ui:
+  case Builtin::BIstdc_bit_ceil_ul:
+  case Builtin::BIstdc_bit_ceil_ull:
   case Builtin::BIstdc_leading_zeros:
   case Builtin::BIstdc_leading_ones:
   case Builtin::BIstdc_trailing_zeros:
@@ -16865,40 +16935,118 @@ bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
     const unsigned ResBitWidth = Info.Ctx.getIntWidth(E->getType());
 
     switch (BuiltinOp) {
+    case Builtin::BIstdc_leading_zeros_uc:
+    case Builtin::BIstdc_leading_zeros_us:
+    case Builtin::BIstdc_leading_zeros_ui:
+    case Builtin::BIstdc_leading_zeros_ul:
+    case Builtin::BIstdc_leading_zeros_ull:
+    case Builtin::BIstdc_leading_zeros:
     case Builtin::BI__builtin_stdc_leading_zeros:
       return Success(APInt(ResBitWidth, Val.countl_zero()), E);
+    case Builtin::BIstdc_leading_ones_uc:
+    case Builtin::BIstdc_leading_ones_us:
+    case Builtin::BIstdc_leading_ones_ui:
+    case Builtin::BIstdc_leading_ones_ul:
+    case Builtin::BIstdc_leading_ones_ull:
+    case Builtin::BIstdc_leading_ones:
     case Builtin::BI__builtin_stdc_leading_ones:
       return Success(APInt(ResBitWidth, Val.countl_one()), E);
+    case Builtin::BIstdc_trailing_zeros_uc:
+    case Builtin::BIstdc_trailing_zeros_us:
+    case Builtin::BIstdc_trailing_zeros_ui:
+    case Builtin::BIstdc_trailing_zeros_ul:
+    case Builtin::BIstdc_trailing_zeros_ull:
+    case Builtin::BIstdc_trailing_zeros:
     case Builtin::BI__builtin_stdc_trailing_zeros:
       return Success(APInt(ResBitWidth, Val.countr_zero()), E);
+    case Builtin::BIstdc_trailing_ones_uc:
+    case Builtin::BIstdc_trailing_ones_us:
+    case Builtin::BIstdc_trailing_ones_ui:
+    case Builtin::BIstdc_trailing_ones_ul:
+    case Builtin::BIstdc_trailing_ones_ull:
+    case Builtin::BIstdc_trailing_ones:
     case Builtin::BI__builtin_stdc_trailing_ones:
       return Success(APInt(ResBitWidth, Val.countr_one()), E);
+    case Builtin::BIstdc_first_leading_zero_uc:
+    case Builtin::BIstdc_first_leading_zero_us:
+    case Builtin::BIstdc_first_leading_zero_ui:
+    case Builtin::BIstdc_first_leading_zero_ul:
+    case Builtin::BIstdc_first_leading_zero_ull:
+    case Builtin::BIstdc_first_leading_zero:
     case Builtin::BI__builtin_stdc_first_leading_zero:
       return Success(
           APInt(ResBitWidth, Val.isAllOnes() ? 0 : Val.countl_one() + 1), E);
+    case Builtin::BIstdc_first_leading_one_uc:
+    case Builtin::BIstdc_first_leading_one_us:
+    case Builtin::BIstdc_first_leading_one_ui:
+    case Builtin::BIstdc_first_leading_one_ul:
+    case Builtin::BIstdc_first_leading_one_ull:
+    case Builtin::BIstdc_first_leading_one:
     case Builtin::BI__builtin_stdc_first_leading_one:
       return Success(
           APInt(ResBitWidth, Val.isZero() ? 0 : Val.countl_zero() + 1), E);
+    case Builtin::BIstdc_first_trailing_zero_uc:
+    case Builtin::BIstdc_first_trailing_zero_us:
+    case Builtin::BIstdc_first_trailing_zero_ui:
+    case Builtin::BIstdc_first_trailing_zero_ul:
+    case Builtin::BIstdc_first_trailing_zero_ull:
+    case Builtin::BIstdc_first_trailing_zero:
     case Builtin::BI__builtin_stdc_first_trailing_zero:
       return Success(
           APInt(ResBitWidth, Val.isAllOnes() ? 0 : Val.countr_one() + 1), E);
+    case Builtin::BIstdc_first_trailing_one_uc:
+    case Builtin::BIstdc_first_trailing_one_us:
+    case Builtin::BIstdc_first_trailing_one_ui:
+    case Builtin::BIstdc_first_trailing_one_ul:
+    case Builtin::BIstdc_first_trailing_one_ull:
+    case Builtin::BIstdc_first_trailing_one:
     case Builtin::BI__builtin_stdc_first_trailing_one:
       return Success(
           APInt(ResBitWidth, Val.isZero() ? 0 : Val.countr_zero() + 1), E);
+    case Builtin::BIstdc_count_zeros_uc:
+    case Builtin::BIstdc_count_zeros_us:
+    case Builtin::BIstdc_count_zeros_ui:
+    case Builtin::BIstdc_count_zeros_ul:
+    case Builtin::BIstdc_count_zeros_ull:
+    case Builtin::BIstdc_count_zeros:
     case Builtin::BI__builtin_stdc_count_zeros: {
       APInt Cnt(ResBitWidth, BitWidth - Val.popcount());
       return Success(APSInt(Cnt, /*IsUnsigned*/ true), E);
     }
+    case Builtin::BIstdc_count_ones_uc:
+    case Builtin::BIstdc_count_ones_us:
+    case Builtin::BIstdc_count_ones_ui:
+    case Builtin::BIstdc_count_ones_ul:
+    case Builtin::BIstdc_count_ones_ull:
+    case Builtin::BIstdc_count_ones:
     case Builtin::BI__builtin_stdc_count_ones: {
       APInt Cnt(ResBitWidth, Val.popcount());
       return Success(APSInt(Cnt, /*IsUnsigned*/ true), E);
     }
+    case Builtin::BIstdc_has_single_bit_uc:
+    case Builtin::BIstdc_has_single_bit_us:
+    case Builtin::BIstdc_has_single_bit_ui:
+    case Builtin::BIstdc_has_single_bit_ul:
+    case Builtin::BIstdc_has_single_bit_ull:
+    case Builtin::BIstdc_has_single_bit:
     case Builtin::BI__builtin_stdc_has_single_bit: {
       APInt Res(ResBitWidth, Val.popcount() == 1 ? 1 : 0);
       return Success(APSInt(Res, /*IsUnsigned*/ true), E);
     }
+    case Builtin::BIstdc_bit_width_uc:
+    case Builtin::BIstdc_bit_width_us:
+    case Builtin::BIstdc_bit_width_ui:
+    case Builtin::BIstdc_bit_width_ul:
+    case Builtin::BIstdc_bit_width_ull:
+    case Builtin::BIstdc_bit_width:
     case Builtin::BI__builtin_stdc_bit_width:
       return Success(APInt(ResBitWidth, BitWidth - Val.countl_zero()), E);
+    case Builtin::BIstdc_bit_floor_uc:
+    case Builtin::BIstdc_bit_floor_us:
+    case Builtin::BIstdc_bit_floor_ui:
+    case Builtin::BIstdc_bit_floor_ul:
+    case Builtin::BIstdc_bit_floor_ull:
+    case Builtin::BIstdc_bit_floor:
     case Builtin::BI__builtin_stdc_bit_floor: {
       if (Val.isZero())
         return Success(APInt(BitWidth, 0), E);
@@ -16906,6 +17054,12 @@ bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
       return Success(
           APSInt(APInt::getOneBitSet(BitWidth, Exp), /*IsUnsigned*/ true), E);
     }
+    case Builtin::BIstdc_bit_ceil_uc:
+    case Builtin::BIstdc_bit_ceil_us:
+    case Builtin::BIstdc_bit_ceil_ui:
+    case Builtin::BIstdc_bit_ceil_ul:
+    case Builtin::BIstdc_bit_ceil_ull:
+    case Builtin::BIstdc_bit_ceil:
     case Builtin::BI__builtin_stdc_bit_ceil: {
       if (Val.ule(1))
         return Success(APSInt(APInt(BitWidth, 1), /*IsUnsigned*/ true), E);

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3790,37 +3790,92 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI_rotr64:
     return emitRotate(E, true);
 
+  case Builtin::BIstdc_leading_zeros_uc:
+  case Builtin::BIstdc_leading_zeros_us:
+  case Builtin::BIstdc_leading_zeros_ui:
+  case Builtin::BIstdc_leading_zeros_ul:
+  case Builtin::BIstdc_leading_zeros_ull:
   case Builtin::BIstdc_leading_zeros:
   case Builtin::BI__builtin_stdc_leading_zeros:
     return emitStdcCountIntrinsic(E, Intrinsic::ctlz, /*InvertArg=*/false);
+  case Builtin::BIstdc_leading_ones_uc:
+  case Builtin::BIstdc_leading_ones_us:
+  case Builtin::BIstdc_leading_ones_ui:
+  case Builtin::BIstdc_leading_ones_ul:
+  case Builtin::BIstdc_leading_ones_ull:
   case Builtin::BIstdc_leading_ones:
   case Builtin::BI__builtin_stdc_leading_ones:
     return emitStdcCountIntrinsic(E, Intrinsic::ctlz, /*InvertArg=*/true);
+  case Builtin::BIstdc_trailing_zeros_uc:
+  case Builtin::BIstdc_trailing_zeros_us:
+  case Builtin::BIstdc_trailing_zeros_ui:
+  case Builtin::BIstdc_trailing_zeros_ul:
+  case Builtin::BIstdc_trailing_zeros_ull:
   case Builtin::BIstdc_trailing_zeros:
   case Builtin::BI__builtin_stdc_trailing_zeros:
     return emitStdcCountIntrinsic(E, Intrinsic::cttz, /*InvertArg=*/false);
+  case Builtin::BIstdc_trailing_ones_uc:
+  case Builtin::BIstdc_trailing_ones_us:
+  case Builtin::BIstdc_trailing_ones_ui:
+  case Builtin::BIstdc_trailing_ones_ul:
+  case Builtin::BIstdc_trailing_ones_ull:
   case Builtin::BIstdc_trailing_ones:
   case Builtin::BI__builtin_stdc_trailing_ones:
     return emitStdcCountIntrinsic(E, Intrinsic::cttz, /*InvertArg=*/true);
+  case Builtin::BIstdc_first_leading_zero_uc:
+  case Builtin::BIstdc_first_leading_zero_us:
+  case Builtin::BIstdc_first_leading_zero_ui:
+  case Builtin::BIstdc_first_leading_zero_ul:
+  case Builtin::BIstdc_first_leading_zero_ull:
   case Builtin::BIstdc_first_leading_zero:
   case Builtin::BI__builtin_stdc_first_leading_zero:
     return emitStdcFirstBit(E, Intrinsic::ctlz, /*InvertArg=*/true);
+  case Builtin::BIstdc_first_leading_one_uc:
+  case Builtin::BIstdc_first_leading_one_us:
+  case Builtin::BIstdc_first_leading_one_ui:
+  case Builtin::BIstdc_first_leading_one_ul:
+  case Builtin::BIstdc_first_leading_one_ull:
   case Builtin::BIstdc_first_leading_one:
   case Builtin::BI__builtin_stdc_first_leading_one:
     return emitStdcFirstBit(E, Intrinsic::ctlz, /*InvertArg=*/false);
+  case Builtin::BIstdc_first_trailing_zero_uc:
+  case Builtin::BIstdc_first_trailing_zero_us:
+  case Builtin::BIstdc_first_trailing_zero_ui:
+  case Builtin::BIstdc_first_trailing_zero_ul:
+  case Builtin::BIstdc_first_trailing_zero_ull:
   case Builtin::BIstdc_first_trailing_zero:
   case Builtin::BI__builtin_stdc_first_trailing_zero:
     return emitStdcFirstBit(E, Intrinsic::cttz, /*InvertArg=*/true);
+  case Builtin::BIstdc_first_trailing_one_uc:
+  case Builtin::BIstdc_first_trailing_one_us:
+  case Builtin::BIstdc_first_trailing_one_ui:
+  case Builtin::BIstdc_first_trailing_one_ul:
+  case Builtin::BIstdc_first_trailing_one_ull:
   case Builtin::BIstdc_first_trailing_one:
   case Builtin::BI__builtin_stdc_first_trailing_one:
     return emitStdcFirstBit(E, Intrinsic::cttz, /*InvertArg=*/false);
+  case Builtin::BIstdc_count_zeros_uc:
+  case Builtin::BIstdc_count_zeros_us:
+  case Builtin::BIstdc_count_zeros_ui:
+  case Builtin::BIstdc_count_zeros_ul:
+  case Builtin::BIstdc_count_zeros_ull:
   case Builtin::BIstdc_count_zeros:
   case Builtin::BI__builtin_stdc_count_zeros:
     return emitStdcBitWidthMinus(E, Intrinsic::ctpop, /*IsPop=*/true);
+  case Builtin::BIstdc_count_ones_uc:
+  case Builtin::BIstdc_count_ones_us:
+  case Builtin::BIstdc_count_ones_ui:
+  case Builtin::BIstdc_count_ones_ul:
+  case Builtin::BIstdc_count_ones_ull:
   case Builtin::BIstdc_count_ones:
   case Builtin::BI__builtin_stdc_count_ones:
     return emitStdcCountIntrinsic(E, Intrinsic::ctpop, /*InvertArg=*/false,
                                   /*IsPop=*/true);
+  case Builtin::BIstdc_has_single_bit_uc:
+  case Builtin::BIstdc_has_single_bit_us:
+  case Builtin::BIstdc_has_single_bit_ui:
+  case Builtin::BIstdc_has_single_bit_ul:
+  case Builtin::BIstdc_has_single_bit_ull:
   case Builtin::BIstdc_has_single_bit:
   case Builtin::BI__builtin_stdc_has_single_bit: {
     Value *ArgValue = EmitScalarExpr(E->getArg(0));
@@ -3830,9 +3885,19 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     Value *PopCnt = Builder.CreateCall(F, ArgValue);
     return RValue::get(Builder.CreateICmpEQ(PopCnt, One));
   }
+  case Builtin::BIstdc_bit_width_uc:
+  case Builtin::BIstdc_bit_width_us:
+  case Builtin::BIstdc_bit_width_ui:
+  case Builtin::BIstdc_bit_width_ul:
+  case Builtin::BIstdc_bit_width_ull:
   case Builtin::BIstdc_bit_width:
   case Builtin::BI__builtin_stdc_bit_width:
     return emitStdcBitWidthMinus(E, Intrinsic::ctlz, /*IsPop=*/false);
+  case Builtin::BIstdc_bit_floor_uc:
+  case Builtin::BIstdc_bit_floor_us:
+  case Builtin::BIstdc_bit_floor_ui:
+  case Builtin::BIstdc_bit_floor_ul:
+  case Builtin::BIstdc_bit_floor_ull:
   case Builtin::BIstdc_bit_floor:
   case Builtin::BI__builtin_stdc_bit_floor: {
     Value *ArgValue = EmitScalarExpr(E->getArg(0));
@@ -3849,6 +3914,11 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     Value *Result = Builder.CreateSelect(IsZero, Zero, Shifted);
     return RValue::get(Result);
   }
+  case Builtin::BIstdc_bit_ceil_uc:
+  case Builtin::BIstdc_bit_ceil_us:
+  case Builtin::BIstdc_bit_ceil_ui:
+  case Builtin::BIstdc_bit_ceil_ul:
+  case Builtin::BIstdc_bit_ceil_ull:
   case Builtin::BIstdc_bit_ceil:
   case Builtin::BI__builtin_stdc_bit_ceil: {
     Value *ArgValue = EmitScalarExpr(E->getArg(0));

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -3859,26 +3859,11 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
   case Builtin::BI__builtin_stdc_bit_ceil:
   case Builtin::BIstdc_bit_floor:
   case Builtin::BIstdc_bit_ceil:
-  case Builtin::BIstdc_bit_floor_uc:
-  case Builtin::BIstdc_bit_floor_us:
-  case Builtin::BIstdc_bit_floor_ui:
-  case Builtin::BIstdc_bit_floor_ul:
-  case Builtin::BIstdc_bit_floor_ull:
-  case Builtin::BIstdc_bit_ceil_uc:
-  case Builtin::BIstdc_bit_ceil_us:
-  case Builtin::BIstdc_bit_ceil_ui:
-  case Builtin::BIstdc_bit_ceil_ul:
-  case Builtin::BIstdc_bit_ceil_ull:
     if (BuiltinStdCBuiltin(*this, TheCall, QualType()))
       return ExprError();
     break;
   case Builtin::BI__builtin_stdc_has_single_bit:
   case Builtin::BIstdc_has_single_bit:
-  case Builtin::BIstdc_has_single_bit_uc:
-  case Builtin::BIstdc_has_single_bit_us:
-  case Builtin::BIstdc_has_single_bit_ui:
-  case Builtin::BIstdc_has_single_bit_ul:
-  case Builtin::BIstdc_has_single_bit_ull:
     if (BuiltinStdCBuiltin(*this, TheCall, Context.BoolTy))
       return ExprError();
     break;
@@ -3904,61 +3889,6 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
   case Builtin::BIstdc_count_zeros:
   case Builtin::BIstdc_count_ones:
   case Builtin::BIstdc_bit_width:
-  case Builtin::BIstdc_leading_zeros_uc:
-  case Builtin::BIstdc_leading_zeros_us:
-  case Builtin::BIstdc_leading_zeros_ui:
-  case Builtin::BIstdc_leading_zeros_ul:
-  case Builtin::BIstdc_leading_zeros_ull:
-  case Builtin::BIstdc_leading_ones_uc:
-  case Builtin::BIstdc_leading_ones_us:
-  case Builtin::BIstdc_leading_ones_ui:
-  case Builtin::BIstdc_leading_ones_ul:
-  case Builtin::BIstdc_leading_ones_ull:
-  case Builtin::BIstdc_trailing_zeros_uc:
-  case Builtin::BIstdc_trailing_zeros_us:
-  case Builtin::BIstdc_trailing_zeros_ui:
-  case Builtin::BIstdc_trailing_zeros_ul:
-  case Builtin::BIstdc_trailing_zeros_ull:
-  case Builtin::BIstdc_trailing_ones_uc:
-  case Builtin::BIstdc_trailing_ones_us:
-  case Builtin::BIstdc_trailing_ones_ui:
-  case Builtin::BIstdc_trailing_ones_ul:
-  case Builtin::BIstdc_trailing_ones_ull:
-  case Builtin::BIstdc_first_leading_zero_uc:
-  case Builtin::BIstdc_first_leading_zero_us:
-  case Builtin::BIstdc_first_leading_zero_ui:
-  case Builtin::BIstdc_first_leading_zero_ul:
-  case Builtin::BIstdc_first_leading_zero_ull:
-  case Builtin::BIstdc_first_leading_one_uc:
-  case Builtin::BIstdc_first_leading_one_us:
-  case Builtin::BIstdc_first_leading_one_ui:
-  case Builtin::BIstdc_first_leading_one_ul:
-  case Builtin::BIstdc_first_leading_one_ull:
-  case Builtin::BIstdc_first_trailing_zero_uc:
-  case Builtin::BIstdc_first_trailing_zero_us:
-  case Builtin::BIstdc_first_trailing_zero_ui:
-  case Builtin::BIstdc_first_trailing_zero_ul:
-  case Builtin::BIstdc_first_trailing_zero_ull:
-  case Builtin::BIstdc_first_trailing_one_uc:
-  case Builtin::BIstdc_first_trailing_one_us:
-  case Builtin::BIstdc_first_trailing_one_ui:
-  case Builtin::BIstdc_first_trailing_one_ul:
-  case Builtin::BIstdc_first_trailing_one_ull:
-  case Builtin::BIstdc_count_zeros_uc:
-  case Builtin::BIstdc_count_zeros_us:
-  case Builtin::BIstdc_count_zeros_ui:
-  case Builtin::BIstdc_count_zeros_ul:
-  case Builtin::BIstdc_count_zeros_ull:
-  case Builtin::BIstdc_count_ones_uc:
-  case Builtin::BIstdc_count_ones_us:
-  case Builtin::BIstdc_count_ones_ui:
-  case Builtin::BIstdc_count_ones_ul:
-  case Builtin::BIstdc_count_ones_ull:
-  case Builtin::BIstdc_bit_width_uc:
-  case Builtin::BIstdc_bit_width_us:
-  case Builtin::BIstdc_bit_width_ui:
-  case Builtin::BIstdc_bit_width_ul:
-  case Builtin::BIstdc_bit_width_ull:
     if (BuiltinStdCBuiltin(*this, TheCall, Context.UnsignedIntTy))
       return ExprError();
     break;

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -3859,11 +3859,26 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
   case Builtin::BI__builtin_stdc_bit_ceil:
   case Builtin::BIstdc_bit_floor:
   case Builtin::BIstdc_bit_ceil:
+  case Builtin::BIstdc_bit_floor_uc:
+  case Builtin::BIstdc_bit_floor_us:
+  case Builtin::BIstdc_bit_floor_ui:
+  case Builtin::BIstdc_bit_floor_ul:
+  case Builtin::BIstdc_bit_floor_ull:
+  case Builtin::BIstdc_bit_ceil_uc:
+  case Builtin::BIstdc_bit_ceil_us:
+  case Builtin::BIstdc_bit_ceil_ui:
+  case Builtin::BIstdc_bit_ceil_ul:
+  case Builtin::BIstdc_bit_ceil_ull:
     if (BuiltinStdCBuiltin(*this, TheCall, QualType()))
       return ExprError();
     break;
   case Builtin::BI__builtin_stdc_has_single_bit:
   case Builtin::BIstdc_has_single_bit:
+  case Builtin::BIstdc_has_single_bit_uc:
+  case Builtin::BIstdc_has_single_bit_us:
+  case Builtin::BIstdc_has_single_bit_ui:
+  case Builtin::BIstdc_has_single_bit_ul:
+  case Builtin::BIstdc_has_single_bit_ull:
     if (BuiltinStdCBuiltin(*this, TheCall, Context.BoolTy))
       return ExprError();
     break;
@@ -3889,6 +3904,61 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
   case Builtin::BIstdc_count_zeros:
   case Builtin::BIstdc_count_ones:
   case Builtin::BIstdc_bit_width:
+  case Builtin::BIstdc_leading_zeros_uc:
+  case Builtin::BIstdc_leading_zeros_us:
+  case Builtin::BIstdc_leading_zeros_ui:
+  case Builtin::BIstdc_leading_zeros_ul:
+  case Builtin::BIstdc_leading_zeros_ull:
+  case Builtin::BIstdc_leading_ones_uc:
+  case Builtin::BIstdc_leading_ones_us:
+  case Builtin::BIstdc_leading_ones_ui:
+  case Builtin::BIstdc_leading_ones_ul:
+  case Builtin::BIstdc_leading_ones_ull:
+  case Builtin::BIstdc_trailing_zeros_uc:
+  case Builtin::BIstdc_trailing_zeros_us:
+  case Builtin::BIstdc_trailing_zeros_ui:
+  case Builtin::BIstdc_trailing_zeros_ul:
+  case Builtin::BIstdc_trailing_zeros_ull:
+  case Builtin::BIstdc_trailing_ones_uc:
+  case Builtin::BIstdc_trailing_ones_us:
+  case Builtin::BIstdc_trailing_ones_ui:
+  case Builtin::BIstdc_trailing_ones_ul:
+  case Builtin::BIstdc_trailing_ones_ull:
+  case Builtin::BIstdc_first_leading_zero_uc:
+  case Builtin::BIstdc_first_leading_zero_us:
+  case Builtin::BIstdc_first_leading_zero_ui:
+  case Builtin::BIstdc_first_leading_zero_ul:
+  case Builtin::BIstdc_first_leading_zero_ull:
+  case Builtin::BIstdc_first_leading_one_uc:
+  case Builtin::BIstdc_first_leading_one_us:
+  case Builtin::BIstdc_first_leading_one_ui:
+  case Builtin::BIstdc_first_leading_one_ul:
+  case Builtin::BIstdc_first_leading_one_ull:
+  case Builtin::BIstdc_first_trailing_zero_uc:
+  case Builtin::BIstdc_first_trailing_zero_us:
+  case Builtin::BIstdc_first_trailing_zero_ui:
+  case Builtin::BIstdc_first_trailing_zero_ul:
+  case Builtin::BIstdc_first_trailing_zero_ull:
+  case Builtin::BIstdc_first_trailing_one_uc:
+  case Builtin::BIstdc_first_trailing_one_us:
+  case Builtin::BIstdc_first_trailing_one_ui:
+  case Builtin::BIstdc_first_trailing_one_ul:
+  case Builtin::BIstdc_first_trailing_one_ull:
+  case Builtin::BIstdc_count_zeros_uc:
+  case Builtin::BIstdc_count_zeros_us:
+  case Builtin::BIstdc_count_zeros_ui:
+  case Builtin::BIstdc_count_zeros_ul:
+  case Builtin::BIstdc_count_zeros_ull:
+  case Builtin::BIstdc_count_ones_uc:
+  case Builtin::BIstdc_count_ones_us:
+  case Builtin::BIstdc_count_ones_ui:
+  case Builtin::BIstdc_count_ones_ul:
+  case Builtin::BIstdc_count_ones_ull:
+  case Builtin::BIstdc_bit_width_uc:
+  case Builtin::BIstdc_bit_width_us:
+  case Builtin::BIstdc_bit_width_ui:
+  case Builtin::BIstdc_bit_width_ul:
+  case Builtin::BIstdc_bit_width_ull:
     if (BuiltinStdCBuiltin(*this, TheCall, Context.UnsignedIntTy))
       return ExprError();
     break;

--- a/clang/test/CodeGen/Inputs/stdbit.h
+++ b/clang/test/CodeGen/Inputs/stdbit.h
@@ -16,4 +16,88 @@
 #define stdc_bit_floor(x) (__builtin_stdc_bit_floor((x)))
 #define stdc_bit_ceil(x) (__builtin_stdc_bit_ceil((x)))
 
+unsigned int stdc_leading_zeros_uc(unsigned char);
+unsigned int stdc_leading_zeros_us(unsigned short);
+unsigned int stdc_leading_zeros_ui(unsigned int);
+unsigned int stdc_leading_zeros_ul(unsigned long);
+unsigned int stdc_leading_zeros_ull(unsigned long long);
+
+unsigned int stdc_leading_ones_uc(unsigned char);
+unsigned int stdc_leading_ones_us(unsigned short);
+unsigned int stdc_leading_ones_ui(unsigned int);
+unsigned int stdc_leading_ones_ul(unsigned long);
+unsigned int stdc_leading_ones_ull(unsigned long long);
+
+unsigned int stdc_trailing_zeros_uc(unsigned char);
+unsigned int stdc_trailing_zeros_us(unsigned short);
+unsigned int stdc_trailing_zeros_ui(unsigned int);
+unsigned int stdc_trailing_zeros_ul(unsigned long);
+unsigned int stdc_trailing_zeros_ull(unsigned long long);
+
+unsigned int stdc_trailing_ones_uc(unsigned char);
+unsigned int stdc_trailing_ones_us(unsigned short);
+unsigned int stdc_trailing_ones_ui(unsigned int);
+unsigned int stdc_trailing_ones_ul(unsigned long);
+unsigned int stdc_trailing_ones_ull(unsigned long long);
+
+unsigned int stdc_first_leading_zero_uc(unsigned char);
+unsigned int stdc_first_leading_zero_us(unsigned short);
+unsigned int stdc_first_leading_zero_ui(unsigned int);
+unsigned int stdc_first_leading_zero_ul(unsigned long);
+unsigned int stdc_first_leading_zero_ull(unsigned long long);
+
+unsigned int stdc_first_leading_one_uc(unsigned char);
+unsigned int stdc_first_leading_one_us(unsigned short);
+unsigned int stdc_first_leading_one_ui(unsigned int);
+unsigned int stdc_first_leading_one_ul(unsigned long);
+unsigned int stdc_first_leading_one_ull(unsigned long long);
+
+unsigned int stdc_first_trailing_zero_uc(unsigned char);
+unsigned int stdc_first_trailing_zero_us(unsigned short);
+unsigned int stdc_first_trailing_zero_ui(unsigned int);
+unsigned int stdc_first_trailing_zero_ul(unsigned long);
+unsigned int stdc_first_trailing_zero_ull(unsigned long long);
+
+unsigned int stdc_first_trailing_one_uc(unsigned char);
+unsigned int stdc_first_trailing_one_us(unsigned short);
+unsigned int stdc_first_trailing_one_ui(unsigned int);
+unsigned int stdc_first_trailing_one_ul(unsigned long);
+unsigned int stdc_first_trailing_one_ull(unsigned long long);
+
+unsigned int stdc_count_zeros_uc(unsigned char);
+unsigned int stdc_count_zeros_us(unsigned short);
+unsigned int stdc_count_zeros_ui(unsigned int);
+unsigned int stdc_count_zeros_ul(unsigned long);
+unsigned int stdc_count_zeros_ull(unsigned long long);
+
+unsigned int stdc_count_ones_uc(unsigned char);
+unsigned int stdc_count_ones_us(unsigned short);
+unsigned int stdc_count_ones_ui(unsigned int);
+unsigned int stdc_count_ones_ul(unsigned long);
+unsigned int stdc_count_ones_ull(unsigned long long);
+
+_Bool stdc_has_single_bit_uc(unsigned char);
+_Bool stdc_has_single_bit_us(unsigned short);
+_Bool stdc_has_single_bit_ui(unsigned int);
+_Bool stdc_has_single_bit_ul(unsigned long);
+_Bool stdc_has_single_bit_ull(unsigned long long);
+
+unsigned int stdc_bit_width_uc(unsigned char);
+unsigned int stdc_bit_width_us(unsigned short);
+unsigned int stdc_bit_width_ui(unsigned int);
+unsigned int stdc_bit_width_ul(unsigned long);
+unsigned int stdc_bit_width_ull(unsigned long long);
+
+unsigned char stdc_bit_floor_uc(unsigned char);
+unsigned short stdc_bit_floor_us(unsigned short);
+unsigned int stdc_bit_floor_ui(unsigned int);
+unsigned long stdc_bit_floor_ul(unsigned long);
+unsigned long long stdc_bit_floor_ull(unsigned long long);
+
+unsigned char stdc_bit_ceil_uc(unsigned char);
+unsigned short stdc_bit_ceil_us(unsigned short);
+unsigned int stdc_bit_ceil_ui(unsigned int);
+unsigned long stdc_bit_ceil_ul(unsigned long);
+unsigned long long stdc_bit_ceil_ull(unsigned long long);
+
 #endif

--- a/clang/test/CodeGen/builtin-stdc-bit-functions.c
+++ b/clang/test/CodeGen/builtin-stdc-bit-functions.c
@@ -1,7 +1,6 @@
 // RUN: %clang_cc1 -ffreestanding -std=c23 %s -emit-llvm -o - | FileCheck %s
 // RUN: %if clang-target-64-bits %{ %clang_cc1 -ffreestanding -std=c23 %s -emit-llvm -o - | FileCheck %s --check-prefix=INT128 %}
 // RUN: %clang_cc1 -std=c23 -isystem %S/Inputs -DTEST_LIB_SPELLINGS %s -emit-llvm -o - | FileCheck %s --check-prefix=LIB
-// RUN: %if clang-target-64-bits %{ %clang_cc1 -std=c23 -isystem %S/Inputs -DTEST_LIB_SPELLINGS -DTEST_UL_TYPED %s -emit-llvm -o - | FileCheck %s --check-prefix=LIBL %}
 
 // CHECK-LABEL: test_leading_zeros
 // CHECK: call i8 @llvm.ctlz.i8(i8 %{{.*}}, i1 false)
@@ -395,6 +394,45 @@ void test_int128_floor_ceil(unsigned __int128 u128) {
 }
 #endif
 
+// CHECK-LABEL: test_ulong
+// CHECK: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// CHECK: xor {{i32|i64}} %{{.*}}, -1
+// CHECK: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// CHECK: call {{i32|i64}} @llvm.cttz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// CHECK: xor {{i32|i64}} %{{.*}}, -1
+// CHECK: call {{i32|i64}} @llvm.cttz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// CHECK: xor {{i32|i64}} %{{.*}}, -1
+// CHECK: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// CHECK: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// CHECK: xor {{i32|i64}} %{{.*}}, -1
+// CHECK: call {{i32|i64}} @llvm.cttz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// CHECK: call {{i32|i64}} @llvm.cttz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// CHECK: call {{i32|i64}} @llvm.ctpop.{{i32|i64}}({{i32|i64}} %{{.*}})
+// CHECK: call {{i32|i64}} @llvm.ctpop.{{i32|i64}}({{i32|i64}} %{{.*}})
+// CHECK: call {{i32|i64}} @llvm.ctpop.{{i32|i64}}({{i32|i64}} %{{.*}})
+// CHECK: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// CHECK: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 true)
+// CHECK: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+void test_ulong(unsigned long ul) {
+  volatile unsigned r;
+  volatile unsigned long rl;
+  volatile _Bool rb;
+  r  = __builtin_stdc_leading_zeros(ul);
+  r  = __builtin_stdc_leading_ones(ul);
+  r  = __builtin_stdc_trailing_zeros(ul);
+  r  = __builtin_stdc_trailing_ones(ul);
+  r  = __builtin_stdc_first_leading_zero(ul);
+  r  = __builtin_stdc_first_leading_one(ul);
+  r  = __builtin_stdc_first_trailing_zero(ul);
+  r  = __builtin_stdc_first_trailing_one(ul);
+  r  = __builtin_stdc_count_zeros(ul);
+  r  = __builtin_stdc_count_ones(ul);
+  rb = __builtin_stdc_has_single_bit(ul);
+  r  = __builtin_stdc_bit_width(ul);
+  rl = __builtin_stdc_bit_floor(ul);
+  rl = __builtin_stdc_bit_ceil(ul);
+}
+
 #ifdef TEST_LIB_SPELLINGS
 #include <stdbit.h>
 
@@ -695,26 +733,25 @@ void test_lib_typed_bit_ceil(unsigned char uc, unsigned short us,
   volatile unsigned long long rll = stdc_bit_ceil_ull(ull);
 }
 
-#ifdef TEST_UL_TYPED
-// LIBL-LABEL: test_lib_typed_ul
-// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
-// LIBL: xor i64 %{{.*}}, -1
-// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
-// LIBL: call i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
-// LIBL: xor i64 %{{.*}}, -1
-// LIBL: call i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
-// LIBL: xor i64 %{{.*}}, -1
-// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
-// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
-// LIBL: xor i64 %{{.*}}, -1
-// LIBL: call i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
-// LIBL: call i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
-// LIBL: call i64 @llvm.ctpop.i64(i64 %{{.*}})
-// LIBL: call i64 @llvm.ctpop.i64(i64 %{{.*}})
-// LIBL: call i64 @llvm.ctpop.i64(i64 %{{.*}})
-// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
-// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 true)
-// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+// LIB-LABEL: test_lib_typed_ul
+// LIB: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// LIB: xor {{i32|i64}} %{{.*}}, -1
+// LIB: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// LIB: call {{i32|i64}} @llvm.cttz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// LIB: xor {{i32|i64}} %{{.*}}, -1
+// LIB: call {{i32|i64}} @llvm.cttz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// LIB: xor {{i32|i64}} %{{.*}}, -1
+// LIB: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// LIB: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// LIB: xor {{i32|i64}} %{{.*}}, -1
+// LIB: call {{i32|i64}} @llvm.cttz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// LIB: call {{i32|i64}} @llvm.cttz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// LIB: call {{i32|i64}} @llvm.ctpop.{{i32|i64}}({{i32|i64}} %{{.*}})
+// LIB: call {{i32|i64}} @llvm.ctpop.{{i32|i64}}({{i32|i64}} %{{.*}})
+// LIB: call {{i32|i64}} @llvm.ctpop.{{i32|i64}}({{i32|i64}} %{{.*}})
+// LIB: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
+// LIB: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 true)
+// LIB: call {{i32|i64}} @llvm.ctlz.{{i32|i64}}({{i32|i64}} %{{.*}}, i1 false)
 void test_lib_typed_ul(unsigned long ul) {
   volatile unsigned r;
   volatile unsigned long rl;
@@ -734,5 +771,4 @@ void test_lib_typed_ul(unsigned long ul) {
   rl = stdc_bit_floor_ul(ul);
   rl = stdc_bit_ceil_ul(ul);
 }
-#endif
 #endif

--- a/clang/test/CodeGen/builtin-stdc-bit-functions.c
+++ b/clang/test/CodeGen/builtin-stdc-bit-functions.c
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -ffreestanding -std=c23 %s -emit-llvm -o - | FileCheck %s
 // RUN: %if clang-target-64-bits %{ %clang_cc1 -ffreestanding -std=c23 %s -emit-llvm -o - | FileCheck %s --check-prefix=INT128 %}
-// RUN: %clang_cc1 -ffreestanding -std=c23 -isystem %S/Inputs -DTEST_LIB_SPELLINGS %s -emit-llvm -o - | FileCheck %s --check-prefix=LIB
+// RUN: %clang_cc1 -std=c23 -isystem %S/Inputs -DTEST_LIB_SPELLINGS %s -emit-llvm -o - | FileCheck %s --check-prefix=LIB
+// RUN: %if clang-target-64-bits %{ %clang_cc1 -std=c23 -isystem %S/Inputs -DTEST_LIB_SPELLINGS -DTEST_UL_TYPED %s -emit-llvm -o - | FileCheck %s --check-prefix=LIBL %}
 
 // CHECK-LABEL: test_leading_zeros
 // CHECK: call i8 @llvm.ctlz.i8(i8 %{{.*}}, i1 false)
@@ -483,4 +484,255 @@ void test_lib_bit_floor(unsigned ui) {
 void test_lib_bit_ceil(unsigned ui) {
   volatile unsigned r = stdc_bit_ceil(ui);
 }
+
+// LIB-LABEL: test_lib_typed_leading_zeros
+// LIB: call i8 @llvm.ctlz.i8(i8 %{{.*}}, i1 false)
+// LIB: call i16 @llvm.ctlz.i16(i16 %{{.*}}, i1 false)
+// LIB: call i32 @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
+// LIB: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+void test_lib_typed_leading_zeros(unsigned char uc, unsigned short us,
+                                  unsigned int ui, unsigned long long ull) {
+  volatile unsigned r;
+  r = stdc_leading_zeros_uc(uc);
+  r = stdc_leading_zeros_us(us);
+  r = stdc_leading_zeros_ui(ui);
+  r = stdc_leading_zeros_ull(ull);
+}
+
+// LIB-LABEL: test_lib_typed_leading_ones
+// LIB: xor i8 %{{.*}}, -1
+// LIB: call i8 @llvm.ctlz.i8(i8 %{{.*}}, i1 false)
+// LIB: xor i16 %{{.*}}, -1
+// LIB: call i16 @llvm.ctlz.i16(i16 %{{.*}}, i1 false)
+// LIB: xor i32 %{{.*}}, -1
+// LIB: call i32 @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
+// LIB: xor i64 %{{.*}}, -1
+// LIB: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+void test_lib_typed_leading_ones(unsigned char uc, unsigned short us,
+                                 unsigned int ui, unsigned long long ull) {
+  volatile unsigned r;
+  r = stdc_leading_ones_uc(uc);
+  r = stdc_leading_ones_us(us);
+  r = stdc_leading_ones_ui(ui);
+  r = stdc_leading_ones_ull(ull);
+}
+
+// LIB-LABEL: test_lib_typed_trailing_zeros
+// LIB: call i8 @llvm.cttz.i8(i8 %{{.*}}, i1 false)
+// LIB: call i16 @llvm.cttz.i16(i16 %{{.*}}, i1 false)
+// LIB: call i32 @llvm.cttz.i32(i32 %{{.*}}, i1 false)
+// LIB: call i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
+void test_lib_typed_trailing_zeros(unsigned char uc, unsigned short us,
+                                   unsigned int ui, unsigned long long ull) {
+  volatile unsigned r;
+  r = stdc_trailing_zeros_uc(uc);
+  r = stdc_trailing_zeros_us(us);
+  r = stdc_trailing_zeros_ui(ui);
+  r = stdc_trailing_zeros_ull(ull);
+}
+
+// LIB-LABEL: test_lib_typed_trailing_ones
+// LIB: xor i8 %{{.*}}, -1
+// LIB: call i8 @llvm.cttz.i8(i8 %{{.*}}, i1 false)
+// LIB: xor i16 %{{.*}}, -1
+// LIB: call i16 @llvm.cttz.i16(i16 %{{.*}}, i1 false)
+// LIB: xor i32 %{{.*}}, -1
+// LIB: call i32 @llvm.cttz.i32(i32 %{{.*}}, i1 false)
+// LIB: xor i64 %{{.*}}, -1
+// LIB: call i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
+void test_lib_typed_trailing_ones(unsigned char uc, unsigned short us,
+                                  unsigned int ui, unsigned long long ull) {
+  volatile unsigned r;
+  r = stdc_trailing_ones_uc(uc);
+  r = stdc_trailing_ones_us(us);
+  r = stdc_trailing_ones_ui(ui);
+  r = stdc_trailing_ones_ull(ull);
+}
+
+// LIB-LABEL: test_lib_typed_first_leading_zero
+// LIB: xor i8 %{{.*}}, -1
+// LIB: call i8 @llvm.ctlz.i8(i8 %{{.*}}, i1 false)
+// LIB: xor i16 %{{.*}}, -1
+// LIB: call i16 @llvm.ctlz.i16(i16 %{{.*}}, i1 false)
+// LIB: xor i32 %{{.*}}, -1
+// LIB: call i32 @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
+// LIB: xor i64 %{{.*}}, -1
+// LIB: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+void test_lib_typed_first_leading_zero(unsigned char uc, unsigned short us,
+                                       unsigned int ui, unsigned long long ull) {
+  volatile unsigned r;
+  r = stdc_first_leading_zero_uc(uc);
+  r = stdc_first_leading_zero_us(us);
+  r = stdc_first_leading_zero_ui(ui);
+  r = stdc_first_leading_zero_ull(ull);
+}
+
+// LIB-LABEL: test_lib_typed_first_leading_one
+// LIB: call i8 @llvm.ctlz.i8(i8 %{{.*}}, i1 false)
+// LIB: call i16 @llvm.ctlz.i16(i16 %{{.*}}, i1 false)
+// LIB: call i32 @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
+// LIB: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+void test_lib_typed_first_leading_one(unsigned char uc, unsigned short us,
+                                      unsigned int ui, unsigned long long ull) {
+  volatile unsigned r;
+  r = stdc_first_leading_one_uc(uc);
+  r = stdc_first_leading_one_us(us);
+  r = stdc_first_leading_one_ui(ui);
+  r = stdc_first_leading_one_ull(ull);
+}
+
+// LIB-LABEL: test_lib_typed_first_trailing_zero
+// LIB: xor i8 %{{.*}}, -1
+// LIB: call i8 @llvm.cttz.i8(i8 %{{.*}}, i1 false)
+// LIB: xor i16 %{{.*}}, -1
+// LIB: call i16 @llvm.cttz.i16(i16 %{{.*}}, i1 false)
+// LIB: xor i32 %{{.*}}, -1
+// LIB: call i32 @llvm.cttz.i32(i32 %{{.*}}, i1 false)
+// LIB: xor i64 %{{.*}}, -1
+// LIB: call i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
+void test_lib_typed_first_trailing_zero(unsigned char uc, unsigned short us,
+                                        unsigned int ui, unsigned long long ull) {
+  volatile unsigned r;
+  r = stdc_first_trailing_zero_uc(uc);
+  r = stdc_first_trailing_zero_us(us);
+  r = stdc_first_trailing_zero_ui(ui);
+  r = stdc_first_trailing_zero_ull(ull);
+}
+
+// LIB-LABEL: test_lib_typed_first_trailing_one
+// LIB: call i8 @llvm.cttz.i8(i8 %{{.*}}, i1 false)
+// LIB: call i16 @llvm.cttz.i16(i16 %{{.*}}, i1 false)
+// LIB: call i32 @llvm.cttz.i32(i32 %{{.*}}, i1 false)
+// LIB: call i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
+void test_lib_typed_first_trailing_one(unsigned char uc, unsigned short us,
+                                       unsigned int ui, unsigned long long ull) {
+  volatile unsigned r;
+  r = stdc_first_trailing_one_uc(uc);
+  r = stdc_first_trailing_one_us(us);
+  r = stdc_first_trailing_one_ui(ui);
+  r = stdc_first_trailing_one_ull(ull);
+}
+
+// LIB-LABEL: test_lib_typed_count_zeros
+// LIB: call i8 @llvm.ctpop.i8(i8 %{{.*}})
+// LIB: call i16 @llvm.ctpop.i16(i16 %{{.*}})
+// LIB: call i32 @llvm.ctpop.i32(i32 %{{.*}})
+// LIB: call i64 @llvm.ctpop.i64(i64 %{{.*}})
+void test_lib_typed_count_zeros(unsigned char uc, unsigned short us,
+                                unsigned int ui, unsigned long long ull) {
+  volatile unsigned r;
+  r = stdc_count_zeros_uc(uc);
+  r = stdc_count_zeros_us(us);
+  r = stdc_count_zeros_ui(ui);
+  r = stdc_count_zeros_ull(ull);
+}
+
+// LIB-LABEL: test_lib_typed_count_ones
+// LIB: call i8 @llvm.ctpop.i8(i8 %{{.*}})
+// LIB: call i16 @llvm.ctpop.i16(i16 %{{.*}})
+// LIB: call i32 @llvm.ctpop.i32(i32 %{{.*}})
+// LIB: call i64 @llvm.ctpop.i64(i64 %{{.*}})
+void test_lib_typed_count_ones(unsigned char uc, unsigned short us,
+                               unsigned int ui, unsigned long long ull) {
+  volatile unsigned r;
+  r = stdc_count_ones_uc(uc);
+  r = stdc_count_ones_us(us);
+  r = stdc_count_ones_ui(ui);
+  r = stdc_count_ones_ull(ull);
+}
+
+// LIB-LABEL: test_lib_typed_has_single_bit
+// LIB: call i8 @llvm.ctpop.i8(i8 %{{.*}})
+// LIB: call i16 @llvm.ctpop.i16(i16 %{{.*}})
+// LIB: call i32 @llvm.ctpop.i32(i32 %{{.*}})
+// LIB: call i64 @llvm.ctpop.i64(i64 %{{.*}})
+void test_lib_typed_has_single_bit(unsigned char uc, unsigned short us,
+                                   unsigned int ui, unsigned long long ull) {
+  volatile _Bool r;
+  r = stdc_has_single_bit_uc(uc);
+  r = stdc_has_single_bit_us(us);
+  r = stdc_has_single_bit_ui(ui);
+  r = stdc_has_single_bit_ull(ull);
+}
+
+// LIB-LABEL: test_lib_typed_bit_width
+// LIB: call i8 @llvm.ctlz.i8(i8 %{{.*}}, i1 false)
+// LIB: call i16 @llvm.ctlz.i16(i16 %{{.*}}, i1 false)
+// LIB: call i32 @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
+// LIB: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+void test_lib_typed_bit_width(unsigned char uc, unsigned short us,
+                              unsigned int ui, unsigned long long ull) {
+  volatile unsigned r;
+  r = stdc_bit_width_uc(uc);
+  r = stdc_bit_width_us(us);
+  r = stdc_bit_width_ui(ui);
+  r = stdc_bit_width_ull(ull);
+}
+
+// LIB-LABEL: test_lib_typed_bit_floor
+// LIB: call i8 @llvm.ctlz.i8(i8 %{{.*}}, i1 true)
+// LIB: call i16 @llvm.ctlz.i16(i16 %{{.*}}, i1 true)
+// LIB: call i32 @llvm.ctlz.i32(i32 %{{.*}}, i1 true)
+// LIB: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 true)
+void test_lib_typed_bit_floor(unsigned char uc, unsigned short us,
+                              unsigned int ui, unsigned long long ull) {
+  volatile unsigned char rc = stdc_bit_floor_uc(uc);
+  volatile unsigned short rs = stdc_bit_floor_us(us);
+  volatile unsigned int ri = stdc_bit_floor_ui(ui);
+  volatile unsigned long long rll = stdc_bit_floor_ull(ull);
+}
+
+// LIB-LABEL: test_lib_typed_bit_ceil
+// LIB: call i8 @llvm.ctlz.i8(i8 %{{.*}}, i1 false)
+// LIB: call i16 @llvm.ctlz.i16(i16 %{{.*}}, i1 false)
+// LIB: call i32 @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
+// LIB: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+void test_lib_typed_bit_ceil(unsigned char uc, unsigned short us,
+                             unsigned int ui, unsigned long long ull) {
+  volatile unsigned char rc = stdc_bit_ceil_uc(uc);
+  volatile unsigned short rs = stdc_bit_ceil_us(us);
+  volatile unsigned int ri = stdc_bit_ceil_ui(ui);
+  volatile unsigned long long rll = stdc_bit_ceil_ull(ull);
+}
+
+#ifdef TEST_UL_TYPED
+// LIBL-LABEL: test_lib_typed_ul
+// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+// LIBL: xor i64 %{{.*}}, -1
+// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+// LIBL: call i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
+// LIBL: xor i64 %{{.*}}, -1
+// LIBL: call i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
+// LIBL: xor i64 %{{.*}}, -1
+// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+// LIBL: xor i64 %{{.*}}, -1
+// LIBL: call i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
+// LIBL: call i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
+// LIBL: call i64 @llvm.ctpop.i64(i64 %{{.*}})
+// LIBL: call i64 @llvm.ctpop.i64(i64 %{{.*}})
+// LIBL: call i64 @llvm.ctpop.i64(i64 %{{.*}})
+// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 true)
+// LIBL: call i64 @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+void test_lib_typed_ul(unsigned long ul) {
+  volatile unsigned r;
+  volatile unsigned long rl;
+  volatile _Bool rb;
+  r  = stdc_leading_zeros_ul(ul);
+  r  = stdc_leading_ones_ul(ul);
+  r  = stdc_trailing_zeros_ul(ul);
+  r  = stdc_trailing_ones_ul(ul);
+  r  = stdc_first_leading_zero_ul(ul);
+  r  = stdc_first_leading_one_ul(ul);
+  r  = stdc_first_trailing_zero_ul(ul);
+  r  = stdc_first_trailing_one_ul(ul);
+  r  = stdc_count_zeros_ul(ul);
+  r  = stdc_count_ones_ul(ul);
+  rb = stdc_has_single_bit_ul(ul);
+  r  = stdc_bit_width_ul(ul);
+  rl = stdc_bit_floor_ul(ul);
+  rl = stdc_bit_ceil_ul(ul);
+}
+#endif
 #endif

--- a/clang/test/Sema/Inputs/stdbit.h
+++ b/clang/test/Sema/Inputs/stdbit.h
@@ -16,4 +16,88 @@
 #define stdc_bit_floor(x) (__builtin_stdc_bit_floor((x)))
 #define stdc_bit_ceil(x) (__builtin_stdc_bit_ceil((x)))
 
+unsigned int stdc_leading_zeros_uc(unsigned char);
+unsigned int stdc_leading_zeros_us(unsigned short);
+unsigned int stdc_leading_zeros_ui(unsigned int);
+unsigned int stdc_leading_zeros_ul(unsigned long);
+unsigned int stdc_leading_zeros_ull(unsigned long long);
+
+unsigned int stdc_leading_ones_uc(unsigned char);
+unsigned int stdc_leading_ones_us(unsigned short);
+unsigned int stdc_leading_ones_ui(unsigned int);
+unsigned int stdc_leading_ones_ul(unsigned long);
+unsigned int stdc_leading_ones_ull(unsigned long long);
+
+unsigned int stdc_trailing_zeros_uc(unsigned char);
+unsigned int stdc_trailing_zeros_us(unsigned short);
+unsigned int stdc_trailing_zeros_ui(unsigned int);
+unsigned int stdc_trailing_zeros_ul(unsigned long);
+unsigned int stdc_trailing_zeros_ull(unsigned long long);
+
+unsigned int stdc_trailing_ones_uc(unsigned char);
+unsigned int stdc_trailing_ones_us(unsigned short);
+unsigned int stdc_trailing_ones_ui(unsigned int);
+unsigned int stdc_trailing_ones_ul(unsigned long);
+unsigned int stdc_trailing_ones_ull(unsigned long long);
+
+unsigned int stdc_first_leading_zero_uc(unsigned char);
+unsigned int stdc_first_leading_zero_us(unsigned short);
+unsigned int stdc_first_leading_zero_ui(unsigned int);
+unsigned int stdc_first_leading_zero_ul(unsigned long);
+unsigned int stdc_first_leading_zero_ull(unsigned long long);
+
+unsigned int stdc_first_leading_one_uc(unsigned char);
+unsigned int stdc_first_leading_one_us(unsigned short);
+unsigned int stdc_first_leading_one_ui(unsigned int);
+unsigned int stdc_first_leading_one_ul(unsigned long);
+unsigned int stdc_first_leading_one_ull(unsigned long long);
+
+unsigned int stdc_first_trailing_zero_uc(unsigned char);
+unsigned int stdc_first_trailing_zero_us(unsigned short);
+unsigned int stdc_first_trailing_zero_ui(unsigned int);
+unsigned int stdc_first_trailing_zero_ul(unsigned long);
+unsigned int stdc_first_trailing_zero_ull(unsigned long long);
+
+unsigned int stdc_first_trailing_one_uc(unsigned char);
+unsigned int stdc_first_trailing_one_us(unsigned short);
+unsigned int stdc_first_trailing_one_ui(unsigned int);
+unsigned int stdc_first_trailing_one_ul(unsigned long);
+unsigned int stdc_first_trailing_one_ull(unsigned long long);
+
+unsigned int stdc_count_zeros_uc(unsigned char);
+unsigned int stdc_count_zeros_us(unsigned short);
+unsigned int stdc_count_zeros_ui(unsigned int);
+unsigned int stdc_count_zeros_ul(unsigned long);
+unsigned int stdc_count_zeros_ull(unsigned long long);
+
+unsigned int stdc_count_ones_uc(unsigned char);
+unsigned int stdc_count_ones_us(unsigned short);
+unsigned int stdc_count_ones_ui(unsigned int);
+unsigned int stdc_count_ones_ul(unsigned long);
+unsigned int stdc_count_ones_ull(unsigned long long);
+
+_Bool stdc_has_single_bit_uc(unsigned char);
+_Bool stdc_has_single_bit_us(unsigned short);
+_Bool stdc_has_single_bit_ui(unsigned int);
+_Bool stdc_has_single_bit_ul(unsigned long);
+_Bool stdc_has_single_bit_ull(unsigned long long);
+
+unsigned int stdc_bit_width_uc(unsigned char);
+unsigned int stdc_bit_width_us(unsigned short);
+unsigned int stdc_bit_width_ui(unsigned int);
+unsigned int stdc_bit_width_ul(unsigned long);
+unsigned int stdc_bit_width_ull(unsigned long long);
+
+unsigned char stdc_bit_floor_uc(unsigned char);
+unsigned short stdc_bit_floor_us(unsigned short);
+unsigned int stdc_bit_floor_ui(unsigned int);
+unsigned long stdc_bit_floor_ul(unsigned long);
+unsigned long long stdc_bit_floor_ull(unsigned long long);
+
+unsigned char stdc_bit_ceil_uc(unsigned char);
+unsigned short stdc_bit_ceil_us(unsigned short);
+unsigned int stdc_bit_ceil_ui(unsigned int);
+unsigned long stdc_bit_ceil_ul(unsigned long);
+unsigned long long stdc_bit_ceil_ull(unsigned long long);
+
 #endif

--- a/clang/test/Sema/builtin-stdc-bit-functions.c
+++ b/clang/test/Sema/builtin-stdc-bit-functions.c
@@ -581,5 +581,78 @@ _Static_assert(__builtin_stdc_has_single_bit((unsigned char)0x8000000080008080UL
 _Static_assert(__builtin_stdc_bit_width((unsigned char)0xFFFFFFFFFFFFFFFFULL) == 8, "");
 _Static_assert(__builtin_stdc_bit_floor((unsigned char)0x8000000080008080ULL) == 0x80, "");
 _Static_assert(__builtin_stdc_bit_ceil((unsigned char)0x800000008000807FULL) == 0x80, "");
+
+// Typed variants: verify correct values and return types.
+_Static_assert(stdc_leading_zeros_uc(0) == 8, "");
+_Static_assert(stdc_leading_zeros_uc((unsigned char)0xFF) == 0, "");
+_Static_assert(stdc_leading_zeros_us(0) == 16, "");
+_Static_assert(stdc_leading_zeros_ui(0) == 32, "");
+_Static_assert(stdc_leading_zeros_ull(0) == 64, "");
+
+_Static_assert(stdc_leading_ones_uc((unsigned char)0xFF) == 8, "");
+_Static_assert(stdc_leading_ones_us((unsigned short)0xFFFF) == 16, "");
+_Static_assert(stdc_leading_ones_ui(0xFFFFFFFFU) == 32, "");
+_Static_assert(stdc_leading_ones_ull(0xFFFFFFFFFFFFFFFFULL) == 64, "");
+
+_Static_assert(stdc_trailing_zeros_uc(0) == 8, "");
+_Static_assert(stdc_trailing_zeros_us(0) == 16, "");
+_Static_assert(stdc_trailing_zeros_ui(0) == 32, "");
+_Static_assert(stdc_trailing_zeros_ull(0) == 64, "");
+
+_Static_assert(stdc_trailing_ones_uc((unsigned char)0xFF) == 8, "");
+_Static_assert(stdc_trailing_ones_us((unsigned short)0xFFFF) == 16, "");
+_Static_assert(stdc_trailing_ones_ui(0xFFFFFFFFU) == 32, "");
+_Static_assert(stdc_trailing_ones_ull(0xFFFFFFFFFFFFFFFFULL) == 64, "");
+
+_Static_assert(stdc_first_leading_zero_uc(0) == 1, "");
+_Static_assert(stdc_first_leading_zero_uc((unsigned char)0xFF) == 0, "");
+_Static_assert(stdc_first_leading_zero_ui(0xFFFFFFFFU) == 0, "");
+_Static_assert(stdc_first_leading_zero_ull(0) == 1, "");
+
+_Static_assert(stdc_first_leading_one_uc(0) == 0, "");
+_Static_assert(stdc_first_leading_one_uc((unsigned char)0x80) == 1, "");
+_Static_assert(stdc_first_leading_one_ui(0x80000000U) == 1, "");
+_Static_assert(stdc_first_leading_one_ull(1ULL) == 64, "");
+
+_Static_assert(stdc_first_trailing_zero_uc(0) == 1, "");
+_Static_assert(stdc_first_trailing_zero_uc((unsigned char)0xFF) == 0, "");
+_Static_assert(stdc_first_trailing_zero_ui(0xFFFFFFFFU) == 0, "");
+_Static_assert(stdc_first_trailing_zero_ull(0) == 1, "");
+
+_Static_assert(stdc_first_trailing_one_uc(0) == 0, "");
+_Static_assert(stdc_first_trailing_one_uc(1) == 1, "");
+_Static_assert(stdc_first_trailing_one_ui(0x80000000U) == 32, "");
+_Static_assert(stdc_first_trailing_one_ull(1ULL) == 1, "");
+
+_Static_assert(stdc_count_zeros_uc(0) == 8, "");
+_Static_assert(stdc_count_zeros_uc((unsigned char)0xFF) == 0, "");
+_Static_assert(stdc_count_zeros_ui(0) == 32, "");
+_Static_assert(stdc_count_zeros_ull(0) == 64, "");
+
+_Static_assert(stdc_count_ones_uc((unsigned char)0xFF) == 8, "");
+_Static_assert(stdc_count_ones_uc(0) == 0, "");
+_Static_assert(stdc_count_ones_ui(0xFFFFFFFFU) == 32, "");
+_Static_assert(stdc_count_ones_ull(0xFFFFFFFFFFFFFFFFULL) == 64, "");
+
+_Static_assert(stdc_has_single_bit_uc(1) == 1, "");
+_Static_assert(stdc_has_single_bit_uc(3) == 0, "");
+_Static_assert(stdc_has_single_bit_ui(0x80000000U) == 1, "");
+_Static_assert(stdc_has_single_bit_ull(0xFFFFFFFFFFFFFFFFULL) == 0, "");
+
+_Static_assert(stdc_bit_width_uc((unsigned char)0xFF) == 8, "");
+_Static_assert(stdc_bit_width_uc(0) == 0, "");
+_Static_assert(stdc_bit_width_ui(0x80000000U) == 32, "");
+_Static_assert(stdc_bit_width_ull(1ULL) == 1, "");
+
+// bit_floor and bit_ceil return T, not unsigned int.
+_Static_assert(stdc_bit_floor_uc((unsigned char)0xFF) == 0x80, "");
+_Static_assert(stdc_bit_floor_uc(0) == 0, "");
+_Static_assert(stdc_bit_floor_ui(0xFFFFFFFFU) == 0x80000000U, "");
+_Static_assert(stdc_bit_floor_ull(1ULL) == 1ULL, "");
+
+_Static_assert(stdc_bit_ceil_uc(0) == 1, "");
+_Static_assert(stdc_bit_ceil_uc((unsigned char)0x7F) == 0x80, "");
+_Static_assert(stdc_bit_ceil_ui(0x7FFFFFFFU) == 0x80000000U, "");
+_Static_assert(stdc_bit_ceil_ull(1ULL) == 1ULL, "");
 #endif
 #endif


### PR DESCRIPTION
  stdc_leading_zeros_{uc,us,ui,ul,ull}
  stdc_leading_ones_{uc,us,ui,ul,ull}
  stdc_trailing_zeros_{uc,us,ui,ul,ull}
  stdc_trailing_ones_{uc,us,ui,ul,ull}
  stdc_first_leading_zero_{uc,us,ui,ul,ull}
  stdc_first_leading_one_{uc,us,ui,ul,ull}
  stdc_first_trailing_zero_{uc,us,ui,ul,ull}
  stdc_first_trailing_one_{uc,us,ui,ul,ull}
  stdc_count_zeros_{uc,us,ui,ul,ull}
  stdc_count_ones_{uc,us,ui,ul,ull}
  stdc_has_single_bit_{uc,us,ui,ul,ull}
  stdc_bit_width_{uc,us,ui,ul,ull}
  stdc_bit_floor_{uc,us,ui,ul,ull}
  stdc_bit_ceil_{uc,us,ui,ul,ull}

Lower type-specific <stdbit.h> functions to LLVM intrinsics (ctlz/cttz/ctpop). Includes constant expression support and tests for Sema, CodeGen, and constant evaluation.

Followup:#79630