### PR TITLE
[NFC] Optimize `SetImpliedBits`

### DIFF
--- a/llvm/lib/MC/MCSubtargetInfo.cpp
+++ b/llvm/lib/MC/MCSubtargetInfo.cpp
@@ -34,9 +34,8 @@ static const T *Find(StringRef S, ArrayRef<T> A) {
 }
 
 /// For each feature that is (transitively) implied by this feature, set it.
-static 
-void SetImpliedBits(FeatureBitset &Bits, FeatureBitset Implies,
-                    ArrayRef<SubtargetFeatureKV> FeatureTable) {
+static void SetImpliedBits(FeatureBitset &Bits, FeatureBitset Implies,
+                           ArrayRef<SubtargetFeatureKV> FeatureTable) {
   // Transitively set all features implied. We don't assume that the features in
   // Bits have already had their implied features set.
   FeatureBitset NewBits = Implies;

--- a/llvm/lib/MC/MCSubtargetInfo.cpp
+++ b/llvm/lib/MC/MCSubtargetInfo.cpp
@@ -34,23 +34,24 @@ static const T *Find(StringRef S, ArrayRef<T> A) {
 }
 
 /// For each feature that is (transitively) implied by this feature, set it.
-static
-void SetImpliedBits(FeatureBitset &Bits, const FeatureBitset &Implies,
+static 
+void SetImpliedBits(FeatureBitset &Bits, FeatureBitset Implies,
                     ArrayRef<SubtargetFeatureKV> FeatureTable) {
   // Transitively set all features implied. We don't assume that the features in
   // Bits have already had their implied features set.
   FeatureBitset NewBits = Implies;
-  while (NewBits.any()) {
+  while (Implies.any()) {
     FeatureBitset Implied;
     for (const SubtargetFeatureKV &FE : FeatureTable) {
-      if (NewBits.test(FE.Value))
+      if (Implies.test(FE.Value))
         Implied |= FE.Implies.getAsBitset();
     }
 
     // Only continue for bits that haven't been set yet.
-    NewBits = Implied & ~Bits;
-    Bits |= NewBits;
+    Implies = Implied & ~NewBits;
+    NewBits |= Implies;
   }
+  Bits |= NewBits;
 }
 
 /// For each feature that (transitively) implies this feature, clear it.

--- a/llvm/lib/MC/MCSubtargetInfo.cpp
+++ b/llvm/lib/MC/MCSubtargetInfo.cpp
@@ -37,12 +37,20 @@ static const T *Find(StringRef S, ArrayRef<T> A) {
 static
 void SetImpliedBits(FeatureBitset &Bits, const FeatureBitset &Implies,
                     ArrayRef<SubtargetFeatureKV> FeatureTable) {
-  // OR the Implies bits in outside the loop. This allows the Implies for CPUs
-  // which might imply features not in FeatureTable to use this.
-  Bits |= Implies;
-  for (const SubtargetFeatureKV &FE : FeatureTable)
-    if (Implies.test(FE.Value))
-      SetImpliedBits(Bits, FE.Implies.getAsBitset(), FeatureTable);
+  // Transitively set all features implied. We don't assume that the features in
+  // Bits have already had their implied features set.
+  FeatureBitset NewBits = Implies;
+  while (NewBits.any()) {
+    FeatureBitset Implied;
+    for (const SubtargetFeatureKV &FE : FeatureTable) {
+      if (NewBits.test(FE.Value))
+        Implied |= FE.Implies.getAsBitset();
+    }
+
+    // Only continue for bits that haven't been set yet.
+    NewBits = Implied & ~Bits;
+    Bits |= NewBits;
+  }
 }
 
 /// For each feature that (transitively) implies this feature, clear it.


### PR DESCRIPTION
This function sometimes shows up on my profiles of slow compiles as using up to ~3% of CPU cycles. This change reduces this to ~0%. So, it's not a huge improvement, but it's not nothing.

Currently, this function recursively sets all implied bits for every feature, which does a lot of redundant work. Many features are implied by multiple different other features.

This changes the algorithm to only process newly implied bits.

I suspect that a better fix would be to avoid so many calls to `SetImpliedBits` in the first place, but this is a deeper change that is probably best made by someone who understands the structure of the surrounding code.

Fixes #155808