### PR TITLE
[lldb] Speculative fix for crash in Function::GetCallEdges()

### DIFF
--- a/lldb/include/lldb/Symbol/Function.h
+++ b/lldb/include/lldb/Symbol/Function.h
@@ -342,19 +342,11 @@ public:
   Function *GetCallee(ModuleList &images, ExecutionContext &exe_ctx) override;
 
 private:
-  void ParseSymbolFileAndResolve(ModuleList &images);
+  Function *ResolveCallee(ModuleList &images);
 
-  // Used to describe a direct call.
-  //
-  // Either the callee's mangled name or its definition, discriminated by
-  // \ref resolved.
-  union {
-    const char *symbol_name;
-    Function *def;
-  } lazy_callee;
-
-  /// Whether or not an attempt was made to find the callee's definition.
-  bool resolved = false;
+  const char *m_symbol_name;
+  std::once_flag m_resolved_flag;
+  Function *m_callee_def = nullptr;
 };
 
 /// An indirect call site. Used to represent call sites where the address of

--- a/lldb/source/Symbol/Function.cpp
+++ b/lldb/source/Symbol/Function.cpp
@@ -158,39 +158,37 @@ lldb::addr_t CallEdge::GetReturnPCAddress(Function &caller,
   return GetLoadAddress(GetUnresolvedReturnPCAddress(), caller, target);
 }
 
-void DirectCallEdge::ParseSymbolFileAndResolve(ModuleList &images) {
-  if (resolved)
-    return;
+Function *DirectCallEdge::ResolveCallee(ModuleList &images) {
+  if (!m_symbol_name)
+    return nullptr;
 
   Log *log = GetLog(LLDBLog::Step);
   LLDB_LOG(log, "DirectCallEdge: Lazily parsing the call graph for {0}",
-           lazy_callee.symbol_name);
+           m_symbol_name);
 
-  auto resolve_lazy_callee = [&]() -> Function * {
-    ConstString callee_name{lazy_callee.symbol_name};
-    SymbolContextList sc_list;
-    images.FindFunctionSymbols(callee_name, eFunctionNameTypeAuto, sc_list);
-    size_t num_matches = sc_list.GetSize();
-    if (num_matches == 0 || !sc_list[0].symbol) {
-      LLDB_LOG(log,
-               "DirectCallEdge: Found no symbols for {0}, cannot resolve it",
-               callee_name);
-      return nullptr;
-    }
-    Address callee_addr = sc_list[0].symbol->GetAddress();
-    if (!callee_addr.IsValid()) {
-      LLDB_LOG(log, "DirectCallEdge: Invalid symbol address");
-      return nullptr;
-    }
-    Function *f = callee_addr.CalculateSymbolContextFunction();
-    if (!f) {
-      LLDB_LOG(log, "DirectCallEdge: Could not find complete function");
-      return nullptr;
-    }
-    return f;
-  };
-  lazy_callee.def = resolve_lazy_callee();
-  resolved = true;
+  SymbolContextList sc_list;
+  images.FindFunctionSymbols(ConstString(m_symbol_name), eFunctionNameTypeAuto,
+                             sc_list);
+  size_t num_matches = sc_list.GetSize();
+  if (num_matches == 0 || !sc_list[0].symbol) {
+    LLDB_LOG(log, "DirectCallEdge: Found no symbols for {0}, cannot resolve it",
+             m_symbol_name);
+    return nullptr;
+  }
+
+  Address callee_addr = sc_list[0].symbol->GetAddress();
+  if (!callee_addr.IsValid()) {
+    LLDB_LOG(log, "DirectCallEdge: Invalid symbol address");
+    return nullptr;
+  }
+
+  Function *f = callee_addr.CalculateSymbolContextFunction();
+  if (!f) {
+    LLDB_LOG(log, "DirectCallEdge: Could not find complete function");
+    return nullptr;
+  }
+
+  return f;
 }
 
 DirectCallEdge::DirectCallEdge(const char *symbol_name,
@@ -198,14 +196,13 @@ DirectCallEdge::DirectCallEdge(const char *symbol_name,
                                lldb::addr_t caller_address, bool is_tail_call,
                                CallSiteParameterArray &&parameters)
     : CallEdge(caller_address_type, caller_address, is_tail_call,
-               std::move(parameters)) {
-  lazy_callee.symbol_name = symbol_name;
-}
+               std::move(parameters)),
+      m_symbol_name(symbol_name) {}
 
 Function *DirectCallEdge::GetCallee(ModuleList &images, ExecutionContext &) {
-  ParseSymbolFileAndResolve(images);
-  assert(resolved && "Did not resolve lazy callee");
-  return lazy_callee.def;
+  std::call_once(m_resolved_flag,
+                 [&] { m_callee_def = ResolveCallee(images); });
+  return m_callee_def;
 }
 
 IndirectCallEdge::IndirectCallEdge(DWARFExpressionList call_target,


### PR DESCRIPTION
Replace the unprotected union+bool lazy resolution in DirectCallEdge with `std::call_once`/`std::once_flag`.

Multiple threads can call `GetCallee` on the same edge concurrently and the old code had no synchronization on the union discriminator or its contents. This could lead to a corrupted pointer that would explain the crash we're observing sporadically.

rdar://175006028