### PR TITLE
[DAGCombine] Relax restriction on (bswap shl(x,c)) combine

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -12102,7 +12102,7 @@ SDValue DAGCombiner::visitBSWAP(SDNode *N) {
     EVT HalfVT = EVT::getIntegerVT(*DAG.getContext(), BW / 2);
     if (ShAmt && ShAmt->getAPIntValue().ult(BW) &&
         ShAmt->getZExtValue() >= (BW / 2) &&
-        (ShAmt->getZExtValue() % 16) == 0 && TLI.isTypeLegal(HalfVT) &&
+        (ShAmt->getZExtValue() % 8) == 0 && TLI.isTypeLegal(HalfVT) &&
         TLI.isTruncateFree(VT, HalfVT) &&
         (!LegalOperations || hasOperation(ISD::BSWAP, HalfVT))) {
       SDValue Res = N0.getOperand(0);

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -12101,9 +12101,8 @@ SDValue DAGCombiner::visitBSWAP(SDNode *N) {
     auto *ShAmt = dyn_cast<ConstantSDNode>(N0.getOperand(1));
     EVT HalfVT = EVT::getIntegerVT(*DAG.getContext(), BW / 2);
     if (ShAmt && ShAmt->getAPIntValue().ult(BW) &&
-        ShAmt->getZExtValue() >= (BW / 2) &&
-        (ShAmt->getZExtValue() % 8) == 0 && TLI.isTypeLegal(HalfVT) &&
-        TLI.isTruncateFree(VT, HalfVT) &&
+        ShAmt->getZExtValue() >= (BW / 2) && (ShAmt->getZExtValue() % 8) == 0 &&
+        TLI.isTypeLegal(HalfVT) && TLI.isTruncateFree(VT, HalfVT) &&
         (!LegalOperations || hasOperation(ISD::BSWAP, HalfVT))) {
       SDValue Res = N0.getOperand(0);
       if (uint64_t NewShAmt = (ShAmt->getZExtValue() - (BW / 2)))

--- a/llvm/test/CodeGen/X86/combine-bswap.ll
+++ b/llvm/test/CodeGen/X86/combine-bswap.ll
@@ -236,6 +236,26 @@ define i64 @test_bswap64_shift48(i64 %a0) {
   ret i64 %b
 }
 
+define i64 @test_bswap64_shift40(i64 %a0) {
+; X86-LABEL: test_bswap64_shift40:
+; X86:       # %bb.0:
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    bswapl %eax
+; X86-NEXT:    shrl $8, %eax
+; X86-NEXT:    xorl %edx, %edx
+; X86-NEXT:    retl
+;
+; X64-LABEL: test_bswap64_shift40:
+; X64:       # %bb.0:
+; X64-NEXT:    movq %rdi, %rax
+; X64-NEXT:    bswapq %rax
+; X64-NEXT:    shrq $40, %rax
+; X64-NEXT:    retq
+  %s = shl i64 %a0, 40
+  %b = call i64 @llvm.bswap.i64(i64 %s)
+  ret i64 %b
+}
+
 define i32 @test_bswap32_shift17(i32 %a0) {
 ; X86-LABEL: test_bswap32_shift17:
 ; X86:       # %bb.0:

--- a/llvm/test/CodeGen/X86/combine-bswap.ll
+++ b/llvm/test/CodeGen/X86/combine-bswap.ll
@@ -248,8 +248,8 @@ define i64 @test_bswap64_shift40(i64 %a0) {
 ; X64-LABEL: test_bswap64_shift40:
 ; X64:       # %bb.0:
 ; X64-NEXT:    movq %rdi, %rax
-; X64-NEXT:    bswapq %rax
-; X64-NEXT:    shrq $40, %rax
+; X64-NEXT:    bswapl %eax
+; X64-NEXT:    shrl $8, %eax
 ; X64-NEXT:    retq
   %s = shl i64 %a0, 40
   %b = call i64 @llvm.bswap.i64(i64 %s)


### PR DESCRIPTION
We can still do the
(bswap shl(x,c)) -> (zext(bswap(trunc(shl(x,sub(c,bw/2))))))
combine if the shift amount is a multiple of 8 not just 16.

https://alive2.llvm.org/ce/z/crnSB6