### PR TITLE
[Offload][AMDGPU] Use ROCr API for APU check

### DIFF
--- a/offload/plugins-nextgen/amdgpu/dynamic_hsa/hsa_ext_amd.h
+++ b/offload/plugins-nextgen/amdgpu/dynamic_hsa/hsa_ext_amd.h
@@ -27,9 +27,6 @@
 extern "C" {
 #endif
 
-/**
- * Macro to determine whether a flag is set within uint8_t[8] types.
- */
 static inline bool hsa_flag_isset64(uint8_t *value, uint32_t bit) {
   unsigned int index = bit / 8;
   unsigned int subBit = bit % 8;
@@ -86,9 +83,6 @@ typedef enum hsa_amd_agent_info_s {
   HSA_AMD_AGENT_INFO_MEMORY_PROPERTIES = 0xA114,
 } hsa_amd_agent_info_t;
 
-/**
- * Agent memory properties attributes
- */
 typedef enum hsa_amd_agent_memory_properties_s {
   HSA_AMD_MEMORY_PROPERTY_AGENT_IS_APU = (1 << 0),
 } hsa_amd_agent_memory_properties_t;

--- a/offload/plugins-nextgen/amdgpu/dynamic_hsa/hsa_ext_amd.h
+++ b/offload/plugins-nextgen/amdgpu/dynamic_hsa/hsa_ext_amd.h
@@ -27,6 +27,15 @@
 extern "C" {
 #endif
 
+/**
+ * Macro to determine whether a flag is set within uint8_t[8] types.
+ */
+static inline bool hsa_flag_isset64(uint8_t *value, uint32_t bit) {
+  unsigned int index = bit / 8;
+  unsigned int subBit = bit % 8;
+  return ((uint8_t *)value)[index] & (1 << subBit);
+}
+
 typedef struct hsa_amd_memory_pool_s {
   uint64_t handle;
 } hsa_amd_memory_pool_t;
@@ -74,7 +83,15 @@ typedef enum hsa_amd_agent_info_s {
   HSA_AMD_AGENT_INFO_COOPERATIVE_QUEUES = 0xA010,
   HSA_AMD_AGENT_INFO_UUID = 0xA011,
   HSA_AMD_AGENT_INFO_TIMESTAMP_FREQUENCY = 0xA016,
+  HSA_AMD_AGENT_INFO_MEMORY_PROPERTIES = 0xA114,
 } hsa_amd_agent_info_t;
+
+/**
+ * Agent memory properties attributes
+ */
+typedef enum hsa_amd_agent_memory_properties_s {
+  HSA_AMD_MEMORY_PROPERTY_AGENT_IS_APU = (1 << 0),
+} hsa_amd_agent_memory_properties_t;
 
 hsa_status_t hsa_amd_memory_pool_get_info(hsa_amd_memory_pool_t memory_pool,
                                           hsa_amd_memory_pool_info_t attribute,

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -3455,23 +3455,18 @@ private:
 
   /// Detect if current architecture is an APU.
   Error checkIfAPU() {
-    // TODO: replace with ROCr API once it becomes available.
-    llvm::StringRef StrGfxName(ComputeUnitKind);
-    bool MayBeAPU = llvm::StringSwitch<bool>(StrGfxName)
-                        .Case("gfx942", true)
-                        .Default(false);
-    if (!MayBeAPU)
-      return Plugin::success();
-
-    // can be MI300A or MI300X
-    uint32_t ChipID = 0;
-    if (auto Err = getDeviceAttr(HSA_AMD_AGENT_INFO_CHIP_ID, ChipID))
-      return Err;
-
-    if (!(ChipID & 0x1)) {
-      IsAPU = true;
+    uint8_t MemoryProperties[8];
+    if (auto Err = getDeviceAttr(HSA_AMD_AGENT_INFO_MEMORY_PROPERTIES,
+                                 MemoryProperties)) {
+      IsAPU = false;
+      ODBG(ODT_Tool) << "HSA_AMD_AGENT_INFO_MEMORY_PROPERTIES is unavailable, "
+                        "assuming not APU";
       return Plugin::success();
     }
+
+    IsAPU = hsa_flag_isset64(MemoryProperties,
+                             HSA_AMD_MEMORY_PROPERTY_AGENT_IS_APU);
+
     return Plugin::success();
   }
 


### PR DESCRIPTION
Use ROCr API for checking whether a device is an APU to replace the old implementation with hard-coded target name. This PR will make the APU check cleaner and better maintainable. 

Tested on MI210, MI300A, Strix Halo (gfx1151).