### PR TITLE
Reland "[Support][JSON] Use std::unordered_map for object storage (#171230)"

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -155,7 +155,7 @@ static void insertComment(Object &Description, json::Value &Comment,
     Description[Key] = std::move(CommentsArray);
     Description["Has" + Key.str()] = true;
   } else {
-    DescriptionIt->getSecond().getAsArray()->push_back(Comment);
+    DescriptionIt->second.getAsArray()->push_back(Comment);
   }
 }
 

--- a/clang/include/clang/Basic/Sarif.h
+++ b/clang/include/clang/Basic/Sarif.h
@@ -34,6 +34,7 @@
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/Version.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"

--- a/clang/lib/Basic/DarwinSDKInfo.cpp
+++ b/clang/lib/Basic/DarwinSDKInfo.cpp
@@ -25,7 +25,7 @@ std::optional<VersionTuple> DarwinSDKInfo::RelatedTargetVersionMapping::map(
     return MaximumValue;
   auto KV = Mapping.find(Key.normalize());
   if (KV != Mapping.end())
-    return KV->getSecond();
+    return KV->second;
   // If no exact entry found, try just the major key version. Only do so when
   // a minor version number is present, to avoid recursing indefinitely into
   // the major-only check.
@@ -43,10 +43,10 @@ DarwinSDKInfo::RelatedTargetVersionMapping::parseJSON(
   VersionTuple MinValue = Min;
   llvm::DenseMap<VersionTuple, VersionTuple> Mapping;
   for (const auto &KV : Obj) {
-    if (auto Val = KV.getSecond().getAsString()) {
+    if (auto Val = KV.second.getAsString()) {
       llvm::VersionTuple KeyVersion;
       llvm::VersionTuple ValueVersion;
-      if (KeyVersion.tryParse(KV.getFirst()) || ValueVersion.tryParse(*Val))
+      if (KeyVersion.tryParse(KV.first) || ValueVersion.tryParse(*Val))
         return std::nullopt;
       Mapping[KeyVersion.normalize()] = ValueVersion;
       if (KeyVersion < Min)
@@ -119,7 +119,7 @@ static DarwinSDKInfo::PlatformInfoStorageType parsePlatformInfos(
 
   for (auto SupportedTargetPair : *SupportedTargets) {
     llvm::json::Object *SupportedTarget =
-        SupportedTargetPair.getSecond().getAsObject();
+        SupportedTargetPair.second.getAsObject();
     auto Vendor = SupportedTarget->getString("LLVMTargetTripleVendor");
     auto OS = SupportedTarget->getString("LLVMTargetTripleSys");
     if (!Vendor || !OS)
@@ -136,7 +136,7 @@ static DarwinSDKInfo::PlatformInfoStorageType parsePlatformInfos(
 
     // The key is either the Xcode platform, or a variant. The platform must be
     // the first entry in the returned PlatformInfoStorageType.
-    StringRef PlatformOrVariant = SupportedTargetPair.getFirst();
+    StringRef PlatformOrVariant = SupportedTargetPair.first;
 
     StringRef EffectivePlatformPrefix;
     // Ignore iosmac value if it exists.
@@ -202,12 +202,12 @@ DarwinSDKInfo::parseDarwinSDKSettingsJSON(std::string FilePath,
     // FIXME: Generalize this out beyond iOS-deriving targets.
     // Look for ios_<targetos> version mapping for targets that derive from ios.
     for (const auto &KV : *VM) {
-      auto Pair = StringRef(KV.getFirst()).split("_");
+      auto Pair = StringRef(KV.first).split("_");
       if (Pair.first.compare_insensitive("ios") == 0) {
         llvm::Triple TT(llvm::Twine("--") + Pair.second.lower());
         if (TT.getOS() != llvm::Triple::UnknownOS) {
           auto Mapping = RelatedTargetVersionMapping::parseJSON(
-              *KV.getSecond().getAsObject(), *MaximumDeploymentVersion);
+              *KV.second.getAsObject(), *MaximumDeploymentVersion);
           if (Mapping)
             VersionMappings[OSEnvPair(llvm::Triple::IOS,
                                       llvm::Triple::UnknownEnvironment,

--- a/clang/tools/clang-installapi/Options.cpp
+++ b/clang/tools/clang-installapi/Options.cpp
@@ -84,8 +84,8 @@ getArgListFromJSON(const StringRef Input, llvm::opt::OptTable *Table,
     return llvm::opt::InputArgList();
 
   for (const auto &KV : *Root) {
-    const Array *ArgList = KV.getSecond().getAsArray();
-    std::string Label = "-X" + KV.getFirst().str();
+    const Array *ArgList = KV.second.getAsArray();
+    std::string Label = "-X" + KV.first.str();
     if (!ArgList)
       return make_error<TextAPIError>(TextAPIErrorCode::InvalidInputFormat);
     for (auto Arg : *ArgList) {

--- a/clang/unittests/Basic/SarifTest.cpp
+++ b/clang/unittests/Basic/SarifTest.cpp
@@ -83,7 +83,7 @@ TEST_F(SarifDocumentWriterTest, canCreateEmptyDocument) {
   const llvm::json::Object &EmptyDoc = Writer.createDocument();
   std::vector<StringRef> Keys(EmptyDoc.size());
   std::transform(EmptyDoc.begin(), EmptyDoc.end(), Keys.begin(),
-                 [](auto Item) { return Item.getFirst(); });
+                 [](auto Item) { return Item.first; });
 
   // THEN:
   ASSERT_THAT(Keys, testing::UnorderedElementsAre("$schema", "version"));

--- a/lldb/source/Plugins/DynamicLoader/Windows-DYLD/DynamicLoaderWindowsDYLD.h
+++ b/lldb/source/Plugins/DynamicLoader/Windows-DYLD/DynamicLoaderWindowsDYLD.h
@@ -12,6 +12,8 @@
 #include "lldb/Target/DynamicLoader.h"
 #include "lldb/lldb-forward.h"
 
+#include "llvm/ADT/DenseMap.h"
+
 namespace lldb_private {
 
 class DynamicLoaderWindowsDYLD : public DynamicLoader {

--- a/lldb/source/Plugins/Process/Linux/IntelPTThreadTraceCollection.h
+++ b/lldb/source/Plugins/Process/Linux/IntelPTThreadTraceCollection.h
@@ -10,6 +10,7 @@
 #define liblldb_IntelPTPerThreadTraceCollection_H_
 
 #include "IntelPTSingleBufferTrace.h"
+#include "llvm/ADT/DenseMap.h"
 #include <optional>
 
 namespace lldb_private {

--- a/llvm/benchmarks/CMakeLists.txt
+++ b/llvm/benchmarks/CMakeLists.txt
@@ -15,6 +15,7 @@ add_benchmark(MustacheBench Mustache.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(SpecialCaseListBM SpecialCaseListBM.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(DWARFVerifierBM DWARFVerifierBM.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(PointerUnionBM PointerUnionBM.cpp PARTIAL_SOURCES_INTENDED)
+add_benchmark(JSONParserBM JSONParserBM.cpp PARTIAL_SOURCES_INTENDED)
 
 add_benchmark(RuntimeLibcallsBench RuntimeLibcalls.cpp PARTIAL_SOURCES_INTENDED)
 

--- a/llvm/benchmarks/JSONParserBM.cpp
+++ b/llvm/benchmarks/JSONParserBM.cpp
@@ -1,0 +1,299 @@
+//===- JSONParserBM.cpp - JSON parser benchmarks --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// \file
+// Benchmarks for LLVM's JSON parser.
+// Runs parsing, tree iteration, and object key lookup with generated inputs.
+// Measures time performance and memory consumption.
+//
+//===----------------------------------------------------------------------===//
+
+#include "benchmark/benchmark.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/JSON.h"
+#include <algorithm>
+#include <atomic>
+#include <random>
+
+using namespace llvm;
+
+//===----------------------------------------------------------------------===//
+// Memory tracking via global operator new
+//
+// These are global overrides so the benchmark might be over-counting memory
+// allocations and usage. The data is still useful for comparisons with this
+// benchmark itself.
+//===----------------------------------------------------------------------===//
+
+static std::atomic_size_t TotalAllocatedBytes{0};
+static std::atomic_size_t NumAllocs{0};
+static bool TrackMemory = false;
+
+// Single-object new/delete.
+void *operator new(std::size_t Size) {
+  if (TrackMemory) {
+    TotalAllocatedBytes += Size;
+    ++NumAllocs;
+  }
+  return std::malloc(Size);
+}
+
+void *operator new(std::size_t Size, std::align_val_t) {
+  if (TrackMemory) {
+    TotalAllocatedBytes += Size;
+    ++NumAllocs;
+  }
+  return std::malloc(Size);
+}
+
+void *operator new(std::size_t Size, const std::nothrow_t &) noexcept {
+  if (TrackMemory) {
+    TotalAllocatedBytes += Size;
+    ++NumAllocs;
+  }
+  return std::malloc(Size);
+}
+
+void *operator new(std::size_t Size, std::align_val_t,
+                   const std::nothrow_t &) noexcept {
+  if (TrackMemory) {
+    TotalAllocatedBytes += Size;
+    ++NumAllocs;
+  }
+  return std::malloc(Size);
+}
+
+void operator delete(void *Ptr) noexcept { std::free(Ptr); }
+void operator delete(void *Ptr, std::align_val_t) noexcept { std::free(Ptr); }
+void operator delete(void *Ptr, std::size_t) noexcept { std::free(Ptr); }
+void operator delete(void *Ptr, std::size_t, std::align_val_t) noexcept {
+  std::free(Ptr);
+}
+
+// Array new/delete.
+void *operator new[](std::size_t Size) {
+  if (TrackMemory) {
+    TotalAllocatedBytes += Size;
+    ++NumAllocs;
+  }
+  return std::malloc(Size);
+}
+
+void *operator new[](std::size_t Size, std::align_val_t) {
+  if (TrackMemory) {
+    TotalAllocatedBytes += Size;
+    ++NumAllocs;
+  }
+  return std::malloc(Size);
+}
+
+void *operator new[](std::size_t Size, const std::nothrow_t &) noexcept {
+  if (TrackMemory) {
+    TotalAllocatedBytes += Size;
+    ++NumAllocs;
+  }
+  return std::malloc(Size);
+}
+
+void *operator new[](std::size_t Size, std::align_val_t,
+                     const std::nothrow_t &) noexcept {
+  if (TrackMemory) {
+    TotalAllocatedBytes += Size;
+    ++NumAllocs;
+  }
+  return std::malloc(Size);
+}
+
+void operator delete[](void *Ptr) noexcept { std::free(Ptr); }
+void operator delete[](void *Ptr, std::align_val_t) noexcept { std::free(Ptr); }
+void operator delete[](void *Ptr, std::size_t) noexcept { std::free(Ptr); }
+void operator delete[](void *Ptr, std::size_t, std::align_val_t) noexcept {
+  std::free(Ptr);
+}
+
+//===----------------------------------------------------------------------===//
+// Test data generation
+//===----------------------------------------------------------------------===//
+
+/// Generate a JSON string with \p N entries in an array. Each entry is a nested
+/// structure with objects and arrays to exercise parsing, iteration, and lookup
+/// at multiple depths.
+///
+/// Structure:
+///   {"items": [
+///     {
+///       "name": "item_I",
+///       "value": I,
+///       "tags": [
+///         {"label": "tag_0", "priority": 0},
+///         ...
+///       ],
+///       "details": {
+///         "description": "description text for item I",
+///         "active": true/false,
+///         "nested": { "x": I, "y": I*100 }
+///       }
+///     },
+///     ...
+///   ]}
+static std::string generateJSON(int N) {
+  std::string S;
+  raw_string_ostream OS(S);
+  OS << "{\"items\": [\n";
+  for (int I = 0; I < N; ++I) {
+    if (I > 0)
+      OS << ",\n";
+    OS << "  {\n"
+       << "    \"name\": \"item_" << I << "\",\n"
+       << "    \"value\": " << I << ",\n"
+       << "    \"tags\": [\n"
+       << "      {\"label\": \"tag_0\", \"priority\": 0},\n"
+       << "      {\"label\": \"tag_1\", \"priority\": 1},\n"
+       << "      {\"label\": \"tag_2\", \"priority\": 2}\n"
+       << "    ],\n"
+       << "    \"details\": {\n"
+       << "      \"description\": \"description text for item " << I << "\",\n"
+       << "      \"active\": " << (I % 2 == 0 ? "true" : "false") << ",\n"
+       << "      \"nested\": {\"x\": " << I << ", \"y\": " << I * 100 << "}\n"
+       << "    }\n"
+       << "  }";
+  }
+  OS << "\n]}";
+  return S;
+}
+
+//===----------------------------------------------------------------------===//
+// Tree traversal helpers
+//===----------------------------------------------------------------------===//
+
+/// Walk the JSON value tree, visiting every node. Returns the number of
+/// nodes visited.
+static size_t walkTree(const json::Value &V) {
+  size_t Count = 1;
+  if (const auto *Obj = V.getAsObject()) {
+    for (const auto &KV : *Obj)
+      Count += walkTree(KV.second);
+  } else if (const auto *Arr = V.getAsArray()) {
+    for (const auto &Elem : *Arr)
+      Count += walkTree(Elem);
+  }
+  return Count;
+}
+
+/// An Object paired with its own keys, for lookup benchmarks.
+struct ObjectWithKeys {
+  const json::Object *Obj;
+  SmallVector<std::string> Keys;
+};
+
+/// Collect every Object in the tree together with its own keys.
+static void collectObjectsWithKeys(const json::Value &V,
+                                   SmallVectorImpl<ObjectWithKeys> &Result) {
+  if (const auto *Obj = V.getAsObject()) {
+    ObjectWithKeys Entry;
+    Entry.Obj = Obj;
+    for (const auto &KV : *Obj) {
+      Entry.Keys.push_back(std::string(StringRef(KV.first)));
+      collectObjectsWithKeys(KV.second, Result);
+    }
+    Result.push_back(std::move(Entry));
+  } else if (const auto *Arr = V.getAsArray()) {
+    for (const auto &Elem : *Arr)
+      collectObjectsWithKeys(Elem, Result);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Benchmarks
+//===----------------------------------------------------------------------===//
+
+/// Benchmark json::parse(). Reports parse throughput and memory allocated.
+static void BM_JSONParse(benchmark::State &State) {
+  std::string JSON = generateJSON(State.range(0));
+
+  // Measure memory for a single parse before the timed loop.
+  TotalAllocatedBytes = 0;
+  NumAllocs = 0;
+  TrackMemory = true;
+  {
+    auto V = json::parse(JSON);
+    benchmark::DoNotOptimize(V);
+  }
+  TrackMemory = false;
+
+  State.counters["AllocBytes"] = TotalAllocatedBytes.load();
+  State.counters["Allocs"] = NumAllocs.load();
+
+  for (auto _ : State) {
+    auto V = json::parse(JSON);
+    benchmark::DoNotOptimize(V);
+  }
+  State.counters["ParseByteRate"] = benchmark::Counter(
+      State.iterations() * JSON.size(), benchmark::Counter::kIsRate,
+      benchmark::Counter::kIs1024);
+}
+BENCHMARK(BM_JSONParse)->Arg(10)->Arg(1000)->Arg(100000);
+
+/// Benchmark recursive tree iteration over a parsed JSON value.
+static void BM_JSONIterate(benchmark::State &State) {
+  std::string JSON = generateJSON(State.range(0));
+  json::Value Root = cantFail(json::parse(JSON));
+  size_t NodeCount = 0;
+  for (auto _ : State) {
+    NodeCount = walkTree(Root);
+    benchmark::DoNotOptimize(NodeCount);
+  }
+  State.SetItemsProcessed(State.iterations() * NodeCount);
+}
+BENCHMARK(BM_JSONIterate)->Arg(10)->Arg(1000)->Arg(100000);
+
+/// Benchmark Object::get() with each object's own keys in insertion order.
+static void BM_JSONLookupSequential(benchmark::State &State) {
+  std::string JSON = generateJSON(State.range(0));
+  json::Value Root = cantFail(json::parse(JSON));
+  SmallVector<ObjectWithKeys> ObjKeys;
+  collectObjectsWithKeys(Root, ObjKeys);
+
+  size_t TotalLookups = 0;
+  for (const auto &OK : ObjKeys)
+    TotalLookups += OK.Keys.size();
+
+  for (auto _ : State) {
+    for (const auto &OK : ObjKeys)
+      for (const auto &K : OK.Keys)
+        benchmark::DoNotOptimize(OK.Obj->get(K));
+  }
+  State.SetItemsProcessed(State.iterations() * TotalLookups);
+}
+BENCHMARK(BM_JSONLookupSequential)->Arg(10)->Arg(1000)->Arg(100000);
+
+/// Benchmark Object::get() with each object's own keys in random order.
+static void BM_JSONLookupRandom(benchmark::State &State) {
+  std::string JSON = generateJSON(State.range(0));
+  json::Value Root = cantFail(json::parse(JSON));
+  SmallVector<ObjectWithKeys> ObjKeys;
+  collectObjectsWithKeys(Root, ObjKeys);
+
+  std::mt19937 RNG(42);
+  size_t TotalLookups = 0;
+  for (auto &OK : ObjKeys) {
+    TotalLookups += OK.Keys.size();
+    std::shuffle(OK.Keys.begin(), OK.Keys.end(), RNG);
+  }
+
+  for (auto _ : State) {
+    for (const auto &OK : ObjKeys)
+      for (const auto &K : OK.Keys)
+        benchmark::DoNotOptimize(OK.Obj->get(K));
+  }
+  State.SetItemsProcessed(State.iterations() * TotalLookups);
+}
+BENCHMARK(BM_JSONLookupRandom)->Arg(10)->Arg(1000)->Arg(100000);
+
+BENCHMARK_MAIN();

--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -46,6 +46,7 @@
 #ifndef LLVM_SUPPORT_JSON_H
 #define LLVM_SUPPORT_JSON_H
 
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -76,10 +77,12 @@ namespace json {
 //   - When retrieving strings from Values (e.g. asString()), the result will
 //     always be valid UTF-8.
 
+template <typename T, bool = std::is_integral_v<T>>
+constexpr bool is_uint_64_bit_v = false;
+
 template <typename T>
-constexpr bool is_uint_64_bit_v =
-    std::is_integral_v<T> && std::is_unsigned_v<T> &&
-    sizeof(T) == sizeof(uint64_t);
+constexpr bool is_uint_64_bit_v<T, true> =
+    std::is_unsigned_v<T> && sizeof(T) == sizeof(uint64_t);
 
 /// Returns true if \p S is valid UTF-8, which is required for use as JSON.
 /// If it returns false, \p Offset is set to a byte offset near the first error.
@@ -90,84 +93,65 @@ LLVM_ABI bool isUTF8(llvm::StringRef S, size_t *ErrOffset = nullptr);
 LLVM_ABI std::string fixUTF8(llvm::StringRef S);
 
 class Array;
-class ObjectKey;
 class Value;
+class Object;
 template <typename T> Value toJSON(const std::optional<T> &Opt);
 
-/// An Object is a JSON object, which maps strings to heterogenous JSON values.
-/// ObjectKey is a maybe-owned string.
-class Object {
-  struct ObjectKeyHash {
-    template <typename T> size_t operator()(const T &Key) const {
-      return hash_value(Key);
-    }
-  };
-  using Storage = std::unordered_map<ObjectKey, Value, ObjectKeyHash>;
-  Storage M;
-
+/// ObjectKey is a used to capture keys in Object. Like Value but:
+///   - only strings are allowed
+///   - it's optimized for the string literal case (Owned == nullptr)
+/// Like Value, strings must be UTF-8. See isUTF8 documentation for details.
+class ObjectKey {
 public:
-  using key_type = ObjectKey;
-  using mapped_type = Value;
-  using value_type = Storage::value_type;
-  using iterator = Storage::iterator;
-  using const_iterator = Storage::const_iterator;
-
-  Object() = default;
-  // KV is a trivial key-value struct for list-initialization.
-  // (using std::pair forces extra copies).
-  struct KV;
-  explicit Object(std::initializer_list<KV> Properties);
-
-  iterator begin() { return M.begin(); }
-  const_iterator begin() const { return M.begin(); }
-  iterator end() { return M.end(); }
-  const_iterator end() const { return M.end(); }
-
-  bool empty() const { return M.empty(); }
-  size_t size() const { return M.size(); }
-
-  void clear() { M.clear(); }
-  std::pair<iterator, bool> insert(KV E);
-  template <typename... Ts>
-  std::pair<iterator, bool> try_emplace(const ObjectKey &K, Ts &&... Args) {
-    return M.try_emplace(K, std::forward<Ts>(Args)...);
+  ObjectKey(const char *S) : ObjectKey(StringRef(S)) {}
+  ObjectKey(std::string S) : Owned(new std::string(std::move(S))) {
+    if (LLVM_UNLIKELY(!isUTF8(*Owned))) {
+      assert(false && "Invalid UTF-8 in value used as JSON");
+      *Owned = fixUTF8(*Owned);
+    }
+    Data = *Owned;
   }
-  template <typename... Ts>
-  std::pair<iterator, bool> try_emplace(ObjectKey &&K, Ts &&... Args) {
-    return M.try_emplace(std::move(K), std::forward<Ts>(Args)...);
+  ObjectKey(llvm::StringRef S) : Data(S) {
+    if (LLVM_UNLIKELY(!isUTF8(Data))) {
+      assert(false && "Invalid UTF-8 in value used as JSON");
+      *this = ObjectKey(fixUTF8(S));
+    }
   }
-  bool erase(StringRef K);
-  void erase(iterator I) { M.erase(I); }
+  ObjectKey(const llvm::SmallVectorImpl<char> &V)
+      : ObjectKey(std::string(V.begin(), V.end())) {}
+  ObjectKey(const llvm::formatv_object_base &V) : ObjectKey(V.str()) {}
 
-  // TODO: Implement heterogeneous lookup using StringRef directly. We need to
-  // make ObjectKey transparent with transparent hash and key equality check.
-  // This is supported for unordered containers in C++20.
-  iterator find(const ObjectKey &K) { return M.find(K); }
-  const_iterator find(const ObjectKey &K) const { return M.find(K); }
-  // operator[] acts as if Value was default-constructible as null.
-  LLVM_ABI Value &operator[](const ObjectKey &K);
-  LLVM_ABI Value &operator[](ObjectKey &&K);
-  // Look up a property, returning nullptr if it doesn't exist.
-  LLVM_ABI Value *get(StringRef K);
-  LLVM_ABI const Value *get(StringRef K) const;
-  // Typed accessors return std::nullopt/nullptr if
-  //   - the property doesn't exist
-  //   - or it has the wrong type
-  LLVM_ABI std::optional<std::nullptr_t> getNull(StringRef K) const;
-  LLVM_ABI std::optional<bool> getBoolean(StringRef K) const;
-  LLVM_ABI std::optional<double> getNumber(StringRef K) const;
-  LLVM_ABI std::optional<int64_t> getInteger(StringRef K) const;
-  LLVM_ABI std::optional<llvm::StringRef> getString(StringRef K) const;
-  LLVM_ABI const json::Object *getObject(StringRef K) const;
-  LLVM_ABI json::Object *getObject(StringRef K);
-  LLVM_ABI const json::Array *getArray(StringRef K) const;
-  LLVM_ABI json::Array *getArray(StringRef K);
+  ObjectKey(const ObjectKey &C) { *this = C; }
+  ObjectKey(ObjectKey &&C) : ObjectKey(static_cast<const ObjectKey &&>(C)) {}
+  ObjectKey &operator=(const ObjectKey &C) {
+    if (C.Owned) {
+      Owned.reset(new std::string(*C.Owned));
+      Data = *Owned;
+    } else {
+      Data = C.Data;
+    }
+    return *this;
+  }
+  ObjectKey &operator=(ObjectKey &&) = default;
 
-  friend LLVM_ABI bool operator==(const Object &LHS, const Object &RHS);
+  operator llvm::StringRef() const { return Data; }
+  std::string str() const { return Data.str(); }
+
+private:
+  // FIXME: this is unneccesarily large (3 pointers). Pointer + length + owned
+  // could be 2 pointers at most.
+  std::unique_ptr<std::string> Owned;
+  llvm::StringRef Data;
 };
-LLVM_ABI bool operator==(const Object &LHS, const Object &RHS);
-inline bool operator!=(const Object &LHS, const Object &RHS) {
-  return !(LHS == RHS);
+
+inline bool operator==(const ObjectKey &L, const ObjectKey &R) {
+  return llvm::StringRef(L) == llvm::StringRef(R);
+}
+inline bool operator!=(const ObjectKey &L, const ObjectKey &R) {
+  return !(L == R);
+}
+inline bool operator<(const ObjectKey &L, const ObjectKey &R) {
+  return StringRef(L) < StringRef(R);
 }
 
 /// An Array is a JSON array, which contains heterogeneous JSON values.
@@ -319,9 +303,7 @@ public:
   }
   template <typename Elt>
   Value(const std::vector<Elt> &C) : Value(json::Array(C)) {}
-  Value(json::Object &&Properties) : Type(T_Object) {
-    create<json::Object>(std::move(Properties));
-  }
+  Value(json::Object &&Properties);
   template <typename Elt>
   Value(const std::map<std::string, Elt> &C) : Value(json::Object(C)) {}
   // Strings: types with value semantics. Must be valid UTF-8.
@@ -472,10 +454,14 @@ public:
     return std::nullopt;
   }
   const json::Object *getAsObject() const {
-    return LLVM_LIKELY(Type == T_Object) ? &as<json::Object>() : nullptr;
+    return LLVM_LIKELY(Type == T_Object)
+               ? as<std::unique_ptr<json::Object>>().get()
+               : nullptr;
   }
   json::Object *getAsObject() {
-    return LLVM_LIKELY(Type == T_Object) ? &as<json::Object>() : nullptr;
+    return LLVM_LIKELY(Type == T_Object)
+               ? as<std::unique_ptr<json::Object>>().get()
+               : nullptr;
   }
   const json::Array *getAsArray() const {
     return LLVM_LIKELY(Type == T_Array) ? &as<json::Array>() : nullptr;
@@ -538,7 +524,7 @@ private:
   mutable ValueType Type;
   mutable llvm::AlignedCharArrayUnion<bool, double, int64_t, uint64_t,
                                       llvm::StringRef, std::string, json::Array,
-                                      json::Object>
+                                      std::unique_ptr<json::Object>>
       Union;
   LLVM_ABI friend bool operator==(const Value &, const Value &);
 };
@@ -589,61 +575,80 @@ inline Array::iterator Array::emplace(const_iterator P, Args &&...A) {
 inline Array::iterator Array::erase(const_iterator P) { return V.erase(P); }
 inline bool operator==(const Array &L, const Array &R) { return L.V == R.V; }
 
-/// ObjectKey is a used to capture keys in Object. Like Value but:
-///   - only strings are allowed
-///   - it's optimized for the string literal case (Owned == nullptr)
-/// Like Value, strings must be UTF-8. See isUTF8 documentation for details.
-class ObjectKey {
+/// An Object is a JSON object, which maps strings to heterogeneous JSON values.
+/// ObjectKey is a maybe-owned string.
+class Object {
+  struct ObjectKeyHash {
+    size_t operator()(const ObjectKey &Key) const {
+      return hash_value(StringRef(Key));
+    }
+  };
+  using Storage = std::unordered_map<ObjectKey, Value, ObjectKeyHash>;
+  Storage M;
+
 public:
-  ObjectKey(const char *S) : ObjectKey(StringRef(S)) {}
-  ObjectKey(std::string S) : Owned(new std::string(std::move(S))) {
-    if (LLVM_UNLIKELY(!isUTF8(*Owned))) {
-      assert(false && "Invalid UTF-8 in value used as JSON");
-      *Owned = fixUTF8(*Owned);
-    }
-    Data = *Owned;
-  }
-  ObjectKey(llvm::StringRef S) : Data(S) {
-    if (LLVM_UNLIKELY(!isUTF8(Data))) {
-      assert(false && "Invalid UTF-8 in value used as JSON");
-      *this = ObjectKey(fixUTF8(S));
-    }
-  }
-  ObjectKey(const llvm::SmallVectorImpl<char> &V)
-      : ObjectKey(std::string(V.begin(), V.end())) {}
-  ObjectKey(const llvm::formatv_object_base &V) : ObjectKey(V.str()) {}
+  using key_type = ObjectKey;
+  using mapped_type = Value;
+  using value_type = Storage::value_type;
+  using iterator = Storage::iterator;
+  using const_iterator = Storage::const_iterator;
 
-  ObjectKey(const ObjectKey &C) { *this = C; }
-  ObjectKey(ObjectKey &&C) : ObjectKey(static_cast<const ObjectKey &&>(C)) {}
-  ObjectKey &operator=(const ObjectKey &C) {
-    if (C.Owned) {
-      Owned.reset(new std::string(*C.Owned));
-      Data = *Owned;
-    } else {
-      Data = C.Data;
-    }
-    return *this;
+  Object() = default;
+  // KV is a trivial key-value struct for list-initialization.
+  // (using std::pair forces extra copies).
+  struct KV;
+  explicit Object(std::initializer_list<KV> Properties);
+
+  iterator begin() { return M.begin(); }
+  const_iterator begin() const { return M.begin(); }
+  iterator end() { return M.end(); }
+  const_iterator end() const { return M.end(); }
+
+  bool empty() const { return M.empty(); }
+  size_t size() const { return M.size(); }
+
+  void clear() { M.clear(); }
+  std::pair<iterator, bool> insert(KV E);
+  template <typename... Ts>
+  std::pair<iterator, bool> try_emplace(const ObjectKey &K, Ts &&...Args) {
+    return M.try_emplace(K, std::forward<Ts>(Args)...);
   }
-  ObjectKey &operator=(ObjectKey &&) = default;
+  template <typename... Ts>
+  std::pair<iterator, bool> try_emplace(ObjectKey &&K, Ts &&...Args) {
+    return M.try_emplace(std::move(K), std::forward<Ts>(Args)...);
+  }
+  bool erase(StringRef K);
+  void erase(iterator I) { M.erase(I); }
 
-  operator llvm::StringRef() const { return Data; }
-  std::string str() const { return Data.str(); }
+  // TODO: Implement heterogeneous lookup using StringRef directly. We need to
+  // make ObjectKey transparent with transparent hash and key equality check.
+  // This is supported for unordered containers in C++20.
+  iterator find(const ObjectKey &K) { return M.find(K); }
+  const_iterator find(const ObjectKey &K) const { return M.find(K); }
+  // operator[] acts as if Value was default-constructible as null.
+  LLVM_ABI Value &operator[](const ObjectKey &K);
+  LLVM_ABI Value &operator[](ObjectKey &&K);
+  // Look up a property, returning nullptr if it doesn't exist.
+  LLVM_ABI Value *get(StringRef K);
+  LLVM_ABI const Value *get(StringRef K) const;
+  // Typed accessors return std::nullopt/nullptr if
+  //   - the property doesn't exist
+  //   - or it has the wrong type
+  LLVM_ABI std::optional<std::nullptr_t> getNull(StringRef K) const;
+  LLVM_ABI std::optional<bool> getBoolean(StringRef K) const;
+  LLVM_ABI std::optional<double> getNumber(StringRef K) const;
+  LLVM_ABI std::optional<int64_t> getInteger(StringRef K) const;
+  LLVM_ABI std::optional<llvm::StringRef> getString(StringRef K) const;
+  LLVM_ABI const json::Object *getObject(StringRef K) const;
+  LLVM_ABI json::Object *getObject(StringRef K);
+  LLVM_ABI const json::Array *getArray(StringRef K) const;
+  LLVM_ABI json::Array *getArray(StringRef K);
 
-private:
-  // FIXME: this is unneccesarily large (3 pointers). Pointer + length + owned
-  // could be 2 pointers at most.
-  std::unique_ptr<std::string> Owned;
-  llvm::StringRef Data;
+  friend LLVM_ABI bool operator==(const Object &LHS, const Object &RHS);
 };
-
-inline bool operator==(const ObjectKey &L, const ObjectKey &R) {
-  return llvm::StringRef(L) == llvm::StringRef(R);
-}
-inline bool operator!=(const ObjectKey &L, const ObjectKey &R) {
-  return !(L == R);
-}
-inline bool operator<(const ObjectKey &L, const ObjectKey &R) {
-  return StringRef(L) < StringRef(R);
+LLVM_ABI bool operator==(const Object &LHS, const Object &RHS);
+inline bool operator!=(const Object &LHS, const Object &RHS) {
+  return !(LHS == RHS);
 }
 
 struct Object::KV {
@@ -663,6 +668,11 @@ inline std::pair<Object::iterator, bool> Object::insert(KV E) {
 }
 inline bool Object::erase(StringRef K) {
   return M.erase(ObjectKey(K));
+}
+
+inline Value::Value(json::Object &&Properties) : Type(T_Object) {
+  create<std::unique_ptr<json::Object>>(
+      std::make_unique<json::Object>(std::move(Properties)));
 }
 
 LLVM_ABI std::vector<const Object::value_type *>

--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -46,17 +46,17 @@
 #ifndef LLVM_SUPPORT_JSON_H
 #define LLVM_SUPPORT_JSON_H
 
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/AlignOf.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cmath>
 #include <map>
+#include <unordered_map>
 
 namespace llvm {
 namespace json {

--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -47,6 +47,7 @@
 #define LLVM_SUPPORT_JSON_H
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -94,9 +95,14 @@ class Value;
 template <typename T> Value toJSON(const std::optional<T> &Opt);
 
 /// An Object is a JSON object, which maps strings to heterogenous JSON values.
-/// It simulates DenseMap<ObjectKey, Value>. ObjectKey is a maybe-owned string.
+/// ObjectKey is a maybe-owned string.
 class Object {
-  using Storage = DenseMap<ObjectKey, Value, llvm::DenseMapInfo<StringRef>>;
+  struct ObjectKeyHash {
+    template <typename T> size_t operator()(const T &Key) const {
+      return hash_value(Key);
+    }
+  };
+  using Storage = std::unordered_map<ObjectKey, Value, ObjectKeyHash>;
   Storage M;
 
 public:
@@ -133,8 +139,11 @@ public:
   bool erase(StringRef K);
   void erase(iterator I) { M.erase(I); }
 
-  iterator find(StringRef K) { return M.find_as(K); }
-  const_iterator find(StringRef K) const { return M.find_as(K); }
+  // TODO: Implement heterogeneous lookup using StringRef directly. We need to
+  // make ObjectKey transparent with transparent hash and key equality check.
+  // This is supported for unordered containers in C++20.
+  iterator find(const ObjectKey &K) { return M.find(K); }
+  const_iterator find(const ObjectKey &K) const { return M.find(K); }
   // operator[] acts as if Value was default-constructible as null.
   LLVM_ABI Value &operator[](const ObjectKey &K);
   LLVM_ABI Value &operator[](ObjectKey &&K);
@@ -646,7 +655,7 @@ inline Object::Object(std::initializer_list<KV> Properties) {
   for (const auto &P : Properties) {
     auto R = try_emplace(P.K, nullptr);
     if (R.second)
-      R.first->getSecond().moveFrom(std::move(P.V));
+      R.first->second.moveFrom(std::move(P.V));
   }
 }
 inline std::pair<Object::iterator, bool> Object::insert(KV E) {

--- a/llvm/lib/Support/JSON.cpp
+++ b/llvm/lib/Support/JSON.cpp
@@ -22,10 +22,10 @@ namespace llvm {
 namespace json {
 
 Value &Object::operator[](const ObjectKey &K) {
-  return try_emplace(K, nullptr).first->getSecond();
+  return try_emplace(K, nullptr).first->second;
 }
 Value &Object::operator[](ObjectKey &&K) {
-  return try_emplace(std::move(K), nullptr).first->getSecond();
+  return try_emplace(std::move(K), nullptr).first->second;
 }
 Value *Object::get(StringRef K) {
   auto I = find(K);

--- a/llvm/lib/Support/JSON.cpp
+++ b/llvm/lib/Support/JSON.cpp
@@ -114,7 +114,8 @@ void Value::copyFrom(const Value &M) {
     create<std::string>(M.as<std::string>());
     break;
   case T_Object:
-    create<json::Object>(M.as<json::Object>());
+    create<std::unique_ptr<json::Object>>(
+        std::make_unique<json::Object>(*M.as<std::unique_ptr<json::Object>>()));
     break;
   case T_Array:
     create<json::Array>(M.as<json::Array>());
@@ -139,7 +140,8 @@ void Value::moveFrom(const Value &&M) {
     create<std::string>(std::move(M.as<std::string>()));
     break;
   case T_Object:
-    create<json::Object>(std::move(M.as<json::Object>()));
+    create<std::unique_ptr<json::Object>>(
+        std::move(M.as<std::unique_ptr<json::Object>>()));
     break;
   case T_Array:
     create<json::Array>(std::move(M.as<json::Array>()));
@@ -164,7 +166,7 @@ void Value::destroy() {
     as<std::string>().~basic_string();
     break;
   case T_Object:
-    as<json::Object>().~Object();
+    as<std::unique_ptr<json::Object>>().~unique_ptr();
     break;
   case T_Array:
     as<json::Array>().~Array();

--- a/llvm/tools/llvm-mca/Views/InstructionInfoView.h
+++ b/llvm/tools/llvm-mca/Views/InstructionInfoView.h
@@ -36,6 +36,7 @@
 
 #include "Views/InstructionView.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstPrinter.h"


### PR DESCRIPTION
#171230 was reverted because of Buildbot failures with libstdc++.

libstdc++ eagerly instantiates `std::pair<const ObjectKey, Value>` with `std::unordered_map<ObjectKey, Value>`, requiring both types to be complete. This creates a circular dependency: `json::Object` needs `json::Value` complete, and `json::Value` needs `json::Object` complete (for `AlignedCharArrayUnion`).

The fix stores a `std::unique_ptr<json::Object>` in Value's union instead of inline, breaking the cycle. This allows reordering the type definitions as `ObjectKey -> Array -> Value -> Object`, so both key and value types are complete when the `unordered_map` is instantiated.

This also changes how `json::Value` is laid out in memory. With #171230, `sizeof(json::Object)` grows from the change to `std::unordered_map`, so `sizeof(json::Value::Union)` also increases. In this fix, the size of `Union` shrinks because we use `std::unique_ptr`, with the trade-off of an additional allocation outside of `AlignedCharArrayUnion`'s buffer to create `json::Object` (only occurring for object-typed values).

Benchmarked again and the performance is roughly the same as in #171230:
```
Running benchmarks/JSONParserBM
Run on (20 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x20)
Load Average: 5.58, 13.78, 10.19
-----------------------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------
BM_JSONParse/10                     21614 ns        21608 ns        31732 AllocBytes=26.048k Allocs=640 ParseByteRate=142.822Mi/s
BM_JSONParse/1000                 2307481 ns      2306885 ns          304 AllocBytes=2.55368M Allocs=63.016k ParseByteRate=137.234Mi/s
BM_JSONParse/100000             237053194 ns    236974667 ns            3 AllocBytes=257.189M Allocs=6.30002M ParseByteRate=137.611Mi/s
BM_JSONIterate/10                     373 ns          372 ns      1881650 items_per_second=515.516M/s
BM_JSONIterate/1000                 36334 ns        36330 ns        19185 items_per_second=523.046M/s
BM_JSONIterate/100000             7852453 ns      7851031 ns          159 items_per_second=242.007M/s
BM_JSONLookupSequential/10           1695 ns         1694 ns       414088 items_per_second=89.1237M/s
BM_JSONLookupSequential/1000       167926 ns       167893 ns         4156 items_per_second=89.3484M/s
BM_JSONLookupSequential/100000   17563538 ns     17554429 ns           35 items_per_second=85.4486M/s
BM_JSONLookupRandom/10               1777 ns         1776 ns       395003 items_per_second=85.0015M/s
BM_JSONLookupRandom/1000           189113 ns       189087 ns         3712 items_per_second=79.334M/s
BM_JSONLookupRandom/100000       22329233 ns     22325500 ns           36 items_per_second=67.1878M/s
```

Assisted-by: Claude Code (claude-opus-4-6)