### PR TITLE
[libc][docs] Add poll.h POSIX header documentation (#122006)

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -55,6 +55,7 @@ if (SPHINX_FOUND)
       locale
       net/if
       netinet/in
+      poll
       pthread
       setjmp
       signal

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -22,6 +22,7 @@ Implementation Status
    math/index.rst
    net/if
    netinet/in
+   poll
    search
    setjmp
    signal

--- a/libc/utils/docgen/poll.yaml
+++ b/libc/utils/docgen/poll.yaml
@@ -1,0 +1,27 @@
+functions:
+  poll:
+    in-latest-posix: ''
+  ppoll:
+    in-latest-posix: ''
+
+macros:
+  POLLERR:
+    in-latest-posix: ''
+  POLLHUP:
+    in-latest-posix: ''
+  POLLIN:
+    in-latest-posix: ''
+  POLLNVAL:
+    in-latest-posix: ''
+  POLLOUT:
+    in-latest-posix: ''
+  POLLPRI:
+    in-latest-posix: ''
+  POLLRDBAND:
+    in-latest-posix: ''
+  POLLRDNORM:
+    in-latest-posix: ''
+  POLLWRBAND:
+    in-latest-posix: ''
+  POLLWRNORM:
+    in-latest-posix: ''


### PR DESCRIPTION
Add poll.h implementation-status docs to llvm-libc.