### PR TITLE
[Github] Set persist-credentials in libclang-python-tests.yml

### DIFF
--- a/.github/workflows/libclang-python-tests.yml
+++ b/.github/workflows/libclang-python-tests.yml
@@ -33,6 +33,8 @@ jobs:
         python-version: ["3.8", "3.13"]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:


### PR DESCRIPTION
Not exactly sure how this slipped through the crack in the mass cleanup,
but fix it now.