### PR TITLE
[NFC][SPIR-V] Consolidate OpVariable insertion point logic into getOpVariableMBBIt

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1493,7 +1493,7 @@ bool SPIRVInstructionSelector::selectFrexp(Register ResVReg,
     Register PointerVReg =
         createVirtualRegister(PointerType, &GR, MRI, MRI->getMF());
 
-    auto It = getOpVariableMBBIt(I);
+    auto It = getOpVariableMBBIt(I.getMF()->front());
     BuildMI(*It->getParent(), It, It->getDebugLoc(), TII.get(SPIRV::OpVariable))
         .addDef(PointerVReg)
         .addUse(GR.getSPIRVTypeID(PointerType))
@@ -1534,7 +1534,7 @@ bool SPIRVInstructionSelector::selectSincos(Register ResVReg,
     Register PointerVReg =
         createVirtualRegister(PointerType, &GR, MRI, MRI->getMF());
 
-    auto It = getOpVariableMBBIt(I);
+    auto It = getOpVariableMBBIt(I.getMF()->front());
     BuildMI(*It->getParent(), It, It->getDebugLoc(), TII.get(SPIRV::OpVariable))
         .addDef(PointerVReg)
         .addUse(GR.getSPIRVTypeID(PointerType))
@@ -6255,7 +6255,7 @@ bool SPIRVInstructionSelector::selectFrameIndex(Register ResVReg,
                                                 MachineInstr &I) const {
   // Change order of instructions if needed: all OpVariable instructions in a
   // function must be the first instructions in the first block
-  auto It = getOpVariableMBBIt(I);
+  auto It = getOpVariableMBBIt(I.getMF()->front());
   BuildMI(*It->getParent(), It, It->getDebugLoc(), TII.get(SPIRV::OpVariable))
       .addDef(ResVReg)
       .addUse(GR.getSPIRVTypeID(ResType))
@@ -6554,8 +6554,7 @@ bool SPIRVInstructionSelector::selectModf(Register ResVReg,
     // new register.
     GR.assignSPIRVTypeToVReg(PtrType, PtrTyReg, MIRBuilder.getMF());
     MachineBasicBlock &EntryBB = I.getMF()->front();
-    MachineBasicBlock::iterator VarPos =
-        getFirstValidInstructionInsertPoint(EntryBB);
+    MachineBasicBlock::iterator VarPos = getOpVariableMBBIt(EntryBB);
     auto AllocaMIB =
         BuildMI(EntryBB, VarPos, I.getDebugLoc(), TII.get(SPIRV::OpVariable))
             .addDef(PtrTyReg)

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1493,7 +1493,7 @@ bool SPIRVInstructionSelector::selectFrexp(Register ResVReg,
     Register PointerVReg =
         createVirtualRegister(PointerType, &GR, MRI, MRI->getMF());
 
-    auto It = getOpVariableMBBIt(I.getMF()->front());
+    auto It = getOpVariableMBBIt(*I.getMF());
     BuildMI(*It->getParent(), It, It->getDebugLoc(), TII.get(SPIRV::OpVariable))
         .addDef(PointerVReg)
         .addUse(GR.getSPIRVTypeID(PointerType))
@@ -1534,7 +1534,7 @@ bool SPIRVInstructionSelector::selectSincos(Register ResVReg,
     Register PointerVReg =
         createVirtualRegister(PointerType, &GR, MRI, MRI->getMF());
 
-    auto It = getOpVariableMBBIt(I.getMF()->front());
+    auto It = getOpVariableMBBIt(*I.getMF());
     BuildMI(*It->getParent(), It, It->getDebugLoc(), TII.get(SPIRV::OpVariable))
         .addDef(PointerVReg)
         .addUse(GR.getSPIRVTypeID(PointerType))
@@ -6255,7 +6255,7 @@ bool SPIRVInstructionSelector::selectFrameIndex(Register ResVReg,
                                                 MachineInstr &I) const {
   // Change order of instructions if needed: all OpVariable instructions in a
   // function must be the first instructions in the first block
-  auto It = getOpVariableMBBIt(I.getMF()->front());
+  auto It = getOpVariableMBBIt(*I.getMF());
   BuildMI(*It->getParent(), It, It->getDebugLoc(), TII.get(SPIRV::OpVariable))
       .addDef(ResVReg)
       .addUse(GR.getSPIRVTypeID(ResType))
@@ -6553,8 +6553,8 @@ bool SPIRVInstructionSelector::selectModf(Register ResVReg,
     // Assign SPIR-V type of the pointer type of the alloca variable to the
     // new register.
     GR.assignSPIRVTypeToVReg(PtrType, PtrTyReg, MIRBuilder.getMF());
+    MachineBasicBlock::iterator VarPos = getOpVariableMBBIt(*I.getMF());
     MachineBasicBlock &EntryBB = I.getMF()->front();
-    MachineBasicBlock::iterator VarPos = getOpVariableMBBIt(EntryBB);
     auto AllocaMIB =
         BuildMI(EntryBB, VarPos, I.getDebugLoc(), TII.get(SPIRV::OpVariable))
             .addDef(PtrTyReg)

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -296,7 +296,8 @@ void buildOpSpirvDecorations(Register Reg, MachineIRBuilder &MIRBuilder,
   }
 }
 
-MachineBasicBlock::iterator getOpVariableMBBIt(MachineBasicBlock &MBB) {
+MachineBasicBlock::iterator getOpVariableMBBIt(MachineFunction &MF) {
+  MachineBasicBlock &MBB = MF.front();
   // Find the position to insert the OpVariable instruction.
   // We will insert it after the last OpFunctionParameter, if any, or
   // after OpFunction otherwise.

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -296,24 +296,28 @@ void buildOpSpirvDecorations(Register Reg, MachineIRBuilder &MIRBuilder,
   }
 }
 
-MachineBasicBlock::iterator getOpVariableMBBIt(MachineInstr &I) {
-  MachineFunction *MF = I.getParent()->getParent();
-  MachineBasicBlock *MBB = &MF->front();
-  MachineBasicBlock::iterator It = MBB->SkipPHIsAndLabels(MBB->begin()),
-                              E = MBB->end();
-  bool IsHeader = false;
-  unsigned Opcode;
-  for (; It != E && It != I; ++It) {
-    Opcode = It->getOpcode();
-    if (Opcode == SPIRV::OpFunction || Opcode == SPIRV::OpFunctionParameter) {
-      IsHeader = true;
-    } else if (IsHeader &&
-               !(Opcode == SPIRV::ASSIGN_TYPE || Opcode == SPIRV::OpLabel)) {
-      ++It;
-      break;
+MachineBasicBlock::iterator getOpVariableMBBIt(MachineBasicBlock &MBB) {
+  // Find the position to insert the OpVariable instruction.
+  // We will insert it after the last OpFunctionParameter, if any, or
+  // after OpFunction otherwise.
+  auto IsPreamble = [](const MachineInstr &MI) {
+    switch (MI.getOpcode()) {
+    case SPIRV::OpFunction:
+    case SPIRV::OpFunctionParameter:
+    case SPIRV::OpLabel:
+    case SPIRV::ASSIGN_TYPE:
+      return true;
+    default:
+      return false;
     }
-  }
-  return It;
+  };
+  MachineBasicBlock::iterator VarPos = MBB.SkipPHIsAndLabels(MBB.begin());
+  while (VarPos != MBB.end() && VarPos->getOpcode() != SPIRV::OpFunction)
+    ++VarPos;
+  // Advance past the preamble.
+  while (VarPos != MBB.end() && IsPreamble(*VarPos))
+    ++VarPos;
+  return VarPos;
 }
 
 MachineBasicBlock::iterator getInsertPtValidEnd(MachineBasicBlock *MBB) {
@@ -1103,29 +1107,6 @@ int64_t foldImm(const MachineOperand &MO, const MachineRegisterInfo *MRI) {
 unsigned getArrayComponentCount(const MachineRegisterInfo *MRI,
                                 const MachineInstr *ResType) {
   return foldImm(ResType->getOperand(2), MRI);
-}
-
-MachineBasicBlock::iterator
-getFirstValidInstructionInsertPoint(MachineBasicBlock &BB) {
-  // Find the position to insert the OpVariable instruction.
-  // We will insert it after the last OpFunctionParameter, if any, or
-  // after OpFunction otherwise.
-  MachineBasicBlock::iterator VarPos = BB.begin();
-  while (VarPos != BB.end() && VarPos->getOpcode() != SPIRV::OpFunction) {
-    ++VarPos;
-  }
-  // Advance VarPos to the next instruction after OpFunction, it will either
-  // be an OpFunctionParameter, so that we can start the next loop, or the
-  // position to insert the OpVariable instruction.
-  ++VarPos;
-  while (VarPos != BB.end() &&
-         VarPos->getOpcode() == SPIRV::OpFunctionParameter) {
-    ++VarPos;
-  }
-  // VarPos is now pointing at after the last OpFunctionParameter, if any,
-  // or after OpFunction, if no parameters.
-  return VarPos != BB.end() && VarPos->getOpcode() == SPIRV::OpLabel ? ++VarPos
-                                                                     : VarPos;
 }
 
 bool matchPeeledArrayPattern(const StructType *Ty, Type *&OriginalElementType,

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -222,7 +222,7 @@ void buildOpSpirvDecorations(Register Reg, MachineIRBuilder &MIRBuilder,
 
 // Return a valid position for the OpVariable instruction inside a function,
 // i.e., at the beginning of the first block of the function.
-MachineBasicBlock::iterator getOpVariableMBBIt(MachineInstr &I);
+MachineBasicBlock::iterator getOpVariableMBBIt(MachineBasicBlock &MBB);
 
 // Return a valid position for the instruction at the end of the block before
 // terminators and debug instructions.
@@ -587,8 +587,6 @@ MachineInstr *getImm(const MachineOperand &MO, const MachineRegisterInfo *MRI);
 int64_t foldImm(const MachineOperand &MO, const MachineRegisterInfo *MRI);
 unsigned getArrayComponentCount(const MachineRegisterInfo *MRI,
                                 const MachineInstr *ResType);
-MachineBasicBlock::iterator
-getFirstValidInstructionInsertPoint(MachineBasicBlock &BB);
 
 std::optional<SPIRV::LinkageType::LinkageType>
 getSpirvLinkageTypeFor(const SPIRVSubtarget &ST, const GlobalValue &GV);

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -222,7 +222,7 @@ void buildOpSpirvDecorations(Register Reg, MachineIRBuilder &MIRBuilder,
 
 // Return a valid position for the OpVariable instruction inside a function,
 // i.e., at the beginning of the first block of the function.
-MachineBasicBlock::iterator getOpVariableMBBIt(MachineBasicBlock &MBB);
+MachineBasicBlock::iterator getOpVariableMBBIt(MachineFunction &MF);
 
 // Return a valid position for the instruction at the end of the block before
 // terminators and debug instructions.


### PR DESCRIPTION
Merge getFirstValidInstructionInsertPoint into getOpVariableMBBIt and remove duplicated utility that computed the same insertion point