### PR TITLE
[libc] Fix .params file generation for integration tests

### DIFF
--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -659,15 +659,20 @@ function(add_integration_test test_name)
   # requires specific command-line arguments or environment variables.  The
   # LibcTest lit format reads this file at test time.  Format: one arg per line,
   # a "---" separator, then one KEY=VALUE env entry per line.
-  if(INTEGRATION_TEST_ARGS OR INTEGRATION_TEST_ENV)
-    set(_params_content "")
-    foreach(_arg IN LISTS INTEGRATION_TEST_ARGS)
-      string(APPEND _params_content "${_arg}\n")
-    endforeach()
-    string(APPEND _params_content "---\n")
-    foreach(_env_entry IN LISTS INTEGRATION_TEST_ENV)
-      string(APPEND _params_content "${_env_entry}\n")
-    endforeach()
+  set(_params_content "")
+  foreach(_arg IN LISTS INTEGRATION_TEST_LOADER_ARGS)
+    string(APPEND _params_content "${_arg}\n")
+  endforeach()
+  string(APPEND _params_content "---\n")
+  foreach(_arg IN LISTS INTEGRATION_TEST_ARGS)
+    string(APPEND _params_content "${_arg}\n")
+  endforeach()
+  string(APPEND _params_content "---\n")
+  foreach(_env_entry IN LISTS INTEGRATION_TEST_ENV)
+    string(APPEND _params_content "${_env_entry}\n")
+  endforeach()
+
+  if(INTEGRATION_TEST_LOADER_ARGS OR INTEGRATION_TEST_ARGS OR INTEGRATION_TEST_ENV)
     file(GENERATE
       OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/${fq_build_target_name}.params"
       CONTENT "${_params_content}"


### PR DESCRIPTION
Update add_integration_test to include loader arguments in the .params file. The lit format already supported three-part .params files, but add_integration_test was only generating two parts.