### PR TITLE
[clang][ssaf][NFC] Standardize getter naming to use `get/take` prefixes

### DIFF
--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/EntityLinker.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/EntityLinker.h
@@ -51,7 +51,7 @@ public:
   ///
   /// \returns LU summary containing all the deduplicated and patched entity
   /// summaries.
-  LUSummaryEncoding getOutput() && { return std::move(Output); }
+  LUSummaryEncoding takeOutput() && { return std::move(Output); }
 
 private:
   /// Resolves a TU entity name to an LU entity name and ID.

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/SummaryData/SummaryDataBuilder.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/SummaryData/SummaryDataBuilder.h
@@ -30,7 +30,7 @@ class LUSummaryConsumer;
 ///
 /// Known to the registry and LUSummaryConsumer. Receives entities one at a
 /// time via \c addSummary(), is finalized via \c finalize(), and transfers
-/// ownership of the built data via \c getData().
+/// ownership of the built data via \c takeData().
 class SummaryDataBuilderBase {
   friend class LUSummaryConsumer;
 
@@ -49,7 +49,7 @@ private:
   /// Transfers ownership of the built data. Called by LUSummaryConsumer after
   /// finalize(). The rvalue ref-qualifier enforces single use — the builder
   /// cannot be accessed after this call.
-  virtual std::unique_ptr<SummaryData> getData() && = 0;
+  virtual std::unique_ptr<SummaryData> takeData() && = 0;
 };
 
 /// Typed intermediate template that concrete builders inherit from.
@@ -81,7 +81,9 @@ protected:
   DataT &getData() & { return *Data; }
 
 private:
