### PR TITLE
Loosen check for clang version string in test to work when setting CLANG_VENDOR.

### DIFF
--- a/clang/bindings/python/tests/cindex/test_version.py
+++ b/clang/bindings/python/tests/cindex/test_version.py
@@ -8,4 +8,4 @@ class TestClangVersion(unittest.TestCase):
         conf = Config()
         version = conf.get_clang_version()
 
-        self.assertRegex(version, r"^.*clang version \d+\.\d+\.\d+")
+        self.assertRegex(version, r"clang version \d+\.\d+\.\d+")

--- a/clang/bindings/python/tests/cindex/test_version.py
+++ b/clang/bindings/python/tests/cindex/test_version.py
@@ -8,4 +8,4 @@ class TestClangVersion(unittest.TestCase):
         conf = Config()
         version = conf.get_clang_version()
 
-        self.assertRegex(version, r"^(.*)*clang version \d+\.\d+\.\d+")
+        self.assertRegex(version, r"^.*clang version \d+\.\d+\.\d+")

--- a/clang/bindings/python/tests/cindex/test_version.py
+++ b/clang/bindings/python/tests/cindex/test_version.py
@@ -8,4 +8,4 @@ class TestClangVersion(unittest.TestCase):
         conf = Config()
         version = conf.get_clang_version()
 
-        self.assertRegex(version, r"^clang version \d+\.\d+\.\d+")
+        self.assertRegex(version, r"^(.*)*clang version \d+\.\d+\.\d+")


### PR DESCRIPTION
I am trying to update our buildbot to use the `-DCLANG_VENDOR` and `-DCLANG_VENDOR_UTI` options, but need to fix some tests first. This is one of them.

This test checks for the default version string, essentially when `CLANG_VENDOR` and `CLANG_VENDOR_UTI` are either not set or empty. If they are set, then the test fails as it checks from the very beginning of the line. I fixed this test by making it more flexible and only checking that the previous check occurs in the line, not necessarily at the beginning. This allows the test to pass in both the default case, and when the `CLANG_VENDOR` and `CLANG_VENDOR_UTI` options are utilized. 