### PR TITLE
[clang] Suppress glibc C11 extension warning in `c-index-test`

### DIFF
--- a/clang/tools/c-index-test/CMakeLists.txt
+++ b/clang/tools/c-index-test/CMakeLists.txt
@@ -12,6 +12,12 @@ if(NOT MSVC)
     SOURCE c-index-test.c
     PROPERTY COMPILE_FLAGS "-std=gnu89"
     )
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    set_property(
+      SOURCE c-index-test.c
+      APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-c11-extensions"
+      )
+  endif()
 endif()
 
 if (LLVM_BUILD_STATIC)


### PR DESCRIPTION
`c-index-test.c` is still compiled with `-std=gnu89` on purpose. That acts
as a useful guard rail: it helps keep the file compatible with older C
dialects instead of silently picking up newer C features because Clang
defaults to a newer language mode.

Ubuntu 26.04 LTS updates glibc's `string.h` so `strchr`, `strrchr` and
`strstr` are routed through `_Generic`-based macros. When Clang compiles
`c-index-test.c` with `-std=gnu89` and `-pedantic`, that now triggers
`-Wc11-extensions` warnings even though the source itself is not using
C11 features.

Keep the gnu89 check in place and suppress this warning only for Clang
when building c-index-test.

Fixes #193356.