### PR TITLE
[Clang] Reject __annotation on unsupported targets

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -500,6 +500,8 @@ Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Fix a crash when passing an unresolved overload set to ``__builtin_classify_type``. (#GH175589)
 - Fixed a crash when calling `__builtin_allow_sanitize_check` with no arguments. (#GH183927)
+- ``__annotation`` is now diagnosed as unsupported on non-Windows/UEFI targets, fixing a
+  crash when using it with ``-fms-extensions`` on other platforms. (#GH184318)
 
 Bug Fixes to Attribute Support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -5597,12 +5597,17 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     SmallVector<Metadata *, 1> Strings;
     for (const Expr *Arg : E->arguments()) {
       const auto *Str = cast<StringLiteral>(Arg->IgnoreParenCasts());
-      assert(Str->getCharByteWidth() == 2);
+      assert(Str->getCharByteWidth() == 2 || Str->getCharByteWidth() == 4);
       StringRef WideBytes = Str->getBytes();
       std::string StrUtf8;
-      if (!convertUTF16ToUTF8String(
-              ArrayRef(WideBytes.data(), WideBytes.size()), StrUtf8)) {
-        CGM.ErrorUnsupported(E, "non-UTF16 __annotation argument");
+      bool Converted =
+          (Str->getCharByteWidth() == 2)
+              ? convertUTF16ToUTF8String(
+                    ArrayRef(WideBytes.data(), WideBytes.size()), StrUtf8)
+              : convertUTF32ToUTF8String(
+                    ArrayRef(WideBytes.data(), WideBytes.size()), StrUtf8);
+      if (!Converted) {
+        CGM.ErrorUnsupported(E, "non-Unicode __annotation argument");
         continue;
       }
       Strings.push_back(llvm::MDString::get(getLLVMContext(), StrUtf8));

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -5597,17 +5597,12 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     SmallVector<Metadata *, 1> Strings;
     for (const Expr *Arg : E->arguments()) {
       const auto *Str = cast<StringLiteral>(Arg->IgnoreParenCasts());
-      assert(Str->getCharByteWidth() == 2 || Str->getCharByteWidth() == 4);
+      assert(Str->getCharByteWidth() == 2);
       StringRef WideBytes = Str->getBytes();
       std::string StrUtf8;
-      bool Converted =
-          (Str->getCharByteWidth() == 2)
-              ? convertUTF16ToUTF8String(
-                    ArrayRef(WideBytes.data(), WideBytes.size()), StrUtf8)
-              : convertUTF32ToUTF8String(
-                    ArrayRef(WideBytes.data(), WideBytes.size()), StrUtf8);
-      if (!Converted) {
-        CGM.ErrorUnsupported(E, "non-Unicode __annotation argument");
+      if (!convertUTF16ToUTF8String(
+              ArrayRef(WideBytes.data(), WideBytes.size()), StrUtf8)) {
+        CGM.ErrorUnsupported(E, "non-UTF16 __annotation argument");
         continue;
       }
       Strings.push_back(llvm::MDString::get(getLLVMContext(), StrUtf8));

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -3263,10 +3263,17 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
   case Builtin::BI##ID:                                                        \
     return AtomicOpsOverloaded(TheCallResult, AtomicExpr::AO##ID);
 #include "clang/Basic/Builtins.inc"
-  case Builtin::BI__annotation:
+  case Builtin::BI__annotation: {
+    const llvm::Triple &TT = Context.getTargetInfo().getTriple();
+    if (!TT.isOSWindows() && !TT.isUEFI()) {
+      Diag(TheCall->getBeginLoc(), diag::err_builtin_target_unsupported)
+          << SourceRange(TheCall->getBeginLoc(), TheCall->getEndLoc());
+      return ExprError();
+    }
     if (BuiltinMSVCAnnotation(*this, TheCall))
       return ExprError();
     break;
+  }
   case Builtin::BI__builtin_annotation:
     if (BuiltinAnnotation(*this, TheCall))
       return ExprError();

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -3267,7 +3267,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     const llvm::Triple &TT = Context.getTargetInfo().getTriple();
     if (!TT.isOSWindows() && !TT.isUEFI()) {
       Diag(TheCall->getBeginLoc(), diag::err_builtin_target_unsupported)
-          << SourceRange(TheCall->getBeginLoc(), TheCall->getEndLoc());
+          << TheCall->getSourceRange();
       return ExprError();
     }
     if (BuiltinMSVCAnnotation(*this, TheCall))

--- a/clang/test/CodeGen/ms-annotation.c
+++ b/clang/test/CodeGen/ms-annotation.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -triple i686-windows %s -fms-extensions -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -triple i686-windows %s -fms-extensions -fwchar-type=int -fsigned-wchar -emit-llvm -o - | FileCheck %s
 //
 // Test that LLVM optimizations leave these intrinsics alone, for the most part.
 // RUN: %clang_cc1 -O2 -triple i686-windows %s -fms-extensions -emit-llvm -o - | FileCheck %s

--- a/clang/test/Sema/ms-annotation.c
+++ b/clang/test/Sema/ms-annotation.c
@@ -1,13 +1,18 @@
 // RUN: %clang_cc1 -triple i686-windows %s -verify -fms-extensions
 // RUN: %clang_cc1 -x c++ -std=c++11 -triple i686-windows %s -verify -fms-extensions
 // RUN: %clang_cc1 -x c++ -std=c++14 -triple i686-windows %s -verify -fms-extensions
+// RUN: %clang_cc1 -triple x86_64-unknown-uefi %s -verify -fms-extensions
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu %s -verify=unsupported -fms-extensions
 
 void test1(void) {
-  __annotation(); // expected-error {{too few arguments to function call, expected at least 1, have 0}}
-  __annotation(1); // expected-error {{must be wide string constants}}
-  __annotation(L"a1");
-  __annotation(L"a1", L"a2");
-  __annotation(L"a1", L"a2", 42); // expected-error {{must be wide string constants}}
-  __annotation(L"a1", L"a2", L"a3");
-  __annotation(L"multi " L"part " L"string");
+  __annotation(); // expected-error {{too few arguments to function call, expected at least 1, have 0}} \
+                  // unsupported-error {{builtin is not supported on this target}}
+  __annotation(1); // expected-error {{must be wide string constants}} \
+                   // unsupported-error {{builtin is not supported on this target}}
+  __annotation(L"a1"); // unsupported-error {{builtin is not supported on this target}}
+  __annotation(L"a1", L"a2"); // unsupported-error {{builtin is not supported on this target}}
+  __annotation(L"a1", L"a2", 42); // expected-error {{must be wide string constants}} \
+                                  // unsupported-error {{builtin is not supported on this target}}
+  __annotation(L"a1", L"a2", L"a3"); // unsupported-error {{builtin is not supported on this target}}
+  __annotation(L"multi " L"part " L"string"); // unsupported-error {{builtin is not supported on this target}}
 }


### PR DESCRIPTION
__annotation emits llvm.codeview.annotation intrinsics, which are only consumed by CodeViewDebug
on Windows and UEFI targets. On other targets the intrinsic is silently dropped, and codegen
hits an assertion due to wchar_t being 4 bytes (UTF-32) instead of the expected 2 bytes
(UTF-16).

Fixes #184318