### PR TITLE
[NFC][SPIR-V] Add urem, srem, and snegate tests for integer arithmetic

### DIFF
--- a/llvm/test/CodeGen/SPIRV/instructions/scalar-integer-arithmetic.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/scalar-integer-arithmetic.ll
@@ -11,15 +11,18 @@
 ; CHECK-DAG: OpName [[SCALAR_MUL:%.+]] "scalar_mul"
 ; CHECK-DAG: OpName [[SCALAR_UDIV:%.+]] "scalar_udiv"
 ; CHECK-DAG: OpName [[SCALAR_SDIV:%.+]] "scalar_sdiv"
-;; TODO: add tests for urem + srem
-;; TODO: add test for OpSNegate
+; CHECK-DAG: OpName [[SCALAR_UREM:%.+]] "scalar_urem"
+; CHECK-DAG: OpName [[SCALAR_SREM:%.+]] "scalar_srem"
+; CHECK-DAG: OpName [[SCALAR_SNEGATE:%.+]] "scalar_snegate"
 
 ; CHECK-NOT: DAG-FENCE
 
 ; CHECK-DAG: [[BOOL:%.+]] = OpTypeBool
 ; CHECK-DAG: [[SCALAR:%.+]] = OpTypeInt 32
 ; CHECK-DAG: [[SCALAR_FN:%.+]] = OpTypeFunction [[SCALAR]] [[SCALAR]] [[SCALAR]]
+; CHECK-DAG: [[SCALAR_FN1:%.+]] = OpTypeFunction [[SCALAR]] [[SCALAR]]
 ; CHECK-DAG: [[BOOL_FN:%.+]] = OpTypeFunction [[BOOL]] [[BOOL]] [[BOOL]]
+; CHECK-DAG: [[ZERO:%.+]] = OpConstantNull [[SCALAR]]
 
 ; CHECK-NOT: DAG-FENCE
 
