### PR TITLE
[libc] Honor per-test timeout in lit test format

### DIFF
--- a/libc/utils/libctest/format.py
+++ b/libc/utils/libctest/format.py
@@ -129,6 +129,9 @@ class LibcTest(lit.formats.ExecutableTest):
 
         If a sidecar <executable>.params file exists, it supplies the
         command-line arguments and environment variables for the test.
+
+        Honors litConfig.maxIndividualTestTime (set via --timeout) to
+        kill tests that exceed the per-test time limit.
         """
 
         test_path = test.getSourcePath()
@@ -166,6 +169,8 @@ class LibcTest(lit.formats.ExecutableTest):
         env["PWD"] = exec_dir
         env.update(extra_env)
 
+        timeout = litConfig.maxIndividualTestTime
+
         test_cmd_template = getattr(test.config, "libc_test_cmd", "")
         if test_cmd_template:
             if "@BINARY@" in test_cmd_template:
@@ -188,13 +193,17 @@ class LibcTest(lit.formats.ExecutableTest):
                 )
             if not cmd_args:
                 cmd_args = [test_path]
-
-            out, err, exit_code = lit.util.executeCommand(
-                cmd_args, cwd=exec_dir, env=env
-            )
         else:
+            cmd_args = [test_path] + test_args
+
+        try:
             out, err, exit_code = lit.util.executeCommand(
-                [test_path] + test_args, cwd=exec_dir, env=env
+                cmd_args, cwd=exec_dir, env=env, timeout=timeout
+            )
+        except lit.util.ExecuteCommandTimeoutException as e:
+            return (
+                lit.Test.TIMEOUT,
+                f"{e.out}\n--\n" f"Reached timeout of {timeout} seconds",
             )
 
         if not exit_code:


### PR DESCRIPTION
The custom LibcTest format did not pass litConfig.maxIndividualTestTime to executeCommand. This caused --timeout to be silently ignored, so hanging tests like fdiv_test on AMDGPU blocked the entire suite until the buildbot watchdog killed the process after 1200s.

Added timeout propagation and handling of ExecuteCommandTimeoutException to return lit.Test.TIMEOUT. This follows the same pattern used by the GoogleTest format in googletest.py.