### PR TITLE
[lld][ELF] Add --print-relax-stats= to emit linker relaxation statistics

### DIFF
--- a/lld/ELF/Arch/X86_64.cpp
+++ b/lld/ELF/Arch/X86_64.cpp
@@ -1251,6 +1251,36 @@ bool X86_64::adjustPrologueForCrossSplitStack(uint8_t *loc, uint8_t *end,
   return false;
 }
 
+// rel.expr was set during scanRelocations to encode whether relaxation will be
+// applied (e.g. R_RELAX_GOT_PC vs R_GOT_PC). We reuse those same checks here.
+static void trackRelaxStats(Ctx &ctx, const Relocation &rel) {
+  bool relaxed;
+  switch (rel.type) {
+  case R_X86_64_GOTPCRELX:
+  case R_X86_64_REX_GOTPCRELX:
+  case R_X86_64_CODE_4_GOTPCRELX:
+    relaxed = rel.expr != R_GOT_PC;
+    break;
+  case R_X86_64_GOTPC32_TLSDESC:
+  case R_X86_64_CODE_4_GOTPC32_TLSDESC:
+  case R_X86_64_TLSGD:
+    relaxed = rel.expr == R_TPREL || rel.expr == R_GOT_PC;
+    break;
+  case R_X86_64_TLSLD:
+  case R_X86_64_GOTTPOFF:
+  case R_X86_64_CODE_4_GOTTPOFF:
+  case R_X86_64_CODE_6_GOTTPOFF:
+    relaxed = rel.expr == R_TPREL;
+    break;
+  default:
+    return;
+  }
+  auto &entry = ctx.relaxStats[rel.type];
+  entry.total.fetch_add(1, std::memory_order_relaxed);
+  if (relaxed)
+    entry.relaxed.fetch_add(1, std::memory_order_relaxed);
+}
+
 void X86_64::relocateAlloc(InputSection &sec, uint8_t *buf) const {
   uint64_t secAddr = sec.getOutputSection()->addr + sec.outSecOff;
   for (const Relocation &rel : sec.relocs()) {
@@ -1259,6 +1289,8 @@ void X86_64::relocateAlloc(InputSection &sec, uint8_t *buf) const {
     uint8_t *loc = buf + rel.offset;
     const uint64_t val = sec.getRelocTargetVA(ctx, rel, secAddr + rel.offset);
     relocate(loc, rel, val);
+    if (!ctx.arg.printRelaxStats.empty())
+      trackRelaxStats(ctx, rel);
   }
   if (sec.jumpInstrMod) {
     applyJumpInstrMod(buf + sec.jumpInstrMod->offset,

--- a/lld/ELF/Arch/X86_64.cpp
+++ b/lld/ELF/Arch/X86_64.cpp
@@ -1251,36 +1251,6 @@ bool X86_64::adjustPrologueForCrossSplitStack(uint8_t *loc, uint8_t *end,
   return false;
 }
 
-// rel.expr was set during scanRelocations to encode whether relaxation will be
-// applied (e.g. R_RELAX_GOT_PC vs R_GOT_PC). We reuse those same checks here.
-static void trackRelaxStats(Ctx &ctx, const Relocation &rel) {
-  bool relaxed;
-  switch (rel.type) {
-  case R_X86_64_GOTPCRELX:
-  case R_X86_64_REX_GOTPCRELX:
-  case R_X86_64_CODE_4_GOTPCRELX:
-    relaxed = rel.expr != R_GOT_PC;
-    break;
-  case R_X86_64_GOTPC32_TLSDESC:
-  case R_X86_64_CODE_4_GOTPC32_TLSDESC:
-  case R_X86_64_TLSGD:
-    relaxed = rel.expr == R_TPREL || rel.expr == R_GOT_PC;
-    break;
-  case R_X86_64_TLSLD:
-  case R_X86_64_GOTTPOFF:
-  case R_X86_64_CODE_4_GOTTPOFF:
-  case R_X86_64_CODE_6_GOTTPOFF:
-    relaxed = rel.expr == R_TPREL;
-    break;
-  default:
-    return;
-  }
-  auto &entry = ctx.relaxStats[rel.type];
-  entry.total.fetch_add(1, std::memory_order_relaxed);
-  if (relaxed)
-    entry.relaxed.fetch_add(1, std::memory_order_relaxed);
-}
-
 void X86_64::relocateAlloc(InputSection &sec, uint8_t *buf) const {
   uint64_t secAddr = sec.getOutputSection()->addr + sec.outSecOff;
   for (const Relocation &rel : sec.relocs()) {
@@ -1289,8 +1259,6 @@ void X86_64::relocateAlloc(InputSection &sec, uint8_t *buf) const {
     uint8_t *loc = buf + rel.offset;
     const uint64_t val = sec.getRelocTargetVA(ctx, rel, secAddr + rel.offset);
     relocate(loc, rel, val);
-    if (!ctx.arg.printRelaxStats.empty())
-      trackRelaxStats(ctx, rel);
   }
   if (sec.jumpInstrMod) {
     applyJumpInstrMod(buf + sec.jumpInstrMod->offset,

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -241,6 +241,7 @@ struct Config {
   llvm::StringRef optStatsFilename;
   llvm::StringRef progName;
   llvm::StringRef printArchiveStats;
+  llvm::StringRef printRelaxStats;
   llvm::StringRef printSymbolOrder;
   llvm::StringRef soName;
   llvm::StringRef sysroot;
@@ -735,6 +736,13 @@ struct Ctx : CommonLinkerContext {
   llvm::raw_fd_ostream openAuxiliaryFile(llvm::StringRef, std::error_code &);
 
   std::optional<AArch64PauthAbiCoreInfo> aarch64PauthAbiCoreInfo;
+
+  struct RelaxStatEntry {
+    std::atomic<uint64_t> total{0};
+    std::atomic<uint64_t> relaxed{0};
+  };
+  static constexpr unsigned relaxStatsMaxType = 2048;
+  std::unique_ptr<RelaxStatEntry[]> relaxStats;
 };
 
 // The first two elements of versionDefinitions represent VER_NDX_LOCAL and

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -736,13 +736,6 @@ struct Ctx : CommonLinkerContext {
   llvm::raw_fd_ostream openAuxiliaryFile(llvm::StringRef, std::error_code &);
 
   std::optional<AArch64PauthAbiCoreInfo> aarch64PauthAbiCoreInfo;
-
-  struct RelaxStatEntry {
-    std::atomic<uint64_t> total{0};
-    std::atomic<uint64_t> relaxed{0};
-  };
-  static constexpr unsigned relaxStatsMaxType = 2048;
-  std::unique_ptr<RelaxStatEntry[]> relaxStats;
 };
 
 // The first two elements of versionDefinitions represent VER_NDX_LOCAL and

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1592,8 +1592,6 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
   ctx.arg.printMemoryUsage = args.hasArg(OPT_print_memory_usage);
   ctx.arg.printArchiveStats = args.getLastArgValue(OPT_print_archive_stats);
   ctx.arg.printRelaxStats = args.getLastArgValue(OPT_print_relax_stats);
-  if (!ctx.arg.printRelaxStats.empty())
-    ctx.relaxStats.reset(new Ctx::RelaxStatEntry[Ctx::relaxStatsMaxType]());
   ctx.arg.printSymbolOrder = args.getLastArgValue(OPT_print_symbol_order);
   ctx.arg.rejectMismatch = !args.hasArg(OPT_no_warn_mismatch);
   ctx.arg.relax = args.hasFlag(OPT_relax, OPT_no_relax, true);
@@ -2496,7 +2494,7 @@ static void writeArchiveStats(Ctx &ctx) {
 }
 
 static void writeRelaxStats(Ctx &ctx) {
-  if (ctx.arg.printRelaxStats.empty() || !ctx.relaxStats)
+  if (ctx.arg.printRelaxStats.empty())
     return;
 
   std::error_code ec;
@@ -2507,17 +2505,34 @@ static void writeRelaxStats(Ctx &ctx) {
     return;
   }
 
+  // Seed with relaxable relocation types, then single-pass count.
+  llvm::DenseMap<uint32_t, std::pair<uint64_t, uint64_t>> stats;
+  if (ctx.arg.emachine == EM_X86_64)
+    for (RelType type :
+         {R_X86_64_GOTPCRELX, R_X86_64_REX_GOTPCRELX, R_X86_64_CODE_4_GOTPCRELX,
+          R_X86_64_GOTPC32_TLSDESC, R_X86_64_CODE_4_GOTPC32_TLSDESC,
+          R_X86_64_TLSGD, R_X86_64_TLSLD, R_X86_64_GOTTPOFF,
+          R_X86_64_CODE_4_GOTTPOFF, R_X86_64_CODE_6_GOTTPOFF})
+      stats[type] = {0, 0};
+
+  for (InputSectionBase *sec : ctx.inputSections)
+    if (sec && sec->isLive())
+      for (const Relocation &rel : sec->relocs())
+        if (stats.count(rel.type)) {
+          ++stats[rel.type].first;
+          if (rel.relaxed)
+            ++stats[rel.type].second;
+        }
+
   llvm::json::OStream j(os, 2);
   j.object([&] {
     j.attributeObject("relaxations", [&] {
-      for (unsigned i = 0; i < Ctx::relaxStatsMaxType; ++i) {
-        uint64_t total =
-            ctx.relaxStats[i].total.load(std::memory_order_relaxed);
+      for (auto &entry : stats) {
+        uint64_t total = entry.second.first;
         if (total == 0)
           continue;
-        uint64_t relaxed =
-            ctx.relaxStats[i].relaxed.load(std::memory_order_relaxed);
-        j.attributeObject(toStr(ctx, RelType(i)), [&] {
+        uint64_t relaxed = entry.second.second;
+        j.attributeObject(toStr(ctx, RelType(entry.first)), [&] {
           j.attribute("total", int64_t(total));
           j.attribute("relaxed", int64_t(relaxed));
           j.attribute("pct_relaxed", relaxed * 100.0 / total);

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -57,6 +57,7 @@
 #include "llvm/Support/Compression.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/GlobPattern.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/LEB128.h"
 #include "llvm/Support/Parallel.h"
 #include "llvm/Support/Path.h"
@@ -1590,6 +1591,9 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
   }
   ctx.arg.printMemoryUsage = args.hasArg(OPT_print_memory_usage);
   ctx.arg.printArchiveStats = args.getLastArgValue(OPT_print_archive_stats);
+  ctx.arg.printRelaxStats = args.getLastArgValue(OPT_print_relax_stats);
+  if (!ctx.arg.printRelaxStats.empty())
+    ctx.relaxStats.reset(new Ctx::RelaxStatEntry[Ctx::relaxStatsMaxType]());
   ctx.arg.printSymbolOrder = args.getLastArgValue(OPT_print_symbol_order);
   ctx.arg.rejectMismatch = !args.hasArg(OPT_no_warn_mismatch);
   ctx.arg.relax = args.hasFlag(OPT_relax, OPT_no_relax, true);
@@ -2489,6 +2493,39 @@ static void writeArchiveStats(Ctx &ctx) {
     // If the archive occurs multiple times, other instances have a count of 0.
     v = 0;
   }
+}
+
+static void writeRelaxStats(Ctx &ctx) {
+  if (ctx.arg.printRelaxStats.empty() || !ctx.relaxStats)
+    return;
+
+  std::error_code ec;
+  raw_fd_ostream os = ctx.openAuxiliaryFile(ctx.arg.printRelaxStats, ec);
+  if (ec) {
+    ErrAlways(ctx) << "--print-relax-stats=: cannot open "
+                   << ctx.arg.printRelaxStats << ": " << ec.message();
+    return;
+  }
+
+  llvm::json::OStream j(os, 2);
+  j.object([&] {
+    j.attributeObject("relaxations", [&] {
+      for (unsigned i = 0; i < Ctx::relaxStatsMaxType; ++i) {
+        uint64_t total =
+            ctx.relaxStats[i].total.load(std::memory_order_relaxed);
+        if (total == 0)
+          continue;
+        uint64_t relaxed =
+            ctx.relaxStats[i].relaxed.load(std::memory_order_relaxed);
+        j.attributeObject(toStr(ctx, RelType(i)), [&] {
+          j.attribute("total", int64_t(total));
+          j.attribute("relaxed", int64_t(relaxed));
+          j.attribute("pct_relaxed", relaxed * 100.0 / total);
+        });
+      }
+    });
+  });
+  os << '\n';
 }
 
 static void writeWhyExtract(Ctx &ctx) {
@@ -3605,4 +3642,6 @@ template <class ELFT> void LinkerDriver::link(opt::InputArgList &args) {
 
   // Write the result to the file.
   writeResult<ELFT>(ctx);
+
+  writeRelaxStats(ctx);
 }

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -403,6 +403,9 @@ def print_archive_stats: J<"print-archive-stats=">,
   HelpText<"Write archive usage statistics to the specified file. "
            "Print the numbers of members and extracted members for each archive">;
 
+def print_relax_stats: J<"print-relax-stats=">,
+  HelpText<"Write linker relaxation statistics to the specified file as JSON">;
+
 defm print_symbol_order: Eq<"print-symbol-order",
   "Print a symbol order specified by --call-graph-ordering-file into the specified file">;
 

--- a/lld/ELF/RelocScan.h
+++ b/lld/ELF/RelocScan.h
@@ -68,7 +68,7 @@ public:
                int64_t addend) const;
   // Process relocation after needsGot/needsPlt flags are already handled.
   void processAux(RelExpr expr, RelType type, uint64_t offset, Symbol &sym,
-                  int64_t addend) const;
+                  int64_t addend, bool relaxed = false) const;
 
   // Process R_PC relocations. These are the most common relocation type, so we
   // inline the isStaticLinkTimeConstant check.
@@ -106,7 +106,7 @@ public:
                    int64_t addend, Symbol &sym) {
     if (enableIeToLe && !ctx.arg.shared && !sym.isPreemptible) {
       // Optimize to Local Exec.
-      sec->addReloc({R_TPREL, type, offset, addend, &sym});
+      sec->addReloc({R_TPREL, type, offset, addend, &sym, /*relaxed=*/true});
     } else {
       sym.setFlags(NEEDS_TLSIE);
       // R_GOT (absolute GOT address) needs a RELATIVE dynamic relocation in
@@ -130,7 +130,7 @@ public:
       return false;
     }
     // Optimize to Local Exec.
-    sec->addReloc({R_TPREL, type, offset, addend, &sym});
+    sec->addReloc({R_TPREL, type, offset, addend, &sym, /*relaxed=*/true});
     return true;
   }
 
@@ -143,10 +143,10 @@ public:
       if (sym.isPreemptible) {
         // Optimize to Initial Exec.
         sym.setFlags(NEEDS_TLSIE);
-        sec->addReloc({ieExpr, type, offset, addend, &sym});
+        sec->addReloc({ieExpr, type, offset, addend, &sym, /*relaxed=*/true});
       } else {
         // Optimize to Local Exec.
-        sec->addReloc({leExpr, type, offset, addend, &sym});
+        sec->addReloc({leExpr, type, offset, addend, &sym, /*relaxed=*/true});
       }
       return true;
     }
@@ -166,10 +166,10 @@ public:
     } else if (sym.isPreemptible) {
       // Optimize to Initial Exec.
       sym.setFlags(NEEDS_TLSIE);
-      sec->addReloc({ieExpr, type, offset, addend, &sym});
+      sec->addReloc({ieExpr, type, offset, addend, &sym, /*relaxed=*/true});
     } else {
       // Optimize to Local Exec.
-      sec->addReloc({R_TPREL, type, offset, addend, &sym});
+      sec->addReloc({R_TPREL, type, offset, addend, &sym, /*relaxed=*/true});
     }
   }
 };

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -919,6 +919,7 @@ void RelocScan::process(RelExpr expr, RelType type, uint64_t offset,
                         Symbol &sym, int64_t addend) const {
   // If non-ifunc non-preemptible, change PLT to direct call and optimize GOT
   // indirection.
+  bool relaxed = false;
   const bool isIfunc = sym.isGnuIFunc();
   if (!sym.isPreemptible && !isIfunc) {
     if (expr != R_GOT_PC) {
@@ -926,6 +927,7 @@ void RelocScan::process(RelExpr expr, RelType type, uint64_t offset,
     } else if (!isAbsoluteOrTls(sym)) {
       expr = ctx.target->adjustGotPcExpr(type, addend,
                                          sec->content().data() + offset);
+      relaxed = expr != R_GOT_PC;
       // If the target adjusted the expression to R_RELAX_GOT_PC, we may end up
       // needing the GOT if we can't relax everything.
       if (expr == R_RELAX_GOT_PC)
@@ -964,21 +966,21 @@ void RelocScan::process(RelExpr expr, RelType type, uint64_t offset,
     sym.setFlags(HAS_DIRECT_RELOC);
   }
 
-  processAux(expr, type, offset, sym, addend);
+  processAux(expr, type, offset, sym, addend, relaxed);
 }
 
 // Process relocation after needsGot/needsPlt flags are already handled.
 // This is the bottom half of process(), handling isStaticLinkTimeConstant
 // check, dynamic relocations, copy relocations, and error reporting.
 void RelocScan::processAux(RelExpr expr, RelType type, uint64_t offset,
-                           Symbol &sym, int64_t addend) const {
+                           Symbol &sym, int64_t addend, bool relaxed) const {
   const bool isIfunc = sym.isGnuIFunc();
 
   // If the relocation is known to be a link-time constant, we know no dynamic
   // relocation will be created, pass the control to relocateAlloc() or
   // relocateNonAlloc() to resolve it.
   if (isStaticLinkTimeConstant(expr, type, sym, offset)) {
-    sec->addReloc({expr, type, offset, addend, &sym});
+    sec->addReloc({expr, type, offset, addend, &sym, relaxed});
     return;
   }
 

--- a/lld/ELF/Relocations.h
+++ b/lld/ELF/Relocations.h
@@ -135,6 +135,7 @@ struct Relocation {
   uint64_t offset;
   int64_t addend;
   Symbol *sym;
+  bool relaxed = false;
 };
 
 // Manipulate jump instructions with these modifiers.  These are used to relax

--- a/lld/test/ELF/print-relax-stats.s
+++ b/lld/test/ELF/print-relax-stats.s
@@ -1,0 +1,42 @@
+# REQUIRES: x86
+
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 a.s -o a.o
+
+## Test that --print-relax-stats produces JSON with per-type relaxation counts.
+# RUN: ld.lld a.o -o a --print-relax-stats=stats.json
+# RUN: FileCheck %s --input-file=stats.json
+
+# CHECK:      "relaxations": {
+# CHECK-NEXT:   "R_X86_64_REX_GOTPCRELX": {
+# CHECK-NEXT:     "total": 1,
+# CHECK-NEXT:     "relaxed": 1,
+# CHECK:        }
+# CHECK:      }
+
+## --no-relax disables GOT optimization. Verify total > 0 but relaxed == 0.
+# RUN: ld.lld --no-relax a.o -o a2 --print-relax-stats=stats-norelax.json
+# RUN: FileCheck %s --check-prefix=NORELAX --input-file=stats-norelax.json
+# NORELAX:      "relaxations": {
+# NORELAX-NEXT:   "R_X86_64_REX_GOTPCRELX": {
+# NORELAX-NEXT:     "total": 1,
+# NORELAX-NEXT:     "relaxed": 0,
+# NORELAX:        }
+# NORELAX:      }
+
+## - means stdout.
+# RUN: ld.lld a.o -o a3 --print-relax-stats=- | FileCheck %s
+
+## Error opening file.
+# RUN: not ld.lld a.o -o /dev/null --print-relax-stats=/ 2>&1 | FileCheck --check-prefix=ERR %s
+# ERR: error: --print-relax-stats=: cannot open /: {{.*}}
+
+#--- a.s
+.globl _start, foo
+.hidden foo
+
+_start:
+  movq foo@GOTPCREL(%rip), %rax
+
+foo:
+  ret


### PR DESCRIPTION
Add a new flag `--print-relax-stats=<file>` that writes per-relocation-type relaxation statistics to a JSON file, following the pattern of `--print-archive-stats=.`

This is motivated by ongoing work I have at Meta for the large code model (`mcmodel=large)`) where we are introducing new relaxations. Relaxation are not guaranteed since displacements may not fit in 32 bits. Knowing the relaxation success rate is critical for evaluating effectiveness or a good indicator for performance to regress for code that adopts the large codemodel.

The flag is also useful in the small code model to understand how many GOT indirections or TLS accesses remain unoptimized (e.g. due to symbol preemptibility).

Currently tracks x86_64 GOT and TLS relaxation types. The infrastructure is architecture-agnostic (array indexed by RelType, names derived from the ELF relocation enum via toStr), so other targets can add tracking by implementing their own trackRelaxStats in relocateAlloc.

Counters use std::atomic since relocateAlloc runs sections in parallel. The stats array is only allocated when the flag is specified.

Sample output:
```
  {
    "relaxations": {
      "R_X86_64_REX_GOTPCRELX": {
        "total": 2,
        "relaxed": 1,
        "pct_relaxed": 50
      },
      "R_X86_64_TLSGD": {
        "total": 1,
        "relaxed": 1,
        "pct_relaxed": 100
      }
    }
  }
```