### PR TITLE
[lldb/test] Update remaining `filecheck` call sites to use `filecheck_log` (NFC)

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
@@ -37,5 +37,5 @@ class TestCase(TestBase):
         account = frame.var("acc")
         self.assertEqual(account.num_children, 1)
 
-        self.filecheck(f"platform shell cat {log}", __file__)
+        self.filecheck_log(log, __file__)
         # CHECK: Bytecode formatter can reuse @update: true (type: `Account`, name: `acc`)

--- a/lldb/test/API/lang/objc/module-import-log/TestClangModuleImportLog.py
+++ b/lldb/test/API/lang/objc/module-import-log/TestClangModuleImportLog.py
@@ -15,5 +15,5 @@ class TestCase(TestBase):
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))
 
         self.runCmd("expression -lobjc -- @import Foundation")
-        self.filecheck(f"platform shell cat {log}", __file__)
+        self.filecheck_log(log, __file__)
         # CHECK: Importing Clang module Foundation from {{.+}}/Foundation-{{[^/]+}}.pcm


### PR DESCRIPTION
A few tests were still using `self.filecheck` with `platform shell cat {log}` to validate test behavior through log inspection which doesn't work when running the testsuite against a remote platform since the logs are saved on the host's filesystem.

This patch updates the remaining call sites to use the `filecheck_log` helper, which ensures the log file is always read from the host platform.

rdar://175393166