### PR TITLE
[libc++] Update macOS and AppleClang

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -198,13 +198,13 @@ jobs:
       matrix:
         include:
         - config: generic-cxx03
-          os: macos-15
+          os: macos-26
         - config: generic-cxx23
-          os: macos-15
+          os: macos-26
         - config: generic-modules
-          os: macos-15
+          os: macos-26
         - config: apple-configuration
-          os: macos-15
+          os: macos-26
         # TODO: These jobs are intended to test back-deployment (building against ToT libc++ but running against an
         #       older system-provided libc++.dylib). Doing this properly would require building the test suite on a
         #       recent macOS using a recent Clang (hence recent Xcode), and then running the actual test suite on an
@@ -216,9 +216,9 @@ jobs:
         #       macOS versions as a way to avoid rotting that configuration, but it doesn't provide a lot of additional
         #       coverage.
         - config: apple-system
-          os: macos-15
+          os: macos-26
         - config: apple-system-hardened
-          os: macos-15
+          os: macos-26
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -226,8 +226,8 @@ jobs:
           persist-credentials: false
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
-          xcode-version: '26.0'
+          # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
+          xcode-version: '26.4'
       - name: Build and test
         run: |
           python3 -m venv .venv

--- a/libcxx/docs/index.rst
+++ b/libcxx/docs/index.rst
@@ -132,7 +132,7 @@ velocity, libc++ drops support for older compilers as newer ones are released.
 Compiler     Versions            Restrictions               Support policy
 ============ =================== ========================== =====================
 Clang        21, 22, 23-git                                 latest two stable releases per `LLVM's release page <https://releases.llvm.org>`_ and the development version
-AppleClang   26.0                                           latest stable release per `Xcode's release page <https://developer.apple.com/documentation/xcode-release-notes>`_
+AppleClang   26.4                                           latest stable release per `Xcode's release page <https://developer.apple.com/documentation/xcode-release-notes>`_
 Open XL      17.1.4 (AIX)                                   latest stable release per `Open XL's documentation page <https://www.ibm.com/docs/en/openxl-c-and-cpp-aix>`_
 GCC          15                  In C++11 or later only     latest stable release per `GCC's release page <https://gcc.gnu.org/releases.html>`_
 ============ =================== ========================== =====================

--- a/libcxx/include/__configuration/compiler.h
+++ b/libcxx/include/__configuration/compiler.h
@@ -37,8 +37,8 @@
 #      warning "Libc++ only supports Clang 21 and later"
 #    endif
 #  elif defined(_LIBCPP_APPLE_CLANG_VER)
-#    if _LIBCPP_APPLE_CLANG_VER < 1700
-#      warning "Libc++ only supports AppleClang 26 and later"
+#    if _LIBCPP_APPLE_CLANG_VER < 2100
+#      warning "Libc++ only supports AppleClang 26.4 and later"
 #    endif
 #  elif defined(_LIBCPP_GCC_VER)
 #    if _LIBCPP_GCC_VER < 1500

--- a/libcxx/test/libcxx/strings/basic.string/nonnull.verify.cpp
+++ b/libcxx/test/libcxx/strings/basic.string/nonnull.verify.cpp
@@ -11,7 +11,7 @@
 // Ensure that APIs which take a CharT* are diagnosing passing a nullptr to them
 
 // AppleClang doesn't have diagnose_if with diagnostic flags
-// UNSUPPORTED: apple-clang-17
+// UNSUPPORTED: apple-clang-21
 
 // ADDITIONAL_COMPILE_FLAGS: -Wno-unused-result
 

--- a/libcxx/test/libcxx/strings/string.view/nonnull.verify.cpp
+++ b/libcxx/test/libcxx/strings/string.view/nonnull.verify.cpp
@@ -11,7 +11,7 @@
 // Ensure that APIs which take a CharT* are diagnosing passing a nullptr to them
 
 // AppleClang doesn't have diagnose_if with diagnostic flags
-// UNSUPPORTED: apple-clang-17
+// UNSUPPORTED: apple-clang-21
 
 // ADDITIONAL_COMPILE_FLAGS: -Wno-unused-result
 

--- a/libcxx/test/std/atomics/atomics.types.generic/cas_non_power_of_2.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/cas_non_power_of_2.pass.cpp
@@ -9,7 +9,7 @@
 // https://github.com/llvm/llvm-project/issues/30023
 // compare exchange does not work with types of which the size is not a power of 2
 
-// XFAIL: clang-21, apple-clang-17
+// XFAIL: clang-21, apple-clang-21
 // UNSUPPORTED: c++03
 
 // TODO: remove the UNSUPPORTED clang-22 once libc++ CI's clang is updated to include

--- a/libcxx/test/std/concepts/concepts.compare/concept.equalitycomparable/equality_comparable_with.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.compare/concept.equalitycomparable/equality_comparable_with.compile.pass.cpp
@@ -1136,7 +1136,7 @@ static_assert(
 static_assert(check_equality_comparable_with<move_only_equality_with_int, int>());
 static_assert(check_equality_comparable_with<std::unique_ptr<int>, std::nullptr_t>());
 // TODO: Clang is broken, see https://llvm.org/PR171438
-#if defined(TEST_COMPILER_CLANG) && !defined(TEST_COMPILER_APPLE_CLANG)
+#if defined(TEST_COMPILER_CLANG)
 static_assert(check_equality_comparable_with<nonmovable_equality_with_int, int>());
 #else
 static_assert(!check_equality_comparable_with<nonmovable_equality_with_int, int>());

--- a/libcxx/test/std/input.output/file.streams/c.files/gets-removed.verify.cpp
+++ b/libcxx/test/std/input.output/file.streams/c.files/gets-removed.verify.cpp
@@ -14,4 +14,7 @@
 
 void f(char* str) {
   (void)std::gets(str); // expected-error {{no member named 'gets' in namespace 'std'}}
+
+  // Apple platforms might diagnose `gets` as deprecated
+  // expected-warning@*:* 0-1 {{deprecated}}
 }

--- a/libcxx/test/std/language.support/cmp/cmp.concept/three_way_comparable_with.compile.pass.cpp
+++ b/libcxx/test/std/language.support/cmp/cmp.concept/three_way_comparable_with.compile.pass.cpp
@@ -248,7 +248,7 @@ struct NonMovableIntComparable {
 };
 
 // TODO: Clang is broken, see https://llvm.org/PR171438
-#if defined(TEST_COMPILER_CLANG) && !defined(TEST_COMPILER_APPLE_CLANG)
+#if defined(TEST_COMPILER_CLANG)
 static_assert(check_three_way_comparable_with<NonMovableIntComparable, int>());
 #else
 static_assert(!check_three_way_comparable_with<NonMovableIntComparable, int>());

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array.pass.cpp
@@ -11,7 +11,7 @@
 // UNSUPPORTED: c++03, c++11
 
 // These compiler versions and platforms don't enable sized deallocation by default.
-// ADDITIONAL_COMPILE_FLAGS(apple-clang-17): -fsized-deallocation
+// ADDITIONAL_COMPILE_FLAGS(apple-clang-21): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=x86_64-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=i686-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=aarch64-w64-windows-gnu): -fsized-deallocation

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete.pass.cpp
@@ -11,7 +11,7 @@
 // UNSUPPORTED: c++03, c++11
 
 // These compiler versions and platforms don't enable sized deallocation by default.
-// ADDITIONAL_COMPILE_FLAGS(apple-clang-17): -fsized-deallocation
+// ADDITIONAL_COMPILE_FLAGS(apple-clang-21): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=x86_64-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=i686-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=aarch64-w64-windows-gnu): -fsized-deallocation

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_monthname.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_monthname.pass.cpp
@@ -10,8 +10,6 @@
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.zh_CN.UTF-8
 
-// XFAIL: LIBCXX-FREEBSD-FIXME
-
 // <locale>
 
 // class time_get_byname<charT, InputIterator>
@@ -69,7 +67,11 @@ int main(int, char**)
     }
     {
         const my_facet f(LOCALE_zh_CN_UTF_8, 1);
+#if defined(__APPLE__) || defined(__FreeBSD__)
+        const char in[] = "6\xE6\x9C\x88";
+#else
         const char in[] = "\xE5\x85\xAD\xE6\x9C\x88";
+#endif
         err = std::ios_base::goodbit;
         t = std::tm();
         I i = f.get_monthname(I(in), I(in+sizeof(in)/sizeof(in[0])-1), ios, err, &t);

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_monthname_wide.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_monthname_wide.pass.cpp
@@ -11,8 +11,6 @@
 // REQUIRES: locale.zh_CN.UTF-8
 // XFAIL: no-wide-characters
 
-// XFAIL: LIBCXX-FREEBSD-FIXME
-
 // <locale>
 
 // class time_get_byname<charT, InputIterator>
@@ -79,7 +77,11 @@ int main(int, char**)
     }
     {
         const my_facet f(LOCALE_zh_CN_UTF_8, 1);
+#if defined(__APPLE__) || defined(__FreeBSD__)
+        const wchar_t in[] = L"6\x6708";
+#else
         const wchar_t in[] = L"\x516D\x6708";
+#endif
         err = std::ios_base::goodbit;
         t = std::tm();
         I i = f.get_monthname(I(in), I(in+sizeof(in)/sizeof(in[0])-1), ios, err, &t);

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_one.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_one.pass.cpp
@@ -9,8 +9,6 @@
 // NetBSD does not support LC_TIME at the moment
 // XFAIL: netbsd
 
-// XFAIL: LIBCXX-FREEBSD-FIXME
-
 // REQUIRES: locale.en_US.UTF-8
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ru_RU.UTF-8
@@ -103,7 +101,7 @@ int main(int, char**)
 #elif defined(_AIX)
         const char in[] = "31 d""\xC3\xA9""c. 2061 ""\xC3\xA0"" 23:55:59";
 #else
-        const char in[] = "Sam 31 d""\xC3\xA9""c 23:55:59 2061";
+        const char in[] = "sam. 31 d""\xC3\xA9""c. 23:55:59 2061";
 #endif
         err = std::ios_base::goodbit;
         t = std::tm();
@@ -196,7 +194,7 @@ int main(int, char**)
         const char in[] = "2061" "\xE5\xB9\xB4" "12" "\xE6\x9C\x88" "31"
                           "\xE6\x97\xA5";
 #else
-        const char in[] = "\xE5\x85\xAD 12/31 23:55:59 2061";
+        const char in[] = "\xE5\x85\xAD 12\xE6\x9C\x88/31 23:55:59 2061";
 #endif
         err = std::ios_base::goodbit;
         t = std::tm();

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_one_wide.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_one_wide.pass.cpp
@@ -9,8 +9,6 @@
 // NetBSD does not support LC_TIME at the moment
 // XFAIL: netbsd
 
-// XFAIL: LIBCXX-FREEBSD-FIXME
-
 // XFAIL: no-wide-characters
 
 // REQUIRES: locale.en_US.UTF-8
@@ -105,7 +103,7 @@ int main(int, char**)
 #elif defined(_AIX)
         const wchar_t in[] = L"31 d" L"\xE9" L"c. 2061" L"\xE0" L"23:55:59";
 #else
-        const wchar_t in[] = L"Sam 31 d" L"\xE9" L"c 23:55:59 2061";
+        const wchar_t in[] = L"sam. 31 d" L"\xE9" L"c. 23:55:59 2061";
 #endif
         err = std::ios_base::goodbit;
         t = std::tm();
@@ -173,7 +171,7 @@ int main(int, char**)
     {
         const my_facet f("zh_CN", 1);
         const wchar_t in[] = L"\x516D"
-                          L" 12/31 23:55:59 2061";
+                          L" 12\x6708/31 23:55:59 2061";
         err = std::ios_base::goodbit;
         t = std::tm();
         I i = f.get(I(in), I(in+sizeof(in)/sizeof(in[0])-1), ios, err, &t, 'c');

--- a/libcxx/test/std/time/time.cal/time.cal.md/time.cal.md.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.md/time.cal.md.nonmembers/ostream.pass.cpp
@@ -90,49 +90,35 @@ static void test() {
              SV("0 is not a valid month/00 is not a valid day"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day{std::chrono::month{0}, 1d}),
              SV("0 is not a valid month/01"));
-#if defined(__APPLE__)
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day{std::chrono::month{1}, 255d}),
-             SV("jan/255 is not a valid day"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day{std::chrono::month{1}, 31d}), SV("jan/31"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day{std::chrono::month{2}, 29d}), SV("fév/29"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day{std::chrono::month{6}, 31d}), SV("jui/31"));
-#else  //  defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day{std::chrono::month{1}, 255d}),
              SV("janv./255 is not a valid day"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day{std::chrono::month{1}, 31d}), SV("janv./31"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day{std::chrono::month{2}, 29d}), SV("févr./29"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day{std::chrono::month{6}, 31d}), SV("juin/31"));
-#endif //  defined(__APPLE__)
 
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{0}, 0d}),
              SV("0 is not a valid month/00 is not a valid day"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{0}, 1d}),
              SV("0 is not a valid month/01"));
-#if defined(__APPLE__)
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{1}, 255d}),
-             SV(" 1/255 is not a valid day"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{1}, 31d}), SV(" 1/31"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{2}, 29d}), SV(" 2/29"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{6}, 31d}), SV(" 6/31"));
-#elif defined(_WIN32) //  defined(__APPLE__)
+#if defined(_WIN32)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{1}, 255d}),
              SV("1/255 is not a valid day"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{1}, 31d}), SV("1/31"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{2}, 29d}), SV("2/29"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{6}, 31d}), SV("6/31"));
-#elif defined(_AIX)   //  defined(__APPLE__)
+#elif defined(_AIX)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{1}, 255d}),
              SV("1月/255 is not a valid day"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{1}, 31d}), SV("1月/31"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{2}, 29d}), SV("2月/29"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{6}, 31d}), SV("6月/31"));
-#else                 //  defined(__APPLE__)
+#else
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{1}, 255d}),
              SV(" 1月/255 is not a valid day"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{1}, 31d}), SV(" 1月/31"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{2}, 29d}), SV(" 2月/29"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day{std::chrono::month{6}, 31d}), SV(" 6月/31"));
-#endif                //  defined(__APPLE__)
+#endif
 }
 
 int main(int, char**) {

--- a/libcxx/test/std/time/time.cal/time.cal.mdlast/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.mdlast/ostream.pass.cpp
@@ -89,28 +89,14 @@ static void test() {
 
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{0}}),
              SV("0 is not a valid month/last"));
-#if defined(__APPLE__)
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{1}}), SV("jan/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{2}}), SV("fév/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{3}}), SV("mar/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{4}}), SV("avr/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{5}}), SV("mai/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{6}}), SV("jui/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{7}}), SV("jul/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{8}}), SV("aoû/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{9}}), SV("sep/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{10}}), SV("oct/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{11}}), SV("nov/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{12}}), SV("déc/last"));
-#else //  defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{1}}), SV("janv./last"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{2}}), SV("févr./last"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{3}}), SV("mars/last"));
-#  if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__) || defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{4}}), SV("avr./last"));
-#  else
+#else
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{4}}), SV("avril/last"));
-#  endif
+#endif
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{5}}), SV("mai/last"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{6}}), SV("juin/last"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{7}}), SV("juil./last"));
@@ -119,7 +105,6 @@ static void test() {
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{10}}), SV("oct./last"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{11}}), SV("nov./last"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{12}}), SV("déc./last"));
-#endif //  defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{13}}),
              SV("13 is not a valid month/last"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_day_last{std::chrono::month{255}}),
@@ -127,18 +112,7 @@ static void test() {
 
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{0}}),
              SV("0 is not a valid month/last"));
-#if defined(__APPLE__) || defined(_WIN32)
-#  if defined(__APPLE__)
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{1}}), SV(" 1/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{2}}), SV(" 2/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{3}}), SV(" 3/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{4}}), SV(" 4/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{5}}), SV(" 5/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{6}}), SV(" 6/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{7}}), SV(" 7/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{8}}), SV(" 8/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{9}}), SV(" 9/last"));
-#  else  // defined(__APPLE__)
+#if defined(_WIN32)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{1}}), SV("1/last"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{2}}), SV("2/last"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{3}}), SV("3/last"));
@@ -148,11 +122,10 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{7}}), SV("7/last"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{8}}), SV("8/last"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{9}}), SV("9/last"));
-#  endif // defined(__APPLE__)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{10}}), SV("10/last"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{11}}), SV("11/last"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{12}}), SV("12/last"));
-#else // defined(__APPLE__) || defined(_WIN32)
+#else // defined(_WIN32)
 #  if defined(_AIX)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{1}}), SV("1月/last"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{2}}), SV("2月/last"));
