### PR TITLE
[clang] Don't omit null pointer checks with -fms-kernel

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -276,6 +276,8 @@ Modified Compiler Flags
 - The `-mno-outline` and `-moutline` compiler flags are now allowed on RISC-V and X86, which both support the machine outliner.
 - The `-mno-outline` flag will now add the `nooutline` IR attribute, so that
   `-mno-outline` and `-moutline` objects can be mixed correctly during LTO.
+- The `-fms-kernel` flag will now implicitly add -fno-delete-null-pointer-checks.
+  Still -fdelete-null-pointer-checks can be used to override this behavior.
 
 Removed Compiler Flags
 ----------------------

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -3047,10 +3047,10 @@ defm rewrite_includes : BoolFOption<"rewrite-includes",
 defm directives_only : OptInCC1FFlag<"directives-only", "">;
 
 defm delete_null_pointer_checks : BoolFOption<"delete-null-pointer-checks",
-  CodeGenOpts<"NullPointerIsValid">, DefaultFalse,
+  CodeGenOpts<"NullPointerIsValid">, Default<"LangOpts->Kernel">,
   NegFlag<SetTrue, [], [ClangOption, CC1Option],
           "Do not treat usage of null pointers as undefined behavior">,
-  PosFlag<SetFalse, [], [ClangOption], "Treat usage of null pointers as undefined behavior (default)">,
+  PosFlag<SetFalse, [], [ClangOption, CC1Option], "Treat usage of null pointers as undefined behavior (default)">,
   BothFlags<[], [ClangOption, CLOption]>>,
   DocBrief<[{When enabled, treat null pointer dereference, creation of a reference to null,
 or passing a null pointer to a function parameter annotated with the "nonnull"

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1924,11 +1924,6 @@ bool CompilerInvocation::ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args,
     Opts.DIBugsReportFilePath = "";
   }
 
-  if (LangOpts->Kernel &&
-      !Args.hasFlag(OPT_fdelete_null_pointer_checks,
-                    OPT_fno_delete_null_pointer_checks, false))
-    Opts.NullPointerIsValid = true;
-
   Opts.NewStructPathTBAA = !Args.hasArg(OPT_no_struct_path_tbaa) &&
                            Args.hasArg(OPT_new_struct_path_tbaa);
   Opts.OptimizeSize = getOptimizationLevelSize(Args);

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1924,6 +1924,11 @@ bool CompilerInvocation::ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args,
     Opts.DIBugsReportFilePath = "";
   }
 
+  if (LangOpts->Kernel &&
+      !Args.hasFlag(OPT_fdelete_null_pointer_checks,
+                    OPT_fno_delete_null_pointer_checks, false))
+    Opts.NullPointerIsValid = true;
+
   Opts.NewStructPathTBAA = !Args.hasArg(OPT_no_struct_path_tbaa) &&
                            Args.hasArg(OPT_new_struct_path_tbaa);
   Opts.OptimizeSize = getOptimizationLevelSize(Args);

--- a/clang/test/CodeGen/MSKernel/null-deref.c
+++ b/clang/test/CodeGen/MSKernel/null-deref.c
@@ -1,10 +1,10 @@
 // Check that null pointer checks are not omited in kernel mode compilations
-// RUN: %clang_cc1 -fms-kernel -fms-extensions -triple x86_64-pc-windows-msvc -O2 %s -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -fms-kernel -fms-extensions -triple x86_64-pc-windows-msvc %s -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -fms-kernel -fms-extensions -triple x86_64-pc-windows-msvc -fdelete-null-pointer-checks %s -emit-llvm -o - | FileCheck %s --check-prefix=NOCHECK
 
-// CHECK:      define dso_local i32 @process(ptr noundef readonly captures(address_is_null) %p) local_unnamed_addr #0
-// CHECK-NEXT: entry:
-// CHECK-NEXT:   %{{.*}} = icmp eq ptr %p, null
-// CHECK:      attributes #0 = {{.*}} null_pointer_is_valid
+// CHECK: define dso_local i32 @process(ptr noundef %p) #0
+// CHECK: attributes #0 = {{.*}} null_pointer_is_valid
+// NOCHECK-NOT: null_pointer_is_valid
 
 struct Obj { int value; int extra; };
 

--- a/clang/test/CodeGen/MSKernel/null-deref.c
+++ b/clang/test/CodeGen/MSKernel/null-deref.c
@@ -1,0 +1,16 @@
+// Check that null pointer checks are not omited in kernel mode compilations
+// RUN: %clang_cc1 -fms-kernel -fms-extensions -triple x86_64-pc-windows-msvc -O2 %s -emit-llvm -o - | FileCheck %s
+
+// CHECK:      define dso_local i32 @process(ptr noundef readonly captures(address_is_null) %p) local_unnamed_addr #0
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   %{{.*}} = icmp eq ptr %p, null
+// CHECK:      attributes #0 = {{.*}} null_pointer_is_valid
+
+struct Obj { int value; int extra; };
+
+int process(struct Obj* p) {
+    int v = p->value;
+    if (!p)
+        return -1;
+    return v + p->extra;
+}


### PR DESCRIPTION
In kernel space, a null (zero) address may be valid, so treating it as "always invalid" and bypassing null checks is not correct. With -fms-kernel, we override the default behavior and disable assumptions about null pointers.
However, -fdelete-null-pointer-checks can still be used to re-enable these optimizations.