### PR TITLE
[clang][DebugInfo] Cache repeated debug info lookups

### DIFF
--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -812,7 +812,6 @@ FileID SourceManager::getFileIDLocal(SourceLocation::UIntTy SLocOffset) const {
   assert(SLocOffset >= LocalSLocEntryTable[0].getOffset() && SLocOffset > 0 &&
          "Invalid SLocOffset");
   assert(LocalSLocEntryTable.size() == LocalLocOffsetTable.size());
-  assert(LastFileIDLookup.ID >= 0 && "Only cache local file sloc entry");
 
   // After the first and second level caches, I see two common sorts of
   // behavior: 1) a lot of searched FileID's are "near" the cached file
@@ -833,10 +832,12 @@ FileID SourceManager::getFileIDLocal(SourceLocation::UIntTy SLocOffset) const {
   // upper bound of the search range.
   unsigned GreaterIndex = LocalLocOffsetTable.size();
   // Use the LastFileIDLookup to prune the search space.
-  if (LastLookupStartOffset < SLocOffset)
-    LessIndex = LastFileIDLookup.ID;
-  else
-    GreaterIndex = LastFileIDLookup.ID;
+  if (LastFileIDLookup.ID >= 0) {
+    if (LastLookupStartOffset < SLocOffset)
+      LessIndex = LastFileIDLookup.ID;
+    else
+      GreaterIndex = LastFileIDLookup.ID;
+  }
 
   // Find the FileID that contains this.
   unsigned NumProbes = 0;
@@ -887,7 +888,13 @@ FileID SourceManager::getFileIDLoaded(SourceLocation::UIntTy SLocOffset) const {
     return FileID();
   }
 
-  return FileID::get(ExternalSLocEntries->getSLocEntryID(SLocOffset));
+  FileID FID = FileID::get(ExternalSLocEntries->getSLocEntryID(SLocOffset));
+  LastFileIDLookup = FID;
+  LastLookupStartOffset = getSLocEntry(FID).getOffset();
+  FileID NextFID = getNextFileID(FID);
+  LastLookupEndOffset =
+      NextFID.isValid() ? getSLocEntry(NextFID).getOffset() : MaxLoadedOffset;
+  return FID;
 }
 
 SourceLocation SourceManager::

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -471,9 +471,12 @@ StringRef CGDebugInfo::getSelectorName(Selector S) {
 
 StringRef CGDebugInfo::getClassName(const RecordDecl *RD,
                                     bool *NameIsSimplified) {
-  // quick optimization to avoid having to intern strings that are already
-  // stored reliably elsewhere
-  if (const IdentifierInfo *II = RD->getIdentifier())
+  const bool IsTemplateSpecialization =
+      isa<ClassTemplateSpecializationDecl>(RD);
+  if (const IdentifierInfo *II;
+      !IsTemplateSpecialization && (II = RD->getIdentifier()))
+    // Quick optimization to avoid having to intern strings that are already
+    // stored reliably elsewhere.
     return II->getName();
 
   const auto *CanonicalRD = cast<RecordDecl>(RD->getCanonicalDecl());
@@ -485,7 +488,7 @@ StringRef CGDebugInfo::getClassName(const RecordDecl *RD,
 
   StringRef Name;
   bool Simplified = false;
-  if (isa<ClassTemplateSpecializationDecl>(RD)) {
+  if (IsTemplateSpecialization) {
     // Copy this name on the side and use its reference.
     Name = internString(GetName(RD, false, &Simplified));
   } else if (CGM.getCodeGenOpts().EmitCodeView) {

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -471,10 +471,10 @@ StringRef CGDebugInfo::getSelectorName(Selector S) {
 
 StringRef CGDebugInfo::getClassName(const RecordDecl *RD,
                                     bool *NameIsSimplified) {
-  const bool IsTemplateSpecialization =
-      isa<ClassTemplateSpecializationDecl>(RD);
-  if (const IdentifierInfo *II;
-      !IsTemplateSpecialization && (II = RD->getIdentifier()))
+  const Decl::Kind DeclKind = RD->getKind();
+  if (const IdentifierInfo *II = RD->getIdentifier();
+      DeclKind != Decl::ClassTemplateSpecialization &&
+      DeclKind != Decl::ClassTemplatePartialSpecialization && II)
     // Quick optimization to avoid having to intern strings that are already
     // stored reliably elsewhere.
     return II->getName();
@@ -488,7 +488,8 @@ StringRef CGDebugInfo::getClassName(const RecordDecl *RD,
 
   StringRef Name;
   bool Simplified = false;
-  if (IsTemplateSpecialization) {
+  if (DeclKind == Decl::ClassTemplateSpecialization ||
+      DeclKind == Decl::ClassTemplatePartialSpecialization) {
     // Copy this name on the side and use its reference.
     Name = internString(GetName(RD, false, &Simplified));
   } else if (CGM.getCodeGenOpts().EmitCodeView) {

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -471,58 +471,71 @@ StringRef CGDebugInfo::getSelectorName(Selector S) {
 
 StringRef CGDebugInfo::getClassName(const RecordDecl *RD,
                                     bool *NameIsSimplified) {
-  if (isa<ClassTemplateSpecializationDecl>(RD)) {
-    // Copy this name on the side and use its reference.
-    return internString(GetName(RD, false, NameIsSimplified));
-  }
-
   // quick optimization to avoid having to intern strings that are already
   // stored reliably elsewhere
   if (const IdentifierInfo *II = RD->getIdentifier())
     return II->getName();
 
-  // The CodeView printer in LLVM wants to see the names of unnamed types
-  // because they need to have a unique identifier.
-  // These names are used to reconstruct the fully qualified type names.
-  if (CGM.getCodeGenOpts().EmitCodeView) {
+  const auto *CanonicalRD = cast<RecordDecl>(RD->getCanonicalDecl());
+  if (auto It = ClassNameCache.find(CanonicalRD); It != ClassNameCache.end()) {
+    if (NameIsSimplified)
+      *NameIsSimplified = It->second.NameIsSimplified;
+    return It->second.Name;
+  }
+
+  StringRef Name;
+  bool Simplified = false;
+  if (isa<ClassTemplateSpecializationDecl>(RD)) {
+    // Copy this name on the side and use its reference.
+    Name = internString(GetName(RD, false, &Simplified));
+  } else if (CGM.getCodeGenOpts().EmitCodeView) {
+    // The CodeView printer in LLVM wants to see the names of unnamed types
+    // because they need to have a unique identifier.
+    // These names are used to reconstruct the fully qualified type names.
     if (const TypedefNameDecl *D = RD->getTypedefNameForAnonDecl()) {
       assert(RD->getDeclContext() == D->getDeclContext() &&
              "Typedef should not be in another decl context!");
       assert(D->getDeclName().getAsIdentifierInfo() &&
              "Typedef was not named!");
-      return D->getDeclName().getAsIdentifierInfo()->getName();
-    }
-
-    if (CGM.getLangOpts().CPlusPlus) {
-      StringRef Name;
+      Name = D->getDeclName().getAsIdentifierInfo()->getName();
+    } else if (CGM.getLangOpts().CPlusPlus) {
+      StringRef UnnamedName;
 
       ASTContext &Context = CGM.getContext();
       if (const DeclaratorDecl *DD = Context.getDeclaratorForUnnamedTagDecl(RD))
         // Anonymous types without a name for linkage purposes have their
         // declarator mangled in if they have one.
-        Name = DD->getName();
+        UnnamedName = DD->getName();
       else if (const TypedefNameDecl *TND =
                    Context.getTypedefNameForUnnamedTagDecl(RD))
         // Anonymous types without a name for linkage purposes have their
         // associate typedef mangled in if they have one.
-        Name = TND->getName();
+        UnnamedName = TND->getName();
 
       // Give lambdas a display name based on their name mangling.
-      if (const CXXRecordDecl *CXXRD = dyn_cast<CXXRecordDecl>(RD))
-        if (CXXRD->isLambda())
-          return internString(
+      if (const CXXRecordDecl *CXXRD = dyn_cast<CXXRecordDecl>(RD)) {
+        if (CXXRD->isLambda()) {
+          Name = internString(
               CGM.getCXXABI().getMangleContext().getLambdaString(CXXRD));
-
-      if (!Name.empty()) {
+        } else if (!UnnamedName.empty()) {
+          SmallString<256> UnnamedType("<unnamed-type-");
+          UnnamedType += UnnamedName;
+          UnnamedType += '>';
+          Name = internString(UnnamedType);
+        }
+      } else if (!UnnamedName.empty()) {
         SmallString<256> UnnamedType("<unnamed-type-");
-        UnnamedType += Name;
+        UnnamedType += UnnamedName;
         UnnamedType += '>';
-        return internString(UnnamedType);
+        Name = internString(UnnamedType);
       }
     }
   }
 
-  return StringRef();
+  ClassNameCache[CanonicalRD] = {Name, Simplified};
+  if (NameIsSimplified)
+    *NameIsSimplified = Simplified;
+  return Name;
 }
 
 std::optional<llvm::DIFile::ChecksumKind>
@@ -661,11 +674,30 @@ std::string CGDebugInfo::remapDIPath(StringRef Path) const {
   return P.str().str();
 }
 
+void CGDebugInfo::cacheLineAndColumn(SourceLocation Loc) const {
+  if (Loc == CachedLineColLoc)
+    return;
+
+  CachedLineColLoc = Loc;
+  CachedLine = 0;
+  CachedColumn = 0;
+  if (Loc.isInvalid())
+    return;
+
+  SourceManager &SM = CGM.getContext().getSourceManager();
+  PresumedLoc PLoc = SM.getPresumedLoc(Loc);
+  if (!PLoc.isValid())
+    return;
+
+  CachedLine = PLoc.getLine();
+  CachedColumn = PLoc.getColumn();
+}
+
 unsigned CGDebugInfo::getLineNumber(SourceLocation Loc) {
   if (Loc.isInvalid())
     return 0;
-  SourceManager &SM = CGM.getContext().getSourceManager();
-  return SM.getPresumedLoc(getMacroDebugLoc(CGM, Loc)).getLine();
+  cacheLineAndColumn(getMacroDebugLoc(CGM, Loc));
+  return CachedLine;
 }
 
 unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
@@ -676,10 +708,8 @@ unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
   // If the location is invalid then use the current column.
   if (Loc.isInvalid() && CurLoc.isInvalid())
     return 0;
-  SourceManager &SM = CGM.getContext().getSourceManager();
-  PresumedLoc PLoc =
-      SM.getPresumedLoc(Loc.isValid() ? getMacroDebugLoc(CGM, Loc) : CurLoc);
-  return PLoc.isValid() ? PLoc.getColumn() : 0;
+  cacheLineAndColumn(Loc.isValid() ? getMacroDebugLoc(CGM, Loc) : CurLoc);
+  return CachedColumn;
 }
 
 StringRef CGDebugInfo::getCurrentDirname() {
@@ -1413,23 +1443,29 @@ static bool needsTypeIdentifier(const TagDecl *TD, CodeGenModule &CGM,
 }
 
 // Returns a unique type identifier string if one exists, or an empty string.
-static SmallString<256> getTypeIdentifier(const TagType *Ty, CodeGenModule &CGM,
-                                          llvm::DICompileUnit *TheCU) {
-  SmallString<256> Identifier;
+StringRef CGDebugInfo::getTypeIdentifier(const TagType *Ty) {
   const TagDecl *TD = Ty->getDecl()->getDefinitionOrSelf();
+  const auto *CanonicalTD = cast<TagDecl>(TD->getCanonicalDecl());
+  if (auto It = TypeIdentifierCache.find(CanonicalTD);
+      It != TypeIdentifierCache.end())
+    return It->second;
 
+  StringRef Identifier;
   if (!needsTypeIdentifier(TD, CGM, TheCU))
-    return Identifier;
+    return TypeIdentifierCache[CanonicalTD] = Identifier;
   if (const auto *RD = dyn_cast<CXXRecordDecl>(TD))
     if (RD->getDefinition())
       if (RD->isDynamicClass() &&
           CGM.getVTableLinkage(RD) == llvm::GlobalValue::ExternalLinkage)
-        return Identifier;
+        return TypeIdentifierCache[CanonicalTD] = Identifier;
 
   // TODO: This is using the RTTI name. Is there a better way to get
   // a unique string for a type?
-  llvm::raw_svector_ostream Out(Identifier);
+  SmallString<256> IdentifierStorage;
+  llvm::raw_svector_ostream Out(IdentifierStorage);
   CGM.getCXXABI().getMangleContext().mangleCXXRTTIName(QualType(Ty, 0), Out);
+  Identifier = internString(IdentifierStorage);
+  TypeIdentifierCache[CanonicalTD] = Identifier;
   return Identifier;
 }
 
@@ -1478,10 +1514,10 @@ CGDebugInfo::getOrCreateRecordFwdDecl(const RecordType *Ty,
       Flags |= llvm::DINode::FlagNonTrivial;
 
   // Create the type.
-  SmallString<256> Identifier;
+  StringRef Identifier;
   // Don't include a linkage name in line tables only.
   if (CGM.getCodeGenOpts().hasReducedDebugInfo())
-    Identifier = getTypeIdentifier(Ty, CGM, TheCU);
+    Identifier = getTypeIdentifier(Ty);
   llvm::DICompositeType *RetTy = DBuilder.createReplaceableCompositeType(
       getTagForRecord(RD), RDName, Ctx, DefUnit, Line, 0, Size, Align, Flags,
       Identifier);
@@ -3936,8 +3972,7 @@ llvm::DIType *CGDebugInfo::CreateType(const HLSLInlineSpirvType *Ty,
   return nullptr;
 }
 
-static auto getEnumInfo(CodeGenModule &CGM, llvm::DICompileUnit *TheCU,
-                        const EnumType *Ty) {
+static auto getEnumInfo(CodeGenModule &CGM, const EnumType *Ty) {
   const EnumDecl *ED = Ty->getDecl()->getDefinitionOrSelf();
 
   uint64_t Size = 0;
@@ -3946,11 +3981,12 @@ static auto getEnumInfo(CodeGenModule &CGM, llvm::DICompileUnit *TheCU,
     Size = CGM.getContext().getTypeSize(QualType(Ty, 0));
     Align = getDeclAlignIfRequired(ED, CGM.getContext());
   }
-  return std::make_tuple(ED, Size, Align, getTypeIdentifier(Ty, CGM, TheCU));
+  return std::make_tuple(ED, Size, Align);
 }
 
 llvm::DIType *CGDebugInfo::CreateEnumType(const EnumType *Ty) {
-  auto [ED, Size, Align, Identifier] = getEnumInfo(CGM, TheCU, Ty);
+  auto [ED, Size, Align] = getEnumInfo(CGM, Ty);
+  StringRef Identifier = getTypeIdentifier(Ty);
 
   bool isImportedFromModule =
       DebugTypeExtRefs && ED->isFromASTFile() && ED->getDefinition();
@@ -3985,7 +4021,8 @@ llvm::DIType *CGDebugInfo::CreateEnumType(const EnumType *Ty) {
 }
 
 llvm::DIType *CGDebugInfo::CreateTypeDefinition(const EnumType *Ty) {
-  auto [ED, Size, Align, Identifier] = getEnumInfo(CGM, TheCU, Ty);
+  auto [ED, Size, Align] = getEnumInfo(CGM, Ty);
+  StringRef Identifier = getTypeIdentifier(Ty);
 
   SmallVector<llvm::Metadata *, 16> Enumerators;
   ED = ED->getDefinition();
@@ -4378,7 +4415,7 @@ llvm::DICompositeType *CGDebugInfo::CreateLimitedType(const RecordType *Ty) {
   // to be used.
   auto Align = getTypeAlignIfRequired(Ty, CGM.getContext());
 
-  SmallString<256> Identifier = getTypeIdentifier(Ty, CGM, TheCU);
+  StringRef Identifier = getTypeIdentifier(Ty);
 
   // Explicitly record the calling convention and export symbols for C++
   // records.

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -69,6 +69,9 @@ class CGDebugInfo {
   ModuleMap *ClangModuleMap = nullptr;
   ASTSourceDescriptor PCHDescriptor;
   SourceLocation CurLoc;
+  mutable SourceLocation CachedLineColLoc;
+  mutable unsigned CachedLine = 0;
+  mutable unsigned CachedColumn = 0;
   llvm::MDNode *CurInlinedAt = nullptr;
   llvm::DIType *VTablePtrType = nullptr;
   llvm::DIType *ClassTy = nullptr;
@@ -165,6 +168,12 @@ class CGDebugInfo {
   /// using declarations and global alias variables) that aren't covered
   /// by other more specific caches.
   llvm::DenseMap<const Decl *, llvm::TrackingMDRef> DeclCache;
+  struct ClassNameCacheEntry {
+    StringRef Name;
+    bool NameIsSimplified;
+  };
+  llvm::DenseMap<const RecordDecl *, ClassNameCacheEntry> ClassNameCache;
+  llvm::DenseMap<const TagDecl *, StringRef> TypeIdentifierCache;
   llvm::DenseMap<const Decl *, llvm::TrackingMDRef> ImportedDeclCache;
   llvm::DenseMap<const NamespaceDecl *, llvm::TrackingMDRef> NamespaceCache;
   llvm::DenseMap<const NamespaceAliasDecl *, llvm::TrackingMDRef>
@@ -740,6 +749,8 @@ private:
   /// Return current directory name.
   StringRef getCurrentDirname();
 
+  void cacheLineAndColumn(SourceLocation Loc) const;
+
   /// Create new compile unit.
   void CreateCompileUnit();
 
@@ -856,6 +867,8 @@ private:
   /// Get class name including template argument list.
   StringRef getClassName(const RecordDecl *RD,
                          bool *NameIsSimplified = nullptr);
+
+  StringRef getTypeIdentifier(const TagType *Ty);
 
   /// Get the vtable name for the given class.
   StringRef getVTableName(const CXXRecordDecl *Decl);


### PR DESCRIPTION
Found while profiling clang compiling SLPVectorizer.cpp.
Avoiding repeated debug location, type identifier, and file lookup work yields small compile-time wins for debug-info builds, mostly noise in optimized non-debug configs, but consistent improvements even up to -3.76% for debug-info builds and -0.76% for the clang build:
https://llvm-compile-time-tracker.com/compare.php?from=78820cb91605693b7d768be4ebc8b66181d3e9c3&to=61237fd627f6f973b05f3bafdeaa67ea29af8862
Stats of RelWithDebInfo SLPVectorizer.cpp build before and after:
```text
Benchmark 1 (3 runs): main -O2 -g compiling SLPVectorizer.cpp with pch
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          32.2s  ± 88.1ms    32.1s  … 32.3s           0 ( 0%)        0%
  peak_rss           1.07GB ±  255KB    1.07GB … 1.07GB          0 ( 0%)        0%
  cpu_cycles          158G  ±  439M      158G  …  159G           0 ( 0%)        0%
  instructions        217G  ± 44.8M      217G  …  217G           0 ( 0%)        0%
  cache_references   4.05G  ± 9.87M     4.04G  … 4.06G           0 ( 0%)        0%
  cache_misses        621M  ±  968K      619M  …  621M           0 ( 0%)        0%
  branch_misses      1.43G  ±  341K     1.43G  … 1.43G           0 ( 0%)        0%
Benchmark 2 (3 runs): perf/cgdebuginfo-lookup-cache -O2 -g compiling SLPVectorizer.cpp with pch
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          32.0s  ±  135ms    31.9s  … 32.2s           0 ( 0%)          -  0.4% ±  0.8%
  peak_rss           1.07GB ±  118KB    1.07GB … 1.07GB          0 ( 0%)          +  0.2% ±  0.0%
  cpu_cycles          158G  ±  593M      157G  …  158G           0 ( 0%)          -  0.4% ±  0.7%
  instructions        214G  ±  108M      214G  …  214G           0 ( 0%)        ⚡-  1.3% ±  0.1%
  cache_references   4.05G  ± 10.8M     4.04G  … 4.06G           0 ( 0%)          -  0.2% ±  0.6%
  cache_misses        620M  ± 2.48M      618M  …  622M           0 ( 0%)          -  0.0% ±  0.7%
  branch_misses      1.43G  ±  559K     1.43G  … 1.43G           0 ( 0%)          -  0.0% ±  0.1%
```