### PR TITLE
[CI] Fix cross-project-tests dependencies

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -316,7 +316,6 @@ def _get_modified_projects(modified_files: list[str]) -> Set[str]:
     modified_projects = set()
     for modified_file in modified_files:
         modified_projects.update(_get_modified_projects_for_file(modified_file))
-    return {"cross-project-tests"}
     return modified_projects
 
 

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -23,7 +23,7 @@ PROJECT_DEPENDENCIES = {
     "bolt": {"clang", "lld", "llvm"},
     "clang-tools-extra": {"clang", "llvm"},
     "compiler-rt": {"clang", "lld"},
-    "cross-project-tests": {"clang", "lldb"},
+    "cross-project-tests": {"clang", "lldb", "lld"},
     "libc": {"clang", "lld"},
     "openmp": {"clang", "lld"},
     "flang": {"llvm", "clang"},

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -23,6 +23,7 @@ PROJECT_DEPENDENCIES = {
     "bolt": {"clang", "lld", "llvm"},
     "clang-tools-extra": {"clang", "llvm"},
     "compiler-rt": {"clang", "lld"},
+    "cross-project-tests": {"clang", "lldb"},
     "libc": {"clang", "lld"},
     "openmp": {"clang", "lld"},
     "flang": {"llvm", "clang"},
@@ -315,6 +316,7 @@ def _get_modified_projects(modified_files: list[str]) -> Set[str]:
     modified_projects = set()
     for modified_file in modified_files:
         modified_projects.update(_get_modified_projects_for_file(modified_file))
+    return {"cross-project-tests"}
     return modified_projects
 
 

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -450,6 +450,18 @@ class TestComputeProjects(unittest.TestCase):
             "check-cxx check-cxxabi check-unwind",
         )
 
+    def test_cross_project_tests(self):
+        env_variables = compute_projects.get_env_variables(
+            ["cross-project-tests/CMakeLists.txt"], "Linux"
+        )
+        self.assertEqual(
+            env_variables["projects_to_build"], "clang;cross-project-tests;lldb;llvm"
+        )
+        self.assertEqual(env_variables["project_check_targets"], "check-cross-project")
+        self.assertEqual(env_variables["runtimes_to_build"], "")
+        self.assertEqual(env_variables["runtimes_check_targets"], "")
+        self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -455,7 +455,8 @@ class TestComputeProjects(unittest.TestCase):
             ["cross-project-tests/CMakeLists.txt"], "Linux"
         )
         self.assertEqual(
-            env_variables["projects_to_build"], "clang;cross-project-tests;lldb;llvm"
+            env_variables["projects_to_build"],
+            "clang;cross-project-tests;lld;lldb;llvm",
         )
         self.assertEqual(env_variables["project_check_targets"], "check-cross-project")
         self.assertEqual(env_variables["runtimes_to_build"], "")


### PR DESCRIPTION
We error out in CMake otherwise if we do not enable `clang`. Avoid adding other dependencies for now as they are optional and otherwise cause us to build them when using cross-project-tests to test other projects like lld.