### PR TITLE
[lldb] Remove trailing newlines from AppendErrorWithFormat calls (part 3)

### DIFF
--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -471,9 +471,8 @@ protected:
     FileSpec file_spec;
     if (!DumpLinesInSymbolContexts(result.GetOutputStream(), sc_list,
                                    module_list, file_spec)) {
-      result.AppendErrorWithFormat("No modules contain load address 0x%" PRIx64
-                                   ".",
-                                   m_options.address);
+      result.AppendErrorWithFormat(
+          "No modules contain load address 0x%" PRIx64 ".", m_options.address);
       return false;
     }
     return true;

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -403,7 +403,7 @@ protected:
       }
     }
     if (num_matches == 0) {
-      result.AppendErrorWithFormat("Could not find function named \'%s\'.\n",
+      result.AppendErrorWithFormat("Could not find function named \'%s\'.",
                                    m_options.symbol_name.c_str());
       return false;
     }
@@ -464,7 +464,7 @@ protected:
     StreamString error_strm;
     if (!GetSymbolContextsForAddress(target.GetImages(), m_options.address,
                                      sc_list, error_strm)) {
-      result.AppendErrorWithFormat("%s.\n", error_strm.GetData());
+      result.AppendErrorWithFormat("%s.", error_strm.GetData());
       return false;
     }
     ModuleList module_list;
@@ -472,7 +472,7 @@ protected:
     if (!DumpLinesInSymbolContexts(result.GetOutputStream(), sc_list,
                                    module_list, file_spec)) {
       result.AppendErrorWithFormat("No modules contain load address 0x%" PRIx64
-                                   ".\n",
+                                   ".",
                                    m_options.address);
       return false;
     }
@@ -835,9 +835,8 @@ protected:
           start_file, line_no, column, 0, m_options.num_lines, "",
           &result.GetOutputStream(), GetBreakpointLocations());
     } else {
-      result.AppendErrorWithFormat(
-          "Could not find function info for: \"%s\".\n",
-          m_options.symbol_name.c_str());
+      result.AppendErrorWithFormat("Could not find function info for: \"%s\".",
+                                   m_options.symbol_name.c_str());
     }
     return 0;
   }
@@ -927,7 +926,7 @@ protected:
       }
 
       if (sc_list.GetSize() == 0) {
-        result.AppendErrorWithFormat("Could not find function named: \"%s\".\n",
+        result.AppendErrorWithFormat("Could not find function named: \"%s\".",
                                      m_options.symbol_name.c_str());
         return;
       }
@@ -975,7 +974,7 @@ protected:
         if (sc_list.GetSize() == 0) {
           result.AppendErrorWithFormat(
               "no modules have source information for file address 0x%" PRIx64
-              ".\n",
+              ".",
               m_options.address);
           return;
         }
@@ -996,7 +995,7 @@ protected:
                            Address::DumpStyleModuleWithFileAddress);
               result.AppendErrorWithFormat("address resolves to %s, but there "
                                            "is no line table information "
-                                           "available for this address.\n",
+                                           "available for this address.",
                                            error_strm.GetData());
               return;
             }
@@ -1005,7 +1004,7 @@ protected:
 
         if (sc_list.GetSize() == 0) {
           result.AppendErrorWithFormat(
-              "no modules contain load address 0x%" PRIx64 ".\n",
+              "no modules contain load address 0x%" PRIx64 ".",
               m_options.address);
           return;
         }
@@ -1140,7 +1139,7 @@ protected:
       }
 
       if (num_matches == 0) {
-        result.AppendErrorWithFormat("Could not find source file \"%s\".\n",
+        result.AppendErrorWithFormat("Could not find source file \"%s\".",
                                      m_options.file_name.c_str());
         return;
       }
@@ -1161,7 +1160,7 @@ protected:
         }
         if (got_multiple) {
           result.AppendErrorWithFormat(
-              "Multiple source files found matching: \"%s.\"\n",
+              "Multiple source files found matching: \"%s.\"",
               m_options.file_name.c_str());
           return;
         }
@@ -1198,7 +1197,7 @@ protected:
 
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
-          result.AppendErrorWithFormat("No comp unit found for: \"%s.\"\n",
+          result.AppendErrorWithFormat("No comp unit found for: \"%s.\"",
                                        m_options.file_name.c_str());
         }
       }

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -450,7 +450,7 @@ protected:
       }
     } else {
       result.AppendErrorWithFormat("'%s' takes exactly one executable path "
-                                   "argument, or use the --core option.\n",
+                                   "argument, or use the --core option.",
                                    m_cmd_name.c_str());
     }
   }
@@ -521,11 +521,11 @@ protected:
         } else {
           if (num_targets > 0) {
             result.AppendErrorWithFormat(
-                "index %u is out of range, valid target indexes are 0 - %u\n",
+                "index %u is out of range, valid target indexes are 0 - %u",
                 target_idx, num_targets - 1);
           } else {
             result.AppendErrorWithFormat(
-                "index %u is out of range since there are no active targets\n",
+                "index %u is out of range since there are no active targets",
                 target_idx);
           }
         }
@@ -547,7 +547,7 @@ protected:
           DumpTargetList(target_list, show_stopped_process_status, strm);
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
-          result.AppendErrorWithFormat("invalid index string value '%s'\n",
+          result.AppendErrorWithFormat("invalid index string value '%s'",
                                        target_identifier);
         }
       }
