### PR TITLE
Revert "Invalidate tests using "touch -a" on Darwin (#192521)"

### DIFF
--- a/clang/test/ClangScanDeps/prune-scanning-modules.m
+++ b/clang/test/ClangScanDeps/prune-scanning-modules.m
@@ -1,5 +1,5 @@
 // NetBSD: noatime mounts currently inhibit 'touch -a' updates
-// UNSUPPORTED: system-netbsd, system-darwin
+// UNSUPPORTED: system-netbsd
 
 // Test the automatic pruning of module cache entries.
 

--- a/llvm/test/tools/llvm-objcopy/ELF/strip-preserve-atime.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/strip-preserve-atime.test
@@ -3,7 +3,7 @@
 # Windows: the last access time is disabled by default in the OS
 # This test is also known to fail on Mac (and possibly elsewhere) when Crowdstrike is installed;
 # please make use of the LIT_XFAIL environment variable on such machines.
-# UNSUPPORTED: system-netbsd, system-windows, system-darwin
+# UNSUPPORTED: system-netbsd, system-windows
 
 # Preserve dates when stripping to an output file.
 # RUN: yaml2obj %s -o %t.1.o


### PR DESCRIPTION
This reverts commit 981da65faca247557efa37f8bc55b6dc36e9b8bd.