### PR TITLE
[clang-format] Don't break module names

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1392,10 +1392,8 @@ private:
         }
         break;
       }
-      if (Line.First->isOneOf(Keywords.kw_module, Keywords.kw_import) ||
-          Line.First->startsSequence(tok::kw_export, Keywords.kw_module) ||
-          Line.First->startsSequence(tok::kw_export, Keywords.kw_import)) {
-        Tok->setType(TT_ModulePartitionColon);
+      if (Line.isCppModuleLine(Keywords)) {
+        Tok->setFinalizedType(TT_ModulePartitionColon);
       } else if (Line.First->is(tok::kw_asm)) {
         Tok->setType(TT_InlineASMColon);
       } else if (Contexts.back().ColonIsDictLiteral || Style.isProto()) {
@@ -2004,6 +2002,13 @@ public:
       auto Type = parsePreprocessorDirective();
       if (Type != LT_Invalid)
         return Type;
+    }
+
+    if (IsCpp && Line.isCppModuleLine(Keywords)) {
+      while (CurrentToken)
+        if (!consumeToken())
+          return LT_Invalid;
+      return LT_ImportStatement;
     }
 
     // Directly allow to 'import <string-literal>' to support protocol buffer

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2008,7 +2008,7 @@ public:
       while (CurrentToken)
         if (!consumeToken())
           return LT_Invalid;
-      return LT_ImportStatement;
+      return LT_CppModuleStatement;
     }
 
     // Directly allow to 'import <string-literal>' to support protocol buffer

--- a/clang/lib/Format/TokenAnnotator.h
+++ b/clang/lib/Format/TokenAnnotator.h
@@ -116,6 +116,25 @@ public:
     return First && First->is(tok::comment) && !First->getNextNonComment();
   }
 
