### PR TITLE
[coverage] llvm-cov export parallel load

### DIFF
--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -1051,6 +1051,10 @@ class CoverageMapping {
       const std::optional<std::reference_wrapper<IndexedInstrProfReader>>
           &ProfileReader);
 
+  /// Merge function records from \p Other into this mapping, deduplicating
+  /// by (filenames hash, function name hash) as loadFunctionRecord does.
+  void mergeFrom(CoverageMapping &&Other);
+
   /// Look up the indices for function records which are at least partially
   /// defined in the specified file. This is guaranteed to return a superset of
   /// such records: extra records not in the file may be included if there is

--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -1080,7 +1080,7 @@ public:
        std::optional<StringRef> ProfileFilename, vfs::FileSystem &FS,
        ArrayRef<StringRef> Arches = {}, StringRef CompilationDir = "",
        const object::BuildIDFetcher *BIDFetcher = nullptr,
-       bool CheckBinaryIDs = false);
+       bool CheckBinaryIDs = false, unsigned MaxLoadThreads = 1);
 
   /// The number of functions that couldn't have their profiles mapped.
   ///

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -966,6 +966,36 @@ Error CoverageMapping::loadFunctionRecord(
   return Error::success();
 }
 
+void CoverageMapping::mergeFrom(CoverageMapping &&Other) {
+  // Shards are produced from the same profile, so this must agree.
+  assert(!SingleByteCoverage || !Other.SingleByteCoverage ||
+         *SingleByteCoverage == *Other.SingleByteCoverage);
+  if (!SingleByteCoverage)
+    SingleByteCoverage = Other.SingleByteCoverage;
+
+  for (auto &Func : Other.Functions) {
+    auto FilenamesHash = hash_combine_range(Func.Filenames);
+    if (!RecordProvenance[FilenamesHash]
+             .insert(hash_value(StringRef(Func.Name)))
+             .second)
+      continue;
+
+    unsigned RecordIndex = Functions.size();
+    Functions.push_back(std::move(Func));
+
+    for (StringRef Filename : Functions.back().Filenames) {
+      auto &RecordIndices = FilenameHash2RecordIndices[hash_value(Filename)];
+      if (RecordIndices.empty() || RecordIndices.back() != RecordIndex)
+        RecordIndices.push_back(RecordIndex);
+    }
+  }
+
+  FuncHashMismatches.insert(
+      FuncHashMismatches.end(),
+      std::make_move_iterator(Other.FuncHashMismatches.begin()),
+      std::make_move_iterator(Other.FuncHashMismatches.end()));
+}
+
 // This function is for memory optimization by shortening the lifetimes
 // of CoverageMappingReader instances.
 Error CoverageMapping::loadFromReaders(

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -27,6 +27,8 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/ThreadPool.h"
+#include "llvm/Support/Threading.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
@@ -1109,11 +1111,84 @@ Expected<std::unique_ptr<CoverageMapping>> CoverageMapping::load(
   };
 
   SmallVector<object::BuildID> FoundBinaryIDs;
-  for (const auto &File : llvm::enumerate(ObjectFilenames)) {
-    if (Error E = loadFromFile(File.value(), GetArch(File.index()),
-                               CompilationDir, ProfileReaderRef, *Coverage,
-                               DataFound, &FoundBinaryIDs))
-      return std::move(E);
+  unsigned NumFiles = ObjectFilenames.size();
+  constexpr unsigned MaxExportThreads = 32;
+  unsigned NumThreads = std::min(
+      {hardware_concurrency(NumFiles).compute_thread_count(),
+       NumFiles, MaxExportThreads});
+
+  if (NumThreads <= 1) {
+    for (const auto &File : llvm::enumerate(ObjectFilenames)) {
+      if (Error E = loadFromFile(File.value(), GetArch(File.index()),
+                                 CompilationDir, ProfileReaderRef, *Coverage,
+                                 DataFound, &FoundBinaryIDs))
+        return std::move(E);
+    }
+  } else {
+    std::vector<std::unique_ptr<IndexedInstrProfReader>> Readers(NumThreads);
+    if (ProfileFilename) {
+      for (unsigned T = 0; T < NumThreads; ++T) {
+        auto ReaderOrErr =
+            IndexedInstrProfReader::create(ProfileFilename.value(), FS);
+        if (Error E = ReaderOrErr.takeError())
+          return createFileError(ProfileFilename.value(), std::move(E));
+        Readers[T] = std::move(ReaderOrErr.get());
+      }
+    }
+
+    struct ShardData {
+      std::unique_ptr<CoverageMapping> Cov =
+          std::unique_ptr<CoverageMapping>(new CoverageMapping());
+      SmallVector<object::BuildID> BIDs;
+      bool Found = false;
+      std::optional<Error> Err;
+    };
+
+    std::vector<ShardData> Shards(NumThreads);
+
+    {
+      DefaultThreadPool Pool(hardware_concurrency(NumFiles));
+      unsigned ChunkSize = (NumFiles + NumThreads - 1) / NumThreads;
+      for (unsigned T = 0; T < NumThreads; ++T) {
+        unsigned Begin = T * ChunkSize;
+        unsigned End = std::min(Begin + ChunkSize, NumFiles);
+        Pool.async([&, T, Begin, End] {
+          auto &S = Shards[T];
+          auto ProfileReaderRef =
+              Readers[T] ? std::optional<
+                               std::reference_wrapper<IndexedInstrProfReader>>(
+                               *Readers[T])
+                         : std::nullopt;
+          for (unsigned I = Begin; I < End; ++I) {
+            if (Error E =
+                    loadFromFile(ObjectFilenames[I], GetArch(I), CompilationDir,
+                                 ProfileReaderRef, *S.Cov, S.Found, &S.BIDs)) {
+              S.Err = std::move(E);
+              return;
+            }
+          }
+        });
+      }
+    }
+
+    // All shard errors must be consumed; unchecked Errors assert in debug builds.
+    Error FirstErr = Error::success();
+    for (auto &S : Shards) {
+      if (S.Err) {
+        if (!FirstErr)
+          FirstErr = std::move(*S.Err);
+        else
+          consumeError(std::move(*S.Err));
+        continue;
+      }
+      if (!FirstErr) {
+        DataFound |= S.Found;
+        FoundBinaryIDs.append(S.BIDs.begin(), S.BIDs.end());
+        Coverage->mergeFrom(std::move(*S.Cov));
+      }
+    }
+    if (FirstErr)
+      return std::move(FirstErr);
   }
 
   if (BIDFetcher) {

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -1081,11 +1081,13 @@ Error CoverageMapping::loadFromFile(
   return Error::success();
 }
 
-Expected<std::unique_ptr<CoverageMapping>> CoverageMapping::load(
-    ArrayRef<StringRef> ObjectFilenames,
-    std::optional<StringRef> ProfileFilename, vfs::FileSystem &FS,
-    ArrayRef<StringRef> Arches, StringRef CompilationDir,
-    const object::BuildIDFetcher *BIDFetcher, bool CheckBinaryIDs) {
+Expected<std::unique_ptr<CoverageMapping>>
+CoverageMapping::load(ArrayRef<StringRef> ObjectFilenames,
+                      std::optional<StringRef> ProfileFilename,
+                      vfs::FileSystem &FS, ArrayRef<StringRef> Arches,
+                      StringRef CompilationDir,
+                      const object::BuildIDFetcher *BIDFetcher,
+                      bool CheckBinaryIDs, unsigned MaxLoadThreads) {
   std::unique_ptr<IndexedInstrProfReader> ProfileReader;
   if (ProfileFilename) {
     auto ProfileReaderOrErr =
@@ -1112,10 +1114,13 @@ Expected<std::unique_ptr<CoverageMapping>> CoverageMapping::load(
 
   SmallVector<object::BuildID> FoundBinaryIDs;
   unsigned NumFiles = ObjectFilenames.size();
-  constexpr unsigned MaxExportThreads = 32;
-  unsigned NumThreads = std::min(
-      {hardware_concurrency(NumFiles).compute_thread_count(),
-       NumFiles, MaxExportThreads});
+  // Stdin can only be consumed once, so parallel loading is not possible.
+  bool IsStdinProfile = ProfileFilename && *ProfileFilename == "-";
+  unsigned NumThreads =
+      (MaxLoadThreads <= 1 || IsStdinProfile)
+          ? 1
+          : std::min({hardware_concurrency(NumFiles).compute_thread_count(),
+                      NumFiles, MaxLoadThreads});
 
   if (NumThreads <= 1) {
     for (const auto &File : llvm::enumerate(ObjectFilenames)) {

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -878,6 +878,15 @@ Error CoverageMapping::loadFunctionRecord(
   else
     OrigFuncName = getFuncNameWithoutPrefix(OrigFuncName, Record.Filenames[0]);
 
+  // Early dedup: skip expensive counter evaluation for already-seen functions.
+  auto FilenamesHash = hash_combine_range(Record.Filenames);
+  auto FuncNameHash = hash_value(OrigFuncName);
+  {
+    auto It = RecordProvenance.find(FilenamesHash);
+    if (It != RecordProvenance.end() && It->second.count(FuncNameHash))
+      return Error::success();
+  }
+
   CounterMappingContext Ctx(Record.Expressions);
 
   std::vector<uint64_t> Counts;
@@ -944,8 +953,7 @@ Error CoverageMapping::loadFunctionRecord(
   }
 
   // Don't create records for (filenames, function) pairs we've already seen.
-  auto FilenamesHash = hash_combine_range(Record.Filenames);
-  if (!RecordProvenance[FilenamesHash].insert(hash_value(OrigFuncName)).second)
+  if (!RecordProvenance[FilenamesHash].insert(FuncNameHash).second)
     return Error::success();
 
   Functions.push_back(std::move(Function));

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -974,6 +974,36 @@ Error CoverageMapping::loadFunctionRecord(
   return Error::success();
 }
 
+void CoverageMapping::mergeFrom(CoverageMapping &&Other) {
+  // Shards are produced from the same profile, so this must agree.
+  assert(!SingleByteCoverage || !Other.SingleByteCoverage ||
+         *SingleByteCoverage == *Other.SingleByteCoverage);
+  if (!SingleByteCoverage)
+    SingleByteCoverage = Other.SingleByteCoverage;
+
+  for (auto &Func : Other.Functions) {
+    auto FilenamesHash = hash_combine_range(Func.Filenames);
+    if (!RecordProvenance[FilenamesHash]
+             .insert(hash_value(StringRef(Func.Name)))
+             .second)
+      continue;
+
+    unsigned RecordIndex = Functions.size();
+    Functions.push_back(std::move(Func));
+
+    for (StringRef Filename : Functions.back().Filenames) {
+      auto &RecordIndices = FilenameHash2RecordIndices[hash_value(Filename)];
+      if (RecordIndices.empty() || RecordIndices.back() != RecordIndex)
+        RecordIndices.push_back(RecordIndex);
+    }
+  }
+
+  FuncHashMismatches.insert(
+      FuncHashMismatches.end(),
+      std::make_move_iterator(Other.FuncHashMismatches.begin()),
+      std::make_move_iterator(Other.FuncHashMismatches.end()));
+}
+
 // This function is for memory optimization by shortening the lifetimes
 // of CoverageMappingReader instances.
 Error CoverageMapping::loadFromReaders(

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -1089,11 +1089,13 @@ Error CoverageMapping::loadFromFile(
   return Error::success();
 }
 
-Expected<std::unique_ptr<CoverageMapping>> CoverageMapping::load(
-    ArrayRef<StringRef> ObjectFilenames,
-    std::optional<StringRef> ProfileFilename, vfs::FileSystem &FS,
-    ArrayRef<StringRef> Arches, StringRef CompilationDir,
-    const object::BuildIDFetcher *BIDFetcher, bool CheckBinaryIDs) {
+Expected<std::unique_ptr<CoverageMapping>>
+CoverageMapping::load(ArrayRef<StringRef> ObjectFilenames,
+                      std::optional<StringRef> ProfileFilename,
+                      vfs::FileSystem &FS, ArrayRef<StringRef> Arches,
+                      StringRef CompilationDir,
+                      const object::BuildIDFetcher *BIDFetcher,
+                      bool CheckBinaryIDs, unsigned MaxLoadThreads) {
   std::unique_ptr<IndexedInstrProfReader> ProfileReader;
   if (ProfileFilename) {
     auto ProfileReaderOrErr =
@@ -1120,10 +1122,11 @@ Expected<std::unique_ptr<CoverageMapping>> CoverageMapping::load(
 
   SmallVector<object::BuildID> FoundBinaryIDs;
   unsigned NumFiles = ObjectFilenames.size();
-  constexpr unsigned MaxExportThreads = 32;
-  unsigned NumThreads = std::min(
-      {hardware_concurrency(NumFiles).compute_thread_count(),
-       NumFiles, MaxExportThreads});
+  unsigned NumThreads =
+      MaxLoadThreads <= 1
+          ? 1
+          : std::min({hardware_concurrency(NumFiles).compute_thread_count(),
+                      NumFiles, MaxLoadThreads});
 
   if (NumThreads <= 1) {
     for (const auto &File : llvm::enumerate(ObjectFilenames)) {

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -27,6 +27,8 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/ThreadPool.h"
+#include "llvm/Support/Threading.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
@@ -1117,11 +1119,77 @@ Expected<std::unique_ptr<CoverageMapping>> CoverageMapping::load(
   };
 
   SmallVector<object::BuildID> FoundBinaryIDs;
-  for (const auto &File : llvm::enumerate(ObjectFilenames)) {
-    if (Error E = loadFromFile(File.value(), GetArch(File.index()),
-                               CompilationDir, ProfileReaderRef, *Coverage,
-                               DataFound, &FoundBinaryIDs))
-      return std::move(E);
+  unsigned NumFiles = ObjectFilenames.size();
+  constexpr unsigned MaxExportThreads = 32;
+  unsigned NumThreads = std::min(
+      {hardware_concurrency(NumFiles).compute_thread_count(),
+       NumFiles, MaxExportThreads});
+
+  if (NumThreads <= 1) {
+    for (const auto &File : llvm::enumerate(ObjectFilenames)) {
+      if (Error E = loadFromFile(File.value(), GetArch(File.index()),
+                                 CompilationDir, ProfileReaderRef, *Coverage,
+                                 DataFound, &FoundBinaryIDs))
+        return std::move(E);
+    }
+  } else {
+    std::vector<std::unique_ptr<IndexedInstrProfReader>> Readers(NumThreads);
+    if (ProfileFilename) {
+      for (unsigned T = 0; T < NumThreads; ++T) {
+        auto ReaderOrErr =
+            IndexedInstrProfReader::create(ProfileFilename.value(), FS);
+        if (Error E = ReaderOrErr.takeError())
+          return createFileError(ProfileFilename.value(), std::move(E));
+        Readers[T] = std::move(ReaderOrErr.get());
+      }
+    }
+
+    struct ShardData {
+      std::unique_ptr<CoverageMapping> Cov;
+      SmallVector<object::BuildID> BIDs;
+      bool Found = false;
+      Error Err;
+      ShardData() : Err(Error::success()) {}
+      ShardData(ShardData &&) = default;
+      ShardData &operator=(ShardData &&) = default;
+    };
+
+    std::vector<ShardData> Shards(NumThreads);
+    for (auto &S : Shards)
+      S.Cov.reset(new CoverageMapping());
+
+    {
+      DefaultThreadPool Pool(hardware_concurrency(NumFiles));
+      unsigned ChunkSize = (NumFiles + NumThreads - 1) / NumThreads;
+      for (unsigned T = 0; T < NumThreads; ++T) {
+        unsigned Begin = T * ChunkSize;
+        unsigned End = std::min(Begin + ChunkSize, NumFiles);
+        Pool.async([&, T, Begin, End] {
+          auto &S = Shards[T];
+          auto ProfileReaderRef =
+              Readers[T] ? std::optional<
+                               std::reference_wrapper<IndexedInstrProfReader>>(
+                               *Readers[T])
+                         : std::nullopt;
+          for (unsigned I = Begin; I < End; ++I) {
+            if (Error E =
+                    loadFromFile(ObjectFilenames[I], GetArch(I), CompilationDir,
+                                 ProfileReaderRef, *S.Cov, S.Found, &S.BIDs)) {
+              S.Err = std::move(E);
+              return;
+            }
+          }
+        });
+      }
+    }
+
+    for (auto &S : Shards) {
+      if (S.Err)
+        return std::move(S.Err);
+      DataFound |= S.Found;
+      FoundBinaryIDs.append(S.BIDs.begin(), S.BIDs.end());
+      Coverage->mergeFrom(std::move(*S.Cov));
+    }
   }
 
   if (BIDFetcher) {

--- a/llvm/test/tools/llvm-cov/load-threads.test
+++ b/llvm/test/tools/llvm-cov/load-threads.test
@@ -1,0 +1,12 @@
+// Test that parallel object loading produces the same results as serial loading.
+// Coverage/profile data recycled from the multiple-objects test.
+//
+// RUN: llvm-cov export -instr-profile %S/Inputs/multiple_objects/merged.profdata \
+// RUN:   %S/Inputs/multiple_objects/use_2.covmapping \
+// RUN:   -object %S/Inputs/multiple_objects/use_1.covmapping \
+// RUN:   -max-load-threads=1 > %t.serial
+// RUN: llvm-cov export -instr-profile %S/Inputs/multiple_objects/merged.profdata \
+// RUN:   %S/Inputs/multiple_objects/use_2.covmapping \
+// RUN:   -object %S/Inputs/multiple_objects/use_1.covmapping \
+// RUN:   -max-load-threads=3 > %t.parallel
+// RUN: diff %t.serial %t.parallel

--- a/llvm/tools/llvm-cov/CodeCoverage.cpp
+++ b/llvm/tools/llvm-cov/CodeCoverage.cpp
@@ -190,6 +190,7 @@ private:
   std::unique_ptr<object::BuildIDFetcher> BIDFetcher;
 
   bool CheckBinaryIDs;
+  unsigned MaxLoadThreads;
 };
 }
 
@@ -462,9 +463,10 @@ std::unique_ptr<CoverageMapping> CodeCoverageTool::load() {
                 ObjectFilename);
   }
   auto FS = vfs::getRealFileSystem();
-  auto CoverageOrErr = CoverageMapping::load(
-      ObjectFilenames, PGOFilename, *FS, CoverageArches,
-      ViewOpts.CompilationDirectory, BIDFetcher.get(), CheckBinaryIDs);
+  auto CoverageOrErr =
+      CoverageMapping::load(ObjectFilenames, PGOFilename, *FS, CoverageArches,
+                            ViewOpts.CompilationDirectory, BIDFetcher.get(),
+                            CheckBinaryIDs, MaxLoadThreads);
   if (Error E = CoverageOrErr.takeError()) {
     error("failed to load coverage: " + toString(std::move(E)));
     return nullptr;
@@ -803,6 +805,10 @@ int CodeCoverageTool::run(Command Cmd, int argc, const char **argv) {
   cl::alias NumThreadsA("j", cl::desc("Alias for --num-threads"),
                         cl::aliasopt(NumThreads));
 
+  cl::opt<unsigned> MaxLoadThreads(
+      "max-load-threads", cl::init(1),
+      cl::desc("Maximum threads to use for loading object files (default: 1)"));
+
   cl::opt<std::string> CompilationDirectory(
       "compilation-dir", cl::init(""),
       cl::desc("Directory used as a base for relative coverage mapping paths"));
@@ -821,6 +827,7 @@ int CodeCoverageTool::run(Command Cmd, int argc, const char **argv) {
       BIDFetcher = std::make_unique<object::BuildIDFetcher>(DebugFileDirectory);
     }
     this->CheckBinaryIDs = CheckBinaryIDs;
+    this->MaxLoadThreads = MaxLoadThreads;
 
     if (!PGOFilename.empty() == EmptyProfile) {
       error(


### PR DESCRIPTION
Currently loading coverage from many object files is a bottleneck in `llvm-cov` at meta — each file's coverage records are parsed, counters evaluated, and regions emitted serially despite being independent work.

This PR parallelizes `CoverageMapping::load` using a `DefaultThreadPool`:

1. **Early dedup in `loadFunctionRecord`** — move the `RecordProvenance` check before expensive counter/bitmap evaluation, skipping already-seen functions early.

2. **`CoverageMapping::mergeFrom`** — method to merge per-thread coverage shards into the final result, using the same dedup logic as `loadFunctionRecord`.

3. **Parallel loading** — each thread gets its own `IndexedInstrProfReader` and `CoverageMapping` shard, processing a contiguous chunk of object files. Results are merged serially.

Cross-shard dedup only happens at merge time, so shards may redundantly process some functions — the early dedup in commit 1 mitigates this within each shard. `BIDFetcher`-based loading remains serial and unchanged.

### Test plan
- Existing `llvm-cov` tests pass unchanged.
- Verified internally: significant wall-time reduction for `llvm-cov export`:

I tested it using 167k measurements (different isolated test runs) across randomly picked 10K C++ binaries we have at meta. All results are identical before and after my changes, so that is purely a speed up. Empirically I came up with **capping max threads at 32 for us** so these are the results between serial processing and 32 concurrent threads (cause I was using a maching with high amount of CPU cores)

### Speed

| | AVG | p50 | p90 | p95 | p99 |
|---|---:|---:|---:|---:|---:|
| Single Thread (s) | 37.5 | 1.5 | 151.7 | 183.4 | 273.6 |
| Sharded (s) | 15.6 | 1.4 | 45.9 | 75.7 | 133.2 |
| **Improvement** | **59%** | **10%** | **70%** | **59%** | **51%** |

### Memory (Peak RSS)

| | AVG | p50 | p90 | p95 | p99 |
|---|---:|---:|---:|---:|---:|
| Single Thread (MB) | 642 | 102 | 1634 | 2262 | 10322 |
| Sharded (MB) | 943 | 125 | 2977 | 3531 | 12166 |
| **Overhead** | **+47%** | **+23%** | **+82%** | **+56%** | **+18%** |

So for large binaries we have 2–3x faster results, but it comes with an obvious price of higher memory usage so I provided a way to cap parallelism externally for the cases that require less memory usage. Also this allows a gradual adoption for folks cause that's an opt-in mechanism.