### PR TITLE
[clang-tidy][Docs] Remove all auto-redirects in documentation. NFC.

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/cert/arr39-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/arr39-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-arr39-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/sizeof-expression.html
 
 cert-arr39-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/con36-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/con36-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-con36-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/spuriously-wake-up-functions.html
 
 cert-con36-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/con54-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/con54-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-con54-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/spuriously-wake-up-functions.html
 
 cert-con54-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/ctr56-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/ctr56-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-ctr56-cpp
-.. meta::
-    :http-equiv=refresh: 5;URL=../bugprone/pointer-arithmetic-on-polymorphic-object.html
 
 cert-ctr56-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl03-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl03-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-dcl03-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/static-assert.html
 
 cert-dcl03-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl16-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl16-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-dcl16-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../readability/uppercase-literal-suffix.html
 
 cert-dcl16-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl37-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl37-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-dcl37-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/reserved-identifier.html
 
 cert-dcl37-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl50-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl50-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-dcl50-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/avoid-variadic-functions.html
 
 cert-dcl50-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl51-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl51-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-dcl51-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/reserved-identifier.html
 
 cert-dcl51-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl54-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl54-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-dcl54-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/new-delete-overloads.html
 
 cert-dcl54-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl58-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl58-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-dcl58-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/std-namespace-modification.html
 
 cert-dcl58-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl59-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl59-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-dcl59-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/anonymous-namespace-in-header.html
 
 cert-dcl59-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/env33-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/env33-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-env33-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/command-processor.html
 
 cert-env33-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err09-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err09-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-err09-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/throw-by-value-catch-by-reference.html
 
 cert-err09-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err34-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err34-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-err34-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/unchecked-string-to-number-conversion.html
 
 cert-err34-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err52-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err52-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-err52-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/avoid-setjmp-longjmp.html
 
 cert-err52-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err58-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err58-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-err58-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/throwing-static-initialization.html
 
 cert-err58-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err60-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err60-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-err60-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/exception-copy-constructor-throws.html
 
 cert-err60-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err61-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err61-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-err61-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/throw-by-value-catch-by-reference.html
 
 cert-err61-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/exp42-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/exp42-c.rst
@@ -1,6 +1,3 @@
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/suspicious-memory-comparison.html
-
 cert-exp42-c
 ============
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/exp42-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/exp42-c.rst
@@ -1,3 +1,5 @@
+.. title:: clang-tidy - cert-exp42-c
+
 cert-exp42-c
 ============
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/exp45-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/exp45-c.rst
@@ -1,3 +1,5 @@
+.. title:: clang-tidy - cert-exp45-c
+
 cert-exp45-c
 ============
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/exp45-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/exp45-c.rst
@@ -1,6 +1,3 @@
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/assignment-in-selection-statement.html
-
 cert-exp45-c
 ============
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/fio38-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/fio38-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-fio38-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/non-copyable-objects.html
 
 cert-fio38-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/flp30-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/flp30-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-flp30-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/float-loop-counter.html
 
 cert-flp30-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/flp37-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/flp37-c.rst
