### PR TITLE
[RISCV][GISel] Add variant_cc test. NFC

### DIFF
--- a/llvm/test/CodeGen/RISCV/GlobalISel/rvv/variant-cc.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/rvv/variant-cc.ll
@@ -1,0 +1,43 @@
+; RUN: llc -mtriple=riscv64 -mattr=+v -global-isel -o - %s | FileCheck %s --check-prefix=CHECK-ASM
+; RUN: llc -mtriple=riscv64 -mattr=+v -global-isel -filetype=obj -o - %s \
+; RUN:   | llvm-readobj --symbols - | FileCheck %s --check-prefix=CHECK-OBJ
+
+define i32 @base_cc() {
+; CHECK-ASM-LABEL: base_cc:
+; CHECK-ASM-NOT: .variant_cc
+; CHECK-OBJ-LABEL: Name: base_cc
+; CHECK-OBJ: Other: 0
+  ret i32 42
+}
+
+define <vscale x 4 x i32> @rvv_vector_cc_1() {
+; CHECK-ASM: .variant_cc rvv_vector_cc_1
+; CHECK-ASM-NEXT: rvv_vector_cc_1:
+; CHECK-OBJ-LABEL: Name: rvv_vector_cc_1
+; CHECK-OBJ: Other [ (0x80)
+  ret <vscale x 4 x i32> poison
+}
+
+define <vscale x 4 x i1> @rvv_vector_cc_2() {
+; CHECK-ASM: .variant_cc rvv_vector_cc_2
+; CHECK-ASM-NEXT: rvv_vector_cc_2:
+; CHECK-OBJ-LABEL: Name: rvv_vector_cc_2
+; CHECK-OBJ: Other [ (0x80)
+  ret <vscale x 4 x i1> poison
+}
+
+define void @rvv_vector_cc_3(<vscale x 4 x i32> %arg) {
+; CHECK-ASM: .variant_cc rvv_vector_cc_3
+; CHECK-ASM-NEXT: rvv_vector_cc_3:
+; CHECK-OBJ-LABEL: Name: rvv_vector_cc_3
+; CHECK-OBJ: Other [ (0x80)
+  ret void
+}
+
+define void @rvv_vector_cc_4(<vscale x 4 x i1> %arg) {
+; CHECK-ASM: .variant_cc rvv_vector_cc_4
+; CHECK-ASM-NEXT: rvv_vector_cc_4:
+; CHECK-OBJ-LABEL: Name: rvv_vector_cc_4
+; CHECK-OBJ: Other [ (0x80)
+  ret void
+}


### PR DESCRIPTION
I couldn't add -global-isel RUN lines to the existing SDAG test because GISel doesn't support fixed vector arguments yet.