### PR TITLE
[RISCV][CodeGen] Add initial CodeGen support of vpair{e,o}

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -5626,7 +5626,8 @@ static SDValue lowerVZIP(unsigned Opc, SDValue Op0, SDValue Op1,
                          const RISCVSubtarget &Subtarget) {
   assert(RISCVISD::RI_VZIPEVEN_VL == Opc || RISCVISD::RI_VZIPODD_VL == Opc ||
          RISCVISD::RI_VZIP2A_VL == Opc || RISCVISD::RI_VZIP2B_VL == Opc ||
-         RISCVISD::RI_VUNZIP2A_VL == Opc || RISCVISD::RI_VUNZIP2B_VL == Opc);
+         RISCVISD::RI_VUNZIP2A_VL == Opc || RISCVISD::RI_VUNZIP2B_VL == Opc ||
+         RISCVISD::VPAIRE_VL == Opc || RISCVISD::VPAIRO_VL == Opc);
   assert(Op0.getSimpleValueType() == Op1.getSimpleValueType());
 
   MVT VT = Op0.getSimpleValueType();
@@ -6497,15 +6498,17 @@ static SDValue lowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG,
       return convertFromScalableVector(VT, Res, DAG, Subtarget);
     }
 
-    if (Subtarget.hasVendorXRivosVizip()) {
+    if (Subtarget.hasVendorXRivosVizip() || Subtarget.hasStdExtZvzip()) {
       bool TryWiden = false;
       unsigned Factor;
       if (isZipEven(SrcInfo, Mask, Factor)) {
         if (Factor == 1) {
           SDValue Src1 = SrcInfo[0].first == 0 ? V1 : V2;
           SDValue Src2 = SrcInfo[1].first == 0 ? V1 : V2;
-          return lowerVZIP(RISCVISD::RI_VZIPEVEN_VL, Src1, Src2, DL, DAG,
-                           Subtarget);
+          unsigned int Opc = Subtarget.hasStdExtZvzip()
+                                 ? RISCVISD::VPAIRE_VL
+                                 : RISCVISD::RI_VZIPEVEN_VL;
+          return lowerVZIP(Opc, Src1, Src2, DL, DAG, Subtarget);
         }
         TryWiden = true;
       }
@@ -6513,8 +6516,10 @@ static SDValue lowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG,
         if (Factor == 1) {
           SDValue Src1 = SrcInfo[1].first == 0 ? V1 : V2;
           SDValue Src2 = SrcInfo[0].first == 0 ? V1 : V2;
-          return lowerVZIP(RISCVISD::RI_VZIPODD_VL, Src1, Src2, DL, DAG,
-                           Subtarget);
+          unsigned int Opc = Subtarget.hasStdExtZvzip()
+                                 ? RISCVISD::VPAIRO_VL
+                                 : RISCVISD::RI_VZIPODD_VL;
+          return lowerVZIP(Opc, Src1, Src2, DL, DAG, Subtarget);
         }
         TryWiden = true;
       }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVVLPatterns.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVVLPatterns.td
@@ -938,14 +938,10 @@ multiclass VPatBinaryVL_VV<SDPatternOperator vop, string instruction_name,
 multiclass VPatBinaryVL_VV_VX<SDPatternOperator vop, string instruction_name,
                               list<VTypeInfo> vtilist = AllIntegerVectors,
                               bit isSEWAware = 0,
-                              list<Predicate> ExtraPreds = [],
-                              bit requireMinimal = false> 
-    : VPatBinaryVL_VV<vop, instruction_name, vtilist, isSEWAware, ExtraPreds, requireMinimal>{
+                              list<Predicate> ExtraPreds = []> 
+    : VPatBinaryVL_VV<vop, instruction_name, vtilist, isSEWAware, ExtraPreds>{
   foreach vti = vtilist in {
-    let Predicates = !listconcat(ExtraPreds,
-                                 !if(requireMinimal,
-                                     GetVTypeMinimalPredicates<vti>.Predicates,
-                                     GetVTypePredicates<vti>.Predicates)) in
+    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<vti>.Predicates) in
     def : VPatBinaryVL_XI<vop, instruction_name, "VX",
                           vti.Vector, vti.Vector, vti.Vector, vti.Mask,
                           vti.Log2SEW, vti.LMul, vti.RegClass, vti.RegClass,
@@ -955,14 +951,10 @@ multiclass VPatBinaryVL_VV_VX<SDPatternOperator vop, string instruction_name,
 
 multiclass VPatBinaryVL_VV_VX_VI<SDPatternOperator vop, string instruction_name,
                                  Operand ImmType = simm5,
-                                 list<Predicate> ExtraPreds = [],
-                                 bit requireMinimal = false>
-    : VPatBinaryVL_VV_VX<vop, instruction_name, AllIntegerVectors, 0, ExtraPreds, requireMinimal> {
+                                 list<Predicate> ExtraPreds = []>
+    : VPatBinaryVL_VV_VX<vop, instruction_name, ExtraPreds=ExtraPreds> {
   foreach vti = AllIntegerVectors in {
-    let Predicates = !listconcat(ExtraPreds,
-                                 !if(requireMinimal,
-                                     GetVTypeMinimalPredicates<vti>.Predicates,
-                                     GetVTypePredicates<vti>.Predicates)) in
+    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<vti>.Predicates) in
     def : VPatBinaryVL_XI<vop, instruction_name, "VI",
                           vti.Vector, vti.Vector, vti.Vector, vti.Mask,
                           vti.Log2SEW, vti.LMul, vti.RegClass, vti.RegClass,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVVLPatterns.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVVLPatterns.td
@@ -920,9 +920,13 @@ class VPatBinaryVL_XI<SDPatternOperator vop,
 multiclass VPatBinaryVL_VV<SDPatternOperator vop, string instruction_name,
                            list<VTypeInfo> vtilist = AllIntegerVectors,
                            bit isSEWAware = 0,
-                           list<Predicate> ExtraPreds = []> {
+                           list<Predicate> ExtraPreds = [],
+                           bit requireMinimal = false> {
   foreach vti = vtilist in {
-    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<vti>.Predicates) in {
+    let Predicates = !listconcat(ExtraPreds,
+                                 !if(requireMinimal,
+                                     GetVTypeMinimalPredicates<vti>.Predicates,
+                                     GetVTypePredicates<vti>.Predicates)) in {
     def : VPatBinaryVL_V<vop, instruction_name, "VV",
                          vti.Vector, vti.Vector, vti.Vector, vti.Mask,
                          vti.Log2SEW, vti.LMul, vti.RegClass, vti.RegClass,
@@ -934,10 +938,14 @@ multiclass VPatBinaryVL_VV<SDPatternOperator vop, string instruction_name,
 multiclass VPatBinaryVL_VV_VX<SDPatternOperator vop, string instruction_name,
                               list<VTypeInfo> vtilist = AllIntegerVectors,
                               bit isSEWAware = 0,
-                              list<Predicate> ExtraPreds = []> 
-    : VPatBinaryVL_VV<vop, instruction_name, vtilist, isSEWAware, ExtraPreds>{
+                              list<Predicate> ExtraPreds = [],
+                              bit requireMinimal = false> 
+    : VPatBinaryVL_VV<vop, instruction_name, vtilist, isSEWAware, ExtraPreds, requireMinimal>{
   foreach vti = vtilist in {
-    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<vti>.Predicates) in
+    let Predicates = !listconcat(ExtraPreds,
+                                 !if(requireMinimal,
+                                     GetVTypeMinimalPredicates<vti>.Predicates,
+                                     GetVTypePredicates<vti>.Predicates)) in
     def : VPatBinaryVL_XI<vop, instruction_name, "VX",
                           vti.Vector, vti.Vector, vti.Vector, vti.Mask,
                           vti.Log2SEW, vti.LMul, vti.RegClass, vti.RegClass,
@@ -947,10 +955,14 @@ multiclass VPatBinaryVL_VV_VX<SDPatternOperator vop, string instruction_name,
 
 multiclass VPatBinaryVL_VV_VX_VI<SDPatternOperator vop, string instruction_name,
                                  Operand ImmType = simm5,
-                                 list<Predicate> ExtraPreds = []>
-    : VPatBinaryVL_VV_VX<vop, instruction_name, ExtraPreds=ExtraPreds> {
+                                 list<Predicate> ExtraPreds = [],
+                                 bit requireMinimal = false>
+    : VPatBinaryVL_VV_VX<vop, instruction_name, AllIntegerVectors, 0, ExtraPreds, requireMinimal> {
   foreach vti = AllIntegerVectors in {
-    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<vti>.Predicates) in
+    let Predicates = !listconcat(ExtraPreds,
+                                 !if(requireMinimal,
+                                     GetVTypeMinimalPredicates<vti>.Predicates,
+                                     GetVTypePredicates<vti>.Predicates)) in
     def : VPatBinaryVL_XI<vop, instruction_name, "VI",
                           vti.Vector, vti.Vector, vti.Vector, vti.Mask,
                           vti.Log2SEW, vti.LMul, vti.RegClass, vti.RegClass,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
@@ -152,24 +152,9 @@ def vpaire_vl  : RVSDNode<"VPAIRE_VL", SDT_RISCVVecBinOp_VL>;
 def vpairo_vl  : RVSDNode<"VPAIRO_VL", SDT_RISCVVecBinOp_VL>;
 } // HasPassthruOp = true, HasMaskOp = true
 
-multiclass VPatVPAIR<SDPatternOperator op, string instruction_name> {
-  foreach vti = AllVectors in {
-    let Predicates = !listconcat([HasStdExtZvzip],
-                                 GetVTypeMinimalPredicates<vti>.Predicates) in {
-      def : Pat<(vti.Vector (op
-                       (vti.Vector vti.RegClass:$rs1),
-                       (vti.Vector vti.RegClass:$rs2),
-                       (vti.Vector vti.RegClass:$passthru),
-                       (vti.Mask VMV0:$vm),
-                       VLOpFrag)),
-                (!cast<Instruction>(instruction_name#"_VV_"#vti.LMul.MX#"_MASK")
-                             vti.RegClass:$passthru,
-                             vti.RegClass:$rs1,
-                             vti.RegClass:$rs2,
-                             (vti.Mask VMV0:$vm), GPR:$vl, vti.Log2SEW, TAIL_AGNOSTIC)>;
-    }
-  }
-}
-
-defm : VPatVPAIR<vpaire_vl, "PseudoVPAIRE">;
-defm : VPatVPAIR<vpairo_vl, "PseudoVPAIRO">;
+defm : VPatBinaryVL_VV<vpaire_vl, "PseudoVPAIRE", AllVectors, 0,
+                       ExtraPreds = [HasStdExtZvzip],
+                       requireMinimal = true>;
+defm : VPatBinaryVL_VV<vpairo_vl, "PseudoVPAIRO", AllVectors, 0,
+                       ExtraPreds = [HasStdExtZvzip],
+                       requireMinimal = true>;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
@@ -138,3 +138,12 @@ defm : VPatBinaryV_VV<"int_riscv_vpairo", "PseudoVPAIRO", AllVectors,
 defm : VPatBinaryW_VV<"int_riscv_vzip", "PseudoVZIP", AllZvzipVectors,
                       ExtraPreds = [HasStdExtZvzip],
                       requireMinimal = true>;
+
+// These are modeled after the int binop VL nodes
+let HasPassthruOp = true, HasMaskOp = true in {
+def vpaire_vl  : RVSDNode<"VPAIRE_VL", SDT_RISCVIntBinOp_VL>;
+def vpairo_vl  : RVSDNode<"VPAIRO_VL", SDT_RISCVIntBinOp_VL>;
+} // HasPassthruOp = true, HasMaskOp = true
+
+defm : VPatBinaryVL_VV<vpaire_vl, "PseudoVPAIRE">;
+defm : VPatBinaryVL_VV<vpairo_vl, "PseudoVPAIRO">;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
@@ -152,9 +152,9 @@ def vpaire_vl  : RVSDNode<"VPAIRE_VL", SDT_RISCVVecBinOp_VL>;
 def vpairo_vl  : RVSDNode<"VPAIRO_VL", SDT_RISCVVecBinOp_VL>;
 } // HasPassthruOp = true, HasMaskOp = true
 
-defm : VPatBinaryVL_VV<vpaire_vl, "PseudoVPAIRE", AllVectors, 0,
+defm : VPatBinaryVL_VV<vpaire_vl, "PseudoVPAIRE", AllVectors,
                        ExtraPreds = [HasStdExtZvzip],
                        requireMinimal = true>;
-defm : VPatBinaryVL_VV<vpairo_vl, "PseudoVPAIRO", AllVectors, 0,
+defm : VPatBinaryVL_VV<vpairo_vl, "PseudoVPAIRO", AllVectors,
                        ExtraPreds = [HasStdExtZvzip],
                        requireMinimal = true>;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
@@ -139,11 +139,37 @@ defm : VPatBinaryW_VV<"int_riscv_vzip", "PseudoVZIP", AllZvzipVectors,
                       ExtraPreds = [HasStdExtZvzip],
                       requireMinimal = true>;
 
-// These are modeled after the int binop VL nodes
+def SDT_RISCVVecBinOp_VL : SDTypeProfile<1, 5, [SDTCisSameAs<0, 1>,
+                                                SDTCisSameAs<0, 2>,
+                                                SDTCisVec<0>,
+                                                SDTCisSameAs<0, 3>,
+                                                SDTCVecEltisVT<4, i1>,
+                                                SDTCisSameNumEltsAs<0, 4>,
+                                                SDTCisVT<5, XLenVT>]>;
+
 let HasPassthruOp = true, HasMaskOp = true in {
-def vpaire_vl  : RVSDNode<"VPAIRE_VL", SDT_RISCVIntBinOp_VL>;
-def vpairo_vl  : RVSDNode<"VPAIRO_VL", SDT_RISCVIntBinOp_VL>;
+def vpaire_vl  : RVSDNode<"VPAIRE_VL", SDT_RISCVVecBinOp_VL>;
+def vpairo_vl  : RVSDNode<"VPAIRO_VL", SDT_RISCVVecBinOp_VL>;
 } // HasPassthruOp = true, HasMaskOp = true
 
-defm : VPatBinaryVL_VV<vpaire_vl, "PseudoVPAIRE">;
-defm : VPatBinaryVL_VV<vpairo_vl, "PseudoVPAIRO">;
+multiclass VPatVPAIR<SDPatternOperator op, string instruction_name> {
+  foreach vti = AllVectors in {
+    let Predicates = !listconcat([HasStdExtZvzip],
+                                 GetVTypeMinimalPredicates<vti>.Predicates) in {
+      def : Pat<(vti.Vector (op
+                       (vti.Vector vti.RegClass:$rs1),
+                       (vti.Vector vti.RegClass:$rs2),
+                       (vti.Vector vti.RegClass:$passthru),
+                       (vti.Mask VMV0:$vm),
+                       VLOpFrag)),
+                (!cast<Instruction>(instruction_name#"_VV_"#vti.LMul.MX#"_MASK")
+                             vti.RegClass:$passthru,
+                             vti.RegClass:$rs1,
+                             vti.RegClass:$rs2,
+                             (vti.Mask VMV0:$vm), GPR:$vl, vti.Log2SEW, TAIL_AGNOSTIC)>;
+    }
+  }
+}
+
+defm : VPatVPAIR<vpaire_vl, "PseudoVPAIRE">;
+defm : VPatVPAIR<vpairo_vl, "PseudoVPAIRO">;

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-deinterleave2.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-deinterleave2.ll
@@ -477,11 +477,10 @@ define void @vnsrl_64_i64(ptr %in, ptr %out) {
 ; ZVZIP:       # %bb.0: # %entry
 ; ZVZIP-NEXT:    vsetivli zero, 4, e64, m1, ta, ma
 ; ZVZIP-NEXT:    vle64.v v8, (a0)
-; ZVZIP-NEXT:    vmv.v.i v0, 1
-; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, mu
+; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vi v9, v8, 2
-; ZVZIP-NEXT:    vslidedown.vi v9, v8, 1, v0.t
-; ZVZIP-NEXT:    vse64.v v9, (a1)
+; ZVZIP-NEXT:    vpairo.vv v10, v8, v9
+; ZVZIP-NEXT:    vse64.v v10, (a1)
 ; ZVZIP-NEXT:    ret
 entry:
   %0 = load <4 x i64>, ptr %in, align 8
@@ -567,11 +566,10 @@ define void @vnsrl_64_double(ptr %in, ptr %out) {
 ; ZVZIP:       # %bb.0: # %entry
 ; ZVZIP-NEXT:    vsetivli zero, 4, e64, m1, ta, ma
 ; ZVZIP-NEXT:    vle64.v v8, (a0)
-; ZVZIP-NEXT:    vmv.v.i v0, 1
-; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, mu
+; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vi v9, v8, 2
-; ZVZIP-NEXT:    vslidedown.vi v9, v8, 1, v0.t
-; ZVZIP-NEXT:    vse64.v v9, (a1)
+; ZVZIP-NEXT:    vpairo.vv v10, v8, v9
+; ZVZIP-NEXT:    vse64.v v10, (a1)
 ; ZVZIP-NEXT:    ret
 entry:
   %0 = load <4 x double>, ptr %in, align 8
@@ -1343,12 +1341,11 @@ define void @vnsrl_32_i32_two_source(ptr %in0, ptr %in1, ptr %out) {
 ;
 ; ZVZIP-LABEL: vnsrl_32_i32_two_source:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, mu
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; ZVZIP-NEXT:    vle32.v v8, (a0)
 ; ZVZIP-NEXT:    vle32.v v9, (a1)
-; ZVZIP-NEXT:    vmv.v.i v0, 1
-; ZVZIP-NEXT:    vslidedown.vi v9, v8, 1, v0.t
-; ZVZIP-NEXT:    vse32.v v9, (a2)
+; ZVZIP-NEXT:    vpairo.vv v10, v8, v9
+; ZVZIP-NEXT:    vse32.v v10, (a2)
 ; ZVZIP-NEXT:    ret
 entry:
   %0 = load <2 x i32>, ptr %in0, align 4
@@ -1434,12 +1431,11 @@ define void @vnsrl_32_float_two_source(ptr %in0, ptr %in1, ptr %out) {
 ;
 ; ZVZIP-LABEL: vnsrl_32_float_two_source:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, mu
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; ZVZIP-NEXT:    vle32.v v8, (a0)
 ; ZVZIP-NEXT:    vle32.v v9, (a1)
-; ZVZIP-NEXT:    vmv.v.i v0, 1
-; ZVZIP-NEXT:    vslidedown.vi v9, v8, 1, v0.t
-; ZVZIP-NEXT:    vse32.v v9, (a2)
+; ZVZIP-NEXT:    vpairo.vv v10, v8, v9
+; ZVZIP-NEXT:    vse32.v v10, (a2)
 ; ZVZIP-NEXT:    ret
 entry:
   %0 = load <2 x float>, ptr %in0, align 4
@@ -1525,12 +1521,11 @@ define void @vnsrl_64_i64_two_source(ptr %in0, ptr %in1, ptr %out) {
 ;
 ; ZVZIP-LABEL: vnsrl_64_i64_two_source:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, mu
+; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
 ; ZVZIP-NEXT:    vle64.v v8, (a0)
 ; ZVZIP-NEXT:    vle64.v v9, (a1)
-; ZVZIP-NEXT:    vmv.v.i v0, 1
-; ZVZIP-NEXT:    vslidedown.vi v9, v8, 1, v0.t
-; ZVZIP-NEXT:    vse64.v v9, (a2)
+; ZVZIP-NEXT:    vpairo.vv v10, v8, v9
+; ZVZIP-NEXT:    vse64.v v10, (a2)
 ; ZVZIP-NEXT:    ret
 entry:
   %0 = load <2 x i64>, ptr %in0, align 8
@@ -1613,12 +1608,11 @@ define void @vnsrl_64_double_two_source(ptr %in0, ptr %in1, ptr %out) {
 ;
 ; ZVZIP-LABEL: vnsrl_64_double_two_source:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, mu
+; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
 ; ZVZIP-NEXT:    vle64.v v8, (a0)
 ; ZVZIP-NEXT:    vle64.v v9, (a1)
-; ZVZIP-NEXT:    vmv.v.i v0, 1
-; ZVZIP-NEXT:    vslidedown.vi v9, v8, 1, v0.t
-; ZVZIP-NEXT:    vse64.v v9, (a2)
+; ZVZIP-NEXT:    vpairo.vv v10, v8, v9
+; ZVZIP-NEXT:    vse64.v v10, (a2)
 ; ZVZIP-NEXT:    ret
 entry:
   %0 = load <2 x double>, ptr %in0, align 8

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-zipeven-zipodd.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-zipeven-zipodd.ll
@@ -23,9 +23,9 @@ define <4 x i32> @zipeven_v4i32(<4 x i32> %a, <4 x i32> %b) {
 ;
 ; ZVZIP-LABEL: zipeven_v4i32:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, mu
-; ZVZIP-NEXT:    vmv.v.i v0, 10
-; ZVZIP-NEXT:    vslideup.vi v8, v9, 1, v0.t
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vpaire.vv v10, v8, v9
+; ZVZIP-NEXT:    vmv.v.v v8, v10
 ; ZVZIP-NEXT:    ret
 entry:
   %c = shufflevector <4 x i32> %a, <4 x i32> %b, <4 x i32> <i32 0, i32 4, i32 2, i32 6>
@@ -50,10 +50,9 @@ define <4 x i32> @zipeven_v4i32_swapped(<4 x i32> %a, <4 x i32> %b) {
 ;
 ; ZVZIP-LABEL: zipeven_v4i32_swapped:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, mu
-; ZVZIP-NEXT:    vmv.v.i v0, 10
-; ZVZIP-NEXT:    vslideup.vi v9, v8, 1, v0.t
-; ZVZIP-NEXT:    vmv.v.v v8, v9
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vpaire.vv v10, v9, v8
+; ZVZIP-NEXT:    vmv.v.v v8, v10
 ; ZVZIP-NEXT:    ret
 entry:
   %c = shufflevector <4 x i32> %a, <4 x i32> %b, <4 x i32> <i32 4, i32 0, i32 6, i32 2>
@@ -78,10 +77,9 @@ define <4 x i64> @zipeven_v4i64(<4 x i64> %a, <4 x i64> %b) {
 ;
 ; ZVZIP-LABEL: zipeven_v4i64:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 1, e8, mf8, ta, ma
-; ZVZIP-NEXT:    vmv.v.i v0, 10
-; ZVZIP-NEXT:    vsetivli zero, 4, e64, m2, ta, mu
-; ZVZIP-NEXT:    vslideup.vi v8, v10, 1, v0.t
+; ZVZIP-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
+; ZVZIP-NEXT:    vpaire.vv v12, v8, v10
+; ZVZIP-NEXT:    vmv.v.v v8, v12
 ; ZVZIP-NEXT:    ret
 entry:
   %c = shufflevector <4 x i64> %a, <4 x i64> %b, <4 x i32> <i32 0, i32 4, i32 2, i32 6>
@@ -105,9 +103,9 @@ define <4 x half> @zipeven_v4f16(<4 x half> %a, <4 x half> %b) {
 ;
 ; ZVZIP-LABEL: zipeven_v4f16:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, mu
-; ZVZIP-NEXT:    vmv.v.i v0, 10
-; ZVZIP-NEXT:    vslideup.vi v8, v9, 1, v0.t
+; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; ZVZIP-NEXT:    vpaire.vv v10, v8, v9
+; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
 entry:
   %c = shufflevector <4 x half> %a, <4 x half> %b, <4 x i32> <i32 0, i32 4, i32 2, i32 6>
@@ -131,9 +129,9 @@ define <4 x float> @zipeven_v4f32(<4 x float> %a, <4 x float> %b) {
 ;
 ; ZVZIP-LABEL: zipeven_v4f32:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, mu
-; ZVZIP-NEXT:    vmv.v.i v0, 10
-; ZVZIP-NEXT:    vslideup.vi v8, v9, 1, v0.t
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vpaire.vv v10, v8, v9
+; ZVZIP-NEXT:    vmv.v.v v8, v10
 ; ZVZIP-NEXT:    ret
 entry:
   %c = shufflevector <4 x float> %a, <4 x float> %b, <4 x i32> <i32 0, i32 4, i32 2, i32 6>
@@ -158,10 +156,9 @@ define <4 x double> @zipeven_v4f64(<4 x double> %a, <4 x double> %b) {
 ;
 ; ZVZIP-LABEL: zipeven_v4f64:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 1, e8, mf8, ta, ma
-; ZVZIP-NEXT:    vmv.v.i v0, 10
-; ZVZIP-NEXT:    vsetivli zero, 4, e64, m2, ta, mu
-; ZVZIP-NEXT:    vslideup.vi v8, v10, 1, v0.t
+; ZVZIP-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
+; ZVZIP-NEXT:    vpaire.vv v12, v8, v10
+; ZVZIP-NEXT:    vmv.v.v v8, v12
 ; ZVZIP-NEXT:    ret
 entry:
   %c = shufflevector <4 x double> %a, <4 x double> %b, <4 x i32> <i32 0, i32 4, i32 2, i32 6>
@@ -187,10 +184,9 @@ define <4 x i32> @zipodd_v4i32(<4 x i32> %a, <4 x i32> %b) {
 ;
 ; ZVZIP-LABEL: zipodd_v4i32:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, mu
-; ZVZIP-NEXT:    vmv.v.i v0, 5
-; ZVZIP-NEXT:    vslidedown.vi v9, v8, 1, v0.t
-; ZVZIP-NEXT:    vmv.v.v v8, v9
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vpairo.vv v10, v8, v9
+; ZVZIP-NEXT:    vmv.v.v v8, v10
 ; ZVZIP-NEXT:    ret
 entry:
   %c = shufflevector <4 x i32> %a, <4 x i32> %b, <4 x i32> <i32 1, i32 5, i32 3, i32 7>
@@ -214,9 +210,9 @@ define <4 x i32> @zipodd_v4i32_swapped(<4 x i32> %a, <4 x i32> %b) {
 ;
 ; ZVZIP-LABEL: zipodd_v4i32_swapped:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, mu
-; ZVZIP-NEXT:    vmv.v.i v0, 5
-; ZVZIP-NEXT:    vslidedown.vi v8, v9, 1, v0.t
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vpairo.vv v10, v9, v8
+; ZVZIP-NEXT:    vmv.v.v v8, v10
 ; ZVZIP-NEXT:    ret
 entry:
   %c = shufflevector <4 x i32> %a, <4 x i32> %b, <4 x i32> <i32 5, i32 1, i32 7, i32 3>
@@ -286,9 +282,9 @@ define <4 x i32> @zipodd_v4i32_both(<4 x i32> %a) {
 ;
 ; ZVZIP-LABEL: zipodd_v4i32_both:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, mu
-; ZVZIP-NEXT:    vmv.v.i v0, 5
-; ZVZIP-NEXT:    vslidedown.vi v8, v8, 1, v0.t
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vpairo.vv v9, v8, v8
+; ZVZIP-NEXT:    vmv.v.v v8, v9
 ; ZVZIP-NEXT:    ret
 entry:
   %c = shufflevector <4 x i32> %a, <4 x i32> poison, <4 x i32> <i32 1, i32 1, i32 3, i32 3>
@@ -314,10 +310,8 @@ define <4 x i32> @zipeven_v4i32_both(<4 x i32> %a) {
 ;
 ; ZVZIP-LABEL: zipeven_v4i32_both:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, mu
-; ZVZIP-NEXT:    vmv.v.i v0, 10
-; ZVZIP-NEXT:    vmv1r.v v9, v8
-; ZVZIP-NEXT:    vslideup.vi v9, v8, 1, v0.t
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vpaire.vv v9, v8, v8
 ; ZVZIP-NEXT:    vmv.v.v v8, v9
 ; ZVZIP-NEXT:    ret
 entry:
@@ -366,10 +360,9 @@ define <4 x i32> @zipodd_v4i32_partial(<4 x i32> %a, <4 x i32> %b) {
 ;
 ; ZVZIP-LABEL: zipodd_v4i32_partial:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, mu
-; ZVZIP-NEXT:    vmv.v.i v0, 5
-; ZVZIP-NEXT:    vslidedown.vi v9, v8, 1, v0.t
-; ZVZIP-NEXT:    vmv.v.v v8, v9
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vpairo.vv v10, v8, v9
+; ZVZIP-NEXT:    vmv.v.v v8, v10
 ; ZVZIP-NEXT:    ret
 entry:
   %c = shufflevector <4 x i32> %a, <4 x i32> %b, <4 x i32> <i32 1, i32 5, i32 3, i32 poison>
@@ -394,10 +387,9 @@ define <8 x i32> @zipeven_v8i32(<8 x i32> %v1, <8 x i32> %v2) {
 ;
 ; ZVZIP-LABEL: zipeven_v8i32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    li a0, 170
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, mu
-; ZVZIP-NEXT:    vmv.s.x v0, a0
-; ZVZIP-NEXT:    vslideup.vi v8, v10, 1, v0.t
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vpaire.vv v12, v8, v10
+; ZVZIP-NEXT:    vmv.v.v v8, v12
 ; ZVZIP-NEXT:    ret
   %out = shufflevector <8 x i32> %v1, <8 x i32> %v2, <8 x i32> <i32 0, i32 8, i32 2, i32 10, i32 4, i32 12, i32 6, i32 14>
   ret <8 x i32> %out
@@ -422,11 +414,9 @@ define <8 x i32> @zipodd_v8i32(<8 x i32> %v1, <8 x i32> %v2) {
 ;
 ; ZVZIP-LABEL: zipodd_v8i32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    li a0, 85
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, mu
-; ZVZIP-NEXT:    vmv.s.x v0, a0
-; ZVZIP-NEXT:    vslidedown.vi v10, v8, 1, v0.t
-; ZVZIP-NEXT:    vmv.v.v v8, v10
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vpairo.vv v12, v8, v10
+; ZVZIP-NEXT:    vmv.v.v v8, v12
 ; ZVZIP-NEXT:    ret
   %out = shufflevector <8 x i32> %v1, <8 x i32> %v2, <8 x i32> <i32 1, i32 9, i32 3, i32 11, i32 5, i32 13, i32 7, i32 15>
   ret <8 x i32> %out
@@ -451,11 +441,9 @@ define <16 x i64> @zipeven_v16i64(<16 x i64> %v1, <16 x i64> %v2) {
 ;
 ; ZVZIP-LABEL: zipeven_v16i64:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    lui a0, 11
-; ZVZIP-NEXT:    addi a0, a0, -1366
-; ZVZIP-NEXT:    vsetivli zero, 16, e64, m8, ta, mu
-; ZVZIP-NEXT:    vmv.s.x v0, a0
-; ZVZIP-NEXT:    vslideup.vi v8, v16, 1, v0.t
+; ZVZIP-NEXT:    vsetivli zero, 16, e64, m8, ta, ma
+; ZVZIP-NEXT:    vpaire.vv v24, v8, v16
+; ZVZIP-NEXT:    vmv.v.v v8, v24
 ; ZVZIP-NEXT:    ret
   %out = shufflevector <16 x i64> %v1, <16 x i64> %v2, <16 x i32> <i32 0, i32 16, i32 2, i32 18, i32 4, i32 20, i32 6, i32 22, i32 8, i32 24, i32 10, i32 26, i32 12, i32 28, i32 14, i32 30>
   ret <16 x i64> %out
@@ -481,12 +469,9 @@ define <16 x i64> @zipodd_v16i64(<16 x i64> %v1, <16 x i64> %v2) {
 ;
 ; ZVZIP-LABEL: zipodd_v16i64:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    lui a0, 5
-; ZVZIP-NEXT:    addi a0, a0, 1365
-; ZVZIP-NEXT:    vsetivli zero, 16, e64, m8, ta, mu
-; ZVZIP-NEXT:    vmv.s.x v0, a0
-; ZVZIP-NEXT:    vslidedown.vi v16, v8, 1, v0.t
-; ZVZIP-NEXT:    vmv.v.v v8, v16
+; ZVZIP-NEXT:    vsetivli zero, 16, e64, m8, ta, ma
+; ZVZIP-NEXT:    vpairo.vv v24, v8, v16
+; ZVZIP-NEXT:    vmv.v.v v8, v24
 ; ZVZIP-NEXT:    ret
   %out = shufflevector <16 x i64> %v1, <16 x i64> %v2, <16 x i32> <i32 1, i32 17, i32 3, i32 19, i32 5, i32 21, i32 7, i32 23, i32 9, i32 25, i32 11, i32 27, i32 13, i32 29, i32 15, i32 31>
   ret <16 x i64> %out
@@ -510,10 +495,9 @@ define <8 x i32> @zipeven_v8i32_as_v4i64(<8 x i32> %v1, <8 x i32> %v2) {
 ;
 ; ZVZIP-LABEL: zipeven_v8i32_as_v4i64:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    li a0, 204
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, mu
-; ZVZIP-NEXT:    vmv.s.x v0, a0
-; ZVZIP-NEXT:    vslideup.vi v8, v10, 2, v0.t
+; ZVZIP-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
+; ZVZIP-NEXT:    vpaire.vv v12, v8, v10
+; ZVZIP-NEXT:    vmv.v.v v8, v12
 ; ZVZIP-NEXT:    ret
   %out = shufflevector <8 x i32> %v1, <8 x i32> %v2, <8 x i32> <i32 0, i32 1, i32 8, i32 9, i32 4, i32 5, i32 12, i32 13>
   ret <8 x i32> %out
@@ -538,11 +522,9 @@ define <8 x i32> @zipodd_v8i32_as_v4i64(<8 x i32> %v1, <8 x i32> %v2) {
 ;
 ; ZVZIP-LABEL: zipodd_v8i32_as_v4i64:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    li a0, 51
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, mu
-; ZVZIP-NEXT:    vmv.s.x v0, a0
-; ZVZIP-NEXT:    vslidedown.vi v10, v8, 2, v0.t
-; ZVZIP-NEXT:    vmv.v.v v8, v10
+; ZVZIP-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
+; ZVZIP-NEXT:    vpairo.vv v12, v8, v10
+; ZVZIP-NEXT:    vmv.v.v v8, v12
 ; ZVZIP-NEXT:    ret
   %out = shufflevector <8 x i32> %v1, <8 x i32> %v2, <8 x i32> <i32 2, i32 3, i32 10, i32 11, i32 6, i32 7, i32 14, i32 15>
   ret <8 x i32> %out

--- a/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
@@ -97,10 +97,8 @@ define {<2 x i64>, <2 x i64>} @vector_deinterleave_v2i64_v4i64(<4 x i64> %vec) {
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 2, e64, m2, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vi v10, v8, 2
-; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, mu
-; ZVZIP-NEXT:    vmv.v.i v0, 1
-; ZVZIP-NEXT:    vmv1r.v v9, v10
-; ZVZIP-NEXT:    vslidedown.vi v9, v8, 1, v0.t
+; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
+; ZVZIP-NEXT:    vpairo.vv v9, v8, v10
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 1
 ; ZVZIP-NEXT:    ret
 %retval = call {<2 x i64>, <2 x i64>} @llvm.vector.deinterleave2.v4i64(<4 x i64> %vec)
@@ -547,10 +545,8 @@ define {<2 x double>, <2 x double>} @vector_deinterleave_v2f64_v4f64(<4 x double
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 2, e64, m2, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vi v10, v8, 2
-; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, mu
-; ZVZIP-NEXT:    vmv.v.i v0, 1
-; ZVZIP-NEXT:    vmv1r.v v9, v10
-; ZVZIP-NEXT:    vslidedown.vi v9, v8, 1, v0.t
+; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
+; ZVZIP-NEXT:    vpairo.vv v9, v8, v10
 ; ZVZIP-NEXT:    vslideup.vi v8, v10, 1
 ; ZVZIP-NEXT:    ret
 %retval = call {<2 x double>, <2 x double>} @llvm.vector.deinterleave2.v4f64(<4 x double> %vec)


### PR DESCRIPTION
Add initial support for vpair{e,o} instructions, which are included in zvzip extension.
Doc:

https://github.com/ved-rivos/riscv-isa-manual/blob/zvzip/src/zvzip.adoc
https://github.com/riscv/riscv-opcodes/blob/master/extensions/unratified/rv_zvzip.