### PR TITLE
[GlobaISel] Protect against Variable 'NumBucketedMatchers' set but not used Error/Warning.

### DIFF
--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -694,10 +694,12 @@ bool SwitchMatcher::addMatcher(Matcher &Candidate) {
 
 void SwitchMatcher::finalize() {
   assert(Condition == nullptr && "Already finalized");
-  [[maybe_unused]] unsigned NumBucketedMatchers = 0;
+#ifndef NDEBUG
+  unsigned NumBucketedMatchers = 0;
   for (const auto &Entry : Buckets)
     NumBucketedMatchers += Entry.second.Matchers.size();
   assert(NumBucketedMatchers == Matchers.size() && "Broken SwitchMatcher");
+#endif
   if (empty())
     return;
 
@@ -748,10 +750,12 @@ void SwitchMatcher::emitPredicateSpecificOpcodes(const PredicateMatcher &P,
 }
 
 void SwitchMatcher::emit(MatchTable &Table) {
-  [[maybe_unused]] unsigned NumBucketedMatchers = 0;
+#ifndef NDEBUG
+  unsigned NumBucketedMatchers = 0;
   for (const auto &Entry : Buckets)
     NumBucketedMatchers += Entry.second.Matchers.size();
   assert(NumBucketedMatchers == Matchers.size() && "Broken SwitchMatcher");
+#endif
   if (empty())
     return;
   assert(Condition != nullptr &&


### PR DESCRIPTION
Fixes the build issue reported on #177158