### PR TITLE
[lldb] Remove trailing newlines from AppendErrorWithFormat calls (part 2)

### DIFF
--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -353,7 +353,7 @@ protected:
     } else {
       if (command.GetArgumentCount() > 1) {
         result.AppendErrorWithFormat(
-            "too many arguments; expected frame-index, saw '%s'.\n",
+            "too many arguments; expected frame-index, saw '%s'.",
             command[0].c_str());
         m_options.GenerateOptionUsage(
             result.GetErrorStream(), *this,
@@ -382,8 +382,7 @@ protected:
       m_exe_ctx.SetFrameSP(thread->GetSelectedFrame(SelectMostRelevantFrame));
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else {
-      result.AppendErrorWithFormat("Frame index (%u) out of range.\n",
-                                   frame_idx);
+      result.AppendErrorWithFormat("Frame index (%u) out of range.", frame_idx);
     }
   }
 
@@ -888,27 +887,26 @@ void CommandObjectFrameRecognizerAdd::DoExecute(Args &command,
                                                 CommandReturnObject &result) {
 #if LLDB_ENABLE_PYTHON
   if (m_options.m_class_name.empty()) {
-    result.AppendErrorWithFormat(
-        "%s needs a Python class name (-l argument).\n", m_cmd_name.c_str());
+    result.AppendErrorWithFormat("%s needs a Python class name (-l argument).",
+                                 m_cmd_name.c_str());
     return;
   }
 
   if (m_options.m_module.empty()) {
-    result.AppendErrorWithFormat("%s needs a module name (-s argument).\n",
+    result.AppendErrorWithFormat("%s needs a module name (-s argument).",
                                  m_cmd_name.c_str());
     return;
   }
 
   if (m_options.m_symbols.empty()) {
     result.AppendErrorWithFormat(
-        "%s needs at least one symbol name (-n argument).\n",
-        m_cmd_name.c_str());
+        "%s needs at least one symbol name (-n argument).", m_cmd_name.c_str());
     return;
   }
 
   if (m_options.m_regex && m_options.m_symbols.size() > 1) {
     result.AppendErrorWithFormat(
-        "%s needs only one symbol regular expression (-n argument).\n",
+        "%s needs only one symbol regular expression (-n argument).",
         m_cmd_name.c_str());
     return;
   }
@@ -1031,7 +1029,7 @@ public:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     uint32_t recognizer_id;
     if (!llvm::to_integer(command.GetArgumentAtIndex(0), recognizer_id)) {
-      result.AppendErrorWithFormat("'%s' is not a valid recognizer id.\n",
+      result.AppendErrorWithFormat("'%s' is not a valid recognizer id.",
                                    command.GetArgumentAtIndex(0));
       return;
     }
@@ -1057,7 +1055,7 @@ protected:
                        uint32_t recognizer_id) override {
     auto &recognizer_mgr = GetTarget().GetFrameRecognizerManager();
     if (!recognizer_mgr.SetEnabledForID(recognizer_id, true)) {
-      result.AppendErrorWithFormat("'%u' is not a valid recognizer id.\n",
+      result.AppendErrorWithFormat("'%u' is not a valid recognizer id.",
                                    recognizer_id);
       return;
     }
@@ -1082,7 +1080,7 @@ protected:
                        uint32_t recognizer_id) override {
     auto &recognizer_mgr = GetTarget().GetFrameRecognizerManager();
     if (!recognizer_mgr.SetEnabledForID(recognizer_id, false)) {
-      result.AppendErrorWithFormat("'%u' is not a valid recognizer id.\n",
+      result.AppendErrorWithFormat("'%u' is not a valid recognizer id.",
                                    recognizer_id);
       return;
     }
@@ -1107,7 +1105,7 @@ protected:
                        uint32_t recognizer_id) override {
     auto &recognizer_mgr = GetTarget().GetFrameRecognizerManager();
     if (!recognizer_mgr.RemoveRecognizerWithID(recognizer_id)) {
-      result.AppendErrorWithFormat("'%u' is not a valid recognizer id.\n",
+      result.AppendErrorWithFormat("'%u' is not a valid recognizer id.",
                                    recognizer_id);
       return;
     }
@@ -1190,7 +1188,7 @@ protected:
     }
     if (command.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat(
-          "'%s' takes exactly one frame index argument.\n", m_cmd_name.c_str());
+          "'%s' takes exactly one frame index argument.", m_cmd_name.c_str());
       return;
     }
 

--- a/lldb/source/Commands/CommandObjectLog.cpp
+++ b/lldb/source/Commands/CommandObjectLog.cpp
@@ -163,7 +163,7 @@ protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
     if (args.GetArgumentCount() < 2) {
       result.AppendErrorWithFormat(
-          "%s takes a log channel and one or more log types.\n",
+          "%s takes a log channel and one or more log types.",
           m_cmd_name.c_str());
       return;
     }
@@ -257,7 +257,7 @@ protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
     if (args.empty()) {
       result.AppendErrorWithFormat(
-          "%s takes a log channel and one or more log types.\n",
+          "%s takes a log channel and one or more log types.",
           m_cmd_name.c_str());
       return;
     }
@@ -372,7 +372,7 @@ protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
     if (args.empty()) {
       result.AppendErrorWithFormat(
-          "%s takes a log channel and one or more log types.\n",
+          "%s takes a log channel and one or more log types.",
           m_cmd_name.c_str());
       return;
     }
@@ -444,7 +444,7 @@ protected:
 
     if (!result.Succeeded()) {
       result.AppendError("Missing subcommand");
-      result.AppendErrorWithFormat("Usage: %s\n", m_cmd_syntax.c_str());
+      result.AppendErrorWithFormat("Usage: %s", m_cmd_syntax.c_str());
     }
   }
 };
@@ -467,7 +467,7 @@ protected:
 
     if (!result.Succeeded()) {
       result.AppendError("Missing subcommand");
-      result.AppendErrorWithFormat("Usage: %s\n", m_cmd_syntax.c_str());
+      result.AppendErrorWithFormat("Usage: %s", m_cmd_syntax.c_str());
     }
   }
 };
@@ -488,7 +488,7 @@ protected:
 
     if (!result.Succeeded()) {
       result.AppendError("Missing subcommand");
-      result.AppendErrorWithFormat("Usage: %s\n", m_cmd_syntax.c_str());
+      result.AppendErrorWithFormat("Usage: %s", m_cmd_syntax.c_str());
     }
   }
 };
