### PR TITLE
[mlir][python] Make type casters in NanobindAdaptors.h faster.

### DIFF
--- a/mlir/include/mlir-c/Bindings/Python/Interop.h
+++ b/mlir/include/mlir-c/Bindings/Python/Interop.h
@@ -57,6 +57,62 @@
 #define MAKE_MLIR_PYTHON_QUALNAME(local)                                       \
   MLIR_PYTHON_STRINGIZE_ARG(MLIR_PYTHON_PACKAGE_PREFIX) local
 
+#define MLIR_PYTHON_CAPSULE_AFFINE_MAP_WRAP                                    \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.AffineMap._CAPIWrap")
+#define MLIR_PYTHON_CAPSULE_AFFINE_MAP_UNWRAP                                  \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.AffineMap._CAPIUnwrap")
+
+#define MLIR_PYTHON_CAPSULE_ATTRIBUTE_WRAP                                     \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Attribute._CAPIWrap")
+#define MLIR_PYTHON_CAPSULE_ATTRIBUTE_UNWRAP                                   \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Attribute._CAPIUnwrap")
+
+#define MLIR_PYTHON_CAPSULE_BLOCK_UNWRAP                                       \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Block._CAPIUnwrap")
+
+#define MLIR_PYTHON_CAPSULE_CONTEXT_UNWRAP                                     \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Context._CAPIUnwrap")
+
+#define MLIR_PYTHON_CAPSULE_DIALECT_REGISTRY_WRAP                              \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.DialectRegistry._CAPIWrap")
+#define MLIR_PYTHON_CAPSULE_DIALECT_REGISTRY_UNWRAP                            \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.DialectRegistry._CAPIUnwrap")
+
+#define MLIR_PYTHON_CAPSULE_LOCATION_WRAP                                      \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Location._CAPIWrap")
+#define MLIR_PYTHON_CAPSULE_LOCATION_UNWRAP                                    \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Location._CAPIUnwrap")
+
+#define MLIR_PYTHON_CAPSULE_MODULE_WRAP                                        \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Module._CAPIWrap")
+#define MLIR_PYTHON_CAPSULE_MODULE_UNWRAP                                      \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Module._CAPIUnwrap")
+
+#define MLIR_PYTHON_CAPSULE_OPERATION_WRAP                                     \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Operation._CAPIWrap")
+#define MLIR_PYTHON_CAPSULE_OPERATION_UNWRAP                                   \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Operation._CAPIUnwrap")
+
+#define MLIR_PYTHON_CAPSULE_TYPE_WRAP                                          \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Type._CAPIWrap")
+#define MLIR_PYTHON_CAPSULE_TYPE_UNWRAP                                        \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Type._CAPIUnwrap")
+
+#define MLIR_PYTHON_CAPSULE_VALUE_WRAP                                         \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Value._CAPIWrap")
+#define MLIR_PYTHON_CAPSULE_VALUE_UNWRAP                                       \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.Value._CAPIUnwrap")
+
+#define MLIR_PYTHON_CAPSULE_TYPEID_WRAP                                        \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.TypeID._CAPIWrap")
+#define MLIR_PYTHON_CAPSULE_TYPEID_UNWRAP                                      \
+  MAKE_MLIR_PYTHON_QUALNAME("ir.TypeID._CAPIUnwrap")
+
+#define MLIR_PYTHON_CAPSULE_FROZEN_REWRITE_PATTERN_SET_WRAP                    \
+  MAKE_MLIR_PYTHON_QUALNAME("rewrite.FrozenRewritePatternSet._CAPIWrap")
+#define MLIR_PYTHON_CAPSULE_FROZEN_REWRITE_PATTERN_SET_UNWRAP                  \
+  MAKE_MLIR_PYTHON_QUALNAME("rewrite.FrozenRewritePatternSet._CAPIUnwrap")
+
 #define MLIR_PYTHON_CAPSULE_AFFINE_EXPR                                        \
   MAKE_MLIR_PYTHON_QUALNAME("ir.AffineExpr._CAPIPtr")
 #define MLIR_PYTHON_CAPSULE_AFFINE_MAP                                         \
@@ -116,6 +172,16 @@
  * (possibly) be an instance of the subclass.
  */
 #define MLIR_PYTHON_MAYBE_DOWNCAST_ATTR "maybe_downcast"
