### PR TITLE
[llvm][test] Fix more test failures when LLVM_WINDOWS_PREFER_FORWARD_…

### DIFF
--- a/llvm/test/tools/llvm-cov/directory_coverage.win.test
+++ b/llvm/test/tools/llvm-cov/directory_coverage.win.test
@@ -11,25 +11,26 @@
 # RUN:   --path-equivalence=/tmp/directory_coverage,%S/Inputs/directory_coverage \
 # RUN:   --format=html --show-directory-coverage -o %t/report-html
 
-# RUN: FileCheck --input-file %t/report-text/index.txt %s --check-prefix=ROOT
-# RUN: FileCheck --input-file %t/report-text/coverage/tmp/directory_coverage/index.txt %s --check-prefix=ROOT
-# RUN: FileCheck --input-file %t/report-text/coverage/tmp/directory_coverage/b0/index.txt %s --check-prefix=B0
-# RUN: FileCheck --input-file %t/report-text/coverage/tmp/directory_coverage/c0/c1/index.txt %s --check-prefix=C1
+# Forward or backward slashes can be used depending on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+# RUN: FileCheck --input-file %t/report-text/index.txt %s --check-prefix=ROOT -DSEP=%{fs-sep}
+# RUN: FileCheck --input-file %t/report-text/coverage/tmp/directory_coverage/index.txt %s --check-prefix=ROOT -DSEP=%{fs-sep}
+# RUN: FileCheck --input-file %t/report-text/coverage/tmp/directory_coverage/b0/index.txt %s --check-prefix=B0 -DSEP=%{fs-sep}
+# RUN: FileCheck --input-file %t/report-text/coverage/tmp/directory_coverage/c0/c1/index.txt %s --check-prefix=C1 -DSEP=%{fs-sep}
 
-# RUN: FileCheck --input-file %t/report-html/index.html %s --check-prefix=HTML-TOP --allow-empty
-# RUN: FileCheck --input-file %t/report-html/coverage/tmp/directory_coverage/index.html %s --check-prefix=ROOT
-# RUN: FileCheck --input-file %t/report-html/coverage/tmp/directory_coverage/b0/index.html %s --check-prefix=B0
-# RUN: FileCheck --input-file %t/report-html/coverage/tmp/directory_coverage/c0/c1/index.html %s --check-prefix=C1
+# RUN: FileCheck --input-file %t/report-html/index.html %s --check-prefix=HTML-TOP --allow-empty -DSEP=%{fs-sep}
+# RUN: FileCheck --input-file %t/report-html/coverage/tmp/directory_coverage/index.html %s --check-prefix=ROOT -DSEP=%{fs-sep}
+# RUN: FileCheck --input-file %t/report-html/coverage/tmp/directory_coverage/b0/index.html %s --check-prefix=B0 -DSEP=%{fs-sep}
+# RUN: FileCheck --input-file %t/report-html/coverage/tmp/directory_coverage/c0/c1/index.html %s --check-prefix=C1 -DSEP=%{fs-sep}
 
 
 
-# HTML-TOP: coverage\index.html
+# HTML-TOP: coverage[[SEP]]index.html
 
-# ROOT: a0\a1\a2.cc
-# ROOT: b0\
+# ROOT: a0[[SEP]]a1[[SEP]]a2.cc
+# ROOT: b0[[SEP]]
 # ROOT-NOT: b1_1.cc
 # ROOT-NOT: b1_2.cc
-# ROOT: c0\c1\
+# ROOT: c0[[SEP]]c1[[SEP]]
 # ROOT-NOT: c2_1.cc
 # ROOT-NOT: b2_2.cc
 # ROOT: main.cc

--- a/llvm/test/tools/llvm-cov/native_separators.c
+++ b/llvm/test/tools/llvm-cov/native_separators.c
@@ -7,14 +7,15 @@
 
 // RUN: llvm-profdata merge %S/Inputs/double_dots.proftext -o %t.profdata
 // RUN: llvm-cov show %S/Inputs/native_separators.covmapping -instr-profile=%t.profdata -o %t.dir
-// RUN: FileCheck -check-prefixes=TEXT-INDEX -input-file=%t.dir/index.txt %s
+// Forward or backward slashes can be used depending on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+// RUN: FileCheck -check-prefixes=TEXT-INDEX -input-file=%t.dir/index.txt %s -DSEP=%{fs-sep}
 // RUN: llvm-cov show -format=html %S/Inputs/native_separators.covmapping -instr-profile=%t.profdata -path-equivalence=/tmp,%S %S/../llvm-"config"/../llvm-"cov"/native_separators.c -o %t.dir
-// RUN: FileCheck -check-prefixes=HTML-INDEX -input-file=%t.dir/index.html %s
+// RUN: FileCheck -check-prefixes=HTML-INDEX -input-file=%t.dir/index.html %s -DSEP=%{fs-sep}
 // RUN: llvm-cov show -format=html %S/Inputs/native_separators.covmapping -instr-profile=%t.profdata -path-equivalence=/tmp,%S %s -o %t.dir
