### PR TITLE
[Flang][Semantics] Adding support of -Wunused-dummy-argument

### DIFF
--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -84,7 +84,8 @@ ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,
     HostAssociatedIntentOutInSpecExpr, NonVolatilePointerToVolatile,
     RealConstantWidening, VolatileOrAsynchronousTemporary, UnusedVariable,
     UsedUndefinedVariable, BadValueInDeadCode, AssumedTypeSizeDummy,
-    MisplacedIgnoreTKR, NamelistParameter, ImpureFinalInPure)
+    MisplacedIgnoreTKR, NamelistParameter, ImpureFinalInPure,
+    UnusedDummyArgument)
 
 using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 using UsageWarnings = EnumSet<UsageWarning, UsageWarning_enumSize>;

--- a/flang/lib/Semantics/semantics.cpp
+++ b/flang/lib/Semantics/semantics.cpp
@@ -203,6 +203,8 @@ static void WarnUnusedOrUndefinedLocal(
       scope.kind() == Scope::Kind::BlockConstruct) {
     for (const auto &[_, symbolRef] : scope) {
       const Symbol &symbol{*symbolRef};
+      const auto *ownerSubp{symbol.detailsIf<SubprogramDetails>()};
+      bool inInterface{ownerSubp && ownerSubp->isInterface()};
       if ((symbol.has<semantics::ObjectEntityDetails>() ||
               (symbol.has<semantics::ProcEntityDetails>() &&
                   IsProcedurePointer(symbol))) &&
@@ -223,6 +225,13 @@ static void WarnUnusedOrUndefinedLocal(
                 symbol.name());
           }
         }
+      }
+      if (symbol.has<semantics::ObjectEntityDetails>() && IsDummy(symbol) &&
+          !inInterface && !context.IsSymbolUsed(symbol) &&
+          scope.kind() == Scope::Kind::Subprogram) {
+        context.Warn(common::UsageWarning::UnusedDummyArgument, symbol.name(),
+            "Value of dummy argument '%s' is never used"_warn_en_US,
+            symbol.name());
       }
     }
   }

--- a/flang/test/Semantics/bind-c17.f90
+++ b/flang/test/Semantics/bind-c17.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror -Wno-unused-dummy-argument
 module m
   type a ! not BIND(C)
   end type

--- a/flang/test/Semantics/bindings03.f90
+++ b/flang/test/Semantics/bindings03.f90
@@ -7,6 +7,7 @@ module m
   end type
  contains
   subroutine sub(x)
+    !WARNING: Value of dummy argument 'x' is never used [-Wunused-dummy-argument]
     class(t), intent(in) :: x
   end subroutine
 end module

--- a/flang/test/Semantics/bug1491.f90
+++ b/flang/test/Semantics/bug1491.f90
@@ -1,4 +1,4 @@
-!RUN: %python %S/test_errors.py %s %flang_fc1 -Werror -pedantic
+!RUN: %python %S/test_errors.py %s %flang_fc1 -Werror -Wno-unused-dummy-argument -pedantic
 module m
   interface
     integer function foo1()

--- a/flang/test/Semantics/call30.f90
+++ b/flang/test/Semantics/call30.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -Werror -pedantic
+! RUN: %python %S/test_errors.py %s %flang_fc1 -Werror -Wno-unused-dummy-argument -pedantic
 ! This test is responsible for checking the fix for passing non-variables as
 ! actual arguments to subroutines/functions whose corresponding dummy argument
 ! expects a VOLATILE variable

--- a/flang/test/Semantics/call37.f90
+++ b/flang/test/Semantics/call37.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror -Wno-unused-dummy-argument
 ! Test warnings on mismatching interfaces involvingCHARACTER arguments
 subroutine constLen(s)
   character(len = 1) s

--- a/flang/test/Semantics/call44.f90
+++ b/flang/test/Semantics/call44.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Wno-portability -Werror
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Wno-portability -Wno-unused-dummy-argument -Werror
 subroutine assumedshape(normal, contig)
   real normal(:)
   real, contiguous :: contig(:)

--- a/flang/test/Semantics/call45.f90
+++ b/flang/test/Semantics/call45.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror -Wno-unused-dummy-argument
 program call45
     integer, target :: v(100) = [(i, i=1, 100)]
     integer, pointer :: p(:) => v

--- a/flang/test/Semantics/deferred01.f90
+++ b/flang/test/Semantics/deferred01.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror -Wno-unused-dummy-argument
 ! Deferred TBPs must be overridden, but when they are private, those
 ! overrides are required to appear in the same module.  We allow overrides
 ! elsewhere as an extension.

--- a/flang/test/Semantics/definable02.f90
+++ b/flang/test/Semantics/definable02.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror -Wno-unused-dummy-argument
 
 ! Ensure that FINAL subroutine can be called for array with vector-valued
 ! subscript.

--- a/flang/test/Semantics/final03.f90
+++ b/flang/test/Semantics/final03.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror -Wno-unused-dummy-argument
 ! PDT sensitivity of FINAL subroutines
 module m
   type :: pdt(k)

--- a/flang/test/Semantics/wunused-dummy-argument.f90
+++ b/flang/test/Semantics/wunused-dummy-argument.f90
@@ -1,0 +1,47 @@
+! RUN: %flang_fc1 -Wunused-dummy-argument %s 2>&1 | FileCheck %s
+! RUN: not %flang_fc1 -Wunused-dummy-argument -Werror %s
+! CHECK: Value of dummy argument 'a4' is never used [-Wunused-dummy-argument]
+! CHECK: Value of dummy argument 'b4' is never used [-Wunused-dummy-argument]
+! CHECK: Value of dummy argument 'a6' is never used [-Wunused-dummy-argument]
+! CHECK: Value of dummy argument 'b6' is never used [-Wunused-dummy-argument]
+
+program main
+        type :: my_type
+                integer :: val
+        end type
+        integer :: not_dummy_arg
+        interface
+                subroutine subroutine_interface(a)
+                        integer, intent(in) :: a
+                end subroutine
+
+                function function_interface(a2)
+                        integer, intent(in) :: a2
+                end function
+        end interface
+contains
+        subroutine subroutine_all_used(a3, b3)
+                integer, intent(inout) :: a3, b3
+                a3 = a3 + b3
+        end subroutine
+
+        subroutine subroutine_unused_both(a4, b4)
+                integer, intent(inout) :: a4(10)
+                type(my_type) :: b4
+        end subroutine
+
+
+        function function_used_all(a5, b5) result(c1)
+                integer, intent(inout) :: a5(10)
+                type(my_type), intent(in) :: b5
+                integer :: c1
+                a5(1) = b5%val
+                c1 = a5(2)
+        end function 
+
+        function function_unused_both(a6, b6) result(c2)
+                integer, intent(inout) :: a6(10)
+                type(my_type) :: b6
+                integer :: c2
+        end function
+end program


### PR DESCRIPTION
Adding support of new warning flags -W[no-]unused-dummy-argument.
Used in ECRAD, but not a mandatory flags for the project (https://github.com/ecmwf-ifs/ecrad).
I think it could be usefull to develop various Fortran projects and avoiding unused dummy arguments.