### PR TITLE
[clang][SSAF][NFC] Remove redundant overrides from analysis templates

### DIFF
--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/DerivedAnalysis.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/DerivedAnalysis.h
@@ -97,13 +97,6 @@ public:
   /// Called once with the fixed dependency results before the step() loop.
   virtual llvm::Error initialize(const DepResultTs &...) = 0;
 
-  /// Performs one step. Returns true if another step is needed; false when
-  /// converged. Single-step analyses always return false.
-  virtual llvm::Expected<bool> step() override = 0;
-
-  /// Called after the step() loop converges. Override for post-processing.
-  virtual llvm::Error finalize() override { return llvm::Error::success(); }
-
 protected:
   /// Read-only access to the result being built.
   const ResultT &getResult() const & { return *Result; }

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/SummaryAnalysis.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/SummaryAnalysis.h
@@ -93,15 +93,8 @@ public:
     return Empty;
   }
 
-  /// Called once before the first add() call. Override for initialization.
-  virtual llvm::Error initialize() override { return llvm::Error::success(); }
-
   /// Called once per matching entity. Implement to accumulate data.
   virtual llvm::Error add(EntityId Id, const EntitySummaryT &Summary) = 0;
-
-  /// Called after all entities have been processed.
-  /// Override for post-processing.
-  virtual llvm::Error finalize() override { return llvm::Error::success(); }
 
 protected:
   /// Read-only access to the result being built.


### PR DESCRIPTION
This PR removes redundant:
- `initialize()` and `finalize()` overrides from `SummaryAnalysis` already provided by `SummaryAnalysisBase`.
- `step()` and `finalize()` overrides from `DerivedAnalysis<>` already provided by `DerivedAnalysisBase`.