@@ -510,7 +510,7 @@ protected:
 
     if (!result.Succeeded()) {
       result.AppendError("Missing subcommand");
-      result.AppendErrorWithFormat("Usage: %s\n", m_cmd_syntax.c_str());
+      result.AppendErrorWithFormat("Usage: %s", m_cmd_syntax.c_str());
     }
   }
 };
@@ -552,7 +552,7 @@ protected:
 
     if (!result.Succeeded()) {
       result.AppendError("Missing subcommand");
-      result.AppendErrorWithFormat("Usage: %s\n", m_cmd_syntax.c_str());
+      result.AppendErrorWithFormat("Usage: %s", m_cmd_syntax.c_str());
     }
   }
 };

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -358,7 +358,7 @@ protected:
 
     if ((argc == 0 && m_next_addr == LLDB_INVALID_ADDRESS) || argc > 2) {
       result.AppendErrorWithFormat("%s takes a start address expression with "
-                                   "an optional end address expression.\n",
+                                   "an optional end address expression.",
                                    m_cmd_name.c_str());
       result.AppendWarning("expressions should be quoted if they contain "
                            "spaces or other special characters");
@@ -440,7 +440,7 @@ protected:
               reference_count = 1;
               type_str.erase(type_str.size() - 1);
             } else {
-              result.AppendErrorWithFormat("invalid type string: '%s'\n",
+              result.AppendErrorWithFormat("invalid type string: '%s'",
                                            view_as_type_cstr);
               return;
             }
@@ -504,7 +504,7 @@ protected:
           compiler_type = type_sp->GetFullCompilerType();
         } else {
           result.AppendErrorWithFormat("unable to find any types that match "
-                                       "the raw type '%s' for full type '%s'\n",
+                                       "the raw type '%s' for full type '%s'",
                                        lookup_type_name.GetCString(),
                                        view_as_type_cstr);
           return;
@@ -597,13 +597,13 @@ protected:
       } else if (end_addr <= addr) {
         result.AppendErrorWithFormat(
             "end address (0x%" PRIx64
-            ") must be greater than the start address (0x%" PRIx64 ").\n",
+            ") must be greater than the start address (0x%" PRIx64 ").",
             end_addr, addr);
         return;
       } else if (m_format_options.GetCountValue().OptionWasSet()) {
         result.AppendErrorWithFormat(
             "specify either the end address (0x%" PRIx64
-            ") or the count (--count %" PRIu64 "), not both.\n",
+            ") or the count (--count %" PRIu64 "), not both.",
             end_addr, (uint64_t)item_count);
         return;
       }
