### PR TITLE
[lldb] Scope symbol lookups to specific modules in ObjC/SystemRuntime plugins

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
@@ -459,20 +459,30 @@ bool AppleObjCRuntime::CalculateHasNewLiteralsAndIndexing() {
   if (!m_process)
     return false;
 
-  Target &target(m_process->GetTarget());
+  Target &target = m_process->GetTarget();
 
   static ConstString s_method_signature(
       "-[NSDictionary objectForKeyedSubscript:]");
   static ConstString s_arclite_method_signature(
       "__arclite_objectForKeyedSubscript");
+  // NSDictionary is toll-free bridged with CFDictionary, so the
+  // implementation lives in CoreFoundation, not Foundation.
+  static ModuleSpec corefoundation_module_spec(FileSpec("CoreFoundation"));
 
+  if (ModuleSP corefoundation_module_sp =
+          target.GetImages().FindFirstModule(corefoundation_module_spec)) {
+    const Symbol *method_symbol =
+        corefoundation_module_sp->FindFirstSymbolWithNameAndType(
+            s_method_signature, eSymbolTypeCode);
+    if (method_symbol)
+      return true;
+  }
+
+  // The arclite variant is a static library linked into the main executable,
+  // not part of CoreFoundation, so search all images.
   SymbolContextList sc_list;
-
-  target.GetImages().FindSymbolsWithNameAndType(s_method_signature,
+  target.GetImages().FindSymbolsWithNameAndType(s_arclite_method_signature,
                                                 eSymbolTypeCode, sc_list);
-  if (sc_list.IsEmpty())
-    target.GetImages().FindSymbolsWithNameAndType(s_arclite_method_signature,
-                                                  eSymbolTypeCode, sc_list);
   return !sc_list.IsEmpty();
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -3481,28 +3481,29 @@ bool AppleObjCRuntimeV2::GetCFBooleanValuesIfNeeded() {
   static ConstString g_kCFBooleanFalse("kCFBooleanFalse");
   static ConstString g_kCFBooleanTrue("kCFBooleanTrue");
 
-  std::function<lldb::addr_t(ConstString, ConstString)> get_symbol =
-      [this](ConstString sym, ConstString real_sym) -> lldb::addr_t {
-    SymbolContextList sc_list;
-    GetProcess()->GetTarget().GetImages().FindSymbolsWithNameAndType(
-        sym, lldb::eSymbolTypeData, sc_list);
-    if (sc_list.GetSize() == 1) {
-      SymbolContext sc;
-      sc_list.GetContextAtIndex(0, sc);
-      if (sc.symbol)
-        return sc.symbol->GetLoadAddress(&GetProcess()->GetTarget());
-    }
-    GetProcess()->GetTarget().GetImages().FindSymbolsWithNameAndType(
-        real_sym, lldb::eSymbolTypeData, sc_list);
-    if (sc_list.GetSize() != 1)
+  static ModuleSpec corefoundation_module_spec(FileSpec("CoreFoundation"));
+
+  ModuleSP corefoundation_module_sp =
+      GetProcess()->GetTarget().GetImages().FindFirstModule(
+          corefoundation_module_spec);
+
+  if (!corefoundation_module_sp)
+    return false;
+
+  auto get_symbol = [this, &corefoundation_module_sp](
+                        ConstString sym, ConstString real_sym) -> lldb::addr_t {
+    const Symbol *symbol =
+        corefoundation_module_sp->FindFirstSymbolWithNameAndType(
+            sym, lldb::eSymbolTypeData);
+    if (symbol)
+      return symbol->GetLoadAddress(&GetProcess()->GetTarget());
+
+    symbol = corefoundation_module_sp->FindFirstSymbolWithNameAndType(
+        real_sym, lldb::eSymbolTypeData);
+    if (!symbol)
       return LLDB_INVALID_ADDRESS;
 
-    SymbolContext sc;
-    sc_list.GetContextAtIndex(0, sc);
-    if (!sc.symbol)
-      return LLDB_INVALID_ADDRESS;
-
-    lldb::addr_t addr = sc.symbol->GetLoadAddress(&GetProcess()->GetTarget());
+    lldb::addr_t addr = symbol->GetLoadAddress(&GetProcess()->GetTarget());
     Status error;
     addr = GetProcess()->ReadPointerFromMemory(addr, error);
     if (error.Fail())

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/SystemRuntimeMacOSX.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/SystemRuntimeMacOSX.cpp
@@ -620,10 +620,15 @@ bool SystemRuntimeMacOSX::BacktraceRecordingHeadersInitialized() {
   addr_t item_info_data_offset_address = LLDB_INVALID_ADDRESS;
   Target &target = m_process->GetTarget();
 
+  ModuleSpec lookup_spec(FileSpec("libBacktraceRecording.dylib"));
+  ModuleSP module_sp(target.GetImages().FindFirstModule(lookup_spec));
+  if (!module_sp)
+    return false;
+
   static ConstString introspection_dispatch_queue_info_version(
       "__introspection_dispatch_queue_info_version");
   SymbolContextList sc_list;
-  m_process->GetTarget().GetImages().FindSymbolsWithNameAndType(
+  module_sp->FindSymbolsWithNameAndType(
       introspection_dispatch_queue_info_version, eSymbolTypeData, sc_list);
   if (!sc_list.IsEmpty()) {
     SymbolContext sc;
@@ -635,7 +640,7 @@ bool SystemRuntimeMacOSX::BacktraceRecordingHeadersInitialized() {
 
   static ConstString introspection_dispatch_queue_info_data_offset(
       "__introspection_dispatch_queue_info_data_offset");
-  m_process->GetTarget().GetImages().FindSymbolsWithNameAndType(
+  module_sp->FindSymbolsWithNameAndType(
       introspection_dispatch_queue_info_data_offset, eSymbolTypeData, sc_list);
   if (!sc_list.IsEmpty()) {
     SymbolContext sc;
@@ -647,7 +652,7 @@ bool SystemRuntimeMacOSX::BacktraceRecordingHeadersInitialized() {
 
   static ConstString introspection_dispatch_item_info_version(
       "__introspection_dispatch_item_info_version");
-  m_process->GetTarget().GetImages().FindSymbolsWithNameAndType(
+  module_sp->FindSymbolsWithNameAndType(
       introspection_dispatch_item_info_version, eSymbolTypeData, sc_list);
   if (!sc_list.IsEmpty()) {
     SymbolContext sc;
@@ -659,7 +664,7 @@ bool SystemRuntimeMacOSX::BacktraceRecordingHeadersInitialized() {
 
   static ConstString introspection_dispatch_item_info_data_offset(
       "__introspection_dispatch_item_info_data_offset");
-  m_process->GetTarget().GetImages().FindSymbolsWithNameAndType(
+  module_sp->FindSymbolsWithNameAndType(
       introspection_dispatch_item_info_data_offset, eSymbolTypeData, sc_list);
   if (!sc_list.IsEmpty()) {
     SymbolContext sc;


### PR DESCRIPTION
This narrows `FindSymbolsWithNameAndType` calls from searching all loaded images to the specific module that owns the symbol (Foundation, CoreFoundation, libBacktraceRecording.dylib).

The arclite fallback in `CalculateHasNewLiteralsAndIndexing` still searches all images because libarclite is a static library linked into the main executable.