### PR TITLE
[ELF] Fix heap-use-after-free with INPUT(relative-path)

### DIFF
--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -344,7 +344,7 @@ void ScriptParser::addFile(StringRef s) {
       SmallString<0> path(directory);
       sys::path::append(path, s);
       if (sys::fs::exists(path)) {
-        ctx.driver.addFile(path, /*withLOption=*/false);
+        ctx.driver.addFile(ctx.saver.save(path.str()), /*withLOption=*/false);
         return;
       }
     }


### PR DESCRIPTION
`ScriptParser::addFile` Case 4 (relative path resolved against the
script's parent directory) passes a `SmallString<0>` stack local by
StringRef, causing asan error after #191690.

Fix with ctx.saver similar to other cases.