### PR TITLE
[AArch64][clang][llvm] Add ACLE macros to support Armv9.7

### DIFF
--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -585,6 +585,18 @@ void AArch64TargetInfo::getTargetDefines(const LangOptions &Opts,
   if (HasSVE_BFSCALE)
     Builder.defineMacro("__ARM_FEATURE_SVE_BFSCALE", "1");
 
+  if (HasSVE_B16MM)
+    Builder.defineMacro("__ARM_FEATURE_SVE_B16MM", "1");
+
+  if (HasF16MM)
+    Builder.defineMacro("__ARM_FEATURE_F16MM", "1");
+
+  if (HasF16F32DOT)
+    Builder.defineMacro("__ARM_FEATURE_F16F32DOT", "1");
+
+  if (HasF16F32MM)
+    Builder.defineMacro("__ARM_FEATURE_F16F32MM", "1");
+
   if (HasSVE_AES2)
     Builder.defineMacro("__ARM_FEATURE_SVE_AES2", "1");
 
@@ -594,8 +606,14 @@ void AArch64TargetInfo::getTargetDefines(const LangOptions &Opts,
   if (HasSVE2p2)
     Builder.defineMacro("__ARM_FEATURE_SVE2p2", "1");
 
+  if (HasSVE2p3)
+    Builder.defineMacro("__ARM_FEATURE_SVE2p3", "1");
+
   if (HasSME2p2)
     Builder.defineMacro("__ARM_FEATURE_SME2p2", "1");
+
+  if (HasSME2p3)
+    Builder.defineMacro("__ARM_FEATURE_SME2p3", "1");
 
   if (HasFMV)
     Builder.defineMacro("__HAVE_FUNCTION_MULTI_VERSIONING", "1");
@@ -940,7 +958,13 @@ void AArch64TargetInfo::computeFeatureLookup() {
       .Case("sve-aes2", HasSVE_AES2)
       .Case("ssve-aes", HasSSVE_AES)
       .Case("sve2p2", FPU & SveMode && HasSVE2p2)
-      .Case("sme2p2", HasSME2p2);
+      .Case("sme2p2", HasSME2p2)
+      .Case("sve2p3", FPU & SveMode && HasSVE2p3)
+      .Case("sme2p3", HasSME2p3)
+      .Case("sve-b16mm", HasSVE_B16MM)
+      .Case("f16mm", HasF16MM)
+      .Case("f16f32dot", HasF16F32DOT)
+      .Case("f16f32mm", HasF16F32MM);
 }
 
 bool AArch64TargetInfo::hasFeature(StringRef Feature) const {
@@ -1181,6 +1205,14 @@ bool AArch64TargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
       HasF8F32MM = true;
     if (Feature == "+sve-f16f32mm")
       HasSVE_F16F32MM = true;
+    if (Feature == "+sve-b16mm")
+      HasSVE_B16MM = true;
+    if (Feature == "+f16mm")
+      HasF16MM = true;
+    if (Feature == "+f16f32dot")
+      HasF16F32DOT = true;
+    if (Feature == "+f16f32mm")
+      HasF16F32MM = true;
     if (Feature == "+sve-bfscale")
       HasSVE_BFSCALE = true;
     if (Feature == "+sve-aes2")
@@ -1189,8 +1221,12 @@ bool AArch64TargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
       HasSSVE_AES = true;
     if (Feature == "+sve2p2")
       HasSVE2p2 = true;
+    if (Feature == "+sve2p3")
+      HasSVE2p3 = true;
     if (Feature == "+sme2p2")
       HasSME2p2 = true;
+    if (Feature == "+sme2p3")
+      HasSME2p3 = true;
 
     // All predecessor archs are added but select the latest one for ArchKind.
     if (Feature == "+v8a" && ArchInfo->Version < llvm::AArch64::ARMV8A.Version)

--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -583,6 +583,18 @@ void AArch64TargetInfo::getTargetDefines(const LangOptions &Opts,
   if (HasSVE_BFSCALE)
     Builder.defineMacro("__ARM_FEATURE_SVE_BFSCALE", "1");
 
+  if (HasSVE_B16MM)
+    Builder.defineMacro("__ARM_FEATURE_SVE_B16MM", "1");
+
+  if (HasF16MM)
+    Builder.defineMacro("__ARM_FEATURE_F16MM", "1");
+
+  if (HasF16F32DOT)
+    Builder.defineMacro("__ARM_FEATURE_F16F32DOT", "1");
+
+  if (HasF16F32MM)
+    Builder.defineMacro("__ARM_FEATURE_F16F32MM", "1");
+
   if (HasSVE_AES2)
     Builder.defineMacro("__ARM_FEATURE_SVE_AES2", "1");
 
@@ -592,8 +604,14 @@ void AArch64TargetInfo::getTargetDefines(const LangOptions &Opts,
   if (HasSVE2p2)
     Builder.defineMacro("__ARM_FEATURE_SVE2p2", "1");
 
+  if (HasSVE2p3)
+    Builder.defineMacro("__ARM_FEATURE_SVE2p3", "1");
+
   if (HasSME2p2)
     Builder.defineMacro("__ARM_FEATURE_SME2p2", "1");
+
+  if (HasSME2p3)
+    Builder.defineMacro("__ARM_FEATURE_SME2p3", "1");
 
   if (HasFMV)
     Builder.defineMacro("__HAVE_FUNCTION_MULTI_VERSIONING", "1");
@@ -938,7 +956,13 @@ void AArch64TargetInfo::computeFeatureLookup() {
       .Case("sve-aes2", HasSVE_AES2)
       .Case("ssve-aes", HasSSVE_AES)
       .Case("sve2p2", FPU & SveMode && HasSVE2p2)
-      .Case("sme2p2", HasSME2p2);
+      .Case("sme2p2", HasSME2p2)
+      .Case("sve2p3", FPU & SveMode && HasSVE2p3)
+      .Case("sme2p3", HasSME2p3)
+      .Case("sve-b16mm", HasSVE_B16MM)
+      .Case("f16mm", HasF16MM)
+      .Case("f16f32dot", HasF16F32DOT)
+      .Case("f16f32mm", HasF16F32MM);
 }
 
 bool AArch64TargetInfo::hasFeature(StringRef Feature) const {
@@ -1179,6 +1203,14 @@ bool AArch64TargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
       HasF8F32MM = true;
     if (Feature == "+sve-f16f32mm")
       HasSVE_F16F32MM = true;
+    if (Feature == "+sve-b16mm")
+      HasSVE_B16MM = true;
+    if (Feature == "+f16mm")
+      HasF16MM = true;
+    if (Feature == "+f16f32dot")
+      HasF16F32DOT = true;
+    if (Feature == "+f16f32mm")
+      HasF16F32MM = true;
     if (Feature == "+sve-bfscale")
       HasSVE_BFSCALE = true;
     if (Feature == "+sve-aes2")
@@ -1187,8 +1219,12 @@ bool AArch64TargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
       HasSSVE_AES = true;
     if (Feature == "+sve2p2")
       HasSVE2p2 = true;
+    if (Feature == "+sve2p3")
+      HasSVE2p3 = true;
     if (Feature == "+sme2p2")
       HasSME2p2 = true;
+    if (Feature == "+sme2p3")
+      HasSME2p3 = true;
 
     // All predecessor archs are added but select the latest one for ArchKind.
     if (Feature == "+v8a" && ArchInfo->Version < llvm::AArch64::ARMV8A.Version)

--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -144,6 +144,12 @@ class LLVM_LIBRARY_VISIBILITY AArch64TargetInfo : public TargetInfo {
   bool HasSSVE_AES = false;
   bool HasSVE2p2 = false;
   bool HasSME2p2 = false;
+  bool HasSVE2p3 = false;
+  bool HasSME2p3 = false;
+  bool HasSVE_B16MM = false;
+  bool HasF16MM = false;
+  bool HasF16F32DOT = false;
+  bool HasF16F32MM = false;
 
   const llvm::AArch64::ArchInfo *ArchInfo = &llvm::AArch64::ARMV8A;
 

--- a/clang/test/Preprocessor/aarch64-target-features.c
+++ b/clang/test/Preprocessor/aarch64-target-features.c
@@ -806,6 +806,38 @@
 //  CHECK-SVE-F16F32MM: __ARM_FEATURE_SVE 1
 //  CHECK-SVE-F16F32MM: __ARM_FEATURE_SVE_F16F32MM 1
 
+// RUN: %clang --target=aarch64 -march=armv9-a+f16f32dot -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-F16F32DOT %s
+// CHECK-F16F32DOT: __ARM_FEATURE_F16F32DOT 1
+
+// RUN: %clang --target=aarch64 -march=armv9-a+f16f32mm -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-F16F32MM %s
+// CHECK-F16F32MM: __ARM_FEATURE_F16F32MM 1
+
+// RUN: %clang --target=aarch64 -march=armv9-a+f16mm -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-F16MM %s
+// CHECK-F16MM: __ARM_FEATURE_F16MM 1
+
+// RUN: %clang --target=aarch64 -march=armv9-a+sve-b16mm -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SVE-B16MM %s
+// CHECK-SVE-B16MM: __ARM_FEATURE_SVE 1
+// CHECK-SVE-B16MM: __ARM_FEATURE_SVE_B16MM 1
+
+// RUN: %clang --target=aarch64 -march=armv9-a+sve2p3 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SVE2p3 %s
+// CHECK-SVE2p3: __ARM_FEATURE_FP16_SCALAR_ARITHMETIC 1
+// CHECK-SVE2p3: __ARM_FEATURE_FP16_VECTOR_ARITHMETIC 1
+// CHECK-SVE2p3: __ARM_FEATURE_SVE2 1
+// CHECK-SVE2p3: __ARM_FEATURE_SVE2p1 1
+// CHECK-SVE2p3: __ARM_FEATURE_SVE2p2 1
+// CHECK-SVE2p3: __ARM_FEATURE_SVE2p3 1
+// CHECK-SVE2p3: __ARM_NEON 1
+// CHECK-SVE2p3: __ARM_NEON_FP 0xE
+// CHECK-SVE2p3: __ARM_NEON_SVE_BRIDGE 1
+
+// RUN: %clang --target=aarch64 -march=armv9-a+sme2p3 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SME2p3 %s
+// CHECK-SME2p3: __ARM_FEATURE_LOCALLY_STREAMING 1
+// CHECK-SME2p3: __ARM_FEATURE_SME 1
+// CHECK-SME2p3: __ARM_FEATURE_SME2 1
+// CHECK-SME2p3: __ARM_FEATURE_SME2p1 1
+// CHECK-SME2p3: __ARM_FEATURE_SME2p2 1
+// CHECK-SME2p3: __ARM_FEATURE_SME2p3 1
+
 //  RUN: %clang --target=aarch64 -march=armv9-a+sve-bfscale -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SVE-BFSCALE %s
 //  CHECK-SVE-BFSCALE: __ARM_FEATURE_SVE_BFSCALE 1
 

--- a/clang/test/Preprocessor/aarch64-target-features.c
+++ b/clang/test/Preprocessor/aarch64-target-features.c
@@ -806,11 +806,19 @@
 //  CHECK-SVE-F16F32MM: __ARM_FEATURE_SVE 1
 //  CHECK-SVE-F16F32MM: __ARM_FEATURE_SVE_F16F32MM 1
 
-// RUN: %clang --target=aarch64 -march=armv9-a+f16f32dot -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-F16F32DOT %s
+// RUN: %clang --target=aarch64 -march=armv8-a+nosimd+f16f32dot -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-F16F32DOT %s
 // CHECK-F16F32DOT: __ARM_FEATURE_F16F32DOT 1
+// CHECK-F16F32DOT: __ARM_FEATURE_FP16_SCALAR_ARITHMETIC 1
+// CHECK-F16F32DOT: __ARM_FEATURE_FP16_VECTOR_ARITHMETIC 1
+// CHECK-F16F32DOT: __ARM_NEON 1
+// CHECK-F16F32DOT: __ARM_NEON_FP 0xE
 
-// RUN: %clang --target=aarch64 -march=armv9-a+f16f32mm -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-F16F32MM %s
+// RUN: %clang --target=aarch64 -march=armv8-a+nosimd+f16f32mm -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-F16F32MM %s
 // CHECK-F16F32MM: __ARM_FEATURE_F16F32MM 1
+// CHECK-F16F32MM: __ARM_FEATURE_FP16_SCALAR_ARITHMETIC 1
+// CHECK-F16F32MM: __ARM_FEATURE_FP16_VECTOR_ARITHMETIC 1
+// CHECK-F16F32MM: __ARM_NEON 1
+// CHECK-F16F32MM: __ARM_NEON_FP 0xE
 
 // RUN: %clang --target=aarch64 -march=armv9-a+f16mm -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-F16MM %s
 // CHECK-F16MM: __ARM_FEATURE_F16MM 1


### PR DESCRIPTION
This patch add the macros for Armv9.7 according to the ACLE[1]

[1] https://github.com/ARM-software/acle/blob/main/main/acle.md