### PR TITLE
[AArch64][PAC] Handle signing of init/fini pointers in AsmPrinter

### DIFF
--- a/clang/include/clang/Basic/PointerAuthOptions.h
+++ b/clang/include/clang/Basic/PointerAuthOptions.h
@@ -27,10 +27,6 @@ namespace clang {
 /// is ptrauth_string_discriminator("block_descriptor")
 constexpr uint16_t BlockDescriptorConstantDiscriminator = 0xC0BB;
 
-/// Constant discriminator to be used with function pointers in .init_array and
-/// .fini_array. The value is ptrauth_string_discriminator("init_fini")
-constexpr uint16_t InitFiniPointerConstantDiscriminator = 0xD9D4;
-
 /// Constant discriminator to be used with method list pointers. The value is
 /// ptrauth_string_discriminator("method_list_t")
 constexpr uint16_t MethodListPointerConstantDiscriminator = 0xC310;
@@ -223,9 +219,6 @@ struct PointerAuthOptions {
 
   /// The ABI for C++ member function pointers.
   PointerAuthSchema CXXMemberFunctionPointers;
-
-  /// The ABI for function addresses in .init_array and .fini_array
-  PointerAuthSchema InitFiniPointers;
 
   /// The ABI for block invocation function pointers.
   PointerAuthSchema BlockInvocationFunctionPointers;

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1392,6 +1392,12 @@ void CodeGenModule::Release() {
 
     if (LangOpts.PointerAuthELFGOT)
       getModule().addModuleFlag(llvm::Module::Error, "ptrauth-elf-got", 1);
+    if (LangOpts.PointerAuthCalls && LangOpts.PointerAuthInitFini) {
+      getModule().addModuleFlag(llvm::Module::Error, "ptrauth-init-fini", 1);
+      if (LangOpts.PointerAuthInitFiniAddressDiscrimination)
+        getModule().addModuleFlag(
+            llvm::Module::Error, "ptrauth-init-fini-address-discrimination", 1);
+    }
 
     if (getTriple().isOSLinux()) {
       if (LangOpts.PointerAuthCalls)
@@ -2432,9 +2438,6 @@ void CodeGenModule::AddGlobalDtor(llvm::Function *Dtor, int Priority,
 void CodeGenModule::EmitCtorList(CtorList &Fns, const char *GlobalName) {
   if (Fns.empty()) return;
 
-  const PointerAuthSchema &InitFiniAuthSchema =
-      getCodeGenOpts().PointerAuth.InitFiniPointers;
-
   // Ctor function type is ptr.
   llvm::PointerType *PtrTy = llvm::PointerType::get(
       getLLVMContext(), TheModule.getDataLayout().getProgramAddressSpace());
@@ -2448,23 +2451,7 @@ void CodeGenModule::EmitCtorList(CtorList &Fns, const char *GlobalName) {
   for (const auto &I : Fns) {
     auto Ctor = Ctors.beginStruct(CtorStructTy);
     Ctor.addInt(Int32Ty, I.Priority);
-    if (InitFiniAuthSchema) {
-      llvm::Constant *StorageAddress =
-          (InitFiniAuthSchema.isAddressDiscriminated()
-               ? llvm::ConstantExpr::getIntToPtr(
-                     llvm::ConstantInt::get(
-                         IntPtrTy,
-                         llvm::ConstantPtrAuth::AddrDiscriminator_CtorsDtors),
-                     PtrTy)
-               : nullptr);
-      llvm::Constant *SignedCtorPtr = getConstantSignedPointer(
-          I.Initializer, InitFiniAuthSchema.getKey(), StorageAddress,
-          llvm::ConstantInt::get(
-              SizeTy, InitFiniAuthSchema.getConstantDiscrimination()));
-      Ctor.add(SignedCtorPtr);
-    } else {
-      Ctor.add(I.Initializer);
-    }
+    Ctor.add(I.Initializer);
     if (I.AssociatedData)
       Ctor.add(I.AssociatedData);
     else

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1539,17 +1539,18 @@ void CodeGenModule::Release() {
                                 "sign-return-address-with-bkey", 2);
   }
   if (T.isAArch64()) {
-    if (getTriple().isOSBinFormatELF())
+    if (getTriple().isOSBinFormatELF()) {
       getModule().addModuleFlag(llvm::Module::Error, "ptrauth-elf-got",
                                 LangOpts.PointerAuthELFGOT);
 
-    getModule().addModuleFlag(llvm::Module::Error, "ptrauth-init-fini",
-                              LangOpts.PointerAuthCalls &&
-                                  LangOpts.PointerAuthInitFini);
-    getModule().addModuleFlag(
-        llvm::Module::Error, "ptrauth-init-fini-address-discrimination",
-        LangOpts.PointerAuthCalls && LangOpts.PointerAuthInitFini &&
-            LangOpts.PointerAuthInitFiniAddressDiscrimination);
+      getModule().addModuleFlag(llvm::Module::Error, "ptrauth-init-fini",
+                                LangOpts.PointerAuthCalls &&
+                                    LangOpts.PointerAuthInitFini);
+      getModule().addModuleFlag(
+          llvm::Module::Error, "ptrauth-init-fini-address-discrimination",
+          LangOpts.PointerAuthCalls && LangOpts.PointerAuthInitFini &&
+              LangOpts.PointerAuthInitFiniAddressDiscrimination);
+    }
 
     if (getTriple().isOSLinux()) {
       getModule().addModuleFlag(llvm::Module::Error, "ptrauth-sign-personality",

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1543,12 +1543,13 @@ void CodeGenModule::Release() {
       getModule().addModuleFlag(llvm::Module::Error, "ptrauth-elf-got",
                                 LangOpts.PointerAuthELFGOT);
 
-    if (LangOpts.PointerAuthCalls && LangOpts.PointerAuthInitFini) {
-      getModule().addModuleFlag(llvm::Module::Error, "ptrauth-init-fini", 1);
-      if (LangOpts.PointerAuthInitFiniAddressDiscrimination)
-        getModule().addModuleFlag(
-            llvm::Module::Error, "ptrauth-init-fini-address-discrimination", 1);
-    }
+    getModule().addModuleFlag(llvm::Module::Error, "ptrauth-init-fini",
+                              LangOpts.PointerAuthCalls &&
+                                  LangOpts.PointerAuthInitFini);
+    getModule().addModuleFlag(
+        llvm::Module::Error, "ptrauth-init-fini-address-discrimination",
+        LangOpts.PointerAuthCalls && LangOpts.PointerAuthInitFini &&
+            LangOpts.PointerAuthInitFiniAddressDiscrimination);
 
     if (getTriple().isOSLinux()) {
       getModule().addModuleFlag(llvm::Module::Error, "ptrauth-sign-personality",

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1543,6 +1543,13 @@ void CodeGenModule::Release() {
       getModule().addModuleFlag(llvm::Module::Error, "ptrauth-elf-got",
                                 LangOpts.PointerAuthELFGOT);
 
+    if (LangOpts.PointerAuthCalls && LangOpts.PointerAuthInitFini) {
+      getModule().addModuleFlag(llvm::Module::Error, "ptrauth-init-fini", 1);
+      if (LangOpts.PointerAuthInitFiniAddressDiscrimination)
+        getModule().addModuleFlag(
+            llvm::Module::Error, "ptrauth-init-fini-address-discrimination", 1);
+    }
+
     if (getTriple().isOSLinux()) {
       getModule().addModuleFlag(llvm::Module::Error, "ptrauth-sign-personality",
                                 LangOpts.PointerAuthCalls);
@@ -2621,9 +2628,6 @@ void CodeGenModule::AddGlobalDtor(llvm::Function *Dtor, int Priority,
 void CodeGenModule::EmitCtorList(CtorList &Fns, const char *GlobalName) {
   if (Fns.empty()) return;
 
-  const PointerAuthSchema &InitFiniAuthSchema =
-      getCodeGenOpts().PointerAuth.InitFiniPointers;
-
   // Ctor function type is ptr.
   llvm::PointerType *PtrTy = llvm::PointerType::get(
       getLLVMContext(), TheModule.getDataLayout().getProgramAddressSpace());
@@ -2637,23 +2641,7 @@ void CodeGenModule::EmitCtorList(CtorList &Fns, const char *GlobalName) {
   for (const auto &I : Fns) {
     auto Ctor = Ctors.beginStruct(CtorStructTy);
     Ctor.addInt(Int32Ty, I.Priority);
-    if (InitFiniAuthSchema) {
-      llvm::Constant *StorageAddress =
-          (InitFiniAuthSchema.isAddressDiscriminated()
-               ? llvm::ConstantExpr::getIntToPtr(
-                     llvm::ConstantInt::get(
-                         IntPtrTy,
-                         llvm::ConstantPtrAuth::AddrDiscriminator_CtorsDtors),
-                     PtrTy)
-               : nullptr);
-      llvm::Constant *SignedCtorPtr = getConstantSignedPointer(
-          I.Initializer, InitFiniAuthSchema.getKey(), StorageAddress,
-          llvm::ConstantInt::get(
-              SizeTy, InitFiniAuthSchema.getConstantDiscrimination()));
-      Ctor.add(SignedCtorPtr);
-    } else {
-      Ctor.add(I.Initializer);
-    }
+    Ctor.add(I.Initializer);
     if (I.AssociatedData)
       Ctor.add(I.AssociatedData);
     else

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1475,12 +1475,6 @@ void CompilerInvocation::setDefaultPointerAuthOptions(
     Opts.CXXMemberFunctionPointers =
         PointerAuthSchema(Key::ASIA, false, Discrimination::Type);
 
-    if (LangOpts.PointerAuthInitFini) {
-      Opts.InitFiniPointers = PointerAuthSchema(
-          Key::ASIA, LangOpts.PointerAuthInitFiniAddressDiscrimination,
-          Discrimination::Constant, InitFiniPointerConstantDiscriminator);
-    }
-
     Opts.BlockInvocationFunctionPointers =
         PointerAuthSchema(Key::ASIA, true, Discrimination::None);
     Opts.BlockHelperFunctionPointers =

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1483,12 +1483,6 @@ void CompilerInvocation::setDefaultPointerAuthOptions(
     Opts.CXXMemberFunctionPointers =
         PointerAuthSchema(Key::ASIA, false, Discrimination::Type);
 
-    if (LangOpts.PointerAuthInitFini) {
-      Opts.InitFiniPointers = PointerAuthSchema(
-          Key::ASIA, LangOpts.PointerAuthInitFiniAddressDiscrimination,
-          Discrimination::Constant, InitFiniPointerConstantDiscriminator);
-    }
-
     Opts.BlockInvocationFunctionPointers =
         PointerAuthSchema(Key::ASIA, true, Discrimination::None);
     Opts.BlockHelperFunctionPointers =

--- a/clang/test/CodeGen/ptrauth-init-fini.c
+++ b/clang/test/CodeGen/ptrauth-init-fini.c
@@ -1,28 +1,36 @@
 // REQUIRES: aarch64-registered-target
 
 // RUN: %clang_cc1 -triple aarch64-elf -target-feature +pauth -fptrauth-calls -fptrauth-init-fini    \
-// RUN:   -emit-llvm %s -o - | FileCheck --check-prefix=SIGNED %s
+// RUN:   -emit-llvm %s -o - | FileCheck --check-prefix=COMMON,SIGNED %s
 
 // RUN: %clang_cc1 -triple aarch64-elf -target-feature +pauth -fptrauth-calls -fptrauth-init-fini    \
-// RUN:   -fptrauth-init-fini-address-discrimination -emit-llvm %s -o - | FileCheck --check-prefix=ADDRDISC %s
+// RUN:   -fptrauth-init-fini-address-discrimination -emit-llvm %s -o - | FileCheck --check-prefix=COMMON,ADDRDISC %s
 
 // RUN: %clang_cc1 -triple aarch64-elf -target-feature +pauth -fptrauth-calls \
-// RUN:   -emit-llvm %s -o - | FileCheck --check-prefix=UNSIGNED %s
+// RUN:   -emit-llvm %s -o - | FileCheck --check-prefix=COMMON,UNSIGNED %s
 
 // RUN: %clang_cc1 -triple aarch64-elf -target-feature +pauth -fptrauth-calls -fptrauth-init-fini-address-discrimination \
-// RUN:   -emit-llvm %s -o - | FileCheck --check-prefix=UNSIGNED %s
+// RUN:   -emit-llvm %s -o - | FileCheck --check-prefix=COMMON,UNSIGNED %s
 
 // RUN: %clang_cc1 -triple aarch64-elf -target-feature +pauth                 -fptrauth-init-fini    \
-// RUN:   -emit-llvm %s -o - | FileCheck --check-prefix=UNSIGNED %s
+// RUN:   -emit-llvm %s -o - | FileCheck --check-prefix=COMMON,UNSIGNED %s
 
-// SIGNED: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764), ptr null }]
-// SIGNED: @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar, i32 0, i64 55764), ptr null }]
+// COMMON: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
+// COMMON: @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar, ptr null }]
 
-// ADDRDISC: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764, ptr inttoptr (i64 1 to ptr)), ptr null }]
-// ADDRDISC: @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar, i32 0, i64 55764, ptr inttoptr (i64 1 to ptr)), ptr null }]
+// The below checks assume no other module flags happens to be set.
 
-// UNSIGNED: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
-// UNSIGNED: @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar, ptr null }]
+// UNSIGNED-NOT: !llvm.module.flags
+// UNSIGNED-NOT: !"ptrauth-init-fini"
+// UNSIGNED-NOT: !"ptrauth-init-fini-address-discrimination"
+
+// SIGNED: !llvm.module.flags = !{!0}
+// SIGNED: !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
+// SIGNED-NOT: !"ptrauth-init-fini-address-discrimination"
+
+// ADDRDISC: !llvm.module.flags = !{!0, !1}
+// ADDRDISC: !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
+// ADDRDISC: !1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 1}
 
 volatile int x = 0;
 

--- a/clang/test/CodeGen/ptrauth-init-fini.c
+++ b/clang/test/CodeGen/ptrauth-init-fini.c
@@ -20,16 +20,18 @@
 
 // The below checks assume no other module flags happens to be set.
 
-// COMMON: !llvm.module.flags = !{!0, !1}
+// COMMON: !llvm.module.flags = !{
+// COMMON-SAME: !1
+// COMMON-SAME: !2
 
-// UNSIGNED: !0 = !{i32 1, !"ptrauth-init-fini", i32 0}
-// UNSIGNED: !1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
+// UNSIGNED: !1 = !{i32 1, !"ptrauth-init-fini", i32 0}
+// UNSIGNED: !2 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 
-// SIGNED:   !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
-// SIGNED:   !1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
+// SIGNED:   !1 = !{i32 1, !"ptrauth-init-fini", i32 1}
+// SIGNED:   !2 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 
-// ADDRDISC: !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
-// ADDRDISC: !1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 1}
+// ADDRDISC: !1 = !{i32 1, !"ptrauth-init-fini", i32 1}
+// ADDRDISC: !2 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 1}
 
 volatile int x = 0;
 

--- a/clang/test/CodeGen/ptrauth-init-fini.c
+++ b/clang/test/CodeGen/ptrauth-init-fini.c
@@ -20,15 +20,14 @@
 
 // The below checks assume no other module flags happens to be set.
 
-// UNSIGNED-NOT: !llvm.module.flags
-// UNSIGNED-NOT: !"ptrauth-init-fini"
-// UNSIGNED-NOT: !"ptrauth-init-fini-address-discrimination"
+// COMMON: !llvm.module.flags = !{!0, !1}
 
-// SIGNED: !llvm.module.flags = !{!0}
-// SIGNED: !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
-// SIGNED-NOT: !"ptrauth-init-fini-address-discrimination"
+// UNSIGNED: !0 = !{i32 1, !"ptrauth-init-fini", i32 0}
+// UNSIGNED: !1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 
-// ADDRDISC: !llvm.module.flags = !{!0, !1}
+// SIGNED:   !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
+// SIGNED:   !1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
+
 // ADDRDISC: !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
 // ADDRDISC: !1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 1}
 

--- a/clang/test/CodeGen/ptrauth-init-fini.c
+++ b/clang/test/CodeGen/ptrauth-init-fini.c
@@ -18,8 +18,6 @@
 // COMMON: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
 // COMMON: @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar, ptr null }]
 
-// The below checks assume no other module flags happens to be set.
-
 // COMMON: !llvm.module.flags = !{
 // COMMON-SAME: !1
 // COMMON-SAME: !2

--- a/clang/test/CodeGen/ptrauth-module-flags.c
+++ b/clang/test/CodeGen/ptrauth-module-flags.c
@@ -13,15 +13,15 @@
 
 // PERSONALITY:      !llvm.module.flags = !{
 // PERSONALITY-SAME: !0
-// PERSONALITY-SAME: !1
+// PERSONALITY-SAME: !3
 // PERSONALITY:      !0 = !{i32 1, !"ptrauth-elf-got", i32 0}
-// PERSONALITY:      !1 = !{i32 1, !"ptrauth-sign-personality", i32 1}
+// PERSONALITY:      !3 = !{i32 1, !"ptrauth-sign-personality", i32 1}
 
 // OFF-LINUX:      !llvm.module.flags = !{
 // OFF-LINUX-SAME: !0
-// OFF-LINUX-SAME: !1
+// OFF-LINUX-SAME: !3
 // OFF-LINUX:      !0 = !{i32 1, !"ptrauth-elf-got", i32 0}
-// OFF-LINUX:      !1 = !{i32 1, !"ptrauth-sign-personality", i32 0}
+// OFF-LINUX:      !3 = !{i32 1, !"ptrauth-sign-personality", i32 0}
 
 // OFF-ELF:      !llvm.module.flags = !{
 // OFF-ELF-SAME: !0

--- a/clang/test/CodeGen/ptrauth-module-flags.c
+++ b/clang/test/CodeGen/ptrauth-module-flags.c
@@ -7,9 +7,9 @@
 
 // ELFGOT:      !llvm.module.flags = !{
 // ELFGOT-SAME: !0
-// ELFGOT-SAME: !1
+// ELFGOT-SAME: !3
 // ELFGOT:      !0 = !{i32 1, !"ptrauth-elf-got", i32 1}
-// ELFGOT:      !1 = !{i32 1, !"ptrauth-sign-personality", i32 0}
+// ELFGOT:      !3 = !{i32 1, !"ptrauth-sign-personality", i32 0}
 
 // PERSONALITY:      !llvm.module.flags = !{
 // PERSONALITY-SAME: !0

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -6165,12 +6165,109 @@ void llvm::UpgradeARCRuntime(Module &M) {
     UpgradeToIntrinsic(I.first, I.second);
 }
 
+// Upgrade from wrapping each pointer stored in the @llvm.global_(ctors|dtors)
+// with ptrauth constant expression to storing plain pointers in these arrays
+// and requesting the particular signing schema globally via module flags.
+//
+// Only perform the upgrade if all elements of *both* arrays agree on a common
+// signing schema. The processing of the array is *not* stopped on the first
+// null function pointer.
+static bool upgradePtrauthInitFiniArrays(Module &M) {
+  // Either "not decided yet" or whether we should request address diversity
+  // in addition to the basic constant diversity.
+  // There is no value representing "decided not to sign", as this results
+  // in immediate return from upgradePtrauthInitFiniArrays.
+  std::optional<bool> UseAddressDisc;
+
+  // Do not attempt upgrading if the new module flags already exist.
+  if (const NamedMDNode *ModFlags = M.getModuleFlagsMetadata()) {
+    for (const MDNode *Flag : ModFlags->operands()) {
+      if (Flag->getNumOperands() != 3)
+        continue;
+      const MDString *ID = dyn_cast_or_null<MDString>(Flag->getOperand(1));
+      if (ID && (ID->getString() == "ptrauth-init-fini" ||
+                 ID->getString() == "ptrauth-init-fini-address-discriminator"))
+        return false;
+    }
+  }
+
+  auto UpgradeSinglePointer = [&UseAddressDisc](Constant *CV) -> Constant * {
+    const unsigned ExpectedConstDisc = 0xD9D4;
+    const unsigned ExpectedAddressMarker = 1;
+
+    auto *CPA = dyn_cast<ConstantPtrAuth>(CV);
+    if (!CPA || !CPA->getDiscriminator()->equalsInt(ExpectedConstDisc))
+      return nullptr; // Nothing to upgrade or unknown pattern found.
+
+    bool HasAddressDisc;
+    if (!CPA->hasAddressDiscriminator())
+      HasAddressDisc = false;
+    else if (CPA->hasSpecialAddressDiscriminator(ExpectedAddressMarker))
+      HasAddressDisc = true;
+    else
+      return nullptr; // Unknown pattern.
+
+    if (UseAddressDisc && *UseAddressDisc != HasAddressDisc)
+      return nullptr; // Disagreement with the decided mode.
+
+    UseAddressDisc = HasAddressDisc;
+    return CPA->getPointer();
+  };
+
+  SmallVector<std::pair<GlobalVariable *, Constant *>> PendingUpgrades;
+  for (const char *Name : {"llvm.global_ctors", "llvm.global_dtors"}) {
+    auto *GV = dyn_cast_if_present<GlobalVariable>(M.getNamedValue(Name));
+    if (!GV || !GV->hasInitializer())
+      continue; // Skip, but it is okay to upgrade the other variable.
+
+    auto *Init = dyn_cast<ConstantArray>(GV->getInitializer());
+    if (!Init)
+      return false;
+
+    std::vector<Constant *> NewStructors;
+    NewStructors.reserve(Init->getNumOperands());
+    for (Use &U : Init->operands()) {
+      auto *Structor = dyn_cast<ConstantStruct>(U.get());
+      if (!Structor || Structor->getNumOperands() != 3)
+        return false;
+
+      Constant *Prio = Structor->getOperand(0);
+      Constant *Func = UpgradeSinglePointer(Structor->getOperand(1));
+      Constant *Arg = Structor->getOperand(2);
+      if (!Func)
+        return false;
+
+      NewStructors.push_back(
+          ConstantStruct::get(Structor->getType(), {Prio, Func, Arg}));
+    }
+
+    Constant *NewInit = ConstantArray::get(Init->getType(), NewStructors);
+    PendingUpgrades.push_back({GV, NewInit});
+  }
+
+  if (PendingUpgrades.empty())
+    return false;
+  assert(UseAddressDisc.has_value());
+
+  for (auto [GV, NewInit] : PendingUpgrades)
+    GV->setInitializer(NewInit);
+  M.addModuleFlag(Module::Error, "ptrauth-init-fini", 1);
+  if (UseAddressDisc.value())
+    M.addModuleFlag(Module::Error, "ptrauth-init-fini-address-discriminator",
+                    1);
+
+  return true;
+}
+
 bool llvm::UpgradeModuleFlags(Module &M) {
+  bool Changed = false;
+  Changed |= upgradePtrauthInitFiniArrays(M);
+
   NamedMDNode *ModFlags = M.getModuleFlagsMetadata();
   if (!ModFlags)
-    return false;
+    return Changed;
 
-  bool HasObjCFlag = false, HasClassProperties = false, Changed = false;
+  bool HasObjCFlag = false, HasClassProperties = false;
   bool HasSwiftVersionFlag = false;
   uint8_t SwiftMajorVersion, SwiftMinorVersion;
   uint32_t SwiftABIVersion;

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -6039,6 +6039,14 @@ Constant *llvm::UpgradeBitCastExpr(unsigned Opc, Constant *C, Type *DestTy) {
   return nullptr;
 }
 
+static std::optional<StringRef> getModuleFlagNameSafely(const MDNode &Flag) {
+  if (Flag.getNumOperands() < 3)
+    return std::nullopt;
+  if (MDString *Name = dyn_cast_or_null<MDString>(Flag.getOperand(1)))
+    return Name->getString();
+  return std::nullopt;
+}
+
 /// Check the debug info version number, if it is out-dated, drop the debug
 /// info. Return true if module is modified.
 bool llvm::UpgradeDebugInfo(Module &M) {
@@ -6052,10 +6060,8 @@ bool llvm::UpgradeDebugInfo(Module &M) {
   unsigned Version = 0;
   if (NamedMDNode *ModFlags = M.getModuleFlagsMetadata()) {
     auto OpIt = find_if(ModFlags->operands(), [](const MDNode *Flag) {
-      if (Flag->getNumOperands() < 3)
-        return false;
-      if (MDString *K = dyn_cast_or_null<MDString>(Flag->getOperand(1)))
-        return K->getString() == "Debug Info Version";
+      if (auto Name = getModuleFlagNameSafely(*Flag))
+        return *Name == "Debug Info Version";
       return false;
     });
     if (OpIt != ModFlags->op_end()) {
@@ -6372,13 +6378,11 @@ void llvm::UpgradeARCRuntime(Module &M) {
     UpgradeToIntrinsic(I.first, I.second);
 }
 
-// Upgrade from wrapping each pointer stored in the @llvm.global_(ctors|dtors)
-// with ptrauth constant expression to storing plain pointers in these arrays
-// and requesting the particular signing schema globally via module flags.
+// Upgrade from storing `ptrauth` constants in `@llvm.global_(ctors|dtors)`
+// arrays to configuring signing of pointers to *structors via module flags.
 //
 // Only perform the upgrade if all elements of *both* arrays agree on a common
-// signing schema. The processing of the array is *not* stopped on the first
-// null function pointer.
+// signing schema.
 static bool upgradePtrauthInitFiniArrays(Module &M) {
   // Either "not decided yet" or whether we should request address diversity
   // in addition to the basic constant diversity.
@@ -6389,11 +6393,9 @@ static bool upgradePtrauthInitFiniArrays(Module &M) {
   // Do not attempt upgrading if the new module flags already exist.
   if (const NamedMDNode *ModFlags = M.getModuleFlagsMetadata()) {
     for (const MDNode *Flag : ModFlags->operands()) {
-      if (Flag->getNumOperands() != 3)
-        continue;
-      const MDString *ID = dyn_cast_or_null<MDString>(Flag->getOperand(1));
-      if (ID && (ID->getString() == "ptrauth-init-fini" ||
-                 ID->getString() == "ptrauth-init-fini-address-discriminator"))
+      std::optional<StringRef> Name = getModuleFlagNameSafely(*Flag);
+      if (Name && (*Name == "ptrauth-init-fini" ||
+                   *Name == "ptrauth-init-fini-address-discriminator"))
         return false;
     }
   }
@@ -6421,26 +6423,32 @@ static bool upgradePtrauthInitFiniArrays(Module &M) {
     return CPA->getPointer();
   };
 
-  SmallVector<std::pair<GlobalVariable *, Constant *>> PendingUpgrades;
+  // Do not apply any changes until we know the upgrade is non-ambiguous.
+  using PendingUpgrade = std::pair<GlobalVariable *, Constant *>;
+  SmallVector<PendingUpgrade, 2> GlobalArraysToUpgrade;
+
   for (const char *Name : {"llvm.global_ctors", "llvm.global_dtors"}) {
     auto *GV = dyn_cast_if_present<GlobalVariable>(M.getNamedValue(Name));
     if (!GV || !GV->hasInitializer())
       continue; // Skip, but it is okay to upgrade the other variable.
 
-    auto *Init = dyn_cast<ConstantArray>(GV->getInitializer());
-    if (!Init)
+    auto *OldStructorsArray = dyn_cast<ConstantArray>(GV->getInitializer());
+    if (!OldStructorsArray)
       return false;
 
     std::vector<Constant *> NewStructors;
-    NewStructors.reserve(Init->getNumOperands());
-    for (Use &U : Init->operands()) {
-      auto *Structor = dyn_cast<ConstantStruct>(U.get());
+    NewStructors.reserve(OldStructorsArray->getNumOperands());
+
+    for (Use &U : OldStructorsArray->operands()) {
+      ConstantStruct *Structor = dyn_cast<ConstantStruct>(U.get());
       if (!Structor || Structor->getNumOperands() != 3)
         return false;
 
       Constant *Prio = Structor->getOperand(0);
-      Constant *Func = UpgradeSinglePointer(Structor->getOperand(1));
+      Constant *Func = Structor->getOperand(1);
       Constant *Arg = Structor->getOperand(2);
+
+      Func = UpgradeSinglePointer(Func);
       if (!Func)
         return false;
 
@@ -6448,16 +6456,18 @@ static bool upgradePtrauthInitFiniArrays(Module &M) {
           ConstantStruct::get(Structor->getType(), {Prio, Func, Arg}));
     }
 
-    Constant *NewInit = ConstantArray::get(Init->getType(), NewStructors);
-    PendingUpgrades.push_back({GV, NewInit});
+    Constant *NewInit =
+        ConstantArray::get(OldStructorsArray->getType(), NewStructors);
+    GlobalArraysToUpgrade.push_back({GV, NewInit});
   }
 
-  if (PendingUpgrades.empty())
+  if (GlobalArraysToUpgrade.empty())
     return false;
   assert(UseAddressDisc.has_value());
 
-  for (auto [GV, NewInit] : PendingUpgrades)
+  for (auto [GV, NewInit] : GlobalArraysToUpgrade)
     GV->setInitializer(NewInit);
+
   M.addModuleFlag(Module::Error, "ptrauth-init-fini", 1);
   if (UseAddressDisc.value())
     M.addModuleFlag(Module::Error, "ptrauth-init-fini-address-discriminator",

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -6378,16 +6378,27 @@ void llvm::UpgradeARCRuntime(Module &M) {
     UpgradeToIntrinsic(I.first, I.second);
 }
 
-// Upgrade from storing `ptrauth` constants in `@llvm.global_(ctors|dtors)`
-// arrays to configuring signing of pointers to *structors via module flags.
+// Upgrade the way signing of pointers to init/fini functions is described.
 //
-// Only perform the upgrade if all elements of *both* arrays agree on a common
-// signing schema.
+// Originally, the `@llvm.global_(ctors|dtors)` arrays contained `ptrauth`
+// constants, if signing was requested. After the upgrade, these arrays contain
+// plain function pointers and the desired signing schema is described via a
+// pair of module flags.
+//
+// Note that the upgrade is only performed if all elements of *both* arrays
+// agree on a common signing schema.
 static bool upgradePtrauthInitFiniArrays(Module &M) {
-  // Either "not decided yet" or whether we should request address diversity
-  // in addition to the basic constant diversity.
-  // There is no value representing "decided not to sign", as this results
-  // in immediate return from upgradePtrauthInitFiniArrays.
+  // As we cannot always decide whether the particular module should have
+  // ptrauth-init-fini flags, we have to treat absent flags as having zero
+  // values for compatibility reasons. Thus, upgradePtrauthInitFiniArrays
+  // returns as soon as it spots any non-signed init/fini pointer: either we
+  // should request non-signed pointers (safe to omit both flags) or there is
+  // no common schema (and thus we do not modify anything).
+  //
+  // UseAddressDisc's value either represents "not decided yet" state (nullopt)
+  // or whether we should request address diversity in addition to the basic
+  // constant diversity. There is no value representing "decided not to sign"
+  // for the reasons explained above.
   std::optional<bool> UseAddressDisc;
 
   // Do not attempt upgrading if the new module flags already exist.
@@ -6469,9 +6480,8 @@ static bool upgradePtrauthInitFiniArrays(Module &M) {
     GV->setInitializer(NewInit);
 
   M.addModuleFlag(Module::Error, "ptrauth-init-fini", 1);
-  if (UseAddressDisc.value())
-    M.addModuleFlag(Module::Error, "ptrauth-init-fini-address-discrimination",
-                    1);
+  M.addModuleFlag(Module::Error, "ptrauth-init-fini-address-discrimination",
+                  *UseAddressDisc);
 
   return true;
 }

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -6395,7 +6395,7 @@ static bool upgradePtrauthInitFiniArrays(Module &M) {
     for (const MDNode *Flag : ModFlags->operands()) {
       std::optional<StringRef> Name = getModuleFlagNameSafely(*Flag);
       if (Name && (*Name == "ptrauth-init-fini" ||
-                   *Name == "ptrauth-init-fini-address-discriminator"))
+                   *Name == "ptrauth-init-fini-address-discrimination"))
         return false;
     }
   }
@@ -6470,7 +6470,7 @@ static bool upgradePtrauthInitFiniArrays(Module &M) {
 
   M.addModuleFlag(Module::Error, "ptrauth-init-fini", 1);
   if (UseAddressDisc.value())
-    M.addModuleFlag(Module::Error, "ptrauth-init-fini-address-discriminator",
+    M.addModuleFlag(Module::Error, "ptrauth-init-fini-address-discrimination",
                     1);
 
   return true;

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -6412,8 +6412,8 @@ static bool upgradePtrauthInitFiniArrays(Module &M) {
   }
 
   auto UpgradeSinglePointer = [&UseAddressDisc](Constant *CV) -> Constant * {
-    const unsigned ExpectedConstDisc = 0xD9D4;
-    const unsigned ExpectedAddressMarker = 1;
+    constexpr unsigned ExpectedConstDisc = 0xD9D4;
+    constexpr unsigned ExpectedAddressMarker = 1;
 
     auto *CPA = dyn_cast<ConstantPtrAuth>(CV);
     if (!CPA || !CPA->getDiscriminator()->equalsInt(ExpectedConstDisc))
@@ -6444,7 +6444,7 @@ static bool upgradePtrauthInitFiniArrays(Module &M) {
       continue; // Skip, but it is okay to upgrade the other variable.
 
     auto *OldStructorsArray = dyn_cast<ConstantArray>(GV->getInitializer());
-    if (!OldStructorsArray)
+    if (!OldStructorsArray || OldStructorsArray->getNumOperands() == 0)
       return false;
 
     std::vector<Constant *> NewStructors;
@@ -6469,7 +6469,7 @@ static bool upgradePtrauthInitFiniArrays(Module &M) {
 
     Constant *NewInit =
         ConstantArray::get(OldStructorsArray->getType(), NewStructors);
-    GlobalArraysToUpgrade.push_back({GV, NewInit});
+    GlobalArraysToUpgrade.emplace_back(GV, NewInit);
   }
 
   if (GlobalArraysToUpgrade.empty())

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -6372,12 +6372,109 @@ void llvm::UpgradeARCRuntime(Module &M) {
     UpgradeToIntrinsic(I.first, I.second);
 }
 
+// Upgrade from wrapping each pointer stored in the @llvm.global_(ctors|dtors)
+// with ptrauth constant expression to storing plain pointers in these arrays
+// and requesting the particular signing schema globally via module flags.
+//
+// Only perform the upgrade if all elements of *both* arrays agree on a common
+// signing schema. The processing of the array is *not* stopped on the first
+// null function pointer.
+static bool upgradePtrauthInitFiniArrays(Module &M) {
+  // Either "not decided yet" or whether we should request address diversity
+  // in addition to the basic constant diversity.
+  // There is no value representing "decided not to sign", as this results
+  // in immediate return from upgradePtrauthInitFiniArrays.
+  std::optional<bool> UseAddressDisc;
+
+  // Do not attempt upgrading if the new module flags already exist.
+  if (const NamedMDNode *ModFlags = M.getModuleFlagsMetadata()) {
+    for (const MDNode *Flag : ModFlags->operands()) {
+      if (Flag->getNumOperands() != 3)
+        continue;
+      const MDString *ID = dyn_cast_or_null<MDString>(Flag->getOperand(1));
+      if (ID && (ID->getString() == "ptrauth-init-fini" ||
+                 ID->getString() == "ptrauth-init-fini-address-discriminator"))
+        return false;
+    }
+  }
+
+  auto UpgradeSinglePointer = [&UseAddressDisc](Constant *CV) -> Constant * {
+    const unsigned ExpectedConstDisc = 0xD9D4;
+    const unsigned ExpectedAddressMarker = 1;
+
+    auto *CPA = dyn_cast<ConstantPtrAuth>(CV);
+    if (!CPA || !CPA->getDiscriminator()->equalsInt(ExpectedConstDisc))
+      return nullptr; // Nothing to upgrade or unknown pattern found.
+
+    bool HasAddressDisc;
+    if (!CPA->hasAddressDiscriminator())
+      HasAddressDisc = false;
+    else if (CPA->hasSpecialAddressDiscriminator(ExpectedAddressMarker))
+      HasAddressDisc = true;
+    else
+      return nullptr; // Unknown pattern.
+
+    if (UseAddressDisc && *UseAddressDisc != HasAddressDisc)
+      return nullptr; // Disagreement with the decided mode.
+
+    UseAddressDisc = HasAddressDisc;
+    return CPA->getPointer();
+  };
+
+  SmallVector<std::pair<GlobalVariable *, Constant *>> PendingUpgrades;
+  for (const char *Name : {"llvm.global_ctors", "llvm.global_dtors"}) {
+    auto *GV = dyn_cast_if_present<GlobalVariable>(M.getNamedValue(Name));
+    if (!GV || !GV->hasInitializer())
+      continue; // Skip, but it is okay to upgrade the other variable.
+
+    auto *Init = dyn_cast<ConstantArray>(GV->getInitializer());
+    if (!Init)
+      return false;
+
+    std::vector<Constant *> NewStructors;
+    NewStructors.reserve(Init->getNumOperands());
+    for (Use &U : Init->operands()) {
+      auto *Structor = dyn_cast<ConstantStruct>(U.get());
+      if (!Structor || Structor->getNumOperands() != 3)
+        return false;
+
+      Constant *Prio = Structor->getOperand(0);
+      Constant *Func = UpgradeSinglePointer(Structor->getOperand(1));
+      Constant *Arg = Structor->getOperand(2);
+      if (!Func)
+        return false;
+
+      NewStructors.push_back(
+          ConstantStruct::get(Structor->getType(), {Prio, Func, Arg}));
+    }
+
+    Constant *NewInit = ConstantArray::get(Init->getType(), NewStructors);
+    PendingUpgrades.push_back({GV, NewInit});
+  }
+
+  if (PendingUpgrades.empty())
+    return false;
+  assert(UseAddressDisc.has_value());
+
+  for (auto [GV, NewInit] : PendingUpgrades)
+    GV->setInitializer(NewInit);
+  M.addModuleFlag(Module::Error, "ptrauth-init-fini", 1);
+  if (UseAddressDisc.value())
+    M.addModuleFlag(Module::Error, "ptrauth-init-fini-address-discriminator",
+                    1);
+
+  return true;
+}
+
 bool llvm::UpgradeModuleFlags(Module &M) {
+  bool Changed = false;
+  Changed |= upgradePtrauthInitFiniArrays(M);
+
   NamedMDNode *ModFlags = M.getModuleFlagsMetadata();
   if (!ModFlags)
-    return false;
+    return Changed;
 
-  bool HasObjCFlag = false, HasClassProperties = false, Changed = false;
+  bool HasObjCFlag = false, HasClassProperties = false;
   bool HasSwiftVersionFlag = false;
   uint8_t SwiftMajorVersion, SwiftMinorVersion;
   uint32_t SwiftABIVersion;

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -910,6 +910,19 @@ void Verifier::visitGlobalVariable(const GlobalVariable &GV) {
       Check(ETy->isPointerTy(), "wrong type for intrinsic global variable",
             &GV);
     }
+
+    auto *Init = GV.hasInitializer()
+                     ? dyn_cast<ConstantArray>(GV.getInitializer())
+                     : nullptr;
+    if (Init) {
+      for (const Use &U : Init->operands()) {
+        auto *Structor = dyn_cast<ConstantStruct>(U);
+        if (!Structor || Structor->getNumOperands() != 3)
+          continue;
+        Check(!isa<ConstantPtrAuth>(Structor->getOperand(1)),
+              "signing of ctors/dtors should be requested via module flags");
+      }
+    }
   }
 
   if (GV.hasName() && (GV.getName() == "llvm.used" ||
@@ -1961,26 +1974,49 @@ void Verifier::visitModuleFlags() {
   // Scan each flag, and track the flags and requirements.
   DenseMap<const MDString*, const MDNode*> SeenIDs;
   SmallVector<const MDNode*, 16> Requirements;
-  uint64_t PAuthABIPlatform = -1;
-  uint64_t PAuthABIVersion = -1;
+  std::optional<uint64_t> PAuthABIPlatform;
+  std::optional<uint64_t> PAuthABIVersion;
+  std::optional<uint64_t> HasPtrauthInitFini;
+  std::optional<uint64_t> HasPtrauthInitFiniAddr;
+
   for (const MDNode *MDN : Flags->operands()) {
     visitModuleFlag(MDN, SeenIDs, Requirements);
     if (MDN->getNumOperands() != 3)
       continue;
+
     if (const auto *FlagName = dyn_cast_or_null<MDString>(MDN->getOperand(1))) {
-      if (FlagName->getString() == "aarch64-elf-pauthabi-platform") {
-        if (const auto *PAP =
+      auto GetFlagNamed = [&](StringRef Name) -> std::optional<uint64_t> {
+        if (FlagName->getString() != Name)
+          return std::nullopt;
+        if (const auto *FlagValue =
                 mdconst::dyn_extract_or_null<ConstantInt>(MDN->getOperand(2)))
-          PAuthABIPlatform = PAP->getZExtValue();
-      } else if (FlagName->getString() == "aarch64-elf-pauthabi-version") {
-        if (const auto *PAV =
-                mdconst::dyn_extract_or_null<ConstantInt>(MDN->getOperand(2)))
-          PAuthABIVersion = PAV->getZExtValue();
-      }
+          return FlagValue->getZExtValue();
+
+        CheckFailed(Name + ": module flag expects integer value");
+        return std::nullopt;
+      };
+
+      if (auto Value = GetFlagNamed("aarch64-elf-pauthabi-platform"))
+        PAuthABIPlatform = *Value;
+      else if (auto Value = GetFlagNamed("aarch64-elf-pauthabi-version"))
+        PAuthABIVersion = *Value;
+      else if (auto Value = GetFlagNamed("ptrauth-init-fini"))
+        HasPtrauthInitFini = *Value;
+      else if (auto Value =
+                   GetFlagNamed("ptrauth-init-fini-address-discrimination"))
+        HasPtrauthInitFiniAddr = *Value;
     }
   }
 
-  if ((PAuthABIPlatform == uint64_t(-1)) != (PAuthABIVersion == uint64_t(-1)))
+  Check(!HasPtrauthInitFini || HasPtrauthInitFini.value() == 1,
+        "ptrauth-init-fini must be set to 1 or unset");
+  Check(!HasPtrauthInitFiniAddr || HasPtrauthInitFiniAddr.value() == 1,
+        "ptrauth-init-fini-address-discrimination must be set to 1 or unset");
+  if (HasPtrauthInitFiniAddr)
+    Check(HasPtrauthInitFini, "ptrauth-init-fini-address-discrimination module "
+                              "flag requires ptrauth-init-fini");
+
+  if (PAuthABIPlatform.has_value() != PAuthABIVersion.has_value())
     CheckFailed("either both or no 'aarch64-elf-pauthabi-platform' and "
                 "'aarch64-elf-pauthabi-version' module flags must be present");
 

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -1835,10 +1835,13 @@ void Verifier::visitModuleFlags() {
   // Scan each flag, and track the flags and requirements.
   DenseMap<const MDString*, const MDNode*> SeenIDs;
   SmallVector<const MDNode*, 16> Requirements;
+
+  // Either both aarch64-elf-pauthabi-* flags should be set or none at all.
   std::optional<uint64_t> PAuthABIPlatform;
   std::optional<uint64_t> PAuthABIVersion;
-  std::optional<uint64_t> HasPtrauthInitFini;
-  std::optional<uint64_t> HasPtrauthInitFiniAddr;
+  // Signing of init/fini pointers: address diversity implies basic signing.
+  uint64_t HasPtrauthInitFini = 0;
+  uint64_t HasPtrauthInitFiniAddr = 0;
 
   for (const MDNode *MDN : Flags->operands()) {
     visitModuleFlag(MDN, SeenIDs, Requirements);
@@ -1869,10 +1872,10 @@ void Verifier::visitModuleFlags() {
     }
   }
 
-  Check(!HasPtrauthInitFini || HasPtrauthInitFini.value() == 1,
-        "ptrauth-init-fini must be set to 1 or unset");
-  Check(!HasPtrauthInitFiniAddr || HasPtrauthInitFiniAddr.value() == 1,
-        "ptrauth-init-fini-address-discrimination must be set to 1 or unset");
+  Check(llvm::is_contained({0u, 1u}, HasPtrauthInitFini),
+        "ptrauth-init-fini must be 0 or 1");
+  Check(llvm::is_contained({0u, 1u}, HasPtrauthInitFiniAddr),
+        "ptrauth-init-fini-address-discrimination must be 0 or 1, if set");
   if (HasPtrauthInitFiniAddr)
     Check(HasPtrauthInitFini, "ptrauth-init-fini-address-discrimination module "
                               "flag requires ptrauth-init-fini");

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -749,6 +749,19 @@ void Verifier::visitGlobalVariable(const GlobalVariable &GV) {
       Check(ETy->isPointerTy(), "wrong type for intrinsic global variable",
             &GV);
     }
+
+    auto *Init = GV.hasInitializer()
+                     ? dyn_cast<ConstantArray>(GV.getInitializer())
+                     : nullptr;
+    if (Init) {
+      for (const Use &U : Init->operands()) {
+        auto *Structor = dyn_cast<ConstantStruct>(U);
+        if (!Structor || Structor->getNumOperands() != 3)
+          continue;
+        Check(!isa<ConstantPtrAuth>(Structor->getOperand(1)),
+              "signing of ctors/dtors should be requested via module flags");
+      }
+    }
   }
 
   if (GV.hasName() && (GV.getName() == "llvm.used" ||
@@ -1822,26 +1835,49 @@ void Verifier::visitModuleFlags() {
   // Scan each flag, and track the flags and requirements.
   DenseMap<const MDString*, const MDNode*> SeenIDs;
   SmallVector<const MDNode*, 16> Requirements;
-  uint64_t PAuthABIPlatform = -1;
-  uint64_t PAuthABIVersion = -1;
+  std::optional<uint64_t> PAuthABIPlatform;
+  std::optional<uint64_t> PAuthABIVersion;
+  std::optional<uint64_t> HasPtrauthInitFini;
+  std::optional<uint64_t> HasPtrauthInitFiniAddr;
+
   for (const MDNode *MDN : Flags->operands()) {
     visitModuleFlag(MDN, SeenIDs, Requirements);
     if (MDN->getNumOperands() != 3)
       continue;
+
     if (const auto *FlagName = dyn_cast_or_null<MDString>(MDN->getOperand(1))) {
-      if (FlagName->getString() == "aarch64-elf-pauthabi-platform") {
-        if (const auto *PAP =
+      auto GetFlagNamed = [&](StringRef Name) -> std::optional<uint64_t> {
+        if (FlagName->getString() != Name)
+          return std::nullopt;
+        if (const auto *FlagValue =
                 mdconst::dyn_extract_or_null<ConstantInt>(MDN->getOperand(2)))
-          PAuthABIPlatform = PAP->getZExtValue();
-      } else if (FlagName->getString() == "aarch64-elf-pauthabi-version") {
-        if (const auto *PAV =
-                mdconst::dyn_extract_or_null<ConstantInt>(MDN->getOperand(2)))
-          PAuthABIVersion = PAV->getZExtValue();
-      }
+          return FlagValue->getZExtValue();
+
+        CheckFailed(Name + ": module flag expects integer value");
+        return std::nullopt;
+      };
+
+      if (auto Value = GetFlagNamed("aarch64-elf-pauthabi-platform"))
+        PAuthABIPlatform = *Value;
+      else if (auto Value = GetFlagNamed("aarch64-elf-pauthabi-version"))
+        PAuthABIVersion = *Value;
+      else if (auto Value = GetFlagNamed("ptrauth-init-fini"))
+        HasPtrauthInitFini = *Value;
+      else if (auto Value =
+                   GetFlagNamed("ptrauth-init-fini-address-discrimination"))
+        HasPtrauthInitFiniAddr = *Value;
     }
   }
 
-  if ((PAuthABIPlatform == uint64_t(-1)) != (PAuthABIVersion == uint64_t(-1)))
+  Check(!HasPtrauthInitFini || HasPtrauthInitFini.value() == 1,
+        "ptrauth-init-fini must be set to 1 or unset");
+  Check(!HasPtrauthInitFiniAddr || HasPtrauthInitFiniAddr.value() == 1,
+        "ptrauth-init-fini-address-discrimination must be set to 1 or unset");
+  if (HasPtrauthInitFiniAddr)
+    Check(HasPtrauthInitFini, "ptrauth-init-fini-address-discrimination module "
+                              "flag requires ptrauth-init-fini");
+
+  if (PAuthABIPlatform.has_value() != PAuthABIVersion.has_value())
     CheckFailed("either both or no 'aarch64-elf-pauthabi-platform' and "
                 "'aarch64-elf-pauthabi-version' module flags must be present");
 

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -98,6 +98,8 @@ class AArch64AsmPrinter : public AsmPrinter {
   FaultMaps FM;
   const AArch64Subtarget *STI;
   bool ShouldEmitWeakSwiftAsyncExtendedFramePointerFlags = false;
+  bool PtrauthInitFini = false;
+  bool PtrauthInitFiniAddressDisc = false;
 #ifndef NDEBUG
   unsigned InstsEmitted;
 #endif
@@ -404,6 +406,11 @@ void AArch64AsmPrinter::emitStartOfAsmFile(Module &M) {
     if (M.getModuleFlag("import-call-optimization"))
       EnableImportCallOptimization = true;
   }
+
+  if (M.getModuleFlag("ptrauth-init-fini"))
+    PtrauthInitFini = true;
+  if (M.getModuleFlag("ptrauth-init-fini-address-discrimination"))
+    PtrauthInitFiniAddressDisc = true;
 
   if (!TT.isOSBinFormatELF())
     return;
@@ -1464,18 +1471,31 @@ void AArch64AsmPrinter::emitFunctionEntryLabel() {
 
 void AArch64AsmPrinter::emitXXStructor(const DataLayout &DL,
                                        const Constant *CV) {
-  if (const auto *CPA = dyn_cast<ConstantPtrAuth>(CV))
-    if (CPA->hasAddressDiscriminator() &&
-        !CPA->hasSpecialAddressDiscriminator(
-            ConstantPtrAuth::AddrDiscriminator_CtorsDtors))
-      report_fatal_error(
-          "unexpected address discrimination value for ctors/dtors entry, only "
-          "'ptr inttoptr (i64 1 to ptr)' is allowed");
-  // If we have signed pointers in xxstructors list, they'll be lowered to @AUTH
-  // MCExpr's via AArch64AsmPrinter::lowerConstantPtrAuth. It does not look at
-  // actual address discrimination value and only checks
-  // hasAddressDiscriminator(), so it's OK to leave special address
-  // discrimination value here.
+  LLVMContext &C = CV->getContext();
+  assert(!isa<ConstantPtrAuth>(CV) &&
+         "ctors/dtors are to be signed by asm printer");
+
+  if (PtrauthInitFini) {
+    IntegerType *Int32Ty = IntegerType::get(C, 32);
+    IntegerType *Int64Ty = IntegerType::get(C, 64);
+    PointerType *PtrTy = PointerType::get(C, 0);
+
+    ConstantInt *Key = ConstantInt::get(Int32Ty, AArch64PAuth::InitFiniKey);
+    ConstantInt *IntDisc = ConstantInt::get(
+        Int64Ty, AArch64PAuth::InitFiniPointerConstantDiscriminator);
+    Constant *Null = ConstantPointerNull::get(PtrTy);
+    Constant *AddressDisc = Null;
+    if (PtrauthInitFiniAddressDisc) {
+      uint64_t Marker = ConstantPtrAuth::AddrDiscriminator_CtorsDtors;
+      AddressDisc =
+          ConstantExpr::getIntToPtr(ConstantInt::get(Int64Ty, Marker), PtrTy);
+    }
+
+    CV = ConstantPtrAuth::get(const_cast<Constant *>(CV), Key, IntDisc,
+                              AddressDisc, /*DeactivationSymbol=*/Null);
+  }
+
+  // Signed pointers will be lowered by AArch64AsmPrinter::lowerConstantPtrAuth.
   AsmPrinter::emitXXStructor(DL, CV);
 }
 

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -400,6 +400,17 @@ private:
 
 } // end anonymous namespace
 
+// Get boolean module flag (0 or 1), treating absent flag as having value 0.
+static bool getOptionalBooleanModuleFlag(Module &M, StringRef Name) {
+  Metadata *Flag = M.getModuleFlag(Name);
+  if (!Flag)
+    return false;
+
+  uint64_t Value = mdconst::extract<ConstantInt>(Flag)->getZExtValue();
+  assert((Value == 0 || Value == 1) && "Boolean flag is expected, if present");
+  return Value;
+}
+
 void AArch64AsmPrinter::emitStartOfAsmFile(Module &M) {
   const Triple &TT = TM.getTargetTriple();
 
@@ -411,10 +422,9 @@ void AArch64AsmPrinter::emitStartOfAsmFile(Module &M) {
       EnableImportCallOptimization = true;
   }
 
-  if (M.getModuleFlag("ptrauth-init-fini"))
-    PtrauthInitFini = true;
-  if (M.getModuleFlag("ptrauth-init-fini-address-discrimination"))
-    PtrauthInitFiniAddressDisc = true;
+  PtrauthInitFini = getOptionalBooleanModuleFlag(M, "ptrauth-init-fini");
+  PtrauthInitFiniAddressDisc = getOptionalBooleanModuleFlag(
+      M, "ptrauth-init-fini-address-discrimination");
 
   if (!TT.isOSBinFormatELF())
     return;

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -98,6 +98,8 @@ class AArch64AsmPrinter : public AsmPrinter {
   FaultMaps FM;
   const AArch64Subtarget *STI;
   bool ShouldEmitWeakSwiftAsyncExtendedFramePointerFlags = false;
+  bool PtrauthInitFini = false;
+  bool PtrauthInitFiniAddressDisc = false;
 #ifndef NDEBUG
   unsigned InstsEmitted;
 #endif
@@ -408,6 +410,11 @@ void AArch64AsmPrinter::emitStartOfAsmFile(Module &M) {
     if (M.getModuleFlag("import-call-optimization"))
       EnableImportCallOptimization = true;
   }
+
+  if (M.getModuleFlag("ptrauth-init-fini"))
+    PtrauthInitFini = true;
+  if (M.getModuleFlag("ptrauth-init-fini-address-discrimination"))
+    PtrauthInitFiniAddressDisc = true;
 
   if (!TT.isOSBinFormatELF())
     return;
@@ -1475,18 +1482,31 @@ void AArch64AsmPrinter::emitFunctionEntryLabel() {
 
 void AArch64AsmPrinter::emitXXStructor(const DataLayout &DL,
                                        const Constant *CV) {
-  if (const auto *CPA = dyn_cast<ConstantPtrAuth>(CV))
-    if (CPA->hasAddressDiscriminator() &&
-        !CPA->hasSpecialAddressDiscriminator(
-            ConstantPtrAuth::AddrDiscriminator_CtorsDtors))
-      report_fatal_error(
-          "unexpected address discrimination value for ctors/dtors entry, only "
-          "'ptr inttoptr (i64 1 to ptr)' is allowed");
-  // If we have signed pointers in xxstructors list, they'll be lowered to @AUTH
-  // MCExpr's via AArch64AsmPrinter::lowerConstantPtrAuth. It does not look at
-  // actual address discrimination value and only checks
-  // hasAddressDiscriminator(), so it's OK to leave special address
-  // discrimination value here.
+  LLVMContext &C = CV->getContext();
+  assert(!isa<ConstantPtrAuth>(CV) &&
+         "ctors/dtors are to be signed by asm printer");
+
+  if (PtrauthInitFini) {
+    IntegerType *Int32Ty = IntegerType::get(C, 32);
+    IntegerType *Int64Ty = IntegerType::get(C, 64);
+    PointerType *PtrTy = PointerType::get(C, 0);
+
+    ConstantInt *Key = ConstantInt::get(Int32Ty, AArch64PAuth::InitFiniKey);
+    ConstantInt *IntDisc = ConstantInt::get(
+        Int64Ty, AArch64PAuth::InitFiniPointerConstantDiscriminator);
+    Constant *Null = ConstantPointerNull::get(PtrTy);
+    Constant *AddressDisc = Null;
+    if (PtrauthInitFiniAddressDisc) {
+      uint64_t Marker = ConstantPtrAuth::AddrDiscriminator_CtorsDtors;
+      AddressDisc =
+          ConstantExpr::getIntToPtr(ConstantInt::get(Int64Ty, Marker), PtrTy);
+    }
+
+    CV = ConstantPtrAuth::get(const_cast<Constant *>(CV), Key, IntDisc,
+                              AddressDisc, /*DeactivationSymbol=*/Null);
+  }
+
+  // Signed pointers will be lowered by AArch64AsmPrinter::lowerConstantPtrAuth.
   AsmPrinter::emitXXStructor(DL, CV);
 }
 

--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.h
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.h
@@ -9,11 +9,17 @@
 #ifndef LLVM_LIB_TARGET_AARCH64_AARCH64POINTERAUTH_H
 #define LLVM_LIB_TARGET_AARCH64_AARCH64POINTERAUTH_H
 
-#include "llvm/CodeGen/MachineBasicBlock.h"
-#include "llvm/CodeGen/Register.h"
+#include "Utils/AArch64BaseInfo.h"
 
 namespace llvm {
 namespace AArch64PAuth {
+
+/// PAuth key to be used with function pointers in .init_array and .fini_array.
+constexpr AArch64PACKey::ID InitFiniKey = AArch64PACKey::IA;
+
+/// Constant discriminator to be used with function pointers in .init_array and
+/// .fini_array. The value is ptrauth_string_discriminator("init_fini")
+constexpr unsigned InitFiniPointerConstantDiscriminator = 0xD9D4;
 
 /// Variants of check performed on an authenticated pointer.
 ///

--- a/llvm/test/CodeGen/AArch64/ptrauth-init-fini-autoupgrade.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-init-fini-autoupgrade.ll
@@ -1,0 +1,143 @@
+; RUN: rm -rf %t && split-file %s %t && cd %t
+
+;--- nodisc.ll
+
+; RUN: opt -S < nodisc.ll | FileCheck %s --check-prefix=NODISC
+
+@llvm.global_ctors = appending global [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo1, i32 0, i64 55764), ptr null }, { i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo2, i32 0, i64 55764), ptr null }]
+@llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar, i32 0, i64 55764), ptr null }]
+
+define void @foo1() {
+  ret void
+}
+
+define void @foo2() {
+  ret void
+}
+
+define void @bar() {
+  ret void
+}
+
+; NODISC: @llvm.global_ctors = appending global [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo1, ptr null }, { i32, ptr, ptr } { i32 65535, ptr @foo2, ptr null }]
+; NODISC: @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar, ptr null }]
+; NODISC: !llvm.module.flags = !{!0}
+; NODISC: !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
+
+;--- disc.ll
+
+; RUN: opt -S < disc.ll | FileCheck %s --check-prefix=DISC
+
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764, ptr inttoptr (i64 1 to ptr)), ptr null }]
+@llvm.global_dtors = appending global [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar1, i32 0, i64 55764, ptr inttoptr (i64 1 to ptr)), ptr null }, { i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar2, i32 0, i64 55764, ptr inttoptr (i64 1 to ptr)), ptr null }]
+
+define void @foo() {
+  ret void
+}
+
+define void @bar1() {
+  ret void
+}
+
+define void @bar2() {
+  ret void
+}
+
+; DISC: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
+; DISC: @llvm.global_dtors = appending global [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar1, ptr null }, { i32, ptr, ptr } { i32 65535, ptr @bar2, ptr null }]
+; DISC: !llvm.module.flags = !{!0, !1}
+; DISC: !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
+; DISC: !1 = !{i32 1, !"ptrauth-init-fini-address-discriminator", i32 1}
+
+;--- err1.ll
+
+; RUN: not opt -S < err1.ll 2>&1 | FileCheck %s --check-prefix=ERR1
+
+; ERR1: signing of ctors/dtors should be requested via module flags
+
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764, ptr inttoptr (i64 2 to ptr)), ptr null }]
+
+define void @foo() {
+  ret void
+}
+
+;--- err2.ll
+
+; RUN: not opt -S < err2.ll 2>&1 | FileCheck %s --check-prefix=ERR2
+
+; ERR2: signing of ctors/dtors should be requested via module flags
+
+@g = external global ptr
+@llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar, i32 0, i64 55764, ptr @g), ptr null }]
+
+define void @bar() {
+  ret void
+}
+
+;--- disagreement1.ll
+
+; RUN: not opt -S < disagreement1.ll 2>&1 | FileCheck %s --check-prefix=DISAGREEMENT1
+
+; DISAGREEMENT1: signing of ctors/dtors should be requested via module flags
+
+@llvm.global_ctors = appending global [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764), ptr null }, { i32, ptr, ptr } { i32 65535, ptr @bar, ptr null }]
+
+define void @foo() {
+  ret void
+}
+
+define void @bar() {
+  ret void
+}
+
+;--- disagreement2.ll
+
+; RUN: not opt -S < disagreement2.ll 2>&1 | FileCheck %s --check-prefix=DISAGREEMENT2
+
+; DISAGREEMENT2: signing of ctors/dtors should be requested via module flags
+
+@llvm.global_ctors = appending global [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764), ptr null }, { i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar, i32 0, i64 55764, ptr inttoptr (i64 1 to ptr)), ptr null }]
+
+define void @foo() {
+  ret void
+}
+
+define void @bar() {
+  ret void
+}
+
+;--- disagreement3.ll
+
+; RUN: not opt -S < disagreement3.ll 2>&1 | FileCheck %s --check-prefix=DISAGREEMENT3
+
+; DISAGREEMENT3: signing of ctors/dtors should be requested via module flags
+
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764), ptr null }]
+@llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar, i32 0, i64 55764, ptr inttoptr (i64 1 to ptr)), ptr null }]
+
+define void @foo() {
+  ret void
+}
+
+define void @bar() {
+  ret void
+}
+
+;--- existing-flags.ll
+
+; RUN: not opt -S < existing-flags.ll 2>&1 | FileCheck %s --check-prefix=EXISTING-FLAGS
+
+; EXISTING-FLAGS: signing of ctors/dtors should be requested via module flags
+
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764), ptr null }]
+
+define void @foo() {
+  ret void
+}
+
+define void @bar() {
+  ret void
+}
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"ptrauth-init-fini", i32 1}

--- a/llvm/test/CodeGen/AArch64/ptrauth-init-fini-autoupgrade.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-init-fini-autoupgrade.ll
@@ -47,7 +47,7 @@ define void @bar2() {
 ; DISC: @llvm.global_dtors = appending global [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar1, ptr null }, { i32, ptr, ptr } { i32 65535, ptr @bar2, ptr null }]
 ; DISC: !llvm.module.flags = !{!0, !1}
 ; DISC: !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
-; DISC: !1 = !{i32 1, !"ptrauth-init-fini-address-discriminator", i32 1}
+; DISC: !1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 1}
 
 ;--- err1.ll
 

--- a/llvm/test/CodeGen/AArch64/ptrauth-init-fini-autoupgrade.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-init-fini-autoupgrade.ll
@@ -1,8 +1,8 @@
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 
-;--- nodisc.ll
+;--- const.ll
 
-; RUN: opt -S < nodisc.ll | FileCheck %s --check-prefix=NODISC
+; RUN: opt -S < const.ll | FileCheck %s --check-prefix=CONST
 
 @llvm.global_ctors = appending global [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo1, i32 0, i64 55764), ptr null }, { i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo2, i32 0, i64 55764), ptr null }]
 @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar, i32 0, i64 55764), ptr null }]
@@ -19,14 +19,15 @@ define void @bar() {
   ret void
 }
 
-; NODISC: @llvm.global_ctors = appending global [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo1, ptr null }, { i32, ptr, ptr } { i32 65535, ptr @foo2, ptr null }]
-; NODISC: @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar, ptr null }]
-; NODISC: !llvm.module.flags = !{!0}
-; NODISC: !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
+; CONST: @llvm.global_ctors = appending global [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo1, ptr null }, { i32, ptr, ptr } { i32 65535, ptr @foo2, ptr null }]
+; CONST: @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar, ptr null }]
+; CONST: !llvm.module.flags = !{!0, !1}
+; CONST: !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
+; CONST: !1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
 
