### PR TITLE
[HLSL] Implement ConstantBuffer<T> with transparent member access

### DIFF
--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -691,6 +691,7 @@ KEYWORD(column_major                , KEYHLSL)
 TYPE_TRAIT_2(__builtin_hlsl_is_scalarized_layout_compatible, IsScalarizedLayoutCompatible, KEYHLSL)
 TYPE_TRAIT_1(__builtin_hlsl_is_intangible, IsIntangibleType, KEYHLSL)
 TYPE_TRAIT_1(__builtin_hlsl_is_typed_resource_element_compatible, IsTypedResourceElementCompatible, KEYHLSL)
+TYPE_TRAIT_1(__builtin_hlsl_is_constant_buffer_element_compatible, IsConstantBufferElementCompatible, KEYHLSL)
 
 // OpenMP Type Traits
 UNARY_EXPR_OR_TYPE_TRAIT(__builtin_omp_required_simd_align, OpenMPRequiredSimdAlign, KEYALL)

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -205,6 +205,7 @@ public:
   // HLSL Type trait implementations
   bool IsScalarizedLayoutCompatible(QualType T1, QualType T2) const;
   bool IsTypedResourceElementCompatible(QualType T1);
+  bool IsConstantBufferElementCompatible(QualType T1);
 
   bool CheckCompatibleParameterABI(FunctionDecl *New, FunctionDecl *Old);
 

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -100,6 +100,7 @@ bool Qualifiers::isTargetAddressSpaceSupersetOf(LangAS A, LangAS B,
          // address spaces to default to work around this problem.
          (A == LangAS::Default && B == LangAS::hlsl_private) ||
          (A == LangAS::Default && B == LangAS::hlsl_device) ||
+         (A == LangAS::Default && B == LangAS::hlsl_constant) ||
          (A == LangAS::Default && B == LangAS::hlsl_input) ||
          (A == LangAS::Default && B == LangAS::hlsl_output) ||
          (A == LangAS::Default && B == LangAS::hlsl_push_constant) ||

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -100,7 +100,6 @@ bool Qualifiers::isTargetAddressSpaceSupersetOf(LangAS A, LangAS B,
          // address spaces to default to work around this problem.
          (A == LangAS::Default && B == LangAS::hlsl_private) ||
          (A == LangAS::Default && B == LangAS::hlsl_device) ||
-         (A == LangAS::Default && B == LangAS::hlsl_constant) ||
          (A == LangAS::Default && B == LangAS::hlsl_input) ||
          (A == LangAS::Default && B == LangAS::hlsl_output) ||
          (A == LangAS::Default && B == LangAS::hlsl_push_constant) ||

--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -2286,9 +2286,15 @@ void CodeGenFunction::EmitAggregateCopy(LValue Dest, LValue Src, QualType Ty,
     }
   }
 
-  if (getLangOpts().HLSL && Ty.getAddressSpace() == LangAS::hlsl_constant)
-    if (CGM.getHLSLRuntime().emitBufferCopy(*this, DestPtr, SrcPtr, Ty))
-      return;
+  if (getLangOpts().HLSL) {
+    unsigned ConstantAS =
+        getContext().getTargetAddressSpace(LangAS::hlsl_constant);
+    if (Ty.getAddressSpace() == LangAS::hlsl_constant ||
+        SrcPtr.getAddressSpace() == ConstantAS) {
+      if (CGM.getHLSLRuntime().emitBufferCopy(*this, DestPtr, SrcPtr, Ty))
+        return;
+    }
+  }
 
   // Aggregate assignment turns into llvm.memcpy.  This is almost valid per
   // C99 6.5.16.1p3, which states "If the value being stored in an object is

--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -2286,15 +2286,9 @@ void CodeGenFunction::EmitAggregateCopy(LValue Dest, LValue Src, QualType Ty,
     }
   }
 
