### PR TITLE
[lldb/test] Fix TestModuleLoadedNotifys duplicate module check

### DIFF
--- a/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
@@ -111,7 +111,11 @@ class ModuleLoadedNotifysTestCase(TestBase):
                         # shared cache. Use the basename so this also works
                         # when reading dyld from the expanded shared cache.
                         exe_basename = lldb.SBFileSpec(exe).basename
-                        if module.file.basename not in ["dyld", exe_basename]:
+                        if module.file.basename not in [
+                            "dyld",
+                            "libsharedcache.dylib",
+                            exe_basename,
+                        ]:
                             self.assertNotIn(
                                 module,
                                 already_loaded_modules,


### PR DESCRIPTION
Similar to dyld and the main binary, `libsharedcache.dylib` can appear in module-loaded events more than once. Add it to the exclusion list so the duplicate check doesn't fail.

rdar://175458917