-;--- disc.ll
+;--- blended.ll
 
-; RUN: opt -S < disc.ll | FileCheck %s --check-prefix=DISC
+; RUN: opt -S < blended.ll | FileCheck %s --check-prefix=BLENDED
 
 @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764, ptr inttoptr (i64 1 to ptr)), ptr null }]
 @llvm.global_dtors = appending global [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar1, i32 0, i64 55764, ptr inttoptr (i64 1 to ptr)), ptr null }, { i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar2, i32 0, i64 55764, ptr inttoptr (i64 1 to ptr)), ptr null }]
@@ -43,11 +44,11 @@ define void @bar2() {
   ret void
 }
 
-; DISC: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
-; DISC: @llvm.global_dtors = appending global [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar1, ptr null }, { i32, ptr, ptr } { i32 65535, ptr @bar2, ptr null }]
-; DISC: !llvm.module.flags = !{!0, !1}
-; DISC: !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
-; DISC: !1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 1}
+; BLENDED: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
+; BLENDED: @llvm.global_dtors = appending global [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar1, ptr null }, { i32, ptr, ptr } { i32 65535, ptr @bar2, ptr null }]
+; BLENDED: !llvm.module.flags = !{!0, !1}
+; BLENDED: !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
+; BLENDED: !1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 1}
 
 ;--- err1.ll
 
