### PR TITLE
[Clang][OpenMP] Validate omp_initial_device omp_invalid_device as device IDs

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12111,6 +12111,9 @@ def note_omp_collapse_ordered_expr : Note<
   "as specified in %select{'collapse'|'ordered'|'collapse' and 'ordered'}0 clause%select{||s}0">;
 def err_omp_negative_expression_in_clause : Error<
   "argument to '%0' clause must be a %select{non-negative|strictly positive}1 integer value">;
+def err_omp_device_expression_invalid : Error<
+  "argument to 'device' clause must be a non-negative integer value, "
+  "'omp_initial_device' (-1), or 'omp_invalid_device' (-2)">;
 def err_omp_large_expression_in_clause : Error<
   "argument to '%0' clause requires a value that can be represented by a 64-bit">;
 def err_omp_not_integral : Error<

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -22318,11 +22318,27 @@ OMPClause *SemaOpenMP::ActOnOpenMPDeviceClause(
   Expr *ValExpr = Device;
   Stmt *HelperValStmt = nullptr;
 
-  // OpenMP [2.9.1, Restrictions]
-  // The device expression must evaluate to a non-negative integer value.
-  ErrorFound = !isNonNegativeIntegerValue(ValExpr, SemaRef, OMPC_device,
-                                          /*StrictlyPositive=*/false) ||
-               ErrorFound;
+  // OpenMP 5.2 [1.3, Execution Model]: a conforming device number is either
+  // a non-negative integer that is less than or equal to omp_get_num_devices()
+  // or equal to omp_initial_device or omp_invalid_device.
+  if (!ValExpr->isTypeDependent() && !ValExpr->isValueDependent() &&
+      !ValExpr->isInstantiationDependent()) {
+    SourceLocation Loc = ValExpr->getExprLoc();
+    ExprResult Value = PerformOpenMPImplicitIntegerConversion(Loc, ValExpr);
+    if (Value.isInvalid()) {
+      ErrorFound = true;
+    } else {
+      ValExpr = Value.get();
+      if (std::optional<llvm::APSInt> Result =
+              ValExpr->getIntegerConstantExpr(getASTContext())) {
+        if (Result->isSigned() && Result->slt(-2)) {
+          Diag(Loc, diag::err_omp_device_expression_invalid)
+              << ValExpr->getSourceRange();
+          ErrorFound = true;
+        }
+      }
+    }
+  }
   if (ErrorFound)
     return nullptr;
 

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -22320,24 +22320,32 @@ OMPClause *SemaOpenMP::ActOnOpenMPDeviceClause(
 
   // OpenMP 5.2 [1.3, Execution Model]: a conforming device number is either
   // a non-negative integer that is less than or equal to omp_get_num_devices()
-  // or equal to omp_initial_device or omp_invalid_device.
-  if (!ValExpr->isTypeDependent() && !ValExpr->isValueDependent() &&
-      !ValExpr->isInstantiationDependent()) {
-    SourceLocation Loc = ValExpr->getExprLoc();
-    ExprResult Value = PerformOpenMPImplicitIntegerConversion(Loc, ValExpr);
-    if (Value.isInvalid()) {
-      ErrorFound = true;
-    } else {
-      ValExpr = Value.get();
-      if (std::optional<llvm::APSInt> Result =
-              ValExpr->getIntegerConstantExpr(getASTContext())) {
-        if (Result->isSigned() && Result->slt(-2)) {
-          Diag(Loc, diag::err_omp_device_expression_invalid)
-              << ValExpr->getSourceRange();
-          ErrorFound = true;
+  // or equal to omp_initial_device or omp_invalid_device. The predefined
+  // identifiers were introduced in OpenMP 5.2; earlier versions require a
+  // non-negative integer.
+  if (getLangOpts().OpenMP >= 52) {
+    if (!ValExpr->isTypeDependent() && !ValExpr->isValueDependent() &&
+        !ValExpr->isInstantiationDependent()) {
+      SourceLocation Loc = ValExpr->getExprLoc();
+      ExprResult Value = PerformOpenMPImplicitIntegerConversion(Loc, ValExpr);
+      if (Value.isInvalid()) {
+        ErrorFound = true;
+      } else {
+        ValExpr = Value.get();
+        if (std::optional<llvm::APSInt> Result =
+                ValExpr->getIntegerConstantExpr(getASTContext())) {
+          if (Result->isSigned() && Result->slt(-2)) {
+            Diag(Loc, diag::err_omp_device_expression_invalid)
+                << ValExpr->getSourceRange();
+            ErrorFound = true;
+          }
         }
       }
     }
+  } else {
+    ErrorFound = !isNonNegativeIntegerValue(ValExpr, SemaRef, OMPC_device,
+                                            /*StrictlyPositive=*/false) ||
+                 ErrorFound;
   }
   if (ErrorFound)
     return nullptr;

--- a/clang/test/OpenMP/target_data_device_messages.cpp
+++ b/clang/test/OpenMP/target_data_device_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
 void foo() {
 }

--- a/clang/test/OpenMP/target_data_device_messages.cpp
+++ b/clang/test/OpenMP/target_data_device_messages.cpp
@@ -22,7 +22,9 @@ int main(int argc, char **argv) {
   #pragma omp target data map(to: a) device (argc + argc + z)
   #pragma omp target data map(to: a) device (argc), device (argc+1) // expected-error {{directive '#pragma omp target data' cannot contain more than one 'device' clause}}
   #pragma omp target data map(to: a) device (S1) // expected-error {{'S1' does not refer to a value}}
-  #pragma omp target data map(to: a) device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+  #pragma omp target data map(to: a) device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  #pragma omp target data map(to: a) device (-2) // OK: omp_invalid_device
+  #pragma omp target data map(to: a) device (-1) // OK: omp_initial_device
   #pragma omp target data map(to: a) device (-10u)
   #pragma omp target data map(to: a) device (ancestor: -10u) // expected-error {{use of undeclared identifier 'ancestor'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   #pragma omp target data map(to: a) device (3.14) // expected-error {{expression must have integral or unscoped enumeration type, not 'double'}}

--- a/clang/test/OpenMP/target_device_messages.cpp
+++ b/clang/test/OpenMP/target_device_messages.cpp
@@ -1,8 +1,8 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify=expected,omp45 -fopenmp -fopenmp-version=45 -ferror-limit 100 -o - %s -Wuninitialized
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify=expected,omp51 -fopenmp -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify=expected,omp52 -fopenmp -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify=expected,omp45 -fopenmp-simd -fopenmp-version=45 -ferror-limit 100 -o - %s -Wuninitialized
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify=expected,omp51 -fopenmp-simd -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify=expected,omp52 -fopenmp-simd -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
 void foo() {
 }
@@ -23,23 +23,23 @@ int main(int argc, char **argv) {
   foo();
   #pragma omp target device (argc // expected-error {{expected ')'}} expected-note {{to match this '('}}
   foo();
-  #pragma omp target device (argc: // expected-error {{expected ')'}} expected-note {{to match this '('}} omp51-error {{expected expression}}
+  #pragma omp target device (argc: // expected-error {{expected ')'}} expected-note {{to match this '('}} omp52-error {{expected expression}}
   foo();
   #pragma omp target device (z-argc)) // expected-warning {{extra tokens at the end of '#pragma omp target' are ignored}}
   foo();
-  #pragma omp target device (device_num : argc > 0 ? argv[1] : argv[2]) // omp45-error {{use of undeclared identifier 'device_num'}} omp45-error {{expected ')'}} omp45-note {{to match this '('}} omp51-error {{expression must have integral or unscoped enumeration type, not 'char *'}}
+  #pragma omp target device (device_num : argc > 0 ? argv[1] : argv[2]) // omp45-error {{use of undeclared identifier 'device_num'}} omp45-error {{expected ')'}} omp45-note {{to match this '('}} omp52-error {{expression must have integral or unscoped enumeration type, not 'char *'}}
   foo();
-  #pragma omp target device (argc: argc + argc) // omp45-error {{expected ')'}} omp45-note {{to match this '('}} omp51-error {{expected 'ancestor' or 'device_num' in OpenMP clause 'device'}}
+  #pragma omp target device (argc: argc + argc) // omp45-error {{expected ')'}} omp45-note {{to match this '('}} omp52-error {{expected 'ancestor' or 'device_num' in OpenMP clause 'device'}}
   foo();
   #pragma omp target device (argc), device (argc+1) // expected-error {{directive '#pragma omp target' cannot contain more than one 'device' clause}}
   foo();
   #pragma omp target device (S1) // expected-error {{'S1' does not refer to a value}}
   foo();
-  #pragma omp target device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  #pragma omp target device (-3) // omp45-error {{argument to 'device' clause must be a non-negative integer value}} omp52-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
   foo();
-  #pragma omp target device (-2) // OK: omp_invalid_device
+  #pragma omp target device (-2) // omp45-error {{argument to 'device' clause must be a non-negative integer value}} OK under OpenMP 5.2: omp_invalid_device
   foo();
-  #pragma omp target device (-1) // OK: omp_initial_device
+  #pragma omp target device (-1) // omp45-error {{argument to 'device' clause must be a non-negative integer value}} OK under OpenMP 5.2: omp_initial_device
   foo();
   #pragma omp target device (-10u)
   foo();

--- a/clang/test/OpenMP/target_device_messages.cpp
+++ b/clang/test/OpenMP/target_device_messages.cpp
@@ -35,7 +35,11 @@ int main(int argc, char **argv) {
   foo();
   #pragma omp target device (S1) // expected-error {{'S1' does not refer to a value}}
   foo();
-  #pragma omp target device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+  #pragma omp target device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  foo();
+  #pragma omp target device (-2) // OK: omp_invalid_device
+  foo();
+  #pragma omp target device (-1) // OK: omp_initial_device
   foo();
   #pragma omp target device (-10u)
   foo();

--- a/clang/test/OpenMP/target_device_omp_initial_invalid.c
+++ b/clang/test/OpenMP/target_device_omp_initial_invalid.c
@@ -1,0 +1,55 @@
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=52 -ferror-limit 100 %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp-simd -fopenmp-version=52 -ferror-limit 100 %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=60 -ferror-limit 100 %s -Wuninitialized
+
+// expected-no-diagnostics
+
+#define omp_initial_device -1
+#define omp_invalid_device -2
+
+void foo(void) {}
+
+int main(void) {
+  int a = 0;
+
+  // Literal values allowed by the spec for the 'device' clause.
+  #pragma omp target device(-1)
+  foo();
+  #pragma omp target device(-2)
+  foo();
+  #pragma omp target device(0)
+  foo();
+  #pragma omp target device(1)
+  foo();
+
+  // Using the predefined identifiers.
+  #pragma omp target device(omp_initial_device)
+  foo();
+  #pragma omp target device(omp_invalid_device)
+  foo();
+
+  // Also accepted on other target-capable directives.
+  #pragma omp target data map(to: a) device(omp_initial_device)
+  foo();
+  #pragma omp target data map(to: a) device(omp_invalid_device)
+  foo();
+
+  #pragma omp target enter data map(to: a) device(omp_initial_device)
+  #pragma omp target enter data map(to: a) device(omp_invalid_device)
+
+  #pragma omp target exit data map(from: a) device(omp_initial_device)
+  #pragma omp target exit data map(from: a) device(omp_invalid_device)
+
+  #pragma omp target update to(a) device(omp_initial_device)
+  #pragma omp target update to(a) device(omp_invalid_device)
+
+  // Runtime-determined device numbers still pass the semantic check. The
+  // initializer is deliberately -3 (an otherwise-rejected value) to prove
+  // that the check does not fold a non-constant expression to its init; a
+  // value of -1 or -2 here would silently pass for the wrong reason.
+  int dev = -3;
+  #pragma omp target device(dev)
+  foo();
+
+  return 0;
+}

--- a/clang/test/OpenMP/target_enter_data_device_messages.cpp
+++ b/clang/test/OpenMP/target_enter_data_device_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
 void foo() {
 }

--- a/clang/test/OpenMP/target_enter_data_device_messages.cpp
+++ b/clang/test/OpenMP/target_enter_data_device_messages.cpp
@@ -22,7 +22,9 @@ int main(int argc, char **argv) {
   #pragma omp target enter data map(to: i) device (argc +z +  argc )
   #pragma omp target enter data map(to: i) device (argc), device (argc+1) // expected-error {{directive '#pragma omp target enter data' cannot contain more than one 'device' clause}}
   #pragma omp target enter data map(to: i) device (S1) // expected-error {{'S1' does not refer to a value}}
-  #pragma omp target enter data map(to: i) device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+  #pragma omp target enter data map(to: i) device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  #pragma omp target enter data map(to: i) device (-2) // OK: omp_invalid_device
+  #pragma omp target enter data map(to: i) device (-1) // OK: omp_initial_device
   #pragma omp target enter data map(to: i) device (-10u)
   #pragma omp target enter data map(to: i) device (device_num: -10u) // expected-error {{use of undeclared identifier 'device_num'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   #pragma omp target enter data map(to: i) device (3.14) // expected-error {{expression must have integral or unscoped enumeration type, not 'double'}}

--- a/clang/test/OpenMP/target_exit_data_device_messages.cpp
+++ b/clang/test/OpenMP/target_exit_data_device_messages.cpp
@@ -22,7 +22,9 @@ int main(int argc, char **argv) {
   #pragma omp target exit data map(from: i) device (argc + argc)
   #pragma omp target exit data map(from: i) device (argc), device (argc+1) // expected-error {{directive '#pragma omp target exit data' cannot contain more than one 'device' clause}}
   #pragma omp target exit data map(from: i) device (S1) // expected-error {{'S1' does not refer to a value}}
-  #pragma omp target exit data map(from: i) device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+  #pragma omp target exit data map(from: i) device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  #pragma omp target exit data map(from: i) device (-2) // OK: omp_invalid_device
+  #pragma omp target exit data map(from: i) device (-1) // OK: omp_initial_device
   #pragma omp target exit data map(from: i) device (-10u + z)
   #pragma omp target exit data map(from: i) device (ancestor: -10u + z) // expected-error {{use of undeclared identifier 'ancestor'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   #pragma omp target exit data map(from: i) device (3.14) // expected-error {{expression must have integral or unscoped enumeration type, not 'double'}}

--- a/clang/test/OpenMP/target_exit_data_device_messages.cpp
+++ b/clang/test/OpenMP/target_exit_data_device_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
 void foo() {
 }

--- a/clang/test/OpenMP/target_parallel_device_messages.cpp
+++ b/clang/test/OpenMP/target_parallel_device_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
 void foo() {
 }

--- a/clang/test/OpenMP/target_parallel_device_messages.cpp
+++ b/clang/test/OpenMP/target_parallel_device_messages.cpp
@@ -31,7 +31,11 @@ int main(int argc, char **argv) {
   foo();
   #pragma omp target parallel device (S1) // expected-error {{'S1' does not refer to a value}}
   foo();
-  #pragma omp target parallel device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+  #pragma omp target parallel device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  foo();
+  #pragma omp target parallel device (-2) // OK: omp_invalid_device
+  foo();
+  #pragma omp target parallel device (-1) // OK: omp_initial_device
   foo();
   #pragma omp target parallel device (-10u)
   foo();

--- a/clang/test/OpenMP/target_parallel_for_device_messages.cpp
+++ b/clang/test/OpenMP/target_parallel_for_device_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
 void foo() {
 }

--- a/clang/test/OpenMP/target_parallel_for_device_messages.cpp
+++ b/clang/test/OpenMP/target_parallel_for_device_messages.cpp
@@ -31,7 +31,11 @@ int main(int argc, char **argv) {
   for (i = 0; i < argc; ++i) foo();
   #pragma omp target parallel for device (S1) // expected-error {{'S1' does not refer to a value}}
   for (i = 0; i < argc; ++i) foo();
-  #pragma omp target parallel for device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+  #pragma omp target parallel for device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  for (i = 0; i < argc; ++i) foo();
+  #pragma omp target parallel for device (-2) // OK: omp_invalid_device
+  for (i = 0; i < argc; ++i) foo();
+  #pragma omp target parallel for device (-1) // OK: omp_initial_device
   for (i = 0; i < argc; ++i) foo();
   #pragma omp target parallel for device (-10u)
   for (i = 0; i < argc; ++i) foo();

--- a/clang/test/OpenMP/target_parallel_for_simd_device_messages.cpp
+++ b/clang/test/OpenMP/target_parallel_for_simd_device_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -verify -fopenmp %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=52 %s -Wuninitialized
 
-// RUN: %clang_cc1 -verify -fopenmp-simd %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp-simd -fopenmp-version=52 %s -Wuninitialized
 
 void foo() {
 }

--- a/clang/test/OpenMP/target_parallel_for_simd_device_messages.cpp
+++ b/clang/test/OpenMP/target_parallel_for_simd_device_messages.cpp
@@ -31,7 +31,11 @@ int main(int argc, char **argv) {
   for (i = 0; i < argc; ++i) foo();
   #pragma omp target parallel for simd device (S1) // expected-error {{'S1' does not refer to a value}}
   for (i = 0; i < argc; ++i) foo();
-  #pragma omp target parallel for simd device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+  #pragma omp target parallel for simd device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  for (i = 0; i < argc; ++i) foo();
+  #pragma omp target parallel for simd device (-2) // OK: omp_invalid_device
+  for (i = 0; i < argc; ++i) foo();
+  #pragma omp target parallel for simd device (-1) // OK: omp_initial_device
   for (i = 0; i < argc; ++i) foo();
   #pragma omp target parallel for simd device (-10u)
   for (i = 0; i < argc; ++i) foo();

--- a/clang/test/OpenMP/target_simd_device_messages.cpp
+++ b/clang/test/OpenMP/target_simd_device_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -verify -fopenmp %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=52 %s -Wuninitialized
 
-// RUN: %clang_cc1 -verify -fopenmp-simd %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp-simd -fopenmp-version=52 %s -Wuninitialized
 
 void foo() {
 }

--- a/clang/test/OpenMP/target_simd_device_messages.cpp
+++ b/clang/test/OpenMP/target_simd_device_messages.cpp
@@ -31,7 +31,11 @@ int main(int argc, char **argv) {
   for (i = 0; i < argc; ++i) foo();
   #pragma omp target simd device (S1) // expected-error {{'S1' does not refer to a value}}
   for (i = 0; i < argc; ++i) foo();
-  #pragma omp target simd device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+  #pragma omp target simd device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  for (i = 0; i < argc; ++i) foo();
+  #pragma omp target simd device (-2) // OK: omp_invalid_device
+  for (i = 0; i < argc; ++i) foo();
+  #pragma omp target simd device (-1) // OK: omp_initial_device
   for (i = 0; i < argc; ++i) foo();
   #pragma omp target simd device (-10u)
   for (i = 0; i < argc; ++i) foo();

--- a/clang/test/OpenMP/target_teams_device_messages.cpp
+++ b/clang/test/OpenMP/target_teams_device_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
 void foo() {
 }

--- a/clang/test/OpenMP/target_teams_device_messages.cpp
+++ b/clang/test/OpenMP/target_teams_device_messages.cpp
@@ -31,7 +31,11 @@ int main(int argc, char **argv) {
   foo();
 #pragma omp target teams device (S1) // expected-error {{'S1' does not refer to a value}}
   foo();
-#pragma omp target teams device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+#pragma omp target teams device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  foo();
+#pragma omp target teams device (-2) // OK: omp_invalid_device
+  foo();
+#pragma omp target teams device (-1) // OK: omp_initial_device
   foo();
 #pragma omp target teams device (-10u)
   foo();

--- a/clang/test/OpenMP/target_teams_distribute_device_messages.cpp
+++ b/clang/test/OpenMP/target_teams_distribute_device_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
 void foo() {
 }

--- a/clang/test/OpenMP/target_teams_distribute_device_messages.cpp
+++ b/clang/test/OpenMP/target_teams_distribute_device_messages.cpp
@@ -31,7 +31,11 @@ int main(int argc, char **argv) {
   for (i = 0; i < argc; ++i) foo();
 #pragma omp target teams distribute device (S1) // expected-error {{'S1' does not refer to a value}}
   for (i = 0; i < argc; ++i) foo();
-#pragma omp target teams distribute device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+#pragma omp target teams distribute device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  for (i = 0; i < argc; ++i) foo();
+#pragma omp target teams distribute device (-2) // OK: omp_invalid_device
+  for (i = 0; i < argc; ++i) foo();
+#pragma omp target teams distribute device (-1) // OK: omp_initial_device
   for (i = 0; i < argc; ++i) foo();
 #pragma omp target teams distribute device (-10u)
   for (i = 0; i < argc; ++i) foo();

--- a/clang/test/OpenMP/target_teams_distribute_parallel_for_device_messages.cpp
+++ b/clang/test/OpenMP/target_teams_distribute_parallel_for_device_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
-// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -ferror-limit 100 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -triple x86_64-apple-macos10.7.0 -verify -fopenmp-simd -fopenmp-version=52 -ferror-limit 100 -o - %s -Wuninitialized
 
 void foo() {
 }

--- a/clang/test/OpenMP/target_teams_distribute_parallel_for_device_messages.cpp
+++ b/clang/test/OpenMP/target_teams_distribute_parallel_for_device_messages.cpp
@@ -31,7 +31,11 @@ int main(int argc, char **argv) {
   for (i = 0; i < argc; ++i) foo();
 #pragma omp target teams distribute parallel for device (S1) // expected-error {{'S1' does not refer to a value}}
   for (i = 0; i < argc; ++i) foo();
-#pragma omp target teams distribute parallel for device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+#pragma omp target teams distribute parallel for device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  for (i = 0; i < argc; ++i) foo();
+#pragma omp target teams distribute parallel for device (-2) // OK: omp_invalid_device
+  for (i = 0; i < argc; ++i) foo();
+#pragma omp target teams distribute parallel for device (-1) // OK: omp_initial_device
   for (i = 0; i < argc; ++i) foo();
 #pragma omp target teams distribute parallel for device (-10u)
   for (i = 0; i < argc; ++i) foo();

--- a/clang/test/OpenMP/target_teams_distribute_parallel_for_simd_device_messages.cpp
+++ b/clang/test/OpenMP/target_teams_distribute_parallel_for_simd_device_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -verify -fopenmp %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=52 %s -Wuninitialized
 
-// RUN: %clang_cc1 -verify -fopenmp-simd %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp-simd -fopenmp-version=52 %s -Wuninitialized
 
 void foo() {
 }

--- a/clang/test/OpenMP/target_teams_distribute_parallel_for_simd_device_messages.cpp
+++ b/clang/test/OpenMP/target_teams_distribute_parallel_for_simd_device_messages.cpp
@@ -31,7 +31,11 @@ int main(int argc, char **argv) {
   for (i = 0; i < argc; ++i) foo();
 #pragma omp target teams distribute parallel for simd device (S1) // expected-error {{'S1' does not refer to a value}}
   for (i = 0; i < argc; ++i) foo();
-#pragma omp target teams distribute parallel for simd device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+#pragma omp target teams distribute parallel for simd device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  for (i = 0; i < argc; ++i) foo();
+#pragma omp target teams distribute parallel for simd device (-2) // OK: omp_invalid_device
+  for (i = 0; i < argc; ++i) foo();
+#pragma omp target teams distribute parallel for simd device (-1) // OK: omp_initial_device
   for (i = 0; i < argc; ++i) foo();
 #pragma omp target teams distribute parallel for simd device (-10u)
   for (i = 0; i < argc; ++i) foo();

--- a/clang/test/OpenMP/target_teams_distribute_simd_device_messages.cpp
+++ b/clang/test/OpenMP/target_teams_distribute_simd_device_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -verify -fopenmp %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=52 %s -Wuninitialized
 
-// RUN: %clang_cc1 -verify -fopenmp-simd %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp-simd -fopenmp-version=52 %s -Wuninitialized
 
 void foo() {
 }

--- a/clang/test/OpenMP/target_teams_distribute_simd_device_messages.cpp
+++ b/clang/test/OpenMP/target_teams_distribute_simd_device_messages.cpp
@@ -31,7 +31,11 @@ int main(int argc, char **argv) {
   for (i = 0; i < argc; ++i) foo();
 #pragma omp target teams distribute simd device (S1) // expected-error {{'S1' does not refer to a value}}
   for (i = 0; i < argc; ++i) foo();
-#pragma omp target teams distribute simd device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+#pragma omp target teams distribute simd device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+  for (i = 0; i < argc; ++i) foo();
+#pragma omp target teams distribute simd device (-2) // OK: omp_invalid_device
+  for (i = 0; i < argc; ++i) foo();
+#pragma omp target teams distribute simd device (-1) // OK: omp_initial_device
   for (i = 0; i < argc; ++i) foo();
 #pragma omp target teams distribute simd device (-10u)
   for (i = 0; i < argc; ++i) foo();

--- a/clang/test/OpenMP/target_update_device_messages.cpp
+++ b/clang/test/OpenMP/target_update_device_messages.cpp
@@ -25,7 +25,9 @@ int tmain(T argc, S **argv) {
 #pragma omp target update from(i) device (argc), device (argc+1) // expected-error {{directive '#pragma omp target update' cannot contain more than one 'device' clause}}
 #pragma omp target update from(i) device (S1) // expected-error {{'S1' does not refer to a value}}
 #pragma omp target update from(i) device (3.14) // expected-error 2 {{expression must have integral or unscoped enumeration type, not 'double'}}
-#pragma omp target update from(i) device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+#pragma omp target update from(i) device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+#pragma omp target update from(i) device (-2) // OK: omp_invalid_device
+#pragma omp target update from(i) device (-1) // OK: omp_initial_device
 }
 
 int main(int argc, char **argv) {
@@ -39,7 +41,9 @@ int main(int argc, char **argv) {
 #pragma omp target update to(j) device (z + argc)
 #pragma omp target update from(j) device (argc), device (argc+1) // expected-error {{directive '#pragma omp target update' cannot contain more than one 'device' clause}}
 #pragma omp target update to(j) device (S1) // expected-error {{'S1' does not refer to a value}}
-#pragma omp target update from(j) device (-2) // expected-error {{argument to 'device' clause must be a non-negative integer value}}
+#pragma omp target update from(j) device (-3) // expected-error {{argument to 'device' clause must be a non-negative integer value, 'omp_initial_device' (-1), or 'omp_invalid_device' (-2)}}
+#pragma omp target update from(j) device (-2) // OK: omp_invalid_device
+#pragma omp target update from(j) device (-1) // OK: omp_initial_device
 #pragma omp target update to(j) device (3.14) // expected-error {{expression must have integral or unscoped enumeration type, not 'double'}}
 
   return tmain(argc, argv); // expected-note {{in instantiation of function template specialization 'tmain<int, char>' requested here}}

--- a/clang/test/OpenMP/target_update_device_messages.cpp
+++ b/clang/test/OpenMP/target_update_device_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -verify -fopenmp -ferror-limit 100 %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=52 -ferror-limit 100 %s -Wuninitialized
 
-// RUN: %clang_cc1 -verify -fopenmp-simd -ferror-limit 100 %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp-simd -fopenmp-version=52 -ferror-limit 100 %s -Wuninitialized
 
 void foo() {
 }

--- a/offload/include/OpenMP/omp.h
+++ b/offload/include/OpenMP/omp.h
@@ -34,6 +34,7 @@ extern "C" {
 ///{
 
 // See definition in OpenMP (omp.h.var/omp_lib.(F90|h).var)
+#define omp_initial_device -1
 #define omp_invalid_device -2
 
 ///}

--- a/openmp/device/include/DeviceTypes.h
+++ b/openmp/device/include/DeviceTypes.h
@@ -22,6 +22,7 @@ template <typename T> using Local = __gpu_local T;
 template <typename T> using Global = __gpu_local T;
 
 // See definition in OpenMP (omp.h.var/omp_lib.(F90|h).var)
+#define omp_initial_device -1
 #define omp_invalid_device -2
 
 enum omp_proc_bind_t {

--- a/openmp/runtime/src/include/omp.h.var
+++ b/openmp/runtime/src/include/omp.h.var
@@ -553,6 +553,7 @@
 
     /* OpenMP 5.2 */
     extern int __KAI_KMPC_CONVENTION omp_in_explicit_task(void);
+    #define omp_initial_device -1
     #define omp_invalid_device -2
 
     /* OpenMP 6.0 */


### PR DESCRIPTION
The counterpart fix for clang (as too done here: [flang-fix](https://github.com/llvm/llvm-project/pull/193669))

The incorrectly interpreted device values in the `target` directive throws:
 
```
 error: argument to 'device' clause must be a non-negative integer value
    #pragma omp target device(-1)
                              ^~
error: argument to 'device' clause must be a non-negative integer value
    #pragma omp target device(omp_invalid_device)
                              ^~~~~~~~~~~~~~~~~~
```