### PR TITLE
[SSAF] Fix -Wunused-variable

### DIFF
--- a/clang/lib/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsageExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsageExtractor.cpp
@@ -114,8 +114,9 @@ void clang::ssaf::UnsafeBufferUsageTUSummaryExtractor::HandleTranslationUnit(
     if (!ContributorName)
       llvm::reportFatalInternalError(makeEntityNameErr(Ctx, CD));
 
-    auto [Ignored, InsertionSucceeded] = SummaryBuilder.addSummary(
-        SummaryBuilder.addEntity(*ContributorName), std::move(*EntitySummary));
+    [[maybe_unused]] auto [Ignored, InsertionSucceeded] =
+        SummaryBuilder.addSummary(SummaryBuilder.addEntity(*ContributorName),
+                                  std::move(*EntitySummary));
 
     assert(InsertionSucceeded && "duplicated contributor extraction");
   }


### PR DESCRIPTION
We currently take the return value of inserting into a map (the iterator
and insertion boolean) to assert on the value of the insertion boolean.
This is unused in non-asserts builds, so mark it [[maybe_unused]] given
we cannot inline due to the insertion having side effects.