### PR TITLE
[DenseMap] Resolves asan + msvc build syntax errors

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -1037,7 +1037,8 @@ private:
     // Note that this cast does not violate aliasing rules as we assert that
     // the memory's dynamic type is the small, inline bucket buffer, and the
     // 'storage' is a POD containing a char buffer.
-#if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_HWADDRESS__)
+#if defined(__clang__) &&                                                      \
+    (defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_HWADDRESS__))
     // Unless it's a sanitizer with container overflow detection. In this case
     // some items in buckets can be partially poisoned, triggering sanitizer
     // report on load.
@@ -1054,7 +1055,8 @@ private:
   const LargeRep *getLargeRep() const {
     assert(!Small);
     // Note, same rule about aliasing as with getInlineBuckets.
-#if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_HWADDRESS__)
+#if defined(__clang__) &&                                                      \
+    (defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_HWADDRESS__))
     __asm__ volatile("" ::: "memory");
 #endif
     return reinterpret_cast<const LargeRep *>(&storage);


### PR DESCRIPTION
The problem was introduced by #183457 as an asan workaround for clang builds to silence false positices, so the fix here just enables the workaround for clang builds.

Fixes #189323
