### PR TITLE
[lldb/DWARF] Support 5-component Swift version in DW_AT_producer

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
@@ -858,8 +858,8 @@ void DWARFUnit::ParseProducerInfo() {
   if (producer.empty())
     return;
 
-  static const RegularExpression g_swiftlang_version_regex(
-      llvm::StringRef(R"(swiftlang-([0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?))"));
+  static const RegularExpression g_swiftlang_version_regex(llvm::StringRef(
+      R"(swiftlang-([0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(\.[0-9]+)?))"));
   static const RegularExpression g_clang_version_regex(
       llvm::StringRef(R"(clang-([0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?))"));
 

--- a/lldb/unittests/SymbolFile/DWARF/DWARFUnitTest.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/DWARFUnitTest.cpp
@@ -157,3 +157,39 @@ DWARF:
   EXPECT_EQ(unit->GetProducer(), eProducerSwift);
   EXPECT_EQ(unit->GetProducerVersion(), llvm::VersionTuple(1300, 0, 31, 1));
 }
+
+TEST(DWARFUnitTest, Swift5ComponentProducer) {
+  const char *yamldata = R"(
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_386
+DWARF:
+  debug_str:
+    - 'Apple Swift version 6.2 (swiftlang-1.2.3.4.5 clang-1300.0.29.1)'
+  debug_abbrev:
+    - Table:
+        - Code:            0x00000001
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_producer
+              Form:            DW_FORM_strp
+  debug_info:
+    - Version:         4
+      AddrSize:        8
+      Entries:
+        - AbbrCode:        0x1
+          Values:
+            - Value:           0x0
+        - AbbrCode:        0x0
+)";
+
+  YAMLModuleTester t(yamldata);
+  DWARFUnit *unit = t.GetDwarfUnit();
+  ASSERT_TRUE((bool)unit);
+  EXPECT_EQ(unit->GetProducer(), eProducerSwift);
+  EXPECT_EQ(unit->GetProducerVersion(), llvm::VersionTuple(1, 2, 3, 4, 5));
+}


### PR DESCRIPTION
The regex used to extract the swiftlang version from the `DW_AT_producer` DWARF attribute only supports up to 4 version components. Since `llvm::VersionTuple` now supports 5-component versions (to accommodate Swift's variant suffix), the regex needs to be updated to capture the optional 5th component as well.

Without this fix, a binary compiled with `swiftlang-X.Y.Z.A.B` will have its producer version parsed as `X.Y.Z.A`, which won't match LLDB's integrated Swift compiler version `X.Y.Z.A.B`, resulting in a spurious toolchain mismatch warning.

Assisted-by Claude.

rdar://175276251