### PR TITLE
[LifetimeSafety] Simplify `AccessPath` root `PointerUnion`

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
@@ -52,15 +52,13 @@ public:
 
 private:
   Kind K;
-  const llvm::PointerUnion<const clang::MaterializeTemporaryExpr *,
-                           const CXXNewExpr *, const clang::ValueDecl *,
-                           const ParmVarDecl *, const CXXMethodDecl *>
-      Root;
+  const uintptr_t Root;
 
 public:
-  AccessPath(const clang::ValueDecl *D) : K(Kind::ValueDecl), Root(D) {}
+  AccessPath(const clang::ValueDecl *D)
+      : K(Kind::ValueDecl), Root(reinterpret_cast<uintptr_t>(D)) {}
   AccessPath(const clang::MaterializeTemporaryExpr *MTE)
-      : K(Kind::MaterializeTemporary), Root(MTE) {}
+      : K(Kind::MaterializeTemporary), Root(reinterpret_cast<uintptr_t>(MTE)) {}
   static AccessPath Placeholder(const ParmVarDecl *PVD) {
     return AccessPath(Kind::PlaceholderParam, PVD);
   }
@@ -72,21 +70,24 @@ public:
   Kind getKind() const { return K; }
 
   const clang::ValueDecl *getAsValueDecl() const {
-    return K == Kind::ValueDecl ? Root.dyn_cast<const clang::ValueDecl *>()
-                                : nullptr;
+    return K == Kind::ValueDecl
+               ? reinterpret_cast<const clang::ValueDecl *>(Root)
+               : nullptr;
   }
   const clang::MaterializeTemporaryExpr *getAsMaterializeTemporaryExpr() const {
     return K == Kind::MaterializeTemporary
-               ? Root.dyn_cast<const clang::MaterializeTemporaryExpr *>()
+               ? reinterpret_cast<const clang::MaterializeTemporaryExpr *>(Root)
                : nullptr;
   }
   const ParmVarDecl *getAsPlaceholderParam() const {
-    return K == Kind::PlaceholderParam ? Root.dyn_cast<const ParmVarDecl *>()
-                                       : nullptr;
+    return K == Kind::PlaceholderParam
+               ? reinterpret_cast<const ParmVarDecl *>(Root)
+               : nullptr;
   }
   const CXXMethodDecl *getAsPlaceholderThis() const {
-    return K == Kind::PlaceholderThis ? Root.dyn_cast<const CXXMethodDecl *>()
-                                      : nullptr;
+    return K == Kind::PlaceholderThis
+               ? reinterpret_cast<const CXXMethodDecl *>(Root)
+               : nullptr;
   }
 
   bool operator==(const AccessPath &RHS) const {
@@ -96,8 +97,10 @@ public:
   void dump(llvm::raw_ostream &OS) const;
 
 private:
-  AccessPath(Kind K, const ParmVarDecl *PVD) : K(K), Root(PVD) {}
-  AccessPath(Kind K, const CXXMethodDecl *MD) : K(K), Root(MD) {}
+  AccessPath(Kind K, const ParmVarDecl *PVD)
+      : K(K), Root(reinterpret_cast<uintptr_t>(PVD)) {}
+  AccessPath(Kind K, const CXXMethodDecl *MD)
+      : K(K), Root(reinterpret_cast<uintptr_t>(MD)) {}
 };
 
 /// Represents lending a storage location.

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
@@ -69,26 +69,24 @@ public:
   Kind getKind() const { return K; }
 
   const clang::ValueDecl *getAsValueDecl() const {
-    return K == Kind::ValueDecl ? dyn_cast<clang::ValueDecl>(
-                                      Root.dyn_cast<const clang::Decl *>())
-                                : nullptr;
+    return K == Kind::ValueDecl
+               ? cast<const clang::ValueDecl>(cast<const clang::Decl *>(Root))
+               : nullptr;
   }
   const clang::MaterializeTemporaryExpr *getAsMaterializeTemporaryExpr() const {
     return K == Kind::MaterializeTemporary
-               ? dyn_cast<clang::MaterializeTemporaryExpr>(
-                     Root.dyn_cast<const clang::Expr *>())
+               ? cast<const MaterializeTemporaryExpr>(
+                     cast<const clang::Expr *>(Root))
                : nullptr;
   }
   const ParmVarDecl *getAsPlaceholderParam() const {
     return K == Kind::PlaceholderParam
-               ? dyn_cast<clang::ParmVarDecl>(
-                     Root.dyn_cast<const clang::Decl *>())
+               ? cast<const ParmVarDecl>(cast<const clang::Decl *>(Root))
                : nullptr;
   }
   const CXXMethodDecl *getAsPlaceholderThis() const {
     return K == Kind::PlaceholderThis
-               ? dyn_cast<clang::CXXMethodDecl>(
-                     Root.dyn_cast<const clang::Decl *>())
+               ? cast<const CXXMethodDecl>(cast<const clang::Decl *>(Root))
                : nullptr;
   }
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
@@ -69,14 +69,14 @@ public:
   Kind getKind() const { return K; }
 
   const clang::ValueDecl *getAsValueDecl() const {
-    return K == Kind::ValueDecl
-               ? dyn_cast<clang::ValueDecl>(Root.dyn_cast<const clang::Decl *>())
-               : nullptr;
+    return K == Kind::ValueDecl ? dyn_cast<clang::ValueDecl>(
+                                      Root.dyn_cast<const clang::Decl *>())
+                                : nullptr;
   }
   const clang::MaterializeTemporaryExpr *getAsMaterializeTemporaryExpr() const {
     return K == Kind::MaterializeTemporary
                ? dyn_cast<clang::MaterializeTemporaryExpr>(
-                      Root.dyn_cast<const clang::Expr *>())
+                     Root.dyn_cast<const clang::Expr *>())
                : nullptr;
   }
   const ParmVarDecl *getAsPlaceholderParam() const {
@@ -88,7 +88,7 @@ public:
   const CXXMethodDecl *getAsPlaceholderThis() const {
     return K == Kind::PlaceholderThis
                ? dyn_cast<clang::CXXMethodDecl>(
-                      Root.dyn_cast<const clang::Decl *>())
+                     Root.dyn_cast<const clang::Decl *>())
                : nullptr;
   }
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
@@ -52,8 +52,8 @@ public:
 
 private:
   Kind K;
