### PR TITLE
[RISCV][MC] Emit ISA mapping symbols on .option arch/rvc/norvc/pop

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -3217,7 +3217,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
 
     if (auto ParseResult =
             RISCVFeatures::parseFeatureBits(isRV64(), STI->getFeatureBits()))
-      getTargetStreamer().emitISAMappingSymbol((*ParseResult)->toString());
+      getTargetStreamer().setISAString((*ParseResult)->toString());
     return false;
   }
 
@@ -3249,7 +3249,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
     setFeatureBits(RISCV::FeatureStdExtC, "c");
     if (auto ParseResult =
             RISCVFeatures::parseFeatureBits(isRV64(), STI->getFeatureBits()))
-      getTargetStreamer().emitISAMappingSymbol((*ParseResult)->toString());
+      getTargetStreamer().setISAString((*ParseResult)->toString());
     return false;
   }
 
@@ -3262,7 +3262,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
     clearFeatureBits(RISCV::FeatureStdExtZca, "zca");
     if (auto ParseResult =
             RISCVFeatures::parseFeatureBits(isRV64(), STI->getFeatureBits()))
-      getTargetStreamer().emitISAMappingSymbol((*ParseResult)->toString());
+      getTargetStreamer().setISAString((*ParseResult)->toString());
     return false;
   }
 
@@ -3386,8 +3386,9 @@ bool RISCVAsmParser::parseDirectiveAttribute() {
     // Then emit the arch string.
     getTargetStreamer().emitTextAttribute(Tag, Result);
 
-    // And then emit mapping symbol with arch string.
-    getTargetStreamer().emitISAMappingSymbol(Result);
+    // And then update the active ISA so the next instruction-run emits
+    // an ISA-specific mapping symbol.
+    getTargetStreamer().setISAString(Result);
   }
 
   return false;

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -3217,7 +3217,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
 
     if (auto ParseResult =
             RISCVFeatures::parseFeatureBits(isRV64(), STI->getFeatureBits()))
-      getTargetStreamer().setISAString((*ParseResult)->toString());
+      getTargetStreamer().setArchString((*ParseResult)->toString());
     return false;
   }
 
@@ -3249,7 +3249,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
     setFeatureBits(RISCV::FeatureStdExtC, "c");
     if (auto ParseResult =
             RISCVFeatures::parseFeatureBits(isRV64(), STI->getFeatureBits()))
-      getTargetStreamer().setISAString((*ParseResult)->toString());
+      getTargetStreamer().setArchString((*ParseResult)->toString());
     return false;
   }
 
@@ -3262,7 +3262,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
     clearFeatureBits(RISCV::FeatureStdExtZca, "zca");
     if (auto ParseResult =
             RISCVFeatures::parseFeatureBits(isRV64(), STI->getFeatureBits()))
-      getTargetStreamer().setISAString((*ParseResult)->toString());
+      getTargetStreamer().setArchString((*ParseResult)->toString());
     return false;
   }
 
@@ -3388,7 +3388,7 @@ bool RISCVAsmParser::parseDirectiveAttribute() {
 
     // And then update the active ISA so the next instruction-run emits
     // an ISA-specific mapping symbol.
-    getTargetStreamer().setISAString(Result);
+    getTargetStreamer().setArchString(Result);
   }
 
   return false;

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -3214,6 +3214,10 @@ bool RISCVAsmParser::parseDirectiveOption() {
       return true;
 
     getTargetStreamer().emitDirectiveOptionArch(Args);
+
+    if (auto ParseResult =
+            RISCVFeatures::parseFeatureBits(isRV64(), STI->getFeatureBits()))
+      getTargetStreamer().emitISAMappingSymbol((*ParseResult)->toString());
     return false;
   }
 
@@ -3243,6 +3247,9 @@ bool RISCVAsmParser::parseDirectiveOption() {
 
     getTargetStreamer().emitDirectiveOptionRVC();
     setFeatureBits(RISCV::FeatureStdExtC, "c");
+    if (auto ParseResult =
+            RISCVFeatures::parseFeatureBits(isRV64(), STI->getFeatureBits()))
+      getTargetStreamer().emitISAMappingSymbol((*ParseResult)->toString());
     return false;
   }
 
@@ -3253,6 +3260,9 @@ bool RISCVAsmParser::parseDirectiveOption() {
     getTargetStreamer().emitDirectiveOptionNoRVC();
     clearFeatureBits(RISCV::FeatureStdExtC, "c");
     clearFeatureBits(RISCV::FeatureStdExtZca, "zca");
+    if (auto ParseResult =
+            RISCVFeatures::parseFeatureBits(isRV64(), STI->getFeatureBits()))
+      getTargetStreamer().emitISAMappingSymbol((*ParseResult)->toString());
     return false;
   }
 
@@ -3375,6 +3385,9 @@ bool RISCVAsmParser::parseDirectiveAttribute() {
 
     // Then emit the arch string.
     getTargetStreamer().emitTextAttribute(Tag, Result);
+
+    // And then emit mapping symbol with arch string.
+    getTargetStreamer().emitISAMappingSymbol(Result);
   }
 
   return false;

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
@@ -45,7 +45,7 @@ RISCVTargetELFStreamer::RISCVTargetELFStreamer(MCStreamer &S,
           STI.hasFeature(RISCV::Feature64Bit), Features)) {
     InitialISAString = (*ParseResult)->toString();
     ISAString = InitialISAString;
-    getStreamer().setCurrentISAString(ISAString);
+    getStreamer().setMappingSymbolISA(ISAString);
   }
 }
 
@@ -59,15 +59,11 @@ RISCVELFStreamer &RISCVTargetELFStreamer::getStreamer() {
   return static_cast<RISCVELFStreamer &>(Streamer);
 }
 
