### PR TITLE
[AMDGPU] Unmark wave reduce intrinsics for constant folding

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -1791,11 +1791,8 @@ bool llvm::canConstantFoldCallTo(const CallBase *Call, const Function *F) {
   case Intrinsic::amdgcn_wave_reduce_umax:
   case Intrinsic::amdgcn_wave_reduce_max:
   case Intrinsic::amdgcn_wave_reduce_min:
-  case Intrinsic::amdgcn_wave_reduce_add:
-  case Intrinsic::amdgcn_wave_reduce_sub:
   case Intrinsic::amdgcn_wave_reduce_and:
   case Intrinsic::amdgcn_wave_reduce_or:
-  case Intrinsic::amdgcn_wave_reduce_xor:
   case Intrinsic::amdgcn_s_wqm:
   case Intrinsic::amdgcn_s_quadmask:
   case Intrinsic::amdgcn_s_bitreplicate:
@@ -3833,11 +3830,8 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
     case Intrinsic::amdgcn_wave_reduce_umax:
     case Intrinsic::amdgcn_wave_reduce_max:
     case Intrinsic::amdgcn_wave_reduce_min:
-    case Intrinsic::amdgcn_wave_reduce_add:
-    case Intrinsic::amdgcn_wave_reduce_sub:
     case Intrinsic::amdgcn_wave_reduce_and:
     case Intrinsic::amdgcn_wave_reduce_or:
-    case Intrinsic::amdgcn_wave_reduce_xor:
       return Operands[0];
     }
 

