### PR TITLE
[clang][test] Fix test failures when LLVM_WINDOWS_PREFER_FORWARD_SLAS…

### DIFF
--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -576,6 +576,30 @@ opt<bool> ExperimentalModulesSupport{
 /// C:\clangd-test\a.cpp on Windows and /clangd-test/a.cpp on Unix.
 class TestScheme : public URIScheme {
 public:
+  llvm::Expected<URI>
+  uriFromAbsolutePath(llvm::StringRef AbsolutePath) const override {
+    llvm::StringRef Body = AbsolutePath;
+    if (!Body.consume_front(getTestDir()))
+      return error("Path {0} doesn't start with root {1}", AbsolutePath,
+                   getTestDir());
+
+    return URI("test", /*Authority=*/"",
+               llvm::sys::path::convert_to_slash(Body));
+  }
+
+  static llvm::StringRef getTestDir() {
+#ifdef _WIN32
+    static const std::string TestDir = []() {
+      llvm::SmallString<32> Path("C:/clangd-test");
+      llvm::sys::path::native(Path);
+      return std::string(Path.str());
+    }();
+    return TestDir;
+#else
+    return "/clangd-test";
+#endif
+  }
+
   llvm::Expected<std::string>
   getAbsolutePath(llvm::StringRef /*Authority*/, llvm::StringRef Body,
                   llvm::StringRef /*HintPath*/) const override {
@@ -589,30 +613,10 @@ public:
     Body = Body.ltrim('/');
     llvm::SmallString<16> Path(Body);
     path::native(Path);
-    path::make_absolute(TestScheme::TestDir, Path);
+    path::make_absolute(getTestDir(), Path);
     return std::string(Path);
   }
-
-  llvm::Expected<URI>
-  uriFromAbsolutePath(llvm::StringRef AbsolutePath) const override {
-    llvm::StringRef Body = AbsolutePath;
-    if (!Body.consume_front(TestScheme::TestDir))
-      return error("Path {0} doesn't start with root {1}", AbsolutePath,
-                   TestDir);
-
-    return URI("test", /*Authority=*/"",
-               llvm::sys::path::convert_to_slash(Body));
-  }
-
-private:
-  const static char TestDir[];
 };
-
-#ifdef _WIN32
-const char TestScheme::TestDir[] = "C:\\clangd-test";
-#else
-const char TestScheme::TestDir[] = "/clangd-test";
-#endif
 
 std::unique_ptr<SymbolIndex>
 loadExternalIndex(const Config::ExternalIndexSpec &External,

--- a/clang-tools-extra/clangd/unittests/TestFS.cpp
+++ b/clang-tools-extra/clangd/unittests/TestFS.cpp
@@ -84,7 +84,14 @@ MockCompilationDatabase::getCompileCommand(PathRef File) const {
 
 const char *testRoot() {
 #ifdef _WIN32
-  return "C:\\clangd-test";
+  // We use a static SmallString to hold the native path, as testRoot() returns
+  // a const char *.
+  static llvm::SmallString<32> Root = []() {
+    llvm::SmallString<32> Path("C:/clangd-test");
+    llvm::sys::path::native(Path);
+    return Path;
+  }();
+  return Root.c_str();
 #else
   return "/clangd-test";
 #endif

--- a/clang-tools-extra/clangd/unittests/URITests.cpp
+++ b/clang-tools-extra/clangd/unittests/URITests.cpp
@@ -133,8 +133,14 @@ TEST(URITest, ParseFailed) {
 
 TEST(URITest, Resolve) {
 #ifdef _WIN32
-  EXPECT_THAT(resolveOrDie(parseOrDie("file:///c%3a/x/y/z")), "c:\\x\\y\\z");
-  EXPECT_THAT(resolveOrDie(parseOrDie("file:///c:/x/y/z")), "c:\\x\\y\\z");
+  // Expected path style depends on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+  auto Native = [](llvm::StringRef Path) {
+    llvm::SmallString<32> NativePath(Path);
+    llvm::sys::path::native(NativePath);
+    return std::string(NativePath.str());
+  };
+  EXPECT_THAT(resolveOrDie(parseOrDie("file:///c%3a/x/y/z")), Native("c:/x/y/z"));
+  EXPECT_THAT(resolveOrDie(parseOrDie("file:///c:/x/y/z")), Native("c:/x/y/z"));
 #else
   EXPECT_EQ(resolveOrDie(parseOrDie("file:/a/b/c")), "/a/b/c");
   EXPECT_EQ(resolveOrDie(parseOrDie("file://auth/a/b/c")), "//auth/a/b/c");
@@ -148,13 +154,19 @@ TEST(URITest, Resolve) {
 
 TEST(URITest, ResolveUNC) {
 #ifdef _WIN32
+  // Expected path style depends on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+  auto Native = [](llvm::StringRef Path) {
+    llvm::SmallString<32> NativePath(Path);
+    llvm::sys::path::native(NativePath);
+    return std::string(NativePath.str());
+  };
   EXPECT_THAT(resolveOrDie(parseOrDie("file://example.com/x/y/z")),
-              "\\\\example.com\\x\\y\\z");
+              Native("//example.com/x/y/z"));
   EXPECT_THAT(resolveOrDie(parseOrDie("file://127.0.0.1/x/y/z")),
-              "\\\\127.0.0.1\\x\\y\\z");
+              Native("//127.0.0.1/x/y/z"));
   // Ensure non-traditional file URI still resolves to correct UNC path.
   EXPECT_THAT(resolveOrDie(parseOrDie("file:////127.0.0.1/x/y/z")),
-              "\\\\127.0.0.1\\x\\y\\z");
+              Native("//127.0.0.1/x/y/z"));
 #else
   EXPECT_THAT(resolveOrDie(parseOrDie("file://example.com/x/y/z")),
               "//example.com/x/y/z");

--- a/clang/test/DebugInfo/Generic/debug-prefix-map.c
+++ b/clang/test/DebugInfo/Generic/debug-prefix-map.c
@@ -27,27 +27,29 @@ void test_rewrite_includes(void) {
   vprintf("string", argp);
 }
 
-// CHECK-NO-MAIN-FILE-NAME: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}{{.*}}",
+// Forward or backward slashes can be used depending on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+// CHECK-NO-MAIN-FILE-NAME: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}{{.*}}",
 // CHECK-NO-MAIN-FILE-NAME-SAME:    directory: "")
-// CHECK-NO-MAIN-FILE-NAME: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}<stdin>",
-// CHECK-NO-MAIN-FILE-NAME: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}Inputs{{/|\\\\}}stdio.h",
+// CHECK-NO-MAIN-FILE-NAME: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}<stdin>",
+// CHECK-NO-MAIN-FILE-NAME: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}Inputs{{/|\\\\}}stdio.h",
 // CHECK-NO-MAIN-FILE-NAME-SAME:    directory: "")
 // CHECK-NO-MAIN-FILE-NAME-NOT: !DIFile(filename:
 
-// CHECK-EVIL: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH=empty{{/|\\\\}}{{.*}}"
-// CHECK-EVIL: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH=empty{{/|\\\\}}{{.*}}Inputs{{/|\\\\}}stdio.h",
+// CHECK-EVIL: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH=empty{{/|\\\\}}{{.*}}"
+// CHECK-EVIL: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH=empty{{/|\\\\}}{{.*}}Inputs{{/|\\\\}}stdio.h",
 // CHECK-EVIL-SAME:    directory: "")
 // CHECK-EVIL-NOT: !DIFile(filename:
 
-// CHECK: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}{{.*}}",
-// CHECK: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}{{.*}}Inputs{{/|\\\\}}stdio.h",
+// CHECK: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}{{.*}}",
+// CHECK: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}{{.*}}Inputs{{/|\\\\}}stdio.h",
 // CHECK-SAME:    directory: ""
 // CHECK-NOT: !DIFile(filename:
 
-// CHECK-COMPILATION-DIR: !DIFile(filename: "{{.*}}", directory: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty")
-// CHECK-COMPILATION-DIR: !DIFile(filename: "{{.*}}Inputs{{/|\\\\}}stdio.h", directory: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty")
+// CHECK-COMPILATION-DIR: !DIFile(filename: "{{.*}}", directory: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty")
+// CHECK-COMPILATION-DIR: !DIFile(filename: "{{.*}}Inputs{{/|\\\\}}stdio.h", directory: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty")
 // CHECK-COMPILATION-DIR-NOT: !DIFile(filename:
-// CHECK-SYSROOT: !DICompileUnit({{.*}}sysroot: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty"
+// CHECK-SYSROOT: !DICompileUnit({{.*}}sysroot: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty"
+
 
 // CHECK-REL: !DIFile(filename: "./UNLIKELY_PATH/empty{{/|\\\\}}{{.*}}",
 // CHECK-REL: !DIFile(filename: "./UNLIKELY_PATH/empty{{/|\\\\}}{{.*}}Inputs/stdio.h",

--- a/clang/test/Driver/ps4-ps5-linker-win.c
+++ b/clang/test/Driver/ps4-ps5-linker-win.c
@@ -16,8 +16,9 @@
 // RUN: env "PATH=%t;%PATH%;" %clang -target x86_64-sie-ps5  %s -shared -### 2>&1 \
 // RUN:   | FileCheck --check-prefixes=CHECK-PS5-LINKER,SHARED %s
 
-// CHECK-PS4-LINKER: \\orbis-ld
-// CHECK-PS5-LINKER: \\prospero-lld
+// Forward or backward slashes can be used depending on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+// CHECK-PS4-LINKER: {{/|\\\\}}orbis-ld
+// CHECK-PS5-LINKER: {{/|\\\\}}prospero-lld
 // SHARED: "--shared"
 
 // RUN: env "PATH=%t;%PATH%;" not %clang --target=x86_64-scei-ps4 %s -fuse-ld=gold -### 2>&1 \

--- a/clang/test/Frontend/absolute-paths-windows.test
+++ b/clang/test/Frontend/absolute-paths-windows.test
@@ -1,9 +1,12 @@
 // REQUIRES: system-windows
 // RUN: rm -rf %t.dir
 // RUN: mkdir -p %t.dir\real
-// RUN: cmd /c mklink /j %t.dir\junc %t.dir\real
+// When LLVM_WINDOWS_PREFER_FORWARD_SLASH is on, %t.dir contains forward slashes.
+// mklink /j does not support forward slashes.
+// Use python to replace forward slashes with backslashes and call mklink.
+// RUN: %python -c "import subprocess; p1 = r'%t.dir/junc'.replace('/', '\\\\'); p2 = r'%t.dir/real'.replace('/', '\\\\'); subprocess.run(['cmd', '/c', 'mklink', '/j', p1, p2], check=True)"
 // RUN: echo "wrong code" > %t.dir\real\foo.cpp
 // RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-absolute-paths %t.dir\junc\foo.cpp 2>&1 | FileCheck %s
 
-// CHECK-NOT: .dir\real\foo.cpp
-// CHECK: .dir\junc\foo.cpp
+// CHECK-NOT: .dir{{[/\\]}}real{{[/\\]}}foo.cpp
+// CHECK: .dir{{[/\\]}}junc{{[/\\]}}foo.cpp

--- a/clang/test/Frontend/dependency-gen-windows-duplicates.c
+++ b/clang/test/Frontend/dependency-gen-windows-duplicates.c
@@ -8,8 +8,9 @@
 
 // RUN: %clang -MD -MF - %t.dir/test.c -fsyntax-only -I %t.dir/subdir | FileCheck %s
 // CHECK: test.o:
-// CHECK-NEXT: \test.c
-// CHECK-NEXT: \SubDir\X.h
+// Forward or backward slashes can be used depending on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+// CHECK-NEXT: {{[/\\]}}test.c \
+// CHECK-NEXT: {{[/\\]}}SubDir{{[/\\]}}X.h
 // File x.h must appear only once (case insensitive check).
 // CHECK-NOT: {{\\|/}}{{x|X}}.{{h|H}}
 

--- a/clang/test/Preprocessor/file_test_windows.c
+++ b/clang/test/Preprocessor/file_test_windows.c
@@ -24,19 +24,20 @@
 filename: __FILE__
 #include "Inputs/include-file-test/file_test.h"
 
-// CHECK: filename: "A:\\UNLIKELY_PATH\\empty\\file_test_windows.c"
-// CHECK: filename: "A:\\UNLIKELY_PATH\\empty\\Inputs/include-file-test/file_test.h"
-// CHECK: basefile: "A:\\UNLIKELY_PATH\\empty\\file_test_windows.c"
+// Forward or backward slashes can be used depending on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+// CHECK: filename: "A:{{[/\\]+}}UNLIKELY_PATH{{[/\\]+}}empty{{[/\\]+}}file_test_windows.c"
+// CHECK: filename: "A:{{[/\\]+}}UNLIKELY_PATH{{[/\\]+}}empty{{[/\\]+}}Inputs/include-file-test/file_test.h"
+// CHECK: basefile: "A:{{[/\\]+}}UNLIKELY_PATH{{[/\\]+}}empty{{[/\\]+}}file_test_windows.c"
 // CHECK-NOT: filename:
 
-// CHECK-EVIL: filename: "A:\\UNLIKELY_PATH=empty\\file_test_windows.c"
-// CHECK-EVIL: filename: "A:\\UNLIKELY_PATH=empty\\Inputs/include-file-test/file_test.h"
-// CHECK-EVIL: basefile: "A:\\UNLIKELY_PATH=empty\\file_test_windows.c"
+// CHECK-EVIL: filename: "A:{{[/\\]+}}UNLIKELY_PATH=empty{{[/\\]+}}file_test_windows.c"
+// CHECK-EVIL: filename: "A:{{[/\\]+}}UNLIKELY_PATH=empty{{[/\\]+}}Inputs/include-file-test/file_test.h"
+// CHECK-EVIL: basefile: "A:{{[/\\]+}}UNLIKELY_PATH=empty{{[/\\]+}}file_test_windows.c"
 // CHECK-EVIL-NOT: filename:
 
-// CHECK-CASE: filename: "A:\\UNLIKELY_PATH_BASE\\file_test_windows.c"
-// CHECK-CASE: filename: "A:\\UNLIKELY_PATH_INC\\include-file-test/file_test.h"
-// CHECK-CASE: basefile: "A:\\UNLIKELY_PATH_BASE\\file_test_windows.c"
+// CHECK-CASE: filename: "A:{{[/\\]+}}UNLIKELY_PATH_BASE{{[/\\]+}}file_test_windows.c"
+// CHECK-CASE: filename: "A:{{[/\\]+}}UNLIKELY_PATH_INC{{[/\\]+}}include-file-test/file_test.h"
+// CHECK-CASE: basefile: "A:{{[/\\]+}}UNLIKELY_PATH_BASE{{[/\\]+}}file_test_windows.c"
 // CHECK-CASE-NOT: filename:
 
 // CHECK-REMOVE: filename: "file_test_windows.c"
@@ -44,23 +45,23 @@ filename: __FILE__
 // CHECK-REMOVE: basefile: "file_test_windows.c"
 // CHECK-REMOVE-NOT: filename:
 
-// CHECK-REPRODUCIBLE: filename: "A:\\UNLIKELY_PATH\\empty\\file_test_windows.c"
-// CHECK-REPRODUCIBLE: filename: "A:\\UNLIKELY_PATH\\empty\\Inputs\\include-file-test\\file_test.h"
-// CHECK-REPRODUCIBLE: basefile: "A:\\UNLIKELY_PATH\\empty\\file_test_windows.c"
+// CHECK-REPRODUCIBLE: filename: "A:{{[/\\]+}}UNLIKELY_PATH{{[/\\]+}}empty{{[/\\]+}}file_test_windows.c"
+// CHECK-REPRODUCIBLE: filename: "A:{{[/\\]+}}UNLIKELY_PATH{{[/\\]+}}empty{{[/\\]+}}Inputs{{[/\\]+}}include-file-test{{[/\\]+}}file_test.h"
+// CHECK-REPRODUCIBLE: basefile: "A:{{[/\\]+}}UNLIKELY_PATH{{[/\\]+}}empty{{[/\\]+}}file_test_windows.c"
 // CHECK-REPRODUCIBLE-NOT: filename:
 
-// CHECK-EVIL-REPRODUCIBLE: filename: "A:\\UNLIKELY_PATH=empty\\file_test_windows.c"
-// CHECK-EVIL-REPRODUCIBLE: filename: "A:\\UNLIKELY_PATH=empty\\Inputs\\include-file-test\\file_test.h"
-// CHECK-EVIL-REPRODUCIBLE: basefile: "A:\\UNLIKELY_PATH=empty\\file_test_windows.c"
+// CHECK-EVIL-REPRODUCIBLE: filename: "A:{{[/\\]+}}UNLIKELY_PATH=empty{{[/\\]+}}file_test_windows.c"
+// CHECK-EVIL-REPRODUCIBLE: filename: "A:{{[/\\]+}}UNLIKELY_PATH=empty{{[/\\]+}}Inputs{{[/\\]+}}include-file-test{{[/\\]+}}file_test.h"
+// CHECK-EVIL-REPRODUCIBLE: basefile: "A:{{[/\\]+}}UNLIKELY_PATH=empty{{[/\\]+}}file_test_windows.c"
 // CHECK-EVIL-REPRODUCIBLE-NOT: filename:
 
-// CHECK-CASE-REPRODUCIBLE: filename: "A:\\UNLIKELY_PATH_BASE\\file_test_windows.c"
-// CHECK-CASE-REPRODUCIBLE: filename: "A:\\UNLIKELY_PATH_INC\\include-file-test\\file_test.h"
-// CHECK-CASE-REPRODUCIBLE: basefile: "A:\\UNLIKELY_PATH_BASE\\file_test_windows.c"
+// CHECK-CASE-REPRODUCIBLE: filename: "A:{{[/\\]+}}UNLIKELY_PATH_BASE{{[/\\]+}}file_test_windows.c"
+// CHECK-CASE-REPRODUCIBLE: filename: "A:{{[/\\]+}}UNLIKELY_PATH_INC{{[/\\]+}}include-file-test{{[/\\]+}}file_test.h"
+// CHECK-CASE-REPRODUCIBLE: basefile: "A:{{[/\\]+}}UNLIKELY_PATH_BASE{{[/\\]+}}file_test_windows.c"
 // CHECK-CASE-REPRODUCIBLE-NOT: filename:
 
 // CHECK-REMOVE-REPRODUCIBLE: filename: "file_test_windows.c"
-// CHECK-REMOVE-REPRODUCIBLE: filename: "Inputs\\include-file-test\\file_test.h"
+// CHECK-REMOVE-REPRODUCIBLE: filename: "Inputs{{[/\\]+}}include-file-test{{[/\\]+}}file_test.h"
 // CHECK-REMOVE-REPRODUCIBLE: basefile: "file_test_windows.c"
 // CHECK-REMOVE-REPRODUCIBLE-NOT: filename:
 

--- a/clang/unittests/Basic/FileManagerTest.cpp
+++ b/clang/unittests/Basic/FileManagerTest.cpp
@@ -493,6 +493,10 @@ TEST_F(FileManagerTest, getVirtualFileFillsRealPathName) {
   SmallString<64> ExpectedResult = CustomWorkingDir;
 
   llvm::sys::path::append(ExpectedResult, "tmp", "test");
+  // Normalize to native path style to match tryGetRealPathName()
+  // which uses native style (potentially forward slashes on Windows
+  // if LLVM_WINDOWS_PREFER_FORWARD_SLASH is on).
+  llvm::sys::path::native(ExpectedResult);
   EXPECT_EQ(file.getFileEntry().tryGetRealPathName(), ExpectedResult);
 }
 
@@ -519,6 +523,10 @@ TEST_F(FileManagerTest, getFileDontOpenRealPath) {
   SmallString<64> ExpectedResult = CustomWorkingDir;
 
   llvm::sys::path::append(ExpectedResult, "tmp", "test");
+  // Normalize to native path style to match tryGetRealPathName()
+  // which uses native style (potentially forward slashes on Windows
+  // if LLVM_WINDOWS_PREFER_FORWARD_SLASH is on).
+  llvm::sys::path::native(ExpectedResult);
   EXPECT_EQ(file->getFileEntry().tryGetRealPathName(), ExpectedResult);
 }
 

--- a/clang/unittests/Driver/ToolChainTest.cpp
+++ b/clang/unittests/Driver/ToolChainTest.cpp
@@ -29,14 +29,19 @@
 #include "llvm/Support/raw_ostream.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include <algorithm>
 #include <memory>
-
-#include "SimpleDiagnosticConsumer.h"
 
 using namespace clang;
 using namespace clang::driver;
 
 namespace {
+
+#ifdef _WIN32
+#define TEST_ROOT "C:\\"
+#else
+#define TEST_ROOT "/"
+#endif
 
 TEST(ToolChainTest, VFSGCCInstallation) {
   DiagnosticOptions DiagOpts;
@@ -818,16 +823,7 @@ TEST(ToolChainTest, ConfigInexistentInclude) {
   DiagnosticsEngine Diags(DiagID, DiagOpts, DiagConsumer.get(), false);
   auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
 
-#ifdef _WIN32
-  const char *TestRoot = "C:\\";
-#define USERCONFIG "C:\\home\\user\\test.cfg"
-#define UNEXISTENT "C:\\home\\user\\file.rsp"
-#else
-  const char *TestRoot = "/";
-#define USERCONFIG "/home/user/test.cfg"
-#define UNEXISTENT "/home/user/file.rsp"
-#endif
-  FS->setCurrentWorkingDirectory(TestRoot);
+  FS->setCurrentWorkingDirectory(TEST_ROOT);
   FS->addFile("/home/user/test.cfg", 0,
               llvm::MemoryBuffer::getMemBuffer("@file.rsp"));
 
@@ -840,14 +836,15 @@ TEST(ToolChainTest, ConfigInexistentInclude) {
     ASSERT_TRUE(C);
     ASSERT_TRUE(C->containsError());
     EXPECT_EQ(1U, DiagConsumer->Errors.size());
-    EXPECT_STRCASEEQ("cannot read configuration file '" USERCONFIG
-                     "': cannot not open file '" UNEXISTENT
+    // Normalize path separators to '/' to ensure robust comparison on Windows,
+    // as the actual separator depends on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+    std::string Error = DiagConsumer->Errors[0].c_str();
+    std::replace(Error.begin(), Error.end(), '\\', '/');
+    EXPECT_STRCASEEQ("cannot read configuration file 'C:/home/user/test.cfg"
+                     "': cannot not open file 'C:/home/user/file.rsp"
                      "': no such file or directory",
-                     DiagConsumer->Errors[0].c_str());
+                     Error.c_str());
   }
-
-#undef USERCONFIG
-#undef UNEXISTENT
 }
 
 TEST(ToolChainTest, ConfigRecursiveInclude) {
@@ -858,16 +855,7 @@ TEST(ToolChainTest, ConfigRecursiveInclude) {
   DiagnosticsEngine Diags(DiagID, DiagOpts, DiagConsumer.get(), false);
   auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
 
-#ifdef _WIN32
-  const char *TestRoot = "C:\\";
-#define USERCONFIG "C:\\home\\user\\test.cfg"
-#define INCLUDED1 "C:\\home\\user\\file1.cfg"
-#else
-  const char *TestRoot = "/";
-#define USERCONFIG "/home/user/test.cfg"
-#define INCLUDED1 "/home/user/file1.cfg"
-#endif
-  FS->setCurrentWorkingDirectory(TestRoot);
+  FS->setCurrentWorkingDirectory(TEST_ROOT);
   FS->addFile("/home/user/test.cfg", 0,
               llvm::MemoryBuffer::getMemBuffer("@file1.cfg"));
   FS->addFile("/home/user/file1.cfg", 0,
@@ -886,13 +874,14 @@ TEST(ToolChainTest, ConfigRecursiveInclude) {
     ASSERT_TRUE(C);
     ASSERT_TRUE(C->containsError());
     EXPECT_EQ(1U, DiagConsumer->Errors.size());
-    EXPECT_STREQ("cannot read configuration file '" USERCONFIG
-                 "': recursive expansion of: '" INCLUDED1 "'",
-                 DiagConsumer->Errors[0].c_str());
+    // Normalize path separators to '/' to ensure robust comparison on Windows,
+    // as the actual separator depends on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+    std::string Error = DiagConsumer->Errors[0].c_str();
+    std::replace(Error.begin(), Error.end(), '\\', '/');
+    EXPECT_STREQ("cannot read configuration file 'C:/home/user/test.cfg"
+                 "': recursive expansion of: 'C:/home/user/file1.cfg'",
+                 Error.c_str());
   }
-
-#undef USERCONFIG
-#undef INCLUDED1
 }
 
 TEST(ToolChainTest, NestedConfigFile) {
@@ -902,12 +891,7 @@ TEST(ToolChainTest, NestedConfigFile) {
   DiagnosticsEngine Diags(DiagID, DiagOpts, new TestDiagnosticConsumer);
   auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
 
-#ifdef _WIN32
-  const char *TestRoot = "C:\\";
-#else
-  const char *TestRoot = "/";
-#endif
-  FS->setCurrentWorkingDirectory(TestRoot);
+  FS->setCurrentWorkingDirectory(TEST_ROOT);
 
   FS->addFile("/opt/sdk/root.cfg", 0,
               llvm::MemoryBuffer::getMemBuffer("--config=platform.cfg\n"));

--- a/clang/unittests/Frontend/ReparseWorkingDirTest.cpp
+++ b/clang/unittests/Frontend/ReparseWorkingDirTest.cpp
@@ -90,6 +90,10 @@ TEST_F(ReparseWorkingDirTest, ReparseWorkingDir) {
   WorkingDir = "/";
 #endif
   llvm::sys::path::append(WorkingDir, "root");
+  // Normalize to native path style to match FileManager's WorkingDir
+  // which uses native style (potentially forward slashes on Windows
+  // if LLVM_WINDOWS_PREFER_FORWARD_SLASH is on).
+  llvm::sys::path::native(WorkingDir);
   setWorkingDirectory(WorkingDir);
 
   SmallString<32> Header;


### PR DESCRIPTION
…H is ON

This commit addresses several test failures in Clang that occur on Windows when the CMake option -DLLVM_WINDOWS_PREFER_FORWARD_SLASH=ON is enabled. This option changes the native path style to prefer forward slashes, causing mismatches in tests that hardcode backslashes in expected output or shell commands.

Key changes:
- unit tests: Normalized expected paths to native style using llvm::sys::path::native (Basic/FileManagerTest, Frontend/ReparseWorkingDirTest) or updated hardcoded strings to use forward slashes which are compatible with both modes (Driver/ToolChainTest).
- regression tests: Updated FileCheck patterns to use flexible regex {{[/\\]}} or {{[/\\]+}} to match both path separator styles.
- absolute-paths-windows.test: Replaced mklink with a Python-based wrapper because mklink does not support forward slashes in directory paths and interprets them as command-line switches.