### PR TITLE
[libcxx][Github] Build container images in separate jobs

### DIFF
--- a/.github/workflows/libcxx-build-containers.yml
+++ b/.github/workflows/libcxx-build-containers.yml
@@ -26,6 +26,9 @@ jobs:
   build-and-push:
     runs-on: ubuntu-24.04
     if: github.repository_owner == 'llvm'
+    strategy:
+      matrix:
+        image_names: ['libcxx-linux-builder-base', 'libcxx-linux-builder', 'libcxx-android-builder']
     permissions:
       packages: write
 
@@ -42,18 +45,8 @@ jobs:
         echo '{ "data-root": "/mnt/docker" }' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
 
-    - name: Build the base image
-      run: docker compose --file libcxx/utils/ci/docker/docker-compose.yml build libcxx-linux-builder-base
-      env:
-        TAG: ${{ github.sha }}
-
-    - name: Build the Linux Github Actions image
-      run: docker compose --file libcxx/utils/ci/docker/docker-compose.yml build libcxx-linux-builder
-      env:
-        TAG: ${{ github.sha }}
-
-    - name: Build the Android builder image
-      run: docker compose --file libcxx/utils/ci/docker/docker-compose.yml build libcxx-android-builder
+    - name: Build the image
+      run: docker compose --file libcxx/utils/ci/docker/docker-compose.yml build "${{ matrix.image_name }}"
       env:
         TAG: ${{ github.sha }}
 
@@ -64,8 +57,8 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Push the images
+    - name: Push the image
       if: github.event_name == 'push'
-      run: docker compose --file libcxx/utils/ci/docker/docker-compose.yml push libcxx-linux-builder-base libcxx-linux-builder libcxx-android-builder
+      run: docker compose --file libcxx/utils/ci/docker/docker-compose.yml push "${{ matrix.image_name }}"
       env:
         TAG: ${{ github.sha }}

--- a/.github/workflows/libcxx-build-containers.yml
+++ b/.github/workflows/libcxx-build-containers.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.repository_owner == 'llvm'
     strategy:
       matrix:
-        image_names: ['libcxx-linux-builder-base', 'libcxx-linux-builder', 'libcxx-android-builder']
+        image_name: ['libcxx-linux-builder-base', 'libcxx-linux-builder', 'libcxx-android-builder']
     permissions:
       packages: write
 


### PR DESCRIPTION
With some recent refactorings, these builds are almost entirely independent (minus some caching of pulled base images). Put them into separate jobs so we can take advantage of paralleism during the builds to get the total wall-time down.

This wouldn't have as big of an advantage if we were using the just built base image, but should still be wall-time advantagous even if we go back to doing that when relevant.