### PR TITLE
[Analysis] Ignore convergence tokens in dead branches in `CodeMetrics`

### DIFF
--- a/llvm/lib/Analysis/CodeMetrics.cpp
+++ b/llvm/lib/Analysis/CodeMetrics.cpp
@@ -16,6 +16,7 @@
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/InstructionCost.h"
@@ -118,7 +119,12 @@ static bool extendsConvergenceOutsideLoop(const Instruction &I, const Loop *L) {
   if (!isa<ConvergenceControlInst>(I))
     return false;
   for (const auto *U : I.users()) {
-    if (!L->contains(cast<Instruction>(U)))
+    const auto *UserInst = cast<Instruction>(U);
+    // Ignore users in dead branches, identified by blocks terminated with
+    // unreachable.
+    if (isa<UnreachableInst>(UserInst->getParent()->getTerminator()))
+      continue;
+    if (!L->contains(UserInst))
       return true;
   }
   return false;

--- a/llvm/lib/Analysis/CodeMetrics.cpp
+++ b/llvm/lib/Analysis/CodeMetrics.cpp
@@ -113,6 +113,28 @@ void CodeMetrics::collectEphemeralValues(
   completeEphemeralValues(Visited, Worklist, EphValues);
 }
 
+/// Check if a block is dead. A block is determined dead if it is terminated by
+/// unreachable and all predecessors are statically known condiational branches
+/// to not go to the branch.
+static bool isDeadBlock(const BasicBlock *BB) {
+  if (!isa<UnreachableInst>(BB->getTerminator()))
+    return false;
+  for (const BasicBlock *Pred : predecessors(BB)) {
+    auto *CondBr = dyn_cast<CondBrInst>(Pred->getTerminator());
+    if (!CondBr)
+      return false;
+    auto *Cond = dyn_cast<ConstantInt>(CondBr->getCondition());
+    if (!Cond)
+      return false;
+    // Check that the dead block is on the not-taken edge.
+    BasicBlock *TakenSucc =
+        Cond->isOne() ? CondBr->getSuccessor(0) : CondBr->getSuccessor(1);
+    if (TakenSucc == BB)
+      return false;
+  }
+  return true;
+}
+
 static bool extendsConvergenceOutsideLoop(const Instruction &I, const Loop *L) {
   if (!L)
     return false;
@@ -120,9 +142,9 @@ static bool extendsConvergenceOutsideLoop(const Instruction &I, const Loop *L) {
     return false;
   for (const auto *U : I.users()) {
     const auto *UserInst = cast<Instruction>(U);
-    // Ignore users in dead branches, identified by blocks terminated with
-    // unreachable.
-    if (isa<UnreachableInst>(UserInst->getParent()->getTerminator()))
+    // Ignore users in dead blocks. These can be of a fully unrolled inner loop
+    // where the exit condition was folded.
+    if (isDeadBlock(UserInst->getParent()))
       continue;
     if (!L->contains(UserInst))
       return true;

--- a/llvm/lib/Analysis/CodeMetrics.cpp
+++ b/llvm/lib/Analysis/CodeMetrics.cpp
@@ -114,8 +114,8 @@ void CodeMetrics::collectEphemeralValues(
 }
 
 /// Check if a block is dead. A block is determined dead if it is terminated by
-/// unreachable and all predecessors are statically known condiational branches
-/// to not go to the branch.
+/// unreachable and all predecessors are statically known conditional branches
+/// that do not branch to the block.
 static bool isDeadBlock(const BasicBlock *BB) {
   if (BB->isEntryBlock())
     return false;

--- a/llvm/lib/Analysis/CodeMetrics.cpp
+++ b/llvm/lib/Analysis/CodeMetrics.cpp
@@ -117,6 +117,8 @@ void CodeMetrics::collectEphemeralValues(
 /// unreachable and all predecessors are statically known condiational branches
 /// to not go to the branch.
 static bool isDeadBlock(const BasicBlock *BB) {
+  if (BB->isEntryBlock())
+    return false;
   if (!isa<UnreachableInst>(BB->getTerminator()))
     return false;
   for (const BasicBlock *Pred : predecessors(BB)) {

--- a/llvm/lib/Analysis/CodeMetrics.cpp
+++ b/llvm/lib/Analysis/CodeMetrics.cpp
@@ -113,12 +113,11 @@ void CodeMetrics::collectEphemeralValues(
   completeEphemeralValues(Visited, Worklist, EphValues);
 }
 
-/// Check if a block is dead. A block is determined dead if it is terminated by
-/// unreachable and all predecessors are statically known conditional branches
-/// that do not branch to the block.
-static bool isDeadBlock(const BasicBlock *BB) {
-  if (BB->isEntryBlock())
-    return false;
+/// Check if a block was previously marked dead by setting the terminator to
+/// `unreachable` and the condiational branch to the block is statically
+/// evaluated. This is done for instance within the unroll pass, between
+/// unrolling inner/outer loops.
+static bool isBlockMarkedDead(const BasicBlock *BB) {
   if (!isa<UnreachableInst>(BB->getTerminator()))
     return false;
   for (const BasicBlock *Pred : predecessors(BB)) {
@@ -144,9 +143,7 @@ static bool extendsConvergenceOutsideLoop(const Instruction &I, const Loop *L) {
     return false;
   for (const auto *U : I.users()) {
     const auto *UserInst = cast<Instruction>(U);
-    // Ignore users in dead blocks. These can be of a fully unrolled inner loop
-    // where the exit condition was folded.
-    if (isDeadBlock(UserInst->getParent()))
+    if (isBlockMarkedDead(UserInst->getParent()))
       continue;
     if (!L->contains(UserInst))
       return true;

--- a/llvm/lib/Analysis/CodeMetrics.cpp
+++ b/llvm/lib/Analysis/CodeMetrics.cpp
@@ -114,9 +114,9 @@ void CodeMetrics::collectEphemeralValues(
 }
 
 /// Check if a block was previously marked dead by setting the terminator to
-/// `unreachable` and the condiational branch to the block is statically
-/// evaluated. This is done for instance within the unroll pass, between
-/// unrolling inner/outer loops.
+/// `unreachable` and their is a statically evaluated conditional branch to NOT
+/// branch to the block. This is done for instance within the unroll pass,
+/// between unrolling inner/outer loops.
 static bool isBlockMarkedDead(const BasicBlock *BB) {
   if (!isa<UnreachableInst>(BB->getTerminator()))
     return false;

--- a/llvm/test/Transforms/LoopUnroll/convergent.controlled.ll
+++ b/llvm/test/Transforms/LoopUnroll/convergent.controlled.ll
@@ -555,6 +555,64 @@ exit:
   ret i32 0
 }
 
+; A convergence token defined in the loop is used outside the loop, but only
+; in a dead branch (block terminated by unreachable). This should not prevent
+; unrolling.
+define i32 @extended_loop_dead_branch(i32 %n) {
+; CHECK-LABEL: @extended_loop_dead_branch(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TMP0:%.*]] = freeze i32 [[N:%.*]]
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[TMP0]], -1
+; CHECK-NEXT:    [[XTRAITER:%.*]] = and i32 [[TMP0]], 1
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult i32 [[TMP1]], 1
+; CHECK-NEXT:    br i1 [[TMP2]], label [[L3_EPIL_PREHEADER:%.*]], label [[ENTRY_NEW:%.*]]
+; CHECK:       entry.new:
+; CHECK-NEXT:    [[UNROLL_ITER:%.*]] = sub i32 [[TMP0]], [[XTRAITER]]
+; CHECK-NEXT:    br label [[L3:%.*]], !llvm.loop [[LOOP4]]
+; CHECK:       l3:
+; CHECK-NEXT:    [[X_0:%.*]] = phi i32 [ 0, [[ENTRY_NEW]] ], [ [[INC_1:%.*]], [[L3]] ]
+; CHECK-NEXT:    [[NITER:%.*]] = phi i32 [ 0, [[ENTRY_NEW]] ], [ [[NITER_NEXT_1:%.*]], [[L3]] ]
+; CHECK-NEXT:    [[TOK_LOOP:%.*]] = call token @llvm.experimental.convergence.anchor()
+; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_LOOP]]) ]
+; CHECK-NEXT:    [[TOK_LOOP_1:%.*]] = call token @llvm.experimental.convergence.anchor()
+; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_LOOP_1]]) ]
+; CHECK-NEXT:    [[INC_1]] = add nsw i32 [[X_0]], 2
+; CHECK-NEXT:    [[NITER_NEXT_1]] = add i32 [[NITER]], 2
+; CHECK-NEXT:    [[NITER_NCMP_1:%.*]] = icmp eq i32 [[NITER_NEXT_1]], [[UNROLL_ITER]]
+; CHECK-NEXT:    br i1 [[NITER_NCMP_1]], label [[EXIT_UNR_LCSSA:%.*]], label [[L3]], !llvm.loop [[LOOP10:![0-9]+]]
+; CHECK:       exit.unr-lcssa:
+; CHECK-NEXT:    [[LCMP_MOD:%.*]] = icmp ne i32 [[XTRAITER]], 0
+; CHECK-NEXT:    br i1 [[LCMP_MOD]], label [[L3_EPIL_PREHEADER]], label [[EXIT:%.*]]
+; CHECK:       l3.epil.preheader:
+; CHECK-NEXT:    [[LCMP_MOD1:%.*]] = icmp ne i32 [[XTRAITER]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[LCMP_MOD1]])
+; CHECK-NEXT:    br label [[L3_EPIL:%.*]]
+; CHECK:       l3.epil:
+; CHECK-NEXT:    [[TOK_LOOP_EPIL:%.*]] = call token @llvm.experimental.convergence.anchor()
+; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_LOOP_EPIL]]) ]
+; CHECK-NEXT:    br label [[EXIT]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret i32 0
+;
+entry:
+  br label %l3, !llvm.loop !1
+
+l3:
+  %x.0 = phi i32 [ 0, %entry ], [ %inc, %l3 ]
+  %tok.loop = call token @llvm.experimental.convergence.anchor()
+  call void @f() [ "convergencectrl"(token %tok.loop) ]
+  %inc = add nsw i32 %x.0, 1
+  %exitcond = icmp eq i32 %inc, %n
+  br i1 %exitcond, label %exit, label %l3, !llvm.loop !1
+
+exit:
+  ret i32 0
+
+dead:
+  call void @f() [ "convergencectrl"(token %tok.loop) ]
+  unreachable
+}
+
 declare token @llvm.experimental.convergence.anchor()
 declare token @llvm.experimental.convergence.loop()
 

