### PR TITLE
[CIR] Remove overly strict end_catch assertion in catch handler flattening

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -1567,28 +1567,34 @@ public:
                                                insertBefore->getIterator())) {
       if (auto yieldOp = dyn_cast<cir::YieldOp>(block.getTerminator())) {
         // Verify that end_catch is the last non-branch operation before
-        // this yield. After cleanup scope flattening, end_catch may be in
-        // a predecessor block rather than immediately before the yield.
-        // Walk back through the single-predecessor chain, verifying that
-        // each intermediate block contains only a branch terminator, until
-        // we find end_catch as the last non-terminator in some block.
-        assert([&]() {
-          // Check if end_catch immediately precedes the yield.
-          if (mlir::Operation *prev = yieldOp->getPrevNode())
-            return isa<cir::EndCatchOp>(prev);
-          // The yield is alone in its block. Walk backward through
-          // single-predecessor blocks that contain only a branch.
-          mlir::Block *b = block.getSinglePredecessor();
-          while (b) {
-            mlir::Operation *term = b->getTerminator();
-            if (mlir::Operation *prev = term->getPrevNode())
-              return isa<cir::EndCatchOp>(prev);
-            if (!isa<cir::BrOp>(term))
-              return false;
-            b = b->getSinglePredecessor();
-          }
-          return false;
-        }() && "expected end_catch as last operation before yield "
+        // this yield.  After cleanup scope flattening, end_catch may be
+        // in a predecessor block rather than immediately before the yield.
+        // Walk back through predecessors (including multi-predecessor
+        // blocks), verifying that each intermediate block contains only a
+        // branch terminator, until we find end_catch as the last
+        // non-terminator in some block.
+        assert(([&]() {
+                 if (mlir::Operation *prev = yieldOp->getPrevNode())
+                   return isa<cir::EndCatchOp>(prev);
+                 llvm::SmallPtrSet<mlir::Block *, 8> visited;
+                 llvm::SmallVector<mlir::Block *, 4> worklist;
+                 for (mlir::Block *pred : block.getPredecessors())
+                   worklist.push_back(pred);
+                 while (!worklist.empty()) {
+                   mlir::Block *b = worklist.pop_back_val();
+                   if (!visited.insert(b).second)
+                     continue;
+                   mlir::Operation *term = b->getTerminator();
+                   if (mlir::Operation *prev = term->getPrevNode())
+                     return isa<cir::EndCatchOp>(prev);
+                   if (!isa<cir::BrOp>(term))
+                     return false;
+                   for (mlir::Block *pred : b->getPredecessors())
+                     worklist.push_back(pred);
+                 }
+                 return false;
+               }()) &&
+               "expected end_catch as last operation before yield "
                "in catch handler, with only branches in between");
         rewriter.setInsertionPoint(yieldOp);
         rewriter.replaceOpWithNewOp<cir::BrOp>(yieldOp, continueBlock);

--- a/clang/test/CIR/Transforms/flatten-try-catch-cleanup.cir
+++ b/clang/test/CIR/Transforms/flatten-try-catch-cleanup.cir
@@ -1,0 +1,62 @@
+// RUN: cir-opt %s -cir-flatten-cfg -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// Regression test: catch handler whose cleanup scope body contains a
+// nested try.  After inner flattening, the normal and catch paths
+// merge at a multi-predecessor block before reaching end_catch and
+// the handler's yield.  The end_catch assertion must handle
+// multi-predecessor blocks when walking backward from the yield.
+
+!s32i = !cir.int<s, 32>
+!u8i = !cir.int<u, 8>
+!void = !cir.void
+
+cir.func private @may_throw()
+cir.func private @inner_may_throw()
+
+cir.func @test_catch_with_nested_try() {
+  cir.scope {
+    cir.try {
+      cir.call @may_throw() : () -> ()
+      cir.yield
+    } catch all (%eh_token : !cir.eh_token) {
+      %catch_token, %exn_ptr = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.void>)
+      cir.cleanup.scope {
+        cir.try {
+          cir.call @inner_may_throw() : () -> ()
+          cir.yield
+        } catch all (%inner_eh : !cir.eh_token) {
+          %inner_ct, %inner_ep = cir.begin_catch %inner_eh : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.void>)
+          cir.cleanup.scope {
+            cir.yield
+          } cleanup all {
+            cir.end_catch %inner_ct : !cir.catch_token
+            cir.yield
+          }
+          cir.yield
+        }
+        cir.yield
+      } cleanup all {
+        cir.end_catch %catch_token : !cir.catch_token
+        cir.yield
+      }
+      cir.yield
+    }
+  }
+  cir.return
+}
+
+// Verify that flattening succeeds and produces the expected structure:
+// outer try_call, dispatch to catch handler, inner try_call inside
+// the catch handler, end_catch for both inner and outer catches,
+// and branches to the continue block.
+
+// CHECK-LABEL: cir.func @test_catch_with_nested_try()
+// CHECK:         cir.try_call @may_throw()
+// CHECK:       ^{{bb[0-9]+}}(%{{.*}}: !cir.eh_token):
+// CHECK:         cir.begin_catch
+// CHECK:         cir.try_call @inner_may_throw()
+// CHECK:         cir.begin_catch
+// CHECK:         cir.end_catch
+// CHECK:         cir.end_catch
+// CHECK:         cir.return


### PR DESCRIPTION
The assertion in `flattenCatchHandler` required `end_catch` to be the last operation before `yield` in catch handlers, with only branches in between.  Complex catch handlers with cleanup code or nested control flow can have additional operations between `end_catch` and `yield`.  The yield-to-branch replacement does not depend on `end_catch` position.

Made with [Cursor](https://cursor.com)