### PR TITLE
[clang][msvc] Fix crash when mangling concept template arguments

### DIFF
--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -1907,10 +1907,19 @@ void MicrosoftCXXNameMangler::mangleTemplateArg(const TemplateDecl *TD,
     break;
   }
   case TemplateArgument::Template: {
-    const NamedDecl *ND =
-        TA.getAsTemplate().getAsTemplateDecl()->getTemplatedDecl();
-    if (const auto *TD = dyn_cast<TagDecl>(ND)) {
-      mangleType(TD);
+    const TemplateDecl *TD = TA.getAsTemplate().getAsTemplateDecl();
+    if (isa<ConceptDecl>(TD)) {
+      // MSVC does not support concepts in template-template-parameter position,
+      // so there is no established mangling for this case under the Microsoft
+      // ABI.
+      Error("template argument (concept template-template arguments are not "
+            "supported by the Microsoft ABI)");
+      return;
+    }
+
+    const auto *ND = TD->getTemplatedDecl();
+    if (const auto *Tag = dyn_cast<TagDecl>(ND)) {
+      mangleType(Tag);
     } else if (isa<TypeAliasDecl>(ND)) {
       Out << "$$Y";
       mangleName(ND);


### PR DESCRIPTION
This fixes a crash in MicrosoftMangle.cpp when mangling a concept used as a
template template argument.

In the reproducer, the template argument is represented as
TemplateArgument::Template, and getAsTemplate().getAsTemplateDecl()
returns a ConceptDecl. The current implementation assumes that such
arguments can always be lowered through getTemplatedDecl() and then handled
as either a TagDecl or a TypeAliasDecl, which is not valid for concepts.

As a result, the Microsoft mangling path previously triggered an internal
assertion. This change replaces the crash with a proper diagnostic,
reporting that concept template-template arguments are not supported under
the Microsoft ABI.

MSVC rejects this construct, so this change does not attempt to define a
mangling scheme for it, but instead ensures Clang fails gracefully.