### PR TITLE
[AMDGPU][WIP] Added mask intrinsics

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
+++ b/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
@@ -3844,6 +3844,16 @@ def int_amdgcn_cooperative_atomic_store_16x8B : AMDGPUCooperativeAtomicStore<llv
 def int_amdgcn_cooperative_atomic_load_8x16B : AMDGPUCooperativeAtomicLoad<llvm_v4i32_ty>;
 def int_amdgcn_cooperative_atomic_store_8x16B : AMDGPUCooperativeAtomicStore<llvm_v4i32_ty>;
 
+def int_amdgcn_mask : ClangBuiltin<"__builtin_amdgcn_mask">,
+  Intrinsic<[llvm_anyint_ty],
+  [llvm_i1_ty], [IntrWillReturn, IntrNoCallback, IntrNoFree]
+>;
+
+def int_amdgcn_reset_mask : ClangBuiltin<"__builtin_amdgcn_reset_mask">,
+  Intrinsic<[],
+  [llvm_anyint_ty], [IntrWillReturn, IntrNoCallback, IntrNoFree]
+>;
+
 //===----------------------------------------------------------------------===//
 // Special Intrinsics for backend internal use only. No frontend
 // should emit calls to these.

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -11742,6 +11742,32 @@ SDValue SITargetLowering::LowerINTRINSIC_W_CHAIN(SDValue Op,
                                    Op->getVTList(), {Chain, Ptr},
                                    MII->getMemoryVT(), MII->getMemOperand());
   }
+  case Intrinsic::amdgcn_mask: {
+    SDNode *N = Op.getNode();
+    SDLoc SL(N);
+    SDValue Pred = N->getOperand(2);
+
+    // generate a new EXEC mask based on the predicate value
+    SmallVector<SDValue, 2> Operands;
+    Operands.push_back(
+        DAG.getTargetConstant(Intrinsic::amdgcn_ballot, SL, MVT::i32));
+    Operands.push_back(Pred);
+    SDValue NewMask =
+        DAG.getNode(ISD::INTRINSIC_WO_CHAIN, SL, MVT::i32, Operands);
+
+    // save the original EXEC mask
+    EVT ExecVT = Subtarget->isWave32() ? MVT::i32 : MVT::i64;
+    Register ExecReg = Subtarget->isWave32() ? AMDGPU::EXEC_LO : AMDGPU::EXEC;
+    SDValue OrigMask =
+        DAG.getCopyFromReg(DAG.getEntryNode(), SL, ExecReg, ExecVT);
+    SDValue Chain = OrigMask.getValue(1);
+
+    // change the EXEC mask
+    SDValue Res = DAG.getCopyToReg(Chain, SL, ExecReg, NewMask, SDValue());
+
+    return DAG.getMergeValues({OrigMask.getValue(0), Res.getValue(0)}, SL);
+  }
+
   default:
 
     if (const AMDGPU::ImageDimIntrinsicInfo *ImageDimIntr =
@@ -12424,6 +12450,16 @@ SDValue SITargetLowering::LowerINTRINSIC_VOID(SDValue Op,
     SDValue Val = Op->getOperand(3);
     return DAG.getAtomic(ISD::ATOMIC_STORE, DL, MII->getMemoryVT(), Chain, Val,
                          Ptr, MII->getMemOperand());
+  }
+  case Intrinsic::amdgcn_reset_mask: {
+    SDNode *N = Op.getNode();
+    SDLoc SL(N);
+
+    SDValue Chain = N->getOperand(0);
+    SDValue Mask = N->getOperand(2);
+    const GCNSubtarget *ST = this->getSubtarget();
+    Register ExecReg = ST->isWave32() ? AMDGPU::EXEC_LO : AMDGPU::EXEC;
+    return DAG.getCopyToReg(Chain, SL, ExecReg, Mask.getValue(0), SDValue());
   }
   default: {
     if (const AMDGPU::ImageDimIntrinsicInfo *ImageDimIntr =


### PR DESCRIPTION
PR relates to [193285](https://github.com/llvm/llvm-project/pull/193285). It tries to address the same problem as before but, despite duplicating intrinsics, it add explicit mask manipulations. I understand that we don't want to expose it. This is just a demo PR and I understood the reasoning of @arsenm regarding side-effects caused by changing EXEC. Probably `@llvm.amdgcn.mask` and `@llvm.amdgcn.reset.mask` must not be exposed as clang-builtin; thus, only projects that directly work on LLVM IR (e.g., rocMLIR, Triton, IREE) to generate these. 

```llvm
; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 %s

declare void @llvm.amdgcn.global.prefetch(ptr addrspace(1) %ptr, i32 %col)
declare i32 @llvm.amdgcn.mask(i1 %pref)
declare void @llvm.amdgcn.reset.mask(i32 %mask)

define void @prefetch(ptr addrspace(1) %addr, i32 %lb) {
  %tid = call i32 @llvm.amdgcn.workitem.id.x()
  %pred = icmp sle i32 %tid, %lb
  %oldmask = call i32 @llvm.amdgcn.mask(i1 %pred)
  call void @llvm.amdgcn.global.prefetch(ptr addrspace(1) %addr, i32 9)
  call void @llvm.amdgcn.reset.mask(i32 %oldmask)
  ret void 
}
```

```bash
prefetch:                            ; @prefetch
; %bb.0:
        s_wait_loadcnt_dscnt 0x0
        s_wait_kmcnt 0x0
        v_and_b32_e32 v3, 0x3ff, v31
        s_mov_b32 s0, exec_lo
        s_delay_alu instid0(VALU_DEP_1)
        v_cmp_le_i32_e32 vcc_lo, v3, v2
        s_mov_b32 exec_lo, vcc_lo
        global_prefetch_b8 v[0:1], off th:TH_LOAD_NT scope:SCOPE_SE
        s_mov_b32 exec_lo, s0
        s_set_pc_i64 s[30:31]:                            ; @prefetch
```