### PR TITLE
[ToolChains][FreeBSD] Pass -s to Linker

### DIFF
--- a/clang/lib/Driver/ToolChains/FreeBSD.cpp
+++ b/clang/lib/Driver/ToolChains/FreeBSD.cpp
@@ -150,6 +150,9 @@ void freebsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (!D.SysRoot.empty())
     CmdArgs.push_back(Args.MakeArgString("--sysroot=" + D.SysRoot));
 
+  if (Args.hasArg(options::OPT_s))
+    CmdArgs.push_back("-s");
+
   if (IsPIE)
     CmdArgs.push_back("-pie");
 


### PR DESCRIPTION
Clang now supports pass -s to Linker instead of using -Wl,-s. This change is in sync with Gnu Toolchain's behavior.