### PR TITLE
[VPlan] Strip vp_post_order_{deep,shallow} (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanCFG.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanCFG.h
@@ -260,20 +260,6 @@ vp_depth_first_shallow(const VPBlockBase *G) {
 }
 
 /// Returns an iterator range to traverse the graph starting at \p G in
-/// post order. The iterator won't traverse through region blocks.
-inline PostOrderTraversal<VPBlockShallowTraversalWrapper<VPBlockBase *>>
-vp_post_order_shallow(VPBlockBase *G) {
-  return post_order(VPBlockShallowTraversalWrapper<VPBlockBase *>(G));
-}
-
-/// Returns an iterator range to traverse the graph starting at \p G in
-/// post order while traversing through region blocks.
-inline PostOrderTraversal<VPBlockDeepTraversalWrapper<VPBlockBase *>>
-vp_post_order_deep(VPBlockBase *G) {
-  return post_order(VPBlockDeepTraversalWrapper<VPBlockBase *>(G));
-}
-
-/// Returns an iterator range to traverse the graph starting at \p G in
 /// depth-first order while traversing through region blocks.
 inline iterator_range<df_iterator<VPBlockDeepTraversalWrapper<VPBlockBase *>>>
 vp_depth_first_deep(VPBlockBase *G) {

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -1071,7 +1071,9 @@ void VPlanTransforms::addMiddleCheck(VPlan &Plan, bool TailFolded) {
 
 void VPlanTransforms::createLoopRegions(VPlan &Plan) {
   VPDominatorTree VPDT(Plan);
-  for (VPBlockBase *HeaderVPB : vp_post_order_shallow(Plan.getEntry()))
+  PostOrderTraversal<VPBlockShallowTraversalWrapper<VPBlockBase *>> POT(
+      Plan.getEntry());
+  for (VPBlockBase *HeaderVPB : POT)
     if (canonicalHeaderAndLatch(HeaderVPB, VPDT))
       createLoopRegion(Plan, HeaderVPB);
 


### PR DESCRIPTION
Post 691a130 ([ADT] Refactor post order traversal, #191047), PostOrderTraversal's lifetime needs to exceed the lifetime of the iterator. The vp_post_order_{deep,shallow} helpers now have the potential for being used incorrectly: hence, strip them, and require the PostOrderTraversal to be constructed explictly, similar to RPOT.