### PR TITLE
[SelectionDAG][AArch64] Legalize vector.[de]interleave6

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
@@ -3990,7 +3990,7 @@ bool SelectionDAGLegalize::ExpandNode(SDNode *Node) {
   }
   case ISD::VECTOR_DEINTERLEAVE: {
     unsigned Factor = Node->getNumOperands();
-    if (Factor <= 2 || !isPowerOf2_32(Factor))
+    if (Factor <= 2 || Factor % 2 != 0)
       break;
     SmallVector<SDValue, 8> Ops(Node->ops());
     EVT VecVT = Node->getValueType(0);
@@ -4015,7 +4015,7 @@ bool SelectionDAGLegalize::ExpandNode(SDNode *Node) {
   }
   case ISD::VECTOR_INTERLEAVE: {
     unsigned Factor = Node->getNumOperands();
-    if (Factor <= 2 || !isPowerOf2_32(Factor))
+    if (Factor <= 2 || Factor % 2 != 0)
       break;
     EVT VecVT = Node->getValueType(0);
     SmallVector<EVT> HalfVTs(Factor / 2, VecVT);

--- a/llvm/test/CodeGen/AArch64/fixed-vector-deinterleave.ll
+++ b/llvm/test/CodeGen/AArch64/fixed-vector-deinterleave.ll
@@ -501,3 +501,121 @@ define {<8 x i8>, <8 x i8>, <8 x i8>} @vector_deinterleave3_v24i8(<8 x i8> %a, <
   %retval = call {<8 x i8>, <8 x i8>, <8 x i8>} @llvm.vector.deinterleave3.v24i8(<24 x i8> %ins2)
   ret {<8 x i8>, <8 x i8>, <8 x i8>} %retval
 }
+
+define {<2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>} @deinterleave6_v12f64(<2 x double> %a, <2 x double> %b, <2 x double> %c, <2 x double> %d, <2 x double> %e, <2 x double> %f){
+; CHECK-LABEL: deinterleave6_v12f64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    sub sp, sp, #96
+; CHECK-NEXT:    .cfi_def_cfa_offset 96
+; CHECK-NEXT:    mov x8, sp
+; CHECK-NEXT:    add x9, sp, #48
+; CHECK-NEXT:    str q5, [sp, #80]
+; CHECK-NEXT:    ld3 { v5.2d, v6.2d, v7.2d }, [x8]
+; CHECK-NEXT:    ld3 { v16.2d, v17.2d, v18.2d }, [x9]
+; CHECK-NEXT:    uzp1 v0.2d, v5.2d, v16.2d
+; CHECK-NEXT:    uzp1 v1.2d, v6.2d, v17.2d
+; CHECK-NEXT:    uzp1 v2.2d, v7.2d, v18.2d
+; CHECK-NEXT:    uzp2 v3.2d, v5.2d, v16.2d
+; CHECK-NEXT:    uzp2 v4.2d, v6.2d, v17.2d
+; CHECK-NEXT:    uzp2 v5.2d, v7.2d, v18.2d
+; CHECK-NEXT:    add sp, sp, #96
+; CHECK-NEXT:    ret
+  %ins0 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> poison, <2 x double> %a, i64 0)
+  %ins1 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> poison, <2 x double> %b, i64 2)
+  %ins2 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> poison, <2 x double> %c, i64 4)
+  %ins3 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> poison, <2 x double> %d, i64 6)
+  %ins4 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> poison, <2 x double> %e, i64 8)
+  %ins5 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> poison, <2 x double> %f, i64 10)
+  %retval = call {<2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>} @llvm.vector.deinterleave6.v12f64(<12 x double> %ins5)
+  ret {<2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>} %retval
+}
+
+define {<4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>} @deinterleave6_v24i32(<4 x i32> %a, <4 x i32> %b, <4 x i32> %c, <4 x i32> %d, <4 x i32> %e, <4 x i32> %f) {
+; CHECK-LABEL: deinterleave6_v24i32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    sub sp, sp, #96
+; CHECK-NEXT:    .cfi_def_cfa_offset 96
+; CHECK-NEXT:    stp q0, q1, [sp]
+; CHECK-NEXT:    add x8, sp, #48
+; CHECK-NEXT:    mov x9, sp
+; CHECK-NEXT:    stp q2, q3, [sp, #32]
+; CHECK-NEXT:    stp q4, q5, [sp, #64]
+; CHECK-NEXT:    ld3 { v5.4s, v6.4s, v7.4s }, [x8]
+; CHECK-NEXT:    ld3 { v16.4s, v17.4s, v18.4s }, [x9]
+; CHECK-NEXT:    uzp1 v0.4s, v16.4s, v5.4s
+; CHECK-NEXT:    uzp1 v1.4s, v17.4s, v6.4s
+; CHECK-NEXT:    uzp1 v2.4s, v18.4s, v7.4s
+; CHECK-NEXT:    uzp2 v3.4s, v16.4s, v5.4s
+; CHECK-NEXT:    uzp2 v4.4s, v17.4s, v6.4s
+; CHECK-NEXT:    uzp2 v5.4s, v18.4s, v7.4s
+; CHECK-NEXT:    add sp, sp, #96
+; CHECK-NEXT:    ret
+  %ins0 = call <24 x i32> @llvm.vector.insert.v24i32.v4i32(<24 x i32> poison,  <4 x i32> %a, i64 0)
+  %ins1 = call <24 x i32> @llvm.vector.insert.v24i32.v4i32(<24 x i32> %ins0,   <4 x i32> %b, i64 4)
+  %ins2 = call <24 x i32> @llvm.vector.insert.v24i32.v4i32(<24 x i32> %ins1,   <4 x i32> %c, i64 8)
+  %ins3 = call <24 x i32> @llvm.vector.insert.v24i32.v4i32(<24 x i32> %ins2,   <4 x i32> %d, i64 12)
+  %ins4 = call <24 x i32> @llvm.vector.insert.v24i32.v4i32(<24 x i32> %ins3,   <4 x i32> %e, i64 16)
+  %ins5 = call <24 x i32> @llvm.vector.insert.v24i32.v4i32(<24 x i32> %ins4,   <4 x i32> %f, i64 20)
+  %retval = call {<4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>} @llvm.vector.deinterleave6.v24i32(<24 x i32> %ins5)
+  ret {<4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>} %retval
+}
+
+define {<8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>} @deinterleave6_v48bf16(<8 x bfloat> %a, <8 x bfloat> %b, <8 x bfloat> %c, <8 x bfloat> %d, <8 x bfloat> %e, <8 x bfloat> %f) {
+; CHECK-LABEL: deinterleave6_v48bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    sub sp, sp, #96
+; CHECK-NEXT:    .cfi_def_cfa_offset 96
+; CHECK-NEXT:    stp q0, q1, [sp]
+; CHECK-NEXT:    add x8, sp, #48
+; CHECK-NEXT:    mov x9, sp
+; CHECK-NEXT:    stp q2, q3, [sp, #32]
+; CHECK-NEXT:    stp q4, q5, [sp, #64]
+; CHECK-NEXT:    ld3 { v5.8h, v6.8h, v7.8h }, [x8]
+; CHECK-NEXT:    ld3 { v16.8h, v17.8h, v18.8h }, [x9]
+; CHECK-NEXT:    uzp1 v0.8h, v16.8h, v5.8h
+; CHECK-NEXT:    uzp1 v1.8h, v17.8h, v6.8h
+; CHECK-NEXT:    uzp1 v2.8h, v18.8h, v7.8h
+; CHECK-NEXT:    uzp2 v3.8h, v16.8h, v5.8h
+; CHECK-NEXT:    uzp2 v4.8h, v17.8h, v6.8h
+; CHECK-NEXT:    uzp2 v5.8h, v18.8h, v7.8h
+; CHECK-NEXT:    add sp, sp, #96
+; CHECK-NEXT:    ret
+  %ins0 = call <48 x bfloat> @llvm.vector.insert.v48bf16.v8bf16(<48 x bfloat> poison, <8 x bfloat> %a, i64 0)
+  %ins1 = call <48 x bfloat> @llvm.vector.insert.v48bf16.v8bf16(<48 x bfloat> %ins0, <8 x bfloat> %b, i64 8)
+  %ins2 = call <48 x bfloat> @llvm.vector.insert.v48bf16.v8bf16(<48 x bfloat> %ins1, <8 x bfloat> %c, i64 16)
+  %ins3 = call <48 x bfloat> @llvm.vector.insert.v48bf16.v8bf16(<48 x bfloat> %ins2, <8 x bfloat> %d, i64 24)
+  %ins4 = call <48 x bfloat> @llvm.vector.insert.v48bf16.v8bf16(<48 x bfloat> %ins3, <8 x bfloat> %e, i64 32)
+  %ins5 = call <48 x bfloat> @llvm.vector.insert.v48bf16.v8bf16(<48 x bfloat> %ins4, <8 x bfloat> %f, i64 40)
+  %retval = call {<8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>} @llvm.vector.deinterleave6.v48bf16(<48 x bfloat> %ins5)
+  ret {<8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>} %retval
+}
+
+define {<16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>} @deinterleave6_v96i8(<16 x i8> %a, <16 x i8> %b, <16 x i8> %c, <16 x i8> %d, <16 x i8> %e, <16 x i8> %f) {
+; CHECK-LABEL: deinterleave6_v96i8:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    sub sp, sp, #96
+; CHECK-NEXT:    .cfi_def_cfa_offset 96
+; CHECK-NEXT:    stp q0, q1, [sp]
+; CHECK-NEXT:    add x8, sp, #48
+; CHECK-NEXT:    mov x9, sp
+; CHECK-NEXT:    stp q2, q3, [sp, #32]
+; CHECK-NEXT:    stp q4, q5, [sp, #64]
+; CHECK-NEXT:    ld3 { v5.16b, v6.16b, v7.16b }, [x8]
+; CHECK-NEXT:    ld3 { v16.16b, v17.16b, v18.16b }, [x9]
+; CHECK-NEXT:    uzp1 v0.16b, v16.16b, v5.16b
+; CHECK-NEXT:    uzp1 v1.16b, v17.16b, v6.16b
+; CHECK-NEXT:    uzp1 v2.16b, v18.16b, v7.16b
+; CHECK-NEXT:    uzp2 v3.16b, v16.16b, v5.16b
+; CHECK-NEXT:    uzp2 v4.16b, v17.16b, v6.16b
+; CHECK-NEXT:    uzp2 v5.16b, v18.16b, v7.16b
+; CHECK-NEXT:    add sp, sp, #96
+; CHECK-NEXT:    ret
+  %ins0 = call <96 x i8> @llvm.vector.insert.v96i8.v16i8(<96 x i8> poison, <16 x i8> %a, i64 0)
+  %ins1 = call <96 x i8> @llvm.vector.insert.v96i8.v16i8(<96 x i8> %ins0, <16 x i8> %b, i64 16)
+  %ins2 = call <96 x i8> @llvm.vector.insert.v96i8.v16i8(<96 x i8> %ins1, <16 x i8> %c, i64 32)
+  %ins3 = call <96 x i8> @llvm.vector.insert.v96i8.v16i8(<96 x i8> %ins2, <16 x i8> %d, i64 48)
+  %ins4 = call <96 x i8> @llvm.vector.insert.v96i8.v16i8(<96 x i8> %ins3, <16 x i8> %e, i64 64)
+  %ins5 = call <96 x i8> @llvm.vector.insert.v96i8.v16i8(<96 x i8> %ins4, <16 x i8> %f, i64 80)
+  %retval = call {<16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>} @llvm.vector.deinterleave6.v96i8(<96 x i8> %ins5)
+  ret {<16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>} %retval
+}

--- a/llvm/test/CodeGen/AArch64/fixed-vector-deinterleave.ll
+++ b/llvm/test/CodeGen/AArch64/fixed-vector-deinterleave.ll
@@ -507,25 +507,27 @@ define {<2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub sp, sp, #96
 ; CHECK-NEXT:    .cfi_def_cfa_offset 96
-; CHECK-NEXT:    mov x8, sp
-; CHECK-NEXT:    add x9, sp, #48
-; CHECK-NEXT:    str q5, [sp, #80]
+; CHECK-NEXT:    stp q0, q1, [sp]
+; CHECK-NEXT:    add x8, sp, #48
+; CHECK-NEXT:    mov x9, sp
+; CHECK-NEXT:    stp q2, q3, [sp, #32]
+; CHECK-NEXT:    stp q4, q5, [sp, #64]
 ; CHECK-NEXT:    ld3 { v5.2d, v6.2d, v7.2d }, [x8]
 ; CHECK-NEXT:    ld3 { v16.2d, v17.2d, v18.2d }, [x9]
-; CHECK-NEXT:    uzp1 v0.2d, v5.2d, v16.2d
-; CHECK-NEXT:    uzp1 v1.2d, v6.2d, v17.2d
-; CHECK-NEXT:    uzp1 v2.2d, v7.2d, v18.2d
-; CHECK-NEXT:    uzp2 v3.2d, v5.2d, v16.2d
-; CHECK-NEXT:    uzp2 v4.2d, v6.2d, v17.2d
-; CHECK-NEXT:    uzp2 v5.2d, v7.2d, v18.2d
+; CHECK-NEXT:    uzp1 v0.2d, v16.2d, v5.2d
+; CHECK-NEXT:    uzp1 v1.2d, v17.2d, v6.2d
+; CHECK-NEXT:    uzp1 v2.2d, v18.2d, v7.2d
+; CHECK-NEXT:    uzp2 v3.2d, v16.2d, v5.2d
+; CHECK-NEXT:    uzp2 v4.2d, v17.2d, v6.2d
+; CHECK-NEXT:    uzp2 v5.2d, v18.2d, v7.2d
 ; CHECK-NEXT:    add sp, sp, #96
 ; CHECK-NEXT:    ret
   %ins0 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> poison, <2 x double> %a, i64 0)
-  %ins1 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> poison, <2 x double> %b, i64 2)
-  %ins2 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> poison, <2 x double> %c, i64 4)
-  %ins3 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> poison, <2 x double> %d, i64 6)
-  %ins4 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> poison, <2 x double> %e, i64 8)
-  %ins5 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> poison, <2 x double> %f, i64 10)
+  %ins1 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> %ins0, <2 x double> %b, i64 2)
+  %ins2 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> %ins1, <2 x double> %c, i64 4)
+  %ins3 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> %ins2, <2 x double> %d, i64 6)
+  %ins4 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> %ins3, <2 x double> %e, i64 8)
+  %ins5 = call <12 x double> @llvm.vector.insert.v12f64.v2f64(<12 x double> %ins4, <2 x double> %f, i64 10)
   %retval = call {<2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>} @llvm.vector.deinterleave6.v12f64(<12 x double> %ins5)
   ret {<2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>} %retval
 }