@@ -123,11 +124,11 @@ define void @bar() {
   ret void
 }
 
-;--- existing-flags.ll
+;--- existing-flags-1.ll
 
-; RUN: not opt -S < existing-flags.ll 2>&1 | FileCheck %s --check-prefix=EXISTING-FLAGS
+; RUN: not opt -S < existing-flags-1.ll 2>&1 | FileCheck %s --check-prefix=EXISTING-FLAGS-1
 
-; EXISTING-FLAGS: signing of ctors/dtors should be requested via module flags
+; EXISTING-FLAGS-1: signing of ctors/dtors should be requested via module flags
 
 @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764), ptr null }]
 
@@ -141,3 +142,22 @@ define void @bar() {
 
 !llvm.module.flags = !{!0}
 !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
+
+;--- existing-flags-2.ll
+
+; RUN: not opt -S < existing-flags-2.ll 2>&1 | FileCheck %s --check-prefix=EXISTING-FLAGS-2
+
+; EXISTING-FLAGS-2: signing of ctors/dtors should be requested via module flags
+
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764), ptr null }]
+
+define void @foo() {
+  ret void
+}
+
+define void @bar() {
+  ret void
+}
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}

--- a/llvm/test/CodeGen/AArch64/ptrauth-init-fini.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-init-fini.ll
@@ -27,8 +27,8 @@
 ;;                              ^^^^ 0xD9D4: constant discriminator = 55764
 ;;                                    ^^ 0x80: bits 61..60 key = IA; bit 63 addr disc = false
 
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764), ptr null }]
-@llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar, i32 0, i64 55764), ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
+@llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar, ptr null }]
 
 define void @foo() {
   ret void
@@ -37,6 +37,9 @@ define void @foo() {
 define void @bar() {
   ret void
 }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"ptrauth-init-fini", i32 1}
 
 ;--- disc.ll
 
@@ -65,8 +68,8 @@ define void @bar() {
 ;;                                   ^^^^ 0xD9D4: constant discriminator = 55764
 ;;                                         ^^ 0x80: bits 61..60 key = IA; bit 63 addr disc = true
 
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764, ptr inttoptr (i64 1 to ptr)), ptr null }]
-@llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar, i32 0, i64 55764, ptr inttoptr (i64 1 to ptr)), ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
+@llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar, ptr null }]
 
 define void @foo() {
   ret void
@@ -75,30 +78,86 @@ define void @foo() {
 define void @bar() {
   ret void
 }
+
+!llvm.module.flags = !{!0, !1}
+!0 = !{i32 1, !"ptrauth-init-fini", i32 1}
+!1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 1}
 
 ;--- err1.ll
 
-; RUN: not --crash llc -mtriple aarch64-elf -mattr=+pauth -filetype=asm -o - err1.ll 2>&1 | \
-; RUN:   FileCheck %s --check-prefix=ERR1
+; RUN: not opt -S < err1.ll 2>&1 | FileCheck %s --check-prefix=ERR1
 
-; ERR1: LLVM ERROR: unexpected address discrimination value for ctors/dtors entry, only 'ptr inttoptr (i64 1 to ptr)' is allowed
+; ERR1: ptrauth-init-fini must be set to 1 or unset
 
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764, ptr inttoptr (i64 2 to ptr)), ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
 
 define void @foo() {
   ret void
 }
 
