### PR TITLE
[LazyValueInfo] Support vector types in ICmp condition handling

### DIFF
--- a/llvm/lib/Analysis/LazyValueInfo.cpp
+++ b/llvm/lib/Analysis/LazyValueInfo.cpp
@@ -1316,8 +1316,9 @@ LazyValueInfoImpl::getValueFromSimpleICmpCondition(CmpInst::Predicate Pred,
                                                    bool UseBlockValue) {
   ConstantRange RHSRange(RHS->getType()->getScalarSizeInBits(),
                          /*isFullSet=*/true);
-  if (ConstantInt *CI = dyn_cast<ConstantInt>(RHS)) {
-    RHSRange = ConstantRange(CI->getValue());
+  const APInt *C;
+  if (match(RHS, m_APInt(C))) {
+    RHSRange = ConstantRange(*C);
   } else if (UseBlockValue) {
     std::optional<ValueLatticeElement> R =
         getBlockValue(RHS, CxtI->getParent(), CxtI);
@@ -1391,7 +1392,7 @@ std::optional<ValueLatticeElement> LazyValueInfoImpl::getValueFromICmpCondition(
   }
 
   Type *Ty = Val->getType();
-  if (!Ty->isIntegerTy())
+  if (!Ty->isIntOrIntVectorTy())
     return ValueLatticeElement::getOverdefined();
 
   unsigned BitWidth = Ty->getScalarSizeInBits();

--- a/llvm/lib/Analysis/LazyValueInfo.cpp
+++ b/llvm/lib/Analysis/LazyValueInfo.cpp
@@ -1316,9 +1316,8 @@ LazyValueInfoImpl::getValueFromSimpleICmpCondition(CmpInst::Predicate Pred,
                                                    bool UseBlockValue) {
   ConstantRange RHSRange(RHS->getType()->getScalarSizeInBits(),
                          /*isFullSet=*/true);
-  const APInt *C;
-  if (match(RHS, m_APInt(C))) {
-    RHSRange = ConstantRange(*C);
+  if (auto *C = dyn_cast<Constant>(RHS)) {
+    RHSRange = C->toConstantRange();
   } else if (UseBlockValue) {
     std::optional<ValueLatticeElement> R =
         getBlockValue(RHS, CxtI->getParent(), CxtI);

--- a/llvm/test/Transforms/CorrelatedValuePropagation/vectors.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/vectors.ll
@@ -219,6 +219,20 @@ define <2 x float> @sitofp(<2 x i8> %a) {
   ret <2 x float> %res
 }
 
+; The and is redundant when the icmp condition guarantees the value is in range.
+define <16 x i16> @select_and_icmp_vector(<16 x i16> noundef %x) {
+; CHECK-LABEL: define range(i16 0, 25) <16 x i16> @select_and_icmp_vector(
+; CHECK-SAME: <16 x i16> noundef [[X:%.*]]) {
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult <16 x i16> [[X]], splat (i16 8)
+; CHECK-NEXT:    [[SEL:%.*]] = select <16 x i1> [[CMP]], <16 x i16> [[X]], <16 x i16> splat (i16 24)
+; CHECK-NEXT:    ret <16 x i16> [[SEL]]
+;
+  %and = and <16 x i16> %x, splat (i16 7)
+  %cmp = icmp ult <16 x i16> %x, splat (i16 8)
+  %sel = select <16 x i1> %cmp, <16 x i16> %and, <16 x i16> splat (i16 24)
+  ret <16 x i16> %sel
+}
+
 define <2 x i16> @and(<2 x i8> %a) {
 ; CHECK-LABEL: define range(i16 0, 256) <2 x i16> @and(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {

--- a/llvm/test/Transforms/CorrelatedValuePropagation/vectors.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/vectors.ll
@@ -233,6 +233,20 @@ define <16 x i16> @select_and_icmp_vector(<16 x i16> noundef %x) {
   ret <16 x i16> %sel
 }
 
+define <2 x i16> @select_and_icmp_nonsplat(<2 x i16> noundef %x) {
+; CHECK-LABEL: define range(i16 0, 31) <2 x i16> @select_and_icmp_nonsplat(
+; CHECK-SAME: <2 x i16> noundef [[X:%.*]]) {
+; CHECK-NEXT:    [[AND:%.*]] = and <2 x i16> [[X]], <i16 7, i16 15>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult <2 x i16> [[X]], <i16 4, i16 8>
+; CHECK-NEXT:    [[SEL:%.*]] = select <2 x i1> [[CMP]], <2 x i16> [[AND]], <2 x i16> <i16 24, i16 30>
+; CHECK-NEXT:    ret <2 x i16> [[SEL]]
+;
+  %and = and <2 x i16> %x, <i16 7, i16 15>
+  %cmp = icmp ult <2 x i16> %x, <i16 4, i16 8>
+  %sel = select <2 x i1> %cmp, <2 x i16> %and, <2 x i16> <i16 24, i16 30>
+  ret <2 x i16> %sel
+}
+
 define <2 x i16> @and(<2 x i8> %a) {
 ; CHECK-LABEL: define range(i16 0, 256) <2 x i16> @and(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {

--- a/llvm/test/Transforms/CorrelatedValuePropagation/vectors.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/vectors.ll
@@ -236,12 +236,11 @@ define <16 x i16> @select_and_icmp_vector(<16 x i16> noundef %x) {
 define <2 x i16> @select_and_icmp_nonsplat(<2 x i16> noundef %x) {
 ; CHECK-LABEL: define range(i16 0, 31) <2 x i16> @select_and_icmp_nonsplat(
 ; CHECK-SAME: <2 x i16> noundef [[X:%.*]]) {
-; CHECK-NEXT:    [[AND:%.*]] = and <2 x i16> [[X]], <i16 7, i16 15>
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult <2 x i16> [[X]], <i16 4, i16 8>
-; CHECK-NEXT:    [[SEL:%.*]] = select <2 x i1> [[CMP]], <2 x i16> [[AND]], <2 x i16> <i16 24, i16 30>
+; CHECK-NEXT:    [[SEL:%.*]] = select <2 x i1> [[CMP]], <2 x i16> [[X]], <2 x i16> <i16 24, i16 30>
 ; CHECK-NEXT:    ret <2 x i16> [[SEL]]
 ;
-  %and = and <2 x i16> %x, <i16 7, i16 15>
+  %and = and <2 x i16> %x, splat (i16 7)
   %cmp = icmp ult <2 x i16> %x, <i16 4, i16 8>
   %sel = select <2 x i1> %cmp, <2 x i16> %and, <2 x i16> <i16 24, i16 30>
   ret <2 x i16> %sel


### PR DESCRIPTION
Use m_APInt matcher instead of ConstantInt dyn_cast so splat vector constants are handled, and relax the integer type check to accept integer vector types.

Fixes https://github.com/llvm/llvm-project/issues/192094