### PR TITLE
[clang][bytecode] 0 bitwidth IntAP values also use one word

### DIFF
--- a/clang/lib/AST/ByteCode/IntegralAP.h
+++ b/clang/lib/AST/ByteCode/IntegralAP.h
@@ -138,7 +138,7 @@ public:
 
   constexpr uint32_t bitWidth() const { return BitWidth; }
   constexpr unsigned numWords() const { return APInt::getNumWords(BitWidth); }
-  constexpr bool singleWord() const { return numWords() == 1; }
+  constexpr bool singleWord() const { return numWords() <= 1; }
   constexpr static bool isNumber() { return true; }
 
   APSInt toAPSInt(unsigned Bits = 0) const {

--- a/clang/test/AST/ByteCode/intap.cpp
+++ b/clang/test/AST/ByteCode/intap.cpp
@@ -69,6 +69,10 @@ constexpr _BitInt(32) nope = top / bottom;  // both-error {{must be initialized 
 constexpr _BitInt(32) noooo = top % bottom; // both-error {{must be initialized by a constant expression}} \
                                             // both-note {{value 2147483648 is outside the range}}
 
+struct {
+  _BitInt(35) void : 33; // both-error {{cannot combine with previous '_BitInt' declaration specifier}}
+} s;
+
 namespace APCast {
   constexpr _BitInt(10) A = 1;
   constexpr _BitInt(11) B = A;


### PR DESCRIPTION
Not 0. This can happen in error cases.