### PR TITLE
[AMDGPU][WIP] Masked global prefetch

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
+++ b/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
@@ -3219,6 +3219,16 @@ def int_amdgcn_global_prefetch : ClangBuiltin<"__builtin_amdgcn_global_prefetch"
     "", [SDNPMemOperand]
   >;
 
+def int_amdgcn_global_prefetch_masked : ClangBuiltin<"__builtin_amdgcn_global_prefetch_masked">,
+  Intrinsic<[],
+  [LLVMQualPointerType<1>,    // Pointer
+   llvm_i32_ty,               // cachepolicy(imm), bits [0-2] = th, bits [3-4] = scope
+   llvm_i1_ty],               // predicate value
+    [IntrInaccessibleMemOrArgMemOnly, IntrWillReturn, NoCapture<ArgIndex<0>>,
+     IntrNoCallback, IntrNoFree, ImmArg<ArgIndex<1>>],
+    "", [SDNPMemOperand]
+  >;
+
 //===----------------------------------------------------------------------===//
 // Deep learning intrinsics.
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -1769,6 +1769,7 @@ void SITargetLowering::getTgtMemIntrinsic(SmallVectorImpl<IntrinsicInfo> &Infos,
   }
   case Intrinsic::amdgcn_s_prefetch_data:
   case Intrinsic::amdgcn_flat_prefetch:
+  case Intrinsic::amdgcn_global_prefetch_masked:
   case Intrinsic::amdgcn_global_prefetch: {
     Info.opc = ISD::INTRINSIC_VOID;
     Info.memVT = EVT::getIntegerVT(CI.getContext(), 8);
@@ -7825,6 +7826,50 @@ static SDValue lowerBALLOTIntrinsic(const SITargetLowering &TLI, SDNode *N,
       DAG.getConstant(0, SL, MVT::i32), DAG.getCondCode(ISD::SETNE));
 }
 
