### PR TITLE
[Github] Bump Github Runner Version to 2.334.0

### DIFF
--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -92,7 +92,7 @@ RUN powershell -Command \
     New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" \
     -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 
-ARG RUNNER_VERSION=2.332.0
+ARG RUNNER_VERSION=2.334.0
 ENV RUNNER_VERSION=$RUNNER_VERSION
 
 RUN powershell -Command \

--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -100,7 +100,7 @@ WORKDIR /home/gha
 
 FROM ci-container AS ci-container-agent
 
-ENV GITHUB_RUNNER_VERSION=2.332.0
+ENV GITHUB_RUNNER_VERSION=2.334.0
 
 RUN mkdir actions-runner && \
     cd actions-runner && \


### PR DESCRIPTION
Release notes imply this probably shouldn't impact us. Update the runner
version in the containers so that we do not run past the support
horizon.