### PR TITLE
[Attributor] Use trivial no side effects check in isAssumedSideEffectFree

### DIFF
--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -4147,6 +4147,9 @@ struct AAIsDeadValueImpl : public AAIsDead {
     if (!I || wouldInstructionBeTriviallyDead(I))
       return true;
 
+    if (!I->isTerminator() && !I->mayHaveSideEffects())
+      return true;
+
     auto *CB = dyn_cast<CallBase>(I);
     if (!CB || isa<IntrinsicInst>(CB))
       return false;


### PR DESCRIPTION
This PR should not change any tests, which is the goal here. To use `mayHaveSideEffects` is a shortcut to avoid expensive checks by pulling in different kind of dependences.

That said, this PR doesn't really need a test.