@@ -617,12 +617,12 @@ protected:
     if (total_byte_size > max_unforced_size && !m_memory_options.m_force) {
       result.AppendErrorWithFormat(
           "Normally, \'memory read\' will not read over %" PRIu32
-          " bytes of data.\n",
+          " bytes of data.",
           max_unforced_size);
       result.AppendErrorWithFormat(
-          "Please use --force to override this restriction just once.\n");
+          "Please use --force to override this restriction just once.");
       result.AppendErrorWithFormat("or set target.max-memory-read-size if you "
-                                   "will often need a larger limit.\n");
+                                   "will often need a larger limit.");
       return;
     }
 
@@ -664,7 +664,7 @@ protected:
           result.AppendError(error_cstr);
         } else {
           result.AppendErrorWithFormat(
-              "failed to read memory from 0x%" PRIx64 ".\n", addr);
+              "failed to read memory from 0x%" PRIx64 ".", addr);
         }
         return;
       }
@@ -706,7 +706,7 @@ protected:
             Address(data_addr), &buffer[0], item_byte_size + 1, error);
         if (error.Fail()) {
           result.AppendErrorWithFormat(
-              "failed to read memory from 0x%" PRIx64 ".\n", addr);
+              "failed to read memory from 0x%" PRIx64 ".", addr);
           return;
         }
 
@@ -772,7 +772,7 @@ protected:
             return;
           } else {
             result.AppendErrorWithFormat("Failed to write %" PRIu64
-                                         " bytes to '%s'.\n",
+                                         " bytes to '%s'.",
                                          (uint64_t)bytes_read, path.c_str());
             return;
           }
@@ -783,7 +783,7 @@ protected:
           output_stream_p = output_stream_storage.get();
         }
       } else {
-        result.AppendErrorWithFormat("Failed to open file '%s' for %s:\n",
+        result.AppendErrorWithFormat("Failed to open file '%s' for %s:",
                                      path.c_str(), append ? "append" : "write");
 
         result.AppendError(llvm::toString(outfile.takeError()));
@@ -815,8 +815,8 @@ protected:
           }
         } else {
           result.AppendErrorWithFormat(
-              "failed to create a value object for: (%s) %s\n",
-              view_as_type_cstr, name_strm.GetData());
+              "failed to create a value object for: (%s) %s", view_as_type_cstr,
+              name_strm.GetData());
           return;
         }
       }
@@ -1261,19 +1261,19 @@ protected:
     if (m_memory_options.m_infile) {
       if (argc < 1) {
         result.AppendErrorWithFormat(
-            "%s takes a destination address when writing file contents.\n",
+            "%s takes a destination address when writing file contents.",
             m_cmd_name.c_str());
         return;
       }
       if (argc > 1) {
         result.AppendErrorWithFormat(
-            "%s takes only a destination address when writing file contents.\n",
+            "%s takes only a destination address when writing file contents.",
             m_cmd_name.c_str());
         return;
       }
     } else if (argc < 2) {
       result.AppendErrorWithFormat(
-          "%s takes a destination address and at least one value.\n",
+          "%s takes a destination address and at least one value.",
           m_cmd_name.c_str());
       return;
     }
