### PR TITLE
[clangd] Add go-to-definition support for fields in offsetof expressions

### DIFF
--- a/clang-tools-extra/clangd/FindTarget.cpp
+++ b/clang-tools-extra/clangd/FindTarget.cpp
@@ -294,6 +294,17 @@ public:
             break;
           }
       }
+      void VisitOffsetOfExpr(const OffsetOfExpr *OOE) {
+        for (unsigned I = OOE->getNumComponents(); I != 0; --I) {
+          const OffsetOfNode &Component = OOE->getComponent(I - 1);
+          if (Component.getKind() == OffsetOfNode::Field) {
+            Outer.add(Component.getField(), Flags);
+            // We don't know which component was intended, we assume the
+            // innermost.
+            break;
+          }
+        }
+      }
       void VisitGotoStmt(const GotoStmt *Goto) {
         if (auto *LabelDecl = Goto->getLabel())
           Outer.add(LabelDecl, Flags);
@@ -812,6 +823,17 @@ llvm::SmallVector<ReferenceLoc> refInStmt(const Stmt *S,
                                     D.getFieldLoc(),
                                     /*IsDecl=*/false,
                                     {D.getFieldDecl()}});
+      }
+    }
+
+    void VisitOffsetOfExpr(const OffsetOfExpr *OOE) {
+      for (unsigned I = 0, N = OOE->getNumComponents(); I < N; ++I) {
+        const OffsetOfNode &Component = OOE->getComponent(I);
+        if (Component.getKind() == OffsetOfNode::Field)
+          Refs.push_back(ReferenceLoc{NestedNameSpecifierLoc(),
+                                      Component.getEndLoc(),
+                                      /*IsDecl=*/false,
+                                      {Component.getField()}});
       }
     }
 

--- a/clang-tools-extra/clangd/unittests/FindTargetTests.cpp
+++ b/clang-tools-extra/clangd/unittests/FindTargetTests.cpp
@@ -342,6 +342,21 @@ TEST_F(TargetDeclTest, DesignatedInit) {
   EXPECT_DECLS("DesignatedInitExpr", "int a");
 }
 
+TEST_F(TargetDeclTest, OffsetOf) {
+  Code = R"cpp(
+    struct Foo { int bar; };
+    int x = __builtin_offsetof(Foo, [[bar]]);
+  )cpp";
+  EXPECT_DECLS("OffsetOfExpr", "int bar");
+
+  // For a nested designator, allTargetDecls reports the innermost field.
+  Code = R"cpp(
+    struct A { struct { int c; } b; };
+    int x = __builtin_offsetof(A, [[b.c]]);
+  )cpp";
+  EXPECT_DECLS("OffsetOfExpr", "int c");
+}
+
 TEST_F(TargetDeclTest, NestedNameSpecifier) {
   Code = R"cpp(
     namespace a { namespace b { int c; } }
@@ -2076,6 +2091,53 @@ TEST_F(FindExplicitReferencesTest, AllRefsInFoo) {
         "6: targets = {bar}, decl\n"
         "7: targets = {foo()::Bar::Foo}\n"
         "8: targets = {foo()::Baz::Field}\n"},
+       // offsetof
+       {R"cpp(
+            void foo() {
+              struct $0^Foo { int $1^bar; };
+              int $2^x = __builtin_offsetof($3^Foo, $4^bar);
+            }
+        )cpp",
+        "0: targets = {Foo}, decl\n"
+        "1: targets = {foo()::Foo::bar}, decl\n"
+        "2: targets = {x}, decl\n"
+        "3: targets = {Foo}\n"
+        "4: targets = {foo()::Foo::bar}\n"},
+       // offsetof with a nested field designator -- each component must
+       // resolve to its own source position, not a shared one.
+       {R"cpp(
+            void foo() {
+              struct $0^A {
+                $1^struct { int $2^c; } $3^B;
+              };
+              int $4^x = __builtin_offsetof($5^A, $6^B.$7^c);
+            }
+        )cpp",
+        "0: targets = {A}, decl\n"
+        "1: targets = {foo()::A::(unnamed struct)}\n"
+        "2: targets = {foo()::A::(unnamed struct)::c}, decl\n"
+        "3: targets = {foo()::A::B}, decl\n"
+        "4: targets = {x}, decl\n"
+        "5: targets = {A}\n"
+        "6: targets = {foo()::A::B}\n"
+        "7: targets = {foo()::A::(unnamed struct)::c}\n"},
+       // offsetof with an array-subscript component -- array indices are not
+       // emitted as offsetof references (the subscript expression is still
+       // visited independently).
+       {R"cpp(
+            void foo() {
+              struct $0^A { int $1^arr[4]; };
+              int $2^i = 0;
+              int $3^x = __builtin_offsetof($4^A, $5^arr[$6^i]);
+            }
+        )cpp",
+        "0: targets = {A}, decl\n"
+        "1: targets = {foo()::A::arr}, decl\n"
+        "2: targets = {i}, decl\n"
+        "3: targets = {x}, decl\n"
+        "4: targets = {A}\n"
+        "5: targets = {foo()::A::arr}\n"
+        "6: targets = {i}\n"},
        {R"cpp(
            template<typename T>
            void crash(T);


### PR DESCRIPTION
clangd had no handling for OffsetOfExpr in FindTarget.cpp, so go-to-definition and find-references on field names inside __builtin_offsetof(Type, field) produced no results.

Fix this by adding VisitOffsetOfExpr to both visitors:
- The TargetFinder visitor in add(const Stmt*) so that allTargetDecls() resolves the referenced FieldDecl(s).
- The refInStmt visitor so that findExplicitReferences() emits a ReferenceLoc per field component, enabling find-references and rename to locate each field at its source position.

Each OffsetOfNode of kind Field is visited; Identifier nodes (unresolved dependent-type designators) and Base nodes (implicit base-class indirections) are intentionally skipped.

Repro:
```                                                                                                                                                                                                                                             
  struct Foo { int bar; };                               
  int x = offsetof(Foo, bar);  // go-to-def on `bar` previously did nothing
```