### PR TITLE
[libc++] Fix constant_wrapper::operator()

### DIFF
--- a/libcxx/include/__utility/constant_wrapper.h
+++ b/libcxx/include/__utility/constant_wrapper.h
@@ -278,14 +278,14 @@ struct __cw_operators {
   }
 };
 
-template <const auto& __callbale, class... _Args>
+template <const auto& _Callable, class... _Args>
 concept __constexpr_callable = (__constexpr_param<remove_cvref_t<_Args>> && ...) && requires {
-  typename constant_wrapper<std::invoke(__callbale, remove_cvref_t<_Args>::value...)>;
+  typename constant_wrapper<std::invoke(_Callable, remove_cvref_t<_Args>::value...)>;
 };
 
-template <const auto& __obj, class... _Args>
+template <const auto& _Obj, class... _Args>
 concept __constexpr_indexable = (__constexpr_param<remove_cvref_t<_Args>> && ...) && requires {
-  typename constant_wrapper<__obj[remove_cvref_t<_Args>::value...]>;
+  typename constant_wrapper<_Obj[remove_cvref_t<_Args>::value...]>;
 };
 
 template <__cw_fixed_value _Xp, class>

--- a/libcxx/include/__utility/constant_wrapper.h
+++ b/libcxx/include/__utility/constant_wrapper.h
@@ -306,7 +306,7 @@ struct constant_wrapper : __cw_operators {
     requires __constexpr_callable<value, _Args...>
   [[nodiscard]]
   _LIBCPP_HIDE_FROM_ABI static constexpr constant_wrapper<std::invoke(value, remove_cvref_t<_Args>::value...)>
-  operator()(_Args&&... __args) noexcept {
+  operator()(_Args&&...) noexcept {
     return {};
   }
 

--- a/libcxx/include/__utility/constant_wrapper.h
+++ b/libcxx/include/__utility/constant_wrapper.h
@@ -12,8 +12,10 @@
 #include <__config>
 #include <__cstddef/size_t.h>
 #include <__functional/invoke.h>
+#include <__type_traits/invoke.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/remove_cvref.h>
+#include <__utility/declval.h>
 #include <__utility/forward.h>
 #include <__utility/integer_sequence.h>
 
@@ -276,42 +278,22 @@ struct __cw_operators {
   }
 };
 
+template <const auto& __callbale, class... _Args>
+concept __constexpr_callable = (__constexpr_param<remove_cvref_t<_Args>> && ...) && requires {
+  typename constant_wrapper<std::invoke(__callbale, remove_cvref_t<_Args>::value...)>;
+};
+
+template <const auto& __obj, class... _Args>
+concept __constexpr_indexable = (__constexpr_param<remove_cvref_t<_Args>> && ...) && requires {
+  typename constant_wrapper<__obj[remove_cvref_t<_Args>::value...]>;
+};
+
 template <__cw_fixed_value _Xp, class>
 struct constant_wrapper : __cw_operators {
   static constexpr const auto& value = _Xp.__data;
   using type                         = constant_wrapper;
   using value_type                   = decltype(_Xp)::__type;
 
-private:
-  template <class... _Args>
-    requires(__constexpr_param<remove_cvref_t<_Args>> && ...)
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __call(_Args&&...) noexcept
-      -> constant_wrapper<std::invoke(value, remove_cvref_t<_Args>::value...)> {
-    return {};
-  }
-
-  template <class... _Args>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto
-  __call(_Args&&... __args) noexcept(noexcept(std::invoke(value, std::forward<_Args>(__args)...)))
-      -> decltype(std::invoke(value, std::forward<_Args>(__args)...)) {
-    return std::invoke(value, std::forward<_Args>(__args)...);
-  }
-
-  template <class... _Args>
-    requires(__constexpr_param<remove_cvref_t<_Args>> && ...)
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __subscript(_Args&&...) noexcept
-      -> constant_wrapper<value[remove_cvref_t<_Args>::value...]> {
-    return {};
-  }
-
-  template <class... _Args>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto
-  __subscript(_Args&&... __args) noexcept(noexcept(value[std::forward<_Args>(__args)...]))
-      -> decltype(value[std::forward<_Args>(__args)...]) {
-    return value[std::forward<_Args>(__args)...];
-  }
-
-public:
   template <__constexpr_param _Rp>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator=(_Rp) const noexcept
       -> constant_wrapper<(value = _Rp::value)> {
@@ -321,17 +303,33 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr operator decltype(value)() const noexcept { return value; }
 
   template <class... _Args>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto
-  operator()(_Args&&... __args) noexcept(noexcept(constant_wrapper::__call(std::forward<_Args>(__args)...)))
-      -> decltype(constant_wrapper::__call(std::forward<_Args>(__args)...)) {
-    return __call(std::forward<_Args>(__args)...);
+    requires __constexpr_callable<value, _Args...>
+  [[nodiscard]]
+  _LIBCPP_HIDE_FROM_ABI static constexpr constant_wrapper<std::invoke(value, remove_cvref_t<_Args>::value...)>
+  operator()(_Args&&... __args) noexcept {
+    return {};
   }
 
   template <class... _Args>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto
-  operator[](_Args&&... __args) noexcept(noexcept(constant_wrapper::__subscript(std::forward<_Args>(__args)...)))
-      -> decltype(constant_wrapper::__subscript(std::forward<_Args>(__args)...)) {
-    return __subscript(std::forward<_Args>(__args)...);
+    requires(!__constexpr_callable<value, _Args...> && is_invocable_v<const value_type&, _Args && ...>)
+  _LIBCPP_HIDE_FROM_ABI static constexpr decltype(auto)
+  operator()(_Args&&... __args) noexcept(noexcept(std::invoke(value, std::forward<_Args>(__args)...))) {
+    return std::invoke(value, std::forward<_Args>(__args)...);
+  }
+
+  template <class... _Args>
+    requires __constexpr_indexable<value, _Args...>
+  [[nodiscard]]
+  _LIBCPP_HIDE_FROM_ABI static constexpr constant_wrapper<value[remove_cvref_t<_Args>::value...]>
+  operator[](_Args&&...) noexcept {
+    return {};
+  }
+
+  template <class... _Args>
+    requires(!__constexpr_indexable<value, _Args...> && requires { value[std::declval<_Args>()...]; })
+  _LIBCPP_HIDE_FROM_ABI static constexpr decltype(auto)
+  operator[](_Args&&... __args) noexcept(noexcept(value[std::forward<_Args>(__args)...])) {
+    return value[std::forward<_Args>(__args)...];
   }
 };
 

--- a/libcxx/test/libcxx/utilities/const.wrap.class/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/utilities/const.wrap.class/nodiscard.verify.cpp
@@ -35,6 +35,9 @@ struct Ops {
   constexpr Ops operator>>=(Ops) const { return {}; }
 
   constexpr Ops operator=(auto) const { return {}; }
+
+  constexpr Ops operator()(Ops) const { return {}; }
+  constexpr Ops operator[](Ops) const { return {}; }
 };
 
 void test() {
@@ -140,4 +143,10 @@ void test() {
   std::constant_wrapper<Ops{}> a;
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   a = std::cw<5>;
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::cw<Ops{}>(std::cw<Ops{}>);
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::cw<Ops{}>[std::cw<Ops{}>];
 }

--- a/libcxx/test/std/utilities/const.wrap.class/call.pass.cpp
+++ b/libcxx/test/std/utilities/const.wrap.class/call.pass.cpp
@@ -82,6 +82,18 @@ static_assert(std::is_nothrow_invocable_v<std::constant_wrapper<throwing_call>, 
               "the call expression is still nothrow because the constexpr path is taken");
 // clang-format on
 
+template <class T>
+struct MustBeInt {
+  static_assert(std::same_as<T, int>);
+};
+
+struct Poison {
+  template <class T>
+  constexpr auto operator()(T) const noexcept -> MustBeInt<T> {
+    return {};
+  }
+};
+
 constexpr bool test() {
   {
     // with runtime param
@@ -225,6 +237,12 @@ constexpr bool test() {
     std::integral_constant<int, 2> ic2;
     std::same_as<std::constant_wrapper<3>> decltype(auto) result = T::operator()(ic1, ic2);
     static_assert(result == 3);
+  }
+
+  {
+    using T = std::constant_wrapper<Poison{}>;
+    [[maybe_unused]] std::same_as<std::constant_wrapper<MustBeInt<int>{}>> decltype(auto) result =
+        T::operator()(std::cw<5>);
   }
 
   return true;

--- a/libcxx/test/std/utilities/const.wrap.class/subscript.pass.cpp
+++ b/libcxx/test/std/utilities/const.wrap.class/subscript.pass.cpp
@@ -85,6 +85,18 @@ static_assert(!HasNothrowSubscript<std::constant_wrapper<ThrowingSubscript{}>, i
 static_assert(HasNothrowSubscript<std::constant_wrapper<ThrowingSubscript{}>, std::constant_wrapper<1>>,
               "the subscript expression is still nothrow because the constexpr path is taken");
 
+template <class T>
+struct MustBeInt {
+  static_assert(std::same_as<T, int>);
+};
+
+struct Poison {
+  template <class T>
+  constexpr auto operator[](T) const noexcept -> MustBeInt<T> {
+    return {};
+  }
+};
+
 constexpr bool test() {
   {
     // with runtime param
@@ -170,6 +182,12 @@ constexpr bool test() {
     using T                                                      = std::constant_wrapper<arr>;
     std::same_as<std::constant_wrapper<2>> decltype(auto) result = T::operator[](std::integral_constant<int, 1>{});
     static_assert(result == 2);
+  }
+
+  {
+    using T = std::constant_wrapper<Poison{}>;
+    [[maybe_unused]] std::same_as<std::constant_wrapper<MustBeInt<int>{}>> decltype(auto) result =
+        T::operator[](std::cw<5>);
   }
 
   return true;


### PR DESCRIPTION
As Tomasz pointed out on mattermost, 
given

```cpp
template <class T>
struct MustBeInt {
  static_assert(std::same_as<T, int>);
};

struct Poison {
  template <class T>
  constexpr auto operator()(T) const noexcept -> MustBeInt<T> {
    return {};
  }
};

std::cw<Poison{}>(std::cw<5>);
```

This should work according to the wording https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3978r3.pdf

```cpp
template<class... Args>
static constexpr decltype(auto) operator()(Args&&... args) noexcept(see below);
```

```
- Let call-expr be constant_wrapper<INVOKE (value, remove_cvref_t<Args>::value...)>{} if all types
in remove_cvref_t<Args>... satisfy constexpr-param and constant_wrapper<INVOKE (value, remove_-
cvref_t<Args>::value...)> is a valid type, otherwise let call-expr be INVOKE (value, std::forward<Args>(args)...).
- Constraints: call-expr is a valid expression.
- Effects: Equivalent to: return call-expr;
- Remarks: The exception specification is equivalent to noexcept(call-expr).
```

so basically the spec says, there are two cases
- constexpr-param case
-  runtime case

and if constexpr-param case works, uses it, otherwise fallback to runtime case if it is valid, otherwise substitution error.

In this case, `std::cw<5>` satisfy `constexpr-param`, and `constant_wrapper<Poison{}(5)>` is valid , it should just work. however, our implementation implemented the two cases in two overload

```cpp
template <class... _Args>
    requires(__constexpr_param<remove_cvref_t<_Args>> && ...)
  _LIBCPP_HIDE_FROM_ABI static constexpr auto __call(_Args&&...) noexcept
      -> constant_wrapper<std::invoke(value, remove_cvref_t<_Args>::value...)> {
  return {};
  }

 template <class... _Args>
  _LIBCPP_HIDE_FROM_ABI static constexpr auto
  __call(_Args&&... __args) noexcept(noexcept(std::invoke(value, std::forward<_Args>(__args)...)))
      -> decltype(std::invoke(value, std::forward<_Args>(__args)...)) {
    return std::invoke(value, std::forward<_Args>(__args)...);
  }
```

The logic is that, both overloads use return type SFINAE and the constexpr-param case's concept is more constrained so it will be picked first if constexpr-param case works.

However, in this example, the second overload's return type SFINAE causes a hard error by the `static_assert` in the user code.

The fix is simply constrain the second overload and not using return type SFINAE so it short circuits if constexpr-param case is valid.


As a drive by, removed the internal helper function and directly make the public interface `operator()` two overloads so that we can apply `[[nodiscard]]` on the constexpr-param case
