### PR TITLE
[DirectX] Apply DXIL op fnattrs to declarations

### DIFF
--- a/llvm/lib/Target/DirectX/DXILOpBuilder.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpBuilder.cpp
@@ -470,18 +470,23 @@ static dxil::Attributes getDXILAttributes(dxil::OpCode OpCode,
 
 // Retreive the set of DXIL Attributes given the version and map them to an
 // llvm function attribute that is set onto the instruction
-static void setDXILAttributes(CallInst *CI, dxil::OpCode OpCode,
-                              VersionTuple DXILVersion) {
+static AttributeList getDXILFnAttributeList(LLVMContext &Ctx,
+                                            dxil::OpCode OpCode,
+                                            VersionTuple DXILVersion) {
   dxil::Attributes Attributes = getDXILAttributes(OpCode, DXILVersion);
+  AttrBuilder FnAttrs(Ctx);
+
   if (Attributes.ReadNone)
-    CI->setDoesNotAccessMemory();
+    FnAttrs.addMemoryAttr(MemoryEffects::none());
   if (Attributes.ReadOnly)
-    CI->setOnlyReadsMemory();
+    FnAttrs.addMemoryAttr(MemoryEffects::readOnly());
   if (Attributes.NoReturn)
-    CI->setDoesNotReturn();
+    FnAttrs.addAttribute(Attribute::NoReturn);
   if (Attributes.NoDuplicate)
-    CI->setCannotDuplicate();
-  return;
+    FnAttrs.addAttribute(Attribute::NoDuplicate);
+  FnAttrs.addAttribute(Attribute::NoUnwind);
+
+  return AttributeList::get(Ctx, AttributeList::FunctionIndex, FnAttrs);
 }
 
 namespace llvm {
@@ -569,8 +574,11 @@ Expected<CallInst *> DXILOpBuilder::tryCreateOp(dxil::OpCode OpCode,
   if (!(ValidShaderKindMask & ModuleStagekind))
     return makeOpError(OpCode, "Invalid stage");
 
+  AttributeList DXILFnAttrs =
+      getDXILFnAttributeList(M.getContext(), OpCode, DXILVersion);
   std::string DXILFnName = constructOverloadName(Kind, OverloadTy, *Prop);
-  FunctionCallee DXILFn = M.getOrInsertFunction(DXILFnName, DXILOpFT);
+  FunctionCallee DXILFn =
+      M.getOrInsertFunction(DXILFnName, DXILOpFT, DXILFnAttrs);
 
   // We need to inject the opcode as the first argument.
   SmallVector<Value *> OpArgs;
@@ -579,9 +587,6 @@ Expected<CallInst *> DXILOpBuilder::tryCreateOp(dxil::OpCode OpCode,
 
   // Create the function call instruction
   CallInst *CI = IRB.CreateCall(DXILFn, OpArgs, Name);
-
-  // We then need to attach available function attributes
-  setDXILAttributes(CI, OpCode, DXILVersion);
 
   return CI;
 }

--- a/llvm/lib/Target/DirectX/DXILOpBuilder.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpBuilder.cpp
@@ -438,8 +438,7 @@ constexpr static uint64_t computeSwitchEnum(dxil::OpCode OpCode,
   return (OpCodePack << 32) | (VersionMajor << 16) | VersionMinor;
 }
 
-// Retreive all the set attributes for a DXIL OpCode given the targeted
-// DXILVersion
+/// Get the set of attributes for a given DXIL OpCode and the DXIL version.
 static dxil::Attributes getDXILAttributes(dxil::OpCode OpCode,
                                           VersionTuple DXILVersion) {
   // Instantiate all versions to iterate through
@@ -468,8 +467,8 @@ static dxil::Attributes getDXILAttributes(dxil::OpCode OpCode,
   return Attributes;
 }
 
-// Retreive the set of DXIL Attributes given the version and map them to an
-// llvm function attribute that is set onto the instruction
+/// Get the attributes to apply to the function for the DXIL operation with the
+/// given OpCode and DXIL version.
 static AttributeList getDXILFnAttributeList(LLVMContext &Ctx,
                                             dxil::OpCode OpCode,
                                             VersionTuple DXILVersion) {

--- a/llvm/test/CodeGen/DirectX/BufferLoad-sm61.ll
+++ b/llvm/test/CodeGen/DirectX/BufferLoad-sm61.ll
@@ -58,3 +58,10 @@ define void @loadnested(i32 %index) {
 
   ret void
 }
+
+; CHECK: declare %dx.types.Handle @dx.op.createHandle(i32, i8, i32, i32, i1) #[[#ATTR0:]]
+; CHECK-DAG: declare %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32, %dx.types.Handle, i32, i32) #[[#ATTR0]]
+; CHECK-DAG: declare %dx.types.ResRet.f16 @dx.op.bufferLoad.f16(i32, %dx.types.Handle, i32, i32) #[[#ATTR0]]
+; CHECK-DAG: declare %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32, %dx.types.Handle, i32, i32) #[[#ATTR0]]
+
+; CHECK-DAG: attributes #[[#ATTR0]] = { nounwind memory(read) }

--- a/llvm/test/CodeGen/DirectX/BufferLoad.ll
+++ b/llvm/test/CodeGen/DirectX/BufferLoad.ll
@@ -16,7 +16,7 @@ define void @loadv4f32() {
   ; The temporary casts should all have been cleaned up
   ; CHECK-NOT: %dx.resource.casthandle
 
-  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef) #[[#ATTR:]]
+  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef)
   %load0 = call {<4 x float>, i1} @llvm.dx.resource.load.typedbuffer(
       target("dx.TypedBuffer", <4 x float>, 0, 0, 0) %buffer, i32 0)
   %data0 = extractvalue {<4 x float>, i1} %load0, 0
@@ -34,7 +34,7 @@ define void @loadv4f32() {
   call void @scalar_user(float %data0_0)
   call void @scalar_user(float %data0_2)
 
-  ; CHECK: [[DATA4:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 4, i32 undef) #[[#ATTR]]
+  ; CHECK: [[DATA4:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 4, i32 undef)
   %load4 = call {<4 x float>, i1} @llvm.dx.resource.load.typedbuffer(
       target("dx.TypedBuffer", <4 x float>, 0, 0, 0) %buffer, i32 4)
   %data4 = extractvalue {<4 x float>, i1} %load4, 0
@@ -49,7 +49,7 @@ define void @loadv4f32() {
   ; CHECK: insertelement <4 x float>
   call void @vector_user(<4 x float> %data4)
 
-  ; CHECK: [[DATA12:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 12, i32 undef) #[[#ATTR]]
+  ; CHECK: [[DATA12:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 12, i32 undef)
   %load12 = call {<4 x float>, i1} @llvm.dx.resource.load.typedbuffer(
       target("dx.TypedBuffer", <4 x float>, 0, 0, 0) %buffer, i32 12)
   %data12 = extractvalue {<4 x float>, i1} %load12, 0
@@ -72,7 +72,7 @@ define void @index_dynamic(i32 %bufindex, i32 %elemindex) {
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v4f32_0_0_0(
           i32 0, i32 0, i32 1, i32 0, ptr null)
 
-  ; CHECK: [[LOAD:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 %bufindex, i32 undef) #[[#ATTR]]
+  ; CHECK: [[LOAD:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 %bufindex, i32 undef)
   %load = call {<4 x float>, i1} @llvm.dx.resource.load.typedbuffer(
       target("dx.TypedBuffer", <4 x float>, 0, 0, 0) %buffer, i32 %bufindex)
   %data = extractvalue {<4 x float>, i1} %load, 0
@@ -108,7 +108,7 @@ define void @loadf32() {
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f32_0_0_0(
           i32 0, i32 0, i32 1, i32 0, ptr null)
 
-  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef) #[[#ATTR]]
+  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef)
   %load0 = call {float, i1} @llvm.dx.resource.load.typedbuffer(
       target("dx.TypedBuffer", float, 0, 0, 0) %buffer, i32 0)
   %data0 = extractvalue {float, i1} %load0, 0
@@ -127,7 +127,7 @@ define void @loadv2f32() {
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f32_0_0_0(
           i32 0, i32 0, i32 1, i32 0, ptr null)
 
-  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef) #[[#ATTR]]
+  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef)
   %data0 = call {<2 x float>, i1} @llvm.dx.resource.load.typedbuffer(
       target("dx.TypedBuffer", <2 x float>, 0, 0, 0) %buffer, i32 0)
 
@@ -141,12 +141,12 @@ define void @loadv4f32_checkbit() {
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v4f32_0_0_0(
           i32 0, i32 0, i32 1, i32 0, ptr null)
 
-  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef) #[[#ATTR]]
+  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef)
   %data0 = call {<4 x float>, i1} @llvm.dx.resource.load.typedbuffer.f32(
       target("dx.TypedBuffer", <4 x float>, 0, 0, 0) %buffer, i32 0)
 
   ; CHECK: [[STATUS:%.*]] = extractvalue %dx.types.ResRet.f32 [[DATA0]], 4
-  ; CHECK: [[MAPPED:%.*]] = call i1 @dx.op.checkAccessFullyMapped.i32(i32 71, i32 [[STATUS]]) #[[#ATTR]]
+  ; CHECK: [[MAPPED:%.*]] = call i1 @dx.op.checkAccessFullyMapped.i32(i32 71, i32 [[STATUS]])
   %check = extractvalue {<4 x float>, i1} %data0, 1
 
   ; CHECK: call void @check_user(i1 [[MAPPED]])
@@ -162,7 +162,7 @@ define void @loadv4i32() {
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v4i32_0_0_0(
           i32 0, i32 0, i32 1, i32 0, ptr null)
 
-  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef) #[[#ATTR]]
+  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef)
   %data0 = call {<4 x i32>, i1} @llvm.dx.resource.load.typedbuffer(
       target("dx.TypedBuffer", <4 x i32>, 0, 0, 0) %buffer, i32 0)
 
@@ -176,7 +176,7 @@ define void @loadv4f16() {
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v4f16_0_0_0(
           i32 0, i32 0, i32 1, i32 0, ptr null)
 
-  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.f16 @dx.op.bufferLoad.f16(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef) #[[#ATTR]]
+  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.f16 @dx.op.bufferLoad.f16(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef)
   %data0 = call {<4 x half>, i1} @llvm.dx.resource.load.typedbuffer(
       target("dx.TypedBuffer", <4 x half>, 0, 0, 0) %buffer, i32 0)
 
@@ -190,7 +190,7 @@ define void @loadv4i16() {
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v4i16_0_0_0(
           i32 0, i32 0, i32 1, i32 0, ptr null)
 
-  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.i16 @dx.op.bufferLoad.i16(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef) #[[#ATTR]]
+  ; CHECK: [[DATA0:%.*]] = call %dx.types.ResRet.i16 @dx.op.bufferLoad.i16(i32 68, %dx.types.Handle [[HANDLE]], i32 0, i32 undef)
   %data0 = call {<4 x i16>, i1} @llvm.dx.resource.load.typedbuffer(
       target("dx.TypedBuffer", <4 x i16>, 0, 0, 0) %buffer, i32 0)
 
@@ -199,34 +199,42 @@ define void @loadv4i16() {
 
 define void @loadf64() {
   ; show dxil op lower can handle typedbuffer load where target is double but load type is <2 x i32>
-  ; CHECK: [[B1:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 1, i32 1, i32 0, i8 1 }, i32 1, i1 false) #0
+  ; CHECK: [[B1:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 1, i32 1, i32 0, i8 1 }, i32 1, i1 false)
   %buffer = call target("dx.TypedBuffer", double, 1, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f64_1_0_0t(
           i32 0, i32 1, i32 1, i32 0, ptr null)
 
-  ; CHECK: [[BA:%.*]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[B1]], %dx.types.ResourceProperties { i32 4106, i32 266 }) #0
+  ; CHECK: [[BA:%.*]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[B1]], %dx.types.ResourceProperties { i32 4106, i32 266 })
   %load = call { <2 x i32>, i1 } @llvm.dx.resource.load.typedbuffer(
       target("dx.TypedBuffer", double, 1, 0, 0) %buffer, i32 0)
 
-; CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle [[BA]], i32 0, i32 undef) #1
+; CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle [[BA]], i32 0, i32 undef)
   %val = extractvalue { <2 x i32>, i1 } %load, 0
   ret void
 }
 
 define void @loadv2f64() {
   ; show dxil op lower can handle typedbuffer load where target is double2 but load type is <4 x i32>
-  ; CHECK: [[B1:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 1, i32 1, i32 0, i8 1 }, i32 1, i1 false) #0
+  ; CHECK: [[B1:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 1, i32 1, i32 0, i8 1 }, i32 1, i1 false)
   %buffer = call target("dx.TypedBuffer", <2 x double>, 1, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v2f64_1_0_0t(
           i32 0, i32 1, i32 1, i32 0, ptr null)
 
-  ; CHECK: [[BA:%.*]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[B1]], %dx.types.ResourceProperties { i32 4106, i32 522 }) #0
+  ; CHECK: [[BA:%.*]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[B1]], %dx.types.ResourceProperties { i32 4106, i32 522 })
   %load = call { <4 x i32>, i1 } @llvm.dx.resource.load.typedbuffer(
       target("dx.TypedBuffer", <2 x double>, 1, 0, 0) %buffer, i32 0)
 
-  ; CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle [[BA]], i32 0, i32 undef) #1
+  ; CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle [[BA]], i32 0, i32 undef)
   %val = extractvalue { <4 x i32>, i1 } %load, 0
   ret void
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(read) {{.*}}}
+; CHECK-DAG: declare %dx.types.Handle @dx.op.createHandleFromBinding(i32, %dx.types.ResBind, i32, i1) #[[#ATTR0:]]
+; CHECK-DAG: declare %dx.types.Handle @dx.op.annotateHandle(i32, %dx.types.Handle, %dx.types.ResourceProperties) #[[#ATTR0]]
+; CHECK-DAG: declare %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32, %dx.types.Handle, i32, i32) #[[#ATTR1:]]
+; CHECK-DAG: declare %dx.types.ResRet.i16 @dx.op.bufferLoad.i16(i32, %dx.types.Handle, i32, i32) #[[#ATTR1]]
+; CHECK-DAG: declare %dx.types.ResRet.f16 @dx.op.bufferLoad.f16(i32, %dx.types.Handle, i32, i32) #[[#ATTR1]]
+; CHECK-DAG: declare %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(i32, %dx.types.Handle, i32, i32) #[[#ATTR1]]
+
+; CHECK-DAG: attributes #[[#ATTR0]] = { nounwind memory(none) }
+; CHECK-DAG: attributes #[[#ATTR1]] = { nounwind memory(read) }

--- a/llvm/test/CodeGen/DirectX/BufferStore-sm61.ll
+++ b/llvm/test/CodeGen/DirectX/BufferStore-sm61.ll
@@ -124,3 +124,11 @@ define void @storenested(i32 %index, i32 %data0, <4 x float> %data1, <3 x half> 
 
   ret void
 }
+
+; CHECK: declare %dx.types.Handle @dx.op.createHandle(i32, i8, i32, i32, i1) #[[#ATTR0:]]
+; CHECK-DAG: declare void @dx.op.bufferStore.i32(i32, %dx.types.Handle, i32, i32, i32, i32, i32, i32, i8) #[[#ATTR1:]]
+; CHECK-DAG: declare void @dx.op.bufferStore.f16(i32, %dx.types.Handle, i32, i32, half, half, half, half, i8) #[[#ATTR1]]
+; CHECK-DAG: declare void @dx.op.bufferStore.f32(i32, %dx.types.Handle, i32, i32, float, float, float, float, i8) #[[#ATTR1]]
+
+; CHECK-DAG: attributes #[[#ATTR0]] = { nounwind memory(read) }
+; CHECK-DAG: attributes #[[#ATTR1]] = { nounwind }

--- a/llvm/test/CodeGen/DirectX/BufferStore.ll
+++ b/llvm/test/CodeGen/DirectX/BufferStore.ll
@@ -202,3 +202,13 @@ define void @storev2f64(<4 x i32> %0) {
       <4 x i32> %0)
   ret void
 }
+
+; CHECK-DAG: declare %dx.types.Handle @dx.op.createHandleFromBinding(i32, %dx.types.ResBind, i32, i1) #[[#ATTR0:]]
+; CHECK-DAG: declare %dx.types.Handle @dx.op.annotateHandle(i32, %dx.types.Handle, %dx.types.ResourceProperties) #[[#ATTR0]]
+; CHECK-DAG: declare void @dx.op.bufferStore.i32(i32, %dx.types.Handle, i32, i32, i32, i32, i32, i32, i8) #[[#ATTR1:]]
+; CHECK-DAG: declare void @dx.op.bufferStore.i16(i32, %dx.types.Handle, i32, i32, i16, i16, i16, i16, i8) #[[#ATTR1]]
+; CHECK-DAG: declare void @dx.op.bufferStore.f16(i32, %dx.types.Handle, i32, i32, half, half, half, half, i8) #[[#ATTR1]]
+; CHECK-DAG: declare void @dx.op.bufferStore.f32(i32, %dx.types.Handle, i32, i32, float, float, float, float, i8) #[[#ATTR1]]
+
+; CHECK-DAG: attributes #[[#ATTR0]] = { nounwind memory(none) }
+; CHECK-DAG: attributes #[[#ATTR1]] = { nounwind }

--- a/llvm/test/CodeGen/DirectX/CreateHandle-NURI.ll
+++ b/llvm/test/CodeGen/DirectX/CreateHandle-NURI.ll
@@ -19,7 +19,7 @@ define void @test_buffers_with_nuri() {
   %nuri1 = tail call noundef i32 @llvm.dx.resource.nonuniformindex(i32 %val)
   %res1 = call target("dx.TypedBuffer", float, 1, 0, 0)
             @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 10, i32 %nuri1, ptr @A.str)
-  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 %val, i1 true) #[[ATTR:.*]]
+  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 %val, i1 true)
   ; CHECK-NOT: @llvm.dx.cast.handle
   ; CHECK-NOT: @llvm.dx.resource.nonuniformindex
 
@@ -29,14 +29,14 @@ define void @test_buffers_with_nuri() {
   %rem1 = urem i32 %nuri2, 10
   %res2 = call target("dx.TypedBuffer", float, 1, 0, 0)
            @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 10, i32 %rem1, ptr @A.str)
-  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 %rem1, i1 true) #[[ATTR]]
+  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 %rem1, i1 true)
 
   ; A[10 + 3 * NonUniformResourceIndex(GI)];
   %mul1 = mul i32 %nuri1, 3
   %add2 = add i32 %mul1, 10
   %res3 = call target("dx.TypedBuffer", float, 1, 0, 0)
            @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 10, i32 %add2, ptr @A.str)
-  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 %add2, i1 true) #[[ATTR]]
+  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 %add2, i1 true)
 
   ; NonUniformResourceIndex value going through store & load - the flag is not going to get picked up:
   %a = tail call noundef i32 @llvm.dx.resource.nonuniformindex(i32 %val)