+!llvm.module.flags = !{!0, !1}
+!0 = !{i32 1, !"ptrauth-init-fini", i32 0}
+!1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 1}
+
 ;--- err2.ll
 
-; RUN: not --crash llc -mtriple aarch64-elf -mattr=+pauth -filetype=asm -o - err2.ll 2>&1 | \
-; RUN:   FileCheck %s --check-prefix=ERR2
+; RUN: not opt -S < err2.ll 2>&1 | FileCheck %s --check-prefix=ERR2
 
-; ERR2: LLVM ERROR: unexpected address discrimination value for ctors/dtors entry, only 'ptr inttoptr (i64 1 to ptr)' is allowed
+; ERR2: ptrauth-init-fini-address-discrimination must be set to 1 or unset
 
-@g = external global ptr
-@llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @bar, i32 0, i64 55764, ptr @g), ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
 
-define void @bar() {
+define void @foo() {
   ret void
 }
+
+!llvm.module.flags = !{!0, !1}
+!0 = !{i32 1, !"ptrauth-init-fini", i32 1}
+!1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
+
+;--- err3.ll
+
+; RUN: not opt -S < err3.ll 2>&1 | FileCheck %s --check-prefix=ERR3
+
+; ERR3: ptrauth-init-fini: module flag expects integer value
+
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
+
+define void @foo() {
+  ret void
+}
+
+!llvm.module.flags = !{!0, !1}
+!0 = !{i32 1, !"ptrauth-init-fini", !"1"}
+!1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 1}
+
+;--- err4.ll
+
+; RUN: not opt -S < err4.ll 2>&1 | FileCheck %s --check-prefix=ERR4
+
+; ERR4: ptrauth-init-fini-address-discrimination: module flag expects integer value
+
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
+
+define void @foo() {
+  ret void
+}
+
+!llvm.module.flags = !{!0, !1}
+!0 = !{i32 1, !"ptrauth-init-fini", i32 1}
+!1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", !"1"}
+
+;--- err5.ll
+
+; RUN: not opt -S < err5.ll 2>&1 | FileCheck %s --check-prefix=ERR5
+
+; ERR5: ptrauth-init-fini-address-discrimination module flag requires ptrauth-init-fini
+
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
+
+define void @foo() {
+  ret void
+}
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 1}

