### PR TITLE
[NFC][Clang][Analyses] Fix AccessPath to have deleted copy assignment

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
@@ -68,6 +68,7 @@ public:
     return AccessPath(Kind::PlaceholderThis, MD);
   }
   AccessPath(const AccessPath &Other) : K(Other.K), Root(Other.Root) {}
+  AccessPath &operator=(const AccessPath &) = delete;
 
   Kind getKind() const { return K; }
 


### PR DESCRIPTION
Static analysis flagged AccessPath because it had a copy constructor but did not declare a copy assignment. It appears the intent is not to allow assignment, so declare it deleted.