### PR TITLE
[libc] Implement shutdown on linux

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1219,6 +1219,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.sys.socket.getsockopt
     libc.src.sys.socket.listen
     libc.src.sys.socket.setsockopt
+    libc.src.sys.socket.shutdown
     libc.src.sys.socket.socket
   )
 endif()

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1353,6 +1353,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.sys.socket.getsockopt
     libc.src.sys.socket.listen
     libc.src.sys.socket.setsockopt
+    libc.src.sys.socket.shutdown
     libc.src.sys.socket.socket
     libc.src.sys.socket.socketpair
     libc.src.sys.socket.send

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1427,6 +1427,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.sys.socket.connect
     libc.src.sys.socket.getsockopt
     libc.src.sys.socket.listen
+    libc.src.sys.socket.shutdown
     libc.src.sys.socket.socketpair
     libc.src.sys.socket.setsockopt
     libc.src.sys.socket.send

--- a/libc/include/llvm-libc-macros/linux/sys-socket-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sys-socket-macros.h
@@ -43,4 +43,8 @@
 #define SO_BSDCOMPAT 14
 #define SO_REUSEPORT 15
 
+#define SHUT_RD 0
+#define SHUT_WR 1
+#define SHUT_RDWR 2
+
 #endif // LLVM_LIBC_MACROS_LINUX_SYS_SOCKET_MACROS_H

--- a/libc/include/sys/socket.yaml
+++ b/libc/include/sys/socket.yaml
@@ -123,6 +123,13 @@ functions:
       - type: int
       - type: const void *
       - type: socklen_t
+  - name: shutdown
+    standards:
+      - POSIX
+    return_type: int
+    arguments:
+      - type: int
+      - type: int
   - name: socket
     standards:
       - POSIX

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/shutdown.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/shutdown.h
@@ -1,0 +1,43 @@
+//===-- Implementation header for shutdown ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SHUTDOWN_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SHUTDOWN_H
+
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+
+#include <linux/net.h>   // For SYS_SHUTDOWN socketcall number.
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> shutdown(int sockfd, int how) {
+#ifdef SYS_shutdown
+  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_shutdown, sockfd, how);
+#elif defined(SYS_socketcall)
+  unsigned long sockcall_args[2] = {static_cast<unsigned long>(sockfd),
+                                    static_cast<unsigned long>(how)};
+  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_socketcall, SYS_SHUTDOWN,
+                                              sockcall_args);
+#else
+#error "shutdown and socketcall syscalls unavailable for this platform."
+#endif
+
+  if (ret < 0)
+    return Error(-static_cast<int>(ret));
+  return ret;
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_SHUTDOWN_H

--- a/libc/src/sys/socket/CMakeLists.txt
+++ b/libc/src/sys/socket/CMakeLists.txt
@@ -99,3 +99,10 @@ add_entrypoint_object(
   DEPENDS
     .${LIBC_TARGET_OS}.recvmsg
 )
+
+add_entrypoint_object(
+  shutdown
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.shutdown
+)

--- a/libc/src/sys/socket/linux/CMakeLists.txt
+++ b/libc/src/sys/socket/linux/CMakeLists.txt
@@ -189,3 +189,15 @@ add_entrypoint_object(
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )
+
+add_entrypoint_object(
+  shutdown
+  SRCS
+    shutdown.cpp
+  HDRS
+    ../shutdown.h
+  DEPENDS
+    libc.include.sys_socket
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)

--- a/libc/src/sys/socket/linux/shutdown.cpp
+++ b/libc/src/sys/socket/linux/shutdown.cpp
@@ -1,0 +1,27 @@
+//===-- Linux implementation of shutdown ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/sys/socket/shutdown.h"
+
+#include "src/__support/OSUtil/linux/syscall_wrappers/shutdown.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, shutdown, (int sockfd, int how)) {
+  auto result = linux_syscalls::shutdown(sockfd, how);
+  if (!result.has_value()) {
+    libc_errno = result.error();
+    return -1;
+  }
+
+  return result.value();
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sys/socket/shutdown.h
+++ b/libc/src/sys/socket/shutdown.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for shutdown ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SYS_SOCKET_SHUTDOWN_H
+#define LLVM_LIBC_SRC_SYS_SOCKET_SHUTDOWN_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int shutdown(int sockfd, int how);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SYS_SOCKET_SHUTDOWN_H