@@ -44,7 +44,7 @@ define void @test_buffers_with_nuri() {
   %b = load i32, ptr %foo
   %res4 = call target("dx.TypedBuffer", float, 1, 0, 0)
            @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 10, i32 %b, ptr @A.str)
-  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 %b, i1 false) #[[ATTR]]
+  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 %b, i1 false)
 
   ; NonUniformResourceIndex index value on a single resouce (not an array) - the flag is not going to get picked up:
   ;
@@ -53,7 +53,7 @@ define void @test_buffers_with_nuri() {
   %nuri3 = tail call noundef i32 @llvm.dx.resource.nonuniformindex(i32 %val)
   %res5 = call target("dx.TypedBuffer", float, 1, 0, 0)
            @llvm.dx.resource.handlefrombinding(i32 20, i32 0, i32 1, i32 %nuri1, ptr @B.str)
-  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 1, i32 %val, i1 false) #[[ATTR]]
+  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 1, i32 %val, i1 false)
 
   ; NonUniformResourceIndex on unrelated value - the call is removed:
   ; foo = NonUniformResourceIndex(val);
@@ -64,7 +64,7 @@ define void @test_buffers_with_nuri() {
 
   ret void
 }
-
-; CHECK: attributes #[[ATTR]] = {{{.*}} memory(read) {{.*}}}
+; CHECK: declare %dx.types.Handle @dx.op.createHandle(i32, i8, i32, i32, i1) #[[#ATTR0:]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(read) }
 
 attributes #0 = { nocallback nofree nosync nounwind willreturn memory(none) }

--- a/llvm/test/CodeGen/DirectX/CreateHandle.ll
+++ b/llvm/test/CodeGen/DirectX/CreateHandle.ll
@@ -26,14 +26,14 @@ define void @test_buffers() {
   %typed0 = call target("dx.TypedBuffer", <4 x float>, 1, 0, 0)
               @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v4f32_1_0_0(
                   i32 3, i32 5, i32 1, i32 0, ptr @BufA.str)
-  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 1, i32 5, i1 false) #[[#ATTR:]]
+  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 1, i32 5, i1 false)
   ; CHECK-NOT: @llvm.dx.cast.handle
 
   ; RWBuffer<int> Buf : register(u7, space2)
   %typed1 = call target("dx.TypedBuffer", i32, 1, 0, 1)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0_1t(
           i32 2, i32 7, i32 1, i32 0, ptr null)
-  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 7, i1 false) #[[#ATTR]]
+  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 7, i1 false)
 
   ; Buffer<uint4> Buf[24] : register(t3, space5)
   ; Buffer<uint4> typed2 = Buf[4]
@@ -41,20 +41,20 @@ define void @test_buffers() {
   %typed2 = call target("dx.TypedBuffer", <4 x i32>, 0, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_0_0_0t(
           i32 5, i32 3, i32 24, i32 4, ptr @BufB.str)
-  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 3, i32 7, i1 false) #[[#ATTR]]
+  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 3, i32 7, i1 false)
 
   ; struct S { float4 a; uint4 b; };
   ; StructuredBuffer<S> Buf : register(t2, space4)
   %struct0 = call target("dx.RawBuffer", {<4 x float>, <4 x i32>}, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_sl_v4f32v4i32s_0_0t(
           i32 4, i32 2, i32 1, i32 0, ptr null)
-  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 2, i32 2, i1 false) #[[#ATTR]]
+  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 2, i32 2, i1 false)
 
   ; ByteAddressBuffer Buf : register(t8, space1)
   %byteaddr0 = call target("dx.RawBuffer", i8, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_i8_0_0t(
           i32 1, i32 8, i32 1, i32 0, ptr null)
-  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 1, i32 8, i1 false) #[[#ATTR]]
+  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 1, i32 8, i1 false)
 
   ; Buffer<float4> Buf[] : register(t7)
   ; Buffer<float4> typed3 = Buf[ix]
@@ -63,12 +63,13 @@ define void @test_buffers() {
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v4f32_0_0_0t(
           i32 0, i32 7, i32 0, i32 %typed3_ix, ptr null)
   ; CHECK: %[[IX:.*]] = add i32 %typed3_ix, 7
-  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 0, i32 %[[IX]], i1 false) #[[#ATTR]]
+  ; CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 0, i32 %[[IX]], i1 false)
 
   ret void
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(read) {{.*}}}
+; CHECK: declare %dx.types.Handle @dx.op.createHandle(i32, i8, i32, i32, i1) #[[#ATTR0:]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(read) }
 
 ; Just check that we have the right types and number of metadata nodes, the
 ; contents of the metadata are tested elsewhere.

--- a/llvm/test/CodeGen/DirectX/CreateHandleFromBinding-NURI.ll
+++ b/llvm/test/CodeGen/DirectX/CreateHandleFromBinding-NURI.ll
@@ -17,10 +17,10 @@ define void @test_buffers_with_nuri() {
   ; A[NonUniformResourceIndex(val)];
 
   %nuri1 = tail call noundef i32 @llvm.dx.resource.nonuniformindex(i32 %val)
-  %res1 = call target("dx.TypedBuffer", float, 1, 0, 0) 
+  %res1 = call target("dx.TypedBuffer", float, 1, 0, 0)
             @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 10, i32 %nuri1, ptr @A.str)
-  ; CHECK: %[[RES1:.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 9, i32 0, i8 1 }, i32 %val, i1 true) #[[ATTR:.*]]
-  ; CHECK: call  %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[RES1]], %dx.types.ResourceProperties { i32 4106, i32 265 }) #[[ATTR]]
+  ; CHECK: %[[RES1:.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 9, i32 0, i8 1 }, i32 %val, i1 true)
+  ; CHECK: call  %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[RES1]], %dx.types.ResourceProperties { i32 4106, i32 265 })
   ; CHECK-NOT: @llvm.dx.cast.handle
   ; CHECK-NOT: @llvm.dx.resource.nonuniformindex
 
@@ -28,18 +28,18 @@ define void @test_buffers_with_nuri() {
   %add1 = add i32 %val, 1
   %nuri2 = tail call noundef i32 @llvm.dx.resource.nonuniformindex(i32 %add1)
   %rem1 = urem i32 %nuri2, 10
-  %res2 = call target("dx.TypedBuffer", float, 1, 0, 0) 
+  %res2 = call target("dx.TypedBuffer", float, 1, 0, 0)
            @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 10, i32 %rem1, ptr @A.str)
-  ; CHECK: %[[RES2:.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 9, i32 0, i8 1 }, i32 %rem1, i1 true) #[[ATTR]]
-  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[RES2]], %dx.types.ResourceProperties { i32 4106, i32 265 }) #[[ATTR]]
+  ; CHECK: %[[RES2:.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 9, i32 0, i8 1 }, i32 %rem1, i1 true)
+  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[RES2]], %dx.types.ResourceProperties { i32 4106, i32 265 })
 
   ; A[10 + 3 * NonUniformResourceIndex(GI)];
   %mul1 = mul i32 %nuri1, 3
   %add2 = add i32 %mul1, 10
   %res3 = call target("dx.TypedBuffer", float, 1, 0, 0)
            @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 10, i32 %add2, ptr @A.str)
-  ; CHECK: %[[RES3:.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 9, i32 0, i8 1 }, i32 %add2, i1 true) #[[ATTR]]
-  ; CHECK: %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[RES3]], %dx.types.ResourceProperties { i32 4106, i32 265 }) #[[ATTR]]
+  ; CHECK: %[[RES3:.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 9, i32 0, i8 1 }, i32 %add2, i1 true)
+  ; CHECK: %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[RES3]], %dx.types.ResourceProperties { i32 4106, i32 265 })
   ret void
 
   ; NonUniformResourceIndex value going through store & load: the flag is not going to get picked up
@@ -48,8 +48,8 @@ define void @test_buffers_with_nuri() {
   %b = load i32, ptr %foo
   %res4 = call target("dx.TypedBuffer", float, 1, 0, 0)
            @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 10, i32 %b, ptr @A.str)
-  ; CHECK: %[[RES4:.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 9, i32 0, i8 1 }, i32 %b, i1 false) #[[ATTR]]
-  ; CHECK: %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[RES4]], %dx.types.ResourceProperties { i32 4106, i32 265 }) #[[ATTR]]
+  ; CHECK: %[[RES4:.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 9, i32 0, i8 1 }, i32 %b, i1 false)
+  ; CHECK: %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[RES4]], %dx.types.ResourceProperties { i32 4106, i32 265 })
 
   ; NonUniformResourceIndex index value on a single resouce (not an array): the flag is not going to get picked up
   ; RWBuffer<float> B : register(u20);
@@ -59,8 +59,8 @@ define void @test_buffers_with_nuri() {
   %nuri3 = tail call noundef i32 @llvm.dx.resource.nonuniformindex(i32 %val)
   %res5 = call target("dx.TypedBuffer", float, 1, 0, 0)
            @llvm.dx.resource.handlefrombinding(i32 20, i32 0, i32 1, i32 %nuri1, ptr @B.str)
-  ; CHECK: %[[RES4:.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 0, i32 20, i8 1 }, i32 %val, i1 false) #[[ATTR]]
-  ; CHECK: %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[RES4]], %dx.types.ResourceProperties { i32 4106, i32 265 }) #[[ATTR]]
+  ; CHECK: %[[RES4:.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 0, i32 20, i8 1 }, i32 %val, i1 false)
+  ; CHECK: %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[RES4]], %dx.types.ResourceProperties { i32 4106, i32 265 })
 
   ; NonUniformResourceIndex on unrelated value - the call is removed:
   ; foo = NonUniformResourceIndex(val);
@@ -72,6 +72,7 @@ define void @test_buffers_with_nuri() {
   ret void
 }
 
-; CHECK: attributes #[[ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK: declare %dx.types.Handle @dx.op.createHandleFromBinding(i32, %dx.types.ResBind, i32, i1) #[[#ATTR0:]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 attributes #0 = { nocallback nofree nosync nounwind willreturn memory(none) }

--- a/llvm/test/CodeGen/DirectX/CreateHandleFromBinding.ll
+++ b/llvm/test/CodeGen/DirectX/CreateHandleFromBinding.ll
@@ -27,15 +27,15 @@ define void @test_bindings() {
   %typed0 = call target("dx.TypedBuffer", <4 x float>, 1, 0, 0)
               @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v4f32_1_0_0(
                   i32 3, i32 5, i32 1, i32 0, ptr @BufA.str)
-  ; CHECK: [[BUF0:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 5, i32 5, i32 3, i8 1 }, i32 5, i1 false) #[[#ATTR:]]
-  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF0]], %dx.types.ResourceProperties { i32 4106, i32 1033 }) #[[#ATTR]]
+  ; CHECK: [[BUF0:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 5, i32 5, i32 3, i8 1 }, i32 5, i1 false)
+  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF0]], %dx.types.ResourceProperties { i32 4106, i32 1033 })
 
   ; RWBuffer<int> Buf : register(u7, space2)
   %typed1 = call target("dx.TypedBuffer", i32, 1, 0, 1)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0_0t(
           i32 2, i32 7, i32 1, i32 0, ptr null)
-  ; CHECK: [[BUF1:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 7, i32 7, i32 2, i8 1 }, i32 7, i1 false) #[[#ATTR]]
-  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF1]], %dx.types.ResourceProperties { i32 4106, i32 260 }) #[[#ATTR]]
+  ; CHECK: [[BUF1:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 7, i32 7, i32 2, i8 1 }, i32 7, i1 false)
+  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF1]], %dx.types.ResourceProperties { i32 4106, i32 260 })
 
   ; Buffer<uint4> Buf[24] : register(t3, space5)
   ; Buffer<uint4> typed2 = Buf[4]
@@ -43,23 +43,23 @@ define void @test_bindings() {
   %typed2 = call target("dx.TypedBuffer", <4 x i32>, 0, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_0_0_0t(
           i32 5, i32 3, i32 24, i32 4, ptr @BufB.str)
-  ; CHECK: [[BUF2:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 3, i32 26, i32 5, i8 0 }, i32 7, i1 false) #[[#ATTR]]
-  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF2]], %dx.types.ResourceProperties { i32 10, i32 1029 }) #[[#ATTR]]
+  ; CHECK: [[BUF2:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 3, i32 26, i32 5, i8 0 }, i32 7, i1 false)
+  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF2]], %dx.types.ResourceProperties { i32 10, i32 1029 })
 
   ; struct S { float4 a; uint4 b; };
   ; StructuredBuffer<S> Buf : register(t2, space4)
   %struct0 = call target("dx.RawBuffer", {<4 x float>, <4 x i32>}, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_sl_v4f32v4i32s_0_0t(
           i32 4, i32 2, i32 1, i32 0, ptr null)
-  ; CHECK: [[BUF3:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 2, i32 2, i32 4, i8 0 }, i32 2, i1 false) #[[#ATTR]]
-  ; CHECK: = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF3]], %dx.types.ResourceProperties { i32 524, i32 32 }) #[[#ATTR]]
+  ; CHECK: [[BUF3:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 2, i32 2, i32 4, i8 0 }, i32 2, i1 false)
+  ; CHECK: = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF3]], %dx.types.ResourceProperties { i32 524, i32 32 })
 
   ; ByteAddressBuffer Buf : register(t8, space1)
   %byteaddr0 = call target("dx.RawBuffer", i8, 0, 0)
       @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_i8_0_0t(
           i32 1, i32 8, i32 1, i32 0, ptr null)
-  ; CHECK: [[BUF4:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 8, i32 8, i32 1, i8 0 }, i32 8, i1 false) #[[#ATTR]]
-  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF4]], %dx.types.ResourceProperties { i32 11, i32 0 }) #[[#ATTR]]
+  ; CHECK: [[BUF4:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 8, i32 8, i32 1, i8 0 }, i32 8, i1 false)
+  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF4]], %dx.types.ResourceProperties { i32 11, i32 0 })
 
   ; Buffer<float4> Buf[] : register(t7)
   ; Buffer<float4> typed3 = Buf[ix]
@@ -68,19 +68,20 @@ define void @test_bindings() {
       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_v4f32_0_0_0t(
           i32 0, i32 7, i32 0, i32 %typed3_ix, ptr null)
   ; CHECK: %[[IX:.*]] = add i32 %typed3_ix, 7
-  ; CHECK: [[BUF5:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 7, i32 -1, i32 0, i8 0 }, i32 %[[IX]], i1 false) #[[#ATTR]]
-  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF5]], %dx.types.ResourceProperties { i32 10, i32 1033 }) #[[#ATTR]]
+  ; CHECK: [[BUF5:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 7, i32 -1, i32 0, i8 0 }, i32 %[[IX]], i1 false)
+  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF5]], %dx.types.ResourceProperties { i32 10, i32 1033 })
 
   ; cbuffer cb0 : register(b0) { int4 i; float4 f; }
   %cb0 = call target("dx.CBuffer", <{ <4 x i32>, <4 x float> }>)
       @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr null)
-  ; CHECK: [[BUF6:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 0, i32 0, i8 2 }, i32 0, i1 false) #[[#ATTR]]
-  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF6]], %dx.types.ResourceProperties { i32 13, i32 32 }) #[[#ATTR]]
+  ; CHECK: [[BUF6:%.*]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 0, i32 0, i8 2 }, i32 0, i1 false)
+  ; CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle [[BUF6]], %dx.types.ResourceProperties { i32 13, i32 32 })
 
   ret void
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK: declare %dx.types.Handle @dx.op.createHandleFromBinding(i32, %dx.types.ResBind, i32, i1) #[[#ATTR0:]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 ; Just check that we have the right types and number of metadata nodes, the
 ; contents of the metadata are tested elsewhere.

