### PR TITLE
[flang-rt] Add support for logical binary input edit descriptor

### DIFF
--- a/flang-rt/lib/runtime/edit-input.cpp
+++ b/flang-rt/lib/runtime/edit-input.cpp
@@ -924,7 +924,7 @@ RT_API_ATTRS bool EditRealInput(
   }
 }
 
-// 13.7.3 in Fortran 2018 (B descriptor is an extension)
+// F2018 13.7.3 (B descriptor is a non-standard extension)
 RT_API_ATTRS bool EditLogicalInput(
     IoStatementState &io, const DataEdit &edit, bool &x) {
   switch (edit.descriptor) {

--- a/flang-rt/lib/runtime/edit-input.cpp
+++ b/flang-rt/lib/runtime/edit-input.cpp
@@ -935,6 +935,7 @@ RT_API_ATTRS bool EditLogicalInput(
     break;
   case 'L':
   case 'G':
+  case 'B':
     break;
   default:
     io.GetIoErrorHandler().SignalError(IostatErrorInFormat,
@@ -951,19 +952,34 @@ RT_API_ATTRS bool EditLogicalInput(
     io.GetIoErrorHandler().SignalError("Empty LOGICAL input field");
     return false;
   }
-  switch (*next) {
-  case 'T':
-  case 't':
-    x = true;
-    break;
-  case 'F':
-  case 'f':
-    x = false;
-    break;
-  default:
-    io.GetIoErrorHandler().SignalError(
-        "Bad character '%lc' in LOGICAL input field", *next);
-    return false;
+  if (edit.descriptor == 'B') {
+    switch (*next) {
+    case '1':
+      x = true;
+      break;
+    case '0':
+      x = false;
+      break;
+    default:
+      io.GetIoErrorHandler().SignalError(
+          "Bad character '%lc' in BINARY input field", *next);
+      return false;
+    }
+  } else {
+    switch (*next) {
+    case 'T':
+    case 't':
+      x = true;
+      break;
+    case 'F':
+    case 'f':
+      x = false;
+      break;
+    default:
+      io.GetIoErrorHandler().SignalError(
+          "Bad character '%lc' in LOGICAL input field", *next);
+      return false;
+    }
   }
   if (remaining || edit.descriptor == DataEdit::ListDirected) {
     // Ignore the rest of the input field; stop after separator when

--- a/flang-rt/lib/runtime/edit-input.cpp
+++ b/flang-rt/lib/runtime/edit-input.cpp
@@ -924,7 +924,7 @@ RT_API_ATTRS bool EditRealInput(
   }
 }
 
-// 13.7.3 in Fortran 2018
+// 13.7.3 in Fortran 2018 (B descriptor is an extension)
 RT_API_ATTRS bool EditLogicalInput(
     IoStatementState &io, const DataEdit &edit, bool &x) {
   switch (edit.descriptor) {

--- a/flang-rt/lib/runtime/edit-input.cpp
+++ b/flang-rt/lib/runtime/edit-input.cpp
@@ -945,7 +945,7 @@ RT_API_ATTRS bool EditLogicalInput(
   }
   common::optional<int> remaining{io.CueUpInput(edit)};
   common::optional<char32_t> next{io.NextInField(remaining, edit)};
-  if (next && *next == '.') { // skip optional period
+  if (next && *next == '.' && edit.descriptor != 'B') { // skip optional period
     next = io.NextInField(remaining, edit);
   }
   if (!next) {

--- a/flang-rt/unittests/Runtime/InputExtensions.cpp
+++ b/flang-rt/unittests/Runtime/InputExtensions.cpp
@@ -88,6 +88,10 @@ TEST(InputExtensionTests, SeparatorInField_L) {
       {2, "(DC,2L4)", ".F;T,", {false, true}},
       {2, "(DC,2L4)", ".T.;F,", {true, false}},
       {2, "(DC,2L4)", ".F.;T,", {false, true}},
+      {2, "(2B4)", "1   0,", {true, false}},
+      {2, "(2B4)", "0   1,", {false, true}},
+      {2, "(DC,2B4)", "1   0,", {true, false}},
+      {2, "(DC,2B4)", "0   1,", {false, true}},
   };
   for (std::size_t j{0}; j < sizeof test / sizeof *test; ++j) {
     auto cookie{IONAME(BeginInternalFormattedInput)(test[j].data,
@@ -100,7 +104,7 @@ TEST(InputExtensionTests, SeparatorInField_L) {
           << "expected " << test[j].expect[k] << ", got " << got;
     }
     auto status{IONAME(EndIoStatement)(cookie)};
-    ASSERT_EQ(status, 0) << "error status " << status << " on L test case "
+    ASSERT_EQ(status, 0) << "error status " << status << " on L/B test case "
                          << j;
   }
 }

--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -238,6 +238,7 @@ end
 * `ASSIGN` statement, assigned `GO TO`, and assigned format
 * `PAUSE` statement
 * Hollerith literals and edit descriptors
+* Binary logical edit descriptor B (1/0 vs T/F)
 * `NAMELIST` allowed in the execution part
 * Omitted colons on type declaration statements with attributes
 * COMPLEX constructor expression, e.g. `(x+y,z)`


### PR DESCRIPTION
Add binary 'B' input edit descriptor support for logical values to flang runtime EditLogicalInput().  The logical binary 'B' edit descriptor is already supported in EditLogicalOutput().

Co-authored-by: John Otken john.otken@hpe.com