### PR TITLE
[ELF] Factor linker-script dispatch loops into helpers. NFC

### DIFF
--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -61,7 +61,9 @@ private:
   void readGroup();
   void readInclude();
   void readInput();
+  void readLinkerScriptStmt(StringRef tok);
   void readMemory();
+  void readMemoryStmt(StringRef tok);
   void readOutput();
   void readOutputArch();
   void readOutputFormat();
@@ -70,6 +72,8 @@ private:
   void readRegionAlias();
   void readSearchDir();
   void readSections();
+  void readSectionsStmt(SmallVectorImpl<SectionCommand *> &v, StringRef tok);
+  void readOutputSectionStmt(OutputSection &osec, StringRef tok);
   void readTarget();
   void readVersion();
   void readVersionScriptCommand();
@@ -239,50 +243,54 @@ void ScriptParser::readLinkerScript() {
     StringRef tok = next();
     if (atEOF())
       break;
-    if (tok == ";")
-      continue;
+    readLinkerScriptStmt(tok);
+  }
+}
 
-    if (tok == "ENTRY") {
-      readEntry();
-    } else if (tok == "EXTERN") {
-      readExtern();
-    } else if (tok == "GROUP") {
-      readGroup();
-    } else if (tok == "INCLUDE") {
-      readInclude();
-    } else if (tok == "INPUT") {
-      readInput();
-    } else if (tok == "MEMORY") {
-      readMemory();
-    } else if (tok == "OUTPUT") {
-      readOutput();
-    } else if (tok == "OUTPUT_ARCH") {
-      readOutputArch();
-    } else if (tok == "OUTPUT_FORMAT") {
-      readOutputFormat();
-    } else if (tok == "OVERWRITE_SECTIONS") {
-      readOverwriteSections();
-    } else if (tok == "PHDRS") {
-      readPhdrs();
-    } else if (tok == "REGION_ALIAS") {
-      readRegionAlias();
-    } else if (tok == "SEARCH_DIR") {
-      readSearchDir();
-    } else if (tok == "SECTIONS") {
-      readSections();
-    } else if (tok == "TARGET") {
-      readTarget();
-    } else if (tok == "VERSION") {
-      readVersion();
-    } else if (tok == "NOCROSSREFS") {
-      readNoCrossRefs(/*to=*/false);
-    } else if (tok == "NOCROSSREFS_TO") {
-      readNoCrossRefs(/*to=*/true);
-    } else if (SymbolAssignment *cmd = readAssignment(tok)) {
-      ctx.script->sectionCommands.push_back(cmd);
-    } else {
-      setError("unknown directive: " + tok);
-    }
+void ScriptParser::readLinkerScriptStmt(StringRef tok) {
+  if (tok == ";")
+    return;
+
+  if (tok == "ENTRY") {
+    readEntry();
+  } else if (tok == "EXTERN") {
+    readExtern();
+  } else if (tok == "GROUP") {
+    readGroup();
+  } else if (tok == "INCLUDE") {
+    readInclude();
+  } else if (tok == "INPUT") {
+    readInput();
+  } else if (tok == "MEMORY") {
+    readMemory();
+  } else if (tok == "OUTPUT") {
+    readOutput();
+  } else if (tok == "OUTPUT_ARCH") {
+    readOutputArch();
+  } else if (tok == "OUTPUT_FORMAT") {
+    readOutputFormat();
+  } else if (tok == "OVERWRITE_SECTIONS") {
+    readOverwriteSections();
+  } else if (tok == "PHDRS") {
+    readPhdrs();
+  } else if (tok == "REGION_ALIAS") {
+    readRegionAlias();
+  } else if (tok == "SEARCH_DIR") {
+    readSearchDir();
+  } else if (tok == "SECTIONS") {
+    readSections();
+  } else if (tok == "TARGET") {
+    readTarget();
+  } else if (tok == "VERSION") {
+    readVersion();
+  } else if (tok == "NOCROSSREFS") {
+    readNoCrossRefs(/*to=*/false);
+  } else if (tok == "NOCROSSREFS_TO") {
+    readNoCrossRefs(/*to=*/true);
+  } else if (SymbolAssignment *cmd = readAssignment(tok)) {
+    ctx.script->sectionCommands.push_back(cmd);
+  } else {
+    setError("unknown directive: " + tok);
   }
 }
 
