### PR TITLE
[clang-cl] Accept separated /wd warning arguments

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9562,7 +9562,7 @@ def _SLASH_WX_ : CLFlag<"WX-">,
   HelpText<"Do not treat warnings as errors (default)">,
   Alias<W_Joined>, AliasArgs<["no-error"]>;
 def _SLASH_w_flag : CLFlag<"w">, HelpText<"Disable all warnings">, Alias<w>;
-def _SLASH_wd : CLCompileJoined<"wd">;
+def _SLASH_wd : CLCompileJoinedOrSeparate<"wd">;
 def _SLASH_vd : CLJoined<"vd">, HelpText<"Control vtordisp placement">,
   Alias<vtordisp_mode_EQ>;
 def _SLASH_X : CLFlag<"X">,

--- a/clang/test/Driver/cl-options.c
+++ b/clang/test/Driver/cl-options.c
@@ -377,6 +377,7 @@
 
 // For some warning ids, we can map from MSVC warning to Clang warning.
 // RUN: %clang_cl -wd4005 -wd4100 -wd4910 -wd4996 -wd12345678 -### -- %s 2>&1 | FileCheck -check-prefix=Wno %s
+// RUN: %clang_cl /wd 4005 /wd 4100 /wd 4910 /wd 4996 /wd 12345678 -### -- %s 2>&1 | FileCheck -check-prefix=Wno %s
 // Wno: "-cc1"
 // Wno: "-Wno-macro-redefined"
 // Wno: "-Wno-unused-parameter"


### PR DESCRIPTION
Fixes #193242.

This changes clang-cl's `/wd` option from joined-only to joined-or-separate.

Today, glued warning-disable options such as `/wd4996` are accepted, but
split-token forms such as `/wd 4996` are not parsed as an option operand. This
matters for clang tooling and clangd because `compile_commands.json` preserves
argv token boundaries.

The implementation is limited to the option table. Existing warning-id mapping
logic already handles the parsed `/wd` argument.

Test coverage is added next to the existing glued-form `/wdNNNN` driver test.