### PR TITLE
[lldb] Remove unused ExpressionPathOptions: NoFragileObjcIvar, NoSyntheticArrayRange (NFC)

### DIFF
--- a/lldb/include/lldb/Target/StackFrame.h
+++ b/lldb/include/lldb/Target/StackFrame.h
@@ -52,13 +52,11 @@ public:
 
   enum ExpressionPathOption {
     eExpressionPathOptionCheckPtrVsMember = (1u << 0),
-    // unused = (1u << 1),
-    eExpressionPathOptionsNoSyntheticChildren = (1u << 2),
-    // unused = (1u << 3),
-    eExpressionPathOptionsAllowDirectIVarAccess = (1u << 4),
-    eExpressionPathOptionsInspectAnonymousUnions = (1u << 5),
-    eExpressionPathOptionsAllowVarUpdates = (1u << 6),
-    eExpressionPathOptionsDisallowGlobals = (1u << 7)
+    eExpressionPathOptionsNoSyntheticChildren = (1u << 1),
+    eExpressionPathOptionsAllowDirectIVarAccess = (1u << 2),
+    eExpressionPathOptionsInspectAnonymousUnions = (1u << 3),
+    eExpressionPathOptionsAllowVarUpdates = (1u << 4),
+    eExpressionPathOptionsDisallowGlobals = (1u << 5)
   };
 
   enum class Kind {

--- a/lldb/include/lldb/Target/StackFrame.h
+++ b/lldb/include/lldb/Target/StackFrame.h
@@ -52,9 +52,9 @@ public:
 
   enum ExpressionPathOption {
     eExpressionPathOptionCheckPtrVsMember = (1u << 0),
-    eExpressionPathOptionsNoFragileObjcIvar = (1u << 1),
+    // unused = (1u << 1),
     eExpressionPathOptionsNoSyntheticChildren = (1u << 2),
-    eExpressionPathOptionsNoSyntheticArrayRange = (1u << 3),
+    // unused = (1u << 3),
     eExpressionPathOptionsAllowDirectIVarAccess = (1u << 4),
     eExpressionPathOptionsInspectAnonymousUnions = (1u << 5),
     eExpressionPathOptionsAllowVarUpdates = (1u << 6),

--- a/lldb/include/lldb/ValueObject/DILEval.h
+++ b/lldb/include/lldb/ValueObject/DILEval.h
@@ -143,7 +143,6 @@ private:
   std::shared_ptr<StackFrame> m_exe_ctx_scope;
   lldb::DynamicValueType m_use_dynamic;
   bool m_use_synthetic;
-  bool m_fragile_ivar;
   bool m_check_ptr_vs_member;
   // TODO: Remove 'maybe_unused' when next PR, using this, gets submitted.
   [[maybe_unused]] bool m_allow_var_updates;

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -595,12 +595,8 @@ ValueObjectSP StackFrame::LegacyGetValueForVariableExpressionPath(
 
   const bool check_ptr_vs_member =
       (options & eExpressionPathOptionCheckPtrVsMember) != 0;
-  const bool no_fragile_ivar =
-      (options & eExpressionPathOptionsNoFragileObjcIvar) != 0;
   const bool no_synth_child =
       (options & eExpressionPathOptionsNoSyntheticChildren) != 0;
-  // const bool no_synth_array = (options &
-  // eExpressionPathOptionsNoSyntheticArrayRange) != 0;
   error.Clear();
   bool deref = false;
   bool address_of = false;
@@ -706,19 +702,6 @@ ValueObjectSP StackFrame::LegacyGetValueForVariableExpressionPath(
       expr_is_ptr = true;
       if (var_expr.size() >= 2 && var_expr[1] != '>')
         return ValueObjectSP();
-
-      if (no_fragile_ivar) {
-        // Make sure we aren't trying to deref an objective
-        // C ivar if this is not allowed
-        const uint32_t pointer_type_flags =
-            valobj_sp->GetCompilerType().GetTypeInfo(nullptr);
-        if ((pointer_type_flags & eTypeIsObjC) &&
-            (pointer_type_flags & eTypeIsPointer)) {
-          // This was an objective C object pointer and it was requested we
-          // skip any fragile ivars so return nothing here
-          return ValueObjectSP();
-        }
-      }
 
       // If we have a non-pointer type with a synthetic value then lets check if
       // we have a synthetic dereference specified.

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -376,8 +376,6 @@ Interpreter::Interpreter(lldb::TargetSP target, llvm::StringRef expr,
 
   const bool check_ptr_vs_member =
       (options & StackFrame::eExpressionPathOptionCheckPtrVsMember) != 0;
-  const bool no_fragile_ivar =
-      (options & StackFrame::eExpressionPathOptionsNoFragileObjcIvar) != 0;
   const bool no_synth_child =
       (options & StackFrame::eExpressionPathOptionsNoSyntheticChildren) != 0;
   const bool allow_var_updates =
@@ -386,7 +384,6 @@ Interpreter::Interpreter(lldb::TargetSP target, llvm::StringRef expr,
       (options & StackFrame::eExpressionPathOptionsDisallowGlobals) != 0;
 
   m_use_synthetic = !no_synth_child;
-  m_fragile_ivar = !no_fragile_ivar;
   m_check_ptr_vs_member = check_ptr_vs_member;
   m_allow_var_updates = allow_var_updates;
   m_allow_globals = !disallow_globals;
@@ -851,19 +848,6 @@ Interpreter::Visit(const MemberOfNode &node) {
 
   // Perform some basic type & correctness checking.
   if (node.GetIsArrow()) {
-    if (!m_fragile_ivar) {
-      // Make sure we aren't trying to deref an objective
-      // C ivar if this is not allowed
-      const uint32_t pointer_type_flags =
-          base->GetCompilerType().GetTypeInfo(nullptr);
-      if ((pointer_type_flags & lldb::eTypeIsObjC) &&
-          (pointer_type_flags & lldb::eTypeIsPointer)) {
-        // This was an objective C object pointer and it was requested we
-        // skip any fragile ivars so return nothing here
-        return lldb::ValueObjectSP();
-      }
-    }
-
     // If we have a non-pointer type with a synthetic value then lets check
     // if we have a synthetic dereference specified.
     if (!base->IsPointerType() && base->HasSyntheticValue()) {


### PR DESCRIPTION
As of #193120, `eExpressionPathOptionsNoFragileObjcIvar` and `eExpressionPathOptionsNoSyntheticArrayRange` are no longer used anywhere, and aren't expected to be used again.