### PR TITLE
[CIR][NFC] Delete unnecessary errorNYI call in emitDelegateCallArg

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -849,12 +849,6 @@ void CIRGenFunction::emitDelegateCallArg(CallArgList &args,
 
   QualType type = param->getType();
 
-  if (type->getAsCXXRecordDecl()) {
-    cgm.errorNYI(param->getSourceRange(),
-                 "emitDelegateCallArg: record argument");
-    return;
-  }
-
   // GetAddrOfLocalVar returns a pointer-to-pointer for references, but the
   // argument needs to be the original pointer.
   if (type->isReferenceType()) {


### PR DESCRIPTION
There was a call to errorNYI in `CIRGenFunction::emitDelegateCallArg` when the parameter decl was a `CXXRecordDecl`. This was an artifact from an older version of this function in classic codegen, which called `ErrorUnsupported` for InAlloca arguments, but that handling was deleted as part of https://reviews.llvm.org/D154007.