-  std::unique_ptr<SummaryData> getData() && override { return std::move(Data); }
+  std::unique_ptr<SummaryData> takeData() && override {
+    return std::move(Data);
+  }
 
   /// Seals the base overload, downcasts, and dispatches to the typed overload.
   void addSummary(EntityId Id, std::unique_ptr<EntitySummary> Summary) final {

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/AnalysisBase.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/AnalysisBase.h
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 //
 // Minimal common base for SummaryAnalysisBase and DerivedAnalysisBase.
-// Carries the identity (analysisName()) and dependency list
-// (dependencyNames()) shared by every analysis regardless of kind.
+// Carries the identity (getAnalysisName()) and dependency list
+// (getDependencyNames()) shared by every analysis regardless of kind.
 //
 //===----------------------------------------------------------------------===//
 
@@ -45,14 +45,14 @@ public:
 
   /// Name of this analysis. Equal to ResultT::analysisName() in both typed
   /// intermediates.
-  virtual AnalysisName analysisName() const = 0;
+  virtual AnalysisName getAnalysisName() const = 0;
 
   /// AnalysisNames of all AnalysisResult dependencies.
-  virtual const std::vector<AnalysisName> &dependencyNames() const = 0;
+  virtual const std::vector<AnalysisName> &getDependencyNames() const = 0;
 
   /// Transfers ownership of the built result. Called once after finalize().
   /// The rvalue ref-qualifier enforces single use.
-  virtual std::unique_ptr<AnalysisResult> result() && = 0;
+  virtual std::unique_ptr<AnalysisResult> takeResult() && = 0;
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/DerivedAnalysis.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/DerivedAnalysis.h
@@ -86,9 +86,9 @@ class DerivedAnalysis : public DerivedAnalysisBase {
 
 public:
   /// Used by AnalysisRegistry::Add to derive the registry entry name.
-  AnalysisName analysisName() const final { return ResultT::analysisName(); }
+  AnalysisName getAnalysisName() const final { return ResultT::analysisName(); }
 
-  const std::vector<AnalysisName> &dependencyNames() const final {
+  const std::vector<AnalysisName> &getDependencyNames() const final {
     static const std::vector<AnalysisName> Names = {
         DepResultTs::analysisName()...};
     return Names;
@@ -106,10 +106,10 @@ public:
 
 protected:
   /// Read-only access to the result being built.
-  const ResultT &result() const & { return *Result; }
+  const ResultT &getResult() const & { return *Result; }
 
   /// Mutable access to the result being built.
-  ResultT &result() & { return *Result; }
+  ResultT &getResult() & { return *Result; }
 
 private:
   /// Seals the type-erased base overload, downcasts, and dispatches to the
@@ -130,7 +130,7 @@ private:
   }
 
   /// Type-erased result extraction for the driver.
-  std::unique_ptr<AnalysisResult> result() && final {
+  std::unique_ptr<AnalysisResult> takeResult() && final {
     return std::move(Result);
   }
 };

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/SummaryAnalysis.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/SummaryAnalysis.h
@@ -44,7 +44,7 @@ protected:
 public:
   /// SummaryName of the EntitySummary type this analysis consumes.
   /// Used by the driver to route entities from the LUSummary.
-  virtual SummaryName summaryName() const = 0;
+  virtual SummaryName getSummaryName() const = 0;
 
 private:
   /// Called once before any add() calls. Default is a no-op.
@@ -64,8 +64,8 @@ private:
 ///   llvm::Error add(EntityId Id, const EntitySummaryT &Summary) override;
 /// and may override initialize() and finalize().
 ///
-/// The result being built is accessible via result() const & (read-only) and
-/// result() & (mutable) within the analysis implementation.
+/// The result being built is accessible via getResult() const & (read-only) and
+/// getResult() & (mutable) within the analysis implementation.
 template <typename ResultT, typename EntitySummaryT>
 class SummaryAnalysis : public SummaryAnalysisBase {
   static_assert(std::is_base_of_v<AnalysisResult, ResultT>,
@@ -82,13 +82,13 @@ class SummaryAnalysis : public SummaryAnalysisBase {
 
 public:
   /// Used by AnalysisRegistry::Add to derive the registry entry name.
-  AnalysisName analysisName() const final { return ResultT::analysisName(); }
+  AnalysisName getAnalysisName() const final { return ResultT::analysisName(); }
 
-  SummaryName summaryName() const final {
+  SummaryName getSummaryName() const final {
     return EntitySummaryT::summaryName();
   }
 
-  const std::vector<AnalysisName> &dependencyNames() const final {
+  const std::vector<AnalysisName> &getDependencyNames() const final {
     static const std::vector<AnalysisName> Empty;
     return Empty;
   }
@@ -105,10 +105,10 @@ public:
 
 protected:
   /// Read-only access to the result being built.
-  const ResultT &result() const & { return *Result; }
+  const ResultT &getResult() const & { return *Result; }
 
   /// Mutable access to the result being built.
-  ResultT &result() & { return *Result; }
+  ResultT &getResult() & { return *Result; }
 
 private:
   /// Seals the type-erased base overload, downcasts, and dispatches to the
@@ -118,7 +118,7 @@ private:
   }
 
   /// Type-erased result extraction for the driver.
-  std::unique_ptr<AnalysisResult> result() && final {
+  std::unique_ptr<AnalysisResult> takeResult() && final {
     return std::move(Result);
   }
 };

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/WPASuite.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/WPASuite.h
@@ -47,7 +47,7 @@ class WPASuite {
 public:
   /// Returns the EntityIdTable that maps EntityId values to their symbolic
   /// names.
-  const EntityIdTable &idTable() const { return IdTable; }
+  const EntityIdTable &getIdTable() const { return IdTable; }
 
   /// Returns true if a result for \p ResultT is present.
   template <typename ResultT> [[nodiscard]] bool contains() const {

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/SummaryData/LUSummaryConsumer.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/SummaryData/LUSummaryConsumer.cpp
@@ -30,7 +30,7 @@ LUSummaryConsumer::build(LUDataIterator LUIt) {
   Builder->finalize();
   LU->Data.erase(LUIt);
 
-  return std::move(*Builder).getData();
+  return std::move(*Builder).takeData();
 }
 
 llvm::Expected<std::unique_ptr<SummaryData>>

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/AnalysisDriver.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/AnalysisDriver.cpp
@@ -72,7 +72,7 @@ AnalysisDriver::toposort(llvm::ArrayRef<AnalysisName> Roots) {
         // Expected on every subsequent access.
         std::unique_ptr<AnalysisBase> Analysis = std::move(*V);
 
-        for (const auto &Dep : Analysis->dependencyNames()) {
+        for (const auto &Dep : Analysis->getDependencyNames()) {
           if (auto Err = visit(Dep)) {
             return Err;
           }
@@ -102,12 +102,12 @@ AnalysisDriver::toposort(llvm::ArrayRef<AnalysisName> Roots) {
 
 llvm::Error AnalysisDriver::executeSummaryAnalysis(SummaryAnalysisBase &Summary,
                                                    WPASuite &Suite) const {
-  SummaryName SN = Summary.summaryName();
+  SummaryName SN = Summary.getSummaryName();
   auto DataIt = LU->Data.find(SN);
   if (DataIt == LU->Data.end()) {
     return ErrorBuilder::create(std::errc::invalid_argument,
                                 "no data for analysis '{0}' in LUSummary",
-                                Summary.analysisName())
+                                Summary.getAnalysisName())
         .build();
   }
 
@@ -132,12 +132,12 @@ llvm::Error AnalysisDriver::executeDerivedAnalysis(DerivedAnalysisBase &Derived,
                                                    WPASuite &Suite) const {
   std::map<AnalysisName, const AnalysisResult *> DepMap;
 
-  for (const auto &DepName : Derived.dependencyNames()) {
+  for (const auto &DepName : Derived.getDependencyNames()) {
     auto It = Suite.Data.find(DepName);
     if (It == Suite.Data.end()) {
       ErrorBuilder::fatal("missing dependency '{0}' for analysis '{1}': "
                           "dependency graph is not topologically sorted",
-                          DepName, Derived.analysisName());
+                          DepName, Derived.getAnalysisName());
     }
     DepMap[DepName] = It->second.get();
   }
@@ -186,8 +186,8 @@ llvm::Expected<WPASuite> AnalysisDriver::execute(
       break;
     }
     }
-    AnalysisName Name = Analysis->analysisName();
-    Suite.Data.emplace(std::move(Name), std::move(*Analysis).result());
+    AnalysisName Name = Analysis->getAnalysisName();
+    Suite.Data.emplace(std::move(Name), std::move(*Analysis).takeResult());
   }
 
   return std::move(Suite);

--- a/clang/lib/ScalableStaticAnalysisFramework/Plugins/ExamplePlugin/PairsAnalysis.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Plugins/ExamplePlugin/PairsAnalysis.cpp
@@ -186,7 +186,7 @@ public:
   using ResultType = PairsAnalysisResult;
 
   llvm::Error add(EntityId Id, const PairsEntitySummary &S) override {
-    result().PairCounts.emplace_back(Id, static_cast<int>(S.Pairs.size()));
+    getResult().PairCounts.emplace_back(Id, static_cast<int>(S.Pairs.size()));
     return llvm::Error::success();
   }
 };

--- a/clang/lib/ScalableStaticAnalysisFramework/Plugins/ExamplePlugin/TagsAnalysis.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Plugins/ExamplePlugin/TagsAnalysis.cpp
@@ -141,13 +141,13 @@ public:
 
   llvm::Error add(EntityId, const TagsEntitySummary &S) override {
     for (const auto &Tag : S.Tags) {
-      result().Tags.push_back(Tag);
+      getResult().Tags.push_back(Tag);
     }
     return llvm::Error::success();
   }
 
   llvm::Error finalize() override {
-    auto &Tags = result().Tags;
+    auto &Tags = getResult().Tags;
     std::sort(Tags.begin(), Tags.end());
     Tags.erase(std::unique(Tags.begin(), Tags.end()), Tags.end());
     return llvm::Error::success();

--- a/clang/lib/ScalableStaticAnalysisFramework/Plugins/ExamplePlugin/TagsPairsAnalysis.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Plugins/ExamplePlugin/TagsPairsAnalysis.cpp
@@ -109,8 +109,8 @@ public:
 
   llvm::Error initialize(const TagsAnalysisResult &Tags,
                          const PairsAnalysisResult &Pairs) override {
-    result().UniqueTagCount = static_cast<int>(Tags.Tags.size());
-    result().EntityCount = static_cast<int>(Pairs.PairCounts.size());
+    getResult().UniqueTagCount = static_cast<int>(Tags.Tags.size());
+    getResult().EntityCount = static_cast<int>(Pairs.PairCounts.size());
 
     int Total = 0;
     int Max = 0;
@@ -119,8 +119,8 @@ public:
       if (Count > Max)
         Max = Count;
     }
-    result().TotalPairCount = Total;
-    result().MaxPairsPerEntity = Max;
+    getResult().TotalPairCount = Total;
+    getResult().MaxPairsPerEntity = Max;
 
     return llvm::Error::success();
   }

--- a/clang/tools/clang-ssaf-linker/SSAFLinker.cpp
+++ b/clang/tools/clang-ssaf-linker/SSAFLinker.cpp
@@ -169,7 +169,7 @@ void link(const LinkerInput &LI, llvm::TimerGroup &TG) {
 
     llvm::TimeRegion _(Time ? &TWrite : nullptr);
 
-    auto Output = std::move(EL).getOutput();
+    auto Output = std::move(EL).takeOutput();
     if (auto Err = LI.OutputFile.Format->writeLUSummaryEncoding(
             Output, LI.OutputFile.Path)) {
       fail(std::move(Err));

--- a/clang/unittests/ScalableStaticAnalysisFramework/EntityLinkerTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/EntityLinkerTest.cpp
@@ -197,7 +197,7 @@ TEST_F(EntityLinkerTest, CreatesEmptyLinker) {
 
   EntityLinker Linker(LUNamespace);
 
-  const auto Output = std::move(Linker).getOutput();
+  const auto Output = std::move(Linker).takeOutput();
   EXPECT_EQ(getIdTable(Output).count(), 0u);
   EXPECT_EQ(getLinkageTable(Output).size(), 0u);
   EXPECT_EQ(getData(Output).size(), 0u);
@@ -214,7 +214,7 @@ TEST_F(EntityLinkerTest, LinksEmptyTranslationUnit) {
 
   EXPECT_THAT_ERROR(Linker.link(std::move(TUEmpty)), llvm::Succeeded());
 
-  const auto Output = std::move(Linker).getOutput();
+  const auto Output = std::move(Linker).takeOutput();
   EXPECT_EQ(getIdTable(Output).count(), 0u);
   EXPECT_EQ(getLinkageTable(Output).size(), 0u);
   EXPECT_EQ(getData(Output).size(), 0u);
@@ -246,7 +246,7 @@ TEST_F(EntityLinkerTest, LinksOneTranslationUnit) {
 
   ASSERT_THAT_ERROR(Linker.link(std::move(TU)), llvm::Succeeded());
 
-  const auto Output = std::move(Linker).getOutput();
+  const auto Output = std::move(Linker).takeOutput();
   const auto &IdTable = getIdTable(Output);
   const auto &Entities = getEntities(IdTable);
   const auto &LinkageTable = getLinkageTable(Output);
@@ -411,7 +411,7 @@ TEST_F(EntityLinkerTest, LinksTwoTranslationUnits) {
 
   ASSERT_THAT_ERROR(Linker.link(std::move(TU2)), llvm::Succeeded());
 
-  const auto Output = std::move(Linker).getOutput();
+  const auto Output = std::move(Linker).takeOutput();
   const auto &IdTable = getIdTable(Output);
   const auto &Entities = getEntities(IdTable);
   const auto &LinkageTable = getLinkageTable(Output);
@@ -648,7 +648,7 @@ TEST_F(EntityLinkerTest, InternalLinkageWithEmptyNamespaceAcrossTUs) {
   ASSERT_THAT_ERROR(Linker.link(std::move(TU2)), llvm::Succeeded());
 
   // Check that the two internal symbols are not merged.
-  const auto Output = std::move(Linker).getOutput();
+  const auto Output = std::move(Linker).takeOutput();
   const auto &IdTable = getIdTable(Output);
 
   NestedBuildNamespace TU1NS{{{CompilationUnit, "TU1"}, {LinkUnit, "LU"}}};

--- a/clang/unittests/ScalableStaticAnalysisFramework/WholeProgramAnalysis/AnalysisDriverTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/WholeProgramAnalysis/AnalysisDriverTest.cpp
@@ -165,17 +165,17 @@ public:
   ~Analysis1() { WasDestroyed = true; }
 
   llvm::Error initialize() override {
-    result().WasInitialized = true;
+    getResult().WasInitialized = true;
     return llvm::Error::success();
   }
 
   llvm::Error add(EntityId Id, const Analysis1EntitySummary &S) override {
-    result().Entries.push_back({Id, S.InstanceId});
+    getResult().Entries.push_back({Id, S.InstanceId});
     return llvm::Error::success();
   }
 
   llvm::Error finalize() override {
-    result().WasFinalized = true;
+    getResult().WasFinalized = true;
     return llvm::Error::success();
   }
 };
@@ -193,17 +193,17 @@ public:
   ~Analysis2() { WasDestroyed = true; }
 
   llvm::Error initialize() override {
-    result().WasInitialized = true;
+    getResult().WasInitialized = true;
     return llvm::Error::success();
   }
 
   llvm::Error add(EntityId Id, const Analysis2EntitySummary &S) override {
-    result().Entries.push_back({Id, S.InstanceId});
+    getResult().Entries.push_back({Id, S.InstanceId});
     return llvm::Error::success();
   }
 
   llvm::Error finalize() override {
-    result().WasFinalized = true;
+    getResult().WasFinalized = true;
     return llvm::Error::success();
   }
 };
@@ -219,17 +219,17 @@ public:
   ~Analysis4() { WasDestroyed = true; }
 
   llvm::Error initialize() override {
-    result().WasInitialized = true;
+    getResult().WasInitialized = true;
     return llvm::Error::success();
   }
 
   llvm::Error add(EntityId Id, const Analysis4EntitySummary &S) override {
-    result().Entries.push_back({Id, S.InstanceId});
+    getResult().Entries.push_back({Id, S.InstanceId});
     return llvm::Error::success();
   }
 
   llvm::Error finalize() override {
-    result().WasFinalized = true;
+    getResult().WasFinalized = true;
     return llvm::Error::success();
   }
 };
@@ -247,20 +247,20 @@ public:
 
   llvm::Error initialize(const Analysis1Result &R1, const Analysis2Result &R2,
                          const Analysis4Result &R4) override {
-    result().CallSequence.push_back("initialize");
-    result().Analysis1Entries = R1.Entries;
-    result().Analysis2Entries = R2.Entries;
-    result().Analysis4Entries = R4.Entries;
+    getResult().CallSequence.push_back("initialize");
+    getResult().Analysis1Entries = R1.Entries;
+    getResult().Analysis2Entries = R2.Entries;
+    getResult().Analysis4Entries = R4.Entries;
     return llvm::Error::success();
   }
 
   llvm::Expected<bool> step() override {
-    result().CallSequence.push_back("step");
+    getResult().CallSequence.push_back("step");
     return ++StepCount < 2;
   }
 
   llvm::Error finalize() override {
-    result().CallSequence.push_back("finalize");
+    getResult().CallSequence.push_back("finalize");
     return llvm::Error::success();
   }
 };


### PR DESCRIPTION
To make our APIs uniform, this change add `get` prefix to instance accessors, and `take` prefix to "move-out" methods. Removing `get` prefix throughout turns out to be a bigger change, so I have chosen to add the prefix to these methods instead.