### PR TITLE
IR: Allow !fpmath metadata on homogeneous float structs

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5751,7 +5751,7 @@ void Verifier::visitInstruction(Instruction &I) {
   }
 
   if (MDNode *MD = I.getMetadata(LLVMContext::MD_fpmath)) {
-    Check(I.getType()->isFPOrFPVectorTy(),
+    Check(FPMathOperator::isSupportedFloatingPointType(I.getType()),
           "fpmath requires a floating point result!", &I);
     Check(MD->getNumOperands() == 1, "fpmath takes one operand!", &I);
     if (ConstantFP *CFP0 =

--- a/llvm/test/Assembler/fpmath.ll
+++ b/llvm/test/Assembler/fpmath.ll
@@ -1,0 +1,19 @@
+; RUN: llvm-as < %s | llvm-dis | FileCheck %s
+
+define { float, float } @use_fpmath_struct(float %x) {
+; CHECK-LABEL: @use_fpmath_struct(
+; CHECK: %ret = call { float, float } @llvm.sincos.f32(float %x), !fpmath !0
+  %ret = call { float, float } @llvm.sincos.f32(float %x), !fpmath !0
+  ret { float, float } %ret
+}
+
+define { <2 x float>, <2 x float> } @use_fpmath_struct_vec(<2 x float> %x) {
+; CHECK-LABEL: @use_fpmath_struct_vec(
+; CHECK: %ret = call { <2 x float>, <2 x float> } @llvm.sincos.v2f32(<2 x float> %x), !fpmath !0
+  %ret = call { <2 x float>, <2 x float> } @llvm.sincos.v2f32(<2 x float> %x), !fpmath !0
+  ret { <2 x float>, <2 x float> } %ret
+}
+
+!0 = !{float 4.0}
+
+; CHECK: !0 = !{float 4.000000e+00}


### PR DESCRIPTION
This matches the logic for fast math flags / nofpclass, and allows
marking llvm.sincos calls with !fpmath.