@@ -1,3 +1,5 @@
+.. title:: clang-tidy - cert-flp37-c
+
 cert-flp37-c
 ============
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/flp37-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/flp37-c.rst
@@ -1,6 +1,3 @@
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/suspicious-memory-comparison.html
-
 cert-flp37-c
 ============
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/int09-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/int09-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-int09-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../readability/enum-initial-value.html
 
 cert-int09-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/mem57-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/mem57-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-mem57-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/default-operator-new-on-overaligned-type.html
 
 cert-mem57-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc24-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc24-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-msc24-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/unsafe-functions.html
 
 cert-msc24-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc30-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc30-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-msc30-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/predictable-rand.html
 
 cert-msc30-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc32-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc32-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-msc32-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/random-generator-seed.html
 
 cert-msc32-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc33-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc33-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-msc33-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/unsafe-functions.html
 
 cert-msc33-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc50-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc50-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-msc50-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/predictable-rand.html
 
 cert-msc50-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc51-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc51-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-msc51-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/random-generator-seed.html
 
 cert-msc51-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc54-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc54-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-msc54-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/signal-handler.html
 
 cert-msc54-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop11-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop11-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-oop11-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../performance/move-constructor-init.html
 
 cert-oop11-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop54-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop54-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-oop54-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/unhandled-self-assignment.html
 
 cert-oop54-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop57-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop57-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-oop57-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/raw-memory-call-on-non-trivial-type.html
 
 cert-oop57-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop58-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop58-cpp.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-oop58-cpp
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/copy-constructor-mutates-argument.html
 
 cert-oop58-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/pos44-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/pos44-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-pos44-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/bad-signal-to-kill-thread.html
 
 cert-pos44-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/pos47-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/pos47-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-pos47-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../concurrency/thread-canceltype-asynchronous.html
 
 cert-pos47-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/sig30-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/sig30-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-sig30-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/signal-handler.html
 
 cert-sig30-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/str34-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/str34-c.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cert-str34-c
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/signed-char-misuse.html
 
 cert-str34-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-c-arrays.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-c-arrays.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cppcoreguidelines-avoid-c-arrays
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/avoid-c-arrays.html
 
 cppcoreguidelines-avoid-c-arrays
 ================================

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-magic-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-magic-numbers.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cppcoreguidelines-avoid-magic-numbers
-.. meta::
-   :http-equiv=refresh: 5;URL=../readability/magic-numbers.html
 
 cppcoreguidelines-avoid-magic-numbers
 =====================================

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/c-copy-assignment-signature.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/c-copy-assignment-signature.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cppcoreguidelines-c-copy-assignment-signature
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/unconventional-assign-operator.html
 
 cppcoreguidelines-c-copy-assignment-signature
 =============================================

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/explicit-virtual-functions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/explicit-virtual-functions.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cppcoreguidelines-explicit-virtual-functions
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/use-override.html
 
 cppcoreguidelines-explicit-virtual-functions
 ============================================

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/macro-to-enum.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/macro-to-enum.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cppcoreguidelines-macro-to-enum
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/macro-to-enum.html
 
 cppcoreguidelines-macro-to-enum
 ===============================

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/narrowing-conversions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/narrowing-conversions.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cppcoreguidelines-narrowing-conversions
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/narrowing-conversions.html
 
 cppcoreguidelines-narrowing-conversions
 =======================================

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-destructor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-destructor.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cppcoreguidelines-noexcept-destructor
-.. meta::
-   :http-equiv=refresh: 5;URL=../performance/noexcept-destructor.html
 
 cppcoreguidelines-noexcept-destructor
 =====================================

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-move-operations.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-move-operations.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cppcoreguidelines-noexcept-move-operations
-.. meta::
-   :http-equiv=refresh: 5;URL=../performance/noexcept-move-constructor.html
 
 cppcoreguidelines-noexcept-move-operations
 ==========================================

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-swap.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/noexcept-swap.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cppcoreguidelines-noexcept-swap
-.. meta::
-   :http-equiv=refresh: 5;URL=../performance/noexcept-swap.html
 
 cppcoreguidelines-noexcept-swap
 ===============================

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/non-private-member-variables-in-classes.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/non-private-member-variables-in-classes.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cppcoreguidelines-non-private-member-variables-in-classes
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/non-private-member-variables-in-classes.html
 
 cppcoreguidelines-non-private-member-variables-in-classes
 =========================================================

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-default-member-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-default-member-init.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - cppcoreguidelines-use-default-member-init
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/use-default-member-init.html
 
 cppcoreguidelines-use-default-member-init
 =========================================

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/header-anon-namespaces.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/header-anon-namespaces.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - fuchsia-header-anon-namespaces
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/anonymous-namespace-in-header.html
 
 fuchsia-header-anon-namespaces
 ==============================

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/multiple-inheritance.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/multiple-inheritance.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - fuchsia-multiple-inheritance
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/multiple-inheritance.html
 
 fuchsia-multiple-inheritance
 ============================

