### PR TITLE
[AIX][Clang][Driver] Fix OBJECT_MODE bug on AIX

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -667,11 +667,7 @@ static llvm::Triple computeTargetTriple(const Driver &D,
 
   // On AIX, the env OBJECT_MODE may affect the resulting arch variant.
   // However, if --target was explicitly specified, it takes precedence.
-  // Only apply OBJECT_MODE if the target architecture is PowerPC.
-  if (Target.isOSAIX() && !Args.hasArg(options::OPT_target) &&
-      (Target.getArch() == llvm::Triple::ppc ||
-       Target.getArch() == llvm::Triple::ppc64 ||
-       Target.getArch() == llvm::Triple::ppc64le)) {
+  if (Target.isOSAIX() && !Args.hasArg(options::OPT_target) {
     if (std::optional<std::string> ObjectModeValue =
             llvm::sys::Process::GetEnv("OBJECT_MODE")) {
       StringRef ObjectMode = *ObjectModeValue;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -666,7 +666,12 @@ static llvm::Triple computeTargetTriple(const Driver &D,
     return Target;
 
   // On AIX, the env OBJECT_MODE may affect the resulting arch variant.
-  if (Target.isOSAIX()) {
+  // However, if --target was explicitly specified, it takes precedence.
+  // Only apply OBJECT_MODE if the target architecture is PowerPC.
+  if (Target.isOSAIX() && !Args.hasArg(options::OPT_target) &&
+      (Target.getArch() == llvm::Triple::ppc ||
+       Target.getArch() == llvm::Triple::ppc64 ||
+       Target.getArch() == llvm::Triple::ppc64le)) {
     if (std::optional<std::string> ObjectModeValue =
             llvm::sys::Process::GetEnv("OBJECT_MODE")) {
       StringRef ObjectMode = *ObjectModeValue;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -667,7 +667,8 @@ static llvm::Triple computeTargetTriple(const Driver &D,
 
   // On AIX, the env OBJECT_MODE may affect the resulting arch variant.
   // However, if --target was explicitly specified, it takes precedence.
-  if (Target.isOSAIX() && !Args.hasArg(options::OPT_target) {
+  #ifdef _AIX
+  if (!Args.hasArg(options::OPT_target)) {
     if (std::optional<std::string> ObjectModeValue =
             llvm::sys::Process::GetEnv("OBJECT_MODE")) {
       StringRef ObjectMode = *ObjectModeValue;
@@ -685,6 +686,7 @@ static llvm::Triple computeTargetTriple(const Driver &D,
         Target.setArch(AT);
     }
   }
+  #endif
 
   // Currently the only architecture supported by *-uefi triples are x86_64.
   if (Target.isUEFI() && Target.getArch() != llvm::Triple::x86_64)

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -667,7 +667,7 @@ static llvm::Triple computeTargetTriple(const Driver &D,
 
   // On AIX, the env OBJECT_MODE may affect the resulting arch variant.
   // However, if --target was explicitly specified, it takes precedence.
-  #ifdef _AIX
+#ifdef _AIX
   if (!Args.hasArg(options::OPT_target)) {
     if (std::optional<std::string> ObjectModeValue =
             llvm::sys::Process::GetEnv("OBJECT_MODE")) {
@@ -686,7 +686,7 @@ static llvm::Triple computeTargetTriple(const Driver &D,
         Target.setArch(AT);
     }
   }
-  #endif
+#endif
 
   // Currently the only architecture supported by *-uefi triples are x86_64.
   if (Target.isUEFI() && Target.getArch() != llvm::Triple::x86_64)

--- a/clang/test/Driver/aix-object-mode.c
+++ b/clang/test/Driver/aix-object-mode.c
@@ -1,9 +1,15 @@
 // Check that setting an OBJECT_MODE converts the AIX triple to the right variant.
 // RUN: env OBJECT_MODE=64 \
-// RUN: %clang --target=powerpc-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK64 %s
+// RUN: %clang --target=powerpc-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK32 %s
+
+// RUN: env OBJECT_MODE=64 \
+// RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK64 %s
 
 // RUN: env OBJECT_MODE=32 \
-// RUN: %clang --target=powerpc64-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK32 %s
+// RUN: %clang --target=powerpc64-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK64 %s
+
+// RUN: env OBJECT_MODE=32 \
+// RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK32 %s
 
 // Command-line options win.
 // RUN: env OBJECT_MODE=64 \
@@ -17,6 +23,6 @@
 
 // Emit a diagnostic if there is an invalid mode.
 // RUN: env OBJECT_MODE=31 \
-// RUN: not %clang --target=powerpc-ibm-aix 2>&1 | FileCheck -check-prefix=DIAG %s
+// RUN: not %clang 2>&1 | FileCheck -check-prefix=DIAG %s
 
 // DIAG: error: OBJECT_MODE setting 31 is not recognized and is not a valid setting

--- a/clang/test/Driver/aix-object-mode.c
+++ b/clang/test/Driver/aix-object-mode.c
@@ -1,3 +1,4 @@
+// REQUIRES: system-aix
 // Check that setting an OBJECT_MODE converts the AIX triple to the right variant.
 // RUN: env OBJECT_MODE=64 \
 // RUN: %clang --target=powerpc-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK32 %s


### PR DESCRIPTION
If `--target` is specified it should take precedence over `OBJECT_MODE`. This is important, for example, for lit tests which want to specify an explicitly 32-bit or 64-bit triple on AIX, or they may get the wrong bit mode depending on the environment they run in.