### PR TITLE
[MemProf] Skip GV `__prof*` during instrumentation

### DIFF
--- a/llvm/include/llvm/ProfileData/InstrProf.h
+++ b/llvm/include/llvm/ProfileData/InstrProf.h
@@ -119,6 +119,9 @@ inline StringRef getInstrProfValueProfMemOpFuncName() {
   return INSTR_PROF_VALUE_PROF_MEMOP_FUNC_STR;
 }
 
+/// Return the prefix of the name of the variables to function as a filter.
+inline StringRef getInstrProfVarPrefix() { return "__prof"; }
+
 /// Return the name prefix of variables containing instrumented function names.
 inline StringRef getInstrProfNameVarPrefix() { return "__profn_"; }
 

--- a/llvm/lib/Transforms/Instrumentation/MemProfInstrumentation.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemProfInstrumentation.cpp
@@ -375,7 +375,7 @@ MemProfiler::isInterestingMemoryAccess(Instruction *I) const {
 
     // Do not instrument accesses to LLVM internal variables.
     if (GV->getName().starts_with("__llvm") ||
-        GV->getName().starts_with(getInstrProfCountersVarPrefix()))
+        GV->getName().starts_with(getInstrProfVarPrefix()))
       return std::nullopt;
   }
 

--- a/llvm/lib/Transforms/Instrumentation/MemProfInstrumentation.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemProfInstrumentation.cpp
@@ -374,7 +374,8 @@ MemProfiler::isInterestingMemoryAccess(Instruction *I) const {
     }
 
     // Do not instrument accesses to LLVM internal variables.
-    if (GV->getName().starts_with("__llvm"))
+    if (GV->getName().starts_with("__llvm") ||
+        GV->getName().starts_with("__prof"))
       return std::nullopt;
   }
 

--- a/llvm/lib/Transforms/Instrumentation/MemProfInstrumentation.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemProfInstrumentation.cpp
@@ -375,7 +375,7 @@ MemProfiler::isInterestingMemoryAccess(Instruction *I) const {
 
     // Do not instrument accesses to LLVM internal variables.
     if (GV->getName().starts_with("__llvm") ||
-        GV->getName().starts_with("__prof"))
+        GV->getName().starts_with(getInstrProfCountersVarPrefix()))
       return std::nullopt;
   }
 


### PR DESCRIPTION
The existing filter in `isInterestingMemoryAccess` skips globals named `__llvm*`, but PGO counter globals are named `__profc_*` (and related `__profd_*`, `__profvp_*`, etc.), so they bypass the name check, e.g.: 

https://github.com/llvm/llvm-project/blob/b48d8a54e29f5f33ef52a4759414126904f01611/llvm/include/llvm/ProfileData/InstrProf.h#L128-L138

The section-based check above catches direct accesses where `stripInBoundsOffsets` resolves to the GlobalVariable, but fails for bias-based counter addressing `(inttoptr(add(ptrtoint(__profc_), bias)))` which the strip cannot see through.

This causes MemProf to instrument PGO counter updates, inflating MGO binary access profiles proportionally to __llvm_prf_cnts section size. Filtering `__prof` prefixed globals closes this gap.

RFC: we have confirmed `__prof*` are dead weight, whether we should block `llvm.*` like `InstrProfiling.cpp` did is an open question for ppl familiar with MemProf, e.g.:

https://github.com/llvm/llvm-project/blob/b48d8a54e29f5f33ef52a4759414126904f01611/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp#L1518-L1521