### PR TITLE
[lldb] Fix empty backtraces for scripted threads with no artificial frames

### DIFF
--- a/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
@@ -164,6 +164,11 @@ bool ScriptedThread::LoadArtificialStackFrames() {
         error, LLDBLog::Thread);
 
   size_t arr_size = arr_sp->GetSize();
+  if (!arr_size)
+    return ScriptedInterface::ErrorWithMessage<bool>(
+        LLVM_PRETTY_FUNCTION, "StackFrame array is empty.", error,
+        LLDBLog::Thread);
+
   if (arr_size > std::numeric_limits<uint32_t>::max())
     return ScriptedInterface::ErrorWithMessage<bool>(
         LLVM_PRETTY_FUNCTION,


### PR DESCRIPTION
Following 86aa43999bec, `ScriptedThread::LoadArtificialStackFrames` unconditionally calls `SetAllFramesFetched` even when the scripted thread provided zero artificial stack frames via `get_stackframes`.

This prevents the normal unwinder from creating frames from the register context, leaving `m_frames` empty. When GetFrameAtIndex(0) is subsequently called, it triggered the follow on assertion builds:

```
  assert(!m_thread.IsValid() && "A valid thread has no frames.")
```

This affects scripted threads that provide register context via `get_register_context` but rely on the unwinder for frame creation rather than overriding `get_stackframes`.

This patch fixes the issue by returning early in `LoadArtificialStackFrames` in case the scripted thread StackFrame array is empty, preventing it from calling `SetAllFramesFetched` on it's StackFrameList.

rdar://175019759