### PR TITLE
[clang][ssaf][NFC] Remove stale `ID` field from `MockSerializationFormat`

### DIFF
--- a/clang/unittests/ScalableStaticAnalysisFramework/Registries/MockSerializationFormat.h
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Registries/MockSerializationFormat.h
@@ -65,8 +65,6 @@ public:
 
   using FormatInfo = FormatInfoEntry<SerializerFn, DeserializerFn>;
   std::map<SummaryName, FormatInfo> FormatInfos;
-
-  static char ID;
 };
 
 } // namespace clang::ssaf


### PR DESCRIPTION
This `ID` field was first introduced for LLVM-style RTTI but was missed from deletion when we removed RTTI support.