### PR TITLE
[CIR] Allow user-defined casts in emitPointerWithAlignment

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -203,6 +203,7 @@ Address CIRGenFunction::emitPointerWithAlignment(const Expr *expr,
     case CK_NullToMemberPointer:
     case CK_NullToPointer:
     case CK_ReinterpretMemberPointer:
+    case CK_UserDefinedConversion:
       // Common pointer conversions, nothing to do here.
       // TODO: Is there any reason to treat base-to-derived conversions
       // specially?
@@ -254,10 +255,16 @@ Address CIRGenFunction::emitPointerWithAlignment(const Expr *expr,
     case CK_PointerToIntegral:
     case CK_ToUnion:
     case CK_ToVoid:
-    case CK_UserDefinedConversion:
     case CK_VectorSplat:
     case CK_ZeroToOCLOpaqueType:
-      llvm_unreachable("unexpected cast for emitPointerWithAlignment");
+      // Classic codegen has a default that does nothing. In CIR, we are issuing
+      // a diagnostic so we can examine casts that are reached here to be sure
+      // no action is needed. If nothing is needed, the cast can be moved to the
+      // group above that does nothing.
+      cgm.errorNYI(ce->getSourceRange(),
+                   "unexpected cast for emitPointerWithAlignment: ",
+                   ce->getCastKindName());
+      break;
     }
   }
 

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -164,3 +164,22 @@ void null_cast(long) {
 // CIR:    cir.store{{.*}} %{{.*}}, %[[NULLPTR]] : !s32i, !cir.ptr<!s32i>
 // CIR:    %[[NULLPTR_A:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!rec_A>
 // CIR:    %[[A_X:.*]] = cir.get_member %[[NULLPTR_A]][0] {name = "x"} : !cir.ptr<!rec_A> -> !cir.ptr<!s32i>
+
+struct B {
+  int *p;
+  operator int *() const { return p; }
+};
+
+int test_unser_defined_cast_with_aligned_load(B x) {
+  return *x;
+}
+
+// CIR: cir.func{{.*}} @_Z41test_unser_defined_cast_with_aligned_load1B
+// CIR:   cir.store %{{.*}}, %[[B_PTR:.*]] : !rec_B, !cir.ptr<!rec_B>
+// CIR:   %[[CAST:.*]] = cir.call @_ZNK1BcvPiEv(%[[B_PTR]])
+// CIR:   %[[LOAD:.*]] = cir.load{{.*}} %[[CAST]]
+
+// LLVM: define{{.*}} i32 @_Z41test_unser_defined_cast_with_aligned_load1B
+// LLVM:   store %struct.B %{{.*}}, ptr %[[B_PTR:.*]], align 8
+// LLVM:   %[[CAST:.*]] = call {{.*}} ptr @_ZNK1BcvPiEv(ptr {{.*}} %[[B_PTR]])
+// LLVM:   %[[LOAD:.*]] = load i32, ptr %[[CAST]]


### PR DESCRIPTION
In CIR, we use a fully-covered switch for casts in emitPointerWithAlignment and only allow casts that are known to be safe to fall through without handling. Classic codegen uses a default and all casts that don't already have special handling fall through. This change moves CK_UserDefinedConversion to the group that we allow to fall through and changes the unanalyzed group to emit an NYI diagnostic rather than calling llvm_unreachable.