### PR TITLE
[flang][acc] Update fir.convert rematerialization handling

### DIFF
--- a/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.h
+++ b/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.h
@@ -14,6 +14,7 @@
 #define FLANG_OPTIMIZER_OPENACC_FIROPENACC_OPS_INTERFACES_H_
 
 #include "flang/Optimizer/Dialect/FIROperationMoveOpInterface.h"
+#include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FortranVariableInterface.h"
 #include "mlir/Dialect/OpenACC/OpenACC.h"
 
@@ -87,7 +88,18 @@ struct IndirectGlobalAccessModel
 template <typename Op>
 struct OutlineRematerializationModel
     : public mlir::acc::OutlineRematerializationOpInterface::ExternalModel<
-          OutlineRematerializationModel<Op>, Op> {};
+          OutlineRematerializationModel<Op>, Op> {
+  bool isRematerializationCandidate(mlir::Operation *op) const {
+    return true;
+  }
+};
+
+template <>
+struct OutlineRematerializationModel<fir::ConvertOp>
+    : public mlir::acc::OutlineRematerializationOpInterface::ExternalModel<
+          OutlineRematerializationModel<fir::ConvertOp>, fir::ConvertOp> {
+  bool isRematerializationCandidate(mlir::Operation *op) const;
+};
 
 /// External model for OffloadRegionOpInterface.
 /// This interface marks operations whose regions are targets for offloading

--- a/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.h
+++ b/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.h
@@ -89,9 +89,7 @@ template <typename Op>
 struct OutlineRematerializationModel
     : public mlir::acc::OutlineRematerializationOpInterface::ExternalModel<
           OutlineRematerializationModel<Op>, Op> {
-  bool isRematerializationCandidate(mlir::Operation *op) const {
-    return true;
-  }
+  bool isRematerializationCandidate(mlir::Operation *op) const { return true; }
 };
 
 template <>

--- a/flang/lib/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.cpp
@@ -122,6 +122,17 @@ bool GlobalVariableModel::isDeviceData(mlir::Operation *op) const {
   return false;
 }
 
+bool OutlineRematerializationModel<
+    fir::ConvertOp>::isRematerializationCandidate(mlir::Operation *op) const {
+  auto convertOp = mlir::cast<fir::ConvertOp>(op);
+  mlir::Type inTy = convertOp.getValue().getType();
+  mlir::Type outTy = convertOp.getType();
+  // Only pointer-to-integer-like converts are rematerialization candidates so
+  // that addresses stay live-in instead of the scalar values.
+  return fir::ConvertOp::isPointerCompatible(inTy) &&
+         fir::ConvertOp::isIntegerCompatible(outTy);
+}
+
 // Helper to recursively process address-of operations in derived type
 // descriptors and collect all needed fir.globals.
 static void processAddrOfOpInDerivedTypeDescriptor(

--- a/flang/test/Fir/OpenACC/offload-livein-value-canonicalization.fir
+++ b/flang/test/Fir/OpenACC/offload-livein-value-canonicalization.fir
@@ -343,6 +343,50 @@ func.func @test_convert_alloca_remat() {
 
 // -----
 
+// Integer-to-integer fir.convert is not an outline rematerialization candidate.
+func.func private @use_i64(i64) -> ()
+
+func.func @test_convert_integer_widen_no_remat(%arg0: !fir.ref<i32>) {
+  %0 = fir.load %arg0 : !fir.ref<i32>
+  %1 = fir.convert %0 : (i32) -> i64
+  fir.call @use_i64(%1) : (i64) -> ()
+  acc.parallel {
+    fir.call @use_i64(%1) : (i64) -> ()
+    acc.yield
+  }
+  return
+}
+
+// CHECK-LABEL: @test_convert_integer_widen_no_remat
+// CHECK: fir.load
+// CHECK: %[[CVT:.*]] = fir.convert
+// CHECK: fir.call @use_i64(%[[CVT]])
+// CHECK: acc.parallel {
+// CHECK-NEXT: fir.call @use_i64(%[[CVT]])
+
+// -----
+
+// Pointer-to-pointer fir.convert is not a rematerialization candidate.
+func.func private @use_ref_f32(!fir.ref<f32>) -> ()
+
+func.func @test_convert_ptr_to_ptr_no_remat(%arg0: !fir.ref<i32>) {
+  %0 = fir.convert %arg0 : (!fir.ref<i32>) -> !fir.ref<f32>
+  fir.call @use_ref_f32(%0) : (!fir.ref<f32>) -> ()
+  acc.parallel {
+    fir.call @use_ref_f32(%0) : (!fir.ref<f32>) -> ()
+    acc.yield
+  }
+  return
+}
+
+// CHECK-LABEL: @test_convert_ptr_to_ptr_no_remat
+// CHECK: %[[CVT:.*]] = fir.convert %arg0
+// CHECK: fir.call @use_ref_f32(%[[CVT]])
+// CHECK: acc.parallel {
+// CHECK-NEXT: fir.call @use_ref_f32(%[[CVT]])
+
+// -----
+
 // Test that an intermediate fir.convert in a trace chain
 // (declare -> convert -> unboxchar) does not get rematerialized,
 // while a direct ptr-to-int fir.convert is correctly sunk.

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCOpsInterfaces.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCOpsInterfaces.td
@@ -117,6 +117,21 @@ def OutlineRematerializationOpInterface : OpInterface<"OutlineRematerializationO
     Operations implementing this interface are expected to be memory effect
     free. Their results are typically used for type construction or providing
     metadata (such as shape information for arrays).
+
+    `isRematerializationCandidate` refines whether a particular operation
+    instance participates in rematerialization; `isa<OutlineRematerializationOpInterface>`
+    requires both a registered model and this predicate.
+  }];
+
+  let methods = [
+    InterfaceMethod<"Returns whether this operation instance should be treated "
+                      "as an outline rematerialization candidate.",
+                      "bool", "isRematerializationCandidate", (ins),
+                      /*methodBody=*/"return true;">,
+  ];
+
+  let extraClassOf = [{
+    return $_op.isRematerializationCandidate();
   }];
 
   let verify = [{

--- a/mlir/lib/Dialect/OpenACC/Transforms/OffloadLiveInValueCanonicalization.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/OffloadLiveInValueCanonicalization.cpp
@@ -186,9 +186,8 @@ static bool isRematerializationCandidate(Value val,
   // getOriginalValue. If the traced op is not a candidate, check the direct
   // defining op of the live-in value.
   if (origVal != val) {
-    definingOp = val.getDefiningOp();
-    if (definingOp &&
-        isa<acc::OutlineRematerializationOpInterface>(definingOp)) {
+    if (isa_and_nonnull<acc::OutlineRematerializationOpInterface>(
+            val.getDefiningOp())) {
       LLVM_DEBUG(llvm::dbgs()
                  << "\t\t-> OutlineRematerializationOpInterface (direct)\n");
       return true;


### PR DESCRIPTION
As of https://github.com/llvm/llvm-project/pull/184218 fir.convert was being treated as a rematerialization candidate always. However, the primary problem intended to be solved were improper classification of pointers due to being casted to integers. Thus use optionally implemented interface instead to only handle this scenario.