--- a/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/wave.reduce.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/wave.reduce.ll
@@ -245,7 +245,8 @@ declare i64 @llvm.amdgcn.wave.reduce.add.i64(i64, i32 immarg)
 define amdgpu_kernel void @test_constant_fold_wave_reduce_add_i32_poison(ptr addrspace(1) %out, i32 %in) {
 ; CHECK-LABEL: @test_constant_fold_wave_reduce_add_i32_poison(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i32 poison, ptr addrspace(1) [[OUT:%.*]], align 4
+; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @llvm.amdgcn.wave.reduce.add.i32(i32 poison, i32 1)
+; CHECK-NEXT:    store i32 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -257,7 +258,8 @@ entry:
 define amdgpu_kernel void @test_constant_fold_wave_reduce_add_i32_const(ptr addrspace(1) %out) {
 ; CHECK-LABEL: @test_constant_fold_wave_reduce_add_i32_const(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i32 123, ptr addrspace(1) [[OUT:%.*]], align 4
+; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @llvm.amdgcn.wave.reduce.add.i32(i32 123, i32 1)
+; CHECK-NEXT:    store i32 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -269,7 +271,8 @@ entry:
 define amdgpu_kernel void @test_constant_fold_wave_reduce_add_i64_poison(ptr addrspace(1) %out, i64 %in) {
 ; CHECK-LABEL: @test_constant_fold_wave_reduce_add_i64_poison(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i64 poison, ptr addrspace(1) [[OUT:%.*]], align 4
+; CHECK-NEXT:    [[RESULT:%.*]] = call i64 @llvm.amdgcn.wave.reduce.add.i64(i64 poison, i32 1)
+; CHECK-NEXT:    store i64 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -281,7 +284,8 @@ entry:
 define amdgpu_kernel void @test_constant_fold_wave_reduce_add_i64_const(ptr addrspace(1) %out) {
 ; CHECK-LABEL: @test_constant_fold_wave_reduce_add_i64_const(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i64 123, ptr addrspace(1) [[OUT:%.*]], align 4
+; CHECK-NEXT:    [[RESULT:%.*]] = call i64 @llvm.amdgcn.wave.reduce.add.i64(i64 123, i32 1)
+; CHECK-NEXT:    store i64 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -300,7 +304,8 @@ declare i64 @llvm.amdgcn.wave.reduce.sub.i64(i64, i32 immarg)
 define amdgpu_kernel void @test_constant_fold_wave_reduce_sub_i32_poison(ptr addrspace(1) %out, i32 %in) {
 ; CHECK-LABEL: @test_constant_fold_wave_reduce_sub_i32_poison(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i32 poison, ptr addrspace(1) [[OUT:%.*]], align 4
+; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @llvm.amdgcn.wave.reduce.sub.i32(i32 poison, i32 1)
+; CHECK-NEXT:    store i32 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -312,7 +317,8 @@ entry:
 define amdgpu_kernel void @test_constant_fold_wave_reduce_sub_i32_const(ptr addrspace(1) %out) {
 ; CHECK-LABEL: @test_constant_fold_wave_reduce_sub_i32_const(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i32 123, ptr addrspace(1) [[OUT:%.*]], align 4
+; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @llvm.amdgcn.wave.reduce.sub.i32(i32 123, i32 1)
+; CHECK-NEXT:    store i32 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -324,7 +330,8 @@ entry:
 define amdgpu_kernel void @test_constant_fold_wave_reduce_sub_i64_poison(ptr addrspace(1) %out, i64 %in) {
 ; CHECK-LABEL: @test_constant_fold_wave_reduce_sub_i64_poison(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i64 poison, ptr addrspace(1) [[OUT:%.*]], align 4
+; CHECK-NEXT:    [[RESULT:%.*]] = call i64 @llvm.amdgcn.wave.reduce.sub.i64(i64 poison, i32 1)
+; CHECK-NEXT:    store i64 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -336,7 +343,8 @@ entry:
 define amdgpu_kernel void @test_constant_fold_wave_reduce_sub_i64_const(ptr addrspace(1) %out) {
 ; CHECK-LABEL: @test_constant_fold_wave_reduce_sub_i64_const(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i64 123, ptr addrspace(1) [[OUT:%.*]], align 4
+; CHECK-NEXT:    [[RESULT:%.*]] = call i64 @llvm.amdgcn.wave.reduce.sub.i64(i64 123, i32 1)
+; CHECK-NEXT:    store i64 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -465,7 +473,8 @@ declare i64 @llvm.amdgcn.wave.reduce.xor.i64(i64, i32 immarg)
 define amdgpu_kernel void @test_constant_fold_wave_reduce_xor_i32_poison(ptr addrspace(1) %out, i32 %in) {
 ; CHECK-LABEL: @test_constant_fold_wave_reduce_xor_i32_poison(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i32 poison, ptr addrspace(1) [[OUT:%.*]], align 4
+; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @llvm.amdgcn.wave.reduce.xor.i32(i32 poison, i32 1)
+; CHECK-NEXT:    store i32 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -477,7 +486,8 @@ entry:
 define amdgpu_kernel void @test_constant_fold_wave_reduce_xor_i32_const(ptr addrspace(1) %out) {
 ; CHECK-LABEL: @test_constant_fold_wave_reduce_xor_i32_const(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i32 123, ptr addrspace(1) [[OUT:%.*]], align 4
+; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @llvm.amdgcn.wave.reduce.xor.i32(i32 123, i32 1)
+; CHECK-NEXT:    store i32 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -489,7 +499,8 @@ entry:
 define amdgpu_kernel void @test_constant_fold_wave_reduce_xor_i64_poison(ptr addrspace(1) %out, i64 %in) {
 ; CHECK-LABEL: @test_constant_fold_wave_reduce_xor_i64_poison(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i64 poison, ptr addrspace(1) [[OUT:%.*]], align 4
+; CHECK-NEXT:    [[RESULT:%.*]] = call i64 @llvm.amdgcn.wave.reduce.xor.i64(i64 poison, i32 1)
+; CHECK-NEXT:    store i64 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -501,7 +512,8 @@ entry:
 define amdgpu_kernel void @test_constant_fold_wave_reduce_xor_i64_const(ptr addrspace(1) %out) {
 ; CHECK-LABEL: @test_constant_fold_wave_reduce_xor_i64_const(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i64 123, ptr addrspace(1) [[OUT:%.*]], align 4
+; CHECK-NEXT:    [[RESULT:%.*]] = call i64 @llvm.amdgcn.wave.reduce.xor.i64(i64 123, i32 1)
+; CHECK-NEXT:    store i64 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:

--- a/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/wave.reduce.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/AMDGPU/wave.reduce.ll
@@ -238,12 +238,13 @@ entry:
 ; --------------------------------------------------------------------
 ; llvm.amdgcn.wave.reduce.add
 ; --------------------------------------------------------------------
-
+; add reduction requires multiplying the constant by number of active
+; lanes, so we can't fold in the constant.
 declare i32 @llvm.amdgcn.wave.reduce.add.i32(i32, i32 immarg)
 declare i64 @llvm.amdgcn.wave.reduce.add.i64(i64, i32 immarg)
 
-define amdgpu_kernel void @test_constant_fold_wave_reduce_add_i32_poison(ptr addrspace(1) %out, i32 %in) {
-; CHECK-LABEL: @test_constant_fold_wave_reduce_add_i32_poison(
+define amdgpu_kernel void @test_no_fold_wave_reduce_add_i32_poison(ptr addrspace(1) %out, i32 %in) {
+; CHECK-LABEL: @test_no_fold_wave_reduce_add_i32_poison(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @llvm.amdgcn.wave.reduce.add.i32(i32 poison, i32 1)
 ; CHECK-NEXT:    store i32 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
@@ -255,8 +256,8 @@ entry:
   ret void
 }
 
-define amdgpu_kernel void @test_constant_fold_wave_reduce_add_i32_const(ptr addrspace(1) %out) {
-; CHECK-LABEL: @test_constant_fold_wave_reduce_add_i32_const(
+define amdgpu_kernel void @test_no_fold_wave_reduce_add_i32_const(ptr addrspace(1) %out) {
+; CHECK-LABEL: @test_no_fold_wave_reduce_add_i32_const(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @llvm.amdgcn.wave.reduce.add.i32(i32 123, i32 1)
 ; CHECK-NEXT:    store i32 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
@@ -268,8 +269,8 @@ entry:
   ret void
 }
 
-define amdgpu_kernel void @test_constant_fold_wave_reduce_add_i64_poison(ptr addrspace(1) %out, i64 %in) {
-; CHECK-LABEL: @test_constant_fold_wave_reduce_add_i64_poison(
+define amdgpu_kernel void @test_no_fold_wave_reduce_add_i64_poison(ptr addrspace(1) %out, i64 %in) {
+; CHECK-LABEL: @test_no_fold_wave_reduce_add_i64_poison(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call i64 @llvm.amdgcn.wave.reduce.add.i64(i64 poison, i32 1)
 ; CHECK-NEXT:    store i64 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
@@ -281,8 +282,8 @@ entry:
   ret void
 }
 
-define amdgpu_kernel void @test_constant_fold_wave_reduce_add_i64_const(ptr addrspace(1) %out) {
-; CHECK-LABEL: @test_constant_fold_wave_reduce_add_i64_const(
+define amdgpu_kernel void @test_no_fold_wave_reduce_add_i64_const(ptr addrspace(1) %out) {
+; CHECK-LABEL: @test_no_fold_wave_reduce_add_i64_const(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call i64 @llvm.amdgcn.wave.reduce.add.i64(i64 123, i32 1)
 ; CHECK-NEXT:    store i64 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
@@ -297,12 +298,13 @@ entry:
 ; --------------------------------------------------------------------
 ; llvm.amdgcn.wave.reduce.sub
 ; --------------------------------------------------------------------
-
+; sub reduction requires multiplying the constant by number of active
+; lanes, so we can't fold in the constant.
 declare i32 @llvm.amdgcn.wave.reduce.sub.i32(i32, i32 immarg)
 declare i64 @llvm.amdgcn.wave.reduce.sub.i64(i64, i32 immarg)
 
-define amdgpu_kernel void @test_constant_fold_wave_reduce_sub_i32_poison(ptr addrspace(1) %out, i32 %in) {
-; CHECK-LABEL: @test_constant_fold_wave_reduce_sub_i32_poison(
+define amdgpu_kernel void @test_no_fold_wave_reduce_sub_i32_poison(ptr addrspace(1) %out, i32 %in) {
+; CHECK-LABEL: @test_no_fold_wave_reduce_sub_i32_poison(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @llvm.amdgcn.wave.reduce.sub.i32(i32 poison, i32 1)
 ; CHECK-NEXT:    store i32 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
@@ -314,8 +316,8 @@ entry:
   ret void
 }
 
-define amdgpu_kernel void @test_constant_fold_wave_reduce_sub_i32_const(ptr addrspace(1) %out) {
-; CHECK-LABEL: @test_constant_fold_wave_reduce_sub_i32_const(
+define amdgpu_kernel void @test_no_fold_wave_reduce_sub_i32_const(ptr addrspace(1) %out) {
+; CHECK-LABEL: @test_no_fold_wave_reduce_sub_i32_const(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @llvm.amdgcn.wave.reduce.sub.i32(i32 123, i32 1)
 ; CHECK-NEXT:    store i32 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
@@ -327,8 +329,8 @@ entry:
   ret void
 }
 
-define amdgpu_kernel void @test_constant_fold_wave_reduce_sub_i64_poison(ptr addrspace(1) %out, i64 %in) {
-; CHECK-LABEL: @test_constant_fold_wave_reduce_sub_i64_poison(
+define amdgpu_kernel void @test_no_fold_wave_reduce_sub_i64_poison(ptr addrspace(1) %out, i64 %in) {
+; CHECK-LABEL: @test_no_fold_wave_reduce_sub_i64_poison(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call i64 @llvm.amdgcn.wave.reduce.sub.i64(i64 poison, i32 1)
 ; CHECK-NEXT:    store i64 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
@@ -340,8 +342,8 @@ entry:
   ret void
 }
 
-define amdgpu_kernel void @test_constant_fold_wave_reduce_sub_i64_const(ptr addrspace(1) %out) {
-; CHECK-LABEL: @test_constant_fold_wave_reduce_sub_i64_const(
+define amdgpu_kernel void @test_no_fold_wave_reduce_sub_i64_const(ptr addrspace(1) %out) {
+; CHECK-LABEL: @test_no_fold_wave_reduce_sub_i64_const(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call i64 @llvm.amdgcn.wave.reduce.sub.i64(i64 123, i32 1)
 ; CHECK-NEXT:    store i64 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
@@ -466,12 +468,13 @@ entry:
 ; --------------------------------------------------------------------
 ; llvm.amdgcn.wave.reduce.xor
 ; --------------------------------------------------------------------
-
+; xor reduction requires multiplying the constant by the parity of the
+; number of active lanes, so we can't fold in the constant.
 declare i32 @llvm.amdgcn.wave.reduce.xor.i32(i32, i32 immarg)
 declare i64 @llvm.amdgcn.wave.reduce.xor.i64(i64, i32 immarg)
 
-define amdgpu_kernel void @test_constant_fold_wave_reduce_xor_i32_poison(ptr addrspace(1) %out, i32 %in) {
-; CHECK-LABEL: @test_constant_fold_wave_reduce_xor_i32_poison(
+define amdgpu_kernel void @test_no_fold_wave_reduce_xor_i32_poison(ptr addrspace(1) %out, i32 %in) {
+; CHECK-LABEL: @test_no_fold_wave_reduce_xor_i32_poison(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @llvm.amdgcn.wave.reduce.xor.i32(i32 poison, i32 1)
 ; CHECK-NEXT:    store i32 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
@@ -483,8 +486,8 @@ entry:
   ret void
 }
 
-define amdgpu_kernel void @test_constant_fold_wave_reduce_xor_i32_const(ptr addrspace(1) %out) {
-; CHECK-LABEL: @test_constant_fold_wave_reduce_xor_i32_const(
+define amdgpu_kernel void @test_no_fold_wave_reduce_xor_i32_const(ptr addrspace(1) %out) {
+; CHECK-LABEL: @test_no_fold_wave_reduce_xor_i32_const(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @llvm.amdgcn.wave.reduce.xor.i32(i32 123, i32 1)
 ; CHECK-NEXT:    store i32 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
@@ -496,8 +499,8 @@ entry:
   ret void
 }
 
-define amdgpu_kernel void @test_constant_fold_wave_reduce_xor_i64_poison(ptr addrspace(1) %out, i64 %in) {
-; CHECK-LABEL: @test_constant_fold_wave_reduce_xor_i64_poison(
+define amdgpu_kernel void @test_no_fold_wave_reduce_xor_i64_poison(ptr addrspace(1) %out, i64 %in) {
+; CHECK-LABEL: @test_no_fold_wave_reduce_xor_i64_poison(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call i64 @llvm.amdgcn.wave.reduce.xor.i64(i64 poison, i32 1)
 ; CHECK-NEXT:    store i64 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4
@@ -509,8 +512,8 @@ entry:
   ret void
 }
 
-define amdgpu_kernel void @test_constant_fold_wave_reduce_xor_i64_const(ptr addrspace(1) %out) {
-; CHECK-LABEL: @test_constant_fold_wave_reduce_xor_i64_const(
+define amdgpu_kernel void @test_no_fold_wave_reduce_xor_i64_const(ptr addrspace(1) %out) {
+; CHECK-LABEL: @test_no_fold_wave_reduce_xor_i64_const(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[RESULT:%.*]] = call i64 @llvm.amdgcn.wave.reduce.xor.i64(i64 123, i32 1)
 ; CHECK-NEXT:    store i64 [[RESULT]], ptr addrspace(1) [[OUT:%.*]], align 4


### PR DESCRIPTION
The `add`, `sub`, and `xor` wave reduction intrinsics
cannot be constant folded, as `add` and `sub` need
to be multipled by the number of active lanes, and
`xor` depends on the parity of the number of
active lanes.