### PR TITLE
[ARM][Thumb1] Consider tBfar safe in noreturn functions

### DIFF
--- a/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
+++ b/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
@@ -1699,8 +1699,15 @@ ARMConstantIslands::fixupUnconditionalBr(ImmBranch &Br) {
   if (!isThumb1)
     llvm_unreachable("fixupUnconditionalBr is Thumb1 only!");
 
-  if (!AFI->isLRSpilled())
-    report_fatal_error("underestimated function size");
+  // If LR was not spilled, then this transformation corrupts the function's
+  // return address, which (as long as the function is _planning_ to return) is
+  // a code generation fault. Check for that case, and turn it into a fatal
+  // error, which is preferable.
+  if (!AFI->isLRSpilled() &&
+      !MF->getFunction().hasFnAttribute(Attribute::NoReturn))
+    report_fatal_error("tried to use tBfar, but LR needed and not spilled "
+                       "(EstimateFunctionSizeInBytes underestimated "
+                       "function size)");
 
   // Use BL to implement far jump.
   Br.MaxDisp = (1 << 21) * 2;

--- a/llvm/test/CodeGen/ARM/noreturn-long-branch.mir
+++ b/llvm/test/CodeGen/ARM/noreturn-long-branch.mir
@@ -1,0 +1,58 @@
+# RUN: llc -mtriple=thumbv6m-none-eabi --run-pass=arm-cp-islands -o - %s | FileCheck %s
+#
+# This test file requires the branch instruction to be turned into a tBfar, aka
+# BL, treating the value written to LR as junk. It's OK that we overwrite LR,
+# even though it was not spilled on function entry, because the function never
+# returns, so the value of LR on entry isn't needed.
+
+--- |
+  ; ModuleID = 'llvmaeng5747b.ll'
+  source_filename = "llvmaeng5747b.ll"
+  target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
+  target triple = "thumbv6m-unknown-none-eabi"
+  
+  ; Function Attrs: nounwind
+  declare i32 @llvm.arm.space(i32 immarg, i32) #0
+  
+  define dso_local noundef i32 @foo(ptr %p) local_unnamed_addr #1 {
+  entry:
+    br label %loop
+  
+  loop:                                             ; preds = %loop, %entry
+    %0 = load volatile i32, ptr %p, align 4
+    %1 = call i32 @llvm.arm.space(i32 8192, i32 %0)
+    br label %loop
+  }
+  
+  attributes #0 = { nounwind }
+  attributes #1 = { noreturn }
+...
+---
+name:            foo
+alignment:       2
+tracksRegLiveness: true
+noPhis:          true
+isSSA:           false
+noVRegs:         true
+hasFakeUses:     false
+tracksDebugUserValues: true
+liveins:
+  - { reg: '$r0' }
+frameInfo:
+  maxAlignment:    1
+  maxCallFrameSize: 0
+  isCalleeSavedInfoValid: true
+machineFunctionInfo:
+  isLRSpilled:     false
+body:             |
+  bb.0.entry:
+    liveins: $r0
+  
+  bb.1.loop:
+    liveins: $r0
+  
+    renamable $r1 = tLDRi renamable $r0, 0, 14 /* CC::al */, $noreg :: (volatile load (s32) from %ir.p)
+    dead renamable $r1 = SPACE 8192, killed renamable $r1
+    tB %bb.1, 14 /* CC::al */, $noreg
+    ; CHECK: tBfar %bb.1, 14 /* CC::al */, $noreg
+...


### PR DESCRIPTION
Transforming a short branch instruction into `tBfar` (aka the `BL` instruction, used as a long branch within a function) corrupts LR, which is bad news if the function prologue didn't anticipate the need to save it on the stack. However, an exception to this is that if the function doesn't return at all (e.g. because it contains an endless while loop), it doesn't matter that it's forgotten its own return address – that address will never be used anyway.

This should eliminate many causes of the "underestimated function size" fatal error, because one of the reasons why a function would _not_ have stacked LR on entry is because it knew it would never return. With this change, a non-leaf function should _never_ be able to trigger this fatal error, because either it saved LR already, or it doesn't matter. Only huge leaf functions are still at risk.

While I'm here, I've also expanded the wording of the fatal error, so that it explains a bit more about why an estimate of the function size was needed and where in the backend you should look for the code that actually calculated the bad estimate.