### PR TITLE
[runtimes] Enable Fortran only with explicit CMAKE_Fortran_COMPILER

### DIFF
--- a/runtimes/cmake/config-Fortran.cmake
+++ b/runtimes/cmake/config-Fortran.cmake
@@ -72,9 +72,20 @@ function (check_fortran_builtins_available)
 endfunction ()
 
 
-# Workarounds for older versions of CMake not recognizing FLang. Hence, we
-# cannot use CMAKE_Fortran_COMPILER_ID.
+set(RUNTIMES_ENABLE_FORTRAN OFF)
+
+# Insert at least one element for
+#
+#    add_dependencies(target ${RUNTIMES_FORTRAN_BUILD_DEPS})
+#
+# to not fail
+add_custom_target(fortran-dummy-dep)
+set(RUNTIMES_FORTRAN_BUILD_DEPS fortran-dummy-dep)
+
+
 if (CMAKE_Fortran_COMPILER)
+  # Workarounds for older versions of CMake not recognizing FLang. Hence, we
+  # cannot use CMAKE_Fortran_COMPILER_ID.
   cmake_path(GET CMAKE_Fortran_COMPILER STEM _Fortran_COMPILER_STEM)
   if (_Fortran_COMPILER_STEM STREQUAL "flang-new" OR _Fortran_COMPILER_STEM STREQUAL "flang")
     # CMake 3.24 is the first version of CMake that directly recognizes Flang.
@@ -124,18 +135,18 @@ if (CMAKE_Fortran_COMPILER)
       set(CMAKE_Fortran_COMPILE_OPTIONS_TARGET "--target=")
     endif ()
   endif ()
+else ()
+  # Do not enable Fortran support unless a Fortran compiler is passed, i.e.
+  # compilation of Fortran is explicitly intended.
+  # The automatically detected C/C++ and Fortran compiler may not play together.
+  # An issue encountered is that CMake adds CMAKE_EXE_LINKER_FLAGS to the linker
+  # line of C/C++ as well as Fortran programs, but the compiler drivers may not
+  # use accept the same flags. Specifically, LLVM adds -Wl,--color-diagnostics
+  # which is supported by lld, but the flag is not accepted by ld.bfd used by
+  # gfortran's driver.
+  return ()
 endif ()
 
-
-set(RUNTIMES_ENABLE_FORTRAN OFF)
-
-# Insert at least one element for
-#
-#    add_dependencies(target ${RUNTIMES_FORTRAN_BUILD_DEPS})
-#
-# to not fail
-add_custom_target(fortran-dummy-dep)
-set(RUNTIMES_FORTRAN_BUILD_DEPS fortran-dummy-dep)
 
 include(CheckLanguage)
 check_language(Fortran)


### PR DESCRIPTION
Only enable Fortran support when the user (or the bootstrapping build) passes `-DCMAKE_Fortran_COMPILER=...`.

`enable_language(...)` other than C/CXX reveals problems with the current build system. LLVM [likes to add `-Wl,--color-diagnostics`](https://github.com/llvm/llvm-project/blob/20ce456138fa2d3a1a330c8c130c8be0173fc74b/llvm/cmake/modules/HandleLLVMOptions.cmake#L1170-L1172) to `CMAKE_EXE_LINKER_FLAGS` whenever possible. The problem is that `CMAKE_EXE_LINKER_FLAGS` is added to the linker line regardless of which language is used, but `HandleLLVMOptions.cmake` probes only `CMAKE_CXX_COMPILER`. Other languages' compilers such as `CMAKE_CUDA_COMPILER` (`nvcc`) or `CMAKE_Fortran_COMPILER` (`gfortran`) may not accept the flag. CMake then fails when those compilers are "not able to compile a simple test program." because it does not accept the `--color-diagnostics` flag. 

`CMAKE_EXE_LINKER_FLAGS` does not support generator expression such that `$<$<COMPILE_LANGUAGE:C,CXX>:-Wl,--color-diagnostics>` does not work either.

We disable automatic detection of a Fortran compiler out of precaution if other such problems are found. The bootstrapping build will pass just-built Clang and Flang together which are compatible to each other. In runtimes default/standalone builds, users will have to pass the compiler explicitly if they want Fortran modules. 