### PR TITLE
[clang][test] Fix test failures when LLVM_WINDOWS_PREFER_FORWARD_SLAS…

### DIFF
--- a/clang/test/DebugInfo/Generic/debug-prefix-map.c
+++ b/clang/test/DebugInfo/Generic/debug-prefix-map.c
@@ -27,27 +27,29 @@ void test_rewrite_includes(void) {
   vprintf("string", argp);
 }
 
-// CHECK-NO-MAIN-FILE-NAME: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}{{.*}}",
+// Forward or backward slashes can be used depending on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+// CHECK-NO-MAIN-FILE-NAME: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}{{.*}}",
 // CHECK-NO-MAIN-FILE-NAME-SAME:    directory: "")
-// CHECK-NO-MAIN-FILE-NAME: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}<stdin>",
-// CHECK-NO-MAIN-FILE-NAME: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}Inputs{{/|\\\\}}stdio.h",
+// CHECK-NO-MAIN-FILE-NAME: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}<stdin>",
+// CHECK-NO-MAIN-FILE-NAME: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}Inputs{{/|\\\\}}stdio.h",
 // CHECK-NO-MAIN-FILE-NAME-SAME:    directory: "")
 // CHECK-NO-MAIN-FILE-NAME-NOT: !DIFile(filename:
 
-// CHECK-EVIL: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH=empty{{/|\\\\}}{{.*}}"
-// CHECK-EVIL: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH=empty{{/|\\\\}}{{.*}}Inputs{{/|\\\\}}stdio.h",
+// CHECK-EVIL: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH=empty{{/|\\\\}}{{.*}}"
+// CHECK-EVIL: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH=empty{{/|\\\\}}{{.*}}Inputs{{/|\\\\}}stdio.h",
 // CHECK-EVIL-SAME:    directory: "")
 // CHECK-EVIL-NOT: !DIFile(filename:
 
-// CHECK: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}{{.*}}",
-// CHECK: !DIFile(filename: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}{{.*}}Inputs{{/|\\\\}}stdio.h",
+// CHECK: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}{{.*}}",
+// CHECK: !DIFile(filename: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty{{/|\\\\}}{{.*}}Inputs{{/|\\\\}}stdio.h",
 // CHECK-SAME:    directory: ""
 // CHECK-NOT: !DIFile(filename:
 
-// CHECK-COMPILATION-DIR: !DIFile(filename: "{{.*}}", directory: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty")
-// CHECK-COMPILATION-DIR: !DIFile(filename: "{{.*}}Inputs{{/|\\\\}}stdio.h", directory: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty")
+// CHECK-COMPILATION-DIR: !DIFile(filename: "{{.*}}", directory: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty")
+// CHECK-COMPILATION-DIR: !DIFile(filename: "{{.*}}Inputs{{/|\\\\}}stdio.h", directory: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty")
 // CHECK-COMPILATION-DIR-NOT: !DIFile(filename:
-// CHECK-SYSROOT: !DICompileUnit({{.*}}sysroot: "{{/|.:\\\\}}UNLIKELY_PATH{{/|\\\\}}empty"
+// CHECK-SYSROOT: !DICompileUnit({{.*}}sysroot: "{{/|.:[/\\]+}}UNLIKELY_PATH{{/|\\\\}}empty"
+
 
 // CHECK-REL: !DIFile(filename: "./UNLIKELY_PATH/empty{{/|\\\\}}{{.*}}",
 // CHECK-REL: !DIFile(filename: "./UNLIKELY_PATH/empty{{/|\\\\}}{{.*}}Inputs/stdio.h",

--- a/clang/test/Driver/ps4-ps5-linker-win.c
+++ b/clang/test/Driver/ps4-ps5-linker-win.c
@@ -16,8 +16,9 @@
 // RUN: env "PATH=%t;%PATH%;" %clang -target x86_64-sie-ps5  %s -shared -### 2>&1 \
 // RUN:   | FileCheck --check-prefixes=CHECK-PS5-LINKER,SHARED %s
 
-// CHECK-PS4-LINKER: \\orbis-ld
-// CHECK-PS5-LINKER: \\prospero-lld
+// Forward or backward slashes can be used depending on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+// CHECK-PS4-LINKER: {{/|\\\\}}orbis-ld
+// CHECK-PS5-LINKER: {{/|\\\\}}prospero-lld
 // SHARED: "--shared"
 
 // RUN: env "PATH=%t;%PATH%;" not %clang --target=x86_64-scei-ps4 %s -fuse-ld=gold -### 2>&1 \

--- a/clang/test/Frontend/absolute-paths-windows.test
+++ b/clang/test/Frontend/absolute-paths-windows.test
@@ -1,4 +1,6 @@
 // REQUIRES: system-windows