@@ -609,7 +609,7 @@ protected:
       for (auto &entry : args.entries()) {
         uint32_t target_idx;
         if (entry.ref().getAsInteger(0, target_idx)) {
-          result.AppendErrorWithFormat("invalid target index '%s'\n",
+          result.AppendErrorWithFormat("invalid target index '%s'",
                                        entry.c_str());
           return;
         }
@@ -622,11 +622,11 @@ protected:
         }
         if (num_targets > 1)
           result.AppendErrorWithFormat("target index %u is out of range, valid "
-                                       "target indexes are 0 - %u\n",
+                                       "target indexes are 0 - %u",
                                        target_idx, num_targets - 1);
         else
           result.AppendErrorWithFormat(
-              "target index %u is out of range, the only valid index is 0\n",
+              "target index %u is out of range, the only valid index is 0",
               target_idx);
 
         return;
@@ -634,7 +634,7 @@ protected:
     } else {
       target_sp = target_list.GetSelectedTarget();
       if (!target_sp) {
-        result.AppendErrorWithFormat("no target is currently selected\n");
+        result.AppendErrorWithFormat("no target is currently selected");
         return;
       }
       delete_target_list.push_back(target_sp);
@@ -925,9 +925,8 @@ protected:
                   "no global variables in current compile unit: {0}\n",
                   comp_unit->GetPrimaryFile());
             else
-              result.AppendErrorWithFormat(
-                  "no debug information for frame %u\n",
-                  frame->GetFrameIndex());
+              result.AppendErrorWithFormat("no debug information for frame %u",
+                                           frame->GetFrameIndex());
           } else
             result.AppendError("'target variable' takes one or more global "
                                "variable names as arguments\n");
@@ -955,7 +954,7 @@ protected:
             } else {
               // Didn't find matching shlib/module in target...
               result.AppendErrorWithFormat(
-                  "target doesn't contain the specified shared library: %s\n",
+                  "target doesn't contain the specified shared library: %s",
                   module_file.GetPath().c_str());
             }
           }
@@ -1163,7 +1162,7 @@ protected:
 
       if (!llvm::to_integer(command.GetArgumentAtIndex(0), insert_idx)) {
         result.AppendErrorWithFormat(
-            "<index> parameter is not an integer: '%s'.\n",
+            "<index> parameter is not an integer: '%s'.",
             command.GetArgumentAtIndex(0));
         return;
       }
@@ -2829,11 +2828,11 @@ protected:
           std::string resolved_path = file_spec.GetPath();
           if (resolved_path != entry.ref()) {
             result.AppendErrorWithFormat(
-                "invalid module path '%s' with resolved path '%s'\n",
+                "invalid module path '%s' with resolved path '%s'",
                 entry.ref().str().c_str(), resolved_path.c_str());
             break;
           }
-          result.AppendErrorWithFormat("invalid module path '%s'\n",
+          result.AppendErrorWithFormat("invalid module path '%s'",
                                        entry.c_str());
           break;
         }
@@ -2919,11 +2918,11 @@ protected:
             module_list.GetModuleAtIndex(0)->GetFileSpec();
       } else if (num_matches > 1) {
         search_using_module_spec = false;
-        result.AppendErrorWithFormat(
-            "more than 1 module matched by name '%s'\n", arg_cstr);
+        result.AppendErrorWithFormat("more than 1 module matched by name '%s'",
+                                     arg_cstr);
       } else {
         search_using_module_spec = false;
-        result.AppendErrorWithFormat("no object file for module '%s'\n",
+        result.AppendErrorWithFormat("no object file for module '%s'",
                                      arg_cstr);
       }
     }
@@ -2981,7 +2980,7 @@ protected:
                         if (section_sp->IsThreadSpecific()) {
                           result.AppendErrorWithFormat(
                               "thread specific sections are not yet "
-                              "supported (section '%s')\n",
+                              "supported (section '%s')",
                               sect_name);
                           break;
                         } else {
@@ -2995,13 +2994,13 @@ protected:
                       } else {
                         result.AppendErrorWithFormat("no section found that "
                                                      "matches the section "
-                                                     "name '%s'\n",
+                                                     "name '%s'",
                                                      sect_name);
                         break;
                       }
                     } else {
                       result.AppendErrorWithFormat(
-                          "invalid load address string '%s'\n", load_addr_cstr);
+                          "invalid load address string '%s'", load_addr_cstr);
                       break;
                     }
                   } else {
@@ -3051,26 +3050,26 @@ protected:
                   addr_t file_entry_addr = file_entry.GetLoadAddress(&target);
                   if (!reg_context->SetPC(file_entry_addr)) {
                     result.AppendErrorWithFormat("failed to set PC value to "
-                                                 "0x%" PRIx64 "\n",
+                                                 "0x%" PRIx64,
                                                  file_entry_addr);
                   }
                 }
               }
             } else {
               module->GetFileSpec().GetPath(path, sizeof(path));
-              result.AppendErrorWithFormat("no sections in object file '%s'\n",
+              result.AppendErrorWithFormat("no sections in object file '%s'",
                                            path);
             }
           } else {
             module->GetFileSpec().GetPath(path, sizeof(path));
-            result.AppendErrorWithFormat("no object file for module '%s'\n",
+            result.AppendErrorWithFormat("no object file for module '%s'",
                                          path);
           }
         } else {
           FileSpec *module_spec_file = module_spec.GetFileSpecPtr();
           if (module_spec_file) {
             module_spec_file->GetPath(path, sizeof(path));
-            result.AppendErrorWithFormat("invalid module '%s'.\n", path);
+            result.AppendErrorWithFormat("invalid module '%s'.", path);
           } else
             result.AppendError("no module spec");
         }
