### PR TITLE
[GISel] Disable opt_brcond_by_inverting_cond combine at O0

### DIFF
--- a/llvm/include/llvm/Target/GlobalISel/Combine.td
+++ b/llvm/include/llvm/Target/GlobalISel/Combine.td
@@ -2383,4 +2383,4 @@ def all_combines : GICombineGroup<[integer_reassoc_combines, trivial_combines,
 // compile time performance.
 def optnone_combines : GICombineGroup<[trivial_combines,
     ptr_add_immed_chain, combines_for_extload,
-    not_cmp_fold, opt_brcond_by_inverting_cond, combine_concat_vector]>;
+    not_cmp_fold, combine_concat_vector]>;

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-outline_atomics.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-outline_atomics.ll
@@ -121,7 +121,6 @@ define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_unordered:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -136,7 +135,6 @@ define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_monotonic:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -151,7 +149,6 @@ define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) 
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_release:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -166,7 +163,6 @@ define dso_local void @store_atomic_i128_aligned_seq_cst(i128 %value, ptr %ptr) 
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_seq_cst:
 ; -O1:    ldaxp xzr, x8, [x2]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-rcpc.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-rcpc.ll
@@ -125,7 +125,6 @@ define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_unordered:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -144,7 +143,6 @@ define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_monotonic:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -163,7 +161,6 @@ define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_release:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -182,7 +179,6 @@ define dso_local void @store_atomic_i128_aligned_seq_cst(i128 %value, ptr %ptr) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_seq_cst:
 ; -O1:    ldaxp xzr, x8, [x2]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-v8_1a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-v8_1a.ll
@@ -121,7 +121,6 @@ define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_unordered:
 ; -O1:    ldp x4, x5, [x2]
@@ -138,7 +137,6 @@ define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x2]
@@ -155,7 +153,6 @@ define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x2]
@@ -172,7 +169,6 @@ define dso_local void @store_atomic_i128_aligned_seq_cst(i128 %value, ptr %ptr) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x2]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-v8a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-v8a.ll
@@ -125,7 +125,6 @@ define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_unordered:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -144,7 +143,6 @@ define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_monotonic:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -163,7 +161,6 @@ define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_release:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -182,7 +179,6 @@ define dso_local void @store_atomic_i128_aligned_seq_cst(i128 %value, ptr %ptr) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_seq_cst:
 ; -O1:    ldaxp xzr, x8, [x2]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lse2.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lse2.ll
