### PR TITLE
[lldb] Add regression test for stale Symbol pointer crash in statusline

### DIFF
--- a/lldb/test/API/functionalities/statusline/TestStatusline.py
+++ b/lldb/test/API/functionalities/statusline/TestStatusline.py
@@ -123,6 +123,45 @@ class TestStatusline(PExpectTest):
         self.child.expect(re.escape("\x1b[1;19r"))
         self.child.expect("(lldb)")
 
+    @skipUnlessPlatform(["linux"])
+    def test_target_symbols_add(self):
+        """Regression test: adding symbols while the statusline is enabled
+        should not crash. The bug was a stale Symbol pointer in the cached
+        execution context after Symtab reallocation; best caught under ASAN."""
+        import shutil
+        import subprocess
+
+        self.build()
+        symfile = self.getBuildArtifact("a.out")
+        stripped_exe = self.getBuildArtifact("stripped.out")
+        shutil.copy2(symfile, stripped_exe)
+        subprocess.check_call(["strip", "--strip-debug", stripped_exe])
+        self.launch(timeout=self.TIMEOUT)
+
+        self.expect(
+            "target create {}".format(stripped_exe),
+            substrs=["Current executable set to"],
+        )
+        self.expect("breakpoint set -n main", substrs=["Breakpoint 1"])
+        self.expect("run", substrs=["stop reason"])
+        self.resize()
+
+        self.expect('set set separator "| "')
+        self.expect(
+            "set set show-statusline true",
+            ["stripped.out | breakpoint 1.1"],
+        )
+
+        # Adding symbols triggers Process::Flush() which (with the fix)
+        # clears the statusline's cached execution context. The expect()
+        # helper waits for the (lldb) prompt, which triggers a statusline
+        # redraw via Redraw(std::nullopt) using the cached (now cleared)
+        # context. Under ASAN, a stale Symbol* here would crash.
+        self.expect(
+            "target symbols add -s {} {}".format(stripped_exe, symfile),
+            ["has been added to"],
+        )
+
     @skipIfRemote
     @skipIfWindows
     @skipIfDarwin


### PR DESCRIPTION
Add a test that exercises the code path fixed in [88f024223cc4](https://github.com/llvm/llvm-project/pull/188377) ("[lldb] Fix stale Symbol pointer crash in statusline after 'target symbols add'").

The bug: when `target symbols add` is called, `Symtab::AddSymbol()` can reallocate the underlying `std::vector<Symbol>`, invalidating all existing `Symbol*` pointers. The statusline caches an `ExecutionContextRef` containing a `StackID` with a `SymbolContextScope*` (which can be a `Symbol*`). If a concurrent statusline redraw occurs between the Symtab reallocation and `Process::Flush()` (e.g. from a progress event on the event handler thread), the cached `StackID` matches the old frame via pointer-equal comparison, and `GetSymbolContext()` dereferences the dangling `Symbol*`.

The test:
  1. Builds a stripped binary and its unstripped counterpart.
  2. Runs the stripped binary and stops at a breakpoint in `main`.
  3. Enables the statusline (populating the cached `ExecutionContextRef`).
  4. Calls `target symbols add` to add debug symbols back.
  5. Forces a statusline redraw via terminal resize, which calls `Redraw(std::nullopt)` using the cached (potentially stale) execution context.
  6. Verifies the statusline still renders correctly.

The dangling pointer is a use-after-free that silently succeeds in non-sanitizer builds (the freed memory is still accessible). This test is most effective under AddressSanitizer, which poisons freed memory and immediately detects the stale access.