### PR TITLE
[MLIR][XeVM] Update API usage. Some OpenCL APIs are not supported.

### DIFF
--- a/mlir/lib/Conversion/XeVMToLLVM/XeVMToLLVM.cpp
+++ b/mlir/lib/Conversion/XeVMToLLVM/XeVMToLLVM.cpp
@@ -99,6 +99,23 @@ std::string mangle(StringRef baseName, ArrayRef<Type> types,
   return os.str();
 }
 
+std::string builtinElemType(ElemType elemType) {
+  switch (elemType) {
+  case ElemType::BF8:
+    return "bf8";
+  case ElemType::F8:
+    return "hf8";
+  case ElemType::BF16:
+    return "bf";
+  case ElemType::F16:
+    return "hf";
+  case ElemType::F32:
+    return "f";
+  default:
+    return stringifyElemType(elemType).str();
+  }
+}
+
 static int32_t getL1CacheControl(LoadCacheControl cc) {
   int32_t control = 0;
   switch (cc) {
@@ -1220,21 +1237,18 @@ class MMAMxToOCLPattern : public OpConversionPattern<MMAMxOp> {
     if (cOrigTy != cTy)
       c = LLVM::BitcastOp::create(rewriter, loc, cTy, c);
 
-    constexpr int32_t systolicDepth{8};
     std::string fnName =
-        llvm::formatv("intel_sub_group_{0}_{1}_scaled_matrix_mad_k{2}_{3}",
-                      stringifyElemType(op.getTypes().getA()).str(),
-                      stringifyElemType(op.getTypes().getB()).str(),
-                      systolicDepth *
-                          getNumOperandsPerDword(op.getTypes().getA()),
-                      stringifyElemType(op.getTypes().getC()).str())
+        llvm::formatv("__builtin_IB_sub_group16_bdpas_{0}_{1}_{2}_{3}_8_8",
+                      builtinElemType(op.getTypes().getD()),
+                      builtinElemType(op.getTypes().getC()),
+                      builtinElemType(op.getTypes().getA()),
+                      builtinElemType(op.getTypes().getB()))
             .str();
     auto scaleA = op.getScaleA();
     auto scaleB = op.getScaleB();
-    SmallVector<Type> argTypes{a.getType(), b.getType(), cTy, scaleA.getType(),
+    SmallVector<Type> argTypes{cTy, a.getType(), b.getType(), scaleA.getType(),
                                scaleB.getType()};
-    fnName = mangle(fnName, argTypes);
-    SmallVector<Value> args{a, b, c, scaleA, scaleB};
+    SmallVector<Value> args{c, a, b, scaleA, scaleB};
 
     auto memAttr = rewriter.getAttr<LLVM::MemoryEffectsAttr>(
         /*other=*/LLVM::ModRefInfo::NoModRef,

--- a/mlir/test/Conversion/XeVMToLLVM/xevm_mx-to-llvm.mlir
+++ b/mlir/test/Conversion/XeVMToLLVM/xevm_mx-to-llvm.mlir
@@ -3,21 +3,21 @@
 // CHECK-LABEL: llvm.func @truncf_f16_to_bf8
 // CHECK-SAME: %[[ARG0:.*]]: vector<16xf16>
 llvm.func @truncf_f16_to_bf8(%src: vector<16xf16>) -> vector<16xi8> {
-  // CHECK:  %[[VAR0:.*]] = llvm.shufflevector %[[ARG0]], %[[ARG0]] [0, 1, 2, 3, 4, 5, 6, 7] : vector<16xf16> 
-  // CHECK:  %[[VAR1:.*]] = llvm.shufflevector %[[ARG0]], %[[ARG0]] [8, 9, 10, 11, 12, 13, 14, 15] : vector<16xf16> 
+  // CHECK:  %[[VAR0:.*]] = llvm.shufflevector %[[ARG0]], %[[ARG0]] [0, 1, 2, 3, 4, 5, 6, 7] : vector<16xf16>
+  // CHECK:  %[[VAR1:.*]] = llvm.shufflevector %[[ARG0]], %[[ARG0]] [8, 9, 10, 11, 12, 13, 14, 15] : vector<16xf16>
   // CHECK:  %[[VAR2:.*]] = llvm.bitcast %[[VAR0]] : vector<8xf16> to vector<16xi8>
   // CHECK:  %[[VAR3:.*]] = llvm.bitcast %[[VAR1]] : vector<8xf16> to vector<16xi8>
-  // CHECK:  %[[VAR4:.*]] = llvm.shufflevector %[[VAR2]], %[[VAR2]] [1, 3, 5, 7, 9, 11, 13, 15] : vector<16xi8> 
-  // CHECK:  %[[VAR5:.*]] = llvm.shufflevector %[[VAR3]], %[[VAR3]] [1, 3, 5, 7, 9, 11, 13, 15] : vector<16xi8> 
-  // CHECK:  %[[VAR6:.*]] = llvm.shufflevector %4, %5 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : vector<8xi8> 
+  // CHECK:  %[[VAR4:.*]] = llvm.shufflevector %[[VAR2]], %[[VAR2]] [1, 3, 5, 7, 9, 11, 13, 15] : vector<16xi8>
+  // CHECK:  %[[VAR5:.*]] = llvm.shufflevector %[[VAR3]], %[[VAR3]] [1, 3, 5, 7, 9, 11, 13, 15] : vector<16xi8>
+  // CHECK:  %[[VAR6:.*]] = llvm.shufflevector %4, %5 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : vector<8xi8>
   %dst = xevm.truncf %src { src_etype = f16, dst_etype = bf8 } : (vector<16xf16>) -> vector<16xi8>
   llvm.return %dst : vector<16xi8>
 }
 
 // -----
 
-// CHECK-LABEL: llvm.func spir_funccc @_Z49intel_sub_group_bf8_bf8_scaled_matrix_mad_k32_f32Dv8_sDv8_iDv8_fcc
-// CHECK-SAME: (vector<8xi16>, vector<8xi32>, vector<8xf32>, i8, i8) -> vector<8xf32>
+// CHECK-LABEL: llvm.func spir_funccc @__builtin_IB_sub_group16_bdpas_f_f_bf8_bf8_8_8
+// CHECK-SAME: (vector<8xf32>, vector<8xi16>, vector<8xi32>, i8, i8) -> vector<8xf32>
 // CHECK-SAME:   attributes {convergent, memory_effects = #llvm.memory_effects<other = none,
 // CHECK-SAME:   argMem = none, inaccessibleMem = none, errnoMem = none,
 // CHECK-SAME:   targetMem0 = none, targetMem1 = none>, no_unwind, will_return}
@@ -25,15 +25,15 @@ llvm.func @truncf_f16_to_bf8(%src: vector<16xf16>) -> vector<16xi8> {
 // CHECK-SAME: %[[ARG0:.*]]: vector<8xi16>, %[[ARG1:.*]]: vector<8xi32>
 // CHECK-SAME: %[[ARG2:.*]]: i8, %[[ARG3:.*]]: i8, %[[ARG4:.*]]: vector<8xf32>
 llvm.func @mma_mx_bf8_bf8_k32_f32(%a: vector<8xi16>, %b: vector<8xi32>, %scale_a: i8, %scale_b: i8, %c: vector<8xf32>) -> vector<8xf32> {
-  // CHECK:  %[[VAR0:.*]] = llvm.call spir_funccc @_Z49intel_sub_group_bf8_bf8_scaled_matrix_mad_k32_f32Dv8_sDv8_iDv8_fcc
-  // CHECK-SAME: (%[[ARG0]], %[[ARG1]], %[[ARG4]], %[[ARG2]], %[[ARG3]])
-  // CHECK-SAME: {convergent, function_type = !llvm.func<vector<8xf32> (vector<8xi16>, vector<8xi32>, vector<8xf32>, i8, i8)>,
+  // CHECK: %[[VAR0:.*]] = llvm.call spir_funccc @__builtin_IB_sub_group16_bdpas_f_f_bf8_bf8_8_8
+  // CHECK-SAME: (%[[ARG4]], %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]])
+  // CHECK-SAME: {convergent, function_type = !llvm.func<vector<8xf32> (vector<8xf32>, vector<8xi16>, vector<8xi32>, i8, i8)>,
   // CHECK-SAME: linkage = #llvm.linkage<external>, memory_effects = #llvm.memory_effects<other = none,
   // CHECK-SAME:   argMem = none, inaccessibleMem = none, errnoMem = none,
   // CHECK-SAME:   targetMem0 = none, targetMem1 = none>,
-  // CHECK-SAME: no_unwind, sym_name = "_Z49intel_sub_group_bf8_bf8_scaled_matrix_mad_k32_f32Dv8_sDv8_iDv8_fcc",
+  // CHECK-SAME: no_unwind, sym_name = "__builtin_IB_sub_group16_bdpas_f_f_bf8_bf8_8_8",
   // CHECK-SAME: visibility_ = 0 : i64, will_return} :
-  // CHECK-SAME: (vector<8xi16>, vector<8xi32>, vector<8xf32>, i8, i8) -> vector<8xf32>
+  // CHECK-SAME: (vector<8xf32>, vector<8xi16>, vector<8xi32>, i8, i8) -> vector<8xf32>
   %result = xevm.mma_mx %a, %b, %scale_a, %scale_b, %c
           {shape=<m=8, n=16, k=32>, types=<d=f32, a=bf8, b=bf8, c=f32>}
           : (vector<8xi16>, vector<8xi32>, i8, i8, vector<8xf32>) -> vector<8xf32>

--- a/mlir/test/Integration/Dialect/XeVM/GPU/xevm_block_scaled_dpas_bf8.mlir
+++ b/mlir/test/Integration/Dialect/XeVM/GPU/xevm_block_scaled_dpas_bf8.mlir
@@ -22,9 +22,9 @@ module @gemm attributes {gpu.container_module} {
       // %load_a_K = arith.muli %K, %load_a_pack_ratio : i32
       // %load_b_K = arith.muli %K, %mx_pack_ratio : i32
 
-      %base_width_a = arith.constant 16 : i32
+      %base_width_a = arith.constant 64 : i32
       %base_height_a = arith.constant 8 : i32
-      %base_pitch_a = arith.constant 16 : i32
+      %base_pitch_a = arith.constant 64 : i32
       %x = arith.constant 0 : i32
       %y = arith.constant 0 : i32
       // A is loaded as fp16, but it will be truncated to bf8 before MMA.
@@ -64,9 +64,9 @@ module @gemm attributes {gpu.container_module} {
           : (vector<8xi16>, vector<8xi32>, i8, i8, vector<8xf32>) -> vector<8xf32>
       %c_result_casted = vector.bitcast %c_result : vector<8xf32> to vector<8xi32>
 
-      %base_width_c = arith.constant 16 : i32
+      %base_width_c = arith.constant 64 : i32
       %base_height_c = arith.constant 8 : i32
-      %base_pitch_c = arith.constant 16 : i32
+      %base_pitch_c = arith.constant 64 : i32
       xevm.blockstore2d %c, %base_width_c, %base_height_c, %base_pitch_c, %x, %y, %c_result_casted
           <{elem_size_in_bits=32 : i32, tile_width=16 : i32, tile_height=8 : i32}>
           : (!llvm.ptr<1>, i32, i32, i32, i32, i32, vector<8xi32>)
@@ -122,7 +122,7 @@ module @gemm attributes {gpu.container_module} {
 
     %A = memref.alloc() : memref<8x32xf16>
     scf.for %i = %c0 to %c8 step %c1 {
-      scf.for %j = %c0 to %c16 step %c1 {
+      scf.for %j = %c0 to %c32 step %c1 {
         memref.store %c1f16, %A[%i, %j] : memref<8x32xf16>
       }
     }
@@ -145,6 +145,8 @@ module @gemm attributes {gpu.container_module} {
     %C_cast = memref.cast %C_res : memref<8x16xf32> to memref<*xf32>
     call @printMemrefF32(%C_cast) : (memref<*xf32>) -> ()
 
+    // CHECK: Unranked Memref base@ = 0x{{[0-9a-f]+}}
+    // CHECK-COUNT-8: [32,   32,   32,   32,   32,   32,   32,   32,   32,   32,   32,   32,   32,   32,   32,   32]
     memref.dealloc %A : memref<8x32xf16>
     memref.dealloc %B : memref<32x16xf8E5M2>
     memref.dealloc %C : memref<8x16xf32>


### PR DESCRIPTION
In such case, use internal APIs for Intel Graphics Compiler directly.