### PR TITLE
[lldb][test] Remove full stop from expected error messages

### DIFF
--- a/lldb/test/API/commands/breakpoint/command/list/TestBreakpointCommandList.py
+++ b/lldb/test/API/commands/breakpoint/command/list/TestBreakpointCommandList.py
@@ -52,5 +52,5 @@ class TestCase(TestBase):
         self.expect(
             "breakpoint command list 2",
             error=True,
-            startstr="error: '2' is not a currently valid breakpoint ID.",
+            startstr="error: '2' is not a currently valid breakpoint ID",
         )

--- a/lldb/test/API/commands/command/container/TestContainerCommands.py
+++ b/lldb/test/API/commands/command/container/TestContainerCommands.py
@@ -237,7 +237,7 @@ class TestCmdContainer(TestBase):
         self.expect(
             "test-multi test-multi-sub welcome friend",
             "did remove subcommand",
-            substrs=["'test-multi-sub' does not have any subcommands."],
+            substrs=["'test-multi-sub' does not have any subcommands"],
             error=True,
         )
         # We should have the new help:
@@ -262,6 +262,6 @@ class TestCmdContainer(TestBase):
         self.expect(
             "test-multi",
             "Root command gone",
-            substrs=["'test-multi' is not a valid command."],
+            substrs=["'test-multi' is not a valid command"],
             error=True,
         )

--- a/lldb/test/API/commands/command/delete/TestCommandDelete.py
+++ b/lldb/test/API/commands/command/delete/TestCommandDelete.py
@@ -10,7 +10,7 @@ class DeleteCommandTestCase(TestBase):
             "command delete settings",
             error=True,
             substrs=[
-                "'settings' is a permanent debugger command and cannot be removed."
+                "'settings' is a permanent debugger command and cannot be removed"
             ],
         )
 

--- a/lldb/test/API/commands/command/invalid-args/TestInvalidArgsCommand.py
+++ b/lldb/test/API/commands/command/invalid-args/TestInvalidArgsCommand.py
@@ -54,7 +54,7 @@ class InvalidArgsCommandTestCase(TestBase):
             "command alias blub foo",
             error=True,
             substrs=[
-                "error: invalid command given to 'command alias'. 'foo' does not begin with a valid command.  No alias created."
+                "error: invalid command given to 'command alias'. 'foo' does not begin with a valid command.  No alias created"
             ],
         )
 
@@ -87,7 +87,5 @@ class InvalidArgsCommandTestCase(TestBase):
         self.expect(
             "command source",
             error=True,
-            substrs=[
-                "'command source' takes exactly one executable filename argument."
-            ],
+            substrs=["'command source' takes exactly one executable filename argument"],
         )

--- a/lldb/test/API/commands/expression/dont_allow_jit/TestAllowJIT.py
+++ b/lldb/test/API/commands/expression/dont_allow_jit/TestAllowJIT.py
@@ -91,7 +91,7 @@ class TestAllowJIT(TestBase):
         self.expect(
             "expr --allow-jit false --top-level -- int i;",
             error=True,
-            substrs=["Can't disable JIT compilation for top-level expressions."],
+            substrs=["Can't disable JIT compilation for top-level expressions"],
         )
 
         self.build()

