### PR TITLE
[SPIR-V][docs] Document supported extensions missing from SPIRVUsage.rst

### DIFF
--- a/llvm/docs/SPIRVUsage.rst
+++ b/llvm/docs/SPIRVUsage.rst
@@ -257,6 +257,26 @@ Below is a list of supported SPIR-V extensions, sorted alphabetically by their e
      - Adds instructions for arbitrary precision floating-point arithmetic. The extension works without SPV_ALTERA_arbitrary_precision_integers, but together they allow greater flexibility in representing arbitrary precision data types.
    * - ``SPV_KHR_fma``
      - Adds a core fused-multiply-add (fma) instruction to replace the different variants that have existed in extended instruction sets.
+   * - ``SPV_AMD_shader_trinary_minmax_extension``
+     - Adds an extended instruction set providing trinary min and max operations for shaders.
+   * - ``SPV_EXT_relaxed_printf_string_address_space``
+     - Allows printf format strings to reside in address spaces other than constant.
+   * - ``SPV_EXT_shader_image_int64``
+     - Enables 64-bit integer types to be used with image read and write operations.
+   * - ``SPV_INTEL_long_composites``
+     - Adds continued instructions to allow composites with a large number of constituents.
+   * - ``SPV_INTEL_masked_gather_scatter``
+     - Adds masked gather and scatter instructions for vectors of pointers.
+   * - ``SPV_INTEL_tensor_float32_conversion``
+     - Adds an instruction to round a floating-point value to TensorFloat32.
+   * - ``SPV_INTEL_unstructured_loop_controls``
+     - Adds an instruction to control loop execution without structured loop constructs.
+   * - ``SPV_KHR_bfloat16``
+     - Adds a 16-bit bfloat floating-point type, along with dot product and cooperative matrix capabilities using bfloat16.
+   * - ``SPV_KHR_cooperative_matrix``
+     - Adds cooperative matrix types and instructions for matrix multiply-add operations across invocations in a subgroup.
+   * - ``SPV_KHR_vulkan_memory_model``
+     - Adds the Vulkan memory model, which defines memory semantics for the Vulkan API.
 
 
 SPIR-V representation in LLVM IR


### PR DESCRIPTION
Add entries for extensions that are actively used in the backend but were not listed in the supported extensions table