### PR TITLE
[lldb][windows] enable BoundsSafetyTestSoftTrapPlugin tests

### DIFF
--- a/lldb/test/API/lang/BoundsSafety/soft_trap/TestBoundsSafetyInstrumentationPlugin.py
+++ b/lldb/test/API/lang/BoundsSafety/soft_trap/TestBoundsSafetyInstrumentationPlugin.py
@@ -76,10 +76,6 @@ class BoundsSafetyTestSoftTrapPlugin(TestBase):
             expected_line_num=line_num,
         )
 
-    # Skip the tests on Windows because they fail due to the stop reason
-    # being `eStopReasonNon` instead of the expected
-    # `eStopReasonInstrumentation`.
-    @skipIfWindows
     @skipUnlessBoundsSafety
     def test_call_minimal(self):
         """
@@ -114,7 +110,6 @@ class BoundsSafetyTestSoftTrapPlugin(TestBase):
         self.assertEqual(process.GetState(), lldb.eStateExited)
         self.assertEqual(process.GetExitStatus(), 0)
 
-    @skipIfWindows
     @skipUnlessBoundsSafety
     def test_call_with_str(self):
         """


### PR DESCRIPTION
This patch enables the `BoundsSafetyTestSoftTrapPlugin` tests on Windows.

The tests run fine at desk on my machine.