### PR TITLE
[lldb][docs] Reorganize website navigation into topic-based sections

### DIFF
--- a/lldb/docs/index.rst
+++ b/lldb/docs/index.rst
@@ -124,25 +124,41 @@ interesting areas to contribute to lldb.
 .. toctree::
    :hidden:
    :maxdepth: 1
-   :caption: Using LLDB
+   :caption: Getting Started
 
    use/tutorial
    use/map
-   use/formatting
-   use/variable
-   use/symbolication
-   use/symbols
-   use/remote
-   use/intel_pt
-   use/ondemand
-   use/aarch64-linux
-   use/symbolfilejson
-   use/lldbdap
-   use/mcp
    use/settings
    use/troubleshooting
-   use/links
    Man Page <man/lldb>
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :caption: Using LLDB
+
+   use/variable
+   use/formatting
+   use/symbolication
+   use/symbols
+   use/ondemand
+   use/remote
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :caption: IDE & Tool Integration
+
+   use/lldbdap
+   use/mcp
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :caption: Platform-Specific Topics
+
+   use/aarch64-linux
+   use/intel_pt
 
 .. toctree::
    :hidden:
@@ -153,40 +169,52 @@ interesting areas to contribute to lldb.
    Python API <python_api>
    Python Extensions <python_extensions>
 
-
 .. toctree::
    :hidden:
    :maxdepth: 1
-   :caption: Developing LLDB
+   :caption: Contributing to LLDB
 
    resources/overview
    resources/contributing
+   resources/lldbdap-contributing
    resources/build
    resources/test
    resources/qemu-testing
    resources/debugging
    resources/fuzzing
-   resources/sbapi
-   resources/dataformatters
-   resources/formatterbytecode
-   resources/extensions
-   resources/lldbgdbremote
-   resources/lldbplatformpackets
-   resources/caveats
-   resources/projects
-   resources/lldbdap-contributing
-   resources/addinglanguagesupport
-   Public C++ API <https://lldb.llvm.org/cpp_reference/namespacelldb.html>
-   Private C++ API <https://lldb.llvm.org/cpp_reference/index.html>
 
 .. toctree::
    :hidden:
    :maxdepth: 1
-   :caption: External Links
+   :caption: Architecture & Internals
 
+   Public C++ API <https://lldb.llvm.org/cpp_reference/namespacelldb.html>
+   Private C++ API <https://lldb.llvm.org/cpp_reference/index.html>
+   resources/sbapi
+   resources/dataformatters
+   resources/formatterbytecode
+   resources/addinglanguagesupport
+   resources/caveats
+   resources/projects
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :caption: Protocol & Format Specifications
+
+   resources/lldbgdbremote
+   resources/lldbplatformpackets
+   resources/extensions
+   use/symbolfilejson
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :caption: Resources
+
+   use/links
    Source Code <https://github.com/llvm/llvm-project>
    Releases <https://github.com/llvm/llvm-project/releases>
-   Join the Discord <https://discord.gg/xS7Z362>
    Discord Channel <https://discord.com/channels/636084430946959380/636732809708306432>
    Discussion Forums <https://discourse.llvm.org/c/subprojects/lldb/8>
    Developer Policy <https://llvm.org/docs/DeveloperPolicy.html>


### PR DESCRIPTION
As we've kept adding more documentation, the website has grown beyond what's easily navigated. This PR breaks the two flat "Using LLDB" and "Developing LLDB" sections into smaller, audience-oriented categories:

1. Getting Started: tutorial, GDB-to-LLDB map, settings, troubleshooting, man page
2. Using LLDB: variables, formatting, symbolication, symbols, on-demand, remote
3. IDE & Tool Integration: lldb-dap, MCP
4. Platform-Specific Topics: AArch64 Linux, Intel PT
5. Scripting LLDB: Python reference, API, extensions (unchanged)
6. Contributing to LLDB: overview, contributing, build, test, debugging, fuzzing
7. Architecture & Internals: C++ APIs, SB API, data formatters, formatter bytecode, language support, caveats, projects
8. Protocol & Format Specifications: symbol file JSON, GDB remote extensions, platform packets
9. Resources: external links, source code, releases, Discord, forums, etc.

My goal is to make it easier to find relevant pages without scanning a long list.