+
+/** Attribute on MLIR Python objects that exposes a capsule wrapping a
+ * function pointer for wrapping the corresponding C-API pointer.
+ * The signature of the function is: def _CAPIWrap(capsule) -> object */
+#define MLIR_PYTHON_CAPI_WRAP_ATTR "_CAPIWrap"
+
+/** Attribute on MLIR Python objects that exposes a capsule wrapping a
+ * function pointer for unwrapping the corresponding Python object.
+ * The signature of the function is: def _CAPIUnwrap(object) -> capsule */
+#define MLIR_PYTHON_CAPI_UNWRAP_ATTR "_CAPIUnwrap"
 
 /** Attribute on main C extension module (_mlir) that corresponds to the
  * type caster registration binding. The signature of the function is:

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -222,6 +222,8 @@ public:
 
   /// Accesses the underlying MlirContext.
   MlirContext get() { return context; }
+  static PyObject *wrap(MlirContext ctx);
+  static MlirContext unwrap(PyObject *obj);
 
   /// Gets a strong reference to this context, which will ensure it is kept
   /// alive for the life of the reference.
@@ -321,6 +323,8 @@ public:
 
   operator MlirLocation() const { return loc; }
   MlirLocation get() const { return loc; }
+  static PyObject *wrap(MlirLocation v);
+  static MlirLocation unwrap(PyObject *obj);
 
   /// Enter and exit the context manager.
   static nanobind::object contextEnter(nanobind::object location);
@@ -523,6 +527,8 @@ public:
 
   operator MlirDialectRegistry() const { return registry; }
   MlirDialectRegistry get() const { return registry; }
+  static PyObject *wrap(MlirDialectRegistry v);
+  static MlirDialectRegistry unwrap(PyObject *obj);
 
   nanobind::object getCapsule();
   static PyDialectRegistry createFromCapsule(nanobind::object capsule);
@@ -552,6 +558,8 @@ public:
   /// Returns a PyModule reference for the given MlirModule. This always returns
   /// a new object.
   static PyModuleRef forModule(MlirModule module);
+  static PyObject *wrap(MlirModule v);
+  static MlirModule unwrap(PyObject *obj);
   PyModule(PyModule &) = delete;
   PyModule(PyMlirContext &&) = delete;
   ~PyModule();
@@ -645,6 +653,8 @@ class MLIR_PYTHON_API_EXPORTED PyOperation : public PyOperationBase,
 public:
   ~PyOperation() override;
   PyOperation &getOperation() override { return *this; }
+  static PyObject *wrap(MlirOperation v);
+  static MlirOperation unwrap(PyObject *obj);
 
   /// Returns a PyOperation for the given MlirOperation, optionally associating
   /// it with a parentKeepAlive.
@@ -830,6 +840,8 @@ public:
 
   void checkValid() { return parentOperation->checkValid(); }
 
+  static MlirBlock unwrap(PyObject *obj);
+
   /// Gets a capsule wrapping the void* within the MlirBlock.
   nanobind::object getCapsule();
 
@@ -891,6 +903,8 @@ public:
   bool operator==(const PyType &other) const;
   operator MlirType() const { return type; }
   MlirType get() const { return type; }
+  static PyObject *wrap(MlirType v);
+  static MlirType unwrap(PyObject *obj);
 
   /// Gets a capsule wrapping the void* within the MlirType.
   nanobind::object getCapsule();
@@ -925,6 +939,9 @@ public:
 
   /// Creates a PyTypeID from the MlirTypeID wrapped by a capsule.
   static PyTypeID createFromCapsule(nanobind::object capsule);
+
+  static PyObject *wrap(MlirTypeID typeID);
+  static MlirTypeID unwrap(PyObject *obj);
 
 private:
   MlirTypeID typeID;
@@ -1018,6 +1035,8 @@ public:
   bool operator==(const PyAttribute &other) const;
   operator MlirAttribute() const { return attr; }
   MlirAttribute get() const { return attr; }
+  static PyObject *wrap(MlirAttribute v);
+  static MlirAttribute unwrap(PyObject *obj);
 
   /// Gets a capsule wrapping the void* within the MlirAttribute.
   nanobind::object getCapsule();
@@ -1184,6 +1203,8 @@ public:
 
   MlirValue get() { return value; }
   PyOperationRef &getParentOperation() { return parentOperation; }
+  static PyObject *wrap(MlirValue v);
+  static MlirValue unwrap(PyObject *obj);
 
   void checkValid() { return parentOperation->checkValid(); }
 
@@ -1240,6 +1261,8 @@ public:
   bool operator==(const PyAffineMap &other) const;
   operator MlirAffineMap() const { return affineMap; }
   MlirAffineMap get() const { return affineMap; }
+  static PyObject *wrap(MlirAffineMap v);
+  static MlirAffineMap unwrap(PyObject *obj);
 
   /// Gets a capsule wrapping the void* within the MlirAffineMap.
   nanobind::object getCapsule();
@@ -1872,11 +1895,11 @@ MLIR_PYTHON_API_EXPORTED void populateRoot(nanobind::module_ &m);
 template <class Func, typename... Args>
 inline nanobind::object classmethod(Func f, Args... args) {
   nanobind::object cf = nanobind::cpp_function(f, args...);
-  static SafeInit<nanobind::object> classmethodFn([]() {
+  static SafeInit<nanobind::object> classmethodFn;
+  return classmethodFn.get([]() {
     return std::make_unique<nanobind::object>(
         nanobind::module_::import_("builtins").attr("classmethod"));
-  });
-  return classmethodFn.get()(cf);
+  })(cf);
 }
 
 } // namespace MLIR_BINDINGS_PYTHON_DOMAIN

--- a/mlir/include/mlir/Bindings/Python/NanobindAdaptors.h
+++ b/mlir/include/mlir/Bindings/Python/NanobindAdaptors.h
@@ -33,14 +33,46 @@
 
 namespace mlir {
 namespace python {
+
 namespace {
 
 nanobind::module_ &irModule() {
-  static SafeInit<nanobind::module_> init([]() {
+  static SafeInit<nanobind::module_> init;
+  return init.get([]() {
     return std::make_unique<nanobind::module_>(
         nanobind::module_::import_(MAKE_MLIR_PYTHON_QUALNAME("ir")));
   });
-  return init.get();
+}
+
+template <typename FuncPtr>
+std::unique_ptr<FuncPtr> getUnwrapFunc(nanobind::handle src,
+                                       const char *capsuleName) {
+  nanobind::object capsule = nanobind::getattr(
+      src.type(), MLIR_PYTHON_CAPI_UNWRAP_ATTR, nanobind::none());
+  if (!capsule.is_none()) {
+    auto ptr = reinterpret_cast<FuncPtr>(
+        PyCapsule_GetPointer(capsule.ptr(), capsuleName));
+    return std::make_unique<FuncPtr>(ptr);
+  }
+  return std::make_unique<FuncPtr>(nullptr);
+}
+
+template <typename FuncPtr>
+std::unique_ptr<FuncPtr> getWrapFunc(nanobind::handle mod,
+                                     const char *className,
+                                     const char *capsuleName) {
+  auto ptr = std::make_unique<FuncPtr>(nullptr);
+  nanobind::object cls = nanobind::getattr(mod, className, nanobind::none());
+  if (cls.is_none())
+    return ptr;
+
+  nanobind::object capsule =
+      nanobind::getattr(cls, MLIR_PYTHON_CAPI_WRAP_ATTR, nanobind::none());
+  if (!capsule.is_none()) {
+    *ptr = reinterpret_cast<FuncPtr>(
+        PyCapsule_GetPointer(capsule.ptr(), capsuleName));
+  }
+  return ptr;
 }
 
 } // namespace
@@ -94,6 +126,16 @@ struct type_caster<MlirAffineMap> {
   NB_TYPE_CASTER(MlirAffineMap,
                  const_name(MAKE_MLIR_PYTHON_QUALNAME("ir.AffineMap")))
   bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+    using FuncPtr = MlirAffineMap (*)(PyObject *);
+    static mlir::python::SafeInit<FuncPtr> unwrap_init;
+    FuncPtr unwrap_func = unwrap_init.get([&]() {
+      return mlir::python::getUnwrapFunc<FuncPtr>(
+          src, MLIR_PYTHON_CAPSULE_AFFINE_MAP_UNWRAP);
+    });
+    if (unwrap_func) {
+      value = unwrap_func(src.ptr());
+      return pyErrClearIfFalse(!mlirAffineMapIsNull(value));
+    }
     if (auto capsule = mlirApiObjectToCapsule(src)) {
       value = mlirPythonCapsuleToAffineMap(capsule->ptr());
       return pyErrClearIfFalse(!mlirAffineMapIsNull(value));
@@ -102,6 +144,18 @@ struct type_caster<MlirAffineMap> {
   }
   static handle from_cpp(MlirAffineMap v, rv_policy,
                          cleanup_list *cleanup) noexcept {
+    if (v.ptr == nullptr)
+      return nanobind::none();
+    using FuncPtr = PyObject *(*)(MlirAffineMap);
+    static mlir::python::SafeInit<FuncPtr> wrap_init;
+    FuncPtr wrap_func = wrap_init.get([]() {
+      return mlir::python::getWrapFunc<FuncPtr>(
+          mlir::python::irModule(), "AffineMap",
+          MLIR_PYTHON_CAPSULE_AFFINE_MAP_WRAP);
+    });
+    if (wrap_func) {
+      return handle(wrap_func(v));
+    }
     nanobind::object capsule =
         nanobind::steal<nanobind::object>(mlirPythonAffineMapToCapsule(v));
     return mlir::python::irModule()
@@ -117,6 +171,16 @@ struct type_caster<MlirAttribute> {
   NB_TYPE_CASTER(MlirAttribute,
                  const_name(MAKE_MLIR_PYTHON_QUALNAME("ir.Attribute")))
   bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+    using FuncPtr = MlirAttribute (*)(PyObject *);
+    static mlir::python::SafeInit<FuncPtr> unwrap_init;
+    FuncPtr unwrap_func = unwrap_init.get([&]() {
+      return mlir::python::getUnwrapFunc<FuncPtr>(
+          src, MLIR_PYTHON_CAPSULE_ATTRIBUTE_UNWRAP);
+    });
+    if (unwrap_func) {
+      value = unwrap_func(src.ptr());
+      return pyErrClearIfFalse(!mlirAttributeIsNull(value));
+    }
     if (auto capsule = mlirApiObjectToCapsule(src)) {
       value = mlirPythonCapsuleToAttribute(capsule->ptr());
       return pyErrClearIfFalse(!mlirAttributeIsNull(value));
@@ -125,6 +189,18 @@ struct type_caster<MlirAttribute> {
   }
   static handle from_cpp(MlirAttribute v, rv_policy,
                          cleanup_list *cleanup) noexcept {
+    if (v.ptr == nullptr)
+      return nanobind::none();
+    using FuncPtr = PyObject *(*)(MlirAttribute);
+    static mlir::python::SafeInit<FuncPtr> wrap_init;
+    FuncPtr wrap_func = wrap_init.get([]() {
+      return mlir::python::getWrapFunc<FuncPtr>(
+          mlir::python::irModule(), "Attribute",
+          MLIR_PYTHON_CAPSULE_ATTRIBUTE_WRAP);
+    });
+    if (wrap_func) {
+      return handle(wrap_func(v));
+    }
     nanobind::object capsule =
         nanobind::steal<nanobind::object>(mlirPythonAttributeToCapsule(v));
     return mlir::python::irModule()
@@ -140,6 +216,17 @@ template <>
 struct type_caster<MlirBlock> {
   NB_TYPE_CASTER(MlirBlock, const_name(MAKE_MLIR_PYTHON_QUALNAME("ir.Block")))
   bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+    using FuncPtr = MlirBlock (*)(PyObject *);
+    static mlir::python::SafeInit<FuncPtr> unwrap_init;
+    FuncPtr unwrap_func = unwrap_init.get([&]() {
+      return mlir::python::getUnwrapFunc<FuncPtr>(
+          src, MLIR_PYTHON_CAPSULE_BLOCK_UNWRAP);
+    });
+
+    if (unwrap_func) {
+      value = unwrap_func(src.ptr());
+      return pyErrClearIfFalse(!mlirBlockIsNull(value));
+    }
     if (auto capsule = mlirApiObjectToCapsule(src)) {
       value = mlirPythonCapsuleToBlock(capsule->ptr());
       return pyErrClearIfFalse(!mlirBlockIsNull(value));
@@ -154,6 +241,20 @@ struct type_caster<MlirContext> {
   NB_TYPE_CASTER(MlirContext,
                  const_name(MAKE_MLIR_PYTHON_QUALNAME("ir.Context")))
   bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+    using FuncPtr = MlirContext (*)(PyObject *);
+    static mlir::python::SafeInit<FuncPtr> unwrap_init;
+    FuncPtr unwrap_func = unwrap_init.get([&]() {
+      return mlir::python::getUnwrapFunc<FuncPtr>(
+          src, MLIR_PYTHON_CAPSULE_CONTEXT_UNWRAP);
+    });
+
+    if (unwrap_func) {
+      value = unwrap_func(src.ptr());
+      if (!mlirContextIsNull(value)) {
+        return true;
+      }
+      PyErr_Clear();
+    }
     if (src.is_none()) {
       // Gets the current thread-bound context.
       src = mlir::python::irModule().attr("Context").attr("current");
@@ -182,6 +283,17 @@ struct type_caster<MlirDialectRegistry> {
   NB_TYPE_CASTER(MlirDialectRegistry,
                  const_name(MAKE_MLIR_PYTHON_QUALNAME("ir.DialectRegistry")))
   bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+    using FuncPtr = MlirDialectRegistry (*)(PyObject *);
+    static mlir::python::SafeInit<FuncPtr> unwrap_init;
+    FuncPtr unwrap_func = unwrap_init.get([&]() {
+      return mlir::python::getUnwrapFunc<FuncPtr>(
+          src, MLIR_PYTHON_CAPSULE_DIALECT_REGISTRY_UNWRAP);
+    });
+
+    if (unwrap_func) {
+      value = unwrap_func(src.ptr());
+      return pyErrClearIfFalse(!mlirDialectRegistryIsNull(value));
+    }
     if (auto capsule = mlirApiObjectToCapsule(src)) {
       value = mlirPythonCapsuleToDialectRegistry(capsule->ptr());
       return pyErrClearIfFalse(!mlirDialectRegistryIsNull(value));
@@ -190,6 +302,18 @@ struct type_caster<MlirDialectRegistry> {
   }
   static handle from_cpp(MlirDialectRegistry v, rv_policy,
                          cleanup_list *cleanup) noexcept {
+    if (v.ptr == nullptr)
+      return nanobind::none();
+    using FuncPtr = PyObject *(*)(MlirDialectRegistry);
+    static mlir::python::SafeInit<FuncPtr> wrap_init;
+    FuncPtr wrap_func = wrap_init.get([]() {
+      return mlir::python::getWrapFunc<FuncPtr>(
+          mlir::python::irModule(), "DialectRegistry",
+          MLIR_PYTHON_CAPSULE_DIALECT_REGISTRY_WRAP);
+    });
+    if (wrap_func) {
+      return handle(wrap_func(v));
+    }
     nanobind::object capsule = nanobind::steal<nanobind::object>(
         mlirPythonDialectRegistryToCapsule(v));
     return mlir::python::irModule()
@@ -205,6 +329,17 @@ struct type_caster<MlirLocation> {
   NB_TYPE_CASTER(MlirLocation,
                  const_name(MAKE_MLIR_PYTHON_QUALNAME("ir.Location")))
   bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+    using FuncPtr = MlirLocation (*)(PyObject *);
+    static mlir::python::SafeInit<FuncPtr> unwrap_init;
+    FuncPtr unwrap_func = unwrap_init.get([&]() {
+      return mlir::python::getUnwrapFunc<FuncPtr>(
+          src, MLIR_PYTHON_CAPSULE_LOCATION_UNWRAP);
+    });
+
+    if (unwrap_func) {
+      value = unwrap_func(src.ptr());
+      return pyErrClearIfFalse(!mlirLocationIsNull(value));
+    }
     if (src.is_none()) {
       // Gets the current thread-bound context.
       src = mlir::python::irModule().attr("Location").attr("current");
@@ -217,6 +352,18 @@ struct type_caster<MlirLocation> {
   }
   static handle from_cpp(MlirLocation v, rv_policy,
                          cleanup_list *cleanup) noexcept {
+    if (v.ptr == nullptr)
+      return nanobind::none();
+    using FuncPtr = PyObject *(*)(MlirLocation);
+    static mlir::python::SafeInit<FuncPtr> wrap_init;
+    FuncPtr wrap_func = wrap_init.get([]() {
+      return mlir::python::getWrapFunc<FuncPtr>(
+          mlir::python::irModule(), "Location",
+          MLIR_PYTHON_CAPSULE_LOCATION_WRAP);
+    });
+    if (wrap_func) {
+      return handle(wrap_func(v));
+    }
     nanobind::object capsule =
         nanobind::steal<nanobind::object>(mlirPythonLocationToCapsule(v));
     return mlir::python::irModule()
@@ -231,6 +378,17 @@ template <>
 struct type_caster<MlirModule> {
   NB_TYPE_CASTER(MlirModule, const_name(MAKE_MLIR_PYTHON_QUALNAME("ir.Module")))
   bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+    using FuncPtr = MlirModule (*)(PyObject *);
+    static mlir::python::SafeInit<FuncPtr> unwrap_init;
+    FuncPtr unwrap_func = unwrap_init.get([&]() {
+      return mlir::python::getUnwrapFunc<FuncPtr>(
+          src, MLIR_PYTHON_CAPSULE_MODULE_UNWRAP);
+    });
+
+    if (unwrap_func) {
+      value = unwrap_func(src.ptr());
+      return pyErrClearIfFalse(!mlirModuleIsNull(value));
+    }
     if (auto capsule = mlirApiObjectToCapsule(src)) {
       value = mlirPythonCapsuleToModule(capsule->ptr());
       return pyErrClearIfFalse(!mlirModuleIsNull(value));
@@ -239,13 +397,24 @@ struct type_caster<MlirModule> {
   }
   static handle from_cpp(MlirModule v, rv_policy,
                          cleanup_list *cleanup) noexcept {
+    if (v.ptr == nullptr)
+      return nanobind::none();
+    using FuncPtr = PyObject *(*)(MlirModule);
+    static mlir::python::SafeInit<FuncPtr> wrap_init;
+    FuncPtr wrap_func = wrap_init.get([]() {
+      return mlir::python::getWrapFunc<FuncPtr>(
+          mlir::python::irModule(), "Module", MLIR_PYTHON_CAPSULE_MODULE_WRAP);
+    });
+    if (wrap_func) {
+      return handle(wrap_func(v));
+    }
     nanobind::object capsule =
         nanobind::steal<nanobind::object>(mlirPythonModuleToCapsule(v));
     return mlir::python::irModule()
         .attr("Module")
         .attr(MLIR_PYTHON_CAPI_FACTORY_ATTR)(capsule)
         .release();
-  };
+  }
 };
 
 /// Casts object <-> MlirFrozenRewritePatternSet.
@@ -253,8 +422,19 @@ template <>
 struct type_caster<MlirFrozenRewritePatternSet> {
   NB_TYPE_CASTER(
       MlirFrozenRewritePatternSet,
-      const_name(MAKE_MLIR_PYTHON_QUALNAME("rewrite.FrozenRewritePatternSet")))
+      const_name("mlir._mlir_libs._mlir.rewrite.FrozenRewritePatternSet"))
   bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+    using FuncPtr = MlirFrozenRewritePatternSet (*)(PyObject *);
+    static mlir::python::SafeInit<FuncPtr> unwrap_init;
+    FuncPtr unwrap_func = unwrap_init.get([&]() {
+      return mlir::python::getUnwrapFunc<FuncPtr>(
+          src, MLIR_PYTHON_CAPSULE_FROZEN_REWRITE_PATTERN_SET_UNWRAP);
+    });
+
+    if (unwrap_func) {
+      value = unwrap_func(src.ptr());
+      return pyErrClearIfFalse(value.ptr != nullptr);
+    }
     if (auto capsule = mlirApiObjectToCapsule(src)) {
       value = mlirPythonCapsuleToFrozenRewritePatternSet(capsule->ptr());
       return pyErrClearIfFalse(value.ptr != nullptr);
@@ -262,14 +442,34 @@ struct type_caster<MlirFrozenRewritePatternSet> {
     return false;
   }
   static handle from_cpp(MlirFrozenRewritePatternSet v, rv_policy,
-                         handle) noexcept {
+                         cleanup_list *cleanup) noexcept {
+    if (v.ptr == nullptr)
+      return nanobind::none();
+    using FuncPtr = PyObject *(*)(MlirFrozenRewritePatternSet);
+    static mlir::python::SafeInit<FuncPtr> wrap_init;
+    FuncPtr wrap_func = wrap_init.get([]() {
+      auto ptr = std::make_unique<FuncPtr>(nullptr);
+      PyObject *mod_ptr =
+          PyImport_ImportModule(MAKE_MLIR_PYTHON_QUALNAME("rewrite"));
+      if (!mod_ptr) {
+        PyErr_Clear();
+        return ptr;
+      }
+      nanobind::object mod = nanobind::steal<nanobind::object>(mod_ptr);
+      return mlir::python::getWrapFunc<FuncPtr>(
+          mod, "FrozenRewritePatternSet",
+          MLIR_PYTHON_CAPSULE_FROZEN_REWRITE_PATTERN_SET_WRAP);
+    });
+    if (wrap_func) {
+      return handle(wrap_func(v));
+    }
     nanobind::object capsule = nanobind::steal<nanobind::object>(
         mlirPythonFrozenRewritePatternSetToCapsule(v));
     return nanobind::module_::import_(MAKE_MLIR_PYTHON_QUALNAME("rewrite"))
         .attr("FrozenRewritePatternSet")
         .attr(MLIR_PYTHON_CAPI_FACTORY_ATTR)(capsule)
         .release();
-  };
+  }
 };
 
 /// Casts object <-> MlirOperation.
@@ -278,6 +478,17 @@ struct type_caster<MlirOperation> {
   NB_TYPE_CASTER(MlirOperation,
                  const_name(MAKE_MLIR_PYTHON_QUALNAME("ir.Operation")))
   bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+    using FuncPtr = MlirOperation (*)(PyObject *);
+    static mlir::python::SafeInit<FuncPtr> unwrap_init;
+    FuncPtr unwrap_func = unwrap_init.get([&]() {
+      return mlir::python::getUnwrapFunc<FuncPtr>(
+          src, MLIR_PYTHON_CAPSULE_OPERATION_UNWRAP);
+    });
+
+    if (unwrap_func) {
+      value = unwrap_func(src.ptr());
+      return pyErrClearIfFalse(!mlirOperationIsNull(value));
+    }
     if (auto capsule = mlirApiObjectToCapsule(src)) {
       value = mlirPythonCapsuleToOperation(capsule->ptr());
       return pyErrClearIfFalse(!mlirOperationIsNull(value));
@@ -288,13 +499,23 @@ struct type_caster<MlirOperation> {
                          cleanup_list *cleanup) noexcept {
     if (v.ptr == nullptr)
       return nanobind::none();
+    using FuncPtr = PyObject *(*)(MlirOperation);
+    static mlir::python::SafeInit<FuncPtr> wrap_init;
+    FuncPtr wrap_func = wrap_init.get([]() {
+      return mlir::python::getWrapFunc<FuncPtr>(
+          mlir::python::irModule(), "Operation",
+          MLIR_PYTHON_CAPSULE_OPERATION_WRAP);
+    });
+    if (wrap_func) {
+      return handle(wrap_func(v));
+    }
     nanobind::object capsule =
         nanobind::steal<nanobind::object>(mlirPythonOperationToCapsule(v));
     return mlir::python::irModule()
         .attr("Operation")
         .attr(MLIR_PYTHON_CAPI_FACTORY_ATTR)(capsule)
         .release();
-  };
+  }
 };
 
 /// Casts object <-> MlirValue.
@@ -302,6 +523,16 @@ template <>
 struct type_caster<MlirValue> {
   NB_TYPE_CASTER(MlirValue, const_name(MAKE_MLIR_PYTHON_QUALNAME("ir.Value")))
   bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+    using FuncPtr = MlirValue (*)(PyObject *);
+    static mlir::python::SafeInit<FuncPtr> unwrap_init;
+    FuncPtr unwrap_func = unwrap_init.get([&]() {
+      return mlir::python::getUnwrapFunc<FuncPtr>(
+          src, MLIR_PYTHON_CAPSULE_VALUE_UNWRAP);
+    });
+    if (unwrap_func) {
+      value = unwrap_func(src.ptr());
+      return pyErrClearIfFalse(!mlirValueIsNull(value));
+    }
     if (auto capsule = mlirApiObjectToCapsule(src)) {
       value = mlirPythonCapsuleToValue(capsule->ptr());
       return pyErrClearIfFalse(!mlirValueIsNull(value));
@@ -312,6 +543,15 @@ struct type_caster<MlirValue> {
                          cleanup_list *cleanup) noexcept {
     if (v.ptr == nullptr)
       return nanobind::none();
+    using FuncPtr = PyObject *(*)(MlirValue);
+    static mlir::python::SafeInit<FuncPtr> wrap_init;
+    FuncPtr wrap_func = wrap_init.get([]() {
+      return mlir::python::getWrapFunc<FuncPtr>(
+          mlir::python::irModule(), "Value", MLIR_PYTHON_CAPSULE_VALUE_WRAP);
+    });
+    if (wrap_func) {
+      return handle(wrap_func(v));
+    }
     nanobind::object capsule =
         nanobind::steal<nanobind::object>(mlirPythonValueToCapsule(v));
     return mlir::python::irModule()
@@ -319,7 +559,7 @@ struct type_caster<MlirValue> {
         .attr(MLIR_PYTHON_CAPI_FACTORY_ATTR)(capsule)
         .attr(MLIR_PYTHON_MAYBE_DOWNCAST_ATTR)()
         .release();
-  };
+  }
 };
 
 /// Casts object -> MlirPassManager.
@@ -341,6 +581,17 @@ template <>
 struct type_caster<MlirTypeID> {
   NB_TYPE_CASTER(MlirTypeID, const_name(MAKE_MLIR_PYTHON_QUALNAME("ir.TypeID")))
   bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+    using FuncPtr = MlirTypeID (*)(PyObject *);
+    static mlir::python::SafeInit<FuncPtr> unwrap_init;
+    FuncPtr unwrap_func = unwrap_init.get([&]() {
+      return mlir::python::getUnwrapFunc<FuncPtr>(
+          src, MLIR_PYTHON_CAPSULE_TYPEID_UNWRAP);
+    });
+
+    if (unwrap_func) {
+      value = unwrap_func(src.ptr());
+      return pyErrClearIfFalse(!mlirTypeIDIsNull(value));
+    }
     if (auto capsule = mlirApiObjectToCapsule(src)) {
       value = mlirPythonCapsuleToTypeID(capsule->ptr());
       return pyErrClearIfFalse(!mlirTypeIDIsNull(value));
@@ -351,13 +602,22 @@ struct type_caster<MlirTypeID> {
                          cleanup_list *cleanup) noexcept {
     if (v.ptr == nullptr)
       return nanobind::none();
+    using FuncPtr = PyObject *(*)(MlirTypeID);
+    static mlir::python::SafeInit<FuncPtr> wrap_init;
+    FuncPtr wrap_func = wrap_init.get([]() {
+      return mlir::python::getWrapFunc<FuncPtr>(
+          mlir::python::irModule(), "TypeID", MLIR_PYTHON_CAPSULE_TYPEID_WRAP);
+    });
+    if (wrap_func) {
+      return handle(wrap_func(v));
+    }
     nanobind::object capsule =
         nanobind::steal<nanobind::object>(mlirPythonTypeIDToCapsule(v));
     return mlir::python::irModule()
         .attr("TypeID")
         .attr(MLIR_PYTHON_CAPI_FACTORY_ATTR)(capsule)
         .release();
-  };
+  }
 };
 
 /// Casts object <-> MlirType.
@@ -365,6 +625,17 @@ template <>
 struct type_caster<MlirType> {
   NB_TYPE_CASTER(MlirType, const_name(MAKE_MLIR_PYTHON_QUALNAME("ir.Type")))
   bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+    using FuncPtr = MlirType (*)(PyObject *);
+    static mlir::python::SafeInit<FuncPtr> unwrap_init;
+    FuncPtr unwrap_func = unwrap_init.get([&]() {
+      return mlir::python::getUnwrapFunc<FuncPtr>(
+          src, MLIR_PYTHON_CAPSULE_TYPE_UNWRAP);
+    });
+
+    if (unwrap_func) {
+      value = unwrap_func(src.ptr());
+      return pyErrClearIfFalse(!mlirTypeIsNull(value));
+    }
     if (auto capsule = mlirApiObjectToCapsule(src)) {
       value = mlirPythonCapsuleToType(capsule->ptr());
       return pyErrClearIfFalse(!mlirTypeIsNull(value));
@@ -373,6 +644,17 @@ struct type_caster<MlirType> {
   }
   static handle from_cpp(MlirType t, rv_policy,
                          cleanup_list *cleanup) noexcept {
+    if (t.ptr == nullptr)
+      return nanobind::none();
+    using FuncPtr = PyObject *(*)(MlirType);
+    static mlir::python::SafeInit<FuncPtr> wrap_init;
+    FuncPtr wrap_func = wrap_init.get([]() {
+      return mlir::python::getWrapFunc<FuncPtr>(
+          mlir::python::irModule(), "Type", MLIR_PYTHON_CAPSULE_TYPE_WRAP);
+    });
+    if (wrap_func) {
+      return handle(wrap_func(t));
+    }
     nanobind::object capsule =
         nanobind::steal<nanobind::object>(mlirPythonTypeToCapsule(t));
     return mlir::python::irModule()
@@ -471,11 +753,11 @@ public:
         std::forward<Func>(f),
         nanobind::name(name), // nanobind::scope(thisClass),
         extra...);
-    static SafeInit<nanobind::object> classmethodFn([]() {
+    static SafeInit<nanobind::object> classmethodFn;
+    thisClass.attr(name) = classmethodFn.get([]() {
       return std::make_unique<nanobind::object>(
           nanobind::module_::import_("builtins").attr("classmethod"));
-    });
-    thisClass.attr(name) = classmethodFn.get()(cf);
+    })(cf);
     return *this;
   }
 

--- a/mlir/include/mlir/Bindings/Python/NanobindUtils.h
+++ b/mlir/include/mlir/Bindings/Python/NanobindUtils.h
@@ -19,7 +19,6 @@
 #include <memory>
 #include <sstream>
 #include <string>
-#include <string_view>
 #include <type_traits>
 #include <typeinfo>
 #include <variant>
@@ -40,11 +39,10 @@ namespace python {
 template <typename T>
 class SafeInit {
 public:
-  typedef std::unique_ptr<T> (*F)();
+  SafeInit() = default;
 
-  explicit SafeInit(F init_fn) : initFn(init_fn) {}
-
-  T &get() {
+  template <typename F>
+  T &get(const F &init_fn) {
     if (T *result = output.load()) {
       return *result;
     }
@@ -53,7 +51,7 @@ public:
     // released during its execution. The intended use case is for module
     // imports which are safe to perform multiple times. We are careful not to
     // hold a lock across init_fn() to avoid lock ordering problems.
-    std::unique_ptr<T> m = initFn();
+    std::unique_ptr<T> m = init_fn();
     {
       nanobind::ft_lock_guard lock(mu);
       if (T *result = output.load()) {
@@ -68,7 +66,6 @@ public:
 private:
   nanobind::ft_mutex mu;
   std::atomic<T *> output{nullptr};
-  F initFn;
 };
 
 struct MlirTypeIDHash {

--- a/mlir/lib/Bindings/Python/IRAffine.cpp
+++ b/mlir/lib/Bindings/Python/IRAffine.cpp
@@ -531,6 +531,22 @@ PyIntegerSet PyIntegerSet::createFromCapsule(const nb::object &capsule) {
 namespace mlir {
 namespace python {
 namespace MLIR_BINDINGS_PYTHON_DOMAIN {
+PyObject *PyAffineMap::wrap(MlirAffineMap map) {
+  if (mlirAffineMapIsNull(map)) {
+    Py_RETURN_NONE;
+  }
+  auto ctx = PyMlirContext::forContext(mlirAffineMapGetContext(map));
+  return nb::cast(PyAffineMap(ctx, map)).release().ptr();
+}
+
+MlirAffineMap PyAffineMap::unwrap(PyObject *obj) {
+  PyAffineMap *pyAffineMap;
+  if (nb::try_cast<PyAffineMap *>(nb::handle(obj), pyAffineMap)) {
+    return pyAffineMap->get();
+  }
+  return {nullptr};
+}
+
 void populateIRAffine(nb::module_ &m) {
   //----------------------------------------------------------------------------
   // Mapping of PyAffineExpr and derived classes.
@@ -706,6 +722,18 @@ void populateIRAffine(nb::module_ &m) {
   // Mapping of PyAffineMap.
   //----------------------------------------------------------------------------
   nb::class_<PyAffineMap>(m, "AffineMap")
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_WRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyAffineMap::wrap),
+                                MLIR_PYTHON_CAPSULE_AFFINE_MAP_WRAP);
+                          })
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_UNWRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyAffineMap::unwrap),
+                                MLIR_PYTHON_CAPSULE_AFFINE_MAP_UNWRAP);
+                          })
       .def_prop_ro(MLIR_PYTHON_CAPI_PTR_ATTR, &PyAffineMap::getCapsule)
       .def(MLIR_PYTHON_CAPI_FACTORY_ATTR, &PyAffineMap::createFromCapsule)
       .def("__eq__",

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -187,6 +187,14 @@ nb::object PyBlock::getCapsule() {
   return nb::steal<nb::object>(mlirPythonBlockToCapsule(get()));
 }
 
+MlirBlock PyBlock::unwrap(PyObject *obj) {
+  PyBlock *pyBlock;
+  if (nb::try_cast<PyBlock *>(nb::handle(obj), pyBlock)) {
+    return pyBlock->get();
+  }
+  return {nullptr};
+}
+
 //------------------------------------------------------------------------------
 // Collections.
 //------------------------------------------------------------------------------
@@ -501,6 +509,19 @@ void PyMlirContext::contextExit(const nb::object &excType,
                                 const nb::object &excVal,
                                 const nb::object &excTb) {
   PyThreadContextEntry::popContext(*this);
+}
+
+MlirContext PyMlirContext::unwrap(PyObject *obj) {
+  if (obj == Py_None) {
+    if (PyMlirContext *current = PyThreadContextEntry::getDefaultContext())
+      return current->get();
+  } else {
+    PyMlirContext *pyCtx;
+    if (nb::try_cast<PyMlirContext *>(nb::handle(obj), pyCtx)) {
+      return pyCtx->get();
+    }
+  }
+  return {nullptr};
 }
 
 nb::object PyMlirContext::attachDiagnosticHandler(nb::object callback) {
@@ -822,6 +843,21 @@ PyDialectRegistry PyDialectRegistry::createFromCapsule(nb::object capsule) {
   return PyDialectRegistry(rawRegistry);
 }
 
+PyObject *PyDialectRegistry::wrap(MlirDialectRegistry registry) {
+  if (mlirDialectRegistryIsNull(registry)) {
+    Py_RETURN_NONE;
+  }
+  return nb::cast(PyDialectRegistry(registry)).release().ptr();
+}
+
+MlirDialectRegistry PyDialectRegistry::unwrap(PyObject *obj) {
+  PyDialectRegistry *pyRegistry;
+  if (nb::try_cast<PyDialectRegistry *>(nb::handle(obj), pyRegistry)) {
+    return pyRegistry->get();
+  }
+  return {nullptr};
+}
+
 //------------------------------------------------------------------------------
 // PyLocation
 //------------------------------------------------------------------------------
@@ -846,6 +882,27 @@ void PyLocation::contextExit(const nb::object &excType,
                              const nb::object &excVal,
                              const nb::object &excTb) {
   PyThreadContextEntry::popLocation(*this);
+}
+
+PyObject *PyLocation::wrap(MlirLocation loc) {
+  if (mlirLocationIsNull(loc)) {
+    Py_RETURN_NONE;
+  }
+  auto ctx = PyMlirContext::forContext(mlirLocationGetContext(loc));
+  return nb::cast(PyLocation(ctx, loc)).release().ptr();
+}
+
+MlirLocation PyLocation::unwrap(PyObject *obj) {
+  if (obj == Py_None) {
+    if (PyLocation *current = PyThreadContextEntry::getDefaultLocation())
+      return current->get();
+  } else {
+    PyLocation *pyLoc;
+    if (nb::try_cast<PyLocation *>(nb::handle(obj), pyLoc)) {
+      return pyLoc->get();
+    }
+  }
+  return {nullptr};
 }
 
 PyLocation &DefaultingPyLocation::resolve() {
@@ -909,6 +966,21 @@ nb::object PyModule::createFromCapsule(nb::object capsule) {
 
 nb::object PyModule::getCapsule() {
   return nb::steal<nb::object>(mlirPythonModuleToCapsule(get()));
+}
+
+PyObject *PyModule::wrap(MlirModule module) {
+  if (mlirModuleIsNull(module)) {
+    Py_RETURN_NONE;
+  }
+  return PyModule::forModule(module).releaseObject().release().ptr();
+}
+
+MlirModule PyModule::unwrap(PyObject *obj) {
+  PyModule *pyModule;
+  if (nb::try_cast<PyModule *>(nb::handle(obj), pyModule)) {
+    return pyModule->get();
+  }
+  return {nullptr};
 }
 
 //------------------------------------------------------------------------------
@@ -1001,6 +1073,22 @@ MlirOperation PyOperation::get() const {
 
 PyOperationRef PyOperation::getRef() {
   return PyOperationRef(this, nb::borrow<nb::object>(handle));
+}
+
+PyObject *PyOperation::wrap(MlirOperation op) {
+  if (mlirOperationIsNull(op)) {
+    Py_RETURN_NONE;
+  }
+  auto ctx = PyMlirContext::forContext(mlirOperationGetContext(op));
+  return PyOperation::forOperation(ctx, op).releaseObject().release().ptr();
+}
+
+MlirOperation PyOperation::unwrap(PyObject *obj) {
+  PyOperation *pyOp;
+  if (nb::try_cast<PyOperation *>(nb::handle(obj), pyOp)) {
+    return pyOp->get();
+  }
+  return {nullptr};
 }
 
 void PyOperation::setAttached(const nb::object &parent) {
@@ -1888,6 +1976,22 @@ nb::typed<nb::object, PyAttribute> PyAttribute::maybeDownCast() {
   return typeCaster.value()(thisObj);
 }
 
+PyObject *PyAttribute::wrap(MlirAttribute attr) {
+  if (mlirAttributeIsNull(attr)) {
+    Py_RETURN_NONE;
+  }
+  auto ctx = PyMlirContext::forContext(mlirAttributeGetContext(attr));
+  return PyAttribute(ctx, attr).maybeDownCast().release().ptr();
+}
+
+MlirAttribute PyAttribute::unwrap(PyObject *obj) {
+  PyAttribute *pyAttribute;
+  if (nb::try_cast<PyAttribute *>(nb::handle(obj), pyAttribute)) {
+    return pyAttribute->get();
+  }
+  return {nullptr};
+}
+
 //------------------------------------------------------------------------------
 // PyNamedAttribute.
 //------------------------------------------------------------------------------
@@ -1934,6 +2038,23 @@ nb::typed<nb::object, PyType> PyType::maybeDownCast() {
   return typeCaster.value()(thisObj);
 }
 
+PyObject *PyType::wrap(MlirType type) {
+  if (mlirTypeIsNull(type)) {
+    Py_RETURN_NONE;
+  }
+  auto ctx = PyMlirContext::forContext(mlirTypeGetContext(type));
+  PyType pyType(ctx, type);
+  return pyType.maybeDownCast().release().ptr();
+}
+
+MlirType PyType::unwrap(PyObject *obj) {
+  PyType *pyType;
+  if (nb::try_cast<PyType *>(nb::handle(obj), pyType)) {
+    return pyType->get();
+  }
+  return {nullptr};
+}
+
 //------------------------------------------------------------------------------
 // PyTypeID.
 //------------------------------------------------------------------------------
@@ -1948,6 +2069,22 @@ PyTypeID PyTypeID::createFromCapsule(nb::object capsule) {
     throw nb::python_error();
   return PyTypeID(mlirTypeID);
 }
+
+PyObject *PyTypeID::wrap(MlirTypeID typeID) {
+  if (mlirTypeIDIsNull(typeID)) {
+    Py_RETURN_NONE;
+  }
+  return nb::cast(PyTypeID(typeID)).release().ptr();
+}
+
+MlirTypeID PyTypeID::unwrap(PyObject *obj) {
+  PyTypeID *pyTypeID;
+  if (nb::try_cast<PyTypeID *>(nb::handle(obj), pyTypeID)) {
+    return pyTypeID->get();
+  }
+  return {nullptr};
+}
+
 bool PyTypeID::operator==(const PyTypeID &other) const {
   return mlirTypeIDEqual(typeID, other.typeID);
 }
@@ -2002,6 +2139,23 @@ PyValue PyValue::createFromCapsule(nb::object capsule) {
     throw nb::python_error();
   PyOperationRef ownerRef = getValueOwnerRef(value);
   return PyValue(ownerRef, value);
+}
+
+PyObject *PyValue::wrap(MlirValue value) {
+  if (mlirValueIsNull(value)) {
+    Py_RETURN_NONE;
+  }
+  PyOperationRef ownerRef = getValueOwnerRef(value);
+  PyValue pyValue(ownerRef, value);
+  return pyValue.maybeDownCast().release().ptr();
+}
+
+MlirValue PyValue::unwrap(PyObject *obj) {
+  PyValue *pyValue;
+  if (nb::try_cast<PyValue *>(nb::handle(obj), pyValue)) {
+    return pyValue->get();
+  }
+  return {nullptr};
 }
 
 //------------------------------------------------------------------------------
@@ -3139,6 +3293,12 @@ void populateIRCore(nb::module_ &m) {
            "Returns the raw pointer to the LLVM thread pool as a string.");
 
   nb::class_<PyMlirContext>(m, "Context")
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_UNWRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyMlirContext::unwrap),
+                                MLIR_PYTHON_CAPSULE_CONTEXT_UNWRAP);
+                          })
       .def(
           "__init__",
           [](PyMlirContext &self) {
@@ -3379,6 +3539,20 @@ void populateIRCore(nb::module_ &m) {
   // Mapping of PyDialectRegistry
   //----------------------------------------------------------------------------
   nb::class_<PyDialectRegistry>(m, "DialectRegistry")
+      .def_prop_ro_static(
+          MLIR_PYTHON_CAPI_WRAP_ATTR,
+          [](nanobind::object /*self*/) {
+            return nb::capsule(
+                reinterpret_cast<void *>(PyDialectRegistry::wrap),
+                MLIR_PYTHON_CAPSULE_DIALECT_REGISTRY_WRAP);
+          })
+      .def_prop_ro_static(
+          MLIR_PYTHON_CAPI_UNWRAP_ATTR,
+          [](nanobind::object /*self*/) {
+            return nb::capsule(
+                reinterpret_cast<void *>(PyDialectRegistry::unwrap),
+                MLIR_PYTHON_CAPSULE_DIALECT_REGISTRY_UNWRAP);
+          })
       .def_prop_ro(MLIR_PYTHON_CAPI_PTR_ATTR, &PyDialectRegistry::getCapsule,
                    "Gets a capsule wrapping the MlirDialectRegistry.")
       .def_static(MLIR_PYTHON_CAPI_FACTORY_ATTR,
@@ -3391,6 +3565,18 @@ void populateIRCore(nb::module_ &m) {
   // Mapping of Location
   //----------------------------------------------------------------------------
   nb::class_<PyLocation>(m, "Location")
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_WRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyLocation::wrap),
+                                MLIR_PYTHON_CAPSULE_LOCATION_WRAP);
+                          })
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_UNWRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyLocation::unwrap),
+                                MLIR_PYTHON_CAPSULE_LOCATION_UNWRAP);
+                          })
       .def_prop_ro(MLIR_PYTHON_CAPI_PTR_ATTR, &PyLocation::getCapsule,
                    "Gets a capsule wrapping the MlirLocation.")
       .def_static(MLIR_PYTHON_CAPI_FACTORY_ATTR, &PyLocation::createFromCapsule,
@@ -3609,6 +3795,18 @@ void populateIRCore(nb::module_ &m) {
   // Mapping of Module
   //----------------------------------------------------------------------------
   nb::class_<PyModule>(m, "Module", nb::is_weak_referenceable())
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_WRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyModule::wrap),
+                                MLIR_PYTHON_CAPSULE_MODULE_WRAP);
+                          })
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_UNWRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyModule::unwrap),
+                                MLIR_PYTHON_CAPSULE_MODULE_UNWRAP);
+                          })
       .def_prop_ro(MLIR_PYTHON_CAPI_PTR_ATTR, &PyModule::getCapsule,
                    "Gets a capsule wrapping the MlirModule.")
       .def_static(MLIR_PYTHON_CAPI_FACTORY_ATTR, &PyModule::createFromCapsule,
@@ -4040,6 +4238,18 @@ void populateIRCore(nb::module_ &m) {
           "trait_cls"_a, "Checks if the operation has a given trait.");
 
   nb::class_<PyOperation, PyOperationBase>(m, "Operation")
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_WRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyOperation::wrap),
+                                MLIR_PYTHON_CAPSULE_OPERATION_WRAP);
+                          })
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_UNWRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyOperation::unwrap),
+                                MLIR_PYTHON_CAPSULE_OPERATION_UNWRAP);
+                          })
       .def_static(
           "create",
           [](std::string_view name,
@@ -4304,6 +4514,12 @@ void populateIRCore(nb::module_ &m) {
   nb::class_<PyBlock>(m, "Block")
       .def_prop_ro(MLIR_PYTHON_CAPI_PTR_ATTR, &PyBlock::getCapsule,
                    "Gets a capsule wrapping the MlirBlock.")
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_UNWRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyBlock::unwrap),
+                                MLIR_PYTHON_CAPSULE_BLOCK_UNWRAP);
+                          })
       .def_prop_ro(
           "owner",
           [](PyBlock &self) -> nb::typed<nb::object, PyOpView> {
@@ -4482,7 +4698,6 @@ void populateIRCore(nb::module_ &m) {
   //----------------------------------------------------------------------------
   // Mapping of PyInsertionPoint.
   //----------------------------------------------------------------------------
-
   nb::class_<PyInsertionPoint>(m, "InsertionPoint")
       .def(nb::init<PyBlock &>(), "block"_a,
            "Inserts after the last operation but still inside the block.")
@@ -4571,6 +4786,18 @@ void populateIRCore(nb::module_ &m) {
       .def_static(
           MLIR_PYTHON_CAPI_FACTORY_ATTR, &PyAttribute::createFromCapsule,
           "Creates an Attribute from a capsule wrapping `MlirAttribute`.")
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_WRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyAttribute::wrap),
+                                MLIR_PYTHON_CAPSULE_ATTRIBUTE_WRAP);
+                          })
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_UNWRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyAttribute::unwrap),
+                                MLIR_PYTHON_CAPSULE_ATTRIBUTE_UNWRAP);
+                          })
       .def_static(
           "parse",
           [](const std::string &attrSpec, DefaultingPyMlirContext context)
@@ -4702,6 +4929,7 @@ void populateIRCore(nb::module_ &m) {
   //----------------------------------------------------------------------------
   // Mapping of PyType.
   //----------------------------------------------------------------------------
+
   nb::class_<PyType>(m, "Type")
       // Delegate to the PyType copy constructor, which will also lifetime
       // extend the backing context which owns the MlirType.
@@ -4711,6 +4939,18 @@ void populateIRCore(nb::module_ &m) {
                    "Gets a capsule wrapping the `MlirType`.")
       .def_static(MLIR_PYTHON_CAPI_FACTORY_ATTR, &PyType::createFromCapsule,
                   "Creates a Type from a capsule wrapping `MlirType`.")
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_WRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyType::wrap),
+                                MLIR_PYTHON_CAPSULE_TYPE_WRAP);
+                          })
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_UNWRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyType::unwrap),
+                                MLIR_PYTHON_CAPSULE_TYPE_UNWRAP);
+                          })
       .def_static(
           "parse",
           [](std::string typeSpec,
@@ -4798,6 +5038,18 @@ void populateIRCore(nb::module_ &m) {
                    "Gets a capsule wrapping the `MlirTypeID`.")
       .def_static(MLIR_PYTHON_CAPI_FACTORY_ATTR, &PyTypeID::createFromCapsule,
                   "Creates a `TypeID` from a capsule wrapping `MlirTypeID`.")
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_WRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyTypeID::wrap),
+                                MLIR_PYTHON_CAPSULE_TYPEID_WRAP);
+                          })
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_UNWRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyTypeID::unwrap),
+                                MLIR_PYTHON_CAPSULE_TYPEID_UNWRAP);
+                          })
       // Note, this tests whether the underlying TypeIDs are the same,
       // not whether the wrapper MlirTypeIDs are the same, nor whether
       // the Python objects are the same (i.e., PyTypeID is a value type).