--- a/llvm/test/CodeGen/DirectX/UAddc.ll
+++ b/llvm/test/CodeGen/DirectX/UAddc.ll
@@ -8,7 +8,7 @@
 define noundef i32 @test_UAddc(i32 noundef %a, i32 noundef %b) {
 ; CHECK-LABEL: define noundef i32 @test_UAddc(
 ; CHECK-SAME: i32 noundef [[A:%.*]], i32 noundef [[B:%.*]]) {
-; CHECK-NEXT:    [[UADDC:%.*]] = call [[DX_TYPES_I32C]] @dx.op.binaryWithCarryOrBorrow.i32(i32 44, i32 [[A]], i32 [[B]]) #[[ATTR0:[0-9]+]]
+; CHECK-NEXT:    [[UADDC:%.*]] = call [[DX_TYPES_I32C]] @dx.op.binaryWithCarryOrBorrow.i32(i32 44, i32 [[A]], i32 [[B]])
 ; CHECK-NEXT:    [[CARRY:%.*]] = extractvalue [[DX_TYPES_I32C]] [[UADDC]], 1
 ; CHECK-NEXT:    [[SUM:%.*]] = extractvalue [[DX_TYPES_I32C]] [[UADDC]], 0
 ; CHECK-NEXT:    [[CARRY_ZEXT:%.*]] = zext i1 [[CARRY]] to i32
@@ -29,10 +29,10 @@ define noundef <2 x i32> @test_UAddc_vec2(<2 x i32> noundef %a, <2 x i32> nounde
 ; CHECK-SAME: <2 x i32> noundef [[A:%.*]], <2 x i32> noundef [[B:%.*]]) {
 ; CHECK-NEXT:    [[A_I0:%.*]] = extractelement <2 x i32> [[A]], i64 0
 ; CHECK-NEXT:    [[B_I0:%.*]] = extractelement <2 x i32> [[B]], i64 0
-; CHECK-NEXT:    [[UADDC_I0:%.*]] = call [[DX_TYPES_I32C]] @dx.op.binaryWithCarryOrBorrow.i32(i32 44, i32 [[A_I0]], i32 [[B_I0]]) #[[ATTR0]]
+; CHECK-NEXT:    [[UADDC_I0:%.*]] = call [[DX_TYPES_I32C]] @dx.op.binaryWithCarryOrBorrow.i32(i32 44, i32 [[A_I0]], i32 [[B_I0]])
 ; CHECK-NEXT:    [[A_I1:%.*]] = extractelement <2 x i32> [[A]], i64 1
 ; CHECK-NEXT:    [[B_I1:%.*]] = extractelement <2 x i32> [[B]], i64 1
-; CHECK-NEXT:    [[UADDC_I1:%.*]] = call [[DX_TYPES_I32C]] @dx.op.binaryWithCarryOrBorrow.i32(i32 44, i32 [[A_I1]], i32 [[B_I1]]) #[[ATTR0]]
+; CHECK-NEXT:    [[UADDC_I1:%.*]] = call [[DX_TYPES_I32C]] @dx.op.binaryWithCarryOrBorrow.i32(i32 44, i32 [[A_I1]], i32 [[B_I1]])
 ; CHECK-NEXT:    [[CARRY_ELEM0:%.*]] = extractvalue [[DX_TYPES_I32C]] [[UADDC_I0]], 1
 ; CHECK-NEXT:    [[CARRY_ELEM1:%.*]] = extractvalue [[DX_TYPES_I32C]] [[UADDC_I1]], 1
 ; CHECK-NEXT:    [[SUM_ELEM0:%.*]] = extractvalue [[DX_TYPES_I32C]] [[UADDC_I0]], 0
@@ -56,7 +56,7 @@ define noundef <2 x i32> @test_UAddc_vec2(<2 x i32> noundef %a, <2 x i32> nounde
 define noundef i32 @test_UAddc_insert(i32 noundef %a, i32 noundef %b) {
 ; CHECK-LABEL: define noundef i32 @test_UAddc_insert(
 ; CHECK-SAME: i32 noundef [[A:%.*]], i32 noundef [[B:%.*]]) {
-; CHECK-NEXT:    [[UADDC:%.*]] = call [[DX_TYPES_I32C]] @dx.op.binaryWithCarryOrBorrow.i32(i32 44, i32 [[A]], i32 [[B]]) #[[ATTR0]]
+; CHECK-NEXT:    [[UADDC:%.*]] = call [[DX_TYPES_I32C]] @dx.op.binaryWithCarryOrBorrow.i32(i32 44, i32 [[A]], i32 [[B]])
 ; CHECK-NEXT:    [[UNUSED:%.*]] = insertvalue [[DX_TYPES_I32C]] [[UADDC]], i32 [[A]], 0
 ; CHECK-NEXT:    [[RESULT:%.*]] = extractvalue [[DX_TYPES_I32C]] [[UADDC]], 0
 ; CHECK-NEXT:    ret i32 [[RESULT]]
@@ -67,5 +67,7 @@ define noundef i32 @test_UAddc_insert(i32 noundef %a, i32 noundef %b) {
   ret i32 %result
 }
 
-declare { i32, i1 } @llvm.uadd.with.overflow.i32(i32, i32)
+; CHECK: declare [[DX_TYPES_I32C]] @dx.op.binaryWithCarryOrBorrow.i32(i32, i32, i32) #[[#ATTR0:]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
+declare { i32, i1 } @llvm.uadd.with.overflow.i32(i32, i32)

--- a/llvm/test/CodeGen/DirectX/WaveGetLaneIndex.ll
+++ b/llvm/test/CodeGen/DirectX/WaveGetLaneIndex.ll
@@ -2,11 +2,12 @@
 
 define void @main() {
 entry:
-; CHECK: call i32 @dx.op.waveGetLaneIndex(i32 111) #[[#ATTR:]]
+; CHECK: call i32 @dx.op.waveGetLaneIndex(i32 111)
   %0 = call i32 @llvm.dx.wave.getlaneindex()
   ret void
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(read) {{.*}}}
+; CHECK: declare i32 @dx.op.waveGetLaneIndex(i32) #[[#ATTR0:]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(read) }
 
 declare i32 @llvm.dx.wave.getlaneindex()

--- a/llvm/test/CodeGen/DirectX/abs.ll
+++ b/llvm/test/CodeGen/DirectX/abs.ll
@@ -8,7 +8,7 @@ define noundef i16 @abs_i16(i16 noundef %a) {
 entry:
 ; CHECK: sub i16 0, %a
 ; EXPCHECK: call i16 @llvm.smax.i16(i16 %a, i16 %{{.*}})
-; DOPCHECK: call i16 @dx.op.binary.i16(i32 37, i16 %a, i16 %{{.*}}) #[[#ATTR:]]
+; DOPCHECK: call i16 @dx.op.binary.i16(i32 37, i16 %a, i16 %{{.*}})
   %elt.abs = call i16 @llvm.abs.i16(i16 %a, i1 false)
   ret i16 %elt.abs
 }
@@ -18,7 +18,7 @@ define noundef i32 @abs_i32(i32 noundef %a) {
 entry:
 ; CHECK: sub i32 0, %a
 ; EXPCHECK: call i32 @llvm.smax.i32(i32 %a, i32 %{{.*}})
-; DOPCHECK: call i32 @dx.op.binary.i32(i32 37, i32 %a, i32 %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call i32 @dx.op.binary.i32(i32 37, i32 %a, i32 %{{.*}})
   %elt.abs = call i32 @llvm.abs.i32(i32 %a, i1 false)
   ret i32 %elt.abs
 }
@@ -28,12 +28,15 @@ define noundef i64 @abs_i64(i64 noundef %a) {
 entry:
 ; CHECK: sub i64 0, %a
 ; EXPCHECK: call i64 @llvm.smax.i64(i64 %a, i64 %{{.*}})
-; DOPCHECK: call i64 @dx.op.binary.i64(i32 37, i64 %a, i64 %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call i64 @dx.op.binary.i64(i32 37, i64 %a, i64 %{{.*}})
   %elt.abs = call i64 @llvm.abs.i64(i64 %a, i1 false)
   ret i64 %elt.abs
 }
 
-; DOPCHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; DOPCHECK-DAG: declare i16 @dx.op.binary.i16(i32, i16, i16) #[[#ATTR0:]]
+; DOPCHECK-DAG: declare i32 @dx.op.binary.i32(i32, i32, i32) #[[#ATTR0]]
+; DOPCHECK-DAG: declare i64 @dx.op.binary.i64(i32, i64, i64) #[[#ATTR0]]
+; DOPCHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare i16 @llvm.abs.i16(i16, i1 immarg)
 declare i32 @llvm.abs.i32(i32, i1 immarg)

--- a/llvm/test/CodeGen/DirectX/acos.ll
+++ b/llvm/test/CodeGen/DirectX/acos.ll
@@ -4,14 +4,14 @@
 
 define noundef float @acos_float(float noundef %a) {
 entry:
-; CHECK:call float @dx.op.unary.f32(i32 15, float %{{.*}}) #[[#ATTR:]]
+; CHECK:call float @dx.op.unary.f32(i32 15, float %{{.*}})
   %elt.acos = call float @llvm.acos.f32(float %a)
   ret float %elt.acos
 }
 
 define noundef half @acos_half(half noundef %a) {
 entry:
-; CHECK:call half @dx.op.unary.f16(i32 15, half %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.unary.f16(i32 15, half %{{.*}})
   %elt.acos = call half @llvm.acos.f16(half %a)
   ret half %elt.acos
 }
@@ -19,22 +19,24 @@ entry:
 define noundef <4 x float> @acos_float4(<4 x float> noundef %a) {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 15, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 15, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 15, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 15, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 15, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 15, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 15, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 15, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.acos.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.acos.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.acos.f16(half)
 declare float @llvm.acos.f32(float)

--- a/llvm/test/CodeGen/DirectX/asin.ll
+++ b/llvm/test/CodeGen/DirectX/asin.ll
@@ -4,14 +4,14 @@
 
 define noundef float @asin_float(float noundef %a) {
 entry:
-; CHECK:call float @dx.op.unary.f32(i32 16, float %{{.*}}) #[[#ATTR:]]
+; CHECK:call float @dx.op.unary.f32(i32 16, float %{{.*}})
   %elt.asin = call float @llvm.asin.f32(float %a)
   ret float %elt.asin
 }
 
 define noundef half @asin_half(half noundef %a) {
 entry:
-; CHECK:call half @dx.op.unary.f16(i32 16, half %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.unary.f16(i32 16, half %{{.*}})
   %elt.asin = call half @llvm.asin.f16(half %a)
   ret half %elt.asin
 }
@@ -19,22 +19,24 @@ entry:
 define noundef <4 x float> @asin_float4(<4 x float> noundef %a) {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 16, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 16, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 16, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 16, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 16, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 16, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 16, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 16, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.asin.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.asin.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.asin.f16(half)
 declare float @llvm.asin.f32(float)

--- a/llvm/test/CodeGen/DirectX/atan.ll
+++ b/llvm/test/CodeGen/DirectX/atan.ll
@@ -4,14 +4,14 @@
 
 define noundef float @atan_float(float noundef %a) {
 entry:
-; CHECK:call float @dx.op.unary.f32(i32 17, float %{{.*}}) #[[#ATTR:]]
+; CHECK:call float @dx.op.unary.f32(i32 17, float %{{.*}})
   %elt.atan = call float @llvm.atan.f32(float %a)
   ret float %elt.atan
 }
 
 define noundef half @atan_half(half noundef %a) {
 entry:
-; CHECK:call half @dx.op.unary.f16(i32 17, half %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.unary.f16(i32 17, half %{{.*}})
   %elt.atan = call half @llvm.atan.f16(half %a)
   ret half %elt.atan
 }
@@ -19,23 +19,25 @@ entry:
 define noundef <4 x float> @atan_float4(<4 x float> noundef %a) {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 17, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 17, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 17, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 17, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 17, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 17, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 17, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 17, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.atan.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.atan.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.atan.f16(half)
 declare float @llvm.atan.f32(float)
-declare <4 x float> @llvm.atan.v4f32(<4 x float>) 
+declare <4 x float> @llvm.atan.v4f32(<4 x float>)

--- a/llvm/test/CodeGen/DirectX/ceil.ll
+++ b/llvm/test/CodeGen/DirectX/ceil.ll
@@ -4,14 +4,14 @@
 
 define noundef float @ceil_float(float noundef %a) {
 entry:
-; CHECK:call float @dx.op.unary.f32(i32 28, float %{{.*}}) #[[#ATTR:]]
+; CHECK:call float @dx.op.unary.f32(i32 28, float %{{.*}})
   %elt.ceil = call float @llvm.ceil.f32(float %a)
   ret float %elt.ceil
 }
 
 define noundef half @ceil_half(half noundef %a) {
 entry:
-; CHECK:call half @dx.op.unary.f16(i32 28, half %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.unary.f16(i32 28, half %{{.*}})
   %elt.ceil = call half @llvm.ceil.f16(half %a)
   ret half %elt.ceil
 }
@@ -19,23 +19,25 @@ entry:
 define noundef <4 x float> @ceil_float4(<4 x float> noundef %a) {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 28, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 28, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 28, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 28, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 28, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 28, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 28, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 28, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.ceil.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.ceil.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.ceil.f16(half)
 declare float @llvm.ceil.f32(float)
-declare <4 x float> @llvm.ceil.v4f32(<4 x float>) 
+declare <4 x float> @llvm.ceil.v4f32(<4 x float>)

--- a/llvm/test/CodeGen/DirectX/comput_ids.ll
+++ b/llvm/test/CodeGen/DirectX/comput_ids.ll
@@ -9,7 +9,7 @@ target triple = "dxil-pc-shadermodel6.7-compute"
 ; Function Attrs: noinline nounwind optnone
 define i32 @test_thread_id(i32 %a) #0 {
 entry:
-; CHECK:call i32 @dx.op.threadId.i32(i32 93, i32 %{{.*}}) #[[#ATTR:]]
+; CHECK:call i32 @dx.op.threadId.i32(i32 93, i32 %{{.*}})
   %0 = call i32 @llvm.dx.thread.id(i32 %a)
   ret i32 %0
 }
@@ -18,7 +18,7 @@ entry:
 ; Function Attrs: noinline nounwind optnone
 define i32 @test_group_id(i32 %a) #0 {
 entry:
-; CHECK: call i32 @dx.op.groupId.i32(i32 94, i32 %{{.*}}) #[[#ATTR]]
+; CHECK: call i32 @dx.op.groupId.i32(i32 94, i32 %{{.*}})
   %0 = call i32 @llvm.dx.group.id(i32 %a)
   ret i32 %0
 }
@@ -27,7 +27,7 @@ entry:
 ; Function Attrs: noinline nounwind optnone
 define i32 @test_thread_id_in_group(i32 %a) #0 {
 entry:
-; CHECK: call i32 @dx.op.threadIdInGroup.i32(i32 95, i32 %{{.*}}) #[[#ATTR]]
+; CHECK: call i32 @dx.op.threadIdInGroup.i32(i32 95, i32 %{{.*}})
   %0 = call i32 @llvm.dx.thread.id.in.group(i32 %a)
   ret i32 %0
 }
@@ -36,12 +36,16 @@ entry:
 ; Function Attrs: noinline nounwind optnone
 define i32 @test_flattened_thread_id_in_group() #0 {
 entry:
-; CHECK: call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96) #[[#ATTR]]
+; CHECK: call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96)
   %0 = call i32 @llvm.dx.flattened.thread.id.in.group()
   ret i32 %0
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare i32 @dx.op.threadId.i32(i32, i32) #[[#ATTR0:]]
+; CHECK-DAG: declare i32 @dx.op.groupId.i32(i32, i32) #[[#ATTR0]]
+; CHECK-DAG: declare i32 @dx.op.flattenedThreadIdInGroup.i32(i32) #[[#ATTR0]]
+; CHECK-DAG: declare i32 @dx.op.threadIdInGroup.i32(i32, i32) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 ; Function Attrs: nounwind readnone willreturn
 declare i32 @llvm.dx.thread.id(i32) #1

--- a/llvm/test/CodeGen/DirectX/cos.ll
+++ b/llvm/test/CodeGen/DirectX/cos.ll
@@ -4,14 +4,14 @@
 
 define noundef float @cos_float(float noundef %a) #0 {
 entry:
-; CHECK:call float @dx.op.unary.f32(i32 12, float %{{.*}}) #[[#ATTR:]]
+; CHECK:call float @dx.op.unary.f32(i32 12, float %{{.*}})
   %elt.cos = call float @llvm.cos.f32(float %a)
   ret float %elt.cos
 }
 
 define noundef half @cos_half(half noundef %a) #0 {
 entry:
-; CHECK:call half @dx.op.unary.f16(i32 12, half %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.unary.f16(i32 12, half %{{.*}})
   %elt.cos = call half @llvm.cos.f16(half %a)
   ret half %elt.cos
 }
@@ -19,22 +19,24 @@ entry:
 define noundef <4 x float> @cos_float4(<4 x float> noundef %a) #0 {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 12, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 12, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 12, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 12, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 12, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 12, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 12, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 12, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.cos.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.cos.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.cos.f16(half)
 declare float @llvm.cos.f32(float)

--- a/llvm/test/CodeGen/DirectX/cosh.ll
+++ b/llvm/test/CodeGen/DirectX/cosh.ll
@@ -4,14 +4,14 @@
 
 define noundef float @cosh_float(float noundef %a) {
 entry:
-; CHECK:call float @dx.op.unary.f32(i32 18, float %{{.*}}) #[[#ATTR:]]
+; CHECK:call float @dx.op.unary.f32(i32 18, float %{{.*}})
   %elt.cosh = call float @llvm.cosh.f32(float %a)
   ret float %elt.cosh
 }
 
 define noundef half @cosh_half(half noundef %a) {
 entry:
-; CHECK:call half @dx.op.unary.f16(i32 18, half %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.unary.f16(i32 18, half %{{.*}})
   %elt.cosh = call half @llvm.cosh.f16(half %a)
   ret half %elt.cosh
 }
@@ -19,22 +19,24 @@ entry:
 define noundef <4 x float> @cosh_float4(<4 x float> noundef %a) #0 {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 18, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 18, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 18, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 18, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 18, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 18, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 18, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 18, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.cosh.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.cosh.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.cosh.f16(half)
 declare float @llvm.cosh.f32(float)

--- a/llvm/test/CodeGen/DirectX/countbits.ll
+++ b/llvm/test/CodeGen/DirectX/countbits.ll
@@ -4,7 +4,7 @@
 
 define noundef i16 @test_countbits_short(i16 noundef %a) {
 entry:
-; CHECK: [[A:%.*]] = call i32 @dx.op.unaryBits.i16(i32 31, i16 %{{.*}}) #[[#ATTR:]]
+; CHECK: [[A:%.*]] = call i32 @dx.op.unaryBits.i16(i32 31, i16 %{{.*}})
 ; CHECK-NEXT: [[B:%.*]] = trunc i32 [[A]] to i16
 ; CHECK-NEXT ret i16 [[B]]
   %elt.ctpop = call i16 @llvm.ctpop.i16(i16 %a)
@@ -13,7 +13,7 @@ entry:
 
 define noundef i32 @test_countbits_short2(i16 noundef %a) {
 entry:
-; CHECK: [[A:%.*]] = call i32 @dx.op.unaryBits.i16(i32 31, i16 %{{.*}}) #[[#ATTR]]
+; CHECK: [[A:%.*]] = call i32 @dx.op.unaryBits.i16(i32 31, i16 %{{.*}})
 ; CHECK-NEXT: ret i32 [[A]]
   %elt.ctpop = call i16 @llvm.ctpop.i16(i16 %a)
   %elt.zext = zext i16 %elt.ctpop to i32
@@ -22,7 +22,7 @@ entry:
 
 define noundef i32 @test_countbits_short3(i16 noundef %a) {
 entry:
-; CHECK: [[A:%.*]] = call i32 @dx.op.unaryBits.i16(i32 31, i16 %{{.*}}) #[[#ATTR]]
+; CHECK: [[A:%.*]] = call i32 @dx.op.unaryBits.i16(i32 31, i16 %{{.*}})
 ; CHECK-NEXT: ret i32 [[A]]
   %elt.ctpop = call i16 @llvm.ctpop.i16(i16 %a)
   %elt.sext = sext i16 %elt.ctpop to i32
@@ -31,7 +31,7 @@ entry:
 
 define noundef i32 @test_countbits_int(i32 noundef %a) {
 entry:
-; CHECK: [[A:%.*]] = call i32 @dx.op.unaryBits.i32(i32 31, i32 %{{.*}}) #[[#ATTR]]
+; CHECK: [[A:%.*]] = call i32 @dx.op.unaryBits.i32(i32 31, i32 %{{.*}})
 ; CHECK-NEXT: ret i32 [[A]]
   %elt.ctpop = call i32 @llvm.ctpop.i32(i32 %a)
   ret i32 %elt.ctpop
@@ -39,7 +39,7 @@ entry:
 
 define noundef i64 @test_countbits_long(i64 noundef %a) {
 entry:
-; CHECK: [[A:%.*]] = call i32 @dx.op.unaryBits.i64(i32 31, i64 %{{.*}}) #[[#ATTR]]
+; CHECK: [[A:%.*]] = call i32 @dx.op.unaryBits.i64(i32 31, i64 %{{.*}})
 ; CHECK-NEXT: [[B:%.*]] = zext i32 [[A]] to i64
 ; CHECK-NEXT ret i64 [[B]]
   %elt.ctpop = call i64 @llvm.ctpop.i64(i64 %a)
@@ -48,7 +48,7 @@ entry:
 
 define noundef i32 @test_countbits_long2(i64 noundef %a) {
 entry:
-; CHECK: [[A:%.*]] = call i32 @dx.op.unaryBits.i64(i32 31, i64 %{{.*}}) #[[#ATTR]]
+; CHECK: [[A:%.*]] = call i32 @dx.op.unaryBits.i64(i32 31, i64 %{{.*}})
 ; CHECK-NEXT: ret i32 [[A]]
   %elt.ctpop = call i64 @llvm.ctpop.i64(i64 %a)
   %elt.trunc = trunc i64 %elt.ctpop to i32
@@ -58,13 +58,13 @@ entry:
 define noundef <4 x i32> @countbits_vec4_i32(<4 x i32> noundef %a)  {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x i32> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call i32 @dx.op.unaryBits.i32(i32 31, i32 [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call i32 @dx.op.unaryBits.i32(i32 31, i32 [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x i32> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call i32 @dx.op.unaryBits.i32(i32 31, i32 [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call i32 @dx.op.unaryBits.i32(i32 31, i32 [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x i32> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call i32 @dx.op.unaryBits.i32(i32 31, i32 [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call i32 @dx.op.unaryBits.i32(i32 31, i32 [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x i32> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call i32 @dx.op.unaryBits.i32(i32 31, i32 [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call i32 @dx.op.unaryBits.i32(i32 31, i32 [[ee3]])
   ; CHECK: insertelement <4 x i32> poison, i32 [[ie0]], i64 0
   ; CHECK: insertelement <4 x i32> %{{.*}}, i32 [[ie1]], i64 1
   ; CHECK: insertelement <4 x i32> %{{.*}}, i32 [[ie2]], i64 2
@@ -73,7 +73,10 @@ entry:
   ret <4 x i32> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare i32 @dx.op.unaryBits.i16(i32, i16) #[[#ATTR0:]]
+; CHECK-DAG: declare i32 @dx.op.unaryBits.i32(i32, i32) #[[#ATTR0]]
+; CHECK-DAG: declare i32 @dx.op.unaryBits.i64(i32, i64) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare i16 @llvm.ctpop.i16(i16)
 declare i32 @llvm.ctpop.i32(i32)

--- a/llvm/test/CodeGen/DirectX/dot4add_i8packed.ll
+++ b/llvm/test/CodeGen/DirectX/dot4add_i8packed.ll
@@ -2,11 +2,12 @@
 
 define void @main(i32 %acc, i32 %x, i32 %y) {
 entry:
-; CHECK: call i32 @dx.op.dot4AddPacked.i32(i32 163, i32 %acc, i32 %x, i32 %y) #[[#ATTR:]]
+; CHECK: call i32 @dx.op.dot4AddPacked.i32(i32 163, i32 %acc, i32 %x, i32 %y)
   %0 = call i32 @llvm.dx.dot4add.i8packed(i32 %acc, i32 %x, i32 %y)
   ret void
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK: declare i32 @dx.op.dot4AddPacked.i32(i32, i32, i32, i32) #[[#ATTR0:]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare i32 @llvm.dx.dot4add.i8packed(i32, i32, i32)

--- a/llvm/test/CodeGen/DirectX/dot4add_u8packed.ll
+++ b/llvm/test/CodeGen/DirectX/dot4add_u8packed.ll
@@ -2,11 +2,12 @@
 
 define void @main(i32 %acc, i32 %x, i32 %y) {
 entry:
-; CHECK: call i32 @dx.op.dot4AddPacked.i32(i32 164, i32 %acc, i32 %x, i32 %y) #[[#ATTR:]]
+; CHECK: call i32 @dx.op.dot4AddPacked.i32(i32 164, i32 %acc, i32 %x, i32 %y)
   %0 = call i32 @llvm.dx.dot4add.u8packed(i32 %acc, i32 %x, i32 %y)
   ret void
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK: declare i32 @dx.op.dot4AddPacked.i32(i32, i32, i32, i32) #[[#ATTR0:]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare i32 @llvm.dx.dot4add.u8packed(i32, i32, i32)

--- a/llvm/test/CodeGen/DirectX/exp.ll
+++ b/llvm/test/CodeGen/DirectX/exp.ll
@@ -4,7 +4,7 @@
 
 ; CHECK-LABEL: exp_float
 ; CHECK: fmul float 0x3FF7154760000000, %{{.*}}
-; CHECK: call float @dx.op.unary.f32(i32 21, float %{{.*}}) #[[#ATTR:]]
+; CHECK: call float @dx.op.unary.f32(i32 21, float %{{.*}})
 define noundef float @exp_float(float noundef %a) {
 entry:
   %a.addr = alloca float, align 4
@@ -16,7 +16,7 @@ entry:
 
 ; CHECK-LABEL: exp_half
 ; CHECK: fmul half 0xH3DC5, %{{.*}}
-; CHECK: call half @dx.op.unary.f16(i32 21, half %{{.*}}) #[[#ATTR]]
+; CHECK: call half @dx.op.unary.f16(i32 21, half %{{.*}})
 ; Function Attrs: noinline nounwind optnone
 define noundef half @exp_half(half noundef %a) {
 entry:
@@ -27,7 +27,9 @@ entry:
   ret half %elt.exp
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.exp.f16(half)
 declare float @llvm.exp.f32(float)

--- a/llvm/test/CodeGen/DirectX/fdot.ll
+++ b/llvm/test/CodeGen/DirectX/fdot.ll
@@ -10,7 +10,7 @@ entry:
 ; CHECK: [[A2:%.*]] = extractelement <2 x half> %a, i32 1
 ; CHECK: [[B1:%.*]] = extractelement <2 x half> %b, i32 0
 ; CHECK: [[B2:%.*]] = extractelement <2 x half> %b, i32 1
-; DOPCHECK: call half @dx.op.dot2.f16(i32 54, half [[A1]], half [[A2]], half [[B1]], half [[B2]]) #[[#ATTR:]]
+; DOPCHECK: call half @dx.op.dot2.f16(i32 54, half [[A1]], half [[A2]], half [[B1]], half [[B2]])
 ; EXPCHECK: call half @llvm.dx.dot2.f16(half [[A1]], half [[A2]], half [[B1]], half [[B2]])
   %dx.dot = call half @llvm.dx.fdot.v2f16(<2 x half> %a, <2 x half> %b)
   ret half %dx.dot
@@ -25,7 +25,7 @@ entry:
 ; CHECK: extractelement <3 x half> %b, i32 0
 ; CHECK: extractelement <3 x half> %b, i32 1
 ; CHECK: extractelement <3 x half> %b, i32 2
-; DOPCHECK: call half @dx.op.dot3.f16(i32 55, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call half @dx.op.dot3.f16(i32 55, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}})
 ; EXPCHECK: call half @llvm.dx.dot3.f16(half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}})
   %dx.dot = call half @llvm.dx.fdot.v3f16(<3 x half> %a, <3 x half> %b)
   ret half %dx.dot
@@ -42,7 +42,7 @@ entry:
 ; CHECK: extractelement <4 x half> %b, i32 1
 ; CHECK: extractelement <4 x half> %b, i32 2
 ; CHECK: extractelement <4 x half> %b, i32 3
-; DOPCHECK: call half @dx.op.dot4.f16(i32 56, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call half @dx.op.dot4.f16(i32 56, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}})
 ; EXPCHECK: call half @llvm.dx.dot4.f16(half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}}, half %{{.*}})
   %dx.dot = call half @llvm.dx.fdot.v4f16(<4 x half> %a, <4 x half> %b)
   ret half %dx.dot
@@ -55,7 +55,7 @@ entry:
 ; CHECK: extractelement <2 x float> %a, i32 1
 ; CHECK: extractelement <2 x float> %b, i32 0
 ; CHECK: extractelement <2 x float> %b, i32 1
-; DOPCHECK: call float @dx.op.dot2.f32(i32 54, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call float @dx.op.dot2.f32(i32 54, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}})
 ; EXPCHECK: call float @llvm.dx.dot2.f32(float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}})
   %dx.dot = call float @llvm.dx.fdot.v2f32(<2 x float> %a, <2 x float> %b)
   ret float %dx.dot
@@ -70,7 +70,7 @@ entry:
 ; CHECK: extractelement <3 x float> %b, i32 0
 ; CHECK: extractelement <3 x float> %b, i32 1
 ; CHECK: extractelement <3 x float> %b, i32 2
-; DOPCHECK: call float @dx.op.dot3.f32(i32 55, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call float @dx.op.dot3.f32(i32 55, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}})
 ; EXPCHECK: call float @llvm.dx.dot3.f32(float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}})
   %dx.dot = call float @llvm.dx.fdot.v3f32(<3 x float> %a, <3 x float> %b)
   ret float %dx.dot
@@ -87,13 +87,19 @@ entry:
 ; CHECK: extractelement <4 x float> %b, i32 1
 ; CHECK: extractelement <4 x float> %b, i32 2
 ; CHECK: extractelement <4 x float> %b, i32 3
-; DOPCHECK: call float @dx.op.dot4.f32(i32 56, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call float @dx.op.dot4.f32(i32 56, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}})
 ; EXPCHECK: call float @llvm.dx.dot4.f32(float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}})
   %dx.dot = call float @llvm.dx.fdot.v4f32(<4 x float> %a, <4 x float> %b)
   ret float %dx.dot
 }
 
-; DOPCHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; DOPCHECK-DAG: declare half @dx.op.dot2.f16(i32, half, half, half, half) #[[#ATTR0:]]
+; DOPCHECK-DAG: declare half @dx.op.dot3.f16(i32, half, half, half, half, half, half) #[[#ATTR0]]
+; DOPCHECK-DAG: declare half @dx.op.dot4.f16(i32, half, half, half, half, half, half, half, half) #[[#ATTR0]]
+; DOPCHECK-DAG: declare float @dx.op.dot2.f32(i32, float, float, float, float) #[[#ATTR0]]
+; DOPCHECK-DAG: declare float @dx.op.dot3.f32(i32, float, float, float, float, float, float) #[[#ATTR0]]
+; DOPCHECK-DAG: declare float @dx.op.dot4.f32(i32, float, float, float, float, float, float, float, float) #[[#ATTR0]]
+; DOPCHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half  @llvm.dx.fdot.v2f16(<2 x half> , <2 x half> )
 declare half  @llvm.dx.fdot.v3f16(<3 x half> , <3 x half> )

--- a/llvm/test/CodeGen/DirectX/floor.ll
+++ b/llvm/test/CodeGen/DirectX/floor.ll
@@ -4,14 +4,14 @@
 
 define noundef float @floor_float(float noundef %a) {
 entry:
-; CHECK:call float @dx.op.unary.f32(i32 27, float %{{.*}}) #[[#ATTR:]]
+; CHECK:call float @dx.op.unary.f32(i32 27, float %{{.*}})
   %elt.floor = call float @llvm.floor.f32(float %a)
   ret float %elt.floor
 }
 
 define noundef half @floor_half(half noundef %a) {
 entry:
-; CHECK:call half @dx.op.unary.f16(i32 27, half %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.unary.f16(i32 27, half %{{.*}})
   %elt.floor = call half @llvm.floor.f16(half %a)
   ret half %elt.floor
 }
@@ -19,22 +19,24 @@ entry:
 define noundef <4 x float> @floor_float4(<4 x float> noundef %a) {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 27, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 27, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 27, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 27, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 27, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 27, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 27, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 27, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.floor.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.floor.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.floor.f16(half)
 declare float @llvm.floor.f32(float)

--- a/llvm/test/CodeGen/DirectX/fma.ll
+++ b/llvm/test/CodeGen/DirectX/fma.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32
 target triple = "dxil-pc-shadermodel6.7-library"
 
 ; CHECK-LABEL: define double @fma_double(
-; CHECK: call double @dx.op.tertiary.f64(i32 47, double %{{.*}}, double %{{.*}}, double %{{.*}}) #[[#ATTR:]]
+; CHECK: call double @dx.op.tertiary.f64(i32 47, double %{{.*}}, double %{{.*}}, double %{{.*}})
 define double @fma_double(double %a, double %b, double %c) {
   %r = call double @llvm.fma.f64(double %a, double %b, double %c)
   ret double %r
@@ -14,11 +14,11 @@ define double @fma_double(double %a, double %b, double %c) {
 ; CHECK: extractelement <2 x double> %a, i64 0
 ; CHECK: extractelement <2 x double> %b, i64 0
 ; CHECK: extractelement <2 x double> %c, i64 0
-; CHECK: call double @dx.op.tertiary.f64(i32 47, double %{{.*}}, double %{{.*}}, double %{{.*}}) #[[#ATTR]]
+; CHECK: call double @dx.op.tertiary.f64(i32 47, double %{{.*}}, double %{{.*}}, double %{{.*}})
 ; CHECK: extractelement <2 x double> %a, i64 1
 ; CHECK: extractelement <2 x double> %b, i64 1
 ; CHECK: extractelement <2 x double> %c, i64 1
-; CHECK: call double @dx.op.tertiary.f64(i32 47, double %{{.*}}, double %{{.*}}, double %{{.*}}) #[[#ATTR]]
+; CHECK: call double @dx.op.tertiary.f64(i32 47, double %{{.*}}, double %{{.*}}, double %{{.*}})
 ; CHECK: insertelement <2 x double> poison, double %{{.*}}, i64 0
 ; CHECK: insertelement <2 x double> %{{.*}}, double %{{.*}}, i64 1
 define <2 x double> @fma_v2f64(<2 x double> %a, <2 x double> %b,
@@ -32,11 +32,11 @@ define <2 x double> @fma_v2f64(<2 x double> %a, <2 x double> %b,
 ; CHECK: extractelement <16 x double> %a, i64 0
 ; CHECK: extractelement <16 x double> %b, i64 0
 ; CHECK: extractelement <16 x double> %c, i64 0
-; CHECK: call double @dx.op.tertiary.f64(i32 47, double %{{.*}}, double %{{.*}}, double %{{.*}}) #[[#ATTR]]
+; CHECK: call double @dx.op.tertiary.f64(i32 47, double %{{.*}}, double %{{.*}}, double %{{.*}})
 ; CHECK: extractelement <16 x double> %a, i64 15
 ; CHECK: extractelement <16 x double> %b, i64 15
 ; CHECK: extractelement <16 x double> %c, i64 15
-; CHECK: call double @dx.op.tertiary.f64(i32 47, double %{{.*}}, double %{{.*}}, double %{{.*}}) #[[#ATTR]]
+; CHECK: call double @dx.op.tertiary.f64(i32 47, double %{{.*}}, double %{{.*}}, double %{{.*}})
 ; CHECK: insertelement <16 x double> poison, double %{{.*}}, i64 0
 ; CHECK: insertelement <16 x double> %{{.*}}, double %{{.*}}, i64 15
 define <16 x double> @fma_v16f64(<16 x double> %a, <16 x double> %b,
@@ -50,4 +50,5 @@ declare double @llvm.fma.f64(double, double, double)
 declare <2 x double> @llvm.fma.v2f64(<2 x double>, <2 x double>, <2 x double>)
 declare <16 x double> @llvm.fma.v16f64(<16 x double>, <16 x double>, <16 x double>)
 
-; CHECK: attributes #[[#ATTR]] = { memory(none) }
+; CHECK: declare double @dx.op.tertiary.f64(i32, double, double, double) #[[#ATTR0:]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }

--- a/llvm/test/CodeGen/DirectX/fmad.ll
+++ b/llvm/test/CodeGen/DirectX/fmad.ll
@@ -1,11 +1,12 @@
 ; RUN: opt -S -dxil-op-lower < %s | FileCheck %s
 
 ; Make sure dxil operation function calls for round are generated for float and half.
-; CHECK:call half @dx.op.tertiary.f16(i32 46, half %{{.*}}, half %{{.*}}, half %{{.*}}) #[[#ATTR:]]
-; CHECK:call float @dx.op.tertiary.f32(i32 46, float %{{.*}}, float %{{.*}}, float %{{.*}}) #[[#ATTR]]
-; CHECK:call double @dx.op.tertiary.f64(i32 46, double %{{.*}}, double %{{.*}}, double %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.tertiary.f16(i32 46, half %{{.*}}, half %{{.*}}, half %{{.*}}) 
+; CHECK:call float @dx.op.tertiary.f32(i32 46, float %{{.*}}, float %{{.*}}, float %{{.*}}) 
+; CHECK:call double @dx.op.tertiary.f64(i32 46, double %{{.*}}, double %{{.*}}, double %{{.*}}) 
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK: declare half @dx.op.tertiary.f16(i32, half, half, half) #[[#ATTR0:]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-pc-shadermodel6.7-library"

--- a/llvm/test/CodeGen/DirectX/fmax.ll
+++ b/llvm/test/CodeGen/DirectX/fmax.ll
@@ -5,7 +5,7 @@
 ; CHECK-LABEL:test_fmax_half
 define noundef half @test_fmax_half(half noundef %a, half noundef %b) {
 entry:
-; CHECK: call half @dx.op.binary.f16(i32 35, half %{{.*}}, half %{{.*}}) #[[#ATTR:]]
+; CHECK: call half @dx.op.binary.f16(i32 35, half %{{.*}}, half %{{.*}})
   %0 = call half @llvm.maxnum.f16(half %a, half %b)
   ret half %0
 }
@@ -13,7 +13,7 @@ entry:
 ; CHECK-LABEL:test_fmax_float
 define noundef float @test_fmax_float(float noundef %a, float noundef %b) {
 entry:
-; CHECK: call float @dx.op.binary.f32(i32 35, float %{{.*}}, float %{{.*}}) #[[#ATTR]]
+; CHECK: call float @dx.op.binary.f32(i32 35, float %{{.*}}, float %{{.*}})
   %0 = call float @llvm.maxnum.f32(float %a, float %b)
   ret float %0
 }
@@ -21,12 +21,15 @@ entry:
 ; CHECK-LABEL:test_fmax_double
 define noundef double @test_fmax_double(double noundef %a, double noundef %b) {
 entry:
-; CHECK: call double @dx.op.binary.f64(i32 35, double %{{.*}}, double %{{.*}}) #[[#ATTR]]
+; CHECK: call double @dx.op.binary.f64(i32 35, double %{{.*}}, double %{{.*}})
   %0 = call double @llvm.maxnum.f64(double %a, double %b)
   ret double %0
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.binary.f16(i32, half, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.binary.f32(i32, float, float) #[[#ATTR0]]
+; CHECK-DAG: declare double @dx.op.binary.f64(i32, double, double) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.maxnum.f16(half, half)
 declare float @llvm.maxnum.f32(float, float)

--- a/llvm/test/CodeGen/DirectX/fmin.ll
+++ b/llvm/test/CodeGen/DirectX/fmin.ll
@@ -5,7 +5,7 @@
 ; CHECK-LABEL:test_fmin_half
 define noundef half @test_fmin_half(half noundef %a, half noundef %b) {
 entry:
-; CHECK: call half @dx.op.binary.f16(i32 36, half %{{.*}}, half %{{.*}}) #[[#ATTR:]]
+; CHECK: call half @dx.op.binary.f16(i32 36, half %{{.*}}, half %{{.*}})
   %0 = call half @llvm.minnum.f16(half %a, half %b)
   ret half %0
 }
@@ -13,7 +13,7 @@ entry:
 ; CHECK-LABEL:test_fmin_float
 define noundef float @test_fmin_float(float noundef %a, float noundef %b) {
 entry:
-; CHECK: call float @dx.op.binary.f32(i32 36, float %{{.*}}, float %{{.*}}) #[[#ATTR]]
+; CHECK: call float @dx.op.binary.f32(i32 36, float %{{.*}}, float %{{.*}})
   %0 = call float @llvm.minnum.f32(float %a, float %b)
   ret float %0
 }
@@ -21,12 +21,15 @@ entry:
 ; CHECK-LABEL:test_fmin_double
 define noundef double @test_fmin_double(double noundef %a, double noundef %b) {
 entry:
-; CHECK: call double @dx.op.binary.f64(i32 36, double %{{.*}}, double %{{.*}}) #[[#ATTR]]
+; CHECK: call double @dx.op.binary.f64(i32 36, double %{{.*}}, double %{{.*}})
   %0 = call double @llvm.minnum.f64(double %a, double %b)
   ret double %0
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.binary.f16(i32, half, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.binary.f32(i32, float, float) #[[#ATTR0]]
+; CHECK-DAG: declare double @dx.op.binary.f64(i32, double, double) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.minnum.f16(half, half)
 declare float @llvm.minnum.f32(float, float)

--- a/llvm/test/CodeGen/DirectX/frac.ll
+++ b/llvm/test/CodeGen/DirectX/frac.ll
@@ -7,7 +7,7 @@ define noundef half @frac_half(half noundef %a) {
 ; CHECK-LABEL: define noundef half @frac_half(
 ; CHECK-SAME: half noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[DX_FRAC1:%.*]] = call half @dx.op.unary.f16(i32 22, half [[A]]) #[[#ATTR:]]
+; CHECK-NEXT:    [[DX_FRAC1:%.*]] = call half @dx.op.unary.f16(i32 22, half [[A]])
 ; CHECK-NEXT:    ret half [[DX_FRAC1]]
 ;
 entry:
@@ -19,7 +19,7 @@ define noundef float @frac_float(float noundef %a) #0 {
 ; CHECK-LABEL: define noundef float @frac_float(
 ; CHECK-SAME: float noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[DX_FRAC1:%.*]] = call float @dx.op.unary.f32(i32 22, float [[A]]) #[[#ATTR]]
+; CHECK-NEXT:    [[DX_FRAC1:%.*]] = call float @dx.op.unary.f32(i32 22, float [[A]])
 ; CHECK-NEXT:    ret float [[DX_FRAC1]]
 ;
 entry:
@@ -32,13 +32,13 @@ define noundef <4 x float> @frac_float4(<4 x float> noundef %a) #0 {
 ; CHECK-SAME: <4 x float> noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[A_I0:%.*]] = extractelement <4 x float> [[A]], i64 0
-; CHECK-NEXT:    [[DOTI04:%.*]] = call float @dx.op.unary.f32(i32 22, float [[A_I0]]) #[[#ATTR]]
+; CHECK-NEXT:    [[DOTI04:%.*]] = call float @dx.op.unary.f32(i32 22, float [[A_I0]])
 ; CHECK-NEXT:    [[A_I1:%.*]] = extractelement <4 x float> [[A]], i64 1
-; CHECK-NEXT:    [[DOTI13:%.*]] = call float @dx.op.unary.f32(i32 22, float [[A_I1]]) #[[#ATTR]]
+; CHECK-NEXT:    [[DOTI13:%.*]] = call float @dx.op.unary.f32(i32 22, float [[A_I1]])
 ; CHECK-NEXT:    [[A_I2:%.*]] = extractelement <4 x float> [[A]], i64 2
-; CHECK-NEXT:    [[DOTI22:%.*]] = call float @dx.op.unary.f32(i32 22, float [[A_I2]]) #[[#ATTR]]
+; CHECK-NEXT:    [[DOTI22:%.*]] = call float @dx.op.unary.f32(i32 22, float [[A_I2]])
 ; CHECK-NEXT:    [[A_I3:%.*]] = extractelement <4 x float> [[A]], i64 3
-; CHECK-NEXT:    [[DOTI31:%.*]] = call float @dx.op.unary.f32(i32 22, float [[A_I3]]) #[[#ATTR]]
+; CHECK-NEXT:    [[DOTI31:%.*]] = call float @dx.op.unary.f32(i32 22, float [[A_I3]])
 ; CHECK-NEXT:    [[DOTUPTO0:%.*]] = insertelement <4 x float> poison, float [[DOTI04]], i64 0
 ; CHECK-NEXT:    [[DOTUPTO1:%.*]] = insertelement <4 x float> [[DOTUPTO0]], float [[DOTI13]], i64 1
 ; CHECK-NEXT:    [[DOTUPTO2:%.*]] = insertelement <4 x float> [[DOTUPTO1]], float [[DOTI22]], i64 2
@@ -50,7 +50,9 @@ entry:
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half  @llvm.dx.frac.f16(half)
 declare float @llvm.dx.frac.f32(float)

--- a/llvm/test/CodeGen/DirectX/idot.ll
+++ b/llvm/test/CodeGen/DirectX/idot.ll
@@ -12,7 +12,7 @@ entry:
 ; CHECK: extractelement <2 x i16> %a, i64 1
 ; CHECK: extractelement <2 x i16> %b, i64 1
 ; EXPCHECK: call i16 @llvm.dx.imad.i16(i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}})
-; DOPCHECK: call i16 @dx.op.tertiary.i16(i32 48, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR:]]
+; DOPCHECK: call i16 @dx.op.tertiary.i16(i32 48, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}})
   %dot = call i16 @llvm.dx.sdot.v3i16(<2 x i16> %a, <2 x i16> %b)
   ret i16 %dot
 }
@@ -26,15 +26,15 @@ entry:
 ; CHECK: extractelement <4 x i32> %a, i64 1
 ; CHECK: extractelement <4 x i32> %b, i64 1
 ; EXPCHECK: call i32 @llvm.dx.imad.i32(i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}})
-; DOPCHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}})
 ; CHECK: extractelement <4 x i32> %a, i64 2
 ; CHECK: extractelement <4 x i32> %b, i64 2
 ; EXPCHECK: call i32 @llvm.dx.imad.i32(i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}})
-; DOPCHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}})
 ; CHECK: extractelement <4 x i32> %a, i64 3
 ; CHECK: extractelement <4 x i32> %b, i64 3
 ; EXPCHECK: call i32 @llvm.dx.imad.i32(i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}})
-; DOPCHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}})
   %dot = call i32 @llvm.dx.sdot.v4i32(<4 x i32> %a, <4 x i32> %b)
   ret i32 %dot
 }
@@ -48,11 +48,11 @@ entry:
 ; CHECK: extractelement <3 x i16> %a, i64 1
 ; CHECK: extractelement <3 x i16> %b, i64 1
 ; EXPCHECK: call i16 @llvm.dx.umad.i16(i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}})
-; DOPCHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}})
 ; CHECK: extractelement <3 x i16> %a, i64 2
 ; CHECK: extractelement <3 x i16> %b, i64 2
 ; EXPCHECK: call i16 @llvm.dx.umad.i16(i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}})
-; DOPCHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}})
   %dot = call i16 @llvm.dx.udot.v3i16(<3 x i16> %a, <3 x i16> %b)
   ret i16 %dot
 }
