### PR TITLE
[MC][debug_frame] Fix a bug in MCDwarfFrameEmitter::emit() so that per-function CIE can be generated when CIEs are different

### DIFF
--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -383,6 +383,12 @@ protected:
   /// names in .cfi_* directives.  Defaults to false.
   bool DwarfRegNumForCFI = false;
 
+  /// When true, emit a new CIE in .debug_frame whenever the CIE key changes
+  /// (e.g. different return-address register per function).  The default LLVM
+  /// behaviour reuses a single CIE for all .debug_frame FDEs; targets that
+  /// need per-function CIE variation must opt in.
+  bool UsePerFunctionDebugFrameCIE = false;
+
   /// True if target uses @ (expr@specifier) for relocation specifiers.
   bool UseAtForSpecifier = false;
 
@@ -674,6 +680,9 @@ public:
 
   bool doDwarfFDESymbolsUseAbsDiff() const { return DwarfFDESymbolsUseAbsDiff; }
   bool useDwarfRegNumForCFI() const { return DwarfRegNumForCFI; }
+  bool usePerFunctionDebugFrameCIE() const {
+    return UsePerFunctionDebugFrameCIE;
+  }
   bool useAtForSpecifier() const { return UseAtForSpecifier; }
   bool useParensForSpecifier() const { return UseParensForSpecifier; }
   bool supportsExtendedDwarfLocDirective() const {

--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -383,12 +383,6 @@ protected:
   /// names in .cfi_* directives.  Defaults to false.
   bool DwarfRegNumForCFI = false;
 
-  /// When true, emit a new CIE in .debug_frame whenever the CIE key changes
-  /// (e.g. different return-address register per function).  The default LLVM
-  /// behaviour reuses a single CIE for all .debug_frame FDEs; targets that
-  /// need per-function CIE variation must opt in.
-  bool UsePerFunctionDebugFrameCIE = false;
-
   /// True if target uses @ (expr@specifier) for relocation specifiers.
   bool UseAtForSpecifier = false;
 
@@ -680,9 +674,6 @@ public:
 
   bool doDwarfFDESymbolsUseAbsDiff() const { return DwarfFDESymbolsUseAbsDiff; }
   bool useDwarfRegNumForCFI() const { return DwarfRegNumForCFI; }
-  bool usePerFunctionDebugFrameCIE() const {
-    return UsePerFunctionDebugFrameCIE;
-  }
   bool useAtForSpecifier() const { return UseAtForSpecifier; }
   bool useParensForSpecifier() const { return UseParensForSpecifier; }
   bool supportsExtendedDwarfLocDirective() const {

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -1979,7 +1979,8 @@ void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
       continue;
 
     CIEKey Key(Frame);
-    if (!LastCIEStart || (IsEH && Key != LastKey)) {
+    if (!LastCIEStart ||
+        (Key != LastKey && (IsEH || AsmInfo->usePerFunctionDebugFrameCIE()))) {
       LastKey = Key;
       LastCIEStart = &Emitter.EmitCIE(Frame);
     }

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -1969,11 +1969,10 @@ void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
   // but the Android libunwindstack rejects eh_frame sections where
   // an FDE refers to a CIE other than the closest previous CIE.
   std::vector<MCDwarfFrameInfo> FrameArrayX(FrameArray.begin(), FrameArray.end());
-  llvm::stable_sort(FrameArrayX,
-                    [IsEH](const MCDwarfFrameInfo &X,
-                           const MCDwarfFrameInfo &Y) {
-                      return CIEKey(X, IsEH) < CIEKey(Y, IsEH);
-                    });
+  llvm::stable_sort(FrameArrayX, [IsEH](const MCDwarfFrameInfo &X,
+                                        const MCDwarfFrameInfo &Y) {
+    return CIEKey(X, IsEH) < CIEKey(Y, IsEH);
+  });
   CIEKey LastKey;
   const MCSymbol *LastCIEStart = nullptr;
   for (auto I = FrameArrayX.begin(), E = FrameArrayX.end(); I != E;) {

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -1868,11 +1868,11 @@ struct CIEKey {
   CIEKey() = default;
 
   explicit CIEKey(const MCDwarfFrameInfo &Frame, bool IsEH)
-      : Personality(IsEH ? Frame.Personality : nullptr),
-        PersonalityEncoding(IsEH ? Frame.PersonalityEncoding : 0),
-        LsdaEncoding(IsEH ? Frame.LsdaEncoding : 0),
-        IsSignalFrame(Frame.IsSignalFrame), IsSimple(Frame.IsSimple),
-        RAReg(Frame.RAReg), IsBKeyFrame(Frame.IsBKeyFrame),
+      : Personality(Frame.Personality),
+        PersonalityEncoding(Frame.PersonalityEncoding),
+        LsdaEncoding(Frame.LsdaEncoding), IsSignalFrame(Frame.IsSignalFrame),
+        IsSimple(Frame.IsSimple), RAReg(Frame.RAReg),
+        IsBKeyFrame(Frame.IsBKeyFrame),
         IsMTETaggedFrame(Frame.IsMTETaggedFrame), IsEH(IsEH) {}
 
   StringRef PersonalityName() const {

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -1867,13 +1867,13 @@ namespace {
 struct CIEKey {
   CIEKey() = default;
 
-  explicit CIEKey(const MCDwarfFrameInfo &Frame)
-      : Personality(Frame.Personality),
-        PersonalityEncoding(Frame.PersonalityEncoding),
-        LsdaEncoding(Frame.LsdaEncoding), IsSignalFrame(Frame.IsSignalFrame),
-        IsSimple(Frame.IsSimple), RAReg(Frame.RAReg),
-        IsBKeyFrame(Frame.IsBKeyFrame),
-        IsMTETaggedFrame(Frame.IsMTETaggedFrame) {}
+  CIEKey(const MCDwarfFrameInfo &Frame, bool IsEH)
+      : Personality(IsEH ? Frame.Personality : nullptr),
+        PersonalityEncoding(IsEH ? Frame.PersonalityEncoding : 0),
+        LsdaEncoding(IsEH ? Frame.LsdaEncoding : 0),
+        IsSignalFrame(Frame.IsSignalFrame), IsSimple(Frame.IsSimple),
+        RAReg(Frame.RAReg), IsBKeyFrame(Frame.IsBKeyFrame),
+        IsMTETaggedFrame(Frame.IsMTETaggedFrame), IsEH(IsEH) {}
 
   StringRef PersonalityName() const {
     if (!Personality)
@@ -1884,18 +1884,21 @@ struct CIEKey {
   bool operator<(const CIEKey &Other) const {
     return std::make_tuple(PersonalityName(), PersonalityEncoding, LsdaEncoding,
                            IsSignalFrame, IsSimple, RAReg, IsBKeyFrame,
-                           IsMTETaggedFrame) <
+                           IsMTETaggedFrame, IsEH) <
            std::make_tuple(Other.PersonalityName(), Other.PersonalityEncoding,
                            Other.LsdaEncoding, Other.IsSignalFrame,
                            Other.IsSimple, Other.RAReg, Other.IsBKeyFrame,
-                           Other.IsMTETaggedFrame);
+                           Other.IsMTETaggedFrame, Other.IsEH);
   }
 
   bool operator==(const CIEKey &Other) const {
-    return Personality == Other.Personality &&
-           PersonalityEncoding == Other.PersonalityEncoding &&
-           LsdaEncoding == Other.LsdaEncoding &&
-           IsSignalFrame == Other.IsSignalFrame && IsSimple == Other.IsSimple &&
+    if (IsEH != Other.IsEH)
+      return false;
+    if (IsEH && (Personality != Other.Personality ||
+                 PersonalityEncoding != Other.PersonalityEncoding ||
+                 LsdaEncoding != Other.LsdaEncoding))
+      return false;
+    return IsSignalFrame == Other.IsSignalFrame && IsSimple == Other.IsSimple &&
            RAReg == Other.RAReg && IsBKeyFrame == Other.IsBKeyFrame &&
            IsMTETaggedFrame == Other.IsMTETaggedFrame;
   }
@@ -1909,6 +1912,7 @@ struct CIEKey {
   unsigned RAReg = UINT_MAX;
   bool IsBKeyFrame = false;
   bool IsMTETaggedFrame = false;
+  bool IsEH = false;
 };
 
 } // end anonymous namespace
@@ -1960,8 +1964,9 @@ void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
   // an FDE refers to a CIE other than the closest previous CIE.
   std::vector<MCDwarfFrameInfo> FrameArrayX(FrameArray.begin(), FrameArray.end());
   llvm::stable_sort(FrameArrayX,
-                    [](const MCDwarfFrameInfo &X, const MCDwarfFrameInfo &Y) {
-                      return CIEKey(X) < CIEKey(Y);
+                    [IsEH](const MCDwarfFrameInfo &X,
+                           const MCDwarfFrameInfo &Y) {
+                      return CIEKey(X, IsEH) < CIEKey(Y, IsEH);
                     });
   CIEKey LastKey;
   const MCSymbol *LastCIEStart = nullptr;
@@ -1978,7 +1983,7 @@ void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
       // section, do not emit anything.
       continue;
 
-    CIEKey Key(Frame);
+    CIEKey Key(Frame, IsEH);
     if (!LastCIEStart || Key != LastKey) {
       LastKey = Key;
       LastCIEStart = &Emitter.EmitCIE(Frame);

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -365,7 +365,7 @@ MCDwarfLineTableHeader::Emit(MCStreamer *MCOS, MCDwarfLineTableParams Params,
               LineStr);
 }
 
-static const MCExpr *forceExpAbs(MCStreamer &OS, const MCExpr* Expr) {
+static const MCExpr *forceExpAbs(MCStreamer &OS, const MCExpr *Expr) {
   MCContext &Context = OS.getContext();
   assert(!isa<MCSymbolRefExpr>(Expr));
   if (!Context.getAsmInfo()->doesSetDirectiveSuppressReloc())
@@ -431,8 +431,8 @@ void MCDwarfLineTableHeader::emitV2FileDirTables(MCStreamer *MCOS) const {
   // Second the file table.
   for (unsigned i = 1; i < MCDwarfFiles.size(); i++) {
     assert(!MCDwarfFiles[i].Name.empty());
-    MCOS->emitBytes(MCDwarfFiles[i].Name); // FileName and...
-    MCOS->emitBytes(StringRef("\0", 1));   // its null terminator.
+    MCOS->emitBytes(MCDwarfFiles[i].Name);               // FileName and...
+    MCOS->emitBytes(StringRef("\0", 1));                 // its null terminator.
     MCOS->emitULEB128IntValue(MCDwarfFiles[i].DirIndex); // Directory number.
     MCOS->emitInt8(0); // Last modification timestamp (always 0).
     MCOS->emitInt8(0); // File size (always 0).
@@ -669,9 +669,8 @@ MCDwarfLineTableHeader::tryGetFile(StringRef &Directory, StringRef &FileName,
     // allocated by inline-assembler .file directives.
     FileNumber = MCDwarfFiles.empty() ? 1 : MCDwarfFiles.size();
     SmallString<256> Buffer;
-    auto IterBool = SourceIdMap.insert(
-        std::make_pair((Directory + Twine('\0') + FileName).toStringRef(Buffer),
-                       FileNumber));
+    auto IterBool = SourceIdMap.insert(std::make_pair(
+        (Directory + Twine('\0') + FileName).toStringRef(Buffer), FileNumber));
     if (!IterBool.second)
       return IterBool.first->second;
   }
@@ -938,7 +937,7 @@ static void EmitGenDwarfAranges(MCStreamer *MCOS,
   // The 1 byte size of a segment descriptor, we use a value of zero.
   MCOS->emitInt8(0);
   // Align the header with the padding if needed, before we put out the table.
-  for(int i = 0; i < Pad; i++)
+  for (int i = 0; i < Pad; i++)
     MCOS->emitInt8(0);
 
   // Now emit the table of pairs of PointerSize'ed values for the section
@@ -1084,7 +1083,7 @@ static void EmitGenDwarfInfo(MCStreamer *MCOS,
 
   // AT_APPLE_flags, the command line arguments of the assembler tool.
   StringRef DwarfDebugFlags = context.getDwarfDebugFlags();
-  if (!DwarfDebugFlags.empty()){
+  if (!DwarfDebugFlags.empty()) {
     MCOS->emitBytes(DwarfDebugFlags);
     MCOS->emitInt8(0); // NULL byte to terminate the string.
   }
@@ -1280,7 +1279,7 @@ void MCGenDwarfLabelEntry::Make(MCSymbol *Symbol, MCStreamer *MCOS,
   // underbar if any.
   StringRef Name = Symbol->getName();
   if (Name.starts_with("_"))
-    Name = Name.substr(1, Name.size()-1);
+    Name = Name.substr(1, Name.size() - 1);
 
   // Get the dwarf file number to be used for the dwarf label.
   unsigned FileNumber = context.getGenDwarfFileNumber();
@@ -1317,7 +1316,8 @@ static unsigned getSizeForEncoding(MCStreamer &streamer,
   MCContext &context = streamer.getContext();
   unsigned format = symbolEncoding & 0x0f;
   switch (format) {
-  default: llvm_unreachable("Unknown Encoding");
+  default:
+    llvm_unreachable("Unknown Encoding");
   case dwarf::DW_EH_PE_absptr:
   case dwarf::DW_EH_PE_signed:
     return context.getAsmInfo()->getCodePointerSize();
@@ -1337,9 +1337,8 @@ static void emitFDESymbol(MCObjectStreamer &streamer, const MCSymbol &symbol,
                           unsigned symbolEncoding, bool isEH) {
   MCContext &context = streamer.getContext();
   const MCAsmInfo *asmInfo = context.getAsmInfo();
-  const MCExpr *v = asmInfo->getExprForFDESymbol(&symbol,
-                                                 symbolEncoding,
-                                                 streamer);
+  const MCExpr *v =
+      asmInfo->getExprForFDESymbol(&symbol, symbolEncoding, streamer);
   unsigned size = getSizeForEncoding(streamer, symbolEncoding);
   if (asmInfo->doDwarfFDESymbolsUseAbsDiff() && isEH)
     emitAbsValue(streamer, v, size);
@@ -1351,9 +1350,8 @@ static void EmitPersonality(MCStreamer &streamer, const MCSymbol &symbol,
                             unsigned symbolEncoding) {
   MCContext &context = streamer.getContext();
   const MCAsmInfo *asmInfo = context.getAsmInfo();
-  const MCExpr *v = asmInfo->getExprForPersonalitySymbol(&symbol,
-                                                         symbolEncoding,
-                                                         streamer);
+  const MCExpr *v =
+      asmInfo->getExprForPersonalitySymbol(&symbol, symbolEncoding, streamer);
   unsigned size = getSizeForEncoding(streamer, symbolEncoding);
   streamer.emitValue(v, size);
 }
@@ -1425,7 +1423,7 @@ void FrameEmitterImpl::emitCFIInstruction(const MCCFIInstruction &Instr) {
   case MCCFIInstruction::OpAdjustCfaOffset:
   case MCCFIInstruction::OpDefCfaOffset: {
     const bool IsRelative =
-      Instr.getOperation() == MCCFIInstruction::OpAdjustCfaOffset;
+        Instr.getOperation() == MCCFIInstruction::OpAdjustCfaOffset;
 
     Streamer.emitInt8(dwarf::DW_CFA_def_cfa_offset);
 
@@ -1474,7 +1472,7 @@ void FrameEmitterImpl::emitCFIInstruction(const MCCFIInstruction &Instr) {
   case MCCFIInstruction::OpOffset:
   case MCCFIInstruction::OpRelOffset: {
     const bool IsRelative =
-      Instr.getOperation() == MCCFIInstruction::OpRelOffset;
+        Instr.getOperation() == MCCFIInstruction::OpRelOffset;
 
     unsigned Reg = Instr.getRegister();
     if (!IsEH)
@@ -1563,7 +1561,8 @@ void FrameEmitterImpl::emitCFIInstructions(ArrayRef<MCCFIInstruction> Instrs,
   for (const MCCFIInstruction &Instr : Instrs) {
     MCSymbol *Label = Instr.getLabel();
     // Throw out move if the label is invalid.
-    if (Label && !Label->isDefined()) continue; // Not emitted, in dead code.
+    if (Label && !Label->isDefined())
+      continue; // Not emitted, in dead code.
 
     // Advance row if new location.
     if (BaseLabel && Label) {
@@ -1606,8 +1605,10 @@ void FrameEmitterImpl::EmitCompactUnwind(const MCDwarfFrameInfo &Frame) {
   //   .quad except_tab1
 
   uint32_t Encoding = Frame.CompactUnwindEncoding;
-  if (!Encoding) return;
-  bool DwarfEHFrameOnly = (Encoding == MOFI->getCompactUnwindDwarfEHFrameOnly());
+  if (!Encoding)
+    return;
+  bool DwarfEHFrameOnly =
+      (Encoding == MOFI->getCompactUnwindDwarfEHFrameOnly());
 
   // The encoding needs to know we have an LSDA.
   if (!DwarfEHFrameOnly && Frame.Lsda)
@@ -1868,11 +1869,11 @@ struct CIEKey {
   CIEKey() = default;
 
   explicit CIEKey(const MCDwarfFrameInfo &Frame, bool IsEH)
-      : Personality(IsEH ? Frame.Personality : nullptr),
-        PersonalityEncoding(IsEH ? Frame.PersonalityEncoding : 0),
-        LsdaEncoding(IsEH ? Frame.LsdaEncoding : 0),
-        IsSignalFrame(Frame.IsSignalFrame), IsSimple(Frame.IsSimple),
-        RAReg(Frame.RAReg), IsBKeyFrame(Frame.IsBKeyFrame),
+      : Personality(Frame.Personality),
+        PersonalityEncoding(Frame.PersonalityEncoding),
+        LsdaEncoding(Frame.LsdaEncoding), IsSignalFrame(Frame.IsSignalFrame),
+        IsSimple(Frame.IsSimple), RAReg(Frame.RAReg),
+        IsBKeyFrame(Frame.IsBKeyFrame),
         IsMTETaggedFrame(Frame.IsMTETaggedFrame), IsEH(IsEH) {}
 
   StringRef PersonalityName() const {
@@ -1882,6 +1883,11 @@ struct CIEKey {
   }
 
   bool operator<(const CIEKey &Other) const {
+    assert(IsEH == Other.IsEH);
+    if (!IsEH)
+      std::make_tuple(RAReg, IsSimple) <
+          std::make_tuple(Other.RAReg, Other.IsSimple);
+
     return std::make_tuple(PersonalityName(), PersonalityEncoding, LsdaEncoding,
                            IsSignalFrame, IsSimple, RAReg, IsBKeyFrame,
                            IsMTETaggedFrame, IsEH) <
@@ -1892,13 +1898,14 @@ struct CIEKey {
   }
 
   bool operator==(const CIEKey &Other) const {
-    if (IsEH != Other.IsEH)
-      return false;
-    if (IsEH && (Personality != Other.Personality ||
-                 PersonalityEncoding != Other.PersonalityEncoding ||
-                 LsdaEncoding != Other.LsdaEncoding))
-      return false;
-    return IsSignalFrame == Other.IsSignalFrame && IsSimple == Other.IsSimple &&
+    assert(IsEH == Other.IsEH);
+    if (!IsEH)
+      RAReg == Other.RAReg &&IsSimple == Other.IsSimple;
+
+    return Personality == Other.Personality &&
+           PersonalityEncoding == Other.PersonalityEncoding &&
+           LsdaEncoding == Other.LsdaEncoding &&
+           IsSignalFrame == Other.IsSignalFrame && IsSimple == Other.IsSimple &&
            RAReg == Other.RAReg && IsBKeyFrame == Other.IsBKeyFrame &&
            IsMTETaggedFrame == Other.IsMTETaggedFrame;
   }
@@ -1930,15 +1937,15 @@ void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
     Streamer.generateCompactUnwindEncodings();
     bool SectionEmitted = false;
     for (const MCDwarfFrameInfo &Frame : FrameArray) {
-      if (Frame.CompactUnwindEncoding == 0) continue;
+      if (Frame.CompactUnwindEncoding == 0)
+        continue;
       if (!SectionEmitted) {
         Streamer.switchSection(MOFI->getCompactUnwindSection());
         Streamer.emitValueToAlignment(Align(AsmInfo->getCodePointerSize()));
         SectionEmitted = true;
       }
-      NeedsEHFrameSection |=
-        Frame.CompactUnwindEncoding ==
-          MOFI->getCompactUnwindDwarfEHFrameOnly();
+      NeedsEHFrameSection |= Frame.CompactUnwindEncoding ==
+                             MOFI->getCompactUnwindDwarfEHFrameOnly();
       Emitter.EmitCompactUnwind(Frame);
     }
   }
@@ -1947,7 +1954,8 @@ void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
   // debug_frame section. Skip emitting FDEs and CIEs when the compact unwind
   // doesn't need an eh_frame section and the emission location is the eh_frame
   // section.
-  if (!NeedsEHFrameSection && IsEH) return;
+  if (!NeedsEHFrameSection && IsEH)
+    return;
 
   MCSection &Section =
       IsEH ? *const_cast<MCObjectFileInfo *>(MOFI)->getEHFrameSection()
@@ -1962,19 +1970,21 @@ void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
   // This isn't technically necessary according to the DWARF standard,
   // but the Android libunwindstack rejects eh_frame sections where
   // an FDE refers to a CIE other than the closest previous CIE.
-  std::vector<MCDwarfFrameInfo> FrameArrayX(FrameArray.begin(), FrameArray.end());
-  llvm::stable_sort(FrameArrayX,
-                    [IsEH](const MCDwarfFrameInfo &X,
-                           const MCDwarfFrameInfo &Y) {
-                      return CIEKey(X, IsEH) < CIEKey(Y, IsEH);
-                    });
+  std::vector<MCDwarfFrameInfo> FrameArrayX(FrameArray.begin(),
+                                            FrameArray.end());
+  llvm::stable_sort(FrameArrayX, [IsEH](const MCDwarfFrameInfo &X,
+                                        const MCDwarfFrameInfo &Y) {
+    return CIEKey(X, IsEH) < CIEKey(Y, IsEH);
+  });
   CIEKey LastKey;
   const MCSymbol *LastCIEStart = nullptr;
   for (auto I = FrameArrayX.begin(), E = FrameArrayX.end(); I != E;) {
     const MCDwarfFrameInfo &Frame = *I;
     ++I;
-    if (CanOmitDwarf && Frame.CompactUnwindEncoding !=
-          MOFI->getCompactUnwindDwarfEHFrameOnly() && IsEH)
+    if (CanOmitDwarf &&
+        Frame.CompactUnwindEncoding !=
+            MOFI->getCompactUnwindDwarfEHFrameOnly() &&
+        IsEH)
       // CIEs and FDEs can be emitted in either the eh_frame section or the
       // debug_frame section, on some platforms (e.g. AArch64) the target object
       // file supports emitting a compact_unwind section without an associated

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -365,7 +365,7 @@ MCDwarfLineTableHeader::Emit(MCStreamer *MCOS, MCDwarfLineTableParams Params,
               LineStr);
 }
 
-static const MCExpr *forceExpAbs(MCStreamer &OS, const MCExpr *Expr) {
+static const MCExpr *forceExpAbs(MCStreamer &OS, const MCExpr* Expr) {
   MCContext &Context = OS.getContext();
   assert(!isa<MCSymbolRefExpr>(Expr));
   if (!Context.getAsmInfo()->doesSetDirectiveSuppressReloc())
@@ -431,8 +431,8 @@ void MCDwarfLineTableHeader::emitV2FileDirTables(MCStreamer *MCOS) const {
   // Second the file table.
   for (unsigned i = 1; i < MCDwarfFiles.size(); i++) {
     assert(!MCDwarfFiles[i].Name.empty());
-    MCOS->emitBytes(MCDwarfFiles[i].Name);               // FileName and...
-    MCOS->emitBytes(StringRef("\0", 1));                 // its null terminator.
+    MCOS->emitBytes(MCDwarfFiles[i].Name); // FileName and...
+    MCOS->emitBytes(StringRef("\0", 1));   // its null terminator.
     MCOS->emitULEB128IntValue(MCDwarfFiles[i].DirIndex); // Directory number.
     MCOS->emitInt8(0); // Last modification timestamp (always 0).
     MCOS->emitInt8(0); // File size (always 0).
@@ -669,8 +669,9 @@ MCDwarfLineTableHeader::tryGetFile(StringRef &Directory, StringRef &FileName,
     // allocated by inline-assembler .file directives.
     FileNumber = MCDwarfFiles.empty() ? 1 : MCDwarfFiles.size();
     SmallString<256> Buffer;
-    auto IterBool = SourceIdMap.insert(std::make_pair(
-        (Directory + Twine('\0') + FileName).toStringRef(Buffer), FileNumber));
+    auto IterBool = SourceIdMap.insert(
+        std::make_pair((Directory + Twine('\0') + FileName).toStringRef(Buffer),
+                       FileNumber));
     if (!IterBool.second)
       return IterBool.first->second;
   }
@@ -937,7 +938,7 @@ static void EmitGenDwarfAranges(MCStreamer *MCOS,
   // The 1 byte size of a segment descriptor, we use a value of zero.
   MCOS->emitInt8(0);
   // Align the header with the padding if needed, before we put out the table.
-  for (int i = 0; i < Pad; i++)
+  for(int i = 0; i < Pad; i++)
     MCOS->emitInt8(0);
 
   // Now emit the table of pairs of PointerSize'ed values for the section
@@ -1083,7 +1084,7 @@ static void EmitGenDwarfInfo(MCStreamer *MCOS,
 
   // AT_APPLE_flags, the command line arguments of the assembler tool.
   StringRef DwarfDebugFlags = context.getDwarfDebugFlags();
-  if (!DwarfDebugFlags.empty()) {
+  if (!DwarfDebugFlags.empty()){
     MCOS->emitBytes(DwarfDebugFlags);
     MCOS->emitInt8(0); // NULL byte to terminate the string.
   }
@@ -1279,7 +1280,7 @@ void MCGenDwarfLabelEntry::Make(MCSymbol *Symbol, MCStreamer *MCOS,
   // underbar if any.
   StringRef Name = Symbol->getName();
   if (Name.starts_with("_"))
-    Name = Name.substr(1, Name.size() - 1);
+    Name = Name.substr(1, Name.size()-1);
 
   // Get the dwarf file number to be used for the dwarf label.
   unsigned FileNumber = context.getGenDwarfFileNumber();
@@ -1316,8 +1317,7 @@ static unsigned getSizeForEncoding(MCStreamer &streamer,
   MCContext &context = streamer.getContext();
   unsigned format = symbolEncoding & 0x0f;
   switch (format) {
-  default:
-    llvm_unreachable("Unknown Encoding");
+  default: llvm_unreachable("Unknown Encoding");
   case dwarf::DW_EH_PE_absptr:
   case dwarf::DW_EH_PE_signed:
     return context.getAsmInfo()->getCodePointerSize();
@@ -1337,8 +1337,9 @@ static void emitFDESymbol(MCObjectStreamer &streamer, const MCSymbol &symbol,
                           unsigned symbolEncoding, bool isEH) {
   MCContext &context = streamer.getContext();
   const MCAsmInfo *asmInfo = context.getAsmInfo();
-  const MCExpr *v =
-      asmInfo->getExprForFDESymbol(&symbol, symbolEncoding, streamer);
+  const MCExpr *v = asmInfo->getExprForFDESymbol(&symbol,
+                                                 symbolEncoding,
+                                                 streamer);
   unsigned size = getSizeForEncoding(streamer, symbolEncoding);
   if (asmInfo->doDwarfFDESymbolsUseAbsDiff() && isEH)
     emitAbsValue(streamer, v, size);
@@ -1350,8 +1351,9 @@ static void EmitPersonality(MCStreamer &streamer, const MCSymbol &symbol,
                             unsigned symbolEncoding) {
   MCContext &context = streamer.getContext();
   const MCAsmInfo *asmInfo = context.getAsmInfo();
-  const MCExpr *v =
-      asmInfo->getExprForPersonalitySymbol(&symbol, symbolEncoding, streamer);
+  const MCExpr *v = asmInfo->getExprForPersonalitySymbol(&symbol,
+                                                         symbolEncoding,
+                                                         streamer);
   unsigned size = getSizeForEncoding(streamer, symbolEncoding);
   streamer.emitValue(v, size);
 }
@@ -1423,7 +1425,7 @@ void FrameEmitterImpl::emitCFIInstruction(const MCCFIInstruction &Instr) {
   case MCCFIInstruction::OpAdjustCfaOffset:
   case MCCFIInstruction::OpDefCfaOffset: {
     const bool IsRelative =
-        Instr.getOperation() == MCCFIInstruction::OpAdjustCfaOffset;
+      Instr.getOperation() == MCCFIInstruction::OpAdjustCfaOffset;
 
     Streamer.emitInt8(dwarf::DW_CFA_def_cfa_offset);
 
@@ -1472,7 +1474,7 @@ void FrameEmitterImpl::emitCFIInstruction(const MCCFIInstruction &Instr) {
   case MCCFIInstruction::OpOffset:
   case MCCFIInstruction::OpRelOffset: {
     const bool IsRelative =
-        Instr.getOperation() == MCCFIInstruction::OpRelOffset;
+      Instr.getOperation() == MCCFIInstruction::OpRelOffset;
 
     unsigned Reg = Instr.getRegister();
     if (!IsEH)
@@ -1561,8 +1563,7 @@ void FrameEmitterImpl::emitCFIInstructions(ArrayRef<MCCFIInstruction> Instrs,
   for (const MCCFIInstruction &Instr : Instrs) {
     MCSymbol *Label = Instr.getLabel();
     // Throw out move if the label is invalid.
-    if (Label && !Label->isDefined())
-      continue; // Not emitted, in dead code.
+    if (Label && !Label->isDefined()) continue; // Not emitted, in dead code.
 
     // Advance row if new location.
     if (BaseLabel && Label) {
@@ -1605,10 +1606,8 @@ void FrameEmitterImpl::EmitCompactUnwind(const MCDwarfFrameInfo &Frame) {
   //   .quad except_tab1
 
   uint32_t Encoding = Frame.CompactUnwindEncoding;
-  if (!Encoding)
-    return;
-  bool DwarfEHFrameOnly =
-      (Encoding == MOFI->getCompactUnwindDwarfEHFrameOnly());
+  if (!Encoding) return;
+  bool DwarfEHFrameOnly = (Encoding == MOFI->getCompactUnwindDwarfEHFrameOnly());
 
   // The encoding needs to know we have an LSDA.
   if (!DwarfEHFrameOnly && Frame.Lsda)
@@ -1869,11 +1868,11 @@ struct CIEKey {
   CIEKey() = default;
 
   explicit CIEKey(const MCDwarfFrameInfo &Frame, bool IsEH)
-      : Personality(Frame.Personality),
-        PersonalityEncoding(Frame.PersonalityEncoding),
-        LsdaEncoding(Frame.LsdaEncoding), IsSignalFrame(Frame.IsSignalFrame),
-        IsSimple(Frame.IsSimple), RAReg(Frame.RAReg),
-        IsBKeyFrame(Frame.IsBKeyFrame),
+      : Personality(IsEH ? Frame.Personality : nullptr),
+        PersonalityEncoding(IsEH ? Frame.PersonalityEncoding : 0),
+        LsdaEncoding(IsEH ? Frame.LsdaEncoding : 0),
+        IsSignalFrame(Frame.IsSignalFrame), IsSimple(Frame.IsSimple),
+        RAReg(Frame.RAReg), IsBKeyFrame(Frame.IsBKeyFrame),
         IsMTETaggedFrame(Frame.IsMTETaggedFrame), IsEH(IsEH) {}
 
   StringRef PersonalityName() const {
@@ -1885,22 +1884,22 @@ struct CIEKey {
   bool operator<(const CIEKey &Other) const {
     assert(IsEH == Other.IsEH);
     if (!IsEH)
-      std::make_tuple(RAReg, IsSimple) <
-          std::make_tuple(Other.RAReg, Other.IsSimple);
+      return std::make_tuple(RAReg, IsSimple) <
+             std::make_tuple(Other.RAReg, Other.IsSimple);
 
     return std::make_tuple(PersonalityName(), PersonalityEncoding, LsdaEncoding,
                            IsSignalFrame, IsSimple, RAReg, IsBKeyFrame,
-                           IsMTETaggedFrame, IsEH) <
+                           IsMTETaggedFrame) <
            std::make_tuple(Other.PersonalityName(), Other.PersonalityEncoding,
                            Other.LsdaEncoding, Other.IsSignalFrame,
                            Other.IsSimple, Other.RAReg, Other.IsBKeyFrame,
-                           Other.IsMTETaggedFrame, Other.IsEH);
+                           Other.IsMTETaggedFrame);
   }
 
   bool operator==(const CIEKey &Other) const {
     assert(IsEH == Other.IsEH);
     if (!IsEH)
-      RAReg == Other.RAReg &&IsSimple == Other.IsSimple;
+      return RAReg == Other.RAReg && IsSimple == Other.IsSimple;
 
     return Personality == Other.Personality &&
            PersonalityEncoding == Other.PersonalityEncoding &&
@@ -1937,15 +1936,15 @@ void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
     Streamer.generateCompactUnwindEncodings();
     bool SectionEmitted = false;
     for (const MCDwarfFrameInfo &Frame : FrameArray) {
-      if (Frame.CompactUnwindEncoding == 0)
-        continue;
+      if (Frame.CompactUnwindEncoding == 0) continue;
       if (!SectionEmitted) {
         Streamer.switchSection(MOFI->getCompactUnwindSection());
         Streamer.emitValueToAlignment(Align(AsmInfo->getCodePointerSize()));
         SectionEmitted = true;
       }
-      NeedsEHFrameSection |= Frame.CompactUnwindEncoding ==
-                             MOFI->getCompactUnwindDwarfEHFrameOnly();
+      NeedsEHFrameSection |=
+        Frame.CompactUnwindEncoding ==
+          MOFI->getCompactUnwindDwarfEHFrameOnly();
       Emitter.EmitCompactUnwind(Frame);
     }
   }
@@ -1954,8 +1953,7 @@ void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
   // debug_frame section. Skip emitting FDEs and CIEs when the compact unwind
   // doesn't need an eh_frame section and the emission location is the eh_frame
   // section.
-  if (!NeedsEHFrameSection && IsEH)
-    return;
+  if (!NeedsEHFrameSection && IsEH) return;
 
   MCSection &Section =
       IsEH ? *const_cast<MCObjectFileInfo *>(MOFI)->getEHFrameSection()
@@ -1970,21 +1968,19 @@ void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
   // This isn't technically necessary according to the DWARF standard,
   // but the Android libunwindstack rejects eh_frame sections where
   // an FDE refers to a CIE other than the closest previous CIE.
-  std::vector<MCDwarfFrameInfo> FrameArrayX(FrameArray.begin(),
-                                            FrameArray.end());
-  llvm::stable_sort(FrameArrayX, [IsEH](const MCDwarfFrameInfo &X,
-                                        const MCDwarfFrameInfo &Y) {
-    return CIEKey(X, IsEH) < CIEKey(Y, IsEH);
-  });
+  std::vector<MCDwarfFrameInfo> FrameArrayX(FrameArray.begin(), FrameArray.end());
+  llvm::stable_sort(FrameArrayX,
+                    [IsEH](const MCDwarfFrameInfo &X,
+                           const MCDwarfFrameInfo &Y) {
+                      return CIEKey(X, IsEH) < CIEKey(Y, IsEH);
+                    });
   CIEKey LastKey;
   const MCSymbol *LastCIEStart = nullptr;
   for (auto I = FrameArrayX.begin(), E = FrameArrayX.end(); I != E;) {
     const MCDwarfFrameInfo &Frame = *I;
     ++I;
-    if (CanOmitDwarf &&
-        Frame.CompactUnwindEncoding !=
-            MOFI->getCompactUnwindDwarfEHFrameOnly() &&
-        IsEH)
+    if (CanOmitDwarf && Frame.CompactUnwindEncoding !=
+          MOFI->getCompactUnwindDwarfEHFrameOnly() && IsEH)
       // CIEs and FDEs can be emitted in either the eh_frame section or the
       // debug_frame section, on some platforms (e.g. AArch64) the target object
       // file supports emitting a compact_unwind section without an associated

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -1867,7 +1867,7 @@ namespace {
 struct CIEKey {
   CIEKey() = default;
 
-  CIEKey(const MCDwarfFrameInfo &Frame, bool IsEH)
+  explicit CIEKey(const MCDwarfFrameInfo &Frame, bool IsEH)
       : Personality(IsEH ? Frame.Personality : nullptr),
         PersonalityEncoding(IsEH ? Frame.PersonalityEncoding : 0),
         LsdaEncoding(IsEH ? Frame.LsdaEncoding : 0),

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -1979,8 +1979,7 @@ void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
       continue;
 
     CIEKey Key(Frame);
-    if (!LastCIEStart ||
-        (Key != LastKey && (IsEH || AsmInfo->usePerFunctionDebugFrameCIE()))) {
+    if (!LastCIEStart || Key != LastKey) {
       LastKey = Key;
       LastCIEStart = &Emitter.EmitCIE(Frame);
     }

--- a/llvm/unittests/MC/CMakeLists.txt
+++ b/llvm/unittests/MC/CMakeLists.txt
@@ -6,6 +6,7 @@ endforeach()
 
 set(LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
+  DebugInfoDWARF
   MC
   MCDisassembler
   Object
@@ -15,6 +16,7 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_unittest(MCTests
   Disassembler.cpp
+  DwarfDebugFrameCIE.cpp
   DwarfLineTables.cpp
   DwarfLineTableHeaders.cpp
   MCInstPrinter.cpp

--- a/llvm/unittests/MC/DwarfDebugFrameCIE.cpp
+++ b/llvm/unittests/MC/DwarfDebugFrameCIE.cpp
@@ -1,0 +1,253 @@
+//===- llvm/unittest/MC/DwarfDebugFrameCIE.cpp ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Verify that .debug_frame emits distinct CIEs when frame parameters (e.g.
+/// the return-address register) differ between functions.  This is a
+/// regression test for a bug where only the first CIE was emitted for
+/// .debug_frame, causing all FDEs to silently reuse that CIE's
+/// return-address register regardless of per-function overrides via
+/// emitCFIReturnColumn.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
+#include "llvm/DebugInfo/DWARF/DWARFDebugFrame.h"
+#include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCDwarf.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCObjectFileInfo.h"
+#include "llvm/MC/MCObjectStreamer.h"
+#include "llvm/MC/MCObjectWriter.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/MC/MCTargetOptions.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/TargetSelect.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+class DwarfDebugFrameCIE : public ::testing::Test {
+public:
+  static constexpr const char *TripleName = "x86_64-pc-linux";
+  Triple TT;
+  std::unique_ptr<MCRegisterInfo> MRI;
+  std::unique_ptr<MCAsmInfo> MAI;
+  std::unique_ptr<const MCSubtargetInfo> STI;
+  MCTargetOptions MCOptions;
+  const Target *TheTarget = nullptr;
+
+  struct StreamerContext {
+    std::unique_ptr<MCObjectFileInfo> MOFI;
+    std::unique_ptr<MCContext> Ctx;
+    std::unique_ptr<const MCInstrInfo> MII;
+    std::unique_ptr<MCStreamer> Streamer;
+  };
+
+  DwarfDebugFrameCIE() : TT(TripleName) {
+    llvm::InitializeAllTargetInfos();
+    llvm::InitializeAllTargetMCs();
+    llvm::InitializeAllDisassemblers();
+
+    std::string Error;
+    TheTarget = TargetRegistry::lookupTarget(TT, Error);
+    if (!TheTarget)
+      return;
+
+    MRI.reset(TheTarget->createMCRegInfo(TT));
+    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TT, MCOptions));
+    STI.reset(TheTarget->createMCSubtargetInfo(TT, "", ""));
+  }
+
+  StreamerContext createStreamer(raw_pwrite_stream &OS) {
+    StreamerContext Res;
+    Res.Ctx = std::make_unique<MCContext>(TT, MAI.get(), MRI.get(),
+                                          /*MSTI=*/nullptr);
+    Res.MOFI.reset(
+        TheTarget->createMCObjectFileInfo(*Res.Ctx, /*PIC=*/false));
+    Res.Ctx->setObjectFileInfo(Res.MOFI.get());
+
+    Res.MII.reset(TheTarget->createMCInstrInfo());
+    MCCodeEmitter *MCE =
+        TheTarget->createMCCodeEmitter(*Res.MII, *Res.Ctx);
+    MCAsmBackend *MAB =
+        TheTarget->createMCAsmBackend(*STI, *MRI, MCTargetOptions());
+    std::unique_ptr<MCObjectWriter> OW = MAB->createObjectWriter(OS);
+    Res.Streamer.reset(TheTarget->createMCObjectStreamer(
+        TT, *Res.Ctx, std::unique_ptr<MCAsmBackend>(MAB), std::move(OW),
+        std::unique_ptr<MCCodeEmitter>(MCE), *STI));
+    return Res;
+  }
+
+  /// Enable .debug_frame emission (instead of the default .eh_frame).
+  void enableDebugFrame(StreamerContext &C) {
+    C.Streamer->emitCFISections(/*EH=*/false, /*Debug=*/true, /*SFrame=*/false);
+  }
+
+  /// Emit a mock function with the given return-address register in its CIE.
+  void emitFunction(StreamerContext &C, StringRef Name, unsigned RAReg) {
+    MCStreamer *S = C.Streamer.get();
+    MCContext &Ctx = *C.Ctx;
+
+    MCSection *TextSec = C.MOFI->getTextSection();
+    TextSec->setHasInstructions(true);
+    S->switchSection(TextSec);
+
+    MCSymbol *FuncSym = Ctx.getOrCreateSymbol(Name);
+    S->emitLabel(FuncSym);
+
+    S->emitCFIStartProc(/*IsSimple=*/true);
+    S->emitCFIReturnColumn(RAReg);
+    S->emitNops(4, 1, SMLoc(), *STI);
+    S->emitCFIEndProc();
+  }
+};
+
+/// Test that two functions with different return-address registers produce
+/// two distinct CIEs in .debug_frame.
+TEST_F(DwarfDebugFrameCIE, DistinctReturnColumnsGetDistinctCIEs) {
+  if (!TheTarget)
+    GTEST_SKIP();
+
+  SmallString<0> ObjContents;
+  raw_svector_ostream VecOS(ObjContents);
+  StreamerContext C = createStreamer(VecOS);
+
+  C.Streamer->initSections(*STI);
+  enableDebugFrame(C);
+
+  // Function A: return-address register = 16 (x86_64 RA)
+  emitFunction(C, "funcA", /*RAReg=*/16);
+  // Function B: return-address register = 0 (different)
+  emitFunction(C, "funcB", /*RAReg=*/0);
+
+  C.Streamer->finish();
+
+  // Parse the emitted ELF and find .debug_frame.
+  std::unique_ptr<MemoryBuffer> MB =
+      MemoryBuffer::getMemBuffer(ObjContents.str(), "", /*RequiresNullTerminator=*/false);
+  auto BinOrErr = llvm::object::createBinary(MB->getMemBufferRef());
+  ASSERT_TRUE(static_cast<bool>(BinOrErr));
+  auto *ELF = dyn_cast<llvm::object::ELFObjectFileBase>(&**BinOrErr);
+  ASSERT_NE(ELF, nullptr);
+
+  // Extract .debug_frame section contents.
+  StringRef FrameContents;
+  bool Found = false;
+  for (const auto &Section : ELF->sections()) {
+    Expected<StringRef> NameOrErr = Section.getName();
+    ASSERT_TRUE(static_cast<bool>(NameOrErr));
+    if (*NameOrErr == ".debug_frame") {
+      Expected<StringRef> ContentsOrErr = Section.getContents();
+      ASSERT_TRUE(static_cast<bool>(ContentsOrErr));
+      FrameContents = *ContentsOrErr;
+      Found = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(Found) << ".debug_frame section not found";
+  ASSERT_FALSE(FrameContents.empty());
+
+  // Parse the .debug_frame section using DWARFDebugFrame.
+  DWARFDataExtractor Data(FrameContents, /*isLittleEndian=*/true,
+                          /*AddressSize=*/8);
+  DWARFDebugFrame DebugFrame(Triple::x86_64, /*IsEH=*/false);
+  Error Err = DebugFrame.parse(Data);
+  ASSERT_FALSE(static_cast<bool>(Err)) << toString(std::move(Err));
+
+  // Collect CIEs and their return-address registers.
+  SmallVector<uint64_t, 4> CIEReturnRegs;
+  unsigned FDECount = 0;
+  for (const auto &Entry : DebugFrame) {
+    if (const auto *CIEp = dyn_cast<dwarf::CIE>(&Entry))
+      CIEReturnRegs.push_back(CIEp->getReturnAddressRegister());
+    else if (isa<dwarf::FDE>(Entry))
+      ++FDECount;
+  }
+
+  // We emitted two functions, so expect two FDEs.
+  EXPECT_EQ(FDECount, 2u);
+  // The two functions use different return-address registers, so there must
+  // be two distinct CIEs.
+  ASSERT_EQ(CIEReturnRegs.size(), 2u);
+  EXPECT_NE(CIEReturnRegs[0], CIEReturnRegs[1]);
+  // Verify both registers are present (order depends on CIEKey sort).
+  llvm::sort(CIEReturnRegs);
+  EXPECT_EQ(CIEReturnRegs[0], 0u);
+  EXPECT_EQ(CIEReturnRegs[1], 16u);
+}
+
+/// Test that two functions with the same return-address register share a
+/// single CIE (deduplication still works).
+TEST_F(DwarfDebugFrameCIE, SameReturnColumnsShareCIE) {
+  if (!TheTarget)
+    GTEST_SKIP();
+
+  SmallString<0> ObjContents;
+  raw_svector_ostream VecOS(ObjContents);
+  StreamerContext C = createStreamer(VecOS);
+
+  C.Streamer->initSections(*STI);
+  enableDebugFrame(C);
+
+  emitFunction(C, "funcC", /*RAReg=*/16);
+  emitFunction(C, "funcD", /*RAReg=*/16);
+
+  C.Streamer->finish();
+
+  std::unique_ptr<MemoryBuffer> MB =
+      MemoryBuffer::getMemBuffer(ObjContents.str(), "", false);
+  auto BinOrErr = llvm::object::createBinary(MB->getMemBufferRef());
+  ASSERT_TRUE(static_cast<bool>(BinOrErr));
+  auto *ELF = dyn_cast<llvm::object::ELFObjectFileBase>(&**BinOrErr);
+  ASSERT_NE(ELF, nullptr);
+
+  StringRef FrameContents;
+  bool Found = false;
+  for (const auto &Section : ELF->sections()) {
+    Expected<StringRef> NameOrErr = Section.getName();
+    ASSERT_TRUE(static_cast<bool>(NameOrErr));
+    if (*NameOrErr == ".debug_frame") {
+      Expected<StringRef> ContentsOrErr = Section.getContents();
+      ASSERT_TRUE(static_cast<bool>(ContentsOrErr));
+      FrameContents = *ContentsOrErr;
+      Found = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(Found) << ".debug_frame section not found";
+
+  DWARFDataExtractor Data(FrameContents, true, 8);
+  DWARFDebugFrame DebugFrame(Triple::x86_64, /*IsEH=*/false);
+  Error Err = DebugFrame.parse(Data);
+  ASSERT_FALSE(static_cast<bool>(Err)) << toString(std::move(Err));
+
+  unsigned CIECount = 0;
+  unsigned FDECount = 0;
+  for (const auto &Entry : DebugFrame) {
+    if (isa<dwarf::CIE>(Entry))
+      ++CIECount;
+    else if (isa<dwarf::FDE>(Entry))
+      ++FDECount;
+  }
+
+  EXPECT_EQ(FDECount, 2u);
+  // Same return-address register → single shared CIE.
+  EXPECT_EQ(CIECount, 1u);
+}
+
+} // namespace

--- a/llvm/unittests/MC/DwarfDebugFrameCIE.cpp
+++ b/llvm/unittests/MC/DwarfDebugFrameCIE.cpp
@@ -146,7 +146,7 @@ TEST_F(DwarfDebugFrameCIE, DistinctReturnColumnsGetDistinctCIEs) {
   // Extract .debug_frame section contents.
   StringRef FrameContents;
   bool Found = false;
-  for (const auto &Section : ELF->sections()) {
+  for (const object::SectionRef &Section : ELF->sections()) {
     Expected<StringRef> NameOrErr = Section.getName();
     ASSERT_TRUE(static_cast<bool>(NameOrErr));
     if (*NameOrErr == ".debug_frame") {
@@ -216,7 +216,7 @@ TEST_F(DwarfDebugFrameCIE, SameReturnColumnsShareCIE) {
 
   StringRef FrameContents;
   bool Found = false;
-  for (const auto &Section : ELF->sections()) {
+  for (const object::SectionRef &Section : ELF->sections()) {
     Expected<StringRef> NameOrErr = Section.getName();
     ASSERT_TRUE(static_cast<bool>(NameOrErr));
     if (*NameOrErr == ".debug_frame") {

--- a/llvm/unittests/MC/DwarfDebugFrameCIE.cpp
+++ b/llvm/unittests/MC/DwarfDebugFrameCIE.cpp
@@ -1,4 +1,4 @@
-//===- llvm/unittest/MC/DwarfDebugFrameCIE.cpp ----------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -172,7 +172,7 @@ TEST_F(DwarfDebugFrameCIE, DistinctReturnColumnsGetDistinctCIEs) {
   // Collect CIEs and their return-address registers.
   SmallVector<uint64_t, 4> CIEReturnRegs;
   unsigned FDECount = 0;
-  for (const auto &Entry : DebugFrame) {
+  for (const dwarf::FrameEntry &Entry : DebugFrame) {
     if (const auto *CIEp = dyn_cast<dwarf::CIE>(&Entry))
       CIEReturnRegs.push_back(CIEp->getReturnAddressRegister());
     else if (isa<dwarf::FDE>(Entry))
@@ -238,7 +238,7 @@ TEST_F(DwarfDebugFrameCIE, SameReturnColumnsShareCIE) {
 
   unsigned CIECount = 0;
   unsigned FDECount = 0;
-  for (const auto &Entry : DebugFrame) {
+  for (const dwarf::FrameEntry &Entry : DebugFrame) {
     if (isa<dwarf::CIE>(Entry))
       ++CIECount;
     else if (isa<dwarf::FDE>(Entry))

--- a/llvm/unittests/MC/DwarfDebugFrameCIE.cpp
+++ b/llvm/unittests/MC/DwarfDebugFrameCIE.cpp
@@ -77,13 +77,11 @@ public:
     StreamerContext Res;
     Res.Ctx = std::make_unique<MCContext>(TT, MAI.get(), MRI.get(),
                                           /*MSTI=*/nullptr);
-    Res.MOFI.reset(
-        TheTarget->createMCObjectFileInfo(*Res.Ctx, /*PIC=*/false));
+    Res.MOFI.reset(TheTarget->createMCObjectFileInfo(*Res.Ctx, /*PIC=*/false));
     Res.Ctx->setObjectFileInfo(Res.MOFI.get());
 
     Res.MII.reset(TheTarget->createMCInstrInfo());
-    MCCodeEmitter *MCE =
-        TheTarget->createMCCodeEmitter(*Res.MII, *Res.Ctx);
+    MCCodeEmitter *MCE = TheTarget->createMCCodeEmitter(*Res.MII, *Res.Ctx);
     MCAsmBackend *MAB =
         TheTarget->createMCAsmBackend(*STI, *MRI, MCTargetOptions());
     std::unique_ptr<MCObjectWriter> OW = MAB->createObjectWriter(OS);
@@ -138,8 +136,8 @@ TEST_F(DwarfDebugFrameCIE, DistinctReturnColumnsGetDistinctCIEs) {
   C.Streamer->finish();
 
   // Parse the emitted ELF and find .debug_frame.
-  std::unique_ptr<MemoryBuffer> MB =
-      MemoryBuffer::getMemBuffer(ObjContents.str(), "", /*RequiresNullTerminator=*/false);
+  std::unique_ptr<MemoryBuffer> MB = MemoryBuffer::getMemBuffer(
+      ObjContents.str(), "", /*RequiresNullTerminator=*/false);
   auto BinOrErr = llvm::object::createBinary(MB->getMemBufferRef());
   ASSERT_TRUE(static_cast<bool>(BinOrErr));
   auto *ELF = dyn_cast<llvm::object::ELFObjectFileBase>(&**BinOrErr);

--- a/llvm/unittests/MC/DwarfDebugFrameCIE.cpp
+++ b/llvm/unittests/MC/DwarfDebugFrameCIE.cpp
@@ -244,7 +244,7 @@ TEST_F(DwarfDebugFrameCIE, SameReturnColumnsShareCIE) {
   }
 
   EXPECT_EQ(FDECount, 2u);
-  // Same return-address register → single shared CIE.
+  // Same return-address register -> single shared CIE.
   EXPECT_EQ(CIECount, 1u);
 }
 


### PR DESCRIPTION
When CIEs of the .debug_frame section are different across multiple functions, CIEs must not be deduplicated. This PR fixes a bug that has prevented generating per-function CIE for `IsEH=false` when they are different.

The test case (DwarfDebugFrameCIE.cpp) generation is assisted by LLM agents.