### PR TITLE
[SPIRV] Do not add aliasing decorations to OpAtomicStore/OpAtomicLoad

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -2571,25 +2571,12 @@ bool SPIRVEmitIntrinsics::shouldTryToAddMemAliasingDecoration(
   const SPIRVSubtarget *STI = TM.getSubtargetImpl(*Inst->getFunction());
   if (!STI->canUseExtension(SPIRV::Extension::SPV_INTEL_memory_access_aliasing))
     return false;
-  // Add aliasing decorations to internal load and store intrinsics
-  // and atomic instructions, skipping atomic store as it won't have ID to
-  // attach the decoration.
-  if (match(Inst, m_AnyIntrinsic<Intrinsic::spv_load, Intrinsic::spv_store>()))
-    return true;
-  auto *CI = dyn_cast<CallInst>(Inst);
-  if (!CI)
-    return false;
-  if (Function *Fun = CI->getCalledFunction()) {
-    if (Fun->isIntrinsic())
-      return false;
-    std::string Name = getOclOrSpirvBuiltinDemangledName(Fun->getName());
-    const std::string Prefix = "__spirv_Atomic";
-    const bool IsAtomic = Name.find(Prefix) == 0;
-
-    if (!Fun->getReturnType()->isVoidTy() && IsAtomic)
-      return true;
-  }
-  return false;
+  // Add aliasing decorations to internal load and store intrinsics.
+  // Do not attach them to store atomic or load atomic intrinsics / instructions
+  // since the extension is inconsistent at the moment (we cannot add the
+  // decoration to atomic stores because they do not have an id).
+  return match(Inst,
+               m_AnyIntrinsic<Intrinsic::spv_load, Intrinsic::spv_store>());
 }
 
 void SPIRVEmitIntrinsics::insertSpirvDecorations(Instruction *I,

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_memory_access_aliasing/alias-load-store-atomic.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_memory_access_aliasing/alias-load-store-atomic.ll
@@ -1,16 +1,11 @@
-; Check aliasing information translation on atomic load and store.
-; For stores, the decoration is not generated since the store opcodes do not have an id.
-; For `load atomic`, the decoration is not generated because we're dropping the extension on atomics.
+; Do not attach aliasing decorations to load/store atomics since the extension is inconsistent.
+; We cannot attach decorations to stores since they have no id (while we can for loads).
 
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown -verify-machineinstrs --spirv-ext=+SPV_INTEL_memory_access_aliasing %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_memory_access_aliasing %s -o - -filetype=obj | spirv-val %}
 
-; CHECK: OpCapability MemoryAccessAliasingINTEL
-; CHECK: OpExtension "SPV_INTEL_memory_access_aliasing"
-; CHECK: %[[#Domain1:]] = OpAliasDomainDeclINTEL
-; CHECK: %[[#Scope1:]] = OpAliasScopeDeclINTEL %[[#Domain1]]
-; CHECK: %[[#List1:]] = OpAliasScopeListDeclINTEL %[[#Scope1]]
-; CHECK: OpDecorateId %[[#LoadFun:]] NoAliasINTEL %[[#List1]]
+; CHECK-NOT: OpCapability MemoryAccessAliasingINTEL
+; CHECK-NOT: OpExtension "SPV_INTEL_memory_access_aliasing"
 ; CHECK-NOT: OpDecorateId
 ; CHECK: %[[#LoadFun:]] = OpAtomicLoad
 ; CHECK: OpAtomicStore


### PR DESCRIPTION
Do not attach them to store atomic or load atomic intrinsics / instructions since the extension is inconsistent at the moment (we cannot add the decoration to atomic stores because they do not have an id).