### PR TITLE
[BOLT][runtime] add missing syscall clobbers to x86_64 __prctl.

### DIFF
--- a/bolt/runtime/sys_x86_64.h
+++ b/bolt/runtime/sys_x86_64.h
@@ -350,7 +350,7 @@ int __prctl(int Option, unsigned long Arg2, unsigned long Arg3,
                        "syscall\n"
                        : "=a"(Ret)
                        : "D"(Option), "S"(Arg2), "d"(rdx), "r"(r10), "r"(r8)
-                       :);
+                       : "cc", "rcx", "r11", "memory");
   return Ret;
 }
 


### PR DESCRIPTION
syscall clobbers RCX and R11; matches the aarch64/riscv64 wrappers.