### PR TITLE
[InstCombine] Remove support for volatile in phi of load transform

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
@@ -705,12 +705,11 @@ Instruction *InstCombinerImpl::foldPHIArgLoadIntoPHI(PHINode &PN) {
 
   // FIXME: This is overconservative; this transform is allowed in some cases
   // for atomic operations.
-  if (FirstLI->isAtomic())
+  if (!FirstLI->isSimple())
     return nullptr;
 
-  // When processing loads, we need to propagate two bits of information to the
-  // sunk load: whether it is volatile, and what its alignment is.
-  bool IsVolatile = FirstLI->isVolatile();
+  // When processing loads, we need to propagate the alignment and address
+  // space of the load.
   Align LoadAlignment = FirstLI->getAlign();
   const unsigned LoadAddrSpace = FirstLI->getPointerAddressSpace();
 
@@ -720,23 +719,15 @@ Instruction *InstCombinerImpl::foldPHIArgLoadIntoPHI(PHINode &PN) {
       !isSafeAndProfitableToSinkLoad(FirstLI))
     return nullptr;
 
-  // If the PHI is of volatile loads and the load block has multiple
-  // successors, sinking it would remove a load of the volatile value from
-  // the path through the other successor.
-  if (IsVolatile &&
-      FirstLI->getParent()->getTerminator()->getNumSuccessors() != 1)
-    return nullptr;
-
   for (auto Incoming : drop_begin(zip(PN.blocks(), PN.incoming_values()))) {
     BasicBlock *InBB = std::get<0>(Incoming);
     Value *InVal = std::get<1>(Incoming);
     LoadInst *LI = dyn_cast<LoadInst>(InVal);
-    if (!LI || !LI->hasOneUser() || LI->isAtomic())
+    if (!LI || !LI->hasOneUser() || !LI->isSimple())
       return nullptr;
 
     // Make sure all arguments are the same type of operation.
-    if (LI->isVolatile() != IsVolatile ||
-        LI->getPointerAddressSpace() != LoadAddrSpace)
+    if (LI->getPointerAddressSpace() != LoadAddrSpace)
       return nullptr;
 
     if (!canReplaceOperandWithVariable(LI, 0))
@@ -748,12 +739,6 @@ Instruction *InstCombinerImpl::foldPHIArgLoadIntoPHI(PHINode &PN) {
       return nullptr;
 
     LoadAlignment = std::min(LoadAlignment, LI->getAlign());
-
-    // If the PHI is of volatile loads and the load block has multiple
-    // successors, sinking it would remove a load of the volatile value from
-    // the path through the other successor.
-    if (IsVolatile && LI->getParent()->getTerminator()->getNumSuccessors() != 1)
-      return nullptr;
   }
 
   // Okay, they are all the same operation.  Create a new PHI node of the
@@ -764,8 +749,8 @@ Instruction *InstCombinerImpl::foldPHIArgLoadIntoPHI(PHINode &PN) {
 
   Value *InVal = FirstLI->getOperand(0);
   NewPN->addIncoming(InVal, PN.getIncomingBlock(0));
-  LoadInst *NewLI =
-      new LoadInst(FirstLI->getType(), NewPN, "", IsVolatile, LoadAlignment);
+  LoadInst *NewLI = new LoadInst(FirstLI->getType(), NewPN, "",
+                                 /*IsVolatile=*/false, LoadAlignment);
   NewLI->copyMetadata(*FirstLI);
 
   // Add all operands to the new PHI and combine TBAA metadata.
@@ -788,13 +773,6 @@ Instruction *InstCombinerImpl::foldPHIArgLoadIntoPHI(PHINode &PN) {
   } else {
     InsertNewInstBefore(NewPN, PN.getIterator());
   }
-
-  // If this was a volatile load that we are merging, make sure to loop through
-  // and mark all the input loads as non-volatile.  If we don't do this, we will
-  // insert a new volatile load and the old ones will not be deletable.
-  if (IsVolatile)
-    for (Value *IncValue : PN.incoming_values())
-      cast<LoadInst>(IncValue)->setVolatile(false);
 
   PHIArgMergedDebugLoc(NewLI, PN);
   return NewLI;

--- a/llvm/test/Transforms/InstCombine/phi.ll
+++ b/llvm/test/Transforms/InstCombine/phi.ll
@@ -340,12 +340,13 @@ define i32 @test_phi_load_volatile(ptr %A, ptr %B) {
 ; CHECK-NEXT:    [[C:%.*]] = icmp eq ptr [[A:%.*]], null
 ; CHECK-NEXT:    br i1 [[C]], label [[BB1:%.*]], label [[BB:%.*]]
 ; CHECK:       bb:
+; CHECK-NEXT:    [[C:%.*]] = load volatile i32, ptr [[B:%.*]], align 4
 ; CHECK-NEXT:    br label [[BB2:%.*]]
 ; CHECK:       bb1:
+; CHECK-NEXT:    [[D:%.*]] = load volatile i32, ptr [[A]], align 4
 ; CHECK-NEXT:    br label [[BB2]]
 ; CHECK:       bb2:
-; CHECK-NEXT:    [[E_IN:%.*]] = phi ptr [ [[B:%.*]], [[BB]] ], [ [[A]], [[BB1]] ]
-; CHECK-NEXT:    [[E:%.*]] = load volatile i32, ptr [[E_IN]], align 4
+; CHECK-NEXT:    [[E:%.*]] = phi i32 [ [[C]], [[BB]] ], [ [[D]], [[BB1]] ]
 ; CHECK-NEXT:    ret i32 [[E]]
 ;
 entry:
@@ -373,13 +374,14 @@ define i32 @test_phi_load_volatile_inaccessiblemem_call(ptr %A, ptr %B) {
 ; CHECK-NEXT:    [[C:%.*]] = icmp eq ptr [[A:%.*]], null
 ; CHECK-NEXT:    br i1 [[C]], label [[BB1:%.*]], label [[BB:%.*]]
 ; CHECK:       bb:
+; CHECK-NEXT:    [[C:%.*]] = load volatile i32, ptr [[B:%.*]], align 4
 ; CHECK-NEXT:    br label [[BB2:%.*]]
 ; CHECK:       bb1:
+; CHECK-NEXT:    [[D:%.*]] = load volatile i32, ptr [[A]], align 4
 ; CHECK-NEXT:    call void @inaccessiblemem()
 ; CHECK-NEXT:    br label [[BB2]]
 ; CHECK:       bb2:
-; CHECK-NEXT:    [[E_IN:%.*]] = phi ptr [ [[B:%.*]], [[BB]] ], [ [[A]], [[BB1]] ]
-; CHECK-NEXT:    [[E:%.*]] = load volatile i32, ptr [[E_IN]], align 4
+; CHECK-NEXT:    [[E:%.*]] = phi i32 [ [[C]], [[BB]] ], [ [[D]], [[BB1]] ]
 ; CHECK-NEXT:    ret i32 [[E]]
 ;
 entry:
@@ -406,14 +408,15 @@ define i32 @test_phi_load_volatile_non_speculatable(ptr %A, ptr %B, ptr %X) {
 ; CHECK-NEXT:    [[C:%.*]] = icmp eq ptr [[A:%.*]], null
 ; CHECK-NEXT:    br i1 [[C]], label [[BB1:%.*]], label [[BB:%.*]]
 ; CHECK:       bb:
+; CHECK-NEXT:    [[C:%.*]] = load volatile i32, ptr [[B:%.*]], align 4
 ; CHECK-NEXT:    br label [[BB2:%.*]]
 ; CHECK:       bb1:
+; CHECK-NEXT:    [[D:%.*]] = load volatile i32, ptr [[A]], align 4
 ; CHECK-NEXT:    [[Y:%.*]] = load i32, ptr [[X:%.*]], align 4
 ; CHECK-NEXT:    br label [[BB2]]
 ; CHECK:       bb2:
-; CHECK-NEXT:    [[E_IN:%.*]] = phi ptr [ [[B:%.*]], [[BB]] ], [ [[A]], [[BB1]] ]
+; CHECK-NEXT:    [[E:%.*]] = phi i32 [ [[C]], [[BB]] ], [ [[D]], [[BB1]] ]
 ; CHECK-NEXT:    [[F:%.*]] = phi i32 [ 0, [[BB]] ], [ [[Y]], [[BB1]] ]
-; CHECK-NEXT:    [[E:%.*]] = load volatile i32, ptr [[E_IN]], align 4
 ; CHECK-NEXT:    [[G:%.*]] = add i32 [[E]], [[F]]
 ; CHECK-NEXT:    ret i32 [[G]]
 ;

--- a/llvm/test/Transforms/InstCombine/phi.ll
+++ b/llvm/test/Transforms/InstCombine/phi.ll
@@ -334,6 +334,109 @@ bb2:
   ret i32 %E
 }
 
+define i32 @test_phi_load_volatile(ptr %A, ptr %B) {
+; CHECK-LABEL: @test_phi_load_volatile(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[C:%.*]] = icmp eq ptr [[A:%.*]], null
+; CHECK-NEXT:    br i1 [[C]], label [[BB1:%.*]], label [[BB:%.*]]
+; CHECK:       bb:
+; CHECK-NEXT:    br label [[BB2:%.*]]
+; CHECK:       bb1:
+; CHECK-NEXT:    br label [[BB2]]
+; CHECK:       bb2:
+; CHECK-NEXT:    [[E_IN:%.*]] = phi ptr [ [[B:%.*]], [[BB]] ], [ [[A]], [[BB1]] ]
+; CHECK-NEXT:    [[E:%.*]] = load volatile i32, ptr [[E_IN]], align 4
+; CHECK-NEXT:    ret i32 [[E]]
+;
+entry:
+  %c = icmp eq ptr %A, null
+  br i1 %c, label %bb1, label %bb
+
+bb:
+  %C = load volatile i32, ptr %B
+  br label %bb2
+
+bb1:
+  %D = load volatile i32, ptr %A
+  br label %bb2
+
+bb2:
+  %E = phi i32 [ %C, %bb ], [ %D, %bb1 ]
+  ret i32 %E
+}
+
+declare void @inaccessiblemem() memory(inaccessiblemem: readwrite)
+
+define i32 @test_phi_load_volatile_inaccessiblemem_call(ptr %A, ptr %B) {
+; CHECK-LABEL: @test_phi_load_volatile_inaccessiblemem_call(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[C:%.*]] = icmp eq ptr [[A:%.*]], null
+; CHECK-NEXT:    br i1 [[C]], label [[BB1:%.*]], label [[BB:%.*]]
+; CHECK:       bb:
+; CHECK-NEXT:    br label [[BB2:%.*]]
+; CHECK:       bb1:
+; CHECK-NEXT:    call void @inaccessiblemem()
+; CHECK-NEXT:    br label [[BB2]]
+; CHECK:       bb2:
+; CHECK-NEXT:    [[E_IN:%.*]] = phi ptr [ [[B:%.*]], [[BB]] ], [ [[A]], [[BB1]] ]
+; CHECK-NEXT:    [[E:%.*]] = load volatile i32, ptr [[E_IN]], align 4
+; CHECK-NEXT:    ret i32 [[E]]
+;
+entry:
+  %c = icmp eq ptr %A, null
+  br i1 %c, label %bb1, label %bb
+
+bb:
+  %C = load volatile i32, ptr %B
+  br label %bb2
+
+bb1:
+  %D = load volatile i32, ptr %A
+  call void @inaccessiblemem()
+  br label %bb2
+
+bb2:
+  %E = phi i32 [ %C, %bb ], [ %D, %bb1 ]
+  ret i32 %E
+}
+
+define i32 @test_phi_load_volatile_non_speculatable(ptr %A, ptr %B, ptr %X) {
+; CHECK-LABEL: @test_phi_load_volatile_non_speculatable(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[C:%.*]] = icmp eq ptr [[A:%.*]], null
+; CHECK-NEXT:    br i1 [[C]], label [[BB1:%.*]], label [[BB:%.*]]
+; CHECK:       bb:
+; CHECK-NEXT:    br label [[BB2:%.*]]
+; CHECK:       bb1:
+; CHECK-NEXT:    [[Y:%.*]] = load i32, ptr [[X:%.*]], align 4
+; CHECK-NEXT:    br label [[BB2]]
+; CHECK:       bb2:
+; CHECK-NEXT:    [[E_IN:%.*]] = phi ptr [ [[B:%.*]], [[BB]] ], [ [[A]], [[BB1]] ]
+; CHECK-NEXT:    [[F:%.*]] = phi i32 [ 0, [[BB]] ], [ [[Y]], [[BB1]] ]
+; CHECK-NEXT:    [[E:%.*]] = load volatile i32, ptr [[E_IN]], align 4
+; CHECK-NEXT:    [[G:%.*]] = add i32 [[E]], [[F]]
+; CHECK-NEXT:    ret i32 [[G]]
+;
+entry:
+  %c = icmp eq ptr %A, null
+  br i1 %c, label %bb1, label %bb
+
+bb:
+  %C = load volatile i32, ptr %B
+  br label %bb2
+
+bb1:
+  %D = load volatile i32, ptr %A
+  %Y = load i32, ptr %X
+  br label %bb2
+
+bb2:
+  %E = phi i32 [ %C, %bb ], [ %D, %bb1 ]
+  %F = phi i32 [ 0, %bb ], [ %Y, %bb1 ]
+  %G = add i32 %E, %F
+  ret i32 %G
+}
+
 
 ; PR1777
 declare i1 @test11a()


### PR DESCRIPTION
The volatile support does not have test coverage, and dates back to when this transform was originally introduced 20 years ago, so it does not appear that volatile support was specifically added -- it was just naively implemented to start with, and then received bug fixes.

The current implementation is still buggy, e.g. it allows sinking volatile past inaccessiblemem calls, which is invalid (as those may contain volatile accesses on allocas).

After https://github.com/llvm/llvm-project/pull/192992, there would be another constraint that all the instructions after the volatile load are speculatable.

This wouldn't be hard to fix, but I'd rather remove volatile support here entirely.