### PR TITLE
[lldb][PlatformDarwin] Fix build failure

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1571,7 +1571,9 @@ PlatformDarwin::GetSafeAutoLoadPaths(const Target &target) const {
 
   XcodeSDK::Type sdk_type =
       XcodeSDK::GetSDKTypeForTriple(target.GetArchitecture().GetTriple());
-  XcodeSDK sdk(XcodeSDK::Info{sdk_type, {}});
+  XcodeSDK::Info info;
+  info.type = sdk_type;
+  XcodeSDK sdk(info);
 
   auto sdk_root_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
   if (!sdk_root_or_err) {


### PR DESCRIPTION
PR #191454 introduced a constructor call that breaks in certain build configs, e.g., with C++20 - https://godbolt.org/z/hTb8166qG.

This fix mimics what's done to construct an instance of `XcodeSDK::Info` further up in the same file.