### PR TITLE
[HLSL][NFC] Refactor worklist loop in HLSLEmitter.cpp to use index-based iteration

### DIFF
--- a/clang/utils/TableGen/HLSLEmitter.cpp
+++ b/clang/utils/TableGen/HLSLEmitter.cpp
@@ -461,7 +461,8 @@ static void emitWorklistOverloads(raw_ostream &OS, const OverloadContext &Ctx,
                                   ArrayRef<int64_t> VectorSizes,
                                   ArrayRef<const Record *> MatrixDimensions) {
   bool InIfdef = false;
-  for (const TypeWorkItem &Item : Worklist) {
+  for (size_t I = 0, E = Worklist.size(); I != E; ++I) {
+    const TypeWorkItem &Item = Worklist[I];
     if (Item.NeedsIfdefGuard && !InIfdef) {
       OS << "#ifdef __HLSL_ENABLE_16_BIT\n";
       InIfdef = true;
@@ -487,8 +488,7 @@ static void emitWorklistOverloads(raw_ostream &OS, const OverloadContext &Ctx,
     }
 
     if (InIfdef) {
-      bool NextIsUnguarded =
-          (&Item == &Worklist.back()) || !(&Item + 1)->NeedsIfdefGuard;
+      bool NextIsUnguarded = (I + 1 == E) || !Worklist[I + 1].NeedsIfdefGuard;
       if (NextIsUnguarded) {
         OS << "#endif\n";
         InIfdef = false;


### PR DESCRIPTION
As suggested by @shafik, the worklist loop in HLSLEmitter.cpp would be more readable as an index-based for-loop as opposed to a range-based for-loop. This PR changes the range-based for-loop over worklist items into an index-based for-loop.