### PR TITLE
[lldb] Directly access object variable in GetObjectPointerValueObject (NFC)

### DIFF
--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -35,11 +35,13 @@
 #include "lldb/Target/Target.h"
 #include "lldb/Target/ThreadPlan.h"
 #include "lldb/Target/ThreadPlanCallUserExpression.h"
+#include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/State.h"
 #include "lldb/Utility/StreamString.h"
 #include "lldb/ValueObject/ValueObjectConstResult.h"
+#include "lldb/lldb-enumerations.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 
 using namespace lldb_private;
@@ -108,16 +110,13 @@ lldb::ValueObjectSP UserExpression::GetObjectPointerValueObject(
     return {};
   }
 
-  lldb::VariableSP var_sp;
-  lldb::ValueObjectSP valobj_sp;
+  if (auto var_list_sp = frame_sp->GetInScopeVariableList(false))
+    if (auto var_sp =
+            var_list_sp->FindVariable(ConstString(object_name), false))
+      return frame_sp->GetValueObjectForFrameVariable(var_sp,
+                                                      lldb::eNoDynamicValues);
 
-  return frame_sp->GetValueForVariableExpressionPath(
-      object_name, lldb::eNoDynamicValues,
-      StackFrame::eExpressionPathOptionCheckPtrVsMember |
-          StackFrame::eExpressionPathOptionsNoFragileObjcIvar |
-          StackFrame::eExpressionPathOptionsNoSyntheticChildren |
-          StackFrame::eExpressionPathOptionsNoSyntheticArrayRange,
-      var_sp, err);
+  return {};
 }
 
 lldb::addr_t UserExpression::GetObjectPointer(lldb::StackFrameSP frame_sp,


### PR DESCRIPTION
The `GetObjectPointerValueObject` function does not need full variable path expressions, or any of its functionality. This function simply gets the value of `this` or `self`.