@@ -177,7 +150,7 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{10}}), SV("10月/last"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{11}}), SV("11月/last"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{12}}), SV("12月/last"));
-#endif   // defined(__APPLE__) || defined(_WIN32)
+#endif   // defined(_WIN32)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{13}}),
              SV("13 is not a valid month/last"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_day_last{std::chrono::month{255}}),

--- a/libcxx/test/std/time/time.cal/time.cal.month/time.cal.month.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.month/time.cal.month.nonmembers/ostream.pass.cpp
@@ -85,28 +85,14 @@ static void test() {
   TEST_EQUAL(stream_c_locale<CharT>(std::chrono::month{255}), SV("255 is not a valid month"));
 
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{0}), SV("0 is not a valid month"));
-#if defined(__APPLE__)
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{1}), SV("jan"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{2}), SV("fév"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{3}), SV("mar"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{4}), SV("avr"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{5}), SV("mai"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{6}), SV("jui"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{7}), SV("jul"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{8}), SV("aoû"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{9}), SV("sep"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{10}), SV("oct"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{11}), SV("nov"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{12}), SV("déc"));
-#else //  defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{1}), SV("janv."));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{2}), SV("févr."));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{3}), SV("mars"));
-#  if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__) || defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{4}), SV("avr."));
-#  else
+#else
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{4}), SV("avril"));
-#  endif
+#endif
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{5}), SV("mai"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{6}), SV("juin"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{7}), SV("juil."));
@@ -115,23 +101,11 @@ static void test() {
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{10}), SV("oct."));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{11}), SV("nov."));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{12}), SV("déc."));
-#endif //  defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{13}), SV("13 is not a valid month"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month{255}), SV("255 is not a valid month"));
 
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{0}), SV("0 is not a valid month"));
-#if defined(__APPLE__) || defined(_WIN32)
-#  if defined(__APPLE__)
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{1}), SV(" 1"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{2}), SV(" 2"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{3}), SV(" 3"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{4}), SV(" 4"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{5}), SV(" 5"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{6}), SV(" 6"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{7}), SV(" 7"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{8}), SV(" 8"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{9}), SV(" 9"));
-#  else  //  defined(__APPLE__)
+#if defined(_WIN32)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{1}), SV("1"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{2}), SV("2"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{3}), SV("3"));
@@ -141,11 +115,10 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{7}), SV("7"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{8}), SV("8"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{9}), SV("9"));
-#  endif // defined(__APPLE__)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{10}), SV("10"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{11}), SV("11"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{12}), SV("12"));
-#else // defined(__APPLE__)|| defined(_WIN32)
+#else // defined(_WIN32)
 #  if defined(_AIX)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{1}), SV("1月"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{2}), SV("2月"));
@@ -170,7 +143,7 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{10}), SV("10月"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{11}), SV("11月"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{12}), SV("12月"));
-#endif   // defined(__APPLE__)|| defined(_WIN32)
+#endif   // defined(_WIN32)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{13}), SV("13 is not a valid month"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month{255}), SV("255 is not a valid month"));
 }

--- a/libcxx/test/std/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/ostream.pass.cpp
@@ -114,53 +114,6 @@ static void test() {
                  std::chrono::month{255}, std::chrono::weekday_indexed{std::chrono::weekday{8}, 0}}),
              SV("255 is not a valid month/8 is not a valid weekday[0 is not a valid index]"));
 
-#if defined(__APPLE__)
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{0}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
-             SV("0 is not a valid month/Dim[1]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday{1}, 1}}),
-             SV("jan/Lun[1]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{2}, std::chrono::weekday_indexed{std::chrono::weekday{2}, 2}}),
-             SV("fév/Mar[2]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{3}, std::chrono::weekday_indexed{std::chrono::weekday{3}, 3}}),
-             SV("mar/Mer[3]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{4}, std::chrono::weekday_indexed{std::chrono::weekday{4}, 4}}),
-             SV("avr/Jeu[4]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{5}, std::chrono::weekday_indexed{std::chrono::weekday{5}, 5}}),
-             SV("mai/Ven[5]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{6}, std::chrono::weekday_indexed{std::chrono::weekday{6}, 6}}),
-             SV("jui/Sam[6 is not a valid index]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{7}, std::chrono::weekday_indexed{std::chrono::weekday{7}, 7}}),
-             SV("jul/Dim[7 is not a valid index]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{8}, std::chrono::weekday_indexed{std::chrono::weekday{8}, 0}}),
-             SV("aoû/8 is not a valid weekday[0 is not a valid index]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{9}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
-             SV("sep/Dim[1]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{10}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
-             SV("oct/Dim[1]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{11}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
-             SV("nov/Dim[1]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{12}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
-             SV("déc/Dim[1]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{13}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
-             SV("13 is not a valid month/Dim[1]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{255}, std::chrono::weekday_indexed{std::chrono::weekday{8}, 0}}),
-             SV("255 is not a valid month/8 is not a valid weekday[0 is not a valid index]"));
-#else //  defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{0}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
              SV("0 is not a valid month/dim.[1]"));
@@ -173,15 +126,15 @@ static void test() {
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{3}, std::chrono::weekday_indexed{std::chrono::weekday{3}, 3}}),
              SV("mars/mer.[3]"));
-#  if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__) || defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{4}, std::chrono::weekday_indexed{std::chrono::weekday{4}, 4}}),
              SV("avr./jeu.[4]"));
-#  else
+#else
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{4}, std::chrono::weekday_indexed{std::chrono::weekday{4}, 4}}),
              SV("avril/jeu.[4]"));
-#  endif
+#endif
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{5}, std::chrono::weekday_indexed{std::chrono::weekday{5}, 5}}),
              SV("mai/ven.[5]"));
@@ -212,41 +165,11 @@ static void test() {
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{255}, std::chrono::weekday_indexed{std::chrono::weekday{8}, 0}}),
              SV("255 is not a valid month/8 is not a valid weekday[0 is not a valid index]"));
-#endif //  defined(__APPLE__)
 
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{0}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
              SV("0 is not a valid month/日[1]"));
-#if defined(__APPLE__) || defined(_WIN32)
-#  if defined(__APPLE__)
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday{1}, 1}}),
-             SV(" 1/月[1]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{2}, std::chrono::weekday_indexed{std::chrono::weekday{2}, 2}}),
-             SV(" 2/火[2]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{3}, std::chrono::weekday_indexed{std::chrono::weekday{3}, 3}}),
-             SV(" 3/水[3]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{4}, std::chrono::weekday_indexed{std::chrono::weekday{4}, 4}}),
-             SV(" 4/木[4]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{5}, std::chrono::weekday_indexed{std::chrono::weekday{5}, 5}}),
-             SV(" 5/金[5]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{6}, std::chrono::weekday_indexed{std::chrono::weekday{6}, 6}}),
-             SV(" 6/土[6 is not a valid index]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{7}, std::chrono::weekday_indexed{std::chrono::weekday{7}, 7}}),
-             SV(" 7/日[7 is not a valid index]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{8}, std::chrono::weekday_indexed{std::chrono::weekday{8}, 0}}),
-             SV(" 8/8 is not a valid weekday[0 is not a valid index]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
-                 std::chrono::month{9}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
-             SV(" 9/日[1]"));
-#  else  // defined(__APPLE__)
+#if defined(_WIN32)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday{1}, 1}}),
              SV("1/月[1]"));
@@ -274,7 +197,6 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{9}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
              SV("9/日[1]"));
-#  endif // defined(__APPLE__)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{10}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
              SV("10/日[1]"));
@@ -284,7 +206,7 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{12}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
              SV("12/日[1]"));
-#else // defined(__APPLE__) || defined(_WIN32)
+#else // defined(_WIN32)
 #  if defined(_AIX)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday{1}, 1}}),
@@ -351,7 +273,7 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{12}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
              SV("12月/日[1]"));
-#endif   // defined(__APPLE__) || defined(_WIN32)
+#endif   // defined(_WIN32)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday{
                  std::chrono::month{13}, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}}),
              SV("13 is not a valid month/日[1]"));

--- a/libcxx/test/std/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/ostream.pass.cpp
@@ -114,50 +114,6 @@ static void test() {
                  std::chrono::month{255}, std::chrono::weekday_last{std::chrono::weekday{8}}}),
              SV("255 is not a valid month/8 is not a valid weekday[last]"));
 
-#if defined(__APPLE__)
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{0}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-             SV("0 is not a valid month/Dim[last]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-             SV("jan/Dim[last]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{2}, std::chrono::weekday_last{std::chrono::weekday{1}}}),
-             SV("fév/Lun[last]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{3}, std::chrono::weekday_last{std::chrono::weekday{2}}}),
-             SV("mar/Mar[last]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{4}, std::chrono::weekday_last{std::chrono::weekday{3}}}),
-             SV("avr/Mer[last]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{5}, std::chrono::weekday_last{std::chrono::weekday{4}}}),
-             SV("mai/Jeu[last]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{6}, std::chrono::weekday_last{std::chrono::weekday{5}}}),
-             SV("jui/Ven[last]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{7}, std::chrono::weekday_last{std::chrono::weekday{6}}}),
-             SV("jul/Sam[last]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{8}, std::chrono::weekday_last{std::chrono::weekday{7}}}),
-             SV("aoû/Dim[last]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{9}, std::chrono::weekday_last{std::chrono::weekday{8}}}),
-             SV("sep/8 is not a valid weekday[last]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{10}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-             SV("oct/Dim[last]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{11}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-             SV("nov/Dim[last]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{12}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-             SV("déc/Dim[last]"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{13}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-             SV("13 is not a valid month/Dim[last]"));
-#else //  defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{0}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
              SV("0 is not a valid month/dim.[last]"));
@@ -170,15 +126,15 @@ static void test() {
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{3}, std::chrono::weekday_last{std::chrono::weekday{2}}}),
              SV("mars/mar.[last]"));
-#  if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__) || defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{4}, std::chrono::weekday_last{std::chrono::weekday{3}}}),
              SV("avr./mer.[last]"));
-#  else  // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#else  // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{4}, std::chrono::weekday_last{std::chrono::weekday{3}}}),
              SV("avril/mer.[last]"));
-#  endif // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#endif // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{5}, std::chrono::weekday_last{std::chrono::weekday{4}}}),
              SV("mai/jeu.[last]"));
@@ -206,44 +162,14 @@ static void test() {
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{13}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
              SV("13 is not a valid month/dim.[last]"));
-#endif   //  defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{255}, std::chrono::weekday_last{std::chrono::weekday{8}}}),
              SV("255 is not a valid month/8 is not a valid weekday[last]"));
 
-#if defined(__APPLE__) || defined(_WIN32)
+#if defined(_WIN32)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{0}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
              SV("0 is not a valid month/日[last]"));
-#  if defined(__APPLE__)
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-             SV(" 1/日[last]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{2}, std::chrono::weekday_last{std::chrono::weekday{1}}}),
-             SV(" 2/月[last]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{3}, std::chrono::weekday_last{std::chrono::weekday{2}}}),
-             SV(" 3/火[last]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{4}, std::chrono::weekday_last{std::chrono::weekday{3}}}),
-             SV(" 4/水[last]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{5}, std::chrono::weekday_last{std::chrono::weekday{4}}}),
-             SV(" 5/木[last]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{6}, std::chrono::weekday_last{std::chrono::weekday{5}}}),
-             SV(" 6/金[last]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{7}, std::chrono::weekday_last{std::chrono::weekday{6}}}),
-             SV(" 7/土[last]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{8}, std::chrono::weekday_last{std::chrono::weekday{7}}}),
-             SV(" 8/日[last]"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
-                 std::chrono::month{9}, std::chrono::weekday_last{std::chrono::weekday{8}}}),
-             SV(" 9/8 is not a valid weekday[last]"));
-#  else  // defined(__APPLE__)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
              SV("1/日[last]"));
@@ -271,7 +197,6 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{9}, std::chrono::weekday_last{std::chrono::weekday{8}}}),
              SV("9/8 is not a valid weekday[last]"));
-#  endif // defined(__APPLE__)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{10}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
              SV("10/日[last]"));
@@ -281,7 +206,7 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{12}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
              SV("12/日[last]"));
-#else // defined(__APPLE__) || defined(_WIN32)
+#else // defined(_WIN32)
 #  if defined(_AIX)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{0}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
@@ -354,7 +279,7 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{12}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
              SV("12月/日[last]"));
-#endif   // defined(__APPLE__) || defined(_WIN32)
+#endif   // defined(_WIN32)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::month_weekday_last{
                  std::chrono::month{13}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
              SV("13 is not a valid month/日[last]"));

--- a/libcxx/test/std/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/ostream.pass.cpp
@@ -76,21 +76,6 @@ static void test() {
   assert(stream_c_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(255), 1}) ==
          SV("255 is not a valid weekday[1]"));
 
-#if defined(__APPLE__)
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(0), 1}) == SV("Dim[1]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(1), 2}) == SV("Lun[2]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(2), 3}) == SV("Mar[3]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(3), 4}) == SV("Mer[4]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(4), 5}) == SV("Jeu[5]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(5), 0}) ==
-         SV("Ven[0 is not a valid index]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(6), 6}) ==
-         SV("Sam[6 is not a valid index]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(7), 7}) ==
-         SV("Dim[7 is not a valid index]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(255), 1}) ==
-         SV("255 is not a valid weekday[1]"));
-#else  // defined(__APPLE__)
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(0), 1}) == SV("dim.[1]"));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(1), 2}) == SV("lun.[2]"));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(2), 3}) == SV("mar.[3]"));
@@ -102,7 +87,6 @@ static void test() {
          SV("sam.[6 is not a valid index]"));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(7), 7}) ==
          SV("dim.[7 is not a valid index]"));
-#endif // defined(__APPLE__)
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(8), 0}) ==
          SV("8 is not a valid weekday[0 is not a valid index]"));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_indexed{std::chrono::weekday(255), 1}) ==

--- a/libcxx/test/std/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/ostream.pass.cpp
@@ -73,16 +73,6 @@ static void test() {
   assert(stream_c_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{255}}) ==
          SV("255 is not a valid weekday[last]"));
 
-#if defined(__APPLE__)
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{0}}) == SV("Dim[last]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{1}}) == SV("Lun[last]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{2}}) == SV("Mar[last]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{3}}) == SV("Mer[last]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{4}}) == SV("Jeu[last]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{5}}) == SV("Ven[last]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{6}}) == SV("Sam[last]"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{7}}) == SV("Dim[last]"));
-#else  // defined(__APPLE__)
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{0}}) == SV("dim.[last]"));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{1}}) == SV("lun.[last]"));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{2}}) == SV("mar.[last]"));
@@ -91,7 +81,6 @@ static void test() {
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{5}}) == SV("ven.[last]"));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{6}}) == SV("sam.[last]"));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{7}}) == SV("dim.[last]"));
-#endif // defined(__APPLE__)
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{8}}) ==
          SV("8 is not a valid weekday[last]"));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday_last{std::chrono::weekday{255}}) ==

--- a/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/ostream.pass.cpp
@@ -71,16 +71,6 @@ static void test() {
   assert(stream_c_locale<CharT>(std::chrono::weekday(8)) == SV("8 is not a valid weekday"));
   assert(stream_c_locale<CharT>(std::chrono::weekday(255)) == SV("255 is not a valid weekday"));
 
-#if defined(__APPLE__)
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(0)) == SV("Dim"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(1)) == SV("Lun"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(2)) == SV("Mar"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(3)) == SV("Mer"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(4)) == SV("Jeu"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(5)) == SV("Ven"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(6)) == SV("Sam"));
-  assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(7)) == SV("Dim"));
-#else
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(0)) == SV("dim."));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(1)) == SV("lun."));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(2)) == SV("mar."));
@@ -89,7 +79,6 @@ static void test() {
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(5)) == SV("ven."));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(6)) == SV("sam."));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(7)) == SV("dim."));
-#endif
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(8)) == SV("8 is not a valid weekday"));
   assert(stream_fr_FR_locale<CharT>(std::chrono::weekday(255)) == SV("255 is not a valid weekday"));
 

