### PR TITLE
[OpenACC] Make sure array-section diag normalizes width for diag

### DIFF
--- a/clang/lib/Sema/SemaOpenACC.cpp
+++ b/clang/lib/Sema/SemaOpenACC.cpp
@@ -996,11 +996,13 @@ ExprResult SemaOpenACC::ActOnArraySectionExpr(Expr *Base, SourceLocation LBLoc,
     }
   }
 
-  // Adding two APSInts requires matching sign, so extract that here.
+  // Adding two APSInts requires matching sign and width, so extract those here.
   auto AddAPSInt = [](llvm::APSInt LHS, llvm::APSInt RHS) -> llvm::APSInt {
-    if (LHS.isSigned() == RHS.isSigned())
+    if (LHS.isSigned() == RHS.isSigned() &&
+        LHS.getBitWidth() == RHS.getBitWidth())
       return LHS + RHS;
 
+    // Width is + 1 so that unsigned->signed conversion just works.
     unsigned Width = std::max(LHS.getBitWidth(), RHS.getBitWidth()) + 1;
     return llvm::APSInt(LHS.sext(Width) + RHS.sext(Width), /*Signed=*/true);
   };

--- a/clang/test/SemaOpenACC/compute-construct-private-clause.cpp
+++ b/clang/test/SemaOpenACC/compute-construct-private-clause.cpp
@@ -178,3 +178,20 @@ void incomplete_use(Incomplete &i) {
 #pragma acc parallel private(i)
   while (1);
 }
+
+namespace gh192783 {
+  constexpr char getChar() { return 3; }
+  constexpr unsigned long long getULL() { return 3; }
+
+void use() {
+  int array[5];
+#pragma acc parallel private(array[getChar():1])
+  while(1);
+#pragma acc parallel private(array[1:getChar()])
+  while(1);
+#pragma acc parallel private(array[getULL():1])
+  while(1);
+#pragma acc parallel private(array[1:getULL()])
+  while(1);
+}
+}


### PR DESCRIPTION
The below issue exposed that the comparison of the values was not properly adjusting the width of the constant values before comparison. Thus, when we did an addition of the two, it caused an assert in APSInt.

This patch makes sure that the 'adjust width + sign' branch is taken if the sign or width don't match.  Previously we only did this if it was a sign mismatch.

Fixes: #192783