### PR TITLE
[Polly] Disable PCH reuse for unit tests

### DIFF
--- a/polly/unittests/CMakeLists.txt
+++ b/polly/unittests/CMakeLists.txt
@@ -6,7 +6,10 @@ set_target_properties(PollyUnitTests PROPERTIES FOLDER "Polly/Tests")
 # Will compile the list of files together and link against Polly and its dependences.
 function(add_polly_unittest test_name)
   if(COMMAND add_unittest)
-    add_unittest(PollyUnitTests ${test_name} ${ARGN})
+    # Match Polly library targets: Polly unit tests inherit Polly's
+    # unconditional -fno-rtti -fno-exceptions policy. Reusing LLVM PCHs
+    # built with RTTI or exceptions enabled is incompatible with Clang.
+    add_unittest(PollyUnitTests ${test_name} DISABLE_PCH_REUSE ${ARGN})
   else()
     add_executable(${test_name} EXCLUDE_FROM_ALL ${ARGN})
     set_target_properties(${test_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Polly library targets already disable PCH reuse because Polly unconditionally builds with -fno-rtti and -fno-exceptions. Reusing LLVM PCHs that were built with RTTI or exceptions enabled is incompatible with Clang when compiling Polly targets under those flags.

After 47eb8b43c990 enabled PCH reuse for unit tests, Polly unit tests can hit the same mismatch as the library targets. Pass DISABLE_PCH_REUSE through the shared add_polly_unittest wrapper so all Polly unit tests follow the existing Polly target policy.

cc @aengelke -- a minor fix for polly.