### PR TITLE
[libc][NFC] Fix typo in GPU test warning message

### DIFF
--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -49,7 +49,7 @@ add_subdirectory(UnitTest)
 
 if(LIBC_TARGET_OS_IS_GPU)
   if(NOT CMAKE_CROSSCOMPILING_EMULATOR)
-    message(WARNING "Cannot build libc GPU tests, set CMAKE_CROSS_COMPILING_EMULATOR.")
+    message(WARNING "Cannot build libc GPU tests, set CMAKE_CROSSCOMPILING_EMULATOR.")
     return()
   elseif(LIBC_GPU_TESTS_DISABLED)
     message(WARNING "Cannot build libc GPU tests, missing target architecture.")


### PR DESCRIPTION
The warning referred to CMAKE_CROSS_COMPILING_EMULATOR (with an extra underscore) instead of CMAKE_CROSSCOMPILING_EMULATOR.