### PR TITLE
Add LIT_UNSUPPORTED support to lit testing

### DIFF
--- a/llvm/docs/CommandGuide/lit.rst
+++ b/llvm/docs/CommandGuide/lit.rst
@@ -366,6 +366,27 @@ The timing data is stored in the `test_exec_root` in a file named
   primary purpose is to suppress an ``XPASS`` result without modifying a test
   case that uses the ``XFAIL`` directive.
 
+.. option:: --unsupported LIST
+
+  Treat those tests whose name is in the semicolon separated list ``LIST`` as
+  ``UNSUPPORTED``. This can be helpful when one does not want to modify the test
+  suite. The environment variable ``LIT_UNSUPPORTED`` can be also used in place
+  of this option, which is especially useful in environments where the call to
+  ``lit`` is issued indirectly.
+
+  The syntax for specifying test names is the same as for :option:`--xfail` and
+  ``LIT_XFAIL``. A test name can be specified as a file name relative to the
+  test suite directory or as the full test name reported in LIT output.
+
+.. option:: --unsupported-not LIST
+
+  Do not treat the specified tests as ``UNSUPPORTED``.  The environment variable
+  ``LIT_UNSUPPORTED_NOT`` can also be used in place of this option.  The syntax
+  is the same as for :option:`--unsupported` and ``LIT_UNSUPPORTED``.
+  :option:`--unsupported-not` and ``LIT_UNSUPPORTED_NOT`` always override all
+  other ``UNSUPPORTED`` specifications, including an :option:`--unsupported`
+  appearing later on the command line.
+
 .. option:: --exclude-xfail
 
   ``XFAIL`` tests won't be run, unless they are listed in the ``--xfail-not``

--- a/llvm/utils/lit/lit/Test.py
+++ b/llvm/utils/lit/lit/Test.py
@@ -262,6 +262,9 @@ class Test:
         # If true, ignore all items in self.xfails.
         self.xfail_not = False
 
+        # If true, ignore all items in self.unsupported.
+        self.unsupported_not = False
+
         # A list of conditions that must be satisfied before running the test.
         # Each condition is a boolean expression of features. All of them
         # must be True for the test to run.
