### PR TITLE
[cross-project-tests] Add llvm-modextract as a dependency

### DIFF
--- a/cross-project-tests/CMakeLists.txt
+++ b/cross-project-tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CROSS_PROJECT_TEST_DEPS
   llvm-config
   llvm-dis
   llvm-dwarfdump
+  llvm-modextract
   llvm-objdump
   not
   obj2yaml


### PR DESCRIPTION
cross-project-tests/dtlto/multimodule.test uses it

Some precommit tests are failing because of this missing dependency, e.g. https://github.com/llvm/llvm-project/actions/runs/24729694507