### PR TITLE
Revert "[Darwin] Remove linker version checks for objc_msgSend selector stubs (#193637)"

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -3410,7 +3410,8 @@ void Darwin::addClangTargetOptions(
   // ld64-811.2+ does, for arm64, arm64e, and arm64_32.
   if (!DriverArgs.hasArgNoClaim(options::OPT_fobjc_msgsend_selector_stubs,
                                 options::OPT_fno_objc_msgsend_selector_stubs) &&
-      getTriple().isAArch64())
+      getTriple().isAArch64() &&
+      (getLinkerVersion(DriverArgs) >= VersionTuple(811, 2)))
     CC1Args.push_back("-fobjc-msgsend-selector-stubs");
 
   // Enable objc_msgSend class selector stubs by default if the linker supports
@@ -3418,7 +3419,8 @@ void Darwin::addClangTargetOptions(
   if (!DriverArgs.hasArgNoClaim(
           options::OPT_fobjc_msgsend_class_selector_stubs,
           options::OPT_fno_objc_msgsend_class_selector_stubs) &&
-      getTriple().isAArch64())
+      getTriple().isAArch64() &&
+      (getLinkerVersion(DriverArgs) >= VersionTuple(1250, 0)))
     CC1Args.push_back("-fobjc-msgsend-class-selector-stubs");
 
   // Pass "-fno-sized-deallocation" only when the user hasn't manually enabled

--- a/clang/test/Driver/darwin-objc-selector-stubs.m
+++ b/clang/test/Driver/darwin-objc-selector-stubs.m
@@ -1,35 +1,64 @@
 // Check default enablement of Objective-C objc_msgSend selector stubs codegen.
 
-// Enabled by default for AArch64 targets.
+// Enabled by default with ld64-811.2+ ...
 
-// arm64
-// RUN: %clang -target arm64-apple-ios15            -### %s 2>&1 | FileCheck %s
-// RUN: %clang -target arm64-apple-macos12          -### %s 2>&1 | FileCheck %s
+// ... for arm64
+// RUN: %clang -target arm64-apple-ios15            -mlinker-version=1250  -### %s 2>&1 | FileCheck %s
+// RUN: %clang -target arm64-apple-ios15            -mlinker-version=1249  -### %s 2>&1 | FileCheck %s --check-prefix=INST_STUB_ONLY
+// RUN: %clang -target arm64-apple-ios15            -mlinker-version=811.2 -### %s 2>&1 | FileCheck %s --check-prefix=INST_STUB_ONLY
+// RUN: %clang -target arm64-apple-ios15            -mlinker-version=811   -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
 
-// arm64e
-// RUN: %clang -target arm64e-apple-ios15           -### %s 2>&1 | FileCheck %s
+// RUN: %clang -target arm64-apple-macos12          -mlinker-version=1250  -### %s 2>&1 | FileCheck %s
+// RUN: %clang -target arm64-apple-macos12          -mlinker-version=1249  -### %s 2>&1 | FileCheck %s --check-prefix=INST_STUB_ONLY
+// RUN: %clang -target arm64-apple-macos12          -mlinker-version=811.2 -### %s 2>&1 | FileCheck %s --check-prefix=INST_STUB_ONLY
+// RUN: %clang -target arm64-apple-macos12          -mlinker-version=811   -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
 
