### PR TITLE
[lldb-dap] Make Breakpoint ids unique.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
@@ -108,7 +108,8 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
         self.build_and_launch(program)
         source = "main.cpp"
         first_loop_break_line = line_number(source, "// first loop breakpoint")
-        self.set_source_breakpoints(source, [first_loop_break_line])
+        first_bp_ids = self.set_source_breakpoints(source, [first_loop_break_line])
+        self.assertEqual(len(first_bp_ids), 1)
         self.continue_to_next_stop()
         self.dap_server.get_local_variables()
         locals_ref = self.get_locals_scope_reference()
@@ -149,6 +150,14 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(arr_2["value"], "42")
         self.assertEqual(i_val, "2")
         self.dap_server.request_setDataBreakpoint([])
+
+        # Verify breakpoints are unique.
+        all_breakpoints = set(
+            [first_bp_ids[0], breakpoints[0]["id"], breakpoints[1]["id"]]
+        )
+        self.assertEqual(
+            len(all_breakpoints), 3, f"found breakpoints {all_breakpoints}"
+        )
 
         # Test hit condition
         second_loop_break_line = line_number(source, "// second loop breakpoint")

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -215,7 +215,8 @@ static void SendStoppedEvent(DAP &dap, lldb::SBThread &thread, bool on_entry,
     } break;
     case lldb::eStopReasonWatchpoint: {
       body.reason = protocol::eStoppedReasonDataBreakpoint;
-      lldb::break_id_t bp_id = thread.GetStopReasonDataAtIndex(0);
+      lldb::break_id_t bp_id =
+          ApplyWatchpointMask(thread.GetStopReasonDataAtIndex(0));
       body.hitBreakpointIds.push_back(bp_id);
       body.text = llvm::formatv("data breakpoint {0}", bp_id).str();
     } break;

--- a/lldb/tools/lldb-dap/ProtocolUtils.h
+++ b/lldb/tools/lldb-dap/ProtocolUtils.h
@@ -17,6 +17,7 @@
 #include "Protocol/ProtocolTypes.h"
 
 #include "lldb/API/SBAddress.h"
+#include "lldb/lldb-types.h"
 
 namespace lldb_dap {
 
@@ -106,6 +107,14 @@ CreateExceptionBreakpointFilter(const ExceptionBreakpoint &bp);
 ///     A string representing the size in a readable format (e.g., "1 KB",
 ///     "2 MB").
 std::string ConvertDebugInfoSizeToString(uint64_t debug_size);
+
+/// Add a mask to the breakpoint's id, this is to avoid id collision
+/// as internally, lldb breakpoint's id and watchpoint's id starts from one.
+/// Similar to the variables_reference we start from 8'000'000.
+inline lldb::break_id_t ApplyWatchpointMask(lldb::break_id_t breakpoint_id) {
+  constexpr lldb::break_id_t watchpoint_mask = 8'000'000;
+  return watchpoint_mask + breakpoint_id;
+}
 
 } // namespace lldb_dap
 

--- a/lldb/tools/lldb-dap/Watchpoint.cpp
+++ b/lldb/tools/lldb-dap/Watchpoint.cpp
@@ -9,6 +9,7 @@
 #include "Watchpoint.h"
 #include "DAP.h"
 #include "Protocol/ProtocolTypes.h"
+#include "ProtocolUtils.h"
 #include "lldb/API/SBTarget.h"
 #include "lldb/lldb-enumerations.h"
 #include "llvm/ADT/StringExtras.h"
@@ -45,7 +46,7 @@ protocol::Breakpoint Watchpoint::ToProtocolBreakpoint() {
       breakpoint.message = m_error.GetCString();
   } else {
     breakpoint.verified = true;
-    breakpoint.id = m_wp.GetID();
+    breakpoint.id = ApplyWatchpointMask(m_wp.GetID());
   }
 
   return breakpoint;


### PR DESCRIPTION
In normal lldb you can have a breakpoint and watchpoint with the same id. This is not the case in DAP protocol as Breakpoint id is unique for each session.

So we end up waiting for the wrong breakpoint id that never gets hit.