--- a/llvm/test/Transforms/LoopUnroll/convergent.controlled.ll
+++ b/llvm/test/Transforms/LoopUnroll/convergent.controlled.ll
@@ -555,55 +555,62 @@ exit:
   ret i32 0
 }
 
-; A convergence token defined in the loop is used outside the loop, but only
-; in a dead branch (block terminated by unreachable). This should not prevent
-; unrolling.
+; The input represents the state after an inner loop has been fully unrolled
+; inside an outer loop. The old inner loop body becomes dead (marked
+; unreachable and conditional branch is statically known) but still has a
+; predecessor from the unrolled code. A convergence token defined in the outer
+; loop is used in the dead block, which should not prevent unrolling of the
+; outer loop.
 define i32 @extended_loop_dead_branch(i32 %n) {
 ; CHECK-LABEL: @extended_loop_dead_branch(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = freeze i32 [[N:%.*]]
-; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[TMP0]], -1
-; CHECK-NEXT:    [[XTRAITER:%.*]] = and i32 [[TMP0]], 1
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult i32 [[TMP1]], 1
-; CHECK-NEXT:    br i1 [[TMP2]], label [[L3_EPIL_PREHEADER:%.*]], label [[ENTRY_NEW:%.*]]
-; CHECK:       entry.new:
-; CHECK-NEXT:    [[UNROLL_ITER:%.*]] = sub i32 [[TMP0]], [[XTRAITER]]
-; CHECK-NEXT:    br label [[L3:%.*]], !llvm.loop [[LOOP4]]
-; CHECK:       l3:
-; CHECK-NEXT:    [[X_0:%.*]] = phi i32 [ 0, [[ENTRY_NEW]] ], [ [[INC_1:%.*]], [[L3]] ]
-; CHECK-NEXT:    [[NITER:%.*]] = phi i32 [ 0, [[ENTRY_NEW]] ], [ [[NITER_NEXT_1:%.*]], [[L3]] ]
+; CHECK-NEXT:    br label [[OUTER:%.*]]
+; CHECK:       outer:
+; CHECK-NEXT:    [[X_0:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_1:%.*]], [[OUTER_LATCH_1:%.*]] ]
 ; CHECK-NEXT:    [[TOK_LOOP:%.*]] = call token @llvm.experimental.convergence.anchor()
-; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_LOOP]]) ]
-; CHECK-NEXT:    [[TOK_LOOP_1:%.*]] = call token @llvm.experimental.convergence.anchor()
-; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_LOOP_1]]) ]
+; CHECK-NEXT:    [[TOK_INNER_0:%.*]] = call token @llvm.experimental.convergence.anchor()
+; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_INNER_0]]) ]
+; CHECK-NEXT:    [[TOK_INNER_1:%.*]] = call token @llvm.experimental.convergence.anchor()
+; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_INNER_1]]) ]
+; CHECK-NEXT:    br i1 false, label [[DEAD:%.*]], label [[OUTER_LATCH:%.*]]
+; CHECK:       outer.latch:
+; CHECK-NEXT:    [[INC:%.*]] = add nuw nsw i32 [[X_0]], 1
+; CHECK-NEXT:    [[EXITCOND:%.*]] = icmp eq i32 [[INC]], [[N:%.*]]
+; CHECK-NEXT:    br i1 [[EXITCOND]], label [[EXIT:%.*]], label [[OUTER_1:%.*]]
+; CHECK:       outer.1:
+; CHECK-NEXT:    [[TOK_INNER_0_1:%.*]] = call token @llvm.experimental.convergence.anchor()
+; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_INNER_0_1]]) ]
+; CHECK-NEXT:    [[TOK_INNER_1_1:%.*]] = call token @llvm.experimental.convergence.anchor()
+; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_INNER_1_1]]) ]
+; CHECK-NEXT:    br i1 false, label [[DEAD]], label [[OUTER_LATCH_1]]
+; CHECK:       outer.latch.1:
 ; CHECK-NEXT:    [[INC_1]] = add nsw i32 [[X_0]], 2
