### PR TITLE
[lldb] Remove full stop from AppendErrorWithFormat format strings

### DIFF
--- a/lldb/source/API/SBCommandInterpreter.cpp
+++ b/lldb/source/API/SBCommandInterpreter.cpp
@@ -215,7 +215,7 @@ void SBCommandInterpreter::HandleCommandsFromFile(
   if (!file.IsValid()) {
     SBStream s;
     file.GetDescription(s);
-    result->AppendErrorWithFormat("File is not valid: %s.", s.GetData());
+    result->AppendErrorWithFormat("File is not valid: %s", s.GetData());
   }
 
   FileSpec tmp_spec = file.ref();

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -3575,7 +3575,7 @@ protected:
     Status error = target.SerializeBreakpointsToFile(file_spec, valid_bp_ids,
                                                      m_options.m_append);
     if (!error.Success()) {
-      result.AppendErrorWithFormat("error serializing breakpoints: %s.",
+      result.AppendErrorWithFormat("error serializing breakpoints: %s",
                                    error.AsCString());
     }
   }
@@ -3717,13 +3717,13 @@ void CommandObjectMultiwordBreakpoint::VerifyIDs(
             &id_str, cur_bp_id.GetBreakpointID(), cur_bp_id.GetLocationID());
         i = valid_ids->GetSize() + 1;
         result.AppendErrorWithFormat(
-            "'%s' is not a currently valid breakpoint/location id.",
+            "'%s' is not a currently valid breakpoint/location id",
             id_str.GetData());
       }
     } else {
       i = valid_ids->GetSize() + 1;
       result.AppendErrorWithFormat(
-          "'%d' is not a currently valid breakpoint ID.",
+          "'%d' is not a currently valid breakpoint ID",
           cur_bp_id.GetBreakpointID());
     }
   }