@@ -422,6 +425,9 @@ class Test:
         in the test configuration's features.
         Throws ValueError if an UNSUPPORTED line has a syntax error.
         """
+
+        if self.unsupported_not:
+            return []
 
         features = self.config.available_features
 

--- a/llvm/utils/lit/lit/cl_arguments.py
+++ b/llvm/utils/lit/lit/cl_arguments.py
@@ -465,6 +465,20 @@ def parse_args():
         action="store_true",
     )
     selection_group.add_argument(
+        "--unsupported",
+        metavar="LIST",
+        type=_semicolon_list,
+        help="UNSUPPORTED tests with paths in the semicolon separated list",
+        default=os.environ.get("LIT_UNSUPPORTED", ""),
+    )
+    selection_group.add_argument(
+        "--unsupported-not",
+        metavar="LIST",
+        type=_semicolon_list,
+        help="do not UNSUPPORTED tests with paths in the semicolon separated list",
+        default=os.environ.get("LIT_UNSUPPORTED_NOT", ""),
+    )
+    selection_group.add_argument(
         "--num-shards",
         dest="numShards",
         metavar="M",

--- a/llvm/utils/lit/lit/cl_arguments.py
+++ b/llvm/utils/lit/lit/cl_arguments.py
@@ -468,14 +468,14 @@ def parse_args():
         "--unsupported",
         metavar="LIST",
         type=_semicolon_list,
-        help="UNSUPPORTED tests with paths in the semicolon separated list",
+        help="Mark tests with paths in the semicolon separated list as UNSUPPORTED",
         default=os.environ.get("LIT_UNSUPPORTED", ""),
     )
     selection_group.add_argument(
         "--unsupported-not",
         metavar="LIST",
         type=_semicolon_list,
-        help="do not UNSUPPORTED tests with paths in the semicolon separated list",
+        help="Do not mark tests with paths in the semicolon separated list as UNSUPPORTED",
         default=os.environ.get("LIT_UNSUPPORTED_NOT", ""),
     )
     selection_group.add_argument(

--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -254,7 +254,7 @@ def mark_unsupported(selected_tests, opts):
         test_file = os.sep.join(t.path_in_suite)
         test_full_name = t.getFullName()
         if test_file in opts.unsupported or test_full_name in opts.unsupported:
-            # Add a special feature that's always present to mark as unsupported
+            # Add a special feature that's always present to mark as unsupported.
             t.config.available_features.add("lit-unsupported-marker")
             t.unsupported.append("lit-unsupported-marker")
         if test_file in opts.unsupported_not or test_full_name in opts.unsupported_not:

--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -122,6 +122,7 @@ def main(builtin_params={}):
     selected_tests = selected_tests[: opts.max_tests]
 
     mark_xfail(discovered_tests, opts)
+    mark_unsupported(discovered_tests, opts)
 
     mark_excluded(discovered_tests, selected_tests)
 
@@ -246,6 +247,18 @@ def mark_xfail(selected_tests, opts):
             t.xfail_not = True
         if opts.exclude_xfail:
             t.exclude_xfail = True
+
+
+def mark_unsupported(selected_tests, opts):
+    for t in selected_tests:
+        test_file = os.sep.join(t.path_in_suite)
+        test_full_name = t.getFullName()
+        if test_file in opts.unsupported or test_full_name in opts.unsupported:
+            # Add a special feature that's always present to mark as unsupported
+            t.config.available_features.add("lit-unsupported-marker")
+            t.unsupported.append("lit-unsupported-marker")
+        if test_file in opts.unsupported_not or test_full_name in opts.unsupported_not:
+            t.unsupported_not = True
 
 
 def mark_excluded(discovered_tests, selected_tests):

--- a/llvm/utils/lit/tests/unsupported-cl.py
+++ b/llvm/utils/lit/tests/unsupported-cl.py
@@ -1,39 +1,27 @@
 # Check that marking tests as UNSUPPORTED works via command line or env var.
 
-# RUN: %{lit} --unsupported 'false.txt;false2.txt;top-level-suite :: b :: test.txt' \
-# RUN:   --unsupported-not 'true-xfail.txt;top-level-suite :: a :: test-xfail.txt' \
-# RUN:   %{inputs}/xfail-cl \
-# RUN: | FileCheck --check-prefix=CHECK-FILTER %s
+# RUN: %{lit} --unsupported 'true.txt' \
+# RUN:   %{inputs}/xfail-cl/true.txt \
+# RUN: | FileCheck --check-prefix=CHECK-UNSUPPORTED %s
 
-# RUN: env LIT_UNSUPPORTED='false.txt;false2.txt;top-level-suite :: b :: test.txt' \
-# RUN:   LIT_UNSUPPORTED_NOT='true-xfail.txt;top-level-suite :: a :: test-xfail.txt' \
-# RUN: %{lit} %{inputs}/xfail-cl \
-# RUN: | FileCheck --check-prefix=CHECK-FILTER %s
+# RUN: env LIT_UNSUPPORTED='true.txt' \
+# RUN: %{lit} %{inputs}/xfail-cl/true.txt \
+# RUN: | FileCheck --check-prefix=CHECK-UNSUPPORTED %s
 
-# Check that --unsupported-not and LIT_UNSUPPORTED_NOT always have precedence.
+# Check that --unsupported-not and LIT_UNSUPPORTED_NOT override --unsupported.
 
-# RUN: env LIT_UNSUPPORTED=true-xfail.txt \
-# RUN: %{lit} --unsupported true-xfail.txt --unsupported-not true-xfail.txt \
-# RUN:   --unsupported true-xfail.txt %{inputs}/xfail-cl/true-xfail.txt \
-# RUN: | FileCheck --check-prefix=CHECK-OVERRIDE %s
+# RUN: %{lit} --unsupported 'true.txt' --unsupported-not 'true.txt' \
+# RUN:   %{inputs}/xfail-cl/true.txt \
+# RUN: | FileCheck --check-prefix=CHECK-NOT-UNSUPPORTED %s
 
-# RUN: env LIT_UNSUPPORTED_NOT=true-xfail.txt LIT_UNSUPPORTED=true-xfail.txt \
-# RUN: %{lit} --unsupported true-xfail.txt %{inputs}/xfail-cl/true-xfail.txt \
-# RUN: | FileCheck --check-prefix=CHECK-OVERRIDE %s
+# RUN: env LIT_UNSUPPORTED='true.txt' LIT_UNSUPPORTED_NOT='true.txt' \
+# RUN: %{lit} %{inputs}/xfail-cl/true.txt \
+# RUN: | FileCheck --check-prefix=CHECK-NOT-UNSUPPORTED %s
 
 # END.
 
-# CHECK-FILTER: Testing: 11 tests, {{[0-9]*}} workers
-# CHECK-FILTER-DAG: {{^}}PASS: top-level-suite :: a :: test.txt
-# CHECK-FILTER-DAG: {{^}}UNSUPPORTED: top-level-suite :: b :: test.txt
-# CHECK-FILTER-DAG: {{^}}UNSUPPORTED: top-level-suite :: a :: false.txt
-# CHECK-FILTER-DAG: {{^}}UNSUPPORTED: top-level-suite :: b :: false.txt
-# CHECK-FILTER-DAG: {{^}}UNSUPPORTED: top-level-suite :: false.txt
-# CHECK-FILTER-DAG: {{^}}UNSUPPORTED: top-level-suite :: false2.txt
-# CHECK-FILTER-DAG: {{^}}PASS: top-level-suite :: true.txt
-# CHECK-FILTER-DAG: {{^}}PASS: top-level-suite :: true-xfail.txt
-# CHECK-FILTER-DAG: {{^}}PASS: top-level-suite :: a :: test-xfail.txt
-# CHECK-FILTER-DAG: {{^}}UNSUPPORTED: top-level-suite :: b :: test-xfail.txt
+# CHECK-UNSUPPORTED: Testing: 1 tests, {{[0-9]*}} workers
+# CHECK-UNSUPPORTED: {{^}}UNSUPPORTED: top-level-suite :: true.txt
 
-# CHECK-OVERRIDE: Testing: 1 tests, {{[0-9]*}} workers
-# CHECK-OVERRIDE: {{^}}PASS: top-level-suite :: true-xfail.txt
+# CHECK-NOT-UNSUPPORTED: Testing: 1 tests, {{[0-9]*}} workers
+# CHECK-NOT-UNSUPPORTED: {{^}}PASS: top-level-suite :: true.txt

--- a/llvm/utils/lit/tests/unsupported-cl.py
+++ b/llvm/utils/lit/tests/unsupported-cl.py
@@ -1,0 +1,39 @@
+# Check that marking tests as UNSUPPORTED works via command line or env var.
+
+# RUN: %{lit} --unsupported 'false.txt;false2.txt;top-level-suite :: b :: test.txt' \
+# RUN:   --unsupported-not 'true-xfail.txt;top-level-suite :: a :: test-xfail.txt' \
+# RUN:   %{inputs}/xfail-cl \
+# RUN: | FileCheck --check-prefix=CHECK-FILTER %s
+
+# RUN: env LIT_UNSUPPORTED='false.txt;false2.txt;top-level-suite :: b :: test.txt' \
+# RUN:   LIT_UNSUPPORTED_NOT='true-xfail.txt;top-level-suite :: a :: test-xfail.txt' \
+# RUN: %{lit} %{inputs}/xfail-cl \
+# RUN: | FileCheck --check-prefix=CHECK-FILTER %s
+
+# Check that --unsupported-not and LIT_UNSUPPORTED_NOT always have precedence.
+
+# RUN: env LIT_UNSUPPORTED=true-xfail.txt \
+# RUN: %{lit} --unsupported true-xfail.txt --unsupported-not true-xfail.txt \
+# RUN:   --unsupported true-xfail.txt %{inputs}/xfail-cl/true-xfail.txt \
+# RUN: | FileCheck --check-prefix=CHECK-OVERRIDE %s
+
+# RUN: env LIT_UNSUPPORTED_NOT=true-xfail.txt LIT_UNSUPPORTED=true-xfail.txt \
+# RUN: %{lit} --unsupported true-xfail.txt %{inputs}/xfail-cl/true-xfail.txt \
+# RUN: | FileCheck --check-prefix=CHECK-OVERRIDE %s
+
+# END.
+
+# CHECK-FILTER: Testing: 11 tests, {{[0-9]*}} workers
+# CHECK-FILTER-DAG: {{^}}PASS: top-level-suite :: a :: test.txt
+# CHECK-FILTER-DAG: {{^}}UNSUPPORTED: top-level-suite :: b :: test.txt
+# CHECK-FILTER-DAG: {{^}}UNSUPPORTED: top-level-suite :: a :: false.txt
+# CHECK-FILTER-DAG: {{^}}UNSUPPORTED: top-level-suite :: b :: false.txt
+# CHECK-FILTER-DAG: {{^}}UNSUPPORTED: top-level-suite :: false.txt
+# CHECK-FILTER-DAG: {{^}}UNSUPPORTED: top-level-suite :: false2.txt
+# CHECK-FILTER-DAG: {{^}}PASS: top-level-suite :: true.txt
+# CHECK-FILTER-DAG: {{^}}PASS: top-level-suite :: true-xfail.txt
+# CHECK-FILTER-DAG: {{^}}PASS: top-level-suite :: a :: test-xfail.txt
+# CHECK-FILTER-DAG: {{^}}UNSUPPORTED: top-level-suite :: b :: test-xfail.txt
+
+# CHECK-OVERRIDE: Testing: 1 tests, {{[0-9]*}} workers
+# CHECK-OVERRIDE: {{^}}PASS: top-level-suite :: true-xfail.txt


### PR DESCRIPTION
Add LIT_UNSUPPORTED support to lit, mirroring the existing LIT_XFAIL
implementation. This allows tests to be marked as UNSUPPORTED via
command line arguments (--unsupported, --unsupported-not) or environment
variables (LIT_UNSUPPORTED, LIT_UNSUPPORTED_NOT).

This feature enables users to dynamically mark tests as unsupported
without modifying test files, useful for CI/CD pipelines and
platform-specific test filtering.

Assisted by AI.