### PR TITLE
[lldb][docs] Add conference talks to the links page

### DIFF
--- a/lldb/docs/use/links.rst
+++ b/lldb/docs/use/links.rst
@@ -42,6 +42,33 @@ custom breakpoints for more powerful debugging. Get the most out of
 Xcode’s view debugging tools to solve UI issues in your app more
 efficiently.
 
+Conference Talks
+~~~~~~~~~~~~~~~~
+
+* `2025 EuroLLVM - What is LLDB-DAP? <https://www.youtube.com/watch?v=sfJkf7U2FUg>`__
+* `2025 US LLVM Developers' Meeting: LLDB MCP <https://www.youtube.com/watch?v=OJas4nknp0o>`__
+* `2025 EuroLLVM - LLDB Statusline <https://www.youtube.com/watch?v=BQFwcsN1dJU>`__
+* `2025 EuroLLVM - LLDB support for Propeller optimized code <https://www.youtube.com/watch?v=osE0UDJULoM>`__
+* `2025 AsiaLLVM - The Data Inspection Language: Fast & Simple Expression Evaluation in LLDB <https://www.youtube.com/watch?v=tgsDbrQga_w>`__
+* `2024 EuroLLVM - Simplifying, Consolidating & Documenting LLDB's Scripting Functionalities <https://www.youtube.com/watch?v=hNvFmZ1iB78>`__
+* `2024 EuroLLVM - LLDB: What's in a Register? <https://www.youtube.com/watch?v=Hb7DbdIr3Rk>`__
+* `2024 EuroLLVM - Mojo debugging: extending MLIR and LLDB <https://www.youtube.com/watch?v=9jfukpjCPIg>`__
+* `2024 EuroLLVM - Debug information for macros <https://www.youtube.com/watch?v=WOkoAHTbsbM>`__
+* `2024 LLVM Dev Mtg - MD5 Checksums in LLDB <https://www.youtube.com/watch?v=JIBhafjL_oo>`__
+* `2024 LLVM Dev Mtg - "Hey, do you want a RISC-V debugger?" - Enabling RISC-V support in LLDB <https://www.youtube.com/watch?v=YSdeFLdL5DM>`__
+* `2023 LLVM Dev Mtg - Seamless debugging of emulated applications with LLDB <https://www.youtube.com/watch?v=tW3jCrCBDRc>`__
+* `2022 LLVM Dev Mtg: Interactive Crashlogs in LLDB <https://www.youtube.com/watch?v=iM2EH5EmoSY>`__
+* `2021 LLVM Dev Mtg "lldb-eval fuzzer: Finding bugs in an LLDB-based expression evaluator" <https://www.youtube.com/watch?v=dJ9k7-pmwvM>`__
+* `2021 LLVM Dev Mtg "Building a faster expression evaluator for LLDB" <https://www.youtube.com/watch?v=9aThSRGjYdA>`__
+* `2020 LLVM Developers' Meeting: "Extending LLDB to More Scripting Languages" <https://www.youtube.com/watch?v=UgfzdAr9AFg>`__
+* `2019 LLVM Developers' Meeting: R. Isemann "Better C++ debugging using Clang Modules in LLDB" <https://www.youtube.com/watch?v=vuNZLlHhy0k>`__
+* `2019 EuroLLVM Developers' Meeting: J. Devlieghere "LLDB Reproducers" <https://www.youtube.com/watch?v=ygdzXnfyvbg>`__
+* `2019 LLVM Developers' Meeting: S. Cook "A Unified Debug Server For Deeply Embedded Systems and LLDB" <https://www.youtube.com/watch?v=IMq3a_SSzFw>`__
+* `2019 LLVM Developers' Meeting: S. Cook "State of LLDB and Deeply Embedded RISC-V" <https://www.youtube.com/watch?v=37ce7gVpgIE>`__
+* `2016 EuroLLVM Developers' Meeting: L. Drummond & E. Crawford "Bringing RenderScript to LLDB" <https://www.youtube.com/watch?v=BBC61L0QKCM>`__
+* `2016 EuroLLVM Developers' Meeting: D. Panickal & A. Warzynski "LLDB Tutorial: Adding debugger ..." <https://www.youtube.com/watch?v=9hhDZeV0fYU>`__
+* `2013 LLVM Developers' Meeting: "Adapting LLDB for your hardware: Remote Debugging the Hexagon DSP" <https://www.youtube.com/watch?v=281sEoJYm8E>`__
+
 Books
 -----
 

--- a/lldb/docs/use/links.rst
+++ b/lldb/docs/use/links.rst
@@ -42,14 +42,15 @@ custom breakpoints for more powerful debugging. Get the most out of
 Xcode’s view debugging tools to solve UI issues in your app more
 efficiently.
 
-Conference Talks
-~~~~~~~~~~~~~~~~
+LLVM Developers' Meeting Talks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * `2025 EuroLLVM - What is LLDB-DAP? <https://www.youtube.com/watch?v=sfJkf7U2FUg>`__
 * `2025 US LLVM Developers' Meeting: LLDB MCP <https://www.youtube.com/watch?v=OJas4nknp0o>`__
 * `2025 EuroLLVM - LLDB Statusline <https://www.youtube.com/watch?v=BQFwcsN1dJU>`__
 * `2025 EuroLLVM - LLDB support for Propeller optimized code <https://www.youtube.com/watch?v=osE0UDJULoM>`__
 * `2025 AsiaLLVM - The Data Inspection Language: Fast & Simple Expression Evaluation in LLDB <https://www.youtube.com/watch?v=tgsDbrQga_w>`__
+* `2024 EuroLLVM - From C++ ranges to shorter template names: A C++ Debugging journey <https://www.youtube.com/watch?v=VT6-fL2hiN8>`__
 * `2024 EuroLLVM - Simplifying, Consolidating & Documenting LLDB's Scripting Functionalities <https://www.youtube.com/watch?v=hNvFmZ1iB78>`__
 * `2024 EuroLLVM - LLDB: What's in a Register? <https://www.youtube.com/watch?v=Hb7DbdIr3Rk>`__
 * `2024 EuroLLVM - Mojo debugging: extending MLIR and LLDB <https://www.youtube.com/watch?v=9jfukpjCPIg>`__


### PR DESCRIPTION
At EuroLLVM, I mentioned a previous LLDB talk and realized they would be a lot more discoverable if we linked them from the website.