### PR TITLE
[OpenCL] Diagnose error for zero-length array

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -122,6 +122,12 @@ Clang Python Bindings Potentially Breaking Changes
   be adapted to refer to it instead. ``_CXUnsavedFile`` will be removed in a
   future release.
 
+OpenCL Potentially Breaking Changes
+-----------------------------------
+- Clang now diagnoses zero-length arrays as errors in OpenCL. OpenCL C 3.0
+  section 6.11.d states that "Variable length arrays and structures with
+  flexible (or unsized) arrays are not supported."
+
 What's New in Clang |release|?
 ==============================
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6691,7 +6691,7 @@ def err_typecheck_invalid_restrict_invalid_pointee : Error<
 def ext_typecheck_zero_array_size : Extension<
   "zero size arrays are an extension">, InGroup<ZeroLengthArray>;
 def err_typecheck_zero_array_size : Error<
-  "zero-length arrays are not permitted in %select{C++|SYCL device code|HIP device code}0">;
+  "zero-length arrays are not permitted in %select{C++|SYCL device code|HIP device code|OpenCL}0">;
 def err_array_size_non_int : Error<"size of array has non-integer type %0">;
 def err_init_element_not_constant : Error<
   "initializer element is not a compile-time constant">;

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -2288,6 +2288,12 @@ QualType Sema::BuildArrayType(QualType T, ArraySizeModifier ASM,
         return QualType();
       }
       if (ConstVal == 0 && !T.isWebAssemblyReferenceType()) {
+        if (getLangOpts().OpenCL) {
+          Diag(ArraySize->getBeginLoc(), diag::err_typecheck_zero_array_size)
+              << 3 << ArraySize->getSourceRange();
+          return QualType();
+        }
+
         // GCC accepts zero sized static arrays. We allow them when
         // we're not in a SFINAE context.
         Diag(ArraySize->getBeginLoc(),

--- a/clang/test/Misc/languageOptsOpenCL.cl
+++ b/clang/test/Misc/languageOptsOpenCL.cl
@@ -4,18 +4,18 @@
 // Test the forced language options for OpenCL are set correctly.
 
 kernel void test() {
-  int v0[(sizeof(int) == 4) - 1];
-  int v1[(__alignof(int)== 4) - 1];
-  int v2[(sizeof(long) == 8) - 1];
-  int v3[(__alignof(long)== 8) - 1];
-  int v4[(sizeof(long long) == 16) - 1];
-  int v5[(__alignof(long long)== 16) - 1];
-  int v6[(sizeof(float) == 4) - 1];
-  int v7[(__alignof(float)== 4) - 1];
+  int v0[(sizeof(int) == 4) ? 1 : -1];
+  int v1[(__alignof(int)== 4) ? 1 : -1];
+  int v2[(sizeof(long) == 8) ? 1 : -1];
+  int v3[(__alignof(long)== 8) ? 1 : -1];
+  int v4[(sizeof(long long) == 16) ? 1 : -1];
+  int v5[(__alignof(long long)== 16) ? 1 : -1];
+  int v6[(sizeof(float) == 4) ? 1 : -1];
+  int v7[(__alignof(float)== 4) ? 1 : -1];
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
-  int v8[(sizeof(double) == 8) - 1];
-  int v9[(__alignof(double)== 8) - 1];
+  int v8[(sizeof(double) == 8) ? 1 : -1];
+  int v9[(__alignof(double)== 8) ? 1 : -1];
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
-  int v10[(sizeof(half) == 2) - 1];
-  int v11[(__alignof(half) == 2) - 1];
+  int v10[(sizeof(half) == 2) ? 1 : -1];
+  int v11[(__alignof(half) == 2) ? 1 : -1];
 }

--- a/clang/test/SemaOpenCL/zero-length-array.cl
+++ b/clang/test/SemaOpenCL/zero-length-array.cl
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 %s -verify -fsyntax-only -cl-std=CL1.2
+// RUN: %clang_cc1 %s -verify -fsyntax-only -cl-std=CL3.0
+
+struct S {
+  int x;
+  int y[0]; // expected-error {{zero-length arrays are not permitted in OpenCL}}
+};
+
+global int g_zero_length_array[0]; // expected-error {{zero-length arrays are not permitted in OpenCL}}
+
+kernel void foo(void) {
+  int a[0]; // expected-error {{zero-length arrays are not permitted in OpenCL}}
+  local int b[0]; // expected-error {{zero-length arrays are not permitted in OpenCL}}
+}


### PR DESCRIPTION
OpenCL C is based on C99 and C11, which don't support zero-length array.