--- a/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
@@ -516,7 +516,7 @@ protected:
             if (bp_loc_sp)
               bp_loc_sp->ClearCallback();
             else {
-              result.AppendErrorWithFormat("Invalid breakpoint ID: %u.%u.",
+              result.AppendErrorWithFormat("Invalid breakpoint ID: %u.%u",
                                            cur_bp_id.GetBreakpointID(),
                                            cur_bp_id.GetLocationID());
               return;
@@ -583,7 +583,7 @@ protected:
             if (cur_bp_id.GetLocationID() != LLDB_INVALID_BREAK_ID) {
               bp_loc_sp = bp->FindLocationByID(cur_bp_id.GetLocationID());
               if (!bp_loc_sp) {
-                result.AppendErrorWithFormat("Invalid breakpoint ID: %u.%u.",
+                result.AppendErrorWithFormat("Invalid breakpoint ID: %u.%u",
                                              cur_bp_id.GetBreakpointID(),
                                              cur_bp_id.GetLocationID());
                 return;
@@ -618,7 +618,7 @@ protected:
           }
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
-          result.AppendErrorWithFormat("Invalid breakpoint ID: %u.",
+          result.AppendErrorWithFormat("Invalid breakpoint ID: %u",
                                        cur_bp_id.GetBreakpointID());
         }
       }

--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -662,8 +662,7 @@ protected:
     if (!m_interpreter.RemoveAlias(command_name)) {
       if (m_interpreter.AliasExists(command_name))
         result.AppendErrorWithFormat(
-            "Error occurred while attempting to unalias '%s'",
-            args[0].c_str());
+            "Error occurred while attempting to unalias '%s'", args[0].c_str());
       else
         result.AppendErrorWithFormat("'%s' is not an existing alias",
                                      args[0].c_str());

--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -115,7 +115,7 @@ protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat(
-          "'%s' takes exactly one executable filename argument.",
+          "'%s' takes exactly one executable filename argument",
           GetCommandName().str().c_str());
       return;
     }
@@ -425,7 +425,7 @@ protected:
     // Verify that the command is alias-able.
     if (m_interpreter.CommandExists(alias_command)) {
       result.AppendErrorWithFormat(
-          "'%s' is a permanent debugger command and cannot be redefined.",
+          "'%s' is a permanent debugger command and cannot be redefined",
           args[0].c_str());
       return;
     }
@@ -448,7 +448,7 @@ protected:
     if (!cmd_obj) {
       result.AppendErrorWithFormat("invalid command given to 'command alias'. "
                                    "'%s' does not begin with a valid command."
-                                   "  No alias created.",
+                                   "  No alias created",
                                    original_raw_command_string.str().c_str());
     } else if (!cmd_obj->WantsRawCommandString()) {
       // Note that args was initialized with the original command, and has not
@@ -518,7 +518,7 @@ protected:
 
     if (m_interpreter.CommandExists(alias_command)) {
       result.AppendErrorWithFormat(
-          "'%s' is a permanent debugger command and cannot be redefined.",
+          "'%s' is a permanent debugger command and cannot be redefined",
           alias_command.c_str());
       return false;
     }
@@ -536,7 +536,7 @@ protected:
     CommandObjectSP subcommand_obj_sp;
     bool use_subcommand = false;
     if (!command_obj_sp) {
-      result.AppendErrorWithFormat("'%s' is not an existing command.",
+      result.AppendErrorWithFormat("'%s' is not an existing command",
                                    actual_command.c_str());
       return false;
     }
@@ -552,7 +552,7 @@ protected:
       if (!subcommand_obj_sp) {
         result.AppendErrorWithFormat(
             "'%s' is not a valid sub-command of '%s'.  "
-            "Unable to create alias.",
+            "Unable to create alias",
             args[0].c_str(), actual_command.c_str());
         return false;
       }
@@ -640,7 +640,7 @@ protected:
     if (!cmd_obj) {
       result.AppendErrorWithFormat(
           "'%s' is not a known command.\nTry 'help' to see a "
-          "current list of commands.",
+          "current list of commands",
           args[0].c_str());
       return;
     }
@@ -649,11 +649,11 @@ protected:
       if (cmd_obj->IsRemovable()) {
         result.AppendErrorWithFormat(
             "'%s' is not an alias, it is a debugger command which can be "
-            "removed using the 'command delete' command.",
+            "removed using the 'command delete' command",
             args[0].c_str());
       } else {
         result.AppendErrorWithFormat(
-            "'%s' is a permanent debugger command and cannot be removed.",
+            "'%s' is a permanent debugger command and cannot be removed",
             args[0].c_str());
       }
       return;
@@ -662,10 +662,10 @@ protected:
     if (!m_interpreter.RemoveAlias(command_name)) {
       if (m_interpreter.AliasExists(command_name))
         result.AppendErrorWithFormat(
-            "Error occurred while attempting to unalias '%s'.",
+            "Error occurred while attempting to unalias '%s'",
             args[0].c_str());
       else
-        result.AppendErrorWithFormat("'%s' is not an existing alias.",
+        result.AppendErrorWithFormat("'%s' is not an existing alias",
                                      args[0].c_str());
       return;
     }
@@ -726,7 +726,7 @@ protected:
 
     if (!m_interpreter.RemoveCommand(command_name)) {
       result.AppendErrorWithFormat(
-          "'%s' is a permanent debugger command and cannot be removed.",
+          "'%s' is a permanent debugger command and cannot be removed",
           args[0].c_str());
       return;
     }
@@ -2638,12 +2638,12 @@ protected:
 
     CommandObjectSP cmd_sp = m_interpreter.GetCommandSPExact(root_cmd);
     if (!cmd_sp) {
-      result.AppendErrorWithFormat("command '%s' not found.",
+      result.AppendErrorWithFormat("command '%s' not found",
                                    command[0].c_str());
       return;
     }
     if (!cmd_sp->IsUserCommand()) {
-      result.AppendErrorWithFormat("command '%s' is not a user command.",
+      result.AppendErrorWithFormat("command '%s' is not a user command",
                                    command[0].c_str());
       return;
     }
@@ -2900,7 +2900,7 @@ protected:
       CommandInterpreter &interp = GetCommandInterpreter();
       CommandObjectSP cmd_sp = interp.GetCommandSPExact(cmd_name);
       if (!cmd_sp) {
-        result.AppendErrorWithFormat("container command %s doesn't exist.",
+        result.AppendErrorWithFormat("container command %s doesn't exist",
                                      cmd_name);
         return;
       }
@@ -2917,7 +2917,7 @@ protected:
 
       bool did_remove = GetCommandInterpreter().RemoveUserMultiword(cmd_name);
       if (!did_remove) {
-        result.AppendErrorWithFormat("error removing command %s.", cmd_name);
+        result.AppendErrorWithFormat("error removing command %s", cmd_name);
         return;
       }
 

--- a/lldb/source/Commands/CommandObjectDisassemble.cpp
+++ b/lldb/source/Commands/CommandObjectDisassemble.cpp
@@ -489,11 +489,11 @@ void CommandObjectDisassemble::DoExecute(Args &command,
     if (plugin_name) {
       result.AppendErrorWithFormat(
           "Unable to find Disassembler plug-in named '%s' that supports the "
-          "'%s' architecture.",
+          "'%s' architecture",
           plugin_name, m_options.arch.GetArchitectureName());
     } else
       result.AppendErrorWithFormat(
-          "Unable to find Disassembler plug-in for the '%s' architecture.",
+          "Unable to find Disassembler plug-in for the '%s' architecture",
           m_options.arch.GetArchitectureName());
     return;
   } else if (flavor_string != nullptr && !disassembler->FlavorValidForArchSpec(
@@ -505,7 +505,7 @@ void CommandObjectDisassemble::DoExecute(Args &command,
 
   if (!command.empty()) {
     result.AppendErrorWithFormat(
-        "\"disassemble\" arguments are specified as options.");
+        "\"disassemble\" arguments are specified as options");
     const int terminal_width =
         GetCommandInterpreter().GetDebugger().GetTerminalWidth();
     const bool use_color = GetCommandInterpreter().GetDebugger().GetUseColor();
@@ -564,11 +564,11 @@ void CommandObjectDisassemble::DoExecute(Args &command,
     } else {
       if (m_options.symbol_containing_addr != LLDB_INVALID_ADDRESS) {
         result.AppendErrorWithFormat(
-            "Failed to disassemble memory in function at 0x%8.8" PRIx64 ".",
+            "Failed to disassemble memory in function at 0x%8.8" PRIx64,
             m_options.symbol_containing_addr);
       } else {
         result.AppendErrorWithFormat(
-            "Failed to disassemble memory at 0x%8.8" PRIx64 ".",
+            "Failed to disassemble memory at 0x%8.8" PRIx64,
             cur_range.GetBaseAddress().GetLoadAddress(&target));
       }
     }

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -420,7 +420,7 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
 
   if (m_command_options.top_level && !m_command_options.allow_jit) {
     result.AppendErrorWithFormat(
-        "Can't disable JIT compilation for top-level expressions.");
+        "Can't disable JIT compilation for top-level expressions");
     return false;
   }
 

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -355,7 +355,7 @@ protected:
     } else {
       if (command.GetArgumentCount() > 1) {
         result.AppendErrorWithFormat(
-            "too many arguments; expected frame-index, saw '%s'.",
+            "too many arguments; expected frame-index, saw '%s'",
             command[0].c_str());
         m_options.GenerateOptionUsage(
             result.GetErrorStream(), *this,
@@ -366,7 +366,7 @@ protected:
 
       if (command.GetArgumentCount() == 1) {
         if (command[0].ref().getAsInteger(0, frame_idx)) {
-          result.AppendErrorWithFormat("invalid frame index argument '%s'.",
+          result.AppendErrorWithFormat("invalid frame index argument '%s'",
                                        command[0].c_str());
           return;
         }
@@ -384,7 +384,7 @@ protected:
       m_exe_ctx.SetFrameSP(thread->GetSelectedFrame(SelectMostRelevantFrame));
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else {
-      result.AppendErrorWithFormat("Frame index (%u) out of range.", frame_idx);
+      result.AppendErrorWithFormat("Frame index (%u) out of range", frame_idx);
     }
   }
 
@@ -585,7 +585,7 @@ protected:
                   findUniqueRegexMatches(regex, regex_var_list, *variable_list);
               if (!results) {
                 result.AppendErrorWithFormat(
-                    "no variables matched the regular expression '%s'.",
+                    "no variables matched the regular expression '%s'",
                     entry.c_str());
                 continue;
               }
@@ -678,7 +678,7 @@ protected:
               else
                 result.AppendErrorWithFormat(
                     "unable to find any variable expression path that matches "
-                    "'%s'.",
+                    "'%s'",
                     entry.c_str());
             }
           }
@@ -907,26 +907,26 @@ void CommandObjectFrameRecognizerAdd::DoExecute(Args &command,
                                                 CommandReturnObject &result) {
 #if LLDB_ENABLE_PYTHON
   if (m_options.m_class_name.empty()) {
-    result.AppendErrorWithFormat("%s needs a Python class name (-l argument).",
+    result.AppendErrorWithFormat("%s needs a Python class name (-l argument)",
                                  m_cmd_name.c_str());
     return;
   }
 
   if (m_options.m_module.empty()) {
-    result.AppendErrorWithFormat("%s needs a module name (-s argument).",
+    result.AppendErrorWithFormat("%s needs a module name (-s argument)",
                                  m_cmd_name.c_str());
     return;
   }
 
   if (m_options.m_symbols.empty()) {
     result.AppendErrorWithFormat(
-        "%s needs at least one symbol name (-n argument).", m_cmd_name.c_str());
+        "%s needs at least one symbol name (-n argument)", m_cmd_name.c_str());
     return;
   }
 
   if (m_options.m_regex && m_options.m_symbols.size() > 1) {
     result.AppendErrorWithFormat(
-        "%s needs only one symbol regular expression (-n argument).",
+        "%s needs only one symbol regular expression (-n argument)",
         m_cmd_name.c_str());
     return;
   }
@@ -1049,7 +1049,7 @@ public:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     uint32_t recognizer_id;
     if (!llvm::to_integer(command.GetArgumentAtIndex(0), recognizer_id)) {
-      result.AppendErrorWithFormat("'%s' is not a valid recognizer id.",
+      result.AppendErrorWithFormat("'%s' is not a valid recognizer id",
                                    command.GetArgumentAtIndex(0));
       return;
     }
@@ -1075,7 +1075,7 @@ protected:
                        uint32_t recognizer_id) override {
     auto &recognizer_mgr = GetTarget().GetFrameRecognizerManager();
     if (!recognizer_mgr.SetEnabledForID(recognizer_id, true)) {
-      result.AppendErrorWithFormat("'%u' is not a valid recognizer id.",
+      result.AppendErrorWithFormat("'%u' is not a valid recognizer id",
                                    recognizer_id);
       return;
     }
@@ -1100,7 +1100,7 @@ protected:
                        uint32_t recognizer_id) override {
     auto &recognizer_mgr = GetTarget().GetFrameRecognizerManager();
     if (!recognizer_mgr.SetEnabledForID(recognizer_id, false)) {
-      result.AppendErrorWithFormat("'%u' is not a valid recognizer id.",
+      result.AppendErrorWithFormat("'%u' is not a valid recognizer id",
                                    recognizer_id);
       return;
     }
@@ -1125,7 +1125,7 @@ protected:
                        uint32_t recognizer_id) override {
     auto &recognizer_mgr = GetTarget().GetFrameRecognizerManager();
     if (!recognizer_mgr.RemoveRecognizerWithID(recognizer_id)) {
-      result.AppendErrorWithFormat("'%u' is not a valid recognizer id.",
+      result.AppendErrorWithFormat("'%u' is not a valid recognizer id",
                                    recognizer_id);
       return;
     }
@@ -1191,7 +1191,7 @@ protected:
     const char *frame_index_str = command.GetArgumentAtIndex(0);
     uint32_t frame_index;
     if (!llvm::to_integer(frame_index_str, frame_index)) {
-      result.AppendErrorWithFormat("'%s' is not a valid frame index.",
+      result.AppendErrorWithFormat("'%s' is not a valid frame index",
                                    frame_index_str);
       return;
     }
@@ -1208,7 +1208,7 @@ protected:
     }
     if (command.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat(
-          "'%s' takes exactly one frame index argument.", m_cmd_name.c_str());
+          "'%s' takes exactly one frame index argument", m_cmd_name.c_str());
       return;
     }
 

--- a/lldb/source/Commands/CommandObjectLog.cpp
+++ b/lldb/source/Commands/CommandObjectLog.cpp
@@ -163,7 +163,7 @@ protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
     if (args.GetArgumentCount() < 2) {
       result.AppendErrorWithFormat(
-          "%s takes a log channel and one or more log types.",
+          "%s takes a log channel and one or more log types",
           m_cmd_name.c_str());
       return;
     }
@@ -257,7 +257,7 @@ protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
     if (args.empty()) {
       result.AppendErrorWithFormat(
-          "%s takes a log channel and one or more log types.",
+          "%s takes a log channel and one or more log types",
           m_cmd_name.c_str());
       return;
     }
@@ -372,7 +372,7 @@ protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
     if (args.empty()) {
       result.AppendErrorWithFormat(
-          "%s takes a log channel and one or more log types.",
+          "%s takes a log channel and one or more log types",
           m_cmd_name.c_str());
       return;
     }

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -1482,8 +1482,8 @@ protected:
 
       case eFormatOctal:
         if (entry.ref().getAsInteger(8, uval64)) {
-          result.AppendErrorWithFormat(
-              "'%s' is not a valid octal string value", entry.c_str());
+          result.AppendErrorWithFormat("'%s' is not a valid octal string value",
+                                       entry.c_str());
           return;
         } else if (!llvm::isUIntN(item_byte_size * 8, uval64)) {
           result.AppendErrorWithFormat("Value %" PRIo64
@@ -1505,8 +1505,7 @@ protected:
           process->WriteMemory(addr, buffer_data, buffer_size, error);
 
       if (write_size != buffer_size) {
-        result.AppendErrorWithFormat("Memory write to 0x%" PRIx64
-                                     " failed: %s",
+        result.AppendErrorWithFormat("Memory write to 0x%" PRIx64 " failed: %s",
                                      addr, error.AsCString());
         return;
       }

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -358,7 +358,7 @@ protected:
 
     if ((argc == 0 && m_next_addr == LLDB_INVALID_ADDRESS) || argc > 2) {
       result.AppendErrorWithFormat("%s takes a start address expression with "
-                                   "an optional end address expression.",
+                                   "an optional end address expression",
                                    m_cmd_name.c_str());
       result.AppendWarning("expressions should be quoted if they contain "
                            "spaces or other special characters");
@@ -597,13 +597,13 @@ protected:
       } else if (end_addr <= addr) {
         result.AppendErrorWithFormat(
             "end address (0x%" PRIx64
-            ") must be greater than the start address (0x%" PRIx64 ").",
+            ") must be greater than the start address (0x%" PRIx64 ")",
             end_addr, addr);
         return;
       } else if (m_format_options.GetCountValue().OptionWasSet()) {
         result.AppendErrorWithFormat(
             "specify either the end address (0x%" PRIx64
-            ") or the count (--count %" PRIu64 "), not both.",
+            ") or the count (--count %" PRIu64 "), not both",
             end_addr, (uint64_t)item_count);
         return;
       }
@@ -617,12 +617,12 @@ protected:
     if (total_byte_size > max_unforced_size && !m_memory_options.m_force) {
       result.AppendErrorWithFormat(
           "Normally, \'memory read\' will not read over %" PRIu32
-          " bytes of data.",
+          " bytes of data",
           max_unforced_size);
       result.AppendErrorWithFormat(
-          "Please use --force to override this restriction just once.");
+          "Please use --force to override this restriction just once");
       result.AppendErrorWithFormat("or set target.max-memory-read-size if you "
-                                   "will often need a larger limit.");
+                                   "will often need a larger limit");
       return;
     }
 
@@ -772,7 +772,7 @@ protected:
             return;
           } else {
             result.AppendErrorWithFormat("Failed to write %" PRIu64
-                                         " bytes to '%s'.",
+                                         " bytes to '%s'",
                                          (uint64_t)bytes_read, path.c_str());
             return;
           }
@@ -1261,19 +1261,19 @@ protected:
     if (m_memory_options.m_infile) {
       if (argc < 1) {
         result.AppendErrorWithFormat(
-            "%s takes a destination address when writing file contents.",
+            "%s takes a destination address when writing file contents",
             m_cmd_name.c_str());
         return;
       }
       if (argc > 1) {
         result.AppendErrorWithFormat(
-            "%s takes only a destination address when writing file contents.",
+            "%s takes only a destination address when writing file contents",
             m_cmd_name.c_str());
         return;
       }
     } else if (argc < 2) {
       result.AppendErrorWithFormat(
-          "%s takes a destination address and at least one value.",
+          "%s takes a destination address and at least one value",
           m_cmd_name.c_str());
       return;
     }
@@ -1322,12 +1322,12 @@ protected:
             result.SetStatus(eReturnStatusSuccessFinishResult);
           } else {
             result.AppendErrorWithFormat("Memory write to 0x%" PRIx64
-                                         " failed: %s.",
+                                         " failed: %s",
                                          addr, error.AsCString());
           }
         }
       } else {
-        result.AppendErrorWithFormat("Unable to read contents of file.");
+        result.AppendErrorWithFormat("Unable to read contents of file");
       }
       return;
     } else if (item_byte_size == 0) {
@@ -1389,13 +1389,13 @@ protected:
         if (!success)
           success = !entry.ref().getAsInteger(16, uval64);
         if (!success) {
-          result.AppendErrorWithFormat("'%s' is not a valid hex string value.",
+          result.AppendErrorWithFormat("'%s' is not a valid hex string value",
                                        entry.c_str());
           return;
         } else if (!llvm::isUIntN(item_byte_size * 8, uval64)) {
           result.AppendErrorWithFormat("Value 0x%" PRIx64
                                        " is too large to fit in a %" PRIu64
-                                       " byte unsigned integer value.",
+                                       " byte unsigned integer value",
                                        uval64, (uint64_t)item_byte_size);
           return;
         }
@@ -1406,7 +1406,7 @@ protected:
         uval64 = OptionArgParser::ToBoolean(entry.ref(), false, &success);
         if (!success) {
           result.AppendErrorWithFormat(
-              "'%s' is not a valid boolean string value.", entry.c_str());
+              "'%s' is not a valid boolean string value", entry.c_str());
           return;
         }
         buffer.PutMaxHex64(uval64, item_byte_size);
@@ -1415,12 +1415,12 @@ protected:
       case eFormatBinary:
         if (entry.ref().getAsInteger(2, uval64)) {
           result.AppendErrorWithFormat(
-              "'%s' is not a valid binary string value.", entry.c_str());
+              "'%s' is not a valid binary string value", entry.c_str());
           return;
         } else if (!llvm::isUIntN(item_byte_size * 8, uval64)) {
           result.AppendErrorWithFormat("Value 0x%" PRIx64
                                        " is too large to fit in a %" PRIu64
-                                       " byte unsigned integer value.",
+                                       " byte unsigned integer value",
                                        uval64, (uint64_t)item_byte_size);
           return;
         }
@@ -1442,7 +1442,7 @@ protected:
           addr += len;
         } else {
           result.AppendErrorWithFormat("Memory write to 0x%" PRIx64
-                                       " failed: %s.\n",
+                                       " failed: %s",
                                        addr, error.AsCString());
           return;
         }
@@ -1451,12 +1451,12 @@ protected:
       case eFormatDecimal:
         if (entry.ref().getAsInteger(0, sval64)) {
           result.AppendErrorWithFormat(
-              "'%s' is not a valid signed decimal value.", entry.c_str());
+              "'%s' is not a valid signed decimal value", entry.c_str());
           return;
         } else if (!llvm::isIntN(item_byte_size * 8, sval64)) {
           result.AppendErrorWithFormat(
               "Value %" PRIi64 " is too large or small to fit in a %" PRIu64
-              " byte signed integer value.",
+              " byte signed integer value",
               sval64, (uint64_t)item_byte_size);
           return;
         }
@@ -1467,13 +1467,13 @@ protected:
 
         if (entry.ref().getAsInteger(0, uval64)) {
           result.AppendErrorWithFormat(
-              "'%s' is not a valid unsigned decimal string value.",
+              "'%s' is not a valid unsigned decimal string value",
               entry.c_str());
           return;
         } else if (!llvm::isUIntN(item_byte_size * 8, uval64)) {
           result.AppendErrorWithFormat("Value %" PRIu64
                                        " is too large to fit in a %" PRIu64
-                                       " byte unsigned integer value.",
+                                       " byte unsigned integer value",
                                        uval64, (uint64_t)item_byte_size);
           return;
         }
@@ -1483,12 +1483,12 @@ protected:
       case eFormatOctal:
         if (entry.ref().getAsInteger(8, uval64)) {
           result.AppendErrorWithFormat(
-              "'%s' is not a valid octal string value.", entry.c_str());
+              "'%s' is not a valid octal string value", entry.c_str());
           return;
         } else if (!llvm::isUIntN(item_byte_size * 8, uval64)) {
           result.AppendErrorWithFormat("Value %" PRIo64
                                        " is too large to fit in a %" PRIu64
-                                       " byte unsigned integer value.",
+                                       " byte unsigned integer value",
                                        uval64, (uint64_t)item_byte_size);
           return;
         }
@@ -1506,7 +1506,7 @@ protected:
 
       if (write_size != buffer_size) {
         result.AppendErrorWithFormat("Memory write to 0x%" PRIx64
-                                     " failed: %s.",
+                                     " failed: %s",
                                      addr, error.AsCString());
         return;
       }

--- a/lldb/source/Commands/CommandObjectMemoryTag.cpp
+++ b/lldb/source/Commands/CommandObjectMemoryTag.cpp
@@ -218,7 +218,7 @@ protected:
       // getAsInteger returns true on failure
       if (entry.ref().getAsInteger(0, tag_value)) {
         result.AppendErrorWithFormat(
-            "'%s' is not a valid unsigned decimal string value.",
+            "'%s' is not a valid unsigned decimal string value",
             entry.c_str());
         return;
       }

--- a/lldb/source/Commands/CommandObjectMemoryTag.cpp
+++ b/lldb/source/Commands/CommandObjectMemoryTag.cpp
@@ -218,8 +218,7 @@ protected:
       // getAsInteger returns true on failure
       if (entry.ref().getAsInteger(0, tag_value)) {
         result.AppendErrorWithFormat(
-            "'%s' is not a valid unsigned decimal string value",
-            entry.c_str());
+            "'%s' is not a valid unsigned decimal string value", entry.c_str());
         return;
       }
       tags.push_back(tag_value);

--- a/lldb/source/Commands/CommandObjectMultiword.cpp
+++ b/lldb/source/Commands/CommandObjectMultiword.cpp
@@ -164,7 +164,7 @@ void CommandObjectMultiword::Execute(const char *args_string,
   }
 
   if (m_subcommand_dict.empty()) {
-    result.AppendErrorWithFormat("'%s' does not have any subcommands.",
+    result.AppendErrorWithFormat("'%s' does not have any subcommands",
                                  GetCommandName().str().c_str());
     return;
   }

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -731,12 +731,12 @@ protected:
           result.SetStatus(eReturnStatusSuccessContinuingNoResult);
         }
       } else {
-        result.AppendErrorWithFormat("Failed to resume process: %s.",
+        result.AppendErrorWithFormat("Failed to resume process: %s",
                                      error.AsCString());
       }
     } else {
       result.AppendErrorWithFormat(
-          "Process cannot be continued from its current state (%s).",
+          "Process cannot be continued from its current state (%s)",
           StateAsCString(state));
     }
   }
@@ -1178,7 +1178,7 @@ protected:
         signo = process->GetUnixSignals()->GetSignalNumberFromName(signal_name);
 
       if (signo == LLDB_INVALID_SIGNAL_NUMBER) {
-        result.AppendErrorWithFormat("Invalid signal argument '%s'.",
+        result.AppendErrorWithFormat("Invalid signal argument '%s'",
                                      command.GetArgumentAtIndex(0));
       } else {
         Status error(process->Signal(signo));

--- a/lldb/source/Commands/CommandObjectRegister.cpp
+++ b/lldb/source/Commands/CommandObjectRegister.cpp
@@ -214,7 +214,7 @@ protected:
                               print_flags))
               strm.Printf("%-12s = error: unavailable\n", reg_info->name);
           } else {
-            result.AppendErrorWithFormat("Invalid register name '%s'.",
+            result.AppendErrorWithFormat("Invalid register name '%s'",
                                          arg_str.str().c_str());
           }
         }
@@ -377,7 +377,7 @@ protected:
               reg_name.str().c_str(), value_str.str().c_str());
         }
       } else {
-        result.AppendErrorWithFormat("Register not found for '%s'.",
+        result.AppendErrorWithFormat("Register not found for '%s'",
                                      reg_name.str().c_str());
       }
     }
@@ -439,7 +439,7 @@ protected:
           GetCommandInterpreter().GetDebugger().GetTerminalWidth());
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else
-      result.AppendErrorWithFormat("No register found with name '%s'.",
+      result.AppendErrorWithFormat("No register found with name '%s'",
                                    reg_name.str().c_str());
   }
 };

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -471,8 +471,8 @@ protected:
     FileSpec file_spec;
     if (!DumpLinesInSymbolContexts(result.GetOutputStream(), sc_list,
                                    module_list, file_spec)) {
-      result.AppendErrorWithFormat(
-          "No modules contain load address 0x%" PRIx64, m_options.address);
+      result.AppendErrorWithFormat("No modules contain load address 0x%" PRIx64,
+                                   m_options.address);
       return false;
     }
     return true;