--- a/llvm/test/CodeGen/AArch64/ptrauth-init-fini.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-init-fini.ll
@@ -1,31 +1,56 @@
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 
-;--- nodisc.ll
+;--- const-1.ll
 
-; RUN: llc -mtriple aarch64-elf -mattr=+pauth -filetype=asm -o - nodisc.ll | \
-; RUN:   FileCheck %s --check-prefix=ASM
-; RUN: llc -mtriple aarch64-elf -mattr=+pauth -filetype=obj -o - nodisc.ll | \
-; RUN:   llvm-readelf -r -x .init_array -x .fini_array - | FileCheck %s --check-prefix=OBJ
+; RUN: llc -mtriple aarch64-elf -mattr=+pauth -filetype=asm -o - const-1.ll | \
+; RUN:   FileCheck %s --check-prefix=ASM-CONST
+; RUN: llc -mtriple aarch64-elf -mattr=+pauth -filetype=obj -o - const-1.ll | \
+; RUN:   llvm-readelf -r -x .init_array -x .fini_array - | FileCheck %s --check-prefix=OBJ-CONST
 
-; ASM:      .section .init_array,"aw",@init_array
-; ASM-NEXT: .p2align 3, 0x0
-; ASM-NEXT: .xword   foo@AUTH(ia,55764)
-; ASM-NEXT: .section .fini_array,"aw",@fini_array
-; ASM-NEXT: .p2align 3, 0x0
-; ASM-NEXT: .xword   bar@AUTH(ia,55764)
+; ASM-CONST:      .section .init_array,"aw",@init_array
+; ASM-CONST-NEXT: .p2align 3, 0x0
+; ASM-CONST-NEXT: .xword   foo@AUTH(ia,55764)
+; ASM-CONST-NEXT: .section .fini_array,"aw",@fini_array
+; ASM-CONST-NEXT: .p2align 3, 0x0
+; ASM-CONST-NEXT: .xword   bar@AUTH(ia,55764)
 
