### PR TITLE
[clang][unittests] Fix flaky PerformPendingInstantiations nesting in TimeProfilerTest

### DIFF
--- a/clang/unittests/Support/TimeProfilerTest.cpp
+++ b/clang/unittests/Support/TimeProfilerTest.cpp
@@ -155,10 +155,10 @@ std::string buildTraceGraph(StringRef Json) {
 
       // Presumably due to timer rounding, PerformPendingInstantiations often
       // appear to be within the timer interval of the immediately previous
-      // event group. We always know these events occur at level 1, not level 2,
-      // in our tests, so pop an event in that case.
+      // event group. We always know these events occur at level 1 in our
+      // tests, so keep popping until the stack is back at the root.
       if (InsideCurrentEvent && Event.Name == "PerformPendingInstantiations" &&
-          EventStack.size() == 2) {
+          EventStack.size() >= 2) {
         InsideCurrentEvent = false;
       }
 


### PR DESCRIPTION
buildTraceGraph already compensates for timer rounding that makes PerformPendingInstantiations appear to be inside the previous event, but only when it is nested exactly one level deep. The aarch64-darwin buildbot produced three-level nesting for ConstantEvaluationC99, which slipped through the normalization and broke the expected trace output.

Keep popping while PerformPendingInstantiations looks nested—we know it is always a top-level event in these tests—instead of stopping at the single-level case.

Followup to https://github.com/llvm/llvm-project/pull/138613.