### PR TITLE
[SPIR-V] Deduce argument types before doing GEP

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -288,43 +288,45 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
         buildOpDecorate(VRegs[i][0], MIRBuilder, SPIRV::Decoration::Alignment,
                         {Alignment});
       }
-      if (Arg.hasAttribute(Attribute::ReadOnly)) {
-        auto Attr =
-            static_cast<unsigned>(SPIRV::FunctionParameterAttribute::NoWrite);
-        buildOpDecorate(VRegs[i][0], MIRBuilder,
-                        SPIRV::Decoration::FuncParamAttr, {Attr});
-      }
-      if (Arg.hasAttribute(Attribute::ZExt)) {
-        auto Attr =
-            static_cast<unsigned>(SPIRV::FunctionParameterAttribute::Zext);
-        buildOpDecorate(VRegs[i][0], MIRBuilder,
-                        SPIRV::Decoration::FuncParamAttr, {Attr});
-      }
-      if (Arg.hasAttribute(Attribute::NoAlias)) {
-        auto Attr =
-            static_cast<unsigned>(SPIRV::FunctionParameterAttribute::NoAlias);
-        buildOpDecorate(VRegs[i][0], MIRBuilder,
-                        SPIRV::Decoration::FuncParamAttr, {Attr});
-      }
-      // TODO: the AMDGPU BE only supports ByRef argument passing, thus for
-      //       AMDGCN flavoured SPIRV we CodeGen for ByRef, but lower it to
-      //       ByVal, handling the impedance mismatch during reverse
-      //       translation from SPIRV to LLVM IR; the vendor check should be
-      //       removed once / if SPIRV adds ByRef support.
-      if (Arg.hasAttribute(Attribute::ByVal) ||
-          (Arg.hasAttribute(Attribute::ByRef) &&
-           F.getParent()->getTargetTriple().getVendor() ==
-               Triple::VendorType::AMD)) {
-        auto Attr =
-            static_cast<unsigned>(SPIRV::FunctionParameterAttribute::ByVal);
-        buildOpDecorate(VRegs[i][0], MIRBuilder,
-                        SPIRV::Decoration::FuncParamAttr, {Attr});
-      }
-      if (Arg.hasAttribute(Attribute::StructRet)) {
-        auto Attr =
-            static_cast<unsigned>(SPIRV::FunctionParameterAttribute::Sret);
-        buildOpDecorate(VRegs[i][0], MIRBuilder,
-                        SPIRV::Decoration::FuncParamAttr, {Attr});
+      if (!ST->isShader()) {
+        if (Arg.hasAttribute(Attribute::ReadOnly)) {
+          auto Attr =
+              static_cast<unsigned>(SPIRV::FunctionParameterAttribute::NoWrite);
+          buildOpDecorate(VRegs[i][0], MIRBuilder,
+                          SPIRV::Decoration::FuncParamAttr, {Attr});
+        }
+        if (Arg.hasAttribute(Attribute::ZExt)) {
+          auto Attr =
+              static_cast<unsigned>(SPIRV::FunctionParameterAttribute::Zext);
+          buildOpDecorate(VRegs[i][0], MIRBuilder,
+                          SPIRV::Decoration::FuncParamAttr, {Attr});
+        }
+        if (Arg.hasAttribute(Attribute::NoAlias)) {
+          auto Attr =
+              static_cast<unsigned>(SPIRV::FunctionParameterAttribute::NoAlias);
+          buildOpDecorate(VRegs[i][0], MIRBuilder,
+                          SPIRV::Decoration::FuncParamAttr, {Attr});
+        }
+        // TODO: the AMDGPU BE only supports ByRef argument passing, thus for
+        //       AMDGCN flavoured SPIRV we CodeGen for ByRef, but lower it to
+        //       ByVal, handling the impedance mismatch during reverse
+        //       translation from SPIRV to LLVM IR; the vendor check should be
+        //       removed once / if SPIRV adds ByRef support.
+        if (Arg.hasAttribute(Attribute::ByVal) ||
+            (Arg.hasAttribute(Attribute::ByRef) &&
+             F.getParent()->getTargetTriple().getVendor() ==
+                 Triple::VendorType::AMD)) {
+          auto Attr =
+              static_cast<unsigned>(SPIRV::FunctionParameterAttribute::ByVal);
+          buildOpDecorate(VRegs[i][0], MIRBuilder,
+                          SPIRV::Decoration::FuncParamAttr, {Attr});
+        }
+        if (Arg.hasAttribute(Attribute::StructRet)) {
+          auto Attr =
+              static_cast<unsigned>(SPIRV::FunctionParameterAttribute::Sret);
+          buildOpDecorate(VRegs[i][0], MIRBuilder,
+                          SPIRV::Decoration::FuncParamAttr, {Attr});
+        }
       }
 
       if (F.getCallingConv() == CallingConv::SPIR_KERNEL) {
@@ -458,19 +460,19 @@ void SPIRVCallLowering::produceIndirectPtrType(
     if (!GR->getSPIRVTypeForVReg(IC.ArgRegs[i]))
       GR->assignSPIRVTypeToVReg(SPIRVTy, IC.ArgRegs[i], MF);
   }
-    // SPIR-V function type:
-    FunctionType *FTy =
-        FunctionType::get(const_cast<Type *>(IC.RetTy), IC.ArgTys, false);
-    SPIRVTypeInst SpirvFuncTy = GR->getOrCreateOpTypeFunctionWithArgs(
-        FTy, SpirvRetTy, SpirvArgTypes, MIRBuilder);
-    // SPIR-V pointer to function type:
-    auto SC = ST.canUseExtension(SPIRV::Extension::SPV_INTEL_function_pointers)
-                  ? SPIRV::StorageClass::CodeSectionINTEL
-                  : SPIRV::StorageClass::Function;
-    SPIRVTypeInst IndirectFuncPtrTy =
-        GR->getOrCreateSPIRVPointerType(SpirvFuncTy, MIRBuilder, SC);
-    // Correct the Callee type
-    GR->assignSPIRVTypeToVReg(IndirectFuncPtrTy, IC.Callee, MF);
+  // SPIR-V function type:
+  FunctionType *FTy =
+      FunctionType::get(const_cast<Type *>(IC.RetTy), IC.ArgTys, false);
+  SPIRVTypeInst SpirvFuncTy = GR->getOrCreateOpTypeFunctionWithArgs(
+      FTy, SpirvRetTy, SpirvArgTypes, MIRBuilder);
+  // SPIR-V pointer to function type:
+  auto SC = ST.canUseExtension(SPIRV::Extension::SPV_INTEL_function_pointers)
+                ? SPIRV::StorageClass::CodeSectionINTEL
+                : SPIRV::StorageClass::Function;
+  SPIRVTypeInst IndirectFuncPtrTy =
+      GR->getOrCreateSPIRVPointerType(SpirvFuncTy, MIRBuilder, SC);
+  // Correct the Callee type
+  GR->assignSPIRVTypeToVReg(IndirectFuncPtrTy, IC.Callee, MF);
 }
 
 bool SPIRVCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -3145,6 +3145,8 @@ bool SPIRVEmitIntrinsics::runOnFunction(Function &Func) {
   AggrStores.clear();
   DeletedInstrs.clear();
 
+  processParamTypesByFunHeader(CurrF, B);
+
   // Fix GEP result types ahead of inference, and simplify if possible.
   // Data structure for dead instructions that were simplified and replaced.
   SmallPtrSet<Instruction *, 4> DeadInsts;
@@ -3175,8 +3177,6 @@ bool SPIRVEmitIntrinsics::runOnFunction(Function &Func) {
     assert(I->use_empty() && "Dead instruction should not have any uses left");
     I->eraseFromParent();
   }
-
-  processParamTypesByFunHeader(CurrF, B);
 
   // StoreInst's operand type can be changed during the next
   // transformations, so we need to store it in the set. Also store already

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/gep-i8-ptr-param-struct.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/gep-i8-ptr-param-struct.ll
@@ -1,0 +1,35 @@
+; RUN: llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s
+
+; The function in the test has external linkage because we want it to be 
+; output. Since this test uses Linkage we cannot validate for Vulkan. That
+; should not be a problem as it is only testing general shader behavior.
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: %[[#i32:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#struct:]] = OpTypeStruct %[[#]] %[[#]] %[[#i32]]
+; CHECK-DAG: %[[#ptr_struct:]] = OpTypePointer Function %[[#struct]]
+; CHECK-DAG: %[[#ptr_i32:]] = OpTypePointer Function %[[#i32]]
+; CHECK-DAG: %[[#idx:]] = OpConstant %[[#]] 2
+
+%struct.VSOutput = type { <4 x float>, <2 x float>, i32 }
+
+; CHECK: %[[#func:]] = OpFunction %[[#i32]] None %[[#]]
+; CHECK: %[[#input:]] = OpFunctionParameter %[[#ptr_struct]]
+define spir_func i32 @_Z13sampleTexture8VSOutput(ptr byval(%struct.VSOutput) align 1 %input) {
+entry:
+; CHECK: %[[#gep:]] = OpInBoundsAccessChain %[[#ptr_i32]] %[[#input]] %[[#idx]]
+  %ColorOffset = getelementptr inbounds nuw i8, ptr %input, i64 24
+  
+; CHECK: %[[#val:]] = OpLoad %[[#i32]] %[[#gep]]
+  %val = load i32, ptr %ColorOffset, align 1
+  
+; CHECK: OpReturnValue %[[#val]]
+  ret i32 %val
+}
+
+define void @main() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "hlsl.shader"="pixel" }


### PR DESCRIPTION
In SPIRVEmitIntrinsics, we try to get the type for a GEP by looking at
the type of the input pointer, and deducing the output pointer type from
it. If the input pointer is a function parameter, we do not have the type
available yet because we deduce the type of the parameters after
processing the GEPs.

There is no reason to have that order. Moving the parameter passes
earlier so the GEP type deduction works.

The same test exposed a problem with function parameter attributes. They
require Kernel, so we no longer emit them when creating a shader.


<!-- branch-stack-start -->

<!-- branch-stack-end -->
