### PR TITLE
[RISCV][P-ext] Custom legalize vector (setne X, allzeros) and (setgt X, allones)

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -593,9 +593,10 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
     setOperationAction(ISD::SELECT, VTs, Custom);
     setOperationAction(ISD::VSELECT, VTs, Legal);
     setOperationAction(ISD::SETCC, VTs, Legal);
-    setCondCodeAction({ISD::SETNE, ISD::SETGT, ISD::SETGE, ISD::SETUGT,
+    setCondCodeAction({ISD::SETGE, ISD::SETUGT,
                        ISD::SETUGE, ISD::SETULE, ISD::SETLE},
                       VTs, Expand);
+    setCondCodeAction({ISD::SETNE, ISD::SETGT}, VTs, Custom);
 
     if (!Subtarget.is64Bit())
       setOperationAction(ISD::BUILD_VECTOR, MVT::v4i8, Custom);
@@ -8736,6 +8737,38 @@ SDValue RISCVTargetLowering::LowerOperation(SDValue Op,
       // SETLT/SETULT.
       CCVal = ISD::getSetCCSwappedOperands(CCVal);
       return DAG.getSetCC(DL, VT, RHS, LHS, CCVal);
+    }
+
+    MVT VT = Op.getSimpleValueType();
+    if (Subtarget.hasStdExtP() && VT.isFixedLengthVector()) {
+      ISD::CondCode CCVal = cast<CondCodeSDNode>(Op.getOperand(2))->get();
+      SDValue LHS = Op.getOperand(0);
+      SDValue RHS = Op.getOperand(1);
+      SDLoc DL(Op);
+      if (CCVal == ISD::SETNE) {
+        // Convert setne X, 0 to setult 0, X.
+        if (ISD::isConstantSplatVectorAllZeros(RHS.getNode())) {
+          return DAG.getSetCC(DL, VT, RHS, LHS, ISD::SETULT);
+        }
+
+        // Not a constant we could handle, convert to SETEQ+Invert
+        SDValue SetCC = DAG.getSetCC(DL, VT, LHS, RHS, ISD::SETEQ);
+        return DAG.getLogicalNOT(DL, SetCC, VT);
+      }
+
+      if (CCVal == ISD::SETGT) {
+        if (ISD::isConstantSplatVectorAllOnes(RHS.getNode())) {
+          SDValue SetCC = DAG.getSetCC(DL, VT, LHS, DAG.getConstant(0, DL, VT), ISD::SETLT);
+          return DAG.getLogicalNOT(DL, SetCC, VT);
+        }
+
+        // Not a constant we could handle, swap the operands and condition code
+        // to SETLT.
+        CCVal = ISD::getSetCCSwappedOperands(CCVal);
+        return DAG.getSetCC(DL, VT, RHS, LHS, CCVal);
+      }
+
+      return SDValue();
     }
 
     if (isPromotedOpNeedingSplit(Op.getOperand(0), Subtarget))

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -593,9 +593,9 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
     setOperationAction(ISD::SELECT, VTs, Custom);
     setOperationAction(ISD::VSELECT, VTs, Legal);
     setOperationAction(ISD::SETCC, VTs, Legal);
-    setCondCodeAction({ISD::SETGE, ISD::SETUGT,
-                       ISD::SETUGE, ISD::SETULE, ISD::SETLE},
-                      VTs, Expand);
+    setCondCodeAction(
+        {ISD::SETGE, ISD::SETUGT, ISD::SETUGE, ISD::SETULE, ISD::SETLE}, VTs,
+        Expand);
     setCondCodeAction({ISD::SETNE, ISD::SETGT}, VTs, Custom);
 
     if (!Subtarget.is64Bit())
@@ -8758,7 +8758,8 @@ SDValue RISCVTargetLowering::LowerOperation(SDValue Op,
 
       if (CCVal == ISD::SETGT) {
         if (ISD::isConstantSplatVectorAllOnes(RHS.getNode())) {
-          SDValue SetCC = DAG.getSetCC(DL, VT, LHS, DAG.getConstant(0, DL, VT), ISD::SETLT);
+          SDValue SetCC =
+              DAG.getSetCC(DL, VT, LHS, DAG.getConstant(0, DL, VT), ISD::SETLT);
           return DAG.getLogicalNOT(DL, SetCC, VT);
         }
 

--- a/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
@@ -1710,6 +1710,17 @@ define <2 x i16> @test_ne_h(<2 x i16> %a, <2 x i16> %b) {
   ret <2 x i16> %res
 }
 
+define <2 x i16> @test_nez_h(<2 x i16> %a, <2 x i16> %b) {
+; CHECK-LABEL: test_nez_h:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pmseqz.h a0, a0
+; CHECK-NEXT:    not a0, a0
+; CHECK-NEXT:    ret
+  %cmp = icmp ne <2 x i16> %a, splat (i16 0)
+  %res = sext <2 x i1> %cmp to <2 x i16>
+  ret <2 x i16> %res
+}
+
 define <2 x i16> @test_slt_h(<2 x i16> %a, <2 x i16> %b) {
 ; CHECK-LABEL: test_slt_h:
 ; CHECK:       # %bb.0:
@@ -1748,6 +1759,17 @@ define <2 x i16> @test_sge_h(<2 x i16> %a, <2 x i16> %b) {
 ; CHECK-NEXT:    not a0, a0
 ; CHECK-NEXT:    ret
   %cmp = icmp sge <2 x i16> %a, %b
+  %res = sext <2 x i1> %cmp to <2 x i16>
+  ret <2 x i16> %res
+}
+
+define <2 x i16> @test_sgez_h(<2 x i16> %a, <2 x i16> %b) {
+; CHECK-LABEL: test_sgez_h:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    li a1, -1
+; CHECK-NEXT:    pmslt.h a0, a1, a0
+; CHECK-NEXT:    ret
+  %cmp = icmp sgt <2 x i16> %a, splat (i16 -1);
   %res = sext <2 x i1> %cmp to <2 x i16>
   ret <2 x i16> %res
 }
@@ -1979,10 +2001,10 @@ define <2 x i16> @test_select_v2i16(i1 %cond, <2 x i16> %a, <2 x i16> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB140_2
+; CHECK-NEXT:    bnez a3, .LBB142_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB140_2:
+; CHECK-NEXT:  .LBB142_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <2 x i16> %a, <2 x i16> %b
   ret <2 x i16> %res
@@ -1993,10 +2015,10 @@ define <4 x i8> @test_select_v4i8(i1 %cond, <4 x i8> %a, <4 x i8> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB141_2
+; CHECK-NEXT:    bnez a3, .LBB143_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB141_2:
+; CHECK-NEXT:  .LBB143_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <4 x i8> %a, <4 x i8> %b
   ret <4 x i8> %res

--- a/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
@@ -1713,8 +1713,7 @@ define <2 x i16> @test_ne_h(<2 x i16> %a, <2 x i16> %b) {
 define <2 x i16> @test_nez_h(<2 x i16> %a, <2 x i16> %b) {
 ; CHECK-LABEL: test_nez_h:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pmseqz.h a0, a0
-; CHECK-NEXT:    not a0, a0
+; CHECK-NEXT:    pmsnez.h a0, a0
 ; CHECK-NEXT:    ret
   %cmp = icmp ne <2 x i16> %a, splat (i16 0)
   %res = sext <2 x i1> %cmp to <2 x i16>
@@ -1766,8 +1765,8 @@ define <2 x i16> @test_sge_h(<2 x i16> %a, <2 x i16> %b) {
 define <2 x i16> @test_sgez_h(<2 x i16> %a, <2 x i16> %b) {
 ; CHECK-LABEL: test_sgez_h:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    li a1, -1
-; CHECK-NEXT:    pmslt.h a0, a1, a0
+; CHECK-NEXT:    pmsltz.h a0, a0
+; CHECK-NEXT:    not a0, a0
 ; CHECK-NEXT:    ret
   %cmp = icmp sgt <2 x i16> %a, splat (i16 -1);
   %res = sext <2 x i1> %cmp to <2 x i16>


### PR DESCRIPTION
(setne X, allzeros) can be lowered to (setult X0, X).

(setgt X, allones) can be lowered to (not (setlt X, 0)). The not
can often be folded into and, orn, xnor, or merge.