### PR TITLE
[OpenMP] Fix use of uninitialized Dl_info when dladdr fails in ompd_init

### DIFF
--- a/openmp/runtime/src/ompd-specific.cpp
+++ b/openmp/runtime/src/ompd-specific.cpp
@@ -89,8 +89,7 @@ void ompd_init() {
   if (!ret) {
     fprintf(stderr, "%s\n", dlerror());
   } else if (strrchr(dl_info.dli_fname, '/')) {
-    int lib_path_length =
-        strrchr(dl_info.dli_fname, '/') - dl_info.dli_fname;
+    int lib_path_length = strrchr(dl_info.dli_fname, '/') - dl_info.dli_fname;
     libname =
         (char *)malloc(lib_path_length + 12 /*for '/libompd.so' and '\0'*/);
     strncpy(libname, dl_info.dli_fname, lib_path_length);

--- a/openmp/runtime/src/ompd-specific.cpp
+++ b/openmp/runtime/src/ompd-specific.cpp
@@ -88,10 +88,9 @@ void ompd_init() {
   int ret = dladdr((void *)ompd_init, &dl_info);
   if (!ret) {
     fprintf(stderr, "%s\n", dlerror());
-  }
-  int lib_path_length;
-  if (strrchr(dl_info.dli_fname, '/')) {
-    lib_path_length = strrchr(dl_info.dli_fname, '/') - dl_info.dli_fname;
+  } else if (strrchr(dl_info.dli_fname, '/')) {
+    int lib_path_length =
+        strrchr(dl_info.dli_fname, '/') - dl_info.dli_fname;
     libname =
         (char *)malloc(lib_path_length + 12 /*for '/libompd.so' and '\0'*/);
     strncpy(libname, dl_info.dli_fname, lib_path_length);


### PR DESCRIPTION
When dladdr() fails, dl_info is left uninitialized. The code printed the error but then fell through to unconditionally call strrchr(dl_info.dli_fname, '/'), accessing an uninitialized pointer -- typically NULL on the stack -- causing a SIGSEGV.

Fix by turning the second 'if' into 'else if', so the path-extraction block is only reached when dladdr() succeeded and dl_info is valid.

Assisted-by: Claude Sonnet 4.6