### PR TITLE
[BOLT] Fix stream position before appendPadding in writeEHFrameHeader

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -6435,6 +6435,7 @@ void RewriteInstance::writeEHFrameHeader() {
 
   // If there was not enough space, allocate more memory for .eh_frame_hdr.
   if (!OldEHFrameHdrSection) {
+    Out->os().seek(getFileOffsetForAddress(NextAvailableAddress));
     NextAvailableAddress =
         appendPadding(Out->os(), NextAvailableAddress, EHFrameHdrAlign);
 


### PR DESCRIPTION
When writeEHFrameHeader needs to allocate new space for .eh_frame_hdr (because the old section is too small), it calls appendPadding to align NextAvailableAddress. appendPadding writes zero bytes at the current stream position, but after the section write loop in rewriteFile the stream is positioned at the end of the last section written in BinarySection::operator< order — not at the file offset corresponding to NextAvailableAddress.

In the common case (single loadObject call) the write order matches file offset order, so the stream happens to be in the right place. But when a runtime library adds sections via additional loadObject calls, the operator< iteration order (code-before-data) can diverge from file offset order: a runtime library code section may have a higher file offset than a runtime library data section that comes after it in the write loop. The stream then ends at a lower offset than expected, and appendPadding's zeros overwrite the beginning of the code section.

Fix by seeking to the correct file offset before calling appendPadding.