--- a/libc/test/src/sys/socket/linux/CMakeLists.txt
+++ b/libc/test/src/sys/socket/linux/CMakeLists.txt
@@ -165,3 +165,22 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
+
+add_libc_unittest(
+  shutdown_test
+  SUITE
+    libc_sys_socket_unittests
+  SRCS
+    shutdown_test.cpp
+  DEPENDS
+    libc.include.sys_socket
+    libc.hdr.sys_socket_macros
+    libc.hdr.types.ssize_t
+    libc.src.errno.errno
+    libc.src.sys.socket.shutdown
+    libc.src.sys.socket.socketpair
+    libc.src.unistd.close
+    libc.src.unistd.read
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
+)

--- a/libc/test/src/sys/socket/linux/shutdown_test.cpp
+++ b/libc/test/src/sys/socket/linux/shutdown_test.cpp
@@ -31,8 +31,8 @@ TEST_F(LlvmLibcShutdownTest, ShutWrProducesEOF) {
 
   // Reading from sv[1] should report end-of-file by returning 0.
   char read_buf[10];
-  ASSERT_EQ(LIBC_NAMESPACE::read(sv[1], read_buf, sizeof(read_buf)),
-            ssize_t(0));
+  ASSERT_THAT(LIBC_NAMESPACE::read(sv[1], read_buf, sizeof(read_buf)),
+              Succeeds(0));
 
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[0]), Succeeds(0));
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[1]), Succeeds(0));
@@ -48,8 +48,8 @@ TEST_F(LlvmLibcShutdownTest, ShutRdPreventsReading) {
 
   // Reading from sv[0] should report end-of-file by returning 0.
   char read_buf[10];
-  ASSERT_EQ(LIBC_NAMESPACE::read(sv[0], read_buf, sizeof(read_buf)),
-            ssize_t(0));
+  ASSERT_THAT(LIBC_NAMESPACE::read(sv[0], read_buf, sizeof(read_buf)),
+              Succeeds(0));
 
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[0]), Succeeds(0));
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[1]), Succeeds(0));
@@ -65,10 +65,10 @@ TEST_F(LlvmLibcShutdownTest, ShutRdWrDoesBoth) {
 
   // Both descriptors should report end-of-file by returning 0.
   char read_buf[10];
-  ASSERT_EQ(LIBC_NAMESPACE::read(sv[0], read_buf, sizeof(read_buf)),
-            ssize_t(0));
-  ASSERT_EQ(LIBC_NAMESPACE::read(sv[1], read_buf, sizeof(read_buf)),
-            ssize_t(0));
+  ASSERT_THAT(LIBC_NAMESPACE::read(sv[0], read_buf, sizeof(read_buf)),
+              Succeeds(0));
+  ASSERT_THAT(LIBC_NAMESPACE::read(sv[1], read_buf, sizeof(read_buf)),
+              Succeeds(0));
 
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[0]), Succeeds(0));
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[1]), Succeeds(0));

