### PR TITLE
[flang] Fix inline transfer for unsigned integer types

### DIFF
--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -8700,8 +8700,8 @@ IntrinsicLibrary::genTransfer(mlir::Type resultType,
           loc, resultType, builder.getDataLayout(), builder.getKindMap());
       if (sourceSizeAndAlign && resultSizeAndAlign &&
           sourceSizeAndAlign->first == resultSizeAndAlign->first) {
-        if (mlir::isa<mlir::IntegerType, mlir::FloatType>(sourceType) &&
-            mlir::isa<mlir::IntegerType, mlir::FloatType>(resultType)) {
+        if (sourceType.isSignlessIntOrFloat() &&
+            resultType.isSignlessIntOrFloat()) {
           mlir::Value val = fir::LoadOp::create(builder, loc, sourceBase);
           if (sourceType != resultType)
             val = mlir::arith::BitcastOp::create(builder, loc, resultType, val);

--- a/flang/test/Lower/Intrinsics/transfer-unsigned.f90
+++ b/flang/test/Lower/Intrinsics/transfer-unsigned.f90
@@ -1,0 +1,16 @@
+! RUN: %flang_fc1 -funsigned -emit-hlfir %s -o - | FileCheck %s
+
+! Unsigned integer transfer: arith.bitcast does not support unsigned types,
+! so this must use fir.convert on the address instead.
+subroutine trans_test_unsigned(store, src)
+  ! CHECK-LABEL: func @_QPtrans_test_unsigned(
+  ! CHECK:         %[[CAST:.*]] = fir.convert {{.*}} : (!fir.ref<i32>) -> !fir.ref<ui32>
+  ! CHECK:         %[[VAL:.*]] = fir.load %[[CAST]] : !fir.ref<ui32>
+  ! CHECK-NOT:     arith.bitcast
+  ! CHECK-NOT:     fir.call @_FortranATransfer
+  ! CHECK:         return
+  ! CHECK:       }
+  unsigned :: store
+  integer :: src
+  store = transfer(src, store)
+end subroutine


### PR DESCRIPTION
Fix a crash when transfer is used with Fortran unsigned types. The arith.bitcast op requires signless integer or float operands, but the inline optimization was applying it to unsigned integer types (ui32), causing a verification failure. Changed the guard from mlir::isa<mlir::IntegerType> to isSignlessIntOrFloat() so unsigned integer transfers fall through to the address-level fir.convert path instead.

This is to fix a regression reported here: https://github.com/llvm/llvm-project/pull/191589#issuecomment-4298846795