### PR TITLE
[flang] NameUniquer helper for detecting module-scope data

### DIFF
--- a/flang/include/flang/Optimizer/Support/InternalNames.h
+++ b/flang/include/flang/Optimizer/Support/InternalNames.h
@@ -156,6 +156,11 @@ struct NameUniquer {
   static bool belongsToModule(llvm::StringRef uniquedName,
                               llvm::StringRef moduleName);
 
+  /// True if \p uniquedName denotes module-scope data (variable, named
+  /// constant, or common block), as opposed to procedures, types, or other
+  /// symbols that may still carry a module prefix in the mangling.
+  static bool isModuleScopeDataUniquedName(llvm::StringRef uniquedName);
+
   /// Given a mangled derived type name, get the name of the related derived
   /// type descriptor object. Returns an empty string if \p mangledTypeName is
   /// not a valid mangled derived type name.

--- a/flang/lib/Optimizer/Support/InternalNames.cpp
+++ b/flang/lib/Optimizer/Support/InternalNames.cpp
@@ -347,6 +347,29 @@ bool fir::NameUniquer::belongsToModule(llvm::StringRef uniquedName,
          result.second.modules[0] == moduleName;
 }
 
+/// Flang records the lexical module/submodule nesting of a symbol in the
+/// uniqued root produced by \c fir::NameUniquer; \c deconstruct exposes that
+/// as \c parts.modules. A non-empty module path means the symbol was declared
+/// under a module or submodule, not only at program or internal unit scope.
+/// We then require \c VARIABLE, \c CONSTANT, or \c COMMON so we match
+/// module-level data (including common), not procedures or other name kinds
+/// that can also carry a module prefix.
+bool fir::NameUniquer::isModuleScopeDataUniquedName(
+    llvm::StringRef uniquedName) {
+  auto [kind, parts] = fir::NameUniquer::deconstruct(uniquedName);
+  if (parts.modules.empty())
+    return false;
+  
+  switch (kind) {
+  case fir::NameUniquer::NameKind::VARIABLE:
+  case fir::NameUniquer::NameKind::CONSTANT:
+  case fir::NameUniquer::NameKind::COMMON:
+    return true;
+  default:
+    return false;
+  }
+}
+
 static std::string
 mangleTypeDescriptorKinds(llvm::ArrayRef<std::int64_t> kinds) {
   if (kinds.empty())

--- a/flang/lib/Optimizer/Support/InternalNames.cpp
+++ b/flang/lib/Optimizer/Support/InternalNames.cpp
@@ -359,7 +359,7 @@ bool fir::NameUniquer::isModuleScopeDataUniquedName(
   auto [kind, parts] = fir::NameUniquer::deconstruct(uniquedName);
   if (parts.modules.empty())
     return false;
-  
+
   switch (kind) {
   case fir::NameUniquer::NameKind::VARIABLE:
   case fir::NameUniquer::NameKind::CONSTANT:


### PR DESCRIPTION
Add NameUniquer::isModuleScopeDataUniquedName to detect uniqued names for module-scope data (variables, named constants, and common blocks), excluding procedures and other prefixed symbols.