### PR TITLE
[SelectionDAG][NVPTX] Allow targets to configure CSE strategy

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -281,9 +281,10 @@ class SelectionDAG {
   /// Pool allocation for nodes.
   NodeAllocatorType NodeAllocator;
 
-  /// This structure is used to memoize nodes, automatically performing
-  /// CSE with existing nodes when a duplicate is requested.
-  FoldingSet<SDNode> CSEMap;
+  /// CSE map for SDNode deduplication.  Uses ContextualFoldingSet so the
+  /// trait Profile() can call SelectionDAGTargetInfo::augmentCSEKey() and
+  /// keep lookup/insertion keys in sync.
+  ContextualFoldingSet<SDNode, const SelectionDAG *> CSEMap;
 
   /// Pool allocation for machine-opcode SDNode operands.
   BumpPtrAllocator OperandAllocator;
@@ -2811,16 +2812,11 @@ private:
   void allnodes_clear();
 
   /// Look up the node specified by ID in CSEMap.  If it exists, return it.  If
-  /// not, return the insertion token that will make insertion faster.  This
-  /// overload is for nodes other than Constant or ConstantFP, use the other one
-  /// for those.
-  SDNode *FindNodeOrInsertPos(const FoldingSetNodeID &ID, void *&InsertPos);
-
-  /// Look up the node specified by ID in CSEMap.  If it exists, return it.  If
-  /// not, return the insertion token that will make insertion faster.  Performs
-  /// additional processing for constant nodes.
+  /// not, return the insertion token that will make insertion faster.
+  /// Opcode is used by target CSE policies to apply node-kind-specific rules.
+  /// Use SDLoc() for DL when there is no associated debug location.
   SDNode *FindNodeOrInsertPos(const FoldingSetNodeID &ID, const SDLoc &DL,
-                              void *&InsertPos);
+                              void *&InsertPos, unsigned Opcode);
 
   /// Maps to auto-CSE operations.
   std::vector<CondCodeSDNode*> CondCodeNodes;

--- a/llvm/include/llvm/CodeGen/SelectionDAGTargetInfo.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGTargetInfo.h
@@ -24,6 +24,8 @@
 namespace llvm {
 
 class CallInst;
+class DebugLoc;
+class FoldingSetNodeID;
 class SelectionDAG;
 
 //===----------------------------------------------------------------------===//
@@ -204,6 +206,14 @@ public:
   virtual bool disableGenericCombines(CodeGenOptLevel OptLevel) const {
     return false;
   }
+
+  /// Mix additional bytes into the CSE key for the given node context.
+  /// Default is a no-op (preserves stock CSE behavior). Called from
+  /// SelectionDAG::FindNodeOrInsertPos and from the ContextualFoldingSet
+  /// trait used by the CSE container, so lookup and insertion agree.
+  virtual void augmentCSEKey(FoldingSetNodeID &ID, unsigned Opcode,
+                             const DebugLoc &DL,
+                             const SelectionDAG &DAG) const {}
 };
 
 /// Proxy class that targets should inherit from if they wish to use

--- a/llvm/include/llvm/IR/DebugLoc.h
+++ b/llvm/include/llvm/IR/DebugLoc.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_IR_DEBUGLOC_H
 #define LLVM_IR_DEBUGLOC_H
 
+#include "llvm/ADT/FoldingSet.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/IR/TrackingMDRef.h"
 #include "llvm/Support/Compiler.h"
@@ -292,6 +293,9 @@ public:
   /// Check if the DebugLoc corresponds to an implicit code.
   LLVM_ABI bool isImplicitCode() const;
   LLVM_ABI void setImplicitCode(bool ImplicitCode);
+
+  /// Add the filename, line, and column to ID.
+  LLVM_ABI void Profile(FoldingSetNodeID &ID) const;
 
   bool operator==(const DebugLoc &DL) const { return Loc == DL.Loc; }
   bool operator!=(const DebugLoc &DL) const { return Loc != DL.Loc; }

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -84,6 +84,23 @@
 using namespace llvm;
 using namespace llvm::SDPatternMatch;
 
+/// FoldingSet trait for the SelectionDAG CSE map.  Routes node profiling
+/// through SelectionDAGTargetInfo::augmentCSEKey so targets can mix extra
+/// bytes into the CSE key (e.g. DebugLoc at -O0).  The default hook is a
+/// no-op, preserving stock CSE behavior for targets that don't override it.
+namespace llvm {
+template <>
+struct ContextualFoldingSetTrait<SDNode, const SelectionDAG *>
+    : public DefaultContextualFoldingSetTrait<SDNode, const SelectionDAG *> {
+  static void Profile(SDNode &N, FoldingSetNodeID &ID,
+                      const SelectionDAG *DAG) {
+    N.Profile(ID);
+    DAG->getSelectionDAGInfo().augmentCSEKey(ID, N.getOpcode(), N.getDebugLoc(),
+                                             *DAG);
+  }
+};
+} // namespace llvm
+
 /// makeVTList - Return an instance of the SDVTList struct initialized with the
 /// specified members.
 static SDVTList makeVTList(const EVT *VTs, unsigned NumVTs) {
@@ -1362,7 +1379,7 @@ SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N, SDValue Op,
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, N->getOpcode(), N->getVTList(), Ops);
   AddNodeIDCustom(ID, N);
-  SDNode *Node = FindNodeOrInsertPos(ID, SDLoc(N), InsertPos);
+  SDNode *Node = FindNodeOrInsertPos(ID, SDLoc(N), InsertPos, N->getOpcode());
   if (Node)
     Node->intersectFlagsWith(N->getFlags());
   return Node;
@@ -1382,7 +1399,7 @@ SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N,
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, N->getOpcode(), N->getVTList(), Ops);
   AddNodeIDCustom(ID, N);
