### PR TITLE
[NFC][LLDB][Part 2] Support enabling/disabling InstrumentationRuntime plugins in an debug session

### DIFF
--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -590,7 +590,7 @@ public:
   UnregisterPlugin(InstrumentationRuntimeCreateInstance create_callback);
 
   static llvm::SmallVector<InstrumentationRuntimeCallbacks>
-  GetInstrumentationRuntimeCallbacks();
+  GetInstrumentationRuntimeCallbacks(bool enabled_only = true);
 
   // TypeSystem
   static bool RegisterPlugin(llvm::StringRef name, llvm::StringRef description,

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -571,13 +571,13 @@ public:
   // Note that this is a copy of the internal state so modifications
   // to the returned instances will not be reflected back to instances
   // stored by the PluginInstances object.
-  llvm::SmallVector<Instance> GetSnapshot() const {
+  llvm::SmallVector<Instance> GetSnapshot(bool enabled_only = true) const {
     std::lock_guard<std::mutex> guard(m_mutex);
 
     llvm::SmallVector<Instance> enabled_instances;
     enabled_instances.reserve(m_instances.size());
     for (const auto &instance : m_instances) {
-      if (instance.enabled)
+      if (!enabled_only || instance.enabled)
         enabled_instances.push_back(instance);
     }
     return enabled_instances;
@@ -590,17 +590,33 @@ public:
         [&](const Instance &instance) { return count++ == idx; });
   }
 
-  std::optional<Instance> GetInstanceForName(llvm::StringRef name) {
+  std::optional<Instance> GetInstanceForName(llvm::StringRef name,
+                                             bool enabled_only = true) {
     if (name.empty())
       return std::nullopt;
 
-    return FindEnabledInstance(
-        [&](const Instance &instance) { return instance.name == name; });
+    auto predicate = [&](const Instance &instance) {
+      return instance.name == name;
+    };
+    if (enabled_only)
+      return FindEnabledInstance(predicate);
+
+    return FindInstance(predicate);
   }
 
   std::optional<Instance>
   FindEnabledInstance(std::function<bool(const Instance &)> predicate) const {
     for (const auto &instance : GetSnapshot()) {
+      if (predicate(instance))
+        return instance;
+    }
+    return std::nullopt;
+  }
+
+  std::optional<Instance>
+  FindInstance(std::function<bool(const Instance &)> predicate) const {
+    std::lock_guard<std::mutex> guard(m_mutex);
+    for (const auto &instance : m_instances) {
       if (predicate(instance))
         return instance;
     }
@@ -1859,8 +1875,16 @@ struct InstrumentationRuntimeInstance
   InstrumentationRuntimeGetType get_type_callback = nullptr;
 };
 
-typedef PluginInstances<InstrumentationRuntimeInstance>
-    InstrumentationRuntimeInstances;
+struct InstrumentationRuntimeInstances
+    : public PluginInstances<InstrumentationRuntimeInstance> {
+
+  InstrumentationRuntimeGetType GetTypeCallbackForName(llvm::StringRef name,
+                                                       bool enabled_only) {
+    if (auto instance = GetInstanceForName(name, enabled_only))
+      return instance->get_type_callback;
+    return nullptr;
+  }
+};
 
 static InstrumentationRuntimeInstances &GetInstrumentationRuntimeInstances() {
   static InstrumentationRuntimeInstances g_instances;
@@ -1881,8 +1905,9 @@ bool PluginManager::UnregisterPlugin(
 }
 
 llvm::SmallVector<InstrumentationRuntimeCallbacks>
-PluginManager::GetInstrumentationRuntimeCallbacks() {
-  auto instances = GetInstrumentationRuntimeInstances().GetSnapshot();
+PluginManager::GetInstrumentationRuntimeCallbacks(bool enabled_only) {
+  auto instances =
+      GetInstrumentationRuntimeInstances().GetSnapshot(enabled_only);
   llvm::SmallVector<InstrumentationRuntimeCallbacks> result;
   result.reserve(instances.size());
   for (auto &instance : instances)


### PR DESCRIPTION
This patch is the second part in a patch series that will allow enabling/disabling InstrumentationRuntime plugins in a running debug session.

This patch contains a set of NFC changes that will be needed when implementing support for enabling/disabling InstrumentationRuntime plugins in the `debugger` and `target` domains.

In particular

* In several places the `PluginManager` was modified to get access to information about disabled plugins. Previously interfaces would only return information about enabled plugins.
* `InstrumentationRuntimeInstances` is now struct rather than a typedef so it can contain a helper method that allows looking up a `InstrumentationRuntimeGetType` callback based on the plugin name. This is very similar to the existing `PluginsInstances::GetCallbackForName` method.

rdar://167725878