### PR TITLE
[lldb] fix unconsumed llvm::Expected's errors

### DIFF
--- a/lldb/source/API/SBProcess.cpp
+++ b/lldb/source/API/SBProcess.cpp
@@ -1042,7 +1042,8 @@ SBStructuredData SBProcess::GetExtendedCrashInformation() {
       platform_sp->FetchExtendedCrashInformation(*process_sp.get());
 
   if (!expected_data) {
-    llvm::consumeError(expected_data.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), expected_data.takeError(),
+                   "FetchExtendedCrashInformation failed: {0}");
     return data;
   }
 

--- a/lldb/source/API/SBProcess.cpp
+++ b/lldb/source/API/SBProcess.cpp
@@ -1041,8 +1041,10 @@ SBStructuredData SBProcess::GetExtendedCrashInformation() {
   auto expected_data =
       platform_sp->FetchExtendedCrashInformation(*process_sp.get());
 
-  if (!expected_data)
+  if (!expected_data) {
+    llvm::consumeError(expected_data.takeError());
     return data;
+  }
 
   StructuredData::ObjectSP fetched_data = *expected_data;
   data.m_impl_up->SetObjectSP(fetched_data);

--- a/lldb/source/Host/posix/MainLoopPosix.cpp
+++ b/lldb/source/Host/posix/MainLoopPosix.cpp
@@ -9,6 +9,7 @@
 #include "lldb/Host/posix/MainLoopPosix.h"
 #include "lldb/Host/Config.h"
 #include "lldb/Host/PosixApi.h"
+#include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Status.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/Errno.h"
@@ -394,7 +395,8 @@ bool MainLoopPosix::Interrupt() {
   char c = '.';
   llvm::Expected<size_t> result_or_err = m_interrupt_pipe.Write(&c, 1);
   if (!result_or_err) {
-    llvm::consumeError(result_or_err.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Host), result_or_err.takeError(),
+                   "interrupt pipe write failed: {0}");
     return false;
   }
   return *result_or_err != 0;

--- a/lldb/source/Host/posix/MainLoopPosix.cpp
+++ b/lldb/source/Host/posix/MainLoopPosix.cpp
@@ -392,6 +392,10 @@ bool MainLoopPosix::Interrupt() {
     return true;
 
   char c = '.';
-  llvm::Expected<size_t> result = m_interrupt_pipe.Write(&c, 1);
-  return result && *result != 0;
+  llvm::Expected<size_t> result_or_err = m_interrupt_pipe.Write(&c, 1);
+  if (!result_or_err) {
+    llvm::consumeError(result_or_err.takeError());
+    return false;
+  }
+  return *result_or_err != 0;
 }

--- a/lldb/source/Interpreter/ScriptInterpreter.cpp
+++ b/lldb/source/Interpreter/ScriptInterpreter.cpp
@@ -263,7 +263,7 @@ ScriptInterpreterIORedirect::Create(bool enable_io, Debugger &debugger,
   auto nullout = FileSystem::Instance().Open(FileSpec(FileSystem::DEV_NULL),
                                              File::eOpenOptionWriteOnly);
   if (!nullout)
-    return nullin.takeError();
+    return nullout.takeError();
 
   return std::unique_ptr<ScriptInterpreterIORedirect>(
       new ScriptInterpreterIORedirect(std::move(*nullin), std::move(*nullout)));

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -470,10 +470,12 @@ bool formatters::LibStdcppVariantSummaryProvider(
   if (!index_obj || !data_obj)
     return false;
 
-  auto index_bytes = index_obj->GetByteSize();
-  if (!index_bytes)
+  auto index_bytes_or_err = index_obj->GetByteSize();
+  if (!index_bytes_or_err) {
+    llvm::consumeError(index_bytes_or_err.takeError());
     return false;
-  auto npos_value = LibStdcppVariantNposValue(*index_bytes);
+  }
+  auto npos_value = LibStdcppVariantNposValue(*index_bytes_or_err);
   auto index = index_obj->GetValueAsUnsigned(0);
   if (index == npos_value) {
     stream.Printf(" No Value");

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -19,6 +19,7 @@
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/Endian.h"
+#include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/ValueObject/ValueObject.h"
@@ -472,7 +473,9 @@ bool formatters::LibStdcppVariantSummaryProvider(
 
   auto index_bytes_or_err = index_obj->GetByteSize();
   if (!index_bytes_or_err) {
-    llvm::consumeError(index_bytes_or_err.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters),
+                   index_bytes_or_err.takeError(),
+                   "failed to get variant index byte size: {0}");
     return false;
   }
   auto npos_value = LibStdcppVariantNposValue(*index_bytes_or_err);

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
@@ -141,16 +141,18 @@ lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::Update() {
     if (!element_type)
       return lldb::eRefetch;
   }
-  auto element_size = element_type.GetByteSize(nullptr);
-  if (!element_size)
+  auto element_size_or_err = element_type.GetByteSize(nullptr);
+  if (!element_size_or_err) {
+    llvm::consumeError(element_size_or_err.takeError());
     return lldb::eRefetch;
+  }
 
   m_map = map_sp.get();
   m_exe_ctx_ref = m_backend.GetExecutionContextRef();
   m_block_size = block_size.ULongLong();
   m_offset = offset;
   m_map_size = map_size;
-  m_element_size = *element_size;
+  m_element_size = *element_size_or_err;
   m_element_type = element_type;
   m_size = size;
   return lldb::eRefetch;

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
@@ -10,6 +10,7 @@
 
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/DataFormatters/TypeSynthetic.h"
+#include "lldb/Utility/LLDBLog.h"
 #include "llvm/Support/ErrorExtras.h"
 
 using namespace lldb;
@@ -143,7 +144,9 @@ lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::Update() {
   }
   auto element_size_or_err = element_type.GetByteSize(nullptr);
   if (!element_size_or_err) {
-    llvm::consumeError(element_size_or_err.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters),
+                   element_size_or_err.takeError(),
+                   "failed to get deque element byte size: {0}");
     return lldb::eRefetch;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVector.cpp
@@ -250,7 +250,9 @@ lldb_private::formatters::MsvcStlVectorBoolSyntheticFrontEnd::Update() {
   llvm::Expected<uint64_t> element_bit_size_or_err =
       begin_ty.GetBitSize(nullptr);
   if (!element_bit_size_or_err) {
-    llvm::consumeError(element_bit_size_or_err.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters),
+                   element_bit_size_or_err.takeError(),
+                   "failed to get vector<bool> element bit size: {0}");
     return lldb::ChildCacheState::eRefetch;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVector.cpp
@@ -247,9 +247,12 @@ lldb_private::formatters::MsvcStlVectorBoolSyntheticFrontEnd::Update() {
   CompilerType begin_ty = begin_sp->GetCompilerType().GetPointeeType();
   if (!begin_ty.IsValid())
     return lldb::ChildCacheState::eRefetch;
-  llvm::Expected<uint64_t> element_bit_size = begin_ty.GetBitSize(nullptr);
-  if (!element_bit_size)
+  llvm::Expected<uint64_t> element_bit_size_or_err =
+      begin_ty.GetBitSize(nullptr);
+  if (!element_bit_size_or_err) {
+    llvm::consumeError(element_bit_size_or_err.takeError());
     return lldb::ChildCacheState::eRefetch;
+  }
 
   uint64_t base_data_address = begin_sp->GetValueAsUnsigned(0);
   if (!base_data_address)
@@ -257,7 +260,7 @@ lldb_private::formatters::MsvcStlVectorBoolSyntheticFrontEnd::Update() {
 
   m_exe_ctx_ref = exe_ctx_ref;
   m_count = count;
-  m_element_bit_size = *element_bit_size;
+  m_element_bit_size = *element_bit_size_or_err;
   m_base_data_address = base_data_address;
   return lldb::ChildCacheState::eRefetch;
 }

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -212,7 +212,9 @@ Status ProcessMinidump::DoLoadCore() {
     // If we can't read an exception stream skip it
     // We should probably serve a warning
     if (!exception_stream_or_err) {
-      llvm::consumeError(exception_stream_or_err.takeError());
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Process),
+                     exception_stream_or_err.takeError(),
+                     "failed to read exception stream: {0}");
       continue;
     }
     const llvm::minidump::ExceptionStream &exception_stream =

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -208,17 +208,21 @@ Status ProcessMinidump::DoLoadCore() {
 
   m_thread_list = m_minidump_parser->GetThreads();
   auto exception_stream_it = m_minidump_parser->GetExceptionStreams();
-  for (auto exception_stream : exception_stream_it) {
+  for (auto exception_stream_or_err : exception_stream_it) {
     // If we can't read an exception stream skip it
     // We should probably serve a warning
-    if (!exception_stream)
+    if (!exception_stream_or_err) {
+      llvm::consumeError(exception_stream_or_err.takeError());
       continue;
+    }
+    const llvm::minidump::ExceptionStream &exception_stream =
+        *exception_stream_or_err;
 
     if (!m_exceptions_by_tid
-             .try_emplace(exception_stream->ThreadId, exception_stream.get())
+             .try_emplace(exception_stream.ThreadId, exception_stream)
              .second) {
       return Status::FromErrorStringWithFormatv(
-          "Duplicate exception stream for tid {0}", exception_stream->ThreadId);
+          "Duplicate exception stream for tid {0}", exception_stream.ThreadId);
     }
   }
 

--- a/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
@@ -258,11 +258,12 @@ bool ScriptedThread::LoadArtificialStackFrames() {
       auto frame_from_script_obj_or_err = create_frame_from_script_object(idx);
 
       if (!frame_from_script_obj_or_err) {
-        llvm::consumeError(frame_from_script_obj_or_err.takeError());
         return ScriptedInterface::ErrorWithMessage<bool>(
             LLVM_PRETTY_FUNCTION,
-            llvm::Twine("Couldn't add artificial frame (" + llvm::Twine(idx) +
-                        llvm::Twine(") to ScriptedThread StackFrameList."))
+            llvm::Twine(
+                "Couldn't add artificial frame (" + llvm::Twine(idx) +
+                llvm::Twine(") to ScriptedThread StackFrameList: ") +
+                llvm::toString(frame_from_script_obj_or_err.takeError()))
                 .str(),
             error, LLDBLog::Thread);
       } else {

--- a/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
@@ -258,6 +258,7 @@ bool ScriptedThread::LoadArtificialStackFrames() {
       auto frame_from_script_obj_or_err = create_frame_from_script_object(idx);
 
       if (!frame_from_script_obj_or_err) {
+        llvm::consumeError(frame_from_script_obj_or_err.takeError());
         return ScriptedInterface::ErrorWithMessage<bool>(
             LLVM_PRETTY_FUNCTION,
             llvm::Twine("Couldn't add artificial frame (" + llvm::Twine(idx) +

--- a/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
@@ -169,8 +169,7 @@ bool ScriptedThread::LoadArtificialStackFrames() {
         LLVM_PRETTY_FUNCTION,
         llvm::Twine(
             "StackFrame array size (" + llvm::Twine(arr_size) +
-            llvm::Twine(
-                ") is greater than maximum authorized for a StackFrameList."))
+            ") is greater than maximum authorized for a StackFrameList.")
             .str(),
         error, LLDBLog::Thread);
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.cpp
@@ -24,6 +24,7 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Utility/LLDBAssert.h"
+#include "lldb/Utility/LLDBLog.h"
 #include <optional>
 #include <string_view>
 
@@ -909,7 +910,8 @@ clang::FunctionDecl *PdbAstBuilderClang::CreateFunctionDecl(
       if (eti) {
         tag_record = CVTagRecord::create(index.tpi().getType(*eti)).asTag();
       } else {
-        llvm::consumeError(eti.takeError());
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), eti.takeError(),
+                       "failed to find full decl for forward ref: {0}");
       }
     }
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.cpp
@@ -908,6 +908,8 @@ clang::FunctionDecl *PdbAstBuilderClang::CreateFunctionDecl(
           index.tpi().findFullDeclForForwardRef(class_index);
       if (eti) {
         tag_record = CVTagRecord::create(index.tpi().getType(*eti)).asTag();
+      } else {
+        llvm::consumeError(eti.takeError());
       }
     }
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -1497,8 +1497,10 @@ bool SymbolFileNativePDB::ParseLineTable(CompileUnit &comp_unit) {
     for (const LineColumnEntry &group : lines) {
       llvm::Expected<uint32_t> file_index_or_err =
           GetFileIndex(*cii, group.NameIndex);
-      if (!file_index_or_err)
+      if (!file_index_or_err) {
+        llvm::consumeError(file_index_or_err.takeError());
         continue;
+      }
       uint32_t file_index = file_index_or_err.get();
       lldbassert(!group.LineNumbers.empty());
       CompilandIndexItem::GlobalLineTable::Entry line_entry(
@@ -1701,8 +1703,10 @@ void SymbolFileNativePDB::ParseInlineSite(PdbCompilandSymId id,
   FileSpec decl_file;
   llvm::Expected<uint32_t> file_index_or_err =
       GetFileIndex(*cii, inlinee_line.Header->FileID);
-  if (!file_index_or_err)
+  if (!file_index_or_err) {
+    llvm::consumeError(file_index_or_err.takeError());
     return;
+  }
   uint32_t file_offset = file_index_or_err.get();
   decl_file = files.GetFileSpecAtIndex(file_offset);
   uint32_t decl_line = inlinee_line.Header->SourceLineNum;
@@ -1937,8 +1941,10 @@ size_t SymbolFileNativePDB::ParseSymbolArrayInScope(
 void SymbolFileNativePDB::DumpClangAST(Stream &s, llvm::StringRef filter,
                                        bool show_color) {
   auto ts_or_err = GetTypeSystemForLanguage(eLanguageTypeC_plus_plus);
-  if (!ts_or_err)
+  if (!ts_or_err) {
+    llvm::consumeError(ts_or_err.takeError());
     return;
+  }
   auto ts = *ts_or_err;
   TypeSystemClang *clang = llvm::dyn_cast_or_null<TypeSystemClang>(ts.get());
   if (!clang)

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -1498,7 +1498,8 @@ bool SymbolFileNativePDB::ParseLineTable(CompileUnit &comp_unit) {
       llvm::Expected<uint32_t> file_index_or_err =
           GetFileIndex(*cii, group.NameIndex);
       if (!file_index_or_err) {
-        llvm::consumeError(file_index_or_err.takeError());
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), file_index_or_err.takeError(),
+                       "failed to get file index for line entry: {0}");
         continue;
       }
       uint32_t file_index = file_index_or_err.get();
@@ -1704,7 +1705,8 @@ void SymbolFileNativePDB::ParseInlineSite(PdbCompilandSymId id,
   llvm::Expected<uint32_t> file_index_or_err =
       GetFileIndex(*cii, inlinee_line.Header->FileID);
   if (!file_index_or_err) {
-    llvm::consumeError(file_index_or_err.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), file_index_or_err.takeError(),
+                   "failed to get file index for inline site: {0}");
     return;
   }
   uint32_t file_offset = file_index_or_err.get();
@@ -1942,7 +1944,8 @@ void SymbolFileNativePDB::DumpClangAST(Stream &s, llvm::StringRef filter,
                                        bool show_color) {
   auto ts_or_err = GetTypeSystemForLanguage(eLanguageTypeC_plus_plus);
   if (!ts_or_err) {
-    llvm::consumeError(ts_or_err.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), ts_or_err.takeError(),
+                   "failed to get C++ type system: {0}");
     return;
   }
   auto ts = *ts_or_err;

--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
@@ -174,7 +174,8 @@ GetFileForModule(const ModuleSpec &module_spec,
   llvm::Expected<std::string> cache_path_or_err = plugin_props.GetCachePath();
   // A cache location is *required*.
   if (!cache_path_or_err) {
-    llvm::consumeError(cache_path_or_err.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), cache_path_or_err.takeError(),
+                   "debuginfod cache path unavailable: {0}");
     return {};
   }
   std::string cache_path = *cache_path_or_err;

--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
@@ -173,8 +173,10 @@ GetFileForModule(const ModuleSpec &module_spec,
   PluginProperties &plugin_props = GetGlobalPluginProperties();
   llvm::Expected<std::string> cache_path_or_err = plugin_props.GetCachePath();
   // A cache location is *required*.
-  if (!cache_path_or_err)
+  if (!cache_path_or_err) {
+    llvm::consumeError(cache_path_or_err.takeError());
     return {};
+  }
   std::string cache_path = *cache_path_or_err;
   llvm::SmallVector<llvm::StringRef> debuginfod_urls =
       llvm::getDefaultDebuginfodUrls();

--- a/lldb/source/Symbol/SymbolFileOnDemand.cpp
+++ b/lldb/source/Symbol/SymbolFileOnDemand.cpp
@@ -515,10 +515,11 @@ SymbolFileOnDemand::GetParameterStackSize(const Symbol &symbol) {
     if (log) {
       llvm::Expected<lldb::addr_t> stack_size =
           m_sym_file_impl->GetParameterStackSize(symbol);
-      if (stack_size) {
+      if (stack_size)
         LLDB_LOG(log, "{0} stack size would return for symbol {1} if hydrated.",
                  *stack_size, symbol.GetName());
-      }
+      else
+        llvm::consumeError(stack_size.takeError());
     }
     return SymbolFile::GetParameterStackSize(symbol);
   }

--- a/lldb/source/Symbol/SymbolFileOnDemand.cpp
+++ b/lldb/source/Symbol/SymbolFileOnDemand.cpp
@@ -519,7 +519,8 @@ SymbolFileOnDemand::GetParameterStackSize(const Symbol &symbol) {
         LLDB_LOG(log, "{0} stack size would return for symbol {1} if hydrated.",
                  *stack_size, symbol.GetName());
       else
-        llvm::consumeError(stack_size.takeError());
+        LLDB_LOG_ERROR(log, stack_size.takeError(),
+                       "failed to get parameter stack size: {0}");
     }
     return SymbolFile::GetParameterStackSize(symbol);
   }

--- a/lldb/source/Target/Statistics.cpp
+++ b/lldb/source/Target/Statistics.cpp
@@ -507,6 +507,8 @@ llvm::json::Value DebuggerStats::ReportStatistics(
       if (auto json_transcript = llvm::json::parse(buffer))
         global_stats.try_emplace("transcript",
                                  std::move(json_transcript.get()));
+      else
+        llvm::consumeError(json_transcript.takeError());
     }
   }
 

--- a/lldb/source/Target/Statistics.cpp
+++ b/lldb/source/Target/Statistics.cpp
@@ -17,6 +17,7 @@
 #include "lldb/Target/Process.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Target/UnixSignals.h"
+#include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/StructuredData.h"
 
 using namespace lldb;
@@ -508,7 +509,8 @@ llvm::json::Value DebuggerStats::ReportStatistics(
         global_stats.try_emplace("transcript",
                                  std::move(json_transcript.get()));
       else
-        llvm::consumeError(json_transcript.takeError());
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Target), json_transcript.takeError(),
+                       "failed to parse transcript JSON: {0}");
     }
   }
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4203,8 +4203,10 @@ Target::StopHookScripted::HandleStop(ExecutionContext &exc_ctx,
   auto should_stop_or_err = m_interface_sp->HandleStop(exc_ctx, stream);
   output_sp->PutCString(
       reinterpret_cast<StreamString *>(stream.get())->GetData());
-  if (!should_stop_or_err)
+  if (!should_stop_or_err) {
+    llvm::consumeError(should_stop_or_err.takeError());
     return StopHookResult::KeepStopped;
+  }
 
   return *should_stop_or_err ? StopHookResult::KeepStopped
                              : StopHookResult::RequestContinue;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4204,7 +4204,8 @@ Target::StopHookScripted::HandleStop(ExecutionContext &exc_ctx,
   output_sp->PutCString(
       reinterpret_cast<StreamString *>(stream.get())->GetData());
   if (!should_stop_or_err) {
-    llvm::consumeError(should_stop_or_err.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Target), should_stop_or_err.takeError(),
+                   "scripted stop hook HandleStop failed: {0}");
     return StopHookResult::KeepStopped;
   }
 

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -94,7 +94,7 @@ Interpreter::UnaryConversion(lldb::ValueObjectSP valobj, uint32_t location) {
       llvm::Expected<uint64_t> uint_bit_size =
           uint_type.GetBitSize(m_exe_ctx_scope.get());
       if (!uint_bit_size)
-        return int_bit_size.takeError();
+        return uint_bit_size.takeError();
       if (bitfield_size < *int_bit_size ||
           (in_type.IsSigned() && bitfield_size == *int_bit_size))
         return valobj->CastToBasicType(int_type);
@@ -1283,6 +1283,7 @@ Interpreter::VerifyArithmeticCast(CompilerType source_type,
     } else {
       std::string errMsg = llvm::formatv("unable to get byte size for type {0}",
                                          target_type.TypeDescription());
+      llvm::consumeError(temp.takeError());
       return llvm::make_error<DILDiagnosticError>(
           m_expr, std::move(errMsg), location,
           target_type.TypeDescription().length());
@@ -1293,6 +1294,7 @@ Interpreter::VerifyArithmeticCast(CompilerType source_type,
     } else {
       std::string errMsg = llvm::formatv("unable to get byte size for type {0}",
                                          source_type.TypeDescription());
+      llvm::consumeError(temp.takeError());
       return llvm::make_error<DILDiagnosticError>(
           m_expr, std::move(errMsg), location,
           source_type.TypeDescription().length());

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -12,6 +12,7 @@
 #include "lldb/Symbol/TypeSystem.h"
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/RegisterContext.h"
+#include "lldb/Utility/LLDBLog.h"
 #include "lldb/ValueObject/DILAST.h"
 #include "lldb/ValueObject/DILParser.h"
 #include "lldb/ValueObject/ValueObject.h"
@@ -1283,7 +1284,8 @@ Interpreter::VerifyArithmeticCast(CompilerType source_type,
     } else {
       std::string errMsg = llvm::formatv("unable to get byte size for type {0}",
                                          target_type.TypeDescription());
-      llvm::consumeError(temp.takeError());
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Expressions), temp.takeError(),
+                     "GetByteSize failed: {0}");
       return llvm::make_error<DILDiagnosticError>(
           m_expr, std::move(errMsg), location,
           target_type.TypeDescription().length());
@@ -1294,7 +1296,8 @@ Interpreter::VerifyArithmeticCast(CompilerType source_type,
     } else {
       std::string errMsg = llvm::formatv("unable to get byte size for type {0}",
                                          source_type.TypeDescription());
-      llvm::consumeError(temp.takeError());
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Expressions), temp.takeError(),
+                     "GetByteSize failed: {0}");
       return llvm::make_error<DILDiagnosticError>(
           m_expr, std::move(errMsg), location,
           source_type.TypeDescription().length());

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -1191,11 +1191,13 @@ llvm::Expected<bool> ValueObject::GetValueAsBool() {
     auto value_or_err = GetValueAsAPSInt();
     if (value_or_err)
       return value_or_err->getBoolValue();
+    llvm::consumeError(value_or_err.takeError());
   }
   if (HasFloatingRepresentation(val_type)) {
     auto value_or_err = GetValueAsAPFloat();
     if (value_or_err)
       return value_or_err->isNonZero();
+    llvm::consumeError(value_or_err.takeError());
   }
   if (val_type.IsArrayType())
     return GetAddressOf().address != 0;
@@ -1275,15 +1277,19 @@ void ValueObject::SetValueFromInteger(lldb::ValueObjectSP new_val_sp,
     auto value_or_err = new_val_sp->GetValueAsAPSInt();
     if (value_or_err)
       SetValueFromInteger(*value_or_err, error, can_update_var);
-    else
+    else {
+      llvm::consumeError(value_or_err.takeError());
       error = Status::FromErrorString("error getting APSInt from new_val_sp");
+    }
   } else if (HasFloatingRepresentation(new_val_type)) {
     auto value_or_err = new_val_sp->GetValueAsAPFloat();
     if (value_or_err)
       SetValueFromInteger(value_or_err->bitcastToAPInt(), error,
                           can_update_var);
-    else
+    else {
+      llvm::consumeError(value_or_err.takeError());
       error = Status::FromErrorString("error getting APFloat from new_val_sp");
+    }
   } else if (new_val_type.IsPointerType()) {
     bool success = true;
     uint64_t int_val = new_val_sp->GetValueAsUnsigned(0, &success);

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -1188,16 +1188,12 @@ llvm::Expected<bool> ValueObject::GetValueAsBool() {
   CompilerType val_type = GetCompilerType();
   if (val_type.IsInteger() || val_type.IsUnscopedEnumerationType() ||
       val_type.IsPointerType()) {
-    auto value_or_err = GetValueAsAPSInt();
-    if (value_or_err)
-      return value_or_err->getBoolValue();
-    llvm::consumeError(value_or_err.takeError());
+    if (auto maybe_value = llvm::expectedToOptional(GetValueAsAPSInt()))
+      return maybe_value->getBoolValue();
   }
   if (HasFloatingRepresentation(val_type)) {
-    auto value_or_err = GetValueAsAPFloat();
-    if (value_or_err)
-      return value_or_err->isNonZero();
-    llvm::consumeError(value_or_err.takeError());
+    if (auto maybe_value = llvm::expectedToOptional(GetValueAsAPFloat()))
+      return maybe_value->isNonZero();
   }
   if (val_type.IsArrayType())
     return GetAddressOf().address != 0;
@@ -1277,19 +1273,15 @@ void ValueObject::SetValueFromInteger(lldb::ValueObjectSP new_val_sp,
     auto value_or_err = new_val_sp->GetValueAsAPSInt();
     if (value_or_err)
       SetValueFromInteger(*value_or_err, error, can_update_var);
-    else {
-      llvm::consumeError(value_or_err.takeError());
-      error = Status::FromErrorString("error getting APSInt from new_val_sp");
-    }
+    else
+      error = Status::FromError(value_or_err.takeError());
   } else if (HasFloatingRepresentation(new_val_type)) {
     auto value_or_err = new_val_sp->GetValueAsAPFloat();
     if (value_or_err)
       SetValueFromInteger(value_or_err->bitcastToAPInt(), error,
                           can_update_var);
-    else {
-      llvm::consumeError(value_or_err.takeError());
-      error = Status::FromErrorString("error getting APFloat from new_val_sp");
-    }
+    else
+      error = Status::FromError(value_or_err.takeError());
   } else if (new_val_type.IsPointerType()) {
     bool success = true;
     uint64_t int_val = new_val_sp->GetValueAsUnsigned(0, &success);

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -1188,12 +1188,20 @@ llvm::Expected<bool> ValueObject::GetValueAsBool() {
   CompilerType val_type = GetCompilerType();
   if (val_type.IsInteger() || val_type.IsUnscopedEnumerationType() ||
       val_type.IsPointerType()) {
-    if (auto maybe_value = llvm::expectedToOptional(GetValueAsAPSInt()))
-      return maybe_value->getBoolValue();
+    auto value_or_err = GetValueAsAPSInt();
+    if (value_or_err)
+      return value_or_err->getBoolValue();
+    else
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Types), value_or_err.takeError(),
+                     "GetValueAsAPSInt failed: {0}");
   }
   if (HasFloatingRepresentation(val_type)) {
-    if (auto maybe_value = llvm::expectedToOptional(GetValueAsAPFloat()))
-      return maybe_value->isNonZero();
+    auto value_or_err = GetValueAsAPFloat();
+    if (value_or_err)
+      return value_or_err->isNonZero();
+    else
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Types), value_or_err.takeError(),
+                     "GetValueAsAPFloat failed: {0}");
   }
   if (val_type.IsArrayType())
     return GetAddressOf().address != 0;

--- a/lldb/source/ValueObject/ValueObjectMemory.cpp
+++ b/lldb/source/ValueObject/ValueObjectMemory.cpp
@@ -12,6 +12,7 @@
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/DataExtractor.h"
+#include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Scalar.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/ValueObject/ValueObject.h"
@@ -150,7 +151,8 @@ llvm::Expected<uint64_t> ValueObjectMemory::GetByteSize() {
             m_type_sp->GetByteSize(exe_ctx.GetBestExecutionContextScope()))
       return *size;
     else
-      llvm::consumeError(size.takeError());
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Types), size.takeError(),
+                     "failed to get byte size from type: {0}");
     return llvm::createStringError("could not get byte size of memory object");
   }
   return m_compiler_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());

--- a/lldb/source/ValueObject/ValueObjectMemory.cpp
+++ b/lldb/source/ValueObject/ValueObjectMemory.cpp
@@ -149,6 +149,8 @@ llvm::Expected<uint64_t> ValueObjectMemory::GetByteSize() {
     if (auto size =
             m_type_sp->GetByteSize(exe_ctx.GetBestExecutionContextScope()))
       return *size;
+    else
+      llvm::consumeError(size.takeError());
     return llvm::createStringError("could not get byte size of memory object");
   }
   return m_compiler_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());


### PR DESCRIPTION
This patch fixes `llvm::Expected` values which were not consumed, which would trigger an assertion crash at the end of their lifetime.

These were found using clang-tidy and Claude to filter through the false positives.