### PR TITLE
[LLVM][BUILD] Fix for #177158

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -2314,7 +2314,10 @@ llvm_target_lib_list = [lib for lib in [
                 "lib/Target/AArch64/AArch64GenFastISel.inc",
             ),
             (
-                ["-gen-global-isel", "-gisel-extended-llt"],
+                [
+                    "-gen-global-isel",
+                    "-gisel-extended-llt",
+                ],
                 "lib/Target/AArch64/AArch64GenGlobalISel.inc",
             ),
             (

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -2314,7 +2314,7 @@ llvm_target_lib_list = [lib for lib in [
                 "lib/Target/AArch64/AArch64GenFastISel.inc",
             ),
             (
-                ["-gen-global-isel"],
+                ["-gen-global-isel", "-gisel-extended-llt"],
                 "lib/Target/AArch64/AArch64GenGlobalISel.inc",
             ),
             (


### PR DESCRIPTION
This option is now passed to the CMake build but not when building with bazel. Forgetting this option results in miscompiles during instruction selection as the generated tables don't match the runtime behaviour.