### PR TITLE
[Clang][SPIRV] Add getSRetAddrSpace() for SPIRV

### DIFF
--- a/clang/lib/CodeGen/Targets/SPIR.cpp
+++ b/clang/lib/CodeGen/Targets/SPIR.cpp
@@ -9,6 +9,7 @@
 #include "ABIInfoImpl.h"
 #include "HLSLBufferLayoutBuilder.h"
 #include "TargetInfo.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/Basic/LangOptions.h"
 #include "llvm/IR/DerivedTypes.h"
 
@@ -144,6 +145,8 @@ public:
     return getABIInfo().getTarget().getTriple().getVendor() !=
            llvm::Triple::AMD;
   }
+
+  LangAS getSRetAddrSpace(const CXXRecordDecl *RD) const override;
 };
 } // End anonymous namespace.
 
@@ -443,6 +446,14 @@ void computeSPIRKernelABIInfo(CodeGenModule &CGM, CGFunctionInfo &FI) {
 
 unsigned CommonSPIRTargetCodeGenInfo::getDeviceKernelCallingConv() const {
   return llvm::CallingConv::SPIR_KERNEL;
+}
+
+LangAS SPIRVTargetCodeGenInfo::getSRetAddrSpace(const CXXRecordDecl *RD) const {
+  // Types with no viable copy/move must be constructed in-place, use the
+  // default AS so the sret pointer matches the "this" convention.
+  if (RD && !RD->canPassInRegisters())
+    return LangAS::Default;
+  return getASTAllocaAddressSpace();
 }
 
 void SPIRVTargetCodeGenInfo::setCUDAKernelCallingConvention(

--- a/clang/test/CodeGenCXX/no-elide-constructors.cpp
+++ b/clang/test/CodeGenCXX/no-elide-constructors.cpp
@@ -29,8 +29,7 @@ X Test()
   // CHECK-CXX98: call void @_ZN1XC1ERKS_(
   // CHECK-CXX11: call void @_ZN1XC1EOS_(
   // CHECK-CXX11-NONZEROALLOCAAS: call void @_ZN1XC1EOS_(ptr noundef nonnull align 1 dereferenceable(1) [[AGG_RESULT]]
-  // CHECK-CXX11-SPIRV: [[TMP0:%.*]] = addrspacecast ptr [[AGG_RESULT]] to ptr addrspace(4)
-  // CHECK-CXX11-SPIRV-NEXT: call spir_func addrspace(4) void @_ZN1XC1EOS_(ptr addrspace(4) noundef align 1 dereferenceable{{.*}}(1) [[TMP0]]
+  // CHECK-CXX11-SPIRV: call spir_func addrspace(4) void @_ZN1XC1EOS_(ptr addrspace(4) noundef align 1 dereferenceable{{.*}}(1) [[AGG_RESULT]]
   // CHECK-CXX98-ELIDE-NOT: call void @_ZN1XC1ERKS_(
   // CHECK-CXX11-ELIDE-NOT: call void @_ZN1XC1EOS_(
   // CHECK-CXX11-NONZEROALLOCAAS-ELIDE-NOT: call void @_ZN1XC1EOS_(

--- a/clang/test/CodeGenHIP/sret-lifetime-markers.cpp
+++ b/clang/test/CodeGenHIP/sret-lifetime-markers.cpp
@@ -54,7 +54,8 @@ template void add_functor<4>(SuperScalar<4>*, int, SuperScalar<4>&);
 // SPIRV-NEXT:    [[IDXPROM:%.*]] = sext i32 [[I]] to i64
 // SPIRV-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds [32 x i8], ptr addrspace(4) [[DATA]], i64 [[IDXPROM]]
 // SPIRV-NEXT:    call addrspace(4) void @llvm.lifetime.start.p0(ptr nonnull [[TMP]]) #[[ATTR3:[0-9]+]]
-// SPIRV-NEXT:    call spir_func addrspace(4) void @_Z16atomic_fetch_addILi4EE11SuperScalarIXT_EEPS1_RKS1_(ptr dead_on_unwind nonnull writable sret([[STRUCT_SUPERSCALAR]]) align 8 [[TMP]], ptr addrspace(4) noundef [[ARRAYIDX]], ptr addrspace(4) noundef align 8 dereferenceable(32) [[UPDATE]]) #[[ATTR3]]
+// SPIRV-NEXT:    [[TMP_ASCAST:%.*]] = addrspacecast ptr [[TMP]] to ptr addrspace(4)
+// SPIRV-NEXT:    call spir_func addrspace(4) void @_Z16atomic_fetch_addILi4EE11SuperScalarIXT_EEPS1_RKS1_(ptr addrspace(4) dead_on_unwind writable sret([[STRUCT_SUPERSCALAR]]) align 8 [[TMP_ASCAST]], ptr addrspace(4) noundef [[ARRAYIDX]], ptr addrspace(4) noundef align 8 dereferenceable(32) [[UPDATE]]) #[[ATTR3]]
 // SPIRV-NEXT:    call addrspace(4) void @llvm.lifetime.end.p0(ptr nonnull [[TMP]]) #[[ATTR3]]
 // SPIRV-NEXT:    ret void
 //

--- a/clang/test/CodeGenHIP/sret-nontrivial-copyable.hip
+++ b/clang/test/CodeGenHIP/sret-nontrivial-copyable.hip
@@ -51,14 +51,12 @@ Wrapper::Wrapper() noexcept : field(make()) {}
 // SPIRV-SAME: ptr addrspace(4) noundef align 8 dereferenceable_or_null(16) [[THIS:%.*]]) unnamed_addr addrspace(4) #[[ATTR0:[0-9]+]] align 2 {
 // SPIRV-NEXT:  [[ENTRY:.*:]]
 // SPIRV-NEXT:    [[THIS_ADDR:%.*]] = alloca ptr addrspace(4), align 8
-// SPIRV-NEXT:    [[TMP:%.*]] = alloca [[STRUCT_NONTRIVIALPTR:%.*]], align 8
 // SPIRV-NEXT:    [[THIS_ADDR_ASCAST:%.*]] = addrspacecast ptr [[THIS_ADDR]] to ptr addrspace(4)
 // SPIRV-NEXT:    store ptr addrspace(4) [[THIS]], ptr addrspace(4) [[THIS_ADDR_ASCAST]], align 8
 // SPIRV-NEXT:    [[THIS1:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[THIS_ADDR_ASCAST]], align 8
 // SPIRV-NEXT:    store ptr addrspace(1) getelementptr inbounds inrange(-16, 16) ({ [4 x ptr addrspace(1)] }, ptr addrspace(1) @_ZTV7Wrapper, i32 0, i32 0, i32 2), ptr addrspace(4) [[THIS1]], align 8
 // SPIRV-NEXT:    [[FIELD:%.*]] = getelementptr inbounds nuw [[STRUCT_WRAPPER:%.*]], ptr addrspace(4) [[THIS1]], i32 0, i32 1
-// SPIRV-NEXT:    call spir_func addrspace(4) void @_Z4makev(ptr dead_on_unwind writable sret([[STRUCT_NONTRIVIALPTR]]) align 8 [[TMP]]) #[[ATTR3:[0-9]+]]
-// SPIRV-NEXT:    call addrspace(4) void @llvm.memcpy.p4.p0.i64(ptr addrspace(4) align 8 [[FIELD]], ptr align 8 [[TMP]], i64 8, i1 false)
+// SPIRV-NEXT:    call spir_func addrspace(4) void @_Z4makev(ptr addrspace(4) dead_on_unwind writable sret([[STRUCT_NONTRIVIALPTR:%.*]]) align 8 [[FIELD]]) #[[ATTR2:[0-9]+]]
 // SPIRV-NEXT:    ret void
 //
 //
@@ -69,6 +67,6 @@ Wrapper::Wrapper() noexcept : field(make()) {}
 // SPIRV-NEXT:    [[THIS_ADDR_ASCAST:%.*]] = addrspacecast ptr [[THIS_ADDR]] to ptr addrspace(4)
 // SPIRV-NEXT:    store ptr addrspace(4) [[THIS]], ptr addrspace(4) [[THIS_ADDR_ASCAST]], align 8
 // SPIRV-NEXT:    [[THIS1:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[THIS_ADDR_ASCAST]], align 8
-// SPIRV-NEXT:    call spir_func addrspace(4) void @_ZN7WrapperC2Ev(ptr addrspace(4) noundef align 8 dereferenceable_or_null(16) [[THIS1]]) #[[ATTR3]]
+// SPIRV-NEXT:    call spir_func addrspace(4) void @_ZN7WrapperC2Ev(ptr addrspace(4) noundef align 8 dereferenceable_or_null(16) [[THIS1]]) #[[ATTR2]]
 // SPIRV-NEXT:    ret void
 //

--- a/clang/test/CodeGenHIP/store-addr-space.hip
+++ b/clang/test/CodeGenHIP/store-addr-space.hip
@@ -35,19 +35,18 @@ struct Foo {
 // AMDGCN-NEXT:    ret void
 //
 // SPIRV-LABEL: define spir_func void @_Z3barPK3Foo(
-// SPIRV-SAME: ptr dead_on_unwind noalias writable sret([[STRUCT_FOO:%.*]]) align 8 [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[SRC_PTR:%.*]]) addrspace(4) #[[ATTR0:[0-9]+]] {
+// SPIRV-SAME: ptr addrspace(4) dead_on_unwind noalias writable sret([[STRUCT_FOO:%.*]]) align 8 [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[SRC_PTR:%.*]]) addrspace(4) #[[ATTR0:[0-9]+]] {
 // SPIRV-NEXT:  [[ENTRY:.*:]]
-// SPIRV-NEXT:    [[RESULT_PTR:%.*]] = alloca ptr, align 8
+// SPIRV-NEXT:    [[RESULT_PTR:%.*]] = alloca ptr addrspace(4), align 8
 // SPIRV-NEXT:    [[SRC_PTR_ADDR:%.*]] = alloca ptr addrspace(4), align 8
 // SPIRV-NEXT:    [[DST:%.*]] = alloca [[UNION_ANON:%.*]], align 8
 // SPIRV-NEXT:    [[RESULT_PTR_ASCAST:%.*]] = addrspacecast ptr [[RESULT_PTR]] to ptr addrspace(4)
 // SPIRV-NEXT:    [[SRC_PTR_ADDR_ASCAST:%.*]] = addrspacecast ptr [[SRC_PTR_ADDR]] to ptr addrspace(4)
-// SPIRV-NEXT:    [[AGG_RESULT_ASCAST:%.*]] = addrspacecast ptr [[AGG_RESULT]] to ptr addrspace(4)
 // SPIRV-NEXT:    [[DST_ASCAST:%.*]] = addrspacecast ptr [[DST]] to ptr addrspace(4)
-// SPIRV-NEXT:    store ptr [[AGG_RESULT]], ptr addrspace(4) [[RESULT_PTR_ASCAST]], align 8
+// SPIRV-NEXT:    store ptr addrspace(4) [[AGG_RESULT]], ptr addrspace(4) [[RESULT_PTR_ASCAST]], align 8
 // SPIRV-NEXT:    store ptr addrspace(4) [[SRC_PTR]], ptr addrspace(4) [[SRC_PTR_ADDR_ASCAST]], align 8
-// SPIRV-NEXT:    call spir_func addrspace(4) void @_ZN3FooC1Ev(ptr addrspace(4) noundef align 8 dereferenceable_or_null(8) [[AGG_RESULT_ASCAST]]) #[[ATTR1:[0-9]+]]
-// SPIRV-NEXT:    store ptr addrspace(4) [[AGG_RESULT_ASCAST]], ptr addrspace(4) [[DST_ASCAST]], align 8
+// SPIRV-NEXT:    call spir_func addrspace(4) void @_ZN3FooC1Ev(ptr addrspace(4) noundef align 8 dereferenceable_or_null(8) [[AGG_RESULT]]) #[[ATTR1:[0-9]+]]
+// SPIRV-NEXT:    store ptr addrspace(4) [[AGG_RESULT]], ptr addrspace(4) [[DST_ASCAST]], align 8
 // SPIRV-NEXT:    [[TMP0:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[SRC_PTR_ADDR_ASCAST]], align 8
 // SPIRV-NEXT:    [[VAL:%.*]] = getelementptr inbounds nuw [[STRUCT_FOO]], ptr addrspace(4) [[TMP0]], i32 0, i32 0
 // SPIRV-NEXT:    [[TMP1:%.*]] = load i64, ptr addrspace(4) [[VAL]], align 8


### PR DESCRIPTION
Override getSRetAddrSpace() so that sret pointers for non-trivially- copyable types use the generic address space (addrspace 4), matching the "this" pointer convention on spirv64-amd-amdhsa.