### PR TITLE
[NFC][sanitizer_common] Fix getpw_getgr.cpp test for large groups

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/getpw_getgr.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/getpw_getgr.cpp
@@ -75,7 +75,7 @@ void test_r(Fn f, Args... args) {
     if (r == ERANGE) {
       buff.resize(buff.size() * 2);
     }
-  } while(r == ERANGE);
+  } while (r == ERANGE);
 
   assert(!r);
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/getpw_getgr.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/getpw_getgr.cpp
@@ -67,14 +67,11 @@ void test_r(Fn f, Args... args) {
   T gr;
   T *result;
   std::string buff;
-  buff.resize(10000);
 
   int r;
   do {
+    buff.resize(1000 + buff.size() * 2);
     r = f(args..., &gr, buff.data(), buff.size(), &result);
-    if (r == ERANGE) {
-      buff.resize(buff.size() * 2);
-    }
   } while (r == ERANGE);
 
   assert(!r);

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/getpw_getgr.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/getpw_getgr.cpp
@@ -1,12 +1,15 @@
 // RUN: %clangxx %s -o %t && %run %t
 
 #include <assert.h>
+#include <errno.h>
 #include <grp.h>
 #include <memory>
 #include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <string>
+#include <unistd.h>
 
 std::unique_ptr<char []> any_group;
 const int N = 123456;
@@ -63,8 +66,19 @@ template <class T, class Fn, class... Args>
 void test_r(Fn f, Args... args) {
   T gr;
   T *result;
-  char buff[10000];
-  assert(!f(args..., &gr, buff, sizeof(buff), &result));
+  std::string buff;
+  buff.resize(1000);
+
+  int r;
+  do {
+    r = f(args..., &gr, buff.data(), buff.size(), &result);
+    if (r == ERANGE) {
+      buff.resize(buff.size() * 2);
+    }
+  } while(r == ERANGE);
+
+  assert(!r);
+
   Check(&gr);
   Check(result);
 }

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/getpw_getgr.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/getpw_getgr.cpp
@@ -67,7 +67,7 @@ void test_r(Fn f, Args... args) {
   T gr;
   T *result;
   std::string buff;
-  buff.resize(1000);
+  buff.resize(10000);
 
   int r;
   do {


### PR DESCRIPTION
On my workstation buffer needs to be about 1MB.
