### PR TITLE
Don't optimize out no-op atomics in kernel mode

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -313,6 +313,7 @@ Value *MakeBinaryAtomicValue(
 
   llvm::Value *Result =
       CGF.Builder.CreateAtomicRMW(Kind, DestAddr, Val, Ordering);
+  cast<llvm::AtomicRMWInst>(Result)->setVolatile(CGF.CGM.getLangOpts().Kernel);
   return EmitFromInt(CGF, Result, T, ValueType);
 }
 

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -313,7 +313,9 @@ Value *MakeBinaryAtomicValue(
 
   llvm::Value *Result =
       CGF.Builder.CreateAtomicRMW(Kind, DestAddr, Val, Ordering);
-  cast<llvm::AtomicRMWInst>(Result)->setVolatile(CGF.CGM.getLangOpts().Kernel);
+  // Consider atomics to be volatile in MS kernel mode.
+  if (CGF.CGM.getLangOpts().Kernel)
+    cast<llvm::AtomicRMWInst>(Result)->setVolatile(true);
   return EmitFromInt(CGF, Result, T, ValueType);
 }
 

--- a/clang/test/CodeGen/AArch64/mskernel-interlocked.c
+++ b/clang/test/CodeGen/AArch64/mskernel-interlocked.c
@@ -1,9 +1,6 @@
 // Check that we don't fold no-op andl to memory barrier
-// RUN: %clang_cc1 -fms-kernel -fms-extensions -Wno-implicit-function-declaration  -triple x86_64-pc-win32 -O2 -S -o - %s | FileCheck %s --check-prefix=X86
+// REQUIRES: aarch64-registered-target
 // RUN: %clang_cc1 -fms-kernel -fms-extensions -Wno-implicit-function-declaration  -triple aarch64-pc-win32 -O2 -S -o - %s | FileCheck %s --check-prefix=ARM64
-
-// X86:      lock andl $-1, (%rcx)
-// X86-NEXT: retq
 
 // ARM64:      ldaxr
 // ARM64-NEXT: stlxr

--- a/clang/test/CodeGen/MSKernel/interlocked.c
+++ b/clang/test/CodeGen/MSKernel/interlocked.c
@@ -1,0 +1,14 @@
+// Check that we don't fold no-op andl to memory barrier
+// RUN: %clang_cc1 -fms-kernel -fms-extensions -Wno-implicit-function-declaration  -triple x86_64-pc-win32 -O2 -S -o - %s | FileCheck %s --check-prefix=X86
+// RUN: %clang_cc1 -fms-kernel -fms-extensions -Wno-implicit-function-declaration  -triple aarch64-pc-win32 -O2 -S -o - %s | FileCheck %s --check-prefix=ARM64
+
+// X86:      lock andl $-1, (%rcx)
+// X86-NEXT: retq
+
+// ARM64:      ldaxr
+// ARM64-NEXT: stlxr
+// ARM64-NEXT: cbnz
+
+void access_via_interlocked(long volatile* addr) {
+    _InterlockedAnd(addr, (long)-1);
+}

--- a/clang/test/CodeGen/X86/mskernel-interlocked.c
+++ b/clang/test/CodeGen/X86/mskernel-interlocked.c
@@ -1,0 +1,10 @@
+// Check that we don't fold no-op andl to memory barrier
+// REQUIRES: x86-registered-target
+// RUN: %clang_cc1 -fms-kernel -fms-extensions -Wno-implicit-function-declaration  -triple x86_64-pc-win32 -O2 -S -o - %s | FileCheck %s --check-prefix=X86
+
+// X86:      lock andl $-1, (%rcx)
+// X86-NEXT: retq
+
+void access_via_interlocked(long volatile* addr) {
+    _InterlockedAnd(addr, (long)-1);
+}

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -1697,7 +1697,9 @@ bool AtomicExpandImpl::expandAtomicCmpXchg(AtomicCmpXchgInst *CI) {
 }
 
 bool AtomicExpandImpl::isIdempotentRMW(AtomicRMWInst *RMWI) {
-  // TODO: Add floating point support.
+  if (RMWI->isVolatile())
+    return false;
+  // TODO: Add floating point support.  
   auto C = dyn_cast<ConstantInt>(RMWI->getValOperand());
   if (!C)
     return false;

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -1699,7 +1699,7 @@ bool AtomicExpandImpl::expandAtomicCmpXchg(AtomicCmpXchgInst *CI) {
 bool AtomicExpandImpl::isIdempotentRMW(AtomicRMWInst *RMWI) {
   if (RMWI->isVolatile())
     return false;
-  // TODO: Add floating point support.  
+  // TODO: Add floating point support.
   auto C = dyn_cast<ConstantInt>(RMWI->getValOperand());
   if (!C)
     return false;

--- a/llvm/test/CodeGen/X86/volatile-atomicrmw.ll
+++ b/llvm/test/CodeGen/X86/volatile-atomicrmw.ll
@@ -1,0 +1,13 @@
+; RUN: opt -S -passes='require<libcall-lowering-info>,expand-ir-insts,atomic-expand' %s -o - | FileCheck %s
+
+; volatile atomicrmw shouldn't be converted to a fence
+; CHECK:  %0 = atomicrmw volatile and ptr %addr, i32 -1 seq_cst
+
+target triple = "x86_64-pc-windows-msvc"
+
+define dso_local void @access_via_interlocked(ptr noundef %addr) {
+entry:
+  %0 = atomicrmw volatile and ptr %addr, i32 -1 seq_cst, align 4
+  ret void
+}
+


### PR DESCRIPTION
The no-op atomics like InterlockedAnd(addr, (UINT32)-1) does not change the value, however kernel code relies on this to access a pool page VA to trigger a #PF during page migration.