### PR TITLE
[CIR] Fix crash in emitPointerWithAlignment for unhandled cast kinds

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -188,76 +188,10 @@ Address CIRGenFunction::emitPointerWithAlignment(const Expr *expr,
                                    ce->getExprLoc());
     }
 
-    case CK_AnyPointerToBlockPointerCast:
-    case CK_BaseToDerived:
-    case CK_BaseToDerivedMemberPointer:
-    case CK_BlockPointerToObjCPointerCast:
-    case CK_BuiltinFnToFnPtr:
-    case CK_CPointerToObjCPointerCast:
-    case CK_DerivedToBaseMemberPointer:
-    case CK_Dynamic:
-    case CK_FunctionToPointerDecay:
-    case CK_IntegralToPointer:
-    case CK_LValueToRValue:
-    case CK_LValueToRValueBitCast:
-    case CK_NullToMemberPointer:
-    case CK_NullToPointer:
-    case CK_ReinterpretMemberPointer:
-      // Common pointer conversions, nothing to do here.
-      // TODO: Is there any reason to treat base-to-derived conversions
-      // specially?
+    // TODO: Is there any reason to treat base-to-derived conversions
+    // specially?
+    default:
       break;
-
-    case CK_ARCConsumeObject:
-    case CK_ARCExtendBlockObject:
-    case CK_ARCProduceObject:
-    case CK_ARCReclaimReturnedObject:
-    case CK_AtomicToNonAtomic:
-    case CK_BooleanToSignedIntegral:
-    case CK_ConstructorConversion:
-    case CK_CopyAndAutoreleaseBlockObject:
-    case CK_Dependent:
-    case CK_FixedPointCast:
-    case CK_FixedPointToBoolean:
-    case CK_FixedPointToFloating:
-    case CK_FixedPointToIntegral:
-    case CK_FloatingCast:
-    case CK_FloatingComplexCast:
-    case CK_FloatingComplexToBoolean:
-    case CK_FloatingComplexToIntegralComplex:
-    case CK_FloatingComplexToReal:
-    case CK_FloatingRealToComplex:
-    case CK_FloatingToBoolean:
-    case CK_FloatingToFixedPoint:
-    case CK_FloatingToIntegral:
-    case CK_HLSLAggregateSplatCast:
-    case CK_HLSLArrayRValue:
-    case CK_HLSLElementwiseCast:
-    case CK_HLSLVectorTruncation:
-    case CK_HLSLMatrixTruncation:
-    case CK_IntToOCLSampler:
-    case CK_IntegralCast:
-    case CK_IntegralComplexCast:
-    case CK_IntegralComplexToBoolean:
-    case CK_IntegralComplexToFloatingComplex:
-    case CK_IntegralComplexToReal:
-    case CK_IntegralRealToComplex:
-    case CK_IntegralToBoolean:
-    case CK_IntegralToFixedPoint:
-    case CK_IntegralToFloating:
-    case CK_LValueBitCast:
-    case CK_MatrixCast:
-    case CK_MemberPointerToBoolean:
-    case CK_NonAtomicToAtomic:
-    case CK_ObjCObjectLValueCast:
-    case CK_PointerToBoolean:
-    case CK_PointerToIntegral:
-    case CK_ToUnion:
-    case CK_ToVoid:
-    case CK_UserDefinedConversion:
-    case CK_VectorSplat:
-    case CK_ZeroToOCLOpaqueType:
-      llvm_unreachable("unexpected cast for emitPointerWithAlignment");
     }
   }
 

--- a/clang/test/CIR/CodeGen/user-defined-conv-ptr.cpp
+++ b/clang/test/CIR/CodeGen/user-defined-conv-ptr.cpp
@@ -1,0 +1,56 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+struct Resource {
+  int value;
+};
+
+template <typename T>
+struct Ptr {
+  T *p;
+  operator T*() const { return p; }
+  T** operator&() { return &p; }
+};
+
+void use_ptr(Resource *r);
+void use_void_pp(void **pp);
+
+// Test user-defined conversion operator producing a pointer
+// (CK_UserDefinedConversion through emitPointerWithAlignment).
+void test_conv_op(Ptr<Resource> smart) {
+  use_ptr(smart);
+}
+
+// CIR-LABEL: @_Z12test_conv_op3PtrI8ResourceE
+// CIR:         cir.call @_ZNK3PtrI8ResourceEcvPS0_Ev
+// CIR-NEXT:    cir.call @_Z7use_ptrP8Resource
+
+// LLVM-LABEL: define dso_local void @_Z12test_conv_op3PtrI8ResourceE
+// LLVM:         call noundef ptr @_ZNK3PtrI8ResourceEcvPS0_Ev
+// LLVM-NEXT:    call void @_Z7use_ptrP8Resource
+
+// OGCG-LABEL: define dso_local void @_Z12test_conv_op3PtrI8ResourceE
+// OGCG:         call noundef ptr @_ZNK3PtrI8ResourceEcvPS0_Ev
+// OGCG-NEXT:    call void @_Z7use_ptrP8Resource
+
+// Test operator& returning pointer-to-pointer, cast to void**.
+void test_addr_op(Ptr<Resource> smart) {
+  use_void_pp((void **)&smart);
+}
+
+// CIR-LABEL: @_Z12test_addr_op3PtrI8ResourceE
+// CIR:         cir.call @_ZN3PtrI8ResourceEadEv
+// CIR:         cir.cast bitcast
+// CIR:         cir.call @_Z11use_void_ppPPv
+
+// LLVM-LABEL: define dso_local void @_Z12test_addr_op3PtrI8ResourceE
+// LLVM:         call noundef ptr @_ZN3PtrI8ResourceEadEv
+// LLVM:         call void @_Z11use_void_ppPPv
+
+// OGCG-LABEL: define dso_local void @_Z12test_addr_op3PtrI8ResourceE
+// OGCG:         call noundef ptr @_ZN3PtrI8ResourceEadEv
+// OGCG:         call void @_Z11use_void_ppPPv


### PR DESCRIPTION
emitPointerWithAlignment explicitly lists every CastKind in a switch and marks ~50 of them as llvm_unreachable.  Classic codegen and the incubator both use `default: break` here — unhandled cast kinds just fall through to makeNaturalAddressForPointer(emitScalarExpr(...)), which is correct.

This crashes on real-world C++ code that uses user-defined conversion operators returning pointers (e.g., COM-style smart pointers with operator T*()).  The fix replaces the two explicit case lists with a single `default: break` to match classic codegen.

Made with [Cursor](https://cursor.com)