### PR TITLE
[compiler-rt] [Darwin] Enable arm64e tests on macOS

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -182,33 +182,33 @@ endfunction()
 function(darwin_filter_host_archs input output)
   list_intersect(tmp_var DARWIN_osx_ARCHS ${input})
   execute_process(
-    COMMAND sysctl hw.cputype
-    OUTPUT_VARIABLE CPUTYPE)
-  string(REGEX MATCH "hw.cputype: ([0-9]*)"
-         CPUTYPE_MATCHED "${CPUTYPE}")
-  set(ARM_HOST Off)
-  if(CPUTYPE_MATCHED)
-    # ARM cputype is (0x01000000 | 12) and X86(_64) is always 7.
-    if(${CMAKE_MATCH_1} GREATER 11)
-      set(ARM_HOST On)
-    endif()
+    COMMAND sysctl hw.optional.arm64
+    OUTPUT_VARIABLE IS_ARM64)
+  string(REGEX MATCH "hw.optional.arm64: ([0-9]*)"
+         ARM64_MATCHED "${IS_ARM64}")
+
+  set(ARM_HOST OFF)
+  if(ARM64_MATCHED AND ("${CMAKE_MATCH_1}" STREQUAL "1"))
+    set(ARM_HOST ON)
   endif()
 
-  # arm64e isn't usually supported out of the box on darwin, because of ABI.
-  list(REMOVE_ITEM tmp_var arm64e)
+  execute_process(
+    COMMAND sysctl hw.cpusubtype
+    OUTPUT_VARIABLE SUBTYPE)
+  string(REGEX MATCH "hw.cpusubtype: ([0-9]*)"
+          SUBTYPE_MATCHED "${SUBTYPE}")
+
+  if(NOT COMPILER_RT_HAS_MAC_PUBLIC_ARM64E)
+    list(REMOVE_ITEM tmp_var arm64e)
+  endif()
 
   if(ARM_HOST)
     list(REMOVE_ITEM tmp_var i386)
     list(REMOVE_ITEM tmp_var x86_64)
     list(REMOVE_ITEM tmp_var x86_64h)
   else()
+    list(REMOVE_ITEM tmp_var arm64e)
     list(REMOVE_ITEM tmp_var arm64)
-    execute_process(
-      COMMAND sysctl hw.cpusubtype
-      OUTPUT_VARIABLE SUBTYPE)
-    string(REGEX MATCH "hw.cpusubtype: ([0-9]*)"
-           SUBTYPE_MATCHED "${SUBTYPE}")
-
     set(HASWELL_SUPPORTED Off)
     if(SUBTYPE_MATCHED)
       if(${CMAKE_MATCH_1} GREATER 7)

--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -198,14 +198,13 @@ function(darwin_filter_host_archs input output)
   string(REGEX MATCH "hw.cpusubtype: ([0-9]*)"
           SUBTYPE_MATCHED "${SUBTYPE}")
 
-  if(NOT COMPILER_RT_HAS_MAC_PUBLIC_ARM64E)
-    list(REMOVE_ITEM tmp_var arm64e)
-  endif()
-
   if(ARM_HOST)
     list(REMOVE_ITEM tmp_var i386)
     list(REMOVE_ITEM tmp_var x86_64)
     list(REMOVE_ITEM tmp_var x86_64h)
+    if(NOT COMPILER_RT_HAS_MAC_PUBLIC_ARM64E)
+      list(REMOVE_ITEM tmp_var arm64e)
+    endif()
   else()
     list(REMOVE_ITEM tmp_var arm64e)
     list(REMOVE_ITEM tmp_var arm64)

--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -226,6 +226,10 @@ if(COMPILER_RT_HAS_GNU_VERSION_SCRIPT_COMPAT)
 endif()
 llvm_check_compiler_linker_flag(C "${VERS_OPTION}" COMPILER_RT_HAS_VERSION_SCRIPT)
 
+if(APPLE)
+  llvm_check_compiler_linker_flag(C "-Wl,-mac_public_arm64e" COMPILER_RT_HAS_MAC_PUBLIC_ARM64E)
+endif()
+
 if(ANDROID)
   llvm_check_compiler_linker_flag(C "-Wl,-z,global" COMPILER_RT_HAS_Z_GLOBAL)
   check_library_exists(log __android_log_write "" COMPILER_RT_HAS_LIBLOG)


### PR DESCRIPTION
This enables compiler-rt tests on Darwin arm64e (when supported by the linker).

Note that arm64e is not enabled for sanitizers yet, but this does add test coverage for builtins.

rdar://175303507