### PR TITLE
[SPIRV] Fix legalization of zero-sized intrinsic globals

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizeZeroSizeArrays.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizeZeroSizeArrays.cpp
@@ -298,12 +298,23 @@ bool SPIRVLegalizeZeroSizeArraysImpl::runOnModule(Module &M) {
 
     Type *NewTy = legalizeType(GV.getValueType());
     Constant *LegalizedInitializer =
-        GV.hasInitializer() ? legalizeConstant(GV.getInitializer()) : nullptr;
+        GV.hasInitializer() && !GV.hasAppendingLinkage()
+            ? legalizeConstant(GV.getInitializer())
+            : nullptr;
+
+    // The new global will have the same linkage type as the original,
+    // except in the case that it is an llvm intrinsic global such as
+    // llvm.global_ctors with appending linkage, in which case we need to change
+    // the linkage as appending linkage is only allowed for arrays.
+    GlobalValue::LinkageTypes NewLT =
+        GV.hasAppendingLinkage()
+            ? GlobalValue::LinkageTypes::ExternalWeakLinkage
+            : GV.getLinkage();
 
     // Use an empty name for now, we will update it in the
     // following step.
     GlobalVariable *NewGV = new GlobalVariable(
-        M, NewTy, GV.isConstant(), GV.getLinkage(), LegalizedInitializer,
+        M, NewTy, GV.isConstant(), NewLT, LegalizedInitializer,
         /*Name=*/"", &GV, GV.getThreadLocalMode(), GV.getAddressSpace(),
         GV.isExternallyInitialized());
     NewGV->copyAttributesFrom(&GV);

--- a/llvm/test/CodeGen/SPIRV/legalize-zero-size-arrays-appending.ll
+++ b/llvm/test/CodeGen/SPIRV/legalize-zero-size-arrays-appending.ll
@@ -1,8 +1,14 @@
 ; RUN: opt -S -passes=spirv-legalize-zero-size-arrays -mtriple=spirv64-unknown-unknown < %s | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; Test that an intrinsic global variable with appending linkage is properly legalized.
+; Test that intrinsic global variables with appending linkage are properly legalized.
 
 @llvm.global_ctors = appending addrspace(1) global [0 x { i32, ptr, ptr }] zeroinitializer
+@llvm.global_dtors = appending addrspace(1) global [0 x { i32, ptr, ptr }] zeroinitializer
+@llvm.used = external addrspace(1) global [0 x ptr addrspace(1)]
+@llvm.compiler.used = external addrspace(1) global [0 x ptr addrspace(1)]
 
 ; CHECK: @llvm.global_ctors = extern_weak addrspace(1) global ptr addrspace(4)
+; CHECK: @llvm.global_dtors = extern_weak addrspace(1) global ptr addrspace(4)
+; CHECK: @llvm.used = external addrspace(1) global ptr addrspace(4)
+; CHECK: @llvm.compiler.used = external addrspace(1) global ptr addrspace(4)

--- a/llvm/test/CodeGen/SPIRV/legalize-zero-size-arrays-appending.ll
+++ b/llvm/test/CodeGen/SPIRV/legalize-zero-size-arrays-appending.ll
@@ -1,0 +1,8 @@
+; RUN: opt -S -passes=spirv-legalize-zero-size-arrays -mtriple=spirv64-unknown-unknown < %s | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Test that an intrinsic global variable with appending linkage is properly legalized.
+
+@llvm.global_ctors = appending addrspace(1) global [0 x { i32, ptr, ptr }] zeroinitializer
+
+; CHECK: @llvm.global_ctors = extern_weak addrspace(1) global ptr addrspace(4)


### PR DESCRIPTION
Some LLVM global intrinsics like `llvm.global_ctors` may become zero-sized arrays if all constructors are inlined/optimized out.

These variables use appending linkage, which is only valid on arrays, however as we are lowing to a pointer, this causes invalid IR if we maintain the same linkage.

Use `ExternalWeak` linkage, the only other mergable linking type allowed for intrinsic global variables with definitions. We also need to not specify an initializer to not produce an invalid module. 

As these variables do not represent user visible code, and all entries were optimized out anyway, the new linkage should be fine.

