### PR TITLE
[IPO] Avoid crash when DISubprogram has no type

### DIFF
--- a/llvm/lib/Transforms/IPO/ArgumentPromotion.cpp
+++ b/llvm/lib/Transforms/IPO/ArgumentPromotion.cpp
@@ -438,8 +438,9 @@ doPromotion(Function *F, FunctionAnalysisManager &FAM,
   // to DISubroutineType to inform debugger that it may not be safe to call this
   // function.
   DISubprogram *SP = NF->getSubprogram();
-  if (SP) {
-    auto Temp = SP->getType()->cloneWithCC(llvm::dwarf::DW_CC_nocall);
+  DISubroutineType *SPTy = SP ? SP->getType() : nullptr;
+  if (SPTy) {
+    auto Temp = SPTy->cloneWithCC(llvm::dwarf::DW_CC_nocall);
     SP->replaceType(MDNode::replaceWithPermanent(std::move(Temp)));
   }
 

--- a/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
+++ b/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
@@ -1087,9 +1087,10 @@ bool DeadArgumentEliminationPass::removeDeadStuffFromFunction(Function *F) {
   // function does not follow standard calling conventions anymore. Hence, add
   // DW_CC_nocall to DISubroutineType to inform debugger that it may not be safe
   // to call this function or try to interpret the return value.
-  if (NFTy != FTy && NF->getSubprogram()) {
-    DISubprogram *SP = NF->getSubprogram();
-    auto Temp = SP->getType()->cloneWithCC(llvm::dwarf::DW_CC_nocall);
+  DISubprogram *SP = NF->getSubprogram();
+  DISubroutineType *SPTy = SP ? SP->getType() : nullptr;
+  if (NFTy != FTy && SPTy) {
+    auto Temp = SPTy->cloneWithCC(llvm::dwarf::DW_CC_nocall);
     SP->replaceType(MDNode::replaceWithPermanent(std::move(Temp)));
   }
 

--- a/llvm/test/Transforms/ArgumentPromotion/debug-info-null-type.ll
+++ b/llvm/test/Transforms/ArgumentPromotion/debug-info-null-type.ll
@@ -1,0 +1,35 @@
+; RUN: opt -S -passes=verify,argpromotion < %s | FileCheck %s
+
+; Test that argpromotion does not crash when a DISubprogram has a null type.
+; This is valid with line-table-only debug info, where no DISubroutineType may
+; be available to mark with DW_CC_nocall.
+; https://github.com/llvm/llvm-project/issues/186557
+
+%struct.pair = type { i32, i32 }
+
+define internal void @test(ptr %X) !dbg !4 {
+; CHECK-LABEL: define internal void @test(
+; CHECK-SAME: i32 %{{.*}}) !dbg [[SP:![0-9]+]]
+  %1 = load ptr, ptr %X, align 8
+  %2 = load i32, ptr %1, align 8
+  call void @sink(i32 %2)
+  ret void
+}
+
+declare void @sink(i32)
+
+define void @caller(ptr %Y, ptr %P) {
+; CHECK-LABEL: define void @caller(
+  call void @test(ptr %Y), !dbg !3
+  ret void
+}
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !2, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly)
+!2 = !DIFile(filename: "test.c", directory: "")
+!3 = !DILocation(line: 8, scope: !4)
+; CHECK: [[SP]] = distinct !DISubprogram(name: "test", scope: null, file: [[FILE:![0-9]+]], line: 3, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: [[CU:![0-9]+]])
+!4 = distinct !DISubprogram(name: "test", scope: null, file: !2, line: 3, type: null, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)

--- a/llvm/test/Transforms/DeadArgElim/debug-info-null-type.ll
+++ b/llvm/test/Transforms/DeadArgElim/debug-info-null-type.ll
@@ -1,0 +1,30 @@
+; RUN: opt -S -passes=verify,deadargelim < %s | FileCheck %s
+
+; Test that deadargelim does not crash when a DISubprogram has a null type.
+; This is valid with line-table-only debug info, where no DISubroutineType may
+; be available to mark with DW_CC_nocall.
+
+define internal i32 @callee(i32 %used, i32 %dead) !dbg !4 {
+; CHECK-LABEL: define internal i32 @callee(
+; CHECK-SAME: i32 [[USED:%.*]]) !dbg [[SP:![0-9]+]]
+entry:
+  ret i32 %used
+}
+
+define i32 @caller(i32 %x) {
+; CHECK-LABEL: define i32 @caller(
+entry:
+; CHECK: call i32 @callee(i32 %x)
+  %r = call i32 @callee(i32 %x, i32 42), !dbg !3
+  ret i32 %r
+}
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !2, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly)
+!2 = !DIFile(filename: "test.c", directory: "")
+!3 = !DILocation(line: 8, scope: !4)
+; CHECK: [[SP]] = distinct !DISubprogram(name: "callee", scope: null, file: [[FILE:![0-9]+]], line: 3, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: [[CU:![0-9]+]])
+!4 = distinct !DISubprogram(name: "callee", scope: null, file: !2, line: 3, type: null, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/186557

  ArgumentPromotion and DeadArgumentElimination update a function's
  DISubroutineType with DW_CC_nocall after changing its signature.
  DISubprogram::getType() can be null for valid IR, for example with
  reduced line-table-only debug info, so guard the update on a present
  DISubroutineType instead of dereferencing null.

  Tests added:
  - llvm/test/Transforms/ArgumentPromotion/debug-info-null-type.ll
  - llvm/test/Transforms/DeadArgElim/debug-info-null-type.ll

  Validation:
  - llvm-lit -sv llvm/test/Transforms/ArgumentPromotion/debug-info-null-type.ll llvm/test/Transforms/DeadArgElim/debug-info-null-type.ll llvm/test/Transforms/ArgumentPromotion/dbg.ll llvm/test/Transforms/DeadArgElim/2010-04-30-DbgInfo.ll