### PR TITLE
[NFC][Clang][DebugInfo] Fix constructor type comment

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -939,7 +939,7 @@ public:
     Other.CGF = nullptr;
   }
 
-  // Define copy assignment operator.
+  // Define move assignment operator.
   ApplyDebugLocation &operator=(ApplyDebugLocation &&Other) {
     if (this != &Other) {
       CGF = Other.CGF;


### PR DESCRIPTION
This corrects a constructor comment to say move instead of copy.