### PR TITLE
[lldb/test] Fix TestCompletion on Windows after realpath change

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2232,7 +2232,8 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
                 # Make sure we found the local shared library in the above code
                 self.assertTrue(os.path.exists(local_shlib_path))
 
-            local_shlib_path = os.path.realpath(local_shlib_path)
+            if lldb.remote_platform:
+                local_shlib_path = os.path.realpath(local_shlib_path)
             # Add the shared library to our target
             shlib_module = target.AddModule(local_shlib_path, None, None, None)
             if lldb.remote_platform:


### PR DESCRIPTION
Only resolve symlinks with os.path.realpath() when running on a remote platform. On Windows, realpath() can resolve mapped drives to a different drive letter, causing os.path.commonpath() to fail with "Paths don't have the same drive".