### PR TITLE
Revert "[clang] fix profiling of pack index expressions"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -523,8 +523,7 @@ Bug Fixes to C++ Support
 - Clang incorrectly instantiated variable specializations outside of the immediate context. (#GH54439)
 - Fixed a crash when instantiating an invalid out-of-line static data member definition in a local class. (#GH176152)
 - Fixed a crash when pack expansions are used as arguments for non-pack parameters of built-in templates. (#GH180307)
-- Fix a problem where pack index expressions where incorrectly being regarded as equivalent.
-- Fixed a bug where captured variables in non-mutable lambdas were incorrectly treated as mutable
+- Fixed a bug where captured variables in non-mutable lambdas were incorrectly treated as mutable 
   when used inside decltype in the return type. (#GH180460)
 - Fixed a crash when evaluating uninitialized GCC vector/ext_vector_type vectors in ``constexpr``. (#GH180044)
 - Fixed a crash when `explicit(bool)` is used with an incomplete enumeration. (#GH183887)

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -2362,14 +2362,14 @@ void StmtProfiler::VisitSizeOfPackExpr(const SizeOfPackExpr *S) {
 }
 
 void StmtProfiler::VisitPackIndexingExpr(const PackIndexingExpr *E) {
-  VisitStmtNoChildren(E);
-  Visit(E->getIndexExpr());
+  VisitExpr(E->getIndexExpr());
+
   if (E->expandsToEmptyPack() || E->getExpressions().size() != 0) {
     ID.AddInteger(E->getExpressions().size());
     for (const Expr *Sub : E->getExpressions())
       Visit(Sub);
   } else {
-    Visit(E->getPackIdExpression());
+    VisitExpr(E->getPackIdExpression());
   }
 }
 

--- a/clang/test/SemaCXX/cxx2c-pack-indexing.cpp
+++ b/clang/test/SemaCXX/cxx2c-pack-indexing.cpp
@@ -344,13 +344,3 @@ namespace GH123033 {
       convert<int, int>(12.34);
   }
 }
-
-namespace PackIndexExprEquivalency1 {
-  template <int... Ts, int... Us>
-    requires (Ts...[0] != 0)
-    void f() {}
-
-  template <int... Ts, int... Us>
-    requires (Us...[0] != 0)
-    void f() {}
-} // namespace PackIndexExprEquivalency1


### PR DESCRIPTION
Reverts llvm/llvm-project#192810

This is needed to fix the BuildBot breakages after a related commit was reverted in https://github.com/llvm/llvm-project/pull/193558.