### PR TITLE
[clangd][test] Fix test failures when LLVM_WINDOWS_PREFER_FORWARD_SLA…

### DIFF
--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -597,30 +597,31 @@ public:
     Body = Body.ltrim('/');
     llvm::SmallString<16> Path(Body);
     path::native(Path);
-    path::make_absolute(TestScheme::TestDir, Path);
+    path::make_absolute(testDir(), Path);
     return std::string(Path);
   }
 
   llvm::Expected<URI>
   uriFromAbsolutePath(llvm::StringRef AbsolutePath) const override {
     llvm::StringRef Body = AbsolutePath;
-    if (!Body.consume_front(TestScheme::TestDir))
+    if (!Body.consume_front(testDir()))
       return error("Path {0} doesn't start with root {1}", AbsolutePath,
-                   TestDir);
+                   testDir());
 
     return URI("test", /*Authority=*/"",
                llvm::sys::path::convert_to_slash(Body));
   }
 
 private:
-  const static char TestDir[];
-};
-
+  static llvm::StringRef testDir() {
 #ifdef _WIN32
-const char TestScheme::TestDir[] = "C:\\clangd-test";
+    static const std::string TestDir = llvm::sys::path::native("C:/clangd-test");
+    return TestDir;
 #else
-const char TestScheme::TestDir[] = "/clangd-test";
+    return "/clangd-test";
 #endif
+  }
+};
 
 std::unique_ptr<SymbolIndex>
 loadExternalIndex(const Config::ExternalIndexSpec &External,

--- a/clang-tools-extra/clangd/unittests/TestFS.cpp
+++ b/clang-tools-extra/clangd/unittests/TestFS.cpp
@@ -84,7 +84,8 @@ MockCompilationDatabase::getCompileCommand(PathRef File) const {
 
 const char *testRoot() {
 #ifdef _WIN32
-  return "C:\\clangd-test";
+  static const std::string Root = llvm::sys::path::native("C:/clangd-test");
+  return Root.c_str();
 #else
   return "/clangd-test";
 #endif

--- a/clang-tools-extra/clangd/unittests/URITests.cpp
+++ b/clang-tools-extra/clangd/unittests/URITests.cpp
@@ -133,8 +133,11 @@ TEST(URITest, ParseFailed) {
 
 TEST(URITest, Resolve) {
 #ifdef _WIN32
-  EXPECT_THAT(resolveOrDie(parseOrDie("file:///c%3a/x/y/z")), "c:\\x\\y\\z");
-  EXPECT_THAT(resolveOrDie(parseOrDie("file:///c:/x/y/z")), "c:\\x\\y\\z");
+  // Expected path style depends on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+  EXPECT_THAT(resolveOrDie(parseOrDie("file:///c%3a/x/y/z")),
+              llvm::sys::path::native("c:/x/y/z"));
+  EXPECT_THAT(resolveOrDie(parseOrDie("file:///c:/x/y/z")),
+              llvm::sys::path::native("c:/x/y/z"));
 #else
   EXPECT_EQ(resolveOrDie(parseOrDie("file:/a/b/c")), "/a/b/c");
   EXPECT_EQ(resolveOrDie(parseOrDie("file://auth/a/b/c")), "//auth/a/b/c");
@@ -148,13 +151,14 @@ TEST(URITest, Resolve) {
 
 TEST(URITest, ResolveUNC) {
 #ifdef _WIN32
+  // Expected path style depends on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
   EXPECT_THAT(resolveOrDie(parseOrDie("file://example.com/x/y/z")),
-              "\\\\example.com\\x\\y\\z");
+              llvm::sys::path::native("//example.com/x/y/z"));
   EXPECT_THAT(resolveOrDie(parseOrDie("file://127.0.0.1/x/y/z")),
-              "\\\\127.0.0.1\\x\\y\\z");
+              llvm::sys::path::native("//127.0.0.1/x/y/z"));
   // Ensure non-traditional file URI still resolves to correct UNC path.
   EXPECT_THAT(resolveOrDie(parseOrDie("file:////127.0.0.1/x/y/z")),
-              "\\\\127.0.0.1\\x\\y\\z");
+              llvm::sys::path::native("//127.0.0.1/x/y/z"));
 #else
   EXPECT_THAT(resolveOrDie(parseOrDie("file://example.com/x/y/z")),
               "//example.com/x/y/z");


### PR DESCRIPTION
…SH is ON

This commit addresses several test failures in Clangd that occur on Windows when the CMake option -DLLVM_WINDOWS_PREFER_FORWARD_SLASH=ON is enabled.

Key changes:
- Updated testRoot() and TestScheme to dynamically return native path styles.
- Normalized expected paths in URI tests using a helper that calls llvm::sys::path::native.