### PR TITLE
[lldb][test] Remove ARCH_CXXFLAGS

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -305,7 +305,7 @@ ifeq ($(CC_TYPE), clang)
 endif
 
 CFLAGS += $(CFLAGS_EXTRAS)
-CXXFLAGS += -std=c++11 $(CFLAGS) $(ARCH_CXXFLAGS)
+CXXFLAGS += -std=c++11 $(CFLAGS)
 # Copy common options to the linker flags (dwarf, arch. & etc).
 # Note: we get some 'garbage' options for linker here (such as -I, --isystem & etc).
 LDFLAGS += $(CFLAGS)


### PR DESCRIPTION
This variable isn't defined anywhere. The way CXXFLAGS get the correct architecture/target triple is through `CFLAGS` (which gets it from `ARCH_CFLAGS`).