-  const llvm::PointerUnion<const clang::ValueDecl *,
-                           const clang::MaterializeTemporaryExpr *,
+  const llvm::PointerUnion<const clang::MaterializeTemporaryExpr *,
+                           const CXXNewExpr *, const clang::ValueDecl *,
                            const ParmVarDecl *, const CXXMethodDecl *>
       Root;
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
@@ -52,13 +52,12 @@ public:
 
 private:
   Kind K;
-  const uintptr_t Root;
+  llvm::PointerUnion<const Expr *, const Decl *> Root;
 
 public:
-  AccessPath(const clang::ValueDecl *D)
-      : K(Kind::ValueDecl), Root(reinterpret_cast<uintptr_t>(D)) {}
+  AccessPath(const clang::ValueDecl *D) : K(Kind::ValueDecl), Root(D) {}
   AccessPath(const clang::MaterializeTemporaryExpr *MTE)
-      : K(Kind::MaterializeTemporary), Root(reinterpret_cast<uintptr_t>(MTE)) {}
+      : K(Kind::MaterializeTemporary), Root(MTE) {}
   static AccessPath Placeholder(const ParmVarDecl *PVD) {
     return AccessPath(Kind::PlaceholderParam, PVD);
   }
@@ -71,22 +70,24 @@ public:
 
   const clang::ValueDecl *getAsValueDecl() const {
     return K == Kind::ValueDecl
-               ? reinterpret_cast<const clang::ValueDecl *>(Root)
+               ? cast<clang::ValueDecl>(Root.dyn_cast<const clang::Decl *>())
                : nullptr;
   }
   const clang::MaterializeTemporaryExpr *getAsMaterializeTemporaryExpr() const {
     return K == Kind::MaterializeTemporary
-               ? reinterpret_cast<const clang::MaterializeTemporaryExpr *>(Root)
+               ? cast<clang::MaterializeTemporaryExpr>(
+                     Root.dyn_cast<const clang::Expr *>())
                : nullptr;
   }
   const ParmVarDecl *getAsPlaceholderParam() const {
     return K == Kind::PlaceholderParam
-               ? reinterpret_cast<const ParmVarDecl *>(Root)
+               ? cast<clang::ParmVarDecl>(Root.dyn_cast<const clang::Decl *>())
                : nullptr;
   }
   const CXXMethodDecl *getAsPlaceholderThis() const {
     return K == Kind::PlaceholderThis
-               ? reinterpret_cast<const CXXMethodDecl *>(Root)
+               ? cast<clang::CXXMethodDecl>(
+                     Root.dyn_cast<const clang::Decl *>())
                : nullptr;
   }
 
@@ -97,10 +98,8 @@ public:
   void dump(llvm::raw_ostream &OS) const;
 
 private:
-  AccessPath(Kind K, const ParmVarDecl *PVD)
-      : K(K), Root(reinterpret_cast<uintptr_t>(PVD)) {}
-  AccessPath(Kind K, const CXXMethodDecl *MD)
-      : K(K), Root(reinterpret_cast<uintptr_t>(MD)) {}
+  AccessPath(Kind K, const ParmVarDecl *PVD) : K(K), Root(PVD) {}
+  AccessPath(Kind K, const CXXMethodDecl *MD) : K(K), Root(MD) {}
 };
 
 /// Represents lending a storage location.

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
@@ -70,24 +70,25 @@ public:
 
   const clang::ValueDecl *getAsValueDecl() const {
     return K == Kind::ValueDecl
-               ? cast<clang::ValueDecl>(Root.dyn_cast<const clang::Decl *>())
+               ? dyn_cast<clang::ValueDecl>(Root.dyn_cast<const clang::Decl *>())
                : nullptr;
   }
   const clang::MaterializeTemporaryExpr *getAsMaterializeTemporaryExpr() const {
     return K == Kind::MaterializeTemporary
-               ? cast<clang::MaterializeTemporaryExpr>(
-                     Root.dyn_cast<const clang::Expr *>())
+               ? dyn_cast<clang::MaterializeTemporaryExpr>(
+                      Root.dyn_cast<const clang::Expr *>())
                : nullptr;
   }
   const ParmVarDecl *getAsPlaceholderParam() const {
     return K == Kind::PlaceholderParam
-               ? cast<clang::ParmVarDecl>(Root.dyn_cast<const clang::Decl *>())
+               ? dyn_cast<clang::ParmVarDecl>(
+                     Root.dyn_cast<const clang::Decl *>())
                : nullptr;
   }
   const CXXMethodDecl *getAsPlaceholderThis() const {
     return K == Kind::PlaceholderThis
-               ? cast<clang::CXXMethodDecl>(
-                     Root.dyn_cast<const clang::Decl *>())
+               ? dyn_cast<clang::CXXMethodDecl>(
+                      Root.dyn_cast<const clang::Decl *>())
                : nullptr;
   }
 


### PR DESCRIPTION
Stores generic `Expr*` and `Decl*` in `AccessPath`'s `PointerUnion` to avoid problems where we do not have enough available low bits when more template parameters are added.