### PR TITLE
[Flang][OpenMP] Fix crash in MapInfoFinalization

### DIFF
--- a/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
+++ b/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
@@ -981,6 +981,9 @@ class MapInfoFinalizationPass
         auto mapClauseOwner =
             llvm::dyn_cast<mlir::omp::MapClauseOwningOpInterface>(*target);
 
+        if (!llvm::is_contained(mapClauseOwner.getMapVars(), op.getResult()))
+          return mlir::WalkResult::advance();
+
         int64_t mapVarIdx = mapClauseOwner.getOperandIndexForMap(op);
         assert(mapVarIdx >= 0 &&
                mapVarIdx <

--- a/flang/test/Transforms/omp-map-info-finalization-member-record.fir
+++ b/flang/test/Transforms/omp-map-info-finalization-member-record.fir
@@ -1,0 +1,42 @@
+// RUN: fir-opt --omp-map-info-finalization %s | FileCheck %s
+
+// Record type with an allocatable member.
+!t1 = !fir.type<_QFTt1{a:!fir.box<!fir.heap<i32>>}>
+// Record type containing t1.
+!t2 = !fir.type<_QFTt2{b:!fir.type<_QFTt1{a:!fir.box<!fir.heap<i32>>}>}>
+
+func.func @test_member_map_not_direct_target_operand(%arg0: !fir.ref<!t2>, %arg1: !fir.ref<!t2>) {
+  %0:2 = hlfir.declare %arg0 {uniq_name = "_QFEvar1"} : (!fir.ref<!t2>) -> (!fir.ref<!t2>, !fir.ref<!t2>)
+  %1:2 = hlfir.declare %arg1 {uniq_name = "_QFEvar2"} : (!fir.ref<!t2>) -> (!fir.ref<!t2>, !fir.ref<!t2>)
+
+  %b1 = hlfir.designate %0#0{"b"} : (!fir.ref<!t2>) -> !fir.ref<!t1>
+  %b2 = hlfir.designate %1#0{"b"} : (!fir.ref<!t2>) -> !fir.ref<!t1>
+
+  // Member maps for var1%b and var2%b. Type t1 is a record with allocatable
+  // member, so isRecordWithAllocatableMember returns true for these. These
+  // maps are NOT direct target operands — they are referenced only through the
+  // parent map's members operand.
+  // Without the fix, the pass would follow getFirstTargetUser through the parent
+  // to the target, then call getOperandIndexForMap which asserts because the member
+  // map is not in map_entries.
+  %map_b1 = omp.map.info var_ptr(%b1 : !fir.ref<!t1>, !t1) map_clauses(to) capture(ByRef) -> !fir.ref<!t1> {name = "var1%b"}
+  %map_b2 = omp.map.info var_ptr(%b2 : !fir.ref<!t1>, !t1) map_clauses(tofrom) capture(ByRef) -> !fir.ref<!t1> {name = "var2%b"}
+
+  // Parent maps for var1 and var2. (direct target operands)
+  %map_var1 = omp.map.info var_ptr(%0#1 : !fir.ref<!t2>, !t2) map_clauses(to) capture(ByRef) members(%map_b1 : [0] : !fir.ref<!t1>) -> !fir.ref<!t2> {name = "var1", partial_map = true}
+  %map_var2 = omp.map.info var_ptr(%1#1 : !fir.ref<!t2>, !t2) map_clauses(tofrom) capture(ByRef) members(%map_b2 : [0] : !fir.ref<!t1>) -> !fir.ref<!t2> {name = "var2", partial_map = true}
+
+  // Target only lists parent maps as direct operands.
+  omp.target map_entries(%map_var1 -> %a0, %map_var2 -> %a1 : !fir.ref<!t2>, !fir.ref<!t2>) {
+    omp.terminator
+  }
+  return
+}
+
+// Member map are added to map_entries
+// CHECK-LABEL: func.func @test_member_map_not_direct_target_operand
+// CHECK: %[[MAP_B1:.*]] = omp.map.info {{.*}} map_clauses(to) {{.*}} {name = "var1%b"}
+// CHECK: %[[MAP_B2:.*]] = omp.map.info {{.*}} map_clauses(tofrom) {{.*}} {name = "var2%b"}
+// CHECK: %[[MAP_VAR1:.*]] = omp.map.info {{.*}} members(%[[MAP_B1]] : [0] : {{.*}}) {{.*}} {name = "var1", partial_map = true}
+// CHECK: %[[MAP_VAR2:.*]] = omp.map.info {{.*}} members(%[[MAP_B2]] : [0] : {{.*}}) {{.*}} {name = "var2", partial_map = true}
+// CHECK: omp.target map_entries(%[[MAP_VAR1]] -> %{{.*}}, %[[MAP_VAR2]] -> %{{.*}}, %[[MAP_B1]] -> %{{.*}}, %[[MAP_B2]] -> %{{.*}} :

--- a/offload/test/offloading/fortran/target-map-nested-dtype-allocatable-member.f90
+++ b/offload/test/offloading/fortran/target-map-nested-dtype-allocatable-member.f90
@@ -1,0 +1,34 @@
+! Offloading test checking that mapping two variables of a derived type
+! containing a nested derived type with an allocatable member does not crash
+! during MapInfoFinalization. The member maps for the inner derived type are
+! not direct target operands; the pass must skip them when walking record types
+! with allocatable members.
+! REQUIRES: flang, amdgpu
+
+! RUN: %libomptarget-compile-fortran-run-and-check-generic
+program main
+    type :: inner_type
+      integer, allocatable :: a
+    end type inner_type
+
+    type :: outer_type
+      type(inner_type) :: b
+    end type outer_type
+
+    type(outer_type) :: var1, var2
+
+    allocate(var1%b%a)
+    allocate(var2%b%a)
+    var1%b%a = 10
+    var2%b%a = 20
+
+    !$omp target map(tofrom: var1%b, var2%b)
+      var1%b%a = var1%b%a + var2%b%a
+    !$omp end target
+
+    print *, var1%b%a
+
+end program main
+
+!CHECK: 30
+


### PR DESCRIPTION
Fix the ICE by skipping member maps that only appear in a parent's member list rather than directly in map_entries.

Fix #187837

Assisted with copilot