### PR TITLE
[CIR] Emit frexp, modf, and powi builtins as library calls

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2199,7 +2199,9 @@ def CIR_CmpOpKind : CIR_I32EnumAttr<"CmpOpKind", "compare operation kind", [
   I32EnumAttrCase<"gt", 2>,
   I32EnumAttrCase<"ge", 3>,
   I32EnumAttrCase<"eq", 4>,
-  I32EnumAttrCase<"ne", 5>
+  I32EnumAttrCase<"ne", 5>,
+  I32EnumAttrCase<"one", 6>,
+  I32EnumAttrCase<"uno", 7>
 ]>;
 
 def CIR_CmpOp : CIR_Op<"cmp", [Pure, SameTypeOperands]> {
@@ -2217,9 +2219,13 @@ def CIR_CmpOp : CIR_Op<"cmp", [Pure, SameTypeOperands]> {
     - `ge`: greater than or equal
     - `eq`: equal
     - `ne`: not equal
+    - `one`: ordered and not equal (floating-point only)
+    - `uno`: unordered (floating-point only, true if either operand is NaN)
 
     For floating-point comparisons, the predicate follows C semantics (e.g.
     NaN comparisons return false for all predicates except `ne`).
+    The `one` and `uno` predicates are floating-point specific: `one` is
+    ordered not-equal (false for NaN), `uno` tests if either operand is NaN.
 
     ```
     %0 = cir.cmp gt %1, %2 : !s32i
@@ -6640,6 +6646,47 @@ def CIR_ATan2Op : CIR_BinaryFPToFPBuiltinOp<"atan2", "ATan2Op"> {
   let description = [{
     `cir.atan2` computes the arc tangent of the first operand divided by the
     second operand, using the signs of both to determine the quadrant.
+  }];
+}
+
+def CIR_FrexpOp : CIR_Op<"frexp", [Pure]> {
+  let summary = "Decomposes a floating-point value into significand and exponent";
+  let description = [{
+    `cir.frexp` splits a floating-point value into a normalized significand
+    (in the range [0.5, 1.0)) and an integral power-of-two exponent, such
+    that `src = significand * 2^exp`.  Returns both as separate results.
+
+    Lowers to `llvm.frexp`.
+
+    Example:
+      %sig, %exp = cir.frexp %x : !cir.float -> !cir.float, !s32i
+  }];
+
+  let arguments = (ins CIR_AnyFloatType:$src);
+  let results = (outs CIR_AnyFloatType:$result, CIR_AnyIntType:$exp);
+
+  let assemblyFormat = [{
+    $src `:` type($src) `->` type($result) `,` type($exp) attr-dict
+  }];
+}
+
+def CIR_ModfOp : CIR_Op<"modf", [Pure]> {
+  let summary = "Decomposes a floating-point value into fractional and integral parts";
+  let description = [{
+    `cir.modf` splits a floating-point value into its fractional and integral
+    parts.  Both parts have the same sign as the input.
+
+    Lowers to `llvm.modf`.
+
+    Example:
+      %frac, %intpart = cir.modf %x : !cir.float -> !cir.float, !cir.float
+  }];
+
+  let arguments = (ins CIR_AnyFloatType:$src);
+  let results = (outs CIR_AnyFloatType:$fractional, CIR_AnyFloatType:$integral);
+
+  let assemblyFormat = [{
+    $src `:` type($src) `->` type($fractional) `,` type($integral) attr-dict
   }];
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1380,24 +1380,82 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
     return RValue::getIgnored();
   case Builtin::BI__builtin_powi:
   case Builtin::BI__builtin_powif:
-  case Builtin::BI__builtin_powil:
+  case Builtin::BI__builtin_powil: {
+    mlir::Value src0 = emitScalarExpr(e->getArg(0));
+    mlir::Value src1 = emitScalarExpr(e->getArg(1));
+    return RValue::get(builder.emitIntrinsicCallOp(
+        getLoc(e->getExprLoc()), "powi", src0.getType(),
+        mlir::ValueRange{src0, src1}));
+  }
   case Builtin::BI__builtin_frexpl:
   case Builtin::BI__builtin_frexp:
   case Builtin::BI__builtin_frexpf:
   case Builtin::BI__builtin_frexpf128:
-  case Builtin::BI__builtin_frexpf16:
+  case Builtin::BI__builtin_frexpf16: {
+    mlir::Value val = emitScalarExpr(e->getArg(0));
+    mlir::Value ptr = emitScalarExpr(e->getArg(1));
+    mlir::Type fpTy = val.getType();
+    QualType intQualTy = e->getArg(1)->getType()->getPointeeType();
+    mlir::Type intTy = convertType(intQualTy);
+    mlir::Location callLoc = getLoc(e->getExprLoc());
+    auto frexpOp = cir::FrexpOp::create(builder, callLoc, fpTy, intTy, val);
+    LValue lv = makeNaturalAlignAddrLValue(ptr, intQualTy);
+    emitStoreOfScalar(frexpOp.getExp(), lv, /*isInit=*/false);
+    return RValue::get(frexpOp.getResult());
+  }
   case Builtin::BImodf:
   case Builtin::BImodff:
   case Builtin::BImodfl:
   case Builtin::BI__builtin_modf:
   case Builtin::BI__builtin_modff:
-  case Builtin::BI__builtin_modfl:
+  case Builtin::BI__builtin_modfl: {
+    mlir::Value val = emitScalarExpr(e->getArg(0));
+    mlir::Value ptr = emitScalarExpr(e->getArg(1));
+    mlir::Type fpTy = val.getType();
+    mlir::Location callLoc = getLoc(e->getExprLoc());
+    auto modfOp = cir::ModfOp::create(builder, callLoc, fpTy, fpTy, val);
+    QualType destPtrTy = e->getArg(1)->getType()->getPointeeType();
+    LValue lv = makeNaturalAlignAddrLValue(ptr, destPtrTy);
+    emitStoreOfScalar(modfOp.getIntegral(), lv, /*isInit=*/false);
+    return RValue::get(modfOp.getFractional());
+  }
   case Builtin::BI__builtin_isgreater:
   case Builtin::BI__builtin_isgreaterequal:
   case Builtin::BI__builtin_isless:
   case Builtin::BI__builtin_islessequal:
   case Builtin::BI__builtin_islessgreater:
-  case Builtin::BI__builtin_isunordered:
+  case Builtin::BI__builtin_isunordered: {
+    CIRGenFunction::CIRGenFPOptionsRAII FPOptsRAII(*this, e);
+    mlir::Value lhs = emitScalarExpr(e->getArg(0));
+    mlir::Value rhs = emitScalarExpr(e->getArg(1));
+    mlir::Location loc = getLoc(e->getBeginLoc());
+    mlir::Type intTy = convertType(e->getType());
+
+    mlir::Value cmpResult;
+    switch (builtinID) {
+    case Builtin::BI__builtin_isgreater:
+      cmpResult = builder.createCompare(loc, cir::CmpOpKind::gt, lhs, rhs);
+      break;
+    case Builtin::BI__builtin_isgreaterequal:
+      cmpResult = builder.createCompare(loc, cir::CmpOpKind::ge, lhs, rhs);
+      break;
+    case Builtin::BI__builtin_isless:
+      cmpResult = builder.createCompare(loc, cir::CmpOpKind::lt, lhs, rhs);
+      break;
+    case Builtin::BI__builtin_islessequal:
+      cmpResult = builder.createCompare(loc, cir::CmpOpKind::le, lhs, rhs);
+      break;
+    case Builtin::BI__builtin_islessgreater:
+      cmpResult = builder.createCompare(loc, cir::CmpOpKind::one, lhs, rhs);
+      break;
+    case Builtin::BI__builtin_isunordered:
+      cmpResult = builder.createCompare(loc, cir::CmpOpKind::uno, lhs, rhs);
+      break;
+    default:
+      llvm_unreachable("Unknown ordered comparison");
+    }
+    return RValue::get(builder.createBoolToInt(cmpResult, intTy));
+  }
   // From https://clang.llvm.org/docs/LanguageExtensions.html#builtin-isfpclass
   //
   //  The `__builtin_isfpclass()` builtin is a generalization of functions

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3240,6 +3240,20 @@ OpFoldResult cir::VecCmpOp::fold(FoldAdaptor adaptor) {
       }
       break;
     }
+    case cir::CmpOpKind::one: {
+      llvm::APFloat::cmpResult cr =
+          mlir::cast<cir::FPAttr>(lhsAttr).getValue().compare(
+              mlir::cast<cir::FPAttr>(rhsAttr).getValue());
+      cmpResult =
+          cr != llvm::APFloat::cmpUnordered && cr != llvm::APFloat::cmpEqual;
+      break;
+    }
+    case cir::CmpOpKind::uno: {
+      cmpResult = mlir::cast<cir::FPAttr>(lhsAttr).getValue().compare(
+                      mlir::cast<cir::FPAttr>(rhsAttr).getValue()) ==
+                  llvm::APFloat::cmpUnordered;
+      break;
+    }
     }
 
     elements[i] = cir::IntAttr::get(getType().getElementType(), cmpResult);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2806,6 +2806,9 @@ convertCmpKindToICmpPredicate(cir::CmpOpKind kind, bool isSigned) {
     return (isSigned ? LLVMICmp::sgt : LLVMICmp::ugt);
   case CIR::ge:
     return (isSigned ? LLVMICmp::sge : LLVMICmp::uge);
+  case CIR::one:
+  case CIR::uno:
+    llvm_unreachable("FP-only comparison used with integer type");
   }
   llvm_unreachable("Unknown CmpOpKind");
 }
@@ -2829,6 +2832,10 @@ convertCmpKindToFCmpPredicate(cir::CmpOpKind kind) {
     return LLVMFCmp::ogt;
   case CIR::ge:
     return LLVMFCmp::oge;
+  case CIR::one:
+    return LLVMFCmp::one;
+  case CIR::uno:
+    return LLVMFCmp::uno;
   }
   llvm_unreachable("Unknown CmpOpKind");
 }
@@ -3033,6 +3040,51 @@ mlir::LogicalResult CIRToLLVMMulOverflowOpLowering::matchAndRewrite(
     cir::MulOverflowOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
   return lowerBinOpOverflow(op, adaptor, rewriter, getTypeConverter(), "mul");
+}
+
+mlir::LogicalResult CIRToLLVMFrexpOpLowering::matchAndRewrite(
+    cir::FrexpOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Location loc = op.getLoc();
+  mlir::Type fpLLVMTy =
+      getTypeConverter()->convertType(op.getResult().getType());
+  mlir::Type intLLVMTy = getTypeConverter()->convertType(op.getExp().getType());
+
+  auto structTy = mlir::LLVM::LLVMStructType::getLiteral(rewriter.getContext(),
+                                                         {fpLLVMTy, intLLVMTy});
+
+  auto callOp = createCallLLVMIntrinsicOp(rewriter, loc, "llvm.frexp", structTy,
+                                          adaptor.getSrc());
+  mlir::Value result = callOp.getResult(0);
+
+  mlir::Value mantissa =
+      mlir::LLVM::ExtractValueOp::create(rewriter, loc, result, 0);
+  mlir::Value exponent =
+      mlir::LLVM::ExtractValueOp::create(rewriter, loc, result, 1);
+  rewriter.replaceOp(op, mlir::ValueRange{mantissa, exponent});
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRToLLVMModfOpLowering::matchAndRewrite(
+    cir::ModfOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Location loc = op.getLoc();
+  mlir::Type fpLLVMTy =
+      getTypeConverter()->convertType(op.getFractional().getType());
+
+  auto structTy = mlir::LLVM::LLVMStructType::getLiteral(rewriter.getContext(),
+                                                         {fpLLVMTy, fpLLVMTy});
+
+  auto callOp = createCallLLVMIntrinsicOp(rewriter, loc, "llvm.modf", structTy,
+                                          adaptor.getSrc());
+  mlir::Value result = callOp.getResult(0);
+
+  mlir::Value fractional =
+      mlir::LLVM::ExtractValueOp::create(rewriter, loc, result, 0);
+  mlir::Value integral =
+      mlir::LLVM::ExtractValueOp::create(rewriter, loc, result, 1);
+  rewriter.replaceOp(op, mlir::ValueRange{fractional, integral});
+  return mlir::success();
 }
 
 mlir::LogicalResult CIRToLLVMShiftOpLowering::matchAndRewrite(

--- a/clang/test/CIR/CodeGenBuiltins/builtin-float.c
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-float.c
@@ -1,0 +1,376 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+// frexp: float, double, long double
+
+float test_frexpf(float x) {
+  int exp;
+  return __builtin_frexpf(x, &exp);
+}
+
+// CIR-LABEL: cir.func {{.*}} @test_frexpf
+// CIR:         %{{.*}}, %{{.*}} = cir.frexp %{{.*}} : !cir.float -> !cir.float, !s32i
+// CIR:         cir.store
+// CIR:         cir.return
+
+// LLVM-LABEL: define {{.*}} float @test_frexpf
+// LLVM:         %{{.*}} = call { float, i32 } @llvm.frexp.f32.i32(float %{{.*}})
+// LLVM:         %{{.*}} = extractvalue { float, i32 } %{{.*}}, 0
+// LLVM:         %{{.*}} = extractvalue { float, i32 } %{{.*}}, 1
+// LLVM:         ret float
+
+// OGCG-LABEL: define {{.*}} float @test_frexpf
+// OGCG:         %{{.*}} = call { float, i32 } @llvm.frexp.f32.i32(float %{{.*}})
+// OGCG:         %{{.*}} = extractvalue { float, i32 } %{{.*}}, 1
+// OGCG:         %{{.*}} = extractvalue { float, i32 } %{{.*}}, 0
+// OGCG:         ret float
+
+double test_frexp(double x) {
+  int exp;
+  return __builtin_frexp(x, &exp);
+}
+
+// CIR-LABEL: cir.func {{.*}} @test_frexp
+// CIR:         %{{.*}}, %{{.*}} = cir.frexp %{{.*}} : !cir.double -> !cir.double, !s32i
+// CIR:         cir.store
+// CIR:         cir.return
+
+// LLVM-LABEL: define {{.*}} double @test_frexp
+// LLVM:         %{{.*}} = call { double, i32 } @llvm.frexp.f64.i32(double %{{.*}})
+// LLVM:         %{{.*}} = extractvalue { double, i32 } %{{.*}}, 0
+// LLVM:         %{{.*}} = extractvalue { double, i32 } %{{.*}}, 1
+// LLVM:         ret double
+
+// OGCG-LABEL: define {{.*}} double @test_frexp
+// OGCG:         %{{.*}} = call { double, i32 } @llvm.frexp.f64.i32(double %{{.*}})
+// OGCG:         %{{.*}} = extractvalue { double, i32 } %{{.*}}, 1
+// OGCG:         %{{.*}} = extractvalue { double, i32 } %{{.*}}, 0
+// OGCG:         ret double
+
+long double test_frexpl(long double x) {
+  int exp;
+  return __builtin_frexpl(x, &exp);
+}
+
+// CIR-LABEL: cir.func {{.*}} @test_frexpl
+// CIR:         %{{.*}}, %{{.*}} = cir.frexp %{{.*}} : !cir.long_double<!cir.f80> -> !cir.long_double<!cir.f80>, !s32i
+// CIR:         cir.store
+// CIR:         cir.return
+
+// LLVM-LABEL: define {{.*}} x86_fp80 @test_frexpl
+// LLVM:         %{{.*}} = call { x86_fp80, i32 } @llvm.frexp.f80.i32(x86_fp80 %{{.*}})
+// LLVM:         %{{.*}} = extractvalue { x86_fp80, i32 } %{{.*}}, 0
+// LLVM:         %{{.*}} = extractvalue { x86_fp80, i32 } %{{.*}}, 1
+// LLVM:         ret x86_fp80
+
+// OGCG-LABEL: define {{.*}} x86_fp80 @test_frexpl
+// OGCG:         %{{.*}} = call { x86_fp80, i32 } @llvm.frexp.f80.i32(x86_fp80 %{{.*}})
+// OGCG:         %{{.*}} = extractvalue { x86_fp80, i32 } %{{.*}}, 1
+// OGCG:         %{{.*}} = extractvalue { x86_fp80, i32 } %{{.*}}, 0
+// OGCG:         ret x86_fp80
+
+__float128 test_frexpf128(__float128 x) {
+  int exp;
+  return __builtin_frexpf128(x, &exp);
+}
+
+// CIR-LABEL: cir.func {{.*}} @test_frexpf128
+// CIR:         %{{.*}}, %{{.*}} = cir.frexp %{{.*}} : !cir.f128 -> !cir.f128, !s32i
+// CIR:         cir.store
+// CIR:         cir.return
+
+// LLVM-LABEL: define {{.*}} fp128 @test_frexpf128
+// LLVM:         %{{.*}} = call { fp128, i32 } @llvm.frexp.f128.i32(fp128 %{{.*}})
+// LLVM:         %{{.*}} = extractvalue { fp128, i32 } %{{.*}}, 0
+// LLVM:         %{{.*}} = extractvalue { fp128, i32 } %{{.*}}, 1
+// LLVM:         ret fp128
+
+// OGCG-LABEL: define {{.*}} fp128 @test_frexpf128
+// OGCG:         %{{.*}} = call { fp128, i32 } @llvm.frexp.f128.i32(fp128 %{{.*}})
+// OGCG:         %{{.*}} = extractvalue { fp128, i32 } %{{.*}}, 1
+// OGCG:         %{{.*}} = extractvalue { fp128, i32 } %{{.*}}, 0
+// OGCG:         ret fp128
+
+// modf: float, double, long double
+
+float test_modff(float x) {
+  float ipart;
+  return __builtin_modff(x, &ipart);
+}
+
+// CIR-LABEL: cir.func {{.*}} @test_modff
+// CIR:         %{{.*}}, %{{.*}} = cir.modf %{{.*}} : !cir.float -> !cir.float, !cir.float
+// CIR:         cir.store
+// CIR:         cir.return
+
+// LLVM-LABEL: define {{.*}} float @test_modff
+// LLVM:         %{{.*}} = call { float, float } @llvm.modf.f32(float %{{.*}})
+// LLVM:         %{{.*}} = extractvalue { float, float } %{{.*}}, 0
+// LLVM:         %{{.*}} = extractvalue { float, float } %{{.*}}, 1
+// LLVM:         ret float
+
+// OGCG-LABEL: define {{.*}} float @test_modff
+// OGCG:         %{{.*}} = call { float, float } @llvm.modf.f32(float %{{.*}})
+// OGCG:         %{{.*}} = extractvalue { float, float } %{{.*}}, 0
+// OGCG:         %{{.*}} = extractvalue { float, float } %{{.*}}, 1
+// OGCG:         ret float
+
+double test_modf(double x) {
+  double ipart;
+  return __builtin_modf(x, &ipart);
+}
+
+// CIR-LABEL: cir.func {{.*}} @test_modf
+// CIR:         %{{.*}}, %{{.*}} = cir.modf %{{.*}} : !cir.double -> !cir.double, !cir.double
+// CIR:         cir.store
+// CIR:         cir.return
+
+// LLVM-LABEL: define {{.*}} double @test_modf
+// LLVM:         %{{.*}} = call { double, double } @llvm.modf.f64(double %{{.*}})
+// LLVM:         %{{.*}} = extractvalue { double, double } %{{.*}}, 0
+// LLVM:         %{{.*}} = extractvalue { double, double } %{{.*}}, 1
+// LLVM:         ret double
+
+// OGCG-LABEL: define {{.*}} double @test_modf
+// OGCG:         %{{.*}} = call { double, double } @llvm.modf.f64(double %{{.*}})
+// OGCG:         %{{.*}} = extractvalue { double, double } %{{.*}}, 0
+// OGCG:         %{{.*}} = extractvalue { double, double } %{{.*}}, 1
+// OGCG:         ret double
+
+long double test_modfl(long double x) {
+  long double ipart;
+  return __builtin_modfl(x, &ipart);
+}
+
+// CIR-LABEL: cir.func {{.*}} @test_modfl
+// CIR:         %{{.*}}, %{{.*}} = cir.modf %{{.*}} : !cir.long_double<!cir.f80> -> !cir.long_double<!cir.f80>, !cir.long_double<!cir.f80>
+// CIR:         cir.store
+// CIR:         cir.return
+
+// LLVM-LABEL: define {{.*}} x86_fp80 @test_modfl
+// LLVM:         %{{.*}} = call { x86_fp80, x86_fp80 } @llvm.modf.f80(x86_fp80 %{{.*}})
+// LLVM:         %{{.*}} = extractvalue { x86_fp80, x86_fp80 } %{{.*}}, 0
+// LLVM:         %{{.*}} = extractvalue { x86_fp80, x86_fp80 } %{{.*}}, 1
+// LLVM:         ret x86_fp80
+
+// OGCG-LABEL: define {{.*}} x86_fp80 @test_modfl
+// OGCG:         %{{.*}} = call { x86_fp80, x86_fp80 } @llvm.modf.f80(x86_fp80 %{{.*}})
+// OGCG:         %{{.*}} = extractvalue { x86_fp80, x86_fp80 } %{{.*}}, 0
+// OGCG:         %{{.*}} = extractvalue { x86_fp80, x86_fp80 } %{{.*}}, 1
+// OGCG:         ret x86_fp80
+
+__float128 test_modff128(__float128 x) {
+  __float128 ipart;
+  return __builtin_modff128(x, &ipart);
+}
+
+// CIR-LABEL: cir.func {{.*}} @test_modff128
+// CIR:         cir.call @modff128
+// CIR:         cir.return
+
+// LLVM-LABEL: define {{.*}} fp128 @test_modff128
+// LLVM:         call fp128 @modff128(fp128 {{.*}}, ptr {{.*}})
+// LLVM:         ret fp128
+
+// OGCG-LABEL: define {{.*}} fp128 @test_modff128
+// OGCG:         call fp128 @modff128(fp128 {{.*}}, ptr {{.*}})
+// OGCG:         ret fp128
+
+// powi: float, double, long double
+
+float test_powif(float x, int y) {
+  return __builtin_powif(x, y);
+}
+
+// CIR-LABEL: cir.func {{.*}} @test_powif
+// CIR:         %{{.*}} = cir.call_llvm_intrinsic "powi" %{{.*}}, %{{.*}} : (!cir.float, !s32i) -> !cir.float
+// CIR:         cir.return
+
+// LLVM-LABEL: define {{.*}} float @test_powif
+// LLVM:         call float @llvm.powi.f32.i32(float %{{.*}}, i32 %{{.*}})
+// LLVM:         ret float
+
+// OGCG-LABEL: define {{.*}} float @test_powif
+// OGCG:         call float @llvm.powi.f32.i32(float %{{.*}}, i32 %{{.*}})
+// OGCG:         ret float
+
+double test_powi(double x, int y) {
+  return __builtin_powi(x, y);
+}
+
+// CIR-LABEL: cir.func {{.*}} @test_powi
+// CIR:         %{{.*}} = cir.call_llvm_intrinsic "powi" %{{.*}}, %{{.*}} : (!cir.double, !s32i) -> !cir.double
+// CIR:         cir.return
+
+// LLVM-LABEL: define {{.*}} double @test_powi
+// LLVM:         call double @llvm.powi.f64.i32(double %{{.*}}, i32 %{{.*}})
+// LLVM:         ret double
+
+// OGCG-LABEL: define {{.*}} double @test_powi
+// OGCG:         call double @llvm.powi.f64.i32(double %{{.*}}, i32 %{{.*}})
+// OGCG:         ret double
+
+long double test_powil(long double x, int y) {
+  return __builtin_powil(x, y);
+}
+
+// CIR-LABEL: cir.func {{.*}} @test_powil
+// CIR:         %{{.*}} = cir.call_llvm_intrinsic "powi" %{{.*}}, %{{.*}} : (!cir.long_double<!cir.f80>, !s32i) -> !cir.long_double<!cir.f80>
+// CIR:         cir.return
+
+// LLVM-LABEL: define {{.*}} x86_fp80 @test_powil
+// LLVM:         call x86_fp80 @llvm.powi.f80.i32(x86_fp80 %{{.*}}, i32 %{{.*}})
+// LLVM:         ret x86_fp80
+
+// OGCG-LABEL: define {{.*}} x86_fp80 @test_powil
+// OGCG:         call x86_fp80 @llvm.powi.f80.i32(x86_fp80 %{{.*}}, i32 %{{.*}})
+// OGCG:         ret x86_fp80
+
+// FP comparison builtins: float
+
+void test_floats(float x, float y, int *out) {
+  out[0] = __builtin_isgreater(x, y);
+  // CIR: cir.cmp gt %{{.*}}, %{{.*}} : !cir.float
+  // LLVM: fcmp ogt float
+  // OGCG: fcmp ogt float
+
+  out[1] = __builtin_isgreaterequal(x, y);
+  // CIR: cir.cmp ge %{{.*}}, %{{.*}} : !cir.float
+  // LLVM: fcmp oge float
+  // OGCG: fcmp oge float
+
+  out[2] = __builtin_isless(x, y);
+  // CIR: cir.cmp lt %{{.*}}, %{{.*}} : !cir.float
+  // LLVM: fcmp olt float
+  // OGCG: fcmp olt float
+
+  out[3] = __builtin_islessequal(x, y);
+  // CIR: cir.cmp le %{{.*}}, %{{.*}} : !cir.float
+  // LLVM: fcmp ole float
+  // OGCG: fcmp ole float
+
+  out[4] = __builtin_islessgreater(x, y);
+  // CIR: cir.cmp one %{{.*}}, %{{.*}} : !cir.float
+  // LLVM: fcmp one float
+  // OGCG: fcmp one float
+
+  out[5] = __builtin_isunordered(x, y);
+  // CIR: cir.cmp uno %{{.*}}, %{{.*}} : !cir.float
+  // LLVM: fcmp uno float
+  // OGCG: fcmp uno float
+}
+
+// FP comparison builtins: double
+
+void test_doubles(double x, double y, int *out) {
+  out[0] = __builtin_isgreater(x, y);
+  // CIR: cir.cmp gt %{{.*}}, %{{.*}} : !cir.double
+  // LLVM: fcmp ogt double
+  // OGCG: fcmp ogt double
+
+  out[1] = __builtin_isgreaterequal(x, y);
+  // CIR: cir.cmp ge %{{.*}}, %{{.*}} : !cir.double
+  // LLVM: fcmp oge double
+  // OGCG: fcmp oge double
+
+  out[2] = __builtin_isless(x, y);
+  // CIR: cir.cmp lt %{{.*}}, %{{.*}} : !cir.double
+  // LLVM: fcmp olt double
+  // OGCG: fcmp olt double
+
+  out[3] = __builtin_islessequal(x, y);
+  // CIR: cir.cmp le %{{.*}}, %{{.*}} : !cir.double
+  // LLVM: fcmp ole double
+  // OGCG: fcmp ole double
+
+  out[4] = __builtin_islessgreater(x, y);
+  // CIR: cir.cmp one %{{.*}}, %{{.*}} : !cir.double
+  // LLVM: fcmp one double
+  // OGCG: fcmp one double
+
+  out[5] = __builtin_isunordered(x, y);
+  // CIR: cir.cmp uno %{{.*}}, %{{.*}} : !cir.double
+  // LLVM: fcmp uno double
+  // OGCG: fcmp uno double
+}
+
+// FP comparison builtins: mixed double + float (fpext)
+
+void test_mixed(double x, float y, int *out) {
+  out[0] = __builtin_isgreater(x, y);
+  // CIR: cir.cast floating %{{.*}} : !cir.float -> !cir.double
+  // CIR: cir.cmp gt %{{.*}}, %{{.*}} : !cir.double
+  // LLVM: fpext float %{{.*}} to double
+  // LLVM: fcmp ogt double
+  // OGCG: fpext float %{{.*}} to double
+  // OGCG: fcmp ogt double
+
+  out[1] = __builtin_isgreaterequal(x, y);
+  // CIR: cir.cast floating %{{.*}} : !cir.float -> !cir.double
+  // CIR: cir.cmp ge %{{.*}}, %{{.*}} : !cir.double
+  // LLVM: fpext float %{{.*}} to double
+  // LLVM: fcmp oge double
+  // OGCG: fpext float %{{.*}} to double
+  // OGCG: fcmp oge double
+
+  out[2] = __builtin_isless(x, y);
+  // CIR: cir.cast floating %{{.*}} : !cir.float -> !cir.double
+  // CIR: cir.cmp lt %{{.*}}, %{{.*}} : !cir.double
+  // LLVM: fpext float %{{.*}} to double
+  // LLVM: fcmp olt double
+  // OGCG: fpext float %{{.*}} to double
+  // OGCG: fcmp olt double
+
+  out[3] = __builtin_islessequal(x, y);
+  // CIR: cir.cast floating %{{.*}} : !cir.float -> !cir.double
+  // CIR: cir.cmp le %{{.*}}, %{{.*}} : !cir.double
+  // LLVM: fpext float %{{.*}} to double
+  // LLVM: fcmp ole double
+  // OGCG: fpext float %{{.*}} to double
+  // OGCG: fcmp ole double
+
+  out[4] = __builtin_islessgreater(x, y);
+  // CIR: cir.cast floating %{{.*}} : !cir.float -> !cir.double
+  // CIR: cir.cmp one %{{.*}}, %{{.*}} : !cir.double
+  // LLVM: fpext float %{{.*}} to double
+  // LLVM: fcmp one double
+  // OGCG: fpext float %{{.*}} to double
+  // OGCG: fcmp one double
+
+  out[5] = __builtin_isunordered(x, y);
+  // CIR: cir.cast floating %{{.*}} : !cir.float -> !cir.double
+  // CIR: cir.cmp uno %{{.*}}, %{{.*}} : !cir.double
+  // LLVM: fpext float %{{.*}} to double
+  // LLVM: fcmp uno double
+  // OGCG: fpext float %{{.*}} to double
+  // OGCG: fcmp uno double
+}
+
+// FP comparison builtins: __fp16 (promoted to float)
+
+int test_isgreater_half(__fp16 *a, __fp16 *b) {
+  return __builtin_isgreater(*a, *b);
+}
+
+// CIR-LABEL: cir.func {{.*}} @test_isgreater_half
+// CIR:         cir.cast floating %{{.*}} : !cir.f16 -> !cir.float
+// CIR:         cir.cast floating %{{.*}} : !cir.f16 -> !cir.float
+// CIR:         cir.cmp gt %{{.*}}, %{{.*}} : !cir.float
+
+// LLVM-LABEL: define {{.*}} i32 @test_isgreater_half
+// LLVM:         fpext half %{{.*}} to float
+// LLVM:         fpext half %{{.*}} to float
+// LLVM:         fcmp ogt float
+// LLVM:         zext i1 %{{.*}} to i32
+// LLVM:         ret i32
+
+// OGCG-LABEL: define {{.*}} i32 @test_isgreater_half
+// OGCG:         fpext half %{{.*}} to float
+// OGCG:         fpext half %{{.*}} to float
+// OGCG:         fcmp ogt float
+// OGCG:         zext i1 %{{.*}} to i32
+// OGCG:         ret i32


### PR DESCRIPTION
`__builtin_frexpf`, `__builtin_modf`, `__builtin_powi`, and related builtins were incorrectly falling through to the `__builtin_isnan` handler in `emitBuiltinExpr`, which calls `createBoolToInt` / `createIsFPClass`.  This produced a `cir.cast` with an integer result type when the actual return type is floating-point, failing CIR verification.

Break out of the switch so these builtins fall through to the `isLibFunction()` path, which emits them as regular library calls.

Made with [Cursor](https://cursor.com)