-  SDNode *Node = FindNodeOrInsertPos(ID, SDLoc(N), InsertPos);
+  SDNode *Node = FindNodeOrInsertPos(ID, SDLoc(N), InsertPos, N->getOpcode());
   if (Node)
     Node->intersectFlagsWith(N->getFlags());
   return Node;
@@ -1400,7 +1417,7 @@ SDNode *SelectionDAG::FindModifiedNodeSlot(SDNode *N, ArrayRef<SDValue> Ops,
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, N->getOpcode(), N->getVTList(), Ops);
   AddNodeIDCustom(ID, N);
-  SDNode *Node = FindNodeOrInsertPos(ID, SDLoc(N), InsertPos);
+  SDNode *Node = FindNodeOrInsertPos(ID, SDLoc(N), InsertPos, N->getOpcode());
   if (Node)
     Node->intersectFlagsWith(N->getFlags());
   return Node;
@@ -1417,7 +1434,7 @@ Align SelectionDAG::getEVTAlign(EVT VT) const {
 SelectionDAG::SelectionDAG(const TargetMachine &tm, CodeGenOptLevel OL)
     : TM(tm), OptLevel(OL), EntryNode(ISD::EntryToken, 0, DebugLoc(),
                                       getVTList(MVT::Other, MVT::Glue)),
-      Root(getEntryNode()) {
+      Root(getEntryNode()), CSEMap(this) {
   InsertNode(&EntryNode);
   DbgInfo = new SDDbgInfo();
 }
@@ -1466,23 +1483,13 @@ void SelectionDAG::allnodes_clear() {
 }
 
 SDNode *SelectionDAG::FindNodeOrInsertPos(const FoldingSetNodeID &ID,
-                                          void *&InsertPos) {
-  SDNode *N = CSEMap.FindNodeOrInsertPos(ID, InsertPos);
-  if (N) {
-    switch (N->getOpcode()) {
-    default: break;
-    case ISD::Constant:
-    case ISD::ConstantFP:
-      llvm_unreachable("Querying for Constant and ConstantFP nodes requires "
-                       "debug location.  Use another overload.");
-    }
-  }
-  return N;
-}
-
-SDNode *SelectionDAG::FindNodeOrInsertPos(const FoldingSetNodeID &ID,
-                                          const SDLoc &DL, void *&InsertPos) {
-  SDNode *N = CSEMap.FindNodeOrInsertPos(ID, InsertPos);
+                                          const SDLoc &DL, void *&InsertPos,
+                                          unsigned Opcode) {
+  // Build the augmented key (the trait does the same on insertion paths so
+  // lookup and insertion agree).
+  FoldingSetNodeID AugID = ID;
+  TSI->augmentCSEKey(AugID, Opcode, DL.getDebugLoc(), *this);
+  SDNode *N = CSEMap.FindNodeOrInsertPos(AugID, InsertPos);
   if (N) {
     switch (N->getOpcode()) {
     case ISD::Constant:
@@ -1833,7 +1840,7 @@ SDValue SelectionDAG::getConstant(const ConstantInt &Val, const SDLoc &DL,
   ID.AddBoolean(isO);
   void *IP = nullptr;
   SDNode *N = nullptr;
-  if ((N = FindNodeOrInsertPos(ID, DL, IP)))
+  if ((N = FindNodeOrInsertPos(ID, DL, IP, Opc)))
     if (!VT.isVector())
       return SDValue(N, 0);
 
@@ -1914,7 +1921,7 @@ SDValue SelectionDAG::getConstantFP(const ConstantFP &V, const SDLoc &DL,
   ID.AddPointer(Elt);
   void *IP = nullptr;
   SDNode *N = nullptr;
-  if ((N = FindNodeOrInsertPos(ID, DL, IP)))
+  if ((N = FindNodeOrInsertPos(ID, DL, IP, Opc)))
     if (!VT.isVector())
       return SDValue(N, 0);
 
@@ -1973,13 +1980,13 @@ SDValue SelectionDAG::getGlobalAddress(const GlobalValue *GV, const SDLoc &DL,
   ID.AddInteger(Offset);
   ID.AddInteger(TargetFlags);
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP, Opc))
     return SDValue(E, 0);
 
   auto *N = newSDNode<GlobalAddressSDNode>(
       Opc, DL.getIROrder(), DL.getDebugLoc(), GV, VTs, Offset, TargetFlags);
   CSEMap.InsertNode(N, IP);
-    InsertNode(N);
+  InsertNode(N);
   return SDValue(N, 0);
 }
 
@@ -1989,7 +1996,8 @@ SDValue SelectionDAG::getDeactivationSymbol(const GlobalValue *GV) {
   AddNodeIDNode(ID, ISD::DEACTIVATION_SYMBOL, VTs, {});
   ID.AddPointer(GV);
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP))
+  if (SDNode *E =
+          FindNodeOrInsertPos(ID, SDLoc(), IP, ISD::DEACTIVATION_SYMBOL))
     return SDValue(E, 0);
 
   auto *N = newSDNode<DeactivationSymbolSDNode>(GV, VTs);
@@ -2005,7 +2013,7 @@ SDValue SelectionDAG::getFrameIndex(int FI, EVT VT, bool isTarget) {
   AddNodeIDNode(ID, Opc, VTs, {});
   ID.AddInteger(FI);
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP, Opc))
     return SDValue(E, 0);
 
   auto *N = newSDNode<FrameIndexSDNode>(FI, VTs, isTarget);
@@ -2025,7 +2033,7 @@ SDValue SelectionDAG::getJumpTable(int JTI, EVT VT, bool isTarget,
   ID.AddInteger(JTI);
   ID.AddInteger(TargetFlags);
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP, Opc))
     return SDValue(E, 0);
 
   auto *N = newSDNode<JumpTableSDNode>(JTI, VTs, isTarget, TargetFlags);
@@ -2059,7 +2067,7 @@ SDValue SelectionDAG::getConstantPool(const Constant *C, EVT VT,
   ID.AddPointer(C);
   ID.AddInteger(TargetFlags);
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP, Opc))
     return SDValue(E, 0);
 
   auto *N = newSDNode<ConstantPoolSDNode>(isTarget, C, VTs, Offset, *Alignment,
@@ -2087,7 +2095,7 @@ SDValue SelectionDAG::getConstantPool(MachineConstantPoolValue *C, EVT VT,
   C->addSelectionDAGCSEId(ID);
   ID.AddInteger(TargetFlags);
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP, Opc))
     return SDValue(E, 0);
 
   auto *N = newSDNode<ConstantPoolSDNode>(isTarget, C, VTs, Offset, *Alignment,
@@ -2102,7 +2110,7 @@ SDValue SelectionDAG::getBasicBlock(MachineBasicBlock *MBB) {
   AddNodeIDNode(ID, ISD::BasicBlock, getVTList(MVT::Other), {});
   ID.AddPointer(MBB);
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP, ISD::BasicBlock))
     return SDValue(E, 0);
 
   auto *N = newSDNode<BasicBlockSDNode>(MBB);
@@ -2401,7 +2409,7 @@ SDValue SelectionDAG::getVectorShuffle(EVT VT, const SDLoc &dl, SDValue N1,
     ID.AddInteger(MaskVec[i]);
 
   void* IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::VECTOR_SHUFFLE))
     return SDValue(E, 0);
 
   // Allocate the mask array for the node out of the BumpPtrAllocator, since