--- a/clang-tools-extra/docs/clang-tidy/checks/google/build-namespaces.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/build-namespaces.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - google-build-namespaces
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/anonymous-namespace-in-header.html
 
 google-build-namespaces
 =======================

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-braces-around-statements.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-braces-around-statements.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - google-readability-braces-around-statements
-.. meta::
-   :http-equiv=refresh: 5;URL=../readability/braces-around-statements.html
 
 google-readability-braces-around-statements
 ===========================================

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-casting.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-casting.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - google-readability-casting
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/avoid-c-style-cast.html
 
 google-readability-casting
 ==========================

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-function-size.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-function-size.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - google-readability-function-size
-.. meta::
-   :http-equiv=refresh: 5;URL=../readability/function-size.html
 
 google-readability-function-size
 ================================

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-namespace-comments.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-namespace-comments.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - google-readability-namespace-comments
-.. meta::
-   :http-equiv=refresh: 5;URL=../llvm/namespace-comment.html
 
 google-readability-namespace-comments
 =====================================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-c-arrays.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-c-arrays.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-avoid-c-arrays
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/avoid-c-arrays.html
 
 hicpp-avoid-c-arrays
 ====================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-goto.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-goto.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-avoid-goto
-.. meta::
-   :http-equiv=refresh: 5;URL=../cppcoreguidelines/avoid-goto.html
 
 hicpp-avoid-goto
 ================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/braces-around-statements.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/braces-around-statements.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-braces-around-statements
-.. meta::
-   :http-equiv=refresh: 5;URL=../readability/braces-around-statements.html
 
 hicpp-braces-around-statements
 ==============================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/deprecated-headers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/deprecated-headers.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-deprecated-headers
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/deprecated-headers.html
 
 hicpp-deprecated-headers
 ========================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/exception-baseclass.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/exception-baseclass.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-exception-baseclass
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/std-exception-baseclass.html
 
 hicpp-exception-baseclass
 =========================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/explicit-conversions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/explicit-conversions.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-explicit-conversions
-.. meta::
-   :http-equiv=refresh: 5;URL=../google/explicit-constructor.html
 
 hicpp-explicit-conversions
 ==========================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/function-size.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/function-size.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-function-size
-.. meta::
-   :http-equiv=refresh: 5;URL=../readability/function-size.html
 
 hicpp-function-size
 ===================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-ignored-remove-result
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/unused-return-value.html
 
 hicpp-ignored-remove-result
 ===========================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/invalid-access-moved.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/invalid-access-moved.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-invalid-access-moved
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/use-after-move.html
 
 hicpp-invalid-access-moved
 ==========================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/member-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/member-init.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-member-init
-.. meta::
-   :http-equiv=refresh: 5;URL=../cppcoreguidelines/pro-type-member-init.html
 
 hicpp-member-init
 =================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/move-const-arg.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/move-const-arg.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-move-const-arg
-.. meta::
-   :http-equiv=refresh: 5;URL=../performance/move-const-arg.html
 
 hicpp-move-const-arg
 ====================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/named-parameter.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/named-parameter.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-named-parameter
-.. meta::
-   :http-equiv=refresh: 5;URL=../readability/named-parameter.html
 
 hicpp-named-parameter
 =====================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/new-delete-operators.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/new-delete-operators.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-new-delete-operators
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/new-delete-overloads.html
 
 hicpp-new-delete-operators
 ==========================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-array-decay.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-array-decay.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-no-array-decay
-.. meta::
-   :http-equiv=refresh: 5;URL=../cppcoreguidelines/pro-bounds-array-to-pointer-decay.html
 
 hicpp-no-array-decay
 ====================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-assembler.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-assembler.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-no-assembler
-.. meta::
-   :http-equiv=refresh: 0;URL=../portability/no-assembler.html
 
 hicpp-no-assembler
 ==================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-malloc.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-malloc.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-no-malloc
-.. meta::
-   :http-equiv=refresh: 5;URL=../cppcoreguidelines/no-malloc.html
 
 hicpp-no-malloc
 ===============

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/noexcept-move.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/noexcept-move.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-noexcept-move
-.. meta::
-   :http-equiv=refresh: 5;URL=../performance/noexcept-move-constructor.html
 
 hicpp-noexcept-move
 ===================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/signed-bitwise.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/signed-bitwise.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-signed-bitwise
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/signed-bitwise.html
 
 hicpp-signed-bitwise
 ====================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/special-member-functions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/special-member-functions.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-special-member-functions
