### PR TITLE
[libcxx][Github] Add generic-llvm-libc config to CI

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -144,6 +144,7 @@ jobs:
           'generic-hardening-mode-extensive-observe-semantic',
           'generic-hardening-mode-fast',
           'generic-hardening-mode-fast-with-abi-breaks',
+          'generic-llvm-libc',
           'generic-merged',
           'generic-modules-cxx17-lsv',
           'generic-no-exceptions',

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -46,7 +46,6 @@ jobs:
           'generic-cxx03',
           'generic-cxx26',
           'generic-modules',
-          'generic-llvm-libc',
         ]
         cc: [  'clang-23' ]
         cxx: [ 'clang++-23' ]

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -45,7 +45,7 @@ jobs:
           'frozen-cxx03-headers',
           'generic-cxx03',
           'generic-cxx26',
-          'generic-modules',
+          'generic-modules'
         ]
         cc: [  'clang-23' ]
         cxx: [ 'clang++-23' ]
@@ -90,7 +90,7 @@ jobs:
           'generic-cxx14',
           'generic-cxx17',
           'generic-cxx20',
-          'generic-cxx23',
+          'generic-cxx23'
         ]
         cc: [ 'clang-23' ]
         cxx: [ 'clang++-23' ]

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -90,7 +90,8 @@ jobs:
           'generic-cxx14',
           'generic-cxx17',
           'generic-cxx20',
-          'generic-cxx23'
+          'generic-cxx23',
+          'generic-llvm-libc',
         ]
         cc: [ 'clang-23' ]
         cxx: [ 'clang++-23' ]

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -45,7 +45,8 @@ jobs:
           'frozen-cxx03-headers',
           'generic-cxx03',
           'generic-cxx26',
-          'generic-modules'
+          'generic-modules',
+          'generic-llvm-libc',
         ]
         cc: [  'clang-23' ]
         cxx: [ 'clang++-23' ]
@@ -91,7 +92,6 @@ jobs:
           'generic-cxx17',
           'generic-cxx20',
           'generic-cxx23',
-          'generic-llvm-libc',
         ]
         cc: [ 'clang-23' ]
         cxx: [ 'clang++-23' ]

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -454,6 +454,7 @@ generic-llvm-libc)
     # Install rsync, which is needed for installing the linux kernel headers.
     sudo apt-get update
     sudo apt-get install -y rsync
+    pip3 install pyyaml==6.0.3
 
     # Install kernel headers from a known-good Linux kernel version to ensure
     # the test is hermetic.

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -466,7 +466,19 @@ generic-llvm-libc)
     # Ensure we have the builtins archive built as we pass it in explicitly in
     # the test config.
     ninja -vC "${BUILD_DIR}" libclang_rt.builtins-x86_64.a
-    check-runtimes
+
+    # Manually run only libcxx/libcxxabi tests as we currently cannot build
+    # libunwind due to a missing dl_iterate_phdr implementation.
+    # TODO(boomanaiden154): Remove this once we can build libunwind and pass
+    # the tests.
+    step "Building libc++ test dependencies"
+    ninja -vC "${BUILD_DIR}" cxx-test-depends
+
+    step "Running the libc++ tests"
+    ninja -vC "${BUILD_DIR}" check-cxx
+
+    step "Running the libc++abi tests"
+    ninja -vC "${BUILD_DIR}" check-cxxabi
 ;;
 #
 # Module builds

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -451,6 +451,10 @@ generic-hardening-mode-debug)
 generic-llvm-libc)
     clean
 
+    # Install rsync, which is needed for installing the linux kernel headers.
+    apt-get update
+    apt-get install -y rsync
+
     # Install kernel headers from a known-good Linux kernel version to ensure
     # the test is hermetic.
     export LINUX_VERSION=7.0.1

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -452,8 +452,8 @@ generic-llvm-libc)
     clean
 
     # Install rsync, which is needed for installing the linux kernel headers.
-    apt-get update
-    apt-get install -y rsync
+    sudo apt-get update
+    sudo apt-get install -y rsync
 
     # Install kernel headers from a known-good Linux kernel version to ensure
     # the test is hermetic.

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -457,7 +457,7 @@ generic-llvm-libc)
     mkdir -p "${BUILD_DIR}"
     curl -L "https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-${LINUX_VERSION}.tar.xz" --output "${BUILD_DIR}/linux.tar.xz"
     tar -xf "${BUILD_DIR}/linux.tar.xz" -C "${BUILD_DIR}"
-    make LLVM=1 INSTALL_HDR_PATH="${BUILD_DIR}/linux-install" -C "${BUILD_DIR}/linux-${LINUX_VERSION}" headers_install
+    make INSTALL_HDR_PATH="${BUILD_DIR}/linux-install" -C "${BUILD_DIR}/linux-${LINUX_VERSION}" headers_install
 
     generate-cmake-base -C "${MONOREPO_ROOT}/libcxx/cmake/caches/Generic-llvm-libc.cmake" \
                         -DLIBCXX_TEST_CONFIG="llvm-libc++-llvm-libc.cfg.in" \

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -451,10 +451,15 @@ generic-hardening-mode-debug)
 generic-llvm-libc)
     clean
 
-    # Install rsync, which is needed for installing the linux kernel headers.
-    sudo apt-get update
-    sudo apt-get install -y rsync
-    pip3 install pyyaml==6.0.3
+    # Install some dependencies that are needed for building the kernel headers
+    # and LLVM libc.
+    # TODO(boomanaiden154): Move these to being part of the base container
+    # image rather than something we install on every run.
+    if [[ -n "$GITHUB_ACTIONS" ]]; then
+        sudo apt-get update
+        sudo apt-get install -y rsync
+        pip3 install pyyaml==6.0.3
+    fi
 
     # Install kernel headers from a known-good Linux kernel version to ensure
     # the test is hermetic.


### PR DESCRIPTION
Add the generic-llvm-libc config for CI so that we can ensure we do not regress the config and easily test changes as we do more work.

Only run libcxx/libxxabi tests for now as libunwind fails to build due to a missing dl_iterate_phdr implementation. It technically passes when we enable the stub implementation, but we should have a reasonable implementation before actually enabling.