### PR TITLE
[lld-macho] Relax safe ICF's keepUnique for ld64-coalesced data sections

### DIFF
--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -453,12 +453,12 @@ void ICF::run() {
   forEachClass([&](size_t begin, size_t end) {
     if (end - begin < 2)
       return;
-    bool useSafeThunks = config->icfLevel == ICFLevel::safe_thunks;
-
     // For ICF level safe_thunks, replace keepUnique function bodies with
-    // thunks. For all other ICF levles, directly merge the functions.
+    // thunks. For all other ICF levels, directly merge the functions.
 
     ConcatInputSection *beginIsec = icfInputs[begin];
+    bool useSafeThunks =
+        config->icfLevel == ICFLevel::safe_thunks && isCodeSection(beginIsec);
     for (size_t i = begin + 1; i < end; ++i) {
       // Skip keepUnique inputs when using safe_thunks (already handled above)
       if (useSafeThunks && icfInputs[i]->keepUnique) {
@@ -583,19 +583,29 @@ void macho::foldIdenticalSections(bool onlyCfStrings) {
 
     bool isCodeSec = isCodeSection(isec);
 
-    // When keepUnique is true, the section is not foldable. Unless we are at
-    // icf level safe_thunks, in which case we still want to fold code sections.
-    // When using safe_thunks we'll apply the safe_thunks logic at merge time
-    // based on the 'keepUnique' flag.
-    bool noUniqueRequirement =
-        !isec->keepUnique ||
-        ((config->icfLevel == ICFLevel::safe_thunks) && isCodeSec);
+    // Determine whether keepUnique forbids folding this section.
+    //   - __cfstring / __objc_classrefs / __objc_selrefs always fold
+    //     regardless of keepUnique. Compilers currently emit over-broad
+    //     __llvm_addrsig entries that can cover non-address-significant data
+    //     symbols in these sections; ld64 coalesces them unconditionally, and
+    //     we match that behavior.
+    //   - Under safe_thunks, keepUnique code sections still fold; the
+    //     safe_thunks logic is applied later at merge time based on the
+    //     keepUnique flag.
+    //   - Otherwise, keepUnique sections are not foldable.
+    bool isUnconditionallyCoalescedData = isCfStringSection(isec) ||
+                                          isClassRefsSection(isec) ||
+                                          isSelRefsSection(isec);
+    bool isSafeThunksCode =
+        config->icfLevel == ICFLevel::safe_thunks && isCodeSec;
+    bool keepUniqueAllowsFolding =
+        !isec->keepUnique || isUnconditionallyCoalescedData || isSafeThunksCode;
 
     // FIXME: consider non-code __text sections as foldable?
     bool isFoldable = (!onlyCfStrings || isCfStringSection(isec)) &&
                       (isCodeSec || isFoldableWithAddendsRemoved ||
                        isGccExceptTabSection(isec)) &&
-                      noUniqueRequirement && !isec->hasAltEntry &&
+                      keepUniqueAllowsFolding && !isec->hasAltEntry &&
                       !isec->shouldOmitFromOutput() && hasFoldableFlags;
     if (isFoldable) {
       foldable.push_back(isec);

--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -593,9 +593,10 @@ void macho::foldIdenticalSections(bool onlyCfStrings) {
     //     safe_thunks logic is applied later at merge time based on the
     //     keepUnique flag.
     //   - Otherwise, keepUnique sections are not foldable.
-    bool isUnconditionallyCoalescedData = isCfStringSection(isec) ||
-                                          isClassRefsSection(isec) ||
-                                          isSelRefsSection(isec);
+    // Happens to match isFoldableWithAddendsRemoved today, but expresses a
+    // different intent (ld64's coalescing semantics, not addend stripping),
+    // so the two may diverge as either list grows.
+    bool isUnconditionallyCoalescedData = isFoldableWithAddendsRemoved;
     bool isSafeThunksCode =
         config->icfLevel == ICFLevel::safe_thunks && isCodeSec;
     bool keepUniqueAllowsFolding =

--- a/lld/test/MachO/icf-safe-data-addrsig.s
+++ b/lld/test/MachO/icf-safe-data-addrsig.s
@@ -1,0 +1,98 @@
+# REQUIRES: aarch64
+
+## Compilers currently emit over-broad __llvm_addrsig entries that also cover
+## data symbols which aren't actually address-significant. To match ld64 --
+## which coalesces __cfstring / __objc_classrefs / __objc_selrefs
+## unconditionally -- LLD deliberately disregards addrsig markings on those
+## data sections, so the duplicate _cfs2 / _cr2 / _sr2 entries must fold into
+## _cfs1 / _cr1 / _sr1 whether the compiler lists data symbols in
+## __llvm_addrsig (with-addrsig.o) or emits no __llvm_addrsig at all
+## (without-addrsig.o), and regardless of ICF level.
+
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc -I %t -filetype=obj -triple=arm64-apple-darwin %t/with-addrsig.s -o %t/with-addrsig.o
+# RUN: llvm-mc -I %t -filetype=obj -triple=arm64-apple-darwin %t/without-addrsig.s -o %t/without-addrsig.o
+# RUN: %lld -arch arm64 -lSystem --icf=safe -dylib -map %t/with-addrsig-safe.map -o %t/with-addrsig-safe.dylib %t/with-addrsig.o
+# RUN: %lld -arch arm64 -lSystem --icf=safe -dylib -map %t/without-addrsig-safe.map -o %t/without-addrsig-safe.dylib %t/without-addrsig.o
+# RUN: %lld -arch arm64 -lSystem --icf=safe_thunks -dylib -map %t/with-addrsig-safe-thunks.map -o %t/with-addrsig-thunks.dylib %t/with-addrsig.o
+# RUN: %lld -arch arm64 -lSystem --icf=safe_thunks -dylib -map %t/without-addrsig-safe-thunks.map -o %t/without-addrsig-thunks.dylib %t/without-addrsig.o
+# RUN: %lld -arch arm64 -lSystem --icf=all -dylib -map %t/with-addrsig-all.map -o %t/with-addrsig-all.dylib %t/with-addrsig.o
+# RUN: %lld -arch arm64 -lSystem --icf=all -dylib -map %t/without-addrsig-all.map -o %t/without-addrsig-all.dylib %t/without-addrsig.o
+# RUN: FileCheck %s < %t/with-addrsig-safe.map
+# RUN: FileCheck %s < %t/without-addrsig-safe.map
+# RUN: FileCheck %s < %t/with-addrsig-safe-thunks.map
+# RUN: FileCheck %s < %t/without-addrsig-safe-thunks.map
+# RUN: FileCheck %s < %t/with-addrsig-all.map
+# RUN: FileCheck %s < %t/without-addrsig-all.map
+
+# CHECK:      0x00000020 [  2] _cfs1
+# CHECK-NEXT: 0x00000000 [  2] _cfs2
+# CHECK:      0x00000008 [  2] _cr1
+# CHECK-NEXT: 0x00000000 [  2] _cr2
+# CHECK:      0x00000008 [  2] _sr1
+# CHECK-NEXT: 0x00000000 [  2] _sr2
+
+#--- common.s
+.subsections_via_symbols
+
+.section __DATA,__cfstring
+.p2align 3
+.globl _cfs1
+_cfs1:
+  .quad _class
+  .long 1992
+  .space 4
+  .quad Lstr
+  .quad 5
+.globl _cfs2
+_cfs2:
+  .quad _class
+  .long 1992
+  .space 4
+  .quad Lstr
+  .quad 5
+
+.section __TEXT,__cstring,cstring_literals
+Lstr:
+  .asciz "hi"
+
+.section __DATA,__objc_data
+.globl _class
+_class:
+  .quad 42
+
+.section __DATA,__objc_classrefs,regular,no_dead_strip
+.p2align 3
+.globl _cr1
+_cr1:
+  .quad _class
+.globl _cr2
+_cr2:
+  .quad _class
+
+.section __TEXT,__objc_methname,cstring_literals
+Lsel:
+  .asciz "msg"
+
+.section __DATA,__objc_selrefs,literal_pointers,no_dead_strip
+.p2align 3
+.globl _sr1
+_sr1:
+  .quad Lsel
+.globl _sr2
+_sr2:
+  .quad Lsel
+
+#--- with-addrsig.s
+.include "common.s"
+
+.addrsig
+.addrsig_sym _cfs1
+.addrsig_sym _cfs2
+.addrsig_sym _cr1
+.addrsig_sym _cr2
+.addrsig_sym _sr1
+.addrsig_sym _sr2
+
+#--- without-addrsig.s
+.include "common.s"

--- a/lld/test/MachO/icf-safe-data-addrsig.s
+++ b/lld/test/MachO/icf-safe-data-addrsig.s
@@ -7,30 +7,37 @@
 ## data sections, so the duplicate _cfs2 / _cr2 / _sr2 entries must fold into
 ## _cfs1 / _cr1 / _sr1 whether the compiler lists data symbols in
 ## __llvm_addrsig (with-addrsig.o) or emits no __llvm_addrsig at all
-## (without-addrsig.o), and regardless of ICF level.
+## (without-addrsig.o) when ICF is enabled. At --icf=none, only __cfstring
+## still folds (via --deduplicate-strings, which is on by default);
+## __objc_classrefs and __objc_selrefs stay unique.
 
 # RUN: rm -rf %t && split-file %s %t
 # RUN: llvm-mc -I %t -filetype=obj -triple=arm64-apple-darwin %t/with-addrsig.s -o %t/with-addrsig.o
 # RUN: llvm-mc -I %t -filetype=obj -triple=arm64-apple-darwin %t/without-addrsig.s -o %t/without-addrsig.o
-# RUN: %lld -arch arm64 -lSystem --icf=safe -dylib -map %t/with-addrsig-safe.map -o %t/with-addrsig-safe.dylib %t/with-addrsig.o
-# RUN: %lld -arch arm64 -lSystem --icf=safe -dylib -map %t/without-addrsig-safe.map -o %t/without-addrsig-safe.dylib %t/without-addrsig.o
-# RUN: %lld -arch arm64 -lSystem --icf=safe_thunks -dylib -map %t/with-addrsig-safe-thunks.map -o %t/with-addrsig-thunks.dylib %t/with-addrsig.o
-# RUN: %lld -arch arm64 -lSystem --icf=safe_thunks -dylib -map %t/without-addrsig-safe-thunks.map -o %t/without-addrsig-thunks.dylib %t/without-addrsig.o
-# RUN: %lld -arch arm64 -lSystem --icf=all -dylib -map %t/with-addrsig-all.map -o %t/with-addrsig-all.dylib %t/with-addrsig.o
-# RUN: %lld -arch arm64 -lSystem --icf=all -dylib -map %t/without-addrsig-all.map -o %t/without-addrsig-all.dylib %t/without-addrsig.o
-# RUN: FileCheck %s < %t/with-addrsig-safe.map
-# RUN: FileCheck %s < %t/without-addrsig-safe.map
-# RUN: FileCheck %s < %t/with-addrsig-safe-thunks.map
-# RUN: FileCheck %s < %t/without-addrsig-safe-thunks.map
-# RUN: FileCheck %s < %t/with-addrsig-all.map
-# RUN: FileCheck %s < %t/without-addrsig-all.map
+# RUN: %lld -arch arm64 -lSystem --icf=safe -dylib -map - -o %t/with-addrsig-safe.dylib %t/with-addrsig.o | FileCheck %s --check-prefixes=CHECK,FOLD
+# RUN: %lld -arch arm64 -lSystem --icf=safe -dylib -map - -o %t/without-addrsig-safe.dylib %t/without-addrsig.o | FileCheck %s --check-prefixes=CHECK,FOLD
+# RUN: %lld -arch arm64 -lSystem --icf=safe_thunks -dylib -map - -o %t/with-addrsig-thunks.dylib %t/with-addrsig.o | FileCheck %s --check-prefixes=CHECK,FOLD
+# RUN: %lld -arch arm64 -lSystem --icf=safe_thunks -dylib -map - -o %t/without-addrsig-thunks.dylib %t/without-addrsig.o | FileCheck %s --check-prefixes=CHECK,FOLD
+# RUN: %lld -arch arm64 -lSystem --icf=all -dylib -map - -o %t/with-addrsig-all.dylib %t/with-addrsig.o | FileCheck %s --check-prefixes=CHECK,FOLD
+# RUN: %lld -arch arm64 -lSystem --icf=all -dylib -map - -o %t/without-addrsig-all.dylib %t/without-addrsig.o | FileCheck %s --check-prefixes=CHECK,FOLD
+# RUN: %lld -arch arm64 -lSystem --icf=none -dylib -map - -o %t/with-addrsig-none.dylib %t/with-addrsig.o | FileCheck %s --check-prefixes=CHECK,NOFOLD
+# RUN: %lld -arch arm64 -lSystem --icf=none -dylib -map - -o %t/without-addrsig-none.dylib %t/without-addrsig.o | FileCheck %s --check-prefixes=CHECK,NOFOLD
 
+## __cfstring folds whenever --deduplicate-strings is on, i.e. at every ICF
+## level including --icf=none.
 # CHECK:      0x00000020 [  2] _cfs1
 # CHECK-NEXT: 0x00000000 [  2] _cfs2
-# CHECK:      0x00000008 [  2] _cr1
-# CHECK-NEXT: 0x00000000 [  2] _cr2
-# CHECK:      0x00000008 [  2] _sr1
-# CHECK-NEXT: 0x00000000 [  2] _sr2
+
+## __objc_classrefs / __objc_selrefs fold only when ICF runs.
+# FOLD:      0x00000008 [  2] _cr1
+# FOLD-NEXT: 0x00000000 [  2] _cr2
+# FOLD:      0x00000008 [  2] _sr1
+# FOLD-NEXT: 0x00000000 [  2] _sr2
+
+# NOFOLD:      0x00000008 [  2] _cr1
+# NOFOLD-NEXT: 0x00000008 [  2] _cr2
+# NOFOLD:      0x00000008 [  2] _sr1
+# NOFOLD-NEXT: 0x00000008 [  2] _sr2
 
 #--- common.s
 .subsections_via_symbols


### PR DESCRIPTION
#188400 regressed data-section folding under --icf=safe{,_thunks}: no-addrsig fallback, and over-broad compiler-emitted addrsig entries covering data symbols, both caused markSymAsAddrSig to set keepUnique on data sections, after which foldIdenticalSections refused to fold them.

ld64 coalesces __cfstring, __objc_classrefs and __objc_selrefs unconditionally regardless of addrsig, so ignore keepUnique for them as a workaround for the imprecise addrsig payload.