### PR TITLE
[clang][docs] open details of C++{17,14,11} implementation by default

### DIFF
--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -1078,7 +1078,7 @@ C++23, informally referred to as C++26.</p>
 You can use Clang in C++17 mode with the <code>-std=c++17</code> option
 (use <code>-std=c++1z</code> in Clang 4 and earlier).</p>
 
-<details>
+<details open>
 <summary>List of features and minimum Clang version with support</summary>
 
 <table width="689" border="1" cellspacing="0">
@@ -1342,7 +1342,7 @@ In Clang 21, the flag was removed altogether.
 <p>You can use Clang in C++14 mode with the <code>-std=c++14</code> option
 (use <code>-std=c++1y</code> in Clang 3.4 and earlier).</p>
 
-<details>
+<details open>
 <summary>List of features and minimum Clang version with support</summary>
 
 <table width="689" border="1" cellspacing="0">
@@ -1437,7 +1437,7 @@ In Clang 21, the flag was removed altogether.
 option. Clang's C++11 mode can be used with
 <a href="https://libcxx.llvm.org/">libc++</a> or with gcc's libstdc++.</p>
 
-<details>
+<details open>
 <summary>List of features and minimum Clang version with support</summary>
 
 <table width="689" border="1" cellspacing="0">


### PR DESCRIPTION
Before https://github.com/llvm/llvm-project/commit/b9c0e590f1fd4ea37da5c2b9b78d8e715c885f56 switched the C++ status page to a reverse chronological order, it made sense to avoid wasting vertical space for already-implemented standards. After that switch, it would make sense however to unfold them by default.

This is for example why I had opened #61426, because CRTL+F did not show P0588 on the status page[^1]. But not just for this paper, I think the ease of finding papers is a good argument for folding out those tables.

[^1]: together with the fact that other status pages ([example](https://en.cppreference.com/cpp/compiler_support/20)) have sorted this paper under C++20 rather than C++11.