### PR TITLE
[lldb] Fix assert frame recognizer for non-macOS Apple platforms

### DIFF
--- a/lldb/source/Target/AssertFrameRecognizer.cpp
+++ b/lldb/source/Target/AssertFrameRecognizer.cpp
@@ -27,6 +27,12 @@ bool GetAbortLocation(llvm::Triple::OSType os, SymbolLocation &location) {
   switch (os) {
   case llvm::Triple::Darwin:
   case llvm::Triple::MacOSX:
+  case llvm::Triple::IOS:
+  case llvm::Triple::TvOS:
+  case llvm::Triple::WatchOS:
+  case llvm::Triple::BridgeOS:
+  case llvm::Triple::DriverKit:
+  case llvm::Triple::XROS:
     location.module_spec = FileSpec("libsystem_kernel.dylib");
     location.symbols.push_back(ConstString("__pthread_kill"));
     break;
@@ -60,6 +66,12 @@ bool GetAssertLocation(llvm::Triple::OSType os, SymbolLocation &location) {
   switch (os) {
   case llvm::Triple::Darwin:
   case llvm::Triple::MacOSX:
+  case llvm::Triple::IOS:
+  case llvm::Triple::TvOS:
+  case llvm::Triple::WatchOS:
+  case llvm::Triple::BridgeOS:
+  case llvm::Triple::DriverKit:
+  case llvm::Triple::XROS:
     location.module_spec = FileSpec("libsystem_c.dylib");
     location.symbols.push_back(ConstString("__assert_rtn"));
     break;


### PR DESCRIPTION
The `AssertFrameRecognizer` only matched `Darwin` and `MacOSX` triples when looking up abort and assert locations. On other Apple platforms (e.g. iOS), the recognizer was never registered, causing the stop reason to remain "signal SIGABRT" instead of "hit program assert".

Add the missing `iOS`, `tvOS`, `watchOS`, `driverKit`, `bridgeOS` and `VisionOS` cases to both `GetAbortLocation` and `GetAssertLocation`, since all Apple platforms use the same `libsystem_kernel`/`libsystem_c` symbols.

rdar://172707282