### PR TITLE
[lldb] Remove trailing newlines from AppendErrorWithFormat calls

### DIFF
--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -3717,13 +3717,13 @@ void CommandObjectMultiwordBreakpoint::VerifyIDs(
             &id_str, cur_bp_id.GetBreakpointID(), cur_bp_id.GetLocationID());
         i = valid_ids->GetSize() + 1;
         result.AppendErrorWithFormat(
-            "'%s' is not a currently valid breakpoint/location id.\n",
+            "'%s' is not a currently valid breakpoint/location id.",
             id_str.GetData());
       }
     } else {
       i = valid_ids->GetSize() + 1;
       result.AppendErrorWithFormat(
-          "'%d' is not a currently valid breakpoint ID.\n",
+          "'%d' is not a currently valid breakpoint ID.",
           cur_bp_id.GetBreakpointID());
     }
   }

--- a/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
@@ -516,7 +516,7 @@ protected:
             if (bp_loc_sp)
               bp_loc_sp->ClearCallback();
             else {
-              result.AppendErrorWithFormat("Invalid breakpoint ID: %u.%u.\n",
+              result.AppendErrorWithFormat("Invalid breakpoint ID: %u.%u.",
                                            cur_bp_id.GetBreakpointID(),
                                            cur_bp_id.GetLocationID());
               return;
@@ -583,7 +583,7 @@ protected:
             if (cur_bp_id.GetLocationID() != LLDB_INVALID_BREAK_ID) {
               bp_loc_sp = bp->FindLocationByID(cur_bp_id.GetLocationID());
               if (!bp_loc_sp) {
-                result.AppendErrorWithFormat("Invalid breakpoint ID: %u.%u.\n",
+                result.AppendErrorWithFormat("Invalid breakpoint ID: %u.%u.",
                                              cur_bp_id.GetBreakpointID(),
                                              cur_bp_id.GetLocationID());
                 return;
@@ -618,7 +618,7 @@ protected:
           }
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
-          result.AppendErrorWithFormat("Invalid breakpoint ID: %u.\n",
+          result.AppendErrorWithFormat("Invalid breakpoint ID: %u.",
                                        cur_bp_id.GetBreakpointID());
         }
       }

--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -115,7 +115,7 @@ protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat(
-          "'%s' takes exactly one executable filename argument.\n",
+          "'%s' takes exactly one executable filename argument.",
           GetCommandName().str().c_str());
       return;
     }
@@ -425,7 +425,7 @@ protected:
     // Verify that the command is alias-able.
     if (m_interpreter.CommandExists(alias_command)) {
       result.AppendErrorWithFormat(
-          "'%s' is a permanent debugger command and cannot be redefined.\n",
+          "'%s' is a permanent debugger command and cannot be redefined.",
           args[0].c_str());
       return;
     }
@@ -433,7 +433,7 @@ protected:
     if (m_interpreter.UserMultiwordCommandExists(alias_command)) {
       result.AppendErrorWithFormat(
           "'%s' is a user container command and cannot be overwritten.\n"
-          "Delete it first with 'command container delete'\n",
+          "Delete it first with 'command container delete'",
           args[0].c_str());
       return;
     }
@@ -518,7 +518,7 @@ protected:
 
     if (m_interpreter.CommandExists(alias_command)) {
       result.AppendErrorWithFormat(
-          "'%s' is a permanent debugger command and cannot be redefined.\n",
+          "'%s' is a permanent debugger command and cannot be redefined.",
           alias_command.c_str());
       return false;
     }
@@ -536,7 +536,7 @@ protected:
     CommandObjectSP subcommand_obj_sp;
     bool use_subcommand = false;
     if (!command_obj_sp) {
-      result.AppendErrorWithFormat("'%s' is not an existing command.\n",
+      result.AppendErrorWithFormat("'%s' is not an existing command.",
                                    actual_command.c_str());
       return false;
     }
@@ -552,7 +552,7 @@ protected:
       if (!subcommand_obj_sp) {
         result.AppendErrorWithFormat(
             "'%s' is not a valid sub-command of '%s'.  "
-            "Unable to create alias.\n",
+            "Unable to create alias.",
             args[0].c_str(), actual_command.c_str());
         return false;
       }
@@ -640,7 +640,7 @@ protected:
     if (!cmd_obj) {
       result.AppendErrorWithFormat(
           "'%s' is not a known command.\nTry 'help' to see a "
-          "current list of commands.\n",
+          "current list of commands.",
           args[0].c_str());
       return;
     }
@@ -649,11 +649,11 @@ protected:
       if (cmd_obj->IsRemovable()) {
         result.AppendErrorWithFormat(
             "'%s' is not an alias, it is a debugger command which can be "
-            "removed using the 'command delete' command.\n",
+            "removed using the 'command delete' command.",
             args[0].c_str());
       } else {
         result.AppendErrorWithFormat(
-            "'%s' is a permanent debugger command and cannot be removed.\n",
+            "'%s' is a permanent debugger command and cannot be removed.",
             args[0].c_str());
       }
       return;
@@ -662,10 +662,10 @@ protected:
     if (!m_interpreter.RemoveAlias(command_name)) {
       if (m_interpreter.AliasExists(command_name))
         result.AppendErrorWithFormat(
-            "Error occurred while attempting to unalias '%s'.\n",
+            "Error occurred while attempting to unalias '%s'.",
             args[0].c_str());
       else
-        result.AppendErrorWithFormat("'%s' is not an existing alias.\n",
+        result.AppendErrorWithFormat("'%s' is not an existing alias.",
                                      args[0].c_str());
       return;
     }
@@ -726,7 +726,7 @@ protected:
 
     if (!m_interpreter.RemoveCommand(command_name)) {
       result.AppendErrorWithFormat(
-          "'%s' is a permanent debugger command and cannot be removed.\n",
+          "'%s' is a permanent debugger command and cannot be removed.",
           args[0].c_str());
       return;
     }

--- a/lldb/source/Commands/CommandObjectDisassemble.cpp
+++ b/lldb/source/Commands/CommandObjectDisassemble.cpp
@@ -489,11 +489,11 @@ void CommandObjectDisassemble::DoExecute(Args &command,
     if (plugin_name) {
       result.AppendErrorWithFormat(
           "Unable to find Disassembler plug-in named '%s' that supports the "
-          "'%s' architecture.\n",
+          "'%s' architecture.",
           plugin_name, m_options.arch.GetArchitectureName());
     } else
       result.AppendErrorWithFormat(
-          "Unable to find Disassembler plug-in for the '%s' architecture.\n",
+          "Unable to find Disassembler plug-in for the '%s' architecture.",
           m_options.arch.GetArchitectureName());
     return;
   } else if (flavor_string != nullptr && !disassembler->FlavorValidForArchSpec(
@@ -505,7 +505,7 @@ void CommandObjectDisassemble::DoExecute(Args &command,
 
   if (!command.empty()) {
     result.AppendErrorWithFormat(
-        "\"disassemble\" arguments are specified as options.\n");
+        "\"disassemble\" arguments are specified as options.");
     const int terminal_width =
         GetCommandInterpreter().GetDebugger().GetTerminalWidth();
     const bool use_color = GetCommandInterpreter().GetDebugger().GetUseColor();
@@ -564,11 +564,11 @@ void CommandObjectDisassemble::DoExecute(Args &command,
     } else {
       if (m_options.symbol_containing_addr != LLDB_INVALID_ADDRESS) {
         result.AppendErrorWithFormat(
-            "Failed to disassemble memory in function at 0x%8.8" PRIx64 ".\n",
+            "Failed to disassemble memory in function at 0x%8.8" PRIx64 ".",
             m_options.symbol_containing_addr);
       } else {
         result.AppendErrorWithFormat(
-            "Failed to disassemble memory at 0x%8.8" PRIx64 ".\n",
+            "Failed to disassemble memory at 0x%8.8" PRIx64 ".",
             cur_range.GetBaseAddress().GetLoadAddress(&target));
       }
     }

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -420,7 +420,7 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
 
   if (m_command_options.top_level && !m_command_options.allow_jit) {
     result.AppendErrorWithFormat(
-        "Can't disable JIT compilation for top-level expressions.\n");
+        "Can't disable JIT compilation for top-level expressions.");
     return false;
   }
 
@@ -454,7 +454,7 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
           Status error(CanBeUsedForElementCountPrinting(*result_valobj_sp));
           if (error.Fail()) {
             result.AppendErrorWithFormat(
-                "expression cannot be used with --element-count %s\n",
+                "expression cannot be used with --element-count %s",
                 error.AsCString(""));
             return false;
           }


### PR DESCRIPTION
This call adds a newline if there isn't one. Changing these will eventually let us always add a newline, which is in line with the other methods on CommandReturnObject.

This is a small part of calls found with:
* VSCode search for `(\.AppendErrorWithFormat\(([\s\r\n]+)?"(?:(?:\\.|[^"\\])*))\\n"` and replace with `$1"`.
* Asserting that the last character of the format string is not a newline.
* Manual inspection.