### PR TITLE
Revert "[clang] fix matching constrained out-of-line definitions of class specialization member function templates"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -512,7 +512,6 @@ Bug Fixes to C++ Support
 - Correctly diagnose uses of ``co_await`` / ``co_yield`` in the default argument of nested function declarations. (#GH98923)
 - Fixed a crash when diagnosing an invalid static member function with an explicit object parameter (#GH177741)
 - Clang incorrectly instantiated variable specializations outside of the immediate context. (#GH54439)
-- Fixed a bug matching constrained out-of-line definitions of class members.
 - Fixed a crash when instantiating an invalid out-of-line static data member definition in a local class. (#GH176152)
 - Fixed a crash when pack expansions are used as arguments for non-pack parameters of built-in templates. (#GH180307)
 - Fix a problem where pack index expressions where incorrectly being regarded as equivalent.

--- a/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
+++ b/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
@@ -924,13 +924,52 @@ buildAssociatedConstraints(Sema &SemaRef, FunctionTemplateDecl *F,
     }
   }
 
-  auto ArgsForBuildingRC = SemaRef.getTemplateInstantiationArgs(
-      F, F->getLexicalDeclContext(),
-      /*Final=*/false, /*Innermost=*/TemplateArgsForBuildingRC,
-      /*RelativeToPrimary=*/true,
-      /*Pattern=*/nullptr,
-      /*ForConstraintInstantiation=*/true);
+  // A list of template arguments for transforming the require-clause of F.
+  // It must contain the entire set of template argument lists.
+  MultiLevelTemplateArgumentList ArgsForBuildingRC;
   ArgsForBuildingRC.setKind(clang::TemplateSubstitutionKind::Rewrite);
+  ArgsForBuildingRC.addOuterTemplateArguments(TemplateArgsForBuildingRC);
+  // For 2), if the underlying deduction guide F is nested in a class template,
+  // we need the entire template argument list, as the constraint AST in the
+  // require-clause of F remains completely uninstantiated.
+  //
+  // For example:
+  //   template <typename T> // depth 0
+  //   struct Outer {
+  //      template <typename U>
+  //      struct Foo { Foo(U); };
+  //
+  //      template <typename U> // depth 1
+  //      requires C<U>
+  //      Foo(U) -> Foo<int>;
+  //   };
+  //   template <typename U>
+  //   using AFoo = Outer<int>::Foo<U>;
+  //
+  // In this scenario, the deduction guide for `Foo` inside `Outer<int>`:
+  //   - The occurrence of U in the require-expression is [depth:1, index:0]
+  //   - The occurrence of U in the function parameter is [depth:0, index:0]
+  //   - The template parameter of U is [depth:0, index:0]
+  //
+  // We add the outer template arguments which is [int] to the multi-level arg
+  // list to ensure that the occurrence U in `C<U>` will be replaced with int
+  // during the substitution.
+  //
+  // NOTE: The underlying deduction guide F is instantiated -- either from an
+  // explicitly-written deduction guide member, or from a constructor.
+  // getInstantiatedFromMemberTemplate() can only handle the former case, so we
+  // check the DeclContext kind.
+  if (F->getLexicalDeclContext()->getDeclKind() ==
+      clang::Decl::ClassTemplateSpecialization) {
+    auto OuterLevelArgs = SemaRef.getTemplateInstantiationArgs(
+        F, F->getLexicalDeclContext(),
+        /*Final=*/false, /*Innermost=*/std::nullopt,
+        /*RelativeToPrimary=*/true,
+        /*Pattern=*/nullptr,
+        /*ForConstraintInstantiation=*/true);
+    for (auto It : OuterLevelArgs)
+      ArgsForBuildingRC.addOuterTemplateArguments(It.Args);
+  }
 
   ExprResult E = SemaRef.SubstExpr(RC, ArgsForBuildingRC);
   if (E.isInvalid())

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -346,56 +346,58 @@ Response HandleFunction(Sema &SemaRef, const FunctionDecl *Function,
 Response HandleFunctionTemplateDecl(Sema &SemaRef,
                                     const FunctionTemplateDecl *FTD,
                                     MultiLevelTemplateArgumentList &Result) {
-  Result.addOuterTemplateArguments(
-      const_cast<FunctionTemplateDecl *>(FTD),
-      const_cast<FunctionTemplateDecl *>(FTD)->getInjectedTemplateArgs(
-          SemaRef.Context),
-      /*Final=*/false);
-
-  NestedNameSpecifier NNS = FTD->getTemplatedDecl()->getQualifier();
-
-  for (const Type *Ty = NNS.getKind() == NestedNameSpecifier::Kind::Type
-                            ? NNS.getAsType()
-                            : nullptr,
-                  *NextTy = nullptr;
-       Ty && Ty->isInstantiationDependentType();
-       Ty = std::exchange(NextTy, nullptr)) {
-    if (NestedNameSpecifier P = Ty->getPrefix();
-        P.getKind() == NestedNameSpecifier::Kind::Type)
-      NextTy = P.getAsType();
-    const auto *TSTy = dyn_cast<TemplateSpecializationType>(Ty);
-    if (!TSTy)
-      continue;
-
-    ArrayRef<TemplateArgument> Arguments = TSTy->template_arguments();
-    // Prefer template arguments from the injected-class-type if possible.
-    // For example,
-    // ```cpp
-    // template <class... Pack> struct S {
-    //   template <class T> void foo();
-    // };
-    // template <class... Pack> template <class T>
-    //           ^^^^^^^^^^^^^ InjectedTemplateArgs
-    //           They're of kind TemplateArgument::Pack, not of
-    //           TemplateArgument::Type.
-    // void S<Pack...>::foo() {}
-    //        ^^^^^^^
-    //        TSTy->template_arguments() (which are of PackExpansionType)
-    // ```
-    // This meets the contract in
-    // TreeTransform::TryExpandParameterPacks that the template arguments
-    // for unexpanded parameters should be of a Pack kind.
-    if (TSTy->isCurrentInstantiation()) {
-      auto *RD = TSTy->getCanonicalTypeInternal()->getAsCXXRecordDecl();
-      if (ClassTemplateDecl *CTD = RD->getDescribedClassTemplate())
-        Arguments = CTD->getInjectedTemplateArgs(SemaRef.Context);
-      else if (auto *Specialization =
-                   dyn_cast<ClassTemplateSpecializationDecl>(RD))
-        Arguments = Specialization->getTemplateInstantiationArgs().asArray();
-    }
+  if (!isa<ClassTemplateSpecializationDecl>(FTD->getDeclContext())) {
     Result.addOuterTemplateArguments(
-        TSTy->getTemplateName().getAsTemplateDecl(), Arguments,
+        const_cast<FunctionTemplateDecl *>(FTD),
+        const_cast<FunctionTemplateDecl *>(FTD)->getInjectedTemplateArgs(
+            SemaRef.Context),
         /*Final=*/false);
+
+    NestedNameSpecifier NNS = FTD->getTemplatedDecl()->getQualifier();
+
+    for (const Type *Ty = NNS.getKind() == NestedNameSpecifier::Kind::Type
+                              ? NNS.getAsType()
+                              : nullptr,
+                    *NextTy = nullptr;
+         Ty && Ty->isInstantiationDependentType();
+         Ty = std::exchange(NextTy, nullptr)) {
+      if (NestedNameSpecifier P = Ty->getPrefix();
+          P.getKind() == NestedNameSpecifier::Kind::Type)
+        NextTy = P.getAsType();
+      const auto *TSTy = dyn_cast<TemplateSpecializationType>(Ty);
+      if (!TSTy)
+        continue;
+
+      ArrayRef<TemplateArgument> Arguments = TSTy->template_arguments();
+      // Prefer template arguments from the injected-class-type if possible.
+      // For example,
+      // ```cpp
+      // template <class... Pack> struct S {
+      //   template <class T> void foo();
+      // };
+      // template <class... Pack> template <class T>
+      //           ^^^^^^^^^^^^^ InjectedTemplateArgs
+      //           They're of kind TemplateArgument::Pack, not of
+      //           TemplateArgument::Type.
+      // void S<Pack...>::foo() {}
+      //        ^^^^^^^
+      //        TSTy->template_arguments() (which are of PackExpansionType)
+      // ```
+      // This meets the contract in
+      // TreeTransform::TryExpandParameterPacks that the template arguments
+      // for unexpanded parameters should be of a Pack kind.
+      if (TSTy->isCurrentInstantiation()) {
+        auto *RD = TSTy->getCanonicalTypeInternal()->getAsCXXRecordDecl();
+        if (ClassTemplateDecl *CTD = RD->getDescribedClassTemplate())
+          Arguments = CTD->getInjectedTemplateArgs(SemaRef.Context);
+        else if (auto *Specialization =
+                     dyn_cast<ClassTemplateSpecializationDecl>(RD))
+          Arguments = Specialization->getTemplateInstantiationArgs().asArray();
+      }
+      Result.addOuterTemplateArguments(
+          TSTy->getTemplateName().getAsTemplateDecl(), Arguments,
+          /*Final=*/false);
+    }
   }
 
   return Response::ChangeDecl(FTD->getLexicalDeclContext());

--- a/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
+++ b/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
@@ -838,7 +838,7 @@ auto TplClass<int>::buggy() -> void {}
 
 }
 
-namespace PackIndexExpr1 {
+namespace PackIndexExpr {
 template <int... T>
 concept C = true;
 
@@ -852,81 +852,7 @@ template <>
 template <int... Ts>
 requires C<Ts...[0]>
 auto TplClass<int>::buggy() -> void {}
-} // namespace PackIndexExpr1
-
-namespace PackIndexExpr2 {
-  template <int... T> concept C = true;
-
-  namespace t1 {
-    template <int...> struct TplClass { // expected-note {{defined here}}
-      template <int... Ts, int... Us>
-      requires C<Ts...[0]>
-      static auto buggy() -> void;
-    };
-
-    template <>
-    template <int... Ts, int... Us>
-    requires C<Us...[0]>
-    auto TplClass<0>::buggy() -> void {}
-    // expected-error@-1 {{out-of-line definition of 'buggy' does not match any declaration}}
-  } // namespace t1
-  namespace t2 {
-    template <int...> struct TplClass { // expected-note {{defined here}}
-      template <int... Ts>
-      requires C<Ts...[0]>
-      static auto buggy() -> void;
-    };
-
-    template <>
-    template <int... Ts>
-    requires C<Ts...[1]>
-    auto TplClass<0>::buggy() -> void {}
-    // expected-error@-1 {{out-of-line definition of 'buggy' does not match any declaration}}
-  } // namespace t2
-  namespace t3 {
-    template <int... Us> struct TplClass { // expected-note {{defined here}}
-      template <int... Ts>
-      requires C<Us...[0]>
-      static auto buggy() -> void;
-    };
-
-    template <>
-    template <int... Ts>
-    requires C<Ts...[0]>
-    auto TplClass<0>::buggy() -> void {}
-    // expected-error@-1 {{out-of-line definition of 'buggy' does not match any declaration}}
-  } // namespace t3
-} // namespace PackIndexExpr2
-
-namespace FuncTemplateInClass {
-  template <int T> concept C = true;
-
-  namespace t1 {
-    template <int> struct TplClass {
-      template <int Ts>
-      requires C<Ts>
-      static auto buggy() -> void;
-    };
-
-    template <>
-    template <int Ts>
-    requires C<Ts>
-    auto TplClass<0>::buggy() -> void {}
-  } //namespace t1
-  namespace t2 {
-    template <int> struct TplClass { // expected-note {{defined here}}
-      template <int Ts, int Us>
-      requires C<Ts>
-      static auto buggy() -> void;
-    };
-
-    template <>
-    template <int Ts, int Us>
-    requires C<Us>
-    auto TplClass<0>::buggy() -> void {}
-    // expected-error@-1 {{out-of-line definition of 'buggy' does not match any declaration}}
-  } //namespace t2
-} // namespace FuncTemplateInClass
+}
 
 namespace GH139476 {
 


### PR DESCRIPTION
Reverts llvm/llvm-project#192806 , which is causing the compiler to reject some valid code.