### PR TITLE
[llvm][ADT] Add erase method to ScopedHashTableScope

### DIFF
--- a/llvm/include/llvm/ADT/ScopedHashTable.h
+++ b/llvm/include/llvm/ADT/ScopedHashTable.h
@@ -46,6 +46,7 @@ template <typename K, typename V>
 class ScopedHashTableVal {
   ScopedHashTableVal *NextInScope;
   ScopedHashTableVal *NextForKey;
+  ScopedHashTableVal *PreInScope;
   K Key;
   V Val;
 
@@ -59,6 +60,7 @@ public:
   ScopedHashTableVal *getNextForKey() { return NextForKey; }
   const ScopedHashTableVal *getNextForKey() const { return NextForKey; }
   ScopedHashTableVal *getNextInScope() { return NextInScope; }
+  ScopedHashTableVal *getPreInScope() { return PreInScope; }
 
   template <typename AllocatorTy>
   static ScopedHashTableVal *Create(ScopedHashTableVal *nextInScope,
@@ -70,6 +72,9 @@ public:
     new (New) ScopedHashTableVal(key, val);
     New->NextInScope = nextInScope;
     New->NextForKey = nextForKey;
+    New->PreInScope = nullptr;
+    if (nextInScope)
+      nextInScope->PreInScope = New;
     return New;
   }
 
@@ -77,6 +82,20 @@ public:
     // Free memory referenced by the item.
     this->~ScopedHashTableVal();
     Allocator.Deallocate(this);
+  }
+
+  template <typename AllocatorTy>
+  static void invalidate(ScopedHashTableVal<K, V> *&ThisEntry,
+                         AllocatorTy &Allocator) {
+    ScopedHashTableVal<K, V> *ToDestroy = ThisEntry;
+    ScopedHashTableVal<K, V> *NextInScope = ThisEntry->NextInScope;
+    ScopedHashTableVal<K, V> *PrevInScope = ThisEntry->PreInScope;
+    if (PrevInScope)
+      PrevInScope->NextInScope = NextInScope;
+    if (NextInScope)
+      NextInScope->PreInScope = PrevInScope;
+    ThisEntry = ThisEntry->NextForKey;
+    ToDestroy->Destroy(Allocator);
   }
 };
 
@@ -101,6 +120,7 @@ public:
 
   ScopedHashTableScope *getParentScope() { return PrevScope; }
   const ScopedHashTableScope *getParentScope() const { return PrevScope; }
+  void invalidate(const K &key);
 
 private:
   friend class ScopedHashTable<K, V, KInfo, AllocatorTy>;
@@ -219,6 +239,8 @@ public:
                              getAllocator());
     S->setLastValInScope(KeyEntry);
   }
+
+  void invalidate(const K &key) { CurScope->invalidate(key); }
 };
 
 /// ScopedHashTableScope ctor - Install this as the current scope for the hash
@@ -257,6 +279,24 @@ ScopedHashTableScope<K, V, KInfo, Allocator>::~ScopedHashTableScope() {
   }
 }
 
+template <typename K, typename V, typename KInfo, typename Allocator>
+void ScopedHashTableScope<K, V, KInfo, Allocator>::invalidate(const K &key) {
+  if (!HT.TopLevelMap.contains(key))
+    return;
+  ScopedHashTableVal<K, V> *&ThisEntry = HT.TopLevelMap[key];
+
+  auto S = this;
+  while (S) {
+    if (ThisEntry == S->LastValInScope) {
+      S->LastValInScope = ThisEntry->getNextInScope();
+      break;
+    }
+    S = S->PrevScope;
+  }
+  if (ThisEntry->getNextForKey() == nullptr)
+    HT.TopLevelMap.erase(key);
+  ScopedHashTableVal<K, V>::invalidate(ThisEntry, HT.getAllocator());
+}
 } // end namespace llvm
 
 #endif // LLVM_ADT_SCOPEDHASHTABLE_H

