### PR TITLE
[CIR] Allow _setjmp and _setjmpex to fall through to library calls

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -2226,9 +2226,15 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI_exception_info:
   case Builtin::BI__abnormal_termination:
   case Builtin::BI_abnormal_termination:
+    return errorBuiltinNYI(*this, e, builtinID);
   case Builtin::BI_setjmpex:
   case Builtin::BI_setjmp:
-    return errorBuiltinNYI(*this, e, builtinID);
+    if (getTarget().getTriple().isOSMSVCRT()) {
+      cgm.errorNYI(e->getSourceRange(), "setjmp/setjmpex on MSVCRT");
+      return getUndefRValue(e->getType());
+    }
+    // Else break and this will be handled as a library call.
+    break;
   case Builtin::BImove:
   case Builtin::BImove_if_noexcept:
   case Builtin::BIforward:

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -20,6 +20,7 @@
 #include "clang/CIR/ABIArgInfo.h"
 #include "clang/CIR/MissingFeatures.h"
 #include "llvm/ADT/FloatingPointMode.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Support/TypeSize.h"
 
 using namespace clang;
@@ -475,10 +476,22 @@ void CIRGenModule::constructAttributeList(
       attrs.erase(cir::CIRDialect::getConvergentAttrName());
   }
 
+  // Collect non-call-site function IR attributes from declaration-specific
+  // information.
+  if (!attrOnCallSite) {
+    // These functions require the returns_twice attribute for correct
+    // codegen, but the attribute may not be added if -fno-builtin is
+    // specified. We explicitly add that attribute here.
+    static const llvm::StringSet<> returnsTwiceFn{
+        "_setjmpex", "setjmp",      "_setjmp", "vfork",
+        "sigsetjmp", "__sigsetjmp", "savectx", "getcontext"};
+    if (returnsTwiceFn.contains(name))
+      addUnitAttr(cir::CIRDialect::getReturnsTwiceAttrName());
+  }
+
   // TODO(cir): A bunch of non-call-site function IR attributes from
   // declaration-specific information, including tail calls,
-  // cmse_nonsecure_entry, additional/automatic 'returns-twice' functions,
-  // CPU-features/overrides, and hotpatch support.
+  // cmse_nonsecure_entry, CPU-features/overrides, and hotpatch support.
 
   // TODO(cir): Add loader-replaceable attribute here.
 

