### PR TITLE
[IR] Fix null pointer dereference in Constant::toConstantRange() for ConstantByte

### DIFF
--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -1989,7 +1989,7 @@ ConstantRange Constant::toConstantRange() const {
       auto *CB = dyn_cast<ConstantByte>(Elem);
       if (!CI && !CB)
         return ConstantRange::getFull(BitWidth);
-      CR = CR.unionWith(CI->getValue());
+      CR = CR.unionWith(CI ? CI->getValue() : CB->getValue());
     }
     return CR;
   }

--- a/llvm/unittests/IR/ConstantsTest.cpp
+++ b/llvm/unittests/IR/ConstantsTest.cpp
@@ -10,6 +10,7 @@
 #include "llvm-c/Core.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/IR/ConstantFold.h"
+#include "llvm/IR/ConstantRange.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instruction.h"
@@ -866,6 +867,30 @@ TEST(ConstantsTest, Float128Test) {
   EXPECT_TRUE(val7 != nullptr);
   LLVMDisposeBuilder(Builder);
   LLVMContextDispose(C);
+}
+
+TEST(ConstantsTest, ToConstantRangeConstantByteVector) {
+  LLVMContext Context;
+  // Use 7-bit ByteType so the vector is not folded into ConstantDataVector
+  // (ConstantDataSequential only supports 8/16/32/64-bit element types).
+  ByteType *B7Ty = Type::getByteNTy(Context, 7);
+
+  ConstantByte *CB1 = ConstantByte::get(B7Ty, 10);
+  ConstantByte *CB2 = ConstantByte::get(B7Ty, 20);
+  Constant *Elts[] = {CB1, CB2};
+  Constant *CV = ConstantVector::get(Elts);
+  ASSERT_TRUE(isa<ConstantVector>(CV));
+
+  ConstantRange CR = CV->toConstantRange();
+  EXPECT_TRUE(CR.contains(APInt(7, 10)));
+  EXPECT_TRUE(CR.contains(APInt(7, 20)));
+
+  Constant *CVWithPoison =
+      ConstantVector::get({CB1, PoisonValue::get(B7Ty), CB2});
+  ASSERT_TRUE(isa<ConstantVector>(CVWithPoison));
+  ConstantRange CRPoison = CVWithPoison->toConstantRange();
+  EXPECT_TRUE(CRPoison.contains(APInt(7, 10)));
+  EXPECT_TRUE(CRPoison.contains(APInt(7, 20)));
 }
 
 } // end anonymous namespace

--- a/llvm/unittests/IR/ConstantsTest.cpp
+++ b/llvm/unittests/IR/ConstantsTest.cpp
@@ -882,15 +882,13 @@ TEST(ConstantsTest, ToConstantRangeConstantByteVector) {
   ASSERT_TRUE(isa<ConstantVector>(CV));
 
   ConstantRange CR = CV->toConstantRange();
-  EXPECT_TRUE(CR.contains(APInt(7, 10)));
-  EXPECT_TRUE(CR.contains(APInt(7, 20)));
+  EXPECT_EQ(CR, ConstantRange(APInt(7, 10), APInt(7, 21)));
 
   Constant *CVWithPoison =
       ConstantVector::get({CB1, PoisonValue::get(B7Ty), CB2});
   ASSERT_TRUE(isa<ConstantVector>(CVWithPoison));
   ConstantRange CRPoison = CVWithPoison->toConstantRange();
-  EXPECT_TRUE(CRPoison.contains(APInt(7, 10)));
-  EXPECT_TRUE(CRPoison.contains(APInt(7, 20)));
+  EXPECT_EQ(CRPoison, ConstantRange(APInt(7, 10), APInt(7, 21)));
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
In the ConstantVector path of toConstantRange(), the code checks that each element is either a ConstantInt or ConstantByte but unconditionally dereferences the ConstantInt pointer to get the value. When the element is a ConstantByte, the ConstantInt pointer is null, causing a crash.

This was introduced in 57568c288dbe when ConstantByte support was added to toConstantRange() but the fallback to CB->getValue() was missed.