### PR TITLE
[analyzer] Fix typo in ExprEngine.h

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -90,7 +90,7 @@ class ProgramStateManager;
 class RegionAndSymbolInvalidationTraits;
 class SymbolManager;
 
-/// Hints for figuring out of a call should be inlined during evalCall().
+/// Hints for figuring out if a call should be inlined during evalCall().
 struct EvalCallOptions {
   /// This call is a constructor or a destructor for which we do not currently
   /// compute the this-region correctly.
@@ -185,7 +185,7 @@ private:
   /// implicitly never returns.
   ObjCNoReturn ObjCNoRet;
 
-  /// The BugReporter associated with this engine.  It is important that
+  /// The BugReporter associated with this engine. It is important that
   /// this object be placed at the very end of member variables so that its
   /// destructor is called before the rest of the ExprEngine is destroyed.
   PathSensitiveBugReporter BR;
@@ -245,8 +245,8 @@ public:
   void setCurrLocationContextAndBlock(const LocationContext *LC,
                                       const CFGBlock *B) {
     // The current LocationContext and Block is reset at the beginning of
-    // dispacthWorkItem. Ideally, this method should be called only once per
-    // dipatchWorkItem call (= elementary analysis step); so the following
+    // dispatchWorkItem. Ideally, this method should be called only once per
+    // dispatchWorkItem call (= elementary analysis step); so the following
     // assertion is there to catch accidental repeated calls. If the current
     // LocationContext and Block needs to change in the middle of a single step
     // (which currently happens only once, in processCallExit), use an explicit
@@ -412,28 +412,28 @@ public:
                                      const CFGBlock *DstT,
                                      const CFGBlock *DstF);
 
-  /// Called by CoreEngine.  Used to processing branching behavior
+  /// Called by CoreEngine. Used to processing branching behavior
   /// at static initializers.
   void processStaticInitializer(const DeclStmt *DS, ExplodedNode *Pred,
                                 ExplodedNodeSet &Dst, const CFGBlock *DstT,
                                 const CFGBlock *DstF);
 
-  /// processIndirectGoto - Called by CoreEngine.  Used to generate successor
+  /// processIndirectGoto - Called by CoreEngine. Used to generate successor
   ///  nodes by processing the 'effects' of a computed goto jump.
   void processIndirectGoto(ExplodedNodeSet &Dst, const Expr *Tgt,
                            const CFGBlock *Dispatch, ExplodedNode *Pred);
 
-  /// ProcessSwitch - Called by CoreEngine.  Used to generate successor
+  /// ProcessSwitch - Called by CoreEngine. Used to generate successor
   ///  nodes by processing the 'effects' of a switch statement.
   void processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
                      ExplodedNodeSet &Dst);
 
-  /// Called by CoreEngine.  Used to notify checkers that processing a
+  /// Called by CoreEngine. Used to notify checkers that processing a
   /// function has begun. Called for both inlined and top-level functions.
   void processBeginOfFunction(ExplodedNode *Pred, ExplodedNodeSet &Dst,
                               const BlockEdge &L);
 
-  /// Called by CoreEngine.  Used to notify checkers that processing a
+  /// Called by CoreEngine. Used to notify checkers that processing a
   /// function has ended. Called for both inlined and top-level functions.
   void processEndOfFunction(ExplodedNode *Pred, const ReturnStmt *RS = nullptr);
 
@@ -686,17 +686,17 @@ public:
     return svalBuilder.evalBinOp(ST, Op, LHS, RHS, T);
   }
 
-  /// Retreives which element is being constructed in a non-POD type array.
+  /// Retrieves which element is being constructed in a non-POD type array.
   static std::optional<unsigned>
   getIndexOfElementToConstruct(ProgramStateRef State, const CXXConstructExpr *E,
                                const LocationContext *LCtx);
 
-  /// Retreives which element is being destructed in a non-POD type array.
+  /// Retrieves which element is being destructed in a non-POD type array.
   static std::optional<unsigned>
   getPendingArrayDestruction(ProgramStateRef State,
                              const LocationContext *LCtx);
 
-  /// Retreives the size of the array in the pending ArrayInitLoopExpr.
+  /// Retrieves the size of the array in the pending ArrayInitLoopExpr.
   static std::optional<unsigned>
   getPendingInitLoop(ProgramStateRef State, const CXXConstructExpr *E,
                      const LocationContext *LCtx);
@@ -911,7 +911,7 @@ private:
       SVal *ElementCountVal = nullptr);
 
   /// Checks whether we construct an array of non-POD type, and decides if the
-  /// constructor should be inkoved once again.
+  /// constructor should be invoked once again.
   bool shouldRepeatCtorCall(ProgramStateRef State, const CXXConstructExpr *E,
                             const LocationContext *LCtx);
 