--- a/llvm/include/llvm/ADT/ScopedHashTable.h
+++ b/llvm/include/llvm/ADT/ScopedHashTable.h
@@ -286,10 +286,10 @@ ScopedHashTableScope<K, V, KInfo, Allocator>::~ScopedHashTableScope() {
 /// This value is owned by "Scope1(HT)".
 template <typename K, typename V, typename KInfo, typename Allocator>
 void ScopedHashTableScope<K, V, KInfo, Allocator>::erase(const K &Key) {
-  auto I = HT.TopLevelMap.find(Key);
-  if (I == HT.TopLevelMap.end())
+  auto It = HT.TopLevelMap.find(Key);
+  if (It == HT.TopLevelMap.end())
     return;
-  ScopedHashTableVal<K, V> *&ThisEntry = I->second;
+  ScopedHashTableVal<K, V> *&ThisEntry = It->second;
 
   // `ThisEntry` may be the LastValInScope of a parent scope rather than the
   // current scope. We iterate through the scope chain to find the scope
@@ -303,7 +303,7 @@ void ScopedHashTableScope<K, V, KInfo, Allocator>::erase(const K &Key) {
     S = S->PrevScope;
   }
   if (ThisEntry->getNextForKey() == nullptr)
-    HT.TopLevelMap.erase(Key);
+    HT.TopLevelMap.erase(It);
   ScopedHashTableVal<K, V>::erase(ThisEntry, HT.getAllocator());
 }
 } // end namespace llvm

--- a/llvm/include/llvm/ADT/ScopedHashTable.h
+++ b/llvm/include/llvm/ADT/ScopedHashTable.h
@@ -289,7 +289,7 @@ void ScopedHashTableScope<K, V, KInfo, Allocator>::erase(const K &Key) {
   auto I = HT.TopLevelMap.find(Key);
   if (I == HT.TopLevelMap.end())
     return;
-  ScopedHashTableVal<K, V> *&ThisEntry = *I;
+  ScopedHashTableVal<K, V> *&ThisEntry = I->second;
 
   // `ThisEntry` may be the LastValInScope of a parent scope rather than the
   // current scope. We iterate through the scope chain to find the scope

--- a/llvm/include/llvm/ADT/ScopedHashTable.h
+++ b/llvm/include/llvm/ADT/ScopedHashTable.h
@@ -85,8 +85,8 @@ public:
   }
 
   template <typename AllocatorTy>
-  static void invalidate(ScopedHashTableVal<K, V> *&ThisEntry,
-                         AllocatorTy &Allocator) {
+  static void erase(ScopedHashTableVal<K, V> *&ThisEntry,
+                    AllocatorTy &Allocator) {
     ScopedHashTableVal<K, V> *ToDestroy = ThisEntry;
     ScopedHashTableVal<K, V> *NextInScope = ThisEntry->NextInScope;
     ScopedHashTableVal<K, V> *PrevInScope = ThisEntry->PreInScope;
@@ -120,7 +120,7 @@ public:
 
   ScopedHashTableScope *getParentScope() { return PrevScope; }
   const ScopedHashTableScope *getParentScope() const { return PrevScope; }
-  void invalidate(const K &key);
+  void erase(const K &key);
 
 private:
   friend class ScopedHashTable<K, V, KInfo, AllocatorTy>;
@@ -240,7 +240,7 @@ public:
     S->setLastValInScope(KeyEntry);
   }
 
-  void invalidate(const K &key) { CurScope->invalidate(key); }
+  void erase(const K &key) { CurScope->erase(key); }
 };
 
 /// ScopedHashTableScope ctor - Install this as the current scope for the hash
@@ -279,13 +279,22 @@ ScopedHashTableScope<K, V, KInfo, Allocator>::~ScopedHashTableScope() {
   }
 }
 
+// This method undoes the latest binding of the given key, effectively
+// reverting to the previous state for that key.
+// In the example at the beginning of this file, if we execute `HT.erase(0)`
+// immediately after `HT.insert(0, 42);`, then the value associated with key "0"
+// reverts to 0. This value is owned by "Scope1(HT)".
 template <typename K, typename V, typename KInfo, typename Allocator>