@@ -1002,8 +1002,7 @@ protected:
 
         if (sc_list.GetSize() == 0) {
           result.AppendErrorWithFormat(
-              "no modules contain load address 0x%" PRIx64,
-              m_options.address);
+              "no modules contain load address 0x%" PRIx64, m_options.address);
           return;
         }
       }

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -403,7 +403,7 @@ protected:
       }
     }
     if (num_matches == 0) {
-      result.AppendErrorWithFormat("Could not find function named \'%s\'.",
+      result.AppendErrorWithFormat("Could not find function named \'%s\'",
                                    m_options.symbol_name.c_str());
       return false;
     }
@@ -464,7 +464,7 @@ protected:
     StreamString error_strm;
     if (!GetSymbolContextsForAddress(target.GetImages(), m_options.address,
                                      sc_list, error_strm)) {
-      result.AppendErrorWithFormat("%s.", error_strm.GetData());
+      result.AppendErrorWithFormat("%s", error_strm.GetData());
       return false;
     }
     ModuleList module_list;
@@ -472,7 +472,7 @@ protected:
     if (!DumpLinesInSymbolContexts(result.GetOutputStream(), sc_list,
                                    module_list, file_spec)) {
       result.AppendErrorWithFormat(
-          "No modules contain load address 0x%" PRIx64 ".", m_options.address);
+          "No modules contain load address 0x%" PRIx64, m_options.address);
       return false;
     }
     return true;
