### PR TITLE
[CIR] Support guard COMDAT for weak linkage in LoweringPrepare

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -193,8 +193,7 @@ struct LoweringPreparePass
         globalOp->emitError("NYI: guard COMDAT for non-local variables");
         return {};
       } else if (hasComdat && globalOp.isWeakForLinker()) {
-        globalOp->emitError("NYI: guard COMDAT for weak linkage");
-        return {};
+        guard.setComdat(true);
       }
 
       setStaticLocalDeclGuardAddress(globalSymName, guard);

--- a/clang/test/CIR/CodeGen/static-local.cpp
+++ b/clang/test/CIR/CodeGen/static-local.cpp
@@ -28,6 +28,23 @@ void f() {
   use(&a);
 }
 
+// Static local in an inline function: the variable and guard both get
+// linkonce_odr linkage and their own COMDAT groups.
+void use(const A *);
+inline const A &getInlineA() {
+  static A a;
+  return a;
+}
+
+void call_inline() {
+  use(&getInlineA());
+}
+
+// CIR-BEFORE-LPP: cir.global linkonce_odr comdat static_local_guard<"_ZGVZ10getInlineAvE1a"> @_ZZ10getInlineAvE1a = ctor : !rec_A {
+// CIR-BEFORE-LPP:   %[[ADDR2:.*]] = cir.get_global static_local @_ZZ10getInlineAvE1a : !cir.ptr<!rec_A>
+// CIR-BEFORE-LPP:   cir.call @_ZN1AC1Ev(%[[ADDR2]]) : (!cir.ptr<!rec_A> {{.*}}) -> ()
+// CIR-BEFORE-LPP: }
+
 // CIR-BEFORE-LPP: cir.global "private" internal dso_local static_local_guard<"_ZGVZ1fvE1a"> @_ZZ1fvE1a = ctor : !rec_A {
 // CIR-BEFORE-LPP:   %[[ADDR:.*]] = cir.get_global static_local @_ZZ1fvE1a : !cir.ptr<!rec_A>
 // CIR-BEFORE-LPP:   cir.call @_ZN1AC1Ev(%[[ADDR]]) : (!cir.ptr<!rec_A> {{.*}}) -> ()