+// mklink /j does not support forward slashes.
+// REQUIRES: !windows-prefer-forward-slash
 // RUN: rm -rf %t.dir
 // RUN: mkdir -p %t.dir\real
 // RUN: cmd /c mklink /j %t.dir\junc %t.dir\real

--- a/clang/test/Frontend/dependency-gen-windows-duplicates.c
+++ b/clang/test/Frontend/dependency-gen-windows-duplicates.c
@@ -8,8 +8,9 @@
 
 // RUN: %clang -MD -MF - %t.dir/test.c -fsyntax-only -I %t.dir/subdir | FileCheck %s
 // CHECK: test.o:
-// CHECK-NEXT: \test.c
-// CHECK-NEXT: \SubDir\X.h
+// Forward or backward slashes can be used depending on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+// CHECK-NEXT: {{[/\\]}}test.c \
+// CHECK-NEXT: {{[/\\]}}SubDir{{[/\\]}}X.h
 // File x.h must appear only once (case insensitive check).
 // CHECK-NOT: {{\\|/}}{{x|X}}.{{h|H}}
 

--- a/clang/test/Preprocessor/file_test_windows.c
+++ b/clang/test/Preprocessor/file_test_windows.c
@@ -24,19 +24,20 @@
 filename: __FILE__
 #include "Inputs/include-file-test/file_test.h"
 
-// CHECK: filename: "A:\\UNLIKELY_PATH\\empty\\file_test_windows.c"
-// CHECK: filename: "A:\\UNLIKELY_PATH\\empty\\Inputs/include-file-test/file_test.h"
-// CHECK: basefile: "A:\\UNLIKELY_PATH\\empty\\file_test_windows.c"
+// Forward or backward slashes can be used depending on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+// CHECK: filename: "A:{{[/\\]+}}UNLIKELY_PATH{{[/\\]+}}empty{{[/\\]+}}file_test_windows.c"
+// CHECK: filename: "A:{{[/\\]+}}UNLIKELY_PATH{{[/\\]+}}empty{{[/\\]+}}Inputs/include-file-test/file_test.h"
+// CHECK: basefile: "A:{{[/\\]+}}UNLIKELY_PATH{{[/\\]+}}empty{{[/\\]+}}file_test_windows.c"
 // CHECK-NOT: filename:
 
-// CHECK-EVIL: filename: "A:\\UNLIKELY_PATH=empty\\file_test_windows.c"
-// CHECK-EVIL: filename: "A:\\UNLIKELY_PATH=empty\\Inputs/include-file-test/file_test.h"
-// CHECK-EVIL: basefile: "A:\\UNLIKELY_PATH=empty\\file_test_windows.c"
+// CHECK-EVIL: filename: "A:{{[/\\]+}}UNLIKELY_PATH=empty{{[/\\]+}}file_test_windows.c"
+// CHECK-EVIL: filename: "A:{{[/\\]+}}UNLIKELY_PATH=empty{{[/\\]+}}Inputs/include-file-test/file_test.h"
+// CHECK-EVIL: basefile: "A:{{[/\\]+}}UNLIKELY_PATH=empty{{[/\\]+}}file_test_windows.c"
 // CHECK-EVIL-NOT: filename:
 
-// CHECK-CASE: filename: "A:\\UNLIKELY_PATH_BASE\\file_test_windows.c"
-// CHECK-CASE: filename: "A:\\UNLIKELY_PATH_INC\\include-file-test/file_test.h"
-// CHECK-CASE: basefile: "A:\\UNLIKELY_PATH_BASE\\file_test_windows.c"
+// CHECK-CASE: filename: "A:{{[/\\]+}}UNLIKELY_PATH_BASE{{[/\\]+}}file_test_windows.c"
+// CHECK-CASE: filename: "A:{{[/\\]+}}UNLIKELY_PATH_INC{{[/\\]+}}include-file-test/file_test.h"
+// CHECK-CASE: basefile: "A:{{[/\\]+}}UNLIKELY_PATH_BASE{{[/\\]+}}file_test_windows.c"
 // CHECK-CASE-NOT: filename:
 
 // CHECK-REMOVE: filename: "file_test_windows.c"
@@ -44,23 +45,23 @@ filename: __FILE__
 // CHECK-REMOVE: basefile: "file_test_windows.c"
 // CHECK-REMOVE-NOT: filename:
 
