### PR TITLE
[LLVM][ConstantFolding] Use correct type when flushing denormals.

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -1440,20 +1440,18 @@ Constant *llvm::ConstantFoldBinaryOpOperands(unsigned Opcode, Constant *LHS,
   return ConstantFoldBinaryInstruction(Opcode, LHS, RHS);
 }
 
-static ConstantFP *flushDenormalConstant(Type *Ty, const APFloat &APF,
-                                         DenormalMode::DenormalModeKind Mode) {
+static Constant *flushDenormalConstant(Type *Ty, const APFloat &APF,
+                                       DenormalMode::DenormalModeKind Mode) {
   switch (Mode) {
   case DenormalMode::Dynamic:
     return nullptr;
   case DenormalMode::IEEE:
-    return ConstantFP::get(Ty->getContext(), APF);
+    return ConstantFP::get(Ty, APF);
   case DenormalMode::PreserveSign:
     return ConstantFP::get(
-        Ty->getContext(),
-        APFloat::getZero(APF.getSemantics(), APF.isNegative()));
+        Ty, APFloat::getZero(APF.getSemantics(), APF.isNegative()));
   case DenormalMode::PositiveZero:
-    return ConstantFP::get(Ty->getContext(),
-                           APFloat::getZero(APF.getSemantics(), false));
+    return ConstantFP::get(Ty, APFloat::getZero(APF.getSemantics(), false));
   default:
     break;
   }
@@ -1470,9 +1468,9 @@ static DenormalMode getInstrDenormalMode(const Instruction *CtxI, Type *Ty) {
       Ty->getScalarType()->getFltSemantics());
 }
 