@@ -4832,6 +5084,18 @@ void populateIRCore(nb::module_ &m) {
                    "Gets a capsule wrapping the `MlirValue`.")
       .def_static(MLIR_PYTHON_CAPI_FACTORY_ATTR, &PyValue::createFromCapsule,
                   "Creates a `Value` from a capsule wrapping `MlirValue`.")
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_WRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyValue::wrap),
+                                MLIR_PYTHON_CAPSULE_VALUE_WRAP);
+                          })
+      .def_prop_ro_static(MLIR_PYTHON_CAPI_UNWRAP_ATTR,
+                          [](nanobind::object /*self*/) {
+                            return nb::capsule(
+                                reinterpret_cast<void *>(PyValue::unwrap),
+                                MLIR_PYTHON_CAPSULE_VALUE_UNWRAP);
+                          })
       .def_prop_ro(
           "context",
           [](PyValue &self) -> nb::typed<nb::object, PyMlirContext> {

--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -353,6 +353,8 @@ public:
       mlirFrozenRewritePatternSetDestroy(set);
   }
   MlirFrozenRewritePatternSet get() { return set; }
+  static PyObject *wrap(MlirFrozenRewritePatternSet set);
+  static MlirFrozenRewritePatternSet unwrap(PyObject *obj);
 
   nb::object getCapsule() {
     return nb::steal<nb::object>(
@@ -370,6 +372,23 @@ public:
 private:
   MlirFrozenRewritePatternSet set;
 };
+
+PyObject *PyFrozenRewritePatternSet::wrap(MlirFrozenRewritePatternSet set) {
+  if (set.ptr == nullptr) {
+    Py_RETURN_NONE;
+  }
+  return nb::cast(PyFrozenRewritePatternSet(set), nb::rv_policy::move)
+      .release()
+      .ptr();
+}
+
+MlirFrozenRewritePatternSet PyFrozenRewritePatternSet::unwrap(PyObject *obj) {
+  PyFrozenRewritePatternSet *pySet;
+  if (nb::try_cast<PyFrozenRewritePatternSet *>(nb::handle(obj), pySet)) {
+    return pySet->get();
+  }
+  return {nullptr};
+}
 
 void PyRewritePatternSet::bind(nb::module_ &m) {
   nb::class_<PyRewritePatternSet>(m, "RewritePatternSet")
@@ -742,6 +761,20 @@ void populateRewriteSubmodule(nb::module_ &m) {
                    "source/target materializations");
 
   nb::class_<PyFrozenRewritePatternSet>(m, "FrozenRewritePatternSet")
+      .def_prop_ro_static(
+          MLIR_PYTHON_CAPI_WRAP_ATTR,
+          [](nanobind::object /*self*/) {
+            return nb::capsule(
+                reinterpret_cast<void *>(PyFrozenRewritePatternSet::wrap),
+                MLIR_PYTHON_CAPSULE_FROZEN_REWRITE_PATTERN_SET_WRAP);
+          })
+      .def_prop_ro_static(
+          MLIR_PYTHON_CAPI_UNWRAP_ATTR,
+          [](nanobind::object /*self*/) {
+            return nb::capsule(
+                reinterpret_cast<void *>(PyFrozenRewritePatternSet::unwrap),
+                MLIR_PYTHON_CAPSULE_FROZEN_REWRITE_PATTERN_SET_UNWRAP);
+          })
       .def_prop_ro(MLIR_PYTHON_CAPI_PTR_ATTR,
                    &PyFrozenRewritePatternSet::getCapsule)
       .def(MLIR_PYTHON_CAPI_FACTORY_ATTR,


### PR DESCRIPTION
To convert a Python value to a C API value we need one attribute lookup and one Python object allocation. Consider MlirValue for instance. We a) lookup the _CAPIPtr attribute on the object
b) in PyValue this attribute is a read-only property that, when read, allocates a new Python capsule object that wraps the underlying C API pointer. c) we then extract the pointer from the capsule and wrap it in an `MlirValue` struct.

To convert a C API value to a Python value we might need one capsule allocation, three attribute accesses and two Python function calls: a) we wrap the MlirValue C API pointer as a fresh python capsule b) we compute `ir.Value._CAPICreate(value).maybe_downcast()`

