### PR TITLE
[lldb] Fix potential TestAlwaysRunThreadNames flakiness

### DIFF
--- a/lldb/test/API/functionalities/always-run-threads/TestAlwaysRunThreadNames.py
+++ b/lldb/test/API/functionalities/always-run-threads/TestAlwaysRunThreadNames.py
@@ -19,17 +19,21 @@ class AlwaysRunThreadNamesTestCase(TestBase):
         # Configure the setting to keep our helper thread running.
         self.runCmd("settings set target.process.always-run-thread-names always-run")
 
+        # Tell step_over_me() to block until the helper thread advances.
+        self.runCmd("expression g_sync_with_helper = true")
+
         # Record the helper thread's counter before stepping.
         counter_before = target.FindFirstGlobalVariable("g_helper_count")
         self.assertTrue(counter_before.IsValid())
         val_before = counter_before.GetValueAsUnsigned()
 
-        # Step over -- this normally suspends all other threads.
+        # The step over normally suspends all other threads, but the
+        # always-run-thread-names setting keeps the helper thread running.
+        # Because g_sync_with_helper is true, step_over_me() will spin until
+        # the helper thread increments the counter.
         thread.StepOver(lldb.eOnlyThisThread)
         self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonPlanComplete)
 
-        # The helper thread should have been allowed to run, so its counter
-        # should have advanced.
         counter_after = target.FindFirstGlobalVariable("g_helper_count")
         val_after = counter_after.GetValueAsUnsigned()
         self.assertGreater(

--- a/lldb/test/API/functionalities/always-run-threads/main.cpp
+++ b/lldb/test/API/functionalities/always-run-threads/main.cpp
@@ -1,5 +1,4 @@
 #include <atomic>
-#include <chrono>
 #include <pthread.h>
 #include <thread>
 
@@ -15,6 +14,7 @@ static void set_thread_name(const char *name) {
 
 volatile int g_helper_count = 0;
 volatile bool g_stop = false;
+volatile bool g_sync_with_helper = false;
 std::atomic<bool> g_ready{false};
 
 void helper_thread_func() {
@@ -22,15 +22,16 @@ void helper_thread_func() {
   g_ready.store(true);
   while (!g_stop) {
     g_helper_count++;
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 }
 
 int step_over_me() {
-  int result = 0;
-  for (int i = 0; i < 1000; i++)
-    result += i;
-  return result;
+  if (g_sync_with_helper) {
+    int count_at_entry = g_helper_count;
+    while (g_helper_count <= count_at_entry)
+      ;
+  }
+  return 42;
 }
 
 int main() {


### PR DESCRIPTION
Change the stepped function to spin on a flag until the helper thread advances the counter, so the step-over can only complete if the helper thread actually ran.

Fixes #193398