@@ -1322,12 +1322,12 @@ protected:
             result.SetStatus(eReturnStatusSuccessFinishResult);
           } else {
             result.AppendErrorWithFormat("Memory write to 0x%" PRIx64
-                                         " failed: %s.\n",
+                                         " failed: %s.",
                                          addr, error.AsCString());
           }
         }
       } else {
-        result.AppendErrorWithFormat("Unable to read contents of file.\n");
+        result.AppendErrorWithFormat("Unable to read contents of file.");
       }
       return;
     } else if (item_byte_size == 0) {
@@ -1389,13 +1389,13 @@ protected:
         if (!success)
           success = !entry.ref().getAsInteger(16, uval64);
         if (!success) {
-          result.AppendErrorWithFormat(
-              "'%s' is not a valid hex string value.\n", entry.c_str());
+          result.AppendErrorWithFormat("'%s' is not a valid hex string value.",
+                                       entry.c_str());
           return;
         } else if (!llvm::isUIntN(item_byte_size * 8, uval64)) {
           result.AppendErrorWithFormat("Value 0x%" PRIx64
                                        " is too large to fit in a %" PRIu64
-                                       " byte unsigned integer value.\n",
+                                       " byte unsigned integer value.",
                                        uval64, (uint64_t)item_byte_size);
           return;
         }
@@ -1406,7 +1406,7 @@ protected:
         uval64 = OptionArgParser::ToBoolean(entry.ref(), false, &success);
         if (!success) {
           result.AppendErrorWithFormat(
-              "'%s' is not a valid boolean string value.\n", entry.c_str());
+              "'%s' is not a valid boolean string value.", entry.c_str());
           return;
         }
         buffer.PutMaxHex64(uval64, item_byte_size);
@@ -1415,12 +1415,12 @@ protected:
       case eFormatBinary:
         if (entry.ref().getAsInteger(2, uval64)) {
           result.AppendErrorWithFormat(
-              "'%s' is not a valid binary string value.\n", entry.c_str());
+              "'%s' is not a valid binary string value.", entry.c_str());
           return;
         } else if (!llvm::isUIntN(item_byte_size * 8, uval64)) {
           result.AppendErrorWithFormat("Value 0x%" PRIx64
                                        " is too large to fit in a %" PRIu64
-                                       " byte unsigned integer value.\n",
+                                       " byte unsigned integer value.",
                                        uval64, (uint64_t)item_byte_size);
           return;
         }
@@ -1451,12 +1451,12 @@ protected:
       case eFormatDecimal:
         if (entry.ref().getAsInteger(0, sval64)) {
           result.AppendErrorWithFormat(
-              "'%s' is not a valid signed decimal value.\n", entry.c_str());
+              "'%s' is not a valid signed decimal value.", entry.c_str());
           return;
         } else if (!llvm::isIntN(item_byte_size * 8, sval64)) {
           result.AppendErrorWithFormat(
               "Value %" PRIi64 " is too large or small to fit in a %" PRIu64
-              " byte signed integer value.\n",
+              " byte signed integer value.",
               sval64, (uint64_t)item_byte_size);
           return;
         }
@@ -1467,13 +1467,13 @@ protected:
 
         if (entry.ref().getAsInteger(0, uval64)) {
           result.AppendErrorWithFormat(
-              "'%s' is not a valid unsigned decimal string value.\n",
+              "'%s' is not a valid unsigned decimal string value.",
               entry.c_str());
           return;
         } else if (!llvm::isUIntN(item_byte_size * 8, uval64)) {
           result.AppendErrorWithFormat("Value %" PRIu64
                                        " is too large to fit in a %" PRIu64
-                                       " byte unsigned integer value.\n",
+                                       " byte unsigned integer value.",
                                        uval64, (uint64_t)item_byte_size);
           return;
         }