@@ -834,7 +834,7 @@ protected:
           start_file, line_no, column, 0, m_options.num_lines, "",
           &result.GetOutputStream(), GetBreakpointLocations());
     } else {
-      result.AppendErrorWithFormat("Could not find function info for: \"%s\".",
+      result.AppendErrorWithFormat("Could not find function info for: \"%s\"",
                                    m_options.symbol_name.c_str());
     }
     return 0;
@@ -925,7 +925,7 @@ protected:
       }
 
       if (sc_list.GetSize() == 0) {
-        result.AppendErrorWithFormat("Could not find function named: \"%s\".",
+        result.AppendErrorWithFormat("Could not find function named: \"%s\"",
                                      m_options.symbol_name.c_str());
         return;
       }
@@ -972,8 +972,7 @@ protected:
 
         if (sc_list.GetSize() == 0) {
           result.AppendErrorWithFormat(
-              "no modules have source information for file address 0x%" PRIx64
-              ".",
+              "no modules have source information for file address 0x%" PRIx64,
               m_options.address);
           return;
         }
@@ -994,7 +993,7 @@ protected:
                            Address::DumpStyleModuleWithFileAddress);
               result.AppendErrorWithFormat("address resolves to %s, but there "
                                            "is no line table information "
-                                           "available for this address.",
+                                           "available for this address",
                                            error_strm.GetData());
               return;
             }
@@ -1003,7 +1002,7 @@ protected:
 
         if (sc_list.GetSize() == 0) {
           result.AppendErrorWithFormat(
-              "no modules contain load address 0x%" PRIx64 ".",
+              "no modules contain load address 0x%" PRIx64,
               m_options.address);
           return;
         }
@@ -1138,7 +1137,7 @@ protected:
       }
 
       if (num_matches == 0) {
-        result.AppendErrorWithFormat("Could not find source file \"%s\".",
+        result.AppendErrorWithFormat("Could not find source file \"%s\"",
                                      m_options.file_name.c_str());
         return;
       }

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -450,7 +450,7 @@ protected:
       }
     } else {
       result.AppendErrorWithFormat("'%s' takes exactly one executable path "
-                                   "argument, or use the --core option.",
+                                   "argument, or use the --core option",
                                    m_cmd_name.c_str());
     }
   }
@@ -1162,7 +1162,7 @@ protected:
 
       if (!llvm::to_integer(command.GetArgumentAtIndex(0), insert_idx)) {
         result.AppendErrorWithFormat(
-            "<index> parameter is not an integer: '%s'.",
+            "<index> parameter is not an integer: '%s'",
             command.GetArgumentAtIndex(0));
         return;
       }
@@ -2180,7 +2180,7 @@ public:
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.GetArgumentCount() != 1) {
-      result.AppendErrorWithFormat("'%s' takes exactly one pcm path argument.",
+      result.AppendErrorWithFormat("'%s' takes exactly one pcm path argument",
                                    m_cmd_name.c_str());
       return;
     }
@@ -3069,7 +3069,7 @@ protected:
           FileSpec *module_spec_file = module_spec.GetFileSpecPtr();
           if (module_spec_file) {
             module_spec_file->GetPath(path, sizeof(path));
-            result.AppendErrorWithFormat("invalid module '%s'.", path);
+            result.AppendErrorWithFormat("invalid module '%s'", path);
           } else
             result.AppendError("no module spec");
         }
@@ -3095,7 +3095,7 @@ protected:
           }
         } else {
           result.AppendErrorWithFormat(
-              "no modules were found  that match%s%s%s%s.",
+              "no modules were found  that match%s%s%s%s",
               path[0] ? " file=" : "", path, !uuid_str.empty() ? " uuid=" : "",
               uuid_str.c_str());
         }
@@ -3193,12 +3193,12 @@ protected:
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
           result.AppendErrorWithFormat(
-              "Couldn't find module matching address: 0x%" PRIx64 ".",
+              "Couldn't find module matching address: 0x%" PRIx64,
               m_options.m_module_addr);
         }
       } else {
         result.AppendErrorWithFormat(
-            "Couldn't find module containing address: 0x%" PRIx64 ".",
+            "Couldn't find module containing address: 0x%" PRIx64,
             m_options.m_module_addr);
       }
       return;