--- a/libc/test/src/sys/socket/linux/shutdown_test.cpp
+++ b/libc/test/src/sys/socket/linux/shutdown_test.cpp
@@ -29,7 +29,7 @@ TEST_F(LlvmLibcShutdownTest, ShutWrProducesEOF) {
   // Shut down write on sv[0].
   ASSERT_THAT(LIBC_NAMESPACE::shutdown(sv[0], SHUT_WR), Succeeds(0));
 
-  // Reading from sv[1] should return 0 (EOF).
+  // Reading from sv[1] should report end-of-file by returning 0.
   char read_buf[10];
   ASSERT_EQ(LIBC_NAMESPACE::read(sv[1], read_buf, sizeof(read_buf)),
             ssize_t(0));
@@ -46,7 +46,7 @@ TEST_F(LlvmLibcShutdownTest, ShutRdPreventsReading) {
   // Shut down read on sv[0].
   ASSERT_THAT(LIBC_NAMESPACE::shutdown(sv[0], SHUT_RD), Succeeds(0));
 
-  // Reading from sv[0] should return 0 (EOF).
+  // Reading from sv[0] should report end-of-file by returning 0.
   char read_buf[10];
   ASSERT_EQ(LIBC_NAMESPACE::read(sv[0], read_buf, sizeof(read_buf)),
             ssize_t(0));
@@ -63,12 +63,10 @@ TEST_F(LlvmLibcShutdownTest, ShutRdWrDoesBoth) {
   // Shut down read and write on sv[0].
   ASSERT_THAT(LIBC_NAMESPACE::shutdown(sv[0], SHUT_RDWR), Succeeds(0));
 
-  // Reading from sv[0] should return 0 (EOF).
+  // Both descriptors should report end-of-file by returning 0.
   char read_buf[10];
   ASSERT_EQ(LIBC_NAMESPACE::read(sv[0], read_buf, sizeof(read_buf)),
             ssize_t(0));
-
-  // Reading from sv[1] should return 0 (EOF).
   ASSERT_EQ(LIBC_NAMESPACE::read(sv[1], read_buf, sizeof(read_buf)),
             ssize_t(0));
 

--- a/libc/test/src/sys/socket/linux/shutdown_test.cpp
+++ b/libc/test/src/sys/socket/linux/shutdown_test.cpp
@@ -1,0 +1,77 @@
+//===-- Unittests for shutdown --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/sys_socket_macros.h"
+#include "hdr/types/ssize_t.h"
+#include "src/sys/socket/shutdown.h"
+#include "src/sys/socket/socketpair.h"
+#include "src/unistd/close.h"
+#include "src/unistd/read.h"
+
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcShutdownTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcShutdownTest, ShutWrProducesEOF) {
+  int sv[2];
+  ASSERT_THAT(LIBC_NAMESPACE::socketpair(AF_UNIX, SOCK_STREAM, 0, sv),
+              Succeeds(0));
+
+  // Shut down write on sv[0].
+  ASSERT_THAT(LIBC_NAMESPACE::shutdown(sv[0], SHUT_WR), Succeeds(0));
+
+  // Reading from sv[1] should return 0 (EOF).
+  char read_buf[10];
+  ASSERT_EQ(LIBC_NAMESPACE::read(sv[1], read_buf, sizeof(read_buf)),
+            ssize_t(0));
+
+  ASSERT_THAT(LIBC_NAMESPACE::close(sv[0]), Succeeds(0));
+  ASSERT_THAT(LIBC_NAMESPACE::close(sv[1]), Succeeds(0));
+}
+
+TEST_F(LlvmLibcShutdownTest, ShutRdPreventsReading) {
+  int sv[2];
+  ASSERT_THAT(LIBC_NAMESPACE::socketpair(AF_UNIX, SOCK_STREAM, 0, sv),
+              Succeeds(0));
+
+  // Shut down read on sv[0].
+  ASSERT_THAT(LIBC_NAMESPACE::shutdown(sv[0], SHUT_RD), Succeeds(0));
+
+  // Reading from sv[0] should return 0 (EOF).
+  char read_buf[10];
+  ASSERT_EQ(LIBC_NAMESPACE::read(sv[0], read_buf, sizeof(read_buf)),
+            ssize_t(0));
+
+  ASSERT_THAT(LIBC_NAMESPACE::close(sv[0]), Succeeds(0));
+  ASSERT_THAT(LIBC_NAMESPACE::close(sv[1]), Succeeds(0));
+}
+
+TEST_F(LlvmLibcShutdownTest, ShutRdWrDoesBoth) {
+  int sv[2];
+  ASSERT_THAT(LIBC_NAMESPACE::socketpair(AF_UNIX, SOCK_STREAM, 0, sv),
+              Succeeds(0));
+
+  // Shut down read and write on sv[0].
+  ASSERT_THAT(LIBC_NAMESPACE::shutdown(sv[0], SHUT_RDWR), Succeeds(0));
+
+  // Reading from sv[0] should return 0 (EOF).
+  char read_buf[10];
+  ASSERT_EQ(LIBC_NAMESPACE::read(sv[0], read_buf, sizeof(read_buf)),
+            ssize_t(0));
+
+  // Reading from sv[1] should return 0 (EOF).
+  ASSERT_EQ(LIBC_NAMESPACE::read(sv[1], read_buf, sizeof(read_buf)),
+            ssize_t(0));
+
+  ASSERT_THAT(LIBC_NAMESPACE::close(sv[0]), Succeeds(0));
+  ASSERT_THAT(LIBC_NAMESPACE::close(sv[1]), Succeeds(0));
+}

--- a/libc/test/src/sys/socket/linux/shutdown_test.cpp
+++ b/libc/test/src/sys/socket/linux/shutdown_test.cpp
@@ -73,3 +73,7 @@ TEST_F(LlvmLibcShutdownTest, ShutRdWrDoesBoth) {
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[0]), Succeeds(0));
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[1]), Succeeds(0));
 }
+
+TEST_F(LlvmLibcShutdownTest, FailsOnInvalidSocket) {
+  ASSERT_THAT(LIBC_NAMESPACE::shutdown(-1, SHUT_WR), Fails(EBADF));
+}


### PR DESCRIPTION
- added the relevant constant definitions
- enabled the entry point on x86_64, aarch64 and riscv
- testing by checking that the call causes an EOF on read (on the appropriate end)