### PR TITLE
[CIR] Add EH cleanup for field and base destructors in constructors

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -286,7 +286,7 @@ void CIRGenFunction::emitBaseInitializer(mlir::Location loc,
   emitAggExpr(baseInit->getInit(), aggSlot);
 
   if (cgm.getLangOpts().Exceptions && !baseClassDecl->hasTrivialDestructor())
-    cgm.errorNYI(baseInit->getSourceRange(), "call base destructor");
+    ehStack.pushCleanup<CallBaseDtor>(EHCleanup, baseClassDecl, isBaseVirtual);
 }
 
 /// This routine generates necessary code to initialize base classes and
@@ -620,7 +620,7 @@ void CIRGenFunction::emitInitializerForField(FieldDecl *field, LValue lhs,
   // constructor.
   QualType::DestructionKind dtorKind = fieldType.isDestructedType();
   if (needsEHCleanup(dtorKind))
-    cgm.errorNYI(init->getSourceRange(), "call field destructor");
+    pushEHDestroy(dtorKind, lhs.getAddress(), fieldType);
 }
 
 Address CIRGenFunction::emitCXXMemberDataPointerAddress(

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -1086,6 +1086,11 @@ void CIRGenFunction::pushDestroy(CleanupKind cleanupKind, Address addr,
   pushFullExprCleanup<DestroyObject>(cleanupKind, addr, type, destroyer);
 }
 
+void CIRGenFunction::pushEHDestroy(QualType::DestructionKind dtorKind,
+                                   Address addr, QualType type) {
+  pushDestroy(EHCleanup, addr, type, getDestroyer(dtorKind));
+}
+
 void CIRGenFunction::pushDestroyAndDeferDeactivation(
     QualType::DestructionKind dtorKind, Address addr, QualType type) {
   assert(dtorKind && "cannot push destructor for trivial type");

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1401,6 +1401,9 @@ public:
   void pushDestroy(CleanupKind kind, Address addr, QualType type,
                    Destroyer *destroyer);
 
+  void pushEHDestroy(QualType::DestructionKind dtorKind, Address addr,
+                     QualType type);
+
   void pushLifetimeExtendedDestroy(CleanupKind kind, Address addr,
                                    QualType type, Destroyer *destroyer,
                                    bool useEHCleanupForArray);

--- a/clang/test/CIR/CodeGen/ctor-field-eh-cleanup.cpp
+++ b/clang/test/CIR/CodeGen/ctor-field-eh-cleanup.cpp
@@ -1,0 +1,73 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fcxx-exceptions -fexceptions -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fcxx-exceptions -fexceptions -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fcxx-exceptions -fexceptions -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+struct Field {
+  int x;
+  Field(int);
+  ~Field();
+};
+
+struct TwoFields {
+  Field a;
+  Field b;
+  TwoFields();
+};
+
+// When constructing 'b', if its constructor throws, 'a' must be destroyed.
+TwoFields::TwoFields() : a(1), b(2) {}
+
+// CIR-LABEL: @_ZN9TwoFieldsC2Ev
+// CIR:         cir.call @_ZN5FieldC1Ei
+// CIR:         cir.cleanup.scope {
+// CIR:           cir.call @_ZN5FieldC1Ei
+// CIR:         } cleanup eh {
+// CIR:           cir.call @_ZN5FieldD1Ev
+
+// LLVM-LABEL: define dso_local void @_ZN9TwoFieldsC2Ev
+// LLVM:         invoke void @_ZN5FieldC1Ei
+// LLVM:         landingpad
+// LLVM:         call void @_ZN5FieldD1Ev
+// LLVM:         resume
+
+// OGCG-LABEL: define dso_local void @_ZN9TwoFieldsC2Ev
+// OGCG:         invoke void @_ZN5FieldC1Ei
+// OGCG:         landingpad
+// OGCG:         call void @_ZN5FieldD1Ev
+// OGCG:         resume
+
+struct Base {
+  int x;
+  Base(int);
+  ~Base();
+};
+
+struct Derived : Base {
+  Field f;
+  Derived();
+};
+
+// When constructing 'f', if its constructor throws, Base must be destroyed.
+Derived::Derived() : Base(1), f(2) {}
+
+// CIR-LABEL: @_ZN7DerivedC2Ev
+// CIR:         cir.call @_ZN4BaseC2Ei
+// CIR:         cir.cleanup.scope {
+// CIR:           cir.call @_ZN5FieldC1Ei
+// CIR:         } cleanup eh {
+// CIR:           cir.call @_ZN4BaseD2Ev
+
+// LLVM-LABEL: define dso_local void @_ZN7DerivedC2Ev
+// LLVM:         invoke void @_ZN5FieldC1Ei
+// LLVM:         landingpad
+// LLVM:         call void @_ZN4BaseD2Ev
+// LLVM:         resume
+
+// OGCG-LABEL: define dso_local void @_ZN7DerivedC2Ev
+// OGCG:         invoke void @_ZN5FieldC1Ei
+// OGCG:         landingpad
+// OGCG:         call void @_ZN4BaseD2Ev
+// OGCG:         resume


### PR DESCRIPTION
Add pushEHDestroy to register EH-only cleanup for field destructors when a later constructor step might throw.  For base destructors, reuse the existing CallBaseDtor cleanup with EHCleanup kind.  Both match classic codegen behavior.

Made with [Cursor](https://cursor.com)