@@ -1483,12 +1483,12 @@ protected:
       case eFormatOctal:
         if (entry.ref().getAsInteger(8, uval64)) {
           result.AppendErrorWithFormat(
-              "'%s' is not a valid octal string value.\n", entry.c_str());
+              "'%s' is not a valid octal string value.", entry.c_str());
           return;
         } else if (!llvm::isUIntN(item_byte_size * 8, uval64)) {
           result.AppendErrorWithFormat("Value %" PRIo64
                                        " is too large to fit in a %" PRIu64
-                                       " byte unsigned integer value.\n",
+                                       " byte unsigned integer value.",
                                        uval64, (uint64_t)item_byte_size);
           return;
         }
@@ -1506,7 +1506,7 @@ protected:
 
       if (write_size != buffer_size) {
         result.AppendErrorWithFormat("Memory write to 0x%" PRIx64
-                                     " failed: %s.\n",
+                                     " failed: %s.",
                                      addr, error.AsCString());
         return;
       }
@@ -1742,7 +1742,7 @@ protected:
             (abi && (abi->FixAnyAddress(load_addr) != load_addr))) {
           result.AppendErrorWithFormat(
               "No next region address set: one address expression argument or "
-              "\"--all\" option required:\nUsage: %s\n",
+              "\"--all\" option required:\nUsage: %s",
               m_cmd_syntax.c_str());
           return;
         }
@@ -1759,14 +1759,14 @@ protected:
       load_addr = OptionArgParser::ToAddress(&m_exe_ctx, load_addr_str,
                                              LLDB_INVALID_ADDRESS, &error);
       if (error.Fail() || load_addr == LLDB_INVALID_ADDRESS) {
-        result.AppendErrorWithFormat("invalid address argument \"%s\": %s\n",
+        result.AppendErrorWithFormat("invalid address argument \"%s\": %s",
                                      command[0].c_str(), error.AsCString());
         return;
       }
     } else {
       // argc > 1
       result.AppendErrorWithFormat(
-          "'%s' takes one argument or \"--all\" option:\nUsage: %s\n",
+          "'%s' takes one argument or \"--all\" option:\nUsage: %s",
           m_cmd_name.c_str(), m_cmd_syntax.c_str());
       return;
     }
@@ -1811,7 +1811,7 @@ protected:
       return;
     }
 
-    result.AppendErrorWithFormat("%s\n", error.AsCString());
+    result.AppendErrorWithFormat("%s", error.AsCString());
   }
 
   std::optional<std::string> GetRepeatCommand(Args &current_command_args,

--- a/lldb/source/Commands/CommandObjectMemoryTag.cpp
+++ b/lldb/source/Commands/CommandObjectMemoryTag.cpp
@@ -218,7 +218,7 @@ protected:
       // getAsInteger returns true on failure
       if (entry.ref().getAsInteger(0, tag_value)) {
         result.AppendErrorWithFormat(
-            "'%s' is not a valid unsigned decimal string value.\n",
+            "'%s' is not a valid unsigned decimal string value.",
             entry.c_str());
         return;
       }

--- a/lldb/source/Commands/CommandObjectMultiword.cpp
+++ b/lldb/source/Commands/CommandObjectMultiword.cpp
@@ -164,7 +164,7 @@ void CommandObjectMultiword::Execute(const char *args_string,
   }
 
   if (m_subcommand_dict.empty()) {
-    result.AppendErrorWithFormat("'%s' does not have any subcommands.\n",
+    result.AppendErrorWithFormat("'%s' does not have any subcommands.",
                                  GetCommandName().str().c_str());
     return;
   }

--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -1242,8 +1242,8 @@ protected:
                                    m_options.show_args, m_options.verbose);
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
-          result.AppendErrorWithFormat(
-              "no process found with pid = %" PRIu64, pid);
+          result.AppendErrorWithFormat("no process found with pid = %" PRIu64,
+                                       pid);
         }
       } else {
         ProcessInstanceInfoList proc_infos;

--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -297,7 +297,7 @@ protected:
           result.AppendError(error.AsCString());
         }
       } else {
-        result.AppendErrorWithFormat("%s\n", error.AsCString());
+        result.AppendErrorWithFormat("%s", error.AsCString());
       }
     } else {
       result.AppendError("no platform is currently selected\n");
@@ -1243,7 +1243,7 @@ protected:
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
           result.AppendErrorWithFormat(
-              "no process found with pid = %" PRIu64 "\n", pid);
+              "no process found with pid = %" PRIu64, pid);
         }
       } else {
         ProcessInstanceInfoList proc_infos;

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -89,9 +89,8 @@ protected:
               result.SetStatus(eReturnStatusSuccessFinishResult);
               process = nullptr;
             } else {
-              result.AppendErrorWithFormat(
-                  "Failed to detach from process: %s\n",
-                  detach_error.AsCString());
+              result.AppendErrorWithFormat("Failed to detach from process: %s",
+                                           detach_error.AsCString());
             }
           } else {
             Status destroy_error(process->Destroy(false));
@@ -99,7 +98,7 @@ protected:
               result.SetStatus(eReturnStatusSuccessFinishResult);
               process = nullptr;
             } else {
-              result.AppendErrorWithFormat("Failed to kill process: %s\n",
+              result.AppendErrorWithFormat("Failed to kill process: %s",
                                            destroy_error.AsCString());
             }
           }
