### PR TITLE
[libclc] Allow testing unresolved symbols on multiple libraries

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -265,6 +265,8 @@ add_libclc_library(libclc-${LIBCLC_TARGET}
   PARENT_TARGET libclc-opencl-builtins
 )
 
+set(LIBCLC_UNRESOLVED_SYMBOL_TEST_TARGETS libclc-${LIBCLC_TARGET})
+
 if(LLVM_INCLUDE_TESTS)
   add_subdirectory(test)
 endif()

--- a/libclc/test/CMakeLists.txt
+++ b/libclc/test/CMakeLists.txt
@@ -9,27 +9,28 @@ umbrella_lit_testsuite_begin(check-libclc)
 # Testing unresolved symbols.
 # Skip nvptx, clspv, spirv targets
 if(ARCH MATCHES amdgcn)
-  # Get the output file from the target property
-  set(target_file "$<TARGET_PROPERTY:libclc-${LIBCLC_TARGET},TARGET_FILE>")
+  foreach(tgt IN LISTS LIBCLC_UNRESOLVED_SYMBOL_TEST_TARGETS)
+    set(target_file "$<TARGET_PROPERTY:${tgt},TARGET_FILE>")
 
-  set(LIBCLC_TARGET_TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/${LIBCLC_TARGET})
-  file(MAKE_DIRECTORY ${LIBCLC_TARGET_TEST_DIR})
-  file(GENERATE OUTPUT ${LIBCLC_TARGET_TEST_DIR}/check-external-funcs.test
-    CONTENT "; RUN: llvm-nm -u \"${target_file}\" | FileCheck %s --allow-empty\n\n; CHECK-NOT: {{.+}}\n"
-  )
+    set(LIBCLC_TARGET_TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/${tgt})
+    file(MAKE_DIRECTORY ${LIBCLC_TARGET_TEST_DIR})
+    file(GENERATE OUTPUT ${LIBCLC_TARGET_TEST_DIR}/check-external-funcs.test
+      CONTENT "; RUN: llvm-nm -u \"${target_file}\" | FileCheck %s --allow-empty\n\n; CHECK-NOT: {{.+}}\n"
+    )
 
-  configure_lit_site_cfg(
-      ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
-      ${LIBCLC_TARGET_TEST_DIR}/lit.site.cfg.py
-      MAIN_CONFIG
-      ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
-  )
+    configure_lit_site_cfg(
+        ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+        ${LIBCLC_TARGET_TEST_DIR}/lit.site.cfg.py
+        MAIN_CONFIG
+        ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+    )
 
-  add_lit_testsuite(check-libclc-external-funcs-${LIBCLC_TARGET} "Running ${LIBCLC_TARGET} tests"
-    ${LIBCLC_TARGET_TEST_DIR}
-    DEPENDS ${LIBCLC_TEST_DEPS}
-  )
-  set_target_properties(check-libclc-external-funcs-${LIBCLC_TARGET} PROPERTIES FOLDER "libclc tests")
+    add_lit_testsuite(check-libclc-external-funcs-${tgt} "Running ${tgt} unresolved symbols tests"
+      ${LIBCLC_TARGET_TEST_DIR}
+      DEPENDS ${LIBCLC_TEST_DEPS}
+    )
+    set_target_properties(check-libclc-external-funcs-${tgt} PROPERTIES FOLDER "libclc tests")
+  endforeach()
 endif()
 
 umbrella_lit_testsuite_end(check-libclc)


### PR DESCRIPTION
Our downstream generates multiple libraries for a single target. This change allows testing multiple libraries.