### PR TITLE
[SystemZ] Fix wrong mask for float vec_insert

### DIFF
--- a/clang/lib/Headers/vecintrin.h
+++ b/clang/lib/Headers/vecintrin.h
@@ -207,7 +207,7 @@ vec_insert(unsigned long long __scalar, __vector unsigned long long __vec,
 #if __ARCH__ >= 12
 static inline __ATTRS_o_ai __vector float
 vec_insert(float __scalar, __vector float __vec, int __index) {
-  __vec[__index & 1] = __scalar;
+  __vec[__index & 3] = __scalar;
   return __vec;
 }
 #endif

--- a/clang/test/CodeGen/SystemZ/builtins-systemz-zvector2.c
+++ b/clang/test/CodeGen/SystemZ/builtins-systemz-zvector2.c
@@ -86,7 +86,10 @@ void test_core(void) {
   vf2 = vf;
   vf = vec_insert(f, vf2, 0);
   // CHECK: insertelement <4 x float> %{{.*}}, float %{{.*}}, i64 0
-  // CHECK-ASM: vlef
+  // CHECK-ASM: vlef %{{.*}}, 0(%{{.*}}), 0
+  vf = vec_insert(f, vf2, 3);
+  // CHECK: insertelement <4 x float> %{{.*}}, float %{{.*}}, i64 3
+  // CHECK-ASM: vlef %{{.*}}, 0(%{{.*}}), 3
   vf = vec_insert(0.0f, vf, 1);
   // CHECK: insertelement <4 x float> %{{.*}}, float 0.000000e+00, i64 1
   // CHECK-ASM: vleif %{{.*}}, 0, 1


### PR DESCRIPTION
This commit fixes an error in vec_insert, where the index masking effectively made the last two float elements of a vector non-insertable.

co-authored-by: @Andreas-Krebbel