### PR TITLE
[clang][SSAF][NFC] Reorder class sections to `public`-`protected`-`private`

### DIFF
--- a/clang/include/clang/ScalableStaticAnalysisFramework/Analyses/EntityPointerLevel/EntityPointerLevel.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Analyses/EntityPointerLevel/EntityPointerLevel.h
@@ -34,15 +34,6 @@ namespace clang::ssaf {
 /// - '(p, 1)' is associated with the 'int *[10]' part of the declared type of
 /// 'p'.
 class EntityPointerLevel {
-  EntityId Entity;
-  unsigned PointerLevel;
-
-  friend class EntityPointerLevelTranslator;
-  friend EntityPointerLevel buildEntityPointerLevel(EntityId, unsigned);
-
-  EntityPointerLevel(EntityId Entity, unsigned PointerLevel)
-      : Entity(Entity), PointerLevel(PointerLevel) {}
-
 public:
   EntityId getEntity() const { return Entity; }
   unsigned getPointerLevel() const { return PointerLevel; }
@@ -76,6 +67,16 @@ public:
       return L.getEntity() < R;
     }
   };
+
+private:
+  friend class EntityPointerLevelTranslator;
+  friend EntityPointerLevel buildEntityPointerLevel(EntityId, unsigned);
+
+  EntityId Entity;
+  unsigned PointerLevel;
+
+  EntityPointerLevel(EntityId Entity, unsigned PointerLevel)
+      : Entity(Entity), PointerLevel(PointerLevel) {}
 };
 
 using EntityPointerLevelSet =

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Analyses/EntityPointerLevel/EntityPointerLevel.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Analyses/EntityPointerLevel/EntityPointerLevel.h
@@ -72,11 +72,11 @@ private:
   friend class EntityPointerLevelTranslator;
   friend EntityPointerLevel buildEntityPointerLevel(EntityId, unsigned);
 
-  EntityId Entity;
-  unsigned PointerLevel;
-
   EntityPointerLevel(EntityId Entity, unsigned PointerLevel)
       : Entity(Entity), PointerLevel(PointerLevel) {}
+
+  EntityId Entity;
+  unsigned PointerLevel;
 };
 
 using EntityPointerLevelSet =

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsage.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsage.h
@@ -21,17 +21,6 @@ namespace clang::ssaf {
 /// An UnsafeBufferUsageEntitySummary is an immutable set of unsafe buffers, in
 /// the form of EntityPointerLevel.
 class UnsafeBufferUsageEntitySummary final : public EntitySummary {
-  const EntityPointerLevelSet UnsafeBuffers;
-
-  friend class UnsafeBufferUsageTUSummaryExtractor;
-  friend UnsafeBufferUsageEntitySummary
-      buildUnsafeBufferUsageEntitySummary(EntityPointerLevelSet);
-  friend llvm::iterator_range<EntityPointerLevelSet::const_iterator>
-  getUnsafeBuffers(const UnsafeBufferUsageEntitySummary &);
-
-  explicit UnsafeBufferUsageEntitySummary(EntityPointerLevelSet UnsafeBuffers)
-      : EntitySummary(), UnsafeBuffers(std::move(UnsafeBuffers)) {}
-
 public:
   static constexpr llvm::StringLiteral Name = "UnsafeBufferUsage";
 
@@ -48,6 +37,18 @@ public:
   bool empty() const { return UnsafeBuffers.empty(); }
 
   static SummaryName summaryName() { return SummaryName{Name.str()}; }
+
+private:
+  friend class UnsafeBufferUsageTUSummaryExtractor;
+  friend UnsafeBufferUsageEntitySummary
+      buildUnsafeBufferUsageEntitySummary(EntityPointerLevelSet);
+  friend llvm::iterator_range<EntityPointerLevelSet::const_iterator>
+  getUnsafeBuffers(const UnsafeBufferUsageEntitySummary &);
+
+  const EntityPointerLevelSet UnsafeBuffers;
+
+  explicit UnsafeBufferUsageEntitySummary(EntityPointerLevelSet UnsafeBuffers)
+      : EntitySummary(), UnsafeBuffers(std::move(UnsafeBuffers)) {}
 };
 } // namespace clang::ssaf
 

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsage.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsage.h
@@ -45,10 +45,10 @@ private:
   friend llvm::iterator_range<EntityPointerLevelSet::const_iterator>
   getUnsafeBuffers(const UnsafeBufferUsageEntitySummary &);
 
