### PR TITLE
Revert "[Bazel] Fixes 8e56a89"

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -2639,10 +2639,7 @@ cc_library(
         "include/clang/ScalableStaticAnalysisFramework/SSAFBuiltinForceLinker.h",
         "include/clang/ScalableStaticAnalysisFramework/SSAFForceLinker.h",
     ]),
-    textual_hdrs = glob([
-        "include/clang/ScalableStaticAnalysisFramework/Core/**/*.def",
-        "include/clang/ScalableStaticAnalysisFramework/*.def",
-    ]),
+    textual_hdrs = glob(["include/clang/ScalableStaticAnalysisFramework/Core/**/*.def"]),
     deps = [
         ":ast",
         ":support",


### PR DESCRIPTION
Reverts llvm/llvm-project#193450

Since original change was also reverted in 582958c4337f539e650096c0257a322315298e1a