### PR TITLE
Revert "[clang-tidy][NFC] add numeric include for transform_reduce"

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.cpp
@@ -8,7 +8,6 @@
 
 #include "IdentifierLengthCheck.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
-#include <numeric>
 
 using namespace clang::ast_matchers;
 


### PR DESCRIPTION
After experiment, this didn't fix the build failure. So revert this to keep the trunk clean.

Reverts llvm/llvm-project#193165