### PR TITLE
Revert "[lldb] Rally around triple rather than arch in the API tests (#191416)"

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -24,7 +24,8 @@ class Builder:
         compiler = lldbutil.which(compiler)
         return os.path.abspath(compiler)
 
-    def getTriple(self):
+    def getTriple(self, arch):
+        """Returns the triple for the given architecture or None."""
         return configuration.triple
 
     def getExtraMakeArgs(self):
@@ -34,15 +35,11 @@ class Builder:
         """
         return []
 
-    def getTripleSpec(self):
-        """Returns the TRIPLE for the make system."""
-        triple = self.getTriple()
-        if triple:
-            return ["TRIPLE=" + triple]
-        return []
-
-    def getArchCFlags(self):
+    def getArchCFlags(self, architecture):
         """Returns the ARCH_CFLAGS for the make system."""
+        triple = self.getTriple(architecture)
+        if triple:
+            return ["ARCH_CFLAGS=-target {}".format(triple)]
         return []
 
     def getMake(self, test_subdir, test_name):
@@ -97,6 +94,13 @@ class Builder:
         cmdline = [setOrAppendVariable(k, v) for k, v in list(d.items())]
 
         return cmdline
+
+    def getArchSpec(self, architecture):
+        """
+        Helper function to return the key-value string to specify the architecture
+        used for the make system.
+        """
+        return ["ARCH=" + architecture] if architecture else []
 
     def getToolchainSpec(self, compiler):
         """
@@ -290,8 +294,8 @@ class Builder:
             self.getMake(testdir, testname),
             debug_info_args,
             make_targets,
-            self.getArchCFlags(),
-            self.getTripleSpec(),
+            self.getArchCFlags(architecture),
+            self.getArchSpec(architecture),
             self.getToolchainSpec(compiler),
             self.getExtraMakeArgs(),
             self.getSDKRootSpec(),

--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -6,23 +6,69 @@ from .builder import Builder
 from lldbsuite.test import configuration
 import lldbsuite.test.lldbutil as lldbutil
 
-TRIPLE_RE = re.compile(
-    r"""^(?P<arch>[a-zA-Z0-9_]+) # arch (required)
-        (?:-(?P<vendor>[a-zA-Z0-9_]+))? # vendor (optional)
-        (?:-(?P<os>[a-zA-Z_]+)(?P<os_version>[\d.]+)?)? # os + version (optional)
-        (?:-(?P<env>[a-zA-Z0-9_]+))? # env/abi (optional)
-        $""",
-    re.X,
-)
+REMOTE_PLATFORM_NAME_RE = re.compile(r"^remote-(.+)$")
+SIMULATOR_PLATFORM_RE = re.compile(r"^(.+)-simulator$")
 
 
-def split_triple(triple):
-    if m := TRIPLE_RE.match(triple):
-        return m.groups()
-    return [None] * TRIPLE_RE.groups
+def get_os_env_from_platform(platform):
+    match = REMOTE_PLATFORM_NAME_RE.match(platform)
+    if match:
+        return match.group(1), ""
+    match = SIMULATOR_PLATFORM_RE.match(platform)
+    if match:
+        return match.group(1), "simulator"
+    return None, None
+
+
+def get_os_from_sdk(sdk):
+    return sdk[: sdk.find(".")], ""
+
+
+def get_os_and_env():
+    if configuration.lldb_platform_name:
+        return get_os_env_from_platform(configuration.lldb_platform_name)
+    if configuration.apple_sdk:
+        return get_os_from_sdk(configuration.apple_sdk)
+    return None, None
+
+
+def get_triple():
+    # Construct the vendor component.
+    vendor = "apple"
+
+    # Construct the os component.
+    os, env = get_os_and_env()
+    if os is None or env is None:
+        return None, None, None, None
+
+    # Get the SDK from the os and env.
+    sdk = lldbutil.get_xcode_sdk(os, env)
+    if sdk is None:
+        return None, None, None, None
+
+    # Get the version from the SDK.
+    version = lldbutil.get_xcode_sdk_version(sdk)
+    if version is None:
+        return None, None, None, None
+
+    return vendor, os, version, env
+
+
+def get_triple_str(arch, vendor, os, version, env):
+    if None in [arch, vendor, os, version, env]:
+        return None
+
+    component = [arch, vendor, os + version]
+    if env:
+        component.append(env)
+    return "-".join(component)
 
 
 class BuilderDarwin(Builder):
