### PR TITLE
[clang-tidy][readability-identifier-length] add structured bindings support

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.cpp
@@ -138,7 +138,8 @@ static bool isShortLived(const ValueDecl *Var, const SourceManager *SrcMgr,
 }
 
 void IdentifierLengthCheck::check(const MatchFinder::MatchResult &Result) {
-  const auto *StandaloneVar = Result.Nodes.getNodeAs<ValueDecl>("standaloneVar");
+  const auto *StandaloneVar =
+      Result.Nodes.getNodeAs<ValueDecl>("standaloneVar");
   if (StandaloneVar) {
     if (!StandaloneVar->getIdentifier())
       return;

--- a/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.cpp
@@ -15,11 +15,13 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::readability {
 
 const unsigned DefaultMinimumVariableNameLength = 3;
+const unsigned DefaultMinimumBindingNameLength = 2;
 const unsigned DefaultMinimumLoopCounterNameLength = 2;
 const unsigned DefaultMinimumExceptionNameLength = 2;
 const unsigned DefaultMinimumParameterNameLength = 3;
-const char DefaultIgnoredLoopCounterNames[] = "^[ijk_]$";
 const char DefaultIgnoredVariableNames[] = "";
+const char DefaultIgnoredBindingNames[] = "_";
+const char DefaultIgnoredLoopCounterNames[] = "^[ijk_]$";
 const char DefaultIgnoredExceptionVariableNames[] = "^[e]$";
 const char DefaultIgnoredParameterNames[] = "^[n]$";
 const unsigned DefaultLineCountThreshold = 0;
@@ -33,6 +35,8 @@ IdentifierLengthCheck::IdentifierLengthCheck(StringRef Name,
     : ClangTidyCheck(Name, Context),
       MinimumVariableNameLength(Options.get("MinimumVariableNameLength",
                                             DefaultMinimumVariableNameLength)),
+      MinimumBindingNameLength(Options.get("MinimumBindingNameLength",
+                                           DefaultMinimumBindingNameLength)),
       MinimumLoopCounterNameLength(Options.get(
           "MinimumLoopCounterNameLength", DefaultMinimumLoopCounterNameLength)),
       MinimumExceptionNameLength(Options.get(
@@ -42,6 +46,9 @@ IdentifierLengthCheck::IdentifierLengthCheck(StringRef Name,
       IgnoredVariableNamesInput(
           Options.get("IgnoredVariableNames", DefaultIgnoredVariableNames)),
       IgnoredVariableNames(IgnoredVariableNamesInput),
+      IgnoredBindingNamesInput(
+          Options.get("IgnoredBindingNames", DefaultIgnoredBindingNames)),
+      IgnoredBindingNames(IgnoredBindingNamesInput),
       IgnoredLoopCounterNamesInput(Options.get("IgnoredLoopCounterNames",
                                                DefaultIgnoredLoopCounterNames)),
       IgnoredLoopCounterNames(IgnoredLoopCounterNamesInput),
@@ -81,6 +88,9 @@ void IdentifierLengthCheck::registerMatchers(MatchFinder *Finder) {
 
   if (MinimumParameterNameLength > 1)
     Finder->addMatcher(parmVarDecl().bind("paramVar"), this);
+
+  if (MinimumBindingNameLength > 1)
+    Finder->addMatcher(bindingDecl().bind("bindingVar"), this);
 
   if (MinimumVariableNameLength > 1)
     Finder->addMatcher(
@@ -143,6 +153,21 @@ void IdentifierLengthCheck::check(const MatchFinder::MatchResult &Result) {
 
     diag(StandaloneVar->getLocation(), ErrorMessage)
         << 0 << StandaloneVar << MinimumVariableNameLength;
+  }
+
+  const auto *BindingVar = Result.Nodes.getNodeAs<VarDecl>("bindingVar");
+  if (BindingVar) {
+    if (!BindingVar->getIdentifier())
+      return;
+
+    const StringRef VarName = BindingVar->getName();
+
+    if (VarName.size() >= MinimumBindingNameLength ||
+        IgnoredBindingNames.match(VarName))
+      return;
+
+    diag(BindingVar->getLocation(), ErrorMessage)
+        << 0 << BindingVar << MinimumBindingNameLength;
   }
 
   auto *ExceptionVarName = Result.Nodes.getNodeAs<VarDecl>("exceptionVar");

--- a/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.cpp
@@ -27,7 +27,7 @@ const char DefaultIgnoredParameterNames[] = "^[n]$";
 const unsigned DefaultLineCountThreshold = 0;
 
 const char ErrorMessage[] =
-    "%select{variable|exception variable|loop variable|"
+    "%select{variable|binding variable|exception variable|loop variable|"
     "parameter}0 name %1 is too short, expected at least %2 characters";
 
 IdentifierLengthCheck::IdentifierLengthCheck(StringRef Name,
@@ -157,7 +157,7 @@ void IdentifierLengthCheck::check(const MatchFinder::MatchResult &Result) {
         << 0 << StandaloneVar << MinimumVariableNameLength;
   }
 
-  const auto *BindingVar = Result.Nodes.getNodeAs<VarDecl>("bindingVar");
+  const auto *BindingVar = Result.Nodes.getNodeAs<BindingDecl>("bindingVar");
   if (BindingVar) {
     if (!BindingVar->getIdentifier())
       return;
@@ -168,12 +168,12 @@ void IdentifierLengthCheck::check(const MatchFinder::MatchResult &Result) {
         IgnoredBindingNames.match(VarName))
       return;
 
-    if (isShortLived(BindingVar, Result.SourceManager, Result.Context,
-                     LineCountThreshold))
-      return;
+    // if (isShortLived(BindingVar, Result.SourceManager, Result.Context,
+    //                  LineCountThreshold))
+    //   return;
 
     diag(BindingVar->getLocation(), ErrorMessage)
-        << 0 << BindingVar << MinimumBindingNameLength;
+        << 1 << BindingVar << MinimumBindingNameLength;
   }
 
   auto *ExceptionVarName = Result.Nodes.getNodeAs<VarDecl>("exceptionVar");
@@ -191,7 +191,7 @@ void IdentifierLengthCheck::check(const MatchFinder::MatchResult &Result) {
       return;
 
     diag(ExceptionVarName->getLocation(), ErrorMessage)
-        << 1 << ExceptionVarName << MinimumExceptionNameLength;
+        << 2 << ExceptionVarName << MinimumExceptionNameLength;
   }
 
   const auto *LoopVar = Result.Nodes.getNodeAs<VarDecl>("loopVar");
@@ -210,7 +210,7 @@ void IdentifierLengthCheck::check(const MatchFinder::MatchResult &Result) {
       return;
 
     diag(LoopVar->getLocation(), ErrorMessage)
-        << 2 << LoopVar << MinimumLoopCounterNameLength;
+        << 3 << LoopVar << MinimumLoopCounterNameLength;
   }
 
   const auto *ParamVar = Result.Nodes.getNodeAs<VarDecl>("paramVar");
@@ -229,7 +229,7 @@ void IdentifierLengthCheck::check(const MatchFinder::MatchResult &Result) {
       return;
 
     diag(ParamVar->getLocation(), ErrorMessage)
-        << 3 << ParamVar << MinimumParameterNameLength;
+        << 4 << ParamVar << MinimumParameterNameLength;
   }
 }
 

--- a/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.cpp
@@ -20,7 +20,7 @@ const unsigned DefaultMinimumLoopCounterNameLength = 2;
 const unsigned DefaultMinimumExceptionNameLength = 2;
 const unsigned DefaultMinimumParameterNameLength = 3;
 const char DefaultIgnoredVariableNames[] = "";
-const char DefaultIgnoredBindingNames[] = "_";
+const char DefaultIgnoredBindingNames[] = "^[_]$";
 const char DefaultIgnoredLoopCounterNames[] = "^[ijk_]$";
 const char DefaultIgnoredExceptionVariableNames[] = "^[e]$";
 const char DefaultIgnoredParameterNames[] = "^[n]$";
@@ -102,7 +102,7 @@ void IdentifierLengthCheck::registerMatchers(MatchFinder *Finder) {
         this);
 }
 
-static std::optional<unsigned> countLinesToLastUse(const VarDecl *Var,
+static std::optional<unsigned> countLinesToLastUse(const ValueDecl *Var,
                                                    const SourceManager *SrcMgr,
                                                    ASTContext *Ctx) {
   const auto *ParentScope = llvm::dyn_cast<FunctionDecl>(Var->getDeclContext());
@@ -125,7 +125,7 @@ static std::optional<unsigned> countLinesToLastUse(const VarDecl *Var,
   return LastUseLine - DeclLine + 1;
 }
 
-static bool isShortLived(const VarDecl *Var, const SourceManager *SrcMgr,
+static bool isShortLived(const ValueDecl *Var, const SourceManager *SrcMgr,
                          ASTContext *Ctx, unsigned LineCountThreshold) {
   if (LineCountThreshold == 0)
     return false;
@@ -138,7 +138,7 @@ static bool isShortLived(const VarDecl *Var, const SourceManager *SrcMgr,
 }
 
 void IdentifierLengthCheck::check(const MatchFinder::MatchResult &Result) {
-  const auto *StandaloneVar = Result.Nodes.getNodeAs<VarDecl>("standaloneVar");
+  const auto *StandaloneVar = Result.Nodes.getNodeAs<ValueDecl>("standaloneVar");
   if (StandaloneVar) {
     if (!StandaloneVar->getIdentifier())
       return;
@@ -157,7 +157,7 @@ void IdentifierLengthCheck::check(const MatchFinder::MatchResult &Result) {
         << 0 << StandaloneVar << MinimumVariableNameLength;
   }
 
-  const auto *BindingVar = Result.Nodes.getNodeAs<BindingDecl>("bindingVar");
+  const auto *BindingVar = Result.Nodes.getNodeAs<ValueDecl>("bindingVar");
   if (BindingVar) {
     if (!BindingVar->getIdentifier())
       return;
@@ -168,15 +168,15 @@ void IdentifierLengthCheck::check(const MatchFinder::MatchResult &Result) {
         IgnoredBindingNames.match(VarName))
       return;
 
-    // if (isShortLived(BindingVar, Result.SourceManager, Result.Context,
-    //                  LineCountThreshold))
-    //   return;
+    if (isShortLived(BindingVar, Result.SourceManager, Result.Context,
+                     LineCountThreshold))
+      return;
 
     diag(BindingVar->getLocation(), ErrorMessage)
         << 1 << BindingVar << MinimumBindingNameLength;
   }
 
-  auto *ExceptionVarName = Result.Nodes.getNodeAs<VarDecl>("exceptionVar");
+  auto *ExceptionVarName = Result.Nodes.getNodeAs<ValueDecl>("exceptionVar");
   if (ExceptionVarName) {
     if (!ExceptionVarName->getIdentifier())
       return;
@@ -194,7 +194,7 @@ void IdentifierLengthCheck::check(const MatchFinder::MatchResult &Result) {
         << 2 << ExceptionVarName << MinimumExceptionNameLength;
   }
 
-  const auto *LoopVar = Result.Nodes.getNodeAs<VarDecl>("loopVar");
+  const auto *LoopVar = Result.Nodes.getNodeAs<ValueDecl>("loopVar");
   if (LoopVar) {
     if (!LoopVar->getIdentifier())
       return;
@@ -213,7 +213,7 @@ void IdentifierLengthCheck::check(const MatchFinder::MatchResult &Result) {
         << 3 << LoopVar << MinimumLoopCounterNameLength;
   }
 
-  const auto *ParamVar = Result.Nodes.getNodeAs<VarDecl>("paramVar");
+  const auto *ParamVar = Result.Nodes.getNodeAs<ValueDecl>("paramVar");
   if (ParamVar) {
     if (!ParamVar->getIdentifier())
       return;

--- a/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.cpp
@@ -64,12 +64,14 @@ IdentifierLengthCheck::IdentifierLengthCheck(StringRef Name,
 
 void IdentifierLengthCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "MinimumVariableNameLength", MinimumVariableNameLength);
+  Options.store(Opts, "MinimumBindingNameLength", MinimumBindingNameLength);
   Options.store(Opts, "MinimumLoopCounterNameLength",
                 MinimumLoopCounterNameLength);
   Options.store(Opts, "MinimumExceptionNameLength", MinimumExceptionNameLength);
   Options.store(Opts, "MinimumParameterNameLength", MinimumParameterNameLength);
-  Options.store(Opts, "IgnoredLoopCounterNames", IgnoredLoopCounterNamesInput);
   Options.store(Opts, "IgnoredVariableNames", IgnoredVariableNamesInput);
+  Options.store(Opts, "IgnoredBindingNames", IgnoredBindingNamesInput);
+  Options.store(Opts, "IgnoredLoopCounterNames", IgnoredLoopCounterNamesInput);
   Options.store(Opts, "IgnoredExceptionVariableNames",
                 IgnoredExceptionVariableNamesInput);
   Options.store(Opts, "IgnoredParameterNames", IgnoredParameterNamesInput);
@@ -164,6 +166,10 @@ void IdentifierLengthCheck::check(const MatchFinder::MatchResult &Result) {
 
     if (VarName.size() >= MinimumBindingNameLength ||
         IgnoredBindingNames.match(VarName))
+      return;
+
+    if (isShortLived(BindingVar, Result.SourceManager, Result.Context,
+                     LineCountThreshold))
       return;
 
     diag(BindingVar->getLocation(), ErrorMessage)

--- a/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierLengthCheck.h
@@ -27,12 +27,16 @@ public:
 
 private:
   const unsigned MinimumVariableNameLength;
+  const unsigned MinimumBindingNameLength;
   const unsigned MinimumLoopCounterNameLength;
   const unsigned MinimumExceptionNameLength;
   const unsigned MinimumParameterNameLength;
 
   std::string IgnoredVariableNamesInput;
   llvm::Regex IgnoredVariableNames;
+
+  std::string IgnoredBindingNamesInput;
+  llvm::Regex IgnoredBindingNames;
 
   std::string IgnoredLoopCounterNamesInput;
   llvm::Regex IgnoredLoopCounterNames;

--- a/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.cpp
+++ b/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.cpp
@@ -366,8 +366,9 @@ bool isOnlyUsedAsConst(const VarDecl &Var, const Stmt &Stmt,
   return isSetDifferenceEmpty(AllDeclRefs, ConstReferenceDeclRefs);
 }
 
-SmallPtrSet<const DeclRefExpr *, 16>
-allDeclRefExprs(const ValueDecl &VarDecl, const Stmt &Stmt, ASTContext &Context) {
+SmallPtrSet<const DeclRefExpr *, 16> allDeclRefExprs(const ValueDecl &VarDecl,
+                                                     const Stmt &Stmt,
+                                                     ASTContext &Context) {
   auto Matches = match(
       findAll(declRefExpr(to(valueDecl(equalsNode(&VarDecl)))).bind("declRef")),
       Stmt, Context);
@@ -376,8 +377,9 @@ allDeclRefExprs(const ValueDecl &VarDecl, const Stmt &Stmt, ASTContext &Context)
   return DeclRefs;
 }
 
-SmallPtrSet<const DeclRefExpr *, 16>
-allDeclRefExprs(const ValueDecl &VarDecl, const Decl &Decl, ASTContext &Context) {
+SmallPtrSet<const DeclRefExpr *, 16> allDeclRefExprs(const ValueDecl &VarDecl,
+                                                     const Decl &Decl,
+                                                     ASTContext &Context) {
   auto Matches = match(
       decl(forEachDescendant(
           declRefExpr(to(valueDecl(equalsNode(&VarDecl)))).bind("declRef"))),

--- a/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.cpp
+++ b/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.cpp
@@ -367,7 +367,7 @@ bool isOnlyUsedAsConst(const VarDecl &Var, const Stmt &Stmt,
 }
 
 SmallPtrSet<const DeclRefExpr *, 16>
-allDeclRefExprs(const VarDecl &VarDecl, const Stmt &Stmt, ASTContext &Context) {
+allDeclRefExprs(const ValueDecl &VarDecl, const Stmt &Stmt, ASTContext &Context) {
   auto Matches = match(
       findAll(declRefExpr(to(varDecl(equalsNode(&VarDecl)))).bind("declRef")),
       Stmt, Context);
@@ -377,7 +377,7 @@ allDeclRefExprs(const VarDecl &VarDecl, const Stmt &Stmt, ASTContext &Context) {
 }
 
 SmallPtrSet<const DeclRefExpr *, 16>
-allDeclRefExprs(const VarDecl &VarDecl, const Decl &Decl, ASTContext &Context) {
+allDeclRefExprs(const ValueDecl &VarDecl, const Decl &Decl, ASTContext &Context) {
   auto Matches = match(
       decl(forEachDescendant(
           declRefExpr(to(varDecl(equalsNode(&VarDecl)))).bind("declRef"))),

--- a/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.cpp
+++ b/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.cpp
@@ -366,23 +366,24 @@ bool isOnlyUsedAsConst(const VarDecl &Var, const Stmt &Stmt,
   return isSetDifferenceEmpty(AllDeclRefs, ConstReferenceDeclRefs);
 }
 
-SmallPtrSet<const DeclRefExpr *, 16> allDeclRefExprs(const ValueDecl &VarDecl,
+SmallPtrSet<const DeclRefExpr *, 16> allDeclRefExprs(const ValueDecl &ValueDecl,
                                                      const Stmt &Stmt,
                                                      ASTContext &Context) {
   auto Matches = match(
-      findAll(declRefExpr(to(valueDecl(equalsNode(&VarDecl)))).bind("declRef")),
+      findAll(
+          declRefExpr(to(valueDecl(equalsNode(&ValueDecl)))).bind("declRef")),
       Stmt, Context);
   SmallPtrSet<const DeclRefExpr *, 16> DeclRefs;
   extractNodesByIdTo(Matches, "declRef", DeclRefs);
   return DeclRefs;
 }
 
-SmallPtrSet<const DeclRefExpr *, 16> allDeclRefExprs(const ValueDecl &VarDecl,
+SmallPtrSet<const DeclRefExpr *, 16> allDeclRefExprs(const ValueDecl &ValueDecl,
                                                      const Decl &Decl,
                                                      ASTContext &Context) {
   auto Matches = match(
       decl(forEachDescendant(
-          declRefExpr(to(valueDecl(equalsNode(&VarDecl)))).bind("declRef"))),
+          declRefExpr(to(valueDecl(equalsNode(&ValueDecl)))).bind("declRef"))),
       Decl, Context);
   SmallPtrSet<const DeclRefExpr *, 16> DeclRefs;
   extractNodesByIdTo(Matches, "declRef", DeclRefs);

--- a/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.cpp
+++ b/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.cpp
@@ -369,7 +369,7 @@ bool isOnlyUsedAsConst(const VarDecl &Var, const Stmt &Stmt,
 SmallPtrSet<const DeclRefExpr *, 16>
 allDeclRefExprs(const ValueDecl &VarDecl, const Stmt &Stmt, ASTContext &Context) {
   auto Matches = match(
-      findAll(declRefExpr(to(varDecl(equalsNode(&VarDecl)))).bind("declRef")),
+      findAll(declRefExpr(to(valueDecl(equalsNode(&VarDecl)))).bind("declRef")),
       Stmt, Context);
   SmallPtrSet<const DeclRefExpr *, 16> DeclRefs;
   extractNodesByIdTo(Matches, "declRef", DeclRefs);
@@ -380,7 +380,7 @@ SmallPtrSet<const DeclRefExpr *, 16>
 allDeclRefExprs(const ValueDecl &VarDecl, const Decl &Decl, ASTContext &Context) {
   auto Matches = match(
       decl(forEachDescendant(
-          declRefExpr(to(varDecl(equalsNode(&VarDecl)))).bind("declRef"))),
+          declRefExpr(to(valueDecl(equalsNode(&VarDecl)))).bind("declRef"))),
       Decl, Context);
   SmallPtrSet<const DeclRefExpr *, 16> DeclRefs;
   extractNodesByIdTo(Matches, "declRef", DeclRefs);

--- a/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.h
+++ b/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.h
@@ -17,11 +17,11 @@ namespace clang::tidy::utils::decl_ref_expr {
 
 /// Returns set of all ``DeclRefExprs`` to ``VarDecl`` within ``Stmt``.
 llvm::SmallPtrSet<const DeclRefExpr *, 16>
-allDeclRefExprs(const VarDecl &VarDecl, const Stmt &Stmt, ASTContext &Context);
+allDeclRefExprs(const ValueDecl &VarDecl, const Stmt &Stmt, ASTContext &Context);
 
 /// Returns set of all ``DeclRefExprs`` to ``VarDecl`` within ``Decl``.
 llvm::SmallPtrSet<const DeclRefExpr *, 16>
-allDeclRefExprs(const VarDecl &VarDecl, const Decl &Decl, ASTContext &Context);
+allDeclRefExprs(const ValueDecl &VarDecl, const Decl &Decl, ASTContext &Context);
 
 /// Returns set of all ``DeclRefExprs`` to ``VarDecl`` within ``Stmt`` where
 /// ``VarDecl`` is guaranteed to be accessed in a const fashion.

--- a/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.h
+++ b/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.h
@@ -15,14 +15,14 @@
 
 namespace clang::tidy::utils::decl_ref_expr {
 
-/// Returns set of all ``DeclRefExprs`` to ``VarDecl`` within ``Stmt``.
+/// Returns set of all ``DeclRefExprs`` to ``ValueDecl`` within ``Stmt``.
 llvm::SmallPtrSet<const DeclRefExpr *, 16>
-allDeclRefExprs(const ValueDecl &VarDecl, const Stmt &Stmt,
+allDeclRefExprs(const ValueDecl &ValueDecl, const Stmt &Stmt,
                 ASTContext &Context);
 
-/// Returns set of all ``DeclRefExprs`` to ``VarDecl`` within ``Decl``.
+/// Returns set of all ``DeclRefExprs`` to ``ValueDecl`` within ``Decl``.
 llvm::SmallPtrSet<const DeclRefExpr *, 16>
-allDeclRefExprs(const ValueDecl &VarDecl, const Decl &Decl,
+allDeclRefExprs(const ValueDecl &ValueDecl, const Decl &Decl,
                 ASTContext &Context);
 
 /// Returns set of all ``DeclRefExprs`` to ``VarDecl`` within ``Stmt`` where

--- a/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.h
+++ b/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.h
@@ -17,11 +17,13 @@ namespace clang::tidy::utils::decl_ref_expr {
 
 /// Returns set of all ``DeclRefExprs`` to ``VarDecl`` within ``Stmt``.
 llvm::SmallPtrSet<const DeclRefExpr *, 16>
-allDeclRefExprs(const ValueDecl &VarDecl, const Stmt &Stmt, ASTContext &Context);
+allDeclRefExprs(const ValueDecl &VarDecl, const Stmt &Stmt,
+                ASTContext &Context);
 
 /// Returns set of all ``DeclRefExprs`` to ``VarDecl`` within ``Decl``.
 llvm::SmallPtrSet<const DeclRefExpr *, 16>
-allDeclRefExprs(const ValueDecl &VarDecl, const Decl &Decl, ASTContext &Context);
+allDeclRefExprs(const ValueDecl &VarDecl, const Decl &Decl,
+                ASTContext &Context);
 
 /// Returns set of all ``DeclRefExprs`` to ``VarDecl`` within ``Stmt`` where
 /// ``VarDecl`` is guaranteed to be accessed in a const fashion.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -504,16 +504,16 @@ Changes in existing checks
   it easier to see which specific enumerators need explicit initialization.
 
 - Improved :doc:`readability-identifier-length
-  <clang-tidy/checks/readability/identifier-length>` check by adding a new
-  option, named `LineCountThreshold`, to silence warnings for short-lived
-  variables, based on distance between declaration and last use.
+  <clang-tidy/checks/readability/identifier-length>` check:
 
-- Improved :doc:`readability-identifier-length
-  <clang-tidy/checks/readability/identifier-length>` check by adding support
-  for structured bindings. Two new options, `MinimumBindingNameLength` and
-  `IgnoredBindingNames`, are added to configure the behavior of the check
-  regarding this new identifier kind. By default, names with at least 2
-  characters are required and the only expection allowed is `_`.
+  - A new option, named `LineCountThreshold`, is added to silence warnings for
+    short-lived variables, based on distance between declaration and last use.
+
+  - Support for structured bindings is added. Two new options, named
+    `MinimumBindingNameLength` and `IgnoredBindingNames` respectively, are
+    added to configure the behavior of the check regarding this new identifier
+    kind. By default, names with at least 2 characters are required and the
+    only expection allowed is `_`.
 
 - Improved :doc:`readability-identifier-naming
   <clang-tidy/checks/readability/identifier-naming>` check:

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -508,6 +508,13 @@ Changes in existing checks
   option, named `LineCountThreshold`, to silence warnings for short-lived
   variables, based on distance between declaration and last use.
 
+- Improved :doc:`readability-identifier-length
+  <clang-tidy/checks/readability/identifier-length>` check by adding support
+  for structured bindings. Two new options, `MinimumBindingNameLength` and
+  `IgnoredBindingNames`, are added to configure the behavior of the check
+  regarding this new identifier kind. By default, names with at least 2
+  characters are required and the only expection allowed is `_`.
+
 - Improved :doc:`readability-identifier-naming
   <clang-tidy/checks/readability/identifier-naming>` check:
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -513,7 +513,7 @@ Changes in existing checks
     `MinimumBindingNameLength` and `IgnoredBindingNames` respectively, are
     added to configure the behavior of the check regarding this new identifier
     kind. By default, names with at least 2 characters are required and the
-    only expection allowed is `_`.
+    only exception allowed is `_`.
 
 - Improved :doc:`readability-identifier-naming
   <clang-tidy/checks/readability/identifier-naming>` check:

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-length.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-length.rst
@@ -14,6 +14,7 @@ Options
 The following options are described below:
 
  - :option:`MinimumVariableNameLength`, :option:`IgnoredVariableNames`
+ - :option:`MinimumBindingNameLength`, :option:`IgnoredBindingNames`
  - :option:`MinimumParameterNameLength`, :option:`IgnoredParameterNames`
  - :option:`MinimumLoopCounterNameLength`, :option:`IgnoredLoopCounterNames`
  - :option:`MinimumExceptionNameLength`,
@@ -39,6 +40,25 @@ The following options are described below:
 
     Specifies a regular expression for variable names that are
     to be ignored. The default value is empty, thus no names are ignored.
+
+.. option:: MinimumBindingNameLength
+
+    All variables introduced by structured bindings are expected to have at
+    least a length of `MinimumBindingNameLength` (default is `2`). Setting it
+    to `0` or `1` disables the check entirely.
+
+    .. code-block:: c++
+
+      auto [a] = get_result();    // warns that 'a' is too short
+
+    This check does not have any fix suggestions in the general case since
+    variable names have semantic value.
+
+.. option:: IgnoredBindingNames
+
+    Specifies a regular expression for variable names introduced by structured
+    bindings that are to be ignored. The default value is `^[_]$`, to allow the
+    use of the `_` idiom to specify that the value is discarded on purpose.
 
 .. option:: MinimumParameterNameLength
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-length-structured-bindings.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-length-structured-bindings.cpp
@@ -1,6 +1,6 @@
 
 // RUN: %check_clang_tidy -std=c++17-or-later %s readability-identifier-length %t \
-// RUN: -config='{CheckOptions: {}}' \
+// RUN: -config='{CheckOptions: {readability-identifier-length.LineCountThreshold: 1}}' \
 // RUN: -- -fexceptions
 
 struct aggregate {
@@ -11,13 +11,18 @@ struct aggregate {
 
 aggregate get_data();
 
+template<typename... T>
+void doIt(T...);
+
 void shouldWarn() {
   auto [f, m, l] = get_data();
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: binding variable name 'f' is too short, expected at least 2 characters [readability-identifier-length]
   // CHECK-MESSAGES: :[[@LINE-2]]:12: warning: binding variable name 'm' is too short, expected at least 2 characters [readability-identifier-length]
   // CHECK-MESSAGES: :[[@LINE-3]]:15: warning: binding variable name 'l' is too short, expected at least 2 characters [readability-identifier-length]
+  doIt(f, m, l);
 }
 
 void shouldNotWarn() {
-  auto [_, mid, last] = get_data();
+  auto [_, mid, last] = get_data(); // '_' is accepted by default
+  doIt(_, mid, last);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-length-structured-bindings.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-length-structured-bindings.cpp
@@ -1,4 +1,3 @@
-
 // RUN: %check_clang_tidy -std=c++17-or-later %s readability-identifier-length %t \
 // RUN: -config='{CheckOptions: {readability-identifier-length.LineCountThreshold: 1}}' \
 // RUN: -- -fexceptions

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-length-structured-bindings.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-length-structured-bindings.cpp
@@ -24,4 +24,6 @@ void shouldWarn() {
 void shouldNotWarn() {
   auto [_, mid, last] = get_data(); // '_' is accepted by default
   doIt(_, mid, last);
+
+  auto [f, m, l] = get_data(); // short names but does not exceed the line count threshold
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-length-structured-bindings.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-length-structured-bindings.cpp
@@ -1,0 +1,23 @@
+
+// RUN: %check_clang_tidy -std=c++17-or-later %s readability-identifier-length %t \
+// RUN: -config='{CheckOptions: {}}' \
+// RUN: -- -fexceptions
+
+struct aggregate {
+  int first;
+  double middle;
+  bool last;
+};
+
+aggregate get_data();
+
+void shouldWarn() {
+  auto [f, m, l] = get_data();
+  // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: binding variable name 'f' is too short, expected at least 2 characters [readability-identifier-length]
+  // CHECK-MESSAGES: :[[@LINE-2]]:12: warning: binding variable name 'm' is too short, expected at least 2 characters [readability-identifier-length]
+  // CHECK-MESSAGES: :[[@LINE-3]]:15: warning: binding variable name 'l' is too short, expected at least 2 characters [readability-identifier-length]
+}
+
+void shouldNotWarn() {
+  auto [_, mid, last] = get_data();
+}


### PR DESCRIPTION
This PR extends the `readability-identifier-length` check to structured binding declarations. Currently, only the names of regular variables, function parameters, exceptions variables in catch blocks and loop variables are checked. In other words, `int a = ...` warns but `auto [a] = ...` does not.

This PR enables the check to warn when the length of the names introduced in structured bindings declarations is too short, following the same rules as for the other kinds of declarations. Two new options are introduced:
- `MinimumBindingNameLength` defines the number of characters below which a warning is issued (the default it set to 2, like for loop variables and exceptions variables)
- `IgnoredBindingNames` defines the names for which warnings should not issued (by default, `_` is the only allowed exception)

To implement this feature, a new matcher is registered which matches all the individual binding names. For example, in `auto [x, y] = ...`, it matches `x` and `y` separately and the logic for determining if a warning should be issued is applied independently to each binding name introduced. Unlike the other matchers which return `VarDecl` nodes, this new matcher returns `BindingDecl` nodes. The `utils::allDeclRefExpr` helper function is modified to work for any `ValueDecl` node (the closest common ancestor of `VarDecl` and `BindingDecl`) in order for the line count threshold feature to work with this extension. 