### PR TITLE
[clang][modules] Fix false positive -Wweak-vtables in named modules

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -19269,7 +19269,8 @@ bool Sema::DefineUsedVTables() {
     // no key function or the key function is inlined. Don't warn in C++ ABIs
     // that lack key functions, since the user won't be able to make one.
     if (Context.getTargetInfo().getCXXABI().hasKeyFunctions() &&
-        Class->isExternallyVisible() && ClassTSK != TSK_ImplicitInstantiation &&
+        Class->isExternallyVisible() && !Class->isInCurrentModuleUnit() &&
+        ClassTSK != TSK_ImplicitInstantiation &&
         ClassTSK != TSK_ExplicitInstantiationDefinition) {
       const FunctionDecl *KeyFunctionDef = nullptr;
       if (!KeyFunction || (KeyFunction->hasBody(KeyFunctionDef) &&

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -19269,7 +19269,9 @@ bool Sema::DefineUsedVTables() {
     // no key function or the key function is inlined. Don't warn in C++ ABIs
     // that lack key functions, since the user won't be able to make one.
     if (Context.getTargetInfo().getCXXABI().hasKeyFunctions() &&
-        Class->isExternallyVisible() && !Class->isInCurrentModuleUnit() &&
+        Class->isExternallyVisible() &&
+        !(Class->getOwningModule() &&
+          Class->getOwningModule()->isInterfaceOrPartition()) &&
         ClassTSK != TSK_ImplicitInstantiation &&
         ClassTSK != TSK_ExplicitInstantiationDefinition) {
       const FunctionDecl *KeyFunctionDef = nullptr;

--- a/clang/test/SemaCXX/warn-weak-vtables.cpp
+++ b/clang/test/SemaCXX/warn-weak-vtables.cpp
@@ -1,12 +1,20 @@
-// RUN: %clang_cc1 %s -fsyntax-only -verify -triple %itanium_abi_triple -Wweak-vtables
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 %t/warn-weak-vtables.cpp -fsyntax-only -verify -triple %itanium_abi_triple -Wweak-vtables
 //
 // Check that this warning is disabled on MS ABI targets which don't have key
 // functions.
-// RUN: %clang_cc1 %s -fsyntax-only -triple %ms_abi_triple -Werror -Wweak-vtables
+// RUN: %clang_cc1 %t/warn-weak-vtables.cpp -fsyntax-only -triple %ms_abi_triple -Werror -Wweak-vtables
 //
 // -Wweak-template-vtables is deprecated but we still parse it.
-// RUN: %clang_cc1 %s -fsyntax-only -Werror -Wweak-template-vtables
+// RUN: %clang_cc1 %t/warn-weak-vtables.cpp -fsyntax-only -Werror -Wweak-template-vtables
+//
+// Test that -Wweak-vtables is not emitted for classes in named module units.
+// RUN: %clang_cc1 -std=c++20 -verify -triple %itanium_abi_triple -Wweak-vtables -emit-module-interface %t/module-weak-vtable.cpp -o %t/m.pcm
 
+//--- warn-weak-vtables.cpp
 struct A { // expected-warning {{'A' has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit}}
   virtual void f() { } 
 };
@@ -80,3 +88,15 @@ void uses_templ() {
   TemplVirt<bool> b;
   TemplVirt<long> l;
 }
+
+//--- module-weak-vtable.cpp
+// expected-no-diagnostics
+export module m;
+
+struct s {
+    virtual void f() {}
+};
+
+export struct t {
+    virtual void g() {}
+};


### PR DESCRIPTION
The -Wweak-vtables warning was incorrectly firing for classes defined in C++20 module units. This warning does not apply to module units as the vtable should be owned by the module and emitted only once.

Fixes #193004