### PR TITLE
Fix -Wformat diagnostic after #190965

### DIFF
--- a/libunwind/src/CompactUnwinder.hpp
+++ b/libunwind/src/CompactUnwinder.hpp
@@ -334,9 +334,10 @@ int CompactUnwinder_x86_64<A>::stepWithCompactEncodingRBPFrame(
       break;
     default:
       (void)functionStart;
-      _LIBUNWIND_DEBUG_LOG("bad register for RBP frame, encoding=%08X for "
-                           "function starting at 0x%" PRIu64 "X",
-                            compactEncoding, functionStart);
+      _LIBUNWIND_DEBUG_LOG(
+          "bad register for RBP frame, encoding=%08X for "
+          "function starting at 0x%" PRIu64 "X",
+          compactEncoding, functionStart);
       _LIBUNWIND_ABORT("invalid compact unwind encoding");
     }
     savedRegisters += 8;
@@ -453,9 +454,10 @@ int CompactUnwinder_x86_64<A>::stepWithCompactEncodingFrameless(
       registers.setRBP(addressSpace.get64(savedRegisters));
       break;
     default:
-      _LIBUNWIND_DEBUG_LOG("bad register for frameless, encoding=%08X for "
-                           "function starting at 0x%" PRIu64 "X",
-                            encoding, functionStart);
+      _LIBUNWIND_DEBUG_LOG(
+          "bad register for frameless, encoding=%08X for "
+          "function starting at 0x%" PRIu64 "X",
+          encoding, functionStart);
       _LIBUNWIND_ABORT("invalid compact unwind encoding");
     }
     savedRegisters += 8;

--- a/libunwind/src/CompactUnwinder.hpp
+++ b/libunwind/src/CompactUnwinder.hpp
@@ -334,10 +334,9 @@ int CompactUnwinder_x86_64<A>::stepWithCompactEncodingRBPFrame(
       break;
     default:
       (void)functionStart;
-      _LIBUNWIND_DEBUG_LOG(
-          "bad register for RBP frame, encoding=%08X for "
-          "function starting at 0x%" PRIu64 "X",
-          compactEncoding, functionStart);
+      _LIBUNWIND_DEBUG_LOG("bad register for RBP frame, encoding=%08X for "
+                           "function starting at 0x%" PRIu64 "X",
+                           compactEncoding, functionStart);
       _LIBUNWIND_ABORT("invalid compact unwind encoding");
     }
     savedRegisters += 8;
@@ -454,10 +453,9 @@ int CompactUnwinder_x86_64<A>::stepWithCompactEncodingFrameless(
       registers.setRBP(addressSpace.get64(savedRegisters));
       break;
     default:
-      _LIBUNWIND_DEBUG_LOG(
-          "bad register for frameless, encoding=%08X for "
-          "function starting at 0x%" PRIu64 "X",
-          encoding, functionStart);
+      _LIBUNWIND_DEBUG_LOG("bad register for frameless, encoding=%08X for "
+                           "function starting at 0x%" PRIu64 "X",
+                           encoding, functionStart);
       _LIBUNWIND_ABORT("invalid compact unwind encoding");
     }
     savedRegisters += 8;

--- a/libunwind/src/CompactUnwinder.hpp
+++ b/libunwind/src/CompactUnwinder.hpp
@@ -12,6 +12,7 @@
 #ifndef __COMPACT_UNWINDER_HPP__
 #define __COMPACT_UNWINDER_HPP__
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/libunwind/src/CompactUnwinder.hpp
+++ b/libunwind/src/CompactUnwinder.hpp
@@ -335,7 +335,7 @@ int CompactUnwinder_x86_64<A>::stepWithCompactEncodingRBPFrame(
     default:
       (void)functionStart;
       _LIBUNWIND_DEBUG_LOG("bad register for RBP frame, encoding=%08X for "
-                           "function starting at 0x%llX",
+                           "function starting at 0x%" PRIu64 "X",
                             compactEncoding, functionStart);
       _LIBUNWIND_ABORT("invalid compact unwind encoding");
     }
@@ -454,7 +454,7 @@ int CompactUnwinder_x86_64<A>::stepWithCompactEncodingFrameless(
       break;
     default:
       _LIBUNWIND_DEBUG_LOG("bad register for frameless, encoding=%08X for "
-                           "function starting at 0x%llX",
+                           "function starting at 0x%" PRIu64 "X",
                             encoding, functionStart);
       _LIBUNWIND_ABORT("invalid compact unwind encoding");
     }


### PR DESCRIPTION
Fixes libunwind compiler diagnostic when building with clang after 034d4dcad6396d1241e8262e69871b8d61da7e4f:
```
In file included from libunwind/src/libunwind.cpp:31:
In file included from libunwind/src/UnwindCursor.hpp:52:
libunwind/src/CompactUnwinder.hpp:339:46: error: format specifies type 'unsigned long long' but the argument has type 'uint64_t' (aka 'unsigned long') [-Werror,-Wformat]
  338 |                            "function starting at 0x%llX",
      |                                                    ~~~~
      |                                                    %lX
  339 |                             compactEncoding, functionStart);
      |                                              ^~~~~~~~~~~~~
libunwind/src/config.h:215:63: note: expanded from macro '_LIBUNWIND_DEBUG_LOG'
  215 |   #define _LIBUNWIND_DEBUG_LOG(msg, ...)  _LIBUNWIND_LOG(msg, __VA_ARGS__)
      |                                                          ~~~  ^~~~~~~~~~~
libunwind/src/config.h:181:45: note: expanded from macro '_LIBUNWIND_LOG'
  181 |     fprintf(stderr, "libunwind: " msg "\n", __VA_ARGS__);                      \
      |                                   ~~~       ^~~~~~~~~~~
In file included from libunwind/src/libunwind.cpp:31:
In file included from libunwind/src/UnwindCursor.hpp:52:
libunwind/src/CompactUnwinder.hpp:458:39: error: format specifies type 'unsigned long long' but the argument has type 'uint64_t' (aka 'unsigned long') [-Werror,-Wformat]
  457 |                            "function starting at 0x%llX",
      |                                                    ~~~~
      |                                                    %lX
  458 |                             encoding, functionStart);
      |                                       ^~~~~~~~~~~~~
libunwind/src/config.h:215:63: note: expanded from macro '_LIBUNWIND_DEBUG_LOG'
  215 |   #define _LIBUNWIND_DEBUG_LOG(msg, ...)  _LIBUNWIND_LOG(msg, __VA_ARGS__)
      |                                                          ~~~  ^~~~~~~~~~~
libunwind/src/config.h:181:45: note: expanded from macro '_LIBUNWIND_LOG'
  181 |     fprintf(stderr, "libunwind: " msg "\n", __VA_ARGS__);                      \
      |                                   ~~~       ^~~~~~~~~~~
```