### PR TITLE
[libc++] Fix any.cpp not compiling with the minimum header version >= 7

### DIFF
--- a/libcxx/src/any.cpp
+++ b/libcxx/src/any.cpp
@@ -27,6 +27,6 @@ public:
 
 const char* bad_any_cast::what() const noexcept { return "bad any cast"; }
 
-#endif
-
 _LIBCPP_END_NAMESPACE_LFTS
+
+#endif


### PR DESCRIPTION
The namespace was accidentally closed outside the header version check
while it was opened inside the check. This moves the closing code into
the check.