@@ -655,26 +663,8 @@ void ScriptParser::readOverwriteSections() {
 void ScriptParser::readSections() {
   expect("{");
   SmallVector<SectionCommand *, 0> v;
-  while (auto tok = till("}")) {
-    if (tok == "OVERLAY") {
-      for (SectionCommand *cmd : readOverlay())
-        v.push_back(cmd);
-      continue;
-    }
-    if (tok == "CLASS") {
-      v.push_back(readSectionClassDescription());
-      continue;
-    }
-    if (tok == "INCLUDE") {
-      readInclude();
-      continue;
-    }
-
-    if (SectionCommand *cmd = readAssignment(tok))
-      v.push_back(cmd);
-    else
-      v.push_back(readOutputSectionDescription(tok));
-  }
+  while (auto tok = till("}"))
+    readSectionsStmt(v, tok);
 
   // If DATA_SEGMENT_RELRO_END is absent, for sections after DATA_SEGMENT_ALIGN,
   // the relro fields should be cleared.
@@ -703,6 +693,28 @@ void ScriptParser::readSections() {
       names.push_back(os->osec.name);
   if (!names.empty())
     ctx.script->insertCommands.push_back({std::move(names), isAfter, where});
+}
+
+void ScriptParser::readSectionsStmt(SmallVectorImpl<SectionCommand *> &v,
+                                    StringRef tok) {
+  if (tok == "OVERLAY") {
+    for (SectionCommand *cmd : readOverlay())
+      v.push_back(cmd);
+    return;
+  }
+  if (tok == "CLASS") {
+    v.push_back(readSectionClassDescription());
+    return;
+  }
+  if (tok == "INCLUDE") {
+    readInclude();
+    return;
+  }
+
+  if (SectionCommand *cmd = readAssignment(tok))
+    v.push_back(cmd);
+  else
+    v.push_back(readOutputSectionDescription(tok));
 }
 
 void ScriptParser::readTarget() {
@@ -1033,44 +1045,8 @@ OutputDesc *ScriptParser::readOutputSectionDescription(StringRef outSec) {
     osec->constraint = ConstraintKind::ReadWrite;
   expect("{");
 
-  while (auto tok = till("}")) {
-    if (tok == ";") {
-      // Empty commands are allowed. Do nothing here.
-    } else if (SymbolAssignment *assign = readAssignment(tok)) {
-      osec->commands.push_back(assign);
-    } else if (ByteCommand *data = readByteCommand(tok)) {
-      osec->commands.push_back(data);
-    } else if (tok == "CONSTRUCTORS") {
-      // CONSTRUCTORS is a keyword to make the linker recognize C++ ctors/dtors
-      // by name. This is for very old file formats such as ECOFF/XCOFF.
-      // For ELF, we should ignore.
-    } else if (tok == "FILL") {
-      // We handle the FILL command as an alias for =fillexp section attribute,
-      // which is different from what GNU linkers do.
-      // https://sourceware.org/binutils/docs/ld/Output-Section-Data.html
-      if (peek() != "(")
-        setError("( expected, but got " + peek());
-      osec->filler = readFill();
-    } else if (tok == "SORT") {
-      readSort();
-    } else if (tok == "INCLUDE") {
-      readInclude();
-    } else if (tok == "(" || tok == ")") {
-      setError("expected filename pattern");
-    } else if (peek() == "(") {
-      osec->commands.push_back(readInputSectionDescription(tok));
-    } else {
-      // We have a file name and no input sections description. It is not a
-      // commonly used syntax, but still acceptable. In that case, all sections
-      // from the file will be included.
-      // FIXME: GNU ld permits INPUT_SECTION_FLAGS to be used here. We do not
-      // handle this case here as it will already have been matched by the
-      // case above.
-      auto *isd = make<InputSectionDescription>(tok);
-      isd->sectionPatterns.push_back({{}, StringMatcher("*")});
-      osec->commands.push_back(isd);
-    }
-  }
+  while (auto tok = till("}"))
+    readOutputSectionStmt(*osec, tok);
 
   if (consume(">"))
     osec->memoryRegionName = std::string(readName());
@@ -1098,6 +1074,45 @@ OutputDesc *ScriptParser::readOutputSectionDescription(StringRef outSec) {
   if (ctx.script->referencedSymbols.size() > symbolsReferenced)
     osec->expressionsUseSymbols = true;
   return cmd;
+}
+
+void ScriptParser::readOutputSectionStmt(OutputSection &osec, StringRef tok) {
+  if (tok == ";") {
+    // Empty commands are allowed. Do nothing here.
+  } else if (SymbolAssignment *assign = readAssignment(tok)) {
+    osec.commands.push_back(assign);
+  } else if (ByteCommand *data = readByteCommand(tok)) {
+    osec.commands.push_back(data);
+  } else if (tok == "CONSTRUCTORS") {
+    // CONSTRUCTORS is a keyword to make the linker recognize C++ ctors/dtors
+    // by name. This is for very old file formats such as ECOFF/XCOFF.
+    // For ELF, we should ignore.
+  } else if (tok == "FILL") {
+    // We handle the FILL command as an alias for =fillexp section attribute,
+    // which is different from what GNU linkers do.
+    // https://sourceware.org/binutils/docs/ld/Output-Section-Data.html
+    if (peek() != "(")
+      setError("( expected, but got " + peek());
+    osec.filler = readFill();
+  } else if (tok == "SORT") {
+    readSort();
+  } else if (tok == "INCLUDE") {
+    readInclude();
+  } else if (tok == "(" || tok == ")") {
+    setError("expected filename pattern");
+  } else if (peek() == "(") {
+    osec.commands.push_back(readInputSectionDescription(tok));
+  } else {
+    // We have a file name and no input sections description. It is not a
+    // commonly used syntax, but still acceptable. In that case, all sections
+    // from the file will be included.
+    // FIXME: GNU ld permits INPUT_SECTION_FLAGS to be used here. We do not
+    // handle this case here as it will already have been matched by the
+    // case above.
+    auto *isd = make<InputSectionDescription>(tok);
+    isd->sectionPatterns.push_back({{}, StringMatcher("*")});
+    osec.commands.push_back(isd);
+  }
 }
 
 // Reads a `=<fillexp>` expression and returns its value as a big-endian number.
@@ -1835,32 +1850,35 @@ Expr ScriptParser::readMemoryAssignment(StringRef s1, StringRef s2,
 // MEMORY { name [(attr)] : ORIGIN = origin, LENGTH = len ... }
 void ScriptParser::readMemory() {
   expect("{");
-  while (auto tok = till("}")) {
-    if (tok == "INCLUDE") {
-      readInclude();
-      continue;
-    }
+  while (auto tok = till("}"))
+    readMemoryStmt(tok);
+}
 
-    uint32_t flags = 0;
-    uint32_t invFlags = 0;
-    uint32_t negFlags = 0;
-    uint32_t negInvFlags = 0;
-    if (consume("(")) {
-      readMemoryAttributes(flags, invFlags, negFlags, negInvFlags);
-      expect(")");
-    }
-    expect(":");
-
-    Expr origin = readMemoryAssignment("ORIGIN", "org", "o");
-    expect(",");
-    Expr length = readMemoryAssignment("LENGTH", "len", "l");
-
-    // Add the memory region to the region map.
-    MemoryRegion *mr = make<MemoryRegion>(tok, origin, length, flags, invFlags,
-                                          negFlags, negInvFlags);
-    if (!ctx.script->memoryRegions.insert({tok, mr}).second)
-      setError("region '" + tok + "' already defined");
+void ScriptParser::readMemoryStmt(StringRef tok) {
+  if (tok == "INCLUDE") {
+    readInclude();
+    return;
   }
+
+  uint32_t flags = 0;
+  uint32_t invFlags = 0;
+  uint32_t negFlags = 0;
+  uint32_t negInvFlags = 0;
+  if (consume("(")) {
+    readMemoryAttributes(flags, invFlags, negFlags, negInvFlags);
+    expect(")");
+  }
+  expect(":");
+
+  Expr origin = readMemoryAssignment("ORIGIN", "org", "o");
+  expect(",");
+  Expr length = readMemoryAssignment("LENGTH", "len", "l");
+
+  // Add the memory region to the region map.
+  MemoryRegion *mr = make<MemoryRegion>(tok, origin, length, flags, invFlags,
+                                        negFlags, negInvFlags);
+  if (!ctx.script->memoryRegions.insert({tok, mr}).second)
+    setError("region '" + tok + "' already defined");
 }
 
 // This function parses the attributes used to match against section


### PR DESCRIPTION
Extract the per-token dispatch inside readLinkerScript, readSections,
readOutputSectionDescription, and readMemory into four new helpers.
Preparatory for making INCLUDE run a nested parse (#193427).