### PR TITLE
[HLSL] Disallow `volatile` keyword

### DIFF
--- a/clang/include/clang/Basic/IdentifierTable.h
+++ b/clang/include/clang/Basic/IdentifierTable.h
@@ -78,10 +78,11 @@ enum TokenKey : unsigned {
   KEYHLSL = 0x8000000,
   KEYFIXEDPOINT = 0x10000000,
   KEYDEFERTS = 0x20000000,
-  KEYMAX = KEYDEFERTS, // The maximum key
+  KEYNOHLSL = 0x40000000,
+  KEYMAX = KEYNOHLSL, // The maximum key
   KEYALLCXX = KEYCXX | KEYCXX11 | KEYCXX20,
-  KEYALL = (KEYMAX | (KEYMAX - 1)) & ~KEYNOMS18 & ~KEYNOOPENCL &
-           ~KEYNOZOS // KEYNOMS18, KEYNOOPENCL, KEYNOZOS are excluded.
+  KEYALL = (KEYMAX | (KEYMAX - 1)) & ~KEYNOMS18 & ~KEYNOOPENCL & ~KEYNOZOS &
+           ~KEYNOHLSL // KEYNOMS18, KEYNOOPENCL, KEYNOZOS, KEYNOHLSL excluded.
 };
 
 /// How a keyword is treated in the selected standard. This enum is ordered

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -288,6 +288,7 @@ PUNCTUATOR(greatergreatergreater, ">>>")
 //   KEYOPENCLC   - This is a keyword in OpenCL C
 //   KEYOPENCLCXX - This is a keyword in C++ for OpenCL
 //   KEYNOOPENCL  - This is a keyword that is not supported in OpenCL
+//   KEYNOHLSL    - This is a keyword that is not supported in HLSL
 //   KEYALTIVEC - This is a keyword in AltiVec
 //   KEYZVECTOR - This is a keyword for the System z vector extensions,
 //                which are heavily based on AltiVec
@@ -335,7 +336,7 @@ KEYWORD(typedef                     , KEYALL)
 KEYWORD(union                       , KEYALL)
 KEYWORD(unsigned                    , KEYALL)
 KEYWORD(void                        , KEYALL)
-KEYWORD(volatile                    , KEYALL)
+KEYWORD(volatile                    , KEYALL|KEYNOHLSL)
 KEYWORD(while                       , KEYALL)
 KEYWORD(_Alignas                    , KEYALL)
 KEYWORD(_Alignof                    , KEYALL)

--- a/clang/lib/Basic/IdentifierTable.cpp
+++ b/clang/lib/Basic/IdentifierTable.cpp
@@ -160,6 +160,7 @@ static KeywordStatus getKeywordStatusHelper(const LangOptions &LangOpts,
   case KEYNOOPENCL:
   case KEYNOMS18:
   case KEYNOZOS:
+  case KEYNOHLSL:
     // The disable behavior for this is handled in getKeywordStatus.
     return KS_Unknown;
   case KEYFIXEDPOINT:
@@ -178,6 +179,8 @@ KeywordStatus clang::getKeywordStatus(const LangOptions &LangOpts,
   // These are tests that need to 'always win', as they are special in that they
   // disable based on certain conditions.
   if (LangOpts.OpenCL && (Flags & KEYNOOPENCL)) return KS_Disabled;
+  if (LangOpts.HLSL && (Flags & KEYNOHLSL))
+    return KS_Disabled;
   if (LangOpts.MSVCCompat && (Flags & KEYNOMS18) &&
       !LangOpts.isCompatibleWithMSVC(LangOptions::MSVC2015))
     return KS_Disabled;

--- a/clang/test/SemaHLSL/Language/Volatile.hlsl
+++ b/clang/test/SemaHLSL/Language/Volatile.hlsl
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -verify %s
+
+RWByteAddressBuffer gBuf : register(u0);
+
+[numthreads(1,1,1)]
+void main() {
+    // expected-error@+1 {{unknown type name 'volatile'}}
+    volatile RWByteAddressBuffer buf = gBuf; // expected-error {{expected ';' at end of declaration}}
+    buf.Store(0, 42); // expected-error {{use of undeclared identifier 'buf'}}
+}


### PR DESCRIPTION
This PR disallows the `volatile` keyword in HLSL.
The keyword is meaningless in this language, and it comes from the C++ foundation that HLSL stands on.
Fixes https://github.com/llvm/llvm-project/issues/192559
It is arguably in the category of this scenario: https://github.com/llvm/wg-hlsl/issues/300
Assisted by: Github Copilot