@@ -121,5 +124,49 @@ define i32 @scalar_sdiv(i32 %a, i32 %b) {
 ; CHECK-NEXT: [[B:%.+]] = OpFunctionParameter [[SCALAR]]
 ; CHECK:      OpLabel
 ; CHECK:      [[C:%.+]] = OpSDiv [[SCALAR]] [[A]] [[B]]
+; CHECK:      OpReturnValue [[C]]
+; CHECK-NEXT: OpFunctionEnd
+
+
+;; Test urem on scalar:
+define i32 @scalar_urem(i32 %a, i32 %b) {
+    %c = urem i32 %a, %b
+    ret i32 %c
+}
+
+; CHECK:      [[SCALAR_UREM]] = OpFunction [[SCALAR]] None [[SCALAR_FN]]
+; CHECK-NEXT: [[A:%.+]] = OpFunctionParameter [[SCALAR]]
+; CHECK-NEXT: [[B:%.+]] = OpFunctionParameter [[SCALAR]]
+; CHECK:      OpLabel
+; CHECK:      [[C:%.+]] = OpUMod [[SCALAR]] [[A]] [[B]]
+; CHECK:      OpReturnValue [[C]]
+; CHECK-NEXT: OpFunctionEnd
+
+
+;; Test srem on scalar:
+define i32 @scalar_srem(i32 %a, i32 %b) {
+    %c = srem i32 %a, %b
+    ret i32 %c
+}
+
+; CHECK:      [[SCALAR_SREM]] = OpFunction [[SCALAR]] None [[SCALAR_FN]]
+; CHECK-NEXT: [[A:%.+]] = OpFunctionParameter [[SCALAR]]
+; CHECK-NEXT: [[B:%.+]] = OpFunctionParameter [[SCALAR]]
+; CHECK:      OpLabel
+; CHECK:      [[C:%.+]] = OpSRem [[SCALAR]] [[A]] [[B]]
+; CHECK:      OpReturnValue [[C]]
+; CHECK-NEXT: OpFunctionEnd
+
+
+;; Test snegate on scalar:
+define i32 @scalar_snegate(i32 %a) {
+    %c = sub i32 0, %a
+    ret i32 %c
+}
+
+; CHECK:      [[SCALAR_SNEGATE]] = OpFunction [[SCALAR]] None [[SCALAR_FN1]]
+; CHECK-NEXT: [[A:%.+]] = OpFunctionParameter [[SCALAR]]
+; CHECK:      OpLabel
+; CHECK:      [[C:%.+]] = OpISub [[SCALAR]] [[ZERO]] [[A]]
 ; CHECK:      OpReturnValue [[C]]
 ; CHECK-NEXT: OpFunctionEnd

--- a/llvm/test/CodeGen/SPIRV/instructions/vector-integer-arithmetic.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/vector-integer-arithmetic.ll
@@ -6,14 +6,17 @@
 ; CHECK-DAG: OpName [[VECTOR_MUL:%.+]] "vector_mul"
 ; CHECK-DAG: OpName [[VECTOR_UDIV:%.+]] "vector_udiv"
 ; CHECK-DAG: OpName [[VECTOR_SDIV:%.+]] "vector_sdiv"
-;; TODO: add tests for urem + srem
-;; TODO: add test for OpSNegate
+; CHECK-DAG: OpName [[VECTOR_UREM:%.+]] "vector_urem"
+; CHECK-DAG: OpName [[VECTOR_SREM:%.+]] "vector_srem"
+; CHECK-DAG: OpName [[VECTOR_SNEGATE:%.+]] "vector_snegate"
 
 ; CHECK-NOT: DAG-FENCE
 
 ; CHECK-DAG: [[I16:%.+]] = OpTypeInt 16
 ; CHECK-DAG: [[VECTOR:%.+]] = OpTypeVector [[I16]]
 ; CHECK-DAG: [[VECTOR_FN:%.+]] = OpTypeFunction [[VECTOR]] [[VECTOR]] [[VECTOR]]
+; CHECK-DAG: [[VECTOR_FN1:%.+]] = OpTypeFunction [[VECTOR]] [[VECTOR]]
+; CHECK-DAG: [[ZERO:%.+]] = OpConstantNull [[VECTOR]]
 
 ; CHECK-NOT: DAG-FENCE
 
@@ -89,5 +92,49 @@ define <2 x i16> @vector_sdiv(<2 x i16> %a, <2 x i16> %b) {
 ; CHECK-NEXT: [[B:%.+]] = OpFunctionParameter [[VECTOR]]
 ; CHECK:      OpLabel
 ; CHECK:      [[C:%.+]] = OpSDiv [[VECTOR]] [[A]] [[B]]
+; CHECK:      OpReturnValue [[C]]
+; CHECK-NEXT: OpFunctionEnd
+
+
+;; Test urem on vector:
+define <2 x i16> @vector_urem(<2 x i16> %a, <2 x i16> %b) {
+    %c = urem <2 x i16> %a, %b
+    ret <2 x i16> %c
+}
+
+; CHECK:      [[VECTOR_UREM]] = OpFunction [[VECTOR]] None [[VECTOR_FN]]
+; CHECK-NEXT: [[A:%.+]] = OpFunctionParameter [[VECTOR]]
+; CHECK-NEXT: [[B:%.+]] = OpFunctionParameter [[VECTOR]]
+; CHECK:      OpLabel
+; CHECK:      [[C:%.+]] = OpUMod [[VECTOR]] [[A]] [[B]]
+; CHECK:      OpReturnValue [[C]]
+; CHECK-NEXT: OpFunctionEnd
+
+
+;; Test srem on vector:
+define <2 x i16> @vector_srem(<2 x i16> %a, <2 x i16> %b) {
+    %c = srem <2 x i16> %a, %b
+    ret <2 x i16> %c
+}
+
+; CHECK:      [[VECTOR_SREM]] = OpFunction [[VECTOR]] None [[VECTOR_FN]]
+; CHECK-NEXT: [[A:%.+]] = OpFunctionParameter [[VECTOR]]
+; CHECK-NEXT: [[B:%.+]] = OpFunctionParameter [[VECTOR]]
+; CHECK:      OpLabel
+; CHECK:      [[C:%.+]] = OpSRem [[VECTOR]] [[A]] [[B]]
+; CHECK:      OpReturnValue [[C]]
+; CHECK-NEXT: OpFunctionEnd
+
+
+;; Test snegate on vector:
+define <2 x i16> @vector_snegate(<2 x i16> %a) {
+    %c = sub <2 x i16> zeroinitializer, %a
+    ret <2 x i16> %c
+}
+
+; CHECK:      [[VECTOR_SNEGATE]] = OpFunction [[VECTOR]] None [[VECTOR_FN1]]
+; CHECK-NEXT: [[A:%.+]] = OpFunctionParameter [[VECTOR]]
+; CHECK:      OpLabel
+; CHECK:      [[C:%.+]] = OpISub [[VECTOR]] [[ZERO]] [[A]]
 ; CHECK:      OpReturnValue [[C]]
 ; CHECK-NEXT: OpFunctionEnd


### PR DESCRIPTION
Add test coverage for OpUMod, OpSRem, and OpISub (negate) for both scalar and vector integer arithmetic