### PR TITLE
[VPlan] Avoid assuming underlying values for GEPs (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -1011,7 +1011,8 @@ private:
 
     if constexpr (std::is_same_v<RecipeTy, VPWidenGEPRecipe>) {
       SourceElementType = DefR->getSourceElementType();
-    } else if (DefR->getOpcode() == Instruction::GetElementPtr) {
+    } else if (DefR->getOpcode() == Instruction::GetElementPtr &&
+               DefR->getUnderlyingValue()) {
       SourceElementType = cast<GetElementPtrInst>(DefR->getUnderlyingInstr())
                               ->getSourceElementType();
     } else if constexpr (std::is_same_v<RecipeTy, VPInstruction>) {

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1279,7 +1279,9 @@ static VPIRValue *tryToFoldLiveIns(VPSingleDefRecipe &R,
                             Ops[1]);
     case Instruction::GetElementPtr: {
       auto &RFlags = cast<VPRecipeWithIRFlags>(R);
-      auto *GEP = cast<GetElementPtrInst>(RFlags.getUnderlyingInstr());
+      auto *GEP = cast_or_null<GetElementPtrInst>(RFlags.getUnderlyingValue());
+      if (!GEP)
+        return nullptr;
       return Folder.FoldGEP(GEP->getSourceElementType(), Ops[0],
                             drop_begin(Ops), RFlags.getGEPNoWrapFlags());
     }


### PR DESCRIPTION
Instruction::GetElementPtr can originate in a non-WidenGEP non-Replicate recipe, which is not guaranteed to have an underlying value. Lift or make explicit the assumption.