### PR TITLE
[NFC] [MC] Fixed rule-of-five for MCPseudoProbeDecoder class

### DIFF
--- a/llvm/include/llvm/MC/MCPseudoProbe.h
+++ b/llvm/include/llvm/MC/MCPseudoProbe.h
@@ -437,6 +437,7 @@ public:
   MCPseudoProbeDecoder(MCPseudoProbeDecoder &&) = delete;
   MCPseudoProbeDecoder &operator=(const MCPseudoProbeDecoder &) = delete;
   MCPseudoProbeDecoder &operator=(MCPseudoProbeDecoder &&) = delete;
+  ~MCPseudoProbeDecoder() = default;
 
   using Uint64Set = DenseSet<uint64_t>;
   using Uint64Map = DenseMap<uint64_t, uint64_t>;


### PR DESCRIPTION
- Added destructor for **MCPseudoProbeDecoder** class as rule of five (https://en.cppreference.com/cpp/language/rule_of_three)  