### PR TITLE
[lldb][macOS] add additional logging print to TestRosetta

### DIFF
--- a/lldb/test/API/macosx/rosetta/TestRosetta.py
+++ b/lldb/test/API/macosx/rosetta/TestRosetta.py
@@ -61,6 +61,7 @@ class TestRosetta(TestBase):
             os_version = get_os_version()
             if self.TraceOn():
                 self.runCmd("image list")
+                self.runCmd("target list")
                 self.runCmd("platform shell ls ~/Library/Developer/Xcode")
                 self.runCmd(
                     'platform shell ls ~/Library/Developer/Xcode/"macOS DeviceSupport/"'


### PR DESCRIPTION
to clearly show that we're executing x86_64 binaries in this debug session.