### PR TITLE
[llvm-dwp] Improvements for the `-e <executable>` option

### DIFF
--- a/llvm/test/tools/llvm-dwp/X86/default_output_from_exec.test
+++ b/llvm/test/tools/llvm-dwp/X86/default_output_from_exec.test
@@ -17,6 +17,7 @@ RUN: ls main.dwp
 ## With multiple -e, an explicit -o is required.
 RUN: rm -f main.dwp libd.so.dwp
 RUN: not llvm-dwp -e main -e libd.so 2>&1 | FileCheck %s --check-prefix=MULTI
+MULTI: error: cannot derive a default output file name when multiple executables are specified; use -o
 RUN: not ls main.dwp
 RUN: not ls libd.so.dwp
 
@@ -26,4 +27,6 @@ RUN: llvm-dwp -e main -o explicit.dwp
 RUN: ls explicit.dwp
 RUN: not ls main.dwp
 
-MULTI: error: cannot derive a default output file name when multiple executables are specified; use -o
+## Without -o or -e, emit a "no output file" error message.
+RUN: not llvm-dwp a.dwo 2>&1 | FileCheck %s --check-prefix=NO-OUTPUT
+NO-OUTPUT: error: no output file specified (use -o or -e)

--- a/llvm/test/tools/llvm-dwp/X86/default_output_from_exec.test
+++ b/llvm/test/tools/llvm-dwp/X86/default_output_from_exec.test
@@ -1,0 +1,29 @@
+## Verify that when -o is not specified, the output file name defaults to
+## <exec>.dwp only when exactly one -e argument is provided.
+
+RUN: rm -rf %t
+RUN: mkdir %t
+RUN: cd %t
+RUN: cp %p/../Inputs/dwos_list_from_exec/a.dwo a.dwo
+RUN: cp %p/../Inputs/dwos_list_from_exec/b.dwo b.dwo
+RUN: cp %p/../Inputs/dwos_list_from_exec/d.dwo d.dwo
+RUN: cp %p/../Inputs/dwos_list_from_exec/main main
+RUN: cp %p/../Inputs/dwos_list_from_exec/libd.so libd.so
+
+## Single -e: output is <exec>.dwp.
+RUN: llvm-dwp -e main
+RUN: ls main.dwp
+
+## With multiple -e, an explicit -o is required.
+RUN: rm -f main.dwp libd.so.dwp
+RUN: not llvm-dwp -e main -e libd.so 2>&1 | FileCheck %s --check-prefix=MULTI
+RUN: not ls main.dwp
+RUN: not ls libd.so.dwp
+
+## An explicit -o still takes precedence.
+RUN: rm -f main.dwp explicit.dwp
+RUN: llvm-dwp -e main -o explicit.dwp
+RUN: ls explicit.dwp
+RUN: not ls main.dwp
+
+MULTI: error: cannot derive a default output file name when multiple executables are specified; use -o

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -194,7 +194,10 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   if (OutputFilename.empty()) {
     if (ExecFilenames.size() == 1) {
       OutputFilename = ExecFilenames[0] + ".dwp";
-    } else if (ExecFilenames.size() > 1) {
+    } else if (ExecFilenames.empty()) {
+      WithColor::error() << "no output file specified (use -o or -e)\n";
+      return 1;
+    } else {
       WithColor::error()
           << "cannot derive a default output file name when multiple "
              "executables are specified; use -o\n";

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -137,6 +137,9 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   if (Args.hasArg(OPT_help)) {
     Tbl.printHelp(llvm::outs(), "llvm-dwp [options] <input files>",
                   "merge split dwarf (.dwo) files");
+    llvm::outs()
+        << "\nIf exactly one -e option is specified and -o is omitted, the "
+           "default output file name is <executable>.dwp.\n";
     std::exit(0);
   }
 
@@ -187,6 +190,17 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
 
   for (const llvm::opt::Arg *A : Args.filtered(OPT_execFileNames))
     ExecFilenames.emplace_back(A->getValue());
+
+  if (OutputFilename.empty()) {
+    if (ExecFilenames.size() == 1) {
+      OutputFilename = ExecFilenames[0] + ".dwp";
+    } else if (ExecFilenames.size() > 1) {
+      WithColor::error()
+          << "cannot derive a default output file name when multiple "
+             "executables are specified; use -o\n";
+      return 1;
+    }
+  }
 
   std::vector<std::string> DWOFilenames;
   for (const llvm::opt::Arg *A : Args.filtered(OPT_INPUT))


### PR DESCRIPTION
I was trying to use llvm-dwp and got a bit confused, so here are two small usability fixes.