### PR TITLE
[CodeGen][NFC] Do not iterate in DCE unless needed

### DIFF
--- a/llvm/lib/CodeGen/DeadMachineInstructionElim.cpp
+++ b/llvm/lib/CodeGen/DeadMachineInstructionElim.cpp
@@ -31,7 +31,6 @@ STATISTIC(NumDeletes,          "Number of dead instructions deleted");
 namespace {
 class DeadMachineInstructionElimImpl {
   const MachineRegisterInfo *MRI = nullptr;
-  const TargetInstrInfo *TII = nullptr;
   LiveRegUnits LivePhysRegs;
 
 public:
@@ -80,13 +79,8 @@ bool DeadMachineInstructionElimImpl::runImpl(MachineFunction &MF) {
   MRI = &MF.getRegInfo();
 
   const TargetSubtargetInfo &ST = MF.getSubtarget();
-  TII = ST.getInstrInfo();
   LivePhysRegs.init(*ST.getRegisterInfo());
-
-  bool AnyChanges = eliminateDeadMI(MF);
-  while (AnyChanges && eliminateDeadMI(MF))
-    ;
-  return AnyChanges;
+  return eliminateDeadMI(MF);
 }
 
 bool DeadMachineInstructionElimImpl::eliminateDeadMI(MachineFunction &MF) {

--- a/llvm/lib/CodeGen/DeadMachineInstructionElim.cpp
+++ b/llvm/lib/CodeGen/DeadMachineInstructionElim.cpp
@@ -31,13 +31,14 @@ STATISTIC(NumDeletes,          "Number of dead instructions deleted");
 namespace {
 class DeadMachineInstructionElimImpl {
   const MachineRegisterInfo *MRI = nullptr;
+  const TargetInstrInfo *TII = nullptr;
   LiveRegUnits LivePhysRegs;
 
 public:
   bool runImpl(MachineFunction &MF);
 
 private:
-  bool eliminateDeadMI(MachineFunction &MF);
+  bool eliminateDeadMI(MachineFunction &MF, bool &NeedAnotherIteration);
 };
 
 class DeadMachineInstructionElim : public MachineFunctionPass {
@@ -79,24 +80,37 @@ bool DeadMachineInstructionElimImpl::runImpl(MachineFunction &MF) {
   MRI = &MF.getRegInfo();
 
   const TargetSubtargetInfo &ST = MF.getSubtarget();
+  TII = ST.getInstrInfo();
   LivePhysRegs.init(*ST.getRegisterInfo());
-  return eliminateDeadMI(MF);
+
+  bool NeedAnotherIteration;
+  bool AnyChanges = eliminateDeadMI(MF, NeedAnotherIteration);
+  while (NeedAnotherIteration)
+    eliminateDeadMI(MF, NeedAnotherIteration);
+  return AnyChanges;
 }
 
-bool DeadMachineInstructionElimImpl::eliminateDeadMI(MachineFunction &MF) {
+bool DeadMachineInstructionElimImpl::eliminateDeadMI(
+    MachineFunction &MF, bool &NeedAnotherIteration) {
   bool AnyChanges = false;
+  SmallPtrSet<MachineBasicBlock *, 4> NeedsProcessing;
 
   // Loop over all instructions in all blocks, from bottom to top, so that it's
   // more likely that chains of dependent but ultimately dead instructions will
   // be cleaned up.
   for (MachineBasicBlock *MBB : post_order(&MF)) {
     LivePhysRegs.addLiveOuts(*MBB);
+    NeedsProcessing.erase(MBB);
 
     // Now scan the instructions and delete dead ones, tracking physreg
     // liveness as we go.
     for (MachineInstr &MI : make_early_inc_range(reverse(*MBB))) {
       // If the instruction is dead, delete it!
       if (MI.isDead(*MRI, &LivePhysRegs)) {
+        if (MI.isPHI()) {
+          for (MachineBasicBlock *P : MBB->predecessors())
+            NeedsProcessing.insert(P);
+        }
         LLVM_DEBUG(dbgs() << "DeadMachineInstructionElim: DELETING: " << MI);
         // It is possible that some DBG_VALUE instructions refer to this
         // instruction. They will be deleted in the live debug variable
@@ -110,5 +124,6 @@ bool DeadMachineInstructionElimImpl::eliminateDeadMI(MachineFunction &MF) {
     }
   }
   LivePhysRegs.clear();
+  NeedAnotherIteration = !NeedsProcessing.empty();
   return AnyChanges;
 }

--- a/llvm/test/CodeGen/ARM/fp16-promote.ll
+++ b/llvm/test/CodeGen/ARM/fp16-promote.ll
@@ -554,10 +554,9 @@ define void @test_phi(ptr %p) #0 {
 ; CHECK-VFP-NEXT:    ldrh r6, [r0]
 ; CHECK-VFP-NEXT:    mov r4, r0
 ; CHECK-VFP-NEXT:  .LBB13_1:
+; CHECK-VFP-NEXT:    mov r0, r4
 ; CHECK-VFP-NEXT:    mov r5, r6
 ; CHECK-VFP-NEXT:    ldrh r6, [r4]
-; CHECK-VFP-NEXT:    mov r0, r4
-; CHECK-VFP-NEXT:    vmov s0, r6
 ; CHECK-VFP-NEXT:    bl test_dummy
 ; CHECK-VFP-NEXT:    tst r0, #1
 ; CHECK-VFP-NEXT:    bne .LBB13_1

--- a/llvm/test/CodeGen/ARM/fp16-promote.ll
+++ b/llvm/test/CodeGen/ARM/fp16-promote.ll
@@ -554,9 +554,10 @@ define void @test_phi(ptr %p) #0 {
 ; CHECK-VFP-NEXT:    ldrh r6, [r0]
 ; CHECK-VFP-NEXT:    mov r4, r0
 ; CHECK-VFP-NEXT:  .LBB13_1:
-; CHECK-VFP-NEXT:    mov r0, r4
 ; CHECK-VFP-NEXT:    mov r5, r6
 ; CHECK-VFP-NEXT:    ldrh r6, [r4]
+; CHECK-VFP-NEXT:    mov r0, r4
+; CHECK-VFP-NEXT:    vmov s0, r6
 ; CHECK-VFP-NEXT:    bl test_dummy
 ; CHECK-VFP-NEXT:    tst r0, #1
 ; CHECK-VFP-NEXT:    bne .LBB13_1


### PR DESCRIPTION
Almost all dead code is found in the first iteration.

In LLVM lit tests, 461931 instructions were deleted in the first iteration and 2 in the second.

In a 3-stage build of llvm, 1305507 instructions were deleted in the first iteration and 0 in the second.

Added code to detect when another DCE iteration is needed.  Number of DCE iterations will almost always be reduced from 2 to 1.