### PR TITLE
[dsymutil] Add x86-registered-target requirement to embed-resource test

### DIFF
--- a/llvm/test/tools/dsymutil/embed-resource.test
+++ b/llvm/test/tools/dsymutil/embed-resource.test
@@ -1,5 +1,7 @@
 Test the --embed-resource option.
 
+REQUIRES: x86-registered-target
+
 Create a temp resource file and embed it into the dSYM bundle.
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir


### PR DESCRIPTION
The test uses an x86_64 Mach-O input and generates output which requires the x86 backend.