### PR TITLE
[docs] alias attribute doc

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -869,7 +869,7 @@ def Alias : Attr {
   let Spellings = [GCC<"alias">];
   let Args = [StringArgument<"Aliasee">];
   let Subjects = SubjectList<[Function, GlobalVar], ErrorDiag>;
-  let Documentation = [Undocumented];
+  let Documentation = [AliasDocs];
 }
 
 def BuiltinAlias : Attr {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -9985,7 +9985,7 @@ exceptions according to their own rules.
 }
 
 def AliasDocs : Documentation {
-  let Category = DocCatFunction;
+  let Category = DocCatDecl;
   let Content = [{
 The ``alias`` attribute causes the declaration to be emitted as an alias to
 another symbol, which must be defined in the same translation unit.
@@ -10014,6 +10014,7 @@ signature. For variables, while Clang allows aliasing ABI-compatible types
 target must have the same size and alignment to avoid undefined behavior.
 
 This attribute requires support from the target's assembler and object file 
-format. Notably, it is not supported on Apple (Darwin) platforms.
+format. Notably, it is not supported on Apple (Darwin) platforms or in 
+CUDA versions prior to 10.0.
   }];
 }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -9983,3 +9983,26 @@ different languages to coexist on the same call stack while each interpreting
 exceptions according to their own rules.
   }];
 }
+
+def AliasDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``alias`` attribute causes the declaration to be emitted as an alias to
+another symbol, which must be defined in the same translation unit.
+
+The attribute can be applied to both functions and global variables. 
+
+.. code-block:: c
+
+  void __impl(void) { /* ... */ }
+  void foo(void) __attribute__((alias("__impl")));
+
+In this example, ``foo`` becomes an alias for ``__impl``. 
+
+Note that the aliasee is specified as a string representing the name of the 
+symbol as it appears in the object file. If the symbols are subject to 
+name mangling (as in C++), the aliasee string must match the mangled name. 
+If the aliasee is not found, Clang will emit a diagnostic suggesting the 
+correct mangled name to use.
+  }];
+}

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -9990,7 +9990,8 @@ def AliasDocs : Documentation {
 The ``alias`` attribute causes the declaration to be emitted as an alias to
 another symbol, which must be defined in the same translation unit.
 
-The attribute can be applied to both functions and global variables. 
+The attribute can be applied to both functions and global variables. The 
+attribute must be placed on a declaration, as opposed to a definition.
 
 .. code-block:: c
 
@@ -10004,5 +10005,15 @@ symbol as it appears in the object file. If the symbols are subject to
 name mangling (as in C++), the aliasee string must match the mangled name. 
 If the aliasee is not found, Clang will emit a diagnostic suggesting the 
 correct mangled name to use.
+
+Clang enforces compatibility between the alias and its target: it emits an 
+error if a function alias points to a variable (or vice versa), and issues 
+a warning if a function alias points to a function with a different 
+signature. For variables, while Clang allows aliasing ABI-compatible types 
+(such as an ``enum`` and its underlying integer type), the alias and the 
+target must have the same size and alignment to avoid undefined behavior.
+
+This attribute requires support from the target's assembler and object file 
+format. Notably, it is not supported on Apple (Darwin) platforms.
   }];
 }


### PR DESCRIPTION
 Resolves #44232

This PR adds the documentation for __attribute((alias("aliasee")))