@@ -2437,7 +2445,7 @@ SDValue SelectionDAG::getRegister(Register Reg, EVT VT) {
   AddNodeIDNode(ID, ISD::Register, VTs, {});
   ID.AddInteger(Reg.id());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP, ISD::Register))
     return SDValue(E, 0);
 
   auto *N = newSDNode<RegisterSDNode>(Reg, VTs);
@@ -2452,7 +2460,7 @@ SDValue SelectionDAG::getRegisterMask(const uint32_t *RegMask) {
   AddNodeIDNode(ID, ISD::RegisterMask, getVTList(MVT::Untyped), {});
   ID.AddPointer(RegMask);
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP, ISD::RegisterMask))
     return SDValue(E, 0);
 
   auto *N = newSDNode<RegisterMaskSDNode>(RegMask);
@@ -2473,7 +2481,7 @@ SDValue SelectionDAG::getLabelNode(unsigned Opcode, const SDLoc &dl,
   AddNodeIDNode(ID, Opcode, getVTList(MVT::Other), Ops);
   ID.AddPointer(Label);
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP, Opcode))
     return SDValue(E, 0);
 
   auto *N =
@@ -2497,7 +2505,7 @@ SDValue SelectionDAG::getBlockAddress(const BlockAddress *BA, EVT VT,
   ID.AddInteger(Offset);
   ID.AddInteger(TargetFlags);
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP, Opc))
     return SDValue(E, 0);
 
   auto *N = newSDNode<BlockAddressSDNode>(Opc, VTs, BA, Offset, TargetFlags);
@@ -2512,7 +2520,7 @@ SDValue SelectionDAG::getSrcValue(const Value *V) {
   ID.AddPointer(V);
 
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP, ISD::SRCVALUE))
     return SDValue(E, 0);
 
   auto *N = newSDNode<SrcValueSDNode>(V);
@@ -2527,7 +2535,7 @@ SDValue SelectionDAG::getMDNode(const MDNode *MD) {
   ID.AddPointer(MD);
 
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP, ISD::MDNODE_SDNODE))
     return SDValue(E, 0);
 
   auto *N = newSDNode<MDNodeSDNode>(MD);
@@ -2553,7 +2561,7 @@ SDValue SelectionDAG::getAddrSpaceCast(const SDLoc &dl, EVT VT, SDValue Ptr,
   ID.AddInteger(DestAS);
 
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::ADDRSPACECAST))
     return SDValue(E, 0);
 
   auto *N = newSDNode<AddrSpaceCastSDNode>(dl.getIROrder(), dl.getDebugLoc(),
@@ -6964,7 +6972,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT) {
   FoldingSetNodeID ID;
   AddNodeIDNode(ID, Opcode, VTs, {});
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP, Opcode))
     return SDValue(E, 0);
 
   auto *N = newSDNode<SDNode>(Opcode, DL.getIROrder(), DL.getDebugLoc(), VTs);
@@ -7345,7 +7353,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opcode, VTs, Ops);
     void *IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP, Opcode)) {
       E->intersectFlagsWith(Flags);
       return SDValue(E, 0);
     }
@@ -8137,7 +8145,7 @@ SDValue SelectionDAG::getAssertAlign(const SDLoc &DL, SDValue Val, Align A) {
   ID.AddInteger(A.value());
 
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP, ISD::AssertAlign))
     return SDValue(E, 0);
 
   auto *N =
@@ -8738,7 +8746,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opcode, VTs, Ops);
     void *IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP, Opcode)) {
       E->intersectFlagsWith(Flags);
       return SDValue(E, 0);
     }
@@ -9006,7 +9014,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opcode, VTs, Ops);
     void *IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP, Opcode)) {
       E->intersectFlagsWith(Flags);
       return SDValue(E, 0);
     }
@@ -10216,7 +10224,8 @@ SDValue SelectionDAG::getAtomic(unsigned Opcode, const SDLoc &dl, EVT MemVT,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void* IP = nullptr;
-  if (auto *E = cast_or_null<AtomicSDNode>(FindNodeOrInsertPos(ID, dl, IP))) {
+  if (auto *E =
+          cast_or_null<AtomicSDNode>(FindNodeOrInsertPos(ID, dl, IP, Opcode))) {
     E->refineAlignment(MMO);
     E->refineRanges(MMO);
     return SDValue(E, 0);
@@ -10356,7 +10365,7 @@ SDValue SelectionDAG::getMemIntrinsicNode(unsigned Opcode, const SDLoc &dl,
       ID.AddInteger(MMO->getFlags());
     }
     void *IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+    if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, Opcode)) {
       cast<MemIntrinsicSDNode>(E)->refineAlignment(MMOs);
       return SDValue(E, 0);
     }
@@ -10390,7 +10399,7 @@ SDValue SelectionDAG::getLifetimeNode(bool IsStart, const SDLoc &dl,
   AddNodeIDNode(ID, Opcode, VTs, Ops);
   ID.AddInteger(FrameIndex);
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, Opcode))
     return SDValue(E, 0);
 
   LifetimeSDNode *N =
