### PR TITLE
[flang] Update LIT test for big-endian platform (NFC)

### DIFF
--- a/flang/test/Lower/constant-logical-transfer.f90
+++ b/flang/test/Lower/constant-logical-transfer.f90
@@ -5,7 +5,7 @@ subroutine test_transfer_constant(l4, l8)
   logical(4) :: l4
   logical(8) :: l8
   l4 = transfer(3, .true._4)
-  l8 = transfer(7, .true._8)
+  l8 = transfer(7_8, .true._8)
 end subroutine
 
 module constant_logical


### PR DESCRIPTION
This is an endian-ness issue. On AIX, since the first argument of the second transfer intrinsic is a default integer (32-bit) constant (`7`). It will fill the higher 32-bit of the 64-bit value (`0x0000000700000000`) in the transfer, the value is `30064771072` instead of `7`. I think the original intent is `7_8` instead. Alternatively, if `7` (not `7_8`) is preferred, a target verification is required.

Ref: https://github.com/llvm/llvm-project/pull/192417