### PR TITLE
[IR] Avoid redundant TrackingMDRef reassignments and DebugLoc copies

### DIFF
--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -244,7 +244,20 @@ public:
   }
 
   /// Set location information used by debugging information.
-  void SetCurrentDebugLocation(DebugLoc L) {
+  void SetCurrentDebugLocation(const DebugLoc &L) {
+    if (StoredDL == L)
+      return;
+
+    // For !dbg metadata attachments, we use DebugLoc instead of the raw MDNode
+    // to include optional introspection data for use in Debugify.
+    StoredDL = L;
+  }
+
+  /// Set location information used by debugging information.
+  void SetCurrentDebugLocation(DebugLoc &&L) {
+    if (StoredDL == L)
+      return;
+
     // For !dbg metadata attachments, we use DebugLoc instead of the raw MDNode
     // to include optional introspection data for use in Debugify.
     StoredDL = std::move(L);

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -245,9 +245,6 @@ public:
 
   /// Set location information used by debugging information.
   void SetCurrentDebugLocation(const DebugLoc &L) {
-    if (StoredDL == L)
-      return;
-
     // For !dbg metadata attachments, we use DebugLoc instead of the raw MDNode
     // to include optional introspection data for use in Debugify.
     StoredDL = L;
@@ -255,9 +252,6 @@ public:
 
   /// Set location information used by debugging information.
   void SetCurrentDebugLocation(DebugLoc &&L) {
-    if (StoredDL == L)
-      return;
-
     // For !dbg metadata attachments, we use DebugLoc instead of the raw MDNode
     // to include optional introspection data for use in Debugify.
     StoredDL = std::move(L);

--- a/llvm/include/llvm/IR/TrackingMDRef.h
+++ b/llvm/include/llvm/IR/TrackingMDRef.h
@@ -33,7 +33,7 @@ public:
   TrackingMDRef(const TrackingMDRef &X) : MD(X.MD) { track(); }
 
   TrackingMDRef &operator=(TrackingMDRef &&X) {
-    if (&X == this)
+    if (&X == this || MD == X.MD)
       return *this;
 
     untrack();
@@ -43,7 +43,7 @@ public:
   }
 
   TrackingMDRef &operator=(const TrackingMDRef &X) {
-    if (&X == this)
+    if (&X == this || MD == X.MD)
       return *this;
 
     untrack();


### PR DESCRIPTION
Found while profiling clang compiling `SLPVectorizer.cpp`. Avoiding redundant `TrackingMDRef` reassignments and `DebugLoc` copies yields nice little speed improvements in almost all cases, especially for builds with debug info, for some even up to -0.7%:
https://llvm-compile-time-tracker.com/compare.php?from=78820cb91605693b7d768be4ebc8b66181d3e9c3&to=60ab989d605cae93452aba2aff459a02b7cc9839