### PR TITLE
[mlir][tosa] Make tosa-attach-target optional in addTosaToLinalgPasses

### DIFF
--- a/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgPass.cpp
+++ b/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgPass.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassOptions.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Passes.h"
 
@@ -98,14 +99,19 @@ void mlir::tosa::addTosaToLinalgPasses(
   pm.addNestedPass<func::FuncOp>(tosa::createTosaLayerwiseConstantFoldPass(
       {options.aggressiveReduceConstant}));
   pm.addNestedPass<func::FuncOp>(tosa::createTosaMakeBroadcastablePass());
-  if (!attachTargetOptions) {
-    attachTargetOptions = TosaAttachTargetOptions();
-    attachTargetOptions->profiles = {"pro_int", "pro_fp"};
-    // TODO: populate with all the extensions that the tosa->linalg conversion
-    // supports
-    attachTargetOptions->extensions = {"doubleround"};
+  // tosa-attach-target writes a tosa.target_env module attribute, schedule it
+  // only when the caller actually needs one. Callers that opt out of both no
+  // longer get a tosa.target_env attribute they did not ask for.
+  if (validationOptions || attachTargetOptions) {
+    if (!attachTargetOptions) {
+      attachTargetOptions = TosaAttachTargetOptions();
+      attachTargetOptions->profiles = {"pro_int", "pro_fp"};
+      // TODO: populate with all the extensions that the tosa->linalg
+      // conversion supports
+      attachTargetOptions->extensions = {"doubleround"};
+    }
+    pm.addPass(tosa::createTosaAttachTarget(*attachTargetOptions));
   }
-  pm.addPass(tosa::createTosaAttachTarget(*attachTargetOptions));
   if (validationOptions)
     pm.addPass(tosa::createTosaValidation(*validationOptions));
   pm.addNestedPass<func::FuncOp>(tosa::createTosaToLinalg());
@@ -115,18 +121,33 @@ void mlir::tosa::addTosaToLinalgPasses(
 // Pipeline registration.
 //===----------------------------------------------------------------------===//
 
+namespace {
+/// Options controlling the registered `tosa-to-linalg-pipeline`.
+struct TosaToLinalgPipelineOptions
+    : public PassPipelineOptions<TosaToLinalgPipelineOptions> {
+  PassOptions::Option<bool> validation{
+      *this, "validation",
+      llvm::cl::desc("Run tosa-attach-target and tosa-validate as part of the "
+                     "pipeline."),
+      llvm::cl::init(true)};
+};
+} // namespace
+
 void mlir::tosa::registerTosaToLinalgPipelines() {
-  PassPipelineRegistration<>(
+  PassPipelineRegistration<TosaToLinalgPipelineOptions>(
       "tosa-to-linalg-pipeline",
       "The default pipeline for converting TOSA operators to the equivalent "
       "operations using the tensor operations in LinAlg as well as LinAlg "
       "named operations.",
-      [](OpPassManager &pm) {
+      [](OpPassManager &pm, const TosaToLinalgPipelineOptions &pipelineOpts) {
         TosaToLinalgOptions tosaToLinalgOptions;
         TosaToLinalgNamedOptions tosaToLinalgNamedOptions;
-        TosaValidationOptions validationOptions;
-        validationOptions.strictOpSpecAlignment = false;
-        validationOptions.allowInvalidOpDatatypeCombinations = false;
+        std::optional<TosaValidationOptions> validationOptions;
+        if (pipelineOpts.validation) {
+          validationOptions = TosaValidationOptions{
+              /*strictOpSpecAlignment=*/false,
+              /*allowInvalidOpDatatypeCombinations=*/false};
+        }
         tosa::addTosaToLinalgPasses(pm, tosaToLinalgOptions,
                                     tosaToLinalgNamedOptions,
                                     validationOptions);

--- a/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg-pipeline-no-validation.mlir
+++ b/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg-pipeline-no-validation.mlir
@@ -1,0 +1,14 @@
+// RUN: mlir-opt %s --tosa-to-linalg-pipeline="validation=false" | FileCheck %s
+
+// Check that --tosa-to-linalg-pipeline="validation=false" lowers to linalg
+// and does not leave a tosa.target_env module attribute behind.
+
+// CHECK-LABEL: module
+// CHECK-NOT: tosa.target_env
+// CHECK-LABEL: func.func @simple_abs
+// CHECK-NOT: tosa.
+// CHECK: linalg.
+func.func @simple_abs(%arg0: tensor<2x3xf32>) -> tensor<2x3xf32> {
+  %0 = tosa.abs %arg0 : (tensor<2x3xf32>) -> tensor<2x3xf32>
+  return %0 : tensor<2x3xf32>
+}


### PR DESCRIPTION
addTosaToLinalgPasses unconditionally scheduled tosa-attach-target, thus adding a `tosa.target_env` attribute to the module. Callers therefore had no way to opt out of such attribute. This attribute is consumed if validationOptions is enabled, which is optional. Therefore, if the caller disables validationOptions, the tosa-attach-target attribute will exist even after TosaToLinalg. So consumers that don't load the TOSA dialect can't even parse the resulting module.

This PR makes sure that we schedule tosa-attach-target only when the caller actually needs it, i.e. when validationOptions or attachTargetOptions is set. The default values stay inside the `!attachTargetOptions` branch so callers that set validationOptions still get a target env to validate against, preserving existing behavior.

Also add a `validation` pipeline option (default `true`) to the registered `tosa-to-linalg-pipeline`, so it can be invoked without scheduling either `tosa-attach-target` / `tosa-validate`. A lit test is also added.