### PR TITLE
Revert "[llvm-cov] Fix error propagation in CoverageMapping::load() (…

### DIFF
--- a/llvm/include/llvm/Debuginfod/BuildIDFetcher.h
+++ b/llvm/include/llvm/Debuginfod/BuildIDFetcher.h
@@ -16,6 +16,7 @@
 #define LLVM_DEBUGINFOD_DIFETCHER_H
 
 #include "llvm/Object/BuildID.h"
+#include <optional>
 
 namespace llvm {
 
@@ -27,7 +28,7 @@ public:
 
   /// Fetches the given Build ID using debuginfod and returns a local path to
   /// the resulting file.
-  Expected<std::string> fetch(object::BuildIDRef BuildID) const override;
+  std::optional<std::string> fetch(object::BuildIDRef BuildID) const override;
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Object/BuildID.h
+++ b/llvm/include/llvm/Object/BuildID.h
@@ -18,7 +18,6 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Compiler.h"
-#include "llvm/Support/Error.h"
 
 namespace llvm {
 namespace object {
@@ -45,7 +44,7 @@ public:
   virtual ~BuildIDFetcher() = default;
 
   /// Returns the path to the debug file with the given build ID.
-  virtual Expected<std::string> fetch(BuildIDRef BuildID) const;
+  virtual std::optional<std::string> fetch(BuildIDRef BuildID) const;
 
 private:
   const std::vector<std::string> DebugFileDirectories;

--- a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
@@ -490,17 +490,14 @@ bool LLVMSymbolizer::getOrFindDebugBinary(const ArrayRef<uint8_t> BuildID,
   }
   if (!BIDFetcher)
     return false;
-  Expected<std::string> Path = BIDFetcher->fetch(BuildID);
-  if (Path) {
+  if (std::optional<std::string> Path = BIDFetcher->fetch(BuildID)) {
     Result = *Path;
     auto InsertResult = BuildIDPaths.insert({BuildIDStr, Result});
     assert(InsertResult.second);
     (void)InsertResult;
     return true;
   }
-  // Failure to fetch debuginfod is rarely an error and most users will not care
-  // why this failed.
-  consumeError(Path.takeError());
+
   return false;
 }
 

--- a/llvm/lib/Debuginfod/BuildIDFetcher.cpp
+++ b/llvm/lib/Debuginfod/BuildIDFetcher.cpp
@@ -15,19 +15,17 @@
 #include "llvm/Debuginfod/BuildIDFetcher.h"
 
 #include "llvm/Debuginfod/Debuginfod.h"
-#include "llvm/Support/Error.h"
 
 using namespace llvm;
 
-Expected<std::string>
+std::optional<std::string>
 DebuginfodFetcher::fetch(ArrayRef<uint8_t> BuildID) const {
-  Expected<std::string> Path = BuildIDFetcher::fetch(BuildID);
-  if (Path)
-    return Path;
-  // Most users will not care why this failed.
-  assert(errorToErrorCode(Path.takeError()) ==
-             std::errc::no_such_file_or_directory &&
-         "BuildIDFetcher::fetch() failed in an unexpected way");
-  consumeError(Path.takeError());
-  return getCachedOrDownloadDebuginfo(BuildID);
+  if (std::optional<std::string> Path = BuildIDFetcher::fetch(BuildID))
+    return std::move(*Path);
+
+  Expected<std::string> PathOrErr = getCachedOrDownloadDebuginfo(BuildID);
+  if (PathOrErr)
+    return *PathOrErr;
+  consumeError(PathOrErr.takeError());
+  return std::nullopt;
 }

--- a/llvm/lib/Object/BuildID.cpp
+++ b/llvm/lib/Object/BuildID.cpp
@@ -15,7 +15,6 @@
 #include "llvm/Object/BuildID.h"
 
 #include "llvm/Object/ELFObjectFile.h"
-#include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 
@@ -80,7 +79,7 @@ BuildIDRef llvm::object::getBuildID(const ObjectFile *Obj) {
   return {};
 }
 
-Expected<std::string> BuildIDFetcher::fetch(BuildIDRef BuildID) const {
+std::optional<std::string> BuildIDFetcher::fetch(BuildIDRef BuildID) const {
   auto GetDebugPath = [&](StringRef Directory) {
     SmallString<128> Path{Directory};
     sys::path::append(Path, ".build-id",
@@ -109,8 +108,5 @@ Expected<std::string> BuildIDFetcher::fetch(BuildIDRef BuildID) const {
         return std::string(Path);
     }
   }
-  return createStringError(
-      make_error_code(std::errc::no_such_file_or_directory),
-      "could not find debug file for build ID '" +
-          llvm::toHex(BuildID, /*LowerCase=*/true) + "'");
+  return std::nullopt;
 }

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -1106,21 +1106,19 @@ Expected<std::unique_ptr<CoverageMapping>> CoverageMapping::load(
     }
 
     for (object::BuildIDRef BinaryID : BinaryIDsToFetch) {
-      if (Expected<std::string> Path = BIDFetcher->fetch(BinaryID)) {
+      std::optional<std::string> PathOpt = BIDFetcher->fetch(BinaryID);
+      if (PathOpt) {
+        std::string Path = std::move(*PathOpt);
         StringRef Arch = Arches.size() == 1 ? Arches.front() : StringRef();
-        if (Error E = loadFromFile(*Path, Arch, CompilationDir,
-                                   ProfileReaderRef, *Coverage, DataFound))
+        if (Error E = loadFromFile(Path, Arch, CompilationDir, ProfileReaderRef,
+                                   *Coverage, DataFound))
           return std::move(E);
-      } else {
-        // Conditionally propagate as new error.
-        consumeError(Path.takeError());
-        if (CheckBinaryIDs) {
-          return createFileError(
-              ProfileFilename.value(),
-              createStringError(errc::no_such_file_or_directory,
-                                "Missing binary ID: " +
-                                    llvm::toHex(BinaryID, /*LowerCase=*/true)));
-        }
+      } else if (CheckBinaryIDs) {
+        return createFileError(
+            ProfileFilename.value(),
+            createStringError(errc::no_such_file_or_directory,
+                              "Missing binary ID: " +
+                                  llvm::toHex(BinaryID, /*LowerCase=*/true)));
       }
     }
   }

--- a/llvm/lib/ProfileData/InstrProfCorrelator.cpp
+++ b/llvm/lib/ProfileData/InstrProfCorrelator.cpp
@@ -114,6 +114,7 @@ llvm::Expected<std::unique_ptr<InstrProfCorrelator>>
 InstrProfCorrelator::get(StringRef Filename, ProfCorrelatorKind FileKind,
                          const object::BuildIDFetcher *BIDFetcher,
                          const ArrayRef<object::BuildID> BIs) {
+  std::optional<std::string> Path;
   if (BIDFetcher) {
     if (BIs.empty())
       return make_error<InstrProfError>(
@@ -126,18 +127,12 @@ InstrProfCorrelator::get(StringRef Filename, ProfCorrelatorKind FileKind,
           "unsupported profile binary correlation when there are multiple "
           "build IDs in a profile");
 
-    Expected<std::string> Path = BIDFetcher->fetch(BIs.front());
-    if (!Path) {
-      // Propagate as InstrProf specific error type.
-      assert(errorToErrorCode(Path.takeError()) ==
-                 std::errc::no_such_file_or_directory &&
-             "BuildIDFetcher::fetch() failed in an unexpected way");
-      consumeError(Path.takeError());
+    Path = BIDFetcher->fetch(BIs.front());
+    if (!Path)
       return make_error<InstrProfError>(
           instrprof_error::unable_to_correlate_profile,
           "Missing build ID: " + llvm::toHex(BIs.front(),
                                              /*LowerCase=*/true));
-    }
     Filename = *Path;
   }
 

--- a/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
+++ b/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
@@ -152,12 +152,10 @@ int llvm_debuginfod_find_main(int argc, char **argv,
 
 // Find a debug file in local build ID directories and via debuginfod.
 std::string fetchDebugInfo(object::BuildIDRef BuildID) {
-  Expected<std::string> PathOrErr =
-      DebuginfodFetcher(DebugFileDirectory).fetch(BuildID);
-  if (PathOrErr)
-    return *PathOrErr;
-  errs() << "Build ID " << llvm::toHex(BuildID, /*Lowercase=*/true) << ": "
+  if (std::optional<std::string> Path =
+          DebuginfodFetcher(DebugFileDirectory).fetch(BuildID))
+    return *Path;
+  errs() << "Build ID " << llvm::toHex(BuildID, /*Lowercase=*/true)
          << " could not be found.\n";
-  consumeError(PathOrErr.takeError());
   exit(1);
 }

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -1743,13 +1743,9 @@ fetchBinaryByBuildID(const ObjectFile &Obj) {
   object::BuildIDRef BuildID = getBuildID(&Obj);
   if (BuildID.empty())
     return std::nullopt;
-  Expected<std::string> Path = BIDFetcher->fetch(BuildID);
-  if (!Path) {
-    // Failure to fetch debuginfod is rarely an error and most users will not
-    // care why this failed.
-    consumeError(Path.takeError());
+  std::optional<std::string> Path = BIDFetcher->fetch(BuildID);
+  if (!Path)
     return std::nullopt;
-  }
   Expected<OwningBinary<Binary>> DebugBinary = createBinary(*Path);
   if (!DebugBinary) {
     reportWarning(toString(DebugBinary.takeError()), *Path);
@@ -3845,10 +3841,8 @@ static void parseObjdumpOptions(const llvm::opt::InputArgList &InputArgs) {
   // Look up any provided build IDs, then append them to the input filenames.
   for (const opt::Arg *A : InputArgs.filtered(OBJDUMP_build_id)) {
     object::BuildID BuildID = parseBuildIDArg(A);
-    Expected<std::string> Path = BIDFetcher->fetch(BuildID);
+    std::optional<std::string> Path = BIDFetcher->fetch(BuildID);
     if (!Path) {
-      // Most users will not care why this failed.
-      consumeError(Path.takeError());
       reportCmdLineError(A->getSpelling() + ": could not find build ID '" +
                          A->getValue() + "'");
     }


### PR DESCRIPTION
…#193197)"

This reverts commit b7cfcfe03deb679befe821d0c7a9c302f8645763.

Revert "[llvm] Errorize DebuginfodFetcher for inspection at call-sites (#191191)"

This reverts commit 337ad44a3e585f62bcf2e30b5766146cb8aacaca.

Reason for revert: Caused debuginfod tests failed in profile runtime:
https://luci-milo.appspot.com/ui/p/fuchsia/builders/toolchain.ci/clang-linux-x64/b8683917826498677969/overview