@@ -66,15 +66,15 @@ entry:
 ; CHECK: extractelement <4 x i32> %a, i64 1
 ; CHECK: extractelement <4 x i32> %b, i64 1
 ; EXPCHECK: call i32 @llvm.dx.umad.i32(i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}})
-; DOPCHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}})
 ; CHECK: extractelement <4 x i32> %a, i64 2
 ; CHECK: extractelement <4 x i32> %b, i64 2
 ; EXPCHECK: call i32 @llvm.dx.umad.i32(i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}})
-; DOPCHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}})
 ; CHECK: extractelement <4 x i32> %a, i64 3
 ; CHECK: extractelement <4 x i32> %b, i64 3
 ; EXPCHECK: call i32 @llvm.dx.umad.i32(i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}})
-; DOPCHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}})
   %dot = call i32 @llvm.dx.udot.v4i32(<4 x i32> %a, <4 x i32> %b)
   ret i32 %dot
 }
@@ -88,12 +88,15 @@ entry:
 ; CHECK: extractelement <2 x i64> %a, i64 1
 ; CHECK: extractelement <2 x i64> %b, i64 1
 ; EXPCHECK: call i64 @llvm.dx.umad.i64(i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}})
-; DOPCHECK: call i64 @dx.op.tertiary.i64(i32 49, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call i64 @dx.op.tertiary.i64(i32 49, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}})
   %dot = call i64 @llvm.dx.udot.v2i64(<2 x i64> %a, <2 x i64> %b)
   ret i64 %dot
 }
 
-; DOPCHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; DOPCHECK-DAG: declare i16 @dx.op.tertiary.i16(i32, i16, i16, i16) #[[#ATTR0:]]
+; DOPCHECK-DAG: declare i32 @dx.op.tertiary.i32(i32, i32, i32, i32) #[[#ATTR0]]
+; DOPCHECK-DAG: declare i64 @dx.op.tertiary.i64(i32, i64, i64, i64) #[[#ATTR0]]
+; DOPCHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare i16 @llvm.dx.sdot.v2i16(<2 x i16>, <2 x i16>)
 declare i32 @llvm.dx.sdot.v4i32(<4 x i32>, <4 x i32>)

--- a/llvm/test/CodeGen/DirectX/imad.ll
+++ b/llvm/test/CodeGen/DirectX/imad.ll
@@ -7,7 +7,7 @@ target triple = "dxil-pc-shadermodel6.7-library"
 ; Function Attrs: noinline nounwind optnone
 define noundef i16 @imad_short(i16 noundef %p0, i16 noundef %p1, i16 noundef %p2) #0 {
 entry:
-  ; CHECK: call i16 @dx.op.tertiary.i16(i32 48, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR:]]
+  ; CHECK: call i16 @dx.op.tertiary.i16(i32 48, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) 
   %p2.addr = alloca i16, align 2
   %p1.addr = alloca i16, align 2
   %p0.addr = alloca i16, align 2
@@ -27,7 +27,7 @@ declare i16 @llvm.dx.imad.i16(i16, i16, i16) #1
 ; Function Attrs: noinline nounwind optnone
 define noundef i32 @imad_int(i32 noundef %p0, i32 noundef %p1, i32 noundef %p2) #0 {
 entry:
-  ; CHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) 
   %p2.addr = alloca i32, align 4
   %p1.addr = alloca i32, align 4
   %p0.addr = alloca i32, align 4
@@ -47,7 +47,7 @@ declare i32 @llvm.dx.imad.i32(i32, i32, i32) #1
 ; Function Attrs: noinline nounwind optnone
 define noundef i64 @imad_int64(i64 noundef %p0, i64 noundef %p1, i64 noundef %p2) #0 {
 entry:
-  ; CHECK: call i64 @dx.op.tertiary.i64(i32 48, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i64 @dx.op.tertiary.i64(i32 48, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) 
   %p2.addr = alloca i64, align 8
   %p1.addr = alloca i64, align 8
   %p0.addr = alloca i64, align 8
@@ -70,19 +70,19 @@ entry:
   ; CHECK: extractelement <4 x i16> %p0, i64 0
   ; CHECK: extractelement <4 x i16> %p1, i64 0
   ; CHECK: extractelement <4 x i16> %p2, i64 0
-  ; CHECK: call i16 @dx.op.tertiary.i16(i32 48, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i16 @dx.op.tertiary.i16(i32 48, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) 
   ; CHECK: extractelement <4 x i16> %p0, i64 1
   ; CHECK: extractelement <4 x i16> %p1, i64 1
   ; CHECK: extractelement <4 x i16> %p2, i64 1
-  ; CHECK: call i16 @dx.op.tertiary.i16(i32 48, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i16 @dx.op.tertiary.i16(i32 48, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) 
   ; CHECK: extractelement <4 x i16> %p0, i64 2
   ; CHECK: extractelement <4 x i16> %p1, i64 2
   ; CHECK: extractelement <4 x i16> %p2, i64 2
-  ; CHECK: call i16 @dx.op.tertiary.i16(i32 48, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i16 @dx.op.tertiary.i16(i32 48, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) 
   ; CHECK: extractelement <4 x i16> %p0, i64 3
   ; CHECK: extractelement <4 x i16> %p1, i64 3
   ; CHECK: extractelement <4 x i16> %p2, i64 3
-  ; CHECK: call i16 @dx.op.tertiary.i16(i32 48, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i16 @dx.op.tertiary.i16(i32 48, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) 
   ; CHECK: insertelement <4 x i16> poison, i16 %{{.*}}, i64 0
   ; CHECK: insertelement <4 x i16> %{{.*}}, i16 %{{.*}}, i64 1
   ; CHECK: insertelement <4 x i16> %{{.*}}, i16 %{{.*}}, i64 2
@@ -100,19 +100,19 @@ entry:
   ; CHECK: extractelement <4 x i32> %p0, i64 0
   ; CHECK: extractelement <4 x i32> %p1, i64 0
   ; CHECK: extractelement <4 x i32> %p2, i64 0
-  ; CHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) 
   ; CHECK: extractelement <4 x i32> %p0, i64 1
   ; CHECK: extractelement <4 x i32> %p1, i64 1
   ; CHECK: extractelement <4 x i32> %p2, i64 1
-  ; CHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) 
   ; CHECK: extractelement <4 x i32> %p0, i64 2
   ; CHECK: extractelement <4 x i32> %p1, i64 2
   ; CHECK: extractelement <4 x i32> %p2, i64 2
-  ; CHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) 
   ; CHECK: extractelement <4 x i32> %p0, i64 3
   ; CHECK: extractelement <4 x i32> %p1, i64 3
   ; CHECK: extractelement <4 x i32> %p2, i64 3
-  ; CHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) 
   ; CHECK: insertelement <4 x i32> poison, i32 %{{.*}}, i64 0
   ; CHECK: insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i64 1
   ; CHECK: insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i64 2
@@ -130,19 +130,19 @@ entry:
   ; CHECK: extractelement <4 x i64> %p0, i64 0
   ; CHECK: extractelement <4 x i64> %p1, i64 0
   ; CHECK: extractelement <4 x i64> %p2, i64 0
-  ; CHECK: call i64 @dx.op.tertiary.i64(i32 48, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i64 @dx.op.tertiary.i64(i32 48, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) 
   ; CHECK: extractelement <4 x i64> %p0, i64 1
   ; CHECK: extractelement <4 x i64> %p1, i64 1
   ; CHECK: extractelement <4 x i64> %p2, i64 1
-  ; CHECK: call i64 @dx.op.tertiary.i64(i32 48, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i64 @dx.op.tertiary.i64(i32 48, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) 
   ; CHECK: extractelement <4 x i64> %p0, i64 2
   ; CHECK: extractelement <4 x i64> %p1, i64 2
   ; CHECK: extractelement <4 x i64> %p2, i64 2
-  ; CHECK: call i64 @dx.op.tertiary.i64(i32 48, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i64 @dx.op.tertiary.i64(i32 48, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) 
   ; CHECK: extractelement <4 x i64> %p0, i64 3
   ; CHECK: extractelement <4 x i64> %p1, i64 3
   ; CHECK: extractelement <4 x i64> %p2, i64 3
-  ; CHECK: call i64 @dx.op.tertiary.i64(i32 48, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i64 @dx.op.tertiary.i64(i32 48, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) 
   ; CHECK: insertelement <4 x i64> poison, i64 %{{.*}}, i64 0
   ; CHECK: insertelement <4 x i64> %{{.*}}, i64 %{{.*}}, i64 1
   ; CHECK: insertelement <4 x i64> %{{.*}}, i64 %{{.*}}, i64 2
@@ -154,4 +154,5 @@ entry:
 ; Function Attrs: nocallback nofree nosync nounwind willreturn
 declare <4 x i64> @llvm.dx.imad.v4i64(<4 x i64>, <4 x i64>, <4 x i64>) #1
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK: declare i16 @dx.op.tertiary.i16(i32, i16, i16, i16) #[[#ATTR0:]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }

--- a/llvm/test/CodeGen/DirectX/is_fpclass.ll
+++ b/llvm/test/CodeGen/DirectX/is_fpclass.ll
@@ -38,7 +38,7 @@ define noundef i1 @isnan(float noundef %a) {
 ; CHECK-LABEL: define noundef i1 @isnan(
 ; CHECK-SAME: float noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 8, float [[A]]) #[[ATTR0:[0-9]+]]
+; CHECK-NEXT:    [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 8, float [[A]])
 ; CHECK-NEXT:    ret i1 [[TMP0]]
 ;
 entry:
@@ -50,7 +50,7 @@ define noundef i1 @isnanh(half noundef %a) {
 ; CHECK-LABEL: define noundef i1 @isnanh(
 ; CHECK-SAME: half noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; SM69CHECK-NEXT:  [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 8, half [[A]]) #[[ATTR0:[0-9]+]]
+; SM69CHECK-NEXT:  [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 8, half [[A]])
 ; SMOLDCHECK-NEXT: [[BITCAST:%.*]] = bitcast half [[A]] to i16
 ; SMOLDCHECK-NEXT: [[AND:%.*]] = and i16 [[BITCAST]], 31744
 ; SMOLDCHECK-NEXT: [[CMPHIGH:%.*]] = icmp eq i16 [[AND]], 31744
@@ -70,9 +70,9 @@ define noundef <2 x i1> @isnanv2(<2 x float> noundef %a) {
 ; CHECK-SAME: <2 x float> noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[A_I0:%.*]] = extractelement <2 x float> [[A]], i64 0
-; CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 8, float [[A_I0]]) #[[ATTR0]]
+; CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 8, float [[A_I0]])
 ; CHECK-NEXT:    [[A_I1:%.*]] = extractelement <2 x float> [[A]], i64 1
-; CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 8, float [[A_I1]]) #[[ATTR0]]
+; CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 8, float [[A_I1]])
 ; CHECK-NEXT:    [[DOTUPTO0:%.*]] = insertelement <2 x i1> poison, i1 [[DOTI02]], i64 0
 ; CHECK-NEXT:    [[TMP0:%.*]] = insertelement <2 x i1> [[DOTUPTO0]], i1 [[DOTI11]], i64 1
 ; CHECK-NEXT:    ret <2 x i1> [[TMP0]]
@@ -87,9 +87,9 @@ define noundef <2 x i1> @isnanhv2(<2 x half> noundef %a) {
 ; CHECK-SAME: <2 x half> noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[A_I0:%.*]] = extractelement <2 x half> [[A]], i64 0
-; SM69CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 8, half [[A_I0]]) #[[ATTR0:[0-9]+]]
+; SM69CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 8, half [[A_I0]])
 ; SM69CHECK-NEXT:    [[A_I1:%.*]] = extractelement <2 x half> [[A]], i64 1
-; SM69CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 8, half [[A_I1]]) #[[ATTR0]]
+; SM69CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 8, half [[A_I1]])
 ; SM69CHECK-NEXT:    [[DOTUPTO0:%.*]] = insertelement <2 x i1> poison, i1 [[DOTI02]], i64 0
 ; SM69CHECK-NEXT:    [[TMP0:%.*]] = insertelement <2 x i1> [[DOTUPTO0]], i1 [[DOTI11]], i64 1
 ; SM69CHECK-NEXT:    ret <2 x i1> [[TMP0]]