-static ConstantFP *flushDenormalConstantFP(ConstantFP *CFP,
-                                           const Instruction *Inst,
-                                           bool IsOutput) {
+static Constant *flushDenormalConstantFP(ConstantFP *CFP,
+                                         const Instruction *Inst,
+                                         bool IsOutput) {
   const APFloat &APF = CFP->getValueAPF();
   if (!APF.isDenormal())
     return CFP;
@@ -1494,7 +1492,7 @@ Constant *llvm::FlushFPConstant(Constant *Operand, const Instruction *Inst,
   VectorType *VecTy = dyn_cast<VectorType>(Ty);
   if (VecTy) {
     if (auto *Splat = dyn_cast_or_null<ConstantFP>(Operand->getSplatValue())) {
-      ConstantFP *Folded = flushDenormalConstantFP(Splat, Inst, IsOutput);
+      Constant *Folded = flushDenormalConstantFP(Splat, Inst, IsOutput);
       if (!Folded)
         return nullptr;
       return ConstantVector::getSplat(VecTy->getElementCount(), Folded);
@@ -1519,7 +1517,7 @@ Constant *llvm::FlushFPConstant(Constant *Operand, const Instruction *Inst,
       if (!CFP)
         return nullptr;
 
-      ConstantFP *Folded = flushDenormalConstantFP(CFP, Inst, IsOutput);
+      Constant *Folded = flushDenormalConstantFP(CFP, Inst, IsOutput);
       if (!Folded)
         return nullptr;
       NewElts.push_back(Folded);
@@ -1536,7 +1534,7 @@ Constant *llvm::FlushFPConstant(Constant *Operand, const Instruction *Inst,
         NewElts.push_back(ConstantFP::get(Ty, Elt));
       } else {
         DenormalMode Mode = getInstrDenormalMode(Inst, Ty);
-        ConstantFP *Folded =
+        Constant *Folded =
             flushDenormalConstant(Ty, Elt, IsOutput ? Mode.Output : Mode.Input);
         if (!Folded)
           return nullptr;

--- a/llvm/test/Transforms/InstSimplify/constant-fold-fp-denormal.ll
+++ b/llvm/test/Transforms/InstSimplify/constant-fold-fp-denormal.ll
@@ -22,6 +22,15 @@ define float @test_float_fadd_ieee() #0 {
   ret float %result
 }
 
+define <4 x float> @test_float_fadd_ieee_vector() #0 {
+; CHECK-LABEL: @test_float_fadd_ieee_vector(
+; CHECK-NEXT:    ret <4 x float> splat (float 0xB800000000000000)
+;
+; default ieee mode leaves result as a denormal
+  %result = fadd <4 x float> splat(float 0xB810000000000000), splat(float 0x3800000000000000)
+  ret <4 x float> %result
+}
+
 define float @test_float_fadd_pzero_out() #1 {
 ; CHECK-LABEL: @test_float_fadd_pzero_out(
 ; CHECK-NEXT:    ret float 0.000000e+00
@@ -31,6 +40,15 @@ define float @test_float_fadd_pzero_out() #1 {
   ret float %result
 }
 
+define <4 x float> @test_float_fadd_pzero_out_vector() #1 {
+; CHECK-LABEL: @test_float_fadd_pzero_out_vector(
+; CHECK-NEXT:    ret <4 x float> zeroinitializer
+;
+; denormal result is flushed to positive zero
+  %result = fadd <4 x float> splat(float 0xB810000000000000), splat(float 0x3800000000000000)
+  ret <4 x float> %result
+}
+
 define float @test_float_fadd_psign_out() #2 {
 ; CHECK-LABEL: @test_float_fadd_psign_out(
 ; CHECK-NEXT:    ret float -0.000000e+00
@@ -38,6 +56,15 @@ define float @test_float_fadd_psign_out() #2 {
 ; denormal result is flushed to sign preserved zero
   %result = fadd float 0xB810000000000000, 0x3800000000000000
   ret float %result
+}
+
+define <4 x float> @test_float_fadd_psign_out_vector() #2 {
+; CHECK-LABEL: @test_float_fadd_psign_out_vector(
+; CHECK-NEXT:    ret <4 x float> splat (float -0.000000e+00)
+;
+; denormal result is flushed to sign preserved zero
+  %result = fadd <4 x float> splat(float 0xB810000000000000), splat(float 0x3800000000000000)
+  ret <4 x float> %result
 }
 
 define float @test_float_fadd_pzero_in() #3 {
@@ -79,6 +106,15 @@ define double @test_double_fadd_ieee() #0 {
   ret double %result
 }
 
+define <2 x double> @test_double_fadd_ieee_vector() #0 {
+; CHECK-LABEL: @test_double_fadd_ieee_vector(
+; CHECK-NEXT:    ret <2 x double> splat (double 0x8008000000000000)
+;
+; default ieee mode leaves result as a denormal
+  %result = fadd <2 x double> splat(double 0x8010000000000000), splat(double 0x0008000000000000)
+  ret <2 x double> %result
+}
+
 define double @test_double_fadd_pzero_out() #1 {
 ; CHECK-LABEL: @test_double_fadd_pzero_out(
 ; CHECK-NEXT:    ret double 0.000000e+00
@@ -88,6 +124,15 @@ define double @test_double_fadd_pzero_out() #1 {
   ret double %result
 }
 
+define <2 x double> @test_double_fadd_pzero_out_vector() #1 {
+; CHECK-LABEL: @test_double_fadd_pzero_out_vector(
+; CHECK-NEXT:    ret <2 x double> zeroinitializer
+;
+; denormal result is flushed to positive zero
+  %result = fadd <2 x double> splat(double 0x8010000000000000), splat(double 0x0008000000000000)
+  ret <2 x double> %result
+}
+
 define double @test_double_fadd_psign_out() #2 {
 ; CHECK-LABEL: @test_double_fadd_psign_out(
 ; CHECK-NEXT:    ret double -0.000000e+00
@@ -95,6 +140,15 @@ define double @test_double_fadd_psign_out() #2 {
 ; denormal result is flushed to sign preserved zero
   %result = fadd double 0x8010000000000000, 0x0008000000000000
   ret double %result
+}
+
+define <2 x double> @test_double_fadd_psign_out_vector() #2 {
+; CHECK-LABEL: @test_double_fadd_psign_out_vector(
+; CHECK-NEXT:    ret <2 x double> splat (double -0.000000e+00)
+;
+; denormal result is flushed to sign preserved zero
+  %result = fadd <2 x double> splat(double 0x8010000000000000), splat(double 0x0008000000000000)
+  ret <2 x double> %result
 }
 
 define double @test_double_fadd_pzero_in() #3 {


### PR DESCRIPTION
flushDenormalConstant always created a scalar ConstantFP even when passed a vector type. I've had to change the return type from ConstantFP* to Constant* because ConstantFP::get does not necessarily return a ConstantFP. This can be reverted when ConstantFP vectors are enabled by default (although additional work is required to support zero).