### PR TITLE
Add missed variable change from a refactor

### DIFF
--- a/libc/utils/libctest/format.py
+++ b/libc/utils/libctest/format.py
@@ -194,7 +194,7 @@ class LibcTest(lit.formats.ExecutableTest):
             )
         else:
             out, err, exit_code = lit.util.executeCommand(
-                [test_path] + extra_args, cwd=exec_dir, env=env
+                [test_path] + test_args, cwd=exec_dir, env=env
             )
 
         if not exit_code:


### PR DESCRIPTION
extra_args got renamed to test_args.