### PR TITLE
[profcheck] Fix assert in getInitializer call on global with no initializer

### DIFF
--- a/llvm/lib/Transforms/Utils/ProfileVerify.cpp
+++ b/llvm/lib/Transforms/Utils/ProfileVerify.cpp
@@ -206,14 +206,15 @@ PreservedAnalyses ProfileVerifierPass::run(Module &M,
                                            ModuleAnalysisManager &MAM) {
   auto PopulateIgnoreList = [&](StringRef GVName) {
     if (const auto *CT = M.getGlobalVariable(GVName))
-      if (const auto *CA =
-              dyn_cast_if_present<ConstantArray>(CT->getInitializer()))
-        for (const auto &Elt : CA->operands())
-          if (const auto *CS = dyn_cast<ConstantStruct>(Elt))
-            if (CS->getNumOperands() >= 2 && CS->getOperand(1))
-              if (const auto *F = dyn_cast<Function>(
-                      CS->getOperand(1)->stripPointerCasts()))
-                IgnoreList.insert(F);
+      if (CT->hasInitializer())
+        if (const auto *CA =
+                dyn_cast_if_present<ConstantArray>(CT->getInitializer()))
+          for (const auto &Elt : CA->operands())
+            if (const auto *CS = dyn_cast<ConstantStruct>(Elt))
+              if (CS->getNumOperands() >= 2 && CS->getOperand(1))
+                if (const auto *F = dyn_cast<Function>(
+                        CS->getOperand(1)->stripPointerCasts()))
+                  IgnoreList.insert(F);
   };
   PopulateIgnoreList("llvm.global_ctors");
   PopulateIgnoreList("llvm.global_dtors");


### PR DESCRIPTION
This code calls `getInitializer` without checking if the global has an initializer, which causes an assert if there isn't one. These globals may have no initializer after optimization from `globalopt`.

Check for an initializer first.

This is already locked down with `CodeGen/SPIRV/legalize-zero-size-arrays-appending.ll` so we don't need a new test.

This issue was exposed by https://github.com/llvm/llvm-project/pull/192730.