### PR TITLE
[SelectOptimize] Emit Fatal Error instead of Asserting on null PSI

### DIFF
--- a/llvm/lib/CodeGen/SelectOptimize.cpp
+++ b/llvm/lib/CodeGen/SelectOptimize.cpp
@@ -369,7 +369,9 @@ PreservedAnalyses SelectOptimizeImpl::run(Function &F,
 
   PSI = FAM.getResult<ModuleAnalysisManagerFunctionProxy>(F)
             .getCachedResult<ProfileSummaryAnalysis>(*F.getParent());
-  assert(PSI && "This pass requires module analysis pass `profile-summary`!");
+  if (!PSI)
+    reportFatalUsageError("This pass requires the profile-summary module "
+                          "analysis to be available.");
   BFI = &FAM.getResult<BlockFrequencyAnalysis>(F);
 
   // When optimizing for size, selects are preferable over branches.


### PR DESCRIPTION
SelectOptimize expects to have PSI available which will normally be available if the pipeline is set up correctly to require ProfileSummaryInfo at the beginning. However, we do not want to assert if someone sets up the pipeline incorrectly, instead reporting a fatal usage error.

Fixes #192759.