### PR TITLE
[lldb] Fix build logic in TestPtrAuthExpressions.py

### DIFF
--- a/lldb/test/API/commands/expression/ptrauth/TestPtrAuthExpressions.py
+++ b/lldb/test/API/commands/expression/ptrauth/TestPtrAuthExpressions.py
@@ -10,12 +10,9 @@ class TestPtrAuthExpressions(TestBase):
     SHARED_BUILD_TESTCASE = False
 
     def build_arm64e(self):
-        if "arm64e" in configuration.triple:
-            self.build()
-        else:
-            self.build(
-                dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
-            )
+        self.build(
+            dictionary={"TRIPLE": configuration.triple.replace("arm64-", "arm64e-")}
+        )
 
     @skipUnlessArm64eSupported
     def test_static_function_pointer(self):

--- a/lldb/test/API/commands/expression/ptrauth/TestPtrAuthExpressions.py
+++ b/lldb/test/API/commands/expression/ptrauth/TestPtrAuthExpressions.py
@@ -10,9 +10,12 @@ class TestPtrAuthExpressions(TestBase):
     SHARED_BUILD_TESTCASE = False
 
     def build_arm64e(self):
-        self.build(
-            dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
-        )
+        if "arm64e" in configuration.triple:
+            self.build()
+        else:
+            self.build(
+                dictionary={"TRIPLE": configuration.triple.replace("arm64", "arm64e")}
+            )
 
     @skipUnlessArm64eSupported
     def test_static_function_pointer(self):


### PR DESCRIPTION
If the triple already has `arm64e` in it, we'll end up with `arm64ee` which is definitely wrong.