### PR TITLE
[flang][OpenMP] Remove OmpEndLoopDirective from PFT

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -141,7 +141,7 @@ using Directives =
     std::tuple<parser::CompilerDirective, parser::OpenACCConstruct,
                parser::OpenACCRoutineConstruct,
                parser::OpenACCDeclarativeConstruct, parser::OpenMPConstruct,
-               parser::OpenMPDeclarativeConstruct, parser::OmpEndLoopDirective,
+               parser::OpenMPDeclarativeConstruct,
                parser::CUFKernelDoConstruct>;
 
 using DeclConstructs = std::tuple<parser::OpenMPDeclarativeConstruct,

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -2391,9 +2391,6 @@ static void genFuseOp(Fortran::lower::AbstractConverter &converter,
 
   llvm::SmallVector<mlir::Value> applyees;
   for (auto &child : eval.getNestedEvaluations()) {
-    // Stop at OmpEndLoopDirective
-    if (&child == &eval.getLastNestedEvaluation())
-      break;
     // Skip any Compiler Directive
     if (child.getIf<parser::CompilerDirective>())
       continue;

--- a/flang/test/Lower/pre-fir-tree03.f90
+++ b/flang/test/Lower/pre-fir-tree03.f90
@@ -21,7 +21,6 @@ program test_omp
     ! CHECK: EndDoStmt
     end do
     ! CHECK: <<End DoConstruct>>
-    ! CHECK: OmpEndLoopDirective
     !$omp end do
     ! CHECK: <<End OpenMPConstruct>>
 


### PR DESCRIPTION
It's no longer necessary. An end-directive for a loop construct used to be a separate construct, but now it only exists as a member in OpenMPLoopConstruct.