### PR TITLE
[CIR] Handle explicit instantiation declaration in getVTableLinkage

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -326,6 +326,9 @@ cir::GlobalOp CIRGenVTables::generateConstructionVTable(
   return vtable;
 }
 
+static bool shouldEmitAvailableExternallyVTable(const CIRGenModule &cgm,
+                                                const CXXRecordDecl *rd);
+
 /// Compute the required linkage of the vtable for the given class.
 ///
 /// Note that we only call this at the end of the translation unit.
@@ -369,7 +372,8 @@ cir::GlobalLinkageKind CIRGenModule::getVTableLinkage(const CXXRecordDecl *rd) {
       return cir::GlobalLinkageKind::WeakODRLinkage;
 
     case TSK_ExplicitInstantiationDeclaration:
-      llvm_unreachable("Should not have been asked to emit this");
+      return !def ? cir::GlobalLinkageKind::AvailableExternallyLinkage
+                  : cir::GlobalLinkageKind::ExternalLinkage;
     }
   }
   // -fapple-kext mode does not support weak linkage, so we must use
@@ -395,11 +399,14 @@ cir::GlobalLinkageKind CIRGenModule::getVTableLinkage(const CXXRecordDecl *rd) {
   case TSK_ImplicitInstantiation:
     return discardableODRLinkage;
 
-  case TSK_ExplicitInstantiationDeclaration: {
-    errorNYI(rd->getSourceRange(),
-             "getVTableLinkage: explicit instantiation declaration");
-    return cir::GlobalLinkageKind::ExternalLinkage;
-  }
+  case TSK_ExplicitInstantiationDeclaration:
+    // Explicit instantiations in MSVC do not provide vtables, so we must emit
+    // our own.
+    if (getTarget().getCXXABI().isMicrosoft())
+      return discardableODRLinkage;
+    return shouldEmitAvailableExternallyVTable(*this, rd)
+               ? cir::GlobalLinkageKind::AvailableExternallyLinkage
+               : cir::GlobalLinkageKind::ExternalLinkage;
 
   case TSK_ExplicitInstantiationDefinition:
     return nonDiscardableODRLinkage;

--- a/clang/test/CIR/CodeGen/vtable-linkage-explicit-instantiation.cpp
+++ b/clang/test/CIR/CodeGen/vtable-linkage-explicit-instantiation.cpp
@@ -1,0 +1,62 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+template <typename T>
+struct Base {
+  virtual ~Base() {}
+  virtual void foo() {}
+  T val;
+};
+
+extern template class Base<int>;
+
+void use(Base<int> *p) {
+  p->foo();
+}
+
+// Constructing a Base<int> forces the vtable to be emitted.
+Base<int> make_base() {
+  Base<int> b;
+  return b;
+}
+
+// Class with a key function (out-of-line virtual destructor).
+template <typename T>
+struct KeyBase {
+  virtual ~KeyBase();
+  T val;
+};
+
+template <typename T> KeyBase<T>::~KeyBase() {}
+
+extern template class KeyBase<int>;
+
+void use_key() {
+  KeyBase<int> k;
+  (void)k;
+}
+
+// Base has no key function and extern template declaration, so the vtable
+// gets external linkage.
+// CHECK: cir.global "private" external @_ZTV4BaseIiE
+
+// The key function (~KeyBase) is not instantiated in this TU, so the vtable
+// also gets external linkage.
+// CHECK: cir.global "private" external @_ZTV7KeyBaseIiE
+
+// Verify the virtual call goes through the vtable.
+// CHECK: cir.func {{.*}} @_Z3useP4BaseIiE
+// CHECK:   cir.vtable.get_vptr
+// CHECK:   cir.vtable.get_virtual_fn_addr
+
+// LLVM: @_ZTV4BaseIiE = external global
+// LLVM: @_ZTV7KeyBaseIiE = external global
+// LLVM: define {{.*}} @_Z3useP4BaseIiE
+
+// OGCG: @_ZTV4BaseIiE = external unnamed_addr constant
+// OGCG: @_ZTV7KeyBaseIiE = external unnamed_addr constant
+// OGCG: define {{.*}} @_Z3useP4BaseIiE


### PR DESCRIPTION
Replace errorNYI for TSK_ExplicitInstantiationDeclaration with the correct linkage logic: use discardable ODR linkage for MSVC, and for Itanium choose between AvailableExternallyLinkage (when the vtable can be speculatively emitted) or ExternalLinkage.

Fixes point 3 of #192330.