### PR TITLE
[clang][RISCV] Remove some of the bits added with RISC-V big endian support

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -437,7 +437,6 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     return std::make_unique<AMDGPUTargetInfo>(Triple, Opts);
 
   case llvm::Triple::riscv32:
-  case llvm::Triple::riscv32be:
     switch (os) {
     case llvm::Triple::NetBSD:
       return std::make_unique<NetBSDTargetInfo<RISCV32TargetInfo>>(Triple,
@@ -448,8 +447,15 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       return std::make_unique<RISCV32TargetInfo>(Triple, Opts);
     }
 
+  case llvm::Triple::riscv32be:
+    switch (os) {
+    case llvm::Triple::Linux:
+      return std::make_unique<LinuxTargetInfo<RISCV32TargetInfo>>(Triple, Opts);
+    default:
+      return std::make_unique<RISCV32TargetInfo>(Triple, Opts);
+    }
+
   case llvm::Triple::riscv64:
-  case llvm::Triple::riscv64be:
     switch (os) {
     case llvm::Triple::FreeBSD:
       return std::make_unique<FreeBSDTargetInfo<RISCV64TargetInfo>>(Triple,
@@ -484,6 +490,14 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     case llvm::Triple::Serenity:
       return std::make_unique<SerenityTargetInfo<RISCV64TargetInfo>>(Triple,
                                                                      Opts);
+    default:
+      return std::make_unique<RISCV64TargetInfo>(Triple, Opts);
+    }
+
+  case llvm::Triple::riscv64be:
+    switch (os) {
+    case llvm::Triple::Linux:
+      return std::make_unique<LinuxTargetInfo<RISCV64TargetInfo>>(Triple, Opts);
     default:
       return std::make_unique<RISCV64TargetInfo>(Triple, Opts);
     }

--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -255,7 +255,6 @@ public:
       break;
     case llvm::Triple::loongarch64:
     case llvm::Triple::riscv64:
-    case llvm::Triple::riscv64be:
       break;
     }
   }
@@ -520,7 +519,6 @@ public:
       break;
     case llvm::Triple::loongarch64:
     case llvm::Triple::riscv64:
-    case llvm::Triple::riscv64be:
       break;
     }
   }

--- a/clang/lib/Driver/ToolChains/FreeBSD.cpp
+++ b/clang/lib/Driver/ToolChains/FreeBSD.cpp
@@ -212,14 +212,6 @@ void freebsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-m");
     CmdArgs.push_back("elf64lriscv");
     break;
-  case llvm::Triple::riscv32be:
-    CmdArgs.push_back("-m");
-    CmdArgs.push_back("elf32briscv");
-    break;
-  case llvm::Triple::riscv64be:
-    CmdArgs.push_back("-m");
-    CmdArgs.push_back("elf64briscv");
-    break;
   case llvm::Triple::loongarch64:
     CmdArgs.push_back("-m");
     CmdArgs.push_back("elf64loongarch");

--- a/clang/test/Driver/freebsd.c
+++ b/clang/test/Driver/freebsd.c
@@ -226,3 +226,6 @@
 // PASS:      "--eh-frame-hdr"
 // PASS-SAME: "-export-dynamic"
 // PASS-SAME: "-s" "-t" "-T" "a.lds"
+
+// RUN: %clang -target riscv32be-unknown-freebsd -### -c %s 2>&1 | FileCheck %s --check-prefix=RV32BE
+// RV32BE-NOT: elf32briscv


### PR DESCRIPTION
- FreeBSD will not have any new 32-bit archs
- *BSD's are unlikely to touch BE RISC-V
- Keep the BE and LE targets separate