### PR TITLE
[LegalizeTypes][RISCV] Don't widen expandload or compresstore with VP_LOAD/VP_STORE.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -6798,7 +6798,7 @@ SDValue DAGTypeLegalizer::WidenVecRes_MLOAD(MaskedLoadSDNode *N) {
       EVT::getVectorVT(*DAG.getContext(), MaskVT.getVectorElementType(),
                        WidenVT.getVectorElementCount());
 
-  if (ExtType == ISD::NON_EXTLOAD &&
+  if (ExtType == ISD::NON_EXTLOAD && !N->isExpandingLoad() &&
       TLI.isOperationLegalOrCustom(ISD::VP_LOAD, WidenVT) &&
       TLI.isTypeLegal(WideMaskVT) &&
       // If there is a passthru, we shouldn't use vp.load. However,
@@ -8107,7 +8107,7 @@ SDValue DAGTypeLegalizer::WidenVecOp_MSTORE(SDNode *N, unsigned OpNo) {
   }
 
   if (TLI.isOperationLegalOrCustom(ISD::VP_STORE, WideVT) &&
-      TLI.isTypeLegal(WideMaskVT)) {
+      TLI.isTypeLegal(WideMaskVT) && !MST->isCompressingStore()) {
     Mask = DAG.getInsertSubvector(dl, DAG.getPOISON(WideMaskVT), Mask, 0);
     SDValue EVL = DAG.getElementCount(dl, TLI.getVPExplicitVectorLengthTy(),
                                       VT.getVectorElementCount());

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-compressstore-int.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-compressstore-int.ll
@@ -54,6 +54,16 @@ define void @compressstore_v8i8(ptr %base, <8 x i8> %v, <8 x i1> %mask) {
   ret void
 }
 
+define void @compressstore_v7i8(ptr %base, <7 x i8> %v, <7 x i1> %mask) {
+; CHECK-LABEL: compressstore_v7i8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetivli zero, 7, e8, mf2, ta, ma
+; CHECK-NEXT:    vse8.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+  call void @llvm.masked.compressstore.v7i8(<7 x i8> %v, ptr %base, <7 x i1> %mask)
+  ret void
+}
+
 define void @compressstore_v1i16(ptr %base, <1 x i16> %v, <1 x i1> %mask) {
 ; CHECK-LABEL: compressstore_v1i16:
 ; CHECK:       # %bb.0:

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-compressstore-int.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-compressstore-int.ll
@@ -57,8 +57,14 @@ define void @compressstore_v8i8(ptr %base, <8 x i8> %v, <8 x i1> %mask) {
 define void @compressstore_v7i8(ptr %base, <7 x i8> %v, <7 x i1> %mask) {
 ; CHECK-LABEL: compressstore_v7i8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 7, e8, mf2, ta, ma
-; CHECK-NEXT:    vse8.v v8, (a0), v0.t
+; CHECK-NEXT:    li a1, 127
+; CHECK-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
+; CHECK-NEXT:    vmv.s.x v9, a1
+; CHECK-NEXT:    vmand.mm v9, v0, v9
+; CHECK-NEXT:    vcompress.vm v10, v8, v9
+; CHECK-NEXT:    vcpop.m a1, v9
+; CHECK-NEXT:    vsetvli zero, a1, e8, mf2, ta, ma
+; CHECK-NEXT:    vse8.v v10, (a0)
 ; CHECK-NEXT:    ret
   call void @llvm.masked.compressstore.v7i8(<7 x i8> %v, ptr %base, <7 x i1> %mask)
   ret void

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-expandload-int.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-expandload-int.ll
@@ -64,6 +64,16 @@ define <8 x i8> @expandload_v8i8(ptr %base, <8 x i8> %src0, <8 x i1> %mask) {
   ret <8 x i8>%res
 }
 
+define <7 x i8> @expandload_v7i8(ptr %base, <7 x i1> %mask) {
+; CHECK-LABEL: expandload_v7i8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetivli zero, 7, e8, mf2, ta, ma
+; CHECK-NEXT:    vle8.v v8, (a0), v0.t
+; CHECK-NEXT:    ret
+  %res = call <7 x i8> @llvm.masked.expandload.v7i8(ptr %base, <7 x i1> %mask, <7 x i8> poison)
+  ret <7 x i8>%res
+}
+
 define <1 x i16> @expandload_v1i16(ptr %base, <1 x i16> %src0, <1 x i1> %mask) {
 ; CHECK-LABEL: expandload_v1i16:
 ; CHECK:       # %bb.0:

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-expandload-int.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-expandload-int.ll
@@ -67,8 +67,16 @@ define <8 x i8> @expandload_v8i8(ptr %base, <8 x i8> %src0, <8 x i1> %mask) {
 define <7 x i8> @expandload_v7i8(ptr %base, <7 x i1> %mask) {
 ; CHECK-LABEL: expandload_v7i8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 7, e8, mf2, ta, ma
-; CHECK-NEXT:    vle8.v v8, (a0), v0.t
+; CHECK-NEXT:    li a1, 127
+; CHECK-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
+; CHECK-NEXT:    vmv.s.x v8, a1
+; CHECK-NEXT:    vmand.mm v0, v0, v8
+; CHECK-NEXT:    vcpop.m a1, v0
+; CHECK-NEXT:    vsetvli zero, a1, e8, mf2, ta, ma
+; CHECK-NEXT:    vle8.v v9, (a0)
+; CHECK-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
+; CHECK-NEXT:    viota.m v10, v0
+; CHECK-NEXT:    vrgather.vv v8, v9, v10, v0.t
 ; CHECK-NEXT:    ret
   %res = call <7 x i8> @llvm.masked.expandload.v7i8(ptr %base, <7 x i1> %mask, <7 x i8> poison)
   ret <7 x i8>%res


### PR DESCRIPTION
We don't support expanding/compressing VP_LOAD/VP_STORE yet.

This probably crashes on scalable vectors, but that's better than
silent miscompile.

Fixes #193277.