@@ -371,7 +370,7 @@ protected:
             "no error returned from Target::Attach, and target has no process");
       }
     } else {
-      result.AppendErrorWithFormat("attach failed: %s\n", error.AsCString());
+      result.AppendErrorWithFormat("attach failed: %s", error.AsCString());
     }
 
     if (!result.Succeeded())
@@ -732,12 +731,12 @@ protected:
           result.SetStatus(eReturnStatusSuccessContinuingNoResult);
         }
       } else {
-        result.AppendErrorWithFormat("Failed to resume process: %s.\n",
+        result.AppendErrorWithFormat("Failed to resume process: %s.",
                                      error.AsCString());
       }
     } else {
       result.AppendErrorWithFormat(
-          "Process cannot be continued from its current state (%s).\n",
+          "Process cannot be continued from its current state (%s).",
           StateAsCString(state));
     }
   }
@@ -827,7 +826,7 @@ protected:
     if (error.Success()) {
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else {
-      result.AppendErrorWithFormat("Detach failed: %s\n", error.AsCString());
+      result.AppendErrorWithFormat("Detach failed: %s", error.AsCString());
     }
   }
 
@@ -896,7 +895,7 @@ protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat(
-          "'%s' takes exactly one argument:\nUsage: %s\n", m_cmd_name.c_str(),
+          "'%s' takes exactly one argument:\nUsage: %s", m_cmd_name.c_str(),
           m_cmd_syntax.c_str());
       return;
     }
@@ -905,7 +904,7 @@ protected:
     if (process && process->IsAlive()) {
       result.AppendErrorWithFormat(
           "Process %" PRIu64
-          " is currently being debugged, kill the process before connecting.\n",
+          " is currently being debugged, kill the process before connecting.",
           process->GetID());
       return;
     }
@@ -1179,20 +1178,20 @@ protected:
         signo = process->GetUnixSignals()->GetSignalNumberFromName(signal_name);
 
       if (signo == LLDB_INVALID_SIGNAL_NUMBER) {
-        result.AppendErrorWithFormat("Invalid signal argument '%s'.\n",
+        result.AppendErrorWithFormat("Invalid signal argument '%s'.",
                                      command.GetArgumentAtIndex(0));
       } else {
         Status error(process->Signal(signo));
         if (error.Success()) {
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
-          result.AppendErrorWithFormat("Failed to send signal %i: %s\n", signo,
+          result.AppendErrorWithFormat("Failed to send signal %i: %s", signo,
                                        error.AsCString());
         }
       }
     } else {
       result.AppendErrorWithFormat(
-          "'%s' takes exactly one signal number argument:\nUsage: %s\n",
+          "'%s' takes exactly one signal number argument:\nUsage: %s",
           m_cmd_name.c_str(), m_cmd_syntax.c_str());
     }
   }
