### PR TITLE
[Flang][Semantics] Allow EVENT_TYPE, LOCK_TYPE and NOTIFY TYPE to be deallocate

### DIFF
--- a/flang/lib/Semantics/check-deallocate.cpp
+++ b/flang/lib/Semantics/check-deallocate.cpp
@@ -84,7 +84,7 @@ void DeallocateChecker::Leave(const parser::DeallocateStmt &deallocateStmt) {
                         whyNot->set_severity(parser::Severity::Because)));
               } else if (auto whyNot{
                              WhyNotDefinable(source, context_.FindScope(source),
-                                 DefinabilityFlags{}, *symbol)}) {
+                                 DefinabilityFlags{DefinabilityFlag::AllowEventLockOrNotifyType}, *symbol)}) {
                 // Catch problems with non-definability of the dynamic object
                 context_
                     .Say(source,
@@ -119,7 +119,7 @@ void DeallocateChecker::Leave(const parser::DeallocateStmt &deallocateStmt) {
                       .Attach(std::move(
                           whyNot->set_severity(parser::Severity::Because)));
                 } else if (auto whyNot{WhyNotDefinable(source,
-                               context_.FindScope(source), DefinabilityFlags{},
+                               context_.FindScope(source), DefinabilityFlags{DefinabilityFlag::AllowEventLockOrNotifyType},
                                *expr)}) {
                   context_
                       .Say(source,

--- a/flang/lib/Semantics/check-deallocate.cpp
+++ b/flang/lib/Semantics/check-deallocate.cpp
@@ -82,9 +82,11 @@ void DeallocateChecker::Leave(const parser::DeallocateStmt &deallocateStmt) {
                         "Name in DEALLOCATE statement is not definable"_err_en_US)
                     .Attach(std::move(
                         whyNot->set_severity(parser::Severity::Because)));
-              } else if (auto whyNot{
-                             WhyNotDefinable(source, context_.FindScope(source),
-                                 DefinabilityFlags{DefinabilityFlag::AllowEventLockOrNotifyType}, *symbol)}) {
+              } else if (auto whyNot{WhyNotDefinable(source,
+                             context_.FindScope(source),
+                             DefinabilityFlags{
+                                 DefinabilityFlag::AllowEventLockOrNotifyType},
+                             *symbol)}) {
                 // Catch problems with non-definability of the dynamic object
                 context_
                     .Say(source,
@@ -119,7 +121,9 @@ void DeallocateChecker::Leave(const parser::DeallocateStmt &deallocateStmt) {
                       .Attach(std::move(
                           whyNot->set_severity(parser::Severity::Because)));
                 } else if (auto whyNot{WhyNotDefinable(source,
-                               context_.FindScope(source), DefinabilityFlags{DefinabilityFlag::AllowEventLockOrNotifyType},
+                               context_.FindScope(source),
+                               DefinabilityFlags{DefinabilityFlag::
+                                       AllowEventLockOrNotifyType},
                                *expr)}) {
                   context_
                       .Say(source,

--- a/flang/test/Semantics/deallocate08.f90
+++ b/flang/test/Semantics/deallocate08.f90
@@ -1,0 +1,55 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! Check there are no semantic errors in DEALLOCATE statements with EVENT_TYPE and LOCK_TYPE.
+
+! CHECK-NOT: Object in DEALLOCATE statement is not deallocatable
+
+module not_iso_fortran_env
+  type event_type
+  end type
+  type lock_type
+  end type
+end module
+
+subroutine deallocate_lock_event_type()
+  use iso_fortran_env
+
+  type oktype1
+    type(event_type), pointer :: event
+    type(lock_type), pointer :: lock
+  end type
+
+  type oktype5
+    type(event_type), allocatable :: event
+  end type
+
+  type oktype2
+    type(event_type) :: event
+  end type
+
+  type oktype3
+    type(lock_type), allocatable :: lock
+  end type
+
+  type oktype4
+    type(lock_type) :: lock
+  end type
+
+  ! Variable with event_type or lock_type have to be coarrays
+  ! see C1604 and 1608.
+  type(oktype1), allocatable :: okt1[:]
+  type(oktype2), allocatable :: okt2[:]
+  type(oktype3), allocatable :: okt3[:]
+  type(oktype5), allocatable :: okt5[:]
+  class(oktype4), allocatable :: okt4[:]
+  type(event_type), allocatable :: event[:]
+  type(lock_type), allocatable :: lock(:)[:]
+
+
+  deallocate(okt1)
+  deallocate(okt2)
+  deallocate(okt3)
+  deallocate(okt4)
+  deallocate(okt5)
+  deallocate(lock)
+  deallocate(event)
+end subroutine

--- a/flang/test/Semantics/deallocate08.f90
+++ b/flang/test/Semantics/deallocate08.f90
@@ -3,13 +3,6 @@
 
 ! CHECK-NOT: Object in DEALLOCATE statement is not deallocatable
 
-module not_iso_fortran_env
-  type event_type
-  end type
-  type lock_type
-  end type
-end module
-
 subroutine deallocate_lock_event_type()
   use iso_fortran_env
 
@@ -44,12 +37,13 @@ subroutine deallocate_lock_event_type()
   type(event_type), allocatable :: event[:]
   type(lock_type), allocatable :: lock(:)[:]
 
-
-  deallocate(okt1)
-  deallocate(okt2)
-  deallocate(okt3)
-  deallocate(okt4)
-  deallocate(okt5)
-  deallocate(lock)
-  deallocate(event)
+  if (.false.) then
+    deallocate(okt1)
+    deallocate(okt2)
+    deallocate(okt3)
+    deallocate(okt4)
+    deallocate(okt5)
+    deallocate(lock)
+    deallocate(event)
+  endif
 end subroutine

--- a/flang/test/Semantics/deallocate08.f90
+++ b/flang/test/Semantics/deallocate08.f90
@@ -9,6 +9,7 @@ subroutine deallocate_lock_event_type()
   type oktype1
     type(event_type), pointer :: event
     type(lock_type), pointer :: lock
+    type(notify_type), pointer ::notify 
   end type
 
   type oktype5
@@ -27,6 +28,14 @@ subroutine deallocate_lock_event_type()
     type(lock_type) :: lock
   end type
 
+  type oktype6
+    type(notify_type), allocatable :: notify
+  end type
+
+  type oktype7
+    type(notify_type) :: notify
+  end type
+
   ! Variable with event_type or lock_type have to be coarrays
   ! see C1604 and 1608.
   type(oktype1), allocatable :: okt1[:]
@@ -34,8 +43,11 @@ subroutine deallocate_lock_event_type()
   type(oktype3), allocatable :: okt3[:]
   type(oktype5), allocatable :: okt5[:]
   class(oktype4), allocatable :: okt4[:]
+  type(oktype6), allocatable :: okt6[:]
+  type(oktype7), allocatable :: okt7[:]
   type(event_type), allocatable :: event[:]
   type(lock_type), allocatable :: lock(:)[:]
+  type(notify_type), allocatable :: notify[:]
 
   if (.false.) then
     deallocate(okt1)
@@ -43,7 +55,10 @@ subroutine deallocate_lock_event_type()
     deallocate(okt3)
     deallocate(okt4)
     deallocate(okt5)
+    deallocate(okt6)
+    deallocate(okt7)
     deallocate(lock)
     deallocate(event)
+    deallocate(notify)
   endif
 end subroutine


### PR DESCRIPTION
It appears that variables of type `EVENT_TYPE`, `LOCK_TYPE`, and `NOTIFY_TYPE` are not allowed in the DEALLOCATE statement (but allowed in ALLOCATE).
The standard does not specify that this type of variable cannot be ALLOCATABLE and/or cannot be called within a DEALLOCATE