@@ -3086,8 +3085,8 @@ protected:
           uuid_str = module_spec.GetUUID().GetAsString();
         if (num_matches > 1) {
           result.AppendErrorWithFormat(
-              "multiple modules match%s%s%s%s:\n", path[0] ? " file=" : "",
-              path, !uuid_str.empty() ? " uuid=" : "", uuid_str.c_str());
+              "multiple modules match%s%s%s%s:", path[0] ? " file=" : "", path,
+              !uuid_str.empty() ? " uuid=" : "", uuid_str.c_str());
           for (size_t i = 0; i < num_matches; ++i) {
             if (matching_modules.GetModulePointerAtIndex(i)
                     ->GetFileSpec()
@@ -3096,7 +3095,7 @@ protected:
           }
         } else {
           result.AppendErrorWithFormat(
-              "no modules were found  that match%s%s%s%s.\n",
+              "no modules were found  that match%s%s%s%s.",
               path[0] ? " file=" : "", path, !uuid_str.empty() ? " uuid=" : "",
               uuid_str.c_str());
         }
@@ -4337,7 +4336,7 @@ protected:
     if (matching_modules.GetSize() > 1) {
       result.AppendErrorWithFormat("multiple modules match symbol file '%s', "
                                    "use the --uuid option to resolve the "
-                                   "ambiguity.\n",
+                                   "ambiguity.",
                                    symfile_path);
       return false;
     }
@@ -4390,8 +4389,8 @@ protected:
       ss_symfile_uuid << ')';
     }
     result.AppendErrorWithFormat(
-        "symbol file '%s'%s does not match any existing module%s\n",
-        symfile_path, ss_symfile_uuid.GetData(),
+        "symbol file '%s'%s does not match any existing module%s", symfile_path,
+        ss_symfile_uuid.GetData(),
         !llvm::sys::fs::is_regular_file(symbol_fspec.GetPath())
             ? "\n       please specify the full path to the symbol file"
             : "");
@@ -4622,11 +4621,11 @@ protected:
                   module_spec.GetSymbolFileSpec().GetPath();
               if (resolved_symfile_path != entry.ref()) {
                 result.AppendErrorWithFormat(
-                    "invalid module path '%s' with resolved path '%s'\n",
+                    "invalid module path '%s' with resolved path '%s'",
                     entry.c_str(), resolved_symfile_path.c_str());
                 break;
               }
-              result.AppendErrorWithFormat("invalid module path '%s'\n",
+              result.AppendErrorWithFormat("invalid module path '%s'",
                                            entry.c_str());
               break;
             }