@@ -5,11 +5,11 @@
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_monotonic:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -20,11 +20,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_acquire:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -35,11 +35,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acquire(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_release:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -50,11 +50,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_release(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_acq_rel:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -65,11 +65,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_seq_cst:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -80,10 +80,10 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_monotonic:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_monotonic:
 ; -O1:    ldxrh w0, [x8]
@@ -94,10 +94,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_monotonic(ptr %ptr, i16 %value)
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_acquire:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acquire:
 ; -O1:    ldaxrh w0, [x8]
@@ -108,10 +108,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acquire(ptr %ptr, i16 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_release:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_release:
 ; -O1:    ldxrh w0, [x8]
@@ -122,10 +122,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_release(ptr %ptr, i16 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w0, [x8]
@@ -136,10 +136,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w0, [x8]
@@ -151,9 +151,9 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_monotonic:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_monotonic:
 ; -O1:    ldxr w0, [x8]
@@ -165,9 +165,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_monotonic(ptr %ptr, i32 %value)
 define dso_local i32 @atomicrmw_xchg_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_acquire:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acquire:
 ; -O1:    ldaxr w0, [x8]
@@ -179,9 +179,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acquire(ptr %ptr, i32 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_release:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_release:
 ; -O1:    ldxr w0, [x8]
@@ -193,9 +193,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_release(ptr %ptr, i32 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_acq_rel:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acq_rel:
 ; -O1:    ldaxr w0, [x8]
@@ -207,9 +207,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_seq_cst:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_seq_cst:
 ; -O1:    ldaxr w0, [x8]
@@ -221,9 +221,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_monotonic:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -235,9 +235,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_monotonic(ptr %ptr, i64 %value)
 define dso_local i64 @atomicrmw_xchg_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_acquire:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -249,9 +249,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acquire(ptr %ptr, i64 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_release:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -263,9 +263,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_release(ptr %ptr, i64 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_acq_rel:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -277,9 +277,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_seq_cst:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -298,7 +298,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O1:    ldxp x8, x1, [x0]
@@ -317,7 +316,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -336,7 +334,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O1:    ldxp x8, x1, [x0]
@@ -355,7 +352,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -374,7 +370,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -385,11 +380,11 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_monotonic:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -400,11 +395,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_acquire:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -415,11 +410,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_release:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -430,11 +425,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_release(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_acq_rel:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -445,11 +440,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_seq_cst:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -601,11 +596,11 @@ define dso_local i128 @atomicrmw_xchg_i128_unaligned_seq_cst(ptr %ptr, i128 %val
 define dso_local i8 @atomicrmw_add_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_monotonic:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -618,11 +613,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_acquire:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -635,11 +630,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_release:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -652,11 +647,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_acq_rel:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -669,11 +664,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_seq_cst:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -686,10 +681,10 @@ define dso_local i8 @atomicrmw_add_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_monotonic:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -702,10 +697,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_add_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_acquire:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -718,10 +713,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_release:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -734,10 +729,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_acq_rel:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -750,10 +745,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_seq_cst:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -765,11 +760,11 @@ define dso_local i16 @atomicrmw_add_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_monotonic:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -781,11 +776,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_add_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_acquire:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -797,11 +792,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_release:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -813,11 +808,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_acq_rel:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -829,11 +824,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_seq_cst:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -845,11 +840,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_monotonic:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -861,11 +856,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_add_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_acquire:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -877,11 +872,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_release:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -893,11 +888,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_acq_rel:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -909,11 +904,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_seq_cst:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -935,7 +930,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -957,7 +951,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -979,7 +972,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1001,7 +993,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1023,7 +1014,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1036,11 +1026,11 @@ define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_add_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_monotonic:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1053,11 +1043,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_acquire:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1070,11 +1060,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_release:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1087,11 +1077,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_acq_rel:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1104,11 +1094,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_seq_cst:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1371,11 +1361,11 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_seq_cst(ptr %ptr, i128 %valu
 define dso_local i8 @atomicrmw_sub_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_monotonic:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1388,11 +1378,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_acquire:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1405,11 +1395,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_release:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1422,11 +1412,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_acq_rel:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1439,11 +1429,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_seq_cst:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1456,10 +1446,10 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_monotonic:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1472,10 +1462,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_sub_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_acquire:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1488,10 +1478,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_release:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1504,10 +1494,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_acq_rel:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1520,10 +1510,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_seq_cst:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1535,11 +1525,11 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_monotonic:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1551,11 +1541,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_acquire:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1567,11 +1557,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_release:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1583,11 +1573,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_acq_rel:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1599,11 +1589,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_seq_cst:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1615,11 +1605,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_monotonic:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -1631,11 +1621,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_acquire:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -1647,11 +1637,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_release:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -1663,11 +1653,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_acq_rel:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -1679,11 +1669,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_seq_cst:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -1704,7 +1694,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1725,7 +1714,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1746,7 +1734,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1767,7 +1754,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1788,7 +1774,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1801,11 +1786,11 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_sub_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_monotonic:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1818,11 +1803,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_acquire:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1835,11 +1820,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_release:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1852,11 +1837,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_acq_rel:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1869,11 +1854,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_seq_cst:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2131,11 +2116,11 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_seq_cst(ptr %ptr, i128 %valu
 define dso_local i8 @atomicrmw_and_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_monotonic:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2148,11 +2133,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_acquire:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2165,11 +2150,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_release:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2182,11 +2167,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_acq_rel:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2199,11 +2184,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_seq_cst:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2216,10 +2201,10 @@ define dso_local i8 @atomicrmw_and_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_monotonic:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2232,10 +2217,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_and_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_acquire:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2248,10 +2233,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_release:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2264,10 +2249,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_acq_rel:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2280,10 +2265,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_seq_cst:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2295,11 +2280,11 @@ define dso_local i16 @atomicrmw_and_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_monotonic:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2311,11 +2296,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_and_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_acquire:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2327,11 +2312,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_release:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2343,11 +2328,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_acq_rel:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2359,11 +2344,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_seq_cst:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2375,11 +2360,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_monotonic:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -2391,11 +2376,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_and_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_acquire:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -2407,11 +2392,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_release:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -2423,11 +2408,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_acq_rel:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -2439,11 +2424,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_seq_cst:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -2465,7 +2450,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2488,7 +2472,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2511,7 +2494,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2534,7 +2516,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2557,7 +2538,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2571,11 +2551,11 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_and_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_monotonic:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2588,11 +2568,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_acquire:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2605,11 +2585,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_release:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2622,11 +2602,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_acq_rel:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2639,11 +2619,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_seq_cst:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2912,11 +2892,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2931,11 +2911,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2950,11 +2930,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2969,11 +2949,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2988,11 +2968,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3007,10 +2987,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3025,10 +3005,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3043,10 +3023,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3061,10 +3041,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3079,10 +3059,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -3095,12 +3075,12 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_monotonic:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -3113,12 +3093,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_acquire:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -3131,12 +3111,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_release:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -3149,12 +3129,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -3167,12 +3147,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -3185,12 +3165,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -3203,12 +3183,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -3221,12 +3201,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -3239,12 +3219,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -3257,12 +3237,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -3287,7 +3267,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3314,7 +3293,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3341,7 +3319,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3368,7 +3345,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3395,7 +3371,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3412,11 +3387,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3431,11 +3406,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3450,11 +3425,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3469,11 +3444,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3488,11 +3463,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3811,11 +3786,11 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_seq_cst(ptr %ptr, i128 %val
 define dso_local i8 @atomicrmw_or_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_monotonic:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3828,11 +3803,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_acquire:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3845,11 +3820,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_release:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3862,11 +3837,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_acq_rel:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3879,11 +3854,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_seq_cst:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3896,10 +3871,10 @@ define dso_local i8 @atomicrmw_or_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_monotonic:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3912,10 +3887,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_acquire:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3928,10 +3903,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_release:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3944,10 +3919,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_acq_rel:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3960,10 +3935,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_seq_cst:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -3975,11 +3950,11 @@ define dso_local i16 @atomicrmw_or_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_monotonic:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -3991,11 +3966,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_acquire:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4007,11 +3982,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_release:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4023,11 +3998,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_acq_rel:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4039,11 +4014,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_seq_cst:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4055,11 +4030,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_monotonic:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4071,11 +4046,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_acquire:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4087,11 +4062,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_release:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4103,11 +4078,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_acq_rel:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4119,11 +4094,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_seq_cst:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4145,7 +4120,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4168,7 +4142,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4191,7 +4164,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4214,7 +4186,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4237,7 +4208,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4251,11 +4221,11 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 define dso_local i8 @atomicrmw_or_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_monotonic:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4268,11 +4238,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_acquire:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4285,11 +4255,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_release:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4302,11 +4272,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_acq_rel:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4319,11 +4289,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_seq_cst:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4591,11 +4561,11 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_seq_cst(ptr %ptr, i128 %value
 define dso_local i8 @atomicrmw_xor_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_monotonic:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4608,11 +4578,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_acquire:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4625,11 +4595,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_release:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4642,11 +4612,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_acq_rel:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4659,11 +4629,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_seq_cst:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4676,10 +4646,10 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_monotonic:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -4692,10 +4662,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_xor_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_acquire:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -4708,10 +4678,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_release:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -4724,10 +4694,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_acq_rel:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -4740,10 +4710,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_seq_cst:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -4755,11 +4725,11 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_monotonic:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4771,11 +4741,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_acquire:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4787,11 +4757,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_release:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4803,11 +4773,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_acq_rel:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4819,11 +4789,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_seq_cst:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4835,11 +4805,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_monotonic:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4851,11 +4821,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_acquire:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4867,11 +4837,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_release:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4883,11 +4853,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_acq_rel:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4899,11 +4869,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_seq_cst:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4925,7 +4895,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4948,7 +4917,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4971,7 +4939,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4994,7 +4961,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5017,7 +4983,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5031,11 +4996,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_xor_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_monotonic:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -5048,11 +5013,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_acquire:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -5065,11 +5030,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_release:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -5082,11 +5047,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_acq_rel:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -5099,11 +5064,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_seq_cst:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -5373,11 +5338,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5394,11 +5359,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5415,11 +5380,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5436,11 +5401,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -5457,11 +5422,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -5478,10 +5443,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -5498,10 +5463,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -5518,10 +5483,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -5538,10 +5503,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -5558,10 +5523,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -5575,12 +5540,12 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -5593,12 +5558,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -5611,12 +5576,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -5629,12 +5594,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -5647,12 +5612,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -5665,12 +5630,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -5683,12 +5648,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -5701,12 +5666,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -5719,12 +5684,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -5737,12 +5702,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5771,7 +5736,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5801,7 +5765,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5831,7 +5794,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5861,7 +5823,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5891,7 +5852,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5908,11 +5868,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5929,11 +5889,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5950,11 +5910,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5971,11 +5931,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -5992,11 +5952,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6343,11 +6303,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6364,11 +6324,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6385,11 +6345,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6406,11 +6366,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6427,11 +6387,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6448,10 +6408,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -6468,10 +6428,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -6488,10 +6448,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -6508,10 +6468,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -6528,10 +6488,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -6545,12 +6505,12 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -6563,12 +6523,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -6581,12 +6541,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -6599,12 +6559,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -6617,12 +6577,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -6635,12 +6595,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -6653,12 +6613,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -6671,12 +6631,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -6689,12 +6649,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -6707,12 +6667,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -6741,7 +6701,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6771,7 +6730,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6801,7 +6759,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6831,7 +6788,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6861,7 +6817,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6878,11 +6833,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6899,11 +6854,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6920,11 +6875,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6941,11 +6896,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6962,11 +6917,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -7313,11 +7268,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7334,11 +7289,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7355,11 +7310,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7376,11 +7331,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7397,11 +7352,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -7417,10 +7372,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -7436,10 +7391,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -7455,10 +7410,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -7474,10 +7429,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -7493,10 +7448,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -7510,12 +7465,12 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -7528,12 +7483,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -7546,12 +7501,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -7564,12 +7519,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -7582,12 +7537,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -7600,12 +7555,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -7618,12 +7573,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -7636,12 +7591,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -7654,12 +7609,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -7672,12 +7627,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -7706,7 +7661,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7736,7 +7690,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7766,7 +7719,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7796,7 +7748,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7826,7 +7777,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7843,11 +7793,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7864,11 +7814,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7885,11 +7835,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7906,11 +7856,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7927,11 +7877,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8273,11 +8223,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8294,11 +8244,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8315,11 +8265,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8336,11 +8286,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8357,11 +8307,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8377,10 +8327,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -8396,10 +8346,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -8415,10 +8365,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -8434,10 +8384,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -8453,10 +8403,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -8470,12 +8420,12 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -8488,12 +8438,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -8506,12 +8456,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -8524,12 +8474,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -8542,12 +8492,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -8560,12 +8510,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -8578,12 +8528,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -8596,12 +8546,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -8614,12 +8564,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -8632,12 +8582,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -8666,7 +8616,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8696,7 +8645,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8726,7 +8674,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8756,7 +8703,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8786,7 +8732,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8803,11 +8748,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8824,11 +8769,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8845,11 +8790,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8866,11 +8811,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8887,11 +8832,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lse2_lse128.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lse2_lse128.ll
@@ -516,7 +516,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -536,7 +535,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -556,7 +554,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -576,7 +573,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -596,7 +592,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -1040,7 +1035,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -1059,7 +1053,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -1078,7 +1071,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -1097,7 +1089,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -1116,7 +1107,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -1936,10 +1926,10 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_seq_cst(ptr %ptr, i128 %valu
 define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -1953,10 +1943,10 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casab w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casab w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -1970,10 +1960,10 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    caslb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    caslb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O1:    and w10, w8, w1
@@ -1987,10 +1977,10 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casalb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casalb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2004,10 +1994,10 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casalb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casalb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -2021,9 +2011,9 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    cash w9, w10, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    mvn w9, w9
+; -O0:    cash w10, w9, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2037,9 +2027,9 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casah w9, w10, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    mvn w9, w9
+; -O0:    casah w10, w9, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2053,9 +2043,9 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    caslh w9, w10, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    mvn w9, w9
+; -O0:    caslh w10, w9, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    and w10, w8, w1
@@ -2069,9 +2059,9 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casalh w9, w10, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    mvn w9, w9
+; -O0:    casalh w10, w9, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2085,9 +2075,9 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casalh w9, w10, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    mvn w9, w9
+; -O0:    casalh w10, w9, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -2100,10 +2090,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_monotonic:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    cas w9, w10, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    and w8, w10, w8
+; -O0:    mvn w8, w8
+; -O0:    cas w9, w8, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2116,10 +2106,10 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_acquire:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casa w9, w10, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    and w8, w10, w8
+; -O0:    mvn w8, w8
+; -O0:    casa w9, w8, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2132,10 +2122,10 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_release:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casl w9, w10, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    and w8, w10, w8
+; -O0:    mvn w8, w8
+; -O0:    casl w9, w8, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    and w10, w8, w1
@@ -2148,10 +2138,10 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casal w9, w10, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    and w8, w10, w8
+; -O0:    mvn w8, w8
+; -O0:    casal w9, w8, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2164,10 +2154,10 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casal w9, w10, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    and w8, w10, w8
+; -O0:    mvn w8, w8
+; -O0:    casal w9, w8, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -2180,10 +2170,10 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x10, x9
-; -O0:    cas x9, x10, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    and x8, x10, x8
+; -O0:    mvn x8, x8
+; -O0:    cas x9, x8, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    and x10, x8, x1
@@ -2196,10 +2186,10 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x10, x9
-; -O0:    casa x9, x10, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    and x8, x10, x8
+; -O0:    mvn x8, x8
+; -O0:    casa x9, x8, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    and x10, x8, x1
@@ -2212,10 +2202,10 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x10, x9
-; -O0:    casl x9, x10, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    and x8, x10, x8
+; -O0:    mvn x8, x8
+; -O0:    casl x9, x8, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    and x10, x8, x1
@@ -2228,10 +2218,10 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x10, x9
-; -O0:    casal x9, x10, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    and x8, x10, x8
+; -O0:    mvn x8, x8
+; -O0:    casal x9, x8, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    and x10, x8, x1
@@ -2244,10 +2234,10 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x10, x9
-; -O0:    casal x9, x10, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    and x8, x10, x8
+; -O0:    mvn x8, x8
+; -O0:    casal x9, x8, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    and x10, x8, x1
@@ -2268,7 +2258,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -2293,7 +2282,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -2318,7 +2306,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -2343,7 +2330,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -2368,7 +2354,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -2386,10 +2371,10 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2403,10 +2388,10 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casab w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casab w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2420,10 +2405,10 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    caslb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    caslb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O1:    and w10, w8, w1
@@ -2437,10 +2422,10 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casalb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casalb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2454,10 +2439,10 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casalb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casalb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -3401,7 +3386,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -3422,7 +3406,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -3443,7 +3426,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -3464,7 +3446,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -3485,7 +3466,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -3942,7 +3922,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -3970,7 +3949,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -3998,7 +3976,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -4026,7 +4003,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -4054,7 +4030,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -4587,7 +4562,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -4615,7 +4589,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -4643,7 +4616,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -4671,7 +4643,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -4699,7 +4670,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -5232,7 +5202,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -5260,7 +5229,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -5288,7 +5256,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -5316,7 +5283,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -5344,7 +5310,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -5872,7 +5837,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -5900,7 +5864,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -5928,7 +5891,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -5956,7 +5918,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -5984,7 +5945,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lsfe.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lsfe.ll
@@ -379,10 +379,10 @@ define dso_local double @atomicrmw_fadd_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fsub_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_monotonic:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -393,10 +393,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fsub_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_acquire:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -407,10 +407,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_release:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -421,10 +421,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_acq_rel:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -435,10 +435,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_seq_cst:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -539,10 +539,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fsub_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_monotonic:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -553,10 +553,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fsub_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_acquire:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -567,10 +567,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_release:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -581,10 +581,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_acq_rel:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -595,10 +595,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_seq_cst:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -609,10 +609,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fsub_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_monotonic:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -623,10 +623,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fsub_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_acquire:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -637,10 +637,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_release:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -651,10 +651,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_acq_rel:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -665,10 +665,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_seq_cst:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-outline_atomics.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-outline_atomics.ll
@@ -149,7 +149,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O1:    ldxp x8, x1, [x0]
@@ -164,7 +163,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -179,7 +177,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O1:    ldxp x8, x1, [x0]
@@ -194,7 +191,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -209,7 +205,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -541,7 +536,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -559,7 +553,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -577,7 +570,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -595,7 +587,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -613,7 +604,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1135,7 +1125,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1152,7 +1141,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1169,7 +1157,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1186,7 +1173,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1203,7 +1189,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1761,7 +1746,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1780,7 +1764,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1799,7 +1782,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1818,7 +1800,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1837,7 +1818,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2253,7 +2233,7 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    and w8, w0, w8
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas2_relax
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2269,7 +2249,7 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    and w8, w0, w8
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas2_acq
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2285,7 +2265,7 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    and w8, w0, w8
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas2_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2301,7 +2281,7 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    and w8, w0, w8
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas2_acq_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2317,7 +2297,7 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    and w8, w0, w8
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas2_acq_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2333,7 +2313,7 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    and w8, w0, w8
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas4_relax
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2349,7 +2329,7 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    and w8, w0, w8
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas4_acq
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2365,7 +2345,7 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    and w8, w0, w8
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas4_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2381,7 +2361,7 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    and w8, w0, w8
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas4_acq_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2397,7 +2377,7 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    and w8, w0, w8
 ; -O0:    mvn w1, w8
 ; -O0:    bl __aarch64_cas4_acq_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2413,7 +2393,7 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    and x8, x0, x8
 ; -O0:    mvn x1, x8
 ; -O0:    bl __aarch64_cas8_relax
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -2429,7 +2409,7 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    and x8, x0, x8
 ; -O0:    mvn x1, x8
 ; -O0:    bl __aarch64_cas8_acq
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -2445,7 +2425,7 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    and x8, x0, x8
 ; -O0:    mvn x1, x8
 ; -O0:    bl __aarch64_cas8_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -2461,7 +2441,7 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    and x8, x0, x8
 ; -O0:    mvn x1, x8
 ; -O0:    bl __aarch64_cas8_acq_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -2477,7 +2457,7 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    and x8, x0, x8
 ; -O0:    mvn x1, x8
 ; -O0:    bl __aarch64_cas8_acq_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -2498,7 +2478,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2521,7 +2500,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2544,7 +2522,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2567,7 +2544,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2590,7 +2566,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3141,7 +3116,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3160,7 +3134,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3179,7 +3152,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3198,7 +3170,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3217,7 +3188,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3666,7 +3636,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3685,7 +3654,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3704,7 +3672,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3723,7 +3690,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3742,7 +3708,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4144,7 +4109,7 @@ define dso_local i16 @atomicrmw_max_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    subs w9, w9, w8, sxth
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas2_relax
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -4162,7 +4127,7 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, sxth
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas2_acq
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -4180,7 +4145,7 @@ define dso_local i16 @atomicrmw_max_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, sxth
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas2_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -4198,7 +4163,7 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, sxth
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas2_acq_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -4216,7 +4181,7 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, sxth
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas2_acq_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -4233,7 +4198,7 @@ define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas4_relax
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4249,7 +4214,7 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas4_acq
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4265,7 +4230,7 @@ define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas4_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4281,7 +4246,7 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas4_acq_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4297,7 +4262,7 @@ define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, gt
 ; -O0:    bl __aarch64_cas4_acq_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4313,7 +4278,7 @@ define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, gt
 ; -O0:    bl __aarch64_cas8_relax
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4329,7 +4294,7 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, gt
 ; -O0:    bl __aarch64_cas8_acq
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4345,7 +4310,7 @@ define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, gt
 ; -O0:    bl __aarch64_cas8_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4361,7 +4326,7 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, gt
 ; -O0:    bl __aarch64_cas8_acq_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4377,7 +4342,7 @@ define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, gt
 ; -O0:    bl __aarch64_cas8_acq_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4402,7 +4367,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4428,7 +4392,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4454,7 +4417,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4480,7 +4442,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4506,7 +4467,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5044,7 +5004,7 @@ define dso_local i16 @atomicrmw_min_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    subs w9, w9, w8, sxth
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas2_relax
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -5062,7 +5022,7 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, sxth
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas2_acq
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -5080,7 +5040,7 @@ define dso_local i16 @atomicrmw_min_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, sxth
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas2_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -5098,7 +5058,7 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, sxth
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas2_acq_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -5116,7 +5076,7 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, sxth
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas2_acq_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -5133,7 +5093,7 @@ define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas4_relax
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -5149,7 +5109,7 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas4_acq
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -5165,7 +5125,7 @@ define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas4_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -5181,7 +5141,7 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas4_acq_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -5197,7 +5157,7 @@ define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, le
 ; -O0:    bl __aarch64_cas4_acq_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -5213,7 +5173,7 @@ define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, le
 ; -O0:    bl __aarch64_cas8_relax
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -5229,7 +5189,7 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, le
 ; -O0:    bl __aarch64_cas8_acq
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -5245,7 +5205,7 @@ define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, le
 ; -O0:    bl __aarch64_cas8_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -5261,7 +5221,7 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, le
 ; -O0:    bl __aarch64_cas8_acq_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -5277,7 +5237,7 @@ define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, le
 ; -O0:    bl __aarch64_cas8_acq_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5302,7 +5262,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5328,7 +5287,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5354,7 +5312,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5380,7 +5337,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5406,7 +5362,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5943,7 +5898,7 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    subs w9, w9, w8, uxth
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas2_relax
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -5960,7 +5915,7 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, uxth
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas2_acq
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -5977,7 +5932,7 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, uxth
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas2_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -5994,7 +5949,7 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, uxth
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas2_acq_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -6011,7 +5966,7 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, uxth
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas2_acq_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -6028,7 +5983,7 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas4_relax
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -6044,7 +5999,7 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas4_acq
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -6060,7 +6015,7 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas4_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -6076,7 +6031,7 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas4_acq_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -6092,7 +6047,7 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, hi
 ; -O0:    bl __aarch64_cas4_acq_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -6108,7 +6063,7 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, hi
 ; -O0:    bl __aarch64_cas8_relax
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -6124,7 +6079,7 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, hi
 ; -O0:    bl __aarch64_cas8_acq
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -6140,7 +6095,7 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, hi
 ; -O0:    bl __aarch64_cas8_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -6156,7 +6111,7 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, hi
 ; -O0:    bl __aarch64_cas8_acq_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -6172,7 +6127,7 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, hi
 ; -O0:    bl __aarch64_cas8_acq_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -6197,7 +6152,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6223,7 +6177,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6249,7 +6202,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6275,7 +6227,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6301,7 +6252,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6833,7 +6783,7 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0:    subs w9, w9, w8, uxth
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas2_relax
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -6850,7 +6800,7 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, uxth
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas2_acq
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -6867,7 +6817,7 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, uxth
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas2_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -6884,7 +6834,7 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, uxth
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas2_acq_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -6901,7 +6851,7 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    subs w9, w9, w8, uxth
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas2_acq_rel
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -6918,7 +6868,7 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value)
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas4_relax
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -6934,7 +6884,7 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas4_acq
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -6950,7 +6900,7 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas4_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -6966,7 +6916,7 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas4_acq_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -6982,7 +6932,7 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0:    subs w9, w0, w8
 ; -O0:    csel w1, w0, w8, ls
 ; -O0:    bl __aarch64_cas4_acq_rel
-; -O0:    subs w8, w0, w8
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -6998,7 +6948,7 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value)
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, ls
 ; -O0:    bl __aarch64_cas8_relax
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -7014,7 +6964,7 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, ls
 ; -O0:    bl __aarch64_cas8_acq
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -7030,7 +6980,7 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, ls
 ; -O0:    bl __aarch64_cas8_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -7046,7 +6996,7 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, ls
 ; -O0:    bl __aarch64_cas8_acq_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -7062,7 +7012,7 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0:    subs x9, x0, x8
 ; -O0:    csel x1, x0, x8, ls
 ; -O0:    bl __aarch64_cas8_acq_rel
-; -O0:    subs x8, x0, x8
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -7087,7 +7037,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7113,7 +7062,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7139,7 +7087,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7165,7 +7112,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7191,7 +7137,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x0, x8
 ; -O0:    eor x9, x1, x9
 ; -O0:    orr x8, x8, x9
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-rcpc.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-rcpc.ll
@@ -5,11 +5,11 @@
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_monotonic:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -20,11 +20,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_acquire:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -35,11 +35,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acquire(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_release:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -50,11 +50,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_release(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_acq_rel:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -65,11 +65,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_seq_cst:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -80,10 +80,10 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_monotonic:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_monotonic:
 ; -O1:    ldxrh w0, [x8]
@@ -94,10 +94,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_monotonic(ptr %ptr, i16 %value)
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_acquire:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acquire:
 ; -O1:    ldaxrh w0, [x8]
@@ -108,10 +108,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acquire(ptr %ptr, i16 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_release:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_release:
 ; -O1:    ldxrh w0, [x8]
@@ -122,10 +122,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_release(ptr %ptr, i16 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w0, [x8]
@@ -136,10 +136,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w0, [x8]
@@ -151,9 +151,9 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_monotonic:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_monotonic:
 ; -O1:    ldxr w0, [x8]
@@ -165,9 +165,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_monotonic(ptr %ptr, i32 %value)
 define dso_local i32 @atomicrmw_xchg_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_acquire:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acquire:
 ; -O1:    ldaxr w0, [x8]
@@ -179,9 +179,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acquire(ptr %ptr, i32 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_release:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_release:
 ; -O1:    ldxr w0, [x8]
@@ -193,9 +193,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_release(ptr %ptr, i32 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_acq_rel:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acq_rel:
 ; -O1:    ldaxr w0, [x8]
@@ -207,9 +207,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_seq_cst:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_seq_cst:
 ; -O1:    ldaxr w0, [x8]
@@ -221,9 +221,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_monotonic:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -235,9 +235,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_monotonic(ptr %ptr, i64 %value)
 define dso_local i64 @atomicrmw_xchg_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_acquire:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -249,9 +249,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acquire(ptr %ptr, i64 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_release:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -263,9 +263,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_release(ptr %ptr, i64 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_acq_rel:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -277,9 +277,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_seq_cst:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -298,7 +298,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O1:    ldxp x8, x1, [x0]
@@ -317,7 +316,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -336,7 +334,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O1:    ldxp x8, x1, [x0]
@@ -355,7 +352,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -374,7 +370,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -385,11 +380,11 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_monotonic:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -400,11 +395,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_acquire:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -415,11 +410,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_release:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -430,11 +425,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_release(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_acq_rel:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -445,11 +440,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_seq_cst:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -601,11 +596,11 @@ define dso_local i128 @atomicrmw_xchg_i128_unaligned_seq_cst(ptr %ptr, i128 %val
 define dso_local i8 @atomicrmw_add_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_monotonic:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -618,11 +613,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_acquire:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -635,11 +630,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_release:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -652,11 +647,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_acq_rel:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -669,11 +664,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_seq_cst:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -686,10 +681,10 @@ define dso_local i8 @atomicrmw_add_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_monotonic:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -702,10 +697,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_add_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_acquire:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -718,10 +713,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_release:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -734,10 +729,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_acq_rel:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -750,10 +745,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_seq_cst:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -765,11 +760,11 @@ define dso_local i16 @atomicrmw_add_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_monotonic:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -781,11 +776,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_add_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_acquire:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -797,11 +792,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_release:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -813,11 +808,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_acq_rel:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -829,11 +824,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_seq_cst:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -845,11 +840,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_monotonic:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -861,11 +856,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_add_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_acquire:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -877,11 +872,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_release:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -893,11 +888,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_acq_rel:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -909,11 +904,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_seq_cst:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -935,7 +930,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -957,7 +951,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -979,7 +972,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1001,7 +993,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1023,7 +1014,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1036,11 +1026,11 @@ define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_add_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_monotonic:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1053,11 +1043,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_acquire:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1070,11 +1060,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_release:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1087,11 +1077,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_acq_rel:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1104,11 +1094,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_seq_cst:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1371,11 +1361,11 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_seq_cst(ptr %ptr, i128 %valu
 define dso_local i8 @atomicrmw_sub_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_monotonic:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1388,11 +1378,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_acquire:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1405,11 +1395,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_release:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1422,11 +1412,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_acq_rel:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1439,11 +1429,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_seq_cst:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1456,10 +1446,10 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_monotonic:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1472,10 +1462,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_sub_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_acquire:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1488,10 +1478,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_release:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1504,10 +1494,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_acq_rel:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1520,10 +1510,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_seq_cst:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1535,11 +1525,11 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_monotonic:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1551,11 +1541,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_acquire:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1567,11 +1557,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_release:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1583,11 +1573,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_acq_rel:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1599,11 +1589,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_seq_cst:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1615,11 +1605,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_monotonic:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -1631,11 +1621,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_acquire:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -1647,11 +1637,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_release:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -1663,11 +1653,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_acq_rel:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -1679,11 +1669,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_seq_cst:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -1704,7 +1694,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1725,7 +1714,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1746,7 +1734,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1767,7 +1754,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1788,7 +1774,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1801,11 +1786,11 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_sub_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_monotonic:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1818,11 +1803,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_acquire:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1835,11 +1820,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_release:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1852,11 +1837,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_acq_rel:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1869,11 +1854,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_seq_cst:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2131,11 +2116,11 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_seq_cst(ptr %ptr, i128 %valu
 define dso_local i8 @atomicrmw_and_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_monotonic:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2148,11 +2133,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_acquire:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2165,11 +2150,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_release:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2182,11 +2167,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_acq_rel:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2199,11 +2184,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_seq_cst:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2216,10 +2201,10 @@ define dso_local i8 @atomicrmw_and_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_monotonic:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2232,10 +2217,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_and_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_acquire:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2248,10 +2233,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_release:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2264,10 +2249,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_acq_rel:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2280,10 +2265,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_seq_cst:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2295,11 +2280,11 @@ define dso_local i16 @atomicrmw_and_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_monotonic:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2311,11 +2296,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_and_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_acquire:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2327,11 +2312,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_release:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2343,11 +2328,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_acq_rel:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2359,11 +2344,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_seq_cst:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2375,11 +2360,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_monotonic:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -2391,11 +2376,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_and_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_acquire:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -2407,11 +2392,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_release:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -2423,11 +2408,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_acq_rel:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -2439,11 +2424,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_seq_cst:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -2465,7 +2450,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2488,7 +2472,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2511,7 +2494,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2534,7 +2516,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2557,7 +2538,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2571,11 +2551,11 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_and_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_monotonic:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2588,11 +2568,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_acquire:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2605,11 +2585,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_release:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2622,11 +2602,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_acq_rel:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2639,11 +2619,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_seq_cst:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2912,11 +2892,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2931,11 +2911,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2950,11 +2930,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2969,11 +2949,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2988,11 +2968,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3007,10 +2987,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3025,10 +3005,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3043,10 +3023,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3061,10 +3041,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3079,10 +3059,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -3095,12 +3075,12 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_monotonic:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -3113,12 +3093,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_acquire:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -3131,12 +3111,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_release:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -3149,12 +3129,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -3167,12 +3147,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -3185,12 +3165,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -3203,12 +3183,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -3221,12 +3201,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -3239,12 +3219,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -3257,12 +3237,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -3287,7 +3267,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3314,7 +3293,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3341,7 +3319,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3368,7 +3345,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3395,7 +3371,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3412,11 +3387,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3431,11 +3406,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3450,11 +3425,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3469,11 +3444,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3488,11 +3463,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3811,11 +3786,11 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_seq_cst(ptr %ptr, i128 %val
 define dso_local i8 @atomicrmw_or_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_monotonic:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3828,11 +3803,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_acquire:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3845,11 +3820,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_release:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3862,11 +3837,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_acq_rel:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3879,11 +3854,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_seq_cst:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3896,10 +3871,10 @@ define dso_local i8 @atomicrmw_or_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_monotonic:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3912,10 +3887,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_acquire:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3928,10 +3903,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_release:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3944,10 +3919,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_acq_rel:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3960,10 +3935,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_seq_cst:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -3975,11 +3950,11 @@ define dso_local i16 @atomicrmw_or_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_monotonic:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -3991,11 +3966,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_acquire:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4007,11 +3982,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_release:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4023,11 +3998,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_acq_rel:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4039,11 +4014,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_seq_cst:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4055,11 +4030,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_monotonic:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4071,11 +4046,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_acquire:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4087,11 +4062,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_release:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4103,11 +4078,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_acq_rel:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4119,11 +4094,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_seq_cst:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4145,7 +4120,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4168,7 +4142,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4191,7 +4164,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4214,7 +4186,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4237,7 +4208,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4251,11 +4221,11 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 define dso_local i8 @atomicrmw_or_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_monotonic:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4268,11 +4238,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_acquire:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4285,11 +4255,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_release:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4302,11 +4272,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_acq_rel:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4319,11 +4289,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_seq_cst:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4591,11 +4561,11 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_seq_cst(ptr %ptr, i128 %value
 define dso_local i8 @atomicrmw_xor_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_monotonic:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4608,11 +4578,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_acquire:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4625,11 +4595,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_release:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4642,11 +4612,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_acq_rel:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4659,11 +4629,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_seq_cst:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4676,10 +4646,10 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_monotonic:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -4692,10 +4662,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_xor_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_acquire:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -4708,10 +4678,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_release:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -4724,10 +4694,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_acq_rel:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -4740,10 +4710,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_seq_cst:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -4755,11 +4725,11 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_monotonic:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4771,11 +4741,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_acquire:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4787,11 +4757,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_release:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4803,11 +4773,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_acq_rel:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4819,11 +4789,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_seq_cst:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4835,11 +4805,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_monotonic:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4851,11 +4821,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_acquire:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4867,11 +4837,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_release:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4883,11 +4853,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_acq_rel:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4899,11 +4869,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_seq_cst:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4925,7 +4895,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4948,7 +4917,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4971,7 +4939,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4994,7 +4961,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5017,7 +4983,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5031,11 +4996,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_xor_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_monotonic:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -5048,11 +5013,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_acquire:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -5065,11 +5030,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_release:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -5082,11 +5047,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_acq_rel:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -5099,11 +5064,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_seq_cst:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -5373,11 +5338,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5394,11 +5359,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5415,11 +5380,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5436,11 +5401,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -5457,11 +5422,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -5478,10 +5443,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -5498,10 +5463,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -5518,10 +5483,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -5538,10 +5503,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -5558,10 +5523,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -5575,12 +5540,12 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -5593,12 +5558,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -5611,12 +5576,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -5629,12 +5594,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -5647,12 +5612,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -5665,12 +5630,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -5683,12 +5648,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -5701,12 +5666,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -5719,12 +5684,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -5737,12 +5702,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5771,7 +5736,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5801,7 +5765,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5831,7 +5794,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5861,7 +5823,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5891,7 +5852,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5908,11 +5868,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5929,11 +5889,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5950,11 +5910,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5971,11 +5931,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -5992,11 +5952,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6343,11 +6303,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6364,11 +6324,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6385,11 +6345,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6406,11 +6366,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6427,11 +6387,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6448,10 +6408,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -6468,10 +6428,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -6488,10 +6448,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -6508,10 +6468,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -6528,10 +6488,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -6545,12 +6505,12 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -6563,12 +6523,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -6581,12 +6541,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -6599,12 +6559,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -6617,12 +6577,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -6635,12 +6595,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -6653,12 +6613,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -6671,12 +6631,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -6689,12 +6649,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -6707,12 +6667,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -6741,7 +6701,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6771,7 +6730,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6801,7 +6759,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6831,7 +6788,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6861,7 +6817,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6878,11 +6833,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6899,11 +6854,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6920,11 +6875,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6941,11 +6896,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6962,11 +6917,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -7313,11 +7268,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7334,11 +7289,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7355,11 +7310,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7376,11 +7331,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7397,11 +7352,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -7417,10 +7372,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -7436,10 +7391,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -7455,10 +7410,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -7474,10 +7429,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -7493,10 +7448,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -7510,12 +7465,12 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -7528,12 +7483,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -7546,12 +7501,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -7564,12 +7519,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -7582,12 +7537,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -7600,12 +7555,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -7618,12 +7573,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -7636,12 +7591,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -7654,12 +7609,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -7672,12 +7627,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -7706,7 +7661,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7736,7 +7690,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7766,7 +7719,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7796,7 +7748,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7826,7 +7777,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7843,11 +7793,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7864,11 +7814,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7885,11 +7835,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7906,11 +7856,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7927,11 +7877,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8273,11 +8223,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8294,11 +8244,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8315,11 +8265,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8336,11 +8286,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8357,11 +8307,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8377,10 +8327,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -8396,10 +8346,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -8415,10 +8365,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -8434,10 +8384,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -8453,10 +8403,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -8470,12 +8420,12 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -8488,12 +8438,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -8506,12 +8456,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -8524,12 +8474,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -8542,12 +8492,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -8560,12 +8510,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -8578,12 +8528,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -8596,12 +8546,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -8614,12 +8564,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -8632,12 +8582,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -8666,7 +8616,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8696,7 +8645,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8726,7 +8674,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8756,7 +8703,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8786,7 +8732,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8803,11 +8748,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8824,11 +8769,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8845,11 +8790,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8866,11 +8811,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8887,11 +8832,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-rcpc3.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-rcpc3.ll
@@ -5,11 +5,11 @@
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_monotonic:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -20,11 +20,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_acquire:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -35,11 +35,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acquire(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_release:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -50,11 +50,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_release(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_acq_rel:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -65,11 +65,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_seq_cst:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -80,10 +80,10 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_monotonic:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_monotonic:
 ; -O1:    ldxrh w0, [x8]
@@ -94,10 +94,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_monotonic(ptr %ptr, i16 %value)
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_acquire:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acquire:
 ; -O1:    ldaxrh w0, [x8]
@@ -108,10 +108,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acquire(ptr %ptr, i16 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_release:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_release:
 ; -O1:    ldxrh w0, [x8]
@@ -122,10 +122,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_release(ptr %ptr, i16 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w0, [x8]
@@ -136,10 +136,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w0, [x8]
@@ -151,9 +151,9 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_monotonic:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_monotonic:
 ; -O1:    ldxr w0, [x8]
@@ -165,9 +165,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_monotonic(ptr %ptr, i32 %value)
 define dso_local i32 @atomicrmw_xchg_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_acquire:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acquire:
 ; -O1:    ldaxr w0, [x8]
@@ -179,9 +179,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acquire(ptr %ptr, i32 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_release:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_release:
 ; -O1:    ldxr w0, [x8]
@@ -193,9 +193,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_release(ptr %ptr, i32 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_acq_rel:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acq_rel:
 ; -O1:    ldaxr w0, [x8]
@@ -207,9 +207,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_seq_cst:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_seq_cst:
 ; -O1:    ldaxr w0, [x8]
@@ -221,9 +221,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_monotonic:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -235,9 +235,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_monotonic(ptr %ptr, i64 %value)
 define dso_local i64 @atomicrmw_xchg_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_acquire:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -249,9 +249,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acquire(ptr %ptr, i64 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_release:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -263,9 +263,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_release(ptr %ptr, i64 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_acq_rel:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -277,9 +277,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_seq_cst:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -298,7 +298,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O1:    ldxp x8, x1, [x0]
@@ -317,7 +316,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -336,7 +334,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O1:    ldxp x8, x1, [x0]
@@ -355,7 +352,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -374,7 +370,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -385,11 +380,11 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_monotonic:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -400,11 +395,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_acquire:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -415,11 +410,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_release:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -430,11 +425,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_release(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_acq_rel:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -445,11 +440,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_seq_cst:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -601,11 +596,11 @@ define dso_local i128 @atomicrmw_xchg_i128_unaligned_seq_cst(ptr %ptr, i128 %val
 define dso_local i8 @atomicrmw_add_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_monotonic:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -618,11 +613,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_acquire:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -635,11 +630,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_release:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -652,11 +647,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_acq_rel:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -669,11 +664,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_seq_cst:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -686,10 +681,10 @@ define dso_local i8 @atomicrmw_add_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_monotonic:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -702,10 +697,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_add_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_acquire:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -718,10 +713,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_release:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -734,10 +729,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_acq_rel:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -750,10 +745,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_seq_cst:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -765,11 +760,11 @@ define dso_local i16 @atomicrmw_add_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_monotonic:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -781,11 +776,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_add_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_acquire:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -797,11 +792,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_release:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -813,11 +808,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_acq_rel:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -829,11 +824,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_seq_cst:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -845,11 +840,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_monotonic:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -861,11 +856,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_add_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_acquire:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -877,11 +872,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_release:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -893,11 +888,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_acq_rel:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -909,11 +904,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_seq_cst:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -935,7 +930,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -957,7 +951,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -979,7 +972,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1001,7 +993,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1023,7 +1014,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1036,11 +1026,11 @@ define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_add_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_monotonic:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1053,11 +1043,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_acquire:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1070,11 +1060,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_release:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1087,11 +1077,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_acq_rel:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1104,11 +1094,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_seq_cst:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1371,11 +1361,11 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_seq_cst(ptr %ptr, i128 %valu
 define dso_local i8 @atomicrmw_sub_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_monotonic:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1388,11 +1378,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_acquire:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1405,11 +1395,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_release:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1422,11 +1412,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_acq_rel:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1439,11 +1429,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_seq_cst:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1456,10 +1446,10 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_monotonic:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1472,10 +1462,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_sub_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_acquire:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1488,10 +1478,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_release:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1504,10 +1494,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_acq_rel:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1520,10 +1510,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_seq_cst:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1535,11 +1525,11 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_monotonic:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1551,11 +1541,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_acquire:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1567,11 +1557,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_release:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1583,11 +1573,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_acq_rel:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1599,11 +1589,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_seq_cst:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1615,11 +1605,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_monotonic:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -1631,11 +1621,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_acquire:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -1647,11 +1637,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_release:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -1663,11 +1653,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_acq_rel:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -1679,11 +1669,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_seq_cst:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -1704,7 +1694,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1725,7 +1714,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1746,7 +1734,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1767,7 +1754,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1788,7 +1774,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1801,11 +1786,11 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_sub_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_monotonic:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1818,11 +1803,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_acquire:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1835,11 +1820,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_release:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1852,11 +1837,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_acq_rel:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1869,11 +1854,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_seq_cst:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2131,11 +2116,11 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_seq_cst(ptr %ptr, i128 %valu
 define dso_local i8 @atomicrmw_and_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_monotonic:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2148,11 +2133,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_acquire:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2165,11 +2150,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_release:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2182,11 +2167,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_acq_rel:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2199,11 +2184,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_seq_cst:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2216,10 +2201,10 @@ define dso_local i8 @atomicrmw_and_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_monotonic:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2232,10 +2217,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_and_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_acquire:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2248,10 +2233,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_release:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2264,10 +2249,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_acq_rel:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2280,10 +2265,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_seq_cst:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2295,11 +2280,11 @@ define dso_local i16 @atomicrmw_and_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_monotonic:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2311,11 +2296,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_and_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_acquire:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2327,11 +2312,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_release:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2343,11 +2328,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_acq_rel:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2359,11 +2344,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_seq_cst:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2375,11 +2360,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_monotonic:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -2391,11 +2376,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_and_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_acquire:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -2407,11 +2392,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_release:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -2423,11 +2408,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_acq_rel:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -2439,11 +2424,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_seq_cst:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -2465,7 +2450,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2488,7 +2472,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2511,7 +2494,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2534,7 +2516,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2557,7 +2538,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2571,11 +2551,11 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_and_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_monotonic:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2588,11 +2568,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_acquire:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2605,11 +2585,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_release:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2622,11 +2602,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_acq_rel:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2639,11 +2619,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_seq_cst:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2912,11 +2892,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2931,11 +2911,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2950,11 +2930,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2969,11 +2949,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2988,11 +2968,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3007,10 +2987,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3025,10 +3005,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3043,10 +3023,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3061,10 +3041,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3079,10 +3059,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -3095,12 +3075,12 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_monotonic:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -3113,12 +3093,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_acquire:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -3131,12 +3111,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_release:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -3149,12 +3129,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -3167,12 +3147,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -3185,12 +3165,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -3203,12 +3183,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -3221,12 +3201,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -3239,12 +3219,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -3257,12 +3237,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -3287,7 +3267,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3314,7 +3293,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3341,7 +3319,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3368,7 +3345,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3395,7 +3371,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3412,11 +3387,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3431,11 +3406,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3450,11 +3425,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3469,11 +3444,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3488,11 +3463,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3811,11 +3786,11 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_seq_cst(ptr %ptr, i128 %val
 define dso_local i8 @atomicrmw_or_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_monotonic:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3828,11 +3803,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_acquire:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3845,11 +3820,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_release:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3862,11 +3837,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_acq_rel:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3879,11 +3854,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_seq_cst:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3896,10 +3871,10 @@ define dso_local i8 @atomicrmw_or_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_monotonic:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3912,10 +3887,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_acquire:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3928,10 +3903,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_release:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3944,10 +3919,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_acq_rel:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3960,10 +3935,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_seq_cst:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -3975,11 +3950,11 @@ define dso_local i16 @atomicrmw_or_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_monotonic:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -3991,11 +3966,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_acquire:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4007,11 +3982,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_release:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4023,11 +3998,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_acq_rel:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4039,11 +4014,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_seq_cst:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4055,11 +4030,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_monotonic:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4071,11 +4046,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_acquire:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4087,11 +4062,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_release:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4103,11 +4078,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_acq_rel:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4119,11 +4094,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_seq_cst:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4145,7 +4120,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4168,7 +4142,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4191,7 +4164,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4214,7 +4186,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4237,7 +4208,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4251,11 +4221,11 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 define dso_local i8 @atomicrmw_or_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_monotonic:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4268,11 +4238,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_acquire:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4285,11 +4255,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_release:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4302,11 +4272,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_acq_rel:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4319,11 +4289,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_seq_cst:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4591,11 +4561,11 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_seq_cst(ptr %ptr, i128 %value
 define dso_local i8 @atomicrmw_xor_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_monotonic:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4608,11 +4578,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_acquire:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4625,11 +4595,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_release:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4642,11 +4612,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_acq_rel:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4659,11 +4629,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_seq_cst:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4676,10 +4646,10 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_monotonic:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -4692,10 +4662,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_xor_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_acquire:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -4708,10 +4678,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_release:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -4724,10 +4694,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_acq_rel:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -4740,10 +4710,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_seq_cst:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -4755,11 +4725,11 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_monotonic:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4771,11 +4741,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_acquire:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4787,11 +4757,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_release:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4803,11 +4773,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_acq_rel:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4819,11 +4789,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_seq_cst:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4835,11 +4805,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_monotonic:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4851,11 +4821,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_acquire:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4867,11 +4837,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_release:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4883,11 +4853,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_acq_rel:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4899,11 +4869,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_seq_cst:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4925,7 +4895,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4948,7 +4917,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4971,7 +4939,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4994,7 +4961,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5017,7 +4983,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5031,11 +4996,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_xor_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_monotonic:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -5048,11 +5013,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_acquire:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -5065,11 +5030,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_release:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -5082,11 +5047,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_acq_rel:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -5099,11 +5064,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_seq_cst:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -5373,11 +5338,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5394,11 +5359,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5415,11 +5380,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5436,11 +5401,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -5457,11 +5422,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -5478,10 +5443,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -5498,10 +5463,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -5518,10 +5483,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -5538,10 +5503,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -5558,10 +5523,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -5575,12 +5540,12 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -5593,12 +5558,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -5611,12 +5576,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -5629,12 +5594,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -5647,12 +5612,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -5665,12 +5630,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -5683,12 +5648,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -5701,12 +5666,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -5719,12 +5684,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -5737,12 +5702,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5771,7 +5736,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5801,7 +5765,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5831,7 +5794,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5861,7 +5823,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5891,7 +5852,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5908,11 +5868,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5929,11 +5889,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5950,11 +5910,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5971,11 +5931,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -5992,11 +5952,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6343,11 +6303,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6364,11 +6324,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6385,11 +6345,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6406,11 +6366,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6427,11 +6387,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6448,10 +6408,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -6468,10 +6428,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -6488,10 +6448,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -6508,10 +6468,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -6528,10 +6488,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -6545,12 +6505,12 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -6563,12 +6523,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -6581,12 +6541,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -6599,12 +6559,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -6617,12 +6577,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -6635,12 +6595,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -6653,12 +6613,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -6671,12 +6631,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -6689,12 +6649,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -6707,12 +6667,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -6741,7 +6701,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6771,7 +6730,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6801,7 +6759,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6831,7 +6788,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6861,7 +6817,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6878,11 +6833,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6899,11 +6854,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6920,11 +6875,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6941,11 +6896,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6962,11 +6917,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -7313,11 +7268,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7334,11 +7289,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7355,11 +7310,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7376,11 +7331,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7397,11 +7352,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -7417,10 +7372,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -7436,10 +7391,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -7455,10 +7410,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -7474,10 +7429,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -7493,10 +7448,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -7510,12 +7465,12 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -7528,12 +7483,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -7546,12 +7501,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -7564,12 +7519,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -7582,12 +7537,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -7600,12 +7555,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -7618,12 +7573,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -7636,12 +7591,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -7654,12 +7609,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -7672,12 +7627,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -7706,7 +7661,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7736,7 +7690,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7766,7 +7719,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7796,7 +7748,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7826,7 +7777,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7843,11 +7793,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7864,11 +7814,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7885,11 +7835,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7906,11 +7856,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7927,11 +7877,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8273,11 +8223,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8294,11 +8244,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8315,11 +8265,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8336,11 +8286,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8357,11 +8307,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8377,10 +8327,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -8396,10 +8346,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -8415,10 +8365,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -8434,10 +8384,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -8453,10 +8403,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -8470,12 +8420,12 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -8488,12 +8438,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -8506,12 +8456,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -8524,12 +8474,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -8542,12 +8492,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -8560,12 +8510,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -8578,12 +8528,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -8596,12 +8546,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -8614,12 +8564,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -8632,12 +8582,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -8666,7 +8616,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8696,7 +8645,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8726,7 +8674,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8756,7 +8703,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8786,7 +8732,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8803,11 +8748,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8824,11 +8769,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8845,11 +8790,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8866,11 +8811,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8887,11 +8832,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8_1a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8_1a.ll
@@ -149,7 +149,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -166,7 +165,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -183,7 +181,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -200,7 +197,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -217,7 +213,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -551,7 +546,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -571,7 +565,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -591,7 +584,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -611,7 +603,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -631,7 +622,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -1075,7 +1065,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -1094,7 +1083,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -1113,7 +1101,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -1132,7 +1119,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -1151,7 +1137,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -1611,7 +1596,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -1632,7 +1616,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -1653,7 +1636,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -1674,7 +1656,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -1695,7 +1676,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -2006,10 +1986,10 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_seq_cst(ptr %ptr, i128 %valu
 define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2023,10 +2003,10 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casab w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casab w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2040,10 +2020,10 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    caslb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    caslb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O1:    and w10, w8, w1
@@ -2057,10 +2037,10 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casalb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casalb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2074,10 +2054,10 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casalb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casalb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -2091,9 +2071,9 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    cash w9, w10, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    mvn w9, w9
+; -O0:    cash w10, w9, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2107,9 +2087,9 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casah w9, w10, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    mvn w9, w9
+; -O0:    casah w10, w9, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2123,9 +2103,9 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    caslh w9, w10, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    mvn w9, w9
+; -O0:    caslh w10, w9, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    and w10, w8, w1
@@ -2139,9 +2119,9 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casalh w9, w10, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    mvn w9, w9
+; -O0:    casalh w10, w9, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2155,9 +2135,9 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casalh w9, w10, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    mvn w9, w9
+; -O0:    casalh w10, w9, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -2170,10 +2150,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_monotonic:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    cas w9, w10, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    and w8, w10, w8
+; -O0:    mvn w8, w8
+; -O0:    cas w9, w8, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2186,10 +2166,10 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_acquire:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casa w9, w10, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    and w8, w10, w8
+; -O0:    mvn w8, w8
+; -O0:    casa w9, w8, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2202,10 +2182,10 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_release:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casl w9, w10, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    and w8, w10, w8
+; -O0:    mvn w8, w8
+; -O0:    casl w9, w8, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    and w10, w8, w1
@@ -2218,10 +2198,10 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casal w9, w10, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    and w8, w10, w8
+; -O0:    mvn w8, w8
+; -O0:    casal w9, w8, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2234,10 +2214,10 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w10, w9
-; -O0:    casal w9, w10, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    and w8, w10, w8
+; -O0:    mvn w8, w8
+; -O0:    casal w9, w8, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -2250,10 +2230,10 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x10, x9
-; -O0:    cas x9, x10, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    and x8, x10, x8
+; -O0:    mvn x8, x8
+; -O0:    cas x9, x8, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    and x10, x8, x1
@@ -2266,10 +2246,10 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x10, x9
-; -O0:    casa x9, x10, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    and x8, x10, x8
+; -O0:    mvn x8, x8
+; -O0:    casa x9, x8, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    and x10, x8, x1
@@ -2282,10 +2262,10 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x10, x9
-; -O0:    casl x9, x10, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    and x8, x10, x8
+; -O0:    mvn x8, x8
+; -O0:    casl x9, x8, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    and x10, x8, x1
@@ -2298,10 +2278,10 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x10, x9
-; -O0:    casal x9, x10, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    and x8, x10, x8
+; -O0:    mvn x8, x8
+; -O0:    casal x9, x8, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    and x10, x8, x1
@@ -2314,10 +2294,10 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x10, x9
-; -O0:    casal x9, x10, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    and x8, x10, x8
+; -O0:    mvn x8, x8
+; -O0:    casal x9, x8, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    and x10, x8, x1
@@ -2338,7 +2318,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -2363,7 +2342,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -2388,7 +2366,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -2413,7 +2390,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -2438,7 +2414,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -2456,10 +2431,10 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O1:    and w10, w8, w1
@@ -2473,10 +2448,10 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casab w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casab w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O1:    and w10, w8, w1
@@ -2490,10 +2465,10 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    caslb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    caslb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O1:    and w10, w8, w1
@@ -2507,10 +2482,10 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casalb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casalb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O1:    and w10, w8, w1
@@ -2524,10 +2499,10 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_nand_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O0:    and w8, w10, w8
-; -O0:    mvn w8, w8
-; -O0:    casalb w9, w8, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    mvn w9, w8
+; -O0:    casalb w8, w9, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O1:    and w10, w8, w1
@@ -2991,7 +2966,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -3012,7 +2986,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -3033,7 +3006,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -3054,7 +3026,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -3075,7 +3046,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -3526,7 +3496,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -3547,7 +3516,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -3568,7 +3536,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -3589,7 +3556,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -3610,7 +3576,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -4067,7 +4032,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -4095,7 +4059,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -4123,7 +4086,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -4151,7 +4113,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -4179,7 +4140,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -4712,7 +4672,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -4740,7 +4699,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -4768,7 +4726,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -4796,7 +4753,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -4824,7 +4780,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -5357,7 +5312,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -5385,7 +5339,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -5413,7 +5366,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -5441,7 +5393,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -5469,7 +5420,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -5997,7 +5947,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -6025,7 +5974,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -6053,7 +6001,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -6081,7 +6028,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -6109,7 +6055,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8a.ll
@@ -5,11 +5,11 @@
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_monotonic:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -20,11 +20,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_acquire:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -35,11 +35,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acquire(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_release:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -50,11 +50,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_release(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_acq_rel:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -65,11 +65,11 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_aligned_seq_cst:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -80,10 +80,10 @@ define dso_local i8 @atomicrmw_xchg_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_monotonic:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_monotonic:
 ; -O1:    ldxrh w0, [x8]
@@ -94,10 +94,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_monotonic(ptr %ptr, i16 %value)
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_acquire:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acquire:
 ; -O1:    ldaxrh w0, [x8]
@@ -108,10 +108,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acquire(ptr %ptr, i16 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_release:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_release:
 ; -O1:    ldxrh w0, [x8]
@@ -122,10 +122,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_release(ptr %ptr, i16 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w0, [x8]
@@ -136,10 +136,10 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 
 define dso_local i16 @atomicrmw_xchg_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i16_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xchg_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w0, [x8]
@@ -151,9 +151,9 @@ define dso_local i16 @atomicrmw_xchg_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_monotonic:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_monotonic:
 ; -O1:    ldxr w0, [x8]
@@ -165,9 +165,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_monotonic(ptr %ptr, i32 %value)
 define dso_local i32 @atomicrmw_xchg_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_acquire:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acquire:
 ; -O1:    ldaxr w0, [x8]
@@ -179,9 +179,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acquire(ptr %ptr, i32 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_release:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_release:
 ; -O1:    ldxr w0, [x8]
@@ -193,9 +193,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_release(ptr %ptr, i32 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_acq_rel:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_acq_rel:
 ; -O1:    ldaxr w0, [x8]
@@ -207,9 +207,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 define dso_local i32 @atomicrmw_xchg_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i32_aligned_seq_cst:
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i32_aligned_seq_cst:
 ; -O1:    ldaxr w0, [x8]
@@ -221,9 +221,9 @@ define dso_local i32 @atomicrmw_xchg_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_monotonic:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -235,9 +235,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_monotonic(ptr %ptr, i64 %value)
 define dso_local i64 @atomicrmw_xchg_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_acquire:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -249,9 +249,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acquire(ptr %ptr, i64 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_release:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -263,9 +263,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_release(ptr %ptr, i64 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_acq_rel:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -277,9 +277,9 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i64_aligned_seq_cst:
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xchg_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -298,7 +298,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O1:    ldxp x8, x1, [x0]
@@ -317,7 +316,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -336,7 +334,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O1:    ldxp x8, x1, [x0]
@@ -355,7 +352,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -374,7 +370,6 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -385,11 +380,11 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_monotonic:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_monotonic:
 ; -O1:    ldxrb w0, [x8]
@@ -400,11 +395,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_acquire:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acquire:
 ; -O1:    ldaxrb w0, [x8]
@@ -415,11 +410,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_release:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_release:
 ; -O1:    ldxrb w0, [x8]
@@ -430,11 +425,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_release(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_acq_rel:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w0, [x8]
@@ -445,11 +440,11 @@ define dso_local i8 @atomicrmw_xchg_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 
 define dso_local i8 @atomicrmw_xchg_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i8_unaligned_seq_cst:
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xchg_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w0, [x8]
@@ -601,11 +596,11 @@ define dso_local i128 @atomicrmw_xchg_i128_unaligned_seq_cst(ptr %ptr, i128 %val
 define dso_local i8 @atomicrmw_add_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_monotonic:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -618,11 +613,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_acquire:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -635,11 +630,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_release:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -652,11 +647,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_acq_rel:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -669,11 +664,11 @@ define dso_local i8 @atomicrmw_add_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_aligned_seq_cst:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -686,10 +681,10 @@ define dso_local i8 @atomicrmw_add_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_monotonic:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -702,10 +697,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_add_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_acquire:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -718,10 +713,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_release:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -734,10 +729,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_acq_rel:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -750,10 +745,10 @@ define dso_local i16 @atomicrmw_add_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_add_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_add_i16_aligned_seq_cst:
 ; -O0:    add w12, w9, w8, uxth
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_add_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -765,11 +760,11 @@ define dso_local i16 @atomicrmw_add_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_monotonic:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -781,11 +776,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_add_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_acquire:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -797,11 +792,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_release:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -813,11 +808,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_acq_rel:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -829,11 +824,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_add_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_add_i32_aligned_seq_cst:
-; -O0:    add w12, w8, w9
+; -O0:    add w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_add_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -845,11 +840,11 @@ define dso_local i32 @atomicrmw_add_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_monotonic:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -861,11 +856,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_add_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_acquire:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -877,11 +872,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_release:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -893,11 +888,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_acq_rel:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -909,11 +904,11 @@ define dso_local i64 @atomicrmw_add_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_add_i64_aligned_seq_cst:
-; -O0:    add x12, x8, x9
+; -O0:    add x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_add_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -935,7 +930,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -957,7 +951,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -979,7 +972,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1001,7 +993,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1023,7 +1014,6 @@ define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1036,11 +1026,11 @@ define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_add_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_monotonic:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1053,11 +1043,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_acquire:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1070,11 +1060,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_release:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1087,11 +1077,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_acq_rel:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1104,11 +1094,11 @@ define dso_local i8 @atomicrmw_add_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_add_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_add_i8_unaligned_seq_cst:
 ; -O0:    add w12, w8, w10, uxth
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_add_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1371,11 +1361,11 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_seq_cst(ptr %ptr, i128 %valu
 define dso_local i8 @atomicrmw_sub_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_monotonic:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1388,11 +1378,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_acquire:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1405,11 +1395,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_release:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1422,11 +1412,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_acq_rel:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1439,11 +1429,11 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_aligned_seq_cst:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -1456,10 +1446,10 @@ define dso_local i8 @atomicrmw_sub_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_monotonic:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1472,10 +1462,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_sub_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_acquire:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1488,10 +1478,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_release:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1504,10 +1494,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_acq_rel:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1520,10 +1510,10 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_sub_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_sub_i16_aligned_seq_cst:
 ; -O0:    subs w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_sub_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1535,11 +1525,11 @@ define dso_local i16 @atomicrmw_sub_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_monotonic:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1551,11 +1541,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_acquire:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1567,11 +1557,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_release:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1583,11 +1573,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_acq_rel:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1599,11 +1589,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_sub_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_sub_i32_aligned_seq_cst:
-; -O0:    subs w12, w8, w9
+; -O0:    subs w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_sub_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1615,11 +1605,11 @@ define dso_local i32 @atomicrmw_sub_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_monotonic:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -1631,11 +1621,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_acquire:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -1647,11 +1637,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_release:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -1663,11 +1653,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_acq_rel:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -1679,11 +1669,11 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_sub_i64_aligned_seq_cst:
-; -O0:    subs x12, x8, x9
+; -O0:    subs x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_sub_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -1704,7 +1694,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1725,7 +1714,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1746,7 +1734,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1767,7 +1754,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1788,7 +1774,6 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1801,11 +1786,11 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_sub_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_monotonic:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -1818,11 +1803,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_acquire:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -1835,11 +1820,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_release:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -1852,11 +1837,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_acq_rel:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -1869,11 +1854,11 @@ define dso_local i8 @atomicrmw_sub_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_sub_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_sub_i8_unaligned_seq_cst:
 ; -O0:    subs w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_sub_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2131,11 +2116,11 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_seq_cst(ptr %ptr, i128 %valu
 define dso_local i8 @atomicrmw_and_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_monotonic:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2148,11 +2133,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_acquire:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2165,11 +2150,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_release:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2182,11 +2167,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_acq_rel:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2199,11 +2184,11 @@ define dso_local i8 @atomicrmw_and_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_aligned_seq_cst:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2216,10 +2201,10 @@ define dso_local i8 @atomicrmw_and_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_monotonic:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2232,10 +2217,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_and_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_acquire:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2248,10 +2233,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_release:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2264,10 +2249,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_acq_rel:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2280,10 +2265,10 @@ define dso_local i16 @atomicrmw_and_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_and_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_and_i16_aligned_seq_cst:
 ; -O0:    and w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_and_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2295,11 +2280,11 @@ define dso_local i16 @atomicrmw_and_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_monotonic:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2311,11 +2296,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_and_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_acquire:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2327,11 +2312,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_release:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2343,11 +2328,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_acq_rel:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2359,11 +2344,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_and_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_and_i32_aligned_seq_cst:
-; -O0:    and w12, w8, w9
+; -O0:    and w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_and_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2375,11 +2360,11 @@ define dso_local i32 @atomicrmw_and_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_monotonic:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -2391,11 +2376,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_and_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_acquire:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -2407,11 +2392,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_release:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -2423,11 +2408,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_acq_rel:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -2439,11 +2424,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_and_i64_aligned_seq_cst:
-; -O0:    and x12, x8, x9
+; -O0:    and x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_and_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -2465,7 +2450,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2488,7 +2472,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2511,7 +2494,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2534,7 +2516,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2557,7 +2538,6 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2571,11 +2551,11 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_and_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_monotonic:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2588,11 +2568,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_acquire:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2605,11 +2585,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_release:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2622,11 +2602,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_acq_rel:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2639,11 +2619,11 @@ define dso_local i8 @atomicrmw_and_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_and_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_and_i8_unaligned_seq_cst:
 ; -O0:    and w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_and_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -2912,11 +2892,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -2931,11 +2911,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -2950,11 +2930,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -2969,11 +2949,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -2988,11 +2968,11 @@ define dso_local i8 @atomicrmw_nand_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3007,10 +2987,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3025,10 +3005,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3043,10 +3023,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3061,10 +3041,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3079,10 +3059,10 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O0:    and w9, w8, w9
 ; -O0:    mvn w12, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_nand_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -3095,12 +3075,12 @@ define dso_local i16 @atomicrmw_nand_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_monotonic:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -3113,12 +3093,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_acquire:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -3131,12 +3111,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_release:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -3149,12 +3129,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -3167,12 +3147,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
-; -O0:    and w9, w8, w9
-; -O0:    mvn w12, w9
+; -O0:    and w8, w10, w8
+; -O0:    mvn w12, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_nand_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -3185,12 +3165,12 @@ define dso_local i32 @atomicrmw_nand_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -3203,12 +3183,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -3221,12 +3201,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -3239,12 +3219,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -3257,12 +3237,12 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    mvn x12, x9
+; -O0:    and x8, x10, x8
+; -O0:    mvn x12, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_nand_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -3287,7 +3267,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3314,7 +3293,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3341,7 +3319,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3368,7 +3345,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3395,7 +3371,6 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3412,11 +3387,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3431,11 +3406,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3450,11 +3425,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3469,11 +3444,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3488,11 +3463,11 @@ define dso_local i8 @atomicrmw_nand_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O0:    and w8, w10, w8
 ; -O0:    mvn w12, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_nand_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3811,11 +3786,11 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_seq_cst(ptr %ptr, i128 %val
 define dso_local i8 @atomicrmw_or_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_monotonic:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -3828,11 +3803,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_acquire:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -3845,11 +3820,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_release:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -3862,11 +3837,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_acq_rel:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -3879,11 +3854,11 @@ define dso_local i8 @atomicrmw_or_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_aligned_seq_cst:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -3896,10 +3871,10 @@ define dso_local i8 @atomicrmw_or_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_monotonic:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -3912,10 +3887,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_acquire:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -3928,10 +3903,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_release:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -3944,10 +3919,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_acq_rel:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -3960,10 +3935,10 @@ define dso_local i16 @atomicrmw_or_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_or_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_or_i16_aligned_seq_cst:
 ; -O0:    orr w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_or_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -3975,11 +3950,11 @@ define dso_local i16 @atomicrmw_or_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_monotonic:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -3991,11 +3966,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_acquire:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4007,11 +3982,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_release:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4023,11 +3998,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_acq_rel:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4039,11 +4014,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_or_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_or_i32_aligned_seq_cst:
-; -O0:    orr w12, w8, w9
+; -O0:    orr w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_or_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4055,11 +4030,11 @@ define dso_local i32 @atomicrmw_or_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_monotonic:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4071,11 +4046,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_acquire:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4087,11 +4062,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_release:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4103,11 +4078,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_acq_rel:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4119,11 +4094,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_or_i64_aligned_seq_cst:
-; -O0:    orr x12, x8, x9
+; -O0:    orr x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_or_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4145,7 +4120,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4168,7 +4142,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4191,7 +4164,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4214,7 +4186,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4237,7 +4208,6 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4251,11 +4221,11 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 define dso_local i8 @atomicrmw_or_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_monotonic:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4268,11 +4238,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_acquire:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4285,11 +4255,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_release:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4302,11 +4272,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_acq_rel:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4319,11 +4289,11 @@ define dso_local i8 @atomicrmw_or_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_or_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_or_i8_unaligned_seq_cst:
 ; -O0:    orr w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_or_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4591,11 +4561,11 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_seq_cst(ptr %ptr, i128 %value
 define dso_local i8 @atomicrmw_xor_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_monotonic:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -4608,11 +4578,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_acquire:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -4625,11 +4595,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_release:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -4642,11 +4612,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_acq_rel:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -4659,11 +4629,11 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_aligned_seq_cst:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -4676,10 +4646,10 @@ define dso_local i8 @atomicrmw_xor_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_monotonic(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_monotonic:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -4692,10 +4662,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 define dso_local i16 @atomicrmw_xor_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_acquire:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -4708,10 +4678,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acquire(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_release:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -4724,10 +4694,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_release(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_acq_rel:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -4740,10 +4710,10 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 define dso_local i16 @atomicrmw_xor_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_xor_i16_aligned_seq_cst:
 ; -O0:    eor w12, w8, w9
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_xor_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -4755,11 +4725,11 @@ define dso_local i16 @atomicrmw_xor_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_monotonic:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -4771,11 +4741,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_acquire:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -4787,11 +4757,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_release:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -4803,11 +4773,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_acq_rel:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -4819,11 +4789,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_xor_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_xor_i32_aligned_seq_cst:
-; -O0:    eor w12, w8, w9
+; -O0:    eor w12, w10, w8
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_xor_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -4835,11 +4805,11 @@ define dso_local i32 @atomicrmw_xor_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_monotonic:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -4851,11 +4821,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_acquire:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -4867,11 +4837,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_release:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -4883,11 +4853,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_acq_rel:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -4899,11 +4869,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_xor_i64_aligned_seq_cst:
-; -O0:    eor x12, x8, x9
+; -O0:    eor x12, x10, x8
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_xor_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -4925,7 +4895,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4948,7 +4917,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4971,7 +4939,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4994,7 +4961,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5017,7 +4983,6 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5031,11 +4996,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 define dso_local i8 @atomicrmw_xor_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_monotonic:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_monotonic:
 ; -O1:    ldxrb w8, [x0]
@@ -5048,11 +5013,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_acquire:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acquire:
 ; -O1:    ldaxrb w8, [x0]
@@ -5065,11 +5030,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_release:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_release:
 ; -O1:    ldxrb w8, [x0]
@@ -5082,11 +5047,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_release(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_acq_rel:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w8, [x0]
@@ -5099,11 +5064,11 @@ define dso_local i8 @atomicrmw_xor_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 define dso_local i8 @atomicrmw_xor_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0-LABEL: atomicrmw_xor_i8_unaligned_seq_cst:
 ; -O0:    eor w12, w10, w8
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_xor_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w8, [x0]
@@ -5373,11 +5338,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5394,11 +5359,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5415,11 +5380,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5436,11 +5401,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -5457,11 +5422,11 @@ define dso_local i8 @atomicrmw_max_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -5478,10 +5443,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -5498,10 +5463,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -5518,10 +5483,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -5538,10 +5503,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -5558,10 +5523,10 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, gt
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_max_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -5575,12 +5540,12 @@ define dso_local i16 @atomicrmw_max_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -5593,12 +5558,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -5611,12 +5576,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -5629,12 +5594,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -5647,12 +5612,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_max_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, gt
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, gt
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_max_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -5665,12 +5630,12 @@ define dso_local i32 @atomicrmw_max_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -5683,12 +5648,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -5701,12 +5666,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -5719,12 +5684,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -5737,12 +5702,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_max_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, gt
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, gt
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_max_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -5771,7 +5736,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5801,7 +5765,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5831,7 +5794,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5861,7 +5823,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5891,7 +5852,6 @@ define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5908,11 +5868,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -5929,11 +5889,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -5950,11 +5910,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -5971,11 +5931,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -5992,11 +5952,11 @@ define dso_local i8 @atomicrmw_max_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, gt
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_max_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6343,11 +6303,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6364,11 +6324,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6385,11 +6345,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6406,11 +6366,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6427,11 +6387,11 @@ define dso_local i8 @atomicrmw_min_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_aligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -6448,10 +6408,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_monotonic(ptr %ptr, i16 %value) 
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -6468,10 +6428,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -6488,10 +6448,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -6508,10 +6468,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -6528,10 +6488,10 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0:    sxth w10, w8
 ; -O0:    subs w10, w10, w9, sxth
 ; -O0:    csel w12, w8, w9, le
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_min_i16_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -6545,12 +6505,12 @@ define dso_local i16 @atomicrmw_min_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -6563,12 +6523,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_monotonic(ptr %ptr, i32 %value) 
 
 define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -6581,12 +6541,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -6599,12 +6559,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -6617,12 +6577,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_min_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, le
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, le
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_min_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -6635,12 +6595,12 @@ define dso_local i32 @atomicrmw_min_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -6653,12 +6613,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_monotonic(ptr %ptr, i64 %value) 
 
 define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -6671,12 +6631,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -6689,12 +6649,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -6707,12 +6667,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_min_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, le
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, le
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_min_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -6741,7 +6701,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6771,7 +6730,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6801,7 +6759,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6831,7 +6788,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6861,7 +6817,6 @@ define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6878,11 +6833,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_monotonic:
 ; -O1:    ldxrb w9, [x0]
@@ -6899,11 +6854,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acquire:
 ; -O1:    ldaxrb w9, [x0]
@@ -6920,11 +6875,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_release:
 ; -O1:    ldxrb w9, [x0]
@@ -6941,11 +6896,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_acq_rel:
 ; -O1:    ldaxrb w9, [x0]
@@ -6962,11 +6917,11 @@ define dso_local i8 @atomicrmw_min_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    sxtb w9, w10
 ; -O0:    subs w9, w9, w8, sxtb
 ; -O0:    csel w12, w10, w8, le
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_min_i8_unaligned_seq_cst:
 ; -O1:    ldaxrb w9, [x0]
@@ -7313,11 +7268,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7334,11 +7289,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7355,11 +7310,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7376,11 +7331,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7397,11 +7352,11 @@ define dso_local i8 @atomicrmw_umax_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -7417,10 +7372,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -7436,10 +7391,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -7455,10 +7410,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -7474,10 +7429,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -7493,10 +7448,10 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, hi
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umax_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -7510,12 +7465,12 @@ define dso_local i16 @atomicrmw_umax_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -7528,12 +7483,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -7546,12 +7501,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -7564,12 +7519,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -7582,12 +7537,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, hi
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, hi
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umax_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -7600,12 +7555,12 @@ define dso_local i32 @atomicrmw_umax_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -7618,12 +7573,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -7636,12 +7591,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -7654,12 +7609,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -7672,12 +7627,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, hi
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, hi
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umax_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -7706,7 +7661,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7736,7 +7690,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7766,7 +7719,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7796,7 +7748,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7826,7 +7777,6 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7843,11 +7793,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -7864,11 +7814,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -7885,11 +7835,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -7906,11 +7856,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -7927,11 +7877,11 @@ define dso_local i8 @atomicrmw_umax_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, hi
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umax_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8273,11 +8223,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_monotonic(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8294,11 +8244,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8315,11 +8265,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8336,11 +8286,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8357,11 +8307,11 @@ define dso_local i8 @atomicrmw_umin_i8_aligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xff
@@ -8377,10 +8327,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_monotonic(ptr %ptr, i16 %value)
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_monotonic:
 ; -O1:    and w9, w1, #0xffff
@@ -8396,10 +8346,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acquire(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acquire:
 ; -O1:    and w9, w1, #0xffff
@@ -8415,10 +8365,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_release(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_release:
 ; -O1:    and w9, w1, #0xffff
@@ -8434,10 +8384,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_acq_rel(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_acq_rel:
 ; -O1:    and w9, w1, #0xffff
@@ -8453,10 +8403,10 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 ; -O0-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O0:    subs w10, w10, w9, uxth
 ; -O0:    csel w12, w8, w9, ls
-; -O0:    ldaxrh w9, [x11]
-; -O0:    cmp w9, w8, uxth
-; -O0:    stlxrh w10, w12, [x11]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w10, [x11]
+; -O0:    cmp w10, w8, uxth
+; -O0:    stlxrh w9, w12, [x11]
+; -O0:    subs w9, w9, w10, uxth
 ;
 ; -O1-LABEL: atomicrmw_umin_i16_aligned_seq_cst:
 ; -O1:    and w9, w1, #0xffff
@@ -8470,12 +8420,12 @@ define dso_local i16 @atomicrmw_umin_i16_aligned_seq_cst(ptr %ptr, i16 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_monotonic:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -8488,12 +8438,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_monotonic(ptr %ptr, i32 %value)
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_acquire:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -8506,12 +8456,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acquire(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_release:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -8524,12 +8474,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_release(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -8542,12 +8492,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_acq_rel(ptr %ptr, i32 %value) {
 
 define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 ; -O0-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
-; -O0:    subs w10, w8, w9
-; -O0:    csel w12, w8, w9, ls
+; -O0:    subs w9, w10, w8
+; -O0:    csel w12, w10, w8, ls
 ; -O0:    ldaxr w9, [x11]
-; -O0:    cmp w9, w8
-; -O0:    stlxr w10, w12, [x11]
-; -O0:    subs w8, w9, w8
+; -O0:    cmp w9, w10
+; -O0:    stlxr w8, w12, [x11]
+; -O0:    subs w9, w9, w10
 ;
 ; -O1-LABEL: atomicrmw_umin_i32_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -8560,12 +8510,12 @@ define dso_local i32 @atomicrmw_umin_i32_aligned_seq_cst(ptr %ptr, i32 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_monotonic:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_monotonic:
 ; -O1:    ldxr x0, [x8]
@@ -8578,12 +8528,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_monotonic(ptr %ptr, i64 %value)
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_acquire:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acquire:
 ; -O1:    ldaxr x0, [x8]
@@ -8596,12 +8546,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acquire(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_release:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_release:
 ; -O1:    ldxr x0, [x8]
@@ -8614,12 +8564,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_release(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_acq_rel:
 ; -O1:    ldaxr x0, [x8]
@@ -8632,12 +8582,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_acq_rel(ptr %ptr, i64 %value) {
 
 define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 ; -O0-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
-; -O0:    subs x10, x8, x9
-; -O0:    csel x12, x8, x9, ls
+; -O0:    subs x9, x10, x8
+; -O0:    csel x12, x10, x8, ls
 ; -O0:    ldaxr x9, [x11]
-; -O0:    cmp x9, x8
-; -O0:    stlxr w10, x12, [x11]
-; -O0:    subs x8, x9, x8
+; -O0:    cmp x9, x10
+; -O0:    stlxr w8, x12, [x11]
+; -O0:    subs x9, x9, x10
 ;
 ; -O1-LABEL: atomicrmw_umin_i64_aligned_seq_cst:
 ; -O1:    ldaxr x0, [x8]
@@ -8666,7 +8616,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8696,7 +8645,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8726,7 +8674,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8756,7 +8703,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8786,7 +8732,6 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    eor x8, x10, x8
 ; -O0:    eor x11, x9, x11
 ; -O0:    orr x8, x8, x11
-; -O0:    subs x8, x8, #0
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8803,11 +8748,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_monotonic(ptr %ptr, i8 %value) 
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_monotonic:
 ; -O1:    and w9, w1, #0xff
@@ -8824,11 +8769,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acquire(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acquire:
 ; -O1:    and w9, w1, #0xff
@@ -8845,11 +8790,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_release(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_release:
 ; -O1:    and w9, w1, #0xff
@@ -8866,11 +8811,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_acq_rel(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_acq_rel:
 ; -O1:    and w9, w1, #0xff
@@ -8887,11 +8832,11 @@ define dso_local i8 @atomicrmw_umin_i8_unaligned_seq_cst(ptr %ptr, i8 %value) {
 ; -O0:    and w9, w10, #0xff
 ; -O0:    subs w9, w9, w8, uxtb
 ; -O0:    csel w12, w10, w8, ls
-; -O0:    ldaxrb w9, [x11]
-; -O0:    cmp w9, w10, uxtb
-; -O0:    stlxrb w8, w12, [x11]
-; -O0:    and w8, w9, #0xff
-; -O0:    subs w8, w8, w10, uxtb
+; -O0:    ldaxrb w8, [x11]
+; -O0:    cmp w8, w10, uxtb
+; -O0:    stlxrb w9, w12, [x11]
+; -O0:    and w9, w8, #0xff
+; -O0:    subs w9, w9, w10, uxtb
 ;
 ; -O1-LABEL: atomicrmw_umin_i8_unaligned_seq_cst:
 ; -O1:    and w9, w1, #0xff

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8a_fp.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8a_fp.ll
@@ -5,10 +5,10 @@
 
 define dso_local half @atomicrmw_fadd_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_monotonic:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -19,10 +19,10 @@ define dso_local half @atomicrmw_fadd_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fadd_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_acquire:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -33,10 +33,10 @@ define dso_local half @atomicrmw_fadd_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fadd_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_release:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -47,10 +47,10 @@ define dso_local half @atomicrmw_fadd_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fadd_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_acq_rel:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -61,10 +61,10 @@ define dso_local half @atomicrmw_fadd_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fadd_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_seq_cst:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -165,10 +165,10 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fadd_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_monotonic:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -179,10 +179,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fadd_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_acquire:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -193,10 +193,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fadd_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_release:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -207,10 +207,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fadd_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_acq_rel:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -221,10 +221,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fadd_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_seq_cst:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -235,10 +235,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fadd_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_monotonic:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -249,10 +249,10 @@ define dso_local double @atomicrmw_fadd_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fadd_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_acquire:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -263,10 +263,10 @@ define dso_local double @atomicrmw_fadd_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fadd_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_release:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -277,10 +277,10 @@ define dso_local double @atomicrmw_fadd_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fadd_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_acq_rel:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -291,10 +291,10 @@ define dso_local double @atomicrmw_fadd_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fadd_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_seq_cst:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -480,10 +480,10 @@ define dso_local double @atomicrmw_fadd_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fsub_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_monotonic:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -494,10 +494,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fsub_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_acquire:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -508,10 +508,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_release:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -522,10 +522,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_acq_rel:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -536,10 +536,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_seq_cst:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -640,10 +640,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fsub_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_monotonic:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -654,10 +654,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fsub_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_acquire:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -668,10 +668,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_release:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -682,10 +682,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_acq_rel:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -696,10 +696,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_seq_cst:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -710,10 +710,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fsub_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_monotonic:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -724,10 +724,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fsub_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_acquire:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -738,10 +738,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_release:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -752,10 +752,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_acq_rel:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -766,10 +766,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_seq_cst:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -955,10 +955,10 @@ define dso_local double @atomicrmw_fsub_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fmax_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_monotonic:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -969,10 +969,10 @@ define dso_local half @atomicrmw_fmax_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fmax_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_acquire:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -983,10 +983,10 @@ define dso_local half @atomicrmw_fmax_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmax_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_release:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -997,10 +997,10 @@ define dso_local half @atomicrmw_fmax_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmax_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_acq_rel:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1011,10 +1011,10 @@ define dso_local half @atomicrmw_fmax_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmax_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_seq_cst:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1115,10 +1115,10 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fmax_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_monotonic:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1129,10 +1129,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fmax_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_acquire:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1143,10 +1143,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmax_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_release:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1157,10 +1157,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmax_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_acq_rel:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1171,10 +1171,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmax_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_seq_cst:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1185,10 +1185,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fmax_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_monotonic:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -1199,10 +1199,10 @@ define dso_local double @atomicrmw_fmax_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fmax_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_acquire:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -1213,10 +1213,10 @@ define dso_local double @atomicrmw_fmax_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmax_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_release:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -1227,10 +1227,10 @@ define dso_local double @atomicrmw_fmax_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmax_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_acq_rel:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -1241,10 +1241,10 @@ define dso_local double @atomicrmw_fmax_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmax_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_seq_cst:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -1430,10 +1430,10 @@ define dso_local double @atomicrmw_fmax_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fmin_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_monotonic:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1444,10 +1444,10 @@ define dso_local half @atomicrmw_fmin_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fmin_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_acquire:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1458,10 +1458,10 @@ define dso_local half @atomicrmw_fmin_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmin_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_release:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1472,10 +1472,10 @@ define dso_local half @atomicrmw_fmin_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmin_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_acq_rel:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1486,10 +1486,10 @@ define dso_local half @atomicrmw_fmin_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmin_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_seq_cst:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1590,10 +1590,10 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fmin_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_monotonic:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1604,10 +1604,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fmin_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_acquire:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1618,10 +1618,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmin_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_release:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1632,10 +1632,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmin_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_acq_rel:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1646,10 +1646,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmin_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_seq_cst:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1660,10 +1660,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fmin_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_monotonic:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -1674,10 +1674,10 @@ define dso_local double @atomicrmw_fmin_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fmin_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_acquire:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -1688,10 +1688,10 @@ define dso_local double @atomicrmw_fmin_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmin_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_release:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -1702,10 +1702,10 @@ define dso_local double @atomicrmw_fmin_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmin_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_acq_rel:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -1716,10 +1716,10 @@ define dso_local double @atomicrmw_fmin_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmin_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_seq_cst:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -1905,10 +1905,10 @@ define dso_local double @atomicrmw_fmin_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_monotonic:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1919,10 +1919,10 @@ define dso_local half @atomicrmw_fmaximum_half_aligned_monotonic(ptr %ptr, half 
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_acquire:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1933,10 +1933,10 @@ define dso_local half @atomicrmw_fmaximum_half_aligned_acquire(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_release:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1947,10 +1947,10 @@ define dso_local half @atomicrmw_fmaximum_half_aligned_release(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_acq_rel:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1961,10 +1961,10 @@ define dso_local half @atomicrmw_fmaximum_half_aligned_acq_rel(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_seq_cst:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2065,10 +2065,10 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_seq_cst(ptr %ptr, bfl
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_monotonic:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2079,10 +2079,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_monotonic(ptr %ptr, flo
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_acquire:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2093,10 +2093,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_acquire(ptr %ptr, float
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_release:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2107,10 +2107,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_release(ptr %ptr, float
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_acq_rel:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2121,10 +2121,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_acq_rel(ptr %ptr, float
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_seq_cst:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2135,10 +2135,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_seq_cst(ptr %ptr, float
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_monotonic:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -2149,10 +2149,10 @@ define dso_local double @atomicrmw_fmaximum_double_aligned_monotonic(ptr %ptr, d
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_acquire:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -2163,10 +2163,10 @@ define dso_local double @atomicrmw_fmaximum_double_aligned_acquire(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_release:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -2177,10 +2177,10 @@ define dso_local double @atomicrmw_fmaximum_double_aligned_release(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_acq_rel:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -2191,10 +2191,10 @@ define dso_local double @atomicrmw_fmaximum_double_aligned_acq_rel(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_seq_cst:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -2380,10 +2380,10 @@ define dso_local double @atomicrmw_fmaximum_double_unaligned_seq_cst(ptr %ptr, d
 
 define dso_local half @atomicrmw_fminimum_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_monotonic:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2394,10 +2394,10 @@ define dso_local half @atomicrmw_fminimum_half_aligned_monotonic(ptr %ptr, half 
 
 define dso_local half @atomicrmw_fminimum_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_acquire:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2408,10 +2408,10 @@ define dso_local half @atomicrmw_fminimum_half_aligned_acquire(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fminimum_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_release:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2422,10 +2422,10 @@ define dso_local half @atomicrmw_fminimum_half_aligned_release(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fminimum_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_acq_rel:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2436,10 +2436,10 @@ define dso_local half @atomicrmw_fminimum_half_aligned_acq_rel(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fminimum_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_seq_cst:
-; -O0:    ldaxrh w0, [x9]
-; -O0:    cmp w0, w10, uxth
-; -O0:    stlxrh w8, w11, [x9]
-; -O0:    subs w8, w8, w0, uxth
+; -O0:    ldaxrh w9, [x10]
+; -O0:    cmp w9, w11, uxth
+; -O0:    stlxrh w8, w12, [x10]
+; -O0:    subs w8, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2540,10 +2540,10 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_seq_cst(ptr %ptr, bfl
 
 define dso_local float @atomicrmw_fminimum_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_monotonic:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2554,10 +2554,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_monotonic(ptr %ptr, flo
 
 define dso_local float @atomicrmw_fminimum_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_acquire:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2568,10 +2568,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_acquire(ptr %ptr, float
 
 define dso_local float @atomicrmw_fminimum_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_release:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2582,10 +2582,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_release(ptr %ptr, float
 
 define dso_local float @atomicrmw_fminimum_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_acq_rel:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2596,10 +2596,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_acq_rel(ptr %ptr, float
 
 define dso_local float @atomicrmw_fminimum_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_seq_cst:
-; -O0:    ldaxr w0, [x9]
-; -O0:    cmp w0, w10
-; -O0:    stlxr w8, w11, [x9]
-; -O0:    subs w8, w0, w8
+; -O0:    ldaxr w8, [x10]
+; -O0:    cmp w8, w11
+; -O0:    stlxr w9, w12, [x10]
+; -O0:    subs w8, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2610,10 +2610,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_seq_cst(ptr %ptr, float
 
 define dso_local double @atomicrmw_fminimum_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_monotonic:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -2624,10 +2624,10 @@ define dso_local double @atomicrmw_fminimum_double_aligned_monotonic(ptr %ptr, d
 
 define dso_local double @atomicrmw_fminimum_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_acquire:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -2638,10 +2638,10 @@ define dso_local double @atomicrmw_fminimum_double_aligned_acquire(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fminimum_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_release:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -2652,10 +2652,10 @@ define dso_local double @atomicrmw_fminimum_double_aligned_release(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fminimum_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_acq_rel:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -2666,10 +2666,10 @@ define dso_local double @atomicrmw_fminimum_double_aligned_acq_rel(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fminimum_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_seq_cst:
-; -O0:    ldaxr x0, [x9]
-; -O0:    cmp x0, x10
-; -O0:    stlxr w8, x11, [x9]
-; -O0:    subs x8, x0, x8
+; -O0:    ldaxr x8, [x10]
+; -O0:    cmp x8, x11
+; -O0:    stlxr w9, x12, [x10]
+; -O0:    subs x8, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]

--- a/llvm/test/CodeGen/AArch64/GlobalISel/arm64-atomic.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/arm64-atomic.ll
@@ -496,28 +496,28 @@ define i32 @fetch_and_nand(ptr %p) #0 {
 ; CHECK-NOLSE-O0-NEXT:  LBB6_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB6_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0x7
-; CHECK-NOLSE-O0-NEXT:    mvn w12, w9
+; CHECK-NOLSE-O0-NEXT:    and w8, w10, #0x7
+; CHECK-NOLSE-O0-NEXT:    mvn w12, w8
 ; CHECK-NOLSE-O0-NEXT:  LBB6_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB6_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB6_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB6_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB6_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB6_2
 ; CHECK-NOLSE-O0-NEXT:  LBB6_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB6_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs w8, w9, w8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB6_1
-; CHECK-NOLSE-O0-NEXT:    b LBB6_5
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB6_5
+; CHECK-NOLSE-O0-NEXT:    b LBB6_1
 ; CHECK-NOLSE-O0-NEXT:  LBB6_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -539,13 +539,14 @@ define i32 @fetch_and_nand(ptr %p) #0 {
 ; CHECK-OUTLINE-O0-NEXT:    and w8, w0, #0x7
 ; CHECK-OUTLINE-O0-NEXT:    mvn w1, w8
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas4_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w0, w8
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov w8, w0
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w8
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB6_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB6_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB6_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB6_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB6_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -576,18 +577,18 @@ define i32 @fetch_and_nand(ptr %p) #0 {
 ; CHECK-LSE-O0-NEXT:    b LBB6_1
 ; CHECK-LSE-O0-NEXT:  LBB6_1: ; %atomicrmw.start
 ; CHECK-LSE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-LSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-LSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-LSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-LSE-O0-NEXT:    and w9, w8, #0x7
-; CHECK-LSE-O0-NEXT:    mvn w10, w9
-; CHECK-LSE-O0-NEXT:    mov x9, x8
-; CHECK-LSE-O0-NEXT:    casl w9, w10, [x11]
-; CHECK-LSE-O0-NEXT:    subs w8, w9, w8
-; CHECK-LSE-O0-NEXT:    cset w8, eq
-; CHECK-LSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-LSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-LSE-O0-NEXT:    tbz w8, #0, LBB6_1
-; CHECK-LSE-O0-NEXT:    b LBB6_2
+; CHECK-LSE-O0-NEXT:    and w8, w10, #0x7
+; CHECK-LSE-O0-NEXT:    mvn w8, w8
+; CHECK-LSE-O0-NEXT:    mov x9, x10
+; CHECK-LSE-O0-NEXT:    casl w9, w8, [x11]
+; CHECK-LSE-O0-NEXT:    mov x8, x9
+; CHECK-LSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-LSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-LSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-LSE-O0-NEXT:    b.eq LBB6_2
+; CHECK-LSE-O0-NEXT:    b LBB6_1
 ; CHECK-LSE-O0-NEXT:  LBB6_2: ; %atomicrmw.end
 ; CHECK-LSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-LSE-O0-NEXT:    add sp, sp, #32
@@ -633,28 +634,28 @@ define i64 @fetch_and_nand_64(ptr %p) #0 {
 ; CHECK-NOLSE-O0-NEXT:  LBB7_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB7_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    and x9, x8, #0x7
-; CHECK-NOLSE-O0-NEXT:    mvn x12, x9
+; CHECK-NOLSE-O0-NEXT:    and x8, x10, #0x7
+; CHECK-NOLSE-O0-NEXT:    mvn x12, x8
 ; CHECK-NOLSE-O0-NEXT:  LBB7_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB7_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x8
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB7_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB7_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB7_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB7_2
 ; CHECK-NOLSE-O0-NEXT:  LBB7_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB7_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs x8, x9, x8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #8] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB7_1
-; CHECK-NOLSE-O0-NEXT:    b LBB7_5
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #8] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB7_5
+; CHECK-NOLSE-O0-NEXT:    b LBB7_1
 ; CHECK-NOLSE-O0-NEXT:  LBB7_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp, #8] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -676,13 +677,14 @@ define i64 @fetch_and_nand_64(ptr %p) #0 {
 ; CHECK-OUTLINE-O0-NEXT:    and x8, x0, #0x7
 ; CHECK-OUTLINE-O0-NEXT:    mvn x1, x8
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas8_acq_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr x8, [sp] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    subs x8, x0, x8
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    ldr x9, [sp] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov x8, x0
+; CHECK-OUTLINE-O0-NEXT:    mov x0, x8
 ; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #8] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs x8, x8, x9
 ; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #24] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB7_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB7_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB7_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB7_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB7_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #8] ; 8-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -713,18 +715,18 @@ define i64 @fetch_and_nand_64(ptr %p) #0 {
 ; CHECK-LSE-O0-NEXT:    b LBB7_1
 ; CHECK-LSE-O0-NEXT:  LBB7_1: ; %atomicrmw.start
 ; CHECK-LSE-O0-NEXT:    ; =>This Inner Loop Header: Depth=1
-; CHECK-LSE-O0-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
+; CHECK-LSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-LSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-LSE-O0-NEXT:    and x9, x8, #0x7
-; CHECK-LSE-O0-NEXT:    mvn x10, x9
-; CHECK-LSE-O0-NEXT:    mov x9, x8
-; CHECK-LSE-O0-NEXT:    casal x9, x10, [x11]
-; CHECK-LSE-O0-NEXT:    subs x8, x9, x8
-; CHECK-LSE-O0-NEXT:    cset w8, eq
-; CHECK-LSE-O0-NEXT:    str x9, [sp, #8] ; 8-byte Spill
-; CHECK-LSE-O0-NEXT:    str x9, [sp, #24] ; 8-byte Spill
-; CHECK-LSE-O0-NEXT:    tbz w8, #0, LBB7_1
-; CHECK-LSE-O0-NEXT:    b LBB7_2
+; CHECK-LSE-O0-NEXT:    and x8, x10, #0x7
+; CHECK-LSE-O0-NEXT:    mvn x8, x8
+; CHECK-LSE-O0-NEXT:    mov x9, x10
+; CHECK-LSE-O0-NEXT:    casal x9, x8, [x11]
+; CHECK-LSE-O0-NEXT:    mov x8, x9
+; CHECK-LSE-O0-NEXT:    str x8, [sp, #8] ; 8-byte Spill
+; CHECK-LSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-LSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-LSE-O0-NEXT:    b.eq LBB7_2
+; CHECK-LSE-O0-NEXT:    b LBB7_1
 ; CHECK-LSE-O0-NEXT:  LBB7_2: ; %atomicrmw.end
 ; CHECK-LSE-O0-NEXT:    ldr x0, [sp, #8] ; 8-byte Reload
 ; CHECK-LSE-O0-NEXT:    add sp, sp, #32
@@ -766,28 +768,28 @@ define i32 @fetch_and_or(ptr %p) #0 {
 ; CHECK-NOLSE-O0-NEXT:  LBB8_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB8_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    mov w9, #5 ; =0x5
-; CHECK-NOLSE-O0-NEXT:    orr w12, w8, w9
+; CHECK-NOLSE-O0-NEXT:    mov w8, #5 ; =0x5
+; CHECK-NOLSE-O0-NEXT:    orr w12, w10, w8
 ; CHECK-NOLSE-O0-NEXT:  LBB8_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB8_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB8_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB8_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB8_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB8_2
 ; CHECK-NOLSE-O0-NEXT:  LBB8_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB8_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs w8, w9, w8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB8_1
-; CHECK-NOLSE-O0-NEXT:    b LBB8_5
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB8_5
+; CHECK-NOLSE-O0-NEXT:    b LBB8_1
 ; CHECK-NOLSE-O0-NEXT:  LBB8_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -840,27 +842,27 @@ define i64 @fetch_and_or_64(ptr %p) #0 {
 ; CHECK-NOLSE-O0-NEXT:  LBB9_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB9_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    orr x12, x8, #0x7
+; CHECK-NOLSE-O0-NEXT:    orr x12, x10, #0x7
 ; CHECK-NOLSE-O0-NEXT:  LBB9_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB9_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x8
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB9_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB9_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB9_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB9_2
 ; CHECK-NOLSE-O0-NEXT:  LBB9_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB9_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs x8, x9, x8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #8] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB9_1
-; CHECK-NOLSE-O0-NEXT:    b LBB9_5
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #8] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB9_5
+; CHECK-NOLSE-O0-NEXT:    b LBB9_1
 ; CHECK-NOLSE-O0-NEXT:  LBB9_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp, #8] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -1880,22 +1882,21 @@ define i8 @atomicrmw_add_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB27_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB27_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrb w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB27_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB27_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrb w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB27_2
+; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB27_2
 ; CHECK-NOLSE-O0-NEXT:  LBB27_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB27_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    and w8, w9, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB27_1
-; CHECK-NOLSE-O0-NEXT:    b LBB27_5
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB27_5
+; CHECK-NOLSE-O0-NEXT:    b LBB27_1
 ; CHECK-NOLSE-O0-NEXT:  LBB27_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -1972,22 +1973,21 @@ define i8 @atomicrmw_xchg_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB28_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB28_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrb w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB28_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB28_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrb w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB28_2
+; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB28_2
 ; CHECK-NOLSE-O0-NEXT:  LBB28_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB28_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    and w8, w9, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB28_1
-; CHECK-NOLSE-O0-NEXT:    b LBB28_5
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB28_5
+; CHECK-NOLSE-O0-NEXT:    b LBB28_1
 ; CHECK-NOLSE-O0-NEXT:  LBB28_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -2066,22 +2066,21 @@ define i8 @atomicrmw_sub_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB29_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB29_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrb w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB29_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB29_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrb w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB29_2
+; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB29_2
 ; CHECK-NOLSE-O0-NEXT:  LBB29_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB29_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    and w8, w9, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB29_1
-; CHECK-NOLSE-O0-NEXT:    b LBB29_5
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB29_5
+; CHECK-NOLSE-O0-NEXT:    b LBB29_1
 ; CHECK-NOLSE-O0-NEXT:  LBB29_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -2164,22 +2163,21 @@ define i8 @atomicrmw_and_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB30_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB30_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrb w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB30_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB30_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrb w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB30_2
+; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB30_2
 ; CHECK-NOLSE-O0-NEXT:  LBB30_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB30_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    and w8, w9, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB30_1
-; CHECK-NOLSE-O0-NEXT:    b LBB30_5
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB30_5
+; CHECK-NOLSE-O0-NEXT:    b LBB30_1
 ; CHECK-NOLSE-O0-NEXT:  LBB30_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -2262,22 +2260,21 @@ define i8 @atomicrmw_or_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB31_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB31_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrb w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB31_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB31_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrb w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB31_2
+; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB31_2
 ; CHECK-NOLSE-O0-NEXT:  LBB31_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB31_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    and w8, w9, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB31_1
-; CHECK-NOLSE-O0-NEXT:    b LBB31_5
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB31_5
+; CHECK-NOLSE-O0-NEXT:    b LBB31_1
 ; CHECK-NOLSE-O0-NEXT:  LBB31_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -2356,22 +2353,21 @@ define i8 @atomicrmw_xor_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB32_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB32_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrb w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB32_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB32_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrb w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB32_2
+; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB32_2
 ; CHECK-NOLSE-O0-NEXT:  LBB32_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB32_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    and w8, w9, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB32_1
-; CHECK-NOLSE-O0-NEXT:    b LBB32_5
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB32_5
+; CHECK-NOLSE-O0-NEXT:    b LBB32_1
 ; CHECK-NOLSE-O0-NEXT:  LBB32_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -2455,22 +2451,21 @@ define i8 @atomicrmw_min_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB33_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB33_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrb w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB33_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB33_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrb w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB33_2
+; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB33_2
 ; CHECK-NOLSE-O0-NEXT:  LBB33_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB33_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    and w8, w9, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB33_1
-; CHECK-NOLSE-O0-NEXT:    b LBB33_5
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB33_5
+; CHECK-NOLSE-O0-NEXT:    b LBB33_1
 ; CHECK-NOLSE-O0-NEXT:  LBB33_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -2502,10 +2497,9 @@ define i8 @atomicrmw_min_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
 ; CHECK-OUTLINE-O0-NEXT:    and w8, w0, #0xff
 ; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxtb
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB33_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB33_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB33_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB33_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB33_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -2575,22 +2569,21 @@ define i8 @atomicrmw_max_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB34_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB34_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrb w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB34_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB34_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrb w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB34_2
+; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB34_2
 ; CHECK-NOLSE-O0-NEXT:  LBB34_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB34_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    and w8, w9, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB34_1
-; CHECK-NOLSE-O0-NEXT:    b LBB34_5
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB34_5
+; CHECK-NOLSE-O0-NEXT:    b LBB34_1
 ; CHECK-NOLSE-O0-NEXT:  LBB34_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -2622,10 +2615,9 @@ define i8 @atomicrmw_max_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
 ; CHECK-OUTLINE-O0-NEXT:    and w8, w0, #0xff
 ; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxtb
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB34_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB34_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB34_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB34_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB34_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -2697,22 +2689,21 @@ define i8 @atomicrmw_umin_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB35_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB35_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrb w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB35_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB35_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrb w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB35_2
+; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB35_2
 ; CHECK-NOLSE-O0-NEXT:  LBB35_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB35_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    and w8, w9, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB35_1
-; CHECK-NOLSE-O0-NEXT:    b LBB35_5
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB35_5
+; CHECK-NOLSE-O0-NEXT:    b LBB35_1
 ; CHECK-NOLSE-O0-NEXT:  LBB35_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -2744,10 +2735,9 @@ define i8 @atomicrmw_umin_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
 ; CHECK-OUTLINE-O0-NEXT:    and w8, w0, #0xff
 ; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxtb
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB35_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB35_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB35_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB35_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB35_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -2819,22 +2809,21 @@ define i8 @atomicrmw_umax_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB36_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB36_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrb w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    ldaxrb w8, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w8, w10, uxtb
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB36_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB36_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrb w8, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB36_2
+; CHECK-NOLSE-O0-NEXT:    stlxrb w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB36_2
 ; CHECK-NOLSE-O0-NEXT:  LBB36_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB36_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    and w8, w9, #0xff
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w10, uxtb
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB36_1
-; CHECK-NOLSE-O0-NEXT:    b LBB36_5
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    and w9, w8, #0xff
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxtb
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB36_5
+; CHECK-NOLSE-O0-NEXT:    b LBB36_1
 ; CHECK-NOLSE-O0-NEXT:  LBB36_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -2866,10 +2855,9 @@ define i8 @atomicrmw_umax_i8(ptr %ptr, i8 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
 ; CHECK-OUTLINE-O0-NEXT:    and w8, w0, #0xff
 ; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxtb
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB36_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB36_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB36_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB36_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB36_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -2934,22 +2922,22 @@ define i16 @atomicrmw_add_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB37_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB37_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrh w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8, uxth
+; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB37_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB37_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrh w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB37_2
+; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB37_2
 ; CHECK-NOLSE-O0-NEXT:  LBB37_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB37_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    uxth w8, w8
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w9, uxth
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB37_1
-; CHECK-NOLSE-O0-NEXT:    b LBB37_5
+; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
+; CHECK-NOLSE-O0-NEXT:    mov w8, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB37_5
+; CHECK-NOLSE-O0-NEXT:    b LBB37_1
 ; CHECK-NOLSE-O0-NEXT:  LBB37_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -3026,22 +3014,22 @@ define i16 @atomicrmw_xchg_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB38_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB38_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrh w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8, uxth
+; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB38_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB38_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrh w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB38_2
+; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB38_2
 ; CHECK-NOLSE-O0-NEXT:  LBB38_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB38_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    uxth w8, w8
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w9, uxth
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB38_1
-; CHECK-NOLSE-O0-NEXT:    b LBB38_5
+; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
+; CHECK-NOLSE-O0-NEXT:    mov w8, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB38_5
+; CHECK-NOLSE-O0-NEXT:    b LBB38_1
 ; CHECK-NOLSE-O0-NEXT:  LBB38_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -3120,22 +3108,22 @@ define i16 @atomicrmw_sub_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB39_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB39_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrh w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8, uxth
+; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB39_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB39_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrh w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB39_2
+; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB39_2
 ; CHECK-NOLSE-O0-NEXT:  LBB39_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB39_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    uxth w8, w8
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w9, uxth
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB39_1
-; CHECK-NOLSE-O0-NEXT:    b LBB39_5
+; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
+; CHECK-NOLSE-O0-NEXT:    mov w8, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB39_5
+; CHECK-NOLSE-O0-NEXT:    b LBB39_1
 ; CHECK-NOLSE-O0-NEXT:  LBB39_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -3218,22 +3206,22 @@ define i16 @atomicrmw_and_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB40_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB40_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrh w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8, uxth
+; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB40_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB40_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrh w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB40_2
+; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB40_2
 ; CHECK-NOLSE-O0-NEXT:  LBB40_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB40_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    uxth w8, w8
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w9, uxth
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB40_1
-; CHECK-NOLSE-O0-NEXT:    b LBB40_5
+; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
+; CHECK-NOLSE-O0-NEXT:    mov w8, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB40_5
+; CHECK-NOLSE-O0-NEXT:    b LBB40_1
 ; CHECK-NOLSE-O0-NEXT:  LBB40_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -3316,22 +3304,22 @@ define i16 @atomicrmw_or_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB41_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB41_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrh w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8, uxth
+; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB41_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB41_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrh w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB41_2
+; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB41_2
 ; CHECK-NOLSE-O0-NEXT:  LBB41_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB41_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    uxth w8, w8
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w9, uxth
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB41_1
-; CHECK-NOLSE-O0-NEXT:    b LBB41_5
+; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
+; CHECK-NOLSE-O0-NEXT:    mov w8, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB41_5
+; CHECK-NOLSE-O0-NEXT:    b LBB41_1
 ; CHECK-NOLSE-O0-NEXT:  LBB41_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -3410,22 +3398,22 @@ define i16 @atomicrmw_xor_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB42_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB42_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrh w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8, uxth
+; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB42_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB42_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrh w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB42_2
+; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB42_2
 ; CHECK-NOLSE-O0-NEXT:  LBB42_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB42_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    uxth w8, w8
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w9, uxth
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB42_1
-; CHECK-NOLSE-O0-NEXT:    b LBB42_5
+; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
+; CHECK-NOLSE-O0-NEXT:    mov w8, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB42_5
+; CHECK-NOLSE-O0-NEXT:    b LBB42_1
 ; CHECK-NOLSE-O0-NEXT:  LBB42_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -3509,22 +3497,22 @@ define i16 @atomicrmw_min_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB43_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB43_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrh w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8, uxth
+; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB43_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB43_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrh w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB43_2
+; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB43_2
 ; CHECK-NOLSE-O0-NEXT:  LBB43_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB43_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    uxth w8, w8
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w9, uxth
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB43_1
-; CHECK-NOLSE-O0-NEXT:    b LBB43_5
+; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
+; CHECK-NOLSE-O0-NEXT:    mov w8, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB43_5
+; CHECK-NOLSE-O0-NEXT:    b LBB43_1
 ; CHECK-NOLSE-O0-NEXT:  LBB43_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -3553,13 +3541,14 @@ define i16 @atomicrmw_min_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, le
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas2_acq
 ; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    mov w9, w0
+; CHECK-OUTLINE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
 ; CHECK-OUTLINE-O0-NEXT:    uxth w8, w8
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w0, uxth
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w9
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxth
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB43_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB43_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB43_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB43_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB43_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -3629,22 +3618,22 @@ define i16 @atomicrmw_max_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB44_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB44_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrh w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8, uxth
+; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB44_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB44_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrh w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB44_2
+; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB44_2
 ; CHECK-NOLSE-O0-NEXT:  LBB44_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB44_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    uxth w8, w8
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w9, uxth
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB44_1
-; CHECK-NOLSE-O0-NEXT:    b LBB44_5
+; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
+; CHECK-NOLSE-O0-NEXT:    mov w8, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB44_5
+; CHECK-NOLSE-O0-NEXT:    b LBB44_1
 ; CHECK-NOLSE-O0-NEXT:  LBB44_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -3673,13 +3662,14 @@ define i16 @atomicrmw_max_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, gt
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas2_rel
 ; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    mov w9, w0
+; CHECK-OUTLINE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
 ; CHECK-OUTLINE-O0-NEXT:    uxth w8, w8
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w0, uxth
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w9
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxth
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB44_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB44_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB44_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB44_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB44_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -3751,22 +3741,22 @@ define i16 @atomicrmw_umin_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB45_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB45_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrh w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8, uxth
+; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB45_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB45_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrh w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB45_2
+; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB45_2
 ; CHECK-NOLSE-O0-NEXT:  LBB45_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB45_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    uxth w8, w8
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w9, uxth
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB45_1
-; CHECK-NOLSE-O0-NEXT:    b LBB45_5
+; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
+; CHECK-NOLSE-O0-NEXT:    mov w8, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB45_5
+; CHECK-NOLSE-O0-NEXT:    b LBB45_1
 ; CHECK-NOLSE-O0-NEXT:  LBB45_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -3795,13 +3785,14 @@ define i16 @atomicrmw_umin_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, ls
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas2_acq_rel
 ; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    mov w9, w0
+; CHECK-OUTLINE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
 ; CHECK-OUTLINE-O0-NEXT:    uxth w8, w8
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w0, uxth
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w9
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxth
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB45_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB45_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB45_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB45_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB45_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -3873,22 +3864,22 @@ define i16 @atomicrmw_umax_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB46_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB46_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
-; CHECK-NOLSE-O0-NEXT:    ldaxrh w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8, uxth
+; CHECK-NOLSE-O0-NEXT:    ldaxrh w10, [x11]
+; CHECK-NOLSE-O0-NEXT:    cmp w10, w8, uxth
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB46_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB46_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxrh w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB46_2
+; CHECK-NOLSE-O0-NEXT:    stlxrh w9, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w9, LBB46_2
 ; CHECK-NOLSE-O0-NEXT:  LBB46_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB46_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    uxth w8, w8
-; CHECK-NOLSE-O0-NEXT:    subs w8, w8, w9, uxth
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB46_1
-; CHECK-NOLSE-O0-NEXT:    b LBB46_5
+; CHECK-NOLSE-O0-NEXT:    str w10, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    uxth w9, w8
+; CHECK-NOLSE-O0-NEXT:    mov w8, w10
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10, uxth
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB46_5
+; CHECK-NOLSE-O0-NEXT:    b LBB46_1
 ; CHECK-NOLSE-O0-NEXT:  LBB46_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -3917,13 +3908,14 @@ define i16 @atomicrmw_umax_i16(ptr %ptr, i16 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, hi
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas2_relax
 ; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    mov w9, w0
+; CHECK-OUTLINE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
 ; CHECK-OUTLINE-O0-NEXT:    uxth w8, w8
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w0, uxth
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w9
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9, uxth
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB46_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB46_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB46_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB46_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB46_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -3981,28 +3973,28 @@ define i32 @atomicrmw_add_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB47_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB47_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add w12, w8, w9
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add w12, w10, w8
 ; CHECK-NOLSE-O0-NEXT:  LBB47_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB47_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB47_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB47_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB47_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB47_2
 ; CHECK-NOLSE-O0-NEXT:  LBB47_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB47_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs w8, w9, w8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB47_1
-; CHECK-NOLSE-O0-NEXT:    b LBB47_5
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB47_5
+; CHECK-NOLSE-O0-NEXT:    b LBB47_1
 ; CHECK-NOLSE-O0-NEXT:  LBB47_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -4074,27 +4066,27 @@ define i32 @atomicrmw_xchg_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB48_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB48_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr w12, [sp, #24] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:  LBB48_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB48_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB48_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB48_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB48_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB48_2
 ; CHECK-NOLSE-O0-NEXT:  LBB48_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB48_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs w8, w9, w8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB48_1
-; CHECK-NOLSE-O0-NEXT:    b LBB48_5
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB48_5
+; CHECK-NOLSE-O0-NEXT:    b LBB48_1
 ; CHECK-NOLSE-O0-NEXT:  LBB48_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -4166,28 +4158,28 @@ define i32 @atomicrmw_sub_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB49_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB49_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs w12, w8, w9
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs w12, w10, w8
 ; CHECK-NOLSE-O0-NEXT:  LBB49_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB49_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB49_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB49_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB49_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB49_2
 ; CHECK-NOLSE-O0-NEXT:  LBB49_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB49_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs w8, w9, w8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB49_1
-; CHECK-NOLSE-O0-NEXT:    b LBB49_5
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB49_5
+; CHECK-NOLSE-O0-NEXT:    b LBB49_1
 ; CHECK-NOLSE-O0-NEXT:  LBB49_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -4263,28 +4255,28 @@ define i32 @atomicrmw_and_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB50_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB50_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    and w12, w8, w9
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    and w12, w10, w8
 ; CHECK-NOLSE-O0-NEXT:  LBB50_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB50_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB50_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB50_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB50_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB50_2
 ; CHECK-NOLSE-O0-NEXT:  LBB50_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB50_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs w8, w9, w8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB50_1
-; CHECK-NOLSE-O0-NEXT:    b LBB50_5
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB50_5
+; CHECK-NOLSE-O0-NEXT:    b LBB50_1
 ; CHECK-NOLSE-O0-NEXT:  LBB50_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -4360,28 +4352,28 @@ define i32 @atomicrmw_or_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB51_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB51_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    orr w12, w8, w9
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    orr w12, w10, w8
 ; CHECK-NOLSE-O0-NEXT:  LBB51_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB51_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB51_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB51_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB51_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB51_2
 ; CHECK-NOLSE-O0-NEXT:  LBB51_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB51_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs w8, w9, w8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB51_1
-; CHECK-NOLSE-O0-NEXT:    b LBB51_5
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB51_5
+; CHECK-NOLSE-O0-NEXT:    b LBB51_1
 ; CHECK-NOLSE-O0-NEXT:  LBB51_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -4453,28 +4445,28 @@ define i32 @atomicrmw_xor_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB52_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB52_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    eor w12, w8, w9
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    eor w12, w10, w8
 ; CHECK-NOLSE-O0-NEXT:  LBB52_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB52_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB52_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB52_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB52_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB52_2
 ; CHECK-NOLSE-O0-NEXT:  LBB52_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB52_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs w8, w9, w8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB52_1
-; CHECK-NOLSE-O0-NEXT:    b LBB52_5
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB52_5
+; CHECK-NOLSE-O0-NEXT:    b LBB52_1
 ; CHECK-NOLSE-O0-NEXT:  LBB52_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -4547,29 +4539,29 @@ define i32 @atomicrmw_min_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB53_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB53_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs w10, w8, w9
-; CHECK-NOLSE-O0-NEXT:    csel w12, w8, w9, le
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs w9, w10, w8
+; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, le
 ; CHECK-NOLSE-O0-NEXT:  LBB53_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB53_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB53_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB53_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB53_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB53_2
 ; CHECK-NOLSE-O0-NEXT:  LBB53_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB53_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs w8, w9, w8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB53_1
-; CHECK-NOLSE-O0-NEXT:    b LBB53_5
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB53_5
+; CHECK-NOLSE-O0-NEXT:    b LBB53_1
 ; CHECK-NOLSE-O0-NEXT:  LBB53_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -4596,13 +4588,14 @@ define i32 @atomicrmw_min_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    subs w9, w0, w8
 ; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, le
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas4_acq
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w0, w8
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov w8, w0
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w8
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB53_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB53_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB53_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB53_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB53_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -4661,29 +4654,29 @@ define i32 @atomicrmw_max_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB54_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB54_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs w10, w8, w9
-; CHECK-NOLSE-O0-NEXT:    csel w12, w8, w9, gt
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs w9, w10, w8
+; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, gt
 ; CHECK-NOLSE-O0-NEXT:  LBB54_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB54_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB54_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB54_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB54_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB54_2
 ; CHECK-NOLSE-O0-NEXT:  LBB54_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB54_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs w8, w9, w8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB54_1
-; CHECK-NOLSE-O0-NEXT:    b LBB54_5
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB54_5
+; CHECK-NOLSE-O0-NEXT:    b LBB54_1
 ; CHECK-NOLSE-O0-NEXT:  LBB54_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -4710,13 +4703,14 @@ define i32 @atomicrmw_max_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    subs w9, w0, w8
 ; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, gt
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas4_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w0, w8
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov w8, w0
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w8
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB54_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB54_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB54_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB54_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB54_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -4775,29 +4769,29 @@ define i32 @atomicrmw_umin_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB55_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB55_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs w10, w8, w9
-; CHECK-NOLSE-O0-NEXT:    csel w12, w8, w9, ls
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs w9, w10, w8
+; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, ls
 ; CHECK-NOLSE-O0-NEXT:  LBB55_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB55_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB55_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB55_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB55_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB55_2
 ; CHECK-NOLSE-O0-NEXT:  LBB55_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB55_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs w8, w9, w8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB55_1
-; CHECK-NOLSE-O0-NEXT:    b LBB55_5
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB55_5
+; CHECK-NOLSE-O0-NEXT:    b LBB55_1
 ; CHECK-NOLSE-O0-NEXT:  LBB55_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -4824,13 +4818,14 @@ define i32 @atomicrmw_umin_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    subs w9, w0, w8
 ; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, ls
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas4_acq_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w0, w8
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov w8, w0
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w8
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB55_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB55_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB55_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB55_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB55_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -4889,29 +4884,29 @@ define i32 @atomicrmw_umax_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB56_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB56_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #28] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr w10, [sp, #28] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr w9, [sp, #24] ; 4-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs w10, w8, w9
-; CHECK-NOLSE-O0-NEXT:    csel w12, w8, w9, hi
+; CHECK-NOLSE-O0-NEXT:    ldr w8, [sp, #24] ; 4-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs w9, w10, w8
+; CHECK-NOLSE-O0-NEXT:    csel w12, w10, w8, hi
 ; CHECK-NOLSE-O0-NEXT:  LBB56_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB56_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr w9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp w9, w8
+; CHECK-NOLSE-O0-NEXT:    cmp w9, w10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB56_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB56_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, w12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB56_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, w12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB56_2
 ; CHECK-NOLSE-O0-NEXT:  LBB56_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB56_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs w8, w9, w8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #12] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str w9, [sp, #28] ; 4-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB56_1
-; CHECK-NOLSE-O0-NEXT:    b LBB56_5
+; CHECK-NOLSE-O0-NEXT:    mov w8, w9
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #12] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs w9, w9, w10
+; CHECK-NOLSE-O0-NEXT:    str w8, [sp, #28] ; 4-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB56_5
+; CHECK-NOLSE-O0-NEXT:    b LBB56_1
 ; CHECK-NOLSE-O0-NEXT:  LBB56_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -4938,13 +4933,14 @@ define i32 @atomicrmw_umax_i32(ptr %ptr, i32 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    subs w9, w0, w8
 ; CHECK-OUTLINE-O0-NEXT:    csel w1, w0, w8, hi
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas4_relax
-; CHECK-OUTLINE-O0-NEXT:    ldr w8, [sp, #8] ; 4-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    subs w8, w0, w8
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    ldr w9, [sp, #8] ; 4-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov w8, w0
+; CHECK-OUTLINE-O0-NEXT:    mov w0, w8
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #12] ; 4-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs w8, w8, w9
 ; CHECK-OUTLINE-O0-NEXT:    str w0, [sp, #28] ; 4-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB56_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB56_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB56_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB56_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB56_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr w0, [sp, #12] ; 4-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #32] ; 16-byte Folded Reload
@@ -5002,28 +4998,28 @@ define i64 @atomicrmw_add_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB57_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB57_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x9, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    add x12, x8, x9
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    add x12, x10, x8
 ; CHECK-NOLSE-O0-NEXT:  LBB57_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB57_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x8
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB57_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB57_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB57_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB57_2
 ; CHECK-NOLSE-O0-NEXT:  LBB57_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB57_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs x8, x9, x8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB57_1
-; CHECK-NOLSE-O0-NEXT:    b LBB57_5
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB57_5
+; CHECK-NOLSE-O0-NEXT:    b LBB57_1
 ; CHECK-NOLSE-O0-NEXT:  LBB57_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -5094,27 +5090,27 @@ define i64 @atomicrmw_xchg_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB58_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB58_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x12, [sp, #16] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:  LBB58_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB58_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x8
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB58_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB58_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB58_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB58_2
 ; CHECK-NOLSE-O0-NEXT:  LBB58_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB58_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs x8, x9, x8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB58_1
-; CHECK-NOLSE-O0-NEXT:    b LBB58_5
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB58_5
+; CHECK-NOLSE-O0-NEXT:    b LBB58_1
 ; CHECK-NOLSE-O0-NEXT:  LBB58_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -5186,28 +5182,28 @@ define i64 @atomicrmw_sub_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB59_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB59_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x9, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs x12, x8, x9
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs x12, x10, x8
 ; CHECK-NOLSE-O0-NEXT:  LBB59_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB59_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x8
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB59_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB59_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB59_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB59_2
 ; CHECK-NOLSE-O0-NEXT:  LBB59_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB59_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs x8, x9, x8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB59_1
-; CHECK-NOLSE-O0-NEXT:    b LBB59_5
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB59_5
+; CHECK-NOLSE-O0-NEXT:    b LBB59_1
 ; CHECK-NOLSE-O0-NEXT:  LBB59_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -5283,28 +5279,28 @@ define i64 @atomicrmw_and_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB60_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB60_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x9, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    and x12, x8, x9
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    and x12, x10, x8
 ; CHECK-NOLSE-O0-NEXT:  LBB60_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB60_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x8
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB60_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB60_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB60_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB60_2
 ; CHECK-NOLSE-O0-NEXT:  LBB60_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB60_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs x8, x9, x8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB60_1
-; CHECK-NOLSE-O0-NEXT:    b LBB60_5
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB60_5
+; CHECK-NOLSE-O0-NEXT:    b LBB60_1
 ; CHECK-NOLSE-O0-NEXT:  LBB60_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -5380,28 +5376,28 @@ define i64 @atomicrmw_or_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB61_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB61_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x9, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    orr x12, x8, x9
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    orr x12, x10, x8
 ; CHECK-NOLSE-O0-NEXT:  LBB61_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB61_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x8
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB61_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB61_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB61_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB61_2
 ; CHECK-NOLSE-O0-NEXT:  LBB61_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB61_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs x8, x9, x8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB61_1
-; CHECK-NOLSE-O0-NEXT:    b LBB61_5
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB61_5
+; CHECK-NOLSE-O0-NEXT:    b LBB61_1
 ; CHECK-NOLSE-O0-NEXT:  LBB61_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -5473,28 +5469,28 @@ define i64 @atomicrmw_xor_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB62_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB62_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x9, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    eor x12, x8, x9
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    eor x12, x10, x8
 ; CHECK-NOLSE-O0-NEXT:  LBB62_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB62_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x8
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB62_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB62_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB62_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB62_2
 ; CHECK-NOLSE-O0-NEXT:  LBB62_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB62_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs x8, x9, x8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB62_1
-; CHECK-NOLSE-O0-NEXT:    b LBB62_5
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB62_5
+; CHECK-NOLSE-O0-NEXT:    b LBB62_1
 ; CHECK-NOLSE-O0-NEXT:  LBB62_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -5567,29 +5563,29 @@ define i64 @atomicrmw_min_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB63_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB63_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x9, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs x10, x8, x9
-; CHECK-NOLSE-O0-NEXT:    csel x12, x8, x9, le
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs x9, x10, x8
+; CHECK-NOLSE-O0-NEXT:    csel x12, x10, x8, le
 ; CHECK-NOLSE-O0-NEXT:  LBB63_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB63_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x8
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB63_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB63_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB63_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB63_2
 ; CHECK-NOLSE-O0-NEXT:  LBB63_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB63_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs x8, x9, x8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB63_1
-; CHECK-NOLSE-O0-NEXT:    b LBB63_5
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB63_5
+; CHECK-NOLSE-O0-NEXT:    b LBB63_1
 ; CHECK-NOLSE-O0-NEXT:  LBB63_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -5616,13 +5612,14 @@ define i64 @atomicrmw_min_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    subs x9, x0, x8
 ; CHECK-OUTLINE-O0-NEXT:    csel x1, x0, x8, le
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas8_acq
-; CHECK-OUTLINE-O0-NEXT:    ldr x8, [sp, #8] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    subs x8, x0, x8
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    ldr x9, [sp, #8] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov x8, x0
+; CHECK-OUTLINE-O0-NEXT:    mov x0, x8
 ; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs x8, x8, x9
 ; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB63_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB63_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB63_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB63_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB63_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #16] ; 8-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #48] ; 16-byte Folded Reload
@@ -5681,29 +5678,29 @@ define i64 @atomicrmw_max_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB64_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB64_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x9, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs x10, x8, x9
-; CHECK-NOLSE-O0-NEXT:    csel x12, x8, x9, gt
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs x9, x10, x8
+; CHECK-NOLSE-O0-NEXT:    csel x12, x10, x8, gt
 ; CHECK-NOLSE-O0-NEXT:  LBB64_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB64_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x8
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB64_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB64_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB64_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB64_2
 ; CHECK-NOLSE-O0-NEXT:  LBB64_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB64_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs x8, x9, x8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB64_1
-; CHECK-NOLSE-O0-NEXT:    b LBB64_5
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB64_5
+; CHECK-NOLSE-O0-NEXT:    b LBB64_1
 ; CHECK-NOLSE-O0-NEXT:  LBB64_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -5730,13 +5727,14 @@ define i64 @atomicrmw_max_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    subs x9, x0, x8
 ; CHECK-OUTLINE-O0-NEXT:    csel x1, x0, x8, gt
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas8_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr x8, [sp, #8] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    subs x8, x0, x8
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    ldr x9, [sp, #8] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov x8, x0
+; CHECK-OUTLINE-O0-NEXT:    mov x0, x8
 ; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs x8, x8, x9
 ; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB64_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB64_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB64_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB64_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB64_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #16] ; 8-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #48] ; 16-byte Folded Reload
@@ -5795,29 +5793,29 @@ define i64 @atomicrmw_umin_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB65_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB65_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x9, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs x10, x8, x9
-; CHECK-NOLSE-O0-NEXT:    csel x12, x8, x9, ls
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs x9, x10, x8
+; CHECK-NOLSE-O0-NEXT:    csel x12, x10, x8, ls
 ; CHECK-NOLSE-O0-NEXT:  LBB65_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB65_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x8
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB65_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB65_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB65_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB65_2
 ; CHECK-NOLSE-O0-NEXT:  LBB65_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB65_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs x8, x9, x8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB65_1
-; CHECK-NOLSE-O0-NEXT:    b LBB65_5
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB65_5
+; CHECK-NOLSE-O0-NEXT:    b LBB65_1
 ; CHECK-NOLSE-O0-NEXT:  LBB65_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -5844,13 +5842,14 @@ define i64 @atomicrmw_umin_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    subs x9, x0, x8
 ; CHECK-OUTLINE-O0-NEXT:    csel x1, x0, x8, ls
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas8_acq_rel
-; CHECK-OUTLINE-O0-NEXT:    ldr x8, [sp, #8] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    subs x8, x0, x8
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    ldr x9, [sp, #8] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov x8, x0
+; CHECK-OUTLINE-O0-NEXT:    mov x0, x8
 ; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs x8, x8, x9
 ; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB65_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB65_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB65_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB65_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB65_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #16] ; 8-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #48] ; 16-byte Folded Reload
@@ -5909,29 +5908,29 @@ define i64 @atomicrmw_umax_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-NOLSE-O0-NEXT:  LBB66_1: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; =>This Loop Header: Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; Child Loop BB66_2 Depth 2
-; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    ldr x10, [sp, #24] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    ldr x11, [sp, #8] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    ldr x9, [sp, #16] ; 8-byte Reload
-; CHECK-NOLSE-O0-NEXT:    subs x10, x8, x9
-; CHECK-NOLSE-O0-NEXT:    csel x12, x8, x9, hi
+; CHECK-NOLSE-O0-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
+; CHECK-NOLSE-O0-NEXT:    subs x9, x10, x8
+; CHECK-NOLSE-O0-NEXT:    csel x12, x10, x8, hi
 ; CHECK-NOLSE-O0-NEXT:  LBB66_2: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; Parent Loop BB66_1 Depth=1
 ; CHECK-NOLSE-O0-NEXT:    ; => This Inner Loop Header: Depth=2
 ; CHECK-NOLSE-O0-NEXT:    ldaxr x9, [x11]
-; CHECK-NOLSE-O0-NEXT:    cmp x9, x8
+; CHECK-NOLSE-O0-NEXT:    cmp x9, x10
 ; CHECK-NOLSE-O0-NEXT:    b.ne LBB66_4
 ; CHECK-NOLSE-O0-NEXT:  ; %bb.3: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB66_2 Depth=2
-; CHECK-NOLSE-O0-NEXT:    stlxr w10, x12, [x11]
-; CHECK-NOLSE-O0-NEXT:    cbnz w10, LBB66_2
+; CHECK-NOLSE-O0-NEXT:    stlxr w8, x12, [x11]
+; CHECK-NOLSE-O0-NEXT:    cbnz w8, LBB66_2
 ; CHECK-NOLSE-O0-NEXT:  LBB66_4: ; %atomicrmw.start
 ; CHECK-NOLSE-O0-NEXT:    ; in Loop: Header=BB66_1 Depth=1
-; CHECK-NOLSE-O0-NEXT:    subs x8, x9, x8
-; CHECK-NOLSE-O0-NEXT:    cset w8, eq
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    str x9, [sp, #24] ; 8-byte Spill
-; CHECK-NOLSE-O0-NEXT:    tbz w8, #0, LBB66_1
-; CHECK-NOLSE-O0-NEXT:    b LBB66_5
+; CHECK-NOLSE-O0-NEXT:    mov x8, x9
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    subs x9, x9, x10
+; CHECK-NOLSE-O0-NEXT:    str x8, [sp, #24] ; 8-byte Spill
+; CHECK-NOLSE-O0-NEXT:    b.eq LBB66_5
+; CHECK-NOLSE-O0-NEXT:    b LBB66_1
 ; CHECK-NOLSE-O0-NEXT:  LBB66_5: ; %atomicrmw.end
 ; CHECK-NOLSE-O0-NEXT:    ldr x0, [sp] ; 8-byte Reload
 ; CHECK-NOLSE-O0-NEXT:    add sp, sp, #32
@@ -5958,13 +5957,14 @@ define i64 @atomicrmw_umax_i64(ptr %ptr, i64 %rhs) {
 ; CHECK-OUTLINE-O0-NEXT:    subs x9, x0, x8
 ; CHECK-OUTLINE-O0-NEXT:    csel x1, x0, x8, hi
 ; CHECK-OUTLINE-O0-NEXT:    bl ___aarch64_cas8_relax
-; CHECK-OUTLINE-O0-NEXT:    ldr x8, [sp, #8] ; 8-byte Reload
-; CHECK-OUTLINE-O0-NEXT:    subs x8, x0, x8
-; CHECK-OUTLINE-O0-NEXT:    cset w8, eq
+; CHECK-OUTLINE-O0-NEXT:    ldr x9, [sp, #8] ; 8-byte Reload
+; CHECK-OUTLINE-O0-NEXT:    mov x8, x0
+; CHECK-OUTLINE-O0-NEXT:    mov x0, x8
 ; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #16] ; 8-byte Spill
+; CHECK-OUTLINE-O0-NEXT:    subs x8, x8, x9
 ; CHECK-OUTLINE-O0-NEXT:    str x0, [sp, #40] ; 8-byte Spill
-; CHECK-OUTLINE-O0-NEXT:    tbz w8, #0, LBB66_1
-; CHECK-OUTLINE-O0-NEXT:    b LBB66_2
+; CHECK-OUTLINE-O0-NEXT:    b.eq LBB66_2
+; CHECK-OUTLINE-O0-NEXT:    b LBB66_1
 ; CHECK-OUTLINE-O0-NEXT:  LBB66_2: ; %atomicrmw.end
 ; CHECK-OUTLINE-O0-NEXT:    ldr x0, [sp, #16] ; 8-byte Reload
 ; CHECK-OUTLINE-O0-NEXT:    ldp x29, x30, [sp, #48] ; 16-byte Folded Reload

--- a/llvm/test/CodeGen/AArch64/GlobalISel/localizer-arm64-tti.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/localizer-arm64-tti.ll
@@ -27,28 +27,27 @@ define i32 @foo() {
   ; CHECK-NEXT:   [[GV2:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @var1
   ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(i32) = G_LOAD [[GV2]](p0) :: (dereferenceable load (i32) from @var1)
   ; CHECK-NEXT:   [[C3:%[0-9]+]]:_(i32) = G_CONSTANT i32 1
-  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(ne), [[LOAD]](i32), [[C3]]
-  ; CHECK-NEXT:   [[C4:%[0-9]+]]:_(i1) = G_CONSTANT i1 true
-  ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.3
-  ; CHECK-NEXT:   G_BR %bb.2
+  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(eq), [[LOAD]](i32), [[C3]]
+  ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.2
+  ; CHECK-NEXT:   G_BR %bb.3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.if.then:
   ; CHECK-NEXT:   successors: %bb.3(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[GV3:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @var2
-  ; CHECK-NEXT:   [[C5:%[0-9]+]]:_(i32) = G_CONSTANT i32 2
-  ; CHECK-NEXT:   G_STORE [[C5]](i32), [[GV3]](p0) :: (store (i32) into @var2)
-  ; CHECK-NEXT:   [[C6:%[0-9]+]]:_(i32) = G_CONSTANT i32 3
+  ; CHECK-NEXT:   [[C4:%[0-9]+]]:_(i32) = G_CONSTANT i32 2
+  ; CHECK-NEXT:   G_STORE [[C4]](i32), [[GV3]](p0) :: (store (i32) into @var2)
+  ; CHECK-NEXT:   [[C5:%[0-9]+]]:_(i32) = G_CONSTANT i32 3
   ; CHECK-NEXT:   [[GV4:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @var1
-  ; CHECK-NEXT:   G_STORE [[C6]](i32), [[GV4]](p0) :: (store (i32) into @var1)
+  ; CHECK-NEXT:   G_STORE [[C5]](i32), [[GV4]](p0) :: (store (i32) into @var1)
   ; CHECK-NEXT:   [[GV5:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @var3
-  ; CHECK-NEXT:   G_STORE [[C5]](i32), [[GV5]](p0) :: (store (i32) into @var3)
-  ; CHECK-NEXT:   G_STORE [[C6]](i32), [[GV4]](p0) :: (store (i32) into @var1)
+  ; CHECK-NEXT:   G_STORE [[C4]](i32), [[GV5]](p0) :: (store (i32) into @var3)
+  ; CHECK-NEXT:   G_STORE [[C5]](i32), [[GV4]](p0) :: (store (i32) into @var1)
   ; CHECK-NEXT:   G_BR %bb.3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.3.if.end:
-  ; CHECK-NEXT:   [[C7:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
-  ; CHECK-NEXT:   $w0 = COPY [[C7]](i32)
+  ; CHECK-NEXT:   [[C6:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
+  ; CHECK-NEXT:   $w0 = COPY [[C6]](i32)
   ; CHECK-NEXT:   RET_ReallyLR implicit $w0
 entry:
   %0 = load i32, ptr @var1, align 4
@@ -84,10 +83,9 @@ define i32 @darwin_tls() {
   ; CHECK-NEXT:   [[GV2:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @var1
   ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(i32) = G_LOAD [[GV2]](p0) :: (dereferenceable load (i32) from @var1)
   ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 1
-  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(ne), [[LOAD]](i32), [[C1]]
-  ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(i1) = G_CONSTANT i1 true
-  ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.3
-  ; CHECK-NEXT:   G_BR %bb.2
+  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(eq), [[LOAD]](i32), [[C1]]
+  ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.2
+  ; CHECK-NEXT:   G_BR %bb.3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.if.then:
   ; CHECK-NEXT:   successors: %bb.3(0x80000000)
@@ -98,8 +96,8 @@ define i32 @darwin_tls() {
   ; CHECK-NEXT:   G_BR %bb.3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.3.if.end:
-  ; CHECK-NEXT:   [[C3:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
-  ; CHECK-NEXT:   $w0 = COPY [[C3]](i32)
+  ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
+  ; CHECK-NEXT:   $w0 = COPY [[C2]](i32)
   ; CHECK-NEXT:   RET_ReallyLR implicit $w0
 entry:
   %0 = load i32, ptr @var1, align 4
@@ -128,10 +126,9 @@ define i32 @imm_cost_too_large_cost_of_2() {
   ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 -2228259
   ; CHECK-NEXT:   [[CONSTANT_FOLD_BARRIER:%[0-9]+]]:_(i32) = G_CONSTANT_FOLD_BARRIER [[C1]]
   ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(i32) = G_CONSTANT i32 1
-  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(ne), [[LOAD]](i32), [[C2]]
-  ; CHECK-NEXT:   [[C3:%[0-9]+]]:_(i1) = G_CONSTANT i1 true
-  ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.4
-  ; CHECK-NEXT:   G_BR %bb.2
+  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(eq), [[LOAD]](i32), [[C2]]
+  ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.2
+  ; CHECK-NEXT:   G_BR %bb.4
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.if.then:
   ; CHECK-NEXT:   successors: %bb.3(0x80000000)
@@ -150,8 +147,8 @@ define i32 @imm_cost_too_large_cost_of_2() {
   ; CHECK-NEXT: bb.4.if.end:
   ; CHECK-NEXT:   [[GV5:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @var3
   ; CHECK-NEXT:   G_STORE [[CONSTANT_FOLD_BARRIER]](i32), [[GV5]](p0) :: (store (i32) into @var3)
-  ; CHECK-NEXT:   [[C4:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
-  ; CHECK-NEXT:   $w0 = COPY [[C4]](i32)
+  ; CHECK-NEXT:   [[C3:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
+  ; CHECK-NEXT:   $w0 = COPY [[C3]](i32)
   ; CHECK-NEXT:   RET_ReallyLR implicit $w0
 entry:
   %0 = load i32, ptr @var1, align 4
@@ -185,10 +182,9 @@ define i64 @imm_cost_too_large_cost_of_4() {
   ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(i64) = G_CONSTANT i64 -2228259
   ; CHECK-NEXT:   [[CONSTANT_FOLD_BARRIER:%[0-9]+]]:_(i64) = G_CONSTANT_FOLD_BARRIER [[C1]]
   ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 1
-  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(ne), [[LOAD]](i64), [[C2]]
-  ; CHECK-NEXT:   [[C3:%[0-9]+]]:_(i1) = G_CONSTANT i1 true
-  ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.4
-  ; CHECK-NEXT:   G_BR %bb.2
+  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(eq), [[LOAD]](i64), [[C2]]
+  ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.2
+  ; CHECK-NEXT:   G_BR %bb.4
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.if.then:
   ; CHECK-NEXT:   successors: %bb.3(0x80000000)
@@ -207,8 +203,8 @@ define i64 @imm_cost_too_large_cost_of_4() {
   ; CHECK-NEXT: bb.4.if.end:
   ; CHECK-NEXT:   [[GV5:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @var3_64
   ; CHECK-NEXT:   G_STORE [[CONSTANT_FOLD_BARRIER]](i64), [[GV5]](p0) :: (store (i64) into @var3_64)
-  ; CHECK-NEXT:   [[C4:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
-  ; CHECK-NEXT:   $x0 = COPY [[C4]](i64)
+  ; CHECK-NEXT:   [[C3:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
+  ; CHECK-NEXT:   $x0 = COPY [[C3]](i64)
   ; CHECK-NEXT:   RET_ReallyLR implicit $x0
 entry:
   %0 = load i64, ptr @var1_64, align 4
@@ -242,10 +238,9 @@ define i64 @f64_imm_cost_too_high(double %a) {
   ; CHECK-NEXT:   [[GV2:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @var1_64
   ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(i64) = G_LOAD [[GV2]](p0) :: (dereferenceable load (i64) from @var1_64, align 4)
   ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 1
-  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(ne), [[LOAD]](i64), [[C2]]
-  ; CHECK-NEXT:   [[C3:%[0-9]+]]:_(i1) = G_CONSTANT i1 true
-  ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.4
-  ; CHECK-NEXT:   G_BR %bb.2
+  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(eq), [[LOAD]](i64), [[C2]]
+  ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.2
+  ; CHECK-NEXT:   G_BR %bb.4
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.if.then:
   ; CHECK-NEXT:   successors: %bb.3(0x80000000)
@@ -264,8 +259,8 @@ define i64 @f64_imm_cost_too_high(double %a) {
   ; CHECK-NEXT: bb.4.if.end:
   ; CHECK-NEXT:   [[GV5:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @var3_64
   ; CHECK-NEXT:   G_STORE [[C]](f64), [[GV5]](p0) :: (store (f64) into @var3_64)
-  ; CHECK-NEXT:   [[C4:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
-  ; CHECK-NEXT:   $x0 = COPY [[C4]](i64)
+  ; CHECK-NEXT:   [[C3:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
+  ; CHECK-NEXT:   $x0 = COPY [[C3]](i64)
   ; CHECK-NEXT:   RET_ReallyLR implicit $x0
 entry:
   %0 = load i64, ptr @var1_64, align 4
@@ -298,33 +293,32 @@ define i64 @f64_imm_cheap(double %a) {
   ; CHECK-NEXT:   [[GV2:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @var1_64
   ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(i64) = G_LOAD [[GV2]](p0) :: (dereferenceable load (i64) from @var1_64, align 4)
   ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 1
-  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(ne), [[LOAD]](i64), [[C2]]
-  ; CHECK-NEXT:   [[C3:%[0-9]+]]:_(i1) = G_CONSTANT i1 true
-  ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.4
-  ; CHECK-NEXT:   G_BR %bb.2
+  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(eq), [[LOAD]](i64), [[C2]]
+  ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.2
+  ; CHECK-NEXT:   G_BR %bb.4
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.if.then:
   ; CHECK-NEXT:   successors: %bb.3(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[GV3:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @var2_64
-  ; CHECK-NEXT:   [[C4:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
-  ; CHECK-NEXT:   G_STORE [[C4]](f64), [[GV3]](p0) :: (store (f64) into @var2_64)
+  ; CHECK-NEXT:   [[C3:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
+  ; CHECK-NEXT:   G_STORE [[C3]](f64), [[GV3]](p0) :: (store (f64) into @var2_64)
   ; CHECK-NEXT:   G_BR %bb.3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.3.if.then2:
   ; CHECK-NEXT:   successors: %bb.4(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[C5:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
+  ; CHECK-NEXT:   [[C4:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
   ; CHECK-NEXT:   [[GV4:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @var1_64
-  ; CHECK-NEXT:   G_STORE [[C5]](f64), [[GV4]](p0) :: (store (f64) into @var1_64)
+  ; CHECK-NEXT:   G_STORE [[C4]](f64), [[GV4]](p0) :: (store (f64) into @var1_64)
   ; CHECK-NEXT:   G_BR %bb.4
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.4.if.end:
   ; CHECK-NEXT:   [[GV5:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @var3_64
-  ; CHECK-NEXT:   [[C6:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
-  ; CHECK-NEXT:   G_STORE [[C6]](f64), [[GV5]](p0) :: (store (f64) into @var3_64)
-  ; CHECK-NEXT:   [[C7:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
-  ; CHECK-NEXT:   $x0 = COPY [[C7]](i64)
+  ; CHECK-NEXT:   [[C5:%[0-9]+]]:_(f64) = G_FCONSTANT double 0.000000e+00
+  ; CHECK-NEXT:   G_STORE [[C5]](f64), [[GV5]](p0) :: (store (f64) into @var3_64)
+  ; CHECK-NEXT:   [[C6:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
+  ; CHECK-NEXT:   $x0 = COPY [[C6]](i64)
   ; CHECK-NEXT:   RET_ReallyLR implicit $x0
 entry:
   %0 = load i64, ptr @var1_64, align 4

--- a/llvm/test/CodeGen/AArch64/aarch64-tbz.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-tbz.ll
@@ -135,8 +135,8 @@ define void @test3(i64 %A, i64 %B) {
 ; CHECK-GIO0-NEXT:  .LBB2_1: // %entry
 ; CHECK-GIO0-NEXT:    ldr x0, [sp] // 8-byte Reload
 ; CHECK-GIO0-NEXT:    mov w8, w0
-; CHECK-GIO0-NEXT:    tbnz w8, #28, .LBB2_3
-; CHECK-GIO0-NEXT:    b .LBB2_2
+; CHECK-GIO0-NEXT:    tbz w8, #28, .LBB2_2
+; CHECK-GIO0-NEXT:    b .LBB2_3
 ; CHECK-GIO0-NEXT:  .LBB2_2: // %if.then2
 ; CHECK-GIO0-NEXT:    ldr x1, [sp, #8] // 8-byte Reload
 ; CHECK-GIO0-NEXT:    ldr x0, [sp] // 8-byte Reload
@@ -187,8 +187,8 @@ define void @test4(i64 %A, i64 %B) {
 ; CHECK-GIO0-NEXT:    b .LBB3_1
 ; CHECK-GIO0-NEXT:  .LBB3_1: // %entry
 ; CHECK-GIO0-NEXT:    ldr x8, [sp] // 8-byte Reload
-; CHECK-GIO0-NEXT:    tbnz x8, #35, .LBB3_3
-; CHECK-GIO0-NEXT:    b .LBB3_2
+; CHECK-GIO0-NEXT:    tbz x8, #35, .LBB3_2
+; CHECK-GIO0-NEXT:    b .LBB3_3
 ; CHECK-GIO0-NEXT:  .LBB3_2: // %if.then2
 ; CHECK-GIO0-NEXT:    ldr x1, [sp, #8] // 8-byte Reload
 ; CHECK-GIO0-NEXT:    ldr x0, [sp] // 8-byte Reload
@@ -227,8 +227,8 @@ define i32 @tbzfromextract(<8 x i8> %b) {
 ; CHECK-GIO0-NEXT:    // implicit-def: $q0
 ; CHECK-GIO0-NEXT:    fmov d0, d1
 ; CHECK-GIO0-NEXT:    umov w8, v0.b[0]
-; CHECK-GIO0-NEXT:    tbnz w8, #31, .LBB4_2
-; CHECK-GIO0-NEXT:    b .LBB4_1
+; CHECK-GIO0-NEXT:    tbz w8, #31, .LBB4_1
+; CHECK-GIO0-NEXT:    b .LBB4_2
 ; CHECK-GIO0-NEXT:  .LBB4_1: // %land.rhs
 ; CHECK-GIO0-NEXT:    mov w0, #1 // =0x1
 ; CHECK-GIO0-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/cpa-globalisel.ll
+++ b/llvm/test/CodeGen/AArch64/cpa-globalisel.ll
@@ -661,8 +661,8 @@ define hidden void @multidim() {
 ; CHECK-CPA-O0-NEXT:    addpt x8, x8, x10, lsl #1
 ; CHECK-CPA-O0-NEXT:    ldrb w8, [x8, w9, sxtw]
 ; CHECK-CPA-O0-NEXT:    uxtb w8, w8
-; CHECK-CPA-O0-NEXT:    cbz w8, .LBB14_2
-; CHECK-CPA-O0-NEXT:    b .LBB14_1
+; CHECK-CPA-O0-NEXT:    cbnz w8, .LBB14_1
+; CHECK-CPA-O0-NEXT:    b .LBB14_2
 ; CHECK-CPA-O0-NEXT:  .LBB14_1:
 ; CHECK-CPA-O0-NEXT:    adrp x0, .L.str
 ; CHECK-CPA-O0-NEXT:    add x0, x0, :lo12:.L.str
@@ -710,8 +710,8 @@ define hidden void @multidim() {
 ; CHECK-NOCPA-O0-NEXT:    add x8, x8, x10, lsl #1
 ; CHECK-NOCPA-O0-NEXT:    ldrb w8, [x8, w9, sxtw]
 ; CHECK-NOCPA-O0-NEXT:    uxtb w8, w8
-; CHECK-NOCPA-O0-NEXT:    cbz w8, .LBB14_2
-; CHECK-NOCPA-O0-NEXT:    b .LBB14_1
+; CHECK-NOCPA-O0-NEXT:    cbnz w8, .LBB14_1
+; CHECK-NOCPA-O0-NEXT:    b .LBB14_2
 ; CHECK-NOCPA-O0-NEXT:  .LBB14_1:
 ; CHECK-NOCPA-O0-NEXT:    adrp x0, .L.str
 ; CHECK-NOCPA-O0-NEXT:    add x0, x0, :lo12:.L.str

--- a/llvm/test/CodeGen/AArch64/misched-fusion-cmp-bcc.ll
+++ b/llvm/test/CodeGen/AArch64/misched-fusion-cmp-bcc.ll
@@ -31,5 +31,5 @@ if_false:
 ; CHECK-LABEL: test_cmp_bcc_fusion:
 ; CHECK: str {{w[0-9]}}, [{{x[0-9]}}]
 ; CHECK-NEXT: subs {{w[0-9]}}, {{w[0-9]}}, {{w[0-9]}}
-; CHECK-NEXT: b.ne .LBB0_2
-; CHECK-NEXT: b .LBB0_1
+; CHECK-NEXT: b.eq .LBB0_1
+; CHECK-NEXT: b .LBB0_2

--- a/llvm/test/CodeGen/AArch64/pcsections.ll
+++ b/llvm/test/CodeGen/AArch64/pcsections.ll
@@ -81,7 +81,7 @@ define i64 @test_complex_atomic() {
 ; CHECK-UNOPT-NEXT:  stlxr
 ; CHECK-UNOPT:     .Lpcsection9:
 ; CHECK-UNOPT-NEXT:  cbnz
-; CHECK-UNOPT:     .Lpcsection13:
+; CHECK-UNOPT:     .Lpcsection12:
 ; CHECK-UNOPT-NEXT:  b
 ; ---
 ; CHECK-NOT:   .Lpcsection
@@ -100,7 +100,7 @@ define i64 @test_complex_atomic() {
 ; CHECK-NEXT:  .Lpcsection_base7:
 ; DEFCM-NEXT:  .word	.Lpcsection5-.Lpcsection_base7
 ; LARGE-NEXT:  .xword	.Lpcsection5-.Lpcsection_base7
-; CHECK-UNOPT: .word	.Lpcsection13-.Lpcsection_base15
+; CHECK-UNOPT: .word	.Lpcsection12-.Lpcsection_base14
 ; CHECK-NEXT:  .text
 entry:
   %0 = atomicrmw add ptr @foo, i64 1 monotonic, align 8, !pcsections !0

--- a/llvm/test/DebugInfo/AArch64/fallthrough-branch.ll
+++ b/llvm/test/DebugInfo/AArch64/fallthrough-branch.ll
@@ -10,7 +10,8 @@ define swiftcc void @"$s1t1f1bySb_tF"(i1 %0) !dbg !35 {
   %3 = bitcast ptr %2 to ptr
   call void @llvm.memset.p0.i64(ptr align 8 %3, i8 0, i64 1, i1 false)
   store i1 %0, ptr %2, align 8, !dbg !37
-; CHECK:   B %[[BB4:bb\.[0-9]+]], debug-location !{{[0-9]+}}
+; CHECK:   TBNZW killed renamable $w0, 0, %[[BB4:bb\.[0-9]+]], debug-location !{{[0-9]+}}
+; CHECK:   B %[[BB5:bb\.[0-9]+]], debug-location !{{[0-9]+}}
   br i1 %0, label %4, label %5, !dbg !38
 
 4:                                                ; preds = %1


### PR DESCRIPTION
This combine should not be necessary at O0 and disabling it is a -0.39% geomean compile-time improvement on stage1-aarch64-O0-g CTMark [1] with no change to code-size [2].

I also measured code-size without -g (cmake/caches/O0.cmake) locally since it's not on llvm-compile-time-tracker and found no change.

[1] https://llvm-compile-time-tracker.com/compare.php?from=f2efeabe314bb0a9b1ef46c07b11f605ed351b9c&to=3d28cf0bb7fb2fc5baebc4b5de09b735c1115e7f&stat=instructions%3Au
[2] https://llvm-compile-time-tracker.com/compare.php?from=f2efeabe314bb0a9b1ef46c07b11f605ed351b9c&to=3d28cf0bb7fb2fc5baebc4b5de09b735c1115e7f&stat=size-total