-void ScopedHashTableScope<K, V, KInfo, Allocator>::invalidate(const K &key) {
-  if (!HT.TopLevelMap.contains(key))
+void ScopedHashTableScope<K, V, KInfo, Allocator>::erase(const K &Key) {
+  auto I = HT.TopLevelMap.find(Key);
+  if (I == HT.TopLevelMap.end())
     return;
-  ScopedHashTableVal<K, V> *&ThisEntry = HT.TopLevelMap[key];
+  ScopedHashTableVal<K, V> *&ThisEntry = *I;
 
-  auto S = this;
+  // `ThisEntry` may be the LastValInScope of a parent scope rather than the
+  // current scope. We iterate through the scope chain to find the scope
+  // that owns ThisEntry as its LastValInScope and update it accordingly.
+  auto *S = this;
   while (S) {
     if (ThisEntry == S->LastValInScope) {
       S->LastValInScope = ThisEntry->getNextInScope();
@@ -294,8 +303,8 @@ void ScopedHashTableScope<K, V, KInfo, Allocator>::invalidate(const K &key) {
     S = S->PrevScope;
   }
   if (ThisEntry->getNextForKey() == nullptr)
-    HT.TopLevelMap.erase(key);
-  ScopedHashTableVal<K, V>::invalidate(ThisEntry, HT.getAllocator());
+    HT.TopLevelMap.erase(Key);
+  ScopedHashTableVal<K, V>::erase(ThisEntry, HT.getAllocator());
 }
 } // end namespace llvm
 

--- a/llvm/include/llvm/ADT/ScopedHashTable.h
+++ b/llvm/include/llvm/ADT/ScopedHashTable.h
@@ -279,11 +279,11 @@ ScopedHashTableScope<K, V, KInfo, Allocator>::~ScopedHashTableScope() {
   }
 }
 
-// This method undoes the latest binding of the given key, effectively
-// reverting to the previous state for that key.
-// In the example at the beginning of this file, if we execute `HT.erase(0)`
-// immediately after `HT.insert(0, 42);`, then the value associated with key "0"
-// reverts to 0. This value is owned by "Scope1(HT)".
+/// This method undoes the latest binding of the given key, effectively
+/// reverting to the previous state for that key. In the example at the
+/// beginning of this file, if we execute `HT.erase(0)` immediately after
+/// `HT.insert(0, 42);`, then the value associated with key "0" reverts to 0.
+/// This value is owned by "Scope1(HT)".
 template <typename K, typename V, typename KInfo, typename Allocator>
 void ScopedHashTableScope<K, V, KInfo, Allocator>::erase(const K &Key) {
   auto I = HT.TopLevelMap.find(Key);

--- a/llvm/unittests/ADT/ScopedHashTableTest.cpp
+++ b/llvm/unittests/ADT/ScopedHashTableTest.cpp
@@ -31,6 +31,7 @@ protected:
   static constexpr StringLiteral kLocalName = "local";
   static constexpr StringLiteral kLocalValue = "lvalue";
   static constexpr StringLiteral kLocalValue2 = "lvalue2";
+  static constexpr StringLiteral KLocalValue3 = "lvalue3";
 };
 
 TEST_F(ScopedHashTableTest, AccessWithNoActiveScope) {
@@ -150,4 +151,33 @@ TEST_F(ScopedHashTableTest, DISABLED_PopScopeOnStack) {
   // `SymbolTableScopeTy.this` is still a pointer to `funScope2`.
   // There is no way to write an assert on an assert in googletest so that we
   // mark the test case as DISABLED.
+}
+
+TEST_F(ScopedHashTableTest, EraseKeyInHashTable) {
+  using SymbolTableScopeTy = ScopedHashTable<StringRef, StringRef>::ScopeTy;
+  StringRef curTestVarA = "a";
+  StringRef curTestVarB = "b";
+  SymbolTableScopeTy funScope(symbolTable);
+  symbolTable.insert(kLocalName, kLocalValue);
+  symbolTable.insert(curTestVarA, curTestVarA);
+  symbolTable.insert(curTestVarB, curTestVarB);
+
+  SymbolTableScopeTy funScope2(symbolTable);
+  symbolTable.insert(curTestVarA, curTestVarA);
+  symbolTable.insert(kLocalName, kLocalValue2);
+  symbolTable.insert(curTestVarB, curTestVarB);
+
+  SymbolTableScopeTy funScope3(symbolTable);
+  symbolTable.insert(curTestVarA, curTestVarA);
+  symbolTable.insert(curTestVarB, curTestVarB);
+  symbolTable.insert(kLocalName, KLocalValue3);
+  SymbolTableScopeTy funScope4(symbolTable);
+
+  EXPECT_EQ(symbolTable.lookup(kLocalName), KLocalValue3);
+  symbolTable.erase(kLocalName);
+  EXPECT_EQ(symbolTable.lookup(kLocalName), kLocalValue2);
+  symbolTable.erase(kLocalName);
+  EXPECT_EQ(symbolTable.lookup(kLocalName), kLocalValue);
+  symbolTable.erase(kLocalName);
+  EXPECT_EQ(symbolTable.lookup(kLocalName), StringRef());
 }


### PR DESCRIPTION
This PR introduces an `erase` method to `ScopedHashTable`, designed to remove the most recent value associated with a given key within the scope stack. To support efficient deletion, the internal `ScopedHashTableVal` structure has been refactored into a doubly linked list, allowing the predecessor of a node to be identified in O(1) time during removal. Fix the MLIR CSE issue https://github.com/llvm/llvm-project/pull/191135#discussion_r3100850607. Part of https://github.com/llvm/llvm-project/pull/193778.