### PR TITLE
[clang] Get the directory identity from `ModuleCache` instead of `FileManager`

### DIFF
--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -56,34 +56,31 @@ using ModuleId = SmallVector<std::pair<std::string, SourceLocation>, 2>;
 
 /// Deduplication key for a loaded module file in \c ModuleManager.
 ///
-/// For implicitly-built modules, this is the \c DirectoryEntry of the module
-/// cache and the module file name with the (optional) context hash.
-/// This enables using \c FileManager's inode-based canonicalization of the
-/// user-provided module cache path without hitting issues on file systems that
-/// recycle inodes for recompiled module files.
+/// For implicitly-built modules, this is a pointer representing the module
+/// cache directory and the module file name with the (optional) context hash.
+/// This enables using inode-based canonicalization of the user-provided module
+/// cache path without hitting issues on file systems that recycle inodes for
+/// recompiled module files.
 ///
 /// For explicitly-built modules, this is \c FileEntry.
 /// This uses \c FileManager's inode-based canonicalization of the user-provided
 /// module file path. Because input explicitly-built modules do not change
 /// during the lifetime of the compiler, inode recycling is not of concern here.
 class ModuleFileKey {
-  /// The FileManager entity used for deduplication.
+  /// The entity used for deduplication.
   const void *Ptr;
   /// The path relative to the module cache path for implicit module file, empty
   /// for other kinds of module files.
   std::string ImplicitModulePathSuffix;
 
-  friend class ModuleFileName;
   friend llvm::DenseMapInfo<ModuleFileKey>;
 
-  ModuleFileKey(const void *Ptr) : Ptr(Ptr) {}
+public:
+  ModuleFileKey(const void *ModuleFile) : Ptr(ModuleFile) {}
 
-  ModuleFileKey(const FileEntry *ModuleFile) : Ptr(ModuleFile) {}
-
-  ModuleFileKey(const DirectoryEntry *ModuleCacheDir, StringRef PathSuffix)
+  ModuleFileKey(const void *ModuleCacheDir, StringRef PathSuffix)
       : Ptr(ModuleCacheDir), ImplicitModulePathSuffix(PathSuffix) {}
 
-public:
   bool operator==(const ModuleFileKey &Other) const {
     return Ptr == Other.Ptr &&
            ImplicitModulePathSuffix == Other.ImplicitModulePathSuffix;
@@ -148,12 +145,6 @@ public:
 
   /// Checks whether the module file name is empty.
   bool empty() const { return Path.empty(); }
-
-  /// Creates the deduplication key for use in \c ModuleManager.
-  /// Returns an empty optional if:
-  /// * the module cache does not exist for an implicit module name,
-  /// * the module file does not exist for an explicit module name.
-  std::optional<ModuleFileKey> makeKey(FileManager &FileMgr) const;
 };
 
 /// The signature of a module, which is a hash of the AST content.

--- a/clang/include/clang/Serialization/ModuleCache.h
+++ b/clang/include/clang/Serialization/ModuleCache.h
@@ -10,6 +10,9 @@
 #define LLVM_CLANG_SERIALIZATION_MODULECACHE_H
 
 #include "clang/Basic/LLVM.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/FileSystem/UniqueID.h"
 
 #include <ctime>
 #include <memory>
@@ -25,10 +28,27 @@ class MemoryBufferRef;
 namespace clang {
 class InMemoryModuleCache;
 
+/// The address of an instance of this class represents the identity of a module
+/// cache directory.
+class ModuleCacheDirectory {};
+
 /// The module cache used for compiling modules implicitly. This centralizes the
 /// operations the compiler might want to perform on the cache.
 class ModuleCache {
+  /// Mapping from a path to the module cache directory identity.
+  llvm::StringMap<const ModuleCacheDirectory *> ByName;
+
+  /// Mapping from the filesystem entity to the module cache directory identity.
+  llvm::DenseMap<llvm::sys::fs::UniqueID, std::unique_ptr<ModuleCacheDirectory>>
+      ByUID;
+
 public:
+  /// Returns an opaque pointer representing the module cache directory. This
+  /// returns the same pointer regardless of the path spelling, as long as it
+  /// resolves to the same file system entity. This also resolves links in the
+  /// path. This may return nullptr if the module cache does not exist.
+  virtual const ModuleCacheDirectory *getDirectoryPtr(StringRef Path);
+
   /// Returns lock for the given module file. The lock is initially unlocked.
   virtual std::unique_ptr<llvm::AdvisoryLock>
   getLock(StringRef ModuleFilename) = 0;

--- a/clang/include/clang/Serialization/ModuleCache.h
+++ b/clang/include/clang/Serialization/ModuleCache.h
@@ -36,7 +36,7 @@ class ModuleCacheDirectory {};
 /// operations the compiler might want to perform on the cache.
 class ModuleCache {
   /// Mapping from a path to the module cache directory identity.
-  llvm::StringMap<const ModuleCacheDirectory *> ByName;
+  llvm::StringMap<const ModuleCacheDirectory *> ByPath;
 
   /// Mapping from the filesystem entity to the module cache directory identity.
   llvm::DenseMap<llvm::sys::fs::UniqueID, std::unique_ptr<ModuleCacheDirectory>>

--- a/clang/include/clang/Serialization/ModuleManager.h
+++ b/clang/include/clang/Serialization/ModuleManager.h
@@ -328,6 +328,12 @@ public:
   /// View the graphviz representation of the module graph.
   void viewGraph();
 
+  /// Creates the deduplication key for use in \c ModuleManager.
+  /// Returns an empty optional if:
+  /// * the module cache does not exist for an implicit module name,
+  /// * the module file does not exist for an explicit module name.
+  std::optional<ModuleFileKey> makeKey(const ModuleFileName &Name) const;
+
   ModuleCache &getModuleCache() const { return ModCache; }
 };
 

--- a/clang/lib/Basic/Module.cpp
+++ b/clang/lib/Basic/Module.cpp
@@ -33,26 +33,6 @@
 
 using namespace clang;
 
-std::optional<ModuleFileKey>
-ModuleFileName::makeKey(FileManager &FileMgr) const {
-  if (ImplicitModuleSuffixLength) {
-    StringRef ModuleCachePath =
-        StringRef(Path).drop_back(ImplicitModuleSuffixLength);
-    StringRef ImplicitModuleSuffix =
-        StringRef(Path).take_back(ImplicitModuleSuffixLength);
-    if (auto ModuleCache = FileMgr.getOptionalDirectoryRef(
-            ModuleCachePath, /*CacheFailure=*/false))
-      return ModuleFileKey(*ModuleCache, ImplicitModuleSuffix);
-  } else {
-    if (auto ModuleFile = FileMgr.getOptionalFileRef(Path, /*OpenFile=*/true,
-                                                     /*CacheFailure=*/false,
-                                                     /*IsText=*/false))
-      return ModuleFileKey(*ModuleFile);
-  }
-
-  return std::nullopt;
-}
-
 Module::Module(ModuleConstructorTag, StringRef Name,
                SourceLocation DefinitionLoc, Module *Parent, bool IsFramework,
                bool IsExplicit, unsigned VisibilityID)

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -41,6 +41,7 @@
 #include "clang/Serialization/GlobalModuleIndex.h"
 #include "clang/Serialization/InMemoryModuleCache.h"
 #include "clang/Serialization/ModuleCache.h"
+#include "clang/Serialization/ModuleManager.h"
 #include "clang/Serialization/SerializationDiagnostic.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/STLExtras.h"
@@ -1945,7 +1946,8 @@ ModuleLoadResult CompilerInstance::findOrCompileModuleAndReadAST(
 
     // Check whether M refers to the file in the prebuilt module path.
     if (M && M->getASTFileKey() &&
-        *M->getASTFileKey() == ModuleFilename.makeKey(*FileMgr))
+        *M->getASTFileKey() ==
+            getASTReader()->getModuleManager().makeKey(ModuleFilename))
       return M;
 
     getDiagnostics().Report(ModuleNameLoc, diag::err_module_prebuilt)

--- a/clang/lib/Serialization/ModuleCache.cpp
+++ b/clang/lib/Serialization/ModuleCache.cpp
@@ -20,7 +20,7 @@
 using namespace clang;
 
 const ModuleCacheDirectory *ModuleCache::getDirectoryPtr(StringRef Path) {
-  auto [ByNameIt, ByNameInserted] = ByName.insert({Path, nullptr});
+  auto [ByNameIt, ByNameInserted] = ByPath.insert({Path, nullptr});
   if (!ByNameIt->second) {
     // This is a compiler-internal input/output, let's bypass the sandbox.
     auto BypassSandbox = llvm::sys::sandbox::scopedDisable();

--- a/clang/lib/Serialization/ModuleCache.cpp
+++ b/clang/lib/Serialization/ModuleCache.cpp
@@ -19,6 +19,23 @@
 
 using namespace clang;
 
+const ModuleCacheDirectory *ModuleCache::getDirectoryPtr(StringRef Path) {
+  auto [ByNameIt, ByNameInserted] = ByName.insert({Path, nullptr});
+  if (!ByNameIt->second) {
+    // This is a compiler-internal input/output, let's bypass the sandbox.
+    auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
+    llvm::sys::fs::file_status Status;
+    if (llvm::sys::fs::status(Path, Status))
+      return nullptr;
+    llvm::sys::fs::UniqueID UID = Status.getUniqueID();
+    auto [ByUIDIt, ByUIDInserted] = ByUID.insert({UID, nullptr});
+    if (!ByUIDIt->second)
+      ByUIDIt->second = std::make_unique<ModuleCacheDirectory>();
+    ByNameIt->second = ByUIDIt->second.get();
+  }
+  return ByNameIt->second;
+}
+
 /// Write a new timestamp file with the given path.
 static void writeTimestampFile(StringRef TimestampFile) {
   std::error_code EC;

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -41,6 +41,23 @@
 using namespace clang;
 using namespace serialization;
 
+std::optional<ModuleFileKey>
+ModuleManager::makeKey(const ModuleFileName &Name) const {
+  if (unsigned SuffixLen = Name.getImplicitModuleSuffixLength()) {
+    StringRef ModuleCachePath = StringRef(Name).drop_back(SuffixLen);
+    StringRef ImplicitModuleSuffix = StringRef(Name).take_back(SuffixLen);
+    if (auto *ModuleCacheDir = ModCache.getDirectoryPtr(ModuleCachePath))
+      return ModuleFileKey(ModuleCacheDir, ImplicitModuleSuffix);
+  } else {
+    if (auto ModuleFile = FileMgr.getOptionalFileRef(Name, /*OpenFile=*/true,
+                                                     /*CacheFailure=*/false,
+                                                     /*IsText=*/false))
+      return ModuleFileKey(*ModuleFile);
+  }
+
+  return std::nullopt;
+}
+
 ModuleFile *ModuleManager::lookupByModuleName(StringRef Name) const {
   if (const Module *Mod = HeaderSearchInfo.getModuleMap().findModule(Name))
     if (const ModuleFileName *FileName = Mod->getASTFileName())
@@ -50,7 +67,7 @@ ModuleFile *ModuleManager::lookupByModuleName(StringRef Name) const {
 }
 
 ModuleFile *ModuleManager::lookupByFileName(ModuleFileName Name) const {
-  std::optional<ModuleFileKey> Key = Name.makeKey(FileMgr);
+  std::optional<ModuleFileKey> Key = makeKey(Name);
   return Key ? lookup(*Key) : nullptr;
 }
 
@@ -134,7 +151,7 @@ AddModuleResult ModuleManager::addModule(
     ExpectedModTime = 0;
   }
 
-  std::optional<ModuleFileKey> FileKey = FileName.makeKey(FileMgr);
+  std::optional<ModuleFileKey> FileKey = makeKey(FileName);
   if (!FileKey) {
     Result.K = AddModuleResult::Missing;
     return Result;


### PR DESCRIPTION
Using `FileManager`'s  caching and deduplication functionality for assigning identity to the module cache is handy, but it relies on two assumptions:
* the rest of the compiler consistently calls `FileManager::getOptionalDirectoryRef()` with `/*CacheFailure=*/false` for the module cache path,
* the VFS is not caching failed stats for the module cache path.

This PR implements this functionality in the `ModuleCache` interface, which is conceptually the right place for it. This PR enables us to land the VFS simplifications in https://github.com/llvm/llvm-project/pull/190843.