All of this is slow! Profiling indicates it could be taking as much as 2s for a JAX LLM tracing benchmark.

In this PR, we add new `_CAPIWrap` and `_CAPIUnwrap` APIs for each python object that perform this task more directly. `_CAPIUnwrap` is a static capsule property on, say, PyValue, that contains a function pointer with signature `MlirValue (*unwrap)(PyObject *)`. We read this function pointer once (using `SafeInit`) per type caster function, and thereafter the work of the type caster can be delegated to it. This avoids much Python overhead.

In passing, we also change `SafeInit` to pass the initializer function to `get()` rather than the constructor. Here we want to use the type of the argument object as an argument to the `from_python` type casters, and that is not something that would be safe to capture for the lifetime of the SafeInit object itself.

Benchmarks on my workstation, CPU time:

```
name                     cpu/op        cpu/op     vs base
bench_value              1074.9n ± 4%   264.0n ± 11%  -75.44% (p=0.002 n=6)
bench_affine_map          707.1n ± 2%   157.9n ±  3%  -77.66% (p=0.002 n=6)
bench_attribute          1056.8n ± 2%   326.9n ±  1%  -69.07% (p=0.002 n=6)
bench_block              208.27n ± 2%   61.03n ±  4%  -70.69% (p=0.002 n=6)
bench_context            221.25n ± 2%   61.70n ±  2%  -72.11% (p=0.002 n=6)
bench_dialect_registry    691.8n ± 5%   163.7n ±  2%  -76.34% (p=0.002 n=6)
bench_location            699.6n ± 3%   162.5n ±  1%  -76.77% (p=0.002 n=6)
bench_module             1157.6n ± 6%   505.0n ±  1%  -56.38% (p=0.002 n=6)
bench_operation           943.5n ± 3%   363.2n ± 15%  -61.50% (p=0.002 n=6)
bench_type_id             614.0n ± 7%   107.1n ±  1%  -82.56% (p=0.002 n=6)
bench_type               1046.4n ± 4%   310.4n ±  8%  -70.33% (p=0.002 n=6)
geomean                  671.7n        184.3n        -72.57%
```

