### PR TITLE
[lldb] Implement delayed breakpoints

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -2275,8 +2275,8 @@ protected:
   UpdateBreakpointSites(const BreakpointSiteToActionMap &site_to_action);
 
 public:
-  Status ExecuteBreakpointSiteAction(BreakpointSite &site,
-                                     Process::BreakpointAction action);
+  llvm::Error ExecuteBreakpointSiteAction(BreakpointSite &site,
+                                          Process::BreakpointAction action);
 
   // This is implemented completely using the lldb::Process API. Subclasses
   // don't need to implement this function unless the standard flow of read

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3562,7 +3562,16 @@ protected:
     }
     void Clear() { m_site_to_action.clear(); }
 
-    std::map<lldb::BreakpointSiteSP, BreakpointAction> m_site_to_action;
+    /// Compare BreakpointSiteSPs by ID, so that iteration order is independent
+    /// of pointer addresses.
+    struct SiteIDCmp {
+      bool operator()(const lldb::BreakpointSiteSP lhs,
+                      const lldb::BreakpointSiteSP &rhs) const {
+        return lhs->GetID() < rhs->GetID();
+      }
+    };
+    std::map<lldb::BreakpointSiteSP, BreakpointAction, SiteIDCmp>
+        m_site_to_action;
   };
 
   DelayedBreakpointCache m_delayed_breakpoints;

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -2263,7 +2263,7 @@ protected:
   /// Compare BreakpointSiteSPs by ID, so that iteration order is independent
   /// of pointer addresses.
   struct SiteIDCmp {
-    bool operator()(const lldb::BreakpointSiteSP lhs,
+    bool operator()(const lldb::BreakpointSiteSP &lhs,
                     const lldb::BreakpointSiteSP &rhs) const {
       return lhs->GetID() < rhs->GetID();
     }

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -2260,8 +2260,19 @@ protected:
         "error: {0} does not support disabling breakpoints", GetPluginName());
   }
 
-  virtual llvm::Error UpdateBreakpointSites(
-      const std::map<lldb::BreakpointSiteSP, BreakpointAction> &site_to_action);
+  /// Compare BreakpointSiteSPs by ID, so that iteration order is independent
+  /// of pointer addresses.
+  struct SiteIDCmp {
+    bool operator()(const lldb::BreakpointSiteSP lhs,
+                    const lldb::BreakpointSiteSP &rhs) const {
+      return lhs->GetID() < rhs->GetID();
+    }
+  };
+  using BreakpointSiteToActionMap =
+      std::map<lldb::BreakpointSiteSP, BreakpointAction, SiteIDCmp>;
+
+  virtual llvm::Error
+  UpdateBreakpointSites(const BreakpointSiteToActionMap &site_to_action);
 
 public:
   Status ExecuteBreakpointSiteAction(BreakpointSite &site,
@@ -3562,16 +3573,7 @@ protected:
     }
     void Clear() { m_site_to_action.clear(); }
 
-    /// Compare BreakpointSiteSPs by ID, so that iteration order is independent
-    /// of pointer addresses.
-    struct SiteIDCmp {
-      bool operator()(const lldb::BreakpointSiteSP lhs,
-                      const lldb::BreakpointSiteSP &rhs) const {
-        return lhs->GetID() < rhs->GetID();
-      }
-    };
-    std::map<lldb::BreakpointSiteSP, BreakpointAction, SiteIDCmp>
-        m_site_to_action;
+    BreakpointSiteToActionMap m_site_to_action;
   };
 
   DelayedBreakpointCache m_delayed_breakpoints;

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -114,6 +114,7 @@ public:
   Args GetAlwaysRunThreadNames() const;
   FollowForkMode GetFollowForkMode() const;
   bool TrackMemoryCacheChanges() const;
+  bool GetUseDelayedBreakpoints() const;
 
 protected:
   Process *m_process; // Can be nullptr for global ProcessProperties
@@ -2246,6 +2247,9 @@ public:
   // Process Breakpoints
   size_t GetSoftwareBreakpointTrapOpcode(BreakpointSite *bp_site);
 
+  enum class BreakpointAction { Enable, Disable };
+
+protected:
   virtual Status EnableBreakpointSite(BreakpointSite *bp_site) {
     return Status::FromErrorStringWithFormatv(
         "error: {0} does not support enabling breakpoints", GetPluginName());
@@ -2255,6 +2259,14 @@ public:
     return Status::FromErrorStringWithFormatv(
         "error: {0} does not support disabling breakpoints", GetPluginName());
   }
+
+  virtual llvm::Error UpdateBreakpointSites(
+      const std::map<lldb::BreakpointSiteSP, BreakpointAction> &site_to_action);
+
+public:
+  Status ExecuteBreakpointSiteAction(BreakpointSite &site,
+                                     Process::BreakpointAction action,
+                                     bool force_now = false);
 
   // This is implemented completely using the lldb::Process API. Subclasses
   // don't need to implement this function unless the standard flow of read
@@ -2280,11 +2292,14 @@ public:
   lldb::break_id_t CreateBreakpointSite(const lldb::BreakpointLocationSP &owner,
                                         bool use_hardware);
 
-  Status DisableBreakpointSiteByID(lldb::user_id_t break_id);
+  Status DisableBreakpointSiteByID(lldb::user_id_t break_id,
+                                   bool force_now = false);
 
   Status EnableBreakpointSiteByID(lldb::user_id_t break_id);
 
   bool IsBreakpointSiteEnabled(const BreakpointSite &site);
+
+  bool IsBreakpointSitePhysicallyEnabled(const BreakpointSite &site);
 
   // BreakpointLocations use RemoveConstituentFromBreakpointSite to remove
   // themselves from the constituent's list of this breakpoint sites.
@@ -3539,6 +3554,20 @@ protected:
   /// A repository for extra crash information, consulted in
   /// GetExtendedCrashInformation.
   StructuredData::DictionarySP m_crash_info_dict_sp;
