### PR TITLE
Revert "[compiler-rt][profile] Use runtimes-libc-headers in the GPU runtimes build"

### DIFF
--- a/compiler-rt/CMakeLists.txt
+++ b/compiler-rt/CMakeLists.txt
@@ -32,14 +32,6 @@ list(INSERT CMAKE_MODULE_PATH 0
   "${LLVM_COMMON_CMAKE_UTILS}/Modules"
   )
 
-# Expose the shared `runtimes-libc-*` targets to compiler-rt subcomponents
-# (same as libcxx / libcxxabi / libunwind).
-if(LLVM_RUNTIMES_BUILD)
-  list(APPEND CMAKE_MODULE_PATH
-       "${CMAKE_CURRENT_SOURCE_DIR}/../runtimes/cmake/Modules")
-  include(HandleLibC)
-endif()
-
 if(CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_CFG_RESOLVED_INTDIR "${CMAKE_CFG_INTDIR}/")
 else()

--- a/compiler-rt/lib/profile/CMakeLists.txt
+++ b/compiler-rt/lib/profile/CMakeLists.txt
@@ -186,15 +186,6 @@ append_list_if(COMPILER_RT_HAS_WD4221_FLAG /wd4221 EXTRA_FLAGS)
 # Disable 'nonstandard extension used: translation unit is empty'.
 append_list_if(COMPILER_RT_HAS_WD4206_FLAG /wd4206 EXTRA_FLAGS)
 
-# In the GPU runtimes build, link `runtimes-libc-headers` for its
-# `-isystem` include dir and for waiting on header generation.
-# The target is created at compiler-rt top level from `HandleLibC.cmake`
-# when `LLVM_RUNTIMES_BUILD` is set.
-set(PROFILE_LINK_LIBS)
-if(COMPILER_RT_GPU_BUILD AND TARGET runtimes-libc-headers)
-  list(APPEND PROFILE_LINK_LIBS runtimes-libc-headers)
-endif()
-
 if(APPLE)
   add_compiler_rt_runtime(clang_rt.profile
     STATIC
@@ -203,7 +194,6 @@ if(APPLE)
     CFLAGS ${EXTRA_FLAGS}
     SOURCES ${PROFILE_SOURCES}
     ADDITIONAL_HEADERS ${PROFILE_HEADERS}
-    LINK_LIBS ${PROFILE_LINK_LIBS}
     PARENT_TARGET profile)
 else()
   add_compiler_rt_runtime(clang_rt.profile
@@ -212,6 +202,5 @@ else()
     CFLAGS ${EXTRA_FLAGS}
     SOURCES ${PROFILE_SOURCES}
     ADDITIONAL_HEADERS ${PROFILE_HEADERS}
-    LINK_LIBS ${PROFILE_LINK_LIBS}
     PARENT_TARGET profile)
 endif()


### PR DESCRIPTION
Reverts llvm/llvm-project#192814

This CL broke the Mac build.
https://luci-milo.appspot.com/ui/p/fuchsia/builders/toolchain.ci/clang-mac-arm64/b8683874769760578273/overview