### PR TITLE
[clang] fix profiling of pack index expressions

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -478,7 +478,8 @@ Bug Fixes to C++ Support
 - Fixed a bug matching constrained out-of-line definitions of class members.
 - Fixed a crash when instantiating an invalid out-of-line static data member definition in a local class. (#GH176152)
 - Fixed a crash when pack expansions are used as arguments for non-pack parameters of built-in templates. (#GH180307)
-- Fixed a bug where captured variables in non-mutable lambdas were incorrectly treated as mutable 
+- Fix a problem where pack index expressions where incorrectly being regarded as equivalent.
+- Fixed a bug where captured variables in non-mutable lambdas were incorrectly treated as mutable
   when used inside decltype in the return type. (#GH180460)
 - Fixed a crash when evaluating uninitialized GCC vector/ext_vector_type vectors in ``constexpr``. (#GH180044)
 - Fixed a crash when `explicit(bool)` is used with an incomplete enumeration. (#GH183887)

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -2362,14 +2362,14 @@ void StmtProfiler::VisitSizeOfPackExpr(const SizeOfPackExpr *S) {
 }
 
 void StmtProfiler::VisitPackIndexingExpr(const PackIndexingExpr *E) {
-  VisitExpr(E->getIndexExpr());
-
+  VisitStmtNoChildren(E);
+  Visit(E->getIndexExpr());
   if (E->expandsToEmptyPack() || E->getExpressions().size() != 0) {
     ID.AddInteger(E->getExpressions().size());
     for (const Expr *Sub : E->getExpressions())
       Visit(Sub);
   } else {
-    VisitExpr(E->getPackIdExpression());
+    Visit(E->getPackIdExpression());
   }
 }
 

--- a/clang/test/SemaCXX/cxx2c-pack-indexing.cpp
+++ b/clang/test/SemaCXX/cxx2c-pack-indexing.cpp
@@ -344,3 +344,13 @@ namespace GH123033 {
       convert<int, int>(12.34);
   }
 }
+
+namespace PackIndexExprEquivalency1 {
+  template <int... Ts, int... Us>
+    requires (Ts...[0] != 0)
+    void f() {}
+
+  template <int... Ts, int... Us>
+    requires (Us...[0] != 0)
+    void f() {}
+} // namespace PackIndexExprEquivalency1


### PR DESCRIPTION
This replaces a few incorrect calls of VisitExpr on subcomponents, which should have been plain `Visit` instead, because the former just implements the commonality between all kind-specific profile functions (marking the class kind and visiting children).

So this for example would visit a DeclRefExpr but not actually profile any of it's properties, like the parameter declaration, so it would fail to distinguish between DeclRefExps referencing distinct entities.

This also adds a call to record the PackIndexExpr's kind in the profile, to avoid false positives when comparing expressions with different kinds.