### PR TITLE
[runtimes] Ensure INSTALLed directory exists

### DIFF
--- a/runtimes/cmake/config-Fortran.cmake
+++ b/runtimes/cmake/config-Fortran.cmake
@@ -193,6 +193,10 @@ if (RUNTIMES_ENABLE_FLANG_MODULES)
   install(DIRECTORY "${RUNTIMES_OUTPUT_RESOURCE_MOD_DIR}"
     DESTINATION "${destination}"
   )
+
+  # The INSTALL'ed directory must exist, even if empty, or `ninja install` will
+  # fail with an error.
+  file(MAKE_DIRECTORY "${RUNTIMES_OUTPUT_RESOURCE_MOD_DIR}")
 else ()
   # If Flang modules are disabled (e.g. because the compiler is not Flang), avoid the risk of Flang accidentally picking them up.
   extend_path(RUNTIMES_OUTPUT_RESOURCE_MOD_DIR "${CMAKE_CURRENT_BINARY_DIR}" "finclude-${CMAKE_Fortran_COMPILER_ID}")


### PR DESCRIPTION
The CMake `install(DIRECTORY ..)` command requires the source directory to exist or it withh throw an error:
```
CMake Error at cmake_install.cmake:41 (file):
  file INSTALL cannot find
  "C:/Users/meinersbur/src/llvm/main/release/lib/clang/23/finclude/flang/x86_64-pc-windows-msvc":
  No error.
```

The install command was added by #171610 directory is currently empty by design to be filled with the upcoming #171515.

Should fix the flang-arm64-windows-msvc-testsuite buildbot. For some reason the nested `ninja install` call inside `runtimes/runtimes-bins` fails but the outer `ninja install` silently just does not install the nested files.