### PR TITLE
[NFC][Clang][docs] Clarify the status of P1949R7 (unicode identifiers)

### DIFF
--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -438,7 +438,12 @@ C++23, informally referred to as C++26.</p>
     <tr>
       <td>C++ identifier syntax using UAX 31</td>
       <td><a href="https://wg21.link/P1949R7">P1949R7</a> (<a href="#dr">DR</a>)</td>
-      <td class="full" align="center">Clang 14</td>
+      <td class="partial" align="center">
+        <details>
+          <summary>Clang 14 (Partial)</summary>
+          Clang supports Unicode identifiers but does not check that they are NFC-normalized.
+        </details>
+      </td>
     </tr>
     <tr>
       <td>Mixed string literal concatenation</td>


### PR DESCRIPTION
Clang does not check identifiers are NFC-normalized, which the standard requires.