### PR TITLE
[libc++][NFC] Move namespace macros into a detail header

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -335,9 +335,11 @@ set(files
   __configuration/attributes.h
   __configuration/availability.h
   __configuration/compiler.h
+  __configuration/diagnostic_suppression.h
   __configuration/experimental.h
   __configuration/hardening.h
   __configuration/language.h
+  __configuration/namespace.h
   __configuration/platform.h
   __coroutine/coroutine_handle.h
   __coroutine/coroutine_traits.h

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -22,9 +22,11 @@
 #  include <__configuration/attributes.h>
 #  include <__configuration/availability.h>
 #  include <__configuration/compiler.h>
+#  include <__configuration/diagnostic_suppression.h>
 #  include <__configuration/experimental.h>
 #  include <__configuration/hardening.h>
 #  include <__configuration/language.h>
+#  include <__configuration/namespace.h>
 #  include <__configuration/platform.h>
 
 // The attributes supported by clang are documented at https://clang.llvm.org/docs/AttributeReference.html
@@ -177,90 +179,6 @@ typedef __char32_t char32_t;
 #  else
 #    define _LIBCPP_HAS_BLOCKS_RUNTIME 0
 #  endif
-
-#  ifdef _LIBCPP_COMPILER_CLANG_BASED
-#    define _LIBCPP_DIAGNOSTIC_PUSH _Pragma("clang diagnostic push")
-#    define _LIBCPP_DIAGNOSTIC_POP _Pragma("clang diagnostic pop")
-#    define _LIBCPP_CLANG_DIAGNOSTIC_IGNORED(str) _Pragma(_LIBCPP_TOSTRING(clang diagnostic ignored str))
-#    define _LIBCPP_GCC_DIAGNOSTIC_IGNORED(str)
-#  elif defined(_LIBCPP_COMPILER_GCC)
-#    define _LIBCPP_DIAGNOSTIC_PUSH _Pragma("GCC diagnostic push")
-#    define _LIBCPP_DIAGNOSTIC_POP _Pragma("GCC diagnostic pop")
-#    define _LIBCPP_CLANG_DIAGNOSTIC_IGNORED(str)
-#    define _LIBCPP_GCC_DIAGNOSTIC_IGNORED(str) _Pragma(_LIBCPP_TOSTRING(GCC diagnostic ignored str))
-#  else
-#    define _LIBCPP_DIAGNOSTIC_PUSH
-#    define _LIBCPP_DIAGNOSTIC_POP
-#    define _LIBCPP_CLANG_DIAGNOSTIC_IGNORED(str)
-#    define _LIBCPP_GCC_DIAGNOSTIC_IGNORED(str)
-#  endif
-
-// Macros to enter and leave a state where deprecation warnings are suppressed.
-#  define _LIBCPP_SUPPRESS_DEPRECATED_PUSH                                                                             \
-    _LIBCPP_DIAGNOSTIC_PUSH _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wdeprecated")                                           \
-        _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wdeprecated-declarations")
-#  define _LIBCPP_SUPPRESS_DEPRECATED_POP _LIBCPP_DIAGNOSTIC_POP
-
-// Clang modules take a significant compile time hit when pushing and popping diagnostics.
-// Since all the headers are marked as system headers unless _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER is defined, we can
-// simply disable this pushing and popping when _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER isn't defined.
-#  ifdef _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER
-#    define _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS                                                                         \
-      _LIBCPP_DIAGNOSTIC_PUSH                                                                                          \
-      _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++11-extensions")                                                           \
-      _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++14-extensions")                                                           \
-      _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++17-extensions")                                                           \
-      _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++20-extensions")                                                           \
-      _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++23-extensions")                                                           \
-      _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++14-extensions")                                                             \
-      _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++17-extensions")                                                             \
-      _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++20-extensions")                                                             \
-      _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++23-extensions")
-#    define _LIBCPP_POP_EXTENSION_DIAGNOSTICS _LIBCPP_DIAGNOSTIC_POP
-#  else
-#    define _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS
-#    define _LIBCPP_POP_EXTENSION_DIAGNOSTICS
-#  endif
-
-// clang-format off
-
-// The unversioned namespace is used when we want to be ABI compatible with other standard libraries in some way. There
-// are two main categories where that's the case:
-// - Historically, we have made exception types ABI compatible with libstdc++ to allow throwing them between libstdc++
-//   and libc++. This is not used anymore for new exception types, since there is no use-case for it anymore.
-// - Types and functions which are used by the compiler are in the unversioned namespace, since the compiler has to know
-//   their mangling without the appropriate declaration in some cases.
-// If it's not clear whether using the unversioned namespace is the correct thing to do, it's not. The versioned
-// namespace (_LIBCPP_BEGIN_NAMESPACE_STD) should almost always be used.
-#  define _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD                                                                      \
-    _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS namespace _LIBCPP_NAMESPACE_VISIBILITY std {
-
-#  define _LIBCPP_END_UNVERSIONED_NAMESPACE_STD } _LIBCPP_POP_EXTENSION_DIAGNOSTICS
-
-#  define _LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD inline namespace _LIBCPP_ABI_NAMESPACE {
-#  define _LIBCPP_END_NAMESPACE_STD } _LIBCPP_END_UNVERSIONED_NAMESPACE_STD
-
-// TODO: This should really be in the versioned namespace
-#define _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD namespace experimental {
-#define _LIBCPP_END_NAMESPACE_EXPERIMENTAL } _LIBCPP_END_UNVERSIONED_NAMESPACE_STD
-
-#define _LIBCPP_BEGIN_NAMESPACE_LFTS _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL inline namespace fundamentals_v1 {
-#define _LIBCPP_END_NAMESPACE_LFTS } _LIBCPP_END_NAMESPACE_EXPERIMENTAL
-
-#define _LIBCPP_BEGIN_NAMESPACE_LFTS_V2 _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL inline namespace fundamentals_v2 {
-#define _LIBCPP_END_NAMESPACE_LFTS_V2 } _LIBCPP_END_NAMESPACE_EXPERIMENTAL
-
-#ifdef _LIBCPP_ABI_NO_FILESYSTEM_INLINE_NAMESPACE
-#  define _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM _LIBCPP_BEGIN_NAMESPACE_STD namespace filesystem {
-#  define _LIBCPP_END_NAMESPACE_FILESYSTEM } _LIBCPP_END_NAMESPACE_STD
-#else
-#  define _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM _LIBCPP_BEGIN_NAMESPACE_STD                                               \
-                                             inline namespace __fs { namespace filesystem {
-
-#  define _LIBCPP_END_NAMESPACE_FILESYSTEM }} _LIBCPP_END_NAMESPACE_STD
-#endif
-
-// clang-format on
 
 #  if !defined(__SIZEOF_INT128__) || defined(_MSC_VER)
 #    define _LIBCPP_HAS_INT128 0

--- a/libcxx/include/__configuration/diagnostic_suppression.h
+++ b/libcxx/include/__configuration/diagnostic_suppression.h
@@ -1,0 +1,43 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___CONFIGURATION_DIAGNOSTIC_SUPPRESSION_H
+#define _LIBCPP___CONFIGURATION_DIAGNOSTIC_SUPPRESSION_H
+
+#include <__config_site>
+#include <__configuration/compiler.h>
+
+#ifndef _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER
+#  pragma GCC system_header
+#endif
+
+#ifdef _LIBCPP_COMPILER_CLANG_BASED
+#  define _LIBCPP_DIAGNOSTIC_PUSH _Pragma("clang diagnostic push")
+#  define _LIBCPP_DIAGNOSTIC_POP _Pragma("clang diagnostic pop")
+#  define _LIBCPP_CLANG_DIAGNOSTIC_IGNORED(str) _Pragma(_LIBCPP_TOSTRING(clang diagnostic ignored str))
+#  define _LIBCPP_GCC_DIAGNOSTIC_IGNORED(str)
+#elif defined(_LIBCPP_COMPILER_GCC)
+#  define _LIBCPP_DIAGNOSTIC_PUSH _Pragma("GCC diagnostic push")
+#  define _LIBCPP_DIAGNOSTIC_POP _Pragma("GCC diagnostic pop")
+#  define _LIBCPP_CLANG_DIAGNOSTIC_IGNORED(str)
+#  define _LIBCPP_GCC_DIAGNOSTIC_IGNORED(str) _Pragma(_LIBCPP_TOSTRING(GCC diagnostic ignored str))
+#else
+#  define _LIBCPP_DIAGNOSTIC_PUSH
+#  define _LIBCPP_DIAGNOSTIC_POP
+#  define _LIBCPP_CLANG_DIAGNOSTIC_IGNORED(str)
+#  define _LIBCPP_GCC_DIAGNOSTIC_IGNORED(str)
+#endif
+
+// Macros to enter and leave a state where deprecation warnings are suppressed.
+#define _LIBCPP_SUPPRESS_DEPRECATED_PUSH                                                                               \
+  _LIBCPP_DIAGNOSTIC_PUSH _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wdeprecated")                                             \
+      _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wdeprecated-declarations")
+#define _LIBCPP_SUPPRESS_DEPRECATED_POP _LIBCPP_DIAGNOSTIC_POP
+
+#endif // _LIBCPP___CONFIGURATION_DIAGNOSTIC_SUPPRESSION_H

--- a/libcxx/include/__configuration/namespace.h
+++ b/libcxx/include/__configuration/namespace.h
@@ -1,0 +1,82 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___CONFIGURATION_NAMESPACE_H
+#define _LIBCPP___CONFIGURATION_NAMESPACE_H
+
+#include <__config_site>
+#include <__configuration/attributes.h>
+#include <__configuration/diagnostic_suppression.h>
+
+#ifndef _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER
+#  pragma GCC system_header
+#endif
+
+// Clang modules take a significant compile time hit when pushing and popping diagnostics.
+// Since all the headers are marked as system headers unless _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER is defined, we can
+// simply disable this pushing and popping when _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER isn't defined.
+#ifdef _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER
+#  define _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS                                                                           \
+    _LIBCPP_DIAGNOSTIC_PUSH                                                                                            \
+    _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++11-extensions")                                                             \
+    _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++14-extensions")                                                             \
+    _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++17-extensions")                                                             \
+    _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++20-extensions")                                                             \
+    _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++23-extensions")                                                             \
+    _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++14-extensions")                                                               \
+    _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++17-extensions")                                                               \
+    _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++20-extensions")                                                               \
+    _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++23-extensions")
+#  define _LIBCPP_POP_EXTENSION_DIAGNOSTICS _LIBCPP_DIAGNOSTIC_POP
+#else
+#  define _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS
+#  define _LIBCPP_POP_EXTENSION_DIAGNOSTICS
+#endif
+
+// clang-format off
+
+// The unversioned namespace is used when we want to be ABI compatible with other standard libraries in some way. There
+// are two main categories where that's the case:
+// - Historically, we have made exception types ABI compatible with libstdc++ to allow throwing them between libstdc++
+//   and libc++. This is not used anymore for new exception types, since there is no use-case for it anymore.
+// - Types and functions which are used by the compiler are in the unversioned namespace, since the compiler has to know
+//   their mangling without the appropriate declaration in some cases.
+// If it's not clear whether using the unversioned namespace is the correct thing to do, it's not. The versioned
+// namespace (_LIBCPP_BEGIN_NAMESPACE_STD) should almost always be used.
+#  define _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD                                                                      \
+    _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS namespace _LIBCPP_NAMESPACE_VISIBILITY std {
+
+#  define _LIBCPP_END_UNVERSIONED_NAMESPACE_STD } _LIBCPP_POP_EXTENSION_DIAGNOSTICS
+
+#  define _LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD inline namespace _LIBCPP_ABI_NAMESPACE {
+#  define _LIBCPP_END_NAMESPACE_STD } _LIBCPP_END_UNVERSIONED_NAMESPACE_STD
+
+// TODO: This should really be in the versioned namespace
+#define _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD namespace experimental {
+#define _LIBCPP_END_NAMESPACE_EXPERIMENTAL } _LIBCPP_END_UNVERSIONED_NAMESPACE_STD
+
+#define _LIBCPP_BEGIN_NAMESPACE_LFTS _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL inline namespace fundamentals_v1 {
+#define _LIBCPP_END_NAMESPACE_LFTS } _LIBCPP_END_NAMESPACE_EXPERIMENTAL
+
+#define _LIBCPP_BEGIN_NAMESPACE_LFTS_V2 _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL inline namespace fundamentals_v2 {
+#define _LIBCPP_END_NAMESPACE_LFTS_V2 } _LIBCPP_END_NAMESPACE_EXPERIMENTAL
+
+#ifdef _LIBCPP_ABI_NO_FILESYSTEM_INLINE_NAMESPACE
+#  define _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM _LIBCPP_BEGIN_NAMESPACE_STD namespace filesystem {
+#  define _LIBCPP_END_NAMESPACE_FILESYSTEM } _LIBCPP_END_NAMESPACE_STD
+#else
+#  define _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM _LIBCPP_BEGIN_NAMESPACE_STD                                               \
+                                             inline namespace __fs { namespace filesystem {
+
+#  define _LIBCPP_END_NAMESPACE_FILESYSTEM }} _LIBCPP_END_NAMESPACE_STD
+#endif
+
+// clang-format on
+
+#endif // _LIBCPP___CONFIGURATION_NAMESPACE_H

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -7,9 +7,11 @@ module std_config [system] {
   textual header "__configuration/attributes.h"
   textual header "__configuration/availability.h"
   textual header "__configuration/compiler.h"
+  textual header "__configuration/diagnostic_suppression.h"
   textual header "__configuration/experimental.h"
   textual header "__configuration/hardening.h"
   textual header "__configuration/language.h"
+  textual header "__configuration/namespace.h"
   textual header "__configuration/platform.h"
   textual header "version"
 }


### PR DESCRIPTION
This is another step in splitting up `<__config>` to make it easier to understand what's going on and have logically separate parts of the configuration properly separated.