--- a/clang/lib/Headers/avx512fintrin.h
+++ b/clang/lib/Headers/avx512fintrin.h
@@ -638,7 +638,7 @@ _mm512_mask_and_epi32(__m512i __src, __mmask16 __k, __m512i __a, __m512i __b) {
                 (__v16si) __src);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_maskz_and_epi32(__mmask16 __k, __m512i __a, __m512i __b)
 {
   return (__m512i) _mm512_mask_and_epi32(_mm512_setzero_si512 (),
@@ -676,7 +676,7 @@ _mm512_andnot_epi32 (__m512i __A, __m512i __B)
   return (__m512i)(~(__v16su)__A & (__v16su)__B);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_mask_andnot_epi32(__m512i __W, __mmask16 __U, __m512i __A, __m512i __B)
 {
   return (__m512i)__builtin_ia32_selectd_512((__mmask16)__U,
@@ -684,7 +684,7 @@ _mm512_mask_andnot_epi32(__m512i __W, __mmask16 __U, __m512i __A, __m512i __B)
                                          (__v16si)__W);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_maskz_andnot_epi32(__mmask16 __U, __m512i __A, __m512i __B)
 {
   return (__m512i)_mm512_mask_andnot_epi32(_mm512_setzero_si512(),
@@ -718,7 +718,7 @@ _mm512_or_epi32(__m512i __a, __m512i __b)
   return (__m512i)((__v16su)__a | (__v16su)__b);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_mask_or_epi32(__m512i __src, __mmask16 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)__builtin_ia32_selectd_512((__mmask16)__k,
@@ -726,7 +726,7 @@ _mm512_mask_or_epi32(__m512i __src, __mmask16 __k, __m512i __a, __m512i __b)
                                              (__v16si)__src);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_maskz_or_epi32(__mmask16 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)_mm512_mask_or_epi32(_mm512_setzero_si512(), __k, __a, __b);
@@ -758,7 +758,7 @@ _mm512_xor_epi32(__m512i __a, __m512i __b)
   return (__m512i)((__v16su)__a ^ (__v16su)__b);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_mask_xor_epi32(__m512i __src, __mmask16 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)__builtin_ia32_selectd_512((__mmask16)__k,
@@ -766,7 +766,7 @@ _mm512_mask_xor_epi32(__m512i __src, __mmask16 __k, __m512i __a, __m512i __b)
                                             (__v16si)__src);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_maskz_xor_epi32(__mmask16 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)_mm512_mask_xor_epi32(_mm512_setzero_si512(), __k, __a, __b);

--- a/clang/lib/Headers/avx512fintrin.h
+++ b/clang/lib/Headers/avx512fintrin.h
@@ -657,7 +657,7 @@ _mm512_mask_and_epi64(__m512i __src, __mmask8 __k, __m512i __a, __m512i __b) {
       (__mmask8)__k, (__v8di)_mm512_and_epi64(__a, __b), (__v8di)__src);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_maskz_and_epi64(__mmask8 __k, __m512i __a, __m512i __b)
 {
   return (__m512i) _mm512_mask_and_epi64(_mm512_setzero_si512 (),
@@ -697,7 +697,7 @@ _mm512_andnot_epi64(__m512i __A, __m512i __B)
   return (__m512i)(~(__v8du)__A & (__v8du)__B);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_mask_andnot_epi64(__m512i __W, __mmask8 __U, __m512i __A, __m512i __B)
 {
   return (__m512i)__builtin_ia32_selectq_512((__mmask8)__U,
@@ -705,7 +705,7 @@ _mm512_mask_andnot_epi64(__m512i __W, __mmask8 __U, __m512i __A, __m512i __B)
                                           (__v8di)__W);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_maskz_andnot_epi64(__mmask8 __U, __m512i __A, __m512i __B)
 {
   return (__m512i)_mm512_mask_andnot_epi64(_mm512_setzero_si512(),
@@ -738,7 +738,7 @@ _mm512_or_epi64(__m512i __a, __m512i __b)
   return (__m512i)((__v8du)__a | (__v8du)__b);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_mask_or_epi64(__m512i __src, __mmask8 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)__builtin_ia32_selectq_512((__mmask8)__k,
@@ -746,7 +746,7 @@ _mm512_mask_or_epi64(__m512i __src, __mmask8 __k, __m512i __a, __m512i __b)
                                              (__v8di)__src);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_maskz_or_epi64(__mmask8 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)_mm512_mask_or_epi64(_mm512_setzero_si512(), __k, __a, __b);
@@ -778,7 +778,7 @@ _mm512_xor_epi64(__m512i __a, __m512i __b)
   return (__m512i)((__v8du)__a ^ (__v8du)__b);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_mask_xor_epi64(__m512i __src, __mmask8 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)__builtin_ia32_selectq_512((__mmask8)__k,
@@ -786,7 +786,7 @@ _mm512_mask_xor_epi64(__m512i __src, __mmask8 __k, __m512i __a, __m512i __b)
                                              (__v8di)__src);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512
+static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
 _mm512_maskz_xor_epi64(__mmask8 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)_mm512_mask_xor_epi64(_mm512_setzero_si512(), __k, __a, __b);

--- a/clang/lib/Headers/avx512fintrin.h
+++ b/clang/lib/Headers/avx512fintrin.h
@@ -638,7 +638,7 @@ _mm512_mask_and_epi32(__m512i __src, __mmask16 __k, __m512i __a, __m512i __b) {
                 (__v16si) __src);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_maskz_and_epi32(__mmask16 __k, __m512i __a, __m512i __b)
 {
   return (__m512i) _mm512_mask_and_epi32(_mm512_setzero_si512 (),
@@ -657,7 +657,7 @@ _mm512_mask_and_epi64(__m512i __src, __mmask8 __k, __m512i __a, __m512i __b) {
       (__mmask8)__k, (__v8di)_mm512_and_epi64(__a, __b), (__v8di)__src);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_maskz_and_epi64(__mmask8 __k, __m512i __a, __m512i __b)
 {
   return (__m512i) _mm512_mask_and_epi64(_mm512_setzero_si512 (),
@@ -676,7 +676,7 @@ _mm512_andnot_epi32 (__m512i __A, __m512i __B)
   return (__m512i)(~(__v16su)__A & (__v16su)__B);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_mask_andnot_epi32(__m512i __W, __mmask16 __U, __m512i __A, __m512i __B)
 {
   return (__m512i)__builtin_ia32_selectd_512((__mmask16)__U,
@@ -684,7 +684,7 @@ _mm512_mask_andnot_epi32(__m512i __W, __mmask16 __U, __m512i __A, __m512i __B)
                                          (__v16si)__W);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_maskz_andnot_epi32(__mmask16 __U, __m512i __A, __m512i __B)
 {
   return (__m512i)_mm512_mask_andnot_epi32(_mm512_setzero_si512(),
@@ -697,7 +697,7 @@ _mm512_andnot_epi64(__m512i __A, __m512i __B)
   return (__m512i)(~(__v8du)__A & (__v8du)__B);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_mask_andnot_epi64(__m512i __W, __mmask8 __U, __m512i __A, __m512i __B)
 {
   return (__m512i)__builtin_ia32_selectq_512((__mmask8)__U,
@@ -705,7 +705,7 @@ _mm512_mask_andnot_epi64(__m512i __W, __mmask8 __U, __m512i __A, __m512i __B)
                                           (__v8di)__W);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_maskz_andnot_epi64(__mmask8 __U, __m512i __A, __m512i __B)
 {
   return (__m512i)_mm512_mask_andnot_epi64(_mm512_setzero_si512(),
@@ -718,7 +718,7 @@ _mm512_or_epi32(__m512i __a, __m512i __b)
   return (__m512i)((__v16su)__a | (__v16su)__b);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_mask_or_epi32(__m512i __src, __mmask16 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)__builtin_ia32_selectd_512((__mmask16)__k,
@@ -726,7 +726,7 @@ _mm512_mask_or_epi32(__m512i __src, __mmask16 __k, __m512i __a, __m512i __b)
                                              (__v16si)__src);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_maskz_or_epi32(__mmask16 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)_mm512_mask_or_epi32(_mm512_setzero_si512(), __k, __a, __b);
@@ -738,7 +738,7 @@ _mm512_or_epi64(__m512i __a, __m512i __b)
   return (__m512i)((__v8du)__a | (__v8du)__b);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_mask_or_epi64(__m512i __src, __mmask8 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)__builtin_ia32_selectq_512((__mmask8)__k,
@@ -746,7 +746,7 @@ _mm512_mask_or_epi64(__m512i __src, __mmask8 __k, __m512i __a, __m512i __b)
                                              (__v8di)__src);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_maskz_or_epi64(__mmask8 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)_mm512_mask_or_epi64(_mm512_setzero_si512(), __k, __a, __b);
@@ -758,7 +758,7 @@ _mm512_xor_epi32(__m512i __a, __m512i __b)
   return (__m512i)((__v16su)__a ^ (__v16su)__b);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_mask_xor_epi32(__m512i __src, __mmask16 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)__builtin_ia32_selectd_512((__mmask16)__k,
@@ -766,7 +766,7 @@ _mm512_mask_xor_epi32(__m512i __src, __mmask16 __k, __m512i __a, __m512i __b)
                                             (__v16si)__src);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_maskz_xor_epi32(__mmask16 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)_mm512_mask_xor_epi32(_mm512_setzero_si512(), __k, __a, __b);
@@ -778,7 +778,7 @@ _mm512_xor_epi64(__m512i __a, __m512i __b)
   return (__m512i)((__v8du)__a ^ (__v8du)__b);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_mask_xor_epi64(__m512i __src, __mmask8 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)__builtin_ia32_selectq_512((__mmask8)__k,
@@ -786,7 +786,7 @@ _mm512_mask_xor_epi64(__m512i __src, __mmask8 __k, __m512i __a, __m512i __b)
                                              (__v8di)__src);
 }
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS512_CONSTEXPR
+static __inline__ __m512i __DEFAULT_FN_ATTRS512
 _mm512_maskz_xor_epi64(__mmask8 __k, __m512i __a, __m512i __b)
 {
   return (__m512i)_mm512_mask_xor_epi64(_mm512_setzero_si512(), __k, __a, __b);


### PR DESCRIPTION
While I was studying the code base I have spotted some typo in the `ExprEngine.h` in this PR I have fixed these typos.