### PR TITLE
[NFC] Add check lines to concepts-out-of-line-def.cpp to fix failure

### DIFF
--- a/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
+++ b/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
@@ -842,7 +842,7 @@ namespace PackIndexExpr {
 template <int... T>
 concept C = true;
 
-template <typename...> struct TplClass {
+template <typename...> struct TplClass { // #TplClassDef
   template <int... Ts>
   requires C<Ts...[0]>
   static auto buggy() -> void;
@@ -852,6 +852,10 @@ template <>
 template <int... Ts>
 requires C<Ts...[0]>
 auto TplClass<int>::buggy() -> void {}
+// FIXME: These shouldn't diagnose, but are a result of a revert: #193558
+// expected-error@-2{{does not match any declaration in}}
+// expected-note@#TplClassDef{{TplClass defined here}}
+//
 }
 
 namespace GH139476 {


### PR DESCRIPTION
Revert in #193558 failed to correct a test that was fixed in the meantime, and was dependent on this.  This patch adds a check-line to make CI go green again.