-void RISCVTargetELFStreamer::setArchString(StringRef Arch) {
+void RISCVTargetELFStreamer::setISAString(StringRef Arch) {
   if (Arch == ISAString)
     return;
   ISAString = std::string(Arch);
-  getStreamer().setCurrentISAString(Arch);
-}
-
-void RISCVTargetELFStreamer::emitISAMappingSymbol(StringRef ISAStr) {
-  setArchString(ISAStr);
+  getStreamer().setMappingSymbolISA(Arch);
 }
 
 void RISCVTargetELFStreamer::emitDirectiveOptionPush() {
@@ -76,7 +72,7 @@ void RISCVTargetELFStreamer::emitDirectiveOptionPush() {
 
 void RISCVTargetELFStreamer::emitDirectiveOptionPop() {
   if (!ISAStringStack.empty())
-    setArchString(ISAStringStack.pop_back_val());
+    setISAString(ISAStringStack.pop_back_val());
 }
 
 void RISCVTargetELFStreamer::emitDirectiveOptionExact() {}
@@ -156,7 +152,7 @@ void RISCVTargetELFStreamer::reset() {
   // still records the full ISA via "$x<ISA>", matching the behaviour set up
   // in the constructor.
   if (!InitialISAString.empty())
-    getStreamer().setCurrentISAString(InitialISAString);
+    getStreamer().setMappingSymbolISA(InitialISAString);
 }
 
 void RISCVTargetELFStreamer::emitDirectiveVariantCC(MCSymbol &Symbol) {
@@ -168,10 +164,10 @@ void RISCVELFStreamer::reset() {
   MCELFStreamer::reset();
   LastMappingSymbols.clear();
   LastEMS = EMS_None;
-  CurrentISAString.clear();
+  MappingSymbolISA.clear();
   LastEmittedISA.clear();
   LastEmittedISAInSection.clear();
-  // Call target streamer reset last: it may call setCurrentISAString to
+  // Call target streamer reset last: it may call setMappingSymbolISA to
   // re-seed the initial ISA after our state has been cleared.
   static_cast<RISCVTargetStreamer *>(getTargetStreamer())->reset();
 }
@@ -186,19 +182,19 @@ void RISCVELFStreamer::emitDataMappingSymbol() {
 void RISCVELFStreamer::emitInstructionsMappingSymbol() {
   // Emit a mapping symbol at the start of each instruction run, and whenever
   // the active ISA has changed since the last one emitted in this section.
-  // The symbol takes the form "$x<ISA>" when CurrentISAString is known, or
+  // The symbol takes the form "$x<ISA>" when MappingSymbolISA is known, or
   // plain "$x" as a fallback.  The comparison with LastEmittedISA provides
   // deduplication: repeating .option arch with the same ISA, or re-entering a
   // section whose last mapping symbol already matches the active ISA, emits
   // no redundant symbol.
   bool NeedSymbol =
-      LastEMS != EMS_Instructions || LastEmittedISA != CurrentISAString;
+      LastEMS != EMS_Instructions || LastEmittedISA != MappingSymbolISA;
   if (NeedSymbol) {
-    if (CurrentISAString.empty())
+    if (MappingSymbolISA.empty())
       emitMappingSymbol("$x");
     else
-      emitMappingSymbol("$x" + CurrentISAString);
-    LastEmittedISA = CurrentISAString;
+      emitMappingSymbol("$x" + MappingSymbolISA);
+    LastEmittedISA = MappingSymbolISA;
   }
   LastEMS = EMS_Instructions;
 }
@@ -211,8 +207,8 @@ void RISCVELFStreamer::emitMappingSymbol(StringRef Name) {
   Symbol->setBinding(ELF::STB_LOCAL);
 }
 
-void RISCVELFStreamer::setCurrentISAString(StringRef Arch) {
-  CurrentISAString = std::string(Arch);
+void RISCVELFStreamer::setMappingSymbolISA(StringRef Arch) {
+  MappingSymbolISA = std::string(Arch);
 }
 
 void RISCVELFStreamer::changeSection(MCSection *Section, uint32_t Subsection) {

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
@@ -34,6 +34,19 @@ RISCVTargetELFStreamer::RISCVTargetELFStreamer(MCStreamer &S,
   setTargetABI(RISCVABI::computeTargetABI(STI.getTargetTriple(), Features,
                                           MAB.getTargetOptions().getABIName()));
   setFlagsFromFeatures(STI);
+
+  // Compute the initial ISA string.  This serves two purposes:
+  //   1. Deduplication: subsequent .option arch/rvc/norvc directives compare
+  //      against ISAString to avoid propagating redundant ISA updates.
+  //   2. Initial symbol: seed the streamer's active ISA so a "$x<ISAString>"
+  //      mapping symbol is emitted before the first instruction, recording
+  //      the full ISA in the object even when no .option directive is present.
+  if (auto ParseResult = RISCVFeatures::parseFeatureBits(
+          STI.hasFeature(RISCV::Feature64Bit), Features)) {
+    InitialISAString = (*ParseResult)->toString();
+    ISAString = InitialISAString;
+    getStreamer().setCurrentISAString(ISAString);
+  }
 }
 
 RISCVELFStreamer::RISCVELFStreamer(MCContext &C,
@@ -46,12 +59,30 @@ RISCVELFStreamer &RISCVTargetELFStreamer::getStreamer() {
   return static_cast<RISCVELFStreamer &>(Streamer);
 }
 
+void RISCVTargetELFStreamer::setArchString(StringRef Arch) {
+  if (Arch == ISAString)
+    return;
+  ISAString = std::string(Arch);
+  getStreamer().setCurrentISAString(Arch);
+}
+
+void RISCVTargetELFStreamer::emitISAMappingSymbol(StringRef ISAStr) {
+  setArchString(ISAStr);
+}
+
+void RISCVTargetELFStreamer::emitDirectiveOptionPush() {
+  ISAStringStack.push_back(ISAString);
+}
+
+void RISCVTargetELFStreamer::emitDirectiveOptionPop() {
+  if (!ISAStringStack.empty())
+    setArchString(ISAStringStack.pop_back_val());
+}
+
 void RISCVTargetELFStreamer::emitDirectiveOptionExact() {}
 void RISCVTargetELFStreamer::emitDirectiveOptionNoExact() {}
 void RISCVTargetELFStreamer::emitDirectiveOptionPIC() {}
 void RISCVTargetELFStreamer::emitDirectiveOptionNoPIC() {}
-void RISCVTargetELFStreamer::emitDirectiveOptionPop() {}
-void RISCVTargetELFStreamer::emitDirectiveOptionPush() {}
 void RISCVTargetELFStreamer::emitDirectiveOptionRelax() {}
 void RISCVTargetELFStreamer::emitDirectiveOptionNoRelax() {}
 void RISCVTargetELFStreamer::emitDirectiveOptionRVC() {}
@@ -119,6 +150,13 @@ void RISCVTargetELFStreamer::finish() {
 
 void RISCVTargetELFStreamer::reset() {
   AttributeSection = nullptr;
+  ISAString = InitialISAString;
+  ISAStringStack.clear();
+  // Re-seed the streamer's active ISA so the first instruction after reset
+  // still records the full ISA via "$x<ISA>", matching the behaviour set up
+  // in the constructor.
+  if (!InitialISAString.empty())
+    getStreamer().setCurrentISAString(InitialISAString);
 }
 
 void RISCVTargetELFStreamer::emitDirectiveVariantCC(MCSymbol &Symbol) {
@@ -127,10 +165,15 @@ void RISCVTargetELFStreamer::emitDirectiveVariantCC(MCSymbol &Symbol) {
 }
 
 void RISCVELFStreamer::reset() {
-  static_cast<RISCVTargetStreamer *>(getTargetStreamer())->reset();
   MCELFStreamer::reset();
   LastMappingSymbols.clear();
   LastEMS = EMS_None;
+  CurrentISAString.clear();
+  LastEmittedISA.clear();
+  LastEmittedISAInSection.clear();
+  // Call target streamer reset last: it may call setCurrentISAString to
+  // re-seed the initial ISA after our state has been cleared.
+  static_cast<RISCVTargetStreamer *>(getTargetStreamer())->reset();
 }
 
 void RISCVELFStreamer::emitDataMappingSymbol() {
@@ -141,9 +184,22 @@ void RISCVELFStreamer::emitDataMappingSymbol() {
 }
 
 void RISCVELFStreamer::emitInstructionsMappingSymbol() {
-  if (LastEMS == EMS_Instructions)
-    return;
-  emitMappingSymbol("$x");
+  // Emit a mapping symbol at the start of each instruction run, and whenever
+  // the active ISA has changed since the last one emitted in this section.
+  // The symbol takes the form "$x<ISA>" when CurrentISAString is known, or
+  // plain "$x" as a fallback.  The comparison with LastEmittedISA provides
+  // deduplication: repeating .option arch with the same ISA, or re-entering a
+  // section whose last mapping symbol already matches the active ISA, emits
+  // no redundant symbol.
+  bool NeedSymbol =
+      LastEMS != EMS_Instructions || LastEmittedISA != CurrentISAString;
+  if (NeedSymbol) {
+    if (CurrentISAString.empty())
+      emitMappingSymbol("$x");
+    else
+      emitMappingSymbol("$x" + CurrentISAString);
+    LastEmittedISA = CurrentISAString;
+  }
   LastEMS = EMS_Instructions;
 }
 
@@ -155,12 +211,22 @@ void RISCVELFStreamer::emitMappingSymbol(StringRef Name) {
   Symbol->setBinding(ELF::STB_LOCAL);
 }
 
+void RISCVELFStreamer::setCurrentISAString(StringRef Arch) {
+  CurrentISAString = std::string(Arch);
+}
+
 void RISCVELFStreamer::changeSection(MCSection *Section, uint32_t Subsection) {
   // We have to keep track of the mapping symbol state of any sections we
   // use. Each one should start off as EMS_None, which is provided as the
-  // default constructor by DenseMap::lookup.
-  LastMappingSymbols[getPreviousSection().first] = LastEMS;
+  // default constructor by DenseMap::lookup.  The last ISA suffix emitted in
+  // each section is also preserved so that re-entering a section only emits a
+  // new "$x<ISA>" symbol when the active ISA has actually changed.
+  const MCSection *Prev = getPreviousSection().first;
+  LastMappingSymbols[Prev] = LastEMS;
+  LastEmittedISAInSection[Prev] = LastEmittedISA;
   LastEMS = LastMappingSymbols.lookup(Section);
+  auto It = LastEmittedISAInSection.find(Section);
+  LastEmittedISA = It != LastEmittedISAInSection.end() ? It->second : "";
 
   MCELFStreamer::changeSection(Section, Subsection);
 }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
@@ -37,15 +37,15 @@ RISCVTargetELFStreamer::RISCVTargetELFStreamer(MCStreamer &S,
 
   // Compute the initial ISA string.  This serves two purposes:
   //   1. Deduplication: subsequent .option arch/rvc/norvc directives compare
-  //      against ISAString to avoid propagating redundant ISA updates.
-  //   2. Initial symbol: seed the streamer's active ISA so a "$x<ISAString>"
+  //      against ArchString to avoid propagating redundant ISA updates.
+  //   2. Initial symbol: seed the streamer's active ISA so a "$x<ArchString>"
   //      mapping symbol is emitted before the first instruction, recording
   //      the full ISA in the object even when no .option directive is present.
   if (auto ParseResult = RISCVFeatures::parseFeatureBits(
           STI.hasFeature(RISCV::Feature64Bit), Features)) {
-    InitialISAString = (*ParseResult)->toString();
-    ISAString = InitialISAString;
-    getStreamer().setMappingSymbolISA(ISAString);
+    InitialArchString = (*ParseResult)->toString();
+    ArchString = InitialArchString;
+    getStreamer().setMappingSymbolArch(ArchString);
   }
 }
 
@@ -59,20 +59,20 @@ RISCVELFStreamer &RISCVTargetELFStreamer::getStreamer() {
   return static_cast<RISCVELFStreamer &>(Streamer);
 }
 
-void RISCVTargetELFStreamer::setISAString(StringRef Arch) {
-  if (Arch == ISAString)
+void RISCVTargetELFStreamer::setArchString(StringRef Arch) {
+  if (Arch == ArchString)
     return;
-  ISAString = std::string(Arch);
-  getStreamer().setMappingSymbolISA(Arch);
+  ArchString = std::string(Arch);
+  getStreamer().setMappingSymbolArch(Arch);
 }
 
 void RISCVTargetELFStreamer::emitDirectiveOptionPush() {
-  ISAStringStack.push_back(ISAString);
+  ArchStringStack.push_back(ArchString);
 }
 
 void RISCVTargetELFStreamer::emitDirectiveOptionPop() {
-  if (!ISAStringStack.empty())
-    setISAString(ISAStringStack.pop_back_val());
+  if (!ArchStringStack.empty())
+    setArchString(ArchStringStack.pop_back_val());
 }
 
 void RISCVTargetELFStreamer::emitDirectiveOptionExact() {}
@@ -146,13 +146,13 @@ void RISCVTargetELFStreamer::finish() {
 
 void RISCVTargetELFStreamer::reset() {
   AttributeSection = nullptr;
-  ISAString = InitialISAString;
-  ISAStringStack.clear();
+  ArchString = InitialArchString;
+  ArchStringStack.clear();
   // Re-seed the streamer's active ISA so the first instruction after reset
   // still records the full ISA via "$x<ISA>", matching the behaviour set up
   // in the constructor.
-  if (!InitialISAString.empty())
-    getStreamer().setMappingSymbolISA(InitialISAString);
+  if (!InitialArchString.empty())
+    getStreamer().setMappingSymbolArch(InitialArchString);
 }
 
 void RISCVTargetELFStreamer::emitDirectiveVariantCC(MCSymbol &Symbol) {
@@ -164,10 +164,10 @@ void RISCVELFStreamer::reset() {
   MCELFStreamer::reset();
   LastMappingSymbols.clear();
   LastEMS = EMS_None;
-  MappingSymbolISA.clear();
-  LastEmittedISA.clear();
-  LastEmittedISAInSection.clear();
-  // Call target streamer reset last: it may call setMappingSymbolISA to
+  MappingSymbolArch.clear();
+  LastEmittedArch.clear();
+  LastEmittedArchInSection.clear();
+  // Call target streamer reset last: it may call setMappingSymbolArch to
   // re-seed the initial ISA after our state has been cleared.
   static_cast<RISCVTargetStreamer *>(getTargetStreamer())->reset();
 }
@@ -182,19 +182,19 @@ void RISCVELFStreamer::emitDataMappingSymbol() {
 void RISCVELFStreamer::emitInstructionsMappingSymbol() {
   // Emit a mapping symbol at the start of each instruction run, and whenever
   // the active ISA has changed since the last one emitted in this section.
-  // The symbol takes the form "$x<ISA>" when MappingSymbolISA is known, or
-  // plain "$x" as a fallback.  The comparison with LastEmittedISA provides
+  // The symbol takes the form "$x<ISA>" when MappingSymbolArch is known, or
+  // plain "$x" as a fallback.  The comparison with LastEmittedArch provides
   // deduplication: repeating .option arch with the same ISA, or re-entering a
   // section whose last mapping symbol already matches the active ISA, emits
   // no redundant symbol.
   bool NeedSymbol =
-      LastEMS != EMS_Instructions || LastEmittedISA != MappingSymbolISA;
+      LastEMS != EMS_Instructions || LastEmittedArch != MappingSymbolArch;
   if (NeedSymbol) {
-    if (MappingSymbolISA.empty())
+    if (MappingSymbolArch.empty())
       emitMappingSymbol("$x");
     else
-      emitMappingSymbol("$x" + MappingSymbolISA);
-    LastEmittedISA = MappingSymbolISA;
+      emitMappingSymbol("$x" + MappingSymbolArch);
+    LastEmittedArch = MappingSymbolArch;
   }
   LastEMS = EMS_Instructions;
 }
@@ -207,8 +207,8 @@ void RISCVELFStreamer::emitMappingSymbol(StringRef Name) {
   Symbol->setBinding(ELF::STB_LOCAL);
 }
 
-void RISCVELFStreamer::setMappingSymbolISA(StringRef Arch) {
-  MappingSymbolISA = std::string(Arch);
+void RISCVELFStreamer::setMappingSymbolArch(StringRef Arch) {
+  MappingSymbolArch = std::string(Arch);
 }
 
 void RISCVELFStreamer::changeSection(MCSection *Section, uint32_t Subsection) {
@@ -219,10 +219,10 @@ void RISCVELFStreamer::changeSection(MCSection *Section, uint32_t Subsection) {
   // new "$x<ISA>" symbol when the active ISA has actually changed.
   const MCSection *Prev = getPreviousSection().first;
   LastMappingSymbols[Prev] = LastEMS;
-  LastEmittedISAInSection[Prev] = LastEmittedISA;
+  LastEmittedArchInSection[Prev] = LastEmittedArch;
   LastEMS = LastMappingSymbols.lookup(Section);
-  auto It = LastEmittedISAInSection.find(Section);
-  LastEmittedISA = It != LastEmittedISAInSection.end() ? It->second : "";
+  auto It = LastEmittedArchInSection.find(Section);
+  LastEmittedArch = It != LastEmittedArchInSection.end() ? It->second : "";
 
   MCELFStreamer::changeSection(Section, Subsection);
 }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.h
@@ -10,6 +10,7 @@
 #define LLVM_LIB_TARGET_RISCV_MCTARGETDESC_RISCVELFSTREAMER_H
 
 #include "RISCVTargetStreamer.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/MC/MCELFStreamer.h"
 
 namespace llvm {
@@ -25,6 +26,18 @@ class RISCVELFStreamer : public MCELFStreamer {
   DenseMap<const MCSection *, ElfMappingSymbol> LastMappingSymbols;
   ElfMappingSymbol LastEMS = EMS_None;
 
+  // Active ISA string propagated from RISCVTargetELFStreamer. When non-empty,
+  // it is used as the suffix for "$x<ISA>" mapping symbols.
+  std::string CurrentISAString;
+
+  // ISA suffix last emitted via "$x<ISA>" in the current section, and the
+  // per-section history preserved across changeSection. A new mapping symbol
+  // is emitted whenever LastEMS != EMS_Instructions or
+  // LastEmittedISA != CurrentISAString, so the ISA in effect at each
+  // instruction run is always recorded.
+  std::string LastEmittedISA;
+  DenseMap<const MCSection *, std::string> LastEmittedISAInSection;
+
 public:
   RISCVELFStreamer(MCContext &C, std::unique_ptr<MCAsmBackend> MAB,
                    std::unique_ptr<MCObjectWriter> MOW,
@@ -35,11 +48,24 @@ public:
   void emitBytes(StringRef Data) override;
   void emitFill(const MCExpr &NumBytes, uint64_t FillValue, SMLoc Loc) override;
   void emitValueImpl(const MCExpr *Value, unsigned Size, SMLoc Loc) override;
+
+  void setCurrentISAString(StringRef Arch);
 };
 
 class RISCVTargetELFStreamer : public RISCVTargetStreamer {
 private:
   StringRef CurrentVendor;
+
+  // Initial ISA string derived from the subtarget features in the constructor.
+  // Used to re-establish state on reset().
+  std::string InitialISAString;
+
+  // Current ISA string, kept in sync with each .option arch/rvc/norvc/pop
+  // and .attribute arch directive. Used to avoid propagating redundant ISA
+  // updates to the streamer when the ISA does not actually change (e.g.,
+  // .option rvc when C is already enabled).
+  std::string ISAString;
+  SmallVector<std::string, 4> ISAStringStack;
 
   MCSection *AttributeSection = nullptr;
 
@@ -51,16 +77,22 @@ private:
 
   void reset() override;
 
+  // Update ISAString and propagate the change to the streamer so the next
+  // instruction-run emits an ISA-specific mapping symbol. A no-op when
+  // Arch == ISAString (deduplication).
+  void setArchString(StringRef Arch);
+
 public:
   RISCVELFStreamer &getStreamer();
   RISCVTargetELFStreamer(MCStreamer &S, const MCSubtargetInfo &STI);
 
+  void emitISAMappingSymbol(StringRef ISAString) override;
+  void emitDirectiveOptionPush() override;
+  void emitDirectiveOptionPop() override;
   void emitDirectiveOptionExact() override;
   void emitDirectiveOptionNoExact() override;
   void emitDirectiveOptionPIC() override;
   void emitDirectiveOptionNoPIC() override;
-  void emitDirectiveOptionPop() override;
-  void emitDirectiveOptionPush() override;
   void emitDirectiveOptionRelax() override;
   void emitDirectiveOptionNoRelax() override;
   void emitDirectiveOptionRVC() override;

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.h
@@ -28,12 +28,12 @@ class RISCVELFStreamer : public MCELFStreamer {
 
   // Active ISA string propagated from RISCVTargetELFStreamer. When non-empty,
   // it is used as the suffix for "$x<ISA>" mapping symbols.
-  std::string CurrentISAString;
+  std::string MappingSymbolISA;
 
   // ISA suffix last emitted via "$x<ISA>" in the current section, and the
   // per-section history preserved across changeSection. A new mapping symbol
   // is emitted whenever LastEMS != EMS_Instructions or
-  // LastEmittedISA != CurrentISAString, so the ISA in effect at each
+  // LastEmittedISA != MappingSymbolISA, so the ISA in effect at each
   // instruction run is always recorded.
   std::string LastEmittedISA;
   DenseMap<const MCSection *, std::string> LastEmittedISAInSection;
@@ -49,7 +49,7 @@ public:
   void emitFill(const MCExpr &NumBytes, uint64_t FillValue, SMLoc Loc) override;
   void emitValueImpl(const MCExpr *Value, unsigned Size, SMLoc Loc) override;
 
-  void setCurrentISAString(StringRef Arch);
+  void setMappingSymbolISA(StringRef Arch);
 };
 
 class RISCVTargetELFStreamer : public RISCVTargetStreamer {
@@ -77,22 +77,20 @@ private:
 
   void reset() override;
 
-  // Update ISAString and propagate the change to the streamer so the next
-  // instruction-run emits an ISA-specific mapping symbol. A no-op when
-  // Arch == ISAString (deduplication).
-  void setArchString(StringRef Arch);
-
 public:
   RISCVELFStreamer &getStreamer();
   RISCVTargetELFStreamer(MCStreamer &S, const MCSubtargetInfo &STI);
 
-  void emitISAMappingSymbol(StringRef ISAString) override;
-  void emitDirectiveOptionPush() override;
-  void emitDirectiveOptionPop() override;
+  // Update ISAString and propagate the change to the streamer so the next
+  // instruction-run emits an ISA-specific mapping symbol. A no-op when
+  // Arch == ISAString (deduplication).
+  void setISAString(StringRef Arch) override;
   void emitDirectiveOptionExact() override;
   void emitDirectiveOptionNoExact() override;
   void emitDirectiveOptionPIC() override;
   void emitDirectiveOptionNoPIC() override;
+  void emitDirectiveOptionPop() override;
+  void emitDirectiveOptionPush() override;
   void emitDirectiveOptionRelax() override;
   void emitDirectiveOptionNoRelax() override;
   void emitDirectiveOptionRVC() override;

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.h
@@ -28,15 +28,15 @@ class RISCVELFStreamer : public MCELFStreamer {
 
   // Active ISA string propagated from RISCVTargetELFStreamer. When non-empty,
   // it is used as the suffix for "$x<ISA>" mapping symbols.
-  std::string MappingSymbolISA;
+  std::string MappingSymbolArch;
 
   // ISA suffix last emitted via "$x<ISA>" in the current section, and the
   // per-section history preserved across changeSection. A new mapping symbol
   // is emitted whenever LastEMS != EMS_Instructions or
-  // LastEmittedISA != MappingSymbolISA, so the ISA in effect at each
+  // LastEmittedArch != MappingSymbolArch, so the ISA in effect at each
   // instruction run is always recorded.
-  std::string LastEmittedISA;
-  DenseMap<const MCSection *, std::string> LastEmittedISAInSection;
+  std::string LastEmittedArch;
+  DenseMap<const MCSection *, std::string> LastEmittedArchInSection;
 
 public:
   RISCVELFStreamer(MCContext &C, std::unique_ptr<MCAsmBackend> MAB,
@@ -49,7 +49,7 @@ public:
   void emitFill(const MCExpr &NumBytes, uint64_t FillValue, SMLoc Loc) override;
   void emitValueImpl(const MCExpr *Value, unsigned Size, SMLoc Loc) override;
 
-  void setMappingSymbolISA(StringRef Arch);
+  void setMappingSymbolArch(StringRef Arch);
 };
 
 class RISCVTargetELFStreamer : public RISCVTargetStreamer {
@@ -58,14 +58,14 @@ private:
 
   // Initial ISA string derived from the subtarget features in the constructor.
   // Used to re-establish state on reset().
-  std::string InitialISAString;
+  std::string InitialArchString;
 
   // Current ISA string, kept in sync with each .option arch/rvc/norvc/pop
   // and .attribute arch directive. Used to avoid propagating redundant ISA
   // updates to the streamer when the ISA does not actually change (e.g.,
   // .option rvc when C is already enabled).
-  std::string ISAString;
-  SmallVector<std::string, 4> ISAStringStack;
+  std::string ArchString;
+  SmallVector<std::string, 4> ArchStringStack;
 
   MCSection *AttributeSection = nullptr;
 
@@ -81,10 +81,10 @@ public:
   RISCVELFStreamer &getStreamer();
   RISCVTargetELFStreamer(MCStreamer &S, const MCSubtargetInfo &STI);
 
-  // Update ISAString and propagate the change to the streamer so the next
+  // Update ArchString and propagate the change to the streamer so the next
   // instruction-run emits an ISA-specific mapping symbol. A no-op when
-  // Arch == ISAString (deduplication).
-  void setISAString(StringRef Arch) override;
+  // Arch == ArchString (deduplication).
+  void setArchString(StringRef Arch) override;
   void emitDirectiveOptionExact() override;
   void emitDirectiveOptionNoExact() override;
   void emitDirectiveOptionPIC() override;

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.h
@@ -52,6 +52,7 @@ public:
   virtual void emitDirectiveOptionNoRelax();
   virtual void emitDirectiveOptionRVC();
   virtual void emitDirectiveOptionNoRVC();
+  virtual void emitISAMappingSymbol(StringRef ISAString) {}
   virtual void emitDirectiveVariantCC(MCSymbol &Symbol);
   virtual void emitAttribute(unsigned Attribute, unsigned Value);
   virtual void finishAttributeSection();

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.h
@@ -52,7 +52,7 @@ public:
   virtual void emitDirectiveOptionNoRelax();
   virtual void emitDirectiveOptionRVC();
   virtual void emitDirectiveOptionNoRVC();
-  virtual void emitISAMappingSymbol(StringRef ISAString) {}
+  virtual void setISAString(StringRef Arch) {}
   virtual void emitDirectiveVariantCC(MCSymbol &Symbol);
   virtual void emitAttribute(unsigned Attribute, unsigned Value);
   virtual void finishAttributeSection();

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.h
@@ -52,7 +52,7 @@ public:
   virtual void emitDirectiveOptionNoRelax();
   virtual void emitDirectiveOptionRVC();
   virtual void emitDirectiveOptionNoRVC();
-  virtual void setISAString(StringRef Arch) {}
+  virtual void setArchString(StringRef Arch) {}
   virtual void emitDirectiveVariantCC(MCSymbol &Symbol);
   virtual void emitAttribute(unsigned Attribute, unsigned Value);
   virtual void finishAttributeSection();

--- a/llvm/test/MC/RISCV/mapping-across-sections.s
+++ b/llvm/test/MC/RISCV/mapping-across-sections.s
@@ -1,5 +1,5 @@
-# RUN: llvm-mc -triple=riscv32 -filetype=obj %s | llvm-readelf -Ss - | FileCheck %s
-# RUN: llvm-mc -triple=riscv64 -filetype=obj %s | llvm-readelf -Ss - | FileCheck %s
+# RUN: llvm-mc -triple=riscv32 -filetype=obj %s | llvm-readelf -Ss - | FileCheck %s --check-prefix=CHECK,CHECK-RV32
+# RUN: llvm-mc -triple=riscv64 -filetype=obj %s | llvm-readelf -Ss - | FileCheck %s --check-prefix=CHECK,CHECK-RV64
 
         .text
         nop
@@ -13,13 +13,14 @@
         .section .starts_data
         .word 42
 
-# Changing back to .text should not emit a redundant $x.
+# Changing back to .text should not emit a redundant $x - the active ISA
+# has not changed since the last mapping symbol emitted in .text.
         .text
         nop
 
 # With all those constraints, we want:
-#   + .text to have $x at 0 and no others
-#   + .wibble to have $x at 0
+#   + .text to have $x<ISA> at 0 and no others
+#   + .wibble to have $x<ISA> at 0 (each code section records the active ISA
 #   + .starts_data to have $d at 0
 
 ## Capture section indices.
@@ -28,6 +29,8 @@
 # CHECK: [[#STARTS_DATA:]]] .starts_data
 
 # CHECK:    Value  Size Type    Bind   Vis     Ndx              Name
-# CHECK: 00000000     0 NOTYPE  LOCAL  DEFAULT [[#TEXT]]        $x{{$}}
-# CHECK: 00000000     0 NOTYPE  LOCAL  DEFAULT [[#WIBBLE]]      $x{{$}}
+# CHECK-RV32: 00000000     0 NOTYPE  LOCAL  DEFAULT [[#TEXT]]        $xrv32i2p1{{$}}
+# CHECK-RV64: 00000000     0 NOTYPE  LOCAL  DEFAULT [[#TEXT]]        $xrv64i2p1{{$}}
+# CHECK-RV32: 00000000     0 NOTYPE  LOCAL  DEFAULT [[#WIBBLE]]      $xrv32i2p1{{$}}
+# CHECK-RV64: 00000000     0 NOTYPE  LOCAL  DEFAULT [[#WIBBLE]]      $xrv64i2p1{{$}}
 # CHECK: 00000000     0 NOTYPE  LOCAL  DEFAULT [[#STARTS_DATA]] $d{{$}}

--- a/llvm/test/MC/RISCV/mapping-isa-attribute.s
+++ b/llvm/test/MC/RISCV/mapping-isa-attribute.s
@@ -1,0 +1,17 @@
+## Test that .attribute 5 (Tag_RISCV_arch) updates the pending ISA mapping
+## symbol.  Unlike .option arch, .attribute 5 is usually placed at the top
+## of the file before any instruction is emitted, so it should *replace*
+## (not add to) the initial "$x<base-ISA>" symbol scheduled by the target
+## streamer constructor.
+
+# RUN: llvm-mc -triple=riscv64 -filetype=obj -o %t.o %s
+# RUN: llvm-readobj --symbols %t.o | FileCheck %s
+
+.attribute 5, "rv64i2p1_f2p2_d2p2_v1p0_zicsr2p0_zve32f1p0_zve32x1p0_zve64d1p0_zve64f1p0_zve64x1p0_zvl128b1p0_zvl32b1p0_zvl64b1p0"
+
+.text
+## The initial mapping symbol reflects the arch widened by .attribute, not
+## the triple-derived base.
+vsetvli a3, a2, e8, m8, tu, mu
+# CHECK: Name: $xrv64i2p1_f2p2_d2p2_v1p0_zicsr2p0_zve32f1p0_zve32x1p0_zve64d1p0_zve64f1p0_zve64x1p0_zvl128b1p0_zvl32b1p0_zvl64b1p0
+# CHECK-NEXT: Value: 0x0

--- a/llvm/test/MC/RISCV/mapping-isa-option-rv32.s
+++ b/llvm/test/MC/RISCV/mapping-isa-option-rv32.s
@@ -1,0 +1,75 @@
+## Test ISA mapping symbol emission for .option rvc/norvc/arch/push/pop on rv32.
+## The assembler emits a "$x<ISAString>" symbol when the active ISA changes,
+## using lazy emission (the symbol appears before the first instruction after
+## the change) and deduplication (no symbol when the ISA is unchanged).
+## An initial "$x<ISAString>" symbol is also emitted before the very first
+## instruction to record the starting ISA in the object file.
+
+# RUN: llvm-mc -triple=riscv32 -mattr=+f,+a -filetype=obj -o %t.o %s
+# RUN: llvm-readobj --symbols %t.o | FileCheck %s
+
+.text
+nop
+# The initial ISA mapping symbol is emitted before the first instruction.
+# CHECK: Name: $xrv32i2p1_a2p1_f2p2_zicsr2p0_zaamo1p0_zalrsc1p0
+# CHECK-NEXT: Value: 0x0
+
+# .option rvc enables C; a new symbol is emitted before the next instruction.
+.option rvc
+nop
+# CHECK: Name: $xrv32i2p1_a2p1_f2p2_c2p0_zicsr2p0_zaamo1p0_zalrsc1p0_zca1p0_zcf1p0
+# CHECK-NEXT: Value: 0x4
+
+# .option norvc disables C; a new symbol without C is emitted.
+.option norvc
+nop
+# CHECK: Name: $xrv32i2p1_a2p1_f2p2_zicsr2p0_zaamo1p0_zalrsc1p0
+# CHECK-NEXT: Value: 0x6
+
+# .option push saves the current ISA; .option arch switches to a full ISA;
+# .option pop restores the pre-push ISA and emits a new symbol for it.
+.option push
+.option arch, rv32imac
+nop
+# CHECK: Name: $xrv32i2p1_m2p0_a2p1_c2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0
+# CHECK-NEXT: Value: 0xA
+
+.option pop
+nop
+# CHECK: Name: $xrv32i2p1_a2p1_f2p2_zicsr2p0_zaamo1p0_zalrsc1p0
+# CHECK-NEXT: Value: 0xC
+
+# Deduplication: repeating the same .option arch does not emit a second symbol.
+.option arch, rv32imac
+nop
+# CHECK: Name: $xrv32i2p1_m2p0_a2p1_c2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0
+# CHECK-NEXT: Value: 0x10
+.option arch, rv32imac
+nop
+# No additional symbol expected between the two instructions above.
+# CHECK-NOT: $xrv32i2p1_m2p0_a2p1_c2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0 {{.*}}Value: 0x1[^0]
+
+# Nested push/pop: walk down to an inner ISA via two pushes with distinct
+# .option arch in between, then walk back up with two pops.  Each level must
+# emit its own mapping symbol so the stack is observable in the object.
+.option push
+.option arch, rv32im
+nop
+# CHECK: Name: $xrv32i2p1_m2p0_zmmul1p0
+# CHECK-NEXT: Value: 0x14
+
+.option push
+.option arch, rv32imc
+nop
+# CHECK: Name: $xrv32i2p1_m2p0_c2p0_zmmul1p0_zca1p0
+# CHECK-NEXT: Value: 0x18
+
+.option pop
+nop
+# CHECK: Name: $xrv32i2p1_m2p0_zmmul1p0
+# CHECK-NEXT: Value: 0x1A
+
+.option pop
+nop
+# CHECK: Name: $xrv32i2p1_m2p0_a2p1_c2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0
+# CHECK-NEXT: Value: 0x1E

--- a/llvm/test/MC/RISCV/mapping-isa-option-rv64.s
+++ b/llvm/test/MC/RISCV/mapping-isa-option-rv64.s
@@ -1,0 +1,75 @@
+## Test ISA mapping symbol emission for .option rvc/norvc/arch/push/pop on rv64.
+## The assembler emits a "$x<ISAString>" symbol when the active ISA changes,
+## using lazy emission (the symbol appears before the first instruction after
+## the change) and deduplication (no symbol when the ISA is unchanged).
+## An initial "$x<ISAString>" symbol is also emitted before the very first
+## instruction to record the starting ISA in the object file.
+
+# RUN: llvm-mc -triple=riscv64 -mattr=+f,+a -filetype=obj -o %t.o %s
+# RUN: llvm-readobj --symbols %t.o | FileCheck %s
+
+.text
+nop
+# The initial ISA mapping symbol is emitted before the first instruction.
+# CHECK: Name: $xrv64i2p1_a2p1_f2p2_zicsr2p0_zaamo1p0_zalrsc1p0
+# CHECK-NEXT: Value: 0x0
+
+# .option rvc enables C; a new symbol is emitted before the next instruction.
+.option rvc
+nop
+# CHECK: Name: $xrv64i2p1_a2p1_f2p2_c2p0_zicsr2p0_zaamo1p0_zalrsc1p0_zca1p0
+# CHECK-NEXT: Value: 0x4
+
+# .option norvc disables C; a new symbol without C is emitted.
+.option norvc
+nop
+# CHECK: Name: $xrv64i2p1_a2p1_f2p2_zicsr2p0_zaamo1p0_zalrsc1p0
+# CHECK-NEXT: Value: 0x6
+
+# .option push saves the current ISA; .option arch switches to a full ISA;
+# .option pop restores the pre-push ISA and emits a new symbol for it.
+.option push
+.option arch, rv64imac
+nop
+# CHECK: Name: $xrv64i2p1_m2p0_a2p1_c2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0
+# CHECK-NEXT: Value: 0xA
+
+.option pop
+nop
+# CHECK: Name: $xrv64i2p1_a2p1_f2p2_zicsr2p0_zaamo1p0_zalrsc1p0
+# CHECK-NEXT: Value: 0xC
+
+# Deduplication: repeating the same .option arch does not emit a second symbol.
+.option arch, rv64imac
+nop
+# CHECK: Name: $xrv64i2p1_m2p0_a2p1_c2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0
+# CHECK-NEXT: Value: 0x10
+.option arch, rv64imac
+nop
+# No additional symbol expected between the two instructions above.
+# CHECK-NOT: $xrv64i2p1_m2p0_a2p1_c2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0 {{.*}}Value: 0x1[^0]
+
+# Nested push/pop: walk down to an inner ISA via two pushes with distinct
+# .option arch in between, then walk back up with two pops.  Each level must
+# emit its own mapping symbol so the stack is observable in the object.
+.option push
+.option arch, rv64im
+nop
+# CHECK: Name: $xrv64i2p1_m2p0_zmmul1p0
+# CHECK-NEXT: Value: 0x14
+
+.option push
+.option arch, rv64imc
+nop
+# CHECK: Name: $xrv64i2p1_m2p0_c2p0_zmmul1p0_zca1p0
+# CHECK-NEXT: Value: 0x18
+
+.option pop
+nop
+# CHECK: Name: $xrv64i2p1_m2p0_zmmul1p0
+# CHECK-NEXT: Value: 0x1A
+
+.option pop
+nop
+# CHECK: Name: $xrv64i2p1_m2p0_a2p1_c2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0
+# CHECK-NEXT: Value: 0x1E

--- a/llvm/test/MC/RISCV/mapping-isa-option-rvc-dedup.s
+++ b/llvm/test/MC/RISCV/mapping-isa-option-rvc-dedup.s
@@ -1,0 +1,28 @@
+## Test deduplication of ISA mapping symbols for .option rvc when the C
+## extension is already active.  The assembler must emit only the initial
+## "$x<ISAString>" symbol because neither .option rvc nor the subsequent
+## .option arch, +c change the active ISA.
+
+# RUN: llvm-mc -triple=riscv32 -mattr=+c -filetype=obj -o %t32.o %s
+# RUN: llvm-readobj --symbols %t32.o | FileCheck %s --check-prefix=RV32
+# RUN: llvm-mc -triple=riscv64 -mattr=+c -filetype=obj -o %t64.o %s
+# RUN: llvm-readobj --symbols %t64.o | FileCheck %s --check-prefix=RV64
+
+.text
+nop
+# Initial mapping symbol records the base ISA (C already enabled via -mattr).
+# RV32: Name: $xrv32i2p1_c2p0_zca1p0
+# RV32-NEXT: Value: 0x0
+# RV64: Name: $xrv64i2p1_c2p0_zca1p0
+# RV64-NEXT: Value: 0x0
+
+.option rvc
+nop
+
+.option arch, +c
+nop
+
+# No additional "$x..." mapping symbol should be emitted after the initial one,
+# because neither .option rvc nor .option arch, +c change the active ISA.
+# RV32-NOT: Name: $x
+# RV64-NOT: Name: $x


### PR DESCRIPTION
When .option arch, .option rvc, .option norvc, or .option pop changes the active ISA, emit a "$x<ISAString>" mapping symbol before the next instruction so that tools can determine the ISA in effect for each code region.

Also emit ISA mapping symbols on begin of first instruction to make sure link with different object still can disassemble correctly.

Based on #67541