The benchmark here is:

```
import google_benchmark as benchmark
from mlir import ir
from mlir.dialects import arith
from . import benchmark_ext

def create_value():
  ctx = ir.Context()
  with ctx, ir.Location.unknown():
    module = ir.Module.create()
    with ir.InsertionPoint(module.body):
      i32 = ir.IntegerType.get_signless(32)
      op = arith.ConstantOp(i32, 1)
      return op.result

def create_affine_map():
  ctx = ir.Context()
  with ctx:
    return ir.AffineMap.get_permutation([0, 1])

def create_attribute():
  ctx = ir.Context()
  with ctx:
    return ir.BoolAttr.get(True)

def create_block():
  ctx = ir.Context()
  with ctx, ir.Location.unknown():
    module = ir.Module.create()
    region = module.operation.regions[0]
    return ir.Block.create_at_start(region, [ir.IntegerType.get_signless(32)])

def create_context():
  return ir.Context()

def create_dialect_registry():
  return ir.DialectRegistry()

def create_location():
  ctx = ir.Context()
  with ctx:
    return ir.Location.unknown()

def create_module():
  ctx = ir.Context()
  with ctx, ir.Location.unknown():
    return ir.Module.create()

def create_operation():
  ctx = ir.Context()
  with ctx, ir.Location.unknown():
    module = ir.Module.create()
    with ir.InsertionPoint(module.body):
      i32 = ir.IntegerType.get_signless(32)
      op = arith.ConstantOp(i32, 1)
      return op.operation

def create_type_id():
  ctx = ir.Context()
  with ctx:
    return ir.IntegerType.get_signless(32).typeid

def create_type():
  ctx = ir.Context()
  with ctx:
    return ir.IntegerType.get_signless(32)

@benchmark.register
def bench_value(state):
  val = create_value()
  while state:
    benchmark_ext.identity_value(val)

@benchmark.register
def bench_affine_map(state):
  val = create_affine_map()
  while state:
    benchmark_ext.identity_affine_map(val)

@benchmark.register
def bench_attribute(state):
  val = create_attribute()
  while state:
    benchmark_ext.identity_attribute(val)

@benchmark.register
def bench_block(state):
  val = create_block()
  while state:
    benchmark_ext.identity_block(val)

@benchmark.register
def bench_context(state):
  val = create_context()
  while state:
    benchmark_ext.identity_context(val)

@benchmark.register
def bench_dialect_registry(state):
  val = create_dialect_registry()
  while state:
    benchmark_ext.identity_dialect_registry(val)

@benchmark.register
def bench_location(state):
  val = create_location()
  while state:
    benchmark_ext.identity_location(val)

@benchmark.register
def bench_module(state):
  val = create_module()
  while state:
    benchmark_ext.identity_module(val)

@benchmark.register
def bench_operation(state):
  val = create_operation()
  while state:
    benchmark_ext.identity_operation(val)

@benchmark.register
def bench_type_id(state):
  val = create_type_id()
  while state:
    benchmark_ext.identity_type_id(val)

@benchmark.register
def bench_type(state):
  val = create_type()
  while state:
    benchmark_ext.identity_type(val)

if __name__ == "__main__":
  benchmark.main()
```

