### PR TITLE
[clang] Disable some module tests on AIX

### DIFF
--- a/clang/test/Modules/DebugInfoSubmodules.c
+++ b/clang/test/Modules/DebugInfoSubmodules.c
@@ -3,6 +3,7 @@
 // RUN:     -fimplicit-module-maps -x c -fmodules-cache-path=%t -I %S/Inputs \
 // RUN:     %s -mllvm -debug-only=pchcontainer -emit-llvm -o %t.ll \
 // RUN:     2>&1 | FileCheck %s
+// UNSUPPORTED: target={{.*}}-aix{{.*}}
 // REQUIRES: asserts
 #include "DebugSubmoduleA.h"
 

--- a/clang/test/Modules/lsv-debuginfo.cpp
+++ b/clang/test/Modules/lsv-debuginfo.cpp
@@ -1,4 +1,5 @@
 // Test C++ -gmodules debug info in the PCMs with local submodule visibility.
+// UNSUPPORTED: target={{.*}}-aix{{.*}}
 // REQUIRES: asserts
 // RUN: rm -rf %t
 // RUN: %clang_cc1 -triple %itanium_abi_triple -std=c++14 \


### PR DESCRIPTION
PR https://github.com/llvm/llvm-project/pull/190062 makes two module tests fail on AIX. Disable them on that platform until we get to the bottom of it.