### PR TITLE
[clang] Fix LifetimeSafety build on 32-bit systems

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
@@ -54,9 +54,9 @@ public:
 
 private:
   Kind K;
-  const llvm::PointerUnion<
-      const clang::ValueDecl *, const clang::MaterializeTemporaryExpr *,
-      const ParmVarDecl *, const CXXMethodDecl *, const CXXNewExpr *>
+  const llvm::PointerUnion<const clang::MaterializeTemporaryExpr *,
+                           const CXXNewExpr *, const clang::ValueDecl *,
+                           const ParmVarDecl *, const CXXMethodDecl *>
       Root;
 
 public:


### PR DESCRIPTION
Reorder template parameters in ascending `NumLowBitsAvailable` order to match the required constrain.

cc: @usx95