@@ -5119,12 +5118,12 @@ protected:
       for (size_t i = 0; i < num_args; i++) {
         lldb::user_id_t user_id;
         if (!llvm::to_integer(command.GetArgumentAtIndex(i), user_id)) {
-          result.AppendErrorWithFormat("invalid stop hook id: \"%s\".\n",
+          result.AppendErrorWithFormat("invalid stop hook id: \"%s\".",
                                        command.GetArgumentAtIndex(i));
           return;
         }
         if (!target.RemoveStopHookByID(user_id)) {
-          result.AppendErrorWithFormat("unknown stop hook id: \"%s\".\n",
+          result.AppendErrorWithFormat("unknown stop hook id: \"%s\".",
                                        command.GetArgumentAtIndex(i));
           return;
         }
@@ -5170,13 +5169,13 @@ protected:
       for (size_t i = 0; i < num_args; i++) {
         lldb::user_id_t user_id;
         if (!llvm::to_integer(command.GetArgumentAtIndex(i), user_id)) {
-          result.AppendErrorWithFormat("invalid stop hook id: \"%s\".\n",
+          result.AppendErrorWithFormat("invalid stop hook id: \"%s\".",
                                        command.GetArgumentAtIndex(i));
           return;
         }
         success = target.SetStopHookActiveStateByID(user_id, m_enable);
         if (!success) {
-          result.AppendErrorWithFormat("unknown stop hook id: \"%s\".\n",
+          result.AppendErrorWithFormat("unknown stop hook id: \"%s\".",
                                        command.GetArgumentAtIndex(i));
           return;
         }
@@ -5515,7 +5514,7 @@ protected:
 
       if (!target->RemoveScriptedFrameProviderDescriptor(provider_id)) {
         result.AppendErrorWithFormat(
-            "no frame provider named '%u' found in target\n", provider_id);
+            "no frame provider named '%u' found in target", provider_id);
         return;
       }
       removed_provider_ids.push_back(provider_id);

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -302,7 +302,7 @@ protected:
         m_exe_ctx.GetProcessPtr()->GetThreadList().FindThreadByID(tid);
     if (!thread_sp) {
       result.AppendErrorWithFormat(
-          "thread disappeared while computing backtraces: 0x%" PRIx64 "\n",
+          "thread disappeared while computing backtraces: 0x%" PRIx64,
           tid);
       return false;
     }
@@ -319,7 +319,7 @@ protected:
       if (thread->IsAnyProviderActive()) {
         result.AppendErrorWithFormat(
             "cannot use '--provider' option while a scripted frame provider is "
-            "being constructed on this thread\n");
+            "being constructed on this thread");
         return false;
       }
 
@@ -407,7 +407,7 @@ protected:
       }
 
       if (first_provider) {
-        result.AppendErrorWithFormat("no provider found in range %u-%u\n",
+        result.AppendErrorWithFormat("no provider found in range %u-%u",
                                      m_options.m_provider_start_id,
                                      m_options.m_provider_end_id);
         return false;
@@ -423,7 +423,7 @@ protected:
                            num_frames_with_source, stop_format,
                            !m_options.m_filtered_backtrace, only_stacks)) {
       result.AppendErrorWithFormat(
-          "error displaying backtrace for thread: \"0x%4.4x\"\n",
+          "error displaying backtrace for thread: \"0x%4.4x\"",
           thread->GetIndexID());
       return false;
     }
@@ -614,7 +614,7 @@ protected:
       uint32_t step_thread_idx;
 
       if (!llvm::to_integer(thread_idx_cstr, step_thread_idx)) {
-        result.AppendErrorWithFormat("invalid thread index '%s'.\n",
+        result.AppendErrorWithFormat("invalid thread index '%s'.",
                                      thread_idx_cstr);
         return;
       }
@@ -622,7 +622,7 @@ protected:
           process->GetThreadList().FindThreadByIndexID(step_thread_idx).get();
       if (thread == nullptr) {
         result.AppendErrorWithFormat(
-            "Thread index %u is out of range (valid values are 0 - %u).\n",
+            "Thread index %u is out of range (valid values are 0 - %u).",
             step_thread_idx, num_threads);
         return;
       }
@@ -858,7 +858,7 @@ public:
           uint32_t thread_idx;
           if (entry.ref().getAsInteger(0, thread_idx)) {
             result.AppendErrorWithFormat(
-                "invalid thread index argument: \"%s\".\n", entry.c_str());
+                "invalid thread index argument: \"%s\".", entry.c_str());
             return;
           }
           Thread *thread =
@@ -867,7 +867,7 @@ public:
           if (thread) {
             resume_threads.push_back(thread);
           } else {
-            result.AppendErrorWithFormat("invalid thread index %u.\n",
+            result.AppendErrorWithFormat("invalid thread index %u.",
                                          thread_idx);
             return;
           }
@@ -954,12 +954,12 @@ public:
           result.SetStatus(eReturnStatusSuccessContinuingNoResult);
         }
       } else {
-        result.AppendErrorWithFormat("Failed to resume process: %s\n",
+        result.AppendErrorWithFormat("Failed to resume process: %s",
                                      error.AsCString());
       }
     } else {
       result.AppendErrorWithFormat(
-          "Process cannot be continued from its current state (%s).\n",
+          "Process cannot be continued from its current state (%s).",
           StateAsCString(state));
     }
   }
@@ -1083,7 +1083,7 @@ protected:
         for (size_t i = 0; i < num_args; i++) {
           uint32_t line_number;
           if (!llvm::to_integer(command.GetArgumentAtIndex(i), line_number)) {
-            result.AppendErrorWithFormat("invalid line number: '%s'.\n",
+            result.AppendErrorWithFormat("invalid line number: '%s'.",
                                          command.GetArgumentAtIndex(i));
             return;
           } else
@@ -1106,7 +1106,7 @@ protected:
       if (thread == nullptr) {
         const uint32_t num_threads = process->GetThreadList().GetSize();
         result.AppendErrorWithFormat(
-            "Thread index %u is out of range (valid values are 0 - %u).\n",
+            "Thread index %u is out of range (valid values are 0 - %u).",
             m_options.m_thread_idx, num_threads);
         return;
       }
@@ -1117,7 +1117,7 @@ protected:
           thread->GetStackFrameAtIndex(m_options.m_frame_idx).get();
       if (frame == nullptr) {
         result.AppendErrorWithFormat(
-            "Frame index %u is out of range for thread id %" PRIu64 ".\n",
+            "Frame index %u is out of range for thread id %" PRIu64 ".",
             m_options.m_frame_idx, thread->GetID());
         return;
       }
@@ -1135,7 +1135,7 @@ protected:
 
         if (line_table == nullptr) {
           result.AppendErrorWithFormat("Failed to resolve the line table for "
-                                       "frame %u of thread id %" PRIu64 ".\n",
+                                       "frame %u of thread id %" PRIu64 ".",
                                        m_options.m_frame_idx, thread->GetID());
           return;
         }
@@ -1200,10 +1200,10 @@ protected:
         if (address_list.empty()) {
           if (found_something)
             result.AppendErrorWithFormat(
-                "Until target outside of the current function.\n");
+                "Until target outside of the current function.");
           else
             result.AppendErrorWithFormat(
-                "No line entries matching until target.\n");
+                "No line entries matching until target.");
 
           return;
         }
@@ -1225,14 +1225,14 @@ protected:
         }
       } else {
         result.AppendErrorWithFormat("Frame index %u of thread id %" PRIu64
-                                     " has no debug information.\n",
+                                     " has no debug information.",
                                      m_options.m_frame_idx, thread->GetID());
         return;
       }
 
       if (!process->GetThreadList().SetSelectedThreadByID(thread->GetID())) {
         result.AppendErrorWithFormat(
-            "Failed to set the selected thread to thread id %" PRIu64 ".\n",
+            "Failed to set the selected thread to thread id %" PRIu64 ".",
             thread->GetID());
         return;
       }
@@ -1259,7 +1259,7 @@ protected:
           result.SetStatus(eReturnStatusSuccessContinuingNoResult);
         }
       } else {
-        result.AppendErrorWithFormat("Failed to resume process: %s.\n",
+        result.AppendErrorWithFormat("Failed to resume process: %s.",
                                      error.AsCString());
       }
     }