@@ -1225,7 +1224,7 @@ protected:
     if (error.Success()) {
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else {
-      result.AppendErrorWithFormat("Failed to halt process: %s\n",
+      result.AppendErrorWithFormat("Failed to halt process: %s",
                                    error.AsCString());
     }
   }
@@ -1257,7 +1256,7 @@ protected:
     if (error.Success()) {
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else {
-      result.AppendErrorWithFormat("Failed to kill process: %s\n",
+      result.AppendErrorWithFormat("Failed to kill process: %s",
                                    error.AsCString());
     }
   }
@@ -1379,7 +1378,7 @@ protected:
               output_file.GetPath(), error);
         }
       } else {
-        result.AppendErrorWithFormat("'%s' takes one arguments:\nUsage: %s\n",
+        result.AppendErrorWithFormat("'%s' takes one arguments:\nUsage: %s",
                                      m_cmd_name.c_str(), m_cmd_syntax.c_str());
       }
     } else {
@@ -1759,8 +1758,8 @@ protected:
               signals_sp->SetShouldNotify(signo, *notify_action);
             ++num_signals_set;
           } else {
-            result.AppendErrorWithFormat("Invalid signal name '%s'\n",
-                                          arg.c_str());
+            result.AppendErrorWithFormat("Invalid signal name '%s'",
+                                         arg.c_str());
             continue;
           }
         } else {

--- a/lldb/source/Commands/CommandObjectRegister.cpp
+++ b/lldb/source/Commands/CommandObjectRegister.cpp
@@ -172,7 +172,7 @@ protected:
             }
           } else {
             result.AppendErrorWithFormat(
-                "invalid register set index: %" PRIu64 "\n", (uint64_t)set_idx);
+                "invalid register set index: %" PRIu64, (uint64_t)set_idx);
             break;
           }
         }
@@ -214,7 +214,7 @@ protected:
                               print_flags))
               strm.Printf("%-12s = error: unavailable\n", reg_info->name);
           } else {
-            result.AppendErrorWithFormat("Invalid register name '%s'.\n",
+            result.AppendErrorWithFormat("Invalid register name '%s'.",
                                          arg_str.str().c_str());
           }
         }
@@ -368,7 +368,7 @@ protected:
         }
         if (error.AsCString()) {
           result.AppendErrorWithFormat(
-              "Failed to write register '%s' with value '%s': %s\n",
+              "Failed to write register '%s' with value '%s': %s",
               reg_name.str().c_str(), value_str.str().c_str(),
               error.AsCString());
         } else {
@@ -377,7 +377,7 @@ protected:
               reg_name.str().c_str(), value_str.str().c_str());
         }
       } else {
-        result.AppendErrorWithFormat("Register not found for '%s'.\n",
+        result.AppendErrorWithFormat("Register not found for '%s'.",
                                      reg_name.str().c_str());
       }
     }
@@ -439,7 +439,7 @@ protected:
           GetCommandInterpreter().GetDebugger().GetTerminalWidth());
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else
-      result.AppendErrorWithFormat("No register found with name '%s'.\n",
+      result.AppendErrorWithFormat("No register found with name '%s'.",
                                    reg_name.str().c_str());
   }
 };

--- a/lldb/source/Commands/CommandObjectRegister.cpp
+++ b/lldb/source/Commands/CommandObjectRegister.cpp
@@ -171,8 +171,8 @@ protected:
               break;
             }
           } else {
-            result.AppendErrorWithFormat(
-                "invalid register set index: %" PRIu64, (uint64_t)set_idx);
+            result.AppendErrorWithFormat("invalid register set index: %" PRIu64,
+                                         (uint64_t)set_idx);
             break;
           }
         }


### PR DESCRIPTION
Follow up to #192965.

This call adds a newline if there isn't one. Changing these will
eventually let us always add a newline, which is in line with
the other methods on CommandReturnObject.

This is a small part of calls found with:
* VSCode search for `(\.AppendErrorWithFormat\(([\s\r\n]+)?"(?:(?:\\.|[^"\\])*))\\n"` and replace with `$1"`.
* Asserting that the last character of the format string is not a newline.
* Manual inspection.