-; CHECK-NEXT:    [[NITER_NEXT_1]] = add i32 [[NITER]], 2
-; CHECK-NEXT:    [[NITER_NCMP_1:%.*]] = icmp eq i32 [[NITER_NEXT_1]], [[UNROLL_ITER]]
-; CHECK-NEXT:    br i1 [[NITER_NCMP_1]], label [[EXIT_UNR_LCSSA:%.*]], label [[L3]], !llvm.loop [[LOOP10:![0-9]+]]
-; CHECK:       exit.unr-lcssa:
-; CHECK-NEXT:    [[LCMP_MOD:%.*]] = icmp ne i32 [[XTRAITER]], 0
-; CHECK-NEXT:    br i1 [[LCMP_MOD]], label [[L3_EPIL_PREHEADER]], label [[EXIT:%.*]]
-; CHECK:       l3.epil.preheader:
-; CHECK-NEXT:    [[LCMP_MOD1:%.*]] = icmp ne i32 [[XTRAITER]], 0
-; CHECK-NEXT:    call void @llvm.assume(i1 [[LCMP_MOD1]])
-; CHECK-NEXT:    br label [[L3_EPIL:%.*]]
-; CHECK:       l3.epil:
-; CHECK-NEXT:    [[TOK_LOOP_EPIL:%.*]] = call token @llvm.experimental.convergence.anchor()
-; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_LOOP_EPIL]]) ]
-; CHECK-NEXT:    br label [[EXIT]]
+; CHECK-NEXT:    [[EXITCOND_1:%.*]] = icmp eq i32 [[INC_1]], [[N]]
+; CHECK-NEXT:    br i1 [[EXITCOND_1]], label [[EXIT]], label [[OUTER]], !llvm.loop [[LOOP10:![0-9]+]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret i32 0
+; CHECK:       dead:
+; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_LOOP]]) ]
+; CHECK-NEXT:    unreachable
 ;
 entry:
-  br label %l3, !llvm.loop !1
+  br label %outer
 
-l3:
-  %x.0 = phi i32 [ 0, %entry ], [ %inc, %l3 ]
+outer:
+  %x.0 = phi i32 [ 0, %entry ], [ %inc, %outer.latch ]
   %tok.loop = call token @llvm.experimental.convergence.anchor()
-  call void @f() [ "convergencectrl"(token %tok.loop) ]
+  ; Unrolled inner iteration 0
+  %tok.inner.0 = call token @llvm.experimental.convergence.anchor()
+  call void @f() [ "convergencectrl"(token %tok.inner.0) ]
+  ; Unrolled inner iteration 1, exit condition folded
+  %tok.inner.1 = call token @llvm.experimental.convergence.anchor()
+  call void @f() [ "convergencectrl"(token %tok.inner.1) ]
+  br i1 false, label %dead, label %outer.latch
+
+outer.latch:
   %inc = add nsw i32 %x.0, 1
   %exitcond = icmp eq i32 %inc, %n
