### PR TITLE
[X86][clang-cl] Make AVX10.2 map to the same target-cpu as AVX10.1

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/X86.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/X86.cpp
@@ -45,7 +45,7 @@ std::string x86::getX86TargetCPU(const Driver &D, const ArgList &Args,
         {"AVX512F", "knl"},
         {"AVX512", "skylake-avx512"},
         {"AVX10.1", "sapphirerapids"},
-        {"AVX10.2", "diamondrapids"},
+        {"AVX10.2", "sapphirerapids"},
     });
     if (Triple.getArch() == llvm::Triple::x86) {
       // 32-bit-only /arch: flags.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8613,6 +8613,10 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
     StringRef Arch = Args.getLastArgValue(options::OPT__SLASH_arch);
     if (Arch == "AVX10.1" || Arch == "AVX10.2")
       CmdArgs.push_back("-mprefer-vector-width=256");
+    if (Arch == "AVX10.2") {
+      CmdArgs.push_back("-target-feature");
+      CmdArgs.push_back("+avx10.2");
+    }
   }
 
   Arg *MostGeneralArg = Args.getLastArg(options::OPT__SLASH_vmg);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8611,8 +8611,11 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
     }
   } else {
     StringRef Arch = Args.getLastArgValue(options::OPT__SLASH_arch);
-    if (Arch == "AVX10.1" || Arch == "AVX10.2")
+    if (Arch == "AVX10.1" || Arch == "AVX10.2") {
       CmdArgs.push_back("-mprefer-vector-width=256");
+      CmdArgs.push_back("-target-feature");
+      CmdArgs.push_back("-amx-tile");
+    }
     if (Arch == "AVX10.2") {
       CmdArgs.push_back("-target-feature");
       CmdArgs.push_back("+avx10.2");

--- a/clang/test/Driver/cl-x86-flags.c
+++ b/clang/test/Driver/cl-x86-flags.c
@@ -105,7 +105,7 @@
 
 // RUN: %clang_cl -m32 -arch:AVX10.2 --target=i386-pc-windows /c /Fo%t.obj -Xclang -verify -DTEST_32_ARCH_AVX10_2_ADD -- %s
 #if defined(TEST_32_ARCH_AVX10_2_ADD)
-#if !__AVX10_2__
+#if !__AVX10_2__ || __APX_F__
 #error fail
 #endif
 #endif
@@ -169,7 +169,7 @@
 
 // RUN: %clang_cl -m64 -arch:AVX10.2 --target=i386-pc-windows /c /Fo%t.obj -Xclang -verify -DTEST_64_ARCH_AVX10_2_ADD -- %s
 #if defined(TEST_64_ARCH_AVX10_2_ADD)
-#if !__AVX10_2__
+#if !__AVX10_2__ || __APX_F__
 #error fail
 #endif
 #endif

--- a/clang/test/Driver/cl-x86-flags.c
+++ b/clang/test/Driver/cl-x86-flags.c
@@ -95,7 +95,8 @@
 // RUN: %clang_cl -m32 -arch:AVX10.2 --target=i386-pc-windows /c /Fo%t.obj -Xclang -verify -DTEST_32_ARCH_AVX10_1_ADD -- %s
 #if defined(TEST_32_ARCH_AVX10_1_ADD)
 #if !__AVX512VL__  || !__AVX512CD__ || !__AVX512DQ__ || !__AVX512VBMI__ || !__AVX512IFMA__ || !__AVX512VNNI__ ||\
-    !__AVX512BF16__ || !__AVX512VPOPCNTDQ__ || !__AVX512VBMI2__ || !__AVX512VPOPCNTDQ__ || !__AVX512BITALG__ || !__AVX512FP16__
+    !__AVX512BF16__ || !__AVX512VPOPCNTDQ__ || !__AVX512VBMI2__ || !__AVX512VPOPCNTDQ__ || !__AVX512BITALG__ ||\
+    !__AVX512FP16__ || __AMX_TILE__
 #error fail
 #endif
 #endif
@@ -159,7 +160,8 @@
 // RUN: %clang_cl -m64 -arch:AVX10.2 --target=i386-pc-windows /c /Fo%t.obj -Xclang -verify -DTEST_64_ARCH_AVX10_1_ADD -- %s
 #if defined(TEST_64_ARCH_AVX10_1_ADD)
 #if !__AVX512VL__  || !__AVX512CD__ || !__AVX512DQ__ || !__AVX512VBMI__ || !__AVX512IFMA__ || !__AVX512VNNI__ ||\
-    !__AVX512BF16__ || !__AVX512VPOPCNTDQ__ || !__AVX512VBMI2__ || !__AVX512VPOPCNTDQ__ || !__AVX512BITALG__ || !__AVX512FP16__
+    !__AVX512BF16__ || !__AVX512VPOPCNTDQ__ || !__AVX512VBMI2__ || !__AVX512VPOPCNTDQ__ || !__AVX512BITALG__ ||\
+    !__AVX512FP16__ || __AMX_TILE__
 #error fail
 #endif
 #endif


### PR DESCRIPTION
Diamondrapids contains a large feature set APX, which should not be enabled by AVX10.2