### PR TITLE
[lldb] Fix crash when evaluating expressions in Wasm targets

### DIFF
--- a/lldb/source/Plugins/Process/wasm/ProcessWasm.cpp
+++ b/lldb/source/Plugins/Process/wasm/ProcessWasm.cpp
@@ -28,6 +28,9 @@ ProcessWasm::ProcessWasm(lldb::TargetSP target_sp, ListenerSP listener_sp)
   // Wasm doesn't have any Unix-like signals as a platform concept, but pretend
   // like it does to appease LLDB.
   m_unix_signals_sp = UnixSignals::Create(target_sp->GetArchitecture());
+  // FIXME: LLVM's RuntimeDyld doesn't support the Wasm object format, so we
+  // can't JIT expressions for this target.
+  SetCanJIT(false);
 }
 
 void ProcessWasm::Initialize() {


### PR DESCRIPTION
LLDB crashes with "LLVM ERROR: Incompatible object format!" when evaluating expressions while debugging WebAssembly because ProcessWasm never disables JIT. RuntimeDyld only supports ELF, MachO, and COFF object formats, so attempting to JIT-compile an expression for a Wasm target produces the aforementioned fatal error.

This PR avoids the crash by calling `SetCanJIT(false)` in the `ProcessWasm` ctor. Simple expressions will still work via the IR interpreter, while expression requiring the JIT now show a proper error message instead of crashing.

Fixes #179915