### PR TITLE
[clang][Modules] Avoid checking for duplicating module definitions when a module does not have a valid definition location

### DIFF
--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -1849,17 +1849,22 @@ void ModuleMapLoader::handleModuleDecl(const modulemap::ModuleDecl &MD) {
     // We might see a (re)definition of a module that we already have a
     // definition for in four cases:
     //  - If the Existing module was loaded from an AST file and we've found its
-    //    original source module map, or
+    //    original source module map, or we cannot determine Existing's
+    //    definition location.
     bool LoadedFromASTFile = Existing->IsFromModuleFile;
     if (LoadedFromASTFile) {
       OptionalFileEntryRef ExistingModMapFile =
           Map.getContainingModuleMapFile(Existing);
       OptionalFileEntryRef CurrentModMapFile =
           SourceMgr.getFileEntryRefForID(ModuleMapFID);
-      if (ExistingModMapFile && CurrentModMapFile &&
-          *ExistingModMapFile == *CurrentModMapFile)
+      if ((ExistingModMapFile && CurrentModMapFile &&
+           *ExistingModMapFile == *CurrentModMapFile) ||
+          Existing->DefinitionLoc.isInvalid()) {
+        // If we do not know Existing's definition location, we have
+        // no way of checking against it, and hence we stay conservative and do
+        // not check for duplicating module definitions.
         LoadedFromASTFile = true;
-      else
+      } else
         LoadedFromASTFile = false;
     }
     //  - If we previously inferred this module from different module map file.


### PR DESCRIPTION
69e0367e8221b8002b5d438fb70ff3daf36257fc enhanced the duplicating module definition diagnostics to check across ModuleMaps in a very specific case. The check proved to be overly strict. This PR makes sure we do not check when the `Existing` module's definition location is unknown. Such cases are only observed when a module built through include-tree (CAS) is imported through a pch (e.g. https://github.com/swiftlang/llvm-project/blob/4a8f552d072f7dfdecc241c02696f82761ec0596/clang/test/ClangScanDeps/modules-include-tree-pch-common-stale-prefix-map.c#L1) Such cases are only present when CAS is used, so no test case is attached here. 

Assisted-by: claude-opus-4.6

rdar://174894322