### PR TITLE
[mlir][spirv] Add missing capabilities for CoopMatrix in TypeExtensionVisitor

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVBase.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVBase.td
@@ -1501,6 +1501,13 @@ def SPIRV_C_Float8EXT : I32EnumAttrCase<"Float8EXT", 4212> {
   ];
 }
 
+def SPIRV_C_Float8CooperativeMatrixEXT                       : I32EnumAttrCase<"Float8CooperativeMatrixEXT", 4213> {
+  list<I32EnumAttrCase> implies = [SPIRV_C_Float8EXT, SPIRV_C_CooperativeMatrixKHR];
+  list<Availability> availability = [
+    Extension<[SPV_EXT_float8]>
+  ];
+}
+
 def SPIRV_CapabilityAttr :
     SPIRV_I32EnumAttr<"Capability", "valid SPIR-V Capability", "capability", [
       SPIRV_C_Matrix, SPIRV_C_Addresses, SPIRV_C_Linkage, SPIRV_C_Kernel, SPIRV_C_Float16,
@@ -1599,7 +1606,7 @@ def SPIRV_CapabilityAttr :
       SPIRV_C_CacheControlsINTEL, SPIRV_C_BFloat16TypeKHR,
       SPIRV_C_BFloat16DotProductKHR, SPIRV_C_BFloat16CooperativeMatrixKHR,
       SPIRV_C_TensorFloat32RoundingINTEL, SPIRV_C_MaskedGatherScatterINTEL,
-      SPIRV_C_Float8EXT
+      SPIRV_C_Float8EXT, SPIRV_C_Float8CooperativeMatrixEXT
     ]>;
 
 def SPIRV_AM_Logical                 : I32EnumAttrCase<"Logical", 0>;

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVTypes.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVTypes.cpp
@@ -307,9 +307,18 @@ void TypeExtensionVisitor::addConcrete(CooperativeMatrixType type) {
 }
 
 void TypeCapabilityVisitor::addConcrete(CooperativeMatrixType type) {
-  add(type.getElementType());
+  Type elementType = type.getElementType();
+  add(elementType);
   static constexpr auto caps = Capability::CooperativeMatrixKHR;
   capabilities.push_back(caps);
+  if (elementType.isBF16()) {
+    static constexpr auto caps = Capability::BFloat16CooperativeMatrixKHR;
+    capabilities.push_back(caps);
+  }
+  if (elementType.isF8E4M3FN() || elementType.isF8E5M2()) {
+    static constexpr auto caps = Capability::Float8CooperativeMatrixEXT;
+    capabilities.push_back(caps);
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/SPIRV/Transforms/vce-deduction.mlir
+++ b/mlir/test/Dialect/SPIRV/Transforms/vce-deduction.mlir
@@ -232,6 +232,45 @@ spirv.module Logical GLSL450 attributes {
   }
 }
 
+// Cooperative matrix with bf16 component type
+// CHECK: requires #spirv.vce<v1.6, [BFloat16TypeKHR, CooperativeMatrixKHR, BFloat16CooperativeMatrixKHR, Shader, Matrix], [SPV_KHR_bfloat16, SPV_KHR_cooperative_matrix]>
+spirv.module Logical GLSL450 attributes {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.6, [Shader, CooperativeMatrixKHR, BFloat16TypeKHR, BFloat16CooperativeMatrixKHR], [SPV_KHR_cooperative_matrix, SPV_KHR_bfloat16]>,
+    #spirv.resource_limits<>
+  >
+} {
+  spirv.func @bf16_coopmatrix(%arg0: !spirv.coopmatrix<4x4xbf16, Subgroup, MatrixA>) -> !spirv.coopmatrix<4x4xbf16, Subgroup, MatrixA> "None" {
+    spirv.ReturnValue %arg0 : !spirv.coopmatrix<4x4xbf16, Subgroup, MatrixA>
+  }
+}
+
+// Cooperative matrix with f8E4M3FN component type
+// CHECK: requires #spirv.vce<v1.6, [Float8EXT, CooperativeMatrixKHR, Float8CooperativeMatrixEXT, Shader, Matrix], [SPV_EXT_float8, SPV_KHR_cooperative_matrix]>
+spirv.module Logical GLSL450 attributes {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.6, [Shader, CooperativeMatrixKHR, Float8EXT, Float8CooperativeMatrixEXT], [SPV_KHR_cooperative_matrix, SPV_EXT_float8]>,
+    #spirv.resource_limits<>
+  >
+} {
+  spirv.func @f8_coopmatrix(%arg0: !spirv.coopmatrix<4x4xf8E4M3FN, Subgroup, MatrixA>) -> !spirv.coopmatrix<4x4xf8E4M3FN, Subgroup, MatrixA> "None" {
+    spirv.ReturnValue %arg0 : !spirv.coopmatrix<4x4xf8E4M3FN, Subgroup, MatrixA>
+  }
+}
+
+// Cooperative matrix with f8E5M2 component type
+// CHECK: requires #spirv.vce<v1.6, [Float8EXT, CooperativeMatrixKHR, Float8CooperativeMatrixEXT, Shader, Matrix], [SPV_EXT_float8, SPV_KHR_cooperative_matrix]>
+spirv.module Logical GLSL450 attributes {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.6, [Shader, CooperativeMatrixKHR, Float8EXT, Float8CooperativeMatrixEXT], [SPV_KHR_cooperative_matrix, SPV_EXT_float8]>,
+    #spirv.resource_limits<>
+  >
+} {
+  spirv.func @f8_coopmatrix(%arg0: !spirv.coopmatrix<4x4xf8E5M2, Subgroup, MatrixA>) -> !spirv.coopmatrix<4x4xf8E5M2, Subgroup, MatrixA> "None" {
+    spirv.ReturnValue %arg0 : !spirv.coopmatrix<4x4xf8E5M2, Subgroup, MatrixA>
+  }
+}
+
 // CHECK: requires #spirv.vce<v1.5, [GraphARM, Int8, TensorsARM, Float16, VulkanMemoryModel], [SPV_ARM_graph, SPV_ARM_tensors, SPV_KHR_vulkan_memory_model]>
 spirv.module Logical Vulkan attributes {
   spirv.target_env = #spirv.target_env<


### PR DESCRIPTION
This adds missing capabilities when CoopMatrix is used with bf16 and fp8.

Assisted-by: Codex