### PR TITLE
[lldb/test] Fix TestOSIndSYM for Darwin embedded platforms

### DIFF
--- a/lldb/test/API/functionalities/plugins/python_os_plugin/os_plugin_in_dsym/TestOSIndSYM.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/os_plugin_in_dsym/TestOSIndSYM.py
@@ -43,41 +43,38 @@ class TestOSPluginIndSYM(TestBase):
 
     @skipUnlessDarwin
     def test_python_os_plugin(self):
-        self.do_test_python_os_plugin(False)
+        """Test that the OS plugin in a dSYM works on attach."""
+        executable = self.build_dsym("my_binary")
+        self.runCmd("settings set target.load-script-from-symbol-file true")
 
+        target = self.dbg.CreateTarget(executable)
+        self.assertTrue(target.IsValid(), "Got a valid target")
+
+        popen = self.spawnSubprocess(executable, [])
+        error = lldb.SBError()
+        process = target.AttachToProcessWithID(lldb.SBListener(), popen.pid, error)
+        self.assertSuccess(error, "Attach succeeded")
+
+        self.verify_os_plugin(process)
+
+    @skipIfDarwinEmbedded
     @skipTestIfFn(no_debugserver)
     @skipTestIfFn(port_not_available)
     def test_python_os_plugin_remote(self):
-        self.do_test_python_os_plugin(True)
-
-    def do_test_python_os_plugin(self, remote):
-        """Test that the environment for os plugins in dSYM's is correct"""
+        """Test that the OS plugin in a dSYM works over a remote connection."""
         executable = self.build_dsym("my_binary")
-
-        # Make sure we're set up to load the symbol file's python
         self.runCmd("settings set target.load-script-from-symbol-file true")
 
-        target = self.dbg.CreateTarget(None)
+        target = self.dbg.CreateTarget(executable)
+        self.assertTrue(target.IsValid(), "Got a valid target")
 
-        error = lldb.SBError()
+        self.setup_remote_platform(executable)
+        process = target.process
+        self.assertTrue(process.IsValid(), "Got a valid process from debugserver")
 
-        # Now run the process, and then attach.  When the attach
-        # succeeds, make sure that we were in the right state when
-        # the OS plugins were run.
-        if not remote:
-            popen = self.spawnSubprocess(executable, [])
+        self.verify_os_plugin(process)
 
-            process = target.AttachToProcessWithID(lldb.SBListener(), popen.pid, error)
-            self.assertSuccess(error, "Attach succeeded")
-        else:
-            self.setup_remote_platform(executable)
-            process = target.process
-            self.assertTrue(process.IsValid(), "Got a valid process from debugserver")
-
-        # We should have figured out the target from the result of the attach:
-        self.assertTrue(target.IsValid, "Got a valid target")
-
-        # Make sure that we got the right plugin:
+    def verify_os_plugin(self, process):
         self.expect(
             "settings show target.process.python-os-plugin-path",
             substrs=["operating_system.py"],
@@ -87,10 +84,6 @@ class TestOSPluginIndSYM(TestBase):
             stack_depth = thread.num_frames
             reg_threads = thread.frames[0].reg
 
-        # OKAY, that realized the threads, now see if the creation
-        # state was correct.  The way we use the OS plugin, it doesn't need
-        # to create a thread, and doesn't have to call get_register_info,
-        # so we don't expect those to get called.
         self.expect(
             "test_report_command",
             substrs=[


### PR DESCRIPTION
The test used CreateTarget(None) and relied on the attach to discover the executable and load the dSYM. On remote platforms this doesn't find the local dSYM, so the OS plugin never loads. Switch to CreateTarget(executable) so the dSYM Python module is loaded before attach.

Also split the test into two methods: test_python_os_plugin uses spawn+attach which works both locally and on real remote platforms, while test_python_os_plugin_remote simulates remote debugging by manually spawning debugserver and is skipped on embedded platforms where this setup conflicts with lldb-platform.

rdar://175455380