### PR TITLE
[lldb] Fix pexpect detection with LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -16,7 +16,7 @@ if(LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS)
 
   if(NOT WIN32)
     # We no longer vendor pexpect and it is not used on Windows.
-    list(APPEND pexpect)
+    list(APPEND useful_python_modules pexpect)
   endif()
 
   foreach(module ${useful_python_modules})


### PR DESCRIPTION
Fixes ec8df555702d85511290742388d28016b69468de / #193437.

In which I tried to not require pexpect on Windows because key parts of it do not work there (https://pexpect.readthedocs.io/en/stable/overview.html#windows).

Which I did but made a mistake which removed pexpect from the list of required modules for *all* platforms as a side effect.

`list(APPEND pexpect)` creates an empty list called foo (https://cmake.org/cmake/help/latest/command/list.html#append), I meant to append to the useful modules list.

With that fixed, we require pexpect everywhere apart from Windows.

GitHub CI is already installing pexpect on Linux
(see .ci/all_requirements.txt). All the Linux bots using LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS have it installed. The Linux remote testing bots don't use that option but pexpect tests don't run when remote anyway.