### PR TITLE
[mlir][spirv] Add SPIRV_FetchOpInterface to SPIRV_ImageFetchOp

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVImageOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVImageOps.td
@@ -592,7 +592,8 @@ def SPIRV_ImageSampleProjDrefImplicitLodOp : SPIRV_Op<"ImageSampleProjDrefImplic
 def SPIRV_ImageFetchOp : SPIRV_Op<"ImageFetch",
     [SPIRV_DimIsNot<"image", ["Cube"]>,
      SPIRV_SampledOperandIs<"image", ["NeedSampler"]>,
-     SPIRV_NoneOrElementMatchImage<"result", "image">]> {
+     SPIRV_NoneOrElementMatchImage<"result", "image">,
+     DeclareOpInterfaceMethods<SPIRV_FetchOpInterface>]> {
   let summary = "Fetch a single texel from an image whose Sampled operand is 1. ";
 
   let description = [{

--- a/mlir/test/Dialect/SPIRV/IR/image-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/image-ops.mlir
@@ -405,7 +405,17 @@ func.func @lod_with_rect(%arg0 : !spirv.sampled_image<!spirv.image<f32, Rect, No
 
 // TODO: We cannot currently test Lod with MS != 0 as all implemented explicit operations already check for that.
 
-// TODO: Add Lod tests for fetch operations once available.
+// -----
+
+// Lod is valid for spirv.ImageFetch (fetch instruction).
+func.func @lod_with_image_fetch(%arg0: !spirv.image<f32, Dim2D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>,
+                                %arg1: vector<2xsi32>, %arg2: si32) -> () {
+  // CHECK: {{%.*}} = spirv.ImageFetch {{%.*}}, {{%.*}} ["Lod"], {{%.*}} : !spirv.image<f32, Dim2D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>, vector<2xsi32>, si32 -> vector<4xf32>
+  %0 = spirv.ImageFetch %arg0, %arg1 ["Lod"], %arg2 :
+      !spirv.image<f32, Dim2D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>,
+      vector<2xsi32>, si32 -> vector<4xf32>
+  spirv.Return
+}
 
 // -----
 


### PR DESCRIPTION
SPIRV_ImageFetchOp was missing the SPIRV_FetchOpInterface interface. Without it, the Lod image operand validation in ImageOps.cpp would reject Lod on spirv.ImageFetch because line 77 checks `(!isa<spirv::ExplicitLodOpInterface>(imageOp) &&
!isa<spirv::FetchOpInterface>(imageOp))`. The fix adds DeclareOpInterfaceMethods<SPIRV_FetchOpInterface> to the op's trait list.