### PR TITLE
[VPlan] Factor vputils::shouldNarrow (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1864,37 +1864,8 @@ static void narrowToSingleScalarRecipes(VPlan &Plan) {
         continue;
       }
 
-      // Skip recipes that aren't single scalars.
-      if (!RepOrWidenR || !vputils::isSingleScalar(RepOrWidenR))
-        continue;
-
-      // Predicate to check if a user of Op introduces extra broadcasts.
-      auto IntroducesBCastOf = [](const VPValue *Op) {
-        return [Op](const VPUser *U) {
-          if (auto *VPI = dyn_cast<VPInstruction>(U)) {
-            if (is_contained({VPInstruction::ExtractLastLane,
-                              VPInstruction::ExtractLastPart,
-                              VPInstruction::ExtractPenultimateElement},
-                             VPI->getOpcode()))
-              return false;
-          }
-          return !U->usesScalars(Op);
-        };
-      };
-
-      if (any_of(RepOrWidenR->users(), IntroducesBCastOf(RepOrWidenR)) &&
-          none_of(RepOrWidenR->operands(), [&](VPValue *Op) {
-            if (any_of(
-                    make_filter_range(Op->users(), not_equal_to(RepOrWidenR)),
-                    IntroducesBCastOf(Op)))
-              return false;
-            // Non-constant live-ins require broadcasts, while constants do not
-            // need explicit broadcasts.
-            auto *IRV = dyn_cast<VPIRValue>(Op);
-            bool LiveInNeedsBroadcast = IRV && !isa<Constant>(IRV->getValue());
-            auto *OpR = dyn_cast<VPReplicateRecipe>(Op);
-            return LiveInNeedsBroadcast || (OpR && OpR->isSingleScalar());
-          }))
+      // Skip recipes that aren't desirable to narrow.
+      if (!RepOrWidenR || !vputils::shouldNarrow(RepOrWidenR))
         continue;
 
       auto *Clone = new VPReplicateRecipe(

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -442,6 +442,38 @@ bool vputils::isUniformAcrossVFsAndUFs(VPValue *V) {
       });
 }
 
+bool vputils::shouldNarrow(const VPSingleDefRecipe *R) {
+  // Predicate to check if a user of Op introduces extra broadcasts.
+  auto IntroducesBCastOf = [](const VPValue *Op) {
+    return [Op](const VPUser *U) {
+      if (auto *VPI = dyn_cast<VPInstruction>(U)) {
+        if (is_contained({VPInstruction::ExtractLastLane,
+                          VPInstruction::ExtractLastPart,
+                          VPInstruction::ExtractPenultimateElement},
+                         VPI->getOpcode()))
+          return false;
+      }
+      return !U->usesScalars(Op);
+    };
+  };
+
+  if (!vputils::isSingleScalar(R))
+    return false;
+
+  return none_of(R->users(), IntroducesBCastOf(R)) ||
+         any_of(R->operands(), [&](VPValue *Op) {
+           if (any_of(make_filter_range(Op->users(), not_equal_to(R)),
+                      IntroducesBCastOf(Op)))
+             return false;
+           // Non-constant live-ins require broadcasts, while constants do not
+           // need explicit broadcasts.
+           auto *IRV = dyn_cast<VPIRValue>(Op);
+           bool LiveInNeedsBroadcast = IRV && !isa<Constant>(IRV->getValue());
+           auto *OpR = dyn_cast<VPReplicateRecipe>(Op);
+           return LiveInNeedsBroadcast || (OpR && OpR->isSingleScalar());
+         });
+}
+
 VPBasicBlock *vputils::getFirstLoopHeader(VPlan &Plan, VPDominatorTree &VPDT) {
   auto DepthFirst = vp_depth_first_shallow(Plan.getEntry());
   auto I = find_if(DepthFirst, [&VPDT](VPBlockBase *VPB) {

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.h
@@ -64,6 +64,12 @@ bool isHeaderMask(const VPValue *V, const VPlan &Plan);
 /// VPDerivedIV or the canonical IV).
 bool isUniformAcrossVFsAndUFs(VPValue *V);
 
+/// Returns true if \p R is more profitable to consider a narrow recipe, as
+/// opposed to a wide one. In particular, check that the recipe is
+/// single-scalar, and that considering it narrow would lead to the elimination
+/// of some undesirable broadcasts.
+bool shouldNarrow(const VPSingleDefRecipe *R);
+
 /// Returns the header block of the first, top-level loop, or null if none
 /// exist.
 VPBasicBlock *getFirstLoopHeader(VPlan &Plan, VPDominatorTree &VPDT);


### PR DESCRIPTION
Factor out a vputils::shouldNarrow from narrowToSingleScalarRecipes, in order to enable reuse.