### PR TITLE
[libcxx][Github] Bump container version

### DIFF
--- a/libcxx/utils/ci/images/libcxx_next_runners.txt
+++ b/libcxx/utils/ci/images/libcxx_next_runners.txt
@@ -1,1 +1,1 @@
-ghcr.io/llvm/libcxx-linux-builder:1930089f256284c96442853137b6312370b7cc21
+ghcr.io/llvm/libcxx-linux-builder:d76111a9650d8d7540677af5ecfa8b958ab59851

--- a/libcxx/utils/ci/images/libcxx_runners.txt
+++ b/libcxx/utils/ci/images/libcxx_runners.txt
@@ -1,1 +1,1 @@
-ghcr.io/llvm/libcxx-linux-builder:a691a452b54ef24876f48ec0d854e6d6a59e97a7
+ghcr.io/llvm/libcxx-linux-builder:d76111a9650d8d7540677af5ecfa8b958ab59851


### PR DESCRIPTION
Now that the rebuilt container images are available with an upgraded
Github runner, bump to the latest image.