### PR TITLE
[LoongArch] Support VBIT{CLR,SET,REV}I patterns for non-native element sizes

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchISelDAGToDAG.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchISelDAGToDAG.cpp
@@ -447,16 +447,18 @@ bool LoongArchDAGToDAGISel::selectVSplatImmNeg(SDValue N,
   return false;
 }
 
+template <unsigned EltBitSize>
 bool LoongArchDAGToDAGISel::selectVSplatUimmInvPow2(SDValue N,
                                                     SDValue &SplatImm) const {
   APInt ImmValue;
   EVT EltTy = N->getValueType(0).getVectorElementType();
+  unsigned EltBitWidth = EltBitSize ? EltBitSize : EltTy.getSizeInBits();
 
   if (N->getOpcode() == ISD::BITCAST)
     N = N->getOperand(0);
 
-  if (selectVSplat(N.getNode(), ImmValue, EltTy.getSizeInBits()) &&
-      ImmValue.getBitWidth() == EltTy.getSizeInBits()) {
+  if (selectVSplat(N.getNode(), ImmValue, EltBitWidth) &&
+      ImmValue.getBitWidth() == EltBitWidth) {
     int32_t Log2 = (~ImmValue).exactLogBase2();
 
     if (Log2 != -1) {
@@ -468,16 +470,18 @@ bool LoongArchDAGToDAGISel::selectVSplatUimmInvPow2(SDValue N,
   return false;
 }
 
+template <unsigned EltBitSize>
 bool LoongArchDAGToDAGISel::selectVSplatUimmPow2(SDValue N,
                                                  SDValue &SplatImm) const {
   APInt ImmValue;
   EVT EltTy = N->getValueType(0).getVectorElementType();
+  unsigned EltBitWidth = EltBitSize ? EltBitSize : EltTy.getSizeInBits();
 
   if (N->getOpcode() == ISD::BITCAST)
     N = N->getOperand(0);
 
-  if (selectVSplat(N.getNode(), ImmValue, EltTy.getSizeInBits()) &&
-      ImmValue.getBitWidth() == EltTy.getSizeInBits()) {
+  if (selectVSplat(N.getNode(), ImmValue, EltBitWidth) &&
+      ImmValue.getBitWidth() == EltBitWidth) {
     int32_t Log2 = ImmValue.exactLogBase2();
 
     if (Log2 != -1) {

--- a/llvm/lib/Target/LoongArch/LoongArchISelDAGToDAG.h
+++ b/llvm/lib/Target/LoongArch/LoongArchISelDAGToDAG.h
@@ -64,8 +64,9 @@ public:
   bool selectVSplatImm(SDValue N, SDValue &SplatVal);
   template <unsigned ImmSize>
   bool selectVSplatImmNeg(SDValue N, SDValue &SplatVal) const;
-
+  template <unsigned EltSize = 0>
   bool selectVSplatUimmInvPow2(SDValue N, SDValue &SplatImm) const;
+  template <unsigned EltSize = 0>
   bool selectVSplatUimmPow2(SDValue N, SDValue &SplatImm) const;
 
   // Return the LoongArch branch opcode that matches the given DAG integer

--- a/llvm/lib/Target/LoongArch/LoongArchLASXInstrInfo.td
+++ b/llvm/lib/Target/LoongArch/LoongArchLASXInstrInfo.td
@@ -1525,6 +1525,15 @@ def : Pat<(and (v8i32 LASX256:$xj), (v8i32 (vsplat_uimm_inv_pow2 uimm5:$imm))),
 def : Pat<(and (v4i64 LASX256:$xj), (v4i64 (vsplat_uimm_inv_pow2 uimm6:$imm))),
           (XVBITCLRI_D LASX256:$xj, uimm6:$imm)>;
 
+foreach vt = [v16i16, v8i32, v4i64] in {
+  def : Pat<(and (vt LASX256:$vj), (vt (vsplat_i8_inv_pow2 grlenimm:$imm))),
+            (XVBITCLRI_B LASX256:$vj, grlenimm:$imm)>;
+  def : Pat<(and (vt LASX256:$vj), (vt (vsplat_i16_inv_pow2 grlenimm:$imm))),
+            (XVBITCLRI_H LASX256:$vj, grlenimm:$imm)>;
+  def : Pat<(and (vt LASX256:$vj), (vt (vsplat_i32_inv_pow2 grlenimm:$imm))),
+            (XVBITCLRI_W LASX256:$vj, grlenimm:$imm)>;
+}
+
 // XVBITSET_{B/H/W/D}
 def : Pat<(or v32i8:$xj, (shl vsplat_imm_eq_1, v32i8:$xk)),
           (v32i8 (XVBITSET_B v32i8:$xj, v32i8:$xk))>;
@@ -1553,6 +1562,15 @@ def : Pat<(or (v8i32 LASX256:$xj), (v8i32 (vsplat_uimm_pow2 uimm5:$imm))),
 def : Pat<(or (v4i64 LASX256:$xj), (v4i64 (vsplat_uimm_pow2 uimm6:$imm))),
           (XVBITSETI_D LASX256:$xj, uimm6:$imm)>;
 
+foreach vt = [v16i16, v8i32, v4i64] in {
+  def : Pat<(or (vt LASX256:$vj), (vt (vsplat_i8_pow2 grlenimm:$imm))),
+            (XVBITSETI_B LASX256:$vj, grlenimm:$imm)>;
+  def : Pat<(or (vt LASX256:$vj), (vt (vsplat_i16_pow2 grlenimm:$imm))),
+            (XVBITSETI_H LASX256:$vj, grlenimm:$imm)>;
+  def : Pat<(or (vt LASX256:$vj), (vt (vsplat_i32_pow2 grlenimm:$imm))),
+            (XVBITSETI_W LASX256:$vj, grlenimm:$imm)>;
+}
+
 // XVBITREV_{B/H/W/D}
 def : Pat<(xor v32i8:$xj, (shl vsplat_imm_eq_1, v32i8:$xk)),
           (v32i8 (XVBITREV_B v32i8:$xj, v32i8:$xk))>;
@@ -1580,6 +1598,15 @@ def : Pat<(xor (v8i32 LASX256:$xj), (v8i32 (vsplat_uimm_pow2 uimm5:$imm))),
           (XVBITREVI_W LASX256:$xj, uimm5:$imm)>;
 def : Pat<(xor (v4i64 LASX256:$xj), (v4i64 (vsplat_uimm_pow2 uimm6:$imm))),
           (XVBITREVI_D LASX256:$xj, uimm6:$imm)>;
+
+foreach vt = [v16i16, v8i32, v4i64] in {
+  def : Pat<(xor (vt LASX256:$vj), (vt (vsplat_i8_pow2 grlenimm:$imm))),
+            (XVBITREVI_B LASX256:$vj, grlenimm:$imm)>;
+  def : Pat<(xor (vt LASX256:$vj), (vt (vsplat_i16_pow2 grlenimm:$imm))),
+            (XVBITREVI_H LASX256:$vj, grlenimm:$imm)>;
+  def : Pat<(xor (vt LASX256:$vj), (vt (vsplat_i32_pow2 grlenimm:$imm))),
+            (XVBITREVI_W LASX256:$vj, grlenimm:$imm)>;
+}
 
 // Vector bswaps
 def : Pat<(bswap (v16i16 LASX256:$xj)), (XVSHUF4I_B LASX256:$xj, 0b10110001)>;

--- a/llvm/lib/Target/LoongArch/LoongArchLASXInstrInfo.td
+++ b/llvm/lib/Target/LoongArch/LoongArchLASXInstrInfo.td
@@ -1526,12 +1526,12 @@ def : Pat<(and (v4i64 LASX256:$xj), (v4i64 (vsplat_uimm_inv_pow2 uimm6:$imm))),
           (XVBITCLRI_D LASX256:$xj, uimm6:$imm)>;
 
 foreach vt = [v16i16, v8i32, v4i64] in {
-  def : Pat<(and (vt LASX256:$vj), (vt (vsplat_i8_inv_pow2 grlenimm:$imm))),
-            (XVBITCLRI_B LASX256:$vj, grlenimm:$imm)>;
-  def : Pat<(and (vt LASX256:$vj), (vt (vsplat_i16_inv_pow2 grlenimm:$imm))),
-            (XVBITCLRI_H LASX256:$vj, grlenimm:$imm)>;
-  def : Pat<(and (vt LASX256:$vj), (vt (vsplat_i32_inv_pow2 grlenimm:$imm))),
-            (XVBITCLRI_W LASX256:$vj, grlenimm:$imm)>;
+  def : Pat<(and (vt LASX256:$xj), (vt (vsplat_i8_inv_pow2 grlenimm:$imm))),
+            (XVBITCLRI_B LASX256:$xj, grlenimm:$imm)>;
+  def : Pat<(and (vt LASX256:$xj), (vt (vsplat_i16_inv_pow2 grlenimm:$imm))),
+            (XVBITCLRI_H LASX256:$xj, grlenimm:$imm)>;
+  def : Pat<(and (vt LASX256:$xj), (vt (vsplat_i32_inv_pow2 grlenimm:$imm))),
+            (XVBITCLRI_W LASX256:$xj, grlenimm:$imm)>;
 }
 
 // XVBITSET_{B/H/W/D}
@@ -1563,12 +1563,12 @@ def : Pat<(or (v4i64 LASX256:$xj), (v4i64 (vsplat_uimm_pow2 uimm6:$imm))),
           (XVBITSETI_D LASX256:$xj, uimm6:$imm)>;
 
 foreach vt = [v16i16, v8i32, v4i64] in {
-  def : Pat<(or (vt LASX256:$vj), (vt (vsplat_i8_pow2 grlenimm:$imm))),
-            (XVBITSETI_B LASX256:$vj, grlenimm:$imm)>;
-  def : Pat<(or (vt LASX256:$vj), (vt (vsplat_i16_pow2 grlenimm:$imm))),
-            (XVBITSETI_H LASX256:$vj, grlenimm:$imm)>;
-  def : Pat<(or (vt LASX256:$vj), (vt (vsplat_i32_pow2 grlenimm:$imm))),
-            (XVBITSETI_W LASX256:$vj, grlenimm:$imm)>;
+  def : Pat<(or (vt LASX256:$xj), (vt (vsplat_i8_pow2 grlenimm:$imm))),
+            (XVBITSETI_B LASX256:$xj, grlenimm:$imm)>;
+  def : Pat<(or (vt LASX256:$xj), (vt (vsplat_i16_pow2 grlenimm:$imm))),
+            (XVBITSETI_H LASX256:$xj, grlenimm:$imm)>;
+  def : Pat<(or (vt LASX256:$xj), (vt (vsplat_i32_pow2 grlenimm:$imm))),
+            (XVBITSETI_W LASX256:$xj, grlenimm:$imm)>;
 }
 
 // XVBITREV_{B/H/W/D}
@@ -1600,12 +1600,12 @@ def : Pat<(xor (v4i64 LASX256:$xj), (v4i64 (vsplat_uimm_pow2 uimm6:$imm))),
           (XVBITREVI_D LASX256:$xj, uimm6:$imm)>;
 
 foreach vt = [v16i16, v8i32, v4i64] in {
-  def : Pat<(xor (vt LASX256:$vj), (vt (vsplat_i8_pow2 grlenimm:$imm))),
-            (XVBITREVI_B LASX256:$vj, grlenimm:$imm)>;
-  def : Pat<(xor (vt LASX256:$vj), (vt (vsplat_i16_pow2 grlenimm:$imm))),
-            (XVBITREVI_H LASX256:$vj, grlenimm:$imm)>;
-  def : Pat<(xor (vt LASX256:$vj), (vt (vsplat_i32_pow2 grlenimm:$imm))),
-            (XVBITREVI_W LASX256:$vj, grlenimm:$imm)>;
+  def : Pat<(xor (vt LASX256:$xj), (vt (vsplat_i8_pow2 grlenimm:$imm))),
+            (XVBITREVI_B LASX256:$xj, grlenimm:$imm)>;
+  def : Pat<(xor (vt LASX256:$xj), (vt (vsplat_i16_pow2 grlenimm:$imm))),
+            (XVBITREVI_H LASX256:$xj, grlenimm:$imm)>;
+  def : Pat<(xor (vt LASX256:$xj), (vt (vsplat_i32_pow2 grlenimm:$imm))),
+            (XVBITREVI_W LASX256:$xj, grlenimm:$imm)>;
 }
 
 // Vector bswaps

--- a/llvm/lib/Target/LoongArch/LoongArchLSXInstrInfo.td
+++ b/llvm/lib/Target/LoongArch/LoongArchLSXInstrInfo.td
@@ -225,7 +225,15 @@ def vsplat_i8_uimm8 : ComplexPattern<vAny, 1, "selectVSplatImm<8, 8>",
 def vsplat_uimm_inv_pow2 : ComplexPattern<vAny, 1, "selectVSplatUimmInvPow2",
                                           [build_vector, bitconvert]>;
 
+foreach N = [8, 16, 32] in
+def vsplat_i#N#_inv_pow2 : ComplexPattern<vAny, 1, "selectVSplatUimmInvPow2<"#N#">",
+                                          [build_vector, bitconvert]>;
+
 def vsplat_uimm_pow2 : ComplexPattern<vAny, 1, "selectVSplatUimmPow2",
+                                      [build_vector, bitconvert]>;
+
+foreach N = [8, 16, 32] in
+def vsplat_i#N#_pow2 : ComplexPattern<vAny, 1, "selectVSplatUimmPow2<"#N#">",
                                       [build_vector, bitconvert]>;
 
 def muladd : PatFrag<(ops node:$vd, node:$vj, node:$vk),
@@ -1754,6 +1762,15 @@ def : Pat<(and (v4i32 LSX128:$vj), (v4i32 (vsplat_uimm_inv_pow2 uimm5:$imm))),
 def : Pat<(and (v2i64 LSX128:$vj), (v2i64 (vsplat_uimm_inv_pow2 uimm6:$imm))),
           (VBITCLRI_D LSX128:$vj, uimm6:$imm)>;
 
+foreach vt = [v8i16, v4i32, v2i64] in {
+  def : Pat<(and (vt LSX128:$vj), (vt (vsplat_i8_inv_pow2 grlenimm:$imm))),
+            (VBITCLRI_B LSX128:$vj, grlenimm:$imm)>;
+  def : Pat<(and (vt LSX128:$vj), (vt (vsplat_i16_inv_pow2 grlenimm:$imm))),
+            (VBITCLRI_H LSX128:$vj, grlenimm:$imm)>;
+  def : Pat<(and (vt LSX128:$vj), (vt (vsplat_i32_inv_pow2 grlenimm:$imm))),
+            (VBITCLRI_W LSX128:$vj, grlenimm:$imm)>;
+}
+
 // VBITSET_{B/H/W/D}
 def : Pat<(or v16i8:$vj, (shl vsplat_imm_eq_1, v16i8:$vk)),
           (v16i8 (VBITSET_B v16i8:$vj, v16i8:$vk))>;
@@ -1782,6 +1799,15 @@ def : Pat<(or (v4i32 LSX128:$vj), (v4i32 (vsplat_uimm_pow2 uimm5:$imm))),
 def : Pat<(or (v2i64 LSX128:$vj), (v2i64 (vsplat_uimm_pow2 uimm6:$imm))),
           (VBITSETI_D LSX128:$vj, uimm6:$imm)>;
 
+foreach vt = [v8i16, v4i32, v2i64] in {
+  def : Pat<(or (vt LSX128:$vj), (vt (vsplat_i8_pow2 grlenimm:$imm))),
+            (VBITSETI_B LSX128:$vj, grlenimm:$imm)>;
+  def : Pat<(or (vt LSX128:$vj), (vt (vsplat_i16_pow2 grlenimm:$imm))),
+            (VBITSETI_H LSX128:$vj, grlenimm:$imm)>;
+  def : Pat<(or (vt LSX128:$vj), (vt (vsplat_i32_pow2 grlenimm:$imm))),
+            (VBITSETI_W LSX128:$vj, grlenimm:$imm)>;
+}
+
 // VBITREV_{B/H/W/D}
 def : Pat<(xor v16i8:$vj, (shl vsplat_imm_eq_1, v16i8:$vk)),
           (v16i8 (VBITREV_B v16i8:$vj, v16i8:$vk))>;
@@ -1809,6 +1835,15 @@ def : Pat<(xor (v4i32 LSX128:$vj), (v4i32 (vsplat_uimm_pow2 uimm5:$imm))),
           (VBITREVI_W LSX128:$vj, uimm5:$imm)>;
 def : Pat<(xor (v2i64 LSX128:$vj), (v2i64 (vsplat_uimm_pow2 uimm6:$imm))),
           (VBITREVI_D LSX128:$vj, uimm6:$imm)>;
+
+foreach vt = [v8i16, v4i32, v2i64] in {
+  def : Pat<(xor (vt LSX128:$vj), (vt (vsplat_i8_pow2 grlenimm:$imm))),
+            (VBITREVI_B LSX128:$vj, grlenimm:$imm)>;
+  def : Pat<(xor (vt LSX128:$vj), (vt (vsplat_i16_pow2 grlenimm:$imm))),
+            (VBITREVI_H LSX128:$vj, grlenimm:$imm)>;
+  def : Pat<(xor (vt LSX128:$vj), (vt (vsplat_i32_pow2 grlenimm:$imm))),
+            (VBITREVI_W LSX128:$vj, grlenimm:$imm)>;
+}
 
 // Vector bswaps
 def : Pat<(bswap (v8i16 LSX128:$vj)), (VSHUF4I_B LSX128:$vj, 0b10110001)>;

--- a/llvm/test/CodeGen/LoongArch/lasx/bitclr.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/bitclr.ll
@@ -55,8 +55,7 @@ entry:
 define <8 x i32> @bitclri_v16i16_v8i32(<8 x i32> %a) nounwind {
 ; CHECK-LABEL: bitclri_v16i16_v8i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xvrepli.h $xr1, -5
-; CHECK-NEXT:    xvand.v $xr0, $xr0, $xr1
+; CHECK-NEXT:    xvbitclri.h $xr0, $xr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = and <8 x i32> %a, splat (i32 -262149)
@@ -76,8 +75,7 @@ entry:
 define <4 x i64> @bitclri_v16i16_v4i64(<4 x i64> %a) nounwind {
 ; CHECK-LABEL: bitclri_v16i16_v4i64:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xvrepli.h $xr1, -5
-; CHECK-NEXT:    xvand.v $xr0, $xr0, $xr1
+; CHECK-NEXT:    xvbitclri.h $xr0, $xr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = and <4 x i64> %a, splat (i64 -1125917086973957)
@@ -87,8 +85,7 @@ entry:
 define <4 x i64> @bitclri_v8i32_v4i64(<4 x i64> %a) nounwind {
 ; CHECK-LABEL: bitclri_v8i32_v4i64:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xvrepli.w $xr1, -5
-; CHECK-NEXT:    xvand.v $xr0, $xr0, $xr1
+; CHECK-NEXT:    xvbitclri.w $xr0, $xr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = and <4 x i64> %a, splat (i64 -17179869189)

--- a/llvm/test/CodeGen/LoongArch/lasx/bitrev.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/bitrev.ll
@@ -55,8 +55,7 @@ entry:
 define <8 x i32> @bitrevi_v16i16_v8i32(<8 x i32> %a) nounwind {
 ; CHECK-LABEL: bitrevi_v16i16_v8i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xvrepli.h $xr1, 4
-; CHECK-NEXT:    xvxor.v $xr0, $xr0, $xr1
+; CHECK-NEXT:    xvbitrevi.h $xr0, $xr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = xor <8 x i32> %a, splat (i32 262148)
@@ -76,8 +75,7 @@ entry:
 define <4 x i64> @bitrevi_v16i16_v4i64(<4 x i64> %a) nounwind {
 ; CHECK-LABEL: bitrevi_v16i16_v4i64:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xvrepli.h $xr1, 4
-; CHECK-NEXT:    xvxor.v $xr0, $xr0, $xr1
+; CHECK-NEXT:    xvbitrevi.h $xr0, $xr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = xor <4 x i64> %a, splat (i64 1125917086973956)
@@ -87,8 +85,7 @@ entry:
 define <4 x i64> @bitrevi_v8i32_v4i64(<4 x i64> %a) nounwind {
 ; CHECK-LABEL: bitrevi_v8i32_v4i64:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xvrepli.w $xr1, 4
-; CHECK-NEXT:    xvxor.v $xr0, $xr0, $xr1
+; CHECK-NEXT:    xvbitrevi.w $xr0, $xr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = xor <4 x i64> %a, splat (i64 17179869188)

--- a/llvm/test/CodeGen/LoongArch/lasx/bitset.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/bitset.ll
@@ -55,8 +55,7 @@ entry:
 define <8 x i32> @bitseti_v16i16_v8i32(<8 x i32> %a) nounwind {
 ; CHECK-LABEL: bitseti_v16i16_v8i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xvrepli.h $xr1, 4
-; CHECK-NEXT:    xvor.v $xr0, $xr0, $xr1
+; CHECK-NEXT:    xvbitseti.h $xr0, $xr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = or <8 x i32> %a, splat (i32 262148)
@@ -76,8 +75,7 @@ entry:
 define <4 x i64> @bitseti_v16i16_v4i64(<4 x i64> %a) nounwind {
 ; CHECK-LABEL: bitseti_v16i16_v4i64:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xvrepli.h $xr1, 4
-; CHECK-NEXT:    xvor.v $xr0, $xr0, $xr1
+; CHECK-NEXT:    xvbitseti.h $xr0, $xr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = or <4 x i64> %a, splat (i64 1125917086973956)
@@ -87,8 +85,7 @@ entry:
 define <4 x i64> @bitseti_v8i32_v4i64(<4 x i64> %a) nounwind {
 ; CHECK-LABEL: bitseti_v8i32_v4i64:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xvrepli.w $xr1, 4
-; CHECK-NEXT:    xvor.v $xr0, $xr0, $xr1
+; CHECK-NEXT:    xvbitseti.w $xr0, $xr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = or <4 x i64> %a, splat (i64 17179869188)

--- a/llvm/test/CodeGen/LoongArch/lsx/bitclr.ll
+++ b/llvm/test/CodeGen/LoongArch/lsx/bitclr.ll
@@ -55,8 +55,7 @@ entry:
 define <4 x i32> @bitclri_v8i16_v4i32(<4 x i32> %a) nounwind {
 ; CHECK-LABEL: bitclri_v8i16_v4i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vrepli.h $vr1, -5
-; CHECK-NEXT:    vand.v $vr0, $vr0, $vr1
+; CHECK-NEXT:    vbitclri.h $vr0, $vr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = and <4 x i32> %a, splat (i32 -262149)
@@ -76,8 +75,7 @@ entry:
 define <2 x i64> @bitclri_v8i16_v2i64(<2 x i64> %a) nounwind {
 ; CHECK-LABEL: bitclri_v8i16_v2i64:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vrepli.h $vr1, -5
-; CHECK-NEXT:    vand.v $vr0, $vr0, $vr1
+; CHECK-NEXT:    vbitclri.h $vr0, $vr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = and <2 x i64> %a, splat (i64 -1125917086973957)
@@ -87,8 +85,7 @@ entry:
 define <2 x i64> @bitclri_v4i32_v2i64(<2 x i64> %a) nounwind {
 ; CHECK-LABEL: bitclri_v4i32_v2i64:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vrepli.w $vr1, -5
-; CHECK-NEXT:    vand.v $vr0, $vr0, $vr1
+; CHECK-NEXT:    vbitclri.w $vr0, $vr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = and <2 x i64> %a, splat (i64 -17179869189)

--- a/llvm/test/CodeGen/LoongArch/lsx/bitrev.ll
+++ b/llvm/test/CodeGen/LoongArch/lsx/bitrev.ll
@@ -55,8 +55,7 @@ entry:
 define <4 x i32> @bitrevi_v8i16_v4i32(<4 x i32> %a) nounwind {
 ; CHECK-LABEL: bitrevi_v8i16_v4i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vrepli.h $vr1, 4
-; CHECK-NEXT:    vxor.v $vr0, $vr0, $vr1
+; CHECK-NEXT:    vbitrevi.h $vr0, $vr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = xor <4 x i32> %a, splat (i32 262148)
@@ -76,8 +75,7 @@ entry:
 define <2 x i64> @bitrevi_v8i16_v2i64(<2 x i64> %a) nounwind {
 ; CHECK-LABEL: bitrevi_v8i16_v2i64:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vrepli.h $vr1, 4
-; CHECK-NEXT:    vxor.v $vr0, $vr0, $vr1
+; CHECK-NEXT:    vbitrevi.h $vr0, $vr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = xor <2 x i64> %a, splat (i64 1125917086973956)
@@ -87,8 +85,7 @@ entry:
 define <2 x i64> @bitrevi_v4i32_v2i64(<2 x i64> %a) nounwind {
 ; CHECK-LABEL: bitrevi_v4i32_v2i64:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vrepli.w $vr1, 4
-; CHECK-NEXT:    vxor.v $vr0, $vr0, $vr1
+; CHECK-NEXT:    vbitrevi.w $vr0, $vr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = xor <2 x i64> %a, splat (i64 17179869188)

--- a/llvm/test/CodeGen/LoongArch/lsx/bitset.ll
+++ b/llvm/test/CodeGen/LoongArch/lsx/bitset.ll
@@ -55,8 +55,7 @@ entry:
 define <4 x i32> @bitseti_v8i16_v4i32(<4 x i32> %a) nounwind {
 ; CHECK-LABEL: bitseti_v8i16_v4i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vrepli.h $vr1, 4
-; CHECK-NEXT:    vor.v $vr0, $vr0, $vr1
+; CHECK-NEXT:    vbitseti.h $vr0, $vr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = or <4 x i32> %a, splat (i32 262148)
@@ -76,8 +75,7 @@ entry:
 define <2 x i64> @bitseti_v8i16_v2i64(<2 x i64> %a) nounwind {
 ; CHECK-LABEL: bitseti_v8i16_v2i64:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vrepli.h $vr1, 4
-; CHECK-NEXT:    vor.v $vr0, $vr0, $vr1
+; CHECK-NEXT:    vbitseti.h $vr0, $vr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = or <2 x i64> %a, splat (i64 1125917086973956)
@@ -87,8 +85,7 @@ entry:
 define <2 x i64> @bitseti_v4i32_v2i64(<2 x i64> %a) nounwind {
 ; CHECK-LABEL: bitseti_v4i32_v2i64:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vrepli.w $vr1, 4
-; CHECK-NEXT:    vor.v $vr0, $vr0, $vr1
+; CHECK-NEXT:    vbitseti.w $vr0, $vr0, 2
 ; CHECK-NEXT:    ret
 entry:
     %0 = or <2 x i64> %a, splat (i64 17179869188)


### PR DESCRIPTION
Extend vsplat_uimm_{pow2,inv_pow2} matching to allow specifying an explicit element bit width, enabling recognition of splat patterns whose logical element size differs from the vector's native element type.

Introduce templated selectVSplatUimm{Pow2,InvPow2} helpers with an optional EltSize parameter, and add corresponding ComplexPattern definitions for i8/i16/i32 element widths. This allows TableGen patterns to match cases such as operating on v8i32/v4i64 vectors with masks derived from smaller element sizes.

With these changes, AND/OR/XOR operations using inverse power-of-two or power-of-two splat masks are now correctly selected to VBITCLRI, VBITSETI, and VBITREVI instructions instead of falling back to vector logical operations with materialized constants.