### PR TITLE
[lldb][windows] fix script interpreter file parsing

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -590,10 +590,10 @@ bool ScriptInterpreterPythonImpl::SetStdHandle(FileSP file_sp,
 
   auto new_file = PythonFile::FromFile(file, mode);
   if (!new_file) {
-    LLDB_LOG(GetLog(LLDBLog::Script),
-             "ScriptInterpreterPythonImpl::SetStdHandle failed to wrap "
-             "sys.{0}: {1}",
-             py_name, llvm::toString(new_file.takeError()));
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Script), new_file.takeError(),
+                   "ScriptInterpreterPythonImpl::SetStdHandle failed to wrap "
+                   "sys.{1}: {0}",
+                   py_name);
     return false;
   }
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -590,7 +590,10 @@ bool ScriptInterpreterPythonImpl::SetStdHandle(FileSP file_sp,
 
   auto new_file = PythonFile::FromFile(file, mode);
   if (!new_file) {
-    llvm::consumeError(new_file.takeError());
+    LLDB_LOG(GetLog(LLDBLog::Script),
+             "ScriptInterpreterPythonImpl::SetStdHandle failed to wrap "
+             "sys.{0}: {1}",
+             py_name, llvm::toString(new_file.takeError()));
     return false;
   }
 

--- a/lldb/test/Shell/ScriptInterpreter/Python/io.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/io.test
@@ -1,5 +1,3 @@
-# UNSUPPORTED: system-windows
-
 # RUN: rm -rf %t.stdout %t.stderr
 # RUN: cat %s | %lldb --script-language python > %t.stdout 2> %t.stderr
 # RUN: cat %t.stdout | FileCheck %s --check-prefix STDOUT

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -449,12 +449,8 @@ int Driver::MainLoop() {
     atexit(reset_stdin_termios);
   }
 
-#ifndef _MSC_VER
-  // Disabling stdin buffering with MSVC's 2015 CRT exposes a bug in fgets
-  // which causes it to miss newlines depending on whether there have been an
-  // odd or even number of characters.  Bug has been reported to MS via Connect.
+
   ::setbuf(stdin, nullptr);
-#endif
   ::setbuf(stdout, nullptr);
 
   m_debugger.SetErrorFileHandle(stderr, false);

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -449,7 +449,6 @@ int Driver::MainLoop() {
     atexit(reset_stdin_termios);
   }
 
-
   ::setbuf(stdin, nullptr);
   ::setbuf(stdout, nullptr);
 


### PR DESCRIPTION
This patch fixes running lldb interpreter commands from an input file.

With the following file:
```
# input.txt
script --language python --
value = 250 + 5
print(value)
```
Running `command source ./input.txt` in lldb would fail.

This patch fixes the issue by assuming we build on a recent version of MSVC (>2015), allowing to reenable `lldb\test\Shell\ScriptInterpreter\Python\io.test`.

rdar://168064451