### PR TITLE
Fix test added in 849de61 to work when the compiler defaults to C++20.

### DIFF
--- a/clang/test/APINotes/unsafe-buffer-usage.cpp
+++ b/clang/test/APINotes/unsafe-buffer-usage.cpp
@@ -1,14 +1,27 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
-// RUN:             -I %S/Inputs/Headers %s -x c++ -verify -Wunsafe-buffer-usage -Wno-unused-value
+// RUN:             -I %S/Inputs/Headers %s -x c++ -std=c++17 -verify -Wunsafe-buffer-usage -Wno-unused-value
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
-// RUN:             -I %S/Inputs/Headers %s -x c++ -Wunused-value -ast-dump -ast-dump-filter unsafeFunc | FileCheck %s --check-prefixes=CHECK-UNSAFE
+// RUN:             -I %S/Inputs/Headers %s -x c++ -std=c++17 -Wunused-value -ast-dump -ast-dump-filter unsafeFunc | FileCheck %s --check-prefixes=CHECK-UNSAFE
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
-// RUN:             -I %S/Inputs/Headers %s -x c++ -Wunused-value -ast-dump -ast-dump-filter annotatedUnsafeFunc | FileCheck %s --check-prefixes=CHECK-ANNO
+// RUN:             -I %S/Inputs/Headers %s -x c++ -std=c++17 -Wunused-value -ast-dump -ast-dump-filter annotatedUnsafeFunc | FileCheck %s --check-prefixes=CHECK-ANNO
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
-// RUN:             -I %S/Inputs/Headers %s -x c++ -Wunused-value -ast-dump -ast-dump-filter falseAPINotesButAnnotatedUnsafeFunc | FileCheck %s --check-prefixes=CHECK-ANNO-FALSE
+// RUN:             -I %S/Inputs/Headers %s -x c++ -std=c++17 -Wunused-value -ast-dump -ast-dump-filter falseAPINotesButAnnotatedUnsafeFunc | FileCheck %s --check-prefixes=CHECK-ANNO-FALSE
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
-// RUN:             -I %S/Inputs/Headers %s -x c++ -Wunused-value -ast-dump -ast-dump-filter funcWithoutAnnotation | FileCheck %s --check-prefixes=CHECK-UNANNO
+// RUN:             -I %S/Inputs/Headers %s -x c++ -std=c++17 -Wunused-value -ast-dump -ast-dump-filter funcWithoutAnnotation | FileCheck %s --check-prefixes=CHECK-UNANNO
+
+// C++20 mode
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
+// RUN:             -I %S/Inputs/Headers %s -x c++ -std=c++20 -verify=expected,cpp20 -Wunsafe-buffer-usage -Wno-unused-value
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
+// RUN:             -I %S/Inputs/Headers %s -x c++ -std=c++20 -Wunused-value -ast-dump -ast-dump-filter unsafeFunc | FileCheck %s --check-prefixes=CHECK-UNSAFE
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
+// RUN:             -I %S/Inputs/Headers %s -x c++ -std=c++20 -Wunused-value -ast-dump -ast-dump-filter annotatedUnsafeFunc | FileCheck %s --check-prefixes=CHECK-ANNO
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
+// RUN:             -I %S/Inputs/Headers %s -x c++ -std=c++20 -Wunused-value -ast-dump -ast-dump-filter falseAPINotesButAnnotatedUnsafeFunc | FileCheck %s --check-prefixes=CHECK-ANNO-FALSE
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
+// RUN:             -I %S/Inputs/Headers %s -x c++ -std=c++20 -Wunused-value -ast-dump -ast-dump-filter funcWithoutAnnotation | FileCheck %s --check-prefixes=CHECK-UNANNO
 
 #include "UnsafeBufferUsage.h"
 
@@ -44,11 +57,15 @@ void falseAPINotesButAnnotatedUnsafeFunc(int *p, int n) {
 
 void funcWithoutAnnotation(int *p, int n) {
   p[n]; // expected-warning{{unsafe buffer access}}
+        // cpp20-note@-1{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
 }
 
 void caller(int *p, int n) {
   unsafeFunc(p, n); // expected-warning{{function introduces unsafe buffer manipulation}}
+                    // cpp20-note@-1{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
   annotatedUnsafeFunc(p, n); // expected-warning{{function introduces unsafe buffer manipulation}}
+                             // cpp20-note@-1{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
   falseAPINotesButAnnotatedUnsafeFunc(p, n); // expected-warning{{function introduces unsafe buffer manipulation}}
+                                             // cpp20-note@-1{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
   funcWithoutAnnotation(p, n);   // no warning
 }


### PR DESCRIPTION
Our downstream compiler defaults to C++20 mode which causes the test added in #189775 to fail due to some additional notes that are emitted which causes the `-verify` steps to fail.
```
# .---command stderr------------
# | error: 'cpp20-note' diagnostics seen but not expected:                                                                                                                                                                                                                                        
# |   File /home/dyung/src/git/merge/clang/test/APINotes/unsafe-buffer-usage.cpp Line 59: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions                                                                                                                              
# |   File /home/dyung/src/git/merge/clang/test/APINotes/unsafe-buffer-usage.cpp Line 64: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions                                                                                                                              
# |   File /home/dyung/src/git/merge/clang/test/APINotes/unsafe-buffer-usage.cpp Line 65: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions                                                                                                                              
# |   File /home/dyung/src/git/merge/clang/test/APINotes/unsafe-buffer-usage.cpp Line 66: pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions                                                                                                                              
# | 4 errors generated.                                                                                                                                                                                                                                                                           
# `-----------------------------   
```

This change updates the test to work with both C++17 and C++20 by explicitly testing both modes and adding the extra expected notes when in C++20 mode.