### PR TITLE
[compiler-rt] Improve ubsan-minimal runtime for GPU use

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
@@ -40,6 +40,9 @@
 #  if SANITIZER_GO
 #    define SANITIZER_INTERFACE_ATTRIBUTE
 #    define SANITIZER_WEAK_ATTRIBUTE
+#  elif SANITIZER_AMDGPU || SANITIZER_NVPTX
+#    define SANITIZER_INTERFACE_ATTRIBUTE __attribute__((visibility("hidden")))
+#    define SANITIZER_WEAK_ATTRIBUTE __attribute__((weak))
 #  else
 #    define SANITIZER_INTERFACE_ATTRIBUTE __attribute__((visibility("default")))
 #    define SANITIZER_WEAK_ATTRIBUTE __attribute__((weak))

--- a/compiler-rt/lib/ubsan_minimal/ubsan_minimal_handlers.cpp
+++ b/compiler-rt/lib/ubsan_minimal/ubsan_minimal_handlers.cpp
@@ -7,9 +7,12 @@
 #if defined(KERNEL_USE)
 extern "C" void ubsan_message(const char *msg);
 static void message(const char *msg) { ubsan_message(msg); }
-#elif defined(SANITIZER_AMDGPU) || defined(SANITIZER_NVPTX)
+#elif SANITIZER_AMDGPU || SANITIZER_NVPTX
 #include <stdio.h>
-static void message(const char *msg) { fprintf(stderr, "%s", msg); }
+template <typename... Args>
+static void message(const char *msg, Args &&...args) {
+  fprintf(stderr, msg, args...);
+}
 #else
 #include <unistd.h>
 static void message(const char *msg) { (void)write(2, msg, strlen(msg)); }
@@ -65,8 +68,18 @@ static void format_msg(const char *kind, uintptr_t caller, char *buf,
   *buf = '\0';
 }
 
-SANITIZER_INTERFACE_WEAK_DEF(void, __ubsan_report_error, const char *kind,
-                             uintptr_t caller) {
+static void format(const char *kind, uintptr_t caller) {
+#if SANITIZER_AMDGPU || SANITIZER_NVPTX
+  (void)format_msg;
+  message("ubsan: %s by %p\n", kind, reinterpret_cast<void *>(caller));
+#else
+  char msg_buf[128];
+  format_msg(kind, caller, msg_buf, msg_buf + sizeof(msg_buf));
+  message(msg_buf);
+#endif
+}
+
+[[gnu::cold]] static void report_error(const char *kind, uintptr_t caller) {
   if (caller == 0)
     return;
   while (true) {
@@ -98,17 +111,20 @@ SANITIZER_INTERFACE_WEAK_DEF(void, __ubsan_report_error, const char *kind,
     }
     __sanitizer::atomic_store_relaxed(&caller_pcs[sz], caller);
 
-    char msg_buf[128];
-    format_msg(kind, caller, msg_buf, msg_buf + sizeof(msg_buf));
-    message(msg_buf);
+    format(kind, caller);
   }
+}
+
+SANITIZER_INTERFACE_WEAK_DEF(void, __ubsan_report_error, const char *kind,
+                             uintptr_t caller) {
+  report_error(kind, caller);
 }
 
 #if PRESERVE_HANDLERS
 SANITIZER_INTERFACE_WEAK_DEF(void, __ubsan_report_error_preserve,
                              const char *kind, uintptr_t caller)
 [[clang::preserve_all]] {
-  // Additional indirecton so the user can override this with their own
+  // Additional indirection so the user can override this with their own
   // preserve_all function. This would allow, e.g., a function that reports the
   // first error only, so for all subsequent calls we can skip the register save
   // / restore.

--- a/compiler-rt/lib/ubsan_minimal/ubsan_minimal_handlers.cpp
+++ b/compiler-rt/lib/ubsan_minimal/ubsan_minimal_handlers.cpp
@@ -147,6 +147,10 @@ static void abort_with_message(const char *kind, uintptr_t caller) {
     android_set_abort_message(msg_buf);
   abort();
 }
+#elif SANITIZER_AMDGPU || SANITIZER_NVPTX
+static void abort_with_message(const char *kind, uintptr_t caller) {
+  __builtin_verbose_trap("ubsan", "unrecoverable error");
+}
 #else
 static void abort_with_message(const char *kind, uintptr_t caller) { abort(); }
 #endif


### PR DESCRIPTION
Summary:
GPUs are resource constrained, and we don't want to incur too much
overhead for using the runtime over a trap version. Unlike the other
targets, we have cheap `printf` on account of all the complexity being
done on the host, so we use that directly instead of custom formatting.
Additionally, we split the main function out into a helper function.
Listing it as `[cold]` prevents spurious inlining that massively bloated
register costs (this is an error reporting mechanism so hopefully that's
not controversial).

In practice for some basic tests, This cuts the register usage by more
than half and the stack size is no longer dynamically sized. The only
stack I saw was for the PC relative checks. This could be lowered
further with more intelligent PC caching, but this is a good, minimally
invasive, start.
