### PR TITLE
[libc] Implement wcscoll

### DIFF
--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -399,6 +399,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wchar.wcschr
     libc.src.wchar.wcsncmp
     libc.src.wchar.wcscmp
+    libc.src.wchar.wcscoll
     libc.src.wchar.wcspbrk
     libc.src.wchar.wcsrchr
     libc.src.wchar.wcsspn

--- a/libc/include/wchar.yaml
+++ b/libc/include/wchar.yaml
@@ -1,6 +1,6 @@
 header: wchar.h
 standards:
-  - stdc 
+  - stdc
 macros:
   - macro_name: "NULL"
     macro_header: null-macro.h
@@ -118,6 +118,13 @@ functions:
       - type: const wchar_t *
       - type: size_t
   - name: wcscmp
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: const wchar_t *
+      - type: const wchar_t *
+  - name: wcscoll
     standards:
       - stdc
     return_type: int

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -333,6 +333,16 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  wcscoll
+  SRCS
+    wcscoll.cpp
+  HDRS
+    wcscoll.h
+  DEPENDS
+    libc.hdr.wchar_macros
+)
+
+add_entrypoint_object(
   wcsdup
   SRCS
     wcsdup.cpp

--- a/libc/src/wchar/wcscoll.cpp
+++ b/libc/src/wchar/wcscoll.cpp
@@ -1,0 +1,29 @@
+//===-- Implementation of wcscoll -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/wcscoll.h"
+
+#include "hdr/types/wchar_t.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// TODO: Add support for locales.
+LLVM_LIBC_FUNCTION(int, wcscoll, (const wchar_t *s1, const wchar_t *s2)) {
+  LIBC_CRASH_ON_NULLPTR(s1);
+  LIBC_CRASH_ON_NULLPTR(s2);
+
+  for (; *s1 && (*s1 == *s2); ++s1, ++s2)
+    ;
+
+  return *s1 - *s2;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/wcscoll.h
+++ b/libc/src/wchar/wcscoll.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for wcscoll ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_WCSCOLL_H
+#define LLVM_LIBC_SRC_WCHAR_WCSCOLL_H
+
+#include "hdr/types/wchar_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int wcscoll(const wchar_t *s1, const wchar_t *s2);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_WCSCOLL_H

--- a/libc/test/src/wchar/CMakeLists.txt
+++ b/libc/test/src/wchar/CMakeLists.txt
@@ -243,6 +243,16 @@ add_libc_test(
 )
 
 add_libc_test(
+  wcscoll_test
+  SUITE
+    libc_wchar_unittests
+  SRCS
+    wcscoll_test.cpp
+  DEPENDS
+    libc.src.wchar.wcscoll
+)
+
+add_libc_test(
   wcspbrk_test
   SUITE
     libc_wchar_unittests

--- a/libc/test/src/wchar/wcscoll_test.cpp
+++ b/libc/test/src/wchar/wcscoll_test.cpp
@@ -1,0 +1,139 @@
+//===-- Unittests for wcscoll ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/signal_macros.h"
+#include "src/wchar/wcscoll.h"
+#include "test/UnitTest/Test.h"
+
+// TODO: Add more comprehensive tests once locale support is added.
+
+TEST(LlvmLibcWcscollTest, EmptyStringsShouldReturnZero) {
+  const wchar_t *s1 = L"";
+  const wchar_t *s2 = L"";
+
+  int result = LIBC_NAMESPACE::wcscoll(s1, s2);
+  ASSERT_EQ(result, 0);
+}
+
+TEST(LlvmLibcWcscollTest, EmptyStringShouldNotEqualNonEmptyString) {
+  const wchar_t *empty = L"";
+  const wchar_t *s = L"abc";
+
+  // An empty string comes before a non empty one lexicographically, so lt 0
+  int result = LIBC_NAMESPACE::wcscoll(empty, s);
+  ASSERT_LT(result, 0);
+
+  // Check the reversed behaviour
+  result = LIBC_NAMESPACE::wcscoll(s, empty);
+  ASSERT_GT(result, 0);
+}
+
+TEST(LlvmLibcWcscollTest, EqualStringsShouldReturnZero) {
+  const wchar_t *s1 = L"abc";
+  const wchar_t *s2 = L"abc";
+
+  // Check if it returns 0 for two equal strings
+  int result = LIBC_NAMESPACE::wcscoll(s1, s2);
+  ASSERT_EQ(result, 0);
+
+  // Verify for reversed operands
+  result = LIBC_NAMESPACE::wcscoll(s2, s1);
+  ASSERT_EQ(result, 0);
+}
+
+TEST(LlvmLibcWcscollTest, LexicographicalTest) {
+  const wchar_t *s1 = L"abc";
+  const wchar_t *s2 = L"def";
+
+  // Check if it returns lt 0 for (abc, def)
+  int result = LIBC_NAMESPACE::wcscoll(s1, s2);
+  ASSERT_LT(result, 0);
+
+  // Check if it returns gt 0 for (def, abc)
+  result = LIBC_NAMESPACE::wcscoll(s2, s1);
+  ASSERT_GT(result, 0);
+}
+
+TEST(LlvmLibcWcscollTest, NonAsciiTest) {
+  const wchar_t *s1 = L"AbCdEf__1230!! \u1111";
+  const wchar_t *s2 = L"AbCdEf__1230!! \u1111\u2222";
+
+  int result = LIBC_NAMESPACE::wcscoll(s1, s2);
+  ASSERT_LT(result, 0);
+
+  result = LIBC_NAMESPACE::wcscoll(s2, s1);
+  ASSERT_GT(result, 0);
+
+  result = LIBC_NAMESPACE::wcscoll(s1, s1);
+  ASSERT_EQ(result, 0);
+
+  // Empty string
+  const wchar_t *empty = L"";
+  result = LIBC_NAMESPACE::wcscoll(empty, s1);
+  ASSERT_LT(result, 0);
+
+  result = LIBC_NAMESPACE::wcscoll(s1, empty);
+  ASSERT_GT(result, 0);
+}
+
+TEST(LlvmLibcWcscollTest, EightDigitUCNTest) {
+  const wchar_t *s1 = L"abC\U0001F44D"; // thumbs up emoji
+  const wchar_t *s2 = L"abC\U0001F44E"; // thumbs down emoji
+
+  int result = LIBC_NAMESPACE::wcscoll(s1, s2);
+  ASSERT_LT(result, 0);
+
+  result = LIBC_NAMESPACE::wcscoll(s2, s1);
+  ASSERT_GT(result, 0);
+
+  result = LIBC_NAMESPACE::wcscoll(s1, s1);
+  ASSERT_EQ(result, 0);
+
+  // empty string
+  const wchar_t *empty = L"";
+  result = LIBC_NAMESPACE::wcscoll(empty, s1);
+  ASSERT_LT(result, 0);
+
+  result = LIBC_NAMESPACE::wcscoll(s1, empty);
+  ASSERT_GT(result, 0);
+}
+
+TEST(LlvmLibcWcscollTest, AsciiVsNonAsciiTest) {
+  const wchar_t *s1 = L"a";
+  const wchar_t *s2 = L"\uFFFF";
+  const wchar_t *s3 = L"\U0001000F";
+
+  // ascii and 4 digit unicode
+  int result = LIBC_NAMESPACE::wcscoll(s1, s2);
+  ASSERT_LT(result, 0);
+
+  result = LIBC_NAMESPACE::wcscoll(s2, s1);
+  ASSERT_GT(result, 0);
+
+  // ascii and 8 digit unicode
+  result = LIBC_NAMESPACE::wcscoll(s1, s3);
+  ASSERT_LT(result, 0);
+
+  result = LIBC_NAMESPACE::wcscoll(s3, s1);
+  ASSERT_GT(result, 0);
+
+  // 4 digit unicode and 8 digit unicode
+  result = LIBC_NAMESPACE::wcscoll(s2, s3);
+  ASSERT_LT(result, 0);
+
+  result = LIBC_NAMESPACE::wcscoll(s3, s2);
+  ASSERT_GT(result, 0);
+}
+
+#if defined(LIBC_ADD_NULL_CHECKS)
+TEST(LlvmLibcWcscollTest, NULLCheck) {
+  // Passing in a nullptr should crash the program
+  EXPECT_DEATH([] { LIBC_NAMESPACE::wcscoll(L"", nullptr); }, WITH_SIGNAL(-1));
+  EXPECT_DEATH([] { LIBC_NAMESPACE::wcscoll(nullptr, L""); }, WITH_SIGNAL(-1));
+}
+#endif // LIBC_ADD_NULL_CHECKS


### PR DESCRIPTION
_Closes #191073_
- `libc/src/wchar/wcscoll.cpp` - Implementation of wcscoll
- `libc/src/wchar/wcscoll.h` - Internal header for wcscoll
- `libc/include/wchar.yaml` - Added wcscoll to public header spec
- `libc/src/wchar/CMakeLists.txt` - Added build target for wcscoll
- `libc/config/linux/x86_64/entrypoints.txt` - Registered wcscoll entrypoint
- `libc/test/src/wchar/wcscoll_test.cpp` - Unit tests for wcscoll
- `libc/test/src/wchar/CMakeLists.txt` - Added test target for wcscoll

Note: Locale support is not yet implemented. `wcscoll` currently behaves identically to `wcscmp` until locale support is available in llvm-libc.