### PR TITLE
[clang][analyzer] Add support for detecting uninitialized dynamically-allocated objects

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
@@ -472,14 +472,14 @@ getConstructedRegion(const CXXConstructorDecl *CtorDecl,
     return TVR->getValueType()->getAsCXXRecordDecl() ? TVR : nullptr;
   }
 
-  QualType DynType = CtorDecl->getThisType()->getPointeeType();
-  if (!DynType->getAsCXXRecordDecl())
+  QualType ThisPointeeTy = CtorDecl->getThisType()->getPointeeType();
+  if (!ThisPointeeTy->getAsCXXRecordDecl())
     return nullptr;
 
   auto &MemMgr = Context.getState()->getStateManager().getRegionManager();
   auto &SVB = Context.getSValBuilder();
 
-  const auto *ElemR = MemMgr.getElementRegion(DynType, SVB.makeZeroArrayIndex(),
+  const auto *ElemR = MemMgr.getElementRegion(ThisPointeeTy, SVB.makeZeroArrayIndex(),
                                               SR, Context.getASTContext());
 
   return ElemR;

--- a/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
@@ -451,26 +451,44 @@ static void printTail(llvm::raw_ostream &Out,
 //                           Utility functions.
 //===----------------------------------------------------------------------===//
 
+static const SubRegion *
+  getConstructedSubRegion(const CXXConstructorDecl *CtorDecl,
+                       CheckerContext &Context) {
+  Loc ThisLoc =
+      Context.getSValBuilder().getCXXThis(CtorDecl, Context.getStackFrame());
+  SVal ObjectV = Context.getState()->getSVal(ThisLoc);
+  return ObjectV.getAsRegion()->getAs<SubRegion>();
+}
+
 static const TypedValueRegion *
 getConstructedRegion(const CXXConstructorDecl *CtorDecl,
                      CheckerContext &Context) {
 
-  Loc ThisLoc =
-      Context.getSValBuilder().getCXXThis(CtorDecl, Context.getStackFrame());
-
-  SVal ObjectV = Context.getState()->getSVal(ThisLoc);
-
-  auto *R = ObjectV.getAsRegion()->getAs<TypedValueRegion>();
-  if (R && !R->getValueType()->getAsCXXRecordDecl())
+  const SubRegion *SR = getConstructedSubRegion(CtorDecl, Context);
+  if (!SR)
     return nullptr;
 
-  return R;
+  if (const auto *TVR = SR->getAs<TypedValueRegion>()) {
+    return TVR->getValueType()->getAsCXXRecordDecl() ? TVR : nullptr;
+  }
+
+  QualType DynType = CtorDecl->getThisType()->getPointeeType();
+  if (!DynType->getAsCXXRecordDecl())
+    return nullptr;
+
+  auto &MemMgr = Context.getState()->getStateManager().getRegionManager();
+  auto &SVB = Context.getSValBuilder();
+
+  const auto *ElemR = MemMgr.getElementRegion(
+      DynType, SVB.makeZeroArrayIndex(), SR, Context.getASTContext());
+
+  return ElemR;
 }
 
 static bool willObjectBeAnalyzedLater(const CXXConstructorDecl *Ctor,
                                       CheckerContext &Context) {
 
-  const TypedValueRegion *CurrRegion = getConstructedRegion(Ctor, Context);
+  const SubRegion *CurrRegion = getConstructedSubRegion(Ctor, Context);
   if (!CurrRegion)
     return false;
 
@@ -482,8 +500,7 @@ static bool willObjectBeAnalyzedLater(const CXXConstructorDecl *Ctor,
     if (!OtherCtor)
       continue;
 
-    const TypedValueRegion *OtherRegion =
-        getConstructedRegion(OtherCtor, Context);
+    const SubRegion *OtherRegion = getConstructedSubRegion(OtherCtor, Context);
     if (!OtherRegion)
       continue;
 

--- a/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
@@ -479,8 +479,8 @@ getConstructedRegion(const CXXConstructorDecl *CtorDecl,
   auto &MemMgr = Context.getState()->getStateManager().getRegionManager();
   auto &SVB = Context.getSValBuilder();
 
-  const auto *ElemR = MemMgr.getElementRegion(ThisPointeeTy, SVB.makeZeroArrayIndex(),
-                                              SR, Context.getASTContext());
+  const auto *ElemR = MemMgr.getElementRegion(
+      ThisPointeeTy, SVB.makeZeroArrayIndex(), SR, Context.getASTContext());
 
   return ElemR;
 }

--- a/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
@@ -452,8 +452,8 @@ static void printTail(llvm::raw_ostream &Out,
 //===----------------------------------------------------------------------===//
 
 static const SubRegion *
-  getConstructedSubRegion(const CXXConstructorDecl *CtorDecl,
-                       CheckerContext &Context) {
+getConstructedSubRegion(const CXXConstructorDecl *CtorDecl,
+                        CheckerContext &Context) {
   Loc ThisLoc =
       Context.getSValBuilder().getCXXThis(CtorDecl, Context.getStackFrame());
   SVal ObjectV = Context.getState()->getSVal(ThisLoc);
@@ -479,8 +479,8 @@ getConstructedRegion(const CXXConstructorDecl *CtorDecl,
   auto &MemMgr = Context.getState()->getStateManager().getRegionManager();
   auto &SVB = Context.getSValBuilder();
 
-  const auto *ElemR = MemMgr.getElementRegion(
-      DynType, SVB.makeZeroArrayIndex(), SR, Context.getASTContext());
+  const auto *ElemR = MemMgr.getElementRegion(DynType, SVB.makeZeroArrayIndex(),
+                                              SR, Context.getASTContext());
 
   return ElemR;
 }

--- a/clang/test/Analysis/cxx-uninitialized-object-inheritance.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object-inheritance.cpp
@@ -32,10 +32,11 @@ public:
 
 void fNonPolymorphicInheritanceTest1() {
   NonPolymorphicInheritanceTest1();
+  new NonPolymorphicInheritanceTest1();
 }
 
 class NonPolymorphicBaseClass2 {
-  int x; // expected-note{{uninitialized field 'this->NonPolymorphicBaseClass2::x'}}
+  int x; // expected-note{{uninitialized field 'this->NonPolymorphicBaseClass2::x'}} expected-note{{uninitialized field 'this->NonPolymorphicBaseClass2::x'}}
 protected:
   int y;
 
@@ -50,19 +51,20 @@ class NonPolymorphicInheritanceTest2 : public NonPolymorphicBaseClass2 {
 public:
   NonPolymorphicInheritanceTest2() {
     y = 5;
-    z = 6; // expected-warning{{1 uninitialized field}}
+    z = 6; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fNonPolymorphicInheritanceTest2() {
   NonPolymorphicInheritanceTest2();
+  new NonPolymorphicInheritanceTest2();
 }
 
 class NonPolymorphicBaseClass3 {
   int x;
 
 protected:
-  int y; // expected-note{{uninitialized field 'this->NonPolymorphicBaseClass3::y'}}
+  int y; // expected-note{{uninitialized field 'this->NonPolymorphicBaseClass3::y'}} expected-note{{uninitialized field 'this->NonPolymorphicBaseClass3::y'}}
 public:
   NonPolymorphicBaseClass3() = default;
   NonPolymorphicBaseClass3(int) : x(7) {}
@@ -74,12 +76,13 @@ class NonPolymorphicInheritanceTest3 : public NonPolymorphicBaseClass3 {
 public:
   NonPolymorphicInheritanceTest3()
       : NonPolymorphicBaseClass3(int{}) {
-    z = 8; // expected-warning{{1 uninitialized field}}
+    z = 8; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fNonPolymorphicInheritanceTest3() {
   NonPolymorphicInheritanceTest3();
+  new NonPolymorphicInheritanceTest3();
 }
 
 class NonPolymorphicBaseClass4 {
@@ -94,17 +97,18 @@ public:
 };
 
 class NonPolymorphicInheritanceTest4 : public NonPolymorphicBaseClass4 {
-  int z; // expected-note{{uninitialized field 'this->z'}}
+  int z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
 
 public:
   NonPolymorphicInheritanceTest4()
       : NonPolymorphicBaseClass4(int{}) {
-    y = 10; // expected-warning{{1 uninitialized field}}
+    y = 10; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fNonPolymorphicInheritanceTest4() {
   NonPolymorphicInheritanceTest4();
+  new NonPolymorphicInheritanceTest4();
 }
 
 //===----------------------------------------------------------------------===//
@@ -137,10 +141,11 @@ public:
 
 void fPolymorphicInheritanceTest1() {
   PolymorphicInheritanceTest1();
+  new PolymorphicInheritanceTest1();
 }
 
 class PolymorphicRight1 {
-  int x; // expected-note{{uninitialized field 'this->PolymorphicRight1::x'}}
+  int x; // expected-note{{uninitialized field 'this->PolymorphicRight1::x'}} expected-note{{uninitialized field 'this->PolymorphicRight1::x'}}
 protected:
   int y;
 
@@ -156,19 +161,20 @@ class PolymorphicInheritanceTest2 : public PolymorphicRight1 {
 public:
   PolymorphicInheritanceTest2() {
     y = 15;
-    z = 16; // expected-warning{{1 uninitialized field}}
+    z = 16; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fPolymorphicInheritanceTest2() {
   PolymorphicInheritanceTest2();
+  new PolymorphicInheritanceTest2();
 }
 
 class PolymorphicBaseClass3 {
   int x;
 
 protected:
-  int y; // expected-note{{uninitialized field 'this->PolymorphicBaseClass3::y'}}
+  int y; // expected-note{{uninitialized field 'this->PolymorphicBaseClass3::y'}} expected-note{{uninitialized field 'this->PolymorphicBaseClass3::y'}}
 public:
   virtual ~PolymorphicBaseClass3() = default;
   PolymorphicBaseClass3() = default;
@@ -181,12 +187,13 @@ class PolymorphicInheritanceTest3 : public PolymorphicBaseClass3 {
 public:
   PolymorphicInheritanceTest3()
       : PolymorphicBaseClass3(int{}) {
-    z = 18; // expected-warning{{1 uninitialized field}}
+    z = 18; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fPolymorphicInheritanceTest3() {
   PolymorphicInheritanceTest3();
+  new PolymorphicInheritanceTest3();
 }
 
 class PolymorphicBaseClass4 {
@@ -202,17 +209,18 @@ public:
 };
 
 class PolymorphicInheritanceTest4 : public PolymorphicBaseClass4 {
-  int z; // expected-note{{uninitialized field 'this->z'}}
+  int z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
 
 public:
   PolymorphicInheritanceTest4()
       : PolymorphicBaseClass4(int{}) {
-    y = 20; // expected-warning{{1 uninitialized field}}
+    y = 20; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fPolymorphicInheritanceTest4() {
   PolymorphicInheritanceTest4();
+  new PolymorphicInheritanceTest4();
 }
 
 //===----------------------------------------------------------------------===//
@@ -245,10 +253,11 @@ public:
 
 void fVirtualInheritanceTest1() {
   VirtualInheritanceTest1();
+  new VirtualInheritanceTest1();
 }
 
 class VirtualPolymorphicRight1 {
-  int x; // expected-note{{uninitialized field 'this->VirtualPolymorphicRight1::x'}}
+  int x; // expected-note{{uninitialized field 'this->VirtualPolymorphicRight1::x'}} expected-note{{uninitialized field 'this->VirtualPolymorphicRight1::x'}}
 protected:
   int y;
 
@@ -264,19 +273,20 @@ class VirtualInheritanceTest2 : virtual public VirtualPolymorphicRight1 {
 public:
   VirtualInheritanceTest2() {
     y = 25;
-    z = 26; // expected-warning{{1 uninitialized field}}
+    z = 26; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fVirtualInheritanceTest2() {
   VirtualInheritanceTest2();
+  new VirtualInheritanceTest2();
 }
 
 class VirtualPolymorphicBaseClass3 {
   int x;
 
 protected:
-  int y; // expected-note{{uninitialized field 'this->VirtualPolymorphicBaseClass3::y'}}
+  int y; // expected-note{{uninitialized field 'this->VirtualPolymorphicBaseClass3::y'}} expected-note{{uninitialized field 'this->VirtualPolymorphicBaseClass3::y'}}
 public:
   virtual ~VirtualPolymorphicBaseClass3() = default;
   VirtualPolymorphicBaseClass3() = default;
@@ -289,12 +299,13 @@ class VirtualInheritanceTest3 : virtual public VirtualPolymorphicBaseClass3 {
 public:
   VirtualInheritanceTest3()
       : VirtualPolymorphicBaseClass3(int{}) {
-    z = 28; // expected-warning{{1 uninitialized field}}
+    z = 28; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fVirtualInheritanceTest3() {
   VirtualInheritanceTest3();
+  new VirtualInheritanceTest3();
 }
 
 //===----------------------------------------------------------------------===//
@@ -348,8 +359,11 @@ public:
 
 void fMultipleInheritanceTest1() {
   MultipleInheritanceTest1();
+  new MultipleInheritanceTest1();
   MultipleInheritanceTest1(int());
+  new MultipleInheritanceTest1(int());
   MultipleInheritanceTest1(int(), int());
+  new MultipleInheritanceTest1(int(), int());
 }
 
 struct Left2 {
@@ -358,7 +372,7 @@ struct Left2 {
   Left2(int) : x(36) {}
 };
 struct Right2 {
-  int y; // expected-note{{uninitialized field 'this->Right2::y'}}
+  int y; // expected-note{{uninitialized field 'this->Right2::y'}} expected-note{{uninitialized field 'this->Right2::y'}}
   Right2() = default;
   Right2(int) : y(37) {}
 };
@@ -369,16 +383,17 @@ class MultipleInheritanceTest2 : public Left2, public Right2 {
 public:
   MultipleInheritanceTest2()
       : Left2(int{}) {
-    z = 38; // expected-warning{{1 uninitialized field}}
+    z = 38; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fMultipleInheritanceTest2() {
   MultipleInheritanceTest2();
+  new MultipleInheritanceTest2();
 }
 
 struct Left3 {
-  int x; // expected-note{{uninitialized field 'this->Left3::x'}}
+  int x; // expected-note{{uninitialized field 'this->Left3::x'}} expected-note{{uninitialized field 'this->Left3::x'}}
   Left3() = default;
   Left3(int) : x(39) {}
 };
@@ -394,12 +409,13 @@ class MultipleInheritanceTest3 : public Left3, public Right3 {
 public:
   MultipleInheritanceTest3()
       : Right3(char{}) {
-    z = 41; // expected-warning{{1 uninitialized field}}
+    z = 41; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fMultipleInheritanceTest3() {
   MultipleInheritanceTest3();
+  new MultipleInheritanceTest3();
 }
 
 struct Left4 {
@@ -414,17 +430,18 @@ struct Right4 {
 };
 
 class MultipleInheritanceTest4 : public Left4, public Right4 {
-  int z; // expected-note{{uninitialized field 'this->z'}}
+  int z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
 
 public:
   MultipleInheritanceTest4()
       : Left4(int{}),
-        Right4(char{}) { // expected-warning{{1 uninitialized field}}
+        Right4(char{}) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fMultipleInheritanceTest4() {
   MultipleInheritanceTest4();
+  new MultipleInheritanceTest4();
 }
 
 struct Left5 {
@@ -433,22 +450,23 @@ struct Left5 {
   Left5(int) : x(44) {}
 };
 struct Right5 {
-  int y; // expected-note{{uninitialized field 'this->Right5::y'}}
+  int y; // expected-note{{uninitialized field 'this->Right5::y'}} expected-note{{uninitialized field 'this->Right5::y'}}
   Right5() = default;
   Right5(int) : y(45) {}
 };
 
 class MultipleInheritanceTest5 : public Left5, public Right5 {
-  int z; // expected-note{{uninitialized field 'this->z'}}
+  int z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
 
 public:
-  MultipleInheritanceTest5() // expected-warning{{2 uninitialized fields}}
+  MultipleInheritanceTest5() // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
       : Left5(int{}) {
   }
 };
 
 void fMultipleInheritanceTest5() {
   MultipleInheritanceTest5();
+  new MultipleInheritanceTest5();
 }
 
 //===----------------------------------------------------------------------===//
@@ -509,12 +527,15 @@ public:
 
 void fNonVirtualDiamondInheritanceTest1() {
   NonVirtualDiamondInheritanceTest1();
+  new NonVirtualDiamondInheritanceTest1();
   NonVirtualDiamondInheritanceTest1(int());
+  new NonVirtualDiamondInheritanceTest1(int());
   NonVirtualDiamondInheritanceTest1(int(), int());
+  new NonVirtualDiamondInheritanceTest1(int(), int());
 }
 
 struct NonVirtualBase2 {
-  int x; // expected-note{{uninitialized field 'this->NonVirtualBase2::x'}}
+  int x; // expected-note{{uninitialized field 'this->NonVirtualBase2::x'}} expected-note{{uninitialized field 'this->NonVirtualBase2::x'}}
   NonVirtualBase2() = default;
   NonVirtualBase2(int) : x(52) {}
 };
@@ -533,16 +554,17 @@ class NonVirtualDiamondInheritanceTest2 : public First2, public Second2 {
 public:
   NonVirtualDiamondInheritanceTest2()
       : First2(int{}) {
-    z = 53; // expected-warning{{1 uninitialized field}}
+    z = 53; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fNonVirtualDiamondInheritanceTest2() {
   NonVirtualDiamondInheritanceTest2();
+  new NonVirtualDiamondInheritanceTest2();
 }
 
 struct NonVirtualBase3 {
-  int x; // expected-note{{uninitialized field 'this->NonVirtualBase3::x'}}
+  int x; // expected-note{{uninitialized field 'this->NonVirtualBase3::x'}} expected-note{{uninitialized field 'this->NonVirtualBase3::x'}}
   NonVirtualBase3() = default;
   NonVirtualBase3(int) : x(54) {}
 };
@@ -561,17 +583,18 @@ class NonVirtualDiamondInheritanceTest3 : public First3, public Second3 {
 public:
   NonVirtualDiamondInheritanceTest3()
       : Second3(int{}) {
-    z = 55; // expected-warning{{1 uninitialized field}}
+    z = 55; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fNonVirtualDiamondInheritanceTest3() {
   NonVirtualDiamondInheritanceTest3();
+  new NonVirtualDiamondInheritanceTest3();
 }
 
 struct NonVirtualBase4 {
-  int x; // expected-note{{uninitialized field 'this->NonVirtualBase4::x'}}
-  // expected-note@-1{{uninitialized field 'this->NonVirtualBase4::x'}}
+  int x; // expected-note{{uninitialized field 'this->NonVirtualBase4::x'}} expected-note{{uninitialized field 'this->NonVirtualBase4::x'}}
+  // expected-note@-1{{uninitialized field 'this->NonVirtualBase4::x'}} expected-note@-1{{uninitialized field 'this->NonVirtualBase4::x'}}
   NonVirtualBase4() = default;
   NonVirtualBase4(int) : x(56) {}
 };
@@ -589,12 +612,13 @@ class NonVirtualDiamondInheritanceTest4 : public First4, public Second4 {
 
 public:
   NonVirtualDiamondInheritanceTest4() {
-    z = 57; // expected-warning{{2 uninitialized fields}}
+    z = 57; // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
   }
 };
 
 void fNonVirtualDiamondInheritanceTest4() {
   NonVirtualDiamondInheritanceTest4();
+  new NonVirtualDiamondInheritanceTest4();
 }
 
 struct NonVirtualBase5 {
@@ -612,21 +636,22 @@ struct Second5 : public NonVirtualBase5 {
 };
 
 class NonVirtualDiamondInheritanceTest5 : public First5, public Second5 {
-  int z; // expected-note{{uninitialized field 'this->z'}}
+  int z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
 
 public:
   NonVirtualDiamondInheritanceTest5()
       : First5(int{}),
-        Second5(int{}) { // expected-warning{{1 uninitialized field}}
+        Second5(int{}) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fNonVirtualDiamondInheritanceTest5() {
   NonVirtualDiamondInheritanceTest5();
+  new NonVirtualDiamondInheritanceTest5();
 }
 
 struct NonVirtualBase6 {
-  int x; // expected-note{{uninitialized field 'this->NonVirtualBase6::x'}}
+  int x; // expected-note{{uninitialized field 'this->NonVirtualBase6::x'}} expected-note{{uninitialized field 'this->NonVirtualBase6::x'}}
   NonVirtualBase6() = default;
   NonVirtualBase6(int) : x(59) {}
 };
@@ -640,10 +665,10 @@ struct Second6 : public NonVirtualBase6 {
 };
 
 class NonVirtualDiamondInheritanceTest6 : public First6, public Second6 {
-  int z; // expected-note{{uninitialized field 'this->z'}}
+  int z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
 
 public:
-  NonVirtualDiamondInheritanceTest6() // expected-warning{{2 uninitialized fields}}
+  NonVirtualDiamondInheritanceTest6() // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
       : First6(int{}) {
     // 'z' and 'Second::x' uninitialized
   }
@@ -651,6 +676,7 @@ public:
 
 void fNonVirtualDiamondInheritanceTest6() {
   NonVirtualDiamondInheritanceTest6();
+  new NonVirtualDiamondInheritanceTest6();
 }
 
 //===----------------------------------------------------------------------===//
@@ -707,12 +733,15 @@ public:
 
 void fVirtualDiamondInheritanceTest1() {
   VirtualDiamondInheritanceTest1();
+  new VirtualDiamondInheritanceTest1();
   VirtualDiamondInheritanceTest1(int());
+  new VirtualDiamondInheritanceTest1(int());
   VirtualDiamondInheritanceTest1(int(), int());
+  new VirtualDiamondInheritanceTest1(int(), int());
 }
 
 struct VirtualBase2 {
-  int x; // expected-note{{uninitialized field 'this->VirtualBase2::x'}}
+  int x; // expected-note{{uninitialized field 'this->VirtualBase2::x'}} expected-note{{uninitialized field 'this->VirtualBase2::x'}}
   VirtualBase2() = default;
   VirtualBase2(int) : x(63) {}
 };
@@ -730,7 +759,7 @@ struct VirtualSecond2 : virtual public VirtualBase2 {
 class VirtualDiamondInheritanceTest2 : public VirtualFirst2, public VirtualSecond2 {
 
 public:
-  VirtualDiamondInheritanceTest2() // expected-warning{{1 uninitialized field}}
+  VirtualDiamondInheritanceTest2() // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
       : VirtualFirst2(int{}) {
     // From the N4659 C++ Standard Working Draft:
     //
@@ -748,10 +777,11 @@ public:
 
 void fVirtualDiamondInheritanceTest2() {
   VirtualDiamondInheritanceTest2();
+  new VirtualDiamondInheritanceTest2();
 }
 
 struct VirtualBase3 {
-  int x; // expected-note{{uninitialized field 'this->VirtualBase3::x'}}
+  int x; // expected-note{{uninitialized field 'this->VirtualBase3::x'}} expected-note{{uninitialized field 'this->VirtualBase3::x'}}
   VirtualBase3() = default;
   VirtualBase3(int) : x(66) {}
 };
@@ -769,12 +799,13 @@ struct VirtualSecond3 : virtual public VirtualBase3 {
 class VirtualDiamondInheritanceTest3 : public VirtualFirst3, public VirtualSecond3 {
 
 public:
-  VirtualDiamondInheritanceTest3() // expected-warning{{1 uninitialized field}}
+  VirtualDiamondInheritanceTest3() // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
       : VirtualFirst3(int{}) {}
 };
 
 void fVirtualDiamondInheritanceTest3() {
   VirtualDiamondInheritanceTest3();
+  new VirtualDiamondInheritanceTest3();
 }
 
 //===----------------------------------------------------------------------===//
@@ -783,38 +814,42 @@ void fVirtualDiamondInheritanceTest3() {
 
 struct DynTBase1 {};
 struct DynTDerived1 : DynTBase1 {
-  int y; // expected-note{{uninitialized field 'static_cast<DynTDerived1 *>(this->bptr)->y'}}
+  int y; // expected-note{{uninitialized field 'static_cast<DynTDerived1 *>(this->bptr)->y'}} expected-note{{uninitialized field 'static_cast<DynTDerived1 *>(this->bptr)->y'}}
 };
 
 struct DynamicTypeTest1 {
   DynTBase1 *bptr;
   int i = 0;
 
-  DynamicTypeTest1(DynTBase1 *bptr) : bptr(bptr) {} // expected-warning{{1 uninitialized field}}
+  DynamicTypeTest1(DynTBase1 *bptr) : bptr(bptr) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fDynamicTypeTest1() {
   DynTDerived1 d;
   DynamicTypeTest1 t(&d);
+  DynTDerived1 dp;
+  new DynamicTypeTest1(&dp);
 };
 
 struct DynTBase2 {
-  int x; // expected-note{{uninitialized field 'static_cast<DynTDerived2 *>(this->bptr)->DynTBase2::x'}}
+  int x; // expected-note{{uninitialized field 'static_cast<DynTDerived2 *>(this->bptr)->DynTBase2::x'}} expected-note{{uninitialized field 'static_cast<DynTDerived2 *>(this->bptr)->DynTBase2::x'}}
 };
 struct DynTDerived2 : DynTBase2 {
-  int y; // expected-note{{uninitialized field 'static_cast<DynTDerived2 *>(this->bptr)->y'}}
+  int y; // expected-note{{uninitialized field 'static_cast<DynTDerived2 *>(this->bptr)->y'}} expected-note{{uninitialized field 'static_cast<DynTDerived2 *>(this->bptr)->y'}}
 };
 
 struct DynamicTypeTest2 {
   DynTBase2 *bptr;
   int i = 0;
 
-  DynamicTypeTest2(DynTBase2 *bptr) : bptr(bptr) {} // expected-warning{{2 uninitialized fields}}
+  DynamicTypeTest2(DynTBase2 *bptr) : bptr(bptr) {} // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
 };
 
 void fDynamicTypeTest2() {
   DynTDerived2 d;
   DynamicTypeTest2 t(&d);
+  DynTDerived2 dp;
+  new DynamicTypeTest2(&dp);
 }
 
 struct SymbolicSuperRegionBase {
@@ -830,4 +865,5 @@ SymbolicSuperRegionDerived *getSymbolicRegion();
 
 void fSymbolicSuperRegionTest() {
   SymbolicSuperRegionDerived test(getSymbolicRegion());
+  new SymbolicSuperRegionDerived(getSymbolicRegion());
 }

--- a/clang/test/Analysis/cxx-uninitialized-object-inheritance.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object-inheritance.cpp
@@ -2,6 +2,16 @@
 // RUN: -analyzer-config optin.cplusplus.UninitializedObject:Pedantic=true -DPEDANTIC \
 // RUN: -analyzer-config optin.cplusplus.UninitializedObject:CheckPointeeInitialization=true \
 // RUN: -std=c++11 -verify  %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,optin.cplusplus.UninitializedObject \
+// RUN: -analyzer-config optin.cplusplus.UninitializedObject:Pedantic=true -DPEDANTIC \
+// RUN: -analyzer-config optin.cplusplus.UninitializedObject:CheckPointeeInitialization=true \
+// RUN: -std=c++11 -verify  %s -DHEAP_ALLOCATION
+
+#ifdef HEAP_ALLOCATION
+#define INIT(CLS, ARGS) new CLS ARGS
+#else
+#define INIT(CLS, ARGS) (void) CLS ARGS
+#endif
 
 //===----------------------------------------------------------------------===//
 // Non-polymorphic inheritance tests
@@ -31,12 +41,11 @@ public:
 };
 
 void fNonPolymorphicInheritanceTest1() {
-  NonPolymorphicInheritanceTest1();
-  new NonPolymorphicInheritanceTest1();
+  INIT(NonPolymorphicInheritanceTest1, ());
 }
 
 class NonPolymorphicBaseClass2 {
-  int x; // expected-note{{uninitialized field 'this->NonPolymorphicBaseClass2::x'}} expected-note{{uninitialized field 'this->NonPolymorphicBaseClass2::x'}}
+  int x; // expected-note{{uninitialized field 'this->NonPolymorphicBaseClass2::x'}}
 protected:
   int y;
 
@@ -51,20 +60,19 @@ class NonPolymorphicInheritanceTest2 : public NonPolymorphicBaseClass2 {
 public:
   NonPolymorphicInheritanceTest2() {
     y = 5;
-    z = 6; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    z = 6; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fNonPolymorphicInheritanceTest2() {
-  NonPolymorphicInheritanceTest2();
-  new NonPolymorphicInheritanceTest2();
+  INIT(NonPolymorphicInheritanceTest2, ());
 }
 
 class NonPolymorphicBaseClass3 {
   int x;
 
 protected:
-  int y; // expected-note{{uninitialized field 'this->NonPolymorphicBaseClass3::y'}} expected-note{{uninitialized field 'this->NonPolymorphicBaseClass3::y'}}
+  int y; // expected-note{{uninitialized field 'this->NonPolymorphicBaseClass3::y'}}
 public:
   NonPolymorphicBaseClass3() = default;
   NonPolymorphicBaseClass3(int) : x(7) {}
@@ -76,13 +84,12 @@ class NonPolymorphicInheritanceTest3 : public NonPolymorphicBaseClass3 {
 public:
   NonPolymorphicInheritanceTest3()
       : NonPolymorphicBaseClass3(int{}) {
-    z = 8; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    z = 8; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fNonPolymorphicInheritanceTest3() {
-  NonPolymorphicInheritanceTest3();
-  new NonPolymorphicInheritanceTest3();
+  INIT(NonPolymorphicInheritanceTest3, ());
 }
 
 class NonPolymorphicBaseClass4 {
@@ -97,18 +104,17 @@ public:
 };
 
 class NonPolymorphicInheritanceTest4 : public NonPolymorphicBaseClass4 {
-  int z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
+  int z; // expected-note{{uninitialized field 'this->z'}}
 
 public:
   NonPolymorphicInheritanceTest4()
       : NonPolymorphicBaseClass4(int{}) {
-    y = 10; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    y = 10; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fNonPolymorphicInheritanceTest4() {
-  NonPolymorphicInheritanceTest4();
-  new NonPolymorphicInheritanceTest4();
+  INIT(NonPolymorphicInheritanceTest4, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -140,12 +146,11 @@ public:
 };
 
 void fPolymorphicInheritanceTest1() {
-  PolymorphicInheritanceTest1();
-  new PolymorphicInheritanceTest1();
+  INIT(PolymorphicInheritanceTest1, ());
 }
 
 class PolymorphicRight1 {
-  int x; // expected-note{{uninitialized field 'this->PolymorphicRight1::x'}} expected-note{{uninitialized field 'this->PolymorphicRight1::x'}}
+  int x; // expected-note{{uninitialized field 'this->PolymorphicRight1::x'}}
 protected:
   int y;
 
@@ -161,20 +166,19 @@ class PolymorphicInheritanceTest2 : public PolymorphicRight1 {
 public:
   PolymorphicInheritanceTest2() {
     y = 15;
-    z = 16; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    z = 16; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fPolymorphicInheritanceTest2() {
-  PolymorphicInheritanceTest2();
-  new PolymorphicInheritanceTest2();
+  INIT(PolymorphicInheritanceTest2, ());
 }
 
 class PolymorphicBaseClass3 {
   int x;
 
 protected:
-  int y; // expected-note{{uninitialized field 'this->PolymorphicBaseClass3::y'}} expected-note{{uninitialized field 'this->PolymorphicBaseClass3::y'}}
+  int y; // expected-note{{uninitialized field 'this->PolymorphicBaseClass3::y'}}
 public:
   virtual ~PolymorphicBaseClass3() = default;
   PolymorphicBaseClass3() = default;
@@ -187,13 +191,12 @@ class PolymorphicInheritanceTest3 : public PolymorphicBaseClass3 {
 public:
   PolymorphicInheritanceTest3()
       : PolymorphicBaseClass3(int{}) {
-    z = 18; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    z = 18; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fPolymorphicInheritanceTest3() {
-  PolymorphicInheritanceTest3();
-  new PolymorphicInheritanceTest3();
+  INIT(PolymorphicInheritanceTest3, ());
 }
 
 class PolymorphicBaseClass4 {
@@ -209,18 +212,17 @@ public:
 };
 
 class PolymorphicInheritanceTest4 : public PolymorphicBaseClass4 {
-  int z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
+  int z; // expected-note{{uninitialized field 'this->z'}}
 
 public:
   PolymorphicInheritanceTest4()
       : PolymorphicBaseClass4(int{}) {
-    y = 20; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    y = 20; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fPolymorphicInheritanceTest4() {
-  PolymorphicInheritanceTest4();
-  new PolymorphicInheritanceTest4();
+  INIT(PolymorphicInheritanceTest4, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -252,12 +254,11 @@ public:
 };
 
 void fVirtualInheritanceTest1() {
-  VirtualInheritanceTest1();
-  new VirtualInheritanceTest1();
+  INIT(VirtualInheritanceTest1, ());
 }
 
 class VirtualPolymorphicRight1 {
-  int x; // expected-note{{uninitialized field 'this->VirtualPolymorphicRight1::x'}} expected-note{{uninitialized field 'this->VirtualPolymorphicRight1::x'}}
+  int x; // expected-note{{uninitialized field 'this->VirtualPolymorphicRight1::x'}}
 protected:
   int y;
 
@@ -273,20 +274,19 @@ class VirtualInheritanceTest2 : virtual public VirtualPolymorphicRight1 {
 public:
   VirtualInheritanceTest2() {
     y = 25;
-    z = 26; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    z = 26; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fVirtualInheritanceTest2() {
-  VirtualInheritanceTest2();
-  new VirtualInheritanceTest2();
+  INIT(VirtualInheritanceTest2, ());
 }
 
 class VirtualPolymorphicBaseClass3 {
   int x;
 
 protected:
-  int y; // expected-note{{uninitialized field 'this->VirtualPolymorphicBaseClass3::y'}} expected-note{{uninitialized field 'this->VirtualPolymorphicBaseClass3::y'}}
+  int y; // expected-note{{uninitialized field 'this->VirtualPolymorphicBaseClass3::y'}}
 public:
   virtual ~VirtualPolymorphicBaseClass3() = default;
   VirtualPolymorphicBaseClass3() = default;
@@ -299,13 +299,12 @@ class VirtualInheritanceTest3 : virtual public VirtualPolymorphicBaseClass3 {
 public:
   VirtualInheritanceTest3()
       : VirtualPolymorphicBaseClass3(int{}) {
-    z = 28; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    z = 28; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fVirtualInheritanceTest3() {
-  VirtualInheritanceTest3();
-  new VirtualInheritanceTest3();
+  INIT(VirtualInheritanceTest3, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -358,12 +357,9 @@ public:
 };
 
 void fMultipleInheritanceTest1() {
-  MultipleInheritanceTest1();
-  new MultipleInheritanceTest1();
-  MultipleInheritanceTest1(int());
-  new MultipleInheritanceTest1(int());
-  MultipleInheritanceTest1(int(), int());
-  new MultipleInheritanceTest1(int(), int());
+  INIT(MultipleInheritanceTest1, ());
+  INIT(MultipleInheritanceTest1, (int()));
+  INIT(MultipleInheritanceTest1, (int(), int()));
 }
 
 struct Left2 {
@@ -372,7 +368,7 @@ struct Left2 {
   Left2(int) : x(36) {}
 };
 struct Right2 {
-  int y; // expected-note{{uninitialized field 'this->Right2::y'}} expected-note{{uninitialized field 'this->Right2::y'}}
+  int y; // expected-note{{uninitialized field 'this->Right2::y'}}
   Right2() = default;
   Right2(int) : y(37) {}
 };
@@ -383,17 +379,16 @@ class MultipleInheritanceTest2 : public Left2, public Right2 {
 public:
   MultipleInheritanceTest2()
       : Left2(int{}) {
-    z = 38; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    z = 38; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fMultipleInheritanceTest2() {
-  MultipleInheritanceTest2();
-  new MultipleInheritanceTest2();
+  INIT(MultipleInheritanceTest2, ());
 }
 
 struct Left3 {
-  int x; // expected-note{{uninitialized field 'this->Left3::x'}} expected-note{{uninitialized field 'this->Left3::x'}}
+  int x; // expected-note{{uninitialized field 'this->Left3::x'}}
   Left3() = default;
   Left3(int) : x(39) {}
 };
@@ -409,13 +404,12 @@ class MultipleInheritanceTest3 : public Left3, public Right3 {
 public:
   MultipleInheritanceTest3()
       : Right3(char{}) {
-    z = 41; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    z = 41; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fMultipleInheritanceTest3() {
-  MultipleInheritanceTest3();
-  new MultipleInheritanceTest3();
+  INIT(MultipleInheritanceTest3, ());
 }
 
 struct Left4 {
@@ -430,18 +424,17 @@ struct Right4 {
 };
 
 class MultipleInheritanceTest4 : public Left4, public Right4 {
-  int z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
+  int z; // expected-note{{uninitialized field 'this->z'}}
 
 public:
   MultipleInheritanceTest4()
       : Left4(int{}),
-        Right4(char{}) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+        Right4(char{}) { // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fMultipleInheritanceTest4() {
-  MultipleInheritanceTest4();
-  new MultipleInheritanceTest4();
+  INIT(MultipleInheritanceTest4, ());
 }
 
 struct Left5 {
@@ -450,23 +443,22 @@ struct Left5 {
   Left5(int) : x(44) {}
 };
 struct Right5 {
-  int y; // expected-note{{uninitialized field 'this->Right5::y'}} expected-note{{uninitialized field 'this->Right5::y'}}
+  int y; // expected-note{{uninitialized field 'this->Right5::y'}}
   Right5() = default;
   Right5(int) : y(45) {}
 };
 
 class MultipleInheritanceTest5 : public Left5, public Right5 {
-  int z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
+  int z; // expected-note{{uninitialized field 'this->z'}}
 
 public:
-  MultipleInheritanceTest5() // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+  MultipleInheritanceTest5() // expected-warning{{2 uninitialized fields}}
       : Left5(int{}) {
   }
 };
 
 void fMultipleInheritanceTest5() {
-  MultipleInheritanceTest5();
-  new MultipleInheritanceTest5();
+  INIT(MultipleInheritanceTest5, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -526,16 +518,13 @@ public:
 };
 
 void fNonVirtualDiamondInheritanceTest1() {
-  NonVirtualDiamondInheritanceTest1();
-  new NonVirtualDiamondInheritanceTest1();
-  NonVirtualDiamondInheritanceTest1(int());
-  new NonVirtualDiamondInheritanceTest1(int());
-  NonVirtualDiamondInheritanceTest1(int(), int());
-  new NonVirtualDiamondInheritanceTest1(int(), int());
+  INIT(NonVirtualDiamondInheritanceTest1, ());
+  INIT(NonVirtualDiamondInheritanceTest1, (int()));
+  INIT(NonVirtualDiamondInheritanceTest1, (int(), int()));
 }
 
 struct NonVirtualBase2 {
-  int x; // expected-note{{uninitialized field 'this->NonVirtualBase2::x'}} expected-note{{uninitialized field 'this->NonVirtualBase2::x'}}
+  int x; // expected-note{{uninitialized field 'this->NonVirtualBase2::x'}}
   NonVirtualBase2() = default;
   NonVirtualBase2(int) : x(52) {}
 };
@@ -554,17 +543,16 @@ class NonVirtualDiamondInheritanceTest2 : public First2, public Second2 {
 public:
   NonVirtualDiamondInheritanceTest2()
       : First2(int{}) {
-    z = 53; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    z = 53; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fNonVirtualDiamondInheritanceTest2() {
-  NonVirtualDiamondInheritanceTest2();
-  new NonVirtualDiamondInheritanceTest2();
+  INIT(NonVirtualDiamondInheritanceTest2, ());
 }
 
 struct NonVirtualBase3 {
-  int x; // expected-note{{uninitialized field 'this->NonVirtualBase3::x'}} expected-note{{uninitialized field 'this->NonVirtualBase3::x'}}
+  int x; // expected-note{{uninitialized field 'this->NonVirtualBase3::x'}}
   NonVirtualBase3() = default;
   NonVirtualBase3(int) : x(54) {}
 };
@@ -583,18 +571,17 @@ class NonVirtualDiamondInheritanceTest3 : public First3, public Second3 {
 public:
   NonVirtualDiamondInheritanceTest3()
       : Second3(int{}) {
-    z = 55; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    z = 55; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fNonVirtualDiamondInheritanceTest3() {
-  NonVirtualDiamondInheritanceTest3();
-  new NonVirtualDiamondInheritanceTest3();
+  INIT(NonVirtualDiamondInheritanceTest3, ());
 }
 
 struct NonVirtualBase4 {
-  int x; // expected-note{{uninitialized field 'this->NonVirtualBase4::x'}} expected-note{{uninitialized field 'this->NonVirtualBase4::x'}}
-  // expected-note@-1{{uninitialized field 'this->NonVirtualBase4::x'}} expected-note@-1{{uninitialized field 'this->NonVirtualBase4::x'}}
+  int x; // expected-note{{uninitialized field 'this->NonVirtualBase4::x'}}
+  // expected-note@-1{{uninitialized field 'this->NonVirtualBase4::x'}}
   NonVirtualBase4() = default;
   NonVirtualBase4(int) : x(56) {}
 };
@@ -612,13 +599,12 @@ class NonVirtualDiamondInheritanceTest4 : public First4, public Second4 {
 
 public:
   NonVirtualDiamondInheritanceTest4() {
-    z = 57; // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+    z = 57; // expected-warning{{2 uninitialized fields}}
   }
 };
 
 void fNonVirtualDiamondInheritanceTest4() {
-  NonVirtualDiamondInheritanceTest4();
-  new NonVirtualDiamondInheritanceTest4();
+  INIT(NonVirtualDiamondInheritanceTest4, ());
 }
 
 struct NonVirtualBase5 {
@@ -636,22 +622,21 @@ struct Second5 : public NonVirtualBase5 {
 };
 
 class NonVirtualDiamondInheritanceTest5 : public First5, public Second5 {
-  int z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
+  int z; // expected-note{{uninitialized field 'this->z'}}
 
 public:
   NonVirtualDiamondInheritanceTest5()
       : First5(int{}),
-        Second5(int{}) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+        Second5(int{}) { // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fNonVirtualDiamondInheritanceTest5() {
-  NonVirtualDiamondInheritanceTest5();
-  new NonVirtualDiamondInheritanceTest5();
+  INIT(NonVirtualDiamondInheritanceTest5, ());
 }
 
 struct NonVirtualBase6 {
-  int x; // expected-note{{uninitialized field 'this->NonVirtualBase6::x'}} expected-note{{uninitialized field 'this->NonVirtualBase6::x'}}
+  int x; // expected-note{{uninitialized field 'this->NonVirtualBase6::x'}}
   NonVirtualBase6() = default;
   NonVirtualBase6(int) : x(59) {}
 };
@@ -665,18 +650,17 @@ struct Second6 : public NonVirtualBase6 {
 };
 
 class NonVirtualDiamondInheritanceTest6 : public First6, public Second6 {
-  int z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
+  int z; // expected-note{{uninitialized field 'this->z'}}
 
 public:
-  NonVirtualDiamondInheritanceTest6() // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+  NonVirtualDiamondInheritanceTest6() // expected-warning{{2 uninitialized fields}}
       : First6(int{}) {
     // 'z' and 'Second::x' uninitialized
   }
 };
 
 void fNonVirtualDiamondInheritanceTest6() {
-  NonVirtualDiamondInheritanceTest6();
-  new NonVirtualDiamondInheritanceTest6();
+  INIT(NonVirtualDiamondInheritanceTest6, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -732,16 +716,13 @@ public:
 };
 
 void fVirtualDiamondInheritanceTest1() {
-  VirtualDiamondInheritanceTest1();
-  new VirtualDiamondInheritanceTest1();
-  VirtualDiamondInheritanceTest1(int());
-  new VirtualDiamondInheritanceTest1(int());
-  VirtualDiamondInheritanceTest1(int(), int());
-  new VirtualDiamondInheritanceTest1(int(), int());
+  INIT(VirtualDiamondInheritanceTest1, ());
+  INIT(VirtualDiamondInheritanceTest1, (int()));
+  INIT(VirtualDiamondInheritanceTest1, (int(), int()));
 }
 
 struct VirtualBase2 {
-  int x; // expected-note{{uninitialized field 'this->VirtualBase2::x'}} expected-note{{uninitialized field 'this->VirtualBase2::x'}}
+  int x; // expected-note{{uninitialized field 'this->VirtualBase2::x'}}
   VirtualBase2() = default;
   VirtualBase2(int) : x(63) {}
 };
@@ -759,7 +740,7 @@ struct VirtualSecond2 : virtual public VirtualBase2 {
 class VirtualDiamondInheritanceTest2 : public VirtualFirst2, public VirtualSecond2 {
 
 public:
-  VirtualDiamondInheritanceTest2() // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  VirtualDiamondInheritanceTest2() // expected-warning{{1 uninitialized field}}
       : VirtualFirst2(int{}) {
     // From the N4659 C++ Standard Working Draft:
     //
@@ -776,12 +757,11 @@ public:
 };
 
 void fVirtualDiamondInheritanceTest2() {
-  VirtualDiamondInheritanceTest2();
-  new VirtualDiamondInheritanceTest2();
+  INIT(VirtualDiamondInheritanceTest2, ());
 }
 
 struct VirtualBase3 {
-  int x; // expected-note{{uninitialized field 'this->VirtualBase3::x'}} expected-note{{uninitialized field 'this->VirtualBase3::x'}}
+  int x; // expected-note{{uninitialized field 'this->VirtualBase3::x'}}
   VirtualBase3() = default;
   VirtualBase3(int) : x(66) {}
 };
@@ -799,13 +779,12 @@ struct VirtualSecond3 : virtual public VirtualBase3 {
 class VirtualDiamondInheritanceTest3 : public VirtualFirst3, public VirtualSecond3 {
 
 public:
-  VirtualDiamondInheritanceTest3() // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  VirtualDiamondInheritanceTest3() // expected-warning{{1 uninitialized field}}
       : VirtualFirst3(int{}) {}
 };
 
 void fVirtualDiamondInheritanceTest3() {
-  VirtualDiamondInheritanceTest3();
-  new VirtualDiamondInheritanceTest3();
+  INIT(VirtualDiamondInheritanceTest3, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -814,42 +793,38 @@ void fVirtualDiamondInheritanceTest3() {
 
 struct DynTBase1 {};
 struct DynTDerived1 : DynTBase1 {
-  int y; // expected-note{{uninitialized field 'static_cast<DynTDerived1 *>(this->bptr)->y'}} expected-note{{uninitialized field 'static_cast<DynTDerived1 *>(this->bptr)->y'}}
+  int y; // expected-note{{uninitialized field 'static_cast<DynTDerived1 *>(this->bptr)->y'}}
 };
 
 struct DynamicTypeTest1 {
   DynTBase1 *bptr;
   int i = 0;
 
-  DynamicTypeTest1(DynTBase1 *bptr) : bptr(bptr) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  DynamicTypeTest1(DynTBase1 *bptr) : bptr(bptr) {} // expected-warning{{1 uninitialized field}}
 };
 
 void fDynamicTypeTest1() {
   DynTDerived1 d;
-  DynamicTypeTest1 t(&d);
-  DynTDerived1 dp;
-  new DynamicTypeTest1(&dp);
+  INIT(DynamicTypeTest1, (&d));
 };
 
 struct DynTBase2 {
-  int x; // expected-note{{uninitialized field 'static_cast<DynTDerived2 *>(this->bptr)->DynTBase2::x'}} expected-note{{uninitialized field 'static_cast<DynTDerived2 *>(this->bptr)->DynTBase2::x'}}
+  int x; // expected-note{{uninitialized field 'static_cast<DynTDerived2 *>(this->bptr)->DynTBase2::x'}}
 };
 struct DynTDerived2 : DynTBase2 {
-  int y; // expected-note{{uninitialized field 'static_cast<DynTDerived2 *>(this->bptr)->y'}} expected-note{{uninitialized field 'static_cast<DynTDerived2 *>(this->bptr)->y'}}
+  int y; // expected-note{{uninitialized field 'static_cast<DynTDerived2 *>(this->bptr)->y'}}
 };
 
 struct DynamicTypeTest2 {
   DynTBase2 *bptr;
   int i = 0;
 
-  DynamicTypeTest2(DynTBase2 *bptr) : bptr(bptr) {} // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+  DynamicTypeTest2(DynTBase2 *bptr) : bptr(bptr) {} // expected-warning{{2 uninitialized fields}}
 };
 
 void fDynamicTypeTest2() {
   DynTDerived2 d;
-  DynamicTypeTest2 t(&d);
-  DynTDerived2 dp;
-  new DynamicTypeTest2(&dp);
+  INIT(DynamicTypeTest2, (&d));
 }
 
 struct SymbolicSuperRegionBase {
@@ -864,6 +839,5 @@ struct SymbolicSuperRegionDerived : SymbolicSuperRegionBase {
 SymbolicSuperRegionDerived *getSymbolicRegion();
 
 void fSymbolicSuperRegionTest() {
-  SymbolicSuperRegionDerived test(getSymbolicRegion());
-  new SymbolicSuperRegionDerived(getSymbolicRegion());
+  INIT(SymbolicSuperRegionDerived, (getSymbolicRegion()));
 }

--- a/clang/test/Analysis/cxx-uninitialized-object-no-dereference.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object-no-dereference.cpp
@@ -1,17 +1,24 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=core,optin.cplusplus.UninitializedObject \
 // RUN:   -std=c++11 -DPEDANTIC -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,optin.cplusplus.UninitializedObject \
+// RUN:   -std=c++11 -DPEDANTIC -verify %s -DHEAP_ALLOCATION
+
+#ifdef HEAP_ALLOCATION
+#define INIT(CLS, ARGS) new CLS ARGS
+#else
+#define INIT(CLS, ARGS) (void) CLS ARGS
+#endif
 
 class UninitPointerTest {
-  int *ptr; // expected-note{{uninitialized pointer 'this->ptr'}} expected-note{{uninitialized pointer 'this->ptr'}}
+  int *ptr; // expected-note{{uninitialized pointer 'this->ptr'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
 public:
-  UninitPointerTest() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  UninitPointerTest() {} // expected-warning{{1 uninitialized field}}
 };
 
 void fUninitPointerTest() {
-  UninitPointerTest();
-  new UninitPointerTest();
+  INIT(UninitPointerTest, ());
 }
 
 class UninitPointeeTest {
@@ -24,6 +31,5 @@ public:
 
 void fUninitPointeeTest() {
   int a;
-  UninitPointeeTest t(&a);
-  new UninitPointeeTest(&a);
+  INIT(UninitPointeeTest, (&a));
 }

--- a/clang/test/Analysis/cxx-uninitialized-object-no-dereference.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object-no-dereference.cpp
@@ -2,15 +2,16 @@
 // RUN:   -std=c++11 -DPEDANTIC -verify %s
 
 class UninitPointerTest {
-  int *ptr; // expected-note{{uninitialized pointer 'this->ptr'}}
+  int *ptr; // expected-note{{uninitialized pointer 'this->ptr'}} expected-note{{uninitialized pointer 'this->ptr'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
 public:
-  UninitPointerTest() {} // expected-warning{{1 uninitialized field}}
+  UninitPointerTest() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fUninitPointerTest() {
   UninitPointerTest();
+  new UninitPointerTest();
 }
 
 class UninitPointeeTest {
@@ -24,4 +25,5 @@ public:
 void fUninitPointeeTest() {
   int a;
   UninitPointeeTest t(&a);
+  new UninitPointeeTest(&a);
 }

--- a/clang/test/Analysis/cxx-uninitialized-object-notes-as-warnings.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object-notes-as-warnings.cpp
@@ -9,10 +9,11 @@ class NotesAsWarningsTest {
   int dontGetFilteredByNonPedanticMode = 0;
 
 public:
-  NotesAsWarningsTest() {} // expected-warning{{uninitialized field 'this->a'}}
-  // expected-warning@-1{{uninitialized field 'this->b'}}
+  NotesAsWarningsTest() {} // expected-warning{{uninitialized field 'this->a'}} expected-warning{{uninitialized field 'this->a'}}
+  // expected-warning@-1{{uninitialized field 'this->b'}} expected-warning@-1{{uninitialized field 'this->b'}}
 };
 
 void fNotesAsWarningsTest() {
   NotesAsWarningsTest();
+  new NotesAsWarningsTest();
 }

--- a/clang/test/Analysis/cxx-uninitialized-object-notes-as-warnings.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object-notes-as-warnings.cpp
@@ -2,6 +2,16 @@
 // RUN:   -analyzer-config optin.cplusplus.UninitializedObject:NotesAsWarnings=true \
 // RUN:   -analyzer-config optin.cplusplus.UninitializedObject:CheckPointeeInitialization=true \
 // RUN:   -std=c++11 -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,optin.cplusplus.UninitializedObject \
+// RUN:   -analyzer-config optin.cplusplus.UninitializedObject:NotesAsWarnings=true \
+// RUN:   -analyzer-config optin.cplusplus.UninitializedObject:CheckPointeeInitialization=true \
+// RUN:   -std=c++11 -verify %s -DHEAP_ALLOCATION
+
+#ifdef HEAP_ALLOCATION
+#define INIT(CLS, ARGS) new CLS ARGS
+#else
+#define INIT(CLS, ARGS) (void) CLS ARGS
+#endif
 
 class NotesAsWarningsTest {
   int a;
@@ -9,11 +19,10 @@ class NotesAsWarningsTest {
   int dontGetFilteredByNonPedanticMode = 0;
 
 public:
-  NotesAsWarningsTest() {} // expected-warning{{uninitialized field 'this->a'}} expected-warning{{uninitialized field 'this->a'}}
-  // expected-warning@-1{{uninitialized field 'this->b'}} expected-warning@-1{{uninitialized field 'this->b'}}
+  NotesAsWarningsTest() {} // expected-warning{{uninitialized field 'this->a'}}
+  // expected-warning@-1{{uninitialized field 'this->b'}}
 };
 
 void fNotesAsWarningsTest() {
-  NotesAsWarningsTest();
-  new NotesAsWarningsTest();
+  INIT(NotesAsWarningsTest, ());
 }

--- a/clang/test/Analysis/cxx-uninitialized-object-ptr-ref.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object-ptr-ref.cpp
@@ -2,10 +2,23 @@
 // RUN:   -analyzer-config optin.cplusplus.UninitializedObject:Pedantic=true -DPEDANTIC \
 // RUN:   -analyzer-config optin.cplusplus.UninitializedObject:CheckPointeeInitialization=true \
 // RUN:   -std=c++11 -verify  %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,unix.Malloc,optin.cplusplus.UninitializedObject \
+// RUN:   -analyzer-config optin.cplusplus.UninitializedObject:Pedantic=true -DPEDANTIC \
+// RUN:   -analyzer-config optin.cplusplus.UninitializedObject:CheckPointeeInitialization=true \
+// RUN:   -std=c++11 -verify  %s -DHEAP_ALLOCATION
 
 // RUN: %clang_analyze_cc1 -analyzer-checker=core,unix.Malloc,optin.cplusplus.UninitializedObject \
 // RUN:   -analyzer-config optin.cplusplus.UninitializedObject:CheckPointeeInitialization=true \
 // RUN:   -std=c++11 -verify  %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,unix.Malloc,optin.cplusplus.UninitializedObject \
+// RUN:   -analyzer-config optin.cplusplus.UninitializedObject:CheckPointeeInitialization=true \
+// RUN:   -std=c++11 -verify  %s -DHEAP_ALLOCATION
+
+#ifdef HEAP_ALLOCATION
+#define INIT(CLS, ARGS) new CLS ARGS
+#else
+#define INIT(CLS, ARGS) (void) CLS ARGS
+#endif
 
 //===----------------------------------------------------------------------===//
 // Concrete location tests.
@@ -18,8 +31,7 @@ struct ConcreteIntLocTest {
 };
 
 void fConcreteIntLocTest() {
-  ConcreteIntLocTest();
-  new ConcreteIntLocTest();
+  INIT(ConcreteIntLocTest, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -29,17 +41,15 @@ void fConcreteIntLocTest() {
 using intptr_t = unsigned long long;
 
 struct LocAsIntegerTest {
-  intptr_t ptr; // expected-note{{uninitialized pointee 'reinterpret_cast<char *>(this->ptr)'}} expected-note{{uninitialized pointee 'reinterpret_cast<char *>(this->ptr)'}}
+  intptr_t ptr; // expected-note{{uninitialized pointee 'reinterpret_cast<char *>(this->ptr)'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  LocAsIntegerTest(void *ptr) : ptr(reinterpret_cast<intptr_t>(ptr)) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  LocAsIntegerTest(void *ptr) : ptr(reinterpret_cast<intptr_t>(ptr)) {} // expected-warning{{1 uninitialized field}}
 };
 
 void fLocAsIntegerTest() {
   char c;
-  LocAsIntegerTest t(&c);
-  char cp;
-  new LocAsIntegerTest(&cp);
+  INIT(LocAsIntegerTest, (&c));
 }
 
 //===----------------------------------------------------------------------===//
@@ -63,8 +73,7 @@ public:
 };
 
 void fNullPtrTest() {
-  NullPtrTest();
-  new NullPtrTest();
+  INIT(NullPtrTest, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -144,8 +153,7 @@ public:
 };
 
 void fHeapPointerTest1() {
-  HeapPointerTest1();
-  new HeapPointerTest1();
+  INIT(HeapPointerTest1, ());
 }
 
 class HeapPointerTest2 {
@@ -165,8 +173,7 @@ public:
 };
 
 void fHeapPointerTest2() {
-  HeapPointerTest2();
-  new HeapPointerTest2();
+  INIT(HeapPointerTest2, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -193,34 +200,30 @@ public:
 void fStackPointerTest1() {
   int ok_a = 28;
   StackPointerTest1::RecordType ok_rec{29, 30};
-  StackPointerTest1(&ok_a, &ok_rec); // 'a', 'rec.x', 'rec.y' uninitialized
-  new StackPointerTest1(&ok_a, &ok_rec);
+  INIT(StackPointerTest1, (&ok_a, &ok_rec)); // 'a', 'rec.x', 'rec.y' uninitialized
 }
 
 #ifdef PEDANTIC
 class StackPointerTest2 {
 public:
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->recPtr->x'}} expected-note{{uninitialized field 'this->recPtr->x'}}
-    int y; // expected-note{{uninitialized field 'this->recPtr->y'}} expected-note{{uninitialized field 'this->recPtr->y'}}
+    int x; // expected-note{{uninitialized field 'this->recPtr->x'}}
+    int y; // expected-note{{uninitialized field 'this->recPtr->y'}}
   };
 
 private:
-  int *ptr; // expected-note{{uninitialized pointee 'this->ptr'}} expected-note{{uninitialized pointee 'this->ptr'}}
+  int *ptr; // expected-note{{uninitialized pointee 'this->ptr'}}
   RecordType *recPtr;
 
 public:
-  StackPointerTest2(int *_ptr, RecordType *_recPtr) : ptr(_ptr), recPtr(_recPtr) { // expected-warning{{3 uninitialized fields}} expected-warning{{3 uninitialized fields}}
+  StackPointerTest2(int *_ptr, RecordType *_recPtr) : ptr(_ptr), recPtr(_recPtr) { // expected-warning{{3 uninitialized fields}}
   }
 };
 
 void fStackPointerTest2() {
   int a;
   StackPointerTest2::RecordType rec;
-  StackPointerTest2(&a, &rec); // 'a', 'rec.x', 'rec.y' uninitialized
-  int ap;
-  StackPointerTest2::RecordType recp;
-  new StackPointerTest2(&ap, &recp);
+  INIT(StackPointerTest2, (&a, &rec)); // 'a', 'rec.x', 'rec.y' uninitialized
 }
 #else
 class StackPointerTest2 {
@@ -242,8 +245,7 @@ public:
 void fStackPointerTest2() {
   int a;
   StackPointerTest2::RecordType rec;
-  StackPointerTest2(&a, &rec); // 'a', 'rec.x', 'rec.y' uninitialized
-  new StackPointerTest2(&a, &rec);
+  INIT(StackPointerTest2, (&a, &rec)); // 'a', 'rec.x', 'rec.y' uninitialized
 }
 #endif // PEDANTIC
 
@@ -253,17 +255,16 @@ class UninitPointerTest {
     int y;
   };
 
-  int *ptr; // expected-note{{uninitialized pointer 'this->ptr'}} expected-note{{uninitialized pointer 'this->ptr'}}
+  int *ptr; // expected-note{{uninitialized pointer 'this->ptr'}}
   RecordType *recPtr;
 
 public:
-  UninitPointerTest() : recPtr(new RecordType{13, 13}) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  UninitPointerTest() : recPtr(new RecordType{13, 13}) { // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fUninitPointerTest() {
-  UninitPointerTest();
-  new UninitPointerTest();
+  INIT(UninitPointerTest, ());
 }
 
 struct CharPointerTest {
@@ -274,19 +275,17 @@ struct CharPointerTest {
 };
 
 void fCharPointerTest() {
-  CharPointerTest();
-  new CharPointerTest();
+  INIT(CharPointerTest, ());
 }
 
 struct VectorSizePointer {
-  VectorSizePointer() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
-  __attribute__((__vector_size__(8))) int *x; // expected-note{{uninitialized pointer 'this->x'}} expected-note{{uninitialized pointer 'this->x'}}
+  VectorSizePointer() {} // expected-warning{{1 uninitialized field}}
+  __attribute__((__vector_size__(8))) int *x; // expected-note{{uninitialized pointer 'this->x'}}
   int dontGetFilteredByNonPedanticMode = 0;
 };
 
 void __vector_size__PointerTest() {
-  VectorSizePointer v;
-  new VectorSizePointer();
+  INIT(VectorSizePointer, ());
 }
 
 struct VectorSizePointee {
@@ -299,32 +298,29 @@ struct VectorSizePointee {
 void __vector_size__PointeeTest() {
   VectorSizePointee::MyVectorType i;
   // TODO: Report v.x's pointee.
-  VectorSizePointee v(&i);
-  new VectorSizePointee(&i);
+  INIT(VectorSizePointee, (&i));
 }
 
 struct CyclicPointerTest1 {
-  int *ptr; // expected-note{{object references itself 'this->ptr'}} expected-note{{object references itself 'this->ptr'}}
+  int *ptr; // expected-note{{object references itself 'this->ptr'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  CyclicPointerTest1() : ptr(reinterpret_cast<int *>(&ptr)) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  CyclicPointerTest1() : ptr(reinterpret_cast<int *>(&ptr)) {} // expected-warning{{1 uninitialized field}}
 };
 
 void fCyclicPointerTest1() {
-  CyclicPointerTest1();
-  new CyclicPointerTest1();
+  INIT(CyclicPointerTest1, ());
 }
 
 struct CyclicPointerTest2 {
-  int **pptr; // expected-note{{object references itself 'this->pptr'}} expected-note{{object references itself 'this->pptr'}}
+  int **pptr; // expected-note{{object references itself 'this->pptr'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  CyclicPointerTest2() : pptr(reinterpret_cast<int **>(&pptr)) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  CyclicPointerTest2() : pptr(reinterpret_cast<int **>(&pptr)) {} // expected-warning{{1 uninitialized field}}
 };
 
 void fCyclicPointerTest2() {
-  CyclicPointerTest2();
-  new CyclicPointerTest2();
+  INIT(CyclicPointerTest2, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -349,8 +345,7 @@ public:
 
 void fVoidPointerTest1() {
   void *vptr = calloc(1, sizeof(int));
-  VoidPointerTest1(vptr, char());
-  new VoidPointerTest1(vptr, char());
+  INIT(VoidPointerTest1, (vptr, char()));
   free(vptr);
 }
 
@@ -365,8 +360,7 @@ public:
 
 void fVoidPointerTest2() {
   void *vptr = calloc(1, sizeof(int));
-  VoidPointerTest2(&vptr, char());
-  new VoidPointerTest2(&vptr, char());
+  INIT(VoidPointerTest2, (&vptr, char()));
   free(vptr);
 }
 
@@ -425,72 +419,64 @@ void fVoidPointerLRefTest() {
 }
 
 struct CyclicVoidPointerTest {
-  void *vptr; // expected-note{{object references itself 'this->vptr'}} expected-note{{object references itself 'this->vptr'}}
+  void *vptr; // expected-note{{object references itself 'this->vptr'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  CyclicVoidPointerTest() : vptr(&vptr) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  CyclicVoidPointerTest() : vptr(&vptr) {} // expected-warning{{1 uninitialized field}}
 };
 
 void fCyclicVoidPointerTest() {
-  CyclicVoidPointerTest();
-  new CyclicVoidPointerTest();
+  INIT(CyclicVoidPointerTest, ());
 }
 
 struct IntDynTypedVoidPointerTest1 {
-  void *vptr; // expected-note{{uninitialized pointee 'static_cast<int *>(this->vptr)'}} expected-note{{uninitialized pointee 'static_cast<int *>(this->vptr)'}}
+  void *vptr; // expected-note{{uninitialized pointee 'static_cast<int *>(this->vptr)'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  IntDynTypedVoidPointerTest1(void *vptr) : vptr(vptr) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  IntDynTypedVoidPointerTest1(void *vptr) : vptr(vptr) {} // expected-warning{{1 uninitialized field}}
 };
 
 void fIntDynTypedVoidPointerTest1() {
   int a;
-  IntDynTypedVoidPointerTest1 tmp(&a);
-  int ap;
-  new IntDynTypedVoidPointerTest1(&ap);
+  INIT(IntDynTypedVoidPointerTest1, (&a));
 }
 
 struct RecordDynTypedVoidPointerTest {
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'static_cast<RecordDynTypedVoidPointerTest::RecordType *>(this->vptr)->x'}} expected-note{{uninitialized field 'static_cast<RecordDynTypedVoidPointerTest::RecordType *>(this->vptr)->x'}}
-    int y; // expected-note{{uninitialized field 'static_cast<RecordDynTypedVoidPointerTest::RecordType *>(this->vptr)->y'}} expected-note{{uninitialized field 'static_cast<RecordDynTypedVoidPointerTest::RecordType *>(this->vptr)->y'}}
+    int x; // expected-note{{uninitialized field 'static_cast<RecordDynTypedVoidPointerTest::RecordType *>(this->vptr)->x'}}
+    int y; // expected-note{{uninitialized field 'static_cast<RecordDynTypedVoidPointerTest::RecordType *>(this->vptr)->y'}}
   };
 
   void *vptr;
   int dontGetFilteredByNonPedanticMode = 0;
 
-  RecordDynTypedVoidPointerTest(void *vptr) : vptr(vptr) {} // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+  RecordDynTypedVoidPointerTest(void *vptr) : vptr(vptr) {} // expected-warning{{2 uninitialized fields}}
 };
 
 void fRecordDynTypedVoidPointerTest() {
   RecordDynTypedVoidPointerTest::RecordType a;
-  RecordDynTypedVoidPointerTest tmp(&a);
-  RecordDynTypedVoidPointerTest::RecordType ap;
-  new RecordDynTypedVoidPointerTest(&ap);
+  INIT(RecordDynTypedVoidPointerTest, (&a));
 }
 
 struct NestedNonVoidDynTypedVoidPointerTest {
   struct RecordType {
-    int x;      // expected-note{{uninitialized field 'static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->x'}} expected-note{{uninitialized field 'static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->x'}}
-    int y;      // expected-note{{uninitialized field 'static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->y'}} expected-note{{uninitialized field 'static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->y'}}
-    void *vptr; // expected-note{{uninitialized pointee 'static_cast<char *>(static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->vptr)'}} expected-note{{uninitialized pointee 'static_cast<char *>(static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->vptr)'}}
+    int x;      // expected-note{{uninitialized field 'static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->x'}}
+    int y;      // expected-note{{uninitialized field 'static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->y'}}
+    void *vptr; // expected-note{{uninitialized pointee 'static_cast<char *>(static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->vptr)'}}
   };
 
   void *vptr;
   int dontGetFilteredByNonPedanticMode = 0;
 
   NestedNonVoidDynTypedVoidPointerTest(void *vptr, void *c) : vptr(vptr) {
-    static_cast<RecordType *>(vptr)->vptr = c; // expected-warning{{3 uninitialized fields}} expected-warning{{3 uninitialized fields}}
+    static_cast<RecordType *>(vptr)->vptr = c; // expected-warning{{3 uninitialized fields}}
   }
 };
 
 void fNestedNonVoidDynTypedVoidPointerTest() {
   NestedNonVoidDynTypedVoidPointerTest::RecordType a;
   char c;
-  NestedNonVoidDynTypedVoidPointerTest tmp(&a, &c);
-  NestedNonVoidDynTypedVoidPointerTest::RecordType ap;
-  char cp;
-  new NestedNonVoidDynTypedVoidPointerTest(&ap, &cp);
+  INIT(NestedNonVoidDynTypedVoidPointerTest, (&a, &c));
 }
 
 //===----------------------------------------------------------------------===//
@@ -506,20 +492,17 @@ public:
   };
 
 private:
-  RecordType **mptr; // expected-note{{uninitialized pointee 'this->mptr'}} expected-note{{uninitialized pointee 'this->mptr'}}
+  RecordType **mptr; // expected-note{{uninitialized pointee 'this->mptr'}}
 
 public:
-  MultiPointerTest1(RecordType **p, int) : mptr(p) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  MultiPointerTest1(RecordType **p, int) : mptr(p) { // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fMultiPointerTest1() {
   MultiPointerTest1::RecordType *p1;
   MultiPointerTest1::RecordType **mptr = &p1;
-  MultiPointerTest1(mptr, int()); // '*mptr' uninitialized
-  MultiPointerTest1::RecordType *p1p;
-  MultiPointerTest1::RecordType **mptrp = &p1p;
-  new MultiPointerTest1(mptrp, int());
+  INIT(MultiPointerTest1, (mptr, int())); // '*mptr' uninitialized
 }
 #else
 class MultiPointerTest1 {
@@ -539,8 +522,7 @@ public:
 void fMultiPointerTest1() {
   MultiPointerTest1::RecordType *p1;
   MultiPointerTest1::RecordType **mptr = &p1;
-  MultiPointerTest1(mptr, int()); // '*mptr' uninitialized
-  new MultiPointerTest1(mptr, int());
+  INIT(MultiPointerTest1, (mptr, int())); // '*mptr' uninitialized
 }
 #endif // PEDANTIC
 
@@ -548,15 +530,15 @@ void fMultiPointerTest1() {
 class MultiPointerTest2 {
 public:
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->mptr->x'}} expected-note{{uninitialized field 'this->mptr->x'}}
-    int y; // expected-note{{uninitialized field 'this->mptr->y'}} expected-note{{uninitialized field 'this->mptr->y'}}
+    int x; // expected-note{{uninitialized field 'this->mptr->x'}}
+    int y; // expected-note{{uninitialized field 'this->mptr->y'}}
   };
 
 private:
   RecordType **mptr;
 
 public:
-  MultiPointerTest2(RecordType **p, int) : mptr(p) { // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+  MultiPointerTest2(RecordType **p, int) : mptr(p) { // expected-warning{{2 uninitialized fields}}
   }
 };
 
@@ -564,11 +546,7 @@ void fMultiPointerTest2() {
   MultiPointerTest2::RecordType i;
   MultiPointerTest2::RecordType *p1 = &i;
   MultiPointerTest2::RecordType **mptr = &p1;
-  MultiPointerTest2(mptr, int()); // '**mptr' uninitialized
-  MultiPointerTest2::RecordType ip;
-  MultiPointerTest2::RecordType *p1p = &ip;
-  MultiPointerTest2::RecordType **mptrp = &p1p;
-  new MultiPointerTest2(mptrp, int());
+  INIT(MultiPointerTest2, (mptr, int())); // '**mptr' uninitialized
 }
 #else
 class MultiPointerTest2 {
@@ -590,8 +568,7 @@ void fMultiPointerTest2() {
   MultiPointerTest2::RecordType i;
   MultiPointerTest2::RecordType *p1 = &i;
   MultiPointerTest2::RecordType **mptr = &p1;
-  MultiPointerTest2(mptr, int()); // '**mptr' uninitialized
-  new MultiPointerTest2(mptr, int());
+  INIT(MultiPointerTest2, (mptr, int())); // '**mptr' uninitialized
 }
 #endif // PEDANTIC
 
@@ -615,8 +592,7 @@ void fMultiPointerTest3() {
   MultiPointerTest3::RecordType i{31, 32};
   MultiPointerTest3::RecordType *p1 = &i;
   MultiPointerTest3::RecordType **mptr = &p1;
-  MultiPointerTest3(mptr, int()); // '**mptr' uninitialized
-  new MultiPointerTest3(mptr, int());
+  INIT(MultiPointerTest3, (mptr, int())); // '**mptr' uninitialized
 }
 
 //===----------------------------------------------------------------------===//
@@ -633,8 +609,7 @@ struct IncompletePointeeTypeTest {
 };
 
 void fIncompletePointeeTypeTest(void *ptr) {
-  IncompletePointeeTypeTest(reinterpret_cast<IncompleteType *>(ptr));
-  new IncompletePointeeTypeTest(reinterpret_cast<IncompleteType *>(ptr));
+  INIT(IncompletePointeeTypeTest, (reinterpret_cast<IncompleteType *>(ptr)));
 }
 
 //===----------------------------------------------------------------------===//
@@ -666,13 +641,12 @@ struct UsefulFunctions {
 
 #ifdef PEDANTIC
 struct PointerToMemberFunctionTest1 {
-  void (UsefulFunctions::*f)(void); // expected-note{{uninitialized field 'this->f'}} expected-note{{uninitialized field 'this->f'}}
+  void (UsefulFunctions::*f)(void); // expected-note{{uninitialized field 'this->f'}}
   PointerToMemberFunctionTest1() {}
 };
 
 void fPointerToMemberFunctionTest1() {
-  PointerToMemberFunctionTest1(); // expected-warning{{1 uninitialized field}}
-  new PointerToMemberFunctionTest1(); // expected-warning{{1 uninitialized field}}
+  INIT(PointerToMemberFunctionTest1, ()); // expected-warning{{1 uninitialized field}}
 }
 
 struct PointerToMemberFunctionTest2 {
@@ -684,18 +658,16 @@ struct PointerToMemberFunctionTest2 {
 
 void fPointerToMemberFunctionTest2() {
   void (UsefulFunctions::*f)(void) = &UsefulFunctions::print;
-  PointerToMemberFunctionTest2 a(f);
-  new PointerToMemberFunctionTest2(f);
+  INIT(PointerToMemberFunctionTest2, (f));
 }
 
 struct MultiPointerToMemberFunctionTest1 {
-  void (UsefulFunctions::**f)(void); // expected-note{{uninitialized pointer 'this->f'}} expected-note{{uninitialized pointer 'this->f'}}
+  void (UsefulFunctions::**f)(void); // expected-note{{uninitialized pointer 'this->f'}}
   MultiPointerToMemberFunctionTest1() {}
 };
 
 void fMultiPointerToMemberFunctionTest1() {
-  MultiPointerToMemberFunctionTest1(); // expected-warning{{1 uninitialized field}}
-  new MultiPointerToMemberFunctionTest1(); // expected-warning{{1 uninitialized field}}
+  INIT(MultiPointerToMemberFunctionTest1, ()); // expected-warning{{1 uninitialized field}}
 }
 
 struct MultiPointerToMemberFunctionTest2 {
@@ -707,18 +679,16 @@ struct MultiPointerToMemberFunctionTest2 {
 
 void fMultiPointerToMemberFunctionTest2() {
   void (UsefulFunctions::*f)(void) = &UsefulFunctions::print;
-  MultiPointerToMemberFunctionTest2 a(&f);
-  new MultiPointerToMemberFunctionTest2(&f);
+  INIT(MultiPointerToMemberFunctionTest2, (&f));
 }
 
 struct PointerToMemberDataTest1 {
-  int UsefulFunctions::*d; // expected-note{{uninitialized field 'this->d'}} expected-note{{uninitialized field 'this->d'}}
+  int UsefulFunctions::*d; // expected-note{{uninitialized field 'this->d'}}
   PointerToMemberDataTest1() {}
 };
 
 void fPointerToMemberDataTest1() {
-  PointerToMemberDataTest1(); // expected-warning{{1 uninitialized field}}
-  new PointerToMemberDataTest1(); // expected-warning{{1 uninitialized field}}
+  INIT(PointerToMemberDataTest1, ()); // expected-warning{{1 uninitialized field}}
 }
 
 struct PointerToMemberDataTest2 {
@@ -730,18 +700,16 @@ struct PointerToMemberDataTest2 {
 
 void fPointerToMemberDataTest2() {
   int UsefulFunctions::*d = &UsefulFunctions::a;
-  PointerToMemberDataTest2 a(d);
-  new PointerToMemberDataTest2(d);
+  INIT(PointerToMemberDataTest2, (d));
 }
 
 struct MultiPointerToMemberDataTest1 {
-  int UsefulFunctions::**d; // expected-note{{uninitialized pointer 'this->d'}} expected-note{{uninitialized pointer 'this->d'}}
+  int UsefulFunctions::**d; // expected-note{{uninitialized pointer 'this->d'}}
   MultiPointerToMemberDataTest1() {}
 };
 
 void fMultiPointerToMemberDataTest1() {
-  MultiPointerToMemberDataTest1(); // expected-warning{{1 uninitialized field}}
-  new MultiPointerToMemberDataTest1(); // expected-warning{{1 uninitialized field}}
+  INIT(MultiPointerToMemberDataTest1, ()); // expected-warning{{1 uninitialized field}}
 }
 
 struct MultiPointerToMemberDataTest2 {
@@ -753,8 +721,7 @@ struct MultiPointerToMemberDataTest2 {
 
 void fMultiPointerToMemberDataTest2() {
   int UsefulFunctions::*d = &UsefulFunctions::a;
-  MultiPointerToMemberDataTest2 a(&d);
-  new MultiPointerToMemberDataTest2(&d);
+  INIT(MultiPointerToMemberDataTest2, (&d));
 }
 #endif // PEDANTIC
 
@@ -779,44 +746,41 @@ public:
 };
 
 void fListTest1() {
-  ListTest1();
-  new ListTest1();
+  INIT(ListTest1, ());
 }
 
 class ListTest2 {
 public:
   struct Node {
     Node *next = nullptr;
-    int i; // expected-note{{uninitialized field 'this->head->i'}} expected-note{{uninitialized field 'this->head->i'}}
+    int i; // expected-note{{uninitialized field 'this->head->i'}}
   };
 
 private:
   Node *head = nullptr;
 
 public:
-  ListTest2(Node *node, int) : head(node) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  ListTest2(Node *node, int) : head(node) { // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fListTest2() {
   ListTest2::Node n;
-  ListTest2(&n, int());
-  ListTest2::Node np;
-  new ListTest2(&np, int());
+  INIT(ListTest2, (&n, int()));
 }
 
 class CyclicList {
 public:
   struct Node {
     Node *next = nullptr;
-    int i; // expected-note{{uninitialized field 'this->head->i'}} expected-note{{uninitialized field 'this->head->i'}}
+    int i; // expected-note{{uninitialized field 'this->head->i'}}
   };
 
 private:
   Node *head = nullptr;
 
 public:
-  CyclicList(Node *node, int) : head(node) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  CyclicList(Node *node, int) : head(node) { // expected-warning{{1 uninitialized field}}
   }
 };
 
@@ -836,16 +800,7 @@ void fCyclicList() {
   n3.i = 50;
   n1.next = &n3;
   // note that n1.i is uninitialized
-  CyclicList(&n1, int());
-  CyclicList::Node n1p;
-  CyclicList::Node n2p;
-  n2p.next = &n1p;
-  n2p.i = 50;
-  CyclicList::Node n3p;
-  n3p.next = &n2p;
-  n3p.i = 50;
-  n1p.next = &n3p;
-  new CyclicList(&n1p, int());
+  INIT(CyclicList, (&n1, int()));
 }
 
 struct RingListTest {
@@ -854,8 +809,7 @@ struct RingListTest {
 };
 
 void fRingListTest() {
-  RingListTest();
-  new RingListTest();
+  INIT(RingListTest, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -881,16 +835,15 @@ public:
 
 void fReferenceTest1() {
   ReferenceTest1::RecordType d{33, 34};
-  ReferenceTest1(d, d);
-  new ReferenceTest1(d, d);
+  INIT(ReferenceTest1, (d, d));
 }
 
 #ifdef PEDANTIC
 class ReferenceTest2 {
 public:
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->lref.x'}} expected-note{{uninitialized field 'this->lref.x'}}
-    int y; // expected-note{{uninitialized field 'this->lref.y'}} expected-note{{uninitialized field 'this->lref.y'}}
+    int x; // expected-note{{uninitialized field 'this->lref.x'}}
+    int y; // expected-note{{uninitialized field 'this->lref.y'}}
   };
 
 private:
@@ -899,15 +852,13 @@ private:
 
 public:
   ReferenceTest2(RecordType &lref, RecordType &rref)
-      : lref(lref), rref(static_cast<RecordType &&>(rref)) { // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+      : lref(lref), rref(static_cast<RecordType &&>(rref)) { // expected-warning{{2 uninitialized fields}}
   }
 };
 
 void fReferenceTest2() {
   ReferenceTest2::RecordType c;
-  ReferenceTest2(c, c);
-  ReferenceTest2::RecordType cp;
-  new ReferenceTest2(cp, cp);
+  INIT(ReferenceTest2, (c, c));
 }
 #else
 class ReferenceTest2 {
@@ -929,16 +880,15 @@ public:
 
 void fReferenceTest2() {
   ReferenceTest2::RecordType c;
-  ReferenceTest2(c, c);
-  new ReferenceTest2(c, c);
+  INIT(ReferenceTest2, (c, c));
 }
 #endif // PEDANTIC
 
 class ReferenceTest3 {
 public:
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->lref.x'}} expected-note{{uninitialized field 'this->lref.x'}}
-    int y; // expected-note{{uninitialized field 'this->lref.y'}} expected-note{{uninitialized field 'this->lref.y'}}
+    int x; // expected-note{{uninitialized field 'this->lref.x'}}
+    int y; // expected-note{{uninitialized field 'this->lref.y'}}
   };
 
 private:
@@ -947,22 +897,20 @@ private:
 
 public:
   ReferenceTest3(RecordType &lref, RecordType &rref)
-      : lref(lref), rref(static_cast<RecordType &&>(rref)) { // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+      : lref(lref), rref(static_cast<RecordType &&>(rref)) { // expected-warning{{2 uninitialized fields}}
   }
 };
 
 void fReferenceTest3() {
   ReferenceTest3::RecordType c, d{35, 36};
-  ReferenceTest3(c, d);
-  ReferenceTest3::RecordType cp, dp{35, 36};
-  new ReferenceTest3(cp, dp);
+  INIT(ReferenceTest3, (c, d));
 }
 
 class ReferenceTest4 {
 public:
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->rref.x'}} expected-note{{uninitialized field 'this->rref.x'}}
-    int y; // expected-note{{uninitialized field 'this->rref.y'}} expected-note{{uninitialized field 'this->rref.y'}}
+    int x; // expected-note{{uninitialized field 'this->rref.x'}}
+    int y; // expected-note{{uninitialized field 'this->rref.y'}}
   };
 
 private:
@@ -971,15 +919,13 @@ private:
 
 public:
   ReferenceTest4(RecordType &lref, RecordType &rref)
-      : lref(lref), rref(static_cast<RecordType &&>(rref)) { // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+      : lref(lref), rref(static_cast<RecordType &&>(rref)) { // expected-warning{{2 uninitialized fields}}
   }
 };
 
 void fReferenceTest5() {
   ReferenceTest4::RecordType c, d{37, 38};
-  ReferenceTest4(d, c);
-  ReferenceTest4::RecordType cp, dp{37, 38};
-  new ReferenceTest4(dp, cp);
+  INIT(ReferenceTest4, (d, c));
 }
 
 //===----------------------------------------------------------------------===//
@@ -987,27 +933,25 @@ void fReferenceTest5() {
 //===----------------------------------------------------------------------===//
 
 struct IntMultipleReferenceToSameObjectTest {
-  int *iptr; // expected-note{{uninitialized pointee 'this->iptr'}} expected-note{{uninitialized pointee 'this->iptr'}}
+  int *iptr; // expected-note{{uninitialized pointee 'this->iptr'}}
   int &iref; // no-note, pointee of this->iref was already reported
 
   int dontGetFilteredByNonPedanticMode = 0;
 
-  IntMultipleReferenceToSameObjectTest(int *i) : iptr(i), iref(*i) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  IntMultipleReferenceToSameObjectTest(int *i) : iptr(i), iref(*i) {} // expected-warning{{1 uninitialized field}}
 };
 
 void fIntMultipleReferenceToSameObjectTest() {
   int a;
-  IntMultipleReferenceToSameObjectTest Test(&a);
-  int ap;
-  new IntMultipleReferenceToSameObjectTest(&ap);
+  INIT(IntMultipleReferenceToSameObjectTest, (&a));
 }
 
 struct IntReferenceWrapper1 {
-  int &a; // expected-note{{uninitialized pointee 'this->a'}} expected-note{{uninitialized pointee 'this->a'}}
+  int &a; // expected-note{{uninitialized pointee 'this->a'}}
 
   int dontGetFilteredByNonPedanticMode = 0;
 
-  IntReferenceWrapper1(int &a) : a(a) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  IntReferenceWrapper1(int &a) : a(a) {} // expected-warning{{1 uninitialized field}}
 };
 
 struct IntReferenceWrapper2 {
@@ -1020,11 +964,6 @@ struct IntReferenceWrapper2 {
 
 void fMultipleObjectsReferencingTheSameObjectTest() {
   int a;
-
-  IntReferenceWrapper1 T1(a);
-  IntReferenceWrapper2 T2(a);
-
-  int ap;
-  new IntReferenceWrapper1(ap);
-  new IntReferenceWrapper2(ap);
+  INIT(IntReferenceWrapper1, (a));
+  INIT(IntReferenceWrapper2, (a));
 }

--- a/clang/test/Analysis/cxx-uninitialized-object-ptr-ref.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object-ptr-ref.cpp
@@ -19,6 +19,7 @@ struct ConcreteIntLocTest {
 
 void fConcreteIntLocTest() {
   ConcreteIntLocTest();
+  new ConcreteIntLocTest();
 }
 
 //===----------------------------------------------------------------------===//
@@ -28,15 +29,17 @@ void fConcreteIntLocTest() {
 using intptr_t = unsigned long long;
 
 struct LocAsIntegerTest {
-  intptr_t ptr; // expected-note{{uninitialized pointee 'reinterpret_cast<char *>(this->ptr)'}}
+  intptr_t ptr; // expected-note{{uninitialized pointee 'reinterpret_cast<char *>(this->ptr)'}} expected-note{{uninitialized pointee 'reinterpret_cast<char *>(this->ptr)'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  LocAsIntegerTest(void *ptr) : ptr(reinterpret_cast<intptr_t>(ptr)) {} // expected-warning{{1 uninitialized field}}
+  LocAsIntegerTest(void *ptr) : ptr(reinterpret_cast<intptr_t>(ptr)) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fLocAsIntegerTest() {
   char c;
   LocAsIntegerTest t(&c);
+  char cp;
+  new LocAsIntegerTest(&cp);
 }
 
 //===----------------------------------------------------------------------===//
@@ -61,6 +64,7 @@ public:
 
 void fNullPtrTest() {
   NullPtrTest();
+  new NullPtrTest();
 }
 
 //===----------------------------------------------------------------------===//
@@ -141,6 +145,7 @@ public:
 
 void fHeapPointerTest1() {
   HeapPointerTest1();
+  new HeapPointerTest1();
 }
 
 class HeapPointerTest2 {
@@ -161,6 +166,7 @@ public:
 
 void fHeapPointerTest2() {
   HeapPointerTest2();
+  new HeapPointerTest2();
 }
 
 //===----------------------------------------------------------------------===//
@@ -188,22 +194,23 @@ void fStackPointerTest1() {
   int ok_a = 28;
   StackPointerTest1::RecordType ok_rec{29, 30};
   StackPointerTest1(&ok_a, &ok_rec); // 'a', 'rec.x', 'rec.y' uninitialized
+  new StackPointerTest1(&ok_a, &ok_rec);
 }
 
 #ifdef PEDANTIC
 class StackPointerTest2 {
 public:
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->recPtr->x'}}
-    int y; // expected-note{{uninitialized field 'this->recPtr->y'}}
+    int x; // expected-note{{uninitialized field 'this->recPtr->x'}} expected-note{{uninitialized field 'this->recPtr->x'}}
+    int y; // expected-note{{uninitialized field 'this->recPtr->y'}} expected-note{{uninitialized field 'this->recPtr->y'}}
   };
 
 private:
-  int *ptr; // expected-note{{uninitialized pointee 'this->ptr'}}
+  int *ptr; // expected-note{{uninitialized pointee 'this->ptr'}} expected-note{{uninitialized pointee 'this->ptr'}}
   RecordType *recPtr;
 
 public:
-  StackPointerTest2(int *_ptr, RecordType *_recPtr) : ptr(_ptr), recPtr(_recPtr) { // expected-warning{{3 uninitialized fields}}
+  StackPointerTest2(int *_ptr, RecordType *_recPtr) : ptr(_ptr), recPtr(_recPtr) { // expected-warning{{3 uninitialized fields}} expected-warning{{3 uninitialized fields}}
   }
 };
 
@@ -211,6 +218,9 @@ void fStackPointerTest2() {
   int a;
   StackPointerTest2::RecordType rec;
   StackPointerTest2(&a, &rec); // 'a', 'rec.x', 'rec.y' uninitialized
+  int ap;
+  StackPointerTest2::RecordType recp;
+  new StackPointerTest2(&ap, &recp);
 }
 #else
 class StackPointerTest2 {
@@ -233,6 +243,7 @@ void fStackPointerTest2() {
   int a;
   StackPointerTest2::RecordType rec;
   StackPointerTest2(&a, &rec); // 'a', 'rec.x', 'rec.y' uninitialized
+  new StackPointerTest2(&a, &rec);
 }
 #endif // PEDANTIC
 
@@ -242,16 +253,17 @@ class UninitPointerTest {
     int y;
   };
 
-  int *ptr; // expected-note{{uninitialized pointer 'this->ptr'}}
+  int *ptr; // expected-note{{uninitialized pointer 'this->ptr'}} expected-note{{uninitialized pointer 'this->ptr'}}
   RecordType *recPtr;
 
 public:
-  UninitPointerTest() : recPtr(new RecordType{13, 13}) { // expected-warning{{1 uninitialized field}}
+  UninitPointerTest() : recPtr(new RecordType{13, 13}) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fUninitPointerTest() {
   UninitPointerTest();
+  new UninitPointerTest();
 }
 
 struct CharPointerTest {
@@ -263,16 +275,18 @@ struct CharPointerTest {
 
 void fCharPointerTest() {
   CharPointerTest();
+  new CharPointerTest();
 }
 
 struct VectorSizePointer {
-  VectorSizePointer() {} // expected-warning{{1 uninitialized field}}
-  __attribute__((__vector_size__(8))) int *x; // expected-note{{uninitialized pointer 'this->x'}}
+  VectorSizePointer() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  __attribute__((__vector_size__(8))) int *x; // expected-note{{uninitialized pointer 'this->x'}} expected-note{{uninitialized pointer 'this->x'}}
   int dontGetFilteredByNonPedanticMode = 0;
 };
 
 void __vector_size__PointerTest() {
   VectorSizePointer v;
+  new VectorSizePointer();
 }
 
 struct VectorSizePointee {
@@ -286,28 +300,31 @@ void __vector_size__PointeeTest() {
   VectorSizePointee::MyVectorType i;
   // TODO: Report v.x's pointee.
   VectorSizePointee v(&i);
+  new VectorSizePointee(&i);
 }
 
 struct CyclicPointerTest1 {
-  int *ptr; // expected-note{{object references itself 'this->ptr'}}
+  int *ptr; // expected-note{{object references itself 'this->ptr'}} expected-note{{object references itself 'this->ptr'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  CyclicPointerTest1() : ptr(reinterpret_cast<int *>(&ptr)) {} // expected-warning{{1 uninitialized field}}
+  CyclicPointerTest1() : ptr(reinterpret_cast<int *>(&ptr)) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fCyclicPointerTest1() {
   CyclicPointerTest1();
+  new CyclicPointerTest1();
 }
 
 struct CyclicPointerTest2 {
-  int **pptr; // expected-note{{object references itself 'this->pptr'}}
+  int **pptr; // expected-note{{object references itself 'this->pptr'}} expected-note{{object references itself 'this->pptr'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  CyclicPointerTest2() : pptr(reinterpret_cast<int **>(&pptr)) {} // expected-warning{{1 uninitialized field}}
+  CyclicPointerTest2() : pptr(reinterpret_cast<int **>(&pptr)) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fCyclicPointerTest2() {
   CyclicPointerTest2();
+  new CyclicPointerTest2();
 }
 
 //===----------------------------------------------------------------------===//
@@ -333,6 +350,7 @@ public:
 void fVoidPointerTest1() {
   void *vptr = calloc(1, sizeof(int));
   VoidPointerTest1(vptr, char());
+  new VoidPointerTest1(vptr, char());
   free(vptr);
 }
 
@@ -348,6 +366,7 @@ public:
 void fVoidPointerTest2() {
   void *vptr = calloc(1, sizeof(int));
   VoidPointerTest2(&vptr, char());
+  new VoidPointerTest2(&vptr, char());
   free(vptr);
 }
 
@@ -406,57 +425,62 @@ void fVoidPointerLRefTest() {
 }
 
 struct CyclicVoidPointerTest {
-  void *vptr; // expected-note{{object references itself 'this->vptr'}}
+  void *vptr; // expected-note{{object references itself 'this->vptr'}} expected-note{{object references itself 'this->vptr'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  CyclicVoidPointerTest() : vptr(&vptr) {} // expected-warning{{1 uninitialized field}}
+  CyclicVoidPointerTest() : vptr(&vptr) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fCyclicVoidPointerTest() {
   CyclicVoidPointerTest();
+  new CyclicVoidPointerTest();
 }
 
 struct IntDynTypedVoidPointerTest1 {
-  void *vptr; // expected-note{{uninitialized pointee 'static_cast<int *>(this->vptr)'}}
+  void *vptr; // expected-note{{uninitialized pointee 'static_cast<int *>(this->vptr)'}} expected-note{{uninitialized pointee 'static_cast<int *>(this->vptr)'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  IntDynTypedVoidPointerTest1(void *vptr) : vptr(vptr) {} // expected-warning{{1 uninitialized field}}
+  IntDynTypedVoidPointerTest1(void *vptr) : vptr(vptr) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fIntDynTypedVoidPointerTest1() {
   int a;
   IntDynTypedVoidPointerTest1 tmp(&a);
+  int ap;
+  new IntDynTypedVoidPointerTest1(&ap);
 }
 
 struct RecordDynTypedVoidPointerTest {
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'static_cast<RecordDynTypedVoidPointerTest::RecordType *>(this->vptr)->x'}}
-    int y; // expected-note{{uninitialized field 'static_cast<RecordDynTypedVoidPointerTest::RecordType *>(this->vptr)->y'}}
+    int x; // expected-note{{uninitialized field 'static_cast<RecordDynTypedVoidPointerTest::RecordType *>(this->vptr)->x'}} expected-note{{uninitialized field 'static_cast<RecordDynTypedVoidPointerTest::RecordType *>(this->vptr)->x'}}
+    int y; // expected-note{{uninitialized field 'static_cast<RecordDynTypedVoidPointerTest::RecordType *>(this->vptr)->y'}} expected-note{{uninitialized field 'static_cast<RecordDynTypedVoidPointerTest::RecordType *>(this->vptr)->y'}}
   };
 
   void *vptr;
   int dontGetFilteredByNonPedanticMode = 0;
 
-  RecordDynTypedVoidPointerTest(void *vptr) : vptr(vptr) {} // expected-warning{{2 uninitialized fields}}
+  RecordDynTypedVoidPointerTest(void *vptr) : vptr(vptr) {} // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
 };
 
 void fRecordDynTypedVoidPointerTest() {
   RecordDynTypedVoidPointerTest::RecordType a;
   RecordDynTypedVoidPointerTest tmp(&a);
+  RecordDynTypedVoidPointerTest::RecordType ap;
+  new RecordDynTypedVoidPointerTest(&ap);
 }
 
 struct NestedNonVoidDynTypedVoidPointerTest {
   struct RecordType {
-    int x;      // expected-note{{uninitialized field 'static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->x'}}
-    int y;      // expected-note{{uninitialized field 'static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->y'}}
-    void *vptr; // expected-note{{uninitialized pointee 'static_cast<char *>(static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->vptr)'}}
+    int x;      // expected-note{{uninitialized field 'static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->x'}} expected-note{{uninitialized field 'static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->x'}}
+    int y;      // expected-note{{uninitialized field 'static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->y'}} expected-note{{uninitialized field 'static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->y'}}
+    void *vptr; // expected-note{{uninitialized pointee 'static_cast<char *>(static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->vptr)'}} expected-note{{uninitialized pointee 'static_cast<char *>(static_cast<NestedNonVoidDynTypedVoidPointerTest::RecordType *>(this->vptr)->vptr)'}}
   };
 
   void *vptr;
   int dontGetFilteredByNonPedanticMode = 0;
 
   NestedNonVoidDynTypedVoidPointerTest(void *vptr, void *c) : vptr(vptr) {
-    static_cast<RecordType *>(vptr)->vptr = c; // expected-warning{{3 uninitialized fields}}
+    static_cast<RecordType *>(vptr)->vptr = c; // expected-warning{{3 uninitialized fields}} expected-warning{{3 uninitialized fields}}
   }
 };
 
@@ -464,6 +488,9 @@ void fNestedNonVoidDynTypedVoidPointerTest() {
   NestedNonVoidDynTypedVoidPointerTest::RecordType a;
   char c;
   NestedNonVoidDynTypedVoidPointerTest tmp(&a, &c);
+  NestedNonVoidDynTypedVoidPointerTest::RecordType ap;
+  char cp;
+  new NestedNonVoidDynTypedVoidPointerTest(&ap, &cp);
 }
 
 //===----------------------------------------------------------------------===//
@@ -479,10 +506,10 @@ public:
   };
 
 private:
-  RecordType **mptr; // expected-note{{uninitialized pointee 'this->mptr'}}
+  RecordType **mptr; // expected-note{{uninitialized pointee 'this->mptr'}} expected-note{{uninitialized pointee 'this->mptr'}}
 
 public:
-  MultiPointerTest1(RecordType **p, int) : mptr(p) { // expected-warning{{1 uninitialized field}}
+  MultiPointerTest1(RecordType **p, int) : mptr(p) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
@@ -490,6 +517,9 @@ void fMultiPointerTest1() {
   MultiPointerTest1::RecordType *p1;
   MultiPointerTest1::RecordType **mptr = &p1;
   MultiPointerTest1(mptr, int()); // '*mptr' uninitialized
+  MultiPointerTest1::RecordType *p1p;
+  MultiPointerTest1::RecordType **mptrp = &p1p;
+  new MultiPointerTest1(mptrp, int());
 }
 #else
 class MultiPointerTest1 {
@@ -510,6 +540,7 @@ void fMultiPointerTest1() {
   MultiPointerTest1::RecordType *p1;
   MultiPointerTest1::RecordType **mptr = &p1;
   MultiPointerTest1(mptr, int()); // '*mptr' uninitialized
+  new MultiPointerTest1(mptr, int());
 }
 #endif // PEDANTIC
 
@@ -517,15 +548,15 @@ void fMultiPointerTest1() {
 class MultiPointerTest2 {
 public:
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->mptr->x'}}
-    int y; // expected-note{{uninitialized field 'this->mptr->y'}}
+    int x; // expected-note{{uninitialized field 'this->mptr->x'}} expected-note{{uninitialized field 'this->mptr->x'}}
+    int y; // expected-note{{uninitialized field 'this->mptr->y'}} expected-note{{uninitialized field 'this->mptr->y'}}
   };
 
 private:
   RecordType **mptr;
 
 public:
-  MultiPointerTest2(RecordType **p, int) : mptr(p) { // expected-warning{{2 uninitialized fields}}
+  MultiPointerTest2(RecordType **p, int) : mptr(p) { // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
   }
 };
 
@@ -534,6 +565,10 @@ void fMultiPointerTest2() {
   MultiPointerTest2::RecordType *p1 = &i;
   MultiPointerTest2::RecordType **mptr = &p1;
   MultiPointerTest2(mptr, int()); // '**mptr' uninitialized
+  MultiPointerTest2::RecordType ip;
+  MultiPointerTest2::RecordType *p1p = &ip;
+  MultiPointerTest2::RecordType **mptrp = &p1p;
+  new MultiPointerTest2(mptrp, int());
 }
 #else
 class MultiPointerTest2 {
@@ -556,6 +591,7 @@ void fMultiPointerTest2() {
   MultiPointerTest2::RecordType *p1 = &i;
   MultiPointerTest2::RecordType **mptr = &p1;
   MultiPointerTest2(mptr, int()); // '**mptr' uninitialized
+  new MultiPointerTest2(mptr, int());
 }
 #endif // PEDANTIC
 
@@ -580,6 +616,7 @@ void fMultiPointerTest3() {
   MultiPointerTest3::RecordType *p1 = &i;
   MultiPointerTest3::RecordType **mptr = &p1;
   MultiPointerTest3(mptr, int()); // '**mptr' uninitialized
+  new MultiPointerTest3(mptr, int());
 }
 
 //===----------------------------------------------------------------------===//
@@ -597,6 +634,7 @@ struct IncompletePointeeTypeTest {
 
 void fIncompletePointeeTypeTest(void *ptr) {
   IncompletePointeeTypeTest(reinterpret_cast<IncompleteType *>(ptr));
+  new IncompletePointeeTypeTest(reinterpret_cast<IncompleteType *>(ptr));
 }
 
 //===----------------------------------------------------------------------===//
@@ -628,12 +666,13 @@ struct UsefulFunctions {
 
 #ifdef PEDANTIC
 struct PointerToMemberFunctionTest1 {
-  void (UsefulFunctions::*f)(void); // expected-note{{uninitialized field 'this->f'}}
+  void (UsefulFunctions::*f)(void); // expected-note{{uninitialized field 'this->f'}} expected-note{{uninitialized field 'this->f'}}
   PointerToMemberFunctionTest1() {}
 };
 
 void fPointerToMemberFunctionTest1() {
   PointerToMemberFunctionTest1(); // expected-warning{{1 uninitialized field}}
+  new PointerToMemberFunctionTest1(); // expected-warning{{1 uninitialized field}}
 }
 
 struct PointerToMemberFunctionTest2 {
@@ -646,15 +685,17 @@ struct PointerToMemberFunctionTest2 {
 void fPointerToMemberFunctionTest2() {
   void (UsefulFunctions::*f)(void) = &UsefulFunctions::print;
   PointerToMemberFunctionTest2 a(f);
+  new PointerToMemberFunctionTest2(f);
 }
 
 struct MultiPointerToMemberFunctionTest1 {
-  void (UsefulFunctions::**f)(void); // expected-note{{uninitialized pointer 'this->f'}}
+  void (UsefulFunctions::**f)(void); // expected-note{{uninitialized pointer 'this->f'}} expected-note{{uninitialized pointer 'this->f'}}
   MultiPointerToMemberFunctionTest1() {}
 };
 
 void fMultiPointerToMemberFunctionTest1() {
   MultiPointerToMemberFunctionTest1(); // expected-warning{{1 uninitialized field}}
+  new MultiPointerToMemberFunctionTest1(); // expected-warning{{1 uninitialized field}}
 }
 
 struct MultiPointerToMemberFunctionTest2 {
@@ -667,15 +708,17 @@ struct MultiPointerToMemberFunctionTest2 {
 void fMultiPointerToMemberFunctionTest2() {
   void (UsefulFunctions::*f)(void) = &UsefulFunctions::print;
   MultiPointerToMemberFunctionTest2 a(&f);
+  new MultiPointerToMemberFunctionTest2(&f);
 }
 
 struct PointerToMemberDataTest1 {
-  int UsefulFunctions::*d; // expected-note{{uninitialized field 'this->d'}}
+  int UsefulFunctions::*d; // expected-note{{uninitialized field 'this->d'}} expected-note{{uninitialized field 'this->d'}}
   PointerToMemberDataTest1() {}
 };
 
 void fPointerToMemberDataTest1() {
   PointerToMemberDataTest1(); // expected-warning{{1 uninitialized field}}
+  new PointerToMemberDataTest1(); // expected-warning{{1 uninitialized field}}
 }
 
 struct PointerToMemberDataTest2 {
@@ -688,15 +731,17 @@ struct PointerToMemberDataTest2 {
 void fPointerToMemberDataTest2() {
   int UsefulFunctions::*d = &UsefulFunctions::a;
   PointerToMemberDataTest2 a(d);
+  new PointerToMemberDataTest2(d);
 }
 
 struct MultiPointerToMemberDataTest1 {
-  int UsefulFunctions::**d; // expected-note{{uninitialized pointer 'this->d'}}
+  int UsefulFunctions::**d; // expected-note{{uninitialized pointer 'this->d'}} expected-note{{uninitialized pointer 'this->d'}}
   MultiPointerToMemberDataTest1() {}
 };
 
 void fMultiPointerToMemberDataTest1() {
   MultiPointerToMemberDataTest1(); // expected-warning{{1 uninitialized field}}
+  new MultiPointerToMemberDataTest1(); // expected-warning{{1 uninitialized field}}
 }
 
 struct MultiPointerToMemberDataTest2 {
@@ -709,6 +754,7 @@ struct MultiPointerToMemberDataTest2 {
 void fMultiPointerToMemberDataTest2() {
   int UsefulFunctions::*d = &UsefulFunctions::a;
   MultiPointerToMemberDataTest2 a(&d);
+  new MultiPointerToMemberDataTest2(&d);
 }
 #endif // PEDANTIC
 
@@ -734,40 +780,43 @@ public:
 
 void fListTest1() {
   ListTest1();
+  new ListTest1();
 }
 
 class ListTest2 {
 public:
   struct Node {
     Node *next = nullptr;
-    int i; // expected-note{{uninitialized field 'this->head->i'}}
+    int i; // expected-note{{uninitialized field 'this->head->i'}} expected-note{{uninitialized field 'this->head->i'}}
   };
 
 private:
   Node *head = nullptr;
 
 public:
-  ListTest2(Node *node, int) : head(node) { // expected-warning{{1 uninitialized field}}
+  ListTest2(Node *node, int) : head(node) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fListTest2() {
   ListTest2::Node n;
   ListTest2(&n, int());
+  ListTest2::Node np;
+  new ListTest2(&np, int());
 }
 
 class CyclicList {
 public:
   struct Node {
     Node *next = nullptr;
-    int i; // expected-note{{uninitialized field 'this->head->i'}}
+    int i; // expected-note{{uninitialized field 'this->head->i'}} expected-note{{uninitialized field 'this->head->i'}}
   };
 
 private:
   Node *head = nullptr;
 
 public:
-  CyclicList(Node *node, int) : head(node) { // expected-warning{{1 uninitialized field}}
+  CyclicList(Node *node, int) : head(node) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
@@ -788,6 +837,15 @@ void fCyclicList() {
   n1.next = &n3;
   // note that n1.i is uninitialized
   CyclicList(&n1, int());
+  CyclicList::Node n1p;
+  CyclicList::Node n2p;
+  n2p.next = &n1p;
+  n2p.i = 50;
+  CyclicList::Node n3p;
+  n3p.next = &n2p;
+  n3p.i = 50;
+  n1p.next = &n3p;
+  new CyclicList(&n1p, int());
 }
 
 struct RingListTest {
@@ -797,6 +855,7 @@ struct RingListTest {
 
 void fRingListTest() {
   RingListTest();
+  new RingListTest();
 }
 
 //===----------------------------------------------------------------------===//
@@ -823,14 +882,15 @@ public:
 void fReferenceTest1() {
   ReferenceTest1::RecordType d{33, 34};
   ReferenceTest1(d, d);
+  new ReferenceTest1(d, d);
 }
 
 #ifdef PEDANTIC
 class ReferenceTest2 {
 public:
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->lref.x'}}
-    int y; // expected-note{{uninitialized field 'this->lref.y'}}
+    int x; // expected-note{{uninitialized field 'this->lref.x'}} expected-note{{uninitialized field 'this->lref.x'}}
+    int y; // expected-note{{uninitialized field 'this->lref.y'}} expected-note{{uninitialized field 'this->lref.y'}}
   };
 
 private:
@@ -839,13 +899,15 @@ private:
 
 public:
   ReferenceTest2(RecordType &lref, RecordType &rref)
-      : lref(lref), rref(static_cast<RecordType &&>(rref)) { // expected-warning{{2 uninitialized fields}}
+      : lref(lref), rref(static_cast<RecordType &&>(rref)) { // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
   }
 };
 
 void fReferenceTest2() {
   ReferenceTest2::RecordType c;
   ReferenceTest2(c, c);
+  ReferenceTest2::RecordType cp;
+  new ReferenceTest2(cp, cp);
 }
 #else
 class ReferenceTest2 {
@@ -868,14 +930,15 @@ public:
 void fReferenceTest2() {
   ReferenceTest2::RecordType c;
   ReferenceTest2(c, c);
+  new ReferenceTest2(c, c);
 }
 #endif // PEDANTIC
 
 class ReferenceTest3 {
 public:
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->lref.x'}}
-    int y; // expected-note{{uninitialized field 'this->lref.y'}}
+    int x; // expected-note{{uninitialized field 'this->lref.x'}} expected-note{{uninitialized field 'this->lref.x'}}
+    int y; // expected-note{{uninitialized field 'this->lref.y'}} expected-note{{uninitialized field 'this->lref.y'}}
   };
 
 private:
@@ -884,20 +947,22 @@ private:
 
 public:
   ReferenceTest3(RecordType &lref, RecordType &rref)
-      : lref(lref), rref(static_cast<RecordType &&>(rref)) { // expected-warning{{2 uninitialized fields}}
+      : lref(lref), rref(static_cast<RecordType &&>(rref)) { // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
   }
 };
 
 void fReferenceTest3() {
   ReferenceTest3::RecordType c, d{35, 36};
   ReferenceTest3(c, d);
+  ReferenceTest3::RecordType cp, dp{35, 36};
+  new ReferenceTest3(cp, dp);
 }
 
 class ReferenceTest4 {
 public:
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->rref.x'}}
-    int y; // expected-note{{uninitialized field 'this->rref.y'}}
+    int x; // expected-note{{uninitialized field 'this->rref.x'}} expected-note{{uninitialized field 'this->rref.x'}}
+    int y; // expected-note{{uninitialized field 'this->rref.y'}} expected-note{{uninitialized field 'this->rref.y'}}
   };
 
 private:
@@ -906,13 +971,15 @@ private:
 
 public:
   ReferenceTest4(RecordType &lref, RecordType &rref)
-      : lref(lref), rref(static_cast<RecordType &&>(rref)) { // expected-warning{{2 uninitialized fields}}
+      : lref(lref), rref(static_cast<RecordType &&>(rref)) { // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
   }
 };
 
 void fReferenceTest5() {
   ReferenceTest4::RecordType c, d{37, 38};
   ReferenceTest4(d, c);
+  ReferenceTest4::RecordType cp, dp{37, 38};
+  new ReferenceTest4(dp, cp);
 }
 
 //===----------------------------------------------------------------------===//
@@ -920,25 +987,27 @@ void fReferenceTest5() {
 //===----------------------------------------------------------------------===//
 
 struct IntMultipleReferenceToSameObjectTest {
-  int *iptr; // expected-note{{uninitialized pointee 'this->iptr'}}
+  int *iptr; // expected-note{{uninitialized pointee 'this->iptr'}} expected-note{{uninitialized pointee 'this->iptr'}}
   int &iref; // no-note, pointee of this->iref was already reported
 
   int dontGetFilteredByNonPedanticMode = 0;
 
-  IntMultipleReferenceToSameObjectTest(int *i) : iptr(i), iref(*i) {} // expected-warning{{1 uninitialized field}}
+  IntMultipleReferenceToSameObjectTest(int *i) : iptr(i), iref(*i) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fIntMultipleReferenceToSameObjectTest() {
   int a;
   IntMultipleReferenceToSameObjectTest Test(&a);
+  int ap;
+  new IntMultipleReferenceToSameObjectTest(&ap);
 }
 
 struct IntReferenceWrapper1 {
-  int &a; // expected-note{{uninitialized pointee 'this->a'}}
+  int &a; // expected-note{{uninitialized pointee 'this->a'}} expected-note{{uninitialized pointee 'this->a'}}
 
   int dontGetFilteredByNonPedanticMode = 0;
 
-  IntReferenceWrapper1(int &a) : a(a) {} // expected-warning{{1 uninitialized field}}
+  IntReferenceWrapper1(int &a) : a(a) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 struct IntReferenceWrapper2 {
@@ -954,4 +1023,8 @@ void fMultipleObjectsReferencingTheSameObjectTest() {
 
   IntReferenceWrapper1 T1(a);
   IntReferenceWrapper2 T2(a);
+
+  int ap;
+  new IntReferenceWrapper1(ap);
+  new IntReferenceWrapper2(ap);
 }

--- a/clang/test/Analysis/cxx-uninitialized-object-unguarded-access.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object-unguarded-access.cpp
@@ -56,7 +56,9 @@ public:
 
 void fNoUnguardedFieldsTest() {
   NoUnguardedFieldsTest T1(NoUnguardedFieldsTest::Kind::A);
+  new NoUnguardedFieldsTest(NoUnguardedFieldsTest::Kind::A);
   NoUnguardedFieldsTest T2(NoUnguardedFieldsTest::Kind::V);
+  new NoUnguardedFieldsTest(NoUnguardedFieldsTest::Kind::V);
 }
 
 class NoUngardedFieldsNoReturnFuncCalledTest {
@@ -96,8 +98,10 @@ public:
 void fNoUngardedFieldsNoReturnFuncCalledTest() {
   NoUngardedFieldsNoReturnFuncCalledTest
     T1(NoUngardedFieldsNoReturnFuncCalledTest::Kind::A);
+  new NoUngardedFieldsNoReturnFuncCalledTest(NoUngardedFieldsNoReturnFuncCalledTest::Kind::A);
   NoUngardedFieldsNoReturnFuncCalledTest
     T2(NoUngardedFieldsNoReturnFuncCalledTest::Kind::V);
+  new NoUngardedFieldsNoReturnFuncCalledTest(NoUngardedFieldsNoReturnFuncCalledTest::Kind::V);
 }
 
 class NoUnguardedFieldsWithUndefMethodTest {
@@ -141,8 +145,10 @@ public:
 void fNoUnguardedFieldsWithUndefMethodTest() {
   NoUnguardedFieldsWithUndefMethodTest
       T1(NoUnguardedFieldsWithUndefMethodTest::Kind::A);
+  new NoUnguardedFieldsWithUndefMethodTest(NoUnguardedFieldsWithUndefMethodTest::Kind::A);
   NoUnguardedFieldsWithUndefMethodTest
       T2(NoUnguardedFieldsWithUndefMethodTest::Kind::V);
+  new NoUnguardedFieldsWithUndefMethodTest(NoUnguardedFieldsWithUndefMethodTest::Kind::V);
 }
 
 class UnguardedFieldThroughMethodTest {
@@ -153,7 +159,7 @@ public:
   };
 
 private:
-  int Volume, Area; // expected-note {{uninitialized field 'this->Volume'}}
+  int Volume, Area; // expected-note {{uninitialized field 'this->Volume'}} expected-note {{uninitialized field 'this->Volume'}}
   Kind K;
 
 public:
@@ -164,7 +170,7 @@ public:
       break;
     case A:
       Area = 0;
-      break; // expected-warning {{1 uninitialized field}}
+      break; // expected-warning {{1 uninitialized field}} expected-warning {{1 uninitialized field}}
     }
   }
 
@@ -180,6 +186,7 @@ public:
 
 void fUnguardedFieldThroughMethodTest() {
   UnguardedFieldThroughMethodTest T1(UnguardedFieldThroughMethodTest::Kind::A);
+  new UnguardedFieldThroughMethodTest(UnguardedFieldThroughMethodTest::Kind::A);
 }
 
 class UnguardedPublicFieldsTest {
@@ -191,7 +198,7 @@ public:
 
 public:
   // Note that fields are public.
-  int Volume, Area; // expected-note {{uninitialized field 'this->Volume'}}
+  int Volume, Area; // expected-note {{uninitialized field 'this->Volume'}} expected-note {{uninitialized field 'this->Volume'}}
   Kind K;
 
 public:
@@ -202,7 +209,7 @@ public:
       break;
     case A:
       Area = 0;
-      break; // expected-warning {{1 uninitialized field}}
+      break; // expected-warning {{1 uninitialized field}} expected-warning {{1 uninitialized field}}
     }
   }
 
@@ -219,6 +226,7 @@ public:
 
 void fUnguardedPublicFieldsTest() {
   UnguardedPublicFieldsTest T1(UnguardedPublicFieldsTest::Kind::A);
+  new UnguardedPublicFieldsTest(UnguardedPublicFieldsTest::Kind::A);
 }
 
 //===----------------------------------------------------------------------===//
@@ -263,6 +271,7 @@ public:
 
 void fUnguardedFalseNegativeTest1() {
   UnguardedFalseNegativeTest1 T1(UnguardedFalseNegativeTest1::Kind::A);
+  new UnguardedFalseNegativeTest1(UnguardedFalseNegativeTest1::Kind::A);
 }
 
 class UnguardedFalseNegativeTest2 {
@@ -301,6 +310,7 @@ public:
 
 void fUnguardedFalseNegativeTest2() {
   UnguardedFalseNegativeTest2 T1(UnguardedFalseNegativeTest2::Kind::A);
+  new UnguardedFalseNegativeTest2(UnguardedFalseNegativeTest2::Kind::A);
 }
 
 //===----------------------------------------------------------------------===//
@@ -350,7 +360,9 @@ public:
 
 void fIfGuardedFieldsTest() {
   IfGuardedFieldsTest T1(IfGuardedFieldsTest::Kind::A);
+  new IfGuardedFieldsTest(IfGuardedFieldsTest::Kind::A);
   IfGuardedFieldsTest T2(IfGuardedFieldsTest::Kind::V);
+  new IfGuardedFieldsTest(IfGuardedFieldsTest::Kind::V);
 }
 
 class SwitchGuardedFieldsTest {
@@ -397,7 +409,9 @@ public:
 
 void fSwitchGuardedFieldsTest() {
   SwitchGuardedFieldsTest T1(SwitchGuardedFieldsTest::Kind::A);
+  new SwitchGuardedFieldsTest(SwitchGuardedFieldsTest::Kind::A);
   SwitchGuardedFieldsTest T2(SwitchGuardedFieldsTest::Kind::V);
+  new SwitchGuardedFieldsTest(SwitchGuardedFieldsTest::Kind::V);
 }
 
 class ConditionalOperatorGuardedFieldsTest {
@@ -435,6 +449,8 @@ public:
 void fConditionalOperatorGuardedFieldsTest() {
   ConditionalOperatorGuardedFieldsTest
       T1(ConditionalOperatorGuardedFieldsTest::Kind::A);
+  new ConditionalOperatorGuardedFieldsTest(ConditionalOperatorGuardedFieldsTest::Kind::A);
   ConditionalOperatorGuardedFieldsTest
       T2(ConditionalOperatorGuardedFieldsTest::Kind::V);
+  new ConditionalOperatorGuardedFieldsTest(ConditionalOperatorGuardedFieldsTest::Kind::V);
 }

--- a/clang/test/Analysis/cxx-uninitialized-object-unguarded-access.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object-unguarded-access.cpp
@@ -2,6 +2,16 @@
 // RUN:   -analyzer-config optin.cplusplus.UninitializedObject:Pedantic=true -DPEDANTIC \
 // RUN:   -analyzer-config optin.cplusplus.UninitializedObject:IgnoreGuardedFields=true \
 // RUN:   -std=c++11 -verify  %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,optin.cplusplus.UninitializedObject \
+// RUN:   -analyzer-config optin.cplusplus.UninitializedObject:Pedantic=true -DPEDANTIC \
+// RUN:   -analyzer-config optin.cplusplus.UninitializedObject:IgnoreGuardedFields=true \
+// RUN:   -std=c++11 -verify  %s -DHEAP_ALLOCATION
+
+#ifdef HEAP_ALLOCATION
+#define INIT(CLS, ARGS) new CLS ARGS
+#else
+#define INIT(CLS, ARGS) (void) CLS ARGS
+#endif
 
 //===----------------------------------------------------------------------===//
 // Helper functions for tests.
@@ -55,10 +65,8 @@ public:
 };
 
 void fNoUnguardedFieldsTest() {
-  NoUnguardedFieldsTest T1(NoUnguardedFieldsTest::Kind::A);
-  new NoUnguardedFieldsTest(NoUnguardedFieldsTest::Kind::A);
-  NoUnguardedFieldsTest T2(NoUnguardedFieldsTest::Kind::V);
-  new NoUnguardedFieldsTest(NoUnguardedFieldsTest::Kind::V);
+  INIT(NoUnguardedFieldsTest, (NoUnguardedFieldsTest::Kind::A));
+  INIT(NoUnguardedFieldsTest, (NoUnguardedFieldsTest::Kind::V));
 }
 
 class NoUngardedFieldsNoReturnFuncCalledTest {
@@ -96,12 +104,8 @@ public:
 };
 
 void fNoUngardedFieldsNoReturnFuncCalledTest() {
-  NoUngardedFieldsNoReturnFuncCalledTest
-    T1(NoUngardedFieldsNoReturnFuncCalledTest::Kind::A);
-  new NoUngardedFieldsNoReturnFuncCalledTest(NoUngardedFieldsNoReturnFuncCalledTest::Kind::A);
-  NoUngardedFieldsNoReturnFuncCalledTest
-    T2(NoUngardedFieldsNoReturnFuncCalledTest::Kind::V);
-  new NoUngardedFieldsNoReturnFuncCalledTest(NoUngardedFieldsNoReturnFuncCalledTest::Kind::V);
+  INIT(NoUngardedFieldsNoReturnFuncCalledTest, (NoUngardedFieldsNoReturnFuncCalledTest::Kind::A));
+  INIT(NoUngardedFieldsNoReturnFuncCalledTest, (NoUngardedFieldsNoReturnFuncCalledTest::Kind::V));
 }
 
 class NoUnguardedFieldsWithUndefMethodTest {
@@ -143,12 +147,8 @@ public:
 };
 
 void fNoUnguardedFieldsWithUndefMethodTest() {
-  NoUnguardedFieldsWithUndefMethodTest
-      T1(NoUnguardedFieldsWithUndefMethodTest::Kind::A);
-  new NoUnguardedFieldsWithUndefMethodTest(NoUnguardedFieldsWithUndefMethodTest::Kind::A);
-  NoUnguardedFieldsWithUndefMethodTest
-      T2(NoUnguardedFieldsWithUndefMethodTest::Kind::V);
-  new NoUnguardedFieldsWithUndefMethodTest(NoUnguardedFieldsWithUndefMethodTest::Kind::V);
+  INIT(NoUnguardedFieldsWithUndefMethodTest, (NoUnguardedFieldsWithUndefMethodTest::Kind::A));
+  INIT(NoUnguardedFieldsWithUndefMethodTest, (NoUnguardedFieldsWithUndefMethodTest::Kind::V));
 }
 
 class UnguardedFieldThroughMethodTest {
@@ -159,7 +159,7 @@ public:
   };
 
 private:
-  int Volume, Area; // expected-note {{uninitialized field 'this->Volume'}} expected-note {{uninitialized field 'this->Volume'}}
+  int Volume, Area; // expected-note {{uninitialized field 'this->Volume'}}
   Kind K;
 
 public:
@@ -170,7 +170,7 @@ public:
       break;
     case A:
       Area = 0;
-      break; // expected-warning {{1 uninitialized field}} expected-warning {{1 uninitialized field}}
+      break; // expected-warning {{1 uninitialized field}}
     }
   }
 
@@ -185,8 +185,7 @@ public:
 };
 
 void fUnguardedFieldThroughMethodTest() {
-  UnguardedFieldThroughMethodTest T1(UnguardedFieldThroughMethodTest::Kind::A);
-  new UnguardedFieldThroughMethodTest(UnguardedFieldThroughMethodTest::Kind::A);
+  INIT(UnguardedFieldThroughMethodTest, (UnguardedFieldThroughMethodTest::Kind::A));
 }
 
 class UnguardedPublicFieldsTest {
@@ -198,7 +197,7 @@ public:
 
 public:
   // Note that fields are public.
-  int Volume, Area; // expected-note {{uninitialized field 'this->Volume'}} expected-note {{uninitialized field 'this->Volume'}}
+  int Volume, Area; // expected-note {{uninitialized field 'this->Volume'}}
   Kind K;
 
 public:
@@ -209,7 +208,7 @@ public:
       break;
     case A:
       Area = 0;
-      break; // expected-warning {{1 uninitialized field}} expected-warning {{1 uninitialized field}}
+      break; // expected-warning {{1 uninitialized field}}
     }
   }
 
@@ -225,8 +224,7 @@ public:
 };
 
 void fUnguardedPublicFieldsTest() {
-  UnguardedPublicFieldsTest T1(UnguardedPublicFieldsTest::Kind::A);
-  new UnguardedPublicFieldsTest(UnguardedPublicFieldsTest::Kind::A);
+  INIT(UnguardedPublicFieldsTest, (UnguardedPublicFieldsTest::Kind::A));
 }
 
 //===----------------------------------------------------------------------===//
@@ -270,8 +268,7 @@ public:
 };
 
 void fUnguardedFalseNegativeTest1() {
-  UnguardedFalseNegativeTest1 T1(UnguardedFalseNegativeTest1::Kind::A);
-  new UnguardedFalseNegativeTest1(UnguardedFalseNegativeTest1::Kind::A);
+  INIT(UnguardedFalseNegativeTest1, (UnguardedFalseNegativeTest1::Kind::A));
 }
 
 class UnguardedFalseNegativeTest2 {
@@ -309,8 +306,7 @@ public:
 };
 
 void fUnguardedFalseNegativeTest2() {
-  UnguardedFalseNegativeTest2 T1(UnguardedFalseNegativeTest2::Kind::A);
-  new UnguardedFalseNegativeTest2(UnguardedFalseNegativeTest2::Kind::A);
+  INIT(UnguardedFalseNegativeTest2, (UnguardedFalseNegativeTest2::Kind::A));
 }
 
 //===----------------------------------------------------------------------===//
@@ -359,10 +355,8 @@ public:
 };
 
 void fIfGuardedFieldsTest() {
-  IfGuardedFieldsTest T1(IfGuardedFieldsTest::Kind::A);
-  new IfGuardedFieldsTest(IfGuardedFieldsTest::Kind::A);
-  IfGuardedFieldsTest T2(IfGuardedFieldsTest::Kind::V);
-  new IfGuardedFieldsTest(IfGuardedFieldsTest::Kind::V);
+  INIT(IfGuardedFieldsTest, (IfGuardedFieldsTest::Kind::A));
+  INIT(IfGuardedFieldsTest, (IfGuardedFieldsTest::Kind::V));
 }
 
 class SwitchGuardedFieldsTest {
@@ -408,10 +402,8 @@ public:
 };
 
 void fSwitchGuardedFieldsTest() {
-  SwitchGuardedFieldsTest T1(SwitchGuardedFieldsTest::Kind::A);
-  new SwitchGuardedFieldsTest(SwitchGuardedFieldsTest::Kind::A);
-  SwitchGuardedFieldsTest T2(SwitchGuardedFieldsTest::Kind::V);
-  new SwitchGuardedFieldsTest(SwitchGuardedFieldsTest::Kind::V);
+  INIT(SwitchGuardedFieldsTest, (SwitchGuardedFieldsTest::Kind::A));
+  INIT(SwitchGuardedFieldsTest, (SwitchGuardedFieldsTest::Kind::V));
 }
 
 class ConditionalOperatorGuardedFieldsTest {
@@ -447,10 +439,6 @@ public:
 };
 
 void fConditionalOperatorGuardedFieldsTest() {
-  ConditionalOperatorGuardedFieldsTest
-      T1(ConditionalOperatorGuardedFieldsTest::Kind::A);
-  new ConditionalOperatorGuardedFieldsTest(ConditionalOperatorGuardedFieldsTest::Kind::A);
-  ConditionalOperatorGuardedFieldsTest
-      T2(ConditionalOperatorGuardedFieldsTest::Kind::V);
-  new ConditionalOperatorGuardedFieldsTest(ConditionalOperatorGuardedFieldsTest::Kind::V);
+  INIT(ConditionalOperatorGuardedFieldsTest, (ConditionalOperatorGuardedFieldsTest::Kind::A));
+  INIT(ConditionalOperatorGuardedFieldsTest, (ConditionalOperatorGuardedFieldsTest::Kind::V));
 }

--- a/clang/test/Analysis/cxx-uninitialized-object-unionlike-constructs.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object-unionlike-constructs.cpp
@@ -2,6 +2,10 @@
 // RUN:   -analyzer-config optin.cplusplus.UninitializedObject:Pedantic=true -DPEDANTIC \
 // RUN:   -analyzer-config optin.cplusplus.UninitializedObject:IgnoreRecordsWithField="[Tt]ag|[Kk]ind" \
 // RUN:   -std=c++11 -verify  %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,optin.cplusplus.UninitializedObject \
+// RUN:   -analyzer-config optin.cplusplus.UninitializedObject:Pedantic=true -DPEDANTIC \
+// RUN:   -analyzer-config optin.cplusplus.UninitializedObject:IgnoreRecordsWithField="[Tt]ag|[Kk]ind" \
+// RUN:   -std=c++11 -verify  %s -DHEAP_ALLOCATION
 
 // RUN: not %clang_analyze_cc1 -verify %s \
 // RUN:   -analyzer-checker=core \
@@ -16,6 +20,11 @@
 // CHECK-UNINIT-INVALID-REGEX-SAME: with error message "parentheses not
 // CHECK-UNINIT-INVALID-REGEX-SAME: balanced"
 
+#ifdef HEAP_ALLOCATION
+#define INIT(CLS, ARGS) new CLS ARGS
+#else
+#define INIT(CLS, ARGS) (void) CLS ARGS
+#endif
 
 // expected-no-diagnostics
 
@@ -42,8 +51,7 @@ struct UnionLikeStruct1 {
 };
 
 void fUnionLikeStruct1() {
-  UnionLikeStruct1 t(UnionLikeStruct1::volume, 10);
-  new UnionLikeStruct1(UnionLikeStruct1::volume, 10);
+  INIT(UnionLikeStruct1, (UnionLikeStruct1::volume, 10));
 }
 
 // Only name contains "kind".
@@ -69,8 +77,7 @@ struct UnionLikeStruct2 {
 };
 
 void fUnionLikeStruct2() {
-  UnionLikeStruct2 t(UnionLikeStruct2::volume, 10);
-  new UnionLikeStruct2(UnionLikeStruct2::volume, 10);
+  INIT(UnionLikeStruct2, (UnionLikeStruct2::volume, 10));
 }
 
 // Only type contains "kind".
@@ -96,8 +103,7 @@ struct UnionLikeStruct3 {
 };
 
 void fUnionLikeStruct3() {
-  UnionLikeStruct3 t(UnionLikeStruct3::volume, 10);
-  new UnionLikeStruct3(UnionLikeStruct3::volume, 10);
+  INIT(UnionLikeStruct3, (UnionLikeStruct3::volume, 10));
 }
 
 // Only type contains "tag".
@@ -123,8 +129,7 @@ struct UnionLikeStruct4 {
 };
 
 void fUnionLikeStruct4() {
-  UnionLikeStruct4 t(UnionLikeStruct4::volume, 10);
-  new UnionLikeStruct4(UnionLikeStruct4::volume, 10);
+  INIT(UnionLikeStruct4, (UnionLikeStruct4::volume, 10));
 }
 
 // Both name and type name contains but does not equal to tag/kind.
@@ -150,6 +155,5 @@ struct UnionLikeStruct5 {
 };
 
 void fUnionLikeStruct5() {
-  UnionLikeStruct5 t(UnionLikeStruct5::volume, 10);
-  new UnionLikeStruct5(UnionLikeStruct5::volume, 10);
+  INIT(UnionLikeStruct5, (UnionLikeStruct5::volume, 10));
 }

--- a/clang/test/Analysis/cxx-uninitialized-object-unionlike-constructs.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object-unionlike-constructs.cpp
@@ -43,6 +43,7 @@ struct UnionLikeStruct1 {
 
 void fUnionLikeStruct1() {
   UnionLikeStruct1 t(UnionLikeStruct1::volume, 10);
+  new UnionLikeStruct1(UnionLikeStruct1::volume, 10);
 }
 
 // Only name contains "kind".
@@ -69,6 +70,7 @@ struct UnionLikeStruct2 {
 
 void fUnionLikeStruct2() {
   UnionLikeStruct2 t(UnionLikeStruct2::volume, 10);
+  new UnionLikeStruct2(UnionLikeStruct2::volume, 10);
 }
 
 // Only type contains "kind".
@@ -95,6 +97,7 @@ struct UnionLikeStruct3 {
 
 void fUnionLikeStruct3() {
   UnionLikeStruct3 t(UnionLikeStruct3::volume, 10);
+  new UnionLikeStruct3(UnionLikeStruct3::volume, 10);
 }
 
 // Only type contains "tag".
@@ -121,6 +124,7 @@ struct UnionLikeStruct4 {
 
 void fUnionLikeStruct4() {
   UnionLikeStruct4 t(UnionLikeStruct4::volume, 10);
+  new UnionLikeStruct4(UnionLikeStruct4::volume, 10);
 }
 
 // Both name and type name contains but does not equal to tag/kind.
@@ -147,4 +151,5 @@ struct UnionLikeStruct5 {
 
 void fUnionLikeStruct5() {
   UnionLikeStruct5 t(UnionLikeStruct5::volume, 10);
+  new UnionLikeStruct5(UnionLikeStruct5::volume, 10);
 }

--- a/clang/test/Analysis/cxx-uninitialized-object.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object.cpp
@@ -24,11 +24,12 @@ public:
 
 void fCompilerGeneratedConstructorTest() {
   CompilerGeneratedConstructorTest();
+  new CompilerGeneratedConstructorTest();
 }
 
 #ifdef PEDANTIC
 class DefaultConstructorTest {
-  int a; // expected-note{{uninitialized field 'this->a'}}
+  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
 
 public:
   DefaultConstructorTest();
@@ -38,6 +39,7 @@ DefaultConstructorTest::DefaultConstructorTest() = default;
 
 void fDefaultConstructorTest() {
   DefaultConstructorTest(); // expected-warning{{1 uninitialized field}}
+  new DefaultConstructorTest(); // expected-warning{{1 uninitialized field}}
 }
 #else
 class DefaultConstructorTest {
@@ -51,6 +53,7 @@ DefaultConstructorTest::DefaultConstructorTest() = default;
 
 void fDefaultConstructorTest() {
   DefaultConstructorTest();
+  new DefaultConstructorTest();
 }
 #endif // PEDANTIC
 
@@ -72,32 +75,35 @@ public:
 
 void fInitListTest1() {
   InitListTest1();
+  new InitListTest1();
 }
 
 class InitListTest2 {
   int a;
-  int b; // expected-note{{uninitialized field 'this->b'}}
+  int b; // expected-note{{uninitialized field 'this->b'}} expected-note{{uninitialized field 'this->b'}}
 
 public:
   InitListTest2()
-      : a(3) {} // expected-warning{{1 uninitialized field}}
+      : a(3) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fInitListTest2() {
   InitListTest2();
+  new InitListTest2();
 }
 
 class InitListTest3 {
-  int a; // expected-note{{uninitialized field 'this->a'}}
+  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
   int b;
 
 public:
   InitListTest3()
-      : b(4) {} // expected-warning{{1 uninitialized field}}
+      : b(4) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fInitListTest3() {
   InitListTest3();
+  new InitListTest3();
 }
 
 //===----------------------------------------------------------------------===//
@@ -117,40 +123,43 @@ public:
 
 void fCtorBodyTest1() {
   CtorBodyTest1();
+  new CtorBodyTest1();
 }
 
 class CtorBodyTest2 {
   int a;
-  int b; // expected-note{{uninitialized field 'this->b'}}
+  int b; // expected-note{{uninitialized field 'this->b'}} expected-note{{uninitialized field 'this->b'}}
 
 public:
   CtorBodyTest2() {
-    a = 7; // expected-warning{{1 uninitialized field}}
+    a = 7; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fCtorBodyTest2() {
   CtorBodyTest2();
+  new CtorBodyTest2();
 }
 
 class CtorBodyTest3 {
-  int a; // expected-note{{uninitialized field 'this->a'}}
+  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
   int b;
 
 public:
   CtorBodyTest3() {
-    b = 8; // expected-warning{{1 uninitialized field}}
+    b = 8; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fCtorBodyTest3() {
   CtorBodyTest3();
+  new CtorBodyTest3();
 }
 
 #ifdef PEDANTIC
 class CtorBodyTest4 {
-  int a; // expected-note{{uninitialized field 'this->a'}}
-  int b; // expected-note{{uninitialized field 'this->b'}}
+  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
+  int b; // expected-note{{uninitialized field 'this->b'}} expected-note{{uninitialized field 'this->b'}}
 
 public:
   CtorBodyTest4() {}
@@ -158,6 +167,7 @@ public:
 
 void fCtorBodyTest4() {
   CtorBodyTest4(); // expected-warning{{2 uninitialized fields}}
+  new CtorBodyTest4(); // expected-warning{{2 uninitialized fields}}
 }
 #else
 class CtorBodyTest4 {
@@ -170,6 +180,7 @@ public:
 
 void fCtorBodyTest4() {
   CtorBodyTest4();
+  new CtorBodyTest4();
 }
 #endif
 
@@ -196,10 +207,11 @@ public:
 
 void fCtorDelegationTest1() {
   CtorDelegationTest1();
+  new CtorDelegationTest1();
 }
 
 class CtorDelegationTest2 {
-  int a; // expected-note{{uninitialized field 'this->a'}}
+  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
   int b;
 
 public:
@@ -209,12 +221,13 @@ public:
   }
 
   CtorDelegationTest2()
-      : CtorDelegationTest2(int{}) { // expected-warning{{1 uninitialized field}}
+      : CtorDelegationTest2(int{}) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fCtorDelegationTest2() {
   CtorDelegationTest2();
+  new CtorDelegationTest2();
 }
 
 //===----------------------------------------------------------------------===//
@@ -239,12 +252,13 @@ public:
 
 void fContainsRecordTest1() {
   ContainsRecordTest1();
+  new ContainsRecordTest1();
 }
 
 class ContainsRecordTest2 {
   struct RecordType {
     int x;
-    int y; // expected-note{{uninitialized field 'this->rec.y'}}
+    int y; // expected-note{{uninitialized field 'this->rec.y'}} expected-note{{uninitialized field 'this->rec.y'}}
   } rec;
   int c, d;
 
@@ -252,47 +266,50 @@ public:
   ContainsRecordTest2()
       : c(16),
         d(17) {
-    rec.x = 18; // expected-warning{{1 uninitialized field}}
+    rec.x = 18; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fContainsRecordTest2() {
   ContainsRecordTest2();
+  new ContainsRecordTest2();
 }
 
 class ContainsRecordTest3 {
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->rec.x'}}
-    int y; // expected-note{{uninitialized field 'this->rec.y'}}
+    int x; // expected-note{{uninitialized field 'this->rec.x'}} expected-note{{uninitialized field 'this->rec.x'}}
+    int y; // expected-note{{uninitialized field 'this->rec.y'}} expected-note{{uninitialized field 'this->rec.y'}}
   } rec;
   int c, d;
 
 public:
   ContainsRecordTest3()
       : c(19),
-        d(20) { // expected-warning{{2 uninitialized fields}}
+        d(20) { // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
   }
 };
 
 void fContainsRecordTest3() {
   ContainsRecordTest3();
+  new ContainsRecordTest3();
 }
 
 class ContainsRecordTest4 {
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->rec.x'}}
-    int y; // expected-note{{uninitialized field 'this->rec.y'}}
+    int x; // expected-note{{uninitialized field 'this->rec.x'}} expected-note{{uninitialized field 'this->rec.x'}}
+    int y; // expected-note{{uninitialized field 'this->rec.y'}} expected-note{{uninitialized field 'this->rec.y'}}
   } rec;
-  int c, d; // expected-note{{uninitialized field 'this->d'}}
+  int c, d; // expected-note{{uninitialized field 'this->d'}} expected-note{{uninitialized field 'this->d'}}
 
 public:
   ContainsRecordTest4()
-      : c(19) { // expected-warning{{3 uninitialized fields}}
+      : c(19) { // expected-warning{{3 uninitialized fields}} expected-warning{{3 uninitialized fields}}
   }
 };
 
 void fContainsRecordTest4() {
   ContainsRecordTest4();
+  new ContainsRecordTest4();
 }
 
 //===----------------------------------------------------------------------===//
@@ -314,26 +331,28 @@ public:
 
 void fIntTemplateClassTest1() {
   IntTemplateClassTest1<int>(22);
+  new IntTemplateClassTest1<int>(22);
 }
 
 template <class T>
 class IntTemplateClassTest2 {
-  T t; // expected-note{{uninitialized field 'this->t'}}
+  T t; // expected-note{{uninitialized field 'this->t'}} expected-note{{uninitialized field 'this->t'}}
   int b;
 
 public:
   IntTemplateClassTest2() {
-    b = 23; // expected-warning{{1 uninitialized field}}
+    b = 23; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fIntTemplateClassTest2() {
   IntTemplateClassTest2<int>();
+  new IntTemplateClassTest2<int>();
 }
 
 struct Record {
-  int x; // expected-note{{uninitialized field 'this->t.x'}}
-  int y; // expected-note{{uninitialized field 'this->t.y'}}
+  int x; // expected-note{{uninitialized field 'this->t.x'}} expected-note{{uninitialized field 'this->t.x'}}
+  int y; // expected-note{{uninitialized field 'this->t.y'}} expected-note{{uninitialized field 'this->t.y'}}
 };
 
 template <class T>
@@ -343,12 +362,13 @@ class RecordTemplateClassTest {
 
 public:
   RecordTemplateClassTest() {
-    b = 24; // expected-warning{{2 uninitialized fields}}
+    b = 24; // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
   }
 };
 
 void fRecordTemplateClassTest() {
   RecordTemplateClassTest<Record>();
+  new RecordTemplateClassTest<Record>();
 }
 
 //===----------------------------------------------------------------------===//
@@ -384,23 +404,27 @@ public:
 
 void fPassingToUnknownFunctionTest1() {
   PassingToUnknownFunctionTest1();
+  new PassingToUnknownFunctionTest1();
   PassingToUnknownFunctionTest1(int());
+  new PassingToUnknownFunctionTest1(int());
   PassingToUnknownFunctionTest1(int(), int());
+  new PassingToUnknownFunctionTest1(int(), int());
 }
 
 class PassingToUnknownFunctionTest2 {
-  int a; // expected-note{{uninitialized field 'this->a'}}
+  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
   int b;
 
 public:
   PassingToUnknownFunctionTest2() {
     wontInitialize(a);
-    b = 4; // expected-warning{{1 uninitialized field}}
+    b = 4; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 };
 
 void fPassingToUnknownFunctionTest2() {
   PassingToUnknownFunctionTest2();
+  new PassingToUnknownFunctionTest2();
 }
 
 //===----------------------------------------------------------------------===//
@@ -428,6 +452,7 @@ public:
 
 void fContainsSimpleUnionTest1() {
   ContainsSimpleUnionTest1();
+  new ContainsSimpleUnionTest1();
 }
 
 class ContainsSimpleUnionTest2 {
@@ -445,6 +470,7 @@ public:
 void fContainsSimpleUnionTest2() {
   // TODO: we'd expect the warning: {{1 uninitialized field}}
   ContainsSimpleUnionTest2(); // no-warning
+  new ContainsSimpleUnionTest2(); // no-warning
 }
 
 class UnionPointerTest1 {
@@ -468,6 +494,7 @@ void fUnionPointerTest1() {
   UnionPointerTest1::SimpleUnion u;
   u.uf = 41;
   UnionPointerTest1(&u, int());
+  new UnionPointerTest1(&u, int());
 }
 
 class UnionPointerTest2 {
@@ -490,6 +517,7 @@ void fUnionPointerTest2() {
   UnionPointerTest2::SimpleUnion u;
   // TODO: we'd expect the warning: {{1 uninitialized field}}
   UnionPointerTest2(&u, int()); // no-warning
+  new UnionPointerTest2(&u, int()); // no-warning
 }
 
 class ContainsUnionWithRecordTest1 {
@@ -513,6 +541,7 @@ public:
 
 void fContainsUnionWithRecordTest1() {
   ContainsUnionWithRecordTest1();
+  new ContainsUnionWithRecordTest1();
 }
 
 class ContainsUnionWithRecordTest2 {
@@ -536,6 +565,7 @@ public:
 
 void fContainsUnionWithRecordTest2() {
   ContainsUnionWithRecordTest1();
+  new ContainsUnionWithRecordTest1();
 }
 
 class ContainsUnionWithRecordTest3 {
@@ -562,6 +592,7 @@ public:
 
 void fContainsUnionWithRecordTest3() {
   ContainsUnionWithRecordTest3();
+  new ContainsUnionWithRecordTest3();
 }
 
 class ContainsUnionWithSimpleUnionTest1 {
@@ -584,6 +615,7 @@ public:
 
 void fContainsUnionWithSimpleUnionTest1() {
   ContainsUnionWithSimpleUnionTest1();
+  new ContainsUnionWithSimpleUnionTest1();
 }
 
 class ContainsUnionWithSimpleUnionTest2 {
@@ -605,6 +637,7 @@ public:
 void fContainsUnionWithSimpleUnionTest2() {
   // TODO: we'd expect the warning: {{1 uninitialized field}}
   ContainsUnionWithSimpleUnionTest2(); // no-warning
+  new ContainsUnionWithSimpleUnionTest2(); // no-warning
 }
 
 //===----------------------------------------------------------------------===//
@@ -628,7 +661,7 @@ void funcToSquelchCompilerWarnings(const T &t);
 
 #ifdef PEDANTIC
 struct CopyConstructorTest {
-  int i; // expected-note{{uninitialized field 'this->i'}}
+  int i; // expected-note{{uninitialized field 'this->i'}} expected-note{{uninitialized field 'this->i'}}
 
   CopyConstructorTest() : i(1337) {}
   CopyConstructorTest(const CopyConstructorTest &other) {}
@@ -637,6 +670,7 @@ struct CopyConstructorTest {
 void fCopyConstructorTest() {
   CopyConstructorTest cct;
   CopyConstructorTest copy = cct; // expected-warning{{1 uninitialized field}}
+  new CopyConstructorTest(cct); // expected-warning{{1 uninitialized field}}
   funcToSquelchCompilerWarnings(copy);
 }
 #else
@@ -650,6 +684,7 @@ struct CopyConstructorTest {
 void fCopyConstructorTest() {
   CopyConstructorTest cct;
   CopyConstructorTest copy = cct;
+  new CopyConstructorTest(cct);
   funcToSquelchCompilerWarnings(copy);
 }
 #endif // PEDANTIC
@@ -667,6 +702,7 @@ void fMoveConstructorTest() {
   MoveConstructorTest cct;
   // TODO: we'd expect the warning: {{1 uninitialized field}}
   MoveConstructorTest copy(static_cast<MoveConstructorTest &&>(cct)); // no-warning
+  new MoveConstructorTest(static_cast<MoveConstructorTest &&>(cct)); // no-warning
   funcToSquelchCompilerWarnings(copy);
 }
 
@@ -684,6 +720,7 @@ struct IntArrayTest {
 
 void fIntArrayTest() {
   IntArrayTest();
+  new IntArrayTest();
 }
 
 struct RecordTypeArrayTest {
@@ -698,6 +735,7 @@ struct RecordTypeArrayTest {
 
 void fRecordTypeArrayTest() {
   RecordTypeArrayTest();
+  new RecordTypeArrayTest();
 }
 
 template <class T>
@@ -727,6 +765,7 @@ struct MemsetTest1 {
 
 void fMemsetTest1() {
   MemsetTest1();
+  new MemsetTest1();
 }
 
 struct MemsetTest2 {
@@ -739,6 +778,7 @@ struct MemsetTest2 {
 
 void fMemsetTest2() {
   MemsetTest2();
+  new MemsetTest2();
 }
 
 //===----------------------------------------------------------------------===//
@@ -773,6 +813,7 @@ struct LambdaTest1 {
 void fLambdaTest1() {
   auto isEven = [](int a) { return a % 2 == 0; };
   LambdaTest1<decltype(isEven)>(isEven, int());
+  new LambdaTest1<decltype(isEven)>(isEven, int());
 }
 
 #ifdef PEDANTIC
@@ -780,13 +821,16 @@ template <class Callable>
 struct LambdaTest2 {
   Callable functor;
 
-  LambdaTest2(const Callable &functor, int) : functor(functor) {} // expected-warning{{1 uninitialized field}}
+  LambdaTest2(const Callable &functor, int) : functor(functor) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fLambdaTest2() {
   int b;
   auto equals = [&b](int a) { return a == b; }; // expected-note{{uninitialized pointee 'this->functor./*captured variable*/b'}}
   LambdaTest2<decltype(equals)>(equals, int());
+  int bp;
+  auto equalsp = [&bp](int a) { return a == bp; }; // expected-note{{uninitialized pointee 'this->functor./*captured variable*/bp'}}
+  new LambdaTest2<decltype(equalsp)>(equalsp, int());
 }
 #else
 template <class Callable>
@@ -800,6 +844,7 @@ void fLambdaTest2() {
   int b;
   auto equals = [&b](int a) { return a == b; };
   LambdaTest2<decltype(equals)>(equals, int());
+  new LambdaTest2<decltype(equals)>(equals, int());
 }
 #endif //PEDANTIC
 
@@ -807,8 +852,8 @@ void fLambdaTest2() {
 namespace LT3Detail {
 
 struct RecordType {
-  int x; // expected-note{{uninitialized field 'this->functor./*captured variable*/rec1.x'}}
-  int y; // expected-note{{uninitialized field 'this->functor./*captured variable*/rec1.y'}}
+  int x; // expected-note{{uninitialized field 'this->functor./*captured variable*/rec1.x'}} expected-note{{uninitialized field 'this->functor./*captured variable*/rec1p.x'}}
+  int y; // expected-note{{uninitialized field 'this->functor./*captured variable*/rec1.y'}} expected-note{{uninitialized field 'this->functor./*captured variable*/rec1p.y'}}
 };
 
 } // namespace LT3Detail
@@ -816,7 +861,7 @@ template <class Callable>
 struct LambdaTest3 {
   Callable functor;
 
-  LambdaTest3(const Callable &functor, int) : functor(functor) {} // expected-warning{{2 uninitialized fields}}
+  LambdaTest3(const Callable &functor, int) : functor(functor) {} // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
 };
 
 void fLambdaTest3() {
@@ -825,6 +870,11 @@ void fLambdaTest3() {
     return rec1.x == rec2.x;
   };
   LambdaTest3<decltype(equals)>(equals, int());
+  LT3Detail::RecordType rec1p;
+  auto equalsp = [&rec1p](LT3Detail::RecordType rec2) {
+    return rec1p.x == rec2.x;
+  };
+  new LambdaTest3<decltype(equalsp)>(equalsp, int());
 }
 #else
 namespace LT3Detail {
@@ -848,6 +898,7 @@ void fLambdaTest3() {
     return rec1.x == rec2.x;
   };
   LambdaTest3<decltype(equals)>(equals, int());
+  new LambdaTest3<decltype(equals)>(equals, int());
 }
 #endif //PEDANTIC
 
@@ -856,7 +907,7 @@ struct MultipleLambdaCapturesTest1 {
   Callable functor;
   int dontGetFilteredByNonPedanticMode = 0;
 
-  MultipleLambdaCapturesTest1(const Callable &functor, int) : functor(functor) {} // expected-warning{{2 uninitialized field}}
+  MultipleLambdaCapturesTest1(const Callable &functor, int) : functor(functor) {} // expected-warning{{2 uninitialized field}} expected-warning{{2 uninitialized field}}
 };
 
 void fMultipleLambdaCapturesTest1() {
@@ -864,6 +915,10 @@ void fMultipleLambdaCapturesTest1() {
   auto equals = [&b1, &b2, &b3](int a) { return a == b1 == b2 == b3; }; // expected-note{{uninitialized pointee 'this->functor./*captured variable*/b1'}}
   // expected-note@-1{{uninitialized pointee 'this->functor./*captured variable*/b3'}}
   MultipleLambdaCapturesTest1<decltype(equals)>(equals, int());
+  int b1p, b2p = 3, b3p;
+  auto equalsp = [&b1p, &b2p, &b3p](int a) { return a == b1p == b2p == b3p; }; // expected-note{{uninitialized pointee 'this->functor./*captured variable*/b1p'}}
+  // expected-note@-1{{uninitialized pointee 'this->functor./*captured variable*/b3p'}}
+  new MultipleLambdaCapturesTest1<decltype(equalsp)>(equalsp, int());
 }
 
 template <class Callable>
@@ -871,13 +926,16 @@ struct MultipleLambdaCapturesTest2 {
   Callable functor;
   int dontGetFilteredByNonPedanticMode = 0;
 
-  MultipleLambdaCapturesTest2(const Callable &functor, int) : functor(functor) {} // expected-warning{{1 uninitialized field}}
+  MultipleLambdaCapturesTest2(const Callable &functor, int) : functor(functor) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fMultipleLambdaCapturesTest2() {
   int b1, b2 = 3, b3;
   auto equals = [b1, &b2, &b3](int a) { return a == b1 == b2 == b3; }; // expected-note{{uninitialized pointee 'this->functor./*captured variable*/b3'}}
   MultipleLambdaCapturesTest2<decltype(equals)>(equals, int());
+  int b1p, b2p = 3, b3p;
+  auto equalsp = [b1p, &b2p, &b3p](int a) { return a == b1p == b2p == b3p; }; // expected-note{{uninitialized pointee 'this->functor./*captured variable*/b3p'}}
+  new MultipleLambdaCapturesTest2<decltype(equalsp)>(equalsp, int());
 }
 
 struct LambdaWrapper {
@@ -921,22 +979,24 @@ struct SystemHeaderTest1 {
 
 void fSystemHeaderTest1() {
   SystemHeaderTest1();
+  new SystemHeaderTest1();
 }
 
 #ifdef PEDANTIC
 struct SystemHeaderTest2 {
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->container.t.x}}
-    int y; // expected-note{{uninitialized field 'this->container.t.y}}
+    int x; // expected-note{{uninitialized field 'this->container.t.x}} expected-note{{uninitialized field 'this->container.t.x}}
+    int y; // expected-note{{uninitialized field 'this->container.t.y}} expected-note{{uninitialized field 'this->container.t.y}}
   };
   ContainerInSystemHeader<RecordType> container;
 
-  SystemHeaderTest2(RecordType &rec, int) : container(rec) {} // expected-warning{{2 uninitialized fields}}
+  SystemHeaderTest2(RecordType &rec, int) : container(rec) {} // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
 };
 
 void fSystemHeaderTest2() {
-  SystemHeaderTest2::RecordType rec;
+  SystemHeaderTest2::RecordType rec, recp;
   SystemHeaderTest2(rec, int());
+  new SystemHeaderTest2(recp, int());
 }
 #else
 struct SystemHeaderTest2 {
@@ -952,6 +1012,7 @@ struct SystemHeaderTest2 {
 void fSystemHeaderTest2() {
   SystemHeaderTest2::RecordType rec;
   SystemHeaderTest2(rec, int());
+  new SystemHeaderTest2(rec, int());
 }
 #endif //PEDANTIC
 
@@ -962,14 +1023,15 @@ void fSystemHeaderTest2() {
 struct IncompleteTypeTest1 {
   struct RecordType;
   // no-crash
-  RecordType *recptr; // expected-note{{uninitialized pointer 'this->recptr}}
+  RecordType *recptr; // expected-note{{uninitialized pointer 'this->recptr}} expected-note{{uninitialized pointer 'this->recptr}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  IncompleteTypeTest1() {} // expected-warning{{1 uninitialized field}}
+  IncompleteTypeTest1() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fIncompleteTypeTest1() {
   IncompleteTypeTest1();
+  new IncompleteTypeTest1();
 }
 
 struct IncompleteTypeTest2 {
@@ -984,6 +1046,7 @@ struct IncompleteTypeTest2 {
 
 void fIncompleteTypeTest2() {
   IncompleteTypeTest2();
+  new IncompleteTypeTest2();
 }
 
 struct IncompleteTypeTest3 {
@@ -998,6 +1061,7 @@ struct IncompleteTypeTest3 {
 
 void fIncompleteTypeTest3() {
   IncompleteTypeTest3();
+  new IncompleteTypeTest3();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1005,54 +1069,58 @@ void fIncompleteTypeTest3() {
 //===----------------------------------------------------------------------===//
 
 struct IntegralTypeTest {
-  int a; // expected-note{{uninitialized field 'this->a'}}
+  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  IntegralTypeTest() {} // expected-warning{{1 uninitialized field}}
+  IntegralTypeTest() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fIntegralTypeTest() {
   IntegralTypeTest();
+  new IntegralTypeTest();
 }
 
 struct FloatingTypeTest {
-  float a; // expected-note{{uninitialized field 'this->a'}}
+  float a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  FloatingTypeTest() {} // expected-warning{{1 uninitialized field}}
+  FloatingTypeTest() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fFloatingTypeTest() {
   FloatingTypeTest();
+  new FloatingTypeTest();
 }
 
 struct NullptrTypeTypeTest {
-  decltype(nullptr) a; // expected-note{{uninitialized field 'this->a'}}
+  decltype(nullptr) a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  NullptrTypeTypeTest() {} // expected-warning{{1 uninitialized field}}
+  NullptrTypeTypeTest() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void fNullptrTypeTypeTest() {
   NullptrTypeTypeTest();
+  new NullptrTypeTypeTest();
 }
 
 struct EnumTest {
   enum Enum {
     A,
     B
-  } enum1; // expected-note{{uninitialized field 'this->enum1'}}
+  } enum1; // expected-note{{uninitialized field 'this->enum1'}} expected-note{{uninitialized field 'this->enum1'}}
   enum class Enum2 {
     A,
     B
-  } enum2; // expected-note{{uninitialized field 'this->enum2'}}
+  } enum2; // expected-note{{uninitialized field 'this->enum2'}} expected-note{{uninitialized field 'this->enum2'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  EnumTest() {} // expected-warning{{2 uninitialized fields}}
+  EnumTest() {} // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
 };
 
 void fEnumTest() {
   EnumTest();
+  new EnumTest();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1069,12 +1137,12 @@ void assert(int b) {
 // While a singleton would make more sense as a static variable, that would zero
 // initialize all of its fields, hence the not too practical implementation.
 struct Singleton {
-  int i; // expected-note{{uninitialized field 'this->i'}}
+  int i; // expected-note{{uninitialized field 'this->i'}} expected-note{{uninitialized field 'this->i'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
   Singleton() {
     assert(!isInstantiated);
-    isInstantiated = true; // expected-warning{{1 uninitialized field}}
+    isInstantiated = true; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
   }
 
   ~Singleton() {
@@ -1091,6 +1159,7 @@ struct SingletonTest {
 
   SingletonTest() {
     Singleton();
+    new Singleton();
   }
 };
 
@@ -1112,6 +1181,7 @@ struct CXX11MemberInitTest1 {
 
 void fCXX11MemberInitTest1() {
   CXX11MemberInitTest1();
+  new CXX11MemberInitTest1();
 }
 
 struct CXX11MemberInitTest2 {
@@ -1133,6 +1203,7 @@ struct CXX11MemberInitTest2 {
 void fCXX11MemberInitTest2() {
   // TODO: we'd expect the warning: {{2 uninitializeds field}}
   CXX11MemberInitTest2(); // no-warning
+  new CXX11MemberInitTest2(); // no-warning
 }
 
 //===----------------------------------------------------------------------===//
@@ -1140,14 +1211,15 @@ void fCXX11MemberInitTest2() {
 //===----------------------------------------------------------------------===//
 
 struct MyAtomicInt {
-  _Atomic(int) x; // expected-note{{uninitialized field 'this->x'}}
+  _Atomic(int) x; // expected-note{{uninitialized field 'this->x'}} expected-note{{uninitialized field 'this->x'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  MyAtomicInt() {} // expected-warning{{1 uninitialized field}}
+  MyAtomicInt() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
 };
 
 void _AtomicTest() {
   MyAtomicInt b;
+  new MyAtomicInt();
 }
 
 struct VectorSizeLong {
@@ -1158,6 +1230,7 @@ struct VectorSizeLong {
 void __vector_size__LongTest() {
   // TODO: Warn for v.x.
   VectorSizeLong v;
+  new VectorSizeLong();
   v.x[0] = 0;
 }
 
@@ -1178,9 +1251,11 @@ struct ComplexInitTest {
 
 void fComplexTest() {
   ComplexInitTest x;
+  new ComplexInitTest();
 
   // TODO: we should emit a warning for x2.x and x2.y.
   ComplexUninitTest x2;
+  new ComplexUninitTest();
 }
 
 struct PaddingBitfieldTest {

--- a/clang/test/Analysis/cxx-uninitialized-object.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object.cpp
@@ -4,12 +4,29 @@
 // RUN:   -analyzer-config optin.cplusplus.UninitializedObject:Pedantic=true -DPEDANTIC \
 // RUN:   -analyzer-config \
 // RUN:     optin.cplusplus.UninitializedObject:CheckPointeeInitialization=true
+// RUN: %clang_analyze_cc1 -std=c++14 -verify  %s \
+// RUN:   -analyzer-checker=core \
+// RUN:   -analyzer-checker=optin.cplusplus.UninitializedObject \
+// RUN:   -analyzer-config optin.cplusplus.UninitializedObject:Pedantic=true -DPEDANTIC \
+// RUN:   -analyzer-config \
+// RUN:     optin.cplusplus.UninitializedObject:CheckPointeeInitialization=true -DHEAP_ALLOCATION
 
 // RUN: %clang_analyze_cc1 -std=c++14 -verify  %s \
 // RUN:   -analyzer-checker=core \
 // RUN:   -analyzer-checker=optin.cplusplus.UninitializedObject \
 // RUN:   -analyzer-config \
 // RUN:     optin.cplusplus.UninitializedObject:CheckPointeeInitialization=true
+// RUN: %clang_analyze_cc1 -std=c++14 -verify  %s \
+// RUN:   -analyzer-checker=core \
+// RUN:   -analyzer-checker=optin.cplusplus.UninitializedObject \
+// RUN:   -analyzer-config \
+// RUN:     optin.cplusplus.UninitializedObject:CheckPointeeInitialization=true -DHEAP_ALLOCATION
+
+#ifdef HEAP_ALLOCATION
+#define INIT(CLS, ARGS) new CLS ARGS
+#else
+#define INIT(CLS, ARGS) (void) CLS ARGS
+#endif
 
 //===----------------------------------------------------------------------===//
 // Default constructor test.
@@ -23,13 +40,12 @@ public:
 };
 
 void fCompilerGeneratedConstructorTest() {
-  CompilerGeneratedConstructorTest();
-  new CompilerGeneratedConstructorTest();
+  INIT(CompilerGeneratedConstructorTest, ());
 }
 
 #ifdef PEDANTIC
 class DefaultConstructorTest {
-  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
+  int a; // expected-note{{uninitialized field 'this->a'}}
 
 public:
   DefaultConstructorTest();
@@ -38,8 +54,7 @@ public:
 DefaultConstructorTest::DefaultConstructorTest() = default;
 
 void fDefaultConstructorTest() {
-  DefaultConstructorTest(); // expected-warning{{1 uninitialized field}}
-  new DefaultConstructorTest(); // expected-warning{{1 uninitialized field}}
+  INIT(DefaultConstructorTest, ()); // expected-warning{{1 uninitialized field}}
 }
 #else
 class DefaultConstructorTest {
@@ -52,8 +67,7 @@ public:
 DefaultConstructorTest::DefaultConstructorTest() = default;
 
 void fDefaultConstructorTest() {
-  DefaultConstructorTest();
-  new DefaultConstructorTest();
+  INIT(DefaultConstructorTest, ());
 }
 #endif // PEDANTIC
 
@@ -74,36 +88,33 @@ public:
 };
 
 void fInitListTest1() {
-  InitListTest1();
-  new InitListTest1();
+  INIT(InitListTest1, ());
 }
 
 class InitListTest2 {
   int a;
-  int b; // expected-note{{uninitialized field 'this->b'}} expected-note{{uninitialized field 'this->b'}}
+  int b; // expected-note{{uninitialized field 'this->b'}}
 
 public:
   InitListTest2()
-      : a(3) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+      : a(3) {} // expected-warning{{1 uninitialized field}}
 };
 
 void fInitListTest2() {
-  InitListTest2();
-  new InitListTest2();
+  INIT(InitListTest2, ());
 }
 
 class InitListTest3 {
-  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
+  int a; // expected-note{{uninitialized field 'this->a'}}
   int b;
 
 public:
   InitListTest3()
-      : b(4) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+      : b(4) {} // expected-warning{{1 uninitialized field}}
 };
 
 void fInitListTest3() {
-  InitListTest3();
-  new InitListTest3();
+  INIT(InitListTest3, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -122,52 +133,48 @@ public:
 };
 
 void fCtorBodyTest1() {
-  CtorBodyTest1();
-  new CtorBodyTest1();
+  INIT(CtorBodyTest1, ());
 }
 
 class CtorBodyTest2 {
   int a;
-  int b; // expected-note{{uninitialized field 'this->b'}} expected-note{{uninitialized field 'this->b'}}
+  int b; // expected-note{{uninitialized field 'this->b'}}
 
 public:
   CtorBodyTest2() {
-    a = 7; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    a = 7; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fCtorBodyTest2() {
-  CtorBodyTest2();
-  new CtorBodyTest2();
+  INIT(CtorBodyTest2, ());
 }
 
 class CtorBodyTest3 {
-  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
+  int a; // expected-note{{uninitialized field 'this->a'}}
   int b;
 
 public:
   CtorBodyTest3() {
-    b = 8; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    b = 8; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fCtorBodyTest3() {
-  CtorBodyTest3();
-  new CtorBodyTest3();
+  INIT(CtorBodyTest3, ());
 }
 
 #ifdef PEDANTIC
 class CtorBodyTest4 {
-  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
-  int b; // expected-note{{uninitialized field 'this->b'}} expected-note{{uninitialized field 'this->b'}}
+  int a; // expected-note{{uninitialized field 'this->a'}}
+  int b; // expected-note{{uninitialized field 'this->b'}}
 
 public:
   CtorBodyTest4() {}
 };
 
 void fCtorBodyTest4() {
-  CtorBodyTest4(); // expected-warning{{2 uninitialized fields}}
-  new CtorBodyTest4(); // expected-warning{{2 uninitialized fields}}
+  INIT(CtorBodyTest4, ()); // expected-warning{{2 uninitialized fields}}
 }
 #else
 class CtorBodyTest4 {
@@ -179,8 +186,7 @@ public:
 };
 
 void fCtorBodyTest4() {
-  CtorBodyTest4();
-  new CtorBodyTest4();
+  INIT(CtorBodyTest4, ());
 }
 #endif
 
@@ -206,12 +212,11 @@ public:
 };
 
 void fCtorDelegationTest1() {
-  CtorDelegationTest1();
-  new CtorDelegationTest1();
+  INIT(CtorDelegationTest1, ());
 }
 
 class CtorDelegationTest2 {
-  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
+  int a; // expected-note{{uninitialized field 'this->a'}}
   int b;
 
 public:
@@ -221,13 +226,12 @@ public:
   }
 
   CtorDelegationTest2()
-      : CtorDelegationTest2(int{}) { // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+      : CtorDelegationTest2(int{}) { // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fCtorDelegationTest2() {
-  CtorDelegationTest2();
-  new CtorDelegationTest2();
+  INIT(CtorDelegationTest2, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -251,14 +255,13 @@ public:
 };
 
 void fContainsRecordTest1() {
-  ContainsRecordTest1();
-  new ContainsRecordTest1();
+  INIT(ContainsRecordTest1, ());
 }
 
 class ContainsRecordTest2 {
   struct RecordType {
     int x;
-    int y; // expected-note{{uninitialized field 'this->rec.y'}} expected-note{{uninitialized field 'this->rec.y'}}
+    int y; // expected-note{{uninitialized field 'this->rec.y'}}
   } rec;
   int c, d;
 
@@ -266,50 +269,47 @@ public:
   ContainsRecordTest2()
       : c(16),
         d(17) {
-    rec.x = 18; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    rec.x = 18; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fContainsRecordTest2() {
-  ContainsRecordTest2();
-  new ContainsRecordTest2();
+  INIT(ContainsRecordTest2, ());
 }
 
 class ContainsRecordTest3 {
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->rec.x'}} expected-note{{uninitialized field 'this->rec.x'}}
-    int y; // expected-note{{uninitialized field 'this->rec.y'}} expected-note{{uninitialized field 'this->rec.y'}}
+    int x; // expected-note{{uninitialized field 'this->rec.x'}}
+    int y; // expected-note{{uninitialized field 'this->rec.y'}}
   } rec;
   int c, d;
 
 public:
   ContainsRecordTest3()
       : c(19),
-        d(20) { // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+        d(20) { // expected-warning{{2 uninitialized fields}}
   }
 };
 
 void fContainsRecordTest3() {
-  ContainsRecordTest3();
-  new ContainsRecordTest3();
+  INIT(ContainsRecordTest3, ());
 }
 
 class ContainsRecordTest4 {
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->rec.x'}} expected-note{{uninitialized field 'this->rec.x'}}
-    int y; // expected-note{{uninitialized field 'this->rec.y'}} expected-note{{uninitialized field 'this->rec.y'}}
+    int x; // expected-note{{uninitialized field 'this->rec.x'}}
+    int y; // expected-note{{uninitialized field 'this->rec.y'}}
   } rec;
-  int c, d; // expected-note{{uninitialized field 'this->d'}} expected-note{{uninitialized field 'this->d'}}
+  int c, d; // expected-note{{uninitialized field 'this->d'}}
 
 public:
   ContainsRecordTest4()
-      : c(19) { // expected-warning{{3 uninitialized fields}} expected-warning{{3 uninitialized fields}}
+      : c(19) { // expected-warning{{3 uninitialized fields}}
   }
 };
 
 void fContainsRecordTest4() {
-  ContainsRecordTest4();
-  new ContainsRecordTest4();
+  INIT(ContainsRecordTest4, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -330,29 +330,27 @@ public:
 };
 
 void fIntTemplateClassTest1() {
-  IntTemplateClassTest1<int>(22);
-  new IntTemplateClassTest1<int>(22);
+  INIT(IntTemplateClassTest1<int>, (22));
 }
 
 template <class T>
 class IntTemplateClassTest2 {
-  T t; // expected-note{{uninitialized field 'this->t'}} expected-note{{uninitialized field 'this->t'}}
+  T t; // expected-note{{uninitialized field 'this->t'}}
   int b;
 
 public:
   IntTemplateClassTest2() {
-    b = 23; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    b = 23; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fIntTemplateClassTest2() {
-  IntTemplateClassTest2<int>();
-  new IntTemplateClassTest2<int>();
+  INIT(IntTemplateClassTest2<int>, ());
 }
 
 struct Record {
-  int x; // expected-note{{uninitialized field 'this->t.x'}} expected-note{{uninitialized field 'this->t.x'}}
-  int y; // expected-note{{uninitialized field 'this->t.y'}} expected-note{{uninitialized field 'this->t.y'}}
+  int x; // expected-note{{uninitialized field 'this->t.x'}}
+  int y; // expected-note{{uninitialized field 'this->t.y'}}
 };
 
 template <class T>
@@ -362,13 +360,12 @@ class RecordTemplateClassTest {
 
 public:
   RecordTemplateClassTest() {
-    b = 24; // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+    b = 24; // expected-warning{{2 uninitialized fields}}
   }
 };
 
 void fRecordTemplateClassTest() {
-  RecordTemplateClassTest<Record>();
-  new RecordTemplateClassTest<Record>();
+  INIT(RecordTemplateClassTest<Record>, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -403,28 +400,24 @@ public:
 };
 
 void fPassingToUnknownFunctionTest1() {
-  PassingToUnknownFunctionTest1();
-  new PassingToUnknownFunctionTest1();
-  PassingToUnknownFunctionTest1(int());
-  new PassingToUnknownFunctionTest1(int());
-  PassingToUnknownFunctionTest1(int(), int());
-  new PassingToUnknownFunctionTest1(int(), int());
+  INIT(PassingToUnknownFunctionTest1, ());
+  INIT(PassingToUnknownFunctionTest1, (int()));
+  INIT(PassingToUnknownFunctionTest1, (int(), int()));
 }
 
 class PassingToUnknownFunctionTest2 {
-  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
+  int a; // expected-note{{uninitialized field 'this->a'}}
   int b;
 
 public:
   PassingToUnknownFunctionTest2() {
     wontInitialize(a);
-    b = 4; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    b = 4; // expected-warning{{1 uninitialized field}}
   }
 };
 
 void fPassingToUnknownFunctionTest2() {
-  PassingToUnknownFunctionTest2();
-  new PassingToUnknownFunctionTest2();
+  INIT(PassingToUnknownFunctionTest2, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -451,8 +444,7 @@ public:
 };
 
 void fContainsSimpleUnionTest1() {
-  ContainsSimpleUnionTest1();
-  new ContainsSimpleUnionTest1();
+  INIT(ContainsSimpleUnionTest1, ());
 }
 
 class ContainsSimpleUnionTest2 {
@@ -469,8 +461,7 @@ public:
 
 void fContainsSimpleUnionTest2() {
   // TODO: we'd expect the warning: {{1 uninitialized field}}
-  ContainsSimpleUnionTest2(); // no-warning
-  new ContainsSimpleUnionTest2(); // no-warning
+  INIT(ContainsSimpleUnionTest2, ()); // no-warning
 }
 
 class UnionPointerTest1 {
@@ -493,8 +484,7 @@ public:
 void fUnionPointerTest1() {
   UnionPointerTest1::SimpleUnion u;
   u.uf = 41;
-  UnionPointerTest1(&u, int());
-  new UnionPointerTest1(&u, int());
+  INIT(UnionPointerTest1, (&u, int()));
 }
 
 class UnionPointerTest2 {
@@ -516,8 +506,7 @@ public:
 void fUnionPointerTest2() {
   UnionPointerTest2::SimpleUnion u;
   // TODO: we'd expect the warning: {{1 uninitialized field}}
-  UnionPointerTest2(&u, int()); // no-warning
-  new UnionPointerTest2(&u, int()); // no-warning
+  INIT(UnionPointerTest2, (&u, int())); // no-warning
 }
 
 class ContainsUnionWithRecordTest1 {
@@ -540,8 +529,7 @@ public:
 };
 
 void fContainsUnionWithRecordTest1() {
-  ContainsUnionWithRecordTest1();
-  new ContainsUnionWithRecordTest1();
+  INIT(ContainsUnionWithRecordTest1, ());
 }
 
 class ContainsUnionWithRecordTest2 {
@@ -564,8 +552,7 @@ public:
 };
 
 void fContainsUnionWithRecordTest2() {
-  ContainsUnionWithRecordTest1();
-  new ContainsUnionWithRecordTest1();
+  INIT(ContainsUnionWithRecordTest1, ());
 }
 
 class ContainsUnionWithRecordTest3 {
@@ -591,8 +578,7 @@ public:
 };
 
 void fContainsUnionWithRecordTest3() {
-  ContainsUnionWithRecordTest3();
-  new ContainsUnionWithRecordTest3();
+  INIT(ContainsUnionWithRecordTest3, ());
 }
 
 class ContainsUnionWithSimpleUnionTest1 {
@@ -614,8 +600,7 @@ public:
 };
 
 void fContainsUnionWithSimpleUnionTest1() {
-  ContainsUnionWithSimpleUnionTest1();
-  new ContainsUnionWithSimpleUnionTest1();
+  INIT(ContainsUnionWithSimpleUnionTest1, ());
 }
 
 class ContainsUnionWithSimpleUnionTest2 {
@@ -636,8 +621,7 @@ public:
 
 void fContainsUnionWithSimpleUnionTest2() {
   // TODO: we'd expect the warning: {{1 uninitialized field}}
-  ContainsUnionWithSimpleUnionTest2(); // no-warning
-  new ContainsUnionWithSimpleUnionTest2(); // no-warning
+  INIT(ContainsUnionWithSimpleUnionTest2, ()); // no-warning
 }
 
 //===----------------------------------------------------------------------===//
@@ -661,7 +645,7 @@ void funcToSquelchCompilerWarnings(const T &t);
 
 #ifdef PEDANTIC
 struct CopyConstructorTest {
-  int i; // expected-note{{uninitialized field 'this->i'}} expected-note{{uninitialized field 'this->i'}}
+  int i; // expected-note{{uninitialized field 'this->i'}}
 
   CopyConstructorTest() : i(1337) {}
   CopyConstructorTest(const CopyConstructorTest &other) {}
@@ -669,9 +653,7 @@ struct CopyConstructorTest {
 
 void fCopyConstructorTest() {
   CopyConstructorTest cct;
-  CopyConstructorTest copy = cct; // expected-warning{{1 uninitialized field}}
-  new CopyConstructorTest(cct); // expected-warning{{1 uninitialized field}}
-  funcToSquelchCompilerWarnings(copy);
+  INIT(CopyConstructorTest, (cct)); // expected-warning{{1 uninitialized field}}
 }
 #else
 struct CopyConstructorTest {
@@ -683,9 +665,7 @@ struct CopyConstructorTest {
 
 void fCopyConstructorTest() {
   CopyConstructorTest cct;
-  CopyConstructorTest copy = cct;
-  new CopyConstructorTest(cct);
-  funcToSquelchCompilerWarnings(copy);
+  INIT(CopyConstructorTest, (cct));
 }
 #endif // PEDANTIC
 
@@ -701,9 +681,7 @@ struct MoveConstructorTest {
 void fMoveConstructorTest() {
   MoveConstructorTest cct;
   // TODO: we'd expect the warning: {{1 uninitialized field}}
-  MoveConstructorTest copy(static_cast<MoveConstructorTest &&>(cct)); // no-warning
-  new MoveConstructorTest(static_cast<MoveConstructorTest &&>(cct)); // no-warning
-  funcToSquelchCompilerWarnings(copy);
+  INIT(MoveConstructorTest, (static_cast<MoveConstructorTest &&>(cct))); // no-warning
 }
 
 //===----------------------------------------------------------------------===//
@@ -719,8 +697,7 @@ struct IntArrayTest {
 };
 
 void fIntArrayTest() {
-  IntArrayTest();
-  new IntArrayTest();
+  INIT(IntArrayTest, ());
 }
 
 struct RecordTypeArrayTest {
@@ -734,8 +711,7 @@ struct RecordTypeArrayTest {
 };
 
 void fRecordTypeArrayTest() {
-  RecordTypeArrayTest();
-  new RecordTypeArrayTest();
+  INIT(RecordTypeArrayTest, ());
 }
 
 template <class T>
@@ -764,8 +740,7 @@ struct MemsetTest1 {
 };
 
 void fMemsetTest1() {
-  MemsetTest1();
-  new MemsetTest1();
+  INIT(MemsetTest1, ());
 }
 
 struct MemsetTest2 {
@@ -777,8 +752,7 @@ struct MemsetTest2 {
 };
 
 void fMemsetTest2() {
-  MemsetTest2();
-  new MemsetTest2();
+  INIT(MemsetTest2, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -812,8 +786,7 @@ struct LambdaTest1 {
 
 void fLambdaTest1() {
   auto isEven = [](int a) { return a % 2 == 0; };
-  LambdaTest1<decltype(isEven)>(isEven, int());
-  new LambdaTest1<decltype(isEven)>(isEven, int());
+  INIT(LambdaTest1<decltype(isEven)>, (isEven, int()));
 }
 
 #ifdef PEDANTIC
@@ -821,16 +794,13 @@ template <class Callable>
 struct LambdaTest2 {
   Callable functor;
 
-  LambdaTest2(const Callable &functor, int) : functor(functor) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  LambdaTest2(const Callable &functor, int) : functor(functor) {} // expected-warning{{1 uninitialized field}}
 };
 
 void fLambdaTest2() {
   int b;
   auto equals = [&b](int a) { return a == b; }; // expected-note{{uninitialized pointee 'this->functor./*captured variable*/b'}}
-  LambdaTest2<decltype(equals)>(equals, int());
-  int bp;
-  auto equalsp = [&bp](int a) { return a == bp; }; // expected-note{{uninitialized pointee 'this->functor./*captured variable*/bp'}}
-  new LambdaTest2<decltype(equalsp)>(equalsp, int());
+  INIT(LambdaTest2<decltype(equals)>, (equals, int()));
 }
 #else
 template <class Callable>
@@ -843,8 +813,7 @@ struct LambdaTest2 {
 void fLambdaTest2() {
   int b;
   auto equals = [&b](int a) { return a == b; };
-  LambdaTest2<decltype(equals)>(equals, int());
-  new LambdaTest2<decltype(equals)>(equals, int());
+  INIT(LambdaTest2<decltype(equals)>, (equals, int()));
 }
 #endif //PEDANTIC
 
@@ -852,8 +821,8 @@ void fLambdaTest2() {
 namespace LT3Detail {
 
 struct RecordType {
-  int x; // expected-note{{uninitialized field 'this->functor./*captured variable*/rec1.x'}} expected-note{{uninitialized field 'this->functor./*captured variable*/rec1p.x'}}
-  int y; // expected-note{{uninitialized field 'this->functor./*captured variable*/rec1.y'}} expected-note{{uninitialized field 'this->functor./*captured variable*/rec1p.y'}}
+  int x; // expected-note{{uninitialized field 'this->functor./*captured variable*/rec1.x'}}
+  int y; // expected-note{{uninitialized field 'this->functor./*captured variable*/rec1.y'}}
 };
 
 } // namespace LT3Detail
@@ -861,7 +830,7 @@ template <class Callable>
 struct LambdaTest3 {
   Callable functor;
 
-  LambdaTest3(const Callable &functor, int) : functor(functor) {} // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+  LambdaTest3(const Callable &functor, int) : functor(functor) {} // expected-warning{{2 uninitialized fields}}
 };
 
 void fLambdaTest3() {
@@ -869,12 +838,7 @@ void fLambdaTest3() {
   auto equals = [&rec1](LT3Detail::RecordType rec2) {
     return rec1.x == rec2.x;
   };
-  LambdaTest3<decltype(equals)>(equals, int());
-  LT3Detail::RecordType rec1p;
-  auto equalsp = [&rec1p](LT3Detail::RecordType rec2) {
-    return rec1p.x == rec2.x;
-  };
-  new LambdaTest3<decltype(equalsp)>(equalsp, int());
+  INIT(LambdaTest3<decltype(equals)>, (equals, int()));
 }
 #else
 namespace LT3Detail {
@@ -897,8 +861,7 @@ void fLambdaTest3() {
   auto equals = [&rec1](LT3Detail::RecordType rec2) {
     return rec1.x == rec2.x;
   };
-  LambdaTest3<decltype(equals)>(equals, int());
-  new LambdaTest3<decltype(equals)>(equals, int());
+  INIT(LambdaTest3<decltype(equals)>, (equals, int()));
 }
 #endif //PEDANTIC
 
@@ -907,18 +870,14 @@ struct MultipleLambdaCapturesTest1 {
   Callable functor;
   int dontGetFilteredByNonPedanticMode = 0;
 
-  MultipleLambdaCapturesTest1(const Callable &functor, int) : functor(functor) {} // expected-warning{{2 uninitialized field}} expected-warning{{2 uninitialized field}}
+  MultipleLambdaCapturesTest1(const Callable &functor, int) : functor(functor) {} // expected-warning{{2 uninitialized field}}
 };
 
 void fMultipleLambdaCapturesTest1() {
   int b1, b2 = 3, b3;
   auto equals = [&b1, &b2, &b3](int a) { return a == b1 == b2 == b3; }; // expected-note{{uninitialized pointee 'this->functor./*captured variable*/b1'}}
   // expected-note@-1{{uninitialized pointee 'this->functor./*captured variable*/b3'}}
-  MultipleLambdaCapturesTest1<decltype(equals)>(equals, int());
-  int b1p, b2p = 3, b3p;
-  auto equalsp = [&b1p, &b2p, &b3p](int a) { return a == b1p == b2p == b3p; }; // expected-note{{uninitialized pointee 'this->functor./*captured variable*/b1p'}}
-  // expected-note@-1{{uninitialized pointee 'this->functor./*captured variable*/b3p'}}
-  new MultipleLambdaCapturesTest1<decltype(equalsp)>(equalsp, int());
+  INIT(MultipleLambdaCapturesTest1<decltype(equals)>, (equals, int()));
 }
 
 template <class Callable>
@@ -926,16 +885,13 @@ struct MultipleLambdaCapturesTest2 {
   Callable functor;
   int dontGetFilteredByNonPedanticMode = 0;
 
-  MultipleLambdaCapturesTest2(const Callable &functor, int) : functor(functor) {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  MultipleLambdaCapturesTest2(const Callable &functor, int) : functor(functor) {} // expected-warning{{1 uninitialized field}}
 };
 
 void fMultipleLambdaCapturesTest2() {
   int b1, b2 = 3, b3;
   auto equals = [b1, &b2, &b3](int a) { return a == b1 == b2 == b3; }; // expected-note{{uninitialized pointee 'this->functor./*captured variable*/b3'}}
-  MultipleLambdaCapturesTest2<decltype(equals)>(equals, int());
-  int b1p, b2p = 3, b3p;
-  auto equalsp = [b1p, &b2p, &b3p](int a) { return a == b1p == b2p == b3p; }; // expected-note{{uninitialized pointee 'this->functor./*captured variable*/b3p'}}
-  new MultipleLambdaCapturesTest2<decltype(equalsp)>(equalsp, int());
+  INIT(MultipleLambdaCapturesTest2<decltype(equals)>, (equals, int()));
 }
 
 struct LambdaWrapper {
@@ -978,25 +934,23 @@ struct SystemHeaderTest1 {
 };
 
 void fSystemHeaderTest1() {
-  SystemHeaderTest1();
-  new SystemHeaderTest1();
+  INIT(SystemHeaderTest1, ());
 }
 
 #ifdef PEDANTIC
 struct SystemHeaderTest2 {
   struct RecordType {
-    int x; // expected-note{{uninitialized field 'this->container.t.x}} expected-note{{uninitialized field 'this->container.t.x}}
-    int y; // expected-note{{uninitialized field 'this->container.t.y}} expected-note{{uninitialized field 'this->container.t.y}}
+    int x; // expected-note{{uninitialized field 'this->container.t.x}}
+    int y; // expected-note{{uninitialized field 'this->container.t.y}}
   };
   ContainerInSystemHeader<RecordType> container;
 
-  SystemHeaderTest2(RecordType &rec, int) : container(rec) {} // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+  SystemHeaderTest2(RecordType &rec, int) : container(rec) {} // expected-warning{{2 uninitialized fields}}
 };
 
 void fSystemHeaderTest2() {
-  SystemHeaderTest2::RecordType rec, recp;
-  SystemHeaderTest2(rec, int());
-  new SystemHeaderTest2(recp, int());
+  SystemHeaderTest2::RecordType rec;
+  INIT(SystemHeaderTest2, (rec, int()));
 }
 #else
 struct SystemHeaderTest2 {
@@ -1011,8 +965,7 @@ struct SystemHeaderTest2 {
 
 void fSystemHeaderTest2() {
   SystemHeaderTest2::RecordType rec;
-  SystemHeaderTest2(rec, int());
-  new SystemHeaderTest2(rec, int());
+  INIT(SystemHeaderTest2, (rec, int()));
 }
 #endif //PEDANTIC
 
@@ -1023,15 +976,14 @@ void fSystemHeaderTest2() {
 struct IncompleteTypeTest1 {
   struct RecordType;
   // no-crash
-  RecordType *recptr; // expected-note{{uninitialized pointer 'this->recptr}} expected-note{{uninitialized pointer 'this->recptr}}
+  RecordType *recptr; // expected-note{{uninitialized pointer 'this->recptr}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  IncompleteTypeTest1() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  IncompleteTypeTest1() {} // expected-warning{{1 uninitialized field}}
 };
 
 void fIncompleteTypeTest1() {
-  IncompleteTypeTest1();
-  new IncompleteTypeTest1();
+  INIT(IncompleteTypeTest1, ());
 }
 
 struct IncompleteTypeTest2 {
@@ -1045,8 +997,7 @@ struct IncompleteTypeTest2 {
 };
 
 void fIncompleteTypeTest2() {
-  IncompleteTypeTest2();
-  new IncompleteTypeTest2();
+  INIT(IncompleteTypeTest2, ());
 }
 
 struct IncompleteTypeTest3 {
@@ -1060,8 +1011,7 @@ struct IncompleteTypeTest3 {
 };
 
 void fIncompleteTypeTest3() {
-  IncompleteTypeTest3();
-  new IncompleteTypeTest3();
+  INIT(IncompleteTypeTest3, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1069,58 +1019,54 @@ void fIncompleteTypeTest3() {
 //===----------------------------------------------------------------------===//
 
 struct IntegralTypeTest {
-  int a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
+  int a; // expected-note{{uninitialized field 'this->a'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  IntegralTypeTest() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  IntegralTypeTest() {} // expected-warning{{1 uninitialized field}}
 };
 
 void fIntegralTypeTest() {
-  IntegralTypeTest();
-  new IntegralTypeTest();
+  INIT(IntegralTypeTest, ());
 }
 
 struct FloatingTypeTest {
-  float a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
+  float a; // expected-note{{uninitialized field 'this->a'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  FloatingTypeTest() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  FloatingTypeTest() {} // expected-warning{{1 uninitialized field}}
 };
 
 void fFloatingTypeTest() {
-  FloatingTypeTest();
-  new FloatingTypeTest();
+  INIT(FloatingTypeTest, ());
 }
 
 struct NullptrTypeTypeTest {
-  decltype(nullptr) a; // expected-note{{uninitialized field 'this->a'}} expected-note{{uninitialized field 'this->a'}}
+  decltype(nullptr) a; // expected-note{{uninitialized field 'this->a'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  NullptrTypeTypeTest() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  NullptrTypeTypeTest() {} // expected-warning{{1 uninitialized field}}
 };
 
 void fNullptrTypeTypeTest() {
-  NullptrTypeTypeTest();
-  new NullptrTypeTypeTest();
+  INIT(NullptrTypeTypeTest, ());
 }
 
 struct EnumTest {
   enum Enum {
     A,
     B
-  } enum1; // expected-note{{uninitialized field 'this->enum1'}} expected-note{{uninitialized field 'this->enum1'}}
+  } enum1; // expected-note{{uninitialized field 'this->enum1'}}
   enum class Enum2 {
     A,
     B
-  } enum2; // expected-note{{uninitialized field 'this->enum2'}} expected-note{{uninitialized field 'this->enum2'}}
+  } enum2; // expected-note{{uninitialized field 'this->enum2'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  EnumTest() {} // expected-warning{{2 uninitialized fields}} expected-warning{{2 uninitialized fields}}
+  EnumTest() {} // expected-warning{{2 uninitialized fields}}
 };
 
 void fEnumTest() {
-  EnumTest();
-  new EnumTest();
+  INIT(EnumTest, ());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1137,12 +1083,12 @@ void assert(int b) {
 // While a singleton would make more sense as a static variable, that would zero
 // initialize all of its fields, hence the not too practical implementation.
 struct Singleton {
-  int i; // expected-note{{uninitialized field 'this->i'}} expected-note{{uninitialized field 'this->i'}}
+  int i; // expected-note{{uninitialized field 'this->i'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
   Singleton() {
     assert(!isInstantiated);
-    isInstantiated = true; // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+    isInstantiated = true; // expected-warning{{1 uninitialized field}}
   }
 
   ~Singleton() {
@@ -1158,8 +1104,7 @@ struct SingletonTest {
   int dontGetFilteredByNonPedanticMode = 0;
 
   SingletonTest() {
-    Singleton();
-    new Singleton();
+    INIT(Singleton, ());
   }
 };
 
@@ -1180,8 +1125,7 @@ struct CXX11MemberInitTest1 {
 };
 
 void fCXX11MemberInitTest1() {
-  CXX11MemberInitTest1();
-  new CXX11MemberInitTest1();
+  INIT(CXX11MemberInitTest1, ());
 }
 
 struct CXX11MemberInitTest2 {
@@ -1202,8 +1146,7 @@ struct CXX11MemberInitTest2 {
 
 void fCXX11MemberInitTest2() {
   // TODO: we'd expect the warning: {{2 uninitializeds field}}
-  CXX11MemberInitTest2(); // no-warning
-  new CXX11MemberInitTest2(); // no-warning
+  INIT(CXX11MemberInitTest2, ()); // no-warning
 }
 
 //===----------------------------------------------------------------------===//
@@ -1211,15 +1154,14 @@ void fCXX11MemberInitTest2() {
 //===----------------------------------------------------------------------===//
 
 struct MyAtomicInt {
-  _Atomic(int) x; // expected-note{{uninitialized field 'this->x'}} expected-note{{uninitialized field 'this->x'}}
+  _Atomic(int) x; // expected-note{{uninitialized field 'this->x'}}
   int dontGetFilteredByNonPedanticMode = 0;
 
-  MyAtomicInt() {} // expected-warning{{1 uninitialized field}} expected-warning{{1 uninitialized field}}
+  MyAtomicInt() {} // expected-warning{{1 uninitialized field}}
 };
 
 void _AtomicTest() {
-  MyAtomicInt b;
-  new MyAtomicInt();
+  INIT(MyAtomicInt, ());
 }
 
 struct VectorSizeLong {
@@ -1250,12 +1192,10 @@ struct ComplexInitTest {
 };
 
 void fComplexTest() {
-  ComplexInitTest x;
-  new ComplexInitTest();
+  INIT(ComplexInitTest, ());
 
   // TODO: we should emit a warning for x2.x and x2.y.
-  ComplexUninitTest x2;
-  new ComplexUninitTest();
+  INIT(ComplexUninitTest, ());
 }
 
 struct PaddingBitfieldTest {

--- a/clang/test/Analysis/objcpp-uninitialized-object.mm
+++ b/clang/test/Analysis/objcpp-uninitialized-object.mm
@@ -4,29 +4,32 @@ typedef void (^myBlock) ();
 
 struct StructWithBlock {
   int a;
-  myBlock z; // expected-note{{uninitialized field 'this->z'}}
+  myBlock z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
 
   StructWithBlock() : a(0), z(^{}) {}
 
   // Miss initialization of field `z`.
-  StructWithBlock(int pA) : a(pA) {} // expected-warning{{1 uninitialized field at the end of the constructor call}}
+  StructWithBlock(int pA) : a(pA) {} // expected-warning{{1 uninitialized field at the end of the constructor call}} expected-warning{{1 uninitialized field at the end of the constructor call}}
 
 };
 
 void warnOnUninitializedBlock() {
   StructWithBlock a(10);
+  new StructWithBlock(10);
 }
 
 void noWarningWhenInitialized() {
   StructWithBlock a;
+  new StructWithBlock();
 }
 
 struct StructWithId {
   int a;
-  id z; // expected-note{{uninitialized pointer 'this->z'}}
-  StructWithId() : a(0) {} // expected-warning{{1 uninitialized field at the end of the constructor call}}
+  id z; // expected-note{{uninitialized pointer 'this->z'}} expected-note{{uninitialized pointer 'this->z'}}
+  StructWithId() : a(0) {} // expected-warning{{1 uninitialized field at the end of the constructor call}} expected-warning{{1 uninitialized field at the end of the constructor call}}
 };
 
 void warnOnUninitializedId() {
   StructWithId s;
+  new StructWithId();
 }

--- a/clang/test/Analysis/objcpp-uninitialized-object.mm
+++ b/clang/test/Analysis/objcpp-uninitialized-object.mm
@@ -1,35 +1,39 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=core,optin.cplusplus.UninitializedObject -std=c++11 -fblocks -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,optin.cplusplus.UninitializedObject -std=c++11 -fblocks -verify %s -DHEAP_ALLOCATION
+
+#ifdef HEAP_ALLOCATION
+#define INIT(CLS, ARGS) new CLS ARGS
+#else
+#define INIT(CLS, ARGS) (void) CLS ARGS
+#endif
 
 typedef void (^myBlock) ();
 
 struct StructWithBlock {
   int a;
-  myBlock z; // expected-note{{uninitialized field 'this->z'}} expected-note{{uninitialized field 'this->z'}}
+  myBlock z; // expected-note{{uninitialized field 'this->z'}}
 
   StructWithBlock() : a(0), z(^{}) {}
 
   // Miss initialization of field `z`.
-  StructWithBlock(int pA) : a(pA) {} // expected-warning{{1 uninitialized field at the end of the constructor call}} expected-warning{{1 uninitialized field at the end of the constructor call}}
+  StructWithBlock(int pA) : a(pA) {} // expected-warning{{1 uninitialized field at the end of the constructor call}}
 
 };
 
 void warnOnUninitializedBlock() {
-  StructWithBlock a(10);
-  new StructWithBlock(10);
+  INIT(StructWithBlock, (10));
 }
 
 void noWarningWhenInitialized() {
-  StructWithBlock a;
-  new StructWithBlock();
+  INIT(StructWithBlock, ());
 }
 
 struct StructWithId {
   int a;
-  id z; // expected-note{{uninitialized pointer 'this->z'}} expected-note{{uninitialized pointer 'this->z'}}
-  StructWithId() : a(0) {} // expected-warning{{1 uninitialized field at the end of the constructor call}} expected-warning{{1 uninitialized field at the end of the constructor call}}
+  id z; // expected-note{{uninitialized pointer 'this->z'}}
+  StructWithId() : a(0) {} // expected-warning{{1 uninitialized field at the end of the constructor call}}
 };
 
 void warnOnUninitializedId() {
-  StructWithId s;
-  new StructWithId();
+  INIT(StructWithId, ());
 }


### PR DESCRIPTION
Adapt the allocated region into a `TypedValueRegion` by retrieving its type and wrapping it in an `ElementRegion`.

The `willObjectBeAnalyzedLater` function must therefore fall back on using `SubRegion`s.

CPP-7677