### PR TITLE
[libc][math] small typo

### DIFF
--- a/libc/src/__support/math/cosf.h
+++ b/libc/src/__support/math/cosf.h
@@ -170,6 +170,6 @@ LIBC_INLINE constexpr float cosf(float x) {
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC___SUPPORT_MATH_COSF_H
-
 #endif // LIBC_MATH_HAS_INTERMEDIATE_COMP_IN_FLOAT
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_COSF_H


### PR DESCRIPTION
small typo in "cosf.h" in comment . not a significant thing.