### PR TITLE
[lldb] Fix flaky TestRunLocker by using lldb.target instead of lldb.frame

### DIFF
--- a/lldb/test/API/python_api/run_locker/TestRunLocker.py
+++ b/lldb/test/API/python_api/run_locker/TestRunLocker.py
@@ -104,7 +104,7 @@ class TestRunLocker(TestBase):
         interp = self.dbg.GetCommandInterpreter()
         result = lldb.SBCommandReturnObject()
         ret = interp.HandleCommand(
-            "script var = lldb.frame.EvaluateExpression('SomethingToCall()'); var.GetError().GetCString()",
+            "script var = lldb.target.EvaluateExpression('SomethingToCall()'); var.GetError().GetCString()",
             result,
         )
         self.assertIn(


### PR DESCRIPTION
`lldb.frame` is a Python convenience variable that resolves to `None` when the process is running (no selected frame), potentially causing an `AttributeError` before the run locker check is ever reached. Use `lldb.target` instead, which is always valid and properly exercises the run locker path.

Fixes #193787