### PR TITLE
[Dexter] Add timestamps to DAP logging

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -51,6 +51,7 @@ class DAPMessageLogger:
         self.out_handle = None
         self.open = False
         self.lock = threading.Lock()
+        self.start_time: None | float = None
 
     def _custom_enter(self):
         self.open = True
@@ -63,6 +64,7 @@ class DAPMessageLogger:
             self.out_handle = sys.stderr
             return
         self.out_handle = open(self.log_file, "w+", encoding="utf-8")
+        self.start_time = time.time()
 
     def _custom_exit(self):
         if (
@@ -94,6 +96,13 @@ class DAPMessageLogger:
 
     def write_message(self, message: dict, incoming: bool):
         prefix = self.prefix_recv if incoming else self.prefix_send
+        if self.start_time is not None:
+            message_time = time.time() - self.start_time
+            minutes = int(message_time / 60)
+            seconds = int(message_time % 60)
+            milliseconds = int((message_time % 1) * 1000)
+            prefix += f" {minutes}:{seconds:02d}:{milliseconds:03d}"
+
         # ANSI escape codes get butchered by json.dumps(), so we fix them up here.
         message_str = json.dumps(
             self._colorize_dap_message(message), indent=self.indent

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -18,6 +18,7 @@ import sys
 import threading
 import time
 from enum import Enum
+from typing import Optional
 
 from dex.debugger.DebuggerBase import DebuggerBase, watch_is_active
 from dex.dextIR import FrameIR, LocIR, StepIR, StopReason, ValueIR
@@ -51,10 +52,11 @@ class DAPMessageLogger:
         self.out_handle = None
         self.open = False
         self.lock = threading.Lock()
-        self.start_time: None | float = None
+        self.start_time: Optional[float] = None
 
     def _custom_enter(self):
         self.open = True
+        self.start_time = time.time()
         if self.log_file is None:
             return
         if self.log_file == "-":
@@ -64,7 +66,6 @@ class DAPMessageLogger:
             self.out_handle = sys.stderr
             return
         self.out_handle = open(self.log_file, "w+", encoding="utf-8")
-        self.start_time = time.time()
 
     def _custom_exit(self):
         if (


### PR DESCRIPTION
DAP logs are currently optionally output by Dexter to assist in debugging or analyzing Dexter sessions. The output currently includes the contents of every DAP message sent to/from the debug adapter, but for some long-running programs it can also be useful to know when messages have been sent and received; to assist, this patch adds timestamps to DAP messages in the log.