### PR TITLE
AMDGPU: Use preferred --target=triple flag in documentation

### DIFF
--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -46,7 +46,7 @@ LLVM
 Target Triples
 --------------
 
-Use the Clang option ``-target <Architecture>-<Vendor>-<OS>-<Environment>``
+Use the Clang option ``--target=<Architecture>-<Vendor>-<OS>-<Environment>``
 to specify the target triple:
 
   .. table:: AMDGPU Architectures


### PR DESCRIPTION
This was using the long deprecated single dash target with space
as the example.