### PR TITLE
[BOLT][AArch64] Refuse to run ThreeWayBranch pass

### DIFF
--- a/bolt/lib/Passes/ThreeWayBranch.cpp
+++ b/bolt/lib/Passes/ThreeWayBranch.cpp
@@ -148,6 +148,11 @@ void ThreeWayBranch::runOnFunction(BinaryFunction &Function) {
 }
 
 Error ThreeWayBranch::runOnFunctions(BinaryContext &BC) {
+  if (!BC.isX86()) {
+    BC.errs() << "BOLT-ERROR: " << getName() << " is supported only on X86\n";
+    exit(1);
+  }
+
   for (auto &It : BC.getBinaryFunctions()) {
     BinaryFunction &Function = It.second;
     if (!shouldRunOnFunction(Function))

--- a/bolt/test/AArch64/unsupported-passes.test
+++ b/bolt/test/AArch64/unsupported-passes.test
@@ -4,8 +4,10 @@
 
 RUN: %clang %cflags %p/../Inputs/hello.c -o %t -Wl,-q,-z,undefs
 RUN: not llvm-bolt %t -o %t.bolt --frame-opt=all 2>&1 | FileCheck %s --check-prefix=CHECK-FRAME-OPT
+RUN: not llvm-bolt %t -o %t.bolt --three-way-branch 2>&1 | FileCheck %s --check-prefix=CHECK-THREE-WAY
 
 CHECK-FRAME-OPT: BOLT-ERROR: frame-optimizer is supported only on X86
+CHECK-THREE-WAY: BOLT-ERROR: three way branch is supported only on X86
 
 RUN: not llvm-bolt %t -o %t.bolt split-functions --split-strategy=cdsplit 2>&1 | FileCheck %s --check-prefix=CHECK-CDSPLIT
 CHECK-CDSPLIT: BOLT-ERROR: CDSplit is not supported with LongJmp. Try with '--compact-code-model'


### PR DESCRIPTION
On AArch64, `--three-way-branch` produces a crash as it is not implemented. This patch adds a guard
and updates relevant test(s).