### PR TITLE
[lldb/test] Fix TestDataFormatterObjCNSBundle.py following 8212cab4128d (NFC)

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSBundle.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSBundle.py
@@ -31,7 +31,7 @@ class ObjCDataFormatterNSBundle(ObjCDataFormatterTestCase):
                 "(NSBundle *) bundle_string = ",
                 ' @"/System/Library/Frameworks/Accelerate.framework"',
                 "(NSBundle *) bundle_url = ",
-                ' "/System/Library/Frameworks/Foundation.framework"',
+                '"/System/Library/Frameworks/Foundation.framework"',
                 "(NSBundle *) main_bundle = ",
                 "data-formatter-objc",
             ],


### PR DESCRIPTION
This removes a spurious space introduced by 8212cab4128d.