### PR TITLE
AMDGPU/GlobalISel: RegbankLegalize rules for merge-like opcodes

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalize.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalize.cpp
@@ -458,16 +458,6 @@ bool AMDGPURegBankLegalize::runOnMachineFunction(MachineFunction &MF) {
     if (!MI->isPreISelOpcode())
       continue;
 
-    unsigned Opc = MI->getOpcode();
-
-    // Opcodes that support pretty much all combinations of reg banks and LLTs
-    // (except S1). There is no point in writing rules for them.
-    if (Opc == AMDGPU::G_BUILD_VECTOR || Opc == AMDGPU::G_MERGE_VALUES ||
-        Opc == AMDGPU::G_CONCAT_VECTORS) {
-      RBLHelper.applyMappingTrivial(*MI);
-      continue;
-    }
-
     if (!RBLHelper.findRuleAndApplyMapping(*MI))
       return false;
   }

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
@@ -2102,28 +2102,6 @@ bool RegBankLegalizeHelper::applyMappingSrc(
   return true;
 }
 
-void RegBankLegalizeHelper::applyMappingTrivial(MachineInstr &MI) {
-  const RegisterBank *RB = MRI.getRegBank(MI.getOperand(0).getReg());
-  // Put RB on all registers
-  unsigned NumDefs = MI.getNumDefs();
-  unsigned NumOperands = MI.getNumOperands();
-
-  assert(verifyRegBankOnOperands(MI, RB, MRI, 0, NumDefs - 1));
-  if (RB == SgprRB)
-    assert(verifyRegBankOnOperands(MI, RB, MRI, NumDefs, NumOperands - 1));
-
-  if (RB == VgprRB) {
-    B.setInstr(MI);
-    for (unsigned i = NumDefs; i < NumOperands; ++i) {
-      Register Reg = MI.getOperand(i).getReg();
-      if (MRI.getRegBank(Reg) != RB) {
-        auto Copy = B.buildCopy({VgprRB, MRI.getType(Reg)}, Reg);
-        MI.getOperand(i).setReg(Copy.getReg(0));
-      }
-    }
-  }
-}
-
 bool RegBankLegalizeHelper::applyRegisterBanksINTRIN_IMAGE(MachineInstr &MI) {
   const AMDGPU::RsrcIntrinsic *RSrcIntrin =
       AMDGPU::lookupRsrcIntrinsic(AMDGPU::getIntrinsicID(MI));

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.h
@@ -95,9 +95,6 @@ public:
 
   bool findRuleAndApplyMapping(MachineInstr &MI);
 
-  // Manual apply helpers.
-  void applyMappingTrivial(MachineInstr &MI);
-
 private:
   bool executeInWaterfallLoop(MachineIRBuilder &B, const WaterfallInfo &WFI);
 

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -690,6 +690,16 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
       .Any({{UniBRC}, {{}, {}, VerifyAllSgpr}})
       .Any({{DivBRC}, {{}, {}, ApplyAllVgpr}});
 
+  addRulesForGOpcs({G_BUILD_VECTOR})
+      .Any({{UniBRC, S16}, {{}, {}, VerifyAllSgpr}})
+      .Any({{UniBRC, BRC}, {{}, {}, VerifyAllSgpr}})
+      .Any({{DivBRC, S16}, {{}, {}, ApplyAllVgpr}})
+      .Any({{DivBRC, BRC}, {{}, {}, ApplyAllVgpr}});
+
+  addRulesForGOpcs({G_MERGE_VALUES, G_CONCAT_VECTORS})
+      .Any({{UniBRC, BRC}, {{}, {}, VerifyAllSgpr}})
+      .Any({{DivBRC, BRC}, {{}, {}, ApplyAllVgpr}});
+
   addRulesForGOpcs({G_PHI})
       .Any({{UniS1}, {{}, {}, AextToS32InIncomingBlockGPHI}})
       .Any({{UniS16}, {{}, {}, VerifyAllSgprGPHI}})


### PR DESCRIPTION
Move RegbankLegalize handling for G_BUILD_VECTOR, G_MERGE_VALUES and
G_CONCAT_VECTORS from AMDGPURegBankLegalize to AMDGPURegBankLegalizeRules
by implementing rules for all supported types.