### PR TITLE
[NFC][CodeGen] Add MachineBlockHashInfoResult for use in NewPM

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineBlockHashInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineBlockHashInfo.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CODEGEN_MACHINEBLOCKHASHINFO_H
 #define LLVM_CODEGEN_MACHINEBLOCKHASHINFO_H
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 
 namespace llvm {
@@ -95,8 +96,18 @@ private:
   uint16_t NeighborHash{0};
 };
 
-class MachineBlockHashInfo : public MachineFunctionPass {
+/// Result object for MachineBlockHashInfo.
+class MachineBlockHashInfoResult {
   DenseMap<const MachineBasicBlock *, uint64_t> MBBHashInfo;
+
+public:
+  MachineBlockHashInfoResult();
+  explicit MachineBlockHashInfoResult(const MachineFunction &MBB);
+  uint64_t getMBBHash(const MachineBasicBlock &MBB) const;
+};
+
+class MachineBlockHashInfo : public MachineFunctionPass {
+  MachineBlockHashInfoResult Result;
 
 public:
   static char ID;
@@ -108,7 +119,7 @@ public:
 
   bool runOnMachineFunction(MachineFunction &F) override;
 
-  uint64_t getMBBHash(const MachineBasicBlock &MBB);
+  uint64_t getMBBHash(const MachineBasicBlock &MBB) const;
 };
 
 } // end namespace llvm

--- a/llvm/lib/CodeGen/MachineBlockHashInfo.cpp
+++ b/llvm/lib/CodeGen/MachineBlockHashInfo.cpp
@@ -63,7 +63,10 @@ struct CollectHashInfo {
   uint64_t NeighborHash;
 };
 
-bool MachineBlockHashInfo::runOnMachineFunction(MachineFunction &F) {
+MachineBlockHashInfoResult::MachineBlockHashInfoResult() = default;
+
+MachineBlockHashInfoResult::MachineBlockHashInfoResult(
+    const MachineFunction &F) {
   DenseMap<const MachineBasicBlock *, CollectHashInfo> HashInfos;
   uint16_t Offset = 0;
   // Initialize hash components
@@ -103,12 +106,21 @@ bool MachineBlockHashInfo::runOnMachineFunction(MachineFunction &F) {
                                  fold_64_to_16(HashInfo.NeighborHash));
     MBBHashInfo[&MBB] = BlendedHash.combine();
   }
+}
 
+uint64_t
+MachineBlockHashInfoResult::getMBBHash(const MachineBasicBlock &MBB) const {
+  auto it = MBBHashInfo.find(&MBB);
+  return it == MBBHashInfo.end() ? 0 : it->second;
+}
+
+bool MachineBlockHashInfo::runOnMachineFunction(MachineFunction &F) {
+  Result = MachineBlockHashInfoResult{F};
   return false;
 }
 
-uint64_t MachineBlockHashInfo::getMBBHash(const MachineBasicBlock &MBB) {
-  return MBBHashInfo[&MBB];
+uint64_t MachineBlockHashInfo::getMBBHash(const MachineBasicBlock &MBB) const {
+  return Result.getMBBHash(MBB);
 }
 
 MachineFunctionPass *llvm::createMachineBlockHashInfoPass() {


### PR DESCRIPTION
This patch extracts the hash computation logic into a separate
`MachineBlockHashInfoResult` class. This allows the data to be
managed independently of the legacy pass manager and prepares
the infrastructure for the New Pass Manager.