@@ -3580,7 +3580,7 @@ protected:
     }
 
     if (sc_list.GetSize() == 0) {
-      result.AppendErrorWithFormat("no unwind data found that matches '%s'.",
+      result.AppendErrorWithFormat("no unwind data found that matches '%s'",
                                    m_options.m_str.c_str());
       return;
     }
@@ -4336,7 +4336,7 @@ protected:
     if (matching_modules.GetSize() > 1) {
       result.AppendErrorWithFormat("multiple modules match symbol file '%s', "
                                    "use the --uuid option to resolve the "
-                                   "ambiguity.",
+                                   "ambiguity",
                                    symfile_path);
       return false;
     }
@@ -5118,12 +5118,12 @@ protected:
       for (size_t i = 0; i < num_args; i++) {
         lldb::user_id_t user_id;
         if (!llvm::to_integer(command.GetArgumentAtIndex(i), user_id)) {
-          result.AppendErrorWithFormat("invalid stop hook id: \"%s\".",
+          result.AppendErrorWithFormat("invalid stop hook id: \"%s\"",
                                        command.GetArgumentAtIndex(i));
           return;
         }
         if (!target.RemoveStopHookByID(user_id)) {
-          result.AppendErrorWithFormat("unknown stop hook id: \"%s\".",
+          result.AppendErrorWithFormat("unknown stop hook id: \"%s\"",
                                        command.GetArgumentAtIndex(i));
           return;
         }
@@ -5169,13 +5169,13 @@ protected:
       for (size_t i = 0; i < num_args; i++) {
         lldb::user_id_t user_id;
         if (!llvm::to_integer(command.GetArgumentAtIndex(i), user_id)) {
-          result.AppendErrorWithFormat("invalid stop hook id: \"%s\".",
+          result.AppendErrorWithFormat("invalid stop hook id: \"%s\"",
                                        command.GetArgumentAtIndex(i));
           return;
         }
         success = target.SetStopHookActiveStateByID(user_id, m_enable);
         if (!success) {
-          result.AppendErrorWithFormat("unknown stop hook id: \"%s\".",
+          result.AppendErrorWithFormat("unknown stop hook id: \"%s\"",
                                        command.GetArgumentAtIndex(i));
           return;
         }

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -613,7 +613,7 @@ protected:
       uint32_t step_thread_idx;
 
       if (!llvm::to_integer(thread_idx_cstr, step_thread_idx)) {
-        result.AppendErrorWithFormat("invalid thread index '%s'.",
+        result.AppendErrorWithFormat("invalid thread index '%s'",
                                      thread_idx_cstr);
         return;
       }
@@ -621,7 +621,7 @@ protected:
           process->GetThreadList().FindThreadByIndexID(step_thread_idx).get();
       if (thread == nullptr) {
         result.AppendErrorWithFormat(
-            "Thread index %u is out of range (valid values are 0 - %u).",
+            "Thread index %u is out of range (valid values are 0 - %u)",
             step_thread_idx, num_threads);
         return;
       }
@@ -629,12 +629,12 @@ protected:
 
     if (m_step_type == eStepTypeScripted) {
       if (m_class_options.GetName().empty()) {
-        result.AppendErrorWithFormat("empty class name for scripted step.");
+        result.AppendErrorWithFormat("empty class name for scripted step");
         return;
       } else if (!GetDebugger().GetScriptInterpreter()->CheckObjectExists(
                      m_class_options.GetName().c_str())) {
         result.AppendErrorWithFormat(
-            "class for scripted step: \"%s\" does not exist.",
+            "class for scripted step: \"%s\" does not exist",
             m_class_options.GetName().c_str());
         return;
       }
@@ -682,7 +682,7 @@ protected:
           Status error;
           Block *block = frame->GetSymbolContext(eSymbolContextBlock).block;
           if (!block) {
-            result.AppendErrorWithFormat("Could not find the current block.");
+            result.AppendErrorWithFormat("Could not find the current block");
             return;
           }
 
@@ -691,7 +691,7 @@ protected:
           block->GetRangeContainingAddress(pc_address, block_range);
           if (!block_range.GetBaseAddress().IsValid()) {
             result.AppendErrorWithFormat(
-                "Could not find the current block address.");
+                "Could not find the current block address");
             return;
           }
           lldb::addr_t pc_offset_in_block =
@@ -857,7 +857,7 @@ public:
           uint32_t thread_idx;
           if (entry.ref().getAsInteger(0, thread_idx)) {
             result.AppendErrorWithFormat(
-                "invalid thread index argument: \"%s\".", entry.c_str());
+                "invalid thread index argument: \"%s\"", entry.c_str());
             return;
           }
           Thread *thread =
@@ -866,7 +866,7 @@ public:
           if (thread) {
             resume_threads.push_back(thread);
           } else {
-            result.AppendErrorWithFormat("invalid thread index %u.",
+            result.AppendErrorWithFormat("invalid thread index %u",
                                          thread_idx);
             return;
           }
@@ -958,7 +958,7 @@ public:
       }
     } else {
       result.AppendErrorWithFormat(
-          "Process cannot be continued from its current state (%s).",
+          "Process cannot be continued from its current state (%s)",
           StateAsCString(state));
     }
   }
@@ -1082,7 +1082,7 @@ protected:
         for (size_t i = 0; i < num_args; i++) {
           uint32_t line_number;
           if (!llvm::to_integer(command.GetArgumentAtIndex(i), line_number)) {
-            result.AppendErrorWithFormat("invalid line number: '%s'.",
+            result.AppendErrorWithFormat("invalid line number: '%s'",
                                          command.GetArgumentAtIndex(i));
             return;
           } else
@@ -1105,7 +1105,7 @@ protected:
       if (thread == nullptr) {
         const uint32_t num_threads = process->GetThreadList().GetSize();
         result.AppendErrorWithFormat(
-            "Thread index %u is out of range (valid values are 0 - %u).",
+            "Thread index %u is out of range (valid values are 0 - %u)",
             m_options.m_thread_idx, num_threads);
         return;
       }
@@ -1116,7 +1116,7 @@ protected:
           thread->GetStackFrameAtIndex(m_options.m_frame_idx).get();
       if (frame == nullptr) {
         result.AppendErrorWithFormat(
-            "Frame index %u is out of range for thread id %" PRIu64 ".",
+            "Frame index %u is out of range for thread id %" PRIu64,
             m_options.m_frame_idx, thread->GetID());
         return;
       }
@@ -1134,7 +1134,7 @@ protected:
 
         if (line_table == nullptr) {
           result.AppendErrorWithFormat("Failed to resolve the line table for "
-                                       "frame %u of thread id %" PRIu64 ".",
+                                       "frame %u of thread id %" PRIu64,
                                        m_options.m_frame_idx, thread->GetID());
           return;
         }
@@ -1146,7 +1146,7 @@ protected:
         // sure it is valid:
         if (!sc.function) {
           result.AppendErrorWithFormat("Have debug information but no "
-                                       "function info - can't get until range.");
+                                       "function info - can't get until range");
           return;
         }
 
@@ -1199,10 +1199,10 @@ protected:
         if (address_list.empty()) {
           if (found_something)
             result.AppendErrorWithFormat(
-                "Until target outside of the current function.");
+                "Until target outside of the current function");
           else
             result.AppendErrorWithFormat(
-                "No line entries matching until target.");
+                "No line entries matching until target");
 
           return;
         }
@@ -1224,14 +1224,14 @@ protected:
         }
       } else {
         result.AppendErrorWithFormat("Frame index %u of thread id %" PRIu64
-                                     " has no debug information.",
+                                     " has no debug information",
                                      m_options.m_frame_idx, thread->GetID());
         return;
       }
 
       if (!process->GetThreadList().SetSelectedThreadByID(thread->GetID())) {
         result.AppendErrorWithFormat(
-            "Failed to set the selected thread to thread id %" PRIu64 ".",
+            "Failed to set the selected thread to thread id %" PRIu64,
             thread->GetID());
         return;
       }
@@ -1258,7 +1258,7 @@ protected:
           result.SetStatus(eReturnStatusSuccessContinuingNoResult);
         }
       } else {
-        result.AppendErrorWithFormat("Failed to resume process: %s.",
+        result.AppendErrorWithFormat("Failed to resume process: %s",
                                      error.AsCString());
       }
     }
@@ -1383,7 +1383,7 @@ protected:
       }
       new_thread = process->GetThreadList().FindThreadByIndexID(index_id).get();
       if (new_thread == nullptr) {
-        result.AppendErrorWithFormat("Invalid thread index #%s.",
+        result.AppendErrorWithFormat("Invalid thread index #%s",
                                      command.GetArgumentAtIndex(0));
         return;
       }
@@ -1391,7 +1391,7 @@ protected:
       new_thread =
           process->GetThreadList().FindThreadByID(m_options.m_thread_id).get();
       if (new_thread == nullptr) {
-        result.AppendErrorWithFormat("Invalid thread ID %" PRIu64 ".",
+        result.AppendErrorWithFormat("Invalid thread ID %" PRIu64,
                                      m_options.m_thread_id);
         return;
       }
@@ -1725,7 +1725,7 @@ protected:
       Status error;
       error = thread->UnwindInnermostExpression();
       if (!error.Success()) {
-        result.AppendErrorWithFormat("Unwinding expression failed - %s.",
+        result.AppendErrorWithFormat("Unwinding expression failed - %s",
                                      error.AsCString());
       } else {
         bool success =
@@ -1736,7 +1736,7 @@ protected:
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
           result.AppendErrorWithFormat(
-              "Could not select 0th frame after unwinding expression.");
+              "Could not select 0th frame after unwinding expression");
         }
       }
       return;
@@ -1769,7 +1769,7 @@ protected:
               return_valobj_sp->GetError().AsCString());
         else
           result.AppendErrorWithFormat(
-              "Unknown error evaluating result expression.");
+              "Unknown error evaluating result expression");
         return;
       }
     }
@@ -1780,7 +1780,7 @@ protected:
     error = thread_sp->ReturnFromFrame(frame_sp, return_valobj_sp, broadcast);
     if (!error.Success()) {
       result.AppendErrorWithFormat(
-          "Error returning from frame %d of thread %d: %s.", frame_idx,
+          "Error returning from frame %d of thread %d: %s", frame_idx,
           thread_sp->GetIndexID(), error.AsCString());
       return;
     }
