### PR TITLE
[HLSL] Update global array convergence test

### DIFF
--- a/clang/test/CodeGenHLSL/convergence/global_array.hlsl
+++ b/clang/test/CodeGenHLSL/convergence/global_array.hlsl
@@ -13,5 +13,4 @@ static RWBuffer<float> s[2];
 
 [numthreads(1,1,1)]
 void main() {
-  s[0][0] = 1.0;
 }

--- a/clang/test/CodeGenHLSL/convergence/global_array.hlsl
+++ b/clang/test/CodeGenHLSL/convergence/global_array.hlsl
@@ -6,17 +6,14 @@
 
 // CHECK: [[loop_entry]]:
 // CHECK: [[loop_token:%.*]] = call token @llvm.experimental.convergence.loop() [ "convergencectrl"(token [[entry_token]]) ]
-// CHECK: call spir_func void {{.*}} [ "convergencectrl"(token [[loop_token]]) ]
+// CHECK: call void {{.*}} [ "convergencectrl"(token [[loop_token]]) ]
 // CHECK: br i1 {{%.*}} label {{%.*}} label %[[loop_entry]]
 
-struct S {
-    int i;
-    S() { i = 10; }
-};
+RWBuffer<float> b[2];
+static RWBuffer<float> s[2];
 
-static S s[2];
-
-[numthreads(4,1,1)]
+[numthreads(1,1,1)]
 void main() {
+  s = b;
+  s[0][0] = 1.0;
 }
-

--- a/clang/test/CodeGenHLSL/convergence/global_array.hlsl
+++ b/clang/test/CodeGenHLSL/convergence/global_array.hlsl
@@ -9,11 +9,9 @@
 // CHECK: call void {{.*}} [ "convergencectrl"(token [[loop_token]]) ]
 // CHECK: br i1 {{%.*}} label {{%.*}} label %[[loop_entry]]
 
-RWBuffer<float> b[2];
 static RWBuffer<float> s[2];
 
 [numthreads(1,1,1)]
 void main() {
-  s = b;
   s[0][0] = 1.0;
 }


### PR DESCRIPTION
Updates global array initialization convergence test to use static array of resources instead of a user-defined struct with a constructor. The test will no longer work as is once the support for user-defined constructors is removed (#193375).