-// RUN: FileCheck -check-prefixes=HTML -input-file=%t.dir/coverage/tmp/native_separators.c.html %s
+// RUN: FileCheck -check-prefixes=HTML -input-file=%t.dir/coverage/tmp/native_separators.c.html %s -DSEP=%{fs-sep}
 
-// TEXT-INDEX: \tmp\native_separators.c
-// HTML-INDEX: >tmp\native_separators.c</a>
-// HTML: <pre>\tmp\native_separators.c</pre>
+// TEXT-INDEX: [[SEP]]tmp[[SEP]]native_separators.c
+// HTML-INDEX: >tmp[[SEP]]native_separators.c</a>
+// HTML: <pre>[[SEP]]tmp[[SEP]]native_separators.c</pre>
 
 int main() {}

--- a/llvm/test/tools/llvm-objdump/X86/source-interleave-prefix-windows.test
+++ b/llvm/test/tools/llvm-objdump/X86/source-interleave-prefix-windows.test
@@ -6,6 +6,7 @@
 
 ; RUN: sed -e "s,SRC_COMPDIR,/Inputs,g" %p/Inputs/source-interleave.ll > %t.ll
 ; RUN: llc -o %t.o -filetype=obj -mtriple=x86_64-pc-linux %t.ll
-; RUN: llvm-objdump --prefix 'myprefix/\' --source %t.o 2>&1 | FileCheck %s -DFILE=%t.o -DPREFIX='myprefix'
-; CHECK: warning: '[[FILE]]': failed to find source [[PREFIX]]/Inputs\source-interleave-x86_64.c
+; Forward or backward slashes can be used depending on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+; RUN: llvm-objdump --prefix 'myprefix/\' --source %t.o 2>&1 | FileCheck %s -DFILE=%t.o -DPREFIX='myprefix' -DSEP=%{fs-sep}
+; CHECK: warning: '[[FILE]]': failed to find source [[PREFIX]][[SEP]]Inputs[[SEP]]source-interleave-x86_64.c
 

--- a/llvm/unittests/Support/CommandLineTest.cpp
+++ b/llvm/unittests/Support/CommandLineTest.cpp
@@ -25,6 +25,7 @@
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include <algorithm>
 #include <fstream>
 #include <stdlib.h>
 #include <string>
@@ -1072,7 +1073,14 @@ TEST(CommandLineTest, RecursiveResponseFiles) {
   ASSERT_FALSE((bool)EC);
   std::string ExpectedMessage =
       std::string("recursive expansion of: '") + std::string(FilePath) + "'";
-  ASSERT_TRUE(toString(std::move(Err)) == ExpectedMessage);
+  // Normalize path separators to '/' to ensure robust comparison on Windows,
+  // as the actual separator depends on LLVM_WINDOWS_PREFER_FORWARD_SLASH.
+  std::string ActualMessage = toString(std::move(Err));
+  std::replace(ActualMessage.begin(), ActualMessage.end(), '\\', '/');
+  std::string NormalizedExpectedMessage = ExpectedMessage;
+  std::replace(NormalizedExpectedMessage.begin(),
+               NormalizedExpectedMessage.end(), '\\', '/');
+  ASSERT_EQ(ActualMessage, NormalizedExpectedMessage);
 
   EXPECT_THAT(Argv,
               testing::Pointwise(StringEquality(),

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -2825,7 +2825,20 @@ TEST_F(FileSystemTest, makeLongFormPath) {
   ASSERT_FALSE(DotAndDotDot.empty())
       << "Expected short 8.3 form path for test directory.";
   auto ContainsDotAndDotDot = [](llvm::StringRef S) {
-    return S.contains("\\.\\") && S.contains("\\..\\");
+    // Both forward and backward slashes can be used as separators on Windows.
+    // The preferred separator depends on LLVM_WINDOWS_PREFER_FORWARD_SLASH,
+    // but some Windows APIs (like GetShortPathName) might still return
+    // backslashes.
+    auto has = [&](llvm::StringRef Comp) {
+      for (char Sep1 : {'/', '\\'})
+        for (char Sep2 : {'/', '\\'}) {
+          std::string Pattern = (std::string(1, Sep1) + Comp.str() + Sep2);
+          if (S.contains(Pattern))
+            return true;
+        }
+      return false;
+    };
+    return has(".") && has("..");
   };
   ASSERT_TRUE(ContainsDotAndDotDot(DotAndDotDot))
       << "Expected '.' and '..' components in: " << DotAndDotDot;


### PR DESCRIPTION
…SLASH is ON

This commit addresses several test failures in LLVM that occur on Windows when
the CMake option -DLLVM_WINDOWS_PREFER_FORWARD_SLASH=ON is enabled.

Key changes:
- llvm/unittests:
  - Updated Path tests to handle mixed separators on Windows (as some Windows
    APIs may still return backslashes even when forward slashes are preferred).
  - Normalized path separators in CommandLine error message comparisons.
- llvm/test:
  - Updated FileCheck patterns in llvm-cov and llvm-objdump to use a [[SEP]]
    variable (defined via -DSEP=%{fs-sep}) for precise native path separator
    matching across both build modes.