@@ -560,6 +562,36 @@ define {<4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>} @deint
   ret {<4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>} %retval
 }
 
+define {<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>} @deinterleave6_v12i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c, <2 x i32> %d, <2 x i32> %e, <2 x i32> %f) {
+; CHECK-LABEL: deinterleave6_v12i32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    sub sp, sp, #48
+; CHECK-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-NEXT:    stp d4, d5, [sp, #32]
+; CHECK-NEXT:    add x8, sp, #24
+; CHECK-NEXT:    mov x9, sp
+; CHECK-NEXT:    stp d2, d3, [sp, #16]
+; CHECK-NEXT:    stp d0, d1, [sp]
+; CHECK-NEXT:    ld3 { v5.2s, v6.2s, v7.2s }, [x8]
+; CHECK-NEXT:    ld3 { v16.2s, v17.2s, v18.2s }, [x9]
+; CHECK-NEXT:    uzp1 v0.2s, v16.2s, v5.2s
+; CHECK-NEXT:    uzp1 v1.2s, v17.2s, v6.2s
+; CHECK-NEXT:    uzp1 v2.2s, v18.2s, v7.2s
+; CHECK-NEXT:    uzp2 v3.2s, v16.2s, v5.2s
+; CHECK-NEXT:    uzp2 v4.2s, v17.2s, v6.2s
+; CHECK-NEXT:    uzp2 v5.2s, v18.2s, v7.2s
+; CHECK-NEXT:    add sp, sp, #48
+; CHECK-NEXT:    ret
+  %ins0 = call <12 x i32> @llvm.vector.insert.v12i32.v2i32(<12 x i32> poison, <2 x i32> %a, i64 0)
+  %ins1 = call <12 x i32> @llvm.vector.insert.v12i32.v2i32(<12 x i32> %ins0,  <2 x i32> %b, i64 2)
+  %ins2 = call <12 x i32> @llvm.vector.insert.v12i32.v2i32(<12 x i32> %ins1,  <2 x i32> %c, i64 4)
+  %ins3 = call <12 x i32> @llvm.vector.insert.v12i32.v2i32(<12 x i32> %ins2,  <2 x i32> %d, i64 6)
+  %ins4 = call <12 x i32> @llvm.vector.insert.v12i32.v2i32(<12 x i32> %ins3,  <2 x i32> %e, i64 8)
+  %ins5 = call <12 x i32> @llvm.vector.insert.v12i32.v2i32(<12 x i32> %ins4,  <2 x i32> %f, i64 10)
+  %retval = call {<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>} @llvm.vector.deinterleave6.v12i32(<12 x i32> %ins5)
+  ret {<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>} %retval
+}
+
 define {<8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>} @deinterleave6_v48bf16(<8 x bfloat> %a, <8 x bfloat> %b, <8 x bfloat> %c, <8 x bfloat> %d, <8 x bfloat> %e, <8 x bfloat> %f) {
 ; CHECK-LABEL: deinterleave6_v48bf16:
 ; CHECK:       // %bb.0:
@@ -590,6 +622,36 @@ define {<8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8
   ret {<8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>} %retval
 }
 
+define {<4 x i16>, <4 x i16>, <4 x i16>, <4 x i16>, <4 x i16>, <4 x i16>} @deinterleave6_v24i16(<4 x i16> %a, <4 x i16> %b, <4 x i16> %c, <4 x i16> %d, <4 x i16> %e, <4 x i16> %f) {
+; CHECK-LABEL: deinterleave6_v24i16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    sub sp, sp, #48
+; CHECK-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-NEXT:    stp d4, d5, [sp, #32]
+; CHECK-NEXT:    add x8, sp, #24
+; CHECK-NEXT:    mov x9, sp
+; CHECK-NEXT:    stp d2, d3, [sp, #16]
+; CHECK-NEXT:    stp d0, d1, [sp]
+; CHECK-NEXT:    ld3 { v5.4h, v6.4h, v7.4h }, [x8]
+; CHECK-NEXT:    ld3 { v16.4h, v17.4h, v18.4h }, [x9]
+; CHECK-NEXT:    uzp1 v0.4h, v16.4h, v5.4h
+; CHECK-NEXT:    uzp1 v1.4h, v17.4h, v6.4h
+; CHECK-NEXT:    uzp1 v2.4h, v18.4h, v7.4h
+; CHECK-NEXT:    uzp2 v3.4h, v16.4h, v5.4h
+; CHECK-NEXT:    uzp2 v4.4h, v17.4h, v6.4h
+; CHECK-NEXT:    uzp2 v5.4h, v18.4h, v7.4h
+; CHECK-NEXT:    add sp, sp, #48
+; CHECK-NEXT:    ret
+  %ins0 = call <24 x i16> @llvm.vector.insert.v24i16.v4i16(<24 x i16> poison, <4 x i16> %a, i64 0)
+  %ins1 = call <24 x i16> @llvm.vector.insert.v24i16.v4i16(<24 x i16> %ins0,  <4 x i16> %b, i64 4)
+  %ins2 = call <24 x i16> @llvm.vector.insert.v24i16.v4i16(<24 x i16> %ins1,  <4 x i16> %c, i64 8)
+  %ins3 = call <24 x i16> @llvm.vector.insert.v24i16.v4i16(<24 x i16> %ins2,  <4 x i16> %d, i64 12)
+  %ins4 = call <24 x i16> @llvm.vector.insert.v24i16.v4i16(<24 x i16> %ins3,  <4 x i16> %e, i64 16)
+  %ins5 = call <24 x i16> @llvm.vector.insert.v24i16.v4i16(<24 x i16> %ins4,  <4 x i16> %f, i64 20)
+  %retval = call {<4 x i16>, <4 x i16>, <4 x i16>, <4 x i16>, <4 x i16>, <4 x i16>} @llvm.vector.deinterleave6.v24i16(<24 x i16> %ins5)
+  ret {<4 x i16>, <4 x i16>, <4 x i16>, <4 x i16>, <4 x i16>, <4 x i16>} %retval
+}
+
 define {<16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>} @deinterleave6_v96i8(<16 x i8> %a, <16 x i8> %b, <16 x i8> %c, <16 x i8> %d, <16 x i8> %e, <16 x i8> %f) {
 ; CHECK-LABEL: deinterleave6_v96i8:
 ; CHECK:       // %bb.0:
@@ -618,4 +680,173 @@ define {<16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>} @deint
   %ins5 = call <96 x i8> @llvm.vector.insert.v96i8.v16i8(<96 x i8> %ins4, <16 x i8> %f, i64 80)
   %retval = call {<16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>} @llvm.vector.deinterleave6.v96i8(<96 x i8> %ins5)
   ret {<16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>} %retval
+}
+
+
+define {<2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>} @deinterleave8_v16f64(
+; CHECK-LABEL: deinterleave8_v16f64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    uzp1 v16.2d, v6.2d, v7.2d
+; CHECK-NEXT:    uzp1 v17.2d, v4.2d, v5.2d
+; CHECK-NEXT:    uzp1 v18.2d, v2.2d, v3.2d
+; CHECK-NEXT:    uzp1 v19.2d, v0.2d, v1.2d
+; CHECK-NEXT:    uzp2 v6.2d, v6.2d, v7.2d
+; CHECK-NEXT:    uzp2 v4.2d, v4.2d, v5.2d
+; CHECK-NEXT:    uzp2 v2.2d, v2.2d, v3.2d
+; CHECK-NEXT:    uzp2 v0.2d, v0.2d, v1.2d
+; CHECK-NEXT:    uzp1 v5.2d, v17.2d, v16.2d
+; CHECK-NEXT:    uzp2 v16.2d, v17.2d, v16.2d
+; CHECK-NEXT:    uzp1 v7.2d, v19.2d, v18.2d
+; CHECK-NEXT:    uzp1 v20.2d, v4.2d, v6.2d
+; CHECK-NEXT:    uzp2 v17.2d, v19.2d, v18.2d
+; CHECK-NEXT:    uzp1 v21.2d, v0.2d, v2.2d
+; CHECK-NEXT:    uzp2 v18.2d, v4.2d, v6.2d
+; CHECK-NEXT:    uzp2 v19.2d, v0.2d, v2.2d
+; CHECK-NEXT:    uzp1 v0.2d, v7.2d, v5.2d
+; CHECK-NEXT:    uzp1 v2.2d, v17.2d, v16.2d
+; CHECK-NEXT:    uzp2 v4.2d, v7.2d, v5.2d
+; CHECK-NEXT:    uzp1 v1.2d, v21.2d, v20.2d
+; CHECK-NEXT:    uzp1 v3.2d, v19.2d, v18.2d
+; CHECK-NEXT:    uzp2 v5.2d, v21.2d, v20.2d
+; CHECK-NEXT:    uzp2 v6.2d, v17.2d, v16.2d
+; CHECK-NEXT:    uzp2 v7.2d, v19.2d, v18.2d
+; CHECK-NEXT:    ret
+    <2 x double> %a, <2 x double> %b, <2 x double> %c, <2 x double> %d,
+    <2 x double> %e, <2 x double> %f, <2 x double> %g, <2 x double> %h) {
+  %ins0 = call <16 x double> @llvm.vector.insert.v16f64.v2f64(<16 x double> poison, <2 x double> %a, i64 0)
+  %ins1 = call <16 x double> @llvm.vector.insert.v16f64.v2f64(<16 x double> %ins0,  <2 x double> %b, i64 2)
+  %ins2 = call <16 x double> @llvm.vector.insert.v16f64.v2f64(<16 x double> %ins1,  <2 x double> %c, i64 4)
+  %ins3 = call <16 x double> @llvm.vector.insert.v16f64.v2f64(<16 x double> %ins2,  <2 x double> %d, i64 6)
+  %ins4 = call <16 x double> @llvm.vector.insert.v16f64.v2f64(<16 x double> %ins3,  <2 x double> %e, i64 8)
+  %ins5 = call <16 x double> @llvm.vector.insert.v16f64.v2f64(<16 x double> %ins4,  <2 x double> %f, i64 10)
+  %ins6 = call <16 x double> @llvm.vector.insert.v16f64.v2f64(<16 x double> %ins5,  <2 x double> %g, i64 12)
+  %ins7 = call <16 x double> @llvm.vector.insert.v16f64.v2f64(<16 x double> %ins6,  <2 x double> %h, i64 14)
+  %retval = call {<2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>} @llvm.vector.deinterleave8.v16f64(<16 x double> %ins7)
+  ret {<2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>, <2 x double>} %retval
+}
+
+define {<4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>} @deinterleave8_v32i32(
+; CHECK-LABEL: deinterleave8_v32i32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    uzp1 v16.4s, v6.4s, v7.4s
+; CHECK-NEXT:    uzp1 v17.4s, v4.4s, v5.4s
+; CHECK-NEXT:    uzp1 v18.4s, v2.4s, v3.4s
+; CHECK-NEXT:    uzp1 v19.4s, v0.4s, v1.4s
+; CHECK-NEXT:    uzp2 v6.4s, v6.4s, v7.4s
+; CHECK-NEXT:    uzp2 v4.4s, v4.4s, v5.4s
+; CHECK-NEXT:    uzp2 v2.4s, v2.4s, v3.4s
+; CHECK-NEXT:    uzp2 v0.4s, v0.4s, v1.4s
+; CHECK-NEXT:    uzp1 v5.4s, v17.4s, v16.4s
+; CHECK-NEXT:    uzp2 v16.4s, v17.4s, v16.4s
+; CHECK-NEXT:    uzp1 v7.4s, v19.4s, v18.4s
+; CHECK-NEXT:    uzp1 v20.4s, v4.4s, v6.4s
+; CHECK-NEXT:    uzp2 v17.4s, v19.4s, v18.4s
+; CHECK-NEXT:    uzp1 v21.4s, v0.4s, v2.4s
+; CHECK-NEXT:    uzp2 v18.4s, v4.4s, v6.4s
+; CHECK-NEXT:    uzp2 v19.4s, v0.4s, v2.4s
+; CHECK-NEXT:    uzp1 v0.4s, v7.4s, v5.4s
+; CHECK-NEXT:    uzp1 v2.4s, v17.4s, v16.4s
+; CHECK-NEXT:    uzp2 v4.4s, v7.4s, v5.4s
+; CHECK-NEXT:    uzp1 v1.4s, v21.4s, v20.4s
+; CHECK-NEXT:    uzp1 v3.4s, v19.4s, v18.4s
+; CHECK-NEXT:    uzp2 v5.4s, v21.4s, v20.4s
+; CHECK-NEXT:    uzp2 v6.4s, v17.4s, v16.4s
+; CHECK-NEXT:    uzp2 v7.4s, v19.4s, v18.4s
+; CHECK-NEXT:    ret
+    <4 x i32> %a, <4 x i32> %b, <4 x i32> %c, <4 x i32> %d,
+    <4 x i32> %e, <4 x i32> %f, <4 x i32> %g, <4 x i32> %h) {
+  %ins0 = call <32 x i32> @llvm.vector.insert.v32i32.v4i32(<32 x i32> poison, <4 x i32> %a, i64 0)
+  %ins1 = call <32 x i32> @llvm.vector.insert.v32i32.v4i32(<32 x i32> %ins0,  <4 x i32> %b, i64 4)
+  %ins2 = call <32 x i32> @llvm.vector.insert.v32i32.v4i32(<32 x i32> %ins1,  <4 x i32> %c, i64 8)
+  %ins3 = call <32 x i32> @llvm.vector.insert.v32i32.v4i32(<32 x i32> %ins2,  <4 x i32> %d, i64 12)
+  %ins4 = call <32 x i32> @llvm.vector.insert.v32i32.v4i32(<32 x i32> %ins3,  <4 x i32> %e, i64 16)
+  %ins5 = call <32 x i32> @llvm.vector.insert.v32i32.v4i32(<32 x i32> %ins4,  <4 x i32> %f, i64 20)
+  %ins6 = call <32 x i32> @llvm.vector.insert.v32i32.v4i32(<32 x i32> %ins5,  <4 x i32> %g, i64 24)
+  %ins7 = call <32 x i32> @llvm.vector.insert.v32i32.v4i32(<32 x i32> %ins6,  <4 x i32> %h, i64 28)
+  %retval = call {<4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>} @llvm.vector.deinterleave8.v32i32(<32 x i32> %ins7)
+  ret {<4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>} %retval
+}
+
+define {<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>} @deinterleave8_v16i32(
+; CHECK-LABEL: deinterleave8_v16i32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    uzp1 v16.2s, v6.2s, v7.2s
+; CHECK-NEXT:    uzp1 v17.2s, v4.2s, v5.2s
+; CHECK-NEXT:    uzp1 v18.2s, v2.2s, v3.2s
+; CHECK-NEXT:    uzp1 v19.2s, v0.2s, v1.2s
+; CHECK-NEXT:    uzp2 v6.2s, v6.2s, v7.2s
+; CHECK-NEXT:    uzp2 v4.2s, v4.2s, v5.2s
+; CHECK-NEXT:    uzp2 v2.2s, v2.2s, v3.2s
+; CHECK-NEXT:    uzp2 v0.2s, v0.2s, v1.2s
+; CHECK-NEXT:    uzp1 v5.2s, v17.2s, v16.2s
+; CHECK-NEXT:    uzp2 v16.2s, v17.2s, v16.2s
+; CHECK-NEXT:    uzp1 v7.2s, v19.2s, v18.2s
+; CHECK-NEXT:    uzp1 v20.2s, v4.2s, v6.2s
+; CHECK-NEXT:    uzp2 v17.2s, v19.2s, v18.2s
+; CHECK-NEXT:    uzp1 v21.2s, v0.2s, v2.2s
+; CHECK-NEXT:    uzp2 v18.2s, v4.2s, v6.2s
+; CHECK-NEXT:    uzp2 v19.2s, v0.2s, v2.2s
+; CHECK-NEXT:    uzp1 v0.2s, v7.2s, v5.2s
+; CHECK-NEXT:    uzp1 v2.2s, v17.2s, v16.2s
+; CHECK-NEXT:    uzp2 v4.2s, v7.2s, v5.2s
+; CHECK-NEXT:    uzp1 v1.2s, v21.2s, v20.2s
+; CHECK-NEXT:    uzp1 v3.2s, v19.2s, v18.2s
+; CHECK-NEXT:    uzp2 v5.2s, v21.2s, v20.2s
+; CHECK-NEXT:    uzp2 v6.2s, v17.2s, v16.2s
+; CHECK-NEXT:    uzp2 v7.2s, v19.2s, v18.2s
+; CHECK-NEXT:    ret
+    <2 x i32> %a, <2 x i32> %b, <2 x i32> %c, <2 x i32> %d,
+    <2 x i32> %e, <2 x i32> %f, <2 x i32> %g, <2 x i32> %h) {
+  %ins0 = call <16 x i32> @llvm.vector.insert.v16i32.v2i32(<16 x i32> poison, <2 x i32> %a, i64 0)
+  %ins1 = call <16 x i32> @llvm.vector.insert.v16i32.v2i32(<16 x i32> %ins0,  <2 x i32> %b, i64 2)
+  %ins2 = call <16 x i32> @llvm.vector.insert.v16i32.v2i32(<16 x i32> %ins1,  <2 x i32> %c, i64 4)
+  %ins3 = call <16 x i32> @llvm.vector.insert.v16i32.v2i32(<16 x i32> %ins2,  <2 x i32> %d, i64 6)
+  %ins4 = call <16 x i32> @llvm.vector.insert.v16i32.v2i32(<16 x i32> %ins3,  <2 x i32> %e, i64 8)
+  %ins5 = call <16 x i32> @llvm.vector.insert.v16i32.v2i32(<16 x i32> %ins4,  <2 x i32> %f, i64 10)
+  %ins6 = call <16 x i32> @llvm.vector.insert.v16i32.v2i32(<16 x i32> %ins5,  <2 x i32> %g, i64 12)
+  %ins7 = call <16 x i32> @llvm.vector.insert.v16i32.v2i32(<16 x i32> %ins6,  <2 x i32> %h, i64 14)
+  %retval = call {<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>} @llvm.vector.deinterleave8.v16i32(<16 x i32> %ins7)
+  ret {<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>} %retval
+}
+
+define {<8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>} @deinterleave8_v64bf16(
+; CHECK-LABEL: deinterleave8_v64bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    uzp1 v16.8h, v6.8h, v7.8h
+; CHECK-NEXT:    uzp1 v17.8h, v4.8h, v5.8h
+; CHECK-NEXT:    uzp1 v18.8h, v2.8h, v3.8h
+; CHECK-NEXT:    uzp1 v19.8h, v0.8h, v1.8h
+; CHECK-NEXT:    uzp2 v6.8h, v6.8h, v7.8h
+; CHECK-NEXT:    uzp2 v4.8h, v4.8h, v5.8h
+; CHECK-NEXT:    uzp2 v2.8h, v2.8h, v3.8h
+; CHECK-NEXT:    uzp2 v0.8h, v0.8h, v1.8h
+; CHECK-NEXT:    uzp1 v5.8h, v17.8h, v16.8h
+; CHECK-NEXT:    uzp2 v16.8h, v17.8h, v16.8h
+; CHECK-NEXT:    uzp1 v7.8h, v19.8h, v18.8h
+; CHECK-NEXT:    uzp1 v20.8h, v4.8h, v6.8h
+; CHECK-NEXT:    uzp2 v17.8h, v19.8h, v18.8h
+; CHECK-NEXT:    uzp1 v21.8h, v0.8h, v2.8h
+; CHECK-NEXT:    uzp2 v18.8h, v4.8h, v6.8h
+; CHECK-NEXT:    uzp2 v19.8h, v0.8h, v2.8h
+; CHECK-NEXT:    uzp1 v0.8h, v7.8h, v5.8h
+; CHECK-NEXT:    uzp1 v2.8h, v17.8h, v16.8h
+; CHECK-NEXT:    uzp2 v4.8h, v7.8h, v5.8h
+; CHECK-NEXT:    uzp1 v1.8h, v21.8h, v20.8h
+; CHECK-NEXT:    uzp1 v3.8h, v19.8h, v18.8h
+; CHECK-NEXT:    uzp2 v5.8h, v21.8h, v20.8h
+; CHECK-NEXT:    uzp2 v6.8h, v17.8h, v16.8h
+; CHECK-NEXT:    uzp2 v7.8h, v19.8h, v18.8h
+; CHECK-NEXT:    ret
+    <8 x bfloat> %a, <8 x bfloat> %b, <8 x bfloat> %c, <8 x bfloat> %d,
+    <8 x bfloat> %e, <8 x bfloat> %f, <8 x bfloat> %g, <8 x bfloat> %h) {
+  %ins0 = call <64 x bfloat> @llvm.vector.insert.v64bf16.v8bf16(<64 x bfloat> poison, <8 x bfloat> %a, i64 0)
+  %ins1 = call <64 x bfloat> @llvm.vector.insert.v64bf16.v8bf16(<64 x bfloat> %ins0,  <8 x bfloat> %b, i64 8)
+  %ins2 = call <64 x bfloat> @llvm.vector.insert.v64bf16.v8bf16(<64 x bfloat> %ins1,  <8 x bfloat> %c, i64 16)
+  %ins3 = call <64 x bfloat> @llvm.vector.insert.v64bf16.v8bf16(<64 x bfloat> %ins2,  <8 x bfloat> %d, i64 24)
+  %ins4 = call <64 x bfloat> @llvm.vector.insert.v64bf16.v8bf16(<64 x bfloat> %ins3,  <8 x bfloat> %e, i64 32)
+  %ins5 = call <64 x bfloat> @llvm.vector.insert.v64bf16.v8bf16(<64 x bfloat> %ins4,  <8 x bfloat> %f, i64 40)
+  %ins6 = call <64 x bfloat> @llvm.vector.insert.v64bf16.v8bf16(<64 x bfloat> %ins5,  <8 x bfloat> %g, i64 48)
+  %ins7 = call <64 x bfloat> @llvm.vector.insert.v64bf16.v8bf16(<64 x bfloat> %ins6,  <8 x bfloat> %h, i64 56)
+  %retval = call {<8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>} @llvm.vector.deinterleave8.v64bf16(<64 x bfloat> %ins7)
+  ret {<8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>, <8 x bfloat>} %retval
 }

--- a/llvm/test/CodeGen/AArch64/fixed-vector-interleave.ll
+++ b/llvm/test/CodeGen/AArch64/fixed-vector-interleave.ll
@@ -677,56 +677,148 @@ define <24 x i32> @interleave6_v24i32(<4 x i32> %vec0, <4 x i32> %vec1, <4 x i32
   ret <24 x i32> %retval
 }
 
-define <48 x bfloat> @interleave6_v48bf16(<8 x bfloat> %vec0, <8 x bfloat> %vec1, <8 x bfloat> %vec2, <8 x bfloat> %vec3, <8 x bfloat> %vec4, <8 x bfloat> %vec5) {
-; CHECK-LABEL: interleave6_v48bf16:
+define <12 x i32> @interleave6_v12i32(<2 x i32> %vec0, <2 x i32> %vec1, <2 x i32> %vec2, <2 x i32> %vec3, <2 x i32> %vec4, <2 x i32> %vec5) {
+; CHECK-LABEL: interleave6_v12i32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    sub sp, sp, #96
-; CHECK-NEXT:    .cfi_def_cfa_offset 96
-; CHECK-NEXT:    zip1 v18.8h, v2.8h, v5.8h
-; CHECK-NEXT:    zip2 v7.8h, v2.8h, v5.8h
+; CHECK-NEXT:    sub sp, sp, #48
+; CHECK-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-NEXT:    zip1 v18.2s, v2.2s, v5.2s
+; CHECK-NEXT:    zip2 v7.2s, v2.2s, v5.2s
 ; CHECK-NEXT:    mov x9, sp
-; CHECK-NEXT:    zip1 v17.8h, v1.8h, v4.8h
-; CHECK-NEXT:    zip2 v6.8h, v1.8h, v4.8h
-; CHECK-NEXT:    zip1 v16.8h, v0.8h, v3.8h
-; CHECK-NEXT:    zip2 v5.8h, v0.8h, v3.8h
-; CHECK-NEXT:    st3 { v16.8h, v17.8h, v18.8h }, [x9]
-; CHECK-NEXT:    add x9, sp, #48
-; CHECK-NEXT:    st3 { v5.8h, v6.8h, v7.8h }, [x9]
-; CHECK-NEXT:    ldp q2, q0, [sp, #64]
-; CHECK-NEXT:    ldp q5, q1, [sp, #32]
-; CHECK-NEXT:    ldp q3, q4, [sp]
-; CHECK-NEXT:    stp q2, q0, [x8, #64]
-; CHECK-NEXT:    stp q5, q1, [x8, #32]
-; CHECK-NEXT:    stp q3, q4, [x8]
-; CHECK-NEXT:    add sp, sp, #96
+; CHECK-NEXT:    zip1 v17.2s, v1.2s, v4.2s
+; CHECK-NEXT:    zip2 v6.2s, v1.2s, v4.2s
+; CHECK-NEXT:    zip1 v16.2s, v0.2s, v3.2s
+; CHECK-NEXT:    zip2 v5.2s, v0.2s, v3.2s
+; CHECK-NEXT:    st3 { v16.2s, v17.2s, v18.2s }, [x9]
+; CHECK-NEXT:    add x9, sp, #24
+; CHECK-NEXT:    st3 { v5.2s, v6.2s, v7.2s }, [x9]
+; CHECK-NEXT:    ldp d1, d0, [sp, #32]
+; CHECK-NEXT:    ldp d3, d2, [sp, #16]
+; CHECK-NEXT:    ldp d5, d4, [sp]
+; CHECK-NEXT:    mov v1.d[1], v0.d[0]
+; CHECK-NEXT:    mov v3.d[1], v2.d[0]
+; CHECK-NEXT:    mov v5.d[1], v4.d[0]
+; CHECK-NEXT:    stp q3, q1, [x8, #16]
+; CHECK-NEXT:    str q5, [x8]
+; CHECK-NEXT:    add sp, sp, #48
 ; CHECK-NEXT:    ret
-  %retval = call <48 x bfloat> @llvm.vector.interleave6.v48bf16(<8 x bfloat> %vec0, <8 x bfloat> %vec1, <8 x bfloat> %vec2, <8 x bfloat> %vec3, <8 x bfloat> %vec4, <8 x bfloat> %vec5)
-  ret <48 x bfloat> %retval
+  %retval = call <12 x i32> @llvm.vector.interleave6.v12i32(<2 x i32> %vec0, <2 x i32> %vec1, <2 x i32> %vec2, <2 x i32> %vec3, <2 x i32> %vec4, <2 x i32> %vec5)
+  ret <12 x i32> %retval
 }
 
-define <96 x i8> @interleave6_v96i8(<16 x i8> %vec0, <16 x i8> %vec1, <16 x i8> %vec2, <16 x i8> %vec3, <16 x i8> %vec4, <16 x i8> %vec5) {
-; CHECK-LABEL: interleave6_v96i8:
+define <24 x i16> @interleave6_v24i16(<4 x i16> %vec0, <4 x i16> %vec1, <4 x i16> %vec2, <4 x i16> %vec3, <4 x i16> %vec4, <4 x i16> %vec5) {
+; CHECK-LABEL: interleave6_v24i16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    sub sp, sp, #96
-; CHECK-NEXT:    .cfi_def_cfa_offset 96
-; CHECK-NEXT:    zip1 v18.16b, v2.16b, v5.16b
-; CHECK-NEXT:    zip2 v7.16b, v2.16b, v5.16b
+; CHECK-NEXT:    sub sp, sp, #48
+; CHECK-NEXT:    .cfi_def_cfa_offset 48
+; CHECK-NEXT:    zip1 v18.4h, v2.4h, v5.4h
+; CHECK-NEXT:    zip2 v7.4h, v2.4h, v5.4h
 ; CHECK-NEXT:    mov x9, sp
-; CHECK-NEXT:    zip1 v17.16b, v1.16b, v4.16b
-; CHECK-NEXT:    zip2 v6.16b, v1.16b, v4.16b
-; CHECK-NEXT:    zip1 v16.16b, v0.16b, v3.16b
-; CHECK-NEXT:    zip2 v5.16b, v0.16b, v3.16b
-; CHECK-NEXT:    st3 { v16.16b, v17.16b, v18.16b }, [x9]
-; CHECK-NEXT:    add x9, sp, #48
-; CHECK-NEXT:    st3 { v5.16b, v6.16b, v7.16b }, [x9]
-; CHECK-NEXT:    ldp q2, q0, [sp, #64]
-; CHECK-NEXT:    ldp q5, q1, [sp, #32]
-; CHECK-NEXT:    ldp q3, q4, [sp]
-; CHECK-NEXT:    stp q2, q0, [x8, #64]
-; CHECK-NEXT:    stp q5, q1, [x8, #32]
-; CHECK-NEXT:    stp q3, q4, [x8]
-; CHECK-NEXT:    add sp, sp, #96
+; CHECK-NEXT:    zip1 v17.4h, v1.4h, v4.4h
+; CHECK-NEXT:    zip2 v6.4h, v1.4h, v4.4h
+; CHECK-NEXT:    zip1 v16.4h, v0.4h, v3.4h
+; CHECK-NEXT:    zip2 v5.4h, v0.4h, v3.4h
+; CHECK-NEXT:    st3 { v16.4h, v17.4h, v18.4h }, [x9]
+; CHECK-NEXT:    add x9, sp, #24
+; CHECK-NEXT:    st3 { v5.4h, v6.4h, v7.4h }, [x9]
+; CHECK-NEXT:    ldp d1, d0, [sp, #32]
+; CHECK-NEXT:    ldp d3, d2, [sp, #16]
+; CHECK-NEXT:    ldp d5, d4, [sp]
+; CHECK-NEXT:    mov v1.d[1], v0.d[0]
+; CHECK-NEXT:    mov v3.d[1], v2.d[0]
+; CHECK-NEXT:    mov v5.d[1], v4.d[0]
+; CHECK-NEXT:    stp q3, q1, [x8, #16]
+; CHECK-NEXT:    str q5, [x8]
+; CHECK-NEXT:    add sp, sp, #48
 ; CHECK-NEXT:    ret
-  %retval = call <96 x i8> @llvm.vector.interleave6.v96i8(<16 x i8> %vec0, <16 x i8> %vec1, <16 x i8> %vec2, <16 x i8> %vec3, <16 x i8> %vec4, <16 x i8> %vec5)
-  ret <96 x i8> %retval
+  %retval = call <24 x i16> @llvm.vector.interleave6.v24i16(<4 x i16> %vec0, <4 x i16> %vec1, <4 x i16> %vec2, <4 x i16> %vec3, <4 x i16> %vec4, <4 x i16> %vec5)
+  ret <24 x i16> %retval
+}
+
+define <16 x double> @interleave8_v16f64(<2 x double> %vec0, <2 x double> %vec1, <2 x double> %vec2, <2 x double> %vec3, <2 x double> %vec4, <2 x double> %vec5, <2 x double> %vec6, <2 x double> %vec7) {
+; CHECK-LABEL: interleave8_v16f64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    zip1 v16.2d, v3.2d, v7.2d
+; CHECK-NEXT:    zip1 v17.2d, v1.2d, v5.2d
+; CHECK-NEXT:    zip1 v18.2d, v2.2d, v6.2d
+; CHECK-NEXT:    zip1 v19.2d, v0.2d, v4.2d
+; CHECK-NEXT:    zip2 v3.2d, v3.2d, v7.2d
+; CHECK-NEXT:    zip2 v1.2d, v1.2d, v5.2d
+; CHECK-NEXT:    zip2 v2.2d, v2.2d, v6.2d
+; CHECK-NEXT:    zip2 v0.2d, v0.2d, v4.2d
+; CHECK-NEXT:    zip1 v4.2d, v17.2d, v16.2d
+; CHECK-NEXT:    zip2 v6.2d, v17.2d, v16.2d
+; CHECK-NEXT:    zip1 v5.2d, v19.2d, v18.2d
+; CHECK-NEXT:    zip2 v7.2d, v19.2d, v18.2d
+; CHECK-NEXT:    zip1 v16.2d, v1.2d, v3.2d
+; CHECK-NEXT:    zip1 v17.2d, v0.2d, v2.2d
+; CHECK-NEXT:    zip2 v18.2d, v1.2d, v3.2d
+; CHECK-NEXT:    zip2 v19.2d, v0.2d, v2.2d
+; CHECK-NEXT:    zip1 v0.2d, v5.2d, v4.2d
+; CHECK-NEXT:    zip2 v1.2d, v5.2d, v4.2d
+; CHECK-NEXT:    zip1 v2.2d, v7.2d, v6.2d
+; CHECK-NEXT:    zip2 v3.2d, v7.2d, v6.2d
+; CHECK-NEXT:    zip1 v4.2d, v17.2d, v16.2d
+; CHECK-NEXT:    zip2 v5.2d, v17.2d, v16.2d
+; CHECK-NEXT:    zip1 v6.2d, v19.2d, v18.2d
+; CHECK-NEXT:    zip2 v7.2d, v19.2d, v18.2d
+; CHECK-NEXT:    ret
+  %retval = call <16 x double> @llvm.vector.interleave8.v16f64(<2 x double> %vec0, <2 x double> %vec1, <2 x double> %vec2, <2 x double> %vec3, <2 x double> %vec4, <2 x double> %vec5, <2 x double> %vec6, <2 x double> %vec7)
+  ret <16 x double> %retval
+}
+
+define <16 x i32> @interleave8_v16i32(<2 x i32> %vec0, <2 x i32> %vec1, <2 x i32> %vec2, <2 x i32> %vec3, <2 x i32> %vec4, <2 x i32> %vec5, <2 x i32> %vec6, <2 x i32> %vec7) {
+; CHECK-LABEL: interleave8_v16i32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    zip1 v16.2s, v3.2s, v7.2s
+; CHECK-NEXT:    zip1 v17.2s, v1.2s, v5.2s
+; CHECK-NEXT:    zip1 v18.2s, v2.2s, v6.2s
+; CHECK-NEXT:    zip1 v19.2s, v0.2s, v4.2s
+; CHECK-NEXT:    zip2 v3.2s, v3.2s, v7.2s
+; CHECK-NEXT:    zip2 v1.2s, v1.2s, v5.2s
+; CHECK-NEXT:    zip2 v2.2s, v2.2s, v6.2s
+; CHECK-NEXT:    zip2 v0.2s, v0.2s, v4.2s
+; CHECK-NEXT:    zip1 v4.2s, v17.2s, v16.2s
+; CHECK-NEXT:    zip2 v6.2s, v17.2s, v16.2s
+; CHECK-NEXT:    zip1 v5.2s, v19.2s, v18.2s
+; CHECK-NEXT:    zip2 v7.2s, v19.2s, v18.2s
+; CHECK-NEXT:    zip1 v16.2s, v1.2s, v3.2s
+; CHECK-NEXT:    zip1 v17.2s, v0.2s, v2.2s
+; CHECK-NEXT:    zip2 v3.2s, v1.2s, v3.2s
+; CHECK-NEXT:    zip2 v18.2s, v0.2s, v2.2s
+; CHECK-NEXT:    zip1 v0.4s, v5.4s, v4.4s
+; CHECK-NEXT:    zip1 v1.4s, v7.4s, v6.4s
+; CHECK-NEXT:    zip1 v2.4s, v17.4s, v16.4s
+; CHECK-NEXT:    zip1 v3.4s, v18.4s, v3.4s
+; CHECK-NEXT:    ret
+  %retval = call <16 x i32> @llvm.vector.interleave8.v16i32(<2 x i32> %vec0, <2 x i32> %vec1, <2 x i32> %vec2, <2 x i32> %vec3, <2 x i32> %vec4, <2 x i32> %vec5, <2 x i32> %vec6, <2 x i32> %vec7)
+  ret <16 x i32> %retval
+}
+
+define <32 x i16> @interleave8_v32i16(<4 x i16> %vec0, <4 x i16> %vec1, <4 x i16> %vec2, <4 x i16> %vec3, <4 x i16> %vec4, <4 x i16> %vec5, <4 x i16> %vec6, <4 x i16> %vec7) {
+; CHECK-LABEL: interleave8_v32i16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    zip1 v16.4h, v3.4h, v7.4h
+; CHECK-NEXT:    zip1 v17.4h, v1.4h, v5.4h
+; CHECK-NEXT:    zip1 v18.4h, v2.4h, v6.4h
+; CHECK-NEXT:    zip1 v19.4h, v0.4h, v4.4h
+; CHECK-NEXT:    zip2 v3.4h, v3.4h, v7.4h
+; CHECK-NEXT:    zip2 v1.4h, v1.4h, v5.4h
+; CHECK-NEXT:    zip2 v2.4h, v2.4h, v6.4h
+; CHECK-NEXT:    zip2 v0.4h, v0.4h, v4.4h
+; CHECK-NEXT:    zip1 v4.4h, v17.4h, v16.4h
+; CHECK-NEXT:    zip2 v6.4h, v17.4h, v16.4h
+; CHECK-NEXT:    zip1 v5.4h, v19.4h, v18.4h
+; CHECK-NEXT:    zip2 v7.4h, v19.4h, v18.4h
+; CHECK-NEXT:    zip1 v16.4h, v1.4h, v3.4h
+; CHECK-NEXT:    zip1 v17.4h, v0.4h, v2.4h
+; CHECK-NEXT:    zip2 v3.4h, v1.4h, v3.4h
+; CHECK-NEXT:    zip2 v18.4h, v0.4h, v2.4h
+; CHECK-NEXT:    zip1 v0.8h, v5.8h, v4.8h
+; CHECK-NEXT:    zip1 v1.8h, v7.8h, v6.8h
+; CHECK-NEXT:    zip1 v2.8h, v17.8h, v16.8h
+; CHECK-NEXT:    zip1 v3.8h, v18.8h, v3.8h
+; CHECK-NEXT:    ret
+  %retval = call <32 x i16> @llvm.vector.interleave8.v32i16(<4 x i16> %vec0, <4 x i16> %vec1, <4 x i16> %vec2, <4 x i16> %vec3, <4 x i16> %vec4, <4 x i16> %vec5, <4 x i16> %vec6, <4 x i16> %vec7)
+  ret <32 x i16> %retval
 }

--- a/llvm/test/CodeGen/AArch64/fixed-vector-interleave.ll
+++ b/llvm/test/CodeGen/AArch64/fixed-vector-interleave.ll
@@ -454,7 +454,7 @@ define <32 x bfloat> @interleave4_v32bf16(<8 x bfloat> %vec0, <8 x bfloat> %vec1
   ret <32 x bfloat> %retval
 }
 
-define <6 x double> @interleave3_v6f64(ptr %p, ptr %p0, <2 x double> %vec0, <2 x double> %vec1, <2 x double> %vec2) {
+define <6 x double> @interleave3_v6f64(<2 x double> %vec0, <2 x double> %vec1, <2 x double> %vec2) {
 ; CHECK-LABEL: interleave3_v6f64:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub sp, sp, #48
@@ -481,7 +481,7 @@ define <6 x double> @interleave3_v6f64(ptr %p, ptr %p0, <2 x double> %vec0, <2 x
   ret <6 x double> %retval
 }
 
-define <12 x float> @interleave3_v12f32(ptr %p, ptr %p0, <4 x float> %vec0, <4 x float> %vec1, <4 x float> %vec2) {
+define <12 x float> @interleave3_v12f32(<4 x float> %vec0, <4 x float> %vec1, <4 x float> %vec2) {
 ; CHECK-LABEL: interleave3_v12f32:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub sp, sp, #48
@@ -501,7 +501,7 @@ define <12 x float> @interleave3_v12f32(ptr %p, ptr %p0, <4 x float> %vec0, <4 x
   ret <12 x float> %retval
 }
 
-define <24 x i16> @interleave3_v24i16(ptr %p, ptr %p0, <8 x i16> %vec0, <8 x i16> %vec1, <8 x i16> %vec2) {
+define <24 x i16> @interleave3_v24i16(<8 x i16> %vec0, <8 x i16> %vec1, <8 x i16> %vec2) {
 ; CHECK-LABEL: interleave3_v24i16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub sp, sp, #48
@@ -521,7 +521,7 @@ define <24 x i16> @interleave3_v24i16(ptr %p, ptr %p0, <8 x i16> %vec0, <8 x i16
   ret <24 x i16> %retval
 }
 
-define <24 x half> @interleave3_v24f16(ptr %p, ptr %p0, <8 x half> %vec0, <8 x half> %vec1, <8 x half> %vec2) {
+define <24 x half> @interleave3_v24f16(<8 x half> %vec0, <8 x half> %vec1, <8 x half> %vec2) {
 ; CHECK-LABEL: interleave3_v24f16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub sp, sp, #48
@@ -541,7 +541,7 @@ define <24 x half> @interleave3_v24f16(ptr %p, ptr %p0, <8 x half> %vec0, <8 x h
   ret <24 x half> %retval
 }
 
-define <24 x bfloat> @interleave3_v24bf16(ptr %p, ptr %p0, <8 x bfloat> %vec0, <8 x bfloat> %vec1, <8 x bfloat> %vec2) {
+define <24 x bfloat> @interleave3_v24bf16(<8 x bfloat> %vec0, <8 x bfloat> %vec1, <8 x bfloat> %vec2) {
 ; CHECK-LABEL: interleave3_v24bf16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub sp, sp, #48
@@ -561,7 +561,7 @@ define <24 x bfloat> @interleave3_v24bf16(ptr %p, ptr %p0, <8 x bfloat> %vec0, <
   ret <24 x bfloat> %retval
 }
 
-define <48 x i8> @interleave3_v48i8(ptr %p, ptr %p0, <16 x i8> %vec0, <16 x i8> %vec1, <16 x i8> %vec2) {
+define <48 x i8> @interleave3_v48i8(<16 x i8> %vec0, <16 x i8> %vec1, <16 x i8> %vec2) {
 ; CHECK-LABEL: interleave3_v48i8:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub sp, sp, #48
@@ -581,7 +581,7 @@ define <48 x i8> @interleave3_v48i8(ptr %p, ptr %p0, <16 x i8> %vec0, <16 x i8> 
   ret <48 x i8> %retval
 }
 
-define <12 x i16> @interleave3_v12i16(ptr %p, ptr %p0, <4 x i16> %vec0, <4 x i16> %vec1, <4 x i16> %vec2) {
+define <12 x i16> @interleave3_v12i16(<4 x i16> %vec0, <4 x i16> %vec1, <4 x i16> %vec2) {
 ; CHECK-LABEL: interleave3_v12i16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub sp, sp, #32
@@ -602,7 +602,7 @@ define <12 x i16> @interleave3_v12i16(ptr %p, ptr %p0, <4 x i16> %vec0, <4 x i16
   ret <12 x i16> %retval
 }
 
-define <24 x i8> @interleave3_v24i8(ptr %p, ptr %p0, <8 x i8> %vec0, <8 x i8> %vec1, <8 x i8> %vec2) {
+define <24 x i8> @interleave3_v24i8(<8 x i8> %vec0, <8 x i8> %vec1, <8 x i8> %vec2) {
 ; CHECK-LABEL: interleave3_v24i8:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub sp, sp, #32
@@ -621,4 +621,112 @@ define <24 x i8> @interleave3_v24i8(ptr %p, ptr %p0, <8 x i8> %vec0, <8 x i8> %v
 ; CHECK-NEXT:    ret
   %retval = call <24 x i8> @llvm.vector.interleave3.v24i8(<8 x i8> %vec0, <8 x i8> %vec1, <8 x i8> %vec2)
   ret <24 x i8> %retval
+}
+
+define <12 x double> @interleave6_v12f64(<2 x double> %vec0, <2 x double> %vec1, <2 x double> %vec2, <2 x double> %vec3, <2 x double> %vec4, <2 x double> %vec5) {
+; CHECK-LABEL: interleave6_v12f64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    sub sp, sp, #96
+; CHECK-NEXT:    .cfi_def_cfa_offset 96
+; CHECK-NEXT:    zip1 v18.2d, v2.2d, v5.2d
+; CHECK-NEXT:    zip2 v7.2d, v2.2d, v5.2d
+; CHECK-NEXT:    mov x9, sp
+; CHECK-NEXT:    zip1 v17.2d, v1.2d, v4.2d
+; CHECK-NEXT:    zip2 v6.2d, v1.2d, v4.2d
+; CHECK-NEXT:    zip1 v16.2d, v0.2d, v3.2d
+; CHECK-NEXT:    zip2 v5.2d, v0.2d, v3.2d
+; CHECK-NEXT:    st3 { v16.2d, v17.2d, v18.2d }, [x9]
+; CHECK-NEXT:    add x9, sp, #48
+; CHECK-NEXT:    st3 { v5.2d, v6.2d, v7.2d }, [x9]
+; CHECK-NEXT:    ldp q2, q0, [sp, #64]
+; CHECK-NEXT:    ldp q5, q1, [sp, #32]
+; CHECK-NEXT:    ldp q3, q4, [sp]
+; CHECK-NEXT:    stp q2, q0, [x8, #64]
+; CHECK-NEXT:    stp q5, q1, [x8, #32]
+; CHECK-NEXT:    stp q3, q4, [x8]
+; CHECK-NEXT:    add sp, sp, #96
+; CHECK-NEXT:    ret
+  %retval = call <12 x double> @llvm.vector.interleave6.v12f64(<2 x double> %vec0, <2 x double> %vec1, <2 x double> %vec2, <2 x double> %vec3, <2 x double> %vec4, <2 x double> %vec5)
+  ret <12 x double> %retval
+}
+
+define <24 x i32> @interleave6_v24i32(<4 x i32> %vec0, <4 x i32> %vec1, <4 x i32> %vec2, <4 x i32> %vec3, <4 x i32> %vec4, <4 x i32> %vec5) {
+; CHECK-LABEL: interleave6_v24i32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    sub sp, sp, #96
+; CHECK-NEXT:    .cfi_def_cfa_offset 96
+; CHECK-NEXT:    zip1 v18.4s, v2.4s, v5.4s
+; CHECK-NEXT:    zip2 v7.4s, v2.4s, v5.4s
+; CHECK-NEXT:    mov x9, sp
+; CHECK-NEXT:    zip1 v17.4s, v1.4s, v4.4s
+; CHECK-NEXT:    zip2 v6.4s, v1.4s, v4.4s
+; CHECK-NEXT:    zip1 v16.4s, v0.4s, v3.4s
+; CHECK-NEXT:    zip2 v5.4s, v0.4s, v3.4s
+; CHECK-NEXT:    st3 { v16.4s, v17.4s, v18.4s }, [x9]
+; CHECK-NEXT:    add x9, sp, #48
+; CHECK-NEXT:    st3 { v5.4s, v6.4s, v7.4s }, [x9]
+; CHECK-NEXT:    ldp q2, q0, [sp, #64]
+; CHECK-NEXT:    ldp q5, q1, [sp, #32]
+; CHECK-NEXT:    ldp q3, q4, [sp]
+; CHECK-NEXT:    stp q2, q0, [x8, #64]
+; CHECK-NEXT:    stp q5, q1, [x8, #32]
+; CHECK-NEXT:    stp q3, q4, [x8]
+; CHECK-NEXT:    add sp, sp, #96
+; CHECK-NEXT:    ret
+  %retval = call <24 x i32> @llvm.vector.interleave6.v24i32(<4 x i32> %vec0, <4 x i32> %vec1, <4 x i32> %vec2, <4 x i32> %vec3, <4 x i32> %vec4, <4 x i32> %vec5)
+  ret <24 x i32> %retval
+}
+
+define <48 x bfloat> @interleave6_v48bf16(<8 x bfloat> %vec0, <8 x bfloat> %vec1, <8 x bfloat> %vec2, <8 x bfloat> %vec3, <8 x bfloat> %vec4, <8 x bfloat> %vec5) {
+; CHECK-LABEL: interleave6_v48bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    sub sp, sp, #96
+; CHECK-NEXT:    .cfi_def_cfa_offset 96
+; CHECK-NEXT:    zip1 v18.8h, v2.8h, v5.8h
+; CHECK-NEXT:    zip2 v7.8h, v2.8h, v5.8h
+; CHECK-NEXT:    mov x9, sp
+; CHECK-NEXT:    zip1 v17.8h, v1.8h, v4.8h
+; CHECK-NEXT:    zip2 v6.8h, v1.8h, v4.8h
+; CHECK-NEXT:    zip1 v16.8h, v0.8h, v3.8h
+; CHECK-NEXT:    zip2 v5.8h, v0.8h, v3.8h
+; CHECK-NEXT:    st3 { v16.8h, v17.8h, v18.8h }, [x9]
+; CHECK-NEXT:    add x9, sp, #48
+; CHECK-NEXT:    st3 { v5.8h, v6.8h, v7.8h }, [x9]
+; CHECK-NEXT:    ldp q2, q0, [sp, #64]
+; CHECK-NEXT:    ldp q5, q1, [sp, #32]
+; CHECK-NEXT:    ldp q3, q4, [sp]
+; CHECK-NEXT:    stp q2, q0, [x8, #64]
+; CHECK-NEXT:    stp q5, q1, [x8, #32]
+; CHECK-NEXT:    stp q3, q4, [x8]
+; CHECK-NEXT:    add sp, sp, #96
+; CHECK-NEXT:    ret
+  %retval = call <48 x bfloat> @llvm.vector.interleave6.v48bf16(<8 x bfloat> %vec0, <8 x bfloat> %vec1, <8 x bfloat> %vec2, <8 x bfloat> %vec3, <8 x bfloat> %vec4, <8 x bfloat> %vec5)
+  ret <48 x bfloat> %retval
+}
+
+define <96 x i8> @interleave6_v96i8(<16 x i8> %vec0, <16 x i8> %vec1, <16 x i8> %vec2, <16 x i8> %vec3, <16 x i8> %vec4, <16 x i8> %vec5) {
+; CHECK-LABEL: interleave6_v96i8:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    sub sp, sp, #96
+; CHECK-NEXT:    .cfi_def_cfa_offset 96
+; CHECK-NEXT:    zip1 v18.16b, v2.16b, v5.16b
+; CHECK-NEXT:    zip2 v7.16b, v2.16b, v5.16b
+; CHECK-NEXT:    mov x9, sp
+; CHECK-NEXT:    zip1 v17.16b, v1.16b, v4.16b
+; CHECK-NEXT:    zip2 v6.16b, v1.16b, v4.16b
+; CHECK-NEXT:    zip1 v16.16b, v0.16b, v3.16b
+; CHECK-NEXT:    zip2 v5.16b, v0.16b, v3.16b
+; CHECK-NEXT:    st3 { v16.16b, v17.16b, v18.16b }, [x9]
+; CHECK-NEXT:    add x9, sp, #48
+; CHECK-NEXT:    st3 { v5.16b, v6.16b, v7.16b }, [x9]
+; CHECK-NEXT:    ldp q2, q0, [sp, #64]
+; CHECK-NEXT:    ldp q5, q1, [sp, #32]
+; CHECK-NEXT:    ldp q3, q4, [sp]
+; CHECK-NEXT:    stp q2, q0, [x8, #64]
+; CHECK-NEXT:    stp q5, q1, [x8, #32]
+; CHECK-NEXT:    stp q3, q4, [x8]
+; CHECK-NEXT:    add sp, sp, #96
+; CHECK-NEXT:    ret
+  %retval = call <96 x i8> @llvm.vector.interleave6.v96i8(<16 x i8> %vec0, <16 x i8> %vec1, <16 x i8> %vec2, <16 x i8> %vec3, <16 x i8> %vec4, <16 x i8> %vec5)
+  ret <96 x i8> %retval
 }

--- a/llvm/test/CodeGen/AArch64/sve-vector-deinterleave.ll
+++ b/llvm/test/CodeGen/AArch64/sve-vector-deinterleave.ll
@@ -836,3 +836,59 @@ define {<vscale x 2 x i32>, <vscale x 2 x i32>} @vector_deinterleave_nxv2i32_nxv
   %retval = call {<vscale x 2 x i32>,<vscale x 2 x i32>} @llvm.vector.deinterleave2.nxv4i32(<vscale x 4 x i32> %vec)
   ret {<vscale x 2 x i32>, <vscale x 2 x i32>} %retval
 }
+
+
+define {<vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>} @vector_deinterleave6_nxv2i64_nxv12i64(<vscale x 12 x i64> %vec) {
+; SVE-LABEL: vector_deinterleave6_nxv2i64_nxv12i64:
+; SVE:       // %bb.0:
+; SVE-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
+; SVE-NEXT:    addvl sp, sp, #-6
+; SVE-NEXT:    .cfi_escape 0x0f, 0x09, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x30, 0x1e, 0x22 // sp + 16 + 48 * VG
+; SVE-NEXT:    .cfi_offset w29, -16
+; SVE-NEXT:    ptrue p0.d
+; SVE-NEXT:    str z5, [sp, #5, mul vl]
+; SVE-NEXT:    str z4, [sp, #4, mul vl]
+; SVE-NEXT:    str z3, [sp, #3, mul vl]
+; SVE-NEXT:    str z2, [sp, #2, mul vl]
+; SVE-NEXT:    str z1, [sp, #1, mul vl]
+; SVE-NEXT:    str z0, [sp]
+; SVE-NEXT:    ld3d { z5.d - z7.d }, p0/z, [sp, #3, mul vl]
+; SVE-NEXT:    ld3d { z24.d - z26.d }, p0/z, [sp]
+; SVE-NEXT:    uzp1 z0.d, z24.d, z5.d
+; SVE-NEXT:    uzp1 z1.d, z25.d, z6.d
+; SVE-NEXT:    uzp1 z2.d, z26.d, z7.d
+; SVE-NEXT:    uzp2 z3.d, z24.d, z5.d
+; SVE-NEXT:    uzp2 z4.d, z25.d, z6.d
+; SVE-NEXT:    uzp2 z5.d, z26.d, z7.d
+; SVE-NEXT:    addvl sp, sp, #6
+; SVE-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; SVE-NEXT:    ret
+;
+; SME2-LABEL: vector_deinterleave6_nxv2i64_nxv12i64:
+; SME2:       // %bb.0:
+; SME2-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
+; SME2-NEXT:    addvl sp, sp, #-6
+; SME2-NEXT:    .cfi_escape 0x0f, 0x09, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x30, 0x1e, 0x22 // sp + 16 + 48 * VG
+; SME2-NEXT:    .cfi_offset w29, -16
+; SME2-NEXT:    ptrue p0.d
+; SME2-NEXT:    str z5, [sp, #5, mul vl]
+; SME2-NEXT:    str z4, [sp, #4, mul vl]
+; SME2-NEXT:    str z3, [sp, #3, mul vl]
+; SME2-NEXT:    str z2, [sp, #2, mul vl]
+; SME2-NEXT:    str z1, [sp, #1, mul vl]
+; SME2-NEXT:    str z0, [sp]
+; SME2-NEXT:    ld3d { z3.d - z5.d }, p0/z, [sp, #3, mul vl]
+; SME2-NEXT:    ld3d { z24.d - z26.d }, p0/z, [sp]
+; SME2-NEXT:    uzp { z2.d, z3.d }, z24.d, z3.d
+; SME2-NEXT:    uzp { z6.d, z7.d }, z25.d, z4.d
+; SME2-NEXT:    uzp { z4.d, z5.d }, z26.d, z5.d
+; SME2-NEXT:    mov z0.d, z2.d
+; SME2-NEXT:    mov z1.d, z6.d
+; SME2-NEXT:    mov z2.d, z4.d
+; SME2-NEXT:    mov z4.d, z7.d
+; SME2-NEXT:    addvl sp, sp, #6
+; SME2-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; SME2-NEXT:    ret
+  %retval = call {<vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>} @llvm.vector.deinterleave6.nxv12i64(<vscale x 12 x i64> %vec)
+  ret {<vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>, <vscale x 2 x i64>} %retval
+}

--- a/llvm/test/CodeGen/AArch64/sve-vector-interleave.ll
+++ b/llvm/test/CodeGen/AArch64/sve-vector-interleave.ll
@@ -834,3 +834,58 @@ define <vscale x 8 x i16> @interleave4_same_const_splat_nxv8i16() {
   %retval = call <vscale x 8 x i16> @llvm.vector.interleave4.nxv8i16(<vscale x 2 x i16> splat(i16 3), <vscale x 2 x i16> splat(i16 3), <vscale x 2 x i16> splat(i16 3), <vscale x 2 x i16> splat(i16 3))
   ret <vscale x 8 x i16> %retval
 }
+
+define <vscale x 12 x i64> @interleave6_nxv12i64(<vscale x 2 x i64> %vec0, <vscale x 2 x i64> %vec1, <vscale x 2 x i64> %vec2, <vscale x 2 x i64> %vec3, <vscale x 2 x i64> %vec4, <vscale x 2 x i64> %vec5) {
+; SVE-LABEL: interleave6_nxv12i64:
+; SVE:       // %bb.0:
+; SVE-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
+; SVE-NEXT:    addvl sp, sp, #-6
+; SVE-NEXT:    .cfi_escape 0x0f, 0x09, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x30, 0x1e, 0x22 // sp + 16 + 48 * VG
+; SVE-NEXT:    .cfi_offset w29, -16
+; SVE-NEXT:    zip1 z26.d, z2.d, z5.d
+; SVE-NEXT:    zip1 z25.d, z1.d, z4.d
+; SVE-NEXT:    zip1 z24.d, z0.d, z3.d
+; SVE-NEXT:    zip2 z2.d, z2.d, z5.d
+; SVE-NEXT:    zip2 z1.d, z1.d, z4.d
+; SVE-NEXT:    zip2 z0.d, z0.d, z3.d
+; SVE-NEXT:    ptrue p0.d
+; SVE-NEXT:    st3d { z24.d - z26.d }, p0, [sp]
+; SVE-NEXT:    st3d { z0.d - z2.d }, p0, [sp, #3, mul vl]
+; SVE-NEXT:    ldr z0, [sp]
+; SVE-NEXT:    ldr z1, [sp, #1, mul vl]
+; SVE-NEXT:    ldr z2, [sp, #2, mul vl]
+; SVE-NEXT:    ldr z3, [sp, #3, mul vl]
+; SVE-NEXT:    ldr z4, [sp, #4, mul vl]
+; SVE-NEXT:    ldr z5, [sp, #5, mul vl]
+; SVE-NEXT:    addvl sp, sp, #6
+; SVE-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; SVE-NEXT:    ret
+;
+; SME2-LABEL: interleave6_nxv12i64:
+; SME2:       // %bb.0:
+; SME2-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
+; SME2-NEXT:    addvl sp, sp, #-6
+; SME2-NEXT:    .cfi_escape 0x0f, 0x09, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x30, 0x1e, 0x22 // sp + 16 + 48 * VG
+; SME2-NEXT:    .cfi_offset w29, -16
+; SME2-NEXT:    zip { z6.d, z7.d }, z2.d, z5.d
+; SME2-NEXT:    zip { z24.d, z25.d }, z1.d, z4.d
+; SME2-NEXT:    zip { z0.d, z1.d }, z0.d, z3.d
+; SME2-NEXT:    mov z4.d, z0.d
+; SME2-NEXT:    mov z5.d, z24.d
+; SME2-NEXT:    mov z2.d, z25.d
+; SME2-NEXT:    mov z3.d, z7.d
+; SME2-NEXT:    ptrue p0.d
+; SME2-NEXT:    st3d { z4.d - z6.d }, p0, [sp]
+; SME2-NEXT:    st3d { z1.d - z3.d }, p0, [sp, #3, mul vl]
+; SME2-NEXT:    ldr z0, [sp]
+; SME2-NEXT:    ldr z1, [sp, #1, mul vl]
+; SME2-NEXT:    ldr z2, [sp, #2, mul vl]
+; SME2-NEXT:    ldr z3, [sp, #3, mul vl]
+; SME2-NEXT:    ldr z4, [sp, #4, mul vl]
+; SME2-NEXT:    ldr z5, [sp, #5, mul vl]
+; SME2-NEXT:    addvl sp, sp, #6
+; SME2-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; SME2-NEXT:    ret
+  %retval = call <vscale x 12 x i64> @llvm.vector.interleave6.nxv12i64(<vscale x 2 x i64> %vec0, <vscale x 2 x i64> %vec1, <vscale x 2 x i64> %vec2, <vscale x 2 x i64> %vec3, <vscale x 2 x i64> %vec4, <vscale x 2 x i64> %vec5)
+  ret <vscale x 12 x i64> %retval
+}


### PR DESCRIPTION
With #192972 and #192677 merged, [de]interleave6 can also benefit from the existing legalization work from #141513