-  const EntityPointerLevelSet UnsafeBuffers;
-
   explicit UnsafeBufferUsageEntitySummary(EntityPointerLevelSet UnsafeBuffers)
       : EntitySummary(), UnsafeBuffers(std::move(UnsafeBuffers)) {}
+
+  const EntityPointerLevelSet UnsafeBuffers;
 };
 } // namespace clang::ssaf
 

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/EntityLinker.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/EntityLinker.h
@@ -51,9 +51,6 @@ public:
   LUSummaryEncoding takeOutput() && { return std::move(Output); }
 
 private:
-  LUSummaryEncoding Output;
-  std::set<BuildNamespace> ProcessedTUNamespaces;
-
   /// Resolves a TU entity name to an LU entity name and ID.
   ///
   /// \param OldName The entity name in the TU namespace.
@@ -85,6 +82,9 @@ private:
   /// \returns Error if patching any encoding fails, success otherwise.
   llvm::Error patch(const std::vector<EntitySummaryEncoding *> &PatchTargets,
                     const std::map<EntityId, EntityId> &EntityResolutionTable);
+
+  LUSummaryEncoding Output;
+  std::set<BuildNamespace> ProcessedTUNamespaces;
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/EntityLinker.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/EntityLinker.h
@@ -26,9 +26,6 @@ namespace clang::ssaf {
 class TUSummaryEncoding;
 
 class EntityLinker {
-  LUSummaryEncoding Output;
-  std::set<BuildNamespace> ProcessedTUNamespaces;
-
 public:
   /// Constructs an EntityLinker to link TU summaries into a LU summary.
   ///
@@ -54,6 +51,9 @@ public:
   LUSummaryEncoding takeOutput() && { return std::move(Output); }
 
 private:
+  LUSummaryEncoding Output;
+  std::set<BuildNamespace> ProcessedTUNamespaces;
+
   /// Resolves a TU entity name to an LU entity name and ID.
   ///
   /// \param OldName The entity name in the TU namespace.

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/LUSummary.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/LUSummary.h
@@ -31,6 +31,11 @@ namespace clang::ssaf {
 /// together. It contains deduplicated entities with their linkage information
 /// and the merged entity summaries.
 class LUSummary {
+public:
+  explicit LUSummary(NestedBuildNamespace LUNamespace)
+      : LUNamespace(std::move(LUNamespace)) {}
+
+private:
   friend class AnalysisDriver;
   friend class LUSummaryConsumer;
   friend class SerializationFormat;
@@ -44,10 +49,6 @@ class LUSummary {
 
   std::map<SummaryName, std::map<EntityId, std::unique_ptr<EntitySummary>>>
       Data;
-
-public:
-  explicit LUSummary(NestedBuildNamespace LUNamespace)
-      : LUNamespace(std::move(LUNamespace)) {}
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/LUSummaryEncoding.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/LUSummaryEncoding.h
@@ -31,6 +31,11 @@ namespace clang::ssaf {
 /// translation units in a format-specific encoding. It is produced by the
 /// entity linker and contains deduplicated and patched entity summaries.
 class LUSummaryEncoding {
+public:
+  explicit LUSummaryEncoding(NestedBuildNamespace LUNamespace)
+      : LUNamespace(std::move(LUNamespace)) {}
+
+private:
   friend class EntityLinker;
   friend class SerializationFormat;
   friend class TestFixture;
@@ -48,10 +53,6 @@ class LUSummaryEncoding {
   std::map<SummaryName,
            std::map<EntityId, std::unique_ptr<EntitySummaryEncoding>>>
       Data;
-
-public:
-  explicit LUSummaryEncoding(NestedBuildNamespace LUNamespace)
-      : LUNamespace(std::move(LUNamespace)) {}
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/TUSummaryEncoding.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/EntityLinker/TUSummaryEncoding.h
@@ -32,6 +32,11 @@ namespace clang::ssaf {
 /// full EntitySummary objects. This enables efficient entity ID patching
 /// during the linking process.
 class TUSummaryEncoding {
+public:
+  explicit TUSummaryEncoding(BuildNamespace TUNamespace)
+      : TUNamespace(std::move(TUNamespace)) {}
+
+private:
   friend class EntityLinker;
   friend class SerializationFormat;
   friend class TestFixture;
@@ -49,10 +54,6 @@ class TUSummaryEncoding {
   std::map<SummaryName,
            std::map<EntityId, std::unique_ptr<EntitySummaryEncoding>>>
       Data;
-
-public:
-  explicit TUSummaryEncoding(BuildNamespace TUNamespace)
-      : TUNamespace(std::move(TUNamespace)) {}
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/BuildNamespace.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/BuildNamespace.h
@@ -61,10 +61,10 @@ private:
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
                                        const BuildNamespace &BN);
 
+  auto asTuple() const { return std::tie(Kind, Name); }
+
   BuildNamespaceKind Kind;
   std::string Name;
-
-  auto asTuple() const { return std::tie(Kind, Name); }
 };
 
 /// Represents a hierarchical sequence of build namespaces.

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/BuildNamespace.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/BuildNamespace.h
@@ -40,11 +40,6 @@ enum class BuildNamespaceKind : unsigned short { CompilationUnit, LinkUnit };
 /// hierarchical namespace structures that model how software is constructed
 /// from its components.
 class BuildNamespace {
-  BuildNamespaceKind Kind;
-  std::string Name;
-
-  auto asTuple() const { return std::tie(Kind, Name); }
-
 public:
   BuildNamespace(BuildNamespaceKind Kind, llvm::StringRef Name)
       : Kind(Kind), Name(Name.str()) {}
@@ -59,11 +54,17 @@ public:
   bool operator!=(const BuildNamespace &Other) const;
   bool operator<(const BuildNamespace &Other) const;
 
+private:
   friend class EntityLinker;
   friend class SerializationFormat;
   friend class TestFixture;
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
                                        const BuildNamespace &BN);
+
+  BuildNamespaceKind Kind;
+  std::string Name;
+
+  auto asTuple() const { return std::tie(Kind, Name); }
 };
 
 /// Represents a hierarchical sequence of build namespaces.
@@ -76,8 +77,6 @@ public:
 /// For example, an entity might be qualified by a compilation unit namespace
 /// followed by a shared library namespace.
 class NestedBuildNamespace {
-  std::vector<BuildNamespace> Namespaces;
-
 public:
   NestedBuildNamespace() = default;
 
@@ -113,10 +112,13 @@ public:
   bool operator!=(const NestedBuildNamespace &Other) const;
   bool operator<(const NestedBuildNamespace &Other) const;
 
+private:
   friend class SerializationFormat;
   friend class TestFixture;
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
                                        const NestedBuildNamespace &NBN);
+
+  std::vector<BuildNamespace> Namespaces;
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, BuildNamespaceKind BNK);

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityId.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityId.h
@@ -29,6 +29,12 @@ class EntityIdTable;
 ///
 /// \see EntityIdTable
 class EntityId {
+public:
+  bool operator==(const EntityId &Other) const { return Index == Other.Index; }
+  bool operator<(const EntityId &Other) const { return Index < Other.Index; }
+  bool operator!=(const EntityId &Other) const { return !(*this == Other); }
+
+private:
   friend class EntityIdTable;
   friend class SerializationFormat;
   friend class TestFixture;
@@ -40,11 +46,6 @@ class EntityId {
   explicit EntityId(size_t Index) : Index(Index) {}
 
   EntityId() = delete;
-
-public:
-  bool operator==(const EntityId &Other) const { return Index == Other.Index; }
-  bool operator<(const EntityId &Other) const { return Index < Other.Index; }
-  bool operator!=(const EntityId &Other) const { return !(*this == Other); }
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const EntityId &Id);

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityId.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityId.h
@@ -41,11 +41,11 @@ private:
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
                                        const EntityId &Id);
 
-  size_t Index;
-
   explicit EntityId(size_t Index) : Index(Index) {}
 
   EntityId() = delete;
+
+  size_t Index;
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const EntityId &Id);

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityIdTable.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityIdTable.h
@@ -21,11 +21,6 @@ namespace clang::ssaf {
 /// The table maps each unique EntityName to exactly one EntityId.
 /// Entities are never removed.
 class EntityIdTable {
-  friend class SerializationFormat;
-  friend class TestFixture;
-
-  std::map<EntityName, EntityId> Entities;
-
 public:
   EntityIdTable() = default;
 
@@ -46,6 +41,12 @@ public:
 
   /// Returns the number of unique entities in the table.
   size_t count() const { return Entities.size(); }
+
+private:
+  friend class SerializationFormat;
+  friend class TestFixture;
+
+  std::map<EntityName, EntityId> Entities;
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityLinkage.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityLinkage.h
@@ -26,9 +26,6 @@ enum class EntityLinkageType {
 /// or external linkage, which determines its visibility and accessibility
 /// across translation units.
 class EntityLinkage {
-  friend class SerializationFormat;
-  friend class TestFixture;
-
 public:
   constexpr explicit EntityLinkage(EntityLinkageType L) : Linkage(L) {}
 
@@ -38,6 +35,9 @@ public:
   bool operator!=(const EntityLinkage &Other) const;
 
 private:
+  friend class SerializationFormat;
+  friend class TestFixture;
+
   EntityLinkageType Linkage;
 };
 

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityName.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityName.h
@@ -49,11 +49,11 @@ private:
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
                                        const EntityName &EN);
 
+  auto asTuple() const { return std::tie(USR, Suffix, Namespace); }
+
   std::string USR;
   llvm::SmallString<16> Suffix;
   NestedBuildNamespace Namespace;
-
-  auto asTuple() const { return std::tie(USR, Suffix, Namespace); }
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const EntityName &EN);

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityName.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityName.h
@@ -26,18 +26,6 @@ namespace clang::ssaf {
 /// Client code should not make assumptions about the implementation details,
 /// such as USRs.
 class EntityName {
-  friend class EntityLinker;
-  friend class SerializationFormat;
-  friend class TestFixture;
-  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
-                                       const EntityName &EN);
-
-  std::string USR;
-  llvm::SmallString<16> Suffix;
-  NestedBuildNamespace Namespace;
-
-  auto asTuple() const { return std::tie(USR, Suffix, Namespace); }
-
 public:
   /// Client code should not use this constructor directly.
   /// Use getEntityName and other functions in ASTEntityMapping.h to get
@@ -53,6 +41,19 @@ public:
   ///
   /// \param Namespace The namespace steps to append to this entity's namespace.
   EntityName makeQualified(NestedBuildNamespace Namespace) const;
+
+private:
+  friend class EntityLinker;
+  friend class SerializationFormat;
+  friend class TestFixture;
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
+                                       const EntityName &EN);
+
+  std::string USR;
+  llvm::SmallString<16> Suffix;
+  NestedBuildNamespace Namespace;
+
+  auto asTuple() const { return std::tie(USR, Suffix, Namespace); }
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const EntityName &EN);

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat.h
@@ -29,13 +29,11 @@ class EntitySummary;
 class SummaryName;
 
 class JSONFormat final : public SerializationFormat {
+public:
   using Array = llvm::json::Array;
   using Object = llvm::json::Object;
   using Value = llvm::json::Value;
 
-  friend class JSONEntitySummaryEncoding;
-
-public:
   llvm::Expected<TUSummary> readTUSummary(llvm::StringRef Path) override;
 
   llvm::Error writeTUSummary(const TUSummary &Summary,
@@ -90,6 +88,8 @@ public:
           JSONFormat, AnalysisResultSerializerFn, AnalysisResultDeserializerFn>;
 
 private:
+  friend class JSONEntitySummaryEncoding;
+
   static std::map<SummaryName, FormatInfo> initFormatInfos();
   const std::map<SummaryName, FormatInfo> FormatInfos = initFormatInfos();
 

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/SummaryData/SummaryDataBuilder.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/SummaryData/SummaryDataBuilder.h
@@ -32,12 +32,12 @@ class LUSummaryConsumer;
 /// time via \c addSummary(), is finalized via \c finalize(), and transfers
 /// ownership of the built data via \c takeData().
 class SummaryDataBuilderBase {
-  friend class LUSummaryConsumer;
-
 public:
   virtual ~SummaryDataBuilderBase() = default;
 
 private:
+  friend class LUSummaryConsumer;
+
   /// Called once per entity belonging to this builder's analysis.
   /// Takes ownership of the summary data.
   virtual void addSummary(EntityId Id,
@@ -58,15 +58,6 @@ private:
 /// \c finalize() for any post-processing needed after all entities are added.
 template <typename DataT, typename SummaryT>
 class SummaryDataBuilder : public SummaryDataBuilderBase {
-  static_assert(std::is_base_of_v<SummaryData, DataT>,
-                "DataT must derive from SummaryData");
-  static_assert(HasSummaryName_v<DataT>,
-                "DataT must have a static summaryName() method");
-  static_assert(std::is_base_of_v<EntitySummary, SummaryT>,
-                "SummaryT must derive from EntitySummary");
-
-  std::unique_ptr<DataT> Data;
-
 public:
   SummaryDataBuilder() : Data(std::make_unique<DataT>()) {}
 
@@ -81,6 +72,15 @@ protected:
   DataT &getData() & { return *Data; }
 
 private:
+  static_assert(std::is_base_of_v<SummaryData, DataT>,
+                "DataT must derive from SummaryData");
+  static_assert(HasSummaryName_v<DataT>,
+                "DataT must have a static summaryName() method");
+  static_assert(std::is_base_of_v<EntitySummary, SummaryT>,
+                "SummaryT must derive from EntitySummary");
+
+  std::unique_ptr<DataT> Data;
+
   std::unique_ptr<SummaryData> takeData() && override {
     return std::move(Data);
   }

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/SummaryData/SummaryDataBuilder.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/SummaryData/SummaryDataBuilder.h
@@ -79,8 +79,6 @@ private:
   static_assert(std::is_base_of_v<EntitySummary, SummaryT>,
                 "SummaryT must derive from EntitySummary");
 
-  std::unique_ptr<DataT> Data;
-
   std::unique_ptr<SummaryData> takeData() && override {
     return std::move(Data);
   }
@@ -90,6 +88,8 @@ private:
     addSummary(Id, std::unique_ptr<SummaryT>(
                        static_cast<SummaryT *>(Summary.release())));
   }
+
+  std::unique_ptr<DataT> Data;
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/SummaryData/SummaryDataBuilderRegistry.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/SummaryData/SummaryDataBuilderRegistry.h
@@ -37,8 +37,6 @@ namespace clang::ssaf {
 class SummaryDataBuilderRegistry {
   using RegistryT = llvm::Registry<SummaryDataBuilderBase>;
 
-  SummaryDataBuilderRegistry() = delete;
-
 public:
   /// Registers \p BuilderT under the name returned by
   /// \c BuilderT::summaryName(). Only a description is required.
@@ -65,6 +63,9 @@ public:
   /// if no such builder is registered.
   static std::unique_ptr<SummaryDataBuilderBase>
   instantiate(llvm::StringRef Name);
+
+private:
+  SummaryDataBuilderRegistry() = delete;
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/SummaryData/SummaryDataStore.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/SummaryData/SummaryDataStore.h
@@ -29,10 +29,6 @@ class LUSummaryConsumer;
 /// Owns a collection of SummaryData objects keyed by SummaryName.
 /// Produced by LUSummaryConsumer::run() variants.
 class SummaryDataStore {
-  friend class LUSummaryConsumer;
-
-  std::map<SummaryName, std::unique_ptr<SummaryData>> Data;
-
 public:
   /// Returns true if data for \p Name is stored.
   [[nodiscard]] bool contains(const SummaryName &Name) const {
@@ -108,6 +104,11 @@ public:
     Data.erase(It);
     return std::move(Ptr);
   }
+
+private:
+  friend class LUSummaryConsumer;
+
+  std::map<SummaryName, std::unique_ptr<SummaryData>> Data;
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Support/ErrorBuilder.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Support/ErrorBuilder.h
@@ -38,27 +38,6 @@ namespace clang::ssaf {
 ///       .build();
 /// \endcode
 class ErrorBuilder {
-  std::error_code Code;
-  std::vector<std::string> ContextStack;
-
-  explicit ErrorBuilder(std::error_code EC) : Code(EC) {}
-
-  void pushContext(std::string Msg) {
-    if (!Msg.empty()) {
-      ContextStack.push_back(std::move(Msg));
-    }
-  }
-
-  template <typename... Args>
-  static std::string formatErrorMessage(const char *Fmt, Args &&...ArgVals) {
-    return llvm::formatv(Fmt, std::forward<Args>(ArgVals)...).str();
-  }
-
-  template <typename... Args>
-  void addFormattedContext(const char *Fmt, Args &&...ArgVals) {
-    pushContext(formatErrorMessage(Fmt, std::forward<Args>(ArgVals)...));
-  }
-
 public:
   /// Create an ErrorBuilder with an error code and formatted message.
   ///
@@ -202,6 +181,28 @@ public:
     llvm::report_fatal_error(llvm::StringRef(formatErrorMessage(
                                  Fmt, std::forward<Args>(ArgVals)...)),
                              false);
+  }
+
+private:
+  std::error_code Code;
+  std::vector<std::string> ContextStack;
+
+  explicit ErrorBuilder(std::error_code EC) : Code(EC) {}
+
+  void pushContext(std::string Msg) {
+    if (!Msg.empty()) {
+      ContextStack.push_back(std::move(Msg));
+    }
+  }
+
+  template <typename... Args>
+  static std::string formatErrorMessage(const char *Fmt, Args &&...ArgVals) {
+    return llvm::formatv(Fmt, std::forward<Args>(ArgVals)...).str();
+  }
+
+  template <typename... Args>
+  void addFormattedContext(const char *Fmt, Args &&...ArgVals) {
+    pushContext(formatErrorMessage(Fmt, std::forward<Args>(ArgVals)...));
   }
 };
 

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Support/ErrorBuilder.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Support/ErrorBuilder.h
@@ -184,9 +184,6 @@ public:
   }
 
 private:
-  std::error_code Code;
-  std::vector<std::string> ContextStack;
-
   explicit ErrorBuilder(std::error_code EC) : Code(EC) {}
 
   void pushContext(std::string Msg) {
@@ -204,6 +201,9 @@ private:
   void addFormattedContext(const char *Fmt, Args &&...ArgVals) {
     pushContext(formatErrorMessage(Fmt, std::forward<Args>(ArgVals)...));
   }
+
+  std::error_code Code;
+  std::vector<std::string> ContextStack;
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummary.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummary.h
@@ -22,6 +22,15 @@ namespace clang::ssaf {
 
 /// Data extracted for a given translation unit and for a given set of analyses.
 class TUSummary {
+public:
+  explicit TUSummary(BuildNamespace TUNamespace)
+      : TUNamespace(std::move(TUNamespace)) {}
+
+private:
+  friend class SerializationFormat;
+  friend class TestFixture;
+  friend class TUSummaryBuilder;
+
   /// Identifies the translation unit.
   BuildNamespace TUNamespace;
 
@@ -31,14 +40,6 @@ class TUSummary {
 
   std::map<SummaryName, std::map<EntityId, std::unique_ptr<EntitySummary>>>
       Data;
-
-public:
-  explicit TUSummary(BuildNamespace TUNamespace)
-      : TUNamespace(std::move(TUNamespace)) {}
-
-  friend class SerializationFormat;
-  friend class TestFixture;
-  friend class TUSummaryBuilder;
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/AnalysisBase.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/AnalysisBase.h
@@ -30,16 +30,6 @@ class SummaryAnalysisBase;
 /// Not subclassed directly -- use SummaryAnalysis<...> or
 /// DerivedAnalysis<...> instead.
 class AnalysisBase {
-  friend class AnalysisDriver;
-  friend class DerivedAnalysisBase;
-  friend class SummaryAnalysisBase;
-
-  enum class Kind { Summary, Derived };
-  Kind TheKind;
-
-protected:
-  explicit AnalysisBase(Kind K) : TheKind(K) {}
-
 public:
   virtual ~AnalysisBase() = default;
 
@@ -53,6 +43,17 @@ public:
   /// Transfers ownership of the built result. Called once after finalize().
   /// The rvalue ref-qualifier enforces single use.
   virtual std::unique_ptr<AnalysisResult> takeResult() && = 0;
+
+protected:
+  enum class Kind { Summary, Derived };
+  explicit AnalysisBase(Kind K) : TheKind(K) {}
+
+private:
+  friend class AnalysisDriver;
+  friend class DerivedAnalysisBase;
+  friend class SummaryAnalysisBase;
+
+  Kind TheKind;
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/AnalysisRegistry.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/AnalysisRegistry.h
@@ -51,8 +51,6 @@ namespace clang::ssaf {
 class AnalysisRegistry {
   using RegistryT = llvm::Registry<AnalysisBase>;
 
-  AnalysisRegistry() = delete;
-
 public:
   /// Registers AnalysisT with the unified registry.
   ///
@@ -96,6 +94,8 @@ public:
   instantiate(const AnalysisName &Name);
 
 private:
+  AnalysisRegistry() = delete;
+
   /// Returns the global list of registered analysis names.
   ///
   /// Uses a function-local static to avoid static initialization order

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/DerivedAnalysis.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/DerivedAnalysis.h
@@ -110,8 +110,6 @@ private:
   friend class AnalysisRegistry;
   using ResultType = ResultT;
 
-  std::unique_ptr<ResultT> Result = std::make_unique<ResultT>();
-
   /// Seals the type-erased base overload, downcasts, and dispatches to the
   /// typed initialize(). All dependencies are guaranteed present by the driver.
   llvm::Error
@@ -133,6 +131,8 @@ private:
   std::unique_ptr<AnalysisResult> takeResult() && final {
     return std::move(Result);
   }
+
+  std::unique_ptr<ResultT> Result = std::make_unique<ResultT>();
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/DerivedAnalysis.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/DerivedAnalysis.h
@@ -36,12 +36,12 @@ class AnalysisRegistry;
 /// A derived analysis consumes previously produced AnalysisResult objects
 /// and computes a new one via an initialize/step/finalize lifecycle.
 class DerivedAnalysisBase : public AnalysisBase {
-  friend class AnalysisDriver;
-
 protected:
   DerivedAnalysisBase() : AnalysisBase(AnalysisBase::Kind::Derived) {}
 
 private:
+  friend class AnalysisDriver;
+
   /// Called once with the dependency results before the step() loop.
   ///
   /// \param DepResults  Immutable results of all declared dependencies, keyed
@@ -70,20 +70,6 @@ private:
 /// finalize() post-processes after convergence.
 template <typename ResultT, typename... DepResultTs>
 class DerivedAnalysis : public DerivedAnalysisBase {
-  static_assert(std::is_base_of_v<AnalysisResult, ResultT>,
-                "ResultT must derive from AnalysisResult");
-  static_assert(HasAnalysisName_v<ResultT>,
-                "ResultT must have a static analysisName() method");
-  static_assert((std::is_base_of_v<AnalysisResult, DepResultTs> && ...),
-                "Every DepResultT must derive from AnalysisResult");
-  static_assert((HasAnalysisName_v<DepResultTs> && ...),
-                "Every DepResultT must have a static analysisName() method");
-
-  friend class AnalysisRegistry;
-  using ResultType = ResultT;
-
-  std::unique_ptr<ResultT> Result = std::make_unique<ResultT>();
-
 public:
   /// Used by AnalysisRegistry::Add to derive the registry entry name.
   AnalysisName getAnalysisName() const final { return ResultT::analysisName(); }
@@ -112,6 +98,20 @@ protected:
   ResultT &getResult() & { return *Result; }
 
 private:
+  static_assert(std::is_base_of_v<AnalysisResult, ResultT>,
+                "ResultT must derive from AnalysisResult");
+  static_assert(HasAnalysisName_v<ResultT>,
+                "ResultT must have a static analysisName() method");
+  static_assert((std::is_base_of_v<AnalysisResult, DepResultTs> && ...),
+                "Every DepResultT must derive from AnalysisResult");
+  static_assert((HasAnalysisName_v<DepResultTs> && ...),
+                "Every DepResultT must have a static analysisName() method");
+
+  friend class AnalysisRegistry;
+  using ResultType = ResultT;
+
+  std::unique_ptr<ResultT> Result = std::make_unique<ResultT>();
+
   /// Seals the type-erased base overload, downcasts, and dispatches to the
   /// typed initialize(). All dependencies are guaranteed present by the driver.
   llvm::Error

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/SummaryAnalysis.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/SummaryAnalysis.h
@@ -109,8 +109,6 @@ private:
   friend class AnalysisRegistry;
   using ResultType = ResultT;
 
-  std::unique_ptr<ResultT> Result = std::make_unique<ResultT>();
-
   /// Seals the type-erased base overload, downcasts, and dispatches to the
   /// typed add().
   llvm::Error add(EntityId Id, const EntitySummary &Summary) final {
@@ -121,6 +119,8 @@ private:
   std::unique_ptr<AnalysisResult> takeResult() && final {
     return std::move(Result);
   }
+
+  std::unique_ptr<ResultT> Result = std::make_unique<ResultT>();
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/SummaryAnalysis.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/SummaryAnalysis.h
@@ -36,17 +36,17 @@ class AnalysisRegistry;
 /// LUSummary one at a time, accumulating whole-program data into an
 /// AnalysisResult.
 class SummaryAnalysisBase : public AnalysisBase {
-  friend class AnalysisDriver;
-
-protected:
-  SummaryAnalysisBase() : AnalysisBase(AnalysisBase::Kind::Summary) {}
-
 public:
   /// SummaryName of the EntitySummary type this analysis consumes.
   /// Used by the driver to route entities from the LUSummary.
   virtual SummaryName getSummaryName() const = 0;
 
+protected:
+  SummaryAnalysisBase() : AnalysisBase(AnalysisBase::Kind::Summary) {}
+
 private:
+  friend class AnalysisDriver;
+
   /// Called once before any add() calls. Default is a no-op.
   virtual llvm::Error initialize() { return llvm::Error::success(); }
 
@@ -68,18 +68,6 @@ private:
 /// getResult() & (mutable) within the analysis implementation.
 template <typename ResultT, typename EntitySummaryT>
 class SummaryAnalysis : public SummaryAnalysisBase {
-  static_assert(std::is_base_of_v<AnalysisResult, ResultT>,
-                "ResultT must derive from AnalysisResult");
-  static_assert(HasAnalysisName_v<ResultT>,
-                "ResultT must have a static analysisName() method");
-  static_assert(std::is_base_of_v<EntitySummary, EntitySummaryT>,
-                "EntitySummaryT must derive from EntitySummary");
-
-  friend class AnalysisRegistry;
-  using ResultType = ResultT;
-
-  std::unique_ptr<ResultT> Result = std::make_unique<ResultT>();
-
 public:
   /// Used by AnalysisRegistry::Add to derive the registry entry name.
   AnalysisName getAnalysisName() const final { return ResultT::analysisName(); }
@@ -111,6 +99,18 @@ protected:
   ResultT &getResult() & { return *Result; }
 
 private:
+  static_assert(std::is_base_of_v<AnalysisResult, ResultT>,
+                "ResultT must derive from AnalysisResult");
+  static_assert(HasAnalysisName_v<ResultT>,
+                "ResultT must have a static analysisName() method");
+  static_assert(std::is_base_of_v<EntitySummary, EntitySummaryT>,
+                "EntitySummaryT must derive from EntitySummary");
+
+  friend class AnalysisRegistry;
+  using ResultType = ResultT;
+
+  std::unique_ptr<ResultT> Result = std::make_unique<ResultT>();
+
   /// Seals the type-erased base overload, downcasts, and dispatches to the
   /// typed add().
   llvm::Error add(EntityId Id, const EntitySummary &Summary) final {

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/WPASuite.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/WPASuite.h
@@ -89,10 +89,10 @@ private:
   friend class SerializationFormat;
   friend class TestFixture;
 
+  WPASuite() = default;
+
   EntityIdTable IdTable;
   std::map<AnalysisName, std::unique_ptr<AnalysisResult>> Data;
-
-  WPASuite() = default;
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/WPASuite.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/WPASuite.h
@@ -35,15 +35,6 @@ class TestFixture;
 /// This is the natural unit of persistence: entity names and analysis results
 /// are self-contained in one object.
 class WPASuite {
-  friend class AnalysisDriver;
-  friend class SerializationFormat;
-  friend class TestFixture;
-
-  EntityIdTable IdTable;
-  std::map<AnalysisName, std::unique_ptr<AnalysisResult>> Data;
-
-  WPASuite() = default;
-
 public:
   /// Returns the EntityIdTable that maps EntityId values to their symbolic
   /// names.
@@ -92,6 +83,16 @@ public:
     }
     return *It->second;
   }
+
+private:
+  friend class AnalysisDriver;
+  friend class SerializationFormat;
+  friend class TestFixture;
+
+  EntityIdTable IdTable;
+  std::map<AnalysisName, std::unique_ptr<AnalysisResult>> Data;
+
+  WPASuite() = default;
 };
 
 } // namespace clang::ssaf


### PR DESCRIPTION
This changes reorders SSAF classes that had non-conforming section order to follow the convention: `public`, then `protected`, then `private`. A few cases required keeping declarations ahead of the public section because they are referenced by public API members.