### PR TITLE
[offload] Remove unnecessary extra allocations in kernel replay tool

### DIFF
--- a/offload/tools/kernelreplay/llvm-omp-kernel-replay.cpp
+++ b/offload/tools/kernelreplay/llvm-omp-kernel-replay.cpp
@@ -240,15 +240,8 @@ Error replayKernel() {
     return createErr("failed to read the globals file");
   auto GlobalsBuffer = std::move(GlobalsBufferOrErr.get());
 
-  // On AMD for currently unknown reasons we cannot copy memory mapped data to
-  // device. This is a work-around.
-  uint8_t *RecordedGlobals = new uint8_t[GlobalsBuffer->getBufferSize()];
-  std::memcpy(RecordedGlobals,
-              const_cast<char *>(GlobalsBuffer->getBuffer().data()),
-              GlobalsBuffer->getBufferSize());
-
-  void *BufferPtr = (void *)RecordedGlobals;
-  uint32_t NumGlobals = *((uint32_t *)(BufferPtr));
+  const void *BufferPtr = const_cast<char *>(GlobalsBuffer->getBufferStart());
+  uint32_t NumGlobals = *((const uint32_t *)(BufferPtr));
   BufferPtr = utils::advancePtr(BufferPtr, sizeof(uint32_t));
 
   SmallVector<llvm::offloading::EntryTy> OffloadEntries(
@@ -268,14 +261,14 @@ Error replayKernel() {
     Global.Address = static_cast<char *>(OffloadEntries[0].Address) + I + 1;
 
     // Setup the offload entry using the information from the file.
-    uint32_t NameSize = *((uint32_t *)(BufferPtr));
+    uint32_t NameSize = *((const uint32_t *)(BufferPtr));
     BufferPtr = utils::advancePtr(BufferPtr, sizeof(uint32_t));
-    uint64_t Size = *((uint64_t *)(BufferPtr));
+    uint64_t Size = *((const uint64_t *)(BufferPtr));
     BufferPtr = utils::advancePtr(BufferPtr, sizeof(uint64_t));
     Global.Size = Size;
-    Global.SymbolName = (char *)BufferPtr;
+    Global.SymbolName = const_cast<char*>(static_cast<const char*>(BufferPtr));
     BufferPtr = utils::advancePtr(BufferPtr, NameSize);
-    Global.AuxAddr = BufferPtr;
+    Global.AuxAddr = const_cast<void *>(BufferPtr);
     BufferPtr = utils::advancePtr(BufferPtr, Size);
   }
 
@@ -320,24 +313,15 @@ Error replayKernel() {
     return createErr("failed to read the kernel record input file");
   auto RecordInputBuffer = std::move(RecordInputBufferOrErr.get());
 
-  // On AMD for currently unknown reasons we cannot copy memory mapped data to
-  // device. This is a work-around.
-  uint8_t *RecordedData = new uint8_t[RecordInputBuffer->getBufferSize()];
-  std::memcpy(RecordedData,
-              const_cast<char *>(RecordInputBuffer->getBuffer().data()),
-              RecordInputBuffer->getBufferSize());
-
   KernelReplayOutcomeTy Outcome;
   Rc = __tgt_target_kernel_replay(
       /*Loc=*/nullptr, DeviceId, OffloadEntries[0].Address,
-      (char *)RecordedData, RecordInputBuffer->getBufferSize(),
+      const_cast<char *>(RecordInputBuffer->getBufferStart()), RecordInputBuffer->getBufferSize(),
       NumGlobals ? &OffloadEntries[1] : nullptr, NumGlobals, TgtArgs.data(),
       TgtArgOffsets.data(), NumArgs, NumTeams, NumThreads, SharedMemorySize,
       LoopTripCount, &Outcome);
   if (Rc != OMP_TGT_SUCCESS)
     return createErr("failed to replay kernel");
-
-  delete[] RecordedData;
 
   // Verify the replay output if requested.
   if (VerifyOpt) {

--- a/offload/tools/kernelreplay/llvm-omp-kernel-replay.cpp
+++ b/offload/tools/kernelreplay/llvm-omp-kernel-replay.cpp
@@ -266,7 +266,8 @@ Error replayKernel() {
     uint64_t Size = *((const uint64_t *)(BufferPtr));
     BufferPtr = utils::advancePtr(BufferPtr, sizeof(uint64_t));
     Global.Size = Size;
-    Global.SymbolName = const_cast<char*>(static_cast<const char*>(BufferPtr));
+    Global.SymbolName =
+        const_cast<char *>(static_cast<const char *>(BufferPtr));
     BufferPtr = utils::advancePtr(BufferPtr, NameSize);
     Global.AuxAddr = const_cast<void *>(BufferPtr);
     BufferPtr = utils::advancePtr(BufferPtr, Size);
@@ -316,7 +317,8 @@ Error replayKernel() {
   KernelReplayOutcomeTy Outcome;
   Rc = __tgt_target_kernel_replay(
       /*Loc=*/nullptr, DeviceId, OffloadEntries[0].Address,
-      const_cast<char *>(RecordInputBuffer->getBufferStart()), RecordInputBuffer->getBufferSize(),
+      const_cast<char *>(RecordInputBuffer->getBufferStart()),
+      RecordInputBuffer->getBufferSize(),
       NumGlobals ? &OffloadEntries[1] : nullptr, NumGlobals, TgtArgs.data(),
       TgtArgOffsets.data(), NumArgs, NumTeams, NumThreads, SharedMemorySize,
       LoopTripCount, &Outcome);


### PR DESCRIPTION
The tool had two extra allocations holding the device memory and globals. Apparently, the AMDGPU plugin failed in the past to transfer data from the file memory mapping, and required these extra buffers. After testing it on MI300A and MI250X, this issue is not present anymore. Thus, we are removing them for now.