+
+  struct DelayedBreakpointCache {
+    void Enqueue(lldb::BreakpointSiteSP site, BreakpointAction action);
+    void RemoveSite(lldb::BreakpointSiteSP site) {
+      m_site_to_action.erase(site);
+    }
+    void Clear() { m_site_to_action.clear(); }
+
+    std::map<lldb::BreakpointSiteSP, BreakpointAction> m_site_to_action;
+  };
+
+  DelayedBreakpointCache m_delayed_breakpoints;
+
+  llvm::Error FlushDelayedBreakpoints();
 
   size_t RemoveBreakpointOpcodesFromBuffer(lldb::addr_t addr, size_t size,
                                            uint8_t *buf) const;

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -2276,8 +2276,7 @@ protected:
 
 public:
   Status ExecuteBreakpointSiteAction(BreakpointSite &site,
-                                     Process::BreakpointAction action,
-                                     bool force_now = false);
+                                     Process::BreakpointAction action);
 
   // This is implemented completely using the lldb::Process API. Subclasses
   // don't need to implement this function unless the standard flow of read
@@ -2303,8 +2302,7 @@ public:
   lldb::break_id_t CreateBreakpointSite(const lldb::BreakpointLocationSP &owner,
                                         bool use_hardware);
 
-  Status DisableBreakpointSiteByID(lldb::user_id_t break_id,
-                                   bool force_now = false);
+  Status DisableBreakpointSiteByID(lldb::user_id_t break_id);
 
   Status EnableBreakpointSiteByID(lldb::user_id_t break_id);
 

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3575,6 +3575,7 @@ protected:
   };
 
   DelayedBreakpointCache m_delayed_breakpoints;
+  std::recursive_mutex m_delayed_breakpoints_mutex;
 
   llvm::Error FlushDelayedBreakpoints();
 

