### PR TITLE
[lldb] Update filecheck_log to use direct input (NFC-ish)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2552,7 +2552,7 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
                 )
 
     def filecheck(
-        self, command, check_file, filecheck_options="", expect_cmd_failure=False
+        self, command, check_file, filecheck_options=None, expect_cmd_failure=False
     ):
         # Run the command.
         self.runCmd(
@@ -2579,7 +2579,10 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
             self.assertTrue(False, "No valid FileCheck executable specified")
         filecheck_args = [filecheck_bin, check_file_abs]
         if filecheck_options:
-            filecheck_args.append(filecheck_options)
+            if isinstance(filecheck_options, list):
+                filecheck_args.extend(filecheck_options)
+            else:
+                filecheck_args.append(str(filecheck_options))
         subproc = Popen(
             filecheck_args,
             stdin=PIPE,
@@ -2611,14 +2614,16 @@ FileCheck output:
 
         self.assertEqual(cmd_status, 0)
 
-    def filecheck_log(
-        self, log_file, check_file, filecheck_options="", expect_cmd_failure=False
-    ):
+    def filecheck_log(self, log_file, check_file, filecheck_options=None):
+        input_option = f"-input-file={log_file}"
+        if filecheck_options:
+            filecheck_options = [filecheck_options, input_option]
+        else:
+            filecheck_options = input_option
         return self.filecheck(
-            f"platform shell -h -- cat {log_file}",
+            "script None",
             check_file,
             filecheck_options,
-            expect_cmd_failure,
         )
 
     def expect(


### PR DESCRIPTION
Pass log files as direct input to `FileCheck` via its `-input-file` option.

I had a failing test case where the log file contains the string being checked for, and yet `FileCheck` failed. While debugging, I noticed the output from running `platform shell -h -- cat ...` was somehow truncated. I have not debugged why. As soon as I saw the issue, I figured it was best to skip all the intermediaries, and pass the log file straight to `FileCheck`.