### PR TITLE
[LLVM] Make -use-constant-fp-for-fixed-length-splat the default.

### DIFF
--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -40,7 +40,7 @@ static cl::opt<bool> UseConstantIntForFixedLengthSplat(
     "use-constant-int-for-fixed-length-splat", cl::init(false), cl::Hidden,
     cl::desc("Use ConstantInt's native fixed-length vector splat support."));
 static cl::opt<bool> UseConstantFPForFixedLengthSplat(
-    "use-constant-fp-for-fixed-length-splat", cl::init(false), cl::Hidden,
+    "use-constant-fp-for-fixed-length-splat", cl::init(true), cl::Hidden,
     cl::desc("Use ConstantFP's native fixed-length vector splat support."));
 static cl::opt<bool> UseConstantIntForScalableSplat(
     "use-constant-int-for-scalable-splat", cl::init(false), cl::Hidden,


### PR DESCRIPTION
This follows on from https://github.com/llvm/llvm-project/pull/186422 with https://github.com/llvm/llvm-project/pull/193254 and https://github.com/llvm/llvm-project/pull/193249 being the final things I've spotted when auditing the code.  

Enabling this for scalable vectors was mostly harmless (1 bug) but presumably the risk is much higher now that fixed-length vectors are included.  That said, my recent (last week) runs of LNT (AArch64 and X86) raised no issues.