### PR TITLE
[lldb/test] Relax NSBundle formatter test for Darwin embedded platforms

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSBundle.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSBundle.py
@@ -31,7 +31,7 @@ class ObjCDataFormatterNSBundle(ObjCDataFormatterTestCase):
                 "(NSBundle *) bundle_string = ",
                 ' @"/System/Library/Frameworks/Accelerate.framework"',
                 "(NSBundle *) bundle_url = ",
-                ' @"/System/Library/Frameworks/Foundation.framework"',
+                ' "/System/Library/Frameworks/Foundation.framework"',
                 "(NSBundle *) main_bundle = ",
                 "data-formatter-objc",
             ],


### PR DESCRIPTION
Some Foundation APIs have been migrated from Objective-C to Swift while maintaining backward compatibility. For instance, that can cause `NSBundle` created via `initWithURL:` to format without the `@"..."` prefix.

Match the path string without requiring the @ prefix so the test passes with both the ObjC and Swift implementations

rdar://175394563