@@ -1885,12 +1885,12 @@ protected:
 
       lldb::addr_t callAddr = dest.GetCallableLoadAddress(target);
       if (callAddr == LLDB_INVALID_ADDRESS) {
-        result.AppendErrorWithFormat("Invalid destination address.");
+        result.AppendErrorWithFormat("Invalid destination address");
         return;
       }
 
       if (!reg_ctx->SetPC(callAddr)) {
-        result.AppendErrorWithFormat("Error changing PC value for thread %d.",
+        result.AppendErrorWithFormat("Error changing PC value for thread %d",
                                      thread->GetIndexID());
         return;
       }
@@ -2095,7 +2095,7 @@ public:
     Thread *thread = m_exe_ctx.GetThreadPtr();
     if (args.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat("Too many arguments, expected one - the "
-                                   "thread plan index - but got %zu.",
+                                   "thread plan index - but got %zu",
                                    args.GetArgumentCount());
       return;
     }
@@ -2103,14 +2103,14 @@ public:
     uint32_t thread_plan_idx;
     if (!llvm::to_integer(args.GetArgumentAtIndex(0), thread_plan_idx)) {
       result.AppendErrorWithFormat(
-          "Invalid thread index: \"%s\" - should be unsigned int.",
+          "Invalid thread index: \"%s\" - should be unsigned int",
           args.GetArgumentAtIndex(0));
       return;
     }
 
     if (thread_plan_idx == 0) {
       result.AppendErrorWithFormat(
-          "You wouldn't really want me to discard the base thread plan.");
+          "You wouldn't really want me to discard the base thread plan");
       return;
     }
 
@@ -2118,7 +2118,7 @@ public:
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     } else {
       result.AppendErrorWithFormat(
-          "Could not find User thread plan with index %s.",
+          "Could not find User thread plan with index %s",
           args.GetArgumentAtIndex(0));
     }
   }

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -866,8 +866,7 @@ public:
           if (thread) {
             resume_threads.push_back(thread);
           } else {
-            result.AppendErrorWithFormat("invalid thread index %u",
-                                         thread_idx);
+            result.AppendErrorWithFormat("invalid thread index %u", thread_idx);
             return;
           }
         }

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -666,7 +666,7 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
-      result.AppendErrorWithFormat("%s takes one or more args.",
+      result.AppendErrorWithFormat("%s takes one or more args",
                                    m_cmd_name.c_str());
       return;
     }
@@ -674,7 +674,7 @@ protected:
     const Format format = m_format_options.GetFormat();
     if (format == eFormatInvalid &&
         m_command_options.m_custom_type_name.empty()) {
-      result.AppendErrorWithFormat("%s needs a valid format.",
+      result.AppendErrorWithFormat("%s needs a valid format",
                                    m_cmd_name.c_str());
       return;
     }
@@ -836,7 +836,7 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc != 1) {
-      result.AppendErrorWithFormat("%s takes 1 arg.", m_cmd_name.c_str());
+      result.AppendErrorWithFormat("%s takes 1 arg", m_cmd_name.c_str());
       return;
     }
 
@@ -880,7 +880,7 @@ protected:
     if (delete_category || extra_deletion) {
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     } else {
-      result.AppendErrorWithFormat("no custom formatter for %s.", typeA);
+      result.AppendErrorWithFormat("no custom formatter for %s", typeA);
     }
   }
 };