--- a/libcxx/test/std/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/ostream.pass.cpp
@@ -101,45 +101,20 @@ static void test() {
 
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{-32'768}, std::chrono::month{0}}),
              SV("-32768 is not a valid year/0 is not a valid month"));
-#if defined(__APPLE__)
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{-32'768}, std::chrono::month{1}}),
-             SV("-32768 is not a valid year/jan"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{-32'767}, std::chrono::month{2}}),
-             SV("-32767/fév"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{3}}),
-             SV("0000/mar"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{1970}, std::chrono::month{4}}),
-             SV("1970/avr"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{32'767}, std::chrono::month{5}}),
-             SV("32767/mai"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{6}}),
-             SV("0000/jui"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{7}}),
-             SV("0000/jul"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{8}}),
-             SV("0000/aoû"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{9}}),
-             SV("0000/sep"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{10}}),
-             SV("0000/oct"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{11}}),
-             SV("0000/nov"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{12}}),
-             SV("0000/déc"));
-#else //  defined(__APPLE__)
+
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{-32'768}, std::chrono::month{1}}),
              SV("-32768 is not a valid year/janv."));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{-32'767}, std::chrono::month{2}}),
              SV("-32767/févr."));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{3}}),
              SV("0000/mars"));
-#  if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__) || defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{1970}, std::chrono::month{4}}),
              SV("1970/avr."));
-#  else  // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#else
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{1970}, std::chrono::month{4}}),
              SV("1970/avril"));
-#  endif // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#endif
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{32'767}, std::chrono::month{5}}),
              SV("32767/mai"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{6}}),
@@ -156,7 +131,6 @@ static void test() {
              SV("0000/nov."));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{12}}),
              SV("0000/déc."));
-#endif   // defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{13}}),
              SV("0000/13 is not a valid month"));
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month{std::chrono::year{-32'768}, std::chrono::month{255}}),
@@ -164,27 +138,7 @@ static void test() {
 
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{-32'768}, std::chrono::month{0}}),
              SV("-32768 is not a valid year/0 is not a valid month"));
-#if defined(__APPLE__) || defined(_WIN32)
-#  if defined(__APPLE__)
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{-32'768}, std::chrono::month{1}}),
-             SV("-32768 is not a valid year/ 1"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{-32'767}, std::chrono::month{2}}),
-             SV("-32767/ 2"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{3}}),
-             SV("0000/ 3"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{1970}, std::chrono::month{4}}),
-             SV("1970/ 4"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{32'767}, std::chrono::month{5}}),
-             SV("32767/ 5"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{6}}),
-             SV("0000/ 6"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{7}}),
-             SV("0000/ 7"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{8}}),
-             SV("0000/ 8"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{9}}),
-             SV("0000/ 9"));
-#  else  // defined(__APPLE__)
+#if defined(_WIN32)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{-32'768}, std::chrono::month{1}}),
              SV("-32768 is not a valid year/1"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{-32'767}, std::chrono::month{2}}),
@@ -203,7 +157,6 @@ static void test() {
              SV("0000/8"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{9}}),
              SV("0000/9"));
-#  endif // defined(__APPLE__)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{10}}),
              SV("0000/10"));
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month{std::chrono::year{0}, std::chrono::month{11}}),

--- a/libcxx/test/std/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/ostream.pass.cpp
@@ -117,44 +117,7 @@ static void test() {
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{0}}}),
              SV("0000/0 is not a valid month/last"));
-#if defined(__APPLE__)
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{-32'768}, std::chrono::month_day_last{std::chrono::month{1}}}),
-             SV("-32768 is not a valid year/jan/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{-32'767}, std::chrono::month_day_last{std::chrono::month{2}}}),
-             SV("-32767/fév/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{3}}}),
-             SV("0000/mar/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::month{4}}}),
-             SV("1970/avr/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{32'767}, std::chrono::month_day_last{std::chrono::month{5}}}),
-             SV("32767/mai/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{6}}}),
-             SV("0000/jui/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{7}}}),
-             SV("0000/jul/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{8}}}),
-             SV("0000/aoû/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{9}}}),
-             SV("0000/sep/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{10}}}),
-             SV("0000/oct/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{11}}}),
-             SV("0000/nov/last"));
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{12}}}),
-             SV("0000/déc/last"));
-#else //  defined(__APPLE__)
+
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{-32'768}, std::chrono::month_day_last{std::chrono::month{1}}}),
              SV("-32768 is not a valid year/janv./last"));
@@ -164,15 +127,15 @@ static void test() {
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{3}}}),
              SV("0000/mars/last"));
-#  if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__) || defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::month{4}}}),
              SV("1970/avr./last"));
-#  else  // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#else
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::month{4}}}),
              SV("1970/avril/last"));
-#  endif // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#endif
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{32'767}, std::chrono::month_day_last{std::chrono::month{5}}}),
              SV("32767/mai/last"));
@@ -197,7 +160,6 @@ static void test() {
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{12}}}),
              SV("0000/déc./last"));
-#endif   //  defined(__APPLE__)
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{13}}}),
              SV("0000/13 is not a valid month/last"));
@@ -208,36 +170,7 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{0}}}),
              SV("0000/0 is not a valid month/last"));
-#if defined(__APPLE__) || defined(_WIN32)
-#  if defined(__APPLE__)
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{-32'768}, std::chrono::month_day_last{std::chrono::month{1}}}),
-             SV("-32768 is not a valid year/ 1/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{-32'767}, std::chrono::month_day_last{std::chrono::month{2}}}),
-             SV("-32767/ 2/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{3}}}),
-             SV("0000/ 3/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::month{4}}}),
-             SV("1970/ 4/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{32'767}, std::chrono::month_day_last{std::chrono::month{5}}}),
-             SV("32767/ 5/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{6}}}),
-             SV("0000/ 6/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{7}}}),
-             SV("0000/ 7/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{8}}}),
-             SV("0000/ 8/last"));
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
-                 std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{9}}}),
-             SV("0000/ 9/last"));
-#  else  // defined(__APPLE__)
+#if defined(_WIN32)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{-32'768}, std::chrono::month_day_last{std::chrono::month{1}}}),
              SV("-32768 is not a valid year/1/last"));
@@ -265,7 +198,6 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{9}}}),
              SV("0000/9/last"));
-#  endif // defined(__APPLE__)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{10}}}),
              SV("0000/10/last"));
@@ -275,7 +207,7 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{12}}}),
              SV("0000/12/last"));
-#else // defined(__APPLE__) || defined(_WIN32)
+#else // defined(_WIN32)
 #  if defined(_AIX)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{-32'768}, std::chrono::month_day_last{std::chrono::month{1}}}),
@@ -342,7 +274,7 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{12}}}),
              SV("0000/12月/last"));
-#endif   // defined(__APPLE__) || defined(_WIN32)
+#endif   // defined(_WIN32)
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_day_last{
                  std::chrono::year{0}, std::chrono::month_day_last{std::chrono::month{13}}}),
              SV("0000/13 is not a valid month/last"));

--- a/libcxx/test/std/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/ostream.pass.cpp
@@ -94,33 +94,6 @@ static void test() {
           std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
       SV("1970/Jan/Sun[1]"));
 
