### PR TITLE
[compiler-rt] Inline __NR_riscv_flush_icache instead of including linux/unistd.h

### DIFF
--- a/compiler-rt/lib/builtins/clear_cache.c
+++ b/compiler-rt/lib/builtins/clear_cache.c
@@ -48,11 +48,6 @@ uintptr_t GetCurrentProcess(void);
 #include <unistd.h>
 #endif
 
-#if defined(__linux__) && defined(__riscv)
-// to get platform-specific syscall definitions
-#include <linux/unistd.h>
-#endif
-
 // The compiler generates calls to __clear_cache() when creating
 // trampoline functions on the stack for use with nested functions.
 // It is expected to invalidate the instruction cache for the
@@ -185,6 +180,10 @@ void __clear_cache(void *start, void *end) {
   for (uintptr_t dword = start_dword; dword < end_dword; dword += dword_size)
     __asm__ volatile("flush %0" : : "r"(dword));
 #elif defined(__riscv) && defined(__linux__)
+  // Inlined for the same reason as __ARM_NR_cacheflush above.
+#ifndef __NR_riscv_flush_icache
+#define __NR_riscv_flush_icache 259
+#endif
   // See: arch/riscv/include/asm/cacheflush.h, arch/riscv/kernel/sys_riscv.c
   register void *start_reg __asm("a0") = start;
   const register void *end_reg __asm("a1") = end;


### PR DESCRIPTION
Avoid the dependency on kernel headers to get __NR_riscv_flush_icache, mirroring the existing approach used for __ARM_NR_cacheflush.

Assisted-by: Claude Sonnet 4.6