### PR TITLE
[lldb] Change TestPublicAPIHeaders.py to only build when the target architecture matches the host's

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1419,7 +1419,7 @@ def skipUnlessPackageAvailable(name):
     return unittest.skipUnless(available, f"requires the '{name}' package")
 
 
-def skipUnlessLLDBFrameworkArchMatches(func):
+def skipUnlessTargetIsHost(func):
     """Skip the test case if the test binary architecture does not match LLDB.framework."""
 
     def check_arch_match():

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1417,3 +1417,21 @@ def skipUnlessPackageAvailable(name):
         available = False
 
     return unittest.skipUnless(available, f"requires the '{name}' package")
+
+
+def skipUnlessLLDBFrameworkArchMatches(func):
+    """Skip the test case if the test binary architecture does not match LLDB.framework."""
+
+    def check_arch_match():
+        if not configuration.lldb_framework_path:
+            return "LLDB.framework was not built."
+
+        # The lldb executable is built the same as the framework.
+        lldb_arch = lldbplatformutil.getLLDBArchitecture()
+        test_arch = lldbplatformutil.getArchitecture()
+
+        if lldb_arch != test_arch:
+            return "Test binary architecture differs from LLDB.framework architecture"
+        return None
+
+    return skipTestIfFn(check_arch_match)(func)

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1423,9 +1423,6 @@ def skipUnlessTargetIsHost(func):
     """Skip the test case if the test binary architecture does not match LLDB.framework."""
 
     def check_arch_match():
-        if not configuration.lldb_framework_path:
-            return "LLDB.framework was not built."
-
         # The lldb executable is built the same as the framework.
         lldb_arch = lldbplatformutil.getLLDBArchitecture()
         test_arch = lldbplatformutil.getArchitecture()

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1428,7 +1428,7 @@ def skipUnlessTargetIsHost(func):
         test_arch = lldbplatformutil.getArchitecture()
 
         if lldb_arch != test_arch:
-            return "Test binary architecture differs from LLDB.framework architecture"
+            return "Test binary architecture differs from host architecture"
         return None
 
     return skipTestIfFn(check_arch_match)(func)

--- a/lldb/test/API/api/check_public_api_headers/TestPublicAPIHeaders.py
+++ b/lldb/test/API/api/check_public_api_headers/TestPublicAPIHeaders.py
@@ -11,7 +11,7 @@ from lldbsuite.test import lldbutil
 @skipIfNoSBHeaders
 @skipIfRemote
 @skipUnlessDarwin
-@skipIf(archs=["arm64e"])
+@skipUnlessLLDBFrameworkArchMatches
 class SBDirCheckerCase(TestBase):
     SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/api/check_public_api_headers/TestPublicAPIHeaders.py
+++ b/lldb/test/API/api/check_public_api_headers/TestPublicAPIHeaders.py
@@ -11,7 +11,7 @@ from lldbsuite.test import lldbutil
 @skipIfNoSBHeaders
 @skipIfRemote
 @skipUnlessDarwin
-@skipUnlessLLDBFrameworkArchMatches
+@skipUnlessTargetIsHost
 class SBDirCheckerCase(TestBase):
     SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/api/check_public_api_headers/TestPublicAPIHeaders.py
+++ b/lldb/test/API/api/check_public_api_headers/TestPublicAPIHeaders.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 @skipIfNoSBHeaders
 @skipIfRemote
 @skipUnlessDarwin
+@skipIf(archs=["arm64e"])
 class SBDirCheckerCase(TestBase):
     SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True


### PR DESCRIPTION
This test requires that LLDB.framework be built the same architecture as the test binary (effectively). There's no way to specify that in our testing logic currently, so let's just mark this test as arm64 only for now.