@@ -10414,7 +10423,7 @@ SDValue SelectionDAG::getPseudoProbeNode(const SDLoc &Dl, SDValue Chain,
   ID.AddInteger(Guid);
   ID.AddInteger(Index);
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, Dl, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, Dl, IP, Opcode))
     return SDValue(E, 0);
 
   auto *N = newSDNode<PseudoProbeSDNode>(
@@ -10531,7 +10540,8 @@ SDValue SelectionDAG::getLoad(ISD::MemIndexedMode AM, ISD::LoadExtType ExtType,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (auto *E = cast_or_null<LoadSDNode>(FindNodeOrInsertPos(ID, dl, IP))) {
+  if (auto *E = cast_or_null<LoadSDNode>(
+          FindNodeOrInsertPos(ID, dl, IP, ISD::LOAD))) {
     E->refineAlignment(MMO);
     E->refineRanges(MMO);
     return SDValue(E, 0);
@@ -10658,7 +10668,7 @@ SDValue SelectionDAG::getStore(SDValue Chain, const SDLoc &dl, SDValue Val,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::STORE)) {
     cast<StoreSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -10756,7 +10766,8 @@ SDValue SelectionDAG::getLoadVP(ISD::MemIndexedMode AM,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (auto *E = cast_or_null<VPLoadSDNode>(FindNodeOrInsertPos(ID, dl, IP))) {
+  if (auto *E = cast_or_null<VPLoadSDNode>(
+          FindNodeOrInsertPos(ID, dl, IP, ISD::VP_LOAD))) {
     E->refineAlignment(MMO);
     E->refineRanges(MMO);
     return SDValue(E, 0);
@@ -10854,7 +10865,7 @@ SDValue SelectionDAG::getStoreVP(SDValue Chain, const SDLoc &dl, SDValue Val,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::VP_STORE)) {
     cast<VPStoreSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -10924,7 +10935,7 @@ SDValue SelectionDAG::getTruncStoreVP(SDValue Chain, const SDLoc &dl,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::VP_STORE)) {
     cast<VPStoreSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -10955,7 +10966,7 @@ SDValue SelectionDAG::getIndexedStoreVP(SDValue OrigStore, const SDLoc &dl,
   ID.AddInteger(ST->getPointerInfo().getAddrSpace());
   ID.AddInteger(ST->getMemOperand()->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::VP_STORE))
     return SDValue(E, 0);
 
   auto *N = newSDNode<VPStoreSDNode>(
@@ -10988,7 +10999,8 @@ SDValue SelectionDAG::getStridedLoadVP(
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
 
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+  if (SDNode *E =
+          FindNodeOrInsertPos(ID, DL, IP, ISD::EXPERIMENTAL_VP_STRIDED_LOAD)) {
     cast<VPStridedLoadSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11043,7 +11055,8 @@ SDValue SelectionDAG::getStridedStoreVP(SDValue Chain, const SDLoc &DL,
       DL.getIROrder(), VTs, AM, IsTruncating, IsCompressing, MemVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+  if (SDNode *E =
+          FindNodeOrInsertPos(ID, DL, IP, ISD::EXPERIMENTAL_VP_STRIDED_STORE)) {
     cast<VPStridedStoreSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11092,7 +11105,8 @@ SDValue SelectionDAG::getTruncStridedStoreVP(SDValue Chain, const SDLoc &DL,
       DL.getIROrder(), VTs, ISD::UNINDEXED, true, IsCompressing, SVT, MMO));
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+  if (SDNode *E =
+          FindNodeOrInsertPos(ID, DL, IP, ISD::EXPERIMENTAL_VP_STRIDED_STORE)) {
     cast<VPStridedStoreSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11121,7 +11135,7 @@ SDValue SelectionDAG::getGatherVP(SDVTList VTs, EVT VT, const SDLoc &dl,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::VP_GATHER)) {
     cast<VPGatherSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11165,7 +11179,7 @@ SDValue SelectionDAG::getScatterVP(SDVTList VTs, EVT VT, const SDLoc &dl,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::VP_SCATTER)) {
     cast<VPScatterSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11215,7 +11229,7 @@ SDValue SelectionDAG::getMaskedLoad(EVT VT, const SDLoc &dl, SDValue Chain,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::MLOAD)) {
     cast<MaskedLoadSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11263,7 +11277,7 @@ SDValue SelectionDAG::getMaskedStore(SDValue Chain, const SDLoc &dl,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::MSTORE)) {
     cast<MaskedStoreSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11305,7 +11319,7 @@ SDValue SelectionDAG::getMaskedGather(SDVTList VTs, EVT MemVT, const SDLoc &dl,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::MGATHER)) {
     cast<MaskedGatherSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11352,7 +11366,7 @@ SDValue SelectionDAG::getMaskedScatter(SDVTList VTs, EVT MemVT, const SDLoc &dl,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::MSCATTER)) {
     cast<MaskedScatterSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11397,7 +11411,8 @@ SDValue SelectionDAG::getMaskedHistogram(SDVTList VTs, EVT MemVT,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP)) {
+  if (SDNode *E =
+          FindNodeOrInsertPos(ID, dl, IP, ISD::EXPERIMENTAL_VECTOR_HISTOGRAM)) {
     cast<MaskedGatherSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11434,7 +11449,7 @@ SDValue SelectionDAG::getLoadFFVP(EVT VT, const SDLoc &DL, SDValue Chain,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+  if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP, ISD::VP_LOAD_FF)) {
     cast<VPLoadFFSDNode>(E)->refineAlignment(MMO);
     return SDValue(E, 0);
   }
@@ -11462,7 +11477,7 @@ SDValue SelectionDAG::getGetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::GET_FPENV_MEM))
     return SDValue(E, 0);
 
   auto *N = newSDNode<FPStateAccessSDNode>(ISD::GET_FPENV_MEM, dl.getIROrder(),
@@ -11489,7 +11504,7 @@ SDValue SelectionDAG::getSetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr,
   ID.AddInteger(MMO->getPointerInfo().getAddrSpace());
   ID.AddInteger(MMO->getFlags());
   void *IP = nullptr;
-  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP))
+  if (SDNode *E = FindNodeOrInsertPos(ID, dl, IP, ISD::SET_FPENV_MEM))
     return SDValue(E, 0);
 
   auto *N = newSDNode<FPStateAccessSDNode>(ISD::SET_FPENV_MEM, dl.getIROrder(),
@@ -11722,7 +11737,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
     AddNodeIDNode(ID, Opcode, VTs, Ops);
     void *IP = nullptr;
 
-    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP, Opcode)) {
       E->intersectFlagsWith(Flags);
       return SDValue(E, 0);
     }
@@ -11918,7 +11933,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, SDVTList VTList,
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opcode, VTList, Ops);
     void *IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP, Opcode)) {
       E->intersectFlagsWith(Flags);
       return SDValue(E, 0);
     }
@@ -12088,7 +12103,8 @@ SDNode *SelectionDAG::UpdateNodeOperands(SDNode *N, SDValue Op) {
 
   updateDivergence(N);
   // If this gets put into a CSE map, add it.
-  if (InsertPos) CSEMap.InsertNode(N, InsertPos);
+  if (InsertPos)
+    CSEMap.InsertNode(N, InsertPos);
   return N;
 }
 
@@ -12117,7 +12133,8 @@ SDNode *SelectionDAG::UpdateNodeOperands(SDNode *N, SDValue Op1, SDValue Op2) {
 
   updateDivergence(N);
   // If this gets put into a CSE map, add it.
-  if (InsertPos) CSEMap.InsertNode(N, InsertPos);
+  if (InsertPos)
+    CSEMap.InsertNode(N, InsertPos);
   return N;
 }
 
@@ -12168,7 +12185,8 @@ UpdateNodeOperands(SDNode *N, ArrayRef<SDValue> Ops) {
 
   updateDivergence(N);
   // If this gets put into a CSE map, add it.
-  if (InsertPos) CSEMap.InsertNode(N, InsertPos);
+  if (InsertPos)
+    CSEMap.InsertNode(N, InsertPos);
   return N;
 }
 
@@ -12321,7 +12339,7 @@ SDNode *SelectionDAG::MorphNodeTo(SDNode *N, unsigned Opc,
   if (VTs.VTs[VTs.NumVTs-1] != MVT::Glue) {
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opc, VTs, Ops);
-    if (SDNode *ON = FindNodeOrInsertPos(ID, SDLoc(N), IP))
+    if (SDNode *ON = FindNodeOrInsertPos(ID, SDLoc(N), IP, Opc))
       return UpdateSDLocOnMergeSDNode(ON, SDLoc(N));
   }
 
@@ -12363,7 +12381,7 @@ SDNode *SelectionDAG::MorphNodeTo(SDNode *N, unsigned Opc,
   }
 
   if (IP)
-    CSEMap.InsertNode(N, IP);   // Memoize the new node.
+    CSEMap.InsertNode(N, IP); // Memoize the new node.
   return N;
 }
 
@@ -12514,7 +12532,7 @@ MachineSDNode *SelectionDAG::getMachineNode(unsigned Opcode, const SDLoc &DL,
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, ~Opcode, VTs, Ops);
     IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP)) {
+    if (SDNode *E = FindNodeOrInsertPos(ID, DL, IP, ~Opcode)) {
       return cast<MachineSDNode>(UpdateSDLocOnMergeSDNode(E, DL));
     }
   }
@@ -12573,7 +12591,7 @@ SDNode *SelectionDAG::getNodeIfExists(unsigned Opcode, SDVTList VTList,
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opcode, VTList, LookupOps);
     void *IP = nullptr;
-    if (SDNode *E = FindNodeOrInsertPos(ID, IP)) {
+    if (SDNode *E = FindNodeOrInsertPos(ID, SDLoc(), IP, Opcode)) {
       E->intersectFlagsWith(Flags);
       return E;
     }
@@ -12596,7 +12614,7 @@ bool SelectionDAG::doesNodeExist(unsigned Opcode, SDVTList VTList,
     FoldingSetNodeID ID;
     AddNodeIDNode(ID, Opcode, VTList, Ops);
     void *IP = nullptr;
-    if (FindNodeOrInsertPos(ID, SDLoc(), IP))
+    if (FindNodeOrInsertPos(ID, SDLoc(), IP, Opcode))
       return true;
   }
   return false;

--- a/llvm/lib/IR/DebugLoc.cpp
+++ b/llvm/lib/IR/DebugLoc.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/IR/DebugLoc.h"
+#include "llvm/ADT/FoldingSet.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/IR/DebugInfo.h"
 
@@ -91,6 +92,13 @@ bool DebugLoc::isImplicitCode() const {
 void DebugLoc::setImplicitCode(bool ImplicitCode) {
   if (DILocation *Loc = get())
     Loc->setImplicitCode(ImplicitCode);
+}
+
+void DebugLoc::Profile(FoldingSetNodeID &ID) const {
+  ID.AddInteger(getLine());
+  ID.AddInteger(getCol());
+  ID.AddPointer(getScope());
+  ID.AddPointer(getInlinedAt());
 }
 
 DebugLoc DebugLoc::replaceInlinedAtSubprogram(

--- a/llvm/lib/Target/NVPTX/NVPTXSelectionDAGInfo.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXSelectionDAGInfo.cpp
@@ -7,11 +7,36 @@
 //===----------------------------------------------------------------------===//
 
 #include "NVPTXSelectionDAGInfo.h"
+#include "llvm/ADT/FoldingSet.h"
+#include "llvm/CodeGen/ISDOpcodes.h"
+#include "llvm/CodeGen/SelectionDAG.h"
+#include "llvm/CodeGen/SelectionDAGNodes.h"
+#include "llvm/IR/DebugLoc.h"
+#include "llvm/Support/CodeGen.h"
 
 #define GET_SDNODE_DESC
 #include "NVPTXGenSDNodeInfo.inc"
 
 using namespace llvm;
+
+void NVPTXSelectionDAGInfo::augmentCSEKey(FoldingSetNodeID &ID, unsigned Opcode,
+                                          const DebugLoc &DL,
+                                          const SelectionDAG &DAG) const {
+  if (DAG.getOptLevel() != CodeGenOptLevel::None)
+    return;
+  if (!DL)
+    return;
+  switch (Opcode) {
+  case ISD::UNDEF:
+  case ISD::Constant:
+  case ISD::ConstantFP:
+  case ISD::TargetConstant:
+  case ISD::TargetConstantFP:
+    return; // Always CSE constants regardless of location.
+  default:
+    DL.Profile(ID);
+  }
+}
 
 NVPTXSelectionDAGInfo::NVPTXSelectionDAGInfo()
     : SelectionDAGGenTargetInfo(NVPTXGenSDNodeInfo) {}

--- a/llvm/lib/Target/NVPTX/NVPTXSelectionDAGInfo.h
+++ b/llvm/lib/Target/NVPTX/NVPTXSelectionDAGInfo.h
@@ -59,6 +59,15 @@ public:
 
   void verifyTargetNode(const SelectionDAG &DAG,
                         const SDNode *N) const override;
+
+  /// At -O0, mix the node's DebugLoc into the CSE key so that identical
+  /// operations at different source lines are kept distinct.  Constant nodes
+  /// (and ISD::UNDEF) are excluded so they keep sharing one SDNode across
+  /// the DAG; the DL-clearing logic in SelectionDAG::FindNodeOrInsertPos
+  /// prevents shared-constant nodes from carrying a misleading source
+  /// location.  Higher opt levels are a no-op.
+  void augmentCSEKey(FoldingSetNodeID &ID, unsigned Opcode, const DebugLoc &DL,
+                     const SelectionDAG &DAG) const override;
 };
 
 } // namespace llvm

--- a/llvm/test/DebugInfo/NVPTX/cse-constants.ll
+++ b/llvm/test/DebugInfo/NVPTX/cse-constants.ll
@@ -1,0 +1,62 @@
+; -combiner-disabled suppresses DAGCombine's generic visit() pass.  We need it
+; here because DAGCombine's reassociateOpsCommutative fires unconditionally at
+; -O0 and would fold (a+42) + (a+42) into (a+a) + 84, hiding the per-line .loc
+; directives this test asserts on.  This test exercises NVPTXSDNodeCSEMap in
+; isolation; DAGCombine's behavior at -O0 is a separate, pre-existing concern.
+;
+; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda -O0 -combiner-disabled | FileCheck %s
+; RUN: %if ptxas %{ llc < %s -mtriple=nvptx64-nvidia-cuda -O0 -combiner-disabled | %ptxas-verify %}
+
+; At -O0, NVPTXSDNodeCSEMap excludes ISD::Constant from DebugLoc keying, so
+; identical constant SDNodes are always shared regardless of source location.
+; Operations with constant operands therefore inherit the normal DebugLoc-keyed
+; behavior: same DebugLoc folds, different DebugLoc does not.
+
+; -- Same DebugLoc: identical operations sharing a constant operand must be
+;    folded into one instruction; the consumer must see the same register for
+;    both operands.
+define i32 @const_same_loc(i32 %a) !dbg !3 {
+; CHECK-LABEL: const_same_loc(
+; CHECK:     .loc {{[0-9]+}} 1
+; CHECK:     add.s32 [[REG:%r[0-9]+]],
+; CHECK-NOT: .loc {{[0-9]+}} 1
+; CHECK:     .loc {{[0-9]+}} 3
+; CHECK:     add.s32 {{%r[0-9]+}}, [[REG]], [[REG]]
+  %x = add i32 %a, 42, !dbg !6
+  %y = add i32 %a, 42, !dbg !6
+  %z = add i32 %x, %y, !dbg !8
+  ret i32 %z, !dbg !9
+}
+
+; -- Different DebugLoc: identical operations sharing a constant operand must
+;    each produce their own .loc and instruction, even though the constant
+;    operand 42 is one shared SDNode.
+define i32 @const_diff_loc(i32 %a) !dbg !10 {
+; CHECK-LABEL: const_diff_loc(
+; CHECK: .loc {{[0-9]+}} 1
+; CHECK: add.s32
+; CHECK: .loc {{[0-9]+}} 2
+; CHECK: add.s32
+  %x = add i32 %a, 42, !dbg !11
+  %y = add i32 %a, 42, !dbg !12
+  %z = add i32 %x, %y, !dbg !13
+  ret i32 %z, !dbg !14
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "test.cu", directory: "/")
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = distinct !DISubprogram(name: "const_same_loc", scope: !1, file: !1, line: 1, type: !4, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !5)
+!4 = !DISubroutineType(types: !5)
+!5 = !{}
+!6 = !DILocation(line: 1, column: 1, scope: !3)
+!8 = !DILocation(line: 3, column: 1, scope: !3)
+!9 = !DILocation(line: 4, column: 1, scope: !3)
+!10 = distinct !DISubprogram(name: "const_diff_loc", scope: !1, file: !1, line: 1, type: !4, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !5)
+!11 = !DILocation(line: 1, column: 1, scope: !10)
+!12 = !DILocation(line: 2, column: 1, scope: !10)
+!13 = !DILocation(line: 3, column: 1, scope: !10)
+!14 = !DILocation(line: 4, column: 1, scope: !10)

--- a/llvm/test/DebugInfo/NVPTX/cse-inlined-at-same.ll
+++ b/llvm/test/DebugInfo/NVPTX/cse-inlined-at-same.ll
@@ -1,0 +1,34 @@
+; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda -O0 | FileCheck %s
+; RUN: %if ptxas %{ llc < %s -mtriple=nvptx64-nvidia-cuda -O0 | %ptxas-verify %}
+
+; Negative control for cse-inlined-at.ll: two operations with identical
+; line:column:scope:inlinedAt must still CSE at -O0.  We're not over-splitting
+; the bucket just because inlinedAt is present.
+
+define i32 @caller(i32 %a, i32 %b) !dbg !3 {
+; CHECK-LABEL: caller(
+; CHECK:     add.s32 [[REG:%r[0-9]+]],
+; CHECK-NOT: add.s32 {{%r[0-9]+}}, %r{{[0-9]+}}, %r{{[0-9]+}}
+; CHECK:     add.s32 {{%r[0-9]+}}, [[REG]], [[REG]]
+  %x = add i32 %a, %b, !dbg !20
+  %y = add i32 %a, %b, !dbg !20
+  %z = add i32 %x, %y, !dbg !10
+  ret i32 %z, !dbg !11
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "test.cu", directory: "/")
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+
+!3 = distinct !DISubprogram(name: "caller", scope: !1, file: !1, line: 1, type: !4, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !5)
+!4 = !DISubroutineType(types: !5)
+!5 = !{}
+!10 = !DILocation(line: 5, column: 1, scope: !3)
+!11 = !DILocation(line: 6, column: 1, scope: !3)
+
+!12 = distinct !DISubprogram(name: "callee", scope: !1, file: !1, line: 10, type: !4, isLocal: false, isDefinition: true, scopeLine: 10, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !5)
+!20 = !DILocation(line: 10, column: 1, scope: !12, inlinedAt: !21)
+!21 = distinct !DILocation(line: 2, column: 1, scope: !3)

--- a/llvm/test/DebugInfo/NVPTX/cse-inlined-at.ll
+++ b/llvm/test/DebugInfo/NVPTX/cse-inlined-at.ll
@@ -1,0 +1,42 @@
+; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda -O0 | FileCheck %s
+; RUN: %if ptxas %{ llc < %s -mtriple=nvptx64-nvidia-cuda -O0 | %ptxas-verify %}
+
+; At -O0, two operations with the same line:column:scope but different
+; `inlinedAt` chains must remain distinct.  Without inlinedAt as part of the
+; CSE key, two callee-side adds inlined at different call sites would collapse
+; into one and step debugging would skip a call site.
+
+define i32 @caller(i32 %a, i32 %b) !dbg !3 {
+; CHECK-LABEL: caller(
+; CHECK: add.s32
+; CHECK: add.s32
+  %x = add i32 %a, %b, !dbg !20
+  %y = add i32 %a, %b, !dbg !30
+  %z = add i32 %x, %y, !dbg !10
+  ret i32 %z, !dbg !11
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "test.cu", directory: "/")
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+
+; caller subprogram + locations inside it.
+!3 = distinct !DISubprogram(name: "caller", scope: !1, file: !1, line: 1, type: !4, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !5)
+!4 = !DISubroutineType(types: !5)
+!5 = !{}
+!10 = !DILocation(line: 5, column: 1, scope: !3)
+!11 = !DILocation(line: 6, column: 1, scope: !3)
+
+; callee subprogram, inlined at two different call sites in caller.
+!12 = distinct !DISubprogram(name: "callee", scope: !1, file: !1, line: 10, type: !4, isLocal: false, isDefinition: true, scopeLine: 10, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !5)
+
+; First inlined copy: callee's add at (10,1), inlined at caller line 2.
+!20 = !DILocation(line: 10, column: 1, scope: !12, inlinedAt: !21)
+!21 = distinct !DILocation(line: 2, column: 1, scope: !3)
+
+; Second inlined copy: callee's add at the same (10,1), inlined at caller line 3.
+!30 = !DILocation(line: 10, column: 1, scope: !12, inlinedAt: !31)
+!31 = distinct !DILocation(line: 3, column: 1, scope: !3)

--- a/llvm/test/DebugInfo/NVPTX/cse-opt.ll
+++ b/llvm/test/DebugInfo/NVPTX/cse-opt.ll
@@ -1,0 +1,34 @@
+; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda -O1 | FileCheck %s
+; RUN: %if ptxas %{ llc < %s -mtriple=nvptx64-nvidia-cuda -O1 | %ptxas-verify %}
+
+; At -O1 and above, NVPTXSDNodeCSEMap does not include DebugLoc in the key, so
+; identical operations at different source locations are folded normally.  The
+; source location from the second operation (line 2) must not appear in the
+; output, and the consumer must see the same register for both operands.
+
+define i32 @cse_opt(i32 %a, i32 %b) !dbg !3 {
+; CHECK-LABEL: cse_opt(
+; CHECK:     .loc {{[0-9]+}} 1
+; CHECK:     add.s32 [[REG:%r[0-9]+]],
+; CHECK-NOT: .loc {{[0-9]+}} 2
+; CHECK:     .loc {{[0-9]+}} 3
+; CHECK:     add.s32 {{%r[0-9]+}}, [[REG]], [[REG]]
+  %x = add i32 %a, %b, !dbg !6
+  %y = add i32 %a, %b, !dbg !7
+  %z = add i32 %x, %y, !dbg !8
+  ret i32 %z, !dbg !9
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "test.cu", directory: "/")
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = distinct !DISubprogram(name: "cse_opt", scope: !1, file: !1, line: 1, type: !4, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !5)
+!4 = !DISubroutineType(types: !5)
+!5 = !{}
+!6 = !DILocation(line: 1, column: 1, scope: !3)
+!7 = !DILocation(line: 2, column: 1, scope: !3)
+!8 = !DILocation(line: 3, column: 1, scope: !3)
+!9 = !DILocation(line: 4, column: 1, scope: !3)

--- a/llvm/test/DebugInfo/NVPTX/cse-same-loc.ll
+++ b/llvm/test/DebugInfo/NVPTX/cse-same-loc.ll
@@ -1,0 +1,33 @@
+; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda -O0 | FileCheck %s
+; RUN: %if ptxas %{ llc < %s -mtriple=nvptx64-nvidia-cuda -O0 | %ptxas-verify %}
+
+; At -O0, NVPTX keys CSE by both DAG structure and DebugLoc.  Two identical
+; operations at the SAME source location must be folded into one instruction;
+; the consumer of both results must therefore see the same register for both
+; operands.
+
+define i32 @cse_same_loc(i32 %a, i32 %b) !dbg !3 {
+; CHECK-LABEL: cse_same_loc(
+; CHECK:     .loc {{[0-9]+}} 1
+; CHECK:     add.s32 [[REG:%r[0-9]+]],
+; CHECK-NOT: .loc {{[0-9]+}} 1
+; CHECK:     .loc {{[0-9]+}} 3
+; CHECK:     add.s32 {{%r[0-9]+}}, [[REG]], [[REG]]
+  %x = add i32 %a, %b, !dbg !6
+  %y = add i32 %a, %b, !dbg !6
+  %z = add i32 %x, %y, !dbg !8
+  ret i32 %z, !dbg !9
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "test.cu", directory: "/")
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = distinct !DISubprogram(name: "cse_same_loc", scope: !1, file: !1, line: 1, type: !4, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !5)
+!4 = !DISubroutineType(types: !5)
+!5 = !{}
+!6 = !DILocation(line: 1, column: 1, scope: !3)
+!8 = !DILocation(line: 3, column: 1, scope: !3)
+!9 = !DILocation(line: 4, column: 1, scope: !3)

--- a/llvm/test/DebugInfo/NVPTX/cse-scope.ll
+++ b/llvm/test/DebugInfo/NVPTX/cse-scope.ll
@@ -1,0 +1,36 @@
+; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda -O0 | FileCheck %s
+; RUN: %if ptxas %{ llc < %s -mtriple=nvptx64-nvidia-cuda -O0 | %ptxas-verify %}
+
+; At -O0, two operations at the same line:column but with different
+; DILexicalBlock scopes (e.g., one inside a `{ ... }` block, one outside)
+; must remain distinct.  Covers the scope half of isSameSourceLocation.
+
+define i32 @scopes(i32 %a, i32 %b) !dbg !3 {
+; CHECK-LABEL: scopes(
+; CHECK: add.s32
+; CHECK: add.s32
+  %x = add i32 %a, %b, !dbg !10
+  %y = add i32 %a, %b, !dbg !11
+  %z = add i32 %x, %y, !dbg !12
+  ret i32 %z, !dbg !13
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "test.cu", directory: "/")
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = distinct !DISubprogram(name: "scopes", scope: !1, file: !1, line: 1, type: !4, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !5)
+!4 = !DISubroutineType(types: !5)
+!5 = !{}
+
+; Two distinct lexical blocks; both have the same file:line:column origin.
+!6 = distinct !DILexicalBlock(scope: !3, file: !1, line: 2, column: 1)
+!7 = distinct !DILexicalBlock(scope: !3, file: !1, line: 2, column: 1)
+
+; %x at (2,1) inside the first block, %y at (2,1) inside the second.
+!10 = !DILocation(line: 2, column: 1, scope: !6)
+!11 = !DILocation(line: 2, column: 1, scope: !7)
+!12 = !DILocation(line: 3, column: 1, scope: !3)
+!13 = !DILocation(line: 4, column: 1, scope: !3)

--- a/llvm/test/DebugInfo/NVPTX/no-cse-diff-loc.ll
+++ b/llvm/test/DebugInfo/NVPTX/no-cse-diff-loc.ll
@@ -1,0 +1,32 @@
+; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda -O0 | FileCheck %s
+; RUN: %if ptxas %{ llc < %s -mtriple=nvptx64-nvidia-cuda -O0 | %ptxas-verify %}
+
+; At -O0, NVPTX keys CSE by both DAG structure and DebugLoc.  Two identical
+; operations at different source lines must each produce their own .loc entry
+; and instruction rather than being folded into one.
+
+define i32 @no_cse_diff_loc(i32 %a, i32 %b) !dbg !3 {
+; CHECK-LABEL: no_cse_diff_loc(
+; CHECK: .loc {{[0-9]+}} 1
+; CHECK: add.s32
+; CHECK: .loc {{[0-9]+}} 2
+; CHECK: add.s32
+  %x = add i32 %a, %b, !dbg !6
+  %y = add i32 %a, %b, !dbg !7
+  %z = add i32 %x, %y, !dbg !8
+  ret i32 %z, !dbg !9
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "test.cu", directory: "/")
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = distinct !DISubprogram(name: "no_cse_diff_loc", scope: !1, file: !1, line: 1, type: !4, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !5)
+!4 = !DISubroutineType(types: !5)
+!5 = !{}
+!6 = !DILocation(line: 1, column: 1, scope: !3)
+!7 = !DILocation(line: 2, column: 1, scope: !3)
+!8 = !DILocation(line: 3, column: 1, scope: !3)
+!9 = !DILocation(line: 4, column: 1, scope: !3)


### PR DESCRIPTION
To improve the debugging experience, CUDA limits CSE in SelectionDAG at `-O0`. This patch introduces a system that allows targets to configure the CSE strategy that SelectionDAG uses. We add a strategy for NVPTX that avoids folding nodes with different debug infos and a default strategy for all other targets that leaves their behavior unchanged.