### PR TITLE
[NFC][AMDGPU] Remove `amdgpu-link-time-lds` module flag

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
@@ -1057,8 +1057,6 @@ public:
       }
     }
 
-    M.addModuleFlag(Module::Error, "amdgpu-link-time-lds", 1);
-
     DenseSet<GlobalVariable *> AllLDSVarsForCleanup = AllReplacedVars;
     AllLDSVarsForCleanup.insert(GlobalScopeVars.begin(), GlobalScopeVars.end());
     removeLocalVarsFromUsedLists(M, AllLDSVarsForCleanup);

--- a/llvm/test/CodeGen/AMDGPU/lower-module-lds-link-time-classify.ll
+++ b/llvm/test/CodeGen/AMDGPU/lower-module-lds-link-time-classify.ll
@@ -51,9 +51,6 @@ declare void @extern_func()
 ; CHECK-DAG: !{ptr @my_kernel, ptr addrspace(3) @lds_global}
 ; CHECK-DAG: !{ptr @func, ptr addrspace(3) @lds_global}
 
-; Module should be marked with the link-time LDS module flag.
-; CHECK: !{i32 1, !"amdgpu-link-time-lds", i32 1}
-
 define void @func() {
   %gep1 = getelementptr [64 x i32], ptr addrspace(3) @lds_global, i32 0, i32 0
   store i32 1, ptr addrspace(3) %gep1

--- a/llvm/test/CodeGen/AMDGPU/lower-module-lds-link-time-global-scope.ll
+++ b/llvm/test/CodeGen/AMDGPU/lower-module-lds-link-time-global-scope.ll
@@ -76,9 +76,6 @@ declare void @extern_func()
 ; CHECK-DAG: !{ptr @leaf_func, ptr addrspace(3) @lds_leaf}
 ; CHECK-DAG: !{ptr @direct_kernel, ptr addrspace(3) @lds_direct}
 
-; Module flag.
-; CHECK: !{i32 1, !"amdgpu-link-time-lds", i32 1}
-
 define void @shared_func() {
   %gep = getelementptr [64 x i32], ptr addrspace(3) @lds_shared, i32 0, i32 0
   store i32 1, ptr addrspace(3) %gep

--- a/llvm/test/CodeGen/AMDGPU/lower-module-lds-link-time-internal-func.ll
+++ b/llvm/test/CodeGen/AMDGPU/lower-module-lds-link-time-internal-func.ll
@@ -23,8 +23,6 @@ declare void @extern_func()
 ; CHECK: !amdgpu.lds.uses = !{{{![0-9]+}}}
 ; CHECK-DAG: !{ptr @helper, ptr addrspace(3) @[[STRUCT]]}
 
-; CHECK: !{i32 1, !"amdgpu-link-time-lds", i32 1}
-
 define internal void @helper() {
   %gep = getelementptr [32 x i32], ptr addrspace(3) @lds_priv, i32 0, i32 0
   store i32 1, ptr addrspace(3) %gep

--- a/llvm/test/CodeGen/AMDGPU/lower-module-lds-link-time-internal-multi-user.ll
+++ b/llvm/test/CodeGen/AMDGPU/lower-module-lds-link-time-internal-multi-user.ll
@@ -30,9 +30,6 @@ source_filename = "source_a.hip"
 ; CHECK-DAG: !{ptr @kernel1, ptr addrspace(3) @[[INTERN]]}
 ; CHECK-DAG: !{ptr @kernel2, ptr addrspace(3) @[[INTERN]]}
 
-; Module should be marked with the link-time LDS module flag.
-; CHECK: !{i32 1, !"amdgpu-link-time-lds", i32 1}
-
 define amdgpu_kernel void @kernel1() {
   %gep_a = getelementptr [32 x i32], ptr addrspace(3) @a, i32 0, i32 0
   store i32 1, ptr addrspace(3) %gep_a


### PR DESCRIPTION
We could just use `AMDGPUTargetMachine::EnableObjectLinking` to control. Don't really need this, which is from a previous design where we wanted to let different components to decide whether we want to use object linking independently, but that would not really work.