--- a/lldb/test/API/commands/frame/recognizer/TestFrameRecognizer.py
+++ b/lldb/test/API/commands/frame/recognizer/TestFrameRecognizer.py
@@ -73,12 +73,12 @@ class FrameRecognizerTestCase(TestBase):
         self.expect(
             "frame recognizer delete 2",
             error=True,
-            substrs=["error: '2' is not a valid recognizer id."],
+            substrs=["error: '2' is not a valid recognizer id"],
         )
         self.expect(
             "frame recognizer delete 0",
             error=True,
-            substrs=["error: '0' is not a valid recognizer id."],
+            substrs=["error: '0' is not a valid recognizer id"],
         )
         # Recognizers should have the same state as above.
         self.expect(
@@ -448,22 +448,22 @@ class FrameRecognizerTestCase(TestBase):
         self.expect(
             "frame recognizer delete a",
             error=True,
-            substrs=["error: 'a' is not a valid recognizer id."],
+            substrs=["error: 'a' is not a valid recognizer id"],
         )
         self.expect(
             'frame recognizer delete ""',
             error=True,
-            substrs=["error: '' is not a valid recognizer id."],
+            substrs=["error: '' is not a valid recognizer id"],
         )
         self.expect(
             "frame recognizer delete -1",
             error=True,
-            substrs=["error: '-1' is not a valid recognizer id."],
+            substrs=["error: '-1' is not a valid recognizer id"],
         )
         self.expect(
             "frame recognizer delete 4294967297",
             error=True,
-            substrs=["error: '4294967297' is not a valid recognizer id."],
+            substrs=["error: '4294967297' is not a valid recognizer id"],
         )
 
     @no_debug_info_test
@@ -471,22 +471,22 @@ class FrameRecognizerTestCase(TestBase):
         self.expect(
             "frame recognizer info a",
             error=True,
-            substrs=["error: 'a' is not a valid frame index."],
+            substrs=["error: 'a' is not a valid frame index"],
         )
         self.expect(
             'frame recognizer info ""',
             error=True,
-            substrs=["error: '' is not a valid frame index."],
+            substrs=["error: '' is not a valid frame index"],
         )
         self.expect(
             "frame recognizer info -1",
             error=True,
-            substrs=["error: '-1' is not a valid frame index."],
+            substrs=["error: '-1' is not a valid frame index"],
         )
         self.expect(
             "frame recognizer info 4294967297",
             error=True,
-            substrs=["error: '4294967297' is not a valid frame index."],
+            substrs=["error: '4294967297' is not a valid frame index"],
         )
 
     @no_debug_info_test

--- a/lldb/test/API/commands/log/invalid-args/TestInvalidArgsLog.py
+++ b/lldb/test/API/commands/log/invalid-args/TestInvalidArgsLog.py
@@ -9,9 +9,7 @@ class InvalidArgsLogTestCase(TestBase):
         self.expect(
             "log enable",
             error=True,
-            substrs=[
-                "error: log enable takes a log channel and one or more log types."
-            ],
+            substrs=["error: log enable takes a log channel and one or more log types"],
         )
 
     @no_debug_info_test
@@ -20,7 +18,7 @@ class InvalidArgsLogTestCase(TestBase):
             "log disable",
             error=True,
             substrs=[
-                "error: log disable takes a log channel and one or more log types."
+                "error: log disable takes a log channel and one or more log types"
             ],
         )
 

--- a/lldb/test/API/commands/process/signal/TestProcessSignal.py
+++ b/lldb/test/API/commands/process/signal/TestProcessSignal.py
@@ -15,15 +15,15 @@ class TestCase(TestBase):
         self.expect(
             "process signal az",
             error=True,
-            startstr="error: Invalid signal argument 'az'.",
+            startstr="error: Invalid signal argument 'az'",
         )
         self.expect(
             "process signal 0x1ffffffff",
             error=True,
-            startstr="error: Invalid signal argument '0x1ffffffff'.",
+            startstr="error: Invalid signal argument '0x1ffffffff'",
         )
         self.expect(
             "process signal 0xffffffff",
             error=True,
-            startstr="error: Invalid signal argument '0xffffffff'.",
+            startstr="error: Invalid signal argument '0xffffffff'",
         )

--- a/lldb/test/API/commands/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register_command/TestRegisters.py
@@ -579,7 +579,7 @@ class RegisterCommandsTestCase(TestBase):
         self.expect(
             "register write blub 1",
             error=True,
-            substrs=["error: Register not found for 'blub'."],
+            substrs=["error: Register not found for 'blub'"],
         )
 
     def test_info_unknown_register(self):
@@ -589,7 +589,7 @@ class RegisterCommandsTestCase(TestBase):
         self.expect(
             "register info blub",
             error=True,
-            substrs=["error: No register found with name 'blub'."],
+            substrs=["error: No register found with name 'blub'"],
         )
 
     def test_info_many_registers(self):

--- a/lldb/test/API/commands/target/modules/search-paths/insert/TestTargetModulesSearchpathsInsert.py
+++ b/lldb/test/API/commands/target/modules/search-paths/insert/TestTargetModulesSearchpathsInsert.py
@@ -14,11 +14,11 @@ class TestCase(TestBase):
         self.expect(
             "target modules search-paths insert -1 a b",
             error=True,
-            startstr="error: <index> parameter is not an integer: '-1'.",
+            startstr="error: <index> parameter is not an integer: '-1'",
         )
 
         self.expect(
             "target modules search-paths insert abcdefx a b",
             error=True,
-            startstr="error: <index> parameter is not an integer: 'abcdefx'.",
+            startstr="error: <index> parameter is not an integer: 'abcdefx'",
         )

--- a/lldb/test/API/commands/target/stop-hook/delete/TestTargetStopHookDelete.py
+++ b/lldb/test/API/commands/target/stop-hook/delete/TestTargetStopHookDelete.py
@@ -10,10 +10,10 @@ class TestCase(TestBase):
         self.expect(
             "target stop-hook delete -1",
             error=True,
-            startstr='error: invalid stop hook id: "-1".',
+            startstr='error: invalid stop hook id: "-1"',
         )
         self.expect(
             "target stop-hook delete abcdfx",
             error=True,
-            startstr='error: invalid stop hook id: "abcdfx".',
+            startstr='error: invalid stop hook id: "abcdfx"',
         )

