### PR TITLE
[Hexagon] Non-pie default on hexagon-unknown-elf

### DIFF
--- a/clang/lib/Driver/ToolChains/Hexagon.h
+++ b/clang/lib/Driver/ToolChains/Hexagon.h
@@ -117,6 +117,10 @@ public:
 
   std::string getCompilerRTPath() const override;
 
+  bool isPIEDefault(const llvm::opt::ArgList &Args) const override {
+    return getTriple().isOSLinux() && Linux::isPIEDefault(Args);
+  }
+
   static bool isAutoHVXEnabled(const llvm::opt::ArgList &Args);
   static StringRef GetDefaultCPU();
   static StringRef GetTargetCPUVersion(const llvm::opt::ArgList &Args);

--- a/clang/test/Driver/hexagon-toolchain-elf.c
+++ b/clang/test/Driver/hexagon-toolchain-elf.c
@@ -519,6 +519,17 @@
 // CHECK351-NOT:  "-pie"
 
 // -----------------------------------------------------------------------------
+// Test that -pie is not set by default
+// -----------------------------------------------------------------------------
+// RUN: %clang -### --target=hexagon-unknown-elf \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
+// RUN:   -mcpu=hexagonv60 \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=CHECK357 %s
+// CHECK357:      "-cc1"
+// CHECK357:      {{hexagon-link|ld}}
+// CHECK357-NOT:  "-pie"
+
+// -----------------------------------------------------------------------------
 // Test Assembler related args
 // -----------------------------------------------------------------------------
 // RUN: %clang -### --target=hexagon-unknown-elf -fno-integrated-as    \


### PR DESCRIPTION
The Hexagon driver on non-linux OS should not default to position independent executable (pie).
For standalone QuRT applications (non FastRPC), default to static executables.