### PR TITLE
[NFC][Clang][ByteCode] Apply rule of three to Context and EvalIDScope

### DIFF
--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -35,7 +35,7 @@ Context::Context(ASTContext &Ctx) : Ctx(Ctx), P(new Program(*this)) {
          "We're assuming 8 bit chars");
 }
 
-Context::~Context() {}
+Context::~Context() = default;
 
 bool Context::isPotentialConstantExpr(State &Parent, const FunctionDecl *FD) {
   assert(Stk.empty());

--- a/clang/lib/AST/ByteCode/Context.h
+++ b/clang/lib/AST/ByteCode/Context.h
@@ -200,6 +200,8 @@ class EvalIDScope {
 public:
   EvalIDScope(Context &Ctx) : Ctx(Ctx), OldID(Ctx.EvalID) { ++Ctx.EvalID; }
   ~EvalIDScope() { Ctx.EvalID = OldID; }
+  EvalIDScope(const EvalIDScope &) = delete;
+  EvalIDScope &operator=(const EvalIDScope &) = delete;
 
 private:
   Context &Ctx;


### PR DESCRIPTION
Static analysis flagged these because they had destructor but did not define copy constructor or copy assignment. For `EvalIDScope` I defined them as deleted and was able to default the destructor for `Context`.