+  bool isCppModuleLine(const AdditionalKeywords &Keywords) const {
+    if (!First)
+      return false;
+    if (startsWith(tok::kw_export, Keywords.kw_module) ||
+        startsWith(tok::kw_export, Keywords.kw_import)) {
+      return true;
+    }
+
+    if (First->isNoneOf(Keywords.kw_module, Keywords.kw_import))
+      return false;
+
+    // Pre C++20 code using import (or module) as identifier e.g. for a
+    // namespace.
+    if (auto Next = First->getNextNonComment())
+      return Next->isNoneOf(tok::coloncolon, tok::period, tok::star);
+
+    return false;
+  }
+
   /// \c true if this line starts with the given tokens in order, ignoring
   /// comments.
   template <typename... Ts> bool startsWith(Ts... Tokens) const {

--- a/clang/lib/Format/TokenAnnotator.h
+++ b/clang/lib/Format/TokenAnnotator.h
@@ -132,8 +132,7 @@ public:
     // namespace.
     if (auto Next = First->getNextNonComment()) {
       return !Next->isMemberAccess() &&
-             Next->isNoneOf(tok::coloncolon, tok::star) &&
-             !Next->isStringLiteral();
+             Next->isNoneOf(tok::coloncolon, tok::star);
     }
 
     return false;

--- a/clang/lib/Format/TokenAnnotator.h
+++ b/clang/lib/Format/TokenAnnotator.h
@@ -35,6 +35,7 @@ enum LineType {
   LT_CommentAbovePPDirective,
   LT_RequiresExpression,
   LT_SimpleRequirement,
+  LT_CppModuleStatement,
 };
 
 enum ScopeType {
@@ -127,10 +128,13 @@ public:
     if (First->isNoneOf(Keywords.kw_module, Keywords.kw_import))
       return false;
 
-    // Pre C++20 code using import (or module) as identifier e.g. for a
+    // Pre-C++20 code using import (or module) as identifier e.g. for a
     // namespace.
-    if (auto Next = First->getNextNonComment())
-      return Next->isNoneOf(tok::coloncolon, tok::period, tok::star);
+    if (auto Next = First->getNextNonComment()) {
+      return !Next->isMemberAccess() &&
+             Next->isNoneOf(tok::coloncolon, tok::star) &&
+             !Next->isStringLiteral();
+    }
 
     return false;
   }

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -1563,11 +1563,12 @@ unsigned UnwrappedLineFormatter::format(
 
       NextLine = Joiner.getNextMergedLine(DryRun, IndentTracker);
       unsigned ColumnLimit = getColumnLimit(TheLine.InPPDirective, NextLine);
-      bool FitsIntoOneLine =
+      const bool FitsIntoOneLine =
           !TheLine.ContainsMacroCall &&
           (TheLine.Last->TotalLength + Indent <= ColumnLimit ||
            (TheLine.Type == LT_ImportStatement &&
             (!Style.isJavaScript() || !Style.JavaScriptWrapImports)) ||
+           TheLine.Type == LT_CppModuleStatement ||
            (Style.isCSharp() &&
             TheLine.InPPDirective)); // don't split #regions in C#
       if (Style.ColumnLimit == 0) {

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1361,11 +1361,8 @@ bool UnwrappedLineParser::parseModuleImport() {
 
   nextToken();
   while (!eof()) {
-    if (FormatTok->is(tok::colon)) {
-      FormatTok->setFinalizedType(TT_ModulePartitionColon);
-    }
     // Handle import <foo/bar.h> as we would an include statement.
-    else if (FormatTok->is(tok::less)) {
+    if (FormatTok->is(tok::less)) {
       nextToken();
       while (FormatTok->isNoneOf(tok::semi, tok::greater) && !eof()) {
         // Mark tokens up to the trailing line comments as implicit string

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1350,7 +1350,7 @@ static bool isC78ParameterDecl(const FormatToken *Tok, const FormatToken *Next,
   return Tok->Previous && Tok->Previous->isOneOf(tok::l_paren, tok::comma);
 }
 
-bool UnwrappedLineParser::parseModuleImport() {
+bool UnwrappedLineParser::parseCppModuleImport() {
   assert(FormatTok->is(Keywords.kw_import) && "'import' expected");
 
   if (auto Token = Tokens->peekNextToken(/*SkipComment=*/true);
@@ -1628,7 +1628,7 @@ void UnwrappedLineParser::parseStructuralElement(
         parseCppExportBlock();
         return;
       }
-      if (FormatTok->is(Keywords.kw_import) && parseModuleImport())
+      if (FormatTok->is(Keywords.kw_import) && parseCppModuleImport())
         return;
     }
     if (Style.isJavaScript()) {
@@ -1658,7 +1658,7 @@ void UnwrappedLineParser::parseStructuralElement(
       return;
     }
     if (FormatTok->is(Keywords.kw_import)) {
-      if (IsCpp && parseModuleImport())
+      if (IsCpp && parseCppModuleImport())
         return;
       if (Style.isJavaScript()) {
         parseJavaScriptEs6ImportExport();

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1359,26 +1359,21 @@ bool UnwrappedLineParser::parseModuleImport() {
     return false;
   }
 
-  nextToken();
-  while (!eof()) {
+  for (nextToken(); !eof(); nextToken()) {
     // Handle import <foo/bar.h> as we would an include statement.
     if (FormatTok->is(tok::less)) {
-      nextToken();
-      while (FormatTok->isNoneOf(tok::semi, tok::greater) && !eof()) {
-        // Mark tokens up to the trailing line comments as implicit string
-        // literals.
-        if (FormatTok->isNot(tok::comment) &&
-            !FormatTok->TokenText.starts_with("//")) {
-          FormatTok->setFinalizedType(TT_ImplicitStringLiteral);
-        }
-        nextToken();
+
+      for (nextToken(); FormatTok->isNoneOf(tok::semi, tok::greater) && !eof();
+           nextToken()) {
+        // Mark tokens as implicit string literals, so that import <A/Foo> will
+        // neither be broken nor have a space added.
+        FormatTok->setFinalizedType(TT_ImplicitStringLiteral);
       }
     }
     if (FormatTok->is(tok::semi)) {
       nextToken();
       break;
     }
-    nextToken();
   }
 
   addUnwrappedLine();
@@ -1623,14 +1618,6 @@ void UnwrappedLineParser::parseStructuralElement(
     }
     break;
   case tok::kw_export:
-    if (Style.isJavaScript()) {
-      parseJavaScriptEs6ImportExport();
-      return;
-    }
-    if (Style.isVerilog()) {
-      parseVerilogExtern();
-      return;
-    }
     if (IsCpp) {
       nextToken();
       if (FormatTok->is(tok::kw_namespace)) {
@@ -1643,6 +1630,14 @@ void UnwrappedLineParser::parseStructuralElement(
       }
       if (FormatTok->is(Keywords.kw_import) && parseModuleImport())
         return;
+    }
+    if (Style.isJavaScript()) {
+      parseJavaScriptEs6ImportExport();
+      return;
+    }
+    if (Style.isVerilog()) {
+      parseVerilogExtern();
+      return;
     }
     break;
   case tok::kw_inline:
@@ -1663,6 +1658,8 @@ void UnwrappedLineParser::parseStructuralElement(
       return;
     }
     if (FormatTok->is(Keywords.kw_import)) {
+      if (IsCpp && parseModuleImport())
+        return;
       if (Style.isJavaScript()) {
         parseJavaScriptEs6ImportExport();
         return;
@@ -1683,8 +1680,6 @@ void UnwrappedLineParser::parseStructuralElement(
         parseVerilogExtern();
         return;
       }
-      if (IsCpp && parseModuleImport())
-        return;
     }
     if (IsCpp && FormatTok->isOneOf(Keywords.kw_signals, Keywords.kw_qsignals,
                                     Keywords.kw_slots, Keywords.kw_qslots)) {

--- a/clang/lib/Format/UnwrappedLineParser.h
+++ b/clang/lib/Format/UnwrappedLineParser.h
@@ -164,7 +164,7 @@ private:
   void parseCaseLabel();
   void parseSwitch(bool IsExpr);
   void parseNamespace();
-  bool parseModuleImport();
+  bool parseCppModuleImport();
   void parseNew();
   void parseAccessSpecifier();
   bool parseEnum();

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -14072,11 +14072,6 @@ TEST_F(FormatTest, HandlesIncludeDirectives) {
   Style.AlwaysBreakBeforeMultilineStrings = true;
   Style.ColumnLimit = 0;
   verifyFormat("#import \"abc.h\"", Style);
-
-  // But 'import' might also be a regular C++ namespace.
-  verifyFormat("import::SomeFunction(aaaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
-               "                     aaaaaaaaaaaaaaaaaaaaaaaaaaaaa);");
-  verifyFormat("import::Bar foo(val ? 2 : 1);");
 }
 
 //===----------------------------------------------------------------------===//
@@ -24630,8 +24625,22 @@ TEST_F(FormatTest, Cpp20ModulesSupport) {
   verifyFormat("module", Style);
   verifyFormat("export", Style);
 
+  Style.ColumnLimit = 10;
+  verifyFormat("import Foo.Bar;", Style);
+  verifyFormat("export import Foo.Bar;", Style);
+  verifyFormat("export module Foo.Bar;", Style);
+  verifyFormat("import Foo.Bar:Baz;", Style);
+  verifyFormat("export import Foo.Bar:Baz;", Style);
+  verifyFormat("export module Foo.Bar:Baz;", Style);
+
+  // Somewhat gracefully handle import in pre C++20 code.
   verifyFormat("import /* not keyword */ = val ? 2 : 1;");
   verifyFormat("_world->import<engine_module>();");
+
+  // But 'import' might also be a regular C++ namespace.
+  verifyFormat("import::SomeFunction(aaaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
+               "                     aaaaaaaaaaaaaaaaaaaaaaaaaaaaa);");
+  verifyFormat("import::Bar foo(val ? 2 : 1);");
 }
 
 TEST_F(FormatTest, CoroutineForCoawait) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -14067,8 +14067,7 @@ TEST_F(FormatTest, HandlesIncludeDirectives) {
   // Protocol buffer definition or missing "#".
   auto Style = getLLVMStyleWithColumns(30);
   Style.Language = FormatStyle::LK_Proto;
-  verifyFormat("import \"aaaaaaaaaaaaaaaaa/aaaaaaaaaaaaaaa\";",
-               Style);
+  verifyFormat("import \"aaaaaaaaaaaaaaaaa/aaaaaaaaaaaaaaa\";", Style);
 
   Style = getLLVMStyle();
   Style.AlwaysBreakBeforeMultilineStrings = true;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -14065,10 +14065,12 @@ TEST_F(FormatTest, HandlesIncludeDirectives) {
   verifyFormat("#define F __has_include_next(<a/b>)");
 
   // Protocol buffer definition or missing "#".
+  auto Style = getLLVMStyleWithColumns(30);
+  Style.Language = FormatStyle::LK_Proto;
   verifyFormat("import \"aaaaaaaaaaaaaaaaa/aaaaaaaaaaaaaaa\";",
-               getLLVMStyleWithColumns(30));
+               Style);
 
-  FormatStyle Style = getLLVMStyle();
+  Style = getLLVMStyle();
   Style.AlwaysBreakBeforeMultilineStrings = true;
   Style.ColumnLimit = 0;
   verifyFormat("#import \"abc.h\"", Style);

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -24625,6 +24625,10 @@ TEST_F(FormatTest, Cpp20ModulesSupport) {
   verifyFormat("module", Style);
   verifyFormat("export", Style);
 
+  verifyFormat("module :private;", Style);
+  verifyFormat("import <Foo/Bar> /* comment */;", Style);
+  verifyFormat("import <Foo/Bar>; // Trailing comment", Style);
+
   Style.ColumnLimit = 10;
   verifyFormat("import Foo.Bar;", Style);
   verifyFormat("export import Foo.Bar;", Style);
@@ -24632,8 +24636,10 @@ TEST_F(FormatTest, Cpp20ModulesSupport) {
   verifyFormat("import Foo.Bar:Baz;", Style);
   verifyFormat("export import Foo.Bar:Baz;", Style);
   verifyFormat("export module Foo.Bar:Baz;", Style);
+  verifyFormat("import <Foo/Bar> /* comment */;", Style);
+  verifyFormat("import <Foo/Bar>; // Trailing comment", Style);
 
-  // Somewhat gracefully handle import in pre C++20 code.
+  // Somewhat gracefully handle import in pre-C++20 code.
   verifyFormat("import /* not keyword */ = val ? 2 : 1;");
   verifyFormat("_world->import<engine_module>();");
 


### PR DESCRIPTION
And somewhat streamline module handling.

Fixes #193676