### PR TITLE
[libcxx][Github] Bump Github Runner to 2.334.0

### DIFF
--- a/libcxx/utils/ci/docker/docker-compose.yml
+++ b/libcxx/utils/ci/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       dockerfile: libcxx/utils/ci/docker/linux-builder.dockerfile
       args:
         BASE_IMAGE_VERSION: e849c68657d88d03235b87da34c740cda3abebd4
-        GITHUB_RUNNER_VERSION: 2.331.0
+        GITHUB_RUNNER_VERSION: 2.334.0
 
   libcxx-android-builder:
     image: ghcr.io/llvm/libcxx-android-builder:${TAG:-latest}


### PR DESCRIPTION
To stay ahead of the support horizon. Use the same base image to prevent
any differences beyond the runner binary.