### PR TITLE
[CIR] Tolerate identical source and destination in cir.copy

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2968,9 +2968,6 @@ LogicalResult cir::CopyOp::verify() {
   if (!getType().getPointee().hasTrait<DataLayoutTypeInterface::Trait>())
     return emitError() << "missing data layout for pointee type";
 
-  if (getSrc() == getDst())
-    return emitError() << "source and destination are the same";
-
   if (getSkipTailPadding() &&
       !mlir::isa<cir::RecordType>(getType().getPointee()))
     return emitError()

--- a/clang/test/CIR/CodeGen/self-assign.c
+++ b/clang/test/CIR/CodeGen/self-assign.c
@@ -1,0 +1,27 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+// This is UB, but Clang allows it and it is used in one of the
+// llvm-test-suite MultiSource tests.
+
+struct S {
+  int a;
+  int b;
+  int c;
+};
+
+void test_self_initialize() {
+  struct S s = s;
+}
+
+// CIR: cir.func{{.*}} @test_self_initialize()
+//   %[[S:.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["s", init]
+//   cir.copy %[[S]] to %[[S]] : !cir.ptr<!rec_S>
+
+// LLVM: define{{.*}} void @test_self_initialize()
+// LLVM:   %[[S:.*]] = alloca %struct.S
+// LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr{{.*}} %[[S]], ptr{{.*}} %[[S]], i64 12, i1 false)

--- a/clang/test/CIR/IR/invalid-copy.cir
+++ b/clang/test/CIR/IR/invalid-copy.cir
@@ -12,17 +12,6 @@ module {
 // -----
 
 module {
-  // Should not copy to same address.
-  cir.func @invalid_copy(%arg0 : !cir.ptr<!cir.int<s, 8>>) {
-    // expected-error@+1 {{source and destination are the same}}
-    cir.copy %arg0 to %arg0 : !cir.ptr<!cir.int<s, 8>>
-    cir.return
-  }
-}
-
-// -----
-
-module {
   // skip_tail_padding is only valid for record pointee types.
   cir.func @invalid_skip_tail_padding(%arg0 : !cir.ptr<!cir.int<s, 32>>, %arg1 : !cir.ptr<!cir.int<s, 32>>) {
     // expected-error@+1 {{skip_tail_padding is only valid for record pointee types}}


### PR DESCRIPTION
The SIBsim4 test in the llvm-test-suite MultiSource tests has code that initializes a structure with itself. This was triggering a CIR verifcation error because we were checking for source and destination addresses matching. Since Clang allows this, this change is updating the cir.copy operation to allow it.