-; OBJ:      Relocation section '.rela.init_array' at offset 0x[[#]] contains 1 entries:
-; OBJ-NEXT:     Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
-; OBJ-NEXT: 0000000000000000  0000000700000244 R_AARCH64_AUTH_ABS64   0000000000000000 foo + 0
-; OBJ:      Relocation section '.rela.fini_array' at offset 0x[[#]] contains 1 entries:
-; OBJ-NEXT:     Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
-; OBJ-NEXT: 0000000000000000  0000000800000244 R_AARCH64_AUTH_ABS64   0000000000000004 bar + 0
-; OBJ:      Hex dump of section '.init_array':
-; OBJ-NEXT: 0x00000000 00000000 d4d90000
-; OBJ:      Hex dump of section '.fini_array':
-; OBJ-NEXT: 0x00000000 00000000 d4d90000
+; OBJ-CONST:      Relocation section '.rela.init_array' at offset 0x[[#]] contains 1 entries:
+; OBJ-CONST-NEXT:     Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
+; OBJ-CONST-NEXT: 0000000000000000  0000000700000244 R_AARCH64_AUTH_ABS64   0000000000000000 foo + 0
+; OBJ-CONST:      Relocation section '.rela.fini_array' at offset 0x[[#]] contains 1 entries:
+; OBJ-CONST-NEXT:     Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
+; OBJ-CONST-NEXT: 0000000000000000  0000000800000244 R_AARCH64_AUTH_ABS64   0000000000000004 bar + 0
+; OBJ-CONST:      Hex dump of section '.init_array':
+; OBJ-CONST-NEXT: 0x00000000 00000000 d4d90000
+; OBJ-CONST:      Hex dump of section '.fini_array':
+; OBJ-CONST-NEXT: 0x00000000 00000000 d4d90000
 ;;                              ^^^^ 0xD9D4: constant discriminator = 55764
 ;;                                    ^^ 0x80: bits 61..60 key = IA; bit 63 addr disc = false
+
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
+@llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar, ptr null }]
+
+define void @foo() {
+  ret void
+}
+
+define void @bar() {
+  ret void
+}
+
+!llvm.module.flags = !{!0, !1}
+!0 = !{i32 1, !"ptrauth-init-fini", i32 1}
+!1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
+
+;--- const-2.ll
+
+; Use the same set of check lines as in const-1.ll, but check that absent flag
+; is treated as having zero value.
+
+; RUN: llc -mtriple aarch64-elf -mattr=+pauth -filetype=asm -o - const-2.ll | \
+; RUN:   FileCheck %s --check-prefix=ASM-CONST
+; RUN: llc -mtriple aarch64-elf -mattr=+pauth -filetype=obj -o - const-2.ll | \
+; RUN:   llvm-readelf -r -x .init_array -x .fini_array - | FileCheck %s --check-prefix=OBJ-CONST
 
 @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
 @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar, ptr null }]
@@ -41,30 +66,30 @@ define void @bar() {
 !llvm.module.flags = !{!0}
 !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
 
-;--- disc.ll
+;--- blended.ll
 
-; RUN: llc -mtriple aarch64-elf -mattr=+pauth -filetype=asm -o - disc.ll | \
-; RUN:   FileCheck %s --check-prefix=ASM-DISC
-; RUN: llc -mtriple aarch64-elf -mattr=+pauth -filetype=obj -o - disc.ll | \
-; RUN:   llvm-readelf -r -x .init_array -x .fini_array - | FileCheck %s --check-prefix=OBJ-DISC
+; RUN: llc -mtriple aarch64-elf -mattr=+pauth -filetype=asm -o - blended.ll | \
+; RUN:   FileCheck %s --check-prefix=ASM-BLENDED
+; RUN: llc -mtriple aarch64-elf -mattr=+pauth -filetype=obj -o - blended.ll | \
+; RUN:   llvm-readelf -r -x .init_array -x .fini_array - | FileCheck %s --check-prefix=OBJ-BLENDED
 
-; ASM-DISC:      .section .init_array,"aw",@init_array
-; ASM-DISC-NEXT: .p2align 3, 0x0
-; ASM-DISC-NEXT: .xword   foo@AUTH(ia,55764,addr)
-; ASM-DISC-NEXT: .section .fini_array,"aw",@fini_array
-; ASM-DISC-NEXT: .p2align 3, 0x0
-; ASM-DISC-NEXT: .xword   bar@AUTH(ia,55764,addr)
+; ASM-BLENDED:      .section .init_array,"aw",@init_array
+; ASM-BLENDED-NEXT: .p2align 3, 0x0
+; ASM-BLENDED-NEXT: .xword   foo@AUTH(ia,55764,addr)
+; ASM-BLENDED-NEXT: .section .fini_array,"aw",@fini_array
+; ASM-BLENDED-NEXT: .p2align 3, 0x0
+; ASM-BLENDED-NEXT: .xword   bar@AUTH(ia,55764,addr)
 
-; OBJ-DISC:      Relocation section '.rela.init_array' at offset 0x[[#]] contains 1 entries:
-; OBJ-DISC-NEXT:     Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
-; OBJ-DISC-NEXT: 0000000000000000  0000000700000244 R_AARCH64_AUTH_ABS64   0000000000000000 foo + 0
-; OBJ-DISC:      Relocation section '.rela.fini_array' at offset 0x[[#]] contains 1 entries:
-; OBJ-DISC-NEXT:     Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
-; OBJ-DISC-NEXT: 0000000000000000  0000000800000244 R_AARCH64_AUTH_ABS64   0000000000000004 bar + 0
-; OBJ-DISC:      Hex dump of section '.init_array':
-; OBJ-DISC-NEXT: 0x00000000 00000000 d4d90080
-; OBJ-DISC:      Hex dump of section '.fini_array':
-; OBJ-DISC-NEXT: 0x00000000 00000000 d4d90080
+; OBJ-BLENDED:      Relocation section '.rela.init_array' at offset 0x[[#]] contains 1 entries:
+; OBJ-BLENDED-NEXT:     Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
+; OBJ-BLENDED-NEXT: 0000000000000000  0000000700000244 R_AARCH64_AUTH_ABS64   0000000000000000 foo + 0
+; OBJ-BLENDED:      Relocation section '.rela.fini_array' at offset 0x[[#]] contains 1 entries:
+; OBJ-BLENDED-NEXT:     Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
+; OBJ-BLENDED-NEXT: 0000000000000000  0000000800000244 R_AARCH64_AUTH_ABS64   0000000000000004 bar + 0
+; OBJ-BLENDED:      Hex dump of section '.init_array':
+; OBJ-BLENDED-NEXT: 0x00000000 00000000 d4d90080
+; OBJ-BLENDED:      Hex dump of section '.fini_array':
+; OBJ-BLENDED-NEXT: 0x00000000 00000000 d4d90080
 ;;                                   ^^^^ 0xD9D4: constant discriminator = 55764
 ;;                                         ^^ 0x80: bits 61..60 key = IA; bit 63 addr disc = true
 
@@ -87,7 +112,7 @@ define void @bar() {
 
 ; RUN: not opt -S < err1.ll 2>&1 | FileCheck %s --check-prefix=ERR1
 
-; ERR1: ptrauth-init-fini must be set to 1 or unset
+; ERR1: ptrauth-init-fini-address-discrimination module flag requires ptrauth-init-fini
 
 @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
 
@@ -103,7 +128,7 @@ define void @foo() {
 
 ; RUN: not opt -S < err2.ll 2>&1 | FileCheck %s --check-prefix=ERR2
 
-; ERR2: ptrauth-init-fini-address-discrimination must be set to 1 or unset
+; ERR2: ptrauth-init-fini-address-discrimination module flag requires ptrauth-init-fini
 
 @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
 
@@ -111,9 +136,8 @@ define void @foo() {
   ret void
 }
 
-!llvm.module.flags = !{!0, !1}
-!0 = !{i32 1, !"ptrauth-init-fini", i32 1}
-!1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 0}
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 1}
 
 ;--- err3.ll
 
@@ -146,18 +170,3 @@ define void @foo() {
 !llvm.module.flags = !{!0, !1}
 !0 = !{i32 1, !"ptrauth-init-fini", i32 1}
 !1 = !{i32 1, !"ptrauth-init-fini-address-discrimination", !"1"}
-
-;--- err5.ll
-
-; RUN: not opt -S < err5.ll 2>&1 | FileCheck %s --check-prefix=ERR5
-
-; ERR5: ptrauth-init-fini-address-discrimination module flag requires ptrauth-init-fini
-
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
-
-define void @foo() {
-  ret void
-}
-
-!llvm.module.flags = !{!0}
-!0 = !{i32 1, !"ptrauth-init-fini-address-discrimination", i32 1}

--- a/llvm/test/CodeGen/AArch64/ptrauth-init-fini.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-init-fini.ll
@@ -24,8 +24,8 @@
 ; OBJ-CONST-NEXT: 0x00000000 00000000 d4d90000
 ; OBJ-CONST:      Hex dump of section '.fini_array':
 ; OBJ-CONST-NEXT: 0x00000000 00000000 d4d90000
-;;                              ^^^^ 0xD9D4: constant discriminator = 55764
-;;                                    ^^ 0x80: bits 61..60 key = IA; bit 63 addr disc = false
+;;                                    ^^^^ 0xD9D4: constant discriminator = 55764
+;;                                          ^^ 0x80: bits 61..60 key = IA; bit 63 addr disc = false
 
 @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
 @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar, ptr null }]
@@ -90,8 +90,8 @@ define void @bar() {
 ; OBJ-BLENDED-NEXT: 0x00000000 00000000 d4d90080
 ; OBJ-BLENDED:      Hex dump of section '.fini_array':
 ; OBJ-BLENDED-NEXT: 0x00000000 00000000 d4d90080
-;;                                   ^^^^ 0xD9D4: constant discriminator = 55764
-;;                                         ^^ 0x80: bits 61..60 key = IA; bit 63 addr disc = true
+;;                                      ^^^^ 0xD9D4: constant discriminator = 55764
+;;                                            ^^ 0x80: bits 61..60 key = IA; bit 63 addr disc = true
 
 @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @foo, ptr null }]
 @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @bar, ptr null }]


### PR DESCRIPTION
Move signing of the contents of `@llvm.global_(ctors|dtors)` from Clang frontend to the AsmPrinter at the end of the backend pipeline.

Signing of the pointers to init/fini functions in the backend fixes registration of the constructors and destructors performed by the optimizer or the backend.

This commit introduces two new module flags, `ptrauth-init-fini` and `ptrauth-init-fini-address-discrimination`, mirroring corresponding Clang options. The flags are semantically boolean, an absent flag is treated as having the `false` value and the latter flag requires the former one. The particular constant discriminator to use is not configurable via module flags and is hardcoded to the value 0xD9D4 in the `llvm/lib/Target/AArch64/AArch64PointerAuth.h` file.