and the extension:

```

NB_MODULE(benchmark_ext, m) {
  // Types with both from_python and from_cpp casters in NanobindAdaptors.h.
  // These benchmark both directions (unwrapping and wrapping).
  m.def("identity_value", [](MlirValue v) { return v; });
  m.def("identity_affine_map", [](MlirAffineMap v) { return v; });
  m.def("identity_attribute", [](MlirAttribute v) { return v; });
  m.def("identity_location", [](MlirLocation v) { return v; });
  m.def("identity_type_id", [](MlirTypeID v) { return v; });
  m.def("identity_type", [](MlirType v) { return v; });

  // Types that only have from_python caster in NanobindAdaptors.h.
  // These only benchmark the Python -> C++ direction (unwrapping).
  m.def("identity_block", [](MlirBlock v) { /* returns void */ });
  m.def("identity_context", [](MlirContext v) { /* returns void */ });

  // Types whose from_cpp caster transfers ownership.
  m.def("identity_dialect_registry",
        [](MlirDialectRegistry v) { return mlirDialectRegistryCreate(); });
  m.def("identity_module", [](MlirModule v) {
    return mlirModuleFromOperation(
        mlirOperationClone(mlirModuleGetOperation(v)));
  });
  m.def("identity_operation",
        [](MlirOperation v) { return mlirOperationClone(v); });
}
```