+static SDValue lowerGlobalPrefetchMaskedIntrinsic(const SITargetLowering &TLI,
+                                                  SDNode *N,
+                                                  SelectionDAG &DAG) {
+  SDLoc SL(N);
+  SDValue Ptr = N->getOperand(2);
+  SDValue Cpol = N->getOperand(3);
+  SDValue Pred = N->getOperand(4);
+
+  // generate a new EXEC mask based on the predicate value
+  SmallVector<SDValue, 8> Operands;
+  Operands.push_back(
+      DAG.getTargetConstant(Intrinsic::amdgcn_ballot, SL, MVT::i32));
+  Operands.push_back(Pred);
+  SDValue Mask = DAG.getNode(ISD::INTRINSIC_WO_CHAIN, SL, MVT::i32, Operands);
+
+  // save the original EXEC mask
+  const GCNSubtarget *ST = TLI.getSubtarget();
+  EVT ExecVT = ST->isWave32() ? MVT::i32 : MVT::i64;
+  Register Exec = ST->isWave32() ? AMDGPU::EXEC_LO : AMDGPU::EXEC;
+  SDValue OrigMask = DAG.getCopyFromReg(DAG.getEntryNode(), SL, Exec, ExecVT);
+  SDValue Chain = OrigMask.getValue(1);
+
+  // change the EXEC mask
+  SDValue ToExec = DAG.getCopyToReg(Chain, SL, Exec, Mask, SDValue());
+  Chain = ToExec.getValue(0);
+
+  // issue prefetch
+  Operands.clear();
+  Operands.push_back(Chain);
+  Operands.push_back(
+      DAG.getTargetConstant(Intrinsic::amdgcn_global_prefetch, SL, MVT::i32));
+  Operands.push_back(Ptr);
+  Operands.push_back(Cpol);
+
+  auto *M = cast<MemIntrinsicSDNode>(N);
+  SDValue Prefetch = DAG.getMemIntrinsicNode(
+      ISD::INTRINSIC_VOID, SL, DAG.getVTList(MVT::Other), Operands,
+      M->getMemoryVT(), M->getMemOperand());
+  Chain = Prefetch.getValue(0);
+
+  // restore the original mask
+  return DAG.getCopyToReg(Chain, SL, Exec, OrigMask.getValue(0), SDValue());
+}
+
 static SDValue lowerLaneOp(const SITargetLowering &TLI, SDNode *N,
                            SelectionDAG &DAG) {
   EVT VT = N->getValueType(0);
@@ -12424,6 +12469,9 @@ SDValue SITargetLowering::LowerINTRINSIC_VOID(SDValue Op,
     SDValue Val = Op->getOperand(3);
     return DAG.getAtomic(ISD::ATOMIC_STORE, DL, MII->getMemoryVT(), Chain, Val,
                          Ptr, MII->getMemOperand());
+  }
+  case Intrinsic::amdgcn_global_prefetch_masked: {
+    return lowerGlobalPrefetchMaskedIntrinsic(*this, Op.getNode(), DAG);
   }
   default: {
     if (const AMDGPU::ImageDimIntrinsicInfo *ImageDimIntr =


### PR DESCRIPTION
Some VMEM instructions are affected by EXEC mask. The AMDGCN backend doesn't expose any mechanisms to manipulate the EXEC mask and it is understandable. The users should rely on the standard branching mechanism and hope that the backend can fold it (rewrite branching with EXEC mask manipulation).

```llvm
; RUN: llc -mtriple=amdgcn -mcpu=gfx1250
define void @prefetch(ptr addrspace(1) %addr, i32 %pred) {
entry:
  %tid = call i32 @llvm.amdgcn.workitem.id.x()
  %cmp = icmp sle i32 %tid, %pred
  br i1 %cmp, label %body, label %exit
body:
  call void @llvm.amdgcn.global.prefetch(ptr addrspace(1) %addr, i32 9)
  br label %exit 
exit:
  ret void
}
```

The above code snippet results in branching:
```bash
prefetch:                            ; @buffer_load
; %bb.0:                                ; %entry
        s_wait_loadcnt_dscnt 0x0
        s_wait_kmcnt 0x0
        v_and_b32_e32 v3, 0x3ff, v31
        s_mov_b32 s0, exec_lo
        s_delay_alu instid0(VALU_DEP_1)
        v_cmpx_le_i32_e64 v3, v2
        s_cbranch_execz .LBB0_2
; %bb.1:                                ; %body
        global_prefetch_b8 v[0:1], off th:TH_LOAD_NT scope:SCOPE_SE
.LBB0_2:                                ; %exit
        s_or_b32 exec_lo, exec_lo, s0
        s_set_pc_i64 s[30:31]
```

People want to use global prefetch in the main loop (hot spot) but this results in braking a huge BB into smaller one. Because many passes in the backend are local we may miss opportunities for better instruction scheduling or RA, etc. etc.

My PR demonstrates how the LLVM intrinsic can be extended by adding a predicate argument to the corresponding intrinsic (at this moment it is just a demo). Now, the users (e.g., Triton) can generate the following code

```llvm
; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 %s

declare void @llvm.amdgcn.global.prefetch(ptr addrspace(1) %ptr, i32 %col)

define void @prefetch(ptr addrspace(1) %addr, i32 %lb) {
  %tid = call i32 @llvm.amdgcn.workitem.id.x()
  %pred = icmp sle i32 %tid, %lb
  call void @llvm.amdgcn.global.prefetch.masked(ptr addrspace(1) %addr, i32 9, i1 %pred)
  ret void 
}
```

which is going to be translated to    

```bash
prefetch:                            ; @buffer_load
; %bb.0:
        s_wait_loadcnt_dscnt 0x0
        s_wait_kmcnt 0x0
        v_and_b32_e32 v3, 0x3ff, v31
        s_mov_b32 s0, exec_lo
        s_delay_alu instid0(VALU_DEP_1)
        v_cmp_le_i32_e32 vcc_lo, v3, v2
        s_mov_b32 exec_lo, vcc_lo
        global_prefetch_b8 v[0:1], off th:TH_LOAD_NT scope:SCOPE_SE
        s_mov_b32 exec_lo, s0
        s_set_pc_i64 s[30:31]
```

I know that it is not a perfect solution because it is not generic. It is just a demo at this moment to start a discussion.


## What I don't like

- I don't like to introduce a new intrinsic. It would be better to add an additional parameter to the existing `int_amdgcn_global_prefetch` with some default value (i'm not sure whether it is possible. I need to think)
- would be nice to have a utility function which sets/unsets EXEC mask that may be useful for a future work.