### PR TITLE
Re-apply: workflows: Use main-branch-only environment when using ISSUE_SUBSCRIBER_TOKEN (#179990)

### DIFF
--- a/.github/workflows/issue-subscriber.yml
+++ b/.github/workflows/issue-subscriber.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   auto-subscribe:
+    environment:
+      name: main-branch-only
+      deployment: false
     runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -10,6 +10,9 @@ jobs:
   automate-issues-labels:
     permissions:
       issues: write
+    environment:
+      name: main-branch-only
+      deployment: false
     runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:

--- a/.github/workflows/new-prs.yml
+++ b/.github/workflows/new-prs.yml
@@ -56,6 +56,10 @@ jobs:
   automate-prs-labels:
     # Greet first so that only the author gets that notification.
     needs: greeter
+    # See https://github.blog/changelog/2025-11-07-actions-pull_request_target-and-environment-branch-protections-changes/
+    environment:
+      name: main-branch-only
+      deployment: false
     runs-on: ubuntu-24.04
     # Ignore PRs with more than 10 commits.  Pull requests with a lot of
     # commits tend to be accidents usually when someone made a mistake while trying

--- a/.github/workflows/pr-subscriber.yml
+++ b/.github/workflows/pr-subscriber.yml
@@ -10,6 +10,10 @@ permissions:
 
 jobs:
   auto-subscribe:
+    # See https://github.blog/changelog/2025-11-07-actions-pull_request_target-and-environment-branch-protections-changes/
+    environment:
+      name: main-branch-only
+      deployment: false
     runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:

--- a/.github/workflows/release-asset-audit.yml
+++ b/.github/workflows/release-asset-audit.yml
@@ -46,6 +46,9 @@ jobs:
 
   notify-audit-failed:
     name: "Notify Audit Failed"
+    environment:
+      name: main-branch-only
+      deployment: false
     runs-on: ubuntu-24.04
     if: >-
       github.repository == 'llvm/llvm-project' &&


### PR DESCRIPTION
This way we can prevent the secret from being used in user branches.

We originally reverted this because it was spamming the PRs with 'deployment' messages.  GitHub has added a new feature to disable these messages, so it should be safe to re-apply this.