### PR TITLE
[flang][OpenMP] Add parallel loop to loop directive parser set

### DIFF
--- a/flang/lib/Parser/openmp-parsers.cpp
+++ b/flang/lib/Parser/openmp-parsers.cpp
@@ -2530,6 +2530,7 @@ static constexpr DirectiveSet GetLoopDirectives() {
       unsigned(Directive::OMPD_master_taskloop_simd),
       unsigned(Directive::OMPD_parallel_do),
       unsigned(Directive::OMPD_parallel_do_simd),
+      unsigned(Directive::OMPD_parallel_loop),
       unsigned(Directive::OMPD_parallel_masked_taskloop),
       unsigned(Directive::OMPD_parallel_masked_taskloop_simd),
       unsigned(Directive::OMPD_parallel_master_taskloop),

--- a/flang/test/Parser/OpenMP/parallel-loop-unparse.f90
+++ b/flang/test/Parser/OpenMP/parallel-loop-unparse.f90
@@ -1,0 +1,69 @@
+! RUN: %flang_fc1 -fdebug-unparse -fopenmp -fopenmp-version=50 %s | \
+! RUN:   FileCheck --ignore-case %s
+
+! RUN: %flang_fc1 -fdebug-dump-parse-tree -fopenmp -fopenmp-version=50 %s | \
+! RUN:   FileCheck --check-prefix="PARSE-TREE" %s
+
+! Check for parsing of parallel loop combined construct (OpenMP 5.0, 2.13.2)
+
+subroutine test_parallel_loop
+  integer :: i, j = 1
+  !PARSE-TREE: OmpBeginLoopDirective
+  !PARSE-TREE-NEXT: OmpDirectiveName -> llvm::omp::Directive = parallel loop
+  !CHECK: !$omp parallel loop
+  !$omp parallel loop
+  do i=1,10
+   j = j + 1
+  end do
+end subroutine
+
+subroutine test_parallel_loop_with_end
+  integer :: i, j = 1
+  !PARSE-TREE: OmpBeginLoopDirective
+  !PARSE-TREE-NEXT: OmpDirectiveName -> llvm::omp::Directive = parallel loop
+  !CHECK: !$omp parallel loop
+  !$omp parallel loop
+  do i=1,10
+   j = j + 1
+  end do
+  !PARSE-TREE: OmpEndLoopDirective
+  !PARSE-TREE-NEXT: OmpDirectiveName -> llvm::omp::Directive = parallel loop
+  !CHECK: !$omp end parallel loop
+  !$omp end parallel loop
+end subroutine
+
+subroutine test_parallel_loop_with_clauses
+  integer :: i, j = 1
+  !PARSE-TREE: OmpBeginLoopDirective
+  !PARSE-TREE-NEXT: OmpDirectiveName -> llvm::omp::Directive = parallel loop
+  !CHECK: !$omp parallel loop num_threads(4_4) collapse(1_4) private(j) default(shared)
+  !$omp parallel loop num_threads(4) collapse(1) private(j) default(shared)
+  do i=1,10
+   j = j + 1
+  end do
+end subroutine
+
+subroutine test_parallel_loop_with_reduction
+  integer :: i, total
+  total = 0
+  !PARSE-TREE: OmpBeginLoopDirective
+  !PARSE-TREE-NEXT: OmpDirectiveName -> llvm::omp::Directive = parallel loop
+  !CHECK: !$omp parallel loop reduction(+: total)
+  !$omp parallel loop reduction(+:total)
+  do i=1,10
+   total = total + i
+  end do
+end subroutine
+
+subroutine test_parallel_loop_with_if
+  integer :: i, j = 1
+  logical :: cond
+  cond = .true.
+  !PARSE-TREE: OmpBeginLoopDirective
+  !PARSE-TREE-NEXT: OmpDirectiveName -> llvm::omp::Directive = parallel loop
+  !CHECK: !$omp parallel loop if(cond) proc_bind(close)
+  !$omp parallel loop if(cond) proc_bind(close)
+  do i=1,10
+   j = j + 1
+  end do
+end subroutine


### PR DESCRIPTION
Add `OMPD_parallel_loop` to `GetLoopDirectives()` in the Flang OpenMP
parser so that the valid OpenMP 5.0 combined construct
`!$omp parallel loop` is recognized as a loop construct.

Previously, the parser failed to match `parallel loop` as a loop
directive. It then fell through to matching `parallel` as a block
construct, leaving `loop` as an unexpected token, producing:

```
error: expected OpenMP construct
    !$omp parallel loop
                       ^
```

The directive was already fully defined in OMP.td and handled in the
semantics directive sets, lowering, and MLIR `GenericLoopConversion`
passes. Only the parser set was missing the entry.

Fixes #193101

Assisted-by: Claude Opus 4.6.
