### PR TITLE
[libunwind] Add SME detection for ZA test on OpenBSD / FreeBSD

### DIFF
--- a/libunwind/test/CMakeLists.txt
+++ b/libunwind/test/CMakeLists.txt
@@ -25,6 +25,8 @@ foreach(target IN LISTS libunwind_test_suite_install_targets)
   add_dependencies(unwind-test-depends libunwind-test-suite-install-${target})
 endforeach()
 
+pythonize_bool(HAVE_GETAUXVAL)
+pythonize_bool(HAVE_ELF_AUX_INFO)
 pythonize_bool(LIBUNWIND_ENABLE_CET)
 pythonize_bool(LIBUNWIND_ENABLE_GCS)
 pythonize_bool(LIBUNWIND_ENABLE_THREADS)

--- a/libunwind/test/aarch64_za_unwind.pass.cpp
+++ b/libunwind/test/aarch64_za_unwind.pass.cpp
@@ -16,7 +16,8 @@
 #include <string.h>
 #if defined(__APPLE__)
 #include <sys/sysctl.h>
-#else
+#endif
+#if defined(_LIBUNWIND_HAVE_GETAUXVAL) || defined(_LIBUNWIND_HAVE_ELF_AUX_INFO)
 #include <sys/auxv.h>
 #endif
 
@@ -32,11 +33,23 @@ static bool checkHasSME() {
     return false;
   return has_sme != 0;
 }
-#else
+#elif defined(_LIBUNWIND_HAVE_GETAUXVAL)
 static bool checkHasSME() {
   constexpr int hwcap2_sme = (1 << 23);
   unsigned long hwcap2 = getauxval(AT_HWCAP2);
   return (hwcap2 & hwcap2_sme) != 0;
+}
+#elif defined(_LIBUNWIND_HAVE_ELF_AUX_INFO)
+static bool checkHasSME() {
+  constexpr int hwcap2_sme = (1 << 23);
+  unsigned long hwcap2 = 0;
+  elf_aux_info(AT_HWCAP2, &hwcap2, sizeof(hwcap2));
+  return (hwcap2 & hwcap2_sme) != 0;
+}
+#else
+static bool checkHasSME() {
+  // TODO: Support other platforms.
+  return false;
 }
 #endif
 

--- a/libunwind/test/configs/llvm-libunwind-merged.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-merged.cfg.in
@@ -8,6 +8,12 @@ lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 compile_flags = []
 link_flags = []
 
+if @HAVE_GETAUXVAL@:
+    compile_flags.append('-D_LIBUNWIND_HAVE_GETAUXVAL')
+
+if @HAVE_ELF_AUX_INFO@:
+    compile_flags.append('-D_LIBUNWIND_HAVE_ELF_AUX_INFO')
+
 if @LIBUNWIND_ENABLE_CET@:
     compile_flags.append('-fcf-protection=full')
 

--- a/libunwind/test/configs/llvm-libunwind-shared.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-shared.cfg.in
@@ -7,6 +7,12 @@ lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 compile_flags = []
 link_flags = []
 
+if @HAVE_GETAUXVAL@:
+    compile_flags.append('-D_LIBUNWIND_HAVE_GETAUXVAL')
+
+if @HAVE_ELF_AUX_INFO@:
+    compile_flags.append('-D_LIBUNWIND_HAVE_ELF_AUX_INFO')
+
 if @LIBUNWIND_ENABLE_CET@:
     compile_flags.append('-fcf-protection=full')
 

--- a/libunwind/test/configs/llvm-libunwind-static.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-static.cfg.in
@@ -10,6 +10,12 @@ link_flags = []
 if @LIBUNWIND_ENABLE_THREADS@:
     link_flags.append('-lpthread')
 
+if @HAVE_GETAUXVAL@:
+    compile_flags.append('-D_LIBUNWIND_HAVE_GETAUXVAL')
+
+if @HAVE_ELF_AUX_INFO@:
+    compile_flags.append('-D_LIBUNWIND_HAVE_ELF_AUX_INFO')
+
 if @LIBUNWIND_ENABLE_CET@:
     compile_flags.append('-fcf-protection=full')
 


### PR DESCRIPTION
Follow up to 588451c160c34b888ced1c3d9263d361df22f757 to
add SME detection on OpenBSD and FreeBSD.