+    def getTriple(self, arch):
+        vendor, os, version, env = get_triple()
+        return get_triple_str(arch, vendor, os, version, env)
+
     def getExtraMakeArgs(self):
         """
         Helper function to return extra argumentsfor the make system. This
@@ -41,37 +87,39 @@ class BuilderDarwin(Builder):
                 )
                 args["FRAMEWORK_INCLUDES"] = "-F{}".format(private_frameworks)
 
-        if triple := self.getTriple():
-            _, _, operating_system, _, env = split_triple(triple)
+        operating_system, env = get_os_and_env()
 
-            builder_dir = os.path.dirname(os.path.abspath(__file__))
-            test_dir = os.path.dirname(builder_dir)
-            if operating_system in [None, "darwin", "macos", "macosx"]:
-                entitlements_file = "entitlements-macos.plist"
+        builder_dir = os.path.dirname(os.path.abspath(__file__))
+        test_dir = os.path.dirname(builder_dir)
+        if not operating_system:
+            entitlements_file = "entitlements-macos.plist"
+        else:
+            if env == "simulator":
+                entitlements_file = "entitlements-simulator.plist"
             else:
-                if env == "simulator":
-                    entitlements_file = "entitlements-simulator.plist"
-                else:
-                    entitlements_file = "entitlements.plist"
-            entitlements = os.path.join(test_dir, "make", entitlements_file)
-            args["CODESIGN"] = "codesign --entitlements {}".format(entitlements)
+                entitlements_file = "entitlements.plist"
+        entitlements = os.path.join(test_dir, "make", entitlements_file)
+        args["CODESIGN"] = "codesign --entitlements {}".format(entitlements)
 
         # Return extra args as a formatted string.
         return ["{}={}".format(key, value) for key, value in args.items()]
 
-    def getArchCFlags(self):
-        triple = self.getTriple()
+    def getArchCFlags(self, arch):
+        """Returns the ARCH_CFLAGS for the make system."""
+        # Get the triple components.
+        vendor, os, version, env = get_triple()
+        triple = get_triple_str(arch, vendor, os, version, env)
         if not triple:
             return []
 
-        _, _, os, version, _ = split_triple(triple)
+        # Construct min version argument
+        version_min = ""
+        if env == "simulator":
+            version_min = "-m{}-simulator-version-min={}".format(os, version)
+        else:
+            version_min = "-m{}-version-min={}".format(os, version)
 
-        if os == "darwin" or not version:
-            return []
-
-        target_os = "-mtargetos={}{}".format(os, version)
-
-        return ["ARCH_CFLAGS={}".format(target_os)]
+        return ["ARCH_CFLAGS=-target {} {}".format(triple, version_min)]
 
     def _getDebugInfoArgs(self, debug_info):
         if debug_info == "dsym":

--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -39,8 +39,7 @@ lldb_framework_path = None
 # Test suite repeat count.  Can be overwritten with '-# count'.
 count = 1
 
-# The 'arch' is derived from the triple. The 'compiler' can be specified via
-# command line.
+# The 'arch' and 'compiler' can be specified via command line.
 arch = None
 compiler = None
 dsymutil = None

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -338,9 +338,12 @@ def parseOptionsAndInitTestdirs():
     if args.triple:
         configuration.triple = args.triple
 
-    configuration.arch = (
-        configuration.triple.split("-")[0] if configuration.triple else platform_machine
-    )
+    if args.arch:
+        configuration.arch = args.arch
+    elif args.triple:
+        configuration.arch = args.triple.split("-")[0]
+    else:
+        configuration.arch = platform_machine
 
     if args.categories_list:
         configuration.categories_list = set(

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -32,11 +32,12 @@ def create_parser():
     # C and Python toolchain options
     group = parser.add_argument_group("Toolchain options")
     group.add_argument(
-        "--triple",
-        metavar="triple",
-        dest="triple",
+        "-A",
+        "--arch",
+        metavar="arch",
+        dest="arch",
         help=textwrap.dedent(
-            """Specify the target triple to test with (e.g. x86_64-unknown-linux-gnu, arm64-apple-macosx)."""
+            """Specify the architecture(s) to test. This option can be specified more than once"""
         ),
     )
     group.add_argument(
@@ -55,6 +56,14 @@ def create_parser():
         default="",
         help=textwrap.dedent(
             """Specify the path to sysroot. This overrides apple_sdk sysroot."""
+        ),
+    )
+    group.add_argument(
+        "--triple",
+        metavar="triple",
+        dest="triple",
+        help=textwrap.dedent(
+            """Specify the target triple. Used for cross compilation."""
         ),
     )
     if sys.platform == "darwin":
@@ -85,12 +94,13 @@ def create_parser():
             "Specify the path to a custom libc++ library directory. Must be used in conjunction with --libcxx-include-dir."
         ),
     )
-    # FIXME? This won't work for different extra flags according to each triple.
+    # FIXME? This won't work for different extra flags according to each arch.
     group.add_argument(
         "-E",
         metavar="extra-flags",
         help=textwrap.dedent(
-            """Specify the extra flags to be passed to the toolchain when building the inferior programs to be debugged."""
+            """Specify the extra flags to be passed to the toolchain when building the inferior programs to be debugged
+                                                           suggestions: do not lump the "-A arch1 -A arch2" together such that the -E option applies to only one of the architectures"""
         ),
     )
 

--- a/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -345,7 +345,7 @@ def getDwarfVersion():
         return str(configuration.dwarf_version)
     if "clang" in getCompiler():
         try:
-            triple = builder_module().getTriple()
+            triple = builder_module().getTriple(getArchitecture())
             target = ["-target", triple] if triple else []
             driver_output = subprocess.check_output(
                 [getCompiler()] + target + "-g -c -x c - -o - -###".split(),

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -109,32 +109,24 @@ else
 endif
 
 #----------------------------------------------------------------------
-# Determine the target triple. The triple is the canonical way to
-# specify the target. When only ARCH is provided we query the compiler
-# for its default triple and replace the arch component.
+# If TRIPLE is not defined try to set the ARCH, CC, CFLAGS, and more
+# from the triple alone
 #----------------------------------------------------------------------
 ARCH_CFLAGS :=
 ifeq "$(OS)" "Android"
 	include $(THIS_FILE_DIR)/Android.rules
 endif
 
-ifeq "$(TRIPLE)" ""
-  ifeq "$(ARCH)" ""
-    # No triple, no arch: query the compiler for its default triple.
-    TRIPLE := $(shell $(CC) --print-target-triple)
-  else
-    # ARCH but no TRIPLE: replace the arch in the compiler's default triple.
-    TRIPLE := $(shell $(CC) --print-target-triple | sed 's/^[^-]*/$(ARCH)/')
-  endif
-endif
-
-# Derive ARCH from the first component of the triple if not already set.
+#----------------------------------------------------------------------
+# If ARCH is not defined, default to x86_64.
+#----------------------------------------------------------------------
 ifeq "$(ARCH)" ""
-  ARCH := $(firstword $(subst -, ,$(TRIPLE)))
+ifeq "$(OS)" "Windows_NT"
+	ARCH = x86
+else
+	ARCH = x86_64
 endif
-
-# Use -target to pass the triple to the compiler.
-ARCH_CFLAGS := -target $(TRIPLE)
+endif
 
 #----------------------------------------------------------------------
 # CC defaults to clang.
@@ -190,10 +182,12 @@ ifeq "$(HOST_OS)" "Darwin"
 	endif
 endif
 
-# Detect x86 from ARCH.
-ifneq (,$(filter amd64 x86_64 x64 x86 i386 i686,$(ARCH)))
-	IS_X86 := 1
-endif
+
+#----------------------------------------------------------------------
+# ARCHFLAG is the flag used to tell the compiler which architecture
+# to compile for. The default is the flag that clang accepts.
+#----------------------------------------------------------------------
+ARCHFLAG ?= -arch
 
 #----------------------------------------------------------------------
 # Change any build/tool options needed
@@ -204,6 +198,68 @@ ifeq "$(OS)" "Darwin"
 	DSYM = $(EXE).dSYM
 	ARFLAGS := -static -o
 else
+	# On non-Apple platforms, -arch becomes -m
+	ARCHFLAG := -m
+
+	# i386, i686, x86 -> 32
+	# amd64, x86_64, x64 -> 64
+	ifeq "$(ARCH)" "amd64"
+		override ARCH := $(subst amd64,64,$(ARCH))
+		IS_X86 := 1
+	endif
+	ifeq "$(ARCH)" "x86_64"
+		override ARCH := $(subst x86_64,64,$(ARCH))
+		IS_X86 := 1
+	endif
+	ifeq "$(ARCH)" "x64"
+		override ARCH := $(subst x64,64,$(ARCH))
+		IS_X86 := 1
+	endif
+	ifeq "$(ARCH)" "x86"
+		override ARCH := $(subst x86,32,$(ARCH))
+		IS_X86 := 1
+	endif
+	ifeq "$(ARCH)" "i386"
+		override ARCH := $(subst i386,32,$(ARCH))
+		IS_X86 := 1
+	endif
+	ifeq "$(ARCH)" "i686"
+		override ARCH := $(subst i686,32,$(ARCH))
+		IS_X86 := 1
+	endif
+	ifeq "$(ARCH)" "powerpc"
+		override ARCH := $(subst powerpc,32,$(ARCH))
+	endif
+	ifeq "$(ARCH)" "powerpc64"
+		override ARCH := $(subst powerpc64,64,$(ARCH))
+	endif
+	ifeq "$(ARCH)" "powerpc64le"
+		override ARCH := $(subst powerpc64le,64,$(ARCH))
+	endif
+	ifeq "$(ARCH)" "aarch64"
+		override ARCH :=
+		override ARCHFLAG :=
+	endif
+	ifeq "$(findstring arm,$(ARCH))" "arm"
+		override ARCH :=
+		override ARCHFLAG :=
+	endif
+	ifeq "$(ARCH)" "s390x"
+		override ARCH :=
+		override ARCHFLAG :=
+	endif
+	ifeq "$(ARCH)" "riscv"
+		override ARCH :=
+		override ARCHFLAG :=
+	endif
+	ifeq "$(findstring mips,$(ARCH))" "mips"
+		override ARCHFLAG := -
+	endif
+	ifeq "$(findstring loongarch,$(ARCH))" "loongarch"
+		override ARCH :=
+		override ARCHFLAG :=
+	endif
+
 	ifeq "$(SPLIT_DEBUG_SYMBOLS)" "YES"
 		DSYM = $(EXE).debug
 	endif
@@ -240,7 +296,9 @@ CFLAGS ?= $(DEBUG_INFO_FLAG) -O0
 CFLAGS += $(SYSROOT_FLAGS)
 
 ifeq "$(OS)" "Darwin"
-	CFLAGS += $(FRAMEWORK_INCLUDES)
+	CFLAGS += $(ARCHFLAG) $(ARCH) $(FRAMEWORK_INCLUDES)
+else
+	CFLAGS += $(ARCHFLAG)$(ARCH)
 endif
 
 CFLAGS += -I$(LLDB_BASE_DIR)/include -I$(LLDB_OBJ_ROOT)/include
@@ -253,7 +311,11 @@ endif
 CFLAGS += $(NO_LIMIT_DEBUG_INFO_FLAGS) $(ARCH_CFLAGS)
 
 # Use this one if you want to build one part of the result without debug information:
-CFLAGS_NO_DEBUG = -O0 $(FRAMEWORK_INCLUDES) $(ARCH_CFLAGS) $(CFLAGS_EXTRAS) $(SYSROOT_FLAGS)
+ifeq "$(OS)" "Darwin"
+	CFLAGS_NO_DEBUG = -O0 $(ARCHFLAG) $(ARCH) $(FRAMEWORK_INCLUDES) $(ARCH_CFLAGS) $(CFLAGS_EXTRAS) $(SYSROOT_FLAGS)
+else
+	CFLAGS_NO_DEBUG = -O0 $(ARCHFLAG)$(ARCH) $(FRAMEWORK_INCLUDES) $(ARCH_CFLAGS) $(CFLAGS_EXTRAS) $(SYSROOT_FLAGS)
+endif
 
 ifeq "$(MAKE_DWO)" "YES"
 	CFLAGS += -gsplit-dwarf

--- a/lldb/test/API/commands/expression/ptrauth-auth-traps/Makefile
+++ b/lldb/test/API/commands/expression/ptrauth-auth-traps/Makefile
@@ -1,3 +1,5 @@
 C_SOURCES := main.c
 
+override ARCH := arm64e
+
 include Makefile.rules

--- a/lldb/test/API/commands/expression/ptrauth-auth-traps/TestPtrAuthAuthTraps.py
+++ b/lldb/test/API/commands/expression/ptrauth-auth-traps/TestPtrAuthAuthTraps.py
@@ -8,21 +8,14 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
-from lldbsuite.test import configuration
 
 
 class TestPtrAuthAuthTraps(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
-    SHARED_BUILD_TESTCASE = False
-
-    def build_arm64e(self):
-        self.build(
-            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
-        )
 
     @skipUnlessArm64eSupported
     def test_static_function_pointer(self):
-        self.build_arm64e()
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
         )
@@ -39,7 +32,7 @@ class TestPtrAuthAuthTraps(TestBase):
 
     @skipUnlessArm64eSupported
     def test_indirect_call_through_caller(self):
-        self.build_arm64e()
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
         )

--- a/lldb/test/API/commands/expression/ptrauth-objc/Makefile
+++ b/lldb/test/API/commands/expression/ptrauth-objc/Makefile
@@ -1,5 +1,7 @@
 OBJC_SOURCES := main.m
 
+override ARCH := arm64e
+
 # We need an arm64e stdlib.
 USE_SYSTEM_STDLIB := 1
 

--- a/lldb/test/API/commands/expression/ptrauth-objc/TestPtrAuthObjectiveC.py
+++ b/lldb/test/API/commands/expression/ptrauth-objc/TestPtrAuthObjectiveC.py
@@ -2,21 +2,14 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
-from lldbsuite.test import configuration
 
 
 class TestPtrAuthObjectiveC(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
-    SHARED_BUILD_TESTCASE = False
-
-    def build_arm64e(self):
-        self.build(
-            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
-        )
 
     @skipUnlessArm64eSupported
     def test_objc_message_send(self):
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)
@@ -30,7 +23,7 @@ class TestPtrAuthObjectiveC(TestBase):
 
     @skipUnlessArm64eSupported
     def test_objc_message_send_with_arg(self):
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)
@@ -44,7 +37,7 @@ class TestPtrAuthObjectiveC(TestBase):
 
     @skipUnlessArm64eSupported
     def test_objc_alloc_and_message(self):
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)
@@ -59,7 +52,7 @@ class TestPtrAuthObjectiveC(TestBase):
 
     @skipUnlessArm64eSupported
     def test_objc_derived_class(self):
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)
@@ -79,7 +72,7 @@ class TestPtrAuthObjectiveC(TestBase):
 
     @skipUnlessArm64eSupported
     def test_objc_isa_check(self):
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m", False)

--- a/lldb/test/API/commands/expression/ptrauth-vtable/Makefile
+++ b/lldb/test/API/commands/expression/ptrauth-vtable/Makefile
@@ -1,5 +1,7 @@
 CXX_SOURCES := main.cpp
 
+override ARCH := arm64e
+
 # We need an arm64e stblib.
 USE_SYSTEM_STDLIB := 1
 

--- a/lldb/test/API/commands/expression/ptrauth-vtable/TestPtrAuthVTableExpressions.py
+++ b/lldb/test/API/commands/expression/ptrauth-vtable/TestPtrAuthVTableExpressions.py
@@ -12,16 +12,10 @@ from lldbsuite.test import lldbutil
 
 class TestPtrAuthVTableExpressions(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
-    SHARED_BUILD_TESTCASE = False
-
-    def build_arm64e(self):
-        self.build(
-            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
-        )
 
     @skipUnlessArm64eSupported
     def test_virtual_call_on_debuggee_object(self):
-        self.build_arm64e()
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.cpp", False)
         )
@@ -31,7 +25,7 @@ class TestPtrAuthVTableExpressions(TestBase):
 
     @skipUnlessArm64eSupported
     def test_virtual_call_through_base_pointer(self):
-        self.build_arm64e()
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.cpp", False)
         )
@@ -40,7 +34,7 @@ class TestPtrAuthVTableExpressions(TestBase):
 
     @skipUnlessArm64eSupported
     def test_virtual_call_via_helper(self):
-        self.build_arm64e()
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.cpp", False)
         )

--- a/lldb/test/API/commands/expression/ptrauth/Makefile
+++ b/lldb/test/API/commands/expression/ptrauth/Makefile
@@ -1,3 +1,5 @@
 C_SOURCES := main.c
 
+override ARCH := arm64e
+
 include Makefile.rules

--- a/lldb/test/API/commands/expression/ptrauth/TestPtrAuthExpressions.py
+++ b/lldb/test/API/commands/expression/ptrauth/TestPtrAuthExpressions.py
@@ -2,17 +2,10 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
-from lldbsuite.test import configuration
 
 
 class TestPtrAuthExpressions(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
-    SHARED_BUILD_TESTCASE = False
-
-    def build_arm64e(self):
-        self.build(
-            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
-        )
 
     @skipUnlessArm64eSupported
     def test_static_function_pointer(self):
@@ -20,7 +13,7 @@ class TestPtrAuthExpressions(TestBase):
         Test that we can call a function through a static function pointer
         from the expression evaluator, which requires "fixing up" the pointer
         signing via the InjectPointerSigningFixups pass."""
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
@@ -44,7 +37,7 @@ class TestPtrAuthExpressions(TestBase):
         correctly signed. The caller() function in the debuggee forces a
         genuine indirect call, preventing the compiler from folding the
         function pointer call into a direct call."""
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
@@ -69,7 +62,7 @@ class TestPtrAuthExpressions(TestBase):
         is signed with the IB key (__ptrauth(1, 0, 0)), which is
         process-specific; this verifies that auth succeeds because expressions
         execute in the debuggee's process, not the debugger's."""
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)
@@ -86,7 +79,7 @@ class TestPtrAuthExpressions(TestBase):
         """Test that computed gotos (GCC labels-as-values) work in the
         expression evaluator on arm64e, where -fptrauth-indirect-gotos signs
         label addresses and the indirect branch authenticates them."""
