### PR TITLE
[libc] Switch check-libc from CTest to lit

### DIFF
--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -1,10 +1,5 @@
-add_custom_target(check-libc)
 add_custom_target(libc-unit-tests)
 add_custom_target(libc-hermetic-tests)
-
-if (TARGET check-hdrgen)
-  add_dependencies(check-libc check-hdrgen)
-endif()
 
 add_custom_target(exhaustive-check-libc)
 add_custom_target(libc-long-running-tests)
@@ -31,18 +26,20 @@ configure_lit_site_cfg(
   "CMAKE_CROSSCOMPILING_EMULATOR"
 )
 
-add_lit_testsuite(check-libc-lit
+add_lit_testsuite(check-libc
   "Running libc tests via lit"
   ${LIBC_BUILD_DIR}/test
 )
 
+if (TARGET check-hdrgen)
+  add_dependencies(check-libc check-hdrgen)
+endif()
+
 if(LIBC_ENABLE_UNITTESTS AND NOT LIBC_TEST_HERMETIC_TEST_ONLY)
-  add_dependencies(check-libc libc-unit-tests)
-  add_dependencies(check-libc-lit libc-unit-tests-build)
+  add_dependencies(check-libc libc-unit-tests-build)
 endif()
 if(LIBC_ENABLE_HERMETIC_TESTS AND NOT LIBC_TEST_UNIT_TEST_ONLY)
-  add_dependencies(check-libc libc-hermetic-tests)
-  add_dependencies(check-libc-lit libc-hermetic-tests-build)
+  add_dependencies(check-libc libc-hermetic-tests-build)
 endif()
 
 add_subdirectory(UnitTest)

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_custom_target(libc_include_tests)
-add_dependencies(check-libc libc_include_tests)
-add_dependencies(check-libc-lit libc_include_tests-build)
+add_dependencies(check-libc libc_include_tests-build)
 
 add_libc_test(
   assert_test

--- a/libc/test/integration/CMakeLists.txt
+++ b/libc/test/integration/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_custom_target(libc-integration-tests)
-add_dependencies(check-libc libc-integration-tests)
-add_dependencies(check-libc-lit libc-integration-tests-build)
+add_dependencies(check-libc libc-integration-tests-build)
 
 function(add_libc_integration_test_suite name)
   add_custom_target(${name})


### PR DESCRIPTION
Renamed check-libc-lit to check-libc, replacing the old CTest-driven target. Dependencies now use -build targets (e.g. libc-hermetic-tests-build) so that check-libc only builds test executables and delegates execution to lit.