### PR TITLE
Revert "XFAIL symbolizer test for TySan"

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/internal_symbolizer.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/internal_symbolizer.cpp
@@ -2,9 +2,6 @@
 
 // REQUIRES: internal_symbolizer
 
-// Look into this
-// XFAIL: tysan
-
 #include <assert.h>
 #include <dlfcn.h>
 #include <link.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/print-stack-trace.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/print-stack-trace.cpp
@@ -9,8 +9,6 @@
 // TODO(yln): temporary failing due to refactoring
 // UNSUPPORTED: ubsan
 
-// XFAIL: tysan
-
 #include <sanitizer/common_interface_defs.h>
 
 static inline void FooBarBaz() {


### PR DESCRIPTION
Reverts llvm/llvm-project#191810

Relates to https://github.com/llvm/llvm-project/pull/191902