-  if (getLangOpts().HLSL) {
-    unsigned ConstantAS =
-        getContext().getTargetAddressSpace(LangAS::hlsl_constant);
-    if (Ty.getAddressSpace() == LangAS::hlsl_constant ||
-        SrcPtr.getAddressSpace() == ConstantAS) {
-      if (CGM.getHLSLRuntime().emitBufferCopy(*this, DestPtr, SrcPtr, Ty))
-        return;
-    }
-  }
+  if (getLangOpts().HLSL && Ty.getAddressSpace() == LangAS::hlsl_constant)
+    if (CGM.getHLSLRuntime().emitBufferCopy(*this, DestPtr, SrcPtr, Ty))
+      return;
 
   // Aggregate assignment turns into llvm.memcpy.  This is almost valid per
   // C99 6.5.16.1p3, which states "If the value being stored in an object is

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -571,12 +571,20 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
   case Builtin::BI__builtin_hlsl_resource_getpointer:
   case Builtin::BI__builtin_hlsl_resource_getpointer_typed: {
     Value *HandleOp = EmitScalarExpr(E->getArg(0));
-    Value *IndexOp = EmitScalarExpr(E->getArg(1));
+    bool IsIndexed = BuiltinID == Builtin::BI__builtin_hlsl_resource_getpointer
+                         ? E->getNumArgs() > 1
+                         : E->getNumArgs() > 2;
 
     llvm::Type *RetTy = ConvertType(E->getType());
+    if (IsIndexed) {
+      Value *IndexOp = EmitScalarExpr(E->getArg(1));
+      return Builder.CreateIntrinsic(
+          RetTy, CGM.getHLSLRuntime().getCreateResourceGetPointerIntrinsic(),
+          ArrayRef<Value *>{HandleOp, IndexOp});
+    }
     return Builder.CreateIntrinsic(
-        RetTy, CGM.getHLSLRuntime().getCreateResourceGetPointerIntrinsic(),
-        ArrayRef<Value *>{HandleOp, IndexOp});
+        RetTy, CGM.getHLSLRuntime().getCreateResourceGetBasePointerIntrinsic(),
+        ArrayRef<Value *>{HandleOp});
   }
   case Builtin::BI__builtin_hlsl_resource_sample: {
     Value *HandleOp = EmitScalarExpr(E->getArg(0));

--- a/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -167,6 +167,8 @@ public:
   GENERATE_HLSL_INTRINSIC_FUNCTION(SClamp, sclamp)
   GENERATE_HLSL_INTRINSIC_FUNCTION(UClamp, uclamp)
 
+  GENERATE_HLSL_INTRINSIC_FUNCTION(CreateResourceGetBasePointer,
+                                   resource_getbasepointer)
   GENERATE_HLSL_INTRINSIC_FUNCTION(CreateResourceGetPointer,
                                    resource_getpointer)
   GENERATE_HLSL_INTRINSIC_FUNCTION(Sample, resource_sample)

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -554,6 +554,11 @@ void BuiltinTypeMethodBuilder::createDecl() {
         AST, DeclBuilder.Record, SourceLocation(), NameInfo, FuncTy, TSInfo,
         ExplicitSpecifier(), false, /*IsInline=*/true, false,
         ConstexprSpecKind::Unspecified);
+  else if (Name.getNameKind() == DeclarationName::CXXConversionFunctionName)
+    Method = CXXConversionDecl::Create(
+        AST, DeclBuilder.Record, SourceLocation(), NameInfo, FuncTy, TSInfo,
+        false, /*isInline=*/true, ExplicitSpecifier(),
+        ConstexprSpecKind::Unspecified, SourceLocation());
   else
     Method = CXXMethodDecl::Create(
         AST, DeclBuilder.Record, SourceLocation(), NameInfo, FuncTy, TSInfo, SC,
@@ -879,7 +884,7 @@ BuiltinTypeMethodBuilder &BuiltinTypeMethodBuilder::returnValue(T ReturnValue) {
   ASTContext &AST = DeclBuilder.SemaRef.getASTContext();
 
   QualType Ty = ReturnValueExpr->getType();
-  if (Ty->isRecordType()) {
+  if (Ty->isRecordType() && !Method->getReturnType()->isReferenceType()) {
     // For record types, create a call to copy constructor to ensure proper copy
     // semantics.
     auto *ICE =
@@ -1053,6 +1058,28 @@ BuiltinTypeDeclBuilder &BuiltinTypeDeclBuilder::addSamplerHandle() {
   addHandleMember(ResourceClass::Sampler, ResourceDimension::Unknown,
                   /*IsROV=*/false, /*RawBuffer=*/false, getHandleElementType());
   return *this;
+}
+
+BuiltinTypeDeclBuilder &BuiltinTypeDeclBuilder::addConversionToType() {
+  assert(!Record->isCompleteDefinition() && "record is already complete");
+  ASTContext &AST = SemaRef.getASTContext();
+  using PH = BuiltinTypeMethodBuilder::PlaceHolder;
+
+  QualType ElemTy = getHandleElementType();
+  QualType AddrSpaceElemTy = AST.getCanonicalType(
+      AST.getAddrSpaceQualType(ElemTy, LangAS::hlsl_constant));
+  QualType ReturnTy =
+      AST.getCanonicalType(AST.getLValueReferenceType(AddrSpaceElemTy));
+
+  DeclarationName Name = AST.DeclarationNames.getCXXConversionFunctionName(
+      AST.getCanonicalType(ReturnTy));
+
+  return BuiltinTypeMethodBuilder(*this, Name, ReturnTy, /*IsConst=*/true)
+      .callBuiltin("__builtin_hlsl_resource_getpointer",
+                   AST.getPointerType(AddrSpaceElemTy), PH::Handle)
+      .dereference(PH::LastStmt)
+      .returnValue(PH::LastStmt)
+      .finalize();
 }
 
 BuiltinTypeDeclBuilder &

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -1067,7 +1067,7 @@ BuiltinTypeDeclBuilder &BuiltinTypeDeclBuilder::addConversionToType() {
 
   QualType ElemTy = getHandleElementType();
   QualType AddrSpaceElemTy = AST.getCanonicalType(
-      AST.getAddrSpaceQualType(ElemTy, LangAS::hlsl_constant));
+      AST.getAddrSpaceQualType(ElemTy.withConst(), LangAS::hlsl_constant));
   QualType ReturnTy =
       AST.getCanonicalType(AST.getLValueReferenceType(AddrSpaceElemTy));
 

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.h
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.h
@@ -83,6 +83,7 @@ public:
   addTextureHandle(ResourceClass RC, bool IsROV, ResourceDimension RD,
                    AccessSpecifier Access = AccessSpecifier::AS_private);
   BuiltinTypeDeclBuilder &addSamplerHandle();
+  BuiltinTypeDeclBuilder &addConversionToType();
   BuiltinTypeDeclBuilder &addArraySubscriptOperators(
       ResourceDimension Dim = ResourceDimension::Unknown);
 

--- a/clang/lib/Sema/HLSLExternalSemaSource.cpp
+++ b/clang/lib/Sema/HLSLExternalSemaSource.cpp
@@ -369,6 +369,28 @@ static Expr *constructTypedBufferConstraintExpr(Sema &S, SourceLocation NameLoc,
 // this concept:
 // template<typename T> concept is_structured_resource_element_compatible =
 // !__is_intangible<T> && sizeof(T) >= 1;
+static Expr *constructConstantBufferConstraintExpr(Sema &S,
+                                                   SourceLocation NameLoc,
+                                                   TemplateTypeParmDecl *T) {
+  ASTContext &Context = S.getASTContext();
+
+  // Obtain the QualType for 'bool'
+  QualType BoolTy = Context.BoolTy;
+
+  // Create a QualType that points to this TemplateTypeParmDecl
+  QualType TType = Context.getTypeDeclType(T);
+
+  // Create a TypeSourceInfo for the template type parameter 'T'
+  TypeSourceInfo *TTypeSourceInfo =
+      Context.getTrivialTypeSourceInfo(TType, NameLoc);
+
+  TypeTraitExpr *ResExpr = TypeTraitExpr::Create(
+      Context, BoolTy, NameLoc, UTT_IsConstantBufferElementCompatible,
+      {TTypeSourceInfo}, NameLoc, true);
+
+  return ResExpr;
+}
+
 static Expr *constructStructuredBufferConstraintExpr(Sema &S,
                                                      SourceLocation NameLoc,
                                                      TemplateTypeParmDecl *T) {
@@ -415,8 +437,10 @@ static Expr *constructStructuredBufferConstraintExpr(Sema &S,
   return CombinedExpr;
 }
 
+enum class HLSLBufferType { Typed, Structured, Constant };
+
 static ConceptDecl *constructBufferConceptDecl(Sema &S, NamespaceDecl *NSD,
-                                               bool isTypedBuffer) {
+                                               HLSLBufferType BT) {
   ASTContext &Context = S.getASTContext();
   DeclContext *DC = NSD->getDeclContext();
   SourceLocation DeclLoc = SourceLocation();
@@ -440,14 +464,22 @@ static ConceptDecl *constructBufferConceptDecl(Sema &S, NamespaceDecl *NSD,
   DeclarationName DeclName;
   Expr *ConstraintExpr = nullptr;
 
-  if (isTypedBuffer) {
+  switch (BT) {
+  case HLSLBufferType::Typed:
     DeclName = DeclarationName(
         &Context.Idents.get("__is_typed_resource_element_compatible"));
     ConstraintExpr = constructTypedBufferConstraintExpr(S, DeclLoc, T);
-  } else {
+    break;
+  case HLSLBufferType::Structured:
     DeclName = DeclarationName(
         &Context.Idents.get("__is_structured_resource_element_compatible"));
     ConstraintExpr = constructStructuredBufferConstraintExpr(S, DeclLoc, T);
+    break;
+  case HLSLBufferType::Constant:
+    DeclName = DeclarationName(
+        &Context.Idents.get("__is_constant_buffer_element_compatible"));
+    ConstraintExpr = constructConstantBufferConstraintExpr(S, DeclLoc, T);
+    break;
   }
 
   // Create a ConceptDecl
@@ -468,9 +500,22 @@ void HLSLExternalSemaSource::defineHLSLTypesWithForwardDeclarations() {
   ASTContext &AST = SemaPtr->getASTContext();
   CXXRecordDecl *Decl;
   ConceptDecl *TypedBufferConcept = constructBufferConceptDecl(
-      *SemaPtr, HLSLNamespace, /*isTypedBuffer*/ true);
+      *SemaPtr, HLSLNamespace, HLSLBufferType::Typed);
   ConceptDecl *StructuredBufferConcept = constructBufferConceptDecl(
-      *SemaPtr, HLSLNamespace, /*isTypedBuffer*/ false);
+      *SemaPtr, HLSLNamespace, HLSLBufferType::Structured);
+  ConceptDecl *ConstantBufferConcept = constructBufferConceptDecl(
+      *SemaPtr, HLSLNamespace, HLSLBufferType::Constant);
+
+  Decl = BuiltinTypeDeclBuilder(*SemaPtr, HLSLNamespace, "ConstantBuffer")
+             .addSimpleTemplateParams({"element_type"}, ConstantBufferConcept)
+             .finalizeForwardDeclaration();
+
+  onCompletion(Decl, [this](CXXRecordDecl *Decl) {
+    setupBufferType(Decl, *SemaPtr, ResourceClass::CBuffer, /*IsROV=*/false,
+                    /*RawBuffer=*/false, /*HasCounter=*/false)
+        .addConversionToType()
+        .completeDefinition();
+  });
 
   Decl = BuiltinTypeDeclBuilder(*SemaPtr, HLSLNamespace, "Buffer")
              .addSimpleTemplateParams({"element_type"}, TypedBufferConcept)

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -1254,7 +1254,7 @@ static ExprResult LookupMemberExpr(Sema &S, LookupResult &R,
                 InnerType.getCanonicalType().getNonReferenceType();
             QualType AddrSpaceType =
                 S.Context.getCanonicalType(S.Context.getAddrSpaceQualType(
-                    CanonType, LangAS::hlsl_constant));
+                    CanonType.withConst(), LangAS::hlsl_constant));
             QualType ReturnTy = S.Context.getCanonicalType(
                 S.Context.getLValueReferenceType(AddrSpaceType));
 

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -1239,6 +1239,58 @@ static ExprResult LookupMemberExpr(Sema &S, LookupResult &R,
 
   QualType BaseType = BaseExpr.get()->getType();
 
+  // TODO: This code should be improved. It should probably be moved to go with
+  // the other HLSL specific code in this function. HLSL: Intercept member
+  // accesses on ConstantBuffer<T>.
+  if (S.getLangOpts().HLSL) {
+    if (auto *RD = BaseType->getAsCXXRecordDecl()) {
+      if (RD->getName() == "ConstantBuffer") {
+        if (auto *CTSD = dyn_cast<ClassTemplateSpecializationDecl>(RD)) {
+          if (CTSD->getTemplateArgs().size() > 0) {
+            QualType InnerType = CTSD->getTemplateArgs()[0].getAsType();
+            // Ensure we have the canonical type and strip any references just
+            // in case
+            QualType CanonType =
+                InnerType.getCanonicalType().getNonReferenceType();
+            QualType AddrSpaceType =
+                S.Context.getCanonicalType(S.Context.getAddrSpaceQualType(
+                    CanonType, LangAS::hlsl_constant));
+            QualType ReturnTy = S.Context.getCanonicalType(
+                S.Context.getLValueReferenceType(AddrSpaceType));
+
+            DeclarationName ConvName =
+                S.Context.DeclarationNames.getCXXConversionFunctionName(
+                    CanQualType::CreateUnsafe(ReturnTy));
+            LookupResult ConvR(S, ConvName, OpLoc, Sema::LookupOrdinaryName);
+            if (S.LookupQualifiedName(ConvR, RD)) {
+              CXXConversionDecl *ConvDecl = nullptr;
+              NamedDecl *FoundDecl = nullptr;
+              for (NamedDecl *D : ConvR) {
+                if (auto *CD =
+                        dyn_cast<CXXConversionDecl>(D->getUnderlyingDecl())) {
+                  ConvDecl = CD;
+                  FoundDecl = D;
+                  break;
+                }
+              }
+              if (ConvDecl) {
+                ExprResult ConvCall = S.BuildCXXMemberCallExpr(
+                    BaseExpr.get(), FoundDecl, ConvDecl,
+                    /*HadMultipleCandidates=*/false);
+                if (!ConvCall.isInvalid()) {
+                  BaseExpr = ConvCall;
+                  return LookupMemberExpr(S, R, BaseExpr, IsArrow, OpLoc, SS,
+                                          ObjCImpDecl, HasTemplateArgs,
+                                          TemplateKWLoc);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   DeclarationName MemberName = R.getLookupName();
   SourceLocation MemberLoc = R.getNameLoc();
 

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4992,8 +4992,6 @@ static bool hasConstantBufferLayout(QualType QT) {
     return false;
 
   if (const auto *RD = Ty->getAsCXXRecordDecl()) {
-    if (RD->isImplicit())
-      return false;
     for (const auto *FD : RD->fields()) {
       if (hasConstantBufferLayout(FD->getType()))
         return true;

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -77,6 +77,19 @@ static RegisterType getRegisterType(const HLSLAttributedResourceType *ResTy) {
   return getRegisterType(ResTy->getAttrs().ResourceClass);
 }
 
+static LangAS getLangASFromResourceClass(ResourceClass RC) {
+  switch (RC) {
+  case ResourceClass::SRV:
+  case ResourceClass::UAV:
+    return LangAS::hlsl_device;
+  case ResourceClass::CBuffer:
+    return LangAS::hlsl_constant;
+  case ResourceClass::Sampler:
+    return LangAS::hlsl_device;
+  }
+  llvm_unreachable("unexpected ResourceClass value");
+}
+
 // Converts the first letter of string Slot to RegisterType.
 // Returns false if the letter does not correspond to a valid register type.
 static bool convertToRegisterType(StringRef Slot, RegisterType *RT) {
@@ -3891,16 +3904,17 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
     break;
   }
   case Builtin::BI__builtin_hlsl_resource_getpointer: {
-    if (SemaRef.checkArgCount(TheCall, 2) ||
+    if (SemaRef.checkArgCountRange(TheCall, 1, 2) ||
         CheckResourceHandle(&SemaRef, TheCall, 0) ||
-        CheckIndexType(&SemaRef, TheCall, 1))
+        (TheCall->getNumArgs() == 2 && CheckIndexType(&SemaRef, TheCall, 1)))
       return true;
 
     auto *ResourceTy =
         TheCall->getArg(0)->getType()->castAs<HLSLAttributedResourceType>();
     QualType ContainedTy = ResourceTy->getContainedType();
-    auto ReturnType =
-        SemaRef.Context.getAddrSpaceQualType(ContainedTy, LangAS::hlsl_device);
+    auto ReturnType = SemaRef.Context.getAddrSpaceQualType(
+        ContainedTy,
+        getLangASFromResourceClass(ResourceTy->getAttrs().ResourceClass));
     ReturnType = SemaRef.Context.getPointerType(ReturnType);
     TheCall->setType(ReturnType);
     TheCall->setValueKind(VK_LValue);
@@ -3924,8 +3938,11 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
           cast<FunctionDecl>(SemaRef.CurContext)->getPointOfInstantiation(),
           diag::err_invalid_use_of_array_type);
 
-    auto ReturnType =
-        SemaRef.Context.getAddrSpaceQualType(ElementTy, LangAS::hlsl_device);
+    auto *ResourceTy =
+        TheCall->getArg(0)->getType()->castAs<HLSLAttributedResourceType>();
+    auto ReturnType = SemaRef.Context.getAddrSpaceQualType(
+        ElementTy,
+        getLangASFromResourceClass(ResourceTy->getAttrs().ResourceClass));
     ReturnType = SemaRef.Context.getPointerType(ReturnType);
     TheCall->setType(ReturnType);
 
@@ -4636,6 +4653,22 @@ static void BuildFlattenedTypeList(QualType BaseTy,
   }
 }
 
+bool SemaHLSL::IsConstantBufferElementCompatible(clang::QualType QT) {
+  if (QT.isNull())
+    return false;
+
+  // Must be a class/struct.
+  const auto *RD = QT->getAsCXXRecordDecl();
+  if (!RD || RD->isUnion())
+    return false;
+
+  // Cannot be a resource type or contain one.
+  if (QT->isHLSLIntangibleType())
+    return false;
+
+  return true;
+}
+
 bool SemaHLSL::IsTypedResourceElementCompatible(clang::QualType QT) {
   // null and array types are not allowed.
   if (QT.isNull() || QT->isArrayType())
@@ -4959,6 +4992,8 @@ static bool hasConstantBufferLayout(QualType QT) {
     return false;
 
   if (const auto *RD = Ty->getAsCXXRecordDecl()) {
+    if (RD->isImplicit())
+      return false;
     for (const auto *FD : RD->fields()) {
       if (hasConstantBufferLayout(FD->getType()))
         return true;

--- a/clang/lib/Sema/SemaTypeTraits.cpp
+++ b/clang/lib/Sema/SemaTypeTraits.cpp
@@ -367,6 +367,7 @@ static bool CheckUnaryTypeTraitTypeCompleteness(Sema &S, TypeTrait UTT,
   case UTT_IsCompound:
   case UTT_IsMemberPointer:
   case UTT_IsTypedResourceElementCompatible:
+  case UTT_IsConstantBufferElementCompatible:
     // Fall-through
 
     // These traits are modeled on type predicates in C++0x [meta.unary.prop]
@@ -1131,6 +1132,14 @@ static bool EvaluateUnaryTypeTrait(Sema &Self, TypeTrait UTT,
       return false;
 
     return Self.HLSL().IsTypedResourceElementCompatible(T);
+
+  case UTT_IsConstantBufferElementCompatible:
+    assert(Self.getLangOpts().HLSL &&
+           "constant buffer element compatible types are an HLSL-only feature");
+    if (T->isIncompleteType())
+      return false;
+
+    return Self.HLSL().IsConstantBufferElementCompatible(T);
   }
 }
 

--- a/clang/test/AST/HLSL/ConstantBuffers-AST-error.hlsl
+++ b/clang/test/AST/HLSL/ConstantBuffers-AST-error.hlsl
@@ -1,0 +1,23 @@
+// RUN: not %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -ast-dump -finclude-default-header -o - %s 2>&1 | FileCheck %s
+
+// This test tracks issue #153055: Implicit conversion from hlsl_constant to generic address space is currently disabled.
+
+struct S {
+  float a;
+};
+ConstantBuffer<S> cb;
+
+void takes_s(S s) {}
+
+void main() {
+  S s;
+
+  // CHECK: error: no viable constructor copying parameter of type 'const hlsl_constant S'
+  takes_s(cb);
+
+  // CHECK: error: no viable constructor copying variable of type 'const hlsl_constant S'
+  S s2 = cb;
+
+  // CHECK: error: no viable conversion from 'ConstantBuffer<S>' to 'const S'
+  s = cb;
+}

--- a/clang/test/AST/HLSL/ConstantBuffers-AST.hlsl
+++ b/clang/test/AST/HLSL/ConstantBuffers-AST.hlsl
@@ -1,0 +1,156 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -x hlsl -ast-dump -disable-llvm-passes -finclude-default-header -o - %s | FileCheck %s
+
+// CHECK: ClassTemplateDecl {{.*}} ConstantBuffer
+// CHECK: TemplateTypeParmDecl {{.*}} element_type
+// CHECK: CXXRecordDecl {{.*}} ConstantBuffer definition
+// CHECK: FinalAttr {{.*}} Implicit final
+// CHECK-NEXT: FieldDecl {{.*}} implicit __handle '__hlsl_resource_t
+// CHECK-SAME{LITERAL}: [[hlsl::resource_class(CBuffer)]]
+// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+
+// CHECK: CXXConstructorDecl {{.*}} ConstantBuffer<element_type> 'void ()' inline
+// CHECK-NEXT: CompoundStmt
+// CHECK-NEXT: BinaryOperator {{.*}} '__hlsl_resource_t
+// CHECK-SAME{LITERAL}: [[hlsl::resource_class(CBuffer)]]
+// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// CHECK-SAME: ' '='
+// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// CHECK-SAME{LITERAL}: [[hlsl::resource_class(CBuffer)]]
+// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// CHECK-SAME: ' lvalue .__handle
+// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::ConstantBuffer<element_type>' lvalue implicit this
+// CHECK-NEXT: CStyleCastExpr {{.*}} '__hlsl_resource_t
+// CHECK-SAME{LITERAL}: [[hlsl::resource_class(CBuffer)]]
+// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// CHECK-SAME: ' <Dependent>
+// CHECK-NEXT: CallExpr {{.*}} '<dependent type>'
+
+// CHECK: CXXConstructorDecl {{.*}} ConstantBuffer<element_type> 'void (const hlsl::ConstantBuffer<element_type> &)' inline
+// CHECK-NEXT: ParmVarDecl {{.*}} other 'const hlsl::ConstantBuffer<element_type> &'
+// CHECK-NEXT: CompoundStmt
+// CHECK-NEXT: BinaryOperator {{.*}} '__hlsl_resource_t
+// CHECK-SAME{LITERAL}: [[hlsl::resource_class(CBuffer)]]
+// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// CHECK-SAME: ' '='
+// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// CHECK-SAME{LITERAL}: [[hlsl::resource_class(CBuffer)]]
+// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// CHECK-SAME: ' lvalue .__handle
+// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::ConstantBuffer<element_type>' lvalue implicit this
+// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// CHECK-SAME{LITERAL}: [[hlsl::resource_class(CBuffer)]]
+// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// CHECK-SAME: ' lvalue .__handle
+// CHECK-NEXT: DeclRefExpr {{.*}} 'const hlsl::ConstantBuffer<element_type>' lvalue ParmVar {{.*}} 'other' 'const hlsl::ConstantBuffer<element_type> &'
+
+// CHECK: CXXMethodDecl {{.*}} operator= 'hlsl::ConstantBuffer<element_type> &(const hlsl::ConstantBuffer<element_type> &)' inline
+// CHECK-NEXT: ParmVarDecl {{.*}} other 'const hlsl::ConstantBuffer<element_type> &'
+// CHECK-NEXT: CompoundStmt
+// CHECK-NEXT: BinaryOperator {{.*}} '__hlsl_resource_t
+// CHECK-SAME{LITERAL}: [[hlsl::resource_class(CBuffer)]]
+// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// CHECK-SAME: ' '='
+// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// CHECK-SAME{LITERAL}: [[hlsl::resource_class(CBuffer)]]
+// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// CHECK-SAME: ' lvalue .__handle
+// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::ConstantBuffer<element_type>' lvalue implicit this
+// CHECK-NEXT: MemberExpr {{.*}} '__hlsl_resource_t
+// CHECK-SAME{LITERAL}: [[hlsl::resource_class(CBuffer)]]
+// CHECK-SAME{LITERAL}: [[hlsl::contained_type(element_type)]]
+// CHECK-SAME: ' lvalue .__handle
+// CHECK-NEXT: DeclRefExpr {{.*}} 'const hlsl::ConstantBuffer<element_type>' lvalue ParmVar {{.*}} 'other' 'const hlsl::ConstantBuffer<element_type> &'
+// CHECK-NEXT: ReturnStmt
+// CHECK-NEXT: CXXThisExpr {{.*}} 'hlsl::ConstantBuffer<element_type>' lvalue implicit this
+
+struct S {
+  float a;
+};
+ConstantBuffer<S> cb;
+
+struct Nested {
+  S s;
+  float b;
+};
+ConstantBuffer<Nested> cb_nested;
+
+void takes_s(S s) {}
+void takes_cb(ConstantBuffer<S> c) {}
+void takes_inout_cb(inout ConstantBuffer<S> c) {}
+
+float main() {
+  // CHECK: FunctionDecl {{.*}} main
+  // CHECK: MemberExpr {{.*}} 'hlsl_constant float' lvalue .a
+  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'hlsl_constant S' lvalue
+  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator hlsl_constant S &
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl::ConstantBuffer<S>' lvalue <NoOp>
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>' lvalue Var {{.*}} 'cb' 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>'
+  float f1 = cb.a;
+
+  // CHECK: MemberExpr {{.*}} 'hlsl_constant float' lvalue .b
+  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'hlsl_constant Nested' lvalue
+  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator hlsl_constant Nested &
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl::ConstantBuffer<Nested>' lvalue <NoOp>
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'ConstantBuffer<Nested>':'hlsl::ConstantBuffer<Nested>' lvalue Var {{.*}} 'cb_nested' 'ConstantBuffer<Nested>':'hlsl::ConstantBuffer<Nested>'
+  float f2 = cb_nested.b;
+
+  // CHECK: MemberExpr {{.*}} 'hlsl_constant float' lvalue .a
+  // CHECK-NEXT: MemberExpr {{.*}} 'hlsl_constant S' lvalue .s
+  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'hlsl_constant Nested' lvalue
+  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator hlsl_constant Nested &
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl::ConstantBuffer<Nested>' lvalue <NoOp>
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'ConstantBuffer<Nested>':'hlsl::ConstantBuffer<Nested>' lvalue Var {{.*}} 'cb_nested' 'ConstantBuffer<Nested>':'hlsl::ConstantBuffer<Nested>'
+  float f3 = cb_nested.s.a;
+
+  // CHECK: CallExpr {{.*}} 'void'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'void (*)(S)' <FunctionToPointerDecay>
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'void (S)' lvalue Function {{.*}} 'takes_s' 'void (S)'
+  // CHECK-NEXT: CXXConstructExpr {{.*}} 'S' 'void (const S &) noexcept'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const S' lvalue <AddressSpaceConversion>
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'hlsl_constant S' lvalue <UserDefinedConversion>
+  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'hlsl_constant S' lvalue
+  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator hlsl_constant S &
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl::ConstantBuffer<S>' lvalue <NoOp>
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>' lvalue Var {{.*}} 'cb' 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>'
+  takes_s(cb);
+
+  // CHECK: CallExpr {{.*}} 'void'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'void (*)(ConstantBuffer<S>)' <FunctionToPointerDecay>
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'void (ConstantBuffer<S>)' lvalue Function {{.*}} 'takes_cb' 'void (ConstantBuffer<S>)'
+  // CHECK-NEXT: CXXConstructExpr {{.*}} 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>' 'void (const hlsl::ConstantBuffer<S> &)'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl::ConstantBuffer<S>' lvalue <NoOp>
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>' lvalue Var {{.*}} 'cb' 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>'
+  takes_cb(cb);
+
+  // CHECK: CallExpr {{.*}} 'void'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'void (*)(inout ConstantBuffer<S>)' <FunctionToPointerDecay>
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'void (inout ConstantBuffer<S>)' lvalue Function {{.*}} 'takes_inout_cb' 'void (inout ConstantBuffer<S>)'
+  // CHECK-NEXT: HLSLOutArgExpr {{.*}} 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>' lvalue inout
+  takes_inout_cb(cb);
+
+  // CHECK: DeclStmt
+  // CHECK-NEXT: VarDecl {{.*}} s 'S' cinit
+  // CHECK-NEXT: CXXConstructExpr {{.*}} 'S' 'void (const S &) noexcept'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const S' lvalue <AddressSpaceConversion>
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'hlsl_constant S' lvalue <UserDefinedConversion>
+  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'hlsl_constant S' lvalue
+  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator hlsl_constant S &
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl::ConstantBuffer<S>' lvalue <NoOp>
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>' lvalue Var {{.*}} 'cb' 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>'
+  S s = cb;
+
+  // CHECK: CXXOperatorCallExpr {{.*}} 'S' lvalue '='
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'S &(*)(const S &) noexcept' <FunctionToPointerDecay>
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'S &(const S &) noexcept' lvalue CXXMethod {{.*}} 'operator=' 'S &(const S &) noexcept'
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'S' lvalue Var {{.*}} 's' 'S'
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const S' lvalue <AddressSpaceConversion>
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl_constant S' lvalue <NoOp>
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'hlsl_constant S' lvalue <UserDefinedConversion>
+  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'hlsl_constant S' lvalue
+  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator hlsl_constant S &
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl::ConstantBuffer<S>' lvalue <NoOp>
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>' lvalue Var {{.*}} 'cb' 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>'
+  s = cb;
+
+  return f1 + f2 + f3;
+}

--- a/clang/test/AST/HLSL/ConstantBuffers-AST.hlsl
+++ b/clang/test/AST/HLSL/ConstantBuffers-AST.hlsl
@@ -80,24 +80,24 @@ void takes_inout_cb(inout ConstantBuffer<S> c) {}
 
 float main() {
   // CHECK: FunctionDecl {{.*}} main
-  // CHECK: MemberExpr {{.*}} 'hlsl_constant float' lvalue .a
-  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'hlsl_constant S' lvalue
-  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator hlsl_constant S &
+  // CHECK: MemberExpr {{.*}} 'const hlsl_constant float' lvalue .a
+  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'const hlsl_constant S' lvalue
+  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator const hlsl_constant S &
   // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl::ConstantBuffer<S>' lvalue <NoOp>
   // CHECK-NEXT: DeclRefExpr {{.*}} 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>' lvalue Var {{.*}} 'cb' 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>'
   float f1 = cb.a;
 
-  // CHECK: MemberExpr {{.*}} 'hlsl_constant float' lvalue .b
-  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'hlsl_constant Nested' lvalue
-  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator hlsl_constant Nested &
+  // CHECK: MemberExpr {{.*}} 'const hlsl_constant float' lvalue .b
+  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'const hlsl_constant Nested' lvalue
+  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator const hlsl_constant Nested &
   // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl::ConstantBuffer<Nested>' lvalue <NoOp>
   // CHECK-NEXT: DeclRefExpr {{.*}} 'ConstantBuffer<Nested>':'hlsl::ConstantBuffer<Nested>' lvalue Var {{.*}} 'cb_nested' 'ConstantBuffer<Nested>':'hlsl::ConstantBuffer<Nested>'
   float f2 = cb_nested.b;
 
-  // CHECK: MemberExpr {{.*}} 'hlsl_constant float' lvalue .a
-  // CHECK-NEXT: MemberExpr {{.*}} 'hlsl_constant S' lvalue .s
-  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'hlsl_constant Nested' lvalue
-  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator hlsl_constant Nested &
+  // CHECK: MemberExpr {{.*}} 'const hlsl_constant float' lvalue .a
+  // CHECK-NEXT: MemberExpr {{.*}} 'const hlsl_constant S' lvalue .s
+  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'const hlsl_constant Nested' lvalue
+  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator const hlsl_constant Nested &
   // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl::ConstantBuffer<Nested>' lvalue <NoOp>
   // CHECK-NEXT: DeclRefExpr {{.*}} 'ConstantBuffer<Nested>':'hlsl::ConstantBuffer<Nested>' lvalue Var {{.*}} 'cb_nested' 'ConstantBuffer<Nested>':'hlsl::ConstantBuffer<Nested>'
   float f3 = cb_nested.s.a;

--- a/clang/test/AST/HLSL/ConstantBuffers-AST.hlsl
+++ b/clang/test/AST/HLSL/ConstantBuffers-AST.hlsl
@@ -103,18 +103,6 @@ float main() {
   float f3 = cb_nested.s.a;
 
   // CHECK: CallExpr {{.*}} 'void'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'void (*)(S)' <FunctionToPointerDecay>
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'void (S)' lvalue Function {{.*}} 'takes_s' 'void (S)'
-  // CHECK-NEXT: CXXConstructExpr {{.*}} 'S' 'void (const S &) noexcept'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const S' lvalue <AddressSpaceConversion>
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'hlsl_constant S' lvalue <UserDefinedConversion>
-  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'hlsl_constant S' lvalue
-  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator hlsl_constant S &
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl::ConstantBuffer<S>' lvalue <NoOp>
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>' lvalue Var {{.*}} 'cb' 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>'
-  takes_s(cb);
-
-  // CHECK: CallExpr {{.*}} 'void'
   // CHECK-NEXT: ImplicitCastExpr {{.*}} 'void (*)(ConstantBuffer<S>)' <FunctionToPointerDecay>
   // CHECK-NEXT: DeclRefExpr {{.*}} 'void (ConstantBuffer<S>)' lvalue Function {{.*}} 'takes_cb' 'void (ConstantBuffer<S>)'
   // CHECK-NEXT: CXXConstructExpr {{.*}} 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>' 'void (const hlsl::ConstantBuffer<S> &)'
@@ -127,30 +115,6 @@ float main() {
   // CHECK-NEXT: DeclRefExpr {{.*}} 'void (inout ConstantBuffer<S>)' lvalue Function {{.*}} 'takes_inout_cb' 'void (inout ConstantBuffer<S>)'
   // CHECK-NEXT: HLSLOutArgExpr {{.*}} 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>' lvalue inout
   takes_inout_cb(cb);
-
-  // CHECK: DeclStmt
-  // CHECK-NEXT: VarDecl {{.*}} s 'S' cinit
-  // CHECK-NEXT: CXXConstructExpr {{.*}} 'S' 'void (const S &) noexcept'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const S' lvalue <AddressSpaceConversion>
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'hlsl_constant S' lvalue <UserDefinedConversion>
-  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'hlsl_constant S' lvalue
-  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator hlsl_constant S &
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl::ConstantBuffer<S>' lvalue <NoOp>
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>' lvalue Var {{.*}} 'cb' 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>'
-  S s = cb;
-
-  // CHECK: CXXOperatorCallExpr {{.*}} 'S' lvalue '='
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'S &(*)(const S &) noexcept' <FunctionToPointerDecay>
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'S &(const S &) noexcept' lvalue CXXMethod {{.*}} 'operator=' 'S &(const S &) noexcept'
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'S' lvalue Var {{.*}} 's' 'S'
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const S' lvalue <AddressSpaceConversion>
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl_constant S' lvalue <NoOp>
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'hlsl_constant S' lvalue <UserDefinedConversion>
-  // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'hlsl_constant S' lvalue
-  // CHECK-NEXT: MemberExpr {{.*}} '<bound member function type>' .operator hlsl_constant S &
-  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'const hlsl::ConstantBuffer<S>' lvalue <NoOp>
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>' lvalue Var {{.*}} 'cb' 'ConstantBuffer<S>':'hlsl::ConstantBuffer<S>'
-  s = cb;
 
   return f1 + f2 + f3;
 }

--- a/clang/test/CodeGenHLSL/builtins/ConstantBuffer-layout.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ConstantBuffer-layout.hlsl
@@ -1,0 +1,68 @@
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefixes=CHECK,CHECK-DXIL
+// RUN: %clang_cc1 -finclude-default-header -triple spirv-vulkan-library %s \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefixes=CHECK,CHECK-SPIRV
+
+// Scenario 1: Basic Padding (No row crossing).
+struct Basic {
+  float3 a;
+  float b;
+};
+// CHECK-DAG: %Basic = type <{ <3 x float>, float }>
+// CHECK-DXIL-DAG: %"class.hlsl::ConstantBuffer" = type { target("dx.CBuffer", %Basic) }
+// CHECK-SPIRV-DAG: %"class.hlsl::ConstantBuffer" = type { target("spirv.VulkanBuffer", %Basic, 2, 0) }
+ConstantBuffer<Basic> cb_basic;
+
+// Scenario 2: Row Boundary Crossing.
+struct RowCrossing {
+  float2 a;
+  float3 b;
+};
+// CHECK-DXIL-DAG: %RowCrossing = type <{ <2 x float>, target("dx.Padding", 8), <3 x float> }>
+// CHECK-SPIRV-DAG: %RowCrossing = type <{ <2 x float>, target("spirv.Padding", 8), <3 x float> }>
+ConstantBuffer<RowCrossing> cb_row_crossing;
+
+// Scenario 3: Arrays.
+struct ArrayPadding {
+  float a[2];
+  float b;
+};
+// CHECK-DXIL-DAG: %ArrayPadding = type <{ <{ [1 x <{ float, target("dx.Padding", 12) }>], float }>, float }>
+// CHECK-SPIRV-DAG: %ArrayPadding = type <{ <{ [1 x <{ float, target("spirv.Padding", 12) }>], float }>, float }>
+ConstantBuffer<ArrayPadding> cb_array;
+
+// Scenario 4: Nested Structs.
+struct Inner {
+  float a;
+};
+struct Outer {
+  Inner i;
+  float3 b;
+};
+// CHECK-DAG: %Inner = type <{ float }>
+// CHECK-DAG: %Outer = type <{ %Inner, <3 x float> }>
+ConstantBuffer<Outer> cb_nested;
+
+[numthreads(1,1,1)]
+void main() {
+  // Scenario 1
+  // CHECK-LABEL: define {{.*}} void @_Z4mainv()
+  // CHECK: %[[CB_BASIC:.*]] = call {{.*}} ptr addrspace({{.*}}) @_ZNK4hlsl14ConstantBufferI5BasicEcvRU{{.*}}S1_Ev
+  // CHECK: getelementptr inbounds nuw %Basic, ptr addrspace({{.*}}) %[[CB_BASIC]], i32 0, i32 1
+  float f1 = cb_basic.b;
+
+  // Scenario 2
+  // CHECK: %[[CB_ROW:.*]] = call {{.*}} ptr addrspace({{.*}}) @_ZNK4hlsl14ConstantBufferI11RowCrossingEcvRU{{.*}}S1_Ev
+  // CHECK: getelementptr inbounds nuw %RowCrossing, ptr addrspace({{.*}}) %[[CB_ROW]], i32 0, i32 2
+  float3 f2 = cb_row_crossing.b;
+
+  // Scenario 3
+  // CHECK: %[[CB_ARRAY:.*]] = call {{.*}} ptr addrspace({{.*}}) @_ZNK4hlsl14ConstantBufferI12ArrayPaddingEcvRU{{.*}}S1_Ev
+  // CHECK: getelementptr inbounds nuw %ArrayPadding, ptr addrspace({{.*}}) %[[CB_ARRAY]], i32 0, i32 1
+  float f3 = cb_array.b;
+
+  // Scenario 4
+  // CHECK: %[[CB_NESTED:.*]] = call {{.*}} ptr addrspace({{.*}}) @_ZNK4hlsl14ConstantBufferI5OuterEcvRU{{.*}}S1_Ev
+  // CHECK: getelementptr inbounds nuw %Outer, ptr addrspace({{.*}}) %[[CB_NESTED]], i32 0, i32 1
+  float3 f4 = cb_nested.b;
+}

--- a/clang/test/CodeGenHLSL/builtins/ConstantBuffer.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ConstantBuffer.hlsl
@@ -11,11 +11,11 @@ struct S {
 ConstantBuffer<S> cb;
 
 // CHECK-LABEL: define {{.*}} void @_Z4mainv()
-// CHECK-DXIL: [[CB_CONV:%.*]] = call noundef {{.*}} ptr addrspace(2) @_ZNK4hlsl14ConstantBufferI1SEcvRU3AS2S1_Ev(ptr noundef nonnull align 4 dereferenceable(4) @_ZL2cb)
+// CHECK-DXIL: [[CB_CONV:%.*]] = call noundef {{.*}} ptr addrspace(2) @_ZNK4hlsl14ConstantBufferI1SEcvRU3AS2KS1_Ev(ptr noundef nonnull align 4 dereferenceable(4) @_ZL2cb)
 // CHECK-DXIL: [[GEP_A:%.*]] = getelementptr inbounds nuw %S, ptr addrspace(2) [[CB_CONV]], i32 0, i32 0
 // CHECK-DXIL: [[LOAD_A:%.*]] = load float, ptr addrspace(2) [[GEP_A]], align 4
 
-// CHECK-SPIRV: [[CB_CONV:%.*]] = call noundef {{.*}} ptr addrspace(12) @_ZNK4hlsl14ConstantBufferI1SEcvRU4AS12S1_Ev(ptr noundef nonnull align 8 dereferenceable(8) @_ZL2cb)
+// CHECK-SPIRV: [[CB_CONV:%.*]] = call noundef {{.*}} ptr addrspace(12) @_ZNK4hlsl14ConstantBufferI1SEcvRU4AS12KS1_Ev(ptr noundef nonnull align 8 dereferenceable(8) @_ZL2cb)
 // CHECK-SPIRV: [[GEP_A:%.*]] = getelementptr inbounds nuw %S, ptr addrspace(12) [[CB_CONV]], i32 0, i32 0
 // CHECK-SPIRV: [[LOAD_A:%.*]] = load float, ptr addrspace(12) [[GEP_A]], align 4
 
@@ -37,14 +37,14 @@ void foo() {
   // CHECK-LABEL: define {{.*}} void @_Z3foov()
   // CHECK-DXIL: [[TMP_CB:%.*]] = alloca %"class.hlsl::ConstantBuffer.0", align 4
   // CHECK-DXIL: call void @_ZN4hlsl14ConstantBufferI6NestedE27__createFromImplicitBindingEjjijPKc(ptr dead_on_unwind writable sret(%"class.hlsl::ConstantBuffer.0") align 4 [[TMP_CB]], i32 noundef 1, i32 noundef 0, i32 noundef 2, i32 noundef 1, ptr noundef @cb_nested.str)
-  // CHECK-DXIL: [[CB_CONV:%.*]] = call noundef {{.*}} ptr addrspace(2) @_ZNK4hlsl14ConstantBufferI6NestedEcvRU3AS2S1_Ev(ptr noundef nonnull align 4 dereferenceable(4) [[TMP_CB]])
+  // CHECK-DXIL: [[CB_CONV:%.*]] = call noundef {{.*}} ptr addrspace(2) @_ZNK4hlsl14ConstantBufferI6NestedEcvRU3AS2KS1_Ev(ptr noundef nonnull align 4 dereferenceable(4) [[TMP_CB]])
   // CHECK-DXIL: [[GEP_S:%.*]] = getelementptr inbounds nuw %Nested, ptr addrspace(2) [[CB_CONV]], i32 0, i32 0
   // CHECK-DXIL: [[GEP_A2:%.*]] = getelementptr inbounds nuw %S, ptr addrspace(2) [[GEP_S]], i32 0, i32 0
   // CHECK-DXIL: [[LOAD_A2:%.*]] = load float, ptr addrspace(2) [[GEP_A2]], align 4
 
   // CHECK-SPIRV: [[TMP_CB:%.*]] = alloca %"class.hlsl::ConstantBuffer.0", align 8
   // CHECK-SPIRV: call void @_ZN4hlsl14ConstantBufferI6NestedE27__createFromImplicitBindingEjjijPKc(ptr dead_on_unwind writable sret(%"class.hlsl::ConstantBuffer.0") align 8 [[TMP_CB]], i32 noundef 1, i32 noundef 0, i32 noundef 2, i32 noundef 1, ptr noundef @cb_nested.str)
-  // CHECK-SPIRV: [[CB_CONV:%.*]] = call noundef {{.*}} ptr addrspace(12) @_ZNK4hlsl14ConstantBufferI6NestedEcvRU4AS12S1_Ev(ptr noundef nonnull align 8 dereferenceable(8) [[TMP_CB]])
+  // CHECK-SPIRV: [[CB_CONV:%.*]] = call noundef {{.*}} ptr addrspace(12) @_ZNK4hlsl14ConstantBufferI6NestedEcvRU4AS12KS1_Ev(ptr noundef nonnull align 8 dereferenceable(8) [[TMP_CB]])
   // CHECK-SPIRV: [[GEP_S:%.*]] = getelementptr inbounds nuw %Nested, ptr addrspace(12) [[CB_CONV]], i32 0, i32 0
   // CHECK-SPIRV: [[GEP_A2:%.*]] = getelementptr inbounds nuw %S, ptr addrspace(12) [[GEP_S]], i32 0, i32 0
   // CHECK-SPIRV: [[LOAD_A2:%.*]] = load float, ptr addrspace(12) [[GEP_A2]], align 4

--- a/clang/test/CodeGenHLSL/builtins/ConstantBuffer.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ConstantBuffer.hlsl
@@ -53,40 +53,13 @@ void foo() {
   float f2 = cb_nested[1].s.a;
 }
 
-void takes_s(S s) {}
 void takes_cb(ConstantBuffer<S> c) {}
 
 [numthreads(1,1,1)]
-void test_assignments_and_params() {
-  // CHECK-LABEL: define {{.*}} void @_Z27test_assignments_and_paramsv()
-  
-  // CHECK-DXIL: [[CB_CONV1:%.*]] = call noundef {{.*}} ptr addrspace(2) @_ZNK4hlsl14ConstantBufferI1SEcvRU3AS2S1_Ev(ptr noundef nonnull align 4 dereferenceable(4) @_ZL2cb)
-  // CHECK-DXIL: [[CB_AS1:%.*]] = addrspacecast ptr addrspace(2) [[CB_CONV1]] to ptr
-  // CHECK-DXIL: call void @llvm.memcpy.p0.p0.i32(ptr align 1 %s, ptr align 1 [[CB_AS1]], i32 8, i1 false)
-  // CHECK-SPIRV: [[CB_CONV1:%.*]] = call noundef {{.*}} ptr addrspace(12) @_ZNK4hlsl14ConstantBufferI1SEcvRU4AS12S1_Ev(ptr noundef nonnull align 8 dereferenceable(8) @_ZL2cb)
-  // CHECK-SPIRV: [[CB_AS1:%.*]] = addrspacecast ptr addrspace(12) [[CB_CONV1]] to ptr
-  // CHECK-SPIRV: call void @llvm.memcpy.p0.p0.i64(ptr align 1 %s, ptr align 1 [[CB_AS1]], i64 8, i1 false)
-  S s = cb;
-
-  // CHECK-DXIL: [[CB_CONV2:%.*]] = call noundef {{.*}} ptr addrspace(2) @_ZNK4hlsl14ConstantBufferI1SEcvRU3AS2S1_Ev(ptr noundef nonnull align 4 dereferenceable(4) @_ZL2cb)
-  // CHECK-DXIL: [[CB_AS2:%.*]] = addrspacecast ptr addrspace(2) [[CB_CONV2]] to ptr
-  // CHECK-DXIL: call void @llvm.memcpy.p0.p0.i32(ptr align 1 %s, ptr align 1 [[CB_AS2]], i32 8, i1 false)
-  // CHECK-SPIRV: [[CB_CONV2:%.*]] = call noundef {{.*}} ptr addrspace(12) @_ZNK4hlsl14ConstantBufferI1SEcvRU4AS12S1_Ev(ptr noundef nonnull align 8 dereferenceable(8) @_ZL2cb)
-  // CHECK-SPIRV: [[CB_AS2:%.*]] = addrspacecast ptr addrspace(12) [[CB_CONV2]] to ptr
-  // CHECK-SPIRV: call void @llvm.memcpy.p0.p0.i64(ptr align 1 %s, ptr align 1 [[CB_AS2]], i64 8, i1 false)
-  s = cb;
-
-  // CHECK-DXIL: [[CB_CONV3:%.*]] = call noundef {{.*}} ptr addrspace(2) @_ZNK4hlsl14ConstantBufferI1SEcvRU3AS2S1_Ev(ptr noundef nonnull align 4 dereferenceable(4) @_ZL2cb)
-  // CHECK-DXIL: [[CB_AS3:%.*]] = addrspacecast ptr addrspace(2) [[CB_CONV3]] to ptr
-  // CHECK-DXIL: call void @llvm.memcpy.p0.p0.i32(ptr align 1 %agg.tmp, ptr align 1 [[CB_AS3]], i32 8, i1 false)
-  // CHECK-DXIL: call void @_Z7takes_s1S(ptr noundef byval(%struct.S) align 1 %agg.tmp)
-  // CHECK-SPIRV: [[CB_CONV3:%.*]] = call noundef {{.*}} ptr addrspace(12) @_ZNK4hlsl14ConstantBufferI1SEcvRU4AS12S1_Ev(ptr noundef nonnull align 8 dereferenceable(8) @_ZL2cb)
-  // CHECK-SPIRV: [[CB_AS3:%.*]] = addrspacecast ptr addrspace(12) [[CB_CONV3]] to ptr
-  // CHECK-SPIRV: call {{.*}} void @_Z7takes_s1S(ptr noundef byval(%struct.S) align 1 %agg.tmp)
-  takes_s(cb);
-
-  // CHECK: call void @_ZN4hlsl14ConstantBufferI1SEC1ERKS2_(ptr noundef nonnull align {{[0-9]+}} dereferenceable({{[0-9]+}}) %agg.tmp{{[0-9]+}}, ptr noundef nonnull align {{[0-9]+}} dereferenceable({{[0-9]+}}) @_ZL2cb)
-  // CHECK-DXIL: call void @_Z8takes_cbN4hlsl14ConstantBufferI1SEE(ptr noundef dead_on_return %agg.tmp{{[0-9]+}})
-  // CHECK-SPIRV: call {{.*}} void @_Z8takes_cbN4hlsl14ConstantBufferI1SEE(ptr noundef dead_on_return %agg.tmp{{[0-9]+}})
+void test_params() {
+  // CHECK-LABEL: define {{.*}} void @_Z11test_paramsv()
+  // CHECK: call void @_ZN4hlsl14ConstantBufferI1SEC1ERKS2_(ptr noundef nonnull align {{[0-9]+}} dereferenceable({{[0-9]+}}) %agg.tmp, ptr noundef nonnull align {{[0-9]+}} dereferenceable({{[0-9]+}}) @_ZL2cb)
+  // CHECK-DXIL: call void @_Z8takes_cbN4hlsl14ConstantBufferI1SEE(ptr noundef dead_on_return %agg.tmp)
+  // CHECK-SPIRV: call {{.*}} void @_Z8takes_cbN4hlsl14ConstantBufferI1SEE(ptr noundef dead_on_return %agg.tmp)
   takes_cb(cb);
 }

--- a/clang/test/CodeGenHLSL/builtins/ConstantBuffer.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ConstantBuffer.hlsl
@@ -1,0 +1,92 @@
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.0-compute -emit-llvm -disable-llvm-passes -o - %s | FileCheck %s --check-prefixes=CHECK,CHECK-DXIL
+// RUN: %clang_cc1 -finclude-default-header -triple spirv-vulkan-library -emit-llvm -disable-llvm-passes -o - %s | FileCheck %s --check-prefixes=CHECK,CHECK-SPIRV
+
+struct S {
+  float a;
+  int b;
+};
+
+// CHECK-DXIL: %"class.hlsl::ConstantBuffer" = type { target("dx.CBuffer", %S) }
+// CHECK-SPIRV: %"class.hlsl::ConstantBuffer" = type { target("spirv.VulkanBuffer", %S, 2, 0) }
+ConstantBuffer<S> cb;
+
+// CHECK-LABEL: define {{.*}} void @_Z4mainv()
+// CHECK-DXIL: [[CB_CONV:%.*]] = call noundef {{.*}} ptr addrspace(2) @_ZNK4hlsl14ConstantBufferI1SEcvRU3AS2S1_Ev(ptr noundef nonnull align 4 dereferenceable(4) @_ZL2cb)
+// CHECK-DXIL: [[GEP_A:%.*]] = getelementptr inbounds nuw %S, ptr addrspace(2) [[CB_CONV]], i32 0, i32 0
+// CHECK-DXIL: [[LOAD_A:%.*]] = load float, ptr addrspace(2) [[GEP_A]], align 4
+
+// CHECK-SPIRV: [[CB_CONV:%.*]] = call noundef {{.*}} ptr addrspace(12) @_ZNK4hlsl14ConstantBufferI1SEcvRU4AS12S1_Ev(ptr noundef nonnull align 8 dereferenceable(8) @_ZL2cb)
+// CHECK-SPIRV: [[GEP_A:%.*]] = getelementptr inbounds nuw %S, ptr addrspace(12) [[CB_CONV]], i32 0, i32 0
+// CHECK-SPIRV: [[LOAD_A:%.*]] = load float, ptr addrspace(12) [[GEP_A]], align 4
+
+// CHECK: store float [[LOAD_A]], ptr %f, align 4
+[numthreads(1,1,1)]
+void main() {
+  float f = cb.a;
+}
+
+struct Nested {
+  S s;
+  float c;
+};
+
+ConstantBuffer<Nested> cb_nested[2];
+
+[numthreads(1,1,1)]
+void foo() {
+  // CHECK-LABEL: define {{.*}} void @_Z3foov()
+  // CHECK-DXIL: [[TMP_CB:%.*]] = alloca %"class.hlsl::ConstantBuffer.0", align 4
+  // CHECK-DXIL: call void @_ZN4hlsl14ConstantBufferI6NestedE27__createFromImplicitBindingEjjijPKc(ptr dead_on_unwind writable sret(%"class.hlsl::ConstantBuffer.0") align 4 [[TMP_CB]], i32 noundef 1, i32 noundef 0, i32 noundef 2, i32 noundef 1, ptr noundef @cb_nested.str)
+  // CHECK-DXIL: [[CB_CONV:%.*]] = call noundef {{.*}} ptr addrspace(2) @_ZNK4hlsl14ConstantBufferI6NestedEcvRU3AS2S1_Ev(ptr noundef nonnull align 4 dereferenceable(4) [[TMP_CB]])
+  // CHECK-DXIL: [[GEP_S:%.*]] = getelementptr inbounds nuw %Nested, ptr addrspace(2) [[CB_CONV]], i32 0, i32 0
+  // CHECK-DXIL: [[GEP_A2:%.*]] = getelementptr inbounds nuw %S, ptr addrspace(2) [[GEP_S]], i32 0, i32 0
+  // CHECK-DXIL: [[LOAD_A2:%.*]] = load float, ptr addrspace(2) [[GEP_A2]], align 4
+
+  // CHECK-SPIRV: [[TMP_CB:%.*]] = alloca %"class.hlsl::ConstantBuffer.0", align 8
+  // CHECK-SPIRV: call void @_ZN4hlsl14ConstantBufferI6NestedE27__createFromImplicitBindingEjjijPKc(ptr dead_on_unwind writable sret(%"class.hlsl::ConstantBuffer.0") align 8 [[TMP_CB]], i32 noundef 1, i32 noundef 0, i32 noundef 2, i32 noundef 1, ptr noundef @cb_nested.str)
+  // CHECK-SPIRV: [[CB_CONV:%.*]] = call noundef {{.*}} ptr addrspace(12) @_ZNK4hlsl14ConstantBufferI6NestedEcvRU4AS12S1_Ev(ptr noundef nonnull align 8 dereferenceable(8) [[TMP_CB]])
+  // CHECK-SPIRV: [[GEP_S:%.*]] = getelementptr inbounds nuw %Nested, ptr addrspace(12) [[CB_CONV]], i32 0, i32 0
+  // CHECK-SPIRV: [[GEP_A2:%.*]] = getelementptr inbounds nuw %S, ptr addrspace(12) [[GEP_S]], i32 0, i32 0
+  // CHECK-SPIRV: [[LOAD_A2:%.*]] = load float, ptr addrspace(12) [[GEP_A2]], align 4
+
+  // CHECK: store float [[LOAD_A2]], ptr %f2, align 4
+  float f2 = cb_nested[1].s.a;
+}
+
+void takes_s(S s) {}
+void takes_cb(ConstantBuffer<S> c) {}
+
+[numthreads(1,1,1)]
+void test_assignments_and_params() {
+  // CHECK-LABEL: define {{.*}} void @_Z27test_assignments_and_paramsv()
+  
+  // CHECK-DXIL: [[CB_CONV1:%.*]] = call noundef {{.*}} ptr addrspace(2) @_ZNK4hlsl14ConstantBufferI1SEcvRU3AS2S1_Ev(ptr noundef nonnull align 4 dereferenceable(4) @_ZL2cb)
+  // CHECK-DXIL: [[CB_AS1:%.*]] = addrspacecast ptr addrspace(2) [[CB_CONV1]] to ptr
+  // CHECK-DXIL: call void @llvm.memcpy.p0.p0.i32(ptr align 1 %s, ptr align 1 [[CB_AS1]], i32 8, i1 false)
+  // CHECK-SPIRV: [[CB_CONV1:%.*]] = call noundef {{.*}} ptr addrspace(12) @_ZNK4hlsl14ConstantBufferI1SEcvRU4AS12S1_Ev(ptr noundef nonnull align 8 dereferenceable(8) @_ZL2cb)
+  // CHECK-SPIRV: [[CB_AS1:%.*]] = addrspacecast ptr addrspace(12) [[CB_CONV1]] to ptr
+  // CHECK-SPIRV: call void @llvm.memcpy.p0.p0.i64(ptr align 1 %s, ptr align 1 [[CB_AS1]], i64 8, i1 false)
+  S s = cb;
+
+  // CHECK-DXIL: [[CB_CONV2:%.*]] = call noundef {{.*}} ptr addrspace(2) @_ZNK4hlsl14ConstantBufferI1SEcvRU3AS2S1_Ev(ptr noundef nonnull align 4 dereferenceable(4) @_ZL2cb)
+  // CHECK-DXIL: [[CB_AS2:%.*]] = addrspacecast ptr addrspace(2) [[CB_CONV2]] to ptr
+  // CHECK-DXIL: call void @llvm.memcpy.p0.p0.i32(ptr align 1 %s, ptr align 1 [[CB_AS2]], i32 8, i1 false)
+  // CHECK-SPIRV: [[CB_CONV2:%.*]] = call noundef {{.*}} ptr addrspace(12) @_ZNK4hlsl14ConstantBufferI1SEcvRU4AS12S1_Ev(ptr noundef nonnull align 8 dereferenceable(8) @_ZL2cb)
+  // CHECK-SPIRV: [[CB_AS2:%.*]] = addrspacecast ptr addrspace(12) [[CB_CONV2]] to ptr
+  // CHECK-SPIRV: call void @llvm.memcpy.p0.p0.i64(ptr align 1 %s, ptr align 1 [[CB_AS2]], i64 8, i1 false)
+  s = cb;
+
+  // CHECK-DXIL: [[CB_CONV3:%.*]] = call noundef {{.*}} ptr addrspace(2) @_ZNK4hlsl14ConstantBufferI1SEcvRU3AS2S1_Ev(ptr noundef nonnull align 4 dereferenceable(4) @_ZL2cb)
+  // CHECK-DXIL: [[CB_AS3:%.*]] = addrspacecast ptr addrspace(2) [[CB_CONV3]] to ptr
+  // CHECK-DXIL: call void @llvm.memcpy.p0.p0.i32(ptr align 1 %agg.tmp, ptr align 1 [[CB_AS3]], i32 8, i1 false)
+  // CHECK-DXIL: call void @_Z7takes_s1S(ptr noundef byval(%struct.S) align 1 %agg.tmp)
+  // CHECK-SPIRV: [[CB_CONV3:%.*]] = call noundef {{.*}} ptr addrspace(12) @_ZNK4hlsl14ConstantBufferI1SEcvRU4AS12S1_Ev(ptr noundef nonnull align 8 dereferenceable(8) @_ZL2cb)
+  // CHECK-SPIRV: [[CB_AS3:%.*]] = addrspacecast ptr addrspace(12) [[CB_CONV3]] to ptr
+  // CHECK-SPIRV: call {{.*}} void @_Z7takes_s1S(ptr noundef byval(%struct.S) align 1 %agg.tmp)
+  takes_s(cb);
+
+  // CHECK: call void @_ZN4hlsl14ConstantBufferI1SEC1ERKS2_(ptr noundef nonnull align {{[0-9]+}} dereferenceable({{[0-9]+}}) %agg.tmp{{[0-9]+}}, ptr noundef nonnull align {{[0-9]+}} dereferenceable({{[0-9]+}}) @_ZL2cb)
+  // CHECK-DXIL: call void @_Z8takes_cbN4hlsl14ConstantBufferI1SEE(ptr noundef dead_on_return %agg.tmp{{[0-9]+}})
+  // CHECK-SPIRV: call {{.*}} void @_Z8takes_cbN4hlsl14ConstantBufferI1SEE(ptr noundef dead_on_return %agg.tmp{{[0-9]+}})
+  takes_cb(cb);
+}

--- a/clang/test/CodeGenHLSL/cbuffer_copy_layout.hlsl
+++ b/clang/test/CodeGenHLSL/cbuffer_copy_layout.hlsl
@@ -1,0 +1,23 @@
+// RUN: not %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s 2>&1 | FileCheck %s
+
+// This test tracks issue #153055: Implicit conversion from hlsl_constant to generic address space is currently disabled.
+
+struct S {
+  float3 a;
+  float2 b;
+};
+
+cbuffer CB {
+  S s_cb;
+}
+
+ConstantBuffer<S> cb;
+
+[numthreads(1,1,1)]
+void main() {
+  // CHECK: error: no matching constructor for initialization of 'S'
+  S l1 = s_cb;
+
+  // CHECK: error: no viable constructor copying variable of type 'const hlsl_constant S'
+  S l2 = cb;
+}

--- a/clang/test/SemaHLSL/BuiltIns/ConstantBuffer-member-funcs.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ConstantBuffer-member-funcs.hlsl
@@ -3,11 +3,11 @@
 struct S {
     float a;
     
-    float foo() {
+    float foo() const {
         return a;
     };
 
-    void bar() {
+    void bar() { // expected-note {{'bar' declared here}}
         a = 1.0;
     }
 };
@@ -16,9 +16,12 @@ ConstantBuffer<S> CB;
 
 [numthreads(4,1,1)]
 void main() {
-    // Calling non-const member function is allowed for parity with DXC.
-    float tmp = CB.foo(); // expected-error {{cannot initialize object parameter of type 'S' with an expression of type 'hlsl_constant S'}}
+    // Calling non-const member function is allowed, but not  implemented yet.
+    // https://github.com/llvm/llvm-project/issues/153055
+    // expected-error@+1 {{cannot initialize object parameter of type 'const S' with an expression of type 'const hlsl_constant S'}}
+    float tmp = CB.foo();
 
-    // Even if it modifies the buffer, it's allowed in Sema (backended/validations will catch it).
-    CB.bar(); // expected-error {{cannot initialize object parameter of type 'S' with an expression of type 'hlsl_constant S'}}
+    // Calling non-const member function is not allowed.
+    // expected-error@+1 {{'this' argument to member function 'bar' has type 'const hlsl_constant S', but function is not marked const}}
+    CB.bar();
 }

--- a/clang/test/SemaHLSL/BuiltIns/ConstantBuffer-member-funcs.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ConstantBuffer-member-funcs.hlsl
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-compute -x hlsl -finclude-default-header -fsyntax-only -verify %s
+
+// expected-no-diagnostics
+
+struct S {
+    float a;
+    
+    float foo() {
+        return a;
+    };
+
+    void bar() {
+        a = 1.0;
+    }
+};
+
+ConstantBuffer<S> CB;
+
+[numthreads(4,1,1)]
+void main() {
+    // Calling non-const member function is allowed for parity with DXC.
+    float tmp = CB.foo();
+
+    // Even if it modifies the buffer, it's allowed in Sema (backended/validations will catch it).
+    CB.bar();
+}

--- a/clang/test/SemaHLSL/BuiltIns/ConstantBuffer-member-funcs.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ConstantBuffer-member-funcs.hlsl
@@ -1,7 +1,5 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-compute -x hlsl -finclude-default-header -fsyntax-only -verify %s
 
-// expected-no-diagnostics
-
 struct S {
     float a;
     
@@ -19,8 +17,8 @@ ConstantBuffer<S> CB;
 [numthreads(4,1,1)]
 void main() {
     // Calling non-const member function is allowed for parity with DXC.
-    float tmp = CB.foo();
+    float tmp = CB.foo(); // expected-error {{cannot initialize object parameter of type 'S' with an expression of type 'hlsl_constant S'}}
 
     // Even if it modifies the buffer, it's allowed in Sema (backended/validations will catch it).
-    CB.bar();
+    CB.bar(); // expected-error {{cannot initialize object parameter of type 'S' with an expression of type 'hlsl_constant S'}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/ConstantBuffer-template.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ConstantBuffer-template.hlsl
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -finclude-default-header -fsyntax-only -verify %s
+
+// expected-no-diagnostics
+
+struct T {
+    int a;
+};
+
+ConstantBuffer<T> c;
+
+RWBuffer<int> b;
+
+template<class Tm>
+void foo(Tm t) {
+    b[0] = t.a;
+}
+
+[numthreads(1,1,1)]
+void main() {
+    T t = c;
+    foo(c);
+}

--- a/clang/test/SemaHLSL/BuiltIns/ConstantBuffer-template.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ConstantBuffer-template.hlsl
@@ -1,8 +1,6 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -finclude-default-header -fsyntax-only -verify %s
 
-// expected-no-diagnostics
-
-struct T {
+struct T { // expected-note 3 {{candidate constructor}}
     int a;
 };
 
@@ -17,6 +15,6 @@ void foo(Tm t) {
 
 [numthreads(1,1,1)]
 void main() {
-    T t = c;
+    T t = c; // expected-error {{no viable constructor copying variable of type 'hlsl_constant T'}}
     foo(c);
 }

--- a/clang/test/SemaHLSL/BuiltIns/ConstantBuffer-template.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ConstantBuffer-template.hlsl
@@ -15,6 +15,9 @@ void foo(Tm t) {
 
 [numthreads(1,1,1)]
 void main() {
-    T t = c; // expected-error {{no viable constructor copying variable of type 'hlsl_constant T'}}
-    foo(c);
+  // An implicit conversion from ConstantBuffer<T> to T should work.
+  // It is not implemented yet
+  // (https://github.com/llvm/llvm-project/issues/153055).
+  // expected-error@+1 {{no viable constructor copying variable of type 'const hlsl_constant T'}}
+  T t = c;
 }

--- a/clang/test/SemaHLSL/BuiltIns/ConstantBuffers.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ConstantBuffers.hlsl
@@ -1,0 +1,62 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -x hlsl -finclude-default-header -fsyntax-only -verify %s
+
+struct S {
+  float a;
+  int b;
+};
+
+struct Empty {};
+
+struct ContainsResource {
+  Texture2D tex;
+};
+
+union U {
+  float a;
+  int b;
+};
+
+// Valid
+ConstantBuffer<S> cb;
+ConstantBuffer<Empty> cb_empty;
+
+// Invalid: non-struct/class
+// expected-error@+1 {{constraints not satisfied for class template 'ConstantBuffer'}}
+ConstantBuffer<float> cb_float;
+// expected-note@* {{because 'float' does not satisfy '__is_constant_buffer_element_compatible'}}
+// expected-note@* {{because '__builtin_hlsl_is_constant_buffer_element_compatible(float)' evaluated to false}}
+
+// expected-error@+1 {{constraints not satisfied for class template 'ConstantBuffer'}}
+ConstantBuffer<float4> cb_float4;
+// expected-note@* {{because 'float4' (aka 'vector<float, 4>') does not satisfy '__is_constant_buffer_element_compatible'}}
+// expected-note@* {{because '__builtin_hlsl_is_constant_buffer_element_compatible(vector<float, 4>)' evaluated to false}}
+
+// expected-error@+1 {{constraints not satisfied for class template 'ConstantBuffer'}}
+ConstantBuffer<float[4]> cb_array;
+// expected-note@* {{because 'float[4]' does not satisfy '__is_constant_buffer_element_compatible'}}
+// expected-note@* {{because '__builtin_hlsl_is_constant_buffer_element_compatible(float[4])' evaluated to false}}
+
+// Invalid: contains resource
+// expected-error@+1 {{constraints not satisfied for class template 'ConstantBuffer'}}
+ConstantBuffer<ContainsResource> cb_res;
+// expected-note@* {{because 'ContainsResource' does not satisfy '__is_constant_buffer_element_compatible'}}
+// expected-note@* {{because '__builtin_hlsl_is_constant_buffer_element_compatible(ContainsResource)' evaluated to false}}
+
+// Invalid: intangible type
+// expected-error@+1 {{use of class template 'Texture2D' requires template arguments}}
+ConstantBuffer<Texture2D> cb_tex;
+// expected-note@* {{template declaration from hidden source}}
+
+// Invalid: union
+// expected-error@+1 {{constraints not satisfied for class template 'ConstantBuffer'}}
+ConstantBuffer<U> cb_union;
+// expected-note@* {{because 'U' does not satisfy '__is_constant_buffer_element_compatible'}}
+// expected-note@* {{because '__builtin_hlsl_is_constant_buffer_element_compatible(U)' evaluated to false}}
+
+// expected-error@+1 {{no viable overloaded '='}}
+void takes_inout_s(inout S s) {}
+// expected-note@*:* {{candidate function not viable: no known conversion from 'S' to 'const hlsl::ConstantBuffer<S>' for 1st argument}}
+
+void foo() {
+  takes_inout_s(cb); // Fails because of inout writeback
+}

--- a/clang/test/SemaHLSL/BuiltIns/ConstantBuffers.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ConstantBuffers.hlsl
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -x hlsl -finclude-default-header -fsyntax-only -verify %s
 
-struct S {
+struct S { // expected-note 3 {{candidate constructor}}
   float a;
   int b;
 };
@@ -53,10 +53,9 @@ ConstantBuffer<U> cb_union;
 // expected-note@* {{because 'U' does not satisfy '__is_constant_buffer_element_compatible'}}
 // expected-note@* {{because '__builtin_hlsl_is_constant_buffer_element_compatible(U)' evaluated to false}}
 
-// expected-error@+1 {{no viable overloaded '='}}
 void takes_inout_s(inout S s) {}
-// expected-note@*:* {{candidate function not viable: no known conversion from 'S' to 'const hlsl::ConstantBuffer<S>' for 1st argument}}
 
 void foo() {
+  // expected-error@+1 {{no viable constructor copying parameter of type 'hlsl_constant S'}}
   takes_inout_s(cb); // Fails because of inout writeback
 }

--- a/clang/test/SemaHLSL/BuiltIns/ConstantBuffers.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/ConstantBuffers.hlsl
@@ -56,6 +56,7 @@ ConstantBuffer<U> cb_union;
 void takes_inout_s(inout S s) {}
 
 void foo() {
-  // expected-error@+1 {{no viable constructor copying parameter of type 'hlsl_constant S'}}
-  takes_inout_s(cb); // Fails because of inout writeback
+  // This case should fail because we cannot writeback to `cb` after the call.
+  // expected-error@+1 {{no viable constructor copying parameter of type 'const hlsl_constant S'}}
+  takes_inout_s(cb);
 }

--- a/clang/test/SemaHLSL/BuiltIns/resource_getpointer-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/resource_getpointer-errors.hlsl
@@ -5,16 +5,19 @@ using handle_t = __hlsl_resource_t
     [[hlsl::resource_class(UAV)]] [[hlsl::contained_type(int)]];
 
 void test_args(unsigned int x) {
-  // expected-error@+1 {{too few arguments to function call, expected 2, have 1}}
+  // expected-error@+1 {{used type 'unsigned int' where __hlsl_resource_t is required}}
   __builtin_hlsl_resource_getpointer(x);
 
-  // expected-error@+1 {{too many arguments to function call, expected 2, have 3}}
+  // expected-error@+1 {{too many arguments to function call, expected at most 2, have 3}}
   __builtin_hlsl_resource_getpointer(x, x, x);
 
   // expected-error@+1 {{used type 'unsigned int' where __hlsl_resource_t is required}}
   __builtin_hlsl_resource_getpointer(x, x);
 
   handle_t res;
+
+  // no error
+  __builtin_hlsl_resource_getpointer(res);
 
   // expected-error@+1 {{used type 'const char *' where integer is required}}
   __builtin_hlsl_resource_getpointer(res, "1");

--- a/llvm/include/llvm/IR/IntrinsicsDirectX.td
+++ b/llvm/include/llvm/IR/IntrinsicsDirectX.td
@@ -40,6 +40,10 @@ def int_dx_resource_getpointer
     : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [llvm_any_ty, llvm_any_ty],
                             [IntrReadMem, IntrInaccessibleMemOnly]>;
 
+def int_dx_resource_getbasepointer
+    : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [llvm_any_ty],
+                            [IntrConvergent, IntrNoMem]>;
+
 def int_dx_resource_nonuniformindex
     : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrNoMem]>;
 

--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -318,6 +318,10 @@ def int_spv_rsqrt : DefaultAttrsIntrinsic<[LLVMMatchType<0>], [llvm_anyfloat_ty]
       : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [llvm_any_ty, llvm_any_ty],
                               [IntrNoMem]>;
 
+  def int_spv_resource_getbasepointer
+      : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [llvm_any_ty],
+                              [IntrNoMem]>;
+
   def int_spv_pushconstant_getpointer
       : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [llvm_any_ty], [IntrNoMem]>;
 

--- a/llvm/lib/Target/DirectX/DXILMemIntrinsics.cpp
+++ b/llvm/lib/Target/DirectX/DXILMemIntrinsics.cpp
@@ -69,7 +69,8 @@ static Type *getPointeeType(Value *Ptr, const DataLayout &DL) {
     return AI->getAllocatedType();
 
   if (auto *II = dyn_cast<IntrinsicInst>(Ptr)) {
-    if (II->getIntrinsicID() == Intrinsic::dx_resource_getpointer) {
+    if (II->getIntrinsicID() == Intrinsic::dx_resource_getbasepointer ||
+        II->getIntrinsicID() == Intrinsic::dx_resource_getpointer) {
       Type *Ty = cast<dxil::AnyResourceExtType>(II->getArgOperand(0)->getType())
                      ->getResourceType();
       assert(Ty && "getpointer used on untyped resource");

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -1047,6 +1047,7 @@ public:
       case Intrinsic::dx_resource_handlefrombinding:
         HasErrors |= lowerHandleFromBinding(F);
         break;
+      case Intrinsic::dx_resource_getbasepointer:
       case Intrinsic::dx_resource_getpointer:
         HasErrors |= lowerGetPointer(F);
         break;

--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -57,7 +57,8 @@ static Value *traverseGEPOffsets(const DataLayout &DL, IRBuilder<> &Builder,
 
   while (Ptr) {
     if (auto *II = dyn_cast<IntrinsicInst>(Ptr)) {
-      assert(II->getIntrinsicID() == Intrinsic::dx_resource_getpointer &&
+      assert((II->getIntrinsicID() == Intrinsic::dx_resource_getbasepointer ||
+              II->getIntrinsicID() == Intrinsic::dx_resource_getpointer) &&
              "Resource access through unexpected intrinsic");
       return Offset ? Offset : ConstantInt::get(Builder.getInt32Ty(), 0);
     }
@@ -574,7 +575,8 @@ static SmallVector<IntrinsicInst *> collectUsedHandles(Value *Ptr) {
     else if (auto *II = dyn_cast<IntrinsicInst>(X)) {
       Intrinsic::ID IID = II->getIntrinsicID();
 
-      if (IID == Intrinsic::dx_resource_getpointer)
+      if (IID == Intrinsic::dx_resource_getbasepointer ||
+          IID == Intrinsic::dx_resource_getpointer)
         Worklist.push_back(II->getArgOperand(/*Handle=*/0));
 
       if (llvm::is_contained(HandleIntrins, IID))
@@ -625,14 +627,16 @@ getAccessIndices(Instruction *I, SmallSetVector<Instruction *, 16> &DeadInsts) {
       return {nullptr, II->getArgOperand(/*Index=*/3)};
     }
 
-    if (II->getIntrinsicID() == Intrinsic::dx_resource_getpointer) {
+    if (II->getIntrinsicID() == Intrinsic::dx_resource_getbasepointer ||
+        II->getIntrinsicID() == Intrinsic::dx_resource_getpointer) {
       auto *V = dyn_cast<Instruction>(II->getArgOperand(/*Handle=*/0));
       auto AccessIdx = getAccessIndices(V, DeadInsts);
       assert(!AccessIdx.hasGetPtrIdx() &&
              "Encountered multiple dx.resource.getpointers in ptr chain?");
-      AccessIdx.GetPtrIdx = II->getArgOperand(1);
-
-      DeadInsts.insert(II);
+      if (II->getIntrinsicID() == Intrinsic::dx_resource_getpointer)
+        AccessIdx.GetPtrIdx = II->getArgOperand(1);
+      else
+        AccessIdx.GetPtrIdx = nullptr;
       return AccessIdx;
     }
   }
@@ -696,7 +700,7 @@ static void
 replaceHandleWithIndices(Instruction *Ptr, IntrinsicInst *OldHandle,
                          SmallSetVector<Instruction *, 16> &DeadInsts) {
   auto AccessIdx = getAccessIndices(Ptr, DeadInsts);
-  assert(AccessIdx.hasGetPtrIdx() && AccessIdx.hasHandleIdx() &&
+  assert(AccessIdx.hasHandleIdx() &&
          "Couldn't retrieve indices. This is guaranteed by getAccessIndices");
 
   IRBuilder<> Builder(Ptr);
@@ -704,9 +708,15 @@ replaceHandleWithIndices(Instruction *Ptr, IntrinsicInst *OldHandle,
   Handle->setArgOperand(/*Index=*/3, AccessIdx.HandleIdx);
   Builder.Insert(Handle);
 
-  auto *GetPtr =
-      Builder.CreateIntrinsic(Ptr->getType(), Intrinsic::dx_resource_getpointer,
-                              {Handle, AccessIdx.GetPtrIdx});
+  Intrinsic::ID GetPtrIID = AccessIdx.hasGetPtrIdx()
+                                ? Intrinsic::dx_resource_getpointer
+                                : Intrinsic::dx_resource_getbasepointer;
+  SmallVector<Value *, 2> Args;
+  Args.push_back(Handle);
+  if (AccessIdx.hasGetPtrIdx())
+    Args.push_back(AccessIdx.GetPtrIdx);
+
+  auto *GetPtr = Builder.CreateIntrinsic(Ptr->getType(), GetPtrIID, Args);
 
   Ptr->replaceAllUsesWith(GetPtr);
   DeadInsts.insert(Ptr);
@@ -796,11 +806,14 @@ static bool transformResourcePointers(Function &F, DXILResourceTypeMap &DRTM) {
   SmallVector<std::pair<IntrinsicInst *, dxil::ResourceTypeInfo>> Resources;
   for (BasicBlock &BB : make_early_inc_range(F))
     for (Instruction &I : BB)
-      if (auto *II = dyn_cast<IntrinsicInst>(&I))
-        if (II->getIntrinsicID() == Intrinsic::dx_resource_getpointer) {
+      if (auto *II = dyn_cast<IntrinsicInst>(&I)) {
+        Intrinsic::ID IID = II->getIntrinsicID();
+        if (IID == Intrinsic::dx_resource_getbasepointer ||
+            IID == Intrinsic::dx_resource_getpointer) {
           auto *HandleTy = cast<TargetExtType>(II->getArgOperand(0)->getType());
           Resources.emplace_back(II, DRTM[HandleTy]);
         }
+      }
 
   for (auto &[II, RI] : Resources)
     replaceAccess(II, RI);

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -411,6 +411,7 @@ bool isConvergenceIntrinsic(const Instruction *I) {
 bool expectIgnoredInIRTranslation(const Instruction *I) {
   return match(I, m_AnyIntrinsic<Intrinsic::invariant_start,
                                  Intrinsic::spv_resource_handlefrombinding,
+                                 Intrinsic::spv_resource_getbasepointer,
                                  Intrinsic::spv_resource_getpointer>());
 }
 
@@ -1014,7 +1015,8 @@ Type *SPIRVEmitIntrinsics::deduceElementTypeHelper(
     // TODO: maybe improve performance by caching demangled names
 
     auto *II = dyn_cast<IntrinsicInst>(I);
-    if (II && II->getIntrinsicID() == Intrinsic::spv_resource_getpointer) {
+    if (II && (II->getIntrinsicID() == Intrinsic::spv_resource_getbasepointer ||
+               II->getIntrinsicID() == Intrinsic::spv_resource_getpointer)) {
       auto *HandleType = cast<TargetExtType>(II->getOperand(0)->getType());
       if (HandleType->getTargetExtName() == "spirv.Image" ||
           HandleType->getTargetExtName() == "spirv.SignedImage") {
@@ -1026,12 +1028,15 @@ Type *SPIRVEmitIntrinsics::deduceElementTypeHelper(
       } else if (HandleType->getTargetExtName() == "spirv.VulkanBuffer") {
         // This call is supposed to index into an array
         Ty = HandleType->getTypeParameter(0);
-        if (Ty->isArrayTy())
-          Ty = Ty->getArrayElementType();
-        else {
-          assert(Ty && Ty->isStructTy());
-          uint32_t Index = cast<ConstantInt>(II->getOperand(1))->getZExtValue();
-          Ty = cast<StructType>(Ty)->getElementType(Index);
+        if (II->getIntrinsicID() == Intrinsic::spv_resource_getpointer) {
+          if (Ty->isArrayTy())
+            Ty = Ty->getArrayElementType();
+          else {
+            assert(Ty && Ty->isStructTy());
+            uint32_t Index =
+                cast<ConstantInt>(II->getOperand(1))->getZExtValue();
+            Ty = cast<StructType>(Ty)->getElementType(Index);
+          }
         }
         Ty = reconstitutePeeledArrayType(Ty);
       } else {

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -700,6 +700,7 @@ static bool intrinsicHasSideEffects(Intrinsic::ID ID) {
   case Intrinsic::spv_radians:
   case Intrinsic::spv_reflect:
   case Intrinsic::spv_refract:
+  case Intrinsic::spv_resource_getbasepointer:
   case Intrinsic::spv_resource_getpointer:
   case Intrinsic::spv_resource_handlefrombinding:
   case Intrinsic::spv_resource_handlefromimplicitbinding:
@@ -1887,7 +1888,9 @@ bool SPIRVInstructionSelector::selectLoad(Register ResVReg,
   auto *PtrDef = getVRegDef(*MRI, Ptr);
   auto *IntPtrDef = dyn_cast<GIntrinsic>(PtrDef);
   if (IntPtrDef &&
-      IntPtrDef->getIntrinsicID() == Intrinsic::spv_resource_getpointer) {
+      (IntPtrDef->getIntrinsicID() == Intrinsic::spv_resource_getbasepointer ||
+       IntPtrDef->getIntrinsicID() == Intrinsic::spv_resource_getpointer)) {
+
     Register HandleReg = IntPtrDef->getOperand(2).getReg();
     SPIRVTypeInst HandleType = GR.getSPIRVTypeForVReg(HandleReg);
     if (HandleType->getOpcode() == SPIRV::OpTypeImage) {
@@ -1979,7 +1982,9 @@ bool SPIRVInstructionSelector::selectStore(MachineInstr &I) const {
   auto *PtrDef = getVRegDef(*MRI, Ptr);
   auto *IntPtrDef = dyn_cast<GIntrinsic>(PtrDef);
   if (IntPtrDef &&
-      IntPtrDef->getIntrinsicID() == Intrinsic::spv_resource_getpointer) {
+      (IntPtrDef->getIntrinsicID() == Intrinsic::spv_resource_getbasepointer ||
+       IntPtrDef->getIntrinsicID() == Intrinsic::spv_resource_getpointer)) {
+
     Register HandleReg = IntPtrDef->getOperand(2).getReg();
     Register NewHandleReg =
         MRI->createVirtualRegister(MRI->getRegClass(HandleReg));
@@ -5094,6 +5099,7 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
   case Intrinsic::spv_resource_gather:
   case Intrinsic::spv_resource_gather_cmp:
     return selectGatherIntrinsic(ResVReg, ResType, I);
+  case Intrinsic::spv_resource_getbasepointer:
   case Intrinsic::spv_resource_getpointer: {
     return selectResourceGetPointer(ResVReg, ResType, I);
   }
@@ -5890,16 +5896,20 @@ bool SPIRVInstructionSelector::selectResourceGetPointer(Register &ResVReg,
   assert(ResType->getOpcode() == SPIRV::OpTypePointer);
   MachineIRBuilder MIRBuilder(I);
 
-  Register IndexReg = I.getOperand(3).getReg();
   Register ZeroReg =
       buildZerosVal(GR.getOrCreateSPIRVIntegerType(32, I, TII), I);
-  BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(SPIRV::OpAccessChain))
-      .addDef(ResVReg)
-      .addUse(GR.getSPIRVTypeID(ResType))
-      .addUse(ResourcePtr)
-      .addUse(ZeroReg)
-      .addUse(IndexReg)
-      .constrainAllUses(TII, TRI, RBI);
+  auto MIB =
+      BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(SPIRV::OpAccessChain))
+          .addDef(ResVReg)
+          .addUse(GR.getSPIRVTypeID(ResType))
+          .addUse(ResourcePtr)
+          .addUse(ZeroReg);
+
+  if (I.getNumExplicitOperands() > 3) {
+    Register IndexReg = I.getOperand(3).getReg();
+    MIB.addUse(IndexReg);
+  }
+  MIB.constrainAllUses(TII, TRI, RBI);
   return true;
 }
 


### PR DESCRIPTION
This patch implements the ConstantBuffer<T> resource type in Clang.
ConstantBuffer<T> provides transparent access to the members of its
underlying type T, allowing it to be used as if it were an instance of T.

Implementation details:
- ConstantBuffer<T> is defined as a builtin template in HLSLExternalSemaSource.
- Member accesses on ConstantBuffer<T> are intercepted in Sema and
  transformed into calls to an implicit conversion operator. This operator
  returns a reference to T in the hlsl_constant address space.
- Qualifiers::isTargetAddressSpaceSupersetOf is updated to allow implicit
  conversions from HLSL-specific address spaces (like hlsl_constant) to the
  default address space, enabling member function calls on the underlying type.
- __builtin_hlsl_resource_getpointer is introduced to resolve resources to
  memory locations, lowering to target-specific intrinsics
  (int_dx_resource_getpointer or int_spv_resource_getpointer).
- DXIL and SPIR-V backends are updated to handle the new resource access
  pattern.
- Sema validation ensures the template argument T is a compatible struct
  or class.
- Comprehensive tests cover AST representation, Sema validation, and
  CodeGen for both DXIL and SPIR-V targets.

Assisted-by: Gemini


<!-- branch-stack-start -->

<!-- branch-stack-end -->