@@ -120,7 +120,7 @@ define noundef i1 @isinf(float noundef %a) {
 ; CHECK-LABEL: define noundef i1 @isinf(
 ; CHECK-SAME: float noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 9, float [[A]]) #[[ATTR0]]
+; CHECK-NEXT:    [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 9, float [[A]])
 ; CHECK-NEXT:    ret i1 [[TMP0]]
 ;
 entry:
@@ -132,7 +132,7 @@ define noundef i1 @isinfh(half noundef %a) {
 ; CHECK-LABEL: define noundef i1 @isinfh(
 ; CHECK-SAME: half noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; SM69CHECK-NEXT:    [[ISINF:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 9, half [[A]]) #[[ATTR0]]
+; SM69CHECK-NEXT:    [[ISINF:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 9, half [[A]])
 ; SMOLDCHECK-NEXT: [[BITCAST:%.*]] = bitcast half [[A]] to i16
 ; SMOLDCHECK-NEXT: [[CMPHIGH:%.*]] = icmp eq i16 [[BITCAST]], 31744
 ; SMOLDCHECK-NEXT: [[CMPLOW:%.*]] = icmp eq i16 [[BITCAST]], -1024
@@ -150,9 +150,9 @@ define noundef <2 x i1> @isinfv2(<2 x float> noundef %a) {
 ; CHECK-SAME: <2 x float> noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[A_I0:%.*]] = extractelement <2 x float> [[A]], i64 0
-; CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 9, float [[A_I0]]) #[[ATTR0]]
+; CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 9, float [[A_I0]])
 ; CHECK-NEXT:    [[A_I1:%.*]] = extractelement <2 x float> [[A]], i64 1
-; CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 9, float [[A_I1]]) #[[ATTR0]]
+; CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 9, float [[A_I1]])
 ; CHECK-NEXT:    [[DOTUPTO0:%.*]] = insertelement <2 x i1> poison, i1 [[DOTI02]], i64 0
 ; CHECK-NEXT:    [[TMP0:%.*]] = insertelement <2 x i1> [[DOTUPTO0]], i1 [[DOTI11]], i64 1
 ; CHECK-NEXT:    ret <2 x i1> [[TMP0]]
@@ -166,7 +166,7 @@ define noundef i1 @isfinite(float noundef %a) {
 ; CHECK-LABEL: define noundef i1 @isfinite(
 ; CHECK-SAME: float noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 10, float [[A]]) #[[ATTR0]]
+; CHECK-NEXT:    [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 10, float [[A]])
 ; CHECK-NEXT:    ret i1 [[TMP0]]
 ;
 entry:
@@ -178,7 +178,7 @@ define noundef i1 @isfiniteh(half noundef %a) {
 ; CHECK-LABEL: define noundef i1 @isfiniteh(
 ; CHECK-SAME: half noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; SM69CHECK-NEXT:  [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 10, half [[A]]) #[[ATTR0]]
+; SM69CHECK-NEXT:  [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 10, half [[A]])
 ; SMOLDCHECK-NEXT: [[BITCAST:%.*]] = bitcast half [[A]] to i16
 ; SMOLDCHECK-NEXT: [[AND:%.*]] = and i16 [[BITCAST]], 31744
 ; SMOLDCHECK-NEXT: [[CMPHIGH:%.*]] = icmp ne i16 [[AND]], 31744
@@ -195,9 +195,9 @@ define noundef <2 x i1> @isfinitev2(<2 x float> noundef %a) {
 ; CHECK-SAME: <2 x float> noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[A_I0:%.*]] = extractelement <2 x float> [[A]], i64 0
-; CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 10, float [[A_I0]]) #[[ATTR0]]
+; CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 10, float [[A_I0]])
 ; CHECK-NEXT:    [[A_I1:%.*]] = extractelement <2 x float> [[A]], i64 1
-; CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 10, float [[A_I1]]) #[[ATTR0]]
+; CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 10, float [[A_I1]])
 ; CHECK-NEXT:    [[DOTUPTO0:%.*]] = insertelement <2 x i1> poison, i1 [[DOTI02]], i64 0
 ; CHECK-NEXT:    [[TMP0:%.*]] = insertelement <2 x i1> [[DOTUPTO0]], i1 [[DOTI11]], i64 1
 ; CHECK-NEXT:    ret <2 x i1> [[TMP0]]
@@ -212,9 +212,9 @@ define noundef <2 x i1> @isfinitehv2(<2 x half> noundef %a) {
 ; CHECK-SAME: <2 x half> noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; SM69CHECK-NEXT:    [[A_I0:%.*]] = extractelement <2 x half> [[A]], i64 0
-; SM69CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 10, half [[A_I0]]) #[[ATTR0:[0-9]+]]
+; SM69CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 10, half [[A_I0]])
 ; SM69CHECK-NEXT:    [[A_I1:%.*]] = extractelement <2 x half> [[A]], i64 1
-; SM69CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 10, half [[A_I1]]) #[[ATTR0]]
+; SM69CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 10, half [[A_I1]])
 ; SM69CHECK-NEXT:    [[DOTUPTO0:%.*]] = insertelement <2 x i1> poison, i1 [[DOTI02]], i64 0
 ; SM69CHECK-NEXT:    [[TMP0:%.*]] = insertelement <2 x i1> [[DOTUPTO0]], i1 [[DOTI11]], i64 1
 ; SM69CHECK-NEXT:    ret <2 x i1> [[TMP0]]
@@ -240,7 +240,7 @@ define noundef i1 @isnormal(float noundef %a) {
 ; CHECK-LABEL: define noundef i1 @isnormal(
 ; CHECK-SAME: float noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 11, float [[A]]) #[[ATTR0]]
+; CHECK-NEXT:    [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 11, float [[A]])
 ; CHECK-NEXT:    ret i1 [[TMP0]]
 ;
 entry:
@@ -252,7 +252,7 @@ define noundef i1 @isnormalh(half noundef %a) {
 ; CHECK-LABEL: define noundef i1 @isnormalh(
 ; CHECK-SAME: half noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; SM69CHECK-NEXT:  [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 11, half [[A]]) #[[ATTR0]]
+; SM69CHECK-NEXT:  [[TMP0:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 11, half [[A]])
 ; SMOLDCHECK-NEXT: [[BITCAST:%.*]] = bitcast half [[A]] to i16
 ; SMOLDCHECK-NEXT: [[AND:%.*]] = and i16 [[BITCAST]], 31744
 ; SMOLDCHECK-NEXT: [[CMPZERO:%.*]] = icmp ne i16 [[AND]], 0
@@ -271,9 +271,9 @@ define noundef <2 x i1> @isnormalv2(<2 x float> noundef %a) {
 ; CHECK-SAME: <2 x float> noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[A_I0:%.*]] = extractelement <2 x float> [[A]], i64 0
-; CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 11, float [[A_I0]]) #[[ATTR0]]
+; CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 11, float [[A_I0]])
 ; CHECK-NEXT:    [[A_I1:%.*]] = extractelement <2 x float> [[A]], i64 1
-; CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 11, float [[A_I1]]) #[[ATTR0]]
+; CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f32(i32 11, float [[A_I1]])
 ; CHECK-NEXT:    [[DOTUPTO0:%.*]] = insertelement <2 x i1> poison, i1 [[DOTI02]], i64 0
 ; CHECK-NEXT:    [[TMP0:%.*]] = insertelement <2 x i1> [[DOTUPTO0]], i1 [[DOTI11]], i64 1
 ; CHECK-NEXT:    ret <2 x i1> [[TMP0]]
@@ -288,9 +288,9 @@ define noundef <2 x i1> @isnormalhv2(<2 x half> noundef %a) {
 ; CHECK-SAME: <2 x half> noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[A_I0:%.*]] = extractelement <2 x half> [[A]], i64 0
-; SM69CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 11, half [[A_I0]]) #[[ATTR0:[0-9]+]]
+; SM69CHECK-NEXT:    [[DOTI02:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 11, half [[A_I0]])
 ; SM69CHECK-NEXT:    [[A_I1:%.*]] = extractelement <2 x half> [[A]], i64 1
-; SM69CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 11, half [[A_I1]]) #[[ATTR0]]
+; SM69CHECK-NEXT:    [[DOTI11:%.*]] = call i1 @dx.op.isSpecialFloat.f16(i32 11, half [[A_I1]])
 ; SM69CHECK-NEXT:    [[DOTUPTO0:%.*]] = insertelement <2 x i1> poison, i1 [[DOTI02]], i64 0
 ; SM69CHECK-NEXT:    [[TMP0:%.*]] = insertelement <2 x i1> [[DOTUPTO0]], i1 [[DOTI11]], i64 1
 ; SM69CHECK-NEXT:    ret <2 x i1> [[TMP0]]
@@ -314,6 +314,10 @@ entry:
   %0 = call <2 x i1> @llvm.is.fpclass.v2f16(<2 x half> %a, i32 264)
   ret <2 x i1> %0
 }
+
+; CHECK-DAG: declare i1 @dx.op.isSpecialFloat.f32(i32, float) #[[#ATTR0:]]
+; SM69CHECK-DAG: declare i1 @dx.op.isSpecialFloat.f16(i32, half) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare i1 @llvm.is.fpclass.f32(float, i32 immarg)
 declare <2 x i1> @llvm.is.fpclass.v2f32(<2 x float>, i32 immarg)

--- a/llvm/test/CodeGen/DirectX/isinf.ll
+++ b/llvm/test/CodeGen/DirectX/isinf.ll
@@ -5,14 +5,14 @@
 
 define noundef i1 @isinf_float(float noundef %a) {
 entry:
-  ; CHECK: call i1 @dx.op.isSpecialFloat.f32(i32 9, float %{{.*}}) #[[#ATTR:]]
+  ; CHECK: call i1 @dx.op.isSpecialFloat.f32(i32 9, float %{{.*}})
   %dx.isinf = call i1 @llvm.dx.isinf.f32(float %a)
   ret i1 %dx.isinf
 }
 
 define noundef i1 @isinf_half(half noundef %a) {
 entry:
-  ; SM69CHECK: call i1 @dx.op.isSpecialFloat.f16(i32 9, half %{{.*}}) #[[#ATTR]]
+  ; SM69CHECK: call i1 @dx.op.isSpecialFloat.f16(i32 9, half %{{.*}})
   ; SMOLDCHECK: [[BITCAST:%.*]] = bitcast half %a to i16
   ; SMOLDCHECK: [[CMPHIGH:%.*]] = icmp eq i16 [[BITCAST]], 31744
   ; SMOLDCHECK: [[CMPLOW:%.*]] = icmp eq i16 [[BITCAST]], -1024
@@ -66,4 +66,6 @@ entry:
   ret <3 x i1> %hlsl.isinf
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare i1 @dx.op.isSpecialFloat.f32(i32, float) #[[#ATTR0:]]
+; SM69CHECK-DAG: declare i1 @dx.op.isSpecialFloat.f16(i32, half) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }

--- a/llvm/test/CodeGen/DirectX/isnan.ll
+++ b/llvm/test/CodeGen/DirectX/isnan.ll
@@ -5,7 +5,8 @@
 
 define noundef i1 @isnan_float(float noundef %a) {
 entry:
-  ; SM69CHECK: call i1 @dx.op.isSpecialFloat.f32(i32 8, float %{{.*}}) #[[#ATTR:]]
+  ; CHECK-LABEL: @isnan_float
+  ; SM69CHECK: call i1 @dx.op.isSpecialFloat.f32(i32 8, float %{{.*}})
   ; SMOLDCHECK: call i1 @llvm.dx.isnan.f32(float %{{.*}})
   %dx.isnan = call i1 @llvm.dx.isnan.f32(float %a)
   ret i1 %dx.isnan
@@ -13,7 +14,8 @@ entry:
 
 define noundef i1 @isnan_half(half noundef %a) {
 entry:
-  ; SM69CHECK: call i1 @dx.op.isSpecialFloat.f16(i32 8, half %{{.*}}) #[[#ATTR]]
+  ; CHECK-LABEL: @isnan_half
+  ; SM69CHECK: call i1 @dx.op.isSpecialFloat.f16(i32 8, half %{{.*}})
   ; SMOLDCHECK: [[BITCAST:%.*]] = bitcast half %{{.*}} to i16
   ; SMOLDCHECK: [[ANDHIGH:%.*]] = and i16 [[BITCAST]], 31744
   ; SMOLDCHECK: [[CMPHIGH:%.*]] = icmp eq i16 [[ANDHIGH]], 31744
@@ -26,6 +28,7 @@ entry:
 
 define noundef <4 x i1> @isnan_half4(<4 x half> noundef %p0) {
 entry:
+  ; CHECK-LABEL: @isnan_half4
   ; SM69CHECK: call i1 @dx.op.isSpecialFloat.f16(i32 8, half
   ; SM69CHECK: call i1 @dx.op.isSpecialFloat.f16(i32 8, half
   ; SM69CHECK: call i1 @dx.op.isSpecialFloat.f16(i32 8, half
@@ -42,6 +45,7 @@ entry:
 
 define noundef <3 x i1> @isnan_float3(<3 x float> noundef %p0) {
 entry:
+  ; CHECK-LABEL: @isnan_float3
   ; SM69CHECK: call i1 @dx.op.isSpecialFloat.f32(i32 8, float
   ; SM69CHECK: call i1 @dx.op.isSpecialFloat.f32(i32 8, float
   ; SM69CHECK: call i1 @dx.op.isSpecialFloat.f32(i32 8, float
@@ -50,4 +54,6 @@ entry:
   ret <3 x i1> %hlsl.isnan
 }
 
-; CHECK: attributes #{{[0-9]*}} = {{{.*}} memory(none) {{.*}}}
+; SM69CHECK-DAG: declare i1 @dx.op.isSpecialFloat.f32(i32, float) #[[#ATTR0:]]
+; SM69CHECK-DAG: declare i1 @dx.op.isSpecialFloat.f16(i32, half) #[[#ATTR0]]
+; SM69CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }

--- a/llvm/test/CodeGen/DirectX/log.ll
+++ b/llvm/test/CodeGen/DirectX/log.ll
@@ -5,7 +5,7 @@
 
 define noundef float @log_float(float noundef %a) #0 {
 entry:
-; DOPCHECK: call float @dx.op.unary.f32(i32 23, float %{{.*}}) #[[#ATTR:]]
+; DOPCHECK: call float @dx.op.unary.f32(i32 23, float %{{.*}})
 ; EXPCHECK: call float @llvm.log2.f32(float %a)
 ; CHECK: fmul float 0x3FE62E4300000000, %{{.*}}
   %elt.log = call float @llvm.log.f32(float %a)
@@ -14,14 +14,16 @@ entry:
 
 define noundef half @log_half(half noundef %a) #0 {
 entry:
-; DOPCHECK: call half @dx.op.unary.f16(i32 23, half %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call half @dx.op.unary.f16(i32 23, half %{{.*}})
 ; EXPCHECK: call half @llvm.log2.f16(half %a)
 ; CHECK: fmul half 0xH398C, %{{.*}}
   %elt.log = call half @llvm.log.f16(half %a)
   ret half %elt.log
 }
 
-; DOPCHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; DOPCHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; DOPCHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; DOPCHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.log.f16(half)
 declare float @llvm.log.f32(float)

--- a/llvm/test/CodeGen/DirectX/log10.ll
+++ b/llvm/test/CodeGen/DirectX/log10.ll
@@ -5,7 +5,7 @@
 
 define noundef float @log10_float(float noundef %a) #0 {
 entry:
-; DOPCHECK: call float @dx.op.unary.f32(i32 23, float %{{.*}}) #[[#ATTR:]]
+; DOPCHECK: call float @dx.op.unary.f32(i32 23, float %{{.*}})
 ; EXPCHECK: call float @llvm.log2.f32(float %a)
 ; CHECK: fmul float 0x3FD3441340000000, %{{.*}}
   %elt.log10 = call float @llvm.log10.f32(float %a)
@@ -14,14 +14,16 @@ entry:
 
 define noundef half @log10_half(half noundef %a) #0 {
 entry:
-; DOPCHECK: call half @dx.op.unary.f16(i32 23, half %{{.*}}) #[[#ATTR]]
+; DOPCHECK: call half @dx.op.unary.f16(i32 23, half %{{.*}})
 ; EXPCHECK: call half @llvm.log2.f16(half %a)
 ; CHECK: fmul half 0xH34D1, %{{.*}}
   %elt.log10 = call half @llvm.log10.f16(half %a)
   ret half %elt.log10
 }
 
-; DOPCHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; DOPCHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; DOPCHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; DOPCHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.log10.f16(half)
 declare float @llvm.log10.f32(float)

--- a/llvm/test/CodeGen/DirectX/log2.ll
+++ b/llvm/test/CodeGen/DirectX/log2.ll
@@ -4,19 +4,21 @@
 
 define noundef float @log2_float(float noundef %a) #0 {
 entry:
-; CHECK:call float @dx.op.unary.f32(i32 23, float %{{.*}}) #[[#ATTR:]]
+; CHECK:call float @dx.op.unary.f32(i32 23, float %{{.*}})
   %elt.log2 = call float @llvm.log2.f32(float %a)
   ret float %elt.log2
 }
 
 define noundef half @log2_half(half noundef %a) #0 {
 entry:
-; CHECK:call half @dx.op.unary.f16(i32 23, half %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.unary.f16(i32 23, half %{{.*}})
   %elt.log2 = call half @llvm.log2.f16(half %a)
   ret half %elt.log2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.log2.f16(half)
 declare float @llvm.log2.f32(float)

--- a/llvm/test/CodeGen/DirectX/reversebits.ll
+++ b/llvm/test/CodeGen/DirectX/reversebits.ll
@@ -5,7 +5,7 @@
 ; Function Attrs: nounwind
 define noundef i16 @test_bitreverse_short(i16 noundef %a) {
 entry:
-; CHECK:call i16 @dx.op.unary.i16(i32 30, i16 %{{.*}}) #[[#ATTR:]]
+; CHECK:call i16 @dx.op.unary.i16(i32 30, i16 %{{.*}})
   %elt.bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
   ret i16 %elt.bitreverse
 }
@@ -13,7 +13,7 @@ entry:
 ; Function Attrs: nounwind
 define noundef i32 @test_bitreverse_int(i32 noundef %a) {
 entry:
-; CHECK:call i32 @dx.op.unary.i32(i32 30, i32 %{{.*}}) #[[#ATTR]]
+; CHECK:call i32 @dx.op.unary.i32(i32 30, i32 %{{.*}})
   %elt.bitreverse = call i32 @llvm.bitreverse.i32(i32 %a)
   ret i32 %elt.bitreverse
 }
@@ -21,7 +21,7 @@ entry:
 ; Function Attrs: nounwind
 define noundef i64 @test_bitreverse_long(i64 noundef %a) {
 entry:
-; CHECK:call i64 @dx.op.unary.i64(i32 30, i64 %{{.*}}) #[[#ATTR]]
+; CHECK:call i64 @dx.op.unary.i64(i32 30, i64 %{{.*}})
   %elt.bitreverse = call i64 @llvm.bitreverse.i64(i64 %a)
   ret i64 %elt.bitreverse
 }
@@ -29,22 +29,25 @@ entry:
 define noundef <4 x i32> @bitreverse_int324(<4 x i32> noundef %a) #0 {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x i32> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call i32 @dx.op.unary.i32(i32 30, i32 [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call i32 @dx.op.unary.i32(i32 30, i32 [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x i32> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call i32 @dx.op.unary.i32(i32 30, i32 [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call i32 @dx.op.unary.i32(i32 30, i32 [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x i32> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call i32 @dx.op.unary.i32(i32 30, i32 [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call i32 @dx.op.unary.i32(i32 30, i32 [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x i32> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call i32 @dx.op.unary.i32(i32 30, i32 [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call i32 @dx.op.unary.i32(i32 30, i32 [[ee3]])
   ; CHECK: insertelement <4 x i32> poison, i32 [[ie0]], i64 0
   ; CHECK: insertelement <4 x i32> %{{.*}}, i32 [[ie1]], i64 1
   ; CHECK: insertelement <4 x i32> %{{.*}}, i32 [[ie2]], i64 2
   ; CHECK: insertelement <4 x i32> %{{.*}}, i32 [[ie3]], i64 3
-  %2 = call <4 x i32> @llvm.bitreverse.v4i32(<4 x i32> %a) 
+  %2 = call <4 x i32> @llvm.bitreverse.v4i32(<4 x i32> %a)
   ret <4 x i32> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare i16 @dx.op.unary.i16(i32, i16) #[[#ATTR0:]]
+; CHECK-DAG: declare i32 @dx.op.unary.i32(i32, i32) #[[#ATTR0]]
+; CHECK-DAG: declare i64 @dx.op.unary.i64(i32, i64) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare i16 @llvm.bitreverse.i16(i16)
 declare i32 @llvm.bitreverse.i32(i32)

--- a/llvm/test/CodeGen/DirectX/round.ll
+++ b/llvm/test/CodeGen/DirectX/round.ll
@@ -5,7 +5,7 @@
 ; CHECK-LABEL: round_half
 define noundef half @round_half(half noundef %a) {
 entry:
-; CHECK: call half @dx.op.unary.f16(i32 26, half %{{.*}}) #[[#ATTR:]]
+; CHECK: call half @dx.op.unary.f16(i32 26, half %{{.*}})
   %elt.roundeven = call half @llvm.roundeven.f16(half %a)
   ret half %elt.roundeven
 }
@@ -13,7 +13,7 @@ entry:
 ; CHECK-LABEL: round_float
 define noundef float @round_float(float noundef %a) {
 entry:
-; CHECK: call float @dx.op.unary.f32(i32 26, float %{{.*}}) #[[#ATTR]]
+; CHECK: call float @dx.op.unary.f32(i32 26, float %{{.*}})
   %elt.roundeven = call float @llvm.roundeven.f32(float %a)
   ret float %elt.roundeven
 }
@@ -21,22 +21,24 @@ entry:
 define noundef <4 x float> @round_float4(<4 x float> noundef %a) #0 {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 26, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 26, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 26, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 26, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 26, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 26, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 26, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 26, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.roundeven.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.roundeven.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.roundeven.f16(half)
 declare float @llvm.roundeven.f32(float)

--- a/llvm/test/CodeGen/DirectX/rsqrt.ll
+++ b/llvm/test/CodeGen/DirectX/rsqrt.ll
@@ -7,7 +7,7 @@
 define noundef float @rsqrt_float(float noundef %a) {
 ; CHECK-SAME: float noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[DX_RSQRT1:%.*]] = call float @dx.op.unary.f32(i32 25, float [[A]]) #[[#ATTR:]]
+; CHECK-NEXT:    [[DX_RSQRT1:%.*]] = call float @dx.op.unary.f32(i32 25, float [[A]]) 
 ; CHECK-NEXT:    ret float [[DX_RSQRT1]]
 ;
 entry:
@@ -19,7 +19,7 @@ entry:
 define noundef half @rsqrt_half(half noundef %a) {
 ; CHECK-SAME: half noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[DX_RSQRT1:%.*]] = call half @dx.op.unary.f16(i32 25, half [[A]]) #[[#ATTR]]
+; CHECK-NEXT:    [[DX_RSQRT1:%.*]] = call half @dx.op.unary.f16(i32 25, half [[A]]) 
 ; CHECK-NEXT:    ret half [[DX_RSQRT1]]
 ;
 entry:
@@ -32,13 +32,13 @@ define noundef <4 x float> @rsqrt_float4(<4 x float> noundef %a) #0 {
 ; CHECK-SAME: <4 x float> noundef [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[A_I0:%.*]] = extractelement <4 x float> [[A]], i64 0
-; CHECK-NEXT:    [[DOTI04:%.*]] = call float @dx.op.unary.f32(i32 25, float [[A_I0]]) #[[#ATTR]]
+; CHECK-NEXT:    [[DOTI04:%.*]] = call float @dx.op.unary.f32(i32 25, float [[A_I0]]) 
 ; CHECK-NEXT:    [[A_I1:%.*]] = extractelement <4 x float> [[A]], i64 1
-; CHECK-NEXT:    [[DOTI13:%.*]] = call float @dx.op.unary.f32(i32 25, float [[A_I1]]) #[[#ATTR]]
+; CHECK-NEXT:    [[DOTI13:%.*]] = call float @dx.op.unary.f32(i32 25, float [[A_I1]]) 
 ; CHECK-NEXT:    [[A_I2:%.*]] = extractelement <4 x float> [[A]], i64 2
-; CHECK-NEXT:    [[DOTI22:%.*]] = call float @dx.op.unary.f32(i32 25, float [[A_I2]]) #[[#ATTR]]
+; CHECK-NEXT:    [[DOTI22:%.*]] = call float @dx.op.unary.f32(i32 25, float [[A_I2]]) 
 ; CHECK-NEXT:    [[A_I3:%.*]] = extractelement <4 x float> [[A]], i64 3
-; CHECK-NEXT:    [[DOTI31:%.*]] = call float @dx.op.unary.f32(i32 25, float [[A_I3]]) #[[#ATTR]]
+; CHECK-NEXT:    [[DOTI31:%.*]] = call float @dx.op.unary.f32(i32 25, float [[A_I3]]) 
 ; CHECK-NEXT:    [[DOTUPTO0:%.*]] = insertelement <4 x float> poison, float [[DOTI04]], i64 0
 ; CHECK-NEXT:    [[DOTUPTO1:%.*]] = insertelement <4 x float> [[DOTUPTO0]], float [[DOTI13]], i64 1
 ; CHECK-NEXT:    [[DOTUPTO2:%.*]] = insertelement <4 x float> [[DOTUPTO1]], float [[DOTI22]], i64 2
@@ -50,7 +50,8 @@ entry:
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.dx.rsqrt.f16(half)
 declare float @llvm.dx.rsqrt.f32(float)

--- a/llvm/test/CodeGen/DirectX/saturate.ll
+++ b/llvm/test/CodeGen/DirectX/saturate.ll
@@ -4,7 +4,7 @@
 ; CHECK-LABEL: test_saturate_half
 define noundef half @test_saturate_half(half noundef %p0) {
 entry:
-  ; CHECK: call half @dx.op.unary.f16(i32 7, half %p0) #[[#ATTR:]]
+  ; CHECK: call half @dx.op.unary.f16(i32 7, half %p0)
   %hlsl.saturate = call half @llvm.dx.saturate.f16(half %p0)
   ; CHECK: ret half
   ret half %hlsl.saturate
@@ -13,7 +13,7 @@ entry:
 ; CHECK-LABEL: test_saturate_float
 define noundef float @test_saturate_float(float noundef %p0) {
 entry:
-  ; CHECK: call float @dx.op.unary.f32(i32 7, float %p0) #[[#ATTR]]
+  ; CHECK: call float @dx.op.unary.f32(i32 7, float %p0)
   %hlsl.saturate = call float @llvm.dx.saturate.f32(float %p0)
   ; CHECK: ret float
   ret float %hlsl.saturate
@@ -22,7 +22,7 @@ entry:
 ; CHECK-LABEL: test_saturate_double
 define noundef double @test_saturate_double(double noundef %p0) {
 entry:
-  ; CHECK: call double @dx.op.unary.f64(i32 7, double %p0) #[[#ATTR]]
+  ; CHECK: call double @dx.op.unary.f64(i32 7, double %p0)
   %hlsl.saturate = call double @llvm.dx.saturate.f64(double %p0)
   ; CHECK: ret double
   ret double %hlsl.saturate
@@ -59,4 +59,7 @@ entry:
 }
 
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK-DAG: declare double @dx.op.unary.f64(i32, double) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }

--- a/llvm/test/CodeGen/DirectX/sin.ll
+++ b/llvm/test/CodeGen/DirectX/sin.ll
@@ -4,14 +4,14 @@
 
 define noundef float @sin_float(float noundef %a) {
 entry:
-  ; CHECK:call float @dx.op.unary.f32(i32 13, float %{{.*}}) #[[#ATTR:]]
+  ; CHECK:call float @dx.op.unary.f32(i32 13, float %{{.*}})
   %1 = call float @llvm.sin.f32(float %a)
   ret float %1
 }
 
 define noundef half @sin_half(half noundef %a) {
 entry:
-  ; CHECK:call half @dx.op.unary.f16(i32 13, half %{{.*}}) #[[#ATTR]]
+  ; CHECK:call half @dx.op.unary.f16(i32 13, half %{{.*}})
   %1 = call half @llvm.sin.f16(half %a)
   ret half %1
 }
@@ -19,22 +19,24 @@ entry:
 define noundef <4 x float> @sin_float4(<4 x float> noundef %a) {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 13, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 13, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 13, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 13, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 13, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 13, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 13, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 13, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.sin.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.sin.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.sin.f16(half)
 declare float @llvm.sin.f32(float)

--- a/llvm/test/CodeGen/DirectX/sinh.ll
+++ b/llvm/test/CodeGen/DirectX/sinh.ll
@@ -4,14 +4,14 @@
 
 define noundef float @sinh_float(float noundef %a) {
 entry:
-; CHECK:call float @dx.op.unary.f32(i32 19, float %{{.*}}) #[[#ATTR:]]
+; CHECK:call float @dx.op.unary.f32(i32 19, float %{{.*}})
   %elt.sinh = call float @llvm.sinh.f32(float %a)
   ret float %elt.sinh
 }
 
 define noundef half @sinh_half(half noundef %a) {
 entry:
-; CHECK:call half @dx.op.unary.f16(i32 19, half %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.unary.f16(i32 19, half %{{.*}})
   %elt.sinh = call half @llvm.sinh.f16(half %a)
   ret half %elt.sinh
 }
@@ -19,22 +19,24 @@ entry:
 define noundef <4 x float> @sinh_float4(<4 x float> noundef %a) {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 19, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 19, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 19, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 19, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 19, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 19, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 19, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 19, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.sinh.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.sinh.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.sinh.f16(half)
 declare float @llvm.sinh.f32(float)

--- a/llvm/test/CodeGen/DirectX/smax.ll
+++ b/llvm/test/CodeGen/DirectX/smax.ll
@@ -5,7 +5,7 @@
 ; CHECK-LABEL:test_smax_i16
 define noundef i16 @test_smax_i16(i16 noundef %a, i16 noundef %b) {
 entry:
-; CHECK: call i16 @dx.op.binary.i16(i32 37, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR:]]
+; CHECK: call i16 @dx.op.binary.i16(i32 37, i16 %{{.*}}, i16 %{{.*}})
   %0 = call i16 @llvm.smax.i16(i16 %a, i16 %b)
   ret i16 %0
 }
@@ -13,7 +13,7 @@ entry:
 ; CHECK-LABEL:test_smax_i32
 define noundef i32 @test_smax_i32(i32 noundef %a, i32 noundef %b) {
 entry:
-; CHECK: call i32 @dx.op.binary.i32(i32 37, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+; CHECK: call i32 @dx.op.binary.i32(i32 37, i32 %{{.*}}, i32 %{{.*}})
   %0 = call i32 @llvm.smax.i32(i32 %a, i32 %b)
   ret i32 %0
 }
@@ -21,12 +21,15 @@ entry:
 ; CHECK-LABEL:test_smax_i64
 define noundef i64 @test_smax_i64(i64 noundef %a, i64 noundef %b) {
 entry:
-; CHECK: call i64 @dx.op.binary.i64(i32 37, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+; CHECK: call i64 @dx.op.binary.i64(i32 37, i64 %{{.*}}, i64 %{{.*}})
   %0 = call i64 @llvm.smax.i64(i64 %a, i64 %b)
   ret i64 %0
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare i16 @dx.op.binary.i16(i32, i16, i16) #[[#ATTR0:]]
+; CHECK-DAG: declare i32 @dx.op.binary.i32(i32, i32, i32) #[[#ATTR0]]
+; CHECK-DAG: declare i64 @dx.op.binary.i64(i32, i64, i64) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare i16 @llvm.smax.i16(i16, i16)
 declare i32 @llvm.smax.i32(i32, i32)

--- a/llvm/test/CodeGen/DirectX/smin.ll
+++ b/llvm/test/CodeGen/DirectX/smin.ll
@@ -5,7 +5,7 @@
 ; CHECK-LABEL:test_smin_i16
 define noundef i16 @test_smin_i16(i16 noundef %a, i16 noundef %b) {
 entry:
-; CHECK: call i16 @dx.op.binary.i16(i32 38, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR:]]
+; CHECK: call i16 @dx.op.binary.i16(i32 38, i16 %{{.*}}, i16 %{{.*}})
   %0 = call i16 @llvm.smin.i16(i16 %a, i16 %b)
   ret i16 %0
 }
@@ -13,7 +13,7 @@ entry:
 ; CHECK-LABEL:test_smin_i32
 define noundef i32 @test_smin_i32(i32 noundef %a, i32 noundef %b) {
 entry:
-; CHECK: call i32 @dx.op.binary.i32(i32 38, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+; CHECK: call i32 @dx.op.binary.i32(i32 38, i32 %{{.*}}, i32 %{{.*}})
   %0 = call i32 @llvm.smin.i32(i32 %a, i32 %b)
   ret i32 %0
 }
@@ -21,12 +21,15 @@ entry:
 ; CHECK-LABEL:test_smin_i64
 define noundef i64 @test_smin_i64(i64 noundef %a, i64 noundef %b) {
 entry:
-; CHECK: call i64 @dx.op.binary.i64(i32 38, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+; CHECK: call i64 @dx.op.binary.i64(i32 38, i64 %{{.*}}, i64 %{{.*}})
   %0 = call i64 @llvm.smin.i64(i64 %a, i64 %b)
   ret i64 %0
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare i16 @dx.op.binary.i16(i32, i16, i16) #[[#ATTR0:]]
+; CHECK-DAG: declare i32 @dx.op.binary.i32(i32, i32, i32) #[[#ATTR0]]
+; CHECK-DAG: declare i64 @dx.op.binary.i64(i32, i64, i64) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare i16 @llvm.smin.i16(i16, i16)
 declare i32 @llvm.smin.i32(i32, i32)

--- a/llvm/test/CodeGen/DirectX/splitdouble.ll
+++ b/llvm/test/CodeGen/DirectX/splitdouble.ll
@@ -5,7 +5,7 @@ define i32 @test_scalar(double noundef %D) {
 ; CHECK-LABEL: define i32 @test_scalar(
 ; CHECK-SAME: double noundef [[D:%.*]]) {
 ; NOLOWER-NEXT:    [[HLSL_ASUINT_I0:%.*]] = call { i32, i32 } @llvm.dx.splitdouble.i32(double [[D]])
-; WITHLOWER-NEXT:  [[HLSL_ASUINT_I0:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double [[D]]) #[[#ATTR:]]
+; WITHLOWER-NEXT:  [[HLSL_ASUINT_I0:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double [[D]]) 
 ; NOLOWER-NEXT:    [[EV1:%.*]] = extractvalue { i32, i32 } [[HLSL_ASUINT_I0]], 0
 ; NOLOWER-NEXT:    [[EV2:%.*]] = extractvalue { i32, i32 } [[HLSL_ASUINT_I0]], 1
 ; WITHLOWER-NEXT:  [[EV1:%.*]] = extractvalue %dx.types.splitdouble [[HLSL_ASUINT_I0]], 0
@@ -26,10 +26,10 @@ define void @test_vector_double_split_void(<2 x double> noundef %d) {
 ; CHECK-SAME: <2 x double> noundef [[D:%.*]]) {
 ; CHECK-NEXT:      [[D_I0:%.*]] = extractelement <2 x double> [[D]], i64 0
 ; NOLOWER-NEXT:    [[HLSL_ASUINT_I0:%.*]] = call { i32, i32 } @llvm.dx.splitdouble.i32(double [[D_I0]])
-; WITHLOWER-NEXT:  [[HLSL_ASUINT_I0:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double [[D_I0]]) #[[#ATTR]]
+; WITHLOWER-NEXT:  [[HLSL_ASUINT_I0:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double [[D_I0]]) 
 ; CHECK-NEXT:      [[D_I1:%.*]] = extractelement <2 x double> [[D]], i64 1
 ; NOLOWER-NEXT:    [[HLSL_ASUINT_I1:%.*]] = call { i32, i32 } @llvm.dx.splitdouble.i32(double [[D_I1]])
-; WITHLOWER-NEXT:  [[HLSL_ASUINT_I1:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double [[D_I1]]) #[[#ATTR]]
+; WITHLOWER-NEXT:  [[HLSL_ASUINT_I1:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double [[D_I1]]) 
 ; CHECK-NEXT:      ret void
 ;
   %hlsl.asuint = call { <2 x i32>, <2 x i32> }  @llvm.dx.splitdouble.v2i32(<2 x double> %d)
@@ -41,13 +41,13 @@ define noundef <3 x i32> @test_vector_double_split(<3 x double> noundef %d) {
 ; CHECK-SAME: <3 x double> noundef [[D:%.*]]) {
 ; CHECK-NEXT:      [[D_I0:%.*]] = extractelement <3 x double> [[D]], i64 0
 ; NOLOWER-NEXT:    [[HLSL_ASUINT_I0:%.*]] = call { i32, i32 } @llvm.dx.splitdouble.i32(double [[D_I0]])
-; WITHLOWER-NEXT:  [[HLSL_ASUINT_I0:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double [[D_I0]]) #[[#ATTR]]
+; WITHLOWER-NEXT:  [[HLSL_ASUINT_I0:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double [[D_I0]]) 
 ; CHECK-NEXT:      [[D_I1:%.*]] = extractelement <3 x double> [[D]], i64 1
 ; NOLOWER-NEXT:    [[HLSL_ASUINT_I1:%.*]] = call { i32, i32 } @llvm.dx.splitdouble.i32(double [[D_I1]])
-; WITHLOWER-NEXT:  [[HLSL_ASUINT_I1:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double [[D_I1]]) #[[#ATTR]]
+; WITHLOWER-NEXT:  [[HLSL_ASUINT_I1:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double [[D_I1]]) 
 ; CHECK-NEXT:      [[D_I2:%.*]] = extractelement <3 x double> [[D]], i64 2
 ; NOLOWER-NEXT:    [[HLSL_ASUINT_I2:%.*]] = call { i32, i32 } @llvm.dx.splitdouble.i32(double [[D_I2]])
-; WITHLOWER-NEXT:  [[HLSL_ASUINT_I2:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double [[D_I2]]) #[[#ATTR]]
+; WITHLOWER-NEXT:  [[HLSL_ASUINT_I2:%.*]] = call %dx.types.splitdouble @dx.op.splitDouble.f64(i32 102, double [[D_I2]]) 
 ; NOLOWER-NEXT:    [[DOTELEM0:%.*]] = extractvalue { i32, i32 } [[HLSL_ASUINT_I0]], 0
 ; WITHLOWER-NEXT:  [[DOTELEM0:%.*]] = extractvalue %dx.types.splitdouble [[HLSL_ASUINT_I0]], 0
 ; NOLOWER-NEXT:    [[DOTELEM01:%.*]] = extractvalue { i32, i32 } [[HLSL_ASUINT_I1]], 0
@@ -75,4 +75,5 @@ define noundef <3 x i32> @test_vector_double_split(<3 x double> noundef %d) {
   ret <3 x i32> %3
 }
 
-; WITHLOWER: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; WITHLOWER: declare %dx.types.splitdouble @dx.op.splitDouble.f64(i32, double) #[[#ATTR0:]]
+; WITHLOWER: attributes #[[#ATTR0]] = { nounwind memory(none) }

--- a/llvm/test/CodeGen/DirectX/sqrt.ll
+++ b/llvm/test/CodeGen/DirectX/sqrt.ll
@@ -4,14 +4,14 @@
 
 define noundef float @sqrt_float(float noundef %a) {
 entry:
-; CHECK:call float @dx.op.unary.f32(i32 24, float %{{.*}}) #[[#ATTR:]]
+; CHECK:call float @dx.op.unary.f32(i32 24, float %{{.*}})
   %elt.sqrt = call float @llvm.sqrt.f32(float %a)
   ret float %elt.sqrt
 }
 
 define noundef half @sqrt_half(half noundef %a) {
 entry:
-; CHECK:call half @dx.op.unary.f16(i32 24, half %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.unary.f16(i32 24, half %{{.*}})
   %elt.sqrt = call half @llvm.sqrt.f16(half %a)
   ret half %elt.sqrt
 }
@@ -19,22 +19,24 @@ entry:
 define noundef <4 x float> @sqrt_float4(<4 x float> noundef %a) {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 24, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 24, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 24, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 24, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 24, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 24, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 24, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 24, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.sqrt.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.sqrt.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.sqrt.f16(half)
 declare float @llvm.sqrt.f32(float)

--- a/llvm/test/CodeGen/DirectX/tan.ll
+++ b/llvm/test/CodeGen/DirectX/tan.ll
@@ -4,14 +4,14 @@
 
 define noundef float @tan_float(float noundef %a) #0 {
 entry:
-; CHECK:call float @dx.op.unary.f32(i32 14, float %{{.*}}) #[[#ATTR:]]
+; CHECK:call float @dx.op.unary.f32(i32 14, float %{{.*}})
   %elt.tan = call float @llvm.tan.f32(float %a)
   ret float %elt.tan
 }
 
 define noundef half @tan_half(half noundef %a) #0 {
 entry:
-; CHECK:call half @dx.op.unary.f16(i32 14, half %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.unary.f16(i32 14, half %{{.*}})
   %elt.tan = call half @llvm.tan.f16(half %a)
   ret half %elt.tan
 }
@@ -19,22 +19,24 @@ entry:
 define noundef <4 x float> @tan_float4(<4 x float> noundef %a) #0 {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 14, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 14, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 14, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 14, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 14, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 14, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 14, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 14, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.tan.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.tan.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.tan.f16(half)
 declare float @llvm.tan.f32(float)

--- a/llvm/test/CodeGen/DirectX/tanh.ll
+++ b/llvm/test/CodeGen/DirectX/tanh.ll
@@ -4,14 +4,14 @@
 
 define noundef float @tan_float(float noundef %a) {
 entry:
-; CHECK:call float @dx.op.unary.f32(i32 20, float %{{.*}}) #[[#ATTR:]]
+; CHECK:call float @dx.op.unary.f32(i32 20, float %{{.*}})
   %elt.tanh = call float @llvm.tanh.f32(float %a)
   ret float %elt.tanh
 }
 
 define noundef half @tan_half(half noundef %a) {
 entry:
-; CHECK:call half @dx.op.unary.f16(i32 20, half %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.unary.f16(i32 20, half %{{.*}})
   %elt.tanh = call half @llvm.tanh.f16(half %a)
   ret half %elt.tanh
 }
@@ -19,22 +19,24 @@ entry:
 define noundef <4 x float> @tanh_float4(<4 x float> noundef %a) #0 {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 20, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 20, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 20, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 20, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 20, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 20, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 20, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 20, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.tanh.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.tanh.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.tanh.f16(half)
 declare float @llvm.tanh.f32(float)

--- a/llvm/test/CodeGen/DirectX/trunc.ll
+++ b/llvm/test/CodeGen/DirectX/trunc.ll
@@ -4,14 +4,14 @@
 
 define noundef float @trunc_float(float noundef %a) {
 entry:
-; CHECK:call float @dx.op.unary.f32(i32 29, float %{{.*}}) #[[#ATTR:]]
+; CHECK:call float @dx.op.unary.f32(i32 29, float %{{.*}})
   %elt.trunc = call float @llvm.trunc.f32(float %a)
   ret float %elt.trunc
 }
 
 define noundef half @trunc_half(half noundef %a) {
 entry:
-; CHECK:call half @dx.op.unary.f16(i32 29, half %{{.*}}) #[[#ATTR]]
+; CHECK:call half @dx.op.unary.f16(i32 29, half %{{.*}})
   %elt.trunc = call half @llvm.trunc.f16(half %a)
   ret half %elt.trunc
 }
@@ -19,22 +19,24 @@ entry:
 define noundef <4 x float> @trunc_float4(<4 x float> noundef %a) #0 {
 entry:
   ; CHECK: [[ee0:%.*]] = extractelement <4 x float> %a, i64 0
-  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 29, float [[ee0]]) #[[#ATTR]]
+  ; CHECK: [[ie0:%.*]] = call float @dx.op.unary.f32(i32 29, float [[ee0]])
   ; CHECK: [[ee1:%.*]] = extractelement <4 x float> %a, i64 1
-  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 29, float [[ee1]]) #[[#ATTR]]
+  ; CHECK: [[ie1:%.*]] = call float @dx.op.unary.f32(i32 29, float [[ee1]])
   ; CHECK: [[ee2:%.*]] = extractelement <4 x float> %a, i64 2
-  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 29, float [[ee2]]) #[[#ATTR]]
+  ; CHECK: [[ie2:%.*]] = call float @dx.op.unary.f32(i32 29, float [[ee2]])
   ; CHECK: [[ee3:%.*]] = extractelement <4 x float> %a, i64 3
-  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 29, float [[ee3]]) #[[#ATTR]]
+  ; CHECK: [[ie3:%.*]] = call float @dx.op.unary.f32(i32 29, float [[ee3]])
   ; CHECK: insertelement <4 x float> poison, float [[ie0]], i64 0
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie1]], i64 1
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie2]], i64 2
   ; CHECK: insertelement <4 x float> %{{.*}}, float [[ie3]], i64 3
-  %2 = call <4 x float> @llvm.trunc.v4f32(<4 x float> %a) 
+  %2 = call <4 x float> @llvm.trunc.v4f32(<4 x float> %a)
   ret <4 x float> %2
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare half @dx.op.unary.f16(i32, half) #[[#ATTR0:]]
+; CHECK-DAG: declare float @dx.op.unary.f32(i32, float) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare half @llvm.trunc.f16(half)
 declare float @llvm.trunc.f32(float)

--- a/llvm/test/CodeGen/DirectX/umad.ll
+++ b/llvm/test/CodeGen/DirectX/umad.ll
@@ -7,7 +7,7 @@ target triple = "dxil-pc-shadermodel6.7-library"
 ; Function Attrs: noinline nounwind optnone
 define noundef i16 @umad_ushort(i16 noundef %p0, i16 noundef %p1, i16 noundef %p2) #0 {
 entry:
-  ; CHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR:]]
+  ; CHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) 
   %p2.addr = alloca i16, align 2
   %p1.addr = alloca i16, align 2
   %p0.addr = alloca i16, align 2
@@ -27,7 +27,7 @@ declare i16 @llvm.dx.umad.i16(i16, i16, i16) #1
 ; Function Attrs: noinline nounwind optnone
 define noundef i32 @umad_uint(i32 noundef %p0, i32 noundef %p1, i32 noundef %p2) #0 {
 entry:
-  ; CHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) 
   %p2.addr = alloca i32, align 4
   %p1.addr = alloca i32, align 4
   %p0.addr = alloca i32, align 4
@@ -47,7 +47,7 @@ declare i32 @llvm.dx.umad.i32(i32, i32, i32) #1
 ; Function Attrs: noinline nounwind optnone
 define noundef i64 @umad_uint64(i64 noundef %p0, i64 noundef %p1, i64 noundef %p2) #0 {
 entry:
-  ; CHECK: call i64 @dx.op.tertiary.i64(i32 49, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i64 @dx.op.tertiary.i64(i32 49, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) 
   %p2.addr = alloca i64, align 8
   %p1.addr = alloca i64, align 8
   %p0.addr = alloca i64, align 8
@@ -70,19 +70,19 @@ entry:
   ; CHECK: extractelement <4 x i16> %p0, i64 0
   ; CHECK: extractelement <4 x i16> %p1, i64 0
   ; CHECK: extractelement <4 x i16> %p2, i64 0
-  ; CHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) 
   ; CHECK: extractelement <4 x i16> %p0, i64 1
   ; CHECK: extractelement <4 x i16> %p1, i64 1
   ; CHECK: extractelement <4 x i16> %p2, i64 1
-  ; CHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) 
   ; CHECK: extractelement <4 x i16> %p0, i64 2
   ; CHECK: extractelement <4 x i16> %p1, i64 2
   ; CHECK: extractelement <4 x i16> %p2, i64 2
-  ; CHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) 
   ; CHECK: extractelement <4 x i16> %p0, i64 3
   ; CHECK: extractelement <4 x i16> %p1, i64 3
   ; CHECK: extractelement <4 x i16> %p2, i64 3
-  ; CHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i16 @dx.op.tertiary.i16(i32 49, i16 %{{.*}}, i16 %{{.*}}, i16 %{{.*}}) 
   ; CHECK: insertelement <4 x i16> poison, i16 %{{.*}}, i64 0
   ; CHECK: insertelement <4 x i16> %{{.*}}, i16 %{{.*}}, i64 1
   ; CHECK: insertelement <4 x i16> %{{.*}}, i16 %{{.*}}, i64 2
@@ -100,19 +100,19 @@ entry:
   ; CHECK: extractelement <4 x i32> %p0, i64 0
   ; CHECK: extractelement <4 x i32> %p1, i64 0
   ; CHECK: extractelement <4 x i32> %p2, i64 0
-  ; CHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) 
   ; CHECK: extractelement <4 x i32> %p0, i64 1
   ; CHECK: extractelement <4 x i32> %p1, i64 1
   ; CHECK: extractelement <4 x i32> %p2, i64 1
-  ; CHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) 
   ; CHECK: extractelement <4 x i32> %p0, i64 2
   ; CHECK: extractelement <4 x i32> %p1, i64 2
   ; CHECK: extractelement <4 x i32> %p2, i64 2
-  ; CHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) 
   ; CHECK: extractelement <4 x i32> %p0, i64 3
   ; CHECK: extractelement <4 x i32> %p1, i64 3
   ; CHECK: extractelement <4 x i32> %p2, i64 3
-  ; CHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}) 
   ; CHECK: insertelement <4 x i32> poison, i32 %{{.*}}, i64 0
   ; CHECK: insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i64 1
   ; CHECK: insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i64 2
@@ -130,19 +130,19 @@ entry:
   ; CHECK: extractelement <4 x i64> %p0, i64 0
   ; CHECK: extractelement <4 x i64> %p1, i64 0
   ; CHECK: extractelement <4 x i64> %p2, i64 0
-  ; CHECK: call i64 @dx.op.tertiary.i64(i32 49, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i64 @dx.op.tertiary.i64(i32 49, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) 
   ; CHECK: extractelement <4 x i64> %p0, i64 1
   ; CHECK: extractelement <4 x i64> %p1, i64 1
   ; CHECK: extractelement <4 x i64> %p2, i64 1
-  ; CHECK: call i64 @dx.op.tertiary.i64(i32 49, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i64 @dx.op.tertiary.i64(i32 49, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) 
   ; CHECK: extractelement <4 x i64> %p0, i64 2
   ; CHECK: extractelement <4 x i64> %p1, i64 2
   ; CHECK: extractelement <4 x i64> %p2, i64 2
-  ; CHECK: call i64 @dx.op.tertiary.i64(i32 49, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i64 @dx.op.tertiary.i64(i32 49, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) 
   ; CHECK: extractelement <4 x i64> %p0, i64 3
   ; CHECK: extractelement <4 x i64> %p1, i64 3
   ; CHECK: extractelement <4 x i64> %p2, i64 3
-  ; CHECK: call i64 @dx.op.tertiary.i64(i32 49, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+  ; CHECK: call i64 @dx.op.tertiary.i64(i32 49, i64 %{{.*}}, i64 %{{.*}}, i64 %{{.*}}) 
   ; CHECK: insertelement <4 x i64> poison, i64 %{{.*}}, i64 0
   ; CHECK: insertelement <4 x i64> %{{.*}}, i64 %{{.*}}, i64 1
   ; CHECK: insertelement <4 x i64> %{{.*}}, i64 %{{.*}}, i64 2
@@ -154,4 +154,5 @@ entry:
 ; Function Attrs: nocallback nofree nosync nounwind willreturn
 declare <4 x i64> @llvm.dx.umad.v4i64(<4 x i64>, <4 x i64>, <4 x i64>) #1
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK: declare i16 @dx.op.tertiary.i16(i32, i16, i16, i16) #[[#ATTR0:]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }

--- a/llvm/test/CodeGen/DirectX/umax.ll
+++ b/llvm/test/CodeGen/DirectX/umax.ll
@@ -5,7 +5,7 @@
 ; CHECK-LABEL:test_umax_i16
 define noundef i16 @test_umax_i16(i16 noundef %a, i16 noundef %b) {
 entry:
-; CHECK: call i16 @dx.op.binary.i16(i32 39, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR:]]
+; CHECK: call i16 @dx.op.binary.i16(i32 39, i16 %{{.*}}, i16 %{{.*}})
   %0 = call i16 @llvm.umax.i16(i16 %a, i16 %b)
   ret i16 %0
 }
@@ -13,7 +13,7 @@ entry:
 ; CHECK-LABEL:test_umax_i32
 define noundef i32 @test_umax_i32(i32 noundef %a, i32 noundef %b) {
 entry:
-; CHECK: call i32 @dx.op.binary.i32(i32 39, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+; CHECK: call i32 @dx.op.binary.i32(i32 39, i32 %{{.*}}, i32 %{{.*}})
   %0 = call i32 @llvm.umax.i32(i32 %a, i32 %b)
   ret i32 %0
 }
@@ -21,12 +21,15 @@ entry:
 ; CHECK-LABEL:test_umax_i64
 define noundef i64 @test_umax_i64(i64 noundef %a, i64 noundef %b) {
 entry:
-; CHECK: call i64 @dx.op.binary.i64(i32 39, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+; CHECK: call i64 @dx.op.binary.i64(i32 39, i64 %{{.*}}, i64 %{{.*}})
   %0 = call i64 @llvm.umax.i64(i64 %a, i64 %b)
   ret i64 %0
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare i16 @dx.op.binary.i16(i32, i16, i16) #[[#ATTR0:]]
+; CHECK-DAG: declare i32 @dx.op.binary.i32(i32, i32, i32) #[[#ATTR0]]
+; CHECK-DAG: declare i64 @dx.op.binary.i64(i32, i64, i64) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare i16 @llvm.umax.i16(i16, i16)
 declare i32 @llvm.umax.i32(i32, i32)

--- a/llvm/test/CodeGen/DirectX/umin.ll
+++ b/llvm/test/CodeGen/DirectX/umin.ll
@@ -5,7 +5,7 @@
 ; CHECK-LABEL:test_umin_i16
 define noundef i16 @test_umin_i16(i16 noundef %a, i16 noundef %b) {
 entry:
-; CHECK: call i16 @dx.op.binary.i16(i32 40, i16 %{{.*}}, i16 %{{.*}}) #[[#ATTR:]]
+; CHECK: call i16 @dx.op.binary.i16(i32 40, i16 %{{.*}}, i16 %{{.*}})
   %0 = call i16 @llvm.umin.i16(i16 %a, i16 %b)
   ret i16 %0
 }
@@ -13,7 +13,7 @@ entry:
 ; CHECK-LABEL:test_umin_i32
 define noundef i32 @test_umin_i32(i32 noundef %a, i32 noundef %b) {
 entry:
-; CHECK: call i32 @dx.op.binary.i32(i32 40, i32 %{{.*}}, i32 %{{.*}}) #[[#ATTR]]
+; CHECK: call i32 @dx.op.binary.i32(i32 40, i32 %{{.*}}, i32 %{{.*}})
   %0 = call i32 @llvm.umin.i32(i32 %a, i32 %b)
   ret i32 %0
 }
@@ -21,12 +21,15 @@ entry:
 ; CHECK-LABEL:test_umin_i64
 define noundef i64 @test_umin_i64(i64 noundef %a, i64 noundef %b) {
 entry:
-; CHECK: call i64 @dx.op.binary.i64(i32 40, i64 %{{.*}}, i64 %{{.*}}) #[[#ATTR]]
+; CHECK: call i64 @dx.op.binary.i64(i32 40, i64 %{{.*}}, i64 %{{.*}})
   %0 = call i64 @llvm.umin.i64(i64 %a, i64 %b)
   ret i64 %0
 }
 
-; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
+; CHECK-DAG: declare i16 @dx.op.binary.i16(i32, i16, i16) #[[#ATTR0:]]
+; CHECK-DAG: declare i32 @dx.op.binary.i32(i32, i32, i32) #[[#ATTR0]]
+; CHECK-DAG: declare i64 @dx.op.binary.i64(i32, i64, i64) #[[#ATTR0]]
+; CHECK: attributes #[[#ATTR0]] = { nounwind memory(none) }
 
 declare i16 @llvm.umin.i16(i16, i16)
 declare i32 @llvm.umin.i32(i32, i32)


### PR DESCRIPTION
We need to apply DXIL op attributes to the functions themselves, and all DXIL ops should have the `unwind` attribute. This matches the DXC behaviour and what consumers like warp's GPU-based validation expect.

Fixes #193620