### PR TITLE
[clang][test] Use ToolSubst for spirv-tools lit substitutions

### DIFF
--- a/clang/test/Tooling/lit.local.cfg
+++ b/clang/test/Tooling/lit.local.cfg
@@ -5,7 +5,7 @@ if not config.root.clang_staticanalyzer:
 
 if config.spirv_tools_tests:
     config.available_features.add("spirv-tools")
-    config.substitutions.append(("spirv-dis", os.path.join(config.llvm_tools_dir, "spirv-dis")))
-    config.substitutions.append(("spirv-val", os.path.join(config.llvm_tools_dir, "spirv-val")))
-    config.substitutions.append(("spirv-as", os.path.join(config.llvm_tools_dir, "spirv-as")))
-    config.substitutions.append(("spirv-link", os.path.join(config.llvm_tools_dir, "spirv-link")))
+    from lit.llvm import llvm_config
+    llvm_config.add_tool_substitutions(
+        ["spirv-dis", "spirv-val", "spirv-as", "spirv-link"]
+    )


### PR DESCRIPTION
Bare-string substitutions match as substrings and the replacement path contains the tool name, causing corrupted RUN lines

The issue is reproducible, for example, when path to llvm has tool name substring at any point

Based on change for llvm tests: https://github.com/llvm/llvm-project/pull/192462