### PR TITLE
[RISCV][CHERIoT] Define ABI_CHERIOT.

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
@@ -60,6 +60,7 @@ ABI computeTargetABI(const Triple &TT, const FeatureBitset &FeatureBits,
   auto TargetABI = getTargetABI(ABIName);
   bool IsRV64 = TT.isArch64Bit();
   bool IsRVE = FeatureBits[RISCV::FeatureStdExtE];
+  bool IsXCheriot = FeatureBits[RISCV::FeatureVendorXCheriot];
 
   if (!ABIName.empty() && TargetABI == ABI_Unknown) {
     errs()
@@ -73,11 +74,16 @@ ABI computeTargetABI(const Triple &TT, const FeatureBitset &FeatureBits,
     errs() << "64-bit ABIs are not supported for 32-bit targets (ignoring "
               "target-abi)\n";
     TargetABI = ABI_Unknown;
-  } else if (!IsRV64 && IsRVE && TargetABI != ABI_ILP32E &&
+  } else if (!IsRV64 && IsRVE && !IsXCheriot && TargetABI != ABI_ILP32E &&
              TargetABI != ABI_Unknown) {
     // TODO: move this checking to RISCVTargetLowering and RISCVAsmParser
     errs()
         << "Only the ilp32e ABI is supported for RV32E (ignoring target-abi)\n";
+    TargetABI = ABI_Unknown;
+  } else if (!IsRV64 && IsRVE && IsXCheriot && TargetABI != ABI_CHERIOT &&
+             TargetABI != ABI_Unknown) {
+    errs() << "Only the cheriot ABI is supported for XCheriot (ignoring "
+              "target-abi)\n";
     TargetABI = ABI_Unknown;
   } else if (IsRV64 && IsRVE && TargetABI != ABI_LP64E &&
              TargetABI != ABI_Unknown) {
@@ -119,6 +125,7 @@ ABI getTargetABI(StringRef ABIName) {
                        .Case("l64pc128", ABI_L64PC128)
                        .Case("l64pc128f", ABI_L64PC128F)
                        .Case("l64pc128d", ABI_L64PC128D)
+                       .Case("cheriot", ABI_CHERIOT)
                        .Default(ABI_Unknown);
   return TargetABI;
 }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
@@ -73,6 +73,7 @@ ABI computeTargetABI(const Triple &TT, const FeatureBitset &FeatureBits,
               "target-abi)\n";
     TargetABI = ABI_Unknown;
   } else if (!IsRV64 && IsRVE && TargetABI != ABI_ILP32E &&
+             TargetABI != ABI_CHERIOT && TargetABI != ABI_CHERIOT_BAREMETAL &&
              TargetABI != ABI_Unknown) {
     // TODO: move this checking to RISCVTargetLowering and RISCVAsmParser
     errs()
@@ -111,6 +112,8 @@ ABI getTargetABI(StringRef ABIName) {
                        .Case("lp64f", ABI_LP64F)
                        .Case("lp64d", ABI_LP64D)
                        .Case("lp64e", ABI_LP64E)
+                       .Case("cheriot", ABI_CHERIOT)
+                       .Case("cheriot-baremetal", ABI_CHERIOT_BAREMETAL)
                        .Default(ABI_Unknown);
   return TargetABI;
 }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
@@ -73,8 +73,7 @@ ABI computeTargetABI(const Triple &TT, const FeatureBitset &FeatureBits,
               "target-abi)\n";
     TargetABI = ABI_Unknown;
   } else if (!IsRV64 && IsRVE && TargetABI != ABI_ILP32E &&
-             TargetABI != ABI_CHERIOT && TargetABI != ABI_CHERIOT_BAREMETAL &&
-             TargetABI != ABI_Unknown) {
+             TargetABI != ABI_CHERIOT && TargetABI != ABI_Unknown) {
     // TODO: move this checking to RISCVTargetLowering and RISCVAsmParser
     errs()
         << "Only the ilp32e ABI is supported for RV32E (ignoring target-abi)\n";
@@ -113,7 +112,6 @@ ABI getTargetABI(StringRef ABIName) {
                        .Case("lp64d", ABI_LP64D)
                        .Case("lp64e", ABI_LP64E)
                        .Case("cheriot", ABI_CHERIOT)
-                       .Case("cheriot-baremetal", ABI_CHERIOT_BAREMETAL)
                        .Default(ABI_Unknown);
   return TargetABI;
 }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -681,6 +681,7 @@ enum ABI {
   ABI_L64PC128,
   ABI_L64PC128F,
   ABI_L64PC128D,
+  ABI_CHERIOT,
   ABI_Unknown
 };
 

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -671,6 +671,8 @@ enum ABI {
   ABI_LP64F,
   ABI_LP64D,
   ABI_LP64E,
+  ABI_CHERIOT,
+  ABI_CHERIOT_BAREMETAL,
   ABI_Unknown
 };
 

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -672,7 +672,6 @@ enum ABI {
   ABI_LP64D,
   ABI_LP64E,
   ABI_CHERIOT,
-  ABI_CHERIOT_BAREMETAL,
   ABI_Unknown
 };
 

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
@@ -142,6 +142,7 @@ void RISCVTargetELFStreamer::finish() {
   case RISCVABI::ABI_ILP32E:
   case RISCVABI::ABI_IL32PC64E:
   case RISCVABI::ABI_LP64E:
+  case RISCVABI::ABI_CHERIOT:
     EFlags |= ELF::EF_RISCV_RVE;
     break;
   case RISCVABI::ABI_Unknown:

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
@@ -108,6 +108,8 @@ void RISCVTargetELFStreamer::finish() {
     break;
   case RISCVABI::ABI_ILP32E:
   case RISCVABI::ABI_LP64E:
+  case RISCVABI::ABI_CHERIOT:
+  case RISCVABI::ABI_CHERIOT_BAREMETAL:
     EFlags |= ELF::EF_RISCV_RVE;
     break;
   case RISCVABI::ABI_Unknown:

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
@@ -109,7 +109,6 @@ void RISCVTargetELFStreamer::finish() {
   case RISCVABI::ABI_ILP32E:
   case RISCVABI::ABI_LP64E:
   case RISCVABI::ABI_CHERIOT:
-  case RISCVABI::ABI_CHERIOT_BAREMETAL:
     EFlags |= ELF::EF_RISCV_RVE;
     break;
   case RISCVABI::ABI_Unknown:

--- a/llvm/test/MC/RISCV/target-abi-invalid.s
+++ b/llvm/test/MC/RISCV/target-abi-invalid.s
@@ -74,6 +74,8 @@
 # RUN:   | FileCheck -check-prefix=RV32EFD-ILP32F %s
 # RUN: not llvm-mc -triple=riscv32 -mattr=+e,+d -target-abi ilp32d < %s 2>&1 \
 # RUN:   | FileCheck -check-prefix=RV32EFD-ILP32D %s
+# RUN: llvm-mc -triple=riscv32 -mattr=+e -target-abi cheriot < %s 2>&1 \
+# RUN:   | FileCheck -check-prefix=RV32E-CHERIOT %s
 
 # RV32E-ILP32: Only the ilp32e ABI is supported for RV32E (ignoring target-abi)
 # RV32EF-ILP32F: Only the ilp32e ABI is supported for RV32E (ignoring target-abi)
@@ -81,6 +83,7 @@
 # RV32EFD-ILP32F: LLVM ERROR: ILP32E cannot be used with the D ISA extension
 # RV32EFD-ILP32D: Only the ilp32e ABI is supported for RV32E (ignoring target-abi)
 # RV32EFD-ILP32D: LLVM ERROR: ILP32E cannot be used with the D ISA extension
+# RV32E-CHERIOT: Only the ilp32e ABI is supported for RV32E (ignoring target-abi)
 
 # RUN: llvm-mc -triple=riscv64 -mattr=+e -target-abi lp64 < %s 2>&1 \
 # RUN:   | FileCheck -check-prefix=RV64EF-LP64F %s
@@ -95,5 +98,10 @@
 # RV64EF-LP64F: Only the lp64e ABI is supported for RV64E (ignoring target-abi)
 # RV64EFD-LP64F: Only the lp64e ABI is supported for RV64E (ignoring target-abi)
 # RV64EFD-LP64D: Only the lp64e ABI is supported for RV64E (ignoring target-abi)
+
+# RUN: llvm-mc -triple=riscv32 -mattr=+e,+xcheriot -target-abi ilp32e < %s 2>&1 \
+# RUN:   | FileCheck -check-prefix=RV32EXCHERIOT-ILP32 %s
+
+# RV32EXCHERIOT-ILP32: Only the cheriot ABI is supported for XCheriot (ignoring target-abi)
 
 nop

--- a/llvm/test/MC/RISCV/target-abi-valid.s
+++ b/llvm/test/MC/RISCV/target-abi-valid.s
@@ -51,6 +51,10 @@
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-RVE %s
 
+# RUN: llvm-mc -triple=riscv32 -mattr=+xcheriot -target-abi cheriot -filetype=obj < %s \
+# RUN:   | llvm-readobj --file-headers - \
+# RUN:   | FileCheck -check-prefix=CHECK-CHERIOT %s
+
 # CHECK-NONE:               Flags [ (0x0)
 # CHECK-NONE-NEXT:          ]
 
@@ -65,5 +69,10 @@
 # CHECK-RVE:                Flags [ (0x8)
 # CHECK-RVE-NEXT:             EF_RISCV_RVE (0x8)
 # CHECK-RVE-NEXT:           ]
+
+# CHECK-CHERIOT:                Flags [ (0x9)
+# CHECK-CHERIOT-NEXT:             EF_RISCV_RVC (0x1)
+# CHECK-CHERIOT-NEXT:             EF_RISCV_RVE (0x8)
+# CHECK-CHERIOT-NEXT:           ]
 
 nop


### PR DESCRIPTION
These correspond to the CHERIoT ABI, documented here: https://github.com/CHERIoT-Platform/cheriot-sail/releases/download/v1.0/cheriot-architecture-v1.0.pdf
In particular, CHERIoT is an RV32E-based architecture extended with CHERI support that is not binary compatible with the proposed RV Y base. Amongst other changes, it has customized calling conventions, such as passing f64 in capability registers.