-#if defined(__APPLE__)
-  TEST_EQUAL(
-      stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday{
-          std::chrono::year{-32'768}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
-      SV("-32768 is not a valid year/jan/Dim[1]"));
-  TEST_EQUAL(
-      stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday{
-          std::chrono::year{-32'767}, std::chrono::month{0}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
-      SV("-32767/0 is not a valid month/Dim[1]"));
-  TEST_EQUAL(
-      stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday{
-          std::chrono::year{-32'767}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(8), 1}}),
-      SV("-32767/jan/8 is not a valid weekday[1]"));
-  TEST_EQUAL(
-      stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday{
-          std::chrono::year{-32'767}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 0}}),
-      SV("-32767/jan/Dim[0 is not a valid index]")); // note 0 is a valid index here...
-  TEST_EQUAL(
-      stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday{
-          std::chrono::year{-32'767}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
-      SV("-32767/jan/Dim[1]"));
-
-  TEST_EQUAL(
-      stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday{
-          std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
-      SV("1970/jan/Dim[1]"));
-#else  //  defined(__APPLE__)
   TEST_EQUAL(
       stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday{
           std::chrono::year{-32'768}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
@@ -146,34 +119,8 @@ static void test() {
       stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday{
           std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
       SV("1970/janv./dim.[1]"));
-#endif //  defined(__APPLE__)
 
-#if defined(__APPLE__)
-  TEST_EQUAL(
-      stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday{
-          std::chrono::year{-32'768}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
-      SV("-32768 is not a valid year/ 1/日[1]"));
-  TEST_EQUAL(
-      stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday{
-          std::chrono::year{-32'767}, std::chrono::month{0}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
-      SV("-32767/0 is not a valid month/日[1]"));
-  TEST_EQUAL(
-      stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday{
-          std::chrono::year{-32'767}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(8), 1}}),
-      SV("-32767/ 1/8 is not a valid weekday[1]"));
-  TEST_EQUAL(
-      stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday{
-          std::chrono::year{-32'767}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 0}}),
-      SV("-32767/ 1/日[0 is not a valid index]")); // note 0 is a valid index here...
-  TEST_EQUAL(
-      stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday{
-          std::chrono::year{-32'767}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
-      SV("-32767/ 1/日[1]"));
-  TEST_EQUAL(
-      stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday{
-          std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
-      SV("1970/ 1/日[1]"));
-#elif defined(_WIN32) // defined(__APPLE__)
+#if defined(_WIN32)
   TEST_EQUAL(
       stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday{
           std::chrono::year{-32'768}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
@@ -199,7 +146,7 @@ static void test() {
       stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday{
           std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
       SV("1970/1/日[1]"));
-#elif defined(_AIX)   // defined(__APPLE__)
+#elif defined(_AIX)
   TEST_EQUAL(
       stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday{
           std::chrono::year{-32'768}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
@@ -226,7 +173,7 @@ static void test() {
       stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday{
           std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
       SV("1970/1月/日[1]"));
-#else                 // defined(__APPLE__)
+#else
   TEST_EQUAL(
       stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday{
           std::chrono::year{-32'768}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
@@ -252,7 +199,7 @@ static void test() {
       stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday{
           std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_indexed{std::chrono::weekday(0), 1}}),
       SV("1970/ 1月/日[1]"));
-#endif                // defined(__APPLE__)
+#endif
 }
 
 int main(int, char**) {

--- a/libcxx/test/std/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/ostream.pass.cpp
@@ -89,28 +89,6 @@ static void test() {
                  std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
              SV("1970/Jan/Sun[last]"));
 
-#if defined(__APPLE__)
-  TEST_EQUAL(
-      stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday_last{
-          std::chrono::year{-32'768}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-      SV("-32768 is not a valid year/jan/Dim[last]"));
-  TEST_EQUAL(
-      stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday_last{
-          std::chrono::year{-32'767}, std::chrono::month{0}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-      SV("-32767/0 is not a valid month/Dim[last]"));
-  TEST_EQUAL(
-      stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday_last{
-          std::chrono::year{-32'767}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{8}}}),
-      SV("-32767/jan/8 is not a valid weekday[last]"));
-  TEST_EQUAL(
-      stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday_last{
-          std::chrono::year{-32'767}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-      SV("-32767/jan/Dim[last]"));
-
-  TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday_last{
-                 std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-             SV("1970/jan/Dim[last]"));
-#else  //  defined(__APPLE__)
   TEST_EQUAL(
       stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday_last{
           std::chrono::year{-32'768}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
@@ -131,30 +109,8 @@ static void test() {
   TEST_EQUAL(stream_fr_FR_locale<CharT>(std::chrono::year_month_weekday_last{
                  std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
              SV("1970/janv./dim.[last]"));
-#endif //  defined(__APPLE__)
 
-#if defined(__APPLE__)
-  TEST_EQUAL(
-      stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday_last{
-          std::chrono::year{-32'768}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-      SV("-32768 is not a valid year/ 1/日[last]"));
-  TEST_EQUAL(
-      stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday_last{
-          std::chrono::year{-32'767}, std::chrono::month{0}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-      SV("-32767/0 is not a valid month/日[last]"));
-  TEST_EQUAL(
-      stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday_last{
-          std::chrono::year{-32'767}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{8}}}),
-      SV("-32767/ 1/8 is not a valid weekday[last]"));
-  TEST_EQUAL(
-      stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday_last{
-          std::chrono::year{-32'767}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-      SV("-32767/ 1/日[last]"));
-
-  TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday_last{
-                 std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
-             SV("1970/ 1/日[last]"));
-#elif defined(_WIN32) // defined(__APPLE__)
+#if defined(_WIN32)
   TEST_EQUAL(
       stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday_last{
           std::chrono::year{-32'768}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
@@ -175,7 +131,7 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday_last{
                  std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
              SV("1970/1/日[last]"));
-#elif defined(_AIX)   // defined(__APPLE__)
+#elif defined(_AIX)
   TEST_EQUAL(
       stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday_last{
           std::chrono::year{-32'768}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
@@ -197,7 +153,7 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday_last{
                  std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
              SV("1970/1月/日[last]"));
-#else                 // defined(__APPLE__)
+#else
   TEST_EQUAL(
       stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday_last{
           std::chrono::year{-32'768}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
@@ -218,7 +174,7 @@ static void test() {
   TEST_EQUAL(stream_ja_JP_locale<CharT>(std::chrono::year_month_weekday_last{
                  std::chrono::year{1970}, std::chrono::month{1}, std::chrono::weekday_last{std::chrono::weekday{0}}}),
              SV("1970/ 1月/日[last]"));
-#endif                // defined(__APPLE__)
+#endif
 }
 
 int main(int, char**) {

--- a/libcxx/test/std/time/time.syn/formatter.file_time.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.file_time.pass.cpp
@@ -155,15 +155,9 @@ static void test_valid_values_month() {
         file_seconds(2'000'000'000s)); // 03:33:20 UTC on Wednesday, 18 May 2033
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%b='jan'\t%h='jan'\t%B='janvier'\t%m='01'\t%Om='01'\n"),
-        lfmt,
-        file_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
-#else
   check(SV("%b='janv.'\t%h='janv.'\t%B='janvier'\t%m='01'\t%Om='01'\n"),
         lfmt,
         file_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
-#endif
 
   check(SV("%b='mai'\t%h='mai'\t%B='mai'\t%m='05'\t%Om='05'\n"),
         lfmt,
@@ -180,7 +174,7 @@ static void test_valid_values_month() {
         SV("%b='5'\t%h='5'\t%B='5月'\t%m='05'\t%Om='05'\n"),
         lfmt,
         file_seconds(2'000'000'000s)); // 03:33:20 UTC on Wednesday, 18 May 2033
-#elif defined(_AIX)                    // _WIN32
+#elif defined(_AIX)
   check(loc,
         SV("%b='1月'\t%h='1月'\t%B='1月'\t%m='01'\t%Om='01'\n"),
         lfmt,
@@ -190,17 +184,7 @@ static void test_valid_values_month() {
         SV("%b='5月'\t%h='5月'\t%B='5月'\t%m='05'\t%Om='05'\n"),
         lfmt,
         file_seconds(2'000'000'000s)); // 03:33:20 UTC on Wednesday, 18 May 2033
-#elif defined(__APPLE__)               // _WIN32
-  check(loc,
-        SV("%b=' 1'\t%h=' 1'\t%B='1月'\t%m='01'\t%Om='01'\n"),
-        lfmt,
-        file_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
-
-  check(loc,
-        SV("%b=' 5'\t%h=' 5'\t%B='5月'\t%m='05'\t%Om='05'\n"),
-        lfmt,
-        file_seconds(2'000'000'000s)); // 03:33:20 UTC on Wednesday, 18 May 2033
-#elif defined(__FreeBSD__)             // _WIN32
+#elif defined(__FreeBSD__) || defined(__APPLE__) // _WIN32
   check(loc,
         SV("%b=' 1月'\t%h=' 1月'\t%B='1月'\t%m='01'\t%Om='01'\n"),
         lfmt,
@@ -300,15 +284,6 @@ static void test_valid_values_weekday() {
         file_seconds(4'294'967'295s)); // 06:28:15 UTC on Sunday, 7 February 2106
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%a='Jeu'\t%A='Jeudi'\t%u='4'\t%Ou='4'\t%w='4'\t%Ow='4'\n"),
-        lfmt,
-        file_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
-
-  check(SV("%a='Dim'\t%A='Dimanche'\t%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\n"),
-        lfmt,
-        file_seconds(4'294'967'295s)); // 06:28:15 UTC on Sunday, 7 February 2106
-#else
   check(SV("%a='jeu.'\t%A='jeudi'\t%u='4'\t%Ou='4'\t%w='4'\t%Ow='4'\n"),
         lfmt,
         file_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
@@ -316,7 +291,6 @@ static void test_valid_values_weekday() {
   check(SV("%a='dim.'\t%A='dimanche'\t%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\n"),
         lfmt,
         file_seconds(4'294'967'295s)); // 06:28:15 UTC on Sunday, 7 February 2106
-#endif
 
   // Use supplied locale (ja_JP).
   // This locale has a different alternate, but not on all platforms
@@ -812,11 +786,9 @@ static void test_valid_values_date_time() {
       SV("%c='jeu. 01 janv. 1970 00:00:00 GMT'\t%Ec='jeu. 01 janv. 1970 00:00:00 GMT'\n"),
 #elif defined(_AIX)
       SV("%c=' 1 janvier 1970 à 00:00:00 UTC'\t%Ec=' 1 janvier 1970 à 00:00:00 UTC'\n"),
-#elif defined(__APPLE__)
-      SV("%c='Jeu  1 jan 00:00:00 1970'\t%Ec='Jeu  1 jan 00:00:00 1970'\n"),
 #elif defined(_WIN32)
       SV("%c='01/01/1970 00:00:00'\t%Ec='01/01/1970 00:00:00'\n"),
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__APPLE__)
       SV("%c='jeu.  1 janv. 00:00:00 1970'\t%Ec='jeu.  1 janv. 00:00:00 1970'\n"),
 #else
       SV("%c='jeu. 01 janv. 1970 00:00:00'\t%Ec='jeu. 01 janv. 1970 00:00:00'\n"),
@@ -832,11 +804,9 @@ static void test_valid_values_date_time() {
       SV("%c='ven. 13 févr. 2009 23:31:30 GMT'\t%Ec='ven. 13 févr. 2009 23:31:30 GMT'\n"),
 #elif defined(_AIX)
       SV("%c='13 février 2009 à 23:31:30 UTC'\t%Ec='13 février 2009 à 23:31:30 UTC'\n"),
-#elif defined(__APPLE__)
-      SV("%c='Ven 13 fév 23:31:30 2009'\t%Ec='Ven 13 fév 23:31:30 2009'\n"),
 #elif defined(_WIN32)
       SV("%c='13/02/2009 23:31:30'\t%Ec='13/02/2009 23:31:30'\n"),
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__APPLE__)
       SV("%c='ven. 13 févr. 23:31:30 2009'\t%Ec='ven. 13 févr. 23:31:30 2009'\n"),
 #else
       SV("%c='ven. 13 févr. 2009 23:31:30'\t%Ec='ven. 13 févr. 2009 23:31:30'\n"),

--- a/libcxx/test/std/time/time.syn/formatter.local_time.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.local_time.pass.cpp
@@ -147,15 +147,9 @@ static void test_valid_values_month() {
         std::chrono::local_seconds(2'000'000'000s)); // 03:33:20 UTC on Wednesday, 18 May 2033
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%b='jan'\t%h='jan'\t%B='janvier'\t%m='01'\t%Om='01'\n"),
-        lfmt,
-        std::chrono::local_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
-#else
   check(SV("%b='janv.'\t%h='janv.'\t%B='janvier'\t%m='01'\t%Om='01'\n"),
         lfmt,
         std::chrono::local_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
-#endif
 
   check(SV("%b='mai'\t%h='mai'\t%B='mai'\t%m='05'\t%Om='05'\n"),
         lfmt,
@@ -182,17 +176,7 @@ static void test_valid_values_month() {
         SV("%b='5月'\t%h='5月'\t%B='5月'\t%m='05'\t%Om='05'\n"),
         lfmt,
         std::chrono::local_seconds(2'000'000'000s)); // 03:33:20 UTC on Wednesday, 18 May 2033
-#elif defined(__APPLE__)                             // _WIN32
-  check(loc,
-        SV("%b=' 1'\t%h=' 1'\t%B='1月'\t%m='01'\t%Om='01'\n"),
-        lfmt,
-        std::chrono::local_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
-
-  check(loc,
-        SV("%b=' 5'\t%h=' 5'\t%B='5月'\t%m='05'\t%Om='05'\n"),
-        lfmt,
-        std::chrono::local_seconds(2'000'000'000s)); // 03:33:20 UTC on Wednesday, 18 May 2033
-#elif defined(__FreeBSD__)                           // _WIN32
+#elif defined(__FreeBSD__) || defined(__APPLE__)     // _WIN32
   check(loc,
         SV("%b=' 1月'\t%h=' 1月'\t%B='1月'\t%m='01'\t%Om='01'\n"),
         lfmt,
@@ -294,15 +278,6 @@ static void test_valid_values_weekday() {
         std::chrono::local_seconds(4'294'967'295s)); // 06:28:15 UTC on Sunday, 7 February 2106
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%a='Jeu'\t%A='Jeudi'\t%u='4'\t%Ou='4'\t%w='4'\t%Ow='4'\n"),
-        lfmt,
-        std::chrono::local_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
-
-  check(SV("%a='Dim'\t%A='Dimanche'\t%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\n"),
-        lfmt,
-        std::chrono::local_seconds(4'294'967'295s)); // 06:28:15 UTC on Sunday, 7 February 2106
-#else
   check(SV("%a='jeu.'\t%A='jeudi'\t%u='4'\t%Ou='4'\t%w='4'\t%Ow='4'\n"),
         lfmt,
         std::chrono::local_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
@@ -310,7 +285,6 @@ static void test_valid_values_weekday() {
   check(SV("%a='dim.'\t%A='dimanche'\t%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\n"),
         lfmt,
         std::chrono::local_seconds(4'294'967'295s)); // 06:28:15 UTC on Sunday, 7 February 2106
-#endif
 
   // Use supplied locale (ja_JP).
   // This locale has a different alternate, but not on all platforms
@@ -811,11 +785,9 @@ static void test_valid_values_date_time() {
       SV("%c='jeu. 01 janv. 1970 00:00:00 GMT'\t%Ec='jeu. 01 janv. 1970 00:00:00 GMT'\n"),
 #elif defined(_AIX)
       SV("%c=' 1 janvier 1970 à 00:00:00 UTC'\t%Ec=' 1 janvier 1970 à 00:00:00 UTC'\n"),
-#elif defined(__APPLE__)
-      SV("%c='Jeu  1 jan 00:00:00 1970'\t%Ec='Jeu  1 jan 00:00:00 1970'\n"),
 #elif defined(_WIN32)
       SV("%c='01/01/1970 00:00:00'\t%Ec='01/01/1970 00:00:00'\n"),
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__APPLE__)
       SV("%c='jeu.  1 janv. 00:00:00 1970'\t%Ec='jeu.  1 janv. 00:00:00 1970'\n"),
 #else
       SV("%c='jeu. 01 janv. 1970 00:00:00'\t%Ec='jeu. 01 janv. 1970 00:00:00'\n"),
@@ -831,11 +803,9 @@ static void test_valid_values_date_time() {
       SV("%c='ven. 13 févr. 2009 23:31:30 GMT'\t%Ec='ven. 13 févr. 2009 23:31:30 GMT'\n"),
 #elif defined(_AIX)
       SV("%c='13 février 2009 à 23:31:30 UTC'\t%Ec='13 février 2009 à 23:31:30 UTC'\n"),
-#elif defined(__APPLE__)
-      SV("%c='Ven 13 fév 23:31:30 2009'\t%Ec='Ven 13 fév 23:31:30 2009'\n"),
 #elif defined(_WIN32)
       SV("%c='13/02/2009 23:31:30'\t%Ec='13/02/2009 23:31:30'\n"),
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__APPLE__)
       SV("%c='ven. 13 févr. 23:31:30 2009'\t%Ec='ven. 13 févr. 23:31:30 2009'\n"),
 #else
       SV("%c='ven. 13 févr. 2009 23:31:30'\t%Ec='ven. 13 févr. 2009 23:31:30'\n"),

--- a/libcxx/test/std/time/time.syn/formatter.month.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.month.pass.cpp
@@ -83,28 +83,14 @@ static void test_valid_values() {
   check(SV("%b='Dec'\t%B='December'\t%h='Dec'\t%m='12'\t%Om='12'\n"), fmt, std::chrono::December);
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%b='jan'\t%B='janvier'\t%h='jan'\t%m='01'\t%Om='01'\n"), lfmt, std::chrono::January);
-  check(SV("%b='fév'\t%B='février'\t%h='fév'\t%m='02'\t%Om='02'\n"), lfmt, std::chrono::February);
-  check(SV("%b='mar'\t%B='mars'\t%h='mar'\t%m='03'\t%Om='03'\n"), lfmt, std::chrono::March);
-  check(SV("%b='avr'\t%B='avril'\t%h='avr'\t%m='04'\t%Om='04'\n"), lfmt, std::chrono::April);
-  check(SV("%b='mai'\t%B='mai'\t%h='mai'\t%m='05'\t%Om='05'\n"), lfmt, std::chrono::May);
-  check(SV("%b='jui'\t%B='juin'\t%h='jui'\t%m='06'\t%Om='06'\n"), lfmt, std::chrono::June);
-  check(SV("%b='jul'\t%B='juillet'\t%h='jul'\t%m='07'\t%Om='07'\n"), lfmt, std::chrono::July);
-  check(SV("%b='aoû'\t%B='août'\t%h='aoû'\t%m='08'\t%Om='08'\n"), lfmt, std::chrono::August);
-  check(SV("%b='sep'\t%B='septembre'\t%h='sep'\t%m='09'\t%Om='09'\n"), lfmt, std::chrono::September);
-  check(SV("%b='oct'\t%B='octobre'\t%h='oct'\t%m='10'\t%Om='10'\n"), lfmt, std::chrono::October);
-  check(SV("%b='nov'\t%B='novembre'\t%h='nov'\t%m='11'\t%Om='11'\n"), lfmt, std::chrono::November);
-  check(SV("%b='déc'\t%B='décembre'\t%h='déc'\t%m='12'\t%Om='12'\n"), lfmt, std::chrono::December);
-#else // defined(__APPLE__)
   check(SV("%b='janv.'\t%B='janvier'\t%h='janv.'\t%m='01'\t%Om='01'\n"), lfmt, std::chrono::January);
   check(SV("%b='févr.'\t%B='février'\t%h='févr.'\t%m='02'\t%Om='02'\n"), lfmt, std::chrono::February);
   check(SV("%b='mars'\t%B='mars'\t%h='mars'\t%m='03'\t%Om='03'\n"), lfmt, std::chrono::March);
-#  if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__) || defined(__APPLE__)
   check(SV("%b='avr.'\t%B='avril'\t%h='avr.'\t%m='04'\t%Om='04'\n"), lfmt, std::chrono::April);
-#  else
+#else
   check(SV("%b='avril'\t%B='avril'\t%h='avril'\t%m='04'\t%Om='04'\n"), lfmt, std::chrono::April);
-#  endif
+#endif
   check(SV("%b='mai'\t%B='mai'\t%h='mai'\t%m='05'\t%Om='05'\n"), lfmt, std::chrono::May);
   check(SV("%b='juin'\t%B='juin'\t%h='juin'\t%m='06'\t%Om='06'\n"), lfmt, std::chrono::June);
   check(SV("%b='juil.'\t%B='juillet'\t%h='juil.'\t%m='07'\t%Om='07'\n"), lfmt, std::chrono::July);
@@ -113,7 +99,6 @@ static void test_valid_values() {
   check(SV("%b='oct.'\t%B='octobre'\t%h='oct.'\t%m='10'\t%Om='10'\n"), lfmt, std::chrono::October);
   check(SV("%b='nov.'\t%B='novembre'\t%h='nov.'\t%m='11'\t%Om='11'\n"), lfmt, std::chrono::November);
   check(SV("%b='déc.'\t%B='décembre'\t%h='déc.'\t%m='12'\t%Om='12'\n"), lfmt, std::chrono::December);
-#endif // defined(__APPLE__)
 
   // Use supplied locale (ja_JP)
 #if defined(_WIN32)
@@ -129,7 +114,7 @@ static void test_valid_values() {
   check(loc, SV("%b='10'\t%B='10月'\t%h='10'\t%m='10'\t%Om='10'\n"), lfmt, std::chrono::October);
   check(loc, SV("%b='11'\t%B='11月'\t%h='11'\t%m='11'\t%Om='11'\n"), lfmt, std::chrono::November);
   check(loc, SV("%b='12'\t%B='12月'\t%h='12'\t%m='12'\t%Om='12'\n"), lfmt, std::chrono::December);
-#elif defined(_AIX)      // defined(_WIN32)
+#elif defined(_AIX)                              // defined(_WIN32)
   check(loc, SV("%b='1月'\t%B='1月'\t%h='1月'\t%m='01'\t%Om='01'\n"), lfmt, std::chrono::January);
   check(loc, SV("%b='2月'\t%B='2月'\t%h='2月'\t%m='02'\t%Om='02'\n"), lfmt, std::chrono::February);
   check(loc, SV("%b='3月'\t%B='3月'\t%h='3月'\t%m='03'\t%Om='03'\n"), lfmt, std::chrono::March);
@@ -142,7 +127,7 @@ static void test_valid_values() {
   check(loc, SV("%b='10月'\t%B='10月'\t%h='10月'\t%m='10'\t%Om='10'\n"), lfmt, std::chrono::October);
   check(loc, SV("%b='11月'\t%B='11月'\t%h='11月'\t%m='11'\t%Om='11'\n"), lfmt, std::chrono::November);
   check(loc, SV("%b='12月'\t%B='12月'\t%h='12月'\t%m='12'\t%Om='12'\n"), lfmt, std::chrono::December);
-#elif defined(__FreeBSD__) // defined(_WIN32)
+#elif defined(__FreeBSD__) || defined(__APPLE__) // defined(_WIN32)
   check(loc, SV("%b=' 1月'\t%B='1月'\t%h=' 1月'\t%m='01'\t%Om='01'\n"), lfmt, std::chrono::January);
   check(loc, SV("%b=' 2月'\t%B='2月'\t%h=' 2月'\t%m='02'\t%Om='02'\n"), lfmt, std::chrono::February);
   check(loc, SV("%b=' 3月'\t%B='3月'\t%h=' 3月'\t%m='03'\t%Om='03'\n"), lfmt, std::chrono::March);
@@ -155,20 +140,7 @@ static void test_valid_values() {
   check(loc, SV("%b='10月'\t%B='10月'\t%h='10月'\t%m='10'\t%Om='10'\n"), lfmt, std::chrono::October);
   check(loc, SV("%b='11月'\t%B='11月'\t%h='11月'\t%m='11'\t%Om='11'\n"), lfmt, std::chrono::November);
   check(loc, SV("%b='12月'\t%B='12月'\t%h='12月'\t%m='12'\t%Om='12'\n"), lfmt, std::chrono::December);
-#elif defined(__APPLE__) // defined(_WIN32)
-  check(loc, SV("%b=' 1'\t%B='1月'\t%h=' 1'\t%m='01'\t%Om='01'\n"), lfmt, std::chrono::January);
-  check(loc, SV("%b=' 2'\t%B='2月'\t%h=' 2'\t%m='02'\t%Om='02'\n"), lfmt, std::chrono::February);
-  check(loc, SV("%b=' 3'\t%B='3月'\t%h=' 3'\t%m='03'\t%Om='03'\n"), lfmt, std::chrono::March);
-  check(loc, SV("%b=' 4'\t%B='4月'\t%h=' 4'\t%m='04'\t%Om='04'\n"), lfmt, std::chrono::April);
-  check(loc, SV("%b=' 5'\t%B='5月'\t%h=' 5'\t%m='05'\t%Om='05'\n"), lfmt, std::chrono::May);
-  check(loc, SV("%b=' 6'\t%B='6月'\t%h=' 6'\t%m='06'\t%Om='06'\n"), lfmt, std::chrono::June);
-  check(loc, SV("%b=' 7'\t%B='7月'\t%h=' 7'\t%m='07'\t%Om='07'\n"), lfmt, std::chrono::July);
-  check(loc, SV("%b=' 8'\t%B='8月'\t%h=' 8'\t%m='08'\t%Om='08'\n"), lfmt, std::chrono::August);
-  check(loc, SV("%b=' 9'\t%B='9月'\t%h=' 9'\t%m='09'\t%Om='09'\n"), lfmt, std::chrono::September);
-  check(loc, SV("%b='10'\t%B='10月'\t%h='10'\t%m='10'\t%Om='10'\n"), lfmt, std::chrono::October);
-  check(loc, SV("%b='11'\t%B='11月'\t%h='11'\t%m='11'\t%Om='11'\n"), lfmt, std::chrono::November);
-  check(loc, SV("%b='12'\t%B='12月'\t%h='12'\t%m='12'\t%Om='12'\n"), lfmt, std::chrono::December);
-#else                    // defined(_WIN32)
+#else                                            // defined(_WIN32)
   check(loc, SV("%b=' 1月'\t%B='1月'\t%h=' 1月'\t%m='01'\t%Om='一'\n"), lfmt, std::chrono::January);
   check(loc, SV("%b=' 2月'\t%B='2月'\t%h=' 2月'\t%m='02'\t%Om='二'\n"), lfmt, std::chrono::February);
   check(loc, SV("%b=' 3月'\t%B='3月'\t%h=' 3月'\t%m='03'\t%Om='三'\n"), lfmt, std::chrono::March);
@@ -181,7 +153,7 @@ static void test_valid_values() {
   check(loc, SV("%b='10月'\t%B='10月'\t%h='10月'\t%m='10'\t%Om='十'\n"), lfmt, std::chrono::October);
   check(loc, SV("%b='11月'\t%B='11月'\t%h='11月'\t%m='11'\t%Om='十一'\n"), lfmt, std::chrono::November);
   check(loc, SV("%b='12月'\t%B='12月'\t%h='12月'\t%m='12'\t%Om='十二'\n"), lfmt, std::chrono::December);
-#endif                   //  defined(_WIN32)
+#endif                                           //  defined(_WIN32)
 
   std::locale::global(std::locale::classic());
 }

--- a/libcxx/test/std/time/time.syn/formatter.month_day.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.month_day.pass.cpp
@@ -179,53 +179,15 @@ static void test_valid_values() {
 #endif   // _WIN32
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%b='jan'\t%B='janvier'\t%h='jan'\t%m='01'\t%Om='01'\t%d='00'\t%e=' 0'\t%Od='00'\t%Oe=' 0'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::January, std::chrono::day{0}});
-  check(SV("%b='fév'\t%B='février'\t%h='fév'\t%m='02'\t%Om='02'\t%d='01'\t%e=' 1'\t%Od='01'\t%Oe=' 1'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::February, std::chrono::day{1}});
-  check(SV("%b='mar'\t%B='mars'\t%h='mar'\t%m='03'\t%Om='03'\t%d='09'\t%e=' 9'\t%Od='09'\t%Oe=' 9'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::March, std::chrono::day{9}});
-  check(SV("%b='avr'\t%B='avril'\t%h='avr'\t%m='04'\t%Om='04'\t%d='10'\t%e='10'\t%Od='10'\t%Oe='10'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::April, std::chrono::day{10}});
-  check(SV("%b='mai'\t%B='mai'\t%h='mai'\t%m='05'\t%Om='05'\t%d='28'\t%e='28'\t%Od='28'\t%Oe='28'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::May, std::chrono::day{28}});
-  check(SV("%b='jui'\t%B='juin'\t%h='jui'\t%m='06'\t%Om='06'\t%d='29'\t%e='29'\t%Od='29'\t%Oe='29'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::June, std::chrono::day{29}});
-  check(SV("%b='jul'\t%B='juillet'\t%h='jul'\t%m='07'\t%Om='07'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::July, std::chrono::day{30}});
-  check(SV("%b='aoû'\t%B='août'\t%h='aoû'\t%m='08'\t%Om='08'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::August, std::chrono::day{31}});
-  check(SV("%b='sep'\t%B='septembre'\t%h='sep'\t%m='09'\t%Om='09'\t%d='32'\t%e='32'\t%Od='32'\t%Oe='32'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::September, std::chrono::day{32}});
-  check(SV("%b='oct'\t%B='octobre'\t%h='oct'\t%m='10'\t%Om='10'\t%d='99'\t%e='99'\t%Od='99'\t%Oe='99'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::October, std::chrono::day{99}});
-  check(SV("%b='nov'\t%B='novembre'\t%h='nov'\t%m='11'\t%Om='11'\t%d='100'\t%e='100'\t%Od='100'\t%Oe='100'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::November, std::chrono::day{100}});
-  check(SV("%b='déc'\t%B='décembre'\t%h='déc'\t%m='12'\t%Om='12'\t%d='255'\t%e='255'\t%Od='255'\t%Oe='255'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::December, std::chrono::day{255}});
-#else // defined(__APPLE__)
-#  if defined(_WIN32)
+#if defined(_WIN32)
   check(SV("%b='janv.'\t%B='janvier'\t%h='janv.'\t%m='01'\t%Om='01'\t%d=''\t%e=''\t%Od=''\t%Oe=''\n"),
         lfmt,
         std::chrono::month_day{std::chrono::January, std::chrono::day{0}});
-#  else
+#else
   check(SV("%b='janv.'\t%B='janvier'\t%h='janv.'\t%m='01'\t%Om='01'\t%d='00'\t%e=' 0'\t%Od='00'\t%Oe=' 0'\n"),
         lfmt,
         std::chrono::month_day{std::chrono::January, std::chrono::day{0}});
-#  endif
+#endif
   check(SV("%b='févr.'\t%B='février'\t%h='févr.'\t%m='02'\t%Om='02'\t%d='01'\t%e=' 1'\t%Od='01'\t%Oe=' 1'\n"),
         lfmt,
         std::chrono::month_day{std::chrono::February, std::chrono::day{1}});
@@ -233,11 +195,11 @@ static void test_valid_values() {
         lfmt,
         std::chrono::month_day{std::chrono::March, std::chrono::day{9}});
   check(
-#  if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__) || defined(__APPLE__)
       SV("%b='avr.'\t%B='avril'\t%h='avr.'\t%m='04'\t%Om='04'\t%d='10'\t%e='10'\t%Od='10'\t%Oe='10'\n"),
-#  else  // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#else
       SV("%b='avril'\t%B='avril'\t%h='avril'\t%m='04'\t%Om='04'\t%d='10'\t%e='10'\t%Od='10'\t%Oe='10'\n"),
-#  endif // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#endif
       lfmt,
       std::chrono::month_day{std::chrono::April, std::chrono::day{10}});
   check(SV("%b='mai'\t%B='mai'\t%h='mai'\t%m='05'\t%Om='05'\t%d='28'\t%e='28'\t%Od='28'\t%Oe='28'\n"),
@@ -252,7 +214,7 @@ static void test_valid_values() {
   check(SV("%b='août'\t%B='août'\t%h='août'\t%m='08'\t%Om='08'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
         lfmt,
         std::chrono::month_day{std::chrono::August, std::chrono::day{31}});
-#  if defined(_WIN32)
+#if defined(_WIN32)
   check(SV("%b='sept.'\t%B='septembre'\t%h='sept.'\t%m='09'\t%Om='09'\t%d=''\t%e=''\t%Od=''\t%Oe=''\n"),
         lfmt,
         std::chrono::month_day{std::chrono::September, std::chrono::day{32}});
@@ -265,30 +227,29 @@ static void test_valid_values() {
   check(SV("%b='déc.'\t%B='décembre'\t%h='déc.'\t%m='12'\t%Om='12'\t%d=''\t%e=''\t%Od=''\t%Oe=''\n"),
         lfmt,
         std::chrono::month_day{std::chrono::December, std::chrono::day{255}});
-#  else // defined(_WIN32)
+#else // defined(_WIN32)
   check(SV("%b='sept.'\t%B='septembre'\t%h='sept.'\t%m='09'\t%Om='09'\t%d='32'\t%e='32'\t%Od='32'\t%Oe='32'\n"),
         lfmt,
         std::chrono::month_day{std::chrono::September, std::chrono::day{32}});
   check(SV("%b='oct.'\t%B='octobre'\t%h='oct.'\t%m='10'\t%Om='10'\t%d='99'\t%e='99'\t%Od='99'\t%Oe='99'\n"),
         lfmt,
         std::chrono::month_day{std::chrono::October, std::chrono::day{99}});
-#    if defined(_AIX)
+#  if defined(_AIX)
   check(SV("%b='nov.'\t%B='novembre'\t%h='nov.'\t%m='11'\t%Om='11'\t%d='00'\t%e=' 0'\t%Od='00'\t%Oe=' 0'\n"),
         lfmt,
         std::chrono::month_day{std::chrono::November, std::chrono::day{100}});
   check(SV("%b='déc.'\t%B='décembre'\t%h='déc.'\t%m='12'\t%Om='12'\t%d='55'\t%e='55'\t%Od='55'\t%Oe='55'\n"),
         lfmt,
         std::chrono::month_day{std::chrono::December, std::chrono::day{255}});
-#    else  //   defined(_AIX)
+#  else  //   defined(_AIX)
   check(SV("%b='nov.'\t%B='novembre'\t%h='nov.'\t%m='11'\t%Om='11'\t%d='100'\t%e='100'\t%Od='100'\t%Oe='100'\n"),
         lfmt,
         std::chrono::month_day{std::chrono::November, std::chrono::day{100}});
   check(SV("%b='déc.'\t%B='décembre'\t%h='déc.'\t%m='12'\t%Om='12'\t%d='255'\t%e='255'\t%Od='255'\t%Oe='255'\n"),
         lfmt,
         std::chrono::month_day{std::chrono::December, std::chrono::day{255}});
-#    endif //   defined(_AIX)
-#  endif   //   defined(_WIN32)
-#endif     // defined(__APPLE__)
+#  endif //   defined(_AIX)
+#endif   //   defined(_WIN32)
 
   // Use supplied locale (ja_JP)
 #if defined(_WIN32)
@@ -389,7 +350,7 @@ static void test_valid_values() {
         SV("%b='12月'\t%B='12月'\t%h='12月'\t%m='12'\t%Om='12'\t%d='55'\t%e='55'\t%Od='55'\t%Oe='55'\n"),
         lfmt,
         std::chrono::month_day{std::chrono::December, std::chrono::day{255}});
-#elif defined(__FreeBSD__) // defined(_WIN32)
+#elif defined(__FreeBSD__) || defined(__APPLE__) // defined(_WIN32)
   check(loc,
         SV("%b=' 1月'\t%B='1月'\t%h=' 1月'\t%m='01'\t%Om='01'\t%d='00'\t%e=' 0'\t%Od='00'\t%Oe=' 0'\n"),
         lfmt,
@@ -436,55 +397,6 @@ static void test_valid_values() {
         std::chrono::month_day{std::chrono::November, std::chrono::day{100}});
   check(loc,
         SV("%b='12月'\t%B='12月'\t%h='12月'\t%m='12'\t%Om='12'\t%d='255'\t%e='255'\t%Od='255'\t%Oe='255'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::December, std::chrono::day{255}});
-#elif defined(__APPLE__) // defined(_WIN32)
-  check(loc,
-        SV("%b=' 1'\t%B='1月'\t%h=' 1'\t%m='01'\t%Om='01'\t%d='00'\t%e=' 0'\t%Od='00'\t%Oe=' 0'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::January, std::chrono::day{0}});
-  check(loc,
-        SV("%b=' 2'\t%B='2月'\t%h=' 2'\t%m='02'\t%Om='02'\t%d='01'\t%e=' 1'\t%Od='01'\t%Oe=' 1'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::February, std::chrono::day{1}});
-  check(loc,
-        SV("%b=' 3'\t%B='3月'\t%h=' 3'\t%m='03'\t%Om='03'\t%d='09'\t%e=' 9'\t%Od='09'\t%Oe=' 9'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::March, std::chrono::day{9}});
-  check(loc,
-        SV("%b=' 4'\t%B='4月'\t%h=' 4'\t%m='04'\t%Om='04'\t%d='10'\t%e='10'\t%Od='10'\t%Oe='10'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::April, std::chrono::day{10}});
-  check(loc,
-        SV("%b=' 5'\t%B='5月'\t%h=' 5'\t%m='05'\t%Om='05'\t%d='28'\t%e='28'\t%Od='28'\t%Oe='28'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::May, std::chrono::day{28}});
-  check(loc,
-        SV("%b=' 6'\t%B='6月'\t%h=' 6'\t%m='06'\t%Om='06'\t%d='29'\t%e='29'\t%Od='29'\t%Oe='29'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::June, std::chrono::day{29}});
-  check(loc,
-        SV("%b=' 7'\t%B='7月'\t%h=' 7'\t%m='07'\t%Om='07'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::July, std::chrono::day{30}});
-  check(loc,
-        SV("%b=' 8'\t%B='8月'\t%h=' 8'\t%m='08'\t%Om='08'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::August, std::chrono::day{31}});
-  check(loc,
-        SV("%b=' 9'\t%B='9月'\t%h=' 9'\t%m='09'\t%Om='09'\t%d='32'\t%e='32'\t%Od='32'\t%Oe='32'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::September, std::chrono::day{32}});
-  check(loc,
-        SV("%b='10'\t%B='10月'\t%h='10'\t%m='10'\t%Om='10'\t%d='99'\t%e='99'\t%Od='99'\t%Oe='99'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::October, std::chrono::day{99}});
-  check(loc,
-        SV("%b='11'\t%B='11月'\t%h='11'\t%m='11'\t%Om='11'\t%d='100'\t%e='100'\t%Od='100'\t%Oe='100'\n"),
-        lfmt,
-        std::chrono::month_day{std::chrono::November, std::chrono::day{100}});
-  check(loc,
-        SV("%b='12'\t%B='12月'\t%h='12'\t%m='12'\t%Om='12'\t%d='255'\t%e='255'\t%Od='255'\t%Oe='255'\n"),
         lfmt,
         std::chrono::month_day{std::chrono::December, std::chrono::day{255}});
 #else                    // defined(_WIN32)

--- a/libcxx/test/std/time/time.syn/formatter.month_day_last.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.month_day_last.pass.cpp
@@ -117,37 +117,6 @@ static void test_valid_values() {
         std::chrono::month_day_last{std::chrono::December});
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%b='jan'\t%B='janvier'\t%h='jan'\t%m='01'\t%Om='01'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::January});
-  check(SV("%b='fév'\t%B='février'\t%h='fév'\t%m='02'\t%Om='02'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::February});
-  check(
-      SV("%b='mar'\t%B='mars'\t%h='mar'\t%m='03'\t%Om='03'\n"), lfmt, std::chrono::month_day_last{std::chrono::March});
-  check(
-      SV("%b='avr'\t%B='avril'\t%h='avr'\t%m='04'\t%Om='04'\n"), lfmt, std::chrono::month_day_last{std::chrono::April});
-  check(SV("%b='mai'\t%B='mai'\t%h='mai'\t%m='05'\t%Om='05'\n"), lfmt, std::chrono::month_day_last{std::chrono::May});
-  check(SV("%b='jui'\t%B='juin'\t%h='jui'\t%m='06'\t%Om='06'\n"), lfmt, std::chrono::month_day_last{std::chrono::June});
-  check(SV("%b='jul'\t%B='juillet'\t%h='jul'\t%m='07'\t%Om='07'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::July});
-  check(
-      SV("%b='aoû'\t%B='août'\t%h='aoû'\t%m='08'\t%Om='08'\n"), lfmt, std::chrono::month_day_last{std::chrono::August});
-  check(SV("%b='sep'\t%B='septembre'\t%h='sep'\t%m='09'\t%Om='09'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::September});
-  check(SV("%b='oct'\t%B='octobre'\t%h='oct'\t%m='10'\t%Om='10'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::October});
-  check(SV("%b='nov'\t%B='novembre'\t%h='nov'\t%m='11'\t%Om='11'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::November});
-  check(SV("%b='déc'\t%B='décembre'\t%h='déc'\t%m='12'\t%Om='12'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::December});
-#else    // defined(__APPLE__)
   check(SV("%b='janv.'\t%B='janvier'\t%h='janv.'\t%m='01'\t%Om='01'\n"),
         lfmt,
         std::chrono::month_day_last{std::chrono::January});
@@ -158,11 +127,11 @@ static void test_valid_values() {
         lfmt,
         std::chrono::month_day_last{std::chrono::March});
   check(
-#  if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__) || defined(__APPLE__)
       SV("%b='avr.'\t%B='avril'\t%h='avr.'\t%m='04'\t%Om='04'\n"),
-#  else  // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#else
       SV("%b='avril'\t%B='avril'\t%h='avril'\t%m='04'\t%Om='04'\n"),
-#  endif // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#endif
       lfmt,
       std::chrono::month_day_last{std::chrono::April});
   check(SV("%b='mai'\t%B='mai'\t%h='mai'\t%m='05'\t%Om='05'\n"), lfmt, std::chrono::month_day_last{std::chrono::May});
@@ -186,7 +155,6 @@ static void test_valid_values() {
   check(SV("%b='déc.'\t%B='décembre'\t%h='déc.'\t%m='12'\t%Om='12'\n"),
         lfmt,
         std::chrono::month_day_last{std::chrono::December});
-#endif   // defined(__APPLE__)
 
   // Use supplied locale (ja_JP)
 #ifdef _WIN32
@@ -209,49 +177,6 @@ static void test_valid_values() {
       loc, SV("%b='8'\t%B='8月'\t%h='8'\t%m='08'\t%Om='08'\n"), lfmt, std::chrono::month_day_last{std::chrono::August});
   check(loc,
         SV("%b='9'\t%B='9月'\t%h='9'\t%m='09'\t%Om='09'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::September});
-  check(loc,
-        SV("%b='10'\t%B='10月'\t%h='10'\t%m='10'\t%Om='10'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::October});
-  check(loc,
-        SV("%b='11'\t%B='11月'\t%h='11'\t%m='11'\t%Om='11'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::November});
-  check(loc,
-        SV("%b='12'\t%B='12月'\t%h='12'\t%m='12'\t%Om='12'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::December});
-#elif defined(__APPLE__) // defined(_WIN32)
-  check(loc,
-        SV("%b=' 1'\t%B='1月'\t%h=' 1'\t%m='01'\t%Om='01'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::January});
-  check(loc,
-        SV("%b=' 2'\t%B='2月'\t%h=' 2'\t%m='02'\t%Om='02'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::February});
-  check(loc,
-        SV("%b=' 3'\t%B='3月'\t%h=' 3'\t%m='03'\t%Om='03'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::March});
-  check(loc,
-        SV("%b=' 4'\t%B='4月'\t%h=' 4'\t%m='04'\t%Om='04'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::April});
-  check(
-      loc, SV("%b=' 5'\t%B='5月'\t%h=' 5'\t%m='05'\t%Om='05'\n"), lfmt, std::chrono::month_day_last{std::chrono::May});
-  check(
-      loc, SV("%b=' 6'\t%B='6月'\t%h=' 6'\t%m='06'\t%Om='06'\n"), lfmt, std::chrono::month_day_last{std::chrono::June});
-  check(
-      loc, SV("%b=' 7'\t%B='7月'\t%h=' 7'\t%m='07'\t%Om='07'\n"), lfmt, std::chrono::month_day_last{std::chrono::July});
-  check(loc,
-        SV("%b=' 8'\t%B='8月'\t%h=' 8'\t%m='08'\t%Om='08'\n"),
-        lfmt,
-        std::chrono::month_day_last{std::chrono::August});
-  check(loc,
-        SV("%b=' 9'\t%B='9月'\t%h=' 9'\t%m='09'\t%Om='09'\n"),
         lfmt,
         std::chrono::month_day_last{std::chrono::September});
   check(loc,
@@ -315,7 +240,7 @@ static void test_valid_values() {
         SV("%b='12月'\t%B='12月'\t%h='12月'\t%m='12'\t%Om='12'\n"),
         lfmt,
         std::chrono::month_day_last{std::chrono::December});
-#elif defined(__FreeBSD__) // defined(_WIN32)
+#elif defined(__FreeBSD__) || defined(__APPLE__) // defined(_WIN32)
   check(loc,
         SV("%b=' 1月'\t%B='1月'\t%h=' 1月'\t%m='01'\t%Om='01'\n"),
         lfmt,

--- a/libcxx/test/std/time/time.syn/formatter.month_weekday.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.month_weekday.pass.cpp
@@ -223,44 +223,6 @@ static void test_valid_month() {
         std::chrono::month_weekday{std::chrono::December, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%b='jan'\t%B='janvier'\t%h='jan'\t%m='01'\t%Om='01'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(SV("%b='fév'\t%B='février'\t%h='fév'\t%m='02'\t%Om='02'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::February, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(SV("%b='mar'\t%B='mars'\t%h='mar'\t%m='03'\t%Om='03'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::March, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(SV("%b='avr'\t%B='avril'\t%h='avr'\t%m='04'\t%Om='04'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::April, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(SV("%b='mai'\t%B='mai'\t%h='mai'\t%m='05'\t%Om='05'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::May, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(SV("%b='jui'\t%B='juin'\t%h='jui'\t%m='06'\t%Om='06'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::June, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(SV("%b='jul'\t%B='juillet'\t%h='jul'\t%m='07'\t%Om='07'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::July, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(SV("%b='aoû'\t%B='août'\t%h='aoû'\t%m='08'\t%Om='08'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::August, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(SV("%b='sep'\t%B='septembre'\t%h='sep'\t%m='09'\t%Om='09'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::September, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(SV("%b='oct'\t%B='octobre'\t%h='oct'\t%m='10'\t%Om='10'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::October, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(SV("%b='nov'\t%B='novembre'\t%h='nov'\t%m='11'\t%Om='11'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::November, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(SV("%b='déc'\t%B='décembre'\t%h='déc'\t%m='12'\t%Om='12'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::December, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-#else    // defined(__APPLE__)
   check(SV("%b='janv.'\t%B='janvier'\t%h='janv.'\t%m='01'\t%Om='01'\n"),
         lfmt,
         std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
@@ -271,11 +233,11 @@ static void test_valid_month() {
         lfmt,
         std::chrono::month_weekday{std::chrono::March, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
   check(
-#  if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__) || defined(__APPLE__)
       SV("%b='avr.'\t%B='avril'\t%h='avr.'\t%m='04'\t%Om='04'\n"),
-#  else  // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#else
       SV("%b='avril'\t%B='avril'\t%h='avril'\t%m='04'\t%Om='04'\n"),
-#  endif // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#endif
       lfmt,
       std::chrono::month_weekday{std::chrono::April, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
   check(SV("%b='mai'\t%B='mai'\t%h='mai'\t%m='05'\t%Om='05'\n"),
@@ -302,7 +264,6 @@ static void test_valid_month() {
   check(SV("%b='déc.'\t%B='décembre'\t%h='déc.'\t%m='12'\t%Om='12'\n"),
         lfmt,
         std::chrono::month_weekday{std::chrono::December, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-#endif   // defined(__APPLE__)
 
   // Use supplied locale (ja_JP)
 #ifdef _WIN32
@@ -340,55 +301,6 @@ static void test_valid_month() {
         std::chrono::month_weekday{std::chrono::August, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
   check(loc,
         SV("%b='9'\t%B='9月'\t%h='9'\t%m='09'\t%Om='09'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::September, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(loc,
-        SV("%b='10'\t%B='10月'\t%h='10'\t%m='10'\t%Om='10'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::October, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(loc,
-        SV("%b='11'\t%B='11月'\t%h='11'\t%m='11'\t%Om='11'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::November, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(loc,
-        SV("%b='12'\t%B='12月'\t%h='12'\t%m='12'\t%Om='12'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::December, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-#elif defined(__APPLE__) // defined(_WIN32)
-  check(loc,
-        SV("%b=' 1'\t%B='1月'\t%h=' 1'\t%m='01'\t%Om='01'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(loc,
-        SV("%b=' 2'\t%B='2月'\t%h=' 2'\t%m='02'\t%Om='02'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::February, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(loc,
-        SV("%b=' 3'\t%B='3月'\t%h=' 3'\t%m='03'\t%Om='03'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::March, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(loc,
-        SV("%b=' 4'\t%B='4月'\t%h=' 4'\t%m='04'\t%Om='04'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::April, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(loc,
-        SV("%b=' 5'\t%B='5月'\t%h=' 5'\t%m='05'\t%Om='05'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::May, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(loc,
-        SV("%b=' 6'\t%B='6月'\t%h=' 6'\t%m='06'\t%Om='06'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::June, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(loc,
-        SV("%b=' 7'\t%B='7月'\t%h=' 7'\t%m='07'\t%Om='07'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::July, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(loc,
-        SV("%b=' 8'\t%B='8月'\t%h=' 8'\t%m='08'\t%Om='08'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::August, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(loc,
-        SV("%b=' 9'\t%B='9月'\t%h=' 9'\t%m='09'\t%Om='09'\n"),
         lfmt,
         std::chrono::month_weekday{std::chrono::September, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
   check(loc,
@@ -452,7 +364,7 @@ static void test_valid_month() {
         SV("%b='12月'\t%B='12月'\t%h='12月'\t%m='12'\t%Om='12'\n"),
         lfmt,
         std::chrono::month_weekday{std::chrono::December, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-#elif defined(__FreeBSD__) // _WIN32
+#elif defined(__FreeBSD__) || defined(__APPLE__) // _WIN32
   check(loc,
         SV("%b=' 1月'\t%B='1月'\t%h=' 1月'\t%m='01'\t%Om='01'\n"),
         lfmt,
@@ -592,32 +504,6 @@ static void test_valid_weekday() {
         std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{7}, 1}});
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='Dim'\t%A='Dimanche'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
-  check(SV("%u='1'\t%Ou='1'\t%w='1'\t%Ow='1'\t%a='Lun'\t%A='Lundi'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{1}, 1}});
-  check(SV("%u='2'\t%Ou='2'\t%w='2'\t%Ow='2'\t%a='Mar'\t%A='Mardi'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{2}, 1}});
-  check(SV("%u='3'\t%Ou='3'\t%w='3'\t%Ow='3'\t%a='Mer'\t%A='Mercredi'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{3}, 1}});
-  check(SV("%u='4'\t%Ou='4'\t%w='4'\t%Ow='4'\t%a='Jeu'\t%A='Jeudi'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{4}, 1}});
-  check(SV("%u='5'\t%Ou='5'\t%w='5'\t%Ow='5'\t%a='Ven'\t%A='Vendredi'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{5}, 1}});
-  check(SV("%u='6'\t%Ou='6'\t%w='6'\t%Ow='6'\t%a='Sam'\t%A='Samedi'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{6}, 1}});
-  check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='Dim'\t%A='Dimanche'\n"),
-        lfmt,
-        std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{7}, 1}});
-#else  // defined(__APPLE__)
   check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='dim.'\t%A='dimanche'\n"),
         lfmt,
         std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{0}, 1}});
@@ -642,7 +528,6 @@ static void test_valid_weekday() {
   check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='dim.'\t%A='dimanche'\n"),
         lfmt,
         std::chrono::month_weekday{std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{7}, 1}});
-#endif // defined(__APPLE__)
 
   // Use supplied locale (ja_JP).
   // This locale has a different alternate, but not on all platforms

--- a/libcxx/test/std/time/time.syn/formatter.sys_time.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.sys_time.pass.cpp
@@ -146,15 +146,9 @@ static void test_valid_values_month() {
         std::chrono::sys_seconds(2'000'000'000s)); // 03:33:20 UTC on Wednesday, 18 May 2033
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%b='jan'\t%h='jan'\t%B='janvier'\t%m='01'\t%Om='01'\n"),
-        lfmt,
-        std::chrono::sys_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
-#else
   check(SV("%b='janv.'\t%h='janv.'\t%B='janvier'\t%m='01'\t%Om='01'\n"),
         lfmt,
         std::chrono::sys_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
-#endif
 
   check(SV("%b='mai'\t%h='mai'\t%B='mai'\t%m='05'\t%Om='05'\n"),
         lfmt,
@@ -181,17 +175,7 @@ static void test_valid_values_month() {
         SV("%b='5月'\t%h='5月'\t%B='5月'\t%m='05'\t%Om='05'\n"),
         lfmt,
         std::chrono::sys_seconds(2'000'000'000s)); // 03:33:20 UTC on Wednesday, 18 May 2033
-#elif defined(__APPLE__)                           // _WIN32
-  check(loc,
-        SV("%b=' 1'\t%h=' 1'\t%B='1月'\t%m='01'\t%Om='01'\n"),
-        lfmt,
-        std::chrono::sys_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
-
-  check(loc,
-        SV("%b=' 5'\t%h=' 5'\t%B='5月'\t%m='05'\t%Om='05'\n"),
-        lfmt,
-        std::chrono::sys_seconds(2'000'000'000s)); // 03:33:20 UTC on Wednesday, 18 May 2033
-#elif defined(__FreeBSD__)                         // _WIN32
+#elif defined(__FreeBSD__) || defined(__APPLE__)   // _WIN32
   check(loc,
         SV("%b=' 1月'\t%h=' 1月'\t%B='1月'\t%m='01'\t%Om='01'\n"),
         lfmt,
@@ -293,15 +277,6 @@ static void test_valid_values_weekday() {
         std::chrono::sys_seconds(4'294'967'295s)); // 06:28:15 UTC on Sunday, 7 February 2106
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%a='Jeu'\t%A='Jeudi'\t%u='4'\t%Ou='4'\t%w='4'\t%Ow='4'\n"),
-        lfmt,
-        std::chrono::sys_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
-
-  check(SV("%a='Dim'\t%A='Dimanche'\t%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\n"),
-        lfmt,
-        std::chrono::sys_seconds(4'294'967'295s)); // 06:28:15 UTC on Sunday, 7 February 2106
-#else
   check(SV("%a='jeu.'\t%A='jeudi'\t%u='4'\t%Ou='4'\t%w='4'\t%Ow='4'\n"),
         lfmt,
         std::chrono::sys_seconds(0s)); // 00:00:00 UTC Thursday, 1 January 1970
@@ -309,7 +284,6 @@ static void test_valid_values_weekday() {
   check(SV("%a='dim.'\t%A='dimanche'\t%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\n"),
         lfmt,
         std::chrono::sys_seconds(4'294'967'295s)); // 06:28:15 UTC on Sunday, 7 February 2106
-#endif
 
   // Use supplied locale (ja_JP).
   // This locale has a different alternate, but not on all platforms
@@ -808,11 +782,9 @@ static void test_valid_values_date_time() {
       SV("%c='jeu. 01 janv. 1970 00:00:00 GMT'\t%Ec='jeu. 01 janv. 1970 00:00:00 GMT'\n"),
 #elif defined(_AIX)
       SV("%c=' 1 janvier 1970 à 00:00:00 UTC'\t%Ec=' 1 janvier 1970 à 00:00:00 UTC'\n"),
-#elif defined(__APPLE__)
-      SV("%c='Jeu  1 jan 00:00:00 1970'\t%Ec='Jeu  1 jan 00:00:00 1970'\n"),
 #elif defined(_WIN32)
       SV("%c='01/01/1970 00:00:00'\t%Ec='01/01/1970 00:00:00'\n"),
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__APPLE__)
       SV("%c='jeu.  1 janv. 00:00:00 1970'\t%Ec='jeu.  1 janv. 00:00:00 1970'\n"),
 #else
       SV("%c='jeu. 01 janv. 1970 00:00:00'\t%Ec='jeu. 01 janv. 1970 00:00:00'\n"),
@@ -828,11 +800,9 @@ static void test_valid_values_date_time() {
       SV("%c='ven. 13 févr. 2009 23:31:30 GMT'\t%Ec='ven. 13 févr. 2009 23:31:30 GMT'\n"),
 #elif defined(_AIX)
       SV("%c='13 février 2009 à 23:31:30 UTC'\t%Ec='13 février 2009 à 23:31:30 UTC'\n"),
-#elif defined(__APPLE__)
-      SV("%c='Ven 13 fév 23:31:30 2009'\t%Ec='Ven 13 fév 23:31:30 2009'\n"),
 #elif defined(_WIN32)
       SV("%c='13/02/2009 23:31:30'\t%Ec='13/02/2009 23:31:30'\n"),
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__APPLE__)
       SV("%c='ven. 13 févr. 23:31:30 2009'\t%Ec='ven. 13 févr. 23:31:30 2009'\n"),
 #else
       SV("%c='ven. 13 févr. 2009 23:31:30'\t%Ec='ven. 13 févr. 2009 23:31:30'\n"),

--- a/libcxx/test/std/time/time.syn/formatter.weekday.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.weekday.pass.cpp
@@ -68,17 +68,6 @@ static void test_valid_values() {
   check(SV("%u='6'\t%Ou='6'\t%w='6'\t%Ow='6'\t%a='Sat'\t%A='Saturday'\n"), fmt, std::chrono::weekday(6));
   check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='Sun'\t%A='Sunday'\n"), fmt, std::chrono::weekday(7));
 
-#if defined(__APPLE__)
-  // Use the global locale (fr_FR)
-  check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='Dim'\t%A='Dimanche'\n"), lfmt, std::chrono::weekday(0));
-  check(SV("%u='1'\t%Ou='1'\t%w='1'\t%Ow='1'\t%a='Lun'\t%A='Lundi'\n"), lfmt, std::chrono::weekday(1));
-  check(SV("%u='2'\t%Ou='2'\t%w='2'\t%Ow='2'\t%a='Mar'\t%A='Mardi'\n"), lfmt, std::chrono::weekday(2));
-  check(SV("%u='3'\t%Ou='3'\t%w='3'\t%Ow='3'\t%a='Mer'\t%A='Mercredi'\n"), lfmt, std::chrono::weekday(3));
-  check(SV("%u='4'\t%Ou='4'\t%w='4'\t%Ow='4'\t%a='Jeu'\t%A='Jeudi'\n"), lfmt, std::chrono::weekday(4));
-  check(SV("%u='5'\t%Ou='5'\t%w='5'\t%Ow='5'\t%a='Ven'\t%A='Vendredi'\n"), lfmt, std::chrono::weekday(5));
-  check(SV("%u='6'\t%Ou='6'\t%w='6'\t%Ow='6'\t%a='Sam'\t%A='Samedi'\n"), lfmt, std::chrono::weekday(6));
-  check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='Dim'\t%A='Dimanche'\n"), lfmt, std::chrono::weekday(7));
-#else
   // Use the global locale (fr_FR)
   check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='dim.'\t%A='dimanche'\n"), lfmt, std::chrono::weekday(0));
   check(SV("%u='1'\t%Ou='1'\t%w='1'\t%Ow='1'\t%a='lun.'\t%A='lundi'\n"), lfmt, std::chrono::weekday(1));
@@ -88,7 +77,6 @@ static void test_valid_values() {
   check(SV("%u='5'\t%Ou='5'\t%w='5'\t%Ow='5'\t%a='ven.'\t%A='vendredi'\n"), lfmt, std::chrono::weekday(5));
   check(SV("%u='6'\t%Ou='6'\t%w='6'\t%Ow='6'\t%a='sam.'\t%A='samedi'\n"), lfmt, std::chrono::weekday(6));
   check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='dim.'\t%A='dimanche'\n"), lfmt, std::chrono::weekday(7));
-#endif
 
   // Use supplied locale (ja_JP).
   // This locale has a different alternate, but not on all platforms

--- a/libcxx/test/std/time/time.syn/formatter.weekday_index.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.weekday_index.pass.cpp
@@ -102,32 +102,6 @@ static void test_valid_values() {
         std::chrono::weekday_indexed{std::chrono::weekday(7), 7});
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='Dim'\t%A='Dimanche'\n"),
-        lfmt,
-        std::chrono::weekday_indexed{std::chrono::weekday(0), 0});
-  check(SV("%u='1'\t%Ou='1'\t%w='1'\t%Ow='1'\t%a='Lun'\t%A='Lundi'\n"),
-        lfmt,
-        std::chrono::weekday_indexed{std::chrono::weekday(1), 1});
-  check(SV("%u='2'\t%Ou='2'\t%w='2'\t%Ow='2'\t%a='Mar'\t%A='Mardi'\n"),
-        lfmt,
-        std::chrono::weekday_indexed{std::chrono::weekday(2), 2});
-  check(SV("%u='3'\t%Ou='3'\t%w='3'\t%Ow='3'\t%a='Mer'\t%A='Mercredi'\n"),
-        lfmt,
-        std::chrono::weekday_indexed{std::chrono::weekday(3), 3});
-  check(SV("%u='4'\t%Ou='4'\t%w='4'\t%Ow='4'\t%a='Jeu'\t%A='Jeudi'\n"),
-        lfmt,
-        std::chrono::weekday_indexed{std::chrono::weekday(4), 4});
-  check(SV("%u='5'\t%Ou='5'\t%w='5'\t%Ow='5'\t%a='Ven'\t%A='Vendredi'\n"),
-        lfmt,
-        std::chrono::weekday_indexed{std::chrono::weekday(5), 5});
-  check(SV("%u='6'\t%Ou='6'\t%w='6'\t%Ow='6'\t%a='Sam'\t%A='Samedi'\n"),
-        lfmt,
-        std::chrono::weekday_indexed{std::chrono::weekday(6), 6});
-  check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='Dim'\t%A='Dimanche'\n"),
-        lfmt,
-        std::chrono::weekday_indexed{std::chrono::weekday(7), 7});
-#else  // defined(__APPLE__)
   check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='dim.'\t%A='dimanche'\n"),
         lfmt,
         std::chrono::weekday_indexed{std::chrono::weekday(0), 0});
@@ -152,7 +126,6 @@ static void test_valid_values() {
   check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='dim.'\t%A='dimanche'\n"),
         lfmt,
         std::chrono::weekday_indexed{std::chrono::weekday(7), 7});
-#endif // defined(__APPLE__)
 
   // Use supplied locale (ja_JP).
   // This locale has a different alternate, but not on all platforms
@@ -373,13 +346,8 @@ static void test_invalid_values() {
     check(SV("%a='Sun'\t%A='Sunday'\n"), fmt, std::chrono::weekday_indexed{std::chrono::weekday(0), 6});
 
     // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-    check(SV("%a='Dim'\t%A='Dimanche'\n"), lfmt, std::chrono::weekday_indexed{std::chrono::weekday(0), 0});
-    check(SV("%a='Dim'\t%A='Dimanche'\n"), lfmt, std::chrono::weekday_indexed{std::chrono::weekday(0), 6});
-#else  // defined(__APPLE__)
     check(SV("%a='dim.'\t%A='dimanche'\n"), lfmt, std::chrono::weekday_indexed{std::chrono::weekday(0), 0});
     check(SV("%a='dim.'\t%A='dimanche'\n"), lfmt, std::chrono::weekday_indexed{std::chrono::weekday(0), 6});
-#endif // defined(__APPLE__)
 
     // Use supplied locale (ja_JP)
     check(loc, SV("%a='日'\t%A='日曜日'\n"), lfmt, std::chrono::weekday_indexed{std::chrono::weekday(0), 0});

--- a/libcxx/test/std/time/time.syn/formatter.weekday_last.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.weekday_last.pass.cpp
@@ -85,32 +85,6 @@ static void test_valid_values() {
         std::chrono::weekday_last{std::chrono::weekday(7)});
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='Dim'\t%A='Dimanche'\n"),
-        lfmt,
-        std::chrono::weekday_last{std::chrono::weekday(0)});
-  check(SV("%u='1'\t%Ou='1'\t%w='1'\t%Ow='1'\t%a='Lun'\t%A='Lundi'\n"),
-        lfmt,
-        std::chrono::weekday_last{std::chrono::weekday(1)});
-  check(SV("%u='2'\t%Ou='2'\t%w='2'\t%Ow='2'\t%a='Mar'\t%A='Mardi'\n"),
-        lfmt,
-        std::chrono::weekday_last{std::chrono::weekday(2)});
-  check(SV("%u='3'\t%Ou='3'\t%w='3'\t%Ow='3'\t%a='Mer'\t%A='Mercredi'\n"),
-        lfmt,
-        std::chrono::weekday_last{std::chrono::weekday(3)});
-  check(SV("%u='4'\t%Ou='4'\t%w='4'\t%Ow='4'\t%a='Jeu'\t%A='Jeudi'\n"),
-        lfmt,
-        std::chrono::weekday_last{std::chrono::weekday(4)});
-  check(SV("%u='5'\t%Ou='5'\t%w='5'\t%Ow='5'\t%a='Ven'\t%A='Vendredi'\n"),
-        lfmt,
-        std::chrono::weekday_last{std::chrono::weekday(5)});
-  check(SV("%u='6'\t%Ou='6'\t%w='6'\t%Ow='6'\t%a='Sam'\t%A='Samedi'\n"),
-        lfmt,
-        std::chrono::weekday_last{std::chrono::weekday(6)});
-  check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='Dim'\t%A='Dimanche'\n"),
-        lfmt,
-        std::chrono::weekday_last{std::chrono::weekday(7)});
-#else  // defined(__APPLE__)
   check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='dim.'\t%A='dimanche'\n"),
         lfmt,
         std::chrono::weekday_last{std::chrono::weekday(0)});
@@ -135,7 +109,6 @@ static void test_valid_values() {
   check(SV("%u='7'\t%Ou='7'\t%w='0'\t%Ow='0'\t%a='dim.'\t%A='dimanche'\n"),
         lfmt,
         std::chrono::weekday_last{std::chrono::weekday(7)});
-#endif // defined(__APPLE__)
 
   // Use supplied locale (ja_JP).
   // This locale has a different alternate, but not on all platforms

--- a/libcxx/test/std/time/time.syn/formatter.year_month.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.year_month.pass.cpp
@@ -126,40 +126,12 @@ static void test_valid_values() {
         std::chrono::year_month{std::chrono::year{2004}, std::chrono::May});
 
   // Use the global locale (fr_FR)
-  check(SV(
-#if defined(__APPLE__)
-            "%b='jan'\t"
-#else
-            "%b='janv.'\t"
-#endif
-            "%B='janvier'\t"
-            "%C='19'\t"
-#if defined(__APPLE__)
-            "%h='jan'\t"
-#else
-            "%h='janv.'\t"
-#endif
-            "%y='70'\t"
-            "%Y='1970'\t"
-            "%EC='19'\t"
-            "%Ey='70'\t"
-            "%EY='1970'\t"
-            "%Oy='70'\t"
-            "\n"),
+  check(SV("%b='janv.'\t%B='janvier'\t%C='19'\t%h='janv.'\t%y='70'\t%Y='1970'\t%EC='19'\t%Ey='70'\t%EY='1970'\t%Oy='70'"
+           "\t\n"),
         lfmt,
         std::chrono::year_month{std::chrono::year{1970}, std::chrono::January});
 
-  check(SV("%b='mai'\t"
-           "%B='mai'\t"
-           "%C='20'\t"
-           "%h='mai'\t"
-           "%y='04'\t"
-           "%Y='2004'\t"
-           "%EC='20'\t"
-           "%Ey='04'\t"
-           "%EY='2004'\t"
-           "%Oy='04'\t"
-           "\n"),
+  check(SV("%b='mai'\t%B='mai'\t%C='20'\t%h='mai'\t%y='04'\t%Y='2004'\t%EC='20'\t%Ey='04'\t%EY='2004'\t%Oy='04'\t\n"),
         lfmt,
         std::chrono::year_month{std::chrono::year{2004}, std::chrono::May});
 
@@ -170,8 +142,6 @@ static void test_valid_values() {
             "%b='1'\t"
 #elif defined(_AIX)      // defined(_WIN32)
             "%b='1月'\t"
-#elif defined(__APPLE__) // defined(_WIN32)
-            "%b=' 1'\t"
 #else                    // defined(_WIN32)
             "%b=' 1月'\t"
 #endif                   // defined(_WIN32)
@@ -181,8 +151,6 @@ static void test_valid_values() {
             "%h='1'\t"
 #elif defined(_AIX)      // defined(_WIN32)
             "%h='1月'\t"
-#elif defined(__APPLE__) // defined(_WIN32)
-            "%h=' 1'\t"
 #else                    // defined(_WIN32)
             "%h=' 1月'\t"
 #endif                   // defined(_WIN32)
@@ -210,8 +178,6 @@ static void test_valid_values() {
             "%b='5'\t"
 #elif defined(_AIX)      // defined(_WIN32)
             "%b='5月'\t"
-#elif defined(__APPLE__) // defined(_WIN32)
-            "%b=' 5'\t"
 #else                    // defined(_WIN32)
             "%b=' 5月'\t"
 #endif                   // defined(_WIN32)
@@ -221,8 +187,6 @@ static void test_valid_values() {
             "%h='5'\t"
 #elif defined(_AIX)      // defined(_WIN32)
             "%h='5月'\t"
-#elif defined(__APPLE__) // defined(_WIN32)
-            "%h=' 5'\t"
 #else                    // defined(_WIN32)
             "%h=' 5月'\t"
 #endif                   // defined(_WIN32)

--- a/libcxx/test/std/time/time.syn/formatter.year_month_day.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.year_month_day.pass.cpp
@@ -464,53 +464,15 @@ static void test_valid_md_values() {
 #endif   // _WIN32
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%b='jan'\t%B='janvier'\t%h='jan'\t%m='01'\t%Om='01'\t%d='00'\t%e=' 0'\t%Od='00'\t%Oe=' 0'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::January, std::chrono::day{0}});
-  check(SV("%b='fév'\t%B='février'\t%h='fév'\t%m='02'\t%Om='02'\t%d='01'\t%e=' 1'\t%Od='01'\t%Oe=' 1'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::February, std::chrono::day{1}});
-  check(SV("%b='mar'\t%B='mars'\t%h='mar'\t%m='03'\t%Om='03'\t%d='09'\t%e=' 9'\t%Od='09'\t%Oe=' 9'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::March, std::chrono::day{9}});
-  check(SV("%b='avr'\t%B='avril'\t%h='avr'\t%m='04'\t%Om='04'\t%d='10'\t%e='10'\t%Od='10'\t%Oe='10'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::April, std::chrono::day{10}});
-  check(SV("%b='mai'\t%B='mai'\t%h='mai'\t%m='05'\t%Om='05'\t%d='28'\t%e='28'\t%Od='28'\t%Oe='28'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::May, std::chrono::day{28}});
-  check(SV("%b='jui'\t%B='juin'\t%h='jui'\t%m='06'\t%Om='06'\t%d='29'\t%e='29'\t%Od='29'\t%Oe='29'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::June, std::chrono::day{29}});
-  check(SV("%b='jul'\t%B='juillet'\t%h='jul'\t%m='07'\t%Om='07'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::July, std::chrono::day{30}});
-  check(SV("%b='aoû'\t%B='août'\t%h='aoû'\t%m='08'\t%Om='08'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::August, std::chrono::day{31}});
-  check(SV("%b='sep'\t%B='septembre'\t%h='sep'\t%m='09'\t%Om='09'\t%d='32'\t%e='32'\t%Od='32'\t%Oe='32'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::September, std::chrono::day{32}});
-  check(SV("%b='oct'\t%B='octobre'\t%h='oct'\t%m='10'\t%Om='10'\t%d='99'\t%e='99'\t%Od='99'\t%Oe='99'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::October, std::chrono::day{99}});
-  check(SV("%b='nov'\t%B='novembre'\t%h='nov'\t%m='11'\t%Om='11'\t%d='100'\t%e='100'\t%Od='100'\t%Oe='100'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::November, std::chrono::day{100}});
-  check(SV("%b='déc'\t%B='décembre'\t%h='déc'\t%m='12'\t%Om='12'\t%d='255'\t%e='255'\t%Od='255'\t%Oe='255'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::December, std::chrono::day{255}});
-#else // defined(__APPLE__)
-#  ifdef _WIN32
+#ifdef _WIN32
   check(SV("%b='janv.'\t%B='janvier'\t%h='janv.'\t%m='01'\t%Om='01'\t%d=''\t%e=''\t%Od=''\t%Oe=''\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::January, std::chrono::day{0}});
-#  else
+#else
   check(SV("%b='janv.'\t%B='janvier'\t%h='janv.'\t%m='01'\t%Om='01'\t%d='00'\t%e=' 0'\t%Od='00'\t%Oe=' 0'\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::January, std::chrono::day{0}});
-#  endif
+#endif
   check(SV("%b='févr.'\t%B='février'\t%h='févr.'\t%m='02'\t%Om='02'\t%d='01'\t%e=' 1'\t%Od='01'\t%Oe=' 1'\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::February, std::chrono::day{1}});
@@ -518,11 +480,11 @@ static void test_valid_md_values() {
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::March, std::chrono::day{9}});
   check(
-#  if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__) || defined(__APPLE__)
       SV("%b='avr.'\t%B='avril'\t%h='avr.'\t%m='04'\t%Om='04'\t%d='10'\t%e='10'\t%Od='10'\t%Oe='10'\n"),
-#  else  // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#else
       SV("%b='avril'\t%B='avril'\t%h='avril'\t%m='04'\t%Om='04'\t%d='10'\t%e='10'\t%Od='10'\t%Oe='10'\n"),
-#  endif // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#endif
       lfmt,
       std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::April, std::chrono::day{10}});
   check(SV("%b='mai'\t%B='mai'\t%h='mai'\t%m='05'\t%Om='05'\t%d='28'\t%e='28'\t%Od='28'\t%Oe='28'\n"),
@@ -537,7 +499,7 @@ static void test_valid_md_values() {
   check(SV("%b='août'\t%B='août'\t%h='août'\t%m='08'\t%Om='08'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::August, std::chrono::day{31}});
-#  ifdef _WIN32
+#ifdef _WIN32
   check(SV("%b='sept.'\t%B='septembre'\t%h='sept.'\t%m='09'\t%Om='09'\t%d=''\t%e=''\t%Od=''\t%Oe=''\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::September, std::chrono::day{32}});
@@ -550,30 +512,29 @@ static void test_valid_md_values() {
   check(SV("%b='déc.'\t%B='décembre'\t%h='déc.'\t%m='12'\t%Om='12'\t%d=''\t%e=''\t%Od=''\t%Oe=''\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::December, std::chrono::day{255}});
-#  else // _WIN32
+#else // _WIN32
   check(SV("%b='sept.'\t%B='septembre'\t%h='sept.'\t%m='09'\t%Om='09'\t%d='32'\t%e='32'\t%Od='32'\t%Oe='32'\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::September, std::chrono::day{32}});
   check(SV("%b='oct.'\t%B='octobre'\t%h='oct.'\t%m='10'\t%Om='10'\t%d='99'\t%e='99'\t%Od='99'\t%Oe='99'\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::October, std::chrono::day{99}});
-#    if defined(_AIX)
+#  if defined(_AIX)
   check(SV("%b='nov.'\t%B='novembre'\t%h='nov.'\t%m='11'\t%Om='11'\t%d='00'\t%e=' 0'\t%Od='00'\t%Oe=' 0'\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::November, std::chrono::day{100}});
   check(SV("%b='déc.'\t%B='décembre'\t%h='déc.'\t%m='12'\t%Om='12'\t%d='55'\t%e='55'\t%Od='55'\t%Oe='55'\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::December, std::chrono::day{255}});
-#    else  //   defined(_AIX)
+#  else  //   defined(_AIX)
   check(SV("%b='nov.'\t%B='novembre'\t%h='nov.'\t%m='11'\t%Om='11'\t%d='100'\t%e='100'\t%Od='100'\t%Oe='100'\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::November, std::chrono::day{100}});
   check(SV("%b='déc.'\t%B='décembre'\t%h='déc.'\t%m='12'\t%Om='12'\t%d='255'\t%e='255'\t%Od='255'\t%Oe='255'\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::December, std::chrono::day{255}});
-#    endif //   defined(_AIX)
-#  endif   // _WIN32
-#endif     // defined(__APPLE__)
+#  endif //   defined(_AIX)
+#endif   // _WIN32
 
   // Use supplied locale (ja_JP)
 #if defined(_WIN32)
@@ -674,7 +635,7 @@ static void test_valid_md_values() {
         SV("%b='12月'\t%B='12月'\t%h='12月'\t%m='12'\t%Om='12'\t%d='55'\t%e='55'\t%Od='55'\t%Oe='55'\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::December, std::chrono::day{255}});
-#elif defined(__FreeBSD__) // defined(_WIN32)
+#elif defined(__FreeBSD__) || defined(__APPLE__) // defined(_WIN32)
   check(loc,
         SV("%b=' 1月'\t%B='1月'\t%h=' 1月'\t%m='01'\t%Om='01'\t%d='00'\t%e=' 0'\t%Od='00'\t%Oe=' 0'\n"),
         lfmt,
@@ -721,55 +682,6 @@ static void test_valid_md_values() {
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::November, std::chrono::day{100}});
   check(loc,
         SV("%b='12月'\t%B='12月'\t%h='12月'\t%m='12'\t%Om='12'\t%d='255'\t%e='255'\t%Od='255'\t%Oe='255'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::December, std::chrono::day{255}});
-#elif defined(__APPLE__) // defined(_WIN32)
-  check(loc,
-        SV("%b=' 1'\t%B='1月'\t%h=' 1'\t%m='01'\t%Om='01'\t%d='00'\t%e=' 0'\t%Od='00'\t%Oe=' 0'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::January, std::chrono::day{0}});
-  check(loc,
-        SV("%b=' 2'\t%B='2月'\t%h=' 2'\t%m='02'\t%Om='02'\t%d='01'\t%e=' 1'\t%Od='01'\t%Oe=' 1'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::February, std::chrono::day{1}});
-  check(loc,
-        SV("%b=' 3'\t%B='3月'\t%h=' 3'\t%m='03'\t%Om='03'\t%d='09'\t%e=' 9'\t%Od='09'\t%Oe=' 9'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::March, std::chrono::day{9}});
-  check(loc,
-        SV("%b=' 4'\t%B='4月'\t%h=' 4'\t%m='04'\t%Om='04'\t%d='10'\t%e='10'\t%Od='10'\t%Oe='10'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::April, std::chrono::day{10}});
-  check(loc,
-        SV("%b=' 5'\t%B='5月'\t%h=' 5'\t%m='05'\t%Om='05'\t%d='28'\t%e='28'\t%Od='28'\t%Oe='28'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::May, std::chrono::day{28}});
-  check(loc,
-        SV("%b=' 6'\t%B='6月'\t%h=' 6'\t%m='06'\t%Om='06'\t%d='29'\t%e='29'\t%Od='29'\t%Oe='29'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::June, std::chrono::day{29}});
-  check(loc,
-        SV("%b=' 7'\t%B='7月'\t%h=' 7'\t%m='07'\t%Om='07'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::July, std::chrono::day{30}});
-  check(loc,
-        SV("%b=' 8'\t%B='8月'\t%h=' 8'\t%m='08'\t%Om='08'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::August, std::chrono::day{31}});
-  check(loc,
-        SV("%b=' 9'\t%B='9月'\t%h=' 9'\t%m='09'\t%Om='09'\t%d='32'\t%e='32'\t%Od='32'\t%Oe='32'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::September, std::chrono::day{32}});
-  check(loc,
-        SV("%b='10'\t%B='10月'\t%h='10'\t%m='10'\t%Om='10'\t%d='99'\t%e='99'\t%Od='99'\t%Oe='99'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::October, std::chrono::day{99}});
-  check(loc,
-        SV("%b='11'\t%B='11月'\t%h='11'\t%m='11'\t%Om='11'\t%d='100'\t%e='100'\t%Od='100'\t%Oe='100'\n"),
-        lfmt,
-        std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::November, std::chrono::day{100}});
-  check(loc,
-        SV("%b='12'\t%B='12月'\t%h='12'\t%m='12'\t%Om='12'\t%d='255'\t%e='255'\t%Od='255'\t%Oe='255'\n"),
         lfmt,
         std::chrono::year_month_day{std::chrono::year{1970}, std::chrono::December, std::chrono::day{255}});
 #else                    // defined(_WIN32)

--- a/libcxx/test/std/time/time.syn/formatter.year_month_day_last.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.year_month_day_last.pass.cpp
@@ -298,44 +298,6 @@ static void test_valid_md_values() {
         std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::December}});
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%b='jan'\t%B='janvier'\t%h='jan'\t%m='01'\t%Om='01'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::January}});
-  check(SV("%b='fév'\t%B='février'\t%h='fév'\t%m='02'\t%Om='02'\t%d='28'\t%e='28'\t%Od='28'\t%Oe='28'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::February}});
-  check(SV("%b='mar'\t%B='mars'\t%h='mar'\t%m='03'\t%Om='03'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::March}});
-  check(SV("%b='avr'\t%B='avril'\t%h='avr'\t%m='04'\t%Om='04'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::April}});
-  check(SV("%b='mai'\t%B='mai'\t%h='mai'\t%m='05'\t%Om='05'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::May}});
-  check(SV("%b='jui'\t%B='juin'\t%h='jui'\t%m='06'\t%Om='06'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::June}});
-  check(SV("%b='jul'\t%B='juillet'\t%h='jul'\t%m='07'\t%Om='07'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::July}});
-  check(SV("%b='aoû'\t%B='août'\t%h='aoû'\t%m='08'\t%Om='08'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::August}});
-  check(SV("%b='sep'\t%B='septembre'\t%h='sep'\t%m='09'\t%Om='09'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::September}});
-  check(SV("%b='oct'\t%B='octobre'\t%h='oct'\t%m='10'\t%Om='10'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::October}});
-  check(SV("%b='nov'\t%B='novembre'\t%h='nov'\t%m='11'\t%Om='11'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::November}});
-  check(SV("%b='déc'\t%B='décembre'\t%h='déc'\t%m='12'\t%Om='12'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::December}});
-#else    // defined(__APPLE__)
   check(SV("%b='janv.'\t%B='janvier'\t%h='janv.'\t%m='01'\t%Om='01'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
         lfmt,
         std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::January}});
@@ -346,11 +308,11 @@ static void test_valid_md_values() {
         lfmt,
         std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::March}});
   check(
-#  if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__) || defined(__APPLE__)
       SV("%b='avr.'\t%B='avril'\t%h='avr.'\t%m='04'\t%Om='04'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-#  else  // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#else
       SV("%b='avril'\t%B='avril'\t%h='avril'\t%m='04'\t%Om='04'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-#  endif // defined(_WIN32) || defined(_AIX) || defined(__FreeBSD__)
+#endif
       lfmt,
       std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::April}});
   check(SV("%b='mai'\t%B='mai'\t%h='mai'\t%m='05'\t%Om='05'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
@@ -377,7 +339,6 @@ static void test_valid_md_values() {
   check(SV("%b='déc.'\t%B='décembre'\t%h='déc.'\t%m='12'\t%Om='12'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
         lfmt,
         std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::December}});
-#endif   // defined(__APPLE__)
 
   // Use supplied locale (ja_JP)
 #if defined(_WIN32)
@@ -478,7 +439,7 @@ static void test_valid_md_values() {
         SV("%b='12月'\t%B='12月'\t%h='12月'\t%m='12'\t%Om='12'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
         lfmt,
         std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::December}});
-#elif defined(__FreeBSD__) // defined(_WIN32)
+#elif defined(__FreeBSD__) || defined(__APPLE__) // defined(_WIN32)
   check(loc,
         SV("%b=' 1月'\t%B='1月'\t%h=' 1月'\t%m='01'\t%Om='01'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
         lfmt,
@@ -525,55 +486,6 @@ static void test_valid_md_values() {
         std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::November}});
   check(loc,
         SV("%b='12月'\t%B='12月'\t%h='12月'\t%m='12'\t%Om='12'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::December}});
-#elif defined(__APPLE__) // defined(_WIN32)
-  check(loc,
-        SV("%b=' 1'\t%B='1月'\t%h=' 1'\t%m='01'\t%Om='01'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::January}});
-  check(loc,
-        SV("%b=' 2'\t%B='2月'\t%h=' 2'\t%m='02'\t%Om='02'\t%d='28'\t%e='28'\t%Od='28'\t%Oe='28'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::February}});
-  check(loc,
-        SV("%b=' 3'\t%B='3月'\t%h=' 3'\t%m='03'\t%Om='03'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::March}});
-  check(loc,
-        SV("%b=' 4'\t%B='4月'\t%h=' 4'\t%m='04'\t%Om='04'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::April}});
-  check(loc,
-        SV("%b=' 5'\t%B='5月'\t%h=' 5'\t%m='05'\t%Om='05'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::May}});
-  check(loc,
-        SV("%b=' 6'\t%B='6月'\t%h=' 6'\t%m='06'\t%Om='06'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::June}});
-  check(loc,
-        SV("%b=' 7'\t%B='7月'\t%h=' 7'\t%m='07'\t%Om='07'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::July}});
-  check(loc,
-        SV("%b=' 8'\t%B='8月'\t%h=' 8'\t%m='08'\t%Om='08'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::August}});
-  check(loc,
-        SV("%b=' 9'\t%B='9月'\t%h=' 9'\t%m='09'\t%Om='09'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::September}});
-  check(loc,
-        SV("%b='10'\t%B='10月'\t%h='10'\t%m='10'\t%Om='10'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::October}});
-  check(loc,
-        SV("%b='11'\t%B='11月'\t%h='11'\t%m='11'\t%Om='11'\t%d='30'\t%e='30'\t%Od='30'\t%Oe='30'\n"),
-        lfmt,
-        std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::November}});
-  check(loc,
-        SV("%b='12'\t%B='12月'\t%h='12'\t%m='12'\t%Om='12'\t%d='31'\t%e='31'\t%Od='31'\t%Oe='31'\n"),
         lfmt,
         std::chrono::year_month_day_last{std::chrono::year{1970}, std::chrono::month_day_last{std::chrono::December}});
 #else                    // defined(_WIN32)

--- a/libcxx/test/std/time/time.syn/formatter.year_month_weekday.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.year_month_weekday.pass.cpp
@@ -290,18 +290,6 @@ static void test_valid_md_values() {
             std::chrono::year{1970}, std::chrono::December, std::chrono::weekday_indexed{std::chrono::weekday{7}, 3}});
 
   // Use the global locale (fr_FR)
-#if defined(__APPLE__)
-  check(SV("%b='jan'\t%B='janvier'\t%h='jan'\t%m='01'\t%Om='01'\t%d='01'\t%e=' 1'\t%Od='01'\t%Oe=' 1'\n"),
-        lfmt,
-        std::chrono::year_month_weekday{
-            std::chrono::year{1970}, std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{4}, 1}});
-
-  check(SV("%b='déc'\t%B='décembre'\t%h='déc'\t%m='12'\t%Om='12'\t%d='20'\t%e='20'\t%Od='20'\t%Oe='20'\n"),
-        lfmt,
-        std::chrono::year_month_weekday{
-            std::chrono::year{1970}, std::chrono::December, std::chrono::weekday_indexed{std::chrono::weekday{7}, 3}});
-
-#else  // defined(__APPLE__)
   check(SV("%b='janv.'\t%B='janvier'\t%h='janv.'\t%m='01'\t%Om='01'\t%d='01'\t%e=' 1'\t%Od='01'\t%Oe=' 1'\n"),
         lfmt,
         std::chrono::year_month_weekday{
@@ -310,8 +298,6 @@ static void test_valid_md_values() {
         lfmt,
         std::chrono::year_month_weekday{
             std::chrono::year{1970}, std::chrono::December, std::chrono::weekday_indexed{std::chrono::weekday{7}, 3}});
-
-#endif // defined(__APPLE__)
 
   // Use supplied locale (ja_JP)
 #if defined(_WIN32)
@@ -340,20 +326,7 @@ static void test_valid_md_values() {
         std::chrono::year_month_weekday{
             std::chrono::year{1970}, std::chrono::December, std::chrono::weekday_indexed{std::chrono::weekday{7}, 3}});
 
-#elif defined(__APPLE__) // defined(_WIN32)
-  check(loc,
-        SV("%b=' 1'\t%B='1月'\t%h=' 1'\t%m='01'\t%Om='01'\t%d='01'\t%e=' 1'\t%Od='01'\t%Oe=' 1'\n"),
-        lfmt,
-        std::chrono::year_month_weekday{
-            std::chrono::year{1970}, std::chrono::January, std::chrono::weekday_indexed{std::chrono::weekday{4}, 1}});
-
-  check(loc,
-        SV("%b='12'\t%B='12月'\t%h='12'\t%m='12'\t%Om='12'\t%d='20'\t%e='20'\t%Od='20'\t%Oe='20'\n"),
-        lfmt,
-        std::chrono::year_month_weekday{
-            std::chrono::year{1970}, std::chrono::December, std::chrono::weekday_indexed{std::chrono::weekday{7}, 3}});
-
-#elif defined(__FreeBSD__) // defined(_WIN32)
+#elif defined(__FreeBSD__) || defined(__APPLE__) // defined(_WIN32)
   check(loc,
         SV("%b=' 1月'\t%B='1月'\t%h=' 1月'\t%m='01'\t%Om='01'\t%d='01'\t%e=' 1'\t%Od='01'\t%Oe=' 1'\n"),
         lfmt,

--- a/libunwind/test/signal_frame.pass.cpp
+++ b/libunwind/test/signal_frame.pass.cpp
@@ -11,7 +11,7 @@
 
 // Older clang versions had a bug: .cfi_signal_frame can't be encoded in compact
 // unwind.
-// XFAIL: apple-clang-17
+// XFAIL: apple-clang-21
 
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan


### PR DESCRIPTION
The new AppleClang is only available on macOS 26, so we need to update both.