-// CHECK-REPRODUCIBLE: filename: "A:\\UNLIKELY_PATH\\empty\\file_test_windows.c"
-// CHECK-REPRODUCIBLE: filename: "A:\\UNLIKELY_PATH\\empty\\Inputs\\include-file-test\\file_test.h"
-// CHECK-REPRODUCIBLE: basefile: "A:\\UNLIKELY_PATH\\empty\\file_test_windows.c"
+// CHECK-REPRODUCIBLE: filename: "A:{{[/\\]+}}UNLIKELY_PATH{{[/\\]+}}empty{{[/\\]+}}file_test_windows.c"
+// CHECK-REPRODUCIBLE: filename: "A:{{[/\\]+}}UNLIKELY_PATH{{[/\\]+}}empty{{[/\\]+}}Inputs{{[/\\]+}}include-file-test{{[/\\]+}}file_test.h"
+// CHECK-REPRODUCIBLE: basefile: "A:{{[/\\]+}}UNLIKELY_PATH{{[/\\]+}}empty{{[/\\]+}}file_test_windows.c"
 // CHECK-REPRODUCIBLE-NOT: filename:
 
-// CHECK-EVIL-REPRODUCIBLE: filename: "A:\\UNLIKELY_PATH=empty\\file_test_windows.c"
-// CHECK-EVIL-REPRODUCIBLE: filename: "A:\\UNLIKELY_PATH=empty\\Inputs\\include-file-test\\file_test.h"
-// CHECK-EVIL-REPRODUCIBLE: basefile: "A:\\UNLIKELY_PATH=empty\\file_test_windows.c"
+// CHECK-EVIL-REPRODUCIBLE: filename: "A:{{[/\\]+}}UNLIKELY_PATH=empty{{[/\\]+}}file_test_windows.c"
+// CHECK-EVIL-REPRODUCIBLE: filename: "A:{{[/\\]+}}UNLIKELY_PATH=empty{{[/\\]+}}Inputs{{[/\\]+}}include-file-test{{[/\\]+}}file_test.h"
+// CHECK-EVIL-REPRODUCIBLE: basefile: "A:{{[/\\]+}}UNLIKELY_PATH=empty{{[/\\]+}}file_test_windows.c"
 // CHECK-EVIL-REPRODUCIBLE-NOT: filename:
 
-// CHECK-CASE-REPRODUCIBLE: filename: "A:\\UNLIKELY_PATH_BASE\\file_test_windows.c"
-// CHECK-CASE-REPRODUCIBLE: filename: "A:\\UNLIKELY_PATH_INC\\include-file-test\\file_test.h"
-// CHECK-CASE-REPRODUCIBLE: basefile: "A:\\UNLIKELY_PATH_BASE\\file_test_windows.c"
+// CHECK-CASE-REPRODUCIBLE: filename: "A:{{[/\\]+}}UNLIKELY_PATH_BASE{{[/\\]+}}file_test_windows.c"
+// CHECK-CASE-REPRODUCIBLE: filename: "A:{{[/\\]+}}UNLIKELY_PATH_INC{{[/\\]+}}include-file-test{{[/\\]+}}file_test.h"
+// CHECK-CASE-REPRODUCIBLE: basefile: "A:{{[/\\]+}}UNLIKELY_PATH_BASE{{[/\\]+}}file_test_windows.c"
 // CHECK-CASE-REPRODUCIBLE-NOT: filename:
 
 // CHECK-REMOVE-REPRODUCIBLE: filename: "file_test_windows.c"
-// CHECK-REMOVE-REPRODUCIBLE: filename: "Inputs\\include-file-test\\file_test.h"
+// CHECK-REMOVE-REPRODUCIBLE: filename: "Inputs{{[/\\]+}}include-file-test{{[/\\]+}}file_test.h"
 // CHECK-REMOVE-REPRODUCIBLE: basefile: "file_test_windows.c"
 // CHECK-REMOVE-REPRODUCIBLE-NOT: filename:
 

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -15,6 +15,9 @@ from lit.llvm.subst import FindTool
 
 # Configuration file for the 'lit' test runner.
 
+if lit.util.pythonize_bool(lit_config.params.get("use_normalized_slashes")):
+    config.available_features.add("windows-prefer-forward-slash")
+
 # name: The name of this test suite.
 config.name = "Clang"
 

--- a/clang/unittests/Basic/FileManagerTest.cpp
+++ b/clang/unittests/Basic/FileManagerTest.cpp
@@ -493,6 +493,10 @@ TEST_F(FileManagerTest, getVirtualFileFillsRealPathName) {
   SmallString<64> ExpectedResult = CustomWorkingDir;
 
   llvm::sys::path::append(ExpectedResult, "tmp", "test");
+  // Normalize to native path style to match tryGetRealPathName()
+  // which uses native style (potentially forward slashes on Windows
+  // if LLVM_WINDOWS_PREFER_FORWARD_SLASH is on).
+  llvm::sys::path::native(ExpectedResult);
   EXPECT_EQ(file.getFileEntry().tryGetRealPathName(), ExpectedResult);
 }
 
