### PR TITLE
[DirectX] Implement lowering of Texture Load and Texture .operator[]

### DIFF
--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -881,7 +881,7 @@ def CBufferLoadLegacy : DXILOp<59, cbufferLoadLegacy> {
 }
 
 def TextureLoad : DXILOp<66, textureLoad> {
-  let Doc = "reads from a Texture";
+  let Doc = "reads from a texture resource";
   // Handle, MipLevelOrSampleCount, Coord0, Coord1, Coord2, Offset0, Offset1, Offset2
   let arguments = [HandleTy, Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty,
                    Int32Ty, Int32Ty];
@@ -1181,7 +1181,7 @@ def WaveActiveBit : DXILOp<120, waveActiveBit> {
   let intrinsics = [
     IntrinSelect<int_dx_wave_reduce_or,
                  [
-                   IntrinArgIndex<0>, IntrinArgI8<WaveBitOpKind_Or>,                   
+                   IntrinArgIndex<0>, IntrinArgI8<WaveBitOpKind_Or>,
                  ]>,
     IntrinSelect<int_dx_wave_reduce_xor,
                  [

--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -880,6 +880,19 @@ def CBufferLoadLegacy : DXILOp<59, cbufferLoadLegacy> {
   let attributes = [Attributes<DXIL1_0, [ReadOnly]>];
 }
 
+def TextureLoad : DXILOp<66, textureLoad> {
+  let Doc = "reads from a Texture";
+  // Handle, MipLevelOrSampleCount, Coord0, Coord1, Coord2, Offset0, Offset1, Offset2
+  let arguments = [HandleTy, Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty,
+                   Int32Ty, Int32Ty];
+  let result = OverloadTy;
+  let overloads =
+      [Overloads<DXIL1_0,
+                 [ResRetHalfTy, ResRetFloatTy, ResRetInt16Ty, ResRetInt32Ty]>];
+  let stages = [Stages<DXIL1_0, [all_stages]>];
+  let attributes = [Attributes<DXIL1_0, [ReadOnly]>];
+}
+
 def BufferLoad : DXILOp<68, bufferLoad> {
   let Doc = "reads from a TypedBuffer";
   // Handle, Coord0, Coord1

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -566,6 +566,73 @@ public:
     });
   }
 
+  [[nodiscard]] bool lowerTextureLoad(Function &F) {
+    IRBuilder<> &IRB = OpBuilder.getIRB();
+    Type *Int32Ty = IRB.getInt32Ty();
+
+    return replaceFunction(F, [&](CallInst *CI) -> Error {
+      IRB.SetInsertPoint(CI);
+
+      Value *Handle =
+          createTmpHandleCast(CI->getArgOperand(0), OpBuilder.getHandleType());
+      Value *Coords = CI->getArgOperand(1);
+      Value *MipLevel = CI->getArgOperand(2);
+      Value *Offsets = CI->getArgOperand(3);
+
+      Type *OldTy = CI->getType();
+      Type *NewRetTy = OpBuilder.getResRetType(OldTy->getScalarType());
+
+      std::array<Value *, 3> CoordArgs = {UndefValue::get(Int32Ty),
+                                          UndefValue::get(Int32Ty),
+                                          UndefValue::get(Int32Ty)};
+
+      Type *CoordTy = Coords->getType();
+      if (auto *VecTy = dyn_cast<FixedVectorType>(CoordTy)) {
+        unsigned NumCoords = VecTy->getNumElements();
+        assert(NumCoords < 3 &&
+               "Expected at most 3 elements in coordinate vector");
+        for (unsigned I = 0; I < NumCoords; ++I)
+          CoordArgs[I] = IRB.CreateExtractElement(Coords, uint64_t(I));
+      } else {
+        CoordArgs[0] = Coords;
+      }
+
+      std::array<Value *, 3> OffsetArgs = {UndefValue::get(Int32Ty),
+                                           UndefValue::get(Int32Ty),
+                                           UndefValue::get(Int32Ty)};
+
+      Type *OffsetTy = Offsets->getType();
+      bool IsZeroOffset = false;
+      if (auto *C = dyn_cast<Constant>(Offsets))
+        IsZeroOffset = C->isNullValue();
+
+      if (!IsZeroOffset) {
+        if (auto *VecTy = dyn_cast<FixedVectorType>(OffsetTy)) {
+          unsigned NumOffsets = VecTy->getNumElements();
+          assert(NumOffsets < 3 &&
+                 "Expected at most 3 elements in offsets vector");
+          for (unsigned I = 0; I < NumOffsets; ++I)
+            OffsetArgs[I] = IRB.CreateExtractElement(Offsets, uint64_t(I));
+        } else {
+          OffsetArgs[0] = Offsets;
+        }
+      }
+
+      std::array<Value *, 8> Args{Handle,        MipLevel,     CoordArgs[0],
+                                  CoordArgs[1],  CoordArgs[2], OffsetArgs[0],
+                                  OffsetArgs[1], OffsetArgs[2]};
+
+      Expected<CallInst *> OpCall = OpBuilder.tryCreateOp(
+          OpCode::TextureLoad, Args, CI->getName(), NewRetTy);
+      if (Error E = OpCall.takeError())
+        return E;
+      if (Error E = replaceResRetUses(CI, *OpCall, /*HasCheckBit=*/false))
+        return E;
+
+      return Error::success();
+    });
+  }
+
   [[nodiscard]] bool lowerRawBufferLoad(Function &F) {
     const DataLayout &DL = F.getDataLayout();
     IRBuilder<> &IRB = OpBuilder.getIRB();
@@ -979,6 +1046,9 @@ public:
         break;
       case Intrinsic::dx_resource_load_typedbuffer:
         HasErrors |= lowerTypedBufferLoad(F, /*HasCheckBit=*/true);
+        break;
+      case Intrinsic::dx_resource_load_level:
+        HasErrors |= lowerTextureLoad(F);
         break;
       case Intrinsic::dx_resource_store_typedbuffer:
         HasErrors |= lowerBufferStore(F, /*IsRaw=*/false);

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -569,9 +569,10 @@ public:
   // Copies `Src` into `Args` starting at `ArgIdx`. If `Src` is a vector, its
   // elements are extracted and stored in consecutive slots; otherwise `Src`
   // is stored directly. At most `MaxElements` elements are expected.
-  static void copyVectorArgs(IRBuilder<> &IRB, MutableArrayRef<Value *> Args,
-                             unsigned ArgIdx, Value *Src,
-                             unsigned MaxElements) {
+  static void extractElementsIntoArgs(IRBuilder<> &IRB,
+                                      MutableArrayRef<Value *> Args,
+                                      unsigned ArgIdx, Value *Src,
+                                      unsigned MaxElements) {
     Type *Ty = Src->getType();
     if (auto *VecTy = dyn_cast<FixedVectorType>(Ty)) {
       unsigned Count = VecTy->getNumElements();
@@ -604,9 +605,9 @@ public:
                                   Undef,  Undef,    Undef, Undef};
 
       // Copy coordinates and offsets into Args.
-      copyVectorArgs(IRB, Args, 2, Coords, 3);
+      extractElementsIntoArgs(IRB, Args, 2, Coords, 3);
       if (auto *C = dyn_cast<Constant>(Offsets); !C || !C->isNullValue())
-        copyVectorArgs(IRB, Args, 5, Offsets, 3);
+        extractElementsIntoArgs(IRB, Args, 5, Offsets, 3);
 
       Expected<CallInst *> OpCall = OpBuilder.tryCreateOp(
           OpCode::TextureLoad, Args, CI->getName(), NewRetTy);

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -582,9 +582,9 @@ public:
       Type *OldTy = CI->getType();
       Type *NewRetTy = OpBuilder.getResRetType(OldTy->getScalarType());
 
-      std::array<Value *, 3> CoordArgs = {UndefValue::get(Int32Ty),
-                                          UndefValue::get(Int32Ty),
-                                          UndefValue::get(Int32Ty)};
+      Value *Undef = UndefValue::get(Int32Ty);
+      std::array<Value *, 8> Args{Handle, MipLevel, Undef, Undef,
+                                  Undef,  Undef,    Undef, Undef};
 
       Type *CoordTy = Coords->getType();
       if (auto *VecTy = dyn_cast<FixedVectorType>(CoordTy)) {
@@ -592,35 +592,27 @@ public:
         assert(NumCoords < 3 &&
                "Expected at most 3 elements in coordinate vector");
         for (unsigned I = 0; I < NumCoords; ++I)
-          CoordArgs[I] = IRB.CreateExtractElement(Coords, uint64_t(I));
+          Args[2 + I] = IRB.CreateExtractElement(Coords, uint64_t(I));
       } else {
-        CoordArgs[0] = Coords;
+        Args[2] = Coords;
       }
 
-      std::array<Value *, 3> OffsetArgs = {UndefValue::get(Int32Ty),
-                                           UndefValue::get(Int32Ty),
-                                           UndefValue::get(Int32Ty)};
-
-      Type *OffsetTy = Offsets->getType();
       bool IsZeroOffset = false;
       if (auto *C = dyn_cast<Constant>(Offsets))
         IsZeroOffset = C->isNullValue();
 
       if (!IsZeroOffset) {
+        Type *OffsetTy = Offsets->getType();
         if (auto *VecTy = dyn_cast<FixedVectorType>(OffsetTy)) {
           unsigned NumOffsets = VecTy->getNumElements();
           assert(NumOffsets < 3 &&
                  "Expected at most 3 elements in offsets vector");
           for (unsigned I = 0; I < NumOffsets; ++I)
-            OffsetArgs[I] = IRB.CreateExtractElement(Offsets, uint64_t(I));
+            Args[5 + I] = IRB.CreateExtractElement(Offsets, uint64_t(I));
         } else {
-          OffsetArgs[0] = Offsets;
+          Args[5] = Offsets;
         }
       }
-
-      std::array<Value *, 8> Args{Handle,        MipLevel,     CoordArgs[0],
-                                  CoordArgs[1],  CoordArgs[2], OffsetArgs[0],
-                                  OffsetArgs[1], OffsetArgs[2]};
 
       Expected<CallInst *> OpCall = OpBuilder.tryCreateOp(
           OpCode::TextureLoad, Args, CI->getName(), NewRetTy);

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -566,6 +566,23 @@ public:
     });
   }
 
+  // Copies `Src` into `Args` starting at `ArgIdx`. If `Src` is a vector, its
+  // elements are extracted and stored in consecutive slots; otherwise `Src`
+  // is stored directly. At most `MaxElements` elements are expected.
+  static void copyVectorArgs(IRBuilder<> &IRB, MutableArrayRef<Value *> Args,
+                             unsigned ArgIdx, Value *Src,
+                             unsigned MaxElements) {
+    Type *Ty = Src->getType();
+    if (auto *VecTy = dyn_cast<FixedVectorType>(Ty)) {
+      unsigned Count = VecTy->getNumElements();
+      assert(Count <= MaxElements && "Expected at most 3 elements in vector");
+      for (unsigned I = 0; I < Count; ++I)
+        Args[ArgIdx + I] = IRB.CreateExtractElement(Src, uint64_t(I));
+    } else {
+      Args[ArgIdx] = Src;
+    }
+  }
+
   [[nodiscard]] bool lowerTextureLoad(Function &F) {
     IRBuilder<> &IRB = OpBuilder.getIRB();
     Type *Int32Ty = IRB.getInt32Ty();
@@ -586,33 +603,10 @@ public:
       std::array<Value *, 8> Args{Handle, MipLevel, Undef, Undef,
                                   Undef,  Undef,    Undef, Undef};
 
-      Type *CoordTy = Coords->getType();
-      if (auto *VecTy = dyn_cast<FixedVectorType>(CoordTy)) {
-        unsigned NumCoords = VecTy->getNumElements();
-        assert(NumCoords < 3 &&
-               "Expected at most 3 elements in coordinate vector");
-        for (unsigned I = 0; I < NumCoords; ++I)
-          Args[2 + I] = IRB.CreateExtractElement(Coords, uint64_t(I));
-      } else {
-        Args[2] = Coords;
-      }
-
-      bool IsZeroOffset = false;
-      if (auto *C = dyn_cast<Constant>(Offsets))
-        IsZeroOffset = C->isNullValue();
-
-      if (!IsZeroOffset) {
-        Type *OffsetTy = Offsets->getType();
-        if (auto *VecTy = dyn_cast<FixedVectorType>(OffsetTy)) {
-          unsigned NumOffsets = VecTy->getNumElements();
-          assert(NumOffsets < 3 &&
-                 "Expected at most 3 elements in offsets vector");
-          for (unsigned I = 0; I < NumOffsets; ++I)
-            Args[5 + I] = IRB.CreateExtractElement(Offsets, uint64_t(I));
-        } else {
-          Args[5] = Offsets;
-        }
-      }
+      // Copy coordinates and offsets into Args.
+      copyVectorArgs(IRB, Args, 2, Coords, 3);
+      if (auto *C = dyn_cast<Constant>(Offsets); !C || !C->isNullValue())
+        copyVectorArgs(IRB, Args, 5, Offsets, 3);
 
       Expected<CallInst *> OpCall = OpBuilder.tryCreateOp(
           OpCode::TextureLoad, Args, CI->getName(), NewRetTy);

--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -273,7 +273,6 @@ static void createTextureLoad(IntrinsicInst *II, LoadInst *LI,
 
   // For operator[], offsets are zero.
   Type *CoordTy = Coords->getType();
-
   Type *OffsetTy;
   if (auto *VecTy = dyn_cast<FixedVectorType>(CoordTy))
     OffsetTy =

--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -260,7 +260,7 @@ static void createTypedBufferLoad(IntrinsicInst *II, LoadInst *LI,
 }
 
 static void createTextureLoad(IntrinsicInst *II, LoadInst *LI,
-                               dxil::ResourceTypeInfo &RTI) {
+                              dxil::ResourceTypeInfo &RTI) {
   const DataLayout &DL = LI->getDataLayout();
   IRBuilder<> Builder(LI);
   Type *ContainedType = RTI.getHandleTy()->getTypeParameter(0);

--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -216,7 +216,7 @@ static void createStoreIntrinsic(IntrinsicInst *II, StoreInst *SI,
   case dxil::ResourceKind::TextureCubeArray:
   case dxil::ResourceKind::FeedbackTexture2D:
   case dxil::ResourceKind::FeedbackTexture2DArray:
-    reportFatalUsageError("DXIL Load not implemented yet");
+    reportFatalUsageError("DXIL Store not implemented for texture resources");
     return;
   case dxil::ResourceKind::CBuffer:
   case dxil::ResourceKind::Sampler:
@@ -240,6 +240,51 @@ static void createTypedBufferLoad(IntrinsicInst *II, LoadInst *LI,
       Builder.CreateIntrinsic(LoadType, Intrinsic::dx_resource_load_typedbuffer,
                               {II->getOperand(0), II->getOperand(1)});
   V = Builder.CreateExtractValue(V, {0});
+
+  Type *ScalarType = ContainedType->getScalarType();
+  uint64_t AccessSize = DL.getTypeSizeInBits(ScalarType) / 8;
+  Value *Offset =
+      traverseGEPOffsets(DL, Builder, LI->getPointerOperand(), AccessSize);
+  auto *ConstantOffset = dyn_cast<ConstantInt>(Offset);
+  if (!ConstantOffset || !ConstantOffset->isZero())
+    V = Builder.CreateExtractElement(V, Offset);
+
+  // If we loaded a <1 x ...> instead of a scalar (presumably to feed a
+  // shufflevector), then make sure we're maintaining the resulting type.
+  if (auto *VT = dyn_cast<FixedVectorType>(LI->getType()))
+    if (VT->getNumElements() == 1 && !isa<FixedVectorType>(V->getType()))
+      V = Builder.CreateInsertElement(PoisonValue::get(VT), V,
+                                      Builder.getInt32(0));
+
+  LI->replaceAllUsesWith(V);
+}
+
+static void createTextureLoad(IntrinsicInst *II, LoadInst *LI,
+                               dxil::ResourceTypeInfo &RTI) {
+  const DataLayout &DL = LI->getDataLayout();
+  IRBuilder<> Builder(LI);
+  Type *ContainedType = RTI.getHandleTy()->getTypeParameter(0);
+
+  Value *Handle = II->getOperand(0);
+  Value *Coords = II->getOperand(1);
+
+  // For operator[], mip level is 0.
+  Value *MipLevel = Builder.getInt32(0);
+
+  // For operator[], offsets are zero.
+  Type *CoordTy = Coords->getType();
+
+  Type *OffsetTy;
+  if (auto *VecTy = dyn_cast<FixedVectorType>(CoordTy))
+    OffsetTy =
+        FixedVectorType::get(Builder.getInt32Ty(), VecTy->getNumElements());
+  else
+    OffsetTy = Builder.getInt32Ty();
+  Value *Offsets = Constant::getNullValue(OffsetTy);
+
+  Value *V =
+      Builder.CreateIntrinsic(ContainedType, Intrinsic::dx_resource_load_level,
+                              {Handle, Coords, MipLevel, Offsets});
 
   Type *ScalarType = ContainedType->getScalarType();
   uint64_t AccessSize = DL.getTypeSizeInBits(ScalarType) / 8;
@@ -482,6 +527,7 @@ static void createLoadIntrinsic(IntrinsicInst *II, LoadInst *LI,
   case dxil::ResourceKind::Texture2DArray:
   case dxil::ResourceKind::Texture2DMSArray:
   case dxil::ResourceKind::TextureCubeArray:
+    return createTextureLoad(II, LI, RTI);
   case dxil::ResourceKind::FeedbackTexture2D:
   case dxil::ResourceKind::FeedbackTexture2DArray:
   case dxil::ResourceKind::TBuffer:

--- a/llvm/test/CodeGen/DirectX/ResourceAccess/load_texture.ll
+++ b/llvm/test/CodeGen/DirectX/ResourceAccess/load_texture.ll
@@ -1,0 +1,97 @@
+; RUN: opt -S -dxil-resource-access %s | FileCheck %s
+
+target triple = "dxil-pc-shadermodel6.6-compute"
+
+declare void @use_float4(<4 x float>)
+declare void @use_float1(<1 x float>)
+declare void @use_float(float)
+declare void @use_int3(<3 x i32>)
+
+; CHECK-LABEL: define void @load_texture2d_float4(
+define void @load_texture2d_float4(<2 x i32> %coords) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK-NOT: @llvm.dx.resource.getpointer
+  %ptr = call ptr @llvm.dx.resource.getpointer(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture, <2 x i32> %coords)
+
+  ; CHECK: %[[VALUE:.*]] = call <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_2t.v2i32.i32.v2i32(target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture, <2 x i32> %coords, i32 0, <2 x i32> zeroinitializer)
+  %data = load <4 x float>, ptr %ptr
+  call void @use_float4(<4 x float> %data)
+
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture2d_float(
+define void @load_texture2d_float(<2 x i32> %coords) {
+  %texture = call target("dx.Texture", float, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_f32_0_0_0_2t(
+          i32 0, i32 1, i32 1, i32 0, ptr null)
+
+  ; CHECK-NOT: @llvm.dx.resource.getpointer
+  %ptr = call ptr @llvm.dx.resource.getpointer(
+      target("dx.Texture", float, 0, 0, 0, 2) %texture, <2 x i32> %coords)
+
+  ; CHECK: %[[VALUE:.*]] = call float @llvm.dx.resource.load.level.f32.tdx.Texture_f32_0_0_0_2t.v2i32.i32.v2i32(target("dx.Texture", float, 0, 0, 0, 2) %texture, <2 x i32> %coords, i32 0, <2 x i32> zeroinitializer)
+  %data = load float, ptr %ptr
+  call void @use_float(float %data)
+
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture2d_int3(
+define void @load_texture2d_int3(<2 x i32> %coords) {
+  %texture = call target("dx.Texture", <3 x i32>, 0, 0, 1, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v3i32_0_0_1_2t(
+          i32 0, i32 2, i32 1, i32 0, ptr null)
+
+  ; CHECK-NOT: @llvm.dx.resource.getpointer
+  %ptr = call ptr @llvm.dx.resource.getpointer(
+      target("dx.Texture", <3 x i32>, 0, 0, 1, 2) %texture, <2 x i32> %coords)
+
+  ; CHECK: %[[VALUE:.*]] = call <3 x i32> @llvm.dx.resource.load.level.v3i32.tdx.Texture_v3i32_0_0_1_2t.v2i32.i32.v2i32(target("dx.Texture", <3 x i32>, 0, 0, 1, 2) %texture, <2 x i32> %coords, i32 0, <2 x i32> zeroinitializer)
+  %data = load <3 x i32>, ptr %ptr
+  call void @use_int3(<3 x i32> %data)
+
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture2d_float_as_float1(
+define void @load_texture2d_float_as_float1(<2 x i32> %coords) {
+  %texture = call target("dx.Texture", float, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_f32_0_0_0_2t(
+          i32 0, i32 1, i32 1, i32 0, ptr null)
+
+  ; CHECK-NOT: @llvm.dx.resource.getpointer
+  %ptr = call ptr @llvm.dx.resource.getpointer(
+      target("dx.Texture", float, 0, 0, 0, 2) %texture, <2 x i32> %coords)
+
+  ; CHECK: %[[VALUE:.*]] = call float @llvm.dx.resource.load.level.f32.tdx.Texture_f32_0_0_0_2t.v2i32.i32.v2i32(target("dx.Texture", float, 0, 0, 0, 2) %texture, <2 x i32> %coords, i32 0, <2 x i32> zeroinitializer)
+  ; CHECK: %[[VEC:.*]] = insertelement <1 x float> poison, float %[[VALUE]], i32 0
+  ; CHECK: call void @use_float1(<1 x float> %[[VEC]])
+  %vec_data = load <1 x float>, ptr %ptr
+  call void @use_float1(<1 x float> %vec_data)
+
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture2d_float4_extract_element(
+define void @load_texture2d_float4_extract_element(<2 x i32> %coords) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK-NOT: @llvm.dx.resource.getpointer
+  %ptr = call ptr @llvm.dx.resource.getpointer(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture, <2 x i32> %coords)
+
+  ; CHECK: %[[VALUE:.*]] = call <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_2t.v2i32.i32.v2i32(target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture, <2 x i32> %coords, i32 0, <2 x i32> zeroinitializer)
+  ; CHECK: extractelement <4 x float> %[[VALUE]], i32 1
+  %y_ptr = getelementptr inbounds <4 x float>, ptr %ptr, i32 0, i32 1
+  %y_data = load float, ptr %y_ptr
+  call void @use_float(float %y_data)
+
+  ret void
+}

--- a/llvm/test/CodeGen/DirectX/TextureLoad.ll
+++ b/llvm/test/CodeGen/DirectX/TextureLoad.ll
@@ -1,0 +1,68 @@
+; RUN: opt -S -dxil-op-lower %s | FileCheck %s
+
+target triple = "dxil-pc-shadermodel6.6-compute"
+
+declare void @use_float4(<4 x float>)
+declare void @use_float(float)
+declare void @use_int3(<3 x i32>)
+
+; CHECK-LABEL: define void @load_texture2d_float4(
+define void @load_texture2d_float4(<2 x i32> %coords) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x i32> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x i32> %coords, i64 1
+  ; CHECK: %[[LOAD:.*]] = call %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66, %dx.types.Handle %{{.*}}, i32 0, i32 %[[COORD0]], i32 %[[COORD1]], i32 undef, i32 undef, i32 undef, i32 undef)
+  %data = call <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_2t.v2i32.i32.v2i32(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      <2 x i32> %coords, i32 0, <2 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[LOAD]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture2d_float(
+define void @load_texture2d_float(<2 x i32> %coords) {
+  %texture = call target("dx.Texture", float, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_f32_0_0_0_2t(
+          i32 0, i32 1, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x i32> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x i32> %coords, i64 1
+  ; CHECK: %[[LOAD:.*]] = call %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66, %dx.types.Handle %{{.*}}, i32 0, i32 %[[COORD0]], i32 %[[COORD1]], i32 undef, i32 undef, i32 undef, i32 undef)
+  %data = call float @llvm.dx.resource.load.level.f32.tdx.Texture_f32_0_0_0_2t.v2i32.i32.v2i32(
+      target("dx.Texture", float, 0, 0, 0, 2) %texture,
+      <2 x i32> %coords, i32 0, <2 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[LOAD]], 0
+  call void @use_float(float %data)
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture2d_int3(
+define void @load_texture2d_int3(<2 x i32> %coords) {
+  %texture = call target("dx.Texture", <3 x i32>, 0, 0, 1, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v3i32_0_0_1_2t(
+          i32 0, i32 2, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x i32> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x i32> %coords, i64 1
+  ; CHECK: %[[LOAD:.*]] = call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %{{.*}}, i32 0, i32 %[[COORD0]], i32 %[[COORD1]], i32 undef, i32 undef, i32 undef, i32 undef)
+  %data = call <3 x i32> @llvm.dx.resource.load.level.v3i32.tdx.Texture_v3i32_0_0_1_2t.v2i32.i32.v2i32(
+      target("dx.Texture", <3 x i32>, 0, 0, 1, 2) %texture,
+      <2 x i32> %coords, i32 0, <2 x i32> zeroinitializer)
+
+  call void @use_int3(<3 x i32> %data)
+  ret void
+}
+
+declare <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_2t.v2i32.i32.v2i32(target("dx.Texture", <4 x float>, 0, 0, 0, 2), <2 x i32>, i32, <2 x i32>)
+declare float @llvm.dx.resource.load.level.f32.tdx.Texture_f32_0_0_0_2t.v2i32.i32.v2i32(target("dx.Texture", float, 0, 0, 0, 2), <2 x i32>, i32, <2 x i32>)
+declare <3 x i32> @llvm.dx.resource.load.level.v3i32.tdx.Texture_v3i32_0_0_1_2t.v2i32.i32.v2i32(target("dx.Texture", <3 x i32>, 0, 0, 1, 2), <2 x i32>, i32, <2 x i32>)
+
+declare target("dx.Texture", <4 x float>, 0, 0, 0, 2) @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(i32, i32, i32, i32, ptr)
+declare target("dx.Texture", float, 0, 0, 0, 2) @llvm.dx.resource.handlefrombinding.tdx.Texture_f32_0_0_0_2t(i32, i32, i32, i32, ptr)
+declare target("dx.Texture", <3 x i32>, 0, 0, 1, 2) @llvm.dx.resource.handlefrombinding.tdx.Texture_v3i32_0_0_1_2t(i32, i32, i32, i32, ptr)

--- a/llvm/test/CodeGen/DirectX/TextureLoad.ll
+++ b/llvm/test/CodeGen/DirectX/TextureLoad.ll
@@ -58,3 +58,57 @@ define void @load_texture2d_int3(<2 x i32> %coords) {
   call void @use_int3(<3 x i32> %data)
   ret void
 }
+
+; CHECK-LABEL: define void @load_texture2d_float4_with_level(
+define void @load_texture2d_float4_with_level(<2 x i32> %coords) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x i32> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x i32> %coords, i64 1
+  ; CHECK: %[[LOAD:.*]] = call %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66, %dx.types.Handle %{{.*}}, i32 2, i32 %[[COORD0]], i32 %[[COORD1]], i32 undef, i32 undef, i32 undef, i32 undef)
+  %data = call <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_2t.v2i32.i32.v2i32(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      <2 x i32> %coords, i32 2, <2 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[LOAD]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture2d_float4_with_offset(
+define void @load_texture2d_float4_with_offset(<2 x i32> %coords) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x i32> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x i32> %coords, i64 1
+  ; CHECK: %[[LOAD:.*]] = call %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66, %dx.types.Handle %{{.*}}, i32 0, i32 %[[COORD0]], i32 %[[COORD1]], i32 undef, i32 1, i32 -2, i32 undef)
+  %data = call <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_2t.v2i32.i32.v2i32(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      <2 x i32> %coords, i32 0, <2 x i32> <i32 1, i32 -2>)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[LOAD]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture2d_float4_with_level_and_offset(
+define void @load_texture2d_float4_with_level_and_offset(<2 x i32> %coords) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x i32> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x i32> %coords, i64 1
+  ; CHECK: %[[LOAD:.*]] = call %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66, %dx.types.Handle %{{.*}}, i32 3, i32 %[[COORD0]], i32 %[[COORD1]], i32 undef, i32 -1, i32 2, i32 undef)
+  %data = call <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_2t.v2i32.i32.v2i32(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+      <2 x i32> %coords, i32 3, <2 x i32> <i32 -1, i32 2>)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[LOAD]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}

--- a/llvm/test/CodeGen/DirectX/TextureLoad.ll
+++ b/llvm/test/CodeGen/DirectX/TextureLoad.ll
@@ -5,6 +5,7 @@ target triple = "dxil-pc-shadermodel6.6-compute"
 declare void @use_float4(<4 x float>)
 declare void @use_float(float)
 declare void @use_int3(<3 x i32>)
+declare void @use_float3(<3 x float>)
 
 ; CHECK-LABEL: define void @load_texture2d_float4(
 define void @load_texture2d_float4(<2 x i32> %coords) {
@@ -107,6 +108,114 @@ define void @load_texture2d_float4_with_level_and_offset(<2 x i32> %coords) {
   %data = call <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_2t.v2i32.i32.v2i32(
       target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
       <2 x i32> %coords, i32 3, <2 x i32> <i32 -1, i32 2>)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[LOAD]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture1d_float4(
+define void @load_texture1d_float4(i32 %coord) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 1)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_1t(
+          i32 0, i32 3, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[LOAD:.*]] = call %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66, %dx.types.Handle %{{.*}}, i32 0, i32 %coord, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef)
+  %data = call <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_1t.i32.i32.i32(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 1) %texture,
+      i32 %coord, i32 0, i32 0)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[LOAD]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture1d_float4_with_level_and_offset(
+define void @load_texture1d_float4_with_level_and_offset(i32 %coord) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 1)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_1t(
+          i32 0, i32 3, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[LOAD:.*]] = call %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66, %dx.types.Handle %{{.*}}, i32 4, i32 %coord, i32 undef, i32 undef, i32 5, i32 undef, i32 undef)
+  %data = call <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_1t.i32.i32.i32(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 1) %texture,
+      i32 %coord, i32 4, i32 5)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[LOAD]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture3d_float3(
+define void @load_texture3d_float3(<3 x i32> %coords) {
+  %texture = call target("dx.Texture", <3 x float>, 0, 0, 0, 4)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v3f32_0_0_0_4t(
+          i32 0, i32 4, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <3 x i32> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <3 x i32> %coords, i64 1
+  ; CHECK: %[[COORD2:.*]] = extractelement <3 x i32> %coords, i64 2
+  ; CHECK: %[[LOAD:.*]] = call %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66, %dx.types.Handle %{{.*}}, i32 0, i32 %[[COORD0]], i32 %[[COORD1]], i32 %[[COORD2]], i32 undef, i32 undef, i32 undef)
+  %data = call <3 x float> @llvm.dx.resource.load.level.v3f32.tdx.Texture_v3f32_0_0_0_4t.v3i32.i32.v3i32(
+      target("dx.Texture", <3 x float>, 0, 0, 0, 4) %texture,
+      <3 x i32> %coords, i32 0, <3 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[LOAD]], 0
+  call void @use_float3(<3 x float> %data)
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture3d_float3_with_level_and_offset(
+define void @load_texture3d_float3_with_level_and_offset(<3 x i32> %coords) {
+  %texture = call target("dx.Texture", <3 x float>, 0, 0, 0, 4)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v3f32_0_0_0_4t(
+          i32 0, i32 4, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <3 x i32> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <3 x i32> %coords, i64 1
+  ; CHECK: %[[COORD2:.*]] = extractelement <3 x i32> %coords, i64 2
+  ; CHECK: %[[LOAD:.*]] = call %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66, %dx.types.Handle %{{.*}}, i32 2, i32 %[[COORD0]], i32 %[[COORD1]], i32 %[[COORD2]], i32 1, i32 -2, i32 3)
+  %data = call <3 x float> @llvm.dx.resource.load.level.v3f32.tdx.Texture_v3f32_0_0_0_4t.v3i32.i32.v3i32(
+      target("dx.Texture", <3 x float>, 0, 0, 0, 4) %texture,
+      <3 x i32> %coords, i32 2, <3 x i32> <i32 1, i32 -2, i32 3>)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[LOAD]], 0
+  call void @use_float3(<3 x float> %data)
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture2darray_float4(
+define void @load_texture2darray_float4(<3 x i32> %coords) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 7)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_7t(
+          i32 0, i32 5, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <3 x i32> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <3 x i32> %coords, i64 1
+  ; CHECK: %[[COORD2:.*]] = extractelement <3 x i32> %coords, i64 2
+  ; CHECK: %[[LOAD:.*]] = call %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66, %dx.types.Handle %{{.*}}, i32 0, i32 %[[COORD0]], i32 %[[COORD1]], i32 %[[COORD2]], i32 undef, i32 undef, i32 undef)
+  %data = call <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_7t.v3i32.i32.v2i32(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 7) %texture,
+      <3 x i32> %coords, i32 0, <2 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[LOAD]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; CHECK-LABEL: define void @load_texture2darray_float4_with_level_and_offset(
+define void @load_texture2darray_float4_with_level_and_offset(<3 x i32> %coords) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 7)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_7t(
+          i32 0, i32 5, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <3 x i32> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <3 x i32> %coords, i64 1
+  ; CHECK: %[[COORD2:.*]] = extractelement <3 x i32> %coords, i64 2
+  ; CHECK: %[[LOAD:.*]] = call %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66, %dx.types.Handle %{{.*}}, i32 1, i32 %[[COORD0]], i32 %[[COORD1]], i32 %[[COORD2]], i32 -1, i32 2, i32 undef)
+  %data = call <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_7t.v3i32.i32.v2i32(
+      target("dx.Texture", <4 x float>, 0, 0, 0, 7) %texture,
+      <3 x i32> %coords, i32 1, <2 x i32> <i32 -1, i32 2>)
 
   ; CHECK: extractvalue %dx.types.ResRet.f32 %[[LOAD]], 0
   call void @use_float4(<4 x float> %data)

--- a/llvm/test/CodeGen/DirectX/TextureLoad.ll
+++ b/llvm/test/CodeGen/DirectX/TextureLoad.ll
@@ -58,11 +58,3 @@ define void @load_texture2d_int3(<2 x i32> %coords) {
   call void @use_int3(<3 x i32> %data)
   ret void
 }
-
-declare <4 x float> @llvm.dx.resource.load.level.v4f32.tdx.Texture_v4f32_0_0_0_2t.v2i32.i32.v2i32(target("dx.Texture", <4 x float>, 0, 0, 0, 2), <2 x i32>, i32, <2 x i32>)
-declare float @llvm.dx.resource.load.level.f32.tdx.Texture_f32_0_0_0_2t.v2i32.i32.v2i32(target("dx.Texture", float, 0, 0, 0, 2), <2 x i32>, i32, <2 x i32>)
-declare <3 x i32> @llvm.dx.resource.load.level.v3i32.tdx.Texture_v3i32_0_0_1_2t.v2i32.i32.v2i32(target("dx.Texture", <3 x i32>, 0, 0, 1, 2), <2 x i32>, i32, <2 x i32>)
-
-declare target("dx.Texture", <4 x float>, 0, 0, 0, 2) @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(i32, i32, i32, i32, ptr)
-declare target("dx.Texture", float, 0, 0, 0, 2) @llvm.dx.resource.handlefrombinding.tdx.Texture_f32_0_0_0_2t(i32, i32, i32, i32, ptr)
-declare target("dx.Texture", <3 x i32>, 0, 0, 1, 2) @llvm.dx.resource.handlefrombinding.tdx.Texture_v3i32_0_0_1_2t(i32, i32, i32, i32, ptr)


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/192546 and https://github.com/llvm/llvm-project/issues/192558

This PR defines the TextureLoad DXIL Op (opcode 66), and implements lowering of the texture load (dx_resource_load_level) intrinsic to the DXIL op.

This PR also implements the transformation of loads from texture resources (via dx_resource_getpointer) into dx_resource_load_level intrinsics.

Assisted-by: Claude Opus 4.7