@@ -1266,7 +1266,7 @@ bool CommandObjectTypeSummaryAdd::Execute_ScriptSummary(
   const size_t argc = command.GetArgumentCount();
 
   if (argc < 1 && !m_options.m_name) {
-    result.AppendErrorWithFormat("%s takes one or more args.",
+    result.AppendErrorWithFormat("%s takes one or more args",
                                  m_cmd_name.c_str());
     return false;
   }
@@ -1381,7 +1381,7 @@ bool CommandObjectTypeSummaryAdd::Execute_StringSummary(
   const size_t argc = command.GetArgumentCount();
 
   if (argc < 1 && !m_options.m_name) {
-    result.AppendErrorWithFormat("%s takes one or more args.",
+    result.AppendErrorWithFormat("%s takes one or more args",
                                  m_cmd_name.c_str());
     return false;
   }
@@ -1753,7 +1753,7 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
-      result.AppendErrorWithFormat("%s takes 1 or more args.",
+      result.AppendErrorWithFormat("%s takes 1 or more args",
                                    m_cmd_name.c_str());
       return;
     }
@@ -1889,7 +1889,7 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
-      result.AppendErrorWithFormat("%s takes 1 or more arg.",
+      result.AppendErrorWithFormat("%s takes 1 or more arg",
                                    m_cmd_name.c_str());
       return;
     }
@@ -2046,7 +2046,7 @@ protected:
         return;
       }
     } else if (argc != 0) {
-      result.AppendErrorWithFormat("%s takes 0 or one arg.",
+      result.AppendErrorWithFormat("%s takes 0 or one arg",
                                    m_cmd_name.c_str());
       return;
     }
@@ -2168,14 +2168,14 @@ bool CommandObjectTypeSynthAdd::Execute_PythonClass(
   const size_t argc = command.GetArgumentCount();
 
   if (argc < 1) {
-    result.AppendErrorWithFormat("%s takes one or more args.",
+    result.AppendErrorWithFormat("%s takes one or more args",
                                  m_cmd_name.c_str());
     return false;
   }
 
   if (m_options.m_class_name.empty() && !m_options.m_input_python) {
     result.AppendErrorWithFormat("%s needs either a Python class name or -P to "
-                                 "directly input Python code.",
+                                 "directly input Python code",
                                  m_cmd_name.c_str());
     return false;
   }
@@ -2477,13 +2477,13 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
-      result.AppendErrorWithFormat("%s takes one or more args.",
+      result.AppendErrorWithFormat("%s takes one or more args",
                                    m_cmd_name.c_str());
       return;
     }
 
     if (m_options.m_expr_paths.empty()) {
-      result.AppendErrorWithFormat("%s needs one or more children.",
+      result.AppendErrorWithFormat("%s needs one or more children",
                                    m_cmd_name.c_str());
       return;
     }

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -2046,8 +2046,7 @@ protected:
         return;
       }
     } else if (argc != 0) {
-      result.AppendErrorWithFormat("%s takes 0 or one arg",
-                                   m_cmd_name.c_str());
+      result.AppendErrorWithFormat("%s takes 0 or one arg", m_cmd_name.c_str());
       return;
     }
 

--- a/lldb/source/Commands/CommandObjectWatchpoint.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpoint.cpp
@@ -906,7 +906,7 @@ protected:
     if (!watch_sp) {
       result.AppendErrorWithFormat(
           "Watchpoint creation failed (addr=0x%" PRIx64 ", size=%" PRIu64
-          ", variable expression='%s').",
+          ", variable expression='%s')",
           addr, static_cast<uint64_t>(size), command.GetArgumentAtIndex(0));
       if (const char *error_message = error.AsCString(nullptr))
         result.AppendError(error_message);
@@ -1104,7 +1104,7 @@ protected:
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else {
       result.AppendErrorWithFormat("Watchpoint creation failed (addr=0x%" PRIx64
-                                   ", size=%" PRIu64 ").",
+                                   ", size=%" PRIu64 ")",
                                    addr, (uint64_t)size);
       if (error.AsCString(nullptr))
         result.AppendError(error.AsCString());

--- a/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
@@ -483,7 +483,7 @@ protected:
         if (wp)
           wp->ClearCallback();
       } else {
-        result.AppendErrorWithFormat("Invalid watchpoint ID: %u.", cur_wp_id);
+        result.AppendErrorWithFormat("Invalid watchpoint ID: %u", cur_wp_id);
         return;
       }
     }
@@ -555,7 +555,7 @@ protected:
           }
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
-          result.AppendErrorWithFormat("Invalid watchpoint ID: %u.", cur_wp_id);
+          result.AppendErrorWithFormat("Invalid watchpoint ID: %u", cur_wp_id);
         }
       }
     }

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1883,7 +1883,7 @@ CommandObject *CommandInterpreter::BuildAliasResult(
 
       result.AppendErrorWithFormat("Not enough arguments provided; you "
                                    "need at least %d arguments to use "
-                                   "this alias.",
+                                   "this alias",
                                    index);
       return nullptr;
     } else {
@@ -2520,7 +2520,7 @@ void CommandInterpreter::BuildAliasCommandArgs(CommandObject *alias_cmd_obj,
       } else if (static_cast<size_t>(index) >= cmd_args.GetArgumentCount()) {
         result.AppendErrorWithFormat("Not enough arguments provided; you "
                                      "need at least %d arguments to use "
-                                     "this alias.",
+                                     "this alias",
                                      index);
         return;
       } else {
@@ -2889,7 +2889,7 @@ void CommandInterpreter::HandleCommands(
         if (idx != num_lines - 1)
           result.AppendErrorWithFormat(
               "Aborting reading of commands after command #%" PRIu64
-              ": '%s' continued the target.",
+              ": '%s' continued the target",
               (uint64_t)idx + 1, cmd);
         else
           result.AppendMessageWithFormatv(
@@ -2909,7 +2909,7 @@ void CommandInterpreter::HandleCommands(
       if (idx != num_lines - 1)
         result.AppendErrorWithFormat(
             "Aborting reading of commands after command #%" PRIu64
-            ": '%s' stopped with a signal or exception.",
+            ": '%s' stopped with a signal or exception",
             (uint64_t)idx + 1, cmd);
       else
         result.AppendMessageWithFormatv(
@@ -2953,7 +2953,7 @@ void CommandInterpreter::HandleCommandsFromFile(
     CommandReturnObject &result) {
   if (!FileSystem::Instance().Exists(cmd_file)) {
     result.AppendErrorWithFormat(
-        "Error reading commands from file %s - file not found.",
+        "Error reading commands from file %s - file not found",
         cmd_file.GetFilename().AsCString("<Unknown>"));
     return;
   }
@@ -3818,7 +3818,7 @@ CommandInterpreter::ResolveCommandImpl(std::string &command_line,
       } else {
         // We didn't have only one match, otherwise we wouldn't get here.
         lldbassert(num_matches == 0);
-        result.AppendErrorWithFormat("'%s' is not a valid command.",
+        result.AppendErrorWithFormat("'%s' is not a valid command",
                                      next_word.c_str());
       }
       if (!done)
@@ -3829,7 +3829,7 @@ CommandInterpreter::ResolveCommandImpl(std::string &command_line,
       if (!suffix.empty()) {
         result.AppendErrorWithFormat(
             "command '%s' did not recognize '%s%s%s' as valid (subcommand "
-            "might be invalid).",
+            "might be invalid)",
             cmd_obj->GetCommandName().str().c_str(),
             next_word.empty() ? "" : next_word.c_str(),
             next_word.empty() ? " -- " : " ", suffix.c_str());

--- a/lldb/test/API/commands/breakpoint/command/list/TestBreakpointCommandList.py
+++ b/lldb/test/API/commands/breakpoint/command/list/TestBreakpointCommandList.py
@@ -52,5 +52,5 @@ class TestCase(TestBase):
         self.expect(
             "breakpoint command list 2",
             error=True,
-            startstr="error: '2' is not a currently valid breakpoint ID.",
+            startstr="error: '2' is not a currently valid breakpoint ID",
         )

--- a/lldb/test/API/commands/command/container/TestContainerCommands.py
+++ b/lldb/test/API/commands/command/container/TestContainerCommands.py
@@ -237,7 +237,7 @@ class TestCmdContainer(TestBase):
         self.expect(
             "test-multi test-multi-sub welcome friend",
             "did remove subcommand",
-            substrs=["'test-multi-sub' does not have any subcommands."],
+            substrs=["'test-multi-sub' does not have any subcommands"],
             error=True,
         )
         # We should have the new help:
@@ -262,6 +262,6 @@ class TestCmdContainer(TestBase):
         self.expect(
             "test-multi",
             "Root command gone",
-            substrs=["'test-multi' is not a valid command."],
+            substrs=["'test-multi' is not a valid command"],
             error=True,
         )

--- a/lldb/test/API/commands/command/delete/TestCommandDelete.py
+++ b/lldb/test/API/commands/command/delete/TestCommandDelete.py
@@ -10,7 +10,7 @@ class DeleteCommandTestCase(TestBase):
             "command delete settings",
             error=True,
             substrs=[
-                "'settings' is a permanent debugger command and cannot be removed."
+                "'settings' is a permanent debugger command and cannot be removed"
             ],
         )
 

--- a/lldb/test/API/commands/command/invalid-args/TestInvalidArgsCommand.py
+++ b/lldb/test/API/commands/command/invalid-args/TestInvalidArgsCommand.py
@@ -54,7 +54,7 @@ class InvalidArgsCommandTestCase(TestBase):
             "command alias blub foo",
             error=True,
             substrs=[
-                "error: invalid command given to 'command alias'. 'foo' does not begin with a valid command.  No alias created."
+                "error: invalid command given to 'command alias'. 'foo' does not begin with a valid command.  No alias created"
             ],
         )
 
@@ -88,6 +88,6 @@ class InvalidArgsCommandTestCase(TestBase):
             "command source",
             error=True,
             substrs=[
-                "'command source' takes exactly one executable filename argument."
+                "'command source' takes exactly one executable filename argument"
             ],
         )

--- a/lldb/test/API/commands/command/invalid-args/TestInvalidArgsCommand.py
+++ b/lldb/test/API/commands/command/invalid-args/TestInvalidArgsCommand.py
@@ -87,7 +87,5 @@ class InvalidArgsCommandTestCase(TestBase):
         self.expect(
             "command source",
             error=True,
-            substrs=[
-                "'command source' takes exactly one executable filename argument"
-            ],
+            substrs=["'command source' takes exactly one executable filename argument"],
         )

--- a/lldb/test/API/commands/expression/dont_allow_jit/TestAllowJIT.py
+++ b/lldb/test/API/commands/expression/dont_allow_jit/TestAllowJIT.py
@@ -91,7 +91,7 @@ class TestAllowJIT(TestBase):
         self.expect(
             "expr --allow-jit false --top-level -- int i;",
             error=True,
-            substrs=["Can't disable JIT compilation for top-level expressions."],
+            substrs=["Can't disable JIT compilation for top-level expressions"],
         )
 
         self.build()

--- a/lldb/test/API/commands/frame/recognizer/TestFrameRecognizer.py
+++ b/lldb/test/API/commands/frame/recognizer/TestFrameRecognizer.py
@@ -73,12 +73,12 @@ class FrameRecognizerTestCase(TestBase):
         self.expect(
             "frame recognizer delete 2",
             error=True,
-            substrs=["error: '2' is not a valid recognizer id."],
+            substrs=["error: '2' is not a valid recognizer id"],
         )
         self.expect(
             "frame recognizer delete 0",
             error=True,
-            substrs=["error: '0' is not a valid recognizer id."],
+            substrs=["error: '0' is not a valid recognizer id"],
         )
         # Recognizers should have the same state as above.
         self.expect(
@@ -448,22 +448,22 @@ class FrameRecognizerTestCase(TestBase):
         self.expect(
             "frame recognizer delete a",
             error=True,
-            substrs=["error: 'a' is not a valid recognizer id."],
+            substrs=["error: 'a' is not a valid recognizer id"],
         )
         self.expect(
             'frame recognizer delete ""',
             error=True,
-            substrs=["error: '' is not a valid recognizer id."],
+            substrs=["error: '' is not a valid recognizer id"],
         )
         self.expect(
             "frame recognizer delete -1",
             error=True,
-            substrs=["error: '-1' is not a valid recognizer id."],
+            substrs=["error: '-1' is not a valid recognizer id"],
         )
         self.expect(
             "frame recognizer delete 4294967297",
             error=True,
-            substrs=["error: '4294967297' is not a valid recognizer id."],
+            substrs=["error: '4294967297' is not a valid recognizer id"],
         )
 
     @no_debug_info_test
@@ -471,22 +471,22 @@ class FrameRecognizerTestCase(TestBase):
         self.expect(
             "frame recognizer info a",
             error=True,
-            substrs=["error: 'a' is not a valid frame index."],
+            substrs=["error: 'a' is not a valid frame index"],
         )
         self.expect(
             'frame recognizer info ""',
             error=True,
-            substrs=["error: '' is not a valid frame index."],
+            substrs=["error: '' is not a valid frame index"],
         )
         self.expect(
             "frame recognizer info -1",
             error=True,
-            substrs=["error: '-1' is not a valid frame index."],
+            substrs=["error: '-1' is not a valid frame index"],
         )
         self.expect(
             "frame recognizer info 4294967297",
             error=True,
-            substrs=["error: '4294967297' is not a valid frame index."],
+            substrs=["error: '4294967297' is not a valid frame index"],
         )
 
     @no_debug_info_test

--- a/lldb/test/API/commands/log/invalid-args/TestInvalidArgsLog.py
+++ b/lldb/test/API/commands/log/invalid-args/TestInvalidArgsLog.py
@@ -10,7 +10,7 @@ class InvalidArgsLogTestCase(TestBase):
             "log enable",
             error=True,
             substrs=[
-                "error: log enable takes a log channel and one or more log types."
+                "error: log enable takes a log channel and one or more log types"
             ],
         )
 
@@ -20,7 +20,7 @@ class InvalidArgsLogTestCase(TestBase):
             "log disable",
             error=True,
             substrs=[
-                "error: log disable takes a log channel and one or more log types."
+                "error: log disable takes a log channel and one or more log types"
             ],
         )
 

--- a/lldb/test/API/commands/log/invalid-args/TestInvalidArgsLog.py
+++ b/lldb/test/API/commands/log/invalid-args/TestInvalidArgsLog.py
@@ -9,9 +9,7 @@ class InvalidArgsLogTestCase(TestBase):
         self.expect(
             "log enable",
             error=True,
-            substrs=[
-                "error: log enable takes a log channel and one or more log types"
-            ],
+            substrs=["error: log enable takes a log channel and one or more log types"],
         )
 
     @no_debug_info_test

--- a/lldb/test/API/commands/process/signal/TestProcessSignal.py
+++ b/lldb/test/API/commands/process/signal/TestProcessSignal.py
@@ -15,15 +15,15 @@ class TestCase(TestBase):
         self.expect(
             "process signal az",
             error=True,
-            startstr="error: Invalid signal argument 'az'.",
+            startstr="error: Invalid signal argument 'az'",
         )
         self.expect(
             "process signal 0x1ffffffff",
             error=True,
-            startstr="error: Invalid signal argument '0x1ffffffff'.",
+            startstr="error: Invalid signal argument '0x1ffffffff'",
         )
         self.expect(
             "process signal 0xffffffff",
             error=True,
-            startstr="error: Invalid signal argument '0xffffffff'.",
+            startstr="error: Invalid signal argument '0xffffffff'",
         )

--- a/lldb/test/API/commands/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register_command/TestRegisters.py
@@ -579,7 +579,7 @@ class RegisterCommandsTestCase(TestBase):
         self.expect(
             "register write blub 1",
             error=True,
-            substrs=["error: Register not found for 'blub'."],
+            substrs=["error: Register not found for 'blub'"],
         )
 
     def test_info_unknown_register(self):
@@ -589,7 +589,7 @@ class RegisterCommandsTestCase(TestBase):
         self.expect(
             "register info blub",
             error=True,
-            substrs=["error: No register found with name 'blub'."],
+            substrs=["error: No register found with name 'blub'"],
         )
 
     def test_info_many_registers(self):

--- a/lldb/test/API/commands/target/modules/search-paths/insert/TestTargetModulesSearchpathsInsert.py
+++ b/lldb/test/API/commands/target/modules/search-paths/insert/TestTargetModulesSearchpathsInsert.py
@@ -14,11 +14,11 @@ class TestCase(TestBase):
         self.expect(
             "target modules search-paths insert -1 a b",
             error=True,
-            startstr="error: <index> parameter is not an integer: '-1'.",
+            startstr="error: <index> parameter is not an integer: '-1'",
         )
 
         self.expect(
             "target modules search-paths insert abcdefx a b",
             error=True,
-            startstr="error: <index> parameter is not an integer: 'abcdefx'.",
+            startstr="error: <index> parameter is not an integer: 'abcdefx'",
         )

--- a/lldb/test/API/commands/target/stop-hook/delete/TestTargetStopHookDelete.py
+++ b/lldb/test/API/commands/target/stop-hook/delete/TestTargetStopHookDelete.py
@@ -10,10 +10,10 @@ class TestCase(TestBase):
         self.expect(
             "target stop-hook delete -1",
             error=True,
-            startstr='error: invalid stop hook id: "-1".',
+            startstr='error: invalid stop hook id: "-1"',
         )
         self.expect(
             "target stop-hook delete abcdfx",
             error=True,
-            startstr='error: invalid stop hook id: "abcdfx".',
+            startstr='error: invalid stop hook id: "abcdfx"',
         )

--- a/lldb/test/API/commands/target/stop-hook/disable/TestTargetStopHookDisable.py
+++ b/lldb/test/API/commands/target/stop-hook/disable/TestTargetStopHookDisable.py
@@ -10,10 +10,10 @@ class TestCase(TestBase):
         self.expect(
             "target stop-hook disable -1",
             error=True,
-            startstr='error: invalid stop hook id: "-1".',
+            startstr='error: invalid stop hook id: "-1"',
         )
         self.expect(
             "target stop-hook disable abcdfx",
             error=True,
-            startstr='error: invalid stop hook id: "abcdfx".',
+            startstr='error: invalid stop hook id: "abcdfx"',
         )

--- a/lldb/test/API/commands/target/stop-hook/enable/TestTargetStopHookEnable.py
+++ b/lldb/test/API/commands/target/stop-hook/enable/TestTargetStopHookEnable.py
@@ -10,10 +10,10 @@ class TestCase(TestBase):
         self.expect(
             "target stop-hook enable -1",
             error=True,
-            startstr='error: invalid stop hook id: "-1".',
+            startstr='error: invalid stop hook id: "-1"',
         )
         self.expect(
             "target stop-hook enable abcdfx",
             error=True,
-            startstr='error: invalid stop hook id: "abcdfx".',
+            startstr='error: invalid stop hook id: "abcdfx"',
         )

--- a/lldb/test/API/commands/thread/select/TestThreadSelect.py
+++ b/lldb/test/API/commands/thread/select/TestThreadSelect.py
@@ -36,7 +36,7 @@ class TestCase(TestBase):
         self.expect(
             "thread select 0xffffffff",
             error=True,
-            startstr="error: Invalid thread index #0xffffffff.",
+            startstr="error: Invalid thread index #0xffffffff",
         )
         self.expect(
             "thread select -t 0xffffffff",

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
@@ -383,7 +383,7 @@ class BreakpointCommandTestCase(TestBase):
         self.expect(
             "breakpoint command list 2",
             error=True,
-            startstr="error: '2' is not a currently valid breakpoint ID.",
+            startstr="error: '2' is not a currently valid breakpoint ID",
         )
 
         # The breakpoint list now only contains breakpoint 1.

--- a/lldb/test/API/functionalities/gdb_remote_client/TestGDBServerTargetXML.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGDBServerTargetXML.py
@@ -881,7 +881,7 @@ class TestGDBServerTargetXML(GDBRemoteTestBase):
         self.match("register read rdx", ["rdx = 0x1817161514131211"])
         # edx should not be added
         self.match(
-            "register read edx", ["error: Invalid register name 'edx'."], error=True
+            "register read edx", ["error: Invalid register name 'edx'"], error=True
         )
 
     @skipIfXmlSupportMissing
@@ -954,7 +954,7 @@ class TestGDBServerTargetXML(GDBRemoteTestBase):
         self.match("register read ecx", ["ecx = 0x14131211"])
         # dx should not be added
         self.match(
-            "register read cx", ["error: Invalid register name 'cx'."], error=True
+            "register read cx", ["error: Invalid register name 'cx'"], error=True
         )
 
     @skipIfXmlSupportMissing
@@ -1049,5 +1049,5 @@ class TestGDBServerTargetXML(GDBRemoteTestBase):
         self.match("register read x1", ["x1 = 0x1817161514131211"])
         # w1 should not be added
         self.match(
-            "register read w1", ["error: Invalid register name 'w1'."], error=True
+            "register read w1", ["error: Invalid register name 'w1'"], error=True
         )

--- a/lldb/test/API/functionalities/wrong_commands/TestWrongCommands.py
+++ b/lldb/test/API/functionalities/wrong_commands/TestWrongCommands.py
@@ -32,4 +32,4 @@ class UnknownCommandTestCase(TestBase):
 
         command_interpreter.HandleCommand("qbert", result)
         self.assertFalse(result.Succeeded())
-        self.assertEqual(result.GetError(), "error: 'qbert' is not a valid command.\n")
+        self.assertEqual(result.GetError(), "error: 'qbert' is not a valid command\n")

--- a/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
+++ b/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
@@ -162,7 +162,7 @@ class CommandInterpreterAPICase(TestBase):
                 "command": "an-unknown-command",
                 # Unresolved commands don't have "commandName"/"commandArguments"
                 "output": "",
-                "error": "error: 'an-unknown-command' is not a valid command.\n",
+                "error": "error: 'an-unknown-command' is not a valid command\n",
             },
         )
 

--- a/lldb/test/Shell/Commands/list-header.test
+++ b/lldb/test/Shell/Commands/list-header.test
@@ -24,7 +24,7 @@
 # CHECK-INLINED: 6   	  *ptr = x; // should crash here
 # CHECK-INLINED: 7   	}
 
-# CHECK-NO-INLINED: error: Could not find source file "foo.h".
+# CHECK-NO-INLINED: error: Could not find source file "foo.h"
 
 #--- foo.h
 // foo.h

--- a/lldb/test/Shell/Minidump/disassemble-no-module.yaml
+++ b/lldb/test/Shell/Minidump/disassemble-no-module.yaml
@@ -7,7 +7,7 @@
 # CHECK: frame #0: 0x0000000000400430
 # CHECK-LABEL: (lldb) disassemble
 # CHECK-NEXT: error: error reading data from section .module_image
-# CHECK-NEXT: error: Failed to disassemble memory at 0x00400430.
+# CHECK-NEXT: error: Failed to disassemble memory at 0x00400430
 
 --- !minidump
 Streams:         


### PR DESCRIPTION
To fit the style guide: https://llvm.org/docs/CodingStandards.html#error-and-warning-messages

I found these with:
* Find `(\.AppendErrorWithFormat\(([\s\r\n]+)?"(?:(?:\\.|[^"\\])*))\."` and replace with `$1"` using Visual Studio Code.
* Putting a call to `validate_diagnostic` in `AppendErrorWithFormat`.
* Manual inspection.

There are a lot more test changes than last time because most tests did not check for a newline, but they did check for the full stop.

I have only run the test suite on Linux, and I expect Windows and MacOS will have failures. For that reason, this change does not include the call to `validate_diagnostic`. If I add that, I'll do it on its own for easier reverts.