-  br i1 %exitcond, label %exit, label %l3, !llvm.loop !1
+  br i1 %exitcond, label %exit, label %outer, !llvm.loop !1
 
 exit:
   ret i32 0

--- a/llvm/test/Transforms/LoopUnroll/convergent.controlled.ll
+++ b/llvm/test/Transforms/LoopUnroll/convergent.controlled.ll
@@ -620,6 +620,59 @@ dead:
   unreachable
 }
 
+; Similar to extended_loop_dead_branch, but the branch to the block with the
+; convergence token use is NOT statically known to be dead (the condition is
+; dynamic). The outer loop should NOT be unrolled because the convergence token
+; extends outside the loop.
+define i32 @extended_loop_not_dead_branch(i32 %n, i1 %cond) {
+; CHECK-LABEL: @extended_loop_not_dead_branch(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br label [[OUTER:%.*]]
+; CHECK:       outer:
+; CHECK-NEXT:    [[X_0:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC:%.*]], [[OUTER_LATCH:%.*]] ]
+; CHECK-NEXT:    [[TOK_LOOP:%.*]] = call token @llvm.experimental.convergence.anchor()
+; CHECK-NEXT:    [[TOK_INNER_0:%.*]] = call token @llvm.experimental.convergence.anchor()
+; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_INNER_0]]) ]
+; CHECK-NEXT:    [[TOK_INNER_1:%.*]] = call token @llvm.experimental.convergence.anchor()
+; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_INNER_1]]) ]
+; CHECK-NEXT:    br i1 [[COND:%.*]], label [[DEAD:%.*]], label [[OUTER_LATCH]]
+; CHECK:       outer.latch:
+; CHECK-NEXT:    [[INC]] = add nsw i32 [[X_0]], 1
+; CHECK-NEXT:    [[EXITCOND:%.*]] = icmp eq i32 [[INC]], [[N:%.*]]
+; CHECK-NEXT:    br i1 [[EXITCOND]], label [[EXIT:%.*]], label [[OUTER]], !llvm.loop [[LOOP4]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret i32 0
+; CHECK:       dead:
+; CHECK-NEXT:    call void @f() [ "convergencectrl"(token [[TOK_LOOP]]) ]
+; CHECK-NEXT:    unreachable
+;
+entry:
+  br label %outer
+
+outer:
+  %x.0 = phi i32 [ 0, %entry ], [ %inc, %outer.latch ]
+  %tok.loop = call token @llvm.experimental.convergence.anchor()
+  ; Unrolled inner iteration 0
+  %tok.inner.0 = call token @llvm.experimental.convergence.anchor()
+  call void @f() [ "convergencectrl"(token %tok.inner.0) ]
+  ; Unrolled inner iteration 1
+  %tok.inner.1 = call token @llvm.experimental.convergence.anchor()
+  call void @f() [ "convergencectrl"(token %tok.inner.1) ]
+  br i1 %cond, label %dead, label %outer.latch
+
+outer.latch:
+  %inc = add nsw i32 %x.0, 1
+  %exitcond = icmp eq i32 %inc, %n
+  br i1 %exitcond, label %exit, label %outer, !llvm.loop !1
+
+exit:
+  ret i32 0
+
+dead:
+  call void @f() [ "convergencectrl"(token %tok.loop) ]
+  unreachable
+}
+
 declare token @llvm.experimental.convergence.anchor()
 declare token @llvm.experimental.convergence.loop()
 


### PR DESCRIPTION
In `extendsConvergenceOutsideLoop`, skip users whose parent block is terminated by unreachable and which are statically known to not branch to anymore, as these represent dead branches. This prevents convergence control tokens in dead code from incorrectly marking a loop as having extended convergence, which could block loop unrolling.

This was discovered when https://github.com/llvm/llvm-project/pull/188792 caused the following failure: https://github.com/llvm/llvm-project/actions/runs/24577221310/job/71865579618. When emitting convergence control tokens, the inner loop successfully unrolls and marks the old body branch as unreachable, it then tries to unroll the outer loop, however the `convergence.loop` token in the outer loop header sees that a convergent op (in this case `dx.resource.getpointer`) in the dead branch is using it and marks it as `Convergence::Extended`, preventing a loop unroll from occurring. In this case it should still be possible to unroll.

Assisted by: Claude Opus 4.6