### PR TITLE
[BoundsSafety][NFC] Introduce LateParsedTypeAttribute for late-parsed type attributes

### DIFF
--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -225,12 +225,11 @@ public:
   }
 };
 
-/// Contains the lexed tokens of an attribute with arguments that
-/// may reference member variables and so need to be parsed at the
-/// end of the class declaration after parsing all other member
-/// member declarations.
-/// FIXME: Perhaps we should change the name of LateParsedDeclaration to
-/// LateParsedTokens.
+/// A late-parsed attribute that will be applied as a type attribute.
+/// Unlike LateParsedAttribute (which applies to declarations via
+/// ActOnFinishDelayedAttribute), this stores cached tokens that are
+/// parsed during type construction when the placeholder LateParsedAttrType
+/// is replaced with a concrete type (e.g., CountAttributedType).
 struct LateParsedTypeAttribute : public LateParsedAttribute {
 
   explicit LateParsedTypeAttribute(Parser *P, IdentifierInfo &Name,
@@ -1533,6 +1532,11 @@ private:
 
   void ParseLexedTypeAttribute(LateParsedTypeAttribute &LA, bool EnterScope,
                                ParsedAttributes &OutAttrs);
+
+  /// Parse cached tokens for a late-parsed attribute and return the parsed
+  /// attributes. Shared implementation used by both ParseLexedCAttribute and
+  /// ParseLexedTypeAttribute.
+  ParsedAttributes ParseLexedCAttributeTokens(LateParsedAttribute &LA);
 
   /// Helper function to move LateParsedTypeAttribute pointers from one list
   /// to another. Filters type attributes from \p From and appends them to \p

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -206,10 +206,15 @@ struct LateParsedAttribute : public LateParsedDeclaration {
 private:
   Kind K;
 
+protected:
+  explicit LateParsedAttribute(Parser *P, IdentifierInfo &Name,
+                               SourceLocation Loc, Kind K)
+      : Self(P), AttrName(Name), AttrNameLoc(Loc), K(K) {}
+
 public:
   explicit LateParsedAttribute(Parser *P, IdentifierInfo &Name,
-                               SourceLocation Loc, Kind K = Kind::Declaration)
-      : Self(P), AttrName(Name), AttrNameLoc(Loc), K(K) {}
+                               SourceLocation Loc)
+      : LateParsedAttribute(P, Name, Loc, Kind::Declaration) {}
 
   void ParseLexedAttributes() override;
 
@@ -1513,7 +1518,7 @@ private:
                                 const char *&PrevSpec, unsigned &DiagID,
                                 bool &isInvalid);
 
-  void ParseLexedCAttributeList(LateParsedAttrList &LA, bool EnterScope,
+  void ParseLexedCAttributeList(LateParsedAttrList &LA,
                                 ParsedAttributes *OutAttrs = nullptr);
 
   /// Finish parsing an attribute for which parsing was delayed.
@@ -1521,10 +1526,10 @@ private:
   /// for each LateParsedAttribute. We consume the saved tokens and
   /// create an attribute with the arguments filled in. We add this
   /// to the Attribute list for the decl.
-  void ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
+  void ParseLexedCAttribute(LateParsedAttribute &LA,
                             ParsedAttributes *OutAttrs = nullptr);
 
-  void ParseLexedTypeAttribute(LateParsedTypeAttribute &LA, bool EnterScope,
+  void ParseLexedTypeAttribute(LateParsedTypeAttribute &LA,
                                ParsedAttributes &OutAttrs);
 
   /// Parse cached tokens for a late-parsed attribute and return the parsed

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -191,9 +191,9 @@ public:
 /// LateParsedTokens.
 struct LateParsedAttribute : public LateParsedDeclaration {
 
-  enum LPA_Kind {
-    LPA_Declaration,
-    LPA_Type,
+  enum class Kind {
+    Declaration,
+    Type,
   };
 
   Parser *Self;
@@ -204,25 +204,20 @@ struct LateParsedAttribute : public LateParsedDeclaration {
   SmallVector<Decl *, 2> Decls;
 
 private:
-  LPA_Kind Kind;
+  Kind K;
 
 public:
   explicit LateParsedAttribute(Parser *P, IdentifierInfo &Name,
-                               SourceLocation Loc,
-                               LPA_Kind Kind = LPA_Declaration)
-      : Self(P), AttrName(Name), AttrNameLoc(Loc), Kind(Kind) {}
+                               SourceLocation Loc, Kind K = Kind::Declaration)
+      : Self(P), AttrName(Name), AttrNameLoc(Loc), K(K) {}
 
   void ParseLexedAttributes() override;
 
   void addDecl(Decl *D) { Decls.push_back(D); }
 
-  LPA_Kind getKind() const { return Kind; }
+  Kind getKind() const { return K; }
 
-  // LLVM-style RTTI support
-  static bool classof(const LateParsedAttribute *LA) {
-    // LateParsedAttribute matches both Declaration and Type kinds
-    return LA->getKind() == LPA_Declaration || LA->getKind() == LPA_Type;
-  }
+  static bool classof(const LateParsedAttribute *LA) { return true; }
 };
 
 /// A late-parsed attribute that will be applied as a type attribute.
@@ -234,7 +229,7 @@ struct LateParsedTypeAttribute : public LateParsedAttribute {
 
   explicit LateParsedTypeAttribute(Parser *P, IdentifierInfo &Name,
                                    SourceLocation Loc)
-      : LateParsedAttribute(P, Name, Loc, LPA_Type) {}
+      : LateParsedAttribute(P, Name, Loc, Kind::Type) {}
 
   void ParseLexedAttributes() override;
 
@@ -243,9 +238,8 @@ struct LateParsedTypeAttribute : public LateParsedAttribute {
   /// parse the cached tokens and produce the final attribute.
   void ParseInto(ParsedAttributes &OutAttrs);
 
-  // LLVM-style RTTI support
   static bool classof(const LateParsedAttribute *LA) {
-    return LA->getKind() == LPA_Type;
+    return LA->getKind() == Kind::Type;
   }
 };
 

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -190,6 +190,12 @@ public:
 /// FIXME: Perhaps we should change the name of LateParsedDeclaration to
 /// LateParsedTokens.
 struct LateParsedAttribute : public LateParsedDeclaration {
+
+  enum LPA_Kind {
+    LPA_Declaration,
+    LPA_Type,
+  };
+
   Parser *Self;
   CachedTokens Toks;
   IdentifierInfo &AttrName;
@@ -197,13 +203,51 @@ struct LateParsedAttribute : public LateParsedDeclaration {
   SourceLocation AttrNameLoc;
   SmallVector<Decl *, 2> Decls;
 
+private:
+  LPA_Kind Kind;
+
+public:
   explicit LateParsedAttribute(Parser *P, IdentifierInfo &Name,
-                               SourceLocation Loc)
-      : Self(P), AttrName(Name), AttrNameLoc(Loc) {}
+                               SourceLocation Loc,
+                               LPA_Kind Kind = LPA_Declaration)
+      : Self(P), AttrName(Name), AttrNameLoc(Loc), Kind(Kind) {}
 
   void ParseLexedAttributes() override;
 
   void addDecl(Decl *D) { Decls.push_back(D); }
+
+  LPA_Kind getKind() const { return Kind; }
+
+  // LLVM-style RTTI support
+  static bool classof(const LateParsedAttribute *LA) {
+    // LateParsedAttribute matches both Declaration and Type kinds
+    return LA->getKind() == LPA_Declaration || LA->getKind() == LPA_Type;
+  }
+};
+
+/// Contains the lexed tokens of an attribute with arguments that
+/// may reference member variables and so need to be parsed at the
+/// end of the class declaration after parsing all other member
+/// member declarations.
+/// FIXME: Perhaps we should change the name of LateParsedDeclaration to
+/// LateParsedTokens.
+struct LateParsedTypeAttribute : public LateParsedAttribute {
+
+  explicit LateParsedTypeAttribute(Parser *P, IdentifierInfo &Name,
+                                   SourceLocation Loc)
+      : LateParsedAttribute(P, Name, Loc, LPA_Type) {}
+
+  void ParseLexedAttributes() override;
+
+  /// Parse this late-parsed type attribute and store results in OutAttrs.
+  /// This method can be called from Sema during type transformation to
+  /// parse the cached tokens and produce the final attribute.
+  void ParseInto(ParsedAttributes &OutAttrs);
+
+  // LLVM-style RTTI support
+  static bool classof(const LateParsedAttribute *LA) {
+    return LA->getKind() == LPA_Type;
+  }
 };
 
 /// Parser - This implements a parser for the C family of languages.  After
@@ -1165,6 +1209,7 @@ private:
 
 private:
   friend struct LateParsedAttribute;
+  friend struct LateParsedTypeAttribute;
 
   struct ParsingClass;
 
@@ -1485,6 +1530,15 @@ private:
   /// to the Attribute list for the decl.
   void ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
                             ParsedAttributes *OutAttrs = nullptr);
+
+  void ParseLexedTypeAttribute(LateParsedTypeAttribute &LA, bool EnterScope,
+                               ParsedAttributes &OutAttrs);
+
+  /// Helper function to move LateParsedTypeAttribute pointers from one list
+  /// to another. Filters type attributes from \p From and appends them to \p
+  /// To.
+  static void TakeTypeAttrsAppendingFrom(LateParsedAttrList &To,
+                                         LateParsedAttrList &From);
 
   void ParseLexedPragmas(ParsingClass &Class);
   void ParseLexedPragma(LateParsedPragma &LP);

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -51,6 +51,7 @@ namespace clang {
   class OverflowBehaviorType;
   struct TemplateIdAnnotation;
   struct LateParsedAttribute;
+  struct LateParsedTypeAttribute;
 
   /// Represents a C++ nested-name-specifier or a global scope specifier.
   ///
@@ -1254,9 +1255,11 @@ typedef SmallVector<Token, 4> CachedTokens;
 class LateParsedAttrList : public SmallVector<LateParsedAttribute *, 2> {
 public:
   LateParsedAttrList(bool PSoon = false,
-                     bool LateAttrParseExperimentalExtOnly = false)
+                     bool LateAttrParseExperimentalExtOnly = false,
+                     bool LateAttrParseTypeAttrOnly = false)
       : ParseSoon(PSoon),
-        LateAttrParseExperimentalExtOnly(LateAttrParseExperimentalExtOnly) {}
+        LateAttrParseExperimentalExtOnly(LateAttrParseExperimentalExtOnly),
+        LateAttrParseTypeAttrOnly(LateAttrParseTypeAttrOnly) {}
 
   bool parseSoon() { return ParseSoon; }
   /// returns true iff the attribute to be parsed should only be late parsed
@@ -1265,9 +1268,12 @@ public:
     return LateAttrParseExperimentalExtOnly;
   }
 
+  bool lateAttrParseTypeAttrOnly() { return LateAttrParseTypeAttrOnly; }
+
 private:
   bool ParseSoon; // Are we planning to parse these shortly after creation?
   bool LateAttrParseExperimentalExtOnly;
+  bool LateAttrParseTypeAttrOnly;
 };
 
 /// One instance of this struct is used for each type in a

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -1261,14 +1261,14 @@ public:
         LateAttrParseExperimentalExtOnly(LateAttrParseExperimentalExtOnly),
         LateAttrParseTypeAttrOnly(LateAttrParseTypeAttrOnly) {}
 
-  bool parseSoon() { return ParseSoon; }
+  bool parseSoon() const { return ParseSoon; }
   /// returns true iff the attribute to be parsed should only be late parsed
   /// if it is annotated with `LateAttrParseExperimentalExt`
-  bool lateAttrParseExperimentalExtOnly() {
+  bool lateAttrParseExperimentalExtOnly() const {
     return LateAttrParseExperimentalExtOnly;
   }
 
-  bool lateAttrParseTypeAttrOnly() { return LateAttrParseTypeAttrOnly; }
+  bool lateAttrParseTypeAttrOnly() const { return LateAttrParseTypeAttrOnly; }
 
 private:
   bool ParseSoon; // Are we planning to parse these shortly after creation?

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -319,6 +319,8 @@ void LateParsedAttribute::ParseLexedAttributes() {
   Self->ParseLexedAttribute(*this, true, false);
 }
 
+void LateParsedTypeAttribute::ParseLexedAttributes() {}
+
 void Parser::LateParsedPragma::ParseLexedPragmas() {
   Self->ParseLexedPragma(*this);
 }

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4825,12 +4825,12 @@ void Parser::ParseStructDeclaration(
 
 // TODO: All callers of this function should be moved to
 // `Parser::ParseLexedAttributeList`.
-void Parser::ParseLexedCAttributeList(LateParsedAttrList &LAs, bool EnterScope,
+void Parser::ParseLexedCAttributeList(LateParsedAttrList &LAs,
                                       ParsedAttributes *OutAttrs) {
   assert(LAs.parseSoon() &&
          "Attribute list should be marked for immediate parsing.");
   for (auto *LA : LAs) {
-    ParseLexedCAttribute(*LA, EnterScope, OutAttrs);
+    ParseLexedCAttribute(*LA, OutAttrs);
     delete LA;
   }
   LAs.clear();
@@ -4876,7 +4876,7 @@ ParsedAttributes Parser::ParseLexedCAttributeTokens(LateParsedAttribute &LA) {
   return Attrs;
 }
 
-void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
+void Parser::ParseLexedCAttribute(LateParsedAttribute &LA,
                                   ParsedAttributes *OutAttrs) {
   ParsedAttributes Attrs = ParseLexedCAttributeTokens(LA);
 
@@ -4888,7 +4888,6 @@ void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
 }
 
 void Parser::ParseLexedTypeAttribute(LateParsedTypeAttribute &LA,
-                                     bool EnterScope,
                                      ParsedAttributes &OutAttrs) {
   ParsedAttributes Attrs = ParseLexedCAttributeTokens(LA);
   OutAttrs.takeAllAppendingFrom(Attrs);
@@ -4896,7 +4895,7 @@ void Parser::ParseLexedTypeAttribute(LateParsedTypeAttribute &LA,
 
 void LateParsedTypeAttribute::ParseInto(ParsedAttributes &OutAttrs) {
   // Delegate to the Parser that created this attribute
-  Self->ParseLexedTypeAttribute(*this, /*EnterScope=*/true, OutAttrs);
+  Self->ParseLexedTypeAttribute(*this, OutAttrs);
 }
 
 void Parser::TakeTypeAttrsAppendingFrom(LateParsedAttrList &To,
@@ -5038,7 +5037,7 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
   MaybeParseGNUAttributes(attrs, &LateFieldAttrs);
 
   // Late parse field attributes if necessary.
-  ParseLexedCAttributeList(LateFieldAttrs, /*EnterScope=*/false);
+  ParseLexedCAttributeList(LateFieldAttrs);
 
   SmallVector<Decl *, 32> FieldDecls(TagDecl->fields());
 

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4885,6 +4885,72 @@ void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
   }
 }
 
+void Parser::ParseLexedTypeAttribute(LateParsedTypeAttribute &LA,
+                                     bool EnterScope,
+                                     ParsedAttributes &OutAttrs) {
+  // Create a fake EOF so that attribute parsing won't go off the end of the
+  // attribute.
+  Token AttrEnd;
+  AttrEnd.startToken();
+  AttrEnd.setKind(tok::eof);
+  AttrEnd.setLocation(Tok.getLocation());
+  AttrEnd.setEofData(LA.Toks.data());
+  LA.Toks.push_back(AttrEnd);
+
+  // Append the current token at the end of the new token stream so that it
+  // doesn't get lost.
+  LA.Toks.push_back(Tok);
+  PP.EnterTokenStream(LA.Toks, /*DisableMacroExpansion=*/true,
+                      /*IsReinject=*/true);
+  // Drop the current token and bring the first cached one. It's the same token
+  // as when we entered this function.
+  ConsumeAnyToken(/*ConsumeCodeCompletionTok=*/true);
+
+  // Note: EnterScope parameter is not used here. Type attributes are parsed
+  // in the context where ActOnFields is called, which already has the proper
+  // scope established. The actual semantic analysis happens during the
+  // RebuildTypeWithLateParsedAttr transformation, not during token parsing.
+  (void)EnterScope;
+
+  ParsedAttributes Attrs(AttrFactory);
+
+  assert(LA.Decls.size() <= 1 &&
+         "late field attribute expects to have at most one declaration.");
+
+  // Dispatch based on the attribute and parse it
+  ParseGNUAttributeArgs(&LA.AttrName, LA.AttrNameLoc, Attrs, nullptr, nullptr,
+                        SourceLocation(), ParsedAttr::Form::GNU(), nullptr);
+
+  // Due to a parsing error, we either went over the cached tokens or
+  // there are still cached tokens left, so we skip the leftover tokens.
+  while (Tok.isNot(tok::eof))
+    ConsumeAnyToken();
+
+  // Consume the fake EOF token if it's there
+  if (Tok.is(tok::eof) && Tok.getEofData() == AttrEnd.getEofData())
+    ConsumeAnyToken();
+
+  OutAttrs.takeAllAppendingFrom(Attrs);
+}
+
+void LateParsedTypeAttribute::ParseInto(ParsedAttributes &OutAttrs) {
+  // Delegate to the Parser that created this attribute
+  Self->ParseLexedTypeAttribute(*this, /*EnterScope=*/true, OutAttrs);
+}
+
+void Parser::TakeTypeAttrsAppendingFrom(LateParsedAttrList &To,
+                                        LateParsedAttrList &From) {
+  auto it =
+      std::remove_if(From.begin(), From.end(), [&](LateParsedAttribute *LA) {
+        if (auto *LTA = dyn_cast<LateParsedTypeAttribute>(LA)) {
+          To.push_back(LTA);
+          return true;
+        }
+        return false;
+      });
+  From.erase(it, From.end());
+}
+
 void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
                                   DeclSpec::TST TagType, RecordDecl *TagDecl) {
   PrettyDeclStackTraceEntry CrashInfo(Actions.Context, TagDecl, RecordLoc,

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4880,7 +4880,7 @@ void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
                                   ParsedAttributes *OutAttrs) {
   ParsedAttributes Attrs = ParseLexedCAttributeTokens(LA);
 
-  for (auto *D : LA.Decls)
+  for (Decl *D : LA.Decls)
     Actions.ActOnFinishDelayedAttribute(getCurScope(), D, Attrs);
 
   if (OutAttrs)
@@ -4901,15 +4901,15 @@ void LateParsedTypeAttribute::ParseInto(ParsedAttributes &OutAttrs) {
 
 void Parser::TakeTypeAttrsAppendingFrom(LateParsedAttrList &To,
                                         LateParsedAttrList &From) {
-  auto it =
-      std::remove_if(From.begin(), From.end(), [&](LateParsedAttribute *LA) {
-        if (auto *LTA = dyn_cast<LateParsedTypeAttribute>(LA)) {
-          To.push_back(LTA);
+  LateParsedAttrList::iterator It =
+      llvm::remove_if(From, [&](LateParsedAttribute *LA) {
+        if (isa<LateParsedTypeAttribute>(LA)) {
+          To.push_back(LA);
           return true;
         }
         return false;
       });
-  From.erase(it, From.end());
+  From.erase(It, From.end());
 }
 
 void Parser::ParseStructUnionBody(SourceLocation RecordLoc,

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4836,8 +4836,7 @@ void Parser::ParseLexedCAttributeList(LateParsedAttrList &LAs, bool EnterScope,
   LAs.clear();
 }
 
-void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
-                                  ParsedAttributes *OutAttrs) {
+ParsedAttributes Parser::ParseLexedCAttributeTokens(LateParsedAttribute &LA) {
   // Create a fake EOF so that attribute parsing won't go off the end of the
   // attribute.
   Token AttrEnd;
@@ -4856,9 +4855,6 @@ void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
   // as when we entered this function.
   ConsumeAnyToken(/*ConsumeCodeCompletionTok=*/true);
 
-  // TODO: Use `EnterScope`
-  (void)EnterScope;
-
   ParsedAttributes Attrs(AttrFactory);
 
   assert(LA.Decls.size() <= 1 &&
@@ -4867,9 +4863,6 @@ void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
   // Dispatch based on the attribute and parse it
   ParseGNUAttributeArgs(&LA.AttrName, LA.AttrNameLoc, Attrs, nullptr, nullptr,
                         SourceLocation(), ParsedAttr::Form::GNU(), nullptr);
-
-  for (auto *D : LA.Decls)
-    Actions.ActOnFinishDelayedAttribute(getCurScope(), D, Attrs);
 
   // Due to a parsing error, we either went over the cached tokens or
   // there are still cached tokens left, so we skip the leftover tokens.
@@ -4880,56 +4873,24 @@ void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
   if (Tok.is(tok::eof) && Tok.getEofData() == AttrEnd.getEofData())
     ConsumeAnyToken();
 
-  if (OutAttrs) {
+  return Attrs;
+}
+
+void Parser::ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
+                                  ParsedAttributes *OutAttrs) {
+  ParsedAttributes Attrs = ParseLexedCAttributeTokens(LA);
+
+  for (auto *D : LA.Decls)
+    Actions.ActOnFinishDelayedAttribute(getCurScope(), D, Attrs);
+
+  if (OutAttrs)
     OutAttrs->takeAllAppendingFrom(Attrs);
-  }
 }
 
 void Parser::ParseLexedTypeAttribute(LateParsedTypeAttribute &LA,
                                      bool EnterScope,
                                      ParsedAttributes &OutAttrs) {
-  // Create a fake EOF so that attribute parsing won't go off the end of the
-  // attribute.
-  Token AttrEnd;
-  AttrEnd.startToken();
-  AttrEnd.setKind(tok::eof);
-  AttrEnd.setLocation(Tok.getLocation());
-  AttrEnd.setEofData(LA.Toks.data());
-  LA.Toks.push_back(AttrEnd);
-
-  // Append the current token at the end of the new token stream so that it
-  // doesn't get lost.
-  LA.Toks.push_back(Tok);
-  PP.EnterTokenStream(LA.Toks, /*DisableMacroExpansion=*/true,
-                      /*IsReinject=*/true);
-  // Drop the current token and bring the first cached one. It's the same token
-  // as when we entered this function.
-  ConsumeAnyToken(/*ConsumeCodeCompletionTok=*/true);
-
-  // Note: EnterScope parameter is not used here. Type attributes are parsed
-  // in the context where ActOnFields is called, which already has the proper
-  // scope established. The actual semantic analysis happens during the
-  // RebuildTypeWithLateParsedAttr transformation, not during token parsing.
-  (void)EnterScope;
-
-  ParsedAttributes Attrs(AttrFactory);
-
-  assert(LA.Decls.size() <= 1 &&
-         "late field attribute expects to have at most one declaration.");
-
-  // Dispatch based on the attribute and parse it
-  ParseGNUAttributeArgs(&LA.AttrName, LA.AttrNameLoc, Attrs, nullptr, nullptr,
-                        SourceLocation(), ParsedAttr::Form::GNU(), nullptr);
-
-  // Due to a parsing error, we either went over the cached tokens or
-  // there are still cached tokens left, so we skip the leftover tokens.
-  while (Tok.isNot(tok::eof))
-    ConsumeAnyToken();
-
-  // Consume the fake EOF token if it's there
-  if (Tok.is(tok::eof) && Tok.getEofData() == AttrEnd.getEofData())
-    ConsumeAnyToken();
-
+  ParsedAttributes Attrs = ParseLexedCAttributeTokens(LA);
   OutAttrs.takeAllAppendingFrom(Attrs);
 }
 


### PR DESCRIPTION
Preparatory refactoring for llvm/llvm-project#179612. The new late parsing approach needs a distinct data structure to carry type-attribute-specific information through the late parsing pipeline, separate from declaration-level late-parsed attributes.
- Add LateParsedTypeAttribute subtyping LateParsedAttribute
- Add ParseLexedTypeAttribute and LateTypeAttrParserCallback to Parser
- Extract the shared token setup, parsing, and cleanup logic from ParseLexedCAttribute and ParseLexedTypeAttribute into a common ParseLexedCAttributeTokens helper.