### PR TITLE
[CIR] Allow multi-block ctor regions on GlobalOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2865,8 +2865,8 @@ def CIR_GlobalOp : CIR_Op<"global", [
                        OptionalAttr<StrAttr>:$section
                        );
 
-  let regions = (region MaxSizedRegion<1>:$ctorRegion,
-                        MaxSizedRegion<1>:$dtorRegion);
+  let regions = (region AnyRegion:$ctorRegion,
+                        AnyRegion:$dtorRegion);
 
   let assemblyFormat = [{
     ($sym_visibility^)?

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -289,8 +289,8 @@ struct LoweringPreparePass
       // Emit the initializer and add a global destructor if appropriate.
       auto &ctorRegion = globalOp.getCtorRegion();
       assert(!ctorRegion.empty() && "This should never be empty here.");
-      if (!ctorRegion.hasOneBlock())
-        llvm_unreachable("Multiple blocks NYI");
+      assert(ctorRegion.hasOneBlock() &&
+             "Multi-block static local ctor regions are not yet supported");
       mlir::Block &block = ctorRegion.front();
       mlir::Block *insertBlock = builder.getInsertionBlock();
       insertBlock->getOperations().splice(insertBlock->end(),
@@ -981,7 +981,12 @@ LoweringPreparePass::buildCXXGlobalVarDeclInitFunc(cir::GlobalOp op) {
   FuncOp f = buildRuntimeFunction(builder, fnName, op.getLoc(), fnType,
                                   cir::GlobalLinkageKind::InternalLinkage);
 
-  // Move over the initialzation code of the ctor region.
+  // Move over the initialization code of the ctor region.
+  // The ctor region may have multiple blocks when exception handling
+  // scaffolding creates extra blocks (e.g., unreachable/trap blocks).
+  // We move all operations from the first block (minus the yield) into
+  // the function entry, and discard extra blocks (which contain only
+  // unreachable terminators from EH cleanup paths).
   mlir::Block *entryBB = f.addEntryBlock();
   if (!op.getCtorRegion().empty()) {
     mlir::Block &block = op.getCtorRegion().front();

--- a/clang/test/CIR/CodeGen/global-var-template-ctor.cpp
+++ b/clang/test/CIR/CodeGen/global-var-template-ctor.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+// Regression test: C++14 variable templates with non-constexpr
+// constructors must not crash CIR with "ctorRegion failed to
+// verify constraint: region with at most 1 blocks".
+
+template<int N> class FixedInt {
+public:
+  static const int value = N;
+  operator int() const { return value; }
+  FixedInt() {}
+};
+
+template<int N>
+static const FixedInt<N> fix{};
+
+int test() {
+  return fix<1> + fix<2>;
+}
+
+// CIR: cir.global "private" internal dso_local @_ZL3fixILi1EE
+// CIR: cir.global "private" internal dso_local @_ZL3fixILi2EE
+// CIR: cir.func {{.*}} @_Z4testv
+
+// LLVM: @_ZL3fixILi1EE = internal global
+// LLVM: @_ZL3fixILi2EE = internal global
+// LLVM: define {{.*}} @_Z4testv
+
+// OGCG: @_ZL3fixILi1EE = internal global
+// OGCG: @_ZL3fixILi2EE = internal global
+// OGCG: define {{.*}} @_Z4testv


### PR DESCRIPTION
C++14 variable templates with non-constexpr constructors (e.g., `static const Foo<N> x{}` where `Foo()` is not constexpr) crash CIR codegen with:

```
'cir.global' op region #0 ('ctorRegion') failed to verify
constraint: region with at most 1 blocks
```

The problem is that `GlobalOp`'s `ctorRegion` is declared as `MaxSizedRegion<1>`, but when exceptions are enabled, `emitAggExpr` can create additional blocks in the ctor region for EH cleanup scaffolding (unreachable/trap terminators).  These extra blocks are dead code — `LoweringPrepare` already discards them when it moves the ctor region into `__cxx_global_var_init`.

This patch relaxes the constraint to `AnyRegion` and replaces the `llvm_unreachable("Multiple blocks NYI")` in the static-local guard path with an assert (that path will be reworked by #193576).

Made with [Cursor](https://cursor.com)