### PR TITLE
Fixed issue of use after move

### DIFF
--- a/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
@@ -443,10 +443,8 @@ static void FactorNodes(MatcherList &ML) {
         std::next(J) != E) {
       LLVM_DEBUG(
           errs() << "Couldn't merge this:\n";
-          EqualMatchers[0].print(errs(), indent(4)); 
-          errs() << "into this:\n";
-          J->print(errs(), indent(4)); 
-          std::next(J)->front()->printOne(errs());
+          EqualMatchers[0].print(errs(), indent(4)); errs() << "into this:\n";
+          J->print(errs(), indent(4)); std::next(J)->front()->printOne(errs());
           if (std::next(J, 2) != E) std::next(J, 2)->front()->printOne(errs());
           errs() << "\n");
     }

--- a/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
@@ -443,8 +443,10 @@ static void FactorNodes(MatcherList &ML) {
         std::next(J) != E) {
       LLVM_DEBUG(
           errs() << "Couldn't merge this:\n";
-          EqualMatchers[0].print(errs(), indent(4)); errs() << "into this:\n";
-          J->print(errs(), indent(4)); std::next(J)->front()->printOne(errs());
+          EqualMatchers[0].print(errs(), indent(4)); 
+          errs() << "into this:\n";
+          J->print(errs(), indent(4)); 
+          std::next(J)->front()->printOne(errs());
           if (std::next(J, 2) != E) std::next(J, 2)->front()->printOne(errs());
           errs() << "\n");
     }

--- a/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
@@ -442,7 +442,7 @@ static void FactorNodes(MatcherList &ML) {
         // Don't print if it's obvious nothing extract could be merged anyway.
         std::next(J) != E) {
       LLVM_DEBUG(
-          errs() << "Couldn't merge this:\n"; I->print(errs(), indent(4));
+          errs() << "Couldn't merge this:\n"; EqualMatchers[0].print(errs(), indent(4));
           errs() << "into this:\n"; J->print(errs(), indent(4));
           std::next(J)->front()->printOne(errs());
           if (std::next(J, 2) != E) std::next(J, 2)->front()->printOne(errs());

--- a/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
@@ -442,9 +442,9 @@ static void FactorNodes(MatcherList &ML) {
         // Don't print if it's obvious nothing extract could be merged anyway.
         std::next(J) != E) {
       LLVM_DEBUG(
-          errs() << "Couldn't merge this:\n"; EqualMatchers[0].print(errs(), indent(4));
-          errs() << "into this:\n"; J->print(errs(), indent(4));
-          std::next(J)->front()->printOne(errs());
+          errs() << "Couldn't merge this:\n";
+          EqualMatchers[0].print(errs(), indent(4)); errs() << "into this:\n";
+          J->print(errs(), indent(4)); std::next(J)->front()->printOne(errs());
           if (std::next(J, 2) != E) std::next(J, 2)->front()->printOne(errs());
           errs() << "\n");
     }


### PR DESCRIPTION
Variable "I" already moved at below code, and but still we are trying to access that after.
```
EqualMatchers.push_back(std::move(*I));
```