--- a/clang/test/CIR/CodeGenBuiltins/setjmp.c
+++ b/clang/test/CIR/CodeGenBuiltins/setjmp.c
@@ -1,0 +1,95 @@
+// RUN: %clang_cc1 -x c %s -triple x86_64-linux-gnu -fclangir -emit-cir -o %t.cir
+// RUN: FileCheck --check-prefix=CIR      --input-file=%t.cir %s
+// RUN: %clang_cc1 -x c %s -triple x86_64-linux-gnu -fno-builtin -fclangir -emit-cir -o %t.cir
+// RUN: FileCheck --check-prefix=CIR      --input-file=%t.cir %s
+// RUN: %clang_cc1 -x c++ %s -triple x86_64-linux-gnu -fclangir -emit-cir -o %t.cir
+// RUN: FileCheck --check-prefix=CIR      --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -x c %s -triple x86_64-linux-gnu -fclangir -emit-llvm -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM      --input-file=%t-cir.ll %s
+// RUN: FileCheck --check-prefix=LLVM-DECL --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -x c %s -triple x86_64-linux-gnu -fno-builtin -fclangir -emit-llvm -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM      --input-file=%t-cir.ll %s
+// RUN: FileCheck --check-prefix=LLVM-DECL --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -x c++ %s -triple x86_64-linux-gnu -fclangir -emit-llvm -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM      --input-file=%t-cir.ll %s
+// RUN: FileCheck --check-prefix=LLVM-DECL --input-file=%t-cir.ll %s
+
+// RUN: %clang_cc1 -x c %s -triple x86_64-linux-gnu -emit-llvm -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM      --input-file=%t.ll %s
+// RUN: FileCheck --check-prefix=LLVM-DECL --input-file=%t.ll %s
+// RUN: %clang_cc1 -x c %s -triple x86_64-linux-gnu -fno-builtin -emit-llvm -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM      --input-file=%t.ll %s
+// RUN: FileCheck --check-prefix=LLVM-DECL --input-file=%t.ll %s
+// RUN: %clang_cc1 -x c++ %s -triple x86_64-linux-gnu -emit-llvm -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM      --input-file=%t.ll %s
+// RUN: FileCheck --check-prefix=LLVM-DECL --input-file=%t.ll %s
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct __jmp_buf_tag { int n; };
+struct __ucontext_t_tag { int n; };
+int setjmp(struct __jmp_buf_tag*);
+int sigsetjmp(struct __jmp_buf_tag*, int);
+int _setjmp(struct __jmp_buf_tag*);
+int __sigsetjmp(struct __jmp_buf_tag*, int);
+int _setjmpex(struct __jmp_buf_tag* env);
+int getcontext(struct __ucontext_t_tag*);
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+typedef struct __ucontext_t_tag ucontext_t[1];
+
+#ifdef __cplusplus
+}
+#endif
+
+// The wildcard in the attributes is to allow this to work with and without -fno-builtin.
+
+// CIR: cir.func private @setjmp({{.*}}) -> !s32i attributes {{{.*}}returns_twice}
+// CIR: cir.func private @sigsetjmp({{.*}}) -> !s32i attributes {{{.*}}returns_twice}
+// CIR: cir.func private @_setjmp({{.*}}) -> !s32i attributes {{{.*}}returns_twice}
+// CIR: cir.func private @__sigsetjmp({{.*}}) -> !s32i attributes {{{.*}}returns_twice}
+// CIR: cir.func private @_setjmpex({{.*}}) -> !s32i attributes {{{.*}}returns_twice}
+// CIR: cir.func private @getcontext({{.*}}) -> !s32i attributes {{{.*}}returns_twice}
+
+void f(void) {
+  jmp_buf jb;
+  ucontext_t ut;
+  // CIR: cir.call @setjmp(
+  // LLVM: call {{.*}} @setjmp(
+  setjmp(jb);
+  // CIR: cir.call @sigsetjmp(
+  // LLVM: call {{.*}} @sigsetjmp(
+  sigsetjmp(jb, 0);
+  // CIR: cir.call @_setjmp(
+  // LLVM: call {{.*}} @_setjmp(
+  _setjmp(jb);
+  // CIR: cir.call @__sigsetjmp(
+  // LLVM: call {{.*}} @__sigsetjmp(
+  __sigsetjmp(jb, 0);
+  // CIR: cir.call @_setjmpex(
+  // LLVM: call {{.*}} @_setjmpex(
+  _setjmpex(jb);
+  // CIR: cir.call @getcontext(
+  // LLVM: call {{.*}} @getcontext(
+  getcontext(ut);
+}
+
+// These are checked with a separate RUN and check prefix because classic
+// codegen emits them after the definition of @f, while CIR emits them before.
+
+// LLVM-DECL: ; Function Attrs: returns_twice
+// LLVM-DECL-NEXT: declare {{.*}} @setjmp(
+// LLVM-DECL: ; Function Attrs: returns_twice
+// LLVM-DECL-NEXT: declare {{.*}} @sigsetjmp(
+// LLVM-DECL: ; Function Attrs: returns_twice
+// LLVM-DECL-NEXT: declare {{.*}} @_setjmp(
+// LLVM-DECL: ; Function Attrs: returns_twice
+// LLVM-DECL-NEXT: declare {{.*}} @__sigsetjmp(
+// LLVM-DECL: ; Function Attrs: returns_twice
+// LLVM-DECL-NEXT: declare {{.*}} @_setjmpex(
+// LLVM-DECL: ; Function Attrs: returns_twice
+// LLVM-DECL-NEXT: declare {{.*}} @getcontext(


### PR DESCRIPTION
This change allows calls to _setjmp and _setjmpex to fall through the builtin handling and be emitted as library calls when we are not targeting OSMSVCRT. It also adds the code to set "returns_twice" on functions matching an explicit list, as they are in classic codegen.