### PR TITLE
[GlobalISel] Fix -Wunused-variable

### DIFF
--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -694,7 +694,7 @@ bool SwitchMatcher::addMatcher(Matcher &Candidate) {
 
 void SwitchMatcher::finalize() {
   assert(Condition == nullptr && "Already finalized");
-  unsigned NumBucketedMatchers = 0;
+  [[maybe_unused]] unsigned NumBucketedMatchers = 0;
   for (const auto &Entry : Buckets)
     NumBucketedMatchers += Entry.second.Matchers.size();
   assert(NumBucketedMatchers == Matchers.size() && "Broken SwitchMatcher");
@@ -748,7 +748,7 @@ void SwitchMatcher::emitPredicateSpecificOpcodes(const PredicateMatcher &P,
 }
 
 void SwitchMatcher::emit(MatchTable &Table) {
-  unsigned NumBucketedMatchers = 0;
+  [[maybe_unused]] unsigned NumBucketedMatchers = 0;
   for (const auto &Entry : Buckets)
     NumBucketedMatchers += Entry.second.Matchers.size();
   assert(NumBucketedMatchers == Matchers.size() && "Broken SwitchMatcher");


### PR DESCRIPTION
These variables are only used in assertions and set outside of the
variable definition, so mark them [[maybe_unused]].