-// arm64_32
-// RUN: %clang -target arm64_32-apple-watchos8      -### %s 2>&1 | FileCheck %s
+// ... for arm64e
+// RUN: %clang -target arm64e-apple-ios15           -mlinker-version=1250  -### %s 2>&1 | FileCheck %s
+// RUN: %clang -target arm64e-apple-ios15           -mlinker-version=1249  -### %s 2>&1 | FileCheck %s --check-prefix=INST_STUB_ONLY
+// RUN: %clang -target arm64e-apple-ios15           -mlinker-version=811.2 -### %s 2>&1 | FileCheck %s --check-prefix=INST_STUB_ONLY
+// RUN: %clang -target arm64e-apple-ios15           -mlinker-version=811   -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
+
+// ... and arm64_32.
+// RUN: %clang -target arm64_32-apple-watchos8      -mlinker-version=1250  -### %s 2>&1 | FileCheck %s
+// RUN: %clang -target arm64_32-apple-watchos8      -mlinker-version=1249  -### %s 2>&1 | FileCheck %s --check-prefix=INST_STUB_ONLY
+// RUN: %clang -target arm64_32-apple-watchos8      -mlinker-version=811.2 -### %s 2>&1 | FileCheck %s --check-prefix=INST_STUB_ONLY
+// RUN: %clang -target arm64_32-apple-watchos8      -mlinker-version=811   -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
 
 
-// Disabled elsewhere, e.g. x86_64 ...
-// RUN: %clang -target x86_64-apple-macos12         -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
-// RUN: %clang -target x86_64-apple-ios15-simulator -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
+// Disabled elsewhere, e.g. x86_64.
+// RUN: %clang -target x86_64-apple-macos12         -mlinker-version=1250  -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
+// RUN: %clang -target x86_64-apple-macos12         -mlinker-version=811.2 -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
+// RUN: %clang -target x86_64-apple-macos12         -mlinker-version=811   -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
+
+// RUN: %clang -target x86_64-apple-ios15-simulator -mlinker-version=1250  -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
+// RUN: %clang -target x86_64-apple-ios15-simulator -mlinker-version=811.2 -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
+// RUN: %clang -target x86_64-apple-ios15-simulator -mlinker-version=811   -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
 
 // ... or armv7k.
-// RUN: %clang -target armv7k-apple-watchos6        -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
+// RUN: %clang -target armv7k-apple-watchos6        -mlinker-version=1250  -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
+// RUN: %clang -target armv7k-apple-watchos6        -mlinker-version=811.2 -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
+// RUN: %clang -target armv7k-apple-watchos6        -mlinker-version=811   -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
 
+
+// Enabled if you ask for it.
+// If the linker version isn't specified on the command line, the cmake default version is used.
+// RUN: %clang -target arm64-apple-macos12 -fobjc-msgsend-selector-stubs                    -### %s 2>&1 | FileCheck %s -check-prefix=INST_STUB
+
+// RUN: %clang -target arm64-apple-macos12 -fobjc-msgsend-selector-stubs -mlinker-version=0 -### %s 2>&1 | FileCheck %s -check-prefix=INST_STUB_ONLY
+// RUN: %clang -target arm64-apple-macos12 -fobjc-msgsend-class-selector-stubs -mlinker-version=0 -### %s 2>&1 | FileCheck %s -check-prefix=CLASS_STUB_ONLY
 
 // Disabled if you ask for that.
-// RUN: %clang -target arm64-apple-macos12 -fno-objc-msgsend-selector-stubs       -### %s 2>&1 | FileCheck %s --check-prefix=CLASS_STUB_ONLY
-// RUN: %clang -target arm64-apple-macos12 -fno-objc-msgsend-class-selector-stubs -### %s 2>&1 | FileCheck %s --check-prefix=INST_STUB_ONLY
+// RUN: %clang -target arm64-apple-macos12 -fno-objc-msgsend-selector-stubs -mlinker-version=811.2 -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
+// RUN: %clang -target arm64-apple-macos12 -fno-objc-msgsend-selector-stubs -mlinker-version=1250 -### %s 2>&1  | FileCheck %s --check-prefix=CLASS_STUB_ONLY
+// RUN: %clang -target arm64-apple-macos12 -fno-objc-msgsend-class-selector-stubs -mlinker-version=1250 -### %s 2>&1 | FileCheck %s --check-prefix=INST_STUB_ONLY
 
 
 // CHECK: "-fobjc-msgsend-selector-stubs" "-fobjc-msgsend-class-selector-stubs"
 // INST_STUB_ONLY-NOT: objc-msgsend-class-selector-stubs
 // INST_STUB_ONLY: objc-msgsend-selector-stubs
 // INST_STUB_ONLY-NOT: objc-msgsend-class-selector-stubs
+// INST_STUB: objc-msgsend-selector-stubs
 // CLASS_STUB_ONLY-NOT: objc-msgsend-selector-stubs
 // CLASS_STUB_ONLY: objc-msgsend-class-selector-stubs
 // CLASS_STUB_ONLY-NOT: objc-msgsend-selector-stubs


### PR DESCRIPTION
This reverts commit a6ab955369ae401cec75ced651c52c2348f117ad.

The linker version checks cannot be removed yet. The commit broke builds that were using old linkers.