### PR TITLE
[llvm-cov] Fix error propagation in CoverageMapping::load()

### DIFF
--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -1122,6 +1122,7 @@ Expected<std::unique_ptr<CoverageMapping>> CoverageMapping::load(
                                     llvm::toHex(BinaryID, /*LowerCase=*/true)));
         }
       }
+    }
   }
 
   if (!DataFound)

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -1106,19 +1106,22 @@ Expected<std::unique_ptr<CoverageMapping>> CoverageMapping::load(
     }
 
     for (object::BuildIDRef BinaryID : BinaryIDsToFetch) {
-      Expected<std::string> Path = BIDFetcher->fetch(BinaryID);
-      if (Path) {
+      if (Expected<std::string> Path = BIDFetcher->fetch(BinaryID)) {
         StringRef Arch = Arches.size() == 1 ? Arches.front() : StringRef();
         if (Error E = loadFromFile(*Path, Arch, CompilationDir,
                                    ProfileReaderRef, *Coverage, DataFound))
           return std::move(E);
+      } else {
+        // Conditionally propagate as new error.
+        consumeError(Path.takeError());
+        if (CheckBinaryIDs) {
+          return createFileError(
+              ProfileFilename.value(),
+              createStringError(errc::no_such_file_or_directory,
+                                "Missing binary ID: " +
+                                    llvm::toHex(BinaryID, /*LowerCase=*/true)));
+        }
       }
-      if (CheckBinaryIDs) {
-        return createFileError(ProfileFilename.value(), Path.takeError());
-      }
-      // Ignore error and continue.
-      consumeError(Path.takeError());
-    }
   }
 
   if (!DataFound)


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/191191 introduced a subtle issue on the error path: if `loadFromFile()` fails there is no error to consume. It broke the `Profile-x86_64 :: Linux/binary-id-lookup.c` test in compiler-rt: https://lab.llvm.org/buildbot/#/builders/174/builds/34707. This patch restores the original behavior.