### PR TITLE
[CIR] Fix eraseOp assertion in TryOp flattening with unreachable handlers

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -1674,10 +1674,14 @@ public:
     }
 
     // If there are no throwing calls and no resume ops from inner cleanup
-    // scopes, exceptions cannot reach the catch handlers. Skip handler and
-    // dispatch block creation — the handler regions will be dropped when
-    // the try op is erased.
+    // scopes, exceptions cannot reach the catch handlers. Drop all uses
+    // from the (unreachable) handler regions before erasing the try op,
+    // since handler ops may reference values that were inlined from the
+    // try body into the parent block.
     if (callsToRewrite.empty() && resumeOpsToChain.empty()) {
+      for (mlir::Region &handlerRegion : handlerRegions)
+        for (mlir::Block &block : handlerRegion)
+          block.dropAllDefinedValueUses();
       rewriter.eraseOp(tryOp);
       return mlir::success();
     }

--- a/clang/test/CIR/CodeGen/try-no-throwing-calls.cpp
+++ b/clang/test/CIR/CodeGen/try-no-throwing-calls.cpp
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-linux-gnu -fcxx-exceptions -fexceptions -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-linux-gnu -fcxx-exceptions -fexceptions -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-linux-gnu -fcxx-exceptions -fexceptions -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+// Regression test: try block with catch handlers but no throwing calls
+// must not crash during TryOp flattening when handler regions reference
+// values inlined from the try body.
+
+int nonThrowing() noexcept { return 42; }
+
+int test() {
+  int result = 0;
+  try {
+    result = nonThrowing();
+  } catch (...) {
+    result = -1;
+  }
+  return result;
+}
+
+// Verify the try body (call + store) is preserved, not discarded.
+
+// CIR: cir.func {{.*}} @_Z4testv
+// CIR:   %[[RESULT:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["result", init]
+// CIR:   %[[CALL:.*]] = cir.call @_Z11nonThrowingv()
+// CIR:   cir.store {{.*}}%[[CALL]], %[[RESULT]]
+
+// LLVM: define {{.*}} @_Z4testv
+// LLVM:   %[[CALL:.*]] = call noundef i32 @_Z11nonThrowingv()
+// LLVM:   store i32 %[[CALL]], ptr %{{.*}}
+
+// OGCG: define {{.*}} @_Z4testv
+// OGCG:   %[[CALL:.*]] = call noundef i32 @_Z11nonThrowingv()
+// OGCG:   store i32 %[[CALL]], ptr %{{.*}}


### PR DESCRIPTION
When a try block has catch handlers but no throwing calls, the handler regions are unreachable and the TryOp is erased.  However, ops inside the handler regions may reference values that were inlined from the try body into the parent block, causing an assertion in `eraseOp` ("expected that op has no uses").

This drops all defined value uses from handler regions before erasing the TryOp.

Made with [Cursor](https://cursor.com)