@@ -39,6 +56,16 @@ void f() {
 // CIR-BEFORE-LPP:   cir.return
 
 // CIR-DAG: cir.global "private" internal dso_local @_ZGVZ1fvE1a = #cir.int<0> : !s64i
+// CIR-DAG: cir.global "private" linkonce_odr comdat @_ZGVZ10getInlineAvE1a = #cir.int<0> : !s64i
+
+// LLVM-DAG: @_ZGVZ1fvE1a = internal global i64 0
+// LLVM-DAG: @_ZZ10getInlineAvE1a = linkonce_odr global %class.A zeroinitializer, comdat, align 1
+// LLVM-DAG: @_ZGVZ10getInlineAvE1a = linkonce_odr global i64 0, comdat, align 8
+
+// OGCG-DAG: @_ZGVZ1fvE1a = internal global i64 0
+// OGCG-DAG: @_ZZ10getInlineAvE1a = linkonce_odr global %class.A zeroinitializer, comdat, align 1
+// OGCG-DAG: @_ZGVZ10getInlineAvE1a = linkonce_odr global i64 0, comdat, align 8
+
 // CIR: cir.func{{.*}}@_Z1fv()
 // CIR:   %[[ADDR:.*]] = cir.get_global static_local @_ZZ1fvE1a : !cir.ptr<!rec_A>
 // CIR:   %[[GUARD:.*]] = cir.get_global @_ZGVZ1fvE1a : !cir.ptr<!s64i>
@@ -54,7 +81,19 @@ void f() {
 // CIR:   cir.call @_Z3useP1A(%[[ADDR]])
 // CIR:   cir.return
 
-// LLVM-DAG: @_ZGVZ1fvE1a = internal global i64 0
+// CIR: cir.func{{.*}}@_Z10getInlineAv()
+// CIR:   %[[ADDR2:.*]] = cir.get_global static_local @_ZZ10getInlineAvE1a : !cir.ptr<!rec_A>
+// CIR:   %[[GUARD2:.*]] = cir.get_global @_ZGVZ10getInlineAvE1a : !cir.ptr<!s64i>
+// CIR:   %[[GUARD_BYTE_PTR2:.*]] = cir.cast bitcast %[[GUARD2]] : !cir.ptr<!s64i> -> !cir.ptr<!s8i>
+// CIR:   %[[GUARD_LOAD2:.*]] = cir.load{{.*}}%[[GUARD_BYTE_PTR2]]
+// CIR:   %[[ZERO2:.*]] = cir.const #cir.int<0>
+// CIR:   %[[IS_UNINIT2:.*]] = cir.cmp eq %[[GUARD_LOAD2]], %[[ZERO2]]
+// CIR:   cir.if %[[IS_UNINIT2]]
+// CIR:     cir.call @__cxa_guard_acquire
+// CIR:     cir.if
+// CIR:       cir.call @_ZN1AC1Ev
+// CIR:       cir.call @__cxa_guard_release
+
 // LLVM: define{{.*}}void @_Z1fv()
 // LLVM:   %[[GUARD:.*]] = load atomic i8, ptr @_ZGVZ1fvE1a acquire
 // LLVM:   %[[IS_UNINIT:.*]] = icmp eq i8 %[[GUARD]], 0
@@ -65,7 +104,14 @@ void f() {
 // LLVM: call void @_Z3useP1A(ptr {{.*}}@_ZZ1fvE1a)
 // LLVM: ret void
 
-// OGCG-DAG: @_ZGVZ1fvE1a = internal global i64 0
+// LLVM: define linkonce_odr {{.*}}ptr @_Z10getInlineAv()
+// LLVM:   %[[GUARD3:.*]] = load atomic i8, ptr @_ZGVZ10getInlineAvE1a acquire
+// LLVM:   %[[IS_UNINIT3:.*]] = icmp eq i8 %[[GUARD3]], 0
+// LLVM:   br i1 %[[IS_UNINIT3]]
+// LLVM: call i32 @__cxa_guard_acquire
+// LLVM: call void @_ZN1AC1Ev
+// LLVM: call void @__cxa_guard_release
+
 // OGCG: define{{.*}}void @_Z1fv()
 // OGCG:   %[[GUARD:.*]] = load atomic i8, ptr @_ZGVZ1fvE1a acquire
 // OGCG:   %[[IS_UNINIT:.*]] = icmp eq i8 %[[GUARD]], 0
@@ -75,3 +121,11 @@ void f() {
 // OGCG: call void @__cxa_guard_release
 // OGCG: call void @_Z3useP1A(ptr {{.*}}@_ZZ1fvE1a)
 // OGCG: ret void
+
+// OGCG: define linkonce_odr {{.*}}ptr @_Z10getInlineAv() {{.*}}comdat
+// OGCG:   %[[GUARD3:.*]] = load atomic i8, ptr @_ZGVZ10getInlineAvE1a acquire
+// OGCG:   %[[IS_UNINIT3:.*]] = icmp eq i8 %[[GUARD3]], 0
+// OGCG:   br i1 %[[IS_UNINIT3]]
+// OGCG: call i32 @__cxa_guard_acquire
+// OGCG: call void @_ZN1AC1Ev
+// OGCG: call void @__cxa_guard_release


### PR DESCRIPTION
Static locals inside inline functions get `linkonce_odr` linkage, and their guard variables need their own COMDAT groups so the linker can deduplicate them across TUs.  We were hitting an NYI error for this case in `LoweringPrepare`.

The fix is straightforward: set `guard.setComdat(true)`, which makes `LowerToLLVM` create a per-symbol COMDAT selector — the same thing classic codegen does at `ItaniumCXXABI.cpp:2798`.

I ran into this while trying to compile the Bullet physics engine through CIR.  Functions like `btMatrix3x3::getIdentity()` use this pattern (return a reference to a function-local static from an inline member function), and 6 of the 121 source files were failing because of it.  With this fix, all 121 compile cleanly.

Made with [Cursor](https://cursor.com)