@@ -1363,13 +1363,13 @@ protected:
                command.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat(
           "'%s' takes exactly one thread index argument, or a thread ID "
-          "option:\nUsage: %s\n",
+          "option:\nUsage: %s",
           m_cmd_name.c_str(), m_cmd_syntax.c_str());
       return;
     } else if (m_options.m_thread_id != LLDB_INVALID_THREAD_ID &&
                command.GetArgumentCount() != 0) {
       result.AppendErrorWithFormat("'%s' cannot take both a thread ID option "
-                                   "and a thread index argument:\nUsage: %s\n",
+                                   "and a thread index argument:\nUsage: %s",
                                    m_cmd_name.c_str(), m_cmd_syntax.c_str());
       return;
     }
@@ -1384,7 +1384,7 @@ protected:
       }
       new_thread = process->GetThreadList().FindThreadByIndexID(index_id).get();
       if (new_thread == nullptr) {
-        result.AppendErrorWithFormat("Invalid thread index #%s.\n",
+        result.AppendErrorWithFormat("Invalid thread index #%s.",
                                      command.GetArgumentAtIndex(0));
         return;
       }
@@ -1392,7 +1392,7 @@ protected:
       new_thread =
           process->GetThreadList().FindThreadByID(m_options.m_thread_id).get();
       if (new_thread == nullptr) {
-        result.AppendErrorWithFormat("Invalid thread ID %" PRIu64 ".\n",
+        result.AppendErrorWithFormat("Invalid thread ID %" PRIu64 ".",
                                      m_options.m_thread_id);
         return;
       }
@@ -1516,7 +1516,7 @@ public:
     ThreadSP thread_sp =
         m_exe_ctx.GetProcessPtr()->GetThreadList().FindThreadByID(tid);
     if (!thread_sp) {
-      result.AppendErrorWithFormat("thread no longer exists: 0x%" PRIx64 "\n",
+      result.AppendErrorWithFormat("thread no longer exists: 0x%" PRIx64,
                                    tid);
       return false;
     }
@@ -1529,7 +1529,7 @@ public:
     if (!thread->GetDescription(strm, eDescriptionLevelFull,
                                 m_options.m_json_thread,
                                 m_options.m_json_stopinfo)) {
-      result.AppendErrorWithFormat("error displaying info for thread: \"%d\"\n",
+      result.AppendErrorWithFormat("error displaying info for thread: \"%d\"",
                                    thread->GetIndexID());
       return false;
     }
@@ -1566,7 +1566,7 @@ public:
     ThreadSP thread_sp =
         m_exe_ctx.GetProcessPtr()->GetThreadList().FindThreadByID(tid);
     if (!thread_sp) {
-      result.AppendErrorWithFormat("thread no longer exists: 0x%" PRIx64 "\n",
+      result.AppendErrorWithFormat("thread no longer exists: 0x%" PRIx64,
                                    tid);
       return false;
     }
@@ -1618,14 +1618,14 @@ public:
     ThreadSP thread_sp =
         m_exe_ctx.GetProcessPtr()->GetThreadList().FindThreadByID(tid);
     if (!thread_sp) {
-      result.AppendErrorWithFormat("thread no longer exists: 0x%" PRIx64 "\n",
+      result.AppendErrorWithFormat("thread no longer exists: 0x%" PRIx64,
                                    tid);
       return false;
     }
 
     Stream &strm = result.GetOutputStream();
     if (!thread_sp->GetDescription(strm, eDescriptionLevelFull, false, false)) {
-      result.AppendErrorWithFormat("error displaying info for thread: \"%d\"\n",
+      result.AppendErrorWithFormat("error displaying info for thread: \"%d\"",
                                    thread_sp->GetIndexID());
       return false;
     }
@@ -2164,12 +2164,12 @@ public:
     for (size_t i = 0; i < num_args; i++) {
       lldb::tid_t tid;
       if (!llvm::to_integer(args.GetArgumentAtIndex(i), tid)) {
-        result.AppendErrorWithFormat("invalid thread specification: \"%s\"\n",
+        result.AppendErrorWithFormat("invalid thread specification: \"%s\"",
                                      args.GetArgumentAtIndex(i));
         return;
       }
       if (!process->PruneThreadPlansForTID(tid)) {
-        result.AppendErrorWithFormat("Could not find unreported tid: \"%s\"\n",
+        result.AppendErrorWithFormat("Could not find unreported tid: \"%s\"",
                                      args.GetArgumentAtIndex(i));
         return;
       }
@@ -2282,13 +2282,13 @@ static ThreadSP GetSingleThreadFromArgs(ExecutionContext &exe_ctx, Args &args,
   uint32_t thread_idx;
 
   if (!llvm::to_integer(arg, thread_idx)) {
-    result.AppendErrorWithFormat("invalid thread specification: \"%s\"\n", arg);
+    result.AppendErrorWithFormat("invalid thread specification: \"%s\"", arg);
     return nullptr;
   }
   ThreadSP thread_sp =
       exe_ctx.GetProcessRef().GetThreadList().FindThreadByIndexID(thread_idx);
   if (!thread_sp)
-    result.AppendErrorWithFormat("no thread with index: \"%s\"\n", arg);
+    result.AppendErrorWithFormat("no thread with index: \"%s\"", arg);
   return thread_sp;
 }
 

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -302,8 +302,7 @@ protected:
         m_exe_ctx.GetProcessPtr()->GetThreadList().FindThreadByID(tid);
     if (!thread_sp) {
       result.AppendErrorWithFormat(
-          "thread disappeared while computing backtraces: 0x%" PRIx64,
-          tid);
+          "thread disappeared while computing backtraces: 0x%" PRIx64, tid);
       return false;
     }
 
@@ -1516,8 +1515,7 @@ public:
     ThreadSP thread_sp =
         m_exe_ctx.GetProcessPtr()->GetThreadList().FindThreadByID(tid);
     if (!thread_sp) {
-      result.AppendErrorWithFormat("thread no longer exists: 0x%" PRIx64,
-                                   tid);
+      result.AppendErrorWithFormat("thread no longer exists: 0x%" PRIx64, tid);
       return false;
     }
 
@@ -1566,8 +1564,7 @@ public:
     ThreadSP thread_sp =
         m_exe_ctx.GetProcessPtr()->GetThreadList().FindThreadByID(tid);
     if (!thread_sp) {
-      result.AppendErrorWithFormat("thread no longer exists: 0x%" PRIx64,
-                                   tid);
+      result.AppendErrorWithFormat("thread no longer exists: 0x%" PRIx64, tid);
       return false;
     }
 
@@ -1618,8 +1615,7 @@ public:
     ThreadSP thread_sp =
         m_exe_ctx.GetProcessPtr()->GetThreadList().FindThreadByID(tid);
     if (!thread_sp) {
-      result.AppendErrorWithFormat("thread no longer exists: 0x%" PRIx64,
-                                   tid);
+      result.AppendErrorWithFormat("thread no longer exists: 0x%" PRIx64, tid);
       return false;
     }
 

--- a/lldb/source/Commands/CommandObjectThreadUtil.cpp
+++ b/lldb/source/Commands/CommandObjectThreadUtil.cpp
@@ -69,7 +69,7 @@ void CommandObjectIterateOverThreads::DoExecute(Args &command,
     for (size_t i = 0; i < num_args; i++) {
       uint32_t thread_idx;
       if (!llvm::to_integer(command.GetArgumentAtIndex(i), thread_idx)) {
-        result.AppendErrorWithFormat("invalid thread specification: \"%s\"\n",
+        result.AppendErrorWithFormat("invalid thread specification: \"%s\"",
                                      command.GetArgumentAtIndex(i));
         return;
       }
@@ -78,7 +78,7 @@ void CommandObjectIterateOverThreads::DoExecute(Args &command,
           process->GetThreadList().FindThreadByIndexID(thread_idx);
 
       if (!thread) {
-        result.AppendErrorWithFormat("no thread with index: \"%s\"\n",
+        result.AppendErrorWithFormat("no thread with index: \"%s\"",
                                      command.GetArgumentAtIndex(i));
         return;
       }
@@ -188,7 +188,7 @@ void CommandObjectMultipleThreads::DoExecute(Args &command,
     for (size_t i = 0; i < num_args; i++) {
       uint32_t thread_idx;
       if (!llvm::to_integer(command.GetArgumentAtIndex(i), thread_idx)) {
-        result.AppendErrorWithFormat("invalid thread specification: \"%s\"\n",
+        result.AppendErrorWithFormat("invalid thread specification: \"%s\"",
                                      command.GetArgumentAtIndex(i));
         return;
       }
@@ -196,7 +196,7 @@ void CommandObjectMultipleThreads::DoExecute(Args &command,
       ThreadSP thread = process.GetThreadList().FindThreadByIndexID(thread_idx);
 
       if (!thread) {
-        result.AppendErrorWithFormat("no thread with index: \"%s\"\n",
+        result.AppendErrorWithFormat("no thread with index: \"%s\"",
                                      command.GetArgumentAtIndex(i));
         return;
       }

--- a/lldb/source/Commands/CommandObjectTrace.cpp
+++ b/lldb/source/Commands/CommandObjectTrace.cpp
@@ -205,7 +205,7 @@ protected:
 
     if (!trace_or_err) {
       result.AppendErrorWithFormat(
-          "%s\n", llvm::toString(trace_or_err.takeError()).c_str());
+          "%s", llvm::toString(trace_or_err.takeError()).c_str());
       return;
     }
 
@@ -277,7 +277,7 @@ protected:
     if (error.Success()) {
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else {
-      result.AppendErrorWithFormat("%s\n", error.AsCString());
+      result.AppendErrorWithFormat("%s", error.AsCString());
     }
   }
 
@@ -367,7 +367,7 @@ protected:
     if (error.Success()) {
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else {
-      result.AppendErrorWithFormat("%s\n", error.AsCString());
+      result.AppendErrorWithFormat("%s", error.AsCString());
     }
   }
 

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -666,7 +666,7 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
-      result.AppendErrorWithFormat("%s takes one or more args.\n",
+      result.AppendErrorWithFormat("%s takes one or more args.",
                                    m_cmd_name.c_str());
       return;
     }
@@ -674,7 +674,7 @@ protected:
     const Format format = m_format_options.GetFormat();
     if (format == eFormatInvalid &&
         m_command_options.m_custom_type_name.empty()) {
-      result.AppendErrorWithFormat("%s needs a valid format.\n",
+      result.AppendErrorWithFormat("%s needs a valid format.",
                                    m_cmd_name.c_str());
       return;
     }
@@ -836,7 +836,7 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc != 1) {
-      result.AppendErrorWithFormat("%s takes 1 arg.\n", m_cmd_name.c_str());
+      result.AppendErrorWithFormat("%s takes 1 arg.", m_cmd_name.c_str());
       return;
     }
 
@@ -880,7 +880,7 @@ protected:
     if (delete_category || extra_deletion) {
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     } else {
-      result.AppendErrorWithFormat("no custom formatter for %s.\n", typeA);
+      result.AppendErrorWithFormat("no custom formatter for %s.", typeA);
     }
   }
 };
@@ -1266,7 +1266,7 @@ bool CommandObjectTypeSummaryAdd::Execute_ScriptSummary(
   const size_t argc = command.GetArgumentCount();
 
   if (argc < 1 && !m_options.m_name) {
-    result.AppendErrorWithFormat("%s takes one or more args.\n",
+    result.AppendErrorWithFormat("%s takes one or more args.",
                                  m_cmd_name.c_str());
     return false;
   }
@@ -1381,7 +1381,7 @@ bool CommandObjectTypeSummaryAdd::Execute_StringSummary(
   const size_t argc = command.GetArgumentCount();
 
   if (argc < 1 && !m_options.m_name) {
-    result.AppendErrorWithFormat("%s takes one or more args.\n",
+    result.AppendErrorWithFormat("%s takes one or more args.",
                                  m_cmd_name.c_str());
     return false;
   }
@@ -1753,7 +1753,7 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
-      result.AppendErrorWithFormat("%s takes 1 or more args.\n",
+      result.AppendErrorWithFormat("%s takes 1 or more args.",
                                    m_cmd_name.c_str());
       return;
     }
@@ -1889,7 +1889,7 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
-      result.AppendErrorWithFormat("%s takes 1 or more arg.\n",
+      result.AppendErrorWithFormat("%s takes 1 or more arg.",
                                    m_cmd_name.c_str());
       return;
     }
@@ -2046,7 +2046,7 @@ protected:
         return;
       }
     } else if (argc != 0) {
-      result.AppendErrorWithFormat("%s takes 0 or one arg.\n",
+      result.AppendErrorWithFormat("%s takes 0 or one arg.",
                                    m_cmd_name.c_str());
       return;
     }
@@ -2168,14 +2168,14 @@ bool CommandObjectTypeSynthAdd::Execute_PythonClass(
   const size_t argc = command.GetArgumentCount();
 
   if (argc < 1) {
-    result.AppendErrorWithFormat("%s takes one or more args.\n",
+    result.AppendErrorWithFormat("%s takes one or more args.",
                                  m_cmd_name.c_str());
     return false;
   }
 
   if (m_options.m_class_name.empty() && !m_options.m_input_python) {
     result.AppendErrorWithFormat("%s needs either a Python class name or -P to "
-                                 "directly input Python code.\n",
+                                 "directly input Python code.",
                                  m_cmd_name.c_str());
     return false;
   }
@@ -2477,13 +2477,13 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
-      result.AppendErrorWithFormat("%s takes one or more args.\n",
+      result.AppendErrorWithFormat("%s takes one or more args.",
                                    m_cmd_name.c_str());
       return;
     }
 
     if (m_options.m_expr_paths.empty()) {
-      result.AppendErrorWithFormat("%s needs one or more children.\n",
+      result.AppendErrorWithFormat("%s needs one or more children.",
                                    m_cmd_name.c_str());
       return;
     }

--- a/lldb/source/Commands/CommandObjectWatchpoint.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpoint.cpp
@@ -906,7 +906,7 @@ protected:
     if (!watch_sp) {
       result.AppendErrorWithFormat(
           "Watchpoint creation failed (addr=0x%" PRIx64 ", size=%" PRIu64
-          ", variable expression='%s').\n",
+          ", variable expression='%s').",
           addr, static_cast<uint64_t>(size), command.GetArgumentAtIndex(0));
       if (const char *error_message = error.AsCString(nullptr))
         result.AppendError(error_message);
@@ -1104,7 +1104,7 @@ protected:
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else {
       result.AppendErrorWithFormat("Watchpoint creation failed (addr=0x%" PRIx64
-                                   ", size=%" PRIu64 ").\n",
+                                   ", size=%" PRIu64 ").",
                                    addr, (uint64_t)size);
       if (error.AsCString(nullptr))
         result.AppendError(error.AsCString());

--- a/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
@@ -483,7 +483,7 @@ protected:
         if (wp)
           wp->ClearCallback();
       } else {
-        result.AppendErrorWithFormat("Invalid watchpoint ID: %u.\n", cur_wp_id);
+        result.AppendErrorWithFormat("Invalid watchpoint ID: %u.", cur_wp_id);
         return;
       }
     }
@@ -555,8 +555,7 @@ protected:
           }
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
-          result.AppendErrorWithFormat("Invalid watchpoint ID: %u.\n",
-                                       cur_wp_id);
+          result.AppendErrorWithFormat("Invalid watchpoint ID: %u.", cur_wp_id);
         }
       }
     }

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1883,7 +1883,7 @@ CommandObject *CommandInterpreter::BuildAliasResult(
 
       result.AppendErrorWithFormat("Not enough arguments provided; you "
                                    "need at least %d arguments to use "
-                                   "this alias.\n",
+                                   "this alias.",
                                    index);
       return nullptr;
     } else {
@@ -2520,7 +2520,7 @@ void CommandInterpreter::BuildAliasCommandArgs(CommandObject *alias_cmd_obj,
       } else if (static_cast<size_t>(index) >= cmd_args.GetArgumentCount()) {
         result.AppendErrorWithFormat("Not enough arguments provided; you "
                                      "need at least %d arguments to use "
-                                     "this alias.\n",
+                                     "this alias.",
                                      index);
         return;
       } else {
@@ -2889,7 +2889,7 @@ void CommandInterpreter::HandleCommands(
         if (idx != num_lines - 1)
           result.AppendErrorWithFormat(
               "Aborting reading of commands after command #%" PRIu64
-              ": '%s' continued the target.\n",
+              ": '%s' continued the target.",
               (uint64_t)idx + 1, cmd);
         else
           result.AppendMessageWithFormatv(
@@ -2909,7 +2909,7 @@ void CommandInterpreter::HandleCommands(
       if (idx != num_lines - 1)
         result.AppendErrorWithFormat(
             "Aborting reading of commands after command #%" PRIu64
-            ": '%s' stopped with a signal or exception.\n",
+            ": '%s' stopped with a signal or exception.",
             (uint64_t)idx + 1, cmd);
       else
         result.AppendMessageWithFormatv(
@@ -2953,7 +2953,7 @@ void CommandInterpreter::HandleCommandsFromFile(
     CommandReturnObject &result) {
   if (!FileSystem::Instance().Exists(cmd_file)) {
     result.AppendErrorWithFormat(
-        "Error reading commands from file %s - file not found.\n",
+        "Error reading commands from file %s - file not found.",
         cmd_file.GetFilename().AsCString("<Unknown>"));
     return;
   }
@@ -3818,7 +3818,7 @@ CommandInterpreter::ResolveCommandImpl(std::string &command_line,
       } else {
         // We didn't have only one match, otherwise we wouldn't get here.
         lldbassert(num_matches == 0);
-        result.AppendErrorWithFormat("'%s' is not a valid command.\n",
+        result.AppendErrorWithFormat("'%s' is not a valid command.",
                                      next_word.c_str());
       }
       if (!done)
@@ -3829,7 +3829,7 @@ CommandInterpreter::ResolveCommandImpl(std::string &command_line,
       if (!suffix.empty()) {
         result.AppendErrorWithFormat(
             "command '%s' did not recognize '%s%s%s' as valid (subcommand "
-            "might be invalid).\n",
+            "might be invalid).",
             cmd_obj->GetCommandName().str().c_str(),
             next_word.empty() ? "" : next_word.c_str(),
             next_word.empty() ? " -- " : " ", suffix.c_str());
@@ -3866,7 +3866,7 @@ CommandInterpreter::ResolveCommandImpl(std::string &command_line,
                 revised_command_line.PutCString(" --");
             } else {
               result.AppendErrorWithFormat(
-                  "the '%s' command doesn't support the --gdb-format option\n",
+                  "the '%s' command doesn't support the --gdb-format option",
                   cmd_obj->GetCommandName().str().c_str());
               return nullptr;
             }
@@ -3874,8 +3874,8 @@ CommandInterpreter::ResolveCommandImpl(std::string &command_line,
           break;
 
         default:
-          result.AppendErrorWithFormat(
-              "unknown command shorthand suffix: '%s'\n", suffix.c_str());
+          result.AppendErrorWithFormat("unknown command shorthand suffix: '%s'",
+                                       suffix.c_str());
           return nullptr;
         }
       }

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommandObjectCPlusPlus.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CommandObjectCPlusPlus.cpp
@@ -47,7 +47,7 @@ void CommandObjectCPlusPlusDemangle::DoExecute(Args &command,
                                       demangled.GetCString());
     } else {
       error_any = true;
-      result.AppendErrorWithFormat("%s is not a valid C++ mangled name\n",
+      result.AppendErrorWithFormat("%s is not a valid C++ mangled name",
                                    entry.ref().str().c_str());
     }
   }

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -862,8 +862,8 @@ bool ScriptInterpreterPythonImpl::ExecuteOneLine(
 
     // The one-liner failed.  Append the error message.
     if (result) {
-      result->AppendErrorWithFormat(
-          "python failed attempting to evaluate '%s'", command_str.c_str());
+      result->AppendErrorWithFormat("python failed attempting to evaluate '%s'",
+                                    command_str.c_str());
     }
     return false;
   }

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -863,7 +863,7 @@ bool ScriptInterpreterPythonImpl::ExecuteOneLine(
     // The one-liner failed.  Append the error message.
     if (result) {
       result->AppendErrorWithFormat(
-          "python failed attempting to evaluate '%s'\n", command_str.c_str());
+          "python failed attempting to evaluate '%s'", command_str.c_str());
     }
     return false;
   }

--- a/lldb/source/Plugins/TraceExporter/ctf/CommandObjectThreadTraceExportCTF.cpp
+++ b/lldb/source/Plugins/TraceExporter/ctf/CommandObjectThreadTraceExportCTF.cpp
@@ -89,7 +89,7 @@ void CommandObjectThreadTraceExportCTF::DoExecute(Args &command,
     };
 
     if (llvm::Error err = do_work()) {
-      result.AppendErrorWithFormat("%s\n", toString(std::move(err)).c_str());
+      result.AppendErrorWithFormat("%s", toString(std::move(err)).c_str());
     }
   }
 }


### PR DESCRIPTION
Follow up to #193168.

This call adds a newline if there isn't one. Changing these will
eventually let us always add a newline, which is in line with
the other methods on CommandReturnObject.

This is a small part of calls found with:
* VSCode search for `(\.AppendErrorWithFormat\(([\s\r\n]+)?"(?:(?:\\.|[^"\\])*))\\n"` and replace with `$1"`.
* Asserting that the last character of the format string is not a newline.
* Manual inspection.