--- a/lldb/source/Plugins/Process/MacOSX-Kernel/ProcessKDP.cpp
+++ b/lldb/source/Plugins/Process/MacOSX-Kernel/ProcessKDP.cpp
@@ -633,7 +633,7 @@ Status ProcessKDP::EnableBreakpointSite(BreakpointSite *bp_site) {
 
   if (m_comm.LocalBreakpointsAreSupported()) {
     Status error;
-    if (!IsBreakpointSiteEnabled(*bp_site)) {
+    if (!IsBreakpointSitePhysicallyEnabled(*bp_site)) {
       if (m_comm.SendRequestBreakpoint(true, bp_site->GetLoadAddress())) {
         SetBreakpointSiteEnabled(*bp_site);
         bp_site->SetType(BreakpointSite::eExternal);
@@ -649,7 +649,7 @@ Status ProcessKDP::EnableBreakpointSite(BreakpointSite *bp_site) {
 Status ProcessKDP::DisableBreakpointSite(BreakpointSite *bp_site) {
   if (m_comm.LocalBreakpointsAreSupported()) {
     Status error;
-    if (IsBreakpointSiteEnabled(*bp_site)) {
+    if (IsBreakpointSitePhysicallyEnabled(*bp_site)) {
       BreakpointSite::Type bp_type = bp_site->GetType();
       if (bp_type == BreakpointSite::eExternal) {
         if (m_destroy_in_process && m_comm.IsRunning()) {

--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
@@ -636,7 +636,7 @@ StopInfoSP StopInfoMachException::CreateStopReasonWithMachException(
   addr_t pc = reg_ctx_sp->GetPC();
   BreakpointSiteSP bp_site_sp =
       process_sp->GetBreakpointSiteList().FindByAddress(pc);
-  if (bp_site_sp && process_sp->IsBreakpointSiteEnabled(*bp_site_sp))
+  if (bp_site_sp && process_sp->IsBreakpointSitePhysicallyEnabled(*bp_site_sp))
     thread.SetThreadStoppedAtUnexecutedBP(pc);
 
   switch (exc_type) {
@@ -771,7 +771,8 @@ StopInfoSP StopInfoMachException::CreateStopReasonWithMachException(
       if (!bp_site_sp && reg_ctx_sp) {
         bp_site_sp = process_sp->GetBreakpointSiteList().FindByAddress(pc);
       }
-      if (bp_site_sp && process_sp->IsBreakpointSiteEnabled(*bp_site_sp)) {
+      if (bp_site_sp &&
+          process_sp->IsBreakpointSitePhysicallyEnabled(*bp_site_sp)) {
         // We've hit this breakpoint, whether it was intended for this thread
         // or not.  Clear this in the Tread object so we step past it on resume.
         thread.SetThreadHitBreakpointSite();
@@ -865,7 +866,8 @@ bool StopInfoMachException::WasContinueInterrupted(Thread &thread) {
   // We have a hardware breakpoint -- this is the kernel bug.
   auto &bp_site_list = process_sp->GetBreakpointSiteList();
   for (auto &site : bp_site_list.Sites()) {
-    if (site->IsHardware() && process_sp->IsBreakpointSiteEnabled(*site)) {
+    if (site->IsHardware() &&
+        process_sp->IsBreakpointSitePhysicallyEnabled(*site)) {
       LLDB_LOGF(log,
                 "Thread stopped with insn-step completed mach exception but "
                 "thread was not stepping; there is a hardware breakpoint set.");

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -415,7 +415,7 @@ void ProcessWindows::RefreshStateAfterStop() {
   // If we're at a BreakpointSite, mark this as an Unexecuted Breakpoint.
   // We'll clear that state if we've actually executed the breakpoint.
   BreakpointSiteSP site(GetBreakpointSiteList().FindByAddress(pc));
-  if (site && IsBreakpointSiteEnabled(*site))
+  if (site && IsBreakpointSitePhysicallyEnabled(*site))
     stop_thread->SetThreadStoppedAtUnexecutedBP(pc);
 
   switch (active_exception->GetExceptionCode()) {

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -1848,7 +1848,7 @@ ThreadSP ProcessGDBRemote::SetThreadStopInfo(
     addr_t pc = thread_sp->GetRegisterContext()->GetPC();
     BreakpointSiteSP bp_site_sp =
         thread_sp->GetProcess()->GetBreakpointSiteList().FindByAddress(pc);
-    if (bp_site_sp && IsBreakpointSiteEnabled(*bp_site_sp))
+    if (bp_site_sp && IsBreakpointSitePhysicallyEnabled(*bp_site_sp))
       thread_sp->SetThreadStoppedAtUnexecutedBP(pc);
 
     if (exc_type != 0) {
@@ -2032,7 +2032,7 @@ ThreadSP ProcessGDBRemote::SetThreadStopInfo(
           // BreakpointSites in any other location, but we can't know for
           // sure what happened so it's a reasonable default.
           if (bp_site_sp) {
-            if (IsBreakpointSiteEnabled(*bp_site_sp))
+            if (IsBreakpointSitePhysicallyEnabled(*bp_site_sp))
               thread_sp->SetThreadHitBreakpointSite();
 
             if (bp_site_sp->ValidForThisThread(*thread_sp)) {
@@ -3429,7 +3429,7 @@ Status ProcessGDBRemote::EnableBreakpointSite(BreakpointSite *bp_site) {
             site_id, (uint64_t)addr);
 
   // Breakpoint already exists and is enabled
-  if (IsBreakpointSiteEnabled(*bp_site)) {
+  if (IsBreakpointSitePhysicallyEnabled(*bp_site)) {
     LLDB_LOGF(log,
               "ProcessGDBRemote::EnableBreakpointSite (size_id = %" PRIu64
               ") address = 0x%" PRIx64 " -- SUCCESS (already enabled)",
@@ -3450,7 +3450,7 @@ Status ProcessGDBRemote::DisableBreakpointSite(BreakpointSite *bp_site) {
             ") addr = 0x%8.8" PRIx64,
             site_id, (uint64_t)addr);
 
-  if (!IsBreakpointSiteEnabled(*bp_site)) {
+  if (!IsBreakpointSitePhysicallyEnabled(*bp_site)) {
     LLDB_LOGF(log,
               "ProcessGDBRemote::DisableBreakpointSite (site_id = %" PRIu64
               ") addr = 0x%8.8" PRIx64 " -- SUCCESS (already disabled)",
@@ -6112,7 +6112,7 @@ void ProcessGDBRemote::DidForkSwitchSoftwareBreakpoints(
 
   GetBreakpointSiteList().ForEach([this, enable, entry_addr,
                                    log](BreakpointSite *bp_site) {
-    if (IsBreakpointSiteEnabled(*bp_site) &&
+    if (IsBreakpointSitePhysicallyEnabled(*bp_site) &&
         (bp_site->GetType() == BreakpointSite::eSoftware ||
          bp_site->GetType() == BreakpointSite::eExternal)) {
       // During expression evaluation, retain the expression-return trap
@@ -6136,7 +6136,7 @@ void ProcessGDBRemote::DidForkSwitchSoftwareBreakpoints(
 void ProcessGDBRemote::DidForkSwitchHardwareTraps(bool enable) {
   if (m_gdb_comm.SupportsGDBStoppointPacket(eBreakpointHardware)) {
     GetBreakpointSiteList().ForEach([this, enable](BreakpointSite *bp_site) {
-      if (IsBreakpointSiteEnabled(*bp_site) &&
+      if (IsBreakpointSitePhysicallyEnabled(*bp_site) &&
           bp_site->GetType() == BreakpointSite::eHardware) {
         m_gdb_comm.SendGDBStoppointTypePacket(
             eBreakpointHardware, enable, bp_site->GetLoadAddress(),

--- a/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
@@ -265,7 +265,7 @@ size_t ScriptedProcess::DoWriteMemory(lldb::addr_t vm_addr, const void *buf,
 Status ScriptedProcess::EnableBreakpointSite(BreakpointSite *bp_site) {
   assert(bp_site != nullptr);
 
-  if (IsBreakpointSiteEnabled(*bp_site)) {
+  if (IsBreakpointSitePhysicallyEnabled(*bp_site)) {
     return {};
   }
 

--- a/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
@@ -316,7 +316,7 @@ bool ScriptedThread::CalculateStopInfo() {
     ProcessSP proc = GetProcess();
     if (BreakpointSiteSP bp_site_sp =
             proc->GetBreakpointSiteList().FindByAddress(pc))
-      if (proc->IsBreakpointSiteEnabled(*bp_site_sp))
+      if (proc->IsBreakpointSitePhysicallyEnabled(*bp_site_sp))
         SetThreadStoppedAtUnexecutedBP(pc);
   }
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1596,6 +1596,7 @@ Status Process::DisableBreakpointSiteByID(lldb::user_id_t break_id) {
 llvm::Error Process::ExecuteBreakpointSiteAction(BreakpointSite &site,
                                                  BreakpointAction action) {
   auto site_sp = site.shared_from_this();
+  std::unique_lock<std::recursive_mutex> guard(m_delayed_breakpoints_mutex);
 
   // Ignore requests that won't change the Site status.
   if (IsBreakpointSiteEnabled(*site_sp) == (action == BreakpointAction::Enable))
@@ -1607,6 +1608,7 @@ llvm::Error Process::ExecuteBreakpointSiteAction(BreakpointSite &site,
   }
 
   m_delayed_breakpoints.RemoveSite(site_sp);
+  guard.unlock();
 
   switch (action) {
   case BreakpointAction::Enable:
@@ -1633,6 +1635,8 @@ Status Process::EnableBreakpointSiteByID(lldb::user_id_t break_id) {
 }
 
 bool Process::IsBreakpointSiteEnabled(const BreakpointSite &site) {
+  std::lock_guard<std::recursive_mutex> guard(m_delayed_breakpoints_mutex);
+
   // `site` won't be mutated, but the cache stores mutable pointers.
   auto it = m_delayed_breakpoints.m_site_to_action.find(
       const_cast<BreakpointSite &>(site).shared_from_this());
@@ -1707,6 +1711,8 @@ static addr_t ComputeConstituentLoadAddress(BreakpointLocation &constituent,
 }
 
 llvm::Error Process::FlushDelayedBreakpoints() {
+  std::unique_lock<std::recursive_mutex> guard(m_delayed_breakpoints_mutex);
+
   // Clear the cache in m_delayed_breakpoints so it can't affect the actual
   // enabling of breakpoints. For example, if `EnableSoftwareBreakpoint` is
   // called outside of FlushDelayedBreakpoints, it needs to check the delayed
@@ -1716,6 +1722,7 @@ llvm::Error Process::FlushDelayedBreakpoints() {
   auto site_to_action = std::move(m_delayed_breakpoints.m_site_to_action);
   m_delayed_breakpoints.m_site_to_action.clear();
 
+  guard.unlock();
   return UpdateBreakpointSites(site_to_action);
 }
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -79,6 +79,17 @@ using namespace lldb;
 using namespace lldb_private;
 using namespace std::chrono;
 
+void Process::DelayedBreakpointCache::Enqueue(lldb::BreakpointSiteSP site,
+                                              BreakpointAction action) {
+  auto [previous, inserted] = m_site_to_action.insert({site, action});
+  // New site or already enqueued for the same action
+  if (inserted || previous->second == action)
+    return;
+  // Previously enqueued for the opposite action, don't update the site.
+  m_site_to_action.erase(previous);
+  assert(site->m_enabled == (action == BreakpointAction::Enable));
+}
+
 class ProcessOptionValueProperties
     : public Cloneable<ProcessOptionValueProperties, OptionValueProperties> {
 public:
@@ -318,6 +329,12 @@ bool ProcessProperties::GetWarningsUnsupportedLanguage() const {
 
 bool ProcessProperties::GetStopOnExec() const {
   const uint32_t idx = ePropertyStopOnExec;
+  return GetPropertyAtIndexAs<bool>(
+      idx, g_process_properties[idx].default_uint_value != 0);
+}
+
+bool ProcessProperties::GetUseDelayedBreakpoints() const {
+  const uint32_t idx = ePropertyUseDelayedBreakpoints;
   return GetPropertyAtIndexAs<bool>(
       idx, g_process_properties[idx].default_uint_value != 0);
 }
@@ -1546,12 +1563,12 @@ Process::GetBreakpointSiteList() const {
 
 void Process::DisableAllBreakpointSites() {
   m_breakpoint_site_list.ForEach([this](BreakpointSite *bp_site) -> void {
-    DisableBreakpointSite(bp_site);
+    ExecuteBreakpointSiteAction(*bp_site, BreakpointAction::Disable);
   });
 }
 
 Status Process::ClearBreakpointSiteByID(lldb::user_id_t break_id) {
-  Status error(DisableBreakpointSiteByID(break_id));
+  Status error(DisableBreakpointSiteByID(break_id, /*force_now=*/true));
 
   if (error.Success())
     m_breakpoint_site_list.Remove(break_id);
@@ -1559,12 +1576,14 @@ Status Process::ClearBreakpointSiteByID(lldb::user_id_t break_id) {
   return error;
 }
 
-Status Process::DisableBreakpointSiteByID(lldb::user_id_t break_id) {
+Status Process::DisableBreakpointSiteByID(lldb::user_id_t break_id,
+                                          bool force_now) {
   Status error;
   BreakpointSiteSP bp_site_sp = m_breakpoint_site_list.FindByID(break_id);
   if (bp_site_sp) {
     if (IsBreakpointSiteEnabled(*bp_site_sp))
-      error = DisableBreakpointSite(bp_site_sp.get());
+      error = ExecuteBreakpointSiteAction(*bp_site_sp,
+                                          BreakpointAction::Disable, force_now);
   } else {
     error = Status::FromErrorStringWithFormat(
         "invalid breakpoint site ID: %" PRIu64, break_id);
@@ -1573,12 +1592,34 @@ Status Process::DisableBreakpointSiteByID(lldb::user_id_t break_id) {
   return error;
 }
 
+Status Process::ExecuteBreakpointSiteAction(BreakpointSite &site,
+                                            BreakpointAction action,
+                                            bool force_now) {
+  if (!force_now && GetUseDelayedBreakpoints()) {
+    m_delayed_breakpoints.Enqueue(site.shared_from_this(), action);
+    return Status();
+  }
+
+  auto site_sp = site.shared_from_this();
+  m_delayed_breakpoints.RemoveSite(site_sp);
+
+  switch (action) {
+  case BreakpointAction::Enable:
+    return EnableBreakpointSite(site_sp.get());
+  case BreakpointAction::Disable:
+    return DisableBreakpointSite(site_sp.get());
+  }
+
+  llvm_unreachable("Unhandled BreakpointAction");
+}
+
 Status Process::EnableBreakpointSiteByID(lldb::user_id_t break_id) {
   Status error;
   BreakpointSiteSP bp_site_sp = m_breakpoint_site_list.FindByID(break_id);
   if (bp_site_sp) {
     if (!IsBreakpointSiteEnabled(*bp_site_sp))
-      error = EnableBreakpointSite(bp_site_sp.get());
+      error =
+          ExecuteBreakpointSiteAction(*bp_site_sp, BreakpointAction::Enable);
   } else {
     error = Status::FromErrorStringWithFormat(
         "invalid breakpoint site ID: %" PRIu64, break_id);
@@ -1587,6 +1628,18 @@ Status Process::EnableBreakpointSiteByID(lldb::user_id_t break_id) {
 }
 
 bool Process::IsBreakpointSiteEnabled(const BreakpointSite &site) {
+  // `site` won't be mutated, but the cache stores mutable pointers.
+  auto it = m_delayed_breakpoints.m_site_to_action.find(
+      const_cast<BreakpointSite &>(site).shared_from_this());
+
+  // If no actions are delayed, use the current state of the site.
+  if (it == m_delayed_breakpoints.m_site_to_action.end())
+    return site.m_enabled;
+
+  return it->second == BreakpointAction::Enable;
+}
+
+bool Process::IsBreakpointSitePhysicallyEnabled(const BreakpointSite &site) {
   return site.m_enabled;
 }
 
@@ -1648,6 +1701,31 @@ static addr_t ComputeConstituentLoadAddress(BreakpointLocation &constituent,
   return resolved_address.GetOpcodeLoadAddress(&target);
 }
 
+llvm::Error Process::FlushDelayedBreakpoints() {
+  // Clear the cache in m_delayed_breakpoints so it can't affect the actual
+  // enabling of breakpoints. For
+  // example, if `EnableSoftwareBreakpoint` is called outside of
+  // FlushDelayedBreakpoints, it needs to check the delayed breakpoints and
+  // possibly early return. However, when called from FlushDelayedBreakpoints,
+  // the queue better be empty so that no early returns take place.
+  auto site_to_action = std::move(m_delayed_breakpoints.m_site_to_action);
+
+  auto error = UpdateBreakpointSites(site_to_action);
+  return error;
+}
+
+llvm::Error Process::UpdateBreakpointSites(
+    const std::map<lldb::BreakpointSiteSP, BreakpointAction> &site_to_action) {
+  llvm::Error error = llvm::Error::success();
+  for (auto [site, action] : site_to_action) {
+    Status new_error = action == BreakpointAction::Enable
+                           ? EnableBreakpointSite(site.get())
+                           : DisableBreakpointSite(site.get());
+    error = llvm::joinErrors(std::move(error), new_error.takeError());
+  }
+  return error;
+}
+
 lldb::break_id_t
 Process::CreateBreakpointSite(const BreakpointLocationSP &constituent,
                               bool use_hardware) {
@@ -1692,7 +1770,8 @@ void Process::RemoveConstituentFromBreakpointSite(
   if (num_constituents == 0) {
     // Don't try to disable the site if we don't have a live process anymore.
     if (IsAlive())
-      DisableBreakpointSite(bp_site_sp.get());
+      ExecuteBreakpointSiteAction(*bp_site_sp, BreakpointAction::Disable,
+                                  /*force_now=*/true);
     m_breakpoint_site_list.RemoveByAddress(bp_site_sp->GetLoadAddress());
   }
 }
@@ -3435,6 +3514,9 @@ Status Process::PrivateResume() {
             "Process::PrivateResume PreResumeActions failed, not resuming.");
       } else {
         m_mod_id.BumpResumeID();
+        if (auto E = FlushDelayedBreakpoints())
+          LLDB_LOG_ERROR(log, std::move(E),
+                         "Failed to update some delayed breakpoints: {0}");
         error = DoResume(direction);
         if (error.Success()) {
           DidResume();
@@ -3641,6 +3723,10 @@ Status Process::Detach(bool keep_stopped) {
 
     m_thread_list.DiscardThreadPlans();
     DisableAllBreakpointSites();
+    if (auto error = FlushDelayedBreakpoints())
+      LLDB_LOG_ERROR(
+          GetLog(LLDBLog::Process), std::move(error),
+          "Failed to update some delayed breakpoints during detach: {0}");
 
     error = DoDetach(keep_stopped);
     if (error.Success()) {
@@ -3710,6 +3796,10 @@ Status Process::DestroyImpl(bool force_kill) {
       // doing this now.
       m_thread_list.DiscardThreadPlans();
       DisableAllBreakpointSites();
+      if (auto error = FlushDelayedBreakpoints())
+        LLDB_LOG_ERROR(
+            GetLog(LLDBLog::Process), std::move(error),
+            "Failed to update some delayed breakpoints during destroy: {0}");
     }
 
     error = DoDestroy();

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -81,7 +81,8 @@ using namespace std::chrono;
 
 void Process::DelayedBreakpointCache::Enqueue(lldb::BreakpointSiteSP site,
                                               BreakpointAction action) {
-  auto [previous, inserted] = m_site_to_action.insert({site, action});
+  auto [previous, inserted] =
+      m_site_to_action.insert({std::move(site), action});
   // New site or already enqueued for the same action.
   if (inserted || previous->second == action)
     return;
@@ -1707,11 +1708,11 @@ static addr_t ComputeConstituentLoadAddress(BreakpointLocation &constituent,
 
 llvm::Error Process::FlushDelayedBreakpoints() {
   // Clear the cache in m_delayed_breakpoints so it can't affect the actual
-  // enabling of breakpoints. For
-  // example, if `EnableSoftwareBreakpoint` is called outside of
-  // FlushDelayedBreakpoints, it needs to check the delayed breakpoints and
-  // possibly early return. However, when called from FlushDelayedBreakpoints,
-  // the queue better be empty so that no early returns take place.
+  // enabling of breakpoints. For example, if `EnableSoftwareBreakpoint` is
+  // called outside of FlushDelayedBreakpoints, it needs to check the delayed
+  // breakpoints and possibly early return. However, when called from
+  // FlushDelayedBreakpoints, the queue better be empty so that no early returns
+  // take place.
   auto site_to_action = std::move(m_delayed_breakpoints.m_site_to_action);
   m_delayed_breakpoints.m_site_to_action.clear();
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -82,7 +82,7 @@ using namespace std::chrono;
 void Process::DelayedBreakpointCache::Enqueue(lldb::BreakpointSiteSP site,
                                               BreakpointAction action) {
   auto [previous, inserted] = m_site_to_action.insert({site, action});
-  // New site or already enqueued for the same action
+  // New site or already enqueued for the same action.
   if (inserted || previous->second == action)
     return;
   // Previously enqueued for the opposite action, don't update the site.

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1595,12 +1595,18 @@ Status Process::DisableBreakpointSiteByID(lldb::user_id_t break_id,
 Status Process::ExecuteBreakpointSiteAction(BreakpointSite &site,
                                             BreakpointAction action,
                                             bool force_now) {
+
+  auto site_sp = site.shared_from_this();
+
+  // Ignore requests that won't change the Site status.
+  if (IsBreakpointSiteEnabled(*site_sp) == (action == BreakpointAction::Enable))
+    return Status();
+
   if (!force_now && GetUseDelayedBreakpoints()) {
     m_delayed_breakpoints.Enqueue(site.shared_from_this(), action);
     return Status();
   }
 
-  auto site_sp = site.shared_from_this();
   m_delayed_breakpoints.RemoveSite(site_sp);
 
   switch (action) {

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -81,8 +81,7 @@ using namespace std::chrono;
 
 void Process::DelayedBreakpointCache::Enqueue(lldb::BreakpointSiteSP site,
                                               BreakpointAction action) {
-  auto [previous, inserted] =
-      m_site_to_action.insert({std::move(site), action});
+  auto [previous, inserted] = m_site_to_action.insert({site, action});
   // New site or already enqueued for the same action.
   if (inserted || previous->second == action)
     return;
@@ -1602,8 +1601,8 @@ llvm::Error Process::ExecuteBreakpointSiteAction(BreakpointSite &site,
   if (IsBreakpointSiteEnabled(*site_sp) == (action == BreakpointAction::Enable))
     return llvm::Error::success();
 
-  if (!GetUseDelayedBreakpoints()) {
-    m_delayed_breakpoints.Enqueue(site.shared_from_this(), action);
+  if (GetUseDelayedBreakpoints()) {
+    m_delayed_breakpoints.Enqueue(site_sp, action);
     return llvm::Error::success();
   }
 
@@ -1723,6 +1722,7 @@ llvm::Error Process::FlushDelayedBreakpoints() {
   m_delayed_breakpoints.m_site_to_action.clear();
 
   guard.unlock();
+  // Use a copy of the cache so that iteration is safe.
   return UpdateBreakpointSites(site_to_action);
 }
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1709,6 +1709,7 @@ llvm::Error Process::FlushDelayedBreakpoints() {
   // possibly early return. However, when called from FlushDelayedBreakpoints,
   // the queue better be empty so that no early returns take place.
   auto site_to_action = std::move(m_delayed_breakpoints.m_site_to_action);
+  m_delayed_breakpoints.m_site_to_action.clear();
 
   auto error = UpdateBreakpointSites(site_to_action);
   return error;

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1568,7 +1568,7 @@ void Process::DisableAllBreakpointSites() {
 }
 
 Status Process::ClearBreakpointSiteByID(lldb::user_id_t break_id) {
-  Status error(DisableBreakpointSiteByID(break_id, /*force_now=*/true));
+  Status error(DisableBreakpointSiteByID(break_id));
 
   if (error.Success())
     m_breakpoint_site_list.Remove(break_id);
@@ -1576,14 +1576,13 @@ Status Process::ClearBreakpointSiteByID(lldb::user_id_t break_id) {
   return error;
 }
 
-Status Process::DisableBreakpointSiteByID(lldb::user_id_t break_id,
-                                          bool force_now) {
+Status Process::DisableBreakpointSiteByID(lldb::user_id_t break_id) {
   Status error;
   BreakpointSiteSP bp_site_sp = m_breakpoint_site_list.FindByID(break_id);
   if (bp_site_sp) {
     if (IsBreakpointSiteEnabled(*bp_site_sp))
-      error = ExecuteBreakpointSiteAction(*bp_site_sp,
-                                          BreakpointAction::Disable, force_now);
+      error =
+          ExecuteBreakpointSiteAction(*bp_site_sp, BreakpointAction::Disable);
   } else {
     error = Status::FromErrorStringWithFormat(
         "invalid breakpoint site ID: %" PRIu64, break_id);
@@ -1593,16 +1592,14 @@ Status Process::DisableBreakpointSiteByID(lldb::user_id_t break_id,
 }
 
 Status Process::ExecuteBreakpointSiteAction(BreakpointSite &site,
-                                            BreakpointAction action,
-                                            bool force_now) {
-
+                                            BreakpointAction action) {
   auto site_sp = site.shared_from_this();
 
   // Ignore requests that won't change the Site status.
   if (IsBreakpointSiteEnabled(*site_sp) == (action == BreakpointAction::Enable))
     return Status();
 
-  if (!force_now && GetUseDelayedBreakpoints()) {
+  if (!GetUseDelayedBreakpoints()) {
     m_delayed_breakpoints.Enqueue(site.shared_from_this(), action);
     return Status();
   }
@@ -1776,8 +1773,7 @@ void Process::RemoveConstituentFromBreakpointSite(
   if (num_constituents == 0) {
     // Don't try to disable the site if we don't have a live process anymore.
     if (IsAlive())
-      ExecuteBreakpointSiteAction(*bp_site_sp, BreakpointAction::Disable,
-                                  /*force_now=*/true);
+      ExecuteBreakpointSiteAction(*bp_site_sp, BreakpointAction::Disable);
     m_breakpoint_site_list.RemoveByAddress(bp_site_sp->GetLoadAddress());
   }
 }

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1563,7 +1563,8 @@ Process::GetBreakpointSiteList() const {
 
 void Process::DisableAllBreakpointSites() {
   m_breakpoint_site_list.ForEach([this](BreakpointSite *bp_site) -> void {
-    ExecuteBreakpointSiteAction(*bp_site, BreakpointAction::Disable);
+    llvm::consumeError(
+        ExecuteBreakpointSiteAction(*bp_site, BreakpointAction::Disable));
   });
 }
 
@@ -1581,8 +1582,8 @@ Status Process::DisableBreakpointSiteByID(lldb::user_id_t break_id) {
   BreakpointSiteSP bp_site_sp = m_breakpoint_site_list.FindByID(break_id);
   if (bp_site_sp) {
     if (IsBreakpointSiteEnabled(*bp_site_sp))
-      error =
-          ExecuteBreakpointSiteAction(*bp_site_sp, BreakpointAction::Disable);
+      error = Status::FromError(
+          ExecuteBreakpointSiteAction(*bp_site_sp, BreakpointAction::Disable));
   } else {
     error = Status::FromErrorStringWithFormat(
         "invalid breakpoint site ID: %" PRIu64, break_id);
@@ -1591,26 +1592,26 @@ Status Process::DisableBreakpointSiteByID(lldb::user_id_t break_id) {
   return error;
 }
 
-Status Process::ExecuteBreakpointSiteAction(BreakpointSite &site,
-                                            BreakpointAction action) {
+llvm::Error Process::ExecuteBreakpointSiteAction(BreakpointSite &site,
+                                                 BreakpointAction action) {
   auto site_sp = site.shared_from_this();
 
   // Ignore requests that won't change the Site status.
   if (IsBreakpointSiteEnabled(*site_sp) == (action == BreakpointAction::Enable))
-    return Status();
+    return llvm::Error::success();
 
   if (!GetUseDelayedBreakpoints()) {
     m_delayed_breakpoints.Enqueue(site.shared_from_this(), action);
-    return Status();
+    return llvm::Error::success();
   }
 
   m_delayed_breakpoints.RemoveSite(site_sp);
 
   switch (action) {
   case BreakpointAction::Enable:
-    return EnableBreakpointSite(site_sp.get());
+    return EnableBreakpointSite(site_sp.get()).takeError();
   case BreakpointAction::Disable:
-    return DisableBreakpointSite(site_sp.get());
+    return DisableBreakpointSite(site_sp.get()).takeError();
   }
 
   llvm_unreachable("Unhandled BreakpointAction");
@@ -1621,8 +1622,8 @@ Status Process::EnableBreakpointSiteByID(lldb::user_id_t break_id) {
   BreakpointSiteSP bp_site_sp = m_breakpoint_site_list.FindByID(break_id);
   if (bp_site_sp) {
     if (!IsBreakpointSiteEnabled(*bp_site_sp))
-      error =
-          ExecuteBreakpointSiteAction(*bp_site_sp, BreakpointAction::Enable);
+      error = Status::FromError(
+          ExecuteBreakpointSiteAction(*bp_site_sp, BreakpointAction::Enable));
   } else {
     error = Status::FromErrorStringWithFormat(
         "invalid breakpoint site ID: %" PRIu64, break_id);
@@ -1773,7 +1774,8 @@ void Process::RemoveConstituentFromBreakpointSite(
   if (num_constituents == 0) {
     // Don't try to disable the site if we don't have a live process anymore.
     if (IsAlive())
-      ExecuteBreakpointSiteAction(*bp_site_sp, BreakpointAction::Disable);
+      llvm::consumeError(
+          ExecuteBreakpointSiteAction(*bp_site_sp, BreakpointAction::Disable));
     m_breakpoint_site_list.RemoveByAddress(bp_site_sp->GetLoadAddress());
   }
 }

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1711,12 +1711,11 @@ llvm::Error Process::FlushDelayedBreakpoints() {
   auto site_to_action = std::move(m_delayed_breakpoints.m_site_to_action);
   m_delayed_breakpoints.m_site_to_action.clear();
 
-  auto error = UpdateBreakpointSites(site_to_action);
-  return error;
+  return UpdateBreakpointSites(site_to_action);
 }
 
 llvm::Error Process::UpdateBreakpointSites(
-    const std::map<lldb::BreakpointSiteSP, BreakpointAction> &site_to_action) {
+    const BreakpointSiteToActionMap &site_to_action) {
   llvm::Error error = llvm::Error::success();
   for (auto [site, action] : site_to_action) {
     Status new_error = action == BreakpointAction::Enable

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1757,7 +1757,15 @@ Process::CreateBreakpointSite(const BreakpointLocationSP &constituent,
 
   BreakpointSiteSP bp_site_sp(
       new BreakpointSite(constituent, load_addr, use_hardware));
-  Status error = EnableBreakpointSite(bp_site_sp.get());
+
+  bool bp_from_address =
+      constituent->GetBreakpoint().GetResolver()->GetResolverTy() ==
+      BreakpointResolver::ResolverTy::AddressResolver;
+  bool should_be_eager = use_hardware || bp_from_address;
+
+  auto error = should_be_eager ? EnableBreakpointSite(bp_site_sp.get())
+                               : Status::FromError(ExecuteBreakpointSiteAction(
+                                     *bp_site_sp, BreakpointAction::Enable));
   if (error.Success()) {
     constituent->SetBreakpointSite(bp_site_sp);
     return m_breakpoint_site_list.Add(bp_site_sp);

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -319,6 +319,11 @@ let Definition = "process", Path = "target.process" in {
         Desc<"A list of thread names. Threads with any of these names will "
              "always be resumed when the process resumes, even when other "
              "threads are suspended during single-stepping operations.">;
+  def UseDelayedBreakpoints
+      : Property<"use-delayed-breakpoints", "Boolean">,
+        DefaultTrue,
+        Desc<"Specify whether to delay setting breakpoints until the process "
+             "is about to resume.">;
 }
 
 let Definition = "platform", Path = "platform" in {

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -322,8 +322,8 @@ let Definition = "process", Path = "target.process" in {
   def UseDelayedBreakpoints
       : Property<"use-delayed-breakpoints", "Boolean">,
         DefaultTrue,
-        Desc<"Specify whether to delay setting breakpoints until the process "
-             "is about to resume.">;
+        Desc<"Specify whether updating breakpoints may be delayed until the "
+             "process is about to resume.">;
 }
 
 let Definition = "platform", Path = "platform" in {

--- a/lldb/source/Target/ThreadPlanStepOverBreakpoint.cpp
+++ b/lldb/source/Target/ThreadPlanStepOverBreakpoint.cpp
@@ -121,8 +121,8 @@ bool ThreadPlanStepOverBreakpoint::DoWillResume(StateType resume_state,
     BreakpointSiteSP bp_site_sp(
         m_process.GetBreakpointSiteList().FindByAddress(m_breakpoint_addr));
     if (bp_site_sp && m_process.IsBreakpointSiteEnabled(*bp_site_sp)) {
-      m_process.ExecuteBreakpointSiteAction(*bp_site_sp,
-                                            Process::BreakpointAction::Disable);
+      llvm::consumeError(m_process.ExecuteBreakpointSiteAction(
+          *bp_site_sp, Process::BreakpointAction::Disable));
       m_reenabled_breakpoint_site = false;
     }
   }
@@ -168,8 +168,8 @@ void ThreadPlanStepOverBreakpoint::ReenableBreakpointSite() {
       if (BreakpointSiteSP bp_site_sp =
               m_process.GetBreakpointSiteList().FindByAddress(
                   m_breakpoint_addr))
-        m_process.ExecuteBreakpointSiteAction(
-            *bp_site_sp, Process::BreakpointAction::Enable);
+        llvm::consumeError(m_process.ExecuteBreakpointSiteAction(
+            *bp_site_sp, Process::BreakpointAction::Enable));
     }
   }
 }

--- a/lldb/source/Target/ThreadPlanStepOverBreakpoint.cpp
+++ b/lldb/source/Target/ThreadPlanStepOverBreakpoint.cpp
@@ -121,7 +121,8 @@ bool ThreadPlanStepOverBreakpoint::DoWillResume(StateType resume_state,
     BreakpointSiteSP bp_site_sp(
         m_process.GetBreakpointSiteList().FindByAddress(m_breakpoint_addr));
     if (bp_site_sp && m_process.IsBreakpointSiteEnabled(*bp_site_sp)) {
-      m_process.DisableBreakpointSite(bp_site_sp.get());
+      m_process.ExecuteBreakpointSiteAction(*bp_site_sp,
+                                            Process::BreakpointAction::Disable);
       m_reenabled_breakpoint_site = false;
     }
   }
@@ -167,7 +168,8 @@ void ThreadPlanStepOverBreakpoint::ReenableBreakpointSite() {
       if (BreakpointSiteSP bp_site_sp =
               m_process.GetBreakpointSiteList().FindByAddress(
                   m_breakpoint_addr))
-        m_process.EnableBreakpointSite(bp_site_sp.get());
+        m_process.ExecuteBreakpointSiteAction(
+            *bp_site_sp, Process::BreakpointAction::Enable);
     }
   }
 }

--- a/lldb/test/API/functionalities/breakpoint/delayed_breakpoints/Makefile
+++ b/lldb/test/API/functionalities/breakpoint/delayed_breakpoints/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/breakpoint/delayed_breakpoints/TestDelayedBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/delayed_breakpoints/TestDelayedBreakpoint.py
@@ -1,0 +1,41 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+import os
+
+
+@skipIfWindows
+class TestDelayedBreakpoint(TestBase):
+    def test(self):
+        self.build()
+        logfile = os.path.join(self.getBuildDir(), "log.txt")
+        self.runCmd(f"log enable -f {logfile} gdb-remote packets")
+
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "main", lldb.SBFileSpec("main.c")
+        )
+
+        self.runCmd(f"proc plugin packet send BEFORE_BPS", check=False)
+
+        breakpoint = target.BreakpointCreateByLocation("main.c", 1)
+        self.assertGreater(breakpoint.GetNumResolvedLocations(), 0)
+
+        self.runCmd(f"proc plugin packet send AFTER_BPS", check=False)
+
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.runCmd(f"log disable all")
+
+        self.runCmd(f"proc plugin packet send AFTER_CONTINUE", check=False)
+
+        self.assertTrue(os.path.exists(logfile))
+        log_text = open(logfile).read()
+
+        log_before_continue = log_text.split("BEFORE_BPS", 1)[-1].split("AFTER_BPS", 1)[
+            0
+        ]
+        self.assertNotIn("send packet: $Z", log_before_continue)
+        self.assertNotIn("send packet: $z", log_before_continue)
+
+        log_after = log_text.split("AFTER_BPS", 1)[-1].split("AFTER_CONTINUE", 1)[0]
+        self.assertIn("send packet: $Z", log_after)

--- a/lldb/test/API/functionalities/breakpoint/delayed_breakpoints/main.c
+++ b/lldb/test/API/functionalities/breakpoint/delayed_breakpoints/main.c
@@ -1,0 +1,7 @@
+int break_on_me() {
+  int i = 10; // breakhere
+  i++;
+  return i; // secondbreak
+}
+
+int main() { return break_on_me(); }


### PR DESCRIPTION
This patch changes the Process class so that it delays *physically* enabling/disabling breakpoints until the process is about to resume/detach/be destroyed, potentially reducing the packets transmitted by batching all breakpoints together.

Most classes only need to know whether a breakpoint is "logically" enabled, as opposed to "physically" enabled (i.e. the remote server has actually enabled the breakpoint). However, lower level classes like derived Process classes, or StopInfo may actually need to know whether the breakpoint was physically enabled. As such, this commit also adds a "IsPhysicallyEnabled" API.

The following PRs are related to the MultiBreakpoint feature:

* https://github.com/llvm/llvm-project/pull/192910
* https://github.com/llvm/llvm-project/pull/192914
* https://github.com/llvm/llvm-project/pull/192915
* https://github.com/llvm/llvm-project/pull/192919
* https://github.com/llvm/llvm-project/pull/192962
* https://github.com/llvm/llvm-project/pull/192964
* https://github.com/llvm/llvm-project/pull/192971
* https://github.com/llvm/llvm-project/pull/192988