@@ -519,6 +523,10 @@ TEST_F(FileManagerTest, getFileDontOpenRealPath) {
   SmallString<64> ExpectedResult = CustomWorkingDir;
 
   llvm::sys::path::append(ExpectedResult, "tmp", "test");
+  // Normalize to native path style to match tryGetRealPathName()
+  // which uses native style (potentially forward slashes on Windows
+  // if LLVM_WINDOWS_PREFER_FORWARD_SLASH is on).
+  llvm::sys::path::native(ExpectedResult);
   EXPECT_EQ(file->getFileEntry().tryGetRealPathName(), ExpectedResult);
 }
 

--- a/clang/unittests/Driver/ToolChainTest.cpp
+++ b/clang/unittests/Driver/ToolChainTest.cpp
@@ -840,10 +840,14 @@ TEST(ToolChainTest, ConfigInexistentInclude) {
     ASSERT_TRUE(C);
     ASSERT_TRUE(C->containsError());
     EXPECT_EQ(1U, DiagConsumer->Errors.size());
-    EXPECT_STRCASEEQ("cannot read configuration file '" USERCONFIG
-                     "': cannot not open file '" UNEXISTENT
-                     "': no such file or directory",
-                     DiagConsumer->Errors[0].c_str());
+    // Expected path style in diagnostics depends on
+    // LLVM_WINDOWS_PREFER_FORWARD_SLASH. Construct the expected string
+    // dynamically to match the native path style.
+    std::string ExpectedError =
+        "cannot read configuration file '" +
+        llvm::sys::path::native(USERCONFIG) + "': cannot not open file '" +
+        llvm::sys::path::native(UNEXISTENT) + "': no such file or directory";
+    EXPECT_STRCASEEQ(ExpectedError.c_str(), DiagConsumer->Errors[0].c_str());
   }
 
 #undef USERCONFIG
@@ -886,9 +890,14 @@ TEST(ToolChainTest, ConfigRecursiveInclude) {
     ASSERT_TRUE(C);
     ASSERT_TRUE(C->containsError());
     EXPECT_EQ(1U, DiagConsumer->Errors.size());
-    EXPECT_STREQ("cannot read configuration file '" USERCONFIG
-                 "': recursive expansion of: '" INCLUDED1 "'",
-                 DiagConsumer->Errors[0].c_str());
+    // Expected path style in diagnostics depends on
+    // LLVM_WINDOWS_PREFER_FORWARD_SLASH. Construct the expected string
+    // dynamically to match the native path style.
+    std::string ExpectedError = "cannot read configuration file '" +
+                                llvm::sys::path::native(USERCONFIG) +
+                                "': recursive expansion of: '" +
+                                llvm::sys::path::native(INCLUDED1) + "'";
+    EXPECT_STRCASEEQ(ExpectedError.c_str(), DiagConsumer->Errors[0].c_str());
   }
 
 #undef USERCONFIG

--- a/clang/unittests/Frontend/ReparseWorkingDirTest.cpp
+++ b/clang/unittests/Frontend/ReparseWorkingDirTest.cpp
@@ -90,6 +90,10 @@ TEST_F(ReparseWorkingDirTest, ReparseWorkingDir) {
   WorkingDir = "/";
 #endif
   llvm::sys::path::append(WorkingDir, "root");
+  // Normalize to native path style to match FileManager's WorkingDir
+  // which uses native style (potentially forward slashes on Windows
+  // if LLVM_WINDOWS_PREFER_FORWARD_SLASH is on).
+  llvm::sys::path::native(WorkingDir);
   setWorkingDirectory(WorkingDir);
 
   SmallString<32> Header;


### PR DESCRIPTION
…H is ON

This commit addresses several test failures in Clang that occur on Windows when
the CMake option -DLLVM_WINDOWS_PREFER_FORWARD_SLASH=ON is enabled.

Key changes:
- unit tests: Normalized expected paths to native style using llvm::sys::path::native
  (Basic/FileManagerTest, Frontend/ReparseWorkingDirTest) or updated diagnostic matching
  to be separator-agnostic (Driver/ToolChainTest).
- regression tests: Updated FileCheck patterns to use flexible regex {{[/\\\\]}} or
  {{[/\\\\]+}} to match both path separator styles.
- absolute-paths-windows.test: Skipped when forward slashes are preferred because
  mklink does not support forward slashes in directory paths and interprets them
  as command-line switches. Added 'windows-prefer-forward-slash' lit feature.