### PR TITLE
[GVN] Reject PartialAlias in canSkipClobberingStore

### DIFF
--- a/llvm/lib/Analysis/MemoryDependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/MemoryDependenceAnalysis.cpp
@@ -355,6 +355,14 @@ static bool canSkipClobberingStore(const StoreInst *SI,
       MemLoc.Size.getValue().getKnownMinValue())
     return false;
 
+  // The alignment check above is necessary but not sufficient: AA may know
+  // that the store destination and MemLoc have a constant offset that causes
+  // partial overlap. In that case the store modifies only part of MemLoc,
+  // so the loaded value may change even though the stored value was originally
+  // read from a MustAlias location.
+  if (BatchAA.alias(MemoryLocation::get(SI), MemLoc) == AliasResult::PartialAlias)
+    return false;
+
   auto *LI = dyn_cast<LoadInst>(SI->getValueOperand());
   if (!LI || LI->getParent() != SI->getParent())
     return false;

--- a/llvm/test/Transforms/GVN/rle-clobbering-store.ll
+++ b/llvm/test/Transforms/GVN/rle-clobbering-store.ll
@@ -126,3 +126,58 @@ entry:
   %1 = load atomic i32, ptr %a unordered, align 4
   ret i32 %1
 }
+
+define i64 @test_partial_overlap(ptr %buf) {
+; CHECK-LABEL: @test_partial_overlap(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[DST:%.*]] = getelementptr inbounds i8, ptr [[BUF:%.*]], i64 2
+; CHECK-NEXT:    [[V1:%.*]] = load i64, ptr [[BUF]], align 8
+; CHECK-NEXT:    store i64 [[V1]], ptr [[DST]], align 8
+; CHECK-NEXT:    [[V2:%.*]] = load i64, ptr [[BUF]], align 8
+; CHECK-NEXT:    ret i64 [[V2]]
+;
+entry:
+  %src = getelementptr inbounds i8, ptr %buf, i64 0
+  %dst = getelementptr inbounds i8, ptr %buf, i64 2
+  %v1 = load i64, ptr %src, align 8
+  store i64 %v1, ptr %dst, align 8
+  %v2 = load i64, ptr %src, align 8
+  ret i64 %v2
+}
+
+; Negative offset partial overlap
+define i64 @test_partial_overlap_neg(ptr %buf) {
+; CHECK-LABEL: @test_partial_overlap_neg(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[SRC:%.*]] = getelementptr inbounds i8, ptr [[BUF:%.*]], i64 4
+; CHECK-NEXT:    [[V1:%.*]] = load i64, ptr [[SRC]], align 8
+; CHECK-NEXT:    store i64 [[V1]], ptr [[BUF]], align 8
+; CHECK-NEXT:    [[V2:%.*]] = load i64, ptr [[SRC]], align 8
+; CHECK-NEXT:    ret i64 [[V2]]
+;
+entry:
+  %src = getelementptr inbounds i8, ptr %buf, i64 4
+  %dst = getelementptr inbounds i8, ptr %buf, i64 0
+  %v1 = load i64, ptr %src, align 8
+  store i64 %v1, ptr %dst, align 8
+  %v2 = load i64, ptr %src, align 8
+  ret i64 %v2
+}
+
+; No overlap (store to non-overlapping region) - GVN SHOULD eliminate the load
+define i64 @test_no_overlap(ptr %buf) {
+; CHECK-LABEL: @test_no_overlap(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[DST:%.*]] = getelementptr inbounds i8, ptr [[BUF:%.*]], i64 64
+; CHECK-NEXT:    [[V1:%.*]] = load i64, ptr [[BUF]], align 8
+; CHECK-NEXT:    store i64 [[V1]], ptr [[DST]], align 8
+; CHECK-NEXT:    ret i64 [[V1]]
+;
+entry:
+  %src = getelementptr inbounds i8, ptr %buf, i64 0
+  %dst = getelementptr inbounds i8, ptr %buf, i64 64
+  %v1 = load i64, ptr %src, align 8
+  store i64 %v1, ptr %dst, align 8
+  %v2 = load i64, ptr %src, align 8
+  ret i64 %v2
+}


### PR DESCRIPTION
`canSkipClobberingStore()` was introduced in [commit 9f12f655c44f](https://github.com/llvm/llvm-project/commit/9f12f655c44faf47e5c42c016b543cc431b66af8#diff-b5ec28fb6d9a0a31bae28bbd34639aed9b8df0c760f698f418628803770fc790) to skip stores that write back the same value to the same location. However, the function only verified that the store's *source* (value operand) was loaded from a MustAlias location, but never checked whether the store's *destination* pointer could partially overlap with the queried MemoryLocation. 

Consider:
 ```
 %src = getelementptr inbounds i8, ptr %buf, i64 0
  %dst = getelementptr inbounds i8, ptr %buf, i64 2
  %v1 = load i64, ptr %src, align 8          ; [buf+0, buf+8)
  store i64 %v1, ptr %dst, align 8           ; [buf+2, buf+10)
  %v2 = load i64, ptr %src, align 8          ; [buf+0, buf+8)
```

AA knows `%dst = %src + 2` and both access 8 bytes → PartialAlias.
The store modifies bytes [2..7] of the region read by `%v2`, so `%v2` != `%v1`
in general. GVN must not replace `%v2 `with `%v1`.