-        self.build_arm64e()
+        self.build()
 
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.c", False)

--- a/lldb/test/API/lang/c/ptrauth/Makefile
+++ b/lldb/test/API/lang/c/ptrauth/Makefile
@@ -1,4 +1,5 @@
 LEVEL = ../../../make
+override ARCH := arm64e
 CFLAGS_EXTRAS = -fptrauth-calls -fptrauth-intrinsics
 C_SOURCES := main.c
 

--- a/lldb/test/API/lang/c/ptrauth/TestPtrAuth.py
+++ b/lldb/test/API/lang/c/ptrauth/TestPtrAuth.py
@@ -4,21 +4,12 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
-from lldbsuite.test import configuration
 
 
 class TestPtrAuth(TestBase):
-    NO_DEBUG_INFO_TESTCASE = True
-    SHARED_BUILD_TESTCASE = False
-
-    def build_arm64e(self):
-        self.build(
-            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
-        )
-
     @skipUnlessArm64eSupported
     def test(self):
-        self.build_arm64e()
+        self.build()
         _, process, _, _ = lldbutil.run_to_source_breakpoint(
             self, "// break in main", lldb.SBFileSpec("main.c")
         )


### PR DESCRIPTION


Temoprarily reverting while we look at the TestMacCatalyst.py and TestRosetta.py fails introduced by this PR, to unblock the CI.

This reverts commit 86397f49c7725f35a51517a8290cb4207c97771d.