-.. meta::
-   :http-equiv=refresh: 5;URL=../cppcoreguidelines/special-member-functions.html
 
 hicpp-special-member-functions
 ==============================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/static-assert.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/static-assert.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-static-assert
-.. meta::
-   :http-equiv=refresh: 5;URL=../misc/static-assert.html
 
 hicpp-static-assert
 ===================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/undelegated-constructor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/undelegated-constructor.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-undelegated-constructor
-.. meta::
-   :http-equiv=refresh: 5;URL=../bugprone/undelegated-constructor.html
 
 hicpp-undelegated-constructor
 =============================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/uppercase-literal-suffix.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/uppercase-literal-suffix.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-uppercase-literal-suffix
-.. meta::
-   :http-equiv=refresh: 5;URL=../readability/uppercase-literal-suffix.html
 
 hicpp-uppercase-literal-suffix
 ==============================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-auto.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-auto.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-use-auto
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/use-auto.html
 
 hicpp-use-auto
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-emplace.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-emplace.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-use-emplace
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/use-emplace.html
 
 hicpp-use-emplace
 =================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-equals-default.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-equals-default.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-use-equals-defaults
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/use-equals-default.html
 
 hicpp-use-equals-default
 ========================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-equals-delete.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-equals-delete.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-use-equals-delete
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/use-equals-delete.html
 
 hicpp-use-equals-delete
 =======================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-noexcept.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-noexcept.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-use-noexcept
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/use-noexcept.html
 
 hicpp-use-noexcept
 ==================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-nullptr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-nullptr.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-use-nullptr
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/use-nullptr.html
 
 hicpp-use-nullptr
 =================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-override.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-override.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-use-override
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/use-override.html
 
 hicpp-use-override
 ==================

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/vararg.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/vararg.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - hicpp-vararg
-.. meta::
-   :http-equiv=refresh: 5;URL=../cppcoreguidelines/pro-type-vararg.html
 
 hicpp-vararg
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/else-after-return.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/else-after-return.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - llvm-else-after-return
-.. meta::
-   :http-equiv=refresh: 5;URL=../readability/else-after-return.html
 
 llvm-else-after-return
 ======================

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/qualified-auto.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/qualified-auto.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - llvm-qualified-auto
-.. meta::
-   :http-equiv=refresh: 5;URL=../readability/qualified-auto.html
 
 llvm-qualified-auto
 ===================

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-default.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-default.rst
@@ -1,8 +1,6 @@
 :orphan:
 
 .. title:: clang-tidy - modernize-use-default
-.. meta::
-   :http-equiv=refresh: 5;URL=../modernize/use-equals-default.html
 
 modernize-use-default
 =====================

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/faster-string-find.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/faster-string-find.rst
@@ -1,6 +1,4 @@
 .. title:: clang-tidy - performance-faster-string-find
-.. meta::
-   :http-equiv=refresh: 5;URL=prefer-single-char-overloads.html
 
 performance-faster-string-find
 ==============================

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/implicit-cast-in-loop.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/implicit-cast-in-loop.rst
@@ -1,8 +1,6 @@
 :orphan:
 
 .. title:: clang-tidy - performance-implicit-cast-in-loop
-.. meta::
-   :http-equiv=refresh: 5;URL=../performance/implicit-conversion-in-loop.html
 
 performance-implicit-cast-in-loop
 =================================

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-cast.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-cast.rst
@@ -1,8 +1,6 @@
 :orphan:
 
 .. title:: clang-tidy - readability-implicit-bool-cast
-.. meta::
-   :http-equiv=refresh: 5;URL=../readability/implicit-bool-conversion.html
 
 readability-implicit-bool-cast
 ==============================


### PR DESCRIPTION
RFC: https://discourse.llvm.org/t/rfc-remove-automatic-redirects-from-clang-tidy-documentation/90633