--- a/lldb/test/API/commands/target/stop-hook/disable/TestTargetStopHookDisable.py
+++ b/lldb/test/API/commands/target/stop-hook/disable/TestTargetStopHookDisable.py
@@ -10,10 +10,10 @@ class TestCase(TestBase):
         self.expect(
             "target stop-hook disable -1",
             error=True,
-            startstr='error: invalid stop hook id: "-1".',
+            startstr='error: invalid stop hook id: "-1"',
         )
         self.expect(
             "target stop-hook disable abcdfx",
             error=True,
-            startstr='error: invalid stop hook id: "abcdfx".',
+            startstr='error: invalid stop hook id: "abcdfx"',
         )

--- a/lldb/test/API/commands/target/stop-hook/enable/TestTargetStopHookEnable.py
+++ b/lldb/test/API/commands/target/stop-hook/enable/TestTargetStopHookEnable.py
@@ -10,10 +10,10 @@ class TestCase(TestBase):
         self.expect(
             "target stop-hook enable -1",
             error=True,
-            startstr='error: invalid stop hook id: "-1".',
+            startstr='error: invalid stop hook id: "-1"',
         )
         self.expect(
             "target stop-hook enable abcdfx",
             error=True,
-            startstr='error: invalid stop hook id: "abcdfx".',
+            startstr='error: invalid stop hook id: "abcdfx"',
         )

--- a/lldb/test/API/commands/thread/select/TestThreadSelect.py
+++ b/lldb/test/API/commands/thread/select/TestThreadSelect.py
@@ -36,7 +36,7 @@ class TestCase(TestBase):
         self.expect(
             "thread select 0xffffffff",
             error=True,
-            startstr="error: Invalid thread index #0xffffffff.",
+            startstr="error: Invalid thread index #0xffffffff",
         )
         self.expect(
             "thread select -t 0xffffffff",

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
@@ -383,7 +383,7 @@ class BreakpointCommandTestCase(TestBase):
         self.expect(
             "breakpoint command list 2",
             error=True,
-            startstr="error: '2' is not a currently valid breakpoint ID.",
+            startstr="error: '2' is not a currently valid breakpoint ID",
         )
 
         # The breakpoint list now only contains breakpoint 1.

--- a/lldb/test/API/functionalities/gdb_remote_client/TestGDBServerTargetXML.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGDBServerTargetXML.py
@@ -881,7 +881,7 @@ class TestGDBServerTargetXML(GDBRemoteTestBase):
         self.match("register read rdx", ["rdx = 0x1817161514131211"])
         # edx should not be added
         self.match(
-            "register read edx", ["error: Invalid register name 'edx'."], error=True
+            "register read edx", ["error: Invalid register name 'edx'"], error=True
         )
 
     @skipIfXmlSupportMissing
@@ -954,7 +954,7 @@ class TestGDBServerTargetXML(GDBRemoteTestBase):
         self.match("register read ecx", ["ecx = 0x14131211"])
         # dx should not be added
         self.match(
-            "register read cx", ["error: Invalid register name 'cx'."], error=True
+            "register read cx", ["error: Invalid register name 'cx'"], error=True
         )
 
     @skipIfXmlSupportMissing
@@ -1049,5 +1049,5 @@ class TestGDBServerTargetXML(GDBRemoteTestBase):
         self.match("register read x1", ["x1 = 0x1817161514131211"])
         # w1 should not be added
         self.match(
-            "register read w1", ["error: Invalid register name 'w1'."], error=True
+            "register read w1", ["error: Invalid register name 'w1'"], error=True
         )

--- a/lldb/test/Shell/Commands/list-header.test
+++ b/lldb/test/Shell/Commands/list-header.test
@@ -24,7 +24,7 @@
 # CHECK-INLINED: 6   	  *ptr = x; // should crash here
 # CHECK-INLINED: 7   	}
 
-# CHECK-NO-INLINED: error: Could not find source file "foo.h".
+# CHECK-NO-INLINED: error: Could not find source file "foo.h"
 
 #--- foo.h
 // foo.h

--- a/lldb/test/Shell/Minidump/disassemble-no-module.yaml
+++ b/lldb/test/Shell/Minidump/disassemble-no-module.yaml
@@ -7,7 +7,7 @@
 # CHECK: frame #0: 0x0000000000400430
 # CHECK-LABEL: (lldb) disassemble
 # CHECK-NEXT: error: error reading data from section .module_image
-# CHECK-NEXT: error: Failed to disassemble memory at 0x00400430.
+# CHECK-NEXT: error: Failed to disassemble memory at 0x00400430
 
 --- !minidump
 Streams:         


### PR DESCRIPTION
I am about to update a bunch of uses of AppendErrorWithFormat to not have a full stop at the end, to confirm to
https://llvm.org/docs/CodingStandards.html#error-and-warning-messages.

Reviewing all those changes is going to be difficult so I am updating the tests first and then we can land the other changes in batches (because the tests will continue to pass as we do that).

Note that I have only run the test suite on Linux AArch64, so there are probably more that need to be updated. We will catch those in CI or post-commit.