### PR TITLE
[CIR][AMDGPU] Add lowering for amdgcn_div_scale builtins

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAMDGPU.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAMDGPU.cpp
@@ -48,10 +48,33 @@ CIRGenFunction::emitAMDGPUBuiltinExpr(unsigned builtinId,
   }
   case AMDGPU::BI__builtin_amdgcn_div_scale:
   case AMDGPU::BI__builtin_amdgcn_div_scalef: {
-    cgm.errorNYI(expr->getSourceRange(),
-                 std::string("unimplemented AMDGPU builtin call: ") +
-                     getContext().BuiltinInfo.getName(builtinId));
-    return mlir::Value{};
+    Address flagOutPtr = emitPointerWithAlignment(expr->getArg(3));
+    llvm::StringRef intrinsicName = "amdgcn.div.scale";
+    mlir::Value x = emitScalarExpr(expr->getArg(0));
+    mlir::Value y = emitScalarExpr(expr->getArg(1));
+    mlir::Value z = emitScalarExpr(expr->getArg(2));
+
+    auto i1Ty = builder.getUIntNTy(1);
+    cir::RecordType resTy = builder.getAnonRecordTy(
+        {x.getType(), i1Ty}, /*packed=*/false, /*padded=*/false);
+
+    mlir::Value structResult =
+        cir::LLVMIntrinsicCallOp::create(builder, getLoc(expr->getExprLoc()),
+                                         builder.getStringAttr(intrinsicName),
+                                         resTy, {x, y, z})
+            .getResult();
+
+    mlir::Value result = cir::ExtractMemberOp::create(
+        builder, getLoc(expr->getExprLoc()), x.getType(), structResult, 0);
+    mlir::Value flag = cir::ExtractMemberOp::create(
+        builder, getLoc(expr->getExprLoc()), i1Ty, structResult, 1);
+
+    mlir::Type flagType = flagOutPtr.getElementType();
+    mlir::Value flagToStore =
+        cir::CastOp::create(builder, getLoc(expr->getExprLoc()), flagType,
+                            cir::CastKind::int_to_bool, flag);
+    builder.createStore(getLoc(expr->getExprLoc()), flagToStore, flagOutPtr);
+    return result;
   }
   case AMDGPU::BI__builtin_amdgcn_div_fmas:
   case AMDGPU::BI__builtin_amdgcn_div_fmasf: {

--- a/clang/test/CIR/CodeGenHIP/builtins-amdgcn.hip
+++ b/clang/test/CIR/CodeGenHIP/builtins-amdgcn.hip
@@ -1,0 +1,49 @@
+#include "../CodeGenCUDA/Inputs/cuda.h"
+
+// REQUIRES: amdgpu-registered-target
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN:            -target-cpu tahiti -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 -fclangir \
+// RUN:            -target-cpu tahiti -fcuda-is-device -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -std=c++11 \
+// RUN:            -target-cpu tahiti -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+//===----------------------------------------------------------------------===//
+// Test AMDGPU builtins
+//===----------------------------------------------------------------------===//
+
+// CIR-LABEL: @_Z18test_div_scale_f64PdPidd
+// CIR: cir.call_llvm_intrinsic "amdgcn.div.scale" {{.*}} : (!cir.double, !cir.double, !cir.bool)
+// LLVM: define{{.*}} void @_Z18test_div_scale_f64PdPidd
+// LLVM: call { double, i1 } @llvm.amdgcn.div.scale.f64(double %{{.+}}, double %{{.+}}, i1 true)
+__device__ void test_div_scale_f64(double* out, int* flagout, double a, double b)
+{
+  bool flag;
+  *out = __builtin_amdgcn_div_scale(a, b, true, &flag);
+  *flagout = flag;
+}
+
+// CIR-LABEL: @_Z18test_div_scale_f32PfPbff
+// CIR: cir.call_llvm_intrinsic "amdgcn.div.scale" {{.*}} : (!cir.float, !cir.float, !cir.bool)
+// LLVM: define{{.*}} void @_Z18test_div_scale_f32PfPbff
+// LLVM: call { float, i1 } @llvm.amdgcn.div.scale.f32(float %{{.+}}, float %{{.+}}, i1 true)
+__device__ void test_div_scale_f32(float* out, bool* flagout, float a, float b)
+{
+  bool flag;
+  *out = __builtin_amdgcn_div_scalef(a, b, true, &flag);
+  *flagout = flag;
+}
+
+// CIR-LABEL: @_Z27test_div_scale_f32_with_ptrPfPiPbff
+// CIR: cir.call_llvm_intrinsic "amdgcn.div.scale" {{.*}} : (!cir.float, !cir.float, !cir.bool)
+// LLVM: define{{.*}} void @_Z27test_div_scale_f32_with_ptrPfPiPbff
+// LLVM: {{.*}}call{{.*}} { float, i1 } @llvm.amdgcn.div.scale.f32(float %{{.+}}, float %{{.+}}, i1 true)
+__device__ void test_div_scale_f32_with_ptr(float* out, int* flagout, bool* flag, float a, float b)
+{
+  *out = __builtin_amdgcn_div_scalef(a, b, true, flag);
+}


### PR DESCRIPTION
Upstreaming clangIR PR: https://github.com/llvm/clangir/pull/2050

This PR adds support for lowering of _builtin_amdgcn_div_scale* amdgpu builtins to clangIR.
Followed similar lowering from reference clang->llvmir in clang/lib/CodeGen/TargetBuiltins/AMDGPU.cpp.