### PR TITLE
[clang] Add constant evaluation support for CK_ToUnion.

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -1007,6 +1007,31 @@ bool Compiler<Emitter>::VisitCastExpr(const CastExpr *E) {
     return true;
   }
 
+  case CK_ToUnion: {
+    const FieldDecl *UnionField = E->getTargetUnionField();
+    const Record *R = this->getRecord(E->getType());
+    assert(R);
+    const Record::Field *RF = R->getField(UnionField);
+    QualType FieldType = RF->Decl->getType();
+
+    if (OptPrimType PT = classify(FieldType)) {
+      if (!this->visit(SubExpr))
+        return false;
+      if (RF->isBitField())
+        return this->emitInitBitFieldActivate(*PT, RF->Offset, RF->bitWidth(),
+                                              E);
+      return this->emitInitFieldActivate(*PT, RF->Offset, E);
+    }
+
+    if (!this->emitGetPtrField(RF->Offset, E))
+      return false;
+    if (!this->emitActivate(E))
+      return false;
+    if (!this->visitInitializer(SubExpr))
+      return false;
+    return this->emitPopPtr(E);
+  }
+
   default:
     return this->emitInvalid(E);
   }

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -11213,6 +11213,22 @@ bool RecordExprEvaluator::VisitCastExpr(const CastExpr *E) {
 
     return true;
   }
+  case CK_ToUnion: {
+    const FieldDecl *Field = E->getTargetUnionField();
+    LValue Subobject = This;
+    if (!HandleLValueMember(Info, E, Subobject, Field))
+      return false;
+    Result = APValue(Field);
+    if (!EvaluateInPlace(Result.getUnionValue(), Info, Subobject,
+                         E->getSubExpr()))
+      return false;
+    if (Field->isBitField()) {
+      if (!truncateBitfieldValue(Info, E->getSubExpr(), Result.getUnionValue(),
+                                 Field))
+        return false;
+    }
+    return true;
+  }
   }
 }
 

--- a/clang/lib/CodeGen/CGExprConstant.cpp
+++ b/clang/lib/CodeGen/CGExprConstant.cpp
@@ -1146,7 +1146,7 @@ EmitArrayConstant(CodeGenModule &CGM, llvm::ArrayType *DesiredType,
 // handled by constant folding.
 //
 // Constant folding is currently missing support for a few features supported
-// here: CK_ToUnion, CK_ReinterpretMemberPointer, and DesignatedInitUpdateExpr.
+// here: CK_ReinterpretMemberPointer, and DesignatedInitUpdateExpr.
 class ConstExprEmitter
     : public ConstStmtVisitor<ConstExprEmitter, llvm::Constant *, QualType> {
   CodeGenModule &CGM;

--- a/clang/test/AST/ByteCode/const-eval.c
+++ b/clang/test/AST/ByteCode/const-eval.c
@@ -179,3 +179,9 @@ void f0(void) { static intptr_t l0 = (unsigned)(intptr_t) f0;} // both-error {{i
 #else
 #error :(
 #endif
+
+struct ToUnion_X { int a; };
+union ToUnion_U { struct ToUnion_X x; double y; int z : 3; };
+_Static_assert(((union ToUnion_U)(struct ToUnion_X){67}).x.a == 67, "");
+_Static_assert(((union ToUnion_U)1.0).y == 1.0, "");
+_Static_assert(((union ToUnion_U)9).z == 1, "");


### PR DESCRIPTION
Implementation is heavily based on the evaluation code for initializer lists, but it's different enough that I couldn't figure out a good way to share the code.

This fixes one of the few remaining gaps where CodeGen can constant-evaluate a value which AST can't evaluate.