### PR TITLE
[Support] Add std::string overload for llvm::sys::path::native

### DIFF
--- a/llvm/include/llvm/Support/Path.h
+++ b/llvm/include/llvm/Support/Path.h
@@ -264,6 +264,14 @@ LLVM_ABI void append(SmallVectorImpl<char> &path, const_iterator begin,
 LLVM_ABI void native(const Twine &path, SmallVectorImpl<char> &result,
                      Style style = Style::native);
 
+/// Convert path to the native form and return it as a std::string. This is used
+/// to give paths to users and operating system calls in the platform's normal
+/// way. For example, on Windows all '/' are converted to '\'. On Unix, it
+/// converts all '\' to '/'.
+///
+/// @param path A path that is transformed to native format.
+LLVM_ABI std::string native(const Twine &path, Style style = Style::native);
+
 /// Convert path to the native form in place. This is used to give paths to
 /// users and operating system calls in the platform's normal way. For example,
 /// on Windows all '/' are converted to '\'.

--- a/llvm/lib/Support/Path.cpp
+++ b/llvm/lib/Support/Path.cpp
@@ -548,6 +548,12 @@ void native(const Twine &path, SmallVectorImpl<char> &result, Style style) {
   native(result, style);
 }
 
+std::string native(const Twine &path, Style style) {
+  SmallString<128> Result;
+  native(path, Result, style);
+  return std::string(Result);
+}
+
 void native(SmallVectorImpl<char> &Path, Style style) {
   if (Path.empty())
     return;

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -1734,6 +1734,16 @@ TEST(Support, NormalizePath) {
   }
 
   for (auto &T : Tests) {
+    std::string Win = path::native(std::get<0>(T), path::Style::windows);
+    std::string Posix = path::native(std::get<0>(T), path::Style::posix);
+    std::string WinSlash =
+        path::native(std::get<0>(T), path::Style::windows_slash);
+    EXPECT_EQ(std::get<1>(T), Win);
+    EXPECT_EQ(std::get<2>(T), Posix);
+    EXPECT_EQ(std::get<2>(T), WinSlash);
+  }
+
+  for (auto &T : Tests) {
     SmallString<64> WinBackslash(std::get<0>(T));
     SmallString<64> Posix(WinBackslash);
     SmallString<64> WinSlash(WinBackslash);


### PR DESCRIPTION
This patch adds an overload of `llvm::sys::path::native` that returns a `std::string` directly, making it more convenient to use when a `std::string` is needed instead of modifying a `SmallVectorImpl<char>` in place.

This is for https://github.com/llvm/llvm-project/pull/193160#discussion_r3117268925, but made separate PR.