### PR TITLE
[lldb] Rewrite make rules for TestFileBreakpointsSameCUName.py

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/same_cu_name/Makefile
+++ b/lldb/test/API/functionalities/breakpoint/same_cu_name/Makefile
@@ -1,19 +1,19 @@
 CXX_SOURCES := main.cpp
 LD_EXTRAS := ns1.o ns2.o ns3.o ns4.o
 
+include Makefile.rules
+
 a.out: main.o ns1.o ns2.o ns3.o ns4.o
 
 ns1.o: common.cpp
-	$(CXX) -gdwarf -c -DNAMESPACE=ns1 -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -DNAMESPACE=ns1 -o $@ $<
 
 ns2.o: common.cpp
-	$(CXX) -gdwarf -c -DNAMESPACE=ns2 -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -DNAMESPACE=ns2 -o $@ $<
 
 ns3.o: common.cpp
-	$(CXX) -gdwarf -c -DNAMESPACE=ns3 -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -DNAMESPACE=ns3 -o $@ $<
 
 ns4.o: common.cpp
-	$(CXX) -gdwarf -c -DNAMESPACE=ns4 -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -DNAMESPACE=ns4 -o $@ $<
 
-
-include Makefile.rules


### PR DESCRIPTION
The logic for building the test cases did not consider the target triple. The easiest thing to do is use the CXXFLAGS computed by Makefile.rules (which calculates this correctly).