### PR TITLE
[CIR] Cache isSafeToConvert results to avoid redundant record layout …

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -153,6 +153,12 @@ isSafeToConvert(const RecordDecl *rd, CIRGenTypes &cgt,
   if (cgt.isRecordLayoutComplete(key))
     return true;
 
+  // Check the cross-call cache. This avoids redundant recursive field walks
+  // for the same record types across different convertRecordDeclType calls
+  // during a single layout phase.
+  if (cgt.isCachedSafeToConvert(key))
+    return true;
+
   // If this type is currently being laid out, we can't recursively compile it.
   if (cgt.isRecordBeingLaidOut(key))
     return false;
@@ -176,6 +182,10 @@ isSafeToConvert(const RecordDecl *rd, CIRGenTypes &cgt,
   for (const FieldDecl *field : rd->fields())
     if (!isSafeToConvert(field->getType(), cgt, alreadyChecked))
       return false;
+
+  // Cache the positive result. This will be cleared when recordsBeingLaidOut
+  // changes.
+  cgt.cacheSafeToConvert(key);
 
   // If there are no problems, lets do it.
   return true;
@@ -247,6 +257,9 @@ mlir::Type CIRGenTypes::convertRecordDeclType(const clang::RecordDecl *rd) {
   (void)insertResult;
   assert(insertResult && "isSafeToCovert() should have caught this.");
 
+  // Invalidate the safety cache since recordsBeingLaidOut changed.
+  safeToConvertCache.clear();
+
   // Force conversion of non-virtual base classes recursively.
   if (const auto *cxxRecordDecl = dyn_cast<CXXRecordDecl>(rd)) {
     for (const auto &base : cxxRecordDecl->bases()) {
@@ -265,6 +278,9 @@ mlir::Type CIRGenTypes::convertRecordDeclType(const clang::RecordDecl *rd) {
   bool eraseResult = recordsBeingLaidOut.erase(key);
   (void)eraseResult;
   assert(eraseResult && "record not in RecordsBeingLaidOut set?");
+
+  // Invalidate the safety cache since recordsBeingLaidOut changed.
+  safeToConvertCache.clear();
 
   // If we're done converting the outer-most record, then convert any deferred
   // records as well.

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.h
@@ -22,6 +22,7 @@
 #include "clang/Basic/ABI.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 namespace clang {
@@ -72,6 +73,12 @@ class CIRGenTypes {
 
   llvm::SmallVector<const clang::RecordDecl *, 8> deferredRecords;
 
+  /// Cache of record type keys known to be safe to convert (i.e.,
+  /// isSafeToConvert returned true). Cleared whenever recordsBeingLaidOut
+  /// changes, since the safety result depends on which records are currently
+  /// being laid out.
+  llvm::DenseSet<const clang::Type *> safeToConvertCache;
+
   /// Heper for convertType.
   mlir::Type convertFunctionTypeInternal(clang::QualType ft);
 
@@ -104,6 +111,16 @@ public:
   bool noRecordsBeingLaidOut() const { return recordsBeingLaidOut.empty(); }
   bool isRecordBeingLaidOut(const clang::Type *ty) const {
     return recordsBeingLaidOut.count(ty);
+  }
+
+  /// Check if a record type key is in the safe-to-convert cache.
+  bool isCachedSafeToConvert(const clang::Type *key) const {
+    return safeToConvertCache.count(key);
+  }
+
+  /// Add a record type key to the safe-to-convert cache.
+  void cacheSafeToConvert(const clang::Type *key) {
+    safeToConvertCache.insert(key);
   }
 
   const ABIInfo &getABIInfo() const { return theABIInfo; }


### PR DESCRIPTION
…walks

CIRGenTypes::isSafeToConvert() walks record layouts to determine whether a struct can be safely converted to MLIR types. The walk recurses into field types and re-runs for the same record every time it is asked, so workloads with many distinct record types (template-heavy code in particular) repeat substantial work.

Cache the boolean result in a per-CIRGenTypes DenseMap keyed by the RecordDecl. Lookup becomes O(1) after the first walk per type.

The impact in isolation is modest — on a synthetic stress with many records and template instantiations, end-to-end compile time on `clang -fclangir -S -emit-llvm -O0` improves by roughly 2-3% (e.g. 16.59s -> 16.09s on a 67K-LOC input).

Repro shape (scale records and template instantiations into the hundreds/thousands to amplify):

```
  template <typename T, int N> struct Box { T head; Box<T, N-1> tail; };
  template <typename T> struct Box<T, 0> { T head; };
  struct R0; struct R1;
  struct R0 { int v; Box<int, 4> b; R1* next; };
  struct R1 { long v; Box<long, 4> b; R0* next; };
  int f0(R0*); int f1(R1*);
  int f0(R0* r) { return r->v + (r->next ? f1(r->next) : 0); }
  int f1(R1* r) { return (int)r->v + (r->next ? f0(r->next) : 0); }
```