### PR TITLE
[RISCV][TableGen] Use ArrayRef instead of vector&. NFC

### DIFF
--- a/llvm/utils/TableGen/Basic/RISCVTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/RISCVTargetDefEmitter.cpp
@@ -49,7 +49,7 @@ static void printExtensionTable(raw_ostream &OS,
   OS << "};\n";
 }
 
-static void emitExtensionTable(std::vector<const Record *> &Extensions,
+static void emitExtensionTable(ArrayRef<const Record *> Extensions,
                                raw_ostream &OS) {
   IfDefEmitter IfDef(OS, "GET_SUPPORTED_EXTENSIONS");
   if (!Extensions.empty()) {
@@ -58,7 +58,7 @@ static void emitExtensionTable(std::vector<const Record *> &Extensions,
   }
 }
 
-static void emitImpliedExtensionTable(std::vector<const Record *> &Extensions,
+static void emitImpliedExtensionTable(ArrayRef<const Record *> Extensions,
                                       raw_ostream &OS) {
   IfDefEmitter IfDef(OS, "GET_IMPLIED_EXTENSIONS");
 


### PR DESCRIPTION
The vector isn't modified so it should be passed as const vector& or ArrayRef.